### PR TITLE
Kafka integration

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
                 text: "Google BigQuery",
                 link: "/supported-sources/bigquery.md",
               },
+              { text: "Kafka", link: "/supported-sources/kafka.md" },
               { text: "Local CSV Files", link: "/supported-sources/csv.md" },
               {
                 text: "Microsoft SQL Server",

--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -1,0 +1,38 @@
+# Apache Kafka
+[Apache Kafka](https://kafka.apache.org/) is a distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
+
+ingestr supports Apache Kafka as a source.
+
+## URI Format
+The URI format for Apache Kafka is as follows:
+
+```plaintext
+kafka://?bootstrap_servers=localhost:9092&group_id=test_group&security_protocol=SASL_SSL&sasl_mechanisms=PLAIN&sasl_username=example_username&sasl_password=example_secret&batch_size=1000&batch_timeout=3
+```
+
+URI parameters:
+- `bootstrap_servers`: The Kafka server(s) to connect to, typically in the form of a host and port (e.g., `localhost:9092`).
+- `group_id`: The consumer group ID used for identifying the client when consuming messages.
+- `security_protocol`: The protocol used to communicate with brokers (e.g., `SASL_SSL` for secure communication).
+- `sasl_mechanisms`: The SASL mechanism to be used for authentication (e.g., `PLAIN`).
+- `sasl_username`: The username for SASL authentication.
+- `sasl_password`: The password for SASL authentication.
+- `batch_size`: The number of messages to fetch in a single batch, defaults to 3000.
+- `batch_timeout`: The maximum time to wait for messages, defaults to 3 seconds.
+
+The URI is used to connect to the Kafka brokers for ingesting messages.
+
+### Group ID
+The group ID is used to identify the consumer group that reads messages from a topic. Kafka uses the group ID to manage consumer offsets and assign partitions to consumers, which means that the group ID is the key to reading messages from the correct partition and position in the topic.
+
+Once you have your Kafka server, credentials, and group ID set up, here's a sample command to ingest messages from a Kafka topic into a duckdb database:
+
+```sh
+ingestr ingest \
+    --source-uri 'kafka://?bootstrap_servers=localhost:9092' \
+    --source-table 'my-topic' \
+    --dest-uri duckdb:///kafka.duckdb \
+    --dest-table 'kafka.my_topic'
+```
+
+The result of this command will be a table in the `kafka.duckdb` database with JSON columns.

--- a/ingestr/src/.gitignore
+++ b/ingestr/src/.gitignore
@@ -1,0 +1,10 @@
+# ignore secrets, virtual environments and typical python compilation artifacts
+secrets.toml
+# ignore basic python artifacts
+.env
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+# ignore duckdb
+*.duckdb
+*.wal

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -21,6 +21,7 @@ from ingestr.src.sources import (
     GoogleSheetsSource,
     GorgiasSource,
     HubspotSource,
+    KafkaSource,
     KlaviyoSource,
     LocalCsvSource,
     MongoDbSource,
@@ -123,6 +124,8 @@ class SourceDestinationFactory:
             return AirtableSource()
         elif self.source_scheme == "klaviyo":
             return KlaviyoSource()
+        elif self.source_scheme == "kafka":
+            return KafkaSource()
         else:
             raise ValueError(f"Unsupported source scheme: {self.source_scheme}")
 

--- a/ingestr/src/kafka/__init__.py
+++ b/ingestr/src/kafka/__init__.py
@@ -1,0 +1,103 @@
+"""A source to extract Kafka messages.
+
+When extraction starts, partitions length is checked -
+data is read only up to it, overriding the default Kafka's
+behavior of waiting for new messages in endless loop.
+"""
+
+from contextlib import closing
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+
+import dlt
+from confluent_kafka import Consumer, Message  # type: ignore
+from dlt.common import logger
+from dlt.common.time import ensure_pendulum_datetime
+from dlt.common.typing import TAnyDateTime, TDataItem
+
+from .helpers import (
+    KafkaCredentials,
+    OffsetTracker,
+    default_msg_processor,
+)
+
+
+@dlt.resource(
+    name="kafka_messages",
+    table_name=lambda msg: msg["_kafka"]["topic"],
+    standalone=True,
+)
+def kafka_consumer(
+    topics: Union[str, List[str]],
+    credentials: Union[KafkaCredentials, Consumer] = dlt.secrets.value,
+    msg_processor: Optional[
+        Callable[[Message], Dict[str, Any]]
+    ] = default_msg_processor,
+    batch_size: Optional[int] = 3000,
+    batch_timeout: Optional[int] = 3,
+    start_from: Optional[TAnyDateTime] = None,
+) -> Iterable[TDataItem]:
+    """Extract recent messages from the given Kafka topics.
+
+    The resource tracks offsets for all the topics and partitions,
+    and so reads data incrementally.
+
+    Messages from different topics are saved in different tables.
+
+    Args:
+        topics (Union[str, List[str]]): Names of topics to extract.
+        credentials (Optional[Union[KafkaCredentials, Consumer]]):
+            Auth credentials or an initiated Kafka consumer. By default,
+            is taken from secrets.
+        msg_processor(Optional[Callable]): A function-converter,
+            which'll process every Kafka message after it's read and
+            before it's transfered to the destination.
+        batch_size (Optional[int]): Messages batch size to read at once.
+        batch_timeout (Optional[int]): Maximum time to wait for a batch
+            consume, in seconds.
+        start_from (Optional[TAnyDateTime]): A timestamp, at which to start
+            reading. Older messages are ignored.
+
+    Yields:
+        Iterable[TDataItem]: Kafka messages.
+    """
+    if not isinstance(topics, list):
+        topics = [topics]
+
+    if isinstance(credentials, Consumer):
+        consumer = credentials
+    elif isinstance(credentials, KafkaCredentials):
+        consumer = credentials.init_consumer()
+    else:
+        raise TypeError(
+            (
+                "Wrong credentials type provided. Need to be of type: "
+                "KafkaCredentials or confluent_kafka.Consumer"
+            )
+        )
+
+    if start_from is not None:
+        start_from = ensure_pendulum_datetime(start_from)
+
+    tracker = OffsetTracker(consumer, topics, dlt.current.resource_state(), start_from)  # type: ignore
+
+    # read messages up to the maximum offsets,
+    # not waiting for new messages
+    with closing(consumer):
+        while tracker.has_unread:
+            messages = consumer.consume(batch_size, timeout=batch_timeout)
+            if not messages:
+                break
+
+            batch = []
+            for msg in messages:
+                if msg.error():
+                    err = msg.error()
+                    if err.retriable() or not err.fatal():
+                        logger.warning(f"ERROR: {err} - RETRYING")
+                    else:
+                        raise err
+                else:
+                    batch.append(msg_processor(msg))  # type: ignore
+                    tracker.renew(msg)
+
+            yield batch

--- a/ingestr/src/kafka/helpers.py
+++ b/ingestr/src/kafka/helpers.py
@@ -1,0 +1,227 @@
+from typing import Any, Dict, List, Optional
+
+from confluent_kafka import Consumer, Message, TopicPartition  # type: ignore
+from confluent_kafka.admin import TopicMetadata  # type: ignore
+from dlt import config
+from dlt.common import pendulum
+from dlt.common.configuration import configspec
+from dlt.common.configuration.specs import CredentialsConfiguration
+from dlt.common.time import ensure_pendulum_datetime
+from dlt.common.typing import DictStrAny, TSecretValue
+from dlt.common.utils import digest128
+
+
+def default_msg_processor(msg: Message) -> Dict[str, Any]:
+    """Basic Kafka message processor.
+
+    Returns the message value and metadata. Timestamp consists of two values:
+    (type of the timestamp, timestamp). Type represents one of the Python
+    Kafka constants:
+        TIMESTAMP_NOT_AVAILABLE - Timestamps not supported by broker.
+        TIMESTAMP_CREATE_TIME - Message creation time (or source / producer time).
+        TIMESTAMP_LOG_APPEND_TIME - Broker receive time.
+
+    Args:
+        msg (confluent_kafka.Message): A single Kafka message.
+
+    Returns:
+        dict: Processed Kafka message.
+    """
+    ts = msg.timestamp()
+    topic = msg.topic()
+    partition = msg.partition()
+    key = msg.key()
+    if key is not None:
+        key = key.decode("utf-8")
+
+    return {
+        "_kafka": {
+            "partition": partition,
+            "topic": topic,
+            "key": key,
+            "offset": msg.offset(),
+            "ts": {
+                "type": ts[0],
+                "value": ensure_pendulum_datetime(ts[1] / 1e3),
+            },
+            "data": msg.value().decode("utf-8"),
+        },
+        "_kafka_msg_id": digest128(topic + str(partition) + str(key)),
+    }
+
+
+class OffsetTracker(dict):  # type: ignore
+    """Object to control offsets of the given topics.
+
+    Tracks all the partitions of the given topics with two params:
+    current offset and maximum offset (partition length).
+
+    Args:
+        consumer (confluent_kafka.Consumer): Kafka consumer.
+        topic_names (List): Names of topics to track.
+        pl_state (DictStrAny): Pipeline current state.
+        start_from (Optional[pendulum.DateTime]): A timestamp, after which messages
+            are read. Older messages are ignored.
+    """
+
+    def __init__(
+        self,
+        consumer: Consumer,
+        topic_names: List[str],
+        pl_state: DictStrAny,
+        start_from: pendulum.DateTime = None,  # type: ignore
+    ):
+        super().__init__()
+
+        self._consumer = consumer
+        self._topics = self._read_topics(topic_names)
+
+        # read/init current offsets
+        self._cur_offsets = pl_state.setdefault(
+            "offsets", {t_name: {} for t_name in topic_names}
+        )
+
+        self._init_partition_offsets(start_from)
+
+    def _read_topics(self, topic_names: List[str]) -> Dict[str, TopicMetadata]:
+        """Read the given topics metadata from Kafka.
+
+        Reads all the topics at once, instead of requesting
+        each in a separate call. Returns only those needed.
+
+        Args:
+            topic_names (list): Names of topics to be read.
+
+        Returns:
+            dict: Metadata of the given topics.
+        """
+        tracked_topics = {}
+        topics = self._consumer.list_topics().topics
+
+        for t_name in topic_names:
+            tracked_topics[t_name] = topics[t_name]
+
+        return tracked_topics
+
+    def _init_partition_offsets(self, start_from: pendulum.DateTime) -> None:
+        """Designate current and maximum offsets for every partition.
+
+        Current offsets are read from the state, if present. Set equal
+        to the partition beginning otherwise.
+
+        Args:
+            start_from (pendulum.DateTime): A timestamp, at which to start
+                reading. Older messages are ignored.
+        """
+        all_parts = []
+        for t_name, topic in self._topics.items():
+            self[t_name] = {}
+
+            # init all the topic partitions from the partitions' metadata
+            parts = [
+                TopicPartition(
+                    t_name,
+                    part,
+                    start_from.int_timestamp * 1000 if start_from is not None else 0,
+                )
+                for part in topic.partitions
+            ]
+
+            # get offsets for the timestamp, if given
+            if start_from is not None:
+                ts_offsets = self._consumer.offsets_for_times(parts)
+
+            # designate current and maximum offsets for every partition
+            for i, part in enumerate(parts):
+                max_offset = self._consumer.get_watermark_offsets(part)[1]
+
+                if start_from is not None:
+                    if ts_offsets[i].offset != -1:
+                        cur_offset = ts_offsets[i].offset
+                    else:
+                        cur_offset = max_offset - 1
+                else:
+                    cur_offset = (
+                        self._cur_offsets[t_name].get(str(part.partition), -1) + 1
+                    )
+
+                self[t_name][str(part.partition)] = {
+                    "cur": cur_offset,
+                    "max": max_offset,
+                }
+
+                parts[i].offset = cur_offset
+
+            all_parts += parts
+
+        # assign the current offsets to the consumer
+        self._consumer.assign(all_parts)
+
+    @property
+    def has_unread(self) -> bool:
+        """Check if there are unread messages in the tracked topics.
+
+        Returns:
+            bool: True, if there are messages to read, False if all
+                the current offsets are equal to their maximums.
+        """
+        for parts in self.values():
+            for part in parts.values():
+                if part["cur"] + 1 < part["max"]:
+                    return True
+
+        return False
+
+    def renew(self, msg: Message) -> None:
+        """Update partition offset from the given message.
+
+        Args:
+            msg (confluent_kafka.Message): A read Kafka message.
+        """
+        topic = msg.topic()
+        partition = str(msg.partition())
+
+        offset = self[topic][partition]
+        offset["cur"] = msg.offset()
+
+        self._cur_offsets[topic][partition] = msg.offset()
+
+
+@configspec
+class KafkaCredentials(CredentialsConfiguration):
+    """Kafka source credentials.
+
+    NOTE: original Kafka credentials are written with a period, e.g.
+    bootstrap.servers. However, KafkaCredentials expect them to
+    use underscore symbols instead, e.g. bootstrap_servers.
+    """
+
+    bootstrap_servers: str = config.value
+    group_id: str = config.value
+    security_protocol: Optional[str] = None
+    sasl_mechanisms: Optional[str] = None
+    sasl_username: Optional[str] = None
+    sasl_password: Optional[TSecretValue] = None
+
+    def init_consumer(self) -> Consumer:
+        """Init a Kafka consumer from this credentials.
+
+        Returns:
+            confluent_kafka.Consumer: an initiated consumer.
+        """
+        config = {
+            "bootstrap.servers": self.bootstrap_servers,
+            "group.id": self.group_id,
+            "auto.offset.reset": "earliest",
+        }
+
+        if self.security_protocol:
+            config["security.protocol"] = self.security_protocol
+        if self.sasl_mechanisms:
+            config["sasl.mechanisms"] = self.sasl_mechanisms
+        if self.sasl_username:
+            config["sasl.username"] = self.sasl_username
+        if self.sasl_password:
+            config["sasl.password"] = self.sasl_password
+
+        return Consumer(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ exclude = [
     'src/slack/.*',
     'src/hubspot/.*',
     'src/facebook_ads/.*',
-    'src/klaviyo/.*'
+    'src/klaviyo/.*',
+    'src/kafka/.*'
   ]
 
 [[tool.mypy.overrides]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cx_Oracle==8.3.0
+confluent-kafka>=2.3.0
 databricks-sql-connector==2.9.3
 dlt==0.5.1
 duckdb_engine==0.11.5


### PR DESCRIPTION
This PR adds support for Kafka as a source for ingestr. With this change, ingestr can be used to get data from Kafka into the data warehouse with a single command.