### PR TITLE
Add Optional utc_offset Parameter to Adjust Source

### DIFF
--- a/docs/supported-sources/adjust.md
+++ b/docs/supported-sources/adjust.md
@@ -9,15 +9,19 @@ ingestr supports Adjust as a source.
 The URI format for Adjust is as follows:
 
 ```plaintext
-adjust://?api_key=<api-key-here>
+adjust://?api_key=<api-key-here>&utc_offset=<utc-offset>
 ```
+
+URI parameters:
+- `api_key`: Required. The API key used for authentication with the Adjust API
+- `utc_offset`: Optional. The UTC offset for the data in the format "+HH:MM" or "-HH:MM". Defaults to "+00:00" if not provided.
 
 An API token is required to retrieve reports from the Adjust reporting API. please follow the guide to [obtain a API key](https://dev.adjust.com/en/api/rs-api/authentication/).
 
 Once you complete the guide, you should have an API key. Let's say your API key is `nr_123`, here's a sample command that will copy the data from Adjust into a duckdb database:
 
 ```sh
-ingestr ingest --source-uri 'adjust://?api_key=nr_123' --source-table 'campaigns' --dest-uri duckdb:///adjust.duckdb --dest-table 'adjust.output' --interval-start '2024-09-05' --interval-end '2024-09-08'
+ingestr ingest --source-uri 'adjust://?api_key=nr_123&utc_offset=+00:00' --source-table 'campaigns' --dest-uri duckdb:///adjust.duckdb --dest-table 'adjust.output' --interval-start '2024-09-05' --interval-end '2024-09-08'
 ```
 
 The result of this command will be a table in the `adjust.duckdb` database

--- a/ingestr/src/adjust/_init_.py
+++ b/ingestr/src/adjust/_init_.py
@@ -11,6 +11,7 @@ def adjust_source(
     start_date: str,
     end_date: str,
     api_key: str,
+    utc_offset: str,
 ) -> Sequence[DltResource]:
     @dlt.resource(write_disposition="merge", merge_key="day")
     def campaigns():
@@ -18,6 +19,7 @@ def adjust_source(
         yield from adjust_api.fetch_report_data(
             start_date=start_date,
             end_date=end_date,
+            utc_offset=utc_offset,
         )
 
     @dlt.resource(write_disposition="merge", merge_key="day")
@@ -25,7 +27,10 @@ def adjust_source(
         dimensions = DEFAULT_DIMENSIONS + ["adgroup", "creative"]
         adjust_api = AdjustAPI(api_key=api_key)
         yield from adjust_api.fetch_report_data(
-            start_date=start_date, end_date=end_date, dimensions=dimensions
+            start_date=start_date,
+            end_date=end_date,
+            dimensions=dimensions,
+            utc_offset=utc_offset,
         )
 
     return campaigns, creatives

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -730,7 +730,7 @@ class AdjustSource:
         source_part = urlparse(uri)
         source_params = parse_qs(source_part.query)
         api_key = source_params.get("api_key")
-        utc_offset = source_params.get("utc_offset")
+        utc_offset = source_params.get("utc_offset", ["+00:00"])
 
         if not api_key:
             raise ValueError("api_key in the URI is required to connect to Adjust")

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -730,6 +730,7 @@ class AdjustSource:
         source_part = urlparse(uri)
         source_params = parse_qs(source_part.query)
         api_key = source_params.get("api_key")
+        utc_offset = source_params.get("utc_offset")
 
         if not api_key:
             raise ValueError("api_key in the URI is required to connect to Adjust")
@@ -751,7 +752,10 @@ class AdjustSource:
             Endpoint = table
 
         return adjust_source(
-            start_date=start_date, end_date=end_date, api_key=api_key[0]
+            start_date=start_date,
+            end_date=end_date,
+            api_key=api_key[0],
+            utc_offset=utc_offset[0]
         ).with_resources(Endpoint)
 
 


### PR DESCRIPTION
This PR adds an optional `utc_offset` parameter to the Adjust source, allowing users to specify a UTC offset for data retrieval. If not provided, it defaults to `"+00:00"`.

#### Key Changes:

- **URI Parsing**: Added `utc_offset` parsing in `AdjustSource`.
- **Source Function**: Updated `adjust_source` to accept `utc_offset`.
- **Helper Function**: Set default `utc_offset` to `"+00:00"` in `fetch_report_data`.
- **Documentation**: Updated Adjust source docs to include `utc_offset`.