### PR TITLE
Add git hook for vulnerability scanning

### DIFF
--- a/.githooks/pre-commit-hook.sh
+++ b/.githooks/pre-commit-hook.sh
@@ -4,19 +4,18 @@ set -euo pipefail
 
 WORK_DIR="/root/code"
 
-
-if [[ ! `which docker` ]]; then
-    echo "docker is required to run gitleaks"
-    echo "for vulnerability scanning. commit aborted."
-    exit 1
-fi
-
-docker run \
-    -v "$PWD:$WORK_DIR" \
-    -w "$WORK_DIR" \
-    ghcr.io/gitleaks/gitleaks:latest dir -v
-
-if [[ $? -ne 0 ]]; then
+secret_detected() {
     echo "secrets detected in source code. commit aborted."
     exit 1
+}
+
+# use gitleaks binary if available
+# else fallback to using docker for running gitleaks
+CMD="gitleaks dir -v"
+
+if [[ ! `which gitleaks`  ]]; then
+    which docker > /dev/null || (echo "gitleaks or docker is required for running secrets scan" && exit 1)
+    CMD="docker run -v $PWD:$WORK_DIR -w $WORK_DIR ghcr.io/gitleaks/gitleaks:latest dir -v"
 fi
+
+$CMD || secret_detected

--- a/.githooks/pre-commit-hook.sh
+++ b/.githooks/pre-commit-hook.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 WORK_DIR="/root/code"
 
+
+if [[ ! `which docker` ]]; then
+    echo "docker is required to run gitleaks"
+    echo "for vulnerability scanning. commit aborted."
+    exit 1
+fi
+
 docker run \
     -v "$PWD:$WORK_DIR" \
     -w "$WORK_DIR" \

--- a/.githooks/pre-commit-hook.sh
+++ b/.githooks/pre-commit-hook.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+echo "scanning for secrets ..."
+
 WORK_DIR="/root/code"
 
 secret_detected() {
@@ -14,7 +16,7 @@ secret_detected() {
 CMD="gitleaks dir -v"
 
 if [[ ! `which gitleaks`  ]]; then
-    which docker > /dev/null || (echo "gitleaks or docker is required for running secrets scan" && exit 1)
+    which docker > /dev/null || (echo "gitleaks or docker is required for running secrets scan." && exit 1)
     CMD="docker run -v $PWD:$WORK_DIR -w $WORK_DIR ghcr.io/gitleaks/gitleaks:latest dir -v"
 fi
 

--- a/.githooks/pre-commit-hook.sh
+++ b/.githooks/pre-commit-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+WORK_DIR="/root/code"
+
+docker run \
+    -v "$PWD:$WORK_DIR" \
+    -w "$WORK_DIR" \
+    ghcr.io/gitleaks/gitleaks:latest dir -v
+
+if [[ $? ]]; then
+    echo "secrets detected in source code. commit aborted."
+    exit 1
+fi

--- a/.githooks/pre-commit-hook.sh
+++ b/.githooks/pre-commit-hook.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 WORK_DIR="/root/code"
 
 
@@ -13,7 +16,7 @@ docker run \
     -w "$WORK_DIR" \
     ghcr.io/gitleaks/gitleaks:latest dir -v
 
-if [[ $? ]]; then
+if [[ $? -ne 0 ]]; then
     echo "secrets detected in source code. commit aborted."
     exit 1
 fi

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,12 @@
+name: secrets_scan
+on: [pull_request, push, workflow_dispatch]
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: scan for secrets (gitleaks)
+        run: docker run -v $PWD:/code -w /code ghcr.io/gitleaks/gitleaks:latest dir -v

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+ingestr/src/telemetry/event.py:generic-api-key:9
+ingestr/src/testdata/fakebqcredentials.json:private-key:5
+docs/supported-sources/shopify.md:generic-api-key:26

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,2 @@
 ingestr/src/telemetry/event.py:generic-api-key:9
 ingestr/src/testdata/fakebqcredentials.json:private-key:5
-docs/supported-sources/shopify.md:generic-api-key:26

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,3 @@
 ingestr/src/telemetry/event.py:generic-api-key:9
 ingestr/src/testdata/fakebqcredentials.json:private-key:5
+docs/supported-sources/shopify.md:generic-api-key:26

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .ONESHELL:
-.PHONY: test lint format ftl test-ci lint-ci build upload-release
+.PHONY: test lint format test-ci lint-ci build upload-release setup
 
 venv: venv/touchfile
 
@@ -40,3 +40,7 @@ build:
 
 upload-release:
 	twine upload --verbose dist/*
+
+setup:
+	@echo "installing git hooks ..."
+	@install -m 755 .githooks/pre-commit-hook.sh .git/hooks/pre-commit

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ You can see the full documentation [here](https://bruin-data.github.io/ingestr/g
 
 Join our Slack community [here](https://join.slack.com/t/bruindatacommunity/shared_invite/zt-2dl2i8foy-bVsuMUauHeN9M2laVm3ZVg).
 
+## Contributing
+
+Pull requests are welcome. However, please open an issue first to discuss what you would like to change. We maybe able to offer you help and feedback regarding any changes you would like to make.
+
+> [!NOTE]
+> After cloning `ingestr` make sure to run `make setup` to install githooks.
+
 ## Supported sources & destinations
 
 <table>


### PR DESCRIPTION
**Summary**
Adds a new make target called `setup` for installing a `pre-commit` hook that runs [gitleaks](https://github.com/gitleaks/gitleaks?tab=readme-ov-file) to ensure that developers don't commit sensitive credentials.

This PR also adds a CI job that runs `gitleaks` to enforce secret scanning on both ends.

**Prerequisites**
Gitleaks or Docker is required. The hook reports an error message in case neither are available.

**Other information**
Gitleaks detected a couple of secrets that are in the codebase right now. 2 were in testdata and 1 in telemetry module. 