### PR TITLE
githooks: gitleaks: clean up docker container

### DIFF
--- a/.githooks/pre-commit-hook.sh
+++ b/.githooks/pre-commit-hook.sh
@@ -17,7 +17,7 @@ CMD="gitleaks dir -v"
 
 if [[ ! `which gitleaks`  ]]; then
     which docker > /dev/null || (echo "gitleaks or docker is required for running secrets scan." && exit 1)
-    CMD="docker run -v $PWD:$WORK_DIR -w $WORK_DIR ghcr.io/gitleaks/gitleaks:latest dir -v"
+    CMD="docker run -v $PWD:$WORK_DIR -w $WORK_DIR --rm ghcr.io/gitleaks/gitleaks:latest dir -v"
 fi
 
 $CMD || secret_detected


### PR DESCRIPTION
We were leaving old (dead) docker containers after running gitleaks.

added `--rm` flag to clean them up.