### PR TITLE
Google Cloud Storage source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
                 text: "Facebook Ads",
                 link: "/supported-sources/facebook-ads.md",
               },
+              { text: "Google Cloud Storage (GCS)", link: "/supported-sources/gcs.md" },
               { text: "Google Analytics", link: "/supported-sources/google_analytics.md" },
               { text: "GitHub", link: "/supported-sources/github.md" },
               { text: "Google Sheets", link: "/supported-sources/gsheets.md" },

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -1,0 +1,62 @@
+# Google Cloud Storage
+
+[Google Cloud Storage](https://cloud.google.com/storage?hl=en) is an online file storage web service for storing and accessing data on Google Cloud Platform infrastructure. The service combines the performance and scalability of Google's cloud with advanced security and sharing capabilities. It is an Infrastructure as a Service (IaaS), comparable to Amazon S3. 
+
+## URI format
+
+The URI format for S3 is as follows:
+
+```plaintext
+gs://<bucket_name>?credentials_path=/path/to/service-account.json>
+```
+
+URI parameters:
+
+- `bucket_name`: The name of the bucket
+- `credentials_path`: path to file containing your Google Cloud [Service Account](https://cloud.google.com/iam/docs/service-account-overview)
+
+## Setting up a GCS Integration
+
+To use Google Cloud Storage source in `ingestr`, you will need:
+* A Google Cloud Project.
+* A Service Account with atleast [roles/storage.objectUser](https://cloud.google.com/storage/docs/access-control/iam-roles) IAM permission.
+* A Service Account key file for the corresponding service account.
+
+For more information on how to create a Service Account or it's keys, see [Create service accounts](https://cloud.google.com/iam/docs/service-accounts-create) and [Create or delete service account keys](https://cloud.google.com/iam/docs/keys-create-delete) on Google cloud docs.
+
+## Example
+
+Let's assume that:
+* Service account key in available in the current directory, under the filename `service_account.json`. 
+* The bucket you want to load data from is called `my-org-bucket`
+* The target file is available at `/data/latest/dump.csv`
+* The data needs to be saved in a duckdb database called `local.db`
+* The destination table name will be `public.latest_dump`
+
+You can run the following command line to achieve this:
+
+```sh
+ingestr ingest \
+    --source-uri "gs://my-org-bucket?credentials_path=$PWD/service_account.json" \
+    --source-table "/data/latest/dump.csv" \
+    --dest-uri "duckdb:///local.db" \
+    --dest-table "public.latest_dump"
+```
+
+## Supported File Formats
+`gs` source only supports loading files in the following formats:
+* `csv`: Comma Separated Values (supports Tab Separated Values as well)
+* `parquet`: [Apache Parquet](https://parquet.apache.org/) storage format.
+* `jsonl`: Line delimited JSON. see [https://jsonlines.org/](https://jsonlines.org/)
+
+## File Pattern
+`ingestr` supports [glob](https://en.wikipedia.org/wiki/Glob_(programming)) like pattern matching for `gs` source.
+This allows for a powerful pattern matching mechanism that allows you to specify multiple files in a single `--source-table`.
+
+Below are some examples of path patterns, each path pattern is a reference from the root of the bucket:
+
+- `**/*.csv`: Retrieves all the CSV files, regardless of how deep they are within the folder structure.
+- `*.csv`: Retrieves all the CSV files from the first level of a folder.
+- `myFolder/**/*.jsonl`: Retrieves all the JSONL files from anywhere under `myFolder`.
+- `myFolder/mySubFolder/users.parquet`: Retrieves the `users.parquet` file from `mySubFolder`.
+- `employees.jsonl`: Retrieves the `employees.jsonl` file from the root level of the bucket.

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -30,7 +30,7 @@ Let's assume that:
 * Service account key in available in the current directory, under the filename `service_account.json`. 
 * The bucket you want to load data from is called `my-org-bucket`
 * The source file is available at `/data/latest/dump.csv`
-* The data needs to be saved in a duckdb database called `local.db`
+* The data needs to be saved in a DuckDB database called `local.db`
 * The destination table name will be `public.latest_dump`
 
 You can run the following command line to achieve this:

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -22,7 +22,7 @@ To use Google Cloud Storage source in `ingestr`, you will need:
 * A Service Account with atleast [roles/storage.objectUser](https://cloud.google.com/storage/docs/access-control/iam-roles) IAM permission.
 * A Service Account key file for the corresponding service account.
 
-For more information on how to create a Service Account or it's keys, see [Create service accounts](https://cloud.google.com/iam/docs/service-accounts-create) and [Create or delete service account keys](https://cloud.google.com/iam/docs/keys-create-delete) on Google cloud docs.
+For more information on how to create a Service Account or it's keys, see [Create service accounts](https://cloud.google.com/iam/docs/service-accounts-create) and [Create or delete service account keys](https://cloud.google.com/iam/docs/keys-create-delete) on Google Cloud docs.
 
 ## Example
 

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -4,7 +4,7 @@
 
 ## URI format
 
-The URI format for S3 is as follows:
+The URI format for Google Cloud Storage is as follows:
 
 ```plaintext
 gs://<bucket_name>?credentials_path=/path/to/service-account.json>

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -29,7 +29,7 @@ For more information on how to create a Service Account or it's keys, see [Creat
 Let's assume that:
 * Service account key in available in the current directory, under the filename `service_account.json`. 
 * The bucket you want to load data from is called `my-org-bucket`
-* The target file is available at `/data/latest/dump.csv`
+* The source file is available at `/data/latest/dump.csv`
 * The data needs to be saved in a duckdb database called `local.db`
 * The destination table name will be `public.latest_dump`
 

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -9,7 +9,7 @@ ingestr supports S3 as a source.
 The URI format for S3 is as follows:
 
 ```plaintext
-s3://<bucket_name>/<path_to_file>?access_key_id=<access_key_id>&secret_access_key=<secret_access_key>
+s3://<bucket_name>?access_key_id=<access_key_id>&secret_access_key=<secret_access_key>
 ```
 
 URI parameters:
@@ -25,7 +25,11 @@ S3 requires an `access_key_id` and a `secret_access_key` to access the bucket. P
 For example, if your `access_key_id` is `AKC3YOW7E`, `secret_access_key` is `XCtkpL5B`, bucket name is `my_bucket`, and `path_to_files` is `students/students_details.csv`, here's a sample command that will copy the data from the S3 bucket into a DuckDB database:
 
 ```sh
-ingestr ingest --source-uri 's3://my_bucket/students/students_details.csv?access_key_id=AKC3YOW7E&secret_access_key=XCtkpL5B' --source-table 'students_details' --dest-uri duckdb:///s3.duckdb --dest-table 'dest.students_details'
+ingestr ingest \
+    --source-uri 's3://my_bucket?access_key_id=AKC3YOW7E&secret_access_key=XCtkpL5B' \
+    --source-table '/students/students_details.csv' \
+    --dest-uri duckdb:///s3.duckdb \
+    --dest-table 'dest.students_details'
 ```
 
 The result of this command will be a table in the DuckDB database in the path `s3.duckdb`.

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -2560,3 +2560,15 @@ def appstore_test_cases() -> Iterable[Callable]:
 def test_appstore(dest, test_case):
     test_case(dest.start())
     dest.stop()
+
+def gcs_test_cases() -> Iterable[Callable]:
+    # TODO: generalise these for s3 
+    return []
+
+@pytest.mark.parametrize(
+    "dest", list(DESTINATIONS.values()), ids=list(DESTINATIONS.keys())
+)
+@pytest.mark.parametrize("test_case", gcs_test_cases())
+def test_gcs(dest, test_case):
+    test_case(dest.start())
+    dest.stop()

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -2617,7 +2617,7 @@ def gcs_test_cases() -> Iterable[Callable]:
             dest_table = f"{schema_rand_prefix}.gcs_{get_random_string(5)}"
             result = invoke_ingest_command(
                 f"gs://bucket?credentials_base64={empty_credentials}",
-                "data.csv",
+                "data.csv", # verify this works with a leading slash
                 dest_uri,
                 dest_table,
             )

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -25,6 +25,7 @@ from ingestr.src.sources import (
     ChessSource,
     DynamoDBSource,
     FacebookAdsSource,
+    GCSSource,
     GitHubSource,
     GoogleAnalyticsSource,
     GoogleSheetsSource,
@@ -124,6 +125,7 @@ class SourceDestinationFactory:
         "tiktok": TikTokSource,
         "googleanalytics": GoogleAnalyticsSource,
         "appstore": AppleAppStoreSource,
+        "gs": GCSSource,
     }
     destinations: Dict[str, Type[DestinationProtocol]] = {
         "bigquery": BigQueryDestination,

--- a/ingestr/src/filesystem/__init__.py
+++ b/ingestr/src/filesystem/__init__.py
@@ -39,8 +39,6 @@ def readers(
     filesystem_resource = filesystem(bucket_url, credentials, file_glob=file_glob)
     filesystem_resource.apply_hints(
         incremental=dlt.sources.incremental("modification_date"),
-        range_end="closed",
-        range_start="closed",
     )
     return (
         filesystem_resource | dlt.transformer(name="read_csv")(_read_csv),

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1507,9 +1507,6 @@ class AppleAppStoreSource:
         return src.with_resources(table)
 
 class GCSSource:
-    SCOPES = [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-    ]
     def handles_incrementality(self) -> bool:
         return True
 

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1539,10 +1539,10 @@ class GCSSource:
             )
         bucket_url = f"gs://{bucket_name}/"
 
-        path_to_file = parsed_uri.path.lstrip("/")
+        path_to_file = parsed_uri.path.lstrip("/") or table.strip()
         if not path_to_file:
             raise ValueError(
-                "Invalid GCS URI: The bucket name is missing. Ensure your GCS URI follows the format 'gs://bucket-name/path/to/file"
+                "--source-table must be specified"
             )
 
         credentials = None

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1535,7 +1535,7 @@ class GCSSource:
             )
         bucket_url = f"gs://{bucket_name}/"
 
-        path_to_file = parsed_uri.path.lstrip("/") or table.strip()
+        path_to_file = parsed_uri.path.lstrip("/") or table.lstrip("/")
         if not path_to_file:
             raise ValueError("--source-table must be specified")
 

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1093,14 +1093,14 @@ class S3Source:
         bucket_name = parsed_uri.hostname
         if not bucket_name:
             raise ValueError(
-                "Invalid S3 URI: The bucket name is missing. Ensure your S3 URI follows the format 's3://bucket-name/path/to/file"
+                "Invalid S3 URI: The bucket name is missing. Ensure your S3 URI follows the format 's3://bucket-name"
             )
         bucket_url = f"s3://{bucket_name}"
 
-        path_to_file = parsed_uri.path.lstrip("/")
+        path_to_file = parsed_uri.path.lstrip("/") or table.strip()
         if not path_to_file:
             raise ValueError(
-                "Invalid S3 URI: The file path is missing. Ensure your S3 URI follows the format 's3://bucket-name/path/to/file"
+                "--source-table must be specified"
             )
 
         aws_credentials = AwsCredentials(

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1545,7 +1545,9 @@ class GCSSource:
 
         credentials = None
         if credentials_path:
-            credentials = GoogleCredentials.from_file(credentials_path[0])
+            credentials = GoogleCredentials.from_service_account_file(
+                credentials_path[0],
+            )
         else:
             credentials = GoogleCredentials.from_service_account_info(
                 base64.b64decode(credentials_base64[0])

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -17,6 +17,7 @@ from typing import (
 from urllib.parse import ParseResult, parse_qs, quote, urlparse
 
 import dlt
+import gcsfs  # type: ignore
 import pendulum
 from dlt.common.configuration.specs import (
     AwsCredentials,
@@ -39,10 +40,8 @@ from dlt.sources.sql_database.schema_types import (
     Table,
     TTypeAdapter,
 )
-import gcsfs
 from sqlalchemy import Column
 from sqlalchemy import types as sa
-
 
 from ingestr.src.adjust import REQUIRED_CUSTOM_DIMENSIONS, adjust_source
 from ingestr.src.adjust.adjust_helpers import parse_filters
@@ -1099,9 +1098,7 @@ class S3Source:
 
         path_to_file = parsed_uri.path.lstrip("/") or table.strip()
         if not path_to_file:
-            raise ValueError(
-                "--source-table must be specified"
-            )
+            raise ValueError("--source-table must be specified")
 
         aws_credentials = AwsCredentials(
             aws_access_key_id=access_key_id[0],
@@ -1506,6 +1503,7 @@ class AppleAppStoreSource:
 
         return src.with_resources(table)
 
+
 class GCSSource:
     def handles_incrementality(self) -> bool:
         return True
@@ -1538,17 +1536,13 @@ class GCSSource:
 
         path_to_file = parsed_uri.path.lstrip("/") or table.strip()
         if not path_to_file:
-            raise ValueError(
-                "--source-table must be specified"
-            )
+            raise ValueError("--source-table must be specified")
 
         credentials = None
         if credentials_path:
-                credentials = credentials_path[0]
+            credentials = credentials_path[0]
         else:
-            credentials = json.loads(
-                base64.b64decode(credentials_base64[0]).decode()
-            )
+            credentials = json.loads(base64.b64decode(credentials_base64[0]).decode())  # type: ignore
 
         # There's a compatiblity issue between google-auth, dlt and gcsfs
         # that makes it difficult to use google.oauth2.service_account.Credentials

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -18,6 +18,7 @@ from urllib.parse import ParseResult, parse_qs, quote, urlparse
 
 import dlt
 import gcsfs  # type: ignore
+import s3fs # type: ignore
 import pendulum
 from dlt.common.configuration.specs import (
     AwsCredentials,
@@ -1096,13 +1097,13 @@ class S3Source:
             )
         bucket_url = f"s3://{bucket_name}"
 
-        path_to_file = parsed_uri.path.lstrip("/") or table.strip()
+        path_to_file = parsed_uri.path.lstrip("/") or table.lstrip("/")
         if not path_to_file:
             raise ValueError("--source-table must be specified")
 
-        aws_credentials = AwsCredentials(
-            aws_access_key_id=access_key_id[0],
-            aws_secret_access_key=TSecretStrValue(secret_access_key[0]),
+        fs = s3fs.S3FileSystem(
+            key=access_key_id[0],
+            secret=secret_access_key[0],
         )
 
         file_extension = path_to_file.split(".")[-1]
@@ -1118,7 +1119,7 @@ class S3Source:
             )
 
         return readers(
-            bucket_url=bucket_url, credentials=aws_credentials, file_glob=path_to_file
+            bucket_url, fs, path_to_file
         ).with_resources(endpoint)
 
 
@@ -1566,5 +1567,5 @@ class GCSSource:
             )
 
         return readers(
-            bucket_url=bucket_url, credentials=fs, file_glob=path_to_file
+            bucket_url, fs, path_to_file
         ).with_resources(endpoint)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ pyathena==3.9.0
 google-analytics-data==0.18.16
 asana==3.2.3
 dataclasses-json==0.6.7
-
+gcsfs==2024.10.0


### PR DESCRIPTION
# URI Format

```
gs://bucket_name?credentials_path=/path/to/service_account.json
```

# Specifying source file paths
This source can accept file paths either in the URI, or via `--source-table`.

For example, the following two command lines are equivalent
```
ingestr ingest --source-uri "gs://example/data/file.csv" [... other flags ...]
```

```
ingestr ingest --source-uri "gs://example" --source-table "/data/file.csv" [... other flags ...]
```

## but why?
Originally, I had intended to only allow file paths in `--source-table`. However, `s3` source uses the convention of requiring file paths in URIs. I wanted to not break expectations of users who are used to that source. Hence I decided that as a middle ground:
* we will allow both forms
* only the `--source-table` form is documentated. Discouraging new users from using the old syntax.

## Misc
This PR also adds testing for S3 source.

The tests currently only target input validation and basic loading scenarios.

