### PR TITLE
GCS+S3: support bucket name in source table

### DIFF
--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -7,13 +7,17 @@
 The URI format for Google Cloud Storage is as follows:
 
 ```plaintext
-gs://<bucket_name>?credentials_path=/path/to/service-account.json>
+gs://?credentials_path=/path/to/service-account.json>
 ```
 
 URI parameters:
 
-- `bucket_name`: The name of the bucket
 - `credentials_path`: path to file containing your Google Cloud [Service Account](https://cloud.google.com/iam/docs/service-account-overview)
+
+The `--source-table` must be in the format:
+```
+{bucket name}/{file glob}
+```
 
 ## Setting up a GCS Integration
 
@@ -29,7 +33,7 @@ For more information on how to create a Service Account or it's keys, see [Creat
 Let's assume that:
 * Service account key in available in the current directory, under the filename `service_account.json`. 
 * The bucket you want to load data from is called `my-org-bucket`
-* The source file is available at `/data/latest/dump.csv`
+* The source file is available at `data/latest/dump.csv`
 * The data needs to be saved in a DuckDB database called `local.db`
 * The destination table name will be `public.latest_dump`
 
@@ -37,8 +41,8 @@ You can run the following command line to achieve this:
 
 ```sh
 ingestr ingest \
-    --source-uri "gs://my-org-bucket?credentials_path=$PWD/service_account.json" \
-    --source-table "/data/latest/dump.csv" \
+    --source-uri "gs://?credentials_path=$PWD/service_account.json" \
+    --source-table "my-org-bucket/data/latest/dump.csv" \
     --dest-uri "duckdb:///local.db" \
     --dest-table "public.latest_dump"
 ```
@@ -53,7 +57,7 @@ ingestr ingest \
 `ingestr` supports [glob](https://en.wikipedia.org/wiki/Glob_(programming)) like pattern matching for `gs` source.
 This allows for a powerful pattern matching mechanism that allows you to specify multiple files in a single `--source-table`.
 
-Below are some examples of path patterns, each path pattern is a reference from the root of the bucket:
+Below are some examples of path patterns, each path pattern is glob you can specify after the bucket name:
 
 - `**/*.csv`: Retrieves all the CSV files, regardless of how deep they are within the folder structure.
 - `*.csv`: Retrieves all the CSV files from the first level of a folder.

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -9,14 +9,17 @@ ingestr supports S3 as a source.
 The URI format for S3 is as follows:
 
 ```plaintext
-s3://<bucket_name>?access_key_id=<access_key_id>&secret_access_key=<secret_access_key>
+s3://?access_key_id=<access_key_id>&secret_access_key=<secret_access_key>
 ```
 
 URI parameters:
 
-- `bucket_name`: The name of the bucket
-- `path_to_files`: The relative path from the root of the bucket. You can find this from the S3 URI. For example, if your S3 URI is `s3://mybucket/students/students_details.csv`, then your bucket name is `mybucket` and `path_to_files` is `students/students_details.csv`.
 - `access_key_id` and `secret_access_key` : Used for accessing S3 bucket.
+
+The `--source-table` must be in the format:
+```
+{bucket name}/{file glob}
+```
 
 ## Setting up a S3 Integration
 
@@ -26,15 +29,15 @@ For example, if your `access_key_id` is `AKC3YOW7E`, `secret_access_key` is `XCt
 
 ```sh
 ingestr ingest \
-    --source-uri 's3://my_bucket?access_key_id=AKC3YOW7E&secret_access_key=XCtkpL5B' \
-    --source-table '/students/students_details.csv' \
+    --source-uri 's3://?access_key_id=AKC3YOW7E&secret_access_key=XCtkpL5B' \
+    --source-table 'my_bucket/students/students_details.csv' \
     --dest-uri duckdb:///s3.duckdb \
     --dest-table 'dest.students_details'
 ```
 
 The result of this command will be a table in the DuckDB database in the path `s3.duckdb`.
 
-Below are some examples of path patterns, each path pattern is a reference from the root of the bucket:
+Below are some examples of path patterns, each path pattern is a glob you can specify after the bucket name:
 
 - `**/*.csv`: Retrieves all the CSV files, regardless of how deep they are within the folder structure.
 - `*.csv`: Retrieves all the CSV files from the first level of a folder.

--- a/ingestr/src/blob.py
+++ b/ingestr/src/blob.py
@@ -21,10 +21,6 @@ def parse_uri(uri: ParseResult, table: str) -> Tuple[BucketName, FileGlob]:
 
     The first form is the prefered method. Other forms are supported
     for backward compatibility, but discouraged.
-
-    Raises:
-
-    Returns: Tuple[bucket_name, file_glob]
     """
 
     table = table.strip()

--- a/ingestr/src/blob.py
+++ b/ingestr/src/blob.py
@@ -47,4 +47,7 @@ def parse_uri(uri: ParseResult, table: str) -> Tuple[BucketName, FileGlob]:
         return host, table.lstrip("/")
 
     parts = table.lstrip("/").split("/", maxsplit=1)
+    if len(parts) != 2:
+        return "", parts[0]
+
     return parts[0], parts[1]

--- a/ingestr/src/blob.py
+++ b/ingestr/src/blob.py
@@ -32,7 +32,7 @@ def parse_uri(uri: ParseResult, table: str) -> Tuple[BucketName, FileGlob]:
 
     if table == "":
         warnings.warn(
-            f"Using the form '{uri.scheme}://bucket-name/file-glob' with table=None is deprecated and will be removed in future versions.",
+            f"Using the form '{uri.scheme}://bucket-name/file-glob' is deprecated and will be removed in future versions.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -40,11 +40,11 @@ def parse_uri(uri: ParseResult, table: str) -> Tuple[BucketName, FileGlob]:
 
     if host != "":
         warnings.warn(
-            f"Using the form '{uri.scheme}://bucket-name' with table='file-glob' is deprecated and will be removed in future versions.",
+            f"Using the form '{uri.scheme}://bucket-name' is deprecated and will be removed in future versions.",
             DeprecationWarning,
             stacklevel=2,
         )
         return host, table.lstrip("/")
 
-    parts = table.split("/", maxsplit=1)
+    parts = table.lstrip("/").split("/", maxsplit=1)
     return parts[0], parts[1]

--- a/ingestr/src/blob.py
+++ b/ingestr/src/blob.py
@@ -1,0 +1,50 @@
+import warnings
+from typing import Tuple, TypeAlias
+from urllib.parse import ParseResult
+
+BucketName: TypeAlias = str
+FileGlob: TypeAlias = str
+
+
+def parse_uri(uri: ParseResult, table: str) -> Tuple[BucketName, FileGlob]:
+    """
+    parse the URI of a blob storage and
+    return the bucket name and the file glob.
+
+    Supports the following Forms:
+    - uri: "gs://"
+      table: "bucket-name/file-glob"
+    - uri: gs://bucket-name/file-glob
+      table: None
+    - uri: "gs://bucket-name"
+      table: "file-glob"
+
+    The first form is the prefered method. Other forms are supported
+    for backward compatibility, but discouraged.
+
+    Raises:
+
+    Returns: Tuple[bucket_name, file_glob]
+    """
+
+    table = table.strip()
+    host = uri.netloc.strip()
+
+    if table == "":
+        warnings.warn(
+            f"Using the form '{uri.scheme}://bucket-name/file-glob' with table=None is deprecated and will be removed in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return host, uri.path.lstrip("/")
+
+    if host != "":
+        warnings.warn(
+            f"Using the form '{uri.scheme}://bucket-name' with table='file-glob' is deprecated and will be removed in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return host, table.lstrip("/")
+
+    parts = table.split("/", maxsplit=1)
+    return parts[0], parts[1]

--- a/ingestr/src/errors.py
+++ b/ingestr/src/errors.py
@@ -8,3 +8,11 @@ class UnsupportedResourceError(Exception):
         super().__init__(
             f"Resource '{resource}' is not supported for {source} source yet, if you are interested in it please create a GitHub issue at https://github.com/bruin-data/ingestr"
         )
+
+
+class InvalidBlobTableError(Exception):
+    def __init__(self, source):
+        super().__init__(
+            f"Invalid source table for {source}"
+            "Ensure that the table is in the format {bucket-name}/{file glob}"
+        )

--- a/ingestr/src/errors.py
+++ b/ingestr/src/errors.py
@@ -13,6 +13,6 @@ class UnsupportedResourceError(Exception):
 class InvalidBlobTableError(Exception):
     def __init__(self, source):
         super().__init__(
-            f"Invalid source table for {source}"
+            f"Invalid source table for {source} "
             "Ensure that the table is in the format {bucket-name}/{file glob}"
         )

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1532,7 +1532,7 @@ class GCSSource:
         if not bucket_name or not path_to_file:
             raise InvalidBlobTableError("GCS")
 
-        bucket_url = f"gs://{bucket_name}/"
+        bucket_url = f"gs://{bucket_name}"
 
         credentials = None
         if credentials_path:


### PR DESCRIPTION
This adds a backward compatiable change in uri/source table schema. The prefererred form for specifying the bucket and file path is now:
```
--source-table "bucket-name/path/to/file"
```

Older formats are still supported, but have a deprecation warning. Docs prescribe the use of the new format, and don't mention the old ones.