### PR TITLE
Bugfix: CSV Destination

### DIFF
--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -1811,6 +1811,10 @@ def test_csv_dest():
                 "dataset.table",  # unused by csv dest
             )
             assert result.exit_code == 0
+            with open(csv_dest.name, "r") as output:
+                reader = csv.DictReader(output)
+                rows = [row for row in reader]
+                assert len(rows) == 4
         finally:
             os.remove(duck_src.name)
             os.remove(csv_dest.name)

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -1784,6 +1784,7 @@ def test_date_coercion_issue():
     source_instance.stop()
     dest_instance.stop()
 
+
 def test_csv_dest():
     """
     Smoke test to ensure that CSV destination works.
@@ -1807,13 +1808,12 @@ def test_csv_dest():
                 f"duckdb:///{duck_src.name}",
                 "public.testdata",
                 f"csv://{csv_dest.name}",
-                "dataset.table", # unused by csv dest
+                "dataset.table",  # unused by csv dest
             )
-            assert result.exit_code == 0 
+            assert result.exit_code == 0
         finally:
             os.remove(duck_src.name)
             os.remove(csv_dest.name)
-
 
 
 @dataclass


### PR DESCRIPTION
`dlt` has switched from using gzipped `jsonl` to `parquet` for temporary staging files. (Or it could be a change in default staging format).

I've updated the destination to read the parquet files and added a test to catch these sorts of issues in the future.