### PR TITLE
add clickhouse as a source

### DIFF
--- a/docs/supported-sources/clickhouse.md
+++ b/docs/supported-sources/clickhouse.md
@@ -1,20 +1,27 @@
 # ClickHouse
 ClickHouse is a fast, open-source, column-oriented database management system that allows for high performance data ingestion and querying.
 
-Ingestr supports ClickHouse as a destination.
+ingestr supports ClickHouse as a source and destination.
 
 ## URI format
+The URI format for ClickHouse as a source is as follows:
+
+```plaintext
+clickhouse://<username>:<password>@<host>:<port>?secure=<secure>
+```
+
 The URI format for ClickHouse as a destination is as follows:
 
 ```plaintext
 clickhouse://<username>:<password>@<host>:<port>?http_port=<http_port>&secure=<secure>
 ```
+
 ## URI parameters:
 - `username` (required): The username is required to authenticate with the ClickHouse server.
 - `password` (required): The password is required to authenticate the provided username.
 - `host` (required): The hostname or IP address of the ClickHouse server where the database is hosted.
 - `port` (required): The TCP port number used by the ClickHouse server.
-- `http_port` (optional): The port number to use when connecting to the ClickHouse server's HTTP interface.By default, it is set to port `8443`.
+- `http_port` (optional): The port number to use when connecting to the ClickHouse server's HTTP interface. By default, it is set to port `8443`. It should only be used when ClickHouse is the destination. 
 - `secure` (optional): Set to `1` for a secure HTTPS connection or `0` for a non-secure HTTP connection. By default, it is set to `1`.
 
 ClickHouse requires a `username`, `password`, `host` and `port` to connect to the ClickHouse server. For more information, read [here](https://dlthub.com/docs/dlt-ecosystem/destinations/clickhouse#2-setup-clickhouse-database). Once you've completed the guide, you should have all the above-mentioned credentials.

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -65,8 +65,9 @@ SQL_SOURCE_SCHEMES = [
     "oracle",
     "oracle+cx_oracle",
     "hana",
+    "clickhouse",
+    
 ]
-
 
 class SourceProtocol(Protocol):
     def dlt_source(self, uri: str, table: str, **kwargs):

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -131,6 +131,11 @@ class SqlSource:
 
         if uri.startswith("mysql://"):
             uri = uri.replace("mysql://", "mysql+pymysql://")
+        
+        if uri.startswith("clickhouse://"):
+            uri = uri.replace("clickhouse://", "clickhouse+native://")
+            if "secure=" not in uri:
+              uri += "?secure=1"
 
         query_adapters = []
         if kwargs.get("sql_limit"):


### PR DESCRIPTION
Users can load data from a ClickHouse database to a  desired destination.
- source_uri = clickhouse://username:password@host:port?secure
 - By default, secure=1.
 
<img width="1065" alt="Screenshot 2025-02-04 at 14 03 19" src="https://github.com/user-attachments/assets/f96fbc1e-df23-4d28-bd0b-fda9461b6b7d" />

