### PR TITLE
CSV Destination: use file-type specific loader

### DIFF
--- a/ingestr/src/destinations.py
+++ b/ingestr/src/destinations.py
@@ -7,7 +7,8 @@ import tempfile
 from urllib.parse import parse_qs, quote, urlparse
 
 import dlt
-import pyarrow.parquet  # type: ignore
+from ingestr.src.loader import load_dlt_file
+
 from dlt.common.configuration.specs import AwsCredentials
 from dlt.destinations.impl.clickhouse.configuration import (
     ClickHouseCredentials,
@@ -184,11 +185,9 @@ class CsvDestination(GenericSqlDestination):
         if output_path.count("/") > 1:
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-        table = pyarrow.parquet.read_table(first_file_path)
-        rows = table.to_pylist()
         with open(output_path, "w", newline="") as csv_file:
             csv_writer = None
-            for row in rows:
+            for row in load_dlt_file(first_file_path):
                 row = filter_keys(row)
                 if csv_writer is None:
                     csv_writer = csv.DictWriter(csv_file, fieldnames=row.keys())

--- a/ingestr/src/destinations.py
+++ b/ingestr/src/destinations.py
@@ -7,12 +7,12 @@ import tempfile
 from urllib.parse import parse_qs, quote, urlparse
 
 import dlt
-from ingestr.src.loader import load_dlt_file
-
 from dlt.common.configuration.specs import AwsCredentials
 from dlt.destinations.impl.clickhouse.configuration import (
     ClickHouseCredentials,
 )
+
+from ingestr.src.loader import load_dlt_file
 
 
 class GenericSqlDestination:

--- a/ingestr/src/loader.py
+++ b/ingestr/src/loader.py
@@ -5,10 +5,10 @@ import subprocess
 from contextlib import contextmanager
 from typing import Generator
 
-from pyarrow.parquet import ParquetFile
-
+from pyarrow.parquet import ParquetFile  # type: ignore
 
 PARQUET_BATCH_SIZE = 64
+
 
 class UnsupportedLoaderFileFormat(Exception):
     pass
@@ -48,6 +48,7 @@ def jsonlfile(filepath: str):
     def reader(fd):
         for line in fd:
             yield json.loads(line.decode().strip())
+
     with gzip.open(filepath) as fd:
         yield reader(fd)
 
@@ -63,6 +64,6 @@ def parquetfile(filepath: str):
     def reader(pf: ParquetFile):
         for batch in pf.iter_batches(PARQUET_BATCH_SIZE):
             yield from batch.to_pylist()
-        
+
     with open(filepath, "rb") as fd:
         yield reader(ParquetFile(fd))

--- a/ingestr/src/loader.py
+++ b/ingestr/src/loader.py
@@ -1,12 +1,60 @@
-import filetype
-
+import csv
+import json
+import gzip
+import subprocess
 from contextlib import contextmanager
+from typing import Generator
+import pyarrow.parquet
 
-@contextmanager
-def load_dlt_file(path: str):
+class UnsupportedLoaderFileFormat(Exception):
+    pass
+
+def load_dlt_file(filepath: str) -> Generator:
     """
     load_dlt_file reads dlt loader files. It handles different loader file formats
     automatically. It returns a generator that yield data items as a python dict
     """
-    kind = filetype.guess(path)
-    pass
+    result = subprocess.run(
+        ['file', '-b', filepath],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    filetype = result.stdout.strip()
+    with factory(filetype, filepath) as reader:
+        yield from reader
+
+
+def factory(filetype: str, filepath: str):
+    # ???(turtledev): can dlt produce non-gizpped jsonl files? 
+    if filetype.startswith("gzip"):
+        return jsonlfile(filepath)
+    elif filetype.startswith("CSV"):
+        return csvfile(filepath)
+    elif filetype.startswith("Apache Parquet"):
+        return parquetfile(filepath)
+    else:
+        raise UnsupportedLoaderFileFormat(filetype)
+
+@contextmanager
+def jsonlfile(filepath: str):
+    reader = lambda f: [
+        json.loads(line.decode().strip())
+        for line in f
+    ]
+    with gzip.open(filepath) as fd:
+        yield reader(fd)
+    
+@contextmanager
+def csvfile(filepath: str):
+    with open(filepath, "r") as fd:
+        yield csv.DictReader(fd)
+
+@contextmanager
+def parquetfile(filepath: str):
+    reader = lambda t: t.to_pylist()
+    with open(filepath, "rb") as fd:
+        table = pyarrow.parquet.read_table(fd)
+        yield reader(table)
+

--- a/ingestr/src/loader.py
+++ b/ingestr/src/loader.py
@@ -1,0 +1,12 @@
+import filetype
+
+from contextlib import contextmanager
+
+@contextmanager
+def load_dlt_file(path: str):
+    """
+    load_dlt_file reads dlt loader files. It handles different loader file formats
+    automatically. It returns a generator that yield data items as a python dict
+    """
+    kind = filetype.guess(path)
+    pass

--- a/ingestr/src/loader_test.py
+++ b/ingestr/src/loader_test.py
@@ -1,0 +1,77 @@
+import os
+import csv
+import gzip
+import json
+import tempfile
+from typing import List
+
+import pytest
+import pyarrow.parquet
+
+from loader import load_dlt_file
+
+TESTDATA = [
+    {
+        "name": "Jhon",
+        "email": "jhon@acme.com"
+    },
+    {
+        "name": "Lisa",
+        "email": "lisa@acme.com"
+    },
+]
+
+def tojsonl(datalist: List[dict]):
+    return "\n".join([
+        json.dumps(data)
+        for data in datalist
+    ]).encode()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def testfiles():
+    with (
+        tempfile.NamedTemporaryFile("w", delete=False) as gzipped_jsonl,
+        tempfile.NamedTemporaryFile("w", delete=False) as plain_csv,
+        tempfile.NamedTemporaryFile("w", delete=False) as parquet,
+    ):
+        # gzipped jsonl
+        gzipped_jsonl.close()
+        writer = gzip.open(gzipped_jsonl.name, "w")
+        writer.write(tojsonl(TESTDATA))
+        writer.close()
+
+        # csv
+        writer = csv.DictWriter(
+            plain_csv,
+            fieldnames=TESTDATA[0].keys(),
+        )
+        writer.writeheader()
+        writer.writerows(TESTDATA)
+        plain_csv.close()
+
+        # parquet
+        parquet.close()
+        pyarrow.parquet.write_table(
+            pyarrow.Table.from_pylist(TESTDATA),
+            parquet.name,
+        )
+
+
+        files = [
+            gzipped_jsonl.name,
+            plain_csv.name,
+            parquet.name,
+        ]
+
+        yield files
+
+        for file in files:
+            os.remove(file)
+
+def test_loader(testfiles):
+    for testfile in testfiles:
+        data = [
+            row for row in load_dlt_file(testfile)
+        ]
+        assert data == TESTDATA

--- a/ingestr/src/loader_test.py
+++ b/ingestr/src/loader_test.py
@@ -1,31 +1,22 @@
-import os
 import csv
 import gzip
 import json
+import os
 import tempfile
 from typing import List
 
-import pytest
 import pyarrow.parquet
-
+import pytest
 from loader import load_dlt_file
 
 TESTDATA = [
-    {
-        "name": "Jhon",
-        "email": "jhon@acme.com"
-    },
-    {
-        "name": "Lisa",
-        "email": "lisa@acme.com"
-    },
+    {"name": "Jhon", "email": "jhon@acme.com"},
+    {"name": "Lisa", "email": "lisa@acme.com"},
 ]
 
+
 def tojsonl(datalist: List[dict]):
-    return "\n".join([
-        json.dumps(data)
-        for data in datalist
-    ]).encode()
+    return "\n".join([json.dumps(data) for data in datalist]).encode()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -57,7 +48,6 @@ def testfiles():
             parquet.name,
         )
 
-
         files = [
             gzipped_jsonl.name,
             plain_csv.name,
@@ -69,9 +59,8 @@ def testfiles():
         for file in files:
             os.remove(file)
 
+
 def test_loader(testfiles):
     for testfile in testfiles:
-        data = [
-            row for row in load_dlt_file(testfile)
-        ]
+        data = [row for row in load_dlt_file(testfile)]
         assert data == TESTDATA

--- a/ingestr/src/loader_test.py
+++ b/ingestr/src/loader_test.py
@@ -1,13 +1,17 @@
 import csv
 import gzip
 import json
+import logging
 import os
 import tempfile
 from typing import List
 
-import pyarrow.parquet
+import pyarrow.parquet  # type: ignore
 import pytest
-from loader import load_dlt_file
+
+from ingestr.src.loader import load_dlt_file
+
+logger = logging.getLogger(__name__)
 
 TESTDATA = [
     {"name": "Jhon", "email": "jhon@acme.com"},
@@ -57,7 +61,10 @@ def testfiles():
         yield files
 
         for file in files:
-            os.remove(file)
+            try:
+                os.remove(file)
+            except Exception as e:
+                logger.error(f"error removing temporary file {file}", exc_info=e)
 
 
 def test_loader(testfiles):


### PR DESCRIPTION
This change adds support for 3 of the 4 DLT [loader file](https://dlthub.com/docs/dlt-ecosystem/file-formats) formats to CSV Destination.

`INSERT` file format is currently not supported. Partly due to complexity involved and also because at this point it's unclear if any destinations/sources actually use it as their preferred loader file format.

All loaders implement streaming, so it's safe to load large files, at the cost of write throughput.