### PR TITLE
CI: PyPI Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: "Release ingestr on pip and ghcr.io"
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  pip-release:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: install uv
+        run: pip install uv
+      - name: install dependencies
+        run: uv pip install -r requirements-dev.txt
+      - name: build
+        run: make build
+      - name: release
+        run: make upload
+
+  docker-release:
+    needs: tests
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+    
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
   pip-release:
     runs-on: ubuntu-latest
     needs: tests
+    env:
+      # TODO: TWINE_USERNAME 
+      TWINE_PASSWORD: ${{ secrets.PYPI_INGESTR_TOKEN }}
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   workflow_dispatch: {}
+  workflow_call: {}
   pull_request:
     branches:
       - main
@@ -12,11 +11,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   tests:
@@ -70,39 +64,3 @@ jobs:
         run: make test-ci
       - name: check the formatting
         run: make lint-ci
-
-  build-and-push-image:
-    needs: tests
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules
 *.db
 *.db.wal
 *.sql
+ingestr/src/buildinfo.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+SHELL := /bin/bash
 .ONESHELL:
 .PHONY: test lint format test-ci lint-ci build upload-release setup docker-shell
+
+BUILDINFO=ingestr/src/buildinfo.py
 
 venv: venv/touchfile
 
@@ -36,7 +39,9 @@ lint-docs:
 tl: test lint
 
 build:
+	cat > ${BUILDINFO} <<< "version = \"$$(git describe --tags --abbrev=0)\""
 	rm -rf dist && python3 -m build
+	rm -f ${BUILDINFO}
 
 upload-release:
 	twine upload --verbose dist/*

--- a/ingestr/src/version.py
+++ b/ingestr/src/version.py
@@ -1,1 +1,5 @@
-__version__ = "0.13.3"
+try:
+    from ingestr.src import buildinfo
+    __version__ = buildinfo.version.lstrip("v")
+except ImportError:
+    __version__ = "0.0.0-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,10 @@ Homepage = "https://github.com/bruin-data/ingestr"
 Issues = "https://github.com/bruin-data/ingestr/issues"
 
 [tool.hatch.version]
+source = "code"
 path = "ingestr/src/version.py"
+expression = "__version__"
+search-paths = ["."]
 
 [tool.hatch.build.targets.wheel]
 packages = ["ingestr"]


### PR DESCRIPTION
This change adds a `release` workflow, and modifes the build system to accomodate git tag based versioning.

When `ingestr` is installed using `pip install $INGESTR_DIR`, the version is set to `0.0.0-dev`. Otherwise, it uses the latest availabe tag in git history.