### PR TITLE
fix: version command show `0.0.0-dev` for released versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ node_modules
 *.db
 *.db.wal
 *.sql
-ingestr/src/buildinfo.py
+./ingestr/src/buildinfo.py

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ node_modules
 *.db
 *.db.wal
 *.sql
-./ingestr/src/buildinfo.py
+ingestr/src/buildinfo.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,10 @@ packages = ["ingestr"]
 ingestr = "ingestr.main:main"
 
 [tool.hatch.build.targets.sdist]
+artifacts = [
+  "ingestr/src/buildinfo.py",
+]
+
 exclude = [
   "*_test.py",
   "*.db"


### PR DESCRIPTION
Hatchling by default doesn't bundle files that are `.gitignored`. Since we gitignored our buildinfo file, it wasn't being bundled during the release step.