### PR TITLE
version: use alternative baby proofing measure for version file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ node_modules
 *.db
 *.db.wal
 *.sql
-ingestr/src/buildinfo.py

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -2950,3 +2950,17 @@ def applovin_test_cases() -> Iterable[Callable]:
 )
 def test_applovin_source(testcase):
     testcase() 
+
+
+def test_version_cmd():
+    """
+    This should always be 0.0.0-dev.
+    """
+    from ingestr.src.version import __version__
+
+    msg = """
+    You maybe have commited ingestr/src/buildinfo.py to git.
+    Remove it to fix this error.
+    """
+
+    assert __version__ == "0.0.0-dev", msg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,10 +166,6 @@ packages = ["ingestr"]
 ingestr = "ingestr.main:main"
 
 [tool.hatch.build.targets.sdist]
-artifacts = [
-  "ingestr/src/buildinfo.py",
-]
-
 exclude = [
   "*_test.py",
   "*.db"


### PR DESCRIPTION
the `.gitignore` file is used by build system in non intuitive ways that makes it difficult to ship it.

Even when shipped as part of the distribution, pip will ignore the file when installing the package due to gitignore.

This change removes the buildinfo file from the gitignore, and instead uses a test to catch erronous buildinfo commits to our VCS.