### PR TITLE
sources: csv: remove empty columns from rows

### DIFF
--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -36,8 +36,8 @@ from testcontainers.clickhouse import ClickHouseContainer  # type: ignore
 from testcontainers.core.waiting_utils import wait_for_logs  # type: ignore
 from testcontainers.kafka import KafkaContainer  # type: ignore
 from testcontainers.localstack import LocalStackContainer  # type: ignore
+from testcontainers.mssql import SqlServerContainer  # type: ignore
 from testcontainers.mysql import MySqlContainer  # type: ignore
-from testcontainers.mssql import SqlServerContainer # type: ignore
 from testcontainers.postgres import PostgresContainer  # type: ignore
 from typer.testing import CliRunner
 
@@ -2950,7 +2950,7 @@ def applovin_test_cases() -> Iterable[Callable]:
 
 @pytest.mark.parametrize("testcase", applovin_test_cases())
 def test_applovin_source(testcase):
-    testcase() 
+    testcase()
 
 
 def test_version_cmd():

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -201,7 +201,7 @@ def test_create_replace_csv_to_duckdb():
         reader = csv.reader(f, delimiter=",", quotechar='"')
         next(reader, None)
         for row in reader:
-            actual_rows.append(row)
+            actual_rows.append([None if v.strip() == "" else v for v in row])
 
     # compare the CSV file with the DuckDB table
     assert len(res) == len(actual_rows)

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -41,6 +41,7 @@ from ingestr.src.sources import (
     LocalCsvSource,
     MongoDbSource,
     NotionSource,
+    PersonioSource,
     S3Source,
     SalesforceSource,
     ShopifySource,
@@ -49,7 +50,6 @@ from ingestr.src.sources import (
     StripeAnalyticsSource,
     TikTokSource,
     ZendeskSource,
-    PersonioSource,
 )
 
 SQL_SOURCE_SCHEMES = [

--- a/ingestr/src/personio/__init__.py
+++ b/ingestr/src/personio/__init__.py
@@ -165,7 +165,7 @@ def personio_source(
         Returns:
             Iterable: A generator of attendances.
         """
-        
+
         end_date = end_date or pendulum.now()
         if updated_at.last_value:
             updated_iso = updated_at.last_value.format("YYYY-MM-DDTHH:mm:ss")

--- a/ingestr/src/personio/helpers.py
+++ b/ingestr/src/personio/helpers.py
@@ -1,4 +1,5 @@
 """Personio source helpers"""
+
 from typing import Any, Iterable, Optional
 from urllib.parse import urljoin
 

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -402,6 +402,7 @@ class LocalCsvSource:
                         if inc_value < incremental.start_value:
                             continue
 
+                    dictionary = self.remove_empty_columns(dictionary)
                     page.append(dictionary)
                     current_items += 1
                 else:
@@ -424,6 +425,9 @@ class LocalCsvSource:
                 range_start="closed",
             )
         )
+
+    def remove_empty_columns(self, row: Dict[str, str]) -> Dict[str, str]:
+        return {k: v for k, v in row.items() if v.strip() != ""}
 
 
 class NotionSource:


### PR DESCRIPTION
Remove empty fields when emitting data to DLT.

This addresses a bug in `dlt` for csv data where a column is missing a value. When the type is set to `float`, dlt treats the empty field as a text value and creates a different column.