### PR TITLE
Athena: Add support for partitioning

### DIFF
--- a/ingestr/main.py
+++ b/ingestr/main.py
@@ -10,6 +10,9 @@ from typing_extensions import Annotated
 
 from ingestr.src.filters import cast_set_to_list
 from ingestr.src.telemetry.event import track
+from ingestr.src.destinations import AthenaDestination
+
+from dlt.destinations.adapters import athena_adapter
 
 app = typer.Typer(
     name="ingestr",
@@ -560,6 +563,9 @@ def ingest(
                 x.apply_hints(columns=column_hints)
 
         run_on_resource(dlt_source, col_h)
+
+        if isinstance(destination, AthenaDestination) and partition_by:
+            run_on_resource(dlt_source, lambda x: athena_adapter(x, partition_by))
 
         if original_incremental_strategy == IncrementalStrategy.delete_insert:
 

--- a/ingestr/main.py
+++ b/ingestr/main.py
@@ -557,7 +557,7 @@ def ingest(
         resource.for_each(dlt_source, col_h)
 
         if isinstance(destination, AthenaDestination) and partition_by:
-            partition.apply_athena_hints(dlt_source, partition_by)
+            partition.apply_athena_hints(dlt_source, partition_by, column_hints)
 
         if original_incremental_strategy == IncrementalStrategy.delete_insert:
 

--- a/ingestr/src/partition.py
+++ b/ingestr/src/partition.py
@@ -13,6 +13,7 @@ def apply_athena_hints(
     additional_hints: Dict[str, TColumnSchema] = {},
 ) -> None:
     def _apply_partition_hint(resource: DltResource) -> None:
+        
         columns = resource.columns if resource.columns else {}
 
         partition_hint = (
@@ -20,13 +21,10 @@ def apply_athena_hints(
             or additional_hints.get(partition_column)
         )
 
-        if partition_hint is None:
-            return
-
         athena_adapter(
             resource,
             athena_partition.day(partition_column)
-            if partition_hint["data_type"] in ("timestamp", "date")
+            if partition_hint and partition_hint["data_type"] in ("timestamp", "date")
             else partition_column,
         )
 

--- a/ingestr/src/partition.py
+++ b/ingestr/src/partition.py
@@ -1,0 +1,23 @@
+from dlt.destinations.adapters import athena_adapter, athena_partition
+from dlt.sources import DltResource, DltSource
+
+import ingestr.src.resource as resource
+
+
+def apply_athena_hints(source: DltSource | DltResource, partition_column: str) -> None:
+    def _apply_partition_hint(resource: DltResource) -> None:
+        if resource.columns is None:
+            return
+
+        partition_hint = resource.columns.get(partition_column)  # type: ignore[union-attr]
+        if partition_hint is None:
+            return
+
+        athena_adapter(
+            resource,
+            athena_partition.day(partition_column)
+            if partition_hint["data_type"] in ("timestamp", "date")
+            else partition_column,
+        )
+
+    resource.for_each(source, _apply_partition_hint)

--- a/ingestr/src/partition.py
+++ b/ingestr/src/partition.py
@@ -1,15 +1,25 @@
+from typing import Dict
+
+from dlt.common.schema.typing import TColumnSchema
 from dlt.destinations.adapters import athena_adapter, athena_partition
 from dlt.sources import DltResource, DltSource
 
 import ingestr.src.resource as resource
 
 
-def apply_athena_hints(source: DltSource | DltResource, partition_column: str) -> None:
+def apply_athena_hints(
+    source: DltSource | DltResource,
+    partition_column: str,
+    additional_hints: Dict[str, TColumnSchema] = {},
+) -> None:
     def _apply_partition_hint(resource: DltResource) -> None:
-        if resource.columns is None:
-            return
+        columns = resource.columns if resource.columns else {}
 
-        partition_hint = resource.columns.get(partition_column)  # type: ignore[union-attr]
+        partition_hint = (
+            columns.get(partition_column)  # type: ignore
+            or additional_hints.get(partition_column)
+        )
+
         if partition_hint is None:
             return
 

--- a/ingestr/src/partition.py
+++ b/ingestr/src/partition.py
@@ -13,7 +13,7 @@ def apply_athena_hints(
     additional_hints: Dict[str, TColumnSchema] = {},
 ) -> None:
     def _apply_partition_hint(resource: DltResource) -> None:
-        
+
         columns = resource.columns if resource.columns else {}
 
         partition_hint = (
@@ -24,7 +24,7 @@ def apply_athena_hints(
         athena_adapter(
             resource,
             athena_partition.day(partition_column)
-            if partition_hint and partition_hint["data_type"] in ("timestamp", "date")
+            if partition_hint and partition_hint.get("data_type") in ("timestamp", "date")
             else partition_column,
         )
 

--- a/ingestr/src/resource.py
+++ b/ingestr/src/resource.py
@@ -1,0 +1,17 @@
+from typing import Callable
+
+from dlt.sources import DltResource, DltSource
+
+
+def for_each(
+    source: DltSource | DltResource, ex: Callable[[DltResource], None | DltResource]
+):
+    """
+    Apply a function to each resource in a source.
+    """
+    if hasattr(source, "selected_resources") and source.selected_resources:
+        resource_names = list(source.selected_resources.keys())
+        for res in resource_names:
+            ex(source.resources[res])  # type: ignore[union-attr]
+    else:
+        ex(source)  # type: ignore[arg-type]


### PR DESCRIPTION
This PR adds support for partitioning athena tables.

`--partition-by` specifies which column is used as the partitioning column. If the data type of the partition column is `date` or `timestamp` then the partitioning happens on a `day` interval. Otherwise, the table is partitioned on the value of the column.

For inferring the data type, both source type hints and `--columns` hints are referenced. Source hints take precedence over command line column hints.