### PR TITLE
speed up imports

### DIFF
--- a/ingestr/main.py
+++ b/ingestr/main.py
@@ -3,11 +3,9 @@ from enum import Enum
 from typing import Optional
 
 import typer
-from dlt.common.runtime.collector import Collector
 from rich.console import Console
 from rich.status import Status
 from typing_extensions import Annotated
-
 import ingestr.src.partition as partition
 import ingestr.src.resource as resource
 from ingestr.src.destinations import AthenaDestination
@@ -44,45 +42,6 @@ PARQUET_SUPPORTED_DESTINATIONS = [
 
 # these sources would return a JSON for sure, which means they cannot be used with Parquet loader for BigQuery
 JSON_RETURNING_SOURCES = ["notion"]
-
-
-class SpinnerCollector(Collector):
-    status: Status
-    current_step: str
-    started: bool
-
-    def __init__(self) -> None:
-        self.status = Status("Ingesting data...", spinner="dots")
-        self.started = False
-
-    def update(
-        self,
-        name: str,
-        inc: int = 1,
-        total: Optional[int] = None,
-        message: Optional[str] = None,  # type: ignore
-        label: str = "",
-        **kwargs,
-    ) -> None:
-        self.status.update(self.current_step)
-
-    def _start(self, step: str) -> None:
-        self.current_step = self.__step_to_label(step)
-        self.status.start()
-
-    def __step_to_label(self, step: str) -> str:
-        verb = step.split(" ")[0].lower()
-        if verb.startswith("normalize"):
-            return "Normalizing the data"
-        elif verb.startswith("load"):
-            return "Loading the data to the destination"
-        elif verb.startswith("extract"):
-            return "Extracting the data from the source"
-
-        return f"{verb.capitalize()} the data"
-
-    def _stop(self) -> None:
-        self.status.stop()
 
 
 class IncrementalStrategy(str, Enum):
@@ -314,6 +273,44 @@ def ingest(
 
     from ingestr.src.factory import SourceDestinationFactory
     from ingestr.src.telemetry.event import track
+
+    class SpinnerCollector(Collector):
+        status: Status
+        current_step: str
+        started: bool
+
+        def __init__(self) -> None:
+            self.status = Status("Ingesting data...", spinner="dots")
+            self.started = False
+
+        def update(
+            self,
+            name: str,
+            inc: int = 1,
+            total: Optional[int] = None,
+            message: Optional[str] = None,  # type: ignore
+            label: str = "",
+            **kwargs,
+        ) -> None:
+            self.status.update(self.current_step)
+
+        def _start(self, step: str) -> None:
+            self.current_step = self.__step_to_label(step)
+            self.status.start()
+
+        def __step_to_label(self, step: str) -> str:
+            verb = step.split(" ")[0].lower()
+            if verb.startswith("normalize"):
+                return "Normalizing the data"
+            elif verb.startswith("load"):
+                return "Loading the data to the destination"
+            elif verb.startswith("extract"):
+                return "Extracting the data from the source"
+
+            return f"{verb.capitalize()} the data"
+
+        def _stop(self) -> None:
+            self.status.stop()
 
     def report_errors(run_info: LoadInfo):
         for load_package in run_info.load_packages:

--- a/ingestr/src/destinations.py
+++ b/ingestr/src/destinations.py
@@ -6,12 +6,6 @@ import shutil
 import tempfile
 from urllib.parse import parse_qs, quote, urlparse
 
-import dlt
-from dlt.common.configuration.specs import AwsCredentials
-from dlt.destinations.impl.clickhouse.configuration import (
-    ClickHouseCredentials,
-)
-
 from ingestr.src.loader import load_dlt_file
 
 
@@ -64,7 +58,8 @@ class BigQueryDestination:
         if source_fields.hostname:
             project_id = source_fields.hostname
 
-        return dlt.destinations.bigquery(
+        from dlt.destinations import bigquery
+        return bigquery(
             credentials=credentials,  # type: ignore
             location=location,
             project_id=project_id,
@@ -91,43 +86,46 @@ class BigQueryDestination:
 
 class PostgresDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.postgres(credentials=uri, **kwargs)
+        from dlt.destinations import postgres
+        return postgres(credentials=uri, **kwargs)
 
 
 class SnowflakeDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.snowflake(credentials=uri, **kwargs)
+        from dlt.destinations import snowflake
+        return snowflake(credentials=uri, **kwargs)
 
 
 class RedshiftDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.redshift(
+        from dlt.destinations import redshift
+        return redshift(
             credentials=uri.replace("redshift://", "postgresql://"), **kwargs
         )
 
 
 class DuckDBDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.duckdb(uri, **kwargs)
+        from dlt.destinations import duckdb
+        return duckdb(uri, **kwargs)
 
 
 class MsSQLDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.mssql(credentials=uri, **kwargs)
+        from dlt.destinations import mssql
+        return mssql(credentials=uri, **kwargs)
 
 
 class DatabricksDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.databricks(credentials=uri, **kwargs)
+        from dlt.destinations import databricks
+        return databricks(credentials=uri, **kwargs)
 
 
 class SynapseDestination(GenericSqlDestination):
     def dlt_dest(self, uri: str, **kwargs):
-        return dlt.destinations.synapse(credentials=uri, **kwargs)
-
-
-class CustomCsvDestination(dlt.destinations.filesystem):
-    pass
+        from dlt.destinations import synapse
+        return synapse(credentials=uri, **kwargs)
 
 
 class CsvDestination(GenericSqlDestination):
@@ -160,7 +158,8 @@ class CsvDestination(GenericSqlDestination):
         temp_path = tempfile.mkdtemp()
         self.actual_path = uri
         self.temp_path = temp_path
-        return CustomCsvDestination(bucket_url=f"file://{temp_path}", **kwargs)
+        from dlt.destinations import filesystem
+        return filesystem(bucket_url=f"file://{temp_path}", **kwargs)
 
     # I dislike this implementation quite a bit since it ties the implementation to some internal details on how dlt works
     # I would prefer a custom destination that allows me to do this easily but dlt seems to have a lot of internal details that are not documented
@@ -242,12 +241,14 @@ class AthenaDestination:
             secret_access_key
         )
 
+        from dlt.common.configuration.specs import AwsCredentials
         credentials = AwsCredentials(
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
             region_name=region_name,
         )
-        return dlt.destinations.athena(
+        from dlt.destinations import athena
+        return athena(
             query_result_bucket=query_result_path,
             athena_work_group=work_group,
             credentials=credentials,
@@ -318,6 +319,9 @@ class ClickhouseDestination:
                 "Invalid value for secure. Set to `1` for a secure HTTPS connection or `0` for a non-secure HTTP connection."
             )
 
+        from dlt.destinations.impl.clickhouse.configuration import (
+            ClickHouseCredentials,
+        )
         credentials = ClickHouseCredentials(
             {
                 "host": host,
@@ -329,7 +333,8 @@ class ClickhouseDestination:
                 "secure": secure,
             }
         )
-        return dlt.destinations.clickhouse(credentials=credentials)
+        from dlt.destinations import clickhouse
+        return clickhouse(credentials=credentials)
 
     def dlt_run_params(self, uri: str, table: str, **kwargs) -> dict:
         table_fields = table.split(".")

--- a/ingestr/src/filters.py
+++ b/ingestr/src/filters.py
@@ -1,4 +1,4 @@
-from dlt.common.libs.sql_alchemy import Table
+
 
 
 def cast_set_to_list(row):
@@ -11,7 +11,8 @@ def cast_set_to_list(row):
 
 
 def table_adapter_exclude_columns(cols: list[str]):
-    def excluder(table: Table):
+    # from dlt.common.libs.sql_alchemy import Table
+    def excluder(table):
         cols_to_remove = [col for col in table._columns if col.name in cols]  # type: ignore
         for col in cols_to_remove:
             table._columns.remove(col)  # type: ignore

--- a/ingestr/src/loader.py
+++ b/ingestr/src/loader.py
@@ -3,9 +3,7 @@ import gzip
 import json
 import subprocess
 from contextlib import contextmanager
-from typing import Generator
-
-from pyarrow.parquet import ParquetFile  # type: ignore
+from typing import Generator  # type: ignore
 
 PARQUET_BATCH_SIZE = 64
 
@@ -61,6 +59,8 @@ def csvfile(filepath: str):
 
 @contextmanager
 def parquetfile(filepath: str):
+    from pyarrow.parquet import ParquetFile
+    
     def reader(pf: ParquetFile):
         for batch in pf.iter_batches(PARQUET_BATCH_SIZE):
             yield from batch.to_pylist()

--- a/ingestr/src/partition.py
+++ b/ingestr/src/partition.py
@@ -1,17 +1,14 @@
 from typing import Dict
 
-from dlt.common.schema.typing import TColumnSchema
-from dlt.destinations.adapters import athena_adapter, athena_partition
-from dlt.sources import DltResource, DltSource
-
-import ingestr.src.resource as resource
-
-
 def apply_athena_hints(
-    source: DltSource | DltResource,
+    source,
     partition_column: str,
-    additional_hints: Dict[str, TColumnSchema] = {},
+    additional_hints: Dict[str, "TColumnSchema"] = {},
 ) -> None:
+    import ingestr.src.resource as resource
+    from dlt.destinations.adapters import athena_adapter, athena_partition
+    from dlt.sources import DltResource, DltSource
+
     def _apply_partition_hint(resource: DltResource) -> None:
 
         columns = resource.columns if resource.columns else {}

--- a/ingestr/src/resource.py
+++ b/ingestr/src/resource.py
@@ -1,11 +1,7 @@
 from typing import Callable
 
-from dlt.sources import DltResource, DltSource
 
-
-def for_each(
-    source: DltSource | DltResource, ex: Callable[[DltResource], None | DltResource]
-):
+def for_each(source):
     """
     Apply a function to each resource in a source.
     """


### PR DESCRIPTION
this PR is an experiment on speeding up the imports. I haven't actually tested the execution, just the imports.
 
before:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/144b92c2-7b7e-4e5e-9e87-c96fb0d05a2b" />


after:
<img width="660" alt="image" src="https://github.com/user-attachments/assets/9eca9ae6-feb9-42ae-a9b3-7ff61970727d" />

after removing pyarrow parquet import:
<img width="663" alt="image" src="https://github.com/user-attachments/assets/81a55516-8aaf-4a04-9222-a7fd57e31b71" />

