### PR TITLE
Feat/pipedrive as source

### DIFF
--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -51,6 +51,7 @@ from ingestr.src.sources import (
     StripeAnalyticsSource,
     TikTokSource,
     ZendeskSource,
+    PipedriveSource,
 )
 
 SQL_SOURCE_SCHEMES = [
@@ -144,6 +145,7 @@ class SourceDestinationFactory:
         "salesforce": SalesforceSource,
         "personio": PersonioSource,
         "kinesis": KinesisSource,
+        "pipedrive": PipedriveSource,
     }
     destinations: Dict[str, Type[DestinationProtocol]] = {
         "bigquery": BigQueryDestination,

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -43,6 +43,7 @@ from ingestr.src.sources import (
     MongoDbSource,
     NotionSource,
     PersonioSource,
+    PipedriveSource,
     S3Source,
     SalesforceSource,
     ShopifySource,
@@ -51,7 +52,6 @@ from ingestr.src.sources import (
     StripeAnalyticsSource,
     TikTokSource,
     ZendeskSource,
-    PipedriveSource,
 )
 
 SQL_SOURCE_SCHEMES = [

--- a/ingestr/src/pipedrive/__init__.py
+++ b/ingestr/src/pipedrive/__init__.py
@@ -9,18 +9,18 @@ Api changelog: https://developers.pipedrive.com/changelog
 To get an api key: https://pipedrive.readme.io/docs/how-to-find-the-api-token
 """
 
-from typing import Any, Dict, Iterator, List, Optional, Union, Iterable, Iterator, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Union  # noqa: F401
 
 import dlt
-
-from .helpers.custom_fields_munger import update_fields_mapping, rename_fields
-from .helpers.pages import get_recent_items_incremental, get_pages
-from .helpers import group_deal_flows
-from .typing import TDataPage
-from .settings import ENTITY_MAPPINGS, RECENTS_ENTITIES
 from dlt.common import pendulum
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.sources import DltResource, TDataItems
+
+from .helpers import group_deal_flows
+from .helpers.custom_fields_munger import rename_fields, update_fields_mapping
+from .helpers.pages import get_pages, get_recent_items_incremental
+from .settings import ENTITY_MAPPINGS, RECENTS_ENTITIES
+from .typing import TDataPage
 
 
 @dlt.source(name="pipedrive", max_table_nesting=0)
@@ -123,9 +123,9 @@ def create_state(pipedrive_api_key: str) -> Iterator[Dict[str, Any]]:
     def _get_pages_for_rename(
         entity: str, fields_entity: str, pipedrive_api_key: str
     ) -> Dict[str, Any]:
-        existing_fields_mapping: Dict[
-            str, Dict[str, str]
-        ] = custom_fields_mapping.setdefault(entity, {})
+        existing_fields_mapping: Dict[str, Dict[str, str]] = (
+            custom_fields_mapping.setdefault(entity, {})
+        )
         # we need to process all pages before yielding
         for page in get_pages(fields_entity, pipedrive_api_key):
             existing_fields_mapping = update_fields_mapping(
@@ -153,7 +153,7 @@ def create_state(pipedrive_api_key: str) -> Iterator[Dict[str, Any]]:
     columns={"options": {"data_type": "json"}},
 )
 def parsed_mapping(
-    custom_fields_mapping: Dict[str, Any]
+    custom_fields_mapping: Dict[str, Any],
 ) -> Optional[Iterator[List[Dict[str, str]]]]:
     """
     Parses and yields custom fields' mapping in order to be stored in destiny by dlt

--- a/ingestr/src/pipedrive/__init__.py
+++ b/ingestr/src/pipedrive/__init__.py
@@ -1,0 +1,198 @@
+"""Highly customizable source for Pipedrive, supports endpoint addition, selection and column rename
+
+Pipedrive api docs: https://developers.pipedrive.com/docs/api/v1
+
+Pipedrive changes or deprecates fields and endpoints without versioning the api.
+If something breaks, it's a good idea to check the changelog.
+Api changelog: https://developers.pipedrive.com/changelog
+
+To get an api key: https://pipedrive.readme.io/docs/how-to-find-the-api-token
+"""
+
+from typing import Any, Dict, Iterator, List, Optional, Union, Iterable, Iterator, Tuple
+
+import dlt
+
+from .helpers.custom_fields_munger import update_fields_mapping, rename_fields
+from .helpers.pages import get_recent_items_incremental, get_pages
+from .helpers import group_deal_flows
+from .typing import TDataPage
+from .settings import ENTITY_MAPPINGS, RECENTS_ENTITIES
+from dlt.common import pendulum
+from dlt.common.time import ensure_pendulum_datetime
+from dlt.sources import DltResource, TDataItems
+
+
+@dlt.source(name="pipedrive")
+def pipedrive_source(
+    pipedrive_api_key: str = dlt.secrets.value,
+    since_timestamp: Optional[Union[pendulum.DateTime, str]] = "1970-01-01 00:00:00",
+) -> Iterator[DltResource]:
+    """
+    Get data from the Pipedrive API. Supports incremental loading and custom fields mapping.
+
+    Args:
+        pipedrive_api_key: https://pipedrive.readme.io/docs/how-to-find-the-api-token
+        since_timestamp: Starting timestamp for incremental loading. By default complete history is loaded on first run.
+        incremental: Enable or disable incremental loading.
+
+    Returns resources:
+        custom_fields_mapping
+        activities
+        activityTypes
+        deals
+        deals_flow
+        deals_participants
+        files
+        filters
+        notes
+        persons
+        organizations
+        pipelines
+        products
+        stages
+        users
+        leads
+
+    For custom fields rename the `custom_fields_mapping` resource must be selected or loaded before other resources.
+
+    Resources that depend on another resource are implemented as transformers
+    so they can re-use the original resource data without re-downloading.
+    Examples:  deals_participants, deals_flow
+    """
+
+    # yield nice rename mapping
+    yield create_state(pipedrive_api_key) | parsed_mapping
+
+    # parse timestamp and build kwargs
+    since_timestamp = ensure_pendulum_datetime(since_timestamp).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    resource_kwargs: Any = (
+        {"since_timestamp": since_timestamp} if since_timestamp else {}
+    )
+
+    # create resources for all endpoints
+    endpoints_resources = {}
+    for entity, resource_name in RECENTS_ENTITIES.items():
+        endpoints_resources[resource_name] = dlt.resource(
+            get_recent_items_incremental,
+            name=resource_name,
+            primary_key="id",
+            write_disposition="merge",
+        )(entity, pipedrive_api_key, **resource_kwargs)
+
+    yield from endpoints_resources.values()
+
+    # create transformers for deals to participants and flows
+    yield endpoints_resources["deals"] | dlt.transformer(
+        name="deals_participants", write_disposition="merge", primary_key="id"
+    )(_get_deals_participants)(pipedrive_api_key)
+
+    yield endpoints_resources["deals"] | dlt.transformer(
+        name="deals_flow", write_disposition="merge", primary_key="id"
+    )(_get_deals_flow)(pipedrive_api_key)
+
+    yield leads(pipedrive_api_key, update_time=since_timestamp)
+
+
+def _get_deals_flow(
+    deals_page: TDataPage, pipedrive_api_key: str
+) -> Iterator[TDataItems]:
+    custom_fields_mapping = dlt.current.source_state().get("custom_fields_mapping", {})
+    for row in deals_page:
+        url = f"deals/{row['id']}/flow"
+        pages = get_pages(url, pipedrive_api_key)
+        for entity, page in group_deal_flows(pages):
+            yield dlt.mark.with_table_name(
+                rename_fields(page, custom_fields_mapping.get(entity, {})),
+                "deals_flow_" + entity,
+            )
+
+
+def _get_deals_participants(
+    deals_page: TDataPage, pipedrive_api_key: str
+) -> Iterator[TDataPage]:
+    for row in deals_page:
+        url = f"deals/{row['id']}/participants"
+        yield from get_pages(url, pipedrive_api_key)
+
+
+@dlt.resource(selected=False)
+def create_state(pipedrive_api_key: str) -> Iterator[Dict[str, Any]]:
+    def _get_pages_for_rename(
+        entity: str, fields_entity: str, pipedrive_api_key: str
+    ) -> Dict[str, Any]:
+        existing_fields_mapping: Dict[
+            str, Dict[str, str]
+        ] = custom_fields_mapping.setdefault(entity, {})
+        # we need to process all pages before yielding
+        for page in get_pages(fields_entity, pipedrive_api_key):
+            existing_fields_mapping = update_fields_mapping(
+                page, existing_fields_mapping
+            )
+        return existing_fields_mapping
+
+    # gets all *Fields data and stores in state
+    custom_fields_mapping = dlt.current.source_state().setdefault(
+        "custom_fields_mapping", {}
+    )
+    for entity, fields_entity, _ in ENTITY_MAPPINGS:
+        if fields_entity is None:
+            continue
+        custom_fields_mapping[entity] = _get_pages_for_rename(
+            entity, fields_entity, pipedrive_api_key
+        )
+
+    yield custom_fields_mapping
+
+
+@dlt.transformer(
+    name="custom_fields_mapping",
+    write_disposition="replace",
+    columns={"options": {"data_type": "json"}},
+)
+def parsed_mapping(
+    custom_fields_mapping: Dict[str, Any]
+) -> Optional[Iterator[List[Dict[str, str]]]]:
+    """
+    Parses and yields custom fields' mapping in order to be stored in destiny by dlt
+    """
+    for endpoint, data_item_mapping in custom_fields_mapping.items():
+        yield [
+            {
+                "endpoint": endpoint,
+                "hash_string": hash_string,
+                "name": names["name"],
+                "normalized_name": names["normalized_name"],
+                "options": names["options"],
+                "field_type": names["field_type"],
+            }
+            for hash_string, names in data_item_mapping.items()
+        ]
+
+
+@dlt.resource(primary_key="id", write_disposition="merge")
+def leads(
+    pipedrive_api_key: str = dlt.secrets.value,
+    update_time: dlt.sources.incremental[str] = dlt.sources.incremental(
+        "update_time", "1970-01-01 00:00:00"
+    ),
+) -> Iterator[TDataPage]:
+    """Resource to incrementally load pipedrive leads by update_time"""
+    # Leads inherit custom fields from deals
+    fields_mapping = (
+        dlt.current.source_state().get("custom_fields_mapping", {}).get("deals", {})
+    )
+    # Load leads pages sorted from newest to oldest and stop loading when
+    # last incremental value is reached
+    pages = get_pages(
+        "leads",
+        pipedrive_api_key,
+        extra_params={"sort": "update_time DESC"},
+    )
+    for page in pages:
+        yield rename_fields(page, fields_mapping)
+
+        if update_time.start_out_of_range:
+            return

--- a/ingestr/src/pipedrive/__init__.py
+++ b/ingestr/src/pipedrive/__init__.py
@@ -23,7 +23,7 @@ from dlt.common.time import ensure_pendulum_datetime
 from dlt.sources import DltResource, TDataItems
 
 
-@dlt.source(name="pipedrive")
+@dlt.source(name="pipedrive", max_table_nesting=0)
 def pipedrive_source(
     pipedrive_api_key: str = dlt.secrets.value,
     since_timestamp: Optional[Union[pendulum.DateTime, str]] = "1970-01-01 00:00:00",

--- a/ingestr/src/pipedrive/helpers/__init__.py
+++ b/ingestr/src/pipedrive/helpers/__init__.py
@@ -1,0 +1,21 @@
+"""Pipedrive source helpers"""
+
+from dlt.common import pendulum
+from typing import Any, Iterable, Tuple, Dict, List, cast
+from itertools import groupby
+
+
+def _deals_flow_group_key(item: Dict[str, Any]) -> str:
+    return item["object"]  # type: ignore[no-any-return]
+
+
+def group_deal_flows(
+    pages: Iterable[Iterable[Dict[str, Any]]]
+) -> Iterable[Tuple[str, List[Dict[str, Any]]]]:
+    for page in pages:
+        for entity, items in groupby(
+            sorted(page, key=_deals_flow_group_key), key=_deals_flow_group_key
+        ):
+            yield entity, [
+                dict(item["data"], timestamp=item["timestamp"]) for item in items
+            ]

--- a/ingestr/src/pipedrive/helpers/__init__.py
+++ b/ingestr/src/pipedrive/helpers/__init__.py
@@ -1,8 +1,9 @@
 """Pipedrive source helpers"""
 
-from dlt.common import pendulum
-from typing import Any, Iterable, Tuple, Dict, List, cast
 from itertools import groupby
+from typing import Any, Dict, Iterable, List, Tuple, cast  # noqa: F401
+
+from dlt.common import pendulum  # noqa: F401
 
 
 def _deals_flow_group_key(item: Dict[str, Any]) -> str:
@@ -10,12 +11,13 @@ def _deals_flow_group_key(item: Dict[str, Any]) -> str:
 
 
 def group_deal_flows(
-    pages: Iterable[Iterable[Dict[str, Any]]]
+    pages: Iterable[Iterable[Dict[str, Any]]],
 ) -> Iterable[Tuple[str, List[Dict[str, Any]]]]:
     for page in pages:
         for entity, items in groupby(
             sorted(page, key=_deals_flow_group_key), key=_deals_flow_group_key
         ):
-            yield entity, [
-                dict(item["data"], timestamp=item["timestamp"]) for item in items
-            ]
+            yield (
+                entity,
+                [dict(item["data"], timestamp=item["timestamp"]) for item in items],
+            )

--- a/ingestr/src/pipedrive/helpers/custom_fields_munger.py
+++ b/ingestr/src/pipedrive/helpers/custom_fields_munger.py
@@ -1,0 +1,102 @@
+from typing import Any, Dict, Iterable, Iterator, TypedDict, Optional
+
+import dlt
+
+from ..typing import TDataPage
+
+
+class TFieldMapping(TypedDict):
+    name: str
+    normalized_name: str
+    options: Optional[Dict[str, str]]
+    field_type: str
+
+
+def update_fields_mapping(
+    new_fields_mapping: TDataPage, existing_fields_mapping: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Specific function to perform data munging and push changes to custom fields' mapping stored in dlt's state
+    The endpoint must be an entity fields' endpoint
+    """
+    for data_item in new_fields_mapping:
+        # 'edit_flag' field contains a boolean value, which is set to 'True' for custom fields and 'False' otherwise.
+        if data_item.get("edit_flag"):
+            # Regarding custom fields, 'key' field contains pipedrive's hash string representation of its name
+            # We assume that pipedrive's hash strings are meant to be an univoque representation of custom fields' name, so dlt's state shouldn't be updated while those values
+            # remain unchanged
+            existing_fields_mapping = _update_field(data_item, existing_fields_mapping)
+        # Built in enum and set fields are mapped if their options have int ids
+        # Enum fields with bool and string key options are left intact
+        elif data_item.get("field_type") in {"set", "enum"}:
+            options = data_item.get("options", [])
+            first_option = options[0]["id"] if len(options) >= 1 else None
+            if isinstance(first_option, int) and not isinstance(first_option, bool):
+                existing_fields_mapping = _update_field(
+                    data_item, existing_fields_mapping
+                )
+    return existing_fields_mapping
+
+
+def _update_field(
+    data_item: Dict[str, Any],
+    existing_fields_mapping: Optional[Dict[str, TFieldMapping]],
+) -> Dict[str, TFieldMapping]:
+    """Create or update the given field's info the custom fields state
+    If the field hash already exists in the state from previous runs the name is not updated.
+    New enum options (if any) are appended to the state.
+    """
+    existing_fields_mapping = existing_fields_mapping or {}
+    key = data_item["key"]
+    options = data_item.get("options", [])
+    new_options_map = {str(o["id"]): o["label"] for o in options}
+    existing_field = existing_fields_mapping.get(key)
+    if not existing_field:
+        existing_fields_mapping[key] = dict(
+            name=data_item["name"],
+            normalized_name=_normalized_name(data_item["name"]),
+            options=new_options_map,
+            field_type=data_item["field_type"],
+        )
+        return existing_fields_mapping
+    existing_options = existing_field.get("options", {})
+    if not existing_options or existing_options == new_options_map:
+        existing_field["options"] = new_options_map
+        existing_field["field_type"] = data_item[
+            "field_type"
+        ]  # Add for backwards compat
+        return existing_fields_mapping
+    # Add new enum options to the existing options array
+    # so that when option is renamed the original label remains valid
+    new_option_keys = set(new_options_map) - set(existing_options)
+    for key in new_option_keys:
+        existing_options[key] = new_options_map[key]
+    existing_field["options"] = existing_options
+    return existing_fields_mapping
+
+
+def _normalized_name(name: str) -> str:
+    source_schema = dlt.current.source_schema()
+    normalized_name = name.strip()  # remove leading and trailing spaces
+    return source_schema.naming.normalize_identifier(normalized_name)
+
+
+def rename_fields(data: TDataPage, fields_mapping: Dict[str, Any]) -> TDataPage:
+    if not fields_mapping:
+        return data
+    for data_item in data:
+        for hash_string, field in fields_mapping.items():
+            if hash_string not in data_item:
+                continue
+            field_value = data_item.pop(hash_string)
+            field_name = field["name"]
+            options_map = field["options"]
+            # Get label instead of ID for 'enum' and 'set' fields
+            if field_value and field["field_type"] == "set":  # Multiple choice
+                field_value = [
+                    options_map.get(str(enum_id), enum_id) for enum_id in field_value
+                ]
+            elif field_value and field["field_type"] == "enum":
+                field_value = options_map.get(str(field_value), field_value)
+            data_item[field_name] = field_value
+    return data

--- a/ingestr/src/pipedrive/helpers/custom_fields_munger.py
+++ b/ingestr/src/pipedrive/helpers/custom_fields_munger.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Iterator, TypedDict, Optional
+from typing import Any, Dict, Optional, TypedDict
 
 import dlt
 

--- a/ingestr/src/pipedrive/helpers/pages.py
+++ b/ingestr/src/pipedrive/helpers/pages.py
@@ -1,0 +1,117 @@
+from itertools import chain, groupby
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
+
+import dlt
+from dlt.sources.helpers import requests
+
+from .custom_fields_munger import rename_fields
+from ..typing import TDataPage
+
+
+def get_pages(
+    entity: str, pipedrive_api_key: str, extra_params: Dict[str, Any] = None
+) -> Iterator[List[Dict[str, Any]]]:
+    """
+    Generic method to retrieve endpoint data based on the required headers and params.
+
+    Args:
+        entity: the endpoint you want to call
+        pipedrive_api_key:
+        extra_params: any needed request params except pagination.
+
+    Returns:
+
+    """
+    headers = {"Content-Type": "application/json"}
+    params = {"api_token": pipedrive_api_key}
+    if extra_params:
+        params.update(extra_params)
+    url = f"https://app.pipedrive.com/v1/{entity}"
+    yield from _paginated_get(url, headers=headers, params=params)
+
+
+def get_recent_items_incremental(
+    entity: str,
+    pipedrive_api_key: str,
+    since_timestamp: dlt.sources.incremental[str] = dlt.sources.incremental(
+        "update_time|modified", "1970-01-01 00:00:00"
+    ),
+) -> Iterator[TDataPage]:
+    """Get a specific entity type from /recents with incremental state."""
+    yield from _get_recent_pages(entity, pipedrive_api_key, since_timestamp.last_value)
+
+
+def _paginated_get(
+    url: str, headers: Dict[str, Any], params: Dict[str, Any]
+) -> Iterator[List[Dict[str, Any]]]:
+    """
+    Requests and yields data 500 records at a time
+    Documentation: https://pipedrive.readme.io/docs/core-api-concepts-pagination
+    """
+    # pagination start and page limit
+    params["start"] = 0
+    params["limit"] = 500
+    while True:
+        page = requests.get(url, headers=headers, params=params).json()
+        # yield data only
+        data = page["data"]
+        if data:
+            yield data
+        # check if next page exists
+        pagination_info = page.get("additional_data", {}).get("pagination", {})
+        # is_next_page is set to True or False
+        if not pagination_info.get("more_items_in_collection", False):
+            break
+        params["start"] = pagination_info.get("next_start")
+
+
+T = TypeVar("T")
+
+
+def _extract_recents_data(data: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Results from recents endpoint contain `data` key which is either a single entity or list of entities
+
+    This returns a flat list of entities from an iterable of recent results
+    """
+    return [
+        data_item
+        for data_item in chain.from_iterable(
+            (_list_wrapped(item["data"]) for item in data)
+        )
+        if data_item is not None
+    ]
+
+
+def _list_wrapped(item: Union[List[T], T]) -> List[T]:
+    if isinstance(item, list):
+        return item
+    return [item]
+
+
+def _get_recent_pages(
+    entity: str, pipedrive_api_key: str, since_timestamp: str
+) -> Iterator[TDataPage]:
+    custom_fields_mapping = (
+        dlt.current.source_state().get("custom_fields_mapping", {}).get(entity, {})
+    )
+    pages = get_pages(
+        "recents",
+        pipedrive_api_key,
+        extra_params=dict(since_timestamp=since_timestamp, items=entity),
+    )
+    pages = (_extract_recents_data(page) for page in pages)
+    for page in pages:
+        yield rename_fields(page, custom_fields_mapping)
+
+
+__source_name__ = "pipedrive"

--- a/ingestr/src/pipedrive/helpers/pages.py
+++ b/ingestr/src/pipedrive/helpers/pages.py
@@ -1,12 +1,10 @@
-from itertools import chain, groupby
+from itertools import chain
 from typing import (
     Any,
     Dict,
     Iterable,
     Iterator,
     List,
-    Optional,
-    Sequence,
     TypeVar,
     Union,
 )
@@ -14,8 +12,8 @@ from typing import (
 import dlt
 from dlt.sources.helpers import requests
 
-from .custom_fields_munger import rename_fields
 from ..typing import TDataPage
+from .custom_fields_munger import rename_fields
 
 
 def get_pages(

--- a/ingestr/src/pipedrive/settings.py
+++ b/ingestr/src/pipedrive/settings.py
@@ -1,0 +1,27 @@
+"""Pipedrive source settings and constants"""
+
+ENTITY_MAPPINGS = [
+    ("activity", "activityFields", {"user_id": 0}),
+    ("organization", "organizationFields", None),
+    ("person", "personFields", None),
+    ("product", "productFields", None),
+    ("deal", "dealFields", None),
+    ("pipeline", None, None),
+    ("stage", None, None),
+    ("user", None, None),
+]
+
+RECENTS_ENTITIES = {
+    "activity": "activities",
+    "activityType": "activity_types",
+    "deal": "deals",
+    "file": "files",
+    "filter": "filters",
+    "note": "notes",
+    "person": "persons",
+    "organization": "organizations",
+    "pipeline": "pipelines",
+    "product": "products",
+    "stage": "stages",
+    "user": "users",
+}

--- a/ingestr/src/pipedrive/typing.py
+++ b/ingestr/src/pipedrive/typing.py
@@ -1,0 +1,4 @@
+from typing import List, Dict, Any
+
+
+TDataPage = List[Dict[str, Any]]

--- a/ingestr/src/pipedrive/typing.py
+++ b/ingestr/src/pipedrive/typing.py
@@ -1,4 +1,3 @@
-from typing import List, Dict, Any
-
+from typing import Any, Dict, List
 
 TDataPage = List[Dict[str, Any]]

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -178,7 +178,7 @@ class SqlSource:
                 scheme="clickhouse+native",
                 query=urlencode(query_params, doseq=True),
             ).geturl()
-         
+
         if uri.startswith("db2://"):
             uri = uri.replace("db2://", "db2+ibm_db://")
 
@@ -1838,8 +1838,8 @@ class AppLovinSource:
 
 
 class ApplovinMaxSource:
-    #expected uri format: applovinmax://?api_key=<api_key>
-    #expected table format: user_ad_revenue:app_id_1,app_id_2
+    # expected uri format: applovinmax://?api_key=<api_key>
+    # expected table format: user_ad_revenue:app_id_1,app_id_2
 
     def handles_incrementality(self) -> bool:
         return True
@@ -1851,7 +1851,7 @@ class ApplovinMaxSource:
         api_key = params.get("api_key")
         if api_key is None:
             raise ValueError("api_key is required to connect to AppLovin Max API.")
-        
+
         AVAILABLE_TABLES = ["user_ad_revenue"]
 
         table_fields = table.split(":")
@@ -1861,7 +1861,7 @@ class ApplovinMaxSource:
             raise ValueError(
                 "Invalid table format. Expected format is user_ad_revenue:app_id_1,app_id_2"
             )
-        
+
         if requested_table not in AVAILABLE_TABLES:
             raise ValueError(
                 f"Table name '{requested_table}' is not supported for AppLovin Max source yet."
@@ -1869,17 +1869,15 @@ class ApplovinMaxSource:
                 "If you need additional tables, please create a GitHub issue at "
                 "https://github.com/bruin-data/ingestr"
             )
-        
-        applications = [i for i in table_fields[1].replace(" ", "").split(",") if i.strip()]
+
+        applications = [
+            i for i in table_fields[1].replace(" ", "").split(",") if i.strip()
+        ]
         if len(applications) == 0:
-            raise ValueError(
-                "At least one application id is required"
-            )
-    
+            raise ValueError("At least one application id is required")
+
         if len(applications) != len(set(applications)):
-            raise ValueError(
-                "Application ids must be unique."
-            )
+            raise ValueError("Application ids must be unique.")
 
         interval_start = kwargs.get("interval_start")
         interval_end = kwargs.get("interval_end")
@@ -2011,24 +2009,35 @@ class KinesisSource:
             stream_name=table, credentials=credentials, initial_at_timestamp=start_date
         )
 
+
 class PipedriveSource:
     def handles_incrementality(self) -> bool:
         return True
-    
+
     def dlt_source(self, uri: str, table: str, **kwargs):
         parsed_uri = urlparse(uri)
         params = parse_qs(parsed_uri.query)
         api_key = params.get("api_token")
         if api_key is None:
             raise MissingValueError("api_token", "Pipedrive")
-        
+
         start_date = kwargs.get("interval_start")
         if start_date is not None:
             start_date = ensure_pendulum_datetime(start_date)
         else:
             start_date = pendulum.parse("2000-01-01")
-        
-        if table not in ["users","activities","persons","organizations","products","stages","deals"]:
+
+        if table not in [
+            "users",
+            "activities",
+            "persons",
+            "organizations",
+            "products",
+            "stages",
+            "deals",
+        ]:
             raise UnsupportedResourceError(table, "Pipedrive")
-        
-        return pipedrive_source(pipedrive_api_key=api_key, since_timestamp=start_date).with_resources(table)
+
+        return pipedrive_source(
+            pipedrive_api_key=api_key, since_timestamp=start_date
+        ).with_resources(table)

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -2009,3 +2009,8 @@ class KinesisSource:
         return kinesis_stream(
             stream_name=table, credentials=credentials, initial_at_timestamp=start_date
         )
+
+class PipedriveSource:
+    def handles_incrementality(self) -> bool:
+        return True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ exclude = [
     'src/clickhouse/.*',
     'src/asana_source/.*',
     'src/tiktok_ads/.*',
+    'src/pipedrive/.*',
   ]
 
 [[tool.mypy.overrides]]
@@ -114,6 +115,7 @@ module = [
   "ingestr.src.tiktok_ads.*",
   "ingestr.src.github.*",
   "ingestr.src.clickhouse.*",
+  "ingestr.src.pipedrive.*",
 ]
 follow_imports = "skip"
 


### PR DESCRIPTION
 Following changes are made in this PR:
- added Pipedrive as a source.
- users can fetch data from different Pipedrive resources/tables such as: users, activities, persons, organizations etc
- supports incremental loading, with the default start date set to 2000-01-01.
- backfill is not supported in this PR; this functionality will be added in another PR.

-- source-uri
`pipedrive://?api_token=$PIPEDRIVE_API_KEY`

<img width="1296" alt="Screenshot 2025-03-28 at 14 00 02" src="https://github.com/user-attachments/assets/fb979d19-d954-472d-8ef0-70ce1f25210d" />

<img width="1490" alt="Screenshot 2025-03-28 at 14 01 57" src="https://github.com/user-attachments/assets/a939b265-631a-4bc9-8e3e-40958012e786" />
