### PR TITLE
start_date and end_date assigned defaults for latest and currencies

### DIFF
--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -2064,6 +2064,11 @@ class FrankfurterSource:
                 end_date = pendulum.now()
             validate_dates(start_date=start_date, end_date=end_date)
 
+        # For currencies and latest tables, set start and end dates to current date
+        else:
+            start_date = pendulum.now()
+            end_date = pendulum.now()
+
         # Validate table
         if table not in ["currencies", "latest", "exchange_rates"]:
             raise ValueError(


### PR DESCRIPTION
In src/sources.py lines 2080-2081, start_date and end_date have to have values assigned despite being optional arguments for frankfurter_source. start_date and end_date are now assigned default values for the tables 'latest' and 'currencies'.