### PR TITLE
bump timeouts across all HTTP clients

### DIFF
--- a/ingestr/src/adjust/adjust_helpers.py
+++ b/ingestr/src/adjust/adjust_helpers.py
@@ -36,7 +36,7 @@ class AdjustAPI:
     def __init__(self, api_key):
         self.api_key = api_key
         self.request_client = Client(
-            request_timeout=8.0,
+            request_timeout=1000,  # Adjust support recommends 1000 seconds of read timeout.
             raise_for_status=False,
             retry_condition=retry_on_limit,
             request_max_attempts=12,

--- a/ingestr/src/applovin_max/__init__.py
+++ b/ingestr/src/applovin_max/__init__.py
@@ -68,7 +68,6 @@ def applovin_max_source(
 
 def create_client() -> requests.Session:
     return Client(
-        request_timeout=10.0,
         raise_for_status=False,
         retry_condition=retry_on_limit,
         request_max_attempts=12,

--- a/ingestr/src/appsflyer/client.py
+++ b/ingestr/src/appsflyer/client.py
@@ -46,7 +46,6 @@ class AppsflyerClient:
             )
 
         request_client = Client(
-            request_timeout=10.0,
             raise_for_status=False,
             retry_condition=retry_on_limit,
             request_max_attempts=12,

--- a/ingestr/src/klaviyo/_init_.py
+++ b/ingestr/src/klaviyo/_init_.py
@@ -18,7 +18,6 @@ def retry_on_limit(response: requests.Response, exception: BaseException) -> boo
 
 def create_client() -> requests.Session:
     return Client(
-        request_timeout=10.0,
         raise_for_status=False,
         retry_condition=retry_on_limit,
         request_max_attempts=12,

--- a/ingestr/src/linkedin_ads/helpers.py
+++ b/ingestr/src/linkedin_ads/helpers.py
@@ -18,7 +18,6 @@ def retry_on_limit(
 
 def create_client() -> requests.Session:
     return Client(
-        request_timeout=10.0,
         raise_for_status=False,
         retry_condition=retry_on_limit,
         request_max_attempts=12,

--- a/ingestr/src/tiktok_ads/tiktok_helpers.py
+++ b/ingestr/src/tiktok_ads/tiktok_helpers.py
@@ -17,7 +17,6 @@ def retry_on_limit(
 
 def create_client() -> requests.Session:
     return Client(
-        request_timeout=10.0,
         raise_for_status=False,
         retry_condition=retry_on_limit,
         request_max_attempts=12,


### PR DESCRIPTION
Adjust support suggests 1000 seconds for the timeout, so I went ahead and removed all the other timeouts as well, which would bump them up to the default, which is 60 seconds.