### PR TITLE
Kinesis: Optionally address streams per StreamARN

### DIFF
--- a/docs/supported-sources/kinesis.md
+++ b/docs/supported-sources/kinesis.md
@@ -31,9 +31,13 @@ ingestr ingest --source-uri 'kinesis://?aws_access_key_id=id_123&aws_secret_acce
  --dest-table 'dest.results'
 ```
 
-When using Kinesis as a source, specify the `stream name` you want to read from as the `--source-table` parameter. For example, if you want to read from a Kinesis stream named "customer_events", you would use `--source-table 'customer_events'`.
+When using Kinesis as a source, specify the [StreamName] you want to read from as the `--source-table` parameter. For example, if you want to read from a Kinesis stream named "customer_events", you would use `--source-table 'customer_events'`.
+You can also use a full Kinesis [StreamARN] to address the stream in [ARN] format, like `arn:aws:kinesis:eu-central-1:842404475894:stream/customer_events`.
 
 ### Initial Load Configuration
 By default, ingestr reads from the beginning of the Kinesis stream. To start reading from a specific time, use the `interval_start` parameter.
 
 
+[ARN]: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+[StreamARN]: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_StreamDescription.html#Streams-Type-StreamDescription-StreamARN
+[StreamName]: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_StreamDescription.html#Streams-Type-StreamDescription-StreamName

--- a/ingestr/src/kinesis/__init__.py
+++ b/ingestr/src/kinesis/__init__.py
@@ -42,7 +42,7 @@ def kinesis_stream(
         initial_at_timestamp (TAnyDateTime): An initial timestamp used to generate AT_TIMESTAMP or LATEST iterator when timestamp value is 0
         max_number_of_messages (int): Maximum number of messages to read in one run. Actual read may exceed that number by up to chunk_size. Defaults to None (no limit).
         milliseconds_behind_latest (int): The number of milliseconds behind the top of the shard to stop reading messages, defaults to 1000.
-        parse_json (bool): If True, assumes that messages are json strings, parses them and returns instead of `data` (otherwise). Defaults to False.
+        parse_json (bool): If True, assumes that messages are json strings, parses them and returns instead of `data` (otherwise). Defaults to True.
         chunk_size (int): The number of records to fetch at once. Defaults to 1000.
     Yields:
             Iterable[TDataItem]: Messages. Contain Kinesis envelope in `kinesis` and bytes data in `data` (if `parse_json` disabled)

--- a/ingestr/src/kinesis/__init__.py
+++ b/ingestr/src/kinesis/__init__.py
@@ -9,7 +9,7 @@ from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.typing import StrStr, TAnyDateTime, TDataItem
 from dlt.common.utils import digest128
 
-from .helpers import get_shard_iterator, max_sequence_by_shard
+from .helpers import get_shard_iterator, get_stream_address, max_sequence_by_shard
 
 
 @dlt.resource(
@@ -65,7 +65,7 @@ def kinesis_stream(
     # so next time we request shards at AT_TIMESTAMP that is now
     resource_state["initial_at_timestamp"] = pendulum.now("UTC").subtract(seconds=1)
 
-    shards_list = kinesis_client.list_shards(StreamName=stream_name)
+    shards_list = kinesis_client.list_shards(**get_stream_address(stream_name))
     shards: List[StrStr] = shards_list["Shards"]
     while next_token := shards_list.get("NextToken"):
         shards_list = kinesis_client.list_shards(NextToken=next_token)


### PR DESCRIPTION
Dear @karakanb,

thanks a stack for starting ingestr. This patch brings in a minor improvement to address a Kinesis stream by ARN instead of name, like using `arn:aws:kinesis:eu-central-1:842404475894:stream/test` instead of just using `test`.

The patch was too lazy to introduce a dedicated parameter, so it modifies just a few bits to optionally accept a [StreamARN](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_StreamDescription.html#Streams-Type-StreamDescription-StreamARN) into the existing `stream_name` parameter without much ado. Do you think it's ok doing it like this? We think it offers excellent usability without needing to introduce yet another parameter.

With kind regards,
Andreas.

## References
- https://github.com/hampsterx/async-kinesis/pull/39