### PR TITLE
Dependencies: Update to dlt-1.11.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ asana==3.2.3
 confluent-kafka==2.8.0
 databricks-sql-connector==2.9.3
 dataclasses-json==0.6.7
-dlt==1.10.0
+dlt==1.11.0
 duckdb_engine==0.17.0
 duckdb==1.2.1
 google-ads==25.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ decorator==5.2.1
     # via gcsfs
 deprecation==2.1.0
     # via rudder-sdk-python
-dlt==1.10.0
+dlt==1.11.0
     # via -r requirements.in
 dnspython==2.7.0
     # via pymongo

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -106,7 +106,7 @@ decorator==5.2.1
     # via gcsfs
 deprecation==2.1.0
     # via rudder-sdk-python
-dlt==1.10.0
+dlt==1.11.0
     # via -r requirements.in
 dnspython==2.7.0
     # via pymongo


### PR DESCRIPTION
## About

What the title says.

## Details

There have been errors on CI with GH-237, which is using the current development head of dlt. Maybe the errors will already surface when using the [newer dlt 1.11.0, released on May 15](https://pypi.org/project/dlt/1.11.0/)? Let's probe it.
