### PR TITLE
Add Criteo source

### DIFF
--- a/ingestr/src/criteo/__init__.py
+++ b/ingestr/src/criteo/__init__.py
@@ -1,0 +1,58 @@
+import json
+from typing import Iterable, Sequence
+
+import dlt
+from dlt.sources import DltResource
+from dlt.sources.helpers import requests
+
+
+@dlt.source(max_table_nesting=0)
+def criteo_source(
+    client_id: str = dlt.secrets.value,
+    client_secret: str = dlt.secrets.value,
+    advertiser_ids: Sequence[str] = dlt.config.value,
+    dimensions: Sequence[str] = dlt.config.value,
+    metrics: Sequence[str] = dlt.config.value,
+    start_date: str = dlt.config.value,
+    end_date: str = dlt.config.value,
+) -> DltResource:
+    """Load reporting data from the Criteo Marketing API."""
+
+    token_resp = requests.post(
+        "https://api.criteo.com/oauth2/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+        timeout=60,
+    )
+    token_resp.raise_for_status()
+    access_token = token_resp.json().get("access_token")
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    report_body = {
+        "advertiserIds": ",".join(advertiser_ids),
+        "startDate": start_date,
+        "endDate": end_date,
+        "dimensions": list(dimensions),
+        "metrics": list(metrics),
+        "format": "json",
+    }
+
+    @dlt.resource(write_disposition="merge", primary_key=list(dimensions))
+    def campaign_report() -> Iterable[dict]:
+        response = requests.post(
+            "https://api.criteo.com/v1/statistics/report",
+            headers=headers,
+            json=report_body,
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, str):
+            data = json.loads(data)
+        for item in data.get("data", []):
+            yield item
+
+    return campaign_report

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -62,6 +62,7 @@ from ingestr.src.sources import (
     SqlSource,
     StripeAnalyticsSource,
     TikTokSource,
+    CriteoSource,
     ZendeskSource,
 )
 
@@ -168,6 +169,7 @@ class SourceDestinationFactory:
         "solidgate": SolidgateSource,
         "smartsheet": SmartsheetSource,
         "sftp": SFTPSource,
+        "criteo": CriteoSource,
     }
     destinations: Dict[str, Type[DestinationProtocol]] = {
         "bigquery": BigQueryDestination,

--- a/requirements.in
+++ b/requirements.in
@@ -55,3 +55,4 @@ sqlalchemy-spanner==1.11.0
 google-cloud-spanner==3.54.0
 smartsheet-python-sdk==3.0.5
 paramiko==3.5.1
+criteo-marketing==1.0.171

--- a/requirements.txt
+++ b/requirements.txt
@@ -630,3 +630,5 @@ zstd==1.5.6.5
     # via
     #   -r requirements.in
     #   asynch
+criteo-marketing==1.0.171
+    # via -r requirements.in

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -628,3 +628,5 @@ zstd==1.5.6.5
     # via
     #   -r requirements.in
     #   asynch
+criteo-marketing==1.0.171
+    # via -r requirements.in


### PR DESCRIPTION
## Summary
- implement Criteo connector using REST API
- wire Criteo source into source factory
- include Criteo client in dependency lists

## Testing
- `pytest ingestr/main_test.py::test_factory_creation -q` *(fails: ModuleNotFoundError: No module named 'confluent_kafka')*

------
https://chatgpt.com/codex/tasks/task_e_6848cbde30d4832bbde7549f5c1ecad4