### PR TITLE
Add Trustpilot source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -123,6 +123,7 @@ export default defineConfig({
               },
               { text: "Frankfurter", link: "/supported-sources/frankfurter.md" },
               { text: "Freshdesk", link: "/supported-sources/freshdesk.md" },
+              { text: "Trustpilot", link: "/supported-sources/trustpilot.md" },
               { text: "Google Cloud Storage (GCS)", link: "/supported-sources/gcs.md" },
               { text: "Google Analytics", link: "/supported-sources/google_analytics.md" },
               { text: "Google Ads", link: "/supported-sources/google-ads.md" },

--- a/docs/supported-sources/trustpilot.md
+++ b/docs/supported-sources/trustpilot.md
@@ -1,0 +1,35 @@
+# Trustpilot
+
+[Trustpilot](https://www.trustpilot.com/) provides a platform for collecting and
+sharing customer reviews.
+
+ingestr supports Trustpilot as a source.
+
+## URI format
+
+The URI format for Trustpilot is:
+
+```
+trustpilot://<business_unit_id>?api_key=<api_key>
+```
+
+URI parameters:
+- `api_key`: Your Trustpilot API key.
+- `business_unit_id`: Identifier of the business unit whose reviews you want to fetch.
+
+## Example usage
+
+Assuming your `business_unit_id` is `123` and your API key is `key_abc`, you can ingest reviews into DuckDB using:
+
+```bash
+ingestr ingest --source-uri 'trustpilot://123?api_key=key_abc' --source-table 'reviews' --dest-uri duckdb:///trustpilot.duckdb --dest-table 'dest.reviews'
+```
+
+## Tables
+
+Currently the Trustpilot source exposes the following table:
+
+| Name    | Description                                 |
+| ------- | ------------------------------------------- |
+| reviews | Customer reviews for the specified business |
+

--- a/ingestr/src/factory.py
+++ b/ingestr/src/factory.py
@@ -61,6 +61,7 @@ from ingestr.src.sources import (
     SolidgateSource,
     SqlSource,
     StripeAnalyticsSource,
+    TrustpilotSource,
     TikTokSource,
     ZendeskSource,
 )
@@ -161,6 +162,7 @@ class SourceDestinationFactory:
         "pipedrive": PipedriveSource,
         "frankfurter": FrankfurterSource,
         "freshdesk": FreshdeskSource,
+        "trustpilot": TrustpilotSource,
         "phantombuster": PhantombusterSource,
         "elasticsearch": ElasticsearchSource,
         "attio": AttioSource,

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -2290,6 +2290,34 @@ class FreshdeskSource:
         ).with_resources(table)
 
 
+class TrustpilotSource:
+    # trustpilot://<business_unit_id>?api_key=<api_key>
+    def handles_incrementality(self) -> bool:
+        return True
+
+    def dlt_source(self, uri: str, table: str, **kwargs):
+        parsed_uri = urlparse(uri)
+        business_unit_id = parsed_uri.netloc
+        params = parse_qs(parsed_uri.query)
+
+        if not business_unit_id:
+            raise MissingValueError("business_unit_id", "Trustpilot")
+
+        api_key = params.get("api_key")
+        if api_key is None:
+            raise MissingValueError("api_key", "Trustpilot")
+
+        if table not in ["reviews"]:
+            raise UnsupportedResourceError(table, "Trustpilot")
+
+        from ingestr.src.trustpilot import trustpilot_source
+
+        return trustpilot_source(
+            business_unit_id=business_unit_id,
+            api_key=api_key[0],
+        ).with_resources(table)
+
+
 class PhantombusterSource:
     def handles_incrementality(self) -> bool:
         return True

--- a/ingestr/src/trustpilot/__init__.py
+++ b/ingestr/src/trustpilot/__init__.py
@@ -1,0 +1,32 @@
+"""Trustpilot source for ingesting reviews."""
+
+from typing import Any, Dict, Generator, Iterable, Optional
+
+import dlt
+from dlt.sources import DltResource
+
+from .client import TrustpilotClient
+
+
+@dlt.source()
+def trustpilot_source(
+    business_unit_id: str,
+    api_key: str = dlt.secrets.value,
+    per_page: int = 100,
+) -> Iterable[DltResource]:
+    """Return resources for Trustpilot."""
+    client = TrustpilotClient(api_key=api_key)
+
+    def reviews(
+        updated_at: Optional[Any] = dlt.sources.incremental(
+            "updated_at", initial_value="1970-01-01T00:00:00Z"
+        )
+    ) -> Generator[Dict[str, Any], None, None]:
+        last_value = updated_at.last_value if updated_at is not None else None
+        yield from client.paginated_reviews(
+            business_unit_id=business_unit_id,
+            per_page=per_page,
+            updated_since=last_value,
+        )
+
+    yield dlt.resource(reviews, name="reviews", write_disposition="merge", primary_key="id")

--- a/ingestr/src/trustpilot/client.py
+++ b/ingestr/src/trustpilot/client.py
@@ -1,0 +1,41 @@
+"""Simple Trustpilot API client."""
+
+from typing import Any, Dict, Iterable, Optional
+
+from dlt.sources.helpers import requests
+
+
+class TrustpilotClient:
+    """Client for the Trustpilot public API."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.base_url = "https://api.trustpilot.com/v1"
+
+    def _get(self, endpoint: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        params = dict(params)
+        params["apikey"] = self.api_key
+        response = requests.get(f"{self.base_url}{endpoint}", params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def paginated_reviews(
+        self,
+        business_unit_id: str,
+        per_page: int = 100,
+        updated_since: Optional[str] = None,
+    ) -> Iterable[Dict[str, Any]]:
+        page = 1
+        while True:
+            params: Dict[str, Any] = {"perPage": per_page, "page": page}
+            if updated_since:
+                params["updatedSince"] = updated_since
+            data = self._get(f"/business-units/{business_unit_id}/reviews", params)
+            reviews = data.get("reviews", data)
+            if not reviews:
+                break
+            for review in reviews:
+                yield review
+            if len(reviews) < per_page:
+                break
+            page += 1


### PR DESCRIPTION
## Summary
- add Trustpilot source with incremental reviews
- wire up new source in factory and sources modules
- document Trustpilot usage
- list Trustpilot in docs navigation

## Testing
- `ruff check ingestr/src/trustpilot ingestr/src/sources.py ingestr/src/factory.py docs/supported-sources/trustpilot.md docs/.vitepress/config.mjs`
- `pytest -k trustpilot -q` *(fails: PluginValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_6847f1dae75c8320a79501343a8957d2