### PR TITLE
Dependencies: Downgrade to `sqlalchemy-cratedb==0.41.0` GA

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ rich==13.9.4
 rudder-sdk-python==2.1.4
 snowflake-sqlalchemy==1.6.1
 sqlalchemy-bigquery==1.12.1
-sqlalchemy-cratedb==0.42.0.dev2
+sqlalchemy-cratedb==0.41.0
 sqlalchemy-hana==2.0.0
 sqlalchemy-redshift==0.8.14
 SQLAlchemy==1.4.52

--- a/requirements.txt
+++ b/requirements.txt
@@ -549,7 +549,7 @@ sqlalchemy==1.4.52
     #   sqlalchemy-spanner
 sqlalchemy-bigquery==1.12.1
     # via -r requirements.in
-sqlalchemy-cratedb==0.42.0.dev2
+sqlalchemy-cratedb==0.41.0
     # via -r requirements.in
 sqlalchemy-hana==2.0.0
     # via -r requirements.in
@@ -622,7 +622,7 @@ urllib3==2.3.0
     #   pyairtable
     #   requests
     #   types-requests
-verlib2==0.3.1
+verlib2==0.2.0
     # via
     #   crate
     #   sqlalchemy-cratedb

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -544,7 +544,7 @@ sqlalchemy==1.4.52
     #   sqlalchemy-spanner
 sqlalchemy-bigquery==1.12.1
     # via -r requirements.in
-sqlalchemy-cratedb==0.42.0.dev2
+sqlalchemy-cratedb==0.41.0
     # via -r requirements.in
 sqlalchemy-hana==2.0.0
     # via -r requirements.in
@@ -620,7 +620,7 @@ urllib3==2.5.0
     #   pyairtable
     #   requests
     #   types-requests
-verlib2==0.3.1
+verlib2==0.2.0
     # via
     #   crate
     #   sqlalchemy-cratedb


### PR DESCRIPTION
## Problem

When using `uv pip install --upgrade ingestr`, only version v0.13.52 gets installed.

## Details

Adding support for CrateDB as a source adapter per GH-232 added the dependency `sqlalchemy-cratedb==0.42.0.dev2`, which is apparently problematic in some cases.

- https://github.com/crate-workbench/ingestr/issues/1#issuecomment-3033703828

To install the latest version of ingestr with `sqlalchemy-cratedb==0.42.0.dev2` successfully, `uv` needs the `--prerelease=allow` option. Otherwise, it will install the much older ingestr version v0.13.52.

## Solution 

Downgrade to a previous GA version of sqlalchemy-cratedb (v0.41.0), to mitigate any such obstacles.

## Outlook

Note to self: We'll need to wrap up another patch'es ingredients to fully conclude the operation making 0.42.0 available.

- https://github.com/crate/sqlalchemy-cratedb/pull/215

## References
- GH-292
