### PR TITLE
mssql:  add support for token auth

### DIFF
--- a/docs/supported-sources/mssql.md
+++ b/docs/supported-sources/mssql.md
@@ -28,3 +28,21 @@ URI parameters:
 - `TrustServerCertificate`: whether to trust the server certificate
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's SQL Server dialect [here](https://docs.sqlalchemy.org/en/20/core/engines.html#microsoft-sql-server).
+
+## Tips & Tricks
+
+If you're using Azure SQL Server, you can use `az cli` to generate access tokens to connect to SQL server. 
+
+Set the password to your token and the `Authentication` parameter to `ActiveDirectoryAccessToken`
+::: code-group
+
+```sh [token-auth-example.sh]
+USER=$(az account show --query user.name -o tsv)
+TOKEN=$(az account get-access-token --resource https://database.windows.net/ --query accessToken -o tsv)
+ingestr ingest \
+    --source-uri "mssql://$USER:$TOKEN@<server>.database.windows.net/<database>?Authentication=ActiveDirectoryAccessToken" \
+    --source-table "dbo.example" \
+    --dest-uri "duckdb:///example.db" \
+    --dest-table "dbo.example" \
+```
+:::

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import tempfile
+import struct
 from datetime import date, datetime, timedelta, timezone
 from typing import (
     Any,
@@ -258,8 +259,49 @@ class SqlSource:
             # override the query adapters, the only one we want is the one here in the case of custom queries
             query_adapters = [custom_query_variable_subsitution(query_value, kwargs)]
 
+        credentials = ConnectionStringCredentials(uri)
+        if uri.startswith("mssql://"):
+            parsed_uri = urlparse(uri)
+            params = parse_qs(parsed_uri.query)
+            params = {k.lower():v for k, v in params.items()}
+            if params.get("authentication") == ["ActiveDirectoryAccessToken"]:
+
+                from ingestr.src.destinations import OdbcMsSqlClient, handle_datetimeoffset
+                from sqlalchemy import create_engine
+                import pyodbc
+                cfg = {
+                    "DRIVER": params.get("driver", ["ODBC Driver 18 for SQL Server"])[0],
+                    "SERVER": f"{parsed_uri.hostname},{parsed_uri.port or 1433}",
+                    "DATABASE": parsed_uri.path.lstrip("/"),
+                }
+                for k, v in params.items():
+                    if k.lower() not in ["driver", "authentication", "connect_timeout"]:
+                        cfg[k.upper()] = v[0]
+
+                token = OdbcMsSqlClient.serialize_token(None, parsed_uri.password)
+                dsn = ";".join([f"{k}={v}" for k, v in cfg.items()])
+
+                def creator():
+                    connection = pyodbc.connect(
+                        dsn,
+                        autocommit=True,
+                        timeout=kwargs.get("connect_timeout", 30),
+                        attrs_before={
+                            OdbcMsSqlClient.SQL_COPT_SS_ACCESS_TOKEN: token,
+                        },
+                    )
+                    connection.add_output_converter(-155, handle_datetimeoffset)
+                    return connection
+
+                credentials = create_engine(
+                    "mssql+pyodbc://",
+                    creator=creator,
+                )
+
+
+
         builder_res = self.table_builder(
-            credentials=ConnectionStringCredentials(uri),
+            credentials=credentials,
             schema=table_fields.dataset,
             table=table_fields.table,
             incremental=incremental,


### PR DESCRIPTION
This change extends SQL Server source and destination to accept access token generated by `az` cli.

We re-purpose the deprecated `ActiveDirectoryAccessToken` Authentication parameter as an indication that the password is a token.

example:
```bash
TOKEN=$(az account get-access-token --resource https://database.windows.net/ --query accessToken -o tsv)
USER=$(az account show --query user.name -o tsv)
SERVER="sql-server-expo"
DB="ingestr"
CONN_STR="mssql://$USER:$TOKEN@$SERVER.database.windows.net/$DB?driver=ODBC+Driver+18+for+SQL+Server&authentication=ActiveDirectoryAccessToken&encrypt=yes"

python3 -m ingestr.main ingest \
    --source-uri "$CONN_STR" \
    --source-table "dbo.example" \
    --dest-uri "$CONN_STR" \
    --dest-table "dbo.example_3" \
    --yes
``` 