### PR TITLE
Tests: Permit running tests without `xdist`

### DIFF
--- a/ingestr/conftest.py
+++ b/ingestr/conftest.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
 from main_test import DESTINATIONS, SOURCES  # type: ignore
 
 
@@ -13,6 +14,14 @@ def pytest_configure(config):
 def pytest_configure_node(node):
     """xdist hook"""
     node.workerinput["shared_directory"] = node.config.shared_directory
+
+
+@pytest.fixture(scope="session")
+def shared_directory(request):
+    if is_master(request.config):
+        return request.config.shared_directory
+    else:
+        return request.config.workerinput["shared_directory"]
 
 
 def is_master(config):

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -565,11 +565,10 @@ DESTINATIONS = {
 
 
 @pytest.fixture(scope="session", autouse=True)
-def manage_containers(request):
-    shared_dir = request.config.workerinput["shared_directory"]
+def manage_containers(request, shared_directory):
     unique_containers = set(SOURCES.values()) | set(DESTINATIONS.values())
     for container in unique_containers:
-        container.container_lock_dir = shared_dir
+        container.container_lock_dir = shared_directory
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Hi again,

when invoking the test suite without using xdist, to speed up startup/cycle time a bit while working on individual spots of GH-284, we observed an error.

```shell
pytest -k test_create_replace_csv_to_duckdb
```
```python
AttributeError: 'Config' object has no attribute 'workerinput'
```

This patch aims to improve the situation by adding a `shared_directory` wrapping fixture, picked up from a [suggestion](https://github.com/pytest-dev/pytest/issues/1402#issuecomment-186299177) by @nicoddemus -- thanks!

With kind regards,
Andreas.
