### PR TITLE
Tests: Adjust software tests for CrateDB

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,3 +89,22 @@ jobs:
         run: make test-ci
       - name: check the formatting
         run: make lint-ci
+
+  tests-cratedb:
+    name: "CrateDB"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v4
+      - name: Install Microsoft ODBC
+        run: sudo ACCEPT_EULA=Y apt-get install msodbcsql18 -y
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install project
+        run: make deps-ci
+      - name: Run tests
+        run: make test-ci-cratedb

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ deps-ci:
 	uv pip install --system -r requirements-dev.txt
 
 test-ci:
-	set -a; source test.env; set +a; TESTCONTAINERS_RYUK_DISABLED=true pytest -n auto -x -rP -vv --tb=short --durations=10 --cov=ingestr --no-cov-on-fail
+	set -a; source test.env; set +a; TESTCONTAINERS_RYUK_DISABLED=true pytest -n auto -x -rP -vv --tb=short --durations=10 --cov=ingestr --no-cov-on-fail -k "not cratedb"
+
+test-ci-cratedb:
+	set -a; source test.env; set +a; TESTCONTAINERS_RYUK_DISABLED=true pytest -rP -vv --tb=short --durations=10 --cov=ingestr --no-cov-on-fail -k "cratedb"
 
 test : venv lock-deps
 	. venv/bin/activate; $(MAKE) test-ci

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -1112,7 +1112,7 @@ def db_to_db_append(
         assert res.exit_code == 0
 
     def get_output_table():
-        dest_engine = sqlalchemy.create_engine(dest_connection_url)
+        dest_engine = sqlalchemy.create_engine(dest_connection_url_read)
         # CrateDB needs an explicit flush to make data available for reads immediately.
         if dest_engine.dialect.name == "crate":
             dest_engine.execute(f"REFRESH TABLE {schema_rand_prefix}.output")

--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -842,6 +842,7 @@ DESTINATIONS = {
     "postgres": pgDocker,
     "duckdb": EphemeralDuckDb(),
     "clickhouse+native": clickHouseDocker,
+    "cratedb": crateDbDocker,
 }
 
 

--- a/ingestr/src/destinations_test.py
+++ b/ingestr/src/destinations_test.py
@@ -4,9 +4,11 @@ import unittest
 
 import dlt
 import pytest
+from sqlglot.helper import classproperty
 
 from ingestr.src.destinations import (
     BigQueryDestination,
+    CrateDBDestination,
     DatabricksDestination,
     DuckDBDestination,
     MsSQLDestination,
@@ -119,3 +121,11 @@ class DatabricksDestinationTest(unittest.TestCase, GenericSqlDestinationFixture)
         self.assertEqual(creds["http_path"], "/path/123")
         self.assertEqual(creds["catalog"], "workspace")
         self.assertEqual(creds["schema"], "dest")
+
+
+class CrateDBDestinationTest(unittest.TestCase, GenericSqlDestinationFixture):
+    destination = CrateDBDestination()
+
+    @classproperty
+    def expected_class(cls):
+        return dlt.destinations.cratedb  # type: ignore[attr-defined]

--- a/ingestr/src/kafka/helpers.py
+++ b/ingestr/src/kafka/helpers.py
@@ -46,7 +46,7 @@ def default_msg_processor(msg: Message) -> Dict[str, Any]:
             },
             "data": msg.value().decode("utf-8"),
         },
-        "_kafka_msg_id": digest128(topic + str(partition) + str(key)),
+        "_kafka__msg_id": digest128(topic + str(partition) + str(key)),
     }
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+cratedb-toolkit[testing]==0.0.37
 mypy==1.15.0
 pytest-cov==4.1.0
 pytest==8.3.3
@@ -12,3 +13,4 @@ testcontainers[postgres,mysql]==4.8.2
 pytest-xdist[psutil]==3.6.1
 pkginfo==1.12.0
 pytest-repeat==0.9.3
+yarl<2


### PR DESCRIPTION
## About
Retroactively add software tests for CrateDB by adjusting the existing test suite.

_It is very unlikely the patch will get merged in its current form, so it will need to be maintained separately to provide quality assurance for the CrateDB source and destination adapters._

## Thoughts
The patch clearly demonstrates where CrateDB is a different animal compared to other DBMS. We don't know yet how to compress or re-shape those anomaly-balancing boilerplate adjustments, in order to reduce the noise of the patch, but we hope to be able to resolve one or another obstacle for the better as we go.

## Backlog
- [x] After making a start per `main_test.py`, expand into ~`sources_test.py` and~ `destinations_test.py` as well.
- [ ] Get rid of the worst code smells, by fixing or improving the dlt adapter, or by providing relevant monkey patches.
- [ ] Release CrateDB Testcontainer for Python to get rid of development dependency to `cratedb-toolkit`.

## References
- GH-238
