### PR TITLE
CLI: For the `columns` option, do not use the `COLUMNS` shell variable

### DIFF
--- a/ingestr/main.py
+++ b/ingestr/main.py
@@ -256,7 +256,7 @@ def ingest(
         Optional[list[str]],
         typer.Option(
             help="The column types to be used for the destination table in the format of 'column_name:column_type'",
-            envvar=["COLUMNS", "INGESTR_COLUMNS"],
+            envvar=["INGESTR_COLUMNS"],
         ),
     ] = None,  # type: ignore
     yield_limit: Annotated[


### PR DESCRIPTION
## Problem
ingestr bails out in `ingestr.main.ingest.parse_columns` at:
```python
>>> column_name, column_type = candidate.split(":")
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    column_name, column_type = candidate.split(":")
    ^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```

## Solution

The `COLUMNS` shell variable has a standard meaning on Unix systems, relaying the number of available characters on your current terminal. Better not overload it with a custom environment variable.

$ echo $COLUMNS
195

$ echo $COLUMNS
207

-- https://askubuntu.com/questions/851397/the-nature-of-echo-columns