### PR TITLE
Naming things: Rename `_kafka_msg_id` to `_kafka__msg_id`

### DIFF
--- a/ingestr/main_test.py
+++ b/ingestr/main_test.py
@@ -1293,7 +1293,7 @@ def test_kafka_to_db(dest):
         dest_engine = sqlalchemy.create_engine(dest_uri)
         with dest_engine.connect() as conn:
             res = conn.execute(
-                "select _kafka__data from testschema.output order by _kafka_msg_id asc"
+                "select _kafka__data from testschema.output order by _kafka__msg_id asc"
             ).fetchall()
         dest_engine.dispose()
         return res

--- a/ingestr/src/kafka/helpers.py
+++ b/ingestr/src/kafka/helpers.py
@@ -46,7 +46,7 @@ def default_msg_processor(msg: Message) -> Dict[str, Any]:
             },
             "data": msg.value().decode("utf-8"),
         },
-        "_kafka_msg_id": digest128(topic + str(partition) + str(key)),
+        "_kafka__msg_id": digest128(topic + str(partition) + str(key)),
     }
 
 


### PR DESCRIPTION
## About
Unfortunately, CrateDB does not permit column names using leading underscores, like `_kafka_msg_id`. However, if two underscores are included, like `_kafka__msg_id`, it works.

The patch improves storage alignment with the other already existing column `_kafka__data`, which is already using two underscores in its name.

## Thoughts
We certainly know the obstacle is on CrateDB, while it is not a problem for any other database destination covered by ingestr.

However, we didn't see many dependencies on this column name, so we are humbly asking if you could do us a favor to rename that column, so we will not need to find a different workaround in form of a runtime patch. 🙏 

## References
- https://github.com/crate-workbench/ingestr/issues/3
