### PR TITLE
Chore: Disable dlt telemetry for sandbox and CI

### DIFF
--- a/.dlt/config.toml
+++ b/.dlt/config.toml
@@ -1,0 +1,3 @@
+[runtime]
+
+dlthub_telemetry=false


### PR DESCRIPTION
When working with the very repository in a sandbox and on CI, we think submitting telemetry information is not necessary.