### PR TITLE
Dependencies: Update to `dlt-cratedb==0.0.2`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ confluent-kafka==2.8.0
 databricks-sql-connector==2.9.3
 dataclasses-json==0.6.7
 dlt==1.11.0
-dlt-cratedb>=0.0.1
+dlt-cratedb==0.0.2
 duckdb_engine==0.17.0
 duckdb==1.2.1
 google-ads==25.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ dlt==1.11.0
     # via
     #   -r requirements.in
     #   dlt-cratedb
-dlt-cratedb==0.0.1
+dlt-cratedb==0.0.2
     # via -r requirements.in
 dnspython==2.7.0
     # via pymongo

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -101,7 +101,7 @@ dlt==1.11.0
     # via
     #   -r requirements.in
     #   dlt-cratedb
-dlt-cratedb==0.0.1
+dlt-cratedb==0.0.2
     # via -r requirements.in
 dnspython==2.7.0
     # via pymongo


### PR DESCRIPTION
## About

That's a very minor version bump of a dependency package.


## References

- https://github.com/crate/dlt-cratedb/releases/tag/v0.0.2
- GH-289
