### PR TITLE
Chore: Format code using `make lint-ci`

### DIFF
--- a/ingestr/src/linear/__init__.py
+++ b/ingestr/src/linear/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Iterable, Iterator
 import dlt
 import pendulum
 
-from .helpers import  _paginate, _normalize_issue, _normalize_team
+from .helpers import _normalize_issue, _normalize_team, _paginate
 
 ISSUES_QUERY = """
 query Issues($cursor: String) {
@@ -143,13 +143,15 @@ def linear_source(
                     yield item
 
     @dlt.resource(name="teams", primary_key="id", write_disposition="merge")
-    def teams( updated_at: dlt.sources.incremental[str] = dlt.sources.incremental(
+    def teams(
+        updated_at: dlt.sources.incremental[str] = dlt.sources.incremental(
             "updatedAt",
             initial_value=start_date.isoformat(),
             end_value=end_date.isoformat() if end_date else None,
             range_start="closed",
             range_end="closed",
-        ),) -> Iterator[Dict[str, Any]]:
+        ),
+    ) -> Iterator[Dict[str, Any]]:
         print(start_date)
         if updated_at.last_value:
             current_start_date = pendulum.parse(updated_at.last_value)

--- a/ingestr/src/linear/helpers.py
+++ b/ingestr/src/linear/helpers.py
@@ -1,9 +1,9 @@
-import json
 from typing import Any, Dict, Iterator, Optional
 
 import requests
 
 LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql"
+
 
 def _graphql(
     api_key: str, query: str, variables: Optional[Dict[str, Any]] = None
@@ -20,6 +20,7 @@ def _graphql(
         raise ValueError(str(payload["errors"]))
     return payload["data"]
 
+
 def _paginate(api_key: str, query: str, root: str) -> Iterator[Dict[str, Any]]:
     cursor: Optional[str] = None
     while True:
@@ -29,6 +30,7 @@ def _paginate(api_key: str, query: str, root: str) -> Iterator[Dict[str, Any]]:
         if not data["pageInfo"]["hasNextPage"]:
             break
         cursor = data["pageInfo"]["endCursor"]
+
 
 def _normalize_issue(item: Dict[str, Any]) -> Dict[str, Any]:
     field_mapping = {
@@ -45,12 +47,22 @@ def _normalize_issue(item: Dict[str, Any]) -> Dict[str, Any]:
         else:
             item[value] = None
             del item[key]
-    json_fields = ["comments", "subscribers", "attachments", "labels", "subtasks","projects", "memberships", "members"]
+    json_fields = [
+        "comments",
+        "subscribers",
+        "attachments",
+        "labels",
+        "subtasks",
+        "projects",
+        "memberships",
+        "members",
+    ]
     for field in json_fields:
         if item.get(field):
             item[f"{field}"] = item[field].get("nodes", [])
-                
+
     return item
+
 
 def _normalize_team(item: Dict[str, Any]) -> Dict[str, Any]:
     json_fields = ["memberships", "members", "projects"]

--- a/ingestr/src/stripe_analytics/helpers.py
+++ b/ingestr/src/stripe_analytics/helpers.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import math
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Union
 

--- a/ingestr/src/zoom/__init__.py
+++ b/ingestr/src/zoom/__init__.py
@@ -42,14 +42,14 @@ def zoom_source(
             end_dt = pendulum.now("UTC")
         else:
             end_dt = pendulum.parse(datetime.end_value)
-        
+
         base_params: Dict[str, Any] = {
             "type": "scheduled",
             "page_size": 300,
             "from": start_dt.to_date_string(),
             "to": end_dt.to_date_string(),
         }
-        
+
         for user in client.get_users():
             user_id = user["id"]
             yield from client.get_meetings(user_id, base_params)

--- a/ingestr/src/zoom/helpers.py
+++ b/ingestr/src/zoom/helpers.py
@@ -62,7 +62,7 @@ class ZoomClient:
                 break
             params["next_page_token"] = token
 
-#https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetings
+    # https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetings
     def get_meetings(
         self, user_id: str, params: Dict[str, Any]
     ) -> Iterator[Dict[str, Any]]:


### PR DESCRIPTION
That's just a little maintenance patch to retroactively refresh code formatting, so it's no longer in the way again and again when working on other patches.