### PR TITLE
Add platform field to applovin max data

### DIFF
--- a/ingestr/src/applovin_max/__init__.py
+++ b/ingestr/src/applovin_max/__init__.py
@@ -113,4 +113,5 @@ def get_data(
     df = pd.read_csv(response_url)
     df["Date"] = pd.to_datetime(df["Date"])
     df["partition_date"] = df["Date"].dt.date
+    df["platform"] = platform
     return df


### PR DESCRIPTION
Add `platform` field to AppLovin Max source data to allow distinguishing between Android, iOS, and FireOS.

Although the AppLovin Max source already separates data by platform internally, this information was not included in the final yielded data, making it impossible to distinguish platforms in the resulting table.

---

[Slack Thread](https://bruintalk.slack.com/archives/C066JBNP3U2/p1751991433070039?thread_ts=1751991433.070039&cid=C066JBNP3U2)