### PR TITLE
OCI: Slightly streamline the `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
 FROM python:3.11-slim
 
+# Guidelines that have been followed.
+# - https://hynek.me/articles/docker-uv/
+
+# Install the `uv` package manager.
+# Security-conscious organizations should package/review uv themselves.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# - Tell uv to byte-compile packages for faster application startups.
+# - Silence uv complaining about not being able to use hard links.
+# - Prevent uv from accidentally downloading isolated Python builds.
+# - Install packages into the system Python environment.
+ENV \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_SYSTEM_PYTHON=1
+
 WORKDIR /app
 
-COPY ./requirements.txt /app/requirements.txt
-COPY ./requirements_arm64.txt /app/requirements_arm64.txt
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    cp /app/requirements_arm64.txt /app/requirements.txt; \
-fi
 
-# Setup dependencies for pyodbc
+# Install all prerequisites.
+
 RUN \
   export ACCEPT_EULA='Y' && \
   # Install build dependencies
@@ -28,17 +41,18 @@ RUN \
   sed 's/Driver=psql/Driver=\/usr\/lib\/x86_64-linux-gnu\/odbc\/psql/;s/CommLog=1/CommLog=0/' /etc/odbcinst.ini > /tmp/temp.ini && \
   mv -f /tmp/temp.ini /etc/odbcinst.ini
 
-ENV VIRTUAL_ENV=/usr/local
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
-RUN /install.sh && rm /install.sh
 
-RUN $HOME/.local/bin/uv pip install --system --no-cache -r requirements.txt
+# Install application.
 
+# Copy sources and activate platform-specific requirements file.
 COPY . /app
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     cp /app/requirements_arm64.txt /app/requirements.txt; \
 fi
 
-RUN $HOME/.local/bin/uv pip install --system . && $HOME/.local/bin/uv pip install --system pyodbc
+# Install all required packages and the application.
+RUN uv pip install --requirement requirements.txt pyodbc .
 
+
+# Ready.
 ENTRYPOINT ["ingestr"]


### PR DESCRIPTION
That's just a few bits of copy-editing the `Dockerfile`.

- Use canonical OCI-based installation method for `uv`
- Use environment variables to configure `uv`
- Remove redundant platform-switch instructions (x64 vs. arm64)
- Compress `uv pip install` into a single incantation
