### PR TITLE
Improve Kafka adapter to provide features closer to Kafka Connect

### DIFF
--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -10,29 +10,81 @@ The URI format for Apache Kafka is as follows:
 kafka://?bootstrap_servers=localhost:9092&group_id=test_group&security_protocol=SASL_SSL&sasl_mechanisms=PLAIN&sasl_username=example_username&sasl_password=example_secret&batch_size=1000&batch_timeout=3
 ```
 
-URI parameters:
+### URI parameters
+
+Connectivity options:
 - `bootstrap_servers`: Required, the Kafka server or servers to connect to, typically in the form of a host and port, e.g. `localhost:9092`
 - `group_id`: Required, the consumer group ID used for identifying the client when consuming messages.
 - `security_protocol`: The protocol used to communicate with brokers, e.g. `SASL_SSL` for secure communication.
 - `sasl_mechanisms`: The SASL mechanism to be used for authentication, e.g. `PLAIN`.
 - `sasl_username`: The username for SASL authentication.
 - `sasl_password`: The password for SASL authentication.
+
+Transfer options:
 - `batch_size`: The number of messages to fetch in a single batch, defaults to 3000.
 - `batch_timeout`: The maximum time to wait for messages, defaults to 3 seconds.
+
+Decoding options:
+- `key_type`: The data type of the Kafka event `key` field. Possible values: `json`.
+- `value_type`: The data type of the Kafka event `value_type` field. Possible values: `json`.
+- `include`: A list of event attributes to include in the output, comma-separated.
+- `select`: A single event attribute to select and drill down into.
+  Use `select=value` to relay the Kafka event **payload data** only.
+- `format`: The output format/layout. Possible values: `standard_v1` (default),
+  `standard_v2`, `flexible`. When using the `include` or `select` option, the
+  decoder will automatically select the `flexible` output format.
 
 The URI is used to connect to the Kafka brokers for ingesting messages.
 
 ### Group ID
 The group ID is used to identify the consumer group that reads messages from a topic. Kafka uses the group ID to manage consumer offsets and assign partitions to consumers, which means that the group ID is the key to reading messages from the correct partition and position in the topic.
 
-Once you have your Kafka server, credentials, and group ID set up, here's a sample command to ingest messages from a Kafka topic into a DuckDB database:
+## Examples
 
+### Kafka to DuckDB
+
+Once you have your Kafka server, credentials, and group ID set up,
+here are a few sample commands to ingest messages from a Kafka topic into a destination database:
+
+Transfer data using the traditional `standard_v1` output format into DuckDB.
+The result of this command will be a table in the `kafka.duckdb` database with JSON columns.
 ```sh
 ingestr ingest \
-    --source-uri 'kafka://?bootstrap_servers=localhost:9092&group_id=test_group' \
+    --source-uri 'kafka://?bootstrap_servers=localhost:9092&group_id=test' \
     --source-table 'my-topic' \
-    --dest-uri duckdb:///kafka.duckdb \
+    --dest-uri 'duckdb:///kafka.duckdb' \
     --dest-table 'dest.my_topic'
 ```
 
-The result of this command will be a table in the `kafka.duckdb` database with JSON columns.
+### Kafka to PostgreSQL
+
+Transfer data converging the Kafka event `value` into a PostgreSQL destination
+table, after decoding from JSON, using the `flexible` output format.
+```sh
+echo '{"sensor_id":1,"ts":"2025-06-01 10:00","reading":42.42}' | kcat -P -b localhost -t demo
+```
+```sh
+ingestr ingest \
+  --source-uri 'kafka://?bootstrap_servers=localhost:9092&group_id=test&value_type=json&select=value' \
+  --source-table 'demo' \
+  --dest-uri 'postgres://postgres:postgres@localhost:5432/?sslmode=disable' \
+  --dest-table 'public.kafka_demo'
+```
+The result of this command will be the `public.kafka_demo` table using
+the Kafka event `value`'s top-level JSON keys as table columns.
+```sh
+psql "postgresql://postgres:postgres@localhost:5432/" \
+  -c '\d+ public.kafka_demo' \
+  -c 'select * from public.kafka_demo;'
+```
+```text
+       Table "public.kafka_demo"
+
+    Column    |           Type           |
+--------------+--------------------------+
+ sensor_id    | bigint                   |
+ ts           | timestamp with time zone |
+ reading      | double precision         |
+ _dlt_load_id | character varying        |
+ _dlt_id      | character varying        |
+```

--- a/ingestr/src/kafka/model.py
+++ b/ingestr/src/kafka/model.py
@@ -1,0 +1,160 @@
+from typing import List, Optional, Tuple, Union
+
+import attrs
+import toolz  # type: ignore[import-untyped]
+from dlt.common.time import ensure_pendulum_datetime
+from dlt.common.utils import digest128
+
+
+@attrs.define
+class KafkaDecodingOptions:
+    """
+    Options that control decoding of the Kafka event.
+    """
+
+    # The data type of the Kafka event `key` field.
+    # Possible values: `json`.
+    key_type: Optional[str] = None
+
+    # The data type of the Kafka event `value` field.
+    # Possible values: `json`.
+    value_type: Optional[str] = None
+
+    # The output format/layout.
+    # Possible values: `standard_v1`, `standard_v2`, `flexible`.
+    format: Optional[str] = None
+
+    # Which fields to include in the output, comma-separated.
+    # Using this option will automatically select the `flexible` output format.
+    include: List[str] = attrs.field(factory=list)
+
+    # Which field to select (pick) into the output.
+    # Using this option will automatically select the `flexible` output format.
+    select: Optional[str] = None
+
+    def __attrs_post_init__(self):
+        if self.format is None:
+            self.format = "standard_v1"
+
+    @classmethod
+    def from_params(
+        cls,
+        key_type: List[str],
+        value_type: List[str],
+        format: List[str],
+        include: List[str],
+        select: List[str],
+    ):
+        """
+        Read options from CLI parameters.
+        """
+        output_format = None
+        include_fields = []
+        select_field = None
+        if format:
+            output_format = format[0]
+        if include:
+            output_format = "flexible"
+            include_fields = list(map(str.strip, include[0].split(",")))
+        if select:
+            output_format = "flexible"
+            select_field = select[0]
+        return cls(
+            key_type=key_type and key_type[0] or None,
+            value_type=value_type and value_type[0] or None,
+            format=output_format,
+            include=include_fields,
+            select=select_field,
+        )
+
+
+@attrs.define
+class KafkaEvent:
+    """
+    Process and decode a typical Kafka event/message/record.
+
+    https://kafka.apache.org/intro#intro_concepts_and_terms
+    """
+
+    ts: Tuple[int, int]
+    topic: str
+    partition: int
+    offset: int
+    key: Union[bytes, str]
+    value: Union[bytes, str]
+
+    def decode_text(self):
+        """
+        Assume `key` and `value` are bytes but decode from UTF-8 well.
+        """
+        if self.key is not None and isinstance(self.key, bytes):
+            self.key = self.key.decode("utf-8")
+        if self.value is not None and isinstance(self.value, bytes):
+            self.value = self.value.decode("utf-8")
+
+    def to_dict(self, options: KafkaDecodingOptions):
+        """
+        Convert Kafka event to designated output format/layout.
+        """
+        # TODO: Make decoding from text optional.
+        self.decode_text()
+
+        message_id = digest128(self.topic + str(self.partition) + str(self.key))
+
+        # The standard message layout as defined per dlt and ingestr.
+        standard_payload = {
+            "partition": self.partition,
+            "topic": self.topic,
+            "key": self.key,
+            "offset": self.offset,
+            "ts": {
+                "type": self.ts[0],
+                "value": ensure_pendulum_datetime(self.ts[1] / 1e3),
+            },
+            "data": self.value,
+        }
+
+        # Basic Kafka message processors providing two formats.
+        # Returns the message value and metadata.
+        # The legacy format `standard_v1` uses the field `_kafka_msg_id`,
+        # while the future `standard_v2` format uses `_kafka__msg_id`,
+        # better aligned with all the other fields.
+        #
+        # Currently, as of July 2025, `standard_v1` is used as the
+        # default to not cause any breaking changes.
+
+        if options.format == "standard_v1":
+            UserWarning(
+                "Future versions of ingestr will use the `standard_v2` output format. "
+                "To retain compatibility, make sure to start using `format=standard_v1` early."
+            )
+            return {
+                "_kafka": standard_payload,
+                "_kafka_msg_id": message_id,
+            }
+
+        if options.format == "standard_v2":
+            standard_payload["msg_id"] = message_id
+            return {
+                "_kafka": standard_payload,
+            }
+
+        # Slightly advanced Kafka message processor providing basic means of projections.
+        # include: A list of event attributes to include.
+        # select: A single event attribute to select and drill down into.
+        #         Use `select=value` to relay the message payload data only.
+        if options.format == "flexible":
+            if options.include:
+                # TODO: Need to cache this variable?
+                include_keys = [
+                    key == "value" and "data" or key for key in options.include
+                ]
+                return toolz.keyfilter(lambda k: k in include_keys, standard_payload)
+            if options.select:
+                # TODO: Instead of a simple dictionary getter, `jsonpointer` or `jqlang`
+                #       can provide easy access to deeper levels of nested data structures.
+                key = options.select.replace("value", "data")
+                return standard_payload.get(key)
+            return standard_payload
+
+        raise NotImplementedError(f"Unknown message processor format: {options.format}")

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -1584,6 +1584,13 @@ class KafkaSource:
         batch_size = source_params.get("batch_size", [3000])
         batch_timeout = source_params.get("batch_timeout", [3])
 
+        # Decoding options.
+        key_type = source_params.get("key_type", [])
+        value_type = source_params.get("value_type", [])
+        format = source_params.get("format", [])
+        include = source_params.get("include", [])
+        select = source_params.get("select", [])
+
         if not bootstrap_servers:
             raise ValueError(
                 "bootstrap_servers in the URI is required to connect to kafka"
@@ -1593,8 +1600,21 @@ class KafkaSource:
             raise ValueError("group_id in the URI is required to connect to kafka")
 
         start_date = kwargs.get("interval_start")
+
         from ingestr.src.kafka import kafka_consumer
-        from ingestr.src.kafka.helpers import KafkaCredentials
+        from ingestr.src.kafka.helpers import (
+            KafkaCredentials,
+            KafkaEventProcessor,
+        )
+        from ingestr.src.kafka.model import KafkaDecodingOptions
+
+        options = KafkaDecodingOptions.from_params(
+            key_type=key_type,
+            value_type=value_type,
+            format=format,
+            include=include,
+            select=select,
+        )
 
         return kafka_consumer(
             topics=[table],
@@ -1610,6 +1630,7 @@ class KafkaSource:
                 sasl_username=sasl_username[0] if len(sasl_username) > 0 else None,  # type: ignore
                 sasl_password=sasl_password[0] if len(sasl_password) > 0 else None,  # type: ignore
             ),
+            msg_processor=KafkaEventProcessor(options=options).process,
             start_from=start_date,
             batch_size=int(batch_size[0]),
             batch_timeout=int(batch_timeout[0]),

--- a/requirements.in
+++ b/requirements.in
@@ -63,3 +63,4 @@ urllib3==2.6.3
 protobuf==5.29.6
 aiohttp==3.13.3
 pyasn1==0.6.2
+toolz==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -593,6 +593,8 @@ tomlkit==0.13.2
     # via
     #   dlt
     #   snowflake-connector-python
+toolz==1.0.0
+    # via -r requirements.in
 tqdm==4.67.1
     # via -r requirements.in
 trino==0.336.0

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -593,6 +593,8 @@ tomlkit==0.13.2
     # via
     #   dlt
     #   snowflake-connector-python
+toolz==1.0.0
+    # via -r requirements.in
 tqdm==4.67.1
     # via -r requirements.in
 trino==0.336.0


### PR DESCRIPTION
## Pitch

Expand Kafka adapter's `default_msg_processor` into a miniature decoding unit.

Loading data from Kafka into a database destination works well, but we found there are no options to specifically _decode and drill down into_ the **Kafka event value** properly, in order to only relay that into the target database, without any metadata information.

## Comparison

For example, [Kafka Connect](https://www.confluent.io/blog/kafka-connect-deep-dive-converters-serialization-explained/) provides such configuration options for similar use cases which are fragments hereof.
```json
"key.converter": "org.apache.kafka.connect.storage.StringConverter",
"value.converter": "org.apache.kafka.connect.json.JsonIotaConverter",
```

## Solution

This patch slightly builds upon and expands the existing `default_msg_processor` implementation to accept a few more options to resolve our needs, and to improve matureness closer to what Kafka Connect provides. **The update is fully backwards compatible, which means the patch does not introduce a breaking change for existing users and applications.**

## Details

- Accept a bunch of decoding options per `KafkaDecodingOptions`
- Provide a bunch of output formatting options per `KafkaEvent`
- Tie both elements together using `KafkaEventProcessor`

The machinery is effectively the same like before, but provides a few more options to allow type decoding for Kafka event's key/value slots (`key_type` and `value_type`), a selection mechanism to limit the output to specific fields only (`include`), a small projection mechanism to optionally drill down into a specific field (`select`), and an option to select the output format (`format`).

In combination, those decoding options allow users to relay JSON-encoded Kafka event values directly into a destination table, without any metadata wrappings. Currently, the output formatter provides three different variants out of the box (`standard_v1`, `standard_v2`, `flexible`) [^standard_v2]. More variants can be added in the future, as other users or use cases may have different requirements in the same area.

Most importantly, the decoding unit is very compact, so relevant tasks do NOT require a corresponding **transformation unit** down the pipeline. This keeps the whole ensemble lean, in the very spirit of ingestr.

## Preview
```sh
uv pip install --upgrade 'ingestr @ git+https://github.com/crate-workbench/ingestr.git@kafka-decoder'
```

## Example
Use URL parameters `value_type=json&select=value` to exclusively emit the Kafka event's message payload into the data sink.
```sh
docker run --rm --name=kafka \
  --publish=9092:9092 docker.io/apache/kafka:latest
```
```sh
echo '{"sensor_id":1,"ts":"2025-06-01 10:00","reading":42.42}' | \
  kcat -P -b localhost -t demo
echo '{"sensor_id":2,"ts":"2025-06-01 11:00","reading":451.00}' | \
  kcat -P -b localhost -t demo
```
```sh
ingestr ingest --yes \
  --source-uri "kafka://?bootstrap_servers=localhost:9092&group_id=test&value_type=json&select=value" \
  --source-table "demo" \
  --dest-uri "duckdb:///kafka.duckdb" \
  --dest-table "demo.kafka"
```
```sh
duckdb kafka.duckdb 'SELECT * FROM demo.kafka WHERE sensor_id>1;'
```

## Backlog

- [x] Add software tests for non-standard decoding and output formatting options
- [x] Add docs and improve inline comments


[^standard_v2]: The `standard_v2` output format is intended to resolve GH-289.
