### PR TITLE
fix databricks destination

### DIFF
--- a/ingestr/src/destinations.py
+++ b/ingestr/src/destinations.py
@@ -291,11 +291,6 @@ class DatabricksDestination(GenericSqlDestination):
         catalog = q.get("catalog", [None])[0]
         schema = q.get("schema", [None])[0]
         
-        print("access_token", access_token)
-        print("server_hostname", server_hostname)
-        print("http_path", http_path)
-        print("catalog", catalog)
-        print("schema", schema)
 
         creds = {
             "access_token": access_token,

--- a/ingestr/src/destinations_test.py
+++ b/ingestr/src/destinations_test.py
@@ -111,3 +111,15 @@ class MsSQLDestinationTest(unittest.TestCase, GenericSqlDestinationFixture):
 class DatabricksDestinationTest(unittest.TestCase, GenericSqlDestinationFixture):
     destination = DatabricksDestination()
     expected_class = dlt.destinations.databricks
+    def test_credentials_are_passed_correctly(self):
+        uri = "databricks://token:password@hostname?http_path=/path/123&catalog=workspace&schema=dest"
+        result = self.destination.dlt_dest(uri)
+
+        self.assertTrue(isinstance(result, self.expected_class))
+        # Override the generic test - expect parsed credentials, not raw URI
+        creds = result.config_params["credentials"]
+        self.assertEqual(creds["access_token"], "password")
+        self.assertEqual(creds["server_hostname"], "hostname")
+        self.assertEqual(creds["http_path"], "/path/123")
+        self.assertEqual(creds["catalog"], "workspace")
+        self.assertEqual(creds["schema"], "dest")

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 asana==3.2.3
 confluent-kafka==2.8.0
-databricks-sql-connector==2.9.3
+databricks-sql-connector==4.0.5
+databricks-sqlalchemy==1.0.2
 dataclasses-json==0.6.7
 dlt==1.11.0
 dlt-cratedb>=0.0.1
@@ -42,7 +43,6 @@ flatten_json==0.1.14
 dataclasses-json==0.6.7
 gcsfs==2025.3.2
 simple-salesforce==1.12.6
-databricks-sqlalchemy==1.0.2
 clickhouse-connect==0.8.14
 clickhouse-driver==0.2.9
 clickhouse-sqlalchemy==0.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,6 @@ asana==3.2.3
     # via -r requirements.in
 asn1crypto==1.5.1
     # via snowflake-connector-python
-async-timeout==5.0.1
-    # via aiohttp
 asynch==0.2.4
     # via clickhouse-sqlalchemy
 attrs==25.1.0
@@ -594,13 +592,11 @@ typing-extensions==4.12.2
     # via
     #   alembic
     #   dlt
-    #   multidict
     #   pyairtable
     #   pydantic
     #   pydantic-core
     #   pyopenssl
     #   reactivex
-    #   rich
     #   simple-salesforce
     #   snowflake-connector-python
     #   sqlalchemy2-stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,15 +16,15 @@ aioitertools==0.12.0
 aiosignal==1.3.2
     # via aiohttp
 alembic==1.15.1
-    # via
-    #   databricks-sql-connector
-    #   sqlalchemy-spanner
+    # via sqlalchemy-spanner
 annotated-types==0.7.0
     # via pydantic
 asana==3.2.3
     # via -r requirements.in
 asn1crypto==1.5.1
     # via snowflake-connector-python
+async-timeout==5.0.1
+    # via aiohttp
 asynch==0.2.4
     # via clickhouse-sqlalchemy
 attrs==25.1.0
@@ -88,7 +88,7 @@ cryptography==44.0.2
     #   snowflake-connector-python
 curlify==2.2.1
     # via facebook-business
-databricks-sql-connector==2.9.3
+databricks-sql-connector==4.0.5
     # via -r requirements.in
 databricks-sqlalchemy==1.0.2
     # via -r requirements.in
@@ -301,9 +301,7 @@ mypy-extensions==1.0.0
 mysql-connector-python==9.2.0
     # via -r requirements.in
 numpy==2.2.3
-    # via
-    #   databricks-sql-connector
-    #   pandas
+    # via pandas
 oauthlib==3.2.2
     # via
     #   databricks-sql-connector
@@ -376,9 +374,7 @@ py-machineid==0.6.0
 pyairtable==2.3.3
     # via -r requirements.in
 pyarrow==18.1.0
-    # via
-    #   -r requirements.in
-    #   databricks-sql-connector
+    # via -r requirements.in
 pyasn1==0.6.1
     # via
     #   pyasn1-modules
@@ -418,6 +414,7 @@ python-dateutil==2.9.0.post0
     # via
     #   aiobotocore
     #   botocore
+    #   databricks-sql-connector
     #   google-cloud-bigquery
     #   influxdb-client
     #   pandas
@@ -546,7 +543,6 @@ sqlalchemy==1.4.52
     #   -r requirements.in
     #   alembic
     #   clickhouse-sqlalchemy
-    #   databricks-sql-connector
     #   databricks-sqlalchemy
     #   duckdb-engine
     #   ibm-db-sa
@@ -598,11 +594,13 @@ typing-extensions==4.12.2
     # via
     #   alembic
     #   dlt
+    #   multidict
     #   pyairtable
     #   pydantic
     #   pydantic-core
     #   pyopenssl
     #   reactivex
+    #   rich
     #   simple-salesforce
     #   snowflake-connector-python
     #   sqlalchemy2-stubs

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -16,9 +16,7 @@ aioitertools==0.12.0
 aiosignal==1.3.2
     # via aiohttp
 alembic==1.15.2
-    # via
-    #   databricks-sql-connector
-    #   sqlalchemy-spanner
+    # via sqlalchemy-spanner
 annotated-types==0.7.0
     # via pydantic
 asana==3.2.3
@@ -88,7 +86,7 @@ cryptography==44.0.2
     #   snowflake-connector-python
 curlify==2.2.1
     # via facebook-business
-databricks-sql-connector==2.9.3
+databricks-sql-connector==4.0.5
     # via -r requirements.in
 databricks-sqlalchemy==1.0.2
     # via -r requirements.in
@@ -297,9 +295,7 @@ mypy-extensions==1.0.0
 mysql-connector-python==9.2.0
     # via -r requirements.in
 numpy==2.2.4
-    # via
-    #   databricks-sql-connector
-    #   pandas
+    # via pandas
 oauthlib==3.2.2
     # via
     #   databricks-sql-connector
@@ -372,9 +368,7 @@ py-machineid==0.6.0
 pyairtable==2.3.3
     # via -r requirements.in
 pyarrow==18.1.0
-    # via
-    #   -r requirements.in
-    #   databricks-sql-connector
+    # via -r requirements.in
 pyasn1==0.6.1
     # via
     #   pyasn1-modules
@@ -414,6 +408,7 @@ python-dateutil==2.9.0.post0
     # via
     #   aiobotocore
     #   botocore
+    #   databricks-sql-connector
     #   google-cloud-bigquery
     #   influxdb-client
     #   pandas
@@ -542,7 +537,6 @@ sqlalchemy==1.4.52
     #   -r requirements.in
     #   alembic
     #   clickhouse-sqlalchemy
-    #   databricks-sql-connector
     #   databricks-sqlalchemy
     #   duckdb-engine
     #   snowflake-sqlalchemy


### PR DESCRIPTION
Following changes are made in this PR:
- Pass credentials via a creds dict instead of the URI to resolve TypeError.
- Use the schema from the URI as dataset_name instead taking from the dest-table to avoid overriding the schema.
- Upgrade databricks-sql-connector from 2.9.3 to 4.0.5 to fix issues with handling NULL values.
- Update test function accordingly

Tested Databricks as both a source and a destination - working fine.