### PR TITLE
feat/masking on the fly

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -43,6 +43,7 @@ export default defineConfig({
             text: "Incremental Loading",
             link: "/getting-started/incremental-loading.md",
           },
+          { text: "Data Masking", link: "/getting-started/data-masking.md" },
           { text: "Telemetry", link: "/getting-started/telemetry.md" },
         ],
       },

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -28,6 +28,7 @@ ingestr ingest \
 - `--interval-end`: Sets the end of the interval for the incremental key. Defaults to `None`.
 - `--primary-key TEXT`: Specifies the primary key for the merge operation. Defaults to `None`.
 - `--columns <column_name>:<column_type>`: Specifies the columns to be ingested. Defaults to `None`.
+- `--mask <column_name>:<algorithm>[:param]`: Applies data masking to specified columns. Can be used multiple times for different columns. See the [Data Masking](../getting-started/data-masking.md) documentation for available algorithms and usage examples. Defaults to `None`.
 
 The `interval-start` and `interval-end` options support various datetime formats, here are some examples:
 - `%Y-%m-%d`: `2023-01-31`
@@ -105,6 +106,26 @@ ingestr ingest
    --interval-end '2023-01-31' \
    --columns 'dt:date'
 ```
+
+### Ingesting with Data Masking
+
+```bash
+ingestr ingest \
+   --source-uri 'postgresql://user:pass@localhost/customers' \
+   --source-table 'customer_data' \
+   --dest-uri 'duckdb:///masked_customers.db' \
+   --dest-table 'masked_customers' \
+   --mask 'email:hash' \
+   --mask 'phone:partial:3' \
+   --mask 'ssn:redact' \
+   --mask 'salary:round:5000'
+```
+
+This example demonstrates masking sensitive customer data:
+- Email addresses are hashed for consistent anonymization
+- Phone numbers show only first and last 3 digits
+- SSNs are completely redacted
+- Salaries are rounded to nearest $5000
 
 > [!INFO]
 > For more examples, please refer to the specific platforms' documentation on the sidebar.

--- a/docs/getting-started/data-masking.md
+++ b/docs/getting-started/data-masking.md
@@ -1,0 +1,377 @@
+# Data Masking
+
+Data masking is a critical security feature that allows you to protect sensitive information while maintaining data utility for development, testing, and analytics purposes. ingestr provides comprehensive masking capabilities that can be applied to any column during the ingestion process.
+
+## Overview
+
+Data masking transforms sensitive data into a protected format while preserving the structure and type of the original data. This is essential for:
+
+- **Compliance** with regulations like GDPR, CCPA, HIPAA
+- **Security** in development and testing environments
+- **Privacy** protection in analytics and reporting
+- **Data sharing** with third parties or external systems
+
+## Usage
+
+Apply masking to specific columns using the `--mask` parameter:
+
+```bash
+ingestr ingest \
+  --source-uri "postgres://user:pass@localhost/db" \
+  --source-table "users" \
+  --dest-uri "duckdb:///masked_data.db" \
+  --dest-table "masked_users" \
+  --mask "email:hash" \
+  --mask "ssn:partial:4" \
+  --mask "salary:round:1000"
+```
+
+### Format
+
+```
+--mask <column_name>:<algorithm>[:<parameter>]
+```
+
+- `column_name`: The name of the column to mask
+- `algorithm`: The masking algorithm to apply
+- `parameter`: Optional parameter for algorithms that require configuration
+
+## Masking Algorithms
+
+### Irreversible Masking
+
+These algorithms permanently transform data in a way that cannot be reversed.
+
+#### `hash` / `sha256`
+Creates a SHA-256 hash of the value. Consistent across runs - the same input always produces the same output.
+
+**Use cases:** Creating anonymous identifiers, consistent tokenization
+```bash
+--mask "user_id:hash"
+# john.doe@example.com → a94a8fe5ccb19ba61c4c0873d391e987982fbbd3
+```
+
+#### `md5`
+Creates an MD5 hash. Faster than SHA-256 but less secure (adequate for non-security purposes).
+
+**Use cases:** Quick checksums, non-security tokenization
+```bash
+--mask "session_id:md5"
+```
+
+#### `hmac`
+Hash-based message authentication code with a secret key. Provides consistent hashing across systems when using the same key.
+
+**Use cases:** Cross-system consistency with shared secret
+```bash
+--mask "customer_id:hmac:my-secret-key"
+```
+
+#### `redact`
+Replaces the entire value with "REDACTED".
+
+**Use cases:** Complete removal of sensitive data
+```bash
+--mask "comments:redact"
+# "Customer complaint about..." → "REDACTED"
+```
+
+### Format-Preserving Masking
+
+These algorithms maintain the format and structure of the original data.
+
+#### `email`
+Masks email addresses while preserving the domain.
+
+**Use cases:** Protecting email addresses while maintaining domain analysis
+```bash
+--mask "email:email"
+# john.doe@example.com → j******e@example.com
+```
+
+#### `phone`
+Masks phone numbers while preserving country and area codes.
+
+**Use cases:** Geographic analysis without exposing full numbers
+```bash
+--mask "phone:phone"
+# +1-555-123-4567 → +1-555-***-****
+```
+
+#### `credit_card`
+Shows only the last 4 digits of credit card numbers.
+
+**Use cases:** Payment processing logs, transaction records
+```bash
+--mask "card_number:credit_card"
+# 4111-1111-1111-1111 → ****-****-****-1111
+```
+
+#### `ssn`
+Masks Social Security Numbers showing only last 4 digits.
+
+**Use cases:** Identity verification systems
+```bash
+--mask "ssn:ssn"
+# 123-45-6789 → ***-**-6789
+```
+
+### Partial Masking
+
+These algorithms show only portions of the original data.
+
+#### `partial`
+Shows first and last N characters, masking the middle.
+
+**Use cases:** Names, addresses, partial visibility
+```bash
+--mask "name:partial:2"
+# "Jonathan" → "Jo****an"
+```
+
+#### `first_letter`
+Shows only the first character.
+
+**Use cases:** Initials, abbreviated names
+```bash
+--mask "first_name:first_letter"
+# "Alice" → "A****"
+```
+
+#### `stars`
+Replaces entire value with asterisks of the same length.
+
+**Use cases:** Password fields, complete obfuscation
+```bash
+--mask "password:stars"
+# "secret123" → "*********"
+```
+
+#### `fixed`
+Replaces with a fixed value.
+
+**Use cases:** Standardized replacement values
+```bash
+--mask "api_key:fixed:MASKED_KEY"
+# "sk_live_abc123" → "MASKED_KEY"
+```
+
+### Tokenization
+
+These algorithms replace values with tokens or identifiers.
+
+#### `uuid`
+Replaces with a UUID token. Same values get the same UUID (consistent).
+
+**Use cases:** Creating surrogate keys, maintaining referential integrity
+```bash
+--mask "customer_id:uuid"
+# "CUST001" → "550e8400-e29b-41d4-a716-446655440000"
+```
+
+#### `sequential`
+Replaces with sequential integers starting from 1.
+
+**Use cases:** Simple anonymization, reducing data size
+```bash
+--mask "account_number:sequential"
+# "ACC-2024-001" → 1
+# "ACC-2024-002" → 2
+```
+
+#### `random`
+Replaces with random data of the same type.
+
+**Use cases:** Test data generation, complete randomization
+```bash
+--mask "age:random"
+# 35 → 67 (random number)
+```
+
+### Numeric Masking
+
+These algorithms transform numeric values while preserving their general magnitude.
+
+#### `round`
+Rounds numbers to the nearest specified value.
+
+**Use cases:** Salary bands, age groups, reducing precision
+```bash
+--mask "salary:round:5000"
+# 52300 → 50000
+
+--mask "age:round:10"
+# 34 → 30
+```
+
+#### `range`
+Replaces with a range bracket.
+
+**Use cases:** Bucketing, categorical analysis
+```bash
+--mask "income:range:10000"
+# 45000 → "40000-50000"
+
+--mask "score:range:100"
+# 234 → "200-300"
+```
+
+#### `noise`
+Adds random noise to numeric values.
+
+**Use cases:** Statistical privacy, differential privacy
+```bash
+--mask "revenue:noise:0.1"
+# 100000 → 91234 (±10% random noise)
+
+--mask "temperature:noise:0.05"
+# 98.6 → 97.2 (±5% random noise)
+```
+
+### Date Masking
+
+These algorithms transform date and datetime values.
+
+#### `date_shift`
+Adds or subtracts random days within a specified range.
+
+**Use cases:** Preserving date relationships while obscuring exact dates
+```bash
+--mask "birth_date:date_shift:30"
+# 1990-05-15 → 1990-06-02 (shifted ±30 days randomly)
+```
+
+#### `year_only`
+Keeps only the year portion of dates.
+
+**Use cases:** Age analysis, cohort studies
+```bash
+--mask "registration_date:year_only"
+# 2024-03-15 → 2024
+```
+
+#### `month_year`
+Keeps only month and year.
+
+**Use cases:** Seasonal analysis, monthly aggregations
+```bash
+--mask "purchase_date:month_year"
+# 2024-03-15 → "2024-03"
+```
+
+## Use Case Examples
+
+### GDPR Compliance for Development Environment
+
+```bash
+ingestr ingest \
+  --source-uri "postgres://prod_user:pass@prod.db/customers" \
+  --source-table "customer_data" \
+  --dest-uri "postgres://dev_user:pass@dev.db/customers" \
+  --dest-table "customer_data" \
+  --mask "email:hash" \
+  --mask "phone:phone" \
+  --mask "name:partial:1" \
+  --mask "address:redact" \
+  --mask "ip_address:hash" \
+  --mask "birth_date:year_only"
+```
+
+### Healthcare Data for Analytics
+
+```bash
+ingestr ingest \
+  --source-uri "mysql://user:pass@hospital.db/patients" \
+  --source-table "patient_records" \
+  --dest-uri "bigquery://project/dataset" \
+  --dest-table "patient_analytics" \
+  --mask "patient_id:uuid" \
+  --mask "ssn:redact" \
+  --mask "diagnosis_notes:redact" \
+  --mask "admission_date:date_shift:7" \
+  --mask "age:round:5"
+```
+
+### Financial Data for Testing
+
+```bash
+ingestr ingest \
+  --source-uri "snowflake://account/database/schema" \
+  --source-table "transactions" \
+  --dest-uri "duckdb:///test_data.db" \
+  --dest-table "test_transactions" \
+  --mask "account_number:sequential" \
+  --mask "card_number:credit_card" \
+  --mask "amount:noise:0.2" \
+  --mask "merchant_name:fixed:TEST_MERCHANT"
+```
+
+### E-commerce Data Sharing
+
+```bash
+ingestr ingest \
+  --source-uri "postgres://internal.db/ecommerce" \
+  --source-table "orders" \
+  --dest-uri "s3://partner-bucket/data.parquet" \
+  --dest-table "shared_orders" \
+  --mask "customer_email:email" \
+  --mask "shipping_address:first_letter" \
+  --mask "order_value:round:10" \
+  --mask "customer_name:partial:2"
+```
+
+## Best Practices
+
+### Choosing the Right Algorithm
+
+1. **For PII (Personally Identifiable Information)**
+   - Use `hash` for consistent anonymization
+   - Use `redact` for complete removal
+   - Use format-preserving masks (`email`, `phone`, `ssn`) for maintaining data structure
+
+2. **For Development/Testing**
+   - Use `uuid` or `sequential` for maintaining relationships
+   - Use `random` for generating test data
+   - Use `partial` for semi-realistic data
+
+3. **For Analytics**
+   - Use `round` or `range` for numerical aggregations
+   - Use `date_shift` for time-series analysis
+   - Use `year_only` or `month_year` for temporal grouping
+
+4. **For Compliance**
+   - GDPR: Consider `hash`, `redact`, or `uuid` for personal data
+   - HIPAA: Use `redact` for medical records, `date_shift` for dates
+   - PCI DSS: Use `credit_card` for card numbers
+
+### Performance Considerations
+
+- **Hash-based algorithms** are fast and consistent
+- **Random algorithms** have minimal overhead but don't preserve consistency
+- **Format-preserving masks** have moderate performance impact
+- **Multiple masks** can be applied efficiently in a single pass
+
+### Security Notes
+
+1. **Hashed values** are one-way transformations but may be vulnerable to rainbow table attacks for common values
+2. **Partial masking** may not provide sufficient protection for highly sensitive data
+3. **Date shifting** preserves intervals between dates, which may leak information
+4. **Consistent tokenization** (uuid, hash) maintains relationships which could be exploited
+5. Always validate that your masking strategy meets your compliance requirements
+
+## Environment Variables
+
+You can also set masking configurations via environment variables:
+
+```bash
+export INGESTR_MASK="email:hash,phone:partial:3,ssn:redact"
+```
+
+Multiple masks should be comma-separated when using environment variables.
+
+## Limitations
+
+- Masking is applied in-memory during the ingestion process
+- The original source data remains unchanged
+- Some algorithms require additional dependencies (e.g., `date_shift` requires `python-dateutil`)
+- Masking adds processing overhead proportional to the data volume and number of masks applied

--- a/ingestr/src/filters.py
+++ b/ingestr/src/filters.py
@@ -51,3 +51,12 @@ def table_adapter_exclude_columns(cols: list[str]):
             table._columns.remove(col)  # type: ignore
 
     return excluder
+
+
+def create_masking_filter(mask_configs: list[str]):
+    from ingestr.src.masking import create_masking_mapper
+
+    if not mask_configs:
+        return lambda x: x
+
+    return create_masking_mapper(mask_configs)

--- a/ingestr/src/frankfurter/__init__.py
+++ b/ingestr/src/frankfurter/__init__.py
@@ -14,14 +14,13 @@ from ingestr.src.frankfurter.helpers import get_path_with_retry
 )
 def frankfurter_source(
     start_date: TAnyDateTime,
-    end_date: TAnyDateTime|None,
+    end_date: TAnyDateTime | None,
     base_currency: str,
 ) -> Any:
     """
     A dlt source for the frankfurter.dev API. It groups several resources (in this case frankfurter.dev API endpoints) containing
     various types of data: currencies, latest rates, historical rates.
     """
-    
 
     @dlt.resource(
         write_disposition="replace",
@@ -35,7 +34,6 @@ def frankfurter_source(
 
         for currency_code, currency_name in currencies_data.items():
             yield {"currency_code": currency_code, "currency_name": currency_name}
-
 
     @dlt.resource(
         write_disposition="merge",
@@ -81,7 +79,6 @@ def frankfurter_source(
                 "base_currency": base_currency,
             }
 
-
     @dlt.resource(
         write_disposition="merge",
         columns={
@@ -93,13 +90,13 @@ def frankfurter_source(
         primary_key=("date", "currency_code", "base_currency"),
     )
     def exchange_rates(
-        date_time = dlt.sources.incremental(
-        "date",
-        initial_value=start_date,
-        end_value=end_date,
-        range_start="closed",
-        range_end="closed",
-    )
+        date_time=dlt.sources.incremental(
+            "date",
+            initial_value=start_date,
+            end_value=end_date,
+            range_start="closed",
+            range_end="closed",
+        ),
     ) -> Iterator[dict]:
         """
         Fetches exchange rates for a specified date range.
@@ -115,9 +112,9 @@ def frankfurter_source(
             end_date = date_time.end_value
         else:
             end_date = pendulum.now()
-        
+
         # Ensure start_date.last_value is a pendulum.DateTime object
-        start_date_obj = ensure_pendulum_datetime(start_date) # type: ignore
+        start_date_obj = ensure_pendulum_datetime(start_date)  # type: ignore
         start_date_str = start_date_obj.format("YYYY-MM-DD")
 
         # Ensure end_date is a pendulum.DateTime object
@@ -158,4 +155,3 @@ def frankfurter_source(
                 }
 
     return currencies, latest, exchange_rates
-    

--- a/ingestr/src/frankfurter/helpers.py
+++ b/ingestr/src/frankfurter/helpers.py
@@ -16,9 +16,9 @@ def get_path_with_retry(path: str) -> StrAny:
     return get_url_with_retry(f"{FRANKFURTER_API_URL}{path}")
 
 
-def validate_dates(start_date: datetime, end_date: datetime|None) -> None:
+def validate_dates(start_date: datetime, end_date: datetime | None) -> None:
     current_date = pendulum.now()
-    
+
     # Check if start_date is in the futurep
     if start_date > current_date:
         raise ValueError("Interval-start cannot be in the future.")

--- a/ingestr/src/masking.py
+++ b/ingestr/src/masking.py
@@ -1,0 +1,344 @@
+import hashlib
+import hmac
+import random
+import re
+import string
+import uuid
+from datetime import date, datetime, timedelta
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+
+class MaskingEngine:
+    def __init__(self):
+        self.token_cache: Dict[str, Union[str, int]] = {}
+        self.sequential_counter = 0
+
+    def parse_mask_config(self, config: str) -> Tuple[str, str, Optional[str]]:
+        parts = config.split(":")
+        if len(parts) == 2:
+            return parts[0], parts[1], None
+        elif len(parts) == 3:
+            return parts[0], parts[1], parts[2]
+        else:
+            raise ValueError(
+                f"Invalid mask configuration: {config}. Expected format: 'column:algorithm[:param]'"
+            )
+
+    def get_masking_function(
+        self, algorithm: str, param: Optional[str] = None
+    ) -> Callable:
+        algorithm = algorithm.lower()
+
+        # Hash-based masking
+        if algorithm == "hash" or algorithm == "sha256":
+            return self._hash_sha256
+        elif algorithm == "md5":
+            return self._hash_md5
+        elif algorithm == "hmac":
+            return lambda x: self._hash_hmac(x, param or "default-key")
+
+        # Format-preserving masking
+        elif algorithm == "email":
+            return self._mask_email
+        elif algorithm == "phone":
+            return self._mask_phone
+        elif algorithm == "credit_card":
+            return self._mask_credit_card
+        elif algorithm == "ssn":
+            return self._mask_ssn
+
+        # Redaction strategies
+        elif algorithm == "redact":
+            return lambda x: "REDACTED"
+        elif algorithm == "stars":
+            return lambda x: "*" * len(str(x)) if x else ""
+        elif algorithm == "fixed":
+            return lambda x: param or "MASKED"
+        elif algorithm == "random":
+            return self._random_replace
+
+        # Partial masking
+        elif algorithm == "partial":
+            chars = int(param) if param else 2
+            return lambda x: self._partial_mask(x, chars)
+        elif algorithm == "first_letter":
+            return self._first_letter_mask
+
+        # Tokenization
+        elif algorithm == "uuid":
+            return self._tokenize_uuid
+        elif algorithm == "sequential":
+            return self._tokenize_sequential
+
+        # Numeric masking
+        elif algorithm == "round":
+            precision = int(param) if param else 10
+            return lambda x: self._round_number(x, precision)
+        elif algorithm == "range":
+            bucket_size = int(param) if param else 100
+            return lambda x: self._range_mask(x, bucket_size)
+        elif algorithm == "noise":
+            noise_level = float(param) if param else 0.1
+            return lambda x: self._add_noise(x, noise_level)
+
+        # Date masking
+        elif algorithm == "date_shift":
+            max_days = int(param) if param else 30
+            return lambda x: self._date_shift(x, max_days)
+        elif algorithm == "year_only":
+            return self._year_only
+        elif algorithm == "month_year":
+            return self._month_year
+
+        else:
+            raise ValueError(f"Unknown masking algorithm: {algorithm}")
+
+    # Hash functions
+    def _hash_sha256(self, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return hashlib.sha256(str(value).encode()).hexdigest()
+
+    def _hash_md5(self, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return hashlib.md5(str(value).encode()).hexdigest()
+
+    def _hash_hmac(self, value: Any, key: str) -> Optional[str]:
+        if value is None:
+            return None
+        return hmac.new(key.encode(), str(value).encode(), hashlib.sha256).hexdigest()
+
+    # Format-preserving masks
+    def _mask_email(self, value: Any) -> Any:
+        if value is None or not value:
+            return value
+        email_str = str(value)
+        if "@" not in email_str:
+            return self._partial_mask(email_str, 2)
+
+        local, domain = email_str.split("@", 1)
+        if len(local) <= 2:
+            masked_local = "*" * len(local)
+        else:
+            masked_local = local[0] + "*" * (len(local) - 2) + local[-1]
+        return f"{masked_local}@{domain}"
+
+    def _mask_phone(self, value: Any) -> Any:
+        if value is None or not value:
+            return value
+        phone_str = re.sub(r"\D", "", str(value))
+        if len(phone_str) < 10:
+            return "*" * len(phone_str)
+
+        # Keep country code and area code, mask the rest
+        if len(phone_str) >= 10:
+            return phone_str[:3] + "-***-****"
+        return phone_str
+
+    def _mask_credit_card(self, value: Any) -> Any:
+        if value is None or not value:
+            return value
+        cc_str = re.sub(r"\D", "", str(value))
+        if len(cc_str) < 12:
+            return "*" * len(cc_str)
+        return "*" * (len(cc_str) - 4) + cc_str[-4:]
+
+    def _mask_ssn(self, value: Any) -> Any:
+        if value is None or not value:
+            return value
+        ssn_str = re.sub(r"\D", "", str(value))
+        if len(ssn_str) != 9:
+            return "*" * len(ssn_str)
+        return "***-**-" + ssn_str[-4:]
+
+    # Partial masking
+    def _partial_mask(self, value: Any, chars_to_show: int) -> Any:
+        if value is None or not value:
+            return value
+        val_str = str(value)
+        if len(val_str) <= chars_to_show * 2:
+            return "*" * len(val_str)
+        return (
+            val_str[:chars_to_show]
+            + "*" * (len(val_str) - chars_to_show * 2)
+            + val_str[-chars_to_show:]
+        )
+
+    def _first_letter_mask(self, value: Any) -> Any:
+        if value is None or not value:
+            return value
+        val_str = str(value)
+        if len(val_str) <= 1:
+            return val_str
+        return val_str[0] + "*" * (len(val_str) - 1)
+
+    # Random replacement
+    def _random_replace(self, value: Any) -> Any:
+        if value is None:
+            return value
+
+        if isinstance(value, (int, float)):
+            # Generate random number in similar range
+            if isinstance(value, int):
+                magnitude = len(str(abs(value)))
+                return random.randint(10 ** (magnitude - 1), 10**magnitude - 1)
+            else:
+                return random.uniform(0, abs(value) * 2)
+        elif isinstance(value, str):
+            # Generate random string of same length
+            return "".join(
+                random.choices(string.ascii_letters + string.digits, k=len(value))
+            )
+        else:
+            return str(value)
+
+    # Tokenization
+    def _tokenize_uuid(self, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        val_str = str(value)
+        if val_str not in self.token_cache:
+            self.token_cache[val_str] = str(uuid.uuid4())
+        return str(self.token_cache[val_str])
+
+    def _tokenize_sequential(self, value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        val_str = str(value)
+        if val_str not in self.token_cache:
+            self.sequential_counter += 1
+            self.token_cache[val_str] = self.sequential_counter
+        return int(self.token_cache[val_str])
+
+    # Numeric masking
+    def _round_number(self, value: Any, precision: int) -> Any:
+        if value is None:
+            return value
+        try:
+            num = float(value)
+            return round(num / precision) * precision
+        except (ValueError, TypeError):
+            return value
+
+    def _range_mask(self, value: Any, bucket_size: int) -> Any:
+        if value is None:
+            return value
+        try:
+            num = float(value)
+            lower = int(num // bucket_size) * bucket_size
+            upper = lower + bucket_size
+            return f"{lower}-{upper}"
+        except (ValueError, TypeError):
+            return value
+
+    def _add_noise(self, value: Any, noise_level: float) -> Any:
+        if value is None:
+            return value
+        try:
+            num = float(value)
+            noise = random.uniform(-noise_level, noise_level) * abs(num)
+            result = num + noise
+            if isinstance(value, int):
+                return int(result)
+            return result
+        except (ValueError, TypeError):
+            return value
+
+    # Date masking
+    def _date_shift(self, value: Any, max_days: int) -> Any:
+        if value is None:
+            return value
+
+        if isinstance(value, (date, datetime)):
+            shift_days = random.randint(-max_days, max_days)
+            return value + timedelta(days=shift_days)
+
+        # Try to parse string dates
+        try:
+            from dateutil import parser
+
+            dt = parser.parse(str(value))
+            shift_days = random.randint(-max_days, max_days)
+            result = dt + timedelta(days=shift_days)
+            if isinstance(value, str):
+                return result.strftime("%Y-%m-%d")
+            return result
+        except Exception:
+            return value
+
+    def _year_only(self, value: Any) -> Any:
+        if value is None:
+            return value
+
+        if isinstance(value, (date, datetime)):
+            return value.year
+
+        # Try to parse string dates
+        try:
+            from dateutil import parser
+
+            dt = parser.parse(str(value))
+            return dt.year
+        except Exception:
+            return value
+
+    def _month_year(self, value: Any) -> Any:
+        if value is None:
+            return value
+
+        if isinstance(value, (date, datetime)):
+            return f"{value.year}-{value.month:02d}"
+
+        # Try to parse string dates
+        try:
+            from dateutil import parser
+
+            dt = parser.parse(str(value))
+            return f"{dt.year}-{dt.month:02d}"
+        except Exception:
+            return value
+
+
+def create_masking_mapper(mask_configs: list[str]) -> Callable:
+    engine = MaskingEngine()
+
+    # Parse all configurations
+    masks = {}
+    for config in mask_configs:
+        column, algorithm, param = engine.parse_mask_config(config)
+        masks[column] = engine.get_masking_function(algorithm, param)
+
+    def apply_masks(data: Any) -> Any:
+        # Handle PyArrow tables
+        try:
+            import pyarrow as pa  # type: ignore
+
+            if isinstance(data, pa.Table):
+                # Convert to pandas for easier manipulation
+                df = data.to_pandas()
+
+                # Apply masks to each column
+                for column, mask_func in masks.items():
+                    if column in df.columns:
+                        df[column] = df[column].apply(mask_func)
+
+                # Convert back to PyArrow table
+                return pa.Table.from_pandas(df)
+        except ImportError:
+            pass
+
+        # Handle dictionaries (original behavior)
+        if isinstance(data, dict):
+            for column, mask_func in masks.items():
+                if column in data:
+                    try:
+                        data[column] = mask_func(data[column])
+                    except Exception as e:
+                        print(f"Warning: Failed to mask column {column}: {e}")
+            return data
+
+        # Return as-is if not a supported type
+        return data
+
+    return apply_masks

--- a/ingestr/src/masking.py
+++ b/ingestr/src/masking.py
@@ -256,7 +256,7 @@ class MaskingEngine:
 
         # Try to parse string dates
         try:
-            from dateutil import parser
+            from dateutil import parser  # type: ignore
 
             dt = parser.parse(str(value))
             shift_days = random.randint(-max_days, max_days)

--- a/ingestr/src/masking_test.py
+++ b/ingestr/src/masking_test.py
@@ -1,0 +1,386 @@
+import random
+import unittest
+from datetime import date, datetime
+from unittest.mock import patch
+
+from ingestr.src.masking import MaskingEngine, create_masking_mapper
+
+
+class TestMaskingEngine(unittest.TestCase):
+    def setUp(self):
+        self.engine = MaskingEngine()
+        # Set seed for reproducible tests
+        random.seed(42)
+
+    def test_parse_mask_config(self):
+        # Test basic config
+        col, algo, param = self.engine.parse_mask_config("email:hash")
+        self.assertEqual(col, "email")
+        self.assertEqual(algo, "hash")
+        self.assertIsNone(param)
+
+        # Test config with parameter
+        col, algo, param = self.engine.parse_mask_config("age:round:10")
+        self.assertEqual(col, "age")
+        self.assertEqual(algo, "round")
+        self.assertEqual(param, "10")
+
+        # Test invalid config
+        with self.assertRaises(ValueError):
+            self.engine.parse_mask_config("invalid")
+
+    def test_hash_sha256(self):
+        result = self.engine._hash_sha256("test@example.com")
+        self.assertEqual(
+            result, "973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b"
+        )
+
+        # Test consistency
+        result2 = self.engine._hash_sha256("test@example.com")
+        self.assertEqual(result, result2)
+
+        # Test None handling
+        self.assertIsNone(self.engine._hash_sha256(None))
+
+    def test_hash_md5(self):
+        result = self.engine._hash_md5("test@example.com")
+        self.assertEqual(result, "55502f40dc8b7c769880b10874abc9d0")
+
+        # Test None handling
+        self.assertIsNone(self.engine._hash_md5(None))
+
+    def test_hash_hmac(self):
+        result = self.engine._hash_hmac("test@example.com", "secret-key")
+        # HMAC should produce consistent results with same key
+        result2 = self.engine._hash_hmac("test@example.com", "secret-key")
+        self.assertEqual(result, result2)
+
+        # Different keys should produce different results
+        result3 = self.engine._hash_hmac("test@example.com", "different-key")
+        self.assertNotEqual(result, result3)
+
+    def test_mask_email(self):
+        result = self.engine._mask_email("john.doe@example.com")
+        self.assertTrue(result.endswith("@example.com"))
+        self.assertTrue("*" in result)
+
+        # Test short email
+        result = self.engine._mask_email("ab@test.com")
+        self.assertEqual(result, "**@test.com")
+
+        # Test invalid email (no @)
+        result = self.engine._mask_email("notanemail")
+        self.assertTrue("*" in result)
+
+        # Test None handling
+        self.assertIsNone(self.engine._mask_email(None))
+
+    def test_mask_phone(self):
+        result = self.engine._mask_phone("555-123-4567")
+        self.assertEqual(result, "555-***-****")
+
+        result = self.engine._mask_phone("+1-555-123-4567")
+        self.assertTrue("***" in result)
+
+        result = self.engine._mask_phone("12345")
+        self.assertEqual(result, "*****")
+
+        self.assertIsNone(self.engine._mask_phone(None))
+
+    def test_mask_credit_card(self):
+        result = self.engine._mask_credit_card("4111-1111-1111-1111")
+        self.assertEqual(result, "************1111")
+
+        result = self.engine._mask_credit_card("4111111111111111")
+        self.assertEqual(result, "************1111")
+
+        result = self.engine._mask_credit_card("1234")
+        self.assertEqual(result, "****")
+
+        self.assertIsNone(self.engine._mask_credit_card(None))
+
+    def test_mask_ssn(self):
+        result = self.engine._mask_ssn("123-45-6789")
+        self.assertEqual(result, "***-**-6789")
+
+        result = self.engine._mask_ssn("123456789")
+        self.assertEqual(result, "***-**-6789")
+
+        result = self.engine._mask_ssn("12345")
+        self.assertEqual(result, "*****")
+
+        self.assertIsNone(self.engine._mask_ssn(None))
+
+    def test_partial_mask(self):
+        result = self.engine._partial_mask("Jonathan", 2)
+        self.assertEqual(result, "Jo****an")
+
+        result = self.engine._partial_mask("test", 1)
+        self.assertEqual(result, "t**t")
+
+        result = self.engine._partial_mask("ab", 2)
+        self.assertEqual(result, "**")
+
+        self.assertIsNone(self.engine._partial_mask(None, 2))
+
+    def test_first_letter_mask(self):
+        result = self.engine._first_letter_mask("Alice")
+        self.assertEqual(result, "A****")
+
+        result = self.engine._first_letter_mask("B")
+        self.assertEqual(result, "B")
+
+        # Test None handling
+        self.assertIsNone(self.engine._first_letter_mask(None))
+
+    def test_tokenize_uuid(self):
+        result1 = self.engine._tokenize_uuid("customer1")
+        result2 = self.engine._tokenize_uuid("customer1")
+
+        # Same value should get same UUID
+        self.assertEqual(result1, result2)
+
+        # Different values should get different UUIDs
+        result3 = self.engine._tokenize_uuid("customer2")
+        self.assertNotEqual(result1, result3)
+
+        # Test None handling
+        self.assertIsNone(self.engine._tokenize_uuid(None))
+
+    def test_tokenize_sequential(self):
+        engine = MaskingEngine()  # Fresh engine for clean counter
+        result1 = engine._tokenize_sequential("customer1")
+        self.assertEqual(result1, 1)
+
+        result2 = engine._tokenize_sequential("customer2")
+        self.assertEqual(result2, 2)
+
+        # Same value should get same sequential ID
+        result3 = engine._tokenize_sequential("customer1")
+        self.assertEqual(result3, 1)
+
+        # Test None handling
+        self.assertIsNone(engine._tokenize_sequential(None))
+
+    def test_round_number(self):
+        result = self.engine._round_number(52300, 5000)
+        self.assertEqual(result, 50000)
+
+        result = self.engine._round_number(34, 10)
+        self.assertEqual(result, 30)
+
+        result = self.engine._round_number(37.5, 10)
+        self.assertEqual(result, 40)
+
+        # Test non-numeric value
+        result = self.engine._round_number("not_a_number", 10)
+        self.assertEqual(result, "not_a_number")
+
+        # Test None handling
+        self.assertIsNone(self.engine._round_number(None, 10))
+
+    def test_range_mask(self):
+        result = self.engine._range_mask(45000, 10000)
+        self.assertEqual(result, "40000-50000")
+
+        result = self.engine._range_mask(234, 100)
+        self.assertEqual(result, "200-300")
+
+        # Test non-numeric value
+        result = self.engine._range_mask("not_a_number", 100)
+        self.assertEqual(result, "not_a_number")
+
+        # Test None handling
+        self.assertIsNone(self.engine._range_mask(None, 100))
+
+    def test_add_noise(self):
+        # Reset seed for consistent test
+        random.seed(42)
+        result = self.engine._add_noise(100, 0.1)
+        # Result should be within 10% of original
+        self.assertTrue(90 <= result <= 110)
+
+        # Test integer preservation
+        result = self.engine._add_noise(100, 0.1)
+        self.assertIsInstance(result, int)
+
+        # Test float preservation
+        result = self.engine._add_noise(100.5, 0.1)
+        self.assertIsInstance(result, float)
+
+        # Test non-numeric value
+        result = self.engine._add_noise("not_a_number", 0.1)
+        self.assertEqual(result, "not_a_number")
+
+        # Test None handling
+        self.assertIsNone(self.engine._add_noise(None, 0.1))
+
+    def test_year_only(self):
+        test_date = date(2024, 3, 15)
+        result = self.engine._year_only(test_date)
+        self.assertEqual(result, 2024)
+
+        test_datetime = datetime(2024, 3, 15, 10, 30)
+        result = self.engine._year_only(test_datetime)
+        self.assertEqual(result, 2024)
+
+        # Test string date
+        result = self.engine._year_only("2024-03-15")
+        self.assertEqual(result, 2024)
+
+        # Test invalid date string
+        result = self.engine._year_only("not_a_date")
+        self.assertEqual(result, "not_a_date")
+
+        # Test None handling
+        self.assertIsNone(self.engine._year_only(None))
+
+    def test_month_year(self):
+        test_date = date(2024, 3, 15)
+        result = self.engine._month_year(test_date)
+        self.assertEqual(result, "2024-03")
+
+        test_datetime = datetime(2024, 3, 15, 10, 30)
+        result = self.engine._month_year(test_datetime)
+        self.assertEqual(result, "2024-03")
+
+        # Test string date
+        result = self.engine._month_year("2024-03-15")
+        self.assertEqual(result, "2024-03")
+
+        # Test invalid date string
+        result = self.engine._month_year("not_a_date")
+        self.assertEqual(result, "not_a_date")
+
+        # Test None handling
+        self.assertIsNone(self.engine._month_year(None))
+
+    def test_get_masking_function(self):
+        # Test hash algorithms
+        func = self.engine.get_masking_function("hash")
+        self.assertIsNotNone(func)
+
+        func = self.engine.get_masking_function("sha256")
+        self.assertIsNotNone(func)
+
+        func = self.engine.get_masking_function("md5")
+        self.assertIsNotNone(func)
+
+        # Test with parameters
+        func = self.engine.get_masking_function("partial", "3")
+        result = func("testing")
+        self.assertEqual(result, "tes*ing")
+
+        func = self.engine.get_masking_function("round", "100")
+        result = func(456)
+        self.assertEqual(result, 500)
+
+        # Test fixed value
+        func = self.engine.get_masking_function("fixed", "MASKED")
+        result = func("anything")
+        self.assertEqual(result, "MASKED")
+
+        # Test unknown algorithm
+        with self.assertRaises(ValueError):
+            self.engine.get_masking_function("unknown_algo")
+
+
+class TestCreateMaskingMapper(unittest.TestCase):
+    def test_create_masking_mapper_basic(self):
+        mask_configs = ["email:hash", "phone:partial:3", "ssn:redact"]
+
+        mapper = create_masking_mapper(mask_configs)
+
+        row = {
+            "email": "test@example.com",
+            "phone": "555-123-4567",
+            "ssn": "123-45-6789",
+            "name": "John Doe",
+        }
+
+        result = mapper(row)
+
+        # Email should be hashed
+        self.assertEqual(
+            result["email"],
+            "973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b",
+        )
+
+        # Phone should be partially masked
+        self.assertTrue("*" in result["phone"])
+
+        # SSN should be redacted
+        self.assertEqual(result["ssn"], "REDACTED")
+
+        # Name should be unchanged
+        self.assertEqual(result["name"], "John Doe")
+
+    def test_create_masking_mapper_empty_config(self):
+        mapper = create_masking_mapper([])
+
+        row = {"email": "test@example.com"}
+        result = mapper(row)
+
+        # Should return unchanged
+        self.assertEqual(result, row)
+
+    def test_create_masking_mapper_non_dict_row(self):
+        mask_configs = ["email:hash"]
+        mapper = create_masking_mapper(mask_configs)
+
+        # Non-dict should be returned unchanged
+        result = mapper("not a dict")
+        self.assertEqual(result, "not a dict")
+
+        result = mapper(None)
+        self.assertIsNone(result)
+
+        result = mapper(123)
+        self.assertEqual(result, 123)
+
+    def test_create_masking_mapper_missing_column(self):
+        mask_configs = ["email:hash", "phone:redact"]
+        mapper = create_masking_mapper(mask_configs)
+
+        row = {"name": "John Doe"}  # No email or phone
+        result = mapper(row)
+
+        # Should not add new columns, just return unchanged
+        self.assertEqual(result, {"name": "John Doe"})
+
+    def test_create_masking_mapper_with_numeric_masks(self):
+        mask_configs = ["age:round:10", "salary:range:10000", "score:noise:0.1"]
+
+        # Set seed for reproducible noise test
+        random.seed(42)
+
+        mapper = create_masking_mapper(mask_configs)
+
+        row = {"age": 34, "salary": 45000, "score": 100}
+
+        result = mapper(row)
+
+        self.assertEqual(result["age"], 30)
+        self.assertEqual(result["salary"], "40000-50000")
+        # Score should be within noise range
+        self.assertTrue(90 <= result["score"] <= 110)
+
+    @patch("builtins.print")
+    def test_create_masking_mapper_error_handling(self, mock_print):
+        mask_configs = ["value:round:10"]  # round expects numeric
+        mapper = create_masking_mapper(mask_configs)
+
+        row = {"value": "not_a_number"}
+        result = mapper(row)
+
+        # Should handle error gracefully and return unchanged
+        self.assertEqual(result["value"], "not_a_number")
+
+        # But for valid numeric it should work
+        row2 = {"value": 123}
+        result2 = mapper(row2)
+        self.assertEqual(result2["value"], 120)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ingestr/src/mongodb/helpers.py
+++ b/ingestr/src/mongodb/helpers.py
@@ -520,20 +520,24 @@ class CollectionAggregationLoader(CollectionLoader):
 
         # Add maxTimeMS to prevent hanging
         cursor = self.collection.aggregate(
-            pipeline, 
-            allowDiskUse=True, 
+            pipeline,
+            allowDiskUse=True,
             batchSize=min(self.chunk_size, 101),
-            maxTimeMS=30000  # 30 second timeout
+            maxTimeMS=30000,  # 30 second timeout
         )
-        
+
         docs_buffer = []
         try:
             for doc in cursor:
                 docs_buffer.append(doc)
-                
+
                 if len(docs_buffer) >= self.chunk_size:
                     res = map_nested_in_place(convert_mongo_objs, docs_buffer)
-                    if len(res) > 0 and "_id" in res[0] and isinstance(res[0]["_id"], dict):
+                    if (
+                        len(res) > 0
+                        and "_id" in res[0]
+                        and isinstance(res[0]["_id"], dict)
+                    ):
                         yield dlt.mark.with_hints(
                             res,
                             dlt.mark.make_hints(columns={"_id": {"data_type": "json"}}),
@@ -541,7 +545,7 @@ class CollectionAggregationLoader(CollectionLoader):
                     else:
                         yield res
                     docs_buffer = []
-            
+
             # Yield any remaining documents
             if docs_buffer:
                 res = map_nested_in_place(convert_mongo_objs, docs_buffer)

--- a/ingestr/src/revenuecat/__init__.py
+++ b/ingestr/src/revenuecat/__init__.py
@@ -8,10 +8,9 @@ from .helpers import (
     _make_request,
     _paginate,
     convert_timestamps_to_iso,
-    process_customer_with_nested_resources_async,
     create_project_resource,
+    process_customer_with_nested_resources_async,
 )
-
 
 
 @dlt.source(name="revenuecat", max_table_nesting=0)
@@ -90,13 +89,14 @@ def revenuecat_source(
     # Create project-dependent resources dynamically
     project_resources = []
     resource_names = ["products", "entitlements", "offerings"]
-    
+
     for resource_name in resource_names:
+
         @dlt.resource(name=resource_name, primary_key="id", write_disposition="merge")
         def create_resource(resource_name=resource_name) -> Iterator[Dict[str, Any]]:
             """Get list of project resource."""
             yield from create_project_resource(resource_name, api_key, project_id)
-        
+
         # Set the function name for better identification
         create_resource.__name__ = resource_name
         project_resources.append(create_resource)

--- a/ingestr/src/revenuecat/helpers.py
+++ b/ingestr/src/revenuecat/helpers.py
@@ -270,22 +270,22 @@ def create_project_resource(
 ) -> Iterator[Dict[str, Any]]:
     """
     Helper function to create DLT resources for project-dependent endpoints.
-    
+
     Args:
         resource_name: Name of the resource (e.g., 'products', 'entitlements', 'offerings')
         api_key: RevenueCat API key
         project_id: RevenueCat project ID
         timestamp_fields: List of timestamp fields to convert to ISO format
-    
+
     Returns:
         Iterator of resource data
     """
     if project_id is None:
         raise ValueError(f"project_id is required for {resource_name} resource")
-    
+
     endpoint = f"/projects/{project_id}/{resource_name}"
     default_timestamp_fields = timestamp_fields or ["created_at", "updated_at"]
-    
+
     for item in _paginate(api_key, endpoint):
         item = convert_timestamps_to_iso(item, default_timestamp_fields)
         yield item

--- a/ingestr/src/revenuecat/helpers_test.py
+++ b/ingestr/src/revenuecat/helpers_test.py
@@ -5,8 +5,6 @@ Unit tests for RevenueCat helper functions.
 import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
-
 from .helpers import (
     _make_request,
     _make_request_async,


### PR DESCRIPTION
This PR:
- Adds --mask CLI parameter to apply data masking during ingestion
- Implements 20+ masking algorithms (hash, redact, tokenize, format-preserving, etc.)
- Supports column-specific masking with syntax: --mask "column:algorithm[:param]"

```bash
python -m ingestr.main ingest \
  --source-uri postgresql://localhost/db \
  --source-table users \
  --dest-uri duckdb:///output.db \
  --dest-table masked_users \
  --mask "email:hash" \
  --mask "phone:partial:3" \
  --mask "ssn:redact" \
  --mask "salary:round:1000"
```

<img width="1042" height="394" alt="image" src="https://github.com/user-attachments/assets/90bc83c2-3023-41e7-a0b3-aefe35b9c22e" />
