### PR TITLE
ci: release: build image in parallel with tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
+          # The following strips the 'sha256:' prefix from the digest using bash parameter expansion.
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
     
       - name: Upload digest


### PR DESCRIPTION
This change adds parallelisation for both multiplatform docker builds _and_ tests.

This speeds up the release pipeline by -10 mins. There's scope for more optimisation (particularly with `linux/arm` images). But those will come in a separate PR.

Reference:
- https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners