### PR TITLE
ci: release: use arm runner for building docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
   docker-build:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
arm emulation of amd64 is much more optimised than amd64 emulation of arm architecture.

This change slows down amd64 builds by 20% but speeds up arm build by a whooping 12x

At that rate, the bottle necks become our tests, not the builds.