### PR TITLE
Skip slow tests for documentation changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.filter.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs-only:
+              - '!**'
+              - '**/*.md'
+              - 'docs/**'
+
   tests:
+    needs: check-changes
+    if: needs.check-changes.outputs.docs-only != 'true'
     strategy:
       matrix:
         # I tried running stuff on macOS but it was too slow and unreliable.


### PR DESCRIPTION
Skip CI tests for documentation-only changes to improve pipeline efficiency.

---
[Slack Thread](https://bruintalk.slack.com/archives/D092PT1JU8H/p1759846879850799?thread_ts=1759846879.850799&cid=D092PT1JU8H)

<a href="https://cursor.com/background-agent?bcId=bc-15d48ea6-0e0c-4851-8e1e-dd09b8b0c1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15d48ea6-0e0c-4851-8e1e-dd09b8b0c1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

