### PR TITLE
fix: use cursor pagination for ad account users and add end_value fal…

### DIFF
--- a/ingestr/src/linkedin_ads/__init__.py
+++ b/ingestr/src/linkedin_ads/__init__.py
@@ -187,7 +187,9 @@ def linked_in_ads_source(
         ),
     ) -> Iterable[TDataItem]:
         fromDate = submittedAt.start_value
-        toDate = submittedAt.end_value if submittedAt.end_value else pendulum.now(tz="UTC")
+        toDate = (
+            submittedAt.end_value if submittedAt.end_value else pendulum.now(tz="UTC")
+        )
 
         for ad_account in ad_accounts:
             account_id = ad_account["id"]


### PR DESCRIPTION
- Switch to fetch_cursor_pagination for adAccountUsers endpoint
- Default submittedAt.end_value to current UTC time when not provided