### PR TITLE
deps: update to confluent-kafka 2.14.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 asana==3.2.3
-confluent-kafka==2.8.0
+confluent-kafka==2.14.0
 couchbase==4.3.6
 databricks-sql-connector==4.0.5
 databricks-sqlalchemy==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ clickhouse-driver==0.2.9
     #   clickhouse-sqlalchemy
 clickhouse-sqlalchemy==0.2.7
     # via -r requirements.in
-confluent-kafka==2.8.0
+confluent-kafka==2.14.0
     # via -r requirements.in
 couchbase==4.3.6
     # via -r requirements.in

--- a/requirements_arm64.txt
+++ b/requirements_arm64.txt
@@ -77,7 +77,7 @@ clickhouse-driver==0.2.9
     #   clickhouse-sqlalchemy
 clickhouse-sqlalchemy==0.2.7
     # via -r requirements.in
-confluent-kafka==2.8.0
+confluent-kafka==2.14.0
     # via -r requirements.in
 couchbase==4.3.6
     # via -r requirements.in


### PR DESCRIPTION
## Problem
An old version of `confluent-kafka` blocks fluent wheel-based installation on Python 3.14 (without needing a compiler toolchain and development headers from `librdkafka-dev`).

## Details
```python
      fatal error: librdkafka/rdkafka.h: No such file or directory
         23 | #include <librdkafka/rdkafka.h>
            |          ^~~~~~~~~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
```

## References
- https://github.com/crate/cratedb-toolkit/pull/592 ([CI failure](https://github.com/crate/cratedb-toolkit/actions/runs/21887476226/job/63185701971#step:6:381))


/cc @turtleDev, @iremcaginyurtturk