### PR TITLE
deps: update to pyodbc 5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ oracle = [
     "oracledb>=2.0.0",
 ]
 odbc = [
-    "pyodbc==5.1.0",
+    "pyodbc==5.3.0",
 ]
 ibm-db = [
     "ibm-db==3.2.6",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest==8.3.3
 ruff==0.11.4
 hatchling==1.27.0
 build==1.2.1
-pyodbc==5.2.0
+pyodbc==5.3.0
 twine==6.0.1
 testcontainers[postgres,mysql]==4.8.2
 pytest-xdist[psutil]==3.6.1


### PR DESCRIPTION
## Problem
An old version of `pyodbc` blocks fluent wheel-based installation on Python 3.13 (without needing a compiler toolchain).

## Details
```python
#37 16.97   × Failed to build `pyodbc==5.1.0`
#37 16.97   ├─▶ The build backend returned an error
#37 16.97   ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
```

## References
- https://github.com/crate/cratedb-toolkit/pull/620 ([CI failure](https://github.com/crate/cratedb-toolkit/actions/runs/21888270520/job/63188289018?pr=620#step:7:1794))
