### PR TITLE
Attio source partitioning

### DIFF
--- a/ingestr/src/attio/__init__.py
+++ b/ingestr/src/attio/__init__.py
@@ -16,9 +16,6 @@ def attio_source(
     @dlt.resource(
         name="objects",
         write_disposition="replace",
-        columns={
-            "created_at": {"data_type": "timestamp", "partition": True},
-        },
     )
     # https://docs.attio.com/rest-api/endpoint-reference/objects/list-objects - does not support pagination
     def fetch_objects() -> Iterator[dict]:
@@ -32,9 +29,6 @@ def attio_source(
     @dlt.resource(
         name="records",
         write_disposition="replace",
-        columns={
-            "created_at": {"data_type": "timestamp", "partition": True},
-        },
     )
     def fetch_records() -> Iterator[dict]:
         if len(params) != 1:
@@ -50,9 +44,6 @@ def attio_source(
     @dlt.resource(
         name="lists",
         write_disposition="replace",
-        columns={
-            "created_at": {"data_type": "timestamp", "partition": True},
-        },
     )
     def fetch_lists() -> Iterator[dict]:
         path = "lists"
@@ -62,9 +53,6 @@ def attio_source(
     @dlt.resource(
         name="list_entries",
         write_disposition="replace",
-        columns={
-            "created_at": {"data_type": "timestamp", "partition": True},
-        },
     )
     def fetch_list_entries() -> Iterator[dict]:
         if len(params) != 1:
@@ -78,9 +66,6 @@ def attio_source(
     @dlt.resource(
         name="all_list_entries",
         write_disposition="replace",
-        columns={
-            "created_at": {"data_type": "timestamp", "partition": True},
-        },
     )
     def fetch_all_list_entries() -> Iterator[dict]:
         if len(params) != 1:


### PR DESCRIPTION
Remove partitioning from the Attio source to prevent write multiplication and BigQuery quota issues.

Attio does not support incremental loading, and the existing partitioning caused each full table refresh to write to multiple partitions based on historical data, leading to BigQuery's "Number of partition modifications to a column partitioned table" quota limit.

---
[Slack Thread](https://bruintalk.slack.com/archives/C07SBCEK5NK/p1772005919012599?thread_ts=1772005919.012599&cid=C07SBCEK5NK)

<p><a href="https://cursor.com/agents/bc-c00e3e70-0e23-574b-ab4b-12d3c54f172e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c00e3e70-0e23-574b-ab4b-12d3c54f172e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

