### PR TITLE
fix: set MongoDB max_table_nesting to 0

### DIFF
--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -562,7 +562,7 @@ class MongoDbSource:
                 incremental=incremental,
                 custom_query=query,
             )
-            table_instance.max_table_nesting = 1
+            table_instance.max_table_nesting = 0
             return table_instance
         else:
             # Default behavior for simple collection names
@@ -586,7 +586,7 @@ class MongoDbSource:
                 parallel=False,
                 incremental=incremental,
             )
-            table_instance.max_table_nesting = 1
+            table_instance.max_table_nesting = 0
 
             return table_instance
 


### PR DESCRIPTION
Sets `max_table_nesting` to `0` for MongoDB sources in both the custom query and default collection code paths. Previously this was set to `1`, which could result in unwanted nested table expansion.