### PR TITLE
feat: extend LinkedIn Ads with demographic pivots, audiences, and insight tags

### DIFF
--- a/docs/supported-sources/linkedin_ads.md
+++ b/docs/supported-sources/linkedin_ads.md
@@ -62,6 +62,9 @@ LinkedIn Ads source allows ingesting the following sources into separate tables:
 | [conversions](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversion-tracking?view=li-lms-2024-11&tabs=http) | id | – | replace | Retrieves conversion rules for each ad account. |
 | [lead_forms](https://learn.microsoft.com/en-us/linkedin/marketing/lead-sync/leadsync?view=li-lms-2025-11&viewFallbackFrom=li-lms-2024-06&tabs=http#lead-forms-1) | id | – | replace | Retrieves lead generation forms for each ad account. |
 | [lead_form_responses](https://learn.microsoft.com/en-us/linkedin/marketing/lead-sync/leadsync?view=li-lms-2025-11&viewFallbackFrom=li-lms-2024-06&tabs=http#get-lead-form-responses) | id | date (interval)| merge | Retrieves lead form responses for each ad account. |
+| dmp_segments | id | – | replace | Retrieves matched/retargeting audience segments (sizes, match rates, rules) for each ad account. |
+| insight_tags | id | – | replace | Retrieves Insight Tag configuration and installation status for each ad account. |
+| insight_tag_domains | id | – | replace | Retrieves domains associated with Insight Tags for each ad account. |
 | [custom](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2024-11&tabs=http#analytics-finder) | [dimension, date] or [dimension, start_date, end_date] | date (daily) or start_date (monthly) | merge | Custom reports allow you to retrieve data based on specific dimensions and metrics. |
 
 Use these as `--source-table` parameter in the `ingestr ingest` command.
@@ -99,7 +102,9 @@ custom:<dimensions>:<metrics>
 ```
 
 **Parameters:**
-- `dimensions`(required): A comma-separated list of dimensions is required. It must include at least one of the following: `campaign`, `account`, or `creative`, along with one time-based dimension, either `date` or `month`.
+- `dimensions`(required): A comma-separated list of dimensions is required. It must include at least one entity dimension and one time-based dimension (`date` or `month`).
+  - Entity dimensions: `campaign`, `account`, `creative`
+  - Demographic dimensions: `member_job_title`, `member_seniority`, `member_industry`, `member_company_size`, `member_company`
   - `date`: group the data in your report by day
   - `month`: group the data in your report by month
 - `metrics`(required): A comma-separated list of [metrics](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2024-11&tabs=http#metrics-available) to retrieve.
@@ -146,6 +151,19 @@ ingestr ingest \
 The applied parameters for the report are:
 - dimensions: `account`, `month`
 - metrics: `totalEngagements`, `impressions`
+
+### Demographic Reports
+
+You can use demographic dimensions to audit targeting quality. For example, to retrieve impressions and clicks broken down by job title:
+```sh
+ingestr ingest \
+    --source-uri "linkedinads://?access_token=token_123&account_ids=id_123,id_456" \
+    --source-table 'custom:member_job_title,date:impressions,clicks' \
+    --dest-uri 'duckdb:///linkedin.duckdb' \
+    --dest-table 'dest.job_title_report'
+```
+
+Available demographic dimensions: `member_job_title`, `member_seniority`, `member_industry`, `member_company_size`, `member_company`.
 
 This command will retrieve data and save it to the destination table in the DuckDB database.
 

--- a/docs/supported-sources/linkedin_ads.md
+++ b/docs/supported-sources/linkedin_ads.md
@@ -64,7 +64,7 @@ LinkedIn Ads source allows ingesting the following sources into separate tables:
 | [lead_form_responses](https://learn.microsoft.com/en-us/linkedin/marketing/lead-sync/leadsync?view=li-lms-2025-11&viewFallbackFrom=li-lms-2024-06&tabs=http#get-lead-form-responses) | id | date (interval)| merge | Retrieves lead form responses for each ad account. |
 | dmp_segments | id | – | replace | Retrieves matched/retargeting audience segments (sizes, match rates, rules) for each ad account. |
 | insight_tags | id | – | replace | Retrieves Insight Tag configuration and installation status for each ad account. |
-| insight_tag_domains | id | – | replace | Retrieves domains associated with Insight Tags for each ad account. |
+| insight_tag_domains | domainName, account_id | – | replace | Retrieves domains associated with Insight Tags for each ad account. |
 | [custom](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2024-11&tabs=http#analytics-finder) | [dimension, date] or [dimension, start_date, end_date] | date (daily) or start_date (monthly) | merge | Custom reports allow you to retrieve data based on specific dimensions and metrics. |
 
 Use these as `--source-table` parameter in the `ingestr ingest` command.

--- a/ingestr/src/linkedin_ads/__init__.py
+++ b/ingestr/src/linkedin_ads/__init__.py
@@ -203,6 +203,54 @@ def linked_in_ads_source(
 
                 yield page
 
+    @dlt.transformer(
+        write_disposition="replace",
+        primary_key="id",
+        data_from=ad_accounts,
+    )
+    def dmp_segments(ad_accounts) -> Iterable[TDataItem]:
+        for ad_account in ad_accounts:
+            account_id = ad_account["id"]
+            encoded_id = quote(f"urn:li:sponsoredAccount:{account_id}")
+            url = f"https://api.linkedin.com/rest/dmpSegments?q=account&account={encoded_id}"
+            for page in linkedin_api.fetch_cursor_pagination(url):
+                for item in page:
+                    item["account_id"] = account_id
+
+                yield page
+
+    @dlt.transformer(
+        write_disposition="replace",
+        primary_key="id",
+        data_from=ad_accounts,
+    )
+    def insight_tags(ad_accounts) -> Iterable[TDataItem]:
+        for ad_account in ad_accounts:
+            account_id = ad_account["id"]
+            encoded_id = quote(f"urn:li:sponsoredAccount:{account_id}")
+            url = f"https://api.linkedin.com/rest/insightTags?q=account&account={encoded_id}"
+            for page in linkedin_api.fetch_cursor_pagination(url):
+                for item in page:
+                    item["account_id"] = account_id
+
+                yield page
+
+    @dlt.transformer(
+        write_disposition="replace",
+        primary_key="id",
+        data_from=ad_accounts,
+    )
+    def insight_tag_domains(ad_accounts) -> Iterable[TDataItem]:
+        for ad_account in ad_accounts:
+            account_id = ad_account["id"]
+            encoded_id = quote(f"urn:li:sponsoredAccount:{account_id}")
+            url = f"https://api.linkedin.com/rest/insightTagDomains?q=account&account={encoded_id}"
+            for page in linkedin_api.fetch_cursor_pagination(url):
+                for item in page:
+                    item["account_id"] = account_id
+
+                yield page
+
     return [
         ad_accounts,
         ad_account_users,
@@ -212,4 +260,7 @@ def linked_in_ads_source(
         conversions,
         lead_forms,
         lead_form_responses,
+        dmp_segments,
+        insight_tags,
+        insight_tag_domains,
     ]

--- a/ingestr/src/linkedin_ads/__init__.py
+++ b/ingestr/src/linkedin_ads/__init__.py
@@ -237,7 +237,7 @@ def linked_in_ads_source(
 
     @dlt.transformer(
         write_disposition="replace",
-        primary_key="id",
+        primary_key=["domainName", "account_id"],
         data_from=ad_accounts,
     )
     def insight_tag_domains(ad_accounts) -> Iterable[TDataItem]:

--- a/ingestr/src/linkedin_ads/dimension_time_enum.py
+++ b/ingestr/src/linkedin_ads/dimension_time_enum.py
@@ -5,6 +5,11 @@ class Dimension(Enum):
     campaign = "campaign"
     creative = "creative"
     account = "account"
+    member_job_title = "member_job_title"
+    member_seniority = "member_seniority"
+    member_industry = "member_industry"
+    member_company_size = "member_company_size"
+    member_company = "member_company"
 
 
 class TimeGranularity(Enum):

--- a/ingestr/src/linkedin_ads/helpers.py
+++ b/ingestr/src/linkedin_ads/helpers.py
@@ -89,7 +89,17 @@ def construct_url(
         [quote(f"urn:li:sponsoredAccount:{account_id}") for account_id in account_ids]
     )
     encoded_accounts = f"List({accounts})"
-    dimension_str = dimension.value.upper()
+    DIMENSION_PIVOT_MAP = {
+        "campaign": "CAMPAIGN",
+        "creative": "CREATIVE",
+        "account": "ACCOUNT",
+        "member_job_title": "MEMBER_JOB_TITLE",
+        "member_seniority": "MEMBER_SENIORITY",
+        "member_industry": "MEMBER_INDUSTRY",
+        "member_company_size": "MEMBER_COMPANY_SIZE",
+        "member_company": "MEMBER_COMPANY",
+    }
+    dimension_str = DIMENSION_PIVOT_MAP[dimension.value]
     time_granularity_str = time_granularity.value
     metrics_str = ",".join([metric for metric in metrics])
 

--- a/ingestr/src/linkedin_ads/helpers.py
+++ b/ingestr/src/linkedin_ads/helpers.py
@@ -75,6 +75,18 @@ def find_intervals(start_date: Date, end_date: Date, time_granularity: TimeGranu
     return intervals
 
 
+DIMENSION_PIVOT_MAP = {
+    "campaign": "CAMPAIGN",
+    "creative": "CREATIVE",
+    "account": "ACCOUNT",
+    "member_job_title": "MEMBER_JOB_TITLE",
+    "member_seniority": "MEMBER_SENIORITY",
+    "member_industry": "MEMBER_INDUSTRY",
+    "member_company_size": "MEMBER_COMPANY_SIZE",
+    "member_company": "MEMBER_COMPANY",
+}
+
+
 def construct_url(
     start: Date,
     end: Date,
@@ -89,16 +101,6 @@ def construct_url(
         [quote(f"urn:li:sponsoredAccount:{account_id}") for account_id in account_ids]
     )
     encoded_accounts = f"List({accounts})"
-    DIMENSION_PIVOT_MAP = {
-        "campaign": "CAMPAIGN",
-        "creative": "CREATIVE",
-        "account": "ACCOUNT",
-        "member_job_title": "MEMBER_JOB_TITLE",
-        "member_seniority": "MEMBER_SENIORITY",
-        "member_industry": "MEMBER_INDUSTRY",
-        "member_company_size": "MEMBER_COMPANY_SIZE",
-        "member_company": "MEMBER_COMPANY",
-    }
     dimension_str = DIMENSION_PIVOT_MAP[dimension.value]
     time_granularity_str = time_granularity.value
     metrics_str = ",".join([metric for metric in metrics])

--- a/ingestr/src/sources.py
+++ b/ingestr/src/sources.py
@@ -2740,13 +2740,22 @@ class LinkedInAdsSource:
 
             dimensions = fields[1].replace(" ", "").split(",")
             dimensions = [item for item in dimensions if item.strip()]
-            if (
-                "campaign" not in dimensions
-                and "creative" not in dimensions
-                and "account" not in dimensions
-            ):
+            valid_entity_dimensions = {
+                "campaign",
+                "creative",
+                "account",
+                "member_job_title",
+                "member_seniority",
+                "member_industry",
+                "member_company_size",
+                "member_company",
+            }
+            if not valid_entity_dimensions.intersection(dimensions):
                 raise ValueError(
-                    "'campaign', 'creative' or 'account' is required to connect to LinkedIn Ads, please provide at least one of these dimensions."
+                    "A valid dimension is required to connect to LinkedIn Ads. "
+                    "Please provide one of: campaign, creative, account, "
+                    "member_job_title, member_seniority, member_industry, "
+                    "member_company_size, member_company."
                 )
             if "date" not in dimensions and "month" not in dimensions:
                 raise ValueError(


### PR DESCRIPTION
## Summary
- Add 5 demographic pivot dimensions (`member_job_title`, `member_seniority`, `member_industry`, `member_company_size`, `member_company`) to custom reports for targeting quality audits
- Add `dmp_segments` table — retrieves matched/retargeting audience segments via `GET /rest/dmpSegments?q=account`
- Add `insight_tags` and `insight_tag_domains` tables — retrieves Insight Tag installation status and associated domains via `GET /rest/insightTags` and `GET /rest/insightTagDomains`

All endpoints verified against the official [LinkedIn Marketing API documentation](https://learn.microsoft.com/en-us/linkedin/marketing/).

### New custom report dimensions
```sh
# Example: impressions by job title
ingestr ingest \
    --source-uri "linkedinads://?access_token=TOKEN&account_ids=ID" \
    --source-table 'custom:member_job_title,date:impressions,clicks' \
    --dest-uri 'duckdb:///linkedin.duckdb' \
    --dest-table 'dest.job_title_report'
```

### New tables
| Table | Endpoint | Details |
|-------|----------|---------|
| `dmp_segments` | `GET /rest/dmpSegments?q=account` | Retargeting audience segments |
| `insight_tags` | `GET /rest/insightTags?q=account` | Insight Tag configuration |
| `insight_tag_domains` | `GET /rest/insightTagDomains?q=account` | Insight Tag domains |

## Test plan
- [ ] Verify demographic custom reports return data: `custom:member_job_title,date:impressions,clicks`
- [ ] Verify `dmp_segments` table ingestion
- [ ] Verify `insight_tags` and `insight_tag_domains` table ingestion
- [ ] Verify existing tables still work (campaigns, creatives, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)