### PR TITLE
docs: add key-pair authentication for Snowflake

### DIFF
--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -19,3 +19,48 @@ URI parameters:
 - `role`: optional, the name of the role to use
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's Snowflake dialect [here](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#connection-parameters).
+
+## Key-Pair Authentication
+
+Snowflake supports key-pair (JWT) authentication as an alternative to password-based authentication. To use it, pass the private key as a URI parameter instead of a password:
+
+```plaintext
+snowflake://user@account/dbname?warehouse=COMPUTE_WH&role=data_scientist&private_key=<url-encoded-pem-key>
+```
+
+You can URL-encode the private key inline or read it from a file:
+
+```bash
+ingestr ingest \
+  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$(python3 -c "import urllib.parse; print(urllib.parse.quote(open('path/to/private_key.pem').read().strip()))")" \
+  --source-table="schema.table_name" \
+  --dest-uri="duckdb:///path/to/output.duckdb" \
+  --dest-table="main.table_name"
+```
+
+### Setting up key-pair authentication
+
+#### Step 1: Generate a key pair
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+#### Step 2: Assign the public key to your Snowflake user
+
+Log into Snowflake and run:
+
+```sql
+ALTER USER your_username SET RSA_PUBLIC_KEY='<contents of rsa_key.pub without header/footer>';
+```
+
+#### Step 3: Use the private key in the URI
+
+Pass the private key file via the `private_key` query parameter as shown above.
+
+If your private key is encrypted with a passphrase, add the `private_key_passphrase` parameter:
+
+```plaintext
+snowflake://user@account/dbname?private_key=<key>&private_key_passphrase=<passphrase>
+```

--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -28,39 +28,6 @@ Snowflake supports key-pair (JWT) authentication as an alternative to password-b
 snowflake://user@account/dbname?warehouse=COMPUTE_WH&role=data_scientist&private_key=<private-key>
 ```
 
-The private key can be provided in several formats:
-
-### Option 1: URL-encoded PEM file
-
-Read the PEM file and URL-encode it:
-
-```bash
-ingestr ingest \
-  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$(python3 -c "import urllib.parse; print(urllib.parse.quote(open('path/to/private_key.pem').read().strip()))")" \
-  --source-table="schema.table_name" \
-  --dest-uri="duckdb:///path/to/output.duckdb" \
-  --dest-table="main.table_name"
-```
-
-### Option 2: Base64-encoded DER
-
-Convert the PEM key to base64 DER (a single line with no headers), which avoids URL-encoding issues:
-
-```bash
-# Convert PEM to base64 DER
-KEY=$(openssl pkey -in private_key.pem -outform DER | base64 | tr -d '\n')
-
-ingestr ingest \
-  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$KEY" \
-  --source-table="schema.table_name" \
-  --dest-uri="duckdb:///path/to/output.duckdb" \
-  --dest-table="main.table_name"
-```
-
-### Option 3: Raw PEM content
-
-The raw PEM content (including `-----BEGIN PRIVATE KEY-----` headers) can be passed directly, but it must be URL-encoded due to newlines and special characters in the PEM format. See Option 1 for how to do this.
-
 If your private key is encrypted with a passphrase, add the `private_key_passphrase` parameter:
 
 ```plaintext
@@ -71,19 +38,52 @@ snowflake://user@account/dbname?private_key=<key>&private_key_passphrase=<passph
 
 #### Step 1: Generate a key pair
 
+Open your terminal and run the following command to create a key pair. If you're using a mac, OpenSSL should be installed by default, so no additional setup is required. For Linux or Windows, you may need to [install OpenSSL first](https://docs.openssl.org/3.4/man7/ossl-guide-introduction/).
+
 ```bash
 openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
 openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
 ```
 
-#### Step 2: Assign the public key to your Snowflake user
+#### Step 2: Set public key for Snowflake user
 
-Log into Snowflake and run:
+Log into Snowflake as an admin, create a new worksheet and run the following command (don't forget the single quotes around the key):
 
 ```sql
-ALTER USER your_username SET RSA_PUBLIC_KEY='<contents of rsa_key.pub without header/footer>';
+ALTER USER your_snowflake_username
+SET RSA_PUBLIC_KEY='your_public_key_here';
 ```
 
-#### Step 3: Use the private key in the URI
+#### Step 3: Verify
 
-Pass the private key via the `private_key` query parameter using any of the options above.
+```sql
+DESC USER your_snowflake_username;
+```
+
+This will show a column named `RSA_PUBLIC_KEY`. You should see your actual key there.
+
+#### Step 4: Use the private key in the URI
+
+URL-encode the PEM file and pass it as the `private_key` parameter:
+
+```bash
+ingestr ingest \
+  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$(python3 -c "import urllib.parse; print(urllib.parse.quote(open('rsa_key.p8').read().strip()))")" \
+  --source-table="schema.table_name" \
+  --dest-uri="duckdb:///path/to/output.duckdb" \
+  --dest-table="main.table_name"
+```
+
+Alternatively, you can convert the key to base64 DER format (a single line with no headers) to avoid URL-encoding:
+
+```bash
+KEY=$(openssl pkey -in rsa_key.p8 -outform DER | base64 | tr -d '\n')
+
+ingestr ingest \
+  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$KEY" \
+  --source-table="schema.table_name" \
+  --dest-uri="duckdb:///path/to/output.duckdb" \
+  --dest-table="main.table_name"
+```
+
+For more details on how to set up key-based authentication, see [this guide](https://select.dev/docs/snowflake-developer-guide/snowflake-key-pair).

--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -64,23 +64,15 @@ This will show a column named `RSA_PUBLIC_KEY`. You should see your actual key t
 
 #### Step 4: Use the private key in the URI
 
-URL-encode the PEM file and pass it as the `private_key` parameter:
+Convert the key to base64 DER format and pass it as the `private_key` parameter:
 
 ```bash
+# Convert PEM to base64 DER (single line, no headers)
+openssl pkey -in rsa_key.p8 -outform DER | base64
+
+# Use the output as the private_key parameter
 ingestr ingest \
-  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$(python3 -c "import urllib.parse; print(urllib.parse.quote(open('rsa_key.p8').read().strip()))")" \
-  --source-table="schema.table_name" \
-  --dest-uri="duckdb:///path/to/output.duckdb" \
-  --dest-table="main.table_name"
-```
-
-Alternatively, you can convert the key to base64 DER format (a single line with no headers) to avoid URL-encoding:
-
-```bash
-KEY=$(openssl pkey -in rsa_key.p8 -outform DER | base64 | tr -d '\n')
-
-ingestr ingest \
-  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$KEY" \
+  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=<base64-der-key>" \
   --source-table="schema.table_name" \
   --dest-uri="duckdb:///path/to/output.duckdb" \
   --dest-table="main.table_name"

--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -22,13 +22,17 @@ The same URI structure can be used both for sources and destinations. You can re
 
 ## Key-Pair Authentication
 
-Snowflake supports key-pair (JWT) authentication as an alternative to password-based authentication. To use it, pass the private key as a URI parameter instead of a password:
+Snowflake supports key-pair (JWT) authentication as an alternative to password-based authentication. To use it, pass the private key via the `private_key` query parameter instead of a password:
 
 ```plaintext
-snowflake://user@account/dbname?warehouse=COMPUTE_WH&role=data_scientist&private_key=<url-encoded-pem-key>
+snowflake://user@account/dbname?warehouse=COMPUTE_WH&role=data_scientist&private_key=<private-key>
 ```
 
-You can URL-encode the private key inline or read it from a file:
+The private key can be provided in several formats:
+
+### Option 1: URL-encoded PEM file
+
+Read the PEM file and URL-encode it:
 
 ```bash
 ingestr ingest \
@@ -36,6 +40,31 @@ ingestr ingest \
   --source-table="schema.table_name" \
   --dest-uri="duckdb:///path/to/output.duckdb" \
   --dest-table="main.table_name"
+```
+
+### Option 2: Base64-encoded DER
+
+Convert the PEM key to base64 DER (a single line with no headers), which avoids URL-encoding issues:
+
+```bash
+# Convert PEM to base64 DER
+KEY=$(openssl pkey -in private_key.pem -outform DER | base64 | tr -d '\n')
+
+ingestr ingest \
+  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$KEY" \
+  --source-table="schema.table_name" \
+  --dest-uri="duckdb:///path/to/output.duckdb" \
+  --dest-table="main.table_name"
+```
+
+### Option 3: Raw PEM content
+
+The raw PEM content (including `-----BEGIN PRIVATE KEY-----` headers) can be passed directly, but it must be URL-encoded due to newlines and special characters in the PEM format. See Option 1 for how to do this.
+
+If your private key is encrypted with a passphrase, add the `private_key_passphrase` parameter:
+
+```plaintext
+snowflake://user@account/dbname?private_key=<key>&private_key_passphrase=<passphrase>
 ```
 
 ### Setting up key-pair authentication
@@ -57,10 +86,4 @@ ALTER USER your_username SET RSA_PUBLIC_KEY='<contents of rsa_key.pub without he
 
 #### Step 3: Use the private key in the URI
 
-Pass the private key file via the `private_key` query parameter as shown above.
-
-If your private key is encrypted with a passphrase, add the `private_key_passphrase` parameter:
-
-```plaintext
-snowflake://user@account/dbname?private_key=<key>&private_key_passphrase=<passphrase>
-```
+Pass the private key via the `private_key` query parameter using any of the options above.

--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -42,7 +42,7 @@ Open your terminal and run the following command to create a key pair. If you're
 
 ```bash
 openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
-openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+openssl pkey -in rsa_key.p8 -pubout -out rsa_key.pub
 ```
 
 #### Step 2: Set public key for Snowflake user

--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -64,15 +64,13 @@ This will show a column named `RSA_PUBLIC_KEY`. You should see your actual key t
 
 #### Step 4: Use the private key in the URI
 
-Convert the key to base64 DER format and pass it as the `private_key` parameter:
+The private key must be URL-encoded when passed as a URI parameter. You can do this directly from the PEM file:
 
 ```bash
-# Convert PEM to base64 DER (single line, no headers)
-openssl pkey -in rsa_key.p8 -outform DER | base64
+KEY=$(python3 -c "import urllib.parse; print(urllib.parse.quote(open('rsa_key.p8').read().strip()))")
 
-# Use the output as the private_key parameter
 ingestr ingest \
-  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=<base64-der-key>" \
+  --source-uri="snowflake://USER@account/dbname?warehouse=WH&role=ROLE&private_key=$KEY" \
   --source-table="schema.table_name" \
   --dest-uri="duckdb:///path/to/output.duckdb" \
   --dest-table="main.table_name"


### PR DESCRIPTION
## Summary
- Add key-pair (JWT) authentication documentation for Snowflake source/destination
- Include step-by-step setup guide (key generation, public key assignment, URI usage)
- Document `private_key` and `private_key_passphrase` URI parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)