### PR TITLE
docs: add Allium and Intercom to sidebar

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -138,6 +138,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             items: [
               { text: "Adjust", link: "/supported-sources/adjust.md" },
               { text: "Airtable", link: "/supported-sources/airtable.md" },
+              { text: "Allium", link: "/supported-sources/allium.md" },
               { text: "Amazon Kinesis", link: "/supported-sources/kinesis.md" },
               { text: "Anthropic", link: "/supported-sources/anthropic.md" },
               { text: "AppsFlyer", link: "/supported-sources/appsflyer.md" },
@@ -173,6 +174,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Indeed", link: "/supported-sources/indeed.md" },
               { text: "Gorgias", link: "/supported-sources/gorgias.md" },
               { text: "HubSpot", link: "/supported-sources/hubspot.md" },
+              { text: "Intercom", link: "/supported-sources/intercom.md" },
               { text: "Internet Society Pulse", link: "/supported-sources/isoc-pulse.md" },
               { text: "Jira", link: "/supported-sources/jira.md" },
               { text: "JobTread", link: "/supported-sources/jobtread.md" },


### PR DESCRIPTION
## Summary
- Add Allium to the Platforms sidebar (between Airtable and Amazon Kinesis)
- Add Intercom to the Platforms sidebar (between HubSpot and Internet Society Pulse)

Both `allium.md` and `intercom.md` already exist under `docs/supported-sources/` but were not linked from the sidebar, so the pages weren't discoverable through navigation.

## Test plan
- [ ] Run the docs build locally and confirm both entries appear in the Platforms section of the sidebar
- [ ] Click each new entry and verify it navigates to the corresponding page

🤖 Generated with [Claude Code](https://claude.com/claude-code)