### PR TITLE
Update CrateDB source docs to use PostgreSQL wire protocol

### DIFF
--- a/docs/supported-sources/cratedb.md
+++ b/docs/supported-sources/cratedb.md
@@ -4,41 +4,37 @@
 massive amounts of data in near real-time, even with complex queries. It is
 PostgreSQL-compatible, and based on Lucene.
 
-ingestr supports CrateDB as a source and destination database, using different
-adapters and protocols (HTTP vs. PostgreSQL, see below).
+ingestr supports CrateDB as both a source and destination database.
 
 ## Source
 
-For connecting to CrateDB as a database source, ingestr uses its SQLAlchemy
-dialect package [sqlalchemy-cratedb], effectively talking HTTP to port 4200
-by default.
+For connecting to CrateDB as a database source, ingestr uses the PostgreSQL
+wire protocol on port 5432 by default.
 
 ### URI format
 
 The URI format for CrateDB as a source is as follows:
 ```plaintext
-crate://<username>:<password>@<host>:<port>?ssl=<ssl>
+cratedb://<username>:<password>@<host>:<port>?sslmode=<sslmode>
 ```
 > [!INFO]
-> The driver does not require any option, and will default to
-> `crate://crate@localhost:4200?ssl=false` when just using `crate://`.
->
 > When connecting to CrateDB on localhost, use:
 > ```plaintext
-> crate://crate@localhost:4200?ssl=false
+> cratedb://crate:@localhost:5432?sslmode=disable
 > ```
 >
 > When connecting to [CrateDB Cloud], the URI looks like this:
 > ```plaintext
-> crate://admin:<PASSWORD>@<CLUSTERNAME>.eks1.eu-west-1.aws.cratedb.net:4200?ssl=true
+> cratedb://admin:<PASSWORD>@<CLUSTERNAME>.eks1.eu-west-1.aws.cratedb.net:5432?sslmode=require
 > ```
 
 ### URI parameters
 - `username` (required): The username is required to authenticate with the CrateDB server.
 - `password` (required): The password is required to authenticate the provided username.
 - `host` (required): The hostname or IP address of the CrateDB server where the database is hosted.
-- `port` (required): The TCP port number used by the CrateDB server. Mostly `4200`.
-- `ssl` (optional): Set to `true` for a secure HTTPS connection. By default, SSL is disabled (`false`).
+- `port` (required): The TCP port number used by the CrateDB server. Mostly `5432`.
+- `sslmode` (optional): Set to one of `disable`, `allow`, `prefer`, `require`, `verify-ca`,
+  or `verify-full`, see [PostgreSQL SSL Mode Descriptions].
 
 ### Example
 
@@ -47,7 +43,7 @@ to DuckDB, then display the content from DuckDB.
 
 ```shell
 ingestr ingest \
-    --source-uri 'crate://crate@localhost:4200/' \
+    --source-uri 'cratedb://crate:@localhost:5432/?sslmode=disable' \
     --source-table 'sys.summits' \
     --dest-uri 'duckdb:///cratedb.duckdb' \
     --dest-table 'dest.summits'
@@ -58,17 +54,10 @@ duckdb cratedb.duckdb 'SELECT * FROM dest.summits LIMIT 5'
 
 <img alt="CrateDB_img" src="../media/cratedb-source.png" />
 
-Note that, as of February 2026, for compatibility and harmonization reasons,
-the CrateDB source adapter can also be addressed using the `cratedb://`-style
-URI format like outlined below. However, please note that both are still
-different adapters using different protocols.
-
 ## Destination
 
 For connecting to CrateDB as a database destination, ingestr uses the
-[dlt cratedb adapter], which is based on the [dlt postgres adapter],
-in turn using the [psycopg2] package, effectively speaking the PostgreSQL
-wire protocol on port 5432 by default.
+PostgreSQL wire protocol on port 5432 by default.
 
 ### URI format
 
@@ -138,10 +127,6 @@ or share relevant issue reports that help us improve interoperability. Thanks!
 
 [CrateDB]: https://github.com/crate/crate
 [CrateDB Cloud]: https://console.cratedb.cloud/
-[dlt cratedb adapter]: https://github.com/dlt-hub/dlt/pull/2733
-[dlt postgres adapter]: https://github.com/dlt-hub/dlt/tree/devel/dlt/destinations/impl/postgres
 [PostgreSQL SSL Mode Descriptions]: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
-[psycopg2]: https://pypi.org/project/psycopg2-binary/
-[sqlalchemy-cratedb]: https://pypi.org/project/sqlalchemy-cratedb/
 [Support for ingestr/CrateDB]: https://github.com/crate/crate-clients-tools/issues/86
 ["tool: dlt/ingestr"]: https://github.com/crate/crate/issues?q=state%3Aopen%20label%3A%22tool%3A%20dlt%2Fingestr%22

--- a/docs/supported-sources/cratedb.md
+++ b/docs/supported-sources/cratedb.md
@@ -105,10 +105,6 @@ uvx crash -c 'SELECT * FROM doc.sample'
 
 <img alt="CrateDB_img" src="../media/cratedb-destination.png" />
 
-> [!WARNING]
-> CrateDB supports the `replace` incremental materialization strategy, but
-> currently does not support the `delete+insert`, `merge`, or `scd2` strategies.
-
 ## Appendix
 
 To start a single-node instance of CrateDB for evaluation purposes,

--- a/docs/supported-sources/cratedb.md
+++ b/docs/supported-sources/cratedb.md
@@ -20,7 +20,7 @@ cratedb://<username>:<password>@<host>:<port>?sslmode=<sslmode>
 > [!INFO]
 > When connecting to CrateDB on localhost, use:
 > ```plaintext
-> cratedb://crate:@localhost:5432?sslmode=disable
+> cratedb://crate@localhost:5432?sslmode=disable
 > ```
 >
 > When connecting to [CrateDB Cloud], the URI looks like this:
@@ -43,7 +43,7 @@ to DuckDB, then display the content from DuckDB.
 
 ```shell
 ingestr ingest \
-    --source-uri 'cratedb://crate:@localhost:5432/?sslmode=disable' \
+    --source-uri 'cratedb://crate@localhost:5432/?sslmode=disable' \
     --source-table 'sys.summits' \
     --dest-uri 'duckdb:///cratedb.duckdb' \
     --dest-table 'dest.summits'
@@ -68,7 +68,7 @@ cratedb://<username>:<password>@<host>:<port>?sslmode=<sslmode>
 > [!INFO]
 > When connecting to CrateDB on localhost, use:
 > ```plaintext
-> cratedb://crate:@localhost:5432?sslmode=disable
+> cratedb://crate@localhost:5432?sslmode=disable
 > ```
 >
 > When connecting to [CrateDB Cloud], the URI looks like this:
@@ -96,7 +96,7 @@ wget -O input.csv https://github.com/bruin-data/ingestr/raw/refs/heads/main/inge
 ingestr ingest \
    --source-uri 'csv://input.csv' \
    --source-table 'sample' \
-   --dest-uri 'cratedb://crate:@localhost:5432/?sslmode=disable' \
+   --dest-uri 'cratedb://crate@localhost:5432/?sslmode=disable' \
    --dest-table 'doc.sample'
 ```
 ```shell


### PR DESCRIPTION
## Summary
- Updated CrateDB source documentation to use PostgreSQL wire protocol (port 5432) instead of HTTP (port 4200)
- Changed source URI scheme from `crate://` to `cratedb://`, aligning source and destination formats
- Simplified destination description by removing references to specific dlt adapters and psycopg2
- Removed unused link references (sqlalchemy-cratedb, dlt cratedb adapter, dlt postgres adapter, psycopg2)

## Test plan
- [ ] Verify documentation renders correctly on the docs site
- [ ] Confirm all link references in the markdown resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)