### PR TITLE
docs(smartsheet): document optional smartsheet_id URI parameter

### DIFF
--- a/docs/supported-sources/smartsheets.md
+++ b/docs/supported-sources/smartsheets.md
@@ -15,9 +15,9 @@ smartsheet://?access_token=<access_token>&smartsheet_id=<sheet_id>
 URI parameters:
 
 - `access_token` (required): Your Smartsheet API access token.
-- `smartsheet_id` (optional): The ID of the sheet to ingest. This is an
-  alternative to passing the sheet ID via `--source-table`. If both are
-  provided, `--source-table` takes priority.
+- `smartsheet_id` (optional): A default sheet ID. It is only used when
+  `--source-table` is set to the literal value `sheet`. A numeric or
+  `sheet:<id>` value passed to `--source-table` always wins.
 
 The URI is used to connect to the Smartsheet API for extracting data. You can generate an access token in Smartsheet by navigating to Account > Personal Settings > API Access.
 
@@ -32,7 +32,17 @@ To set up a Smartsheet integration, you'll need an API Access Token.
 5. Give your token a name and click "OK".
 6. Copy the generated token. This will be your `access_token`.
 
-The sheet to ingest is identified by its `sheet_id`. You can find the `sheet_id` by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there. You can pass it either via `--source-table` or as the `smartsheet_id` URI parameter — at least one must be provided, and `--source-table` wins when both are set.
+The sheet to ingest is identified by its `sheet_id`. You can find the `sheet_id` by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there.
+
+`--source-table` accepts three forms:
+
+| Form | Behaviour |
+| --- | --- |
+| `<sheet_id>` | Use the value as the sheet ID. |
+| `sheet:<sheet_id>` | Strip the `sheet:` prefix and use the rest as the sheet ID. |
+| `sheet` | Use the `smartsheet_id` URI parameter. Errors if it isn't set. |
+
+A literal value (`<sheet_id>` or `sheet:<sheet_id>`) always wins over the URI parameter — the URI's `smartsheet_id` is only consulted when `--source-table` is `sheet`.
 
 Let's say your access token is `YOUR_ACCESS_TOKEN` and the sheet ID is `1234567890123456`. Here's a sample command using `--source-table`:
 
@@ -44,11 +54,12 @@ ingestr ingest \
     --dest-table 'des.my_sheet_data'
 ```
 
-Equivalently, with the sheet ID baked into the URI:
+Equivalently, with the sheet ID baked into the URI and the `sheet` alias used for `--source-table`:
 
 ```sh
 ingestr ingest \
     --source-uri 'smartsheet://?access_token=YOUR_ACCESS_TOKEN&smartsheet_id=1234567890123456' \
+    --source-table 'sheet' \
     --dest-uri 'duckdb:///smartsheet_data.duckdb' \
     --dest-table 'des.my_sheet_data'
 ```

--- a/docs/supported-sources/smartsheets.md
+++ b/docs/supported-sources/smartsheets.md
@@ -9,12 +9,15 @@ ingestr supports Smartsheet as a source.
 The URI format for Smartsheet is as follows:
 
 ```plaintext
-smartsheet://?access_token=<access_token>
+smartsheet://?access_token=<access_token>&smartsheet_id=<sheet_id>
 ```
 
 URI parameters:
 
-- `access_token`: Your Smartsheet API access token.
+- `access_token` (required): Your Smartsheet API access token.
+- `smartsheet_id` (optional): The ID of the sheet to ingest. This is an
+  alternative to passing the sheet ID via `--source-table`. If both are
+  provided, `--source-table` takes priority.
 
 The URI is used to connect to the Smartsheet API for extracting data. You can generate an access token in Smartsheet by navigating to Account > Personal Settings > API Access.
 
@@ -29,14 +32,23 @@ To set up a Smartsheet integration, you'll need an API Access Token.
 5. Give your token a name and click "OK".
 6. Copy the generated token. This will be your `access_token`.
 
-The source table you'll use for ingestr will be the `sheet_id` of the Smartsheet you want to ingest. You can find the `sheet_id` by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there.
+The sheet to ingest is identified by its `sheet_id`. You can find the `sheet_id` by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there. You can pass it either via `--source-table` or as the `smartsheet_id` URI parameter — at least one must be provided, and `--source-table` wins when both are set.
 
-Let's say your access token is `YOUR_ACCESS_TOKEN` and the sheet ID is `1234567890123456`, here's a sample command that will copy the data from Smartsheet into a DuckDB database:
+Let's say your access token is `YOUR_ACCESS_TOKEN` and the sheet ID is `1234567890123456`. Here's a sample command using `--source-table`:
 
 ```sh
 ingestr ingest \
     --source-uri 'smartsheet://?access_token=YOUR_ACCESS_TOKEN' \
     --source-table '1234567890123456' \
+    --dest-uri 'duckdb:///smartsheet_data.duckdb' \
+    --dest-table 'des.my_sheet_data'
+```
+
+Equivalently, with the sheet ID baked into the URI:
+
+```sh
+ingestr ingest \
+    --source-uri 'smartsheet://?access_token=YOUR_ACCESS_TOKEN&smartsheet_id=1234567890123456' \
     --dest-uri 'duckdb:///smartsheet_data.duckdb' \
     --dest-table 'des.my_sheet_data'
 ```

--- a/docs/supported-sources/smartsheets.md
+++ b/docs/supported-sources/smartsheets.md
@@ -31,11 +31,11 @@ To set up a Smartsheet integration, you'll need an API Access Token.
 
 The source table you'll use for ingestr will be the `sheet_id` of the Smartsheet you want to ingest. You can find the `sheet_id` by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there.
 
-Let's say your access token is `llk2k3j4l5k6j7h8g9f0` and the sheet ID is `1234567890123456`, here's a sample command that will copy the data from Smartsheet into a DuckDB database:
+Let's say your access token is `YOUR_ACCESS_TOKEN` and the sheet ID is `1234567890123456`, here's a sample command that will copy the data from Smartsheet into a DuckDB database:
 
 ```sh
 ingestr ingest \
-    --source-uri 'smartsheet://?access_token=llk2k3j4l5k6j7h8g9f0' \
+    --source-uri 'smartsheet://?access_token=YOUR_ACCESS_TOKEN' \
     --source-table '1234567890123456' \
     --dest-uri 'duckdb:///smartsheet_data.duckdb' \
     --dest-table 'des.my_sheet_data'


### PR DESCRIPTION
## Summary
Smartsheet ingestion now runs through gong by default in Bruin, and gong supports passing the sheet ID either via `--source-table` or as the `smartsheet_id` URI parameter (with `--source-table` taking priority). Surface that in the ingestr docs so users know both shapes are valid.

This PR is **docs-only** — no code change. The runtime behaviour lives in:
- gong: bruin-data/gongestr#437
- bruin: bruin-data/bruin#2005

## Changes
- `docs/supported-sources/smartsheets.md`
  - Document `smartsheet_id` as an optional URI parameter alongside `access_token`.
  - Add a second example showing the URI-only form.
  - Replace the high-entropy fake token (`llk2k3j4l5k6j7h8g9f0`) with `YOUR_ACCESS_TOKEN` so gitleaks stops flagging the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)