### PR TITLE
fix(schemaevolution): align staging table with final destination schema

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ type IngestConfig struct {
 	PipelinesDir   string
 	StagingBucket  string
 	StagingDataset string
+	KeepStaging    bool // testing only: skip final DropTable so tests can inspect staging
 
 	CDCResumeLSN  string // For CDC sources: resume from this LSN (auto-detected from destination)
 	CDCSlotSuffix string // For CDC sources: suffix appended to auto-generated slot names (derived from dest URI)

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1246,7 +1246,7 @@ func (d *BigQueryDestination) SCD2Table(ctx context.Context, opts destination.SC
 	}
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditionsBigQuery(nonPKColumns, "t", "s")
 	onConditions := make([]string, len(opts.PrimaryKeys))
 	for i, pk := range opts.PrimaryKeys {
@@ -1305,7 +1305,7 @@ func (d *BigQueryDestination) SCD2Table(ctx context.Context, opts destination.SC
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := make([]string, len(allColumns))
 	for i, col := range allColumns {
 		quotedColumns[i] = fmt.Sprintf("`%s`", col)

--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -340,7 +340,7 @@ func (d *ClickHouseDestination) SCD2Table(ctx context.Context, opts destination.
 	targetDB, targetName := d.parseTableName(opts.TargetTable)
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditionsClickHouse(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 	// Format timestamp as ClickHouse DateTime64 literal
@@ -408,7 +408,7 @@ func (d *ClickHouseDestination) SCD2Table(ctx context.Context, opts destination.
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -345,7 +345,7 @@ func (d *CrateDBDestination) SCD2Table(ctx context.Context, opts destination.SCD
 	// 2. Soft-delete rows missing from staging
 	// 3. Insert only changed + new rows from staging
 
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 
 	// Build change detection: compare non-PK columns between staging and target
 	// We identify PKs where at least one non-PK column differs
@@ -417,9 +417,7 @@ func (d *CrateDBDestination) SCD2Table(ctx context.Context, opts destination.SCD
 	d.refreshTable(ctx, opts.TargetTable)
 
 	// Step 3: Insert rows from staging that don't have a matching current row in target
-	allColumns := make([]string, len(opts.Columns), len(opts.Columns)+3)
-	copy(allColumns, opts.Columns)
-	allColumns = append(allColumns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	// Only insert where no current row exists (changed rows were closed in step 1, new rows never existed)

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -528,7 +528,7 @@ func (d *DuckDBDestination) SCD2Table(ctx context.Context, opts destination.SCD2
 	}()
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditions(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
@@ -580,7 +580,7 @@ func (d *DuckDBDestination) SCD2Table(ctx context.Context, opts destination.SCD2
 	// Insert records that either:
 	// - Don't exist at all (net-new)
 	// - Exist but have changed (new version - the old version was closed in step 1)
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -487,7 +487,7 @@ func (d *MSSQLDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	defer func() { _ = tx.Rollback() }()
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditionsMSSQL(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
@@ -536,7 +536,7 @@ func (d *MSSQLDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -475,7 +475,7 @@ func (d *MySQLDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	defer func() { _ = tx.Rollback() }()
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditionsMySQL(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
@@ -524,7 +524,7 @@ func (d *MySQLDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(
@@ -642,7 +642,7 @@ func (d *MySQLDestination) GetTableSchema(ctx context.Context, table string) (*s
 		if numScale != nil {
 			col.Scale = *numScale
 		}
-		if charMaxLen != nil {
+		if charMaxLen != nil && !isMySQLTextFamily(dataType) {
 			col.MaxLength = *charMaxLen
 		}
 
@@ -662,6 +662,17 @@ func (d *MySQLDestination) GetTableSchema(ctx context.Context, table string) (*s
 		Schema:  d.database,
 		Columns: columns,
 	}, nil
+}
+
+// isMySQLTextFamily reports whether dataType is a TEXT-family column.
+// Their character_maximum_length is the type's intrinsic engine cap, not a
+// user constraint. So must not roundtrip back into CREATE TABLE as VARCHAR(N).
+func isMySQLTextFamily(dataType string) bool {
+	switch strings.ToLower(dataType) {
+	case "text", "tinytext", "mediumtext", "longtext":
+		return true
+	}
+	return false
 }
 
 func mapMySQLTypeToSchema(dataType, columnType string) schema.DataType {

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -608,7 +608,7 @@ func (d *PostgresDestination) SCD2Table(ctx context.Context, opts destination.SC
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditions(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
@@ -659,7 +659,7 @@ func (d *PostgresDestination) SCD2Table(ctx context.Context, opts destination.SC
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/scd2_columns.go
+++ b/pkg/destination/scd2_columns.go
@@ -1,0 +1,39 @@
+package destination
+
+import "slices"
+
+// SCD2 metadata column names. Strategies and destinations must agree on these.
+const (
+	SCD2ValidFromColumn = "_scd_valid_from"
+	SCD2ValidToColumn   = "_scd_valid_to"
+	SCD2IsCurrentColumn = "_scd_is_current"
+)
+
+func SCD2MetadataColumns() []string {
+	return []string{SCD2ValidFromColumn, SCD2ValidToColumn, SCD2IsCurrentColumn}
+}
+
+// SCD2NonDataColumns returns the list of columns to exclude when computing
+// "data columns" for SCD2 change detection (primary keys and SCD metadata
+// columns).
+func SCD2NonDataColumns(primaryKeys []string) []string {
+	scd := SCD2MetadataColumns()
+	out := make([]string, 0, len(primaryKeys)+len(scd))
+	out = append(out, primaryKeys...)
+	out = append(out, scd...)
+	return out
+}
+
+// AppendSCD2Columns appends the SCD2 metadata column names to cols, skipping
+// any that are already present.
+func AppendSCD2Columns(cols []string) []string {
+	scd := SCD2MetadataColumns()
+	out := make([]string, len(cols), len(cols)+len(scd))
+	copy(out, cols)
+	for _, c := range scd {
+		if !slices.Contains(cols, c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/pkg/destination/scd2_columns_test.go
+++ b/pkg/destination/scd2_columns_test.go
@@ -121,4 +121,3 @@ func TestAppendSCD2Columns(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/destination/scd2_columns_test.go
+++ b/pkg/destination/scd2_columns_test.go
@@ -1,0 +1,124 @@
+package destination
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSCD2MetadataColumns(t *testing.T) {
+	got := SCD2MetadataColumns()
+	want := []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SCD2MetadataColumns() = %v, want %v", got, want)
+	}
+}
+
+// TestSCD2MetadataColumnsReturnsCopy verifies that SCD2MetadataColumns returns a new slice on each call, not a shared slice.
+func TestSCD2MetadataColumnsReturnsCopy(t *testing.T) {
+	a := SCD2MetadataColumns()
+	a[0] = "mutated"
+	b := SCD2MetadataColumns()
+	if b[0] != "_scd_valid_from" {
+		t.Errorf("SCD2MetadataColumns() returned a shared slice; got %q after mutation", b[0])
+	}
+}
+
+func TestSCD2NonDataColumns(t *testing.T) {
+	tests := []struct {
+		name        string
+		primaryKeys []string
+		expected    []string
+	}{
+		{
+			name:        "no primary keys",
+			primaryKeys: nil,
+			expected:    []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:        "empty primary keys",
+			primaryKeys: []string{},
+			expected:    []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:        "single primary key",
+			primaryKeys: []string{"id"},
+			expected:    []string{"id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:        "multiple primary keys",
+			primaryKeys: []string{"id", "tenant_id"},
+			expected:    []string{"id", "tenant_id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:        "primary key overlaps scd metadata",
+			primaryKeys: []string{"_scd_valid_from"},
+			expected:    []string{"_scd_valid_from", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SCD2NonDataColumns(tt.primaryKeys)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("SCD2NonDataColumns(%v) = %v, want %v", tt.primaryKeys, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSCD2NonDataColumnsDoesNotMutateInput(t *testing.T) {
+	pks := []string{"id"}
+	_ = SCD2NonDataColumns(pks)
+	if !reflect.DeepEqual(pks, []string{"id"}) {
+		t.Errorf("SCD2NonDataColumns mutated input slice: %v", pks)
+	}
+}
+
+func TestAppendSCD2Columns(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:     "data columns only",
+			input:    []string{"id", "name"},
+			expected: []string{"id", "name", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:     "one scd column already present",
+			input:    []string{"id", "_scd_valid_from"},
+			expected: []string{"id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:     "all scd columns already present",
+			input:    []string{"id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+			expected: []string{"id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		},
+		{
+			name:     "scd columns in different order",
+			input:    []string{"_scd_is_current", "id", "_scd_valid_to"},
+			expected: []string{"_scd_is_current", "id", "_scd_valid_to", "_scd_valid_from"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AppendSCD2Columns(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("AppendSCD2Columns(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -521,7 +521,7 @@ func (d *SnowflakeDestination) SCD2Table(ctx context.Context, opts destination.S
 	defer func() { _ = tx.Rollback() }()
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditionsSnowflake(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
@@ -569,7 +569,7 @@ func (d *SnowflakeDestination) SCD2Table(ctx context.Context, opts destination.S
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedCols := make([]string, len(allColumns))
 	for i, col := range allColumns {
 		quotedCols[i] = quoteIdentifier(col)

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -548,7 +548,7 @@ func (d *SQLiteDestination) SCD2Table(ctx context.Context, opts destination.SCD2
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditionsSQLite(nonPKColumns, quotedTargetTable, "source")
 	onCondition := buildJoinConditionSQLite(opts.PrimaryKeys, quotedTargetTable, "source")
 
@@ -598,7 +598,7 @@ func (d *SQLiteDestination) SCD2Table(ctx context.Context, opts destination.SCD2
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -509,7 +509,7 @@ func (d *SynapseDestination) SCD2Table(ctx context.Context, opts destination.SCD
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 	changeConditions := buildChangeConditions(nonPKColumns, "target", "source")
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
@@ -555,7 +555,7 @@ func (d *SynapseDestination) SCD2Table(ctx context.Context, opts destination.SCD
 		}
 	}
 
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedColumns := quoteColumns(allColumns)
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -401,7 +401,7 @@ func (d *TrinoDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	}
 
 	// Step 3: Insert new versions + net-new records
-	allColumns := append(opts.Columns, "_scd_valid_from", "_scd_valid_to", "_scd_is_current")
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
 	quotedCols := quoteColumns(allColumns)
 
 	// Build NOT EXISTS condition for insert

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -150,6 +150,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	// Check if source has known schema or needs inference
 	var tableSchema *schema.TableSchema
 	var bufferedRecords <-chan source.RecordBatchResult
+	var inferBuffer *databuffer.FileBuffer
 
 	if table.HasKnownSchema() {
 		tableSchema, err = table.GetSchema(ctx)
@@ -157,12 +158,17 @@ func (p *Pipeline) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to get schema: %w", err)
 		}
 	} else {
-		// Schema inference path: read all data first
+		// Schema inference path: read all data first. Buffer is opened later
 		config.Debug("[PIPELINE] Source has unknown schema, inferring from data...")
-		tableSchema, bufferedRecords, err = p.inferSchemaFromData(ctx, table, tracker)
+		tableSchema, inferBuffer, err = p.inferSchemaFromData(ctx, table, tracker)
 		if err != nil {
 			return fmt.Errorf("failed to infer schema: %w", err)
 		}
+		defer func() {
+			if inferBuffer != nil {
+				_ = inferBuffer.Close()
+			}
+		}()
 		if tableSchema != nil {
 			config.Debug("[PIPELINE] Inferred schema with %d columns", len(tableSchema.Columns))
 		} else {
@@ -279,10 +285,25 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 
 	// Schema contract handling: evolve destination schema if needed (skip for replace strategy)
+	// Build the evolution plan but do NOT apply it here. Strategies decide when to apply.
+	var evolutionPlan *schemaevolution.EvolutionPlan
 	if resolvedStrategy != config.StrategyReplace {
-		if err := p.evolveSchemaIfNeeded(ctx, destSchema); err != nil {
+		evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, destSchema)
+		if err != nil {
 			return fmt.Errorf("schema evolution failed: %w", err)
 		}
+		if evolutionPlan != nil && evolutionPlan.FinalSchema != nil {
+			destSchema = evolutionPlan.FinalSchema
+		}
+	}
+
+	if inferBuffer != nil {
+		bufferTarget := p.buildBufferReaderTarget(originalSourceSchema, destSchema)
+		bufferedRecords, err = inferBuffer.Reader(ctx, bufferTarget)
+		if err != nil {
+			return fmt.Errorf("failed to open buffer reader: %w", err)
+		}
+		inferBuffer = nil
 	}
 
 	strat, err := strategy.Get(resolvedStrategy)
@@ -353,6 +374,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		ColumnRenamer:       p.columnRenamer,
 		IngestrColumnFiller: p.ingestrColumnFiller,
 		ColumnMasker:        columnMasker,
+		EvolutionPlan:       evolutionPlan,
 	}
 
 	// For known-schema sources with column type overrides, add a type caster
@@ -438,7 +460,7 @@ func (p *Pipeline) createTracker(ctx context.Context) (progress.Tracker, error) 
 	return tracker, nil
 }
 
-func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceTable, tracker progress.Tracker) (*schema.TableSchema, <-chan source.RecordBatchResult, error) {
+func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceTable, tracker progress.Tracker) (*schema.TableSchema, *databuffer.FileBuffer, error) {
 	// Create schema inferrer and file-backed data buffer
 	inferrer := schemainfer.NewSchemaInferrer()
 	buffer, err := databuffer.NewFileBuffer()
@@ -549,13 +571,55 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 		return nil, nil, fmt.Errorf("failed to append missing override columns: %w", err)
 	}
 
-	bufferedRecords, err := buffer.Reader(ctx, tableSchema.ToArrowSchema())
-	if err != nil {
-		_ = buffer.Close()
-		return nil, nil, fmt.Errorf("failed to create buffer reader: %w", err)
+	return tableSchema, buffer, nil
+}
+
+// buildBufferReaderTarget builds the Arrow schema for buffer.Reader:
+// dest order, source names (for buffer file match), dest types (for staging
+// match). Ingestr/SCD2 metadata cols are skipped and dest-only cols get null-fill.
+func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.TableSchema) *arrow.Schema {
+	var renameMap map[string]string
+	if p.columnRenamer != nil && p.columnRenamer.HasRenames() {
+		renameMap = p.columnRenamer.Mapping()
 	}
 
-	return tableSchema, bufferedRecords, nil
+	srcByDestName := make(map[string]schema.Column, len(sourceSchema.Columns))
+	for _, c := range sourceSchema.Columns {
+		key := c.Name
+		if r, ok := renameMap[key]; ok {
+			key = r
+		}
+		srcByDestName[key] = c
+	}
+
+	fields := make([]arrow.Field, 0, len(destSchema.Columns))
+	for _, dc := range destSchema.Columns {
+		if naming.IsIngestrColumn(dc.Name) || isSCD2MetadataColumn(dc.Name) {
+			continue
+		}
+		if sc, ok := srcByDestName[dc.Name]; ok {
+			m := sc
+			m.DataType, m.Precision, m.Scale, m.ArrayType = dc.DataType, dc.Precision, dc.Scale, dc.ArrayType
+			fields = append(fields, arrowField(sc.Name, m, m.Nullable || dc.Nullable)) // add columns using dest types but source names
+			continue
+		}
+		fields = append(fields, arrowField(dc.Name, dc, true)) // add soft deleted columns using dest names
+	}
+
+	return arrow.NewSchema(fields, nil)
+}
+
+func arrowField(name string, col schema.Column, nullable bool) arrow.Field {
+	return arrow.Field{Name: name, Type: schema.DataTypeToArrowType(col), Nullable: nullable}
+}
+
+func isSCD2MetadataColumn(name string) bool {
+	for _, scd := range destination.SCD2MetadataColumns() {
+		if scd == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Pipeline) filterDroppedPKs(pks []string) []string {
@@ -724,15 +788,17 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	return nil
 }
 
-func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schema.TableSchema) error {
+// evolveSchemaIfNeeded inspects the destination's current schema and builds an
+// EvolutionPlan describing how it should change to accommodate sourceSchema.
+func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
 	// Get destination table schema (nil if table doesn't exist)
 	destSchema, err := p.dest.GetTableSchema(ctx, p.config.DestTable)
 	if err != nil {
-		return fmt.Errorf("failed to get destination schema: %w", err)
+		return nil, fmt.Errorf("failed to get destination schema: %w", err)
 	}
 	if destSchema == nil {
 		config.Debug("[SCHEMA EVOLUTION] Destination table doesn't exist yet, skipping evolution")
-		return nil
+		return nil, nil
 	}
 
 	// Store destination schema for use by strategies
@@ -741,7 +807,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 	// Parse schema contract mode
 	contractMode, err := schemaevolution.ParseContractMode(p.config.SchemaContract)
 	if err != nil {
-		return fmt.Errorf("failed to parse schema contract: %w", err)
+		return nil, fmt.Errorf("failed to parse schema contract: %w", err)
 	}
 	contract := schemaevolution.SchemaContract{Mode: contractMode}
 	config.Debug("[SCHEMA EVOLUTION] Using schema contract mode: %s", contractMode)
@@ -749,7 +815,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 	// Parse column overrides from config
 	overrides, err := schemaevolution.ParseColumnOverrides(p.config.Columns)
 	if err != nil {
-		return fmt.Errorf("failed to parse column overrides: %w", err)
+		return nil, fmt.Errorf("failed to parse column overrides: %w", err)
 	}
 	if len(overrides) > 0 {
 		config.Debug("[SCHEMA EVOLUTION] Applying %d column type overrides", len(overrides))
@@ -759,11 +825,14 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 	opts := &schemaevolution.CompareOptions{Overrides: overrides}
 	comparison, err := schemaevolution.Compare(sourceSchema, destSchema, opts)
 	if err != nil {
-		return fmt.Errorf("failed to compare schemas: %w", err)
+		return nil, fmt.Errorf("failed to compare schemas: %w", err)
 	}
 	if !comparison.HasChanges {
 		config.Debug("[SCHEMA EVOLUTION] No schema changes detected")
-		return nil
+		return &schemaevolution.EvolutionPlan{
+			FinalSchema: schemaevolution.BuildFinalSchema(destSchema, nil),
+			Migration:   nil,
+		}, nil
 	}
 
 	config.Debug("[SCHEMA EVOLUTION] Detected %d schema changes", len(comparison.Changes))
@@ -786,10 +855,13 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 	switch contract.Mode {
 	case schemaevolution.ContractFreeze:
 		if contractResult.HasViolations() {
-			return contractResult.ViolationError()
+			return nil, contractResult.ViolationError()
 		}
 		p.filteredSchemaComparison = comparison
-		return nil
+		return &schemaevolution.EvolutionPlan{
+			FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+			Migration:   nil,
+		}, nil
 
 	case schemaevolution.ContractDiscardRow:
 		if contractResult.HasViolations() {
@@ -831,7 +903,10 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 				Changes:    []schemaevolution.SchemaChange{},
 				HasChanges: false,
 			}
-			return nil
+			return &schemaevolution.EvolutionPlan{
+				FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+				Migration:   nil,
+			}, nil
 		}
 		// For migration, only apply allowed changes (new columns) for discard_value mode
 		// Type changes are NOT applied, but they ARE captured for runtime transformation
@@ -848,14 +923,17 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 	dialect := schemaevolution.GetDialect(p.dest.GetScheme())
 	if dialect == nil {
 		config.Debug("[SCHEMA EVOLUTION] No dialect registered for scheme %s, skipping", p.dest.GetScheme())
-		return nil
+		return &schemaevolution.EvolutionPlan{
+			FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+			Migration:   nil,
+		}, nil
 	}
 
 	// Generate migration using the FILTERED schema comparison (after contract filtering)
 	// This ensures we only apply allowed changes (e.g., new columns in discard_value mode)
 	migration, err := schemaevolution.GenerateMigration(p.filteredSchemaComparison, dialect, p.config.DestTable)
 	if err != nil {
-		return fmt.Errorf("failed to generate migration: %w", err)
+		return nil, fmt.Errorf("failed to generate migration: %w", err)
 	}
 
 	// Log warnings
@@ -868,13 +946,13 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 		config.Debug("[SCHEMA EVOLUTION] %s", sql)
 	}
 
-	// Apply migration
-	if err := schemaevolution.ApplyMigration(ctx, p.dest, migration); err != nil {
-		return fmt.Errorf("failed to apply migration: %w", err)
+	// Build the plan; migration is NOT applied here.
+	plan := &schemaevolution.EvolutionPlan{
+		FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+		Migration:   migration,
 	}
-
-	config.Debug("[SCHEMA EVOLUTION] Successfully applied %d schema changes", len(migration.Statements))
-	return nil
+	config.Debug("[SCHEMA EVOLUTION] Built plan with %d statements (deferred apply)", len(migration.Statements))
+	return plan, nil
 }
 
 func (p *Pipeline) setupIngestrColumns(ctx context.Context, sourceSchema *schema.TableSchema) (*schema.TableSchema, error) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 )
 
 type mockDestination struct {
@@ -1020,4 +1022,222 @@ func TestDroppedColumnsPKFiltering(t *testing.T) {
 			}
 		})
 	}
+}
+
+func tcol(name string, dt schema.DataType) schema.Column {
+	return schema.Column{Name: name, DataType: dt, Nullable: true}
+}
+
+func tschema(name string, cols ...schema.Column) *schema.TableSchema {
+	return &schema.TableSchema{Name: name, Columns: cols}
+}
+
+func arrowFieldNames(s *arrow.Schema) []string {
+	out := make([]string, s.NumFields())
+	for i, f := range s.Fields() {
+		out[i] = f.Name
+	}
+	return out
+}
+
+// Case 1: identical source and dest schemas, target equals dest's order,
+// types come from dest.
+func TestBuildBufferReaderTarget_NoDriftIdenticalOrder(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("age", schema.TypeInt32),
+	)
+	dest := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("age", schema.TypeInt32),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name", "age"})
+	if got.Field(0).Type.ID() != arrow.PrimitiveTypes.Int64.ID() {
+		t.Errorf("field 0 type = %s, want int64", got.Field(0).Type)
+	}
+	if got.Field(1).Type.ID() != arrow.BinaryTypes.String.ID() {
+		t.Errorf("field 1 type = %s, want string", got.Field(1).Type)
+	}
+	if got.Field(2).Type.ID() != arrow.PrimitiveTypes.Int32.ID() {
+		t.Errorf("field 2 type = %s, want int32", got.Field(2).Type)
+	}
+}
+
+// source-only columns reach destSchema via the evolve phase (ChangeAddColumn);
+// when destSchema doesn't carry them, this function drops them.
+func TestBuildBufferReaderTarget_SourceOnlyColumnIsDropped(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("email", schema.TypeString),
+	)
+	dest := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
+}
+
+func TestBuildBufferReaderTarget_OrderFollowsDest(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("email", schema.TypeString),
+		tcol("age", schema.TypeInt32),
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+	)
+	dest := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("age", schema.TypeInt32),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name", "age"})
+}
+
+// Case 4a: dest has an ingestr metadata column NOT in source. It must be
+// SKIPPED in the target. IngestrColumnFiller adds it downstream; including
+// it here would cause a duplicate.
+func TestBuildBufferReaderTarget_SkipsIngestrMetadataColumn(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+	)
+	dest := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("_dlt_load_id", schema.TypeString),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
+}
+
+// Case 4b: dest has a NON-ingestr column NOT in source (soft-removed under
+// evolve mode). It MUST be included in the target so the buffer reader
+// null-fills it; staging then gets the column with NULLs, MERGE inserts NULL
+// into the dest column for new rows.
+func TestBuildBufferReaderTarget_IncludesSoftRemovedColumn(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+	)
+	dest := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("email", schema.TypeString), // soft-removed from source
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name", "email"})
+	if !got.Field(2).Nullable {
+		t.Errorf("soft-removed column must be nullable")
+	}
+}
+
+// Case 5: dest type differs from source type. Target uses dest's type so the
+// buffer reader casts batches to the staging-table column type.
+func TestBuildBufferReaderTarget_UsesDestTypes(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"events",
+		tcol("id", schema.TypeInt64),
+		tcol("created_at", schema.TypeTimestamp), // source: TIMESTAMP
+	)
+	dest := tschema(
+		"events",
+		tcol("id", schema.TypeInt64),
+		tcol("created_at", schema.TypeString), // dest: STRING
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	if got.Field(1).Name != "created_at" {
+		t.Errorf("field 1 name = %q, want created_at", got.Field(1).Name)
+	}
+	if got.Field(1).Type.ID() != arrow.BinaryTypes.String.ID() {
+		t.Errorf("field 1 type = %s, want string", got.Field(1).Type)
+	}
+}
+
+// Case 6: a ColumnRenamer bridges source camelCase names to dest snake_case.
+// Field names in the target stay as SOURCE names (to match buffer files), but
+// type lookup goes through the rename map to find the dest column.
+func TestBuildBufferReaderTarget_HonorsRenamer(t *testing.T) {
+	p := &Pipeline{
+		columnRenamer: transformer.NewColumnRenamer(map[string]string{
+			"userId":    "user_id",
+			"createdAt": "created_at",
+		}),
+	}
+	src := tschema(
+		"users",
+		tcol("userId", schema.TypeInt64),
+		tcol("createdAt", schema.TypeTimestamp),
+	)
+	dest := tschema(
+		"users",
+		tcol("user_id", schema.TypeInt64),
+		tcol("created_at", schema.TypeString), // wider dest type
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"userId", "createdAt"})
+	if got.Field(1).Type.ID() != arrow.BinaryTypes.String.ID() {
+		t.Errorf("field 1 type = %s, want string", got.Field(1).Type)
+	}
+}
+
+// Case 7: realistic evolve scenario.
+func TestBuildBufferReaderTarget_EvolveScenario(t *testing.T) {
+	p := &Pipeline{}
+	// Source order can be anything — we only care about names.
+	src := tschema(
+		"orders",
+		tcol("age", schema.TypeInt64),
+		tcol("email", schema.TypeString), // new
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("score", schema.TypeInt64),
+	)
+
+	dest := tschema(
+		"orders",
+		tcol("age", schema.TypeInt64),
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("score", schema.TypeInt64),
+		tcol("email", schema.TypeString), // added by Compare.ChangeAddColumn
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"age", "id", "name", "score", "email"})
 }

--- a/pkg/schemaevolution/plan.go
+++ b/pkg/schemaevolution/plan.go
@@ -1,0 +1,65 @@
+package schemaevolution
+
+import (
+	"context"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+// EvolutionPlan represents what the destination should look like after the
+// pending migration is applied, without actually applying it yet.
+type EvolutionPlan struct {
+	FinalSchema *schema.TableSchema
+	Migration   *Migration
+}
+
+func (p *EvolutionPlan) HasMigration() bool {
+	return p != nil && p.Migration != nil && len(p.Migration.Statements) > 0
+}
+
+func (p *EvolutionPlan) Apply(ctx context.Context, executor SQLExecutor) error {
+	if p == nil || p.Migration == nil || len(p.Migration.Statements) == 0 {
+		return nil
+	}
+	if err := ApplyMigration(ctx, executor, p.Migration); err != nil {
+		return err
+	}
+	p.Migration.Statements = nil
+	return nil
+}
+
+// BuildFinalSchema computes what the destination table will look like AFTER a
+// given comparison's changes have been applied via ALTER.
+func BuildFinalSchema(destSchema *schema.TableSchema, comparison *SchemaComparison) *schema.TableSchema {
+	if destSchema == nil {
+		return nil
+	}
+
+	result := *destSchema
+	result.Columns = append([]schema.Column{}, destSchema.Columns...)
+	result.PrimaryKeys = append([]string{}, destSchema.PrimaryKeys...)
+
+	if comparison == nil || !comparison.HasChanges {
+		return &result
+	}
+
+	for _, change := range comparison.Changes {
+		switch change.Type {
+		case ChangeAddColumn:
+			result.Columns = append(result.Columns, change.NewColumn)
+
+		case ChangeWidenType, ChangeOverrideType:
+			for i, col := range result.Columns {
+				if col.Name == change.ColumnName {
+					result.Columns[i] = change.NewColumn
+					break
+				}
+			}
+
+		case ChangeRemoveColumn:
+			// Soft remove: dest keeps the column, future rows have NULL there.
+		}
+	}
+
+	return &result
+}

--- a/pkg/strategy/append.go
+++ b/pkg/strategy/append.go
@@ -43,6 +43,10 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		return fmt.Errorf("failed to prepare table: %w", err)
 	}
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	parallelism := job.Config.ExtractParallelism
 	if parallelism <= 0 {
 		parallelism = 4

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -110,8 +110,10 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 
 	if intervalStart == nil || intervalEnd == nil {
 		config.Debug("[DELETE+INSERT] No interval detected (empty data?), skipping delete+insert")
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
+		if !job.Config.KeepStaging {
+			if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
+				config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
+			}
 		}
 		return nil
 	}
@@ -151,8 +153,10 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		return fmt.Errorf("failed to delete+insert data: %w", err)
 	}
 
-	if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-		config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
+	if !job.Config.KeepStaging {
+		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
+			config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -134,6 +134,10 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		intervalEnd = toDateOnly(intervalEnd)
 	}
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	if err := job.Destination.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
 		StagingTable:       stagingTable,
 		TargetTable:        job.Config.DestTable,

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -135,9 +135,11 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		return fmt.Errorf("failed to merge data: %w", err)
 	}
 
-	// Drop staging table
-	if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-		config.Debug("[MERGE] Warning: failed to drop staging table: %v", err)
+	// Drop staging table (skip when KeepStaging is set for test inspection).
+	if !job.Config.KeepStaging {
+		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
+			config.Debug("[MERGE] Warning: failed to drop staging table: %v", err)
+		}
 	}
 
 	return nil
@@ -280,8 +282,10 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 				return
 			}
 
-			if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-				config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, err)
+			if !job.Config.KeepStaging {
+				if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
+					config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, err)
+				}
 			}
 		}(tableInfo)
 	}

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -118,6 +118,10 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	// Perform merge: UPDATE existing + INSERT new
 	// Note: We only use source columns here. Destination-only columns (removed columns)
 	// will naturally receive NULL for new rows and remain unchanged for existing rows.

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -148,9 +148,11 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 		return fmt.Errorf("failed to perform SCD2 merge: %w", err)
 	}
 
-	// Drop staging table
-	if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-		config.Debug("[SCD2] Warning: failed to drop staging table: %v", err)
+	// Drop staging table (skip when KeepStaging is set for test inspection).
+	if !job.Config.KeepStaging {
+		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
+			config.Debug("[SCD2] Warning: failed to drop staging table: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -131,6 +131,10 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	// Perform SCD2 merge
 	config.Debug("[SCD2] Executing SCD2 merge operation")
 	if err := job.Destination.SCD2Table(ctx, destination.SCD2Options{
@@ -159,15 +163,27 @@ func extendSchemaWithSCDColumns(original *schema.TableSchema) *schema.TableSchem
 		{Name: "_scd_is_current", DataType: schema.TypeBoolean, Nullable: false},
 	}
 
+	// Skip SCD columns that already exist.
+	existing := make(map[string]bool, len(original.Columns))
+	for _, c := range original.Columns {
+		existing[c.Name] = true
+	}
+	toAdd := make([]schema.Column, 0, len(scdColumns))
+	for _, c := range scdColumns {
+		if !existing[c.Name] {
+			toAdd = append(toAdd, c)
+		}
+	}
+
 	extended := &schema.TableSchema{
 		Name:        original.Name,
 		Schema:      original.Schema,
-		Columns:     make([]schema.Column, len(original.Columns)+len(scdColumns)),
+		Columns:     make([]schema.Column, len(original.Columns)+len(toAdd)),
 		PrimaryKeys: nil, // SCD2 tables don't have primary keys
 	}
 
 	copy(extended.Columns, original.Columns)
-	copy(extended.Columns[len(original.Columns):], scdColumns)
+	copy(extended.Columns[len(original.Columns):], toAdd)
 
 	return extended
 }

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -46,6 +46,9 @@ type IngestionJob struct {
 
 	// ColumnMasker replaces values in user-specified columns (e.g. passwords).
 	ColumnMasker *transformer.ColumnMasker
+
+	// EvolutionPlan holds the deferred schema evolution to apply on the destination.
+	EvolutionPlan *schemaevolution.EvolutionPlan
 }
 
 // GetRecords returns either buffered records (for schema-unknown sources)
@@ -55,6 +58,14 @@ func (j *IngestionJob) GetRecords(ctx context.Context, opts source.ReadOptions) 
 		return j.BufferedRecords, nil
 	}
 	return j.Table.Read(ctx, opts)
+}
+
+// ApplyEvolution applies the pending schema evolution plan to the destination.
+func (j *IngestionJob) ApplyEvolution(ctx context.Context) error {
+	if j.EvolutionPlan == nil || !j.EvolutionPlan.HasMigration() {
+		return nil
+	}
+	return j.EvolutionPlan.Apply(ctx, j.Destination)
 }
 
 type WriteStrategy interface {

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -58,6 +58,10 @@ func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob)
 		return fmt.Errorf("failed to prepare table: %w", err)
 	}
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
 		return fmt.Errorf("failed to truncate table: %w", err)
 	}

--- a/tests/integration/staging_inspect_test.go
+++ b/tests/integration/staging_inspect_test.go
@@ -218,9 +218,11 @@ func TestStaging_SoftRemovedColumnNullFilled(t *testing.T) {
 
 	var nullCount, totalCount int
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s WHERE deprecated_note IS NULL", staging)).Scan(&nullCount))
+		"SELECT COUNT(*) FROM %s WHERE deprecated_note IS NULL", staging,
+	)).Scan(&nullCount))
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s", staging)).Scan(&totalCount))
+		"SELECT COUNT(*) FROM %s", staging,
+	)).Scan(&totalCount))
 	assert.Equal(t, totalCount, nullCount,
 		"every row in staging must have NULL for the soft-removed column")
 }
@@ -315,11 +317,14 @@ func TestStaging_SCD2HasMetadataColumns(t *testing.T) {
 
 	var nullFrom, notCurrent, total int
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s", staging)).Scan(&total))
+		"SELECT COUNT(*) FROM %s", staging,
+	)).Scan(&total))
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s WHERE _scd_valid_from IS NULL", staging)).Scan(&nullFrom))
+		"SELECT COUNT(*) FROM %s WHERE _scd_valid_from IS NULL", staging,
+	)).Scan(&nullFrom))
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s WHERE _scd_is_current = false", staging)).Scan(&notCurrent))
+		"SELECT COUNT(*) FROM %s WHERE _scd_is_current = false", staging,
+	)).Scan(&notCurrent))
 
 	assert.Greater(t, total, 0, "staging should have rows")
 	assert.Equal(t, 0, nullFrom, "every staging row must have _scd_valid_from set")
@@ -387,10 +392,10 @@ func TestStaging_MixedDrift_AddWidenSoftRemove(t *testing.T) {
 	destURI, destPath, destTable := newDuckDBDest(t)
 
 	preCreateDest(t, ctx, destURI, destTable, []schema.Column{
-		nullCol("id", schema.TypeInt32),     // source BIGINT (wider) → ALTER fires
-		nullCol("name", schema.TypeString),  // matches
-		nullCol("active", schema.TypeString), // source BOOLEAN (narrower) → no ALTER
-		nullCol("score", schema.TypeFloat64), // matches
+		nullCol("id", schema.TypeInt32),          // source BIGINT (wider) → ALTER fires
+		nullCol("name", schema.TypeString),       // matches
+		nullCol("active", schema.TypeString),     // source BOOLEAN (narrower) → no ALTER
+		nullCol("score", schema.TypeFloat64),     // matches
 		nullCol("deprecated", schema.TypeString), // soft-removed
 	})
 
@@ -428,9 +433,11 @@ func TestStaging_MixedDrift_AddWidenSoftRemove(t *testing.T) {
 
 	var nullDep, total int
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s", staging)).Scan(&total))
+		"SELECT COUNT(*) FROM %s", staging,
+	)).Scan(&total))
 	require.NoError(t, db.QueryRow(fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s WHERE deprecated IS NULL", staging)).Scan(&nullDep))
+		"SELECT COUNT(*) FROM %s WHERE deprecated IS NULL", staging,
+	)).Scan(&nullDep))
 	assert.Equal(t, total, nullDep, "deprecated column must be NULL for every staging row")
 	assert.Equal(t, mergeInitialRows, total, "staging should contain all source rows")
 }

--- a/tests/integration/staging_inspect_test.go
+++ b/tests/integration/staging_inspect_test.go
@@ -1,0 +1,485 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests verify the invariant: STAGING TABLE MIRRORS DEST SCHEMA.
+//
+// They run the pipeline with KeepStaging=true so the staging table survives
+// past the merge, then inspect it directly via SQL.
+//
+// Shape of each test:
+//   1. Set up a DuckDB file
+//   2. Optionally pre-create the dest table with a different schema (drift)
+//   3. Run pipeline with KeepStaging=true
+//   4. Find the staging table (in _bruin_staging schema)
+//   5. Assert: staging schema == dest schema (cols, types, order)
+//   6. Assert: staging data is what we expect
+
+func newDuckDBDest(t *testing.T) (uri, path, destTable string) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, fmt.Sprintf("staging_inspect_%d.duckdb", time.Now().UnixNano()))
+	uri = fmt.Sprintf("duckdb:///%s", path)
+	destTable = "main.users"
+	return
+}
+
+func openDuckDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", path))
+	require.NoError(t, err, "open duckdb")
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func preCreateDest(t *testing.T, ctx context.Context, destURI, table string, cols []schema.Column) {
+	t.Helper()
+	d := duckdb.NewDuckDBDestination()
+	require.NoError(t, d.Connect(ctx, destURI), "connect duckdb")
+	t.Cleanup(func() { _ = d.Close(ctx) })
+
+	err := d.PrepareTable(ctx, destination.PrepareOptions{
+		Table:     table,
+		Schema:    &schema.TableSchema{Name: table, Columns: cols},
+		DropFirst: true,
+	})
+	require.NoError(t, err, "pre-create dest")
+	require.NoError(t, d.Close(ctx))
+}
+
+// findStagingTable returns the fully-qualified staging table name.
+func findStagingTable(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	rows, err := db.Query(`
+		SELECT table_schema, table_name
+		FROM information_schema.tables
+		WHERE table_schema = '_bruin_staging'`)
+	require.NoError(t, err, "list staging tables")
+	defer func() { _ = rows.Close() }()
+
+	var found []string
+	for rows.Next() {
+		var s, n []byte
+		require.NoError(t, rows.Scan(&s, &n))
+		found = append(found, fmt.Sprintf("%s.%s", string(s), string(n)))
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, found, 1, "expected exactly one staging table, got: %v", found)
+	return found[0]
+}
+
+type colInfo struct {
+	name     string
+	dataType string
+	nullable bool
+}
+
+func tableColumns(t *testing.T, db *sql.DB, qualifiedTable string) []colInfo {
+	t.Helper()
+	parts := strings.SplitN(qualifiedTable, ".", 2)
+	require.Len(t, parts, 2, "expected schema.table, got %q", qualifiedTable)
+	tableSchema, name := parts[0], parts[1]
+
+	// String-interpolate instead of `?` placeholders — ADBC's prepared-statement
+	// path mis-counts parameters on some DuckDB queries.
+	q := fmt.Sprintf(`
+		SELECT column_name, data_type, is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = '%s' AND table_name = '%s'
+		ORDER BY ordinal_position`, tableSchema, name)
+	rows, err := db.Query(q)
+	require.NoError(t, err, "query columns")
+	defer func() { _ = rows.Close() }()
+
+	var out []colInfo
+	for rows.Next() {
+		var nameRaw, typeRaw, nullableRaw []byte
+		require.NoError(t, rows.Scan(&nameRaw, &typeRaw, &nullableRaw))
+		out = append(out, colInfo{
+			name:     string(nameRaw),
+			dataType: strings.ToUpper(string(typeRaw)),
+			nullable: strings.EqualFold(string(nullableRaw), "YES"),
+		})
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func colNames(cols []colInfo) []string {
+	out := make([]string, len(cols))
+	for i, c := range cols {
+		out[i] = c.name
+	}
+	return out
+}
+
+func nullCol(name string, dt schema.DataType) schema.Column {
+	return schema.Column{Name: name, DataType: dt, Nullable: true}
+}
+
+// =====================================================================
+// Case 1: Basic merge — no drift. Staging should mirror dest exactly.
+// =====================================================================
+func TestStaging_BasicMergeMirrorsDest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+	sourceURI := jsonlURI(t, "testdata/conformance_merge_initial.jsonl")
+
+	cfg := &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         true,
+	}
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "pipeline should succeed")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+
+	stagingCols := tableColumns(t, db, staging)
+	destCols := tableColumns(t, db, destTable)
+
+	assert.Equal(t, colNames(destCols), colNames(stagingCols),
+		"staging columns must match dest exactly in order")
+	for i := range destCols {
+		assert.Equal(t, destCols[i].dataType, stagingCols[i].dataType,
+			"col %q: type mismatch", destCols[i].name)
+	}
+
+	var rowCount int
+	require.NoError(t, db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", staging)).Scan(&rowCount))
+	assert.Equal(t, mergeInitialRows, rowCount, "staging should contain all source rows")
+}
+
+// =====================================================================
+// Case 2: Soft-removed column. Dest has an extra column that source
+// doesn't. Staging MUST include that column (null-filled) so the MERGE
+// can write NULLs into dest for new rows.
+// =====================================================================
+func TestStaging_SoftRemovedColumnNullFilled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+
+	preCreateDest(t, ctx, destURI, destTable, []schema.Column{
+		nullCol("id", schema.TypeInt64),
+		nullCol("name", schema.TypeString),
+		nullCol("active", schema.TypeBoolean),
+		nullCol("score", schema.TypeFloat64),
+		nullCol("deprecated_note", schema.TypeString), // dest-only
+	})
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         true,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "pipeline should succeed")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+
+	stagingCols := tableColumns(t, db, staging)
+	destCols := tableColumns(t, db, destTable)
+
+	assert.Equal(t, colNames(destCols), colNames(stagingCols),
+		"staging must include the dest-only soft-removed column")
+
+	var nullCount, totalCount int
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s WHERE deprecated_note IS NULL", staging)).Scan(&nullCount))
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s", staging)).Scan(&totalCount))
+	assert.Equal(t, totalCount, nullCount,
+		"every row in staging must have NULL for the soft-removed column")
+}
+
+// =====================================================================
+// Case 3: source DOUBLE, dest VARCHAR (pre-existing). Evolution doesn't
+// fire (VARCHAR absorbs DOUBLE). Staging MUST be created with VARCHAR.
+// =====================================================================
+func TestStaging_WidenedDestTypeUsedInStaging(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+
+	preCreateDest(t, ctx, destURI, destTable, []schema.Column{
+		nullCol("id", schema.TypeInt64),
+		nullCol("name", schema.TypeString),
+		nullCol("active", schema.TypeBoolean),
+		nullCol("score", schema.TypeString), // source has DOUBLE; dest already wider
+	})
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         true,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "pipeline should succeed")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+
+	stagingByName := map[string]colInfo{}
+	for _, c := range tableColumns(t, db, staging) {
+		stagingByName[c.name] = c
+	}
+	destByName := map[string]colInfo{}
+	for _, c := range tableColumns(t, db, destTable) {
+		destByName[c.name] = c
+	}
+
+	assert.Equal(t, destByName["score"].dataType, stagingByName["score"].dataType,
+		"staging.score type must mirror dest, not source")
+	assert.Equal(t, "VARCHAR", stagingByName["score"].dataType,
+		"staging.score should be VARCHAR (dest's pre-existing type)")
+}
+
+// =====================================================================
+// Case 4: SCD2. Staging must contain _scd_valid_from, _scd_valid_to,
+// _scd_is_current at the END of the column list and every row must
+// have those filled.
+// =====================================================================
+func TestStaging_SCD2HasMetadataColumns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_scd2_initial.jsonl"),
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategySCD2,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         true,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "SCD2 pipeline should succeed")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+
+	stagingCols := tableColumns(t, db, staging)
+	destCols := tableColumns(t, db, destTable)
+
+	assert.Equal(t, colNames(destCols), colNames(stagingCols),
+		"staging schema must match dest exactly (cols + order)")
+
+	require.GreaterOrEqual(t, len(stagingCols), 3, "staging should have at least 3 cols")
+	last3 := colNames(stagingCols[len(stagingCols)-3:])
+	assert.Equal(t,
+		[]string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+		last3,
+		"SCD2 metadata cols must be appended at the end of staging in canonical order")
+
+	var nullFrom, notCurrent, total int
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s", staging)).Scan(&total))
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s WHERE _scd_valid_from IS NULL", staging)).Scan(&nullFrom))
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s WHERE _scd_is_current = false", staging)).Scan(&notCurrent))
+
+	assert.Greater(t, total, 0, "staging should have rows")
+	assert.Equal(t, 0, nullFrom, "every staging row must have _scd_valid_from set")
+	assert.Equal(t, 0, notCurrent, "every staging row must be marked current=true")
+}
+
+// =====================================================================
+// Case 5: Source narrower — BOOLEAN source, VARCHAR dest. No ALTER.
+// Staging must use dest's VARCHAR.
+// =====================================================================
+func TestStaging_SourceNarrower_BooleanVsVarchar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+
+	preCreateDest(t, ctx, destURI, destTable, []schema.Column{
+		nullCol("id", schema.TypeInt64),
+		nullCol("name", schema.TypeString),
+		nullCol("active", schema.TypeString), // source BOOLEAN; dest wider
+		nullCol("score", schema.TypeFloat64),
+	})
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         true,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "pipeline should succeed")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+
+	stagingByName := map[string]colInfo{}
+	for _, c := range tableColumns(t, db, staging) {
+		stagingByName[c.name] = c
+	}
+	destByName := map[string]colInfo{}
+	for _, c := range tableColumns(t, db, destTable) {
+		destByName[c.name] = c
+	}
+
+	assert.Equal(t, "VARCHAR", destByName["active"].dataType, "dest stays VARCHAR (no ALTER)")
+	assert.Equal(t, "VARCHAR", stagingByName["active"].dataType,
+		"staging.active must be VARCHAR (dest's wider type)")
+}
+
+// =====================================================================
+// Case 6: Mixed drift. Source wider (id), source narrower (active),
+// no-drift (name, score), and a soft-removed dest-only col.
+// Exercises every code path of buildBufferReaderTarget at once.
+// =====================================================================
+func TestStaging_MixedDrift_AddWidenSoftRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+
+	preCreateDest(t, ctx, destURI, destTable, []schema.Column{
+		nullCol("id", schema.TypeInt32),     // source BIGINT (wider) → ALTER fires
+		nullCol("name", schema.TypeString),  // matches
+		nullCol("active", schema.TypeString), // source BOOLEAN (narrower) → no ALTER
+		nullCol("score", schema.TypeFloat64), // matches
+		nullCol("deprecated", schema.TypeString), // soft-removed
+	})
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         true,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "pipeline should succeed")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+
+	stagingCols := tableColumns(t, db, staging)
+	destCols := tableColumns(t, db, destTable)
+
+	assert.Equal(t, colNames(destCols), colNames(stagingCols),
+		"staging and dest must have identical column lists in identical order")
+	for i := range destCols {
+		assert.Equal(t, destCols[i].dataType, stagingCols[i].dataType,
+			"col %q: staging=%s dest=%s", destCols[i].name,
+			stagingCols[i].dataType, destCols[i].dataType)
+	}
+
+	destByName := map[string]colInfo{}
+	for _, c := range destCols {
+		destByName[c.name] = c
+	}
+	assert.Equal(t, "BIGINT", destByName["id"].dataType, "id widened INTEGER → BIGINT")
+	assert.Equal(t, "VARCHAR", destByName["active"].dataType, "active stays VARCHAR")
+
+	var nullDep, total int
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s", staging)).Scan(&total))
+	require.NoError(t, db.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s WHERE deprecated IS NULL", staging)).Scan(&nullDep))
+	assert.Equal(t, total, nullDep, "deprecated column must be NULL for every staging row")
+	assert.Equal(t, mergeInitialRows, total, "staging should contain all source rows")
+}
+
+// =====================================================================
+// Case 7: Two consecutive runs, schema drifts between them. After the
+// SECOND run, staging from the second pipeline must STILL mirror dest.
+// =====================================================================
+func TestStaging_SecondRun_StillMirrorsDest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	ctx := context.Background()
+	destURI, destPath, destTable := newDuckDBDest(t)
+
+	preCreateDest(t, ctx, destURI, destTable, []schema.Column{
+		nullCol("id", schema.TypeInt32), // source BIGINT will widen
+		nullCol("name", schema.TypeString),
+		nullCol("active", schema.TypeBoolean),
+		nullCol("score", schema.TypeFloat64),
+	})
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "users",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		KeepStaging:         false, // first run cleans up so the second is unambiguous
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "first run")
+
+	cfg.SourceURI = jsonlURI(t, "testdata/conformance_merge_update.jsonl")
+	cfg.SourceTable = "users"
+	cfg.KeepStaging = true
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "second run")
+
+	db := openDuckDB(t, destPath)
+	staging := findStagingTable(t, db)
+	stagingCols := tableColumns(t, db, staging)
+	destCols := tableColumns(t, db, destTable)
+
+	assert.Equal(t, colNames(destCols), colNames(stagingCols),
+		"second-run staging must still mirror the (now-evolved) dest")
+	for i := range destCols {
+		assert.Equal(t, destCols[i].dataType, stagingCols[i].dataType,
+			"col %q: staging=%s dest=%s", destCols[i].name,
+			stagingCols[i].dataType, destCols[i].dataType)
+	}
+}


### PR DESCRIPTION
Previously, when source was narrower than dest in the widening graph (e.g. source TIMESTAMP, dest TEXT), evolve emitted no ALTER but staging was still created from source-derived job.Schema. This left staging with source types while dest kept its existing types relying on engine-specific implicit coercion. This fix builds an EvolutionPlan during pipeline setup with FinalSchema + Migration and defer Apply to strategies. Staging is now created from FinalSchema so it mirrors dest's post-evolve shape.