### PR TITLE
[codex] Add Granola source

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
         <td>-</td>
     </tr>
+    <tr>
+        <td>Granola</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
      <tr>
         <td>Klaviyo</td>
         <td>✅</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -170,6 +170,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Google Ads", link: "/supported-sources/google-ads.md" },
               { text: "GitHub", link: "/supported-sources/github.md" },
               { text: "Google Sheets", link: "/supported-sources/gsheets.md" },
+              { text: "Granola", link: "/supported-sources/granola.md" },
               { text: "Hostaway", link: "/supported-sources/hostaway.md" },
               { text: "Indeed", link: "/supported-sources/indeed.md" },
               { text: "Gorgias", link: "/supported-sources/gorgias.md" },

--- a/docs/supported-sources/granola.md
+++ b/docs/supported-sources/granola.md
@@ -1,0 +1,47 @@
+# Granola
+
+[Granola](https://www.granola.ai/) is an AI meeting-notes product. Ingestr supports Granola as a source for notes and folders through the Granola public API.
+
+## URI Format
+
+```plaintext
+granola://?api_key=<api-key>
+```
+
+URI parameters:
+
+- `api_key` (required): Granola API token used as a bearer token.
+
+## Example
+
+```sh
+ingestr ingest \
+  --source-uri 'granola://?api_key=your-api-key' \
+  --source-table 'notes' \
+  --dest-uri duckdb:///granola.duckdb \
+  --dest-table 'main.notes'
+```
+
+## Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| ----- | -- | ------- | ------------ | ------- |
+| `notes` | `id` | `updated_at` | `merge` | Meeting notes listed from `/v1/notes` and hydrated from `/v1/notes/{note_id}`, including summary, transcript, attendees, folder membership, calendar event, and web URL. Incremental runs use Granola's `updated_after` parameter. |
+| `folders` | `id` | - | `replace` | Accessible folders returned by the `/v1/folders` endpoint. |
+
+## Incremental Loading
+
+The `notes` table supports incremental loading by `updated_at`.
+
+```sh
+ingestr ingest \
+  --source-uri 'granola://?api_key=your-api-key' \
+  --source-table 'notes' \
+  --dest-uri duckdb:///granola.duckdb \
+  --dest-table 'main.notes' \
+  --interval-start '2026-01-01T00:00:00Z'
+```
+
+The `folders` table is loaded as a full refresh.
+
+The `notes` table fetches note details with `include=transcript`, so transcripts are available in the `transcript` JSON column when Granola returns them.

--- a/pkg/source/granola/granola.go
+++ b/pkg/source/granola/granola.go
@@ -1,0 +1,408 @@
+package granola
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	baseURL         = "https://public-api.granola.ai"
+	maxPageSize     = 30
+	defaultPageSize = 30
+)
+
+var supportedTables = []string{
+	"notes",
+	"folders",
+}
+
+var noteFields = []schema.Column{
+	{Name: "id", DataType: schema.TypeString, Nullable: false},
+	{Name: "title", DataType: schema.TypeString, Nullable: true},
+	{Name: "owner", DataType: schema.TypeJSON, Nullable: true},
+	{Name: "created_at", DataType: schema.TypeTimestampTZ, Nullable: true},
+	{Name: "updated_at", DataType: schema.TypeTimestampTZ, Nullable: true},
+	{Name: "object", DataType: schema.TypeString, Nullable: true},
+	{Name: "web_url", DataType: schema.TypeString, Nullable: true},
+	{Name: "calendar_event", DataType: schema.TypeJSON, Nullable: true},
+	{Name: "attendees", DataType: schema.TypeJSON, Nullable: true},
+	{Name: "folder_membership", DataType: schema.TypeJSON, Nullable: true},
+	{Name: "summary_text", DataType: schema.TypeString, Nullable: true},
+	{Name: "summary_markdown", DataType: schema.TypeString, Nullable: true},
+	{Name: "transcript", DataType: schema.TypeJSON, Nullable: true},
+}
+
+var folderFields = []schema.Column{
+	{Name: "id", DataType: schema.TypeString, Nullable: false},
+	{Name: "name", DataType: schema.TypeString, Nullable: true},
+	{Name: "parent_folder_id", DataType: schema.TypeString, Nullable: true},
+}
+
+type GranolaSource struct {
+	apiKey string
+	client *ingestrhttp.Client
+}
+
+func NewGranolaSource() *GranolaSource {
+	return &GranolaSource{}
+}
+
+func (s *GranolaSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *GranolaSource) Schemes() []string {
+	return []string{"granola"}
+}
+
+func (s *GranolaSource) Connect(ctx context.Context, uri string) error {
+	apiKey, err := parseGranolaURI(uri)
+	if err != nil {
+		return err
+	}
+	s.apiKey = apiKey
+
+	s.client = ingestrhttp.New(
+		ingestrhttp.WithBaseURL(baseURL),
+		ingestrhttp.WithTimeout(60*time.Second),
+		ingestrhttp.WithRetry(5, 2*time.Second, 30*time.Second),
+		ingestrhttp.WithDebug(config.DebugMode),
+		ingestrhttp.WithAuth(ingestrhttp.NewBearerAuth(apiKey)),
+	)
+
+	config.Debug("[GRANOLA] Connected successfully")
+	return nil
+}
+
+func (s *GranolaSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseGranolaURI(uri string) (string, error) {
+	if !strings.HasPrefix(uri, "granola://") {
+		return "", fmt.Errorf("invalid granola URI: must start with granola://")
+	}
+
+	rest := strings.TrimPrefix(uri, "granola://")
+	if rest == "" || rest == "?" {
+		return "", fmt.Errorf("api_key is required in granola URI (granola://?api_key=...)")
+	}
+
+	rest = strings.TrimPrefix(rest, "?")
+
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse granola URI query: %w", err)
+	}
+
+	apiKey := values.Get("api_key")
+	if apiKey == "" {
+		return "", fmt.Errorf("api_key is required in granola URI (granola://?api_key=...)")
+	}
+
+	return apiKey, nil
+}
+
+func (s *GranolaSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName := req.Name
+
+	if !isValidTable(tableName) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, strings.Join(supportedTables, ", "))
+	}
+
+	tableSchema, err := getSchema(tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	incrementalKey := ""
+	strategy := config.StrategyReplace
+	if tableName == "notes" {
+		incrementalKey = "updated_at"
+		strategy = config.StrategyMerge
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    tableSchema.PrimaryKeys,
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return tableSchema, nil
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, opts)
+		},
+	}, nil
+}
+
+func isValidTable(table string) bool {
+	for _, supported := range supportedTables {
+		if table == supported {
+			return true
+		}
+	}
+	return false
+}
+
+func getSchema(table string) (*schema.TableSchema, error) {
+	switch table {
+	case "notes":
+		return &schema.TableSchema{
+			Name:           table,
+			Columns:        noteFields,
+			PrimaryKeys:    []string{"id"},
+			IncrementalKey: "updated_at",
+		}, nil
+	case "folders":
+		return &schema.TableSchema{
+			Name:        table,
+			Columns:     folderFields,
+			PrimaryKeys: []string{"id"},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported table: %s", table)
+	}
+}
+
+func (s *GranolaSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "notes":
+			err = s.readNotes(ctx, opts, results)
+		case "folders":
+			err = s.readFolders(ctx, opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", table)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *GranolaSource) readNotes(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	params := map[string]string{}
+	if opts.IntervalStart != nil {
+		params["updated_after"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+	}
+
+	return s.paginate(ctx, "notes", "notes", params, noteFields, opts, results)
+}
+
+func (s *GranolaSource) readFolders(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	return s.paginate(ctx, "folders", "folders", nil, folderFields, opts, results)
+}
+
+type listResponse struct {
+	Notes   []map[string]interface{} `json:"notes"`
+	Folders []map[string]interface{} `json:"folders"`
+	HasMore bool                     `json:"hasMore"`
+	Cursor  *string                  `json:"cursor"`
+}
+
+func (s *GranolaSource) paginate(
+	ctx context.Context,
+	endpoint string,
+	responseKey string,
+	params map[string]string,
+	fields []schema.Column,
+	opts source.ReadOptions,
+	results chan<- source.RecordBatchResult,
+) error {
+	pageSize := resolvePageSize(opts)
+	totalSent := 0
+	var cursor string
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		reqParams := map[string]string{
+			"page_size": fmt.Sprintf("%d", pageSize),
+		}
+		for k, v := range params {
+			reqParams[k] = v
+		}
+		if cursor != "" {
+			reqParams["cursor"] = cursor
+		}
+
+		config.Debug("[GRANOLA] Fetching %s with params: %+v", endpoint, reqParams)
+		resp, err := s.client.R(ctx).SetQueryParams(reqParams).Get("/v1/" + endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", endpoint, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("failed to fetch %s: status %d: %s", endpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body listResponse
+		if err := resp.JSON(&body); err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", endpoint, err)
+		}
+
+		items, err := responseItems(body, responseKey)
+		if err != nil {
+			return err
+		}
+		items = filterItemsByInterval(items, opts.IncrementalKey, opts.IntervalStart, opts.IntervalEnd)
+		if opts.Limit > 0 && totalSent+len(items) > opts.Limit {
+			items = items[:opts.Limit-totalSent]
+		}
+		if responseKey == "notes" && len(items) > 0 {
+			items, err = s.hydrateNotes(ctx, items)
+			if err != nil {
+				return err
+			}
+		}
+
+		if len(items) > 0 {
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, fields, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", endpoint, err)
+			}
+			results <- source.RecordBatchResult{Batch: record}
+			totalSent += len(items)
+		}
+
+		if opts.Limit > 0 && totalSent >= opts.Limit {
+			return nil
+		}
+		if !body.HasMore || body.Cursor == nil || *body.Cursor == "" {
+			return nil
+		}
+		cursor = *body.Cursor
+	}
+}
+
+func (s *GranolaSource) hydrateNotes(ctx context.Context, notes []map[string]interface{}) ([]map[string]interface{}, error) {
+	hydrated := make([]map[string]interface{}, 0, len(notes))
+	for _, note := range notes {
+		noteID, ok := note["id"].(string)
+		if !ok || noteID == "" {
+			hydrated = append(hydrated, note)
+			continue
+		}
+
+		detail, err := s.fetchNoteDetail(ctx, noteID)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range note {
+			if _, exists := detail[k]; !exists {
+				detail[k] = v
+			}
+		}
+		hydrated = append(hydrated, detail)
+	}
+	return hydrated, nil
+}
+
+func (s *GranolaSource) fetchNoteDetail(ctx context.Context, noteID string) (map[string]interface{}, error) {
+	resp, err := s.client.R(ctx).
+		SetQueryParam("include", "transcript").
+		Get("/v1/notes/" + url.PathEscape(noteID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch note %s: %w", noteID, err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("failed to fetch note %s: status %d: %s", noteID, resp.StatusCode(), resp.String())
+	}
+
+	var detail map[string]interface{}
+	if err := resp.JSON(&detail); err != nil {
+		return nil, fmt.Errorf("failed to parse note %s response: %w", noteID, err)
+	}
+	return detail, nil
+}
+
+func resolvePageSize(opts source.ReadOptions) int {
+	pageSize := opts.PageSize
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = defaultPageSize
+	}
+	if opts.Limit > 0 && opts.Limit < pageSize {
+		pageSize = opts.Limit
+	}
+	return pageSize
+}
+
+func responseItems(body listResponse, responseKey string) ([]map[string]interface{}, error) {
+	switch responseKey {
+	case "notes":
+		return body.Notes, nil
+	case "folders":
+		return body.Folders, nil
+	default:
+		return nil, fmt.Errorf("unsupported response key: %s", responseKey)
+	}
+}
+
+func filterItemsByInterval(items []map[string]interface{}, incrementalKey string, start, end *time.Time) []map[string]interface{} {
+	if incrementalKey == "" || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		raw, ok := item[incrementalKey]
+		if !ok || raw == nil {
+			filtered = append(filtered, item)
+			continue
+		}
+
+		t, ok := parseTimestamp(raw)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && t.Before(*start) {
+			continue
+		}
+		if end != nil && t.After(*end) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func parseTimestamp(v interface{}) (time.Time, bool) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, true
+	case string:
+		parsed, err := time.Parse(time.RFC3339, t)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return parsed, true
+	default:
+		return time.Time{}, false
+	}
+}

--- a/pkg/source/granola/granola_test.go
+++ b/pkg/source/granola/granola_test.go
@@ -1,0 +1,329 @@
+package granola
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGranolaURI(t *testing.T) {
+	tests := []struct {
+		name      string
+		uri       string
+		want      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid URI",
+			uri:  "granola://?api_key=granola-token",
+			want: "granola-token",
+		},
+		{
+			name: "token with special characters",
+			uri:  "granola://?api_key=tok_abc%2F123%3Axyz",
+			want: "tok_abc/123:xyz",
+		},
+		{
+			name:      "missing scheme",
+			uri:       "https://public-api.granola.ai",
+			wantErr:   true,
+			errSubstr: "must start with granola://",
+		},
+		{
+			name:      "missing api key",
+			uri:       "granola://",
+			wantErr:   true,
+			errSubstr: "api_key is required",
+		},
+		{
+			name:      "empty api key",
+			uri:       "granola://?api_key=",
+			wantErr:   true,
+			errSubstr: "api_key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGranolaURI(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetTableConfig(t *testing.T) {
+	src := NewGranolaSource()
+
+	notes, err := src.GetTable(context.Background(), source.TableRequest{Name: "notes"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, notes.PrimaryKeys())
+	assert.Equal(t, "updated_at", notes.IncrementalKey())
+	assert.Equal(t, config.StrategyMerge, notes.Strategy())
+
+	folders, err := src.GetTable(context.Background(), source.TableRequest{Name: "folders"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, folders.PrimaryKeys())
+	assert.Empty(t, folders.IncrementalKey())
+	assert.Equal(t, config.StrategyReplace, folders.Strategy())
+}
+
+func TestGetTableUnsupported(t *testing.T) {
+	src := NewGranolaSource()
+	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "meetings"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported table")
+}
+
+func TestReadNotesUsesUpdatedAfterAndCursorPagination(t *testing.T) {
+	var requests []map[string]string
+	var detailRequests []map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path != "/v1/notes" {
+			detailRequests = append(detailRequests, map[string]string{
+				"path":    r.URL.Path,
+				"include": r.URL.Query().Get("include"),
+			})
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":               strings.TrimPrefix(r.URL.Path, "/v1/notes/"),
+				"title":            "Hydrated note",
+				"owner":            map[string]interface{}{"name": "Oat Benson", "email": "oat@granola.ai"},
+				"created_at":       "2026-01-27T15:30:00Z",
+				"updated_at":       "2026-01-27T16:45:00Z",
+				"web_url":          "https://notes.granola.ai/d/example",
+				"summary_text":     "Hydrated summary",
+				"summary_markdown": "## Hydrated summary",
+				"attendees":        []map[string]interface{}{{"name": "Oat Benson", "email": "oat@granola.ai"}},
+				"transcript":       []map[string]interface{}{{"text": "Hello", "start_time": "2026-01-27T15:30:00Z"}},
+			})
+			return
+		}
+
+		requests = append(requests, map[string]string{
+			"page_size":     r.URL.Query().Get("page_size"),
+			"updated_after": r.URL.Query().Get("updated_after"),
+			"cursor":        r.URL.Query().Get("cursor"),
+		})
+
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"notes": []map[string]interface{}{
+					{
+						"id":         "not_1",
+						"title":      "First note",
+						"owner":      map[string]interface{}{"name": "Oat Benson", "email": "oat@granola.ai"},
+						"created_at": "2026-01-27T15:30:00Z",
+						"updated_at": "2026-01-27T16:45:00Z",
+					},
+				},
+				"hasMore": true,
+				"cursor":  "next-cursor",
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"notes": []map[string]interface{}{
+				{
+					"id":         "not_2",
+					"title":      "Second note",
+					"owner":      map[string]interface{}{"name": "Groat", "email": "groat@granola.ai"},
+					"created_at": "2026-01-28T15:30:00Z",
+					"updated_at": "2026-01-28T16:45:00Z",
+				},
+			},
+			"hasMore": false,
+			"cursor":  nil,
+		})
+	}))
+	defer server.Close()
+
+	src := newTestSource(server.URL)
+	start := time.Date(2026, 1, 27, 16, 0, 0, 0, time.UTC)
+	records, err := src.read(context.Background(), "notes", source.ReadOptions{
+		IncrementalKey: "updated_at",
+		IntervalStart:  &start,
+		PageSize:       100,
+	})
+	require.NoError(t, err)
+
+	var rowCount int64
+	for result := range records {
+		require.NoError(t, result.Err)
+		rowCount += result.Batch.NumRows()
+		result.Batch.Release()
+	}
+
+	require.Len(t, requests, 2)
+	assert.Equal(t, "30", requests[0]["page_size"])
+	assert.Equal(t, "2026-01-27T16:00:00Z", requests[0]["updated_after"])
+	assert.Empty(t, requests[0]["cursor"])
+	assert.Equal(t, "next-cursor", requests[1]["cursor"])
+	assert.Equal(t, int64(2), rowCount)
+	require.Len(t, detailRequests, 2)
+	assert.Equal(t, "/v1/notes/not_1", detailRequests[0]["path"])
+	assert.Equal(t, "transcript", detailRequests[0]["include"])
+	assert.Equal(t, "/v1/notes/not_2", detailRequests[1]["path"])
+	assert.Equal(t, "transcript", detailRequests[1]["include"])
+}
+
+func TestReadFoldersIsFullRefreshCursorPaginated(t *testing.T) {
+	var requests []map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/folders", r.URL.Path)
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		requests = append(requests, map[string]string{
+			"page_size": r.URL.Query().Get("page_size"),
+			"cursor":    r.URL.Query().Get("cursor"),
+		})
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"folders": []map[string]interface{}{
+				{"id": "fol_1", "name": "Top secret recipes", "parent_folder_id": nil},
+				{"id": "fol_2", "name": "Desserts", "parent_folder_id": "fol_1"},
+			},
+			"hasMore": false,
+			"cursor":  nil,
+		})
+	}))
+	defer server.Close()
+
+	src := newTestSource(server.URL)
+	records, err := src.read(context.Background(), "folders", source.ReadOptions{PageSize: 10})
+	require.NoError(t, err)
+
+	var rowCount int64
+	for result := range records {
+		require.NoError(t, result.Err)
+		rowCount += result.Batch.NumRows()
+		result.Batch.Release()
+	}
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, "10", requests[0]["page_size"])
+	assert.Empty(t, requests[0]["cursor"])
+	assert.Equal(t, int64(2), rowCount)
+}
+
+func TestFilterItemsByInterval(t *testing.T) {
+	start := time.Date(2026, 1, 27, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 28, 0, 0, 0, 0, time.UTC)
+	items := []map[string]interface{}{
+		{"id": "before", "updated_at": "2026-01-26T23:59:59Z"},
+		{"id": "inside", "updated_at": "2026-01-27T12:00:00Z"},
+		{"id": "after", "updated_at": "2026-01-28T00:00:01Z"},
+		{"id": "unknown", "updated_at": "not-a-time"},
+	}
+
+	filtered := filterItemsByInterval(items, "updated_at", &start, &end)
+	require.Len(t, filtered, 2)
+	assert.Equal(t, "inside", filtered[0]["id"])
+	assert.Equal(t, "unknown", filtered[1]["id"])
+}
+
+func TestNotesRecordContainsOwnerJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/notes/not_1" {
+			require.Equal(t, "transcript", r.URL.Query().Get("include"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":               "not_1",
+				"title":            "Quarterly review",
+				"owner":            map[string]interface{}{"name": "Oat Benson", "email": "oat@granola.ai"},
+				"created_at":       "2026-01-27T15:30:00Z",
+				"updated_at":       "2026-01-27T16:45:00Z",
+				"web_url":          "https://notes.granola.ai/d/example",
+				"calendar_event":   map[string]interface{}{"event_title": "Quarterly review"},
+				"attendees":        []map[string]interface{}{{"name": "Oat Benson", "email": "oat@granola.ai"}},
+				"summary_text":     "The quarterly review was a success.",
+				"summary_markdown": "## Quarterly review",
+				"transcript":       []map[string]interface{}{{"text": "Hello", "start_time": "2026-01-27T15:30:00Z"}},
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"notes": []map[string]interface{}{
+				{
+					"id":         "not_1",
+					"title":      "Quarterly review",
+					"owner":      map[string]interface{}{"name": "Oat Benson", "email": "oat@granola.ai"},
+					"created_at": "2026-01-27T15:30:00Z",
+					"updated_at": "2026-01-27T16:45:00Z",
+				},
+			},
+			"hasMore": false,
+			"cursor":  nil,
+		})
+	}))
+	defer server.Close()
+
+	src := newTestSource(server.URL)
+	records, err := src.read(context.Background(), "notes", source.ReadOptions{IncrementalKey: "updated_at"})
+	require.NoError(t, err)
+
+	result, ok := <-records
+	require.True(t, ok)
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	ownerColumn, ok := result.Batch.Column(2).(array.ExtensionArray)
+	require.True(t, ok)
+	ownerStorage := ownerColumn.Storage().(*array.String)
+	assert.JSONEq(t, `{"email":"oat@granola.ai","name":"Oat Benson"}`, ownerStorage.Value(0))
+
+	summaryColumn := result.Batch.Column(columnIndex(result.Batch, "summary_text")).(*array.String)
+	assert.Equal(t, "The quarterly review was a success.", summaryColumn.Value(0))
+
+	transcriptColumn, ok := result.Batch.Column(columnIndex(result.Batch, "transcript")).(array.ExtensionArray)
+	require.True(t, ok)
+	transcriptStorage := transcriptColumn.Storage().(*array.String)
+	assert.JSONEq(t, `[{"start_time":"2026-01-27T15:30:00Z","text":"Hello"}]`, transcriptStorage.Value(0))
+
+	_, ok = <-records
+	assert.False(t, ok)
+}
+
+func columnIndex(record arrow.Record, name string) int {
+	for i, field := range record.Schema().Fields() {
+		if field.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func newTestSource(baseURL string) *GranolaSource {
+	return &GranolaSource{
+		apiKey: "test-token",
+		client: ingestrhttp.New(
+			ingestrhttp.WithBaseURL(baseURL),
+			ingestrhttp.WithAuth(ingestrhttp.NewBearerAuth("test-token")),
+			ingestrhttp.WithDisableRetry(),
+		),
+	}
+}

--- a/pkg/source/granola/granola_test.go
+++ b/pkg/source/granola/granola_test.go
@@ -308,7 +308,7 @@ func TestNotesRecordContainsOwnerJSON(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func columnIndex(record arrow.Record, name string) int {
+func columnIndex(record arrow.RecordBatch, name string) int {
 	for i, field := range record.Schema().Fields() {
 		if field.Name == name {
 			return i

--- a/pkg/source/granola/register.go
+++ b/pkg/source/granola/register.go
@@ -1,0 +1,10 @@
+package granola
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"granola"},
+		func() interface{} { return NewGranolaSource() },
+	)
+}


### PR DESCRIPTION
Adds Granola source support with bearer-token auth, cursor pagination, and `notes`/`folders` tables.

`notes` uses merge on `id`/`updated_at`, applies Granola's `updated_after` cursor field, and hydrates note details with `include=transcript` to expose summary, transcript, attendees, folder membership, calendar event, and web URL; `folders` loads by full refresh.

Docs, sidebar registration, and the README supported-source entry are included.

Validation: `go test ./pkg/source/granola`, live Granola-to-DuckDB loads for notes/folders; full `go test ./...` was attempted and only failed in existing Frankfurter integration tests due equal interval-start/end.