### PR TITLE
Add RudderStack telemetry

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,5 @@
 ingestr/src/telemetry/event.py:generic-api-key:17
+internal/telemetry/client.go:generic-api-key:26
 ingestr/src/testdata/fakebqcredentials.json:private-key:5
 docs/supported-sources/shopify.md:generic-api-key:26
 docs/supported-sources/smartsheets.md:generic-api-key:38

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
 	"github.com/bruin-data/ingestr/pkg/strategy"
@@ -180,7 +181,12 @@ func IngestCommand() *cli.Command {
 	}
 }
 
-func runIngest(ctx context.Context, c *cli.Command) error {
+func runIngest(ctx context.Context, c *cli.Command) (err error) {
+	trackCommandTriggered(ctx, "ingest")
+	defer func() {
+		trackCommandFinished(ctx, "ingest", err)
+	}()
+
 	config.DebugMode = c.Bool("debug")
 	cfg := config.DefaultConfig()
 
@@ -245,6 +251,8 @@ func runIngest(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
+	trackCommandRunning(ctx, "ingest", ingestTelemetryProperties(cfg))
+
 	p := pipeline.New(cfg)
 	if err := p.Run(ctx); err != nil {
 		return err
@@ -256,6 +264,25 @@ func runIngest(ctx context.Context, c *cli.Command) error {
 
 	color.Green("Ingestion completed successfully!")
 	return nil
+}
+
+func ingestTelemetryProperties(cfg *config.IngestConfig) map[string]any {
+	properties := map[string]any{}
+	if sourceType := telemetryScheme(cfg.SourceURI); sourceType != "" {
+		properties["source_type"] = sourceType
+	}
+	if destinationType := telemetryScheme(cfg.DestURI); destinationType != "" {
+		properties["destination_type"] = destinationType
+	}
+	return properties
+}
+
+func telemetryScheme(rawURI string) string {
+	parsed, err := uri.Parse(rawURI)
+	if err != nil {
+		return ""
+	}
+	return parsed.Scheme
 }
 
 func parseDateTime(s string) (time.Time, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,11 +8,15 @@ import (
 
 var Version = "dev"
 
+func versionFlagValue() string {
+	return Version
+}
+
 func NewApp() *cli.Command {
 	return &cli.Command{
 		Name:    "ingestr",
 		Usage:   "A CLI tool for data ingestion between databases",
-		Version: Version,
+		Version: versionFlagValue(),
 		Commands: []*cli.Command{
 			IngestCommand(),
 			ServerCommand(),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -41,11 +41,18 @@ func ServerCommand() *cli.Command {
 	}
 }
 
-func runServer(ctx context.Context, c *cli.Command) error {
+func runServer(ctx context.Context, c *cli.Command) (err error) {
+	trackCommandTriggered(ctx, "server")
+	defer func() {
+		trackCommandFinished(ctx, "server", err)
+	}()
+
 	port := int(c.Int("port"))
 	credsFile := c.String("creds-file")
 	logsDir := c.String("logs-dir")
 	dbPath := c.String("db")
+
+	trackCommandRunning(ctx, "server", nil)
 
 	s, err := server.New(port, credsFile, logsDir, dbPath)
 	if err != nil {

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/telemetry"
+)
+
+func trackCommandTriggered(ctx context.Context, command string) {
+	telemetry.Track(ctx, "command_triggered", map[string]any{
+		"command": command,
+	}, Version)
+}
+
+func trackCommandRunning(ctx context.Context, command string, properties map[string]any) {
+	eventProperties := map[string]any{
+		"command": command,
+	}
+	for key, value := range properties {
+		eventProperties[key] = value
+	}
+	telemetry.Track(ctx, "command_running", eventProperties, Version)
+}
+
+func trackCommandFinished(ctx context.Context, command string, err error) {
+	properties := map[string]any{
+		"command": command,
+		"status":  "success",
+	}
+	if err != nil {
+		properties["status"] = "failed"
+		properties["error"] = commandTelemetryError(err)
+	}
+
+	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, Version)
+}
+
+func commandTelemetryError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	var validationErr *config.ValidationError
+	if errors.As(err, &validationErr) {
+		return "validation_error"
+	}
+	return "error"
+}

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -9,32 +9,35 @@ import (
 )
 
 func trackCommandTriggered(ctx context.Context, command string) {
-	telemetry.Track(ctx, "command_triggered", map[string]any{
-		"command": command,
-	}, Version)
+	telemetry.Track(ctx, "command_triggered", commandTelemetryProperties(command, nil), versionFlagValue())
 }
 
 func trackCommandRunning(ctx context.Context, command string, properties map[string]any) {
-	eventProperties := map[string]any{
-		"command": command,
-	}
-	for key, value := range properties {
-		eventProperties[key] = value
-	}
-	telemetry.Track(ctx, "command_running", eventProperties, Version)
+	telemetry.Track(ctx, "command_running", commandTelemetryProperties(command, properties), versionFlagValue())
 }
 
 func trackCommandFinished(ctx context.Context, command string, err error) {
-	properties := map[string]any{
-		"command": command,
-		"status":  "success",
-	}
+	properties := commandTelemetryProperties(command, map[string]any{
+		"status": "success",
+	})
 	if err != nil {
 		properties["status"] = "failed"
 		properties["error"] = commandTelemetryError(err)
 	}
 
-	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, Version)
+	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, versionFlagValue())
+}
+
+func commandTelemetryProperties(command string, properties map[string]any) map[string]any {
+	eventProperties := map[string]any{
+		"command": command,
+		"version": versionFlagValue(),
+	}
+	for key, value := range properties {
+		eventProperties[key] = value
+	}
+	eventProperties["version"] = versionFlagValue()
+	return eventProperties
 }
 
 func commandTelemetryError(err error) string {

--- a/cmd/telemetry_test.go
+++ b/cmd/telemetry_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandTelemetryPropertiesIncludeVersionFlagValue(t *testing.T) {
+	originalVersion := Version
+	Version = "v9.8.7"
+	t.Cleanup(func() { Version = originalVersion })
+
+	properties := commandTelemetryProperties("ingest", map[string]any{
+		"source_type": "postgres",
+		"version":     "stale",
+	})
+
+	require.Equal(t, "ingest", properties["command"])
+	require.Equal(t, "postgres", properties["source_type"])
+	require.Equal(t, "v9.8.7", properties["version"])
+}
+
+func TestNewAppUsesVersionFlagValue(t *testing.T) {
+	originalVersion := Version
+	Version = "v1.2.3"
+	t.Cleanup(func() { Version = originalVersion })
+
+	require.Equal(t, versionFlagValue(), NewApp().Version)
+}

--- a/docs/getting-started/telemetry.md
+++ b/docs/getting-started/telemetry.md
@@ -8,7 +8,7 @@ ingestr uses a very basic form of **anonymous telemetry** to be able to keep tra
 - It sends the following information:
   - ingestr version
   - machine ID
-  - OS information: OS, architecture, Python version
+  - OS information: OS, architecture, Go version
   - command executed
   - success/failure
 
@@ -24,3 +24,4 @@ The questions we answer by these simple events are:
 
 ## Disabling telemetry
 If you'd like to turn off the telemetry, simply set the `INGESTR_DISABLE_TELEMETRY` environment variable to `true`.
+The legacy `DISABLE_TELEMETRY` environment variable is also supported.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.9.2
 	github.com/couchbase/gocb/v2 v2.12.1
 	github.com/databricks/databricks-sdk-go v0.95.0
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/elastic/go-elasticsearch/v9 v9.3.1
 	github.com/fatih/color v1.18.0
 	github.com/go-chi/chi/v5 v5.2.3

--- a/go.sum
+++ b/go.sum
@@ -850,6 +850,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,0 +1,181 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+const (
+	defaultDataPlaneURL = "https://getbruinbumlky.dataplane.rudderstack.com"
+	defaultTimeout      = 2 * time.Second
+)
+
+const (
+	writeKeyPart1 = "2cUr13DDQcX2x2kAf"
+	writeKeyPart2 = "MEfdrKvrQa"
+)
+
+var defaultClient = NewClient()
+
+type Client struct {
+	WriteKey     string
+	DataPlaneURL string
+	HTTPClient   *http.Client
+	Timeout      time.Duration
+	MachineID    func() (string, error)
+	Now          func() time.Time
+}
+
+func NewClient() *Client {
+	return &Client{
+		WriteKey:     writeKeyPart1 + writeKeyPart2,
+		DataPlaneURL: defaultDataPlaneURL,
+		HTTPClient:   http.DefaultClient,
+		Timeout:      defaultTimeout,
+		MachineID:    protectedMachineID,
+		Now:          time.Now,
+	}
+}
+
+func Track(ctx context.Context, event string, properties map[string]any, version string) {
+	_ = defaultClient.Track(ctx, event, properties, version)
+}
+
+func (c *Client) Track(ctx context.Context, event string, properties map[string]any, version string) error {
+	if c == nil || Disabled() || strings.TrimSpace(event) == "" {
+		return nil
+	}
+
+	userID, err := c.machineID()
+	if err != nil {
+		userID = fallbackMachineID()
+	}
+
+	payload := map[string]any{
+		"userId":     userID,
+		"event":      event,
+		"properties": c.enrichProperties(properties, version),
+		"context": map[string]any{
+			"app": map[string]any{
+				"name":    "ingestr",
+				"version": version,
+			},
+			"os": map[string]any{
+				"name": runtime.GOOS,
+			},
+			"library": map[string]any{
+				"name":    "ingestr-go",
+				"version": version,
+			},
+		},
+		"timestamp": c.now().UTC().Format(time.RFC3339Nano),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal telemetry event: %w", err)
+	}
+
+	reqCtx := ctx
+	cancel := func() {}
+	if timeout := c.timeout(); timeout > 0 {
+		reqCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, strings.TrimRight(c.DataPlaneURL, "/")+"/v1/track", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create telemetry request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.WriteKey, "")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("send telemetry event: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("telemetry request failed with status %s", resp.Status)
+	}
+	return nil
+}
+
+func Disabled() bool {
+	return envDisablesTelemetry(os.Getenv("DISABLE_TELEMETRY")) ||
+		envDisablesTelemetry(os.Getenv("INGESTR_DISABLE_TELEMETRY"))
+}
+
+func envDisablesTelemetry(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+func (c *Client) enrichProperties(properties map[string]any, version string) map[string]any {
+	enriched := make(map[string]any, len(properties)+5)
+	for key, value := range properties {
+		enriched[key] = value
+	}
+	enriched["version"] = version
+	enriched["os"] = runtime.GOOS
+	enriched["platform"] = runtime.GOOS + "/" + runtime.GOARCH
+	enriched["architecture"] = runtime.GOARCH
+	enriched["go_version"] = runtime.Version()
+	return enriched
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (c *Client) machineID() (string, error) {
+	if c.MachineID != nil {
+		return c.MachineID()
+	}
+	return protectedMachineID()
+}
+
+func (c *Client) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func (c *Client) timeout() time.Duration {
+	if c.Timeout != 0 {
+		return c.Timeout
+	}
+	return defaultTimeout
+}
+
+func protectedMachineID() (string, error) {
+	return machineid.ProtectedID("ingestr")
+}
+
+func fallbackMachineID() string {
+	hostname, _ := os.Hostname()
+	sum := sha256.Sum256([]byte(runtime.GOOS + ":" + hostname))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -106,7 +106,9 @@ func (c *Client) Track(ctx context.Context, event string, properties map[string]
 	if err != nil {
 		return fmt.Errorf("send telemetry event: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,126 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackSendsRudderStackPayload(t *testing.T) {
+	clearTelemetryEnv(t)
+
+	var got map[string]any
+	var authUser, authPassword string
+	var hasAuth bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/track", r.URL.Path)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		authUser, authPassword, hasAuth = r.BasicAuth()
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		WriteKey:     "test-key",
+		DataPlaneURL: server.URL,
+		HTTPClient:   server.Client(),
+		Timeout:      time.Second,
+		MachineID: func() (string, error) {
+			return "machine-123", nil
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 5, 25, 17, 8, 0, 0, time.UTC)
+		},
+	}
+
+	err := client.Track(context.Background(), "command_triggered", map[string]any{"command": "ingest"}, "v1.2.3")
+	require.NoError(t, err)
+
+	require.True(t, hasAuth)
+	require.Equal(t, "test-key", authUser)
+	require.Empty(t, authPassword)
+
+	require.Equal(t, "machine-123", got["userId"])
+	require.Equal(t, "command_triggered", got["event"])
+	require.Equal(t, "2026-05-25T17:08:00Z", got["timestamp"])
+
+	properties := got["properties"].(map[string]any)
+	require.Equal(t, "ingest", properties["command"])
+	require.Equal(t, "v1.2.3", properties["version"])
+	require.Equal(t, runtime.GOOS, properties["os"])
+	require.Equal(t, runtime.GOARCH, properties["architecture"])
+	require.Equal(t, runtime.Version(), properties["go_version"])
+}
+
+func TestTrackHonorsDisableTelemetryEnv(t *testing.T) {
+	t.Setenv("DISABLE_TELEMETRY", "")
+	t.Setenv("INGESTR_DISABLE_TELEMETRY", "true")
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		WriteKey:     "test-key",
+		DataPlaneURL: server.URL,
+		HTTPClient:   server.Client(),
+		MachineID: func() (string, error) {
+			return "machine-123", nil
+		},
+	}
+
+	err := client.Track(context.Background(), "command_triggered", nil, "dev")
+	require.NoError(t, err)
+	require.False(t, called)
+}
+
+func TestEnvDisablesTelemetry(t *testing.T) {
+	for _, value := range []string{"", "0", "false", "False", "no", "off"} {
+		require.False(t, envDisablesTelemetry(value), value)
+	}
+	for _, value := range []string{"1", "true", "yes", "on", "anything"} {
+		require.True(t, envDisablesTelemetry(value), value)
+	}
+}
+
+func TestTrackFallsBackWhenMachineIDFails(t *testing.T) {
+	clearTelemetryEnv(t)
+
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		WriteKey:     "test-key",
+		DataPlaneURL: server.URL,
+		HTTPClient:   server.Client(),
+		MachineID: func() (string, error) {
+			return "", errors.New("unavailable")
+		},
+	}
+
+	err := client.Track(context.Background(), "command_triggered", nil, "dev")
+	require.NoError(t, err)
+	require.NotEmpty(t, got["userId"])
+}
+
+func clearTelemetryEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DISABLE_TELEMETRY", "")
+	t.Setenv("INGESTR_DISABLE_TELEMETRY", "")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an internal RudderStack telemetry client using protected machine IDs and the v0 RudderStack data plane/write key
- Emit command lifecycle events for `ingest` and `server`, including source/destination types for ingestion
- Add a `version` property to command telemetry events from the same value used by the CLI `--version` output
- Support `INGESTR_DISABLE_TELEMETRY` and legacy `DISABLE_TELEMETRY` opt-outs and update telemetry docs
- Allowlist the intentional RudderStack write key fingerprint for gitleaks, matching the existing v0 telemetry allowlist pattern
- Handle telemetry response body cleanup explicitly for lint

## Tests
- `go test ./internal/telemetry`
- `go test ./cmd`
- `go test ./internal/telemetry ./cmd`
- `go run . --version`
- `go test -short ./...`
- `git diff --check`

## Notes
- Could not run the exact Docker-based gitleaks command locally because Docker is not installed in this cloud image.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://bruintalk.slack.com/archives/C08KG7UT94K/p1779728778220749?thread_ts=1779728778.220749&cid=C08KG7UT94K)

<div><a href="https://cursor.com/agents/bc-3abd4eb2-5b98-537d-af72-96e23ad2bed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3abd4eb2-5b98-537d-af72-96e23ad2bed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

