### PR TITLE
[codex] Update benchmark tools

### DIFF
--- a/benchmarks/scenarios.yaml
+++ b/benchmarks/scenarios.yaml
@@ -86,10 +86,10 @@ scenarios:
 
 tools:
   gong:
-    binary: /Users/burak/conductor/workspaces/gongestr/colombo/bin/gong
+    binary: bin/ingestr
 
   ingestr:
-    command_prefix: "uv tool run --python 3.11 ingestr@0.14.141 ingest"
+    command_prefix: "uv tool run --python 3.11 ingestr@0.14.155 ingest"
     requires: uv
     uri_scheme_overrides:
       postgres: postgresql

--- a/benchmarks/scripts/bench_dlt.py
+++ b/benchmarks/scripts/bench_dlt.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#     "dlt[postgres,duckdb,bigquery]==1.23.0",
+#     "dlt[postgres,duckdb,bigquery]==1.27.0",
 #     "pymysql",
 #     "sqlalchemy>=1.4,<2",
 #     "duckdb-engine",


### PR DESCRIPTION
Updates the benchmark tool configuration to use the local bin/ingestr binary for gong and bumps the ingestr benchmark command to 0.14.155.

Also updates the dlt benchmark dependency from 1.23.0 to 1.27.0.

Validation: reviewed git diff against origin/main; no benchmark suite was run.