### PR TITLE
Dedupe by primary key in truncate+insert

### DIFF
--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
@@ -10,16 +11,26 @@ import (
 )
 
 // TruncateInsertStrategy empties the destination table in place and writes new
-// rows directly into it. Unlike ReplaceStrategy (which drops + recreates via a
-// staging swap), this preserves the table definition and any dependent objects
+// rows into it. Unlike ReplaceStrategy (which drops + recreates via a staging
+// swap), this preserves the table definition and any dependent objects
 // (views, grants, foreign keys).
 //
+// When primary keys are configured, rows are first written to a staging table
+// and then deduplicated by PK into the truncated target via the destination's
+// existing merge SQL. This tolerates sources that emit the same PK more than
+// once (e.g., page-based pagination over a live table). Without PKs, dedup is
+// not possible and rows are written directly into the truncated target.
+//
 // Tradeoffs the user has already accepted by opting in:
-//   - Non-atomic: the table is empty for the duration of the load, so
-//     concurrent readers may see an empty result set.
+//   - Non-atomic: the target is empty between TRUNCATE and the final insert,
+//     so concurrent readers may see an empty result set.
 //   - No rollback: if the insert fails after truncate, the target is left empty.
 //   - Schema drift: the existing table's schema is preserved as-is; this
 //     strategy does not drop and recreate to pick up schema changes.
+//   - ClickHouse caveat: ClickHouse's merge implementation relies on
+//     ReplacingMergeTree semantics for dedup rather than pre-filtering, so
+//     duplicate PKs in staging will only be collapsed if the target table is
+//     a ReplacingMergeTree.
 type TruncateInsertStrategy struct{}
 
 func (s *TruncateInsertStrategy) Name() config.IncrementalStrategy {
@@ -44,8 +55,15 @@ func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob)
 		return fmt.Errorf("destination does not support truncate+insert strategy; use replace instead")
 	}
 
+	if len(job.Config.PrimaryKeys) > 0 {
+		return s.executeWithStaging(ctx, job, truncator)
+	}
+	return s.executeDirect(ctx, job, truncator)
+}
+
+func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *IngestionJob, truncator destination.TruncateCapable) error {
 	targetTable := job.Config.DestTable
-	config.Debug("[TRUNCATE+INSERT] Target table: %s", targetTable)
+	config.Debug("[TRUNCATE+INSERT] Target table: %s (direct path, no PKs)", targetTable)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:       targetTable,
@@ -104,6 +122,106 @@ func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob)
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 	}); err != nil {
 		return fmt.Errorf("failed to write data: %w", err)
+	}
+
+	return nil
+}
+
+func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *IngestionJob, truncator destination.TruncateCapable) error {
+	if !job.Destination.SupportsMergeStrategy() {
+		return fmt.Errorf("destination does not support deduplicated truncate+insert (merge not supported); use replace instead")
+	}
+
+	targetTable := job.Config.DestTable
+	stagingTable := GenerateStagingTableName(targetTable, "ti", job.Config.StagingDataset)
+	fmt.Printf("[TRUNCATE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+
+	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       targetTable,
+		Schema:      job.Schema,
+		DropFirst:   false,
+		PrimaryKeys: job.Config.PrimaryKeys,
+		PartitionBy: job.Config.PartitionBy,
+		ClusterBy:   job.Config.ClusterBy,
+	}); err != nil {
+		return fmt.Errorf("failed to prepare destination table: %w", err)
+	}
+
+	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        stagingTable,
+		Schema:       job.Schema,
+		DropFirst:    true,
+		PrimaryKeys:  nil,
+		PartitionBy:  job.Config.PartitionBy,
+		ClusterBy:    job.Config.ClusterBy,
+		ExpiresAfter: destination.ManagedStagingTTL,
+	}); err != nil {
+		return fmt.Errorf("failed to prepare staging table: %w", err)
+	}
+
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+
+	readOpts := source.ReadOptions{
+		IncrementalKey: job.Config.IncrementalKey,
+		IntervalStart:  job.Config.IntervalStart,
+		IntervalEnd:    job.Config.IntervalEnd,
+		PageSize:       job.Config.PageSize,
+		Limit:          job.Config.SQLLimit,
+		ExcludeColumns: job.Config.SQLExcludeColumns,
+		Parallelism:    parallelism,
+		Schema:         job.SourceSchema,
+	}
+
+	records, err := job.GetRecords(ctx, readOpts)
+	if err != nil {
+		return fmt.Errorf("failed to get records: %w", err)
+	}
+
+	records, err = job.ApplyBatchTransformation(ctx, records)
+	if err != nil {
+		return fmt.Errorf("failed to apply batch transformation: %w", err)
+	}
+
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+
+	if err := job.Destination.WriteParallel(ctx, records, destination.WriteOptions{
+		Table:            stagingTable,
+		Parallelism:      parallelism,
+		StagingTable:     true,
+		StagingBucket:    job.Config.StagingBucket,
+		LoaderFileSize:   job.Config.LoaderFileSize,
+		LoaderFileFormat: job.Config.LoaderFileFormat,
+	}); err != nil {
+		return fmt.Errorf("failed to write to staging: %w", err)
+	}
+
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
+	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
+		return fmt.Errorf("failed to truncate target: %w", err)
+	}
+
+	config.Debug("[TRUNCATE+INSERT] Executing deduplicated insert via merge from staging")
+	if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: stagingTable,
+		TargetTable:  targetTable,
+		PrimaryKeys:  job.Config.PrimaryKeys,
+		Columns:      job.Schema.ColumnNames(),
+	}); err != nil {
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+
+	if !job.Config.KeepStaging {
+		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
+			config.Debug("[TRUNCATE+INSERT] Warning: failed to drop staging table: %v", err)
+		}
 	}
 
 	return nil

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -621,6 +621,59 @@ func TestDestinations_TruncateInsert(t *testing.T) {
 	}
 }
 
+// TestDestinations_TruncateInsert_Dedup validates that truncate+insert
+// deduplicates source rows by primary key. The fixture contains 10 rows with
+// only 5 distinct ids (each id appearing twice). After the run, the target
+// must contain exactly 5 rows.
+func TestDestinations_TruncateInsert_Dedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	if _, err := strategy.Get(config.StrategyTruncateInsert); err != nil {
+		t.Skip("truncate+insert strategy not implemented yet")
+	}
+
+	ctx := context.Background()
+	dupesURI := jsonlURI(t, "testdata/conformance_truncate_dupes.jsonl")
+
+	for _, tc := range destinationCases() {
+		tc := tc
+		if tc.sqlBackend == nil || !tc.truncateInsertCapable {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Skip("destination does not support truncate+insert")
+			})
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			destURI, destTable, cleanup := tc.setup(t, ctx)
+			defer cleanup()
+
+			cfg := &config.IngestConfig{
+				SourceURI:           dupesURI,
+				SourceTable:         "truncate_dupes",
+				DestURI:             destURI,
+				DestTable:           destTable,
+				IncrementalStrategy: config.StrategyTruncateInsert,
+				PrimaryKeys:         []string{"id"},
+			}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+			db, err := tc.sqlBackend.openDB(destURI)
+			if err != nil {
+				t.Skipf("Could not open SQL backend for truncate+insert dedup validation: %v", err)
+				return
+			}
+			defer func() { _ = db.Close() }()
+
+			var count int
+			require.NoError(t, db.QueryRow(tc.sqlBackend.countQuery(destTable)).Scan(&count))
+			assert.Equal(t, 5, count, "expected 5 distinct ids after dedup")
+		})
+	}
+}
+
 // TestDestinations_SCD2 validates SCD2 (Slowly Changing Dimensions Type 2) semantics:
 // - Initial load: 5 records inserted as current rows with _scd_valid_from, _scd_valid_to=NULL, _scd_is_current=true
 // - Update load:SCD2Table

--- a/tests/integration/testdata/conformance_truncate_dupes.jsonl
+++ b/tests/integration/testdata/conformance_truncate_dupes.jsonl
@@ -1,0 +1,10 @@
+{"id":1,"name":"alpha","active":true,"score":10.5}
+{"id":1,"name":"alpha-dup","active":false,"score":11.0}
+{"id":2,"name":"bravo","active":false,"score":20.0}
+{"id":2,"name":"bravo-dup","active":true,"score":21.0}
+{"id":3,"name":"charlie","active":true,"score":30.25}
+{"id":3,"name":"charlie-dup","active":false,"score":31.0}
+{"id":4,"name":"delta","active":true,"score":40.75}
+{"id":4,"name":"delta-dup","active":false,"score":41.0}
+{"id":5,"name":"echo","active":false,"score":50.0}
+{"id":5,"name":"echo-dup","active":true,"score":51.0}


### PR DESCRIPTION
When primary keys are configured, route truncate+insert through a staging table and rely on the destination's existing MergeTable to dedupe by PK into the truncated target. This tolerates sources that emit the same PK more than once (e.g., page-based pagination over a live table) which previously surfaced as unique-constraint violations during the load.

Without primary keys, the existing direct-COPY path is preserved.