### PR TITLE
Fix Snowflake ADBC driver install when running inside a Python venv

### DIFF
--- a/pkg/source/adbc/install.go
+++ b/pkg/source/adbc/install.go
@@ -13,6 +13,7 @@ import (
 
 var dbcInstallMu sync.Mutex
 
+// InstallDriver installs an ADBC driver using the native dbc client library.
 func InstallDriver(ctx context.Context, driverName string) error {
 	dbcInstallMu.Lock()
 	defer dbcInstallMu.Unlock()

--- a/pkg/source/adbc/install.go
+++ b/pkg/source/adbc/install.go
@@ -3,6 +3,7 @@ package adbc
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -12,7 +13,6 @@ import (
 
 var dbcInstallMu sync.Mutex
 
-// InstallDriver installs an ADBC driver using the native dbc client library.
 func InstallDriver(ctx context.Context, driverName string) error {
 	dbcInstallMu.Lock()
 	defer dbcInstallMu.Unlock()
@@ -37,8 +37,14 @@ func InstallDriver(ctx context.Context, driverName string) error {
 
 func dbcInstallConfig() dbcconfig.Config {
 	configs := dbcconfig.Get()
-	if cfg := configs[dbcconfig.ConfigEnv]; cfg.Location != "" {
-		return cfg
+	// dbc's env-level location also picks up $VIRTUAL_ENV and $CONDA_PREFIX,
+	// but the ADBC driver manager only searches ADBC_DRIVER_PATH and the
+	// user/system config dirs — so only honor env-level when ADBC_DRIVER_PATH
+	// is explicitly set.
+	if os.Getenv("ADBC_DRIVER_PATH") != "" {
+		if cfg := configs[dbcconfig.ConfigEnv]; cfg.Location != "" {
+			return cfg
+		}
 	}
 	return configs[dbcconfig.ConfigUser]
 }


### PR DESCRIPTION
## Summary

- Running ingestr from a shell with `VIRTUAL_ENV` (or `CONDA_PREFIX`) set caused the Snowflake ADBC driver install to fail with `snowflake ADBC driver still not available after installation`, even though dbc reported success.
- Root cause: dbc's env-level install location silently includes `$VIRTUAL_ENV/etc/adbc/drivers` and `$CONDA_PREFIX/etc/adbc/drivers`, but the Go ADBC driver manager only searches `ADBC_DRIVER_PATH` and the user/system config dirs. The driver landed in the venv, where the manager never looks.
- Fix: only honor dbc's env-level config when `ADBC_DRIVER_PATH` is explicitly set (the var the driver manager actually reads). Otherwise install into the user dir, which the manager always scans.