### PR TITLE
Handle column-name collisions after snake_case normalization

### DIFF
--- a/pkg/naming/detect.go
+++ b/pkg/naming/detect.go
@@ -142,6 +142,7 @@ func BuildColumnMapping(sourceSchema *schema.TableSchema, convention NamingConve
 		destName := convention.Normalize(col.Name)
 		if claimed[destName] {
 			drops[col.Name] = true
+			renames[col.Name] = destName
 			continue
 		}
 		claimed[destName] = true

--- a/pkg/naming/detect.go
+++ b/pkg/naming/detect.go
@@ -119,15 +119,35 @@ func normalizeForDetection(name string) string {
 	return strings.ToLower(name)
 }
 
-// BuildColumnMapping creates a mapping from source column names to destination column names
-// based on the naming convention.
-func BuildColumnMapping(sourceSchema *schema.TableSchema, convention NamingConvention) map[string]string {
-	mapping := make(map[string]string)
-	for _, col := range sourceSchema.Columns {
+// BuildColumnMapping computes how source columns should be renamed and which
+// should be dropped to honor the naming convention.
+//
+// Returned values:
+//   - renames: source column name → destination column name. Only contains
+//     entries where the destination differs from the source.
+//   - drops: set of source column names to remove entirely. Populated when
+//     multiple source columns normalize to the same destination name: the LAST
+//     source column (in source order) keeps the normalized name, all earlier
+//     colliding columns are added to drops.
+func BuildColumnMapping(sourceSchema *schema.TableSchema, convention NamingConvention) (renames map[string]string, drops map[string]bool) {
+	renames = make(map[string]string)
+	drops = make(map[string]bool)
+	if sourceSchema == nil {
+		return renames, drops
+	}
+
+	claimed := make(map[string]bool)
+	for i := len(sourceSchema.Columns) - 1; i >= 0; i-- {
+		col := sourceSchema.Columns[i]
 		destName := convention.Normalize(col.Name)
+		if claimed[destName] {
+			drops[col.Name] = true
+			continue
+		}
+		claimed[destName] = true
 		if destName != col.Name {
-			mapping[col.Name] = destName
+			renames[col.Name] = destName
 		}
 	}
-	return mapping
+	return renames, drops
 }

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -243,20 +243,89 @@ func TestBuildColumnMapping(t *testing.T) {
 
 	t.Run("DirectReturnsEmptyMapping", func(t *testing.T) {
 		conv := Get(Direct)
-		mapping := BuildColumnMapping(sourceSchema, conv)
-		assert.Empty(t, mapping)
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
+		assert.Empty(t, renames)
+		assert.Empty(t, drops)
 	})
 
 	t.Run("SnakeCaseReturnsMapping", func(t *testing.T) {
 		conv := Get(SnakeCase)
-		mapping := BuildColumnMapping(sourceSchema, conv)
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
 
-		assert.Len(t, mapping, 2)
-		assert.Equal(t, "user_id", mapping["userId"])
-		assert.Equal(t, "created_at", mapping["createdAt"])
-		// user_name is already snake_case, so no mapping needed
-		_, exists := mapping["user_name"]
+		assert.Empty(t, drops)
+		assert.Len(t, renames, 2)
+		assert.Equal(t, "user_id", renames["userId"])
+		assert.Equal(t, "created_at", renames["createdAt"])
+		_, exists := renames["user_name"]
 		assert.False(t, exists)
+	})
+}
+
+func TestBuildColumnMappingCollisions(t *testing.T) {
+	conv := Get(SnakeCase)
+
+	t.Run("LastWinsEarlierDropped", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id"},
+				{Name: "created_at"},
+				{Name: "createdAt"},
+			},
+		}
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
+		assert.Equal(t, "created_at", renames["createdAt"])
+		assert.True(t, drops["created_at"])
+		assert.False(t, drops["createdAt"])
+		_, ok := renames["id"]
+		assert.False(t, ok)
+		_, ok = renames["created_at"]
+		assert.False(t, ok, "dropped column shouldn't appear in renames")
+	})
+
+	t.Run("MultipleColumnsAllDroppedExceptLast", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "FirstName"},
+				{Name: "FirstNAME"},
+				{Name: "First_Name"},
+				{Name: "first_name"},
+			},
+		}
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
+		// `first_name` (last) is already snake_case → no rename entry, not dropped.
+		_, hasLast := renames["first_name"]
+		assert.False(t, hasLast)
+		assert.False(t, drops["first_name"])
+		assert.True(t, drops["FirstName"])
+		assert.True(t, drops["FirstNAME"])
+		assert.True(t, drops["First_Name"])
+	})
+
+	t.Run("LastIsCamelStillRenamedTargetSnakeCase", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "created_at"},
+				{Name: "createdAt"},
+				{Name: "CreatedAt"},
+			},
+		}
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
+		assert.Equal(t, "created_at", renames["CreatedAt"])
+		assert.True(t, drops["created_at"])
+		assert.True(t, drops["createdAt"])
+	})
+
+	t.Run("NoCollision", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "userId"},
+				{Name: "createdAt"},
+			},
+		}
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
+		assert.Empty(t, drops)
+		assert.Equal(t, "user_id", renames["userId"])
+		assert.Equal(t, "created_at", renames["createdAt"])
 	})
 }
 

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -278,8 +278,7 @@ func TestBuildColumnMappingCollisions(t *testing.T) {
 		assert.False(t, drops["createdAt"])
 		_, ok := renames["id"]
 		assert.False(t, ok)
-		_, ok = renames["created_at"]
-		assert.False(t, ok, "dropped column shouldn't appear in renames")
+		assert.Equal(t, "created_at", renames["created_at"])
 	})
 
 	t.Run("MultipleColumnsAllDroppedExceptLast", func(t *testing.T) {
@@ -299,6 +298,9 @@ func TestBuildColumnMappingCollisions(t *testing.T) {
 		assert.True(t, drops["FirstName"])
 		assert.True(t, drops["FirstNAME"])
 		assert.True(t, drops["First_Name"])
+		assert.Equal(t, "first_name", renames["FirstName"])
+		assert.Equal(t, "first_name", renames["FirstNAME"])
+		assert.Equal(t, "first_name", renames["First_Name"])
 	})
 
 	t.Run("LastIsCamelStillRenamedTargetSnakeCase", func(t *testing.T) {
@@ -313,6 +315,25 @@ func TestBuildColumnMappingCollisions(t *testing.T) {
 		assert.Equal(t, "created_at", renames["CreatedAt"])
 		assert.True(t, drops["created_at"])
 		assert.True(t, drops["createdAt"])
+		// Losers also have rename entries pointing at the winner's normalized name.
+		assert.Equal(t, "created_at", renames["created_at"])
+		assert.Equal(t, "created_at", renames["createdAt"])
+	})
+
+	t.Run("LoserHasRenameEntryWhenWinnerIsAlreadySnakeCase", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "userId"},
+				{Name: "user_id"},
+			},
+		}
+		renames, drops := BuildColumnMapping(sourceSchema, conv)
+		assert.True(t, drops["userId"])
+		assert.False(t, drops["user_id"])
+		assert.Equal(t, "user_id", renames["userId"],
+			"dropped loser must have rename entry to winner's name")
+		_, hasWinner := renames["user_id"]
+		assert.False(t, hasWinner, "winner (already snake_case) needs no rename")
 	})
 
 	t.Run("NoCollision", func(t *testing.T) {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1027,20 +1027,25 @@ func (p *Pipeline) setupNamingConvention(ctx context.Context, sourceSchema *sche
 	config.Debug("[NAMING] Using %s naming convention", namingConv.Name())
 
 	// Build column mapping
-	columnMapping := naming.BuildColumnMapping(sourceSchema, namingConv)
-	if len(columnMapping) == 0 {
+	renames, drops := naming.BuildColumnMapping(sourceSchema, namingConv)
+	if len(renames) == 0 && len(drops) == 0 {
 		config.Debug("[NAMING] No column renames needed")
 		return nil
 	}
-
 	// Log the column mappings
-	for src, dest := range columnMapping {
+	for src, dest := range renames {
 		config.Debug("[NAMING] Column rename: %s -> %s", src, dest)
 	}
-	fmt.Printf("Naming convention: %s (%d columns will be renamed)\n", namingConv.Name(), len(columnMapping))
+	for src := range drops {
+		config.Debug("[NAMING] Column drop (collides with later column): %s", src)
+		fmt.Printf("Naming collision: dropping column %q (a later column normalizes to the same name)\n", src)
+	}
+	if len(renames) > 0 {
+		fmt.Printf("Naming convention: %s (%d columns will be renamed)\n", namingConv.Name(), len(renames))
+	}
 
-	p.namingMapping = columnMapping
-	p.applyColumnMapping(sourceSchema, columnMapping)
+	p.namingMapping = renames
+	p.applyColumnMapping(sourceSchema, renames, drops)
 	return nil
 }
 
@@ -1051,39 +1056,69 @@ func (p *Pipeline) shortenLongIdentifiers(sourceSchema *schema.TableSchema) {
 		return
 	}
 	fmt.Printf("Identifier shortening: %d column(s) shortened to fit %d-byte limit\n", len(mapping), maxLen)
-	p.applyColumnMapping(sourceSchema, mapping)
+	p.applyColumnMapping(sourceSchema, mapping, nil)
 }
 
-// applyColumnMapping renames schema columns/PKs/incremental key and updates the column renamer.
-func (p *Pipeline) applyColumnMapping(s *schema.TableSchema, mapping map[string]string) {
+// applyColumnMapping mutates the schema to drop columns in `drops` and rename
+// the rest per `renames`. PKs, incremental key, and partition key follow the
+// same rules. The pipeline's columnRenamer is updated to compose this step
+// with any prior rename/drop steps so incoming batches are transformed in one
+// pass.
+func (p *Pipeline) applyColumnMapping(s *schema.TableSchema, renames map[string]string, drops map[string]bool) {
+	if len(drops) > 0 {
+		kept := make([]schema.Column, 0, len(s.Columns))
+		for _, col := range s.Columns {
+			if drops[col.Name] {
+				continue
+			}
+			kept = append(kept, col)
+		}
+		s.Columns = kept
+	}
+
 	for i := range s.Columns {
-		if newName, ok := mapping[s.Columns[i].Name]; ok {
+		if newName, ok := renames[s.Columns[i].Name]; ok {
 			s.Columns[i].Name = newName
 		}
 	}
 	for i, pk := range s.PrimaryKeys {
-		if newName, ok := mapping[pk]; ok {
+		if newName, ok := renames[pk]; ok {
 			s.PrimaryKeys[i] = newName
 		}
 	}
-	if newName, ok := mapping[s.IncrementalKey]; ok {
+	if newName, ok := renames[s.IncrementalKey]; ok {
 		s.IncrementalKey = newName
 	}
-	if newName, ok := mapping[s.PartitionBy]; ok {
+	if newName, ok := renames[s.PartitionBy]; ok {
 		s.PartitionBy = newName
 	}
 
-	// Compose with existing renamer: if A→B already exists and B→C is new, result is A→C.
+	// Compose with existing renamer. Assumes follow-on steps only rename and
+	// don't drop (true for shortenLongIdentifiers, the only current second-stage
+	// caller). With no new drops to translate, the composition reduces to:
+	//   - If old renamed A→B and this step renames B→C, then A → C.
+	//   - Otherwise old's rename A→B carries forward.
+	//   - Old's drops persist unchanged.
 	if p.columnRenamer != nil && p.columnRenamer.HasRenames() {
+		composedRenames := make(map[string]string, len(renames))
+		for k, v := range renames {
+			composedRenames[k] = v
+		}
 		for src, dst := range p.columnRenamer.Mapping() {
-			if newDst, ok := mapping[dst]; ok {
-				mapping[src] = newDst
+			if newDst, ok := composedRenames[dst]; ok {
+				composedRenames[src] = newDst
 			} else {
-				mapping[src] = dst
+				composedRenames[src] = dst
 			}
 		}
+		composedDrops := make(map[string]bool, len(p.columnRenamer.Drops()))
+		for d := range p.columnRenamer.Drops() {
+			composedDrops[d] = true
+		}
+		renames = composedRenames
+		drops = composedDrops
 	}
-	p.columnRenamer = transformer.NewColumnRenamer(mapping)
+	p.columnRenamer = transformer.NewColumnRenamerWithDrops(renames, drops)
 }
 
 func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1394,12 +1394,12 @@ func TestApplyColumnMappingComposition(t *testing.T) {
 
 // TestEndToEndRenamingWithCollisions exercises the full naming pipeline on a
 // realistic Arrow batch:
-//   1. setupNamingConvention with snake_case + collisions → renames last,
-//      drops earlier.
-//   2. shortenLongIdentifiers if any name exceeds the destination's limit →
-//      composed with naming's renamer.
-//   3. Renamer.Transform applied to a batch carrying ORIGINAL source column
-//      names → produces the expected output schema and data.
+//  1. setupNamingConvention with snake_case + collisions → renames last,
+//     drops earlier.
+//  2. shortenLongIdentifiers if any name exceeds the destination's limit →
+//     composed with naming's renamer.
+//  3. Renamer.Transform applied to a batch carrying ORIGINAL source column
+//     names → produces the expected output schema and data.
 //
 // This is the real downstream consumer's view: whatever the destination
 // receives is whatever this batch ends up looking like.
@@ -1463,10 +1463,10 @@ func TestEndToEndRenamingWithCollisions(t *testing.T) {
 		}
 		cols := []arrow.Array{
 			idB.NewArray(),
-			mkStr("A1", "A2"),       // userID — should be dropped
-			mkStr("B1", "B2"),       // userId — should be dropped
-			mkStr("C1", "C2"),       // user_ID — should be renamed to user_id, data preserved
-			mkStr("t1", "t2"),       // createdAt — should be renamed to created_at
+			mkStr("A1", "A2"), // userID — should be dropped
+			mkStr("B1", "B2"), // userId — should be dropped
+			mkStr("C1", "C2"), // user_ID — should be renamed to user_id, data preserved
+			mkStr("t1", "t2"), // createdAt — should be renamed to created_at
 		}
 		batch := array.NewRecordBatch(inputSchema, cols, 2)
 		for _, c := range cols {
@@ -1607,5 +1607,46 @@ func TestEndToEndRenamingWithCollisions(t *testing.T) {
 		// Renamer correctly drops original `created_at` and renames `createdAt`.
 		assert.True(t, p.columnRenamer.Drops()["created_at"])
 		assert.Equal(t, "created_at", p.columnRenamer.Mapping()["createdAt"])
+	})
+
+	t.Run("KeyReferencesRewrittenWhenWinnerIsAlreadySnakeCase", func(t *testing.T) {
+		src := schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "userId", DataType: schema.TypeString},
+				{Name: "user_id", DataType: schema.TypeString},
+			},
+			PrimaryKeys:    []string{"userId"},
+			IncrementalKey: "userId",
+			PartitionBy:    "userId",
+		}
+
+		p := &Pipeline{
+			config: &config.IngestConfig{
+				DestTable:    "users",
+				SchemaNaming: "snake_case",
+			},
+			dest: &mockDestination{scheme: "postgres"},
+		}
+
+		require.NoError(t, p.setupNamingConvention(context.Background(), &src))
+
+		// Schema: id + the surviving user_id (winner needed no rename).
+		gotCols := make([]string, len(src.Columns))
+		for i, c := range src.Columns {
+			gotCols[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "user_id"}, gotCols)
+
+		// All three key references rewritten from "userId" to "user_id" so
+		// they keep pointing at a column that actually exists.
+		assert.Equal(t, []string{"user_id"}, src.PrimaryKeys)
+		assert.Equal(t, "user_id", src.IncrementalKey)
+		assert.Equal(t, "user_id", src.PartitionBy)
+
+		// userId is dropped from batches; the rename entry is present so the
+		// PK/IK rewrite above can resolve it
+		assert.True(t, p.columnRenamer.Drops()["userId"])
+		assert.Equal(t, "user_id", p.columnRenamer.Mapping()["userId"])
 	})
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -6,19 +6,28 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockDestination struct {
 	destination.Destination
 	tableSchema *schema.TableSchema
+	scheme      string
 }
 
 func (m *mockDestination) GetTableSchema(_ context.Context, _ string) (*schema.TableSchema, error) {
 	return m.tableSchema, nil
+}
+
+func (m *mockDestination) GetScheme() string {
+	return m.scheme
 }
 
 func TestSetupNamingConvention(t *testing.T) {
@@ -1240,4 +1249,363 @@ func TestBuildBufferReaderTarget_EvolveScenario(t *testing.T) {
 	got := p.buildBufferReaderTarget(src, dest)
 
 	assertColumns(t, "fields", arrowFieldNames(got), []string{"age", "id", "name", "score", "email"})
+}
+
+func TestApplyColumnMapping(t *testing.T) {
+	t.Run("RenamesOnly", func(t *testing.T) {
+		p := &Pipeline{}
+		s := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id"},
+				{Name: "userId"},
+				{Name: "createdAt"},
+			},
+			PrimaryKeys:    []string{"userId"},
+			IncrementalKey: "createdAt",
+			PartitionBy:    "createdAt",
+		}
+		renames := map[string]string{
+			"userId":    "user_id",
+			"createdAt": "created_at",
+		}
+
+		p.applyColumnMapping(s, renames, nil)
+
+		got := make([]string, len(s.Columns))
+		for i, c := range s.Columns {
+			got[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "user_id", "created_at"}, got)
+		assert.Equal(t, []string{"user_id"}, s.PrimaryKeys)
+		assert.Equal(t, "created_at", s.IncrementalKey)
+		assert.Equal(t, "created_at", s.PartitionBy)
+		assert.True(t, p.columnRenamer.HasRenames())
+		assert.Equal(t, renames, p.columnRenamer.Mapping())
+	})
+
+	t.Run("DropOnlyTrulyRemovesColumn", func(t *testing.T) {
+		// No rename reclaims the dropped name → column truly disappears.
+		p := &Pipeline{}
+		s := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id"},
+				{Name: "ssn"},
+				{Name: "email"},
+			},
+		}
+		drops := map[string]bool{"ssn": true}
+
+		p.applyColumnMapping(s, nil, drops)
+
+		got := make([]string, len(s.Columns))
+		for i, c := range s.Columns {
+			got[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "email"}, got)
+		assert.True(t, p.columnRenamer.Drops()["ssn"])
+	})
+
+	t.Run("DropThenRenameRestoresName_KeyReferencesSurvive", func(t *testing.T) {
+		// `created_at` is dropped (collision loser) but the next step renames
+		// `createdAt → created_at`, restoring the name. The PK / incremental
+		// key / partition key all point at "created_at" and must keep working.
+		p := &Pipeline{}
+		s := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id"},
+				{Name: "created_at"},
+				{Name: "createdAt"},
+			},
+			PrimaryKeys:    []string{"created_at"},
+			IncrementalKey: "created_at",
+			PartitionBy:    "created_at",
+		}
+		renames := map[string]string{"createdAt": "created_at"}
+		drops := map[string]bool{"created_at": true}
+
+		p.applyColumnMapping(s, renames, drops)
+
+		got := make([]string, len(s.Columns))
+		for i, c := range s.Columns {
+			got[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "created_at"}, got)
+		assert.Equal(t, []string{"created_at"}, s.PrimaryKeys)
+		assert.Equal(t, "created_at", s.IncrementalKey)
+		assert.Equal(t, "created_at", s.PartitionBy)
+	})
+
+	t.Run("EmptyMapsAreNoop", func(t *testing.T) {
+		p := &Pipeline{}
+		s := &schema.TableSchema{
+			Columns: []schema.Column{{Name: "id"}, {Name: "name"}},
+		}
+		p.applyColumnMapping(s, nil, nil)
+
+		got := make([]string, len(s.Columns))
+		for i, c := range s.Columns {
+			got[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "name"}, got)
+		assert.False(t, p.columnRenamer.HasRenames())
+	})
+}
+
+func TestApplyColumnMappingComposition(t *testing.T) {
+	t.Run("OldDropPreservedAcrossSecondStep", func(t *testing.T) {
+		// Step 1: drop D.
+		// Step 2: rename X -> Y (no drops).
+		// Composed renamer: D still dropped, X still renamed.
+		// Mirrors the real flow: setupNamingConvention may drop columns,
+		// shortenLongIdentifiers only renames — composition must carry old
+		// drops forward across a rename-only second step.
+		p := &Pipeline{}
+		s := &schema.TableSchema{
+			Columns: []schema.Column{{Name: "X"}, {Name: "D"}, {Name: "Z"}},
+		}
+
+		p.applyColumnMapping(s, nil, map[string]bool{"D": true})
+		p.applyColumnMapping(s, map[string]string{"X": "Y"}, nil)
+
+		assert.True(t, p.columnRenamer.Drops()["D"])
+		assert.Equal(t, "Y", p.columnRenamer.Mapping()["X"])
+		got := make([]string, len(s.Columns))
+		for i, c := range s.Columns {
+			got[i] = c.Name
+		}
+		assert.Equal(t, []string{"Y", "Z"}, got)
+	})
+
+	t.Run("ChainedRenameThroughIntermediateName", func(t *testing.T) {
+		// Step 1: A -> B.
+		// Step 2: B -> C (no drops).
+		// Composed: A -> C.
+		p := &Pipeline{}
+		s := &schema.TableSchema{
+			Columns: []schema.Column{{Name: "A"}, {Name: "other"}},
+		}
+
+		p.applyColumnMapping(s, map[string]string{"A": "B"}, nil)
+		p.applyColumnMapping(s, map[string]string{"B": "C"}, nil)
+
+		assert.Equal(t, "C", p.columnRenamer.Mapping()["A"])
+	})
+}
+
+// TestEndToEndRenamingWithCollisions exercises the full naming pipeline on a
+// realistic Arrow batch:
+//   1. setupNamingConvention with snake_case + collisions → renames last,
+//      drops earlier.
+//   2. shortenLongIdentifiers if any name exceeds the destination's limit →
+//      composed with naming's renamer.
+//   3. Renamer.Transform applied to a batch carrying ORIGINAL source column
+//      names → produces the expected output schema and data.
+//
+// This is the real downstream consumer's view: whatever the destination
+// receives is whatever this batch ends up looking like.
+func TestEndToEndRenamingWithCollisions(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	t.Run("CollisionDropsEarlierAndRenamesLast", func(t *testing.T) {
+		// Source has 3 columns that all normalize to "user_id":
+		//   userID, userId, user_ID
+		// Under snake_case, the LAST (user_ID) wins, earlier two are dropped.
+		src := schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "userID", DataType: schema.TypeString},
+				{Name: "userId", DataType: schema.TypeString},
+				{Name: "user_ID", DataType: schema.TypeString},
+				{Name: "createdAt", DataType: schema.TypeString},
+			},
+		}
+
+		p := &Pipeline{
+			config: &config.IngestConfig{
+				DestTable:    "users",
+				SchemaNaming: "snake_case",
+			},
+			dest: &mockDestination{scheme: "postgres"}, // 63-char limit
+		}
+
+		if err := p.setupNamingConvention(context.Background(), &src); err != nil {
+			t.Fatalf("setupNamingConvention: %v", err)
+		}
+		p.shortenLongIdentifiers(&src)
+
+		// Schema after naming: collision losers gone, winner renamed.
+		gotCols := make([]string, len(src.Columns))
+		for i, c := range src.Columns {
+			gotCols[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "user_id", "created_at"}, gotCols)
+
+		// Build an incoming batch with the ORIGINAL source column names + values.
+		// id=[1,2], userID="A1"/"A2", userId="B1"/"B2", user_ID="C1"/"C2", createdAt=t1/t2.
+		fields := []arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+			{Name: "userID", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "userId", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "user_ID", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "createdAt", Type: arrow.BinaryTypes.String, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		idB := array.NewInt64Builder(pool)
+		defer idB.Release()
+		idB.AppendValues([]int64{1, 2}, nil)
+
+		mkStr := func(vals ...string) arrow.Array {
+			b := array.NewStringBuilder(pool)
+			defer b.Release()
+			b.AppendValues(vals, nil)
+			return b.NewArray()
+		}
+		cols := []arrow.Array{
+			idB.NewArray(),
+			mkStr("A1", "A2"),       // userID — should be dropped
+			mkStr("B1", "B2"),       // userId — should be dropped
+			mkStr("C1", "C2"),       // user_ID — should be renamed to user_id, data preserved
+			mkStr("t1", "t2"),       // createdAt — should be renamed to created_at
+		}
+		batch := array.NewRecordBatch(inputSchema, cols, 2)
+		for _, c := range cols {
+			c.Release()
+		}
+		defer batch.Release()
+
+		out, err := p.columnRenamer.Transform(batch)
+		require.NoError(t, err)
+		defer out.Release()
+
+		// Output schema: id, user_id, created_at (in that order).
+		require.Equal(t, int64(3), out.NumCols())
+		assert.Equal(t, "id", out.Schema().Field(0).Name)
+		assert.Equal(t, "user_id", out.Schema().Field(1).Name)
+		assert.Equal(t, "created_at", out.Schema().Field(2).Name)
+
+		// user_id carries user_ID's data (C1/C2), NOT userID/userId.
+		userIDOut, ok := out.Column(1).(*array.String)
+		require.True(t, ok)
+		assert.Equal(t, "C1", userIDOut.Value(0))
+		assert.Equal(t, "C2", userIDOut.Value(1))
+
+		// created_at carries createdAt's data.
+		createdAtOut, ok := out.Column(2).(*array.String)
+		require.True(t, ok)
+		assert.Equal(t, "t1", createdAtOut.Value(0))
+		assert.Equal(t, "t2", createdAtOut.Value(1))
+	})
+
+	t.Run("ShorteningComposesWithNaming", func(t *testing.T) {
+		// Pick a column whose snake_case form exceeds Postgres's 63-char limit
+		// so the second-stage shortening fires AND has to compose with the
+		// naming renamer from the first stage.
+		longCamel := "thisIsAReallyVeryLongCamelCaseColumnNameThatExceedsTheSixtyThreeCharacterLimit"
+		// (snake_case form is even longer — guaranteed over 63.)
+
+		src := schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: longCamel, DataType: schema.TypeString},
+			},
+		}
+
+		p := &Pipeline{
+			config: &config.IngestConfig{
+				DestTable:    "things",
+				SchemaNaming: "snake_case",
+			},
+			dest: &mockDestination{scheme: "postgres"},
+		}
+
+		require.NoError(t, p.setupNamingConvention(context.Background(), &src))
+		p.shortenLongIdentifiers(&src)
+
+		// Confirm shortening kicked in for the long column.
+		require.Equal(t, 2, len(src.Columns))
+		assert.Equal(t, "id", src.Columns[0].Name)
+		shortened := src.Columns[1].Name
+		assert.LessOrEqual(t, len(shortened), 63, "shortened name must fit Postgres limit")
+		assert.NotEqual(t, longCamel, shortened, "must differ from original")
+
+		// Run a batch through the composed renamer. Incoming batch uses the
+		// ORIGINAL source name (longCamel) — composition must rewrite that
+		// directly to the shortened name in one pass.
+		fields := []arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+			{Name: longCamel, Type: arrow.BinaryTypes.String, Nullable: true},
+		}
+		idB := array.NewInt64Builder(pool)
+		defer idB.Release()
+		idB.AppendValues([]int64{1}, nil)
+		valB := array.NewStringBuilder(pool)
+		defer valB.Release()
+		valB.AppendValues([]string{"hello"}, nil)
+
+		cols := []arrow.Array{idB.NewArray(), valB.NewArray()}
+		batch := array.NewRecordBatch(arrow.NewSchema(fields, nil), cols, 1)
+		for _, c := range cols {
+			c.Release()
+		}
+		defer batch.Release()
+
+		out, err := p.columnRenamer.Transform(batch)
+		require.NoError(t, err)
+		defer out.Release()
+
+		require.Equal(t, int64(2), out.NumCols())
+		assert.Equal(t, "id", out.Schema().Field(0).Name)
+		assert.Equal(t, shortened, out.Schema().Field(1).Name,
+			"composed renamer must rewrite original source name directly to shortened name")
+
+		// Data preserved.
+		valOut, ok := out.Column(1).(*array.String)
+		require.True(t, ok)
+		assert.Equal(t, "hello", valOut.Value(0))
+	})
+
+	t.Run("PrimaryKeyAndIncrementalKeySurviveCollision", func(t *testing.T) {
+		// Source columns collide (created_at + createdAt → created_at), AND
+		// the dropped name is referenced as both PK and incremental key.
+		// The rename step restores the name with the winner's data, so the
+		// key references must remain intact.
+		src := schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "created_at", DataType: schema.TypeString},
+				{Name: "createdAt", DataType: schema.TypeString},
+			},
+			PrimaryKeys:    []string{"id", "created_at"},
+			IncrementalKey: "created_at",
+			PartitionBy:    "created_at",
+		}
+
+		p := &Pipeline{
+			config: &config.IngestConfig{
+				DestTable:    "events",
+				SchemaNaming: "snake_case",
+			},
+			dest: &mockDestination{scheme: "postgres"},
+		}
+
+		require.NoError(t, p.setupNamingConvention(context.Background(), &src))
+
+		// Key references still resolve — the dropped column's name was
+		// reclaimed by the rename.
+		assert.Equal(t, []string{"id", "created_at"}, src.PrimaryKeys)
+		assert.Equal(t, "created_at", src.IncrementalKey)
+		assert.Equal(t, "created_at", src.PartitionBy)
+
+		// Schema has the survivors.
+		gotCols := make([]string, len(src.Columns))
+		for i, c := range src.Columns {
+			gotCols[i] = c.Name
+		}
+		assert.Equal(t, []string{"id", "created_at"}, gotCols)
+
+		// Renamer correctly drops original `created_at` and renames `createdAt`.
+		assert.True(t, p.columnRenamer.Drops()["created_at"])
+		assert.Equal(t, "created_at", p.columnRenamer.Mapping()["createdAt"])
+	})
 }

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ColumnRenamer renames columns in record batches, optionally dropping a
-// specified set of columns. 
+// specified set of columns.
 type ColumnRenamer struct {
 	mapping map[string]string // source name -> destination name
 	drops   map[string]bool   // source names to remove from each batch

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -5,39 +5,54 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-// ColumnRenamer renames columns in record batches based on a mapping.
+// ColumnRenamer renames columns in record batches, optionally dropping a
+// specified set of columns. 
 type ColumnRenamer struct {
 	mapping map[string]string // source name -> destination name
+	drops   map[string]bool   // source names to remove from each batch
 }
 
-// NewColumnRenamer creates a new ColumnRenamer with the specified column name mapping.
-// The mapping is from source column names to destination column names.
+// NewColumnRenamer creates a ColumnRenamer that only renames columns.
 func NewColumnRenamer(mapping map[string]string) *ColumnRenamer {
-	return &ColumnRenamer{
-		mapping: mapping,
-	}
+	return &ColumnRenamer{mapping: mapping}
 }
 
-// Transform renames columns in the batch according to the mapping.
+// NewColumnRenamerWithDrops creates a ColumnRenamer that also drops columns
+// whose source name is in drops.
+func NewColumnRenamerWithDrops(mapping map[string]string, drops map[string]bool) *ColumnRenamer {
+	return &ColumnRenamer{mapping: mapping, drops: drops}
+}
+
+// Transform renames columns in the batch according to the mapping and removes
+// any column whose name is in the drop set.
 func (r *ColumnRenamer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, error) {
-	if len(r.mapping) == 0 {
+	if len(r.mapping) == 0 && len(r.drops) == 0 {
 		batch.Retain()
 		return batch, nil
 	}
 
-	// Build new schema with renamed fields
-	newSchema := r.OutputSchema(batch.Schema())
-
-	// Collect columns (retain references)
-	cols := make([]arrow.Array, batch.NumCols())
-	for i := 0; i < int(batch.NumCols()); i++ {
-		cols[i] = batch.Column(i)
-		cols[i].Retain()
+	inputSchema := batch.Schema()
+	fields := make([]arrow.Field, 0, inputSchema.NumFields())
+	cols := make([]arrow.Array, 0, inputSchema.NumFields())
+	for i, field := range inputSchema.Fields() {
+		if r.drops[field.Name] {
+			continue
+		}
+		if renamed, ok := r.mapping[field.Name]; ok {
+			field = arrow.Field{
+				Name:     renamed,
+				Type:     field.Type,
+				Nullable: field.Nullable,
+				Metadata: field.Metadata,
+			}
+		}
+		fields = append(fields, field)
+		col := batch.Column(i)
+		col.Retain()
+		cols = append(cols, col)
 	}
 
-	// Create new record batch with renamed schema
-	newBatch := array.NewRecordBatch(newSchema, cols, batch.NumRows())
-
+	newBatch := array.NewRecordBatch(arrow.NewSchema(fields, nil), cols, batch.NumRows())
 	// Release our references to the columns
 	for _, col := range cols {
 		col.Release()
@@ -46,35 +61,43 @@ func (r *ColumnRenamer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, e
 	return newBatch, nil
 }
 
-// OutputSchema returns the schema with renamed columns.
+// OutputSchema returns the schema with renamed columns; dropped columns are removed.
 func (r *ColumnRenamer) OutputSchema(inputSchema *arrow.Schema) *arrow.Schema {
-	if len(r.mapping) == 0 {
+	if len(r.mapping) == 0 && len(r.drops) == 0 {
 		return inputSchema
 	}
 
-	fields := make([]arrow.Field, len(inputSchema.Fields()))
-	for i, field := range inputSchema.Fields() {
-		newName := field.Name
+	fields := make([]arrow.Field, 0, len(inputSchema.Fields()))
+	for _, field := range inputSchema.Fields() {
+		if r.drops[field.Name] {
+			continue
+		}
 		if renamed, ok := r.mapping[field.Name]; ok {
-			newName = renamed
+			fields = append(fields, arrow.Field{
+				Name:     renamed,
+				Type:     field.Type,
+				Nullable: field.Nullable,
+				Metadata: field.Metadata,
+			})
+			continue
 		}
-		fields[i] = arrow.Field{
-			Name:     newName,
-			Type:     field.Type,
-			Nullable: field.Nullable,
-			Metadata: field.Metadata,
-		}
+		fields = append(fields, field)
 	}
 
 	return arrow.NewSchema(fields, nil)
 }
 
-// HasRenames returns true if any columns will be renamed.
+// HasRenames returns true if the renamer will modify any batch (rename or drop).
 func (r *ColumnRenamer) HasRenames() bool {
-	return len(r.mapping) > 0
+	return len(r.mapping) > 0 || len(r.drops) > 0
 }
 
-// Mapping returns the column name mapping.
+// Mapping returns the rename map.
 func (r *ColumnRenamer) Mapping() map[string]string {
 	return r.mapping
+}
+
+// Drops returns the drop set.
+func (r *ColumnRenamer) Drops() map[string]bool {
+	return r.drops
 }

--- a/pkg/transformer/column_renamer_test.go
+++ b/pkg/transformer/column_renamer_test.go
@@ -99,6 +99,63 @@ func TestColumnRenamer(t *testing.T) {
 		assert.Equal(t, mapping, renamer.Mapping())
 	})
 
+	t.Run("DropsColumnsViaExplicitDropSet", func(t *testing.T) {
+		// Drops are passed as a separate set, not encoded as empty-string targets.
+		mapping := map[string]string{
+			"createdAt": "created_at", // collide winner, renamed
+		}
+		drops := map[string]bool{
+			"created_at": true, // collide loser, dropped
+		}
+		renamer := NewColumnRenamerWithDrops(mapping, drops)
+
+		fields := []arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+			{Name: "created_at", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "createdAt", Type: arrow.BinaryTypes.String, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		idBuilder := array.NewInt64Builder(pool)
+		defer idBuilder.Release()
+		idBuilder.AppendValues([]int64{1, 2}, nil)
+
+		dropBuilder := array.NewStringBuilder(pool)
+		defer dropBuilder.Release()
+		dropBuilder.AppendValues([]string{"drop1", "drop2"}, nil)
+
+		keepBuilder := array.NewStringBuilder(pool)
+		defer keepBuilder.Release()
+		keepBuilder.AppendValues([]string{"keep1", "keep2"}, nil)
+
+		cols := []arrow.Array{idBuilder.NewArray(), dropBuilder.NewArray(), keepBuilder.NewArray()}
+		batch := array.NewRecordBatch(inputSchema, cols, 2)
+		for _, col := range cols {
+			col.Release()
+		}
+		defer batch.Release()
+
+		transformed, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer transformed.Release()
+
+		assert.Equal(t, int64(2), transformed.NumCols())
+		assert.Equal(t, "id", transformed.Schema().Field(0).Name)
+		assert.Equal(t, "created_at", transformed.Schema().Field(1).Name)
+
+		// Verify the surviving created_at carries the *renamed* column's data,
+		// not the dropped column's.
+		strCol, ok := transformed.Column(1).(*array.String)
+		require.True(t, ok)
+		assert.Equal(t, "keep1", strCol.Value(0))
+		assert.Equal(t, "keep2", strCol.Value(1))
+
+		outSchema := renamer.OutputSchema(inputSchema)
+		require.Equal(t, 2, len(outSchema.Fields()))
+		assert.Equal(t, "id", outSchema.Field(0).Name)
+		assert.Equal(t, "created_at", outSchema.Field(1).Name)
+	})
+
 	t.Run("OutputSchema", func(t *testing.T) {
 		mapping := map[string]string{"userId": "user_id"}
 		renamer := NewColumnRenamer(mapping)

--- a/tests/integration/naming_collision_drop_test.go
+++ b/tests/integration/naming_collision_drop_test.go
@@ -1,0 +1,139 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamingCollision_LastWinsEarlierDropped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	csv := "id,userID,userId,user_ID,createdAt\n" +
+		"1,A1,B1,C1,t1\n" +
+		"2,A2,B2,C2,t2\n"
+
+	csvPath := filepath.Join(tmpDir, "input.csv")
+	require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
+
+	duckDBPath := filepath.Join(tmpDir, "out.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           fmt.Sprintf("csv://%s", csvPath),
+		SourceTable:         "input",
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckDBPath),
+		DestTable:           "main.input",
+		IncrementalStrategy: config.StrategyReplace,
+		SchemaNaming:        "snake_case",
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	types := readDuckDBColumnTypes(t, duckDBPath, "main.input")
+	require.Equal(t, 3, len(types), "got: %v", types)
+	assert.Contains(t, types, "id")
+	assert.Contains(t, types, "user_id")
+	assert.Contains(t, types, "created_at")
+	assert.NotContains(t, types, "userid", "userID or userId leaked through; both should be dropped") // duckdb lowercases to userid
+
+	assert.Equal(t, 2, readDuckDBRowCount(t, duckDBPath, "main.input"))
+
+	// Surviving user_id carries user_ID's data (C1/C2), not userID's (A1/A2)
+	// or userId's (B1/B2).
+	db := openDuckDBForTest(t, duckDBPath)
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query("SELECT id, user_id, created_at FROM main.input ORDER BY id")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	type row struct {
+		id        int
+		userID    string
+		createdAt string
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		var idBytes, userIDBytes, createdAtBytes sql.RawBytes
+		require.NoError(t, rows.Scan(&idBytes, &userIDBytes, &createdAtBytes))
+		_, err = fmt.Sscanf(string(idBytes), "%d", &r.id)
+		require.NoError(t, err)
+		r.userID = string(userIDBytes)
+		r.createdAt = string(createdAtBytes)
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+
+	require.Len(t, got, 2)
+	assert.Equal(t, 1, got[0].id)
+	assert.Equal(t, "C1", got[0].userID, "user_id must carry user_ID's data, not userID/userId")
+	assert.Equal(t, "t1", got[0].createdAt)
+	assert.Equal(t, 2, got[1].id)
+	assert.Equal(t, "C2", got[1].userID)
+	assert.Equal(t, "t2", got[1].createdAt)
+}
+
+func TestNamingCollision_WinnerAlreadyInSnakeCase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	csv := "id,FirstName,FirstNAME,First_Name,first_name\n" +
+		"1,camel,caps_tail,underscored,winner_1\n" +
+		"2,camel2,caps_tail2,underscored2,winner_2\n"
+
+	csvPath := filepath.Join(tmpDir, "input.csv")
+	require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
+
+	duckDBPath := filepath.Join(tmpDir, "out.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           fmt.Sprintf("csv://%s", csvPath),
+		SourceTable:         "input",
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckDBPath),
+		DestTable:           "main.input",
+		IncrementalStrategy: config.StrategyReplace,
+		SchemaNaming:        "snake_case",
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	types := readDuckDBColumnTypes(t, duckDBPath, "main.input")
+	require.Equal(t, 2, len(types), "expected [id, first_name]; got: %v", types)
+	assert.Contains(t, types, "id")
+	assert.Contains(t, types, "first_name")
+
+	// Row data: the winner is the last source column `first_name`.
+	db := openDuckDBForTest(t, duckDBPath)
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query("SELECT id, first_name FROM main.input ORDER BY id")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var pairs [][2]string
+	for rows.Next() {
+		var idB, nameB sql.RawBytes
+		require.NoError(t, rows.Scan(&idB, &nameB))
+		pairs = append(pairs, [2]string{string(idB), string(nameB)})
+	}
+	require.NoError(t, rows.Err())
+
+	require.Len(t, pairs, 2)
+	assert.Equal(t, "winner_1", pairs[0][1], "first_name must carry the LAST source column's data")
+	assert.Equal(t, "winner_2", pairs[1][1])
+}


### PR DESCRIPTION
## Summary

- When multiple source columns normalize to the same destination name under `snake_case` (e.g. `userID`, `userId`, `user_ID` all → `user_id`), the previous code passed all of them through and let the destination fail at `CREATE TABLE` with errors like `Field user_id already exists in schema`.
- Now the **last** source column in source order keeps the normalized name; **earlier** colliding columns are dropped from each batch. Matches dlt's last-write-wins semantics.

## What changed

- **`pkg/naming/detect.go`** — `BuildColumnMapping` returns `(renames, drops)`. Single reverse pass: walking from the last column to the first, the first time we see a normalized name is the winner; every later occurrence (= an earlier column in source order) goes into drops.
- **`pkg/transformer/column_renamer.go`** — `ColumnRenamer` now carries an explicit `drops map[string]bool` set in addition to the rename map. `NewColumnRenamerWithDrops` constructor. `Transform` / `OutputSchema` skip fields whose name is in drops. `HasRenames` returns true if either set is non-empty.
- **`pkg/pipeline/pipeline.go`** — `applyColumnMapping(s, renames, drops)` drops columns from `s.Columns` first, then renames the rest. Renamer composition handles the second `applyColumnMapping` call (from `shortenLongIdentifiers`): old's renames get rewritten so the composed renamer is keyed by original source names; old's drops are carried forward.