### PR TITLE
Coalesce name-colliding columns per row

### DIFF
--- a/pkg/naming/detect.go
+++ b/pkg/naming/detect.go
@@ -119,15 +119,37 @@ func normalizeForDetection(name string) string {
 	return strings.ToLower(name)
 }
 
-// BuildColumnMapping creates a mapping from source column names to destination column names
-// based on the naming convention.
-func BuildColumnMapping(sourceSchema *schema.TableSchema, convention NamingConvention) map[string]string {
-	mapping := make(map[string]string)
-	for _, col := range sourceSchema.Columns {
-		destName := convention.Normalize(col.Name)
-		if destName != col.Name {
-			mapping[col.Name] = destName
-		}
+// BuildColumnMapping computes how source columns must be transformed to honor
+// the naming convention.
+//
+// Returns:
+//   - renames: source column name → target name, for 1-to-1 renames.
+//   - merges:  target name → ordered source columns (in source order) that all
+//     normalize to the same target.
+func BuildColumnMapping(sourceSchema *schema.TableSchema, convention NamingConvention) (renames map[string]string, merges map[string][]string) {
+	renames = make(map[string]string)
+	merges = make(map[string][]string)
+	if sourceSchema == nil {
+		return renames, merges
 	}
-	return mapping
+
+	groups := make(map[string][]string)
+	for _, col := range sourceSchema.Columns {
+		target := convention.Normalize(col.Name)
+		groups[target] = append(groups[target], col.Name)
+	}
+
+	for target, names := range groups {
+		if len(names) == 1 {
+			if names[0] != target {
+				renames[names[0]] = target
+			}
+			continue
+		}
+		sources := make([]string, len(names))
+		copy(sources, names)
+		merges[target] = sources
+	}
+
+	return renames, merges
 }

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -243,20 +243,86 @@ func TestBuildColumnMapping(t *testing.T) {
 
 	t.Run("DirectReturnsEmptyMapping", func(t *testing.T) {
 		conv := Get(Direct)
-		mapping := BuildColumnMapping(sourceSchema, conv)
-		assert.Empty(t, mapping)
+		renames, merges := BuildColumnMapping(sourceSchema, conv)
+		assert.Empty(t, renames)
+		assert.Empty(t, merges)
 	})
 
 	t.Run("SnakeCaseReturnsMapping", func(t *testing.T) {
 		conv := Get(SnakeCase)
-		mapping := BuildColumnMapping(sourceSchema, conv)
+		renames, merges := BuildColumnMapping(sourceSchema, conv)
 
-		assert.Len(t, mapping, 2)
-		assert.Equal(t, "user_id", mapping["userId"])
-		assert.Equal(t, "created_at", mapping["createdAt"])
+		assert.Empty(t, merges)
+		assert.Len(t, renames, 2)
+		assert.Equal(t, "user_id", renames["userId"])
+		assert.Equal(t, "created_at", renames["createdAt"])
 		// user_name is already snake_case, so no mapping needed
-		_, exists := mapping["user_name"]
+		_, exists := renames["user_name"]
 		assert.False(t, exists)
+	})
+}
+
+func TestBuildColumnMappingCollisions(t *testing.T) {
+	conv := Get(SnakeCase)
+
+	t.Run("MultipleVariantsBecomeMergeGroup", func(t *testing.T) {
+		// userId, user_id, UserID all normalize to user_id → must coalesce per
+		// row rather than dropping data.
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "_id"},
+				{Name: "userId"},
+				{Name: "user_id"},
+				{Name: "UserID"},
+			},
+		}
+		renames, merges := BuildColumnMapping(sourceSchema, conv)
+
+		// Variants do not produce per-variant rename entries — merge is authoritative.
+		_, hasUserId := renames["userId"]
+		_, hasUserUnderscoreId := renames["user_id"]
+		_, hasUserID := renames["UserID"]
+		assert.False(t, hasUserId)
+		assert.False(t, hasUserUnderscoreId)
+		assert.False(t, hasUserID)
+
+		// _id has no collision and is already snake_case → no entry.
+		_, hasId := renames["_id"]
+		assert.False(t, hasId)
+
+		// Merge group preserves source order; last variant (UserID) wins ties.
+		assert.Equal(t, []string{"userId", "user_id", "UserID"}, merges["user_id"])
+	})
+
+	t.Run("SourceOrderPreserved", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "CreatedAt"},
+				{Name: "createdAt"},
+				{Name: "created_at"},
+			},
+		}
+		_, merges := BuildColumnMapping(sourceSchema, conv)
+		assert.Equal(t, []string{"CreatedAt", "createdAt", "created_at"}, merges["created_at"])
+	})
+
+	t.Run("NoCollisionsProducesNoMerges", func(t *testing.T) {
+		sourceSchema := &schema.TableSchema{
+			Columns: []schema.Column{
+				{Name: "userId"},
+				{Name: "createdAt"},
+			},
+		}
+		renames, merges := BuildColumnMapping(sourceSchema, conv)
+		assert.Empty(t, merges)
+		assert.Equal(t, "user_id", renames["userId"])
+		assert.Equal(t, "created_at", renames["createdAt"])
+	})
+
+	t.Run("NilSchemaReturnsEmptyMaps", func(t *testing.T) {
+		renames, merges := BuildColumnMapping(nil, conv)
+		assert.Empty(t, renames)
+		assert.Empty(t, merges)
 	})
 }
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -579,8 +579,15 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 // match). Ingestr/SCD2 metadata cols are skipped and dest-only cols get null-fill.
 func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.TableSchema) *arrow.Schema {
 	var renameMap map[string]string
+	var mergeMap map[string][]string
 	if p.columnRenamer != nil && p.columnRenamer.HasRenames() {
 		renameMap = p.columnRenamer.Mapping()
+		mergeMap = p.columnRenamer.Merges()
+	}
+
+	srcByOrigName := make(map[string]schema.Column, len(sourceSchema.Columns))
+	for _, c := range sourceSchema.Columns {
+		srcByOrigName[c.Name] = c
 	}
 
 	srcByDestName := make(map[string]schema.Column, len(sourceSchema.Columns))
@@ -595,6 +602,18 @@ func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.Tabl
 	fields := make([]arrow.Field, 0, len(destSchema.Columns))
 	for _, dc := range destSchema.Columns {
 		if naming.IsIngestrColumn(dc.Name) || isSCD2MetadataColumn(dc.Name) {
+			continue
+		}
+		if variants, ok := mergeMap[dc.Name]; ok {
+			for _, sname := range variants {
+				sc, ok := srcByOrigName[sname]
+				if !ok {
+					continue
+				}
+				m := sc
+				m.DataType, m.Precision, m.Scale, m.ArrayType = dc.DataType, dc.Precision, dc.Scale, dc.ArrayType
+				fields = append(fields, arrowField(sname, m, true))
+			}
 			continue
 		}
 		if sc, ok := srcByDestName[dc.Name]; ok {
@@ -1026,21 +1045,27 @@ func (p *Pipeline) setupNamingConvention(ctx context.Context, sourceSchema *sche
 	namingConv := naming.Get(convention)
 	config.Debug("[NAMING] Using %s naming convention", namingConv.Name())
 
-	// Build column mapping
-	columnMapping := naming.BuildColumnMapping(sourceSchema, namingConv)
-	if len(columnMapping) == 0 {
+	// Build column mapping. When multiple source columns normalize to the same
+	// target name, they enter `merges` and are coalesced per row downstream.
+	renames, merges := naming.BuildColumnMapping(sourceSchema, namingConv)
+	if len(renames) == 0 && len(merges) == 0 {
 		config.Debug("[NAMING] No column renames needed")
 		return nil
 	}
 
-	// Log the column mappings
-	for src, dest := range columnMapping {
+	for src, dest := range renames {
 		config.Debug("[NAMING] Column rename: %s -> %s", src, dest)
 	}
-	fmt.Printf("Naming convention: %s (%d columns will be renamed)\n", namingConv.Name(), len(columnMapping))
+	for target, sources := range merges {
+		config.Debug("[NAMING] Column merge: %v -> %s (last-non-null wins per row)", sources, target)
+		fmt.Printf("Naming collision: merging %d variants into %q (last-non-null wins per row): %v\n", len(sources), target, sources)
+	}
+	if len(renames) > 0 {
+		fmt.Printf("Naming convention: %s (%d columns will be renamed)\n", namingConv.Name(), len(renames))
+	}
 
-	p.namingMapping = columnMapping
-	p.applyColumnMapping(sourceSchema, columnMapping)
+	p.namingMapping = renames
+	p.applyColumnMapping(sourceSchema, renames, merges)
 	return nil
 }
 
@@ -1051,39 +1076,96 @@ func (p *Pipeline) shortenLongIdentifiers(sourceSchema *schema.TableSchema) {
 		return
 	}
 	fmt.Printf("Identifier shortening: %d column(s) shortened to fit %d-byte limit\n", len(mapping), maxLen)
-	p.applyColumnMapping(sourceSchema, mapping)
+	p.applyColumnMapping(sourceSchema, mapping, nil)
 }
 
 // applyColumnMapping renames schema columns/PKs/incremental key and updates the column renamer.
-func (p *Pipeline) applyColumnMapping(s *schema.TableSchema, mapping map[string]string) {
+func (p *Pipeline) applyColumnMapping(s *schema.TableSchema, renames map[string]string, merges map[string][]string) {
+	if len(merges) > 0 {
+		// For each merge group, the LAST source variant wins: it takes the target
+		// name and stays in the schema; earlier variants are dropped here (their
+		// data is coalesced into the winner at runtime by the renamer).
+		targetOf := make(map[string]string)
+		isWinner := make(map[string]bool)
+		for target, sources := range merges {
+			if len(sources) == 0 {
+				continue
+			}
+			for _, src := range sources {
+				targetOf[src] = target
+			}
+			isWinner[sources[len(sources)-1]] = true
+		}
+
+		kept := s.Columns[:0]
+		for _, c := range s.Columns {
+			target, isVariant := targetOf[c.Name]
+			if isVariant && !isWinner[c.Name] {
+				continue
+			}
+			if isVariant {
+				c.Name = target
+			}
+			kept = append(kept, c)
+		}
+		s.Columns = kept
+
+		rewrite := func(name string) string {
+			if t, ok := targetOf[name]; ok {
+				return t
+			}
+			return name
+		}
+		for i, pk := range s.PrimaryKeys {
+			s.PrimaryKeys[i] = rewrite(pk)
+		}
+		s.IncrementalKey = rewrite(s.IncrementalKey)
+		s.PartitionBy = rewrite(s.PartitionBy)
+
+		if len(s.PrimaryKeys) > 1 {
+			seen := make(map[string]bool, len(s.PrimaryKeys))
+			deduped := s.PrimaryKeys[:0]
+			for _, pk := range s.PrimaryKeys {
+				if !seen[pk] {
+					seen[pk] = true
+					deduped = append(deduped, pk)
+				}
+			}
+			s.PrimaryKeys = deduped
+		}
+	}
+
 	for i := range s.Columns {
-		if newName, ok := mapping[s.Columns[i].Name]; ok {
+		if newName, ok := renames[s.Columns[i].Name]; ok {
 			s.Columns[i].Name = newName
 		}
 	}
 	for i, pk := range s.PrimaryKeys {
-		if newName, ok := mapping[pk]; ok {
+		if newName, ok := renames[pk]; ok {
 			s.PrimaryKeys[i] = newName
 		}
 	}
-	if newName, ok := mapping[s.IncrementalKey]; ok {
+	if newName, ok := renames[s.IncrementalKey]; ok {
 		s.IncrementalKey = newName
 	}
-	if newName, ok := mapping[s.PartitionBy]; ok {
+	if newName, ok := renames[s.PartitionBy]; ok {
 		s.PartitionBy = newName
 	}
 
 	// Compose with existing renamer: if A→B already exists and B→C is new, result is A→C.
 	if p.columnRenamer != nil && p.columnRenamer.HasRenames() {
 		for src, dst := range p.columnRenamer.Mapping() {
-			if newDst, ok := mapping[dst]; ok {
-				mapping[src] = newDst
+			if newDst, ok := renames[dst]; ok {
+				renames[src] = newDst
 			} else {
-				mapping[src] = dst
+				renames[src] = dst
 			}
 		}
+		if existing := p.columnRenamer.Merges(); len(existing) > 0 && len(merges) == 0 {
+			merges = existing
+		}
 	}
-	p.columnRenamer = transformer.NewColumnRenamer(mapping)
+	p.columnRenamer = transformer.NewColumnRenamerWithMerges(renames, merges)
 }
 
 func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -198,6 +198,7 @@ func TestSetupNamingConvention(t *testing.T) {
 		}
 	})
 }
+
 func TestSetupNamingConventionCollisionMerge(t *testing.T) {
 	src := schema.TableSchema{
 		Columns: []schema.Column{

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -198,6 +198,55 @@ func TestSetupNamingConvention(t *testing.T) {
 		}
 	})
 }
+func TestSetupNamingConventionCollisionMerge(t *testing.T) {
+	src := schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "_id", DataType: schema.TypeInt64},
+			{Name: "userId", DataType: schema.TypeInt64},
+			{Name: "user_id", DataType: schema.TypeInt64},
+			{Name: "UserID", DataType: schema.TypeInt64},
+		},
+	}
+
+	p := &Pipeline{
+		config: &config.IngestConfig{
+			DestTable:    "users",
+			SchemaNaming: "snake_case",
+		},
+		dest: &mockDestination{tableSchema: nil},
+	}
+
+	if err := p.setupNamingConvention(context.Background(), &src); err != nil {
+		t.Fatalf("setupNamingConvention() error = %v", err)
+	}
+
+	// Schema collapses to two columns: _id and user_id.
+	gotCols := src.ColumnNames()
+	wantCols := []string{"_id", "user_id"}
+	if len(gotCols) != len(wantCols) {
+		t.Fatalf("columns = %v, want %v", gotCols, wantCols)
+	}
+	for i, w := range wantCols {
+		if gotCols[i] != w {
+			t.Errorf("column[%d] = %q, want %q", i, gotCols[i], w)
+		}
+	}
+
+	// Renamer holds a merge group with all three variants in source order.
+	if p.columnRenamer == nil || !p.columnRenamer.HasRenames() {
+		t.Fatalf("expected column renamer with merges")
+	}
+	got := p.columnRenamer.Merges()["user_id"]
+	want := []string{"userId", "user_id", "UserID"}
+	if len(got) != len(want) {
+		t.Fatalf("merges[user_id] = %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("merges[user_id][%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
 
 func TestApplyColumnOverrides(t *testing.T) {
 	tests := []struct {

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -180,76 +180,56 @@ func coalesceColumns(batch arrow.RecordBatch, sources []string) (arrow.Array, er
 	}
 
 	pool := memory.NewGoAllocator()
-	builder := array.NewBuilder(pool, baseType)
-	defer builder.Release()
-
 	numRows := int(batch.NumRows())
+
+	winners := make([]int, numRows)
 	for row := 0; row < numRows; row++ {
-		var picked arrow.Array
+		winners[row] = -1
 		for i := len(columns) - 1; i >= 0; i-- {
 			c := columns[i]
 			if row < c.Len() && !c.IsNull(row) {
-				picked = c
+				winners[row] = i
 				break
 			}
 		}
-		if picked == nil {
-			builder.AppendNull()
-			continue
-		}
-		if err := appendArrayValue(builder, picked, row); err != nil {
-			return nil, err
-		}
 	}
-	return builder.NewArray(), nil
-}
 
-// appendArrayValue copies the value at `idx` from `src` into `dst`. Caller
-// must ensure src.DataType() == dst.Type().
-func appendArrayValue(dst array.Builder, src arrow.Array, idx int) error {
-	switch b := dst.(type) {
-	case *array.Int64Builder:
-		b.Append(src.(*array.Int64).Value(idx))
-	case *array.Int32Builder:
-		b.Append(src.(*array.Int32).Value(idx))
-	case *array.Int16Builder:
-		b.Append(src.(*array.Int16).Value(idx))
-	case *array.Int8Builder:
-		b.Append(src.(*array.Int8).Value(idx))
-	case *array.Uint64Builder:
-		b.Append(src.(*array.Uint64).Value(idx))
-	case *array.Uint32Builder:
-		b.Append(src.(*array.Uint32).Value(idx))
-	case *array.Uint16Builder:
-		b.Append(src.(*array.Uint16).Value(idx))
-	case *array.Uint8Builder:
-		b.Append(src.(*array.Uint8).Value(idx))
-	case *array.Float64Builder:
-		b.Append(src.(*array.Float64).Value(idx))
-	case *array.Float32Builder:
-		b.Append(src.(*array.Float32).Value(idx))
-	case *array.BooleanBuilder:
-		b.Append(src.(*array.Boolean).Value(idx))
-	case *array.StringBuilder:
-		b.Append(src.(*array.String).Value(idx))
-	case *array.LargeStringBuilder:
-		b.Append(src.(*array.LargeString).Value(idx))
-	case *array.BinaryBuilder:
-		b.Append(src.(*array.Binary).Value(idx))
-	case *array.TimestampBuilder:
-		b.Append(src.(*array.Timestamp).Value(idx))
-	case *array.Date32Builder:
-		b.Append(src.(*array.Date32).Value(idx))
-	case *array.Date64Builder:
-		b.Append(src.(*array.Date64).Value(idx))
-	case *array.Time32Builder:
-		b.Append(src.(*array.Time32).Value(idx))
-	case *array.Time64Builder:
-		b.Append(src.(*array.Time64).Value(idx))
-	case *array.Decimal128Builder:
-		b.Append(src.(*array.Decimal128).Value(idx))
-	default:
-		return fmt.Errorf("unsupported arrow type for coalesce: %s", dst.Type())
+	buildNullRun := func(n int) arrow.Array {
+		b := array.NewBuilder(pool, baseType)
+		defer b.Release()
+		for j := 0; j < n; j++ {
+			b.AppendNull()
+		}
+		return b.NewArray()
 	}
-	return nil
+
+	var slices []arrow.Array
+	releaseSlices := func() {
+		for _, s := range slices {
+			s.Release()
+		}
+	}
+
+	for i := 0; i < numRows; {
+		w := winners[i]
+		j := i + 1
+		for j < numRows && winners[j] == w {
+			j++
+		}
+		var s arrow.Array
+		if w == -1 {
+			s = buildNullRun(j - i)
+		} else {
+			s = array.NewSlice(columns[w], int64(i), int64(j))
+		}
+		slices = append(slices, s)
+		i = j
+	}
+
+	out, err := array.Concatenate(slices, pool)
+	releaseSlices()
+	if err != nil {
+		return nil, fmt.Errorf("concatenate coalesce slices: %w", err)
+	}
+	return out, nil
 }

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -182,6 +182,10 @@ func coalesceColumns(batch arrow.RecordBatch, sources []string) (arrow.Array, er
 	pool := memory.NewGoAllocator()
 	numRows := int(batch.NumRows())
 
+	if numRows == 0 {
+		return array.NewSlice(columns[len(columns)-1], 0, 0), nil
+	}
+
 	winners := make([]int, numRows)
 	for row := 0; row < numRows; row++ {
 		winners[row] = -1

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -108,7 +108,7 @@ func (r *ColumnRenamer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, e
 
 	newBatch := array.NewRecordBatch(arrow.NewSchema(fields, nil), cols, batch.NumRows())
 	// Release our references to the columns
- 	for _, col := range cols {
+	for _, col := range cols {
 		col.Release()
 	}
 

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -1,80 +1,255 @@
 package transformer
 
 import (
+	"fmt"
+
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 )
 
-// ColumnRenamer renames columns in record batches based on a mapping.
+// ColumnRenamer renames columns in record batches, and optionally coalesces
+// multiple source columns into a single target column when their normalized
+// names collide.
 type ColumnRenamer struct {
-	mapping map[string]string // source name -> destination name
+	mapping map[string]string   // source name → destination name (1-to-1)
+	merges  map[string][]string // target name → ordered source columns to coalesce
 }
 
-// NewColumnRenamer creates a new ColumnRenamer with the specified column name mapping.
-// The mapping is from source column names to destination column names.
+// NewColumnRenamer creates a renamer that only does 1-to-1 renames.
 func NewColumnRenamer(mapping map[string]string) *ColumnRenamer {
-	return &ColumnRenamer{
-		mapping: mapping,
-	}
+	return &ColumnRenamer{mapping: mapping}
 }
 
-// Transform renames columns in the batch according to the mapping.
+// NewColumnRenamerWithMerges creates a renamer that also coalesces colliding
+// source columns into a single target column.
+func NewColumnRenamerWithMerges(mapping map[string]string, merges map[string][]string) *ColumnRenamer {
+	return &ColumnRenamer{mapping: mapping, merges: merges}
+}
+
+// HasRenames returns true if any rename or merge will modify a batch.
+func (r *ColumnRenamer) HasRenames() bool {
+	return len(r.mapping) > 0 || len(r.merges) > 0
+}
+
+// Mapping returns the 1-to-1 rename map.
+func (r *ColumnRenamer) Mapping() map[string]string { return r.mapping }
+
+// Merges returns the merge groups (target → ordered source columns).
+func (r *ColumnRenamer) Merges() map[string][]string { return r.merges }
+
+type mergeBinding struct {
+	target   string
+	isWinner bool
+	sources  []string
+}
+
+func (r *ColumnRenamer) bindings() map[string]mergeBinding {
+	b := make(map[string]mergeBinding)
+	for target, sources := range r.merges {
+		if len(sources) == 0 {
+			continue
+		}
+		winner := sources[len(sources)-1]
+		for _, s := range sources {
+			b[s] = mergeBinding{target: target, isWinner: s == winner, sources: sources}
+		}
+	}
+	return b
+}
+
+// Transform produces a new record batch with columns renamed per the mapping
+// and merge groups coalesced into single columns.
 func (r *ColumnRenamer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, error) {
-	if len(r.mapping) == 0 {
+	if !r.HasRenames() {
 		batch.Retain()
 		return batch, nil
 	}
 
-	// Build new schema with renamed fields
-	newSchema := r.OutputSchema(batch.Schema())
+	bindings := r.bindings()
+	inputSchema := batch.Schema()
+	fields := make([]arrow.Field, 0, inputSchema.NumFields())
+	cols := make([]arrow.Array, 0, inputSchema.NumFields())
 
-	// Collect columns (retain references)
-	cols := make([]arrow.Array, batch.NumCols())
-	for i := 0; i < int(batch.NumCols()); i++ {
-		cols[i] = batch.Column(i)
-		cols[i].Retain()
+	for i, field := range inputSchema.Fields() {
+		if b, ok := bindings[field.Name]; ok {
+			if !b.isWinner {
+				continue
+			}
+			merged, err := coalesceColumns(batch, b.sources)
+			if err != nil {
+				for _, c := range cols {
+					c.Release()
+				}
+				return nil, fmt.Errorf("coalesce columns for %q: %w", b.target, err)
+			}
+			fields = append(fields, arrow.Field{
+				Name:     b.target,
+				Type:     merged.DataType(),
+				Nullable: true,
+			})
+			cols = append(cols, merged)
+			continue
+		}
+		name := field.Name
+		if renamed, ok := r.mapping[name]; ok {
+			name = renamed
+		}
+		fields = append(fields, arrow.Field{
+			Name:     name,
+			Type:     field.Type,
+			Nullable: field.Nullable,
+			Metadata: field.Metadata,
+		})
+		col := batch.Column(i)
+		col.Retain()
+		cols = append(cols, col)
 	}
 
-	// Create new record batch with renamed schema
-	newBatch := array.NewRecordBatch(newSchema, cols, batch.NumRows())
-
+	newBatch := array.NewRecordBatch(arrow.NewSchema(fields, nil), cols, batch.NumRows())
 	// Release our references to the columns
-	for _, col := range cols {
+ 	for _, col := range cols {
 		col.Release()
 	}
 
 	return newBatch, nil
 }
 
-// OutputSchema returns the schema with renamed columns.
+// OutputSchema returns the schema after rename and merge.
 func (r *ColumnRenamer) OutputSchema(inputSchema *arrow.Schema) *arrow.Schema {
-	if len(r.mapping) == 0 {
+	if !r.HasRenames() {
 		return inputSchema
 	}
 
-	fields := make([]arrow.Field, len(inputSchema.Fields()))
-	for i, field := range inputSchema.Fields() {
-		newName := field.Name
-		if renamed, ok := r.mapping[field.Name]; ok {
-			newName = renamed
+	bindings := r.bindings()
+	fields := make([]arrow.Field, 0, len(inputSchema.Fields()))
+	for _, field := range inputSchema.Fields() {
+		if b, ok := bindings[field.Name]; ok {
+			if !b.isWinner {
+				continue
+			}
+			fields = append(fields, arrow.Field{
+				Name:     b.target,
+				Type:     field.Type,
+				Nullable: true,
+				Metadata: field.Metadata,
+			})
+			continue
 		}
-		fields[i] = arrow.Field{
-			Name:     newName,
+		name := field.Name
+		if renamed, ok := r.mapping[name]; ok {
+			name = renamed
+		}
+		fields = append(fields, arrow.Field{
+			Name:     name,
 			Type:     field.Type,
 			Nullable: field.Nullable,
 			Metadata: field.Metadata,
-		}
+		})
 	}
-
 	return arrow.NewSchema(fields, nil)
 }
 
-// HasRenames returns true if any columns will be renamed.
-func (r *ColumnRenamer) HasRenames() bool {
-	return len(r.mapping) > 0
+// coalesceColumns picks values column-wise: per row, the LAST non-null value
+// across `sources` (in their original order) is taken. Result type follows the
+// last source's type — caller is responsible for ensuring all variants share a
+// compatible type.
+func coalesceColumns(batch arrow.RecordBatch, sources []string) (arrow.Array, error) {
+	inputSchema := batch.Schema()
+	columns := make([]arrow.Array, 0, len(sources))
+	for _, name := range sources {
+		idxs := inputSchema.FieldIndices(name)
+		if len(idxs) == 0 {
+			continue
+		}
+		columns = append(columns, batch.Column(idxs[0]))
+	}
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("no source columns present in batch")
+	}
+	if len(columns) == 1 {
+		columns[0].Retain()
+		return columns[0], nil
+	}
+
+	baseType := columns[len(columns)-1].DataType()
+	for i, col := range columns {
+		if !arrow.TypeEqual(col.DataType(), baseType) {
+			return nil, fmt.Errorf("type mismatch on variant %d: %s vs winner type %s", i, col.DataType(), baseType)
+		}
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewBuilder(pool, baseType)
+	defer builder.Release()
+
+	numRows := int(batch.NumRows())
+	for row := 0; row < numRows; row++ {
+		var picked arrow.Array
+		for i := len(columns) - 1; i >= 0; i-- {
+			c := columns[i]
+			if row < c.Len() && !c.IsNull(row) {
+				picked = c
+				break
+			}
+		}
+		if picked == nil {
+			builder.AppendNull()
+			continue
+		}
+		if err := appendArrayValue(builder, picked, row); err != nil {
+			return nil, err
+		}
+	}
+	return builder.NewArray(), nil
 }
 
-// Mapping returns the column name mapping.
-func (r *ColumnRenamer) Mapping() map[string]string {
-	return r.mapping
+// appendArrayValue copies the value at `idx` from `src` into `dst`. Caller
+// must ensure src.DataType() == dst.Type().
+func appendArrayValue(dst array.Builder, src arrow.Array, idx int) error {
+	switch b := dst.(type) {
+	case *array.Int64Builder:
+		b.Append(src.(*array.Int64).Value(idx))
+	case *array.Int32Builder:
+		b.Append(src.(*array.Int32).Value(idx))
+	case *array.Int16Builder:
+		b.Append(src.(*array.Int16).Value(idx))
+	case *array.Int8Builder:
+		b.Append(src.(*array.Int8).Value(idx))
+	case *array.Uint64Builder:
+		b.Append(src.(*array.Uint64).Value(idx))
+	case *array.Uint32Builder:
+		b.Append(src.(*array.Uint32).Value(idx))
+	case *array.Uint16Builder:
+		b.Append(src.(*array.Uint16).Value(idx))
+	case *array.Uint8Builder:
+		b.Append(src.(*array.Uint8).Value(idx))
+	case *array.Float64Builder:
+		b.Append(src.(*array.Float64).Value(idx))
+	case *array.Float32Builder:
+		b.Append(src.(*array.Float32).Value(idx))
+	case *array.BooleanBuilder:
+		b.Append(src.(*array.Boolean).Value(idx))
+	case *array.StringBuilder:
+		b.Append(src.(*array.String).Value(idx))
+	case *array.LargeStringBuilder:
+		b.Append(src.(*array.LargeString).Value(idx))
+	case *array.BinaryBuilder:
+		b.Append(src.(*array.Binary).Value(idx))
+	case *array.TimestampBuilder:
+		b.Append(src.(*array.Timestamp).Value(idx))
+	case *array.Date32Builder:
+		b.Append(src.(*array.Date32).Value(idx))
+	case *array.Date64Builder:
+		b.Append(src.(*array.Date64).Value(idx))
+	case *array.Time32Builder:
+		b.Append(src.(*array.Time32).Value(idx))
+	case *array.Time64Builder:
+		b.Append(src.(*array.Time64).Value(idx))
+	case *array.Decimal128Builder:
+		b.Append(src.(*array.Decimal128).Value(idx))
+	default:
+		return fmt.Errorf("unsupported arrow type for coalesce: %s", dst.Type())
+	}
+	return nil
 }

--- a/pkg/transformer/column_renamer_test.go
+++ b/pkg/transformer/column_renamer_test.go
@@ -232,4 +232,42 @@ func TestColumnRenamerCoalesce(t *testing.T) {
 		require.Equal(t, 1, out.NumFields())
 		assert.Equal(t, "target", out.Field(0).Name)
 	})
+
+	t.Run("CoalesceWorksForFixedSizeBinary", func(t *testing.T) {
+		fsbType := &arrow.FixedSizeBinaryType{ByteWidth: 4}
+		fields := []arrow.Field{
+			{Name: "a", Type: fsbType, Nullable: true},
+			{Name: "b", Type: fsbType, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		aB := array.NewFixedSizeBinaryBuilder(pool, fsbType)
+		defer aB.Release()
+		aB.AppendValues([][]byte{{0x01, 0x02, 0x03, 0x04}, nil}, []bool{true, false})
+
+		bB := array.NewFixedSizeBinaryBuilder(pool, fsbType)
+		defer bB.Release()
+		bB.AppendValues([][]byte{nil, {0xAA, 0xBB, 0xCC, 0xDD}}, []bool{false, true})
+
+		cols := []arrow.Array{aB.NewArray(), bB.NewArray()}
+		batch := array.NewRecordBatch(inputSchema, cols, 2)
+		for _, c := range cols {
+			c.Release()
+		}
+		defer batch.Release()
+
+		renamer := NewColumnRenamerWithMerges(nil, map[string][]string{
+			"merged": {"a", "b"},
+		})
+
+		out, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer out.Release()
+
+		require.Equal(t, int64(1), out.NumCols())
+		got := out.Column(0).(*array.FixedSizeBinary)
+		require.Equal(t, 2, got.Len())
+		assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, got.Value(0))
+		assert.Equal(t, []byte{0xAA, 0xBB, 0xCC, 0xDD}, got.Value(1))
+	})
 }

--- a/pkg/transformer/column_renamer_test.go
+++ b/pkg/transformer/column_renamer_test.go
@@ -120,3 +120,116 @@ func TestColumnRenamer(t *testing.T) {
 		assert.False(t, outputSchema.Field(1).Nullable)
 	})
 }
+
+func TestColumnRenamerCoalesce(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	t.Run("LastNonNullPerRowWins", func(t *testing.T) {
+		fields := []arrow.Field{
+			{Name: "_id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "userId", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "user_id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "UserID", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		idB := array.NewInt64Builder(pool)
+		defer idB.Release()
+		idB.AppendValues([]int64{1, 2, 3, 4}, nil)
+
+		userIdB := array.NewInt64Builder(pool)
+		defer userIdB.Release()
+		userIdB.AppendValues([]int64{101, 0, 0, 401}, []bool{true, false, false, true})
+
+		userUnderscoreB := array.NewInt64Builder(pool)
+		defer userUnderscoreB.Release()
+		userUnderscoreB.AppendValues([]int64{0, 202, 0, 402}, []bool{false, true, false, true})
+
+		userIDB := array.NewInt64Builder(pool)
+		defer userIDB.Release()
+		userIDB.AppendValues([]int64{0, 0, 303, 403}, []bool{false, false, true, true})
+
+		cols := []arrow.Array{idB.NewArray(), userIdB.NewArray(), userUnderscoreB.NewArray(), userIDB.NewArray()}
+		batch := array.NewRecordBatch(inputSchema, cols, 4)
+		for _, c := range cols {
+			c.Release()
+		}
+		defer batch.Release()
+
+		renamer := NewColumnRenamerWithMerges(nil, map[string][]string{
+			"user_id": {"userId", "user_id", "UserID"},
+		})
+
+		out, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer out.Release()
+
+		// 2 columns: _id and the coalesced user_id (emitted at the winner's position).
+		require.Equal(t, int64(2), out.NumCols())
+		assert.Equal(t, "_id", out.Schema().Field(0).Name)
+		assert.Equal(t, "user_id", out.Schema().Field(1).Name)
+
+		got := out.Column(1).(*array.Int64)
+		require.Equal(t, 4, got.Len())
+		for _, idx := range []int{0, 1, 2, 3} {
+			assert.False(t, got.IsNull(idx), "row %d should be non-null", idx)
+		}
+		assert.Equal(t, int64(101), got.Value(0))
+		assert.Equal(t, int64(202), got.Value(1))
+		assert.Equal(t, int64(303), got.Value(2))
+		assert.Equal(t, int64(403), got.Value(3)) // last variant wins on the row that has all three
+	})
+
+	t.Run("AllNullRowStaysNull", func(t *testing.T) {
+		fields := []arrow.Field{
+			{Name: "a", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "b", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		aB := array.NewInt64Builder(pool)
+		defer aB.Release()
+		aB.AppendValues([]int64{0, 0}, []bool{false, false})
+
+		bB := array.NewInt64Builder(pool)
+		defer bB.Release()
+		bB.AppendValues([]int64{0, 0}, []bool{false, false})
+
+		cols := []arrow.Array{aB.NewArray(), bB.NewArray()}
+		batch := array.NewRecordBatch(inputSchema, cols, 2)
+		for _, c := range cols {
+			c.Release()
+		}
+		defer batch.Release()
+
+		renamer := NewColumnRenamerWithMerges(nil, map[string][]string{
+			"merged": {"a", "b"},
+		})
+
+		out, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer out.Release()
+
+		require.Equal(t, int64(1), out.NumCols())
+		got := out.Column(0).(*array.Int64)
+		assert.True(t, got.IsNull(0))
+		assert.True(t, got.IsNull(1))
+	})
+
+	t.Run("OutputSchemaCollapsesMergeGroup", func(t *testing.T) {
+		fields := []arrow.Field{
+			{Name: "a", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "b", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "c", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		renamer := NewColumnRenamerWithMerges(nil, map[string][]string{
+			"target": {"a", "b", "c"},
+		})
+
+		out := renamer.OutputSchema(inputSchema)
+		require.Equal(t, 1, out.NumFields())
+		assert.Equal(t, "target", out.Field(0).Name)
+	})
+}

--- a/pkg/transformer/column_renamer_test.go
+++ b/pkg/transformer/column_renamer_test.go
@@ -233,6 +233,38 @@ func TestColumnRenamerCoalesce(t *testing.T) {
 		assert.Equal(t, "target", out.Field(0).Name)
 	})
 
+	t.Run("ZeroRowBatchReturnsEmptyArray", func(t *testing.T) {
+		fields := []arrow.Field{
+			{Name: "a", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "b", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		aB := array.NewInt64Builder(pool)
+		defer aB.Release()
+		bB := array.NewInt64Builder(pool)
+		defer bB.Release()
+
+		cols := []arrow.Array{aB.NewArray(), bB.NewArray()}
+		batch := array.NewRecordBatch(inputSchema, cols, 0)
+		for _, c := range cols {
+			c.Release()
+		}
+		defer batch.Release()
+
+		renamer := NewColumnRenamerWithMerges(nil, map[string][]string{
+			"merged": {"a", "b"},
+		})
+
+		out, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer out.Release()
+
+		require.Equal(t, int64(1), out.NumCols())
+		assert.Equal(t, "merged", out.Schema().Field(0).Name)
+		assert.Equal(t, int64(0), out.NumRows())
+	})
+
 	t.Run("CoalesceWorksForFixedSizeBinary", func(t *testing.T) {
 		fsbType := &arrow.FixedSizeBinaryType{ByteWidth: 4}
 		fields := []arrow.Field{


### PR DESCRIPTION
Coalesce name-colliding columns per row instead of dropping data

When multiple source columns normalize to the same destination name, this change collapses colliding variants into one destination column via per-row coalesce: each row picks the last non-null value across the variants in source order.

Example input:
  {_id: 1, userId: 101}
  {_id: 2, user_id: 202}
  {_id: 3, UserID: 303}
  {_id: 4, userId: 401, user_id: 402, UserID: 403}

Before:
  Field user_id already exists in schema, invalid
After:
  user_id = [101, 202, 303, 403]


Step-by-step flow
─────────────────

1. naming.BuildColumnMapping (pkg/naming/detect.go)

   Input  source columns: [_id, userId, user_id, UserID]
   Output renames:        {}
          merges:         {"user_id": ["userId", "user_id", "UserID"]}

   Single-source columns produce 1-to-1 renames; multi-source collisions produce a merges entry carrying the ordered variants. Last variant in source order is the canonical "winner".

2. pipeline.applyColumnMapping (pkg/pipeline/pipeline.go)

   Collapses merge groups in the schema:
     before: Columns      = [_id, userId, user_id, UserID]
     after:  Columns      = [_id, user_id]

   Redirects PK/IK/Partition refs that pointed at any variant:
     PrimaryKeys=["userId"]  →  PrimaryKeys=["user_id"]

   Dedupes PKs after redirect so two variant refs don't collapse into "PRIMARY KEY (user_id, user_id)".

3. pipeline.buildBufferReaderTarget (pkg/pipeline/pipeline.go)

   The destination schema has only [_id, user_id], but the buffer files hold the raw variant columns. Fans merge-target dest columns back out to N source-variant fields so the buffer reader replays all variants:

     destSchema:          [_id, user_id]
     buffer-reader target: [_id, userId, user_id, UserID]

4. ColumnRenamer.Transform + coalesceColumns (pkg/transformer/...)

   Per replayed batch, for each merge group: scan variants right to-left per row, take the first non-null. Emit one coalesced output column at the winner's position.

   Replayed batch in:
     _id   userId   user_id   UserID
      1     101      null      null
      2     null     202       null
      3     null     null      303
      4     401      402       403

   Per-row coalesce (winner UserID checked first, then user_id, then userId):
     row 1: UserID=null, user_id=null, userId=101  → 101
     row 2: UserID=null, user_id=202               → 202
     row 3: UserID=303                              → 303
     row 4: UserID=403                              → 403

   Output batch:
     _id   user_id
      1     101
      2     202
      3     303
      4     403

