### PR TITLE
fix(snowflake): align case-insensitivity and decimal handling for case-folding destinations

### DIFF
--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -580,6 +580,8 @@ func AppendValue(builder array.Builder, val interface{}) {
 			}
 		case *big.Int:
 			b.Append(decimal128.FromBigInt(v))
+		case json.Number:
+			AppendValue(b, string(v))
 		default:
 			b.AppendNull()
 		}

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -283,12 +283,6 @@ func TestAppendValue_TimestampBuilder(t *testing.T) {
 	}
 }
 
-// Regression: Decimal128Builder was the only numeric builder in this file
-// missing a json.Number branch. Schema-inferred sources (JSONL, MongoDB)
-// decode JSON numbers as json.Number via UseNumber(); any DECIMAL/NUMERIC
-// destination column silently received NULL through that path. The
-// delegation to the existing string branch must also inherit the
-// big.Float fallback for scientific notation.
 func TestAppendValue_Decimal128_JSONNumber(t *testing.T) {
 	dt := &arrow.Decimal128Type{Precision: 38, Scale: 0}
 
@@ -296,12 +290,12 @@ func TestAppendValue_Decimal128_JSONNumber(t *testing.T) {
 		name     string
 		val      json.Number
 		wantNull bool
-		wantBigI string // decimal representation expected via BigInt()
+		wantBigI string
 	}{
 		{name: "simple integer", val: json.Number("1"), wantBigI: "1"},
 		{name: "large positive", val: json.Number("42"), wantBigI: "42"},
 		{name: "negative", val: json.Number("-7"), wantBigI: "-7"},
-		{name: "scientific notation (uses big.Float fallback)", val: json.Number("1.5e10"), wantBigI: "15000000000"},
+		{name: "scientific notation", val: json.Number("1.5e10"), wantBigI: "15000000000"},
 		{name: "empty string", val: json.Number(""), wantNull: true},
 		{name: "garbage", val: json.Number("xyz"), wantNull: true},
 	}

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
@@ -278,6 +279,48 @@ func TestAppendValue_TimestampBuilder(t *testing.T) {
 					time.UnixMicro(got).UTC().Format(time.RFC3339Nano),
 					time.UnixMicro(tt.wantUsec).UTC().Format(time.RFC3339Nano))
 			}
+		})
+	}
+}
+
+// Regression: Decimal128Builder was the only numeric builder in this file
+// missing a json.Number branch. Schema-inferred sources (JSONL, MongoDB)
+// decode JSON numbers as json.Number via UseNumber(); any DECIMAL/NUMERIC
+// destination column silently received NULL through that path. The
+// delegation to the existing string branch must also inherit the
+// big.Float fallback for scientific notation.
+func TestAppendValue_Decimal128_JSONNumber(t *testing.T) {
+	dt := &arrow.Decimal128Type{Precision: 38, Scale: 0}
+
+	tests := []struct {
+		name     string
+		val      json.Number
+		wantNull bool
+		wantBigI string // decimal representation expected via BigInt()
+	}{
+		{name: "simple integer", val: json.Number("1"), wantBigI: "1"},
+		{name: "large positive", val: json.Number("42"), wantBigI: "42"},
+		{name: "negative", val: json.Number("-7"), wantBigI: "-7"},
+		{name: "scientific notation (uses big.Float fallback)", val: json.Number("1.5e10"), wantBigI: "15000000000"},
+		{name: "empty string", val: json.Number(""), wantNull: true},
+		{name: "garbage", val: json.Number("xyz"), wantNull: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := array.NewDecimal128Builder(memory.NewGoAllocator(), dt)
+			AppendValue(b, tt.val)
+			arr := b.NewArray().(*array.Decimal128)
+			defer arr.Release()
+
+			require.Equal(t, 1, arr.Len())
+			if tt.wantNull {
+				assert.True(t, arr.IsNull(0), "expected null for input %q", string(tt.val))
+				return
+			}
+			assert.False(t, arr.IsNull(0), "got null for input %q", string(tt.val))
+			gotBigI := decimal128.Num(arr.Value(0)).BigInt().String()
+			assert.Equal(t, tt.wantBigI, gotBigI)
 		})
 	}
 }

--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -194,13 +195,13 @@ func CastRecordToSchema(record arrow.RecordBatch, targetSchema *arrow.Schema, sa
 
 	existingCols := make(map[string]arrow.Array)
 	for i := 0; i < int(record.NumCols()); i++ {
-		existingCols[record.Schema().Field(i).Name] = record.Column(i)
+		existingCols[strings.ToLower(record.Schema().Field(i).Name)] = record.Column(i)
 	}
 
 	cols := make([]arrow.Array, targetSchema.NumFields())
 	for i := 0; i < targetSchema.NumFields(); i++ {
 		field := targetSchema.Field(i)
-		existingCol, ok := existingCols[field.Name]
+		existingCol, ok := existingCols[strings.ToLower(field.Name)]
 		if !ok {
 			nullArray, err := makeNullArray(mem, field.Type, int(numRows))
 			if err != nil {

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -664,10 +664,6 @@ func TestCastRecordToSchema(t *testing.T) {
 	})
 
 	t.Run("matches case-insensitively (uppercase target → lowercase source)", func(t *testing.T) {
-		// Snowflake's GetTableSchema returns column names uppercased.
-		// The buffer file holds records written with the source's casing
-		// (lowercase from JSONL inference). Without case-insensitive
-		// matching every column would miss the lookup and be null-filled.
 		sourceSchema := arrow.NewSchema([]arrow.Field{
 			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
@@ -698,8 +694,8 @@ func TestCastRecordToSchema(t *testing.T) {
 		defer casted.Release()
 
 		idCol := casted.Column(0).(*array.Int64)
-		assert.Equal(t, int64(1), idCol.Value(0), "id values must be preserved across case-insensitive match")
-		assert.Equal(t, 0, idCol.NullN(), "no nulls expected — case-sensitive lookup would have produced all-null array")
+		assert.Equal(t, int64(1), idCol.Value(0))
+		assert.Equal(t, 0, idCol.NullN())
 
 		nameCol := casted.Column(1).(*array.String)
 		assert.Equal(t, "alice", nameCol.Value(0))

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -662,6 +662,49 @@ func TestCastRecordToSchema(t *testing.T) {
 		nameCol := casted.Column(1).(*array.String)
 		assert.Equal(t, "alice", nameCol.Value(0))
 	})
+
+	t.Run("matches case-insensitively (uppercase target → lowercase source)", func(t *testing.T) {
+		// Snowflake's GetTableSchema returns column names uppercased.
+		// The buffer file holds records written with the source's casing
+		// (lowercase from JSONL inference). Without case-insensitive
+		// matching every column would miss the lookup and be null-filled.
+		sourceSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		}, nil)
+
+		targetSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "ID", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "NAME", Type: arrow.BinaryTypes.String, Nullable: true},
+		}, nil)
+
+		idBuilder := array.NewInt64Builder(mem)
+		idBuilder.AppendValues([]int64{1, 2, 3}, nil)
+		idArr := idBuilder.NewArray()
+		idBuilder.Release()
+
+		nameBuilder := array.NewStringBuilder(mem)
+		nameBuilder.AppendValues([]string{"alice", "bob", "carol"}, nil)
+		nameArr := nameBuilder.NewArray()
+		nameBuilder.Release()
+
+		record := array.NewRecordBatch(sourceSchema, []arrow.Array{idArr, nameArr}, 3)
+		idArr.Release()
+		nameArr.Release()
+		defer record.Release()
+
+		casted, err := CastRecordToSchema(record, targetSchema, true)
+		require.NoError(t, err)
+		defer casted.Release()
+
+		idCol := casted.Column(0).(*array.Int64)
+		assert.Equal(t, int64(1), idCol.Value(0), "id values must be preserved across case-insensitive match")
+		assert.Equal(t, 0, idCol.NullN(), "no nulls expected — case-sensitive lookup would have produced all-null array")
+
+		nameCol := casted.Column(1).(*array.String)
+		assert.Equal(t, "alice", nameCol.Value(0))
+		assert.Equal(t, 0, nameCol.NullN())
+	})
 }
 
 // ============================================================================

--- a/pkg/destination/scd2_columns.go
+++ b/pkg/destination/scd2_columns.go
@@ -1,6 +1,9 @@
 package destination
 
-import "slices"
+import (
+	"slices"
+	"strings"
+)
 
 // SCD2 metadata column names. Strategies and destinations must agree on these.
 const (
@@ -25,13 +28,15 @@ func SCD2NonDataColumns(primaryKeys []string) []string {
 }
 
 // AppendSCD2Columns appends the SCD2 metadata column names to cols, skipping
-// any that are already present.
+// any that are already present (case-insensitive).
 func AppendSCD2Columns(cols []string) []string {
 	scd := SCD2MetadataColumns()
 	out := make([]string, len(cols), len(cols)+len(scd))
 	copy(out, cols)
 	for _, c := range scd {
-		if !slices.Contains(cols, c) {
+		if !slices.ContainsFunc(cols, func(existing string) bool {
+			return strings.EqualFold(existing, c)
+		}) {
 			out = append(out, c)
 		}
 	}

--- a/pkg/destination/scd2_columns_test.go
+++ b/pkg/destination/scd2_columns_test.go
@@ -111,9 +111,7 @@ func TestAppendSCD2Columns(t *testing.T) {
 			expected: []string{"_scd_is_current", "id", "_scd_valid_to", "_scd_valid_from"},
 		},
 		{
-			// Case-folding destinations (Snowflake) report SCD columns
-			// uppercased — must not get duplicated by appending lowercase.
-			name:     "scd columns present but uppercased (case-folding destination)",
+			name:     "scd columns present but uppercased",
 			input:    []string{"id", "_SCD_VALID_FROM", "_SCD_VALID_TO", "_SCD_IS_CURRENT"},
 			expected: []string{"id", "_SCD_VALID_FROM", "_SCD_VALID_TO", "_SCD_IS_CURRENT"},
 		},

--- a/pkg/destination/scd2_columns_test.go
+++ b/pkg/destination/scd2_columns_test.go
@@ -110,6 +110,18 @@ func TestAppendSCD2Columns(t *testing.T) {
 			input:    []string{"_scd_is_current", "id", "_scd_valid_to"},
 			expected: []string{"_scd_is_current", "id", "_scd_valid_to", "_scd_valid_from"},
 		},
+		{
+			// Case-folding destinations (Snowflake) report SCD columns
+			// uppercased — must not get duplicated by appending lowercase.
+			name:     "scd columns present but uppercased (case-folding destination)",
+			input:    []string{"id", "_SCD_VALID_FROM", "_SCD_VALID_TO", "_SCD_IS_CURRENT"},
+			expected: []string{"id", "_SCD_VALID_FROM", "_SCD_VALID_TO", "_SCD_IS_CURRENT"},
+		},
+		{
+			name:     "scd columns present in mixed case",
+			input:    []string{"id", "_Scd_Valid_From", "_scd_valid_to", "_SCD_IS_CURRENT"},
+			expected: []string{"id", "_Scd_Valid_From", "_scd_valid_to", "_SCD_IS_CURRENT"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -589,6 +589,7 @@ func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.Tabl
 		if r, ok := renameMap[key]; ok {
 			key = r
 		}
+		key = strings.ToLower(key)
 		srcByDestName[key] = append(srcByDestName[key], c)
 	}
 
@@ -597,7 +598,7 @@ func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.Tabl
 		if naming.IsIngestrColumn(dc.Name) || isSCD2MetadataColumn(dc.Name) {
 			continue
 		}
-		if sourceCols, ok := srcByDestName[dc.Name]; ok {
+		if sourceCols, ok := srcByDestName[strings.ToLower(dc.Name)]; ok {
 			for _, sc := range sourceCols {
 				m := sc
 				m.DataType, m.Precision, m.Scale, m.ArrayType = dc.DataType, dc.Precision, dc.Scale, dc.ArrayType

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1305,6 +1305,5 @@ func TestBuildBufferReaderTarget_CaseInsensitiveMatch(t *testing.T) {
 
 	got := p.buildBufferReaderTarget(src, dest)
 
-	// Source-case names so CastRecordToSchema can find them in the buffer file.
 	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1289,3 +1289,22 @@ func TestBuildBufferReaderTarget_EvolveScenario(t *testing.T) {
 
 	assertColumns(t, "fields", arrowFieldNames(got), []string{"age", "id", "name", "score", "email"})
 }
+
+func TestBuildBufferReaderTarget_CaseInsensitiveMatch(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"orders",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+	)
+	dest := tschema(
+		"orders",
+		tcol("ID", schema.TypeInt64),
+		tcol("NAME", schema.TypeString),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	// Source-case names so CastRecordToSchema can find them in the buffer file.
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
+}

--- a/pkg/strategy/interval_tracker.go
+++ b/pkg/strategy/interval_tracker.go
@@ -97,6 +97,18 @@ func extractValue(col arrow.Array, idx int) interface{} {
 		return arr.Value(idx)
 	case *array.Float32:
 		return float64(arr.Value(idx))
+	case *array.Decimal128:
+		dt, ok := arr.DataType().(*arrow.Decimal128Type)
+		if !ok {
+			return nil
+		}
+		return arr.Value(idx).ToFloat64(dt.Scale)
+	case *array.Decimal256:
+		dt, ok := arr.DataType().(*arrow.Decimal256Type)
+		if !ok {
+			return nil
+		}
+		return arr.Value(idx).ToFloat64(dt.Scale)
 	case *array.String:
 		return arr.Value(idx)
 	case *array.LargeString:

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -314,11 +314,6 @@ func TestIsNilInterface(t *testing.T) {
 	}
 }
 
-// Regression: when the buffer-reader types an incremental-key column as
-// Decimal128 (because the destination column is e.g. Snowflake NUMBER),
-// IntervalTracker must extract a comparable value. Without the Decimal128
-// case it returned nil → Min/Max stayed nil → the delete+insert strategy
-// hit its "no interval detected, skip" branch and never issued DELETE.
 func TestIntervalTracker_Decimal128_MinMax(t *testing.T) {
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	t.Cleanup(func() { pool.AssertSize(t, 0) })

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -310,5 +311,53 @@ func TestIsNilInterface(t *testing.T) {
 	}
 	if isNilInterface(0) {
 		t.Fatalf("expected int(0) not to be nil")
+	}
+}
+
+// Regression: when the buffer-reader types an incremental-key column as
+// Decimal128 (because the destination column is e.g. Snowflake NUMBER),
+// IntervalTracker must extract a comparable value. Without the Decimal128
+// case it returned nil → Min/Max stayed nil → the delete+insert strategy
+// hit its "no interval detected, skip" branch and never issued DELETE.
+func TestIntervalTracker_Decimal128_MinMax(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { pool.AssertSize(t, 0) })
+
+	dt := &arrow.Decimal128Type{Precision: 38, Scale: 0}
+	fields := []arrow.Field{{Name: "id", Type: dt, Nullable: true}}
+	schema := arrow.NewSchema(fields, nil)
+
+	b := array.NewDecimal128Builder(pool, dt)
+	defer b.Release()
+
+	b.Append(decimal128.FromI64(3))
+	b.Append(decimal128.FromI64(1))
+	b.AppendNull()
+	b.Append(decimal128.FromI64(7))
+	b.Append(decimal128.FromI64(5))
+	arr := b.NewArray()
+	defer arr.Release()
+
+	rec := array.NewRecordBatch(schema, []arrow.Array{arr}, 5)
+
+	tk := NewIntervalTracker("id")
+	in := mustClosedRecords(source.RecordBatchResult{Batch: rec})
+	out := tk.Wrap(in)
+	for res := range out {
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+	}
+
+	if tk.Min == nil || tk.Max == nil {
+		t.Fatalf("Min/Max should be set for Decimal128 column, got %v/%v", tk.Min, tk.Max)
+	}
+	minF, okMin := tk.Min.(float64)
+	maxF, okMax := tk.Max.(float64)
+	if !okMin || !okMax {
+		t.Fatalf("expected float64 bounds for Decimal128, got %T/%T", tk.Min, tk.Max)
+	}
+	if minF != 1 || maxF != 7 {
+		t.Fatalf("Min/Max = %v/%v, want 1/7", minF, maxF)
 	}
 }

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -165,14 +166,14 @@ func extendSchemaWithSCDColumns(original *schema.TableSchema) *schema.TableSchem
 		{Name: "_scd_is_current", DataType: schema.TypeBoolean, Nullable: false},
 	}
 
-	// Skip SCD columns that already exist.
+	// Skip SCD columns that already exist (case-insensitive).
 	existing := make(map[string]bool, len(original.Columns))
 	for _, c := range original.Columns {
-		existing[c.Name] = true
+		existing[strings.ToLower(c.Name)] = true
 	}
 	toAdd := make([]schema.Column, 0, len(scdColumns))
 	for _, c := range scdColumns {
-		if !existing[c.Name] {
+		if !existing[strings.ToLower(c.Name)] {
 			toAdd = append(toAdd, c)
 		}
 	}

--- a/pkg/strategy/scd2_test.go
+++ b/pkg/strategy/scd2_test.go
@@ -124,3 +124,33 @@ func TestSCD2Strategy_ExtendSchemaWithSCDColumns(t *testing.T) {
 		}
 	}
 }
+
+// Regression: when the destination already contains SCD metadata columns
+// but reports them in a different case (Snowflake stores unquoted
+// identifiers as UPPERCASE), the dedup must skip them — otherwise the
+// staging CREATE TABLE ends up with both "_SCD_VALID_FROM" and
+// "_scd_valid_from" and the database rejects it as a duplicate column.
+func TestSCD2Strategy_ExtendSchemaWithSCDColumns_CaseInsensitive(t *testing.T) {
+	original := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "_SCD_VALID_FROM", DataType: schema.TypeTimestampTZ, Nullable: false},
+			{Name: "_SCD_VALID_TO", DataType: schema.TypeTimestampTZ, Nullable: true},
+			{Name: "_SCD_IS_CURRENT", DataType: schema.TypeBoolean, Nullable: false},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+
+	extended := extendSchemaWithSCDColumns(original)
+
+	// No new columns should be appended; the existing uppercase ones cover all three.
+	assert.Equal(t, 5, len(extended.Columns), "uppercase SCD cols must dedup against lowercase constants")
+
+	colNames := make([]string, len(extended.Columns))
+	for i, col := range extended.Columns {
+		colNames[i] = col.Name
+	}
+	// Exact column set is preserved — no lowercase duplicates added.
+	assert.Equal(t, []string{"id", "name", "_SCD_VALID_FROM", "_SCD_VALID_TO", "_SCD_IS_CURRENT"}, colNames)
+}

--- a/pkg/strategy/scd2_test.go
+++ b/pkg/strategy/scd2_test.go
@@ -125,11 +125,6 @@ func TestSCD2Strategy_ExtendSchemaWithSCDColumns(t *testing.T) {
 	}
 }
 
-// Regression: when the destination already contains SCD metadata columns
-// but reports them in a different case (Snowflake stores unquoted
-// identifiers as UPPERCASE), the dedup must skip them — otherwise the
-// staging CREATE TABLE ends up with both "_SCD_VALID_FROM" and
-// "_scd_valid_from" and the database rejects it as a duplicate column.
 func TestSCD2Strategy_ExtendSchemaWithSCDColumns_CaseInsensitive(t *testing.T) {
 	original := &schema.TableSchema{
 		Columns: []schema.Column{
@@ -144,13 +139,11 @@ func TestSCD2Strategy_ExtendSchemaWithSCDColumns_CaseInsensitive(t *testing.T) {
 
 	extended := extendSchemaWithSCDColumns(original)
 
-	// No new columns should be appended; the existing uppercase ones cover all three.
-	assert.Equal(t, 5, len(extended.Columns), "uppercase SCD cols must dedup against lowercase constants")
+	assert.Equal(t, 5, len(extended.Columns))
 
 	colNames := make([]string, len(extended.Columns))
 	for i, col := range extended.Columns {
 		colNames[i] = col.Name
 	}
-	// Exact column set is preserved — no lowercase duplicates added.
 	assert.Equal(t, []string{"id", "name", "_SCD_VALID_FROM", "_SCD_VALID_TO", "_SCD_IS_CURRENT"}, colNames)
 }


### PR DESCRIPTION
## Bug

On non-first runs against a Snowflake target, every non-`replace` strategy produced wrong data. Snowflake stores unquoted identifiers as UPPERCASE; the source emits lowercase; several layers in the pipeline compared names case-sensitively.

Throughout this writeup: **source columns are lowercase** (as the JSONL fixture produces them) and **destination/target table columns are UPPERCASE** (as Snowflake stores them after `CREATE TABLE` via `quoteIdentifier` which uppercases).

---

## `truncate+insert` — every column landed as NULL

**Source** (`JSONL`, 10 rows, lowercase keys):

| id | name | active | score |
|---|---|---|---|
| 1 | alpha | true | 10.5 |
| 2 | bravo | false | 20 |
| … | … | … | … |
| 10 | juliet | false | 100 |

**Target table** *(pre-seeded with 5 rows via `replace`, Snowflake stored as UPPERCASE)* after `truncate+insert`:

| ID | NAME | ACTIVE | SCORE | Before fix |  | ID | NAME | ACTIVE | SCORE | After fix |
|---|---|---|---|---|---|---|---|---|---|---|
| `null` | `null` | `null` | `null` | row 1 |  | 1 | alpha | true | 10.5 | row 1 |
| `null` | `null` | `null` | `null` | row 2 |  | 2 | bravo | false | 20 | row 2 |
| `null` | `null` | `null` | `null` | row 3 |  | 3 | charlie | true | 30.25 | row 3 |
| `null` | `null` | `null` | `null` | … |  | … | … | … | … | … |
| `null` | `null` | `null` | `null` | row 10 |  | 10 | juliet | false | 100 | row 10 |

10 rows landed either way, but **every column was NULL before the fix**.

---

## `delete+insert` — DELETE silently skipped, rows weren't replaced

**Initial seed** (10 rows from JSONL, ids `[1,2,3,4,5,6,8,9,10,11]`):

| id | name |
|---|---|
| 1 | v1-1 |
| 2 | v1-2 |
| 3 | v1-3 |
| … | … |

**Interval source** (5 rows, ids `[3,4,5,6,7]` — strategy should DELETE 3..7 then INSERT these):

| id | name |
|---|---|
| 3 | v2-3 |
| 4 | v2-4 |
| 5 | v2-5 |
| 6 | v2-6 |
| 7 | v2-7 |

**Target table** (Snowflake, UPPERCASE columns) after `delete+insert`:

| ID | NAME (Before fix) | NAME (After fix) |
|---|---|---|
| 1 | v1-1 | v1-1 |
| 2 | v1-2 | v1-2 |
| **3** | **v1-3** ← DELETE skipped, INSERT skipped | **v2-3** |
| **4** | **v1-4** ← stale | **v2-4** |
| 5 | v1-5 | v2-5 |
| 6 | v1-6 | v2-6 |
| **7** | *missing* — never inserted | **v2-7** |
| 8 | v1-8 | v1-8 |
| 9 | v1-9 | v1-9 |
| 10 | v1-10 | v1-10 |
| 11 | v1-11 | v1-11 |
| **Count** | **10** (expected 11) | **11** |

`IntervalTracker.extractValue` had no case for `*array.Decimal128` (Snowflake `NUMBER` incremental key) → returned `nil` → `Min/Max` never set → strategy hit "no interval detected, skip" → DELETE and INSERT both skipped.

---

## `scd2` — CREATE TABLE fails before any data is even read

**Existing target schema** *(returned by `GetTableSchema` — Snowflake stores them UPPERCASE)*:

| Column |
|---|
| `ID` |
| `NAME` |
| `_SCD_VALID_FROM` |
| `_SCD_VALID_TO` |
| `_SCD_IS_CURRENT` |

**The column list `extendSchemaWithSCDColumns` builds for the staging `CREATE TABLE`:**

| Before fix | After fix |
|---|---|
| `ID` | `ID` |
| `NAME` | `NAME` |
| `_SCD_VALID_FROM` *(existing, uppercase)* | `_SCD_VALID_FROM` |
| `_SCD_VALID_TO` *(existing)* | `_SCD_VALID_TO` |
| `_SCD_IS_CURRENT` *(existing)* | `_SCD_IS_CURRENT` |
| **`_scd_valid_from`** ← lowercase constant appended (case-sensitive dedup missed the existing uppercase one) | — |
| **`_scd_valid_to`** ← appended | — |
| **`_scd_is_current`** ← appended | — |

The Snowflake destination's `quoteIdentifier` then uppercases each name when emitting SQL, so the `CREATE TABLE` statement ends up with `"_SCD_VALID_FROM"` listed twice → Snowflake rejects:

```
002025 (42S21): SQL compilation error: duplicate column name '_SCD_VALID_FROM'
```

After the fix, dedup is case-insensitive: the lowercase constant matches the existing uppercase column → not re-appended → `CREATE TABLE` succeeds.

---

## `merge` / `append` — load job fails on NOT NULL primary key

**Source** (JSONL, lowercase):

| id | name | active | score |
|---|---|---|---|
| 1 | alpha | true | 10.5 |
| 2 | bravo | false | 20 |
| … | … | … | … |

**Records the buffer reader emits into staging** *(Arrow field names = staging table column names = UPPERCASE because the buggy `buildBufferReaderTarget` fell into its soft-deleted branch and used the dest-case name)*:

| ID | NAME | ACTIVE | SCORE | Before fix |  | ID | NAME | ACTIVE | SCORE | After fix |
|---|---|---|---|---|---|---|---|---|---|---|
| `null` | `null` | `null` | `null` | row 1 |  | 1 | alpha | true | 10.5 | row 1 |
| `null` | `null` | `null` | `null` | row 2 |  | 2 | bravo | false | 20 | row 2 |
| … | … | … | … | … |  | … | … | … | … | … |

`merge`/`append` then write those rows from staging into the target table where `ID` is `NOT NULL`:

|  | Before fix | After fix |
|---|---|---|
| Snowflake response | `100072 (22000): DML operation to table … failed on column ID with error: NULL result in a non-nullable column` | rows inserted / merged correctly |
| Strategy result | aborts | succeeds |

---

## Test plan

- [x] 7 new unit regression tests fail on `main`, pass with the fix
- [x] Full unit suite (`go test -short ./...`) passes
- [x] Full Snowflake conformance against a real account: 5 previously-failing tests now pass, no regressions
- [x] Full local integration suite passes (Postgres, MySQL, MSSQL, DuckDB, SQLite, CrateDB, CSV, Parquet, Discard)
- [x] Athena conformance against a real AWS account: passes
- [x] BigQuery conformance against a real GCP account: no new failures vs `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)