### PR TITLE
bigquery: retry load job on transient "Not found: Dataset"

### DIFF
--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -30,7 +30,7 @@ const (
 	stagedGCSObjectChunkSize   = 32 * 1024 * 1024
 	stagedGCSBufferSize        = 1 * 1024 * 1024
 	maxLocalLoadJobParallelism = 4
-	localLoadJobMaxAttempts    = 4
+	loadJobMaxAttempts         = 4
 )
 
 type loadJobFileFormat string
@@ -648,10 +648,7 @@ func (d *BigQueryDestination) runSingleLoadJob(
 	format loadJobFileFormat,
 	chunk stagedLoadChunk,
 ) error {
-	maxAttempts := 1
-	if chunk.localPath != "" {
-		maxAttempts = localLoadJobMaxAttempts
-	}
+	maxAttempts := loadJobMaxAttempts
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		config.Debug(
@@ -756,7 +753,8 @@ func isRetryableLoadJobError(err error) bool {
 		strings.Contains(msg, "quotaexceeded") ||
 		strings.Contains(msg, "exceeded rate limits") ||
 		strings.Contains(msg, "jobbackenderror") ||
-		strings.Contains(msg, "backenderror")
+		strings.Contains(msg, "backenderror") ||
+		strings.Contains(msg, "not found: dataset")
 }
 
 func isRetryableLoadJobReason(reason string, message string) bool {
@@ -766,6 +764,9 @@ func isRetryableLoadJobReason(reason string, message string) bool {
 	}
 
 	msg := strings.ToLower(message)
+	if strings.Contains(msg, "not found: dataset") {
+		return true
+	}
 	return strings.Contains(msg, "exceeded rate limits") ||
 		strings.Contains(msg, "retrying the job may solve the problem")
 }

--- a/pkg/destination/bigquery/load_job_test.go
+++ b/pkg/destination/bigquery/load_job_test.go
@@ -517,6 +517,21 @@ func TestIsRetryableLoadJobError(t *testing.T) {
 			err:  gcbq.Error{Reason: "internalError", Message: "internal"},
 			want: false,
 		},
+		{
+			name: "dataset not found (eventual consistency after staging dataset create)",
+			err:  gcbq.Error{Reason: "notFound", Message: "Not found: Dataset my-project:_bruin_staging"},
+			want: true,
+		},
+		{
+			name: "wrapped dataset not found",
+			err:  fmt.Errorf("wrapped: %w", &gcbq.Error{Reason: "notFound", Message: "Not found: Dataset my-project:_bruin_staging, notFound"}),
+			want: true,
+		},
+		{
+			name: "table not found stays non-retryable (real bug, not propagation)",
+			err:  gcbq.Error{Reason: "notFound", Message: "Not found: Table my-project:_bruin_staging.orders"},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Treat `Not found: Dataset` as a retryable load-job error.
- Apply the same 4-attempt retry budget to GCS-staged chunks that local-file chunks already had.

## Why

When `PrepareTable` creates `_bruin_staging` and immediately fires the load job, BigQuery's job-submission endpoint can briefly fail to see the freshly-created dataset (eventual consistency). Previously, GCS-staged chunks ran with `maxAttempts = 1` and `notFound` was not in the retryable set, so a single propagation 404 failed the entire run with:

```
failed to start load job for chunk 1: googleapi: Error 404:
Not found: Dataset <project>:_bruin_staging, notFound
```

This is the failure mode that bit a customer on a `replace --full-refresh` run.

## What changed

`pkg/destination/bigquery/load_job.go`:

- Renamed `localLoadJobMaxAttempts` → `loadJobMaxAttempts`; dropped the local-vs-GCS gating in `runSingleLoadJob`. Both paths now retry up to 4 times.
- Added `"not found: dataset"` to both retry-classification branches: the `gcbq.Error.Message` path in `isRetryableLoadJobReason` and the err-string fallback in `isRetryableLoadJobError` (which catches the `googleapi.Error` returned by `loader.Run`).

`pkg/destination/bigquery/load_job_test.go`:

- Three new cases: positive (`gcbq.Error` with `Dataset` message), wrapped positive, negative (`Table` not found stays non-retryable).

## Test plan

- [x] `go test ./pkg/destination/bigquery/...` passes (full package).
- [x] Reproduced the failure deterministically against real BQ by simulating propagation lag (drop dataset between PrepareTable success and load-job submit) — exact error message matches the customer report.
- [x] With this fix applied, the simulated run retries and recovers.
- [x] Baseline ingestion (`_bruin_staging` absent, US target, `replace` strategy) still passes end-to-end.