### PR TITLE
Add Microsoft Fabric Data Warehouse destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Pull requests are welcome. However, please open an issue first to discuss what y
     </tr>
     <tr>
         <td>Microsoft Fabric</td>
-        <td>-</td>
+        <td>✅</td>
         <td>✅</td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
+        <td>Microsoft Fabric</td>
+        <td>-</td>
+        <td>✅</td>
+    </tr>
+    <tr>
         <td>Microsoft SQL Server</td>
         <td>✅</td>
         <td>✅</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -111,6 +111,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Kafka", link: "/supported-sources/kafka.md" },
               { text: "Local CSV Files", link: "/supported-sources/csv.md" },
               {
+                text: "Microsoft Fabric",
+                link: "/supported-sources/fabric.md",
+              },
+              {
                 text: "Microsoft SQL Server",
                 link: "/supported-sources/mssql.md",
               },

--- a/docs/supported-sources/fabric.md
+++ b/docs/supported-sources/fabric.md
@@ -2,7 +2,7 @@
 
 [Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/data-warehouse/) Data Warehouse is a lake-centric, SQL-based data warehouse that speaks the SQL Server (TDS) protocol.
 
-ingestr supports Microsoft Fabric Warehouse as a destination.
+ingestr supports Microsoft Fabric Warehouse as both a source and a destination.
 
 ## URI format
 
@@ -32,9 +32,9 @@ You can select any workflow explicitly with the `fedauth` query parameter, for e
 - `fedauth=ActiveDirectoryServicePrincipalAccessToken` — pass a pre-fetched access token as the password
 - `fedauth=ActiveDirectoryManagedIdentity` — authenticate with a managed identity
 
-## Example
+## Examples
 
-Copy a table from a local SQLite database into a Fabric Warehouse:
+Load a table **into** a Fabric Warehouse (Fabric as destination):
 
 ```bash
 ingestr ingest \
@@ -44,9 +44,19 @@ ingestr ingest \
     --dest-table "dbo.users"
 ```
 
+Read a table **from** a Fabric Warehouse (Fabric as source):
+
+```bash
+ingestr ingest \
+    --source-uri "fabric://$CLIENT_ID:$CLIENT_SECRET@myworkspace.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=$TENANT_ID" \
+    --source-table "dbo.users" \
+    --dest-uri "duckdb:///local.db" \
+    --dest-table "main.users"
+```
+
 ## Notes & limitations
 
-- **Type mapping**: Fabric does not support a number of SQL Server types. Strings are written as `VARCHAR` (UTF-8) and timestamps as `DATETIME2(6)`; timezone-aware timestamps are stored as their UTC instant (Fabric has no `DATETIMEOFFSET`).
+- **Type mapping (destination)**: Fabric does not support a number of SQL Server types. Strings are written as `VARCHAR` (UTF-8) and timestamps as `DATETIME2(6)`; timezone-aware timestamps are stored as their UTC instant (Fabric has no `DATETIMEOFFSET`).
 - **Primary keys** are created as `NONCLUSTERED ... NOT ENFORCED`, as required by Fabric.
 - **Replace strategy** writes directly to the target table (drop and recreate) rather than performing an atomic staging-table swap, since the warehouse stages data in a separate schema.
 - **Schema evolution** can add new (nullable) columns; changing an existing column's type is not performed.

--- a/docs/supported-sources/fabric.md
+++ b/docs/supported-sources/fabric.md
@@ -1,0 +1,53 @@
+# Microsoft Fabric
+
+[Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/data-warehouse/) Data Warehouse is a lake-centric, SQL-based data warehouse that speaks the SQL Server (TDS) protocol.
+
+ingestr supports Microsoft Fabric Warehouse as a destination.
+
+## URI format
+
+The URI format for Microsoft Fabric is as follows:
+
+```plaintext
+fabric://<client_id>:<client_secret>@<workspace>.datawarehouse.fabric.microsoft.com/<warehouse>?tenant_id=<tenant_id>
+```
+
+URI parameters:
+- `client_id`: the application (client) ID of the Microsoft Entra service principal
+- `client_secret`: the client secret of the service principal
+- `host`: the warehouse's SQL connection string, e.g. `<workspace>.datawarehouse.fabric.microsoft.com`
+- `warehouse`: the name of the warehouse to connect to
+- `tenant_id`: the Microsoft Entra tenant ID the service principal belongs to
+- `fedauth` (optional): the Microsoft Entra authentication workflow to use (see below)
+
+## Authentication
+
+Fabric Warehouse only supports **Microsoft Entra ID** authentication — there is no SQL username/password login. The connection is encrypted (TLS) by default.
+
+By default, ingestr authenticates with a **service principal**: supply the client ID, secret and `tenant_id`, and ingestr uses the `ActiveDirectoryServicePrincipal` workflow. The service principal must be granted access to the workspace (Contributor role or item-level permissions on the warehouse), and your Fabric admin must allow service principals to use the APIs.
+
+If you omit the credentials, ingestr falls back to `ActiveDirectoryDefault`, which uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) — picking up environment variables, a managed identity, or your Azure CLI login.
+
+You can select any workflow explicitly with the `fedauth` query parameter, for example:
+- `fedauth=ActiveDirectoryServicePrincipalAccessToken` — pass a pre-fetched access token as the password
+- `fedauth=ActiveDirectoryManagedIdentity` — authenticate with a managed identity
+
+## Example
+
+Copy a table from a local SQLite database into a Fabric Warehouse:
+
+```bash
+ingestr ingest \
+    --source-uri "sqlite:///source.db" \
+    --source-table "main.users" \
+    --dest-uri "fabric://$CLIENT_ID:$CLIENT_SECRET@myworkspace.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=$TENANT_ID" \
+    --dest-table "dbo.users"
+```
+
+## Notes & limitations
+
+- **Type mapping**: Fabric does not support a number of SQL Server types. Strings are written as `VARCHAR` (UTF-8) and timestamps as `DATETIME2(6)`; timezone-aware timestamps are stored as their UTC instant (Fabric has no `DATETIMEOFFSET`).
+- **Primary keys** are created as `NONCLUSTERED ... NOT ENFORCED`, as required by Fabric.
+- **Replace strategy** writes directly to the target table (drop and recreate) rather than performing an atomic staging-table swap, since the warehouse stages data in a separate schema.
+- **Schema evolution** can add new (nullable) columns; changing an existing column's type is not performed.
+- The default warehouse collation is case-sensitive (`Latin1_General_100_BIN2_UTF8`), so string-keyed merges and joins are case-sensitive.

--- a/pkg/destination/fabric/dialect.go
+++ b/pkg/destination/fabric/dialect.go
@@ -1,0 +1,54 @@
+package fabric
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+)
+
+func init() {
+	dialect := &Dialect{}
+	schemaevolution.RegisterDialect("fabric", dialect)
+}
+
+type Dialect struct{}
+
+func (d *Dialect) Name() string {
+	return "Fabric"
+}
+
+// AddColumnSQL emits an ADD COLUMN. Fabric only allows adding nullable columns,
+// so the column is always declared NULL regardless of the source nullability.
+func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
+	return fmt.Sprintf("ALTER TABLE %s ADD %s %s NULL",
+		table,
+		d.QuoteIdentifier(col.Name),
+		d.TypeName(col))
+}
+
+func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {
+	nullable := " NULL"
+	if !newType.Nullable {
+		nullable = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s %s%s",
+		table,
+		d.QuoteIdentifier(colName),
+		d.TypeName(newType),
+		nullable)
+}
+
+// SupportsAlterType is false for v1: ALTER COLUMN type changes are a preview
+// feature in Fabric Warehouse.
+func (d *Dialect) SupportsAlterType() bool {
+	return false
+}
+
+func (d *Dialect) TypeName(col schema.Column) string {
+	return MapDataTypeToFabric(col)
+}
+
+func (d *Dialect) QuoteIdentifier(name string) string {
+	return fmt.Sprintf("[%s]", name)
+}

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -1,0 +1,823 @@
+package fabric
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	_ "github.com/microsoft/go-mssqldb"         // registers the "sqlserver" driver
+	_ "github.com/microsoft/go-mssqldb/azuread" // registers the "azuresql" driver (Microsoft Entra auth)
+)
+
+// maxParamLimit is the go-mssqldb driver parameter limit, shared with Fabric's
+// TDS endpoint. Multi-row INSERTs are batched to stay under it.
+const maxParamLimit = 2100
+
+type FabricDestination struct {
+	db       *sql.DB
+	uri      string
+	database string
+}
+
+func NewFabricDestination() *FabricDestination {
+	return &FabricDestination{}
+}
+
+func (d *FabricDestination) Schemes() []string {
+	return []string{"fabric"}
+}
+
+func (d *FabricDestination) Connect(ctx context.Context, uri string) error {
+	connStr, database, err := uriToConnString(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse Fabric URI: %w", err)
+	}
+
+	// Fabric Warehouse only supports Microsoft Entra ID authentication, which
+	// is handled by the azuread driver ("azuresql"), not the plain "sqlserver"
+	// driver.
+	db, err := sql.Open("azuresql", connStr)
+	if err != nil {
+		return fmt.Errorf("failed to open Fabric connection: %w", err)
+	}
+
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping Fabric: %w", err)
+	}
+
+	d.db = db
+	d.uri = uri
+	d.database = database
+	config.Debug("[Fabric] Connected to warehouse: %s", database)
+	return nil
+}
+
+// uriToConnString converts a fabric:// URI into a sqlserver:// DSN understood by
+// the azuread driver. The expected input is:
+//
+//	fabric://<clientid>:<secret>@<host>/<warehouse>?tenant_id=<tid>[&fedauth=...]
+//
+// The Entra workflow defaults to ActiveDirectoryServicePrincipal when a client
+// id is supplied, otherwise ActiveDirectoryDefault; an explicit ?fedauth= always
+// wins (so e.g. ActiveDirectoryManagedIdentity or
+// ActiveDirectoryServicePrincipalAccessToken work without code changes).
+func uriToConnString(uri string) (string, string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", "", err
+	}
+
+	if scheme := strings.ToLower(u.Scheme); scheme != "fabric" {
+		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "1433"
+	}
+
+	var clientID, secret string
+	if u.User != nil {
+		clientID = u.User.Username()
+		secret, _ = u.User.Password()
+	}
+
+	database := strings.TrimPrefix(u.Path, "/")
+
+	query := u.Query()
+	query.Del("driver")
+
+	tenantID := query.Get("tenant_id")
+	query.Del("tenant_id")
+
+	if query.Get("fedauth") == "" {
+		if clientID != "" {
+			query.Set("fedauth", "ActiveDirectoryServicePrincipal")
+		} else {
+			query.Set("fedauth", "ActiveDirectoryDefault")
+		}
+	}
+
+	if database != "" {
+		query.Set("database", database)
+	}
+
+	// Fabric requires TLS. Set encrypt=true explicitly so the server certificate
+	// is validated rather than blindly trusted.
+	if query.Get("encrypt") == "" {
+		query.Set("encrypt", "true")
+	}
+
+	connURL := &url.URL{
+		Scheme: "sqlserver",
+		Host:   fmt.Sprintf("%s:%s", host, port),
+	}
+
+	// The azuread driver expects the service-principal identity as
+	// "clientID@tenantID" in the user-id position and the secret as the
+	// password. url.UserPassword percent-encodes the "@" and any reserved
+	// characters in the secret.
+	if clientID != "" {
+		userID := clientID
+		if tenantID != "" {
+			userID = clientID + "@" + tenantID
+		}
+		if secret != "" {
+			connURL.User = url.UserPassword(userID, secret)
+		} else {
+			connURL.User = url.User(userID)
+		}
+	}
+
+	connURL.RawQuery = query.Encode()
+
+	return connURL.String(), database, nil
+}
+
+func (d *FabricDestination) Close(ctx context.Context) error {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}
+
+func (d *FabricDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	schemaName, _ := parseTableName(opts.Table)
+	if err := d.ensureSchemaExists(ctx, schemaName); err != nil {
+		return fmt.Errorf("failed to ensure schema exists: %w", err)
+	}
+
+	if opts.DropFirst {
+		dropSQL := fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s",
+			escapeTableName(opts.Table), quoteTable(opts.Table))
+		if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+			config.LogFailedQuery(dropSQL, err)
+			return fmt.Errorf("failed to drop table: %w", err)
+		}
+	}
+
+	if opts.Schema != nil {
+		createSQL := buildCreateTableSQL(opts.Table, opts.Schema.Columns, opts.PrimaryKeys)
+		if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+			config.LogFailedQuery(createSQL, err)
+			return fmt.Errorf("failed to create table: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (d *FabricDestination) ensureSchemaExists(ctx context.Context, schemaName string) error {
+	if schemaName == "" || schemaName == "dbo" {
+		return nil
+	}
+
+	createSchemaSQL := fmt.Sprintf(
+		"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') EXEC('CREATE SCHEMA [%s]')",
+		strings.ReplaceAll(schemaName, "'", "''"),
+		strings.ReplaceAll(schemaName, "]", "]]"),
+	)
+	if _, err := d.db.ExecContext(ctx, createSchemaSQL); err != nil {
+		config.LogFailedQuery(createSchemaSQL, err)
+		return fmt.Errorf("failed to create schema %s: %w", schemaName, err)
+	}
+	config.Debug("[Fabric] Ensured schema exists: %s", schemaName)
+	return nil
+}
+
+func parseTableName(table string) (string, string) {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "dbo", table
+}
+
+func (d *FabricDestination) TruncateTable(ctx context.Context, table string) error {
+	truncateSQL := fmt.Sprintf("TRUNCATE TABLE %s", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate table %s: %w", table, err)
+	}
+	config.Debug("[Fabric] Truncated table: %s", table)
+	return nil
+}
+
+func (d *FabricDestination) DropTable(ctx context.Context, table string) error {
+	dropSQL := fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s",
+		escapeTableName(table), quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+		config.LogFailedQuery(dropSQL, err)
+		return fmt.Errorf("failed to drop table %s: %w", table, err)
+	}
+	config.Debug("[Fabric] Dropped table: %s", table)
+	return nil
+}
+
+func (d *FabricDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.WriteParallel(ctx, records, opts)
+}
+
+func (d *FabricDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	startTime := time.Now()
+	var totalRows int64
+	var batchNum int
+
+	config.Debug("[Fabric] Starting write to %s", opts.Table)
+
+	for result := range records {
+		if result.Err != nil {
+			return result.Err
+		}
+
+		batchNum++
+		startBatch := time.Now()
+
+		rows, err := d.writeRecordBatch(ctx, result.Batch, opts.Table)
+		if err != nil {
+			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
+		}
+
+		totalRows += rows
+		rate := float64(rows) / time.Since(startBatch).Seconds()
+		config.Debug("[Fabric] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
+			batchNum, rows, time.Since(startBatch), rate, totalRows)
+
+		result.Batch.Release()
+	}
+
+	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
+	config.Debug("[Fabric] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTime), totalRate)
+	return nil
+}
+
+func (d *FabricDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+	numRows := record.NumRows()
+	numCols := int(record.NumCols())
+
+	if numRows == 0 || numCols == 0 {
+		return 0, nil
+	}
+
+	colNames := make([]string, numCols)
+	for i := 0; i < numCols; i++ {
+		colNames[i] = fmt.Sprintf("[%s]", record.Schema().Field(i).Name)
+	}
+	colList := strings.Join(colNames, ", ")
+
+	maxRowsPerBatch := maxParamLimit / numCols
+	if maxRowsPerBatch > 1000 {
+		maxRowsPerBatch = 1000
+	}
+	if maxRowsPerBatch < 1 {
+		maxRowsPerBatch = 1
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	for batchStart := int64(0); batchStart < numRows; batchStart += int64(maxRowsPerBatch) {
+		batchEnd := batchStart + int64(maxRowsPerBatch)
+		if batchEnd > numRows {
+			batchEnd = numRows
+		}
+
+		var valueClauses []string
+		var allValues []interface{}
+		paramIdx := 1
+
+		for rowIdx := batchStart; rowIdx < batchEnd; rowIdx++ {
+			placeholders := make([]string, numCols)
+			for colIdx := 0; colIdx < numCols; colIdx++ {
+				placeholders[colIdx] = fmt.Sprintf("@p%d", paramIdx)
+				paramIdx++
+				allValues = append(allValues, extractValue(record.Column(colIdx), int(rowIdx)))
+			}
+			valueClauses = append(valueClauses, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
+		}
+
+		insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+			quoteTable(table), colList, strings.Join(valueClauses, ", "))
+
+		if _, err := tx.ExecContext(ctx, insertSQL, allValues...); err != nil {
+			config.LogFailedQuery(insertSQL, err)
+			_ = tx.Rollback()
+			return batchStart, fmt.Errorf("failed to insert rows %d-%d: %w", batchStart, batchEnd-1, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return numRows, nil
+}
+
+// SwapTable is intentionally unsupported for Fabric. SupportsAtomicSwap returns
+// false, so the replace strategy writes directly to the target and never calls
+// this method. An atomic swap would require moving the staging table across
+// schemas (ALTER SCHEMA ... TRANSFER), which is not part of Fabric Warehouse's
+// documented T-SQL surface area.
+func (d *FabricDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	return fmt.Errorf("atomic table swap is not supported for Fabric; replace writes directly to the target")
+}
+
+func (d *FabricDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	startMerge := time.Now()
+
+	quotedColumns := quoteColumns(opts.Columns)
+	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
+
+	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns)
+	config.Debug("[Fabric MERGE] Executing MERGE: %s", mergeSQL)
+
+	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to execute merge: %w", err)
+	}
+
+	config.Debug("[Fabric MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
+
+func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
+	onConditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
+	}
+
+	var updateSet string
+	if len(nonPKColumns) > 0 {
+		updates := make([]string, len(nonPKColumns))
+		for i, col := range nonPKColumns {
+			updates[i] = fmt.Sprintf("target.[%s] = source.[%s]", col, col)
+		}
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	insertCols := strings.Join(quotedColumns, ", ")
+	sourceCols := make([]string, len(quotedColumns))
+	for i, col := range quotedColumns {
+		sourceCols[i] = "source." + col
+	}
+
+	// Deduplicate the staging side so duplicate PKs don't break MERGE.
+	quotedPKs := quoteColumns(primaryKeys)
+	dedupSource := fmt.Sprintf(
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
+		insertCols,
+		insertCols,
+		strings.Join(quotedPKs, ", "),
+		quoteTable(stagingTable),
+	)
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s AS source
+ON %s
+%s
+WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		dedupSource,
+		strings.Join(onConditions, " AND "),
+		updateSet,
+		insertCols,
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func (d *FabricDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
+	startOp := time.Now()
+
+	quotedColumns := quoteColumns(opts.Columns)
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deleteSQL := fmt.Sprintf(
+		"DELETE FROM %s WHERE [%s] >= @p1 AND [%s] <= @p2",
+		quoteTable(opts.TargetTable), opts.IncrementalKey, opts.IncrementalKey,
+	)
+	config.Debug("[Fabric DELETE+INSERT] Executing DELETE: %s", deleteSQL)
+
+	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
+		config.LogFailedQuery(deleteSQL, err)
+		return fmt.Errorf("failed to delete records: %w", err)
+	}
+
+	insertSQL := fmt.Sprintf(
+		`INSERT INTO %s (%s) SELECT %s FROM %s`,
+		quoteTable(opts.TargetTable),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		quoteTable(opts.StagingTable),
+	)
+	config.Debug("[Fabric DELETE+INSERT] Executing INSERT: %s", insertSQL)
+
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert records: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	config.Debug("[Fabric DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
+	return nil
+}
+
+// SCD2Table performs SCD2 (Slowly Changing Dimensions Type 2) merge logic.
+func (d *FabricDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
+	startOp := time.Now()
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
+	changeConditions := buildChangeConditions(nonPKColumns, "target", "source")
+	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
+
+	// Step 1: Close changed records.
+	updateSQL := fmt.Sprintf(
+		`
+		UPDATE target SET
+			target.[_scd_valid_to] = source.[_scd_valid_from],
+			target.[_scd_is_current] = 0
+		FROM %s AS target
+		INNER JOIN %s AS source ON %s
+		WHERE target.[_scd_is_current] = 1
+		  AND (%s)`,
+		quoteTable(opts.TargetTable),
+		quoteTable(opts.StagingTable),
+		onCondition,
+		changeConditions,
+	)
+	config.Debug("[Fabric SCD2] Step 1 - Close changed records: %s", updateSQL)
+
+	if _, err := tx.ExecContext(ctx, updateSQL); err != nil {
+		config.LogFailedQuery(updateSQL, err)
+		return fmt.Errorf("failed to close changed records: %w", err)
+	}
+
+	// Step 2: Soft-delete missing records (only if no incremental_key).
+	if opts.IncrementalKey == "" {
+		softDeleteSQL := fmt.Sprintf(
+			`
+			UPDATE target SET
+				target.[_scd_valid_to] = @p1,
+				target.[_scd_is_current] = 0
+			FROM %s AS target
+			WHERE target.[_scd_is_current] = 1
+			  AND NOT EXISTS (SELECT 1 FROM %s AS source WHERE %s)`,
+			quoteTable(opts.TargetTable),
+			quoteTable(opts.StagingTable),
+			onCondition,
+		)
+		config.Debug("[Fabric SCD2] Step 2 - Soft-delete missing: %s", softDeleteSQL)
+
+		if _, err := tx.ExecContext(ctx, softDeleteSQL, opts.Timestamp); err != nil {
+			config.LogFailedQuery(softDeleteSQL, err)
+			return fmt.Errorf("failed to soft-delete missing records: %w", err)
+		}
+	}
+
+	// Step 3: Insert new versions + net-new records.
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
+	quotedColumns := quoteColumns(allColumns)
+
+	insertSQL := fmt.Sprintf(
+		`
+		INSERT INTO %s (%s)
+		SELECT %s FROM %s AS source
+		WHERE NOT EXISTS (
+			SELECT 1 FROM %s AS target
+			WHERE %s
+			  AND target.[_scd_is_current] = 1
+		)`,
+		quoteTable(opts.TargetTable),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		quoteTable(opts.StagingTable),
+		quoteTable(opts.TargetTable),
+		onCondition,
+	)
+	config.Debug("[Fabric SCD2] Step 3 - Insert new versions: %s", insertSQL)
+
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert new versions: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	config.Debug("[Fabric SCD2] SCD2 merge completed in %v", time.Since(startOp))
+	return nil
+}
+
+func (d *FabricDestination) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	_, err := d.db.ExecContext(ctx, sql, args...)
+	if err != nil {
+		config.LogFailedQuery(sql, err)
+	}
+	return err
+}
+
+func (d *FabricDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &fabricTransaction{tx: tx}, nil
+}
+
+type fabricTransaction struct {
+	tx *sql.Tx
+}
+
+func (t *fabricTransaction) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	_, err := t.tx.ExecContext(ctx, sql, args...)
+	if err != nil {
+		config.LogFailedQuery(sql, err)
+	}
+	return err
+}
+
+func (t *fabricTransaction) Commit(ctx context.Context) error {
+	return t.tx.Commit()
+}
+
+func (t *fabricTransaction) Rollback(ctx context.Context) error {
+	return t.tx.Rollback()
+}
+
+func (d *FabricDestination) SupportsReplaceStrategy() bool      { return true }
+func (d *FabricDestination) SupportsAppendStrategy() bool       { return true }
+func (d *FabricDestination) SupportsMergeStrategy() bool        { return true }
+func (d *FabricDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *FabricDestination) SupportsSCD2Strategy() bool         { return true }
+
+// SupportsAtomicSwap is false: staging tables live in a separate schema and
+// Fabric does not document ALTER SCHEMA ... TRANSFER, so the replace strategy
+// writes directly to the target instead of swapping a staging table.
+func (d *FabricDestination) SupportsAtomicSwap() bool { return false }
+
+func (d *FabricDestination) GetScheme() string { return "fabric" }
+
+func (d *FabricDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	schemaName, tableName := parseTableName(table)
+
+	query := `
+		SELECT c.COLUMN_NAME, c.DATA_TYPE, c.IS_NULLABLE,
+		       c.NUMERIC_PRECISION, c.NUMERIC_SCALE, c.CHARACTER_MAXIMUM_LENGTH
+		FROM INFORMATION_SCHEMA.COLUMNS c
+		JOIN INFORMATION_SCHEMA.TABLES t ON c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME
+		WHERE c.TABLE_SCHEMA = @p1 AND c.TABLE_NAME = @p2
+		ORDER BY c.ORDINAL_POSITION`
+
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query table schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	for rows.Next() {
+		var colName, dataType, isNullable string
+		var numPrecision, numScale, charMaxLen *int
+
+		if err := rows.Scan(&colName, &dataType, &isNullable, &numPrecision, &numScale, &charMaxLen); err != nil {
+			return nil, fmt.Errorf("failed to scan column: %w", err)
+		}
+
+		col := schema.Column{
+			Name:     colName,
+			DataType: mapFabricTypeToSchema(dataType),
+			Nullable: isNullable == "YES",
+		}
+
+		if numPrecision != nil {
+			col.Precision = *numPrecision
+		}
+		if numScale != nil {
+			col.Scale = *numScale
+		}
+		if charMaxLen != nil {
+			col.MaxLength = *charMaxLen
+		}
+
+		columns = append(columns, col)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if len(columns) == 0 {
+		return nil, nil
+	}
+
+	return &schema.TableSchema{
+		Name:    tableName,
+		Schema:  schemaName,
+		Columns: columns,
+	}, nil
+}
+
+func mapFabricTypeToSchema(dataType string) schema.DataType {
+	switch strings.ToLower(dataType) {
+	case "bit":
+		return schema.TypeBoolean
+	case "tinyint", "smallint":
+		return schema.TypeInt16
+	case "int":
+		return schema.TypeInt32
+	case "bigint":
+		return schema.TypeInt64
+	case "real":
+		return schema.TypeFloat32
+	case "float":
+		return schema.TypeFloat64
+	case "decimal", "numeric":
+		return schema.TypeDecimal
+	case "char", "varchar":
+		return schema.TypeString
+	case "binary", "varbinary":
+		return schema.TypeBinary
+	case "date":
+		return schema.TypeDate
+	case "time":
+		return schema.TypeTime
+	case "datetime2":
+		return schema.TypeTimestamp
+	case "uniqueidentifier":
+		return schema.TypeUUID
+	default:
+		return schema.TypeString
+	}
+}
+
+func quoteTable(table string) string {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return fmt.Sprintf("[%s].[%s]", parts[0], parts[1])
+	}
+	return fmt.Sprintf("[%s]", table)
+}
+
+func quoteColumns(columns []string) []string {
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = fmt.Sprintf("[%s]", col)
+	}
+	return quoted
+}
+
+func filterColumns(columns []string, exclude []string) []string {
+	excludeMap := make(map[string]bool)
+	for _, col := range exclude {
+		excludeMap[strings.ToLower(col)] = true
+	}
+
+	var result []string
+	for _, col := range columns {
+		if !excludeMap[strings.ToLower(col)] {
+			result = append(result, col)
+		}
+	}
+	return result
+}
+
+func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
+	conditions := make([]string, len(keys))
+	for i, key := range keys {
+		conditions[i] = fmt.Sprintf("%s.[%s] = %s.[%s]", targetAlias, key, sourceAlias, key)
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+// buildChangeConditions builds change-detection conditions. Fabric (like SQL
+// Server) has no IS DISTINCT FROM, so NULLs are compared explicitly.
+func buildChangeConditions(columns []string, targetAlias, sourceAlias string) string {
+	if len(columns) == 0 {
+		return "0=1"
+	}
+	conditions := make([]string, len(columns))
+	for i, col := range columns {
+		conditions[i] = fmt.Sprintf(
+			`((%s.[%s] IS NULL AND %s.[%s] IS NOT NULL) OR (%s.[%s] IS NOT NULL AND %s.[%s] IS NULL) OR %s.[%s] <> %s.[%s])`,
+			targetAlias, col, sourceAlias, col,
+			targetAlias, col, sourceAlias, col,
+			targetAlias, col, sourceAlias, col,
+		)
+	}
+	return strings.Join(conditions, " OR ")
+}
+
+func escapeTableName(table string) string {
+	return strings.ReplaceAll(table, "'", "''")
+}
+
+func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
+	var colDefs []string
+	for _, col := range columns {
+		colDefs = append(colDefs, fmt.Sprintf("[%s] %s", col.Name, MapDataTypeToFabric(col)))
+	}
+
+	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))
+
+	if len(primaryKeys) > 0 {
+		quotedKeys := make([]string, len(primaryKeys))
+		for i, k := range primaryKeys {
+			quotedKeys[i] = fmt.Sprintf("[%s]", k)
+		}
+		// Fabric only allows NONCLUSTERED, NOT ENFORCED primary keys.
+		createPart += fmt.Sprintf(",\n  PRIMARY KEY NONCLUSTERED (%s) NOT ENFORCED", strings.Join(quotedKeys, ", "))
+	}
+
+	createPart += "\n)"
+
+	return fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NULL %s", escapeTableName(table), createPart)
+}
+
+func extractValue(arr arrow.Array, idx int) interface{} {
+	if arr.IsNull(idx) {
+		return nil
+	}
+
+	switch a := arr.(type) {
+	case *array.Boolean:
+		if a.Value(idx) {
+			return 1
+		}
+		return 0
+	case *array.Int16:
+		return a.Value(idx)
+	case *array.Int32:
+		return a.Value(idx)
+	case *array.Int64:
+		return a.Value(idx)
+	case *array.Float32:
+		return a.Value(idx)
+	case *array.Float64:
+		return a.Value(idx)
+	case *array.String:
+		return a.Value(idx)
+	case *array.LargeString:
+		return a.Value(idx)
+	case *array.Binary:
+		return a.Value(idx)
+	case *array.Date32:
+		return a.Value(idx).ToTime().Format("2006-01-02")
+	case *array.Date64:
+		return a.Value(idx).ToTime().Format("2006-01-02")
+	case *array.Time64:
+		raw := int64(a.Value(idx))
+		unit := a.DataType().(*arrow.Time64Type).Unit
+		micros := raw
+		if unit == arrow.Nanosecond {
+			micros = raw / 1000
+		}
+		t := time.Duration(micros) * time.Microsecond
+		hours := int(t.Hours())
+		mins := int(t.Minutes()) % 60
+		secs := int(t.Seconds()) % 60
+		frac := micros % 1000000
+		return fmt.Sprintf("%02d:%02d:%02d.%06d", hours, mins, secs, frac)
+	case *array.Timestamp:
+		ts := a.Value(idx)
+		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.0000000")
+	case *array.Decimal128:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case array.ExtensionArray:
+		return extractValue(a.Storage(), idx)
+	default:
+		return arr.ValueStr(idx)
+	}
+}

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -1,0 +1,118 @@
+package fabric
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestURIToConnString(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantErr      bool
+		wantDatabase string
+		wantHost     string
+		wantUser     string // expected decoded user-id ("" means no userinfo)
+		wantPassword string
+		wantQuery    map[string]string
+	}{
+		{
+			name:         "service principal with tenant",
+			uri:          "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=tenant-123",
+			wantDatabase: "MyWarehouse",
+			wantHost:     "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:     "client-id@tenant-123",
+			wantPassword: "s3cr3t",
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryServicePrincipal",
+				"database": "MyWarehouse",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:         "no credentials defaults to ActiveDirectoryDefault",
+			uri:          "fabric://abc.datawarehouse.fabric.microsoft.com/wh",
+			wantDatabase: "wh",
+			wantHost:     "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:     "",
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryDefault",
+				"database": "wh",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:         "explicit fedauth and port are preserved",
+			uri:          "fabric://client-id:token@host.example.com:1234/wh?fedauth=ActiveDirectoryServicePrincipalAccessToken&tenant_id=t1",
+			wantDatabase: "wh",
+			wantHost:     "host.example.com:1234",
+			wantUser:     "client-id@t1",
+			wantPassword: "token",
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryServicePrincipalAccessToken",
+				"database": "wh",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:    "wrong scheme errors",
+			uri:     "mssql://user:pass@host/db",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			connStr, database, err := uriToConnString(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (connStr=%q)", connStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if database != tt.wantDatabase {
+				t.Errorf("database = %q, want %q", database, tt.wantDatabase)
+			}
+
+			u, perr := url.Parse(connStr)
+			if perr != nil {
+				t.Fatalf("result DSN is not a valid URL: %v", perr)
+			}
+			if u.Scheme != "sqlserver" {
+				t.Errorf("scheme = %q, want sqlserver", u.Scheme)
+			}
+			if u.Host != tt.wantHost {
+				t.Errorf("host = %q, want %q", u.Host, tt.wantHost)
+			}
+
+			gotUser := ""
+			if u.User != nil {
+				gotUser = u.User.Username()
+			}
+			if gotUser != tt.wantUser {
+				t.Errorf("user = %q, want %q", gotUser, tt.wantUser)
+			}
+			if tt.wantPassword != "" {
+				gotPass, _ := u.User.Password()
+				if gotPass != tt.wantPassword {
+					t.Errorf("password = %q, want %q", gotPass, tt.wantPassword)
+				}
+			}
+
+			q := u.Query()
+			for k, want := range tt.wantQuery {
+				if got := q.Get(k); got != want {
+					t.Errorf("query[%q] = %q, want %q", k, got, want)
+				}
+			}
+			// tenant_id must never leak into the DSN query.
+			if q.Has("tenant_id") {
+				t.Errorf("tenant_id should not appear in DSN query, got %q", q.Get("tenant_id"))
+			}
+		})
+	}
+}

--- a/pkg/destination/fabric/mapper.go
+++ b/pkg/destination/fabric/mapper.go
@@ -1,0 +1,73 @@
+package fabric
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+// MapDataTypeToFabric maps an internal schema type to a Fabric Warehouse column
+// type. Fabric does not support several SQL Server types (NVARCHAR, DATETIME,
+// DATETIMEOFFSET, MONEY, TINYINT, TEXT, JSON, XML), so this differs from the
+// mssql mapper: strings use VARCHAR (UTF-8) and timestamps use DATETIME2.
+func MapDataTypeToFabric(col schema.Column) string {
+	switch col.DataType {
+	case schema.TypeBoolean:
+		return "BIT"
+	case schema.TypeInt16:
+		return "SMALLINT"
+	case schema.TypeInt32:
+		return "INT"
+	case schema.TypeInt64:
+		return "BIGINT"
+	case schema.TypeFloat32:
+		return "REAL"
+	case schema.TypeFloat64:
+		return "FLOAT"
+	case schema.TypeDecimal:
+		precision := col.Precision
+		scale := col.Scale
+		if precision <= 0 {
+			precision = 38
+		}
+		if scale < 0 {
+			scale = 0
+		}
+		if precision > 38 {
+			precision = 38
+		}
+		if scale > precision {
+			scale = precision
+		}
+		return fmt.Sprintf("DECIMAL(%d,%d)", precision, scale)
+	case schema.TypeString:
+		if col.MaxLength > 0 && col.MaxLength <= 8000 {
+			return fmt.Sprintf("VARCHAR(%d)", col.MaxLength)
+		}
+		return "VARCHAR(MAX)"
+	case schema.TypeBinary:
+		if col.MaxLength > 0 && col.MaxLength <= 8000 {
+			return fmt.Sprintf("VARBINARY(%d)", col.MaxLength)
+		}
+		return "VARBINARY(MAX)"
+	case schema.TypeDate:
+		return "DATE"
+	case schema.TypeTime:
+		return "TIME(6)"
+	case schema.TypeTimestamp:
+		return "DATETIME2(6)"
+	case schema.TypeTimestampTZ:
+		// Fabric has no DATETIMEOFFSET; store the UTC instant as DATETIME2.
+		return "DATETIME2(6)"
+	case schema.TypeJSON:
+		return "VARCHAR(MAX)"
+	case schema.TypeUUID:
+		return "UNIQUEIDENTIFIER"
+	case schema.TypeArray:
+		return "VARCHAR(MAX)"
+	case schema.TypeInterval:
+		return "VARCHAR(255)"
+	default:
+		return "VARCHAR(MAX)"
+	}
+}

--- a/pkg/destination/fabric/register.go
+++ b/pkg/destination/fabric/register.go
@@ -1,0 +1,10 @@
+package fabric
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"fabric"},
+		func() interface{} { return NewFabricDestination() },
+	)
+}

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/cratedb"
 	"github.com/bruin-data/ingestr/pkg/destination/databricks"
 	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
+	"github.com/bruin-data/ingestr/pkg/destination/fabric"
 	"github.com/bruin-data/ingestr/pkg/destination/mssql"
 	"github.com/bruin-data/ingestr/pkg/destination/mysql"
 	"github.com/bruin-data/ingestr/pkg/destination/postgres"
@@ -25,6 +26,7 @@ var (
 	_ destination.Destination = (*cratedb.CrateDBDestination)(nil)
 	_ destination.Destination = (*databricks.DatabricksDestination)(nil)
 	_ destination.Destination = (*duckdb.DuckDBDestination)(nil)
+	_ destination.Destination = (*fabric.FabricDestination)(nil)
 	_ destination.Destination = (*mssql.MSSQLDestination)(nil)
 	_ destination.Destination = (*mysql.MySQLDestination)(nil)
 	_ destination.Destination = (*postgres.PostgresDestination)(nil)

--- a/pkg/destination/shorten.go
+++ b/pkg/destination/shorten.go
@@ -23,6 +23,7 @@ var maxIdentifierLengths = map[string]int{
 	"trino":               128,
 	"cratedb":             255,
 	"synapse":             128,
+	"fabric":              128,
 	"clickhouse":          255, // no engine-side limit; bounded by filesystem filename length (ext4/xfs 255 bytes)
 	"databricks":          255, // Unity Catalog / Spark identifier
 	"duckdb":              1024,

--- a/pkg/source/fabric/fabric.go
+++ b/pkg/source/fabric/fabric.go
@@ -1,0 +1,552 @@
+package fabric
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	_ "github.com/microsoft/go-mssqldb"         // registers the "sqlserver" driver
+	_ "github.com/microsoft/go-mssqldb/azuread" // registers the "azuresql" driver (Microsoft Entra auth)
+)
+
+var _ source.Source = (*FabricSource)(nil)
+
+type FabricSource struct {
+	db  *sql.DB
+	uri string
+}
+
+func NewFabricSource() *FabricSource {
+	return &FabricSource{}
+}
+
+func (s *FabricSource) Schemes() []string {
+	return []string{"fabric"}
+}
+
+func (s *FabricSource) Connect(ctx context.Context, uri string) error {
+	connStr, err := uriToConnString(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse Fabric URI: %w", err)
+	}
+
+	// Fabric Warehouse only supports Microsoft Entra ID authentication, handled
+	// by the azuread driver ("azuresql"), not the plain "sqlserver" driver.
+	db, err := sql.Open("azuresql", connStr)
+	if err != nil {
+		return fmt.Errorf("failed to open Fabric connection: %w", err)
+	}
+
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping Fabric: %w", err)
+	}
+
+	s.db = db
+	s.uri = uri
+	return nil
+}
+
+// uriToConnString converts a fabric:// URI into a sqlserver:// DSN understood by
+// the azuread driver. Expected input:
+//
+//	fabric://<clientid>:<secret>@<host>/<warehouse>?tenant_id=<tid>[&fedauth=...]
+//
+// The Entra workflow defaults to ActiveDirectoryServicePrincipal when a client
+// id is supplied, otherwise ActiveDirectoryDefault; an explicit ?fedauth= always
+// wins.
+func uriToConnString(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	if scheme := strings.ToLower(u.Scheme); scheme != "fabric" {
+		return "", fmt.Errorf("unsupported scheme: %s", scheme)
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "1433"
+	}
+
+	var clientID, secret string
+	if u.User != nil {
+		clientID = u.User.Username()
+		secret, _ = u.User.Password()
+	}
+
+	database := strings.TrimPrefix(u.Path, "/")
+
+	query := u.Query()
+	query.Del("driver")
+
+	tenantID := query.Get("tenant_id")
+	query.Del("tenant_id")
+
+	if query.Get("fedauth") == "" {
+		if clientID != "" {
+			query.Set("fedauth", "ActiveDirectoryServicePrincipal")
+		} else {
+			query.Set("fedauth", "ActiveDirectoryDefault")
+		}
+	}
+
+	if database != "" {
+		query.Set("database", database)
+	}
+
+	// Fabric requires TLS; set encrypt=true explicitly so the server certificate
+	// is validated rather than blindly trusted.
+	if query.Get("encrypt") == "" {
+		query.Set("encrypt", "true")
+	}
+
+	connURL := &url.URL{
+		Scheme: "sqlserver",
+		Host:   fmt.Sprintf("%s:%s", host, port),
+	}
+
+	// The azuread driver expects the service-principal identity as
+	// "clientID@tenantID" in the user-id position and the secret as the
+	// password. url.UserPassword percent-encodes the "@" and reserved
+	// characters in the secret.
+	if clientID != "" {
+		userID := clientID
+		if tenantID != "" {
+			userID = clientID + "@" + tenantID
+		}
+		if secret != "" {
+			connURL.User = url.UserPassword(userID, secret)
+		} else {
+			connURL.User = url.User(userID)
+		}
+	}
+
+	connURL.RawQuery = query.Encode()
+
+	return connURL.String(), nil
+}
+
+func (s *FabricSource) Close(ctx context.Context) error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+func (s *FabricSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *FabricSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if _, ok := source.IsCustomQuery(req.Name); ok {
+		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+	}
+
+	tableSchema, err := s.getSchema(ctx, req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	pks := req.PrimaryKeys
+	if len(pks) == 0 {
+		pks = tableSchema.PrimaryKeys
+	}
+
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	tableName := req.Name
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    pks,
+		TableIncrementalKey: req.IncrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         true,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return tableSchema, nil
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, tableSchema, opts)
+		},
+	}, nil
+}
+
+func (s *FabricSource) getSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	schemaName, tableName := parseTableName(table)
+
+	query := `
+		SELECT
+			COLUMN_NAME,
+			DATA_TYPE,
+			IS_NULLABLE,
+			NUMERIC_PRECISION,
+			NUMERIC_SCALE,
+			CHARACTER_MAXIMUM_LENGTH
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+		ORDER BY ORDINAL_POSITION
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	for rows.Next() {
+		var columnName, dataType, isNullable string
+		var numericPrecision, numericScale, charMaxLen sql.NullInt64
+
+		if err := rows.Scan(&columnName, &dataType, &isNullable, &numericPrecision, &numericScale, &charMaxLen); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		dt, precision, scale, arrayType := MapFabricToDataType(dataType)
+
+		col := schema.Column{
+			Name:      columnName,
+			DataType:  dt,
+			Nullable:  isNullable == "YES",
+			ArrayType: arrayType,
+		}
+
+		if numericPrecision.Valid {
+			col.Precision = int(numericPrecision.Int64)
+		} else if precision > 0 {
+			col.Precision = precision
+		}
+
+		if numericScale.Valid {
+			col.Scale = int(numericScale.Int64)
+		} else if scale > 0 {
+			col.Scale = scale
+		}
+
+		if charMaxLen.Valid {
+			col.MaxLength = int(charMaxLen.Int64)
+		}
+
+		columns = append(columns, col)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("table %s not found or has no columns", table)
+	}
+
+	// Get primary keys
+	pkQuery := `
+		SELECT c.COLUMN_NAME
+		FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+		JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE c
+			ON tc.CONSTRAINT_NAME = c.CONSTRAINT_NAME
+			AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA
+		WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
+			AND tc.TABLE_SCHEMA = @p1
+			AND tc.TABLE_NAME = @p2
+		ORDER BY c.ORDINAL_POSITION
+	`
+
+	var primaryKeys []string
+	pkRows, err := s.db.QueryContext(ctx, pkQuery, schemaName, tableName)
+	if err == nil {
+		defer func() { _ = pkRows.Close() }()
+		for pkRows.Next() {
+			var pkName string
+			if err := pkRows.Scan(&pkName); err == nil {
+				primaryKeys = append(primaryKeys, pkName)
+			}
+		}
+	}
+
+	for i := range columns {
+		for _, pk := range primaryKeys {
+			if columns[i].Name == pk {
+				columns[i].IsPrimaryKey = true
+				break
+			}
+		}
+	}
+
+	return &schema.TableSchema{
+		Name:        tableName,
+		Schema:      schemaName,
+		Columns:     columns,
+		PrimaryKeys: primaryKeys,
+	}, nil
+}
+
+func (s *FabricSource) read(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	startTotal := time.Now()
+	config.Debug("[SOURCE] Starting read from %s", table)
+
+	columns := filterColumns(tableSchema.Columns, opts.ExcludeColumns)
+	arrowSchema := buildArrowSchema(columns)
+
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		query := buildSelectQuery(table, columns, opts)
+
+		startQuery := time.Now()
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to query: %w", err)}
+			return
+		}
+		defer func() { _ = rows.Close() }()
+		config.Debug("[SOURCE] Query started in %v", time.Since(startQuery))
+
+		batchNum := 0
+		totalRows := int64(0)
+
+		for {
+			startBatch := time.Now()
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+
+			if count == 0 {
+				break
+			}
+
+			batchNum++
+			totalRows += count
+			config.Debug("[SOURCE] Batch %d: %d rows read in %v (total: %d)", batchNum, count, time.Since(startBatch), totalRows)
+
+			results <- source.RecordBatchResult{Batch: record}
+		}
+
+		config.Debug("[SOURCE] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
+	}()
+
+	return results, nil
+}
+
+func (s *FabricSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		config.Debug("[SOURCE] Executing custom query: %s", query)
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to execute custom query: %w", err)}
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		colTypes, err := rows.ColumnTypes()
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to get column types: %w", err)}
+			return
+		}
+
+		columns := make([]schema.Column, len(colTypes))
+		for i, ct := range colTypes {
+			dt, precision, scale, arrayType := MapFabricToDataType(ct.DatabaseTypeName())
+			nullable, _ := ct.Nullable()
+			columns[i] = schema.Column{
+				Name:      ct.Name(),
+				DataType:  dt,
+				Nullable:  nullable,
+				Precision: precision,
+				Scale:     scale,
+				ArrayType: arrayType,
+			}
+		}
+		arrowSchema := buildArrowSchema(columns)
+
+		for {
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+			if count == 0 {
+				break
+			}
+			results <- source.RecordBatchResult{Batch: record}
+		}
+	}()
+
+	return results, nil
+}
+
+func parseTableName(table string) (string, string) {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	// Fabric (SQL Server) default schema is dbo
+	return "dbo", table
+}
+
+func filterColumns(columns []schema.Column, exclude []string) []schema.Column {
+	if len(exclude) == 0 {
+		return columns
+	}
+
+	excludeMap := make(map[string]bool)
+	for _, col := range exclude {
+		excludeMap[strings.ToLower(col)] = true
+	}
+
+	var filtered []schema.Column
+	for _, col := range columns {
+		if !excludeMap[strings.ToLower(col.Name)] {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered
+}
+
+func buildArrowSchema(columns []schema.Column) *arrow.Schema {
+	fields := make([]arrow.Field, len(columns))
+	for i, col := range columns {
+		fields[i] = arrow.Field{
+			Name:     col.Name,
+			Type:     schema.DataTypeToArrowType(col),
+			Nullable: col.Nullable,
+		}
+	}
+	return arrow.NewSchema(fields, nil)
+}
+
+func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOptions) string {
+	colNames := make([]string, len(columns))
+	for i, col := range columns {
+		colNames[i] = fmt.Sprintf("[%s]", col.Name)
+	}
+
+	// SQL Server / Fabric use TOP instead of LIMIT.
+	selectClause := "SELECT"
+	if opts.Limit > 0 {
+		selectClause = fmt.Sprintf("SELECT TOP %d", opts.Limit)
+	}
+
+	query := fmt.Sprintf("%s %s FROM %s", selectClause, strings.Join(colNames, ", "), quoteTable(table))
+
+	var conditions []string
+	if opts.IncrementalKey != "" {
+		if opts.IntervalStart != nil {
+			conditions = append(conditions, fmt.Sprintf("[%s] >= '%s'", opts.IncrementalKey, opts.IntervalStart.Format("2006-01-02 15:04:05")))
+		}
+		if opts.IntervalEnd != nil {
+			conditions = append(conditions, fmt.Sprintf("[%s] <= '%s'", opts.IncrementalKey, opts.IntervalEnd.Format("2006-01-02 15:04:05")))
+		}
+	}
+
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	return query
+}
+
+func quoteTable(table string) string {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return fmt.Sprintf("[%s].[%s]", parts[0], parts[1])
+	}
+	return fmt.Sprintf("[%s]", table)
+}
+
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+	mem := memory.NewGoAllocator()
+	builders := make([]array.Builder, len(columns))
+
+	for i, field := range arrowSchema.Fields() {
+		builders[i] = array.NewBuilder(mem, field.Type)
+	}
+
+	scanDest := make([]interface{}, len(columns))
+	for i := range columns {
+		scanDest[i] = new(interface{})
+	}
+
+	var rowCount int64
+	for rows.Next() {
+		if err := rows.Scan(scanDest...); err != nil {
+			for _, b := range builders {
+				b.Release()
+			}
+			return nil, 0, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		for i, dest := range scanDest {
+			val := *dest.(*interface{})
+			arrowconv.AppendValue(builders[i], val)
+		}
+		rowCount++
+
+		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+	}
+
+	if rowCount == 0 {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, nil
+	}
+
+	if err := rows.Err(); err != nil {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	arrays := make([]arrow.Array, len(builders))
+	for i, b := range builders {
+		arrays[i] = b.NewArray()
+	}
+
+	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
+
+	for _, arr := range arrays {
+		arr.Release()
+	}
+
+	return record, rowCount, nil
+}

--- a/pkg/source/fabric/fabric_test.go
+++ b/pkg/source/fabric/fabric_test.go
@@ -1,0 +1,109 @@
+package fabric
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestURIToConnString(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantErr      bool
+		wantHost     string
+		wantUser     string // expected decoded user-id ("" means no userinfo)
+		wantPassword string
+		wantQuery    map[string]string
+	}{
+		{
+			name:         "service principal with tenant",
+			uri:          "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=tenant-123",
+			wantHost:     "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:     "client-id@tenant-123",
+			wantPassword: "s3cr3t",
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryServicePrincipal",
+				"database": "MyWarehouse",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:     "no credentials defaults to ActiveDirectoryDefault",
+			uri:      "fabric://abc.datawarehouse.fabric.microsoft.com/wh",
+			wantHost: "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser: "",
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryDefault",
+				"database": "wh",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:         "explicit fedauth and port are preserved",
+			uri:          "fabric://client-id:token@host.example.com:1234/wh?fedauth=ActiveDirectoryServicePrincipalAccessToken&tenant_id=t1",
+			wantHost:     "host.example.com:1234",
+			wantUser:     "client-id@t1",
+			wantPassword: "token",
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryServicePrincipalAccessToken",
+				"database": "wh",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:    "wrong scheme errors",
+			uri:     "mssql://user:pass@host/db",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			connStr, err := uriToConnString(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (connStr=%q)", connStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			u, perr := url.Parse(connStr)
+			if perr != nil {
+				t.Fatalf("result DSN is not a valid URL: %v", perr)
+			}
+			if u.Scheme != "sqlserver" {
+				t.Errorf("scheme = %q, want sqlserver", u.Scheme)
+			}
+			if u.Host != tt.wantHost {
+				t.Errorf("host = %q, want %q", u.Host, tt.wantHost)
+			}
+
+			gotUser := ""
+			if u.User != nil {
+				gotUser = u.User.Username()
+			}
+			if gotUser != tt.wantUser {
+				t.Errorf("user = %q, want %q", gotUser, tt.wantUser)
+			}
+			if tt.wantPassword != "" {
+				gotPass, _ := u.User.Password()
+				if gotPass != tt.wantPassword {
+					t.Errorf("password = %q, want %q", gotPass, tt.wantPassword)
+				}
+			}
+
+			q := u.Query()
+			for k, want := range tt.wantQuery {
+				if got := q.Get(k); got != want {
+					t.Errorf("query[%q] = %q, want %q", k, got, want)
+				}
+			}
+			if q.Has("tenant_id") {
+				t.Errorf("tenant_id should not appear in DSN query, got %q", q.Get("tenant_id"))
+			}
+		})
+	}
+}

--- a/pkg/source/fabric/mapper.go
+++ b/pkg/source/fabric/mapper.go
@@ -1,0 +1,104 @@
+package fabric
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+var decimalPrecisionRegex = regexp.MustCompile(`(?i)(?:decimal|numeric)\((\d+)(?:,\s*(\d+))?\)`)
+
+// MapFabricToDataType maps Fabric Warehouse (SQL Server) type names to the
+// internal DataType. Fabric returns a subset of SQL Server types, but the full
+// SQL Server set is handled here so custom-query column types map correctly.
+func MapFabricToDataType(fabricType string) (schema.DataType, int, int, schema.DataType) {
+	fabricType = strings.TrimSpace(fabricType)
+	upperType := strings.ToUpper(fabricType)
+
+	// Handle DECIMAL(p,s), NUMERIC(p,s)
+	if matches := decimalPrecisionRegex.FindStringSubmatch(fabricType); len(matches) >= 2 {
+		precision, _ := strconv.Atoi(matches[1])
+		scale := 0
+		if len(matches) >= 3 && matches[2] != "" {
+			scale, _ = strconv.Atoi(matches[2])
+		}
+		return schema.TypeDecimal, precision, scale, schema.TypeUnknown
+	}
+
+	// Extract base type (remove parenthetical parameters)
+	baseType := upperType
+	if idx := strings.Index(upperType, "("); idx != -1 {
+		baseType = upperType[:idx]
+	}
+
+	switch baseType {
+	// Boolean
+	case "BIT":
+		return schema.TypeBoolean, 0, 0, schema.TypeUnknown
+
+	// Integer types
+	case "TINYINT":
+		return schema.TypeInt16, 0, 0, schema.TypeUnknown
+	case "SMALLINT":
+		return schema.TypeInt16, 0, 0, schema.TypeUnknown
+	case "INT":
+		return schema.TypeInt32, 0, 0, schema.TypeUnknown
+	case "BIGINT":
+		return schema.TypeInt64, 0, 0, schema.TypeUnknown
+
+	// Floating point
+	case "REAL":
+		return schema.TypeFloat32, 0, 0, schema.TypeUnknown
+	case "FLOAT":
+		return schema.TypeFloat64, 0, 0, schema.TypeUnknown
+
+	// Decimal/Numeric/Money
+	case "DECIMAL", "NUMERIC":
+		return schema.TypeDecimal, 18, 0, schema.TypeUnknown
+	case "MONEY":
+		return schema.TypeDecimal, 19, 4, schema.TypeUnknown
+	case "SMALLMONEY":
+		return schema.TypeDecimal, 10, 4, schema.TypeUnknown
+
+	// String types
+	case "CHAR", "VARCHAR", "TEXT":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+	case "NCHAR", "NVARCHAR", "NTEXT":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+	case "XML":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+
+	// Binary types
+	case "BINARY", "VARBINARY", "IMAGE":
+		return schema.TypeBinary, 0, 0, schema.TypeUnknown
+
+	// Date/Time
+	case "DATE":
+		return schema.TypeDate, 0, 0, schema.TypeUnknown
+	case "TIME":
+		return schema.TypeTime, 0, 0, schema.TypeUnknown
+	case "DATETIME", "DATETIME2", "SMALLDATETIME":
+		return schema.TypeTimestamp, 0, 0, schema.TypeUnknown
+	case "DATETIMEOFFSET":
+		return schema.TypeTimestampTZ, 0, 0, schema.TypeUnknown
+
+	// UUID
+	case "UNIQUEIDENTIFIER":
+		return schema.TypeUUID, 0, 0, schema.TypeUnknown
+
+	// Spatial types - return as string
+	case "GEOMETRY", "GEOGRAPHY":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+
+	// Hierarchical/Special
+	case "HIERARCHYID":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+	case "SQL_VARIANT":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+
+	default:
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+	}
+}

--- a/pkg/source/fabric/register.go
+++ b/pkg/source/fabric/register.go
@@ -1,0 +1,10 @@
+package fabric
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"fabric"},
+		func() interface{} { return NewFabricSource() },
+	)
+}

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/microsoft/go-mssqldb"
+	_ "github.com/microsoft/go-mssqldb/azuread" // registers the "azuresql" driver for Fabric
 	_ "github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,6 +261,30 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+		},
+		{
+			name: "fabric",
+			setup: func(t *testing.T, ctx context.Context) (string, string, func()) {
+				fabricURI := os.Getenv("GONG_TEST_FABRIC_URI")
+				if fabricURI == "" {
+					t.Skip("Set GONG_TEST_FABRIC_URI to run Fabric destination conformance, e.g. fabric://<clientid>:<secret>@<guid>.datawarehouse.fabric.microsoft.com/<warehouse>?tenant_id=<tid>")
+				}
+
+				table := fmt.Sprintf("dbo.conformance_%s", uniqueSuffix())
+				cleanup := func() {
+					db, err := sql.Open("azuresql", fabricConnString(fabricURI))
+					if err == nil {
+						_, _ = db.ExecContext(ctx, fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s", table, quoteTableMSSQL(table)))
+						_ = db.Close()
+					}
+				}
+				return fabricURI, table, cleanup
+			},
+			sqlBackend:            fabricBackend(),
+			mergeCapable:          true,
+			deleteInsertCapable:   true,
+			truncateInsertCapable: true,
+			scd2Capable:           true,
 		},
 		{
 			name: "cratedb",
@@ -1747,6 +1773,132 @@ func normalizeMSSQLType(mssqlType string) string {
 		return "float"
 	default:
 		return mssqlType
+	}
+}
+
+// fabricConnString converts a fabric:// URI into the sqlserver:// DSN understood
+// by the azuread ("azuresql") driver, mirroring fabric.uriToConnString.
+func fabricConnString(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return uri
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "1433"
+	}
+
+	var clientID, secret string
+	if u.User != nil {
+		clientID = u.User.Username()
+		secret, _ = u.User.Password()
+	}
+
+	database := strings.TrimPrefix(u.Path, "/")
+
+	query := u.Query()
+	query.Del("driver")
+	tenantID := query.Get("tenant_id")
+	query.Del("tenant_id")
+	if query.Get("fedauth") == "" {
+		if clientID != "" {
+			query.Set("fedauth", "ActiveDirectoryServicePrincipal")
+		} else {
+			query.Set("fedauth", "ActiveDirectoryDefault")
+		}
+	}
+	if database != "" {
+		query.Set("database", database)
+	}
+	if query.Get("encrypt") == "" {
+		query.Set("encrypt", "true")
+	}
+
+	connURL := &url.URL{Scheme: "sqlserver", Host: fmt.Sprintf("%s:%s", host, port)}
+	if clientID != "" {
+		userID := clientID
+		if tenantID != "" {
+			userID = clientID + "@" + tenantID
+		}
+		if secret != "" {
+			connURL.User = url.UserPassword(userID, secret)
+		} else {
+			connURL.User = url.User(userID)
+		}
+	}
+	connURL.RawQuery = query.Encode()
+	return connURL.String()
+}
+
+func fabricBackend() *sqlBackend {
+	return &sqlBackend{
+		openDB: func(uri string) (*sql.DB, error) {
+			return sql.Open("azuresql", fabricConnString(uri))
+		},
+		schemaTypes: func(db *sql.DB, table string) (map[string]string, error) {
+			schemaName, tableName := splitSchemaTable(table, "dbo")
+			rows, err := db.Query(`
+				SELECT COLUMN_NAME, DATA_TYPE
+				FROM INFORMATION_SCHEMA.COLUMNS
+				WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+				ORDER BY ORDINAL_POSITION
+			`, schemaName, tableName)
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = rows.Close() }()
+			out := map[string]string{}
+			for rows.Next() {
+				var name, dt string
+				if err := rows.Scan(&name, &dt); err != nil {
+					return nil, err
+				}
+				out[strings.ToLower(name)] = normalizeFabricType(dt)
+			}
+			return out, rows.Err()
+		},
+		expectedTypes: map[string]string{
+			"id":     "bigint",
+			"name":   "varchar",
+			"active": "bit",
+			"score":  "float",
+		},
+		countQuery: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteTableMSSQL(table))
+		},
+		nameByIDQuery: func(table string, id int) string {
+			return fmt.Sprintf("SELECT name FROM %s WHERE id=%d", quoteTableMSSQL(table), id)
+		},
+		ageByIDQuery: func(table string, id int) string {
+			return fmt.Sprintf("SELECT age FROM %s WHERE id=%d", quoteTableMSSQL(table), id)
+		},
+		scd2CountCurrent: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE _scd_is_current = 1", quoteTableMSSQL(table))
+		},
+		scd2CountByID: func(table string, id int) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE id = %d", quoteTableMSSQL(table), id)
+		},
+		scd2HistNoValidTo: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE _scd_is_current = 0 AND _scd_valid_to IS NULL", quoteTableMSSQL(table))
+		},
+	}
+}
+
+func normalizeFabricType(fabricType string) string {
+	fabricType = strings.ToLower(strings.TrimSpace(fabricType))
+	switch fabricType {
+	case "int", "integer", "bigint":
+		return "bigint"
+	case "varchar", "char":
+		return "varchar"
+	case "bit", "boolean", "bool":
+		return "bit"
+	case "float", "real", "double":
+		return "float"
+	default:
+		return fabricType
 	}
 }
 


### PR DESCRIPTION
Adds a `fabric://` destination for Microsoft Fabric Warehouse, which speaks the TDS/SQL Server protocol. Cloned from the mssql/synapse destinations with Fabric-specific deltas:

- Auth: Entra ID only, via the go-mssqldb azuread ("azuresql") driver. URI form fabric://<clientid>:<secret>@<host>/<wh>?tenant_id=<tid>; defaults to ActiveDirectoryServicePrincipal when creds are given, ActiveDirectoryDefault otherwise, with explicit ?fedauth= override.
- Types: VARCHAR/DATETIME2 (Fabric has no NVARCHAR/DATETIMEOFFSET/ MONEY/TINYINT/TEXT/JSON/XML).
- CREATE TABLE uses PRIMARY KEY NONCLUSTERED (...) NOT ENFORCED.
- Loading: batched multi-row INSERT (COPY INTO deferred).
- SupportsAtomicSwap()=false: staging lands in a separate schema and ALTER SCHEMA TRANSFER is not in Fabric's documented surface area, so replace writes directly to the target. Merge/delete-insert/SCD2/ truncate-insert reference cross-schema staging directly.
- Schema evolution adds nullable columns only; SupportsAlterType()=false (ALTER COLUMN type change is preview-only in Fabric).

Wires fabric into shorten.go and the interface-compliance test, and adds an env-gated (GONG_TEST_FABRIC_URI) conformance case plus a unit test for the URI->DSN conversion.