### PR TITLE
[codex] Coalesce duplicate canonical columns

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -583,13 +583,13 @@ func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.Tabl
 		renameMap = p.columnRenamer.Mapping()
 	}
 
-	srcByDestName := make(map[string]schema.Column, len(sourceSchema.Columns))
+	srcByDestName := make(map[string][]schema.Column, len(sourceSchema.Columns))
 	for _, c := range sourceSchema.Columns {
 		key := c.Name
 		if r, ok := renameMap[key]; ok {
 			key = r
 		}
-		srcByDestName[key] = c
+		srcByDestName[key] = append(srcByDestName[key], c)
 	}
 
 	fields := make([]arrow.Field, 0, len(destSchema.Columns))
@@ -597,10 +597,12 @@ func (p *Pipeline) buildBufferReaderTarget(sourceSchema, destSchema *schema.Tabl
 		if naming.IsIngestrColumn(dc.Name) || isSCD2MetadataColumn(dc.Name) {
 			continue
 		}
-		if sc, ok := srcByDestName[dc.Name]; ok {
-			m := sc
-			m.DataType, m.Precision, m.Scale, m.ArrayType = dc.DataType, dc.Precision, dc.Scale, dc.ArrayType
-			fields = append(fields, arrowField(sc.Name, m, m.Nullable || dc.Nullable)) // add columns using dest types but source names
+		if sourceCols, ok := srcByDestName[dc.Name]; ok {
+			for _, sc := range sourceCols {
+				m := sc
+				m.DataType, m.Precision, m.Scale, m.ArrayType = dc.DataType, dc.Precision, dc.Scale, dc.ArrayType
+				fields = append(fields, arrowField(sc.Name, m, m.Nullable || dc.Nullable)) // add columns using dest types but source names
+			}
 			continue
 		}
 		fields = append(fields, arrowField(dc.Name, dc, true)) // add soft deleted columns using dest names
@@ -1061,11 +1063,15 @@ func (p *Pipeline) applyColumnMapping(s *schema.TableSchema, mapping map[string]
 			s.Columns[i].Name = newName
 		}
 	}
+	s.Columns = dedupeMappedColumns(s.Columns)
+
 	for i, pk := range s.PrimaryKeys {
 		if newName, ok := mapping[pk]; ok {
 			s.PrimaryKeys[i] = newName
 		}
 	}
+	s.PrimaryKeys = dedupeStringsPreserveOrder(s.PrimaryKeys)
+
 	if newName, ok := mapping[s.IncrementalKey]; ok {
 		s.IncrementalKey = newName
 	}
@@ -1084,6 +1090,79 @@ func (p *Pipeline) applyColumnMapping(s *schema.TableSchema, mapping map[string]
 		}
 	}
 	p.columnRenamer = transformer.NewColumnRenamer(mapping)
+}
+
+func dedupeMappedColumns(columns []schema.Column) []schema.Column {
+	if len(columns) < 2 {
+		return columns
+	}
+
+	merged := make([]schema.Column, 0, len(columns))
+	indexByName := make(map[string]int, len(columns))
+	for _, col := range columns {
+		if idx, ok := indexByName[col.Name]; ok {
+			merged[idx] = mergeSchemaColumns(merged[idx], col)
+			continue
+		}
+		indexByName[col.Name] = len(merged)
+		merged = append(merged, col)
+	}
+
+	return merged
+}
+
+func mergeSchemaColumns(existing, next schema.Column) schema.Column {
+	merged := existing
+	merged.Nullable = existing.Nullable || next.Nullable
+	merged.IsPrimaryKey = existing.IsPrimaryKey || next.IsPrimaryKey
+	if next.MaxLength > merged.MaxLength {
+		merged.MaxLength = next.MaxLength
+	}
+
+	switch {
+	case existing.DataType == schema.TypeUnknown:
+		merged.DataType = next.DataType
+	case next.DataType == schema.TypeUnknown:
+		merged.DataType = existing.DataType
+	default:
+		merged.DataType, _ = schemaevolution.GetWidenedType(existing.DataType, next.DataType)
+	}
+
+	if merged.DataType == schema.TypeDecimal {
+		merged.Precision, merged.Scale = schemaevolution.MergeDecimalPrecision(existing, next)
+	} else {
+		merged.Precision = 0
+		merged.Scale = 0
+	}
+
+	if merged.DataType == schema.TypeArray {
+		if existing.ArrayType == next.ArrayType {
+			merged.ArrayType = existing.ArrayType
+		} else {
+			merged.ArrayType, _ = schemaevolution.GetWidenedType(existing.ArrayType, next.ArrayType)
+		}
+	} else {
+		merged.ArrayType = schema.TypeUnknown
+	}
+
+	return merged
+}
+
+func dedupeStringsPreserveOrder(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+
+	seen := make(map[string]bool, len(values))
+	deduped := values[:0]
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		deduped = append(deduped, value)
+	}
+	return deduped
 }
 
 func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1215,6 +1215,54 @@ func TestBuildBufferReaderTarget_HonorsRenamer(t *testing.T) {
 	}
 }
 
+func TestBuildBufferReaderTarget_KeepsAliasesForCanonicalDuplicate(t *testing.T) {
+	p := &Pipeline{
+		columnRenamer: transformer.NewColumnRenamer(map[string]string{
+			"userId": "user_id",
+			"UserID": "user_id",
+		}),
+	}
+	src := tschema(
+		"users",
+		tcol("_id", schema.TypeInt64),
+		tcol("userId", schema.TypeInt64),
+		tcol("user_id", schema.TypeInt64),
+		tcol("UserID", schema.TypeInt64),
+	)
+	dest := tschema(
+		"users",
+		tcol("_id", schema.TypeInt64),
+		tcol("user_id", schema.TypeInt64),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"_id", "userId", "user_id", "UserID"})
+}
+
+func TestApplyColumnMapping_DedupesCanonicalColumns(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("_id", schema.TypeInt64),
+		tcol("userId", schema.TypeInt32),
+		tcol("user_id", schema.TypeInt64),
+		tcol("UserID", schema.TypeInt64),
+	)
+	src.PrimaryKeys = []string{"userId", "UserID"}
+
+	p.applyColumnMapping(src, map[string]string{
+		"userId": "user_id",
+		"UserID": "user_id",
+	})
+
+	assertColumns(t, "columns", src.ColumnNames(), []string{"_id", "user_id"})
+	assertColumns(t, "primary keys", src.PrimaryKeys, []string{"user_id"})
+	if got := src.Columns[1].DataType; got != schema.TypeInt64 {
+		t.Fatalf("user_id type = %v, want %v", got, schema.TypeInt64)
+	}
+}
+
 // Case 7: realistic evolve scenario.
 func TestBuildBufferReaderTarget_EvolveScenario(t *testing.T) {
 	p := &Pipeline{}

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -1,11 +1,14 @@
 package transformer
 
 import (
+	"fmt"
+
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/databuffer"
 	"github.com/bruin-data/ingestr/pkg/schemainfer"
 )
 
@@ -40,23 +43,35 @@ func (r *ColumnRenamer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, e
 			continue
 		}
 
-		builder := array.NewBuilder(memory.DefaultAllocator, group.field.Type)
-		for row := 0; row < int(batch.NumRows()); row++ {
-			var val any
-			for _, colIdx := range group.indices {
-				col := batch.Column(colIdx)
-				if !col.IsNull(row) {
-					val = arrowutil.Value(col, row)
+		castedCols, err := castGroupColumns(batch, group)
+		if err != nil {
+			for _, col := range cols[:i] {
+				if col != nil {
+					col.Release()
 				}
 			}
-			if val == nil {
+			return nil, err
+		}
+
+		builder := array.NewBuilder(memory.DefaultAllocator, group.field.Type)
+		for row := 0; row < int(batch.NumRows()); row++ {
+			var selected arrow.Array
+			for _, col := range castedCols {
+				if !col.IsNull(row) {
+					selected = col
+				}
+			}
+			if selected == nil {
 				builder.AppendNull()
 			} else {
-				arrowconv.AppendValue(builder, val)
+				appendArrayValue(builder, selected, row)
 			}
 		}
 		cols[i] = builder.NewArray()
 		builder.Release()
+		for _, col := range castedCols {
+			col.Release()
+		}
 	}
 
 	newBatch := array.NewRecordBatch(newSchema, cols, batch.NumRows())
@@ -137,6 +152,60 @@ func mergeArrowFields(existing, next arrow.Field) arrow.Field {
 		Nullable: existing.Nullable || next.Nullable,
 		Metadata: existing.Metadata,
 	}
+}
+
+func appendArrayValue(builder array.Builder, col arrow.Array, row int) {
+	if err := builder.AppendValueFromString(col.ValueStr(row)); err == nil {
+		return
+	}
+	arrowconv.AppendValue(builder, arrowutil.Value(col, row))
+}
+
+func castGroupColumns(batch arrow.RecordBatch, group columnRenameGroup) ([]arrow.Array, error) {
+	castedCols := make([]arrow.Array, len(group.indices))
+	for i, colIdx := range group.indices {
+		col := batch.Column(colIdx)
+		if arrow.TypeEqual(col.DataType(), group.field.Type) {
+			col.Retain()
+			castedCols[i] = col
+			continue
+		}
+
+		casted, err := castColumnToField(batch, colIdx, group.field)
+		if err != nil {
+			for _, c := range castedCols {
+				if c != nil {
+					c.Release()
+				}
+			}
+			return nil, err
+		}
+		castedCols[i] = casted
+	}
+
+	return castedCols, nil
+}
+
+func castColumnToField(batch arrow.RecordBatch, colIdx int, field arrow.Field) (arrow.Array, error) {
+	sourceField := field
+	sourceField.Name = batch.Schema().Field(colIdx).Name
+	sourceField.Type = batch.Column(colIdx).DataType()
+	sourceSchema := arrow.NewSchema([]arrow.Field{sourceField}, nil)
+	sourceBatch := array.NewRecordBatch(sourceSchema, []arrow.Array{batch.Column(colIdx)}, batch.NumRows())
+	defer sourceBatch.Release()
+
+	targetField := field
+	targetField.Name = sourceField.Name
+	targetSchema := arrow.NewSchema([]arrow.Field{targetField}, nil)
+	castedBatch, err := databuffer.CastRecordToSchema(sourceBatch, targetSchema, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cast duplicate column %s to %s: %w", sourceField.Name, field.Type, err)
+	}
+	defer castedBatch.Release()
+
+	casted := castedBatch.Column(0)
+	casted.Retain()
+	return casted, nil
 }
 
 func schemaFromGroups(groups []columnRenameGroup) *arrow.Schema {

--- a/pkg/transformer/column_renamer.go
+++ b/pkg/transformer/column_renamer.go
@@ -3,6 +3,10 @@ package transformer
 import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/arrowutil"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 )
 
 // ColumnRenamer renames columns in record batches based on a mapping.
@@ -25,20 +29,38 @@ func (r *ColumnRenamer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, e
 		return batch, nil
 	}
 
-	// Build new schema with renamed fields
-	newSchema := r.OutputSchema(batch.Schema())
+	groups, hasDuplicates := r.outputGroups(batch.Schema())
+	newSchema := schemaFromGroups(groups)
 
-	// Collect columns (retain references)
-	cols := make([]arrow.Array, batch.NumCols())
-	for i := 0; i < int(batch.NumCols()); i++ {
-		cols[i] = batch.Column(i)
-		cols[i].Retain()
+	cols := make([]arrow.Array, len(groups))
+	for i, group := range groups {
+		if !hasDuplicates || len(group.indices) == 1 {
+			cols[i] = batch.Column(group.indices[0])
+			cols[i].Retain()
+			continue
+		}
+
+		builder := array.NewBuilder(memory.DefaultAllocator, group.field.Type)
+		for row := 0; row < int(batch.NumRows()); row++ {
+			var val any
+			for _, colIdx := range group.indices {
+				col := batch.Column(colIdx)
+				if !col.IsNull(row) {
+					val = arrowutil.Value(col, row)
+				}
+			}
+			if val == nil {
+				builder.AppendNull()
+			} else {
+				arrowconv.AppendValue(builder, val)
+			}
+		}
+		cols[i] = builder.NewArray()
+		builder.Release()
 	}
 
-	// Create new record batch with renamed schema
 	newBatch := array.NewRecordBatch(newSchema, cols, batch.NumRows())
 
-	// Release our references to the columns
 	for _, col := range cols {
 		col.Release()
 	}
@@ -52,21 +74,8 @@ func (r *ColumnRenamer) OutputSchema(inputSchema *arrow.Schema) *arrow.Schema {
 		return inputSchema
 	}
 
-	fields := make([]arrow.Field, len(inputSchema.Fields()))
-	for i, field := range inputSchema.Fields() {
-		newName := field.Name
-		if renamed, ok := r.mapping[field.Name]; ok {
-			newName = renamed
-		}
-		fields[i] = arrow.Field{
-			Name:     newName,
-			Type:     field.Type,
-			Nullable: field.Nullable,
-			Metadata: field.Metadata,
-		}
-	}
-
-	return arrow.NewSchema(fields, nil)
+	groups, _ := r.outputGroups(inputSchema)
+	return schemaFromGroups(groups)
 }
 
 // HasRenames returns true if any columns will be renamed.
@@ -77,4 +86,63 @@ func (r *ColumnRenamer) HasRenames() bool {
 // Mapping returns the column name mapping.
 func (r *ColumnRenamer) Mapping() map[string]string {
 	return r.mapping
+}
+
+type columnRenameGroup struct {
+	field   arrow.Field
+	indices []int
+}
+
+func (r *ColumnRenamer) outputGroups(inputSchema *arrow.Schema) ([]columnRenameGroup, bool) {
+	groups := make([]columnRenameGroup, 0, inputSchema.NumFields())
+	groupByName := make(map[string]int, inputSchema.NumFields())
+	hasDuplicates := false
+
+	for i, field := range inputSchema.Fields() {
+		field.Name = r.outputName(field.Name)
+		if groupIdx, ok := groupByName[field.Name]; ok {
+			hasDuplicates = true
+			group := &groups[groupIdx]
+			group.field = mergeArrowFields(group.field, field)
+			group.indices = append(group.indices, i)
+			continue
+		}
+
+		groupByName[field.Name] = len(groups)
+		groups = append(groups, columnRenameGroup{
+			field:   field,
+			indices: []int{i},
+		})
+	}
+
+	return groups, hasDuplicates
+}
+
+func (r *ColumnRenamer) outputName(name string) string {
+	if renamed, ok := r.mapping[name]; ok {
+		return renamed
+	}
+	return name
+}
+
+func mergeArrowFields(existing, next arrow.Field) arrow.Field {
+	mergedType, err := schemainfer.MergeArrowTypes(existing.Type, next.Type)
+	if err != nil {
+		mergedType = arrow.BinaryTypes.String
+	}
+
+	return arrow.Field{
+		Name:     existing.Name,
+		Type:     mergedType,
+		Nullable: existing.Nullable || next.Nullable,
+		Metadata: existing.Metadata,
+	}
+}
+
+func schemaFromGroups(groups []columnRenameGroup) *arrow.Schema {
+	fields := make([]arrow.Field, len(groups))
+	for i, group := range groups {
+		fields[i] = group.field
+	}
+	return arrow.NewSchema(fields, nil)
 }

--- a/pkg/transformer/column_renamer_test.go
+++ b/pkg/transformer/column_renamer_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/stretchr/testify/assert"
@@ -174,5 +175,48 @@ func TestColumnRenamer(t *testing.T) {
 		outputSchema := renamer.OutputSchema(inputSchema)
 		require.Equal(t, 1, outputSchema.NumFields())
 		assert.Equal(t, "user_id", outputSchema.Field(0).Name)
+	})
+
+	t.Run("CoalescesMixedNumericCanonicalNames", func(t *testing.T) {
+		mapping := map[string]string{
+			"totalCents": "total_cents",
+		}
+		renamer := NewColumnRenamer(mapping)
+
+		decimalType := &arrow.Decimal128Type{Precision: 38, Scale: 9}
+		fields := []arrow.Field{
+			{Name: "total_cents", Type: decimalType, Nullable: true},
+			{Name: "totalCents", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		decimalBuilder := array.NewDecimal128Builder(pool, decimalType)
+		defer decimalBuilder.Release()
+		decimalBuilder.Append(decimal128.FromI64(1250000000))
+		decimalBuilder.AppendNull()
+
+		intBuilder := array.NewInt32Builder(pool)
+		defer intBuilder.Release()
+		intBuilder.AppendNull()
+		intBuilder.Append(250)
+
+		cols := []arrow.Array{
+			decimalBuilder.NewArray(),
+			intBuilder.NewArray(),
+		}
+		batch := array.NewRecordBatch(inputSchema, cols, 2)
+		for _, col := range cols {
+			col.Release()
+		}
+		defer batch.Release()
+
+		transformed, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer transformed.Release()
+
+		require.Equal(t, int64(1), transformed.NumCols())
+		assert.Equal(t, decimalType, transformed.Schema().Field(0).Type)
+		assert.InDelta(t, 1.25, arrowutil.Value(transformed.Column(0), 0), 0.000001)
+		assert.InDelta(t, 250.0, arrowutil.Value(transformed.Column(0), 1), 0.000001)
 	})
 }

--- a/pkg/transformer/column_renamer_test.go
+++ b/pkg/transformer/column_renamer_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,5 +119,60 @@ func TestColumnRenamer(t *testing.T) {
 		assert.Equal(t, "other", outputSchema.Field(1).Name)
 		assert.Equal(t, arrow.BinaryTypes.String, outputSchema.Field(1).Type)
 		assert.False(t, outputSchema.Field(1).Nullable)
+	})
+
+	t.Run("CoalescesDuplicateCanonicalNames", func(t *testing.T) {
+		mapping := map[string]string{
+			"userId": "user_id",
+			"UserID": "user_id",
+		}
+		renamer := NewColumnRenamer(mapping)
+
+		fields := []arrow.Field{
+			{Name: "userId", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "user_id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "UserID", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		}
+		inputSchema := arrow.NewSchema(fields, nil)
+
+		userIDBuilder := array.NewInt64Builder(pool)
+		defer userIDBuilder.Release()
+		userIDBuilder.AppendValues([]int64{101, 0, 0, 401}, []bool{true, false, false, true})
+
+		userIDSnakeBuilder := array.NewInt64Builder(pool)
+		defer userIDSnakeBuilder.Release()
+		userIDSnakeBuilder.AppendValues([]int64{0, 202, 0, 402}, []bool{false, true, false, true})
+
+		userIDUpperBuilder := array.NewInt64Builder(pool)
+		defer userIDUpperBuilder.Release()
+		userIDUpperBuilder.AppendValues([]int64{0, 0, 303, 403}, []bool{false, false, true, true})
+
+		cols := []arrow.Array{
+			userIDBuilder.NewArray(),
+			userIDSnakeBuilder.NewArray(),
+			userIDUpperBuilder.NewArray(),
+		}
+		batch := array.NewRecordBatch(inputSchema, cols, 4)
+		for _, col := range cols {
+			col.Release()
+		}
+		defer batch.Release()
+
+		transformed, err := renamer.Transform(batch)
+		require.NoError(t, err)
+		defer transformed.Release()
+
+		require.Equal(t, int64(1), transformed.NumCols())
+		assert.Equal(t, "user_id", transformed.Schema().Field(0).Name)
+		assert.Equal(t, []any{int64(101), int64(202), int64(303), int64(403)}, []any{
+			arrowutil.Value(transformed.Column(0), 0),
+			arrowutil.Value(transformed.Column(0), 1),
+			arrowutil.Value(transformed.Column(0), 2),
+			arrowutil.Value(transformed.Column(0), 3),
+		})
+
+		outputSchema := renamer.OutputSchema(inputSchema)
+		require.Equal(t, 1, outputSchema.NumFields())
+		assert.Equal(t, "user_id", outputSchema.Field(0).Name)
 	})
 }


### PR DESCRIPTION
Fixes duplicate canonical column handling when multiple source columns normalize to the same destination name, for example userId/user_id/UserID. The root cause was that schema planning could keep duplicate normalized columns while runtime renaming emitted duplicate Arrow fields or lost aliases during buffered replay. This change dedupes mapped schema columns and primary keys, preserves all aliases during buffered replay, and coalesces duplicate output fields per row with the later non-null alias in schema order winning. Validated with go test ./pkg/transformer, go test ./pkg/pipeline, JSONL to DuckDB, JSONL to an existing DuckDB JSON column, and Postgres to DuckDB checks.