### PR TITLE
Retry hubspot search POSTs and observe 429s outside retry loop

### DIFF
--- a/pkg/http/options.go
+++ b/pkg/http/options.go
@@ -99,6 +99,12 @@ func WithDisableRetry() Option {
 	}
 }
 
+func WithAllowNonIdempotentRetry() Option {
+	return func(c *Client) {
+		c.resty.SetAllowNonIdempotentRetry(true)
+	}
+}
+
 func WithInsecureSkipVerify() Option {
 	return func(c *Client) {
 		c.resty.SetTransport(&http.Transport{

--- a/pkg/http/retry_test.go
+++ b/pkg/http/retry_test.go
@@ -1,0 +1,98 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newThrottleServer returns a test server that responds 429 for the first
+// throttleCount requests, then 200, while counting total requests received.
+func newThrottleServer(throttleCount int32) (*httptest.Server, *int32) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&hits, 1) <= throttleCount {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	return srv, &hits
+}
+
+func zeroDelayStrategy(_ *Response, _ error) (time.Duration, error) {
+	return time.Millisecond, nil
+}
+
+func TestPostNotRetriedByDefault(t *testing.T) {
+	srv, hits := newThrottleServer(5)
+	defer srv.Close()
+
+	client := New(
+		WithBaseURL(srv.URL),
+		WithRetry(5, time.Millisecond, time.Millisecond),
+		WithRetryStrategy(zeroDelayStrategy),
+	)
+	defer client.Close()
+
+	resp, err := client.R(context.Background()).Post("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 (no retry), got %d", resp.StatusCode())
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Fatalf("expected exactly 1 request without retry, got %d", got)
+	}
+}
+
+func TestPostRetriedWithAllowNonIdempotent(t *testing.T) {
+	srv, hits := newThrottleServer(3)
+	defer srv.Close()
+
+	client := New(
+		WithBaseURL(srv.URL),
+		WithRetry(5, time.Millisecond, time.Millisecond),
+		WithAllowNonIdempotentRetry(),
+		WithRetryStrategy(zeroDelayStrategy),
+	)
+	defer client.Close()
+
+	resp, err := client.R(context.Background()).Post("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		t.Fatalf("expected 200 after retries, got %d", resp.StatusCode())
+	}
+	if got := atomic.LoadInt32(hits); got != 4 {
+		t.Fatalf("expected 4 requests (3 x 429 + 1 x 200), got %d", got)
+	}
+}
+
+func TestGetRetriedByDefault(t *testing.T) {
+	srv, hits := newThrottleServer(2)
+	defer srv.Close()
+
+	client := New(
+		WithBaseURL(srv.URL),
+		WithRetry(5, time.Millisecond, time.Millisecond),
+		WithRetryStrategy(zeroDelayStrategy),
+	)
+	defer client.Close()
+
+	resp, err := client.R(context.Background()).Get("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		t.Fatalf("expected 200 after retries, got %d", resp.StatusCode())
+	}
+	if got := atomic.LoadInt32(hits); got != 3 {
+		t.Fatalf("expected 3 requests (2 x 429 + 1 x 200), got %d", got)
+	}
+}

--- a/pkg/http/retry_test.go
+++ b/pkg/http/retry_test.go
@@ -36,7 +36,9 @@ func TestPostNotRetriedByDefault(t *testing.T) {
 		WithRetry(5, time.Millisecond, time.Millisecond),
 		WithRetryStrategy(zeroDelayStrategy),
 	)
-	defer client.Close()
+	defer func() {
+		_ = client.Close()
+	}()
 
 	resp, err := client.R(context.Background()).Post("/")
 	if err != nil {
@@ -60,7 +62,9 @@ func TestPostRetriedWithAllowNonIdempotent(t *testing.T) {
 		WithAllowNonIdempotentRetry(),
 		WithRetryStrategy(zeroDelayStrategy),
 	)
-	defer client.Close()
+	defer func() {
+		_ = client.Close()
+	}()
 
 	resp, err := client.R(context.Background()).Post("/")
 	if err != nil {
@@ -83,7 +87,9 @@ func TestGetRetriedByDefault(t *testing.T) {
 		WithRetry(5, time.Millisecond, time.Millisecond),
 		WithRetryStrategy(zeroDelayStrategy),
 	)
-	defer client.Close()
+	defer func() {
+		_ = client.Close()
+	}()
 
 	resp, err := client.R(context.Background()).Get("/")
 	if err != nil {

--- a/pkg/source/hubspot/hubspot.go
+++ b/pkg/source/hubspot/hubspot.go
@@ -39,43 +39,37 @@ const (
 	retryMaxWait = 5 * time.Minute
 )
 
-// makeRetryStrategy returns a resty retry-delay function that honors the
-// standard Retry-After HTTP header or the `retry_after` field HubSpot/Cloudflare
-// returns in JSON error bodies, falling back to exponential backoff with
-// equal jitter. When a 429 is observed it signals the adaptive limiter to
-// shrink before the next attempt fires.
-func makeRetryStrategy(adaptive *adaptiveLimiter) func(*httpclient.Response, error) (time.Duration, error) {
-	return func(resp *httpclient.Response, _ error) (time.Duration, error) {
-		if resp != nil && resp.StatusCode() == http.StatusTooManyRequests && adaptive != nil {
-			adaptive.onThrottle()
-		}
-
-		if resp != nil {
-			if v := resp.Header().Get("Retry-After"); v != "" {
-				if secs, parseErr := strconv.Atoi(v); parseErr == nil && secs > 0 {
-					return jitter(time.Duration(secs) * time.Second), nil
-				}
-			}
-			var body struct {
-				RetryAfter int `json:"retry_after"`
-			}
-			if jsonErr := json.Unmarshal(resp.Body(), &body); jsonErr == nil && body.RetryAfter > 0 {
-				return jitter(time.Duration(body.RetryAfter) * time.Second), nil
+// hubspotRetryStrategy honors the standard Retry-After HTTP header or the
+// `retry_after` field HubSpot/Cloudflare returns in JSON error bodies, falling
+// back to exponential backoff with equal jitter. Limiter adjustment is handled
+// by the response middleware (see attachAdaptiveHooks), not here, so that 429s
+// are observed even when no retry is scheduled.
+func hubspotRetryStrategy(resp *httpclient.Response, _ error) (time.Duration, error) {
+	if resp != nil {
+		if v := resp.Header().Get("Retry-After"); v != "" {
+			if secs, parseErr := strconv.Atoi(v); parseErr == nil && secs > 0 {
+				return jitter(time.Duration(secs) * time.Second), nil
 			}
 		}
-
-		attempt := 1
-		if resp != nil {
-			if a := resp.Attempt(); a > 0 {
-				attempt = a
-			}
+		var body struct {
+			RetryAfter int `json:"retry_after"`
 		}
-		delay := time.Duration(math.Min(
-			float64(retryMaxWait),
-			float64(retryWait)*math.Exp2(float64(attempt)),
-		))
-		return jitter(delay), nil
+		if jsonErr := json.Unmarshal(resp.Body(), &body); jsonErr == nil && body.RetryAfter > 0 {
+			return jitter(time.Duration(body.RetryAfter) * time.Second), nil
+		}
 	}
+
+	attempt := 1
+	if resp != nil {
+		if a := resp.Attempt(); a > 0 {
+			attempt = a
+		}
+	}
+	delay := time.Duration(math.Min(
+		float64(retryMaxWait),
+		float64(retryWait)*math.Exp2(float64(attempt)),
+	))
+	return jitter(delay), nil
 }
 
 // jitter applies equal-jitter (delay/2 fixed + delay/2 random) to break
@@ -126,32 +120,41 @@ func (s *Hubspotsource) Connect(ctx context.Context, uri string) error {
 		httpclient.WithTimeout(5*time.Minute),
 		httpclient.WithRateLimiterInstance(crmLimiter),
 		httpclient.WithRetry(retryCount, retryWait, retryMaxWait),
-		httpclient.WithRetryStrategy(makeRetryStrategy(s.crmAdaptive)),
+		httpclient.WithRetryStrategy(hubspotRetryStrategy),
 		httpclient.WithAuth(httpclient.NewBearerAuth(apiKey)),
 		httpclient.WithDebug(config.DebugMode),
 		httpclient.WithHeader("Accept", "application/json"),
 	)
-	attachSuccessHook(s.client, s.crmAdaptive)
+	attachAdaptiveHooks(s.client, s.crmAdaptive)
 
 	s.searchClient = httpclient.New(
 		httpclient.WithBaseURL(baseURL),
 		httpclient.WithTimeout(5*time.Minute),
 		httpclient.WithRateLimiterInstance(searchLimiter),
 		httpclient.WithRetry(retryCount, retryWait, retryMaxWait),
-		httpclient.WithRetryStrategy(makeRetryStrategy(s.searchAdaptive)),
+		// HubSpot search endpoints are POST but semantically read-only; without
+		// this resty treats them as non-idempotent and skips retries entirely.
+		httpclient.WithAllowNonIdempotentRetry(),
+		httpclient.WithRetryStrategy(hubspotRetryStrategy),
 		httpclient.WithAuth(httpclient.NewBearerAuth(apiKey)),
 		httpclient.WithDebug(config.DebugMode),
 		httpclient.WithHeader("Accept", "application/json"),
 	)
-	attachSuccessHook(s.searchClient, s.searchAdaptive)
+	attachAdaptiveHooks(s.searchClient, s.searchAdaptive)
 
 	config.Debug("[HUBSPOT] Connected successfully")
 	return nil
 }
 
-func attachSuccessHook(client *httpclient.Client, adaptive *adaptiveLimiter) {
+// attachAdaptiveHooks drives the adaptive limiter from every response, not just
+// retried ones: a 429 shrinks the rate (even on the final attempt or when no
+// retry is scheduled), and a 2xx counts toward growing it back.
+func attachAdaptiveHooks(client *httpclient.Client, adaptive *adaptiveLimiter) {
 	client.Resty().AddResponseMiddleware(func(_ *resty.Client, resp *resty.Response) error {
-		if resp.StatusCode() >= 200 && resp.StatusCode() < 300 {
+		switch {
+		case resp.StatusCode() == http.StatusTooManyRequests:
+			adaptive.onThrottle()
+		case resp.StatusCode() >= 200 && resp.StatusCode() < 300:
 			adaptive.onSuccess()
 		}
 		return nil


### PR DESCRIPTION
HubSpot search endpoints are POST, which resty treats as non-idempotent and skips retrying — so a single 429 failed the request with zero retries. Enable AllowNonIdempotentRetry on the search client (the search POST is semantically a read).

Also move the adaptive limiter's throttle/success signals from the retry-delay strategy into a response middleware. The strategy only runs when a retry is scheduled, so 429s on the final attempt — or with retries skipped — never shrank the limiter. The middleware sees every response.