### PR TITLE
bigquery: make ADD COLUMN idempotent to fix schema evolution error

### DIFF
--- a/pkg/destination/bigquery/dialect.go
+++ b/pkg/destination/bigquery/dialect.go
@@ -20,7 +20,10 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+	// IF NOT EXISTS makes this idempotent: BigQuery's own PrepareTable also
+	// adds missing columns via the table-metadata API, so by the time this
+	// SQL runs the column may already exist.
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s",
 		table,
 		d.QuoteIdentifier(col.Name),
 		d.TypeName(col))
@@ -29,7 +32,7 @@ func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
 func (d *Dialect) BatchAddColumnsSQL(table string, cols []schema.Column) string {
 	clauses := make([]string, 0, len(cols))
 	for _, col := range cols {
-		clauses = append(clauses, fmt.Sprintf("ADD COLUMN %s %s", d.QuoteIdentifier(col.Name), d.TypeName(col)))
+		clauses = append(clauses, fmt.Sprintf("ADD COLUMN IF NOT EXISTS %s %s", d.QuoteIdentifier(col.Name), d.TypeName(col)))
 	}
 	return fmt.Sprintf("ALTER TABLE %s %s", table, strings.Join(clauses, ", "))
 }


### PR DESCRIPTION
## Summary
- BigQuery destination has two parallel mechanisms that add new source columns to an existing destination table: `addMissingColumns` inside `PrepareTable` (BigQuery table-metadata API), and the deferred schema-evolution plan that strategies run via `job.ApplyEvolution` (SQL `ALTER TABLE ... ADD COLUMN`).
- Both fire on the same ingestion when a source has a new column. `addMissingColumns` runs first; the ALTER TABLE then fails with `Error 400: Column already exists`, breaking `merge`, `truncate+insert`, `append`, `delete+insert`, and `scd2` ingestions.
- Fix: emit `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` in the BigQuery schema-evolution dialect so the ALTER is idempotent. Both code paths now coexist safely — no behavior change for the other dialects.

### Reproduction (before fix)
1. `ingestr ingest --dest-uri 'bigquery://<project>/<dataset>' --incremental-strategy merge --primary-key id` with initial rows containing `id, name, age, score`.
2. Re-run with a source that adds a new `email` column.
3. Pipeline fails:
```
Error: ingestion failed: failed to apply schema evolution: failed to execute migration: ALTER TABLE … ADD COLUMN `email` STRING: googleapi: Error 400: Column already exists: email
```

### After fix
- `merge` (and other non-replace strategies) with a new column complete successfully; existing rows have `NULL` for the new column, new rows have the new value, table contains the new column.
- `replace` strategy continues to add new columns via `addMissingColumns` (unchanged path).
- Existing BigQuery unit tests and `pkg/schemaevolution` tests still pass.

## Test plan
- [x] Reproduced the original failure manually against a real BigQuery dataset using the `merge` strategy.
- [x] Verified the same scenario passes with the fix; verified row contents include the new column.
- [x] Verified `replace` strategy with a new column still succeeds.
- [x] `go test -short ./pkg/destination/bigquery/... ./pkg/schemaevolution/...` passes.
- [ ] CI: full integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)