### PR TITLE
Stay strictly under MSSQL/Fabric 2100-parameter limit

### DIFF
--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -19,7 +19,8 @@ import (
 )
 
 // maxParamLimit is the go-mssqldb driver parameter limit, shared with Fabric's
-// TDS endpoint. Multi-row INSERTs are batched to stay under it.
+// TDS endpoint. The server documents 2100 as the maximum but rejects requests
+// at exactly 2100, so we batch to stay strictly below it.
 const maxParamLimit = 2100
 
 type FabricDestination struct {
@@ -280,7 +281,7 @@ func (d *FabricDestination) writeRecordBatch(ctx context.Context, record arrow.R
 	}
 	colList := strings.Join(colNames, ", ")
 
-	maxRowsPerBatch := maxParamLimit / numCols
+	maxRowsPerBatch := (maxParamLimit - 1) / numCols
 	if maxRowsPerBatch > 1000 {
 		maxRowsPerBatch = 1000
 	}

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -228,7 +228,9 @@ func (d *SynapseDestination) WriteParallel(ctx context.Context, records <-chan s
 	return nil
 }
 
-// maxParamLimit is the go-mssqldb driver parameter limit.
+// maxParamLimit is the go-mssqldb driver parameter limit. The server documents
+// 2100 as the maximum but rejects requests at exactly 2100, so we batch to stay
+// strictly below it.
 const maxParamLimit = 2100
 
 func (d *SynapseDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
@@ -245,7 +247,7 @@ func (d *SynapseDestination) writeRecordBatch(ctx context.Context, record arrow.
 	}
 	colList := strings.Join(colNames, ", ")
 
-	maxRowsPerBatch := maxParamLimit / numCols
+	maxRowsPerBatch := (maxParamLimit - 1) / numCols
 	if maxRowsPerBatch > 1000 {
 		maxRowsPerBatch = 1000
 	}


### PR DESCRIPTION
Integer division of 2100 by numCols can yield a batch size that multiplies back to exactly 2100 (e.g. 6 cols -> 350 rows). The server rejects requests at exactly 2100 despite documenting it as the maximum, so subtract 1 before dividing.