### PR TITLE
[codex] Tag integration tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+# Integration tests are behind the `integration` build tag. Without this,
+# golangci-lint would silently drop those files from analysis.
+run:
+  build-tags:
+    - integration

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test: generate
 
 test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && go test -tags integration -v -p 64 -parallel 64 -timeout 10m ./...
+	@if [ -f test.env ]; then . ./test.env; fi && go test -tags integration -v -p 64 -parallel 64 -timeout 10m ./tests/integration/...
 
 test-conformance:
 	@echo "$(OK_COLOR)==> Running destination standards tests$(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ test: generate
 
 test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && go test -v -p 64 -parallel 64 -timeout 10m ./tests/integration/...
+	@if [ -f test.env ]; then . ./test.env; fi && go test -tags integration -v -p 64 -parallel 64 -timeout 10m ./...
 
 test-conformance:
 	@echo "$(OK_COLOR)==> Running destination standards tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && go test -v -timeout 10m ./tests/integration -run TestDestinations_
+	@if [ -f test.env ]; then . ./test.env; fi && go test -tags integration -v -timeout 10m ./tests/integration -run TestDestinations_
 
 
 # Format code and run linters (for local development)

--- a/pkg/destination/clickhouse/integration_test.go
+++ b/pkg/destination/clickhouse/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package clickhouse_test
 
 import (

--- a/pkg/destination/trino/trino_swap_test.go
+++ b/pkg/destination/trino/trino_swap_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package trino
 
 import (

--- a/pkg/source/airtable/airtable_integration_test.go
+++ b/pkg/source/airtable/airtable_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package airtable_test
 
 import (

--- a/pkg/source/allium/allium_integration_test.go
+++ b/pkg/source/allium/allium_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package allium_test
 
 import (

--- a/pkg/source/asana/asana_integration_test.go
+++ b/pkg/source/asana/asana_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package asana_test
 
 import (

--- a/pkg/source/clickhouse/integration_test.go
+++ b/pkg/source/clickhouse/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package clickhouse_test
 
 import (

--- a/pkg/source/clickup/clickup_integration_test.go
+++ b/pkg/source/clickup/clickup_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package clickup_test
 
 import (

--- a/pkg/source/couchbase/couchbase_integration_test.go
+++ b/pkg/source/couchbase/couchbase_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package couchbase_test
 
 import (

--- a/pkg/source/customerio/customerio_integration_test.go
+++ b/pkg/source/customerio/customerio_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package customerio_test
 
 import (

--- a/pkg/source/fireflies/fireflies_integration_test.go
+++ b/pkg/source/fireflies/fireflies_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package fireflies_test
 
 import (

--- a/pkg/source/frankfurter/frankfurter_integration_test.go
+++ b/pkg/source/frankfurter/frankfurter_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package frankfurter_test
 
 import (

--- a/pkg/source/freshdesk/freshdesk_integration_test.go
+++ b/pkg/source/freshdesk/freshdesk_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package freshdesk_test
 
 import (

--- a/pkg/source/github/github_integration_test.go
+++ b/pkg/source/github/github_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package github_test
 
 import (

--- a/pkg/source/gorgias/gorgias_integration_test.go
+++ b/pkg/source/gorgias/gorgias_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package gorgias_test
 
 import (

--- a/pkg/source/influxdb/influxdb_integration_test.go
+++ b/pkg/source/influxdb/influxdb_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package influxdb_test
 
 import (

--- a/pkg/source/intercom/intercom_integration_test.go
+++ b/pkg/source/intercom/intercom_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package intercom_test
 
 import (

--- a/pkg/source/jira/jira_integration_test.go
+++ b/pkg/source/jira/jira_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package jira_test
 
 import (

--- a/pkg/source/klaviyo/klaviyo_integration_test.go
+++ b/pkg/source/klaviyo/klaviyo_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package klaviyo_test
 
 import (

--- a/pkg/source/linear/linear_integration_test.go
+++ b/pkg/source/linear/linear_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package linear_test
 
 import (

--- a/pkg/source/mailchimp/mailchimp_integration_test.go
+++ b/pkg/source/mailchimp/mailchimp_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package mailchimp_test
 
 import (

--- a/pkg/source/mixpanel/mixpanel_integration_test.go
+++ b/pkg/source/mixpanel/mixpanel_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package mixpanel_test
 
 import (

--- a/pkg/source/monday/monday_integration_test.go
+++ b/pkg/source/monday/monday_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package monday_test
 
 import (

--- a/pkg/source/notion/notion_integration_test.go
+++ b/pkg/source/notion/notion_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package notion_test
 
 import (

--- a/pkg/source/personio/personio_integration_test.go
+++ b/pkg/source/personio/personio_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package personio
 
 import (

--- a/pkg/source/pinterest/pinterest_integration_test.go
+++ b/pkg/source/pinterest/pinterest_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package pinterest_test
 
 import (

--- a/pkg/source/pipedrive/pipedrive_integration_test.go
+++ b/pkg/source/pipedrive/pipedrive_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package pipedrive_test
 
 import (

--- a/pkg/source/plusvibeai/plusvibeai_integration_test.go
+++ b/pkg/source/plusvibeai/plusvibeai_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package plusvibeai
 
 import (

--- a/pkg/source/posthog/posthog_integration_test.go
+++ b/pkg/source/posthog/posthog_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package posthog_test
 
 import (

--- a/pkg/source/primer/primer_integration_test.go
+++ b/pkg/source/primer/primer_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package primer
 
 import (

--- a/pkg/source/quickbooks/quickbooks_integration_test.go
+++ b/pkg/source/quickbooks/quickbooks_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package quickbooks_test
 
 import (

--- a/pkg/source/revenuecat/revenuecat_integration_test.go
+++ b/pkg/source/revenuecat/revenuecat_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package revenuecat_test
 
 import (

--- a/pkg/source/salesforce/salesforce_integration_test.go
+++ b/pkg/source/salesforce/salesforce_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package salesforce_test
 
 import (

--- a/pkg/source/shopify/shopify_integration_test.go
+++ b/pkg/source/shopify/shopify_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package shopify_test
 
 import (

--- a/pkg/source/slack/slack_integration_test.go
+++ b/pkg/source/slack/slack_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package slack_test
 
 import (

--- a/pkg/source/stripe/stripe_integration_test.go
+++ b/pkg/source/stripe/stripe_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package stripe_test
 
 import (

--- a/pkg/source/wise/wise_integration_test.go
+++ b/pkg/source/wise/wise_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package wise_test
 
 import (

--- a/pkg/source/zoom/zoom_integration_test.go
+++ b/pkg/source/zoom/zoom_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package zoom_test
 
 import (

--- a/tests/integration/bigquery_dedup_test.go
+++ b/tests/integration/bigquery_dedup_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/blobstore_test.go
+++ b/tests/integration/blobstore_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/clickhouse_container_test.go
+++ b/tests/integration/clickhouse_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/column_overrides_test.go
+++ b/tests/integration/column_overrides_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // CSV → DuckDB end-to-end tests for the --columns flag. DuckDB is in-process
 // (no container needed), but these tests still live in package integration
 // so they share fixtures with the Postgres variant in

--- a/tests/integration/cratedb_container_test.go
+++ b/tests/integration/cratedb_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/custom_query_test.go
+++ b/tests/integration/custom_query_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/delete_insert_test.go
+++ b/tests/integration/delete_insert_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/dynamodb_container_test.go
+++ b/tests/integration/dynamodb_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/dynamodb_test.go
+++ b/tests/integration/dynamodb_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/dynamodb_types_test.go
+++ b/tests/integration/dynamodb_types_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/file_seed_test.go
+++ b/tests/integration/file_seed_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/minio_container_test.go
+++ b/tests/integration/minio_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/mongodb_evolution_test.go
+++ b/tests/integration/mongodb_evolution_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/mssql_confidence_test.go
+++ b/tests/integration/mssql_confidence_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/mssql_container_test.go
+++ b/tests/integration/mssql_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/multitable_conformance_test.go
+++ b/tests/integration/multitable_conformance_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/mysql_container_test.go
+++ b/tests/integration/mysql_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/override_naming_collision_test.go
+++ b/tests/integration/override_naming_collision_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/postgres_container_test.go
+++ b/tests/integration/postgres_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/rabbitmq_container_test.go
+++ b/tests/integration/rabbitmq_container_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/rabbitmq_test.go
+++ b/tests/integration/rabbitmq_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/restricted_permissions_test.go
+++ b/tests/integration/restricted_permissions_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/schema_contract_test.go
+++ b/tests/integration/schema_contract_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/shared_postgres_usage_test.go
+++ b/tests/integration/shared_postgres_usage_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/staging_inspect_test.go
+++ b/tests/integration/staging_inspect_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/swap_table_test.go
+++ b/tests/integration/swap_table_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/tests/integration/testenv_postgres_test.go
+++ b/tests/integration/testenv_postgres_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (


### PR DESCRIPTION
Adds the `integration` build tag to integration-style tests so the short `make test` path does not compile and verify those binaries. Updates `make test-integration` and `make test-conformance` to opt into that tag, preserving explicit integration coverage. Adds golangci-lint build-tag config so the tagged tests remain visible to linting. Validated with `make test`.