### PR TITLE
fix(postgres-cdc): accumulate single-table CDC batches across transac…

### DIFF
--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -120,6 +121,21 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 
 	accum := newBatchAccumulator(batchSize)
 
+	return streamLoop(ctx, repl, r.cdcConfig.Mode, targetLSN, batchSize, accum, results)
+}
+
+// batchReplicator is the subset of *Replicator that streamLoop depends on,
+// allowing the accumulation loop to be tested without a live connection.
+type batchReplicator interface {
+	NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, bool, error)
+	CurrentLSN() pglogrepl.LSN
+}
+
+// streamLoop pulls batches from repl and feeds them through the accumulator,
+// flushing only when the replicator reports a genuine idle period. Treating
+// every batch-less call as idle would flush after every transaction and defeat
+// accumulation entirely (see hadActivity in Replicator.NextBatch).
+func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, targetLSN pglogrepl.LSN, batchSize int, accum *batchAccumulator, results chan<- source.RecordBatchResult) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -129,7 +145,7 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 		default:
 		}
 
-		batch, err := repl.NextBatch(ctx, batchSize)
+		batch, hadActivity, err := repl.NextBatch(ctx, batchSize)
 		if err != nil {
 			accum.flushAll(results)
 			return fmt.Errorf("failed to get next batch: %w", err)
@@ -142,7 +158,7 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 		accum.flushReady(results)
 
 		// For batch mode, check if we've caught up to the target LSN
-		if r.cdcConfig.Mode == ModeBatch && targetLSN > 0 {
+		if mode == ModeBatch && targetLSN > 0 {
 			currentLSN := repl.CurrentLSN()
 			if currentLSN >= targetLSN {
 				config.Debug("[CDC] Batch mode: reached target LSN %s (current: %s)", targetLSN, currentLSN)
@@ -151,8 +167,10 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 			}
 		}
 
-		// When idle (no data from WAL), flush any pending batches
-		if batch == nil || batch.NumRows() == 0 {
+		// When idle (no WAL activity), flush any pending batches. Buffered
+		// non-commit messages and keepalives count as activity, so we keep
+		// accumulating across transactions instead of flushing each one.
+		if !hadActivity {
 			accum.flushAll(results)
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -83,11 +83,16 @@ func (r *Replicator) CurrentLSN() pglogrepl.LSN {
 	return r.clientXLogPos
 }
 
-func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, error) {
+// NextBatch returns the next decoded batch, if any. The hadActivity flag
+// distinguishes a genuine idle period (receive timeout / nil message) from
+// WAL activity that produced no batch yet (keepalives, buffered Begin/Insert/
+// Update/Delete messages awaiting a Commit). Callers use it to avoid flushing
+// the batch accumulator after every transaction.
+func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, bool, error) {
 	// Start replication if not yet started
 	if !r.started {
 		if err := r.Start(ctx); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
@@ -113,30 +118,30 @@ func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.Record
 	msg, err := r.source.replConn.ReceiveMessage(ctxWithTimeout)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, false, ctx.Err()
 		}
 		// Timeout is expected when no data is available
 		if ctxWithTimeout.Err() != nil {
-			return nil, nil
+			return nil, false, nil
 		}
-		return nil, fmt.Errorf("failed to receive message: %w", err)
+		return nil, false, fmt.Errorf("failed to receive message: %w", err)
 	}
 
 	if msg == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	switch msg := msg.(type) {
 	case *pgproto3.CopyData:
 		if len(msg.Data) == 0 {
-			return nil, nil
+			return nil, true, nil // Received a message, even if empty
 		}
 
 		switch msg.Data[0] {
 		case pglogrepl.PrimaryKeepaliveMessageByteID:
 			pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse keepalive: %w", err)
+				return nil, true, fmt.Errorf("failed to parse keepalive: %w", err)
 			}
 
 			if pkm.ReplyRequested {
@@ -150,21 +155,21 @@ func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.Record
 		case pglogrepl.XLogDataByteID:
 			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse xlog data: %w", err)
+				return nil, true, fmt.Errorf("failed to parse xlog data: %w", err)
 			}
 
 			batch, err := r.decoder.Decode(xld.WALData, xld.WALStart)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode WAL data: %w", err)
+				return nil, true, fmt.Errorf("failed to decode WAL data: %w", err)
 			}
 
 			if xld.WALStart > r.clientXLogPos {
 				r.clientXLogPos = xld.WALStart
 			}
 
-			return batch, nil
+			return batch, true, nil
 		}
 	}
 
-	return nil, nil
+	return nil, true, nil // Received some message type we don't handle
 }

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -72,7 +72,8 @@ func buildSingleRowTxnStream(n int) (steps []replStep, targetLSN pglogrepl.LSN) 
 		return replStep{batch: batch, hadActivity: true, lsn: lsn}
 	}
 	for i := range n {
-		steps = append(steps,
+		steps = append(
+			steps,
 			next(nil),                    // Begin
 			next(nil),                    // Insert
 			next(makeRowBatch(int64(i))), // Commit

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -1,0 +1,116 @@
+package postgres_cdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// replStep is one NextBatch result in a scripted WAL stream.
+type replStep struct {
+	batch       arrow.RecordBatch
+	hadActivity bool
+	lsn         pglogrepl.LSN
+}
+
+// fakeReplicator replays a scripted sequence of NextBatch results, mimicking
+// the WAL message stream a real Replicator produces (Begin/Insert/Relation
+// messages return no batch but are still activity; only Commit yields a batch).
+type fakeReplicator struct {
+	steps []replStep
+	idx   int
+	lsn   pglogrepl.LSN
+}
+
+func (f *fakeReplicator) NextBatch(_ context.Context, _ int) (arrow.RecordBatch, bool, error) {
+	if f.idx >= len(f.steps) {
+		// Stream exhausted: report idle with no further LSN progress.
+		return nil, false, nil
+	}
+	s := f.steps[f.idx]
+	f.idx++
+	if s.lsn > f.lsn {
+		f.lsn = s.lsn
+	}
+	return s.batch, s.hadActivity, nil
+}
+
+func (f *fakeReplicator) CurrentLSN() pglogrepl.LSN { return f.lsn }
+
+func makeRowBatch(id int64) arrow.RecordBatch {
+	mem := memory.NewGoAllocator()
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	b := array.NewInt64Builder(mem)
+	defer b.Release()
+	b.Append(id)
+	col := b.NewArray()
+	defer col.Release()
+
+	return array.NewRecordBatch(arrowSchema, []arrow.Array{col}, 1)
+}
+
+// buildSingleRowTxnStream models n single-row transactions and returns the
+// scripted steps plus the target LSN (the LSN of the final commit). Each
+// transaction in the pgoutput protocol is Begin -> Insert -> Commit; Begin and
+// Insert produce no batch but ARE activity, and only Commit emits the 1-row
+// batch. LSNs increase monotonically across every step so batch mode only
+// catches up after the very last commit is read.
+func buildSingleRowTxnStream(n int) (steps []replStep, targetLSN pglogrepl.LSN) {
+	var lsn pglogrepl.LSN
+	next := func(batch arrow.RecordBatch) replStep {
+		lsn++
+		return replStep{batch: batch, hadActivity: true, lsn: lsn}
+	}
+	for i := range n {
+		steps = append(steps,
+			next(nil),                    // Begin
+			next(nil),                    // Insert
+			next(makeRowBatch(int64(i))), // Commit
+		)
+	}
+	return steps, lsn
+}
+
+func drainStreamLoop(t *testing.T, steps []replStep, targetLSN pglogrepl.LSN) (batchCount int, totalRows int64) {
+	t.Helper()
+
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, len(steps)+1)
+	accum := newBatchAccumulator(10000)
+
+	err := streamLoop(context.Background(), repl, ModeBatch, targetLSN, 10000, accum, results)
+	require.NoError(t, err)
+	close(results)
+
+	for res := range results {
+		require.NoError(t, res.Err)
+		batchCount++
+		totalRows += res.Batch.NumRows()
+	}
+	return batchCount, totalRows
+}
+
+// TestStreamLoopAccumulatesSingleRowTransactions is a regression test for the
+// bug where each single-row WAL transaction was emitted as its own batch
+// (batches == rows). With activity-aware idle detection, the per-transaction
+// 1-row batches accumulate and flush as a single merged batch.
+func TestStreamLoopAccumulatesSingleRowTransactions(t *testing.T) {
+	const numTxns = 50
+	steps, targetLSN := buildSingleRowTxnStream(numTxns)
+
+	batchCount, totalRows := drainStreamLoop(t, steps, targetLSN)
+
+	assert.Equal(t, int64(numTxns), totalRows, "all rows should be emitted")
+	assert.Equal(t, 1, batchCount, "single-row transactions should merge into one batch, not one batch per row")
+	assert.Less(t, batchCount, numTxns, "batch count must not equal row count")
+}


### PR DESCRIPTION
…tions

The single-table CDC streaming loop flushed the batch accumulator on every batch-less NextBatch call. Since each non-commit WAL message (Begin, Insert, keepalive, receive timeout) returns no batch, the accumulator was flushed after every transaction, emitting each single-row transaction as its own batch (batches == rows) and defeating accumulation entirely.

Mirror the multi-table path: Replicator.NextBatch now returns a hadActivity flag that is false only on a genuine idle period (timeout / nil message) and true for buffered WAL messages and keepalives. The loop flushes on !hadActivity, so per-transaction 1-row batches accumulate and flush as a single merged batch.

Extract the loop into a testable streamLoop function behind a batchReplicator interface and add a regression test that replays a realistic Begin/Insert/ Commit WAL stream and asserts the rows merge into one batch.