### PR TITLE
[codex] add snowflake destination benchmark

### DIFF
--- a/benchmarks/scenarios.yaml
+++ b/benchmarks/scenarios.yaml
@@ -55,6 +55,11 @@ destinations:
     uri_from_env: BENCH_BQ_URI
     table: bench_data
 
+  snowflake:
+    type: snowflake
+    uri_from_env: BENCH_SNOWFLAKE_URI
+    table: public.bench_data
+
 scenarios:
   # Local (self-contained, no external dependencies)
   - source: local_postgres
@@ -104,6 +109,10 @@ scenarios:
   - source: local_duckdb
     destination: bigquery
 
+  # Snowflake (requires BENCH_SNOWFLAKE_URI env var)
+  - source: local_duckdb
+    destination: snowflake
+
 tools:
   gong:
     binary: bin/ingestr
@@ -130,3 +139,4 @@ tools:
       - source_type: duckdb
       - destination_type: duckdb
       - destination_type: bigquery
+      - destination_type: snowflake

--- a/benchmarks/scripts/bench_dlt.py
+++ b/benchmarks/scripts/bench_dlt.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#     "dlt[postgres,duckdb,bigquery]==1.27.0",
+#     "dlt[postgres,duckdb,bigquery,snowflake]==1.27.0",
 #     "dlt-verified-sources @ git+https://github.com/dlt-hub/verified-sources.git@75b3ec17eab99d0079d9f61b7f47fc8b899a5738",
 #     "pymysql",
 #     "pymongo",
@@ -68,11 +68,22 @@ def mongodb_source(uri: str, table: str):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--source-uri", required=True)
+    parser.add_argument("--source-uri")
+    parser.add_argument("--source-uri-env")
     parser.add_argument("--source-table", required=True)
-    parser.add_argument("--dest-uri", required=True)
+    parser.add_argument("--dest-uri")
+    parser.add_argument("--dest-uri-env")
     parser.add_argument("--dest-table", required=True)
     args = parser.parse_args()
+
+    if args.source_uri_env:
+        args.source_uri = os.environ.get(args.source_uri_env)
+    if args.dest_uri_env:
+        args.dest_uri = os.environ.get(args.dest_uri_env)
+    if not args.source_uri:
+        raise ValueError("--source-uri or --source-uri-env is required")
+    if not args.dest_uri:
+        raise ValueError("--dest-uri or --dest-uri-env is required")
 
     if "." in args.source_table:
         src_schema, src_table = args.source_table.split(".", 1)
@@ -118,6 +129,8 @@ def main():
         if creds:
             bq_kwargs["credentials"] = creds
         destination = dlt.destinations.bigquery(**bq_kwargs)
+    elif dest_uri.startswith("snowflake://"):
+        destination = dlt.destinations.snowflake(credentials=dest_uri)
     else:
         raise ValueError(f"Unsupported destination: {dest_uri}")
 

--- a/benchmarks/scripts/runner.py
+++ b/benchmarks/scripts/runner.py
@@ -20,9 +20,11 @@ import fnmatch
 import glob
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
+from urllib.parse import parse_qs, unquote, urlparse
 from datetime import datetime
 from pathlib import Path
 
@@ -109,6 +111,82 @@ def bq_parts_from_uri(uri: str) -> tuple[str, str]:
     return project, dataset
 
 
+def snowflake_connection_from_uri(uri: str) -> dict:
+    parsed = urlparse(uri)
+    path_parts = [unquote(p) for p in parsed.path.strip("/").split("/") if p]
+    query = {k: v[-1] for k, v in parse_qs(parsed.query).items() if v}
+
+    cfg = {
+        "type": "snowflake",
+        "account": parsed.hostname or "",
+    }
+    if parsed.username:
+        cfg["user"] = unquote(parsed.username)
+    if parsed.password:
+        cfg["password"] = unquote(parsed.password)
+    if path_parts:
+        cfg["database"] = path_parts[0]
+    if len(path_parts) > 1:
+        cfg["schema"] = path_parts[1]
+
+    for key in (
+        "warehouse", "role", "authenticator", "token",
+        "private_key", "private_key_passphrase",
+    ):
+        if query.get(key):
+            cfg[key] = query[key]
+
+    return cfg
+
+
+def snowflake_name(name: str) -> str:
+    """Return Snowflake's stored identifier name for unquoted benchmark config."""
+    if name.startswith('"') and name.endswith('"'):
+        return name[1:-1].replace('""', '"')
+    return name.upper()
+
+
+def quote_snowflake_identifier(name: str) -> str:
+    stored = snowflake_name(name)
+    return f'"{stored.replace(chr(34), chr(34) + chr(34))}"'
+
+
+def snowflake_full_table(schema: str, table: str) -> str:
+    schema = schema or "PUBLIC"
+    return f"{quote_snowflake_identifier(schema)}.{quote_snowflake_identifier(table)}"
+
+
+def snowflake_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def snowflake_sql_command(uri: str, sql: str, mode: str = "exec") -> str:
+    helper = "./benchmarks/scripts/snowflake_sql.go"
+    env_name = env_name_for_uri(uri)
+    if env_name:
+        return (
+            f"cd {shlex.quote(str(PROJECT_ROOT))} && "
+            f"go run {shlex.quote(helper)} -mode {shlex.quote(mode)} "
+            f"-uri-env {shlex.quote(env_name)} {shlex.quote(sql)}"
+        )
+    return (
+        f"cd {shlex.quote(str(PROJECT_ROOT))} && "
+        f"go run {shlex.quote(helper)} -mode {shlex.quote(mode)} "
+        f"{shlex.quote(uri)} {shlex.quote(sql)}"
+    )
+
+
+def run_snowflake_sql(uri: str, sql: str, mode: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "_BENCH_SNOWFLAKE_SQL_URI": uri}
+    return subprocess.run(
+        ["go", "run", "./benchmarks/scripts/snowflake_sql.go",
+         "-mode", mode, "-uri-env", "_BENCH_SNOWFLAKE_SQL_URI", sql],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True, text=True, timeout=120,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
@@ -187,6 +265,33 @@ def translate_uri(uri: str, tool_cfg: dict) -> str:
     return uri
 
 
+def env_name_for_uri(uri: str) -> str | None:
+    for name, value in os.environ.items():
+        if value == uri and (
+            name.startswith("BENCH_")
+            or name.startswith("SNOWFLAKE_")
+            or name.endswith("_URI")
+        ):
+            return name
+    return None
+
+
+def shell_uri_arg(uri: str, tool_cfg: dict | None = None) -> str:
+    env_name = env_name_for_uri(uri)
+    if env_name and not (tool_cfg or {}).get("uri_scheme_overrides"):
+        return f'"${env_name}"'
+    if tool_cfg:
+        uri = translate_uri(uri, tool_cfg)
+    return shlex.quote(uri)
+
+
+def uri_option(flag: str, uri: str, tool_cfg: dict | None = None) -> str:
+    env_name = env_name_for_uri(uri)
+    if env_name and not (tool_cfg or {}).get("uri_scheme_overrides"):
+        return f"{flag}-env {shlex.quote(env_name)}"
+    return f"{flag} {shell_uri_arg(uri, tool_cfg)}"
+
+
 def sling_env_name(role: str, name: str) -> str:
     return f"SLING_{role}_{name.upper()}"
 
@@ -199,6 +304,8 @@ def sling_connection_value(uri: str, db_type: str) -> str:
         if creds:
             cfg["gc_key_file"] = creds
         return json.dumps(cfg)
+    if db_type == "snowflake":
+        return json.dumps(snowflake_connection_from_uri(uri))
     return uri
 
 
@@ -213,9 +320,9 @@ def build_tool_command(
         binary = PROJECT_ROOT / tool_cfg.get("binary", "bin/gong")
         return (
             f"INGESTR_DISABLE_TELEMETRY=1 DISABLE_TELEMETRY=1 '{binary}' ingest"
-            f" --source-uri '{src_uri}'"
+            f" --source-uri {shell_uri_arg(src_uri)}"
             f" --source-table '{src_table}'"
-            f" --dest-uri '{dst_uri}'"
+            f" --dest-uri {shell_uri_arg(dst_uri)}"
             f" --dest-table '{dst_table}'"
             f" --incremental-strategy replace --progress log --yes"
         )
@@ -226,14 +333,12 @@ def build_tool_command(
             "uv tool run --python 3.11 ingestr@0.14.141 ingest",
         )
         prefix = f"INGESTR_DISABLE_TELEMETRY=1 DISABLE_TELEMETRY=1 {prefix}"
-        tsrc = translate_uri(src_uri, tool_cfg)
-        tdst = translate_uri(dst_uri, tool_cfg)
         extra = tool_cfg.get("extra_args_by_source", {}).get(src_type, "")
         parts = [
             prefix,
-            f"--source-uri '{tsrc}'",
+            f"--source-uri {shell_uri_arg(src_uri, tool_cfg)}",
             f"--source-table '{src_table}'",
-            f"--dest-uri '{tdst}'",
+            f"--dest-uri {shell_uri_arg(dst_uri, tool_cfg)}",
             f"--dest-table '{dst_table}'",
             "--yes --full-refresh",
         ]
@@ -266,9 +371,9 @@ def build_tool_command(
         script = BENCH_DIR / tool_cfg.get("script", "scripts/bench_dlt.py")
         return (
             f"RUNTIME__DLTHUB_TELEMETRY=false uv run '{script}'"
-            f" --source-uri '{src_uri}'"
+            f" {uri_option('--source-uri', src_uri)}"
             f" --source-table '{src_table}'"
-            f" --dest-uri '{dst_uri}'"
+            f" {uri_option('--dest-uri', dst_uri)}"
             f" --dest-table '{dst_table}'"
         )
 
@@ -276,9 +381,9 @@ def build_tool_command(
         script = BENCH_DIR / tool_cfg.get("script", "scripts/bench_airbyte.py")
         return (
             f"AIRBYTE_ANALYTICS_DISABLED=1 DO_NOT_TRACK=1 uv run '{script}'"
-            f" --source-uri '{src_uri}'"
+            f" --source-uri {shell_uri_arg(src_uri)}"
             f" --source-table '{src_table}'"
-            f" --dest-uri '{dst_uri}'"
+            f" --dest-uri {shell_uri_arg(dst_uri)}"
             f" --dest-table '{dst_table}'"
         )
 
@@ -323,6 +428,15 @@ def build_prepare_command(
             for t in tables
         ]
         return "; ".join(cmds) + "; true"
+
+    if dst_type == "snowflake":
+        schema, table = parse_table_parts(dst_table)
+        tables = [table, "_dlt_loads", "_dlt_version", "_dlt_pipeline_state"]
+        drops = [
+            f"DROP TABLE IF EXISTS {snowflake_full_table(schema, t)}"
+            for t in tables
+        ]
+        return snowflake_sql_command(dst_uri, "; ".join(drops), mode="exec")
 
     raise ValueError(f"Unknown destination type: {dst_type}")
 
@@ -591,6 +705,34 @@ def query_destination(dst_type: str, dst_uri: str, table: str, schema: str, quer
             lines = [l.strip() for l in result.stdout.strip().split("\n") if l.strip()]
             if query_type == "columns":
                 return lines[1:] if len(lines) > 1 else []
+            return lines[-1] if lines else None
+
+        elif dst_type == "snowflake":
+            schema = schema or "PUBLIC"
+            full_table = snowflake_full_table(schema, table)
+            if query_type == "count":
+                sql = f"SELECT COUNT(*) FROM {full_table}"
+            elif query_type == "sum_id":
+                sql = f"SELECT COALESCE(SUM(ID), 0) FROM {full_table}"
+            elif query_type == "columns":
+                schema_name = snowflake_name(schema)
+                table_name = snowflake_name(table)
+                sql = (
+                    "SELECT LOWER(COLUMN_NAME) FROM INFORMATION_SCHEMA.COLUMNS "
+                    f"WHERE TABLE_SCHEMA = {snowflake_literal(schema_name)} "
+                    f"AND TABLE_NAME = {snowflake_literal(table_name)} "
+                    "ORDER BY ORDINAL_POSITION"
+                )
+            else:
+                return None
+
+            mode = "list" if query_type == "columns" else "scalar"
+            result = run_snowflake_sql(dst_uri, sql, mode)
+            if result.returncode != 0:
+                return None
+            lines = [l.strip() for l in result.stdout.strip().split("\n") if l.strip()]
+            if query_type == "columns":
+                return lines
             return lines[-1] if lines else None
 
     except Exception:

--- a/benchmarks/scripts/snowflake_sql.go
+++ b/benchmarks/scripts/snowflake_sql.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	sfauth "github.com/bruin-data/ingestr/pkg/snowflake"
+	_ "github.com/snowflakedb/gosnowflake"
+)
+
+func main() {
+	mode := flag.String("mode", "scalar", "execution mode: exec, scalar, or list")
+	timeout := flag.Duration("timeout", 2*time.Minute, "query timeout")
+	uriEnv := flag.String("uri-env", "", "environment variable containing the Snowflake URI")
+	flag.Parse()
+
+	var uri string
+	var query string
+	if *uriEnv != "" {
+		if flag.NArg() != 1 {
+			fmt.Fprintln(os.Stderr, "usage: snowflake_sql [-mode exec|scalar|list] -uri-env <env> <sql>")
+			os.Exit(2)
+		}
+		uri = os.Getenv(*uriEnv)
+		if uri == "" {
+			fmt.Fprintf(os.Stderr, "environment variable %s is not set\n", *uriEnv)
+			os.Exit(2)
+		}
+		query = flag.Arg(0)
+	} else {
+		if flag.NArg() != 2 {
+			fmt.Fprintln(os.Stderr, "usage: snowflake_sql [-mode exec|scalar|list] <snowflake-uri> <sql>")
+			os.Exit(2)
+		}
+		uri = flag.Arg(0)
+		query = flag.Arg(1)
+	}
+
+	if query == "" {
+		fmt.Fprintln(os.Stderr, "sql query is required")
+		os.Exit(2)
+	}
+
+	db, err := sfauth.OpenDB(uri)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open Snowflake connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	switch *mode {
+	case "exec":
+		err = execStatements(ctx, db, query)
+	case "scalar":
+		err = printScalar(ctx, db, query)
+	case "list":
+		err = printList(ctx, db, query)
+	default:
+		err = fmt.Errorf("unknown mode %q", *mode)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func execStatements(ctx context.Context, db *sql.DB, query string) error {
+	for _, stmt := range strings.Split(query, ";") {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to execute %q: %w", stmt, err)
+		}
+	}
+	return nil
+}
+
+func printScalar(ctx context.Context, db *sql.DB, query string) error {
+	var value any
+	if err := db.QueryRowContext(ctx, query).Scan(&value); err != nil {
+		return fmt.Errorf("failed to query scalar: %w", err)
+	}
+	fmt.Println(formatValue(value))
+	return nil
+}
+
+func printList(ctx context.Context, db *sql.DB, query string) error {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to query list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("failed to inspect columns: %w", err)
+	}
+	values := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range values {
+		ptrs[i] = &values[i]
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(ptrs...); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+		formatted := make([]string, len(values))
+		for i, value := range values {
+			formatted[i] = formatValue(value)
+		}
+		fmt.Println(strings.Join(formatted, "\t"))
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed while reading rows: %w", err)
+	}
+	return nil
+}
+
+func formatValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case []byte:
+		return string(v)
+	case time.Time:
+		return v.Format(time.RFC3339Nano)
+	default:
+		return fmt.Sprint(v)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a Snowflake destination benchmark scenario for the local DuckDB source.
- Add Snowflake cleanup and validation support to the benchmark runner.
- Add dlt Snowflake destination support and Sling Snowflake connection conversion for key-pair auth.
- Add a small Go SQL helper for Snowflake prepare/validation queries.

## Validation
- `python3 -m py_compile benchmarks/scripts/runner.py benchmarks/scripts/bench_dlt.py`
- `go test ./benchmarks/scripts ./pkg/snowflake ./pkg/destination/snowflake`
- `uv run benchmarks/scripts/runner.py --validate --tools sling --scenarios duckdb_to_snowflake --skip-setup`
- `uv run benchmarks/scripts/runner.py --validate --tools dlt --scenarios duckdb_to_snowflake --skip-setup`
- `uv run benchmarks/scripts/runner.py --rows 1000 --runs 1 --warmup 0 --tools sling dlt --scenarios duckdb_to_snowflake --skip-setup`

Observed 1k benchmark results:
- sling: 16.23s
- dlt: 17.89s
