### PR TITLE
[codex] add snowflake benchmark source scenarios

### DIFF
--- a/benchmarks/scenarios.yaml
+++ b/benchmarks/scenarios.yaml
@@ -110,6 +110,15 @@ scenarios:
     destination: bigquery
 
   # Snowflake (requires BENCH_SNOWFLAKE_URI env var)
+  - source: local_postgres
+    destination: snowflake
+
+  - source: local_mysql
+    destination: snowflake
+
+  - source: local_mongodb
+    destination: snowflake
+
   - source: local_duckdb
     destination: snowflake
 


### PR DESCRIPTION
## Summary
- Add Postgres, MySQL, and MongoDB source scenarios for the Snowflake benchmark destination.
- Keep the existing DuckDB-to-Snowflake scenario in the same Snowflake block.

## Validation
- `python3 -m py_compile benchmarks/scripts/runner.py`
- Verified `BENCH_SNOWFLAKE_URI` config resolution includes:
  - `postgres_to_snowflake`
  - `mysql_to_snowflake`
  - `mongodb_to_snowflake`
  - `duckdb_to_snowflake`
