### PR TITLE
Add LinkedIn Ads analytics streams

### DIFF
--- a/docs/supported-sources/linkedin_ads.md
+++ b/docs/supported-sources/linkedin_ads.md
@@ -62,9 +62,16 @@ LinkedIn Ads source allows ingesting the following sources into separate tables:
 | [conversions](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversion-tracking?view=li-lms-2024-11&tabs=http) | id | – | replace | Retrieves conversion rules for each ad account. |
 | [lead_forms](https://learn.microsoft.com/en-us/linkedin/marketing/lead-sync/leadsync?view=li-lms-2025-11&viewFallbackFrom=li-lms-2024-06&tabs=http#lead-forms-1) | id | – | replace | Retrieves lead generation forms for each ad account. |
 | [lead_form_responses](https://learn.microsoft.com/en-us/linkedin/marketing/lead-sync/leadsync?view=li-lms-2025-11&viewFallbackFrom=li-lms-2024-06&tabs=http#get-lead-form-responses) | id | date (interval)| merge | Retrieves lead form responses for each ad account. |
-| dmp_segments | id | – | replace | Retrieves matched/retargeting audience segments (sizes, match rates, rules) for each ad account. |
-| insight_tags | id | – | replace | Retrieves Insight Tag configuration and installation status for each ad account. |
-| insight_tag_domains | domainName, account_id | – | replace | Retrieves domains associated with Insight Tags for each ad account. |
+| ad_campaign_analytics | campaign, date | date | merge | Retrieves daily ad analytics by campaign. |
+| ad_creative_analytics | creative, date | date | merge | Retrieves daily ad analytics by creative. |
+| ad_impression_device_analytics | impression_device, date | date | merge | Retrieves daily ad analytics by impression device. |
+| ad_member_company_size_analytics | member_company_size, date | date | merge | Retrieves daily ad analytics by member company size. |
+| ad_member_country_analytics | member_country, date | date | merge | Retrieves daily ad analytics by member country. |
+| ad_member_job_function_analytics | member_job_function, date | date | merge | Retrieves daily ad analytics by member job function. |
+| ad_member_job_title_analytics | member_job_title, date | date | merge | Retrieves daily ad analytics by member job title. |
+| ad_member_industry_analytics | member_industry, date | date | merge | Retrieves daily ad analytics by member industry. |
+| ad_member_region_analytics | member_region, date | date | merge | Retrieves daily ad analytics by member region. |
+| ad_member_company_analytics | member_company, date | date | merge | Retrieves daily ad analytics by member company. |
 | [custom](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2024-11&tabs=http#analytics-finder) | [dimension, date] or [dimension, start_date, end_date] | date (daily) or start_date (monthly) | merge | Custom reports allow you to retrieve data based on specific dimensions and metrics. |
 
 Use these as `--source-table` parameter in the `ingestr ingest` command.
@@ -102,11 +109,14 @@ custom:<dimensions>:<metrics>
 ```
 
 **Parameters:**
-- `dimensions`(required): A comma-separated list of dimensions is required. It must include at least one entity dimension and one time-based dimension (`date` or `month`).
-  - Entity dimensions: `campaign`, `account`, `creative`
-  - Demographic dimensions: `member_job_title`, `member_seniority`, `member_industry`, `member_company_size`, `member_company`
-  - `date`: group the data in your report by day
-  - `month`: group the data in your report by month
+- `dimensions`(required): A comma-separated list of dimensions is required. It must include at least one pivot dimension and one time-based dimension (`date` or `month`).
+  - Pivot dimensions (pick one):
+    - Entity: `campaign`, `creative`, `account`
+    - Placement & device: `impression_device`
+    - Demographic: `member_job_title`, `member_job_function`, `member_industry`, `member_company_size`, `member_company`, `member_country`, `member_region`
+  - Time dimensions:
+    - `date`: group the data in your report by day
+    - `month`: group the data in your report by month
 - `metrics`(required): A comma-separated list of [metrics](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2024-11&tabs=http#metrics-available) to retrieve.
 
 > [!NOTE]
@@ -163,7 +173,7 @@ ingestr ingest \
     --dest-table 'dest.job_title_report'
 ```
 
-Available demographic dimensions: `member_job_title`, `member_seniority`, `member_industry`, `member_company_size`, `member_company`.
+Available demographic dimensions: `member_job_title`, `member_job_function`, `member_industry`, `member_company_size`, `member_company`, `member_country`, `member_region`.
 
 This command will retrieve data and save it to the destination table in the DuckDB database.
 

--- a/pkg/source/linkedin_ads/helpers.go
+++ b/pkg/source/linkedin_ads/helpers.go
@@ -195,6 +195,7 @@ const (
 )
 
 type customAnalyticsConfig struct {
+	tableName       string
 	dimensions      []string
 	metrics         []string
 	pivot           string
@@ -236,13 +237,17 @@ func parseCustomTableName(tableName string) (*customAnalyticsConfig, error) {
 		return nil, fmt.Errorf("at least one metric is required")
 	}
 
-	// Validate dimensions - must have one of campaign, creative, or account
-	validDimensions := []string{"campaign", "creative", "account"}
 	dimensionIdx := slices.IndexFunc(dimensions, func(d string) bool {
-		return slices.Contains(validDimensions, d)
+		_, ok := dimensionPivotMap[d]
+		return ok
 	})
 	if dimensionIdx == -1 {
-		return nil, fmt.Errorf("'campaign', 'creative' or 'account' is required in dimensions")
+		validDimensions := make([]string, 0, len(dimensionPivotMap))
+		for k := range dimensionPivotMap {
+			validDimensions = append(validDimensions, k)
+		}
+		slices.Sort(validDimensions)
+		return nil, fmt.Errorf("dimensions must include one of: %s", strings.Join(validDimensions, ", "))
 	}
 	pivot := dimensions[dimensionIdx]
 
@@ -273,6 +278,7 @@ func parseCustomTableName(tableName string) (*customAnalyticsConfig, error) {
 	}
 
 	return &customAnalyticsConfig{
+		tableName:       "custom_reports",
 		dimensions:      dimensions,
 		metrics:         metrics,
 		pivot:           pivot,
@@ -316,6 +322,24 @@ func findIntervals(startDate, endDate time.Time, granularity timeGranularity) ([
 	return intervals, nil
 }
 
+// dimensionPivotMap translates a user-supplied dimension name to the
+// LinkedIn Ad Analytics `pivot` API enum. Keep this as the single source of
+// truth — strings.ToUpper is unsafe because some enums have suffixes (e.g.
+// MEMBER_COUNTRY_V2, IMPRESSION_DEVICE_TYPE).
+var dimensionPivotMap = map[string]string{
+	"campaign":            "CAMPAIGN",
+	"creative":            "CREATIVE",
+	"account":             "ACCOUNT",
+	"impression_device":   "IMPRESSION_DEVICE_TYPE",
+	"member_job_title":    "MEMBER_JOB_TITLE",
+	"member_job_function": "MEMBER_JOB_FUNCTION",
+	"member_industry":     "MEMBER_INDUSTRY",
+	"member_company_size": "MEMBER_COMPANY_SIZE",
+	"member_company":      "MEMBER_COMPANY",
+	"member_country":      "MEMBER_COUNTRY_V2",
+	"member_region":       "MEMBER_REGION_V2",
+}
+
 func constructAnalyticsURL(start, end time.Time, accountIDs []string, metrics []string, pivot string, granularity timeGranularity) string {
 	dateRange := fmt.Sprintf("(start:(year:%d,month:%d,day:%d),end:(year:%d,month:%d,day:%d))",
 		start.Year(), int(start.Month()), start.Day(),
@@ -327,7 +351,7 @@ func constructAnalyticsURL(start, end time.Time, accountIDs []string, metrics []
 	}
 	accounts := fmt.Sprintf("List(%s)", strings.Join(encodedAccounts, ","))
 
-	pivotStr := strings.ToUpper(pivot)
+	pivotStr := dimensionPivotMap[pivot]
 	metricsStr := strings.Join(metrics, ",")
 
 	return fmt.Sprintf("/adAnalytics?q=analytics&timeGranularity=%s&dateRange=%s&accounts=%s&pivot=%s&fields=%s",

--- a/pkg/source/linkedin_ads/helpers_test.go
+++ b/pkg/source/linkedin_ads/helpers_test.go
@@ -200,6 +200,19 @@ func TestConstructAnalyticsURL(t *testing.T) {
 		expected := "/adAnalytics?q=analytics&timeGranularity=DAILY&dateRange=(start:(year:2024,month:6,day:15),end:(year:2024,month:12,day:15))&accounts=List(urn%3Ali%3AsponsoredAccount%3A999888)&pivot=ACCOUNT&fields=impressions,clicks"
 		assert.Equal(t, expected, url)
 	})
+
+	t.Run("daily granularity with impression device pivot", func(t *testing.T) {
+		start := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 12, 15, 0, 0, 0, 0, time.UTC)
+		accountIDs := []string{"999888"}
+		metrics := []string{"impressions", "clicks"}
+		pivot := "impression_device"
+
+		url := constructAnalyticsURL(start, end, accountIDs, metrics, pivot, timeGranularityDaily)
+
+		expected := "/adAnalytics?q=analytics&timeGranularity=DAILY&dateRange=(start:(year:2024,month:6,day:15),end:(year:2024,month:12,day:15))&accounts=List(urn%3Ali%3AsponsoredAccount%3A999888)&pivot=IMPRESSION_DEVICE_TYPE&fields=impressions,clicks"
+		assert.Equal(t, expected, url)
+	})
 }
 
 func TestParseCustomTable(t *testing.T) {
@@ -238,6 +251,15 @@ func TestParseCustomTable(t *testing.T) {
 		assert.Equal(t, "account", cfg.pivot)
 	})
 
+	t.Run("valid custom table with member country", func(t *testing.T) {
+		cfg, err := parseCustomTableName("custom:member_country,date:impressions")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg)
+		assert.Equal(t, "member_country", cfg.pivot)
+		assert.Equal(t, []string{"member_country", "date"}, cfg.primaryKeys)
+	})
+
 	t.Run("invalid format - missing parts", func(t *testing.T) {
 		_, err := parseCustomTableName("custom:campaign")
 
@@ -249,7 +271,7 @@ func TestParseCustomTable(t *testing.T) {
 		_, err := parseCustomTableName("custom:date:impressions")
 
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "'campaign', 'creative' or 'account' is required")
+		assert.Contains(t, err.Error(), "dimensions must include one of")
 	})
 
 	t.Run("invalid format - missing time dimension", func(t *testing.T) {
@@ -265,6 +287,45 @@ func TestParseCustomTable(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "at least one metric is required")
 	})
+
+	t.Run("invalid format - unsupported pivot", func(t *testing.T) {
+		_, err := parseCustomTableName("custom:objective_type,date:impressions")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "dimensions must include one of")
+	})
+}
+
+func TestAnalyticsTables(t *testing.T) {
+	s := NewLinkedInAdsSource()
+	tables := s.getTables()
+
+	testCases := []struct {
+		name string
+		pks  []string
+	}{
+		{name: "ad_campaign_analytics", pks: []string{"campaign", "date"}},
+		{name: "ad_creative_analytics", pks: []string{"creative", "date"}},
+		{name: "ad_impression_device_analytics", pks: []string{"impression_device", "date"}},
+		{name: "ad_member_company_size_analytics", pks: []string{"member_company_size", "date"}},
+		{name: "ad_member_country_analytics", pks: []string{"member_country", "date"}},
+		{name: "ad_member_job_function_analytics", pks: []string{"member_job_function", "date"}},
+		{name: "ad_member_job_title_analytics", pks: []string{"member_job_title", "date"}},
+		{name: "ad_member_industry_analytics", pks: []string{"member_industry", "date"}},
+		{name: "ad_member_region_analytics", pks: []string{"member_region", "date"}},
+		{name: "ad_member_company_analytics", pks: []string{"member_company", "date"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			table, ok := tables[tc.name]
+
+			assert.True(t, ok)
+			assert.Equal(t, tc.name, table.Name())
+			assert.Equal(t, tc.pks, table.PrimaryKeys())
+			assert.Equal(t, "date", table.IncrementalKey())
+		})
+	}
 }
 
 func TestParseTimeInterval(t *testing.T) {

--- a/pkg/source/linkedin_ads/linkedin_ads.go
+++ b/pkg/source/linkedin_ads/linkedin_ads.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -52,6 +53,45 @@ type accountFetchResult struct {
 }
 
 type accountItemFetcher func(ctx context.Context, accountID string, pageSize int) ([]map[string]interface{}, error)
+
+type analyticsTableConfig struct {
+	tableName string
+	pivot     string
+}
+
+var analyticsTableConfigs = []analyticsTableConfig{
+	{tableName: "ad_campaign_analytics", pivot: "campaign"},
+	{tableName: "ad_creative_analytics", pivot: "creative"},
+	{tableName: "ad_impression_device_analytics", pivot: "impression_device"},
+	{tableName: "ad_member_company_size_analytics", pivot: "member_company_size"},
+	{tableName: "ad_member_country_analytics", pivot: "member_country"},
+	{tableName: "ad_member_job_function_analytics", pivot: "member_job_function"},
+	{tableName: "ad_member_job_title_analytics", pivot: "member_job_title"},
+	{tableName: "ad_member_industry_analytics", pivot: "member_industry"},
+	{tableName: "ad_member_region_analytics", pivot: "member_region"},
+	{tableName: "ad_member_company_analytics", pivot: "member_company"},
+}
+
+var defaultAnalyticsMetrics = []string{
+	"actionClicks",
+	"adUnitClicks",
+	"clicks",
+	"commentLikes",
+	"comments",
+	"companyPageClicks",
+	"costInLocalCurrency",
+	"costInUsd",
+	"follows",
+	"impressions",
+	"landingPageClicks",
+	"likes",
+	"oneClickLeads",
+	"opens",
+	"sends",
+	"shares",
+	"totalEngagements",
+	"videoViews",
+}
 
 func NewLinkedInAdsSource() *LinkedInAdsSource {
 	return &LinkedInAdsSource{}
@@ -103,7 +143,7 @@ func (s *LinkedInAdsSource) GetTable(ctx context.Context, req source.TableReques
 
 	table, ok := s.tables[req.Name]
 	if !ok {
-		return nil, fmt.Errorf("unsupported table: %s (supported: ad_accounts, ad_account_users, campaign_groups, campaigns, creatives, conversions, lead_forms, lead_form_responses, custom:<dimensions>:<metrics>)", req.Name)
+		return nil, fmt.Errorf("unsupported table: %s (supported: ad_accounts, ad_account_users, campaign_groups, campaigns, creatives, conversions, lead_forms, lead_form_responses, ad_campaign_analytics, ad_creative_analytics, ad_impression_device_analytics, ad_member_company_size_analytics, ad_member_country_analytics, ad_member_job_function_analytics, ad_member_job_title_analytics, ad_member_industry_analytics, ad_member_region_analytics, ad_member_company_analytics, custom:<dimensions>:<metrics>)", req.Name)
 	}
 	return table, nil
 }
@@ -143,7 +183,7 @@ func (s *LinkedInAdsSource) getTables() map[string]source.SourceTable {
 		return nil, fmt.Errorf("LinkedIn Ads source does not have a predefined schema; schema inference is required")
 	}
 
-	return map[string]source.SourceTable{
+	tables := map[string]source.SourceTable{
 		"ad_accounts": &source.DynamicSourceTable{
 			TableName:           "ad_accounts",
 			TablePrimaryKeys:    []string{"id"},
@@ -233,6 +273,25 @@ func (s *LinkedInAdsSource) getTables() map[string]source.SourceTable {
 			},
 		},
 	}
+
+	for _, analyticsCfg := range analyticsTableConfigs {
+		cfg := analyticsCfg
+		tables[cfg.tableName] = &source.DynamicSourceTable{
+			TableName:           cfg.tableName,
+			TablePrimaryKeys:    []string{cfg.pivot, "date"},
+			TableIncrementalKey: "date",
+			TableStrategy:       config.StrategyMerge,
+			KnownSchema:         false,
+			SchemaFn:            schemaFn,
+			ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+				return s.readTable(ctx, func(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+					return s.readAnalyticsTable(ctx, cfg, opts, results)
+				}, opts)
+			},
+		}
+	}
+
+	return tables
 }
 
 func normalizePageSize(pageSize int) int {
@@ -353,8 +412,8 @@ func (s *LinkedInAdsSource) runParallelAccountFetch(
 		close(resultChan)
 	}()
 
-	// Collect results
 	var allItems []map[string]interface{}
+	var firstErr error
 	for result := range resultChan {
 		select {
 		case <-ctx.Done():
@@ -362,11 +421,17 @@ func (s *LinkedInAdsSource) runParallelAccountFetch(
 		default:
 		}
 		if result.err != nil {
-			continue // Error already logged
+			if firstErr == nil {
+				firstErr = fmt.Errorf("account %s: %w", result.accountID, result.err)
+			}
+			continue
 		}
 		allItems = append(allItems, result.items...)
 	}
 
+	if firstErr != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", tableName, firstErr)
+	}
 	return allItems, nil
 }
 
@@ -748,6 +813,30 @@ func (s *LinkedInAdsSource) readLeadFormResponses(ctx context.Context, opts sour
 // ----------------------------------------------------------------------------
 // Custom Analytics
 
+func (s *LinkedInAdsSource) readAnalyticsTable(ctx context.Context, table analyticsTableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(s.accountIDs) == 0 {
+		return fmt.Errorf("account_ids is required in URI for analytics tables")
+	}
+
+	cfg := &customAnalyticsConfig{
+		tableName:       table.tableName,
+		dimensions:      []string{table.pivot, "date"},
+		metrics:         append([]string{}, defaultAnalyticsMetrics...),
+		pivot:           table.pivot,
+		timeGranularity: timeGranularityDaily,
+		primaryKeys:     []string{table.pivot, "date"},
+		incrementalKey:  "date",
+	}
+	if !slices.Contains(cfg.metrics, "dateRange") {
+		cfg.metrics = append(cfg.metrics, "dateRange")
+	}
+	if !slices.Contains(cfg.metrics, "pivotValues") {
+		cfg.metrics = append(cfg.metrics, "pivotValues")
+	}
+
+	return s.readCustomAnalytics(ctx, cfg, opts, results)
+}
+
 func (s *LinkedInAdsSource) getCustomAnalyticsTable(tableName string) (source.SourceTable, error) {
 	cfg, err := parseCustomTableName(tableName)
 	if err != nil {
@@ -828,7 +917,7 @@ func (s *LinkedInAdsSource) readCustomAnalytics(ctx context.Context, cfg *custom
 		dateHints = dailyDateColumns
 	}
 
-	return sendAsArrowRecord(allItems, dateHints, opts.ExcludeColumns, results, "custom_reports")
+	return sendAsArrowRecord(allItems, dateHints, opts.ExcludeColumns, results, cfg.tableName)
 }
 
 var _ source.Source = (*LinkedInAdsSource)(nil)


### PR DESCRIPTION
## Summary
- add fixed LinkedIn Ads analytics streams for campaign, creative, impression device, and member demographics
- reuse the custom analytics reader for named daily analytics tables
- trim custom report dimensions to the supported analytics pivots and update docs/tests

## Tests
- go test ./pkg/source/linkedin_ads