### PR TITLE
Add source_column field to map source→destination column names in ing…

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -148,7 +148,7 @@ func IngestCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "columns",
-				Usage:   "Override column types for schema evolution (format: 'col:type,col2:type2'). Types: bigint, int, smallint, float, double, decimal(p,s), string, text, boolean, date, timestamp (with tz), timestamp_ntz (no tz), json, uuid, binary",
+				Usage:   "Override column types and/or rename columns. Per-column format: 'name:type' (type override), 'name:type:source' (rename + type), or 'name::source' (rename only). Multiple entries comma-separated, e.g. 'id:bigint,first_name:string:fname,email::eml'. Types: bigint, int, smallint, float, double, decimal(p,s), string, text, boolean, date, timestamp (with tz), timestamp_ntz (no tz), json, uuid, binary",
 				Sources: cli.EnvVars("INGESTR_COLUMNS"),
 			},
 			&cli.StringSliceFlag{

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -27,7 +27,7 @@ ingestr ingest \
 - `--interval-start`: Sets the start of the interval for the incremental key. Defaults to `None`.
 - `--interval-end`: Sets the end of the interval for the incremental key. Defaults to `None`.
 - `--primary-key TEXT`: Specifies the primary key for the merge operation. Defaults to `None`.
-- `--columns <column_name>:<column_type>`: Specifies the columns to be ingested. Defaults to `None`.
+- `--columns <name>:<type>:<source>`: Specifies the columns to be ingested. Use `name:type` to override a column's type, `name:type:source` to rename `source` to `name` with a type, or `name::source` to rename only. Multiple entries are comma-separated. Defaults to `None`.
 - `--mask <column_name>:<algorithm>[:param]`: Applies data masking to specified columns. Can be used multiple times for different columns. See the [Data Masking](../getting-started/data-masking.md) documentation for available algorithms and usage examples. Defaults to `None`.
 - `--schema-naming` Specifies what naming convention to use for table and column names on the destination. Can be `default` or `direct`.default is snake_case. `direct is case sensitive and doesn't contract underscores.
 
@@ -40,6 +40,7 @@ The `interval-start` and `interval-end` options support various datetime formats
 
 > [!INFO]
 > For the details around the incremental key and the various strategies, please refer to the [Incremental Loading](../getting-started/incremental-loading.md) section.
+
 
 ## General flags
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1176,8 +1176,14 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 	}
 
 	applied := 0
+	renameMap := make(map[string]string)
 	for i, col := range sourceSchema.Columns {
-		if override, ok := overrides.GetForColumn(col.Name, p.config.SchemaNaming); ok {
+		override, ok := overrides.GetForColumn(col.Name, p.config.SchemaNaming)
+		if !ok {
+			continue
+		}
+
+		if override.DataType != schema.TypeUnknown {
 			newCol := override.ApplyToColumn(col)
 			if col.DataType != newCol.DataType || col.Precision != newCol.Precision || col.Scale != newCol.Scale {
 				fmt.Printf("Column override: %q type changed from %v(p=%v,s=%v) to %v(p=%v,s=%v)\n",
@@ -1187,10 +1193,19 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 			config.Debug("[PIPELINE] Column override applied: %s -> %v", col.Name, override.DataType)
 			applied++
 		}
+
+		if override.RenameTo != "" && override.RenameTo != sourceSchema.Columns[i].Name {
+			renameMap[sourceSchema.Columns[i].Name] = override.RenameTo
+			fmt.Printf("Column rename: %q -> %q (from --columns)\n", sourceSchema.Columns[i].Name, override.RenameTo)
+		}
 	}
 
 	if applied > 0 {
 		config.Debug("[PIPELINE] Applied %d column type overrides", applied)
+	}
+
+	if len(renameMap) > 0 {
+		p.applyColumnMapping(sourceSchema, renameMap)
 	}
 
 	return nil

--- a/pkg/schemaevolution/override.go
+++ b/pkg/schemaevolution/override.go
@@ -101,7 +101,7 @@ func ParseColumnOverrides(input string) (ColumnOverrides, error) {
 	}
 
 	overrides := make(ColumnOverrides)
-	pairs := splitColumnPairs(input)
+	pairs := SplitColumnPairs(input)
 
 	for _, pair := range pairs {
 		pair = strings.TrimSpace(pair)
@@ -124,9 +124,9 @@ func ParseColumnOverrides(input string) (ColumnOverrides, error) {
 	return overrides, nil
 }
 
-// splitColumnPairs splits the input by commas, but respects parentheses.
+// SplitColumnPairs splits the input by commas, but respects parentheses.
 // E.g., "a:decimal(10,2),b:int" -> ["a:decimal(10,2)", "b:int"]
-func splitColumnPairs(input string) []string {
+func SplitColumnPairs(input string) []string {
 	var pairs []string
 	var current strings.Builder
 	depth := 0

--- a/pkg/schemaevolution/override.go
+++ b/pkg/schemaevolution/override.go
@@ -12,6 +12,7 @@ import (
 // ColumnOverride represents a user-specified column type override.
 type ColumnOverride struct {
 	Name      string
+	RenameTo  string
 	DataType  schema.DataType
 	Precision int
 	Scale     int
@@ -85,8 +86,15 @@ var StandardTypeNames = map[string]schema.DataType{
 	"interval": schema.TypeInterval,
 }
 
-// ParseColumnOverrides parses a comma-separated list of column:type pairs.
-// Format: "col1:type1,col2:type2" or "col1:decimal(10,2),col2:bigint"
+// ParseColumnOverrides parses a comma-separated list of column override
+// entries. Each entry takes one of these shapes:
+//
+//	name:type            — apply type to source column "name"
+//	dest:type:source     — rename source column "source" to "dest" and apply type
+//	dest::source         — rename source column "source" to "dest" (no type change)
+//
+// Examples: "col1:type1,col2:type2", "col1:decimal(10,2),col2:bigint",
+// "first_name:string:fname,email::eml".
 func ParseColumnOverrides(input string) (ColumnOverrides, error) {
 	if input == "" {
 		return nil, nil
@@ -151,22 +159,39 @@ func splitColumnPairs(input string) []string {
 }
 
 func parseColumnOverride(pair string) (ColumnOverride, error) {
-	colonIdx := strings.Index(pair, ":")
-	if colonIdx == -1 {
+	if !strings.Contains(pair, ":") {
 		return ColumnOverride{}, fmt.Errorf("invalid column override format '%s': expected 'column:type'", pair)
 	}
 
-	colName := strings.TrimSpace(pair[:colonIdx])
-	typeSpec := strings.TrimSpace(pair[colonIdx+1:])
+	// Parameterized type names like decimal(10,2) use ',' inside parens, not
+	// ':' — so splitting the entry on ':' is safe.
+	parts := strings.Split(pair, ":")
+
+	var colName, typeSpec, renameTo string
+	switch len(parts) {
+	case 2:
+		colName = strings.TrimSpace(parts[0])
+		typeSpec = strings.TrimSpace(parts[1])
+	case 3:
+		renameTo = strings.TrimSpace(parts[0])
+		typeSpec = strings.TrimSpace(parts[1])
+		colName = strings.TrimSpace(parts[2])
+	default:
+		return ColumnOverride{}, fmt.Errorf("invalid column override format '%s': expected 'col:type', 'dest:type:source', or 'dest::source'", pair)
+	}
 
 	if colName == "" {
 		return ColumnOverride{}, nil
 	}
 	if typeSpec == "" {
-		return ColumnOverride{}, fmt.Errorf("empty type in override '%s'", pair)
+		if renameTo == "" {
+			return ColumnOverride{}, fmt.Errorf("empty type in override '%s'", pair)
+		}
+		// Rename-only override: leave DataType at TypeUnknown.
+		return ColumnOverride{Name: colName, RenameTo: renameTo}, nil
 	}
 
-	override := ColumnOverride{Name: colName}
+	override := ColumnOverride{Name: colName, RenameTo: renameTo}
 
 	// Check for parameterized types like decimal(10,2)
 	if parenIdx := strings.Index(typeSpec, "("); parenIdx != -1 {
@@ -264,8 +289,12 @@ func overrideMatchConvention(schemaNaming string) naming.NamingConvention {
 }
 
 // ApplyToColumn applies the override to a column, returning the modified column.
+// A TypeUnknown override is treated as "no type change" (rename-only override),
+// so the column's existing type is preserved.
 func (o ColumnOverride) ApplyToColumn(col schema.Column) schema.Column {
-	col.DataType = o.DataType
+	if o.DataType != schema.TypeUnknown {
+		col.DataType = o.DataType
+	}
 	if o.Precision > 0 {
 		col.Precision = o.Precision
 	}

--- a/pkg/schemaevolution/override_test.go
+++ b/pkg/schemaevolution/override_test.go
@@ -145,6 +145,83 @@ func TestParseColumnOverrides_CaseInsensitive(t *testing.T) {
 	assert.Equal(t, schema.TypeInt64, id2.DataType)
 }
 
+func TestParseColumnOverrides_RenameWithType(t *testing.T) {
+	overrides, err := ParseColumnOverrides("first_name:string:fname")
+	require.NoError(t, err)
+	require.Len(t, overrides, 1)
+
+	// Keyed by the SOURCE name (fname), not the destination name.
+	ov, ok := overrides.Get("fname")
+	assert.True(t, ok)
+	assert.Equal(t, "fname", ov.Name)
+	assert.Equal(t, "first_name", ov.RenameTo)
+	assert.Equal(t, schema.TypeString, ov.DataType)
+
+	_, ok = overrides.Get("first_name")
+	assert.False(t, ok, "override should not be keyed by destination name")
+}
+
+func TestParseColumnOverrides_RenameOnly(t *testing.T) {
+	overrides, err := ParseColumnOverrides("first_name::fname")
+	require.NoError(t, err)
+	require.Len(t, overrides, 1)
+
+	ov, ok := overrides.Get("fname")
+	assert.True(t, ok)
+	assert.Equal(t, "fname", ov.Name)
+	assert.Equal(t, "first_name", ov.RenameTo)
+	assert.Equal(t, schema.TypeUnknown, ov.DataType)
+}
+
+func TestParseColumnOverrides_RenameMixed(t *testing.T) {
+	overrides, err := ParseColumnOverrides("id:bigint,first_name:string:fname,email::eml")
+	require.NoError(t, err)
+	require.Len(t, overrides, 3)
+
+	id, ok := overrides.Get("id")
+	require.True(t, ok)
+	assert.Empty(t, id.RenameTo)
+	assert.Equal(t, schema.TypeInt64, id.DataType)
+
+	fname, ok := overrides.Get("fname")
+	require.True(t, ok)
+	assert.Equal(t, "first_name", fname.RenameTo)
+	assert.Equal(t, schema.TypeString, fname.DataType)
+
+	eml, ok := overrides.Get("eml")
+	require.True(t, ok)
+	assert.Equal(t, "email", eml.RenameTo)
+	assert.Equal(t, schema.TypeUnknown, eml.DataType)
+}
+
+func TestParseColumnOverrides_RenameWithDecimal(t *testing.T) {
+	overrides, err := ParseColumnOverrides("amt:decimal(10,2):amount_raw")
+	require.NoError(t, err)
+	require.Len(t, overrides, 1)
+
+	ov, ok := overrides.Get("amount_raw")
+	require.True(t, ok)
+	assert.Equal(t, "amt", ov.RenameTo)
+	assert.Equal(t, schema.TypeDecimal, ov.DataType)
+	assert.Equal(t, 10, ov.Precision)
+	assert.Equal(t, 2, ov.Scale)
+}
+
+func TestColumnOverride_ApplyToColumn_RenameOnly(t *testing.T) {
+	col := schema.Column{
+		Name:     "fname",
+		DataType: schema.TypeString,
+		Nullable: true,
+	}
+	override := ColumnOverride{
+		Name:     "fname",
+		RenameTo: "first_name",
+		// No DataType: TypeUnknown means "don't change type"
+	}
+	result := override.ApplyToColumn(col)
+	assert.Equal(t, schema.TypeString, result.DataType, "type should be preserved on rename-only override")
+}
+
 func TestParseColumnOverrides_Errors(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/schemainfer/overrides.go
+++ b/pkg/schemainfer/overrides.go
@@ -166,14 +166,32 @@ func AppendMissingOverrideColumns(tableSchema *schema.TableSchema, columnsSpec, 
 
 	for _, name := range names {
 		ov := overrides[name]
-		if existing[normalize(ov.Name)] {
+		// If a rename was requested, the appended column should use the
+		// destination name.
+		finalName := ov.Name
+		if ov.RenameTo != "" {
+			finalName = ov.RenameTo
+		}
+		if existing[normalize(finalName)] {
 			continue
 		}
+
+		dataType := ov.DataType
+		precision := ov.Precision
+		scale := ov.Scale
+		// Rename-only overrides carry no type. Fall back to STRING
+		if dataType == schema.TypeUnknown {
+			dataType = schema.TypeString
+			precision = 0
+			scale = 0
+			fmt.Printf("Warning: column %q created as STRING placeholder (no type in --columns); pass --columns %s:<type>:%s for correct typing\n", finalName, finalName, ov.Name)
+		}
+
 		tableSchema.Columns = append(tableSchema.Columns, schema.Column{
-			Name:      ov.Name,
-			DataType:  ov.DataType,
-			Precision: ov.Precision,
-			Scale:     ov.Scale,
+			Name:      finalName,
+			DataType:  dataType,
+			Precision: precision,
+			Scale:     scale,
 			Nullable:  true,
 		})
 	}

--- a/pkg/source/http/http.go
+++ b/pkg/source/http/http.go
@@ -297,8 +297,8 @@ func buildSchemaColumns(headers []string, overrides schemaevolution.ColumnOverri
 	orderedNames := make([]string, 0, len(pairs))
 	for _, pair := range pairs {
 		pair = strings.TrimSpace(pair)
-		if colonIdx := strings.Index(pair, ":"); colonIdx != -1 {
-			orderedNames = append(orderedNames, strings.TrimSpace(pair[:colonIdx]))
+		if name := overrideEntryReadName(pair); name != "" {
+			orderedNames = append(orderedNames, name)
 		}
 	}
 
@@ -309,16 +309,37 @@ func buildSchemaColumns(headers []string, overrides schemaevolution.ColumnOverri
 	}
 
 	for _, name := range names {
+		// Default to string so rename-only overrides (no type given) keep the
+		// string type; a real type override below will replace it.
 		col := schema.Column{Name: name, DataType: schema.TypeString, Nullable: true}
 		if override, ok := overrides.Get(name); ok {
-			col.DataType = override.DataType
-			col.Precision = override.Precision
-			col.Scale = override.Scale
+			if override.DataType != schema.TypeUnknown {
+				col.DataType = override.DataType
+				col.Precision = override.Precision
+				col.Scale = override.Scale
+			}
 		}
 		cols = append(cols, col)
 	}
 
 	return cols
+}
+
+// For headerless CSV, the column names in --columns may be in the form "col1:type:read_name" or "col1:type" or just "col1". 
+// If "read_name" is provided, it is used for matching overrides to the actual column; otherwise the original column name is used.
+func overrideEntryReadName(pair string) string {
+	pair = strings.TrimSpace(pair)
+	if pair == "" {
+		return ""
+	}
+	if !strings.Contains(pair, ":") {
+		return pair
+	}
+	parts := strings.Split(pair, ":")
+	if len(parts) == 3 {
+		return strings.TrimSpace(parts[2])
+	}
+	return strings.TrimSpace(parts[0])
 }
 
 func readJSON(_ context.Context, data []byte, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
@@ -542,11 +563,11 @@ func parseColumnNames(columns string, numCols int) []string {
 		parts := strings.Split(columns, ",")
 		for i := 0; i < numCols; i++ {
 			if i < len(parts) {
-				name := strings.TrimSpace(parts[i])
-				if colonIdx := strings.Index(name, ":"); colonIdx != -1 {
-					name = strings.TrimSpace(name[:colonIdx])
+				name := overrideEntryReadName(strings.TrimSpace(parts[i]))
+				if name == "" {
+					name = fmt.Sprintf("unknown_col_%d", i)
 				}
-				headers[i] = strings.TrimSpace(name)
+				headers[i] = name
 			} else {
 				headers[i] = fmt.Sprintf("unknown_col_%d", i)
 			}

--- a/pkg/source/http/http.go
+++ b/pkg/source/http/http.go
@@ -293,7 +293,7 @@ func readCSV(_ context.Context, reader io.Reader, results chan<- source.RecordBa
 }
 
 func buildSchemaColumns(headers []string, overrides schemaevolution.ColumnOverrides, columnsStr string) []schema.Column {
-	pairs := strings.Split(columnsStr, ",")
+	pairs := schemaevolution.SplitColumnPairs(columnsStr)
 	orderedNames := make([]string, 0, len(pairs))
 	for _, pair := range pairs {
 		pair = strings.TrimSpace(pair)
@@ -325,7 +325,7 @@ func buildSchemaColumns(headers []string, overrides schemaevolution.ColumnOverri
 	return cols
 }
 
-// For headerless CSV, the column names in --columns may be in the form "col1:type:read_name" or "col1:type" or just "col1". 
+// For headerless CSV, the column names in --columns may be in the form "col1:type:read_name" or "col1:type" or just "col1".
 // If "read_name" is provided, it is used for matching overrides to the actual column; otherwise the original column name is used.
 func overrideEntryReadName(pair string) string {
 	pair = strings.TrimSpace(pair)
@@ -560,7 +560,7 @@ func excludeArrowColumns(rec arrow.RecordBatch, exclude map[string]struct{}) arr
 func parseColumnNames(columns string, numCols int) []string {
 	headers := make([]string, numCols)
 	if columns != "" {
-		parts := strings.Split(columns, ",")
+		parts := schemaevolution.SplitColumnPairs(columns)
 		for i := 0; i < numCols; i++ {
 			if i < len(parts) {
 				name := overrideEntryReadName(strings.TrimSpace(parts[i]))

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -69,6 +69,8 @@ func TestParseColumnNames(t *testing.T) {
 		{"fewer columns than data", "id:bigint,name:text", 3, []string{"id", "name", "unknown_col_2"}},
 		{"more columns than data", "id:bigint,name:text,value:double,extra:int", 3, []string{"id", "name", "value"}},
 		{"with spaces", " id : bigint , name : text ", 2, []string{"id", "name"}},
+		{"3-part picks source name", "first_name:string:fname,email::eml", 2, []string{"fname", "eml"}},
+		{"mixed 2 and 3 part", "id:bigint,first_name:string:fname", 2, []string{"id", "fname"}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -71,6 +71,8 @@ func TestParseColumnNames(t *testing.T) {
 		{"with spaces", " id : bigint , name : text ", 2, []string{"id", "name"}},
 		{"3-part picks source name", "first_name:string:fname,email::eml", 2, []string{"fname", "eml"}},
 		{"mixed 2 and 3 part", "id:bigint,first_name:string:fname", 2, []string{"id", "fname"}},
+		{"decimal type with rename", "amount:decimal(10,2):raw_amount,name:text", 2, []string{"raw_amount", "name"}},
+		{"decimal type without rename", "id:bigint,amount:decimal(10,2)", 2, []string{"id", "amount"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pair of PRs adds column name mapping for ingestr assets, allowing columns to be renamed as they move from a source to a destination. In an asset, name stays the destination column and source_column holds the name it has in the source; on ingestion the column is renamed accordingly, with optional type enforcement. The Bruin PR introduces the source_column field and passes the mapping through to ingestr, while the companion ingestr PR handles parsing and applying that mapping on its side. Together they provide a simple, declarative way to standardize column names at load time without post-processing. 