### PR TITLE
[codex] Support Salesforce client credentials auth

### DIFF
--- a/docs/supported-sources/salesforce.md
+++ b/docs/supported-sources/salesforce.md
@@ -5,7 +5,7 @@ Ingestr supports Salesforce as a source.
 
 ## URI format
 
-The URI format for Salesforce is as follows:
+The URI format for Salesforce using username, password, and security token authentication is as follows:
 ```
 salesforce://?username=<username>&password=<password>&token=<token>&domain=<domain>
 ```
@@ -14,7 +14,18 @@ URI parameters:
 - `username` is your Salesforce account username.
 - `password` is your Salesforce account password.
 - `token` is your Salesforce security token.
-- `domain` is your Salesforce instance domain (for example, `login`, `test`, or `your-domain.my`). Do **not** include `.salesforce.com`.
+- `domain` is your Salesforce instance domain (for example, `login`, `test`, or `your-domain.my`). You can also pass the full Salesforce host or URL.
+
+To use the OAuth 2.0 client credentials flow, use the following URI:
+```
+salesforce://?grant_type=client_credentials&client_id=<client_id>&client_secret=<client_secret>&domain=<domain>
+```
+
+URI parameters:
+- `grant_type=client_credentials` selects the client credentials flow. This is optional when both `client_id` and `client_secret` are provided.
+- `client_id` is the consumer key for your Salesforce connected app.
+- `client_secret` is the consumer secret for your Salesforce connected app.
+- `domain` is your Salesforce My Domain or instance domain (for example, `your-domain.my`). You can also pass the full Salesforce host or URL.
 
 You can obtain your security token by logging into your Salesforce account and navigating to the user settings under "Reset My Security Token."
 
@@ -76,6 +87,15 @@ ingestr ingest \
   --dest-table "public.user_role"
 ```
 
+Copy account data using OAuth 2.0 client credentials:
+```sh
+ingestr ingest \
+  --source-uri "salesforce://?grant_type=client_credentials&client_id=<client_id>&client_secret=<client_secret>&domain=<domain>" \
+  --source-table "account" \
+  --dest-uri "duckdb:///sf.db" \
+  --dest-table "public.account"
+```
+
 Copy custom object data from Salesforce into a DuckDB database:
 ```sh
 ingestr ingest \
@@ -87,4 +107,3 @@ ingestr ingest \
 
 > [!WARNING]
 > Salesforce API limits may affect the frequency and volume of data ingestion. Incremental loading is supported for objects with the `SystemModstamp` field, but some objects may require full-refresh loads. This is indicated by `mode` in the tables above. Tables with mode `replace` don't support incremental loads, while the ones with `merge` do.
-

--- a/pkg/source/salesforce/salesforce.go
+++ b/pkg/source/salesforce/salesforce.go
@@ -19,19 +19,40 @@ import (
 )
 
 const (
-	defaultAPIVersion = "59.0"
+	defaultAPIVersion        = "59.0"
+	salesforceOAuthTokenPath = "/services/oauth2/token"
+)
+
+type salesforceAuthMethod string
+
+const (
+	salesforceAuthPassword          salesforceAuthMethod = "password"
+	salesforceAuthClientCredentials salesforceAuthMethod = "client_credentials"
 )
 
 type salesforceSource struct {
-	client      *simpleforce.Client
-	httpClient  *httpclient.Client
-	instanceURL string
-	sessionID   string
-	useBulkAPI  bool
-	sfUser      string
-	sfPassword  string
-	sfToken     string
-	sfUrl       string
+	client         *simpleforce.Client
+	httpClient     *httpclient.Client
+	instanceURL    string
+	sessionID      string
+	useBulkAPI     bool
+	sfUser         string
+	sfPassword     string
+	sfToken        string
+	sfClientID     string
+	sfClientSecret string
+	sfUrl          string
+	authMethod     salesforceAuthMethod
+}
+
+type salesforceConfig struct {
+	username     string
+	password     string
+	token        string
+	domain       string
+	clientID     string
+	clientSecret string
+	authMethod   salesforceAuthMethod
 }
 
 func NewSalesforceSource() *salesforceSource {
@@ -43,23 +64,35 @@ func (s *salesforceSource) Schemes() []string {
 }
 
 func (s *salesforceSource) Connect(ctx context.Context, uri string) error {
-	sfUser, sfPassword, sfToken, sfDomain, err := parseSalesforceURI(uri)
+	cfg, err := parseSalesforceURI(uri)
 	if err != nil {
 		return err
 	}
-	s.sfUser = sfUser
-	s.sfPassword = sfPassword
-	s.sfToken = sfToken
-	s.sfUrl = fmt.Sprintf("https://%s.salesforce.com/", sfDomain)
+	s.sfUser = cfg.username
+	s.sfPassword = cfg.password
+	s.sfToken = cfg.token
+	s.sfClientID = cfg.clientID
+	s.sfClientSecret = cfg.clientSecret
+	s.authMethod = cfg.authMethod
+	s.sfUrl = salesforceBaseURL(cfg.domain)
 
-	s.client = simpleforce.NewClient(s.sfUrl, simpleforce.DefaultClientID, defaultAPIVersion)
+	s.client = simpleforce.NewClient(s.sfUrl, s.simpleforceClientID(), defaultAPIVersion)
 
 	if s.client == nil {
 		return fmt.Errorf("failed to create Salesforce client")
 	}
-	err = s.client.LoginPassword(s.sfUser, s.sfPassword, s.sfToken)
-	if err != nil {
-		return fmt.Errorf("failed to login to Salesforce: %w", err)
+
+	switch s.authMethod {
+	case salesforceAuthPassword:
+		if err := s.client.LoginPassword(s.sfUser, s.sfPassword, s.sfToken); err != nil {
+			return fmt.Errorf("failed to login to Salesforce: %w", err)
+		}
+	case salesforceAuthClientCredentials:
+		if err := s.loginClientCredentials(ctx); err != nil {
+			return fmt.Errorf("failed to login to Salesforce with client credentials: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported Salesforce auth method: %s", s.authMethod)
 	}
 
 	s.sessionID = s.client.GetSid()
@@ -76,36 +109,130 @@ func (s *salesforceSource) Connect(ctx context.Context, uri string) error {
 	return nil
 }
 
-func parseSalesforceURI(uri string) (sfUser, sfPassword, sfToken, sfUrl string, err error) {
+func parseSalesforceURI(uri string) (salesforceConfig, error) {
 	if !strings.HasPrefix(uri, "salesforce://") {
-		return "", "", "", "", fmt.Errorf("invalid salesforce URI: must start with salesforce://")
+		return salesforceConfig{}, fmt.Errorf("invalid salesforce URI: must start with salesforce://")
 	}
 
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return "", "", "", "", fmt.Errorf("failed to parse salesforce URI: %w", err)
+		return salesforceConfig{}, fmt.Errorf("failed to parse salesforce URI: %w", err)
 	}
 
 	params := parsed.Query()
-	sfUser = params.Get("username")
-	sfPassword = params.Get("password")
-	sfToken = params.Get("token")
-	sfDomain := params.Get("domain")
-
-	if sfUser == "" {
-		return "", "", "", "", fmt.Errorf("sfUser is required for Salesforce")
-	}
-	if sfPassword == "" {
-		return "", "", "", "", fmt.Errorf("sfPassword is required for Salesforce")
-	}
-	if sfToken == "" {
-		return "", "", "", "", fmt.Errorf("sfToken is required for Salesforce")
-	}
-	if sfDomain == "" {
-		return "", "", "", "", fmt.Errorf("sfUrl is required for Salesforce")
+	cfg := salesforceConfig{
+		username:     params.Get("username"),
+		password:     params.Get("password"),
+		token:        params.Get("token"),
+		domain:       params.Get("domain"),
+		clientID:     params.Get("client_id"),
+		clientSecret: params.Get("client_secret"),
 	}
 
-	return sfUser, sfPassword, sfToken, sfDomain, nil
+	authMethod := params.Get("auth_method")
+	if authMethod == "" {
+		authMethod = params.Get("grant_type")
+	}
+	switch authMethod {
+	case "":
+		if cfg.clientID != "" || cfg.clientSecret != "" {
+			cfg.authMethod = salesforceAuthClientCredentials
+		} else {
+			cfg.authMethod = salesforceAuthPassword
+		}
+	case string(salesforceAuthPassword), "username_password":
+		cfg.authMethod = salesforceAuthPassword
+	case string(salesforceAuthClientCredentials):
+		cfg.authMethod = salesforceAuthClientCredentials
+	default:
+		return salesforceConfig{}, fmt.Errorf("unsupported Salesforce auth_method: %s", authMethod)
+	}
+
+	if cfg.domain == "" {
+		return salesforceConfig{}, fmt.Errorf("domain is required for Salesforce")
+	}
+
+	switch cfg.authMethod {
+	case salesforceAuthPassword:
+		if cfg.username == "" {
+			return salesforceConfig{}, fmt.Errorf("username is required for Salesforce")
+		}
+		if cfg.password == "" {
+			return salesforceConfig{}, fmt.Errorf("password is required for Salesforce")
+		}
+		if cfg.token == "" {
+			return salesforceConfig{}, fmt.Errorf("token is required for Salesforce")
+		}
+	case salesforceAuthClientCredentials:
+		if cfg.clientID == "" {
+			return salesforceConfig{}, fmt.Errorf("client_id is required for Salesforce client credentials")
+		}
+		if cfg.clientSecret == "" {
+			return salesforceConfig{}, fmt.Errorf("client_secret is required for Salesforce client credentials")
+		}
+	}
+
+	return cfg, nil
+}
+
+func salesforceBaseURL(domain string) string {
+	domain = strings.TrimRight(strings.TrimSpace(domain), "/")
+	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
+		return domain
+	}
+	if strings.HasSuffix(domain, ".salesforce.com") {
+		return fmt.Sprintf("https://%s", domain)
+	}
+	return fmt.Sprintf("https://%s.salesforce.com", domain)
+}
+
+func (s *salesforceSource) simpleforceClientID() string {
+	if s.authMethod == salesforceAuthClientCredentials && s.sfClientID != "" {
+		return s.sfClientID
+	}
+	return simpleforce.DefaultClientID
+}
+
+func (s *salesforceSource) loginClientCredentials(ctx context.Context) error {
+	tokenClient := httpclient.New(
+		httpclient.WithTimeout(30*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+	)
+	defer func() { _ = tokenClient.Close() }()
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		InstanceURL string `json:"instance_url"`
+		TokenType   string `json:"token_type"`
+	}
+
+	resp, err := tokenClient.R(ctx).
+		SetHeader("Accept", "application/json").
+		SetFormData(map[string]string{
+			"grant_type":    string(salesforceAuthClientCredentials),
+			"client_id":     s.sfClientID,
+			"client_secret": s.sfClientSecret,
+		}).
+		SetResult(&tokenResp).
+		Post(fmt.Sprintf("%s%s", strings.TrimRight(s.sfUrl, "/"), salesforceOAuthTokenPath))
+	if err != nil {
+		return fmt.Errorf("token request failed: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("token request failed with status %d: %s", resp.StatusCode(), resp.String())
+	}
+	if tokenResp.AccessToken == "" {
+		return fmt.Errorf("empty access token in response")
+	}
+	if tokenResp.InstanceURL == "" {
+		return fmt.Errorf("empty instance_url in response")
+	}
+	if tokenResp.TokenType != "" && !strings.EqualFold(tokenResp.TokenType, "bearer") {
+		return fmt.Errorf("unsupported token type in response: %s", tokenResp.TokenType)
+	}
+
+	s.client.SetSidLoc(tokenResp.AccessToken, strings.TrimRight(tokenResp.InstanceURL, "/"))
+	return nil
 }
 
 func (s *salesforceSource) Close(ctx context.Context) error {

--- a/pkg/source/salesforce/salesforce_integration_test.go
+++ b/pkg/source/salesforce/salesforce_integration_test.go
@@ -5,6 +5,7 @@ package salesforce_test
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,13 +23,28 @@ func TestSalesforcePipeline(t *testing.T) {
 	username := os.Getenv("SALESFORCE_USERNAME")
 	password := os.Getenv("SALESFORCE_PASSWORD")
 	token := os.Getenv("SALESFORCE_TOKEN")
+	clientID := os.Getenv("SALESFORCE_CLIENT_ID")
+	clientSecret := os.Getenv("SALESFORCE_CLIENT_SECRET")
 	domain := os.Getenv("SALESFORCE_DOMAIN")
-	if username == "" || password == "" || token == "" || domain == "" {
-		t.Skip("Set SALESFORCE_USERNAME, SALESFORCE_PASSWORD, SALESFORCE_TOKEN, and SALESFORCE_DOMAIN to run Salesforce integration tests")
+	if domain == "" {
+		t.Skip("Set SALESFORCE_DOMAIN to run Salesforce integration tests")
 	}
 
 	ctx := context.Background()
-	sourceURI := fmt.Sprintf("salesforce://localhost?username=%s&password=%s&token=%s&domain=%s", username, password, token, domain)
+	params := url.Values{"domain": []string{domain}}
+	if clientID != "" && clientSecret != "" {
+		params.Set("grant_type", "client_credentials")
+		params.Set("client_id", clientID)
+		params.Set("client_secret", clientSecret)
+	} else {
+		if username == "" || password == "" || token == "" {
+			t.Skip("Set SALESFORCE_CLIENT_ID and SALESFORCE_CLIENT_SECRET, or SALESFORCE_USERNAME, SALESFORCE_PASSWORD, and SALESFORCE_TOKEN to run Salesforce integration tests")
+		}
+		params.Set("username", username)
+		params.Set("password", password)
+		params.Set("token", token)
+	}
+	sourceURI := "salesforce://?" + params.Encode()
 
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, fmt.Sprintf("salesforce_%d.duckdb", time.Now().UnixNano()))

--- a/pkg/source/salesforce/salesforce_test.go
+++ b/pkg/source/salesforce/salesforce_test.go
@@ -1,0 +1,123 @@
+package salesforce
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/simpleforce/simpleforce"
+)
+
+func TestParseSalesforceURIWithPasswordAuth(t *testing.T) {
+	cfg, err := parseSalesforceURI("salesforce://?username=user&password=pass&token=tok&domain=login")
+	if err != nil {
+		t.Fatalf("parseSalesforceURI returned error: %v", err)
+	}
+
+	if cfg.authMethod != salesforceAuthPassword {
+		t.Fatalf("authMethod = %q, want %q", cfg.authMethod, salesforceAuthPassword)
+	}
+	if cfg.username != "user" || cfg.password != "pass" || cfg.token != "tok" || cfg.domain != "login" {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestParseSalesforceURIWithClientCredentialsAuth(t *testing.T) {
+	cfg, err := parseSalesforceURI("salesforce://?client_id=id&client_secret=secret&domain=my-domain.my&grant_type=client_credentials")
+	if err != nil {
+		t.Fatalf("parseSalesforceURI returned error: %v", err)
+	}
+
+	if cfg.authMethod != salesforceAuthClientCredentials {
+		t.Fatalf("authMethod = %q, want %q", cfg.authMethod, salesforceAuthClientCredentials)
+	}
+	if cfg.clientID != "id" || cfg.clientSecret != "secret" || cfg.domain != "my-domain.my" {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestParseSalesforceURIInfersClientCredentialsAuth(t *testing.T) {
+	cfg, err := parseSalesforceURI("salesforce://?client_id=id&client_secret=secret&domain=test")
+	if err != nil {
+		t.Fatalf("parseSalesforceURI returned error: %v", err)
+	}
+
+	if cfg.authMethod != salesforceAuthClientCredentials {
+		t.Fatalf("authMethod = %q, want %q", cfg.authMethod, salesforceAuthClientCredentials)
+	}
+}
+
+func TestParseSalesforceURIRequiresClientSecretForClientCredentials(t *testing.T) {
+	_, err := parseSalesforceURI("salesforce://?client_id=id&domain=test&grant_type=client_credentials")
+	if err == nil {
+		t.Fatal("parseSalesforceURI returned nil error, want validation error")
+	}
+}
+
+func TestSalesforceBaseURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		want   string
+	}{
+		{name: "login domain", domain: "login", want: "https://login.salesforce.com"},
+		{name: "my domain", domain: "company.my", want: "https://company.my.salesforce.com"},
+		{name: "salesforce host", domain: "company.my.salesforce.com", want: "https://company.my.salesforce.com"},
+		{name: "explicit URL", domain: "http://127.0.0.1:8080", want: "http://127.0.0.1:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := salesforceBaseURL(tt.domain)
+			if got != tt.want {
+				t.Fatalf("salesforceBaseURL(%q) = %q, want %q", tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoginClientCredentials(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != salesforceOAuthTokenPath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, salesforceOAuthTokenPath)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %q, want %q", r.Method, http.MethodPost)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm returned error: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != string(salesforceAuthClientCredentials) {
+			t.Fatalf("grant_type = %q, want %q", got, salesforceAuthClientCredentials)
+		}
+		if got := r.Form.Get("client_id"); got != "client-id" {
+			t.Fatalf("client_id = %q, want %q", got, "client-id")
+		}
+		if got := r.Form.Get("client_secret"); got != "client-secret" {
+			t.Fatalf("client_secret = %q, want %q", got, "client-secret")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access-token","instance_url":"` + server.URL + `","token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	src := &salesforceSource{
+		client:         simpleforce.NewClient(server.URL, "client-id", defaultAPIVersion),
+		sfUrl:          server.URL,
+		sfClientID:     "client-id",
+		sfClientSecret: "client-secret",
+	}
+
+	if err := src.loginClientCredentials(context.Background()); err != nil {
+		t.Fatalf("loginClientCredentials returned error: %v", err)
+	}
+	if got := src.client.GetSid(); got != "access-token" {
+		t.Fatalf("sid = %q, want %q", got, "access-token")
+	}
+	if got := src.client.GetLoc(); got != server.URL {
+		t.Fatalf("instance URL = %q, want %q", got, server.URL)
+	}
+}


### PR DESCRIPTION
## Summary

- Add Salesforce OAuth 2.0 `client_credentials` authentication alongside the existing username/password/security-token flow.
- Parse `grant_type=client_credentials`, `client_id`, and `client_secret` from Salesforce source URIs, and install the returned access token into the Salesforce client used by REST and Bulk API reads.
- Document the new URI format and update Salesforce integration test setup to support either auth mode.

Closes #656.

## Validation

- `go test ./pkg/source/salesforce`
- `git diff --check`