### PR TITLE
[codex] add Azure SQL source connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
+        <td>Azure SQL</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Microsoft Fabric</td>
         <td>✅</td>
         <td>✅</td>

--- a/docs/supported-sources/azuresql.md
+++ b/docs/supported-sources/azuresql.md
@@ -1,0 +1,75 @@
+# Azure SQL
+
+[Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) is Microsoft's managed SQL Server database service.
+
+ingestr supports Azure SQL Database as a source.
+
+## URI format
+
+The URI format for Azure SQL is:
+
+```plaintext
+azuresql://user:password@server.database.windows.net:1433/database
+```
+
+URI parameters:
+- `user`: SQL username, Microsoft Entra username, managed identity client ID, or service principal client ID
+- `password`: SQL password, Microsoft Entra password, access token, or service principal secret
+- `host`: Azure SQL server host, usually `<server>.database.windows.net`
+- `port`: optional, defaults to `1433`
+- `database`: the database to read from
+- `encrypt`: optional, defaults to `true`
+- `fedauth`: optional Microsoft Entra authentication workflow
+- `tenant_id`: optional tenant ID; with service principal auth, ingestr appends it to the client ID as `client_id@tenant_id`
+
+## Authentication
+
+SQL authentication works without extra query parameters:
+
+```bash
+ingestr ingest \
+    --source-uri "azuresql://$SQL_USER:$SQL_PASSWORD@myserver.database.windows.net/mydb" \
+    --source-table "dbo.users" \
+    --dest-uri "duckdb:///local.db" \
+    --dest-table "main.users"
+```
+
+For Microsoft Entra service principal authentication:
+
+```bash
+ingestr ingest \
+    --source-uri "azuresql://$CLIENT_ID:$CLIENT_SECRET@myserver.database.windows.net/mydb?tenant_id=$TENANT_ID&fedauth=ActiveDirectoryServicePrincipal" \
+    --source-table "dbo.users" \
+    --dest-uri "duckdb:///local.db" \
+    --dest-table "main.users"
+```
+
+For local Azure CLI, managed identity, or default environment credentials, omit username and password and choose the `fedauth` workflow:
+
+```bash
+ingestr ingest \
+    --source-uri "azuresql://myserver.database.windows.net/mydb?fedauth=ActiveDirectoryDefault" \
+    --source-table "dbo.users" \
+    --dest-uri "duckdb:///local.db" \
+    --dest-table "main.users"
+```
+
+Common `fedauth` values:
+- `ActiveDirectoryDefault`
+- `ActiveDirectoryAzCli`
+- `ActiveDirectoryManagedIdentity`
+- `ActiveDirectoryServicePrincipal`
+- `ActiveDirectoryServicePrincipalAccessToken`
+- `ActiveDirectoryPassword`
+
+The `azure-sql://` scheme is also accepted.
+
+## Local testing
+
+You can test the Azure SQL source path locally with the integration test suite:
+
+```bash
+go test -tags integration -run TestAzureSQLSourceScheme_SQLServerContainerToSQLite -count=1 ./tests/integration
+```
+
+This starts a SQL Server 2022 container, reads it with an `azuresql://` source URI using SQL authentication, and writes the result to SQLite. It validates the Azure SQL scheme, driver selection, schema discovery, and read path without requiring a real Azure SQL server. Microsoft Entra-only `fedauth` workflows still require Azure-hosted credentials to test end to end.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -1,5 +1,7 @@
 package server
 
+import "net/url"
+
 type ConnectorField struct {
 	Name        string        `json:"name"`
 	Label       string        `json:"label"`
@@ -73,6 +75,30 @@ func GetConnectors() []ConnectorType {
 				{Name: "user", Label: "Username", Type: "string", Required: true, Placeholder: "sa"},
 				{Name: "password", Label: "Password", Type: "password", Required: false},
 				{Name: "database", Label: "Database", Type: "string", Required: true, Placeholder: "master"},
+			},
+		},
+		{
+			ID:            "azuresql",
+			Name:          "Azure SQL",
+			Schemes:       []string{"azuresql", "azure-sql"},
+			IsSource:      true,
+			IsDestination: false,
+			Fields: []ConnectorField{
+				{Name: "host", Label: "Server", Type: "string", Required: true, Placeholder: "myserver.database.windows.net"},
+				{Name: "port", Label: "Port", Type: "number", Required: false, Default: "1433", Placeholder: "1433"},
+				{Name: "user", Label: "Username / Client ID", Type: "string", Required: false},
+				{Name: "password", Label: "Password / Token", Type: "password", Required: false},
+				{Name: "database", Label: "Database", Type: "string", Required: true, Placeholder: "mydb"},
+				{Name: "fedauth", Label: "Authentication", Type: "select", Required: false, Options: []FieldOption{
+					{Value: "", Label: "SQL Authentication"},
+					{Value: "ActiveDirectoryDefault", Label: "Microsoft Entra Default"},
+					{Value: "ActiveDirectoryServicePrincipal", Label: "Service Principal"},
+					{Value: "ActiveDirectoryManagedIdentity", Label: "Managed Identity"},
+					{Value: "ActiveDirectoryServicePrincipalAccessToken", Label: "Access Token"},
+					{Value: "ActiveDirectoryAzCli", Label: "Azure CLI"},
+				}},
+				{Name: "tenant_id", Label: "Tenant ID", Type: "string", Required: false},
+				{Name: "encrypt", Label: "Encrypt", Type: "checkbox", Required: false, Default: "true"},
 			},
 		},
 		{
@@ -215,6 +241,8 @@ func BuildURI(connectorID string, fields map[string]string) string {
 		return buildStandardURI("mysql", fields, "3306")
 	case "mssql":
 		return buildStandardURI("mssql", fields, "1433")
+	case "azuresql":
+		return buildAzureSQLURI(fields)
 	case "mongodb":
 		scheme := "mongodb"
 		if fields["srv"] == "true" {
@@ -276,6 +304,45 @@ func BuildURI(connectorID string, fields map[string]string) string {
 	default:
 		return ""
 	}
+}
+
+func buildAzureSQLURI(fields map[string]string) string {
+	host := fields["host"]
+	port := fields["port"]
+	if port == "" {
+		port = "1433"
+	}
+
+	u := &url.URL{
+		Scheme: "azuresql",
+		Host:   host + ":" + port,
+	}
+	if fields["user"] != "" || fields["password"] != "" {
+		if fields["password"] != "" {
+			u.User = url.UserPassword(fields["user"], fields["password"])
+		} else {
+			u.User = url.User(fields["user"])
+		}
+	}
+	if fields["database"] != "" {
+		u.Path = "/" + fields["database"]
+	}
+
+	query := url.Values{}
+	if fields["fedauth"] != "" {
+		query.Set("fedauth", fields["fedauth"])
+	}
+	if fields["tenant_id"] != "" {
+		query.Set("tenant_id", fields["tenant_id"])
+	}
+	if fields["encrypt"] == "" {
+		query.Set("encrypt", "true")
+	} else {
+		query.Set("encrypt", fields["encrypt"])
+	}
+	u.RawQuery = query.Encode()
+
+	return u.String()
 }
 
 func buildStandardURI(scheme string, fields map[string]string, defaultPort string) string {

--- a/internal/server/connectors_test.go
+++ b/internal/server/connectors_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestAzureSQLConnectorMetadata(t *testing.T) {
+	connector := GetConnectorByID("azuresql")
+	if connector == nil {
+		t.Fatal("expected Azure SQL connector to be registered")
+	}
+	if !connector.IsSource {
+		t.Fatal("Azure SQL connector should be source-capable")
+	}
+	if connector.IsDestination {
+		t.Fatal("Azure SQL connector should not be marked as a destination")
+	}
+}
+
+func TestBuildAzureSQLURI(t *testing.T) {
+	uri := BuildURI("azuresql", map[string]string{
+		"host":      "myserver.database.windows.net",
+		"user":      "client-id",
+		"password":  "secret",
+		"database":  "appdb",
+		"fedauth":   "ActiveDirectoryServicePrincipal",
+		"tenant_id": "tenant-123",
+	})
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		t.Fatalf("invalid URI: %v", err)
+	}
+	if parsed.Scheme != "azuresql" {
+		t.Errorf("scheme = %q, want azuresql", parsed.Scheme)
+	}
+	if parsed.Host != "myserver.database.windows.net:1433" {
+		t.Errorf("host = %q, want myserver.database.windows.net:1433", parsed.Host)
+	}
+	if parsed.User.Username() != "client-id" {
+		t.Errorf("user = %q, want client-id", parsed.User.Username())
+	}
+	password, _ := parsed.User.Password()
+	if password != "secret" {
+		t.Errorf("password = %q, want secret", password)
+	}
+	if parsed.Path != "/appdb" {
+		t.Errorf("path = %q, want /appdb", parsed.Path)
+	}
+
+	query := parsed.Query()
+	if got := query.Get("encrypt"); got != "true" {
+		t.Errorf("encrypt = %q, want true", got)
+	}
+	if got := query.Get("fedauth"); got != "ActiveDirectoryServicePrincipal" {
+		t.Errorf("fedauth = %q, want ActiveDirectoryServicePrincipal", got)
+	}
+	if got := query.Get("tenant_id"); got != "tenant-123" {
+		t.Errorf("tenant_id = %q, want tenant-123", got)
+	}
+}

--- a/internal/uri/parser.go
+++ b/internal/uri/parser.go
@@ -98,6 +98,7 @@ func NormalizeScheme(scheme string) string {
 		"postgresql+asyncpg":  "postgres",
 		"pg":                  "postgres",
 		"redshift+psycopg2":   "redshift",
+		"azure-sql":           "azuresql",
 	}
 	if canonical, ok := aliases[scheme]; ok {
 		return canonical

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -16,6 +16,12 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	_ "github.com/microsoft/go-mssqldb"
+	_ "github.com/microsoft/go-mssqldb/azuread"
+)
+
+const (
+	sqlServerDriverName = "sqlserver"
+	azureSQLDriverName  = "azuresql"
 )
 
 type MSSQLSource struct {
@@ -28,16 +34,16 @@ func NewMSSQLSource() *MSSQLSource {
 }
 
 func (s *MSSQLSource) Schemes() []string {
-	return []string{"mssql", "sqlserver", "mssql+pyodbc"}
+	return []string{"mssql", "sqlserver", "mssql+pyodbc", "azuresql", "azure-sql"}
 }
 
 func (s *MSSQLSource) Connect(ctx context.Context, uri string) error {
-	connStr, err := uriToConnString(uri)
+	connStr, driverName, err := uriToConnString(uri)
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL Server URI: %w", err)
 	}
 
-	db, err := sql.Open("sqlserver", connStr)
+	db, err := sql.Open(driverName, connStr)
 	if err != nil {
 		return fmt.Errorf("failed to open SQL Server connection: %w", err)
 	}
@@ -57,19 +63,20 @@ func (s *MSSQLSource) Connect(ctx context.Context, uri string) error {
 	return nil
 }
 
-// uriToConnString converts a SQL Server URI to the connection string format
+// uriToConnString converts SQL Server and Azure SQL URIs to the connection
+// string format expected by go-mssqldb.
 // URI format: mssql://user:pass@host:port/database?param=value
 // Conn string format: sqlserver://user:pass@host:port?database=db&param=value
-func uriToConnString(uri string) (string, error) {
+func uriToConnString(uri string) (string, string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// Normalize scheme
 	scheme := strings.ToLower(u.Scheme)
-	if !strings.HasPrefix(scheme, "mssql") && scheme != "sqlserver" {
-		return "", fmt.Errorf("unsupported scheme: %s", scheme)
+	isAzureSQL := scheme == "azuresql" || scheme == "azure-sql"
+	if !strings.HasPrefix(scheme, "mssql") && scheme != "sqlserver" && !isAzureSQL {
+		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
 	}
 
 	host := u.Hostname()
@@ -85,14 +92,56 @@ func uriToConnString(uri string) (string, error) {
 	}
 
 	database := strings.TrimPrefix(u.Path, "/")
+	query := u.Query()
+	deleteQueryParamCI(query, "driver")
 
-	// Build sqlserver:// connection string
+	auth, hasAuthentication := normalizeQueryParamCI(query, "authentication")
+	if hasAuthentication {
+		deleteQueryParamCI(query, "authentication")
+		if _, hasFedAuth := normalizeQueryParamCI(query, "fedauth"); !hasFedAuth {
+			if fedAuth := fedAuthFromAuthentication(auth); fedAuth != "" {
+				query.Set("fedauth", fedAuth)
+			}
+		}
+	}
+
+	fedAuth, hasFedAuth := normalizeQueryParamCI(query, "fedauth")
+	tenantID, hasTenantID := normalizeQueryParamCI(query, "tenant_id")
+	if hasTenantID {
+		deleteQueryParamCI(query, "tenant_id")
+	}
+
+	if isAzureSQL {
+		if _, hasEncrypt := normalizeQueryParamCI(query, "encrypt"); !hasEncrypt {
+			query.Set("encrypt", "true")
+		}
+		if !hasFedAuth {
+			switch {
+			case tenantID != "" && user != "":
+				fedAuth = "ActiveDirectoryServicePrincipal"
+				query.Set("fedauth", fedAuth)
+			case user == "":
+				fedAuth = "ActiveDirectoryDefault"
+				query.Set("fedauth", fedAuth)
+			}
+		}
+	}
+
+	driverName := sqlServerDriverName
+	if isAzureSQL || hasFedAuth || hasAuthentication {
+		driverName = azureSQLDriverName
+	}
+
+	if tenantID != "" && user != "" && isServicePrincipalFedAuth(fedAuth) && !strings.Contains(user, "@") {
+		user = user + "@" + tenantID
+	}
+
 	connURL := &url.URL{
 		Scheme: "sqlserver",
 		Host:   fmt.Sprintf("%s:%s", host, port),
 	}
 
-	if user != "" {
+	if user != "" || password != "" {
 		if password != "" {
 			connURL.User = url.UserPassword(user, password)
 		} else {
@@ -100,14 +149,67 @@ func uriToConnString(uri string) (string, error) {
 		}
 	}
 
-	// Add query parameters
-	query := u.Query()
 	if database != "" {
 		query.Set("database", database)
 	}
 	connURL.RawQuery = query.Encode()
 
-	return connURL.String(), nil
+	return connURL.String(), driverName, nil
+}
+
+func normalizeQueryParamCI(query url.Values, canonical string) (string, bool) {
+	for key, values := range query {
+		if !strings.EqualFold(key, canonical) {
+			continue
+		}
+		value := ""
+		if len(values) > 0 {
+			value = values[0]
+		}
+		if key != canonical {
+			query.Del(key)
+			query.Set(canonical, value)
+		}
+		return value, true
+	}
+	return "", false
+}
+
+func deleteQueryParamCI(query url.Values, key string) {
+	for existing := range query {
+		if strings.EqualFold(existing, key) {
+			query.Del(existing)
+		}
+	}
+}
+
+func fedAuthFromAuthentication(authentication string) string {
+	normalized := strings.ToLower(strings.ReplaceAll(authentication, " ", ""))
+	switch normalized {
+	case "activedirectoryaccesstoken", "activedirectoryserviceprincipalaccesstoken":
+		return "ActiveDirectoryServicePrincipalAccessToken"
+	case "activedirectoryserviceprincipal", "activedirectoryapplication":
+		return "ActiveDirectoryServicePrincipal"
+	case "activedirectorydefault":
+		return "ActiveDirectoryDefault"
+	case "activedirectorymanagedidentity", "activedirectorymsi":
+		return "ActiveDirectoryManagedIdentity"
+	case "activedirectorypassword":
+		return "ActiveDirectoryPassword"
+	case "activedirectoryazcli":
+		return "ActiveDirectoryAzCli"
+	case "activedirectorydevicecode":
+		return "ActiveDirectoryDeviceCode"
+	case "activedirectoryinteractive":
+		return "ActiveDirectoryInteractive"
+	default:
+		return ""
+	}
+}
+
+func isServicePrincipalFedAuth(fedAuth string) bool {
+	return strings.EqualFold(fedAuth, "ActiveDirectoryServicePrincipal") ||
+		strings.EqualFold(fedAuth, "ActiveDirectoryApplication")
 }
 
 func (s *MSSQLSource) Close(ctx context.Context) error {

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -1,0 +1,143 @@
+package mssql
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestURIToConnString(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantErr      bool
+		wantDriver   string
+		wantHost     string
+		wantUser     string
+		wantPassword string
+		wantQuery    map[string]string
+		absentQuery  []string
+	}{
+		{
+			name:         "sql server keeps sqlserver driver",
+			uri:          "mssql://sa:pass@localhost/testdb?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=true",
+			wantDriver:   sqlServerDriverName,
+			wantHost:     "localhost:1433",
+			wantUser:     "sa",
+			wantPassword: "pass",
+			wantQuery: map[string]string{
+				"database":               "testdb",
+				"TrustServerCertificate": "true",
+			},
+			absentQuery: []string{"driver"},
+		},
+		{
+			name:         "azure sql auth uses azuresql driver and encryption",
+			uri:          "azuresql://app_user:s3cr3t@myserver.database.windows.net/appdb",
+			wantDriver:   azureSQLDriverName,
+			wantHost:     "myserver.database.windows.net:1433",
+			wantUser:     "app_user",
+			wantPassword: "s3cr3t",
+			wantQuery: map[string]string{
+				"database": "appdb",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:         "azure sql service principal tenant is encoded in user",
+			uri:          "azuresql://client-id:secret@myserver.database.windows.net/appdb?tenant_id=tenant-123",
+			wantDriver:   azureSQLDriverName,
+			wantHost:     "myserver.database.windows.net:1433",
+			wantUser:     "client-id@tenant-123",
+			wantPassword: "secret",
+			wantQuery: map[string]string{
+				"database": "appdb",
+				"encrypt":  "true",
+				"fedauth":  "ActiveDirectoryServicePrincipal",
+			},
+			absentQuery: []string{"tenant_id"},
+		},
+		{
+			name:       "azure sql without credentials defaults to Entra default",
+			uri:        "azure-sql://myserver.database.windows.net/appdb",
+			wantDriver: azureSQLDriverName,
+			wantHost:   "myserver.database.windows.net:1433",
+			wantQuery: map[string]string{
+				"database": "appdb",
+				"encrypt":  "true",
+				"fedauth":  "ActiveDirectoryDefault",
+			},
+		},
+		{
+			name:         "odbc access token authentication maps to fedauth",
+			uri:          "mssql://:token@myserver.database.windows.net/appdb?Authentication=ActiveDirectoryAccessToken",
+			wantDriver:   azureSQLDriverName,
+			wantHost:     "myserver.database.windows.net:1433",
+			wantUser:     "",
+			wantPassword: "token",
+			wantQuery: map[string]string{
+				"database": "appdb",
+				"fedauth":  "ActiveDirectoryServicePrincipalAccessToken",
+			},
+			absentQuery: []string{"Authentication"},
+		},
+		{
+			name:    "wrong scheme errors",
+			uri:     "postgres://user:pass@localhost/db",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			connStr, driverName, err := uriToConnString(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (connStr=%q)", connStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if driverName != tt.wantDriver {
+				t.Fatalf("driver = %q, want %q", driverName, tt.wantDriver)
+			}
+
+			u, perr := url.Parse(connStr)
+			if perr != nil {
+				t.Fatalf("result DSN is not a valid URL: %v", perr)
+			}
+			if u.Scheme != "sqlserver" {
+				t.Errorf("scheme = %q, want sqlserver", u.Scheme)
+			}
+			if u.Host != tt.wantHost {
+				t.Errorf("host = %q, want %q", u.Host, tt.wantHost)
+			}
+
+			gotUser := ""
+			gotPassword := ""
+			if u.User != nil {
+				gotUser = u.User.Username()
+				gotPassword, _ = u.User.Password()
+			}
+			if gotUser != tt.wantUser {
+				t.Errorf("user = %q, want %q", gotUser, tt.wantUser)
+			}
+			if gotPassword != tt.wantPassword {
+				t.Errorf("password = %q, want %q", gotPassword, tt.wantPassword)
+			}
+
+			query := u.Query()
+			for key, want := range tt.wantQuery {
+				if got := query.Get(key); got != want {
+					t.Errorf("query[%q] = %q, want %q", key, got, want)
+				}
+			}
+			for _, key := range tt.absentQuery {
+				if query.Has(key) {
+					t.Errorf("query[%q] should be absent, got %q", key, query.Get(key))
+				}
+			}
+		})
+	}
+}

--- a/pkg/source/mssql/register.go
+++ b/pkg/source/mssql/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterSource(
-		[]string{"mssql", "sqlserver", "mssql+pyodbc"},
+		[]string{"mssql", "sqlserver", "mssql+pyodbc", "azuresql", "azure-sql"},
 		func() interface{} { return NewMSSQLSource() },
 	)
 }

--- a/tests/integration/mssql_confidence_test.go
+++ b/tests/integration/mssql_confidence_test.go
@@ -196,6 +196,65 @@ func TestMSSQLSource_TableToSQLite_CustomSchemaFiltersAndExcludeColumns(t *testi
 	assert.LessOrEqual(t, maxTS, "2024-01-01 00:40:00", "interval end filter should be applied")
 }
 
+func TestAzureSQLSourceScheme_SQLServerContainerToSQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	ctx := context.Background()
+	db := openMSSQLTestDB(t, mssqlDest.uri)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tableName := fmt.Sprintf("dbo.azuresql_source_%s", uniqueSuffix())
+	dropMSSQLTable(t, ctx, db, tableName)
+	t.Cleanup(func() { dropMSSQLTable(t, ctx, db, tableName) })
+
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %s (
+		id INT PRIMARY KEY,
+		name NVARCHAR(100) NOT NULL
+	)`, quoteTableMSSQL(tableName)))
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(
+		ctx,
+		fmt.Sprintf("INSERT INTO %s (id, name) VALUES (@p1, @p2), (@p3, @p4)", quoteTableMSSQL(tableName)),
+		1, "alpha",
+		2, "bravo",
+	)
+	require.NoError(t, err)
+
+	tmpFile, err := os.CreateTemp("", "azuresql_source_*.db")
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	azureSourceURI := strings.Replace(mssqlDest.uri, "mssql://", "azuresql://", 1)
+	cfg := &config.IngestConfig{
+		SourceURI:           azureSourceURI,
+		SourceTable:         tableName,
+		DestURI:             fmt.Sprintf("sqlite:///%s", tmpFile.Name()),
+		DestTable:           "azuresql_rows",
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	destDB, err := sql.Open("sqlite3", tmpFile.Name())
+	require.NoError(t, err)
+	defer func() { _ = destDB.Close() }()
+
+	var count int
+	require.NoError(t, destDB.QueryRow("SELECT COUNT(*) FROM azuresql_rows").Scan(&count))
+	assert.Equal(t, 2, count)
+
+	var name string
+	require.NoError(t, destDB.QueryRow("SELECT name FROM azuresql_rows WHERE id = 2").Scan(&name))
+	assert.Equal(t, "bravo", name)
+}
+
 func TestMSSQLDestination_Replace_CustomSchemaSwapCleanup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
Adds Azure SQL as a source scheme backed by the existing SQL Server reader while using the Go `azuresql` driver for Azure-specific authentication paths. Adds server connector metadata, URI normalization, Microsoft Entra/fedauth translation, and docs for SQL auth, service principal, managed identity, default credentials, and local testing. Includes unit coverage for URI conversion and connector URI building plus a Docker-backed integration test that reads a SQL Server container through `azuresql://` into SQLite. Validated with `go test -short ./...` and `go test -tags integration -run TestAzureSQLSourceScheme_SQLServerContainerToSQLite -count=1 ./tests/integration`.