### PR TITLE
Dedupe staging by primary key in delete+insert strategy

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1211,7 +1211,7 @@ func (d *BigQueryDestination) DeleteInsertTable(ctx context.Context, opts destin
 		for i, pk := range opts.PrimaryKeys {
 			pkCols[i] = fmt.Sprintf("`%s`", pk)
 		}
-		selectClause += fmt.Sprintf(" QUALIFY ROW_NUMBER() OVER (PARTITION BY %s) = 1", strings.Join(pkCols, ", "))
+		selectClause += fmt.Sprintf(" QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `%s` DESC) = 1", strings.Join(pkCols, ", "), opts.IncrementalKey)
 	}
 
 	insertSQL := fmt.Sprintf(

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -444,11 +444,6 @@ func (d *DatabricksDestination) DeleteInsertTable(ctx context.Context, opts dest
 	stagingFull := d.quoteFullTable(stagingSchema, stagingName)
 	targetFull := d.quoteFullTable(targetSchema, targetName)
 
-	quotedCols := make([]string, len(opts.Columns))
-	for i, col := range opts.Columns {
-		quotedCols[i] = fmt.Sprintf("`%s`", col)
-	}
-
 	startVal := d.formatValue(opts.IntervalStart)
 	endVal := d.formatValue(opts.IntervalEnd)
 
@@ -463,19 +458,9 @@ func (d *DatabricksDestination) DeleteInsertTable(ctx context.Context, opts dest
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	colList := strings.Join(quotedCols, ", ")
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf("SELECT %s FROM %s", colList, stagingFull)
-	if len(opts.PrimaryKeys) > 0 {
-		quotedPKs := make([]string, len(opts.PrimaryKeys))
-		for i, pk := range opts.PrimaryKeys {
-			quotedPKs[i] = fmt.Sprintf("`%s`", pk)
-		}
-		selectClause = fmt.Sprintf(
-			"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
-			colList, colList, strings.Join(quotedPKs, ", "), stagingFull,
-		)
-	}
+	colList := strings.Join(quoteColumns(opts.Columns), ", ")
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFull, fmt.Sprintf("`%s`", opts.IncrementalKey))
 	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFull, colList, selectClause)
 	config.Debug("[DATABRICKS] Executing INSERT: %s", insertSQL)
 
@@ -604,6 +589,14 @@ func (d *DatabricksDestination) parseTableName(table string) (schemaName, tableN
 
 func (d *DatabricksDestination) quoteFullTable(schemaName, tableName string) string {
 	return fmt.Sprintf("`%s`.`%s`.`%s`", d.catalog, schemaName, tableName)
+}
+
+func quoteColumns(cols []string) []string {
+	quoted := make([]string, len(cols))
+	for i, col := range cols {
+		quoted[i] = fmt.Sprintf("`%s`", col)
+	}
+	return quoted
 }
 
 func (d *DatabricksDestination) extractWarehouseID() string {

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -463,13 +463,20 @@ func (d *DatabricksDestination) DeleteInsertTable(ctx context.Context, opts dest
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		"INSERT INTO %s (%s) SELECT %s FROM %s",
-		targetFull,
-		strings.Join(quotedCols, ", "),
-		strings.Join(quotedCols, ", "),
-		stagingFull,
-	)
+	colList := strings.Join(quotedCols, ", ")
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", colList, stagingFull)
+	if len(opts.PrimaryKeys) > 0 {
+		quotedPKs := make([]string, len(opts.PrimaryKeys))
+		for i, pk := range opts.PrimaryKeys {
+			quotedPKs[i] = fmt.Sprintf("`%s`", pk)
+		}
+		selectClause = fmt.Sprintf(
+			"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
+			colList, colList, strings.Join(quotedPKs, ", "), stagingFull,
+		)
+	}
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFull, colList, selectClause)
 	config.Debug("[DATABRICKS] Executing INSERT: %s", insertSQL)
 
 	if err := d.executeStatement(ctx, insertSQL); err != nil {

--- a/pkg/destination/dedup.go
+++ b/pkg/destination/dedup.go
@@ -1,0 +1,26 @@
+package destination
+
+import "fmt"
+
+// DedupStagingSelect builds a SELECT over the staging table that keeps a single
+// row per primary key. When quotedOrderByCol is non-empty, ROW_NUMBER orders by
+// it DESC so the latest row per key wins (e.g. the incremental key); otherwise
+// it falls back to a no-op order for engines that require an ORDER BY inside
+// ROW_NUMBER. quotedColumns and quotedPrimaryKeys are already dialect-quoted,
+// comma-joined lists, and stagingExpr is the quoted staging table reference.
+// When there are no primary keys it returns a plain SELECT (no dedup).
+func DedupStagingSelect(quotedColumns, quotedPrimaryKeys, stagingExpr, quotedOrderByCol string) string {
+	if quotedPrimaryKeys == "" {
+		return fmt.Sprintf("SELECT %s FROM %s", quotedColumns, stagingExpr)
+	}
+
+	orderBy := "(SELECT NULL)"
+	if quotedOrderByCol != "" {
+		orderBy = quotedOrderByCol + " DESC"
+	}
+
+	return fmt.Sprintf(
+		"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
+		quotedColumns, quotedColumns, quotedPrimaryKeys, orderBy, stagingExpr,
+	)
+}

--- a/pkg/destination/dedup_test.go
+++ b/pkg/destination/dedup_test.go
@@ -1,0 +1,39 @@
+package destination
+
+import "testing"
+
+func TestDedupStagingSelect(t *testing.T) {
+	cols := `"id", "name", "ts"`
+
+	t.Run("no primary keys returns plain select", func(t *testing.T) {
+		got := DedupStagingSelect(cols, "", `"staging"`, `"ts"`)
+		want := `SELECT "id", "name", "ts" FROM "staging"`
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("orders by incremental key DESC so latest wins", func(t *testing.T) {
+		got := DedupStagingSelect(cols, `"id"`, `"staging"`, `"ts"`)
+		want := `SELECT "id", "name", "ts" FROM (SELECT "id", "name", "ts", ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "ts" DESC) AS __bruin_dedup_rn FROM "staging") AS _numbered WHERE __bruin_dedup_rn = 1`
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("composite primary key", func(t *testing.T) {
+		got := DedupStagingSelect(cols, `"a", "b"`, `"staging"`, `"ts"`)
+		want := `SELECT "id", "name", "ts" FROM (SELECT "id", "name", "ts", ROW_NUMBER() OVER (PARTITION BY "a", "b" ORDER BY "ts" DESC) AS __bruin_dedup_rn FROM "staging") AS _numbered WHERE __bruin_dedup_rn = 1`
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty order column falls back to no-op order", func(t *testing.T) {
+		got := DedupStagingSelect(cols, `"id"`, `"staging"`, "")
+		want := `SELECT "id", "name", "ts" FROM (SELECT "id", "name", "ts", ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM "staging") AS _numbered WHERE __bruin_dedup_rn = 1`
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -488,13 +488,16 @@ func (d *DuckDBDestination) DeleteInsertTable(ctx context.Context, opts destinat
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quotedTargetTable,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quotedStagingTable,
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, quotedStagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable,
+		)
+	}
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quotedTargetTable, colList, selectClause)
 	config.Debug("[DUCKDB DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if err := d.exec(ctx, insertSQL); err != nil {

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -489,14 +489,8 @@ func (d *DuckDBDestination) DeleteInsertTable(ctx context.Context, opts destinat
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, quotedStagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable,
-		)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable, quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quotedTargetTable, colList, selectClause)
 	config.Debug("[DUCKDB DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -714,6 +714,44 @@ func TestMergeTable(t *testing.T) {
 	assert.Equal(t, 300, value)
 }
 
+func TestDeleteInsertTable_DedupesStagingByPK(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	err := dest.Exec(ctx, `CREATE TABLE target_table (id BIGINT, name VARCHAR, ts BIGINT)`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `CREATE TABLE staging_table (id BIGINT, name VARCHAR, ts BIGINT)`)
+	require.NoError(t, err)
+
+	// Staging holds duplicate primary keys for id=1.
+	err = dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(1, 'Alice', 10),
+			(1, 'Alice Dup', 11),
+			(2, 'Bob', 20)
+	`)
+	require.NoError(t, err)
+
+	err = dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable:   "staging_table",
+		TargetTable:    "target_table",
+		IncrementalKey: "ts",
+		IntervalStart:  int64(0),
+		IntervalEnd:    int64(100),
+		Columns:        []string{"id", "name", "ts"},
+		PrimaryKeys:    []string{"id"},
+	})
+	require.NoError(t, err)
+
+	db := openDuckDB(t, ctx, path)
+	var total, id1 int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM target_table").Scan(&total))
+	assert.Equal(t, 2, total, "duplicate PK in staging should collapse to one row")
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM target_table WHERE id = 1").Scan(&id1))
+	assert.Equal(t, 1, id1, "id=1 should appear exactly once")
+}
+
 func TestSwapTable(t *testing.T) {
 	ctx := context.Background()
 	dest, path := connectTestDuckDB(t, ctx)

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -427,15 +427,8 @@ func (d *FabricDestination) DeleteInsertTable(ctx context.Context, opts destinat
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	stagingTable := quoteTable(opts.StagingTable)
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
-		)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quoteTable(opts.StagingTable), quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[Fabric DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -426,13 +426,17 @@ func (d *FabricDestination) DeleteInsertTable(ctx context.Context, opts destinat
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quoteTable(opts.TargetTable),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quoteTable(opts.StagingTable),
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	stagingTable := quoteTable(opts.StagingTable)
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
+		)
+	}
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[Fabric DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -454,13 +454,17 @@ func (d *MSSQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quoteTable(opts.TargetTable),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quoteTable(opts.StagingTable),
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	stagingTable := quoteTable(opts.StagingTable)
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
+		)
+	}
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -455,15 +455,8 @@ func (d *MSSQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	stagingTable := quoteTable(opts.StagingTable)
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
-		)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quoteTable(opts.StagingTable), quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -442,13 +442,17 @@ func (d *MySQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quoteTable(opts.TargetTable),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quoteTable(opts.StagingTable),
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	stagingTable := quoteTable(opts.StagingTable)
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
+		)
+	}
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -443,15 +443,8 @@ func (d *MySQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	stagingTable := quoteTable(opts.StagingTable)
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
-		)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quoteTable(opts.StagingTable), quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -583,13 +583,8 @@ func (d *PostgresDestination) DeleteInsertTable(ctx context.Context, opts destin
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, quotedStagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		// DISTINCT ON dedupes staging by PK so duplicate keys don't reach the
-		// target. No recency column exists here, so the winner per PK is arbitrary.
-		pkList := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
-		selectClause = fmt.Sprintf(`SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s`, pkList, colList, quotedStagingTable, pkList)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable, quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(
 		`INSERT INTO %s (%s) %s`,
 		quotedTargetTable,

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -582,12 +582,19 @@ func (d *PostgresDestination) DeleteInsertTable(ctx context.Context, opts destin
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
+	colList := strings.Join(quotedColumns, ", ")
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, quotedStagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		// DISTINCT ON dedupes staging by PK so duplicate keys don't reach the
+		// target. No recency column exists here, so the winner per PK is arbitrary.
+		pkList := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
+		selectClause = fmt.Sprintf(`SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s`, pkList, colList, quotedStagingTable, pkList)
+	}
 	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
+		`INSERT INTO %s (%s) %s`,
 		quotedTargetTable,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quotedStagingTable,
+		colList,
+		selectClause,
 	)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -516,13 +516,20 @@ func (d *SnowflakeDestination) DeleteInsertTable(ctx context.Context, opts desti
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		"INSERT INTO %s (%s) SELECT %s FROM %s",
-		targetFull,
-		strings.Join(quotedCols, ", "),
-		strings.Join(quotedCols, ", "),
-		stagingFull,
-	)
+	colList := strings.Join(quotedCols, ", ")
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", colList, stagingFull)
+	if len(opts.PrimaryKeys) > 0 {
+		quotedPKs := make([]string, len(opts.PrimaryKeys))
+		for i, pk := range opts.PrimaryKeys {
+			quotedPKs[i] = quoteIdentifier(pk)
+		}
+		selectClause = fmt.Sprintf(
+			"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
+			colList, colList, strings.Join(quotedPKs, ", "), stagingFull,
+		)
+	}
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFull, colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -491,11 +491,6 @@ func (d *SnowflakeDestination) DeleteInsertTable(ctx context.Context, opts desti
 	stagingFull := quoteIdentifier(stagingSchema) + "." + quoteIdentifier(stagingName)
 	targetFull := quoteIdentifier(targetSchema) + "." + quoteIdentifier(targetName)
 
-	quotedCols := make([]string, len(opts.Columns))
-	for i, col := range opts.Columns {
-		quotedCols[i] = quoteIdentifier(col)
-	}
-
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -516,19 +511,9 @@ func (d *SnowflakeDestination) DeleteInsertTable(ctx context.Context, opts desti
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	colList := strings.Join(quotedCols, ", ")
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf("SELECT %s FROM %s", colList, stagingFull)
-	if len(opts.PrimaryKeys) > 0 {
-		quotedPKs := make([]string, len(opts.PrimaryKeys))
-		for i, pk := range opts.PrimaryKeys {
-			quotedPKs[i] = quoteIdentifier(pk)
-		}
-		selectClause = fmt.Sprintf(
-			"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
-			colList, colList, strings.Join(quotedPKs, ", "), stagingFull,
-		)
-	}
+	colList := strings.Join(quoteColumns(opts.Columns), ", ")
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFull, quoteIdentifier(opts.IncrementalKey))
 	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFull, colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
@@ -849,6 +834,14 @@ func quoteIdentifier(name string) string {
 		return name
 	}
 	return fmt.Sprintf(`"%s"`, strings.ToUpper(name))
+}
+
+func quoteColumns(cols []string) []string {
+	quoted := make([]string, len(cols))
+	for i, col := range cols {
+		quoted[i] = quoteIdentifier(col)
+	}
+	return quoted
 }
 
 func filterColumns(columns []string, exclude []string) []string {

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -512,13 +512,16 @@ func (d *SQLiteDestination) DeleteInsertTable(ctx context.Context, opts destinat
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quotedTargetTable,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quotedStagingTable,
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, quotedStagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable,
+		)
+	}
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quotedTargetTable, colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -513,14 +513,8 @@ func (d *SQLiteDestination) DeleteInsertTable(ctx context.Context, opts destinat
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, quotedStagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable,
-		)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quotedStagingTable, quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quotedTargetTable, colList, selectClause)
 	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -480,13 +480,17 @@ func (d *SynapseDestination) DeleteInsertTable(ctx context.Context, opts destina
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quoteTable(opts.TargetTable),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quoteTable(opts.StagingTable),
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	stagingTable := quoteTable(opts.StagingTable)
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
+		)
+	}
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[Synapse DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -481,15 +481,8 @@ func (d *SynapseDestination) DeleteInsertTable(ctx context.Context, opts destina
 	}
 
 	colList := strings.Join(quotedColumns, ", ")
-	stagingTable := quoteTable(opts.StagingTable)
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf(`SELECT %s FROM %s`, colList, stagingTable)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			`SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1`,
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingTable,
-		)
-	}
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), quoteTable(opts.StagingTable), quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (%s) %s`, quoteTable(opts.TargetTable), colList, selectClause)
 	config.Debug("[Synapse DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -315,16 +315,9 @@ func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destinati
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	quotedColumns := quoteColumns(opts.Columns)
-	colList := strings.Join(quotedColumns, ", ")
-	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
-	selectClause := fmt.Sprintf("SELECT %s FROM %s", colList, stagingFQN)
-	if len(opts.PrimaryKeys) > 0 {
-		selectClause = fmt.Sprintf(
-			"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
-			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFQN,
-		)
-	}
+	colList := strings.Join(quoteColumns(opts.Columns), ", ")
+	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFQN, quoteColumns([]string{opts.IncrementalKey})[0])
 	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFQN, colList, selectClause)
 	config.Debug("[TRINO DELETE+INSERT] Executing INSERT: %s", insertSQL)
 

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -316,13 +316,16 @@ func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	}
 
 	quotedColumns := quoteColumns(opts.Columns)
-	insertSQL := fmt.Sprintf(
-		"INSERT INTO %s (%s) SELECT %s FROM %s",
-		targetFQN,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		stagingFQN,
-	)
+	colList := strings.Join(quotedColumns, ", ")
+	// Dedupe staging by primary key so duplicate keys don't produce duplicate rows.
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", colList, stagingFQN)
+	if len(opts.PrimaryKeys) > 0 {
+		selectClause = fmt.Sprintf(
+			"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
+			colList, colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFQN,
+		)
+	}
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFQN, colList, selectClause)
 	config.Debug("[TRINO DELETE+INSERT] Executing INSERT: %s", insertSQL)
 
 	if _, err := d.db.ExecContext(ctx, insertSQL); err != nil {

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -52,7 +52,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		Table:        stagingTable,
 		Schema:       job.Schema,
 		DropFirst:    true,
-		PrimaryKeys:  job.Config.PrimaryKeys,
+		PrimaryKeys:  nil,
 		PartitionBy:  job.Config.PartitionBy,
 		ClusterBy:    job.Config.ClusterBy,
 		ExpiresAfter: destination.ManagedStagingTTL,

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -593,6 +593,83 @@ func TestDestinations_DeleteInsert(t *testing.T) {
 	}
 }
 
+// TestDestinations_DeleteInsert_DedupesStagingByPK exercises delete+insert with
+// primary keys in two phases on the same target:
+//
+//  1. Dedup on load: a source with duplicate primary keys (5 rows across 3
+//     distinct ids {1,1,2,3,3}) must collapse to exactly 3 rows.
+//  2. Normal incremental delete+insert: a second source over the interval
+//     [3,4] must replace id=3 in place, insert net-new id=4, and leave id=1
+//     and id=2 (outside the interval) untouched — ending at 4 rows.
+func TestDestinations_DeleteInsert_DedupesStagingByPK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	if _, err := strategy.Get(config.StrategyDeleteInsert); err != nil {
+		t.Skip("delete+insert strategy not implemented yet")
+	}
+
+	ctx := context.Background()
+	dupURI := jsonlURI(t, "testdata/conformance_deleteinsert_dedup.jsonl")
+	intervalURI := jsonlURI(t, "testdata/conformance_deleteinsert_dedup_interval.jsonl")
+
+	for _, tc := range destinationCases() {
+		tc := tc
+		if tc.sqlBackend == nil || !tc.deleteInsertCapable {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Skip("destination does not support delete+insert")
+			})
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			destURI, destTable, cleanup := tc.setup(t, ctx)
+			defer cleanup()
+
+			countRows := func() int {
+				db, err := tc.sqlBackend.openDB(destURI)
+				require.NoError(t, err)
+				defer func() { _ = db.Close() }()
+				var n int
+				require.NoError(t, db.QueryRow(tc.sqlBackend.countQuery(destTable)).Scan(&n))
+				return n
+			}
+			nameByID := func(id int) string {
+				db, err := tc.sqlBackend.openDB(destURI)
+				require.NoError(t, err)
+				defer func() { _ = db.Close() }()
+				var raw []byte
+				require.NoError(t, db.QueryRow(tc.sqlBackend.nameByIDQuery(destTable, id)).Scan(&raw))
+				return string(raw)
+			}
+
+			cfg := &config.IngestConfig{
+				SourceURI:           dupURI,
+				SourceTable:         "deleteinsert_dedup",
+				DestURI:             destURI,
+				DestTable:           destTable,
+				IncrementalStrategy: config.StrategyDeleteInsert,
+				IncrementalKey:      "id",
+				PrimaryKeys:         []string{"id"},
+			}
+
+			// Phase 1: dedup on load — duplicate PKs collapse to one row each.
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			assert.Equal(t, 3, countRows(), "duplicate primary keys in staging should collapse to one row per key")
+
+			// Phase 2: normal incremental delete+insert over interval [3,4].
+			cfg.SourceURI = intervalURI
+			cfg.SourceTable = "deleteinsert_dedup_interval"
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+			assert.Equal(t, 4, countRows(), "interval delete+insert should replace id=3 and add net-new id=4")
+			assert.Equal(t, "v2-3", nameByID(3), "id=3 inside the interval should be replaced")
+			assert.Equal(t, "v2-4", nameByID(4), "net-new id=4 inside the interval should be inserted")
+		})
+	}
+}
+
 // TestDestinations_TruncateInsert validates truncate+insert semantics:
 //   - seed the destination with a small set of rows via replace
 //   - run truncate+insert with a larger source fixture

--- a/tests/integration/testdata/conformance_deleteinsert_dedup.jsonl
+++ b/tests/integration/testdata/conformance_deleteinsert_dedup.jsonl
@@ -1,0 +1,5 @@
+{"id":1,"name":"v1-1","active":true,"score":11.0}
+{"id":1,"name":"v1-1-dup","active":false,"score":12.0}
+{"id":2,"name":"v1-2","active":true,"score":21.0}
+{"id":3,"name":"v1-3","active":true,"score":31.0}
+{"id":3,"name":"v1-3-dup","active":false,"score":32.0}

--- a/tests/integration/testdata/conformance_deleteinsert_dedup_interval.jsonl
+++ b/tests/integration/testdata/conformance_deleteinsert_dedup_interval.jsonl
@@ -1,0 +1,2 @@
+{"id":3,"name":"v2-3","active":true,"score":33.0}
+{"id":4,"name":"v2-4","active":true,"score":44.0}


### PR DESCRIPTION
Fixes duplicate-row output from the `delete+insert` strategy when the source has duplicate primary keys.

## Changes

- `pkg/strategy/delete_insert.go`: prepare staging with `PrimaryKeys: nil` (matching the merge strategy) so duplicate keys can land in staging.
- `DeleteInsertTable` in the SQL destinations now dedupes the staging SELECT by PK, `ROW_NUMBER() … = 1` for most, `DISTINCT ON` for Postgres, `QUALIFY` already present for BigQuery. (clickhouse/cratedb unchanged, engine handles dedup.)
- New conformance test `TestDestinations_DeleteInsert_DedupesStagingByPK` (dedup on load + normal incremental delete+insert) and a DuckDB unit test.

## Conformance results

`TestDestinations_*` (cloud sourced from test.env):

| Destination | Result |
|---|---|
| postgres, mysql, mssql, sqlite, duckdb, cratedb | ✅ pass |
| bigquery, snowflake | ✅ pass (live) |
| clickhouse, fabric | ⏭️ skipped (disabled / no creds) |
| athena | n/a (delete+insert unsupported) |

Note: synapse, trino, and databricks received the same dedup code but aren't in the conformance harness, so they're covered by inspection, not tests.
