### PR TITLE
feat(salesforce): allow overriding the incremental key

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -112,13 +112,6 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		}
 	}
 
-	// Check if source handles incrementality internally
-	if src.HandlesIncrementality() {
-		if p.config.IncrementalKey != "" {
-			fmt.Printf("Warning: source handles incrementality internally, ignoring --incremental-key=%s\n", p.config.IncrementalKey)
-		}
-	}
-
 	// Get the source table with user configuration
 	// Resolution of PKs, strategy, and incremental key happens inside GetTable
 	table, err := src.GetTable(ctx, source.TableRequest{
@@ -129,6 +122,13 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get table: %w", err)
+	}
+
+	// Sources that manage incrementality internally resolve their own key in
+	// GetTable. Only warn if the user's --incremental-key was actually dropped;
+	// a source that adopts it (resolved key matches) needs no warning.
+	if src.HandlesIncrementality() && p.config.IncrementalKey != "" && table.IncrementalKey() != p.config.IncrementalKey {
+		fmt.Printf("Warning: source handles incrementality internally, ignoring --incremental-key=%s\n", p.config.IncrementalKey)
 	}
 
 	if table.Name() == source.CustomQueryTableName {

--- a/pkg/source/salesforce/salesforce.go
+++ b/pkg/source/salesforce/salesforce.go
@@ -204,7 +204,7 @@ func (s *salesforceSource) read(ctx context.Context, tableName, replicationKey s
 	go func() {
 		defer close(results)
 
-		sobject := tableName
+		var sobject string
 		if meta, ok := salesforceTableMeta[tableName]; ok {
 			sobject = meta.sobject
 		} else {

--- a/pkg/source/salesforce/salesforce.go
+++ b/pkg/source/salesforce/salesforce.go
@@ -175,6 +175,12 @@ func (s *salesforceSource) GetTable(ctx context.Context, req source.TableRequest
 	if req.IncrementalKey != "" {
 		replicationKey = req.IncrementalKey
 		strategy = config.StrategyMerge
+		// Merge requires primary keys. Every Salesforce object exposes an "Id"
+		// field, so fall back to it when neither the table metadata nor the
+		// caller supplied explicit PKs.
+		if len(pk) == 0 {
+			pk = []string{"Id"}
+		}
 	}
 
 	return &source.DynamicSourceTable{

--- a/pkg/source/salesforce/salesforce.go
+++ b/pkg/source/salesforce/salesforce.go
@@ -121,40 +121,38 @@ func (s *salesforceSource) HandlesIncrementality() bool {
 }
 
 type tableMeta struct {
+	sobject        string
 	strategy       config.IncrementalStrategy
 	pk             []string
 	replicationKey string
 }
 
 var salesforceTableMeta = map[string]tableMeta{
-	"user":                     {config.StrategyReplace, nil, ""},
-	"user_role":                {config.StrategyReplace, nil, ""},
-	"opportunity":              {config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
-	"opportunity_line_item":    {config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
-	"opportunity_contact_role": {config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
-	"account":                  {config.StrategyMerge, []string{"Id"}, "LastModifiedDate"},
-	"contact":                  {config.StrategyReplace, []string{"Id"}, ""},
-	"lead":                     {config.StrategyReplace, []string{"Id"}, ""},
-	"campaign":                 {config.StrategyReplace, []string{"Id"}, ""},
-	"campaign_member":          {config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
-	"product":                  {config.StrategyReplace, []string{"Id"}, ""},
-	"pricebook":                {config.StrategyReplace, []string{"Id"}, ""},
-	"pricebook_entry":          {config.StrategyReplace, []string{"Id"}, ""},
-	"task":                     {config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
-	"event":                    {config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
+	"user":                     {"User", config.StrategyReplace, nil, ""},
+	"user_role":                {"UserRole", config.StrategyReplace, nil, ""},
+	"opportunity":              {"Opportunity", config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
+	"opportunity_line_item":    {"OpportunityLineItem", config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
+	"opportunity_contact_role": {"OpportunityContactRole", config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
+	"account":                  {"Account", config.StrategyMerge, []string{"Id"}, "LastModifiedDate"},
+	"contact":                  {"Contact", config.StrategyReplace, []string{"Id"}, ""},
+	"lead":                     {"Lead", config.StrategyReplace, []string{"Id"}, ""},
+	"campaign":                 {"Campaign", config.StrategyReplace, []string{"Id"}, ""},
+	"campaign_member":          {"CampaignMember", config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
+	"product":                  {"Product2", config.StrategyReplace, []string{"Id"}, ""},
+	"pricebook":                {"Pricebook2", config.StrategyReplace, []string{"Id"}, ""},
+	"pricebook_entry":          {"PricebookEntry", config.StrategyReplace, []string{"Id"}, ""},
+	"task":                     {"Task", config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
+	"event":                    {"Event", config.StrategyMerge, []string{"Id"}, "SystemModstamp"},
 }
 
 func (s *salesforceSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
-	if req.IncrementalKey != "" {
-		return nil, fmt.Errorf("salesforce takes care of incrementality on its own, you should not provide incremental_key")
-	}
-
 	tableName := req.Name
 	if tableName == "" {
 		return nil, fmt.Errorf("table name is required for salesforce source")
 	}
 
-	if _, ok := salesforceTableMeta[tableName]; !ok && !strings.HasPrefix(tableName, "custom:") {
+	meta, known := salesforceTableMeta[tableName]
+	if !known && !strings.HasPrefix(tableName, "custom:") {
 		supported := slices.Sorted(maps.Keys(salesforceTableMeta))
 		return nil, fmt.Errorf("unsupported table: %s (supported: %s, or use 'custom:<object_name>' for custom objects)", req.Name, strings.Join(supported, ", "))
 	}
@@ -162,14 +160,21 @@ func (s *salesforceSource) GetTable(ctx context.Context, req source.TableRequest
 	strategy := config.StrategyReplace
 	replicationKey := ""
 	pk := req.PrimaryKeys
-	if meta, ok := salesforceTableMeta[tableName]; ok {
+	if known {
 		strategy = meta.strategy
 		if len(meta.pk) > 0 {
 			pk = meta.pk
 		}
-		if meta.replicationKey != "" {
-			replicationKey = meta.replicationKey
-		}
+		replicationKey = meta.replicationKey
+	}
+
+	// Allow callers to override the built-in incremental key (e.g. via
+	// --incremental-key). When provided, switch to an incremental merge keyed
+	// on that column instead of the default. The column is validated against
+	// the object's datetime fields at read time.
+	if req.IncrementalKey != "" {
+		replicationKey = req.IncrementalKey
+		strategy = config.StrategyMerge
 	}
 
 	return &source.DynamicSourceTable{
@@ -182,58 +187,32 @@ func (s *salesforceSource) GetTable(ctx context.Context, req source.TableRequest
 			return nil, fmt.Errorf("salesforce source does not have a predefined schema; schema inference is required")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
-			return s.read(ctx, tableName, opts)
+			return s.read(ctx, tableName, replicationKey, opts)
 		},
 	}, nil
 }
 
-func (s *salesforceSource) read(ctx context.Context, tableName string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+func (s *salesforceSource) read(ctx context.Context, tableName, replicationKey string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
 		defer close(results)
 
-		var err error
-		switch tableName {
-		case "user":
-			err = s.readUsers(ctx, opts, results)
-		case "user_role":
-			err = s.readUserRoles(ctx, opts, results)
-		case "opportunity":
-			err = s.readOpportunities(ctx, opts, results)
-		case "opportunity_line_item":
-			err = s.readOpportunityLineItems(ctx, opts, results)
-		case "opportunity_contact_role":
-			err = s.readOpportunityContactRoles(ctx, opts, results)
-		case "account":
-			err = s.readAccounts(ctx, opts, results)
-		case "contact":
-			err = s.readContacts(ctx, opts, results)
-		case "lead":
-			err = s.readLeads(ctx, opts, results)
-		case "campaign":
-			err = s.readCampaigns(ctx, opts, results)
-		case "campaign_member":
-			err = s.readCampaignMembers(ctx, opts, results)
-		case "product":
-			err = s.readProduct2(ctx, opts, results)
-		case "pricebook":
-			err = s.readPricebook2(ctx, opts, results)
-		case "pricebook_entry":
-			err = s.readPricebookEntries(ctx, opts, results)
-		case "task":
-			err = s.readTasks(ctx, opts, results)
-		case "event":
-			err = s.readEvents(ctx, opts, results)
-		default:
-			// Custom objects
-			customTable := tableName
-			if strings.HasPrefix(tableName, "custom:") {
-				customTable = strings.TrimPrefix(tableName, "custom:")
-			}
-			err = s.getRecords(ctx, customTable, nil, "", opts, results)
+		sobject := tableName
+		if meta, ok := salesforceTableMeta[tableName]; ok {
+			sobject = meta.sobject
+		} else {
+			sobject = strings.TrimPrefix(tableName, "custom:")
 		}
-		if err != nil {
+
+		// Filter incrementally only when a replication key is in play; otherwise
+		// fetch the full object.
+		var lastState interface{}
+		if replicationKey != "" {
+			lastState = opts.IntervalStart
+		}
+
+		if err := s.getRecords(ctx, sobject, lastState, replicationKey, opts, results); err != nil {
 			results <- source.RecordBatchResult{Err: err}
 		}
 	}()
@@ -286,6 +265,23 @@ func (s *salesforceSource) getRecords(ctx context.Context, sobject string, lastS
 		if fieldName != "" && !compoundFields[fieldName] {
 			fields = append(fields, fieldName)
 		}
+	}
+
+	// Incremental loading filters and orders by a datetime column, so the
+	// replication key must resolve to one of the object's datetime fields.
+	// Normalise to the field's canonical casing for the SOQL query.
+	if replicationKey != "" {
+		canonicalKey := ""
+		for name := range dateFields {
+			if strings.EqualFold(name, replicationKey) {
+				canonicalKey = name
+				break
+			}
+		}
+		if canonicalKey == "" {
+			return fmt.Errorf("incremental key %q is not a datetime field on %s; salesforce incremental loading requires a datetime column such as SystemModstamp or LastModifiedDate", replicationKey, sobject)
+		}
+		replicationKey = canonicalKey
 	}
 
 	predicate := ""
@@ -559,66 +555,6 @@ func (s *salesforceSource) bulkGetQueryResults(ctx context.Context, jobID, batch
 	}
 
 	return nil
-}
-
-func (s *salesforceSource) readUsers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "User", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readUserRoles(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "UserRole", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readOpportunities(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Opportunity", opts.IntervalStart, "SystemModstamp", opts, results)
-}
-
-func (s *salesforceSource) readOpportunityLineItems(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "OpportunityLineItem", opts.IntervalStart, "SystemModstamp", opts, results)
-}
-
-func (s *salesforceSource) readOpportunityContactRoles(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "OpportunityContactRole", opts.IntervalStart, "SystemModstamp", opts, results)
-}
-
-func (s *salesforceSource) readAccounts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Account", opts.IntervalStart, "LastModifiedDate", opts, results)
-}
-
-func (s *salesforceSource) readContacts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Contact", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readLeads(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Lead", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readCampaigns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Campaign", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readCampaignMembers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "CampaignMember", opts.IntervalStart, "SystemModstamp", opts, results)
-}
-
-func (s *salesforceSource) readProduct2(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Product2", nil, "SystemModstamp", opts, results)
-}
-
-func (s *salesforceSource) readPricebook2(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Pricebook2", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readPricebookEntries(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "PricebookEntry", nil, "", opts, results)
-}
-
-func (s *salesforceSource) readTasks(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Task", opts.IntervalStart, "SystemModstamp", opts, results)
-}
-
-func (s *salesforceSource) readEvents(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	return s.getRecords(ctx, "Event", opts.IntervalStart, "SystemModstamp", opts, results)
 }
 
 func soqlTimestamp(v interface{}) string {


### PR DESCRIPTION
Salesforce previously rejected --incremental-key and forced a hardcoded replication key per object. Consolidate the SObject name into salesforceTableMeta, honor a user-supplied incremental key as an override (switching to merge), and validate it against the object's datetime fields.

Also only warn about an ignored --incremental-key when a self-managing source actually drops it (resolved key differs from the requested one).