### PR TITLE
docs: sync README supported sources & destinations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,17 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td colspan="3" style='text-align:center;'><strong>Databases</strong></td>
     </tr>
     <tr>
-        <td>BigQuery</td>
+        <td>AWS Athena</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <td>AWS Redshift</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <td>Cassandra</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
@@ -88,6 +98,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>ClickHouse</td>
         <td>✅</td>
         <td>✅</td>
+    </tr>
+    <tr>
+        <td>Couchbase</td>
+        <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>CrateDB</td>
@@ -100,11 +115,6 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
-        <td>IBM Db2</td>
-        <td>✅</td>
-        <td>-</td>
-    </tr>
-    <tr>
         <td>DuckDB</td>
         <td>✅</td>
         <td>✅</td>
@@ -112,15 +122,35 @@ Pull requests are welcome. However, please open an issue first to discuss what y
     <tr>
         <td>DynamoDB</td>
         <td>✅</td>
-        <td>-</td>
+        <td>✅</td>
     </tr>
     <tr>
         <td>Elasticsearch</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
-     <tr>
+    <tr>
+        <td>Google BigQuery</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
         <td>GCP Spanner</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>IBM Db2</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>InfluxDB</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Kafka</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -130,18 +160,13 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
-        <td>Azure SQL</td>
-        <td>✅</td>
-        <td>-</td>
-    </tr>
-    <tr>
         <td>Microsoft Fabric</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
     <tr>
         <td>Microsoft OneLake</td>
-        <td>❌</td>
+        <td>-</td>
         <td>✅</td>
     </tr>
     <tr>
@@ -162,27 +187,27 @@ Pull requests are welcome. However, please open an issue first to discuss what y
     <tr>
         <td>MySQL</td>
         <td>✅</td>
-        <td>❌</td>
+        <td>✅</td>
     </tr>
     <tr>
         <td>Oracle</td>
         <td>✅</td>
-        <td>❌</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Postgres</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
-     <tr>
-        <td>Redshift</td>
+    <tr>
+        <td>RabbitMQ</td>
         <td>✅</td>
-        <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>SAP Hana</td>
         <td>✅</td>
-        <td>❌</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Snowflake</td>
@@ -190,8 +215,18 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
+        <td>Socrata</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>SQLite</td>
         <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <td>Synapse</td>
+        <td>-</td>
         <td>✅</td>
     </tr>
     <tr>
@@ -202,11 +237,18 @@ Pull requests are welcome. However, please open an issue first to discuss what y
     <tr>
         <td colspan="3" style='text-align:center;'><strong>Platforms</strong></td>
     </tr>
+    <tr>
         <td>Adjust</td>
         <td>✅</td>
         <td>-</td>
+    </tr>
     <tr>
         <td>Airtable</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Allium</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -216,7 +258,7 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
-        <td>Apache Kafka</td>
+        <td>Anthropic</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -226,7 +268,22 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
-        <td>App Store</td>
+        <td>Apple Ads</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Apple App Store</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Applovin</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Applovin Max</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -241,7 +298,37 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Azure Data Lake Storage Gen2</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <td>Bruin</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Chess.com</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>ClickUp</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Cursor</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Docebo</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Dune</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -251,17 +338,37 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Fireflies</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Fluxx</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Frankfurter</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Freshdesk</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>FundraiseUp</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>G2</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>GitHub</td>
-        <td>✅</td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td>Gorgias</td>
-        <td>✅</td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td>Google Sheets</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -276,17 +383,87 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Google Cloud Storage (GCS)</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <td>Google Sheets</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Gorgias</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Granola</td>
         <td>✅</td>
         <td>-</td>
     </tr>
-     <tr>
+    <tr>
+        <td>Hostaway</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>HubSpot</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Indeed</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Intercom</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Internet Society Pulse</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Jira</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>JobTread</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Klaviyo</td>
         <td>✅</td>
         <td>-</td>
     </tr>
     <tr>
+        <td>Linear</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>LinkedIn Ads</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Mailchimp</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Mixpanel</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Monday</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -300,8 +477,13 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
         <td>-</td>
     </tr>
-     <tr>
-        <td>Phantombuster</td>
+    <tr>
+        <td>PhantomBuster</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Pinterest</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -310,18 +492,48 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
         <td>-</td>
     </tr>
-     <tr>
-        <td>Azure Data Lake Storage Gen2</td>
-        <td>✅</td>
-        <td>✅</td>
-    </tr>
-     <tr>
-        <td>S3</td>
+    <tr>
+        <td>Plus Vibe AI</td>
         <td>✅</td>
         <td>-</td>
     </tr>
     <tr>
+        <td>PostHog</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Primer</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>QuickBooks</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Reddit Ads</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>RevenueCat</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>S3</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
         <td>Salesforce</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>SFTP</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -330,13 +542,18 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
         <td>-</td>
     </tr>
-     <tr>
+    <tr>
         <td>Slack</td>
         <td>✅</td>
         <td>-</td>
     </tr>
     <tr>
-        <td>Smartsheets</td>
+        <td>Smartsheet</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Snapchat Ads</td>
         <td>✅</td>
         <td>-</td>
     </tr>
@@ -351,12 +568,32 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>SurveyMonkey</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>TikTok Ads</td>
         <td>✅</td>
         <td>-</td>
     </tr>
     <tr>
+        <td>Trustpilot</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Wise</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Zendesk</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>Zoom</td>
         <td>✅</td>
         <td>-</td>
     </tr>


### PR DESCRIPTION
Align the README table with docs/.vitepress sidebar and the actual destination registry. Adds ~50 missing connectors and fixes destination flags.