### PR TITLE
[codex] Fix unknown JSON string casting

### DIFF
--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -2,6 +2,7 @@ package databuffer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -340,6 +341,10 @@ func castUnknownArray(arr arrow.Array, target arrow.DataType) (arrow.Array, erro
 		return nil, fmt.Errorf("unknown type is not an extension array")
 	}
 
+	if isJSONType(target) {
+		return castUnknownArrayToJSON(ext, target)
+	}
+
 	builder := array.NewBuilder(memory.DefaultAllocator, target)
 	defer builder.Release()
 
@@ -364,6 +369,48 @@ func castUnknownArray(arr arrow.Array, target arrow.DataType) (arrow.Array, erro
 	}
 
 	return builder.NewArray(), nil
+}
+
+func castUnknownArrayToJSON(ext array.ExtensionArray, target arrow.DataType) (arrow.Array, error) {
+	extType, ok := target.(arrow.ExtensionType)
+	if !ok {
+		return nil, fmt.Errorf("target type is not an extension type")
+	}
+
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer builder.Release()
+
+	storage := ext.Storage()
+	for i := 0; i < ext.Len(); i++ {
+		if ext.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+
+		raw, ok := schemainfer.StringValueAt(storage, i)
+		if !ok {
+			builder.AppendNull()
+			continue
+		}
+
+		// Unknown storage is already JSON text; pass it through unless it came
+		// from a non-JSON fallback, in which case quote it as a JSON string.
+		if json.Valid([]byte(raw)) {
+			builder.Append(raw)
+			continue
+		}
+
+		jsonBytes, err := json.Marshal(raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode unknown value as JSON: %w", err)
+		}
+		builder.Append(string(jsonBytes))
+	}
+
+	storageArr := builder.NewArray()
+	defer storageArr.Release()
+
+	return array.NewExtensionArrayWithStorage(extType, storageArr), nil
 }
 
 func castArrayToJSON(ctx context.Context, arr arrow.Array, target arrow.DataType) (arrow.Array, error) {

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -2,6 +2,7 @@ package databuffer
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -701,6 +702,55 @@ func TestCastRecordToSchema(t *testing.T) {
 		assert.Equal(t, "alice", nameCol.Value(0))
 		assert.Equal(t, 0, nameCol.NullN())
 	})
+}
+
+func TestCastRecordToSchema_UnknownToJSONEncodesScalarStrings(t *testing.T) {
+	mem := memory.DefaultAllocator
+
+	sourceSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "mixed_val", Type: schema.UnknownArrowType, Nullable: true},
+	}, nil)
+
+	builder := array.NewBuilder(mem, schema.UnknownArrowType).(*array.ExtensionBuilder)
+	storage := builder.StorageBuilder().(*array.StringBuilder)
+	storage.Append("1")
+	storage.Append(`{"kind":"document","row":2}`)
+	storage.Append(`"mixed_3"`)
+	storage.Append("plain-text")
+	storage.AppendNull()
+	unknownArr := builder.NewArray()
+	builder.Release()
+
+	record := array.NewRecordBatch(sourceSchema, []arrow.Array{unknownArr}, 5)
+	unknownArr.Release()
+	defer record.Release()
+
+	targetSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "mixed_val", Type: schema.JSONArrowType, Nullable: true},
+	}, nil)
+
+	casted, err := CastRecordToSchema(record, targetSchema, true)
+	require.NoError(t, err)
+	defer casted.Release()
+
+	jsonCol, ok := casted.Column(0).(array.ExtensionArray)
+	require.True(t, ok, "expected JSON extension array, got %T", casted.Column(0))
+
+	storageCol, ok := jsonCol.Storage().(*array.String)
+	require.True(t, ok, "expected JSON storage to be string, got %T", jsonCol.Storage())
+
+	want := []string{
+		`1`,
+		`{"kind":"document","row":2}`,
+		`"mixed_3"`,
+		`"plain-text"`,
+	}
+	for i, expected := range want {
+		got := storageCol.Value(i)
+		assert.True(t, json.Valid([]byte(got)), "row %d should be valid JSON: %q", i, got)
+		assert.Equal(t, expected, got)
+	}
+	assert.True(t, storageCol.IsNull(4))
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes MongoDB mixed-type unknown columns inferred as JSON when replaying buffered batches into JSON destinations. Unknown storage that is already valid JSON is passed through unchanged, while non-JSON fallback text is quoted as a JSON string before building JSON extension storage. This prevents Postgres JSONB COPY failures for scalar strings like mixed_3 while preserving objects and numeric JSON without reserializing normal values. Validated with `go test ./pkg/databuffer` and a real MongoDB -> Postgres container repro that fails without the change and passes with `mixed_val` as `jsonb`.