### PR TITLE
[codex] fix MaxCompute row iterator errors

### DIFF
--- a/pkg/source/maxcompute/maxcompute.go
+++ b/pkg/source/maxcompute/maxcompute.go
@@ -524,17 +524,18 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		}
 	}
 
-	if rowCount == 0 {
-		for _, b := range builders {
-			b.Release()
-		}
-		return nil, 0, nil
-	}
 	if err := rows.Err(); err != nil {
 		for _, b := range builders {
 			b.Release()
 		}
 		return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if rowCount == 0 {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, nil
 	}
 
 	arrays := make([]arrow.Array, len(builders))

--- a/pkg/source/maxcompute/maxcompute_test.go
+++ b/pkg/source/maxcompute/maxcompute_test.go
@@ -1,11 +1,23 @@
 package maxcompute
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
+
+const errorRowsDriverName = "maxcompute_error_rows_test"
+
+var errRowsIteration = errors.New("rows iteration failed")
+
+func init() {
+	sql.Register(errorRowsDriverName, errorRowsDriver{})
+}
 
 func TestIntervalLiteralPreservesTimezoneForTimestampTZ(t *testing.T) {
 	t.Parallel()
@@ -31,4 +43,70 @@ func TestIntervalLiteralKeepsBareDatetimeForTimestampNTZ(t *testing.T) {
 	if got != want {
 		t.Fatalf("intervalLiteral(timestamp_ntz) = %q, want %q", got, want)
 	}
+}
+
+func TestRowsToArrowRecordBatchReturnsIteratorErrorBeforeFirstRow(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open(errorRowsDriverName, "")
+	if err != nil {
+		t.Fatalf("open test driver: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.QueryContext(context.Background(), "SELECT id")
+	if err != nil {
+		t.Fatalf("query test driver: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	columns := []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: true}}
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 100)
+	if !errors.Is(err, errRowsIteration) {
+		t.Fatalf("rowsToArrowRecordBatch error = %v, want %v", err, errRowsIteration)
+	}
+	if record != nil {
+		t.Fatal("expected no record batch")
+	}
+	if count != 0 {
+		t.Fatalf("row count = %d, want 0", count)
+	}
+}
+
+type errorRowsDriver struct{}
+
+func (errorRowsDriver) Open(string) (driver.Conn, error) {
+	return errorRowsConn{}, nil
+}
+
+type errorRowsConn struct{}
+
+func (errorRowsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not implemented")
+}
+
+func (errorRowsConn) Close() error {
+	return nil
+}
+
+func (errorRowsConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not implemented")
+}
+
+func (errorRowsConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return errorRows{}, nil
+}
+
+type errorRows struct{}
+
+func (errorRows) Columns() []string {
+	return []string{"id"}
+}
+
+func (errorRows) Close() error {
+	return nil
+}
+
+func (errorRows) Next([]driver.Value) error {
+	return errRowsIteration
 }


### PR DESCRIPTION
## Summary

- Check `rows.Err()` before returning an empty MaxCompute SQL batch.
- Add a regression test for an iterator failure before the first row is read.

## Root Cause

`database/sql.Rows.Next()` returns `false` for both clean exhaustion and iteration failure. The MaxCompute SQL conversion path checked `rowCount == 0` before `rows.Err()`, so a pre-row stream error could be reported as a clean empty result.

## Impact

The ODPS SQL path now surfaces mid-stream failures instead of silently truncating data when a batch has not yet accumulated any rows.

Refs #674.

## Validation

- `git diff --check`
- `go test ./pkg/source/maxcompute`