### PR TITLE
feat(annotation): classify queries by ETL phase via type

### DIFF
--- a/internal/annotation/annotation.go
+++ b/internal/annotation/annotation.go
@@ -5,12 +5,13 @@
 // The format matches bruin's own annotation comment so the same cost-tracking
 // tooling parses both:
 //
-//	-- @bruin.config: {"asset":"raw.orders","pipeline":"shopify","type":"ingestr","ingestr_step":"merge"}
+//	-- @bruin.config: {"asset":"raw.orders","pipeline":"shopify","type":"ingestr_transform","ingestr_step":"merge"}
 //	MERGE INTO raw.orders ...
 //
 // The caller (typically bruin) supplies the external keys (e.g. pipeline,
 // asset) via the --query-annotations flag. ingestr adds the keys only it knows
-// at runtime: type ("ingestr") and ingestr_step (which operation is running).
+// at runtime: type (the ETL phase — ingestr_load or ingestr_transform, or plain
+// ingestr when no step is set) and ingestr_step (which operation is running).
 // Snowflake strips leading comments, so for Snowflake the same JSON is applied
 // via the native QUERY_TAG instead (see QueryTag).
 package annotation
@@ -29,8 +30,9 @@ const commentPrefix = "-- @bruin.config: "
 // own slice in the cost report's Step Type breakdown.
 const ingestrType = "ingestr"
 
-// ingestr_step values, one per distinct destination operation.
+// ingestr_step values, one per distinct operation.
 const (
+	StepExtract      = "extract"       // source read (SELECT) — only meaningful for warehouse sources
 	StepDDL          = "ddl"           // PrepareTable: create target/staging tables
 	StepLoad         = "load"          // Write/WriteParallel: bulk-load rows
 	StepMerge        = "merge"         // MergeTable
@@ -40,6 +42,31 @@ const (
 	StepTruncate     = "truncate"      // TruncateTable: empty target in place
 	StepCleanup      = "cleanup"       // DropTable: drop staging tables
 )
+
+// ingestr classifies each query by ETL phase via the "type" value:
+//
+//	ingestr_extract   — read from the source: the SELECT a warehouse source runs
+//	ingestr_load      — move data in:   ddl, load, swap, truncate, cleanup
+//	ingestr_transform — apply strategy: merge, delete_insert, scd2
+const (
+	typeIngestrExtract   = "ingestr_extract"
+	typeIngestrLoad      = "ingestr_load"
+	typeIngestrTransform = "ingestr_transform"
+)
+
+// typeForStep classifies an ingestr_step into its ETL-phase type.
+func typeForStep(step string) string {
+	switch step {
+	case StepExtract:
+		return typeIngestrExtract
+	case StepMerge, StepDeleteInsert, StepSCD2:
+		return typeIngestrTransform
+	case StepDDL, StepLoad, StepSwap, StepCleanup, StepTruncate:
+		return typeIngestrLoad
+	default:
+		return ingestrType
+	}
+}
 
 // Payload holds the external annotation keys supplied by the caller. Values are
 // kept as interface{} (matching bruin) so callers may pass non-string values.
@@ -95,8 +122,9 @@ func stepFrom(ctx context.Context) string {
 }
 
 // build returns the merged annotation JSON for the current context. ingestr
-// always annotates its destination queries with its own keys (type, and
-// ingestr_step when a step is set), so build never returns "" in practice; the
+// always annotates its destination queries with its own keys (a phase-specific
+// type, and ingestr_step when a step is set), so build never returns "" in
+// practice; the
 // caller-supplied payload from --query-annotations is merged in on top. ingestr-
 // owned keys (type, ingestr_step) always win over caller-supplied keys of the
 // same name. encoding/json marshals map keys in sorted order, so the output is
@@ -110,6 +138,7 @@ func build(ctx context.Context) string {
 	}
 	merged["type"] = ingestrType
 	if step := stepFrom(ctx); step != "" {
+		merged["type"] = typeForStep(step)
 		merged["ingestr_step"] = step
 	}
 	b, err := json.Marshal(merged)

--- a/internal/annotation/annotation_test.go
+++ b/internal/annotation/annotation_test.go
@@ -56,7 +56,7 @@ func TestPrepend_emitsIngestrKeysWithoutPayload(t *testing.T) {
 	// A step alone, without a caller payload, carries type + ingestr_step.
 	ctx := WithStep(context.Background(), StepMerge)
 	got = Prepend(ctx, sql)
-	want = `-- @bruin.config: {"ingestr_step":"merge","type":"ingestr"}` + "\n" + sql
+	want = `-- @bruin.config: {"ingestr_step":"merge","type":"ingestr_transform"}` + "\n" + sql
 	if got != want {
 		t.Fatalf("expected ingestr_step annotation without payload\n got: %q\nwant: %q", got, want)
 	}
@@ -68,7 +68,7 @@ func TestPrepend_buildsComment(t *testing.T) {
 
 	got := Prepend(ctx, "MERGE INTO raw.orders ...")
 	// Keys are emitted in sorted order by encoding/json.
-	const wantComment = `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr"}` + "\n"
+	const wantComment = `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr_transform"}` + "\n"
 	want := wantComment + "MERGE INTO raw.orders ..."
 	if got != want {
 		t.Fatalf("comment mismatch\n got: %q\nwant: %q", got, want)
@@ -81,7 +81,7 @@ func TestPrepend_ingestrKeysWin(t *testing.T) {
 	ctx := WithStep(WithPayload(context.Background(), p), StepDDL)
 
 	got := Prepend(ctx, "X")
-	want := `-- @bruin.config: {"asset":"a","ingestr_step":"ddl","type":"ingestr"}` + "\n" + "X"
+	want := `-- @bruin.config: {"asset":"a","ingestr_step":"ddl","type":"ingestr_load"}` + "\n" + "X"
 	if got != want {
 		t.Fatalf("expected ingestr keys to win\n got: %q\nwant: %q", got, want)
 	}
@@ -98,6 +98,27 @@ func TestPrepend_noStepOmitsStepKey(t *testing.T) {
 	}
 }
 
+func TestTypeForStep(t *testing.T) {
+	cases := map[string]string{
+		StepExtract:      typeIngestrExtract,
+		StepLoad:         typeIngestrLoad,
+		StepDDL:          typeIngestrLoad,
+		StepSwap:         typeIngestrLoad,
+		StepCleanup:      typeIngestrLoad,
+		StepTruncate:     typeIngestrLoad,
+		StepMerge:        typeIngestrTransform,
+		StepDeleteInsert: typeIngestrTransform,
+		StepSCD2:         typeIngestrTransform,
+		"":               ingestrType, // no step → plain ingestr fallback
+		"unknown":        ingestrType,
+	}
+	for step, want := range cases {
+		if got := typeForStep(step); got != want {
+			t.Fatalf("typeForStep(%q) = %q, want %q", step, got, want)
+		}
+	}
+}
+
 func TestQueryTag(t *testing.T) {
 	t.Run("emits ingestr keys without payload", func(t *testing.T) {
 		ctx := WithStep(context.Background(), StepMerge)
@@ -105,7 +126,7 @@ func TestQueryTag(t *testing.T) {
 		if !ok {
 			t.Fatal("expected ok=true: ingestr always annotates")
 		}
-		want := `{"ingestr_step":"merge","type":"ingestr"}`
+		want := `{"ingestr_step":"merge","type":"ingestr_transform"}`
 		if tag != want {
 			t.Fatalf("tag mismatch\n got: %q\nwant: %q", tag, want)
 		}
@@ -119,7 +140,7 @@ func TestQueryTag(t *testing.T) {
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
-		want := `{"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr"}`
+		want := `{"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr_transform"}`
 		if tag != want {
 			t.Fatalf("tag mismatch\n got: %q\nwant: %q", tag, want)
 		}

--- a/internal/annotation/annotation_test.go
+++ b/internal/annotation/annotation_test.go
@@ -114,7 +114,7 @@ func TestTypeForStep(t *testing.T) {
 	}
 	for step, want := range cases {
 		if got := typeForStep(step); got != want {
-			t.Fatalf("typeForStep(%q) = %q, want %q", step, got, want)
+			t.Errorf("typeForStep(%q) = %q, want %q", step, got, want)
 		}
 	}
 }

--- a/pkg/destination/bigquery/bigquery_annotation_test.go
+++ b/pkg/destination/bigquery/bigquery_annotation_test.go
@@ -22,7 +22,7 @@ func TestAnnotatedQueryComment(t *testing.T) {
 		ctx := annotation.WithStep(base, annotation.StepMerge)
 		got := annotation.Prepend(ctx, "MERGE INTO `p`.`raw`.`orders` ...")
 
-		wantComment := `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr"}`
+		wantComment := `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr_transform"}`
 		if !strings.HasPrefix(got, wantComment+"\n") {
 			t.Fatalf("missing/incorrect annotation comment\n got: %q\nwant prefix: %q", got, wantComment)
 		}
@@ -35,7 +35,7 @@ func TestAnnotatedQueryComment(t *testing.T) {
 		ctx := annotation.WithStep(base, annotation.StepDDL)
 		got := annotation.Prepend(ctx, "TRUNCATE TABLE `p`.`raw`.`orders`")
 
-		wantComment := `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"ddl","pipeline":"shopify","type":"ingestr"}`
+		wantComment := `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"ddl","pipeline":"shopify","type":"ingestr_load"}`
 		if !strings.HasPrefix(got, wantComment+"\n") {
 			t.Fatalf("missing/incorrect annotation comment\n got: %q\nwant prefix: %q", got, wantComment)
 		}
@@ -46,7 +46,7 @@ func TestAnnotatedQueryComment(t *testing.T) {
 		const sql = "MERGE INTO `p`.`raw`.`orders` ..."
 		got := annotation.Prepend(ctx, sql)
 
-		wantComment := `-- @bruin.config: {"ingestr_step":"merge","type":"ingestr"}`
+		wantComment := `-- @bruin.config: {"ingestr_step":"merge","type":"ingestr_transform"}`
 		if !strings.HasPrefix(got, wantComment+"\n") {
 			t.Fatalf("expected ingestr annotation without caller keys\n got: %q\nwant prefix: %q", got, wantComment)
 		}

--- a/pkg/destination/snowflake/snowflake_annotation_test.go
+++ b/pkg/destination/snowflake/snowflake_annotation_test.go
@@ -21,7 +21,7 @@ func TestAnnotate(t *testing.T) {
 		if !ok {
 			t.Fatal("expected a query tag: ingestr always annotates")
 		}
-		want := `{"ingestr_step":"merge","type":"ingestr"}`
+		want := `{"ingestr_step":"merge","type":"ingestr_transform"}`
 		if tag != want {
 			t.Fatalf("query tag mismatch\n got: %s\nwant: %s", tag, want)
 		}
@@ -32,14 +32,14 @@ func TestAnnotate(t *testing.T) {
 		base := annotation.WithPayload(context.Background(), payload)
 
 		cases := map[string]string{
-			annotation.StepDDL:          `{"asset":"raw.orders","ingestr_step":"ddl","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepLoad:         `{"asset":"raw.orders","ingestr_step":"load","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepMerge:        `{"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepDeleteInsert: `{"asset":"raw.orders","ingestr_step":"delete_insert","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepSCD2:         `{"asset":"raw.orders","ingestr_step":"scd2","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepSwap:         `{"asset":"raw.orders","ingestr_step":"swap","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepTruncate:     `{"asset":"raw.orders","ingestr_step":"truncate","pipeline":"shopify","type":"ingestr"}`,
-			annotation.StepCleanup:      `{"asset":"raw.orders","ingestr_step":"cleanup","pipeline":"shopify","type":"ingestr"}`,
+			annotation.StepDDL:          `{"asset":"raw.orders","ingestr_step":"ddl","pipeline":"shopify","type":"ingestr_load"}`,
+			annotation.StepLoad:         `{"asset":"raw.orders","ingestr_step":"load","pipeline":"shopify","type":"ingestr_load"}`,
+			annotation.StepMerge:        `{"asset":"raw.orders","ingestr_step":"merge","pipeline":"shopify","type":"ingestr_transform"}`,
+			annotation.StepDeleteInsert: `{"asset":"raw.orders","ingestr_step":"delete_insert","pipeline":"shopify","type":"ingestr_transform"}`,
+			annotation.StepSCD2:         `{"asset":"raw.orders","ingestr_step":"scd2","pipeline":"shopify","type":"ingestr_transform"}`,
+			annotation.StepSwap:         `{"asset":"raw.orders","ingestr_step":"swap","pipeline":"shopify","type":"ingestr_load"}`,
+			annotation.StepTruncate:     `{"asset":"raw.orders","ingestr_step":"truncate","pipeline":"shopify","type":"ingestr_load"}`,
+			annotation.StepCleanup:      `{"asset":"raw.orders","ingestr_step":"cleanup","pipeline":"shopify","type":"ingestr_load"}`,
 		}
 
 		for step, want := range cases {

--- a/pkg/source/adbc/source.go
+++ b/pkg/source/adbc/source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -398,6 +399,11 @@ func (s *ADBCSource) read(ctx context.Context, table string, tableSchema *schema
 		defer close(results)
 
 		query := BuildSelectQuery(table, columns, opts, s.dialect.QuoteIdentifier)
+		// Annotate the source read so a warehouse source (e.g. BigQuery) attributes
+		// the extract query's cost. Prepend keeps a leading comment (BigQuery,
+		// DuckDB); Snowflake strips it, so a Snowflake source would need a QUERY_TAG
+		// instead — not handled here.
+		query = annotation.Prepend(annotation.WithStep(ctx, annotation.StepExtract), query)
 		config.Debug("[%s] Executing query: %s", s.dialect.Name(), query)
 
 		startQuery := time.Now()


### PR DESCRIPTION
## What

Makes the `@bruin.config` annotation `type` reflect the **ETL phase** instead of a flat `"ingestr"`, so warehouse cost can be split into extract / load / transform within an ingestr asset:

| `type` | steps |
|---|---|
| `ingestr_extract` | source read `SELECT` (warehouse sources via the SQL path) |
| `ingestr_load` | `ddl`, `load`, `swap`, `truncate`, `cleanup` |
| `ingestr_transform` | `merge`, `delete_insert`, `scd2` |

Falls back to plain `ingestr` when no step is set. `ingestr_step` is still emitted for fine-grained detail.

## Source extract

The ADBC source now annotates its `SELECT` (`StepExtract`) so a queryable warehouse source attributes the extract query. Caveats (inherent, not query-annotatable):
- BigQuery **table** sources read via the Storage Read API (no query) → `ingestr_extract` appears only for **view** sources (SQL fallback).
- Storage Read/Write APIs and load jobs run no query, so they carry no annotation.
