### PR TITLE
exclude column

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1064,7 +1064,7 @@ func (p *Pipeline) resolveNamingConvention(ctx context.Context, sourceSchema *sc
 
 func (p *Pipeline) applyNamingConvention(sourceSchema *schema.TableSchema, namingConv naming.NamingConvention) error {
 	// If using direct naming (no transformation), skip setup
-	if namingConv.Name() == "direct" {
+	if namingConv.Name() == string(naming.Direct) {
 		config.Debug("[NAMING] Using direct naming (no column transformation)")
 		return nil
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -244,9 +244,16 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		tableSchema.PartitionBy = pt.PartitionBy()
 	}
 
+	// Resolve the naming convention up front so excluded columns can be matched
+	// against either the source name or the destination name they map to.
+	namingConv, err := p.resolveNamingConvention(ctx, tableSchema)
+	if err != nil {
+		return fmt.Errorf("failed to resolve naming convention: %w", err)
+	}
+
 	// Excluded columns should be removed from the effective schema before destination
 	// preparation, even for known-schema sources where read-time filtering alone is not enough.
-	tableSchema = p.applyExcludedColumnsToSchema(tableSchema)
+	tableSchema = p.applyExcludedColumnsToSchema(tableSchema, namingConv)
 
 	// Preserve the original source column names before naming convention renames them.
 	// The source needs original names for its SELECT queries; the ColumnRenamer
@@ -261,8 +268,8 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	copy(originalSourceSchema.Columns, tableSchema.Columns)
 	copy(originalSourceSchema.PrimaryKeys, tableSchema.PrimaryKeys)
 
-	// Setup naming convention and column renamer
-	if err := p.setupNamingConvention(ctx, tableSchema); err != nil {
+	// Setup naming convention and column renamer using the convention resolved above.
+	if err := p.applyNamingConvention(tableSchema, namingConv); err != nil {
 		return fmt.Errorf("failed to setup naming convention: %w", err)
 	}
 
@@ -651,7 +658,7 @@ func (p *Pipeline) filterDroppedPKs(pks []string) []string {
 	return filtered
 }
 
-func (p *Pipeline) applyExcludedColumnsToSchema(tableSchema *schema.TableSchema) *schema.TableSchema {
+func (p *Pipeline) applyExcludedColumnsToSchema(tableSchema *schema.TableSchema, namingConv naming.NamingConvention) *schema.TableSchema {
 	if tableSchema == nil || len(p.config.SQLExcludeColumns) == 0 {
 		return tableSchema
 	}
@@ -661,9 +668,21 @@ func (p *Pipeline) applyExcludedColumnsToSchema(tableSchema *schema.TableSchema)
 		excluded[strings.ToLower(col)] = true
 	}
 
+	// A column matches if the user named it either by its source name or by the
+	// destination name it gets after the naming convention is applied
+	isExcluded := func(name string) bool {
+		if name == "" {
+			return false
+		}
+		if excluded[strings.ToLower(name)] {
+			return true
+		}
+		return namingConv != nil && excluded[strings.ToLower(namingConv.Normalize(name))]
+	}
+
 	filteredCols := make([]schema.Column, 0, len(tableSchema.Columns))
 	for _, col := range tableSchema.Columns {
-		if excluded[strings.ToLower(col.Name)] {
+		if isExcluded(col.Name) {
 			config.Debug("[PIPELINE] Excluding column from effective schema: %s", col.Name)
 			continue
 		}
@@ -672,7 +691,7 @@ func (p *Pipeline) applyExcludedColumnsToSchema(tableSchema *schema.TableSchema)
 
 	filteredPKs := make([]string, 0, len(tableSchema.PrimaryKeys))
 	for _, pk := range tableSchema.PrimaryKeys {
-		if excluded[strings.ToLower(pk)] {
+		if isExcluded(pk) {
 			config.Debug("[PIPELINE] Excluding primary key column from effective schema: %s", pk)
 			continue
 		}
@@ -680,7 +699,7 @@ func (p *Pipeline) applyExcludedColumnsToSchema(tableSchema *schema.TableSchema)
 	}
 
 	incrementalKey := tableSchema.IncrementalKey
-	if excluded[strings.ToLower(incrementalKey)] {
+	if isExcluded(incrementalKey) {
 		config.Debug("[PIPELINE] Excluding incremental key column from effective schema: %s", incrementalKey)
 		incrementalKey = ""
 	}
@@ -1009,9 +1028,19 @@ func (p *Pipeline) setupIngestrColumns(ctx context.Context, sourceSchema *schema
 }
 
 func (p *Pipeline) setupNamingConvention(ctx context.Context, sourceSchema *schema.TableSchema) error {
-	convention, err := naming.ParseConvention(p.config.SchemaNaming)
+	namingConv, err := p.resolveNamingConvention(ctx, sourceSchema)
 	if err != nil {
 		return err
+	}
+	return p.applyNamingConvention(sourceSchema, namingConv)
+}
+
+// resolveNamingConvention determines which naming convention applies, resolving
+// the "auto" setting by inspecting the destination table. It never returns Auto.
+func (p *Pipeline) resolveNamingConvention(ctx context.Context, sourceSchema *schema.TableSchema) (naming.NamingConvention, error) {
+	convention, err := naming.ParseConvention(p.config.SchemaNaming)
+	if err != nil {
+		return nil, err
 	}
 
 	// For auto detection, check if destination exists and has snake_case naming
@@ -1030,14 +1059,16 @@ func (p *Pipeline) setupNamingConvention(ctx context.Context, sourceSchema *sche
 		}
 	}
 
+	return naming.Get(convention), nil
+}
+
+func (p *Pipeline) applyNamingConvention(sourceSchema *schema.TableSchema, namingConv naming.NamingConvention) error {
 	// If using direct naming (no transformation), skip setup
-	if convention == naming.Direct {
+	if namingConv.Name() == "direct" {
 		config.Debug("[NAMING] Using direct naming (no column transformation)")
 		return nil
 	}
 
-	// Get the naming convention implementation
-	namingConv := naming.Get(convention)
 	config.Debug("[NAMING] Using %s naming convention", namingConv.Name())
 
 	// Build column mapping

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -364,11 +364,11 @@ func runLabel(i int) string {
 func TestApplyExcludedColumnsNamingAware(t *testing.T) {
 	source := schema.TableSchema{
 		Columns: []schema.Column{
-			{Name: "id", DataType: schema.TypeInt64, IsPrimaryKey: true},
+			{Name: "UserId", DataType: schema.TypeInt64, IsPrimaryKey: true},
 			{Name: "FullName", DataType: schema.TypeString},
 			{Name: "SecretToken", DataType: schema.TypeString},
 		},
-		PrimaryKeys:    []string{"id"},
+		PrimaryKeys:    []string{"UserId"},
 		IncrementalKey: "FullName",
 	}
 
@@ -377,34 +377,55 @@ func TestApplyExcludedColumnsNamingAware(t *testing.T) {
 		schemaNaming string
 		exclude      []string
 		wantColumns  []string
+		wantPKs      []string
 		wantIncKey   string
 	}{
 		{
 			name:         "exclude by source name",
 			schemaNaming: "snake_case",
 			exclude:      []string{"SecretToken"},
-			wantColumns:  []string{"id", "FullName"},
+			wantColumns:  []string{"UserId", "FullName"},
+			wantPKs:      []string{"UserId"},
 			wantIncKey:   "FullName",
 		},
 		{
 			name:         "exclude by destination snake_case name",
 			schemaNaming: "snake_case",
 			exclude:      []string{"secret_token"},
-			wantColumns:  []string{"id", "FullName"},
+			wantColumns:  []string{"UserId", "FullName"},
+			wantPKs:      []string{"UserId"},
 			wantIncKey:   "FullName",
 		},
 		{
 			name:         "exclude incremental key by destination name",
 			schemaNaming: "snake_case",
 			exclude:      []string{"full_name"},
-			wantColumns:  []string{"id", "SecretToken"},
+			wantColumns:  []string{"UserId", "SecretToken"},
+			wantPKs:      []string{"UserId"},
 			wantIncKey:   "",
+		},
+		{
+			name:         "exclude primary key by destination name",
+			schemaNaming: "snake_case",
+			exclude:      []string{"user_id"},
+			wantColumns:  []string{"FullName", "SecretToken"},
+			wantPKs:      []string{},
+			wantIncKey:   "FullName",
+		},
+		{
+			name:         "exclude primary key by source name",
+			schemaNaming: "snake_case",
+			exclude:      []string{"UserId"},
+			wantColumns:  []string{"FullName", "SecretToken"},
+			wantPKs:      []string{},
+			wantIncKey:   "FullName",
 		},
 		{
 			name:         "direct naming does not match snake_case name",
 			schemaNaming: "direct",
-			exclude:      []string{"secret_token"},
-			wantColumns:  []string{"id", "FullName", "SecretToken"},
+			exclude:      []string{"secret_token", "user_id"},
+			wantColumns:  []string{"UserId", "FullName", "SecretToken"},
+			wantPKs:      []string{"UserId"},
 			wantIncKey:   "FullName",
 		},
 	}
@@ -438,6 +459,14 @@ func TestApplyExcludedColumnsNamingAware(t *testing.T) {
 			for i, want := range tt.wantColumns {
 				if gotColumns[i] != want {
 					t.Errorf("column[%d] = %q, want %q", i, gotColumns[i], want)
+				}
+			}
+			if len(got.PrimaryKeys) != len(tt.wantPKs) {
+				t.Fatalf("primary keys = %v, want %v", got.PrimaryKeys, tt.wantPKs)
+			}
+			for i, want := range tt.wantPKs {
+				if got.PrimaryKeys[i] != want {
+					t.Errorf("primary key[%d] = %q, want %q", i, got.PrimaryKeys[i], want)
 				}
 			}
 			if got.IncrementalKey != tt.wantIncKey {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -361,6 +361,92 @@ func runLabel(i int) string {
 	return fmt.Sprintf("run%d", i)
 }
 
+func TestApplyExcludedColumnsNamingAware(t *testing.T) {
+	source := schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, IsPrimaryKey: true},
+			{Name: "FullName", DataType: schema.TypeString},
+			{Name: "SecretToken", DataType: schema.TypeString},
+		},
+		PrimaryKeys:    []string{"id"},
+		IncrementalKey: "FullName",
+	}
+
+	tests := []struct {
+		name         string
+		schemaNaming string
+		exclude      []string
+		wantColumns  []string
+		wantIncKey   string
+	}{
+		{
+			name:         "exclude by source name",
+			schemaNaming: "snake_case",
+			exclude:      []string{"SecretToken"},
+			wantColumns:  []string{"id", "FullName"},
+			wantIncKey:   "FullName",
+		},
+		{
+			name:         "exclude by destination snake_case name",
+			schemaNaming: "snake_case",
+			exclude:      []string{"secret_token"},
+			wantColumns:  []string{"id", "FullName"},
+			wantIncKey:   "FullName",
+		},
+		{
+			name:         "exclude incremental key by destination name",
+			schemaNaming: "snake_case",
+			exclude:      []string{"full_name"},
+			wantColumns:  []string{"id", "SecretToken"},
+			wantIncKey:   "",
+		},
+		{
+			name:         "direct naming does not match snake_case name",
+			schemaNaming: "direct",
+			exclude:      []string{"secret_token"},
+			wantColumns:  []string{"id", "FullName", "SecretToken"},
+			wantIncKey:   "FullName",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := source
+			src.Columns = make([]schema.Column, len(source.Columns))
+			copy(src.Columns, source.Columns)
+			src.PrimaryKeys = append([]string(nil), source.PrimaryKeys...)
+
+			p := &Pipeline{
+				config: &config.IngestConfig{
+					DestTable:         "users_out",
+					SchemaNaming:      tt.schemaNaming,
+					SQLExcludeColumns: tt.exclude,
+				},
+				dest: &mockDestination{},
+			}
+
+			namingConv, err := p.resolveNamingConvention(context.Background(), &src)
+			if err != nil {
+				t.Fatalf("resolveNamingConvention() error = %v", err)
+			}
+
+			got := p.applyExcludedColumnsToSchema(&src, namingConv)
+			gotColumns := got.ColumnNames()
+			if len(gotColumns) != len(tt.wantColumns) {
+				t.Fatalf("columns = %v, want %v", gotColumns, tt.wantColumns)
+			}
+			for i, want := range tt.wantColumns {
+				if gotColumns[i] != want {
+					t.Errorf("column[%d] = %q, want %q", i, gotColumns[i], want)
+				}
+			}
+			if got.IncrementalKey != tt.wantIncKey {
+				t.Errorf("incremental key = %q, want %q", got.IncrementalKey, tt.wantIncKey)
+			}
+		})
+	}
+}
+
 func TestNamingConsistency(t *testing.T) {
 	camelCaseSourceSchema := &schema.TableSchema{
 		Columns: []schema.Column{


### PR DESCRIPTION
`--sql-exclude-columns `previously matched only the raw source column names, and that check ran before the schema-naming convention renamed columns for the destination. So when a column was renamed (e.g. the default auto/snake_case turns `SecretToken` into `secret_token`), excluding it by the destination name the user actually sees in their warehouse silently did nothing. The column was ingested anyway with no error or warning. This change resolves the naming convention once up front (splitting the old `setupNamingConvention` into `resolveNamingConvention` + `applyNamingConvention`) and reuses it during exclusion, so a column is now dropped from the effective schema if the user names it by either its source name or its post-naming destination name.