### PR TITLE
bq partition by date error fix

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -342,7 +342,7 @@ func isDatePartitionColumn(s *schema.TableSchema, column string) bool {
 		return false
 	}
 	for _, col := range s.Columns {
-		if col.Name == column {
+		if strings.EqualFold(col.Name, column) {
 			return col.DataType == schema.TypeDate
 		}
 	}
@@ -354,7 +354,7 @@ func isDatePartitionColumn(s *schema.TableSchema, column string) bool {
 // available.
 func partitionFieldIsDate(s bigquery.Schema, column string) bool {
 	for _, field := range s {
-		if field.Name == column {
+		if strings.EqualFold(field.Name, column) {
 			return field.Type == bigquery.DateFieldType
 		}
 	}

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -54,8 +54,9 @@ type BigQueryDestination struct {
 	loadMethod         bigQueryLoadMethod
 
 	// Table metadata for current operation
-	partitionBy string
-	clusterBy   []string
+	partitionBy       string
+	partitionByIsDate bool
+	clusterBy         []string
 
 	// Cache for dataset existence checks
 	knownDatasets map[string]bool
@@ -334,6 +335,28 @@ func jobRef(job *bigquery.Job) string {
 	return job.ID()
 }
 
+func isDatePartitionColumn(s *schema.TableSchema, column string) bool {
+	if s == nil || column == "" {
+		return false
+	}
+	for _, col := range s.Columns {
+		if col.Name == column {
+			return col.DataType == schema.TypeDate
+		}
+	}
+	return false
+}
+
+// partitionByClause builds the PARTITION BY clause for a partition column.
+// BigQuery requires a DATE-valued expression: an already-DATE column is used
+// bare, while TIMESTAMP/DATETIME columns are wrapped in DATE().
+func partitionByClause(column string, isDateColumn bool) string {
+	if isDateColumn {
+		return fmt.Sprintf("PARTITION BY `%s`\n", column)
+	}
+	return fmt.Sprintf("PARTITION BY DATE(`%s`)\n", column)
+}
+
 // PrepareTable creates or recreates a table with the given schema.
 func (d *BigQueryDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
 	ctx = annotation.WithStep(ctx, annotation.StepDDL)
@@ -346,6 +369,7 @@ func (d *BigQueryDestination) PrepareTable(ctx context.Context, opts destination
 
 	// Store partition and cluster information for use in SwapTable
 	d.partitionBy = opts.PartitionBy
+	d.partitionByIsDate = isDatePartitionColumn(opts.Schema, opts.PartitionBy)
 	d.clusterBy = opts.ClusterBy
 
 	if opts.DropFirst {
@@ -850,7 +874,7 @@ func (d *BigQueryDestination) SwapTable(ctx context.Context, opts destination.Sw
 		sql := fmt.Sprintf("CREATE OR REPLACE TABLE `%s`.`%s`.`%s`\n", d.projectID, targetDataset, targetTableName)
 
 		if d.partitionBy != "" {
-			sql += fmt.Sprintf("PARTITION BY DATE(`%s`)\n", d.partitionBy)
+			sql += partitionByClause(d.partitionBy, d.partitionByIsDate)
 		}
 
 		if len(d.clusterBy) > 0 {
@@ -1111,7 +1135,14 @@ func (d *BigQueryDestination) buildAlterColumnTypeRewriteSQL(
 	var sqlBuilder strings.Builder
 	fmt.Fprintf(&sqlBuilder, "CREATE OR REPLACE TABLE `%s`.`%s`.`%s`\n", d.projectID, dataset, table)
 	if meta.TimePartitioning != nil && meta.TimePartitioning.Field != "" {
-		fmt.Fprintf(&sqlBuilder, "PARTITION BY DATE(`%s`)\n", meta.TimePartitioning.Field)
+		isDate := false
+		for _, field := range meta.Schema {
+			if field.Name == meta.TimePartitioning.Field {
+				isDate = field.Type == bigquery.DateFieldType
+				break
+			}
+		}
+		sqlBuilder.WriteString(partitionByClause(meta.TimePartitioning.Field, isDate))
 	}
 	if meta.Clustering != nil && len(meta.Clustering.Fields) > 0 {
 		clusterCols := make([]string, len(meta.Clustering.Fields))

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -54,9 +54,8 @@ type BigQueryDestination struct {
 	loadMethod         bigQueryLoadMethod
 
 	// Table metadata for current operation
-	partitionBy       string
-	partitionByIsDate bool
-	clusterBy         []string
+	partitionBy string
+	clusterBy   []string
 
 	// Cache for dataset existence checks
 	knownDatasets map[string]bool
@@ -335,6 +334,9 @@ func jobRef(job *bigquery.Job) string {
 	return job.ID()
 }
 
+// isDatePartitionColumn reports whether the named partition column is a DATE
+// column in the given internal schema. A DATE column must be referenced bare in
+// a PARTITION BY clause; TIMESTAMP/DATETIME columns must be wrapped in DATE().
 func isDatePartitionColumn(s *schema.TableSchema, column string) bool {
 	if s == nil || column == "" {
 		return false
@@ -342,6 +344,18 @@ func isDatePartitionColumn(s *schema.TableSchema, column string) bool {
 	for _, col := range s.Columns {
 		if col.Name == column {
 			return col.DataType == schema.TypeDate
+		}
+	}
+	return false
+}
+
+// partitionFieldIsDate is the equivalent of isDatePartitionColumn for a live
+// BigQuery schema, used where only table metadata (not the internal schema) is
+// available.
+func partitionFieldIsDate(s bigquery.Schema, column string) bool {
+	for _, field := range s {
+		if field.Name == column {
+			return field.Type == bigquery.DateFieldType
 		}
 	}
 	return false
@@ -369,7 +383,6 @@ func (d *BigQueryDestination) PrepareTable(ctx context.Context, opts destination
 
 	// Store partition and cluster information for use in SwapTable
 	d.partitionBy = opts.PartitionBy
-	d.partitionByIsDate = isDatePartitionColumn(opts.Schema, opts.PartitionBy)
 	d.clusterBy = opts.ClusterBy
 
 	if opts.DropFirst {
@@ -874,7 +887,7 @@ func (d *BigQueryDestination) SwapTable(ctx context.Context, opts destination.Sw
 		sql := fmt.Sprintf("CREATE OR REPLACE TABLE `%s`.`%s`.`%s`\n", d.projectID, targetDataset, targetTableName)
 
 		if d.partitionBy != "" {
-			sql += partitionByClause(d.partitionBy, d.partitionByIsDate)
+			sql += partitionByClause(d.partitionBy, isDatePartitionColumn(opts.Schema, d.partitionBy))
 		}
 
 		if len(d.clusterBy) > 0 {
@@ -1135,14 +1148,7 @@ func (d *BigQueryDestination) buildAlterColumnTypeRewriteSQL(
 	var sqlBuilder strings.Builder
 	fmt.Fprintf(&sqlBuilder, "CREATE OR REPLACE TABLE `%s`.`%s`.`%s`\n", d.projectID, dataset, table)
 	if meta.TimePartitioning != nil && meta.TimePartitioning.Field != "" {
-		isDate := false
-		for _, field := range meta.Schema {
-			if field.Name == meta.TimePartitioning.Field {
-				isDate = field.Type == bigquery.DateFieldType
-				break
-			}
-		}
-		sqlBuilder.WriteString(partitionByClause(meta.TimePartitioning.Field, isDate))
+		sqlBuilder.WriteString(partitionByClause(meta.TimePartitioning.Field, partitionFieldIsDate(meta.Schema, meta.TimePartitioning.Field)))
 	}
 	if meta.Clustering != nil && len(meta.Clustering.Fields) > 0 {
 		clusterCols := make([]string, len(meta.Clustering.Fields))

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -872,6 +872,26 @@ func TestIsDatePartitionColumn(t *testing.T) {
 	}
 }
 
+func TestPartitionFieldIsDate(t *testing.T) {
+	s := bigquery.Schema{
+		{Name: "day", Type: bigquery.DateFieldType},
+		{Name: "created_at", Type: bigquery.TimestampFieldType},
+	}
+
+	if !partitionFieldIsDate(s, "day") {
+		t.Fatal("expected day to be detected as a DATE column")
+	}
+	if partitionFieldIsDate(s, "created_at") {
+		t.Fatal("expected created_at not to be detected as a DATE column")
+	}
+	if partitionFieldIsDate(s, "missing") {
+		t.Fatal("expected missing column to default to false")
+	}
+	if partitionFieldIsDate(nil, "day") {
+		t.Fatal("expected nil schema to default to false")
+	}
+}
+
 func TestPartitionByClause(t *testing.T) {
 	if got := partitionByClause("day", true); got != "PARTITION BY `day`\n" {
 		t.Fatalf("DATE column clause = %q", got)

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -821,6 +821,66 @@ func TestBuildAlterColumnTypeRewriteSQL(t *testing.T) {
 	}
 }
 
+func TestBuildAlterColumnTypeRewriteSQL_DatePartitionNotWrapped(t *testing.T) {
+	dest := NewBigQueryDestination()
+	dest.projectID = "my-project"
+
+	meta := &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "day", Type: bigquery.DateFieldType},
+			{Name: "age", Type: bigquery.IntegerFieldType},
+		},
+		TimePartitioning: &bigquery.TimePartitioning{
+			Field: "day",
+		},
+	}
+
+	sql, err := dest.buildAlterColumnTypeRewriteSQL("my_dataset", "my_table", "age", "STRING", meta)
+	if err != nil {
+		t.Fatalf("buildAlterColumnTypeRewriteSQL returned error: %v", err)
+	}
+	if !contains(sql, "PARTITION BY `day`") {
+		t.Fatalf("DATE partition column should be referenced bare:\n%s", sql)
+	}
+	if contains(sql, "PARTITION BY DATE(`day`)") {
+		t.Fatalf("DATE partition column must not be wrapped in DATE():\n%s", sql)
+	}
+}
+
+func TestIsDatePartitionColumn(t *testing.T) {
+	s := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "day", DataType: schema.TypeDate},
+			{Name: "created_at", DataType: schema.TypeTimestamp},
+		},
+	}
+
+	if !isDatePartitionColumn(s, "day") {
+		t.Fatal("expected day to be detected as a DATE column")
+	}
+	if isDatePartitionColumn(s, "created_at") {
+		t.Fatal("expected created_at not to be detected as a DATE column")
+	}
+	if isDatePartitionColumn(s, "missing") {
+		t.Fatal("expected missing column to default to false")
+	}
+	if isDatePartitionColumn(nil, "day") {
+		t.Fatal("expected nil schema to default to false")
+	}
+	if isDatePartitionColumn(s, "") {
+		t.Fatal("expected empty column to default to false")
+	}
+}
+
+func TestPartitionByClause(t *testing.T) {
+	if got := partitionByClause("day", true); got != "PARTITION BY `day`\n" {
+		t.Fatalf("DATE column clause = %q", got)
+	}
+	if got := partitionByClause("created_at", false); got != "PARTITION BY DATE(`created_at`)\n" {
+		t.Fatalf("timestamp column clause = %q", got)
+	}
+}
+
 func TestBuildMergeSQL(t *testing.T) {
 	dest := NewBigQueryDestination()
 	dest.projectID = "my-project"

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -870,6 +870,9 @@ func TestIsDatePartitionColumn(t *testing.T) {
 	if isDatePartitionColumn(s, "") {
 		t.Fatal("expected empty column to default to false")
 	}
+	if !isDatePartitionColumn(s, "Day") {
+		t.Fatal("expected case-insensitive match for BigQuery identifiers")
+	}
 }
 
 func TestPartitionFieldIsDate(t *testing.T) {
@@ -889,6 +892,9 @@ func TestPartitionFieldIsDate(t *testing.T) {
 	}
 	if partitionFieldIsDate(nil, "day") {
 		t.Fatal("expected nil schema to default to false")
+	}
+	if !partitionFieldIsDate(s, "Day") {
+		t.Fatal("expected case-insensitive match for BigQuery identifiers")
 	}
 }
 

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -63,6 +63,7 @@ type SwapOptions struct {
 	TargetTable    string
 	PrimaryKeys    []string
 	IncrementalKey string
+	Schema         *schema.TableSchema
 }
 
 // SCD2Options contains parameters for SCD2 (Slowly Changing Dimensions Type 2) operations.

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -141,6 +141,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 			TargetTable:    targetTable,
 			PrimaryKeys:    job.Config.PrimaryKeys,
 			IncrementalKey: job.Config.IncrementalKey,
+			Schema:         job.Schema,
 		}); err != nil {
 			if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {
 				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
@@ -269,6 +270,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 				StagingTable: stagingTable,
 				TargetTable:  destTable,
 				PrimaryKeys:  tableInfo.PrimaryKeys,
+				Schema:       tableInfo.Schema,
 			}); err != nil {
 				return fmt.Errorf("failed to swap table %s: %w", tableInfo.Name, err)
 			}


### PR DESCRIPTION
Fixes ingesting into BigQuery with `partition_by` set to a column that is already a `DATE` type fails 