### PR TITLE
Add blobstore modified-date incremental loading

### DIFF
--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -170,20 +170,21 @@ Supported format hints include:
 File type hinting works with `gzip` compressed files as well.
 :::
 
-### Incremental loading by source file modification date
+### Incremental loading by source file timestamps
 
-When GCS is used as a source, ingestr can use the GCS object `Updated` timestamp as the incremental key. This filters matching objects before they are downloaded, so only files modified inside the requested interval are read.
+When GCS is used as a source, ingestr can use the GCS object `Updated` or `Created` timestamp as the incremental key. This filters matching objects before they are downloaded, so only files inside the requested timestamp interval are read.
 
-This mode is opt-in for backward compatibility. Existing GCS ingestions without `--incremental-key _ingestr_source_file_modified_at` keep the previous schema and file-listing behavior.
+This mode is opt-in for backward compatibility. Existing GCS ingestions without `--incremental-key _ingestr_source_file_modified_at` or `--incremental-key _ingestr_source_file_created_at` keep the previous schema and file-listing behavior.
 
-When enabled, the source adds these metadata columns to every emitted row:
+When enabled, the source adds the selected timestamp column and the source file path to every emitted row:
 
 - `_ingestr_source_file_modified_at`: the GCS object `Updated` timestamp in UTC.
+- `_ingestr_source_file_created_at`: the GCS object `Created` timestamp in UTC.
 - `_ingestr_source_file_path`: the full `gs://bucket/key` path for the source object.
 
-Use `--incremental-key _ingestr_source_file_modified_at` to select this mode. Other `--incremental-key` values are treated as regular columns from the file data for destination write strategies. They do not enable GCS object modified-date filtering, add file metadata columns, or filter rows while reading the files.
+Use `--incremental-key _ingestr_source_file_modified_at` or `--incremental-key _ingestr_source_file_created_at` to select this mode. Other `--incremental-key` values are treated as regular columns from the file data for destination write strategies. They do not enable GCS object timestamp filtering, add file metadata columns, or filter rows while reading the files.
 
-Use `--interval-start` and optionally `--interval-end` to load only objects modified in that window:
+Use `--interval-start` and optionally `--interval-end` to load only objects whose selected timestamp is in that window:
 
 ```sh
 ingestr ingest \
@@ -196,9 +197,9 @@ ingestr ingest \
     --interval-start "2026-01-01T00:00:00Z"
 ```
 
-The interval bounds are compared to GCS object metadata, not row values inside the files. The interval is half-open: `--interval-start` is inclusive, and `--interval-end` is exclusive. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
+The interval bounds are compared to the selected GCS object timestamp, not row values inside the files. The interval is half-open: `--interval-start` is inclusive, and `--interval-end` is exclusive. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the selected metadata columns.
 
-The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
+The `_ingestr_source_file_modified_at`, `_ingestr_source_file_created_at`, and `_ingestr_source_file_path` column names must not already exist in the files when they are emitted. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding the selected timestamp column also means it will not be available to destination strategies as an incremental key.
 
 ### CSV files without headers
 

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -196,7 +196,7 @@ ingestr ingest \
     --interval-start "2026-01-01T00:00:00Z"
 ```
 
-The interval bounds are compared to GCS object metadata, not row values inside the files. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
+The interval bounds are compared to GCS object metadata, not row values inside the files. The interval is half-open: `--interval-start` is inclusive, and `--interval-end` is exclusive. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
 
 The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
 

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -170,6 +170,36 @@ Supported format hints include:
 File type hinting works with `gzip` compressed files as well.
 :::
 
+### Incremental loading by source file modification date
+
+When GCS is used as a source, ingestr can use the GCS object `Updated` timestamp as the incremental key. This filters matching objects before they are downloaded, so only files modified inside the requested interval are read.
+
+This mode is opt-in for backward compatibility. Existing GCS ingestions without `--incremental-key _ingestr_source_file_modified_at` keep the previous schema and file-listing behavior.
+
+When enabled, the source adds these metadata columns to every emitted row:
+
+- `_ingestr_source_file_modified_at`: the GCS object `Updated` timestamp in UTC.
+- `_ingestr_source_file_path`: the full `gs://bucket/key` path for the source object.
+
+Use `--incremental-key _ingestr_source_file_modified_at` to select this mode. Other `--incremental-key` values are treated as regular columns from the file data for destination write strategies. They do not enable GCS object modified-date filtering, add file metadata columns, or filter rows while reading the files.
+
+Use `--interval-start` and optionally `--interval-end` to load only objects modified in that window:
+
+```sh
+ingestr ingest \
+    --source-uri "gs://?credentials_path=$PWD/service_account.json" \
+    --source-table "my-org-bucket/logs/**/*.jsonl" \
+    --dest-uri "duckdb:///logs.duckdb" \
+    --dest-table "logs.events" \
+    --incremental-strategy append \
+    --incremental-key _ingestr_source_file_modified_at \
+    --interval-start "2026-01-01T00:00:00Z"
+```
+
+The interval bounds are compared to GCS object metadata, not row values inside the files. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
+
+The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
+
 ### CSV files without headers
 
 For CSV files that don't have a header row, use the `#csv_headless` format hint. You can optionally provide column names using the `--columns` flag:

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -16,7 +16,16 @@ s3://?access_key_id=<your_access_key_id>&secret_access_key=<your_secret_access_k
 
 *   `access_key_id`: Your AWS access key ID.
 *   `secret_access_key`: Your AWS secret access key.
+*   `region`: AWS region for S3 and, unless `athena_region` is set, Athena.
 *   `endpoint_url`: URL of an S3-Compatible API Server (optional, for S3-compatible storage like Minio)
+*   `file_discovery`: File discovery backend for S3 sources. Supported values are `list` (default) and `athena_inventory`.
+*   `athena_inventory_table`: Qualified Athena table name for S3 Inventory, e.g. `inventory_db.inventory_table`. Required when `file_discovery=athena_inventory`.
+*   `athena_results_location`: S3 location for Athena query results, e.g. `s3://my-query-results/ingestr/`. Required when `file_discovery=athena_inventory`.
+*   `athena_workgroup`: Athena workgroup to use for inventory queries (optional).
+*   `athena_region`: Athena region if different from `region` (optional).
+*   `athena_inventory_bucket_column`: Bucket column in the inventory table. Defaults to `bucket`.
+*   `athena_inventory_key_column`: Object key column in the inventory table. Defaults to `key`.
+*   `athena_inventory_modified_column`: Object modified timestamp column in the inventory table. Defaults to `last_modified_date`.
 *   `layout`: Layout template (optional, destination only)
 
 These credentials are required to authenticate and authorize access to your S3 buckets.
@@ -216,6 +225,27 @@ ingestr ingest \
 The interval bounds are compared to S3 object metadata, not row values inside the files. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
 
 The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
+
+#### Large buckets: S3 Inventory with Athena
+
+By default, ingestr discovers S3 source files with the S3 `ListObjectsV2` API. S3 can filter that listing by prefix, but not by object `LastModified`, so broad patterns such as `my_bucket/**/*.jsonl` may require many S3 list requests.
+
+For large buckets, you can opt into Athena-backed file discovery over an S3 Inventory table:
+
+```sh
+ingestr ingest \
+    --source-uri 's3://?access_key_id=AKC3YOW7E&secret_access_key=XCtkpL5B&region=us-east-1&file_discovery=athena_inventory&athena_inventory_table=s3_inventory.my_bucket_inventory&athena_results_location=s3://my-athena-results/ingestr/&athena_workgroup=primary' \
+    --source-table 'my_bucket/logs/**/*.jsonl' \
+    --dest-uri duckdb:///logs.duckdb \
+    --dest-table 'logs.events' \
+    --incremental-strategy append \
+    --incremental-key _ingestr_source_file_modified_at \
+    --interval-start '2026-01-01T00:00:00Z'
+```
+
+In this mode, Athena is used only to discover candidate files. For a source table such as `my_bucket/logs/**/*.jsonl`, ingestr derives the static prefix `logs/` and queries the inventory table by bucket, prefix, and source file modified interval. It then applies the full glob pattern locally before downloading the selected files.
+
+S3 Inventory is usually generated on a schedule, so Athena-backed discovery reflects the latest available inventory snapshot rather than real-time object changes. Use the default `file_discovery=list` mode when you need to see newly written files immediately.
 
 ### CSV files without headers
 

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -222,7 +222,7 @@ ingestr ingest \
     --interval-start '2026-01-01T00:00:00Z'
 ```
 
-The interval bounds are compared to S3 object metadata, not row values inside the files. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
+The interval bounds are compared to S3 object metadata, not row values inside the files. The interval is half-open: `--interval-start` is inclusive, and `--interval-end` is exclusive. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
 
 The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
 

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -187,6 +187,36 @@ Supported format hints include:
 File type hinting works with `gzip` compressed files as well.
 :::
 
+### Incremental loading by source file modification date
+
+When S3 is used as a source, ingestr can use the S3 object `LastModified` timestamp as the incremental key. This filters matching objects before they are downloaded, so only files modified inside the requested interval are read.
+
+This mode is opt-in for backward compatibility. Existing S3 ingestions without `--incremental-key _ingestr_source_file_modified_at` keep the previous schema and file-listing behavior.
+
+When enabled, the source adds these metadata columns to every emitted row:
+
+- `_ingestr_source_file_modified_at`: the S3 object `LastModified` timestamp in UTC.
+- `_ingestr_source_file_path`: the full `s3://bucket/key` path for the source object.
+
+Use `--incremental-key _ingestr_source_file_modified_at` to select this mode. Other `--incremental-key` values are treated as regular columns from the file data for destination write strategies. They do not enable S3 object modified-date filtering, add file metadata columns, or filter rows while reading the files.
+
+Use `--interval-start` and optionally `--interval-end` to load only objects modified in that window:
+
+```sh
+ingestr ingest \
+    --source-uri 's3://?access_key_id=AKC3YOW7E&secret_access_key=XCtkpL5B' \
+    --source-table 'my_bucket/logs/**/*.jsonl' \
+    --dest-uri duckdb:///logs.duckdb \
+    --dest-table 'logs.events' \
+    --incremental-strategy append \
+    --incremental-key _ingestr_source_file_modified_at \
+    --interval-start '2026-01-01T00:00:00Z'
+```
+
+The interval bounds are compared to S3 object metadata, not row values inside the files. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
+
+The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
+
 ### CSV files without headers
 
 For CSV files that don't have a header row, use the `#csv_headless` format hint. You can optionally provide column names using the `--columns` flag:

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -25,7 +25,7 @@ s3://?access_key_id=<your_access_key_id>&secret_access_key=<your_secret_access_k
 *   `athena_region`: Athena region if different from `region` (optional).
 *   `athena_inventory_bucket_column`: Bucket column in the inventory table. Defaults to `bucket`.
 *   `athena_inventory_key_column`: Object key column in the inventory table. Defaults to `key`.
-*   `athena_inventory_modified_column`: Object modified timestamp column in the inventory table. Defaults to `last_modified_date`.
+*   `athena_inventory_modified_column`: Object timestamp column in the inventory table used for source file timestamp filtering. Defaults to `last_modified_date`.
 *   `layout`: Layout template (optional, destination only)
 
 These credentials are required to authenticate and authorize access to your S3 buckets.
@@ -196,20 +196,21 @@ Supported format hints include:
 File type hinting works with `gzip` compressed files as well.
 :::
 
-### Incremental loading by source file modification date
+### Incremental loading by source file timestamps
 
-When S3 is used as a source, ingestr can use the S3 object `LastModified` timestamp as the incremental key. This filters matching objects before they are downloaded, so only files modified inside the requested interval are read.
+When S3 is used as a source, ingestr can use the S3 object timestamp as the incremental key. This filters matching objects before they are downloaded, so only files inside the requested timestamp interval are read.
 
-This mode is opt-in for backward compatibility. Existing S3 ingestions without `--incremental-key _ingestr_source_file_modified_at` keep the previous schema and file-listing behavior.
+This mode is opt-in for backward compatibility. Existing S3 ingestions without `--incremental-key _ingestr_source_file_modified_at` or `--incremental-key _ingestr_source_file_created_at` keep the previous schema and file-listing behavior.
 
-When enabled, the source adds these metadata columns to every emitted row:
+When enabled, the source adds the selected timestamp column and the source file path to every emitted row:
 
 - `_ingestr_source_file_modified_at`: the S3 object `LastModified` timestamp in UTC.
+- `_ingestr_source_file_created_at`: the S3 object timestamp in UTC. S3 listing and standard S3 Inventory expose the object `LastModified` timestamp, so this uses the same timestamp as `_ingestr_source_file_modified_at`.
 - `_ingestr_source_file_path`: the full `s3://bucket/key` path for the source object.
 
-Use `--incremental-key _ingestr_source_file_modified_at` to select this mode. Other `--incremental-key` values are treated as regular columns from the file data for destination write strategies. They do not enable S3 object modified-date filtering, add file metadata columns, or filter rows while reading the files.
+Use `--incremental-key _ingestr_source_file_modified_at` or `--incremental-key _ingestr_source_file_created_at` to select this mode. Other `--incremental-key` values are treated as regular columns from the file data for destination write strategies. They do not enable S3 object timestamp filtering, add file metadata columns, or filter rows while reading the files.
 
-Use `--interval-start` and optionally `--interval-end` to load only objects modified in that window:
+Use `--interval-start` and optionally `--interval-end` to load only objects whose selected timestamp is in that window:
 
 ```sh
 ingestr ingest \
@@ -222,9 +223,9 @@ ingestr ingest \
     --interval-start '2026-01-01T00:00:00Z'
 ```
 
-The interval bounds are compared to S3 object metadata, not row values inside the files. The interval is half-open: `--interval-start` is inclusive, and `--interval-end` is exclusive. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the metadata columns.
+The interval bounds are compared to the selected S3 object timestamp, not row values inside the files. The interval is half-open: `--interval-start` is inclusive, and `--interval-end` is exclusive. If no interval is provided, ingestr reads all files matching the source-table pattern and still emits the selected metadata columns.
 
-The `_ingestr_source_file_modified_at` and `_ingestr_source_file_path` column names must not already exist in the files. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding `_ingestr_source_file_modified_at` also means it will not be available to destination strategies as an incremental key.
+The `_ingestr_source_file_modified_at`, `_ingestr_source_file_created_at`, and `_ingestr_source_file_path` column names must not already exist in the files when they are emitted. Use `--exclude-columns` only if you intentionally want to suppress one of these emitted metadata columns; excluding the selected timestamp column also means it will not be available to destination strategies as an incremental key.
 
 #### Large buckets: S3 Inventory with Athena
 
@@ -243,7 +244,7 @@ ingestr ingest \
     --interval-start '2026-01-01T00:00:00Z'
 ```
 
-In this mode, Athena is used only to discover candidate files. For a source table such as `my_bucket/logs/**/*.jsonl`, ingestr derives the static prefix `logs/` and queries the inventory table by bucket, prefix, and source file modified interval. It then applies the full glob pattern locally before downloading the selected files.
+In this mode, Athena is used only to discover candidate files. For a source table such as `my_bucket/logs/**/*.jsonl`, ingestr derives the static prefix `logs/` and queries the inventory table by bucket, prefix, and selected source file timestamp interval. It then applies the full glob pattern locally before downloading the selected files. For both `_ingestr_source_file_modified_at` and `_ingestr_source_file_created_at`, the Athena query uses the configured `athena_inventory_modified_column`.
 
 S3 Inventory is usually generated on a schedule, so Athena-backed discovery reflects the latest available inventory snapshot rather than real-time object changes. Use the default `file_discovery=list` mode when you need to see newly written files immediately.
 

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -521,7 +521,7 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 			}
 
 			updated := attrs.Updated
-			if matchesGlobPattern(attrs.Name, pattern) && objectMatchesIncrementalOptions(&updated, opts) {
+			if matchesGlobPattern(attrs.Name, pattern) && objectMatchesIncrementalOptions(s.provider, &updated, opts) {
 				select {
 				case fileChan <- blobstoreFile{key: attrs.Name, lastModified: copyTimePtr(&updated)}:
 					count++
@@ -623,7 +623,7 @@ func (s *BlobstoreSource) listMatchingS3Objects(ctx context.Context, bucket, pat
 
 		for _, obj := range page.Contents {
 			key := aws.ToString(obj.Key)
-			if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(obj.LastModified, opts) {
+			if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(s.provider, obj.LastModified, opts) {
 				select {
 				case fileChan <- blobstoreFile{key: key, lastModified: copyTimePtr(obj.LastModified)}:
 					count++
@@ -750,7 +750,7 @@ func (s *BlobstoreSource) streamS3InventoryQueryResults(ctx context.Context, exe
 				if err != nil {
 					return count, fmt.Errorf("failed to parse Athena inventory modified timestamp for key %q: %w", key, err)
 				}
-				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(modified, opts) {
+				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(s.provider, modified, opts) {
 					select {
 					case fileChan <- blobstoreFile{key: key, lastModified: modified}:
 						count++
@@ -803,8 +803,8 @@ func hasModifiedInterval(opts source.ReadOptions) bool {
 	return opts.IntervalStart != nil || opts.IntervalEnd != nil
 }
 
-func objectMatchesIncrementalOptions(lastModified *time.Time, opts source.ReadOptions) bool {
-	if !usesBlobstoreModifiedIncrementality(opts) {
+func objectMatchesIncrementalOptions(provider Provider, lastModified *time.Time, opts source.ReadOptions) bool {
+	if !handlesBlobstoreModifiedIncrementality(provider) || !usesBlobstoreModifiedIncrementality(opts) {
 		return true
 	}
 	return objectModifiedInInterval(lastModified, opts.IntervalStart, opts.IntervalEnd)
@@ -827,7 +827,7 @@ func objectModifiedInInterval(lastModified, intervalStart, intervalEnd *time.Tim
 	}
 	if intervalEnd != nil {
 		end := intervalEnd.UTC()
-		if modified.After(end) {
+		if !modified.Before(end) {
 			return false
 		}
 	}
@@ -899,7 +899,7 @@ func buildS3InventoryQuery(parsed *parsedBlobstoreURI, bucket, prefix string, op
 		}
 		if opts.IntervalEnd != nil {
 			conditions = append(conditions, fmt.Sprintf(
-				"%s <= timestamp '%s'",
+				"%s < timestamp '%s'",
 				modifiedColumn,
 				formatAthenaTimestamp(*opts.IntervalEnd),
 			))

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -639,7 +639,7 @@ func (s *BlobstoreSource) listMatchingS3Objects(ctx context.Context, bucket, pat
 
 func (s *BlobstoreSource) listMatchingS3InventoryFiles(ctx context.Context, bucket, pattern, prefix string, opts source.ReadOptions, fileChan chan<- blobstoreFile) (int, error) {
 	if s.athenaClient == nil {
-		return 0, fmt.Errorf("Athena client is not initialized for S3 file discovery")
+		return 0, fmt.Errorf("athena client is not initialized for S3 file discovery")
 	}
 	if s.parsedURI == nil {
 		return 0, fmt.Errorf("S3 source URI is not initialized")
@@ -705,7 +705,7 @@ func (s *BlobstoreSource) waitForAthenaQuery(ctx context.Context, executionID st
 			if resp.QueryExecution.Status.StateChangeReason != nil && *resp.QueryExecution.Status.StateChangeReason != "" {
 				reason = *resp.QueryExecution.Status.StateChangeReason
 			}
-			return fmt.Errorf("Athena inventory query %s %s: %s", executionID, strings.ToLower(string(resp.QueryExecution.Status.State)), reason)
+			return fmt.Errorf("athena inventory query %s %s: %s", executionID, strings.ToLower(string(resp.QueryExecution.Status.State)), reason)
 		}
 
 		select {

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -55,6 +55,7 @@ const (
 	defaultParallelism               = 5
 	defaultBlobstoreFilePathColumn   = "_ingestr_source_file_path"
 	defaultBlobstoreModifiedAtColumn = "_ingestr_source_file_modified_at"
+	defaultBlobstoreCreatedAtColumn  = "_ingestr_source_file_created_at"
 )
 
 type FileFormat string
@@ -85,13 +86,14 @@ type BlobstoreSource struct {
 }
 
 type blobstoreFile struct {
-	key          string
-	lastModified *time.Time
+	key        string
+	modifiedAt *time.Time
+	createdAt  *time.Time
 }
 
 type blobstoreFileMetadata struct {
 	incrementalKey string
-	lastModified   *time.Time
+	incrementalAt  *time.Time
 	filepathColumn string
 	filepath       string
 }
@@ -416,8 +418,8 @@ func (s *BlobstoreSource) read(ctx context.Context, table string, opts source.Re
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to list files: %w", err)}
 		} else if count == 0 {
-			if handlesBlobstoreModifiedIncrementality(s.provider) && usesBlobstoreModifiedIncrementality(opts) && hasModifiedInterval(opts) {
-				config.Debug("[BLOBSTORE-SRC] No files found matching pattern=%s/%s and modified interval", bucket, pattern)
+			if handlesBlobstoreTimestampIncrementality(s.provider) && usesBlobstoreTimestampIncrementality(opts) && hasBlobstoreTimestampInterval(opts) {
+				config.Debug("[BLOBSTORE-SRC] No files found matching pattern=%s/%s and source file timestamp interval", bucket, pattern)
 			} else {
 				results <- source.RecordBatchResult{Err: fmt.Errorf("no files found matching pattern: %s/%s", bucket, pattern)}
 			}
@@ -476,7 +478,7 @@ func (s *BlobstoreSource) processFile(ctx context.Context, bucket string, file b
 
 	var totalRows int64
 	var batchNum int
-	metadata := s.fileMetadata(opts, bucket, file.key, file.lastModified)
+	metadata := s.fileMetadata(opts, bucket, file.key, file.modifiedAt, file.createdAt)
 
 	switch format {
 	case FormatParquet:
@@ -521,9 +523,10 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 			}
 
 			updated := attrs.Updated
-			if matchesGlobPattern(attrs.Name, pattern) && objectMatchesIncrementalOptions(s.provider, &updated, opts) {
+			created := attrs.Created
+			if matchesGlobPattern(attrs.Name, pattern) && objectMatchesIncrementalOptions(s.provider, &updated, &created, opts) {
 				select {
-				case fileChan <- blobstoreFile{key: attrs.Name, lastModified: copyTimePtr(&updated)}:
+				case fileChan <- blobstoreFile{key: attrs.Name, modifiedAt: copyTimePtr(&updated), createdAt: copyTimePtr(&created)}:
 					count++
 				case <-ctx.Done():
 					return count, ctx.Err()
@@ -623,9 +626,9 @@ func (s *BlobstoreSource) listMatchingS3Objects(ctx context.Context, bucket, pat
 
 		for _, obj := range page.Contents {
 			key := aws.ToString(obj.Key)
-			if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(s.provider, obj.LastModified, opts) {
+			if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(s.provider, obj.LastModified, obj.LastModified, opts) {
 				select {
-				case fileChan <- blobstoreFile{key: key, lastModified: copyTimePtr(obj.LastModified)}:
+				case fileChan <- blobstoreFile{key: key, modifiedAt: copyTimePtr(obj.LastModified), createdAt: copyTimePtr(obj.LastModified)}:
 					count++
 				case <-ctx.Done():
 					return count, ctx.Err()
@@ -746,13 +749,13 @@ func (s *BlobstoreSource) streamS3InventoryQueryResults(ctx context.Context, exe
 				if key == "" {
 					continue
 				}
-				modified, err := parseAthenaInventoryTime(athenaRowValue(row, 1))
+				sourceTimestamp, err := parseAthenaInventoryTime(athenaRowValue(row, 1))
 				if err != nil {
-					return count, fmt.Errorf("failed to parse Athena inventory modified timestamp for key %q: %w", key, err)
+					return count, fmt.Errorf("failed to parse Athena inventory timestamp for key %q: %w", key, err)
 				}
-				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(s.provider, modified, opts) {
+				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(s.provider, sourceTimestamp, sourceTimestamp, opts) {
 					select {
-					case fileChan <- blobstoreFile{key: key, lastModified: modified}:
+					case fileChan <- blobstoreFile{key: key, modifiedAt: sourceTimestamp, createdAt: sourceTimestamp}:
 						count++
 					case <-ctx.Done():
 						return count, ctx.Err()
@@ -771,16 +774,18 @@ func (s *BlobstoreSource) streamS3InventoryQueryResults(ctx context.Context, exe
 	return count, nil
 }
 
-func (s *BlobstoreSource) fileMetadata(opts source.ReadOptions, bucket, key string, lastModified *time.Time) blobstoreFileMetadata {
-	if !handlesBlobstoreModifiedIncrementality(s.provider) || !usesBlobstoreModifiedIncrementality(opts) {
+func (s *BlobstoreSource) fileMetadata(opts source.ReadOptions, bucket, key string, modifiedAt, createdAt *time.Time) blobstoreFileMetadata {
+	if !handlesBlobstoreTimestampIncrementality(s.provider) || !usesBlobstoreTimestampIncrementality(opts) {
 		return blobstoreFileMetadata{}
 	}
 
 	metadata := blobstoreFileMetadata{}
-	if lastModified != nil && !lastModified.IsZero() && !isExcludedColumn(defaultBlobstoreModifiedAtColumn, opts.ExcludeColumns) {
-		t := lastModified.UTC()
-		metadata.incrementalKey = defaultBlobstoreModifiedAtColumn
-		metadata.lastModified = &t
+	incrementalKey := blobstoreTimestampIncrementalColumn(opts)
+	incrementalAt := blobstoreTimestampForColumn(incrementalKey, modifiedAt, createdAt)
+	if incrementalAt != nil && !incrementalAt.IsZero() && !isExcludedColumn(incrementalKey, opts.ExcludeColumns) {
+		t := incrementalAt.UTC()
+		metadata.incrementalKey = incrementalKey
+		metadata.incrementalAt = &t
 	}
 
 	if key != "" && !isExcludedColumn(defaultBlobstoreFilePathColumn, opts.ExcludeColumns) {
@@ -791,7 +796,7 @@ func (s *BlobstoreSource) fileMetadata(opts source.ReadOptions, bucket, key stri
 	return metadata
 }
 
-func handlesBlobstoreModifiedIncrementality(provider Provider) bool {
+func handlesBlobstoreTimestampIncrementality(provider Provider) bool {
 	return provider == ProviderS3 || provider == ProviderGCS
 }
 
@@ -799,35 +804,65 @@ func usesBlobstoreModifiedIncrementality(opts source.ReadOptions) bool {
 	return strings.EqualFold(opts.IncrementalKey, defaultBlobstoreModifiedAtColumn)
 }
 
-func hasModifiedInterval(opts source.ReadOptions) bool {
+func usesBlobstoreCreatedIncrementality(opts source.ReadOptions) bool {
+	return strings.EqualFold(opts.IncrementalKey, defaultBlobstoreCreatedAtColumn)
+}
+
+func usesBlobstoreTimestampIncrementality(opts source.ReadOptions) bool {
+	return blobstoreTimestampIncrementalColumn(opts) != ""
+}
+
+func blobstoreTimestampIncrementalColumn(opts source.ReadOptions) string {
+	if usesBlobstoreModifiedIncrementality(opts) {
+		return defaultBlobstoreModifiedAtColumn
+	}
+	if usesBlobstoreCreatedIncrementality(opts) {
+		return defaultBlobstoreCreatedAtColumn
+	}
+	return ""
+}
+
+func blobstoreTimestampForColumn(column string, modifiedAt, createdAt *time.Time) *time.Time {
+	switch {
+	case strings.EqualFold(column, defaultBlobstoreModifiedAtColumn):
+		return modifiedAt
+	case strings.EqualFold(column, defaultBlobstoreCreatedAtColumn):
+		return createdAt
+	default:
+		return nil
+	}
+}
+
+func hasBlobstoreTimestampInterval(opts source.ReadOptions) bool {
 	return opts.IntervalStart != nil || opts.IntervalEnd != nil
 }
 
-func objectMatchesIncrementalOptions(provider Provider, lastModified *time.Time, opts source.ReadOptions) bool {
-	if !handlesBlobstoreModifiedIncrementality(provider) || !usesBlobstoreModifiedIncrementality(opts) {
+func objectMatchesIncrementalOptions(provider Provider, modifiedAt, createdAt *time.Time, opts source.ReadOptions) bool {
+	if !handlesBlobstoreTimestampIncrementality(provider) || !usesBlobstoreTimestampIncrementality(opts) {
 		return true
 	}
-	return objectModifiedInInterval(lastModified, opts.IntervalStart, opts.IntervalEnd)
+	incrementalAt := blobstoreTimestampForColumn(blobstoreTimestampIncrementalColumn(opts), modifiedAt, createdAt)
+	return objectTimestampInInterval(incrementalAt, opts.IntervalStart, opts.IntervalEnd)
 }
 
-func objectModifiedInInterval(lastModified, intervalStart, intervalEnd *time.Time) bool {
+func objectTimestampInInterval(timestamp, intervalStart, intervalEnd *time.Time) bool {
 	if intervalStart == nil && intervalEnd == nil {
 		return true
 	}
-	if lastModified == nil || lastModified.IsZero() {
+	if timestamp == nil || timestamp.IsZero() {
 		return false
 	}
 
-	modified := lastModified.UTC()
+	ts := timestamp.UTC()
 	if intervalStart != nil {
 		start := intervalStart.UTC()
-		if modified.Before(start) {
+		if ts.Before(start) {
 			return false
 		}
 	}
 	if intervalEnd != nil {
 		end := intervalEnd.UTC()
-		if !modified.Before(end) {
+		if !ts.Before(end) {
 			return false
 		}
 	}
@@ -870,11 +905,11 @@ func buildS3InventoryQuery(parsed *parsedBlobstoreURI, bucket, prefix string, op
 	}
 
 	keyColumn := quoteAthenaIdent(parsed.athenaInventoryKeyColumn)
-	modifiedColumn := quoteAthenaIdent(parsed.athenaInventoryModifiedColumn)
+	timestampColumn := quoteAthenaIdent(parsed.athenaInventoryModifiedColumn)
 	query = fmt.Sprintf(
 		"SELECT %s, %s FROM %s",
 		keyColumn,
-		modifiedColumn,
+		timestampColumn,
 		quoteAthenaTableRef(database, table),
 	)
 
@@ -889,18 +924,18 @@ func buildS3InventoryQuery(parsed *parsedBlobstoreURI, bucket, prefix string, op
 			escapeAthenaString(prefix),
 		))
 	}
-	if usesBlobstoreModifiedIncrementality(opts) {
+	if usesBlobstoreTimestampIncrementality(opts) {
 		if opts.IntervalStart != nil {
 			conditions = append(conditions, fmt.Sprintf(
 				"%s >= timestamp '%s'",
-				modifiedColumn,
+				timestampColumn,
 				formatAthenaTimestamp(*opts.IntervalStart),
 			))
 		}
 		if opts.IntervalEnd != nil {
 			conditions = append(conditions, fmt.Sprintf(
 				"%s < timestamp '%s'",
-				modifiedColumn,
+				timestampColumn,
 				formatAthenaTimestamp(*opts.IntervalEnd),
 			))
 		}
@@ -1223,12 +1258,12 @@ func addBlobstoreMetadataColumns(record arrow.RecordBatch, metadata blobstoreFil
 		return record, false, nil
 	}
 
-	addLastModified := metadata.incrementalKey != "" && metadata.lastModified != nil
+	addIncrementalTimestamp := metadata.incrementalKey != "" && metadata.incrementalAt != nil
 	addFilepath := metadata.filepathColumn != "" && metadata.filepath != ""
-	if !addLastModified && !addFilepath {
+	if !addIncrementalTimestamp && !addFilepath {
 		return record, false, nil
 	}
-	if addLastModified && addFilepath && strings.EqualFold(metadata.incrementalKey, metadata.filepathColumn) {
+	if addIncrementalTimestamp && addFilepath && strings.EqualFold(metadata.incrementalKey, metadata.filepathColumn) {
 		return nil, false, fmt.Errorf("blobstore metadata columns conflict on %q; choose a different --incremental-key", metadata.incrementalKey)
 	}
 
@@ -1242,7 +1277,7 @@ func addBlobstoreMetadataColumns(record arrow.RecordBatch, metadata blobstoreFil
 	}
 
 	addedCols := 0
-	if addLastModified {
+	if addIncrementalTimestamp {
 		addedCols++
 	}
 	if addFilepath {
@@ -1258,7 +1293,7 @@ func addBlobstoreMetadataColumns(record arrow.RecordBatch, metadata blobstoreFil
 	}
 
 	nextCol := int(record.NumCols())
-	if addLastModified {
+	if addIncrementalTimestamp {
 		timestampType := &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
 		fields[nextCol] = arrow.Field{
 			Name:     metadata.incrementalKey,
@@ -1268,7 +1303,7 @@ func addBlobstoreMetadataColumns(record arrow.RecordBatch, metadata blobstoreFil
 
 		builder := array.NewTimestampBuilder(memory.DefaultAllocator, timestampType)
 		for i := int64(0); i < record.NumRows(); i++ {
-			builder.Append(arrow.Timestamp(metadata.lastModified.UTC().UnixMicro()))
+			builder.Append(arrow.Timestamp(metadata.incrementalAt.UTC().UnixMicro()))
 		}
 		columns[nextCol] = builder.NewArray()
 		builder.Release()

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -27,6 +27,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/bruin-data/ingestr/internal/adlsutil"
@@ -64,14 +66,22 @@ const (
 	FormatUnknown FileFormat = "unknown"
 )
 
+type s3FileDiscovery string
+
+const (
+	s3FileDiscoveryList            s3FileDiscovery = "list"
+	s3FileDiscoveryAthenaInventory s3FileDiscovery = "athena_inventory"
+)
+
 type BlobstoreSource struct {
-	provider   Provider
-	s3Client   *s3.Client
-	gcsClient  *storage.Client
-	adlsClient *azureDatalakeSourceClient
-	sftpClient *sftp.Client
-	sshClient  *ssh.Client
-	parsedURI  *parsedBlobstoreURI
+	provider     Provider
+	s3Client     *s3.Client
+	athenaClient athenaAPI
+	gcsClient    *storage.Client
+	adlsClient   *azureDatalakeSourceClient
+	sftpClient   *sftp.Client
+	sshClient    *ssh.Client
+	parsedURI    *parsedBlobstoreURI
 }
 
 type blobstoreFile struct {
@@ -84,6 +94,12 @@ type blobstoreFileMetadata struct {
 	lastModified   *time.Time
 	filepathColumn string
 	filepath       string
+}
+
+type athenaAPI interface {
+	StartQueryExecution(context.Context, *athena.StartQueryExecutionInput, ...func(*athena.Options)) (*athena.StartQueryExecutionOutput, error)
+	GetQueryExecution(context.Context, *athena.GetQueryExecutionInput, ...func(*athena.Options)) (*athena.GetQueryExecutionOutput, error)
+	GetQueryResults(context.Context, *athena.GetQueryResultsInput, ...func(*athena.Options)) (*athena.GetQueryResultsOutput, error)
 }
 
 func NewBlobstoreSource() *BlobstoreSource {
@@ -110,6 +126,13 @@ func (s *BlobstoreSource) Connect(ctx context.Context, uri string) error {
 			return fmt.Errorf("failed to create S3 client: %w", err)
 		}
 		s.s3Client = client
+		if parsed.s3FileDiscovery == s3FileDiscoveryAthenaInventory {
+			athenaClient, err := createS3DiscoveryAthenaClient(ctx, parsed)
+			if err != nil {
+				return fmt.Errorf("failed to create Athena client for S3 file discovery: %w", err)
+			}
+			s.athenaClient = athenaClient
+		}
 		config.Debug("[BLOBSTORE-SRC] Connected to S3")
 
 	case ProviderGCS:
@@ -145,21 +168,7 @@ func (s *BlobstoreSource) Connect(ctx context.Context, uri string) error {
 }
 
 func createS3Client(ctx context.Context, parsed *parsedBlobstoreURI) (*s3.Client, error) {
-	var opts []func(*awsconfig.LoadOptions) error
-
-	if parsed.accessKeyID != "" && parsed.secretAccessKey != "" {
-		opts = append(opts, awsconfig.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(parsed.accessKeyID, parsed.secretAccessKey, ""),
-		))
-	}
-
-	if parsed.region != "" {
-		opts = append(opts, awsconfig.WithRegion(parsed.region))
-	} else {
-		opts = append(opts, awsconfig.WithRegion("us-east-1"))
-	}
-
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	cfg, err := loadAWSConfig(ctx, parsed, parsed.region)
 	if err != nil {
 		return nil, err
 	}
@@ -178,6 +187,34 @@ func createS3Client(ctx context.Context, parsed *parsedBlobstoreURI) (*s3.Client
 	}
 
 	return s3.NewFromConfig(cfg, s3Opts...), nil
+}
+
+func createS3DiscoveryAthenaClient(ctx context.Context, parsed *parsedBlobstoreURI) (athenaAPI, error) {
+	cfg, err := loadAWSConfig(ctx, parsed, parsed.athenaRegion)
+	if err != nil {
+		return nil, err
+	}
+	return athena.NewFromConfig(cfg), nil
+}
+
+func loadAWSConfig(ctx context.Context, parsed *parsedBlobstoreURI, region string) (aws.Config, error) {
+	var opts []func(*awsconfig.LoadOptions) error
+
+	if parsed.accessKeyID != "" && parsed.secretAccessKey != "" {
+		opts = append(opts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(parsed.accessKeyID, parsed.secretAccessKey, ""),
+		))
+	}
+
+	if region == "" {
+		region = parsed.region
+	}
+	if region == "" {
+		region = "us-east-1"
+	}
+	opts = append(opts, awsconfig.WithRegion(region))
+
+	return awsconfig.LoadDefaultConfig(ctx, opts...)
 }
 
 func createGCSClient(ctx context.Context, parsed *parsedBlobstoreURI) (*storage.Client, error) {
@@ -463,29 +500,14 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 
 	switch s.provider {
 	case ProviderS3:
-		paginator := s3.NewListObjectsV2Paginator(s.s3Client, &s3.ListObjectsV2Input{
-			Bucket: aws.String(bucket),
-			Prefix: aws.String(prefix),
-		})
-
-		for paginator.HasMorePages() {
-			page, err := paginator.NextPage(ctx)
-			if err != nil {
-				return count, fmt.Errorf("failed to list S3 objects: %w", err)
-			}
-
-			for _, obj := range page.Contents {
-				key := aws.ToString(obj.Key)
-				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(obj.LastModified, opts) {
-					select {
-					case fileChan <- blobstoreFile{key: key, lastModified: copyTimePtr(obj.LastModified)}:
-						count++
-					case <-ctx.Done():
-						return count, ctx.Err()
-					}
-				}
-			}
+		if s.parsedURI != nil && s.parsedURI.s3FileDiscovery == s3FileDiscoveryAthenaInventory {
+			return s.listMatchingS3InventoryFiles(ctx, bucket, pattern, prefix, opts, fileChan)
 		}
+		s3Count, err := s.listMatchingS3Objects(ctx, bucket, pattern, prefix, opts, fileChan)
+		if err != nil {
+			return count, err
+		}
+		count += s3Count
 
 	case ProviderGCS:
 		it := s.gcsClient.Bucket(bucket).Objects(ctx, &storage.Query{Prefix: prefix})
@@ -586,6 +608,169 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 	return count, nil
 }
 
+func (s *BlobstoreSource) listMatchingS3Objects(ctx context.Context, bucket, pattern, prefix string, opts source.ReadOptions, fileChan chan<- blobstoreFile) (int, error) {
+	count := 0
+	paginator := s3.NewListObjectsV2Paginator(s.s3Client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return count, fmt.Errorf("failed to list S3 objects: %w", err)
+		}
+
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+			if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(obj.LastModified, opts) {
+				select {
+				case fileChan <- blobstoreFile{key: key, lastModified: copyTimePtr(obj.LastModified)}:
+					count++
+				case <-ctx.Done():
+					return count, ctx.Err()
+				}
+			}
+		}
+	}
+
+	return count, nil
+}
+
+func (s *BlobstoreSource) listMatchingS3InventoryFiles(ctx context.Context, bucket, pattern, prefix string, opts source.ReadOptions, fileChan chan<- blobstoreFile) (int, error) {
+	if s.athenaClient == nil {
+		return 0, fmt.Errorf("Athena client is not initialized for S3 file discovery")
+	}
+	if s.parsedURI == nil {
+		return 0, fmt.Errorf("S3 source URI is not initialized")
+	}
+
+	query, database, err := buildS3InventoryQuery(s.parsedURI, bucket, prefix, opts)
+	if err != nil {
+		return 0, err
+	}
+	config.Debug("[BLOBSTORE-SRC] Discovering S3 files with Athena inventory query: %s", query)
+
+	execID, err := s.startAthenaQuery(ctx, query, database)
+	if err != nil {
+		return 0, err
+	}
+	if err := s.waitForAthenaQuery(ctx, execID); err != nil {
+		return 0, err
+	}
+
+	return s.streamS3InventoryQueryResults(ctx, execID, pattern, opts, fileChan)
+}
+
+func (s *BlobstoreSource) startAthenaQuery(ctx context.Context, query, database string) (string, error) {
+	input := &athena.StartQueryExecutionInput{
+		QueryString: aws.String(query),
+		ResultConfiguration: &athenatypes.ResultConfiguration{
+			OutputLocation: aws.String(s.parsedURI.athenaResultsLocation),
+		},
+	}
+	if database != "" {
+		input.QueryExecutionContext = &athenatypes.QueryExecutionContext{Database: aws.String(database)}
+	}
+	if s.parsedURI.athenaWorkgroup != "" {
+		input.WorkGroup = aws.String(s.parsedURI.athenaWorkgroup)
+	}
+
+	resp, err := s.athenaClient.StartQueryExecution(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("failed to start Athena inventory query: %w", err)
+	}
+	if resp.QueryExecutionId == nil || *resp.QueryExecutionId == "" {
+		return "", fmt.Errorf("failed to start Athena inventory query: empty execution id")
+	}
+	return *resp.QueryExecutionId, nil
+}
+
+func (s *BlobstoreSource) waitForAthenaQuery(ctx context.Context, executionID string) error {
+	delay := 400 * time.Millisecond
+	for {
+		resp, err := s.athenaClient.GetQueryExecution(ctx, &athena.GetQueryExecutionInput{QueryExecutionId: aws.String(executionID)})
+		if err != nil {
+			return fmt.Errorf("failed to get Athena inventory query status: %w", err)
+		}
+		if resp.QueryExecution == nil || resp.QueryExecution.Status == nil || resp.QueryExecution.Status.State == "" {
+			return fmt.Errorf("failed to get Athena inventory query status: missing state")
+		}
+
+		switch resp.QueryExecution.Status.State {
+		case athenatypes.QueryExecutionStateSucceeded:
+			return nil
+		case athenatypes.QueryExecutionStateFailed, athenatypes.QueryExecutionStateCancelled:
+			reason := "unknown reason"
+			if resp.QueryExecution.Status.StateChangeReason != nil && *resp.QueryExecution.Status.StateChangeReason != "" {
+				reason = *resp.QueryExecution.Status.StateChangeReason
+			}
+			return fmt.Errorf("Athena inventory query %s %s: %s", executionID, strings.ToLower(string(resp.QueryExecution.Status.State)), reason)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+			if delay < 5*time.Second {
+				delay *= 2
+				if delay > 5*time.Second {
+					delay = 5 * time.Second
+				}
+			}
+		}
+	}
+}
+
+func (s *BlobstoreSource) streamS3InventoryQueryResults(ctx context.Context, executionID, pattern string, opts source.ReadOptions, fileChan chan<- blobstoreFile) (int, error) {
+	count := 0
+	skipHeader := true
+	var nextToken *string
+
+	for {
+		out, err := s.athenaClient.GetQueryResults(ctx, &athena.GetQueryResultsInput{
+			QueryExecutionId: aws.String(executionID),
+			NextToken:        nextToken,
+			MaxResults:       aws.Int32(1000),
+		})
+		if err != nil {
+			return count, fmt.Errorf("failed to get Athena inventory query results: %w", err)
+		}
+
+		if out.ResultSet != nil {
+			for i, row := range out.ResultSet.Rows {
+				if skipHeader && i == 0 {
+					continue
+				}
+				key := athenaRowValue(row, 0)
+				if key == "" {
+					continue
+				}
+				modified, err := parseAthenaInventoryTime(athenaRowValue(row, 1))
+				if err != nil {
+					return count, fmt.Errorf("failed to parse Athena inventory modified timestamp for key %q: %w", key, err)
+				}
+				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(modified, opts) {
+					select {
+					case fileChan <- blobstoreFile{key: key, lastModified: modified}:
+						count++
+					case <-ctx.Done():
+						return count, ctx.Err()
+					}
+				}
+			}
+		}
+
+		skipHeader = false
+		if out.NextToken == nil || *out.NextToken == "" {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	return count, nil
+}
+
 func (s *BlobstoreSource) fileMetadata(opts source.ReadOptions, bucket, key string, lastModified *time.Time) blobstoreFileMetadata {
 	if !handlesBlobstoreModifiedIncrementality(s.provider) || !usesBlobstoreModifiedIncrementality(opts) {
 		return blobstoreFileMetadata{}
@@ -676,6 +861,112 @@ func isExcludedColumn(name string, excludeColumns []string) bool {
 		}
 	}
 	return false
+}
+
+func buildS3InventoryQuery(parsed *parsedBlobstoreURI, bucket, prefix string, opts source.ReadOptions) (query, database string, err error) {
+	database, table, err := parseAthenaTableRef(parsed.athenaInventoryTable)
+	if err != nil {
+		return "", "", err
+	}
+
+	keyColumn := quoteAthenaIdent(parsed.athenaInventoryKeyColumn)
+	modifiedColumn := quoteAthenaIdent(parsed.athenaInventoryModifiedColumn)
+	query = fmt.Sprintf(
+		"SELECT %s, %s FROM %s",
+		keyColumn,
+		modifiedColumn,
+		quoteAthenaTableRef(database, table),
+	)
+
+	conditions := []string{
+		fmt.Sprintf("%s = '%s'", quoteAthenaIdent(parsed.athenaInventoryBucketColumn), escapeAthenaString(bucket)),
+	}
+	if prefix != "" {
+		conditions = append(conditions, fmt.Sprintf(
+			"substr(%s, 1, %d) = '%s'",
+			keyColumn,
+			len([]rune(prefix)),
+			escapeAthenaString(prefix),
+		))
+	}
+	if usesBlobstoreModifiedIncrementality(opts) {
+		if opts.IntervalStart != nil {
+			conditions = append(conditions, fmt.Sprintf(
+				"%s >= timestamp '%s'",
+				modifiedColumn,
+				formatAthenaTimestamp(*opts.IntervalStart),
+			))
+		}
+		if opts.IntervalEnd != nil {
+			conditions = append(conditions, fmt.Sprintf(
+				"%s <= timestamp '%s'",
+				modifiedColumn,
+				formatAthenaTimestamp(*opts.IntervalEnd),
+			))
+		}
+	}
+
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	return query, database, nil
+}
+
+func athenaRowValue(row athenatypes.Row, index int) string {
+	if index < 0 || index >= len(row.Data) || row.Data[index].VarCharValue == nil {
+		return ""
+	}
+	return *row.Data[index].VarCharValue
+}
+
+func parseAthenaInventoryTime(value string) (*time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+
+	formats := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05.999",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	var lastErr error
+	for _, format := range formats {
+		t, err := time.ParseInLocation(format, value, time.UTC)
+		if err == nil {
+			utc := t.UTC()
+			return &utc, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func parseAthenaTableRef(tableRef string) (database, table string, err error) {
+	parts := strings.Split(tableRef, ".")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("athena_inventory_table must be qualified as <database>.<table>")
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+func quoteAthenaTableRef(database, table string) string {
+	return quoteAthenaIdent(database) + "." + quoteAthenaIdent(table)
+}
+
+func quoteAthenaIdent(ident string) string {
+	return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
+}
+
+func escapeAthenaString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+func formatAthenaTimestamp(t time.Time) string {
+	return t.UTC().Format("2006-01-02 15:04:05")
 }
 
 func (s *BlobstoreSource) downloadFile(ctx context.Context, bucket, key string) ([]byte, error) {
@@ -1045,22 +1336,30 @@ func parseCSVValue(s string) interface{} {
 }
 
 type parsedBlobstoreURI struct {
-	provider          Provider
-	accessKeyID       string
-	secretAccessKey   string
-	region            string
-	endpointURL       string
-	credentialsFile   string
-	accountName       string
-	accountKey        string
-	sasToken          string
-	clientCredentials adlsutil.ClientCredentials
-	sftpHost          string
-	sftpPort          string
-	sftpUsername      string
-	sftpPassword      string
-	sftpKeyFile       string
-	sftpKeyPassphrase string
+	provider                      Provider
+	accessKeyID                   string
+	secretAccessKey               string
+	region                        string
+	endpointURL                   string
+	s3FileDiscovery               s3FileDiscovery
+	athenaInventoryTable          string
+	athenaInventoryBucketColumn   string
+	athenaInventoryKeyColumn      string
+	athenaInventoryModifiedColumn string
+	athenaResultsLocation         string
+	athenaWorkgroup               string
+	athenaRegion                  string
+	credentialsFile               string
+	accountName                   string
+	accountKey                    string
+	sasToken                      string
+	clientCredentials             adlsutil.ClientCredentials
+	sftpHost                      string
+	sftpPort                      string
+	sftpUsername                  string
+	sftpPassword                  string
+	sftpKeyFile                   string
+	sftpKeyPassphrase             string
 }
 
 func parseBlobstoreURI(uri string) (*parsedBlobstoreURI, error) {
@@ -1074,10 +1373,9 @@ func parseBlobstoreURI(uri string) (*parsedBlobstoreURI, error) {
 	switch u.Scheme {
 	case "s3":
 		parsed.provider = ProviderS3
-		parsed.accessKeyID = u.Query().Get("access_key_id")
-		parsed.secretAccessKey = u.Query().Get("secret_access_key")
-		parsed.region = u.Query().Get("region")
-		parsed.endpointURL = u.Query().Get("endpoint_url")
+		if err := parseS3BlobstoreURIOptions(u, parsed); err != nil {
+			return nil, err
+		}
 	case "gs", "gcs":
 		parsed.provider = ProviderGCS
 		parsed.credentialsFile = u.Query().Get("credentials_file")
@@ -1109,6 +1407,74 @@ func parseBlobstoreURI(uri string) (*parsedBlobstoreURI, error) {
 	}
 
 	return parsed, nil
+}
+
+func parseS3BlobstoreURIOptions(u *url.URL, parsed *parsedBlobstoreURI) error {
+	q := u.Query()
+	parsed.accessKeyID = q.Get("access_key_id")
+	parsed.secretAccessKey = q.Get("secret_access_key")
+	parsed.region = q.Get("region")
+	parsed.endpointURL = q.Get("endpoint_url")
+
+	discovery := strings.TrimSpace(q.Get("file_discovery"))
+	switch discovery {
+	case "", string(s3FileDiscoveryList), "s3_list", "list_objects":
+		parsed.s3FileDiscovery = s3FileDiscoveryList
+	case string(s3FileDiscoveryAthenaInventory):
+		parsed.s3FileDiscovery = s3FileDiscoveryAthenaInventory
+	default:
+		return fmt.Errorf("unsupported S3 file_discovery %q; supported values are %q and %q", discovery, s3FileDiscoveryList, s3FileDiscoveryAthenaInventory)
+	}
+
+	parsed.athenaInventoryTable = strings.TrimSpace(q.Get("athena_inventory_table"))
+	parsed.athenaInventoryBucketColumn = strings.TrimSpace(q.Get("athena_inventory_bucket_column"))
+	if parsed.athenaInventoryBucketColumn == "" {
+		parsed.athenaInventoryBucketColumn = "bucket"
+	}
+	parsed.athenaInventoryKeyColumn = strings.TrimSpace(q.Get("athena_inventory_key_column"))
+	if parsed.athenaInventoryKeyColumn == "" {
+		parsed.athenaInventoryKeyColumn = "key"
+	}
+	parsed.athenaInventoryModifiedColumn = strings.TrimSpace(q.Get("athena_inventory_modified_column"))
+	if parsed.athenaInventoryModifiedColumn == "" {
+		parsed.athenaInventoryModifiedColumn = "last_modified_date"
+	}
+	parsed.athenaWorkgroup = strings.TrimSpace(q.Get("athena_workgroup"))
+	parsed.athenaRegion = strings.TrimSpace(q.Get("athena_region"))
+	parsed.athenaResultsLocation = strings.TrimSpace(q.Get("athena_results_location"))
+
+	if parsed.s3FileDiscovery != s3FileDiscoveryAthenaInventory {
+		return nil
+	}
+	if parsed.athenaInventoryTable == "" {
+		return fmt.Errorf("athena_inventory_table is required when file_discovery=%s", s3FileDiscoveryAthenaInventory)
+	}
+	resultsLocation, err := normalizeS3Location(parsed.athenaResultsLocation, "athena_results_location")
+	if err != nil {
+		return err
+	}
+	parsed.athenaResultsLocation = resultsLocation
+	if _, _, err := parseAthenaTableRef(parsed.athenaInventoryTable); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizeS3Location(value, field string) (string, error) {
+	s := strings.TrimSpace(value)
+	if s == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	s = strings.TrimPrefix(s, "s3://")
+	s = strings.TrimLeft(s, "/")
+	if s == "" {
+		return "", fmt.Errorf("invalid %s %q", field, value)
+	}
+	out := "s3://" + s
+	if !strings.HasSuffix(out, "/") {
+		out += "/"
+	}
+	return out, nil
 }
 
 func buildAzureDatalakeFilesystemURL(accountName, fileSystem string) string {

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -19,6 +19,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/filesystem"
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet/file"
@@ -49,7 +50,9 @@ const (
 	ProviderAzureDatalake Provider = "adls"
 	ProviderSFTP          Provider = "sftp"
 
-	defaultParallelism = 5
+	defaultParallelism               = 5
+	defaultBlobstoreFilePathColumn   = "_ingestr_source_file_path"
+	defaultBlobstoreModifiedAtColumn = "_ingestr_source_file_modified_at"
 )
 
 type FileFormat string
@@ -69,6 +72,18 @@ type BlobstoreSource struct {
 	sftpClient *sftp.Client
 	sshClient  *ssh.Client
 	parsedURI  *parsedBlobstoreURI
+}
+
+type blobstoreFile struct {
+	key          string
+	lastModified *time.Time
+}
+
+type blobstoreFileMetadata struct {
+	incrementalKey string
+	lastModified   *time.Time
+	filepathColumn string
+	filepath       string
 }
 
 func NewBlobstoreSource() *BlobstoreSource {
@@ -281,6 +296,9 @@ func (s *BlobstoreSource) Close(ctx context.Context) error {
 }
 
 func (s *BlobstoreSource) HandlesIncrementality() bool {
+	// Blobstore still supports user-defined row-level incremental keys from file
+	// data. Object modified filtering is a reserved-key read mode, not a global
+	// source-managed incrementality contract.
 	return false
 }
 
@@ -334,7 +352,7 @@ func (s *BlobstoreSource) read(ctx context.Context, table string, opts source.Re
 	config.Debug("[BLOBSTORE-SRC] Starting with parallelism %d", parallelism)
 
 	results := make(chan source.RecordBatchResult, parallelism*2)
-	fileChan := make(chan string, parallelism*2)
+	fileChan := make(chan blobstoreFile, parallelism*2)
 
 	var wg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {
@@ -357,11 +375,15 @@ func (s *BlobstoreSource) read(ctx context.Context, table string, opts source.Re
 	go func() {
 		defer wg.Done()
 		defer close(fileChan)
-		count, err := s.listMatchingFiles(ctx, bucket, pattern, fileChan)
+		count, err := s.listMatchingFiles(ctx, bucket, pattern, opts, fileChan)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to list files: %w", err)}
 		} else if count == 0 {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("no files found matching pattern: %s/%s", bucket, pattern)}
+			if handlesBlobstoreModifiedIncrementality(s.provider) && usesBlobstoreModifiedIncrementality(opts) && hasModifiedInterval(opts) {
+				config.Debug("[BLOBSTORE-SRC] No files found matching pattern=%s/%s and modified interval", bucket, pattern)
+			} else {
+				results <- source.RecordBatchResult{Err: fmt.Errorf("no files found matching pattern: %s/%s", bucket, pattern)}
+			}
 		} else {
 			config.Debug("[BLOBSTORE-SRC] Found %d matching files", count)
 		}
@@ -377,8 +399,9 @@ func (s *BlobstoreSource) read(ctx context.Context, table string, opts source.Re
 	return results, nil
 }
 
-func (s *BlobstoreSource) processFile(ctx context.Context, bucket, fileKey string, formatHint FileFormat, tableEncoding string, batchSize int, opts source.ReadOptions, results chan<- source.RecordBatchResult) {
+func (s *BlobstoreSource) processFile(ctx context.Context, bucket string, file blobstoreFile, formatHint FileFormat, tableEncoding string, batchSize int, opts source.ReadOptions, results chan<- source.RecordBatchResult) {
 	startFile := time.Now()
+	fileKey := file.key
 	format := detectFileFormat(fileKey, formatHint)
 	if format == FormatUnknown {
 		config.Debug("[BLOBSTORE-SRC] Skipping file with unknown format: %s", fileKey)
@@ -416,14 +439,15 @@ func (s *BlobstoreSource) processFile(ctx context.Context, bucket, fileKey strin
 
 	var totalRows int64
 	var batchNum int
+	metadata := s.fileMetadata(opts, bucket, file.key, file.lastModified)
 
 	switch format {
 	case FormatParquet:
-		err = s.readParquetFile(ctx, data, results, &totalRows, &batchNum, opts)
+		err = s.readParquetFile(ctx, data, results, &totalRows, &batchNum, opts, metadata)
 	case FormatJSONL:
-		err = s.readJSONLFile(ctx, dataReader, results, &totalRows, &batchNum, batchSize, opts)
+		err = s.readJSONLFile(ctx, dataReader, results, &totalRows, &batchNum, batchSize, opts, metadata)
 	case FormatCSV:
-		err = s.readCSVFile(ctx, dataReader, tableEncoding, results, &totalRows, &batchNum, batchSize, opts)
+		err = s.readCSVFile(ctx, dataReader, tableEncoding, results, &totalRows, &batchNum, batchSize, opts, metadata)
 	}
 
 	if err != nil {
@@ -433,7 +457,7 @@ func (s *BlobstoreSource) processFile(ctx context.Context, bucket, fileKey strin
 	config.Debug("[BLOBSTORE-SRC] File %s: %d rows in %d batches, read time: %v", fileKey, totalRows, batchNum, time.Since(startFile))
 }
 
-func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern string, fileChan chan<- string) (int, error) {
+func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern string, opts source.ReadOptions, fileChan chan<- blobstoreFile) (int, error) {
 	count := 0
 	prefix := extractPrefix(pattern)
 
@@ -452,9 +476,9 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 
 			for _, obj := range page.Contents {
 				key := aws.ToString(obj.Key)
-				if matchesGlobPattern(key, pattern) {
+				if matchesGlobPattern(key, pattern) && objectMatchesIncrementalOptions(obj.LastModified, opts) {
 					select {
-					case fileChan <- key:
+					case fileChan <- blobstoreFile{key: key, lastModified: copyTimePtr(obj.LastModified)}:
 						count++
 					case <-ctx.Done():
 						return count, ctx.Err()
@@ -474,9 +498,10 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 				return count, fmt.Errorf("failed to list GCS objects: %w", err)
 			}
 
-			if matchesGlobPattern(attrs.Name, pattern) {
+			updated := attrs.Updated
+			if matchesGlobPattern(attrs.Name, pattern) && objectMatchesIncrementalOptions(&updated, opts) {
 				select {
-				case fileChan <- attrs.Name:
+				case fileChan <- blobstoreFile{key: attrs.Name, lastModified: copyTimePtr(&updated)}:
 					count++
 				case <-ctx.Done():
 					return count, ctx.Err()
@@ -519,7 +544,7 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 				key := *item.Name
 				if matchesGlobPattern(key, pattern) {
 					select {
-					case fileChan <- key:
+					case fileChan <- blobstoreFile{key: key}:
 						count++
 					case <-ctx.Done():
 						return count, ctx.Err()
@@ -549,7 +574,7 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 			relPath := strings.TrimPrefix(walker.Path(), "/")
 			if matchesGlobPattern(relPath, pattern) {
 				select {
-				case fileChan <- walker.Path():
+				case fileChan <- blobstoreFile{key: walker.Path()}:
 					count++
 				case <-ctx.Done():
 					return count, ctx.Err()
@@ -559,6 +584,98 @@ func (s *BlobstoreSource) listMatchingFiles(ctx context.Context, bucket, pattern
 	}
 
 	return count, nil
+}
+
+func (s *BlobstoreSource) fileMetadata(opts source.ReadOptions, bucket, key string, lastModified *time.Time) blobstoreFileMetadata {
+	if !handlesBlobstoreModifiedIncrementality(s.provider) || !usesBlobstoreModifiedIncrementality(opts) {
+		return blobstoreFileMetadata{}
+	}
+
+	metadata := blobstoreFileMetadata{}
+	if lastModified != nil && !lastModified.IsZero() && !isExcludedColumn(defaultBlobstoreModifiedAtColumn, opts.ExcludeColumns) {
+		t := lastModified.UTC()
+		metadata.incrementalKey = defaultBlobstoreModifiedAtColumn
+		metadata.lastModified = &t
+	}
+
+	if key != "" && !isExcludedColumn(defaultBlobstoreFilePathColumn, opts.ExcludeColumns) {
+		metadata.filepathColumn = defaultBlobstoreFilePathColumn
+		metadata.filepath = s.filepath(bucket, key)
+	}
+
+	return metadata
+}
+
+func handlesBlobstoreModifiedIncrementality(provider Provider) bool {
+	return provider == ProviderS3 || provider == ProviderGCS
+}
+
+func usesBlobstoreModifiedIncrementality(opts source.ReadOptions) bool {
+	return strings.EqualFold(opts.IncrementalKey, defaultBlobstoreModifiedAtColumn)
+}
+
+func hasModifiedInterval(opts source.ReadOptions) bool {
+	return opts.IntervalStart != nil || opts.IntervalEnd != nil
+}
+
+func objectMatchesIncrementalOptions(lastModified *time.Time, opts source.ReadOptions) bool {
+	if !usesBlobstoreModifiedIncrementality(opts) {
+		return true
+	}
+	return objectModifiedInInterval(lastModified, opts.IntervalStart, opts.IntervalEnd)
+}
+
+func objectModifiedInInterval(lastModified, intervalStart, intervalEnd *time.Time) bool {
+	if intervalStart == nil && intervalEnd == nil {
+		return true
+	}
+	if lastModified == nil || lastModified.IsZero() {
+		return false
+	}
+
+	modified := lastModified.UTC()
+	if intervalStart != nil {
+		start := intervalStart.UTC()
+		if modified.Before(start) {
+			return false
+		}
+	}
+	if intervalEnd != nil {
+		end := intervalEnd.UTC()
+		if modified.After(end) {
+			return false
+		}
+	}
+	return true
+}
+
+func copyTimePtr(t *time.Time) *time.Time {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	copied := t.UTC()
+	return &copied
+}
+
+func (s *BlobstoreSource) filepath(bucket, key string) string {
+	if bucket == "" {
+		return key
+	}
+
+	scheme := string(s.provider)
+	if s.provider == ProviderGCS {
+		scheme = "gs"
+	}
+	return scheme + "://" + strings.TrimRight(bucket, "/") + "/" + strings.TrimLeft(key, "/")
+}
+
+func isExcludedColumn(name string, excludeColumns []string) bool {
+	for _, excluded := range excludeColumns {
+		if strings.EqualFold(name, excluded) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *BlobstoreSource) downloadFile(ctx context.Context, bucket, key string) ([]byte, error) {
@@ -612,7 +729,7 @@ func (s *BlobstoreSource) downloadFile(ctx context.Context, bucket, key string) 
 	return nil, fmt.Errorf("unsupported provider: %s", s.provider)
 }
 
-func (s *BlobstoreSource) readParquetFile(ctx context.Context, data []byte, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, opts source.ReadOptions) error {
+func (s *BlobstoreSource) readParquetFile(ctx context.Context, data []byte, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, opts source.ReadOptions, metadata blobstoreFileMetadata) error {
 	reader := bytes.NewReader(data)
 	pr, err := file.NewParquetReader(reader)
 	if err != nil {
@@ -647,7 +764,9 @@ func (s *BlobstoreSource) readParquetFile(ctx context.Context, data []byte, resu
 		*totalRows += rows
 		config.Debug("[BLOBSTORE-SRC] Parquet batch %d: %d rows (total: %d)", *batchNum, rows, *totalRows)
 
-		results <- source.RecordBatchResult{Batch: rec}
+		if err := sendRecordBatchWithMetadata(results, rec, metadata); err != nil {
+			return err
+		}
 
 		if opts.Limit > 0 && *totalRows >= int64(opts.Limit) {
 			break
@@ -657,7 +776,7 @@ func (s *BlobstoreSource) readParquetFile(ctx context.Context, data []byte, resu
 	return tr.Err()
 }
 
-func (s *BlobstoreSource) readJSONLFile(ctx context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
+func (s *BlobstoreSource) readJSONLFile(ctx context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions, metadata blobstoreFileMetadata) error {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
 
@@ -689,7 +808,9 @@ func (s *BlobstoreSource) readJSONLFile(ctx context.Context, reader io.Reader, r
 			*totalRows += int64(len(items))
 			config.Debug("[BLOBSTORE-SRC] JSONL batch %d: %d items (total: %d)", *batchNum, len(items), *totalRows)
 
-			results <- source.RecordBatchResult{Batch: record}
+			if err := sendRecordBatchWithMetadata(results, record, metadata); err != nil {
+				return err
+			}
 			items = make([]map[string]interface{}, 0, batchSize)
 
 			if opts.Limit > 0 && *totalRows >= int64(opts.Limit) {
@@ -712,13 +833,15 @@ func (s *BlobstoreSource) readJSONLFile(ctx context.Context, reader io.Reader, r
 		*totalRows += int64(len(items))
 		config.Debug("[BLOBSTORE-SRC] JSONL batch %d: %d items (total: %d)", *batchNum, len(items), *totalRows)
 
-		results <- source.RecordBatchResult{Batch: record}
+		if err := sendRecordBatchWithMetadata(results, record, metadata); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (s *BlobstoreSource) readCSVFile(ctx context.Context, reader io.Reader, tableEncoding string, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
+func (s *BlobstoreSource) readCSVFile(ctx context.Context, reader io.Reader, tableEncoding string, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions, metadata blobstoreFileMetadata) error {
 	decoded, err := csvsource.Decode(reader, tableEncoding)
 	if err != nil {
 		return fmt.Errorf("failed to set up CSV decoder: %w", err)
@@ -762,7 +885,9 @@ func (s *BlobstoreSource) readCSVFile(ctx context.Context, reader io.Reader, tab
 			*totalRows += int64(len(rows))
 			config.Debug("[BLOBSTORE-SRC] CSV batch %d: %d rows (total: %d)", *batchNum, len(rows), *totalRows)
 
-			results <- source.RecordBatchResult{Batch: rec}
+			if err := sendRecordBatchWithMetadata(results, rec, metadata); err != nil {
+				return err
+			}
 			rows = make([]map[string]interface{}, 0, batchSize)
 
 			if opts.Limit > 0 && *totalRows >= int64(opts.Limit) {
@@ -781,10 +906,113 @@ func (s *BlobstoreSource) readCSVFile(ctx context.Context, reader io.Reader, tab
 		*totalRows += int64(len(rows))
 		config.Debug("[BLOBSTORE-SRC] CSV batch %d: %d rows (total: %d)", *batchNum, len(rows), *totalRows)
 
-		results <- source.RecordBatchResult{Batch: rec}
+		if err := sendRecordBatchWithMetadata(results, rec, metadata); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func sendRecordBatchWithMetadata(results chan<- source.RecordBatchResult, record arrow.RecordBatch, metadata blobstoreFileMetadata) error {
+	out, added, err := addBlobstoreMetadataColumns(record, metadata)
+	if err != nil {
+		record.Release()
+		return err
+	}
+	if added {
+		record.Release()
+	}
+	results <- source.RecordBatchResult{Batch: out}
+	return nil
+}
+
+func addBlobstoreMetadataColumns(record arrow.RecordBatch, metadata blobstoreFileMetadata) (arrow.RecordBatch, bool, error) {
+	if record == nil {
+		return record, false, nil
+	}
+
+	addLastModified := metadata.incrementalKey != "" && metadata.lastModified != nil
+	addFilepath := metadata.filepathColumn != "" && metadata.filepath != ""
+	if !addLastModified && !addFilepath {
+		return record, false, nil
+	}
+	if addLastModified && addFilepath && strings.EqualFold(metadata.incrementalKey, metadata.filepathColumn) {
+		return nil, false, fmt.Errorf("blobstore metadata columns conflict on %q; choose a different --incremental-key", metadata.incrementalKey)
+	}
+
+	for _, name := range []string{metadata.incrementalKey, metadata.filepathColumn} {
+		if name == "" {
+			continue
+		}
+		if recordHasColumn(record, name) {
+			return nil, false, fmt.Errorf("blobstore metadata column %q already exists in file data; choose a different --incremental-key or exclude the column", name)
+		}
+	}
+
+	addedCols := 0
+	if addLastModified {
+		addedCols++
+	}
+	if addFilepath {
+		addedCols++
+	}
+
+	fields := make([]arrow.Field, int(record.NumCols())+addedCols)
+	columns := make([]arrow.Array, int(record.NumCols())+addedCols)
+	for i := 0; i < int(record.NumCols()); i++ {
+		fields[i] = record.Schema().Field(i)
+		columns[i] = record.Column(i)
+		columns[i].Retain()
+	}
+
+	nextCol := int(record.NumCols())
+	if addLastModified {
+		timestampType := &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
+		fields[nextCol] = arrow.Field{
+			Name:     metadata.incrementalKey,
+			Type:     timestampType,
+			Nullable: false,
+		}
+
+		builder := array.NewTimestampBuilder(memory.DefaultAllocator, timestampType)
+		for i := int64(0); i < record.NumRows(); i++ {
+			builder.Append(arrow.Timestamp(metadata.lastModified.UTC().UnixMicro()))
+		}
+		columns[nextCol] = builder.NewArray()
+		builder.Release()
+		nextCol++
+	}
+
+	if addFilepath {
+		fields[nextCol] = arrow.Field{
+			Name:     metadata.filepathColumn,
+			Type:     arrow.BinaryTypes.String,
+			Nullable: false,
+		}
+
+		builder := array.NewStringBuilder(memory.DefaultAllocator)
+		for i := int64(0); i < record.NumRows(); i++ {
+			builder.Append(metadata.filepath)
+		}
+		columns[nextCol] = builder.NewArray()
+		builder.Release()
+	}
+
+	newRecord := array.NewRecordBatch(arrow.NewSchema(fields, nil), columns, record.NumRows())
+	for _, col := range columns {
+		col.Release()
+	}
+	return newRecord, true, nil
+}
+
+func recordHasColumn(record arrow.RecordBatch, name string) bool {
+	for _, field := range record.Schema().Fields() {
+		if strings.EqualFold(field.Name, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseCSVValue(s string) interface{} {

--- a/pkg/source/blobstore/blobstore_test.go
+++ b/pkg/source/blobstore/blobstore_test.go
@@ -607,9 +607,16 @@ func TestGetTableBlobstoreIncrementalKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, defaultBlobstoreModifiedAtColumn, table.IncrementalKey())
+
+	table, err = s.GetTable(context.Background(), source.TableRequest{
+		Name:           "bucket/test.csv",
+		IncrementalKey: defaultBlobstoreCreatedAtColumn,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, defaultBlobstoreCreatedAtColumn, table.IncrementalKey())
 }
 
-func TestObjectModifiedInInterval(t *testing.T) {
+func TestObjectTimestampInInterval(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	mid := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
@@ -618,30 +625,35 @@ func TestObjectModifiedInInterval(t *testing.T) {
 	after := end.Add(time.Second)
 	zero := time.Time{}
 
-	assert.True(t, objectModifiedInInterval(&mid, nil, nil))
-	assert.True(t, objectModifiedInInterval(&start, &start, &end), "start bound is inclusive")
-	assert.True(t, objectModifiedInInterval(&justBeforeEnd, &start, &end), "values before end bound are included")
-	assert.False(t, objectModifiedInInterval(&end, &start, &end), "end bound is exclusive")
-	assert.False(t, objectModifiedInInterval(&before, &start, &end))
-	assert.False(t, objectModifiedInInterval(&after, &start, &end))
-	assert.False(t, objectModifiedInInterval(nil, &start, &end))
-	assert.False(t, objectModifiedInInterval(&zero, &start, &end))
+	assert.True(t, objectTimestampInInterval(&mid, nil, nil))
+	assert.True(t, objectTimestampInInterval(&start, &start, &end), "start bound is inclusive")
+	assert.True(t, objectTimestampInInterval(&justBeforeEnd, &start, &end), "values before end bound are included")
+	assert.False(t, objectTimestampInInterval(&end, &start, &end), "end bound is exclusive")
+	assert.False(t, objectTimestampInInterval(&before, &start, &end))
+	assert.False(t, objectTimestampInInterval(&after, &start, &end))
+	assert.False(t, objectTimestampInInterval(nil, &start, &end))
+	assert.False(t, objectTimestampInInterval(&zero, &start, &end))
 }
 
 func TestObjectMatchesIncrementalOptionsRequiresReservedKey(t *testing.T) {
 	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	before := start.Add(-time.Hour)
+	after := start.Add(time.Hour)
 
-	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, source.ReadOptions{IntervalStart: &start}))
-	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, source.ReadOptions{
+	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, &before, source.ReadOptions{IntervalStart: &start}))
+	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, &before, source.ReadOptions{
 		IncrementalKey: "updated_at",
 		IntervalStart:  &start,
 	}))
-	assert.False(t, objectMatchesIncrementalOptions(ProviderS3, &before, source.ReadOptions{
+	assert.False(t, objectMatchesIncrementalOptions(ProviderS3, &before, &after, source.ReadOptions{
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
 		IntervalStart:  &start,
 	}))
-	assert.True(t, objectMatchesIncrementalOptions(ProviderSFTP, &before, source.ReadOptions{
+	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, &after, source.ReadOptions{
+		IncrementalKey: defaultBlobstoreCreatedAtColumn,
+		IntervalStart:  &start,
+	}))
+	assert.True(t, objectMatchesIncrementalOptions(ProviderSFTP, &before, &before, source.ReadOptions{
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
 		IntervalStart:  &start,
 	}))
@@ -659,6 +671,15 @@ func TestBuildS3InventoryQuery(t *testing.T) {
 
 	query, database, err := buildS3InventoryQuery(parsed, "my-bucket", "logs/", source.ReadOptions{
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		IntervalStart:  &start,
+		IntervalEnd:    &end,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inventory_db", database)
+	assert.Equal(t, `SELECT "key", "last_modified_date" FROM "inventory_db"."inventory_table" WHERE "bucket" = 'my-bucket' AND substr("key", 1, 5) = 'logs/' AND "last_modified_date" >= timestamp '2026-01-02 01:04:05' AND "last_modified_date" < timestamp '2026-01-03 04:05:06'`, query)
+
+	query, database, err = buildS3InventoryQuery(parsed, "my-bucket", "logs/", source.ReadOptions{
+		IncrementalKey: defaultBlobstoreCreatedAtColumn,
 		IntervalStart:  &start,
 		IntervalEnd:    &end,
 	})
@@ -756,61 +777,87 @@ func TestStreamS3InventoryQueryResultsFiltersRows(t *testing.T) {
 	require.Equal(t, 1, count)
 	file := <-files
 	assert.Equal(t, "logs/2026/keep.jsonl", file.key)
-	require.NotNil(t, file.lastModified)
-	assert.Equal(t, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), *file.lastModified)
+	require.NotNil(t, file.modifiedAt)
+	require.NotNil(t, file.createdAt)
+	assert.Equal(t, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), *file.modifiedAt)
+	assert.Equal(t, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), *file.createdAt)
 }
 
 func TestBlobstoreFileMetadata(t *testing.T) {
 	modified := time.Date(2026, 1, 2, 3, 4, 5, 0, time.FixedZone("UTC+2", 2*60*60))
+	created := time.Date(2026, 1, 1, 3, 4, 5, 0, time.FixedZone("UTC+2", 2*60*60))
 	s := NewBlobstoreSource()
 	s.provider = ProviderS3
 
-	metadata := s.fileMetadata(source.ReadOptions{}, "bucket", "data/file.csv", &modified)
+	metadata := s.fileMetadata(source.ReadOptions{}, "bucket", "data/file.csv", &modified, &created)
 	assert.Empty(t, metadata.incrementalKey)
-	assert.Nil(t, metadata.lastModified)
+	assert.Nil(t, metadata.incrementalAt)
 	assert.Empty(t, metadata.filepathColumn)
 	assert.Empty(t, metadata.filepath)
 
-	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "bucket", "data/file.csv", &modified)
-	require.NotNil(t, metadata.lastModified)
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "bucket", "data/file.csv", &modified, &created)
+	require.NotNil(t, metadata.incrementalAt)
 	assert.Equal(t, defaultBlobstoreModifiedAtColumn, metadata.incrementalKey)
-	assert.Equal(t, time.UTC, metadata.lastModified.Location())
+	assert.Equal(t, time.UTC, metadata.incrementalAt.Location())
+	assert.Equal(t, modified.UTC(), *metadata.incrementalAt)
+	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
+	assert.Equal(t, "s3://bucket/data/file.csv", metadata.filepath)
+
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreCreatedAtColumn}, "bucket", "data/file.csv", &modified, &created)
+	require.NotNil(t, metadata.incrementalAt)
+	assert.Equal(t, defaultBlobstoreCreatedAtColumn, metadata.incrementalKey)
+	assert.Equal(t, created.UTC(), *metadata.incrementalAt)
 	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
 	assert.Equal(t, "s3://bucket/data/file.csv", metadata.filepath)
 
 	s.provider = ProviderGCS
-	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "bucket", "data/file.csv", &modified)
-	require.NotNil(t, metadata.lastModified)
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "bucket", "data/file.csv", &modified, &created)
+	require.NotNil(t, metadata.incrementalAt)
 	assert.Equal(t, defaultBlobstoreModifiedAtColumn, metadata.incrementalKey)
 	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
 	assert.Equal(t, "gs://bucket/data/file.csv", metadata.filepath)
 
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreCreatedAtColumn}, "bucket", "data/file.csv", &modified, &created)
+	require.NotNil(t, metadata.incrementalAt)
+	assert.Equal(t, defaultBlobstoreCreatedAtColumn, metadata.incrementalKey)
+	assert.Equal(t, created.UTC(), *metadata.incrementalAt)
+	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
+	assert.Equal(t, "gs://bucket/data/file.csv", metadata.filepath)
+
 	s.provider = ProviderS3
-	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: "modified_at"}, "bucket", "data/file.csv", &modified)
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: "modified_at"}, "bucket", "data/file.csv", &modified, &created)
 	assert.Empty(t, metadata.incrementalKey)
-	assert.Nil(t, metadata.lastModified)
+	assert.Nil(t, metadata.incrementalAt)
 	assert.Empty(t, metadata.filepathColumn)
 	assert.Empty(t, metadata.filepath)
 
 	metadata = s.fileMetadata(source.ReadOptions{
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
 		ExcludeColumns: []string{"_INGESTR_SOURCE_FILE_MODIFIED_AT"},
-	}, "bucket", "data/file.csv", &modified)
+	}, "bucket", "data/file.csv", &modified, &created)
 	assert.Empty(t, metadata.incrementalKey)
-	assert.Nil(t, metadata.lastModified)
+	assert.Nil(t, metadata.incrementalAt)
+	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
+
+	metadata = s.fileMetadata(source.ReadOptions{
+		IncrementalKey: defaultBlobstoreCreatedAtColumn,
+		ExcludeColumns: []string{"_INGESTR_SOURCE_FILE_CREATED_AT"},
+	}, "bucket", "data/file.csv", &modified, &created)
+	assert.Empty(t, metadata.incrementalKey)
+	assert.Nil(t, metadata.incrementalAt)
 	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
 
 	metadata = s.fileMetadata(source.ReadOptions{
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
 		ExcludeColumns: []string{"_INGESTR_SOURCE_FILE_PATH"},
-	}, "bucket", "data/file.csv", &modified)
+	}, "bucket", "data/file.csv", &modified, &created)
 	assert.Empty(t, metadata.filepathColumn)
 	assert.Empty(t, metadata.filepath)
 
 	s.provider = ProviderSFTP
-	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "", "data/file.csv", &modified)
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "", "data/file.csv", &modified, &created)
 	assert.Empty(t, metadata.incrementalKey)
-	assert.Nil(t, metadata.lastModified)
+	assert.Nil(t, metadata.incrementalAt)
 	assert.Empty(t, metadata.filepathColumn)
 	assert.Empty(t, metadata.filepath)
 }
@@ -845,7 +892,7 @@ func TestAddBlobstoreMetadataColumns(t *testing.T) {
 	modified := time.Date(2026, 1, 2, 3, 4, 5, 123456000, time.UTC)
 	output, added, err := addBlobstoreMetadataColumns(input, blobstoreFileMetadata{
 		incrementalKey: defaultBlobstoreModifiedAtColumn,
-		lastModified:   &modified,
+		incrementalAt:  &modified,
 		filepathColumn: defaultBlobstoreFilePathColumn,
 		filepath:       "s3://bucket/data/file.csv",
 	})
@@ -886,7 +933,7 @@ func TestAddBlobstoreMetadataColumnsRejectsExistingColumn(t *testing.T) {
 	modified := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	output, added, err := addBlobstoreMetadataColumns(input, blobstoreFileMetadata{
 		incrementalKey: defaultBlobstoreModifiedAtColumn,
-		lastModified:   &modified,
+		incrementalAt:  &modified,
 	})
 	require.Error(t, err)
 	assert.Nil(t, output)
@@ -911,7 +958,7 @@ func TestAddBlobstoreMetadataColumnsRejectsMetadataColumnConflict(t *testing.T) 
 	modified := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	output, added, err := addBlobstoreMetadataColumns(input, blobstoreFileMetadata{
 		incrementalKey: defaultBlobstoreFilePathColumn,
-		lastModified:   &modified,
+		incrementalAt:  &modified,
 		filepathColumn: defaultBlobstoreFilePathColumn,
 		filepath:       "s3://bucket/data/file.csv",
 	})

--- a/pkg/source/blobstore/blobstore_test.go
+++ b/pkg/source/blobstore/blobstore_test.go
@@ -614,12 +614,14 @@ func TestObjectModifiedInInterval(t *testing.T) {
 	mid := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
 	before := start.Add(-time.Second)
+	justBeforeEnd := end.Add(-time.Nanosecond)
 	after := end.Add(time.Second)
 	zero := time.Time{}
 
 	assert.True(t, objectModifiedInInterval(&mid, nil, nil))
 	assert.True(t, objectModifiedInInterval(&start, &start, &end), "start bound is inclusive")
-	assert.True(t, objectModifiedInInterval(&end, &start, &end), "end bound is inclusive")
+	assert.True(t, objectModifiedInInterval(&justBeforeEnd, &start, &end), "values before end bound are included")
+	assert.False(t, objectModifiedInInterval(&end, &start, &end), "end bound is exclusive")
 	assert.False(t, objectModifiedInInterval(&before, &start, &end))
 	assert.False(t, objectModifiedInInterval(&after, &start, &end))
 	assert.False(t, objectModifiedInInterval(nil, &start, &end))
@@ -630,12 +632,16 @@ func TestObjectMatchesIncrementalOptionsRequiresReservedKey(t *testing.T) {
 	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	before := start.Add(-time.Hour)
 
-	assert.True(t, objectMatchesIncrementalOptions(&before, source.ReadOptions{IntervalStart: &start}))
-	assert.True(t, objectMatchesIncrementalOptions(&before, source.ReadOptions{
+	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, source.ReadOptions{IntervalStart: &start}))
+	assert.True(t, objectMatchesIncrementalOptions(ProviderS3, &before, source.ReadOptions{
 		IncrementalKey: "updated_at",
 		IntervalStart:  &start,
 	}))
-	assert.False(t, objectMatchesIncrementalOptions(&before, source.ReadOptions{
+	assert.False(t, objectMatchesIncrementalOptions(ProviderS3, &before, source.ReadOptions{
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		IntervalStart:  &start,
+	}))
+	assert.True(t, objectMatchesIncrementalOptions(ProviderSFTP, &before, source.ReadOptions{
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
 		IntervalStart:  &start,
 	}))
@@ -658,7 +664,7 @@ func TestBuildS3InventoryQuery(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "inventory_db", database)
-	assert.Equal(t, `SELECT "key", "last_modified_date" FROM "inventory_db"."inventory_table" WHERE "bucket" = 'my-bucket' AND substr("key", 1, 5) = 'logs/' AND "last_modified_date" >= timestamp '2026-01-02 01:04:05' AND "last_modified_date" <= timestamp '2026-01-03 04:05:06'`, query)
+	assert.Equal(t, `SELECT "key", "last_modified_date" FROM "inventory_db"."inventory_table" WHERE "bucket" = 'my-bucket' AND substr("key", 1, 5) = 'logs/' AND "last_modified_date" >= timestamp '2026-01-02 01:04:05' AND "last_modified_date" < timestamp '2026-01-03 04:05:06'`, query)
 }
 
 func TestBuildS3InventoryQueryWithoutModifiedIncrementality(t *testing.T) {
@@ -722,6 +728,7 @@ func TestParseAthenaInventoryTime(t *testing.T) {
 func TestStreamS3InventoryQueryResultsFiltersRows(t *testing.T) {
 	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	s := &BlobstoreSource{
+		provider: ProviderS3,
 		athenaClient: &fakeAthenaAPI{
 			results: []*athena.GetQueryResultsOutput{
 				{

--- a/pkg/source/blobstore/blobstore_test.go
+++ b/pkg/source/blobstore/blobstore_test.go
@@ -3,7 +3,11 @@ package blobstore
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/adlsutil"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -474,6 +478,229 @@ func TestGetTable(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, table)
 	assert.False(t, table.HasKnownSchema())
+}
+
+func TestHandlesIncrementality_BlobstoreUsesFrameworkKeyHandling(t *testing.T) {
+	s := NewBlobstoreSource()
+	assert.False(t, s.HandlesIncrementality())
+
+	s.provider = ProviderS3
+	assert.False(t, s.HandlesIncrementality())
+
+	s.provider = ProviderGCS
+	assert.False(t, s.HandlesIncrementality())
+
+	s.provider = ProviderSFTP
+	assert.False(t, s.HandlesIncrementality())
+}
+
+func TestGetTableBlobstoreIncrementalKey(t *testing.T) {
+	s := NewBlobstoreSource()
+	s.provider = ProviderS3
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "bucket/test.csv"})
+	require.NoError(t, err)
+	assert.Empty(t, table.IncrementalKey())
+
+	table, err = s.GetTable(context.Background(), source.TableRequest{
+		Name:           "bucket/test.csv",
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, defaultBlobstoreModifiedAtColumn, table.IncrementalKey())
+}
+
+func TestObjectModifiedInInterval(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mid := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+	before := start.Add(-time.Second)
+	after := end.Add(time.Second)
+	zero := time.Time{}
+
+	assert.True(t, objectModifiedInInterval(&mid, nil, nil))
+	assert.True(t, objectModifiedInInterval(&start, &start, &end), "start bound is inclusive")
+	assert.True(t, objectModifiedInInterval(&end, &start, &end), "end bound is inclusive")
+	assert.False(t, objectModifiedInInterval(&before, &start, &end))
+	assert.False(t, objectModifiedInInterval(&after, &start, &end))
+	assert.False(t, objectModifiedInInterval(nil, &start, &end))
+	assert.False(t, objectModifiedInInterval(&zero, &start, &end))
+}
+
+func TestObjectMatchesIncrementalOptionsRequiresReservedKey(t *testing.T) {
+	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	before := start.Add(-time.Hour)
+
+	assert.True(t, objectMatchesIncrementalOptions(&before, source.ReadOptions{IntervalStart: &start}))
+	assert.True(t, objectMatchesIncrementalOptions(&before, source.ReadOptions{
+		IncrementalKey: "updated_at",
+		IntervalStart:  &start,
+	}))
+	assert.False(t, objectMatchesIncrementalOptions(&before, source.ReadOptions{
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		IntervalStart:  &start,
+	}))
+}
+
+func TestBlobstoreFileMetadata(t *testing.T) {
+	modified := time.Date(2026, 1, 2, 3, 4, 5, 0, time.FixedZone("UTC+2", 2*60*60))
+	s := NewBlobstoreSource()
+	s.provider = ProviderS3
+
+	metadata := s.fileMetadata(source.ReadOptions{}, "bucket", "data/file.csv", &modified)
+	assert.Empty(t, metadata.incrementalKey)
+	assert.Nil(t, metadata.lastModified)
+	assert.Empty(t, metadata.filepathColumn)
+	assert.Empty(t, metadata.filepath)
+
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "bucket", "data/file.csv", &modified)
+	require.NotNil(t, metadata.lastModified)
+	assert.Equal(t, defaultBlobstoreModifiedAtColumn, metadata.incrementalKey)
+	assert.Equal(t, time.UTC, metadata.lastModified.Location())
+	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
+	assert.Equal(t, "s3://bucket/data/file.csv", metadata.filepath)
+
+	s.provider = ProviderGCS
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "bucket", "data/file.csv", &modified)
+	require.NotNil(t, metadata.lastModified)
+	assert.Equal(t, defaultBlobstoreModifiedAtColumn, metadata.incrementalKey)
+	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
+	assert.Equal(t, "gs://bucket/data/file.csv", metadata.filepath)
+
+	s.provider = ProviderS3
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: "modified_at"}, "bucket", "data/file.csv", &modified)
+	assert.Empty(t, metadata.incrementalKey)
+	assert.Nil(t, metadata.lastModified)
+	assert.Empty(t, metadata.filepathColumn)
+	assert.Empty(t, metadata.filepath)
+
+	metadata = s.fileMetadata(source.ReadOptions{
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		ExcludeColumns: []string{"_INGESTR_SOURCE_FILE_MODIFIED_AT"},
+	}, "bucket", "data/file.csv", &modified)
+	assert.Empty(t, metadata.incrementalKey)
+	assert.Nil(t, metadata.lastModified)
+	assert.Equal(t, defaultBlobstoreFilePathColumn, metadata.filepathColumn)
+
+	metadata = s.fileMetadata(source.ReadOptions{
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		ExcludeColumns: []string{"_INGESTR_SOURCE_FILE_PATH"},
+	}, "bucket", "data/file.csv", &modified)
+	assert.Empty(t, metadata.filepathColumn)
+	assert.Empty(t, metadata.filepath)
+
+	s.provider = ProviderSFTP
+	metadata = s.fileMetadata(source.ReadOptions{IncrementalKey: defaultBlobstoreModifiedAtColumn}, "", "data/file.csv", &modified)
+	assert.Empty(t, metadata.incrementalKey)
+	assert.Nil(t, metadata.lastModified)
+	assert.Empty(t, metadata.filepathColumn)
+	assert.Empty(t, metadata.filepath)
+}
+
+func TestBlobstoreFilepath(t *testing.T) {
+	s := NewBlobstoreSource()
+
+	s.provider = ProviderS3
+	assert.Equal(t, "s3://bucket/data/file.csv", s.filepath("bucket", "data/file.csv"))
+	assert.Equal(t, "s3://bucket/data/file.csv", s.filepath("bucket/", "/data/file.csv"))
+	assert.Equal(t, "data/file.csv", s.filepath("", "data/file.csv"))
+
+	s.provider = ProviderGCS
+	assert.Equal(t, "gs://bucket/data/file.csv", s.filepath("bucket", "data/file.csv"))
+	assert.Equal(t, "gs://bucket/data/file.csv", s.filepath("bucket/", "/data/file.csv"))
+}
+
+func TestAddBlobstoreMetadataColumns(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	idBuilder := array.NewInt64Builder(mem)
+	idBuilder.AppendValues([]int64{1, 2}, nil)
+	idArray := idBuilder.NewArray()
+	idBuilder.Release()
+	defer idArray.Release()
+
+	inputSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+	input := array.NewRecordBatch(inputSchema, []arrow.Array{idArray}, 2)
+	defer input.Release()
+
+	modified := time.Date(2026, 1, 2, 3, 4, 5, 123456000, time.UTC)
+	output, added, err := addBlobstoreMetadataColumns(input, blobstoreFileMetadata{
+		incrementalKey: defaultBlobstoreModifiedAtColumn,
+		lastModified:   &modified,
+		filepathColumn: defaultBlobstoreFilePathColumn,
+		filepath:       "s3://bucket/data/file.csv",
+	})
+	require.NoError(t, err)
+	require.True(t, added)
+	defer output.Release()
+
+	assert.Equal(t, int64(2), output.NumRows())
+	assert.Equal(t, int64(3), output.NumCols())
+	assert.Equal(t, defaultBlobstoreModifiedAtColumn, output.Schema().Field(1).Name)
+	assert.Equal(t, defaultBlobstoreFilePathColumn, output.Schema().Field(2).Name)
+
+	tsCol, ok := output.Column(1).(*array.Timestamp)
+	require.True(t, ok)
+	assert.Equal(t, modified, tsCol.Value(0).ToTime(arrow.Microsecond))
+	assert.Equal(t, modified, tsCol.Value(1).ToTime(arrow.Microsecond))
+
+	pathCol, ok := output.Column(2).(*array.String)
+	require.True(t, ok)
+	assert.Equal(t, "s3://bucket/data/file.csv", pathCol.Value(0))
+	assert.Equal(t, "s3://bucket/data/file.csv", pathCol.Value(1))
+}
+
+func TestAddBlobstoreMetadataColumnsRejectsExistingColumn(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	builder := array.NewStringBuilder(mem)
+	builder.Append("existing")
+	existingArray := builder.NewArray()
+	builder.Release()
+	defer existingArray.Release()
+
+	inputSchema := arrow.NewSchema([]arrow.Field{
+		{Name: defaultBlobstoreModifiedAtColumn, Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	input := array.NewRecordBatch(inputSchema, []arrow.Array{existingArray}, 1)
+	defer input.Release()
+
+	modified := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	output, added, err := addBlobstoreMetadataColumns(input, blobstoreFileMetadata{
+		incrementalKey: defaultBlobstoreModifiedAtColumn,
+		lastModified:   &modified,
+	})
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.False(t, added)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestAddBlobstoreMetadataColumnsRejectsMetadataColumnConflict(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	idBuilder := array.NewInt64Builder(mem)
+	idBuilder.Append(1)
+	idArray := idBuilder.NewArray()
+	idBuilder.Release()
+	defer idArray.Release()
+
+	inputSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+	input := array.NewRecordBatch(inputSchema, []arrow.Array{idArray}, 1)
+	defer input.Release()
+
+	modified := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	output, added, err := addBlobstoreMetadataColumns(input, blobstoreFileMetadata{
+		incrementalKey: defaultBlobstoreFilePathColumn,
+		lastModified:   &modified,
+		filepathColumn: defaultBlobstoreFilePathColumn,
+		filepath:       "s3://bucket/data/file.csv",
+	})
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.False(t, added)
+	assert.Contains(t, err.Error(), "conflict")
 }
 
 func TestParseCSVValue(t *testing.T) {

--- a/pkg/source/blobstore/blobstore_test.go
+++ b/pkg/source/blobstore/blobstore_test.go
@@ -8,12 +8,40 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/bruin-data/ingestr/internal/adlsutil"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeAthenaAPI struct {
+	results []*athena.GetQueryResultsOutput
+}
+
+func (f *fakeAthenaAPI) StartQueryExecution(context.Context, *athena.StartQueryExecutionInput, ...func(*athena.Options)) (*athena.StartQueryExecutionOutput, error) {
+	return &athena.StartQueryExecutionOutput{QueryExecutionId: aws.String("exec-1")}, nil
+}
+
+func (f *fakeAthenaAPI) GetQueryExecution(context.Context, *athena.GetQueryExecutionInput, ...func(*athena.Options)) (*athena.GetQueryExecutionOutput, error) {
+	return &athena.GetQueryExecutionOutput{
+		QueryExecution: &athenatypes.QueryExecution{
+			Status: &athenatypes.QueryExecutionStatus{State: athenatypes.QueryExecutionStateSucceeded},
+		},
+	}, nil
+}
+
+func (f *fakeAthenaAPI) GetQueryResults(context.Context, *athena.GetQueryResultsInput, ...func(*athena.Options)) (*athena.GetQueryResultsOutput, error) {
+	if len(f.results) == 0 {
+		return &athena.GetQueryResultsOutput{}, nil
+	}
+	out := f.results[0]
+	f.results = f.results[1:]
+	return out, nil
+}
 
 func TestParseBlobstoreURI_S3(t *testing.T) {
 	tests := []struct {
@@ -26,30 +54,93 @@ func TestParseBlobstoreURI_S3(t *testing.T) {
 			name: "basic S3 with credentials",
 			uri:  "s3://?access_key_id=AKIAIOSFODNN7EXAMPLE&secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 			want: &parsedBlobstoreURI{
-				provider:        ProviderS3,
-				accessKeyID:     "AKIAIOSFODNN7EXAMPLE",
-				secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				provider:                      ProviderS3,
+				accessKeyID:                   "AKIAIOSFODNN7EXAMPLE",
+				secretAccessKey:               "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				s3FileDiscovery:               s3FileDiscoveryList,
+				athenaInventoryBucketColumn:   "bucket",
+				athenaInventoryKeyColumn:      "key",
+				athenaInventoryModifiedColumn: "last_modified_date",
 			},
 		},
 		{
 			name: "S3 with region",
 			uri:  "s3://?access_key_id=ABC&secret_access_key=XYZ&region=eu-west-1",
 			want: &parsedBlobstoreURI{
-				provider:        ProviderS3,
-				accessKeyID:     "ABC",
-				secretAccessKey: "XYZ",
-				region:          "eu-west-1",
+				provider:                      ProviderS3,
+				accessKeyID:                   "ABC",
+				secretAccessKey:               "XYZ",
+				region:                        "eu-west-1",
+				s3FileDiscovery:               s3FileDiscoveryList,
+				athenaInventoryBucketColumn:   "bucket",
+				athenaInventoryKeyColumn:      "key",
+				athenaInventoryModifiedColumn: "last_modified_date",
 			},
 		},
 		{
 			name: "S3 with endpoint URL (Minio)",
 			uri:  "s3://?access_key_id=ABC&secret_access_key=XYZ&endpoint_url=http://localhost:9000",
 			want: &parsedBlobstoreURI{
-				provider:        ProviderS3,
-				accessKeyID:     "ABC",
-				secretAccessKey: "XYZ",
-				endpointURL:     "http://localhost:9000",
+				provider:                      ProviderS3,
+				accessKeyID:                   "ABC",
+				secretAccessKey:               "XYZ",
+				endpointURL:                   "http://localhost:9000",
+				s3FileDiscovery:               s3FileDiscoveryList,
+				athenaInventoryBucketColumn:   "bucket",
+				athenaInventoryKeyColumn:      "key",
+				athenaInventoryModifiedColumn: "last_modified_date",
 			},
+		},
+		{
+			name: "S3 with Athena inventory discovery",
+			uri:  "s3://?access_key_id=ABC&secret_access_key=XYZ&region=us-east-1&file_discovery=athena_inventory&athena_inventory_table=inventory_db.inventory_table&athena_results_location=s3://query-results/ingestr&athena_workgroup=primary",
+			want: &parsedBlobstoreURI{
+				provider:                      ProviderS3,
+				accessKeyID:                   "ABC",
+				secretAccessKey:               "XYZ",
+				region:                        "us-east-1",
+				s3FileDiscovery:               s3FileDiscoveryAthenaInventory,
+				athenaInventoryTable:          "inventory_db.inventory_table",
+				athenaInventoryBucketColumn:   "bucket",
+				athenaInventoryKeyColumn:      "key",
+				athenaInventoryModifiedColumn: "last_modified_date",
+				athenaResultsLocation:         "s3://query-results/ingestr/",
+				athenaWorkgroup:               "primary",
+			},
+		},
+		{
+			name: "S3 with Athena inventory custom columns",
+			uri:  "s3://?file_discovery=athena_inventory&athena_inventory_table=inventory_db.inventory_table&athena_results_location=query-results/ingestr&athena_inventory_bucket_column=b&athena_inventory_key_column=k&athena_inventory_modified_column=m&athena_region=eu-west-1",
+			want: &parsedBlobstoreURI{
+				provider:                      ProviderS3,
+				s3FileDiscovery:               s3FileDiscoveryAthenaInventory,
+				athenaInventoryTable:          "inventory_db.inventory_table",
+				athenaInventoryBucketColumn:   "b",
+				athenaInventoryKeyColumn:      "k",
+				athenaInventoryModifiedColumn: "m",
+				athenaResultsLocation:         "s3://query-results/ingestr/",
+				athenaRegion:                  "eu-west-1",
+			},
+		},
+		{
+			name:    "S3 with invalid file discovery",
+			uri:     "s3://?file_discovery=magic",
+			wantErr: true,
+		},
+		{
+			name:    "S3 Athena inventory requires table",
+			uri:     "s3://?file_discovery=athena_inventory&athena_results_location=s3://query-results/ingestr",
+			wantErr: true,
+		},
+		{
+			name:    "S3 Athena inventory requires results location",
+			uri:     "s3://?file_discovery=athena_inventory&athena_inventory_table=inventory_db.inventory_table",
+			wantErr: true,
+		},
+		{
+			name:    "S3 Athena inventory requires qualified table",
+			uri:     "s3://?file_discovery=athena_inventory&athena_inventory_table=inventory_table&athena_results_location=s3://query-results/ingestr",
+			wantErr: true,
 		},
 	}
 
@@ -66,6 +157,14 @@ func TestParseBlobstoreURI_S3(t *testing.T) {
 			assert.Equal(t, tt.want.secretAccessKey, got.secretAccessKey)
 			assert.Equal(t, tt.want.region, got.region)
 			assert.Equal(t, tt.want.endpointURL, got.endpointURL)
+			assert.Equal(t, tt.want.s3FileDiscovery, got.s3FileDiscovery)
+			assert.Equal(t, tt.want.athenaInventoryTable, got.athenaInventoryTable)
+			assert.Equal(t, tt.want.athenaInventoryBucketColumn, got.athenaInventoryBucketColumn)
+			assert.Equal(t, tt.want.athenaInventoryKeyColumn, got.athenaInventoryKeyColumn)
+			assert.Equal(t, tt.want.athenaInventoryModifiedColumn, got.athenaInventoryModifiedColumn)
+			assert.Equal(t, tt.want.athenaResultsLocation, got.athenaResultsLocation)
+			assert.Equal(t, tt.want.athenaWorkgroup, got.athenaWorkgroup)
+			assert.Equal(t, tt.want.athenaRegion, got.athenaRegion)
 		})
 	}
 }
@@ -540,6 +639,118 @@ func TestObjectMatchesIncrementalOptionsRequiresReservedKey(t *testing.T) {
 		IncrementalKey: defaultBlobstoreModifiedAtColumn,
 		IntervalStart:  &start,
 	}))
+}
+
+func TestBuildS3InventoryQuery(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.FixedZone("UTC+2", 2*60*60))
+	end := time.Date(2026, 1, 3, 4, 5, 6, 0, time.UTC)
+	parsed := &parsedBlobstoreURI{
+		athenaInventoryTable:          "inventory_db.inventory_table",
+		athenaInventoryBucketColumn:   "bucket",
+		athenaInventoryKeyColumn:      "key",
+		athenaInventoryModifiedColumn: "last_modified_date",
+	}
+
+	query, database, err := buildS3InventoryQuery(parsed, "my-bucket", "logs/", source.ReadOptions{
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		IntervalStart:  &start,
+		IntervalEnd:    &end,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inventory_db", database)
+	assert.Equal(t, `SELECT "key", "last_modified_date" FROM "inventory_db"."inventory_table" WHERE "bucket" = 'my-bucket' AND substr("key", 1, 5) = 'logs/' AND "last_modified_date" >= timestamp '2026-01-02 01:04:05' AND "last_modified_date" <= timestamp '2026-01-03 04:05:06'`, query)
+}
+
+func TestBuildS3InventoryQueryWithoutModifiedIncrementality(t *testing.T) {
+	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	parsed := &parsedBlobstoreURI{
+		athenaInventoryTable:          "inventory_db.inventory_table",
+		athenaInventoryBucketColumn:   "bucket",
+		athenaInventoryKeyColumn:      "key",
+		athenaInventoryModifiedColumn: "last_modified_date",
+	}
+
+	query, database, err := buildS3InventoryQuery(parsed, "my-bucket", "", source.ReadOptions{
+		IncrementalKey: "updated_at",
+		IntervalStart:  &start,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inventory_db", database)
+	assert.Equal(t, `SELECT "key", "last_modified_date" FROM "inventory_db"."inventory_table" WHERE "bucket" = 'my-bucket'`, query)
+}
+
+func TestBuildS3InventoryQueryEscapesIdentifiersAndValues(t *testing.T) {
+	parsed := &parsedBlobstoreURI{
+		athenaInventoryTable:          `inventory_db.inventory"table`,
+		athenaInventoryBucketColumn:   `bucket"col`,
+		athenaInventoryKeyColumn:      `key"col`,
+		athenaInventoryModifiedColumn: "modified",
+	}
+
+	query, _, err := buildS3InventoryQuery(parsed, "bucket'1", "logs/o'hare/", source.ReadOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, `SELECT "key""col", "modified" FROM "inventory_db"."inventory""table" WHERE "bucket""col" = 'bucket''1' AND substr("key""col", 1, 12) = 'logs/o''hare/'`, query)
+}
+
+func TestParseAthenaInventoryTime(t *testing.T) {
+	tests := []struct {
+		value string
+		want  time.Time
+	}{
+		{"2026-01-02T03:04:05Z", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)},
+		{"2026-01-02 03:04:05", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)},
+		{"2026-01-02 03:04:05.123456", time.Date(2026, 1, 2, 3, 4, 5, 123456000, time.UTC)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := parseAthenaInventoryTime(tt.value)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, *got)
+		})
+	}
+
+	got, err := parseAthenaInventoryTime("")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	_, err = parseAthenaInventoryTime("not-a-time")
+	require.Error(t, err)
+}
+
+func TestStreamS3InventoryQueryResultsFiltersRows(t *testing.T) {
+	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	s := &BlobstoreSource{
+		athenaClient: &fakeAthenaAPI{
+			results: []*athena.GetQueryResultsOutput{
+				{
+					ResultSet: &athenatypes.ResultSet{
+						Rows: []athenatypes.Row{
+							{Data: []athenatypes.Datum{{VarCharValue: aws.String("key")}, {VarCharValue: aws.String("last_modified_date")}}},
+							{Data: []athenatypes.Datum{{VarCharValue: aws.String("logs/2026/keep.jsonl")}, {VarCharValue: aws.String("2026-01-02 03:04:05")}}},
+							{Data: []athenatypes.Datum{{VarCharValue: aws.String("logs/2026/skip.csv")}, {VarCharValue: aws.String("2026-01-02 03:04:05")}}},
+							{Data: []athenatypes.Datum{{VarCharValue: aws.String("logs/2026/old.jsonl")}, {VarCharValue: aws.String("2026-01-01 03:04:05")}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	files := make(chan blobstoreFile, 3)
+
+	count, err := s.streamS3InventoryQueryResults(context.Background(), "exec-1", "logs/**/*.jsonl", source.ReadOptions{
+		IncrementalKey: defaultBlobstoreModifiedAtColumn,
+		IntervalStart:  &start,
+	}, files)
+	require.NoError(t, err)
+	close(files)
+
+	require.Equal(t, 1, count)
+	file := <-files
+	assert.Equal(t, "logs/2026/keep.jsonl", file.key)
+	require.NotNil(t, file.lastModified)
+	assert.Equal(t, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), *file.lastModified)
 }
 
 func TestBlobstoreFileMetadata(t *testing.T) {

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -1996,6 +1996,7 @@ func TestChessSource_ToDestinations(t *testing.T) {
 				IncrementalStrategy: config.StrategyReplace,
 				IntervalStart:       &intervalStart,
 				IntervalEnd:         &intervalEnd,
+				Columns:             "end_time:timestamptz",
 			}
 
 			p := pipeline.New(cfg)


### PR DESCRIPTION
## Summary
- add opt-in source-file modified-date incrementality for S3 and GCS using `_ingestr_source_file_modified_at`
- emit `_ingestr_source_file_path` with each row when the metadata incremental mode is enabled
- keep custom row-level incremental keys backward-compatible as file-data columns, without blobstore read filtering
- add optional S3 `file_discovery=athena_inventory` mode to discover candidate files from S3 Inventory via Athena for large buckets
- document S3 and GCS source-file modification incremental loading, including the Athena inventory option for S3

Closes #688

## Tests
- `go test ./pkg/source/blobstore ./pkg/source/athena`
- `git diff --check`