### PR TITLE
[codex] Add no-inference schema mode

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -151,6 +151,11 @@ func IngestCommand() *cli.Command {
 				Usage:   "Override column types and/or rename columns. Per-column format: 'name:type' (type override), 'name:type:source' (rename + type), or 'name::source' (rename only). Multiple entries comma-separated, e.g. 'id:bigint,first_name:string:fname,email::eml'. Types: bigint, int, smallint, float, double, decimal(p,s), string, text, boolean, date, timestamp (with tz), timestamp_ntz (no tz), json, uuid, binary",
 				Sources: cli.EnvVars("INGESTR_COLUMNS"),
 			},
+			&cli.BoolFlag{
+				Name:    "no-inference",
+				Usage:   "Skip schema inference for schema-less sources and use --columns as the source schema",
+				Sources: cli.EnvVars("NO_INFERENCE", "INGESTR_NO_INFERENCE"),
+			},
 			&cli.StringSliceFlag{
 				Name:    "mask",
 				Usage:   "Column masking configuration in format 'column:algorithm[:param]'. Algorithms: hash, sha256, md5, hmac, email, phone, credit_card, ssn, redact, stars, fixed, random, partial, first_letter, uuid, sequential, round, range, noise, date_shift, year_only, month_year.",
@@ -215,6 +220,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.SQLLimit = int(c.Int("sql-limit"))
 	cfg.SQLExcludeColumns = c.StringSlice("sql-exclude-columns")
 	cfg.Columns = c.String("columns")
+	cfg.NoInference = c.Bool("no-inference")
 	cfg.Mask = c.StringSlice("mask")
 	cfg.PipelinesDir = c.String("pipelines-dir")
 	cfg.StagingBucket = c.String("staging-bucket")

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -28,6 +28,7 @@ ingestr ingest \
 - `--interval-end`: Sets the end of the interval for the incremental key. Defaults to `None`.
 - `--primary-key TEXT`: Specifies the primary key for the merge operation. Defaults to `None`.
 - `--columns <name>:<type>:<source>`: Specifies the columns to be ingested. Use `name:type` to override a column's type, `name:type:source` to rename `source` to `name` with a type, or `name::source` to rename only. Multiple entries are comma-separated. Defaults to `None`.
+- `--no-inference`: Skips schema inference for schema-less sources and uses `--columns` as the source schema. Requires `--columns`.
 - `--mask <column_name>:<algorithm>[:param]`: Applies data masking to specified columns. Can be used multiple times for different columns. See the [Data Masking](../getting-started/data-masking.md) documentation for available algorithms and usage examples. Defaults to `None`.
 - `--schema-naming` Specifies what naming convention to use for table and column names on the destination. Can be `default` or `direct`.default is snake_case. `direct is case sensitive and doesn't contract underscores.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type IngestConfig struct {
 	SQLLimit          int
 	SQLExcludeColumns []string
 	Columns           string // Raw column overrides string (parsed by pipeline)
+	NoInference       bool   // Skip schema inference for unknown-schema sources and use Columns as the schema
 	Mask              []string
 
 	PipelinesDir   string
@@ -112,6 +113,9 @@ func (c *IngestConfig) Validate() error {
 			Field:   "interval-start",
 			Message: fmt.Sprintf("must be earlier than interval-end (got start=%s, end=%s)", c.IntervalStart.Format(time.RFC3339), c.IntervalEnd.Format(time.RFC3339)),
 		}
+	}
+	if c.NoInference && strings.TrimSpace(c.Columns) == "" {
+		return &ValidationError{Field: "columns", Message: "is required when no-inference is enabled"}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIngestConfigValidate_NoInferenceRequiresColumns(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "mongodb://localhost:27017/db"
+	cfg.SourceTable = "db.users"
+	cfg.DestURI = "duckdb://out.duckdb"
+	cfg.NoInference = true
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "columns") {
+		t.Fatalf("expected columns validation error, got %v", err)
+	}
+}
+
+func TestIngestConfigValidate_NoInferenceWithColumns(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "mongodb://localhost:27017/db"
+	cfg.SourceTable = "db.users"
+	cfg.DestURI = "duckdb://out.duckdb"
+	cfg.Columns = "_id:string,name:string"
+	cfg.NoInference = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -168,6 +168,12 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to get schema: %w", err)
 		}
+	} else if p.config.NoInference {
+		tableSchema, err = p.schemaFromColumnOverrides(table)
+		if err != nil {
+			return err
+		}
+		config.Debug("[PIPELINE] Schema inference disabled; using %d columns from --columns", len(tableSchema.Columns))
 	} else {
 		// Schema inference path: read all data first. Buffer is opened later
 		config.Debug("[PIPELINE] Source has unknown schema, inferring from data...")
@@ -388,9 +394,13 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		EvolutionPlan:       evolutionPlan,
 	}
 
-	// For known-schema sources with column type overrides, add a type caster
-	// that converts Arrow batches from source types to the overridden types.
-	if p.config.Columns != "" && bufferedRecords == nil {
+	// For --no-inference, enforce the user-provided source schema even when
+	// a schema-less source does not apply ReadOptions.Schema itself.
+	if p.config.NoInference && bufferedRecords == nil {
+		job.TypeCaster = p.buildSourceSchemaCaster(originalSourceSchema)
+	} else if p.config.Columns != "" && bufferedRecords == nil {
+		// For known-schema sources with column type overrides, add a type caster
+		// that converts Arrow batches from source types to the overridden types.
 		job.TypeCaster = p.buildTypeCaster(tableSchema, destSchema)
 	}
 
@@ -399,6 +409,44 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (p *Pipeline) schemaFromColumnOverrides(table source.SourceTable) (*schema.TableSchema, error) {
+	tableSchema, err := schemainfer.SourceTableSchemaFromColumnOverrides(p.config.Columns, table.Name())
+	if err != nil {
+		return nil, fmt.Errorf("failed to build schema from column overrides: %w", err)
+	}
+	if tableSchema == nil || len(tableSchema.Columns) == 0 {
+		return nil, fmt.Errorf("--no-inference requires at least one column in --columns")
+	}
+
+	pks := p.config.PrimaryKeys
+	if len(pks) == 0 {
+		pks = table.PrimaryKeys()
+	}
+	ik := p.config.IncrementalKey
+	if ik == "" {
+		ik = table.IncrementalKey()
+	}
+	partitionCol := resolvePartitionBy(p.config, table)
+	if err := schemainfer.AddKeyColumnsIfMissing(tableSchema, pks, ik, partitionCol, p.config.SchemaNaming); err != nil {
+		return nil, fmt.Errorf("failed to add key columns to --columns schema: %w", err)
+	}
+
+	return tableSchema, nil
+}
+
+func (p *Pipeline) buildSourceSchemaCaster(sourceSchema *schema.TableSchema) *transformer.TypeCaster {
+	if sourceSchema == nil {
+		return nil
+	}
+
+	fields := make([]arrow.Field, len(sourceSchema.Columns))
+	for i, col := range sourceSchema.Columns {
+		fields[i] = arrowField(col.Name, col, col.Nullable)
+	}
+
+	return transformer.NewTypeCaster(arrow.NewSchema(fields, nil))
 }
 
 // buildTypeCaster creates a TypeCaster when column type overrides differ from the source types.

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -1238,6 +1240,68 @@ func TestBuildBufferReaderTarget_KeepsAliasesForCanonicalDuplicate(t *testing.T)
 	got := p.buildBufferReaderTarget(src, dest)
 
 	assertColumns(t, "fields", arrowFieldNames(got), []string{"_id", "userId", "user_id", "UserID"})
+}
+
+func TestBuildSourceSchemaCaster_ProjectsAndCastsToSourceSchema(t *testing.T) {
+	p := &Pipeline{}
+	sourceSchema := tschema(
+		"events",
+		tcol("id", schema.TypeInt64),
+		tcol("count", schema.TypeInt64),
+	)
+
+	caster := p.buildSourceSchemaCaster(sourceSchema)
+	if caster == nil {
+		t.Fatal("expected source schema caster")
+	}
+
+	mem := memory.NewGoAllocator()
+	idBuilder := array.NewInt64Builder(mem)
+	idBuilder.Append(7)
+	idArr := idBuilder.NewArray()
+	idBuilder.Release()
+	defer idArr.Release()
+
+	extraBuilder := array.NewStringBuilder(mem)
+	extraBuilder.Append("drop me")
+	extraArr := extraBuilder.NewArray()
+	extraBuilder.Release()
+	defer extraArr.Release()
+
+	countBuilder := array.NewStringBuilder(mem)
+	countBuilder.Append("42")
+	countArr := countBuilder.NewArray()
+	countBuilder.Release()
+	defer countArr.Release()
+
+	input := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "extra", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "count", Type: arrow.BinaryTypes.String, Nullable: true},
+		}, nil),
+		[]arrow.Array{idArr, extraArr, countArr},
+		1,
+	)
+	defer input.Release()
+
+	got, err := caster.Transform(input)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+	defer got.Release()
+
+	assertColumns(t, "fields", arrowFieldNames(got.Schema()), []string{"id", "count"})
+	if got.Column(1).DataType().ID() != arrow.INT64 {
+		t.Fatalf("count type = %s, want int64", got.Column(1).DataType())
+	}
+	countCol, ok := got.Column(1).(*array.Int64)
+	if !ok {
+		t.Fatalf("count column type = %T, want *array.Int64", got.Column(1))
+	}
+	if got := countCol.Value(0); got != 42 {
+		t.Fatalf("count = %d, want 42", got)
+	}
 }
 
 func TestApplyColumnMapping_DedupesCanonicalColumns(t *testing.T) {

--- a/pkg/schemainfer/overrides.go
+++ b/pkg/schemainfer/overrides.go
@@ -11,7 +11,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 )
 
-// Builds a TableSchema purely from --columns when a schema-less source produced no rows.
+// Builds a destination-facing TableSchema purely from --columns when a
+// schema-less source produced no rows.
 func TableSchemaFromColumnOverrides(columnsSpec, tableName, schemaNaming string) (*schema.TableSchema, error) {
 	if columnsSpec == "" {
 		return nil, nil
@@ -31,6 +32,60 @@ func TableSchemaFromColumnOverrides(columnsSpec, tableName, schemaNaming string)
 	if len(ts.Columns) == 0 {
 		return nil, nil
 	}
+	return ts, nil
+}
+
+// SourceTableSchemaFromColumnOverrides builds a source-facing TableSchema from
+// --columns. Rename overrides keep the source column name here; the pipeline
+// later applies the rename to the destination schema and record batches.
+func SourceTableSchemaFromColumnOverrides(columnsSpec, tableName string) (*schema.TableSchema, error) {
+	if columnsSpec == "" {
+		return nil, nil
+	}
+
+	schemaName := ""
+	tblName := tableName
+	if idx := strings.LastIndex(tableName, "."); idx > 0 {
+		schemaName = tableName[:idx]
+		tblName = tableName[idx+1:]
+	}
+
+	overrides, err := schemaevolution.ParseColumnOverrides(columnsSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse column overrides: %w", err)
+	}
+	if len(overrides) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(overrides))
+	for name := range overrides {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	ts := &schema.TableSchema{Name: tblName, Schema: schemaName}
+	for _, name := range names {
+		ov := overrides[name]
+		dataType := ov.DataType
+		precision := ov.Precision
+		scale := ov.Scale
+		if dataType == schema.TypeUnknown {
+			dataType = schema.TypeString
+			precision = 0
+			scale = 0
+			fmt.Printf("Warning: column %q created as STRING placeholder (no type in --columns); pass --columns %s:<type> for correct typing\n", ov.Name, ov.Name)
+		}
+
+		ts.Columns = append(ts.Columns, schema.Column{
+			Name:      ov.Name,
+			DataType:  dataType,
+			Precision: precision,
+			Scale:     scale,
+			Nullable:  true,
+		})
+	}
+
 	return ts, nil
 }
 

--- a/pkg/schemainfer/overrides.go
+++ b/pkg/schemainfer/overrides.go
@@ -74,7 +74,11 @@ func SourceTableSchemaFromColumnOverrides(columnsSpec, tableName string) (*schem
 			dataType = schema.TypeString
 			precision = 0
 			scale = 0
-			fmt.Printf("Warning: column %q created as STRING placeholder (no type in --columns); pass --columns %s:<type> for correct typing\n", ov.Name, ov.Name)
+			if ov.RenameTo != "" {
+				fmt.Printf("Warning: column %q created as STRING placeholder (no type in --columns); pass --columns %s:<type>:%s for correct typing\n", ov.Name, ov.RenameTo, ov.Name)
+			} else {
+				fmt.Printf("Warning: column %q created as STRING placeholder (no type in --columns); pass --columns %s:<type> for correct typing\n", ov.Name, ov.Name)
+			}
 		}
 
 		ts.Columns = append(ts.Columns, schema.Column{

--- a/pkg/schemainfer/overrides_test.go
+++ b/pkg/schemainfer/overrides_test.go
@@ -1,6 +1,9 @@
 package schemainfer
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -101,6 +104,50 @@ func TestSourceTableSchemaFromColumnOverrides_KeepsSourceNamesForRenames(t *test
 	if cols["fname"].DataType != schema.TypeString {
 		t.Errorf("fname type = %v, want string", cols["fname"].DataType)
 	}
+}
+
+func TestSourceTableSchemaFromColumnOverrides_RenameOnlyWarningUsesRenameSyntax(t *testing.T) {
+	output := captureStdout(t, func() {
+		if _, err := SourceTableSchemaFromColumnOverrides("first_name::fname", "users"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "pass --columns first_name:<type>:fname") {
+		t.Fatalf("warning = %q, want rename syntax advice", output)
+	}
+	if strings.Contains(output, "pass --columns fname:<type>") {
+		t.Fatalf("warning = %q, should not suggest a plain source-column override", output)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return buf.String()
 }
 
 func TestAppendMissingOverrideColumns_NilSchemaIsNoop(t *testing.T) {

--- a/pkg/schemainfer/overrides_test.go
+++ b/pkg/schemainfer/overrides_test.go
@@ -71,6 +71,38 @@ func TestTableSchemaFromColumnOverrides_InvalidType(t *testing.T) {
 	}
 }
 
+func TestSourceTableSchemaFromColumnOverrides_KeepsSourceNamesForRenames(t *testing.T) {
+	got, err := SourceTableSchemaFromColumnOverrides("id:string:_id,first_name:string:fname", "main.users")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected schema, got nil")
+	}
+	if got.Schema != "main" || got.Name != "users" {
+		t.Fatalf("schema/table = %q/%q, want main/users", got.Schema, got.Name)
+	}
+
+	names := got.ColumnNames()
+	want := []string{"_id", "fname"}
+	if len(names) != len(want) {
+		t.Fatalf("column names = %v, want %v", names, want)
+	}
+	for i, name := range names {
+		if name != want[i] {
+			t.Fatalf("column names = %v, want %v", names, want)
+		}
+	}
+
+	cols := indexColumns(got.Columns)
+	if cols["_id"].DataType != schema.TypeString {
+		t.Errorf("_id type = %v, want string", cols["_id"].DataType)
+	}
+	if cols["fname"].DataType != schema.TypeString {
+		t.Errorf("fname type = %v, want string", cols["fname"].DataType)
+	}
+}
+
 func TestAppendMissingOverrideColumns_NilSchemaIsNoop(t *testing.T) {
 	if err := AppendMissingOverrideColumns(nil, "id:bigint", "snake_case"); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"go.mongodb.org/mongo-driver/bson"
@@ -537,7 +538,10 @@ func (s *MongoDBSource) consumeCursor(ctx context.Context, cursor *mongo.Cursor,
 		}
 
 		startBatch := time.Now()
-		builder := newMongoBatchBuilder(opts.ExcludeColumns)
+		var builder mongoRecordBatchBuilder = newMongoBatchBuilder(opts.ExcludeColumns)
+		if opts.Schema != nil {
+			builder = newMongoSchemaBatchBuilder(opts.Schema.Columns, opts.ExcludeColumns)
+		}
 		batchRows := 0
 
 		for batchRows < batchSize && cursor.Next(ctx) {
@@ -635,6 +639,12 @@ type mongoBatchBuilder struct {
 	rowCount   int
 }
 
+type mongoRecordBatchBuilder interface {
+	AppendDocument(doc bson.M) error
+	NewRecordBatch() (arrow.RecordBatch, error)
+	Release()
+}
+
 func newMongoBatchBuilder(excludeColumns []string) *mongoBatchBuilder {
 	excludeMap := make(map[string]bool, len(excludeColumns))
 	for _, col := range excludeColumns {
@@ -715,6 +725,89 @@ func (b *mongoBatchBuilder) Release() {
 func (b *mongoBatchBuilder) reset() {
 	b.fieldOrder = b.fieldOrder[:0]
 	b.cols = make(map[string]*typedColumnBuilder)
+	b.rowCount = 0
+}
+
+type mongoSchemaBatchBuilder struct {
+	columns  []schema.Column
+	builders []array.Builder
+	rowCount int
+}
+
+func newMongoSchemaBatchBuilder(columns []schema.Column, excludeColumns []string) *mongoSchemaBatchBuilder {
+	excludeMap := make(map[string]bool, len(excludeColumns))
+	for _, col := range excludeColumns {
+		excludeMap[strings.ToLower(col)] = true
+	}
+
+	filtered := make([]schema.Column, 0, len(columns))
+	for _, col := range columns {
+		if excludeMap[strings.ToLower(col.Name)] {
+			continue
+		}
+		filtered = append(filtered, col)
+	}
+
+	mem := memory.NewGoAllocator()
+	builders := make([]array.Builder, len(filtered))
+	for i, col := range filtered {
+		builders[i] = array.NewBuilder(mem, schema.DataTypeToArrowType(col))
+	}
+
+	return &mongoSchemaBatchBuilder{
+		columns:  filtered,
+		builders: builders,
+	}
+}
+
+func (b *mongoSchemaBatchBuilder) AppendDocument(doc bson.M) error {
+	for i, col := range b.columns {
+		val, ok := doc[col.Name]
+		if !ok || val == nil {
+			b.builders[i].AppendNull()
+			continue
+		}
+		arrowconv.AppendValue(b.builders[i], convertBSONValue(val))
+	}
+	b.rowCount++
+	return nil
+}
+
+func (b *mongoSchemaBatchBuilder) NewRecordBatch() (arrow.RecordBatch, error) {
+	if len(b.columns) == 0 {
+		emptySchema := arrow.NewSchema([]arrow.Field{}, nil)
+		return array.NewRecordBatch(emptySchema, []arrow.Array{}, int64(b.rowCount)), nil
+	}
+
+	fields := make([]arrow.Field, len(b.columns))
+	arrays := make([]arrow.Array, len(b.columns))
+	for i, col := range b.columns {
+		fields[i] = arrow.Field{
+			Name:     col.Name,
+			Type:     schema.DataTypeToArrowType(col),
+			Nullable: col.Nullable,
+		}
+		arrays[i] = b.builders[i].NewArray()
+	}
+
+	record := array.NewRecordBatch(arrow.NewSchema(fields, nil), arrays, int64(b.rowCount))
+
+	for _, arr := range arrays {
+		arr.Release()
+	}
+	b.Release()
+
+	return record, nil
+}
+
+func (b *mongoSchemaBatchBuilder) Release() {
+	for _, builder := range b.builders {
+		if builder != nil {
+			builder.Release()
+		}
+	}
+	b.builders = nil
+	b.columns = nil
 	b.rowCount = 0
 }
 

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/arrowutil"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -602,6 +603,75 @@ func TestMongoBatchBuilder_AllNullColumnEmittedAsUnknown(t *testing.T) {
 		if !isUnknownType(field.Type) {
 			t.Fatalf("all-null column b: type = %s, want unknown", field.Type)
 		}
+	}
+}
+
+func TestMongoSchemaBatchBuilder_UsesProvidedSchema(t *testing.T) {
+	oid, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
+	created := primitive.NewDateTimeFromTime(time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC))
+
+	builder := newMongoSchemaBatchBuilder([]schema.Column{
+		{Name: "_id", DataType: schema.TypeString, Nullable: false},
+		{Name: "count", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "created_at", DataType: schema.TypeTimestampTZ, Nullable: true},
+	}, nil)
+
+	if err := builder.AppendDocument(bson.M{
+		"_id":        oid,
+		"count":      "42",
+		"created_at": created,
+		"extra":      "ignored",
+	}); err != nil {
+		t.Fatalf("AppendDocument error = %v", err)
+	}
+
+	record, err := builder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("NewRecordBatch error = %v", err)
+	}
+	defer record.Release()
+
+	if got := record.NumCols(); got != 3 {
+		t.Fatalf("NumCols = %d, want 3", got)
+	}
+	wantNames := []string{"_id", "count", "created_at"}
+	for i, want := range wantNames {
+		if got := record.Schema().Field(i).Name; got != want {
+			t.Fatalf("field %d = %q, want %q", i, got, want)
+		}
+	}
+	if got := arrowutil.Value(record.Column(0), 0); got != oid.Hex() {
+		t.Fatalf("_id = %#v, want %q", got, oid.Hex())
+	}
+	if got := arrowutil.Value(record.Column(1), 0); got != int64(42) {
+		t.Fatalf("count = %#v, want %v", got, int64(42))
+	}
+	if got := record.Schema().Field(2).Type.String(); got != "timestamp[us, tz=UTC]" {
+		t.Fatalf("created_at type = %s, want timestamp[us, tz=UTC]", got)
+	}
+}
+
+func TestMongoSchemaBatchBuilder_ExcludesSchemaColumns(t *testing.T) {
+	builder := newMongoSchemaBatchBuilder([]schema.Column{
+		{Name: "keep", DataType: schema.TypeString},
+		{Name: "skip", DataType: schema.TypeString},
+	}, []string{"skip"})
+
+	if err := builder.AppendDocument(bson.M{"keep": "one", "skip": "two"}); err != nil {
+		t.Fatalf("AppendDocument error = %v", err)
+	}
+
+	record, err := builder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("NewRecordBatch error = %v", err)
+	}
+	defer record.Release()
+
+	if got := record.NumCols(); got != 1 {
+		t.Fatalf("NumCols = %d, want 1", got)
+	}
+	if got := record.Schema().Field(0).Name; got != "keep" {
+		t.Fatalf("field 0 = %q, want keep", got)
 	}
 }
 


### PR DESCRIPTION
Adds a `--no-inference` ingest flag that lets schema-less sources use `--columns` as the declared source schema.

This builds source-facing schemas from column overrides, preserves source names for rename overrides, and enforces the declared schema before downstream renames and writes so sources that ignore `ReadOptions.Schema` do not leak extra fields.

MongoDB now honors provided schemas during batch construction, including projection, type conversion, and excluded columns.

Validated with `go test ./internal/config ./pkg/schemainfer ./pkg/source/mongodb ./pkg/pipeline ./pkg/strategy ./pkg/transformer` and the commit hook gitleaks scan.