### PR TITLE
[codex] Disable telemetry in CI and tests

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -3,6 +3,10 @@ name: Bump Version
 on:
   workflow_dispatch:
 
+env:
+  INGESTR_DISABLE_TELEMETRY: "true"
+  DISABLE_TELEMETRY: "true"
+
 jobs:
   bump_version:
     name: Bump Version

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  INGESTR_DISABLE_TELEMETRY: "true"
+  DISABLE_TELEMETRY: "true"
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   INSTALL_URL: https://getbruin.com/install/ingestr
+  INGESTR_DISABLE_TELEMETRY: "true"
+  DISABLE_TELEMETRY: "true"
 
 jobs:
   integration-tests:
@@ -51,7 +53,7 @@ jobs:
       - name: Run GoReleaser
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          docker run --privileged   -v /var/run/docker.sock:/var/run/docker.sock -e GGOOS=darwin -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} -e COMMIT_SHA=${{ github.sha }} -e VERSION=${{ github.ref_name }} -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v $(pwd):/src -w /src goreleaser/goreleaser-cross-pro:v1.23 release --clean --split --verbose
+          docker run --privileged   -v /var/run/docker.sock:/var/run/docker.sock -e INGESTR_DISABLE_TELEMETRY=true -e DISABLE_TELEMETRY=true -e GGOOS=darwin -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} -e COMMIT_SHA=${{ github.sha }} -e VERSION=${{ github.ref_name }} -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v $(pwd):/src -w /src goreleaser/goreleaser-cross-pro:v1.23 release --clean --split --verbose
 
 
   prepare-linux:
@@ -74,7 +76,7 @@ jobs:
       - name: Run GoReleaser
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          docker run --privileged   -v /var/run/docker.sock:/var/run/docker.sock -e GGOOS=linux -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} -e COMMIT_SHA=${{ github.sha }} -e VERSION=${{ github.ref_name }} -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v $(pwd):/src -w /src goreleaser/goreleaser-cross-pro:v1.23 release --clean --split --verbose
+          docker run --privileged   -v /var/run/docker.sock:/var/run/docker.sock -e INGESTR_DISABLE_TELEMETRY=true -e DISABLE_TELEMETRY=true -e GGOOS=linux -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} -e COMMIT_SHA=${{ github.sha }} -e VERSION=${{ github.ref_name }} -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v $(pwd):/src -w /src goreleaser/goreleaser-cross-pro:v1.23 release --clean --split --verbose
 
 
   release-unix:

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,5 +1,10 @@
 name: secrets_scan
 on: [push, workflow_dispatch]
+
+env:
+  INGESTR_DISABLE_TELEMETRY: "true"
+  DISABLE_TELEMETRY: "true"
+
 jobs:
   scan:
     name: gitleaks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: bruin-data/ingestr
+  INGESTR_DISABLE_TELEMETRY: "true"
+  DISABLE_TELEMETRY: "true"
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ VERSION ?= dev
 GO_LICENSES_MODULE ?= github.com/google/go-licenses@v1.6.0
 LICENSE_DISALLOWED_TYPES ?= forbidden,restricted,unknown
 LICENSE_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
+export INGESTR_DISABLE_TELEMETRY := true
+export DISABLE_TELEMETRY := true
+TELEMETRY_ENV := INGESTR_DISABLE_TELEMETRY=true DISABLE_TELEMETRY=true
 
 NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
@@ -58,15 +61,15 @@ run: build
 
 test: generate
 	@echo "$(OK_COLOR)==> Running unit tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && go test -short -race -cover -timeout 5m ./...
+	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -short -race -cover -timeout 5m ./...
 
 test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && go test -tags integration -v -p 64 -parallel 64 -timeout 10m ./tests/integration/...
+	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -p 64 -parallel 64 -timeout 10m ./tests/integration/...
 
 test-conformance:
 	@echo "$(OK_COLOR)==> Running destination standards tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && go test -tags integration -v -timeout 10m ./tests/integration -run TestDestinations_
+	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -timeout 10m ./tests/integration -run TestDestinations_
 
 
 # Format code and run linters (for local development)

--- a/internal/telemetry/integration.go
+++ b/internal/telemetry/integration.go
@@ -1,0 +1,10 @@
+//go:build integration
+
+package telemetry
+
+import "os"
+
+func init() {
+	_ = os.Setenv("INGESTR_DISABLE_TELEMETRY", "true")
+	_ = os.Setenv("DISABLE_TELEMETRY", "true")
+}


### PR DESCRIPTION
This disables ingestr telemetry for Makefile-driven test commands, all GitHub Actions workflows, release Docker runs, and integration-tagged Go test binaries.
The false counts came from CI and test execution inheriting normal telemetry defaults, so these paths now force both INGESTR_DISABLE_TELEMETRY and legacy DISABLE_TELEMETRY.
This keeps local/CI validation and release smoke checks from reporting synthetic usage while preserving production telemetry behavior.
Validated with `go test ./internal/telemetry`, `go test -tags integration ./internal/telemetry`, `go run ./cmd/genregistry && go test -tags integration -short ./tests/integration/...`, `git diff --check`, and workflow YAML parsing.
