### PR TITLE
fix(trino source): type-aware incremental literals + UUID typing

### DIFF
--- a/pkg/source/trino/incremental_test.go
+++ b/pkg/source/trino/incremental_test.go
@@ -1,0 +1,84 @@
+package trino
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+func TestFormatIncrementalLiteral(t *testing.T) {
+	ts := time.Date(2024, 3, 15, 10, 20, 30, 456000000, time.UTC)
+	tsLocal := time.Date(2024, 3, 15, 10, 20, 30, 456000000, time.FixedZone("CET", 3600))
+
+	tests := []struct {
+		name string
+		col  *schema.Column
+		t    time.Time
+		want string
+	}{
+		{
+			name: "nil column falls back to TIMESTAMP",
+			col:  nil,
+			t:    ts,
+			want: `TIMESTAMP '2024-03-15 10:20:30.456000'`,
+		},
+		{
+			name: "date column",
+			col:  &schema.Column{Name: "d", DataType: schema.TypeDate},
+			t:    ts,
+			want: `DATE '2024-03-15'`,
+		},
+		{
+			name: "time column",
+			col:  &schema.Column{Name: "t", DataType: schema.TypeTime},
+			t:    ts,
+			want: `TIME '10:20:30.456000'`,
+		},
+		{
+			name: "timestamp column",
+			col:  &schema.Column{Name: "ts", DataType: schema.TypeTimestamp},
+			t:    ts,
+			want: `TIMESTAMP '2024-03-15 10:20:30.456000'`,
+		},
+		{
+			name: "timestamp_tz column converts to UTC",
+			col:  &schema.Column{Name: "ts", DataType: schema.TypeTimestampTZ},
+			t:    tsLocal,
+			want: `TIMESTAMP '2024-03-15 09:20:30.456000 UTC'`,
+		},
+		{
+			name: "unknown column falls back to TIMESTAMP",
+			col:  &schema.Column{Name: "v", DataType: schema.TypeString},
+			t:    ts,
+			want: `TIMESTAMP '2024-03-15 10:20:30.456000'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatIncrementalLiteral(tt.col, tt.t)
+			if got != tt.want {
+				t.Errorf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindColumn(t *testing.T) {
+	cols := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "Name", DataType: schema.TypeString},
+		{Name: "updated_at", DataType: schema.TypeTimestamp},
+	}
+
+	if got := findColumn(cols, "updated_at"); got == nil || got.DataType != schema.TypeTimestamp {
+		t.Errorf("exact match miss: got %+v", got)
+	}
+	if got := findColumn(cols, "UPDATED_AT"); got == nil || got.DataType != schema.TypeTimestamp {
+		t.Errorf("case-insensitive match miss: got %+v", got)
+	}
+	if got := findColumn(cols, "missing"); got != nil {
+		t.Errorf("expected nil for missing column, got %+v", got)
+	}
+}

--- a/pkg/source/trino/mapper.go
+++ b/pkg/source/trino/mapper.go
@@ -79,7 +79,7 @@ func MapTrinoToDataType(trinoType string) (schema.DataType, int, int, schema.Dat
 	case "JSON":
 		return schema.TypeJSON, 0, 0, schema.TypeUnknown
 	case "UUID":
-		return schema.TypeString, 0, 0, schema.TypeUnknown
+		return schema.TypeUUID, 0, 0, schema.TypeUnknown
 	case "IPADDRESS":
 		return schema.TypeString, 0, 0, schema.TypeUnknown
 	case "INTERVAL":

--- a/pkg/source/trino/mapper_test.go
+++ b/pkg/source/trino/mapper_test.go
@@ -38,7 +38,7 @@ func TestMapTrinoToDataType(t *testing.T) {
 		{"timestamp with time zone", schema.TypeTimestampTZ, 0, 0, schema.TypeUnknown},
 		{"timestamp(6) with time zone", schema.TypeTimestampTZ, 0, 0, schema.TypeUnknown},
 		{"json", schema.TypeJSON, 0, 0, schema.TypeUnknown},
-		{"uuid", schema.TypeString, 0, 0, schema.TypeUnknown},
+		{"uuid", schema.TypeUUID, 0, 0, schema.TypeUnknown},
 		{"ipaddress", schema.TypeString, 0, 0, schema.TypeUnknown},
 		{"array(integer)", schema.TypeArray, 0, 0, schema.TypeInt64},
 		{"array(varchar)", schema.TypeArray, 0, 0, schema.TypeString},

--- a/pkg/source/trino/trino.go
+++ b/pkg/source/trino/trino.go
@@ -294,11 +294,12 @@ func (s *TrinoSource) buildSelectQuery(table string, columns []schema.Column, op
 
 	var conditions []string
 	if opts.IncrementalKey != "" {
+		incrementalCol := findColumn(columns, opts.IncrementalKey)
 		if opts.IntervalStart != nil {
-			conditions = append(conditions, fmt.Sprintf(`"%s" >= TIMESTAMP '%s'`, opts.IncrementalKey, opts.IntervalStart.Format("2006-01-02 15:04:05.000000")))
+			conditions = append(conditions, fmt.Sprintf(`"%s" >= %s`, opts.IncrementalKey, formatIncrementalLiteral(incrementalCol, *opts.IntervalStart)))
 		}
 		if opts.IntervalEnd != nil {
-			conditions = append(conditions, fmt.Sprintf(`"%s" <= TIMESTAMP '%s'`, opts.IncrementalKey, opts.IntervalEnd.Format("2006-01-02 15:04:05.000000")))
+			conditions = append(conditions, fmt.Sprintf(`"%s" <= %s`, opts.IncrementalKey, formatIncrementalLiteral(incrementalCol, *opts.IntervalEnd)))
 		}
 	}
 
@@ -311,6 +312,33 @@ func (s *TrinoSource) buildSelectQuery(table string, columns []schema.Column, op
 	}
 
 	return query
+}
+
+func findColumn(columns []schema.Column, name string) *schema.Column {
+	for i := range columns {
+		if strings.EqualFold(columns[i].Name, name) {
+			return &columns[i]
+		}
+	}
+	return nil
+}
+
+// formatIncrementalLiteral emits a typed Trino literal — Trino rejects
+// comparisons between mismatched literal/column types (e.g. TIMESTAMP vs DATE).
+func formatIncrementalLiteral(col *schema.Column, t time.Time) string {
+	if col == nil {
+		return fmt.Sprintf("TIMESTAMP '%s'", t.Format("2006-01-02 15:04:05.000000"))
+	}
+	switch col.DataType {
+	case schema.TypeDate:
+		return fmt.Sprintf("DATE '%s'", t.Format("2006-01-02"))
+	case schema.TypeTime:
+		return fmt.Sprintf("TIME '%s'", t.Format("15:04:05.000000"))
+	case schema.TypeTimestampTZ:
+		return fmt.Sprintf("TIMESTAMP '%s UTC'", t.UTC().Format("2006-01-02 15:04:05.000000"))
+	default:
+		return fmt.Sprintf("TIMESTAMP '%s'", t.Format("2006-01-02 15:04:05.000000"))
+	}
 }
 
 func filterColumns(columns []schema.Column, exclude []string) []schema.Column {


### PR DESCRIPTION
## Summary

Source-only Trino fixes:

- **Type-aware incremental WHERE literals.** `buildSelectQuery` previously always emitted `TIMESTAMP '...'` for `IntervalStart` / `IntervalEnd`. Trino is strict about literal types, so a TIMESTAMP literal against a `DATE` or `TIME` column raises a comparison error. The source now looks up the incremental column from the table schema and emits `DATE '...'` / `TIME '...'` / `TIMESTAMP '...'` / `TIMESTAMP '... UTC'` to match.
- **UUID type fidelity.** `MapTrinoToDataType` now maps Trino `UUID` columns to `schema.TypeUUID` (was `TypeString`). The mapping flows through to the Arrow schema and downstream destinations that distinguish UUIDs from generic strings.
- Added unit tests covering `formatIncrementalLiteral` (date/time/timestamp/timestamp_tz/nil/fallback) and the case-insensitive `findColumn` helper.

## Out of scope (will be separate PRs)

- Destination-side type collapse and prepared INSERTs.
- Shared `internal/trinouri` package and the new auth methods (mTLS, http_headers, v0 aliases).
- Athena schema-evolution dialect split.
- Doc rewrites.

## Test plan

- [x] `go test ./pkg/source/trino/...` — pass
- [ ] Manual smoke against Trino with `DATE` and `TIME` typed incremental columns to confirm Trino accepts the new WHERE literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)