### PR TITLE
refactor(athena): split schema-evolution dialect out of trino package

### DIFF
--- a/pkg/destination/athena/dialect.go
+++ b/pkg/destination/athena/dialect.go
@@ -1,4 +1,4 @@
-package trino
+package athena
 
 import (
 	"fmt"
@@ -8,14 +8,15 @@ import (
 )
 
 func init() {
-	schemaevolution.RegisterDialect("trino", &Dialect{})
+	schemaevolution.RegisterDialect("athena", &Dialect{})
 }
 
-// Dialect implements the schemaevolution.Dialect interface for Trino.
+// Dialect implements schemaevolution.Dialect for Athena. Athena's SQL grammar
+// is Trino-compatible, so this mirrors the historical shared Trino dialect.
 type Dialect struct{}
 
 func (d *Dialect) Name() string {
-	return "Trino"
+	return "Athena"
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {


### PR DESCRIPTION
## Summary

Athena's schema-evolution dialect lived in \`pkg/destination/trino/dialect.go\` and was registered via a second \`RegisterDialect(\"athena\", ...)\` call inside Trino's \`init()\`. That coupling meant any future change to Trino's \`TypeName\` would silently mutate Athena's \`ALTER ADD COLUMN\` emission — and Athena's CREATE-time mapper (\`athenaCastTypeForColumn\` in \`sql.go\`) uses native widths, so any drift between CREATE and ALTER would produce inconsistent columns within the same Athena table.

This PR moves Athena's dialect into its own file. The \`TypeName\` logic is a verbatim copy of the old shared dialect, so Athena's SQL output is byte-for-byte identical.

## Behavior change

**Zero functional change.** The only observable difference is one warning-text string: when a column type-change is skipped, the message now reads *\"Athena does not support ALTER COLUMN TYPE\"* instead of *\"Trino does not support ALTER COLUMN TYPE\"* (\`pkg/schemaevolution/migrate.go:49\`). Strictly an accuracy improvement.

## Motivation

This unblocks future work on the Trino destination (type-mapping collapse to v0-compat, prepared INSERTs) without affecting Athena.