### PR TITLE
fix: escape SQL identifiers to prevent injection (go/sql-injection)

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -879,12 +879,12 @@ func (d *BigQueryDestination) SwapTable(ctx context.Context, opts destination.Sw
 		return nil
 	}
 
-	stagingFQN := fmt.Sprintf("`%s`.`%s`.`%s`", d.projectID, stagingDataset, stagingTableName)
+	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(d.projectID), quoteIdentifier(stagingDataset), quoteIdentifier(stagingTableName))
 	selectClause := buildBigQueryDedupSelect(stagingFQN, opts.PrimaryKeys, opts.IncrementalKey)
 
 	if d.partitionBy != "" || len(d.clusterBy) > 0 {
 		// For partitioned/clustered tables, must use SQL to apply partitioning
-		sql := fmt.Sprintf("CREATE OR REPLACE TABLE `%s`.`%s`.`%s`\n", d.projectID, targetDataset, targetTableName)
+		sql := fmt.Sprintf("CREATE OR REPLACE TABLE %s.%s.%s\n", quoteIdentifier(d.projectID), quoteIdentifier(targetDataset), quoteIdentifier(targetTableName))
 
 		if d.partitionBy != "" {
 			sql += partitionByClause(d.partitionBy, isDatePartitionColumn(opts.Schema, d.partitionBy))
@@ -893,7 +893,7 @@ func (d *BigQueryDestination) SwapTable(ctx context.Context, opts destination.Sw
 		if len(d.clusterBy) > 0 {
 			clusterCols := make([]string, len(d.clusterBy))
 			for i, col := range d.clusterBy {
-				clusterCols[i] = "`" + col + "`"
+				clusterCols[i] = quoteIdentifier(col)
 			}
 			sql += fmt.Sprintf("CLUSTER BY %s\n", strings.Join(clusterCols, ", "))
 		}
@@ -912,8 +912,8 @@ func (d *BigQueryDestination) SwapTable(ctx context.Context, opts destination.Sw
 	} else {
 		// Use SQL CREATE OR REPLACE TABLE AS SELECT * — Copy Jobs don't read
 		// from the streaming buffer, so they'd copy 0 rows after Storage Write API writes.
-		sql := fmt.Sprintf("CREATE OR REPLACE TABLE `%s`.`%s`.`%s` AS %s",
-			d.projectID, targetDataset, targetTableName, selectClause)
+		sql := fmt.Sprintf("CREATE OR REPLACE TABLE %s.%s.%s AS %s",
+			quoteIdentifier(d.projectID), quoteIdentifier(targetDataset), quoteIdentifier(targetTableName), selectClause)
 
 		config.Debug("[DEST] Executing SQL swap: %s", sql)
 
@@ -1135,35 +1135,35 @@ func (d *BigQueryDestination) buildAlterColumnTypeRewriteSQL(
 	foundColumn := false
 	for _, field := range meta.Schema {
 		if field.Name == columnName {
-			selectExprs = append(selectExprs, fmt.Sprintf("CAST(`%s` AS %s) AS `%s`", field.Name, newType, field.Name))
+			selectExprs = append(selectExprs, fmt.Sprintf("CAST(%s AS %s) AS %s", quoteIdentifier(field.Name), newType, quoteIdentifier(field.Name)))
 			foundColumn = true
 			continue
 		}
-		selectExprs = append(selectExprs, fmt.Sprintf("`%s`", field.Name))
+		selectExprs = append(selectExprs, quoteIdentifier(field.Name))
 	}
 	if !foundColumn {
 		return "", fmt.Errorf("column %q not found in table metadata", columnName)
 	}
 
 	var sqlBuilder strings.Builder
-	fmt.Fprintf(&sqlBuilder, "CREATE OR REPLACE TABLE `%s`.`%s`.`%s`\n", d.projectID, dataset, table)
+	fmt.Fprintf(&sqlBuilder, "CREATE OR REPLACE TABLE %s.%s.%s\n", quoteIdentifier(d.projectID), quoteIdentifier(dataset), quoteIdentifier(table))
 	if meta.TimePartitioning != nil && meta.TimePartitioning.Field != "" {
 		sqlBuilder.WriteString(partitionByClause(meta.TimePartitioning.Field, partitionFieldIsDate(meta.Schema, meta.TimePartitioning.Field)))
 	}
 	if meta.Clustering != nil && len(meta.Clustering.Fields) > 0 {
 		clusterCols := make([]string, len(meta.Clustering.Fields))
 		for i, field := range meta.Clustering.Fields {
-			clusterCols[i] = fmt.Sprintf("`%s`", field)
+			clusterCols[i] = quoteIdentifier(field)
 		}
 		fmt.Fprintf(&sqlBuilder, "CLUSTER BY %s\n", strings.Join(clusterCols, ", "))
 	}
 	fmt.Fprintf(
 		&sqlBuilder,
-		"AS SELECT %s FROM `%s`.`%s`.`%s`",
+		"AS SELECT %s FROM %s.%s.%s",
 		strings.Join(selectExprs, ", "),
-		d.projectID,
-		dataset,
-		table,
+		quoteIdentifier(d.projectID),
+		quoteIdentifier(dataset),
+		quoteIdentifier(table),
 	)
 
 	return sqlBuilder.String(), nil
@@ -1381,7 +1381,7 @@ func (d *BigQueryDestination) SCD2Table(ctx context.Context, opts destination.SC
 }
 
 func quoteIdentifier(s string) string {
-	return fmt.Sprintf("`%s`", s)
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(s, "`", "``"))
 }
 
 func filterColumns(columns []string, exclude []string) []string {

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -152,7 +152,7 @@ func (d *MSSQLDestination) ensureSchemaExists(ctx context.Context, schemaName st
 	createSchemaSQL := fmt.Sprintf(
 		"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') EXEC('CREATE SCHEMA [%s]')",
 		strings.ReplaceAll(schemaName, "'", "''"),
-		strings.ReplaceAll(schemaName, "]", "]]"),
+		strings.ReplaceAll(strings.ReplaceAll(schemaName, "]", "]]"), "'", "''"),
 	)
 	if _, err := d.db.ExecContext(ctx, createSchemaSQL); err != nil {
 		config.LogFailedQuery(createSchemaSQL, err)
@@ -344,7 +344,7 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 			_ = tx.Rollback()
 			return fmt.Errorf("failed to ensure target schema exists: %w", err)
 		}
-		transferSQL := fmt.Sprintf("ALTER SCHEMA [%s] TRANSFER %s", targetSchema, quoteTable(stagingTable))
+		transferSQL := fmt.Sprintf("ALTER SCHEMA %s TRANSFER %s", quoteIdentifier(targetSchema), quoteTable(stagingTable))
 		if _, err := tx.ExecContext(ctx, transferSQL); err != nil {
 			config.LogFailedQuery(transferSQL, err)
 			_ = tx.Rollback()
@@ -365,7 +365,7 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 
 	if exists > 0 {
 		renameSQL := fmt.Sprintf("EXEC sp_rename '%s', '%s'",
-			escapeTableNameForRename(targetTable), extractTableName(oldTable))
+			escapeTableNameForRename(targetTable), escapeTableNameForRename(extractTableName(oldTable)))
 		if _, err := tx.ExecContext(ctx, renameSQL); err != nil {
 			config.LogFailedQuery(renameSQL, err)
 			_ = tx.Rollback()
@@ -373,7 +373,7 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 		}
 
 		renameSQL = fmt.Sprintf("EXEC sp_rename '%s', '%s'",
-			escapeTableNameForRename(stagingTable), extractTableName(targetTable))
+			escapeTableNameForRename(stagingTable), escapeTableNameForRename(extractTableName(targetTable)))
 		if _, err := tx.ExecContext(ctx, renameSQL); err != nil {
 			config.LogFailedQuery(renameSQL, err)
 			_ = tx.Rollback()
@@ -389,7 +389,7 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 		}
 	} else {
 		renameSQL := fmt.Sprintf("EXEC sp_rename '%s', '%s'",
-			escapeTableNameForRename(stagingTable), extractTableName(targetTable))
+			escapeTableNameForRename(stagingTable), escapeTableNameForRename(extractTableName(targetTable)))
 		if _, err := tx.ExecContext(ctx, renameSQL); err != nil {
 			config.LogFailedQuery(renameSQL, err)
 			_ = tx.Rollback()
@@ -427,14 +427,16 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
-		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
+		quotedPK := quoteIdentifier(pk)
+		onConditions[i] = fmt.Sprintf("target.%s = source.%s", quotedPK, quotedPK)
 	}
 
 	var updateSet string
 	if len(nonPKColumns) > 0 {
 		updates := make([]string, len(nonPKColumns))
 		for i, col := range nonPKColumns {
-			updates[i] = fmt.Sprintf("target.[%s] = source.[%s]", col, col)
+			quotedCol := quoteIdentifier(col)
+			updates[i] = fmt.Sprintf("target.%s = source.%s", quotedCol, quotedCol)
 		}
 		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
 	}
@@ -483,9 +485,10 @@ func (d *MSSQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	quotedIncrementalKey := quoteIdentifier(opts.IncrementalKey)
 	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE [%s] >= @p1 AND [%s] <= @p2",
-		quoteTable(opts.TargetTable), opts.IncrementalKey, opts.IncrementalKey,
+		"DELETE FROM %s WHERE %s >= @p1 AND %s <= @p2",
+		quoteTable(opts.TargetTable), quotedIncrementalKey, quotedIncrementalKey,
 	)
 	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
@@ -750,18 +753,22 @@ func mapMSSQLTypeToSchema(dataType string) schema.DataType {
 	}
 }
 
+func quoteIdentifier(s string) string {
+	return "[" + strings.ReplaceAll(s, "]", "]]") + "]"
+}
+
 func quoteTable(table string) string {
 	parts := strings.SplitN(table, ".", 2)
 	if len(parts) == 2 {
-		return fmt.Sprintf("[%s].[%s]", parts[0], parts[1])
+		return fmt.Sprintf("%s.%s", quoteIdentifier(parts[0]), quoteIdentifier(parts[1]))
 	}
-	return fmt.Sprintf("[%s]", table)
+	return quoteIdentifier(table)
 }
 
 func quoteColumns(columns []string) []string {
 	quoted := make([]string, len(columns))
 	for i, col := range columns {
-		quoted[i] = fmt.Sprintf("[%s]", col)
+		quoted[i] = quoteIdentifier(col)
 	}
 	return quoted
 }
@@ -789,7 +796,8 @@ func extractTableName(table string) string {
 func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
 	conditions := make([]string, len(keys))
 	for i, key := range keys {
-		conditions[i] = fmt.Sprintf("%s.[%s] = %s.[%s]", targetAlias, key, sourceAlias, key)
+		quotedKey := quoteIdentifier(key)
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quotedKey, sourceAlias, quotedKey)
 	}
 	return strings.Join(conditions, " AND ")
 }
@@ -802,11 +810,12 @@ func buildChangeConditionsMSSQL(columns []string, targetAlias, sourceAlias strin
 	conditions := make([]string, len(columns))
 	for i, col := range columns {
 		// MSSQL doesn't have IS DISTINCT FROM, use ISNULL or COALESCE comparison
+		quotedCol := quoteIdentifier(col)
 		conditions[i] = fmt.Sprintf(
-			`((%s.[%s] IS NULL AND %s.[%s] IS NOT NULL) OR (%s.[%s] IS NOT NULL AND %s.[%s] IS NULL) OR %s.[%s] <> %s.[%s])`,
-			targetAlias, col, sourceAlias, col,
-			targetAlias, col, sourceAlias, col,
-			targetAlias, col, sourceAlias, col,
+			`((%s.%s IS NULL AND %s.%s IS NOT NULL) OR (%s.%s IS NOT NULL AND %s.%s IS NULL) OR %s.%s <> %s.%s)`,
+			targetAlias, quotedCol, sourceAlias, quotedCol,
+			targetAlias, quotedCol, sourceAlias, quotedCol,
+			targetAlias, quotedCol, sourceAlias, quotedCol,
 		)
 	}
 	return strings.Join(conditions, " OR ")
@@ -829,7 +838,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := mapColumnTypeForCreate(col, primaryKeySet[strings.ToLower(col.Name)])
-		colDefs = append(colDefs, fmt.Sprintf("[%s] %s", col.Name, colType))
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
 	}
 
 	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))
@@ -837,7 +846,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	if len(primaryKeys) > 0 {
 		quotedKeys := make([]string, len(primaryKeys))
 		for i, k := range primaryKeys {
-			quotedKeys[i] = fmt.Sprintf("[%s]", k)
+			quotedKeys[i] = quoteIdentifier(k)
 		}
 		createPart += fmt.Sprintf(",\n  PRIMARY KEY (%s)", strings.Join(quotedKeys, ", "))
 	}

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -154,8 +154,7 @@ func (d *MySQLDestination) ensureDatabaseExists(ctx context.Context, database st
 	if exists {
 		return nil
 	}
-	escaped := strings.ReplaceAll(database, "`", "``")
-	createSQL := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", escaped)
+	createSQL := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdentifier(database))
 	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
 		config.LogFailedQuery(createSQL, err)
 		return fmt.Errorf("failed to create database %s: %w", database, err)
@@ -241,7 +240,7 @@ func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.Re
 	colNames := make([]string, numCols)
 	placeholders := make([]string, numCols)
 	for i := 0; i < numCols; i++ {
-		colNames[i] = fmt.Sprintf("`%s`", record.Schema().Field(i).Name)
+		colNames[i] = quoteIdentifier(record.Schema().Field(i).Name)
 		placeholders[i] = "?"
 	}
 
@@ -432,8 +431,8 @@ func (d *MySQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	defer func() { _ = tx.Rollback() }()
 
 	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE `%s` >= ? AND `%s` <= ?",
-		quoteTable(opts.TargetTable), opts.IncrementalKey, opts.IncrementalKey,
+		"DELETE FROM %s WHERE %s >= ? AND %s <= ?",
+		quoteTable(opts.TargetTable), quoteIdentifier(opts.IncrementalKey), quoteIdentifier(opts.IncrementalKey),
 	)
 	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
@@ -713,18 +712,22 @@ func mapMySQLTypeToSchema(dataType, columnType string) schema.DataType {
 	}
 }
 
+func quoteIdentifier(s string) string {
+	return "`" + strings.ReplaceAll(s, "`", "``") + "`"
+}
+
 func quoteTable(table string) string {
 	parts := strings.SplitN(table, ".", 2)
 	if len(parts) == 2 {
-		return fmt.Sprintf("`%s`.`%s`", parts[0], parts[1])
+		return quoteIdentifier(parts[0]) + "." + quoteIdentifier(parts[1])
 	}
-	return fmt.Sprintf("`%s`", table)
+	return quoteIdentifier(table)
 }
 
 func quoteColumns(columns []string) []string {
 	quoted := make([]string, len(columns))
 	for i, col := range columns {
-		quoted[i] = fmt.Sprintf("`%s`", col)
+		quoted[i] = quoteIdentifier(col)
 	}
 	return quoted
 }
@@ -747,7 +750,7 @@ func filterColumns(columns []string, exclude []string) []string {
 func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
 	conditions := make([]string, len(keys))
 	for i, key := range keys {
-		conditions[i] = fmt.Sprintf("%s.`%s` = %s.`%s`", targetAlias, key, sourceAlias, key)
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteIdentifier(key), sourceAlias, quoteIdentifier(key))
 	}
 	return strings.Join(conditions, " AND ")
 }
@@ -755,13 +758,13 @@ func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
 func buildUpdateSet(columns []string, targetAlias, sourceAlias string) string {
 	sets := make([]string, len(columns))
 	for i, col := range columns {
-		sets[i] = fmt.Sprintf("%s.`%s` = %s.`%s`", targetAlias, col, sourceAlias, col)
+		sets[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteIdentifier(col), sourceAlias, quoteIdentifier(col))
 	}
 	return strings.Join(sets, ", ")
 }
 
 func quoteColumn(col string) string {
-	return fmt.Sprintf("`%s`", col)
+	return quoteIdentifier(col)
 }
 
 // buildChangeConditionsMySQL builds change detection conditions using COALESCE for NULL handling.
@@ -786,7 +789,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToMySQL(col)
-		colDefs = append(colDefs, fmt.Sprintf("`%s` %s", col.Name, colType))
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))
@@ -794,7 +797,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	if len(primaryKeys) > 0 {
 		quotedKeys := make([]string, len(primaryKeys))
 		for i, k := range primaryKeys {
-			quotedKeys[i] = fmt.Sprintf("`%s`", k)
+			quotedKeys[i] = quoteIdentifier(k)
 		}
 		sql += fmt.Sprintf(",\n  PRIMARY KEY (%s)", strings.Join(quotedKeys, ", "))
 	}

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -169,7 +169,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 
 	// Use the implicit table stage (@%table_name) which exists automatically
 	// for every table and doesn't require CREATE STAGE privilege
-	stageName := fmt.Sprintf(`%s.%%"%s"`, quoteIdentifier(schemaName), tableName)
+	stageName := fmt.Sprintf(`%s.%%"%s"`, quoteIdentifier(schemaName), strings.ReplaceAll(strings.ToUpper(tableName), `"`, `""`))
 	loadID := fmt.Sprintf("%d", time.Now().UnixNano())
 
 	type uploadResult struct {
@@ -861,7 +861,7 @@ func quoteIdentifier(name string) string {
 	if strings.HasPrefix(name, `"`) && strings.HasSuffix(name, `"`) {
 		return name
 	}
-	return fmt.Sprintf(`"%s"`, strings.ToUpper(name))
+	return `"` + strings.ReplaceAll(strings.ToUpper(name), `"`, `""`) + `"`
 }
 
 func quoteColumns(cols []string) []string {
@@ -890,7 +890,7 @@ func filterColumns(columns []string, exclude []string) []string {
 func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
 	conditions := make([]string, len(keys))
 	for i, key := range keys {
-		conditions[i] = fmt.Sprintf(`%s."%s" = %s."%s"`, targetAlias, strings.ToUpper(key), sourceAlias, strings.ToUpper(key))
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteIdentifier(key), sourceAlias, quoteIdentifier(key))
 	}
 	return strings.Join(conditions, " AND ")
 }
@@ -902,7 +902,7 @@ func buildChangeConditionsSnowflake(columns []string, targetAlias, sourceAlias s
 	conditions := make([]string, len(columns))
 	for i, col := range columns {
 		// Snowflake supports IS DISTINCT FROM
-		conditions[i] = fmt.Sprintf(`%s."%s" IS DISTINCT FROM %s."%s"`, targetAlias, strings.ToUpper(col), sourceAlias, strings.ToUpper(col))
+		conditions[i] = fmt.Sprintf("%s.%s IS DISTINCT FROM %s.%s", targetAlias, quoteIdentifier(col), sourceAlias, quoteIdentifier(col))
 	}
 	return strings.Join(conditions, " OR ")
 }

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -244,7 +244,7 @@ func (d *SQLiteDestination) writeRecordBatch(ctx context.Context, record arrow.R
 	colNames := make([]string, numCols)
 	placeholders := make([]string, numCols)
 	for i := 0; i < numCols; i++ {
-		colNames[i] = fmt.Sprintf(`"%s"`, record.Schema().Field(i).Name)
+		colNames[i] = destination.QuoteIdentifier(record.Schema().Field(i).Name)
 		placeholders[i] = "?"
 	}
 
@@ -502,8 +502,8 @@ func (d *SQLiteDestination) DeleteInsertTable(ctx context.Context, opts destinat
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
 
 	deleteSQL := fmt.Sprintf(
-		`DELETE FROM %s WHERE "%s" >= ? AND "%s" <= ?`,
-		quotedTargetTable, opts.IncrementalKey, opts.IncrementalKey,
+		`DELETE FROM %s WHERE %s >= ? AND %s <= ?`,
+		quotedTargetTable, destination.QuoteIdentifier(opts.IncrementalKey), destination.QuoteIdentifier(opts.IncrementalKey),
 	)
 	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
@@ -747,7 +747,7 @@ func mapSQLiteTypeToSchema(colType string) schema.DataType {
 func quoteColumns(columns []string) []string {
 	quoted := make([]string, len(columns))
 	for i, col := range columns {
-		quoted[i] = fmt.Sprintf(`"%s"`, col)
+		quoted[i] = destination.QuoteIdentifier(col)
 	}
 	return quoted
 }
@@ -772,7 +772,7 @@ func filterColumns(columns []string, exclude []string) []string {
 func buildJoinConditionSQLite(keys []string, targetAlias, sourceAlias string) string {
 	conditions := make([]string, len(keys))
 	for i, key := range keys {
-		conditions[i] = fmt.Sprintf(`%s."%s" = %s."%s"`, targetAlias, key, sourceAlias, key)
+		conditions[i] = fmt.Sprintf(`%s.%s = %s.%s`, targetAlias, destination.QuoteIdentifier(key), sourceAlias, destination.QuoteIdentifier(key))
 	}
 	return strings.Join(conditions, " AND ")
 }
@@ -781,7 +781,7 @@ func buildJoinConditionSQLite(keys []string, targetAlias, sourceAlias string) st
 func buildUpdateSetSQLite(columns []string, sourceAlias string) string {
 	sets := make([]string, len(columns))
 	for i, col := range columns {
-		sets[i] = fmt.Sprintf(`"%s" = %s."%s"`, col, sourceAlias, col)
+		sets[i] = fmt.Sprintf(`%s = %s.%s`, destination.QuoteIdentifier(col), sourceAlias, destination.QuoteIdentifier(col))
 	}
 	return strings.Join(sets, ", ")
 }
@@ -793,7 +793,7 @@ func buildChangeConditionsSQLite(columns []string, targetAlias, sourceAlias stri
 	}
 	conditions := make([]string, len(columns))
 	for i, col := range columns {
-		conditions[i] = fmt.Sprintf(`%s."%s" IS NOT %s."%s"`, targetAlias, col, sourceAlias, col)
+		conditions[i] = fmt.Sprintf(`%s.%s IS NOT %s.%s`, targetAlias, destination.QuoteIdentifier(col), sourceAlias, destination.QuoteIdentifier(col))
 	}
 	return strings.Join(conditions, " OR ")
 }
@@ -831,7 +831,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToSQLite(col)
-		colDefs = append(colDefs, fmt.Sprintf(`"%s" %s`, col.Name, colType))
+		colDefs = append(colDefs, fmt.Sprintf(`%s %s`, destination.QuoteIdentifier(col.Name), colType))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", table, strings.Join(colDefs, ",\n  "))
@@ -839,7 +839,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	if len(primaryKeys) > 0 {
 		quotedKeys := make([]string, len(primaryKeys))
 		for i, k := range primaryKeys {
-			quotedKeys[i] = fmt.Sprintf(`"%s"`, k)
+			quotedKeys[i] = destination.QuoteIdentifier(k)
 		}
 		sql += fmt.Sprintf(",\n  PRIMARY KEY (%s)", strings.Join(quotedKeys, ", "))
 	}

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -243,7 +243,7 @@ func (d *SynapseDestination) writeRecordBatch(ctx context.Context, record arrow.
 
 	colNames := make([]string, numCols)
 	for i := 0; i < numCols; i++ {
-		colNames[i] = fmt.Sprintf("[%s]", record.Schema().Field(i).Name)
+		colNames[i] = quoteIdentifier(record.Schema().Field(i).Name)
 	}
 	colList := strings.Join(colNames, ", ")
 
@@ -316,7 +316,7 @@ func (d *SynapseDestination) SwapTable(ctx context.Context, opts destination.Swa
 		if err := d.ensureSchemaExists(ctx, schemaName); err != nil {
 			return fmt.Errorf("failed to ensure target schema exists: %w", err)
 		}
-		transferSQL := fmt.Sprintf("ALTER SCHEMA [%s] TRANSFER %s", schemaName, quoteTable(stagingTable))
+		transferSQL := fmt.Sprintf("ALTER SCHEMA %s TRANSFER %s", quoteIdentifier(schemaName), quoteTable(stagingTable))
 		if _, err := d.db.ExecContext(ctx, transferSQL); err != nil {
 			config.LogFailedQuery(transferSQL, err)
 			return fmt.Errorf("failed to transfer staging table to target schema: %w", err)
@@ -330,8 +330,8 @@ func (d *SynapseDestination) SwapTable(ctx context.Context, opts destination.Swa
 				return
 			}
 			currentLocation := schemaName + "." + stagingName
-			reverseSQL := fmt.Sprintf("ALTER SCHEMA [%s] TRANSFER %s",
-				stagingSchema, quoteTable(currentLocation))
+			reverseSQL := fmt.Sprintf("ALTER SCHEMA %s TRANSFER %s",
+				quoteIdentifier(stagingSchema), quoteTable(currentLocation))
 			if _, rbErr := d.db.ExecContext(ctx, reverseSQL); rbErr != nil {
 				config.Debug("[Synapse] Failed to reverse-transfer staging back to %s: %v", stagingSchema, rbErr)
 			}
@@ -349,20 +349,20 @@ func (d *SynapseDestination) SwapTable(ctx context.Context, opts destination.Swa
 	}
 
 	if exists > 0 {
-		renameSQL := fmt.Sprintf("RENAME OBJECT %s TO [%s]",
-			quoteTable(targetTable), oldTableName)
+		renameSQL := fmt.Sprintf("RENAME OBJECT %s TO %s",
+			quoteTable(targetTable), quoteIdentifier(oldTableName))
 		if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
 			config.LogFailedQuery(renameSQL, err)
 			return fmt.Errorf("failed to rename target table: %w", err)
 		}
 
-		renameSQL = fmt.Sprintf("RENAME OBJECT %s TO [%s]",
-			quoteTable(stagingTable), extractTableName(targetTable))
+		renameSQL = fmt.Sprintf("RENAME OBJECT %s TO %s",
+			quoteTable(stagingTable), quoteIdentifier(extractTableName(targetTable)))
 		if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
 			config.LogFailedQuery(renameSQL, err)
 			// Rollback: rename _old back to original target
-			rollbackSQL := fmt.Sprintf("RENAME OBJECT %s TO [%s]",
-				quoteTable(oldTable), extractTableName(targetTable))
+			rollbackSQL := fmt.Sprintf("RENAME OBJECT %s TO %s",
+				quoteTable(oldTable), quoteIdentifier(extractTableName(targetTable)))
 			if _, rbErr := d.db.ExecContext(ctx, rollbackSQL); rbErr != nil {
 				config.Debug("[Synapse] Rollback rename also failed: %v", rbErr)
 			}
@@ -378,8 +378,8 @@ func (d *SynapseDestination) SwapTable(ctx context.Context, opts destination.Swa
 			return fmt.Errorf("failed to drop old table: %w", err)
 		}
 	} else {
-		renameSQL := fmt.Sprintf("RENAME OBJECT %s TO [%s]",
-			quoteTable(stagingTable), extractTableName(targetTable))
+		renameSQL := fmt.Sprintf("RENAME OBJECT %s TO %s",
+			quoteTable(stagingTable), quoteIdentifier(extractTableName(targetTable)))
 		if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
 			config.LogFailedQuery(renameSQL, err)
 			return fmt.Errorf("failed to rename staging table: %w", err)
@@ -414,14 +414,14 @@ func (d *SynapseDestination) MergeTable(ctx context.Context, opts destination.Me
 func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
-		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
+		onConditions[i] = fmt.Sprintf("target.%s = source.%s", quoteIdentifier(pk), quoteIdentifier(pk))
 	}
 
 	var updateSet string
 	if len(nonPKColumns) > 0 {
 		updates := make([]string, len(nonPKColumns))
 		for i, col := range nonPKColumns {
-			updates[i] = fmt.Sprintf("target.[%s] = source.[%s]", col, col)
+			updates[i] = fmt.Sprintf("target.%s = source.%s", quoteIdentifier(col), quoteIdentifier(col))
 		}
 		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
 	}
@@ -470,8 +470,8 @@ func (d *SynapseDestination) DeleteInsertTable(ctx context.Context, opts destina
 	defer func() { _ = tx.Rollback() }()
 
 	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE [%s] >= @p1 AND [%s] <= @p2",
-		quoteTable(opts.TargetTable), opts.IncrementalKey, opts.IncrementalKey,
+		"DELETE FROM %s WHERE %s >= @p1 AND %s <= @p2",
+		quoteTable(opts.TargetTable), quoteIdentifier(opts.IncrementalKey), quoteIdentifier(opts.IncrementalKey),
 	)
 	config.Debug("[Synapse DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
@@ -730,18 +730,22 @@ func mapSynapseTypeToSchema(dataType string) schema.DataType {
 	}
 }
 
+func quoteIdentifier(s string) string {
+	return "[" + strings.ReplaceAll(s, "]", "]]") + "]"
+}
+
 func quoteTable(table string) string {
 	parts := strings.SplitN(table, ".", 2)
 	if len(parts) == 2 {
-		return fmt.Sprintf("[%s].[%s]", parts[0], parts[1])
+		return fmt.Sprintf("%s.%s", quoteIdentifier(parts[0]), quoteIdentifier(parts[1]))
 	}
-	return fmt.Sprintf("[%s]", table)
+	return quoteIdentifier(table)
 }
 
 func quoteColumns(columns []string) []string {
 	quoted := make([]string, len(columns))
 	for i, col := range columns {
-		quoted[i] = fmt.Sprintf("[%s]", col)
+		quoted[i] = quoteIdentifier(col)
 	}
 	return quoted
 }
@@ -769,7 +773,7 @@ func extractTableName(table string) string {
 func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
 	conditions := make([]string, len(keys))
 	for i, key := range keys {
-		conditions[i] = fmt.Sprintf("%s.[%s] = %s.[%s]", targetAlias, key, sourceAlias, key)
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteIdentifier(key), sourceAlias, quoteIdentifier(key))
 	}
 	return strings.Join(conditions, " AND ")
 }
@@ -780,11 +784,12 @@ func buildChangeConditions(columns []string, targetAlias, sourceAlias string) st
 	}
 	conditions := make([]string, len(columns))
 	for i, col := range columns {
+		qc := quoteIdentifier(col)
 		conditions[i] = fmt.Sprintf(
-			`((%s.[%s] IS NULL AND %s.[%s] IS NOT NULL) OR (%s.[%s] IS NOT NULL AND %s.[%s] IS NULL) OR %s.[%s] <> %s.[%s])`,
-			targetAlias, col, sourceAlias, col,
-			targetAlias, col, sourceAlias, col,
-			targetAlias, col, sourceAlias, col,
+			`((%s.%s IS NULL AND %s.%s IS NOT NULL) OR (%s.%s IS NOT NULL AND %s.%s IS NULL) OR %s.%s <> %s.%s)`,
+			targetAlias, qc, sourceAlias, qc,
+			targetAlias, qc, sourceAlias, qc,
+			targetAlias, qc, sourceAlias, qc,
 		)
 	}
 	return strings.Join(conditions, " OR ")
@@ -798,7 +803,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToSynapse(col)
-		colDefs = append(colDefs, fmt.Sprintf("[%s] %s", col.Name, colType))
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
 	}
 
 	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))
@@ -806,7 +811,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	if len(primaryKeys) > 0 {
 		quotedKeys := make([]string, len(primaryKeys))
 		for i, k := range primaryKeys {
-			quotedKeys[i] = fmt.Sprintf("[%s]", k)
+			quotedKeys[i] = quoteIdentifier(k)
 		}
 		createPart += fmt.Sprintf(",\n  PRIMARY KEY NONCLUSTERED (%s) NOT ENFORCED", strings.Join(quotedKeys, ", "))
 	}

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -73,7 +73,7 @@ func (d *TrinoDestination) PrepareTable(ctx context.Context, opts destination.Pr
 
 	if opts.DropFirst {
 		startDrop := time.Now()
-		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS \"%s\".\"%s\".\"%s\"", catalog, schemaName, tableName)
+		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s.%s", quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(tableName))
 		if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
 			config.LogFailedQuery(dropSQL, err)
 			return fmt.Errorf("failed to drop table: %w", err)
@@ -98,11 +98,11 @@ func (d *TrinoDestination) ensureSchemaExists(ctx context.Context, catalog, sche
 		return nil
 	}
 
-	createSchemaSQL := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS \"%s\".\"%s\"", catalog, schemaName)
+	createSchemaSQL := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s.%s", quoteIdentifier(catalog), quoteIdentifier(schemaName))
 	if _, err := d.db.ExecContext(ctx, createSchemaSQL); err != nil {
 		// Some catalogs (like memory) don't support CREATE SCHEMA, but have a default schema
 		// Check if the schema already exists by querying information_schema
-		checkSQL := fmt.Sprintf("SELECT 1 FROM \"%s\".information_schema.schemata WHERE schema_name = '%s'", catalog, schemaName)
+		checkSQL := fmt.Sprintf("SELECT 1 FROM %s.information_schema.schemata WHERE schema_name = '%s'", quoteIdentifier(catalog), strings.ReplaceAll(schemaName, "'", "''"))
 		rows, checkErr := d.db.QueryContext(ctx, checkSQL)
 		if checkErr != nil {
 			config.LogFailedQuery(createSchemaSQL, err)
@@ -200,11 +200,11 @@ func (d *TrinoDestination) SwapTable(ctx context.Context, opts destination.SwapO
 	stagingCatalog, stagingSchema, stagingName := d.parseTableName(opts.StagingTable)
 	targetCatalog, targetSchema, targetName := d.parseTableName(opts.TargetTable)
 
-	stagingFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", stagingCatalog, stagingSchema, stagingName)
-	targetFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", targetCatalog, targetSchema, targetName)
+	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
+	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
 	oldNameCandidate := fmt.Sprintf("%s_old_%d", targetName, time.Now().UnixNano())
 	oldName := destination.ShortenIdentifier(oldNameCandidate, oldNameCandidate, destination.MaxIdentifierLength("trino"))
-	oldFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", targetCatalog, targetSchema, oldName)
+	oldFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(oldName))
 
 	// Replace only PrepareTables the staging side, so the target schema may
 	// not exist yet on first run with the _bruin_staging design.
@@ -240,27 +240,27 @@ func (d *TrinoDestination) MergeTable(ctx context.Context, opts destination.Merg
 	stagingCatalog, stagingSchema, stagingName := d.parseTableName(opts.StagingTable)
 	targetCatalog, targetSchema, targetName := d.parseTableName(opts.TargetTable)
 
-	stagingFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", stagingCatalog, stagingSchema, stagingName)
-	targetFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", targetCatalog, targetSchema, targetName)
+	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
+	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
 
 	var onConditions []string
 	for _, pk := range opts.PrimaryKeys {
-		onConditions = append(onConditions, fmt.Sprintf("t.\"%s\" = s.\"%s\"", pk, pk))
+		onConditions = append(onConditions, fmt.Sprintf("t.%s = s.%s", quoteIdentifier(pk), quoteIdentifier(pk)))
 	}
 
 	var updateSets []string
 	var insertCols []string
 	var insertVals []string
 	for _, col := range opts.Columns {
-		updateSets = append(updateSets, fmt.Sprintf("\"%s\" = s.\"%s\"", col, col))
-		insertCols = append(insertCols, fmt.Sprintf("\"%s\"", col))
-		insertVals = append(insertVals, fmt.Sprintf("s.\"%s\"", col))
+		updateSets = append(updateSets, fmt.Sprintf("%s = s.%s", quoteIdentifier(col), quoteIdentifier(col)))
+		insertCols = append(insertCols, quoteIdentifier(col))
+		insertVals = append(insertVals, fmt.Sprintf("s.%s", quoteIdentifier(col)))
 	}
 
 	// Build dedup subquery to handle duplicate PKs in staging
 	quotedPKsForPartition := make([]string, len(opts.PrimaryKeys))
 	for i, pk := range opts.PrimaryKeys {
-		quotedPKsForPartition[i] = fmt.Sprintf(`"%s"`, pk)
+		quotedPKsForPartition[i] = quoteIdentifier(pk)
 	}
 	dedupSource := fmt.Sprintf(
 		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
@@ -301,12 +301,14 @@ func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	stagingCatalog, stagingSchema, stagingName := d.parseTableName(opts.StagingTable)
 	targetCatalog, targetSchema, targetName := d.parseTableName(opts.TargetTable)
 
-	stagingFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", stagingCatalog, stagingSchema, stagingName)
-	targetFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", targetCatalog, targetSchema, targetName)
+	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
+	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
 
 	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE \"%s\" >= '%v' AND \"%s\" <= '%v'",
-		targetFQN, opts.IncrementalKey, opts.IntervalStart, opts.IncrementalKey, opts.IntervalEnd,
+		"DELETE FROM %s WHERE %s >= '%s' AND %s <= '%s'",
+		targetFQN,
+		quoteIdentifier(opts.IncrementalKey), escapeSQLValue(opts.IntervalStart),
+		quoteIdentifier(opts.IncrementalKey), escapeSQLValue(opts.IntervalEnd),
 	)
 	config.Debug("[TRINO DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
@@ -336,8 +338,8 @@ func (d *TrinoDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	stagingCatalog, stagingSchema, stagingName := d.parseTableName(opts.StagingTable)
 	targetCatalog, targetSchema, targetName := d.parseTableName(opts.TargetTable)
 
-	stagingFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", stagingCatalog, stagingSchema, stagingName)
-	targetFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", targetCatalog, targetSchema, targetName)
+	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
+	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
 
 	// Build column comparison for change detection (excluding SCD columns and PKs)
 	nonPKColumns := filterSCD2Columns(opts.Columns, opts.PrimaryKeys)
@@ -427,7 +429,7 @@ func (d *TrinoDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 
 func (d *TrinoDestination) DropTable(ctx context.Context, table string) error {
 	catalog, schemaName, tableName := d.parseTableName(table)
-	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS \"%s\".\"%s\".\"%s\"", catalog, schemaName, tableName)
+	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s.%s", quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(tableName))
 	if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
 		config.LogFailedQuery(dropSQL, err)
 		return fmt.Errorf("failed to drop table %s: %w", table, err)
@@ -556,12 +558,12 @@ func buildCreateTableSQL(catalog, schemaName, table string, columns []schema.Col
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToTrino(col)
-		colDefs = append(colDefs, fmt.Sprintf("\"%s\" %s", col.Name, colType))
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
 	}
 
 	sql := fmt.Sprintf(
-		"CREATE TABLE IF NOT EXISTS \"%s\".\"%s\".\"%s\" (\n  %s\n)",
-		catalog, schemaName, table,
+		"CREATE TABLE IF NOT EXISTS %s.%s.%s (\n  %s\n)",
+		quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(table),
 		strings.Join(colDefs, ",\n  "),
 	)
 
@@ -571,7 +573,7 @@ func buildCreateTableSQL(catalog, schemaName, table string, columns []schema.Col
 func buildInsertSQLWithValues(catalog, schemaName, table string, columns []string, record arrow.RecordBatch, startRow, endRow int) string {
 	quotedCols := make([]string, len(columns))
 	for i, col := range columns {
-		quotedCols[i] = fmt.Sprintf("\"%s\"", col)
+		quotedCols[i] = quoteIdentifier(col)
 	}
 
 	var rows []string
@@ -583,8 +585,8 @@ func buildInsertSQLWithValues(catalog, schemaName, table string, columns []strin
 		rows = append(rows, "("+strings.Join(values, ", ")+")")
 	}
 
-	return fmt.Sprintf("INSERT INTO \"%s\".\"%s\".\"%s\" (%s) VALUES %s",
-		catalog, schemaName, table,
+	return fmt.Sprintf("INSERT INTO %s.%s.%s (%s) VALUES %s",
+		quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(table),
 		strings.Join(quotedCols, ", "),
 		strings.Join(rows, ", "))
 }
@@ -700,10 +702,18 @@ func escapeString(s string) string {
 	return "'" + escaped + "'"
 }
 
+func quoteIdentifier(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+func escapeSQLValue(v interface{}) string {
+	return strings.ReplaceAll(fmt.Sprintf("%v", v), "'", "''")
+}
+
 func quoteColumns(columns []string) []string {
 	quoted := make([]string, len(columns))
 	for i, col := range columns {
-		quoted[i] = fmt.Sprintf("\"%s\"", col)
+		quoted[i] = quoteIdentifier(col)
 	}
 	return quoted
 }
@@ -728,7 +738,7 @@ func filterSCD2Columns(columns []string, exclude []string) []string {
 func buildSCD2PKMatchCondition(keys []string) string {
 	conditions := make([]string, len(keys))
 	for i, key := range keys {
-		conditions[i] = fmt.Sprintf(`source."%s" = "%s"`, key, key)
+		conditions[i] = fmt.Sprintf(`source.%s = %s`, quoteIdentifier(key), quoteIdentifier(key))
 	}
 	return strings.Join(conditions, " AND ")
 }
@@ -737,7 +747,7 @@ func buildSCD2PKMatchCondition(keys []string) string {
 func buildSCD2ChangeDetectionSubquery(stagingFQN string, primaryKeys, nonPKColumns []string) string {
 	pkConditions := make([]string, len(primaryKeys))
 	for i, key := range primaryKeys {
-		pkConditions[i] = fmt.Sprintf(`source."%s" = "%s"`, key, key)
+		pkConditions[i] = fmt.Sprintf(`source.%s = %s`, quoteIdentifier(key), quoteIdentifier(key))
 	}
 
 	if len(nonPKColumns) == 0 {
@@ -746,7 +756,7 @@ func buildSCD2ChangeDetectionSubquery(stagingFQN string, primaryKeys, nonPKColum
 
 	changeConditions := make([]string, len(nonPKColumns))
 	for i, col := range nonPKColumns {
-		changeConditions[i] = fmt.Sprintf(`"%s" IS DISTINCT FROM source."%s"`, col, col)
+		changeConditions[i] = fmt.Sprintf(`%s IS DISTINCT FROM source.%s`, quoteIdentifier(col), quoteIdentifier(col))
 	}
 
 	return fmt.Sprintf(`EXISTS (
@@ -760,7 +770,7 @@ func buildSCD2ChangeDetectionSubquery(stagingFQN string, primaryKeys, nonPKColum
 func buildSCD2NotExistsCondition(stagingFQN string, primaryKeys []string) string {
 	pkConditions := make([]string, len(primaryKeys))
 	for i, key := range primaryKeys {
-		pkConditions[i] = fmt.Sprintf(`source."%s" = "%s"`, key, key)
+		pkConditions[i] = fmt.Sprintf(`source.%s = %s`, quoteIdentifier(key), quoteIdentifier(key))
 	}
 
 	return fmt.Sprintf(`NOT EXISTS (
@@ -773,7 +783,7 @@ func buildSCD2NotExistsCondition(stagingFQN string, primaryKeys []string) string
 func buildSCD2InsertNotExistsCondition(targetFQN string, primaryKeys []string) string {
 	pkConditions := make([]string, len(primaryKeys))
 	for i, key := range primaryKeys {
-		pkConditions[i] = fmt.Sprintf(`target."%s" = source."%s"`, key, key)
+		pkConditions[i] = fmt.Sprintf(`target.%s = source.%s`, quoteIdentifier(key), quoteIdentifier(key))
 	}
 
 	return fmt.Sprintf(`NOT EXISTS (

--- a/pkg/source/adbc/query.go
+++ b/pkg/source/adbc/query.go
@@ -51,7 +51,7 @@ func BuildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 		colNames[i] = quoteFunc(col.Name)
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), table)
+	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), quoteTableName(table, quoteFunc))
 
 	var conditions []string
 	config.Debug("[QUERY] Building query with IncrementalKey=%s, IntervalStart=%v, IntervalEnd=%v", opts.IncrementalKey, opts.IntervalStart, opts.IntervalEnd)
@@ -80,18 +80,26 @@ func BuildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	return query
 }
 
+func quoteTableName(table string, quoteFunc func(string) string) string {
+	parts := strings.Split(table, ".")
+	for i, part := range parts {
+		parts[i] = quoteFunc(part)
+	}
+	return strings.Join(parts, ".")
+}
+
 // DefaultQuoteIdentifier provides the default quoting style (double quotes).
 // Used by PostgreSQL, DuckDB, Snowflake, BigQuery, SQL Server (ANSI mode).
 func DefaultQuoteIdentifier(name string) string {
-	return fmt.Sprintf(`"%s"`, name)
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
 }
 
 // BacktickQuoteIdentifier uses backticks for quoting (MySQL style).
 func BacktickQuoteIdentifier(name string) string {
-	return fmt.Sprintf("`%s`", name)
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
 }
 
 // BracketQuoteIdentifier uses brackets for quoting (SQL Server style).
 func BracketQuoteIdentifier(name string) string {
-	return fmt.Sprintf("[%s]", name)
+	return fmt.Sprintf("[%s]", strings.ReplaceAll(name, "]", "]]"))
 }

--- a/pkg/source/bigquery/dialect.go
+++ b/pkg/source/bigquery/dialect.go
@@ -207,7 +207,7 @@ func (d *Dialect) MapDataType(dbType string) (schema.DataType, int, int, schema.
 }
 
 func (d *Dialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf("`%s`", name)
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
 }
 
 func (d *Dialect) ParsePrimaryKeyResult(rawValue interface{}) []string {

--- a/pkg/source/duckdb/dialect.go
+++ b/pkg/source/duckdb/dialect.go
@@ -189,7 +189,7 @@ func (d *Dialect) MapDataType(dbType string) (schema.DataType, int, int, schema.
 }
 
 func (d *Dialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf(`"%s"`, name)
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
 }
 
 func (d *Dialect) ParsePrimaryKeyResult(rawValue interface{}) []string {

--- a/pkg/source/hana/hana.go
+++ b/pkg/source/hana/hana.go
@@ -426,7 +426,7 @@ func buildArrowSchema(columns []schema.Column) *arrow.Schema {
 func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOptions) string {
 	colNames := make([]string, len(columns))
 	for i, col := range columns {
-		colNames[i] = fmt.Sprintf("\"%s\"", col.Name)
+		colNames[i] = fmt.Sprintf("\"%s\"", strings.ReplaceAll(col.Name, "\"", "\"\""))
 	}
 
 	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), quoteTable(table))

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -525,7 +525,7 @@ func buildArrowSchema(columns []schema.Column) *arrow.Schema {
 func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOptions) string {
 	colNames := make([]string, len(columns))
 	for i, col := range columns {
-		colNames[i] = fmt.Sprintf("[%s]", col.Name)
+		colNames[i] = quoteIdentifier(col.Name)
 	}
 
 	// Handle TOP for limit (SQL Server uses TOP instead of LIMIT)
@@ -539,10 +539,10 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	var conditions []string
 	if opts.IncrementalKey != "" {
 		if opts.IntervalStart != nil {
-			conditions = append(conditions, fmt.Sprintf("[%s] >= '%s'", opts.IncrementalKey, opts.IntervalStart.Format("2006-01-02 15:04:05")))
+			conditions = append(conditions, fmt.Sprintf("%s >= '%s'", quoteIdentifier(opts.IncrementalKey), opts.IntervalStart.Format("2006-01-02 15:04:05")))
 		}
 		if opts.IntervalEnd != nil {
-			conditions = append(conditions, fmt.Sprintf("[%s] <= '%s'", opts.IncrementalKey, opts.IntervalEnd.Format("2006-01-02 15:04:05")))
+			conditions = append(conditions, fmt.Sprintf("%s <= '%s'", quoteIdentifier(opts.IncrementalKey), opts.IntervalEnd.Format("2006-01-02 15:04:05")))
 		}
 	}
 
@@ -553,12 +553,16 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	return query
 }
 
+func quoteIdentifier(s string) string {
+	return "[" + strings.ReplaceAll(s, "]", "]]") + "]"
+}
+
 func quoteTable(table string) string {
 	parts := strings.SplitN(table, ".", 2)
 	if len(parts) == 2 {
-		return fmt.Sprintf("[%s].[%s]", parts[0], parts[1])
+		return quoteIdentifier(parts[0]) + "." + quoteIdentifier(parts[1])
 	}
-	return fmt.Sprintf("[%s]", table)
+	return quoteIdentifier(table)
 }
 
 func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -420,7 +420,7 @@ func buildArrowSchema(columns []schema.Column) *arrow.Schema {
 func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOptions) string {
 	colNames := make([]string, len(columns))
 	for i, col := range columns {
-		colNames[i] = fmt.Sprintf("`%s`", col.Name)
+		colNames[i] = quoteIdentifier(col.Name)
 	}
 
 	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), quoteTable(table))
@@ -428,10 +428,10 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	var conditions []string
 	if opts.IncrementalKey != "" {
 		if opts.IntervalStart != nil {
-			conditions = append(conditions, fmt.Sprintf("`%s` >= '%s'", opts.IncrementalKey, opts.IntervalStart.Format("2006-01-02 15:04:05")))
+			conditions = append(conditions, fmt.Sprintf("%s >= '%s'", quoteIdentifier(opts.IncrementalKey), opts.IntervalStart.Format("2006-01-02 15:04:05")))
 		}
 		if opts.IntervalEnd != nil {
-			conditions = append(conditions, fmt.Sprintf("`%s` <= '%s'", opts.IncrementalKey, opts.IntervalEnd.Format("2006-01-02 15:04:05")))
+			conditions = append(conditions, fmt.Sprintf("%s <= '%s'", quoteIdentifier(opts.IncrementalKey), opts.IntervalEnd.Format("2006-01-02 15:04:05")))
 		}
 	}
 
@@ -446,12 +446,16 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	return query
 }
 
+func quoteIdentifier(s string) string {
+	return "`" + strings.ReplaceAll(s, "`", "``") + "`"
+}
+
 func quoteTable(table string) string {
 	parts := strings.SplitN(table, ".", 2)
 	if len(parts) == 2 {
-		return fmt.Sprintf("`%s`.`%s`", parts[0], parts[1])
+		return quoteIdentifier(parts[0]) + "." + quoteIdentifier(parts[1])
 	}
-	return fmt.Sprintf("`%s`", table)
+	return quoteIdentifier(table)
 }
 
 func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {

--- a/pkg/source/oracle/oracle.go
+++ b/pkg/source/oracle/oracle.go
@@ -527,9 +527,9 @@ func quoteIdentifier(name string) string {
 func quoteTable(table string) string {
 	parts := strings.SplitN(table, ".", 2)
 	if len(parts) == 2 {
-		return fmt.Sprintf("\"%s\".\"%s\"", strings.ToUpper(parts[0]), strings.ToUpper(parts[1]))
+		return quoteIdentifier(strings.ToUpper(parts[0])) + "." + quoteIdentifier(strings.ToUpper(parts[1]))
 	}
-	return fmt.Sprintf("\"%s\"", strings.ToUpper(table))
+	return quoteIdentifier(strings.ToUpper(table))
 }
 
 func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {

--- a/pkg/source/snowflake/dialect.go
+++ b/pkg/source/snowflake/dialect.go
@@ -147,7 +147,7 @@ func (d *Dialect) MapDataType(dbType string) (schema.DataType, int, int, schema.
 }
 
 func (d *Dialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf(`"%s"`, strings.ToUpper(name))
+	return `"` + strings.ReplaceAll(strings.ToUpper(name), `"`, `""`) + `"`
 }
 
 func (d *Dialect) ParsePrimaryKeyResult(rawValue interface{}) []string {
@@ -180,7 +180,7 @@ func (d *Dialect) GetSchema(ctx context.Context, table string) (*schema.TableSch
 	}
 
 	schemaName, tableName := d.ParseTableName(table)
-	fullTable := fmt.Sprintf("%s.%s", schemaName, tableName)
+	fullTable := fmt.Sprintf("%s.%s", d.QuoteIdentifier(schemaName), d.QuoteIdentifier(tableName))
 
 	config.Debug("[SNOWFLAKE] Using DESCRIBE TABLE for schema fetching: %s", fullTable)
 

--- a/pkg/source/snowflake/reader.go
+++ b/pkg/source/snowflake/reader.go
@@ -60,7 +60,7 @@ func (d *Dialect) ReadWithStorageAPI(ctx context.Context, table string, opts sou
 	// Build the query
 	columns := srcadbc.FilterColumns(opts.Schema.Columns, opts.ExcludeColumns)
 	schemaName, tableName := d.ParseTableName(table)
-	fullTable := fmt.Sprintf("%s.%s", schemaName, tableName)
+	fullTable := fmt.Sprintf("%s.%s", d.QuoteIdentifier(schemaName), d.QuoteIdentifier(tableName))
 	query := srcadbc.BuildSelectQuery(fullTable, columns, opts, d.QuoteIdentifier)
 	config.Debug("[SNOWFLAKE-NATIVE] Query: %s", query)
 

--- a/pkg/source/trino/trino.go
+++ b/pkg/source/trino/trino.go
@@ -111,10 +111,10 @@ func (s *TrinoSource) getSchema(ctx context.Context, table string) (*schema.Tabl
 			column_name,
 			data_type,
 			is_nullable
-		FROM "%s".information_schema.columns
+		FROM %s.information_schema.columns
 		WHERE table_schema = ? AND table_name = ?
 		ORDER BY ordinal_position
-	`, catalog)
+	`, quoteIdentifier(catalog))
 
 	rows, err := s.db.QueryContext(ctx, query, schemaName, tableName)
 	if err != nil {
@@ -284,11 +284,11 @@ func (s *TrinoSource) parseTableName(table string) (catalog, schemaName, tableNa
 func (s *TrinoSource) buildSelectQuery(table string, columns []schema.Column, opts source.ReadOptions) string {
 	colNames := make([]string, len(columns))
 	for i, col := range columns {
-		colNames[i] = fmt.Sprintf(`"%s"`, col.Name)
+		colNames[i] = quoteIdentifier(col.Name)
 	}
 
 	catalog, schemaName, tableName := s.parseTableName(table)
-	fqn := fmt.Sprintf(`"%s"."%s"."%s"`, catalog, schemaName, tableName)
+	fqn := fmt.Sprintf("%s.%s.%s", quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(tableName))
 
 	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), fqn)
 
@@ -296,10 +296,10 @@ func (s *TrinoSource) buildSelectQuery(table string, columns []schema.Column, op
 	if opts.IncrementalKey != "" {
 		incrementalCol := findColumn(columns, opts.IncrementalKey)
 		if opts.IntervalStart != nil {
-			conditions = append(conditions, fmt.Sprintf(`"%s" >= %s`, opts.IncrementalKey, formatIncrementalLiteral(incrementalCol, *opts.IntervalStart)))
+			conditions = append(conditions, fmt.Sprintf(`%s >= %s`, quoteIdentifier(opts.IncrementalKey), formatIncrementalLiteral(incrementalCol, *opts.IntervalStart)))
 		}
 		if opts.IntervalEnd != nil {
-			conditions = append(conditions, fmt.Sprintf(`"%s" <= %s`, opts.IncrementalKey, formatIncrementalLiteral(incrementalCol, *opts.IntervalEnd)))
+			conditions = append(conditions, fmt.Sprintf(`%s <= %s`, quoteIdentifier(opts.IncrementalKey), formatIncrementalLiteral(incrementalCol, *opts.IntervalEnd)))
 		}
 	}
 
@@ -339,6 +339,10 @@ func formatIncrementalLiteral(col *schema.Column, t time.Time) string {
 	default:
 		return fmt.Sprintf("TIMESTAMP '%s'", t.Format("2006-01-02 15:04:05.000000"))
 	}
+}
+
+func quoteIdentifier(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 }
 
 func filterColumns(columns []schema.Column, exclude []string) []schema.Column {


### PR DESCRIPTION
## Summary

Closes the **"Database query built from user-controlled sources"** (`go/sql-injection`) code-scanning alerts. Table, schema, column, and catalog names come from user input (CLI flags and source database schemas) and are interpolated into SQL strings. Identifiers **cannot** be passed as bound parameters, so the correct fix is to escape the quoting delimiter.

The root cause: several quoting helpers wrapped identifiers in delimiters (`` ` ``, `[ ]`, `"`) **without escaping the delimiter character**, allowing breakout. This PR makes delimiter escaping consistent everywhere:

- double-quote: `"` → `""`
- backtick: `` ` `` → ` `` `
- bracket: `]` → `]]`

Existing semantics are preserved (Snowflake/Oracle upper-casing, already-quoted passthrough). User-controlled **string literals** (e.g. `WHERE name = '%s'`) now escape single quotes, including nested cases like SQL Server's `EXEC('CREATE SCHEMA [%s]')`. Escaping is a no-op for valid identifiers, so behavior is unchanged for normal names.

