### PR TITLE
fix(benchmarks): bump nltk to 3.9.4 (Zip Slip CVE)

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -19,3 +19,4 @@ dependencies = [
 
 [tool.uv]
 package = false
+constraint-dependencies = ["nltk>=3.9.4"]

--- a/benchmarks/uv.lock
+++ b/benchmarks/uv.lock
@@ -2815,7 +2815,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.1"
+version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2823,9 +2823,9 @@ dependencies = [
     { name = "regex", marker = "python_full_version >= '3.10'" },
     { name = "tqdm", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.470Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Addresses Dependabot alert #171 (NLTK Zip Slip vulnerability in `_unzip_iter` / `zipfile.extractall`)
- `nltk` is a transitive dep via `airbyte` in `benchmarks/uv.lock` — pinned via `[tool.uv] constraint-dependencies` rather than adding an unused direct dep
- `uv.lock` updated surgically: only the `nltk` entry is bumped `3.9.1 → 3.9.4` with new sdist/wheel URLs + sha256 hashes from PyPI. Existing `python_full_version >= '3.10'` marker is preserved (matches nltk 3.9.4's `requires_python: >=3.10`)

## Why a surgical lock edit
Regenerating `uv.lock` locally with `uv 0.9.21` caused significant resolver drift unrelated to the security fix — it collapsed `airbyte 0.35.7` (used for Python ≥3.10 in the existing lock) back to `airbyte 0.8.1` for all Python versions, removing many transitive deps. To keep this PR scoped to the security fix, only the `nltk` entry was updated.

## Test plan
- [ ] Confirm Dependabot alert #171 closes after merge
- [ ] CI passes