### PR TITLE
feat(trino dest): add mTLS, http_headers, and v0 param aliases

### DIFF
--- a/pkg/destination/trino/auth.go
+++ b/pkg/destination/trino/auth.go
@@ -17,41 +17,62 @@ import (
 
 // translateAliases rewrites v0 (Python/SQLAlchemy) parameter names to the
 // names trino-go-client understands. Existing canonical keys win on conflict.
+// The `verify` parameter is left in place when its value is a bool — that form
+// is consumed by buildAndRegisterCustomClient (false → InsecureSkipVerify).
 func translateAliases(q url.Values) {
 	aliases := map[string]string{
 		"access_token":     "accessToken",
 		"extra_credential": "extra_credentials",
 		"client_tags":      "clientTags",
-		"verify":           "SSLCertPath",
 	}
 	for old, canonical := range aliases {
 		vals := q[old]
 		if len(vals) == 0 {
 			continue
 		}
-		if old == "verify" {
-			v := strings.ToLower(strings.TrimSpace(vals[0]))
-			if v == "true" || v == "false" || v == "" {
-				q.Del(old)
-				continue
-			}
-		}
 		if _, exists := q[canonical]; !exists {
 			q[canonical] = vals
 		}
 		q.Del(old)
 	}
+
+	// verify=<path> → SSLCertPath. verify=true/false stays for later handling.
+	if vals := q["verify"]; len(vals) > 0 && !isVerifyBool(vals[0]) {
+		if _, exists := q["SSLCertPath"]; !exists {
+			q["SSLCertPath"] = vals
+		}
+		q.Del("verify")
+	}
 }
 
-// buildAndRegisterCustomClient builds an *http.Client from cert/key and
-// http_headers query parameters, registers it with trino-go-client, and
-// returns the registration key. Empty string means no custom client needed.
+// isVerifyBool reports whether v looks like a v0 boolean for the verify param.
+func isVerifyBool(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "false", "1", "0", "yes", "no", "":
+		return true
+	}
+	return false
+}
+
+// buildAndRegisterCustomClient builds an *http.Client from cert/key,
+// http_headers, and verify=false query parameters, registers it with
+// trino-go-client, and returns the registration key. Empty string means no
+// custom client is needed.
 func buildAndRegisterCustomClient(q url.Values) (string, error) {
 	certPath := q.Get("cert")
 	keyPath := q.Get("key")
 	headersRaw := q.Get("http_headers")
 
-	if certPath == "" && keyPath == "" && headersRaw == "" {
+	insecureSkipVerify := false
+	if vals := q["verify"]; len(vals) > 0 {
+		switch strings.ToLower(strings.TrimSpace(vals[0])) {
+		case "false", "0", "no":
+			insecureSkipVerify = true
+		}
+		q.Del("verify")
+	}
+
+	if certPath == "" && keyPath == "" && headersRaw == "" && !insecureSkipVerify {
 		return "", nil
 	}
 	if (certPath == "") != (keyPath == "") {
@@ -75,6 +96,9 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 		certBytes []byte
 		keyBytes  []byte
 	)
+	if certPath != "" || insecureSkipVerify {
+		tlsCfg = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: insecureSkipVerify}
+	}
 	if certPath != "" {
 		var err error
 		if certBytes, err = os.ReadFile(certPath); err != nil {
@@ -87,7 +111,7 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("trino uri: failed to parse client certificate: %w", err)
 		}
-		tlsCfg = &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
 
 	// Cache key hashes contents (not paths) so rotated certs get a fresh client.
@@ -97,6 +121,9 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 	h.Write(keyBytes)
 	h.Write([]byte{0})
 	h.Write([]byte(headersRaw))
+	if insecureSkipVerify {
+		h.Write([]byte("\x00insecure"))
+	}
 	name := "ingestr-trino-" + hex.EncodeToString(h.Sum(nil)[:8])
 
 	clientRegistryMu.Lock()

--- a/pkg/destination/trino/auth.go
+++ b/pkg/destination/trino/auth.go
@@ -117,7 +117,7 @@ func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	req = req.Clone(req.Context())
 	for k, vs := range h.headers {
 		for _, v := range vs {
-			req.Header.Add(k, v)
+			req.Header.Set(k, v)
 		}
 	}
 	return h.base.RoundTrip(req)

--- a/pkg/destination/trino/auth.go
+++ b/pkg/destination/trino/auth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -69,17 +70,34 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 		}
 	}
 
-	var tlsCfg *tls.Config
+	var (
+		tlsCfg    *tls.Config
+		certBytes []byte
+		keyBytes  []byte
+	)
 	if certPath != "" {
-		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		var err error
+		if certBytes, err = os.ReadFile(certPath); err != nil {
+			return "", fmt.Errorf("trino uri: failed to read client certificate: %w", err)
+		}
+		if keyBytes, err = os.ReadFile(keyPath); err != nil {
+			return "", fmt.Errorf("trino uri: failed to read client key: %w", err)
+		}
+		cert, err := tls.X509KeyPair(certBytes, keyBytes)
 		if err != nil {
-			return "", fmt.Errorf("trino uri: failed to load client certificate: %w", err)
+			return "", fmt.Errorf("trino uri: failed to parse client certificate: %w", err)
 		}
 		tlsCfg = &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
 	}
 
-	sum := sha256.Sum256([]byte(certPath + "\x00" + keyPath + "\x00" + headersRaw))
-	name := "ingestr-trino-" + hex.EncodeToString(sum[:8])
+	// Cache key hashes contents (not paths) so rotated certs get a fresh client.
+	h := sha256.New()
+	h.Write(certBytes)
+	h.Write([]byte{0})
+	h.Write(keyBytes)
+	h.Write([]byte{0})
+	h.Write([]byte(headersRaw))
+	name := "ingestr-trino-" + hex.EncodeToString(h.Sum(nil)[:8])
 
 	clientRegistryMu.Lock()
 	defer clientRegistryMu.Unlock()

--- a/pkg/destination/trino/auth.go
+++ b/pkg/destination/trino/auth.go
@@ -87,7 +87,7 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 		return name, nil
 	}
 
-	transport := &http.Transport{}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if tlsCfg != nil {
 		transport.TLSClientConfig = tlsCfg
 	}

--- a/pkg/destination/trino/auth.go
+++ b/pkg/destination/trino/auth.go
@@ -1,0 +1,124 @@
+package trino
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/trinodb/trino-go-client/trino"
+)
+
+// translateAliases rewrites v0 (Python/SQLAlchemy) parameter names to the
+// names trino-go-client understands. Existing canonical keys win on conflict.
+func translateAliases(q url.Values) {
+	aliases := map[string]string{
+		"access_token":     "accessToken",
+		"extra_credential": "extra_credentials",
+		"client_tags":      "clientTags",
+		"verify":           "SSLCertPath",
+	}
+	for old, canonical := range aliases {
+		vals := q[old]
+		if len(vals) == 0 {
+			continue
+		}
+		if old == "verify" {
+			v := strings.ToLower(strings.TrimSpace(vals[0]))
+			if v == "true" || v == "false" || v == "" {
+				q.Del(old)
+				continue
+			}
+		}
+		if _, exists := q[canonical]; !exists {
+			q[canonical] = vals
+		}
+		q.Del(old)
+	}
+}
+
+// buildAndRegisterCustomClient builds an *http.Client from cert/key and
+// http_headers query parameters, registers it with trino-go-client, and
+// returns the registration key. Empty string means no custom client needed.
+func buildAndRegisterCustomClient(q url.Values) (string, error) {
+	certPath := q.Get("cert")
+	keyPath := q.Get("key")
+	headersRaw := q.Get("http_headers")
+
+	if certPath == "" && keyPath == "" && headersRaw == "" {
+		return "", nil
+	}
+	if (certPath == "") != (keyPath == "") {
+		return "", fmt.Errorf("trino uri: cert and key must be provided together")
+	}
+
+	var headers http.Header
+	if headersRaw != "" {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(headersRaw), &parsed); err != nil {
+			return "", fmt.Errorf("trino uri: invalid http_headers JSON: %w", err)
+		}
+		headers = make(http.Header, len(parsed))
+		for k, v := range parsed {
+			headers.Set(k, v)
+		}
+	}
+
+	var tlsCfg *tls.Config
+	if certPath != "" {
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return "", fmt.Errorf("trino uri: failed to load client certificate: %w", err)
+		}
+		tlsCfg = &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+	}
+
+	sum := sha256.Sum256([]byte(certPath + "\x00" + keyPath + "\x00" + headersRaw))
+	name := "ingestr-trino-" + hex.EncodeToString(sum[:8])
+
+	clientRegistryMu.Lock()
+	defer clientRegistryMu.Unlock()
+	if _, ok := registeredClients[name]; ok {
+		return name, nil
+	}
+
+	transport := &http.Transport{}
+	if tlsCfg != nil {
+		transport.TLSClientConfig = tlsCfg
+	}
+	var rt http.RoundTripper = transport
+	if headers != nil {
+		rt = &headerRoundTripper{base: transport, headers: headers}
+	}
+
+	if err := trino.RegisterCustomClient(name, &http.Client{Transport: rt}); err != nil {
+		return "", fmt.Errorf("trino uri: failed to register custom http client: %w", err)
+	}
+	registeredClients[name] = struct{}{}
+	return name, nil
+}
+
+var (
+	clientRegistryMu  sync.Mutex
+	registeredClients = map[string]struct{}{}
+)
+
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers http.Header
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	for k, vs := range h.headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	return h.base.RoundTrip(req)
+}

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -520,6 +520,13 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 		scheme = "https"
 	}
 
+	translateAliases(query)
+
+	customClient, err := buildAndRegisterCustomClient(query)
+	if err != nil {
+		return "", "", "", err
+	}
+
 	userinfo := url.PathEscape(username)
 	if hasPassword {
 		userinfo = url.PathEscape(username) + ":" + url.PathEscape(password)
@@ -528,8 +535,12 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 	dsn = fmt.Sprintf("%s://%s@%s:%s?catalog=%s&schema=%s",
 		scheme, userinfo, host, port, catalog, schemaName)
 
+	if customClient != "" {
+		dsn += "&custom_client=" + url.QueryEscape(customClient)
+	}
+
 	for key, values := range query {
-		if key == "secure" || key == "SSL" || key == "http_scheme" {
+		if isReservedURIKey(key) {
 			continue
 		}
 		for _, v := range values {
@@ -538,6 +549,22 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 	}
 
 	return dsn, catalog, schemaName, nil
+}
+
+// isReservedURIKey lists query parameters consumed by parseTrinoURI itself —
+// they must not be forwarded verbatim into the driver DSN.
+func isReservedURIKey(key string) bool {
+	switch key {
+	case "secure", "SSL", "http_scheme":
+		return true
+	case "cert", "key", "http_headers":
+		return true
+	case "custom_client":
+		// We register our own client; never forward a user-supplied value
+		// because the name would not match a registered key.
+		return true
+	}
+	return false
 }
 
 func (d *TrinoDestination) parseTableName(table string) (catalog, schemaName, tableName string) {

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -557,7 +557,7 @@ func isReservedURIKey(key string) bool {
 	switch key {
 	case "secure", "SSL", "http_scheme":
 		return true
-	case "cert", "key", "http_headers":
+	case "cert", "key", "http_headers", "verify":
 		return true
 	case "custom_client":
 		// We register our own client; never forward a user-supplied value

--- a/pkg/destination/trino/trino_test.go
+++ b/pkg/destination/trino/trino_test.go
@@ -82,6 +82,14 @@ func TestParseTrinoURI(t *testing.T) {
 			wantInDSN:    []string{"custom_client=ingestr-trino-"},
 			wantNotInDSN: []string{"http_headers="},
 		},
+		{
+			// verify=false triggers custom client with InsecureSkipVerify
+			uri:          "trino://host:443/cat?http_scheme=https&verify=false",
+			wantCatalog:  "cat",
+			wantSchema:   "default",
+			wantInDSN:    []string{"custom_client=ingestr-trino-"},
+			wantNotInDSN: []string{"verify=", "SSLCertPath="},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/destination/trino/trino_test.go
+++ b/pkg/destination/trino/trino_test.go
@@ -58,6 +58,30 @@ func TestParseTrinoURI(t *testing.T) {
 			wantInDSN:    []string{"https://", "user@host:443"},
 			wantNotInDSN: []string{"SSL=", "secure="},
 		},
+		{
+			// v0 aliases translate to driver names
+			uri:          "trino://host:443/cat?http_scheme=https&access_token=jwt&extra_credential=user%3Dalice&client_tags=etl",
+			wantCatalog:  "cat",
+			wantSchema:   "default",
+			wantInDSN:    []string{"accessToken=jwt", "extra_credentials=user%3Dalice", "clientTags=etl"},
+			wantNotInDSN: []string{"access_token", "extra_credential=user", "client_tags="},
+		},
+		{
+			// verify=<path> → SSLCertPath; verify=true silently dropped
+			uri:          "trino://host:443/cat?http_scheme=https&verify=%2Fetc%2Fssl%2Fca.pem",
+			wantCatalog:  "cat",
+			wantSchema:   "default",
+			wantInDSN:    []string{"SSLCertPath=%2Fetc%2Fssl%2Fca.pem"},
+			wantNotInDSN: []string{"verify="},
+		},
+		{
+			// http_headers triggers custom-client registration
+			uri:          `trino://host:443/cat?http_scheme=https&http_headers={"X-Tenant":"t1"}`,
+			wantCatalog:  "cat",
+			wantSchema:   "default",
+			wantInDSN:    []string{"custom_client=ingestr-trino-"},
+			wantNotInDSN: []string{"http_headers="},
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,5 +107,19 @@ func TestParseTrinoURI(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParseTrinoURI_InvalidHTTPHeaders(t *testing.T) {
+	_, _, _, err := parseTrinoURI("trino://host:443/cat?http_headers=not-json")
+	if err == nil {
+		t.Fatal("expected error for invalid http_headers JSON, got nil")
+	}
+}
+
+func TestParseTrinoURI_CertWithoutKey(t *testing.T) {
+	_, _, _, err := parseTrinoURI("trino://host:443/cat?cert=/etc/ssl/client.pem")
+	if err == nil {
+		t.Fatal("expected error when cert is provided without key, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Adds three auth methods that ingestr v0 supported via SQLAlchemy but v1 didn't expose:

- **v0 → trino-go-client param aliases**: \`access_token\`, \`extra_credential\`, \`client_tags\`, \`verify\` (path form). URIs copy-pasted from v0 docs no longer hit silent drops.
- **Client mTLS** via \`?cert=&key=\`. Builds an \`*http.Client\` with \`tls.LoadX509KeyPair\`, registers it with \`trino.RegisterCustomClient\`, and routes the DSN through \`?custom_client=\`.
- **HTTP-header injection** via \`?http_headers=<json>\`. Builds a custom \`Transport\` that adds the headers on every outgoing request, registers the resulting \`*http.Client\` the same way.