### PR TITLE
Add CDC merge for local SQL destinations

### DIFF
--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -256,6 +256,15 @@ func (d *CrateDBDestination) MergeTable(ctx context.Context, opts destination.Me
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
 
+	if destination.HasCDCDeletedColumn(columns) {
+		if err := d.executeCDCMerge(ctx, opts, quotedTargetTable, quotedStagingTable, quotedColumns, nonPKColumns, quotedPKs); err != nil {
+			return err
+		}
+		d.refreshTable(ctx, opts.TargetTable)
+		config.Debug("[CRATEDB MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	var upsertSQL string
 	if len(nonPKColumns) == 0 {
 		upsertSQL = fmt.Sprintf(
@@ -287,6 +296,106 @@ func (d *CrateDBDestination) MergeTable(ctx context.Context, opts destination.Me
 	d.refreshTable(ctx, opts.TargetTable)
 
 	config.Debug("[CRATEDB MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
+
+func cratedbLatestCDCSource(stagingTable string, primaryKeys, columns []string, filter, alias string) string {
+	quotedCols := quoteColumns(columns)
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY "_cdc_lsn" DESC, "_cdc_synced_at" DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s`,
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		destination.QuoteTableName(stagingTable),
+		where,
+		alias,
+	)
+}
+
+func cratedbAliasJoin(primaryKeys []string, leftAlias, rightAlias string) string {
+	conditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		conditions[i] = fmt.Sprintf(`%s."%s" = %s."%s"`, leftAlias, pk, rightAlias, pk)
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func buildCrateDBCDCMergeSQL(opts destination.MergeOptions, quotedTargetTable string, quotedColumns, nonPKColumns, quotedPKs []string) string {
+	dataColumns := destination.CDCDataColumns(opts.Columns, opts.PrimaryKeys)
+	activeColumns := append(append([]string{}, opts.PrimaryKeys...), dataColumns...)
+	latestAll := cratedbLatestCDCSource(opts.StagingTable, opts.PrimaryKeys, opts.Columns, "", "latest_all")
+	latestActive := cratedbLatestCDCSource(opts.StagingTable, opts.PrimaryKeys, activeColumns, `"_cdc_deleted" = false`, "latest_active")
+
+	selects := make([]string, len(opts.Columns))
+	for i, col := range opts.Columns {
+		switch {
+		case destination.IsCDCColumn(col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		case containsColumn(opts.PrimaryKeys, col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		default:
+			selects[i] = fmt.Sprintf(
+				`CASE WHEN latest_all."_cdc_deleted" = false THEN latest_all."%s" WHEN latest_active."%s" IS NOT NULL THEN latest_active."%s" ELSE existing."%s" END AS "%s"`,
+				col,
+				opts.PrimaryKeys[0],
+				col,
+				col,
+				col,
+			)
+		}
+	}
+
+	var conflictAction string
+	if len(nonPKColumns) == 0 {
+		conflictAction = "DO NOTHING"
+	} else {
+		conflictAction = "DO UPDATE SET " + buildConflictUpdateSet(nonPKColumns)
+	}
+
+	return fmt.Sprintf(
+		`INSERT INTO %s (%s)
+SELECT %s
+FROM %s
+LEFT JOIN %s ON %s
+LEFT JOIN %s AS existing ON %s
+WHERE latest_all."_cdc_deleted" = false OR latest_active."%s" IS NOT NULL OR existing."%s" IS NOT NULL
+ON CONFLICT (%s) %s`,
+		quotedTargetTable,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		cratedbAliasJoin(opts.PrimaryKeys, "latest_all", "latest_active"),
+		quotedTargetTable,
+		cratedbAliasJoin(opts.PrimaryKeys, "existing", "latest_all"),
+		opts.PrimaryKeys[0],
+		opts.PrimaryKeys[0],
+		strings.Join(quotedPKs, ", "),
+		conflictAction,
+	)
+}
+
+func containsColumn(columns []string, column string) bool {
+	for _, col := range columns {
+		if strings.EqualFold(col, column) {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *CrateDBDestination) executeCDCMerge(ctx context.Context, opts destination.MergeOptions, quotedTargetTable, _ string, quotedColumns, nonPKColumns, quotedPKs []string) error {
+	mergeSQL := buildCrateDBCDCMergeSQL(opts, quotedTargetTable, quotedColumns, nonPKColumns, quotedPKs)
+	config.Debug("[CRATEDB MERGE] Executing CDC merge: %s", mergeSQL)
+	if _, err := d.pool.Exec(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to execute CDC merge: %w", err)
+	}
 	return nil
 }
 
@@ -557,7 +666,24 @@ func (d *CrateDBDestination) SupportsAppendStrategy() bool       { return true }
 func (d *CrateDBDestination) SupportsMergeStrategy() bool        { return true }
 func (d *CrateDBDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *CrateDBDestination) SupportsSCD2Strategy() bool         { return true }
+func (d *CrateDBDestination) SupportsCDCMerge() bool             { return true }
 func (d *CrateDBDestination) SupportsAtomicSwap() bool           { return false }
+
+func (d *CrateDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN *string
+	query := fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %s`, destination.QuoteTableName(table))
+	if err := d.pool.QueryRow(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "RelationUnknown") || strings.Contains(err.Error(), "does not exist") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if maxLSN == nil {
+		return "", nil
+	}
+	return *maxLSN, nil
+}
 
 func (d *CrateDBDestination) refreshTable(ctx context.Context, table string) {
 	sql := fmt.Sprintf("REFRESH TABLE %s", destination.QuoteTableName(table))

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -391,6 +391,7 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 	columns := opts.Columns
 	quotedColumns := quoteColumns(columns)
 	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
+	hasCDCDeleted := destination.HasCDCDeletedColumn(columns)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -407,6 +408,22 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
+
+	if hasCDCDeleted {
+		if len(opts.PrimaryKeys) == 0 {
+			return fmt.Errorf("CDC merge requires at least one primary key")
+		}
+		if err := d.executeCDCMergeLocked(ctx, opts, quotedTargetTable, quotedColumns, nonPKColumns); err != nil {
+			return err
+		}
+		if err := d.exec(ctx, "COMMIT"); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		commit = true
+
+		config.Debug("[DUCKDB CDC MERGE] Merge completed in %v", time.Since(startMerge))
+		return nil
+	}
 
 	// Build dedup subquery to handle duplicate PKs in staging
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
@@ -455,6 +472,101 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	config.Debug("[DUCKDB MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func (d *DuckDBDestination) executeCDCMergeLocked(ctx context.Context, opts destination.MergeOptions, quotedTargetTable string, quotedColumns []string, nonPKColumns []string) error {
+	mergeSQL := buildDuckDBCDCMergeSQL(opts, quotedTargetTable, quotedColumns, nonPKColumns)
+	config.Debug("[DUCKDB CDC MERGE] Executing CDC merge: %s", mergeSQL)
+	if err := d.exec(ctx, mergeSQL); err != nil {
+		return fmt.Errorf("failed to execute CDC merge: %w", err)
+	}
+	return nil
+}
+
+func duckDBLatestCDCCTE(name string, stagingTable string, primaryKeys, columns []string, filter string) string {
+	quotedCols := quoteColumns(columns)
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	orderByParts := append(append([]string{}, quotedPKs...), `"_cdc_lsn" DESC`, `"_cdc_synced_at" DESC`, `rowid DESC`)
+	return fmt.Sprintf(
+		`%s AS (SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1)`,
+		name,
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		strings.Join(orderByParts, ", "),
+		destination.QuoteTableName(stagingTable),
+		where,
+	)
+}
+
+func buildDuckDBCDCMergeSQL(opts destination.MergeOptions, quotedTargetTable string, quotedColumns []string, nonPKColumns []string) string {
+	dataColumns := destination.CDCDataColumns(opts.Columns, opts.PrimaryKeys)
+	activeColumns := append(append([]string{}, opts.PrimaryKeys...), dataColumns...)
+	latestAll := duckDBLatestCDCCTE("latest_all", opts.StagingTable, opts.PrimaryKeys, opts.Columns, "")
+	latestActive := duckDBLatestCDCCTE("latest_active", opts.StagingTable, opts.PrimaryKeys, activeColumns, `"_cdc_deleted" = false`)
+
+	selects := make([]string, len(opts.Columns))
+	for i, col := range opts.Columns {
+		switch {
+		case destination.IsCDCColumn(col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		case containsColumn(opts.PrimaryKeys, col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		default:
+			selects[i] = fmt.Sprintf(
+				`CASE WHEN latest_all."_cdc_deleted" = false THEN latest_all."%s" WHEN latest_active."%s" IS NOT NULL THEN latest_active."%s" ELSE existing."%s" END AS "%s"`,
+				col,
+				opts.PrimaryKeys[0],
+				col,
+				col,
+				col,
+			)
+		}
+	}
+
+	updates := make([]string, len(nonPKColumns))
+	for i, col := range nonPKColumns {
+		updates[i] = fmt.Sprintf(`"%s" = excluded."%s"`, col, col)
+	}
+
+	return fmt.Sprintf(
+		`WITH %s, %s, source AS (
+	SELECT %s
+	FROM latest_all
+	LEFT JOIN latest_active ON %s
+	LEFT JOIN %s AS existing ON %s
+	WHERE latest_all."_cdc_deleted" = false OR latest_active."%s" IS NOT NULL OR existing."%s" IS NOT NULL
+)
+INSERT INTO %s (%s)
+SELECT %s FROM source
+ON CONFLICT (%s) DO UPDATE SET %s`,
+		latestAll,
+		latestActive,
+		strings.Join(selects, ", "),
+		buildJoinCondition(opts.PrimaryKeys, "latest_all", "latest_active"),
+		quotedTargetTable,
+		buildJoinCondition(opts.PrimaryKeys, "existing", "latest_all"),
+		opts.PrimaryKeys[0],
+		opts.PrimaryKeys[0],
+		quotedTargetTable,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+		strings.Join(updates, ", "),
+	)
+}
+
+func containsColumn(columns []string, column string) bool {
+	for _, col := range columns {
+		if strings.EqualFold(col, column) {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *DuckDBDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
@@ -687,6 +799,7 @@ func (d *DuckDBDestination) SupportsMergeStrategy() bool        { return true }
 func (d *DuckDBDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *DuckDBDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *DuckDBDestination) SupportsAtomicSwap() bool           { return true }
+func (d *DuckDBDestination) SupportsCDCMerge() bool             { return true }
 
 // GetScheme returns the primary URI scheme for DuckDB.
 func (d *DuckDBDestination) GetScheme() string { return "duckdb" }

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -714,6 +714,137 @@ func TestMergeTable(t *testing.T) {
 	assert.Equal(t, 300, value)
 }
 
+func TestMergeTable_CDCUpdateDeleteSameBatch(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE target_table (
+			id BIGINT PRIMARY KEY,
+			name VARCHAR,
+			value INTEGER,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMPTZ
+		)
+	`))
+	require.NoError(t, dest.Exec(ctx, `
+		INSERT INTO target_table VALUES
+			(1, 'Alice', 100, '00000000000000000001:00000000000000000000:00', false, TIMESTAMPTZ '2024-01-01 00:00:00+00'),
+			(2, 'Bob', 200, '00000000000000000001:00000000000000000000:00', false, TIMESTAMPTZ '2024-01-01 00:00:00+00')
+	`))
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE staging_table (
+			id BIGINT,
+			name VARCHAR,
+			value INTEGER,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMPTZ
+		)
+	`))
+	require.NoError(t, dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(1, 'Alice Updated', 150, '00000000000000000002:00000000000000000001:04', false, TIMESTAMPTZ '2024-01-01 00:01:00+00'),
+			(1, 'Alice Updated', 150, '00000000000000000002:00000000000000000002:01', true, TIMESTAMPTZ '2024-01-01 00:02:00+00'),
+			(3, 'Charlie', 300, '00000000000000000003:00000000000000000001:02', false, TIMESTAMPTZ '2024-01-01 00:03:00+00'),
+			(3, 'Charlie', 300, '00000000000000000003:00000000000000000002:01', true, TIMESTAMPTZ '2024-01-01 00:04:00+00')
+	`))
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		TargetTable:  "target_table",
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "value", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"},
+	})
+	require.NoError(t, err)
+
+	db := openDuckDB(t, ctx, path)
+	var total, active int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM target_table`).Scan(&total))
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM target_table WHERE "_cdc_deleted" = false`).Scan(&active))
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 1, active)
+
+	var nameRaw []byte
+	var value int
+	var deleted bool
+	var lsnRaw []byte
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name, value, "_cdc_deleted", "_cdc_lsn" FROM target_table WHERE id = 1`).Scan(&nameRaw, &value, &deleted, &lsnRaw))
+	assert.Equal(t, "Alice Updated", string(append([]byte(nil), nameRaw...)))
+	assert.Equal(t, 150, value)
+	assert.True(t, deleted)
+	assert.Equal(t, "00000000000000000002:00000000000000000002:01", string(append([]byte(nil), lsnRaw...)))
+
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name, value, "_cdc_deleted", "_cdc_lsn" FROM target_table WHERE id = 3`).Scan(&nameRaw, &value, &deleted, &lsnRaw))
+	assert.Equal(t, "Charlie", string(append([]byte(nil), nameRaw...)))
+	assert.Equal(t, 300, value)
+	assert.True(t, deleted)
+	assert.Equal(t, "00000000000000000003:00000000000000000002:01", string(append([]byte(nil), lsnRaw...)))
+}
+
+func TestMergeTable_CDCUsesStagingOrderForIdenticalLSNAndTimestamp(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE target_table (
+			id BIGINT PRIMARY KEY,
+			name VARCHAR,
+			value INTEGER,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMPTZ
+		)
+	`))
+	require.NoError(t, dest.Exec(ctx, `
+		INSERT INTO target_table VALUES
+			(1, 'Alice', 100, '0/1', false, TIMESTAMPTZ '2024-01-01 00:00:00+00')
+	`))
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE staging_table (
+			id BIGINT,
+			name VARCHAR,
+			value INTEGER,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMPTZ
+		)
+	`))
+	require.NoError(t, dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(1, 'Alice Updated', 150, '0/2', false, TIMESTAMPTZ '2024-01-01 00:01:00+00'),
+			(1, 'Alice Updated', 150, '0/2', true, TIMESTAMPTZ '2024-01-01 00:01:00+00'),
+			(3, 'Charlie Deleted', 250, '0/2', true, TIMESTAMPTZ '2024-01-01 00:01:00+00'),
+			(3, 'Charlie Inserted', 300, '0/2', false, TIMESTAMPTZ '2024-01-01 00:01:00+00')
+	`))
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		TargetTable:  "target_table",
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "value", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"},
+	})
+	require.NoError(t, err)
+
+	db := openDuckDB(t, ctx, path)
+
+	var nameRaw []byte
+	var value int
+	var deleted bool
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name, value, "_cdc_deleted" FROM target_table WHERE id = 1`).Scan(&nameRaw, &value, &deleted))
+	assert.Equal(t, "Alice Updated", string(append([]byte(nil), nameRaw...)))
+	assert.Equal(t, 150, value)
+	assert.True(t, deleted)
+
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name, value, "_cdc_deleted" FROM target_table WHERE id = 3`).Scan(&nameRaw, &value, &deleted))
+	assert.Equal(t, "Charlie Inserted", string(append([]byte(nil), nameRaw...)))
+	assert.Equal(t, 300, value)
+	assert.False(t, deleted)
+}
+
 func TestSwapTable(t *testing.T) {
 	ctx := context.Background()
 	dest, path := connectTestDuckDB(t, ctx)

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -372,6 +372,18 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	quotedColumns := quoteColumns(columns)
 	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
 
+	if destination.HasCDCDeletedColumn(columns) {
+		mergeSQL := buildCDCMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, columns, quotedColumns, nonPKColumns)
+		config.Debug("[MERGE] Executing CDC MERGE: %s", mergeSQL)
+		if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+			config.LogFailedQuery(mergeSQL, err)
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
+		}
+
+		config.Debug("[MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns)
 	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
 
@@ -382,6 +394,178 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func buildMSSQLLatestCDCSource(stagingTable string, primaryKeys, quotedColumns []string, filter, alias string) string {
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY [_cdc_lsn] DESC, [_cdc_synced_at] DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s`,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedPKs, ", "),
+		quoteTable(stagingTable),
+		where,
+		alias,
+	)
+}
+
+func mssqlActiveAlias(index int) string {
+	return fmt.Sprintf("__bruin_active_%d", index)
+}
+
+func buildMSSQLCDCSource(stagingTable string, primaryKeys, allColumns, dataColumns []string) string {
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := buildMSSQLLatestCDCSource(stagingTable, primaryKeys, quoteColumns(allColumns), "", "latest_all")
+	latestActive := buildMSSQLLatestCDCSource(stagingTable, primaryKeys, quoteColumns(activeColumns), "[_cdc_deleted] = 0", "latest_active")
+
+	selects := []string{
+		"latest_all.*",
+		fmt.Sprintf("CASE WHEN latest_active.[%s] IS NULL THEN 0 ELSE 1 END AS [__bruin_has_active]", primaryKeys[0]),
+	}
+	for i, col := range dataColumns {
+		selects = append(selects, fmt.Sprintf("latest_active.[%s] AS [%s]", col, mssqlActiveAlias(i)))
+	}
+
+	return fmt.Sprintf(
+		`(SELECT %s FROM %s LEFT JOIN %s ON %s) AS source`,
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		buildJoinCondition(primaryKeys, "latest_all", "latest_active"),
+	)
+}
+
+func buildCDCMergeSQL(targetTable, stagingTable string, primaryKeys, allColumns, quotedColumns, nonPKColumns []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	dataColumnIndex := make(map[string]int, len(dataColumns))
+	for i, col := range dataColumns {
+		dataColumnIndex[strings.ToLower(col)] = i
+	}
+	pkMap := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	updates := make([]string, 0, len(nonPKColumns))
+	for _, col := range nonPKColumns {
+		if destination.IsCDCColumn(col) {
+			updates = append(updates, fmt.Sprintf("target.[%s] = source.[%s]", col, col))
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		updates = append(updates, fmt.Sprintf(
+			"target.[%s] = CASE WHEN source.[_cdc_deleted] = 1 THEN CASE WHEN source.[__bruin_has_active] = 1 THEN source.[%s] ELSE target.[%s] END ELSE source.[%s] END",
+			col,
+			mssqlActiveAlias(activeIndex),
+			col,
+			col,
+		))
+	}
+
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		quotedCol := fmt.Sprintf("[%s]", col)
+		if destination.IsCDCColumn(col) {
+			sourceCols[i] = "source." + quotedCol
+			continue
+		}
+
+		if pkMap[strings.ToLower(col)] {
+			sourceCols[i] = "source." + quotedCol
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		sourceCols[i] = fmt.Sprintf(
+			"CASE WHEN source.[_cdc_deleted] = 1 AND source.[__bruin_has_active] = 1 THEN source.[%s] ELSE source.%s END",
+			mssqlActiveAlias(activeIndex),
+			quotedCol,
+		)
+	}
+
+	var updateSet string
+	if len(updates) > 0 {
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s
+ON %s
+%s
+WHEN NOT MATCHED AND (source.[_cdc_deleted] = 0 OR source.[__bruin_has_active] = 1) THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		buildMSSQLCDCSource(stagingTable, primaryKeys, allColumns, dataColumns),
+		buildJoinCondition(primaryKeys, "target", "source"),
+		updateSet,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func buildCDCActiveMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
+	onConditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
+	}
+
+	var updateSet string
+	if len(nonPKColumns) > 0 {
+		updates := make([]string, len(nonPKColumns))
+		for i, col := range nonPKColumns {
+			updates[i] = fmt.Sprintf("target.[%s] = source.[%s]", col, col)
+		}
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	insertCols := strings.Join(quotedColumns, ", ")
+	sourceCols := make([]string, len(quotedColumns))
+	for i, col := range quotedColumns {
+		sourceCols[i] = "source." + col
+	}
+
+	dedupSource := buildMSSQLLatestCDCSource(stagingTable, primaryKeys, quotedColumns, "[_cdc_deleted] = 0", "source")
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s
+ON %s
+%s
+WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		dedupSource,
+		strings.Join(onConditions, " AND "),
+		updateSet,
+		insertCols,
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func buildCDCDeletedUpdateSQL(targetTable, stagingTable string, primaryKeys []string) string {
+	cdcColumns := append([]string{}, primaryKeys...)
+	cdcColumns = append(cdcColumns, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+	quotedCDCColumns := quoteColumns(cdcColumns)
+	latestAll := buildMSSQLLatestCDCSource(stagingTable, primaryKeys, quotedCDCColumns, "", "latest")
+	latestDeleted := buildMSSQLLatestCDCSource(stagingTable, primaryKeys, quotedCDCColumns, "[_cdc_deleted] = 1", "deleted")
+
+	return fmt.Sprintf(
+		`UPDATE target
+SET target.[_cdc_deleted] = 1, target.[_cdc_lsn] = deleted.[_cdc_lsn], target.[_cdc_synced_at] = deleted.[_cdc_synced_at]
+FROM %s AS target
+INNER JOIN %s ON %s
+INNER JOIN %s ON %s
+WHERE latest.[_cdc_deleted] = 1;`,
+		quoteTable(targetTable),
+		latestDeleted,
+		buildJoinCondition(primaryKeys, "target", "deleted"),
+		latestAll,
+		buildJoinCondition(primaryKeys, "deleted", "latest"),
+	)
 }
 
 func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
@@ -612,8 +796,25 @@ func (d *MSSQLDestination) SupportsMergeStrategy() bool        { return true }
 func (d *MSSQLDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *MSSQLDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *MSSQLDestination) SupportsAtomicSwap() bool           { return true }
+func (d *MSSQLDestination) SupportsCDCMerge() bool             { return true }
 
 func (d *MSSQLDestination) GetScheme() string { return "mssql" }
+
+func (d *MSSQLDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf("SELECT MAX([_cdc_lsn]) FROM %s", quoteTable(table))
+	if err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "Invalid object name") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *MSSQLDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	schemaName, tableName := parseTableName(table)

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -370,6 +370,17 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if destination.HasCDCDeletedColumn(columns) {
+		if err := executeMySQLCDCMerge(ctx, tx, opts, quotedColumns, nonPKColumns); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		config.Debug("[MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	// Build dedup subquery to handle duplicate PKs in staging
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
 	dedupSource := fmt.Sprintf(
@@ -417,6 +428,95 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	}
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
+
+func mysqlLatestCDCSource(stagingTable string, primaryKeys, columns []string, filter, alias string) string {
+	quotedCols := quoteColumns(columns)
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		"(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC, `_cdc_synced_at` DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s",
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		quoteTable(stagingTable),
+		where,
+		alias,
+	)
+}
+
+func buildMySQLCDCMergeSQL(opts destination.MergeOptions, quotedColumns, nonPKColumns []string) string {
+	dataColumns := destination.CDCDataColumns(opts.Columns, opts.PrimaryKeys)
+	activeColumns := append(append([]string{}, opts.PrimaryKeys...), dataColumns...)
+	latestAll := mysqlLatestCDCSource(opts.StagingTable, opts.PrimaryKeys, opts.Columns, "", "latest_all")
+	latestActive := mysqlLatestCDCSource(opts.StagingTable, opts.PrimaryKeys, activeColumns, "`_cdc_deleted` = false", "latest_active")
+
+	selects := make([]string, len(opts.Columns))
+	for i, col := range opts.Columns {
+		switch {
+		case destination.IsCDCColumn(col):
+			selects[i] = fmt.Sprintf("latest_all.`%s` AS `%s`", col, col)
+		case containsColumn(opts.PrimaryKeys, col):
+			selects[i] = fmt.Sprintf("latest_all.`%s` AS `%s`", col, col)
+		default:
+			selects[i] = fmt.Sprintf(
+				"CASE WHEN latest_all.`_cdc_deleted` = false THEN latest_all.`%s` WHEN latest_active.`%s` IS NOT NULL THEN latest_active.`%s` ELSE existing.`%s` END AS `%s`",
+				col,
+				opts.PrimaryKeys[0],
+				col,
+				col,
+				col,
+			)
+		}
+	}
+
+	updates := make([]string, len(nonPKColumns))
+	for i, col := range nonPKColumns {
+		updates[i] = fmt.Sprintf("`%s` = VALUES(`%s`)", col, col)
+	}
+
+	return fmt.Sprintf(
+		`INSERT INTO %s (%s)
+SELECT %s
+FROM %s
+LEFT JOIN %s ON %s
+LEFT JOIN %s AS existing ON %s
+WHERE latest_all.`+"`_cdc_deleted`"+` = false OR latest_active.`+"`%s`"+` IS NOT NULL OR existing.`+"`%s`"+` IS NOT NULL
+ON DUPLICATE KEY UPDATE %s`,
+		quoteTable(opts.TargetTable),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		buildJoinCondition(opts.PrimaryKeys, "latest_all", "latest_active"),
+		quoteTable(opts.TargetTable),
+		buildJoinCondition(opts.PrimaryKeys, "existing", "latest_all"),
+		opts.PrimaryKeys[0],
+		opts.PrimaryKeys[0],
+		strings.Join(updates, ", "),
+	)
+}
+
+func containsColumn(columns []string, column string) bool {
+	for _, col := range columns {
+		if strings.EqualFold(col, column) {
+			return true
+		}
+	}
+	return false
+}
+
+func executeMySQLCDCMerge(ctx context.Context, tx *sql.Tx, opts destination.MergeOptions, quotedColumns []string, nonPKColumns []string) error {
+	mergeSQL := buildMySQLCDCMergeSQL(opts, quotedColumns, nonPKColumns)
+	config.Debug("[MERGE] Executing CDC merge: %s", mergeSQL)
+	if _, err := tx.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to execute CDC merge: %w", err)
+	}
 	return nil
 }
 
@@ -600,8 +700,25 @@ func (d *MySQLDestination) SupportsMergeStrategy() bool        { return true }
 func (d *MySQLDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *MySQLDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *MySQLDestination) SupportsAtomicSwap() bool           { return true }
+func (d *MySQLDestination) SupportsCDCMerge() bool             { return true }
 
 func (d *MySQLDestination) GetScheme() string { return "mysql" }
+
+func (d *MySQLDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf("SELECT MAX(`_cdc_lsn`) FROM %s", quoteTable(table))
+	if err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "doesn't exist") || strings.Contains(err.Error(), "does not exist") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *MySQLDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	tableName := extractTableName(table)

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -454,7 +453,7 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
 
 	// Check if this is CDC mode (has _cdc_deleted column)
-	hasCDCDeleted := slices.Contains(columns, "_cdc_deleted")
+	hasCDCDeleted := destination.HasCDCDeletedColumn(columns)
 
 	// Begin transaction for atomic merge
 	tx, err := d.pool.Begin(ctx)
@@ -467,60 +466,11 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
 
 	if hasCDCDeleted {
-		// CDC mode: dedupe within the staging table and apply changes deterministically.
-		// We upsert the latest non-deleted row per PK, then mark deletes only if the
-		// latest change for that PK is a delete (preserving row data).
-		pkList := strings.Join(quotedPKs, ", ")
-		selectCols := strings.Join(quotedColumns, ", ")
-		orderByParts := append(append([]string{}, quotedPKs...), `"_cdc_lsn"::pg_lsn DESC`, `"_cdc_synced_at" DESC`)
-		orderBy := strings.Join(orderByParts, ", ")
-
-		latestActive := fmt.Sprintf(
-			`latest_active AS (SELECT DISTINCT ON (%s) %s FROM %s WHERE "_cdc_deleted" = false ORDER BY %s)`,
-			pkList, selectCols, quotedStagingTable, orderBy,
-		)
-		latestAll := fmt.Sprintf(
-			`latest_all AS (SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s)`,
-			pkList, selectCols, quotedStagingTable, orderBy,
-		)
-		latestDeleted := fmt.Sprintf(
-			`latest_deleted AS (SELECT DISTINCT ON (%s) %s FROM %s WHERE "_cdc_deleted" = true ORDER BY %s)`,
-			pkList, selectCols, quotedStagingTable, orderBy,
-		)
-
-		// Step 1: Upsert latest non-deleted rows (data changes)
-		upsertSQL := fmt.Sprintf(
-			`WITH %s INSERT INTO %s (%s) SELECT %s FROM latest_active ON CONFLICT (%s) DO UPDATE SET %s`,
-			latestActive,
-			quotedTargetTable,
-			strings.Join(quotedColumns, ", "),
-			strings.Join(quotedColumns, ", "),
-			strings.Join(quotedPKs, ", "),
-			buildConflictUpdateSet(nonPKColumns),
-		)
-		config.Debug("[MERGE] Executing upsert for non-deleted rows: %s", upsertSQL)
-
-		if _, err := tx.Exec(ctx, upsertSQL); err != nil {
-			config.LogFailedQuery(upsertSQL, err)
-			return fmt.Errorf("failed to upsert non-deleted records: %w", err)
-		}
-
-		// Step 2: Mark deletes only when the latest change is a delete
-		onLatestCondition := buildJoinCondition(opts.PrimaryKeys, "deleted", "latest")
-		onTargetCondition := buildJoinCondition(opts.PrimaryKeys, "target", "deleted")
-		updateDeletedSQL := fmt.Sprintf(
-			`WITH %s, %s UPDATE %s AS target SET "_cdc_deleted" = true, "_cdc_lsn" = deleted."_cdc_lsn", "_cdc_synced_at" = deleted."_cdc_synced_at" FROM latest_deleted AS deleted JOIN latest_all AS latest ON %s WHERE %s AND latest."_cdc_deleted" = true`,
-			latestAll,
-			latestDeleted,
-			quotedTargetTable,
-			onLatestCondition,
-			onTargetCondition,
-		)
-		config.Debug("[MERGE] Executing UPDATE for deleted rows: %s", updateDeletedSQL)
-
-		if _, err := tx.Exec(ctx, updateDeletedSQL); err != nil {
-			config.LogFailedQuery(updateDeletedSQL, err)
-			return fmt.Errorf("failed to update deleted records: %w", err)
+		mergeSQL := buildPostgresCDCMergeSQL(quotedStagingTable, quotedTargetTable, opts.PrimaryKeys, columns, quotedColumns, nonPKColumns, quotedPKs)
+		config.Debug("[MERGE] Executing CDC merge: %s", mergeSQL)
+		if _, err := tx.Exec(ctx, mergeSQL); err != nil {
+			config.LogFailedQuery(mergeSQL, err)
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
 		}
 	} else {
 		// Non-CDC mode: efficient upsert using INSERT ... ON CONFLICT.
@@ -554,6 +504,86 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func postgresLatestCDCCTE(name, quotedTable string, primaryKeys, columns []string, filter string) string {
+	quotedPKs := quoteColumns(primaryKeys)
+	quotedCols := quoteColumns(columns)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	orderByParts := append(append([]string{}, quotedPKs...), `"_cdc_lsn" DESC`, `"_cdc_synced_at" DESC`)
+	return fmt.Sprintf(
+		`%s AS (SELECT DISTINCT ON (%s) %s FROM %s%s ORDER BY %s)`,
+		name,
+		strings.Join(quotedPKs, ", "),
+		strings.Join(quotedCols, ", "),
+		quotedTable,
+		where,
+		strings.Join(orderByParts, ", "),
+	)
+}
+
+func buildPostgresCDCMergeSQL(quotedStagingTable, quotedTargetTable string, primaryKeys, allColumns, quotedColumns, nonPKColumns, quotedPKs []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := postgresLatestCDCCTE("latest_all", quotedStagingTable, primaryKeys, allColumns, "")
+	latestActive := postgresLatestCDCCTE("latest_active", quotedStagingTable, primaryKeys, activeColumns, `"_cdc_deleted" = false`)
+
+	selects := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		switch {
+		case destination.IsCDCColumn(col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		case containsColumn(primaryKeys, col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		default:
+			selects[i] = fmt.Sprintf(
+				`CASE WHEN latest_all."_cdc_deleted" = false THEN latest_all."%s" WHEN latest_active."%s" IS NOT NULL THEN latest_active."%s" ELSE existing."%s" END AS "%s"`,
+				col,
+				primaryKeys[0],
+				col,
+				col,
+				col,
+			)
+		}
+	}
+
+	return fmt.Sprintf(
+		`WITH %s, %s, source AS (
+	SELECT %s
+	FROM latest_all
+	LEFT JOIN latest_active ON %s
+	LEFT JOIN %s AS existing ON %s
+	WHERE latest_all."_cdc_deleted" = false OR latest_active."%s" IS NOT NULL OR existing."%s" IS NOT NULL
+)
+INSERT INTO %s (%s)
+SELECT %s FROM source
+ON CONFLICT (%s) DO UPDATE SET %s`,
+		latestAll,
+		latestActive,
+		strings.Join(selects, ", "),
+		buildJoinCondition(primaryKeys, "latest_all", "latest_active"),
+		quotedTargetTable,
+		buildJoinCondition(primaryKeys, "existing", "latest_all"),
+		primaryKeys[0],
+		primaryKeys[0],
+		quotedTargetTable,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedPKs, ", "),
+		buildConflictUpdateSet(nonPKColumns),
+	)
+}
+
+func containsColumn(columns []string, column string) bool {
+	for _, col := range columns {
+		if strings.EqualFold(col, column) {
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteInsertTable performs a DELETE + INSERT operation using a transaction.

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -434,6 +434,17 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 
+	if destination.HasCDCDeletedColumn(columns) {
+		if err := executeSQLiteCDCMerge(ctx, tx, opts, quotedTargetTable, quotedColumns, nonPKColumns); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		config.Debug("[MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	// Build dedup subquery to handle duplicate PKs in staging
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
 	dedupSource := fmt.Sprintf(
@@ -483,6 +494,109 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 	}
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
+
+func sqliteLatestCDCCTE(name string, stagingTable string, primaryKeys, columns []string, filter string) string {
+	quotedCols := quoteColumns(columns)
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		`%s AS (SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY "_cdc_lsn" DESC, "_cdc_synced_at" DESC, rowid DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1)`,
+		name,
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		destination.QuoteTableName(stagingTable),
+		where,
+	)
+}
+
+func sqliteCDCDeletedPredicate(value bool) string {
+	if value {
+		return `("_cdc_deleted" = true OR "_cdc_deleted" = 1 OR lower(CAST("_cdc_deleted" AS TEXT)) = 'true')`
+	}
+	return `("_cdc_deleted" = false OR "_cdc_deleted" = 0 OR lower(CAST("_cdc_deleted" AS TEXT)) = 'false')`
+}
+
+func buildSQLiteCDCMergeSQL(opts destination.MergeOptions, quotedTargetTable string, quotedColumns []string, nonPKColumns []string) string {
+	dataColumns := destination.CDCDataColumns(opts.Columns, opts.PrimaryKeys)
+	activeColumns := append(append([]string{}, opts.PrimaryKeys...), dataColumns...)
+	latestAll := sqliteLatestCDCCTE("latest_all", opts.StagingTable, opts.PrimaryKeys, opts.Columns, "")
+	latestActive := sqliteLatestCDCCTE("latest_active", opts.StagingTable, opts.PrimaryKeys, activeColumns, sqliteCDCDeletedPredicate(false))
+
+	selects := make([]string, len(opts.Columns))
+	for i, col := range opts.Columns {
+		switch {
+		case destination.IsCDCColumn(col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		case containsColumn(opts.PrimaryKeys, col):
+			selects[i] = fmt.Sprintf(`latest_all."%s" AS "%s"`, col, col)
+		default:
+			selects[i] = fmt.Sprintf(
+				`CASE WHEN %s THEN latest_all."%s" WHEN latest_active."%s" IS NOT NULL THEN latest_active."%s" ELSE existing."%s" END AS "%s"`,
+				strings.ReplaceAll(sqliteCDCDeletedPredicate(false), `"_cdc_deleted"`, `latest_all."_cdc_deleted"`),
+				col,
+				opts.PrimaryKeys[0],
+				col,
+				col,
+				col,
+			)
+		}
+	}
+
+	updates := make([]string, len(nonPKColumns))
+	for i, col := range nonPKColumns {
+		updates[i] = fmt.Sprintf(`"%s" = excluded."%s"`, col, col)
+	}
+
+	return fmt.Sprintf(
+		`WITH %s, %s, source AS (
+	SELECT %s
+	FROM latest_all
+	LEFT JOIN latest_active ON %s
+	LEFT JOIN %s AS existing ON %s
+	WHERE %s OR latest_active."%s" IS NOT NULL OR existing."%s" IS NOT NULL
+)
+INSERT INTO %s (%s)
+SELECT %s FROM source WHERE true
+ON CONFLICT (%s) DO UPDATE SET %s`,
+		latestAll,
+		latestActive,
+		strings.Join(selects, ", "),
+		buildJoinConditionSQLite(opts.PrimaryKeys, "latest_all", "latest_active"),
+		quotedTargetTable,
+		buildJoinConditionSQLite(opts.PrimaryKeys, "existing", "latest_all"),
+		strings.ReplaceAll(sqliteCDCDeletedPredicate(false), `"_cdc_deleted"`, `latest_all."_cdc_deleted"`),
+		opts.PrimaryKeys[0],
+		opts.PrimaryKeys[0],
+		quotedTargetTable,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+		strings.Join(updates, ", "),
+	)
+}
+
+func containsColumn(columns []string, column string) bool {
+	for _, col := range columns {
+		if strings.EqualFold(col, column) {
+			return true
+		}
+	}
+	return false
+}
+
+func executeSQLiteCDCMerge(ctx context.Context, tx *sql.Tx, opts destination.MergeOptions, quotedTargetTable string, quotedColumns []string, nonPKColumns []string) error {
+	mergeSQL := buildSQLiteCDCMergeSQL(opts, quotedTargetTable, quotedColumns, nonPKColumns)
+	config.Debug("[MERGE] Executing CDC merge: %s", mergeSQL)
+	if _, err := tx.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to execute CDC merge: %w", err)
+	}
 	return nil
 }
 
@@ -677,8 +791,26 @@ func (d *SQLiteDestination) SupportsSCD2Strategy() bool { return true }
 // SupportsAtomicSwap returns true as SQLite supports atomic table renames.
 func (d *SQLiteDestination) SupportsAtomicSwap() bool { return true }
 
+func (d *SQLiteDestination) SupportsCDCMerge() bool { return true }
+
 // GetScheme returns the primary URI scheme for SQLite.
 func (d *SQLiteDestination) GetScheme() string { return "sqlite" }
+
+func (d *SQLiteDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %s`, destination.QuoteTableName(table))
+	if err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 // GetTableSchema returns the current schema of a table, or nil if table doesn't exist.
 func (d *SQLiteDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {

--- a/tests/integration/mssql_cdc_test.go
+++ b/tests/integration/mssql_cdc_test.go
@@ -1,0 +1,490 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMSSQLCDC_DuckDB_UpdateDeleteAndSchemaChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	ctx := context.Background()
+	sourceURI := createMSSQLCDCDatabase(t, ctx)
+	db := openMSSQLTestDB(t, sourceURI)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE dbo.accounts (
+			id INT NOT NULL PRIMARY KEY,
+			name NVARCHAR(100) NOT NULL,
+			balance INT NOT NULL,
+			note NVARCHAR(100) NULL
+		)
+	`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO dbo.accounts (id, name, balance, note) VALUES
+			(1, N'alpha', 100, N'a'),
+			(2, N'bravo', 200, N'b'),
+			(3, N'charlie', 300, N'c')
+	`)
+	require.NoError(t, err)
+	enableMSSQLCDCTable(t, ctx, db, "dbo", "accounts")
+
+	duckPath := filepath.Join(t.TempDir(), "mssql_cdc.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           mssqlCDCURI(sourceURI),
+		SourceTable:         "dbo.accounts",
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckPath),
+		DestTable:           "accounts_dest",
+		IncrementalStrategy: config.StrategyMerge,
+		SchemaContract:      "evolve",
+		PageSize:            2,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	requireDuckDBCount(t, ctx, duckPath, "accounts_dest", 3)
+	firstMax := duckDBString(t, ctx, duckPath, `SELECT MAX("_cdc_lsn") FROM accounts_dest`)
+	require.NotEmpty(t, firstMax)
+
+	beforeChange := mssqlCDCMaxLSN(t, ctx, db)
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `UPDATE dbo.accounts SET name = N'alpha-updated', balance = 150 WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `DELETE FROM dbo.accounts WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `UPDATE dbo.accounts SET balance = 250 WHERE id = 2`)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `DELETE FROM dbo.accounts WHERE id = 3`)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `INSERT INTO dbo.accounts (id, name, balance, note) VALUES (4, N'delta', 400, N'd')`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	waitForMSSQLCDCAdvance(t, ctx, db, beforeChange)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	requireDuckDBCount(t, ctx, duckPath, "accounts_dest", 4)
+	requireDuckDBCountWhere(t, ctx, duckPath, "accounts_dest", `"_cdc_deleted" = false`, 2)
+
+	var name string
+	var balance int
+	var deleted bool
+	queryDuckDBRow(t, ctx, duckPath, `SELECT name, balance, "_cdc_deleted" FROM accounts_dest WHERE id = 1`, &name, &balance, &deleted)
+	assert.Equal(t, "alpha-updated", name)
+	assert.Equal(t, 150, balance)
+	assert.True(t, deleted)
+
+	queryDuckDBRow(t, ctx, duckPath, `SELECT balance, "_cdc_deleted" FROM accounts_dest WHERE id = 2`, &balance, &deleted)
+	assert.Equal(t, 250, balance)
+	assert.False(t, deleted)
+
+	disableMSSQLCDCTable(t, ctx, db, "dbo", "accounts", "dbo_accounts")
+	_, err = db.ExecContext(ctx, `ALTER TABLE dbo.accounts ADD tier NVARCHAR(20) NULL`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.accounts SET tier = N'gold' WHERE id = 2`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `ALTER TABLE dbo.accounts DROP COLUMN note`)
+	require.NoError(t, err)
+	enableMSSQLCDCTable(t, ctx, db, "dbo", "accounts")
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	queryDuckDBRow(t, ctx, duckPath, `SELECT tier FROM accounts_dest WHERE id = 2`, &name)
+	assert.Equal(t, "gold", name)
+	assert.True(t, duckDBColumnExists(t, ctx, duckPath, "accounts_dest", "tier"))
+	assert.True(t, duckDBColumnExists(t, ctx, duckPath, "accounts_dest", "note"), "dropped source columns should be soft-retained in the destination")
+}
+
+func TestMSSQLCDC_Postgres_UpdateDeleteResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	ctx := context.Background()
+	sourceURI := createMSSQLCDCDatabase(t, ctx)
+	db := openMSSQLTestDB(t, sourceURI)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE dbo.orders (
+			id INT NOT NULL PRIMARY KEY,
+			status NVARCHAR(50) NOT NULL,
+			amount INT NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO dbo.orders (id, status, amount) VALUES
+			(10, N'new', 100),
+			(20, N'new', 200)
+	`)
+	require.NoError(t, err)
+	enableMSSQLCDCTable(t, ctx, db, "dbo", "orders")
+
+	destURI := sharedPostgresURI(t, "dest")
+	destSchema := uniqueSchemaName(t, "mssql_cdc_pg")
+	ensurePostgresSchema(t, ctx, destURI, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, destURI, destSchema) })
+
+	cfg := &config.IngestConfig{
+		SourceURI:           mssqlCDCURI(sourceURI),
+		SourceTable:         "dbo.orders",
+		DestURI:             destURI,
+		DestTable:           destSchema + ".orders_dest",
+		IncrementalStrategy: config.StrategyMerge,
+		SchemaContract:      "evolve",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pgdb, err := sql.Open("pgx", destURI)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgdb.Close() })
+
+	var count int
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."orders_dest"`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count)
+
+	beforeChange := mssqlCDCMaxLSN(t, ctx, db)
+	_, err = db.ExecContext(ctx, `
+		UPDATE dbo.orders SET status = N'paid', amount = 250 WHERE id = 20;
+		DELETE FROM dbo.orders WHERE id = 10;
+		INSERT INTO dbo.orders (id, status, amount) VALUES (30, N'new', 300);
+	`)
+	require.NoError(t, err)
+	waitForMSSQLCDCAdvance(t, ctx, db, beforeChange)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."orders_dest"`, destSchema)).Scan(&count))
+	assert.Equal(t, 3, count)
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."orders_dest" WHERE "_cdc_deleted" = false`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count)
+
+	var status string
+	var amount int
+	var deleted bool
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT status, amount, "_cdc_deleted" FROM "%s"."orders_dest" WHERE id = 20`, destSchema)).Scan(&status, &amount, &deleted))
+	assert.Equal(t, "paid", status)
+	assert.Equal(t, 250, amount)
+	assert.False(t, deleted)
+
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT "_cdc_deleted" FROM "%s"."orders_dest" WHERE id = 10`, destSchema)).Scan(&deleted))
+	assert.True(t, deleted)
+}
+
+func TestMSSQLCDC_DuckDB_MultiTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	ctx := context.Background()
+	sourceURI := createMSSQLCDCDatabase(t, ctx)
+	db := openMSSQLTestDB(t, sourceURI)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE dbo.customers (
+			id INT NOT NULL PRIMARY KEY,
+			name NVARCHAR(100) NOT NULL
+		);
+		CREATE TABLE dbo.invoices (
+			id INT NOT NULL PRIMARY KEY,
+			customer_id INT NOT NULL,
+			amount INT NOT NULL
+		);
+		INSERT INTO dbo.customers (id, name) VALUES (1, N'Alice'), (2, N'Bob');
+		INSERT INTO dbo.invoices (id, customer_id, amount) VALUES (100, 1, 50), (200, 2, 75);
+	`)
+	require.NoError(t, err)
+	enableMSSQLCDCTable(t, ctx, db, "dbo", "customers")
+	enableMSSQLCDCTable(t, ctx, db, "dbo", "invoices")
+
+	duckPath := filepath.Join(t.TempDir(), "mssql_cdc_multitable.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           mssqlCDCURI(sourceURI),
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckPath),
+		IncrementalStrategy: config.StrategyMerge,
+		SchemaContract:      "evolve",
+		PageSize:            1,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	requireDuckDBCount(t, ctx, duckPath, `"dbo"."customers"`, 2)
+	requireDuckDBCount(t, ctx, duckPath, `"dbo"."invoices"`, 2)
+
+	beforeChange := mssqlCDCMaxLSN(t, ctx, db)
+	_, err = db.ExecContext(ctx, `
+		UPDATE dbo.customers SET name = N'Alice Cooper' WHERE id = 1;
+		DELETE FROM dbo.invoices WHERE id = 100;
+		INSERT INTO dbo.invoices (id, customer_id, amount) VALUES (300, 1, 125);
+	`)
+	require.NoError(t, err)
+	waitForMSSQLCDCAdvance(t, ctx, db, beforeChange)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var name string
+	queryDuckDBRow(t, ctx, duckPath, `SELECT name FROM "dbo"."customers" WHERE id = 1`, &name)
+	assert.Equal(t, "Alice Cooper", name)
+	requireDuckDBCountWhere(t, ctx, duckPath, `"dbo"."invoices"`, `"_cdc_deleted" = false`, 2)
+	requireDuckDBCountWhere(t, ctx, duckPath, `"dbo"."invoices"`, `id = 100 AND "_cdc_deleted" = true`, 1)
+}
+
+func TestMSSQLCDC_Postgres_MultiTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	ctx := context.Background()
+	sourceURI := createMSSQLCDCDatabase(t, ctx)
+	db := openMSSQLTestDB(t, sourceURI)
+	t.Cleanup(func() { _ = db.Close() })
+
+	sourceSchema := "mtpg_" + uniqueSuffix()
+	ensureMSSQLSchema(t, ctx, db, sourceSchema)
+
+	customersTable := sourceSchema + ".customers"
+	invoicesTable := sourceSchema + ".invoices"
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id INT NOT NULL PRIMARY KEY,
+			name NVARCHAR(100) NOT NULL
+		);
+		CREATE TABLE %s (
+			id INT NOT NULL PRIMARY KEY,
+			customer_id INT NOT NULL,
+			amount INT NOT NULL
+		);
+		INSERT INTO %s (id, name) VALUES (1, N'Alice'), (2, N'Bob');
+		INSERT INTO %s (id, customer_id, amount) VALUES (100, 1, 50), (200, 2, 75);
+	`, quoteTableMSSQL(customersTable), quoteTableMSSQL(invoicesTable), quoteTableMSSQL(customersTable), quoteTableMSSQL(invoicesTable)))
+	require.NoError(t, err)
+	enableMSSQLCDCTable(t, ctx, db, sourceSchema, "customers")
+	enableMSSQLCDCTable(t, ctx, db, sourceSchema, "invoices")
+
+	destURI := sharedPostgresURI(t, "dest")
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, destURI, sourceSchema) })
+
+	cfg := &config.IngestConfig{
+		SourceURI:           mssqlCDCURI(sourceURI),
+		DestURI:             destURI,
+		IncrementalStrategy: config.StrategyMerge,
+		SchemaContract:      "evolve",
+		PageSize:            1,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pgdb, err := sql.Open("pgx", destURI)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgdb.Close() })
+
+	var count int
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."customers"`, sourceSchema)).Scan(&count))
+	assert.Equal(t, 2, count)
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."invoices"`, sourceSchema)).Scan(&count))
+	assert.Equal(t, 2, count)
+
+	beforeChange := mssqlCDCMaxLSN(t, ctx, db)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s SET name = N'Alice Cooper' WHERE id = 1;
+		DELETE FROM %s WHERE id = 100;
+		INSERT INTO %s (id, customer_id, amount) VALUES (300, 1, 125);
+	`, quoteTableMSSQL(customersTable), quoteTableMSSQL(invoicesTable), quoteTableMSSQL(invoicesTable)))
+	require.NoError(t, err)
+	waitForMSSQLCDCAdvance(t, ctx, db, beforeChange)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var name string
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT name FROM "%s"."customers" WHERE id = 1`, sourceSchema)).Scan(&name))
+	assert.Equal(t, "Alice Cooper", name)
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."invoices" WHERE "_cdc_deleted" = false`, sourceSchema)).Scan(&count))
+	assert.Equal(t, 2, count)
+	require.NoError(t, pgdb.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"."invoices" WHERE id = 100 AND "_cdc_deleted" = true`, sourceSchema)).Scan(&count))
+	assert.Equal(t, 1, count)
+}
+
+func createMSSQLCDCDatabase(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	dbName := "cdc_" + uniqueSuffix()
+	adminDB := openMSSQLTestDB(t, mssqlDest.uri)
+	defer func() { _ = adminDB.Close() }()
+
+	_, err := adminDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE [%s]", dbName))
+	require.NoError(t, err)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET ALLOW_SNAPSHOT_ISOLATION ON", dbName))
+	require.NoError(t, err)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE", dbName))
+	require.NoError(t, err)
+
+	uri := mssqlURIWithDatabase(t, mssqlDest.uri, dbName)
+	db := openMSSQLTestDB(t, uri)
+	defer func() { _ = db.Close() }()
+	_, err = db.ExecContext(ctx, "EXEC sys.sp_cdc_enable_db")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupDB := openMSSQLTestDB(t, mssqlDest.uri)
+		defer func() { _ = cleanupDB.Close() }()
+		_, _ = cleanupDB.ExecContext(context.Background(), fmt.Sprintf("ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", dbName))
+		_, _ = cleanupDB.ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS [%s]", dbName))
+	})
+
+	return uri
+}
+
+func mssqlURIWithDatabase(t *testing.T, rawURI string, database string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURI)
+	require.NoError(t, err)
+	parsed.Path = "/" + database
+	return parsed.String()
+}
+
+func mssqlCDCURI(rawURI string) string {
+	return strings.Replace(rawURI, "mssql://", "mssql+cdc://", 1)
+}
+
+func enableMSSQLCDCTable(t *testing.T, ctx context.Context, db *sql.DB, schemaName, tableName string) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, "EXEC sys.sp_cdc_enable_table @source_schema = @p1, @source_name = @p2, @role_name = NULL, @supports_net_changes = 0", schemaName, tableName)
+	require.NoError(t, err)
+	waitForMSSQLCDCTable(t, ctx, db, schemaName+"_"+tableName)
+}
+
+func disableMSSQLCDCTable(t *testing.T, ctx context.Context, db *sql.DB, schemaName, tableName, captureInstance string) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, "EXEC sys.sp_cdc_disable_table @source_schema = @p1, @source_name = @p2, @capture_instance = @p3", schemaName, tableName, captureInstance)
+	require.NoError(t, err)
+}
+
+func waitForMSSQLCDCTable(t *testing.T, ctx context.Context, db *sql.DB, captureInstance string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var exists bool
+		err := db.QueryRowContext(ctx, "SELECT CAST(CASE WHEN EXISTS (SELECT 1 FROM cdc.change_tables WHERE capture_instance = @p1) THEN 1 ELSE 0 END AS bit)", captureInstance).Scan(&exists)
+		return err == nil && exists
+	}, 30*time.Second, 500*time.Millisecond)
+}
+
+func mssqlCDCMaxLSN(t *testing.T, ctx context.Context, db *sql.DB) string {
+	t.Helper()
+	var lsn sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT CONVERT(varchar(20), sys.fn_cdc_get_max_lsn(), 2)").Scan(&lsn))
+	if !lsn.Valid {
+		return ""
+	}
+	return strings.ToUpper(lsn.String)
+}
+
+func waitForMSSQLCDCAdvance(t *testing.T, ctx context.Context, db *sql.DB, previous string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, _ = db.ExecContext(ctx, "EXEC sys.sp_cdc_scan")
+		current := mssqlCDCMaxLSN(t, ctx, db)
+		return current != "" && current != previous
+	}, 60*time.Second, time.Second)
+}
+
+func queryDuckDBRow(t *testing.T, ctx context.Context, path, query string, dest ...any) {
+	t.Helper()
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", path))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	scanDest := make([]any, len(dest))
+	for i := range dest {
+		switch dest[i].(type) {
+		case *string:
+			var raw []byte
+			scanDest[i] = &raw
+			defer func(i int, rawPtr *[]byte) {
+				*(dest[i].(*string)) = string(append([]byte(nil), (*rawPtr)...))
+			}(i, &raw)
+		default:
+			scanDest[i] = dest[i]
+		}
+	}
+	require.NoError(t, db.QueryRowContext(ctx, query).Scan(scanDest...))
+}
+
+func duckDBString(t *testing.T, ctx context.Context, path, query string) string {
+	t.Helper()
+	var got string
+	queryDuckDBRow(t, ctx, path, query, &got)
+	return got
+}
+
+func requireDuckDBCount(t *testing.T, ctx context.Context, path, table string, expected int) {
+	t.Helper()
+	requireDuckDBCountWhere(t, ctx, path, table, "1 = 1", expected)
+}
+
+func requireDuckDBCountWhere(t *testing.T, ctx context.Context, path, table, where string, expected int) {
+	t.Helper()
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", path))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", table, where)).Scan(&count))
+	assert.Equal(t, expected, count)
+}
+
+func duckDBColumnExists(t *testing.T, ctx context.Context, path, table, column string) bool {
+	t.Helper()
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", path))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("DESCRIBE %s", table))
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name string
+		var rest []any
+		scanDest := []any{&name}
+		for range 5 {
+			var v any
+			rest = append(rest, &v)
+			scanDest = append(scanDest, &v)
+		}
+		if err := rows.Scan(scanDest...); err == nil && strings.EqualFold(name, column) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/integration/mssql_container_test.go
+++ b/tests/integration/mssql_container_test.go
@@ -24,6 +24,9 @@ func startMSSQLContainerRaw(ctx context.Context, name string) (testcontainers.Co
 		"mcr.microsoft.com/mssql/server:2022-latest",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(mssqlPassword),
+		testcontainers.WithEnv(map[string]string{
+			"MSSQL_AGENT_ENABLED": "true",
+		}),
 		testcontainers.WithWaitStrategy(
 			wait.ForAll(
 				wait.ForListeningPort("1433/tcp"),


### PR DESCRIPTION
## Summary
- add CDC-aware merge semantics for Postgres, DuckDB, SQLite, MySQL, MSSQL, and CrateDB
- preserve latest active data while marking latest tombstones
- suppress delete-only rows
- add DuckDB unit coverage and MSSQL CDC integration coverage

## Tests
- go test ./pkg/destination/postgres ./pkg/destination/duckdb ./pkg/destination/sqlite ./pkg/destination/mysql ./pkg/destination/mssql ./pkg/destination/cratedb
- go test ./pkg/source/mssql_cdc ./pkg/source/postgres_cdc ./pkg/source/mssql ./pkg/pipeline ./pkg/strategy ./pkg/destination ./pkg/destination/postgres ./pkg/destination/duckdb ./pkg/destination/sqlite ./pkg/destination/mysql ./pkg/destination/mssql ./pkg/destination/cratedb ./pkg/destination/bigquery ./pkg/destination/snowflake ./pkg/destination/redshift ./pkg/destination/fabric ./pkg/destination/synapse ./pkg/destination/trino ./pkg/destination/databricks

## Stack
1. #732
2. This PR
3. pr/cdc-cloud-destinations
4. pr/cdc-sql-warehouses
5. pr/cdc-conformance