### PR TITLE
Add CDC merge for SQL warehouse destinations

### DIFF
--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -371,6 +371,18 @@ func (d *DatabricksDestination) MergeTable(ctx context.Context, opts destination
 	stagingFull := d.quoteFullTable(stagingSchema, stagingName)
 	targetFull := d.quoteFullTable(targetSchema, targetName)
 
+	if destination.HasCDCDeletedColumn(opts.Columns) {
+		mergeSQL := buildDatabricksCDCMergeSQL(targetFull, stagingFull, opts.PrimaryKeys, opts.Columns)
+		config.Debug("[DATABRICKS] Executing CDC MERGE: %s", mergeSQL)
+		if err := d.executeStatement(ctx, mergeSQL); err != nil {
+			config.LogFailedQuery(mergeSQL, err)
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
+		}
+
+		config.Debug("[DATABRICKS] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	onConditions := make([]string, len(opts.PrimaryKeys))
 	for i, pk := range opts.PrimaryKeys {
 		onConditions[i] = fmt.Sprintf("target.`%s` = source.`%s`", pk, pk)
@@ -432,6 +444,188 @@ func (d *DatabricksDestination) MergeTable(ctx context.Context, opts destination
 
 	config.Debug("[DATABRICKS] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func databricksQuoteColumns(columns []string) []string {
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = fmt.Sprintf("`%s`", col)
+	}
+	return quoted
+}
+
+func databricksAliasJoin(primaryKeys []string, leftAlias, rightAlias string) string {
+	conditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		conditions[i] = fmt.Sprintf("%s.`%s` = %s.`%s`", leftAlias, pk, rightAlias, pk)
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func buildDatabricksLatestCDCSource(stagingFull string, primaryKeys, columns []string, filter, alias string) string {
+	quotedCols := databricksQuoteColumns(columns)
+	quotedPKs := databricksQuoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+
+	return fmt.Sprintf(
+		"(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC, `_cdc_synced_at` DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s",
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		stagingFull,
+		where,
+		alias,
+	)
+}
+
+func databricksActiveAlias(index int) string {
+	return fmt.Sprintf("__bruin_active_%d", index)
+}
+
+func buildDatabricksCDCSource(stagingFull string, primaryKeys, allColumns, dataColumns []string) string {
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := buildDatabricksLatestCDCSource(stagingFull, primaryKeys, allColumns, "", "latest_all")
+	latestActive := buildDatabricksLatestCDCSource(stagingFull, primaryKeys, activeColumns, "`_cdc_deleted` = false", "latest_active")
+
+	selects := []string{
+		"latest_all.*",
+		fmt.Sprintf("latest_active.`%s` IS NOT NULL AS `__bruin_has_active`", primaryKeys[0]),
+	}
+	for i, col := range dataColumns {
+		selects = append(selects, fmt.Sprintf("latest_active.`%s` AS `%s`", col, databricksActiveAlias(i)))
+	}
+
+	return fmt.Sprintf(
+		`(SELECT %s FROM %s LEFT JOIN %s ON %s) AS source`,
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		databricksAliasJoin(primaryKeys, "latest_all", "latest_active"),
+	)
+}
+
+func buildDatabricksCDCMergeSQL(targetFull, stagingFull string, primaryKeys, allColumns []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	dataColumnIndex := make(map[string]int, len(dataColumns))
+	for i, col := range dataColumns {
+		dataColumnIndex[strings.ToLower(col)] = i
+	}
+
+	pkMap := make(map[string]bool)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	var updateSets []string
+	for _, col := range allColumns {
+		if pkMap[strings.ToLower(col)] {
+			continue
+		}
+		if destination.IsCDCColumn(col) {
+			updateSets = append(updateSets, fmt.Sprintf("target.`%s` = source.`%s`", col, col))
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		updateSets = append(updateSets, fmt.Sprintf(
+			"target.`%s` = CASE WHEN source.`_cdc_deleted` = true THEN CASE WHEN source.`__bruin_has_active` THEN source.`%s` ELSE target.`%s` END ELSE source.`%s` END",
+			col,
+			databricksActiveAlias(activeIndex),
+			col,
+			col,
+		))
+	}
+
+	quotedCols := databricksQuoteColumns(allColumns)
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+			sourceCols[i] = fmt.Sprintf("source.`%s`", col)
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		sourceCols[i] = fmt.Sprintf(
+			"CASE WHEN source.`_cdc_deleted` = true AND source.`__bruin_has_active` THEN source.`%s` ELSE source.`%s` END",
+			databricksActiveAlias(activeIndex),
+			col,
+		)
+	}
+
+	var mergeSQL strings.Builder
+	fmt.Fprintf(&mergeSQL, "MERGE INTO %s AS target\n", targetFull)
+	fmt.Fprintf(&mergeSQL, "USING %s\n", buildDatabricksCDCSource(stagingFull, primaryKeys, allColumns, dataColumns))
+	fmt.Fprintf(&mergeSQL, "ON %s\n", databricksAliasJoin(primaryKeys, "target", "source"))
+	if len(updateSets) > 0 {
+		mergeSQL.WriteString("WHEN MATCHED THEN\n")
+		fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+	}
+	mergeSQL.WriteString("WHEN NOT MATCHED AND (source.`_cdc_deleted` = false OR source.`__bruin_has_active`) THEN\n")
+	fmt.Fprintf(&mergeSQL, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+	fmt.Fprintf(&mergeSQL, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+	return mergeSQL.String()
+}
+
+func buildDatabricksCDCActiveMergeSQL(targetFull, stagingFull string, primaryKeys, allColumns []string) string {
+	pkMap := make(map[string]bool)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	var updateSets []string
+	for _, col := range allColumns {
+		if !pkMap[strings.ToLower(col)] {
+			updateSets = append(updateSets, fmt.Sprintf("target.`%s` = source.`%s`", col, col))
+		}
+	}
+
+	quotedCols := databricksQuoteColumns(allColumns)
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		sourceCols[i] = fmt.Sprintf("source.`%s`", col)
+	}
+
+	source := buildDatabricksLatestCDCSource(stagingFull, primaryKeys, allColumns, "`_cdc_deleted` = false", "source")
+
+	var mergeSQL strings.Builder
+	fmt.Fprintf(&mergeSQL, "MERGE INTO %s AS target\n", targetFull)
+	fmt.Fprintf(&mergeSQL, "USING %s\n", source)
+	fmt.Fprintf(&mergeSQL, "ON %s\n", databricksAliasJoin(primaryKeys, "target", "source"))
+	if len(updateSets) > 0 {
+		mergeSQL.WriteString("WHEN MATCHED THEN\n")
+		fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+	}
+	mergeSQL.WriteString("WHEN NOT MATCHED THEN\n")
+	fmt.Fprintf(&mergeSQL, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+	fmt.Fprintf(&mergeSQL, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+	return mergeSQL.String()
+}
+
+func buildDatabricksCDCDeletedMergeSQL(targetFull, stagingFull string, primaryKeys []string) string {
+	cdcColumns := append([]string{}, primaryKeys...)
+	cdcColumns = append(cdcColumns, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+	latestAll := buildDatabricksLatestCDCSource(stagingFull, primaryKeys, cdcColumns, "", "latest")
+	latestDeleted := buildDatabricksLatestCDCSource(stagingFull, primaryKeys, cdcColumns, "`_cdc_deleted` = true", "deleted")
+
+	source := fmt.Sprintf(
+		`(SELECT deleted.* FROM %s JOIN %s ON %s WHERE latest.`+"`_cdc_deleted`"+` = true) AS source`,
+		latestDeleted,
+		latestAll,
+		databricksAliasJoin(primaryKeys, "deleted", "latest"),
+	)
+
+	return fmt.Sprintf(
+		`MERGE INTO %s AS target
+USING %s
+ON %s
+WHEN MATCHED THEN UPDATE SET target.`+"`_cdc_deleted`"+` = true, target.`+"`_cdc_lsn`"+` = source.`+"`_cdc_lsn`"+`, target.`+"`_cdc_synced_at`"+` = source.`+"`_cdc_synced_at`",
+		targetFull,
+		source,
+		databricksAliasJoin(primaryKeys, "target", "source"),
+	)
 }
 
 func (d *DatabricksDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
@@ -553,6 +747,7 @@ func (d *DatabricksDestination) SupportsMergeStrategy() bool        { return tru
 func (d *DatabricksDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *DatabricksDestination) SupportsSCD2Strategy() bool         { return false }
 func (d *DatabricksDestination) SupportsAtomicSwap() bool           { return true }
+func (d *DatabricksDestination) SupportsCDCMerge() bool             { return true }
 
 func (d *DatabricksDestination) GetScheme() string { return "databricks" }
 

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -346,6 +346,18 @@ func (d *FabricDestination) MergeTable(ctx context.Context, opts destination.Mer
 	quotedColumns := quoteColumns(opts.Columns)
 	nonPKColumns := filterColumns(opts.Columns, opts.PrimaryKeys)
 
+	if destination.HasCDCDeletedColumn(opts.Columns) {
+		mergeSQL := buildCDCMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, quotedColumns, nonPKColumns)
+		config.Debug("[Fabric MERGE] Executing CDC MERGE: %s", mergeSQL)
+		if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+			config.LogFailedQuery(mergeSQL, err)
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
+		}
+
+		config.Debug("[Fabric MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns)
 	config.Debug("[Fabric MERGE] Executing MERGE: %s", mergeSQL)
 
@@ -356,6 +368,178 @@ func (d *FabricDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	config.Debug("[Fabric MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func buildFabricLatestCDCSource(stagingTable string, primaryKeys, quotedColumns []string, filter, alias string) string {
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY [_cdc_lsn] DESC, [_cdc_synced_at] DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s`,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedPKs, ", "),
+		quoteTable(stagingTable),
+		where,
+		alias,
+	)
+}
+
+func fabricActiveAlias(index int) string {
+	return fmt.Sprintf("__bruin_active_%d", index)
+}
+
+func buildFabricCDCSource(stagingTable string, primaryKeys, allColumns, dataColumns []string) string {
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := buildFabricLatestCDCSource(stagingTable, primaryKeys, quoteColumns(allColumns), "", "latest_all")
+	latestActive := buildFabricLatestCDCSource(stagingTable, primaryKeys, quoteColumns(activeColumns), "[_cdc_deleted] = 0", "latest_active")
+
+	selects := []string{
+		"latest_all.*",
+		fmt.Sprintf("CASE WHEN latest_active.[%s] IS NULL THEN 0 ELSE 1 END AS [__bruin_has_active]", primaryKeys[0]),
+	}
+	for i, col := range dataColumns {
+		selects = append(selects, fmt.Sprintf("latest_active.[%s] AS [%s]", col, fabricActiveAlias(i)))
+	}
+
+	return fmt.Sprintf(
+		`(SELECT %s FROM %s LEFT JOIN %s ON %s) AS source`,
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		buildJoinCondition(primaryKeys, "latest_all", "latest_active"),
+	)
+}
+
+func buildCDCMergeSQL(targetTable, stagingTable string, primaryKeys, allColumns, quotedColumns, nonPKColumns []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	dataColumnIndex := make(map[string]int, len(dataColumns))
+	for i, col := range dataColumns {
+		dataColumnIndex[strings.ToLower(col)] = i
+	}
+	pkMap := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	updates := make([]string, 0, len(nonPKColumns))
+	for _, col := range nonPKColumns {
+		if destination.IsCDCColumn(col) {
+			updates = append(updates, fmt.Sprintf("target.[%s] = source.[%s]", col, col))
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		updates = append(updates, fmt.Sprintf(
+			"target.[%s] = CASE WHEN source.[_cdc_deleted] = 1 THEN CASE WHEN source.[__bruin_has_active] = 1 THEN source.[%s] ELSE target.[%s] END ELSE source.[%s] END",
+			col,
+			fabricActiveAlias(activeIndex),
+			col,
+			col,
+		))
+	}
+
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		quotedCol := fmt.Sprintf("[%s]", col)
+		if destination.IsCDCColumn(col) {
+			sourceCols[i] = "source." + quotedCol
+			continue
+		}
+
+		if pkMap[strings.ToLower(col)] {
+			sourceCols[i] = "source." + quotedCol
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		sourceCols[i] = fmt.Sprintf(
+			"CASE WHEN source.[_cdc_deleted] = 1 AND source.[__bruin_has_active] = 1 THEN source.[%s] ELSE source.%s END",
+			fabricActiveAlias(activeIndex),
+			quotedCol,
+		)
+	}
+
+	var updateSet string
+	if len(updates) > 0 {
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s
+ON %s
+%s
+WHEN NOT MATCHED AND (source.[_cdc_deleted] = 0 OR source.[__bruin_has_active] = 1) THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		buildFabricCDCSource(stagingTable, primaryKeys, allColumns, dataColumns),
+		buildJoinCondition(primaryKeys, "target", "source"),
+		updateSet,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func buildCDCActiveMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
+	onConditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
+	}
+
+	var updateSet string
+	if len(nonPKColumns) > 0 {
+		updates := make([]string, len(nonPKColumns))
+		for i, col := range nonPKColumns {
+			updates[i] = fmt.Sprintf("target.[%s] = source.[%s]", col, col)
+		}
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	insertCols := strings.Join(quotedColumns, ", ")
+	sourceCols := make([]string, len(quotedColumns))
+	for i, col := range quotedColumns {
+		sourceCols[i] = "source." + col
+	}
+
+	dedupSource := buildFabricLatestCDCSource(stagingTable, primaryKeys, quotedColumns, "[_cdc_deleted] = 0", "source")
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s
+ON %s
+%s
+WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		dedupSource,
+		strings.Join(onConditions, " AND "),
+		updateSet,
+		insertCols,
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func buildCDCDeletedUpdateSQL(targetTable, stagingTable string, primaryKeys []string) string {
+	cdcColumns := append([]string{}, primaryKeys...)
+	cdcColumns = append(cdcColumns, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+	quotedCDCColumns := quoteColumns(cdcColumns)
+	latestAll := buildFabricLatestCDCSource(stagingTable, primaryKeys, quotedCDCColumns, "", "latest")
+	latestDeleted := buildFabricLatestCDCSource(stagingTable, primaryKeys, quotedCDCColumns, "[_cdc_deleted] = 1", "deleted")
+
+	return fmt.Sprintf(
+		`UPDATE target
+SET target.[_cdc_deleted] = 1, target.[_cdc_lsn] = deleted.[_cdc_lsn], target.[_cdc_synced_at] = deleted.[_cdc_synced_at]
+FROM %s AS target
+INNER JOIN %s ON %s
+INNER JOIN %s ON %s
+WHERE latest.[_cdc_deleted] = 1;`,
+		quoteTable(targetTable),
+		latestDeleted,
+		buildJoinCondition(primaryKeys, "target", "deleted"),
+		latestAll,
+		buildJoinCondition(primaryKeys, "deleted", "latest"),
+	)
 }
 
 func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
@@ -582,6 +766,7 @@ func (d *FabricDestination) SupportsAppendStrategy() bool       { return true }
 func (d *FabricDestination) SupportsMergeStrategy() bool        { return true }
 func (d *FabricDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *FabricDestination) SupportsSCD2Strategy() bool         { return true }
+func (d *FabricDestination) SupportsCDCMerge() bool             { return true }
 
 // SupportsAtomicSwap is false: staging tables live in a separate schema and
 // Fabric does not document ALTER SCHEMA ... TRANSFER, so the replace strategy
@@ -589,6 +774,22 @@ func (d *FabricDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *FabricDestination) SupportsAtomicSwap() bool { return false }
 
 func (d *FabricDestination) GetScheme() string { return "fabric" }
+
+func (d *FabricDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf("SELECT MAX([_cdc_lsn]) FROM %s", quoteTable(table))
+	if err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "Invalid object name") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *FabricDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	schemaName, tableName := parseTableName(table)

--- a/pkg/destination/redshift/redshift.go
+++ b/pkg/destination/redshift/redshift.go
@@ -3,7 +3,6 @@ package redshift
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -151,6 +150,17 @@ func (d *RedshiftDestination) MergeTable(ctx context.Context, opts destination.M
 		return fmt.Errorf("merge requires at least one primary key")
 	}
 
+	if destination.HasCDCDeletedColumn(opts.Columns) {
+		mergeSQL := d.buildCDCMergeSQL(opts.StagingTable, opts.TargetTable, opts.PrimaryKeys, opts.Columns)
+		config.Debug("[MERGE] Executing CDC MERGE: %s", mergeSQL)
+		if err := d.Exec(ctx, mergeSQL); err != nil {
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
+		}
+
+		config.Debug("[MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	mergeSQL := d.buildMergeSQL(opts.StagingTable, opts.TargetTable, opts.PrimaryKeys, opts.Columns)
 	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
 
@@ -160,6 +170,184 @@ func (d *RedshiftDestination) MergeTable(ctx context.Context, opts destination.M
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func redshiftQuoteColumns(columns []string) []string {
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = fmt.Sprintf(`"%s"`, col)
+	}
+	return quoted
+}
+
+func redshiftLatestCDCCTE(name, table string, primaryKeys, columns []string, filter string) string {
+	quotedCols := redshiftQuoteColumns(columns)
+	quotedPKs := redshiftQuoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		`%s AS (SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY "_cdc_lsn" DESC, "_cdc_synced_at" DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1)`,
+		name,
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		destination.QuoteTableName(table),
+		where,
+	)
+}
+
+func redshiftAliasJoin(primaryKeys []string, leftAlias, rightAlias string) string {
+	conditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		conditions[i] = fmt.Sprintf(`%s."%s" = %s."%s"`, leftAlias, pk, rightAlias, pk)
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func redshiftActiveAlias(index int) string {
+	return fmt.Sprintf("__bruin_active_%d", index)
+}
+
+func redshiftCDCSource(stagingTable string, primaryKeys, allColumns, dataColumns []string) string {
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := redshiftLatestCDCCTE("latest_all", stagingTable, primaryKeys, allColumns, "")
+	latestActive := redshiftLatestCDCCTE("latest_active", stagingTable, primaryKeys, activeColumns, `"_cdc_deleted" = false`)
+
+	selects := []string{
+		"latest_all.*",
+		fmt.Sprintf(`latest_active."%s" IS NOT NULL AS "__bruin_has_active"`, primaryKeys[0]),
+	}
+	for i, col := range dataColumns {
+		selects = append(selects, fmt.Sprintf(`latest_active."%s" AS "%s"`, col, redshiftActiveAlias(i)))
+	}
+
+	return fmt.Sprintf(
+		`(WITH %s, %s SELECT %s FROM latest_all LEFT JOIN latest_active ON %s)`,
+		latestAll,
+		latestActive,
+		strings.Join(selects, ", "),
+		redshiftAliasJoin(primaryKeys, "latest_all", "latest_active"),
+	)
+}
+
+func (d *RedshiftDestination) buildCDCMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	dataColumnIndex := make(map[string]int, len(dataColumns))
+	for i, col := range dataColumns {
+		dataColumnIndex[strings.ToLower(col)] = i
+	}
+
+	pkMap := make(map[string]bool)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	var updateSets []string
+	for _, col := range allColumns {
+		if pkMap[strings.ToLower(col)] {
+			continue
+		}
+		if destination.IsCDCColumn(col) {
+			updateSets = append(updateSets, fmt.Sprintf(`"%s" = source."%s"`, col, col))
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		updateSets = append(updateSets, fmt.Sprintf(
+			`"%s" = CASE WHEN source."_cdc_deleted" = true THEN CASE WHEN source."__bruin_has_active" THEN source."%s" ELSE target."%s" END ELSE source."%s" END`,
+			col,
+			redshiftActiveAlias(activeIndex),
+			col,
+			col,
+		))
+	}
+
+	quotedCols := redshiftQuoteColumns(allColumns)
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+			sourceCols[i] = fmt.Sprintf(`source."%s"`, col)
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		sourceCols[i] = fmt.Sprintf(
+			`CASE WHEN source."_cdc_deleted" = true AND source."__bruin_has_active" THEN source."%s" ELSE source."%s" END`,
+			redshiftActiveAlias(activeIndex),
+			col,
+		)
+	}
+
+	var sql strings.Builder
+	fmt.Fprintf(&sql, "MERGE INTO %s AS target\n", destination.QuoteTableName(targetTable))
+	fmt.Fprintf(&sql, "USING %s AS source\n", redshiftCDCSource(stagingTable, primaryKeys, allColumns, dataColumns))
+	fmt.Fprintf(&sql, "ON %s\n", redshiftAliasJoin(primaryKeys, "target", "source"))
+	if len(updateSets) > 0 {
+		sql.WriteString("WHEN MATCHED THEN\n")
+		fmt.Fprintf(&sql, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+	}
+	sql.WriteString(`WHEN NOT MATCHED AND (source."_cdc_deleted" = false OR source."__bruin_has_active") THEN` + "\n")
+	fmt.Fprintf(&sql, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+	fmt.Fprintf(&sql, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+	return sql.String()
+}
+
+func (d *RedshiftDestination) buildCDCActiveMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []string) string {
+	quotedCols := redshiftQuoteColumns(allColumns)
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		sourceCols[i] = fmt.Sprintf(`source."%s"`, col)
+	}
+
+	pkMap := make(map[string]bool)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	var updateSets []string
+	for _, col := range allColumns {
+		if !pkMap[strings.ToLower(col)] {
+			updateSets = append(updateSets, fmt.Sprintf(`"%s" = source."%s"`, col, col))
+		}
+	}
+
+	latestActive := redshiftLatestCDCCTE("latest_active", stagingTable, primaryKeys, allColumns, `"_cdc_deleted" = false`)
+
+	var sql strings.Builder
+	fmt.Fprintf(&sql, "MERGE INTO %s AS target\n", destination.QuoteTableName(targetTable))
+	fmt.Fprintf(&sql, "USING (WITH %s SELECT * FROM latest_active) AS source\n", latestActive)
+	fmt.Fprintf(&sql, "ON %s\n", redshiftAliasJoin(primaryKeys, "target", "source"))
+	if len(updateSets) > 0 {
+		sql.WriteString("WHEN MATCHED THEN\n")
+		fmt.Fprintf(&sql, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+	}
+	sql.WriteString("WHEN NOT MATCHED THEN\n")
+	fmt.Fprintf(&sql, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+	fmt.Fprintf(&sql, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+	return sql.String()
+}
+
+func (d *RedshiftDestination) buildCDCDeletedUpdateSQL(stagingTable, targetTable string, primaryKeys []string) string {
+	cdcColumns := append([]string{}, primaryKeys...)
+	cdcColumns = append(cdcColumns, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+	latestAll := redshiftLatestCDCCTE("latest_all", stagingTable, primaryKeys, cdcColumns, "")
+	latestDeleted := redshiftLatestCDCCTE("latest_deleted", stagingTable, primaryKeys, cdcColumns, `"_cdc_deleted" = true`)
+
+	return fmt.Sprintf(
+		`WITH %s, %s
+UPDATE %s AS target
+SET "_cdc_deleted" = true, "_cdc_lsn" = deleted."_cdc_lsn", "_cdc_synced_at" = deleted."_cdc_synced_at"
+FROM latest_deleted AS deleted
+JOIN latest_all AS latest ON %s
+WHERE %s AND latest."_cdc_deleted" = true`,
+		latestAll,
+		latestDeleted,
+		destination.QuoteTableName(targetTable),
+		redshiftAliasJoin(primaryKeys, "deleted", "latest"),
+		redshiftAliasJoin(primaryKeys, "target", "deleted"),
+	)
 }
 
 func (d *RedshiftDestination) buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []string) string {
@@ -188,7 +376,7 @@ func (d *RedshiftDestination) buildMergeSQL(stagingTable, targetTable string, pr
 		sourceCols[i] = fmt.Sprintf(`source."%s"`, col)
 	}
 
-	hasCDCDeleted := slices.Contains(allColumns, "_cdc_deleted")
+	hasCDCDeleted := destination.HasCDCDeletedColumn(allColumns)
 
 	// Build dedup subquery to handle duplicate PKs in staging
 	quotedPKsForPartition := make([]string, len(primaryKeys))

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -399,6 +399,18 @@ func (d *SynapseDestination) MergeTable(ctx context.Context, opts destination.Me
 	quotedColumns := quoteColumns(columns)
 	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
 
+	if destination.HasCDCDeletedColumn(columns) {
+		mergeSQL := buildCDCMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, columns, quotedColumns, nonPKColumns)
+		config.Debug("[Synapse MERGE] Executing CDC MERGE: %s", mergeSQL)
+		if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+			config.LogFailedQuery(mergeSQL, err)
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
+		}
+
+		config.Debug("[Synapse MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns)
 	config.Debug("[Synapse MERGE] Executing MERGE: %s", mergeSQL)
 
@@ -409,6 +421,178 @@ func (d *SynapseDestination) MergeTable(ctx context.Context, opts destination.Me
 
 	config.Debug("[Synapse MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func buildSynapseLatestCDCSource(stagingTable string, primaryKeys, quotedColumns []string, filter, alias string) string {
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+	return fmt.Sprintf(
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY [_cdc_lsn] DESC, [_cdc_synced_at] DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s`,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(quotedPKs, ", "),
+		quoteTable(stagingTable),
+		where,
+		alias,
+	)
+}
+
+func synapseActiveAlias(index int) string {
+	return fmt.Sprintf("__bruin_active_%d", index)
+}
+
+func buildSynapseCDCSource(stagingTable string, primaryKeys, allColumns, dataColumns []string) string {
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := buildSynapseLatestCDCSource(stagingTable, primaryKeys, quoteColumns(allColumns), "", "latest_all")
+	latestActive := buildSynapseLatestCDCSource(stagingTable, primaryKeys, quoteColumns(activeColumns), "[_cdc_deleted] = 0", "latest_active")
+
+	selects := []string{
+		"latest_all.*",
+		fmt.Sprintf("CASE WHEN latest_active.[%s] IS NULL THEN 0 ELSE 1 END AS [__bruin_has_active]", primaryKeys[0]),
+	}
+	for i, col := range dataColumns {
+		selects = append(selects, fmt.Sprintf("latest_active.[%s] AS [%s]", col, synapseActiveAlias(i)))
+	}
+
+	return fmt.Sprintf(
+		`(SELECT %s FROM %s LEFT JOIN %s ON %s) AS source`,
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		buildJoinCondition(primaryKeys, "latest_all", "latest_active"),
+	)
+}
+
+func buildCDCMergeSQL(targetTable, stagingTable string, primaryKeys, allColumns, quotedColumns, nonPKColumns []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	dataColumnIndex := make(map[string]int, len(dataColumns))
+	for i, col := range dataColumns {
+		dataColumnIndex[strings.ToLower(col)] = i
+	}
+	pkMap := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	updates := make([]string, 0, len(nonPKColumns))
+	for _, col := range nonPKColumns {
+		if destination.IsCDCColumn(col) {
+			updates = append(updates, fmt.Sprintf("target.[%s] = source.[%s]", col, col))
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		updates = append(updates, fmt.Sprintf(
+			"target.[%s] = CASE WHEN source.[_cdc_deleted] = 1 THEN CASE WHEN source.[__bruin_has_active] = 1 THEN source.[%s] ELSE target.[%s] END ELSE source.[%s] END",
+			col,
+			synapseActiveAlias(activeIndex),
+			col,
+			col,
+		))
+	}
+
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		quotedCol := fmt.Sprintf("[%s]", col)
+		if destination.IsCDCColumn(col) {
+			sourceCols[i] = "source." + quotedCol
+			continue
+		}
+
+		if pkMap[strings.ToLower(col)] {
+			sourceCols[i] = "source." + quotedCol
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		sourceCols[i] = fmt.Sprintf(
+			"CASE WHEN source.[_cdc_deleted] = 1 AND source.[__bruin_has_active] = 1 THEN source.[%s] ELSE source.%s END",
+			synapseActiveAlias(activeIndex),
+			quotedCol,
+		)
+	}
+
+	var updateSet string
+	if len(updates) > 0 {
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s
+ON %s
+%s
+WHEN NOT MATCHED AND (source.[_cdc_deleted] = 0 OR source.[__bruin_has_active] = 1) THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		buildSynapseCDCSource(stagingTable, primaryKeys, allColumns, dataColumns),
+		buildJoinCondition(primaryKeys, "target", "source"),
+		updateSet,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func buildCDCActiveMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
+	onConditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
+	}
+
+	var updateSet string
+	if len(nonPKColumns) > 0 {
+		updates := make([]string, len(nonPKColumns))
+		for i, col := range nonPKColumns {
+			updates[i] = fmt.Sprintf("target.[%s] = source.[%s]", col, col)
+		}
+		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
+	}
+
+	insertCols := strings.Join(quotedColumns, ", ")
+	sourceCols := make([]string, len(quotedColumns))
+	for i, col := range quotedColumns {
+		sourceCols[i] = "source." + col
+	}
+
+	dedupSource := buildSynapseLatestCDCSource(stagingTable, primaryKeys, quotedColumns, "[_cdc_deleted] = 0", "source")
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s
+ON %s
+%s
+WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		dedupSource,
+		strings.Join(onConditions, " AND "),
+		updateSet,
+		insertCols,
+		strings.Join(sourceCols, ", "),
+	)
+}
+
+func buildCDCDeletedUpdateSQL(targetTable, stagingTable string, primaryKeys []string) string {
+	cdcColumns := append([]string{}, primaryKeys...)
+	cdcColumns = append(cdcColumns, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+	quotedCDCColumns := quoteColumns(cdcColumns)
+	latestAll := buildSynapseLatestCDCSource(stagingTable, primaryKeys, quotedCDCColumns, "", "latest")
+	latestDeleted := buildSynapseLatestCDCSource(stagingTable, primaryKeys, quotedCDCColumns, "[_cdc_deleted] = 1", "deleted")
+
+	return fmt.Sprintf(
+		`UPDATE target
+SET target.[_cdc_deleted] = 1, target.[_cdc_lsn] = deleted.[_cdc_lsn], target.[_cdc_synced_at] = deleted.[_cdc_synced_at]
+FROM %s AS target
+INNER JOIN %s ON %s
+INNER JOIN %s ON %s
+WHERE latest.[_cdc_deleted] = 1;`,
+		quoteTable(targetTable),
+		latestDeleted,
+		buildJoinCondition(primaryKeys, "target", "deleted"),
+		latestAll,
+		buildJoinCondition(primaryKeys, "deleted", "latest"),
+	)
 }
 
 func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
@@ -633,8 +817,25 @@ func (d *SynapseDestination) SupportsMergeStrategy() bool        { return true }
 func (d *SynapseDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *SynapseDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *SynapseDestination) SupportsAtomicSwap() bool           { return true }
+func (d *SynapseDestination) SupportsCDCMerge() bool             { return true }
 
 func (d *SynapseDestination) GetScheme() string { return "synapse" }
+
+func (d *SynapseDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf("SELECT MAX([_cdc_lsn]) FROM %s", quoteTable(table))
+	if err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "Invalid object name") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *SynapseDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	schemaName, tableName := parseTableName(table)

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -243,6 +243,18 @@ func (d *TrinoDestination) MergeTable(ctx context.Context, opts destination.Merg
 	stagingFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", stagingCatalog, stagingSchema, stagingName)
 	targetFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", targetCatalog, targetSchema, targetName)
 
+	if destination.HasCDCDeletedColumn(opts.Columns) {
+		mergeSQL := buildTrinoCDCMergeSQL(targetFQN, stagingFQN, opts.PrimaryKeys, opts.Columns)
+		config.Debug("[TRINO MERGE] Executing CDC MERGE: %s", mergeSQL)
+		if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+			config.LogFailedQuery(mergeSQL, err)
+			return fmt.Errorf("failed to execute CDC merge: %w", err)
+		}
+
+		config.Debug("[TRINO MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	var onConditions []string
 	for _, pk := range opts.PrimaryKeys {
 		onConditions = append(onConditions, fmt.Sprintf("t.\"%s\" = s.\"%s\"", pk, pk))
@@ -293,6 +305,180 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)`,
 
 	config.Debug("[TRINO MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func trinoAliasJoin(primaryKeys []string, leftAlias, rightAlias string) string {
+	conditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		conditions[i] = fmt.Sprintf("%s.\"%s\" = %s.\"%s\"", leftAlias, pk, rightAlias, pk)
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func buildTrinoLatestCDCSource(stagingFQN string, primaryKeys, columns []string, filter, alias string) string {
+	quotedCols := quoteColumns(columns)
+	quotedPKs := quoteColumns(primaryKeys)
+	where := ""
+	if filter != "" {
+		where = " WHERE " + filter
+	}
+
+	return fmt.Sprintf(
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY "_cdc_lsn" DESC, "_cdc_synced_at" DESC) AS __bruin_cdc_rn FROM %s%s) AS _numbered WHERE __bruin_cdc_rn = 1) AS %s`,
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedCols, ", "),
+		strings.Join(quotedPKs, ", "),
+		stagingFQN,
+		where,
+		alias,
+	)
+}
+
+func trinoActiveAlias(index int) string {
+	return fmt.Sprintf("__bruin_active_%d", index)
+}
+
+func buildTrinoCDCSource(stagingFQN string, primaryKeys, allColumns, dataColumns []string) string {
+	activeColumns := append(append([]string{}, primaryKeys...), dataColumns...)
+	latestAll := buildTrinoLatestCDCSource(stagingFQN, primaryKeys, allColumns, "", "latest_all")
+	latestActive := buildTrinoLatestCDCSource(stagingFQN, primaryKeys, activeColumns, `"_cdc_deleted" = false`, "latest_active")
+
+	selects := []string{
+		"latest_all.*",
+		fmt.Sprintf(`latest_active."%s" IS NOT NULL AS "__bruin_has_active"`, primaryKeys[0]),
+	}
+	for i, col := range dataColumns {
+		selects = append(selects, fmt.Sprintf(`latest_active."%s" AS "%s"`, col, trinoActiveAlias(i)))
+	}
+
+	return fmt.Sprintf(
+		`(SELECT %s FROM %s LEFT JOIN %s ON %s)`,
+		strings.Join(selects, ", "),
+		latestAll,
+		latestActive,
+		trinoAliasJoin(primaryKeys, "latest_all", "latest_active"),
+	)
+}
+
+func buildTrinoCDCMergeSQL(targetFQN, stagingFQN string, primaryKeys, allColumns []string) string {
+	dataColumns := destination.CDCDataColumns(allColumns, primaryKeys)
+	dataColumnIndex := make(map[string]int, len(dataColumns))
+	for i, col := range dataColumns {
+		dataColumnIndex[strings.ToLower(col)] = i
+	}
+
+	pkMap := make(map[string]bool)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	var updateSets []string
+	for _, col := range allColumns {
+		if pkMap[strings.ToLower(col)] {
+			continue
+		}
+		if destination.IsCDCColumn(col) {
+			updateSets = append(updateSets, fmt.Sprintf(`"%s" = source."%s"`, col, col))
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		updateSets = append(updateSets, fmt.Sprintf(
+			`"%s" = CASE WHEN source."_cdc_deleted" = true THEN CASE WHEN source."__bruin_has_active" THEN source."%s" ELSE target."%s" END ELSE source."%s" END`,
+			col,
+			trinoActiveAlias(activeIndex),
+			col,
+			col,
+		))
+	}
+
+	quotedCols := quoteColumns(allColumns)
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+			sourceCols[i] = fmt.Sprintf(`source."%s"`, col)
+			continue
+		}
+
+		activeIndex := dataColumnIndex[strings.ToLower(col)]
+		sourceCols[i] = fmt.Sprintf(
+			`CASE WHEN source."_cdc_deleted" = true AND source."__bruin_has_active" THEN source."%s" ELSE source."%s" END`,
+			trinoActiveAlias(activeIndex),
+			col,
+		)
+	}
+
+	var mergeSQL strings.Builder
+	fmt.Fprintf(&mergeSQL, "MERGE INTO %s AS target\n", targetFQN)
+	fmt.Fprintf(&mergeSQL, "USING %s AS source\n", buildTrinoCDCSource(stagingFQN, primaryKeys, allColumns, dataColumns))
+	fmt.Fprintf(&mergeSQL, "ON %s\n", trinoAliasJoin(primaryKeys, "target", "source"))
+	if len(updateSets) > 0 {
+		mergeSQL.WriteString("WHEN MATCHED THEN\n")
+		fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+	}
+	mergeSQL.WriteString(`WHEN NOT MATCHED AND (source."_cdc_deleted" = false OR source."__bruin_has_active") THEN` + "\n")
+	fmt.Fprintf(&mergeSQL, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+	fmt.Fprintf(&mergeSQL, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+	return mergeSQL.String()
+}
+
+func buildTrinoCDCActiveMergeSQL(targetFQN, stagingFQN string, primaryKeys, allColumns []string) string {
+	pkMap := make(map[string]bool)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	var updateSets []string
+	for _, col := range allColumns {
+		if !pkMap[strings.ToLower(col)] {
+			updateSets = append(updateSets, fmt.Sprintf("\"%s\" = source.\"%s\"", col, col))
+		}
+	}
+
+	quotedCols := quoteColumns(allColumns)
+	sourceCols := make([]string, len(allColumns))
+	for i, col := range allColumns {
+		sourceCols[i] = fmt.Sprintf("source.\"%s\"", col)
+	}
+
+	source := buildTrinoLatestCDCSource(stagingFQN, primaryKeys, allColumns, `"_cdc_deleted" = false`, "source")
+
+	var mergeSQL strings.Builder
+	fmt.Fprintf(&mergeSQL, "MERGE INTO %s AS target\n", targetFQN)
+	fmt.Fprintf(&mergeSQL, "USING %s\n", source)
+	fmt.Fprintf(&mergeSQL, "ON %s\n", trinoAliasJoin(primaryKeys, "target", "source"))
+	if len(updateSets) > 0 {
+		mergeSQL.WriteString("WHEN MATCHED THEN\n")
+		fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+	}
+	mergeSQL.WriteString("WHEN NOT MATCHED THEN\n")
+	fmt.Fprintf(&mergeSQL, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+	fmt.Fprintf(&mergeSQL, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+	return mergeSQL.String()
+}
+
+func buildTrinoCDCDeletedMergeSQL(targetFQN, stagingFQN string, primaryKeys []string) string {
+	cdcColumns := append([]string{}, primaryKeys...)
+	cdcColumns = append(cdcColumns, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+	latestAll := buildTrinoLatestCDCSource(stagingFQN, primaryKeys, cdcColumns, "", "latest")
+	latestDeleted := buildTrinoLatestCDCSource(stagingFQN, primaryKeys, cdcColumns, `"_cdc_deleted" = true`, "deleted")
+
+	source := fmt.Sprintf(
+		`(SELECT deleted.* FROM %s JOIN %s ON %s WHERE latest."_cdc_deleted" = true) AS source`,
+		latestDeleted,
+		latestAll,
+		trinoAliasJoin(primaryKeys, "deleted", "latest"),
+	)
+
+	return fmt.Sprintf(
+		`MERGE INTO %s AS target
+USING %s
+ON %s
+WHEN MATCHED THEN UPDATE SET "_cdc_deleted" = true, "_cdc_lsn" = source."_cdc_lsn", "_cdc_synced_at" = source."_cdc_synced_at"`,
+		targetFQN,
+		source,
+		trinoAliasJoin(primaryKeys, "target", "source"),
+	)
 }
 
 func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
@@ -472,8 +658,28 @@ func (d *TrinoDestination) SupportsMergeStrategy() bool        { return true }
 func (d *TrinoDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *TrinoDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *TrinoDestination) SupportsAtomicSwap() bool           { return false }
+func (d *TrinoDestination) SupportsCDCMerge() bool             { return true }
 
 func (d *TrinoDestination) GetScheme() string { return "trino" }
+
+func (d *TrinoDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	catalog, schemaName, tableName := d.parseTableName(table)
+	tableFQN := fmt.Sprintf("\"%s\".\"%s\".\"%s\"", catalog, schemaName, tableName)
+	query := fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %s`, tableFQN)
+
+	var maxLSN sql.NullString
+	if err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "does not exist") {
+			return "", nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *TrinoDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	return nil, nil


### PR DESCRIPTION
## Summary
- add CDC-aware merge semantics for Redshift
- add CDC-aware merge semantics for Fabric and Synapse
- add CDC-aware merge semantics for Trino and Databricks
- expose CDC merge support/resume hooks where the destination can query SQL state

## Tests
- go test ./pkg/destination/redshift ./pkg/destination/fabric ./pkg/destination/synapse ./pkg/destination/trino ./pkg/destination/databricks
- go test ./pkg/source/mssql_cdc ./pkg/source/postgres_cdc ./pkg/source/mssql ./pkg/pipeline ./pkg/strategy ./pkg/destination ./pkg/destination/postgres ./pkg/destination/duckdb ./pkg/destination/sqlite ./pkg/destination/mysql ./pkg/destination/mssql ./pkg/destination/cratedb ./pkg/destination/bigquery ./pkg/destination/snowflake ./pkg/destination/redshift ./pkg/destination/fabric ./pkg/destination/synapse ./pkg/destination/trino ./pkg/destination/databricks

## Stack
1. #732
2. #733
3. #734
4. This PR
5. pr/cdc-conformance