### PR TITLE
Add Wistia source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -220,6 +220,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "SurveyMonkey", link: "/supported-sources/surveymonkey.md" },
               { text: "TikTok Ads", link: "/supported-sources/tiktok-ads.md" },
               { text: "Wise", link: "/supported-sources/wise.md" },
+              { text: "Wistia", link: "/supported-sources/wistia.md" },
               { text: "Zendesk", link: "/supported-sources/zendesk.md" },
               { text: "Zoom", link: "/supported-sources/zoom.md" },
             ],

--- a/docs/supported-sources/wistia.md
+++ b/docs/supported-sources/wistia.md
@@ -1,0 +1,74 @@
+# Wistia
+
+Wistia can be used as a source with the `wistia://` URI scheme.
+
+```bash
+ingestr ingest \
+  --source-uri 'wistia://?access_token=<YOUR_WISTIA_API_TOKEN>' \
+  --source-table 'medias' \
+  --dest-uri duckdb:///wistia.duckdb \
+  --dest-table 'dest.medias'
+```
+
+## URI
+
+```text
+wistia://?access_token=<YOUR_WISTIA_API_TOKEN>
+```
+
+The source also accepts `api_key` or `token` as aliases for `access_token`.
+
+Optional parameters:
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `api_version` | Value sent as the `X-Wistia-API-Version` header. | `2026-03` |
+| `base_url` | Override the Wistia API base URL, mostly for tests. | `https://api.wistia.com/modern` |
+
+## Tables
+
+Available Data API tables:
+
+| Table | Description |
+| --- | --- |
+| `account` | Current account summary. |
+| `token` | Current token summary. |
+| `allowed_domains` | Allowed domains. |
+| `folders` | Folders. |
+| `folder:<folder_id>` | A single folder. |
+| `folder_sharings:<folder_id>` | Sharing records for a folder. |
+| `subfolders:<folder_id>` | Subfolders for a folder. |
+| `medias` | Media records. |
+| `media:<media_id>` | A single media record. |
+| `captions` | Captions across the account. |
+| `captions:<media_id>` | Captions filtered by media. |
+| `media_captions:<media_id>` | Captions for a media. |
+| `media_localizations:<media_id>` | Localizations for a media. |
+| `media_customizations:<media_id>` | Customizations for a media. |
+| `media_stats:<media_id>` | Aggregated media stats from the Data API. |
+| `channels` | Channels. |
+| `channel:<channel_id>` | A single channel. |
+| `channel_episodes` | Channel episodes. |
+| `channel_episodes_by_channel:<channel_id>` | Episodes in a channel. |
+| `tags` | Tags. |
+| `webinars` | Webinars. |
+| `webinar:<webinar_id>` | A single webinar. |
+
+Available Stats API tables:
+
+| Table | Description |
+| --- | --- |
+| `stats_account` | Current account stats. |
+| `stats_account_by_date` | Account stats by date. |
+| `stats_events` | Event records. |
+| `stats_events:<media_id>` | Event records filtered by media. |
+| `stats_events_by_visitor:<visitor_key>` | Event records filtered by visitor. |
+| `stats_visitors` | Visitors. |
+| `stats_event:<event_key>` | A single event. |
+| `stats_visitor:<visitor_key>` | A single visitor. |
+| `stats_media:<media_id>` | Stats for a media. |
+| `stats_media_by_date:<media_id>` | Stats for a media by date. |
+| `stats_media_engagement:<media_id>` | Engagement stats for a media. |
+| `stats_project:<project_id>` | Stats for a project/folder. |
+
+Date-filtered Stats API tables use `--interval-start` and `--interval-end` as Wistia `start_date` and `end_date` query parameters. For `stats_account_by_date`, ingestr sends yesterday/today when no interval is provided because the Wistia endpoint currently returns an internal server error without an explicit date range.

--- a/docs/supported-sources/wistia.md
+++ b/docs/supported-sources/wistia.md
@@ -56,19 +56,19 @@ Available Data API tables:
 
 Available Stats API tables:
 
-| Table | Description |
-| --- | --- |
-| `stats_account` | Current account stats. |
-| `stats_account_by_date` | Account stats by date. |
-| `stats_events` | Event records. |
-| `stats_events:<media_id>` | Event records filtered by media. |
-| `stats_events_by_visitor:<visitor_key>` | Event records filtered by visitor. |
-| `stats_visitors` | Visitors. |
-| `stats_event:<event_key>` | A single event. |
-| `stats_visitor:<visitor_key>` | A single visitor. |
-| `stats_media:<media_id>` | Stats for a media. |
-| `stats_media_by_date:<media_id>` | Stats for a media by date. |
-| `stats_media_engagement:<media_id>` | Engagement stats for a media. |
-| `stats_project:<project_id>` | Stats for a project/folder. |
+| Table | Description | Incremental |
+| --- | --- | --- |
+| `stats_account` | Current account stats. | No |
+| `stats_account_by_date` | Account stats by date. | Yes, using `date` |
+| `stats_events` | Event records. | Yes, using `received_at` |
+| `stats_events:<media_id>` | Event records filtered by media. | Yes, using `received_at` |
+| `stats_events_by_visitor:<visitor_key>` | Event records filtered by visitor. | Yes, using `received_at` |
+| `stats_visitors` | Visitors. | No |
+| `stats_event:<event_key>` | A single event. | No |
+| `stats_visitor:<visitor_key>` | A single visitor. | No |
+| `stats_media:<media_id>` | Stats for a media. | No |
+| `stats_media_by_date:<media_id>` | Stats for a media by date. | Yes, using `date` |
+| `stats_media_engagement:<media_id>` | Engagement stats for a media. | No |
+| `stats_project:<project_id>` | Stats for a project/folder. | No |
 
 Date-filtered Stats API tables use `--interval-start` and `--interval-end` as Wistia `start_date` and `end_date` query parameters. For `stats_account_by_date`, ingestr sends yesterday/today when no interval is provided because the Wistia endpoint currently returns an internal server error without an explicit date range.

--- a/pkg/source/wistia/register.go
+++ b/pkg/source/wistia/register.go
@@ -1,0 +1,10 @@
+package wistia
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"wistia"},
+		func() interface{} { return NewWistiaSource() },
+	)
+}

--- a/pkg/source/wistia/wistia.go
+++ b/pkg/source/wistia/wistia.go
@@ -1,0 +1,738 @@
+package wistia
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	defaultBaseURL     = "https://api.wistia.com/modern"
+	defaultAPIVersion  = "2026-03"
+	defaultPageSize    = 100
+	maxPageSize        = 100
+	rateLimit          = 8.0
+	rateLimitBurst     = 5
+	apiVersionHeader   = "X-Wistia-API-Version"
+	authorizationError = "access_token or api_key is required in wistia URI"
+)
+
+type tableConfig struct {
+	endpoint         string
+	paginated        bool
+	arrayResponse    bool
+	requiresParam    bool
+	allowsParam      bool
+	queryParam       string
+	paramColumn      string
+	dateFilter       bool
+	defaultDateRange bool
+	primaryKeys      []string
+	incrementalKey   string
+	strategy         config.IncrementalStrategy
+	partitionBy      string
+}
+
+var tableConfigs = map[string]tableConfig{
+	"account": {
+		endpoint:    "/account",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+	},
+	"token": {
+		endpoint: "/token",
+		strategy: config.StrategyReplace,
+	},
+	"allowed_domains": {
+		endpoint:      "/allowed_domains",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"domain"},
+		strategy:      config.StrategyReplace,
+	},
+	"folders": {
+		endpoint:      "/folders",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"folder": {
+		endpoint:      "/folders/{id}",
+		requiresParam: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"folder_sharings": {
+		endpoint:      "/folders/{id}/sharings",
+		paginated:     true,
+		arrayResponse: true,
+		requiresParam: true,
+		paramColumn:   "folder_id",
+		primaryKeys:   []string{"folder_id", "id"},
+		strategy:      config.StrategyReplace,
+	},
+	"subfolders": {
+		endpoint:      "/folders/{id}/subfolders",
+		paginated:     true,
+		arrayResponse: true,
+		requiresParam: true,
+		paramColumn:   "folder_id",
+		primaryKeys:   []string{"folder_id", "id"},
+		strategy:      config.StrategyReplace,
+	},
+	"medias": {
+		endpoint:      "/medias",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"media": {
+		endpoint:      "/medias/{id}",
+		requiresParam: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"captions": {
+		endpoint:      "/captions",
+		paginated:     true,
+		arrayResponse: true,
+		allowsParam:   true,
+		queryParam:    "media_id",
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"id"},
+		strategy:      config.StrategyReplace,
+	},
+	"media_captions": {
+		endpoint:      "/medias/{id}/captions",
+		paginated:     true,
+		arrayResponse: true,
+		requiresParam: true,
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"media_id", "language"},
+		strategy:      config.StrategyReplace,
+	},
+	"media_localizations": {
+		endpoint:      "/medias/{id}/localizations",
+		paginated:     true,
+		arrayResponse: true,
+		requiresParam: true,
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"media_id", "hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"media_customizations": {
+		endpoint:      "/medias/{id}/customizations",
+		requiresParam: true,
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"media_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"media_stats": {
+		endpoint:      "/medias/{id}/stats",
+		requiresParam: true,
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"media_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"channels": {
+		endpoint:      "/channels",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"channel": {
+		endpoint:      "/channels/{id}",
+		requiresParam: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"channel_episodes": {
+		endpoint:      "/channel_episodes",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"channel_episodes_by_channel": {
+		endpoint:      "/channels/{id}/channel_episodes",
+		paginated:     true,
+		arrayResponse: true,
+		requiresParam: true,
+		paramColumn:   "channel_id",
+		primaryKeys:   []string{"channel_id", "hashed_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"tags": {
+		endpoint:      "/tags",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"name"},
+		strategy:      config.StrategyReplace,
+	},
+	"webinars": {
+		endpoint:      "/webinars",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"id"},
+		strategy:      config.StrategyReplace,
+	},
+	"webinar": {
+		endpoint:      "/webinars/{id}",
+		requiresParam: true,
+		primaryKeys:   []string{"id"},
+		strategy:      config.StrategyReplace,
+	},
+	"stats_account": {
+		endpoint: "/stats/account",
+		strategy: config.StrategyReplace,
+	},
+	"stats_account_by_date": {
+		endpoint:         "/stats/account/by_date",
+		arrayResponse:    true,
+		dateFilter:       true,
+		defaultDateRange: true,
+		primaryKeys:      []string{"date"},
+		incrementalKey:   "date",
+		strategy:         config.StrategyMerge,
+		partitionBy:      "date",
+	},
+	"stats_events": {
+		endpoint:       "/stats/events",
+		paginated:      true,
+		arrayResponse:  true,
+		allowsParam:    true,
+		queryParam:     "media_id",
+		paramColumn:    "media_id",
+		dateFilter:     true,
+		primaryKeys:    []string{"event_key"},
+		incrementalKey: "received_at",
+		strategy:       config.StrategyMerge,
+		partitionBy:    "received_at",
+	},
+	"stats_events_by_visitor": {
+		endpoint:       "/stats/events",
+		paginated:      true,
+		arrayResponse:  true,
+		requiresParam:  true,
+		queryParam:     "visitor_key",
+		paramColumn:    "visitor_key",
+		dateFilter:     true,
+		primaryKeys:    []string{"event_key"},
+		incrementalKey: "received_at",
+		strategy:       config.StrategyMerge,
+		partitionBy:    "received_at",
+	},
+	"stats_visitors": {
+		endpoint:      "/stats/visitors",
+		paginated:     true,
+		arrayResponse: true,
+		primaryKeys:   []string{"visitor_key"},
+		strategy:      config.StrategyReplace,
+	},
+	"stats_event": {
+		endpoint:      "/stats/events/{id}",
+		requiresParam: true,
+		primaryKeys:   []string{"event_key"},
+		strategy:      config.StrategyReplace,
+	},
+	"stats_visitor": {
+		endpoint:      "/stats/visitors/{id}",
+		requiresParam: true,
+		primaryKeys:   []string{"visitor_key"},
+		strategy:      config.StrategyReplace,
+	},
+	"stats_media": {
+		endpoint:      "/stats/medias/{id}",
+		requiresParam: true,
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"media_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"stats_media_by_date": {
+		endpoint:       "/stats/medias/{id}/by_date",
+		arrayResponse:  true,
+		requiresParam:  true,
+		paramColumn:    "media_id",
+		dateFilter:     true,
+		primaryKeys:    []string{"media_id", "date"},
+		incrementalKey: "date",
+		strategy:       config.StrategyMerge,
+		partitionBy:    "date",
+	},
+	"stats_media_engagement": {
+		endpoint:      "/stats/medias/{id}/engagement",
+		requiresParam: true,
+		paramColumn:   "media_id",
+		primaryKeys:   []string{"media_id"},
+		strategy:      config.StrategyReplace,
+	},
+	"stats_project": {
+		endpoint:      "/stats/projects/{id}",
+		requiresParam: true,
+		paramColumn:   "project_id",
+		primaryKeys:   []string{"project_id"},
+		strategy:      config.StrategyReplace,
+	},
+}
+
+type WistiaSource struct {
+	accessToken string
+	apiVersion  string
+	client      *ingestrhttp.Client
+}
+
+type wistiaCredentials struct {
+	accessToken string
+	apiVersion  string
+	apiURL      string
+}
+
+func NewWistiaSource() *WistiaSource {
+	return &WistiaSource{}
+}
+
+func (s *WistiaSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *WistiaSource) Schemes() []string {
+	return []string{"wistia"}
+}
+
+func parseWistiaURI(uri string) (*wistiaCredentials, error) {
+	if !strings.HasPrefix(uri, "wistia://") {
+		return nil, fmt.Errorf("invalid wistia URI: must start with wistia://")
+	}
+
+	rest := strings.TrimPrefix(uri, "wistia://")
+	if rest == "" || rest == "?" {
+		return nil, fmt.Errorf(authorizationError)
+	}
+
+	var values url.Values
+	var accessToken string
+	if !strings.Contains(rest, "=") && !strings.HasPrefix(rest, "?") {
+		token, err := url.QueryUnescape(strings.Trim(rest, "/"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse wistia token: %w", err)
+		}
+		accessToken = token
+		values = url.Values{}
+	} else {
+		rest = strings.TrimPrefix(rest, "?")
+		parsed, err := url.ParseQuery(rest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse wistia URI query: %w", err)
+		}
+		values = parsed
+		accessToken = firstNonEmpty(values.Get("access_token"), values.Get("api_key"), values.Get("token"))
+	}
+
+	if accessToken == "" {
+		return nil, fmt.Errorf(authorizationError)
+	}
+
+	apiVersion := values.Get("api_version")
+	if apiVersion == "" {
+		apiVersion = defaultAPIVersion
+	}
+
+	apiURL := values.Get("base_url")
+	if apiURL == "" {
+		apiURL = defaultBaseURL
+	}
+
+	return &wistiaCredentials{
+		accessToken: accessToken,
+		apiVersion:  apiVersion,
+		apiURL:      strings.TrimRight(apiURL, "/"),
+	}, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (s *WistiaSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseWistiaURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.accessToken = creds.accessToken
+	s.apiVersion = creds.apiVersion
+	s.client = ingestrhttp.New(
+		ingestrhttp.WithBaseURL(creds.apiURL),
+		ingestrhttp.WithTimeout(60*time.Second),
+		ingestrhttp.WithRateLimiter(rateLimit, rateLimitBurst),
+		ingestrhttp.WithDebug(config.DebugMode),
+		ingestrhttp.WithAuth(ingestrhttp.NewBearerAuth(s.accessToken)),
+		ingestrhttp.WithHeader("Accept", "application/json"),
+		ingestrhttp.WithHeader(apiVersionHeader, s.apiVersion),
+	)
+
+	config.Debug("[WISTIA] Connected successfully with API version %s", s.apiVersion)
+	return nil
+}
+
+func (s *WistiaSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *WistiaSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	cfg, tableName, err := resolveTable(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	primaryKeys := cfg.primaryKeys
+	if len(primaryKeys) == 0 {
+		primaryKeys = req.PrimaryKeys
+	}
+
+	strategy := cfg.strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    primaryKeys,
+		TableIncrementalKey: cfg.incrementalKey,
+		TableStrategy:       strategy,
+		TablePartitionBy:    cfg.partitionBy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("wistia source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, opts)
+		},
+	}, nil
+}
+
+func resolveTable(table string) (tableConfig, string, error) {
+	base, param := parseTableName(table)
+	cfg, ok := tableConfigs[base]
+	if !ok {
+		return tableConfig{}, "", fmt.Errorf("unsupported table: %s (supported: %s)", table, strings.Join(supportedTableNames(), ", "))
+	}
+	if cfg.requiresParam && param == "" {
+		return tableConfig{}, "", fmt.Errorf("%s requires an id parameter, e.g. %s:abc123", base, base)
+	}
+	if param != "" && !cfg.requiresParam && !cfg.allowsParam {
+		return tableConfig{}, "", fmt.Errorf("%s does not accept an id parameter", base)
+	}
+	return cfg, table, nil
+}
+
+func parseTableName(table string) (string, string) {
+	base, param, found := strings.Cut(table, ":")
+	if !found {
+		return table, ""
+	}
+	return base, param
+}
+
+func supportedTableNames() []string {
+	names := make([]string, 0, len(tableConfigs))
+	for name, cfg := range tableConfigs {
+		if cfg.requiresParam {
+			names = append(names, name+":<id>")
+		} else if cfg.allowsParam {
+			names = append(names, name+"[:<id>]")
+		} else {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *WistiaSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	cfg, _, err := resolveTable(table)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer close(results)
+
+		var err error
+		if cfg.paginated {
+			err = s.readPaginated(ctx, table, cfg, opts, results)
+		} else {
+			err = s.readOnce(ctx, table, cfg, opts, results)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *WistiaSource) readPaginated(ctx context.Context, table string, cfg tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	_, param := parseTableName(table)
+	pageSize := pageSizeFromOptions(opts)
+	total := 0
+
+	for page := 1; ; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("page", strconv.Itoa(page)).
+			SetQueryParam("per_page", strconv.Itoa(pageSize))
+		applyConfiguredParams(req, cfg, param, opts)
+
+		resp, err := req.Get(endpointFor(cfg, param))
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s page %d: %w", table, page, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("%s page %d returned status %d: %s", table, page, resp.StatusCode(), resp.String())
+		}
+
+		items, err := responseItems(resp.Body(), true)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s page %d response: %w", table, page, err)
+		}
+		addParamColumn(items, cfg, param)
+
+		if opts.Limit > 0 {
+			remaining := opts.Limit - total
+			if remaining <= 0 {
+				break
+			}
+			if len(items) > remaining {
+				items = items[:remaining]
+			}
+		}
+
+		if len(items) > 0 {
+			if err := sendBatch(ctx, items, opts, results); err != nil {
+				return err
+			}
+			total += len(items)
+			config.Debug("[WISTIA] Fetched %d rows from %s page %d (total: %d)", len(items), table, page, total)
+		}
+
+		if len(items) < pageSize || (opts.Limit > 0 && total >= opts.Limit) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *WistiaSource) readOnce(ctx context.Context, table string, cfg tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	_, param := parseTableName(table)
+	req := s.client.R(ctx)
+	applyConfiguredParams(req, cfg, param, opts)
+
+	resp, err := req.Get(endpointFor(cfg, param))
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s: %w", table, err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("%s returned status %d: %s", table, resp.StatusCode(), resp.String())
+	}
+
+	items, err := responseItems(resp.Body(), cfg.arrayResponse)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s response: %w", table, err)
+	}
+	addParamColumn(items, cfg, param)
+
+	if opts.Limit > 0 && len(items) > opts.Limit {
+		items = items[:opts.Limit]
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	config.Debug("[WISTIA] Fetched %d rows from %s", len(items), table)
+	return sendBatch(ctx, items, opts, results)
+}
+
+func endpointFor(cfg tableConfig, param string) string {
+	endpoint := cfg.endpoint
+	if param != "" {
+		endpoint = strings.ReplaceAll(endpoint, "{id}", url.PathEscape(param))
+	}
+	return endpoint
+}
+
+func applyConfiguredParams(req *ingestrhttp.Request, cfg tableConfig, param string, opts source.ReadOptions) {
+	if cfg.queryParam != "" && param != "" {
+		req.SetQueryParam(cfg.queryParam, param)
+	}
+	if cfg.dateFilter {
+		applyDateParams(req, cfg, opts)
+	}
+}
+
+func applyDateParams(req *ingestrhttp.Request, cfg tableConfig, opts source.ReadOptions) {
+	start, end := wistiaDateRange(cfg, opts)
+	if start != "" {
+		req.SetQueryParam("start_date", start)
+	}
+	if end != "" {
+		req.SetQueryParam("end_date", end)
+	}
+}
+
+func wistiaDateRange(cfg tableConfig, opts source.ReadOptions) (string, string) {
+	start := opts.IntervalStart
+	end := opts.IntervalEnd
+
+	if start == nil && end == nil {
+		if !cfg.defaultDateRange {
+			return "", ""
+		}
+		today := truncateUTCDate(time.Now().UTC())
+		yesterday := today.AddDate(0, 0, -1)
+		return yesterday.Format("2006-01-02"), today.Format("2006-01-02")
+	}
+
+	if start == nil && end != nil {
+		endDate := truncateUTCDate(*end)
+		startDate := endDate.AddDate(0, 0, -1)
+		return startDate.Format("2006-01-02"), endDate.Format("2006-01-02")
+	}
+
+	if start != nil && end == nil {
+		startDate := truncateUTCDate(*start)
+		endDate := truncateUTCDate(time.Now().UTC())
+		if endDate.Before(startDate) {
+			endDate = startDate
+		}
+		return startDate.Format("2006-01-02"), endDate.Format("2006-01-02")
+	}
+
+	return start.Format("2006-01-02"), end.Format("2006-01-02")
+}
+
+func truncateUTCDate(t time.Time) time.Time {
+	utc := t.UTC()
+	return time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func pageSizeFromOptions(opts source.ReadOptions) int {
+	pageSize := opts.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	if opts.Limit > 0 && opts.Limit < pageSize {
+		pageSize = opts.Limit
+	}
+	return pageSize
+}
+
+func responseItems(body []byte, expectArray bool) ([]map[string]interface{}, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var decoded interface{}
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+
+	switch value := decoded.(type) {
+	case []interface{}:
+		return interfaceSliceToItems(value), nil
+	case map[string]interface{}:
+		if expectArray {
+			if data, ok := value["data"].([]interface{}); ok {
+				return interfaceSliceToItems(data), nil
+			}
+			if data, ok := value["items"].([]interface{}); ok {
+				return interfaceSliceToItems(data), nil
+			}
+			if data, ok := value["results"].([]interface{}); ok {
+				return interfaceSliceToItems(data), nil
+			}
+		}
+		return []map[string]interface{}{value}, nil
+	case nil:
+		return nil, nil
+	default:
+		return []map[string]interface{}{{"value": value}}, nil
+	}
+}
+
+func interfaceSliceToItems(values []interface{}) []map[string]interface{} {
+	items := make([]map[string]interface{}, 0, len(values))
+	for _, value := range values {
+		if item, ok := value.(map[string]interface{}); ok {
+			items = append(items, item)
+			continue
+		}
+		items = append(items, map[string]interface{}{"value": value})
+	}
+	return items
+}
+
+func addParamColumn(items []map[string]interface{}, cfg tableConfig, param string) {
+	if cfg.paramColumn == "" || param == "" {
+		return
+	}
+	for _, item := range items {
+		if _, ok := item[cfg.paramColumn]; !ok {
+			item[cfg.paramColumn] = param
+		}
+	}
+}
+
+func sendBatch(ctx context.Context, items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	var cols []schema.Column
+	if opts.Schema != nil {
+		cols = opts.Schema.Columns
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cols, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert Wistia response to Arrow: %w", err)
+	}
+
+	select {
+	case results <- source.RecordBatchResult{Batch: record}:
+		return nil
+	case <-ctx.Done():
+		record.Release()
+		return ctx.Err()
+	}
+}

--- a/pkg/source/wistia/wistia.go
+++ b/pkg/source/wistia/wistia.go
@@ -532,9 +532,6 @@ func (s *WistiaSource) readPaginated(ctx context.Context, table string, cfg tabl
 
 		if opts.Limit > 0 {
 			remaining := opts.Limit - total
-			if remaining <= 0 {
-				break
-			}
 			if len(items) > remaining {
 				items = items[:remaining]
 			}
@@ -686,6 +683,7 @@ func responseItems(body []byte, expectArray bool) ([]map[string]interface{}, err
 			if data, ok := value["results"].([]interface{}); ok {
 				return interfaceSliceToItems(data), nil
 			}
+			return nil, fmt.Errorf("expected array response or object envelope with data, items, or results")
 		}
 		return []map[string]interface{}{value}, nil
 	case nil:

--- a/pkg/source/wistia/wistia.go
+++ b/pkg/source/wistia/wistia.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -321,7 +322,7 @@ func parseWistiaURI(uri string) (*wistiaCredentials, error) {
 
 	rest := strings.TrimPrefix(uri, "wistia://")
 	if rest == "" || rest == "?" {
-		return nil, fmt.Errorf(authorizationError)
+		return nil, errors.New(authorizationError)
 	}
 
 	var values url.Values
@@ -344,7 +345,7 @@ func parseWistiaURI(uri string) (*wistiaCredentials, error) {
 	}
 
 	if accessToken == "" {
-		return nil, fmt.Errorf(authorizationError)
+		return nil, errors.New(authorizationError)
 	}
 
 	apiVersion := values.Get("api_version")

--- a/pkg/source/wistia/wistia_test.go
+++ b/pkg/source/wistia/wistia_test.go
@@ -1,0 +1,189 @@
+package wistia
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWistiaURI(t *testing.T) {
+	t.Run("query token", func(t *testing.T) {
+		creds, err := parseWistiaURI("wistia://?access_token=abc&api_version=2026-03&base_url=https%3A%2F%2Fexample.com%2Fmodern%2F")
+		require.NoError(t, err)
+		assert.Equal(t, "abc", creds.accessToken)
+		assert.Equal(t, "2026-03", creds.apiVersion)
+		assert.Equal(t, "https://example.com/modern", creds.apiURL)
+	})
+
+	t.Run("api key alias", func(t *testing.T) {
+		creds, err := parseWistiaURI("wistia://?api_key=abc")
+		require.NoError(t, err)
+		assert.Equal(t, "abc", creds.accessToken)
+		assert.Equal(t, defaultAPIVersion, creds.apiVersion)
+		assert.Equal(t, defaultBaseURL, creds.apiURL)
+	})
+
+	t.Run("bare token", func(t *testing.T) {
+		creds, err := parseWistiaURI("wistia://abc123")
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", creds.accessToken)
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		_, err := parseWistiaURI("wistia://?api_version=2026-03")
+		require.Error(t, err)
+	})
+}
+
+func TestGetTable(t *testing.T) {
+	src := NewWistiaSource()
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stats_media_by_date:abc123"})
+	require.NoError(t, err)
+	assert.Equal(t, "stats_media_by_date:abc123", table.Name())
+	assert.Equal(t, []string{"media_id", "date"}, table.PrimaryKeys())
+	assert.Equal(t, "date", table.IncrementalKey())
+	assert.Equal(t, "date", table.(source.PartitionedTable).PartitionBy())
+
+	table, err = src.GetTable(context.Background(), source.TableRequest{Name: "captions"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, table.PrimaryKeys())
+
+	_, err = src.GetTable(context.Background(), source.TableRequest{Name: "stats_media_by_date"})
+	require.Error(t, err)
+
+	_, err = src.GetTable(context.Background(), source.TableRequest{Name: "unknown"})
+	require.Error(t, err)
+}
+
+func TestReadPaginated(t *testing.T) {
+	var pages []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		assert.Equal(t, "2026-03", r.Header.Get(apiVersionHeader))
+		assert.Equal(t, "/medias", r.URL.Path)
+		assert.Equal(t, "2", r.URL.Query().Get("per_page"))
+
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		require.NoError(t, err)
+		pages = append(pages, page)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch page {
+		case 1:
+			require.NoError(t, json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"hashed_id": "a", "name": "A"},
+				{"hashed_id": "b", "name": "B"},
+			}))
+		case 2:
+			require.NoError(t, json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"hashed_id": "c", "name": "C"},
+			}))
+		default:
+			require.NoError(t, json.NewEncoder(w).Encode([]map[string]interface{}{}))
+		}
+	}))
+	defer server.Close()
+
+	src := NewWistiaSource()
+	err := src.Connect(context.Background(), "wistia://?access_token=secret&base_url="+url.QueryEscape(server.URL))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, src.Close(context.Background())) }()
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "medias"})
+	require.NoError(t, err)
+
+	records, err := table.Read(context.Background(), source.ReadOptions{PageSize: 2})
+	require.NoError(t, err)
+
+	var rows int64
+	for result := range records {
+		require.NoError(t, result.Err)
+		rows += result.Batch.NumRows()
+		result.Batch.Release()
+	}
+
+	assert.Equal(t, int64(3), rows)
+	assert.Equal(t, []int{1, 2}, pages)
+}
+
+func TestReadDateFilteredParameterizedTable(t *testing.T) {
+	var gotQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		assert.Equal(t, "/stats/medias/abc123/by_date", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"date": "2026-01-02", "play_count": 3},
+		}))
+	}))
+	defer server.Close()
+
+	src := NewWistiaSource()
+	err := src.Connect(context.Background(), "wistia://?access_token=secret&base_url="+url.QueryEscape(server.URL))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, src.Close(context.Background())) }()
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stats_media_by_date:abc123"})
+	require.NoError(t, err)
+
+	start := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 3, 10, 0, 0, 0, time.UTC)
+	records, err := table.Read(context.Background(), source.ReadOptions{
+		IntervalStart: &start,
+		IntervalEnd:   &end,
+	})
+	require.NoError(t, err)
+
+	var batchCount int
+	for result := range records {
+		require.NoError(t, result.Err)
+		batchCount++
+		assert.Equal(t, int64(1), result.Batch.NumRows())
+		indices := result.Batch.Schema().FieldIndices("media_id")
+		require.NotEmpty(t, indices)
+		result.Batch.Release()
+	}
+
+	assert.Equal(t, 1, batchCount)
+	assert.Equal(t, "2026-01-02", gotQuery.Get("start_date"))
+	assert.Equal(t, "2026-01-03", gotQuery.Get("end_date"))
+}
+
+func TestWistiaDateRange(t *testing.T) {
+	defaultingCfg := tableConfigs["stats_account_by_date"]
+	nonDefaultingCfg := tableConfigs["stats_media_by_date"]
+
+	start, end := wistiaDateRange(defaultingCfg, source.ReadOptions{})
+	require.NotEmpty(t, start)
+	require.NotEmpty(t, end)
+
+	startDate, err := time.Parse("2006-01-02", start)
+	require.NoError(t, err)
+	endDate, err := time.Parse("2006-01-02", end)
+	require.NoError(t, err)
+	assert.Equal(t, 24*time.Hour, endDate.Sub(startDate))
+
+	start, end = wistiaDateRange(nonDefaultingCfg, source.ReadOptions{})
+	assert.Empty(t, start)
+	assert.Empty(t, end)
+
+	onlyEnd := time.Date(2026, 1, 3, 10, 0, 0, 0, time.UTC)
+	start, end = wistiaDateRange(nonDefaultingCfg, source.ReadOptions{IntervalEnd: &onlyEnd})
+	assert.Equal(t, "2026-01-02", start)
+	assert.Equal(t, "2026-01-03", end)
+
+	onlyStart := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+	start, end = wistiaDateRange(nonDefaultingCfg, source.ReadOptions{IntervalStart: &onlyStart})
+	assert.Equal(t, "2026-01-02", start)
+	require.NotEmpty(t, end)
+}

--- a/pkg/source/wistia/wistia_test.go
+++ b/pkg/source/wistia/wistia_test.go
@@ -187,3 +187,27 @@ func TestWistiaDateRange(t *testing.T) {
 	assert.Equal(t, "2026-01-02", start)
 	require.NotEmpty(t, end)
 }
+
+func TestResponseItems(t *testing.T) {
+	t.Run("rejects unexpected object for array response", func(t *testing.T) {
+		items, err := responseItems([]byte(`{"pagination":{"next":2}}`), true)
+		require.Error(t, err)
+		assert.Nil(t, items)
+		assert.Contains(t, err.Error(), "expected array response")
+	})
+
+	t.Run("keeps object for single item response", func(t *testing.T) {
+		items, err := responseItems([]byte(`{"id":"abc123","name":"A"}`), false)
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "abc123", items[0]["id"])
+	})
+
+	t.Run("unwraps recognized array envelope", func(t *testing.T) {
+		items, err := responseItems([]byte(`{"data":[{"id":"a"},{"id":"b"}]}`), true)
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0]["id"])
+		assert.Equal(t, "b", items[1]["id"])
+	})
+}


### PR DESCRIPTION
Adds Wistia as a source with supported Data and Stats API tables, pagination, parameterized table reads, and date filters.

Includes Wistia source docs and unit coverage for URI parsing, table metadata, pagination, and interval handling.

Validation: go test -short ./...