### PR TITLE
Add MSK IAM OAuth support for Kafka

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -9909,6 +9909,194 @@ THE SOFTWARE.
 
 
 ===============================================================================
+github.com/aws/aws-msk-iam-sasl-signer-go/signer/LICENSE
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+
+===============================================================================
+github.com/aws/aws-msk-iam-sasl-signer-go/signer/NOTICE
+===============================================================================
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+===============================================================================
 github.com/aws/aws-sdk-go-v2/LICENSE.txt
 ===============================================================================
 

--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -13,10 +13,17 @@ kafka://?bootstrap_servers=localhost:9092&group_id=test_group&security_protocol=
 URI parameters:
 - `bootstrap_servers`: Required, the Kafka server or servers to connect to, typically in the form of a host and port, e.g. `localhost:9092`
 - `group_id`: Required, the consumer group ID used for identifying the client when consuming messages.
-- `security_protocol`: The protocol used to communicate with brokers, e.g. `SASL_SSL` for secure communication.
-- `sasl_mechanisms`: The SASL mechanism to be used for authentication, e.g. `PLAIN`.
+- `security_protocol`: The protocol used to communicate with brokers, e.g. `SASL_SSL` for secure communication. `OAUTHBEARER` automatically enables TLS unless this is set to `SASL_PLAINTEXT`.
+- `sasl_mechanisms`: The SASL mechanism to be used for authentication. Supported values are `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, and `OAUTHBEARER`.
 - `sasl_username`: The username for SASL authentication.
 - `sasl_password`: The password for SASL authentication.
+- `aws_region`: Required for `OAUTHBEARER`; the AWS region used to sign Amazon MSK IAM tokens.
+- `aws_role_arn`: Optional for `OAUTHBEARER`; IAM role to assume before signing.
+- `aws_role_session_name`: Optional for `OAUTHBEARER`; STS session name when `aws_role_arn` is supplied.
+- `aws_profile`: Optional for `OAUTHBEARER`; AWS named profile used for signing.
+- `aws_access_key_id`: Optional for `OAUTHBEARER`; static AWS access key ID.
+- `aws_secret_access_key`: Optional for `OAUTHBEARER`; static AWS secret access key. Must be provided with `aws_access_key_id`.
+- `aws_session_token`: Optional for `OAUTHBEARER`; static AWS session token.
 - `batch_size`: The number of messages to fetch in a single batch, defaults to 3000.
 - `batch_timeout`: The maximum time to wait for messages, defaults to 3 seconds.
 
@@ -36,3 +43,16 @@ ingestr ingest \
 ```
 
 The result of this command will be a table in the `kafka.duckdb` database with JSON columns.
+
+### Amazon MSK IAM
+Amazon MSK clusters that use IAM access control require `OAUTHBEARER` and usually listen on port `9098`:
+
+```sh
+ingestr ingest \
+    --source-uri 'kafka://?bootstrap_servers=b-1.mycluster.kafka.us-east-1.amazonaws.com:9098&group_id=test_group&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1' \
+    --source-table 'my-topic' \
+    --dest-uri duckdb:///kafka.duckdb \
+    --dest-table 'dest.my_topic'
+```
+
+When no AWS credential parameters are supplied, ingestr uses the default AWS credential chain, including environment variables, shared config, EC2/ECS/EKS roles, IRSA, and EKS Pod Identity.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.5.1
 	github.com/apache/cassandra-gocql-driver/v2 v2.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
+	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6

--- a/go.sum
+++ b/go.sum
@@ -734,6 +734,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4 h1:2jAwFwA0Xgcx94dUId+K24yFabsKYDtAhCgyMit6OqE=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4/go.mod h1:MVYeeOhILFFemC/XlYTClvBjYZrg/EPd3ts885KrNTI=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -40,8 +40,19 @@ type kafkaConfig struct {
 	SASLMechanism    string
 	SASLUsername     string
 	SASLPassword     string
+	AWS              kafkaAWSConfig
 	BatchSize        int
 	BatchTimeout     time.Duration
+}
+
+type kafkaAWSConfig struct {
+	Region          string
+	RoleARN         string
+	RoleSessionName string
+	Profile         string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
 }
 
 type KafkaSource struct {
@@ -355,14 +366,18 @@ func (s *KafkaSource) buildDialer() (*kafkago.Dialer, error) {
 		DualStack: true,
 	}
 
-	if s.cfg.SecurityProtocol == "SASL_SSL" || s.cfg.SecurityProtocol == "SSL" {
+	securityProtocol := strings.ToUpper(s.cfg.SecurityProtocol)
+	saslMechanism := strings.ToUpper(s.cfg.SASLMechanism)
+
+	if securityProtocol == "SASL_SSL" || securityProtocol == "SSL" ||
+		(saslMechanism == "OAUTHBEARER" && securityProtocol != "SASL_PLAINTEXT") {
 		dialer.TLS = &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		}
 	}
 
-	if s.cfg.SASLMechanism != "" && s.cfg.SASLUsername != "" {
-		mechanism, err := buildSASLMechanism(s.cfg.SASLMechanism, s.cfg.SASLUsername, s.cfg.SASLPassword)
+	if s.cfg.SASLMechanism != "" && (s.cfg.SASLUsername != "" || saslMechanism == "OAUTHBEARER") {
+		mechanism, err := buildSASLMechanism(s.cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -372,27 +387,29 @@ func (s *KafkaSource) buildDialer() (*kafkago.Dialer, error) {
 	return dialer, nil
 }
 
-func buildSASLMechanism(mechanism, username, password string) (sasl.Mechanism, error) {
-	switch strings.ToUpper(mechanism) {
+func buildSASLMechanism(cfg kafkaConfig) (sasl.Mechanism, error) {
+	switch strings.ToUpper(cfg.SASLMechanism) {
 	case "PLAIN":
 		return &plain.Mechanism{
-			Username: username,
-			Password: password,
+			Username: cfg.SASLUsername,
+			Password: cfg.SASLPassword,
 		}, nil
 	case "SCRAM-SHA-256":
-		m, err := scram.Mechanism(scram.SHA256, username, password)
+		m, err := scram.Mechanism(scram.SHA256, cfg.SASLUsername, cfg.SASLPassword)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create SCRAM-SHA-256 mechanism: %w", err)
 		}
 		return m, nil
 	case "SCRAM-SHA-512":
-		m, err := scram.Mechanism(scram.SHA512, username, password)
+		m, err := scram.Mechanism(scram.SHA512, cfg.SASLUsername, cfg.SASLPassword)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create SCRAM-SHA-512 mechanism: %w", err)
 		}
 		return m, nil
+	case "OAUTHBEARER":
+		return newOAuthBearerMechanism(cfg.AWS)
 	default:
-		return nil, fmt.Errorf("unsupported SASL mechanism: %s (supported: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)", mechanism)
+		return nil, fmt.Errorf("unsupported SASL mechanism: %s (supported: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER)", cfg.SASLMechanism)
 	}
 }
 
@@ -490,13 +507,36 @@ func parseKafkaURI(uri string) (kafkaConfig, error) {
 		batchTimeout = time.Duration(parsed) * time.Second
 	}
 
+	saslMechanism := values.Get("sasl_mechanisms")
+	awsCfg := kafkaAWSConfig{
+		Region:          values.Get("aws_region"),
+		RoleARN:         values.Get("aws_role_arn"),
+		RoleSessionName: values.Get("aws_role_session_name"),
+		Profile:         values.Get("aws_profile"),
+		AccessKeyID:     values.Get("aws_access_key_id"),
+		SecretAccessKey: values.Get("aws_secret_access_key"),
+		SessionToken:    values.Get("aws_session_token"),
+	}
+	if strings.EqualFold(saslMechanism, "OAUTHBEARER") {
+		if awsCfg.Region == "" {
+			return kafkaConfig{}, fmt.Errorf("aws_region is required for OAUTHBEARER")
+		}
+		if (awsCfg.AccessKeyID == "") != (awsCfg.SecretAccessKey == "") {
+			return kafkaConfig{}, fmt.Errorf("aws_access_key_id and aws_secret_access_key must be provided together")
+		}
+		if awsCfg.SessionToken != "" && (awsCfg.AccessKeyID == "" || awsCfg.SecretAccessKey == "") {
+			return kafkaConfig{}, fmt.Errorf("aws_session_token requires aws_access_key_id and aws_secret_access_key")
+		}
+	}
+
 	return kafkaConfig{
 		BootstrapServers: bootstrapServers,
 		GroupID:          groupID,
 		SecurityProtocol: values.Get("security_protocol"),
-		SASLMechanism:    values.Get("sasl_mechanisms"),
+		SASLMechanism:    saslMechanism,
 		SASLUsername:     values.Get("sasl_username"),
 		SASLPassword:     values.Get("sasl_password"),
+		AWS:              awsCfg,
 		BatchSize:        batchSize,
 		BatchTimeout:     batchTimeout,
 	}, nil

--- a/pkg/source/kafka/kafka_test.go
+++ b/pkg/source/kafka/kafka_test.go
@@ -79,6 +79,54 @@ func TestParseKafkaURI(t *testing.T) {
 			},
 		},
 		{
+			name: "oauthbearer with default AWS credential chain",
+			uri:  "kafka://?bootstrap_servers=b-1.example.kafka.us-east-1.amazonaws.com:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1",
+			check: func(t *testing.T, cfg kafkaConfig) {
+				if cfg.SASLMechanism != "OAUTHBEARER" {
+					t.Errorf("SASLMechanism = %q, want %q", cfg.SASLMechanism, "OAUTHBEARER")
+				}
+				if cfg.AWS.Region != "us-east-1" {
+					t.Errorf("AWS.Region = %q, want %q", cfg.AWS.Region, "us-east-1")
+				}
+			},
+		},
+		{
+			name: "oauthbearer with assume role",
+			uri:  "kafka://?bootstrap_servers=localhost:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1&aws_role_arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fmsk&aws_role_session_name=ingestr",
+			check: func(t *testing.T, cfg kafkaConfig) {
+				if cfg.AWS.RoleARN != "arn:aws:iam::123456789012:role/msk" {
+					t.Errorf("AWS.RoleARN = %q, want role ARN", cfg.AWS.RoleARN)
+				}
+				if cfg.AWS.RoleSessionName != "ingestr" {
+					t.Errorf("AWS.RoleSessionName = %q, want ingestr", cfg.AWS.RoleSessionName)
+				}
+			},
+		},
+		{
+			name: "oauthbearer with static session credentials",
+			uri:  "kafka://?bootstrap_servers=localhost:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1&aws_access_key_id=AKID&aws_secret_access_key=SECRET&aws_session_token=TOKEN",
+			check: func(t *testing.T, cfg kafkaConfig) {
+				if cfg.AWS.AccessKeyID != "AKID" {
+					t.Errorf("AWS.AccessKeyID = %q, want AKID", cfg.AWS.AccessKeyID)
+				}
+				if cfg.AWS.SecretAccessKey != "SECRET" {
+					t.Errorf("AWS.SecretAccessKey = %q, want SECRET", cfg.AWS.SecretAccessKey)
+				}
+				if cfg.AWS.SessionToken != "TOKEN" {
+					t.Errorf("AWS.SessionToken = %q, want TOKEN", cfg.AWS.SessionToken)
+				}
+			},
+		},
+		{
+			name: "non-oauth ignores incomplete AWS credentials",
+			uri:  "kafka://?bootstrap_servers=localhost:9092&group_id=g1&sasl_mechanisms=PLAIN&sasl_username=user&sasl_password=pass&aws_access_key_id=AKID",
+			check: func(t *testing.T, cfg kafkaConfig) {
+				if cfg.SASLMechanism != "PLAIN" {
+					t.Errorf("SASLMechanism = %q, want PLAIN", cfg.SASLMechanism)
+				}
+			},
+		},
+		{
 			name:    "wrong scheme",
 			uri:     "postgres://localhost:9092",
 			wantErr: true,
@@ -121,6 +169,21 @@ func TestParseKafkaURI(t *testing.T) {
 		{
 			name:    "zero batch_timeout",
 			uri:     "kafka://?bootstrap_servers=localhost:9092&group_id=g1&batch_timeout=0",
+			wantErr: true,
+		},
+		{
+			name:    "oauthbearer missing aws_region",
+			uri:     "kafka://?bootstrap_servers=localhost:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER",
+			wantErr: true,
+		},
+		{
+			name:    "static credentials missing secret",
+			uri:     "kafka://?bootstrap_servers=localhost:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1&aws_access_key_id=AKID",
+			wantErr: true,
+		},
+		{
+			name:    "session token without static credentials",
+			uri:     "kafka://?bootstrap_servers=localhost:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1&aws_session_token=TOKEN",
 			wantErr: true,
 		},
 	}
@@ -343,22 +406,76 @@ func TestBuildDialer_SASL_SSL(t *testing.T) {
 	}
 }
 
+func TestBuildDialer_OAUTHBEARERAutoTLS(t *testing.T) {
+	s := &KafkaSource{
+		cfg: kafkaConfig{
+			BootstrapServers: "localhost:9098",
+			GroupID:          "test",
+			SASLMechanism:    "OAUTHBEARER",
+			AWS: kafkaAWSConfig{
+				Region: "us-east-1",
+			},
+		},
+	}
+
+	dialer, err := s.buildDialer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dialer.TLS == nil {
+		t.Error("TLS should be auto-enabled for OAUTHBEARER")
+	}
+	if dialer.SASLMechanism == nil {
+		t.Fatal("SASL mechanism should be set")
+	}
+	if dialer.SASLMechanism.Name() != "OAUTHBEARER" {
+		t.Errorf("SASL mechanism = %q, want OAUTHBEARER", dialer.SASLMechanism.Name())
+	}
+}
+
+func TestBuildDialer_OAUTHBEARERSASLPlaintext(t *testing.T) {
+	s := &KafkaSource{
+		cfg: kafkaConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test",
+			SecurityProtocol: "SASL_PLAINTEXT",
+			SASLMechanism:    "OAUTHBEARER",
+			AWS: kafkaAWSConfig{
+				Region: "us-east-1",
+			},
+		},
+	}
+
+	dialer, err := s.buildDialer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dialer.TLS != nil {
+		t.Error("TLS should be nil when OAUTHBEARER explicitly uses SASL_PLAINTEXT")
+	}
+	if dialer.SASLMechanism == nil {
+		t.Fatal("SASL mechanism should be set")
+	}
+}
+
 func TestBuildSASLMechanism(t *testing.T) {
 	tests := []struct {
-		name      string
-		mechanism string
-		wantErr   bool
+		name    string
+		cfg     kafkaConfig
+		wantErr bool
 	}{
-		{name: "PLAIN", mechanism: "PLAIN"},
-		{name: "SCRAM-SHA-256", mechanism: "SCRAM-SHA-256"},
-		{name: "SCRAM-SHA-512", mechanism: "SCRAM-SHA-512"},
-		{name: "lowercase plain", mechanism: "plain"},
-		{name: "unsupported", mechanism: "OAUTHBEARER", wantErr: true},
+		{name: "PLAIN", cfg: kafkaConfig{SASLMechanism: "PLAIN", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "SCRAM-SHA-256", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-256", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "SCRAM-SHA-512", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-512", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "lowercase plain", cfg: kafkaConfig{SASLMechanism: "plain", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "OAUTHBEARER", cfg: kafkaConfig{SASLMechanism: "OAUTHBEARER", AWS: kafkaAWSConfig{Region: "us-east-1"}}},
+		{name: "oauthbearer missing region", cfg: kafkaConfig{SASLMechanism: "OAUTHBEARER"}, wantErr: true},
+		{name: "unsupported", cfg: kafkaConfig{SASLMechanism: "unsupported"}, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := buildSASLMechanism(tt.mechanism, "user", "pass")
+			m, err := buildSASLMechanism(tt.cfg)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -372,6 +489,59 @@ func TestBuildSASLMechanism(t *testing.T) {
 				t.Fatal("mechanism is nil")
 			}
 		})
+	}
+}
+
+func TestOAuthBearerMechanismStart(t *testing.T) {
+	calls := 0
+	m := oauthBearerMechanism{
+		generate: func(context.Context) (string, error) {
+			calls++
+			return "test-token", nil
+		},
+	}
+
+	state, ir, err := m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []byte("n,,\x01auth=Bearer test-token\x01\x01")
+	if string(ir) != string(want) {
+		t.Errorf("initial response = %q, want %q", string(ir), string(want))
+	}
+	done, response, err := state.Next(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected Next error: %v", err)
+	}
+	if !done {
+		t.Error("Next done = false, want true")
+	}
+	if response != nil {
+		t.Errorf("Next response = %v, want nil", response)
+	}
+
+	_, _, err = m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected second Start error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("token generator calls = %d, want 2", calls)
+	}
+}
+
+func TestOAuthBearerMechanismStartError(t *testing.T) {
+	m := oauthBearerMechanism{
+		generate: func(context.Context) (string, error) {
+			return "", errors.New("no credentials")
+		},
+	}
+
+	_, _, err := m.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to generate MSK IAM auth token") {
+		t.Errorf("error = %v, want MSK IAM context", err)
 	}
 }
 

--- a/pkg/source/kafka/oauthbearer.go
+++ b/pkg/source/kafka/oauthbearer.go
@@ -1,0 +1,66 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/segmentio/kafka-go/sasl"
+)
+
+type oauthBearerMechanism struct {
+	generate func(context.Context) (string, error)
+}
+
+func newOAuthBearerMechanism(cfg kafkaAWSConfig) (sasl.Mechanism, error) {
+	if cfg.Region == "" {
+		return nil, fmt.Errorf("aws_region is required for OAUTHBEARER")
+	}
+	return oauthBearerMechanism{
+		generate: func(ctx context.Context) (string, error) {
+			return generateMSKIAMAuthToken(ctx, cfg)
+		},
+	}, nil
+}
+
+func (oauthBearerMechanism) Name() string {
+	return "OAUTHBEARER"
+}
+
+func (m oauthBearerMechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error) {
+	token, err := m.generate(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate MSK IAM auth token: %w", err)
+	}
+	return oauthBearerState{}, []byte("n,,\x01auth=Bearer " + token + "\x01\x01"), nil
+}
+
+type oauthBearerState struct{}
+
+func (oauthBearerState) Next(context.Context, []byte) (bool, []byte, error) {
+	return true, nil, nil
+}
+
+func generateMSKIAMAuthToken(ctx context.Context, cfg kafkaAWSConfig) (string, error) {
+	var (
+		token string
+		err   error
+	)
+
+	switch {
+	case cfg.RoleARN != "":
+		token, _, err = signer.GenerateAuthTokenFromRole(ctx, cfg.Region, cfg.RoleARN, cfg.RoleSessionName)
+	case cfg.Profile != "":
+		token, _, err = signer.GenerateAuthTokenFromProfile(ctx, cfg.Region, cfg.Profile)
+	case cfg.AccessKeyID != "":
+		provider := credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken)
+		token, _, err = signer.GenerateAuthTokenFromCredentialsProvider(ctx, cfg.Region, provider)
+	default:
+		token, _, err = signer.GenerateAuthToken(ctx, cfg.Region)
+	}
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}


### PR DESCRIPTION
Adds Kafka OAUTHBEARER support for Amazon MSK IAM using the AWS signer. Documents the new URI parameters and covers the parsing and SASL mechanism paths with Kafka source tests.\n\nValidation: go test ./pkg/source/kafka