### PR TITLE
refactor(replace): unify primary-key deduplication across destinations

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1187,11 +1187,22 @@ func (d *BigQueryDestination) MergeTable(ctx context.Context, opts destination.M
 		return fmt.Errorf("invalid target table name: %w", err)
 	}
 
+	// The merge target may have just been created asynchronously by PrepareTable
+	// (e.g. the deduplicated replace table). Wait for that creation to finish so
+	// the MERGE doesn't 404 on a not-yet-visible table.
+	if _, _, tableKey, resolveErr := d.resolveTable(opts.TargetTable); resolveErr == nil {
+		if pendingErr := d.takePendingTableErr(tableKey); pendingErr != nil {
+			if err := <-pendingErr; err != nil {
+				return fmt.Errorf("failed to prepare merge target table: %w", err)
+			}
+		}
+	}
+
 	// Fetch target and staging table schemas to detect type mismatches
 	castMap := d.buildCastMap(ctx, targetDataset, targetTableName, stagingDataset, stagingTableName)
 
 	// Build MERGE statement
-	mergeSQL := d.buildMergeSQL(targetDataset, targetTableName, stagingDataset, stagingTableName, opts.PrimaryKeys, opts.Columns, castMap)
+	mergeSQL := d.buildMergeSQL(targetDataset, targetTableName, stagingDataset, stagingTableName, opts.PrimaryKeys, opts.Columns, castMap, opts.IncrementalKey)
 
 	config.Debug("[MERGE] Executing MERGE statement")
 	config.Debug("[MERGE] SQL: %s", mergeSQL)
@@ -1508,7 +1519,7 @@ func buildBigQueryDedupSelect(qualifiedTable string, primaryKeys []string, order
 }
 
 // buildMergeSQL constructs a BigQuery MERGE statement
-func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string) string {
+func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string, incrementalKey string) string {
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
 		sourceCol := castSourceCol(pk, castMap)
@@ -1561,10 +1572,16 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 			pkPartition[i] = fmt.Sprintf("`%s`", pk)
 		}
 
+		// When an incremental key is set the latest row per PK wins; otherwise
+		// the winner is arbitrary.
+		dedupOrderBy := ""
+		if incrementalKey != "" {
+			dedupOrderBy = fmt.Sprintf(" ORDER BY `%s` DESC", incrementalKey)
+		}
 		fmt.Fprintf(
 			&sql,
-			"USING (SELECT * FROM `%s`.`%s`.`%s` QUALIFY ROW_NUMBER() OVER (PARTITION BY %s) = 1) AS s\n",
-			d.projectID, stagingDataset, stagingTable, strings.Join(pkPartition, ", "),
+			"USING (SELECT * FROM `%s`.`%s`.`%s` QUALIFY ROW_NUMBER() OVER (PARTITION BY %s%s) = 1) AS s\n",
+			d.projectID, stagingDataset, stagingTable, strings.Join(pkPartition, ", "), dedupOrderBy,
 		)
 	}
 

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -912,7 +912,7 @@ func TestBuildMergeSQL(t *testing.T) {
 	dest.projectID = "my-project"
 
 	t.Run("single_pk", func(t *testing.T) {
-		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id"}, []string{"id", "name", "updated_at"}, nil)
+		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id"}, []string{"id", "name", "updated_at"}, nil, "")
 
 		if !contains(sql, "MERGE `my-project`.`target_ds`.`target_tbl` AS t\n") {
 			t.Fatalf("sql missing merge header:\n%s", sql)
@@ -941,7 +941,7 @@ func TestBuildMergeSQL(t *testing.T) {
 	})
 
 	t.Run("all_columns_are_pk_no_update", func(t *testing.T) {
-		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id"}, []string{"id"}, nil)
+		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id"}, []string{"id"}, nil, "")
 		if contains(sql, "WHEN MATCHED THEN") {
 			t.Fatalf("sql should not include matched update when there are no non-PK columns:\n%s", sql)
 		}
@@ -951,7 +951,7 @@ func TestBuildMergeSQL(t *testing.T) {
 	})
 
 	t.Run("on_clause_is_null_safe_single_pk", func(t *testing.T) {
-		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id"}, []string{"id", "name"}, nil)
+		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id"}, []string{"id", "name"}, nil, "")
 
 		if !contains(sql, "ON (t.`id` = s.`id` OR (t.`id` IS NULL AND s.`id` IS NULL))\n") {
 			t.Fatalf("sql missing null-safe on clause:\n%s", sql)
@@ -962,7 +962,7 @@ func TestBuildMergeSQL(t *testing.T) {
 	})
 
 	t.Run("on_clause_is_null_safe_composite_pk", func(t *testing.T) {
-		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"tenant_id", "user_id"}, []string{"tenant_id", "user_id", "value"}, nil)
+		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"tenant_id", "user_id"}, []string{"tenant_id", "user_id", "value"}, nil, "")
 
 		expected := "ON (t.`tenant_id` = s.`tenant_id` OR (t.`tenant_id` IS NULL AND s.`tenant_id` IS NULL)) AND (t.`user_id` = s.`user_id` OR (t.`user_id` IS NULL AND s.`user_id` IS NULL))\n"
 		if !contains(sql, expected) {
@@ -975,7 +975,7 @@ func TestBuildMergeSQL(t *testing.T) {
 
 	t.Run("with_cast_map", func(t *testing.T) {
 		castMap := map[string]string{"day": "STRING"}
-		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id", "day"}, []string{"id", "day", "amount"}, castMap)
+		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl", []string{"id", "day"}, []string{"id", "day", "amount"}, castMap, "")
 
 		if !contains(sql, "(t.`day` = CAST(s.`day` AS STRING) OR (t.`day` IS NULL AND CAST(s.`day` AS STRING) IS NULL))") {
 			t.Fatalf("sql missing cast in ON clause:\n%s", sql)

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -396,16 +396,22 @@ func (d *DatabricksDestination) MergeTable(ctx context.Context, opts destination
 		sourceCols[i] = fmt.Sprintf("source.`%s`", col)
 	}
 
-	// Build dedup subquery to handle duplicate PKs in staging
+	// Build dedup subquery to handle duplicate PKs in staging. When an
+	// incremental key is set the latest row per PK wins; otherwise arbitrary.
 	quotedPKsForPartition := make([]string, len(opts.PrimaryKeys))
 	for i, pk := range opts.PrimaryKeys {
 		quotedPKsForPartition[i] = fmt.Sprintf("`%s`", pk)
 	}
+	dedupOrderBy := ""
+	if opts.IncrementalKey != "" {
+		dedupOrderBy = fmt.Sprintf(" ORDER BY `%s` DESC", opts.IncrementalKey)
+	}
 	dedupSource := fmt.Sprintf(
-		"(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)",
+		"(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s%s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)",
 		strings.Join(quotedCols, ", "),
 		strings.Join(quotedCols, ", "),
 		strings.Join(quotedPKsForPartition, ", "),
+		dedupOrderBy,
 		stagingFull,
 	)
 

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -41,10 +41,11 @@ type Transaction interface {
 
 // MergeOptions contains parameters for merge operations.
 type MergeOptions struct {
-	StagingTable string
-	TargetTable  string
-	PrimaryKeys  []string
-	Columns      []string
+	StagingTable   string
+	TargetTable    string
+	PrimaryKeys    []string
+	Columns        []string
+	IncrementalKey string
 }
 
 // DeleteInsertOptions contains parameters for delete+insert operations.

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -408,13 +408,19 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
-	// Build dedup subquery to handle duplicate PKs in staging
+	// Build dedup subquery to handle duplicate PKs in staging. When an
+	// incremental key is set the latest row per PK wins; otherwise arbitrary.
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
+	dedupOrderBy := "(SELECT NULL)"
+	if opts.IncrementalKey != "" {
+		dedupOrderBy = destination.QuoteIdentifier(opts.IncrementalKey) + " DESC"
+	}
 	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedPKs, ", "),
+		dedupOrderBy,
 		destination.QuoteTableName(opts.StagingTable),
 	)
 

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -412,7 +412,7 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	quotedColumns := quoteColumns(columns)
 	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
 
-	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns)
+	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns, opts.IncrementalKey)
 	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
 
 	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
@@ -424,7 +424,7 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	return nil
 }
 
-func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
+func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string, incrementalKey string) string {
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
 		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
@@ -445,13 +445,19 @@ func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns,
 		sourceCols[i] = "source." + col
 	}
 
-	// Build dedup subquery to handle duplicate PKs in staging
+	// Build dedup subquery to handle duplicate PKs in staging. When an
+	// incremental key is set the latest row per PK wins; otherwise arbitrary.
 	quotedPKs := quoteColumns(primaryKeys)
+	dedupOrderBy := "(SELECT NULL)"
+	if incrementalKey != "" {
+		dedupOrderBy = quoteColumns([]string{incrementalKey})[0] + " DESC"
+	}
 	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
 		insertCols,
 		insertCols,
 		strings.Join(quotedPKs, ", "),
+		dedupOrderBy,
 		quoteTable(stagingTable),
 	)
 

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -370,13 +370,19 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Build dedup subquery to handle duplicate PKs in staging
+	// Build dedup subquery to handle duplicate PKs in staging. When an
+	// incremental key is set the latest row per PK wins; otherwise arbitrary.
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
+	dedupOrderBy := "(SELECT NULL)"
+	if opts.IncrementalKey != "" {
+		dedupOrderBy = quoteColumns([]string{opts.IncrementalKey})[0] + " DESC"
+	}
 	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedPKs, ", "),
+		dedupOrderBy,
 		quoteTable(opts.StagingTable),
 	)
 

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -526,9 +526,13 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 		// Non-CDC mode: efficient upsert using INSERT ... ON CONFLICT.
 		// DISTINCT ON dedupes staging by PK so the same target row isn't
 		// affected twice in one statement, which Postgres rejects with
-		// SQLSTATE 21000. No deterministic recency column exists outside
-		// CDC mode, so the winner per PK is arbitrary.
+		// SQLSTATE 21000. When an incremental key is set the latest row per PK
+		// wins; otherwise the winner is arbitrary.
 		pkList := strings.Join(quotedPKs, ", ")
+		orderBy := pkList
+		if opts.IncrementalKey != "" {
+			orderBy = fmt.Sprintf("%s, %s DESC", pkList, destination.QuoteIdentifier(opts.IncrementalKey))
+		}
 		upsertSQL := fmt.Sprintf(
 			`INSERT INTO %s (%s) SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s ON CONFLICT (%s) DO UPDATE SET %s`,
 			quotedTargetTable,
@@ -536,7 +540,7 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 			pkList,
 			strings.Join(quotedColumns, ", "),
 			quotedStagingTable,
-			pkList,
+			orderBy,
 			pkList,
 			buildConflictUpdateSet(nonPKColumns),
 		)

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -385,7 +385,7 @@ func (d *SnowflakeDestination) MergeTable(ctx context.Context, opts destination.
 		return errors.New("merge requires at least one primary key")
 	}
 
-	mergeSQL := buildMergeSQL(opts.StagingTable, opts.TargetTable, opts.PrimaryKeys, opts.Columns)
+	mergeSQL := buildMergeSQL(opts.StagingTable, opts.TargetTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
 
 	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
 
@@ -398,7 +398,7 @@ func (d *SnowflakeDestination) MergeTable(ctx context.Context, opts destination.
 	return nil
 }
 
-func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []string) string {
+func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []string, incrementalKey string) string {
 	stagingSchema, stagingName := parseSchemaTable(stagingTable)
 	targetSchema, targetName := parseSchemaTable(targetTable)
 
@@ -442,6 +442,8 @@ func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []s
 		dedupOrderBy = fmt.Sprintf("%s DESC, %s DESC",
 			quoteIdentifier("_cdc_lsn"),
 			quoteIdentifier("_cdc_deleted"))
+	} else if incrementalKey != "" {
+		dedupOrderBy = quoteIdentifier(incrementalKey) + " DESC"
 	}
 
 	dedupSource := fmt.Sprintf(

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBuildMergeSQL(t *testing.T) {
 	t.Run("non_cdc", func(t *testing.T) {
-		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, []string{"id", "name", "updated_at"})
+		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, []string{"id", "name", "updated_at"}, "")
 
 		assert.Contains(t, sql, `MERGE INTO "TARGET_SCHEMA"."TARGET_TBL" AS target`)
 		assert.Contains(t, sql, `FROM "STAGING_SCHEMA"."STAGING_TBL"`)
@@ -25,15 +25,22 @@ func TestBuildMergeSQL(t *testing.T) {
 		assert.NotContains(t, sql, "_CDC_DELETED")
 	})
 
+	t.Run("non_cdc_with_incremental_key", func(t *testing.T) {
+		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, []string{"id", "name", "updated_at"}, "updated_at")
+
+		assert.Contains(t, sql, `ORDER BY "UPDATED_AT" DESC`)
+		assert.NotContains(t, sql, "ORDER BY (SELECT NULL)")
+	})
+
 	t.Run("non_cdc_all_pk_columns", func(t *testing.T) {
-		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, []string{"id"})
+		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, []string{"id"}, "")
 		assert.NotContains(t, sql, "WHEN MATCHED THEN")
 		assert.Contains(t, sql, "WHEN NOT MATCHED THEN")
 	})
 
 	t.Run("cdc", func(t *testing.T) {
 		columns := []string{"id", "name", "value", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"}
-		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns)
+		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns, "")
 
 		assert.Contains(t, sql, `ORDER BY "_CDC_LSN" DESC, "_CDC_DELETED" DESC`)
 		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = false THEN`)
@@ -46,7 +53,7 @@ func TestBuildMergeSQL(t *testing.T) {
 
 	t.Run("cdc_only_pk_and_metadata", func(t *testing.T) {
 		columns := []string{"id", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"}
-		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns)
+		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns, "")
 
 		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = false THEN`)
 		assert.Contains(t, sql, `target."_CDC_LSN" = source."_CDC_LSN"`)

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -434,13 +434,19 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 
-	// Build dedup subquery to handle duplicate PKs in staging
+	// Build dedup subquery to handle duplicate PKs in staging. When an
+	// incremental key is set the latest row per PK wins; otherwise arbitrary.
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
+	dedupOrderBy := "(SELECT NULL)"
+	if opts.IncrementalKey != "" {
+		dedupOrderBy = destination.QuoteIdentifier(opts.IncrementalKey) + " DESC"
+	}
 	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedPKs, ", "),
+		dedupOrderBy,
 		destination.QuoteTableName(opts.StagingTable),
 	)
 

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -399,7 +399,7 @@ func (d *SynapseDestination) MergeTable(ctx context.Context, opts destination.Me
 	quotedColumns := quoteColumns(columns)
 	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
 
-	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns)
+	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns, opts.IncrementalKey)
 	config.Debug("[Synapse MERGE] Executing MERGE: %s", mergeSQL)
 
 	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
@@ -411,7 +411,7 @@ func (d *SynapseDestination) MergeTable(ctx context.Context, opts destination.Me
 	return nil
 }
 
-func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string) string {
+func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string, incrementalKey string) string {
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
 		onConditions[i] = fmt.Sprintf("target.[%s] = source.[%s]", pk, pk)
@@ -433,11 +433,16 @@ func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns,
 	}
 
 	quotedPKs := quoteColumns(primaryKeys)
+	dedupOrderBy := "(SELECT NULL)"
+	if incrementalKey != "" {
+		dedupOrderBy = quoteColumns([]string{incrementalKey})[0] + " DESC"
+	}
 	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY (SELECT NULL)) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
+		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
 		insertCols,
 		insertCols,
 		strings.Join(quotedPKs, ", "),
+		dedupOrderBy,
 		quoteTable(stagingTable),
 	)
 

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -116,8 +116,11 @@ func TestReplaceStrategy_Execute_HappyPath(t *testing.T) {
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if len(dest.prepareCalls) != 1 {
-		t.Fatalf("expected 1 PrepareTable call, got %d", len(dest.prepareCalls))
+	// Primary keys are set and the destination can merge, so replace
+	// deduplicates: write to a PK-free staging table, merge-dedup into a table in
+	// the target's schema, then atomically swap that table into the target.
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected 2 PrepareTable calls (staging + dedup), got %d", len(dest.prepareCalls))
 	}
 	stagingTable := dest.prepareCalls[0].Table
 	if !strings.HasPrefix(stagingTable, "_bruin_staging.ds__tbl_staging_") {
@@ -126,16 +129,34 @@ func TestReplaceStrategy_Execute_HappyPath(t *testing.T) {
 	if !dest.prepareCalls[0].DropFirst {
 		t.Fatalf("PrepareTable.DropFirst = false, want true")
 	}
+	if len(dest.prepareCalls[0].PrimaryKeys) != 0 {
+		t.Fatalf("staging table should be PK-free, got %v", dest.prepareCalls[0].PrimaryKeys)
+	}
+	normalisedTable := dest.prepareCalls[1].Table
+	if !strings.HasPrefix(normalisedTable, "ds.ds__tbl_staging_normalised_") {
+		t.Fatalf("normalised table = %q, expected prefix %q (target schema)", normalisedTable, "ds.ds__tbl_staging_normalised_")
+	}
+
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected 1 MergeTable call, got %d", len(dest.mergeCalls))
+	}
+	if dest.mergeCalls[0].StagingTable != stagingTable || dest.mergeCalls[0].TargetTable != normalisedTable {
+		t.Fatalf("MergeTable = %q -> %q, want %q -> %q", dest.mergeCalls[0].StagingTable, dest.mergeCalls[0].TargetTable, stagingTable, normalisedTable)
+	}
+	if dest.mergeCalls[0].IncrementalKey != job.Config.IncrementalKey {
+		t.Fatalf("MergeTable.IncrementalKey = %q, want %q", dest.mergeCalls[0].IncrementalKey, job.Config.IncrementalKey)
+	}
 
 	if len(dest.swapCalls) != 1 {
 		t.Fatalf("expected 1 SwapTable call, got %d", len(dest.swapCalls))
 	}
-	if dest.swapCalls[0][0] != stagingTable || dest.swapCalls[0][1] != job.Config.DestTable {
-		t.Fatalf("SwapTable args = %v, want [%q %q]", dest.swapCalls[0], stagingTable, job.Config.DestTable)
+	if dest.swapCalls[0][0] != normalisedTable || dest.swapCalls[0][1] != job.Config.DestTable {
+		t.Fatalf("SwapTable args = %v, want [%q %q]", dest.swapCalls[0], normalisedTable, job.Config.DestTable)
 	}
 
-	if len(dest.dropCalls) != 0 {
-		t.Fatalf("expected no DropTable calls, got %v", dest.dropCalls)
+	// The raw staging table is dropped after dedup.
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != stagingTable {
+		t.Fatalf("expected DropTable(%q) after dedup, got %v", stagingTable, dest.dropCalls)
 	}
 	if len(dest.writeCalls) != 1 {
 		t.Fatalf("expected 1 WriteParallel call, got %d", len(dest.writeCalls))
@@ -191,9 +212,13 @@ func TestReplaceStrategy_Execute_SwapFails_DropsStaging(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// Dedup path: raw staging is dropped after the merge, then the swap fails and
+	// the normalised table is dropped too.
 	stagingTable := dest.prepareCalls[0].Table
-	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != stagingTable {
-		t.Fatalf("expected DropTable(%q), got %v", stagingTable, dest.dropCalls)
+	normalisedTable := dest.prepareCalls[1].Table
+	want := []string{stagingTable, normalisedTable}
+	if len(dest.dropCalls) != 2 || dest.dropCalls[0] != want[0] || dest.dropCalls[1] != want[1] {
+		t.Fatalf("expected DropTable %v, got %v", want, dest.dropCalls)
 	}
 }
 

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -343,7 +343,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 			swapPrimaryKeys := tableInfo.PrimaryKeys
 			if replaceShouldDedup(job.Destination, tableInfo.PrimaryKeys) {
 				normalised, err := deduplicateStaging(ctx, job.Destination, stagingTable, destTable,
-					job.Config.StagingDataset, "", tableInfo.Schema, tableInfo.PrimaryKeys, "", nil)
+					job.Config.StagingDataset, tableInfo.Schema.IncrementalKey, tableInfo.Schema, tableInfo.PrimaryKeys, "", nil)
 				if err != nil {
 					return fmt.Errorf("failed to deduplicate table %s: %w", tableInfo.Name, err)
 				}

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -10,8 +10,60 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
+
+// replaceShouldDedup reports whether deduplicated replace applies for the
+// destination: it can merge and isn't ClickHouse (which deduplicates natively
+// via its table engine).
+func replaceShouldDedup(dest destination.Destination, primaryKeys []string) bool {
+	return len(primaryKeys) > 0 &&
+		dest.SupportsMergeStrategy() &&
+		dest.GetScheme() != "clickhouse"
+}
+
+// deduplicateStaging collapses duplicate primary keys from rawTable into a
+// normalised table in the target's schema, drops rawTable, and returns the
+// normalised table to swap into the target. Callers swap the returned table with
+// nil primary keys, since it already carries the PK and lives in the target's
+// schema (so the swap is a same-schema atomic rename rather than a second
+// recreate+copy). Staging tables are cleaned up on error.
+func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTable, targetTable, stagingDataset, incrementalKey string, tableSchema *schema.TableSchema, primaryKeys []string, partitionBy string, clusterBy []string) (string, error) {
+	normalised := GenerateNormalisedStagingTableName(targetTable, stagingDataset)
+	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        normalised,
+		Schema:       tableSchema,
+		DropFirst:    true,
+		PrimaryKeys:  primaryKeys,
+		PartitionBy:  partitionBy,
+		ClusterBy:    clusterBy,
+		ExpiresAfter: destination.ManagedStagingTTL,
+	}); err != nil {
+		if dropErr := dest.DropTable(ctx, rawTable); dropErr != nil {
+			config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
+		}
+		return "", fmt.Errorf("failed to prepare normalised staging table: %w", err)
+	}
+	if err := dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   rawTable,
+		TargetTable:    normalised,
+		PrimaryKeys:    primaryKeys,
+		Columns:        tableSchema.ColumnNames(),
+		IncrementalKey: incrementalKey,
+	}); err != nil {
+		for _, t := range []string{rawTable, normalised} {
+			if dropErr := dest.DropTable(ctx, t); dropErr != nil {
+				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
+			}
+		}
+		return "", fmt.Errorf("failed to deduplicate staging table: %w", err)
+	}
+	if dropErr := dest.DropTable(ctx, rawTable); dropErr != nil {
+		config.Debug("[REPLACE] Warning: failed to drop raw staging table: %v", dropErr)
+	}
+	return normalised, nil
+}
 
 type ReplaceStrategy struct{}
 
@@ -45,11 +97,18 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		config.Debug("[STRATEGY] Direct write to target (no staging): %s", writeTable)
 	}
 
+	// Deduplicated replace: Load a PK-free staging table so duplicate keys can land.
+	dedup := useStaging && replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+	stagingPrimaryKeys := job.Config.PrimaryKeys
+	if dedup {
+		stagingPrimaryKeys = nil
+	}
+
 	prepareOpts := destination.PrepareOptions{
 		Table:       writeTable,
 		Schema:      job.Schema,
 		DropFirst:   true,
-		PrimaryKeys: job.Config.PrimaryKeys,
+		PrimaryKeys: stagingPrimaryKeys,
 		PartitionBy: job.Config.PartitionBy,
 		ClusterBy:   job.Config.ClusterBy,
 	}
@@ -137,14 +196,27 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 				}
 			}
 		}
+		swapTable := writeTable
+		swapPrimaryKeys := job.Config.PrimaryKeys
+		if dedup {
+			normalised, err := deduplicateStaging(ctx, job.Destination, writeTable, targetTable,
+				job.Config.StagingDataset, job.Config.IncrementalKey, job.Schema,
+				job.Config.PrimaryKeys, job.Config.PartitionBy, job.Config.ClusterBy)
+			if err != nil {
+				return err
+			}
+			swapTable = normalised
+			swapPrimaryKeys = nil
+		}
+
 		if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-			StagingTable:   writeTable,
+			StagingTable:   swapTable,
 			TargetTable:    targetTable,
-			PrimaryKeys:    job.Config.PrimaryKeys,
+			PrimaryKeys:    swapPrimaryKeys,
 			IncrementalKey: job.Config.IncrementalKey,
 			Schema:         job.Schema,
 		}); err != nil {
-			if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {
+			if dropErr := job.Destination.DropTable(ctx, swapTable); dropErr != nil {
 				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
 			}
 			return fmt.Errorf("failed to swap tables: %w", err)
@@ -267,10 +339,22 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 		for _, tableInfo := range job.Tables {
 			destTable := job.GetDestTableName(tableInfo.Name)
 			stagingTable := stagingTables[tableInfo.Name]
+			swapTable := stagingTable
+			swapPrimaryKeys := tableInfo.PrimaryKeys
+			if replaceShouldDedup(job.Destination, tableInfo.PrimaryKeys) {
+				normalised, err := deduplicateStaging(ctx, job.Destination, stagingTable, destTable,
+					job.Config.StagingDataset, "", tableInfo.Schema, tableInfo.PrimaryKeys, "", nil)
+				if err != nil {
+					return fmt.Errorf("failed to deduplicate table %s: %w", tableInfo.Name, err)
+				}
+				swapTable = normalised
+				swapPrimaryKeys = nil
+			}
+
 			if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-				StagingTable: stagingTable,
+				StagingTable: swapTable,
 				TargetTable:  destTable,
-				PrimaryKeys:  tableInfo.PrimaryKeys,
+				PrimaryKeys:  swapPrimaryKeys,
 				Schema:       tableInfo.Schema,
 			}); err != nil {
 				return fmt.Errorf("failed to swap table %s: %w", tableInfo.Name, err)

--- a/pkg/strategy/staging.go
+++ b/pkg/strategy/staging.go
@@ -55,3 +55,17 @@ func GenerateStagingTableName(targetTable, suffix, stagingDataset string) string
 
 	return fmt.Sprintf("%s.%s%s", stagingSchema, embeddedName, tail)
 }
+
+// GenerateNormalisedStagingTableName returns a transient table name in the
+// TARGET table's own schema (not the staging schema).
+func GenerateNormalisedStagingTableName(targetTable, stagingDataset string) string {
+	staged := GenerateStagingTableName(targetTable, "staging_normalised", stagingDataset)
+	name := staged
+	if i := strings.Index(staged, "."); i >= 0 {
+		name = staged[i+1:]
+	}
+	if parts := strings.SplitN(targetTable, ".", 2); len(parts) == 2 {
+		return parts[0] + "." + name
+	}
+	return name
+}

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -212,10 +212,11 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 
 	config.Debug("[TRUNCATE+INSERT] Executing deduplicated insert via merge from staging")
 	if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
-		StagingTable: stagingTable,
-		TargetTable:  targetTable,
-		PrimaryKeys:  job.Config.PrimaryKeys,
-		Columns:      job.Schema.ColumnNames(),
+		StagingTable:   stagingTable,
+		TargetTable:    targetTable,
+		PrimaryKeys:    job.Config.PrimaryKeys,
+		Columns:        job.Schema.ColumnNames(),
+		IncrementalKey: job.Config.IncrementalKey,
 	}); err != nil {
 		return fmt.Errorf("failed to insert from staging: %w", err)
 	}

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -67,8 +67,14 @@ type destCase struct {
 	truncateInsertCapable  bool
 	scd2Capable            bool
 	schemaEvolutionCapable bool
-	validateNonSQL         func(t *testing.T, destURI, destTable string)
-	validateAppendNonSQL   func(t *testing.T, destURI, destTable string)
+	// replaceDedupCapable marks destinations that deduplicate by primary key on
+	// replace, so the dedup conformance tests run against them. Most swap+merge
+	// destinations do this via the strategy's pre-swap normalised table; Postgres
+	// via truncate+insert. Excludes ClickHouse (dedup is engine-dependent) and
+	// destinations without atomic swap (which write directly, no dedup).
+	replaceDedupCapable  bool
+	validateNonSQL       func(t *testing.T, destURI, destTable string)
+	validateAppendNonSQL func(t *testing.T, destURI, destTable string)
 }
 
 func destinationCases() []destCase {
@@ -96,6 +102,7 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+			replaceDedupCapable:    true,
 		},
 		{
 			name: "sqlite",
@@ -112,6 +119,7 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: false, // SQLite doesn't support ALTER COLUMN TYPE
+			replaceDedupCapable:    true,
 		},
 		{
 			name: "duckdb",
@@ -127,6 +135,7 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+			replaceDedupCapable:    true,
 		},
 		{
 			name: "csv",
@@ -190,6 +199,7 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+			replaceDedupCapable:    true,
 		},
 		{
 			name: "clickhouse",
@@ -237,6 +247,7 @@ func destinationCases() []destCase {
 			mergeCapable:           true,
 			deleteInsertCapable:    true,
 			truncateInsertCapable:  true,
+			replaceDedupCapable:    true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
 		},
@@ -287,6 +298,7 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+			replaceDedupCapable:    true,
 		},
 		{
 			name: "fabric",
@@ -359,6 +371,7 @@ func destinationCases() []destCase {
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+			replaceDedupCapable:    true,
 		},
 		{
 			name: "athena",
@@ -2572,6 +2585,138 @@ func TestDestinations_Replace_PreservesConstraints(t *testing.T) {
 			require.NoError(t, pipeline.New(cfg).Run(ctx), "Second replace should succeed")
 			assert.True(t, hasPrimaryKey(t, tc.sqlBackend, destURI, destTable, "id"),
 				"PRIMARY KEY on id should still be present after second replace (cross-schema swap)")
+		})
+	}
+}
+
+// TestDestinations_Replace_DedupesByPK verifies that, for destinations that opt
+// into deduplicated replace (DuckDB, SQLite, BigQuery, Postgres), a source
+// containing duplicate primary keys collapses to one row per key in the target,
+// keeping the latest row by incremental key. The fixture has 5 rows over 3
+// distinct ids ({1,1,2,3,3}); incremental key = score, so the higher-score row
+// wins.
+func TestDestinations_Replace_DedupesByPK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceURI := jsonlURI(t, "testdata/conformance_replace_dedup.jsonl")
+
+	for _, tc := range destinationCases() {
+		tc := tc
+		if tc.sqlBackend == nil || !tc.replaceDedupCapable {
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			destURI, destTable, cleanup := tc.setup(t, ctx)
+			defer cleanup()
+
+			cfg := &config.IngestConfig{
+				SourceURI:           sourceURI,
+				SourceTable:         "replace_dedup",
+				DestURI:             destURI,
+				DestTable:           destTable,
+				IncrementalStrategy: config.StrategyReplace,
+				IncrementalKey:      "score",
+				PrimaryKeys:         []string{"id"},
+			}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+			if tc.name == "duckdb" || tc.name == "sqlite" || tc.name == "postgres" || tc.name == "mssql" {
+				assert.True(t, hasPrimaryKey(t, tc.sqlBackend, destURI, destTable, "id"),
+					"target should keep its PRIMARY KEY after a deduplicated replace")
+			}
+
+			db, err := tc.sqlBackend.openDB(destURI)
+			if err != nil {
+				t.Skipf("Could not open SQL backend for dedup validation: %v", err)
+				return
+			}
+			defer func() { _ = db.Close() }()
+
+			var count int
+			require.NoError(t, db.QueryRow(tc.sqlBackend.countQuery(destTable)).Scan(&count))
+			assert.Equal(t, 3, count, "duplicate primary keys should collapse to one row per key")
+
+			// Latest row per key wins (highest score).
+			var name1Raw []byte
+			require.NoError(t, db.QueryRow(tc.sqlBackend.nameByIDQuery(destTable, 1)).Scan(&name1Raw))
+			assert.Equal(t, "v1-latest", string(name1Raw), "id=1 should keep the latest row by incremental key")
+
+			var name3Raw []byte
+			require.NoError(t, db.QueryRow(tc.sqlBackend.nameByIDQuery(destTable, 3)).Scan(&name3Raw))
+			assert.Equal(t, "v3-latest", string(name3Raw), "id=3 should keep the latest row by incremental key")
+		})
+	}
+}
+
+// TestDestinations_Replace_DedupesByPK_NoIncrementalKey verifies that a
+// deduplicated replace with NO incremental key still collapses duplicate primary
+// keys to one row per key. Without an incremental key the dedup ORDER BY falls
+// back to "(SELECT NULL)", so the surviving row per key is arbitrary; this test
+// asserts only the collapse and that each survivor is a real source row — not
+// which duplicate wins. Uses the same fixture (5 rows over 3 distinct ids).
+func TestDestinations_Replace_DedupesByPK_NoIncrementalKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceURI := jsonlURI(t, "testdata/conformance_replace_dedup.jsonl")
+
+	// The arbitrary dedup winner for each id must be one of these real rows.
+	validNames := map[int][]string{
+		1: {"v1-old", "v1-latest"},
+		2: {"v2"},
+		3: {"v3-old", "v3-latest"},
+	}
+
+	for _, tc := range destinationCases() {
+		tc := tc
+		if tc.sqlBackend == nil || !tc.replaceDedupCapable {
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			destURI, destTable, cleanup := tc.setup(t, ctx)
+			defer cleanup()
+
+			cfg := &config.IngestConfig{
+				SourceURI:           sourceURI,
+				SourceTable:         "replace_dedup",
+				DestURI:             destURI,
+				DestTable:           destTable,
+				IncrementalStrategy: config.StrategyReplace,
+				PrimaryKeys:         []string{"id"},
+				// No IncrementalKey: dedup keeps one arbitrary row per key.
+			}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+			if tc.name == "duckdb" || tc.name == "sqlite" || tc.name == "postgres" || tc.name == "mssql" {
+				assert.True(t, hasPrimaryKey(t, tc.sqlBackend, destURI, destTable, "id"),
+					"target should keep its PRIMARY KEY after a deduplicated replace")
+			}
+
+			db, err := tc.sqlBackend.openDB(destURI)
+			if err != nil {
+				t.Skipf("Could not open SQL backend for dedup validation: %v", err)
+				return
+			}
+			defer func() { _ = db.Close() }()
+
+			var count int
+			require.NoError(t, db.QueryRow(tc.sqlBackend.countQuery(destTable)).Scan(&count))
+			assert.Equal(t, 3, count, "duplicate primary keys should collapse to one row per key")
+
+			// Each id survives exactly once, holding one of its real source rows.
+			for id, names := range validNames {
+				var nameRaw []byte
+				require.NoError(t, db.QueryRow(tc.sqlBackend.nameByIDQuery(destTable, id)).Scan(&nameRaw))
+				assert.Contains(t, names, string(nameRaw),
+					"id=%d should keep one of the real source rows (arbitrary winner)", id)
+			}
 		})
 	}
 }

--- a/tests/integration/testdata/conformance_replace_dedup.jsonl
+++ b/tests/integration/testdata/conformance_replace_dedup.jsonl
@@ -1,0 +1,5 @@
+{"id":1,"name":"v1-old","active":true,"score":10.0}
+{"id":1,"name":"v1-latest","active":false,"score":11.0}
+{"id":2,"name":"v2","active":true,"score":20.0}
+{"id":3,"name":"v3-old","active":true,"score":30.0}
+{"id":3,"name":"v3-latest","active":false,"score":31.0}


### PR DESCRIPTION
Replace a per-destination patchwork of dedup logic with a single pre-swap step: when primary keys are set and the destination can merge, load a PK-free raw staging table (staging_raw), dedupe it by PK into a normalised table (staging_normalized) in the target's schema (via MergeTable), then atomically rename it in. Keeping the normalised table in the target schema makes the final swap an O(1) same-schema rename on every destination. Dedup keeps the latest row per key by incremental key, or an arbitrary winner when none is set. Single-table and multi-table replace share the helper.