### PR TITLE
docs(supported-sources): replace external links with self-contained setup steps

### DIFF
--- a/docs/supported-sources/athena.md
+++ b/docs/supported-sources/athena.md
@@ -16,20 +16,78 @@ athena://?bucket=<your-destination-bucket> \
 ```
 URI parameters:
 - `bucket` (required): The name of the bucket where the data will be stored, containing the Parquet files that Athena will work with, e.g. `your_bucket_name` or `s3://your_bucket_name`.
-- `access_key_id` and `secret_access_key` (required): These are AWS credentials that will be used to authenticate with AWS services like S3 and Athena.
-- `session_token` (optional): The session token for temporary credentials.
-- `region_name` (required if there's no local profile found): The AWS region of the Athena service and S3 buckets, e.g. `eu-central-1`
-- `workgroup` (optional): The name of the Athena workgroup, e.g. `my_group`
-- `profile` (optional): The name of the AWS profile to use, e.g. `my_profile`
+- `access_key_id` and `secret_access_key` (required unless `profile` is set): AWS credentials used to authenticate with S3, Athena, and Glue.
+- `session_token` (optional): Session token for temporary credentials (e.g. credentials copied from the AWS Identity Center access portal).
+- `region_name` (required if there's no local profile found): The AWS region of the Athena service and S3 buckets, e.g. `eu-central-1`.
+- `workgroup` (optional): The name of the Athena workgroup. Defaults to the account's `primary` workgroup if not provided.
+- `profile` (optional): The name of a local AWS profile to use (e.g. one configured via `aws configure sso`). When set, ingestr reads credentials from your local AWS credentials file instead of from the URI.
 
-You have two ways of providing credentials:
-1. Provide `access_key_id` and `secret_access_key` directly in the URI.
-2. Provide the name of the AWS profile to use in the `profile` parameter.
-
-If there's no access key and secret key provided, ingestr will try to find the credentials in the local AWS credentials file.
+There are three ways to provide credentials, covered in detail under [Setting up an Athena Integration](#setting-up-an-athena-integration) below: a dedicated IAM user with long-lived keys, an AWS Identity Center (SSO) login via a local profile, or short-lived keys copied from the SSO access portal.
 
 ## Setting up an Athena Integration
-Athena requires a `bucket`, `access_key_id`, `secret_access_key` and `region_name` to access the S3 bucket. Please follow the guide on dltHub to obtain [credentials](https://dlthub.com/docs/dlt-ecosystem/destinations/athena#2-setup-bucket-storage-and-athena-credentials). Once you've completed the guide, you should have all the above-mentioned credentials.
+Athena requires a `bucket`, a `region_name`, and AWS credentials. The bucket is used to store both the data files written by ingestr and the query results that Athena produces.
+
+### 1. Storage and permissions (always required)
+
+These steps are the same no matter how you authenticate.
+
+1. **Create an S3 bucket** for ingestr data in the same AWS region you plan to query from. In the [S3 console](https://s3.console.aws.amazon.com/), click **Create bucket**, choose a unique name (e.g. `my-company-ingestr`), keep "Block all public access" enabled, and create it. This name is the `bucket` URI parameter.
+2. **Create an Athena workgroup** (optional). AWS already provides a default workgroup called `primary`. If you do not pass `workgroup=` in the URI, ingestr uses `primary` — just make sure it has a **Query result location** configured under **Athena → Workgroups → primary → Edit**. If you prefer to isolate ingestr's queries, create a new workgroup with its own query result location (e.g. `s3://my-company-ingestr/athena-results/`) and pass the workgroup name as the `workgroup` URI parameter.
+3. **Note the region** of your bucket and Athena workgroup, for example `eu-central-1`. This is the `region_name` URI parameter.
+4. **Decide what permissions ingestr will need.** Whichever identity you use in the next step must be allowed to:
+   - `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` on your bucket and its objects (the AWS-managed `AmazonS3FullAccess` works for testing, but a bucket-scoped policy is safer).
+   - `athena:StartQueryExecution`, `athena:GetQueryExecution`, `athena:GetQueryResults`, `athena:StopQueryExecution` (or the managed `AmazonAthenaFullAccess` policy).
+   - `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`, `glue:DeleteTable`, `glue:GetPartitions`, `glue:BatchCreatePartition` so ingestr can register external tables in the AWS Glue Data Catalog that Athena reads from.
+
+### 2. Choose a credential method
+
+Pick **one** of the following based on how you sign in to AWS. If you are unsure which one applies, the quickest test is: open the [AWS console](https://console.aws.amazon.com/), click your name in the top-right corner, and look at the badge under your name — if it says `AssumedRole/AWSReservedSSO_…`, you are signed in via Identity Center (SSO) and should use Option B or C. Otherwise Option A is fine.
+
+#### Option A — IAM user with long-lived access keys (no SSO)
+
+Best for: accounts that are **not** managed by AWS Identity Center, or for creating a dedicated service identity for ingestr.
+
+1. In the [IAM console](https://console.aws.amazon.com/iam/), go to **Users → Create user**, give it a name (e.g. `ingestr-athena`), and continue without granting console access.
+2. On the **Set permissions** step, attach a policy granting the S3 / Athena / Glue permissions from step 4 above.
+3. Open the new user, go to the **Security credentials** tab → **Access keys** → **Create access key**, choose **Application running outside AWS**, and copy the **Access key ID** (`access_key_id`) and **Secret access key** (`secret_access_key`).
+
+URI:
+```plaintext
+athena://?bucket=my-company-ingestr&access_key_id=AKIA...&secret_access_key=...&region_name=eu-central-1
+```
+
+#### Option B — AWS Identity Center (SSO) via a local profile
+
+Best for: developer machines where you already use `aws configure sso` / `aws sso login`. ingestr reads the credentials (including the rotating session token) from your local AWS credentials file, so you never paste secrets into the URI.
+
+1. If you have not yet, run `aws configure sso` and follow the prompts to attach your Identity Center login to a named profile, e.g. `ingestr`.
+2. Whenever the session has expired, run `aws sso login --profile ingestr` to refresh it.
+3. In your Identity Center permission set, confirm that the role you assume includes the S3 / Athena / Glue permissions from step 4 above.
+
+URI:
+```plaintext
+athena://?bucket=my-company-ingestr&profile=ingestr&region_name=eu-central-1
+```
+
+#### Option C — Short-lived credentials from the SSO access portal
+
+Best for: a one-off ingestion run from a machine that does not have the AWS CLI configured.
+
+1. Open your AWS access portal (`https://<your-sso-portal>.awsapps.com/start`).
+2. Pick the target account, then click **Access keys** next to the permission set you want to use.
+3. Copy the **Access key ID**, **Secret access key**, and **Session token** from the screen.
+
+URI:
+```plaintext
+athena://?bucket=my-company-ingestr&access_key_id=ASIA...&secret_access_key=...&session_token=...&region_name=eu-central-1
+```
+
+> [!WARNING]
+> Credentials from Option C expire after a few hours. Do not use them for scheduled pipelines — use Option A (dedicated IAM user) or Option B (refreshable SSO profile) instead.
+
+### 3. Run ingestr
+
+Here's a sample command using Option A credentials:
 ```
 ingestr ingest \
   --source-uri "stripe://?api_key=key123" \

--- a/docs/supported-sources/facebook-ads.md
+++ b/docs/supported-sources/facebook-ads.md
@@ -21,9 +21,38 @@ The URI is used to connect to Facebook Ads API for extracting data.
 
 ## Setting up a Facebook Ads Integration
 
-Facebook Ads requires a few steps to set up an integration, please follow the guide dltHub [has built here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/facebook_ads#setup-guide).
+Facebook Ads is accessed through the [Marketing API](https://developers.facebook.com/docs/marketing-api/) and requires a long-lived access token with `ads_read` permission. ingestr currently calls Graph API `v21.0`.
 
-Once you complete the guide, you should have an access token and an Account ID. Let's say your `access_token` is `abcdef` and `account_id` is `1234`, here's a sample command that will copy the data from Facebook Ads into a DuckDB database:
+1. **Grant yourself access to the Ad Account.** In [Business Manager](https://business.facebook.com/) under **Business settings → Accounts → Ad accounts**, confirm that the user (or System User — see step 6) you plan to authenticate as has at least **View performance** access to every Ad Account you want to ingest from.
+
+2. **Create a Meta app.** Open [Meta for Developers → My Apps](https://developers.facebook.com/apps/) and click **Create app**. When asked what your app does, pick the option that lets you manage business assets and the Marketing API (currently labelled "Other" → "Business" in most regions). Give the app a name and finish creating it.
+
+3. **Add the Marketing API product.** In the new app's dashboard, find **Add a product** (or **Add products to your app**) and click **Set up** on the **Marketing API** card. This unlocks the `ads_read`, `ads_management`, and `leads_retrieval` permissions for your app.
+
+4. **Generate a short-lived access token.** Open the [Graph API Explorer](https://developers.facebook.com/tools/explorer/), select your app in the **Meta App** dropdown, set **User or Page** to **User Token**, click **Add a Permission**, and add at least:
+   - `ads_read` — required for `campaigns`, `ad_sets`, `ads`, `ad_creatives`, and `facebook_insights`.
+   - `leads_retrieval` — additionally required for the `leads` table.
+   - `business_management` — recommended if you use a System User or need to list all ad accounts in a business.
+
+   Click **Generate Access Token** and copy the token that appears. This short-lived token expires in about an hour.
+
+5. **Exchange it for a long-lived token.** Long-lived user tokens last about 60 days. To exchange, call:
+
+   ```text
+   https://graph.facebook.com/v21.0/oauth/access_token
+       ?grant_type=fb_exchange_token
+       &client_id=<APP_ID>
+       &client_secret=<APP_SECRET>
+       &fb_exchange_token=<SHORT_LIVED_TOKEN>
+   ```
+
+   Find `<APP_ID>` and `<APP_SECRET>` in your app's **Settings → Basic** page. The `access_token` field in the JSON response is what you pass to ingestr.
+
+6. **(Recommended for production)** Use a **System User token** instead. User tokens still expire after 60 days, which will break scheduled pipelines. In **Business Manager → Business settings → Users → System users**, create a new system user, click **Add assets** to grant it access to the relevant Ad Accounts, then click **Generate new token**, pick your app, select the same permissions as step 4, and choose **Never** for expiration. Use that token as `access_token`.
+
+7. **Find your Ad Account ID.** In [Ads Manager](https://www.facebook.com/adsmanager/) the account selector shows IDs in the form `act_1234567890`. Pass only the numeric part (`1234567890`) as `account_id` — ingestr automatically prepends `act_` when calling the API.
+
+Once you complete these steps, you should have an access token and an Account ID. Let's say your `access_token` is `abcdef` and `account_id` is `1234`, here's a sample command that will copy the data from Facebook Ads into a DuckDB database:
 
 ```sh
 ingestr ingest \

--- a/docs/supported-sources/intercom.md
+++ b/docs/supported-sources/intercom.md
@@ -21,9 +21,16 @@ The URI is used to connect to the Intercom API for extracting data.
 
 ## Setting up an Intercom Integration
 
-Intercom requires a few steps to set up an integration, please follow the guide dltHub [has built here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/intercom).
+To obtain an Intercom access token, create a private app in your workspace:
 
-Once you complete the guide, you should have an access token. Let's say your access token is `dG9rOjE...` and your workspace is in the US region, here's a sample command that will copy the data from Intercom into a DuckDB database:
+1. Sign in to the [Intercom Developer Hub](https://app.intercom.com/a/developer-signup) with the workspace you want to ingest data from.
+2. Click **New app**, give it a name, select your workspace, and create it.
+3. Open the new app and go to **Authentication** in the left sidebar.
+4. Under **Access token**, click **Generate token** (or copy the existing one). This token is the value you will pass as `access_token`.
+5. Go to **Authentication → Permissions** and enable read access for the resources you intend to ingest (e.g. contacts, companies, conversations, articles, tags, segments, admins, teams, data attributes).
+6. Note the region your workspace is hosted in (`us`, `eu`, or `au`). You can confirm it by checking the URL you sign in from (`app.intercom.com` for US, `app.eu.intercom.com` for EU, `app.au.intercom.com` for AU).
+
+Once you have an access token, let's say your access token is `dG9rOjE...` and your workspace is in the US region, here's a sample command that will copy the data from Intercom into a DuckDB database:
 
 ```sh
 ingestr ingest \

--- a/docs/supported-sources/kinesis.md
+++ b/docs/supported-sources/kinesis.md
@@ -20,9 +20,23 @@ URI parameters:
 
 
 ## Setting up a Kinesis Integration
-To get Kinesis credentials, please refer to the guide [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/amazon_kinesis#grab-credentials)
 
-Once you complete the guide, you should have a aws_access_key_id, aws_secret_access_key and region_name. Let's say your `aws_access_key_id` is id_123, your `aws_secret_access_key` is secret_123 and your `region_name` is eu-central-1, here's a sample command that will copy the data from Kinesis into a DuckDB database:
+To read from Kinesis, you need an AWS access key pair with permission to describe the stream and read its records. The recommended approach is to create a dedicated IAM user:
+
+1. Sign in to the [AWS IAM console](https://console.aws.amazon.com/iam/).
+2. Go to **Users → Create user**, give the user a name (e.g. `ingestr-kinesis`), and continue without granting console access.
+3. On the **Set permissions** step, choose **Attach policies directly** and attach a policy that allows reading the streams you want to ingest. The AWS-managed policy `AmazonKinesisReadOnlyAccess` is sufficient for most cases, or you can create a custom policy granting at minimum:
+   - `kinesis:DescribeStream`
+   - `kinesis:DescribeStreamSummary`
+   - `kinesis:GetShardIterator`
+   - `kinesis:GetRecords`
+   - `kinesis:ListShards`
+   - `kinesis:ListStreams`
+4. Finish creating the user, then open the user and go to the **Security credentials** tab → **Access keys** → **Create access key**.
+5. Select **Application running outside AWS**, create the key, and copy the **Access key ID** (your `aws_access_key_id`) and **Secret access key** (your `aws_secret_access_key`).
+6. Note the AWS region where your stream lives (e.g. `eu-central-1`); that is your `region_name`. You can find it in the [Kinesis console](https://console.aws.amazon.com/kinesis/).
+
+Once you have these credentials, let's say your `aws_access_key_id` is id_123, your `aws_secret_access_key` is secret_123 and your `region_name` is eu-central-1, here's a sample command that will copy the data from Kinesis into a DuckDB database:
 
 ```bash
 ingestr ingest --source-uri 'kinesis://?aws_access_key_id=id_123&aws_secret_access_key=secret_123&region_name=eu-central-1' \

--- a/docs/supported-sources/personio.md
+++ b/docs/supported-sources/personio.md
@@ -20,9 +20,15 @@ URI parameters:
 
 ## Setting up a Personio Integration
 
-To grab personio credentials, please follow the guide [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/personio#grab-credentials).
+Personio uses an API client (a `client_id` / `client_secret` pair) for authentication. You need an administrator account to create one:
 
-Once you complete the guide, you should have a client ID and client secret. Let's say your `client_id` is id_123 and your `client_secret` is secret_123, here's a sample command that will copy the data from Personio into a DuckDB database:
+1. Sign in to your Personio workspace as an administrator.
+2. Open **Settings** (the gear icon) and go to **Integrations → API credentials**.
+3. Click **Generate new credentials** and give the credential a descriptive name (e.g. `ingestr`).
+4. Under **Scopes / Readable attributes**, enable read access for every endpoint and attribute you plan to ingest (e.g. employees, absences, absence types, attendances, projects, document categories, custom reports). Without these scopes the corresponding tables will return empty or error.
+5. Save the credential. Personio will show the **Client ID** and **Client Secret** once — copy them immediately, as the secret cannot be retrieved later.
+
+Once you complete these steps, you should have a client ID and client secret. Let's say your `client_id` is id_123 and your `client_secret` is secret_123, here's a sample command that will copy the data from Personio into a DuckDB database:
 
 ```bash
 ingestr ingest --source-uri 'personio://?client_id=id_123&client_secret=secret_123' \

--- a/docs/supported-sources/pipedrive.md
+++ b/docs/supported-sources/pipedrive.md
@@ -14,11 +14,16 @@ pipedrive://?api_token=<api_token>
 URI parameters:
 - api_token: token used for authentication with the Pipedrive API
 
-## Setting up a pipedrive Integration
+## Setting up a Pipedrive Integration
 
-To grab pipedrive credentials, please follow the guide [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/pipedrive#grab-api-token).
+Pipedrive uses a personal API token for authentication. Each user has their own token, and the token inherits that user's permissions:
 
-Once you complete the guide, you should have a `api_token`. Let's say your `api_token` is token_123, here's a sample command that will copy the data from pipedriveinto a DuckDB database:
+1. Sign in to your Pipedrive account with the user whose access you want ingestr to use. Make sure that user has visibility into the data you want to copy (deals, persons, organizations, etc.).
+2. Click your profile picture in the top-right corner and choose **Personal preferences**.
+3. Open the **API** tab. If you do not see this tab, ask an admin to enable API access for your user under **Settings → User management**.
+4. Copy the value shown under **Your personal API token**. This is your `api_token`.
+
+Once you have the token, let's say your `api_token` is token_123, here's a sample command that will copy the data from Pipedrive into a DuckDB database:
 
 ```bash
 ingestr ingest \


### PR DESCRIPTION
## Summary

Removes remaining old links from six source/destination guides and replaces them with step-by-step credentials instructions readers can follow without leaving the ingestr docs.

- **intercom.md** — Developer Hub app creation, access token generation, workspace region identification.
- **kinesis.md** — IAM user creation with `AmazonKinesisReadOnlyAccess`, access key generation. Step 4 made explicit about the **Security credentials** tab inside the user (per UI feedback).
- **personio.md** — Admin Settings → Integrations → API credentials, scope/readable-attributes warning.
- **pipedrive.md** — Personal preferences → API tab.
- **facebook-ads.md** — Meta app creation, Marketing API product, Graph API Explorer token generation, long-lived token exchange, System User recommendation for production. Updated the Graph API version in the token-exchange URL from `v19.0` to `v21.0` to match what ingestr's code actually calls (`pkg/source/facebook_ads/facebook_ads.go:21`). Added the `leads_retrieval` scope which was missing.
- **athena.md** — Restructured into shared setup (bucket, workgroup, permissions) plus three named credential options:
  - **Option A** — IAM user with long-lived access keys.
  - **Option B** — AWS Identity Center (SSO) via a local `profile=` URI parameter.
  - **Option C** — Short-lived keys + `session_token=` from the SSO access portal.

  All three options have a URI example directly under them. Verified that `session_token` and `profile` URI parameters are actually supported by `pkg/source/athena/config.go`.