### PR TITLE
feat(hubspot): support service keys as a credential

### DIFF
--- a/docs/supported-sources/hubspot.md
+++ b/docs/supported-sources/hubspot.md
@@ -12,17 +12,28 @@ The URI format for HubSpot is as follows:
 hubspot://?api_key=<api-key-here>
 ```
 
+or, using a service key:
+
+```plaintext
+hubspot://?service_key=<service-key-here>
+```
+
 URI parameters:
 
-- `api_key`: The API key is used for authentication with the HubSpot API.
+- `api_key`: A private app access token used for authentication with the HubSpot API.
+- `service_key`: A HubSpot [service key](https://developers.hubspot.com/blog/hubspot-service-keys-the-right-api-credential-for-data-integrations) used for authentication with the HubSpot API.
+
+Provide exactly one of `api_key` or `service_key`. Both are sent to HubSpot as an HTTP Bearer token, so they are interchangeable as the credential.
 
 The URI is used to connect to the HubSpot API for extracting data.
 
 ## Setting up a HubSpot Integration
 
-HubSpot requires a few steps to set up an integration, please follow the guide dltHub [has built here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/hubspot#setup-guide).
+To authenticate with a **service key**, go to Settings → Integrations → Service Keys in your HubSpot account, create a key, grant it the required scopes, and copy the generated key.
 
-Once you complete the guide, you should have an API key. Let's say your API key is `pat_test_12345`, here's a sample command that will copy the data from HubSpot into a DuckDB database:
+To authenticate with a **private app access token**, go to Settings → Integrations → Private Apps in your HubSpot account, create a private app, grant it the required scopes, and copy the generated access token.
+
+Once you have a key (for example `pat_test_12345`), here's a sample command that will copy the data from HubSpot into a DuckDB database:
 
 ```sh
 ingestr ingest --source-uri 'hubspot://?api_key=pat_test_12345' --source-table 'companies' --dest-uri duckdb:///hubspot.duckdb --dest-table 'companies.data'

--- a/docs/supported-sources/hubspot.md
+++ b/docs/supported-sources/hubspot.md
@@ -25,6 +25,8 @@ URI parameters:
 
 Provide exactly one of `api_key` or `service_key`. Both are sent to HubSpot as an HTTP Bearer token, so they are interchangeable as the credential.
 
+> **Note:** HubSpot service keys are currently in **public beta**. The feature may change before general availability, so keep that in mind before relying on it for production workloads.
+
 The URI is used to connect to the HubSpot API for extracting data.
 
 ## Setting up a HubSpot Integration

--- a/pkg/source/hubspot/hubspot.go
+++ b/pkg/source/hubspot/hubspot.go
@@ -172,7 +172,7 @@ func parseHubspotURI(uri string) (string, error) {
 
 	rest := strings.TrimPrefix(uri, "hubspot://")
 	if rest == "" || rest == "?" {
-		return "", fmt.Errorf("api_key is required in hubspot URI")
+		return "", fmt.Errorf("api_key or service_key is required in hubspot URI")
 	}
 
 	rest = strings.TrimPrefix(rest, "?")
@@ -183,11 +183,18 @@ func parseHubspotURI(uri string) (string, error) {
 	}
 
 	apiKey := values.Get("api_key")
-	if apiKey == "" {
-		return "", fmt.Errorf("api_key is required in hubspot URI")
-	}
+	serviceKey := values.Get("service_key")
 
-	return apiKey, nil
+	switch {
+	case apiKey != "" && serviceKey != "" && apiKey != serviceKey:
+		return "", fmt.Errorf("provide either api_key or service_key in hubspot URI, not both")
+	case apiKey != "":
+		return apiKey, nil
+	case serviceKey != "":
+		return serviceKey, nil
+	default:
+		return "", fmt.Errorf("api_key or service_key is required in hubspot URI")
+	}
 }
 
 func (s *Hubspotsource) Close(ctx context.Context) error {

--- a/pkg/source/hubspot/hubspot_test.go
+++ b/pkg/source/hubspot/hubspot_test.go
@@ -93,6 +93,69 @@ func TestParseHistoryTableName(t *testing.T) {
 	}
 }
 
+func TestParseHubspotURI(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "api_key",
+			input: "hubspot://?api_key=pat_test_12345",
+			want:  "pat_test_12345",
+		},
+		{
+			name:  "service_key",
+			input: "hubspot://?service_key=sk_test_67890",
+			want:  "sk_test_67890",
+		},
+		{
+			name:  "both equal",
+			input: "hubspot://?api_key=tok&service_key=tok",
+			want:  "tok",
+		},
+		{
+			name:    "both differ",
+			input:   "hubspot://?api_key=a&service_key=b",
+			wantErr: true,
+		},
+		{
+			name:    "missing credential",
+			input:   "hubspot://?",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "hubspot://",
+			wantErr: true,
+		},
+		{
+			name:    "wrong scheme",
+			input:   "postgres://?api_key=x",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseHubspotURI(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseTableAssocOverride(t *testing.T) {
 	cases := []struct {
 		name         string


### PR DESCRIPTION
The connector now accepts a `service_key` query parameter as an interchangeable alias for `api_key`:

```
hubspot://?service_key=<service-key-here>
```
