### PR TITLE
refactor(debug): emit zap-compatible debug log format

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ var DebugMode bool
 
 func Debug(format string, args ...interface{}) {
 	if DebugMode {
-		fmt.Printf("[%s] %s\n", time.Now().Format("15:04:05.000"), fmt.Sprintf(format, args...))
+		fmt.Printf("%s\tDEBUG\t%s\n", time.Now().Format("2006-01-02T15:04:05.000Z0700"), fmt.Sprintf(format, args...))
 	}
 }
 


### PR DESCRIPTION
## Summary

`config.Debug` now writes lines in the same tab-separated, ISO8601-prefixed shape that bruin's Zap logger produces, so a single parser can route debug output from both ingestr and bruin into a unified debug log stream.

**Before:**
```
[14:32:58.976] [DUCKDB] Destination path: /tmp/bruin-test-pipeline/dest.db
```

**After:**
```
2026-06-08T14:55:36.559+0300	DEBUG	[DUCKDB] Destination path: /tmp/bruin-test-pipeline/dest.db
```

The module tag (`[DUCKDB]`, `[HTTP]`, etc.) stays inside the message field, so the ~1,700 existing `config.Debug` call sites do not need to change.