### PR TITLE
feat(pipeline): print readable type names in column override logs

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1276,7 +1276,7 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 		if override.DataType != schema.TypeUnknown {
 			newCol := override.ApplyToColumn(col)
 			if col.DataType != newCol.DataType || col.Precision != newCol.Precision || col.Scale != newCol.Scale {
-				fmt.Printf("Column override: %q type changed from %v(p=%v,s=%v) to %v(p=%v,s=%v)\n",
+				fmt.Printf("Column override: %q type changed from %s(p=%v,s=%v) to %s(p=%v,s=%v)\n",
 					col.Name, col.DataType, col.Precision, col.Scale, newCol.DataType, newCol.Precision, newCol.Scale)
 			}
 			sourceSchema.Columns[i] = newCol

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -27,6 +27,47 @@ const (
 	TypeArray
 )
 
+func (d DataType) String() string {
+	switch d {
+	case TypeBoolean:
+		return "boolean"
+	case TypeInt16:
+		return "int16"
+	case TypeInt32:
+		return "int32"
+	case TypeInt64:
+		return "int64"
+	case TypeFloat32:
+		return "float32"
+	case TypeFloat64:
+		return "float64"
+	case TypeDecimal:
+		return "decimal"
+	case TypeString:
+		return "string"
+	case TypeBinary:
+		return "binary"
+	case TypeDate:
+		return "date"
+	case TypeTime:
+		return "time"
+	case TypeTimestamp:
+		return "timestamp_ntz"
+	case TypeTimestampTZ:
+		return "timestamp"
+	case TypeInterval:
+		return "interval"
+	case TypeJSON:
+		return "json"
+	case TypeUUID:
+		return "uuid"
+	case TypeArray:
+		return "array"
+	default:
+		return "unknown"
+	}
+}
+
 type Column struct {
 	Name         string
 	DataType     DataType

--- a/pkg/schemaevolution/contract.go
+++ b/pkg/schemaevolution/contract.go
@@ -97,17 +97,17 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 func describeChange(change SchemaChange) string {
 	switch change.Type {
 	case ChangeAddColumn:
-		return fmt.Sprintf("new column detected (type: %s)", dataTypeName(change.NewColumn.DataType))
+		return fmt.Sprintf("new column detected (type: %s)", change.NewColumn.DataType)
 	case ChangeWidenType:
 		if change.OldColumn != nil {
-			return fmt.Sprintf("type change from %s to %s", dataTypeName(change.OldColumn.DataType), dataTypeName(change.NewColumn.DataType))
+			return fmt.Sprintf("type change from %s to %s", change.OldColumn.DataType, change.NewColumn.DataType)
 		}
-		return fmt.Sprintf("type widened to %s", dataTypeName(change.NewColumn.DataType))
+		return fmt.Sprintf("type widened to %s", change.NewColumn.DataType)
 	case ChangeOverrideType:
 		if change.OldColumn != nil {
-			return fmt.Sprintf("type override from %s to %s", dataTypeName(change.OldColumn.DataType), dataTypeName(change.NewColumn.DataType))
+			return fmt.Sprintf("type override from %s to %s", change.OldColumn.DataType, change.NewColumn.DataType)
 		}
-		return fmt.Sprintf("type override to %s", dataTypeName(change.NewColumn.DataType))
+		return fmt.Sprintf("type override to %s", change.NewColumn.DataType)
 	case ChangeRemoveColumn:
 		return "column removed from source (future values will be NULL)"
 	default:

--- a/pkg/schemaevolution/contract_test.go
+++ b/pkg/schemaevolution/contract_test.go
@@ -182,22 +182,22 @@ func TestDescribeChange(t *testing.T) {
 		{
 			"add column",
 			SchemaChange{Type: ChangeAddColumn, ColumnName: "new_col", NewColumn: schema.Column{DataType: schema.TypeString}},
-			[]string{"new column", "STRING"},
+			[]string{"new column", "string"},
 		},
 		{
 			"widen type with old",
 			SchemaChange{Type: ChangeWidenType, ColumnName: "val", OldColumn: &schema.Column{DataType: schema.TypeInt32}, NewColumn: schema.Column{DataType: schema.TypeInt64}},
-			[]string{"type change", "INT32", "INT64"},
+			[]string{"type change", "int32", "int64"},
 		},
 		{
 			"widen type without old",
 			SchemaChange{Type: ChangeWidenType, ColumnName: "val", NewColumn: schema.Column{DataType: schema.TypeString}},
-			[]string{"widened", "STRING"},
+			[]string{"widened", "string"},
 		},
 		{
 			"override type",
 			SchemaChange{Type: ChangeOverrideType, ColumnName: "val", OldColumn: &schema.Column{DataType: schema.TypeString}, NewColumn: schema.Column{DataType: schema.TypeInt64}},
-			[]string{"override", "STRING", "INT64"},
+			[]string{"override", "string", "int64"},
 		},
 	}
 
@@ -216,7 +216,7 @@ func TestViolationError(t *testing.T) {
 		Mode: ContractFreeze,
 		Violations: []ContractViolation{
 			{ColumnName: "col1", Description: "new column detected"},
-			{ColumnName: "col2", Description: "type change from INT32 to INT64"},
+			{ColumnName: "col2", Description: "type change from int32 to int64"},
 		},
 	}
 

--- a/pkg/schemaevolution/dialect_test.go
+++ b/pkg/schemaevolution/dialect_test.go
@@ -54,47 +54,6 @@ func allDialects() []dialectConformanceTest {
 	return dialects
 }
 
-func dataTypeName(dt schema.DataType) string {
-	switch dt {
-	case schema.TypeBoolean:
-		return "BOOLEAN"
-	case schema.TypeInt16:
-		return "INT16"
-	case schema.TypeInt32:
-		return "INT32"
-	case schema.TypeInt64:
-		return "INT64"
-	case schema.TypeFloat32:
-		return "FLOAT32"
-	case schema.TypeFloat64:
-		return "FLOAT64"
-	case schema.TypeDecimal:
-		return "DECIMAL"
-	case schema.TypeString:
-		return "STRING"
-	case schema.TypeBinary:
-		return "BINARY"
-	case schema.TypeDate:
-		return "DATE"
-	case schema.TypeTime:
-		return "TIME"
-	case schema.TypeTimestamp:
-		return "TIMESTAMP"
-	case schema.TypeTimestampTZ:
-		return "TIMESTAMPTZ"
-	case schema.TypeInterval:
-		return "INTERVAL"
-	case schema.TypeJSON:
-		return "JSON"
-	case schema.TypeUUID:
-		return "UUID"
-	case schema.TypeArray:
-		return "ARRAY"
-	default:
-		return "UNKNOWN"
-	}
-}
-
 func TestDialectRegistry(t *testing.T) {
 	schemes := []string{
 		"postgres",
@@ -241,7 +200,7 @@ func TestAllDialects_TypeName_Integers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(dataTypeName(tt.dataType), func(t *testing.T) {
+		t.Run(tt.dataType.String(), func(t *testing.T) {
 			col := schema.Column{Name: "val", DataType: tt.dataType}
 			for scheme, exp := range tt.expected {
 				t.Run(scheme, func(t *testing.T) {
@@ -292,7 +251,7 @@ func TestAllDialects_TypeName_Floats(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(dataTypeName(tt.dataType), func(t *testing.T) {
+		t.Run(tt.dataType.String(), func(t *testing.T) {
 			col := schema.Column{Name: "val", DataType: tt.dataType}
 			for scheme, exp := range tt.expected {
 				t.Run(scheme, func(t *testing.T) {
@@ -424,7 +383,7 @@ func TestAllDialects_TypeName_AllTypes(t *testing.T) {
 			for _, dataType := range types {
 				col := schema.Column{Name: "test", DataType: dataType, Precision: 10, Scale: 2}
 				typeName := dt.Dialect.TypeName(col)
-				assert.NotEmpty(t, typeName, "type %s should produce non-empty type name", dataTypeName(dataType))
+				assert.NotEmpty(t, typeName, "type %s should produce non-empty type name", dataType.String())
 			}
 		})
 	}

--- a/pkg/schemaevolution/widen.go
+++ b/pkg/schemaevolution/widen.go
@@ -87,14 +87,14 @@ func GetWidenedType(src, dest schema.DataType) (schema.DataType, string) {
 	if srcOrder > destOrder {
 		if CanWiden(dest, src) {
 			if src == schema.TypeString || src == schema.TypeJSON {
-				return src, "type widened to " + dataTypeName(src)
+				return src, "type widened to " + src.String()
 			}
 			return src, ""
 		}
 	} else {
 		if CanWiden(src, dest) {
 			if dest == schema.TypeString || dest == schema.TypeJSON {
-				return dest, "type widened to " + dataTypeName(dest)
+				return dest, "type widened to " + dest.String()
 			}
 			return dest, ""
 		}
@@ -140,45 +140,4 @@ func MergeDecimalPrecision(src, dest schema.Column) (precision, scale int) {
 	}
 
 	return precision, scale
-}
-
-func dataTypeName(dt schema.DataType) string {
-	switch dt {
-	case schema.TypeBoolean:
-		return "BOOLEAN"
-	case schema.TypeInt16:
-		return "INT16"
-	case schema.TypeInt32:
-		return "INT32"
-	case schema.TypeInt64:
-		return "INT64"
-	case schema.TypeFloat32:
-		return "FLOAT32"
-	case schema.TypeFloat64:
-		return "FLOAT64"
-	case schema.TypeDecimal:
-		return "DECIMAL"
-	case schema.TypeString:
-		return "STRING"
-	case schema.TypeBinary:
-		return "BINARY"
-	case schema.TypeDate:
-		return "DATE"
-	case schema.TypeTime:
-		return "TIME"
-	case schema.TypeTimestamp:
-		return "TIMESTAMP"
-	case schema.TypeTimestampTZ:
-		return "TIMESTAMPTZ"
-	case schema.TypeInterval:
-		return "INTERVAL"
-	case schema.TypeJSON:
-		return "JSON"
-	case schema.TypeUUID:
-		return "UUID"
-	case schema.TypeArray:
-		return "ARRAY"
-	default:
-		return "UNKNOWN"
-	}
 }

--- a/pkg/schemaevolution/widen_test.go
+++ b/pkg/schemaevolution/widen_test.go
@@ -100,7 +100,7 @@ func TestCanWiden_NumericToDecimal(t *testing.T) {
 	}
 
 	for _, from := range numericTypes {
-		t.Run(from.String()+"_to_DECIMAL", func(t *testing.T) {
+		t.Run(from.String()+"_to_"+schema.TypeDecimal.String(), func(t *testing.T) {
 			assert.True(t, CanWiden(from, schema.TypeDecimal))
 		})
 	}
@@ -125,7 +125,7 @@ func TestCanWiden_ToStringPath(t *testing.T) {
 	}
 
 	for _, from := range typesWithStringPath {
-		t.Run(from.String()+"_to_STRING", func(t *testing.T) {
+		t.Run(from.String()+"_to_"+schema.TypeString.String(), func(t *testing.T) {
 			assert.True(t, CanWiden(from, schema.TypeString))
 		})
 	}
@@ -152,7 +152,7 @@ func TestCanWiden_ToJSONPath(t *testing.T) {
 	}
 
 	for _, from := range allTypes {
-		t.Run(from.String()+"_to_JSON", func(t *testing.T) {
+		t.Run(from.String()+"_to_"+schema.TypeJSON.String(), func(t *testing.T) {
 			assert.True(t, CanWiden(from, schema.TypeJSON))
 		})
 	}

--- a/pkg/schemaevolution/widen_test.go
+++ b/pkg/schemaevolution/widen_test.go
@@ -28,7 +28,7 @@ func TestCanWiden_SameType(t *testing.T) {
 	}
 
 	for _, dt := range types {
-		t.Run(dataTypeName(dt), func(t *testing.T) {
+		t.Run(dt.String(), func(t *testing.T) {
 			assert.True(t, CanWiden(dt, dt), "same type should always be widenable")
 		})
 	}
@@ -49,7 +49,7 @@ func TestCanWiden_IntegerHierarchy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(dataTypeName(tt.from)+"_to_"+dataTypeName(tt.to), func(t *testing.T) {
+		t.Run(tt.from.String()+"_to_"+tt.to.String(), func(t *testing.T) {
 			assert.Equal(t, tt.expected, CanWiden(tt.from, tt.to))
 		})
 	}
@@ -68,7 +68,7 @@ func TestCanWiden_IntToFloat(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(dataTypeName(tt.from)+"_to_"+dataTypeName(tt.to), func(t *testing.T) {
+		t.Run(tt.from.String()+"_to_"+tt.to.String(), func(t *testing.T) {
 			assert.Equal(t, tt.expected, CanWiden(tt.from, tt.to))
 		})
 	}
@@ -85,7 +85,7 @@ func TestCanWiden_FloatHierarchy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(dataTypeName(tt.from)+"_to_"+dataTypeName(tt.to), func(t *testing.T) {
+		t.Run(tt.from.String()+"_to_"+tt.to.String(), func(t *testing.T) {
 			assert.Equal(t, tt.expected, CanWiden(tt.from, tt.to))
 		})
 	}
@@ -100,7 +100,7 @@ func TestCanWiden_NumericToDecimal(t *testing.T) {
 	}
 
 	for _, from := range numericTypes {
-		t.Run(dataTypeName(from)+"_to_DECIMAL", func(t *testing.T) {
+		t.Run(from.String()+"_to_DECIMAL", func(t *testing.T) {
 			assert.True(t, CanWiden(from, schema.TypeDecimal))
 		})
 	}
@@ -125,7 +125,7 @@ func TestCanWiden_ToStringPath(t *testing.T) {
 	}
 
 	for _, from := range typesWithStringPath {
-		t.Run(dataTypeName(from)+"_to_STRING", func(t *testing.T) {
+		t.Run(from.String()+"_to_STRING", func(t *testing.T) {
 			assert.True(t, CanWiden(from, schema.TypeString))
 		})
 	}
@@ -152,7 +152,7 @@ func TestCanWiden_ToJSONPath(t *testing.T) {
 	}
 
 	for _, from := range allTypes {
-		t.Run(dataTypeName(from)+"_to_JSON", func(t *testing.T) {
+		t.Run(from.String()+"_to_JSON", func(t *testing.T) {
 			assert.True(t, CanWiden(from, schema.TypeJSON))
 		})
 	}
@@ -175,7 +175,7 @@ func TestCanWiden_TemporalTypes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(dataTypeName(tt.from)+"_to_"+dataTypeName(tt.to), func(t *testing.T) {
+		t.Run(tt.from.String()+"_to_"+tt.to.String(), func(t *testing.T) {
 			assert.Equal(t, tt.expected, CanWiden(tt.from, tt.to))
 		})
 	}
@@ -193,7 +193,7 @@ func TestGetWidenedType_SameType(t *testing.T) {
 	}
 
 	for _, dt := range types {
-		t.Run(dataTypeName(dt), func(t *testing.T) {
+		t.Run(dt.String(), func(t *testing.T) {
 			result, warning := GetWidenedType(dt, dt)
 			assert.Equal(t, dt, result)
 			assert.Empty(t, warning)
@@ -357,33 +357,33 @@ func TestDataTypeName(t *testing.T) {
 		dt       schema.DataType
 		expected string
 	}{
-		{schema.TypeBoolean, "BOOLEAN"},
-		{schema.TypeInt16, "INT16"},
-		{schema.TypeInt32, "INT32"},
-		{schema.TypeInt64, "INT64"},
-		{schema.TypeFloat32, "FLOAT32"},
-		{schema.TypeFloat64, "FLOAT64"},
-		{schema.TypeDecimal, "DECIMAL"},
-		{schema.TypeString, "STRING"},
-		{schema.TypeBinary, "BINARY"},
-		{schema.TypeDate, "DATE"},
-		{schema.TypeTime, "TIME"},
-		{schema.TypeTimestamp, "TIMESTAMP"},
-		{schema.TypeTimestampTZ, "TIMESTAMPTZ"},
-		{schema.TypeInterval, "INTERVAL"},
-		{schema.TypeJSON, "JSON"},
-		{schema.TypeUUID, "UUID"},
-		{schema.TypeArray, "ARRAY"},
+		{schema.TypeBoolean, "boolean"},
+		{schema.TypeInt16, "int16"},
+		{schema.TypeInt32, "int32"},
+		{schema.TypeInt64, "int64"},
+		{schema.TypeFloat32, "float32"},
+		{schema.TypeFloat64, "float64"},
+		{schema.TypeDecimal, "decimal"},
+		{schema.TypeString, "string"},
+		{schema.TypeBinary, "binary"},
+		{schema.TypeDate, "date"},
+		{schema.TypeTime, "time"},
+		{schema.TypeTimestamp, "timestamp_ntz"},
+		{schema.TypeTimestampTZ, "timestamp"},
+		{schema.TypeInterval, "interval"},
+		{schema.TypeJSON, "json"},
+		{schema.TypeUUID, "uuid"},
+		{schema.TypeArray, "array"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
-			assert.Equal(t, tt.expected, dataTypeName(tt.dt))
+			assert.Equal(t, tt.expected, tt.dt.String())
 		})
 	}
 }
 
 func TestDataTypeName_Unknown(t *testing.T) {
 	unknown := schema.DataType(99)
-	assert.Equal(t, "UNKNOWN", dataTypeName(unknown))
+	assert.Equal(t, "unknown", unknown.String())
 }


### PR DESCRIPTION
The column override notice printed raw DataType enum integers (e.g. "12 -> 13"), which were hard to read. Add a DataType.String() method that maps each type to a readable name aligned with the --columns vocabulary, so the message now reads "timestamp_ntz -> timestamp".

Consolidate the duplicate dataTypeName switches in pkg/schemaevolution onto the new String() method while here.