### PR TITLE
feat(debug): mask known credentials in debug output via --debug-mask

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -161,6 +161,11 @@ func IngestCommand() *cli.Command {
 				Usage:   "Column masking configuration in format 'column:algorithm[:param]'. Algorithms: hash, sha256, md5, hmac, email, phone, credit_card, ssn, redact, stars, fixed, random, partial, first_letter, uuid, sequential, round, range, noise, date_shift, year_only, month_year.",
 				Sources: cli.EnvVars("MASK", "INGESTR_MASK"),
 			},
+			&cli.StringSliceFlag{
+				Name:    "debug-mask",
+				Usage:   "Exact strings to redact in debug output. Repeatable. Use to mask credentials in cloud runs without sanitizing every call site.",
+				Sources: cli.EnvVars("DEBUG_MASK", "INGESTR_DEBUG_MASK"),
+			},
 			&cli.StringFlag{
 				Name:    "pipelines-dir",
 				Usage:   "The path to store pipeline metadata",
@@ -222,6 +227,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.Columns = c.String("columns")
 	cfg.NoInference = c.Bool("no-inference")
 	cfg.Mask = c.StringSlice("mask")
+	config.SetDebugMaskValues(c.StringSlice("debug-mask"))
 	cfg.PipelinesDir = c.String("pipelines-dir")
 	cfg.StagingBucket = c.String("staging-bucket")
 	cfg.StagingDataset = c.String("staging-dataset")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,15 +2,47 @@ package config
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
 
-var DebugMode bool
+// minMaskLength drops too-short masks to avoid catastrophic collisions
+// (e.g. an unfortunate password of "test" masking the literal word everywhere).
+const minMaskLength = 8
+
+var (
+	DebugMode       bool
+	debugMaskValues []string
+)
+
+// SetDebugMaskValues installs the set of strings to redact inside Debug
+// output. Values under minMaskLength characters are dropped. Sorted
+// longest-first so substring overlaps mask the longer match first.
+// Should be called once during startup before any goroutines call Debug.
+func SetDebugMaskValues(values []string) {
+	filtered := make([]string, 0, len(values))
+	for _, v := range values {
+		if len(v) >= minMaskLength {
+			filtered = append(filtered, v)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return len(filtered[i]) > len(filtered[j])
+	})
+	debugMaskValues = filtered
+}
+
+func maskDebugMessage(msg string) string {
+	for _, secret := range debugMaskValues {
+		msg = strings.ReplaceAll(msg, secret, "***")
+	}
+	return msg
+}
 
 func Debug(format string, args ...interface{}) {
 	if DebugMode {
-		fmt.Printf("%s\tDEBUG\t%s\n", time.Now().Format("2006-01-02T15:04:05.000Z0700"), fmt.Sprintf(format, args...))
+		fmt.Printf("%s\tDEBUG\t%s\n", time.Now().Format("2006-01-02T15:04:05.000Z0700"), maskDebugMessage(fmt.Sprintf(format, args...)))
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,48 @@ import (
 	"testing"
 )
 
+func TestSetDebugMaskValues_DropsShortValues(t *testing.T) {
+	defer SetDebugMaskValues(nil)
+	SetDebugMaskValues([]string{"short", "longenoughsecret"})
+	got := maskDebugMessage("short and longenoughsecret here")
+	if !strings.Contains(got, "short") {
+		t.Errorf("expected short value to be left alone, got %q", got)
+	}
+	if strings.Contains(got, "longenoughsecret") {
+		t.Errorf("expected long secret to be masked, got %q", got)
+	}
+}
+
+func TestSetDebugMaskValues_LongestFirst(t *testing.T) {
+	defer SetDebugMaskValues(nil)
+	// "supersecret" is a prefix of "supersecretvalue"; longest-first
+	// ordering ensures the longer match wins.
+	SetDebugMaskValues([]string{"supersecret", "supersecretvalue"})
+	got := maskDebugMessage("here is supersecretvalue")
+	if got != "here is ***" {
+		t.Errorf("expected longest match to be replaced fully, got %q", got)
+	}
+}
+
+func TestMaskDebugMessage_NoMasksNoOp(t *testing.T) {
+	defer SetDebugMaskValues(nil)
+	SetDebugMaskValues(nil)
+	in := "some debug line with no secrets"
+	if got := maskDebugMessage(in); got != in {
+		t.Errorf("expected no-op, got %q", got)
+	}
+}
+
+func TestMaskDebugMessage_MultipleOccurrences(t *testing.T) {
+	defer SetDebugMaskValues(nil)
+	SetDebugMaskValues([]string{"hunter2hunter2"})
+	got := maskDebugMessage("connect with hunter2hunter2 and again hunter2hunter2")
+	want := "connect with *** and again ***"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestIngestConfigValidate_NoInferenceRequiresColumns(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.SourceURI = "mongodb://localhost:27017/db"


### PR DESCRIPTION
## Summary

Adds a repeatable `--debug-mask` flag that takes exact strings to redact from every `config.Debug` emission.

**Before** (running ingestr with `--debug` against an HTTP source whose URI contains a token):
```
2026-06-08T17:08:08.686+0300	DEBUG	[HTTP] Connected to URL: http://api.example.invalid?api_key=sk_live_SECRET_KEY_12345&token=Bearer_abcXYZdef
```

**After** (same command, plus `--debug-mask sk_live_SECRET_KEY_12345 --debug-mask Bearer_abcXYZdef`):
```
2026-06-08T17:08:08.686+0300	DEBUG	[HTTP] Connected to URL: http://api.example.invalid?api_key=***&token=***
```

## Why

The intended caller is bruin in cloud mode (orchestrator-driven runs). Bruin knows the full set of credentials in use — they live in connection configs — so it can pass them explicitly. This avoids the deny-list maintenance burden of regex-based sanitization and gives 100% coverage of known secrets without anticipating leak shapes.

**Local users running `ingestr --debug` without `--debug-mask` see unredacted output**, which is the desired behaviour: they own the credentials they pass and need debug output to be useful for debugging.

## Implementation

- `SetDebugMaskValues(values)` installs the mask set once at startup. Values under 8 characters are dropped (avoids catastrophic collisions where a short password masks a common English word everywhere). Sorted longest-first so overlapping substrings mask the longer match.
- `maskDebugMessage(msg)` runs `strings.ReplaceAll` per mask before printing.
- `Debug()` pipes its formatted message through `maskDebugMessage` before the Zap-style emit.
- Flag declaration in `cmd/ingest.go` mirrors the existing `--mask` pattern: `cli.StringSliceFlag`, env sources `DEBUG_MASK` / `INGESTR_DEBUG_MASK`.

## Test plan

- [x] Unit tests in `internal/config/config_test.go`:
  - Short values dropped, long values masked
  - Longest-first ordering for overlapping substrings
  - No-op when no masks set
  - Multiple occurrences in the same line all replaced
- [x] End-to-end manual verification against an HTTP source with credentials in the URI — both `api_key` and `token` values replaced with `***`, scheme/host/param-names preserved

## Stacked on

This PR depends on #748 (Zap-compatible debug log format). It targets that branch so the diff shown is just the masking change. When #748 merges, GitHub will retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)