### PR TITLE
feat: add support for AWS MSK OAUTHBEARER authentication

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -9909,6 +9909,194 @@ THE SOFTWARE.
 
 
 ===============================================================================
+github.com/aws/aws-msk-iam-sasl-signer-go/signer/LICENSE
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+
+===============================================================================
+github.com/aws/aws-msk-iam-sasl-signer-go/signer/NOTICE
+===============================================================================
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+===============================================================================
 github.com/aws/aws-sdk-go-v2/LICENSE.txt
 ===============================================================================
 

--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -14,13 +14,36 @@ URI parameters:
 - `bootstrap_servers`: Required, the Kafka server or servers to connect to, typically in the form of a host and port, e.g. `localhost:9092`
 - `group_id`: Required, the consumer group ID used for identifying the client when consuming messages.
 - `security_protocol`: The protocol used to communicate with brokers, e.g. `SASL_SSL` for secure communication.
-- `sasl_mechanisms`: The SASL mechanism to be used for authentication, e.g. `PLAIN`.
-- `sasl_username`: The username for SASL authentication.
-- `sasl_password`: The password for SASL authentication.
+- `sasl_mechanisms`: The SASL mechanism to be used for authentication. Supported values are `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, and `OAUTHBEARER` (for AWS MSK IAM authentication).
+- `sasl_username`: The username for SASL authentication (not used with `OAUTHBEARER`).
+- `sasl_password`: The password for SASL authentication (not used with `OAUTHBEARER`).
 - `batch_size`: The number of messages to fetch in a single batch, defaults to 3000.
 - `batch_timeout`: The maximum time to wait for messages, defaults to 3 seconds.
 
 The URI is used to connect to the Kafka brokers for ingesting messages.
+
+### AWS MSK IAM authentication
+For [Amazon MSK](https://aws.amazon.com/msk/) clusters that use IAM access control, set `sasl_mechanisms=OAUTHBEARER`. ingestr generates a short-lived IAM auth token for each connection using the AWS MSK IAM signer. MSK IAM is served over TLS (typically port `9098`), and TLS is enabled automatically for this mechanism.
+
+Additional URI parameters for MSK IAM:
+- `aws_region`: Required, the AWS region of the MSK cluster, e.g. `us-east-1`.
+- `aws_role_arn`: Optional, an IAM role ARN to assume for generating the token.
+- `aws_role_session_name`: Optional, the STS session name used when assuming `aws_role_arn`.
+- `aws_profile`: Optional, an AWS named profile to load credentials from.
+- `aws_access_key_id` / `aws_secret_access_key`: Optional static credentials. Both are required together.
+- `aws_session_token`: Optional session token to use with static credentials.
+
+When none of the credential parameters are provided, the default AWS credential chain is used (environment variables, shared config, and EC2/ECS/EKS instance roles). This is the common setup when ingestr runs inside AWS with an attached IAM role.
+
+> On EKS, the default chain also covers [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IAM Roles for Service Accounts) and EKS Pod Identity automatically — just set `aws_region` and let the service account's IAM role provide credentials.
+
+```sh
+ingestr ingest \
+    --source-uri 'kafka://?bootstrap_servers=b-1.mycluster.kafka.us-east-1.amazonaws.com:9098&group_id=test_group&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1' \
+    --source-table 'my-topic' \
+    --dest-uri duckdb:///kafka.duckdb \
+    --dest-table 'dest.my_topic'
+```
 
 ### Group ID
 The group ID is used to identify the consumer group that reads messages from a topic. Kafka uses the group ID to manage consumer offsets and assign partitions to consumers, which means that the group ID is the key to reading messages from the correct partition and position in the topic.

--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -28,7 +28,7 @@ For [Amazon MSK](https://aws.amazon.com/msk/) clusters that use IAM access contr
 Additional URI parameters for MSK IAM:
 - `aws_region`: Required, the AWS region of the MSK cluster, e.g. `us-east-1`.
 - `aws_role_arn`: Optional, an IAM role ARN to assume for generating the token.
-- `aws_role_session_name`: Optional, the STS session name used when assuming `aws_role_arn`.
+- `aws_role_session_name`: Optional, the STS session name used when assuming `aws_role_arn`. Defaults to `ingestr-msk-iam` when omitted. When provided, it must be 2-64 characters and contain only letters, numbers, and `_+=,.@-`.
 - `aws_profile`: Optional, an AWS named profile to load credentials from.
 - `aws_access_key_id` / `aws_secret_access_key`: Optional static credentials. Both are required together.
 - `aws_session_token`: Optional session token to use with static credentials.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.5.1
 	github.com/apache/cassandra-gocql-driver/v2 v2.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
+	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6

--- a/go.sum
+++ b/go.sum
@@ -734,6 +734,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4 h1:2jAwFwA0Xgcx94dUId+K24yFabsKYDtAhCgyMit6OqE=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4/go.mod h1:MVYeeOhILFFemC/XlYTClvBjYZrg/EPd3ts885KrNTI=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -370,39 +370,49 @@ func (s *KafkaSource) buildDialer() (*kafkago.Dialer, error) {
 		}
 	}
 
-	// MSK IAM serves OAUTHBEARER only over TLS and the token is a sensitive
-	// presigned URL, so enable TLS unless the user explicitly opted out.
-	if strings.EqualFold(s.cfg.SASLMechanism, "OAUTHBEARER") &&
-		dialer.TLS == nil && !strings.EqualFold(s.cfg.SecurityProtocol, "SASL_PLAINTEXT") {
-		dialer.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
-		config.Debug("[KAFKA] OAUTHBEARER: TLS auto-enabled (MSK IAM requires TLS)")
-	}
-
 	if s.cfg.SASLMechanism != "" {
 		mechanism, err := buildSASLMechanism(s.cfg)
 		if err != nil {
 			return nil, err
 		}
 		dialer.SASLMechanism = mechanism
+
+		// MSK IAM serves OAUTHBEARER only over TLS and the token is a sensitive
+		// presigned URL, so enable TLS unless the user explicitly opted out.
+		if strings.EqualFold(s.cfg.SASLMechanism, "OAUTHBEARER") &&
+			dialer.TLS == nil && !strings.EqualFold(s.cfg.SecurityProtocol, "SASL_PLAINTEXT") {
+			dialer.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
+			config.Debug("[KAFKA] OAUTHBEARER: TLS auto-enabled (MSK IAM requires TLS)")
+		}
 	}
 
 	return dialer, nil
 }
 
 func buildSASLMechanism(cfg kafkaConfig) (sasl.Mechanism, error) {
-	switch strings.ToUpper(cfg.SASLMechanism) {
+	mechanism := strings.ToUpper(cfg.SASLMechanism)
+	switch mechanism {
 	case "PLAIN":
+		if err := validateSASLCredentials(mechanism, cfg); err != nil {
+			return nil, err
+		}
 		return &plain.Mechanism{
 			Username: cfg.SASLUsername,
 			Password: cfg.SASLPassword,
 		}, nil
 	case "SCRAM-SHA-256":
+		if err := validateSASLCredentials(mechanism, cfg); err != nil {
+			return nil, err
+		}
 		m, err := scram.Mechanism(scram.SHA256, cfg.SASLUsername, cfg.SASLPassword)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create SCRAM-SHA-256 mechanism: %w", err)
 		}
 		return m, nil
 	case "SCRAM-SHA-512":
+		if err := validateSASLCredentials(mechanism, cfg); err != nil {
+			return nil, err
+		}
 		m, err := scram.Mechanism(scram.SHA512, cfg.SASLUsername, cfg.SASLPassword)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create SCRAM-SHA-512 mechanism: %w", err)
@@ -417,6 +427,13 @@ func buildSASLMechanism(cfg kafkaConfig) (sasl.Mechanism, error) {
 	default:
 		return nil, fmt.Errorf("unsupported SASL mechanism: %s (supported: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER)", cfg.SASLMechanism)
 	}
+}
+
+func validateSASLCredentials(mechanism string, cfg kafkaConfig) error {
+	if cfg.SASLUsername == "" || cfg.SASLPassword == "" {
+		return fmt.Errorf("kafka SASL %s requires sasl_username and sasl_password", mechanism)
+	}
+	return nil
 }
 
 func (s *KafkaSource) getPartitions(ctx context.Context, dialer *kafkago.Dialer, brokers []string, topic string) ([]int, error) {

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -42,6 +42,15 @@ type kafkaConfig struct {
 	SASLPassword     string
 	BatchSize        int
 	BatchTimeout     time.Duration
+
+	// AWS MSK IAM (SASL OAUTHBEARER) settings.
+	AWSRegion          string
+	AWSRoleArn         string
+	AWSRoleSessionName string
+	AWSProfile         string
+	AWSAccessKeyID     string
+	AWSSecretAccessKey string
+	AWSSessionToken    string
 }
 
 type KafkaSource struct {
@@ -361,8 +370,16 @@ func (s *KafkaSource) buildDialer() (*kafkago.Dialer, error) {
 		}
 	}
 
-	if s.cfg.SASLMechanism != "" && s.cfg.SASLUsername != "" {
-		mechanism, err := buildSASLMechanism(s.cfg.SASLMechanism, s.cfg.SASLUsername, s.cfg.SASLPassword)
+	// MSK IAM serves OAUTHBEARER only over TLS and the token is a sensitive
+	// presigned URL, so enable TLS unless the user explicitly opted out.
+	if strings.EqualFold(s.cfg.SASLMechanism, "OAUTHBEARER") &&
+		dialer.TLS == nil && !strings.EqualFold(s.cfg.SecurityProtocol, "SASL_PLAINTEXT") {
+		dialer.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
+		config.Debug("[KAFKA] OAUTHBEARER: TLS auto-enabled (MSK IAM requires TLS)")
+	}
+
+	if s.cfg.SASLMechanism != "" {
+		mechanism, err := buildSASLMechanism(s.cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -372,27 +389,33 @@ func (s *KafkaSource) buildDialer() (*kafkago.Dialer, error) {
 	return dialer, nil
 }
 
-func buildSASLMechanism(mechanism, username, password string) (sasl.Mechanism, error) {
-	switch strings.ToUpper(mechanism) {
+func buildSASLMechanism(cfg kafkaConfig) (sasl.Mechanism, error) {
+	switch strings.ToUpper(cfg.SASLMechanism) {
 	case "PLAIN":
 		return &plain.Mechanism{
-			Username: username,
-			Password: password,
+			Username: cfg.SASLUsername,
+			Password: cfg.SASLPassword,
 		}, nil
 	case "SCRAM-SHA-256":
-		m, err := scram.Mechanism(scram.SHA256, username, password)
+		m, err := scram.Mechanism(scram.SHA256, cfg.SASLUsername, cfg.SASLPassword)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create SCRAM-SHA-256 mechanism: %w", err)
 		}
 		return m, nil
 	case "SCRAM-SHA-512":
-		m, err := scram.Mechanism(scram.SHA512, username, password)
+		m, err := scram.Mechanism(scram.SHA512, cfg.SASLUsername, cfg.SASLPassword)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create SCRAM-SHA-512 mechanism: %w", err)
 		}
 		return m, nil
+	case "OAUTHBEARER":
+		provider, err := newOAuthBearerTokenProvider(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return oauthBearerMechanism{provider: provider}, nil
 	default:
-		return nil, fmt.Errorf("unsupported SASL mechanism: %s (supported: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)", mechanism)
+		return nil, fmt.Errorf("unsupported SASL mechanism: %s (supported: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER)", cfg.SASLMechanism)
 	}
 }
 
@@ -491,14 +514,21 @@ func parseKafkaURI(uri string) (kafkaConfig, error) {
 	}
 
 	return kafkaConfig{
-		BootstrapServers: bootstrapServers,
-		GroupID:          groupID,
-		SecurityProtocol: values.Get("security_protocol"),
-		SASLMechanism:    values.Get("sasl_mechanisms"),
-		SASLUsername:     values.Get("sasl_username"),
-		SASLPassword:     values.Get("sasl_password"),
-		BatchSize:        batchSize,
-		BatchTimeout:     batchTimeout,
+		BootstrapServers:   bootstrapServers,
+		GroupID:            groupID,
+		SecurityProtocol:   values.Get("security_protocol"),
+		SASLMechanism:      values.Get("sasl_mechanisms"),
+		SASLUsername:       values.Get("sasl_username"),
+		SASLPassword:       values.Get("sasl_password"),
+		BatchSize:          batchSize,
+		BatchTimeout:       batchTimeout,
+		AWSRegion:          values.Get("aws_region"),
+		AWSRoleArn:         values.Get("aws_role_arn"),
+		AWSRoleSessionName: values.Get("aws_role_session_name"),
+		AWSProfile:         values.Get("aws_profile"),
+		AWSAccessKeyID:     values.Get("aws_access_key_id"),
+		AWSSecretAccessKey: values.Get("aws_secret_access_key"),
+		AWSSessionToken:    values.Get("aws_session_token"),
 	}, nil
 }
 

--- a/pkg/source/kafka/kafka_test.go
+++ b/pkg/source/kafka/kafka_test.go
@@ -1,11 +1,13 @@
 package kafka
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"syscall"
 	"testing"
@@ -407,8 +409,19 @@ func TestBuildDialer_OAuthBearer_MissingRegion(t *testing.T) {
 		},
 	}
 
-	if _, err := s.buildDialer(); err == nil {
-		t.Fatal("expected error for OAUTHBEARER without aws_region")
+	oldDebugMode := config.DebugMode
+	config.DebugMode = true
+	t.Cleanup(func() {
+		config.DebugMode = oldDebugMode
+	})
+
+	output := captureStdout(t, func() {
+		if _, err := s.buildDialer(); err == nil {
+			t.Fatal("expected error for OAUTHBEARER without aws_region")
+		}
+	})
+	if strings.Contains(output, "TLS auto-enabled") {
+		t.Fatalf("debug output = %q, should not log TLS auto-enable for invalid OAUTHBEARER config", output)
 	}
 }
 
@@ -445,6 +458,12 @@ func TestBuildSASLMechanism(t *testing.T) {
 		{name: "SCRAM-SHA-256", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-256", SASLUsername: "user", SASLPassword: "pass"}},
 		{name: "SCRAM-SHA-512", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-512", SASLUsername: "user", SASLPassword: "pass"}},
 		{name: "lowercase plain", cfg: kafkaConfig{SASLMechanism: "plain", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "PLAIN missing username", cfg: kafkaConfig{SASLMechanism: "PLAIN", SASLPassword: "pass"}, wantErr: true},
+		{name: "PLAIN missing password", cfg: kafkaConfig{SASLMechanism: "PLAIN", SASLUsername: "user"}, wantErr: true},
+		{name: "SCRAM-SHA-256 missing username", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-256", SASLPassword: "pass"}, wantErr: true},
+		{name: "SCRAM-SHA-256 missing password", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-256", SASLUsername: "user"}, wantErr: true},
+		{name: "SCRAM-SHA-512 missing username", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-512", SASLPassword: "pass"}, wantErr: true},
+		{name: "SCRAM-SHA-512 missing password", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-512", SASLUsername: "user"}, wantErr: true},
 		{name: "OAUTHBEARER", cfg: kafkaConfig{SASLMechanism: "OAUTHBEARER", AWSRegion: "us-east-1"}},
 		{name: "OAUTHBEARER missing region", cfg: kafkaConfig{SASLMechanism: "OAUTHBEARER"}, wantErr: true},
 		{name: "unsupported", cfg: kafkaConfig{SASLMechanism: "GSSAPI"}, wantErr: true},
@@ -467,6 +486,35 @@ func TestBuildSASLMechanism(t *testing.T) {
 			}
 		})
 	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return buf.String()
 }
 
 func TestGetTable(t *testing.T) {

--- a/pkg/source/kafka/kafka_test.go
+++ b/pkg/source/kafka/kafka_test.go
@@ -79,6 +79,36 @@ func TestParseKafkaURI(t *testing.T) {
 			},
 		},
 		{
+			name: "OAUTHBEARER MSK IAM URI",
+			uri:  "kafka://?bootstrap_servers=b1:9098&group_id=g1&sasl_mechanisms=OAUTHBEARER&aws_region=us-east-1&aws_role_arn=arn:aws:iam::123456789012:role/msk&aws_role_session_name=ingestr&aws_profile=default&aws_access_key_id=AKID&aws_secret_access_key=SECRET&aws_session_token=TOKEN",
+			check: func(t *testing.T, cfg kafkaConfig) {
+				if cfg.SASLMechanism != "OAUTHBEARER" {
+					t.Errorf("SASLMechanism = %q, want %q", cfg.SASLMechanism, "OAUTHBEARER")
+				}
+				if cfg.AWSRegion != "us-east-1" {
+					t.Errorf("AWSRegion = %q, want %q", cfg.AWSRegion, "us-east-1")
+				}
+				if cfg.AWSRoleArn != "arn:aws:iam::123456789012:role/msk" {
+					t.Errorf("AWSRoleArn = %q, want %q", cfg.AWSRoleArn, "arn:aws:iam::123456789012:role/msk")
+				}
+				if cfg.AWSRoleSessionName != "ingestr" {
+					t.Errorf("AWSRoleSessionName = %q, want %q", cfg.AWSRoleSessionName, "ingestr")
+				}
+				if cfg.AWSProfile != "default" {
+					t.Errorf("AWSProfile = %q, want %q", cfg.AWSProfile, "default")
+				}
+				if cfg.AWSAccessKeyID != "AKID" {
+					t.Errorf("AWSAccessKeyID = %q, want %q", cfg.AWSAccessKeyID, "AKID")
+				}
+				if cfg.AWSSecretAccessKey != "SECRET" {
+					t.Errorf("AWSSecretAccessKey = %q, want %q", cfg.AWSSecretAccessKey, "SECRET")
+				}
+				if cfg.AWSSessionToken != "TOKEN" {
+					t.Errorf("AWSSessionToken = %q, want %q", cfg.AWSSessionToken, "TOKEN")
+				}
+			},
+		},
+		{
 			name:    "wrong scheme",
 			uri:     "postgres://localhost:9092",
 			wantErr: true,
@@ -343,22 +373,86 @@ func TestBuildDialer_SASL_SSL(t *testing.T) {
 	}
 }
 
+func TestBuildDialer_OAuthBearer(t *testing.T) {
+	s := &KafkaSource{
+		cfg: kafkaConfig{
+			BootstrapServers: "b1:9098",
+			GroupID:          "test",
+			SASLMechanism:    "OAUTHBEARER",
+			AWSRegion:        "us-east-1",
+		},
+	}
+
+	dialer, err := s.buildDialer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dialer.SASLMechanism == nil {
+		t.Fatal("SASL mechanism should be set for OAUTHBEARER")
+	}
+	if dialer.SASLMechanism.Name() != "OAUTHBEARER" {
+		t.Errorf("mechanism name = %q, want OAUTHBEARER", dialer.SASLMechanism.Name())
+	}
+	if dialer.TLS == nil {
+		t.Error("TLS should be auto-enabled for OAUTHBEARER")
+	}
+}
+
+func TestBuildDialer_OAuthBearer_MissingRegion(t *testing.T) {
+	s := &KafkaSource{
+		cfg: kafkaConfig{
+			BootstrapServers: "b1:9098",
+			GroupID:          "test",
+			SASLMechanism:    "OAUTHBEARER",
+		},
+	}
+
+	if _, err := s.buildDialer(); err == nil {
+		t.Fatal("expected error for OAUTHBEARER without aws_region")
+	}
+}
+
+func TestBuildDialer_OAuthBearer_PlaintextEscapeHatch(t *testing.T) {
+	s := &KafkaSource{
+		cfg: kafkaConfig{
+			BootstrapServers: "b1:9092",
+			GroupID:          "test",
+			SASLMechanism:    "OAUTHBEARER",
+			SecurityProtocol: "SASL_PLAINTEXT",
+			AWSRegion:        "us-east-1",
+		},
+	}
+
+	dialer, err := s.buildDialer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dialer.SASLMechanism == nil {
+		t.Fatal("SASL mechanism should be set for OAUTHBEARER")
+	}
+	if dialer.TLS != nil {
+		t.Error("TLS should not be auto-enabled when SASL_PLAINTEXT is explicitly set")
+	}
+}
+
 func TestBuildSASLMechanism(t *testing.T) {
 	tests := []struct {
-		name      string
-		mechanism string
-		wantErr   bool
+		name    string
+		cfg     kafkaConfig
+		wantErr bool
 	}{
-		{name: "PLAIN", mechanism: "PLAIN"},
-		{name: "SCRAM-SHA-256", mechanism: "SCRAM-SHA-256"},
-		{name: "SCRAM-SHA-512", mechanism: "SCRAM-SHA-512"},
-		{name: "lowercase plain", mechanism: "plain"},
-		{name: "unsupported", mechanism: "OAUTHBEARER", wantErr: true},
+		{name: "PLAIN", cfg: kafkaConfig{SASLMechanism: "PLAIN", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "SCRAM-SHA-256", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-256", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "SCRAM-SHA-512", cfg: kafkaConfig{SASLMechanism: "SCRAM-SHA-512", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "lowercase plain", cfg: kafkaConfig{SASLMechanism: "plain", SASLUsername: "user", SASLPassword: "pass"}},
+		{name: "OAUTHBEARER", cfg: kafkaConfig{SASLMechanism: "OAUTHBEARER", AWSRegion: "us-east-1"}},
+		{name: "OAUTHBEARER missing region", cfg: kafkaConfig{SASLMechanism: "OAUTHBEARER"}, wantErr: true},
+		{name: "unsupported", cfg: kafkaConfig{SASLMechanism: "GSSAPI"}, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := buildSASLMechanism(tt.mechanism, "user", "pass")
+			m, err := buildSASLMechanism(tt.cfg)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/pkg/source/kafka/oauthbearer.go
+++ b/pkg/source/kafka/oauthbearer.go
@@ -36,7 +36,11 @@ func (m oauthBearerMechanism) Start(ctx context.Context) (sasl.StateMachine, []b
 
 type oauthBearerSession struct{}
 
-func (oauthBearerSession) Next(_ context.Context, _ []byte) (bool, []byte, error) {
+func (oauthBearerSession) Next(_ context.Context, challenge []byte) (bool, []byte, error) {
+	if len(challenge) > 0 {
+		return false, nil, fmt.Errorf("unexpected OAUTHBEARER broker challenge: %s", string(challenge))
+	}
+
 	// The broker rejects an invalid token by failing the SASL exchange before
 	// Next is reached, so arriving here means authentication succeeded. This
 	// mirrors kafka-go's built-in plain.Mechanism.
@@ -66,7 +70,7 @@ func newOAuthBearerTokenProvider(cfg kafkaConfig) (tokenProvider, error) {
 			return token, err
 		}, nil
 
-	case cfg.AWSAccessKeyID != "" || cfg.AWSSecretAccessKey != "":
+	case cfg.AWSAccessKeyID != "" || cfg.AWSSecretAccessKey != "" || cfg.AWSSessionToken != "":
 		if cfg.AWSAccessKeyID == "" || cfg.AWSSecretAccessKey == "" {
 			return nil, fmt.Errorf("kafka OAUTHBEARER: both aws_access_key_id and aws_secret_access_key are required for static credentials")
 		}

--- a/pkg/source/kafka/oauthbearer.go
+++ b/pkg/source/kafka/oauthbearer.go
@@ -1,0 +1,85 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/segmentio/kafka-go/sasl"
+)
+
+// tokenProvider returns a fresh OAUTHBEARER token. It is invoked on every SASL
+// handshake, allowing short-lived tokens (e.g. AWS MSK IAM presigned URLs) to be
+// regenerated per connection.
+type tokenProvider func(ctx context.Context) (string, error)
+
+// oauthBearerMechanism implements sasl.Mechanism for the OAUTHBEARER mechanism
+// (RFC 7628). It is stateless and safe for concurrent use: Start generates a new
+// token for each connection via its provider.
+type oauthBearerMechanism struct {
+	provider tokenProvider
+}
+
+func (oauthBearerMechanism) Name() string {
+	return "OAUTHBEARER"
+}
+
+func (m oauthBearerMechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error) {
+	token, err := m.provider(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate OAUTHBEARER token: %w", err)
+	}
+	ir := []byte(fmt.Sprintf("n,,\x01auth=Bearer %s\x01\x01", token))
+	return oauthBearerSession{}, ir, nil
+}
+
+type oauthBearerSession struct{}
+
+func (oauthBearerSession) Next(_ context.Context, _ []byte) (bool, []byte, error) {
+	// The broker rejects an invalid token by failing the SASL exchange before
+	// Next is reached, so arriving here means authentication succeeded. This
+	// mirrors kafka-go's built-in plain.Mechanism.
+	return true, nil, nil
+}
+
+// newOAuthBearerTokenProvider selects an AWS MSK IAM token generator based on the
+// supplied configuration. Region is always required. Credential resolution order:
+// explicit role ARN, named profile, static credentials, then the default AWS
+// credential chain (environment variables, EC2/ECS/EKS instance role, etc.).
+func newOAuthBearerTokenProvider(cfg kafkaConfig) (tokenProvider, error) {
+	region := cfg.AWSRegion
+	if region == "" {
+		return nil, fmt.Errorf("kafka OAUTHBEARER (MSK IAM) requires aws_region")
+	}
+
+	switch {
+	case cfg.AWSRoleArn != "":
+		return func(ctx context.Context) (string, error) {
+			token, _, err := signer.GenerateAuthTokenFromRole(ctx, region, cfg.AWSRoleArn, cfg.AWSRoleSessionName)
+			return token, err
+		}, nil
+
+	case cfg.AWSProfile != "":
+		return func(ctx context.Context) (string, error) {
+			token, _, err := signer.GenerateAuthTokenFromProfile(ctx, region, cfg.AWSProfile)
+			return token, err
+		}, nil
+
+	case cfg.AWSAccessKeyID != "" || cfg.AWSSecretAccessKey != "":
+		if cfg.AWSAccessKeyID == "" || cfg.AWSSecretAccessKey == "" {
+			return nil, fmt.Errorf("kafka OAUTHBEARER: both aws_access_key_id and aws_secret_access_key are required for static credentials")
+		}
+		provider := credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSSessionToken)
+		return func(ctx context.Context) (string, error) {
+			token, _, err := signer.GenerateAuthTokenFromCredentialsProvider(ctx, region, provider)
+			return token, err
+		}, nil
+
+	default:
+		return func(ctx context.Context) (string, error) {
+			token, _, err := signer.GenerateAuthToken(ctx, region)
+			return token, err
+		}, nil
+	}
+}

--- a/pkg/source/kafka/oauthbearer.go
+++ b/pkg/source/kafka/oauthbearer.go
@@ -3,11 +3,16 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/segmentio/kafka-go/sasl"
 )
+
+const defaultOAuthBearerRoleSessionName = "ingestr-msk-iam"
+
+var validOAuthBearerRoleSessionName = regexp.MustCompile(`^[A-Za-z0-9_+=,.@-]{2,64}$`)
 
 // tokenProvider returns a fresh OAUTHBEARER token. It is invoked on every SASL
 // handshake, allowing short-lived tokens (e.g. AWS MSK IAM presigned URLs) to be
@@ -59,8 +64,12 @@ func newOAuthBearerTokenProvider(cfg kafkaConfig) (tokenProvider, error) {
 
 	switch {
 	case cfg.AWSRoleArn != "":
+		sessionName, err := resolveOAuthBearerRoleSessionName(cfg.AWSRoleSessionName)
+		if err != nil {
+			return nil, err
+		}
 		return func(ctx context.Context) (string, error) {
-			token, _, err := signer.GenerateAuthTokenFromRole(ctx, region, cfg.AWSRoleArn, cfg.AWSRoleSessionName)
+			token, _, err := signer.GenerateAuthTokenFromRole(ctx, region, cfg.AWSRoleArn, sessionName)
 			return token, err
 		}, nil
 
@@ -86,4 +95,14 @@ func newOAuthBearerTokenProvider(cfg kafkaConfig) (tokenProvider, error) {
 			return token, err
 		}, nil
 	}
+}
+
+func resolveOAuthBearerRoleSessionName(sessionName string) (string, error) {
+	if sessionName == "" {
+		return defaultOAuthBearerRoleSessionName, nil
+	}
+	if !validOAuthBearerRoleSessionName.MatchString(sessionName) {
+		return "", fmt.Errorf("kafka OAUTHBEARER: aws_role_session_name must be 2-64 characters and contain only letters, numbers, and _+=,.@-")
+	}
+	return sessionName, nil
 }

--- a/pkg/source/kafka/oauthbearer_test.go
+++ b/pkg/source/kafka/oauthbearer_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -87,8 +88,12 @@ func TestNewOAuthBearerTokenProvider_Selection(t *testing.T) {
 		cfg  kafkaConfig
 	}{
 		{
-			name: "role arn",
+			name: "role arn uses default session name",
 			cfg:  kafkaConfig{AWSRegion: "us-east-1", AWSRoleArn: "arn:aws:iam::123:role/msk"},
+		},
+		{
+			name: "role arn with explicit session name",
+			cfg:  kafkaConfig{AWSRegion: "us-east-1", AWSRoleArn: "arn:aws:iam::123:role/msk", AWSRoleSessionName: "ingestr"},
 		},
 		{
 			name: "profile",
@@ -116,6 +121,19 @@ func TestNewOAuthBearerTokenProvider_Selection(t *testing.T) {
 				t.Fatal("provider should not be nil")
 			}
 		})
+	}
+}
+
+func TestNewOAuthBearerTokenProvider_InvalidRoleSessionName(t *testing.T) {
+	cases := []kafkaConfig{
+		{AWSRegion: "us-east-1", AWSRoleArn: "arn:aws:iam::123:role/msk", AWSRoleSessionName: "a"},
+		{AWSRegion: "us-east-1", AWSRoleArn: "arn:aws:iam::123:role/msk", AWSRoleSessionName: strings.Repeat("a", 65)},
+		{AWSRegion: "us-east-1", AWSRoleArn: "arn:aws:iam::123:role/msk", AWSRoleSessionName: "bad session"},
+	}
+	for _, cfg := range cases {
+		if _, err := newOAuthBearerTokenProvider(cfg); err == nil || !strings.Contains(err.Error(), "aws_role_session_name") {
+			t.Errorf("expected aws_role_session_name error for config %+v, got %v", cfg, err)
+		}
 	}
 }
 

--- a/pkg/source/kafka/oauthbearer_test.go
+++ b/pkg/source/kafka/oauthbearer_test.go
@@ -1,0 +1,119 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestOAuthBearerMechanism_Name(t *testing.T) {
+	m := oauthBearerMechanism{}
+	if m.Name() != "OAUTHBEARER" {
+		t.Errorf("Name() = %q, want OAUTHBEARER", m.Name())
+	}
+}
+
+func TestOAuthBearerMechanism_StartWireFormat(t *testing.T) {
+	m := oauthBearerMechanism{
+		provider: func(_ context.Context) (string, error) { return "FAKE_TOKEN", nil },
+	}
+
+	sess, ir, err := m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("session should not be nil")
+	}
+	want := "n,,\x01auth=Bearer FAKE_TOKEN\x01\x01"
+	if string(ir) != want {
+		t.Errorf("initial response = %q, want %q", string(ir), want)
+	}
+}
+
+func TestOAuthBearerMechanism_StartProviderError(t *testing.T) {
+	sentinel := errors.New("boom")
+	m := oauthBearerMechanism{
+		provider: func(_ context.Context) (string, error) { return "", sentinel },
+	}
+
+	sess, ir, err := m.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error = %v, want it to wrap %v", err, sentinel)
+	}
+	if sess != nil || ir != nil {
+		t.Error("session and initial response should be nil on error")
+	}
+}
+
+func TestOAuthBearerSession_Next(t *testing.T) {
+	done, resp, err := oauthBearerSession{}.Next(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Error("Next should report done")
+	}
+	if resp != nil {
+		t.Errorf("response = %q, want nil", string(resp))
+	}
+}
+
+func TestNewOAuthBearerTokenProvider_RequiresRegion(t *testing.T) {
+	if _, err := newOAuthBearerTokenProvider(kafkaConfig{}); err == nil {
+		t.Fatal("expected error when aws_region is empty")
+	}
+}
+
+func TestNewOAuthBearerTokenProvider_Selection(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  kafkaConfig
+	}{
+		{
+			name: "role arn",
+			cfg:  kafkaConfig{AWSRegion: "us-east-1", AWSRoleArn: "arn:aws:iam::123:role/msk"},
+		},
+		{
+			name: "profile",
+			cfg:  kafkaConfig{AWSRegion: "us-east-1", AWSProfile: "default"},
+		},
+		{
+			name: "static credentials",
+			cfg:  kafkaConfig{AWSRegion: "us-east-1", AWSAccessKeyID: "AKID", AWSSecretAccessKey: "SECRET"},
+		},
+		{
+			name: "default credential chain",
+			cfg:  kafkaConfig{AWSRegion: "us-east-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Only assert selection succeeds; do not invoke the provider so no
+			// AWS calls are made.
+			provider, err := newOAuthBearerTokenProvider(tt.cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if provider == nil {
+				t.Fatal("provider should not be nil")
+			}
+		})
+	}
+}
+
+func TestNewOAuthBearerTokenProvider_PartialStaticCredentials(t *testing.T) {
+	cases := []kafkaConfig{
+		{AWSRegion: "us-east-1", AWSAccessKeyID: "AKID"},
+		{AWSRegion: "us-east-1", AWSSecretAccessKey: "SECRET"},
+	}
+	for _, cfg := range cases {
+		if _, err := newOAuthBearerTokenProvider(cfg); err == nil {
+			t.Errorf("expected error for partial static credentials: %+v", cfg)
+		}
+	}
+}

--- a/pkg/source/kafka/oauthbearer_test.go
+++ b/pkg/source/kafka/oauthbearer_test.go
@@ -62,6 +62,19 @@ func TestOAuthBearerSession_Next(t *testing.T) {
 	}
 }
 
+func TestOAuthBearerSession_NextNonEmptyChallenge(t *testing.T) {
+	done, resp, err := oauthBearerSession{}.Next(context.Background(), []byte(`{"status":"invalid_token"}`))
+	if err == nil {
+		t.Fatal("expected error for non-empty broker challenge")
+	}
+	if done {
+		t.Error("Next should not report done on broker challenge")
+	}
+	if resp != nil {
+		t.Errorf("response = %q, want nil", string(resp))
+	}
+}
+
 func TestNewOAuthBearerTokenProvider_RequiresRegion(t *testing.T) {
 	if _, err := newOAuthBearerTokenProvider(kafkaConfig{}); err == nil {
 		t.Fatal("expected error when aws_region is empty")
@@ -110,6 +123,7 @@ func TestNewOAuthBearerTokenProvider_PartialStaticCredentials(t *testing.T) {
 	cases := []kafkaConfig{
 		{AWSRegion: "us-east-1", AWSAccessKeyID: "AKID"},
 		{AWSRegion: "us-east-1", AWSSecretAccessKey: "SECRET"},
+		{AWSRegion: "us-east-1", AWSSessionToken: "TOKEN"},
 	}
 	for _, cfg := range cases {
 		if _, err := newOAuthBearerTokenProvider(cfg); err == nil {


### PR DESCRIPTION
## Summary
- Add Kafka SASL OAUTHBEARER support for AWS MSK IAM authentication, including URI parameters for region, role/profile, static credentials, and session tokens.
- Generate fresh AWS MSK IAM auth tokens per SASL handshake and auto-enable TLS for valid OAUTHBEARER/MSK IAM connections unless SASL_PLAINTEXT is explicitly selected.
- Document MSK IAM Kafka source configuration and example usage.

## Review Follow-up
- Validate username/password for PLAIN and SCRAM SASL mechanisms while keeping credential-less OAUTHBEARER supported.
- Reject unexpected non-empty OAUTHBEARER broker challenges instead of silently reporting success.
- Treat aws_session_token as part of static AWS credential validation so partial static credential configs fail early.
- Avoid logging TLS auto-enable for invalid OAUTHBEARER configs such as missing aws_region.

## Validation
- go test ./pkg/source/kafka
- go test -short ./...
- make test