### PR TITLE
Fix MSSQL UUID formatting for Snowflake loads

### DIFF
--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
-	_ "github.com/microsoft/go-mssqldb"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread"
 )
 
@@ -25,8 +26,9 @@ const (
 )
 
 type MSSQLSource struct {
-	db  *sql.DB
-	uri string
+	db             *sql.DB
+	uri            string
+	guidConversion bool
 }
 
 func NewMSSQLSource() *MSSQLSource {
@@ -60,6 +62,7 @@ func (s *MSSQLSource) Connect(ctx context.Context, uri string) error {
 
 	s.db = db
 	s.uri = uri
+	s.guidConversion = guidConversionEnabled(connStr)
 	return nil
 }
 
@@ -210,6 +213,21 @@ func fedAuthFromAuthentication(authentication string) string {
 func isServicePrincipalFedAuth(fedAuth string) bool {
 	return strings.EqualFold(fedAuth, "ActiveDirectoryServicePrincipal") ||
 		strings.EqualFold(fedAuth, "ActiveDirectoryApplication")
+}
+
+func guidConversionEnabled(connStr string) bool {
+	u, err := url.Parse(connStr)
+	if err != nil {
+		return false
+	}
+
+	raw, ok := normalizeQueryParamCI(u.Query(), "guid conversion")
+	if !ok || raw == "" {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(raw)
+	return err == nil && enabled
 }
 
 func (s *MSSQLSource) Close(ctx context.Context) error {
@@ -403,7 +421,7 @@ func (s *MSSQLSource) read(ctx context.Context, table string, tableSchema *schem
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -467,7 +485,7 @@ func (s *MSSQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -561,7 +579,7 @@ func quoteTable(table string) string {
 	return fmt.Sprintf("[%s]", table)
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, guidConversion bool) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -586,6 +604,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 
 		for i, dest := range scanDest {
 			val := *dest.(*interface{})
+			if columns[i].DataType == schema.TypeUUID {
+				var err error
+				val, err = normalizeUUIDValue(val, guidConversion)
+				if err != nil {
+					for _, b := range builders {
+						b.Release()
+					}
+					return nil, 0, fmt.Errorf("failed to convert uniqueidentifier column %q: %w", columns[i].Name, err)
+				}
+			}
 			arrowconv.AppendValue(builders[i], val)
 		}
 		rowCount++
@@ -621,4 +649,48 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	return record, rowCount, nil
+}
+
+func normalizeUUIDValue(val interface{}, guidConversion bool) (interface{}, error) {
+	switch v := val.(type) {
+	case nil:
+		return nil, nil
+	case []byte:
+		return formatUUIDBytes(v, guidConversion)
+	case mssqldb.UniqueIdentifier:
+		return v.String(), nil
+	case *mssqldb.UniqueIdentifier:
+		if v == nil {
+			return nil, nil
+		}
+		return v.String(), nil
+	case mssqldb.NullUniqueIdentifier:
+		if !v.Valid {
+			return nil, nil
+		}
+		return v.UUID.String(), nil
+	case *mssqldb.NullUniqueIdentifier:
+		if v == nil || !v.Valid {
+			return nil, nil
+		}
+		return v.UUID.String(), nil
+	default:
+		return val, nil
+	}
+}
+
+func formatUUIDBytes(raw []byte, guidConversion bool) (string, error) {
+	if len(raw) != 16 {
+		return "", fmt.Errorf("invalid uniqueidentifier length %d", len(raw))
+	}
+
+	if guidConversion {
+		return fmt.Sprintf("%X-%X-%X-%X-%X", raw[0:4], raw[4:6], raw[6:8], raw[8:10], raw[10:]), nil
+	}
+
+	var uuid mssqldb.UniqueIdentifier
+	if err := uuid.Scan(raw); err != nil {
+		return "", err
+	}
+	return uuid.String(), nil
 }

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -3,6 +3,8 @@ package mssql
 import (
 	"net/url"
 	"testing"
+
+	mssqldb "github.com/microsoft/go-mssqldb"
 )
 
 func TestURIToConnString(t *testing.T) {
@@ -139,5 +141,111 @@ func TestURIToConnString(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGuidConversionEnabled(t *testing.T) {
+	connStr, _, err := uriToConnString("mssql://sa:pass@localhost/db?guid+conversion=true")
+	if err != nil {
+		t.Fatalf("uriToConnString error: %v", err)
+	}
+	if !guidConversionEnabled(connStr) {
+		t.Fatal("expected guid conversion to be enabled")
+	}
+
+	connStr, _, err = uriToConnString("mssql://sa:pass@localhost/db?guid+conversion=false")
+	if err != nil {
+		t.Fatalf("uriToConnString error: %v", err)
+	}
+	if guidConversionEnabled(connStr) {
+		t.Fatal("expected guid conversion to be disabled")
+	}
+
+	connStr, _, err = uriToConnString("mssql://sa:pass@localhost/db?GUID+CONVERSION=1")
+	if err != nil {
+		t.Fatalf("uriToConnString error: %v", err)
+	}
+	if !guidConversionEnabled(connStr) {
+		t.Fatal("expected case-insensitive guid conversion to be enabled")
+	}
+}
+
+func TestNormalizeUUIDValueFormatsRawSQLServerBytes(t *testing.T) {
+	raw := []byte{
+		0x6F, 0x96, 0x19, 0xFF,
+		0x8B, 0x86,
+		0xD0, 0x11,
+		0xB4, 0x2D,
+		0x00, 0xC0, 0x4F, 0xC9, 0x64, 0xFF,
+	}
+
+	got, err := normalizeUUIDValue(raw, false)
+	if err != nil {
+		t.Fatalf("normalizeUUIDValue error: %v", err)
+	}
+	if got != "FF19966F-868B-11D0-B42D-00C04FC964FF" {
+		t.Fatalf("got %q, want canonical UUID", got)
+	}
+}
+
+func TestNormalizeUUIDValueFormatsGuidConvertedBytes(t *testing.T) {
+	raw := []byte{
+		0xFF, 0x19, 0x96, 0x6F,
+		0x86, 0x8B,
+		0x11, 0xD0,
+		0xB4, 0x2D,
+		0x00, 0xC0, 0x4F, 0xC9, 0x64, 0xFF,
+	}
+
+	got, err := normalizeUUIDValue(raw, true)
+	if err != nil {
+		t.Fatalf("normalizeUUIDValue error: %v", err)
+	}
+	if got != "FF19966F-868B-11D0-B42D-00C04FC964FF" {
+		t.Fatalf("got %q, want canonical UUID", got)
+	}
+}
+
+func TestNormalizeUUIDValueHandlesDriverUUIDTypes(t *testing.T) {
+	uuid := mssqldb.UniqueIdentifier{
+		0xFF, 0x19, 0x96, 0x6F,
+		0x86, 0x8B,
+		0x11, 0xD0,
+		0xB4, 0x2D,
+		0x00, 0xC0, 0x4F, 0xC9, 0x64, 0xFF,
+	}
+
+	got, err := normalizeUUIDValue(mssqldb.NullUniqueIdentifier{UUID: uuid, Valid: true}, false)
+	if err != nil {
+		t.Fatalf("normalizeUUIDValue error: %v", err)
+	}
+	if got != "FF19966F-868B-11D0-B42D-00C04FC964FF" {
+		t.Fatalf("got %q, want canonical UUID", got)
+	}
+
+	got, err = normalizeUUIDValue(mssqldb.NullUniqueIdentifier{}, false)
+	if err != nil {
+		t.Fatalf("normalizeUUIDValue error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+func TestNormalizeUUIDValuePassesStringsThrough(t *testing.T) {
+	const want = "ff19966f-868b-11d0-b42d-00c04fc964ff"
+
+	got, err := normalizeUUIDValue(want, false)
+	if err != nil {
+		t.Fatalf("normalizeUUIDValue error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeUUIDValueRejectsInvalidByteLength(t *testing.T) {
+	if _, err := normalizeUUIDValue([]byte{0x01, 0x02}, false); err == nil {
+		t.Fatal("expected invalid uniqueidentifier length error")
 	}
 }


### PR DESCRIPTION
Fixes SQL Server uniqueidentifier reads so raw 16-byte GUID values are converted to canonical UUID strings before Arrow appending. This prevents Snowflake COPY from receiving invalid UTF-8 in VARCHAR(36) UUID columns. Added coverage for default go-mssqldb bytes, guid conversion mode, nulls, and invalid byte lengths. Validated with go test ./pkg/source/mssql, go test -race ./pkg/source/mssql, and go test -short ./....