### PR TITLE
fix(mssql,mysql): use original source column names for read queries

### DIFF
--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -392,7 +392,15 @@ func (s *MSSQLSource) read(ctx context.Context, table string, tableSchema *schem
 	startTotal := time.Now()
 	config.Debug("[SOURCE] Starting read from %s", table)
 
-	columns := filterColumns(tableSchema.Columns, opts.ExcludeColumns)
+	schemaToUse := tableSchema
+	if opts.Schema != nil {
+		schemaToUse = opts.Schema
+		config.Debug("[SOURCE] Using provided schema (%d columns)", len(schemaToUse.Columns))
+	} else {
+		config.Debug("[SOURCE] Using pre-fetched schema (%d columns)", len(schemaToUse.Columns))
+	}
+
+	columns := filterColumns(schemaToUse.Columns, opts.ExcludeColumns)
 	arrowSchema := buildArrowSchema(columns)
 
 	batchSize := opts.PageSize

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -2,8 +2,11 @@ package mssql
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	mssqldb "github.com/microsoft/go-mssqldb"
 )
 
@@ -141,6 +144,27 @@ func TestURIToConnString(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildSelectQueryPreservesColumnCasing(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "RowPointer"},
+		{Name: "NoteExistsFlag"},
+		{Name: "CreatedBy"},
+	}
+
+	query := buildSelectQuery("dbo.notes", columns, source.ReadOptions{})
+
+	for _, name := range []string{"[RowPointer]", "[NoteExistsFlag]", "[CreatedBy]"} {
+		if !strings.Contains(query, name) {
+			t.Errorf("query %q missing original column %q", query, name)
+		}
+	}
+	for _, name := range []string{"row_pointer", "note_exists_flag", "created_by"} {
+		if strings.Contains(query, name) {
+			t.Errorf("query %q must not contain renamed column %q", query, name)
+		}
 	}
 }
 

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -269,7 +269,15 @@ func (s *MySQLSource) read(ctx context.Context, table string, tableSchema *schem
 	startTotal := time.Now()
 	config.Debug("[SOURCE] Starting read from %s", table)
 
-	columns := filterColumns(tableSchema.Columns, opts.ExcludeColumns)
+	schemaToUse := tableSchema
+	if opts.Schema != nil {
+		schemaToUse = opts.Schema
+		config.Debug("[SOURCE] Using provided schema (%d columns)", len(schemaToUse.Columns))
+	} else {
+		config.Debug("[SOURCE] Using pre-fetched schema (%d columns)", len(schemaToUse.Columns))
+	}
+
+	columns := filterColumns(schemaToUse.Columns, opts.ExcludeColumns)
 	arrowSchema := buildArrowSchema(columns)
 
 	batchSize := opts.PageSize

--- a/pkg/source/mysql/mysql_test.go
+++ b/pkg/source/mysql/mysql_test.go
@@ -1,0 +1,30 @@
+package mysql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestBuildSelectQueryPreservesColumnCasing(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "RowPointer"},
+		{Name: "NoteExistsFlag"},
+		{Name: "CreatedBy"},
+	}
+
+	query := buildSelectQuery("testdb.notes", columns, source.ReadOptions{})
+
+	for _, name := range []string{"`RowPointer`", "`NoteExistsFlag`", "`CreatedBy`"} {
+		if !strings.Contains(query, name) {
+			t.Errorf("query %q missing original column %q", query, name)
+		}
+	}
+	for _, name := range []string{"row_pointer", "note_exists_flag", "created_by"} {
+		if strings.Contains(query, name) {
+			t.Errorf("query %q must not contain renamed column %q", query, name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Ingesting a SQL Server (or MySQL) table with camelCase/PascalCase columns under the **default** snake_case naming convention fails:

The snake_case naming convention renames the source `TableSchema` columns **in place** for the destination. The mssql and mysql sources built their `SELECT` from that same mutated schema, so they queried destination-side names that don't exist in the source.

The pipeline already preserves the original-name schema and passes it via `ReadOptions.Schema`.

Honor `ReadOptions.Schema` when building the read query in both sources (matching postgres). Column renaming now applies to the destination only; the source read always uses original column names.