### PR TITLE
fix(annotation): tag schema-evolution ALTERs with ingestr_step

### DIFF
--- a/internal/annotation/annotation.go
+++ b/internal/annotation/annotation.go
@@ -34,6 +34,7 @@ const ingestrType = "ingestr"
 const (
 	StepExtract      = "extract"       // source read (SELECT) — only meaningful for warehouse sources
 	StepDDL          = "ddl"           // PrepareTable: create target/staging tables
+	StepEvolve       = "evolve"        // ApplyEvolution: ALTER existing table to match new source schema
 	StepLoad         = "load"          // Write/WriteParallel: bulk-load rows
 	StepMerge        = "merge"         // MergeTable
 	StepDeleteInsert = "delete_insert" // DeleteInsertTable
@@ -46,7 +47,7 @@ const (
 // ingestr classifies each query by ETL phase via the "type" value:
 //
 //	ingestr_extract   — read from the source: the SELECT a warehouse source runs
-//	ingestr_load      — move data in:   ddl, load, swap, truncate, cleanup
+//	ingestr_load      — move data in:   ddl, evolve, load, swap, truncate, cleanup
 //	ingestr_transform — apply strategy: merge, delete_insert, scd2
 const (
 	typeIngestrExtract   = "ingestr_extract"
@@ -61,7 +62,7 @@ func typeForStep(step string) string {
 		return typeIngestrExtract
 	case StepMerge, StepDeleteInsert, StepSCD2:
 		return typeIngestrTransform
-	case StepDDL, StepLoad, StepSwap, StepCleanup, StepTruncate:
+	case StepDDL, StepEvolve, StepLoad, StepSwap, StepCleanup, StepTruncate:
 		return typeIngestrLoad
 	default:
 		return ingestrType

--- a/internal/annotation/annotation_test.go
+++ b/internal/annotation/annotation_test.go
@@ -103,6 +103,7 @@ func TestTypeForStep(t *testing.T) {
 		StepExtract:      typeIngestrExtract,
 		StepLoad:         typeIngestrLoad,
 		StepDDL:          typeIngestrLoad,
+		StepEvolve:       typeIngestrLoad,
 		StepSwap:         typeIngestrLoad,
 		StepCleanup:      typeIngestrLoad,
 		StepTruncate:     typeIngestrLoad,

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/progress"
@@ -65,6 +66,7 @@ func (j *IngestionJob) ApplyEvolution(ctx context.Context) error {
 	if j.EvolutionPlan == nil || !j.EvolutionPlan.HasMigration() {
 		return nil
 	}
+	ctx = annotation.WithStep(ctx, annotation.StepEvolve)
 	return j.EvolutionPlan.Apply(ctx, j.Destination)
 }
 

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -10,9 +11,11 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,6 +70,11 @@ func (t *fakeSourceTable) Read(ctx context.Context, opts source.ReadOptions) (<-
 	return t.readCh, t.readErr
 }
 
+type execCall struct {
+	ctx context.Context
+	sql string
+}
+
 type fakeDestination struct {
 	mu sync.Mutex
 
@@ -78,6 +86,7 @@ type fakeDestination struct {
 	mergeCalls   []destination.MergeOptions
 	diCalls      []destination.DeleteInsertOptions
 	dropCalls    []string
+	execCalls    []execCall
 	waitCalls    []struct {
 		Table        string
 		ExpectedRows int64
@@ -96,6 +105,9 @@ func (d *fakeDestination) Schemes() []string                             { retur
 func (d *fakeDestination) Connect(ctx context.Context, uri string) error { return nil }
 func (d *fakeDestination) Close(ctx context.Context) error               { return nil }
 func (d *fakeDestination) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	d.mu.Lock()
+	d.execCalls = append(d.execCalls, execCall{ctx: ctx, sql: sql})
+	d.mu.Unlock()
 	return nil
 }
 
@@ -353,6 +365,35 @@ func minimalJob() (*IngestionJob, *fakeSourceTable, *fakeDestination) {
 		SourceSchema: tableSchema,
 	}
 	return job, src, dest
+}
+
+func TestApplyEvolution_AnnotatesWithEvolveStep(t *testing.T) {
+	job, _, dest := minimalJob()
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Migration: &schemaevolution.Migration{
+			Statements: []string{"ALTER TABLE ds.tbl ADD COLUMN new_col INT"},
+		},
+	}
+
+	err := job.ApplyEvolution(context.Background())
+	require.NoError(t, err)
+	require.Len(t, dest.execCalls, 1)
+
+	got := annotation.Prepend(dest.execCalls[0].ctx, "X")
+	assert.True(t, strings.Contains(got, `"ingestr_step":"evolve"`), "missing ingestr_step=evolve: %s", got)
+	assert.True(t, strings.Contains(got, `"type":"ingestr_load"`), "missing type=ingestr_load: %s", got)
+}
+
+func TestApplyEvolution_NoMigrationDoesNothing(t *testing.T) {
+	job, _, dest := minimalJob()
+	// Nil plan
+	require.NoError(t, job.ApplyEvolution(context.Background()))
+	assert.Empty(t, dest.execCalls)
+
+	// Empty plan
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{Migration: &schemaevolution.Migration{}}
+	require.NoError(t, job.ApplyEvolution(context.Background()))
+	assert.Empty(t, dest.execCalls)
 }
 
 func TestDeleteInsertStrategy_UsesIncrementalKeyFromLaterBatch(t *testing.T) {


### PR DESCRIPTION
## Summary

`IngestionJob.ApplyEvolution` dispatched its schema-evolution ALTER statements through `Destination.Exec` without setting `annotation.WithStep`, so the `-- @bruin.config: …` comment that landed on the query had no `ingestr_step` and a generic `type:"ingestr"` instead of the phase-specific `ingestr_load`.