### PR TITLE
fix(mssql): repair main build — align test with exported URIToConnString

### DIFF
--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -169,25 +169,25 @@ func TestBuildSelectQueryPreservesColumnCasing(t *testing.T) {
 }
 
 func TestGuidConversionEnabled(t *testing.T) {
-	connStr, _, err := uriToConnString("mssql://sa:pass@localhost/db?guid+conversion=true")
+	connStr, _, err := URIToConnString("mssql://sa:pass@localhost/db?guid+conversion=true")
 	if err != nil {
-		t.Fatalf("uriToConnString error: %v", err)
+		t.Fatalf("URIToConnString error: %v", err)
 	}
 	if !guidConversionEnabled(connStr) {
 		t.Fatal("expected guid conversion to be enabled")
 	}
 
-	connStr, _, err = uriToConnString("mssql://sa:pass@localhost/db?guid+conversion=false")
+	connStr, _, err = URIToConnString("mssql://sa:pass@localhost/db?guid+conversion=false")
 	if err != nil {
-		t.Fatalf("uriToConnString error: %v", err)
+		t.Fatalf("URIToConnString error: %v", err)
 	}
 	if guidConversionEnabled(connStr) {
 		t.Fatal("expected guid conversion to be disabled")
 	}
 
-	connStr, _, err = uriToConnString("mssql://sa:pass@localhost/db?GUID+CONVERSION=1")
+	connStr, _, err = URIToConnString("mssql://sa:pass@localhost/db?GUID+CONVERSION=1")
 	if err != nil {
-		t.Fatalf("uriToConnString error: %v", err)
+		t.Fatalf("URIToConnString error: %v", err)
 	}
 	if !guidConversionEnabled(connStr) {
 		t.Fatal("expected case-insensitive guid conversion to be enabled")


### PR DESCRIPTION
`pkg/source/mssql/mssql.go` exports the function as `URIToConnString`, but `mssql_test.go` (in `TestGuidConversionEnabled`) still called the lowercase `uriToConnString`. 