### PR TITLE
fix(deps): force postcss >=8.5.10 (XSS in stringify, GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,9 +1554,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1599,9 +1599,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1619,7 +1619,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "devDependencies": {
     "rollup": "^4.27.3",
     "vitepress": "^1.6.3"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## What

Adds an npm `overrides` entry forcing `postcss` to `^8.5.10` and regenerates `package-lock.json` (postcss now resolves to **8.5.15**).

## Why

Dependabot alert **#149** — [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93): *PostCSS has XSS via Unescaped `</style>` in its CSS Stringify Output* (medium). postcss is a transitive dependency pulled in via `vitepress → vite` and `vitepress → @vue/compiler-sfc`, previously pinned to the vulnerable `8.5.6`. An `overrides` entry forces the patched version. `8.5.10` is the first patched release.

postcss here is only part of the VitePress docs build toolchain — build-only, no `ingestr` runtime/CLI impact.

## Verification

- `npm ci` — clean install, lockfile in sync with `package.json`
- `npm run docs:build` — docs build succeeds with postcss 8.5.15

## Scope

Single-issue fix on its own branch off `main`, independent of the rollup (#767) and preact (#768) fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)