### PR TITLE
feat: add tinyint (8-bit integer) as a --column type

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -148,7 +148,7 @@ func IngestCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "columns",
-				Usage:   "Override column types and/or rename columns. Per-column format: 'name:type' (type override), 'name:type:source' (rename + type), or 'name::source' (rename only). Multiple entries comma-separated, e.g. 'id:bigint,first_name:string:fname,email::eml'. Types: bigint, int, smallint, float, double, decimal(p,s), string, text, boolean, date, timestamp (with tz), timestamp_ntz (no tz), json, uuid, binary",
+				Usage:   "Override column types and/or rename columns. Per-column format: 'name:type' (type override), 'name:type:source' (rename + type), or 'name::source' (rename only). Multiple entries comma-separated, e.g. 'id:bigint,first_name:string:fname,email::eml'. Types: bigint, int, smallint, tinyint, float, double, decimal(p,s), string, text, boolean, date, timestamp (with tz), timestamp_ntz (no tz), json, uuid, binary",
 				Sources: cli.EnvVars("INGESTR_COLUMNS"),
 			},
 			&cli.BoolFlag{

--- a/internal/arrowutil/value.go
+++ b/internal/arrowutil/value.go
@@ -20,6 +20,8 @@ func Value(arr interface {
 	switch a := arr.(type) {
 	case interface{ Value(int) bool }:
 		return a.Value(idx)
+	case interface{ Value(int) int8 }:
+		return a.Value(idx)
 	case interface{ Value(int) int16 }:
 		return a.Value(idx)
 	case interface{ Value(int) int32 }:

--- a/internal/cassandrautil/mapper.go
+++ b/internal/cassandrautil/mapper.go
@@ -65,6 +65,8 @@ func MapDataTypeToCassandra(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "boolean"
+	case schema.TypeInt8:
+		return "tinyint"
 	case schema.TypeInt16:
 		return "smallint"
 	case schema.TypeInt32:

--- a/internal/maxcomputeutil/types.go
+++ b/internal/maxcomputeutil/types.go
@@ -74,6 +74,8 @@ func MapDataTypeToMaxCompute(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -241,6 +241,7 @@ func duckdbSchemaTypes(db *sql.DB, table string) (map[string]string, error) {
 var schemaTypeToDuckDBMap = map[schema.DataType]string{
 	schema.TypeString:      "varchar",
 	schema.TypeBoolean:     "boolean",
+	schema.TypeInt8:        "tinyint",
 	schema.TypeInt16:       "smallint",
 	schema.TypeInt32:       "integer",
 	schema.TypeInt64:       "bigint",

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -182,6 +182,38 @@ func AppendValue(builder array.Builder, val interface{}) {
 			b.AppendNull()
 		}
 
+	case *array.Int8Builder:
+		switch v := val.(type) {
+		case int8:
+			b.Append(v)
+		case int16:
+			b.Append(int8(v))
+		case int32:
+			b.Append(int8(v))
+		case int64:
+			b.Append(int8(v))
+		case int:
+			b.Append(int8(v))
+		case float64:
+			b.Append(int8(v))
+		case uint8:
+			b.Append(int8(v))
+		case string:
+			if i, err := strconv.ParseInt(v, 10, 8); err == nil {
+				b.Append(int8(i))
+			} else {
+				b.AppendNull()
+			}
+		case json.Number:
+			if i, err := v.Int64(); err == nil {
+				b.Append(int8(i))
+			} else {
+				b.AppendNull()
+			}
+		default:
+			b.AppendNull()
+		}
+
 	case *array.Int16Builder:
 		switch v := val.(type) {
 		case int16:

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -145,6 +145,32 @@ func IsFloat(dt arrow.DataType) bool {
 	}
 }
 
+// appendInt8/appendInt16/appendInt32 narrow an int64 into a fixed-width
+// builder, appending a null instead of silently truncating out-of-range values.
+func appendInt8(b *array.Int8Builder, i int64) {
+	if i >= math.MinInt8 && i <= math.MaxInt8 {
+		b.Append(int8(i))
+	} else {
+		b.AppendNull()
+	}
+}
+
+func appendInt16(b *array.Int16Builder, i int64) {
+	if i >= math.MinInt16 && i <= math.MaxInt16 {
+		b.Append(int16(i))
+	} else {
+		b.AppendNull()
+	}
+}
+
+func appendInt32(b *array.Int32Builder, i int64) {
+	if i >= math.MinInt32 && i <= math.MaxInt32 {
+		b.Append(int32(i))
+	} else {
+		b.AppendNull()
+	}
+}
+
 func AppendValue(builder array.Builder, val interface{}) {
 	if val == nil {
 		builder.AppendNull()
@@ -184,24 +210,17 @@ func AppendValue(builder array.Builder, val interface{}) {
 		}
 
 	case *array.Int8Builder:
-		appendInt8 := func(i int64) {
-			if i >= math.MinInt8 && i <= math.MaxInt8 {
-				b.Append(int8(i))
-			} else {
-				b.AppendNull()
-			}
-		}
 		switch v := val.(type) {
 		case int8:
 			b.Append(v)
 		case int16:
-			appendInt8(int64(v))
+			appendInt8(b, int64(v))
 		case int32:
-			appendInt8(int64(v))
+			appendInt8(b, int64(v))
 		case int64:
-			appendInt8(v)
+			appendInt8(b, v)
 		case int:
-			appendInt8(int64(v))
+			appendInt8(b, int64(v))
 		case float64:
 			if v >= math.MinInt8 && v <= math.MaxInt8 {
 				b.Append(int8(v))
@@ -209,7 +228,7 @@ func AppendValue(builder array.Builder, val interface{}) {
 				b.AppendNull()
 			}
 		case uint8:
-			appendInt8(int64(v))
+			appendInt8(b, int64(v))
 		case string:
 			if i, err := strconv.ParseInt(v, 10, 8); err == nil {
 				b.Append(int8(i))
@@ -218,7 +237,7 @@ func AppendValue(builder array.Builder, val interface{}) {
 			}
 		case json.Number:
 			if i, err := v.Int64(); err == nil {
-				appendInt8(i)
+				appendInt8(b, i)
 			} else {
 				b.AppendNull()
 			}
@@ -231,17 +250,21 @@ func AppendValue(builder array.Builder, val interface{}) {
 		case int16:
 			b.Append(v)
 		case int32:
-			b.Append(int16(v))
+			appendInt16(b, int64(v))
 		case int64:
-			b.Append(int16(v))
+			appendInt16(b, v)
 		case int:
-			b.Append(int16(v))
+			appendInt16(b, int64(v))
 		case float64:
-			b.Append(int16(v))
+			if v >= math.MinInt16 && v <= math.MaxInt16 {
+				b.Append(int16(v))
+			} else {
+				b.AppendNull()
+			}
 		case uint8:
 			b.Append(int16(v))
 		case uint16:
-			b.Append(int16(v))
+			appendInt16(b, int64(v))
 		case int8:
 			b.Append(int16(v))
 		case string:
@@ -252,7 +275,7 @@ func AppendValue(builder array.Builder, val interface{}) {
 			}
 		case json.Number:
 			if i, err := v.Int64(); err == nil {
-				b.Append(int16(i))
+				appendInt16(b, i)
 			} else {
 				b.AppendNull()
 			}
@@ -265,9 +288,9 @@ func AppendValue(builder array.Builder, val interface{}) {
 		case int32:
 			b.Append(v)
 		case int:
-			b.Append(int32(v))
+			appendInt32(b, int64(v))
 		case int64:
-			b.Append(int32(v))
+			appendInt32(b, v)
 		case int8:
 			b.Append(int32(v))
 		case int16:
@@ -277,9 +300,13 @@ func AppendValue(builder array.Builder, val interface{}) {
 		case uint16:
 			b.Append(int32(v))
 		case uint32:
-			b.Append(int32(v))
+			appendInt32(b, int64(v))
 		case float64:
-			b.Append(int32(v))
+			if v >= math.MinInt32 && v <= math.MaxInt32 {
+				b.Append(int32(v))
+			} else {
+				b.AppendNull()
+			}
 		case string:
 			if i, err := strconv.ParseInt(v, 10, 32); err == nil {
 				b.Append(int32(i))
@@ -288,7 +315,7 @@ func AppendValue(builder array.Builder, val interface{}) {
 			}
 		case json.Number:
 			if i, err := v.Int64(); err == nil {
-				b.Append(int32(i))
+				appendInt32(b, i)
 			} else {
 				b.AppendNull()
 			}
@@ -317,7 +344,11 @@ func AppendValue(builder array.Builder, val interface{}) {
 		case uint32:
 			b.Append(int64(v))
 		case uint64:
-			b.Append(int64(v))
+			if v <= math.MaxInt64 {
+				b.Append(int64(v))
+			} else {
+				b.AppendNull()
+			}
 		case string:
 			if i, err := strconv.ParseInt(v, 10, 64); err == nil {
 				b.Append(i)

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -205,7 +205,7 @@ func AppendValue(builder array.Builder, val interface{}) {
 				b.AppendNull()
 			}
 		case json.Number:
-			if i, err := v.Int64(); err == nil {
+			if i, err := v.Int64(); err == nil && i >= -128 && i <= 127 {
 				b.Append(int8(i))
 			} else {
 				b.AppendNull()

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -184,21 +184,32 @@ func AppendValue(builder array.Builder, val interface{}) {
 		}
 
 	case *array.Int8Builder:
+		appendInt8 := func(i int64) {
+			if i >= math.MinInt8 && i <= math.MaxInt8 {
+				b.Append(int8(i))
+			} else {
+				b.AppendNull()
+			}
+		}
 		switch v := val.(type) {
 		case int8:
 			b.Append(v)
 		case int16:
-			b.Append(int8(v))
+			appendInt8(int64(v))
 		case int32:
-			b.Append(int8(v))
+			appendInt8(int64(v))
 		case int64:
-			b.Append(int8(v))
+			appendInt8(v)
 		case int:
-			b.Append(int8(v))
+			appendInt8(int64(v))
 		case float64:
-			b.Append(int8(v))
+			if v >= math.MinInt8 && v <= math.MaxInt8 {
+				b.Append(int8(v))
+			} else {
+				b.AppendNull()
+			}
 		case uint8:
-			b.Append(int8(v))
+			appendInt8(int64(v))
 		case string:
 			if i, err := strconv.ParseInt(v, 10, 8); err == nil {
 				b.Append(int8(i))
@@ -206,8 +217,8 @@ func AppendValue(builder array.Builder, val interface{}) {
 				b.AppendNull()
 			}
 		case json.Number:
-			if i, err := v.Int64(); err == nil && i >= math.MinInt8 && i <= math.MaxInt8 {
-				b.Append(int8(i))
+			if i, err := v.Int64(); err == nil {
+				appendInt8(i)
 			} else {
 				b.AppendNull()
 			}

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"sort"
@@ -205,7 +206,7 @@ func AppendValue(builder array.Builder, val interface{}) {
 				b.AppendNull()
 			}
 		case json.Number:
-			if i, err := v.Int64(); err == nil && i >= -128 && i <= 127 {
+			if i, err := v.Int64(); err == nil && i >= math.MinInt8 && i <= math.MaxInt8 {
 				b.Append(int8(i))
 			} else {
 				b.AppendNull()

--- a/pkg/destination/athena/dialect.go
+++ b/pkg/destination/athena/dialect.go
@@ -38,6 +38,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/athena/sql.go
+++ b/pkg/destination/athena/sql.go
@@ -85,6 +85,8 @@ func athenaCastTypeForColumn(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "boolean"
+	case schema.TypeInt8:
+		return "tinyint"
 	case schema.TypeInt16:
 		return "smallint"
 	case schema.TypeInt32:

--- a/pkg/destination/bigquery/dialect.go
+++ b/pkg/destination/bigquery/dialect.go
@@ -49,7 +49,7 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOL"
-	case schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
 		return "INT64"
 	case schema.TypeFloat32, schema.TypeFloat64:
 		return "FLOAT64"

--- a/pkg/destination/bigquery/mapper.go
+++ b/pkg/destination/bigquery/mapper.go
@@ -18,7 +18,7 @@ func MapDataTypeToBigQuery(col schema.Column) bigquery.FieldType {
 	case schema.TypeBoolean:
 		return bigquery.BooleanFieldType
 
-	case schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
 		return bigquery.IntegerFieldType
 
 	case schema.TypeFloat32, schema.TypeFloat64:

--- a/pkg/destination/clickhouse/dialect.go
+++ b/pkg/destination/clickhouse/dialect.go
@@ -48,6 +48,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "Bool"
+	case schema.TypeInt8:
+		return "Int8"
 	case schema.TypeInt16:
 		return "Int16"
 	case schema.TypeInt32:

--- a/pkg/destination/clickhouse/mapper.go
+++ b/pkg/destination/clickhouse/mapper.go
@@ -19,6 +19,8 @@ func mapBaseType(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "Bool"
+	case schema.TypeInt8:
+		return "Int8"
 	case schema.TypeInt16:
 		return "Int16"
 	case schema.TypeInt32:

--- a/pkg/destination/cratedb/mapper.go
+++ b/pkg/destination/cratedb/mapper.go
@@ -10,7 +10,7 @@ func mapDataTypeToCrateDB(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
-	case schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
 		return "BIGINT"
 	case schema.TypeFloat32, schema.TypeFloat64:
 		return "DOUBLE PRECISION"

--- a/pkg/destination/csv/csv.go
+++ b/pkg/destination/csv/csv.go
@@ -307,6 +307,8 @@ func formatValue(arr arrow.Array, idx int) string {
 			return "true"
 		}
 		return "false"
+	case *array.Int8:
+		return fmt.Sprintf("%d", a.Value(idx))
 	case *array.Int16:
 		return fmt.Sprintf("%d", a.Value(idx))
 	case *array.Int32:

--- a/pkg/destination/databricks/mapper.go
+++ b/pkg/destination/databricks/mapper.go
@@ -10,6 +10,8 @@ func MapDataTypeToDatabricks(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/duckdb/dialect.go
+++ b/pkg/destination/duckdb/dialect.go
@@ -53,6 +53,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/duckdb/mapper.go
+++ b/pkg/destination/duckdb/mapper.go
@@ -10,6 +10,8 @@ func MapDataTypeToDuckDB(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/dynamodb/dynamodb.go
+++ b/pkg/destination/dynamodb/dynamodb.go
@@ -189,7 +189,7 @@ func (d *DynamoDBDestination) createTable(ctx context.Context, table string, sch
 
 func schemaTypeToDynamoDBScalar(dt schema.DataType) types.ScalarAttributeType {
 	switch dt {
-	case schema.TypeInt16, schema.TypeInt32, schema.TypeInt64,
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64,
 		schema.TypeFloat32, schema.TypeFloat64, schema.TypeDecimal:
 		return types.ScalarAttributeTypeN
 	default:

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -775,6 +775,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 			return 1
 		}
 		return 0
+	case *array.Int8:
+		return a.Value(idx)
 	case *array.Int16:
 		return a.Value(idx)
 	case *array.Int32:

--- a/pkg/destination/fabric/mapper.go
+++ b/pkg/destination/fabric/mapper.go
@@ -14,6 +14,8 @@ func MapDataTypeToFabric(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BIT"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/maxcompute/maxcompute.go
+++ b/pkg/destination/maxcompute/maxcompute.go
@@ -558,6 +558,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 	switch a := arr.(type) {
 	case *array.Boolean:
 		return a.Value(idx)
+	case *array.Int8:
+		return a.Value(idx)
 	case *array.Int16:
 		return a.Value(idx)
 	case *array.Int32:

--- a/pkg/destination/mssql/mapper.go
+++ b/pkg/destination/mssql/mapper.go
@@ -10,6 +10,8 @@ func MapDataTypeToMSSQL(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BIT"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/mysql/dialect.go
+++ b/pkg/destination/mysql/dialect.go
@@ -59,6 +59,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "TINYINT(1)"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/mysql/mapper.go
+++ b/pkg/destination/mysql/mapper.go
@@ -10,6 +10,8 @@ func MapDataTypeToMySQL(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -820,6 +820,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 			return 1
 		}
 		return 0
+	case *array.Int8:
+		return a.Value(idx)
 	case *array.Int16:
 		return a.Value(idx)
 	case *array.Int32:

--- a/pkg/destination/onelake/delta.go
+++ b/pkg/destination/onelake/delta.go
@@ -33,6 +33,8 @@ func deltaTypeFor(col schema.Column) any {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "boolean"
+	case schema.TypeInt8:
+		return "byte"
 	case schema.TypeInt16:
 		return "short"
 	case schema.TypeInt32:

--- a/pkg/destination/postgres/dialect.go
+++ b/pkg/destination/postgres/dialect.go
@@ -48,6 +48,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/postgres/mapper.go
+++ b/pkg/destination/postgres/mapper.go
@@ -11,6 +11,8 @@ func MapDataTypeToPostgres(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/redshift/dialect.go
+++ b/pkg/destination/redshift/dialect.go
@@ -41,6 +41,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/snowflake/dialect.go
+++ b/pkg/destination/snowflake/dialect.go
@@ -41,6 +41,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/snowflake/mapper.go
+++ b/pkg/destination/snowflake/mapper.go
@@ -10,6 +10,8 @@ func MapDataTypeToSnowflake(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/sqlite/dialect.go
+++ b/pkg/destination/sqlite/dialect.go
@@ -38,7 +38,7 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "INTEGER"
-	case schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
 		return "INTEGER"
 	case schema.TypeFloat32, schema.TypeFloat64:
 		return "REAL"

--- a/pkg/destination/sqlite/mapper.go
+++ b/pkg/destination/sqlite/mapper.go
@@ -9,7 +9,7 @@ func MapDataTypeToSQLite(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "INTEGER" // SQLite uses 0/1 for boolean
-	case schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
 		return "INTEGER"
 	case schema.TypeFloat32, schema.TypeFloat64:
 		return "REAL"

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -866,6 +866,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 			return 1
 		}
 		return 0
+	case *array.Int8:
+		return a.Value(idx)
 	case *array.Int16:
 		return a.Value(idx)
 	case *array.Int32:

--- a/pkg/destination/synapse/dialect.go
+++ b/pkg/destination/synapse/dialect.go
@@ -56,6 +56,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BIT"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/synapse/mapper.go
+++ b/pkg/destination/synapse/mapper.go
@@ -10,6 +10,8 @@ func MapDataTypeToSynapse(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BIT"
+	case schema.TypeInt8:
+		return "SMALLINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -834,6 +834,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 			return 1
 		}
 		return 0
+	case *array.Int8:
+		return a.Value(idx)
 	case *array.Int16:
 		return a.Value(idx)
 	case *array.Int32:

--- a/pkg/destination/trino/dialect.go
+++ b/pkg/destination/trino/dialect.go
@@ -37,6 +37,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/destination/trino/mapper.go
+++ b/pkg/destination/trino/mapper.go
@@ -15,6 +15,8 @@ func mapBaseType(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
 	case schema.TypeInt16:
 		return "SMALLINT"
 	case schema.TypeInt32:

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -9,6 +9,7 @@ type DataType int
 const (
 	TypeUnknown DataType = iota
 	TypeBoolean
+	TypeInt8
 	TypeInt16
 	TypeInt32
 	TypeInt64
@@ -31,6 +32,8 @@ func (d DataType) String() string {
 	switch d {
 	case TypeBoolean:
 		return "boolean"
+	case TypeInt8:
+		return "int8"
 	case TypeInt16:
 		return "int16"
 	case TypeInt32:
@@ -114,6 +117,8 @@ func DataTypeToArrowType(col Column) arrow.DataType {
 		return UnknownArrowType
 	case TypeBoolean:
 		return arrow.FixedWidthTypes.Boolean
+	case TypeInt8:
+		return arrow.PrimitiveTypes.Int8
 	case TypeInt16:
 		return arrow.PrimitiveTypes.Int16
 	case TypeInt32:

--- a/pkg/schemaevolution/override.go
+++ b/pkg/schemaevolution/override.go
@@ -38,6 +38,8 @@ var StandardTypeNames = map[string]schema.DataType{
 	"bool":    schema.TypeBoolean,
 
 	// Integer types
+	"int8":     schema.TypeInt8,
+	"tinyint":  schema.TypeInt8,
 	"int16":    schema.TypeInt16,
 	"smallint": schema.TypeInt16,
 	"int32":    schema.TypeInt32,

--- a/pkg/schemaevolution/override_test.go
+++ b/pkg/schemaevolution/override_test.go
@@ -83,6 +83,8 @@ func TestParseColumnOverrides_AllTypes(t *testing.T) {
 	}{
 		{"col:boolean", schema.TypeBoolean},
 		{"col:bool", schema.TypeBoolean},
+		{"col:int8", schema.TypeInt8},
+		{"col:tinyint", schema.TypeInt8},
 		{"col:int16", schema.TypeInt16},
 		{"col:smallint", schema.TypeInt16},
 		{"col:int32", schema.TypeInt32},

--- a/pkg/schemaevolution/widen.go
+++ b/pkg/schemaevolution/widen.go
@@ -8,22 +8,23 @@ import (
 // Higher index = wider type.
 var wideningOrder = map[schema.DataType]int{
 	schema.TypeBoolean:     0,
-	schema.TypeInt16:       1,
-	schema.TypeInt32:       2,
-	schema.TypeInt64:       3,
-	schema.TypeFloat32:     4,
-	schema.TypeFloat64:     5,
-	schema.TypeDecimal:     6,
-	schema.TypeDate:        7,
-	schema.TypeTime:        8,
-	schema.TypeTimestamp:   9,
-	schema.TypeTimestampTZ: 10,
-	schema.TypeBinary:      10,
-	schema.TypeUUID:        10,
-	schema.TypeInterval:    10,
-	schema.TypeArray:       10,
-	schema.TypeString:      11,
-	schema.TypeJSON:        12,
+	schema.TypeInt8:        1,
+	schema.TypeInt16:       2,
+	schema.TypeInt32:       3,
+	schema.TypeInt64:       4,
+	schema.TypeFloat32:     5,
+	schema.TypeFloat64:     6,
+	schema.TypeDecimal:     7,
+	schema.TypeDate:        8,
+	schema.TypeTime:        9,
+	schema.TypeTimestamp:   10,
+	schema.TypeTimestampTZ: 11,
+	schema.TypeBinary:      11,
+	schema.TypeUUID:        11,
+	schema.TypeInterval:    11,
+	schema.TypeArray:       11,
+	schema.TypeString:      12,
+	schema.TypeJSON:        13,
 }
 
 // wideningPaths defines valid type widening paths.
@@ -31,6 +32,7 @@ var wideningOrder = map[schema.DataType]int{
 var wideningPaths = map[schema.DataType][]schema.DataType{
 	schema.TypeBoolean: {schema.TypeString, schema.TypeJSON},
 
+	schema.TypeInt8:    {schema.TypeInt16, schema.TypeInt32, schema.TypeInt64, schema.TypeFloat64, schema.TypeDecimal, schema.TypeString, schema.TypeJSON},
 	schema.TypeInt16:   {schema.TypeInt32, schema.TypeInt64, schema.TypeFloat64, schema.TypeDecimal, schema.TypeString, schema.TypeJSON},
 	schema.TypeInt32:   {schema.TypeInt64, schema.TypeFloat64, schema.TypeDecimal, schema.TypeString, schema.TypeJSON},
 	schema.TypeInt64:   {schema.TypeFloat64, schema.TypeDecimal, schema.TypeString, schema.TypeJSON},

--- a/tests/integration/column_overrides_test.go
+++ b/tests/integration/column_overrides_test.go
@@ -103,6 +103,48 @@ func TestColumnOverrides_CSVToDuckDB_AppliesTypes(t *testing.T) {
 	assert.Equal(t, 3, readDuckDBRowCount(t, duckDBPath, "main.users"))
 }
 
+func TestColumnOverrides_CSVToDuckDB_TinyInt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	csvPath := filepath.Join(tmpDir, "users.csv")
+	require.NoError(t, os.WriteFile(csvPath, []byte(csvWithRows), 0o644))
+
+	duckDBPath := filepath.Join(tmpDir, "out.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           fmt.Sprintf("csv://%s", csvPath),
+		SourceTable:         "users",
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckDBPath),
+		DestTable:           "main.users",
+		IncrementalStrategy: config.StrategyReplace,
+		Columns:             "age:tinyint",
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	types := readDuckDBColumnTypes(t, duckDBPath, "main.users")
+	assert.Equal(t, "TINYINT", types["age"], "age should be overridden to 8-bit TINYINT")
+	assert.Equal(t, 3, readDuckDBRowCount(t, duckDBPath, "main.users"))
+
+	db := openDuckDBForTest(t, duckDBPath)
+	defer func() { _ = db.Close() }()
+	rows, err := db.Query("SELECT age FROM main.users ORDER BY age")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var got []int64
+	for rows.Next() {
+		var age int64
+		require.NoError(t, rows.Scan(&age))
+		got = append(got, age)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int64{25, 30, 35}, got, "8-bit integer values should round-trip intact")
+}
+
 func TestColumnMasking_CSVToDuckDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
Maps tinyint/int8 to schema.TypeInt8 -> Arrow Int8 end-to-end.

- schema: new TypeInt8 enum, String(), and DataTypeToArrowType
- override: register tinyint/int8 type names + CLI docs + widening rules
- arrowconv: add *array.Int8Builder case (was nulling Int8 values)
- arrowutil.Value: add int8 case for shared destination extractor
- destinations: add Int8 DDL mapping + *array.Int8 value writers, using native TINYINT where signed 8-bit is supported, SMALLINT otherwise
- tests: unit coverage + CSV->DuckDB tinyint round-trip