### PR TITLE
[codex] fix snowflake parquet timestamp loading

### DIFF
--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -219,14 +219,8 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 
 				startBatch := time.Now()
 
-				// Write to parquet in memory
 				buf := new(bytes.Buffer)
-				writerProps := parquet.NewWriterProperties(
-					parquet.WithCompression(compress.Codecs.Snappy),
-					parquet.WithBatchSize(64*1024),
-				)
-				arrowProps := pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(memory.DefaultAllocator))
-
+				writerProps, arrowProps := snowflakeParquetWriterProperties()
 				writer, err := pqarrow.NewFileWriter(record.Schema(), buf, writerProps, arrowProps)
 				if err != nil {
 					record.Release()
@@ -308,8 +302,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 	config.Debug("[DEST] Loading %d files with single COPY INTO...", len(uploadedFiles))
 	startCopy := time.Now()
 
-	copySQL := fmt.Sprintf("COPY INTO %s FROM @%s/%s FILE_FORMAT = (TYPE = PARQUET) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE",
-		fullTable, stageName, loadID)
+	copySQL := buildCopyIntoSQL(fullTable, stageName, loadID)
 
 	if _, err := d.db.ExecContext(ctx, copySQL); err != nil {
 		config.LogFailedQuery(copySQL, err)
@@ -319,6 +312,23 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 	config.Debug("[DEST] COPY INTO completed in %v", time.Since(startCopy))
 	config.Debug("[DEST] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), float64(totalRows)/time.Since(startTotal).Seconds())
 	return nil
+}
+
+func snowflakeParquetWriterProperties() (*parquet.WriterProperties, pqarrow.ArrowWriterProperties) {
+	writerProps := parquet.NewWriterProperties(
+		parquet.WithCompression(compress.Codecs.Snappy),
+		parquet.WithBatchSize(64*1024),
+	)
+	arrowProps := pqarrow.NewArrowWriterProperties(
+		pqarrow.WithAllocator(memory.DefaultAllocator),
+		pqarrow.WithStoreSchema(),
+	)
+	return writerProps, arrowProps
+}
+
+func buildCopyIntoSQL(fullTable, stageName, loadID string) string {
+	return fmt.Sprintf("COPY INTO %s FROM @%s/%s FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE",
+		fullTable, stageName, loadID)
 }
 
 func (d *SnowflakeDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -1,11 +1,20 @@
 package snowflake
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	pqgo "github.com/apache/arrow-go/v18/parquet"
+	pqfile "github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	pqschema "github.com/apache/arrow-go/v18/parquet/schema"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildMergeSQL(t *testing.T) {
@@ -171,6 +180,54 @@ func TestImplicitTableStageName(t *testing.T) {
 			assert.Equal(t, tt.wantStage, stageName)
 		})
 	}
+}
+
+func TestBuildCopyIntoSQLUsesParquetLogicalTypes(t *testing.T) {
+	got := buildCopyIntoSQL(`"PUBLIC"."EVENTS"`, `"PUBLIC".%"EVENTS"`, "123456789")
+	want := `COPY INTO "PUBLIC"."EVENTS" FROM @"PUBLIC".%"EVENTS"/123456789 FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE`
+	assert.Equal(t, want, got)
+}
+
+func TestSnowflakeParquetWriterTimestampLogicalTypes(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "created_at", Type: &arrow.TimestampType{Unit: arrow.Microsecond}, Nullable: true},
+		{Name: "synced_at", Type: &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}, Nullable: true},
+	}, nil)
+
+	builder := array.NewRecordBuilder(mem, arrowSchema)
+	builder.Field(0).(*array.TimestampBuilder).Append(arrow.Timestamp(1717245296789123))
+	builder.Field(1).(*array.TimestampBuilder).Append(arrow.Timestamp(1717245296789123))
+	record := builder.NewRecord()
+	builder.Release()
+	defer record.Release()
+
+	var buf bytes.Buffer
+	writerProps, arrowProps := snowflakeParquetWriterProperties()
+	writer, err := pqarrow.NewFileWriter(record.Schema(), &buf, writerProps, arrowProps)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+
+	reader, err := pqfile.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer func() { _ = reader.Close() }()
+
+	createdAt := reader.MetaData().Schema.Column(0)
+	assert.Equal(t, pqgo.Types.Int64, createdAt.PhysicalType())
+	createdAtLogical, ok := createdAt.LogicalType().(pqschema.TimestampLogicalType)
+	require.True(t, ok, "created_at logical type = %T", createdAt.LogicalType())
+	assert.Equal(t, pqschema.TimeUnitMicros, createdAtLogical.TimeUnit())
+	assert.False(t, createdAtLogical.IsAdjustedToUTC())
+
+	syncedAt := reader.MetaData().Schema.Column(1)
+	assert.Equal(t, pqgo.Types.Int64, syncedAt.PhysicalType())
+	syncedAtLogical, ok := syncedAt.LogicalType().(pqschema.TimestampLogicalType)
+	require.True(t, ok, "synced_at logical type = %T", syncedAt.LogicalType())
+	assert.Equal(t, pqschema.TimeUnitMicros, syncedAtLogical.TimeUnit())
+	assert.True(t, syncedAtLogical.IsAdjustedToUTC())
 }
 
 func TestMapDataTypeToSnowflake(t *testing.T) {

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -200,7 +200,7 @@ func TestSnowflakeParquetWriterTimestampLogicalTypes(t *testing.T) {
 	builder := array.NewRecordBuilder(mem, arrowSchema)
 	builder.Field(0).(*array.TimestampBuilder).Append(arrow.Timestamp(1717245296789123))
 	builder.Field(1).(*array.TimestampBuilder).Append(arrow.Timestamp(1717245296789123))
-	record := builder.NewRecord()
+	record := builder.NewRecordBatch()
 	builder.Release()
 	defer record.Release()
 


### PR DESCRIPTION
## Summary

- Enable Snowflake Parquet `COPY INTO` loads to honor Parquet logical types with `USE_LOGICAL_TYPE = TRUE`.
- Store Arrow schema metadata in the staged Parquet writer used by Snowflake loads.
- Add regression coverage for the generated COPY SQL and timestamp logical metadata in staged Parquet files.

## Root Cause

Snowflake's Parquet file format defaults `USE_LOGICAL_TYPE` to false for COPY loads. Arrow was writing MSSQL/Synapse datetime values as microsecond timestamp data with Parquet timestamp logical metadata, but Snowflake was not instructed to use that metadata during load, so timestamp values could be interpreted at the wrong unit.

## Validation

- `go test ./pkg/destination/snowflake`
- `go test ./pkg/source/mssql`
- `go test ./pkg/arrowconv`
- `make generate && go test -short ./...`
- Live Snowflake validation using the shared key-pair URI: loaded JSONL rows with `timestamp_ntz` and `timestamp` columns through Snowflake Parquet staging, queried them back, and verified microsecond timestamp values landed correctly. Temporary table `PUBLIC.CODEX_TS_1781022985` was dropped after verification.

Fixes #773