### PR TITLE
[codex] Fix ClickHouse low-cardinality array mapping

### DIFF
--- a/pkg/source/clickhouse/mapper.go
+++ b/pkg/source/clickhouse/mapper.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	decimalRegex    = regexp.MustCompile(`(?i)Decimal(?:32|64|128|256)?\s*\(\s*(\d+)\s*(?:,\s*(\d+))?\s*\)`)
-	arrayRegex      = regexp.MustCompile(`(?i)Array\s*\(\s*(.+)\s*\)`)
-	nullableRegex   = regexp.MustCompile(`(?i)Nullable\s*\(\s*(.+)\s*\)`)
-	lowCardRegex    = regexp.MustCompile(`(?i)LowCardinality\s*\(\s*(.+)\s*\)`)
+	arrayRegex      = regexp.MustCompile(`(?i)^Array\s*\(\s*(.+)\s*\)$`)
+	nullableRegex   = regexp.MustCompile(`(?i)^Nullable\s*\(\s*(.+)\s*\)$`)
+	lowCardRegex    = regexp.MustCompile(`(?i)^LowCardinality\s*\(\s*(.+)\s*\)$`)
 	fixedStringRe   = regexp.MustCompile(`(?i)FixedString\s*\(\s*(\d+)\s*\)`)
 	enumRegex       = regexp.MustCompile(`(?i)Enum(?:8|16)\s*\(`)
 	datetime64Regex = regexp.MustCompile(`(?i)DateTime64\s*\(\s*(\d+)`)

--- a/pkg/source/clickhouse/mapper_test.go
+++ b/pkg/source/clickhouse/mapper_test.go
@@ -1,0 +1,78 @@
+package clickhouse
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapClickHouseToDataType_ArrayWrappers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantType  schema.DataType
+		wantArray schema.DataType
+	}{
+		{
+			name:      "array low cardinality string",
+			input:     "Array(LowCardinality(String))",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeString,
+		},
+		{
+			name:      "array nullable string",
+			input:     "Array(Nullable(String))",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeString,
+		},
+		{
+			name:      "nullable array low cardinality string",
+			input:     "Nullable(Array(LowCardinality(String)))",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeString,
+		},
+		{
+			name:      "low cardinality nullable string",
+			input:     "LowCardinality(Nullable(String))",
+			wantType:  schema.TypeString,
+			wantArray: schema.TypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotType, gotPrecision, gotScale, gotArray := MapClickHouseToDataType(tt.input)
+
+			require.Equal(t, tt.wantType, gotType)
+			require.Equal(t, 0, gotPrecision)
+			require.Equal(t, 0, gotScale)
+			require.Equal(t, tt.wantArray, gotArray)
+		})
+	}
+}
+
+func TestNativeScanTarget_ArrayWrappers(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"Array(LowCardinality(String))",
+		"Array(Nullable(String))",
+		"Nullable(Array(LowCardinality(String)))",
+	}
+
+	wantType := reflect.TypeOf(new([]string))
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, wantType, reflect.TypeOf(nativeScanTarget(input, false)))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix ClickHouse source type parsing for array columns whose element type is wrapped, such as `Array(LowCardinality(String))`.

The previous regexes were unanchored, so `LowCardinality(String)` or `Nullable(String)` inside an outer `Array(...)` could match first and cause the whole column to be mapped as a scalar string. That later made the native scanner fall back to scanning the ClickHouse array into `*string`, producing errors like `needs a slice or any`.

This change anchors the ClickHouse wrapper regexes so they only unwrap the whole type expression, preserving the outer `Array(...)` and allowing the scanner to use a slice target.

Fixes #776

## Tests

- `go test -count=1 ./pkg/source/clickhouse`

## Notes

- `go test -short ./...` was attempted in this workspace but fails before completion because `github.com/bruin-data/ingestr/internal/registry/imports` is missing here.