### PR TITLE
fix(indeed): preserve per-(job × platform) rows in traffic_stats

### DIFF
--- a/docs/supported-sources/indeed.md
+++ b/docs/supported-sources/indeed.md
@@ -52,11 +52,11 @@ Indeed source allows ingesting the following resources into separate tables:
 | `campaign_properties` | campaignId | - | merge | Retrieves properties for each campaign |
 | `campaign_stats` | campaignId, Date | Date | merge | Retrieves daily statistics for each campaign |
 | `account` | employerId, jobSourceId | - | merge | Retrieves account information including job sources |
-| `traffic_stats` | - | date | merge | Retrieves daily traffic statistics |
+| `traffic_stats` | - | date | delete+insert | Retrieves daily traffic statistics |
 
 ## Incremental Loading
 
-The `campaign_stats` and `traffic_stats` tables support incremental loading using date-based merge strategy. Use `--interval-start` and `--interval-end` to specify the date range:
+The `campaign_stats` and `traffic_stats` tables support incremental loading using a date-based strategy (`merge` for `campaign_stats`, `delete+insert` for `traffic_stats`). Use `--interval-start` and `--interval-end` to specify the date range:
 
 ```sh
 ingestr ingest \

--- a/pkg/source/indeed/indeed.go
+++ b/pkg/source/indeed/indeed.go
@@ -198,8 +198,9 @@ func (s *IndeedSource) GetTable(ctx context.Context, req source.TableRequest) (s
 	case "account":
 		primaryKeys = []string{"employerId", "jobSourceId"}
 	case "traffic_stats":
-		primaryKeys = []string{"date"}
+		// No PK: report has no row identity (multi-row per date by job × platform); merge would collapse them.
 		incrementalKey = "date"
+		strategy = config.StrategyDeleteInsert
 	}
 
 	return &source.DynamicSourceTable{


### PR DESCRIPTION
## Summary
- Indeed `traffic_stats` was configured with `merge` + PK=`["date"]`, which dedupes the staging batch to a single row per day — collapsing the report's multi-row-per-day output (jobs × platforms) to one row.
- Switch to `delete+insert` with no PK. The strategy deletes the date window in the target and bulk-inserts staging.