### PR TITLE
Fix delete+insert transaction handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
+        <td>MaxCompute</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
         <td>Microsoft Fabric</td>
         <td>✅</td>
         <td>✅</td>

--- a/docs/getting-started/incremental-loading.md
+++ b/docs/getting-started/incremental-loading.md
@@ -176,6 +176,9 @@ A few important notes about the `delete+insert` strategy:
 - it does not guarantee the order of the rows in the destination table, as it will delete and insert the rows in the destination table.
 - it does not deduplicate the rows in the destination table, as it will delete and insert the rows in the destination table, which means you may have multiple rows with the same `incremental_key` in the destination table.
 
+> [!WARNING]
+> **Breaking change:** `delete+insert` is no longer supported for **CrateDB** and **Trino** destinations. These platforms cannot make the delete and insert steps atomic (CrateDB commits every statement immediately despite accepting `BEGIN`/`START TRANSACTION`; Trino transaction support depends on the catalog connector), so ingestr previously ran them as two non-atomic statements that could leave the table in a partially-updated state on failure or under concurrent runs. ingestr now fails this strategy up front for these destinations instead of loading data unsafely. Use `merge` or `replace` instead. See the [CrateDB](/supported-sources/cratedb) and [Trino](/supported-sources/trino) destination notes for details.
+
 ### Example
 Let's assume you had the following source table:
 | id | name | updated_at |

--- a/docs/supported-sources/clickhouse.md
+++ b/docs/supported-sources/clickhouse.md
@@ -55,4 +55,10 @@ ingestr ingest \
     see https://github.com/dlt-hub/dlt/issues/2248
 -->
 > [!WARNING]
-> Clickhouse currently doesn't support `delete+insert`, `merge` or `scd2` incremental strategies.
+> ingestr does not use ClickHouse transactions. ClickHouse `delete+insert` is supported as a best-effort two-step operation: ingestr runs `ALTER TABLE ... DELETE`, waits for the mutation to finish, and then inserts rows from the staging table. This is not a single atomic transaction.
+
+## Supported destination strategies
+
+When using ClickHouse as a destination, ingestr supports `replace`, `append`, `merge`, `delete+insert`, `truncate+insert`, and `scd2`.
+
+`delete+insert` does not use ClickHouse's experimental transaction feature. Concurrent ingestr runs writing to the same ClickHouse table can still interleave between the delete and insert steps.

--- a/docs/supported-sources/cratedb.md
+++ b/docs/supported-sources/cratedb.md
@@ -105,6 +105,17 @@ uvx crash -c 'SELECT * FROM doc.sample'
 
 <img alt="CrateDB_img" src="../media/cratedb-destination.png" />
 
+### Supported destination strategies
+
+When using CrateDB as a destination, ingestr supports `replace`, `append`, `merge`, `truncate+insert`, and `scd2`.
+
+`delete+insert` is not supported for CrateDB destinations. CrateDB accepts transaction-control statements such as `BEGIN` and `START TRANSACTION` for PostgreSQL wire compatibility, but it does not provide transaction control; every statement commits immediately. Because ingestr cannot make the delete and insert steps atomic on CrateDB, it fails this strategy before loading staging data.
+
+See CrateDB's transaction notes:
+
+- [`BEGIN`](https://cratedb.com/docs/crate/reference/en/latest/sql/statements/begin.html)
+- [SQL compatibility: transactions](https://cratedb.com/docs/crate/reference/en/latest/appendices/compatibility.html#transactions-begin-start-commit-and-rollback)
+
 ## Appendix
 
 To start a single-node instance of CrateDB for evaluation purposes,

--- a/docs/supported-sources/databricks.md
+++ b/docs/supported-sources/databricks.md
@@ -42,3 +42,9 @@ To set up OAuth M2M authentication:
 You can read more about Databricks OAuth M2M authentication [here](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html).
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's Databricks dialect [here](https://docs.databricks.com/en/dev-tools/sqlalchemy.html).
+
+## Supported destination strategies
+
+When using Databricks as a destination, ingestr supports `replace`, `append`, `merge`, `delete+insert`, `truncate+insert`, and `scd2`.
+
+`delete+insert` is executed as a Databricks `BEGIN ATOMIC ... END` compound statement so the delete and insert run together. ingestr does not expose a separate destination transaction API for Databricks; transaction requests fail instead of returning a no-op transaction wrapper.

--- a/docs/supported-sources/databricks.md
+++ b/docs/supported-sources/databricks.md
@@ -45,6 +45,6 @@ The same URI structure can be used both for sources and destinations. You can re
 
 ## Supported destination strategies
 
-When using Databricks as a destination, ingestr supports `replace`, `append`, `merge`, `delete+insert`, `truncate+insert`, and `scd2`.
+When using Databricks as a destination, ingestr supports `replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`.
 
-`delete+insert` is executed as a Databricks `BEGIN ATOMIC ... END` compound statement so the delete and insert run together. ingestr does not expose a separate destination transaction API for Databricks; transaction requests fail instead of returning a no-op transaction wrapper.
+`delete+insert` is executed as a Databricks `BEGIN ATOMIC ... END` compound statement so the delete and insert run together. `scd2` is not supported for Databricks destinations. ingestr does not expose a separate destination transaction API for Databricks; transaction requests fail instead of returning a no-op transaction wrapper.

--- a/docs/supported-sources/maxcompute.md
+++ b/docs/supported-sources/maxcompute.md
@@ -1,0 +1,47 @@
+# MaxCompute
+
+MaxCompute is Alibaba Cloud's distributed data processing and warehousing platform.
+
+ingestr supports MaxCompute as both a source and destination. The `odps` URI scheme is also accepted.
+
+## URI format
+
+```plaintext
+maxcompute://<access_id>:<access_key>@<host>/<project>?schema=<schema>
+```
+
+You can also provide the full endpoint as a query parameter:
+
+```plaintext
+maxcompute://<access_id>:<access_key>@placeholder/<project>?endpoint=https://service.<region>.maxcompute.aliyun.com/api&schema=<schema>
+```
+
+URI parameters:
+
+- `access_id`: Alibaba Cloud access key ID. It can also be supplied with `ALIBABA_CLOUD_ACCESS_KEY_ID` or `ODPS_ACCESS_ID`.
+- `access_key`: Alibaba Cloud access key secret. It can also be supplied with `ALIBABA_CLOUD_ACCESS_KEY_SECRET` or `ODPS_ACCESS_KEY`.
+- `host`: MaxCompute endpoint host. If `endpoint` is supplied, this can be any non-empty placeholder host.
+- `project`: MaxCompute project name. This can be supplied in the URI path or as `project`.
+- `schema` (optional): MaxCompute schema name.
+- `endpoint` (optional): Full MaxCompute endpoint URL.
+- `tunnel_endpoint` (optional): Tunnel endpoint.
+- `tunnel_quota_name` (optional): Tunnel quota name.
+- `sts_token` (optional): STS token.
+
+The same URI structure can be used for sources and destinations.
+
+## Example
+
+```sh
+ingestr ingest \
+  --source-uri "postgres://user:pass@localhost:5432/app" \
+  --source-table "public.events" \
+  --dest-uri "maxcompute://<access_id>:<access_key>@service.cn-hangzhou.maxcompute.aliyun.com/<project>?protocol=https&schema=analytics" \
+  --dest-table "events"
+```
+
+## Supported destination strategies
+
+When using MaxCompute as a destination, ingestr supports `replace`, `append`, and `truncate+insert`.
+
+`merge`, `delete+insert`, and `scd2` are not supported for MaxCompute destinations. ingestr also does not expose destination transactions for MaxCompute. The test emulator may use a local SQL transaction internally, but real MaxCompute destinations fail transaction requests instead of returning a no-op transaction wrapper.

--- a/docs/supported-sources/trino.md
+++ b/docs/supported-sources/trino.md
@@ -80,7 +80,9 @@ ingestr ingest \
 ```
 
 ## Supported write dispositions
-When using Trino as a destination, all the existing write dispositions are supported.
+When using Trino as a destination, ingestr supports `replace`, `append`, `merge`, `truncate+insert`, and `scd2`.
+
+`delete+insert` is not supported for Trino destinations. Transaction support in Trino depends on the catalog connector, and ingestr does not expose a destination transaction for Trino. Because ingestr cannot make the delete and insert steps atomic across Trino catalogs, it fails this strategy before loading staging data.
 
 ## Data type handling
 Trino automatically handles most SQL data type conversions. When used as a destination:

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	defaultWriteParallelism   = 4
-	exactRowCountWaitTimeout  = 30 * time.Second
-	exactRowCountPollInterval = 1 * time.Second
+	defaultWriteParallelism            = 4
+	exactRowCountWaitTimeout           = 30 * time.Second
+	exactRowCountPollInterval          = 1 * time.Second
+	queryJobMaxAttempts                = 4
+	deleteInsertTransactionMaxAttempts = 8
 )
 
 type bigQueryLoadMethod string
@@ -959,7 +961,18 @@ func (d *BigQueryDestination) Exec(ctx context.Context, sql string, args ...inte
 // BigQuery jobs are atomic — failed jobs do not commit partial work — so
 // retrying on the reasons checked by isRetryableLoadJobError is safe.
 func (d *BigQueryDestination) runQueryJobWithRetry(ctx context.Context, sql, opLabel string) (*bigquery.Job, error) {
-	const maxAttempts = 4
+	return d.runQueryJobWithRetryAttempts(ctx, sql, opLabel, queryJobMaxAttempts)
+}
+
+func (d *BigQueryDestination) runTransactionScriptWithRetry(ctx context.Context, sql, opLabel string) (*bigquery.Job, error) {
+	return d.runQueryJobWithRetryAttempts(ctx, sql, opLabel, deleteInsertTransactionMaxAttempts)
+}
+
+func (d *BigQueryDestination) runQueryJobWithRetryAttempts(ctx context.Context, sql, opLabel string, maxAttempts int) (*bigquery.Job, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = queryJobMaxAttempts
+	}
+
 	var (
 		lastJob *bigquery.Job
 		lastErr error
@@ -975,7 +988,7 @@ func (d *BigQueryDestination) runQueryJobWithRetry(ctx context.Context, sql, opL
 			if attempt < maxAttempts && isRetryableLoadJobError(err) {
 				lastErr = err
 				config.Debug("[%s] Retrying after start error: %v", opLabel, err)
-				if sleepErr := sleepWithContextForLoadJob(ctx, time.Duration(attempt)*time.Second); sleepErr != nil {
+				if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(attempt, err)); sleepErr != nil {
 					return nil, sleepErr
 				}
 				continue
@@ -989,7 +1002,7 @@ func (d *BigQueryDestination) runQueryJobWithRetry(ctx context.Context, sql, opL
 			if attempt < maxAttempts && isRetryableLoadJobError(err) {
 				lastErr = err
 				config.Debug("[%s] Retrying after wait error: %v", opLabel, err)
-				if sleepErr := sleepWithContextForLoadJob(ctx, time.Duration(attempt)*time.Second); sleepErr != nil {
+				if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(attempt, err)); sleepErr != nil {
 					return job, sleepErr
 				}
 				continue
@@ -1000,7 +1013,7 @@ func (d *BigQueryDestination) runQueryJobWithRetry(ctx context.Context, sql, opL
 			if attempt < maxAttempts && isRetryableLoadJobError(err) {
 				lastErr = err
 				config.Debug("[%s] Retrying after job error: %v", opLabel, err)
-				if sleepErr := sleepWithContextForLoadJob(ctx, time.Duration(attempt)*time.Second); sleepErr != nil {
+				if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(attempt, err)); sleepErr != nil {
 					return job, sleepErr
 				}
 				continue
@@ -1233,6 +1246,27 @@ func (d *BigQueryDestination) DeleteInsertTable(ctx context.Context, opts destin
 		return fmt.Errorf("invalid target table name: %w", err)
 	}
 
+	deleteSQL, insertSQL := d.buildDeleteInsertStatements(stagingDataset, stagingTableName, targetDataset, targetTableName, opts)
+	transactionSQL := buildBigQueryTransactionScript(deleteSQL, insertSQL)
+
+	config.Debug("[DELETE+INSERT] Executing transaction")
+	config.Debug("[DELETE+INSERT] DELETE: %s", deleteSQL)
+	config.Debug("[DELETE+INSERT] INSERT: %s", insertSQL)
+
+	job, err := d.runTransactionScriptWithRetry(ctx, transactionSQL, "DELETE+INSERT")
+	if err != nil {
+		config.LogFailedQuery(transactionSQL, err)
+		if job == nil {
+			return fmt.Errorf("failed to start delete+insert transaction job: %w", err)
+		}
+		return fmt.Errorf("delete+insert transaction job failed (job %s): %w", jobRef(job), err)
+	}
+
+	config.Debug("[DELETE+INSERT] Delete+Insert completed successfully (job %s)", jobRef(job))
+	return nil
+}
+
+func (d *BigQueryDestination) buildDeleteInsertStatements(stagingDataset, stagingTableName, targetDataset, targetTableName string, opts destination.DeleteInsertOptions) (string, string) {
 	startVal := formatBigQueryValue(opts.IntervalStart, opts.IncrementalKeyType)
 	endVal := formatBigQueryValue(opts.IntervalEnd, opts.IncrementalKeyType)
 
@@ -1242,12 +1276,6 @@ func (d *BigQueryDestination) DeleteInsertTable(ctx context.Context, opts destin
 		quoteIdentifier(opts.IncrementalKey), startVal,
 		quoteIdentifier(opts.IncrementalKey), endVal,
 	)
-
-	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
-
-	if err := d.Exec(ctx, deleteSQL); err != nil {
-		return fmt.Errorf("failed to delete records: %w", err)
-	}
 
 	quotedCols := make([]string, len(opts.Columns))
 	for i, col := range opts.Columns {
@@ -1274,14 +1302,7 @@ func (d *BigQueryDestination) DeleteInsertTable(ctx context.Context, opts destin
 		selectClause,
 	)
 
-	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
-
-	if err := d.Exec(ctx, insertSQL); err != nil {
-		return fmt.Errorf("failed to insert records: %w", err)
-	}
-
-	config.Debug("[DELETE+INSERT] Delete+Insert completed successfully")
-	return nil
+	return deleteSQL, insertSQL
 }
 
 // SCD2Table performs SCD2 (Slowly Changing Dimensions Type 2) merge logic.
@@ -1619,11 +1640,71 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 	return sql.String()
 }
 
-// BeginTransaction begins a transaction.
-func (d *BigQueryDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
-	// BigQuery doesn't support traditional transactions
-	// Use MergeTable method instead for merge operations
-	return nil, errors.New("transactions not supported for BigQuery - use MergeTable for merge operations")
+func buildBigQueryTransactionScript(statements ...string) string {
+	var sql strings.Builder
+	sql.WriteString("BEGIN TRANSACTION;\n")
+	for _, statement := range statements {
+		statement = strings.TrimSpace(statement)
+		if statement == "" {
+			continue
+		}
+		sql.WriteString(statement)
+		if !strings.HasSuffix(statement, ";") {
+			sql.WriteString(";")
+		}
+		sql.WriteString("\n")
+	}
+	sql.WriteString("COMMIT TRANSACTION;")
+	return sql.String()
+}
+
+// BeginTransaction begins a BigQuery multi-statement transaction.
+func (d *BigQueryDestination) BeginTransaction(_ context.Context) (destination.Transaction, error) {
+	return &bigQueryTransaction{destination: d}, nil
+}
+
+type bigQueryTransaction struct {
+	destination *BigQueryDestination
+	statements  []string
+	closed      bool
+}
+
+func (t *bigQueryTransaction) Exec(_ context.Context, sql string, args ...interface{}) error {
+	if t.closed {
+		return errors.New("transaction is already closed")
+	}
+	if len(args) > 0 {
+		return errors.New("BigQuery transaction does not support positional query args")
+	}
+	t.statements = append(t.statements, sql)
+	return nil
+}
+
+func (t *bigQueryTransaction) Commit(ctx context.Context) error {
+	if t.closed {
+		return errors.New("transaction is already closed")
+	}
+	t.closed = true
+	if len(t.statements) == 0 {
+		return nil
+	}
+
+	transactionSQL := buildBigQueryTransactionScript(t.statements...)
+	job, err := t.destination.runTransactionScriptWithRetry(ctx, transactionSQL, "transaction")
+	if err != nil {
+		config.LogFailedQuery(transactionSQL, err)
+		if job == nil {
+			return fmt.Errorf("failed to start transaction job: %w", err)
+		}
+		return fmt.Errorf("transaction job failed (job %s): %w", jobRef(job), err)
+	}
+	return nil
+}
+
+func (t *bigQueryTransaction) Rollback(_ context.Context) error {
+	t.closed = true
+	t.statements = nil
+	return nil
 }
 
 // DropTable drops a table if it exists.

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -304,14 +304,36 @@ func TestSupportsStrategies(t *testing.T) {
 	}
 }
 
-func TestBeginTransaction_NotSupported(t *testing.T) {
+func TestBeginTransaction_ReturnsScriptTransaction(t *testing.T) {
 	dest := NewBigQueryDestination()
-	_, err := dest.BeginTransaction(context.Background())
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	tx, err := dest.BeginTransaction(context.Background())
+	if err != nil {
+		t.Fatalf("BeginTransaction returned error: %v", err)
 	}
-	if !contains(err.Error(), "transactions not supported") {
-		t.Fatalf("unexpected error: %v", err)
+
+	bqTx, ok := tx.(*bigQueryTransaction)
+	if !ok {
+		t.Fatalf("transaction type = %T, want *bigQueryTransaction", tx)
+	}
+
+	if err := bqTx.Exec(context.Background(), "DELETE FROM `p`.`d`.`t` WHERE TRUE"); err != nil {
+		t.Fatalf("Exec returned error: %v", err)
+	}
+	if err := bqTx.Exec(context.Background(), "INSERT INTO `p`.`d`.`t` SELECT * FROM `p`.`d`.`s`"); err != nil {
+		t.Fatalf("Exec returned error: %v", err)
+	}
+
+	got := buildBigQueryTransactionScript(bqTx.statements...)
+	want := "BEGIN TRANSACTION;\n" +
+		"DELETE FROM `p`.`d`.`t` WHERE TRUE;\n" +
+		"INSERT INTO `p`.`d`.`t` SELECT * FROM `p`.`d`.`s`;\n" +
+		"COMMIT TRANSACTION;"
+	if got != want {
+		t.Fatalf("transaction script =\n%s\nwant:\n%s", got, want)
+	}
+
+	if err := bqTx.Exec(context.Background(), "SELECT 1", 1); err == nil || !contains(err.Error(), "does not support positional query args") {
+		t.Fatalf("Exec with args error = %v", err)
 	}
 }
 
@@ -762,6 +784,32 @@ func TestFormatBigQueryValue(t *testing.T) {
 				t.Fatalf("formatBigQueryValue(%T) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildDeleteInsertTransactionScript(t *testing.T) {
+	dest := NewBigQueryDestination()
+	dest.projectID = "my-project"
+
+	opts := destination.DeleteInsertOptions{
+		StagingTable:       "staging_ds.staging_tbl",
+		TargetTable:        "target_ds.target_tbl",
+		IncrementalKey:     "ts",
+		IncrementalKeyType: schema.TypeInt64,
+		IntervalStart:      int64(1),
+		IntervalEnd:        int64(10),
+		Columns:            []string{"id", "ts", "name"},
+		PrimaryKeys:        []string{"id"},
+	}
+
+	deleteSQL, insertSQL := dest.buildDeleteInsertStatements("staging_ds", "staging_tbl", "target_ds", "target_tbl", opts)
+	got := buildBigQueryTransactionScript(deleteSQL, insertSQL)
+	want := "BEGIN TRANSACTION;\n" +
+		"DELETE FROM `my-project`.`target_ds`.`target_tbl` WHERE `ts` >= 1 AND `ts` <= 10;\n" +
+		"INSERT INTO `my-project`.`target_ds`.`target_tbl` (`id`, `ts`, `name`) SELECT `id`, `ts`, `name` FROM `my-project`.`staging_ds`.`staging_tbl` QUALIFY ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `ts` DESC) = 1;\n" +
+		"COMMIT TRANSACTION;"
+	if got != want {
+		t.Fatalf("transaction script =\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -3,10 +3,12 @@ package bigquery
 import (
 	"bufio"
 	"context"
+	cryptorand "crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +27,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 	"google.golang.org/api/option"
 )
+
+var queryJobJitter = randomQueryJobJitter
 
 const (
 	stagedGCSObjectChunkSize   = 32 * 1024 * 1024
@@ -754,12 +758,13 @@ func isRetryableLoadJobError(err error) bool {
 		strings.Contains(msg, "exceeded rate limits") ||
 		strings.Contains(msg, "jobbackenderror") ||
 		strings.Contains(msg, "backenderror") ||
-		strings.Contains(msg, "not found: dataset")
+		strings.Contains(msg, "not found: dataset") ||
+		isBigQueryConcurrentUpdateError(err)
 }
 
 func isRetryableLoadJobReason(reason string, message string) bool {
 	switch strings.ToLower(reason) {
-	case "ratelimitexceeded", "quotaexceeded", "backenderror", "jobbackenderror":
+	case "ratelimitexceeded", "quotaexceeded", "backenderror", "jobbackenderror", "aborted":
 		return true
 	}
 
@@ -768,7 +773,40 @@ func isRetryableLoadJobReason(reason string, message string) bool {
 		return true
 	}
 	return strings.Contains(msg, "exceeded rate limits") ||
-		strings.Contains(msg, "retrying the job may solve the problem")
+		strings.Contains(msg, "retrying the job may solve the problem") ||
+		strings.Contains(msg, "could not serialize access") ||
+		strings.Contains(msg, "concurrent update") ||
+		strings.Contains(msg, "transaction is aborted")
+}
+
+func retryDelayForQueryJob(attempt int, err error) time.Duration {
+	delay := time.Duration(attempt) * time.Second
+	if !isBigQueryConcurrentUpdateError(err) {
+		return delay
+	}
+
+	return delay + queryJobJitter(time.Duration(attempt+1)*time.Second)
+}
+
+func randomQueryJobJitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	n, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return time.Duration(time.Now().UnixNano() % int64(max))
+	}
+	return time.Duration(n.Int64())
+}
+
+func isBigQueryConcurrentUpdateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "could not serialize access") ||
+		strings.Contains(msg, "concurrent update") ||
+		strings.Contains(msg, "transaction is aborted")
 }
 
 func sleepWithContextForLoadJob(ctx context.Context, d time.Duration) error {

--- a/pkg/destination/bigquery/load_job_test.go
+++ b/pkg/destination/bigquery/load_job_test.go
@@ -498,8 +498,18 @@ func TestIsRetryableLoadJobError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "bigquery aborted transaction reason",
+			err:  gcbq.Error{Reason: "aborted", Message: "Transaction is aborted due to concurrent update"},
+			want: true,
+		},
+		{
 			name: "bigquery backend error message hint",
 			err:  gcbq.Error{Reason: "", Message: "The job encountered an error during execution. Retrying the job may solve the problem."},
+			want: true,
+		},
+		{
+			name: "bigquery concurrent update message",
+			err:  gcbq.Error{Reason: "invalidQuery", Message: "Could not serialize access to table due to concurrent update"},
 			want: true,
 		},
 		{
@@ -541,6 +551,35 @@ func TestIsRetryableLoadJobError(t *testing.T) {
 				t.Fatalf("isRetryableLoadJobError() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRetryDelayForQueryJobAddsJitterForConcurrentUpdates(t *testing.T) {
+	oldJitter := queryJobJitter
+	defer func() { queryJobJitter = oldJitter }()
+
+	var gotMax time.Duration
+	queryJobJitter = func(max time.Duration) time.Duration {
+		gotMax = max
+		return 123 * time.Millisecond
+	}
+
+	err := gcbq.Error{Reason: "aborted", Message: "Could not serialize access due to concurrent update"}
+	delay := retryDelayForQueryJob(2, err)
+	if gotMax != 3*time.Second {
+		t.Fatalf("jitter max = %v, want 3s", gotMax)
+	}
+	if delay != 2*time.Second+123*time.Millisecond {
+		t.Fatalf("delay = %v, want 2.123s", delay)
+	}
+
+	gotMax = 0
+	delay = retryDelayForQueryJob(2, gcbq.Error{Reason: "backendError", Message: "backend"})
+	if gotMax != 0 {
+		t.Fatalf("jitter called for non-concurrent error with max %v", gotMax)
+	}
+	if delay != 2*time.Second {
+		t.Fatalf("non-concurrent delay = %v, want 2s", delay)
 	}
 }
 

--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math"
 	"net/url"
@@ -273,56 +274,17 @@ func (d *ClickHouseDestination) MergeTable(ctx context.Context, opts destination
 func (d *ClickHouseDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
 	startOp := time.Now()
 
-	stagingDB, stagingName := d.parseTableName(opts.StagingTable)
-	targetDB, targetName := d.parseTableName(opts.TargetTable)
+	deleteSQL, insertSQL, targetDB, targetName := d.buildDeleteInsertStatements(opts)
 
-	quotedColumns := quoteColumns(opts.Columns)
-
-	deleteSQL := fmt.Sprintf(
-		"ALTER TABLE %s.%s DELETE WHERE %s >= '%v' AND %s <= '%v'",
-		quoteIdentifier(targetDB), quoteIdentifier(targetName), quoteIdentifier(opts.IncrementalKey), opts.IntervalStart, quoteIdentifier(opts.IncrementalKey), opts.IntervalEnd,
-	)
 	config.Debug("[CLICKHOUSE DELETE+INSERT] Executing DELETE: %s", deleteSQL)
-
 	if err := d.conn.Exec(ctx, deleteSQL); err != nil {
 		config.LogFailedQuery(deleteSQL, err)
 		return fmt.Errorf("failed to delete records: %w", err)
 	}
 
-	waitSQL := fmt.Sprintf(
-		"SELECT count() FROM system.mutations WHERE database = '%s' AND table = '%s' AND is_done = 0",
-		targetDB, targetName,
-	)
-	for i := 0; i < 60; i++ {
-		rows, err := d.conn.Query(ctx, waitSQL)
-		if err != nil {
-			break
-		}
-		var count uint64
-		if rows.Next() {
-			if err := rows.Scan(&count); err != nil {
-				_ = rows.Close()
-				break
-			}
-		}
-		if err := rows.Close(); err != nil {
-			break
-		}
-		if count == 0 {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	d.waitForMutations(ctx, targetDB, targetName)
 
-	insertSQL := fmt.Sprintf(
-		"INSERT INTO %s.%s (%s) SELECT %s FROM %s.%s",
-		quoteIdentifier(targetDB), quoteIdentifier(targetName),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quoteIdentifier(stagingDB), quoteIdentifier(stagingName),
-	)
 	config.Debug("[CLICKHOUSE DELETE+INSERT] Executing INSERT: %s", insertSQL)
-
 	if err := d.conn.Exec(ctx, insertSQL); err != nil {
 		config.LogFailedQuery(insertSQL, err)
 		return fmt.Errorf("failed to insert records: %w", err)
@@ -494,27 +456,8 @@ func (d *ClickHouseDestination) Exec(ctx context.Context, sql string, args ...in
 }
 
 func (d *ClickHouseDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
-	return &clickhouseTransaction{conn: d.conn}, nil
-}
-
-type clickhouseTransaction struct {
-	conn driver.Conn
-}
-
-func (t *clickhouseTransaction) Exec(ctx context.Context, sql string, args ...interface{}) error {
-	err := t.conn.Exec(ctx, sql, args...)
-	if err != nil {
-		config.LogFailedQuery(sql, err)
-	}
-	return err
-}
-
-func (t *clickhouseTransaction) Commit(ctx context.Context) error {
-	return nil
-}
-
-func (t *clickhouseTransaction) Rollback(ctx context.Context) error {
-	return nil
+	_ = ctx
+	return nil, errors.New("clickhouse destination does not support transactions")
 }
 
 func (d *ClickHouseDestination) SupportsReplaceStrategy() bool      { return true }
@@ -816,6 +759,75 @@ func mapDataTypeForColumn(col schema.Column, isPrimaryKey bool) string {
 
 func buildInsertSQL(database, table string, columns []string) string {
 	return fmt.Sprintf("INSERT INTO %s.%s (%s)", quoteIdentifier(database), quoteIdentifier(table), strings.Join(quoteColumns(columns), ", "))
+}
+
+func (d *ClickHouseDestination) buildDeleteInsertStatements(opts destination.DeleteInsertOptions) (string, string, string, string) {
+	stagingDB, stagingName := d.parseTableName(opts.StagingTable)
+	targetDB, targetName := d.parseTableName(opts.TargetTable)
+
+	quotedColumns := quoteColumns(opts.Columns)
+	colList := strings.Join(quotedColumns, ", ")
+	stagingFQN := fmt.Sprintf("%s.%s", quoteIdentifier(stagingDB), quoteIdentifier(stagingName))
+	targetFQN := fmt.Sprintf("%s.%s", quoteIdentifier(targetDB), quoteIdentifier(targetName))
+	incrementalKey := quoteIdentifier(opts.IncrementalKey)
+
+	deleteSQL := fmt.Sprintf(
+		"ALTER TABLE %s DELETE WHERE %s >= %s AND %s <= %s",
+		targetFQN,
+		incrementalKey,
+		formatClickHouseLiteral(opts.IntervalStart, opts.IncrementalKeyType),
+		incrementalKey,
+		formatClickHouseLiteral(opts.IntervalEnd, opts.IncrementalKeyType),
+	)
+
+	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFQN, incrementalKey)
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFQN, colList, selectClause)
+
+	return deleteSQL, insertSQL, targetDB, targetName
+}
+
+func formatClickHouseLiteral(value interface{}, dataType schema.DataType) string {
+	switch v := value.(type) {
+	case time.Time:
+		switch dataType {
+		case schema.TypeDate:
+			return fmt.Sprintf("toDate('%s')", v.Format("2006-01-02"))
+		case schema.TypeTimestamp, schema.TypeTimestampTZ:
+			return fmt.Sprintf("toDateTime64('%s', 6)", v.Format("2006-01-02 15:04:05.000000"))
+		default:
+			return fmt.Sprintf("'%s'", escapeClickHouseString(v.Format(time.RFC3339Nano)))
+		}
+	case string:
+		switch dataType {
+		case schema.TypeDate:
+			return fmt.Sprintf("toDate('%s')", escapeClickHouseString(v))
+		case schema.TypeTimestamp, schema.TypeTimestampTZ:
+			return fmt.Sprintf("toDateTime64('%s', 6)", escapeClickHouseString(v))
+		case schema.TypeString, schema.TypeUUID:
+			return fmt.Sprintf("'%s'", escapeClickHouseString(v))
+		default:
+			return fmt.Sprintf("'%s'", escapeClickHouseString(v))
+		}
+	case bool:
+		if v {
+			return "1"
+		}
+		return "0"
+	}
+
+	switch dataType {
+	case schema.TypeString, schema.TypeUUID:
+		return fmt.Sprintf("'%s'", escapeClickHouseString(fmt.Sprint(value)))
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func escapeClickHouseString(value string) string {
+	return strings.NewReplacer(
+		`\`, `\\`,
+		`'`, `\'`,
+	).Replace(value)
 }
 
 func quoteColumns(columns []string) []string {

--- a/pkg/destination/clickhouse/clickhouse_test.go
+++ b/pkg/destination/clickhouse/clickhouse_test.go
@@ -1,9 +1,12 @@
 package clickhouse
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -38,6 +41,26 @@ func TestValidateEngineType(t *testing.T) {
 				t.Errorf("mergeTree: got %v, want %v", gotMergeTree, tt.wantMergeTree)
 			}
 		})
+	}
+}
+
+func TestStrategySupport(t *testing.T) {
+	t.Parallel()
+	dest := NewClickHouseDestination()
+	if !dest.SupportsReplaceStrategy() {
+		t.Fatal("replace strategy should be supported")
+	}
+	if !dest.SupportsAppendStrategy() {
+		t.Fatal("append strategy should be supported")
+	}
+	if !dest.SupportsMergeStrategy() {
+		t.Fatal("merge strategy should be supported")
+	}
+	if !dest.SupportsDeleteInsertStrategy() {
+		t.Fatal("delete+insert strategy should be supported")
+	}
+	if !dest.SupportsSCD2Strategy() {
+		t.Fatal("scd2 strategy should be supported")
 	}
 }
 
@@ -247,5 +270,83 @@ func TestBuildCreateTableSQL_Engine(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildDeleteInsertStatements(t *testing.T) {
+	t.Parallel()
+
+	dest := &ClickHouseDestination{database: "default"}
+	start := time.Date(2026, 1, 2, 3, 4, 5, 6000, time.UTC)
+	end := time.Date(2026, 1, 3, 4, 5, 6, 7000, time.UTC)
+
+	deleteSQL, insertSQL, targetDB, targetName := dest.buildDeleteInsertStatements(destination.DeleteInsertOptions{
+		StagingTable:       "analytics.events_staging",
+		TargetTable:        "analytics.events",
+		IncrementalKey:     "event_time",
+		IncrementalKeyType: schema.TypeTimestamp,
+		IntervalStart:      start,
+		IntervalEnd:        end,
+		Columns:            []string{"id", "name", "event_time"},
+		PrimaryKeys:        []string{"id"},
+	})
+
+	if targetDB != "analytics" || targetName != "events" {
+		t.Fatalf("target = %s.%s, want analytics.events", targetDB, targetName)
+	}
+
+	wantDelete := "ALTER TABLE `analytics`.`events` DELETE WHERE `event_time` >= toDateTime64('2026-01-02 03:04:05.000006', 6) AND `event_time` <= toDateTime64('2026-01-03 04:05:06.000007', 6)"
+	if deleteSQL != wantDelete {
+		t.Fatalf("delete SQL = %q, want %q", deleteSQL, wantDelete)
+	}
+
+	wantParts := []string{
+		"INSERT INTO `analytics`.`events` (`id`, `name`, `event_time`)",
+		"ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `event_time` DESC)",
+		"FROM `analytics`.`events_staging`",
+		"WHERE __bruin_dedup_rn = 1",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(insertSQL, part) {
+			t.Fatalf("insert SQL missing %q:\n%s", part, insertSQL)
+		}
+	}
+}
+
+func TestFormatClickHouseLiteralTimeFallbackIsQuoted(t *testing.T) {
+	t.Parallel()
+
+	value := time.Date(2026, 1, 2, 3, 4, 5, 6000, time.UTC)
+
+	got := formatClickHouseLiteral(value, schema.TypeString)
+	want := "'2026-01-02T03:04:05.000006Z'"
+	if got != want {
+		t.Fatalf("literal = %q, want %q", got, want)
+	}
+}
+
+func TestFormatClickHouseLiteralStringFallbackIsQuotedAndEscaped(t *testing.T) {
+	t.Parallel()
+
+	got := formatClickHouseLiteral("2026-01-02' OR 1=1 --", schema.TypeJSON)
+	want := "'2026-01-02\\' OR 1=1 --'"
+	if got != want {
+		t.Fatalf("literal = %q, want %q", got, want)
+	}
+}
+
+func TestBeginTransactionUnsupported(t *testing.T) {
+	t.Parallel()
+
+	dest := NewClickHouseDestination()
+	tx, err := dest.BeginTransaction(context.Background())
+	if err == nil {
+		t.Fatal("BeginTransaction() error = nil, want unsupported error")
+	}
+	if tx != nil {
+		t.Fatalf("BeginTransaction() tx = %#v, want nil", tx)
+	}
+	if !strings.Contains(err.Error(), "does not support transactions") {
+		t.Fatalf("BeginTransaction() error = %v, want transaction unsupported error", err)
 	}
 }

--- a/pkg/destination/clickhouse/integration_test.go
+++ b/pkg/destination/clickhouse/integration_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/testutil"
+	destpkg "github.com/bruin-data/ingestr/pkg/destination"
+	chdest "github.com/bruin-data/ingestr/pkg/destination/clickhouse"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -205,7 +208,70 @@ func TestClickHouseDestination_Merge(t *testing.T) {
 	assert.Equal(t, 6, count2, "expected 6 rows after merge")
 }
 
+func TestClickHouseDestination_DeleteInsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, err := startClickHouseContainer(ctx)
+	if err != nil {
+		t.Skipf("failed to start ClickHouse container: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	targetTable := fmt.Sprintf("%s.dest_delete_insert_%d", clickhouseDB, time.Now().UnixNano())
+	stagingTable := fmt.Sprintf("%s.staging_delete_insert_%d", clickhouseDB, time.Now().UnixNano())
+	defer cleanupClickHouseTable(ctx, uri, targetTable)
+	defer cleanupClickHouseTable(ctx, uri, stagingTable)
+
+	createClickHouseTable(t, ctx, uri, targetTable)
+	insertClickHouseRow(t, ctx, uri, targetTable, 1, "User_1", 10.5, false)
+	insertClickHouseRow(t, ctx, uri, targetTable, 2, "User_2", 21.0, true)
+	insertClickHouseRow(t, ctx, uri, targetTable, 3, "User_3", 31.5, false)
+	insertClickHouseRow(t, ctx, uri, targetTable, 4, "User_4", 42.0, true)
+
+	createClickHouseTable(t, ctx, uri, stagingTable)
+	insertClickHouseRow(t, ctx, uri, stagingTable, 2, "Updated_2", 22.0, true)
+	insertClickHouseRow(t, ctx, uri, stagingTable, 3, "Updated_3a", 33.0, false)
+	insertClickHouseRow(t, ctx, uri, stagingTable, 3, "Updated_3b", 33.5, false)
+	insertClickHouseRow(t, ctx, uri, stagingTable, 5, "User_5", 52.5, false)
+
+	dest := chdest.NewClickHouseDestination()
+	require.NoError(t, dest.Connect(ctx, uri))
+	t.Cleanup(func() { _ = dest.Close(ctx) })
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destpkg.DeleteInsertOptions{
+		StagingTable:       stagingTable,
+		TargetTable:        targetTable,
+		IncrementalKey:     "id",
+		IncrementalKeyType: schema.TypeInt64,
+		IntervalStart:      int64(2),
+		IntervalEnd:        int64(5),
+		Columns:            []string{"id", "name", "score", "active"},
+		PrimaryKeys:        []string{"id"},
+	}))
+
+	assert.Equal(t, 4, countClickHouseRows(t, ctx, uri, targetTable))
+	assert.Equal(t, 1, countClickHouseRowsByID(t, ctx, uri, targetTable, 1))
+	assert.Equal(t, 1, countClickHouseRowsByID(t, ctx, uri, targetTable, 2))
+	assert.Equal(t, 1, countClickHouseRowsByID(t, ctx, uri, targetTable, 3))
+	assert.Equal(t, 0, countClickHouseRowsByID(t, ctx, uri, targetTable, 4))
+	assert.Equal(t, 1, countClickHouseRowsByID(t, ctx, uri, targetTable, 5))
+}
+
 func setupClickHouseSourceTable(t *testing.T, ctx context.Context, uri string, table string, numRows int) {
+	t.Helper()
+
+	createClickHouseTable(t, ctx, uri, table)
+
+	for i := 1; i <= numRows; i++ {
+		insertClickHouseRow(t, ctx, uri, table, i, fmt.Sprintf("User_%d", i), float64(i)*10.5, i%2 == 0)
+	}
+}
+
+func createClickHouseTable(t *testing.T, ctx context.Context, uri string, table string) {
 	t.Helper()
 
 	opts, err := clickhouse.ParseDSN(uri)
@@ -226,15 +292,6 @@ func setupClickHouseSourceTable(t *testing.T, ctx context.Context, uri string, t
 
 	_, err = db.ExecContext(ctx, createSQL)
 	require.NoError(t, err)
-
-	for i := 1; i <= numRows; i++ {
-		insertSQL := fmt.Sprintf(
-			"INSERT INTO %s VALUES (%d, 'User_%d', %f, %s)",
-			table, i, i, float64(i)*10.5, boolStr(i%2 == 0),
-		)
-		_, err = db.ExecContext(ctx, insertSQL)
-		require.NoError(t, err)
-	}
 }
 
 func insertClickHouseRow(t *testing.T, ctx context.Context, uri string, table string, id int, name string, score float64, active bool) {
@@ -265,6 +322,21 @@ func countClickHouseRows(t *testing.T, ctx context.Context, uri, table string) i
 
 	var count int
 	err = db.QueryRowContext(ctx, fmt.Sprintf("SELECT count() FROM %s", table)).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func countClickHouseRowsByID(t *testing.T, ctx context.Context, uri, table string, id int) int {
+	t.Helper()
+
+	opts, err := clickhouse.ParseDSN(uri)
+	require.NoError(t, err)
+
+	db := clickhouse.OpenDB(opts)
+	defer func() { _ = db.Close() }()
+
+	var count int
+	err = db.QueryRowContext(ctx, fmt.Sprintf("SELECT count() FROM %s WHERE id = %d", table, id)).Scan(&count)
 	require.NoError(t, err)
 	return count
 }

--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -3,6 +3,7 @@ package cratedb
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -291,45 +292,7 @@ func (d *CrateDBDestination) MergeTable(ctx context.Context, opts destination.Me
 }
 
 func (d *CrateDBDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
-	startOp := time.Now()
-
-	d.refreshTable(ctx, opts.StagingTable)
-
-	quotedColumns := quoteColumns(opts.Columns)
-	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
-	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
-
-	deleteSQL := fmt.Sprintf(
-		`DELETE FROM %s WHERE %s >= $1 AND %s <= $2`,
-		quotedTargetTable, destination.QuoteIdentifier(opts.IncrementalKey), destination.QuoteIdentifier(opts.IncrementalKey),
-	)
-	config.Debug("[CRATEDB DELETE+INSERT] Executing DELETE: %s", deleteSQL)
-
-	if _, err := d.pool.Exec(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
-		config.LogFailedQuery(deleteSQL, err)
-		return fmt.Errorf("failed to delete records: %w", err)
-	}
-
-	d.refreshTable(ctx, opts.TargetTable)
-
-	insertSQL := fmt.Sprintf(
-		`INSERT INTO %s (%s) SELECT %s FROM %s`,
-		quotedTargetTable,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quotedStagingTable,
-	)
-	config.Debug("[CRATEDB DELETE+INSERT] Executing INSERT: %s", insertSQL)
-
-	if _, err := d.pool.Exec(ctx, insertSQL); err != nil {
-		config.LogFailedQuery(insertSQL, err)
-		return fmt.Errorf("failed to insert records: %w", err)
-	}
-
-	d.refreshTable(ctx, opts.TargetTable)
-
-	config.Debug("[CRATEDB DELETE+INSERT] Completed in %v", time.Since(startOp))
-	return nil
+	return errors.New("delete+insert strategy is not supported for cratedb destination")
 }
 
 func (d *CrateDBDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
@@ -488,23 +451,8 @@ func (d *CrateDBDestination) Exec(ctx context.Context, sql string, args ...any) 
 }
 
 func (d *CrateDBDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
-	return &noopTransaction{pool: d.pool}, nil
+	return nil, errors.New("transactions are not supported for cratedb destination")
 }
-
-type noopTransaction struct {
-	pool *pgxpool.Pool
-}
-
-func (t *noopTransaction) Exec(ctx context.Context, sql string, args ...any) error {
-	_, err := t.pool.Exec(ctx, sql, args...)
-	if err != nil {
-		config.LogFailedQuery(sql, err)
-	}
-	return err
-}
-
-func (t *noopTransaction) Commit(_ context.Context) error   { return nil }
-func (t *noopTransaction) Rollback(_ context.Context) error { return nil }
 
 func (d *CrateDBDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	schemaName, tableName := parseSchemaTable(table)
@@ -555,7 +503,7 @@ func (d *CrateDBDestination) GetScheme() string                  { return "crate
 func (d *CrateDBDestination) SupportsReplaceStrategy() bool      { return true }
 func (d *CrateDBDestination) SupportsAppendStrategy() bool       { return true }
 func (d *CrateDBDestination) SupportsMergeStrategy() bool        { return true }
-func (d *CrateDBDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *CrateDBDestination) SupportsDeleteInsertStrategy() bool { return false }
 func (d *CrateDBDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *CrateDBDestination) SupportsAtomicSwap() bool           { return false }
 

--- a/pkg/destination/cratedb/cratedb_test.go
+++ b/pkg/destination/cratedb/cratedb_test.go
@@ -1,9 +1,11 @@
 package cratedb
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,9 +29,30 @@ func TestStrategySupport(t *testing.T) {
 	assert.True(t, d.SupportsReplaceStrategy())
 	assert.True(t, d.SupportsAppendStrategy())
 	assert.True(t, d.SupportsMergeStrategy())
-	assert.True(t, d.SupportsDeleteInsertStrategy())
+	assert.False(t, d.SupportsDeleteInsertStrategy())
 	assert.True(t, d.SupportsSCD2Strategy())
 	assert.False(t, d.SupportsAtomicSwap())
+}
+
+func TestDeleteInsertUnsupported(t *testing.T) {
+	t.Parallel()
+	d := NewCrateDBDestination()
+	err := d.DeleteInsertTable(t.Context(), destination.DeleteInsertOptions{})
+	if err == nil || !strings.Contains(err.Error(), "delete+insert strategy is not supported") {
+		t.Fatalf("DeleteInsertTable error = %v, want unsupported error", err)
+	}
+}
+
+func TestBeginTransactionUnsupported(t *testing.T) {
+	t.Parallel()
+	d := NewCrateDBDestination()
+	tx, err := d.BeginTransaction(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "transactions are not supported") {
+		t.Fatalf("BeginTransaction error = %v, want unsupported error", err)
+	}
+	if tx != nil {
+		t.Fatalf("BeginTransaction tx = %T, want nil", tx)
+	}
 }
 
 func TestParseSchemaTable(t *testing.T) {

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -443,7 +443,20 @@ func (d *DatabricksDestination) MergeTable(ctx context.Context, opts destination
 func (d *DatabricksDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
 	startOp := time.Now()
 
-	// Staging table is always in ingestr_staging schema
+	deleteSQL, insertSQL, atomicSQL := d.buildDeleteInsertSQL(opts)
+	config.Debug("[DATABRICKS] Executing DELETE: %s", deleteSQL)
+	config.Debug("[DATABRICKS] Executing INSERT: %s", insertSQL)
+
+	if err := d.executeStatement(ctx, atomicSQL); err != nil {
+		config.LogFailedQuery(atomicSQL, err)
+		return fmt.Errorf("failed to execute atomic delete+insert: %w", err)
+	}
+
+	config.Debug("[DATABRICKS] Delete+Insert completed in %v", time.Since(startOp))
+	return nil
+}
+
+func (d *DatabricksDestination) buildDeleteInsertSQL(opts destination.DeleteInsertOptions) (string, string, string) {
 	_, stagingName := d.parseTableName(opts.StagingTable)
 	targetSchema, targetName := d.parseTableName(opts.TargetTable)
 
@@ -457,26 +470,13 @@ func (d *DatabricksDestination) DeleteInsertTable(ctx context.Context, opts dest
 		"DELETE FROM %s WHERE %s >= %s AND %s <= %s",
 		targetFull, quoteIdentifier(opts.IncrementalKey), startVal, quoteIdentifier(opts.IncrementalKey), endVal,
 	)
-	config.Debug("[DATABRICKS] Executing DELETE: %s", deleteSQL)
-
-	if err := d.executeStatement(ctx, deleteSQL); err != nil {
-		config.LogFailedQuery(deleteSQL, err)
-		return fmt.Errorf("failed to delete records: %w", err)
-	}
 
 	colList := strings.Join(quoteColumns(opts.Columns), ", ")
-	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
 	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFull, quoteIdentifier(opts.IncrementalKey))
 	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFull, colList, selectClause)
-	config.Debug("[DATABRICKS] Executing INSERT: %s", insertSQL)
 
-	if err := d.executeStatement(ctx, insertSQL); err != nil {
-		config.LogFailedQuery(insertSQL, err)
-		return fmt.Errorf("failed to insert records: %w", err)
-	}
-
-	config.Debug("[DATABRICKS] Delete+Insert completed in %v", time.Since(startOp))
-	return nil
+	atomicSQL := fmt.Sprintf("BEGIN ATOMIC\n  %s;\n  %s;\nEND;", deleteSQL, insertSQL)
+	return deleteSQL, insertSQL, atomicSQL
 }
 
 func (d *DatabricksDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
@@ -525,24 +525,8 @@ func (d *DatabricksDestination) Exec(ctx context.Context, sql string, args ...in
 }
 
 func (d *DatabricksDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
-	return &databricksTransaction{dest: d, ctx: ctx}, nil
-}
-
-type databricksTransaction struct {
-	dest *DatabricksDestination
-	ctx  context.Context
-}
-
-func (t *databricksTransaction) Exec(ctx context.Context, sql string, args ...interface{}) error {
-	return t.dest.Exec(ctx, sql, args...)
-}
-
-func (t *databricksTransaction) Commit(ctx context.Context) error {
-	return nil
-}
-
-func (t *databricksTransaction) Rollback(ctx context.Context) error {
-	return nil
+	_ = ctx
+	return nil, errors.New("databricks destination does not support transactions")
 }
 
 func (d *DatabricksDestination) SupportsReplaceStrategy() bool      { return true }

--- a/pkg/destination/databricks/databricks_test.go
+++ b/pkg/destination/databricks/databricks_test.go
@@ -1,0 +1,62 @@
+package databricks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+)
+
+func TestBuildDeleteInsertSQLUsesAtomicBlock(t *testing.T) {
+	t.Parallel()
+
+	dest := &DatabricksDestination{catalog: "main"}
+	if !dest.SupportsDeleteInsertStrategy() {
+		t.Fatal("SupportsDeleteInsertStrategy() = false, want true")
+	}
+
+	deleteSQL, insertSQL, atomicSQL := dest.buildDeleteInsertSQL(destination.DeleteInsertOptions{
+		StagingTable:   "scratch.orders_di",
+		TargetTable:    "analytics.orders",
+		IncrementalKey: "updated_at",
+		IntervalStart:  "2026-01-01",
+		IntervalEnd:    "2026-01-31",
+		Columns:        []string{"id", "name", "updated_at"},
+		PrimaryKeys:    []string{"id"},
+	})
+
+	if want := "DELETE FROM `main`.`analytics`.`orders` WHERE `updated_at` >= '2026-01-01' AND `updated_at` <= '2026-01-31'"; deleteSQL != want {
+		t.Fatalf("deleteSQL = %q, want %q", deleteSQL, want)
+	}
+	for _, want := range []string{
+		"INSERT INTO `main`.`analytics`.`orders` (`id`, `name`, `updated_at`)",
+		"ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC)",
+		"FROM `main`.`ingestr_staging`.`orders_di`",
+	} {
+		if !strings.Contains(insertSQL, want) {
+			t.Fatalf("insertSQL missing %q:\n%s", want, insertSQL)
+		}
+	}
+
+	wantAtomic := "BEGIN ATOMIC\n  " + deleteSQL + ";\n  " + insertSQL + ";\nEND;"
+	if atomicSQL != wantAtomic {
+		t.Fatalf("atomicSQL = %q, want %q", atomicSQL, wantAtomic)
+	}
+}
+
+func TestBeginTransactionUnsupported(t *testing.T) {
+	t.Parallel()
+
+	dest := NewDatabricksDestination()
+	tx, err := dest.BeginTransaction(context.Background())
+	if err == nil {
+		t.Fatal("BeginTransaction() error = nil, want unsupported error")
+	}
+	if tx != nil {
+		t.Fatalf("BeginTransaction() tx = %#v, want nil", tx)
+	}
+	if !strings.Contains(err.Error(), "does not support transactions") {
+		t.Fatalf("BeginTransaction() error = %v, want transaction unsupported error", err)
+	}
+}

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -415,10 +415,7 @@ func (d *FabricDestination) DeleteInsertTable(ctx context.Context, opts destinat
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE %s >= @p1 AND %s <= @p2",
-		quoteTable(opts.TargetTable), quoteColumn(opts.IncrementalKey), quoteColumn(opts.IncrementalKey),
-	)
+	deleteSQL := buildDeleteInsertDeleteSQL(opts.TargetTable, opts.IncrementalKey)
 	config.Debug("[Fabric DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
 	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
@@ -443,6 +440,13 @@ func (d *FabricDestination) DeleteInsertTable(ctx context.Context, opts destinat
 
 	config.Debug("[Fabric DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
 	return nil
+}
+
+func buildDeleteInsertDeleteSQL(targetTable, incrementalKey string) string {
+	return fmt.Sprintf(
+		"DELETE FROM %s WITH (TABLOCKX, HOLDLOCK) WHERE %s >= @p1 AND %s <= @p2",
+		quoteTable(targetTable), quoteColumn(incrementalKey), quoteColumn(incrementalKey),
+	)
 }
 
 // SCD2Table performs SCD2 (Slowly Changing Dimensions Type 2) merge logic.

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -2,6 +2,7 @@ package fabric
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -114,5 +115,16 @@ func TestURIToConnString(t *testing.T) {
 				t.Errorf("tenant_id should not appear in DSN query, got %q", q.Get("tenant_id"))
 			}
 		})
+	}
+}
+
+func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
+	sql := buildDeleteInsertDeleteSQL("dbo.events", "updated_at")
+
+	if !strings.Contains(sql, "DELETE FROM [dbo].[events] WITH (TABLOCKX, HOLDLOCK)") {
+		t.Fatalf("delete SQL missing table lock: %s", sql)
+	}
+	if !strings.Contains(sql, "[updated_at] >= @p1") || !strings.Contains(sql, "[updated_at] <= @p2") {
+		t.Fatalf("delete SQL missing interval predicate: %s", sql)
 	}
 }

--- a/pkg/destination/maxcompute/maxcompute.go
+++ b/pkg/destination/maxcompute/maxcompute.go
@@ -242,7 +242,8 @@ func (d *MaxComputeDestination) BeginTransaction(ctx context.Context) (destinati
 		}
 		return &sqlTransaction{tx: tx}, nil
 	}
-	return &maxComputeTransaction{dest: d}, nil
+	_ = ctx
+	return nil, errors.New("MaxCompute destination does not support transactions")
 }
 
 func (d *MaxComputeDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
@@ -628,24 +629,6 @@ func containsFold(values []string, needle string) bool {
 		}
 	}
 	return false
-}
-
-type maxComputeTransaction struct {
-	dest *MaxComputeDestination
-}
-
-func (t *maxComputeTransaction) Exec(ctx context.Context, sql string, args ...interface{}) error {
-	return t.dest.Exec(ctx, sql, args...)
-}
-
-func (t *maxComputeTransaction) Commit(ctx context.Context) error {
-	_ = ctx
-	return nil
-}
-
-func (t *maxComputeTransaction) Rollback(ctx context.Context) error {
-	_ = ctx
-	return nil
 }
 
 type sqlTransaction struct {

--- a/pkg/destination/maxcompute/maxcompute_test.go
+++ b/pkg/destination/maxcompute/maxcompute_test.go
@@ -1,14 +1,17 @@
 package maxcompute
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-odps-go-sdk/odps/restclient"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
 )
 
 func TestExtractValueDefaultUsesRowValue(t *testing.T) {
@@ -47,5 +50,35 @@ func TestIsNotFoundErrorRequiresTypedHTTP404(t *testing.T) {
 	}
 	if isNotFoundError(errors.New("DNS: host not found")) {
 		t.Fatal("isNotFoundError should not match arbitrary not found text")
+	}
+}
+
+func TestBeginTransactionUnsupportedWithoutEmulator(t *testing.T) {
+	t.Parallel()
+
+	dest := NewMaxComputeDestination()
+	tx, err := dest.BeginTransaction(context.Background())
+	if err == nil {
+		t.Fatal("BeginTransaction() error = nil, want unsupported error")
+	}
+	if tx != nil {
+		t.Fatalf("BeginTransaction() tx = %#v, want nil", tx)
+	}
+	if !strings.Contains(err.Error(), "does not support transactions") {
+		t.Fatalf("BeginTransaction() error = %v, want transaction unsupported error", err)
+	}
+}
+
+func TestDeleteInsertUnsupported(t *testing.T) {
+	t.Parallel()
+
+	dest := NewMaxComputeDestination()
+	if dest.SupportsDeleteInsertStrategy() {
+		t.Fatal("SupportsDeleteInsertStrategy() = true, want false")
+	}
+
+	err := dest.DeleteInsertTable(context.Background(), destination.DeleteInsertOptions{})
+	if err == nil || !strings.Contains(err.Error(), "does not support delete+insert strategy") {
+		t.Fatalf("DeleteInsertTable() error = %v, want unsupported error", err)
 	}
 }

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -489,10 +489,7 @@ func (d *MSSQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE %s >= @p1 AND %s <= @p2",
-		quoteTable(opts.TargetTable), quoteColumn(opts.IncrementalKey), quoteColumn(opts.IncrementalKey),
-	)
+	deleteSQL := buildDeleteInsertDeleteSQL(opts.TargetTable, opts.IncrementalKey)
 	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
 	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
@@ -517,6 +514,13 @@ func (d *MSSQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 
 	config.Debug("[DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
 	return nil
+}
+
+func buildDeleteInsertDeleteSQL(targetTable, incrementalKey string) string {
+	return fmt.Sprintf(
+		"DELETE FROM %s WITH (TABLOCKX, HOLDLOCK) WHERE %s >= @p1 AND %s <= @p2",
+		quoteTable(targetTable), quoteColumn(incrementalKey), quoteColumn(incrementalKey),
+	)
 }
 
 // SCD2Table performs SCD2 (Slowly Changing Dimensions Type 2) merge logic.

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -35,6 +35,14 @@ func TestBuildCreateTableSQL_CapsLongStringPrimaryKeyLength(t *testing.T) {
 	assertContains(t, sql, "[name] NVARCHAR(1000)")
 }
 
+func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
+	sql := buildDeleteInsertDeleteSQL("dbo.events", "updated_at")
+
+	assertContains(t, sql, "DELETE FROM [dbo].[events] WITH (TABLOCKX, HOLDLOCK)")
+	assertContains(t, sql, "[updated_at] >= @p1")
+	assertContains(t, sql, "[updated_at] <= @p2")
+}
+
 func TestDialectTypeNameUsesDestinationTypeMapping(t *testing.T) {
 	dialect := &Dialect{}
 	columns := []schema.Column{

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"hash/fnv"
 	"net/url"
 	"strings"
 	"time"
@@ -431,7 +432,25 @@ func (d *MySQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 
 	quotedColumns := quoteColumns(opts.Columns)
 
-	tx, err := d.db.BeginTx(ctx, nil)
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	releaseLock, err := acquireDeleteInsertLock(ctx, conn, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := releaseLock(releaseCtx); err != nil {
+			config.Debug("[DELETE+INSERT] Warning: failed to release target table lock: %v", err)
+		}
+	}()
+
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -465,6 +484,34 @@ func (d *MySQLDestination) DeleteInsertTable(ctx context.Context, opts destinati
 
 	config.Debug("[DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
 	return nil
+}
+
+func acquireDeleteInsertLock(ctx context.Context, conn *sql.Conn, targetTable string) (func(context.Context) error, error) {
+	lockName := deleteInsertLockName(targetTable)
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 60)", lockName).Scan(&acquired); err != nil {
+		return nil, fmt.Errorf("failed to acquire target table lock: %w", err)
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		return nil, fmt.Errorf("timed out acquiring target table lock")
+	}
+
+	return func(ctx context.Context) error {
+		var released sql.NullInt64
+		if err := conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released); err != nil {
+			return fmt.Errorf("failed to release target table lock: %w", err)
+		}
+		if !released.Valid || released.Int64 != 1 {
+			return fmt.Errorf("target table lock was not released")
+		}
+		return nil
+	}, nil
+}
+
+func deleteInsertLockName(targetTable string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(targetTable))
+	return fmt.Sprintf("ingestr_di_%016x", h.Sum64())
 }
 
 // SCD2Table performs SCD2 (Slowly Changing Dimensions Type 2) merge logic.

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -394,3 +394,14 @@ func TestMySQLDestination_StrategySupport(t *testing.T) {
 	assert.True(t, dest.SupportsDeleteInsertStrategy())
 	assert.True(t, dest.SupportsAtomicSwap())
 }
+
+func TestDeleteInsertLockName(t *testing.T) {
+	first := deleteInsertLockName("analytics.orders")
+	second := deleteInsertLockName("analytics.orders")
+	other := deleteInsertLockName("analytics.customers")
+
+	assert.Equal(t, first, second)
+	assert.NotEqual(t, first, other)
+	assert.LessOrEqual(t, len(first), 64)
+	assert.Contains(t, first, "ingestr_di_")
+}

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -3,12 +3,16 @@ package onelake
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
+	datalakefile "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/file"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/parquet"
@@ -29,7 +33,12 @@ const (
 	modeFiles
 )
 
-const defaultLayout = "{load_id}.{file_id}.{ext}"
+const (
+	defaultLayout          = "{load_id}.{file_id}.{ext}"
+	maxDeltaCommitAttempts = 5
+)
+
+var errDeltaCommitConflict = errors.New("delta commit version already exists")
 
 // OneLakeDestination writes data to a Microsoft Fabric OneLake lakehouse. It can
 // target the lakehouse "Tables" area (written as a Delta table so it is queryable
@@ -38,6 +47,8 @@ type OneLakeDestination struct {
 	workspace string
 	lakehouse string
 	client    *adlsutil.DataLakeClient
+	cred      azcore.TokenCredential
+	sasToken  string
 	layout    string
 
 	mu          sync.Mutex
@@ -107,6 +118,8 @@ func (d *OneLakeDestination) Connect(ctx context.Context, uri string) error {
 
 	d.workspace = parsed.workspace
 	d.lakehouse = parsed.lakehouse
+	d.cred = nil
+	d.sasToken = parsed.sasToken
 	d.layout = parsed.layout
 	if d.layout == "" {
 		d.layout = defaultLayout
@@ -119,6 +132,7 @@ func (d *OneLakeDestination) Connect(ctx context.Context, uri string) error {
 		if err != nil {
 			return err
 		}
+		d.cred = cred
 		d.client = adlsutil.NewDataLakeClientWithToken(adlsutil.OneLakeAccountName, adlsutil.OneLakeDNSSuffix, cred)
 	}
 
@@ -320,33 +334,115 @@ func (d *OneLakeDestination) writeTablesMode(ctx context.Context, data []byte) e
 	adds := []deltaAddFile{{Path: dataFile, Size: int64(len(data))}}
 	nowMillis := time.Now().UnixMilli()
 
+	for attempt := 0; attempt < maxDeltaCommitAttempts; attempt++ {
+		version, err := d.nextDeltaVersion(ctx, logDir)
+		if err != nil {
+			return err
+		}
+
+		var commit []byte
+		if version == 0 {
+			commit, err = buildInitialCommit(cols, adds, uuid.New().String(), nowMillis)
+		} else {
+			commit, err = buildAppendCommit(adds, nowMillis)
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := d.uploadDeltaCommit(ctx, logDir, version, commit); err != nil {
+			if errors.Is(err, errDeltaCommitConflict) {
+				config.Debug("[ONELAKE] Delta commit version %d already exists; retrying append commit", version)
+				continue
+			}
+			return err
+		}
+		config.Debug("[ONELAKE] Committed delta version %d to %s", version, tableDir)
+		return nil
+	}
+
+	return fmt.Errorf("failed to commit delta table after %d attempts: %w", maxDeltaCommitAttempts, errDeltaCommitConflict)
+}
+
+func (d *OneLakeDestination) uploadDeltaCommit(ctx context.Context, logDir string, version int64, commit []byte) error {
+	commitPath := logDir + "/" + commitFileName(version)
+	if err := d.client.EnsureDirectories(ctx, d.workspace, logDir); err != nil {
+		return fmt.Errorf("failed to prepare delta log directory: %w", err)
+	}
+
+	tempPath := deltaCommitTempPath(logDir)
+	if err := d.client.UploadBuffer(ctx, d.workspace, tempPath, commit); err != nil {
+		return fmt.Errorf("failed to upload temporary delta commit %s: %w", tempPath, err)
+	}
+
+	tempFileClient, err := d.newOneLakeFileClient(tempPath)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tempFileClient.Rename(ctx, commitPath, deltaCommitRenameOptions()); err != nil {
+		if _, deleteErr := tempFileClient.Delete(ctx, nil); deleteErr != nil {
+			config.Debug("[ONELAKE] Failed to delete temporary delta commit %s: %v", tempPath, deleteErr)
+		}
+		if isDeltaCommitConflict(err) {
+			return errDeltaCommitConflict
+		}
+		return fmt.Errorf("failed to publish delta commit %s: %w", commitPath, err)
+	}
+	return nil
+}
+
+func (d *OneLakeDestination) newOneLakeFileClient(path string) (*datalakefile.Client, error) {
+	pathURL, err := adlsutil.PathURLWithSuffix(adlsutil.OneLakeAccountName, adlsutil.OneLakeDNSSuffix, d.workspace, path)
+	if err != nil {
+		return nil, err
+	}
+	if d.sasToken != "" {
+		return datalakefile.NewClientWithNoCredential(adlsutil.AppendSASToken(pathURL, d.sasToken), nil)
+	}
+	if d.cred == nil {
+		return nil, fmt.Errorf("OneLake destination is not connected")
+	}
+	return datalakefile.NewClient(pathURL, d.cred, nil)
+}
+
+func deltaCommitRenameOptions() *datalakefile.RenameOptions {
+	etagAny := azcore.ETagAny
+	return &datalakefile.RenameOptions{
+		AccessConditions: &datalakefile.AccessConditions{
+			ModifiedAccessConditions: &datalakefile.ModifiedAccessConditions{
+				IfNoneMatch: &etagAny,
+			},
+		},
+	}
+}
+
+func deltaCommitTempPath(logDir string) string {
+	tableDir := strings.TrimSuffix(logDir, "/_delta_log")
+	return tableDir + "/_bruin_delta_tmp/" + uuid.New().String() + ".tmp"
+}
+
+func isDeltaCommitConflict(err error) bool {
+	return datalakeerror.HasCode(
+		err,
+		datalakeerror.ConditionNotMet,
+		datalakeerror.PathAlreadyExists,
+		datalakeerror.ResourceAlreadyExists,
+	)
+}
+
+func (d *OneLakeDestination) nextDeltaVersion(ctx context.Context, logDir string) (int64, error) {
 	version := int64(0)
-	var commit []byte
 	if !d.dropFirst {
 		versions, err := d.client.ListLogVersions(ctx, d.workspace, logDir)
 		if err != nil {
-			return fmt.Errorf("failed to inspect delta log: %w", err)
+			return 0, fmt.Errorf("failed to inspect delta log: %w", err)
 		}
 		if len(versions) > 0 {
 			version = versions[len(versions)-1] + 1
 		}
 	}
-
-	if version == 0 {
-		commit, err = buildInitialCommit(cols, adds, uuid.New().String(), nowMillis)
-	} else {
-		commit, err = buildAppendCommit(adds, nowMillis)
-	}
-	if err != nil {
-		return err
-	}
-
-	commitPath := logDir + "/" + commitFileName(version)
-	if err := d.client.UploadBuffer(ctx, d.workspace, commitPath, commit); err != nil {
-		return fmt.Errorf("failed to write delta commit: %w", err)
-	}
-	config.Debug("[ONELAKE] Committed delta version %d to %s", version, tableDir)
-	return nil
+	return version, nil
 }
 
 // columns returns the schema columns, deriving them from the Arrow schema when an
@@ -435,73 +531,97 @@ func (d *OneLakeDestination) readTable(ctx context.Context, table, op string) (s
 }
 
 func (d *OneLakeDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
-	tDir, tSnap, tBatches, err := d.readTable(ctx, opts.TargetTable, "merge")
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(tBatches)
-	_, _, sBatches, err := d.readTable(ctx, opts.StagingTable, "merge")
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(sBatches)
-
-	merged, err := mergeBatches(ctx, tBatches, sBatches, opts.PrimaryKeys)
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(merged)
-
-	return d.commitRewrite(ctx, tDir, tSnap, merged, "MERGE")
+	return d.rewriteTableWithRetry(ctx, opts.TargetTable, opts.StagingTable, "merge", "MERGE", func(target, staging []arrow.RecordBatch) ([]arrow.RecordBatch, error) {
+		return mergeBatches(ctx, target, staging, opts.PrimaryKeys)
+	})
 }
 
 func (d *OneLakeDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
-	tDir, tSnap, tBatches, err := d.readTable(ctx, opts.TargetTable, "delete+insert")
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(tBatches)
-	_, _, sBatches, err := d.readTable(ctx, opts.StagingTable, "delete+insert")
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(sBatches)
-
-	result, err := deleteInsertBatches(ctx, tBatches, sBatches, opts)
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(result)
-
-	return d.commitRewrite(ctx, tDir, tSnap, result, "DELETE+INSERT")
+	return d.rewriteTableWithRetry(ctx, opts.TargetTable, opts.StagingTable, "delete+insert", "DELETE+INSERT", func(target, staging []arrow.RecordBatch) ([]arrow.RecordBatch, error) {
+		return deleteInsertBatches(ctx, target, staging, opts)
+	})
 }
 
 func (d *OneLakeDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
-	tDir, tSnap, tBatches, err := d.readTable(ctx, opts.TargetTable, "scd2")
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(tBatches)
-	_, _, sBatches, err := d.readTable(ctx, opts.StagingTable, "scd2")
+	return d.rewriteTableWithRetry(ctx, opts.TargetTable, opts.StagingTable, "scd2", "SCD2", func(target, staging []arrow.RecordBatch) ([]arrow.RecordBatch, error) {
+		return scd2Batches(ctx, target, staging, opts)
+	})
+}
+
+func (d *OneLakeDestination) rewriteTableWithRetry(ctx context.Context, targetTable, stagingTable, readOp, commitOp string, transform func(target, staging []arrow.RecordBatch) ([]arrow.RecordBatch, error)) error {
+	_, _, sBatches, err := d.readTable(ctx, stagingTable, readOp)
 	if err != nil {
 		return err
 	}
 	defer releaseBatches(sBatches)
 
-	result, err := scd2Batches(ctx, tBatches, sBatches, opts)
-	if err != nil {
+	dataFile := fmt.Sprintf("part-00000-%s.c000.snappy.parquet", uuid.New().String())
+	var lastConflict error
+	for attempt := 0; attempt < maxDeltaCommitAttempts; attempt++ {
+		tDir, tSnap, tBatches, err := d.readTable(ctx, targetTable, readOp)
+		if err != nil {
+			return err
+		}
+
+		result, err := transform(tBatches, sBatches)
+		releaseBatches(tBatches)
+		if err != nil {
+			return err
+		}
+
+		rewrite, err := d.uploadRewriteData(ctx, tDir, dataFile, result)
+		releaseBatches(result)
+		if err != nil {
+			return err
+		}
+
+		err = d.commitRewrite(ctx, tDir, tSnap, rewrite, commitOp)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, errDeltaCommitConflict) {
+			lastConflict = err
+			config.Debug("[ONELAKE] Delta commit conflict during %s; retrying from latest snapshot", readOp)
+			continue
+		}
 		return err
 	}
-	defer releaseBatches(result)
 
-	return d.commitRewrite(ctx, tDir, tSnap, result, "SCD2")
+	return fmt.Errorf("failed to commit %s after %d attempts: %w", readOp, maxDeltaCommitAttempts, lastConflict)
 }
 
-// commitRewrite writes the given batches as a single new Parquet data file and
-// commits a new Delta version that removes the prior data files and adds the new
-// one (copy-on-write). If the table did not exist, it writes version 0.
-func (d *OneLakeDestination) commitRewrite(ctx context.Context, tableDir string, snap *deltaSnapshot, batches []arrow.RecordBatch, operation string) error {
-	if len(batches) == 0 && (snap == nil || !snap.exists) {
+type rewriteData struct {
+	adds []deltaAddFile
+	cols []schema.Column
+}
+
+func (d *OneLakeDestination) uploadRewriteData(ctx context.Context, tableDir, dataFile string, batches []arrow.RecordBatch) (*rewriteData, error) {
+	if len(batches) == 0 {
+		return &rewriteData{}, nil
+	}
+
+	data, arrowSchema, err := writeBatchesToParquet(batches)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.client.UploadBuffer(ctx, d.workspace, tableDir+"/"+dataFile, data); err != nil {
+		return nil, fmt.Errorf("failed to upload data file: %w", err)
+	}
+
+	return &rewriteData{
+		adds: []deltaAddFile{{Path: dataFile, Size: int64(len(data))}},
+		cols: arrowSchemaToColumns(arrowSchema),
+	}, nil
+}
+
+// commitRewrite commits a new Delta version that removes the prior data files
+// and adds the prepared rewrite data file (copy-on-write). If the table did not
+// exist and the rewrite has no rows, it writes nothing.
+func (d *OneLakeDestination) commitRewrite(ctx context.Context, tableDir string, snap *deltaSnapshot, rewrite *rewriteData, operation string) error {
+	if rewrite == nil {
+		rewrite = &rewriteData{}
+	}
+	if len(rewrite.adds) == 0 && (snap == nil || !snap.exists) {
 		config.Debug("[ONELAKE] %s produced no rows and table does not exist; nothing to do", operation)
 		return nil
 	}
@@ -513,21 +633,6 @@ func (d *OneLakeDestination) commitRewrite(ctx context.Context, tableDir string,
 		removePaths = snap.activeFiles
 	}
 
-	var adds []deltaAddFile
-	var cols []schema.Column
-	if len(batches) > 0 {
-		data, arrowSchema, err := writeBatchesToParquet(batches)
-		if err != nil {
-			return err
-		}
-		dataFile := fmt.Sprintf("part-00000-%s.c000.snappy.parquet", uuid.New().String())
-		if err := d.client.UploadBuffer(ctx, d.workspace, tableDir+"/"+dataFile, data); err != nil {
-			return fmt.Errorf("failed to upload data file: %w", err)
-		}
-		adds = append(adds, deltaAddFile{Path: dataFile, Size: int64(len(data))})
-		cols = arrowSchemaToColumns(arrowSchema)
-	}
-
 	version := int64(0)
 	if snap != nil && snap.exists {
 		version = snap.version + 1
@@ -536,16 +641,16 @@ func (d *OneLakeDestination) commitRewrite(ctx context.Context, tableDir string,
 	var commit []byte
 	var err error
 	if version == 0 {
-		commit, err = buildInitialCommit(cols, adds, uuid.New().String(), nowMillis)
+		commit, err = buildInitialCommit(rewrite.cols, rewrite.adds, uuid.New().String(), nowMillis)
 	} else {
-		commit, err = buildRewriteCommit(removePaths, adds, operation, nowMillis)
+		commit, err = buildRewriteCommit(removePaths, rewrite.adds, operation, nowMillis)
 	}
 	if err != nil {
 		return err
 	}
 
-	if err := d.client.UploadBuffer(ctx, d.workspace, logDir+"/"+commitFileName(version), commit); err != nil {
-		return fmt.Errorf("failed to write delta commit: %w", err)
+	if err := d.uploadDeltaCommit(ctx, logDir, version, commit); err != nil {
+		return err
 	}
 	config.Debug("[ONELAKE] %s committed delta version %d to %s", operation, version, tableDir)
 	return nil

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -555,7 +555,6 @@ func (d *OneLakeDestination) rewriteTableWithRetry(ctx context.Context, targetTa
 	}
 	defer releaseBatches(sBatches)
 
-	dataFile := fmt.Sprintf("part-00000-%s.c000.snappy.parquet", uuid.New().String())
 	var lastConflict error
 	for attempt := 0; attempt < maxDeltaCommitAttempts; attempt++ {
 		tDir, tSnap, tBatches, err := d.readTable(ctx, targetTable, readOp)
@@ -569,6 +568,10 @@ func (d *OneLakeDestination) rewriteTableWithRetry(ctx context.Context, targetTa
 			return err
 		}
 
+		// Delta data files are immutable, so each attempt writes a fresh file
+		// rather than overwriting the previous attempt's object. Files left by
+		// conflicting attempts are unreferenced and reclaimed by VACUUM.
+		dataFile := fmt.Sprintf("part-00000-%s.c000.snappy.parquet", uuid.New().String())
 		rewrite, err := d.uploadRewriteData(ctx, tDir, dataFile, result)
 		releaseBatches(result)
 		if err != nil {

--- a/pkg/destination/onelake/onelake_test.go
+++ b/pkg/destination/onelake/onelake_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,6 +264,25 @@ func TestBuildAppendCommit(t *testing.T) {
 	// No protocol/metaData on append commits.
 	_, hasProtocol := lines[0]["protocol"]
 	assert.False(t, hasProtocol)
+}
+
+func TestDeltaCommitRenameOptionsUsesIfNoneMatchAny(t *testing.T) {
+	t.Parallel()
+
+	opts := deltaCommitRenameOptions()
+	require.NotNil(t, opts.AccessConditions)
+	require.NotNil(t, opts.AccessConditions.ModifiedAccessConditions)
+	require.NotNil(t, opts.AccessConditions.ModifiedAccessConditions.IfNoneMatch)
+	assert.Equal(t, azcore.ETagAny, *opts.AccessConditions.ModifiedAccessConditions.IfNoneMatch)
+}
+
+func TestDeltaCommitTempPathStaysOutsideDeltaLog(t *testing.T) {
+	t.Parallel()
+
+	got := deltaCommitTempPath("lakehouse.Lakehouse/Tables/orders/_delta_log")
+	assert.Contains(t, got, "lakehouse.Lakehouse/Tables/orders/_bruin_delta_tmp/")
+	assert.NotContains(t, got, "/_delta_log/")
+	assert.True(t, strings.HasSuffix(got, ".tmp"))
 }
 
 func TestCommitFileName(t *testing.T) {

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -575,6 +575,13 @@ func (d *PostgresDestination) DeleteInsertTable(ctx context.Context, opts destin
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
 
+	lockSQL := buildDeleteInsertLockSQL(quotedTargetTable)
+	config.Debug("[DELETE+INSERT] Locking target table: %s", lockSQL)
+	if _, err := tx.Exec(ctx, lockSQL); err != nil {
+		config.LogFailedQuery(lockSQL, err)
+		return fmt.Errorf("failed to lock target table: %w", err)
+	}
+
 	deleteSQL := fmt.Sprintf(
 		`DELETE FROM %s WHERE %s >= $1 AND %s <= $2`,
 		quotedTargetTable, destination.QuoteIdentifier(opts.IncrementalKey), destination.QuoteIdentifier(opts.IncrementalKey),
@@ -608,6 +615,10 @@ func (d *PostgresDestination) DeleteInsertTable(ctx context.Context, opts destin
 
 	config.Debug("[DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
 	return nil
+}
+
+func buildDeleteInsertLockSQL(quotedTargetTable string) string {
+	return fmt.Sprintf("LOCK TABLE %s IN EXCLUSIVE MODE", quotedTargetTable)
 }
 
 // SCD2Table performs SCD2 (Slowly Changing Dimensions Type 2) merge logic.

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -1,0 +1,11 @@
+package postgres
+
+import "testing"
+
+func TestBuildDeleteInsertLockSQL(t *testing.T) {
+	got := buildDeleteInsertLockSQL(`"public"."orders"`)
+	want := `LOCK TABLE "public"."orders" IN EXCLUSIVE MODE`
+	if got != want {
+		t.Fatalf("buildDeleteInsertLockSQL() = %q, want %q", got, want)
+	}
+}

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -474,10 +474,7 @@ func (d *SynapseDestination) DeleteInsertTable(ctx context.Context, opts destina
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE %s >= @p1 AND %s <= @p2",
-		quoteTable(opts.TargetTable), quoteColumn(opts.IncrementalKey), quoteColumn(opts.IncrementalKey),
-	)
+	deleteSQL := buildDeleteInsertDeleteSQL(opts.TargetTable, opts.IncrementalKey)
 	config.Debug("[Synapse DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 
 	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
@@ -502,6 +499,13 @@ func (d *SynapseDestination) DeleteInsertTable(ctx context.Context, opts destina
 
 	config.Debug("[Synapse DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
 	return nil
+}
+
+func buildDeleteInsertDeleteSQL(targetTable, incrementalKey string) string {
+	return fmt.Sprintf(
+		"DELETE FROM %s WITH (TABLOCKX, HOLDLOCK) WHERE %s >= @p1 AND %s <= @p2",
+		quoteTable(targetTable), quoteColumn(incrementalKey), quoteColumn(incrementalKey),
+	)
 }
 
 func (d *SynapseDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {

--- a/pkg/destination/synapse/synapse_test.go
+++ b/pkg/destination/synapse/synapse_test.go
@@ -1,0 +1,17 @@
+package synapse
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
+	sql := buildDeleteInsertDeleteSQL("dbo.events", "updated_at")
+
+	if !strings.Contains(sql, "DELETE FROM [dbo].[events] WITH (TABLOCKX, HOLDLOCK)") {
+		t.Fatalf("delete SQL missing table lock: %s", sql)
+	}
+	if !strings.Contains(sql, "[updated_at] >= @p1") || !strings.Contains(sql, "[updated_at] <= @p2") {
+		t.Fatalf("delete SQL missing interval predicate: %s", sql)
+	}
+}

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -3,6 +3,7 @@ package trino
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -296,38 +297,7 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)`,
 }
 
 func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
-	startOp := time.Now()
-
-	stagingCatalog, stagingSchema, stagingName := d.parseTableName(opts.StagingTable)
-	targetCatalog, targetSchema, targetName := d.parseTableName(opts.TargetTable)
-
-	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
-	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
-
-	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE %s >= '%v' AND %s <= '%v'",
-		targetFQN, quoteIdentifier(opts.IncrementalKey), opts.IntervalStart, quoteIdentifier(opts.IncrementalKey), opts.IntervalEnd,
-	)
-	config.Debug("[TRINO DELETE+INSERT] Executing DELETE: %s", deleteSQL)
-
-	if _, err := d.db.ExecContext(ctx, deleteSQL); err != nil {
-		config.LogFailedQuery(deleteSQL, err)
-		return fmt.Errorf("failed to delete records: %w", err)
-	}
-
-	colList := strings.Join(quoteColumns(opts.Columns), ", ")
-	// Dedupe staging by primary key, keeping the latest row per key by incremental key.
-	selectClause := destination.DedupStagingSelect(colList, strings.Join(quoteColumns(opts.PrimaryKeys), ", "), stagingFQN, quoteColumns([]string{opts.IncrementalKey})[0])
-	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFQN, colList, selectClause)
-	config.Debug("[TRINO DELETE+INSERT] Executing INSERT: %s", insertSQL)
-
-	if _, err := d.db.ExecContext(ctx, insertSQL); err != nil {
-		config.LogFailedQuery(insertSQL, err)
-		return fmt.Errorf("failed to insert records: %w", err)
-	}
-
-	config.Debug("[TRINO DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
-	return nil
+	return errors.New("delete+insert strategy is not supported for trino destination")
 }
 
 func (d *TrinoDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
@@ -445,27 +415,14 @@ func (d *TrinoDestination) Exec(ctx context.Context, sqlStr string, args ...inte
 }
 
 func (d *TrinoDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
-	return &trinoTransaction{}, nil
-}
-
-type trinoTransaction struct{}
-
-func (t *trinoTransaction) Exec(ctx context.Context, sql string, args ...interface{}) error {
-	return nil
-}
-
-func (t *trinoTransaction) Commit(ctx context.Context) error {
-	return nil
-}
-
-func (t *trinoTransaction) Rollback(ctx context.Context) error {
-	return nil
+	_ = ctx
+	return nil, errors.New("trino destination does not support transactions")
 }
 
 func (d *TrinoDestination) SupportsReplaceStrategy() bool      { return true }
 func (d *TrinoDestination) SupportsAppendStrategy() bool       { return true }
 func (d *TrinoDestination) SupportsMergeStrategy() bool        { return true }
-func (d *TrinoDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *TrinoDestination) SupportsDeleteInsertStrategy() bool { return false }
 func (d *TrinoDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *TrinoDestination) SupportsAtomicSwap() bool           { return false }
 

--- a/pkg/destination/trino/trino_test.go
+++ b/pkg/destination/trino/trino_test.go
@@ -1,8 +1,11 @@
 package trino
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
 )
 
 func TestParseTrinoURI(t *testing.T) {
@@ -129,5 +132,35 @@ func TestParseTrinoURI_CertWithoutKey(t *testing.T) {
 	_, _, _, err := parseTrinoURI("trino://host:443/cat?cert=/etc/ssl/client.pem")
 	if err == nil {
 		t.Fatal("expected error when cert is provided without key, got nil")
+	}
+}
+
+func TestDeleteInsertUnsupported(t *testing.T) {
+	t.Parallel()
+
+	dest := NewTrinoDestination()
+	if dest.SupportsDeleteInsertStrategy() {
+		t.Fatal("SupportsDeleteInsertStrategy() = true, want false")
+	}
+
+	err := dest.DeleteInsertTable(context.Background(), destination.DeleteInsertOptions{})
+	if err == nil || !strings.Contains(err.Error(), "delete+insert strategy is not supported") {
+		t.Fatalf("DeleteInsertTable() error = %v, want unsupported error", err)
+	}
+}
+
+func TestBeginTransactionUnsupported(t *testing.T) {
+	t.Parallel()
+
+	dest := NewTrinoDestination()
+	tx, err := dest.BeginTransaction(context.Background())
+	if err == nil {
+		t.Fatal("BeginTransaction() error = nil, want unsupported error")
+	}
+	if tx != nil {
+		t.Fatalf("BeginTransaction() tx = %#v, want nil", tx)
+	}
+	if !strings.Contains(err.Error(), "does not support transactions") {
+		t.Fatalf("BeginTransaction() error = %v, want transaction unsupported error", err)
 	}
 }

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -34,6 +34,10 @@ func (s *DeleteInsertStrategy) RequiresIncrementalKey() bool {
 }
 
 func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) error {
+	if !job.Destination.SupportsDeleteInsertStrategy() {
+		return fmt.Errorf("destination %s does not support delete+insert strategy", job.Destination.GetScheme())
+	}
+
 	stagingTable := GenerateStagingTableName(job.Config.DestTable, "di", job.Config.StagingDataset)
 	fmt.Printf("[DELETE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -120,6 +120,25 @@ func TestDeleteInsertStrategy_Validate(t *testing.T) {
 	}
 }
 
+func TestDeleteInsertStrategy_Execute_RejectsUnsupportedDestinationBeforeStaging(t *testing.T) {
+	job, _, dest := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
+	job.Config.IncrementalKey = "id"
+	dest.noDeleteInsert = true
+
+	strat := &DeleteInsertStrategy{}
+	err := strat.Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected unsupported destination error")
+	}
+	if !strings.Contains(err.Error(), "does not support delete+insert strategy") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dest.prepareCalls) != 0 || len(dest.writeCalls) != 0 || len(dest.diCalls) != 0 {
+		t.Fatalf("expected no staging work, got prepare=%d write=%d di=%d", len(dest.prepareCalls), len(dest.writeCalls), len(dest.diCalls))
+	}
+}
+
 func TestDeleteInsertStrategy_Execute_SkipsWhenNoIntervalDetected(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -99,6 +99,7 @@ type fakeDestination struct {
 	deleteInsertErr   error
 	waitErr           error
 	dropErrByTable    map[string]error
+	noDeleteInsert    bool
 }
 
 func (d *fakeDestination) Schemes() []string                             { return nil }
@@ -117,7 +118,7 @@ func (d *fakeDestination) BeginTransaction(ctx context.Context) (destination.Tra
 func (d *fakeDestination) SupportsReplaceStrategy() bool      { return true }
 func (d *fakeDestination) SupportsAppendStrategy() bool       { return true }
 func (d *fakeDestination) SupportsMergeStrategy() bool        { return true }
-func (d *fakeDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *fakeDestination) SupportsDeleteInsertStrategy() bool { return !d.noDeleteInsert }
 func (d *fakeDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *fakeDestination) SupportsAtomicSwap() bool           { return true }
 func (d *fakeDestination) GetScheme() string                  { return "fake" }

--- a/tests/integration/bigquery_dedup_test.go
+++ b/tests/integration/bigquery_dedup_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -322,6 +323,90 @@ func TestBigQuery_DeleteInsertTable_DedupsDuplicateStagingPKs(t *testing.T) {
 	))
 	require.Len(t, rows, 1)
 	require.EqualValues(t, 3, rows[0][0], "expected 3 distinct ids inside the delete-insert window")
+}
+
+func TestBigQuery_DeleteInsertTable_ConcurrentWritersDoNotDuplicate(t *testing.T) {
+	dest, client, project, dataset := bqDedupSetup(t)
+	ctx := context.Background()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	targetTbl := fmt.Sprintf("dedup_di_concurrent_target_%s", suffix)
+	stagingTbls := []string{
+		fmt.Sprintf("dedup_di_concurrent_staging_a_%s", suffix),
+		fmt.Sprintf("dedup_di_concurrent_staging_b_%s", suffix),
+		fmt.Sprintf("dedup_di_concurrent_staging_c_%s", suffix),
+	}
+	allTables := append([]string{targetTbl}, stagingTbls...)
+	defer bqDropTables(ctx, client, dataset, allTables...)
+	defer func() { _ = dest.Close(ctx) }()
+
+	require.NoError(t, dest.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s.%s.%s` (id INT64, ts INT64, name STRING)",
+		project, dataset, targetTbl,
+	)))
+	require.NoError(t, dest.Exec(ctx, fmt.Sprintf(`INSERT INTO `+"`%s.%s.%s`"+` VALUES
+		(99, 999, 'outside-window'),
+		(1, 100, 'stale-a'),
+		(2, 101, 'stale-b'),
+		(3, 102, 'stale-c')`, project, dataset, targetTbl)))
+
+	for i, tbl := range stagingTbls {
+		require.NoError(t, dest.Exec(ctx, fmt.Sprintf(
+			"CREATE TABLE `%s.%s.%s` (id INT64, ts INT64, name STRING)",
+			project, dataset, tbl,
+		)))
+		require.NoError(t, dest.Exec(ctx, fmt.Sprintf(`INSERT INTO `+"`%s.%s.%s`"+` VALUES
+			(1, 100, 'writer-%d-a-old'),
+			(1, 110, 'writer-%d-a-new'),
+			(2, 101, 'writer-%d-b-old'),
+			(2, 111, 'writer-%d-b-new'),
+			(3, 102, 'writer-%d-c')`, project, dataset, tbl, i, i, i, i, i)))
+	}
+
+	start := make(chan struct{})
+	errCh := make(chan error, len(stagingTbls))
+	var wg sync.WaitGroup
+	for _, tbl := range stagingTbls {
+		wg.Add(1)
+		go func(stagingTbl string) {
+			defer wg.Done()
+			<-start
+			errCh <- dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+				StagingTable:       dataset + "." + stagingTbl,
+				TargetTable:        dataset + "." + targetTbl,
+				IncrementalKey:     "ts",
+				IncrementalKeyType: schema.TypeInt64,
+				IntervalStart:      int64(0),
+				IntervalEnd:        int64(200),
+				Columns:            []string{"id", "ts", "name"},
+				PrimaryKeys:        []string{"id"},
+			})
+		}(tbl)
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	rows := bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT COUNT(*) FROM `%s.%s.%s`", project, dataset, targetTbl,
+	))
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 4, rows[0][0], "expected three interval rows plus one outside-window row")
+
+	rows = bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT id, COUNT(*) FROM `%s.%s.%s` WHERE ts BETWEEN 0 AND 200 GROUP BY id HAVING COUNT(*) > 1",
+		project, dataset, targetTbl,
+	))
+	require.Empty(t, rows, "concurrent delete-insert writers must not leave duplicate primary keys")
+
+	rows = bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT name FROM `%s.%s.%s` WHERE id = 99", project, dataset, targetTbl,
+	))
+	require.Len(t, rows, 1, "outside-window row must survive concurrent delete-insert")
+	require.Equal(t, "outside-window", rows[0][0])
 }
 
 func TestBigQuery_MergeTable_NullSafeCompositePrimaryKey(t *testing.T) {

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -343,7 +343,6 @@ func destinationCases() []destCase {
 			},
 			sqlBackend:             cratedbBackend(),
 			mergeCapable:           true,
-			deleteInsertCapable:    true,
 			truncateInsertCapable:  true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: false,


### PR DESCRIPTION
Runs BigQuery delete+insert in a transaction with conflict retrying and adds a real concurrent BigQuery test.

Tightens delete+insert behavior across destinations by adding locks/atomic blocks where available, disabling unsafe no-op transaction paths, and documenting the platform caveats.

Validated with focused destination tests, go test -short ./..., BigQuery integration, and ClickHouse delete+insert integration.