### PR TITLE
Fix ClickHouse array ingestion

### DIFF
--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -18,6 +18,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/araddon/dateparse"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/shopspring/decimal"
 )
 
 // ItemsToArrowRecordWithSchema builds an Arrow RecordBatch from items and a given schema,
@@ -591,6 +592,13 @@ func AppendValue(builder array.Builder, val interface{}) {
 		switch v := val.(type) {
 		case decimal128.Num:
 			b.Append(v)
+		case decimal.Decimal:
+			num, err := decimal128.FromString(v.String(), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
 		case string:
 			v = strings.TrimSpace(v)
 			if v == "" {
@@ -633,6 +641,55 @@ func AppendValue(builder array.Builder, val interface{}) {
 			} else {
 				b.Append(num)
 			}
+		case int8:
+			num, err := decimal128.FromString(strconv.FormatInt(int64(v), 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
+		case int16:
+			num, err := decimal128.FromString(strconv.FormatInt(int64(v), 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
+		case int32:
+			num, err := decimal128.FromString(strconv.FormatInt(int64(v), 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
+		case uint8:
+			num, err := decimal128.FromString(strconv.FormatUint(uint64(v), 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
+		case uint16:
+			num, err := decimal128.FromString(strconv.FormatUint(uint64(v), 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
+		case uint32:
+			num, err := decimal128.FromString(strconv.FormatUint(uint64(v), 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
+		case uint64:
+			num, err := decimal128.FromString(strconv.FormatUint(v, 10), dt.Precision, dt.Scale)
+			if err != nil {
+				b.AppendNull()
+			} else {
+				b.Append(num)
+			}
 		case []byte:
 			s := strings.TrimSpace(string(v))
 			if s == "" {
@@ -670,136 +727,44 @@ func AppendValue(builder array.Builder, val interface{}) {
 }
 
 func appendListValue(b *array.ListBuilder, val interface{}) {
-	switch v := val.(type) {
-	case []string:
-		b.Append(true)
-		vb := b.ValueBuilder().(*array.StringBuilder)
-		for _, s := range v {
-			vb.Append(s)
-		}
-	case []bool:
-		b.Append(true)
-		vb := b.ValueBuilder().(*array.BooleanBuilder)
-		for _, n := range v {
-			vb.Append(n)
-		}
-	default:
-		appendListNumeric(b, val)
-	}
-}
-
-func appendListNumeric(b *array.ListBuilder, val interface{}) {
-	if bigs, ok := val.([]*big.Int); ok {
-		vb, isDecimal := b.ValueBuilder().(*array.Decimal128Builder)
-		if !isDecimal {
-			b.AppendNull()
-			return
-		}
-		b.Append(true)
-		for _, bi := range bigs {
-			if bi == nil {
-				vb.AppendNull()
-			} else {
-				vb.Append(decimal128.FromBigInt(bi))
-			}
-		}
-		return
-	}
-
 	rv := reflect.ValueOf(val)
 	if rv.Kind() != reflect.Slice {
 		b.AppendNull()
 		return
 	}
-	elemKind := rv.Type().Elem().Kind()
-	asInt64 := func(i int) (int64, bool) {
-		e := rv.Index(i)
-		switch elemKind {
-		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return e.Int(), true
-		case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return int64(e.Uint()), true
-		case reflect.Float32, reflect.Float64:
-			return int64(e.Float()), true
-		}
-		return 0, false
-	}
-	asFloat64 := func(i int) (float64, bool) {
-		e := rv.Index(i)
-		switch elemKind {
-		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return float64(e.Int()), true
-		case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return float64(e.Uint()), true
-		case reflect.Float32, reflect.Float64:
-			return e.Float(), true
-		}
-		return 0, false
-	}
 
-	n := rv.Len()
-	switch vb := b.ValueBuilder().(type) {
-	case *array.Int16Builder:
-		b.Append(true)
-		for i := 0; i < n; i++ {
-			if x, ok := asInt64(i); ok {
-				vb.Append(int16(x))
-			} else {
-				vb.AppendNull()
-			}
+	b.Append(true)
+	vb := b.ValueBuilder()
+	for i := 0; i < rv.Len(); i++ {
+		elem, ok := listElementValue(rv.Index(i))
+		if !ok {
+			vb.AppendNull()
+			continue
 		}
-	case *array.Int32Builder:
-		b.Append(true)
-		for i := 0; i < n; i++ {
-			if x, ok := asInt64(i); ok {
-				vb.Append(int32(x))
-			} else {
-				vb.AppendNull()
-			}
-		}
-	case *array.Int64Builder:
-		b.Append(true)
-		for i := 0; i < n; i++ {
-			if x, ok := asInt64(i); ok {
-				vb.Append(x)
-			} else {
-				vb.AppendNull()
-			}
-		}
-	case *array.Float32Builder:
-		b.Append(true)
-		for i := 0; i < n; i++ {
-			if x, ok := asFloat64(i); ok {
-				vb.Append(float32(x))
-			} else {
-				vb.AppendNull()
-			}
-		}
-	case *array.Float64Builder:
-		b.Append(true)
-		for i := 0; i < n; i++ {
-			if x, ok := asFloat64(i); ok {
-				vb.Append(x)
-			} else {
-				vb.AppendNull()
-			}
-		}
-	case *array.Decimal128Builder:
-		b.Append(true)
-		for i := 0; i < n; i++ {
-			e := rv.Index(i)
-			switch elemKind {
-			case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-				vb.Append(decimal128.FromBigInt(new(big.Int).SetUint64(e.Uint())))
-			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-				vb.Append(decimal128.FromBigInt(big.NewInt(e.Int())))
-			default:
-				vb.AppendNull()
-			}
-		}
-	default:
-		b.AppendNull()
+		AppendValue(vb, elem)
 	}
+}
+
+func listElementValue(v reflect.Value) (interface{}, bool) {
+	if !v.IsValid() {
+		return nil, false
+	}
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil, false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil, false
+		}
+		if v.Type() == reflect.TypeOf((*big.Int)(nil)) {
+			return v.Interface(), true
+		}
+		v = v.Elem()
+	}
+	return v.Interface(), true
 }
 
 func AppendJSONStringValue(b *array.StringBuilder, val interface{}) {

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -2,6 +2,7 @@ package arrowconv
 
 import (
 	"encoding/json"
+	"net"
 	"testing"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -281,6 +284,110 @@ func TestAppendValue_TimestampBuilder(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAppendValue_ListTimestampBuilder(t *testing.T) {
+	tsType := &arrow.TimestampType{Unit: arrow.Microsecond}
+	builder := array.NewListBuilder(memory.DefaultAllocator, tsType)
+	defer builder.Release()
+
+	first := time.Date(2026, 6, 10, 12, 0, 0, 123_000_000, time.UTC)
+	second := time.Date(2026, 6, 10, 13, 30, 0, 456_000_000, time.UTC)
+
+	AppendValue(builder, []time.Time{first, second})
+
+	arr := builder.NewArray().(*array.List)
+	defer arr.Release()
+
+	require.Equal(t, 1, arr.Len())
+	assert.False(t, arr.IsNull(0))
+
+	values := arr.ListValues().(*array.Timestamp)
+	require.Equal(t, 2, values.Len())
+	assert.Equal(t, arrow.Timestamp(first.UnixMicro()), values.Value(0))
+	assert.Equal(t, arrow.Timestamp(second.UnixMicro()), values.Value(1))
+}
+
+func TestAppendValue_ListNullableScalarElements(t *testing.T) {
+	textBuilder := array.NewListBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String)
+	defer textBuilder.Release()
+	alpha := "alpha"
+	omega := "omega"
+	AppendValue(textBuilder, []*string{&alpha, nil, &omega})
+
+	textArr := textBuilder.NewArray().(*array.List)
+	defer textArr.Release()
+	textValues := textArr.ListValues().(*array.String)
+	require.Equal(t, 3, textValues.Len())
+	assert.Equal(t, "alpha", textValues.Value(0))
+	assert.True(t, textValues.IsNull(1))
+	assert.Equal(t, "omega", textValues.Value(2))
+
+	intBuilder := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int32)
+	defer intBuilder.Release()
+	one := uint16(1)
+	two := uint16(2)
+	AppendValue(intBuilder, []*uint16{&one, nil, &two})
+
+	intArr := intBuilder.NewArray().(*array.List)
+	defer intArr.Release()
+	intValues := intArr.ListValues().(*array.Int32)
+	require.Equal(t, 3, intValues.Len())
+	assert.Equal(t, int32(1), intValues.Value(0))
+	assert.True(t, intValues.IsNull(1))
+	assert.Equal(t, int32(2), intValues.Value(2))
+
+	boolBuilder := array.NewListBuilder(memory.DefaultAllocator, arrow.FixedWidthTypes.Boolean)
+	defer boolBuilder.Release()
+	yes := true
+	no := false
+	AppendValue(boolBuilder, []*bool{&yes, nil, &no})
+
+	boolArr := boolBuilder.NewArray().(*array.List)
+	defer boolArr.Release()
+	boolValues := boolArr.ListValues().(*array.Boolean)
+	require.Equal(t, 3, boolValues.Len())
+	assert.True(t, boolValues.Value(0))
+	assert.True(t, boolValues.IsNull(1))
+	assert.False(t, boolValues.Value(2))
+}
+
+func TestAppendValue_ListStringerElements(t *testing.T) {
+	builder := array.NewListBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String)
+	defer builder.Release()
+
+	firstUUID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	secondUUID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	AppendValue(builder, []*uuid.UUID{&firstUUID, nil, &secondUUID})
+	AppendValue(builder, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("8.8.8.8")})
+
+	arr := builder.NewArray().(*array.List)
+	defer arr.Release()
+	values := arr.ListValues().(*array.String)
+	require.Equal(t, 5, values.Len())
+	assert.Equal(t, firstUUID.String(), values.Value(0))
+	assert.True(t, values.IsNull(1))
+	assert.Equal(t, secondUUID.String(), values.Value(2))
+	assert.Equal(t, "127.0.0.1", values.Value(3))
+	assert.Equal(t, "8.8.8.8", values.Value(4))
+}
+
+func TestAppendValue_ListDecimalBuilder(t *testing.T) {
+	dt := &arrow.Decimal128Type{Precision: 18, Scale: 5}
+	builder := array.NewListBuilder(memory.DefaultAllocator, dt)
+	defer builder.Release()
+
+	first := decimal.RequireFromString("12.34567")
+	second := decimal.RequireFromString("89.00001")
+	AppendValue(builder, []*decimal.Decimal{&first, nil, &second})
+
+	arr := builder.NewArray().(*array.List)
+	defer arr.Release()
+	values := arr.ListValues().(*array.Decimal128)
+	require.Equal(t, 3, values.Len())
+	assert.Equal(t, "1234567", decimal128.Num(values.Value(0)).BigInt().String())
+	assert.True(t, values.IsNull(1))
+	assert.Equal(t, "8900001", decimal128.Num(values.Value(2)).BigInt().String())
 }
 
 func TestAppendValue_Decimal128_JSONNumber(t *testing.T) {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -151,7 +151,7 @@ func DataTypeToArrowType(col Column) arrow.DataType {
 	case TypeTimestampTZ:
 		return &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
 	case TypeArray:
-		elemType := DataTypeToArrowType(Column{DataType: col.ArrayType})
+		elemType := DataTypeToArrowType(Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale})
 		return arrow.ListOf(elemType)
 	default:
 		return arrow.BinaryTypes.String

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,0 +1,27 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataTypeToArrowType_ArrayDecimalPreservesPrecisionScale(t *testing.T) {
+	t.Parallel()
+
+	got := DataTypeToArrowType(Column{
+		DataType:  TypeArray,
+		ArrayType: TypeDecimal,
+		Precision: 18,
+		Scale:     5,
+	})
+
+	listType, ok := got.(*arrow.ListType)
+	require.True(t, ok)
+
+	decimalType, ok := listType.Elem().(*arrow.Decimal128Type)
+	require.True(t, ok)
+	require.Equal(t, int32(18), decimalType.Precision)
+	require.Equal(t, int32(5), decimalType.Scale)
+}

--- a/pkg/source/clickhouse/clickhouse.go
+++ b/pkg/source/clickhouse/clickhouse.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"math/big"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
 
@@ -439,47 +441,7 @@ func nativeScanTarget(chType string, nullable bool) interface{} {
 	}
 
 	if m := arrayRegex.FindStringSubmatch(t); len(m) == 2 {
-		elem := strings.TrimSpace(m[1])
-		for {
-			if mm := nullableRegex.FindStringSubmatch(elem); len(mm) == 2 {
-				elem = strings.TrimSpace(mm[1])
-				continue
-			}
-			if mm := lowCardRegex.FindStringSubmatch(elem); len(mm) == 2 {
-				elem = strings.TrimSpace(mm[1])
-				continue
-			}
-			break
-		}
-		switch strings.ToUpper(elem) {
-		case "INT8":
-			return new([]int8)
-		case "INT16":
-			return new([]int16)
-		case "INT32":
-			return new([]int32)
-		case "INT64":
-			return new([]int64)
-		case "UINT8":
-			return new([]uint8)
-		case "UINT16":
-			return new([]uint16)
-		case "UINT32":
-			return new([]uint32)
-		case "UINT64":
-			return new([]uint64)
-		case "INT128", "UINT128", "INT256", "UINT256":
-			return new([]*big.Int)
-		case "FLOAT32":
-			return new([]float32)
-		case "FLOAT64":
-			return new([]float64)
-		case "STRING":
-			return new([]string)
-		case "BOOL", "BOOLEAN":
-			return new([]bool)
-		}
-		return nil
+		return nativeArrayScanTarget(m[1])
 	}
 
 	switch strings.ToUpper(t) {
@@ -515,6 +477,81 @@ func nativeScanTarget(chType string, nullable bool) interface{} {
 		return new(*big.Int)
 	}
 	return nil
+}
+
+func nativeArrayScanTarget(chType string) interface{} {
+	elem, nullable := unwrapClickHouseType(chType)
+	upperElem := strings.ToUpper(elem)
+
+	if enumRegex.MatchString(elem) || fixedStringRe.MatchString(elem) {
+		return arrayScanTarget[string](nullable)
+	}
+	if decimalRegex.MatchString(elem) {
+		return arrayScanTarget[decimal.Decimal](nullable)
+	}
+	if datetime64Regex.MatchString(elem) || datetimeRegex.MatchString(elem) || upperElem == "DATE" || upperElem == "DATE32" {
+		return arrayScanTarget[time.Time](nullable)
+	}
+
+	switch upperElem {
+	case "BOOL", "BOOLEAN":
+		return arrayScanTarget[bool](nullable)
+	case "INT8", "TINYINT":
+		return arrayScanTarget[int8](nullable)
+	case "INT16", "SMALLINT":
+		return arrayScanTarget[int16](nullable)
+	case "INT32", "INT", "INTEGER":
+		return arrayScanTarget[int32](nullable)
+	case "INT64", "BIGINT":
+		return arrayScanTarget[int64](nullable)
+	case "UINT8":
+		return arrayScanTarget[uint8](nullable)
+	case "UINT16":
+		return arrayScanTarget[uint16](nullable)
+	case "UINT32":
+		return arrayScanTarget[uint32](nullable)
+	case "UINT64":
+		return arrayScanTarget[uint64](nullable)
+	case "INT128", "UINT128", "INT256", "UINT256":
+		return new([]*big.Int)
+	case "FLOAT32", "FLOAT":
+		return arrayScanTarget[float32](nullable)
+	case "FLOAT64", "DOUBLE":
+		return arrayScanTarget[float64](nullable)
+	case "STRING", "JSON", "OBJECT":
+		return arrayScanTarget[string](nullable)
+	case "IPV4", "IPV6":
+		return arrayScanTarget[net.IP](nullable)
+	case "UUID":
+		return arrayScanTarget[uuid.UUID](nullable)
+	}
+
+	return nil
+}
+
+func unwrapClickHouseType(chType string) (string, bool) {
+	t := strings.TrimSpace(chType)
+	nullable := false
+	for {
+		if m := nullableRegex.FindStringSubmatch(t); len(m) == 2 {
+			t = strings.TrimSpace(m[1])
+			nullable = true
+			continue
+		}
+		if m := lowCardRegex.FindStringSubmatch(t); len(m) == 2 {
+			t = strings.TrimSpace(m[1])
+			continue
+		}
+		break
+	}
+	return t, nullable
+}
+
+func arrayScanTarget[T any](nullable bool) interface{} {
+	if nullable {
+		return new([]*T)
+	}
+	return new([]T)
 }
 
 func createTypedScanTargets(columns []schema.Column, rawTypes []string) []interface{} {
@@ -681,6 +718,7 @@ func extractValue(target interface{}) interface{} {
 		}
 		return **v
 	case *[]byte:
+		// byte is an alias for uint8, so this also handles Array(UInt8).
 		return *v
 	case *time.Time:
 		return *v
@@ -698,25 +736,65 @@ func extractValue(target interface{}) interface{} {
 		return *v
 	case *[]string:
 		return *v
+	case *[]*string:
+		return *v
 	case *[]bool:
+		return *v
+	case *[]*bool:
 		return *v
 	case *[]int8:
 		return *v
+	case *[]*int8:
+		return *v
 	case *[]int16:
+		return *v
+	case *[]*int16:
 		return *v
 	case *[]int32:
 		return *v
+	case *[]*int32:
+		return *v
 	case *[]int64:
+		return *v
+	case *[]*int64:
+		return *v
+	case *[]*uint8:
 		return *v
 	case *[]uint16:
 		return *v
+	case *[]*uint16:
+		return *v
 	case *[]uint32:
+		return *v
+	case *[]*uint32:
 		return *v
 	case *[]uint64:
 		return *v
+	case *[]*uint64:
+		return *v
+	case *[]time.Time:
+		return *v
+	case *[]*time.Time:
+		return *v
 	case *[]float32:
 		return *v
+	case *[]*float32:
+		return *v
 	case *[]float64:
+		return *v
+	case *[]*float64:
+		return *v
+	case *[]decimal.Decimal:
+		return *v
+	case *[]*decimal.Decimal:
+		return *v
+	case *[]uuid.UUID:
+		return *v
+	case *[]*uuid.UUID:
+		return *v
+	case *[]net.IP:
+		return *v
+	case *[]*net.IP:
 		return *v
 	case *[]*big.Int:
 		return *v

--- a/pkg/source/clickhouse/integration_test.go
+++ b/pkg/source/clickhouse/integration_test.go
@@ -12,10 +12,16 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/testutil"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // Register ADBC driver
+	chsource "github.com/bruin-data/ingestr/pkg/source/clickhouse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -279,6 +285,78 @@ func TestClickHouseSource_ToDuckDB_Merge(t *testing.T) {
 	assert.Equal(t, "User_6", string(nameRaw), "expected new row with id=6")
 }
 
+func TestClickHouseSource_ReadArrayTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, err := startClickHouseContainer(ctx)
+	if err != nil {
+		t.Skipf("failed to start ClickHouse container: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	sourceTable := fmt.Sprintf("source_array_types_%d", time.Now().UnixNano())
+	first := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	second := time.Date(2024, 1, 2, 13, 30, 0, 0, time.UTC)
+	setupClickHouseArrayTypesTable(t, ctx, uri, sourceTable, first, second)
+	defer cleanupClickHouseTable(ctx, uri, sourceTable)
+
+	src := chsource.NewClickHouseSource()
+	require.NoError(t, src.Connect(ctx, uri))
+	defer func() { _ = src.Close(ctx) }()
+
+	table, err := src.GetTable(ctx, source.TableRequest{Name: sourceTable})
+	require.NoError(t, err)
+
+	tableSchema, err := table.GetSchema(ctx)
+	require.NoError(t, err)
+	require.Len(t, tableSchema.Columns, 11)
+	requireArrayColumn(t, tableSchema.Columns[1], schema.TypeTimestamp, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[2], schema.TypeTimestamp, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[3], schema.TypeString, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[4], schema.TypeInt32, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[5], schema.TypeBoolean, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[6], schema.TypeDecimal, 18, 5)
+	requireArrayColumn(t, tableSchema.Columns[7], schema.TypeUUID, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[8], schema.TypeString, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[9], schema.TypeString, 0, 0)
+	requireArrayColumn(t, tableSchema.Columns[10], schema.TypeString, 0, 0)
+
+	records, err := table.Read(ctx, source.ReadOptions{PageSize: 10})
+	require.NoError(t, err)
+
+	var batch arrow.RecordBatch
+	for res := range records {
+		require.NoError(t, res.Err)
+		if batch == nil {
+			batch = res.Batch
+			continue
+		}
+		res.Batch.Release()
+	}
+	require.NotNil(t, batch)
+	defer batch.Release()
+
+	require.Equal(t, int64(1), batch.NumRows())
+	requireTimestampList(t, batch.Column(1), []*time.Time{&first, &second})
+	requireTimestampList(t, batch.Column(2), []*time.Time{&first, nil, &second})
+	requireStringList(t, batch.Column(3), []*string{stringPtr("alpha"), nil, stringPtr("omega")})
+	requireInt32List(t, batch.Column(4), []*int32{int32Ptr(1), nil, int32Ptr(65535)})
+	requireBoolList(t, batch.Column(5), []*bool{boolPtr(true), nil, boolPtr(false)})
+	requireDecimalList(t, batch.Column(6), []string{"1234567", "", "8900001"})
+	requireStringList(t, batch.Column(7), []*string{
+		stringPtr("11111111-1111-1111-1111-111111111111"),
+		nil,
+		stringPtr("22222222-2222-2222-2222-222222222222"),
+	})
+	requireStringList(t, batch.Column(8), []*string{stringPtr("127.0.0.1"), nil, stringPtr("8.8.8.8")})
+	requireStringList(t, batch.Column(9), []*string{stringPtr("Click\x00\x00\x00\x00\x00"), nil, stringPtr("House\x00\x00\x00\x00\x00")})
+	requireStringList(t, batch.Column(10), []*string{stringPtr("click"), nil, stringPtr("house")})
+}
+
 func countDuckDBRows(t *testing.T, dbPath, table string) int {
 	t.Helper()
 	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", dbPath))
@@ -369,6 +447,158 @@ func setupClickHouseSourceTableWithTimestamp(t *testing.T, ctx context.Context, 
 		require.NoError(t, err)
 	}
 }
+
+func setupClickHouseArrayTypesTable(t *testing.T, ctx context.Context, uri string, table string, first, second time.Time) {
+	t.Helper()
+
+	opts, err := clickhouse.ParseDSN(uri)
+	require.NoError(t, err)
+
+	db := clickhouse.OpenDB(opts)
+	defer func() { _ = db.Close() }()
+
+	createSQL := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id UInt8,
+			offer_departure Array(DateTime),
+			nullable_departure Array(Nullable(DateTime)),
+			tags Array(Nullable(String)),
+			scores Array(Nullable(UInt16)),
+			flags Array(Nullable(Bool)),
+			prices Array(Nullable(Decimal(18,5))),
+			uuids Array(Nullable(UUID)),
+			ips Array(Nullable(IPv4)),
+			fixed_names Array(Nullable(FixedString(10))),
+			event_types Array(Nullable(Enum8('click' = 1, 'house' = 2)))
+		) ENGINE = MergeTree()
+		ORDER BY id
+	`, table)
+
+	_, err = db.ExecContext(ctx, createSQL)
+	require.NoError(t, err)
+
+	insertSQL := fmt.Sprintf(
+		`INSERT INTO %s VALUES (
+			1,
+			[toDateTime('%s'), toDateTime('%s')],
+			[toDateTime('%s'), NULL, toDateTime('%s')],
+			['alpha', NULL, 'omega'],
+			[1, NULL, 65535],
+			[true, NULL, false],
+			[toDecimal64(12.34567, 5), NULL, toDecimal64(89.00001, 5)],
+			[toUUID('11111111-1111-1111-1111-111111111111'), NULL, toUUID('22222222-2222-2222-2222-222222222222')],
+			[toIPv4('127.0.0.1'), NULL, toIPv4('8.8.8.8')],
+			['Click', NULL, 'House'],
+			['click', NULL, 'house']
+		)`,
+		table,
+		first.Format("2006-01-02 15:04:05"),
+		second.Format("2006-01-02 15:04:05"),
+		first.Format("2006-01-02 15:04:05"),
+		second.Format("2006-01-02 15:04:05"),
+	)
+	_, err = db.ExecContext(ctx, insertSQL)
+	require.NoError(t, err)
+}
+
+func requireArrayColumn(t *testing.T, col schema.Column, arrayType schema.DataType, precision, scale int) {
+	t.Helper()
+	require.Equal(t, schema.TypeArray, col.DataType)
+	require.Equal(t, arrayType, col.ArrayType)
+	require.Equal(t, precision, col.Precision)
+	require.Equal(t, scale, col.Scale)
+}
+
+func requireTimestampList(t *testing.T, col arrow.Array, want []*time.Time) {
+	t.Helper()
+	list, ok := col.(*array.List)
+	require.True(t, ok)
+	require.False(t, list.IsNull(0))
+	values := list.ListValues().(*array.Timestamp)
+	require.Equal(t, len(want), values.Len())
+	for i, expected := range want {
+		if expected == nil {
+			assert.True(t, values.IsNull(i))
+			continue
+		}
+		assert.False(t, values.IsNull(i))
+		assert.Equal(t, arrow.Timestamp(expected.UnixMicro()), values.Value(i))
+	}
+}
+
+func requireStringList(t *testing.T, col arrow.Array, want []*string) {
+	t.Helper()
+	list, ok := col.(*array.List)
+	require.True(t, ok)
+	require.False(t, list.IsNull(0))
+	values := list.ListValues().(*array.String)
+	require.Equal(t, len(want), values.Len())
+	for i, expected := range want {
+		if expected == nil {
+			assert.True(t, values.IsNull(i))
+			continue
+		}
+		assert.False(t, values.IsNull(i))
+		assert.Equal(t, *expected, values.Value(i))
+	}
+}
+
+func requireInt32List(t *testing.T, col arrow.Array, want []*int32) {
+	t.Helper()
+	list, ok := col.(*array.List)
+	require.True(t, ok)
+	require.False(t, list.IsNull(0))
+	values := list.ListValues().(*array.Int32)
+	require.Equal(t, len(want), values.Len())
+	for i, expected := range want {
+		if expected == nil {
+			assert.True(t, values.IsNull(i))
+			continue
+		}
+		assert.False(t, values.IsNull(i))
+		assert.Equal(t, *expected, values.Value(i))
+	}
+}
+
+func requireBoolList(t *testing.T, col arrow.Array, want []*bool) {
+	t.Helper()
+	list, ok := col.(*array.List)
+	require.True(t, ok)
+	require.False(t, list.IsNull(0))
+	values := list.ListValues().(*array.Boolean)
+	require.Equal(t, len(want), values.Len())
+	for i, expected := range want {
+		if expected == nil {
+			assert.True(t, values.IsNull(i))
+			continue
+		}
+		assert.False(t, values.IsNull(i))
+		assert.Equal(t, *expected, values.Value(i))
+	}
+}
+
+func requireDecimalList(t *testing.T, col arrow.Array, wantRawScaled []string) {
+	t.Helper()
+	list, ok := col.(*array.List)
+	require.True(t, ok)
+	require.False(t, list.IsNull(0))
+	values := list.ListValues().(*array.Decimal128)
+	require.Equal(t, len(wantRawScaled), values.Len())
+	for i, expected := range wantRawScaled {
+		if expected == "" {
+			assert.True(t, values.IsNull(i))
+			continue
+		}
+		assert.False(t, values.IsNull(i))
+		assert.Equal(t, expected, decimal128.Num(values.Value(i)).BigInt().String())
+	}
+}
+
+func stringPtr(v string) *string { return &v }
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func boolPtr(v bool) *bool { return &v }
 
 func insertClickHouseSimpleRow(t *testing.T, ctx context.Context, uri string, table string, id int, name string, score float64, active bool) {
 	t.Helper()

--- a/pkg/source/clickhouse/mapper.go
+++ b/pkg/source/clickhouse/mapper.go
@@ -16,6 +16,7 @@ var (
 	fixedStringRe   = regexp.MustCompile(`(?i)FixedString\s*\(\s*(\d+)\s*\)`)
 	enumRegex       = regexp.MustCompile(`(?i)Enum(?:8|16)\s*\(`)
 	datetime64Regex = regexp.MustCompile(`(?i)DateTime64\s*\(\s*(\d+)`)
+	datetimeRegex   = regexp.MustCompile(`(?i)^DateTime\s*(?:\(.+\))?$`)
 )
 
 func MapClickHouseToDataType(chType string) (schema.DataType, int, int, schema.DataType) {
@@ -33,8 +34,8 @@ func MapClickHouseToDataType(chType string) (schema.DataType, int, int, schema.D
 
 	// Handle Array(T)
 	if matches := arrayRegex.FindStringSubmatch(chType); len(matches) == 2 {
-		elemType, _, _, _ := MapClickHouseToDataType(matches[1])
-		return schema.TypeArray, 0, 0, elemType
+		elemType, precision, scale, _ := MapClickHouseToDataType(matches[1])
+		return schema.TypeArray, precision, scale, elemType
 	}
 
 	// Handle Decimal types with precision/scale
@@ -58,7 +59,7 @@ func MapClickHouseToDataType(chType string) (schema.DataType, int, int, schema.D
 	}
 
 	// Handle DateTime64 with precision
-	if datetime64Regex.MatchString(chType) {
+	if datetime64Regex.MatchString(chType) || datetimeRegex.MatchString(chType) {
 		return schema.TypeTimestamp, 0, 0, schema.TypeUnknown
 	}
 

--- a/pkg/source/clickhouse/mapper_test.go
+++ b/pkg/source/clickhouse/mapper_test.go
@@ -1,10 +1,15 @@
 package clickhouse
 
 import (
+	"math/big"
+	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,6 +41,30 @@ func TestMapClickHouseToDataType_ArrayWrappers(t *testing.T) {
 			wantArray: schema.TypeString,
 		},
 		{
+			name:      "array datetime",
+			input:     "Array(DateTime)",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeTimestamp,
+		},
+		{
+			name:      "array datetime64 timezone",
+			input:     "Array(DateTime64(3, 'Europe/Moscow'))",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeTimestamp,
+		},
+		{
+			name:      "array datetime timezone",
+			input:     "Array(DateTime('UTC'))",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeTimestamp,
+		},
+		{
+			name:      "array decimal",
+			input:     "Array(Decimal(18,5))",
+			wantType:  schema.TypeArray,
+			wantArray: schema.TypeDecimal,
+		},
+		{
 			name:      "low cardinality nullable string",
 			input:     "LowCardinality(Nullable(String))",
 			wantType:  schema.TypeString,
@@ -50,8 +79,13 @@ func TestMapClickHouseToDataType_ArrayWrappers(t *testing.T) {
 			gotType, gotPrecision, gotScale, gotArray := MapClickHouseToDataType(tt.input)
 
 			require.Equal(t, tt.wantType, gotType)
-			require.Equal(t, 0, gotPrecision)
-			require.Equal(t, 0, gotScale)
+			if tt.input == "Array(Decimal(18,5))" {
+				require.Equal(t, 18, gotPrecision)
+				require.Equal(t, 5, gotScale)
+			} else {
+				require.Equal(t, 0, gotPrecision)
+				require.Equal(t, 0, gotScale)
+			}
 			require.Equal(t, tt.wantArray, gotArray)
 		})
 	}
@@ -62,7 +96,6 @@ func TestNativeScanTarget_ArrayWrappers(t *testing.T) {
 
 	tests := []string{
 		"Array(LowCardinality(String))",
-		"Array(Nullable(String))",
 		"Nullable(Array(LowCardinality(String)))",
 	}
 
@@ -75,4 +108,131 @@ func TestNativeScanTarget_ArrayWrappers(t *testing.T) {
 			require.Equal(t, wantType, reflect.TypeOf(nativeScanTarget(input, false)))
 		})
 	}
+}
+
+func TestNativeScanTarget_ArrayScalarTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		wantType reflect.Type
+	}{
+		{
+			input:    "Array(Bool)",
+			wantType: reflect.TypeOf(new([]bool)),
+		},
+		{
+			input:    "Array(Nullable(Bool))",
+			wantType: reflect.TypeOf(new([]*bool)),
+		},
+		{
+			input:    "Array(Int8)",
+			wantType: reflect.TypeOf(new([]int8)),
+		},
+		{
+			input:    "Array(Nullable(Int16))",
+			wantType: reflect.TypeOf(new([]*int16)),
+		},
+		{
+			input:    "Array(UInt8)",
+			wantType: reflect.TypeOf(new([]uint8)),
+		},
+		{
+			input:    "Array(Nullable(UInt16))",
+			wantType: reflect.TypeOf(new([]*uint16)),
+		},
+		{
+			input:    "Array(UInt64)",
+			wantType: reflect.TypeOf(new([]uint64)),
+		},
+		{
+			input:    "Array(Int128)",
+			wantType: reflect.TypeOf(new([]*big.Int)),
+		},
+		{
+			input:    "Array(Nullable(UInt256))",
+			wantType: reflect.TypeOf(new([]*big.Int)),
+		},
+		{
+			input:    "Array(Float32)",
+			wantType: reflect.TypeOf(new([]float32)),
+		},
+		{
+			input:    "Array(Nullable(Float64))",
+			wantType: reflect.TypeOf(new([]*float64)),
+		},
+		{
+			input:    "Array(String)",
+			wantType: reflect.TypeOf(new([]string)),
+		},
+		{
+			input:    "Array(Nullable(String))",
+			wantType: reflect.TypeOf(new([]*string)),
+		},
+		{
+			input:    "Array(FixedString(10))",
+			wantType: reflect.TypeOf(new([]string)),
+		},
+		{
+			input:    "Array(Nullable(Enum8('click' = 1, 'house' = 2)))",
+			wantType: reflect.TypeOf(new([]*string)),
+		},
+		{
+			input:    "Array(Decimal(18,5))",
+			wantType: reflect.TypeOf(new([]decimal.Decimal)),
+		},
+		{
+			input:    "Array(Nullable(Decimal(18,5)))",
+			wantType: reflect.TypeOf(new([]*decimal.Decimal)),
+		},
+		{
+			input:    "Array(UUID)",
+			wantType: reflect.TypeOf(new([]uuid.UUID)),
+		},
+		{
+			input:    "Array(Nullable(UUID))",
+			wantType: reflect.TypeOf(new([]*uuid.UUID)),
+		},
+		{
+			input:    "Array(IPv4)",
+			wantType: reflect.TypeOf(new([]net.IP)),
+		},
+		{
+			input:    "Array(Nullable(IPv6))",
+			wantType: reflect.TypeOf(new([]*net.IP)),
+		},
+		{
+			input:    "Array(Date)",
+			wantType: reflect.TypeOf(new([]time.Time)),
+		},
+		{
+			input:    "Array(DateTime)",
+			wantType: reflect.TypeOf(new([]time.Time)),
+		},
+		{
+			input:    "Array(DateTime64(3, 'Europe/Moscow'))",
+			wantType: reflect.TypeOf(new([]time.Time)),
+		},
+		{
+			input:    "Array(Nullable(DateTime))",
+			wantType: reflect.TypeOf(new([]*time.Time)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.wantType, reflect.TypeOf(nativeScanTarget(tt.input, false)))
+		})
+	}
+}
+
+func TestExtractValue_ArrayUint8(t *testing.T) {
+	t.Parallel()
+
+	values := []uint8{1, 2, 255}
+	got := extractValue(&values)
+
+	require.Equal(t, values, got)
 }


### PR DESCRIPTION
Improves ClickHouse array ingestion for nullable scalar arrays, timestamps, decimals, UUIDs, IPs, fixed strings, and enums.\n\nIt also preserves decimal precision/scale for array Arrow types and adds focused unit and integration coverage.\n\nValidated with go test ./pkg/arrowconv ./pkg/schema ./pkg/source/clickhouse and go test -short ./....

Fixes #780 