### PR TITLE
ci: install uv in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - name: Install uv
+        run: |
+          python3 -m pip install --user uv
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run test suite
         run: make ${{ matrix.suite }}
 


### PR DESCRIPTION
## Summary
- install uv in the release workflow before the test matrix runs
- mirror the existing PR CI setup so make test can run Python SDK tests

## Validation
- make format
- make lint
- make test

Direct push to main was rejected by repository rules requiring changes through a pull request.