### PR TITLE
ci: install uv with setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Install uv
-        run: |
-          python3 -m pip install --user uv
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Run test suite
         run: make ${{ matrix.suite }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,7 @@ jobs:
           go-version-file: 'go.mod'
           cache-dependency-path: "go.sum"
       - name: Install uv
-        run: |
-          python3 -m pip install --user uv
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        uses: astral-sh/setup-uv@v8.2.0
       - run: make test
 
   end2end:


### PR DESCRIPTION
## Summary
- replace pip-based uv installation with astral-sh/setup-uv@v8 in CI and release workflows
- keep the PR and release test jobs aligned while avoiding macOS/Homebrew Python PEP 668 failures

## Root cause
The release workflow now installs uv before running tests, but the macOS runner uses an externally managed Python environment. That makes python3 -m pip install --user uv fail before the test suite starts.

## Validation
- make format
- make lint
- make test

## Notes
The failed release run was for tag v1.0.29 at 4eec6fc6535043dd8f7864093dcde13377067357. Re-running that same tag workflow will still use the workflow file from that tag commit; after this merges, a new tag or moved tag is needed for the release workflow to pick up this fix.