### PR TITLE
Validate SQL Server CDC source and fix CDC merge semantics across all destinations

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1576,16 +1576,40 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 	fmt.Fprintf(&sql, "MERGE %s.%s.%s AS t\n", quoteIdentifier(d.projectID), quoteIdentifier(targetDataset), quoteIdentifier(targetTable))
 
 	if hasCDCDeleted && len(primaryKeys) > 0 {
-		// CDC mode: deduplicate staging table by PKs, keeping the latest change per row.
-		// This handles cases where the same row appears in both the snapshot and WAL stream.
+		// CDC mode: compose the merge source from two per-PK dedups of staging:
+		// data columns come from the latest non-deleted change (so a trailing
+		// delete doesn't discard the last update's values), while the CDC
+		// columns and deleted flag come from the latest change overall. This
+		// also materializes rows that were inserted and deleted within one sync
+		// window as soft-deleted rows, storing the delete's LSN for resume.
 		pkPartition := make([]string, len(primaryKeys))
+		laActJoin := make([]string, len(primaryKeys))
 		for i, pk := range primaryKeys {
-			pkPartition[i] = quoteIdentifier(pk)
+			quoted := quoteIdentifier(pk)
+			pkPartition[i] = quoted
+			laActJoin[i] = fmt.Sprintf("(la.%s = act.%s OR (la.%s IS NULL AND act.%s IS NULL))", quoted, quoted, quoted, quoted)
 		}
+
+		selectCols := make([]string, 0, len(allColumns)+1)
+		for _, col := range allColumns {
+			alias := "act"
+			if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+				alias = "la"
+			}
+			selectCols = append(selectCols, fmt.Sprintf("%s.%s", alias, quoteIdentifier(col)))
+		}
+		selectCols = append(selectCols, "act.`_cdc_lsn` IS NOT NULL AS `__ingestr_has_active`")
+
+		stagingRef := fmt.Sprintf("%s.%s.%s", quoteIdentifier(d.projectID), quoteIdentifier(stagingDataset), quoteIdentifier(stagingTable))
 		fmt.Fprintf(
 			&sql,
-			"USING (SELECT * FROM %s.%s.%s QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC, `_cdc_deleted` DESC) = 1) AS s\n",
-			quoteIdentifier(d.projectID), quoteIdentifier(stagingDataset), quoteIdentifier(stagingTable), strings.Join(pkPartition, ", "),
+			"USING (SELECT %s FROM (SELECT * FROM %s QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC, `_cdc_deleted` DESC) = 1) AS la LEFT JOIN (SELECT * FROM %s WHERE `_cdc_deleted` = false QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC) = 1) AS act ON %s) AS s\n",
+			strings.Join(selectCols, ", "),
+			stagingRef,
+			strings.Join(pkPartition, ", "),
+			stagingRef,
+			strings.Join(pkPartition, ", "),
+			strings.Join(laActJoin, " AND "),
 		)
 	} else {
 		pkPartition := make([]string, len(primaryKeys))
@@ -1609,20 +1633,25 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 	fmt.Fprintf(&sql, "ON %s\n", onClause)
 
 	if hasCDCDeleted {
-		// CDC mode: handle deleted rows specially (only update CDC columns to preserve original data)
-
-		// WHEN MATCHED AND NOT deleted: full update
+		// Full update whenever the window has a non-deleted change carrying row
+		// data; for deleted PKs this applies the last active values together
+		// with the delete marking. Clause order matters: BigQuery executes the
+		// first matching WHEN clause.
 		if len(updateSets) > 0 {
-			sql.WriteString("WHEN MATCHED AND s.`_cdc_deleted` = false THEN\n")
+			sql.WriteString("WHEN MATCHED AND (s.`_cdc_deleted` = false OR s.`__ingestr_has_active`) THEN\n")
 			fmt.Fprintf(&sql, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
 		}
 
-		// WHEN MATCHED AND deleted: only update CDC columns (preserve original data)
+		// Delete-only window for an existing row: update CDC columns and keep
+		// the row data as-is (the delete change carries no usable row image for
+		// all sources).
 		sql.WriteString("WHEN MATCHED AND s.`_cdc_deleted` = true THEN\n")
 		sql.WriteString("  UPDATE SET t.`_cdc_deleted` = true, t.`_cdc_lsn` = s.`_cdc_lsn`, t.`_cdc_synced_at` = s.`_cdc_synced_at`\n")
 
-		// WHEN NOT MATCHED AND NOT deleted: insert
-		sql.WriteString("WHEN NOT MATCHED AND s.`_cdc_deleted` = false THEN\n")
+		// Insert new rows, including ones already deleted within the window
+		// (materialized as soft-deleted). A delete-only window for an unknown
+		// row has no data to materialize and is skipped.
+		sql.WriteString("WHEN NOT MATCHED AND (s.`_cdc_deleted` = false OR s.`__ingestr_has_active`) THEN\n")
 		fmt.Fprintf(&sql, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
 		fmt.Fprintf(&sql, "  VALUES (%s)", strings.Join(sourceCols, ", "))
 	} else {
@@ -1886,6 +1915,22 @@ func isAlreadyExistsError(err error) bool {
 // contains checks if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsHelper(s, substr))
+}
+
+// DestTableName maps a multi-table source name like "dbo.orders" to a valid
+// BigQuery "dataset.table" name: BigQuery table IDs cannot contain dots, so
+// the source's schema qualifier is folded into the table name. The dataset is
+// the configured dest_schema, falling back to the dataset from the URI.
+func (d *BigQueryDestination) DestTableName(destSchema, sourceTable string) string {
+	dataset := destSchema
+	if dataset == "" {
+		dataset = d.datasetID
+	}
+	table := strings.ReplaceAll(sourceTable, ".", "_")
+	if dataset == "" {
+		return table
+	}
+	return dataset + "." + table
 }
 
 func (d *BigQueryDestination) SupportsCDCMerge() bool {

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1570,7 +1569,7 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 	}
 
 	// Check if this is CDC mode (has _cdc_deleted column)
-	hasCDCDeleted := slices.Contains(allColumns, "_cdc_deleted")
+	hasCDCDeleted := destination.HasCDCDeletedColumn(allColumns)
 
 	var sql strings.Builder
 	fmt.Fprintf(&sql, "MERGE %s.%s.%s AS t\n", quoteIdentifier(d.projectID), quoteIdentifier(targetDataset), quoteIdentifier(targetTable))

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1602,10 +1602,11 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 		stagingRef := fmt.Sprintf("%s.%s.%s", quoteIdentifier(d.projectID), quoteIdentifier(stagingDataset), quoteIdentifier(stagingTable))
 		fmt.Fprintf(
 			&sql,
-			"USING (SELECT %s FROM (SELECT * FROM %s QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC, `_cdc_deleted` DESC) = 1) AS la LEFT JOIN (SELECT * FROM %s WHERE `_cdc_deleted` = false QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC) = 1) AS act ON %s) AS s\n",
+			"USING (SELECT %s FROM (SELECT * FROM %s QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1) AS la LEFT JOIN (SELECT * FROM %s WHERE `_cdc_deleted` = false QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC) = 1) AS act ON %s) AS s\n",
 			strings.Join(selectCols, ", "),
 			stagingRef,
 			strings.Join(pkPartition, ", "),
+			destination.CDCLatestOverallOrderBy(quoteIdentifier),
 			stagingRef,
 			strings.Join(pkPartition, ", "),
 			strings.Join(laActJoin, " AND "),

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -1038,6 +1038,33 @@ func TestBuildMergeSQL(t *testing.T) {
 			t.Fatalf("sql missing null-safe on clause for non-cast pk:\n%s", sql)
 		}
 	})
+
+	t.Run("cdc_mode", func(t *testing.T) {
+		sql := dest.buildMergeSQL("target_ds", "target_tbl", "staging_ds", "staging_tbl",
+			[]string{"id"}, []string{"id", "name", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"}, nil, "")
+
+		if !contains(sql, "SELECT la.`id`, act.`name`, la.`_cdc_lsn`, la.`_cdc_deleted`, la.`_cdc_synced_at`, act.`_cdc_lsn` IS NOT NULL AS `__ingestr_has_active`") {
+			t.Fatalf("sql missing composed source columns (data from latest active, CDC from latest overall):\n%s", sql)
+		}
+		if !contains(sql, "ORDER BY `_cdc_lsn` DESC, `_cdc_deleted` DESC) = 1) AS la") {
+			t.Fatalf("sql missing latest-overall dedup:\n%s", sql)
+		}
+		if !contains(sql, "WHERE `_cdc_deleted` = false QUALIFY ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `_cdc_lsn` DESC) = 1) AS act") {
+			t.Fatalf("sql missing latest-active dedup:\n%s", sql)
+		}
+		if !contains(sql, "WHEN MATCHED AND (s.`_cdc_deleted` = false OR s.`__ingestr_has_active`) THEN\n  UPDATE SET t.`name` = s.`name`") {
+			t.Fatalf("sql missing full update for active or update-then-deleted rows:\n%s", sql)
+		}
+		if !contains(sql, "WHEN MATCHED AND s.`_cdc_deleted` = true THEN\n  UPDATE SET t.`_cdc_deleted` = true, t.`_cdc_lsn` = s.`_cdc_lsn`, t.`_cdc_synced_at` = s.`_cdc_synced_at`") {
+			t.Fatalf("sql missing CDC-only update for delete-only windows:\n%s", sql)
+		}
+		if !contains(sql, "WHEN NOT MATCHED AND (s.`_cdc_deleted` = false OR s.`__ingestr_has_active`) THEN\n  INSERT (`id`, `name`, `_cdc_lsn`, `_cdc_deleted`, `_cdc_synced_at`)") {
+			t.Fatalf("sql missing insert clause materializing insert-then-deleted rows:\n%s", sql)
+		}
+		if contains(sql, "WHEN NOT MATCHED AND s.`_cdc_deleted` = false THEN") {
+			t.Fatalf("sql still has the old insert clause that drops insert-then-deleted rows:\n%s", sql)
+		}
+	})
 }
 
 func TestBuildBigQueryDedupSelect_StringShape(t *testing.T) {

--- a/pkg/destination/bigquery/mapper_test.go
+++ b/pkg/destination/bigquery/mapper_test.go
@@ -445,3 +445,48 @@ func TestSplitTableName(t *testing.T) {
 		})
 	}
 }
+
+func TestDestTableName(t *testing.T) {
+	tests := []struct {
+		name        string
+		destSchema  string
+		sourceTable string
+		datasetID   string
+		want        string
+	}{
+		{
+			name:        "qualified_source_with_dest_schema",
+			destSchema:  "raw",
+			sourceTable: "dbo.orders",
+			want:        "raw.dbo_orders",
+		},
+		{
+			name:        "falls_back_to_uri_dataset",
+			sourceTable: "dbo.orders",
+			datasetID:   "mydataset",
+			want:        "mydataset.dbo_orders",
+		},
+		{
+			name:        "unqualified_source",
+			destSchema:  "raw",
+			sourceTable: "orders",
+			want:        "raw.orders",
+		},
+		{
+			name:        "no_dataset_anywhere",
+			sourceTable: "dbo.orders",
+			want:        "dbo_orders",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := NewBigQueryDestination()
+			dest.datasetID = tt.datasetID
+			got := dest.DestTableName(tt.destSchema, tt.sourceTable)
+			if got != tt.want {
+				t.Errorf("DestTableName(%q, %q) = %q, want %q", tt.destSchema, tt.sourceTable, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/destination/cassandra/cassandra.go
+++ b/pkg/destination/cassandra/cassandra.go
@@ -378,10 +378,11 @@ func (d *CassandraDestination) MergeTable(ctx context.Context, opts destination.
 // from a bare delete image.
 func (d *CassandraDestination) mergeCDC(ctx context.Context, targetRef, selectSQL, insertSQL string, opts destination.MergeOptions) error {
 	type cdcEntry struct {
-		latest    map[string]interface{}
-		latestLSN string
-		active    map[string]interface{}
-		activeLSN string
+		latest        map[string]interface{}
+		latestLSN     string
+		latestDeleted bool
+		active        map[string]interface{}
+		activeLSN     string
 	}
 	entries := map[string]*cdcEntry{}
 
@@ -405,9 +406,10 @@ func (d *CassandraDestination) mergeCDC(ctx context.Context, targetRef, selectSQ
 		}
 		lsn, _ := row[destination.CDCLSNColumn].(string)
 		deleted, _ := row[destination.CDCDeletedColumn].(bool)
-		if entry.latest == nil || lsn > entry.latestLSN {
+		if entry.latest == nil || destination.CDCSupersedes(lsn, deleted, entry.latestLSN, entry.latestDeleted) {
 			entry.latest = row
 			entry.latestLSN = lsn
+			entry.latestDeleted = deleted
 		}
 		if !deleted && (entry.active == nil || lsn > entry.activeLSN) {
 			entry.active = row

--- a/pkg/destination/cassandra/cassandra.go
+++ b/pkg/destination/cassandra/cassandra.go
@@ -99,6 +99,12 @@ func (d *CassandraDestination) PrepareTable(ctx context.Context, opts destinatio
 	if len(pks) == 0 {
 		pks = opts.Schema.PrimaryKeys
 	}
+	if opts.CDCMode {
+		// CDC staging holds multiple change rows per source PK, which a
+		// PK-keyed table would silently collapse (CQL INSERT is an upsert).
+		// Add the LSN as a clustering key; LSNs are unique per change row.
+		pks = append(append([]string{}, pks...), destination.CDCLSNColumn)
+	}
 	createSQL, err := buildCreateTableSQL(tableRef, opts.Schema.Columns, pks)
 	if err != nil {
 		return err
@@ -333,6 +339,10 @@ func (d *CassandraDestination) MergeTable(ctx context.Context, opts destination.
 		strings.Join(placeholders, ", "),
 	)
 
+	if destination.HasCDCDeletedColumn(opts.Columns) && len(opts.PrimaryKeys) > 0 {
+		return d.mergeCDC(ctx, targetRef, selectSQL, insertSQL, opts)
+	}
+
 	iter := d.session.Query(selectSQL).IterContext(ctx)
 
 	var merged int64
@@ -357,6 +367,128 @@ func (d *CassandraDestination) MergeTable(ctx context.Context, opts destination.
 
 	config.Debug("[CASSANDRA DEST] Merge complete: %d rows upserted into %s", merged, opts.TargetTable)
 	return nil
+}
+
+// mergeCDC composes one row per PK from CDC staging data: row data comes from
+// the latest non-deleted change (so a trailing delete keeps the last update's
+// values), CDC columns and the deleted flag from the latest change overall.
+// Scan order is token order, so the latest change per PK is tracked by
+// comparing the fixed-width LSN strings. Delete-only windows update CDC
+// columns on existing rows only (IF EXISTS); unknown rows are not materialized
+// from a bare delete image.
+func (d *CassandraDestination) mergeCDC(ctx context.Context, targetRef, selectSQL, insertSQL string, opts destination.MergeOptions) error {
+	type cdcEntry struct {
+		latest    map[string]interface{}
+		latestLSN string
+		active    map[string]interface{}
+		activeLSN string
+	}
+	entries := map[string]*cdcEntry{}
+
+	iter := d.session.Query(selectSQL).IterContext(ctx)
+	for {
+		row := make(map[string]interface{}, len(opts.Columns))
+		if !iter.MapScan(row) {
+			break
+		}
+
+		keyParts := make([]string, len(opts.PrimaryKeys))
+		for i, pk := range opts.PrimaryKeys {
+			keyParts[i] = fmt.Sprintf("%v", row[pk])
+		}
+		key := strings.Join(keyParts, "\x00")
+
+		entry, ok := entries[key]
+		if !ok {
+			entry = &cdcEntry{}
+			entries[key] = entry
+		}
+		lsn, _ := row[destination.CDCLSNColumn].(string)
+		deleted, _ := row[destination.CDCDeletedColumn].(bool)
+		if entry.latest == nil || lsn > entry.latestLSN {
+			entry.latest = row
+			entry.latestLSN = lsn
+		}
+		if !deleted && (entry.active == nil || lsn > entry.activeLSN) {
+			entry.active = row
+			entry.activeLSN = lsn
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return fmt.Errorf("failed to scan Cassandra staging table: %w", err)
+	}
+
+	pkConds := make([]string, len(opts.PrimaryKeys))
+	for i, pk := range opts.PrimaryKeys {
+		pkConds[i] = cassandrautil.QuoteIdentifier(pk) + " = ?"
+	}
+	markDeletedSQL := fmt.Sprintf(
+		"UPDATE %s SET %s = ?, %s = ?, %s = ? WHERE %s IF EXISTS",
+		targetRef,
+		cassandrautil.QuoteIdentifier(destination.CDCDeletedColumn),
+		cassandrautil.QuoteIdentifier(destination.CDCLSNColumn),
+		cassandrautil.QuoteIdentifier(destination.CDCSyncedAtColumn),
+		strings.Join(pkConds, " AND "),
+	)
+
+	var merged int64
+	for _, entry := range entries {
+		if entry.active == nil {
+			values := []interface{}{
+				entry.latest[destination.CDCDeletedColumn],
+				entry.latest[destination.CDCLSNColumn],
+				entry.latest[destination.CDCSyncedAtColumn],
+			}
+			for _, pk := range opts.PrimaryKeys {
+				values = append(values, entry.latest[pk])
+			}
+			if err := d.session.Query(markDeletedSQL, values...).ExecContext(ctx); err != nil {
+				return fmt.Errorf("failed to mark CDC delete during merge: %w", err)
+			}
+			merged++
+			continue
+		}
+
+		row := entry.active
+		row[destination.CDCDeletedColumn] = entry.latest[destination.CDCDeletedColumn]
+		row[destination.CDCLSNColumn] = entry.latest[destination.CDCLSNColumn]
+		row[destination.CDCSyncedAtColumn] = entry.latest[destination.CDCSyncedAtColumn]
+
+		values := make([]interface{}, len(opts.Columns))
+		for i, col := range opts.Columns {
+			values[i] = row[col]
+		}
+		if err := d.session.Query(insertSQL, values...).ExecContext(ctx); err != nil {
+			return fmt.Errorf("failed to upsert Cassandra CDC row during merge: %w", err)
+		}
+		merged++
+	}
+
+	config.Debug("[CASSANDRA DEST] CDC merge complete: %d rows applied to %s", merged, opts.TargetTable)
+	return nil
+}
+
+func (d *CassandraDestination) SupportsCDCMerge() bool { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *CassandraDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	tableRef, err := cassandrautil.QuoteTable(d.keyspace, table)
+	if err != nil {
+		return "", err
+	}
+
+	var maxLSN *string
+	query := fmt.Sprintf("SELECT MAX(%s) FROM %s", cassandrautil.QuoteIdentifier(destination.CDCLSNColumn), tableRef)
+	if err := d.session.Query(query).ScanContext(ctx, &maxLSN); err != nil {
+		if strings.Contains(err.Error(), "unconfigured table") || strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "keyspace") {
+			return "", nil
+		}
+		return "", err
+	}
+	if maxLSN == nil {
+		return "", nil
+	}
+	return *maxLSN, nil
 }
 
 func (d *CassandraDestination) DeleteInsertTable(_ context.Context, _ destination.DeleteInsertOptions) error {

--- a/pkg/destination/cdc.go
+++ b/pkg/destination/cdc.go
@@ -23,6 +23,26 @@ func IsCDCColumn(column string) bool {
 		strings.EqualFold(column, CDCSyncedAtColumn)
 }
 
+// CDCLatestOverallOrderBy returns the ORDER BY expression that picks the
+// latest change per PK overall: highest LSN first, preferring deletes on LSN
+// ties (e.g. rows sharing a snapshot stamp) so a tied delete still marks the
+// row deleted. LSN strings are fixed-width per source, so plain text ordering
+// matches LSN order.
+func CDCLatestOverallOrderBy(quote func(string) string) string {
+	return quote(CDCLSNColumn) + " DESC, " + quote(CDCDeletedColumn) + " DESC"
+}
+
+// CDCSupersedes reports whether a change (lsn, deleted) replaces a previously
+// seen change (prevLSN, prevDeleted) as the latest change overall for a PK.
+// It mirrors CDCLatestOverallOrderBy for destinations that compose changes in
+// Go instead of SQL.
+func CDCSupersedes(lsn string, deleted bool, prevLSN string, prevDeleted bool) bool {
+	if lsn != prevLSN {
+		return lsn > prevLSN
+	}
+	return deleted && !prevDeleted
+}
+
 func CDCDataColumns(columns, primaryKeys []string) []string {
 	pkSet := make(map[string]bool, len(primaryKeys))
 	for _, pk := range primaryKeys {

--- a/pkg/destination/cdc_test.go
+++ b/pkg/destination/cdc_test.go
@@ -1,0 +1,40 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCDCLatestOverallOrderBy(t *testing.T) {
+	ansi := func(s string) string { return `"` + s + `"` }
+	backtick := func(s string) string { return "`" + s + "`" }
+	bracket := func(s string) string { return "[" + s + "]" }
+
+	assert.Equal(t, `"_cdc_lsn" DESC, "_cdc_deleted" DESC`, CDCLatestOverallOrderBy(ansi))
+	assert.Equal(t, "`_cdc_lsn` DESC, `_cdc_deleted` DESC", CDCLatestOverallOrderBy(backtick))
+	assert.Equal(t, "[_cdc_lsn] DESC, [_cdc_deleted] DESC", CDCLatestOverallOrderBy(bracket))
+}
+
+func TestCDCSupersedes(t *testing.T) {
+	tests := []struct {
+		name        string
+		lsn         string
+		deleted     bool
+		prevLSN     string
+		prevDeleted bool
+		want        bool
+	}{
+		{"higher LSN wins", "0002", false, "0001", true, true},
+		{"lower LSN loses", "0001", true, "0002", false, false},
+		{"tie: delete supersedes non-delete", "0001", true, "0001", false, true},
+		{"tie: non-delete does not supersede delete", "0001", false, "0001", true, false},
+		{"tie: equal deleted flags keep first", "0001", true, "0001", true, false},
+		{"tie: equal non-deleted keep first", "0001", false, "0001", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CDCSupersedes(tt.lsn, tt.deleted, tt.prevLSN, tt.prevDeleted))
+		})
+	}
+}

--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -317,14 +317,14 @@ func buildCDCMergeInsert(targetDB, targetName, stagingDB, stagingName string, co
 	target := fmt.Sprintf("%s.%s", quoteIdentifier(targetDB), quoteIdentifier(targetName))
 
 	return fmt.Sprintf(
-		"INSERT INTO %s (%s) SELECT %s FROM (SELECT * FROM %s ORDER BY `_cdc_lsn` DESC, `_cdc_synced_at` DESC LIMIT 1 BY %s) AS la "+
+		"INSERT INTO %s (%s) SELECT %s FROM (SELECT * FROM %s ORDER BY %s LIMIT 1 BY %s) AS la "+
 			"LEFT JOIN (SELECT * FROM %s WHERE `_cdc_deleted` = false ORDER BY `_cdc_lsn` DESC LIMIT 1 BY %s) AS act ON %s "+
 			"LEFT JOIN (SELECT * FROM %s FINAL) AS t ON %s "+
 			"WHERE la.`_cdc_deleted` = false OR act.`_cdc_lsn` != '' OR t.`_cdc_lsn` != ''",
 		target,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(selectCols, ", "),
-		staging, pkList,
+		staging, destination.CDCLatestOverallOrderBy(quoteIdentifier), pkList,
 		staging, pkList, joinOn("la", "act"),
 		target, joinOn("la", "t"),
 	)

--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -247,13 +247,18 @@ func (d *ClickHouseDestination) MergeTable(ctx context.Context, opts destination
 
 	quotedColumns := quoteColumns(opts.Columns)
 
-	insertSQL := fmt.Sprintf(
-		"INSERT INTO %s.%s (%s) SELECT %s FROM %s.%s",
-		quoteIdentifier(targetDB), quoteIdentifier(targetName),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		quoteIdentifier(stagingDB), quoteIdentifier(stagingName),
-	)
+	var insertSQL string
+	if destination.HasCDCDeletedColumn(opts.Columns) && len(opts.PrimaryKeys) > 0 {
+		insertSQL = buildCDCMergeInsert(targetDB, targetName, stagingDB, stagingName, opts.Columns, opts.PrimaryKeys)
+	} else {
+		insertSQL = fmt.Sprintf(
+			"INSERT INTO %s.%s (%s) SELECT %s FROM %s.%s",
+			quoteIdentifier(targetDB), quoteIdentifier(targetName),
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedColumns, ", "),
+			quoteIdentifier(stagingDB), quoteIdentifier(stagingName),
+		)
+	}
 	config.Debug("[CLICKHOUSE MERGE] Executing INSERT: %s", insertSQL)
 
 	if err := d.conn.Exec(ctx, insertSQL); err != nil {
@@ -269,6 +274,77 @@ func (d *ClickHouseDestination) MergeTable(ctx context.Context, opts destination
 
 	config.Debug("[CLICKHOUSE MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+// buildCDCMergeInsert composes one row per PK for ReplacingMergeTree: data
+// columns come from the latest non-deleted change in staging, falling back to
+// the current target row for delete-only windows; CDC columns and the deleted
+// flag come from the latest change overall. Rows inserted and deleted within
+// one window materialize as soft-deleted; a delete-only window for an unknown
+// row is skipped. ClickHouse LEFT JOIN fills misses with type defaults (not
+// NULLs), so existence checks compare _cdc_lsn against the empty string.
+func buildCDCMergeInsert(targetDB, targetName, stagingDB, stagingName string, columns, primaryKeys []string) string {
+	pkMap := make(map[string]bool, len(primaryKeys))
+	quotedPKs := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+		quotedPKs[i] = quoteIdentifier(pk)
+	}
+	pkList := strings.Join(quotedPKs, ", ")
+
+	joinOn := func(left, right string) string {
+		conds := make([]string, len(quotedPKs))
+		for i, pk := range quotedPKs {
+			conds[i] = fmt.Sprintf("%s.%s = %s.%s", left, pk, right, pk)
+		}
+		return strings.Join(conds, " AND ")
+	}
+
+	quotedColumns := make([]string, len(columns))
+	selectCols := make([]string, len(columns))
+	for i, col := range columns {
+		quoted := quoteIdentifier(col)
+		quotedColumns[i] = quoted
+		switch {
+		case pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col):
+			selectCols[i] = "la." + quoted
+		default:
+			selectCols[i] = fmt.Sprintf("if(act.`_cdc_lsn` != '', act.%s, t.%s)", quoted, quoted)
+		}
+	}
+
+	staging := fmt.Sprintf("%s.%s", quoteIdentifier(stagingDB), quoteIdentifier(stagingName))
+	target := fmt.Sprintf("%s.%s", quoteIdentifier(targetDB), quoteIdentifier(targetName))
+
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM (SELECT * FROM %s ORDER BY `_cdc_lsn` DESC, `_cdc_synced_at` DESC LIMIT 1 BY %s) AS la "+
+			"LEFT JOIN (SELECT * FROM %s WHERE `_cdc_deleted` = false ORDER BY `_cdc_lsn` DESC LIMIT 1 BY %s) AS act ON %s "+
+			"LEFT JOIN (SELECT * FROM %s FINAL) AS t ON %s "+
+			"WHERE la.`_cdc_deleted` = false OR act.`_cdc_lsn` != '' OR t.`_cdc_lsn` != ''",
+		target,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(selectCols, ", "),
+		staging, pkList,
+		staging, pkList, joinOn("la", "act"),
+		target, joinOn("la", "t"),
+	)
+}
+
+func (d *ClickHouseDestination) SupportsCDCMerge() bool { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *ClickHouseDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	db, name := d.parseTableName(table)
+	query := fmt.Sprintf("SELECT MAX(`_cdc_lsn`) FROM %s.%s", quoteIdentifier(db), quoteIdentifier(name))
+
+	var maxLSN string
+	if err := d.conn.QueryRow(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "UNKNOWN_TABLE") || strings.Contains(err.Error(), "doesn't exist") {
+			return "", nil
+		}
+		return "", err
+	}
+	return maxLSN, nil
 }
 
 func (d *ClickHouseDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {

--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -331,7 +331,7 @@ func (d *CrateDBDestination) mergeCDC(ctx context.Context, quotedTargetTable, qu
 			colList, colList, pkList, orderBy, quotedStagingTable, where,
 		)
 	}
-	latestAll := dedup("", `"_cdc_lsn" DESC, "_cdc_synced_at" DESC`)
+	latestAll := dedup("", destination.CDCLatestOverallOrderBy(destination.QuoteIdentifier))
 	latestActive := dedup(` WHERE "_cdc_deleted" = false`, `"_cdc_lsn" DESC`)
 
 	upsertActiveSQL := fmt.Sprintf(

--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -257,6 +257,15 @@ func (d *CrateDBDestination) MergeTable(ctx context.Context, opts destination.Me
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
 
+	if destination.HasCDCDeletedColumn(columns) && len(opts.PrimaryKeys) > 0 {
+		if err := d.mergeCDC(ctx, quotedTargetTable, quotedStagingTable, columns, opts.PrimaryKeys); err != nil {
+			return err
+		}
+		d.refreshTable(ctx, opts.TargetTable)
+		config.Debug("[CRATEDB MERGE] CDC merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	var upsertSQL string
 	if len(nonPKColumns) == 0 {
 		upsertSQL = fmt.Sprintf(
@@ -289,6 +298,107 @@ func (d *CrateDBDestination) MergeTable(ctx context.Context, opts destination.Me
 
 	config.Debug("[CRATEDB MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+// mergeCDC applies CDC staging data deterministically. CrateDB has no
+// UPDATE ... FROM, so it runs three upserts: (1) latest non-deleted change per
+// PK, (2) full row for PKs whose latest change is a delete but that carry row
+// data from an earlier change in the window (update/insert then delete), and
+// (3) CDC-columns-only marking for delete-only windows, restricted via an
+// inner join to rows already present in the target so unknown rows are not
+// materialized from a bare delete image.
+func (d *CrateDBDestination) mergeCDC(ctx context.Context, quotedTargetTable, quotedStagingTable string, columns, primaryKeys []string) error {
+	pkMap := make(map[string]bool, len(primaryKeys))
+	quotedPKs := quoteColumns(primaryKeys)
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+	pkList := strings.Join(quotedPKs, ", ")
+	quotedColumns := quoteColumns(columns)
+	colList := strings.Join(quotedColumns, ", ")
+	nonPKColumns := filterColumns(columns, primaryKeys)
+
+	joinOn := func(left, right string) string {
+		conds := make([]string, len(quotedPKs))
+		for i, pk := range quotedPKs {
+			conds[i] = fmt.Sprintf("%s.%s = %s.%s", left, pk, right, pk)
+		}
+		return strings.Join(conds, " AND ")
+	}
+	dedup := func(where, orderBy string) string {
+		return fmt.Sprintf(
+			`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s%s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
+			colList, colList, pkList, orderBy, quotedStagingTable, where,
+		)
+	}
+	latestAll := dedup("", `"_cdc_lsn" DESC, "_cdc_synced_at" DESC`)
+	latestActive := dedup(` WHERE "_cdc_deleted" = false`, `"_cdc_lsn" DESC`)
+
+	upsertActiveSQL := fmt.Sprintf(
+		`INSERT INTO %s (%s) SELECT %s FROM %s AS act ON CONFLICT (%s) DO UPDATE SET %s`,
+		quotedTargetTable, colList,
+		prefixColumns(quotedColumns, "act"),
+		latestActive, pkList, buildConflictUpdateSet(nonPKColumns),
+	)
+
+	composed := make([]string, len(columns))
+	for i, col := range columns {
+		alias := "act"
+		if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+			alias = "la"
+		}
+		composed[i] = alias + "." + quotedColumns[i]
+	}
+	upsertDeletedWithDataSQL := fmt.Sprintf(
+		`INSERT INTO %s (%s) SELECT %s FROM %s AS la JOIN %s AS act ON %s WHERE la."_cdc_deleted" = true ON CONFLICT (%s) DO UPDATE SET %s`,
+		quotedTargetTable, colList,
+		strings.Join(composed, ", "),
+		latestAll, latestActive, joinOn("la", "act"), pkList, buildConflictUpdateSet(nonPKColumns),
+	)
+
+	markDeletedSQL := fmt.Sprintf(
+		`INSERT INTO %s (%s) SELECT %s FROM %s AS la JOIN %s AS t ON %s LEFT JOIN %s AS act ON %s WHERE la."_cdc_deleted" = true AND act."_cdc_lsn" IS NULL ON CONFLICT (%s) DO UPDATE SET "_cdc_deleted" = excluded."_cdc_deleted", "_cdc_lsn" = excluded."_cdc_lsn", "_cdc_synced_at" = excluded."_cdc_synced_at"`,
+		quotedTargetTable, colList,
+		prefixColumns(quotedColumns, "la"),
+		latestAll, quotedTargetTable, joinOn("la", "t"), latestActive, joinOn("la", "act"), pkList,
+	)
+
+	for _, sql := range []string{upsertActiveSQL, upsertDeletedWithDataSQL, markDeletedSQL} {
+		config.Debug("[CRATEDB MERGE] Executing CDC statement: %s", sql)
+		if _, err := d.pool.Exec(ctx, sql); err != nil {
+			config.LogFailedQuery(sql, err)
+			return fmt.Errorf("failed to apply CDC merge: %w", err)
+		}
+	}
+	return nil
+}
+
+func prefixColumns(quotedColumns []string, alias string) string {
+	prefixed := make([]string, len(quotedColumns))
+	for i, col := range quotedColumns {
+		prefixed[i] = alias + "." + col
+	}
+	return strings.Join(prefixed, ", ")
+}
+
+func (d *CrateDBDestination) SupportsCDCMerge() bool { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *CrateDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	d.refreshTable(ctx, table)
+
+	var maxLSN *string
+	query := fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %s`, destination.QuoteTableName(table))
+	if err := d.pool.QueryRow(ctx, query).Scan(&maxLSN); err != nil {
+		if strings.Contains(err.Error(), "unknown") || strings.Contains(err.Error(), "RelationUnknown") {
+			return "", nil
+		}
+		return "", err
+	}
+	if maxLSN == nil {
+		return "", nil
+	}
+	return *maxLSN, nil
 }
 
 func (d *CrateDBDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -148,6 +148,15 @@ type AtomicCommitWriter interface {
 	SupportsAtomicCommitWrites() bool
 }
 
+// MultiTableNamer is an optional interface for destinations whose table names
+// cannot embed a multi-table source's qualified name verbatim (e.g. BigQuery
+// table IDs cannot contain dots). It maps a source table name like
+// "dbo.orders" plus the configured destination schema to a destination table
+// name. Destinations without this interface get "<destSchema>.<sourceTable>".
+type MultiTableNamer interface {
+	DestTableName(destSchema, sourceTable string) string
+}
+
 // ExactRowCountWaiter is an optional interface for destinations that can
 // verify when a table has become query-consistent at an exact row count.
 type ExactRowCountWaiter interface {

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -416,7 +416,7 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 	isCDC := destination.HasCDCDeletedColumn(columns)
 	dedupOrderBy := "(SELECT NULL)"
 	if isCDC {
-		dedupOrderBy = `"_cdc_lsn" DESC, "_cdc_synced_at" DESC`
+		dedupOrderBy = destination.CDCLatestOverallOrderBy(quoteIdentifier)
 	} else if opts.IncrementalKey != "" {
 		dedupOrderBy = destination.QuoteIdentifier(opts.IncrementalKey) + " DESC"
 	}

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -408,28 +408,43 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
 
-	// Build dedup subquery to handle duplicate PKs in staging. When an
-	// incremental key is set the latest row per PK wins; otherwise arbitrary.
+	// Build dedup subquery to handle duplicate PKs in staging. For CDC data the
+	// latest change per PK wins (LSN strings are fixed-width and sort
+	// lexicographically); otherwise, when an incremental key is set the latest
+	// row per PK wins, else arbitrary.
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
+	isCDC := destination.HasCDCDeletedColumn(columns)
 	dedupOrderBy := "(SELECT NULL)"
-	if opts.IncrementalKey != "" {
+	if isCDC {
+		dedupOrderBy = `"_cdc_lsn" DESC, "_cdc_synced_at" DESC`
+	} else if opts.IncrementalKey != "" {
 		dedupOrderBy = destination.QuoteIdentifier(opts.IncrementalKey) + " DESC"
 	}
-	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedPKs, ", "),
-		dedupOrderBy,
-		destination.QuoteTableName(opts.StagingTable),
-	)
+	dedupSource := func(where string) string {
+		return fmt.Sprintf(
+			`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s%s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedPKs, ", "),
+			dedupOrderBy,
+			destination.QuoteTableName(opts.StagingTable),
+			where,
+		)
+	}
+
+	// For CDC, upsert from the latest non-deleted change per PK so a delete
+	// followed by nothing doesn't clobber row data; deletes are applied below.
+	upsertSource := dedupSource("")
+	if isCDC {
+		upsertSource = dedupSource(` WHERE "_cdc_deleted" = false`)
+	}
 
 	if len(nonPKColumns) > 0 {
 		updateSQL := fmt.Sprintf(
 			`UPDATE %s AS target SET %s FROM %s WHERE %s`,
 			quotedTargetTable,
 			buildUpdateSet(nonPKColumns, "source"),
-			dedupSource,
+			upsertSource,
 			onCondition,
 		)
 		config.Debug("[DUCKDB MERGE] Executing UPDATE: %s", updateSQL)
@@ -444,7 +459,7 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 		quotedTargetTable,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
-		dedupSource,
+		upsertSource,
 		quotedTargetTable,
 		onCondition,
 	)
@@ -452,6 +467,22 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	if err := d.exec(ctx, insertSQL); err != nil {
 		return fmt.Errorf("failed to insert new records: %w", err)
+	}
+
+	if isCDC {
+		// Mark rows deleted only when the latest change for the PK is a delete,
+		// carrying the delete's LSN so resume picks up after it.
+		markDeletedSQL := fmt.Sprintf(
+			`UPDATE %s AS target SET "_cdc_deleted" = true, "_cdc_lsn" = source."_cdc_lsn", "_cdc_synced_at" = source."_cdc_synced_at" FROM %s WHERE %s AND source."_cdc_deleted" = true`,
+			quotedTargetTable,
+			dedupSource(""),
+			onCondition,
+		)
+		config.Debug("[DUCKDB MERGE] Executing CDC delete marking: %s", markDeletedSQL)
+
+		if err := d.exec(ctx, markDeletedSQL); err != nil {
+			return fmt.Errorf("failed to mark deleted records: %w", err)
+		}
 	}
 
 	if err := d.exec(ctx, "COMMIT"); err != nil {
@@ -690,6 +721,7 @@ func (d *DuckDBDestination) SupportsMergeStrategy() bool        { return true }
 func (d *DuckDBDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *DuckDBDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *DuckDBDestination) SupportsAtomicSwap() bool           { return true }
+func (d *DuckDBDestination) SupportsCDCMerge() bool             { return true }
 
 // GetScheme returns the primary URI scheme for DuckDB.
 func (d *DuckDBDestination) GetScheme() string { return "duckdb" }

--- a/pkg/destination/dynamodb/dynamodb.go
+++ b/pkg/destination/dynamodb/dynamodb.go
@@ -492,10 +492,11 @@ func (d *DynamoDBDestination) MergeTable(ctx context.Context, opts destination.M
 // existing items only; unknown rows are not materialized from a bare delete.
 func (d *DynamoDBDestination) mergeCDC(ctx context.Context, opts destination.MergeOptions) error {
 	type cdcEntry struct {
-		latest    map[string]types.AttributeValue
-		latestLSN string
-		active    map[string]types.AttributeValue
-		activeLSN string
+		latest        map[string]types.AttributeValue
+		latestLSN     string
+		latestDeleted bool
+		active        map[string]types.AttributeValue
+		activeLSN     string
 	}
 	entries := map[string]*cdcEntry{}
 
@@ -533,11 +534,13 @@ func (d *DynamoDBDestination) mergeCDC(ctx context.Context, opts destination.Mer
 				entries[key] = entry
 			}
 			lsn := itemLSN(item)
-			if entry.latest == nil || lsn > entry.latestLSN {
+			deleted := itemDeleted(item)
+			if entry.latest == nil || destination.CDCSupersedes(lsn, deleted, entry.latestLSN, entry.latestDeleted) {
 				entry.latest = item
 				entry.latestLSN = lsn
+				entry.latestDeleted = deleted
 			}
-			if !itemDeleted(item) && (entry.active == nil || lsn > entry.activeLSN) {
+			if !deleted && (entry.active == nil || lsn > entry.activeLSN) {
 				entry.active = item
 				entry.activeLSN = lsn
 			}

--- a/pkg/destination/dynamodb/dynamodb.go
+++ b/pkg/destination/dynamodb/dynamodb.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -73,6 +74,18 @@ func (d *DynamoDBDestination) PrepareTable(ctx context.Context, opts destination
 		if len(pks) == 0 && opts.Schema != nil {
 			pks = opts.Schema.PrimaryKeys
 		}
+	}
+
+	if opts.CDCMode {
+		// CDC staging holds multiple change rows per source PK, which a
+		// PK-keyed table would collapse (and BatchWriteItem rejects duplicate
+		// keys within a batch). Key staging by (pk, _cdc_lsn) instead; LSNs
+		// are unique per change row. Snapshot rows share one LSN stamp, so
+		// composite source PKs cannot be represented safely.
+		if len(pks) != 1 {
+			return fmt.Errorf("CDC merge into DynamoDB requires exactly one primary key, got %d", len(pks))
+		}
+		pks = []string{pks[0], destination.CDCLSNColumn}
 	}
 
 	if opts.DropFirst {
@@ -434,6 +447,10 @@ func (d *DynamoDBDestination) SwapTable(_ context.Context, _ destination.SwapOpt
 }
 
 func (d *DynamoDBDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	if destination.HasCDCDeletedColumn(opts.Columns) {
+		return d.mergeCDC(ctx, opts)
+	}
+
 	// DynamoDB PutItem is inherently an upsert — we scan the staging table and put all items into the target.
 	paginator := dynamodb.NewScanPaginator(d.client, &dynamodb.ScanInput{
 		TableName: aws.String(opts.StagingTable),
@@ -465,6 +482,161 @@ func (d *DynamoDBDestination) MergeTable(ctx context.Context, opts destination.M
 	}
 
 	return nil
+}
+
+// mergeCDC composes one item per PK from CDC staging data: row data comes from
+// the latest non-deleted change (so a trailing delete keeps the last update's
+// values), CDC attributes and the deleted flag from the latest change overall.
+// Scan order is arbitrary, so the latest change per PK is tracked by comparing
+// the fixed-width LSN strings. Delete-only windows update CDC attributes on
+// existing items only; unknown rows are not materialized from a bare delete.
+func (d *DynamoDBDestination) mergeCDC(ctx context.Context, opts destination.MergeOptions) error {
+	type cdcEntry struct {
+		latest    map[string]types.AttributeValue
+		latestLSN string
+		active    map[string]types.AttributeValue
+		activeLSN string
+	}
+	entries := map[string]*cdcEntry{}
+
+	itemLSN := func(item map[string]types.AttributeValue) string {
+		if s, ok := item[destination.CDCLSNColumn].(*types.AttributeValueMemberS); ok {
+			return s.Value
+		}
+		return ""
+	}
+	itemDeleted := func(item map[string]types.AttributeValue) bool {
+		if b, ok := item[destination.CDCDeletedColumn].(*types.AttributeValueMemberBOOL); ok {
+			return b.Value
+		}
+		return false
+	}
+
+	paginator := dynamodb.NewScanPaginator(d.client, &dynamodb.ScanInput{
+		TableName: aws.String(opts.StagingTable),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to scan staging table %q: %w", opts.StagingTable, err)
+		}
+		for _, item := range page.Items {
+			keyParts := make([]string, len(opts.PrimaryKeys))
+			for i, pk := range opts.PrimaryKeys {
+				keyParts[i] = fmt.Sprintf("%#v", item[pk])
+			}
+			key := strings.Join(keyParts, "\x00")
+
+			entry, ok := entries[key]
+			if !ok {
+				entry = &cdcEntry{}
+				entries[key] = entry
+			}
+			lsn := itemLSN(item)
+			if entry.latest == nil || lsn > entry.latestLSN {
+				entry.latest = item
+				entry.latestLSN = lsn
+			}
+			if !itemDeleted(item) && (entry.active == nil || lsn > entry.activeLSN) {
+				entry.active = item
+				entry.activeLSN = lsn
+			}
+		}
+	}
+
+	chunk := make([]types.WriteRequest, 0, maxBatchWriteItems)
+	for _, entry := range entries {
+		if entry.active == nil {
+			if err := d.markCDCDeleted(ctx, opts, entry.latest); err != nil {
+				return err
+			}
+			continue
+		}
+
+		item := make(map[string]types.AttributeValue, len(entry.active))
+		for k, v := range entry.active {
+			item[k] = v
+		}
+		item[destination.CDCLSNColumn] = entry.latest[destination.CDCLSNColumn]
+		item[destination.CDCDeletedColumn] = entry.latest[destination.CDCDeletedColumn]
+		item[destination.CDCSyncedAtColumn] = entry.latest[destination.CDCSyncedAtColumn]
+
+		chunk = append(chunk, types.WriteRequest{PutRequest: &types.PutRequest{Item: item}})
+		if len(chunk) == maxBatchWriteItems {
+			if _, err := d.batchWrite(ctx, opts.TargetTable, chunk); err != nil {
+				return err
+			}
+			chunk = chunk[:0]
+		}
+	}
+	if len(chunk) > 0 {
+		if _, err := d.batchWrite(ctx, opts.TargetTable, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DynamoDBDestination) markCDCDeleted(ctx context.Context, opts destination.MergeOptions, deletedItem map[string]types.AttributeValue) error {
+	key := map[string]types.AttributeValue{}
+	for _, pk := range opts.PrimaryKeys {
+		key[pk] = deletedItem[pk]
+	}
+
+	_, err := d.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:           aws.String(opts.TargetTable),
+		Key:                 key,
+		ConditionExpression: aws.String("attribute_exists(#pk)"),
+		UpdateExpression:    aws.String("SET #del = :del, #lsn = :lsn, #syn = :syn"),
+		ExpressionAttributeNames: map[string]string{
+			"#pk":  opts.PrimaryKeys[0],
+			"#del": destination.CDCDeletedColumn,
+			"#lsn": destination.CDCLSNColumn,
+			"#syn": destination.CDCSyncedAtColumn,
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":del": deletedItem[destination.CDCDeletedColumn],
+			":lsn": deletedItem[destination.CDCLSNColumn],
+			":syn": deletedItem[destination.CDCSyncedAtColumn],
+		},
+	})
+	if err != nil {
+		var condErr *types.ConditionalCheckFailedException
+		if errors.As(err, &condErr) {
+			return nil
+		}
+		return fmt.Errorf("failed to mark CDC delete in %q: %w", opts.TargetTable, err)
+	}
+	return nil
+}
+
+func (d *DynamoDBDestination) SupportsCDCMerge() bool { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *DynamoDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	paginator := dynamodb.NewScanPaginator(d.client, &dynamodb.ScanInput{
+		TableName:                aws.String(table),
+		ProjectionExpression:     aws.String("#lsn"),
+		ExpressionAttributeNames: map[string]string{"#lsn": destination.CDCLSNColumn},
+	})
+
+	maxLSN := ""
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			var notFound *types.ResourceNotFoundException
+			if errors.As(err, &notFound) {
+				return "", nil
+			}
+			return "", fmt.Errorf("failed to scan %q for max CDC LSN: %w", table, err)
+		}
+		for _, item := range page.Items {
+			if s, ok := item[destination.CDCLSNColumn].(*types.AttributeValueMemberS); ok && s.Value > maxLSN {
+				maxLSN = s.Value
+			}
+		}
+	}
+	return maxLSN, nil
 }
 
 func (d *DynamoDBDestination) DeleteInsertTable(_ context.Context, _ destination.DeleteInsertOptions) error {

--- a/pkg/destination/mongodb/mongodb.go
+++ b/pkg/destination/mongodb/mongodb.go
@@ -235,8 +235,9 @@ func (d *MongoDBDestination) MergeTable(ctx context.Context, opts destination.Me
 	if isCDC {
 		// Process changes in LSN order so the per-PK composition below sees the
 		// latest change last (LSN strings are fixed-width and sort
-		// lexicographically).
-		findOpts.SetSort(bson.D{{Key: destination.CDCLSNColumn, Value: 1}, {Key: destination.CDCSyncedAtColumn, Value: 1}})
+		// lexicographically). Deletes sort after other changes with the same
+		// LSN so a tied delete wins, mirroring destination.CDCLatestOverallOrderBy.
+		findOpts.SetSort(bson.D{{Key: destination.CDCLSNColumn, Value: 1}, {Key: destination.CDCDeletedColumn, Value: 1}})
 	}
 
 	cursor, err := stagingCol.Find(ctx, bson.D{}, findOpts)

--- a/pkg/destination/mongodb/mongodb.go
+++ b/pkg/destination/mongodb/mongodb.go
@@ -230,7 +230,16 @@ func (d *MongoDBDestination) MergeTable(ctx context.Context, opts destination.Me
 		return fmt.Errorf("failed to get target collection: %w", err)
 	}
 
-	cursor, err := stagingCol.Find(ctx, bson.D{})
+	isCDC := destination.HasCDCDeletedColumn(opts.Columns)
+	findOpts := options.Find()
+	if isCDC {
+		// Process changes in LSN order so the per-PK composition below sees the
+		// latest change last (LSN strings are fixed-width and sort
+		// lexicographically).
+		findOpts.SetSort(bson.D{{Key: destination.CDCLSNColumn, Value: 1}, {Key: destination.CDCSyncedAtColumn, Value: 1}})
+	}
+
+	cursor, err := stagingCol.Find(ctx, bson.D{}, findOpts)
 	if err != nil {
 		return fmt.Errorf("failed to read staging collection: %w", err)
 	}
@@ -239,6 +248,17 @@ func (d *MongoDBDestination) MergeTable(ctx context.Context, opts destination.Me
 	const batchSize = 1000
 	var operations []mongo.WriteModel
 	var totalUpserted int64
+
+	// For CDC, compose one document per PK: row data comes from the latest
+	// non-deleted change (so a trailing delete keeps the last update's values),
+	// CDC columns and the deleted flag from the latest change overall.
+	type cdcComposed struct {
+		filter bson.M
+		latest bson.M
+		active bson.M
+	}
+	var composedOrder []string
+	composedByPK := map[string]*cdcComposed{}
 
 	for cursor.Next(ctx) {
 		var doc bson.M
@@ -252,6 +272,21 @@ func (d *MongoDBDestination) MergeTable(ctx context.Context, opts destination.Me
 		}
 
 		delete(doc, "_id")
+
+		if isCDC {
+			key := fmt.Sprintf("%v", filter)
+			entry, ok := composedByPK[key]
+			if !ok {
+				entry = &cdcComposed{filter: filter}
+				composedByPK[key] = entry
+				composedOrder = append(composedOrder, key)
+			}
+			entry.latest = doc
+			if deleted, _ := doc[destination.CDCDeletedColumn].(bool); !deleted {
+				entry.active = doc
+			}
+			continue
+		}
 
 		operations = append(operations, mongo.NewReplaceOneModel().
 			SetFilter(filter).
@@ -271,6 +306,39 @@ func (d *MongoDBDestination) MergeTable(ctx context.Context, opts destination.Me
 		return fmt.Errorf("staging cursor error: %w", err)
 	}
 
+	for _, key := range composedOrder {
+		entry := composedByPK[key]
+		doc := entry.active
+		if doc == nil {
+			// Delete-only window: update CDC columns on an existing document
+			// without clobbering row data; unknown rows are not materialized
+			// from a bare delete image.
+			operations = append(operations, mongo.NewUpdateOneModel().
+				SetFilter(entry.filter).
+				SetUpdate(bson.M{"$set": bson.M{
+					destination.CDCDeletedColumn:  entry.latest[destination.CDCDeletedColumn],
+					destination.CDCLSNColumn:      entry.latest[destination.CDCLSNColumn],
+					destination.CDCSyncedAtColumn: entry.latest[destination.CDCSyncedAtColumn],
+				}}))
+		} else {
+			doc[destination.CDCDeletedColumn] = entry.latest[destination.CDCDeletedColumn]
+			doc[destination.CDCLSNColumn] = entry.latest[destination.CDCLSNColumn]
+			doc[destination.CDCSyncedAtColumn] = entry.latest[destination.CDCSyncedAtColumn]
+			operations = append(operations, mongo.NewReplaceOneModel().
+				SetFilter(entry.filter).
+				SetReplacement(doc).
+				SetUpsert(true))
+		}
+
+		if len(operations) >= batchSize {
+			if _, err := targetCol.BulkWrite(ctx, operations, options.BulkWrite().SetOrdered(false)); err != nil {
+				return fmt.Errorf("failed to bulk write merge batch: %w", err)
+			}
+			totalUpserted += int64(len(operations))
+			operations = operations[:0]
+		}
+	}
+
 	if len(operations) > 0 {
 		if _, err := targetCol.BulkWrite(ctx, operations, options.BulkWrite().SetOrdered(false)); err != nil {
 			return fmt.Errorf("failed to bulk write final merge batch: %w", err)
@@ -280,6 +348,29 @@ func (d *MongoDBDestination) MergeTable(ctx context.Context, opts destination.Me
 
 	config.Debug("[MONGODB DEST] Merge complete: %d documents upserted into %s", totalUpserted, opts.TargetTable)
 	return nil
+}
+
+func (d *MongoDBDestination) SupportsCDCMerge() bool { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the collection for CDC resume.
+func (d *MongoDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	collection, err := d.getCollection(table)
+	if err != nil {
+		return "", err
+	}
+
+	opts := options.FindOne().SetSort(bson.D{{Key: destination.CDCLSNColumn, Value: -1}}).SetProjection(bson.M{destination.CDCLSNColumn: 1})
+	var doc bson.M
+	if err := collection.FindOne(ctx, bson.M{}, opts).Decode(&doc); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return "", nil
+		}
+		return "", err
+	}
+	if lsn, ok := doc[destination.CDCLSNColumn].(string); ok {
+		return lsn, nil
+	}
+	return "", nil
 }
 
 func (d *MongoDBDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -521,7 +521,7 @@ func buildCDCMergeSQL(targetTable, stagingTable string, primaryKeys, columns, no
 	composedSource := fmt.Sprintf(
 		"(SELECT %s FROM %s AS la LEFT JOIN %s AS act ON %s)",
 		strings.Join(selectCols, ", "),
-		dedup("", "[_cdc_lsn] DESC, [_cdc_synced_at] DESC"),
+		dedup("", destination.CDCLatestOverallOrderBy(quoteColumn)),
 		dedup(" WHERE [_cdc_deleted] = 0", "[_cdc_lsn] DESC"),
 		strings.Join(laActJoin, " AND "),
 	)

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -408,11 +408,7 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
 	startMerge := time.Now()
 
-	columns := opts.Columns
-	quotedColumns := quoteColumns(columns)
-	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
-
-	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, quotedColumns, nonPKColumns, opts.IncrementalKey)
+	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
 	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
 
 	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
@@ -424,10 +420,27 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	return nil
 }
 
-func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns, nonPKColumns []string, incrementalKey string) string {
+func buildMergeSQL(targetTable, stagingTable string, primaryKeys, columns []string, incrementalKey string) string {
+	quotedColumns := quoteColumns(columns)
+	nonPKColumns := filterColumns(columns, primaryKeys)
+	isCDC := destination.HasCDCDeletedColumn(columns)
+
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
 		onConditions[i] = fmt.Sprintf("target.%s = source.%s", quoteColumn(pk), quoteColumn(pk))
+	}
+
+	insertCols := strings.Join(quotedColumns, ", ")
+	sourceCols := make([]string, len(quotedColumns))
+	for i, col := range quotedColumns {
+		sourceCols[i] = "source." + col
+	}
+
+	quotedPKs := quoteColumns(primaryKeys)
+	pkPartition := strings.Join(quotedPKs, ", ")
+
+	if isCDC {
+		return buildCDCMergeSQL(targetTable, stagingTable, primaryKeys, columns, nonPKColumns, onConditions, insertCols, sourceCols, pkPartition)
 	}
 
 	var updateSet string
@@ -439,15 +452,8 @@ func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns,
 		updateSet = fmt.Sprintf("WHEN MATCHED THEN UPDATE SET %s", strings.Join(updates, ", "))
 	}
 
-	insertCols := strings.Join(quotedColumns, ", ")
-	sourceCols := make([]string, len(quotedColumns))
-	for i, col := range quotedColumns {
-		sourceCols[i] = "source." + col
-	}
-
 	// Build dedup subquery to handle duplicate PKs in staging. When an
 	// incremental key is set the latest row per PK wins; otherwise arbitrary.
-	quotedPKs := quoteColumns(primaryKeys)
 	dedupOrderBy := "(SELECT NULL)"
 	if incrementalKey != "" {
 		dedupOrderBy = quoteColumns([]string{incrementalKey})[0] + " DESC"
@@ -456,7 +462,7 @@ func buildMergeSQL(targetTable, stagingTable string, primaryKeys, quotedColumns,
 		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
 		insertCols,
 		insertCols,
-		strings.Join(quotedPKs, ", "),
+		pkPartition,
 		dedupOrderBy,
 		quoteTable(stagingTable),
 	)
@@ -476,6 +482,75 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	)
 
 	return sql
+}
+
+// buildCDCMergeSQL builds a CDC-aware MERGE: data columns come from the latest
+// non-deleted change per PK (so a trailing delete keeps the last update's
+// values), CDC columns and the deleted flag from the latest change overall.
+// Rows inserted and deleted within one window materialize as soft-deleted.
+// T-SQL allows only one UPDATE among WHEN MATCHED clauses, so the "delete-only
+// window keeps existing row data" rule is expressed with CASE instead of a
+// second clause.
+func buildCDCMergeSQL(targetTable, stagingTable string, primaryKeys, columns, nonPKColumns, onConditions []string, insertCols string, sourceCols []string, pkPartition string) string {
+	pkMap := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkMap[strings.ToLower(pk)] = true
+	}
+
+	laActJoin := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		laActJoin[i] = fmt.Sprintf("la.%s = act.%s", quoteColumn(pk), quoteColumn(pk))
+	}
+
+	selectCols := make([]string, 0, len(columns)+1)
+	for _, col := range columns {
+		alias := "act"
+		if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+			alias = "la"
+		}
+		selectCols = append(selectCols, fmt.Sprintf("%s.%s", alias, quoteColumn(col)))
+	}
+	selectCols = append(selectCols, "CASE WHEN act.[_cdc_lsn] IS NOT NULL THEN 1 ELSE 0 END AS [__ingestr_has_active]")
+
+	dedup := func(where, orderBy string) string {
+		return fmt.Sprintf(
+			`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s%s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
+			insertCols, insertCols, pkPartition, orderBy, quoteTable(stagingTable), where,
+		)
+	}
+	composedSource := fmt.Sprintf(
+		"(SELECT %s FROM %s AS la LEFT JOIN %s AS act ON %s)",
+		strings.Join(selectCols, ", "),
+		dedup("", "[_cdc_lsn] DESC, [_cdc_synced_at] DESC"),
+		dedup(" WHERE [_cdc_deleted] = 0", "[_cdc_lsn] DESC"),
+		strings.Join(laActJoin, " AND "),
+	)
+
+	hasRowData := "(source.[_cdc_deleted] = 0 OR source.[__ingestr_has_active] = 1)"
+	updates := make([]string, len(nonPKColumns))
+	for i, col := range nonPKColumns {
+		quoted := quoteColumn(col)
+		if destination.IsCDCColumn(col) {
+			updates[i] = fmt.Sprintf("target.%s = source.%s", quoted, quoted)
+		} else {
+			updates[i] = fmt.Sprintf("target.%s = CASE WHEN %s THEN source.%s ELSE target.%s END", quoted, hasRowData, quoted, quoted)
+		}
+	}
+
+	return fmt.Sprintf(
+		`MERGE %s AS target
+USING %s AS source
+ON %s
+WHEN MATCHED THEN UPDATE SET %s
+WHEN NOT MATCHED AND %s THEN INSERT (%s) VALUES (%s);`,
+		quoteTable(targetTable),
+		composedSource,
+		strings.Join(onConditions, " AND "),
+		strings.Join(updates, ", "),
+		hasRowData,
+		insertCols,
+		strings.Join(sourceCols, ", "),
+	)
 }
 
 func (d *MSSQLDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
@@ -659,6 +734,24 @@ func (d *MSSQLDestination) SupportsMergeStrategy() bool        { return true }
 func (d *MSSQLDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *MSSQLDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *MSSQLDestination) SupportsAtomicSwap() bool           { return true }
+func (d *MSSQLDestination) SupportsCDCMerge() bool             { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *MSSQLDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf("SELECT MAX([_cdc_lsn]) FROM %s", quoteTable(table))
+	err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN)
+	if err != nil {
+		if strings.Contains(err.Error(), "Invalid object name") {
+			return "", nil
+		}
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *MSSQLDestination) GetScheme() string { return "mssql" }
 

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -379,7 +379,7 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	isCDC := destination.HasCDCDeletedColumn(columns)
 	dedupOrderBy := "(SELECT NULL)"
 	if isCDC {
-		dedupOrderBy = "`_cdc_lsn` DESC, `_cdc_synced_at` DESC"
+		dedupOrderBy = destination.CDCLatestOverallOrderBy(quoteColumn)
 	} else if opts.IncrementalKey != "" {
 		dedupOrderBy = quoteColumns([]string{opts.IncrementalKey})[0] + " DESC"
 	}

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -371,27 +371,42 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Build dedup subquery to handle duplicate PKs in staging. When an
-	// incremental key is set the latest row per PK wins; otherwise arbitrary.
+	// Build dedup subquery to handle duplicate PKs in staging. For CDC data the
+	// latest change per PK wins (LSN strings are fixed-width and sort
+	// lexicographically); otherwise, when an incremental key is set the latest
+	// row per PK wins, else arbitrary.
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
+	isCDC := destination.HasCDCDeletedColumn(columns)
 	dedupOrderBy := "(SELECT NULL)"
-	if opts.IncrementalKey != "" {
+	if isCDC {
+		dedupOrderBy = "`_cdc_lsn` DESC, `_cdc_synced_at` DESC"
+	} else if opts.IncrementalKey != "" {
 		dedupOrderBy = quoteColumns([]string{opts.IncrementalKey})[0] + " DESC"
 	}
-	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedPKs, ", "),
-		dedupOrderBy,
-		quoteTable(opts.StagingTable),
-	)
+	dedupSource := func(where string) string {
+		return fmt.Sprintf(
+			`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s%s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedPKs, ", "),
+			dedupOrderBy,
+			quoteTable(opts.StagingTable),
+			where,
+		)
+	}
+
+	// For CDC, upsert from the latest non-deleted change per PK so a delete
+	// followed by nothing doesn't clobber row data; deletes are applied below.
+	upsertSource := dedupSource("")
+	if isCDC {
+		upsertSource = dedupSource(" WHERE `_cdc_deleted` = 0")
+	}
 
 	if len(nonPKColumns) > 0 {
 		updateSQL := fmt.Sprintf(
 			`UPDATE %s AS target INNER JOIN %s ON %s SET %s`,
 			quoteTable(opts.TargetTable),
-			dedupSource,
+			upsertSource,
 			buildJoinCondition(opts.PrimaryKeys, "target", "source"),
 			buildUpdateSet(nonPKColumns, "target", "source"),
 		)
@@ -408,7 +423,7 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 		quoteTable(opts.TargetTable),
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
-		dedupSource,
+		upsertSource,
 		quoteTable(opts.TargetTable),
 		buildJoinCondition(opts.PrimaryKeys, "target", "source"),
 	)
@@ -417,6 +432,23 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
 		config.LogFailedQuery(insertSQL, err)
 		return fmt.Errorf("failed to insert new records: %w", err)
+	}
+
+	if isCDC {
+		// Mark rows deleted only when the latest change for the PK is a delete,
+		// carrying the delete's LSN so resume picks up after it.
+		markDeletedSQL := fmt.Sprintf(
+			"UPDATE %s AS target INNER JOIN %s ON %s SET target.`_cdc_deleted` = 1, target.`_cdc_lsn` = source.`_cdc_lsn`, target.`_cdc_synced_at` = source.`_cdc_synced_at` WHERE source.`_cdc_deleted` = 1",
+			quoteTable(opts.TargetTable),
+			dedupSource(""),
+			buildJoinCondition(opts.PrimaryKeys, "target", "source"),
+		)
+		config.Debug("[MERGE] Executing CDC delete marking: %s", markDeletedSQL)
+
+		if _, err := tx.ExecContext(ctx, markDeletedSQL); err != nil {
+			config.LogFailedQuery(markDeletedSQL, err)
+			return fmt.Errorf("failed to mark deleted records: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -650,6 +682,24 @@ func (d *MySQLDestination) SupportsMergeStrategy() bool        { return true }
 func (d *MySQLDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *MySQLDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *MySQLDestination) SupportsAtomicSwap() bool           { return true }
+func (d *MySQLDestination) SupportsCDCMerge() bool             { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *MySQLDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf("SELECT MAX(`_cdc_lsn`) FROM %s", quoteTable(table))
+	err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN)
+	if err != nil {
+		if strings.Contains(err.Error(), "doesn't exist") {
+			return "", nil
+		}
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 func (d *MySQLDestination) GetScheme() string { return "mysql" }
 

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -481,9 +481,7 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 		// latest change for that PK is a delete (preserving row data).
 		pkList := strings.Join(quotedPKs, ", ")
 		selectCols := strings.Join(quotedColumns, ", ")
-		// CDC LSN strings are fixed-width per source (Postgres %08X/%08X,
-		// SQL Server hex:hex:op), so plain text ordering matches LSN order.
-		orderByParts := append(append([]string{}, quotedPKs...), `"_cdc_lsn" DESC`, `"_cdc_synced_at" DESC`)
+		orderByParts := append(append([]string{}, quotedPKs...), destination.CDCLatestOverallOrderBy(destination.QuoteIdentifier))
 		orderBy := strings.Join(orderByParts, ", ")
 
 		latestActive := fmt.Sprintf(

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -154,6 +156,13 @@ func (d *PostgresDestination) ensureSchemaExists(ctx context.Context, schemaName
 
 	createSchemaSQL := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", destination.QuoteIdentifier(schemaName))
 	if _, err := d.pool.Exec(ctx, createSchemaSQL); err != nil {
+		// IF NOT EXISTS is not race-safe: concurrent creators (e.g. multi-table
+		// CDC preparing staging tables in parallel) can both pass the existence
+		// check and one loses with a duplicate error. Treat that as success.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && (pgErr.Code == "23505" || pgErr.Code == "42P06") {
+			return nil
+		}
 		config.LogFailedQuery(createSchemaSQL, err)
 		return fmt.Errorf("failed to create schema %s: %w", schemaName, err)
 	}
@@ -472,7 +481,9 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 		// latest change for that PK is a delete (preserving row data).
 		pkList := strings.Join(quotedPKs, ", ")
 		selectCols := strings.Join(quotedColumns, ", ")
-		orderByParts := append(append([]string{}, quotedPKs...), `"_cdc_lsn"::pg_lsn DESC`, `"_cdc_synced_at" DESC`)
+		// CDC LSN strings are fixed-width per source (Postgres %08X/%08X,
+		// SQL Server hex:hex:op), so plain text ordering matches LSN order.
+		orderByParts := append(append([]string{}, quotedPKs...), `"_cdc_lsn" DESC`, `"_cdc_synced_at" DESC`)
 		orderBy := strings.Join(orderByParts, ", ")
 
 		latestActive := fmt.Sprintf(

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -495,10 +495,13 @@ func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []s
 				where,
 			)
 		}
+		quoteActual := func(col string) string {
+			return quoteIdentifier(actualColumnName(allColumns, col))
+		}
 		composedSource := fmt.Sprintf(
 			"(SELECT %s FROM %s AS la LEFT JOIN %s AS act ON %s)",
 			strings.Join(selectCols, ", "),
-			dedup("", fmt.Sprintf("%s DESC, %s DESC", cdcLSN, cdcDeleted)),
+			dedup("", destination.CDCLatestOverallOrderBy(quoteActual)),
 			dedup(fmt.Sprintf(" WHERE %s = false", cdcDeleted), cdcLSN+" DESC"),
 			strings.Join(laActJoin, " AND "),
 		)

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -498,7 +498,7 @@ func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []s
 		composedSource := fmt.Sprintf(
 			"(SELECT %s FROM %s AS la LEFT JOIN %s AS act ON %s)",
 			strings.Join(selectCols, ", "),
-			dedup("", fmt.Sprintf("%s DESC, %s DESC", cdcLSN, cdcSyncedAt)),
+			dedup("", fmt.Sprintf("%s DESC, %s DESC", cdcLSN, cdcDeleted)),
 			dedup(fmt.Sprintf(" WHERE %s = false", cdcDeleted), cdcLSN+" DESC"),
 			strings.Join(laActJoin, " AND "),
 		)

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -445,15 +444,83 @@ func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []s
 		quotedPKList[i] = quoteIdentifier(pk)
 	}
 
-	hasCDCDeleted := slices.Contains(allColumns, "_cdc_deleted")
+	// Column names may have been case-mapped by the naming layer (Snowflake
+	// commonly uppercases), so CDC columns must be detected case-insensitively
+	// and referenced by their actual names.
+	hasCDCDeleted := destination.HasCDCDeletedColumn(allColumns)
 
 	dedupOrderBy := "(SELECT NULL)"
-	if hasCDCDeleted {
-		dedupOrderBy = fmt.Sprintf("%s DESC, %s DESC",
-			quoteIdentifier("_cdc_lsn"),
-			quoteIdentifier("_cdc_deleted"))
-	} else if incrementalKey != "" {
+	if incrementalKey != "" {
 		dedupOrderBy = quoteIdentifier(incrementalKey) + " DESC"
+	}
+
+	var mergeSQL strings.Builder
+	fmt.Fprintf(&mergeSQL, "MERGE INTO %s AS target\n", targetFull)
+
+	if hasCDCDeleted {
+		// CDC mode: compose the merge source from two per-PK dedups of staging:
+		// data columns come from the latest non-deleted change (so a trailing
+		// delete doesn't discard the last update's values), while the CDC
+		// columns and deleted flag come from the latest change overall. This
+		// also materializes rows inserted and deleted within one sync window
+		// as soft-deleted rows, storing the delete's LSN for resume.
+		cdcLSN := quoteIdentifier(actualColumnName(allColumns, destination.CDCLSNColumn))
+		cdcDeleted := quoteIdentifier(actualColumnName(allColumns, destination.CDCDeletedColumn))
+		cdcSyncedAt := quoteIdentifier(actualColumnName(allColumns, destination.CDCSyncedAtColumn))
+
+		laActJoin := make([]string, len(primaryKeys))
+		for i, pk := range primaryKeys {
+			quoted := quoteIdentifier(pk)
+			laActJoin[i] = fmt.Sprintf("(la.%s = act.%s OR (la.%s IS NULL AND act.%s IS NULL))", quoted, quoted, quoted, quoted)
+		}
+
+		selectCols := make([]string, 0, len(allColumns)+1)
+		for _, col := range allColumns {
+			alias := "act"
+			if pkMap[strings.ToLower(col)] || destination.IsCDCColumn(col) {
+				alias = "la"
+			}
+			selectCols = append(selectCols, fmt.Sprintf("%s.%s", alias, quoteIdentifier(col)))
+		}
+		selectCols = append(selectCols, fmt.Sprintf("act.%s IS NOT NULL AS \"__ingestr_has_active\"", cdcLSN))
+
+		dedup := func(where, orderBy string) string {
+			return fmt.Sprintf(
+				`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s%s) AS _numbered WHERE __bruin_dedup_rn = 1)`,
+				strings.Join(quotedCols, ", "),
+				strings.Join(quotedCols, ", "),
+				strings.Join(quotedPKList, ", "),
+				orderBy,
+				stagingFull,
+				where,
+			)
+		}
+		composedSource := fmt.Sprintf(
+			"(SELECT %s FROM %s AS la LEFT JOIN %s AS act ON %s)",
+			strings.Join(selectCols, ", "),
+			dedup("", fmt.Sprintf("%s DESC, %s DESC", cdcLSN, cdcSyncedAt)),
+			dedup(fmt.Sprintf(" WHERE %s = false", cdcDeleted), cdcLSN+" DESC"),
+			strings.Join(laActJoin, " AND "),
+		)
+
+		fmt.Fprintf(&mergeSQL, "USING %s AS source\n", composedSource)
+		fmt.Fprintf(&mergeSQL, "ON %s\n", onClause)
+
+		hasRowData := fmt.Sprintf("(source.%s = false OR source.\"__ingestr_has_active\")", cdcDeleted)
+		if len(updateSets) > 0 {
+			fmt.Fprintf(&mergeSQL, "WHEN MATCHED AND %s THEN\n", hasRowData)
+			fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
+		}
+
+		fmt.Fprintf(&mergeSQL, "WHEN MATCHED AND source.%s = true THEN\n", cdcDeleted)
+		fmt.Fprintf(&mergeSQL, "  UPDATE SET target.%s = true, target.%s = source.%s, target.%s = source.%s\n",
+			cdcDeleted, cdcLSN, cdcLSN, cdcSyncedAt, cdcSyncedAt)
+
+		fmt.Fprintf(&mergeSQL, "WHEN NOT MATCHED AND %s THEN\n", hasRowData)
+		fmt.Fprintf(&mergeSQL, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
+		fmt.Fprintf(&mergeSQL, "  VALUES (%s)", strings.Join(sourceCols, ", "))
+
+		return mergeSQL.String()
 	}
 
 	dedupSource := fmt.Sprintf(
@@ -465,27 +532,10 @@ func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []s
 		stagingFull,
 	)
 
-	var mergeSQL strings.Builder
-	fmt.Fprintf(&mergeSQL, "MERGE INTO %s AS target\n", targetFull)
 	fmt.Fprintf(&mergeSQL, "USING %s AS source\n", dedupSource)
 	fmt.Fprintf(&mergeSQL, "ON %s\n", onClause)
 
-	if hasCDCDeleted {
-		if len(updateSets) > 0 {
-			fmt.Fprintf(&mergeSQL, "WHEN MATCHED AND source.%s = false THEN\n", quoteIdentifier("_cdc_deleted"))
-			fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
-		}
-
-		fmt.Fprintf(&mergeSQL, "WHEN MATCHED AND source.%s = true THEN\n", quoteIdentifier("_cdc_deleted"))
-		fmt.Fprintf(&mergeSQL, "  UPDATE SET target.%s = true, target.%s = source.%s, target.%s = source.%s\n",
-			quoteIdentifier("_cdc_deleted"),
-			quoteIdentifier("_cdc_lsn"), quoteIdentifier("_cdc_lsn"),
-			quoteIdentifier("_cdc_synced_at"), quoteIdentifier("_cdc_synced_at"))
-
-		fmt.Fprintf(&mergeSQL, "WHEN NOT MATCHED AND source.%s = false THEN\n", quoteIdentifier("_cdc_deleted"))
-		fmt.Fprintf(&mergeSQL, "  INSERT (%s)\n", strings.Join(quotedCols, ", "))
-		fmt.Fprintf(&mergeSQL, "  VALUES (%s)", strings.Join(sourceCols, ", "))
-	} else {
+	{
 		if len(updateSets) > 0 {
 			mergeSQL.WriteString("WHEN MATCHED THEN\n")
 			fmt.Fprintf(&mergeSQL, "  UPDATE SET %s\n", strings.Join(updateSets, ", "))
@@ -497,6 +547,16 @@ func buildMergeSQL(stagingTable, targetTable string, primaryKeys, allColumns []s
 	}
 
 	return mergeSQL.String()
+}
+
+// actualColumnName resolves the case-mapped name of a logical column.
+func actualColumnName(columns []string, name string) string {
+	for _, col := range columns {
+		if strings.EqualFold(col, name) {
+			return col
+		}
+	}
+	return name
 }
 
 func (d *SnowflakeDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -51,12 +51,26 @@ func TestBuildMergeSQL(t *testing.T) {
 		columns := []string{"id", "name", "value", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"}
 		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns, "")
 
-		assert.Contains(t, sql, `ORDER BY "_CDC_LSN" DESC, "_CDC_DELETED" DESC`)
-		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = false THEN`)
+		// Composed source: data columns from the latest non-deleted change,
+		// CDC columns from the latest change overall.
+		assert.Contains(t, sql, `SELECT la."ID", act."NAME", act."VALUE", la."_CDC_LSN", la."_CDC_DELETED", la."_CDC_SYNCED_AT", act."_CDC_LSN" IS NOT NULL AS "__ingestr_has_active"`)
+		assert.Contains(t, sql, `ORDER BY "_CDC_LSN" DESC, "_CDC_SYNCED_AT" DESC`)
+		assert.Contains(t, sql, `WHERE "_CDC_DELETED" = false`)
+		assert.Contains(t, sql, `WHEN MATCHED AND (source."_CDC_DELETED" = false OR source."__ingestr_has_active") THEN`)
 		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = true THEN`)
 		assert.Contains(t, sql, `target."_CDC_DELETED" = true, target."_CDC_LSN" = source."_CDC_LSN", target."_CDC_SYNCED_AT" = source."_CDC_SYNCED_AT"`)
-		assert.Contains(t, sql, `WHEN NOT MATCHED AND source."_CDC_DELETED" = false THEN`)
-		assert.NotContains(t, sql, `WHEN NOT MATCHED AND source."_CDC_DELETED" = true`)
+		assert.Contains(t, sql, `WHEN NOT MATCHED AND (source."_CDC_DELETED" = false OR source."__ingestr_has_active") THEN`)
+		assert.NotContains(t, sql, "WHEN NOT MATCHED THEN\n")
+	})
+
+	t.Run("cdc_uppercased_columns", func(t *testing.T) {
+		// The naming layer commonly uppercases columns for Snowflake; CDC
+		// detection must be case-insensitive.
+		columns := []string{"ID", "NAME", "_CDC_LSN", "_CDC_DELETED", "_CDC_SYNCED_AT"}
+		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"ID"}, columns, "")
+
+		assert.Contains(t, sql, `"__ingestr_has_active"`)
+		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = true THEN`)
 		assert.NotContains(t, sql, "WHEN NOT MATCHED THEN\n")
 	})
 
@@ -64,11 +78,11 @@ func TestBuildMergeSQL(t *testing.T) {
 		columns := []string{"id", "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"}
 		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns, "")
 
-		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = false THEN`)
+		assert.Contains(t, sql, `WHEN MATCHED AND (source."_CDC_DELETED" = false OR source."__ingestr_has_active") THEN`)
 		assert.Contains(t, sql, `target."_CDC_LSN" = source."_CDC_LSN"`)
 		assert.NotContains(t, sql, `target."NAME" = source."NAME"`)
 		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = true THEN`)
-		assert.Contains(t, sql, `WHEN NOT MATCHED AND source."_CDC_DELETED" = false THEN`)
+		assert.Contains(t, sql, `WHEN NOT MATCHED AND (source."_CDC_DELETED" = false OR source."__ingestr_has_active") THEN`)
 	})
 }
 

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -54,7 +54,7 @@ func TestBuildMergeSQL(t *testing.T) {
 		// Composed source: data columns from the latest non-deleted change,
 		// CDC columns from the latest change overall.
 		assert.Contains(t, sql, `SELECT la."ID", act."NAME", act."VALUE", la."_CDC_LSN", la."_CDC_DELETED", la."_CDC_SYNCED_AT", act."_CDC_LSN" IS NOT NULL AS "__ingestr_has_active"`)
-		assert.Contains(t, sql, `ORDER BY "_CDC_LSN" DESC, "_CDC_SYNCED_AT" DESC`)
+		assert.Contains(t, sql, `ORDER BY "_CDC_LSN" DESC, "_CDC_DELETED" DESC`)
 		assert.Contains(t, sql, `WHERE "_CDC_DELETED" = false`)
 		assert.Contains(t, sql, `WHEN MATCHED AND (source."_CDC_DELETED" = false OR source."__ingestr_has_active") THEN`)
 		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = true THEN`)

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -434,21 +434,36 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 
-	// Build dedup subquery to handle duplicate PKs in staging. When an
-	// incremental key is set the latest row per PK wins; otherwise arbitrary.
+	// Build dedup subquery to handle duplicate PKs in staging. For CDC data the
+	// latest change per PK wins (LSN strings are fixed-width and sort
+	// lexicographically); otherwise, when an incremental key is set the latest
+	// row per PK wins, else arbitrary.
 	quotedPKs := quoteColumns(opts.PrimaryKeys)
+	isCDC := destination.HasCDCDeletedColumn(columns)
 	dedupOrderBy := "(SELECT NULL)"
-	if opts.IncrementalKey != "" {
+	if isCDC {
+		dedupOrderBy = `"_cdc_lsn" DESC, "_cdc_synced_at" DESC`
+	} else if opts.IncrementalKey != "" {
 		dedupOrderBy = destination.QuoteIdentifier(opts.IncrementalKey) + " DESC"
 	}
-	dedupSource := fmt.Sprintf(
-		`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedColumns, ", "),
-		strings.Join(quotedPKs, ", "),
-		dedupOrderBy,
-		destination.QuoteTableName(opts.StagingTable),
-	)
+	dedupSource := func(where string) string {
+		return fmt.Sprintf(
+			`(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s%s) AS _numbered WHERE __bruin_dedup_rn = 1) AS source`,
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedColumns, ", "),
+			strings.Join(quotedPKs, ", "),
+			dedupOrderBy,
+			destination.QuoteTableName(opts.StagingTable),
+			where,
+		)
+	}
+
+	// For CDC, upsert from the latest non-deleted change per PK so a delete
+	// followed by nothing doesn't clobber row data; deletes are applied below.
+	upsertSource := dedupSource("")
+	if isCDC {
+		upsertSource = dedupSource(` WHERE "_cdc_deleted" = 0`)
+	}
 
 	// UPDATE existing records using SQLite syntax
 	if len(nonPKColumns) > 0 {
@@ -456,7 +471,7 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 			`UPDATE %s SET %s FROM %s WHERE %s`,
 			quotedTargetTable,
 			buildUpdateSetSQLite(nonPKColumns, "source"),
-			dedupSource,
+			upsertSource,
 			buildJoinConditionSQLite(opts.PrimaryKeys, quotedTargetTable, "source"),
 		)
 		config.Debug("[MERGE] Executing UPDATE: %s", updateSQL)
@@ -473,7 +488,7 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 		quotedTargetTable,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
-		dedupSource,
+		upsertSource,
 		quotedTargetTable,
 		buildJoinConditionSQLite(opts.PrimaryKeys, "target", "source"),
 	)
@@ -482,6 +497,23 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
 		config.LogFailedQuery(insertSQL, err)
 		return fmt.Errorf("failed to insert new records: %w", err)
+	}
+
+	if isCDC {
+		// Mark rows deleted only when the latest change for the PK is a delete,
+		// carrying the delete's LSN so resume picks up after it.
+		markDeletedSQL := fmt.Sprintf(
+			`UPDATE %s SET "_cdc_deleted" = 1, "_cdc_lsn" = source."_cdc_lsn", "_cdc_synced_at" = source."_cdc_synced_at" FROM %s WHERE %s AND source."_cdc_deleted" = 1`,
+			quotedTargetTable,
+			dedupSource(""),
+			buildJoinConditionSQLite(opts.PrimaryKeys, quotedTargetTable, "source"),
+		)
+		config.Debug("[MERGE] Executing CDC delete marking: %s", markDeletedSQL)
+
+		if _, err := tx.ExecContext(ctx, markDeletedSQL); err != nil {
+			config.LogFailedQuery(markDeletedSQL, err)
+			return fmt.Errorf("failed to mark deleted records: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -679,6 +711,25 @@ func (d *SQLiteDestination) SupportsSCD2Strategy() bool { return true }
 
 // SupportsAtomicSwap returns true as SQLite supports atomic table renames.
 func (d *SQLiteDestination) SupportsAtomicSwap() bool { return true }
+
+func (d *SQLiteDestination) SupportsCDCMerge() bool { return true }
+
+// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
+func (d *SQLiteDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	var maxLSN sql.NullString
+	query := fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %s`, destination.QuoteTableName(table))
+	err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return "", nil
+		}
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
 
 // GetScheme returns the primary URI scheme for SQLite.
 func (d *SQLiteDestination) GetScheme() string { return "sqlite" }

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -442,7 +442,7 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 	isCDC := destination.HasCDCDeletedColumn(columns)
 	dedupOrderBy := "(SELECT NULL)"
 	if isCDC {
-		dedupOrderBy = `"_cdc_lsn" DESC, "_cdc_synced_at" DESC`
+		dedupOrderBy = destination.CDCLatestOverallOrderBy(destination.QuoteIdentifier)
 	} else if opts.IncrementalKey != "" {
 		dedupOrderBy = destination.QuoteIdentifier(opts.IncrementalKey) + " DESC"
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -817,9 +817,12 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	}
 
 	tableDestNames := make(map[string]string)
+	namer, _ := p.dest.(destination.MultiTableNamer)
 	for _, table := range tables {
 		destName := table.Name
-		if table.DestSchema != "" {
+		if namer != nil {
+			destName = namer.DestTableName(table.DestSchema, table.Name)
+		} else if table.DestSchema != "" {
 			// TODO(turtledev): When a publication in a non-public
 			// schema is created, the tables names may (?) have a schema.
 			//

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -312,7 +312,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	// Build the evolution plan but do NOT apply it here. Strategies decide when to apply.
 	var evolutionPlan *schemaevolution.EvolutionPlan
 	if resolvedStrategy != config.StrategyReplace {
-		evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, destSchema)
+		evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, p.config.DestTable, destSchema)
 		if err != nil {
 			return fmt.Errorf("schema evolution failed: %w", err)
 		}
@@ -836,6 +836,24 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 		tableDestNames[table.Name] = destName
 	}
 
+	// Schema contract handling: build a per-table evolution plan so destination
+	// tables gain columns added at the source (skip for replace, which drops and
+	// recreates). Plans are built sequentially because evolveSchemaIfNeeded
+	// keeps comparison state on the pipeline; strategies apply them per table.
+	var evolutionPlans map[string]*schemaevolution.EvolutionPlan
+	if resolvedStrategy != config.StrategyReplace {
+		evolutionPlans = make(map[string]*schemaevolution.EvolutionPlan)
+		for _, table := range tables {
+			plan, err := p.evolveSchemaIfNeeded(ctx, tableDestNames[table.Name], table.Schema)
+			if err != nil {
+				return fmt.Errorf("schema evolution failed for table %s: %w", table.Name, err)
+			}
+			if plan != nil {
+				evolutionPlans[table.Name] = plan
+			}
+		}
+	}
+
 	// For CDC sources, query per-table max LSNs for resume
 	var cdcResumeLSNs map[string]string
 	if isCDCSource(p.config.SourceURI) && !p.config.FullRefresh {
@@ -866,6 +884,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 		TableDestNames: tableDestNames,
 		Tracker:        tracker,
 		CDCResumeLSNs:  cdcResumeLSNs,
+		EvolutionPlans: evolutionPlans,
 	}
 
 	if err := mtStrat.ExecuteMultiTable(ctx, job); err != nil {
@@ -877,9 +896,9 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 // evolveSchemaIfNeeded inspects the destination's current schema and builds an
 // EvolutionPlan describing how it should change to accommodate sourceSchema.
-func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, sourceSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
 	// Get destination table schema (nil if table doesn't exist)
-	destSchema, err := p.dest.GetTableSchema(ctx, p.config.DestTable)
+	destSchema, err := p.dest.GetTableSchema(ctx, destTable)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get destination schema: %w", err)
 	}
@@ -1018,7 +1037,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, sourceSchema *schem
 
 	// Generate migration using the FILTERED schema comparison (after contract filtering)
 	// This ensures we only apply allowed changes (e.g., new columns in discard_value mode)
-	migration, err := schemaevolution.GenerateMigration(p.filteredSchemaComparison, dialect, p.config.DestTable)
+	migration, err := schemaevolution.GenerateMigration(p.filteredSchemaComparison, dialect, destTable)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate migration: %w", err)
 	}

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -645,12 +645,17 @@ func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta ta
 	if err != nil {
 		return "", err
 	}
-	if snapshotLSN == "" || isZeroLSN(snapshotLSN) {
-		minLSN, minErr := s.minLSN(ctx, meta)
-		if minErr != nil {
-			return "", minErr
-		}
-		if minLSN != "" && !isZeroLSN(minLSN) {
+	// The harvest watermark (fn_cdc_get_max_lsn) can lag behind the capture
+	// instance's min LSN, e.g. for a freshly enabled table. Stamping the
+	// snapshot below min LSN would invalidate the next run's resume check and
+	// force an endless re-snapshot loop, so clamp up to the instance min LSN.
+	// Both bounds precede any post-snapshot change, so this never skips data.
+	minLSN, err := s.minLSN(ctx, meta)
+	if err != nil {
+		return "", err
+	}
+	if minLSN != "" && !isZeroLSN(minLSN) {
+		if snapshotLSN == "" || isZeroLSN(snapshotLSN) || compareLSNHex(minLSN, snapshotLSN) > 0 {
 			snapshotLSN = minLSN
 		}
 	}
@@ -695,9 +700,18 @@ func (s *MSSQLCDCSource) maxLSNFromQueryer(ctx context.Context, q queryer) (stri
 	return normalizeLSNHex(lsn.String), nil
 }
 
+// minLSN returns the capture instance's low-watermark LSN. It reads
+// cdc.change_tables.start_lsn directly instead of sys.fn_cdc_get_min_lsn
+// because the latter returns NULL until the capture job first processes the
+// instance, while start_lsn is set at enable time. Cleanup raises start_lsn,
+// so it carries the same change-retention semantics.
 func (s *MSSQLCDCSource) minLSN(ctx context.Context, meta tableMetadata) (string, error) {
 	var lsn sql.NullString
-	if err := s.db.QueryRowContext(ctx, "SELECT CONVERT(varchar(20), sys.fn_cdc_get_min_lsn(@p1), 2)", meta.CaptureInstance).Scan(&lsn); err != nil {
+	err := s.db.QueryRowContext(ctx, "SELECT CONVERT(varchar(20), start_lsn, 2) FROM cdc.change_tables WHERE capture_instance = @p1 AND end_lsn IS NULL", meta.CaptureInstance).Scan(&lsn)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
 		return "", fmt.Errorf("failed to get SQL Server CDC min LSN for %s: %w", tableName(meta), err)
 	}
 	if !lsn.Valid {

--- a/pkg/strategy/append.go
+++ b/pkg/strategy/append.go
@@ -113,6 +113,11 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 
 			destTable := job.GetDestTableName(ti.Name)
 
+			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+				errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+				return
+			}
+
 			if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 				Table:       destTable,
 				Schema:      ti.Schema,

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -183,6 +183,11 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			stagingTable := GenerateStagingTableName(destTable, "merge", job.Config.StagingDataset)
 			isCDC := hasCDCColumns(ti.Schema)
 
+			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+				errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+				return
+			}
+
 			if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 				Table:       destTable,
 				Schema:      ti.Schema,

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -87,7 +87,18 @@ type MultiTableIngestionJob struct {
 	Tables         []source.SourceTableInfo
 	TableDestNames map[string]string // source table → dest table mapping
 	Tracker        progress.Tracker
-	CDCResumeLSNs  map[string]string // Per-table CDC resume LSNs: source table → max LSN already processed
+	CDCResumeLSNs  map[string]string                         // Per-table CDC resume LSNs: source table → max LSN already processed
+	EvolutionPlans map[string]*schemaevolution.EvolutionPlan // Per-table schema evolution plans: source table → plan
+}
+
+// ApplyEvolutionFor applies the pending schema evolution plan for a source table.
+func (j *MultiTableIngestionJob) ApplyEvolutionFor(ctx context.Context, sourceTable string) error {
+	plan := j.EvolutionPlans[sourceTable]
+	if plan == nil || !plan.HasMigration() {
+		return nil
+	}
+	ctx = annotation.WithStep(ctx, annotation.StepEvolve)
+	return plan.Apply(ctx, j.Destination)
 }
 
 // GetDestTableName returns the destination table name for a source table.

--- a/tests/integration/mssql_cdc_test.go
+++ b/tests/integration/mssql_cdc_test.go
@@ -193,6 +193,113 @@ func TestMSSQLCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
 	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 5 AND name = 'item5' AND value = 555 AND NOT "_cdc_deleted"`), "insert+update in one window must keep the updated value")
 }
 
+// applyMSSQLCDCAdversarialChanges applies the standard change window covering
+// every same-PK composition case, then waits until the capture job has
+// harvested all change rows (3 seed inserts + 11 window rows).
+func applyMSSQLCDCAdversarialChanges(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	for _, stmt := range []string{
+		`UPDATE dbo.items SET value = 150 WHERE id = 1`,
+		`DELETE FROM dbo.items WHERE id = 2`,
+		`UPDATE dbo.items SET name = N'item3_final', value = 999 WHERE id = 3`,
+		`DELETE FROM dbo.items WHERE id = 3`,
+		`INSERT INTO dbo.items (id, name, value) VALUES (5, N'item5', 500)`,
+		`UPDATE dbo.items SET value = 555 WHERE id = 5`,
+		`INSERT INTO dbo.items (id, name, value) VALUES (6, N'item6', 600)`,
+		`DELETE FROM dbo.items WHERE id = 6`,
+	} {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 14)
+}
+
+// verifyMSSQLCDCEndState checks the canonical end state after the adversarial
+// window through a database/sql connection to the destination.
+func verifyMSSQLCDCEndState(t *testing.T, db *sql.DB, table string) {
+	t.Helper()
+
+	queryCount := func(query string) int {
+		var n int
+		require.NoError(t, db.QueryRow(query).Scan(&n))
+		return n
+	}
+
+	assert.Equal(t, 5, queryCount(`SELECT COUNT(*) FROM `+table), "total rows")
+	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM `+table+` WHERE id = 1 AND value = 150 AND _cdc_deleted = false`), "plain update")
+	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM `+table+` WHERE id = 2 AND value = 200 AND _cdc_deleted = true`), "plain delete keeps last values")
+	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM `+table+` WHERE id = 3 AND name = 'item3_final' AND value = 999 AND _cdc_deleted = true`), "update+delete in one window")
+	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM `+table+` WHERE id = 5 AND value = 555 AND _cdc_deleted = false`), "insert+update in one window")
+	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM `+table+` WHERE id = 6 AND value = 600 AND _cdc_deleted = true`), "insert+delete in one window materializes soft-deleted")
+}
+
+func TestMSSQLCDC_SnapshotAndIncremental_SQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+	createMSSQLCDCItemsTable(t, ctx, db)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 3)
+
+	tmpDir, err := os.MkdirTemp("", "mssql_cdc_sqlite_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sqlitePath := tmpDir + "/test.db"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"mode": "batch"}),
+		SourceTable: "dbo.items",
+		DestURI:     "sqlite:///" + sqlitePath,
+		DestTable:   "items_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	applyMSSQLCDCAdversarialChanges(t, ctx, db)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	dest, err := sql.Open("sqlite3", sqlitePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dest.Close() })
+	verifyMSSQLCDCEndState(t, dest, "items_dest")
+}
+
+func TestMSSQLCDC_SnapshotAndIncremental_MySQL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mysqlDest.uri == "" {
+		t.Skip("shared mysql container not available")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+	createMSSQLCDCItemsTable(t, ctx, db)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 3)
+
+	destTable := fmt.Sprintf("items_dest_%s", uniqueSuffix())
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"mode": "batch"}),
+		SourceTable: "dbo.items",
+		DestURI:     mysqlDest.uri,
+		DestTable:   destTable,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	applyMSSQLCDCAdversarialChanges(t, ctx, db)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	dest, err := sql.Open("mysql", mysqlDSN(mysqlDest.uri))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = dest.Exec("DROP TABLE IF EXISTS " + destTable)
+		_ = dest.Close()
+	})
+	verifyMSSQLCDCEndState(t, dest, destTable)
+}
+
 func TestMSSQLCDC_SnapshotAndIncremental_Postgres(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/tests/integration/mssql_cdc_test.go
+++ b/tests/integration/mssql_cdc_test.go
@@ -1,0 +1,402 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mssqlURIForDatabase(t *testing.T, baseURI, scheme, dbName string, params map[string]string) string {
+	t.Helper()
+
+	u, err := url.Parse(baseURI)
+	require.NoError(t, err)
+	u.Scheme = scheme
+	u.Path = "/" + dbName
+	q := u.Query()
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// setupMSSQLCDCDatabase creates a dedicated database on the shared SQL Server
+// container, enables CDC on it, and returns a connection to it along with the
+// database name. The database is dropped on cleanup.
+func setupMSSQLCDCDatabase(t *testing.T, ctx context.Context) (string, *sql.DB) {
+	t.Helper()
+
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	adminDB := openMSSQLTestDB(t, mssqlDest.uri)
+	t.Cleanup(func() { _ = adminDB.Close() })
+
+	dbName := fmt.Sprintf("cdc_%s", uniqueSuffix())
+	_, err := adminDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE [%s]", dbName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", dbName))
+		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE [%s]", dbName))
+	})
+
+	db := openMSSQLTestDB(t, mssqlURIForDatabase(t, mssqlDest.uri, "mssql", dbName, nil))
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.ExecContext(ctx, "EXEC sys.sp_cdc_enable_db")
+	require.NoError(t, err)
+
+	return dbName, db
+}
+
+func enableMSSQLCDCOnTable(t *testing.T, ctx context.Context, db *sql.DB, tableName string) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'%s', @role_name = NULL, @supports_net_changes = 0",
+		tableName,
+	))
+	require.NoError(t, err)
+}
+
+// waitForMSSQLCDCRows polls the change table until the CDC capture job has
+// harvested at least `want` change rows. The capture job scans every few
+// seconds, so changes are not visible to CDC functions immediately.
+func waitForMSSQLCDCRows(t *testing.T, ctx context.Context, db *sql.DB, captureInstance string, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(90 * time.Second)
+	query := fmt.Sprintf("SELECT COUNT(*) FROM cdc.[%s_CT]", captureInstance)
+	var count int
+	for time.Now().Before(deadline) {
+		if err := db.QueryRowContext(ctx, query).Scan(&count); err == nil && count >= want {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d CDC change rows in %s (have %d); is SQL Server Agent running?", want, captureInstance, count)
+}
+
+func createMSSQLCDCItemsTable(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE dbo.items (
+		id INT NOT NULL PRIMARY KEY,
+		name NVARCHAR(100) NOT NULL,
+		value INT NULL
+	)`)
+	require.NoError(t, err)
+
+	enableMSSQLCDCOnTable(t, ctx, db, "items")
+
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (1, N'item1', 100), (2, N'item2', 200), (3, N'item3', 300)`)
+	require.NoError(t, err)
+}
+
+type cdcRow struct {
+	name    string
+	value   int64
+	deleted bool
+}
+
+func TestMSSQLCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+	createMSSQLCDCItemsTable(t, ctx, db)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 3)
+
+	tmpDir, err := os.MkdirTemp("", "mssql_cdc_duckdb_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	duckdbPath := tmpDir + "/test.duckdb"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"mode": "batch"}),
+		SourceTable: "dbo.items",
+		DestURI:     "duckdb:///" + duckdbPath,
+		DestTable:   "items_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	// String values must not be scanned through the adbc_generic driver: it
+	// hands database/sql strings that alias Arrow buffers owned by the C
+	// driver, which dangle once the reader advances. Compare strings in SQL
+	// and only scan scalar results instead.
+	queryDuckCount := func(query string) int64 {
+		duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+		require.NoError(t, err)
+		defer func() { _ = duck.Close() }()
+
+		var v int64
+		require.NoError(t, duck.QueryRow(query).Scan(&v))
+		return v
+	}
+
+	assert.EqualValues(t, 3, queryDuckCount(`SELECT COUNT(*) FROM items_dest`), "should have 3 rows from snapshot")
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE "_cdc_deleted"`), "no snapshot row should be deleted")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 1 AND name = 'item1' AND value = 100`))
+	firstLSNRank := queryDuckCount(`SELECT COUNT(DISTINCT "_cdc_lsn") FROM items_dest`)
+	assert.EqualValues(t, 1, firstLSNRank, "snapshot rows share one LSN stamp")
+
+	// Plain insert/update/delete picked up incrementally.
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (4, N'item4', 400)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET value = 150 WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 2`)
+	require.NoError(t, err)
+	// 3 inserts + 1 insert + update (old+new image) + 1 delete = 7
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 7)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.EqualValues(t, 4, queryDuckCount(`SELECT COUNT(*) FROM items_dest`))
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 1 AND value = 150 AND NOT "_cdc_deleted"`), "update should be applied")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 2 AND value = 200 AND "_cdc_deleted"`), "delete should be soft-applied, keeping last values")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 4 AND name = 'item4' AND value = 400 AND NOT "_cdc_deleted"`), "insert should be applied")
+	assert.Greater(t, queryDuckCount(`SELECT COUNT(DISTINCT "_cdc_lsn") FROM items_dest`), firstLSNRank, "LSN should advance after incremental sync")
+
+	// Multiple changes to the same PK within one sync window: the latest
+	// change must win and a trailing delete must be honored.
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET name = N'item3_final', value = 999 WHERE id = 3`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 3`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (5, N'item5', 500)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET value = 555 WHERE id = 5`)
+	require.NoError(t, err)
+	// + update (2) + delete (1) + insert (1) + update (2) = 13
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 13)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.EqualValues(t, 5, queryDuckCount(`SELECT COUNT(*) FROM items_dest`))
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 3 AND name = 'item3_final' AND value = 999 AND "_cdc_deleted"`), "update+delete in one window must end deleted with the last update's values")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 5 AND name = 'item5' AND value = 555 AND NOT "_cdc_deleted"`), "insert+update in one window must keep the updated value")
+}
+
+func TestMSSQLCDC_SnapshotAndIncremental_Postgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if pgDest.uri == "" {
+		t.Skip("shared postgres dest container not available")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+	createMSSQLCDCItemsTable(t, ctx, db)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 3)
+
+	destSchema := uniqueSchemaName(t, "mssql_cdc")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
+	destTable := destSchema + ".items_dest"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"mode": "batch"}),
+		SourceTable: "dbo.items",
+		DestURI:     pgDest.uri,
+		DestTable:   destTable,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pg, err := sql.Open("pgx", pgDest.uri)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+
+	queryRows := func() map[int64]cdcRow {
+		rows, err := pg.QueryContext(ctx, fmt.Sprintf(`SELECT id, name, value, "_cdc_deleted" FROM %q.items_dest ORDER BY id`, destSchema))
+		require.NoError(t, err)
+		defer func() { _ = rows.Close() }()
+
+		out := map[int64]cdcRow{}
+		for rows.Next() {
+			var id, value int64
+			var name string
+			var deleted bool
+			require.NoError(t, rows.Scan(&id, &name, &value, &deleted))
+			out[id] = cdcRow{name: name, value: value, deleted: deleted}
+		}
+		require.NoError(t, rows.Err())
+		return out
+	}
+
+	rows := queryRows()
+	require.Len(t, rows, 3, "should have 3 rows from snapshot")
+	var firstMaxLSN string
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %q.items_dest`, destSchema)).Scan(&firstMaxLSN))
+
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (4, N'item4', 400)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET value = 150 WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 2`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET name = N'item3_final', value = 999 WHERE id = 3`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 3`)
+	require.NoError(t, err)
+	// 3 + insert (1) + update (2) + delete (1) + update (2) + delete (1) = 10
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 10)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows = queryRows()
+	require.Len(t, rows, 4)
+	assert.Equal(t, int64(150), rows[1].value, "update should be applied")
+	assert.True(t, rows[2].deleted, "delete should be soft-applied")
+	assert.Equal(t, cdcRow{name: "item3_final", value: 999, deleted: true}, rows[3], "update+delete in one window must keep latest values and end deleted")
+	assert.False(t, rows[4].deleted, "insert should be applied")
+
+	var secondMaxLSN string
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %q.items_dest`, destSchema)).Scan(&secondMaxLSN))
+	assert.Greater(t, secondMaxLSN, firstMaxLSN, "LSN should advance after incremental sync")
+}
+
+// TestMSSQLCDC_FreshCaptureInstanceResume reproduces a harvest-lag bug: when a
+// table is snapshotted right after sp_cdc_enable_table, sys.fn_cdc_get_max_lsn
+// can still be below the new capture instance's start_lsn. The snapshot stamp
+// must be clamped up to start_lsn, otherwise the next run considers the resume
+// LSN invalid, re-snapshots, and silently drops upstream deletes.
+func TestMSSQLCDC_FreshCaptureInstanceResume_DuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE dbo.fresh (id INT NOT NULL PRIMARY KEY, v INT NOT NULL)`)
+	require.NoError(t, err)
+	enableMSSQLCDCOnTable(t, ctx, db, "fresh")
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.fresh (id, v) VALUES (1, 10), (2, 20)`)
+	require.NoError(t, err)
+
+	tmpDir, err := os.MkdirTemp("", "mssql_cdc_fresh_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	duckdbPath := tmpDir + "/test.duckdb"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"mode": "batch"}),
+		SourceTable: "dbo.fresh",
+		DestURI:     "duckdb:///" + duckdbPath,
+		DestTable:   "fresh_dest",
+	}
+	// Snapshot immediately, before the capture job has harvested anything.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	_, err = db.ExecContext(ctx, `UPDATE dbo.fresh SET v = 11 WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.fresh WHERE id = 2`)
+	require.NoError(t, err)
+	// 2 inserts + update (2) + delete (1) = 5
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_fresh", 5)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = duck.Close() })
+
+	var v int64
+	var deleted bool
+	require.NoError(t, duck.QueryRow(`SELECT v, "_cdc_deleted" FROM fresh_dest WHERE id = 1`).Scan(&v, &deleted))
+	assert.Equal(t, int64(11), v, "update after fresh snapshot must be applied")
+	assert.False(t, deleted)
+
+	require.NoError(t, duck.QueryRow(`SELECT v, "_cdc_deleted" FROM fresh_dest WHERE id = 2`).Scan(&v, &deleted))
+	assert.True(t, deleted, "delete after fresh snapshot must be applied")
+}
+
+func TestMSSQLCDC_MultiTable_Postgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if pgDest.uri == "" {
+		t.Skip("shared postgres dest container not available")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+	createMSSQLCDCItemsTable(t, ctx, db)
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE dbo.orders (
+		order_id BIGINT NOT NULL PRIMARY KEY,
+		item_id INT NOT NULL,
+		qty INT NOT NULL
+	)`)
+	require.NoError(t, err)
+	enableMSSQLCDCOnTable(t, ctx, db, "orders")
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.orders (order_id, item_id, qty) VALUES (1001, 1, 2), (1002, 2, 1)`)
+	require.NoError(t, err)
+
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 3)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_orders", 2)
+
+	destSchema := uniqueSchemaName(t, "mssql_cdc_mt")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
+
+	cfg := &config.IngestConfig{
+		SourceURI: mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{
+			"mode":        "batch",
+			"dest_schema": destSchema,
+		}),
+		DestURI: pgDest.uri,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pg, err := sql.Open("pgx", pgDest.uri)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+
+	var count int
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q."dbo.items"`, destSchema)).Scan(&count))
+	assert.Equal(t, 3, count, "items snapshot")
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q."dbo.orders"`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count, "orders snapshot")
+
+	_, err = db.ExecContext(ctx, `UPDATE dbo.orders SET qty = 99 WHERE order_id = 1001`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.orders WHERE order_id = 1002`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (4, N'item4', 400)`)
+	require.NoError(t, err)
+	// orders: 2 inserts + update (2) + delete (1) = 5; items: 3 + insert (1) = 4
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_orders", 5)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 4)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var qty int
+	var deleted bool
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT qty, "_cdc_deleted" FROM %q."dbo.orders" WHERE order_id = 1001`, destSchema)).Scan(&qty, &deleted))
+	assert.Equal(t, 99, qty, "orders update should be applied")
+	assert.False(t, deleted)
+
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT "_cdc_deleted" FROM %q."dbo.orders" WHERE order_id = 1002`, destSchema)).Scan(&deleted))
+	assert.True(t, deleted, "orders delete should be soft-applied")
+
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q."dbo.items"`, destSchema)).Scan(&count))
+	assert.Equal(t, 4, count, "items insert should be applied")
+}

--- a/tests/integration/mssql_container_test.go
+++ b/tests/integration/mssql_container_test.go
@@ -24,6 +24,8 @@ func startMSSQLContainerRaw(ctx context.Context, name string) (testcontainers.Co
 		"mcr.microsoft.com/mssql/server:2022-latest",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(mssqlPassword),
+		// SQL Server Agent is required by the CDC capture/cleanup jobs.
+		testcontainers.WithEnv(map[string]string{"MSSQL_AGENT_ENABLED": "true"}),
 		testcontainers.WithWaitStrategy(
 			wait.ForAll(
 				wait.ForListeningPort("1433/tcp"),

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -669,3 +669,89 @@ func TestPostgresCDC_IncrementalResume_DuckDB(t *testing.T) {
 	assert.NotEqual(t, firstMaxLSN, secondMaxLSN, "LSN should have advanced after incremental sync")
 	t.Logf("Second run max LSN: %v", secondMaxLSN)
 }
+
+// TestPostgresCDC_MultiTable_SchemaEvolution reproduces issue #766: a column
+// added at the source between multi-table CDC runs must be added to the
+// destination table via schema evolution before the merge.
+func TestPostgresCDC_MultiTable_SchemaEvolution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if pgDest.uri == "" {
+		t.Skip("shared postgres dest container not available")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.products (
+		id INT PRIMARY KEY,
+		name VARCHAR(100)
+	)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.customers (
+		id INT PRIMARY KEY,
+		email VARCHAR(100)
+	)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.products (id, name) VALUES (1, 'widget'), (2, 'gadget')`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.customers (id, email) VALUES (1, 'a@example.com')`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `CREATE PUBLICATION evo_pub FOR TABLE public.products, public.customers`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	destSchema := uniqueSchemaName(t, "cdc_evo")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
+
+	cfg := &config.IngestConfig{
+		SourceURI: "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+			"&publication=evo_pub&mode=batch&dest_schema=" + destSchema,
+		DestURI: pgDest.uri,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pg, err := sql.Open("pgx", pgDest.uri)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+
+	var count int
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.products`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count, "products snapshot")
+
+	// Evolve the source schema and write rows that use the new column.
+	_, err = srcPool.Exec(ctx, `ALTER TABLE public.products ADD COLUMN category VARCHAR(50)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `UPDATE public.products SET category = 'tools' WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.products (id, name, category) VALUES (3, 'doohickey', 'misc')`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.customers (id, email) VALUES (2, 'b@example.com')`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var category string
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT category FROM %q.products WHERE id = 1`, destSchema)).Scan(&category),
+		"destination should have gained the category column via schema evolution")
+	assert.Equal(t, "tools", category)
+
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT category FROM %q.products WHERE id = 3`, destSchema)).Scan(&category))
+	assert.Equal(t, "misc", category)
+
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.products`, destSchema)).Scan(&count))
+	assert.Equal(t, 3, count)
+
+	// The untouched table must keep working alongside the evolved one.
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.customers`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count)
+}


### PR DESCRIPTION
## Summary

Validates the SQL Server CDC source end-to-end and makes CDC merge semantics correct and uniform across every merge-capable destination. All work was verified live against a real SQL Server CDC source with an adversarial change window (update, delete, update→delete, insert→update, insert→delete on the same primary keys), plus idempotent-rerun checks.

### SQL Server CDC source fixes
- **Snapshot LSN clamping**: `fn_cdc_get_max_lsn()` (the harvest watermark) can lag a freshly enabled capture instance's `start_lsn`, which stamped snapshots below the instance minimum and forced an endless re-snapshot loop. The snapshot LSN is now clamped up to `cdc.change_tables.start_lsn` (read directly, since `fn_cdc_get_min_lsn` is NULL until the first harvest).
- **Multi-table destination naming**: new `MultiTableNamer` destination interface so BigQuery can map `dbo.orders` → `dataset.dbo_orders` instead of rejecting the three-part name.

### Uniform CDC merge semantics across destinations
All destinations now converge on identical semantics for same-PK windows:
- data columns come from the latest **non-deleted** change; CDC metadata from the latest change overall
- update→delete keeps the last update's values with `_cdc_deleted = true`
- insert→delete within one window materializes the row as soft-deleted
- delete of an unknown row is skipped; delete of an existing row updates only CDC columns
- reruns are idempotent (read 0 rows)

Notable bugs fixed along the way:
- **Snowflake**: the existing CDC merge silently never ran — a case-sensitive check for `_cdc_deleted` failed against Snowflake's uppercased columns, falling back to arbitrary-winner dedup (lost updates, unmarked deletes). Detection is now case-insensitive and the merge resolves actual column names.
- **DuckDB/SQLite/MySQL/MSSQL/Postgres**: arbitrary-winner dedup in same-PK windows replaced with LSN-ordered composed merges; SQLite/MySQL gained `GetMaxCDCLSN` so resume works at all.
- **ClickHouse**: `ReplacingMergeTree` resolved duplicates arbitrarily; CDC inserts now compose one row per PK via `LIMIT 1 BY` with target-state fallback.
- **DynamoDB**: `BatchWriteItem` rejected CDC staging outright (duplicate keys); staging is now keyed `(pk, _cdc_lsn)`, merge composes in Go, delete-marking is conditional.
- **Cassandra**: CQL INSERT-as-upsert silently collapsed staged change rows; `_cdc_lsn` is now a clustering key on CDC staging.
- **CrateDB**: three-statement upsert sequence (no `UPDATE…FROM` support).
- **Postgres**: dropped the `::pg_lsn` cast (incompatible with SQL Server LSN strings; fixed-width format makes text ordering correct) and made `ensureSchemaExists` race-safe.

### Validation matrix
DuckDB, Postgres, BigQuery (live), Snowflake (live), SQLite, MySQL, MSSQL, ClickHouse, CrateDB, MongoDB, DynamoDB, Cassandra — all pass the adversarial scenario. Trino is documented unsupported (the default `_bruin_staging` prefix parses as a catalog, and the memory connector rejects MERGE — pre-existing, separate issue).

### Tests
- New integration tests: snapshot+incremental against DuckDB/SQLite/MySQL/Postgres, fresh-capture-instance resume, and multi-table→Postgres (containerized SQL Server with agent enabled).
- Full integration suite green; unit tests, gofumpt, and golangci-lint clean.

### Known limitation
A forced re-snapshot after genuine CDC cleanup loss does not reconcile deletes that happened in the gap (rows deleted at the source remain in the destination until touched again). Documented; fixing it requires chunked/ad-hoc snapshots with anti-join reconciliation, which is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
