### PR TITLE
ci: gate release on docker-test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
   release-unix:
     runs-on: depot-ubuntu-latest
-    needs: [prepare-linux, prepare-darwin, integration-tests, docker-test]
+    needs: [prepare-linux, prepare-darwin, integration-tests]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -396,7 +396,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [install-unix, install-windows]
+    needs: [install-unix, install-windows, docker-test]
     steps:
       - uses: actions/checkout@v4
       - name: Extract tag from ref


### PR DESCRIPTION
Dependency chain:

```
integration-tests -> docker-build -> docker-test -> release
```

The docker branch and the binary branch both start after `integration-tests` and run in parallel, then converge at `release`.