### PR TITLE
Support multipart SQL Server source tables

### DIFF
--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -551,7 +551,11 @@ func (r mssqlTableRef) informationSchemaQualifier() string {
 	if len(r.catalogParts) == 0 {
 		return "INFORMATION_SCHEMA"
 	}
-	return quoteIdentifierPath(r.catalogParts) + ".INFORMATION_SCHEMA"
+	quotedCatalog := quoteCatalogIdentifierPath(r.catalogParts)
+	if quotedCatalog == "" {
+		return "INFORMATION_SCHEMA"
+	}
+	return quotedCatalog + ".INFORMATION_SCHEMA"
 }
 
 func splitMSSQLIdentifierPath(path string) []string {
@@ -670,13 +674,28 @@ func quoteTable(table string) string {
 	return quoteIdentifierPath(tableRef.parts)
 }
 
+// quoteIdentifierPath joins parts as bracket-quoted SQL Server identifiers.
+// Empty parts are kept as empty strings so two-dot notation (e.g. [db]..[table])
+// round-trips correctly when tableRef.parts is passed directly.
 func quoteIdentifierPath(parts []string) string {
-	quoted := make([]string, len(parts))
-	for i, part := range parts {
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			quoted = append(quoted, "")
+			continue
+		}
+		quoted = append(quoted, quoteColumn(part))
+	}
+	return strings.Join(quoted, ".")
+}
+
+func quoteCatalogIdentifierPath(parts []string) string {
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
 		if part == "" {
 			continue
 		}
-		quoted[i] = quoteColumn(part)
+		quoted = append(quoted, quoteColumn(part))
 	}
 	return strings.Join(quoted, ".")
 }

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -280,20 +280,9 @@ func (s *MSSQLSource) GetTable(ctx context.Context, req source.TableRequest) (so
 }
 
 func (s *MSSQLSource) getSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
-	schemaName, tableName := parseTableName(table)
-
-	query := `
-		SELECT
-			COLUMN_NAME,
-			DATA_TYPE,
-			IS_NULLABLE,
-			NUMERIC_PRECISION,
-			NUMERIC_SCALE,
-			CHARACTER_MAXIMUM_LENGTH
-		FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
-		ORDER BY ORDINAL_POSITION
-	`
+	tableRef := parseMSSQLTableRef(table)
+	schemaName, tableName := tableRef.schemaName, tableRef.tableName
+	query, pkQuery := schemaMetadataQueries(tableRef)
 
 	rows, err := s.db.QueryContext(ctx, query, schemaName, tableName)
 	if err != nil {
@@ -346,19 +335,6 @@ func (s *MSSQLSource) getSchema(ctx context.Context, table string) (*schema.Tabl
 		return nil, fmt.Errorf("table %s not found or has no columns", table)
 	}
 
-	// Get primary keys
-	pkQuery := `
-		SELECT c.COLUMN_NAME
-		FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-		JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE c
-			ON tc.CONSTRAINT_NAME = c.CONSTRAINT_NAME
-			AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA
-		WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
-			AND tc.TABLE_SCHEMA = @p1
-			AND tc.TABLE_NAME = @p2
-		ORDER BY c.ORDINAL_POSITION
-	`
-
 	var primaryKeys []string
 	pkRows, err := s.db.QueryContext(ctx, pkQuery, schemaName, tableName)
 	if err == nil {
@@ -386,6 +362,36 @@ func (s *MSSQLSource) getSchema(ctx context.Context, table string) (*schema.Tabl
 		Columns:     columns,
 		PrimaryKeys: primaryKeys,
 	}, nil
+}
+
+func schemaMetadataQueries(tableRef mssqlTableRef) (string, string) {
+	infoSchema := tableRef.informationSchemaQualifier()
+	columnsQuery := fmt.Sprintf(`
+		SELECT
+			COLUMN_NAME,
+			DATA_TYPE,
+			IS_NULLABLE,
+			NUMERIC_PRECISION,
+			NUMERIC_SCALE,
+			CHARACTER_MAXIMUM_LENGTH
+		FROM %s.COLUMNS
+		WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+		ORDER BY ORDINAL_POSITION
+	`, infoSchema)
+
+	pkQuery := fmt.Sprintf(`
+		SELECT c.COLUMN_NAME
+		FROM %s.TABLE_CONSTRAINTS tc
+		JOIN %s.KEY_COLUMN_USAGE c
+			ON tc.CONSTRAINT_NAME = c.CONSTRAINT_NAME
+			AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA
+		WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
+			AND tc.TABLE_SCHEMA = @p1
+			AND tc.TABLE_NAME = @p2
+		ORDER BY c.ORDINAL_POSITION
+	`, infoSchema, infoSchema)
+
+	return columnsQuery, pkQuery
 }
 
 func (s *MSSQLSource) read(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -508,13 +514,93 @@ func (s *MSSQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 	return results, nil
 }
 
+type mssqlTableRef struct {
+	parts        []string
+	catalogParts []string
+	schemaName   string
+	tableName    string
+}
+
 func parseTableName(table string) (string, string) {
-	parts := strings.SplitN(table, ".", 2)
-	if len(parts) == 2 {
-		return parts[0], parts[1]
+	tableRef := parseMSSQLTableRef(table)
+	return tableRef.schemaName, tableRef.tableName
+}
+
+func parseMSSQLTableRef(table string) mssqlTableRef {
+	parts := splitMSSQLIdentifierPath(table)
+	tableName := parts[len(parts)-1]
+	schemaName := "dbo"
+	if len(parts) > 1 && parts[len(parts)-2] != "" {
+		schemaName = parts[len(parts)-2]
 	}
-	// SQL Server default schema is dbo
-	return "dbo", table
+
+	var catalogParts []string
+	if len(parts) > 2 {
+		catalogParts = parts[:len(parts)-2]
+	}
+
+	return mssqlTableRef{
+		parts:        parts,
+		catalogParts: catalogParts,
+		schemaName:   schemaName,
+		tableName:    tableName,
+	}
+}
+
+func (r mssqlTableRef) informationSchemaQualifier() string {
+	if len(r.catalogParts) == 0 {
+		return "INFORMATION_SCHEMA"
+	}
+	return quoteIdentifierPath(r.catalogParts) + ".INFORMATION_SCHEMA"
+}
+
+func splitMSSQLIdentifierPath(path string) []string {
+	path = strings.TrimSpace(path)
+	var rawParts []string
+	var current strings.Builder
+	inBracket := false
+
+	for i := 0; i < len(path); i++ {
+		ch := path[i]
+		if inBracket {
+			current.WriteByte(ch)
+			if ch == ']' {
+				if i+1 < len(path) && path[i+1] == ']' {
+					i++
+					current.WriteByte(path[i])
+					continue
+				}
+				inBracket = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '[':
+			inBracket = true
+			current.WriteByte(ch)
+		case '.':
+			rawParts = append(rawParts, current.String())
+			current.Reset()
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	rawParts = append(rawParts, current.String())
+
+	parts := make([]string, len(rawParts))
+	for i, part := range rawParts {
+		parts[i] = normalizeMSSQLIdentifierPart(part)
+	}
+	return parts
+}
+
+func normalizeMSSQLIdentifierPart(part string) string {
+	part = strings.TrimSpace(part)
+	if len(part) >= 2 && part[0] == '[' && part[len(part)-1] == ']' {
+		return strings.ReplaceAll(part[1:len(part)-1], "]]", "]")
+	}
+	return part
 }
 
 func filterColumns(columns []schema.Column, exclude []string) []schema.Column {
@@ -580,11 +666,19 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 }
 
 func quoteTable(table string) string {
-	parts := strings.SplitN(table, ".", 2)
-	if len(parts) == 2 {
-		return fmt.Sprintf("[%s].[%s]", strings.ReplaceAll(parts[0], "]", "]]"), strings.ReplaceAll(parts[1], "]", "]]"))
+	tableRef := parseMSSQLTableRef(table)
+	return quoteIdentifierPath(tableRef.parts)
+}
+
+func quoteIdentifierPath(parts []string) string {
+	quoted := make([]string, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		quoted[i] = quoteColumn(part)
 	}
-	return fmt.Sprintf("[%s]", strings.ReplaceAll(table, "]", "]]"))
+	return strings.Join(quoted, ".")
 }
 
 func quoteColumn(name string) string {

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -263,6 +263,11 @@ func TestQuoteTableSupportsMultipartIdentifiers(t *testing.T) {
 			table: "[LINKED]]SRV].[RemoteDB].[dbo].[my]]table]",
 			want:  "[LINKED]]SRV].[RemoteDB].[dbo].[my]]table]",
 		},
+		{
+			name:  "empty schema segment",
+			table: "RemoteDB..orders",
+			want:  "[RemoteDB]..[orders]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -271,6 +276,16 @@ func TestQuoteTableSupportsMultipartIdentifiers(t *testing.T) {
 				t.Errorf("quoteTable(%q) = %q, want %q", tt.table, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestInformationSchemaQualifierSkipsEmptyCatalogParts(t *testing.T) {
+	tableRef := parseMSSQLTableRef("LINKED_SRV..dbo.my_table")
+
+	got := tableRef.informationSchemaQualifier()
+	want := "[LINKED_SRV].INFORMATION_SCHEMA"
+	if got != want {
+		t.Fatalf("information schema qualifier = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -168,6 +168,140 @@ func TestBuildSelectQueryPreservesColumnCasing(t *testing.T) {
 	}
 }
 
+func TestParseTableNameSupportsMultipartIdentifiers(t *testing.T) {
+	tests := []struct {
+		name       string
+		table      string
+		wantSchema string
+		wantTable  string
+	}{
+		{
+			name:       "unqualified table defaults schema",
+			table:      "users",
+			wantSchema: "dbo",
+			wantTable:  "users",
+		},
+		{
+			name:       "schema qualified table",
+			table:      "sales.orders",
+			wantSchema: "sales",
+			wantTable:  "orders",
+		},
+		{
+			name:       "database qualified table",
+			table:      "RemoteDB.dbo.orders",
+			wantSchema: "dbo",
+			wantTable:  "orders",
+		},
+		{
+			name:       "linked server qualified table",
+			table:      "LINKED_SRV.RemoteDB.dbo.my_table",
+			wantSchema: "dbo",
+			wantTable:  "my_table",
+		},
+		{
+			name:       "bracketed identifiers with dots",
+			table:      "[LINKED_SRV].[RemoteDB].[erp.schema].[my.table]",
+			wantSchema: "erp.schema",
+			wantTable:  "my.table",
+		},
+		{
+			name:       "escaped bracket in identifier",
+			table:      "[LINKED]]SRV].[RemoteDB].[dbo].[my]]table]",
+			wantSchema: "dbo",
+			wantTable:  "my]table",
+		},
+		{
+			name:       "empty schema segment defaults schema",
+			table:      "RemoteDB..orders",
+			wantSchema: "dbo",
+			wantTable:  "orders",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSchema, gotTable := parseTableName(tt.table)
+			if gotSchema != tt.wantSchema {
+				t.Errorf("schema = %q, want %q", gotSchema, tt.wantSchema)
+			}
+			if gotTable != tt.wantTable {
+				t.Errorf("table = %q, want %q", gotTable, tt.wantTable)
+			}
+		})
+	}
+}
+
+func TestQuoteTableSupportsMultipartIdentifiers(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		want  string
+	}{
+		{
+			name:  "unqualified table",
+			table: "users",
+			want:  "[users]",
+		},
+		{
+			name:  "schema qualified table",
+			table: "dbo.notes",
+			want:  "[dbo].[notes]",
+		},
+		{
+			name:  "linked server qualified table",
+			table: "LINKED_SRV.RemoteDB.dbo.my_table",
+			want:  "[LINKED_SRV].[RemoteDB].[dbo].[my_table]",
+		},
+		{
+			name:  "bracketed identifiers with dots",
+			table: "[LINKED_SRV].[RemoteDB].[erp.schema].[my.table]",
+			want:  "[LINKED_SRV].[RemoteDB].[erp.schema].[my.table]",
+		},
+		{
+			name:  "escaped bracket in identifier",
+			table: "[LINKED]]SRV].[RemoteDB].[dbo].[my]]table]",
+			want:  "[LINKED]]SRV].[RemoteDB].[dbo].[my]]table]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quoteTable(tt.table); got != tt.want {
+				t.Errorf("quoteTable(%q) = %q, want %q", tt.table, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSelectQuerySupportsLinkedServerTable(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id"},
+		{Name: "CreatedAt"},
+	}
+
+	query := buildSelectQuery("LINKED_SRV.RemoteDB.dbo.my_table", columns, source.ReadOptions{Limit: 10})
+	want := "SELECT TOP 10 [id], [CreatedAt] FROM [LINKED_SRV].[RemoteDB].[dbo].[my_table]"
+	if query != want {
+		t.Fatalf("query = %q, want %q", query, want)
+	}
+}
+
+func TestSchemaMetadataQueriesUseCatalogPrefix(t *testing.T) {
+	tableRef := parseMSSQLTableRef("LINKED_SRV.RemoteDB.dbo.my_table")
+	columnsQuery, pkQuery := schemaMetadataQueries(tableRef)
+
+	if !strings.Contains(columnsQuery, "FROM [LINKED_SRV].[RemoteDB].INFORMATION_SCHEMA.COLUMNS") {
+		t.Fatalf("columns query does not use linked-server information schema: %s", columnsQuery)
+	}
+	if !strings.Contains(pkQuery, "FROM [LINKED_SRV].[RemoteDB].INFORMATION_SCHEMA.TABLE_CONSTRAINTS") {
+		t.Fatalf("pk query does not use linked-server table constraints: %s", pkQuery)
+	}
+	if !strings.Contains(pkQuery, "JOIN [LINKED_SRV].[RemoteDB].INFORMATION_SCHEMA.KEY_COLUMN_USAGE") {
+		t.Fatalf("pk query does not use linked-server key column usage: %s", pkQuery)
+	}
+}
+
 func TestGuidConversionEnabled(t *testing.T) {
 	connStr, _, err := URIToConnString("mssql://sa:pass@localhost/db?guid+conversion=true")
 	if err != nil {

--- a/tests/integration/mssql_confidence_test.go
+++ b/tests/integration/mssql_confidence_test.go
@@ -196,6 +196,73 @@ func TestMSSQLSource_TableToSQLite_CustomSchemaFiltersAndExcludeColumns(t *testi
 	assert.LessOrEqual(t, maxTS, "2024-01-01 00:40:00", "interval end filter should be applied")
 }
 
+func TestMSSQLSource_TableToSQLite_DatabaseQualifiedTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	ctx := context.Background()
+	adminDB := openMSSQLTestDB(t, mssqlDest.uri)
+	t.Cleanup(func() { _ = adminDB.Close() })
+
+	dbName := fmt.Sprintf("qualified_%s", uniqueSuffix())
+	quotedDBName := strings.ReplaceAll(dbName, "]", "]]")
+	_, err := adminDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE [%s]", quotedDBName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", quotedDBName))
+		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE [%s]", quotedDBName))
+	})
+
+	sourceDB := openMSSQLTestDB(t, mssqlURIForDatabase(t, mssqlDest.uri, "mssql", dbName, nil))
+	t.Cleanup(func() { _ = sourceDB.Close() })
+
+	tableName := "database_qualified_source"
+	_, err = sourceDB.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %s (
+		id INT PRIMARY KEY,
+		name NVARCHAR(100) NOT NULL
+	)`, quoteTableMSSQL("dbo."+tableName)))
+	require.NoError(t, err)
+
+	_, err = sourceDB.ExecContext(
+		ctx,
+		fmt.Sprintf("INSERT INTO %s (id, name) VALUES (@p1, @p2), (@p3, @p4)", quoteTableMSSQL("dbo."+tableName)),
+		1, "alpha",
+		2, "bravo",
+	)
+	require.NoError(t, err)
+
+	tmpFile, err := os.CreateTemp("", "mssql_source_qualified_*.db")
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           mssqlDest.uri,
+		SourceTable:         dbName + ".dbo." + tableName,
+		DestURI:             fmt.Sprintf("sqlite:///%s", tmpFile.Name()),
+		DestTable:           "qualified_rows",
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	destDB, err := sql.Open("sqlite3", tmpFile.Name())
+	require.NoError(t, err)
+	defer func() { _ = destDB.Close() }()
+
+	var count int
+	require.NoError(t, destDB.QueryRow("SELECT COUNT(*) FROM qualified_rows").Scan(&count))
+	assert.Equal(t, 2, count)
+
+	var name string
+	require.NoError(t, destDB.QueryRow("SELECT name FROM qualified_rows WHERE id = 2").Scan(&name))
+	assert.Equal(t, "bravo", name)
+}
+
 func TestAzureSQLSourceScheme_SQLServerContainerToSQLite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
Fixes #795.

Supports multipart SQL Server source table names by parsing bracketed N-part identifiers, qualifying metadata lookups through the catalog prefix, and quoting full table paths for reads.

Tests: `make format`; `make lint`; `make test`; `go test -tags integration -run '^TestMSSQLSource_TableToSQLite_DatabaseQualifiedTable$' ./tests/integration -count=1 -v`.