### PR TITLE
Add --stream flag for continuous (streaming) ingestion

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -181,6 +181,23 @@ func IngestCommand() *cli.Command {
 				Usage:   "Enable debug logging",
 				Sources: cli.EnvVars("DEBUG", "INGESTR_DEBUG"),
 			},
+			&cli.BoolFlag{
+				Name:    "stream",
+				Usage:   "Continuously ingest from the source, flushing to the destination on an interval or record-count trigger (CDC and message-broker sources only)",
+				Sources: cli.EnvVars("INGESTR_STREAM"),
+			},
+			&cli.DurationFlag{
+				Name:    "flush-interval",
+				Usage:   "How often to flush buffered records to the destination in streaming mode",
+				Value:   30 * time.Second,
+				Sources: cli.EnvVars("INGESTR_FLUSH_INTERVAL"),
+			},
+			&cli.IntFlag{
+				Name:    "flush-records",
+				Usage:   "Flush to the destination when this many records are buffered in streaming mode",
+				Value:   50000,
+				Sources: cli.EnvVars("INGESTR_FLUSH_RECORDS"),
+			},
 			&cli.StringFlag{
 				Name:    "query-annotations",
 				Usage:   "JSON object of caller annotation keys (e.g. {\"pipeline\":\"p\",\"asset\":\"a\"}) merged into the '-- @bruin.config' comment on destination queries (QUERY_TAG on Snowflake) for cost attribution. ingestr always annotates with its own keys (type, ingestr_step); this flag adds the caller's keys on top.",
@@ -226,6 +243,19 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.StagingBucket = c.String("staging-bucket")
 	cfg.StagingDataset = c.String("staging-dataset")
 	cfg.QueryAnnotations = c.String("query-annotations")
+	cfg.Stream = c.Bool("stream")
+	cfg.FlushInterval = c.Duration("flush-interval")
+	cfg.FlushRecords = int(c.Int("flush-records"))
+
+	if !cfg.Stream && (c.IsSet("flush-interval") || c.IsSet("flush-records")) {
+		return fmt.Errorf("--flush-interval and --flush-records are only valid together with --stream")
+	}
+	// In streaming mode the source decides the default strategy (merge for CDC,
+	// append for brokers); only treat the strategy as a user override when the
+	// flag was explicitly set, since it defaults to "replace".
+	if cfg.Stream && !c.IsSet("incremental-strategy") {
+		cfg.IncrementalStrategy = ""
+	}
 
 	if clusterBy := c.String("cluster-by"); clusterBy != "" {
 		// Split by comma to support multiple clustering columns
@@ -259,8 +289,10 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 		return err
 	}
 
-	if _, err := strategy.Get(cfg.IncrementalStrategy); err != nil {
-		return err
+	if cfg.IncrementalStrategy != "" {
+		if _, err := strategy.Get(cfg.IncrementalStrategy); err != nil {
+			return err
+		}
 	}
 
 	trackCommandRunning(ctx, "ingest", ingestTelemetryProperties(cfg))
@@ -271,6 +303,12 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	}
 
 	if ctx.Err() != nil {
+		// In streaming mode, cancellation (SIGINT/SIGTERM) is the normal way to
+		// stop; the pipeline has already flushed pending data.
+		if cfg.Stream {
+			color.Green("Streaming ingestion stopped.")
+			return nil
+		}
 		return ctx.Err()
 	}
 

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -31,6 +31,9 @@ ingestr ingest \
 - `--no-inference`: Skips schema inference for schema-less sources and uses `--columns` as the source schema. Requires `--columns`.
 - `--mask <column_name>:<algorithm>[:param]`: Applies data masking to specified columns. Can be used multiple times for different columns. See the [Data Masking](../getting-started/data-masking.md) documentation for available algorithms and usage examples. Defaults to `None`.
 - `--schema-naming` Specifies what naming convention to use for table and column names on the destination. Can be `default` or `direct`.default is snake_case. `direct is case sensitive and doesn't contract underscores.
+- `--stream`: Runs continuous (streaming) ingestion instead of a one-shot load. Supported by CDC sources (`postgres+cdc`, `mssql+cdc`) and message brokers (`kafka`, `amqp`). The process runs until interrupted (SIGINT/SIGTERM), flushing buffered records to the destination on an interval or record-count trigger. See [Streaming ingestion](#streaming-ingestion) below.
+- `--flush-interval`: In streaming mode, flush buffered records to the destination at least this often. Defaults to `30s`. Only valid with `--stream`.
+- `--flush-records`: In streaming mode, flush when this many records have been buffered. Defaults to `50000`. Only valid with `--stream`.
 
 The `interval-start` and `interval-end` options support various datetime formats, here are some examples:
 - `%Y-%m-%d`: `2023-01-31`
@@ -42,6 +45,53 @@ The `interval-start` and `interval-end` options support various datetime formats
 > [!INFO]
 > For the details around the incremental key and the various strategies, please refer to the [Incremental Loading](../getting-started/incremental-loading.md) section.
 
+
+## Streaming ingestion
+
+The `--stream` flag turns `ingest` into a long-running process that continuously
+pulls changes from the source and flushes them to the destination, rather than
+running once and exiting. It is supported by:
+
+- **CDC sources** (`postgres+cdc`, `mssql+cdc`): captures every insert, update,
+  and delete across all tables in the publication/capture set and applies them
+  with the `merge` strategy.
+- **Message brokers** (`kafka`, `amqp`): consumes messages into a fixed envelope
+  schema — a `msg_id` primary key, a JSON `data` column holding the decoded body and
+  metadata, and an `_ingestr_order` column (source offset / delivery tag) — and
+  applies them with `merge` keyed on `msg_id`, keeping the latest record per key
+  within each flush window. Schema inference is skipped (a never-ending stream
+  has no end to infer from).
+
+A flush happens whenever **either** `--flush-interval` (default 30s) **or**
+`--flush-records` (default 50000) is reached, whichever comes first.
+`--flush-records` is the memory bound: records are buffered until a flush.
+
+Each flush writes the buffered records, merges them into the destination, and
+only then confirms the source position as durable. This gives **at-least-once
+delivery**: a crash before a flush completes re-delivers the un-flushed changes
+on restart, and the `merge` (by primary key / `msg_id`) makes replays
+idempotent. The stream resumes automatically — CDC from the destination's last
+recorded LSN, brokers from their committed offset / unacknowledged messages.
+
+Stop a stream with `Ctrl+C` (SIGINT) or SIGTERM; ingestr performs a final flush
+of buffered data and exits cleanly.
+
+```bash
+# Stream all changes from a Postgres publication into BigQuery, flushing
+# every 15 seconds or 100k changes, whichever comes first.
+ingestr ingest \
+   --source-uri 'postgres+cdc://user:pass@localhost:5432/mydb?publication=my_pub' \
+   --dest-uri 'bigquery://my_project?credentials_path=/path/to/sa.json' \
+   --stream \
+   --flush-interval 15s \
+   --flush-records 100000
+```
+
+> [!INFO]
+> Schema changes are picked up at startup. If the source schema changes while a
+> stream is running, restart the stream to apply the new schema. Run streaming
+> ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after
+> transient source/destination outages.
 
 ## General flags
 

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -48,33 +48,16 @@ The `interval-start` and `interval-end` options support various datetime formats
 
 ## Streaming ingestion
 
-The `--stream` flag turns `ingest` into a long-running process that continuously
-pulls changes from the source and flushes them to the destination, rather than
-running once and exiting. It is supported by:
+The `--stream` flag turns `ingest` into a long-running process that continuously pulls changes from the source and flushes them to the destination, rather than running once and exiting. It is supported by:
 
-- **CDC sources** (`postgres+cdc`, `mssql+cdc`): captures every insert, update,
-  and delete across all tables in the publication/capture set and applies them
-  with the `merge` strategy.
-- **Message brokers** (`kafka`, `amqp`): consumes messages into a fixed envelope
-  schema — a `msg_id` primary key, a JSON `data` column holding the decoded body and
-  metadata, and an `_ingestr_order` column (source offset / delivery tag) — and
-  applies them with `merge` keyed on `msg_id`, keeping the latest record per key
-  within each flush window. Schema inference is skipped (a never-ending stream
-  has no end to infer from).
+- **CDC sources** (`postgres+cdc`, `mssql+cdc`): captures every insert, update, and delete across all tables in the publication/capture set and applies them with the `merge` strategy.
+- **Message brokers** (`kafka`, `amqp`): consumes messages into a fixed envelope schema — a `msg_id` primary key, a JSON `data` column holding the decoded body and metadata, and an `_ingestr_order` column (source offset / delivery tag) — and applies them with `merge` keyed on `msg_id`, keeping the latest record per key within each flush window. Schema inference is skipped (a never-ending stream has no end to infer from).
 
-A flush happens whenever **either** `--flush-interval` (default 30s) **or**
-`--flush-records` (default 50000) is reached, whichever comes first.
-`--flush-records` is the memory bound: records are buffered until a flush.
+A flush happens whenever **either** `--flush-interval` (default 30s) **or** `--flush-records` (default 50000) is reached, whichever comes first. `--flush-records` is the memory bound: records are buffered until a flush.
 
-Each flush writes the buffered records, merges them into the destination, and
-only then confirms the source position as durable. This gives **at-least-once
-delivery**: a crash before a flush completes re-delivers the un-flushed changes
-on restart, and the `merge` (by primary key / `msg_id`) makes replays
-idempotent. The stream resumes automatically — CDC from the destination's last
-recorded LSN, brokers from their committed offset / unacknowledged messages.
+Each flush writes the buffered records, merges them into the destination, and only then confirms the source position as durable. This gives **at-least-once delivery**: a crash before a flush completes re-delivers the un-flushed changes on restart, and the `merge` (by primary key / `msg_id`) makes replays idempotent. The stream resumes automatically — CDC from the destination's last recorded LSN, brokers from their committed offset / unacknowledged messages.
 
-Stop a stream with `Ctrl+C` (SIGINT) or SIGTERM; ingestr performs a final flush
-of buffered data and exits cleanly.
+Stop a stream with `Ctrl+C` (SIGINT) or SIGTERM; ingestr performs a final flush of buffered data and exits cleanly.
 
 ```bash
 # Stream all changes from a Postgres publication into BigQuery, flushing
@@ -88,10 +71,7 @@ ingestr ingest \
 ```
 
 > [!INFO]
-> Schema changes are picked up at startup. If the source schema changes while a
-> stream is running, restart the stream to apply the new schema. Run streaming
-> ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after
-> transient source/destination outages.
+> Schema changes are picked up at startup. If the source schema changes while a stream is running, restart the stream to apply the new schema. Run streaming ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after transient source/destination outages.
 
 ## General flags
 

--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -62,12 +62,7 @@ The result of this command will be a table in the `kafka.duckdb` database with J
 
 ## Streaming ingestion
 
-Add `--stream` to consume the topic continuously instead of reading the current
-backlog and exiting. In streaming mode each message is projected into a fixed
-envelope schema — a `msg_id` primary key plus a JSON `data` column holding the
-key, value, and metadata — and changes are merged on `msg_id` (latest record per key wins within a flush window, ordered by an `_ingestr_order` column). The consumer
-group's offsets are committed only after a flush succeeds, so a restart resumes
-where it left off. See [`ingest --stream`](../commands/ingest.md#streaming-ingestion).
+Add `--stream` to consume the topic continuously instead of reading the current backlog and exiting. In streaming mode each message is projected into a fixed envelope schema — a `msg_id` primary key plus a JSON `data` column holding the key, value, and metadata — and changes are merged on `msg_id` (latest record per key wins within a flush window, ordered by an `_ingestr_order` column). The consumer group's offsets are committed only after a flush succeeds, so a restart resumes where it left off. See [`ingest --stream`](../commands/ingest.md#streaming-ingestion).
 
 ```sh
 ingestr ingest \

--- a/docs/supported-sources/kafka.md
+++ b/docs/supported-sources/kafka.md
@@ -59,3 +59,21 @@ ingestr ingest \
 ```
 
 The result of this command will be a table in the `kafka.duckdb` database with JSON columns.
+
+## Streaming ingestion
+
+Add `--stream` to consume the topic continuously instead of reading the current
+backlog and exiting. In streaming mode each message is projected into a fixed
+envelope schema — a `msg_id` primary key plus a JSON `data` column holding the
+key, value, and metadata — and changes are merged on `msg_id` (latest record per key wins within a flush window, ordered by an `_ingestr_order` column). The consumer
+group's offsets are committed only after a flush succeeds, so a restart resumes
+where it left off. See [`ingest --stream`](../commands/ingest.md#streaming-ingestion).
+
+```sh
+ingestr ingest \
+    --source-uri 'kafka://?bootstrap_servers=localhost:9092&group_id=test_group' \
+    --source-table 'my-topic' \
+    --dest-uri duckdb:///kafka.duckdb \
+    --dest-table 'dest.my_topic' \
+    --stream
+```

--- a/docs/supported-sources/rabbitmq.md
+++ b/docs/supported-sources/rabbitmq.md
@@ -50,12 +50,7 @@ The result of this command will be a table in the `rabbitmq.duckdb` database wit
 
 ## Streaming ingestion
 
-Add `--stream` to consume the queue continuously instead of reading what is
-currently available and exiting. In streaming mode each message is projected
-into a fixed envelope schema — a `msg_id` primary key plus a JSON `data` column
-holding the decoded body and metadata — and changes are merged on `msg_id` (latest record per key wins within a flush window, ordered by an `_ingestr_order` column)
-(so at-least-once redeliveries are idempotent). Deliveries are acknowledged only
-after a flush succeeds. See [`ingest --stream`](../commands/ingest.md#streaming-ingestion).
+Add `--stream` to consume the queue continuously instead of reading what is currently available and exiting. In streaming mode each message is projected into a fixed envelope schema — a `msg_id` primary key plus a JSON `data` column holding the decoded body and metadata — and changes are merged on `msg_id` (latest record per key wins within a flush window, ordered by an `_ingestr_order` column) (so at-least-once redeliveries are idempotent). Deliveries are acknowledged only after a flush succeeds. See [`ingest --stream`](../commands/ingest.md#streaming-ingestion).
 
 ```sh
 ingestr ingest \

--- a/docs/supported-sources/rabbitmq.md
+++ b/docs/supported-sources/rabbitmq.md
@@ -47,3 +47,21 @@ ingestr ingest \
 ```
 
 The result of this command will be a table in the `rabbitmq.duckdb` database with JSON columns containing the message data and metadata.
+
+## Streaming ingestion
+
+Add `--stream` to consume the queue continuously instead of reading what is
+currently available and exiting. In streaming mode each message is projected
+into a fixed envelope schema — a `msg_id` primary key plus a JSON `data` column
+holding the decoded body and metadata — and changes are merged on `msg_id` (latest record per key wins within a flush window, ordered by an `_ingestr_order` column)
+(so at-least-once redeliveries are idempotent). Deliveries are acknowledged only
+after a flush succeeds. See [`ingest --stream`](../commands/ingest.md#streaming-ingestion).
+
+```sh
+ingestr ingest \
+    --source-uri 'amqp://guest:guest@localhost:5672/' \
+    --source-table 'my_queue' \
+    --dest-uri 'duckdb://./rabbitmq.duckdb' \
+    --dest-table 'dest.my_queue' \
+    --stream
+```

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.41.0
+	github.com/testcontainers/testcontainers-go/modules/redpanda v0.41.0
 	github.com/trinodb/trino-go-client v0.333.0
 	github.com/urfave/cli/v3 v3.0.0-beta1
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78

--- a/go.sum
+++ b/go.sum
@@ -1414,6 +1414,8 @@ github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0 h1:s2bIayFX
 github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0/go.mod h1:h+u/2KoREGTnTl9UwrQ/g+XhasAT8E6dClclAADeXoQ=
 github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.41.0 h1:JQS8FXKuzRTxvfEfHUhNFOgRAv0rovEw7c4+Ne2nqtY=
 github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.41.0/go.mod h1:p7PE0uLxjRRNZJnnndNoJUadUZoE0jMzzjpSP0DxcUM=
+github.com/testcontainers/testcontainers-go/modules/redpanda v0.41.0 h1:YEbx+louxePq04rKCqTe7Xph8WuiAlxp6nXXzeN0fRo=
+github.com/testcontainers/testcontainers-go/modules/redpanda v0.41.0/go.mod h1:u3Lgwe9NX+X2i+2Ok6zI2/+NBWvw2zsTR1gqvTpiFN8=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
@@ -1421,6 +1423,12 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
+github.com/twmb/franz-go v1.16.1 h1:rpWc7fB9jd7TgmCyfxzenBI+QbgS8ZfJOUQE+tzPtbE=
+github.com/twmb/franz-go v1.16.1/go.mod h1:/pER254UPPGp/4WfGqRi+SIRGE50RSQzVubQp6+N4FA=
+github.com/twmb/franz-go/pkg/kadm v1.11.0 h1:FfeWJ0qadntFpAcQt8JzNXW4dijjytZNLrzJuzzzuxA=
+github.com/twmb/franz-go/pkg/kadm v1.11.0/go.mod h1:qrhkdH+SWS3ivmbqOgHbpgVHamhaKcjH0UM+uOp0M1A=
+github.com/twmb/franz-go/pkg/kmsg v1.7.0 h1:a457IbvezYfA5UkiBvyV3zj0Is3y1i8EJgqjJYoij2E=
+github.com/twmb/franz-go/pkg/kmsg v1.7.0/go.mod h1:se9Mjdt0Nwzc9lnjJ0HyDtLyBnaBDAd7pCje47OhSyw=
 github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjcw9Zg=
 github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,10 @@ type IngestConfig struct {
 	CDCResumeLSN  string // For CDC sources: resume from this LSN (auto-detected from destination)
 	CDCSlotSuffix string // For CDC sources: suffix appended to auto-generated slot names (derived from dest URI)
 
+	Stream        bool          // Continuous ingestion: flush buffered records on an interval or record-count trigger
+	FlushInterval time.Duration // Streaming mode: flush at least this often
+	FlushRecords  int           // Streaming mode: flush when this many records are buffered
+
 	// QueryAnnotations is a JSON object of external annotation keys (e.g. asset,
 	// pipeline) supplied by the caller. When set, ingestr prepends a
 	// "-- @bruin.config: {...}" comment to destination queries (QUERY_TAG on
@@ -91,6 +95,8 @@ func DefaultConfig() *IngestConfig {
 		PageSize:            25000,
 		LoaderFileSize:      25000,
 		ExtractParallelism:  5,
+		FlushInterval:       30 * time.Second,
+		FlushRecords:        50000,
 	}
 }
 
@@ -116,6 +122,28 @@ func (c *IngestConfig) Validate() error {
 	}
 	if c.NoInference && strings.TrimSpace(c.Columns) == "" {
 		return &ValidationError{Field: "columns", Message: "is required when no-inference is enabled"}
+	}
+	if c.Stream {
+		if c.FullRefresh {
+			return &ValidationError{Field: "full-refresh", Message: "cannot be combined with --stream"}
+		}
+		if c.IntervalEnd != nil {
+			return &ValidationError{Field: "interval-end", Message: "cannot be combined with --stream (a bounded end contradicts continuous ingestion)"}
+		}
+		if c.SQLLimit > 0 {
+			return &ValidationError{Field: "sql-limit", Message: "cannot be combined with --stream"}
+		}
+		if c.FlushInterval <= 0 {
+			return &ValidationError{Field: "flush-interval", Message: "must be positive"}
+		}
+		if c.FlushRecords <= 0 {
+			return &ValidationError{Field: "flush-records", Message: "must be positive"}
+		}
+		switch c.IncrementalStrategy {
+		case "", StrategyMerge, StrategyAppend:
+		default:
+			return &ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("%q is not supported with --stream (only merge and append)", c.IncrementalStrategy)}
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestIngestConfigValidate_NoInferenceRequiresColumns(t *testing.T) {
@@ -31,5 +32,91 @@ func TestIngestConfigValidate_NoInferenceWithColumns(t *testing.T) {
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestIngestConfigValidate_Stream(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		mutate  func(c *IngestConfig)
+		wantErr string
+	}{
+		{
+			name:   "valid defaults",
+			mutate: func(c *IngestConfig) {},
+		},
+		{
+			name:    "full refresh rejected",
+			mutate:  func(c *IngestConfig) { c.FullRefresh = true },
+			wantErr: "full-refresh",
+		},
+		{
+			name:    "interval end rejected",
+			mutate:  func(c *IngestConfig) { c.IntervalEnd = &now },
+			wantErr: "interval-end",
+		},
+		{
+			name:    "sql limit rejected",
+			mutate:  func(c *IngestConfig) { c.SQLLimit = 100 },
+			wantErr: "sql-limit",
+		},
+		{
+			name:    "non-positive flush interval rejected",
+			mutate:  func(c *IngestConfig) { c.FlushInterval = 0 },
+			wantErr: "flush-interval",
+		},
+		{
+			name:    "non-positive flush records rejected",
+			mutate:  func(c *IngestConfig) { c.FlushRecords = -1 },
+			wantErr: "flush-records",
+		},
+		{
+			name:    "replace strategy rejected",
+			mutate:  func(c *IngestConfig) { c.IncrementalStrategy = StrategyReplace },
+			wantErr: "incremental-strategy",
+		},
+		{
+			name:    "scd2 strategy rejected",
+			mutate:  func(c *IngestConfig) { c.IncrementalStrategy = StrategySCD2 },
+			wantErr: "incremental-strategy",
+		},
+		{
+			name:   "merge strategy allowed",
+			mutate: func(c *IngestConfig) { c.IncrementalStrategy = StrategyMerge },
+		},
+		{
+			name:   "append strategy allowed",
+			mutate: func(c *IngestConfig) { c.IncrementalStrategy = StrategyAppend },
+		},
+		{
+			name:   "empty strategy allowed",
+			mutate: func(c *IngestConfig) { c.IncrementalStrategy = "" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.SourceURI = "postgres+cdc://localhost:5432/db"
+			cfg.DestURI = "duckdb://out.duckdb"
+			cfg.Stream = true
+			cfg.IncrementalStrategy = ""
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected validation error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
 	}
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -73,6 +73,13 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 	defer func() { _ = src.Close(ctx) }()
 
+	if p.config.Stream {
+		ss, ok := src.(source.StreamingSource)
+		if !ok || !ss.SupportsStreaming() {
+			return fmt.Errorf("--stream is not supported by this source; streaming requires a CDC source (postgres+cdc, mssql+cdc) or a message broker source (kafka, amqp)")
+		}
+	}
+
 	dest, err := uri.DefaultRegistry.GetDestination(p.config.DestURI)
 	if err != nil {
 		return fmt.Errorf("failed to get destination: %w", err)
@@ -119,6 +126,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		IncrementalKey: p.config.IncrementalKey,
 		PrimaryKeys:    p.config.PrimaryKeys,
 		Strategy:       p.config.IncrementalStrategy,
+		Streaming:      p.config.Stream,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get table: %w", err)
@@ -419,6 +427,20 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		// For known-schema sources with column type overrides, add a type caster
 		// that converts Arrow batches from source types to the overridden types.
 		job.TypeCaster = p.buildTypeCaster(tableSchema, destSchema)
+	}
+
+	if p.config.Stream {
+		committer, _ := src.(source.StreamCommitter)
+		exec := strategy.NewStreamingExecutor(strategy.StreamingOptions{
+			FlushInterval: p.config.FlushInterval,
+			FlushRecords:  int64(p.config.FlushRecords),
+			Strategy:      resolvedStrategy,
+			Committer:     committer,
+		})
+		if err := exec.Execute(ctx, job); err != nil {
+			return fmt.Errorf("streaming ingestion failed: %w", err)
+		}
+		return nil
 	}
 
 	if err := strat.Execute(ctx, job); err != nil {
@@ -784,6 +806,11 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	config.Debug("[PIPELINE] Multi-table mode: %d tables", len(tables))
 
 	resolvedStrategy := p.config.IncrementalStrategy
+	if p.config.Stream && resolvedStrategy == "" {
+		if ss, ok := src.(source.StreamingSource); ok {
+			resolvedStrategy = ss.DefaultStreamingStrategy()
+		}
+	}
 	if isCDCSource(p.config.SourceURI) && !p.config.FullRefresh && (resolvedStrategy == "" || resolvedStrategy == config.StrategyReplace) {
 		resolvedStrategy = config.StrategyMerge
 	}
@@ -895,6 +922,20 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 		Tracker:        tracker,
 		CDCResumeLSNs:  cdcResumeLSNs,
 		EvolutionPlans: evolutionPlans,
+	}
+
+	if p.config.Stream {
+		committer, _ := src.(source.StreamCommitter)
+		exec := strategy.NewStreamingExecutor(strategy.StreamingOptions{
+			FlushInterval: p.config.FlushInterval,
+			FlushRecords:  int64(p.config.FlushRecords),
+			Strategy:      resolvedStrategy,
+			Committer:     committer,
+		})
+		if err := exec.ExecuteMultiTable(ctx, job); err != nil {
+			return fmt.Errorf("streaming ingestion failed: %w", err)
+		}
+		return nil
 	}
 
 	if err := mtStrat.ExecuteMultiTable(ctx, job); err != nil {
@@ -1348,6 +1389,11 @@ func resolveStrategy(cfg *config.IngestConfig, src source.Source, table source.S
 		s = table.Strategy()
 	} else {
 		s = cfg.IncrementalStrategy
+	}
+	if cfg.Stream && s == "" {
+		if ss, ok := src.(source.StreamingSource); ok {
+			s = ss.DefaultStreamingStrategy()
+		}
 	}
 	if isCDCSource(cfg.SourceURI) && !cfg.FullRefresh && (s == "" || s == config.StrategyReplace) {
 		s = config.StrategyMerge

--- a/pkg/schemaevolution/transform.go
+++ b/pkg/schemaevolution/transform.go
@@ -203,11 +203,12 @@ func TransformBatchStream(ctx context.Context, batches <-chan source.RecordBatch
 			// Transform batch
 			transformed, err := transformer.Transform(ctx, result.Batch)
 			if err != nil {
-				out <- source.RecordBatchResult{Err: err}
+				out <- source.RecordBatchResult{Err: err, TableName: result.TableName}
 				continue
 			}
 
-			out <- source.RecordBatchResult{Batch: transformed}
+			result.Batch = transformed
+			out <- result
 		}
 	}()
 

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -95,7 +95,12 @@ func (s *KafkaSource) CommitStream(ctx context.Context, token any) error {
 	reader := s.streamReader
 	s.mu.Unlock()
 	if reader == nil {
-		return fmt.Errorf("kafka: no active streaming reader to commit")
+		// The reader was already closed (e.g. a final flush racing shutdown).
+		// The data is durably written, so skipping the offset commit is safe
+		// under at-least-once: the group re-reads from its last committed
+		// position on the next start.
+		config.Debug("[KAFKA] CommitStream: no active reader, skipping offset commit")
+		return nil
 	}
 	flat := make([]kafkago.Message, 0, len(msgs))
 	for _, m := range msgs {
@@ -145,6 +150,15 @@ func (s *KafkaSource) Connect(ctx context.Context, uri string) error {
 }
 
 func (s *KafkaSource) Close(ctx context.Context) error {
+	// The streaming reader outlives its fetch goroutine so the pipeline's final
+	// flush can commit offsets; it is closed here, after Run has returned.
+	s.mu.Lock()
+	r := s.streamReader
+	s.streamReader = nil
+	s.mu.Unlock()
+	if r != nil {
+		return r.Close()
+	}
 	return nil
 }
 
@@ -227,13 +241,10 @@ func (s *KafkaSource) readStreaming(ctx context.Context, topic string, opts sour
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
+		// Only close the results channel here; the reader is kept open (and
+		// s.streamReader set) so the pipeline's final flush after cancellation
+		// can still commit offsets via CommitStream. Close() closes the reader.
 		defer close(results)
-		defer func() { _ = reader.Close() }()
-		defer func() {
-			s.mu.Lock()
-			s.streamReader = nil
-			s.mu.Unlock()
-		}()
 
 		envelopeCols := streamingEnvelopeSchema(topic).Columns
 		batch := make([]map[string]interface{}, 0, s.cfg.BatchSize)

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -1,9 +1,11 @@
 package kafka
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -55,6 +57,11 @@ type kafkaConfig struct {
 
 type KafkaSource struct {
 	cfg kafkaConfig
+
+	// streamReader holds the live consumer-group reader in streaming mode so
+	// CommitStream can commit offsets after the pipeline has flushed.
+	mu           sync.Mutex
+	streamReader *kafkago.Reader
 }
 
 func NewKafkaSource() *KafkaSource {
@@ -64,6 +71,64 @@ func NewKafkaSource() *KafkaSource {
 func (s *KafkaSource) HandlesIncrementality() bool {
 	return false
 }
+
+// SupportsStreaming reports that Kafka can be consumed continuously.
+func (s *KafkaSource) SupportsStreaming() bool {
+	return true
+}
+
+// DefaultStreamingStrategy returns merge keyed on the envelope msg_id so
+// at-least-once redeliveries (e.g. after a group rebalance) are idempotent
+// rather than producing duplicate rows or violating the msg_id primary key.
+func (s *KafkaSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyMerge
+}
+
+// CommitStream commits the per-partition offsets captured in the token after
+// the pipeline has durably written the corresponding messages.
+func (s *KafkaSource) CommitStream(ctx context.Context, token any) error {
+	msgs, ok := token.(map[int]kafkago.Message)
+	if !ok {
+		return fmt.Errorf("kafka: unexpected commit token type %T", token)
+	}
+	s.mu.Lock()
+	reader := s.streamReader
+	s.mu.Unlock()
+	if reader == nil {
+		return fmt.Errorf("kafka: no active streaming reader to commit")
+	}
+	flat := make([]kafkago.Message, 0, len(msgs))
+	for _, m := range msgs {
+		flat = append(flat, m)
+	}
+	if len(flat) == 0 {
+		return nil
+	}
+	if err := reader.CommitMessages(ctx, flat...); err != nil {
+		return fmt.Errorf("kafka: failed to commit offsets: %w", err)
+	}
+	return nil
+}
+
+// streamingEnvelopeSchema is the fixed schema for streaming Kafka ingestion:
+// a primary-key message id plus a JSON column with the key, value, and metadata.
+func streamingEnvelopeSchema(topic string) *schema.TableSchema {
+	return &schema.TableSchema{
+		Name: topic,
+		Columns: []schema.Column{
+			{Name: "msg_id", DataType: schema.TypeString, Nullable: false, IsPrimaryKey: true},
+			{Name: "data", DataType: schema.TypeJSON, Nullable: true},
+			// Monotonic per-key source position (Kafka offset). Used as the merge
+			// incremental key so the latest record per msg_id wins within a flush
+			// cycle. Same key => same partition => offsets are ordered.
+			{Name: streamOrderColumn, DataType: schema.TypeInt64, Nullable: false},
+		},
+		PrimaryKeys:    []string{"msg_id"},
+		IncrementalKey: streamOrderColumn,
+	}
+}
+
+const streamOrderColumn = "_ingestr_order"
 
 func (s *KafkaSource) Schemes() []string {
 	return []string{"kafka"}
@@ -94,6 +159,28 @@ func (s *KafkaSource) GetTable(ctx context.Context, req source.TableRequest) (so
 		strategy = config.StrategyReplace
 	}
 
+	// Streaming mode has no inferable schema (the stream never ends), so every
+	// message is projected into a fixed msg_id + data envelope.
+	if req.Streaming {
+		primaryKeys := req.PrimaryKeys
+		if len(primaryKeys) == 0 {
+			primaryKeys = []string{"msg_id"}
+		}
+		return &source.DynamicSourceTable{
+			TableName:           topicName,
+			TablePrimaryKeys:    primaryKeys,
+			TableIncrementalKey: req.IncrementalKey,
+			TableStrategy:       strategy,
+			KnownSchema:         true,
+			SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+				return streamingEnvelopeSchema(topicName), nil
+			},
+			ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+				return s.readStreaming(ctx, topicName, opts)
+			},
+		}, nil
+	}
+
 	return &source.DynamicSourceTable{
 		TableName:           topicName,
 		TablePrimaryKeys:    req.PrimaryKeys,
@@ -107,6 +194,103 @@ func (s *KafkaSource) GetTable(ctx context.Context, req source.TableRequest) (so
 			return s.read(ctx, topicName, opts)
 		},
 	}, nil
+}
+
+// readStreaming consumes the topic continuously via a consumer-group reader,
+// committing offsets only after the pipeline durably writes each flush (so
+// delivery is at-least-once). It uses FetchMessage (not ReadMessage) so offsets
+// are never auto-committed before the data is durable.
+func (s *KafkaSource) readStreaming(ctx context.Context, topic string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	dialer, err := s.buildDialer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kafka dialer: %w", err)
+	}
+
+	if opts.IntervalStart != nil {
+		fmt.Printf("Warning: --interval-start is ignored for streaming Kafka; the consumer group's committed offsets determine the start position\n")
+	}
+
+	reader := kafkago.NewReader(kafkago.ReaderConfig{
+		Brokers:     strings.Split(s.cfg.BootstrapServers, ","),
+		GroupID:     s.cfg.GroupID,
+		Topic:       topic,
+		Dialer:      dialer,
+		MinBytes:    1,
+		MaxBytes:    10e6,
+		StartOffset: kafkago.FirstOffset, // only used when the group has no committed offset
+	})
+
+	s.mu.Lock()
+	s.streamReader = reader
+	s.mu.Unlock()
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+		defer func() { _ = reader.Close() }()
+		defer func() {
+			s.mu.Lock()
+			s.streamReader = nil
+			s.mu.Unlock()
+		}()
+
+		envelopeCols := streamingEnvelopeSchema(topic).Columns
+		batch := make([]map[string]interface{}, 0, s.cfg.BatchSize)
+		latest := make(map[int]kafkago.Message) // per-partition highest message seen, for committing
+
+		flush := func() bool {
+			if len(batch) == 0 {
+				return true
+			}
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, envelopeCols, opts.ExcludeColumns)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert kafka messages to Arrow: %w", err)}
+				return false
+			}
+			// Cumulative token: a copy of the per-partition offsets emitted so far.
+			token := make(map[int]kafkago.Message, len(latest))
+			for p, m := range latest {
+				token[p] = kafkago.Message{Topic: m.Topic, Partition: m.Partition, Offset: m.Offset}
+			}
+			results <- source.RecordBatchResult{Batch: record, CommitToken: token}
+			batch = batch[:0]
+			return true
+		}
+
+		for {
+			fetchCtx, cancel := context.WithTimeout(ctx, s.cfg.BatchTimeout)
+			msg, err := reader.FetchMessage(fetchCtx)
+			cancel()
+
+			if err != nil {
+				if ctx.Err() != nil {
+					flush()
+					return
+				}
+				if errors.Is(err, context.DeadlineExceeded) {
+					// Idle: flush any partial batch and keep consuming.
+					if !flush() {
+						return
+					}
+					continue
+				}
+				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to fetch from topic %s: %w", topic, err)}
+				return
+			}
+
+			batch = append(batch, messageToEnvelope(msg))
+			latest[msg.Partition] = msg
+
+			if len(batch) >= s.cfg.BatchSize {
+				if !flush() {
+					return
+				}
+			}
+		}
+	}()
+
+	return results, nil
 }
 
 func (s *KafkaSource) read(ctx context.Context, topic string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -305,6 +489,12 @@ func (s *KafkaSource) readPartition(
 	return nil
 }
 
+var (
+	_ source.Source          = (*KafkaSource)(nil)
+	_ source.StreamingSource = (*KafkaSource)(nil)
+	_ source.StreamCommitter = (*KafkaSource)(nil)
+)
+
 func messageToItem(msg kafkago.Message) map[string]interface{} {
 	var keyStr interface{}
 	if msg.Key != nil {
@@ -333,6 +523,36 @@ func messageToItem(msg kafkago.Message) map[string]interface{} {
 	return map[string]interface{}{
 		"_kafka":        kafkaMeta,
 		"_kafka_msg_id": msgID,
+	}
+}
+
+// messageToEnvelope projects a Kafka message into the streaming envelope:
+// a primary-key msg_id and a JSON data column holding the key, value, and
+// metadata. The value is decoded as JSON so it nests as a structured object
+// (parity with the RabbitMQ envelope); non-JSON values fall back to a string.
+func messageToEnvelope(msg kafkago.Message) map[string]interface{} {
+	item := messageToItem(msg)
+	msgID, _ := item["_kafka_msg_id"].(string)
+
+	meta, _ := item["_kafka"].(map[string]interface{})
+	if meta != nil {
+		var body any
+		dec := json.NewDecoder(bytes.NewReader(msg.Value))
+		dec.UseNumber()
+		if err := dec.Decode(&body); err != nil {
+			body = string(msg.Value)
+		}
+		meta["data"] = body
+	}
+
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		encoded = fmt.Appendf(nil, "%q", string(msg.Value))
+	}
+	return map[string]interface{}{
+		"msg_id":          msgID,
+		"data":            string(encoded),
+		streamOrderColumn: msg.Offset,
 	}
 }
 

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -543,7 +543,7 @@ func messageToItem(msg kafkago.Message) map[string]interface{} {
 // (parity with the RabbitMQ envelope); non-JSON values fall back to a string.
 func messageToEnvelope(msg kafkago.Message) map[string]interface{} {
 	item := messageToItem(msg)
-	msgID, _ := item["_kafka_msg_id"].(string)
+	msgID := streamMsgID(msg)
 
 	meta, _ := item["_kafka"].(map[string]interface{})
 	if meta != nil {
@@ -565,6 +565,20 @@ func messageToEnvelope(msg kafkago.Message) map[string]interface{} {
 		"data":            string(encoded),
 		streamOrderColumn: msg.Offset,
 	}
+}
+
+// streamMsgID derives the streaming envelope's primary key. For keyed messages
+// it is stable per key (so the merge keeps the latest record per key —
+// changelog/compaction semantics). For keyless messages it includes the offset
+// so every message gets a distinct id; otherwise all keyless messages on a
+// partition would collide on one id and the merge would keep only the last per
+// flush window (silent data loss). topic/partition/offset is stable across
+// redeliveries, so at-least-once dedup still works.
+func streamMsgID(msg kafkago.Message) string {
+	if len(msg.Key) > 0 {
+		return generateMsgID(msg.Topic, msg.Partition, msg.Offset, string(msg.Key))
+	}
+	return fmt.Sprintf("%s:%d:%d", msg.Topic, msg.Partition, msg.Offset)
 }
 
 func generateMsgID(topic string, partition int, offset int64, key interface{}) string {

--- a/pkg/source/kafka/kafka_test.go
+++ b/pkg/source/kafka/kafka_test.go
@@ -237,6 +237,30 @@ func TestGenerateMsgID_NilKey(t *testing.T) {
 	}
 }
 
+func TestStreamMsgID(t *testing.T) {
+	// Keyless messages must get distinct ids per offset (otherwise the merge
+	// envelope collapses every keyless message on a partition into one row).
+	a := streamMsgID(kafkago.Message{Topic: "t", Partition: 0, Offset: 1})
+	b := streamMsgID(kafkago.Message{Topic: "t", Partition: 0, Offset: 2})
+	if a == b {
+		t.Errorf("keyless messages at different offsets share msg_id: %q", a)
+	}
+	// Same offset (e.g. a redelivery) is stable so at-least-once dedup works.
+	if a2 := streamMsgID(kafkago.Message{Topic: "t", Partition: 0, Offset: 1}); a != a2 {
+		t.Errorf("keyless msg_id not stable for the same offset: %q != %q", a, a2)
+	}
+
+	// Keyed messages dedup by key regardless of offset (last-value-per-key).
+	k1 := streamMsgID(kafkago.Message{Topic: "t", Partition: 0, Offset: 10, Key: []byte("k")})
+	k2 := streamMsgID(kafkago.Message{Topic: "t", Partition: 0, Offset: 11, Key: []byte("k")})
+	if k1 != k2 {
+		t.Errorf("keyed messages with the same key should share msg_id: %q != %q", k1, k2)
+	}
+	if kOther := streamMsgID(kafkago.Message{Topic: "t", Partition: 0, Offset: 12, Key: []byte("k2")}); k1 == kOther {
+		t.Error("different keys should produce different msg_ids")
+	}
+}
+
 func TestMessageToItem(t *testing.T) {
 	ts := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 	msg := kafkago.Message{

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -126,6 +126,27 @@ func (s *MSSQLCDCSource) HandlesIncrementality() bool {
 	return true
 }
 
+// SupportsStreaming reports that SQL Server CDC can run in continuous mode.
+func (s *MSSQLCDCSource) SupportsStreaming() bool {
+	return true
+}
+
+// DefaultStreamingStrategy returns merge: CDC changes (including deletes) are
+// applied by primary key.
+func (s *MSSQLCDCSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyMerge
+}
+
+// applyStreamingMode forces continuous polling when --stream is set, regardless
+// of the URI ?mode= parameter. SQL Server CDC reads change tables via polling
+// and has no consumer-side acknowledgement, so there is no StreamCommitter:
+// at-least-once is provided by resuming from the destination's max _cdc_lsn.
+func (s *MSSQLCDCSource) applyStreamingMode(streaming bool) {
+	if streaming {
+		s.cdcConfig.Mode = ModeStream
+	}
+}
+
 func (s *MSSQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
 	if req.Name == "" {
 		return nil, fmt.Errorf("table name is required")
@@ -202,6 +223,7 @@ func (s *MSSQLCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInf
 }
 
 func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	s.applyStreamingMode(opts.Streaming)
 	allTables, err := s.GetTables(ctx)
 	if err != nil {
 		return nil, err
@@ -572,6 +594,7 @@ func (t *CDCTable) GetSchema(ctx context.Context) (*schema.TableSchema, error) {
 }
 
 func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	t.source.applyStreamingMode(opts.Streaming)
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -1110,5 +1133,6 @@ func isZeroLSN(lsn string) bool {
 var (
 	_ source.Source           = (*MSSQLCDCSource)(nil)
 	_ source.MultiTableSource = (*MSSQLCDCSource)(nil)
+	_ source.StreamingSource  = (*MSSQLCDCSource)(nil)
 	_ source.SourceTable      = (*CDCTable)(nil)
 )

--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pglogrepl"
 )
 
 // batchAccumulator collects small per-table Arrow batches and merges them
@@ -14,6 +15,11 @@ import (
 type batchAccumulator struct {
 	batches   map[string][]arrow.RecordBatch
 	rowCounts map[string]int64
+	// minLSN tracks the lowest (oldest) transaction LSN still buffered per
+	// table. Batches are added in non-decreasing LSN order, so the first batch
+	// buffered for a table after a flush carries that table's minimum. Used to
+	// compute a safe commit position for streaming mode.
+	minLSN    map[string]pglogrepl.LSN
 	threshold int64
 
 	// transform, when set, post-processes each merged batch just before it is
@@ -28,32 +34,55 @@ func newBatchAccumulator(threshold int) *batchAccumulator {
 	return &batchAccumulator{
 		batches:   make(map[string][]arrow.RecordBatch),
 		rowCounts: make(map[string]int64),
+		minLSN:    make(map[string]pglogrepl.LSN),
 		threshold: int64(threshold),
 	}
 }
 
-func (a *batchAccumulator) add(tableName string, batch arrow.RecordBatch) {
+func (a *batchAccumulator) add(tableName string, batch arrow.RecordBatch, lsn pglogrepl.LSN) {
+	if _, ok := a.minLSN[tableName]; !ok {
+		a.minLSN[tableName] = lsn
+	}
 	a.batches[tableName] = append(a.batches[tableName], batch)
 	a.rowCounts[tableName] += batch.NumRows()
 }
 
+// minPendingLSN returns the lowest transaction LSN still buffered across all
+// tables, or (0, false) when the accumulator is empty.
+func (a *batchAccumulator) minPendingLSN() (pglogrepl.LSN, bool) {
+	var min pglogrepl.LSN
+	found := false
+	for _, lsn := range a.minLSN {
+		if !found || lsn < min {
+			min = lsn
+			found = true
+		}
+	}
+	return min, found
+}
+
+// tokenFunc computes the CommitToken to attach to a flushed batch. It is
+// evaluated after the flushed table's batches have been removed from the
+// accumulator, so it reflects only data that remains un-emitted.
+type tokenFunc func() any
+
 // flushReady sends merged batches for tables that have accumulated enough rows.
-func (a *batchAccumulator) flushReady(results chan<- source.RecordBatchResult) {
+func (a *batchAccumulator) flushReady(results chan<- source.RecordBatchResult, token tokenFunc) {
 	for tableName, count := range a.rowCounts {
 		if count >= a.threshold {
-			a.flushTable(tableName, results)
+			a.flushTable(tableName, results, token)
 		}
 	}
 }
 
 // flushAll sends merged batches for all tables, regardless of row count.
-func (a *batchAccumulator) flushAll(results chan<- source.RecordBatchResult) {
+func (a *batchAccumulator) flushAll(results chan<- source.RecordBatchResult, token tokenFunc) {
 	for tableName := range a.batches {
-		a.flushTable(tableName, results)
+		a.flushTable(tableName, results, token)
 	}
 }
 
-func (a *batchAccumulator) flushTable(tableName string, results chan<- source.RecordBatchResult) {
+func (a *batchAccumulator) flushTable(tableName string, results chan<- source.RecordBatchResult, token tokenFunc) {
 	batches := a.batches[tableName]
 	if len(batches) == 0 {
 		return
@@ -61,6 +90,12 @@ func (a *batchAccumulator) flushTable(tableName string, results chan<- source.Re
 
 	delete(a.batches, tableName)
 	delete(a.rowCounts, tableName)
+	delete(a.minLSN, tableName)
+
+	var commitToken any
+	if token != nil {
+		commitToken = token()
+	}
 
 	var out arrow.RecordBatch
 	if len(batches) == 1 {
@@ -83,8 +118,9 @@ func (a *batchAccumulator) flushTable(tableName string, results chan<- source.Re
 	}
 
 	results <- source.RecordBatchResult{
-		Batch:     out,
-		TableName: tableName,
+		Batch:       out,
+		TableName:   tableName,
+		CommitToken: commitToken,
 	}
 }
 

--- a/pkg/source/postgres_cdc/commit_state.go
+++ b/pkg/source/postgres_cdc/commit_state.go
@@ -1,0 +1,110 @@
+package postgres_cdc
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+)
+
+// deadConnectionTimeout bounds how long the replicator tolerates total silence
+// from the server before declaring the replication connection dead. Postgres
+// sends keepalives roughly every wal_sender_timeout/2 (default 30s), so a
+// prolonged gap with no data and no keepalives indicates a broken or half-open
+// connection (e.g. the server terminated the wal sender). Surfacing it as an
+// error lets the stream exit so a supervisor can restart it, rather than
+// spinning forever on a 100ms read timeout that masks the dead socket.
+const deadConnectionTimeout = 2 * time.Minute
+
+// receiveTimeout bounds a single ReceiveMessage call. It governs how quickly the
+// loop reacts to context cancellation and flushes idle batches. It must not be
+// too small: churning the replication connection's read deadline every few
+// milliseconds races with pgconn's background reader and can wedge the
+// connection so the server stops delivering WAL. One second keeps the loop
+// responsive while leaving the deadline stable enough to avoid that race.
+const receiveTimeout = 1 * time.Second
+
+// streamPosition holds the LSN the pipeline has confirmed durable (flushed and
+// merged into the destination). The pipeline goroutine advances it via
+// CommitStream; the replicator goroutine reads it when sending standby status
+// updates, so that the slot's confirmed_flush_lsn only moves once data is
+// durable. A monotonic CAS-max keeps it safe across goroutines and tolerates
+// out-of-order or stale commits.
+type streamPosition struct {
+	committed atomic.Uint64
+}
+
+func newStreamPosition() *streamPosition {
+	return &streamPosition{}
+}
+
+func (p *streamPosition) Commit(lsn pglogrepl.LSN) {
+	for {
+		cur := p.committed.Load()
+		if uint64(lsn) <= cur {
+			return
+		}
+		if p.committed.CompareAndSwap(cur, uint64(lsn)) {
+			return
+		}
+	}
+}
+
+func (p *streamPosition) Committed() pglogrepl.LSN {
+	return pglogrepl.LSN(p.committed.Load())
+}
+
+// lowWaterReporter exposes the in-flight position state needed to compute a
+// safe commit LSN. Both the single- and multi-table replicators implement it.
+type lowWaterReporter interface {
+	// PendingLowWater returns the lowest LSN of any change the replicator has
+	// received but not yet handed to the accumulator (buffered batches from a
+	// multi-row transaction, plus an in-flight transaction whose COMMIT has not
+	// arrived). The bool is false when nothing is pending inside the replicator.
+	PendingLowWater() (pglogrepl.LSN, bool)
+	CurrentLSN() pglogrepl.LSN
+}
+
+// safeCommitLSN computes the highest LSN below which every change has already
+// been emitted into the results channel, so confirming it to the slot cannot
+// discard WAL the destination has not seen. Un-emitted data may sit in the
+// replicator (PendingLowWater) or the accumulator (minPendingLSN); the safe
+// position is one below the oldest of those. When nothing is pending anywhere,
+// every received change has been emitted and the current received position is
+// safe.
+func safeCommitLSN(repl lowWaterReporter, accum *batchAccumulator) pglogrepl.LSN {
+	low, pending := repl.PendingLowWater()
+	if l, ok := accum.minPendingLSN(); ok {
+		if !pending || l < low {
+			low = l
+		}
+		pending = true
+	}
+	if !pending {
+		return repl.CurrentLSN()
+	}
+	if low == 0 {
+		return 0
+	}
+	return low - 1
+}
+
+// standbyUpdate computes the standby status positions to report to Postgres.
+// In streaming mode the flushed/applied positions track the confirmed durable
+// LSN (committed) rather than the received position, so the slot only advances
+// once data is durable. committed==0 (nothing confirmed yet) falls back to the
+// replication start LSN so pglogrepl does not default the flush position to the
+// received position.
+func standbyUpdate(streaming bool, received, committed, start pglogrepl.LSN) pglogrepl.StandbyStatusUpdate {
+	ssu := pglogrepl.StandbyStatusUpdate{WALWritePosition: received}
+	if !streaming {
+		return ssu
+	}
+	flush := committed
+	if flush == 0 {
+		flush = start
+	}
+	ssu.WALFlushPosition = flush
+	ssu.WALApplyPosition = flush
+	return ssu
+}

--- a/pkg/source/postgres_cdc/commit_state_test.go
+++ b/pkg/source/postgres_cdc/commit_state_test.go
@@ -1,0 +1,193 @@
+package postgres_cdc
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamPosition_MonotonicMax(t *testing.T) {
+	p := newStreamPosition()
+	assert.Equal(t, pglogrepl.LSN(0), p.Committed())
+
+	p.Commit(100)
+	assert.Equal(t, pglogrepl.LSN(100), p.Committed())
+
+	// A lower commit must not move it backwards.
+	p.Commit(50)
+	assert.Equal(t, pglogrepl.LSN(100), p.Committed())
+
+	p.Commit(200)
+	assert.Equal(t, pglogrepl.LSN(200), p.Committed())
+}
+
+func TestStreamPosition_ConcurrentMax(t *testing.T) {
+	p := newStreamPosition()
+	var wg sync.WaitGroup
+	for i := 1; i <= 100; i++ {
+		wg.Add(1)
+		go func(lsn pglogrepl.LSN) {
+			defer wg.Done()
+			p.Commit(lsn)
+		}(pglogrepl.LSN(i))
+	}
+	wg.Wait()
+	assert.Equal(t, pglogrepl.LSN(100), p.Committed())
+}
+
+func TestStandbyUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		streaming   bool
+		received    pglogrepl.LSN
+		committed   pglogrepl.LSN
+		start       pglogrepl.LSN
+		wantWrite   pglogrepl.LSN
+		wantFlush   pglogrepl.LSN
+		wantApply   pglogrepl.LSN
+		flushIsZero bool
+	}{
+		{
+			name:        "batch mode reports only write position",
+			streaming:   false,
+			received:    500,
+			committed:   300,
+			start:       100,
+			wantWrite:   500,
+			flushIsZero: true, // pglogrepl defaults flush:=write when 0
+		},
+		{
+			name:      "streaming reports committed as flush/apply",
+			streaming: true,
+			received:  500,
+			committed: 300,
+			start:     100,
+			wantWrite: 500,
+			wantFlush: 300,
+			wantApply: 300,
+		},
+		{
+			name:      "streaming with no commit yet falls back to start",
+			streaming: true,
+			received:  500,
+			committed: 0,
+			start:     100,
+			wantWrite: 500,
+			wantFlush: 100,
+			wantApply: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ssu := standbyUpdate(tt.streaming, tt.received, tt.committed, tt.start)
+			assert.Equal(t, tt.wantWrite, ssu.WALWritePosition)
+			if tt.flushIsZero {
+				assert.Equal(t, pglogrepl.LSN(0), ssu.WALFlushPosition, "flush must stay 0 in batch mode so behavior is unchanged")
+				return
+			}
+			assert.Equal(t, tt.wantFlush, ssu.WALFlushPosition)
+			assert.Equal(t, tt.wantApply, ssu.WALApplyPosition)
+		})
+	}
+}
+
+func TestSafeCommitLSN(t *testing.T) {
+	tests := []struct {
+		name         string
+		replLowWater func() (pglogrepl.LSN, bool)
+		accumBatches []struct{ lsn pglogrepl.LSN } // batches added to a single table
+		currentLSN   pglogrepl.LSN
+		flushAccum   bool // flush the accumulator before computing (drains it)
+		want         pglogrepl.LSN
+	}{
+		{
+			name:         "fully drained returns current received LSN",
+			replLowWater: func() (pglogrepl.LSN, bool) { return 0, false },
+			currentLSN:   500,
+			want:         500,
+		},
+		{
+			name:         "replicator pending caps below its low water",
+			replLowWater: func() (pglogrepl.LSN, bool) { return 200, true },
+			currentLSN:   500,
+			want:         199,
+		},
+		{
+			name:         "accumulator pending caps below its min LSN",
+			replLowWater: func() (pglogrepl.LSN, bool) { return 0, false },
+			accumBatches: []struct{ lsn pglogrepl.LSN }{{100}, {200}},
+			currentLSN:   500,
+			want:         99,
+		},
+		{
+			name:         "min of replicator and accumulator pending wins",
+			replLowWater: func() (pglogrepl.LSN, bool) { return 300, true },
+			accumBatches: []struct{ lsn pglogrepl.LSN }{{150}},
+			currentLSN:   500,
+			want:         149,
+		},
+		{
+			name:         "replicator pending lower than accumulator wins",
+			replLowWater: func() (pglogrepl.LSN, bool) { return 80, true },
+			accumBatches: []struct{ lsn pglogrepl.LSN }{{150}},
+			currentLSN:   500,
+			want:         79,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repl := &fakeReplicator{lsn: tt.currentLSN, pendingLowWater: tt.replLowWater}
+			accum := newBatchAccumulator(10000)
+			for _, b := range tt.accumBatches {
+				accum.add("t", makeRowBatch(1), b.lsn)
+			}
+			defer accum.flushAll(make(chan source.RecordBatchResult, 16), nil)
+
+			got := safeCommitLSN(repl, accum)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestStreamLoopCumulativeTokens verifies that when a small transaction is
+// parked in the accumulator (below the flush threshold) while a larger one
+// flushes, the emitted token never claims the parked transaction is durable.
+func TestStreamLoopCumulativeTokens(t *testing.T) {
+	// Threshold 3 rows: table "small" gets a 1-row txn at LSN 100 (stays
+	// buffered); table "big" gets a 3-row txn at LSN 200 (flushes immediately).
+	accum := newBatchAccumulator(3)
+	results := make(chan source.RecordBatchResult, 16)
+
+	repl := &fakeReplicator{lsn: 200}
+	token := func() any { return safeCommitLSN(repl, accum) }
+
+	accum.add("small", makeRowBatch(1), 100)
+	accum.add("big", makeNRowBatch(3), 200)
+
+	accum.flushReady(results, token)
+	close(results)
+
+	var bigToken pglogrepl.LSN
+	sawBig := false
+	for res := range results {
+		require.NoError(t, res.Err)
+		if res.TableName == "big" {
+			sawBig = true
+			lsn, ok := res.CommitToken.(pglogrepl.LSN)
+			require.True(t, ok, "expected an LSN commit token")
+			bigToken = lsn
+		}
+		res.Batch.Release()
+	}
+
+	require.True(t, sawBig, "big table should have flushed")
+	// The parked "small" txn is at LSN 100, so the token must be below 100.
+	assert.Less(t, bigToken, pglogrepl.LSN(100), "token must not claim the parked LSN-100 txn is durable")
+	assert.Equal(t, pglogrepl.LSN(99), bigToken)
+}

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -193,6 +193,23 @@ func (d *Decoder) handleBegin(data []byte, lsn pglogrepl.LSN) error {
 	return nil
 }
 
+// CurrentTxLSN returns the LSN of the transaction currently being decoded. It
+// remains valid after a COMMIT until the next BEGIN, so callers can read the
+// LSN of the batch just returned by Decode.
+func (d *Decoder) CurrentTxLSN() pglogrepl.LSN {
+	return d.currentTxLSN
+}
+
+// InFlightTxLSN returns the LSN of a transaction whose changes have been
+// decoded but not yet emitted (BEGIN seen, COMMIT not yet processed). The bool
+// is false when no transaction is mid-flight.
+func (d *Decoder) InFlightTxLSN() (pglogrepl.LSN, bool) {
+	if len(d.pendingChanges) == 0 {
+		return 0, false
+	}
+	return d.currentTxLSN, true
+}
+
 func (d *Decoder) handleCommit() (arrow.RecordBatch, error) {
 	if len(d.pendingChanges) == 0 {
 		return nil, nil

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -176,6 +176,16 @@ func (d *MultiTableDecoder) handleBegin(data []byte, lsn pglogrepl.LSN) error {
 	return nil
 }
 
+// InFlightTxLSN returns the LSN of a transaction whose changes have been
+// decoded but not yet emitted (BEGIN seen, COMMIT not yet processed). The bool
+// is false when no transaction is mid-flight.
+func (d *MultiTableDecoder) InFlightTxLSN() (pglogrepl.LSN, bool) {
+	if len(d.pendingChanges) == 0 {
+		return 0, false
+	}
+	return d.currentTxLSN, true
+}
+
 func (d *MultiTableDecoder) handleCommit() ([]DecodedBatch, error) {
 	if len(d.pendingChanges) == 0 {
 		return nil, nil

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -106,9 +106,10 @@ func (r *MultiTableCDCReader) Read(ctx context.Context, opts source.MultiTableRe
 			startLSN = minResumeLSN
 		}
 
-		// For batch mode, get the current WAL LSN as our target
+		// For batch mode, get the current WAL LSN as our target.
+		// --stream forces continuous mode regardless of the URI ?mode= param.
 		var targetLSN pglogrepl.LSN
-		if r.cdcConfig.Mode == ModeBatch {
+		if r.cdcConfig.Mode == ModeBatch && !opts.Streaming {
 			var err error
 			targetLSN, err = r.getCurrentWALLSN(ctx)
 			if err != nil {
@@ -274,7 +275,7 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 	cdcConfigWithSlot.SlotName = slotName
 
 	// Create multi-table replicator
-	repl, err := NewMultiTableReplicator(r.source, r.tables, cdcConfigWithSlot, startLSN, r)
+	repl, err := NewMultiTableReplicator(r.source, r.tables, cdcConfigWithSlot, startLSN, r, opts.Streaming)
 	if err != nil {
 		return fmt.Errorf("failed to create replicator: %w", err)
 	}
@@ -298,42 +299,50 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		return forwardFillUnchanged(batch, pkByTable[tableName])
 	}
 
+	// In streaming mode, batches carry a CommitToken (safe LSN) so the pipeline
+	// confirms the slot only after the data is durable. targetLSN is 0 in
+	// streaming mode, so the catch-up exit below never triggers.
+	var token tokenFunc
+	if opts.Streaming {
+		token = func() any { return safeCommitLSN(repl, accum) }
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			config.Debug("[CDC] Context cancelled, stopping stream")
-			accum.flushAll(results)
+			accum.flushAll(results, token)
 			return ctx.Err()
 		default:
 		}
 
 		// Get next batch (may be from any table)
-		batch, tableName, hadActivity, err := repl.NextBatch(ctx, batchSize)
+		batch, tableName, lsn, hadActivity, err := repl.NextBatch(ctx, batchSize)
 		if err != nil {
-			accum.flushAll(results)
+			accum.flushAll(results, token)
 			return fmt.Errorf("failed to get next batch: %w", err)
 		}
 
 		if batch != nil && batch.NumRows() > 0 {
-			accum.add(tableName, batch)
+			accum.add(tableName, batch, lsn)
 		}
 
 		// Flush tables that have accumulated enough rows
-		accum.flushReady(results)
+		accum.flushReady(results, token)
 
 		// For batch mode, check if we've caught up to the target LSN
-		if r.cdcConfig.Mode == ModeBatch && targetLSN > 0 {
+		if targetLSN > 0 {
 			currentLSN := repl.CurrentLSN()
 			if currentLSN >= targetLSN {
 				config.Debug("[CDC] Batch mode: reached target LSN %s (current: %s)", targetLSN, currentLSN)
-				accum.flushAll(results)
+				accum.flushAll(results, token)
 				return nil
 			}
 		}
 
 		// When idle (no WAL activity), flush any pending batches
 		if !hadActivity {
-			accum.flushAll(results)
+			accum.flushAll(results, token)
 			time.Sleep(100 * time.Millisecond)
 		}
 	}
@@ -386,6 +395,11 @@ func (r *MultiTableCDCReader) ShouldFilterChange(tableName string, changeLSN pgl
 		return false
 	}
 
-	// Filter if change LSN is <= last processed LSN for this table
-	return changeLSN <= lastProcessed
+	// Strict less-than is required at the snapshot boundary: the snapshot is
+	// exported at the slot's consistent point, and the first transaction that
+	// commits afterwards carries a BEGIN LSN equal to that point. It is NOT in
+	// the snapshot, so it must be streamed. On resume, processedLSN is the
+	// BEGIN LSN of the last already-applied transaction; re-emitting it is
+	// harmless because the merge is idempotent by primary key (at-least-once).
+	return changeLSN < lastProcessed
 }

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -34,13 +34,15 @@ type MultiTableReplicator struct {
 	lsnFilter     LSNUpdater
 	clientXLogPos pglogrepl.LSN
 	standbyTimer  time.Time
+	lastMessageAt time.Time
 	started       bool
+	streaming     bool
 
 	// Buffered batches from a single transaction (may contain multiple tables)
 	pendingBatches []DecodedBatch
 }
 
-func NewMultiTableReplicator(src *PostgresCDCSource, tables []source.SourceTableInfo, cdcConfig CDCConfig, startLSN pglogrepl.LSN, lsnFilter LSNUpdater) (*MultiTableReplicator, error) {
+func NewMultiTableReplicator(src *PostgresCDCSource, tables []source.SourceTableInfo, cdcConfig CDCConfig, startLSN pglogrepl.LSN, lsnFilter LSNUpdater, streaming bool) (*MultiTableReplicator, error) {
 	decoder := NewMultiTableDecoder(tables)
 
 	return &MultiTableReplicator{
@@ -52,8 +54,39 @@ func NewMultiTableReplicator(src *PostgresCDCSource, tables []source.SourceTable
 		lsnFilter:     lsnFilter,
 		clientXLogPos: startLSN,
 		standbyTimer:  time.Now(),
+		lastMessageAt: time.Now(),
 		started:       false,
+		streaming:     streaming,
 	}, nil
+}
+
+// PendingLowWater reports the lowest LSN of any change received but not yet
+// emitted: batches buffered from a multi-table transaction plus an in-flight
+// transaction whose COMMIT has not arrived.
+func (r *MultiTableReplicator) PendingLowWater() (pglogrepl.LSN, bool) {
+	low := pglogrepl.LSN(0)
+	found := false
+	for _, b := range r.pendingBatches {
+		if !found || b.LSN < low {
+			low = b.LSN
+			found = true
+		}
+	}
+	if lsn, ok := r.decoder.InFlightTxLSN(); ok {
+		if !found || lsn < low {
+			low = lsn
+		}
+		found = true
+	}
+	return low, found
+}
+
+func (r *MultiTableReplicator) standbyStatus() pglogrepl.StandbyStatusUpdate {
+	var committed pglogrepl.LSN
+	if r.streaming && r.source.pos != nil {
+		committed = r.source.pos.Committed()
+	}
+	return standbyUpdate(r.streaming, r.clientXLogPos, committed, r.startLSN)
 }
 
 func (r *MultiTableReplicator) Start(ctx context.Context) error {
@@ -97,10 +130,11 @@ func (r *MultiTableReplicator) CurrentLSN() pglogrepl.LSN {
 	return r.clientXLogPos
 }
 
-// NextBatch returns the next batch, its source table name, and a flag indicating WAL activity.
-// Returns (nil, "", false, nil) when no data is available.
-// Returns (nil, "", true, nil) when WAL data was received but no complete batch yet (e.g., buffering transaction).
-func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, string, bool, error) {
+// NextBatch returns the next batch, its source table name, the LSN of the
+// transaction that produced it, and a flag indicating WAL activity.
+// Returns (nil, "", 0, false, nil) when no data is available.
+// Returns (nil, "", 0, true, nil) when WAL data was received but no complete batch yet (e.g., buffering transaction).
+func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, string, pglogrepl.LSN, bool, error) {
 	// Return buffered batches first
 	if len(r.pendingBatches) > 0 {
 		batch := r.pendingBatches[0]
@@ -111,62 +145,69 @@ func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (ar
 			r.lsnFilter.updateProcessedLSN(batch.TableName, batch.LSN)
 		}
 
-		return batch.Batch, batch.TableName, true, nil
+		return batch.Batch, batch.TableName, batch.LSN, true, nil
 	}
 
 	// Start replication if not yet started
 	if !r.started {
 		if err := r.Start(ctx); err != nil {
-			return nil, "", false, err
+			return nil, "", 0, false, err
 		}
 	}
 
-	// Send standby status periodically
+	// Send standby status periodically. A send failure means the replication
+	// connection is broken, so surface it rather than spinning on dead reads.
 	if time.Since(r.standbyTimer) > 10*time.Second {
 		err := pglogrepl.SendStandbyStatusUpdate(
 			ctx,
 			r.source.replConn,
-			pglogrepl.StandbyStatusUpdate{
-				WALWritePosition: r.clientXLogPos,
-			},
+			r.standbyStatus(),
 		)
 		if err != nil {
-			config.Debug("[CDC] Failed to send standby status: %v", err)
+			return nil, "", 0, false, fmt.Errorf("failed to send standby status (replication connection lost): %w", err)
 		}
 		r.standbyTimer = time.Now()
 	}
 
-	// Set a short deadline for receiving messages
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	// Bound a single receive so the loop can react to cancellation and flush
+	// idle batches. See receiveTimeout for why this is not sub-second.
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, receiveTimeout)
 	defer cancel()
 
 	msg, err := r.source.replConn.ReceiveMessage(ctxWithTimeout)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, "", false, ctx.Err()
+			return nil, "", 0, false, ctx.Err()
 		}
-		// Timeout is expected when no data is available
+		// Timeout is expected when no data is available. But total silence for
+		// longer than deadConnectionTimeout (no data and no keepalives) means a
+		// dead or half-open connection that the per-call read timeout would mask forever.
 		if ctxWithTimeout.Err() != nil {
-			return nil, "", false, nil
+			if time.Since(r.lastMessageAt) > deadConnectionTimeout {
+				return nil, "", 0, false, fmt.Errorf("no message from server for %s; replication connection appears dead", deadConnectionTimeout)
+			}
+			return nil, "", 0, false, nil
 		}
-		return nil, "", false, fmt.Errorf("failed to receive message: %w", err)
+		return nil, "", 0, false, fmt.Errorf("failed to receive message: %w", err)
 	}
 
+	r.lastMessageAt = time.Now()
+
 	if msg == nil {
-		return nil, "", false, nil
+		return nil, "", 0, false, nil
 	}
 
 	switch msg := msg.(type) {
 	case *pgproto3.CopyData:
 		if len(msg.Data) == 0 {
-			return nil, "", true, nil // Received a message, even if empty
+			return nil, "", 0, true, nil // Received a message, even if empty
 		}
 
 		switch msg.Data[0] {
 		case pglogrepl.PrimaryKeepaliveMessageByteID:
 			pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
 			if err != nil {
-				return nil, "", true, fmt.Errorf("failed to parse keepalive: %w", err)
+				return nil, "", 0, true, fmt.Errorf("failed to parse keepalive: %w", err)
 			}
 
 			if pkm.ReplyRequested {
@@ -180,14 +221,14 @@ func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (ar
 		case pglogrepl.XLogDataByteID:
 			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
 			if err != nil {
-				return nil, "", true, fmt.Errorf("failed to parse xlog data: %w", err)
+				return nil, "", 0, true, fmt.Errorf("failed to parse xlog data: %w", err)
 			}
 
 			config.Debug("[CDC] Received XLogData at LSN %s, data len=%d, first byte=%x", xld.WALStart, len(xld.WALData), xld.WALData[0])
 
 			batches, err := r.decoder.Decode(xld.WALData, xld.WALStart)
 			if err != nil {
-				return nil, "", true, fmt.Errorf("failed to decode WAL data: %w", err)
+				return nil, "", 0, true, fmt.Errorf("failed to decode WAL data: %w", err)
 			}
 
 			if len(batches) > 0 {
@@ -213,7 +254,7 @@ func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (ar
 			}
 
 			if len(filteredBatches) == 0 {
-				return nil, "", true, nil // WAL data received but no new batches (filtered or buffered)
+				return nil, "", 0, true, nil // WAL data received but no new batches (filtered or buffered)
 			}
 
 			// Return first batch, buffer the rest
@@ -227,9 +268,9 @@ func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (ar
 				r.lsnFilter.updateProcessedLSN(first.TableName, first.LSN)
 			}
 
-			return first.Batch, first.TableName, true, nil
+			return first.Batch, first.TableName, first.LSN, true, nil
 		}
 	}
 
-	return nil, "", true, nil // Received some message type we don't handle
+	return nil, "", 0, true, nil // Received some message type we don't handle
 }

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -87,9 +87,15 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 }
 
 func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, slotName string, results chan<- source.RecordBatchResult, opts source.ReadOptions) error {
+	// --stream forces continuous mode regardless of the URI ?mode= param.
+	mode := r.cdcConfig.Mode
+	if opts.Streaming {
+		mode = ModeStream
+	}
+
 	// For batch mode, get the current WAL LSN as our target before starting
 	var targetLSN pglogrepl.LSN
-	if r.cdcConfig.Mode == ModeBatch {
+	if mode == ModeBatch {
 		var lsnStr string
 		err := r.source.queryPool.QueryRow(ctx, "SELECT pg_current_wal_lsn()::text").Scan(&lsnStr)
 		if err != nil {
@@ -108,7 +114,7 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 	cdcConfigWithSlot := r.cdcConfig
 	cdcConfigWithSlot.SlotName = slotName
 
-	repl, err := NewReplicator(r.source, r.tableName, r.tableSchema, cdcConfigWithSlot, startLSN)
+	repl, err := NewReplicator(r.source, r.tableName, r.tableSchema, cdcConfigWithSlot, startLSN, opts.Streaming)
 	if err != nil {
 		return fmt.Errorf("failed to create replicator: %w", err)
 	}
@@ -125,48 +131,57 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 		return forwardFillUnchanged(batch, pkNames)
 	}
 
-	return streamLoop(ctx, repl, r.cdcConfig.Mode, targetLSN, batchSize, accum, results)
+	return streamLoop(ctx, repl, mode, targetLSN, batchSize, accum, results, opts.Streaming)
 }
 
 // batchReplicator is the subset of *Replicator that streamLoop depends on,
 // allowing the accumulation loop to be tested without a live connection.
 type batchReplicator interface {
-	NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, bool, error)
+	NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, pglogrepl.LSN, bool, error)
 	CurrentLSN() pglogrepl.LSN
+	PendingLowWater() (pglogrepl.LSN, bool)
 }
 
 // streamLoop pulls batches from repl and feeds them through the accumulator,
 // flushing only when the replicator reports a genuine idle period. Treating
 // every batch-less call as idle would flush after every transaction and defeat
 // accumulation entirely (see hadActivity in Replicator.NextBatch).
-func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, targetLSN pglogrepl.LSN, batchSize int, accum *batchAccumulator, results chan<- source.RecordBatchResult) error {
+//
+// When streaming, each flushed batch carries a CommitToken (a safe LSN) so the
+// pipeline can confirm the replication slot only after the data is durable.
+func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, targetLSN pglogrepl.LSN, batchSize int, accum *batchAccumulator, results chan<- source.RecordBatchResult, streaming bool) error {
+	var token tokenFunc
+	if streaming {
+		token = func() any { return safeCommitLSN(repl, accum) }
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			config.Debug("[CDC] Context cancelled, stopping stream")
-			accum.flushAll(results)
+			accum.flushAll(results, token)
 			return ctx.Err()
 		default:
 		}
 
-		batch, hadActivity, err := repl.NextBatch(ctx, batchSize)
+		batch, lsn, hadActivity, err := repl.NextBatch(ctx, batchSize)
 		if err != nil {
-			accum.flushAll(results)
+			accum.flushAll(results, token)
 			return fmt.Errorf("failed to get next batch: %w", err)
 		}
 
 		if batch != nil && batch.NumRows() > 0 {
-			accum.add("", batch)
+			accum.add("", batch, lsn)
 		}
 
-		accum.flushReady(results)
+		accum.flushReady(results, token)
 
 		// For batch mode, check if we've caught up to the target LSN
 		if mode == ModeBatch && targetLSN > 0 {
 			currentLSN := repl.CurrentLSN()
 			if currentLSN >= targetLSN {
 				config.Debug("[CDC] Batch mode: reached target LSN %s (current: %s)", targetLSN, currentLSN)
-				accum.flushAll(results)
+				accum.flushAll(results, token)
 				return nil
 			}
 		}
@@ -175,7 +190,7 @@ func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, targetL
 		// non-commit messages and keepalives count as activity, so we keep
 		// accumulating across transactions instead of flushing each one.
 		if !hadActivity {
-			accum.flushAll(results)
+			accum.flushAll(results, token)
 			time.Sleep(100 * time.Millisecond)
 		}
 	}

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -21,10 +21,12 @@ type Replicator struct {
 	decoder       *Decoder
 	clientXLogPos pglogrepl.LSN
 	standbyTimer  time.Time
+	lastMessageAt time.Time
 	started       bool
+	streaming     bool
 }
 
-func NewReplicator(src *PostgresCDCSource, tableName string, tableSchema *schema.TableSchema, cdcConfig CDCConfig, startLSN pglogrepl.LSN) (*Replicator, error) {
+func NewReplicator(src *PostgresCDCSource, tableName string, tableSchema *schema.TableSchema, cdcConfig CDCConfig, startLSN pglogrepl.LSN, streaming bool) (*Replicator, error) {
 	schemaName, tblName := parseTableName(tableName)
 
 	decoder := NewDecoder(tableSchema, schemaName, tblName)
@@ -38,8 +40,18 @@ func NewReplicator(src *PostgresCDCSource, tableName string, tableSchema *schema
 		decoder:       decoder,
 		clientXLogPos: startLSN,
 		standbyTimer:  time.Now(),
+		lastMessageAt: time.Now(),
 		started:       false,
+		streaming:     streaming,
 	}, nil
+}
+
+// PendingLowWater reports the lowest LSN of an in-flight transaction whose
+// changes have not yet been emitted. The single-table replicator emits each
+// transaction's batch immediately, so only an undecoded (BEGIN-without-COMMIT)
+// transaction can be pending.
+func (r *Replicator) PendingLowWater() (pglogrepl.LSN, bool) {
+	return r.decoder.InFlightTxLSN()
 }
 
 func (r *Replicator) Start(ctx context.Context) error {
@@ -83,65 +95,81 @@ func (r *Replicator) CurrentLSN() pglogrepl.LSN {
 	return r.clientXLogPos
 }
 
-// NextBatch returns the next decoded batch, if any. The hadActivity flag
-// distinguishes a genuine idle period (receive timeout / nil message) from
-// WAL activity that produced no batch yet (keepalives, buffered Begin/Insert/
-// Update/Delete messages awaiting a Commit). Callers use it to avoid flushing
-// the batch accumulator after every transaction.
-func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, bool, error) {
+func (r *Replicator) standbyStatus() pglogrepl.StandbyStatusUpdate {
+	var committed pglogrepl.LSN
+	if r.streaming && r.source.pos != nil {
+		committed = r.source.pos.Committed()
+	}
+	return standbyUpdate(r.streaming, r.clientXLogPos, committed, r.startLSN)
+}
+
+// NextBatch returns the next decoded batch, if any, with the LSN of the
+// transaction that produced it. The hadActivity flag distinguishes a genuine
+// idle period (receive timeout / nil message) from WAL activity that produced
+// no batch yet (keepalives, buffered Begin/Insert/Update/Delete messages
+// awaiting a Commit). Callers use it to avoid flushing the batch accumulator
+// after every transaction.
+func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.RecordBatch, pglogrepl.LSN, bool, error) {
 	// Start replication if not yet started
 	if !r.started {
 		if err := r.Start(ctx); err != nil {
-			return nil, false, err
+			return nil, 0, false, err
 		}
 	}
 
-	// Send standby status periodically
+	// Send standby status periodically. A send failure means the replication
+	// connection is broken, so surface it rather than spinning on dead reads.
 	if time.Since(r.standbyTimer) > 10*time.Second {
 		err := pglogrepl.SendStandbyStatusUpdate(
 			ctx,
 			r.source.replConn,
-			pglogrepl.StandbyStatusUpdate{
-				WALWritePosition: r.clientXLogPos,
-			},
+			r.standbyStatus(),
 		)
 		if err != nil {
-			config.Debug("[CDC] Failed to send standby status: %v", err)
+			return nil, 0, false, fmt.Errorf("failed to send standby status (replication connection lost): %w", err)
 		}
 		r.standbyTimer = time.Now()
 	}
 
-	// Set a short deadline for receiving messages
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	// Bound a single receive so the loop can react to cancellation and flush
+	// idle batches. See receiveTimeout for why this is not sub-second.
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, receiveTimeout)
 	defer cancel()
 
 	msg, err := r.source.replConn.ReceiveMessage(ctxWithTimeout)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, false, ctx.Err()
+			return nil, 0, false, ctx.Err()
 		}
-		// Timeout is expected when no data is available
+		// Timeout is expected when no data is available. But total silence for
+		// longer than deadConnectionTimeout (no data and no keepalives) means a
+		// dead or half-open connection that the per-call read timeout would mask forever.
 		if ctxWithTimeout.Err() != nil {
-			return nil, false, nil
+			if time.Since(r.lastMessageAt) > deadConnectionTimeout {
+				return nil, 0, false, fmt.Errorf("no message from server for %s; replication connection appears dead", deadConnectionTimeout)
+			}
+			return nil, 0, false, nil
 		}
-		return nil, false, fmt.Errorf("failed to receive message: %w", err)
+		return nil, 0, false, fmt.Errorf("failed to receive message: %w", err)
 	}
 
+	r.lastMessageAt = time.Now()
+
 	if msg == nil {
-		return nil, false, nil
+		return nil, 0, false, nil
 	}
 
 	switch msg := msg.(type) {
 	case *pgproto3.CopyData:
 		if len(msg.Data) == 0 {
-			return nil, true, nil // Received a message, even if empty
+			return nil, 0, true, nil // Received a message, even if empty
 		}
 
 		switch msg.Data[0] {
 		case pglogrepl.PrimaryKeepaliveMessageByteID:
 			pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
 			if err != nil {
-				return nil, true, fmt.Errorf("failed to parse keepalive: %w", err)
+				return nil, 0, true, fmt.Errorf("failed to parse keepalive: %w", err)
 			}
 
 			if pkm.ReplyRequested {
@@ -155,21 +183,21 @@ func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.Record
 		case pglogrepl.XLogDataByteID:
 			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
 			if err != nil {
-				return nil, true, fmt.Errorf("failed to parse xlog data: %w", err)
+				return nil, 0, true, fmt.Errorf("failed to parse xlog data: %w", err)
 			}
 
 			batch, err := r.decoder.Decode(xld.WALData, xld.WALStart)
 			if err != nil {
-				return nil, true, fmt.Errorf("failed to decode WAL data: %w", err)
+				return nil, 0, true, fmt.Errorf("failed to decode WAL data: %w", err)
 			}
 
 			if xld.WALStart > r.clientXLogPos {
 				r.clientXLogPos = xld.WALStart
 			}
 
-			return batch, true, nil
+			return batch, r.decoder.CurrentTxLSN(), true, nil
 		}
 	}
 
-	return nil, true, nil // Received some message type we don't handle
+	return nil, 0, true, nil // Received some message type we don't handle
 }

--- a/pkg/source/postgres_cdc/snapshot.go
+++ b/pkg/source/postgres_cdc/snapshot.go
@@ -188,6 +188,14 @@ func (s *Snapshot) readWithSnapshot(ctx context.Context, snapshotName string, ls
 	lsnStr := FormatLSN(lsn)
 	syncedAt := time.Now().UTC()
 
+	// In streaming mode, snapshot batches carry the snapshot's consistent-point
+	// LSN as a commit token. It is always safe to confirm: streaming begins from
+	// this LSN, so nothing earlier remains to be read.
+	var commitToken any
+	if opts.Streaming {
+		commitToken = lsn
+	}
+
 	// Build Arrow schema including CDC columns
 	arrowSchema := buildArrowSchema(s.tableSchema.Columns)
 
@@ -208,7 +216,7 @@ func (s *Snapshot) readWithSnapshot(ctx context.Context, snapshotName string, ls
 		totalRows += count
 		config.Debug("[CDC] Snapshot batch %d: %d rows (total: %d)", batchNum, count, totalRows)
 
-		results <- source.RecordBatchResult{Batch: record}
+		results <- source.RecordBatchResult{Batch: record, CommitToken: commitToken}
 	}
 
 	config.Debug("[CDC] Snapshot completed: %d rows in %d batches", totalRows, batchNum)

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -35,10 +36,14 @@ type PostgresCDCSource struct {
 	replConn  *pgconn.PgConn // Replication connection
 	uri       string
 	cdcConfig CDCConfig
+	// pos holds the LSN the pipeline has confirmed durable in streaming mode.
+	// It is shared between the pipeline goroutine (CommitStream) and the
+	// replication goroutine (standby status updates).
+	pos *streamPosition
 }
 
 func NewPostgresCDCSource() *PostgresCDCSource {
-	return &PostgresCDCSource{}
+	return &PostgresCDCSource{pos: newStreamPosition()}
 }
 
 func (s *PostgresCDCSource) Schemes() []string {
@@ -113,6 +118,34 @@ func (s *PostgresCDCSource) Close(ctx context.Context) error {
 
 func (s *PostgresCDCSource) HandlesIncrementality() bool {
 	return false
+}
+
+// SupportsStreaming reports that Postgres CDC can run in continuous mode.
+func (s *PostgresCDCSource) SupportsStreaming() bool {
+	return true
+}
+
+// DefaultStreamingStrategy returns merge: CDC changes (including deletes) must
+// be applied by primary key.
+func (s *PostgresCDCSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyMerge
+}
+
+// CommitStream records the durable LSN reported by the pipeline after a
+// successful flush. The replication goroutine reads it when sending standby
+// status updates so the slot's confirmed_flush_lsn only advances past durable
+// data. The token is the pglogrepl.LSN attached to the last flushed batch.
+func (s *PostgresCDCSource) CommitStream(_ context.Context, token any) error {
+	lsn, ok := token.(pglogrepl.LSN)
+	if !ok {
+		return fmt.Errorf("postgres cdc: unexpected commit token type %T", token)
+	}
+	if s.pos == nil {
+		return fmt.Errorf("postgres cdc: stream position not initialized")
+	}
+	s.pos.Commit(lsn)
+	config.Debug("[CDC] Confirmed durable LSN: %s", lsn)
+	return nil
 }
 
 func (s *PostgresCDCSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
@@ -326,4 +359,6 @@ const (
 var (
 	_ source.Source           = (*PostgresCDCSource)(nil)
 	_ source.MultiTableSource = (*PostgresCDCSource)(nil)
+	_ source.StreamingSource  = (*PostgresCDCSource)(nil)
+	_ source.StreamCommitter  = (*PostgresCDCSource)(nil)
 )

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -27,24 +27,38 @@ type fakeReplicator struct {
 	steps []replStep
 	idx   int
 	lsn   pglogrepl.LSN
+
+	// pendingLowWater, when set, scripts PendingLowWater's return value.
+	pendingLowWater func() (pglogrepl.LSN, bool)
 }
 
-func (f *fakeReplicator) NextBatch(_ context.Context, _ int) (arrow.RecordBatch, bool, error) {
+func (f *fakeReplicator) NextBatch(_ context.Context, _ int) (arrow.RecordBatch, pglogrepl.LSN, bool, error) {
 	if f.idx >= len(f.steps) {
 		// Stream exhausted: report idle with no further LSN progress.
-		return nil, false, nil
+		return nil, 0, false, nil
 	}
 	s := f.steps[f.idx]
 	f.idx++
 	if s.lsn > f.lsn {
 		f.lsn = s.lsn
 	}
-	return s.batch, s.hadActivity, nil
+	return s.batch, s.lsn, s.hadActivity, nil
 }
 
 func (f *fakeReplicator) CurrentLSN() pglogrepl.LSN { return f.lsn }
 
+func (f *fakeReplicator) PendingLowWater() (pglogrepl.LSN, bool) {
+	if f.pendingLowWater != nil {
+		return f.pendingLowWater()
+	}
+	return 0, false
+}
+
 func makeRowBatch(id int64) arrow.RecordBatch {
+	return makeNRowBatch(1)
+}
+
+func makeNRowBatch(n int) arrow.RecordBatch {
 	mem := memory.NewGoAllocator()
 	arrowSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
@@ -52,11 +66,13 @@ func makeRowBatch(id int64) arrow.RecordBatch {
 
 	b := array.NewInt64Builder(mem)
 	defer b.Release()
-	b.Append(id)
+	for i := range n {
+		b.Append(int64(i))
+	}
 	col := b.NewArray()
 	defer col.Release()
 
-	return array.NewRecordBatch(arrowSchema, []arrow.Array{col}, 1)
+	return array.NewRecordBatch(arrowSchema, []arrow.Array{col}, int64(n))
 }
 
 // buildSingleRowTxnStream models n single-row transactions and returns the
@@ -89,7 +105,7 @@ func drainStreamLoop(t *testing.T, steps []replStep, targetLSN pglogrepl.LSN) (b
 	results := make(chan source.RecordBatchResult, len(steps)+1)
 	accum := newBatchAccumulator(10000)
 
-	err := streamLoop(context.Background(), repl, ModeBatch, targetLSN, 10000, accum, results)
+	err := streamLoop(context.Background(), repl, ModeBatch, targetLSN, 10000, accum, results, false)
 	require.NoError(t, err)
 	close(results)
 

--- a/pkg/source/rabbitmq/rabbitmq.go
+++ b/pkg/source/rabbitmq/rabbitmq.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -25,11 +26,71 @@ const (
 
 type RabbitMQSource struct {
 	conn *amqp.Connection
+
+	// streamCh holds the live consumer channel in streaming mode so CommitStream
+	// can acknowledge deliveries after the pipeline has flushed them.
+	mu       sync.Mutex
+	streamCh *amqp.Channel
 }
 
 func NewRabbitMQSource() *RabbitMQSource {
 	return &RabbitMQSource{}
 }
+
+// SupportsStreaming reports that RabbitMQ can be consumed continuously.
+func (s *RabbitMQSource) SupportsStreaming() bool {
+	return true
+}
+
+// DefaultStreamingStrategy returns merge keyed on the envelope msg_id. Brokers
+// deliver at-least-once, so the same message (same msg_id) can be redelivered
+// after a restart; merge makes that idempotent (effectively-once) instead of
+// piling up duplicate rows or violating the msg_id primary key.
+func (s *RabbitMQSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyMerge
+}
+
+// CommitStream acknowledges all deliveries up to and including the given tag.
+// The pipeline calls this only after the batch carrying the tag has been
+// durably written, giving at-least-once delivery.
+func (s *RabbitMQSource) CommitStream(_ context.Context, token any) error {
+	tag, ok := token.(uint64)
+	if !ok {
+		return fmt.Errorf("rabbitmq: unexpected commit token type %T", token)
+	}
+	// Hold the lock across Ack so it cannot race with the consumer goroutine
+	// clearing and closing the channel on shutdown (both guarded by s.mu).
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.streamCh == nil {
+		return fmt.Errorf("rabbitmq: no active streaming consumer to acknowledge")
+	}
+	if err := s.streamCh.Ack(tag, true); err != nil {
+		return fmt.Errorf("rabbitmq: failed to ack up to delivery tag %d: %w", tag, err)
+	}
+	return nil
+}
+
+// streamingEnvelopeSchema is the fixed schema used for schema-less broker
+// sources in streaming mode: a primary-key message id plus a JSON column
+// holding the decoded body and metadata.
+func streamingEnvelopeSchema(queue string) *schema.TableSchema {
+	return &schema.TableSchema{
+		Name: queue,
+		Columns: []schema.Column{
+			{Name: "msg_id", DataType: schema.TypeString, Nullable: false, IsPrimaryKey: true},
+			{Name: "data", DataType: schema.TypeJSON, Nullable: true},
+			// Monotonic per-consumer source position (AMQP delivery tag). Used as
+			// the merge incremental key so the latest record per msg_id wins
+			// within a flush cycle.
+			{Name: streamOrderColumn, DataType: schema.TypeInt64, Nullable: false},
+		},
+		PrimaryKeys:    []string{"msg_id"},
+		IncrementalKey: streamOrderColumn,
+	}
+}
+
+const streamOrderColumn = "_ingestr_order"
 
 func (s *RabbitMQSource) Schemes() []string {
 	return []string{"amqp", "amqps"}
@@ -75,6 +136,28 @@ func (s *RabbitMQSource) GetTable(_ context.Context, req source.TableRequest) (s
 		strategy = config.StrategyReplace
 	}
 
+	// In streaming mode the queue has no inferable schema (the stream never
+	// ends), so we project every message into a fixed msg_id + data envelope.
+	if req.Streaming {
+		primaryKeys := req.PrimaryKeys
+		if len(primaryKeys) == 0 {
+			primaryKeys = []string{"msg_id"}
+		}
+		return &source.DynamicSourceTable{
+			TableName:           queueName,
+			TablePrimaryKeys:    primaryKeys,
+			TableIncrementalKey: req.IncrementalKey,
+			TableStrategy:       strategy,
+			KnownSchema:         true,
+			SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+				return streamingEnvelopeSchema(queueName), nil
+			},
+			ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+				return s.read(ctx, queueName, opts)
+			},
+		}, nil
+	}
+
 	return &source.DynamicSourceTable{
 		TableName:           queueName,
 		TablePrimaryKeys:    req.PrimaryKeys,
@@ -101,7 +184,17 @@ func (s *RabbitMQSource) read(ctx context.Context, queue string, opts source.Rea
 		batchSize = defaultBatchSize
 	}
 
-	if err := ch.Qos(batchSize, 0, false); err != nil {
+	streaming := opts.Streaming
+
+	// In streaming mode the pipeline acks (via CommitStream) only after a flush,
+	// so the un-acked window can exceed any prefetch limit. Unlimited prefetch
+	// (0) avoids stalling the consumer; backpressure comes from the bounded
+	// results channel. Non-streaming acks per batch, so batchSize prefetch is fine.
+	prefetch := batchSize
+	if streaming {
+		prefetch = 0
+	}
+	if err := ch.Qos(prefetch, 0, false); err != nil {
 		_ = ch.Close()
 		return nil, fmt.Errorf("failed to set QoS: %w", err)
 	}
@@ -120,11 +213,34 @@ func (s *RabbitMQSource) read(ctx context.Context, queue string, opts source.Rea
 		return nil, fmt.Errorf("failed to start consuming from queue %s: %w", queue, err)
 	}
 
+	if streaming {
+		s.mu.Lock()
+		s.streamCh = ch
+		s.mu.Unlock()
+	}
+
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
 		defer close(results)
-		defer func() { _ = ch.Close() }()
+		if streaming {
+			// Clear and close the channel under the lock so a concurrent
+			// CommitStream (which acks under the same lock) never touches a
+			// closing channel.
+			defer func() {
+				s.mu.Lock()
+				s.streamCh = nil
+				_ = ch.Close()
+				s.mu.Unlock()
+			}()
+		} else {
+			defer func() { _ = ch.Close() }()
+		}
+
+		var envelopeCols []schema.Column
+		if streaming {
+			envelopeCols = streamingEnvelopeSchema(queue).Columns
+		}
 
 		batch := make([]map[string]any, 0, batchSize)
 		var lastDeliveryTag uint64
@@ -146,22 +262,37 @@ func (s *RabbitMQSource) read(ctx context.Context, queue string, opts source.Rea
 			timer.Reset(defaultBatchTimeout)
 		}
 
+		// flush emits the accumulated batch. In streaming mode it attaches the
+		// highest delivery tag as a cumulative CommitToken and does NOT ack;
+		// the pipeline acks via CommitStream after the data is durable. In
+		// non-streaming mode it acks immediately after emitting.
 		flush := func() bool {
-			record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, nil, opts.ExcludeColumns)
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, envelopeCols, opts.ExcludeColumns)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert RabbitMQ messages to Arrow: %w", err)}
 				return false
 			}
 
-			results <- source.RecordBatchResult{Batch: record}
+			res := source.RecordBatchResult{Batch: record}
+			if streaming {
+				res.CommitToken = lastDeliveryTag
+			}
+			results <- res
 
-			if err := ch.Ack(lastDeliveryTag, true); err != nil {
-				config.Debug("[RABBITMQ] Failed to ack messages up to tag %d: %v", lastDeliveryTag, err)
+			if !streaming {
+				if err := ch.Ack(lastDeliveryTag, true); err != nil {
+					config.Debug("[RABBITMQ] Failed to ack messages up to tag %d: %v", lastDeliveryTag, err)
+				}
 			}
 
 			batchNum++
 			config.Debug("[RABBITMQ] Batch %d: %d messages (total: %d)", batchNum, len(batch), totalRead)
 			return true
+		}
+
+		appendMsg := deliveryToItem
+		if streaming {
+			appendMsg = deliveryToEnvelope
 		}
 
 		for {
@@ -180,7 +311,7 @@ func (s *RabbitMQSource) read(ctx context.Context, queue string, opts source.Rea
 					return
 				}
 
-				batch = append(batch, deliveryToItem(msg))
+				batch = append(batch, appendMsg(msg))
 				lastDeliveryTag = msg.DeliveryTag
 				totalRead++
 				receivedSinceLastTick = true
@@ -209,7 +340,8 @@ func (s *RabbitMQSource) read(ctx context.Context, queue string, opts source.Rea
 					receivedSinceLastTick = false
 					continue
 				}
-				if !receivedSinceLastTick {
+				// In streaming mode never exit on idle; keep consuming.
+				if !streaming && !receivedSinceLastTick {
 					config.Debug("[RABBITMQ] No new messages received, finishing read (total: %d)", totalRead)
 					return
 				}
@@ -260,6 +392,24 @@ func deliveryToItem(msg amqp.Delivery) map[string]any {
 	return item
 }
 
+// deliveryToEnvelope projects a message into the streaming envelope schema:
+// a primary-key msg_id and a JSON data column holding the decoded body and
+// metadata (everything deliveryToItem would have produced, minus msg_id).
+func deliveryToEnvelope(msg amqp.Delivery) map[string]any {
+	item := deliveryToItem(msg)
+	msgID, _ := item["msg_id"].(string)
+	delete(item, "msg_id")
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		encoded = fmt.Appendf(nil, "%q", string(msg.Body))
+	}
+	return map[string]any{
+		"msg_id":          msgID,
+		"data":            string(encoded),
+		streamOrderColumn: int64(msg.DeliveryTag),
+	}
+}
+
 func generateMsgID(msg amqp.Delivery) string {
 	if msg.MessageId != "" {
 		return msg.MessageId
@@ -284,4 +434,8 @@ func sanitizeURI(uri string) string {
 	return uri
 }
 
-var _ source.Source = (*RabbitMQSource)(nil)
+var (
+	_ source.Source          = (*RabbitMQSource)(nil)
+	_ source.StreamingSource = (*RabbitMQSource)(nil)
+	_ source.StreamCommitter = (*RabbitMQSource)(nil)
+)

--- a/pkg/source/rabbitmq/rabbitmq.go
+++ b/pkg/source/rabbitmq/rabbitmq.go
@@ -63,7 +63,12 @@ func (s *RabbitMQSource) CommitStream(_ context.Context, token any) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.streamCh == nil {
-		return fmt.Errorf("rabbitmq: no active streaming consumer to acknowledge")
+		// The channel was already closed (e.g. a final flush racing shutdown).
+		// Messages are durably written; skipping the ack is safe under
+		// at-least-once — RabbitMQ re-delivers the un-acked tail on the next
+		// consumer start.
+		config.Debug("[RABBITMQ] CommitStream: no active channel, skipping ack")
+		return nil
 	}
 	if err := s.streamCh.Ack(tag, true); err != nil {
 		return fmt.Errorf("rabbitmq: failed to ack up to delivery tag %d: %w", tag, err)
@@ -108,6 +113,15 @@ func (s *RabbitMQSource) Connect(ctx context.Context, uri string) error {
 }
 
 func (s *RabbitMQSource) Close(_ context.Context) error {
+	// Close the streaming consumer channel (kept open past its goroutine so the
+	// final flush could ack) before tearing down the connection.
+	s.mu.Lock()
+	if s.streamCh != nil {
+		_ = s.streamCh.Close()
+		s.streamCh = nil
+	}
+	s.mu.Unlock()
+
 	if s.conn != nil {
 		err := s.conn.Close()
 		if err != nil {
@@ -223,17 +237,10 @@ func (s *RabbitMQSource) read(ctx context.Context, queue string, opts source.Rea
 
 	go func() {
 		defer close(results)
-		if streaming {
-			// Clear and close the channel under the lock so a concurrent
-			// CommitStream (which acks under the same lock) never touches a
-			// closing channel.
-			defer func() {
-				s.mu.Lock()
-				s.streamCh = nil
-				_ = ch.Close()
-				s.mu.Unlock()
-			}()
-		} else {
+		// In streaming mode the channel stays open (and s.streamCh set) after
+		// this goroutine exits so the pipeline's final flush can still ack via
+		// CommitStream; Close() closes it. Non-streaming closes it here.
+		if !streaming {
 			defer func() { _ = ch.Close() }()
 		}
 

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -22,12 +22,18 @@ type ReadOptions struct {
 	CDCSlotSuffix  string              // Optional: suffix for auto-generated replication slot names (dest-aware)
 	FullRefresh    bool
 	Columns        string // Optional: column definitions for schema-less sources (e.g., "id:bigint,name:text")
+	Streaming      bool   // Continuous mode: never exit on caught-up/idle; attach cumulative CommitTokens
 }
 
 type RecordBatchResult struct {
 	Batch     arrow.RecordBatch
 	Err       error
 	TableName string // Source table name for multi-table sources (empty for single-table)
+
+	// CommitToken is an opaque, cumulative position marker for streaming mode.
+	// Committing a token via StreamCommitter acknowledges everything emitted up
+	// to and including the batch that carried it. Nil means no feedback needed.
+	CommitToken any
 }
 
 // TableRequest contains user-provided configuration for table instantiation.
@@ -37,6 +43,7 @@ type TableRequest struct {
 	IncrementalKey string                     // User-specified incremental key (validated by source)
 	PrimaryKeys    []string                   // User-specified PKs (used only if source doesn't define them)
 	Strategy       config.IncrementalStrategy // User-specified strategy (used only if source doesn't define it)
+	Streaming      bool                       // Table will be read in streaming mode (--stream)
 }
 
 // Source represents a data source that can provide tables.
@@ -81,6 +88,24 @@ type MultiTableReadOptions struct {
 	ReadOptions
 	Tables        []string          // Filter to specific tables (empty = all tables)
 	CDCResumeLSNs map[string]string // Per-table CDC resume LSNs: table name → max LSN already processed
+}
+
+// StreamingSource is an optional capability for sources that support
+// continuous ingestion via the --stream flag.
+type StreamingSource interface {
+	SupportsStreaming() bool
+
+	// DefaultStreamingStrategy is the write strategy used in streaming mode
+	// when the user doesn't specify one (merge for CDC, append for brokers).
+	DefaultStreamingStrategy() config.IncrementalStrategy
+}
+
+// StreamCommitter is an optional capability for streaming sources that need
+// durability feedback. After each successful flush the pipeline calls
+// CommitStream with the CommitToken of the last flushed batch; tokens are
+// cumulative, so committing a token acknowledges everything emitted up to it.
+type StreamCommitter interface {
+	CommitStream(ctx context.Context, token any) error
 }
 
 // MultiTableSource represents a source that emits data from multiple tables.

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -15,6 +15,68 @@ import (
 
 type MergeStrategy struct{}
 
+// mergeTableParams describes one dest/staging table pair for a merge.
+type mergeTableParams struct {
+	DestTable    string
+	StagingTable string
+	Schema       *schema.TableSchema
+	PrimaryKeys  []string
+	PartitionBy  string
+	ClusterBy    []string
+	IsCDC        bool
+}
+
+// prepareMergeTables ensures the destination table exists (without dropping it)
+// and creates a fresh staging table for it.
+func prepareMergeTables(ctx context.Context, dest destination.Destination, p mergeTableParams) error {
+	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       p.DestTable,
+		Schema:      destination.DestinationTableSchema(p.Schema),
+		DropFirst:   false,
+		PrimaryKeys: p.PrimaryKeys,
+		PartitionBy: p.PartitionBy,
+		ClusterBy:   p.ClusterBy,
+	}); err != nil {
+		return fmt.Errorf("failed to prepare destination table %s: %w", p.DestTable, err)
+	}
+
+	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        p.StagingTable,
+		Schema:       p.Schema,
+		DropFirst:    true,
+		PrimaryKeys:  nil,
+		CDCMode:      p.IsCDC, // Allow NULLs for CDC deletes in staging
+		PartitionBy:  p.PartitionBy,
+		ClusterBy:    p.ClusterBy,
+		ExpiresAfter: destination.ManagedStagingTTL,
+	}); err != nil {
+		return fmt.Errorf("failed to prepare staging table %s: %w", p.StagingTable, err)
+	}
+
+	return nil
+}
+
+// mergeStagingInto merges the staging table into the target table by primary
+// key. A non-empty incrementalKey makes the per-PK dedup keep the row with the
+// highest value of that key (latest wins) instead of an arbitrary one.
+func mergeStagingInto(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey string) error {
+	return dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   stagingTable,
+		TargetTable:    targetTable,
+		PrimaryKeys:    primaryKeys,
+		Columns:        destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
+		IncrementalKey: incrementalKey,
+	})
+}
+
+// warnIfCDCMergeUnsupported prints a warning when CDC data is headed at a
+// destination that can't process deletes during merge.
+func warnIfCDCMergeUnsupported(dest destination.Destination) {
+	if cdcAware, ok := dest.(destination.CDCMergeAware); !ok || !cdcAware.SupportsCDCMerge() {
+		fmt.Printf("Warning: CDC data detected but the destination does not support CDC-aware merge; deleted rows will be inserted as regular data with _cdc_deleted=true instead of being processed as deletes\n")
+	}
+}
+
 func (s *MergeStrategy) Name() config.IncrementalStrategy {
 	return config.StrategyMerge
 }
@@ -40,37 +102,19 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	fmt.Printf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	isCDC := hasCDCColumns(job.Schema)
 	if isCDC {
-		if cdcAware, ok := job.Destination.(destination.CDCMergeAware); !ok || !cdcAware.SupportsCDCMerge() {
-			fmt.Printf("Warning: CDC data detected but the destination does not support CDC-aware merge; deleted rows will be inserted as regular data with _cdc_deleted=true instead of being processed as deletes\n")
-		}
+		warnIfCDCMergeUnsupported(job.Destination)
 	}
 
-	destSchema := destination.DestinationTableSchema(job.Schema)
-
-	// Ensure destination table exists (don't drop it)
-	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       job.Config.DestTable,
-		Schema:      destSchema,
-		DropFirst:   false,
-		PrimaryKeys: job.Config.PrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
-	}); err != nil {
-		return fmt.Errorf("failed to prepare destination table: %w", err)
-	}
-
-	// Create staging table with same schema
-	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-		Table:        stagingTable,
+	if err := prepareMergeTables(ctx, job.Destination, mergeTableParams{
+		DestTable:    job.Config.DestTable,
+		StagingTable: stagingTable,
 		Schema:       job.Schema,
-		DropFirst:    true,
-		PrimaryKeys:  nil,
-		CDCMode:      isCDC, // Allow NULLs for CDC deletes in staging
+		PrimaryKeys:  job.Config.PrimaryKeys,
 		PartitionBy:  job.Config.PartitionBy,
 		ClusterBy:    job.Config.ClusterBy,
-		ExpiresAfter: destination.ManagedStagingTTL,
+		IsCDC:        isCDC,
 	}); err != nil {
-		return fmt.Errorf("failed to prepare staging table: %w", err)
+		return err
 	}
 
 	// Read from source
@@ -129,12 +173,7 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	// Note: We only use source columns here. Destination-only columns (removed columns)
 	// will naturally receive NULL for new rows and remain unchanged for existing rows.
 	config.Debug("[MERGE] Executing merge operation")
-	if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
-		StagingTable: stagingTable,
-		TargetTable:  job.Config.DestTable,
-		PrimaryKeys:  job.Config.PrimaryKeys,
-		Columns:      destination.MergeColumnsFor(job.Destination, job.Schema.ColumnNames()),
-	}); err != nil {
+	if err := mergeStagingInto(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, ""); err != nil {
 		return fmt.Errorf("failed to merge data: %w", err)
 	}
 
@@ -164,9 +203,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 		}
 	}
 	if anyTableHasCDC {
-		if cdcAware, ok := job.Destination.(destination.CDCMergeAware); !ok || !cdcAware.SupportsCDCMerge() {
-			fmt.Printf("Warning: CDC data detected but the destination does not support CDC-aware merge; deleted rows will be inserted as regular data with _cdc_deleted=true instead of being processed as deletes\n")
-		}
+		warnIfCDCMergeUnsupported(job.Destination)
 	}
 
 	stagingTables := make(map[string]string)
@@ -183,34 +220,20 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 
 			destTable := job.GetDestTableName(ti.Name)
 			stagingTable := GenerateStagingTableName(destTable, "merge", job.Config.StagingDataset)
-			isCDC := hasCDCColumns(ti.Schema)
-
-			tableDestSchema := destination.DestinationTableSchema(ti.Schema)
 
 			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
 				errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
 				return
 			}
 
-			if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-				Table:       destTable,
-				Schema:      tableDestSchema,
-				DropFirst:   false,
-				PrimaryKeys: ti.PrimaryKeys,
-			}); err != nil {
-				errChan <- fmt.Errorf("failed to prepare destination table %s: %w", ti.Name, err)
-				return
-			}
-
-			if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-				Table:        stagingTable,
+			if err := prepareMergeTables(ctx, job.Destination, mergeTableParams{
+				DestTable:    destTable,
+				StagingTable: stagingTable,
 				Schema:       ti.Schema,
-				DropFirst:    true,
-				PrimaryKeys:  nil,
-				CDCMode:      isCDC, // Make non-PK columns nullable for CDC staging tables
-				ExpiresAfter: destination.ManagedStagingTTL,
+				PrimaryKeys:  ti.PrimaryKeys,
+				IsCDC:        hasCDCColumns(ti.Schema), // Make non-PK columns nullable for CDC staging tables
 			}); err != nil {
-				errChan <- fmt.Errorf("failed to prepare staging table for %s: %w", ti.Name, err)
+				errChan <- err
 				return
 			}
 
@@ -282,12 +305,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			destTable := job.GetDestTableName(ti.Name)
 			stagingTable := stagingTables[ti.Name]
 
-			if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
-				StagingTable: stagingTable,
-				TargetTable:  destTable,
-				PrimaryKeys:  ti.PrimaryKeys,
-				Columns:      destination.MergeColumnsFor(job.Destination, ti.Schema.ColumnNames()),
-			}); err != nil {
+			if err := mergeStagingInto(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, ti.Schema, ""); err != nil {
 				mergeErrChan <- fmt.Errorf("failed to merge table %s: %w", ti.Name, err)
 				return
 			}

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -1,0 +1,493 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	// streamDrainTimeout bounds how long shutdown waits for the source to flush
+	// its internal buffers into the channel after cancellation.
+	streamDrainTimeout = 15 * time.Second
+
+	// streamFinalFlushTimeout bounds the final flush performed on a detached
+	// context after the run context has been cancelled.
+	streamFinalFlushTimeout = 60 * time.Second
+)
+
+// StreamingOptions configures the streaming flush loop.
+type StreamingOptions struct {
+	FlushInterval time.Duration
+	FlushRecords  int64
+	Strategy      config.IncrementalStrategy // merge or append
+	Committer     source.StreamCommitter     // nil = source needs no durability feedback
+}
+
+// StreamingExecutor runs continuous ingestion: it buffers record batches from
+// the source and flushes them to the destination whenever FlushInterval
+// elapses or FlushRecords rows are buffered, whichever comes first. Merge mode
+// reuses one staging table per destination table across cycles; append mode
+// writes directly. After each successful flush the source's CommitStream is
+// invoked so it can confirm the durable position (LSN, delivery tag, offsets).
+type StreamingExecutor struct {
+	opts StreamingOptions
+}
+
+func NewStreamingExecutor(opts StreamingOptions) *StreamingExecutor {
+	return &StreamingExecutor{opts: opts}
+}
+
+func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) error {
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
+	st := &streamTableState{
+		destTable:      job.Config.DestTable,
+		schema:         job.Schema,
+		primaryKeys:    job.Config.PrimaryKeys,
+		incrementalKey: job.Schema.IncrementalKey,
+		isCDC:          hasCDCColumns(job.Schema),
+		partitionBy:    job.Config.PartitionBy,
+		clusterBy:      job.Config.ClusterBy,
+	}
+	if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
+		return err
+	}
+
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+
+	records, err := job.GetRecords(ctx, source.ReadOptions{
+		IncrementalKey: job.Config.IncrementalKey,
+		IntervalStart:  job.Config.IntervalStart,
+		PageSize:       job.Config.PageSize,
+		ExcludeColumns: job.Config.SQLExcludeColumns,
+		Parallelism:    parallelism,
+		Schema:         job.SourceSchema,
+		CDCResumeLSN:   job.Config.CDCResumeLSN,
+		CDCSlotSuffix:  job.Config.CDCSlotSuffix,
+		Streaming:      true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get records: %w", err)
+	}
+
+	records, err = job.ApplyBatchTransformation(ctx, records)
+	if err != nil {
+		return fmt.Errorf("failed to apply batch transformation: %w", err)
+	}
+
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+
+	loop := newFlushLoop(job.Destination, job.Config, e.opts, map[string]*streamTableState{"": st})
+	defer loop.cleanup(ctx)
+	return loop.run(ctx, records)
+}
+
+// ExecuteMultiTable runs the streaming loop over a multi-table source (CDC).
+func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTableIngestionJob) error {
+	if len(job.Tables) == 0 {
+		return nil
+	}
+
+	anyTableHasCDC := false
+	for _, ti := range job.Tables {
+		if hasCDCColumns(ti.Schema) {
+			anyTableHasCDC = true
+			break
+		}
+	}
+	if anyTableHasCDC && e.opts.Strategy == config.StrategyMerge {
+		warnIfCDCMergeUnsupported(job.Destination)
+	}
+
+	tables := make(map[string]*streamTableState, len(job.Tables))
+	for _, ti := range job.Tables {
+		st := &streamTableState{
+			destTable:      job.GetDestTableName(ti.Name),
+			schema:         ti.Schema,
+			primaryKeys:    ti.PrimaryKeys,
+			incrementalKey: ti.Schema.IncrementalKey,
+			isCDC:          hasCDCColumns(ti.Schema),
+		}
+
+		if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+			return fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+		}
+		if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
+			return err
+		}
+
+		tables[ti.Name] = st
+	}
+
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+
+	records, err := job.Source.ReadAll(ctx, source.MultiTableReadOptions{
+		ReadOptions: source.ReadOptions{
+			Parallelism:   parallelism,
+			PageSize:      job.Config.PageSize,
+			CDCSlotSuffix: job.Config.CDCSlotSuffix,
+			Streaming:     true,
+		},
+		CDCResumeLSNs: job.CDCResumeLSNs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to read from multi-table source: %w", err)
+	}
+
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+
+	loop := newFlushLoop(job.Destination, job.Config, e.opts, tables)
+	defer loop.cleanup(ctx)
+	return loop.run(ctx, records)
+}
+
+// prepareTable sets up the destination (and staging, for merge) tables for one
+// stream table and records the staging name on the state.
+func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.Destination, cfg *config.IngestConfig, st *streamTableState) error {
+	switch e.opts.Strategy {
+	case config.StrategyMerge:
+		st.stagingTable = GenerateStagingTableName(st.destTable, "stream", cfg.StagingDataset)
+		fmt.Printf("[STREAM] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), st.stagingTable)
+		return prepareMergeTables(ctx, dest, mergeTableParams{
+			DestTable:    st.destTable,
+			StagingTable: st.stagingTable,
+			Schema:       st.schema,
+			PrimaryKeys:  st.primaryKeys,
+			PartitionBy:  st.partitionBy,
+			ClusterBy:    st.clusterBy,
+			IsCDC:        st.isCDC,
+		})
+	case config.StrategyAppend:
+		// Append must not enforce the primary key as a unique constraint:
+		// streaming is at-least-once, so the same key (e.g. a broker msg_id)
+		// can be redelivered, and an enforced PK would turn that into a
+		// duplicate-key error that aborts the stream. The key stays a regular
+		// column (available for downstream dedup or a later merge).
+		if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+			Table:       st.destTable,
+			Schema:      destination.DestinationTableSchema(st.schema),
+			DropFirst:   false,
+			PrimaryKeys: nil,
+			PartitionBy: st.partitionBy,
+			ClusterBy:   st.clusterBy,
+		}); err != nil {
+			return fmt.Errorf("failed to prepare destination table %s: %w", st.destTable, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("streaming supports only merge and append strategies, got %q", e.opts.Strategy)
+	}
+}
+
+// streamTableState tracks one destination table's buffered batches across
+// flush cycles. stagingTable is empty in append mode.
+type streamTableState struct {
+	destTable      string
+	stagingTable   string
+	schema         *schema.TableSchema
+	primaryKeys    []string
+	incrementalKey string
+	isCDC          bool
+	partitionBy    string
+	clusterBy      []string
+
+	pending     []arrow.RecordBatch
+	pendingRows int64
+}
+
+type flushLoop struct {
+	dest   destination.Destination
+	cfg    *config.IngestConfig
+	opts   StreamingOptions
+	tables map[string]*streamTableState // key = RecordBatchResult.TableName ("" for single-table)
+
+	buffered int64 // rows buffered across all tables
+
+	// lastToken is the newest CommitToken seen; tokenDirty marks that it has
+	// not been committed yet. Tokens may be uncomparable types (maps), so a
+	// dirty flag is used instead of comparing tokens.
+	lastToken  any
+	tokenDirty bool
+
+	cycles int64
+}
+
+func newFlushLoop(dest destination.Destination, cfg *config.IngestConfig, opts StreamingOptions, tables map[string]*streamTableState) *flushLoop {
+	return &flushLoop{
+		dest:   dest,
+		cfg:    cfg,
+		opts:   opts,
+		tables: tables,
+	}
+}
+
+func (l *flushLoop) run(ctx context.Context, records <-chan source.RecordBatchResult) error {
+	defer l.releasePending()
+
+	ticker := time.NewTicker(l.opts.FlushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case res, ok := <-records:
+			if !ok {
+				// Source ended on its own (e.g. its context was cancelled and
+				// it closed the channel before we observed ctx.Done).
+				return l.finalFlush(ctx)
+			}
+			if res.Err != nil {
+				if ctx.Err() != nil {
+					return l.shutdown(ctx, records)
+				}
+				return fmt.Errorf("source error: %w", res.Err)
+			}
+			l.buffer(res)
+			if l.buffered >= l.opts.FlushRecords {
+				if err := l.flush(ctx); err != nil {
+					return err
+				}
+				ticker.Reset(l.opts.FlushInterval)
+			}
+
+		case <-ticker.C:
+			if l.buffered == 0 && !l.tokenDirty {
+				continue
+			}
+			if err := l.flush(ctx); err != nil {
+				return err
+			}
+
+		case <-ctx.Done():
+			return l.shutdown(ctx, records)
+		}
+	}
+}
+
+func (l *flushLoop) buffer(res source.RecordBatchResult) {
+	if res.CommitToken != nil {
+		l.lastToken = res.CommitToken
+		l.tokenDirty = true
+	}
+	if res.Batch == nil {
+		return
+	}
+	if res.Batch.NumRows() == 0 {
+		res.Batch.Release()
+		return
+	}
+	st, ok := l.tables[res.TableName]
+	if !ok {
+		config.Debug("[STREAM] Dropping batch for unknown table %q (%d rows)", res.TableName, res.Batch.NumRows())
+		res.Batch.Release()
+		return
+	}
+	st.pending = append(st.pending, res.Batch)
+	st.pendingRows += res.Batch.NumRows()
+	l.buffered += res.Batch.NumRows()
+}
+
+// flush writes all buffered batches to the destination (one write+merge cycle
+// per table) and then confirms the durable position with the source. The
+// ordering write → merge → reset staging → commit is what makes delivery
+// at-least-once: a crash before commit re-delivers from the last committed
+// position and the merge is idempotent by primary key.
+func (l *flushLoop) flush(ctx context.Context) error {
+	start := time.Now()
+	var flushedRows int64
+
+	for name, st := range l.tables {
+		if st.pendingRows == 0 {
+			continue
+		}
+		batches := st.pending
+		rows := st.pendingRows
+		st.pending = nil
+		st.pendingRows = 0
+		l.buffered -= rows
+
+		displayName := name
+		if displayName == "" {
+			displayName = st.destTable
+		}
+
+		writeOpts := destination.WriteOptions{
+			Table:            st.destTable,
+			Schema:           st.schema,
+			Parallelism:      l.parallelism(),
+			StagingBucket:    l.cfg.StagingBucket,
+			LoaderFileSize:   l.cfg.LoaderFileSize,
+			LoaderFileFormat: l.cfg.LoaderFileFormat,
+		}
+		if st.stagingTable != "" {
+			writeOpts.Table = st.stagingTable
+			writeOpts.StagingTable = true
+		}
+
+		ch := prefilledBatchChannel(batches)
+		if err := l.dest.WriteParallel(ctx, ch, writeOpts); err != nil {
+			drainAndRelease(ch)
+			return fmt.Errorf("streaming flush: failed to write %d rows for table %s: %w", rows, displayName, err)
+		}
+
+		if st.stagingTable != "" {
+			if err := mergeStagingInto(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey); err != nil {
+				return fmt.Errorf("streaming flush: failed to merge table %s: %w", displayName, err)
+			}
+			if err := l.resetStaging(ctx, st); err != nil {
+				return fmt.Errorf("streaming flush: failed to reset staging table %s: %w", st.stagingTable, err)
+			}
+		}
+
+		flushedRows += rows
+	}
+
+	if l.opts.Committer != nil && l.tokenDirty {
+		if err := l.opts.Committer.CommitStream(ctx, l.lastToken); err != nil {
+			return fmt.Errorf("streaming flush: failed to commit source position: %w", err)
+		}
+	}
+	l.tokenDirty = false
+
+	l.cycles++
+	if flushedRows > 0 {
+		fmt.Printf("[STREAM] %s | cycle %d: flushed %d rows in %s\n", time.Now().Format("15:04:05"), l.cycles, flushedRows, time.Since(start).Round(time.Millisecond))
+	}
+	return nil
+}
+
+// resetStaging empties the staging table for the next cycle, preferring an
+// in-place truncate over drop+recreate.
+func (l *flushLoop) resetStaging(ctx context.Context, st *streamTableState) error {
+	if tc, ok := l.dest.(destination.TruncateCapable); ok {
+		return tc.TruncateTable(ctx, st.stagingTable)
+	}
+	return l.dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        st.stagingTable,
+		Schema:       st.schema,
+		DropFirst:    true,
+		PrimaryKeys:  nil,
+		CDCMode:      st.isCDC,
+		PartitionBy:  st.partitionBy,
+		ClusterBy:    st.clusterBy,
+		ExpiresAfter: destination.ManagedStagingTTL,
+	})
+}
+
+// shutdown handles context cancellation: it drains whatever the source still
+// flushes into the channel, then performs a final flush on a detached context
+// so the buffered tail reaches the destination.
+func (l *flushLoop) shutdown(ctx context.Context, records <-chan source.RecordBatchResult) error {
+	deadline := time.NewTimer(streamDrainTimeout)
+	defer deadline.Stop()
+
+drain:
+	for {
+		select {
+		case res, ok := <-records:
+			if !ok {
+				break drain
+			}
+			if res.Err != nil {
+				// Cancellation errors from the source are expected here.
+				config.Debug("[STREAM] Ignoring source error during shutdown: %v", res.Err)
+				continue
+			}
+			l.buffer(res)
+		case <-deadline.C:
+			config.Debug("[STREAM] Drain deadline reached, proceeding to final flush")
+			break drain
+		}
+	}
+
+	return l.finalFlush(ctx)
+}
+
+// finalFlush flushes any remaining buffered data. It detaches from the
+// (possibly cancelled) run context while preserving its values, so destination
+// writes still carry query annotations.
+func (l *flushLoop) finalFlush(ctx context.Context) error {
+	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), streamFinalFlushTimeout)
+	defer cancel()
+
+	if l.buffered == 0 && !l.tokenDirty {
+		return nil
+	}
+	config.Debug("[STREAM] Final flush: %d buffered rows", l.buffered)
+	return l.flush(flushCtx)
+}
+
+// cleanup drops staging tables (best-effort) regardless of how the loop ended.
+func (l *flushLoop) cleanup(ctx context.Context) {
+	if l.cfg.KeepStaging {
+		return
+	}
+	dropCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), streamFinalFlushTimeout)
+	defer cancel()
+	for _, st := range l.tables {
+		if st.stagingTable == "" {
+			continue
+		}
+		if err := l.dest.DropTable(dropCtx, st.stagingTable); err != nil {
+			config.Debug("[STREAM] Warning: failed to drop staging table %s: %v", st.stagingTable, err)
+		}
+	}
+}
+
+func (l *flushLoop) releasePending() {
+	for _, st := range l.tables {
+		for _, b := range st.pending {
+			b.Release()
+		}
+		l.buffered -= st.pendingRows
+		st.pending = nil
+		st.pendingRows = 0
+	}
+}
+
+func (l *flushLoop) parallelism() int {
+	if l.cfg.ExtractParallelism > 0 {
+		return l.cfg.ExtractParallelism
+	}
+	return 4
+}
+
+// prefilledBatchChannel wraps already-buffered batches in a closed channel so
+// WriteParallel (which consumes until close) performs exactly one bounded
+// write cycle. Ownership of the batches passes to the writer, which releases
+// them after writing.
+func prefilledBatchChannel(batches []arrow.RecordBatch) chan source.RecordBatchResult {
+	ch := make(chan source.RecordBatchResult, len(batches))
+	for _, b := range batches {
+		ch <- source.RecordBatchResult{Batch: b}
+	}
+	close(ch)
+	return ch
+}
+
+// drainAndRelease releases batches a failed writer left unconsumed.
+func drainAndRelease(ch <-chan source.RecordBatchResult) {
+	for res := range ch {
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+	}
+}

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -1,0 +1,465 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCommitter struct {
+	mu     sync.Mutex
+	tokens []any
+	err    error
+}
+
+func (c *fakeCommitter) CommitStream(_ context.Context, token any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokens = append(c.tokens, token)
+	return c.err
+}
+
+func (c *fakeCommitter) committed() []any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]any(nil), c.tokens...)
+}
+
+// ctxRecordingDest records the context error observed at each WriteParallel
+// call so tests can assert the final flush runs on a non-cancelled context.
+type ctxRecordingDest struct {
+	*fakeDestination
+	mu           sync.Mutex
+	writeCtxErrs []error
+}
+
+func (d *ctxRecordingDest) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.mu.Lock()
+	d.writeCtxErrs = append(d.writeCtxErrs, ctx.Err())
+	d.mu.Unlock()
+	return d.fakeDestination.WriteParallel(ctx, records, opts)
+}
+
+type truncatingDest struct {
+	*fakeDestination
+	mu            sync.Mutex
+	truncateCalls []string
+}
+
+func (d *truncatingDest) TruncateTable(_ context.Context, table string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.truncateCalls = append(d.truncateCalls, table)
+	return nil
+}
+
+func streamTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+}
+
+func mergeTableState(name string) *streamTableState {
+	return &streamTableState{
+		destTable:    name,
+		stagingTable: name + "_staging",
+		schema:       streamTestSchema(),
+		primaryKeys:  []string{"id"},
+	}
+}
+
+func newTestLoop(dest destination.Destination, opts StreamingOptions, tables map[string]*streamTableState) *flushLoop {
+	return newFlushLoop(dest, &config.IngestConfig{ExtractParallelism: 2}, opts, tables)
+}
+
+func writeCallCount(d *fakeDestination) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.writeCalls)
+}
+
+func TestStreaming_CountTriggerFlushes(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(ctx, records) }()
+
+	for i := range 3 {
+		records <- source.RecordBatchResult{
+			Batch:       int64RecordBatch(t, "id", []int64{1, 2, 3, 4}, nil),
+			CommitToken: i,
+		}
+	}
+	// 3 batches x 4 rows = 12 rows, threshold 100 not reached yet: no flush.
+	assert.Equal(t, 0, writeCallCount(dest))
+
+	big := make([]int64, 100)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", big, nil), CommitToken: 3}
+
+	require.Eventually(t, func() bool { return writeCallCount(dest) == 1 }, 5*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return len(committer.committed()) == 1 }, 5*time.Second, time.Millisecond)
+
+	// Order: write to staging, merge into dest, reset staging (PrepareTable
+	// fallback since fakeDestination is not TruncateCapable), then commit.
+	dest.mu.Lock()
+	assert.Equal(t, []string{"WriteParallel", "MergeTable", "PrepareTable"}, dest.calls)
+	assert.Equal(t, "ds.tbl_staging", dest.writeCalls[0].Table)
+	assert.True(t, dest.writeCalls[0].StagingTable)
+	assert.Equal(t, "ds.tbl_staging", dest.mergeCalls[0].StagingTable)
+	assert.Equal(t, "ds.tbl", dest.mergeCalls[0].TargetTable)
+	dest.mu.Unlock()
+	// Cumulative token semantics: only the newest token is committed.
+	assert.Equal(t, []any{3}, committer.committed())
+
+	cancel()
+	close(records)
+	require.NoError(t, <-done)
+}
+
+func TestStreaming_IntervalTriggerFlushes(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: 20 * time.Millisecond,
+		FlushRecords:  1 << 30,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(ctx, records) }()
+
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil), CommitToken: "t1"}
+
+	require.Eventually(t, func() bool { return writeCallCount(dest) == 1 }, 5*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return len(committer.committed()) == 1 }, 5*time.Second, time.Millisecond)
+	assert.Equal(t, []any{"t1"}, committer.committed())
+
+	cancel()
+	close(records)
+	require.NoError(t, <-done)
+	// Nothing was buffered after the flush, so shutdown adds no extra writes.
+	assert.Equal(t, 1, writeCallCount(dest))
+}
+
+func TestStreaming_EmptyCyclesSkipped(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: 5 * time.Millisecond,
+		FlushRecords:  1 << 30,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(ctx, records) }()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, writeCallCount(dest))
+	assert.Empty(t, committer.committed())
+
+	// A token-only result (CDC keepalive advanced the position with no rows)
+	// must still be committed so the source can release retention.
+	records <- source.RecordBatchResult{CommitToken: "keepalive"}
+	require.Eventually(t, func() bool { return len(committer.committed()) == 1 }, 5*time.Second, time.Millisecond)
+	assert.Equal(t, 0, writeCallCount(dest))
+	assert.Equal(t, []any{"keepalive"}, committer.committed())
+
+	// Token already committed: subsequent ticks stay idle.
+	time.Sleep(30 * time.Millisecond)
+	assert.Len(t, committer.committed(), 1)
+
+	cancel()
+	close(records)
+	require.NoError(t, <-done)
+}
+
+func TestStreaming_MergeFailureAbortsWithoutCommit(t *testing.T) {
+	dest := &fakeDestination{mergeErr: errors.New("merge exploded")}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  2,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	ctx := context.Background()
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2, 3}, nil), CommitToken: "t1"}
+
+	done := make(chan error, 1)
+	go func() { done <- loop.run(ctx, records) }()
+
+	err := <-done
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge exploded")
+	assert.Empty(t, committer.committed())
+}
+
+func TestStreaming_SourceErrorAborts(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1 << 30,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records <- source.RecordBatchResult{Err: errors.New("replication slot vanished")}
+
+	err := loop.run(context.Background(), records)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replication slot vanished")
+}
+
+func TestStreaming_GracefulShutdownFlushesTail(t *testing.T) {
+	dest := &ctxRecordingDest{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1 << 30,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(ctx, records) }()
+
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2, 3}, nil), CommitToken: "tail"}
+	cancel()
+	// Source reacts to cancellation by flushing its accumulator and closing.
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{4}, nil), CommitToken: "tail2"}
+	close(records)
+
+	require.NoError(t, <-done)
+
+	assert.Equal(t, 1, writeCallCount(dest.fakeDestination))
+	assert.Equal(t, []any{"tail2"}, committer.committed())
+
+	// The final flush must run on a fresh, non-cancelled context.
+	dest.mu.Lock()
+	require.Len(t, dest.writeCtxErrs, 1)
+	assert.NoError(t, dest.writeCtxErrs[0])
+	dest.mu.Unlock()
+}
+
+func TestStreaming_ChannelCloseTriggersFinalFlush(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1 << 30,
+		Strategy:      config.StrategyAppend,
+	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchema()}})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil)}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 1)
+	assert.Equal(t, "ds.tbl", dest.writeCalls[0].Table)
+	assert.False(t, dest.writeCalls[0].StagingTable)
+	assert.Empty(t, dest.mergeCalls)
+	dest.mu.Unlock()
+}
+
+func TestStreaming_MultiTableRouting(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  4,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{
+		"public.users":  mergeTableState("ds.users"),
+		"public.orders": mergeTableState("ds.orders"),
+	})
+
+	records := make(chan source.RecordBatchResult, 3)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil), TableName: "public.users"}
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{3, 4}, nil), TableName: "public.orders"}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.writeCalls, 2)
+	writtenTables := []string{dest.writeCalls[0].Table, dest.writeCalls[1].Table}
+	assert.ElementsMatch(t, []string{"ds.users_staging", "ds.orders_staging"}, writtenTables)
+	require.Len(t, dest.mergeCalls, 2)
+	mergedTables := []string{dest.mergeCalls[0].TargetTable, dest.mergeCalls[1].TargetTable}
+	assert.ElementsMatch(t, []string{"ds.users", "ds.orders"}, mergedTables)
+}
+
+func TestStreaming_UnknownTableBatchDropped(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.users": mergeTableState("ds.users")})
+
+	records := make(chan source.RecordBatchResult, 1)
+	// The CheckedAllocator cleanup in int64RecordBatch verifies this gets released.
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.unknown"}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+	assert.Equal(t, 0, writeCallCount(dest))
+}
+
+func TestStreaming_TruncateCapableResetsStagingInPlace(t *testing.T) {
+	dest := &truncatingDest{fakeDestination: &fakeDestination{}}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"": mergeTableState("ds.tbl")})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	assert.Equal(t, []string{"ds.tbl_staging"}, dest.truncateCalls)
+	dest.mu.Unlock()
+	dest.fakeDestination.mu.Lock()
+	assert.Empty(t, dest.prepareCalls, "truncate-capable destinations must not drop+recreate staging")
+	dest.fakeDestination.mu.Unlock()
+}
+
+func TestStreaming_CommitFailureAborts(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{err: errors.New("ack failed")}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyAppend,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchema()}})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), CommitToken: "t1"}
+	close(records)
+
+	err := loop.run(context.Background(), records)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ack failed")
+}
+
+func TestStreaming_AppendDoesNotEnforcePrimaryKey(t *testing.T) {
+	// At-least-once streaming can redeliver the same key, so the append path
+	// must create the table without an enforced primary-key constraint.
+	dest := &fakeDestination{}
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyAppend})
+	st := &streamTableState{
+		destTable: "ds.evt",
+		schema: &schema.TableSchema{
+			Columns:     []schema.Column{{Name: "msg_id", DataType: schema.TypeString}, {Name: "data", DataType: schema.TypeJSON}},
+			PrimaryKeys: []string{"msg_id"},
+		},
+		primaryKeys: []string{"msg_id"},
+	}
+
+	require.NoError(t, exec.prepareTable(context.Background(), dest, &config.IngestConfig{}, st))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.prepareCalls, 1)
+	assert.Equal(t, "ds.evt", dest.prepareCalls[0].Table)
+	assert.Empty(t, dest.prepareCalls[0].PrimaryKeys, "append must not enforce a primary-key constraint")
+	assert.Empty(t, st.stagingTable, "append uses no staging table")
+}
+
+func TestStreaming_MergeEnforcesPrimaryKey(t *testing.T) {
+	dest := &fakeDestination{}
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+	st := &streamTableState{
+		destTable:   "ds.evt",
+		schema:      streamTestSchema(),
+		primaryKeys: []string{"id"},
+	}
+
+	require.NoError(t, exec.prepareTable(context.Background(), dest, &config.IngestConfig{}, st))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	// merge prepares the dest table (with PK) and a staging table.
+	require.GreaterOrEqual(t, len(dest.prepareCalls), 2)
+	assert.Equal(t, []string{"id"}, dest.prepareCalls[0].PrimaryKeys, "merge must keep the primary key for upserts")
+	assert.NotEmpty(t, st.stagingTable)
+}
+
+func TestStreaming_MergePassesIncrementalKeyForOrdering(t *testing.T) {
+	// Broker streams set an incremental key (e.g. _ingestr_order) so the per-PK
+	// dedup keeps the latest record within a flush cycle rather than arbitrary.
+	dest := &fakeDestination{}
+	st := mergeTableState("ds.tbl")
+	st.incrementalKey = "_ingestr_order"
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"": st})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+	assert.Equal(t, "_ingestr_order", dest.mergeCalls[0].IncrementalKey, "merge must order dedup by the incremental key")
+}
+
+func TestStreaming_CleanupDropsStagingTables(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{
+		"a": mergeTableState("ds.a"),
+		"b": {destTable: "ds.b", schema: streamTestSchema()}, // append-style: no staging
+	})
+
+	loop.cleanup(context.Background())
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	assert.Equal(t, []string{"ds.a_staging"}, dest.dropCalls)
+}

--- a/tests/integration/streaming_cdc_test.go
+++ b/tests/integration/streaming_cdc_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestPostgresCDC_Streaming verifies continuous (--stream) CDC ingestion:
+// a snapshot followed by live INSERT/UPDATE/DELETE changes merged into the
+// destination on a flush interval, then a graceful shutdown via context
+// cancellation, and that the replication slot's confirmed_flush_lsn advances
+// only as data becomes durable (commit-after-flush).
+func TestPostgresCDC_Streaming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.evt (id BIGINT PRIMARY KEY, val BIGINT);
+		INSERT INTO public.evt SELECT g, 0 FROM generate_series(1, 500) g;
+		CREATE PUBLICATION stream_pub FOR TABLE public.evt;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=stream_pub"
+
+	cfg := &config.IngestConfig{
+		SourceURI:           cdcSourceURI,
+		DestURI:             destConnString,
+		IncrementalStrategy: config.StrategyMerge,
+		Stream:              true,
+		FlushInterval:       1 * time.Second,
+		FlushRecords:        200,
+		Progress:            config.ProgressLog,
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	destTable := "public.evt"
+	liveCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM `+destTable+` WHERE _cdc_deleted = false`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+	liveSum := func() int64 {
+		var s int64
+		if err := destPool.QueryRow(ctx, `SELECT COALESCE(sum(val),0) FROM `+destTable+` WHERE _cdc_deleted = false`).Scan(&s); err != nil {
+			return -1
+		}
+		return s
+	}
+
+	// 1. Snapshot lands.
+	require.Eventually(t, func() bool { return liveCount() == 500 }, 60*time.Second, 500*time.Millisecond,
+		"snapshot of 500 rows should appear in destination")
+
+	confirmedBefore := confirmedFlushLSN(t, ctx, srcPool)
+
+	// 2. Apply live changes while streaming.
+	_, err = srcPool.Exec(ctx, `UPDATE public.evt SET val = id * 10 WHERE id <= 250`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `DELETE FROM public.evt WHERE id BETWEEN 1 AND 100`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.evt SELECT g, g FROM generate_series(501, 600) g`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `UPDATE public.evt SET val = val + 1 WHERE id > 250 AND id <= 500`)
+	require.NoError(t, err)
+
+	// Expected source state: 500 - 100 deleted + 100 inserted = 500 rows.
+	var wantCount int
+	var wantSum int64
+	require.NoError(t, srcPool.QueryRow(ctx, `SELECT count(*), COALESCE(sum(val),0) FROM public.evt`).Scan(&wantCount, &wantSum))
+
+	// 3. Destination converges to the exact source state.
+	require.Eventually(t, func() bool {
+		return liveCount() == wantCount && liveSum() == wantSum
+	}, 60*time.Second, 500*time.Millisecond,
+		"destination should converge to source state (count=%d sum=%d), got count=%d sum=%d",
+		wantCount, wantSum, liveCount(), liveSum())
+
+	// 4. Slot confirmed_flush_lsn advanced (data was confirmed durable).
+	require.Eventually(t, func() bool {
+		return confirmedFlushLSN(t, ctx, srcPool) > confirmedBefore
+	}, 30*time.Second, 500*time.Millisecond, "confirmed_flush_lsn should advance after flushes")
+
+	// 5. Graceful shutdown: cancellation is the normal exit.
+	cancelStream()
+	select {
+	case err := <-runErr:
+		// Run returns ctx.Err() (context.Canceled) on cancellation; the CLI maps
+		// that to a clean exit. Either nil or context.Canceled is acceptable.
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30s of cancellation")
+	}
+
+	// Final state is intact after shutdown.
+	assert.Equal(t, wantCount, liveCount())
+	assert.Equal(t, wantSum, liveSum())
+}
+
+// TestPostgresCDC_StreamingResume verifies a restarted stream resumes from the
+// destination's max LSN without re-snapshotting and without losing changes
+// made while it was down.
+func TestPostgresCDC_StreamingResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.r (id BIGINT PRIMARY KEY, val BIGINT);
+		INSERT INTO public.r SELECT g, g FROM generate_series(1, 100) g;
+		CREATE PUBLICATION resume_pub FOR TABLE public.r;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=resume_pub"
+	cfg := &config.IngestConfig{
+		SourceURI:           cdcSourceURI,
+		DestURI:             destConnString,
+		IncrementalStrategy: config.StrategyMerge,
+		Stream:              true,
+		FlushInterval:       1 * time.Second,
+		FlushRecords:        100,
+		Progress:            config.ProgressLog,
+	}
+
+	liveCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM public.r WHERE _cdc_deleted = false`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	// First run: snapshot + one change, then stop.
+	ctx1, cancel1 := context.WithCancel(ctx)
+	run1 := make(chan error, 1)
+	go func() { run1 <- pipeline.New(cfg).Run(ctx1) }()
+
+	require.Eventually(t, func() bool { return liveCount() == 100 }, 60*time.Second, 500*time.Millisecond)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.r SELECT g, g FROM generate_series(101, 150) g`)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return liveCount() == 150 }, 30*time.Second, 500*time.Millisecond)
+	cancel1()
+	<-run1
+
+	// Changes made while the stream is down.
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.r SELECT g, g FROM generate_series(151, 200) g`)
+	require.NoError(t, err)
+
+	// Second run: must resume (no full re-snapshot) and pick up the gap.
+	ctx2, cancel2 := context.WithCancel(ctx)
+	run2 := make(chan error, 1)
+	go func() { run2 <- pipeline.New(cfg).Run(ctx2) }()
+
+	require.Eventually(t, func() bool { return liveCount() == 200 }, 60*time.Second, 500*time.Millisecond,
+		"resumed stream should reach 200 rows")
+	cancel2()
+	<-run2
+}
+
+func confirmedFlushLSN(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uint64 {
+	t.Helper()
+	var lsnText string
+	err := pool.QueryRow(ctx, `
+		SELECT COALESCE(confirmed_flush_lsn::text, '0/0')
+		FROM pg_replication_slots
+		WHERE slot_name LIKE 'ingestr_%'
+		LIMIT 1
+	`).Scan(&lsnText)
+	if err != nil {
+		return 0
+	}
+	var hi, lo uint64
+	if _, err := fmt.Sscanf(lsnText, "%X/%X", &hi, &lo); err != nil {
+		return 0
+	}
+	return hi<<32 | lo
+}

--- a/tests/integration/streaming_kafka_test.go
+++ b/tests/integration/streaming_kafka_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/kafka"
+	"github.com/jackc/pgx/v5/pgxpool"
+	kafkago "github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestKafka_Streaming verifies continuous (--stream) ingestion from a Kafka
+// topic: messages produced before and during the stream are appended under the
+// msg_id+data envelope, offsets are committed only after a flush (a second run
+// in the same group reads nothing new), and the stream exits on cancellation.
+func TestKafka_Streaming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	rp, err := redpanda.Run(ctx, "redpandadata/redpanda:v24.2.7")
+	require.NoError(t, err)
+	defer func() { _ = rp.Terminate(ctx) }()
+
+	broker, err := rp.KafkaSeedBroker(ctx)
+	require.NoError(t, err)
+
+	topic := fmt.Sprintf("evt_%d", time.Now().UnixNano())
+	groupID := "ingestr_test_group"
+	ensureKafkaTopic(t, broker, topic)
+	produceKafka(t, broker, topic, 1, 50)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	sourceURI := fmt.Sprintf("kafka://?bootstrap_servers=%s&group_id=%s", broker, groupID)
+	cfg := &config.IngestConfig{
+		SourceURI:     sourceURI,
+		SourceTable:   topic,
+		DestURI:       destConnString,
+		DestTable:     "public.events",
+		Stream:        true,
+		FlushInterval: 1 * time.Second,
+		FlushRecords:  20,
+		Progress:      config.ProgressLog,
+	}
+
+	rowCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM public.events`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return rowCount() == 50
+	}, 90*time.Second, 500*time.Millisecond, "50 pre-produced messages should be ingested")
+
+	// Envelope schema.
+	var cols int
+	require.NoError(t, destPool.QueryRow(ctx,
+		`SELECT count(*) FROM information_schema.columns WHERE table_name='events' AND column_name IN ('msg_id','data')`).Scan(&cols))
+	assert.Equal(t, 2, cols, "envelope should have msg_id and data columns")
+
+	// Produce more while streaming.
+	produceKafka(t, broker, topic, 51, 30)
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return rowCount() == 80
+	}, 90*time.Second, 500*time.Millisecond, "messages produced during streaming should be ingested")
+
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30s of cancellation")
+	}
+
+	// Offsets were committed after flush: a second run in the same group reads
+	// nothing new (merge would dedup anyway, so assert the count is unchanged).
+	before := rowCount()
+	ctx2, cancel2 := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel2()
+	_ = pipeline.New(cfg).Run(ctx2)
+	assert.Equal(t, before, rowCount(), "committed offsets should prevent reprocessing")
+}
+
+func ensureKafkaTopic(t *testing.T, broker, topic string) {
+	t.Helper()
+	conn, err := kafkago.Dial("tcp", broker)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	controller, err := conn.Controller()
+	require.NoError(t, err)
+	ctrlConn, err := kafkago.Dial("tcp", net.JoinHostPort(controller.Host, strconv.Itoa(controller.Port)))
+	require.NoError(t, err)
+	defer func() { _ = ctrlConn.Close() }()
+
+	err = ctrlConn.CreateTopics(kafkago.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1})
+	require.NoError(t, err)
+
+	// Wait until the topic's partition leader is available.
+	require.Eventually(t, func() bool {
+		parts, err := conn.ReadPartitions(topic)
+		return err == nil && len(parts) == 1 && parts[0].Leader.Host != ""
+	}, 30*time.Second, 500*time.Millisecond, "topic %s should become available", topic)
+}
+
+func produceKafka(t *testing.T, broker, topic string, startID, count int) {
+	t.Helper()
+	w := &kafkago.Writer{
+		Addr:                   kafkago.TCP(broker),
+		Topic:                  topic,
+		Balancer:               &kafkago.LeastBytes{},
+		AllowAutoTopicCreation: true,
+	}
+	defer func() { _ = w.Close() }()
+
+	msgs := make([]kafkago.Message, count)
+	for i := 0; i < count; i++ {
+		id := startID + i
+		msgs[i] = kafkago.Message{
+			Key:   []byte(fmt.Sprintf("k-%d", id)),
+			Value: []byte(fmt.Sprintf(`{"seq":%d}`, id)),
+		}
+	}
+	// Retry briefly: auto topic creation can lag on first write.
+	var err error
+	for attempt := 0; attempt < 10; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err = w.WriteMessages(ctx, msgs...)
+		cancel()
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "Unknown Topic") && !strings.Contains(err.Error(), "Leader Not Available") {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	require.NoError(t, err)
+	t.Logf("produced %d messages (ids %d..%d) to topic %s", count, startID, startID+count-1, topic)
+}

--- a/tests/integration/streaming_mssql_cdc_test.go
+++ b/tests/integration/streaming_mssql_cdc_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestMSSQLCDC_Streaming verifies continuous (--stream) ingestion from SQL
+// Server CDC: an initial snapshot followed by live insert/update/delete changes
+// merged into the destination via the polling stream, plus a clean shutdown on
+// cancellation. SQL Server's capture job harvests changes every few seconds, so
+// the assertions use generous timeouts.
+func TestMSSQLCDC_Streaming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+	createMSSQLCDCItemsTable(t, ctx, db)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 3)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	cfg := &config.IngestConfig{
+		SourceURI:     mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"poll_interval": "1s"}),
+		SourceTable:   "dbo.items",
+		DestURI:       destConnString,
+		DestTable:     "public.items",
+		Stream:        true,
+		FlushInterval: 1 * time.Second,
+		FlushRecords:  50,
+		Progress:      config.ProgressLog,
+	}
+
+	count := func(where string) int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM public.items WHERE `+where).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	// Snapshot of 3 rows lands.
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return count("_cdc_deleted = false") == 3
+	}, 90*time.Second, time.Second, "snapshot of 3 rows should land")
+
+	// Live changes.
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (4, N'item4', 400)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET value = 150 WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 2`)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return count("_cdc_deleted = false") == 3 && // 3 + insert(4) - delete(2)
+			count("id = 1 AND value = 150 AND _cdc_deleted = false") == 1 &&
+			count("id = 2 AND _cdc_deleted = true") == 1 &&
+			count("id = 4 AND value = 400 AND _cdc_deleted = false") == 1
+	}, 120*time.Second, time.Second, "live insert/update/delete should be merged")
+
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30s of cancellation")
+	}
+
+	assert.Equal(t, 3, count("_cdc_deleted = false"))
+}

--- a/tests/integration/streaming_rabbitmq_test.go
+++ b/tests/integration/streaming_rabbitmq_test.go
@@ -132,6 +132,82 @@ func TestRabbitMQ_Streaming(t *testing.T) {
 	assert.Equal(t, before, rowCount(), "no messages should be redelivered after acknowledgment")
 }
 
+// TestRabbitMQ_StreamingShutdownFlushesPending verifies that cancelling a
+// stream that still has un-flushed buffered data exits cleanly and acks during
+// the final flush (regression test: the consumer channel must outlive its
+// goroutine so CommitStream can ack at shutdown).
+func TestRabbitMQ_StreamingShutdownFlushesPending(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	rmqURI := sharedRabbitMQURI(t)
+	queueName := fmt.Sprintf("stream_shutdown_%d", time.Now().UnixNano())
+	publishStreamMessages(t, rmqURI, queueName, 1, 40)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"), postgres.WithUsername("destuser"), postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	rowCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM public.events`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	// Long interval + high record cap so nothing flushes until shutdown.
+	cfg := &config.IngestConfig{
+		SourceURI: rmqURI, SourceTable: queueName, DestURI: destConnString, DestTable: "public.events",
+		Stream: true, FlushInterval: 60 * time.Second, FlushRecords: 1_000_000, Progress: config.ProgressLog,
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	// Let the consumer drain the queue into its buffer (un-acked, un-flushed).
+	require.Eventually(t, func() bool { return queueDepth(t, rmqURI, queueName) == 0 }, 30*time.Second, 500*time.Millisecond,
+		"messages should be consumed into the buffer")
+	time.Sleep(2 * time.Second)
+	require.Equal(t, 0, rowCount(), "no flush should have happened yet (long interval)")
+
+	// Cancel with data still buffered: the final flush must write and ack.
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled, "shutdown with pending data must exit cleanly, not error on commit")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("pipeline did not exit within 30s of cancellation")
+	}
+
+	assert.Equal(t, 40, rowCount(), "final flush should have written all buffered messages")
+	require.Eventually(t, func() bool { return queueDepth(t, rmqURI, queueName) == 0 }, 15*time.Second, 500*time.Millisecond,
+		"queue must stay drained — the final flush acked the messages")
+
+	// No redelivery on a fresh run: confirms the shutdown ack actually committed.
+	ctx2, cancel2 := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel2()
+	_ = pipeline.New(cfg).Run(ctx2)
+	assert.Equal(t, 40, rowCount(), "no messages should be redelivered after the shutdown ack")
+}
+
 // publishStreamMessages publishes count messages with unique, sequential
 // message IDs starting at startID (msg-<startID>..msg-<startID+count-1>).
 func publishStreamMessages(t *testing.T, uri, queueName string, startID, count int) {

--- a/tests/integration/streaming_rabbitmq_test.go
+++ b/tests/integration/streaming_rabbitmq_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/rabbitmq"
+	"github.com/jackc/pgx/v5/pgxpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestRabbitMQ_Streaming verifies continuous (--stream) ingestion from a queue:
+// messages published before and during the stream are appended to the
+// destination under the fixed msg_id+data envelope schema, deliveries are
+// acked only after a flush (queue drains, no redelivery on a second run), and
+// the stream exits cleanly on cancellation.
+func TestRabbitMQ_Streaming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	rmqURI := sharedRabbitMQURI(t)
+
+	queueName := fmt.Sprintf("stream_queue_%d", time.Now().UnixNano())
+	// Unique message IDs across batches (real brokers assign unique ids).
+	publishStreamMessages(t, rmqURI, queueName, 1, 50)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	cfg := &config.IngestConfig{
+		SourceURI:     rmqURI,
+		SourceTable:   queueName,
+		DestURI:       destConnString,
+		DestTable:     "public.events",
+		Stream:        true,
+		FlushInterval: 1 * time.Second,
+		FlushRecords:  20,
+		Progress:      config.ProgressLog,
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	rowCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM public.events`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	// First 50 messages land.
+	require.Eventually(t, func() bool { return rowCount() == 50 }, 60*time.Second, 500*time.Millisecond,
+		"50 pre-published messages should be appended")
+
+	// Envelope schema: msg_id (PK) + data columns.
+	cols := map[string]bool{}
+	rows, err := destPool.Query(ctx, `SELECT column_name FROM information_schema.columns WHERE table_name='events'`)
+	require.NoError(t, err)
+	for rows.Next() {
+		var c string
+		require.NoError(t, rows.Scan(&c))
+		cols[c] = true
+	}
+	rows.Close()
+	assert.True(t, cols["msg_id"], "envelope should have msg_id column")
+	assert.True(t, cols["data"], "envelope should have data column")
+
+	// 30 more published while streaming, with fresh unique ids.
+	publishStreamMessages(t, rmqURI, queueName, 51, 30)
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return rowCount() == 80
+	}, 60*time.Second, 500*time.Millisecond,
+		"messages published during streaming should also be appended")
+
+	// Graceful shutdown.
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30s of cancellation")
+	}
+
+	// Ack-after-flush: the queue should be drained (all acked).
+	require.Eventually(t, func() bool { return queueDepth(t, rmqURI, queueName) == 0 }, 15*time.Second, 500*time.Millisecond,
+		"queue should be empty after acked flushes")
+
+	// No redelivery: a second short run appends nothing.
+	before := rowCount()
+	ctx2, cancel2 := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel2()
+	_ = pipeline.New(cfg).Run(ctx2)
+	assert.Equal(t, before, rowCount(), "no messages should be redelivered after acknowledgment")
+}
+
+// publishStreamMessages publishes count messages with unique, sequential
+// message IDs starting at startID (msg-<startID>..msg-<startID+count-1>).
+func publishStreamMessages(t *testing.T, uri, queueName string, startID, count int) {
+	t.Helper()
+	conn, err := amqp.Dial(uri)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	ch, err := conn.Channel()
+	require.NoError(t, err)
+	defer func() { _ = ch.Close() }()
+	_, err = ch.QueueDeclare(queueName, false, false, false, false, nil)
+	require.NoError(t, err)
+	for i := 0; i < count; i++ {
+		id := startID + i
+		err = ch.PublishWithContext(context.Background(), "", queueName, false, false, amqp.Publishing{
+			ContentType: "application/json",
+			Body:        []byte(fmt.Sprintf(`{"seq":%d}`, id)),
+			MessageId:   fmt.Sprintf("msg-%d", id),
+			Timestamp:   time.Now(),
+		})
+		require.NoError(t, err)
+	}
+	t.Logf("published %d messages (ids %d..%d) to %s", count, startID, startID+count-1, queueName)
+}
+
+func queueDepth(t *testing.T, uri, queue string) int {
+	t.Helper()
+	conn, err := amqp.Dial(uri)
+	if err != nil {
+		return -1
+	}
+	defer func() { _ = conn.Close() }()
+	ch, err := conn.Channel()
+	if err != nil {
+		return -1
+	}
+	defer func() { _ = ch.Close() }()
+	q, err := ch.QueueDeclarePassive(queue, false, false, false, false, nil)
+	if err != nil {
+		return -1
+	}
+	return q.Messages
+}


### PR DESCRIPTION
## What

Adds a first-class `--stream` flag that turns one-shot `ingest` into a long-running flush loop. Supported by CDC sources (`postgres+cdc`, `mssql+cdc`) and message brokers (`kafka`, `amqp`). Records are buffered and flushed to the destination whenever `--flush-interval` (default `30s`) **or** `--flush-records` (default `50000`) is reached — whichever comes first — until interrupted (SIGINT/SIGTERM), which triggers a final flush and clean exit.

## How it works

- **Capability interfaces** (`pkg/source/source.go`): `StreamingSource` gates the flag and picks the default strategy; `StreamCommitter` provides durability feedback. `RecordBatchResult` gains a cumulative `CommitToken`; `ReadOptions`/`TableRequest` gain `Streaming`.
- **Streaming executor** (`pkg/strategy/streaming.go`): buffers Arrow batches per table and runs each cycle as `write → merge → reset-staging → commit`. This ordering gives **at-least-once** delivery — a crash before commit re-delivers, and the merge (by PK / `msg_id`) makes replays idempotent. Memory is bounded by `--flush-records`.
- **Durability:** Postgres CDC confirms the replication-slot LSN only after a flush+merge; RabbitMQ acks and Kafka commits group offsets only after a flush. MSSQL CDC resumes from the destination's `max(_cdc_lsn)` (no consumer ack concept).
- **Brokers** stream into a fixed envelope: `msg_id` (PK) + JSON `data` + `_ingestr_order` (Kafka offset / AMQP delivery tag). Merged on `msg_id` with last-value-per-key ordering within each flush window. Append mode does not enforce the PK (so at-least-once redeliveries don't crash on duplicate keys).

## Bugs fixed during validation

- **Multi-table CDC boundary data loss:** the per-table filter used `changeLSN <= processedLSN`, dropping the first transaction whose BEGIN LSN equals the snapshot consistent-point (it is *not* in the snapshot). Changed to strict `<` (safe on resume — merge is idempotent).
- **Replication read stall:** a 100ms per-call `ReceiveMessage` deadline churned the connection and raced pgconn's background reader, wedging the stream after the first flush under load. Raised to 1s and added dead-connection detection (fatal standby-send failure + a 2-minute liveness timeout) so a broken connection errors out for a supervisor to restart instead of hanging silently.

## Testing

- Unit tests: flush loop (count/interval triggers, empty-cycle skip, commit ordering, abort, graceful shutdown, routing, truncate fallback, append-no-PK, incremental-key ordering), `safeCommitLSN`, commit-state, config validation.
- Integration tests (`//go:build integration`): Postgres CDC streaming + resume, RabbitMQ, Kafka (adds a Redpanda testcontainer), MSSQL CDC.
- Manually validated end-to-end: 10M+ messages Kafka→Postgres with exact counts, bounded memory, and clean shutdown.

## Notes for reviewers

- The 100ms→1s receive timeout also applies to the existing **batch-mode** CDC path (idle-poll cadence only; batch tests pass) — intentional, it's strictly less wasteful.
- New dependency `testcontainers-go/modules/redpanda` is **test-only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)