### PR TITLE
Handle duplicate BigQuery query jobs

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -996,7 +996,15 @@ func (d *BigQueryDestination) runQueryJobWithRetryAttempts(ctx context.Context, 
 			if isBigQueryDuplicateJobError(err) {
 				recoveredJob, recoverErr := d.recoverDuplicateQueryJob(ctx, jobID, annotatedSQL)
 				if recoverErr != nil {
-					return nil, fmt.Errorf("failed to recover duplicate %s job %s: %w", opLabel, jobID, recoverErr)
+					lastErr = fmt.Errorf("failed to recover duplicate %s job %s: %w", opLabel, jobID, recoverErr)
+					if attempt < maxAttempts {
+						config.Debug("[%s] Retrying after duplicate recovery error: %v", opLabel, lastErr)
+						if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(attempt, recoverErr)); sleepErr != nil {
+							return nil, sleepErr
+						}
+						continue
+					}
+					return nil, lastErr
 				}
 				config.Debug("[%s] Recovered duplicate job insert as existing job %s", opLabel, jobRef(recoveredJob))
 				job = recoveredJob
@@ -1071,9 +1079,22 @@ func validateRecoveredQueryJob(job *bigquery.Job, sql string) error {
 		return fmt.Errorf("existing job is %T, not a query job", cfg)
 	}
 	if queryCfg.Q != sql {
-		return errors.New("existing job SQL does not match retried query")
+		return fmt.Errorf(
+			"existing job SQL does not match retried query (existing=%q expected=%q)",
+			queryJobSQLSnippet(queryCfg.Q),
+			queryJobSQLSnippet(sql),
+		)
 	}
 	return nil
+}
+
+func queryJobSQLSnippet(sql string) string {
+	const limit = 256
+	runes := []rune(strings.TrimSpace(sql))
+	if len(runes) <= limit {
+		return string(runes)
+	}
+	return string(runes[:limit]) + "..."
 }
 
 func newBigQueryQueryJobID() string {

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -2,9 +2,12 @@ package bigquery
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -18,6 +21,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -978,22 +982,35 @@ func (d *BigQueryDestination) runQueryJobWithRetryAttempts(ctx context.Context, 
 		lastErr error
 	)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		query := d.client.Query(annotation.Prepend(ctx, sql))
+		annotatedSQL := annotation.Prepend(ctx, sql)
+		jobID := newBigQueryQueryJobID()
+		query := d.client.Query(annotatedSQL)
+		query.JobID = jobID
+		query.ProjectID = d.projectID
 		if d.location != "" {
 			query.Location = d.location
 		}
 
 		job, err := query.Run(ctx)
 		if err != nil {
-			if attempt < maxAttempts && isRetryableLoadJobError(err) {
-				lastErr = err
-				config.Debug("[%s] Retrying after start error: %v", opLabel, err)
-				if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(attempt, err)); sleepErr != nil {
-					return nil, sleepErr
+			if isBigQueryDuplicateJobError(err) {
+				recoveredJob, recoverErr := d.recoverDuplicateQueryJob(ctx, jobID, annotatedSQL)
+				if recoverErr != nil {
+					return nil, fmt.Errorf("failed to recover duplicate %s job %s: %w", opLabel, jobID, recoverErr)
 				}
-				continue
+				config.Debug("[%s] Recovered duplicate job insert as existing job %s", opLabel, jobRef(recoveredJob))
+				job = recoveredJob
+			} else {
+				if attempt < maxAttempts && isRetryableLoadJobError(err) {
+					lastErr = err
+					config.Debug("[%s] Retrying after start error: %v", opLabel, err)
+					if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(attempt, err)); sleepErr != nil {
+						return nil, sleepErr
+					}
+					continue
+				}
+				return nil, err
 			}
-			return nil, err
 		}
 		lastJob = job
 
@@ -1031,6 +1048,68 @@ func (d *BigQueryDestination) runQueryJobWithRetryAttempts(ctx context.Context, 
 		return lastJob, lastErr
 	}
 	return lastJob, fmt.Errorf("%s job exhausted retries", opLabel)
+}
+
+func (d *BigQueryDestination) recoverDuplicateQueryJob(ctx context.Context, jobID, sql string) (*bigquery.Job, error) {
+	job, err := d.client.JobFromProject(ctx, d.projectID, jobID, d.location)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRecoveredQueryJob(job, sql); err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+func validateRecoveredQueryJob(job *bigquery.Job, sql string) error {
+	cfg, err := job.Config()
+	if err != nil {
+		return err
+	}
+	queryCfg, ok := cfg.(*bigquery.QueryConfig)
+	if !ok {
+		return fmt.Errorf("existing job is %T, not a query job", cfg)
+	}
+	if queryCfg.Q != sql {
+		return errors.New("existing job SQL does not match retried query")
+	}
+	return nil
+}
+
+func newBigQueryQueryJobID() string {
+	var b [16]byte
+	if _, err := cryptorand.Read(b[:]); err != nil {
+		return fmt.Sprintf("ingestr_%d", time.Now().UnixNano())
+	}
+	return "ingestr_" + hex.EncodeToString(b[:])
+}
+
+func isBigQueryDuplicateJobError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr != nil {
+		if apiErr.Code != http.StatusConflict {
+			return false
+		}
+		msg := strings.ToLower(apiErr.Message)
+		if strings.Contains(msg, "already exists: job") {
+			return true
+		}
+		for _, item := range apiErr.Errors {
+			if strings.EqualFold(item.Reason, "duplicate") && strings.Contains(strings.ToLower(item.Message), "job") {
+				return true
+			}
+		}
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "error 409") &&
+		strings.Contains(msg, "already exists: job") &&
+		strings.Contains(msg, "duplicate")
 }
 
 func isBigQueryAlterTypeRewriteCandidate(sql string, err error) bool {

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1078,7 +1078,7 @@ func validateRecoveredQueryJob(job *bigquery.Job, sql string) error {
 	if !ok {
 		return fmt.Errorf("existing job is %T, not a query job", cfg)
 	}
-	if queryCfg.Q != sql {
+	if !queryJobSQLMatches(queryCfg.Q, sql) {
 		return fmt.Errorf(
 			"existing job SQL does not match retried query (existing=%q expected=%q)",
 			queryJobSQLSnippet(queryCfg.Q),
@@ -1086,6 +1086,25 @@ func validateRecoveredQueryJob(job *bigquery.Job, sql string) error {
 		)
 	}
 	return nil
+}
+
+func queryJobSQLMatches(existing, expected string) bool {
+	if existing == expected {
+		return true
+	}
+	return stripLeadingQueryAnnotation(existing) == stripLeadingQueryAnnotation(expected)
+}
+
+func stripLeadingQueryAnnotation(sql string) string {
+	trimmed := strings.TrimLeft(sql, " \t\r\n")
+	if !strings.HasPrefix(trimmed, "-- @bruin.config: ") {
+		return sql
+	}
+	_, rest, ok := strings.Cut(trimmed, "\n")
+	if !ok {
+		return sql
+	}
+	return rest
 }
 
 func queryJobSQLSnippet(sql string) string {

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -229,6 +229,186 @@ func TestRunQueryJobWithRetryRecoversDuplicateJobInsert(t *testing.T) {
 	}
 }
 
+func TestRunQueryJobWithRetryUsesRemainingAttemptsAfterDuplicateRecoveryFailure(t *testing.T) {
+	ctx := context.Background()
+	const sql = "SELECT 1"
+
+	var insertCalls int
+	var jobGetCalls int
+	var queryResultsCalls int
+	var gotJobID string
+	var gotSQL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/projects/test-project/jobs"):
+			insertCalls++
+			var req struct {
+				JobReference struct {
+					JobID string `json:"jobId"`
+				} `json:"jobReference"`
+				Configuration struct {
+					Query struct {
+						Query string `json:"query"`
+					} `json:"query"`
+				} `json:"configuration"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			gotJobID = req.JobReference.JobID
+			gotSQL = req.Configuration.Query.Query
+
+			if insertCalls == 1 {
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    http.StatusConflict,
+						"message": fmt.Sprintf("Already Exists: Job test-project:US.%s", gotJobID),
+						"errors": []map[string]string{
+							{
+								"domain":  "global",
+								"message": fmt.Sprintf("Already Exists: Job test-project:US.%s", gotJobID),
+								"reason":  "duplicate",
+							},
+						},
+					},
+				})
+				return
+			}
+
+			writeBigQueryTestJob(w, gotJobID, gotSQL)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/test-project/jobs/"):
+			jobGetCalls++
+			if jobGetCalls == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    http.StatusNotFound,
+						"message": "Not found: Job",
+					},
+				})
+				return
+			}
+			writeBigQueryTestJob(w, gotJobID, gotSQL)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/test-project/queries/"):
+			queryResultsCalls++
+			writeBigQueryTestQueryResults(w, gotJobID)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := bigquery.NewClient(ctx, "test-project", option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	dest := &BigQueryDestination{
+		client:    client,
+		projectID: "test-project",
+		location:  "US",
+	}
+
+	job, err := dest.runQueryJobWithRetryAttempts(ctx, sql, "MERGE", 2)
+	if err != nil {
+		t.Fatalf("runQueryJobWithRetryAttempts() error = %v", err)
+	}
+	if job == nil {
+		t.Fatal("runQueryJobWithRetryAttempts() returned nil job")
+	}
+	if insertCalls != 2 {
+		t.Fatalf("insertCalls = %d, want 2", insertCalls)
+	}
+	if jobGetCalls != 2 {
+		t.Fatalf("jobGetCalls = %d, want 2", jobGetCalls)
+	}
+	if queryResultsCalls != 1 {
+		t.Fatalf("queryResultsCalls = %d, want 1", queryResultsCalls)
+	}
+}
+
+func TestRecoverDuplicateQueryJobReportsSQLMismatch(t *testing.T) {
+	ctx := context.Background()
+	const expectedSQL = "SELECT 1"
+	const existingSQL = "SELECT 2"
+	const jobID = "ingestr_test"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/test-project/jobs/") {
+			writeBigQueryTestJob(w, jobID, existingSQL)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, err := bigquery.NewClient(ctx, "test-project", option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	dest := &BigQueryDestination{
+		client:    client,
+		projectID: "test-project",
+		location:  "US",
+	}
+
+	_, err = dest.recoverDuplicateQueryJob(ctx, jobID, expectedSQL)
+	if err == nil {
+		t.Fatal("recoverDuplicateQueryJob() error = nil, want mismatch")
+	}
+	if !strings.Contains(err.Error(), `existing="SELECT 2"`) || !strings.Contains(err.Error(), `expected="SELECT 1"`) {
+		t.Fatalf("recoverDuplicateQueryJob() error = %q, want existing and expected SQL snippets", err)
+	}
+}
+
+func writeBigQueryTestJob(w http.ResponseWriter, jobID, sql string) {
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jobReference": map[string]string{
+			"projectId": "test-project",
+			"jobId":     jobID,
+			"location":  "US",
+		},
+		"configuration": map[string]interface{}{
+			"query": map[string]interface{}{
+				"query":        sql,
+				"useLegacySql": false,
+			},
+		},
+		"status": map[string]string{
+			"state": "DONE",
+		},
+		"statistics": map[string]interface{}{
+			"query": map[string]string{
+				"statementType": "SELECT",
+			},
+		},
+	})
+}
+
+func writeBigQueryTestQueryResults(w http.ResponseWriter, jobID string) {
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jobReference": map[string]string{
+			"projectId": "test-project",
+			"jobId":     jobID,
+			"location":  "US",
+		},
+		"jobComplete": true,
+		"totalRows":   "0",
+		"schema": map[string]interface{}{
+			"fields": []interface{}{},
+		},
+	})
+}
+
 func TestIsBigQueryDuplicateJobError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -370,6 +370,43 @@ func TestRecoverDuplicateQueryJobReportsSQLMismatch(t *testing.T) {
 	}
 }
 
+func TestRecoverDuplicateQueryJobAllowsDifferentAnnotation(t *testing.T) {
+	ctx := context.Background()
+	const expectedSQL = "-- @bruin.config: {\"request_id\":\"expected\"}\nSELECT 1"
+	const existingSQL = "-- @bruin.config: {\"request_id\":\"existing\"}\nSELECT 1"
+	const jobID = "ingestr_test"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/test-project/jobs/") {
+			writeBigQueryTestJob(w, jobID, existingSQL)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, err := bigquery.NewClient(ctx, "test-project", option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	dest := &BigQueryDestination{
+		client:    client,
+		projectID: "test-project",
+		location:  "US",
+	}
+
+	job, err := dest.recoverDuplicateQueryJob(ctx, jobID, expectedSQL)
+	if err != nil {
+		t.Fatalf("recoverDuplicateQueryJob() error = %v", err)
+	}
+	if job == nil {
+		t.Fatal("recoverDuplicateQueryJob() returned nil job")
+	}
+}
+
 func writeBigQueryTestJob(w http.ResponseWriter, jobID, sql string) {
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"jobReference": map[string]string{

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +20,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 func duckdbCompatible(sql string) string {
@@ -89,6 +94,179 @@ func TestNewBigQueryDestination(t *testing.T) {
 	dest := NewBigQueryDestination()
 	if dest == nil {
 		t.Fatal("NewBigQueryDestination returned nil")
+	}
+}
+
+func TestRunQueryJobWithRetryRecoversDuplicateJobInsert(t *testing.T) {
+	ctx := context.Background()
+	const sql = "SELECT 1"
+
+	var insertCalls int
+	var jobGetCalls int
+	var queryResultsCalls int
+	var gotJobID string
+	var gotSQL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/projects/test-project/jobs"):
+			insertCalls++
+			var req struct {
+				JobReference struct {
+					ProjectID string `json:"projectId"`
+					JobID     string `json:"jobId"`
+					Location  string `json:"location"`
+				} `json:"jobReference"`
+				Configuration struct {
+					Query struct {
+						Query string `json:"query"`
+					} `json:"query"`
+				} `json:"configuration"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			gotJobID = req.JobReference.JobID
+			gotSQL = req.Configuration.Query.Query
+
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error": map[string]interface{}{
+					"code":    http.StatusConflict,
+					"message": fmt.Sprintf("Already Exists: Job test-project:US.%s", gotJobID),
+					"status":  "ALREADY_EXISTS",
+					"errors": []map[string]string{
+						{
+							"domain":  "global",
+							"message": fmt.Sprintf("Already Exists: Job test-project:US.%s", gotJobID),
+							"reason":  "duplicate",
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/test-project/jobs/"):
+			jobGetCalls++
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jobReference": map[string]string{
+					"projectId": "test-project",
+					"jobId":     gotJobID,
+					"location":  "US",
+				},
+				"configuration": map[string]interface{}{
+					"query": map[string]interface{}{
+						"query":        gotSQL,
+						"useLegacySql": false,
+					},
+				},
+				"status": map[string]string{
+					"state": "DONE",
+				},
+				"statistics": map[string]interface{}{
+					"query": map[string]string{
+						"statementType": "SELECT",
+					},
+				},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/test-project/queries/"):
+			queryResultsCalls++
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jobReference": map[string]string{
+					"projectId": "test-project",
+					"jobId":     gotJobID,
+					"location":  "US",
+				},
+				"jobComplete": true,
+				"totalRows":   "0",
+				"schema": map[string]interface{}{
+					"fields": []interface{}{},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := bigquery.NewClient(ctx, "test-project", option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	dest := &BigQueryDestination{
+		client:    client,
+		projectID: "test-project",
+		location:  "US",
+	}
+
+	job, err := dest.runQueryJobWithRetryAttempts(ctx, sql, "MERGE", 1)
+	if err != nil {
+		t.Fatalf("runQueryJobWithRetryAttempts() error = %v", err)
+	}
+	if job == nil {
+		t.Fatal("runQueryJobWithRetryAttempts() returned nil job")
+	}
+	if job.ID() != gotJobID {
+		t.Fatalf("job.ID() = %q, want %q", job.ID(), gotJobID)
+	}
+	if !strings.HasPrefix(gotJobID, "ingestr_") {
+		t.Fatalf("job ID = %q, want ingestr_ prefix", gotJobID)
+	}
+	if !strings.Contains(gotSQL, sql) {
+		t.Fatalf("submitted SQL = %q, want it to contain %q", gotSQL, sql)
+	}
+	if insertCalls != 1 {
+		t.Fatalf("insertCalls = %d, want 1", insertCalls)
+	}
+	if jobGetCalls == 0 {
+		t.Fatal("expected duplicate recovery to fetch the existing job")
+	}
+	if queryResultsCalls != 1 {
+		t.Fatalf("queryResultsCalls = %d, want 1", queryResultsCalls)
+	}
+}
+
+func TestIsBigQueryDuplicateJobError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "googleapi duplicate job",
+			err: &googleapi.Error{
+				Code:    http.StatusConflict,
+				Message: "Already Exists: Job test:US.job",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "duplicate", Message: "Already Exists: Job test:US.job"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "string duplicate job",
+			err:  errors.New("googleapi: Error 409: Already Exists: Job bruin-internal-dwh:US.w61mnz2N9xQMtY2nzHLeEotitcQ, duplicate"),
+			want: true,
+		},
+		{
+			name: "table already exists is not duplicate job",
+			err: &googleapi.Error{
+				Code:    http.StatusConflict,
+				Message: "Already Exists: Table test.dataset.table",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBigQueryDuplicateJobError(tt.err); got != tt.want {
+				t.Fatalf("isBigQueryDuplicateJobError() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Recover BigQuery query jobs when `jobs.insert` returns a duplicate-job `409`.
- Generate ingestr-owned query job IDs so the destination can fetch and wait on the existing job.
- Add regression coverage for the duplicate insert recovery path and duplicate-job detection.

## Root Cause

BigQuery query job insertion is idempotent by job ID. If the initial insert succeeds but the client receives a retry/duplicate response, BigQuery can return `Already Exists: Job ... duplicate` even though the original job is valid and should be waited on.

## Validation

- `go test ./pkg/destination/bigquery`
- `make format`
- `make lint`
- `make test`
