### PR TITLE
Add Spark benchmark and optimize MSSQL writes

### DIFF
--- a/benchmarks/scenarios.yaml
+++ b/benchmarks/scenarios.yaml
@@ -181,3 +181,13 @@ tools:
       - destination_type: bigquery
       - destination_type: snowflake
       - destination_type: mssql
+
+  spark:
+    script: scripts/bench_spark.py
+    requires:
+      - uv
+      - java
+    skip:
+      - source_type: mongodb
+      - destination_type: bigquery
+      - destination_type: snowflake

--- a/benchmarks/scripts/bench_spark.py
+++ b/benchmarks/scripts/bench_spark.py
@@ -1,0 +1,277 @@
+# /// script
+# requires-python = ">=3.11,<3.12"
+# dependencies = [
+#     "pyspark>=3.5,<3.6",
+# ]
+# ///
+"""Single-node Spark ingestion benchmark."""
+
+import argparse
+import os
+import sys
+from urllib.parse import parse_qsl, urlencode, unquote, urlparse
+
+os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
+os.environ.setdefault("SPARK_LOCAL_IP", "127.0.0.1")
+
+from pyspark.sql import SparkSession
+
+
+JDBC_PACKAGES = {
+    "postgres": "org.postgresql:postgresql:42.7.3",
+    "mysql": "com.mysql:mysql-connector-j:8.4.0",
+    "mssql": "com.microsoft.sqlserver:mssql-jdbc:12.6.1.jre11",
+    "sqlserver": "com.microsoft.sqlserver:mssql-jdbc:12.6.1.jre11",
+    "duckdb": "org.duckdb:duckdb_jdbc:1.0.0",
+}
+
+DUCKDB_COLUMN_TYPES = (
+    "id INTEGER, "
+    "small_str STRING, "
+    "medium_str STRING, "
+    "large_str STRING, "
+    "tiny_int SMALLINT, "
+    "regular_int INTEGER, "
+    "big_int BIGINT, "
+    "float_val DOUBLE, "
+    "decimal_val DECIMAL(18,4), "
+    "bool_val BOOLEAN, "
+    "date_val DATE, "
+    "ts_val TIMESTAMP, "
+    "ts_tz_val TIMESTAMP, "
+    "json_val STRING, "
+    "extra_text STRING"
+)
+
+
+def int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if not value:
+        return default
+    return int(value)
+
+
+def default_partitions() -> int:
+    return max(os.cpu_count() or 1, 1)
+
+
+def required_packages(source_type: str, dest_type: str) -> str:
+    override = os.environ.get("BENCH_SPARK_JARS_PACKAGES")
+    if override is not None:
+        return override
+
+    packages = []
+    for db_type in (source_type, dest_type):
+        package = JDBC_PACKAGES.get(db_type)
+        if package and package not in packages:
+            packages.append(package)
+    return ",".join(packages)
+
+
+def query_string(params: dict[str, str]) -> str:
+    return urlencode({k: v for k, v in params.items() if v is not None})
+
+
+def parse_credentials(parsed) -> dict[str, str]:
+    credentials = {}
+    if parsed.username:
+        credentials["user"] = unquote(parsed.username)
+    if parsed.password:
+        credentials["password"] = unquote(parsed.password)
+    return credentials
+
+
+def postgres_config(uri: str) -> dict:
+    parsed = urlparse(uri.replace("postgres://", "postgresql://", 1))
+    database = parsed.path.lstrip("/")
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    url = f"jdbc:postgresql://{parsed.hostname}:{parsed.port or 5432}/{database}"
+    if params:
+        url += f"?{query_string(params)}"
+    return {
+        "url": url,
+        "driver": "org.postgresql.Driver",
+        "properties": parse_credentials(parsed),
+    }
+
+
+def mysql_config(uri: str) -> dict:
+    parsed = urlparse(uri)
+    database = parsed.path.lstrip("/")
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    params.setdefault("useSSL", "false")
+    params.setdefault("allowPublicKeyRetrieval", "true")
+    params.setdefault("useCursorFetch", "true")
+    url = f"jdbc:mysql://{parsed.hostname}:{parsed.port or 3306}/{database}"
+    if params:
+        url += f"?{query_string(params)}"
+    return {
+        "url": url,
+        "driver": "com.mysql.cj.jdbc.Driver",
+        "properties": parse_credentials(parsed),
+    }
+
+
+def mssql_config(uri: str) -> dict:
+    parsed = urlparse(uri.replace("sqlserver://", "mssql://", 1))
+    database = parsed.path.lstrip("/") or "master"
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    encrypt = params.pop("encrypt", params.pop("Encrypt", "false"))
+    if encrypt.lower() in ("disable", "false", "no", "0"):
+        encrypt = "false"
+
+    params.setdefault("encrypt", encrypt)
+    params.setdefault("trustServerCertificate", "true")
+    params.setdefault("databaseName", database)
+
+    props = [f"{key}={value}" for key, value in params.items()]
+    url = f"jdbc:sqlserver://{parsed.hostname}:{parsed.port or 1433};" + ";".join(props)
+    return {
+        "url": url,
+        "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        "properties": parse_credentials(parsed),
+    }
+
+
+def duckdb_path_from_uri(uri: str) -> str:
+    return uri.split("duckdb:///", 1)[1]
+
+
+def duckdb_config(uri: str) -> dict:
+    return {
+        "url": f"jdbc:duckdb:{duckdb_path_from_uri(uri)}",
+        "driver": "org.duckdb.DuckDBDriver",
+        "properties": {},
+    }
+
+
+def jdbc_config(db_type: str, uri: str) -> dict:
+    if db_type == "postgres":
+        return postgres_config(uri)
+    if db_type == "mysql":
+        return mysql_config(uri)
+    if db_type in ("mssql", "sqlserver"):
+        return mssql_config(uri)
+    if db_type == "duckdb":
+        return duckdb_config(uri)
+    raise ValueError(f"Unsupported Spark benchmark database type: {db_type}")
+
+
+def jdbc_options(config: dict, table: str) -> dict[str, str]:
+    options = {
+        "url": config["url"],
+        "dbtable": table,
+        "driver": config["driver"],
+    }
+    options.update(config["properties"])
+    return options
+
+
+def duckdb_source_table(table: str) -> str:
+    return (
+        "(SELECT "
+        "id, small_str, medium_str, large_str, tiny_int, "
+        "regular_int, big_int, float_val, decimal_val, bool_val, "
+        "date_val, ts_val, CAST(ts_tz_val AS TIMESTAMP) AS ts_tz_val, "
+        "json_val, extra_text "
+        f"FROM {table}) AS bench_source"
+    )
+
+
+def create_spark(source_type: str, dest_type: str) -> SparkSession:
+    partitions = str(int_env("BENCH_SPARK_SQL_SHUFFLE_PARTITIONS", default_partitions()))
+    builder = (
+        SparkSession.builder.appName("bench_spark_ingestion")
+        .master(os.environ.get("BENCH_SPARK_MASTER", "local[*]"))
+        .config("spark.ui.enabled", os.environ.get("BENCH_SPARK_UI", "false"))
+        .config("spark.driver.memory", os.environ.get("BENCH_SPARK_DRIVER_MEMORY", "4g"))
+        .config("spark.sql.shuffle.partitions", partitions)
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.driver.extraJavaOptions", "-Duser.timezone=UTC")
+        .config("spark.executor.extraJavaOptions", "-Duser.timezone=UTC")
+    )
+
+    packages = required_packages(source_type, dest_type)
+    if packages:
+        builder = builder.config("spark.jars.packages", packages)
+
+    return builder.getOrCreate()
+
+
+def read_source(spark: SparkSession, args) -> object:
+    config = jdbc_config(args.source_type, args.source_uri)
+    options = jdbc_options(config, args.source_table)
+    options["fetchsize"] = os.environ.get("BENCH_SPARK_FETCH_SIZE", "10000")
+
+    if args.source_type == "duckdb":
+        options["dbtable"] = duckdb_source_table(args.source_table)
+
+    if args.source_type in ("postgres", "mysql"):
+        options["customSchema"] = "json_val STRING"
+
+    rows = args.rows or int(os.environ.get("BENCH_ROWS") or "0")
+    partition_column = os.environ.get("BENCH_SPARK_PARTITION_COLUMN", "id")
+    if rows > 1 and partition_column:
+        options["partitionColumn"] = partition_column
+        options["lowerBound"] = os.environ.get("BENCH_SPARK_LOWER_BOUND", "1")
+        options["upperBound"] = str(rows)
+        options["numPartitions"] = os.environ.get(
+            "BENCH_SPARK_NUM_PARTITIONS",
+            str(default_partitions()),
+        )
+
+    return spark.read.format("jdbc").options(**options).load()
+
+
+def write_destination(df, args):
+    config = jdbc_config(args.dest_type, args.dest_uri)
+    options = jdbc_options(config, args.dest_table)
+    options["batchsize"] = os.environ.get("BENCH_SPARK_BATCH_SIZE", "10000")
+
+    output = df
+    if args.dest_type == "duckdb":
+        options["createTableColumnTypes"] = DUCKDB_COLUMN_TYPES
+        output = df.coalesce(1)
+
+    output.write.format("jdbc").mode("overwrite").options(**options).save()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-type", required=True)
+    parser.add_argument("--source-uri")
+    parser.add_argument("--source-uri-env")
+    parser.add_argument("--source-table", required=True)
+    parser.add_argument("--dest-type", required=True)
+    parser.add_argument("--dest-uri")
+    parser.add_argument("--dest-uri-env")
+    parser.add_argument("--dest-table", required=True)
+    parser.add_argument("--rows", type=int, default=0)
+    args = parser.parse_args()
+
+    if args.source_uri_env:
+        args.source_uri = os.environ.get(args.source_uri_env)
+    if args.dest_uri_env:
+        args.dest_uri = os.environ.get(args.dest_uri_env)
+    if not args.source_uri:
+        raise ValueError("--source-uri or --source-uri-env is required")
+    if not args.dest_uri:
+        raise ValueError("--dest-uri or --dest-uri-env is required")
+
+    return args
+
+
+def main():
+    args = parse_args()
+    spark = create_spark(args.source_type, args.dest_type)
+    spark.sparkContext.setLogLevel(os.environ.get("BENCH_SPARK_LOG_LEVEL", "ERROR"))
+    try:
+        df = read_source(spark, args)
+        write_destination(df, args)
+    finally:
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/scripts/check_tools.sh
+++ b/benchmarks/scripts/check_tools.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REQUIRED_TOOLS=("hyperfine" "docker" "psql" "duckdb")
-OPTIONAL_TOOLS=("uv" "sling")
+OPTIONAL_TOOLS=("uv" "sling" "java")
 
 errors=0
 for tool in "${REQUIRED_TOOLS[@]}"; do

--- a/benchmarks/scripts/runner.py
+++ b/benchmarks/scripts/runner.py
@@ -298,7 +298,9 @@ def check_tool_available(name: str, tool_cfg: dict) -> bool:
         return (PROJECT_ROOT / binary).exists()
     requires = tool_cfg.get("requires")
     if requires:
-        return shutil.which(requires) is not None
+        if isinstance(requires, str):
+            requires = [requires]
+        return all(shutil.which(tool) is not None for tool in requires)
     return True
 
 
@@ -406,6 +408,7 @@ def build_tool_command(
     dst_uri: str, dst_table: str,
     src_type: str, dst_type: str,
     src_cfg_name: str, dst_cfg_name: str,
+    rows: int | None = None,
 ) -> str:
     if tool_name == "gong":
         binary = PROJECT_ROOT / tool_cfg.get("binary", "bin/gong")
@@ -485,6 +488,20 @@ def build_tool_command(
             f" --source-table '{src_table}'"
             f" --dest-uri {shell_uri_arg(dst_uri)}"
             f" --dest-table '{dst_table}'"
+        )
+
+    if tool_name == "spark":
+        script = BENCH_DIR / tool_cfg.get("script", "scripts/bench_spark.py")
+        rows_arg = f" --rows {rows}" if rows else ""
+        return (
+            f"BENCH_ROWS={rows or ''} SPARK_LOCAL_IP=127.0.0.1 {uv_python_command(script, '3.11')}"
+            f" --source-type {shlex.quote(src_type)}"
+            f" {uri_option('--source-uri', src_uri)}"
+            f" --source-table '{src_table}'"
+            f" --dest-type {shlex.quote(dst_type)}"
+            f" {uri_option('--dest-uri', dst_uri)}"
+            f" --dest-table '{dst_table}'"
+            f"{rows_arg}"
         )
 
     raise ValueError(f"Unknown tool: {tool_name}")
@@ -649,6 +666,7 @@ def run_benchmarks(
                 dst["uri"], dst_table,
                 src["type"], dst["type"],
                 src_name, dst_name,
+                rows,
             )
             names.append(tool_name)
             cmds.append(cmd)
@@ -939,6 +957,7 @@ def run_tool_once(
     dst_uri: str, dst_table: str,
     src_type: str, dst_type: str,
     src_cfg_name: str, dst_cfg_name: str,
+    rows: int | None = None,
 ) -> int:
     cmd = build_tool_command(
         tool_name, tool_cfg,
@@ -946,6 +965,7 @@ def run_tool_once(
         dst_uri, dst_table,
         src_type, dst_type,
         src_cfg_name, dst_cfg_name,
+        rows,
     )
     result = subprocess.run(
         ["bash", "-c", cmd],
@@ -1014,6 +1034,7 @@ def run_validation(
                 dst["uri"], dst_table,
                 src["type"], dst["type"],
                 src_name, dst_name,
+                rows,
             )
 
             if rc != 0:
@@ -1315,6 +1336,8 @@ def main():
             available_tools.append(tool_name)
         else:
             req = tool_cfg.get("requires", tool_cfg.get("binary", "?"))
+            if isinstance(req, list):
+                req = ", ".join(req)
             console.print(f"  [dim]Tool '{tool_name}' skipped ({req} not found)[/dim]")
 
     if not available_tools:

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -227,15 +227,17 @@ func (d *MSSQLDestination) writeSerialBatches(ctx context.Context, records <-cha
 		}
 
 		totalRows += rows
-		rate := float64(rows) / time.Since(startBatch).Seconds()
+		batchDuration := time.Since(startBatch)
+		rate := rowsPerSecond(rows, batchDuration)
 		config.Debug("[MSSQL] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
-			batchNum, rows, time.Since(startBatch), rate, totalRows)
+			batchNum, rows, batchDuration, rate, totalRows)
 
 		result.Batch.Release()
 	}
 
-	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
-	config.Debug("[MSSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTime), totalRate)
+	totalDuration := time.Since(startTime)
+	totalRate := rowsPerSecond(totalRows, totalDuration)
+	config.Debug("[MSSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, totalDuration, totalRate)
 	return nil
 }
 
@@ -316,16 +318,24 @@ func (d *MSSQLDestination) writeParallelBatches(ctx context.Context, records <-c
 
 		totalRows += res.rows
 		config.Debug("[MSSQL] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
-			res.batchNum, res.rows, res.duration, float64(res.rows)/res.duration.Seconds(), totalRows)
+			res.batchNum, res.rows, res.duration, rowsPerSecond(res.rows, res.duration), totalRows)
 	}
 
 	if firstErr != nil {
 		return fmt.Errorf("parallel write failed: %w", firstErr)
 	}
 
-	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
-	config.Debug("[MSSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTime), totalRate)
+	totalDuration := time.Since(startTime)
+	totalRate := rowsPerSecond(totalRows, totalDuration)
+	config.Debug("[MSSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, totalDuration, totalRate)
 	return nil
+}
+
+func rowsPerSecond(rows int64, duration time.Duration) float64 {
+	if duration <= 0 {
+		return 0
+	}
+	return float64(rows) / duration.Seconds()
 }
 
 func (d *MSSQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string, tableSchema *schema.TableSchema) (int64, error) {
@@ -508,15 +518,12 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	startMerge := time.Now()
 
 	if len(opts.PrimaryKeys) > 0 && !destination.HasCDCDeletedColumn(opts.Columns) {
-		empty, err := d.tableIsEmpty(ctx, opts.TargetTable)
+		insertSQL := buildInsertDedupSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
+		inserted, err := d.insertIntoEmptyTarget(ctx, opts.TargetTable, opts.PrimaryKeys, insertSQL)
 		if err != nil {
-			return fmt.Errorf("failed to check target table before merge: %w", err)
+			return err
 		}
-		if empty {
-			insertSQL := buildInsertDedupSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
-			if err := d.insertIntoEmptyTarget(ctx, opts.TargetTable, opts.PrimaryKeys, insertSQL); err != nil {
-				return err
-			}
+		if inserted {
 			config.Debug("[MERGE] Deduplicated insert completed in %v", time.Since(startMerge))
 			return nil
 		}
@@ -534,10 +541,10 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	return nil
 }
 
-func (d *MSSQLDestination) tableIsEmpty(ctx context.Context, table string) (bool, error) {
-	query := fmt.Sprintf("SELECT TOP (1) 1 FROM %s", quoteTable(table))
+func tableIsEmptyForUpdate(ctx context.Context, tx *sql.Tx, table string) (bool, error) {
+	query := buildTableIsEmptyForUpdateSQL(table)
 	var v int
-	if err := d.db.QueryRowContext(ctx, query).Scan(&v); err != nil {
+	if err := tx.QueryRowContext(ctx, query).Scan(&v); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return true, nil
 		}
@@ -547,10 +554,14 @@ func (d *MSSQLDestination) tableIsEmpty(ctx context.Context, table string) (bool
 	return false, nil
 }
 
-func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTable string, primaryKeys []string, insertSQL string) error {
+func buildTableIsEmptyForUpdateSQL(table string) string {
+	return fmt.Sprintf("SELECT TOP (1) 1 FROM %s WITH (TABLOCKX, HOLDLOCK)", quoteTable(table))
+}
+
+func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTable string, primaryKeys []string, insertSQL string) (bool, error) {
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to begin deduplicated insert transaction: %w", err)
+		return false, fmt.Errorf("failed to begin deduplicated insert transaction: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -559,32 +570,40 @@ func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTabl
 		}
 	}()
 
+	empty, err := tableIsEmptyForUpdate(ctx, tx, targetTable)
+	if err != nil {
+		return false, fmt.Errorf("failed to check target table before merge: %w", err)
+	}
+	if !empty {
+		return false, nil
+	}
+
 	var pkName string
 	var droppedPK bool
 	if isNormalisedStagingTable(targetTable) {
 		pkName, droppedPK, err = dropPrimaryKeyIfExists(ctx, tx, targetTable)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	config.Debug("[MERGE] Empty target, executing deduplicated INSERT: %s", insertSQL)
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
 		config.LogFailedQuery(insertSQL, err)
-		return fmt.Errorf("failed to insert deduplicated records: %w", err)
+		return false, fmt.Errorf("failed to insert deduplicated records: %w", err)
 	}
 
 	if droppedPK {
 		if err := addPrimaryKey(ctx, tx, targetTable, pkName, primaryKeys); err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit deduplicated insert transaction: %w", err)
+		return false, fmt.Errorf("failed to commit deduplicated insert transaction: %w", err)
 	}
 	committed = true
-	return nil
+	return true, nil
 }
 
 func isNormalisedStagingTable(table string) bool {

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -3,10 +3,13 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -197,6 +200,13 @@ func (d *MSSQLDestination) Write(ctx context.Context, records <-chan source.Reco
 }
 
 func (d *MSSQLDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if opts.StagingTable && opts.Parallelism > 1 {
+		return d.writeParallelBatches(ctx, records, opts)
+	}
+	return d.writeSerialBatches(ctx, records, opts)
+}
+
+func (d *MSSQLDestination) writeSerialBatches(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	startTime := time.Now()
 	var totalRows int64
 	var batchNum int
@@ -222,6 +232,95 @@ func (d *MSSQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 			batchNum, rows, time.Since(startBatch), rate, totalRows)
 
 		result.Batch.Release()
+	}
+
+	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
+	config.Debug("[MSSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTime), totalRate)
+	return nil
+}
+
+func (d *MSSQLDestination) writeParallelBatches(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	parallelism := opts.Parallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+
+	startTime := time.Now()
+	config.Debug("[MSSQL] Starting parallel write to %s with %d workers", opts.Table, parallelism)
+
+	type writeResult struct {
+		batchNum int
+		rows     int64
+		duration time.Duration
+		err      error
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make(chan writeResult, parallelism*2)
+	var wg sync.WaitGroup
+	var batchNum atomic.Int64
+
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for result := range records {
+				myBatch := int(batchNum.Add(1))
+				if result.Err != nil {
+					results <- writeResult{batchNum: myBatch, err: result.Err}
+					cancel()
+					return
+				}
+
+				record := result.Batch
+				if record == nil {
+					continue
+				}
+
+				startBatch := time.Now()
+				rows, err := d.writeRecordBatch(ctx, record, opts.Table, opts.Schema)
+				record.Release()
+				if err != nil {
+					results <- writeResult{batchNum: myBatch, rows: rows, duration: time.Since(startBatch), err: err}
+					cancel()
+					return
+				}
+
+				results <- writeResult{
+					batchNum: myBatch,
+					rows:     rows,
+					duration: time.Since(startBatch),
+				}
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var totalRows int64
+	var firstErr error
+	for res := range results {
+		if res.err != nil {
+			if firstErr == nil {
+				firstErr = res.err
+				config.Debug("[MSSQL] Batch %d failed after %v: %v", res.batchNum, res.duration, res.err)
+			}
+			continue
+		}
+
+		totalRows += res.rows
+		config.Debug("[MSSQL] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
+			res.batchNum, res.rows, res.duration, float64(res.rows)/res.duration.Seconds(), totalRows)
+	}
+
+	if firstErr != nil {
+		return fmt.Errorf("parallel write failed: %w", firstErr)
 	}
 
 	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
@@ -408,6 +507,21 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
 	startMerge := time.Now()
 
+	if len(opts.PrimaryKeys) > 0 && !destination.HasCDCDeletedColumn(opts.Columns) {
+		empty, err := d.tableIsEmpty(ctx, opts.TargetTable)
+		if err != nil {
+			return fmt.Errorf("failed to check target table before merge: %w", err)
+		}
+		if empty {
+			insertSQL := buildInsertDedupSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
+			if err := d.insertIntoEmptyTarget(ctx, opts.TargetTable, opts.PrimaryKeys, insertSQL); err != nil {
+				return err
+			}
+			config.Debug("[MERGE] Deduplicated insert completed in %v", time.Since(startMerge))
+			return nil
+		}
+	}
+
 	mergeSQL := buildMergeSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
 	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
 
@@ -418,6 +532,125 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func (d *MSSQLDestination) tableIsEmpty(ctx context.Context, table string) (bool, error) {
+	query := fmt.Sprintf("SELECT TOP (1) 1 FROM %s", quoteTable(table))
+	var v int
+	if err := d.db.QueryRowContext(ctx, query).Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return true, nil
+		}
+		config.LogFailedQuery(query, err)
+		return false, err
+	}
+	return false, nil
+}
+
+func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTable string, primaryKeys []string, insertSQL string) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin deduplicated insert transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var pkName string
+	var droppedPK bool
+	if isNormalisedStagingTable(targetTable) {
+		pkName, droppedPK, err = dropPrimaryKeyIfExists(ctx, tx, targetTable)
+		if err != nil {
+			return err
+		}
+	}
+
+	config.Debug("[MERGE] Empty target, executing deduplicated INSERT: %s", insertSQL)
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert deduplicated records: %w", err)
+	}
+
+	if droppedPK {
+		if err := addPrimaryKey(ctx, tx, targetTable, pkName, primaryKeys); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit deduplicated insert transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func isNormalisedStagingTable(table string) bool {
+	return strings.Contains(table, "_staging_normalised_")
+}
+
+func dropPrimaryKeyIfExists(ctx context.Context, tx *sql.Tx, table string) (string, bool, error) {
+	query := `SELECT kc.name
+FROM sys.key_constraints AS kc
+WHERE kc.parent_object_id = OBJECT_ID(@p1) AND kc.[type] = 'PK'`
+
+	var constraintName string
+	if err := tx.QueryRowContext(ctx, query, table).Scan(&constraintName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		config.LogFailedQuery(query, err)
+		return "", false, fmt.Errorf("failed to find primary key constraint: %w", err)
+	}
+
+	dropSQL := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", quoteTable(table), quoteColumn(constraintName))
+	config.Debug("[MERGE] Dropping target primary key before bulk insert: %s", dropSQL)
+	if _, err := tx.ExecContext(ctx, dropSQL); err != nil {
+		config.LogFailedQuery(dropSQL, err)
+		return "", false, fmt.Errorf("failed to drop primary key before deduplicated insert: %w", err)
+	}
+	return constraintName, true, nil
+}
+
+func addPrimaryKey(ctx context.Context, tx *sql.Tx, table, constraintName string, primaryKeys []string) error {
+	quotedKeys := strings.Join(quoteColumns(primaryKeys), ", ")
+	constraintClause := ""
+	if constraintName != "" {
+		constraintClause = " CONSTRAINT " + quoteColumn(constraintName)
+	}
+
+	addSQL := fmt.Sprintf("ALTER TABLE %s ADD%s PRIMARY KEY (%s)", quoteTable(table), constraintClause, quotedKeys)
+	config.Debug("[MERGE] Recreating target primary key after bulk insert: %s", addSQL)
+	if _, err := tx.ExecContext(ctx, addSQL); err != nil {
+		config.LogFailedQuery(addSQL, err)
+		return fmt.Errorf("failed to recreate primary key after deduplicated insert: %w", err)
+	}
+	return nil
+}
+
+func buildInsertDedupSQL(targetTable, stagingTable string, primaryKeys, columns []string, incrementalKey string) string {
+	quotedColumns := quoteColumns(columns)
+	colList := strings.Join(quotedColumns, ", ")
+
+	orderByCol := ""
+	if incrementalKey != "" {
+		orderByCol = quoteColumn(incrementalKey)
+	}
+
+	selectClause := destination.DedupStagingSelect(
+		colList,
+		strings.Join(quoteColumns(primaryKeys), ", "),
+		quoteTable(stagingTable),
+		orderByCol,
+	)
+
+	return buildInsertSQL(targetTable, colList, selectClause)
+}
+
+func buildInsertSQL(targetTable, colList, selectClause string) string {
+	return fmt.Sprintf("INSERT INTO %s WITH (TABLOCK) (%s) %s", quoteTable(targetTable), colList, selectClause)
 }
 
 func buildMergeSQL(targetTable, stagingTable string, primaryKeys, columns []string, incrementalKey string) string {

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -43,6 +43,21 @@ func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
 	assertContains(t, sql, "[updated_at] <= @p2")
 }
 
+func TestRowsPerSecondAllowsZeroDuration(t *testing.T) {
+	if got := rowsPerSecond(10, 0); got != 0 {
+		t.Fatalf("rowsPerSecond with zero duration = %v, want 0", got)
+	}
+	if got := rowsPerSecond(10, time.Second); got != 10 {
+		t.Fatalf("rowsPerSecond = %v, want 10", got)
+	}
+}
+
+func TestBuildTableIsEmptyForUpdateSQLLocksTarget(t *testing.T) {
+	sql := buildTableIsEmptyForUpdateSQL("dbo.events")
+
+	assertContains(t, sql, "FROM [dbo].[events] WITH (TABLOCKX, HOLDLOCK)")
+}
+
 func TestBuildInsertDedupSQLUsesTableLockAndDedupsPrimaryKey(t *testing.T) {
 	sql := buildInsertDedupSQL(
 		"dbo.events",

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -43,6 +43,32 @@ func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
 	assertContains(t, sql, "[updated_at] <= @p2")
 }
 
+func TestBuildInsertDedupSQLUsesTableLockAndDedupsPrimaryKey(t *testing.T) {
+	sql := buildInsertDedupSQL(
+		"dbo.events",
+		"_bruin_staging.events_raw",
+		[]string{"id"},
+		[]string{"id", "name", "updated_at"},
+		"updated_at",
+	)
+
+	assertContains(t, sql, "INSERT INTO [dbo].[events] WITH (TABLOCK) ([id], [name], [updated_at])")
+	assertContains(t, sql, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY [updated_at] DESC)")
+	assertContains(t, sql, "FROM [_bruin_staging].[events_raw]")
+}
+
+func TestBuildInsertDedupSQLAllowsNoIncrementalKey(t *testing.T) {
+	sql := buildInsertDedupSQL(
+		"dbo.events",
+		"_bruin_staging.events_raw",
+		[]string{"id"},
+		[]string{"id", "name"},
+		"",
+	)
+
+	assertContains(t, sql, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY (SELECT NULL))")
+}
+
 func TestDialectTypeNameUsesDestinationTypeMapping(t *testing.T) {
 	dialect := &Dialect{}
 	columns := []schema.Column{


### PR DESCRIPTION
Adds a single-node Spark benchmark tool, wires multi-tool requirements into the benchmark runner, and improves MSSQL staging writes plus empty-target merges.

Validated with make format, make lint, and make test.