### PR TITLE
fix pg primary key logs

### DIFF
--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -191,23 +191,35 @@ func (s *PostgresSource) getSchema(ctx context.Context, table string) (*schema.T
 	}
 
 	pkQuery := `
-		SELECT a.attname
-		FROM pg_index i
-		JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-		WHERE i.indrelid = format('%I.%I', $1, $2)::regclass
-		AND i.indisprimary
+		SELECT kcu.column_name
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+			ON tc.constraint_catalog = kcu.constraint_catalog
+			AND tc.constraint_schema = kcu.constraint_schema
+			AND tc.constraint_name = kcu.constraint_name
+			AND tc.table_schema = kcu.table_schema
+			AND tc.table_name = kcu.table_name
+		WHERE tc.constraint_type = 'PRIMARY KEY'
+			AND tc.table_schema = $1
+			AND tc.table_name = $2
+		ORDER BY kcu.ordinal_position
 	`
 
 	var primaryKeys []string
 	pkRows, err := s.pool.Query(ctx, pkQuery, schemaName, tableName)
-	if err == nil {
-		defer pkRows.Close()
-		for pkRows.Next() {
-			var pkName string
-			if err := pkRows.Scan(&pkName); err == nil {
-				primaryKeys = append(primaryKeys, pkName)
-			}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query primary keys: %w", err)
+	}
+	defer pkRows.Close()
+	for pkRows.Next() {
+		var pkName string
+		if err := pkRows.Scan(&pkName); err != nil {
+			return nil, fmt.Errorf("failed to scan primary key row: %w", err)
 		}
+		primaryKeys = append(primaryKeys, pkName)
+	}
+	if err := pkRows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating primary key rows: %w", err)
 	}
 
 	for i := range columns {

--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"sort"
 	"strings"
 	"time"
 
@@ -92,6 +93,7 @@ func (s *PostgresSource) GetTable(ctx context.Context, req source.TableRequest) 
 	if len(pks) == 0 {
 		pks = tableSchema.PrimaryKeys
 	}
+	pksUnique := len(req.PrimaryKeys) == 0 && len(tableSchema.PrimaryKeys) > 0
 
 	// Use user's strategy or default to replace
 	strategy := req.Strategy
@@ -100,11 +102,12 @@ func (s *PostgresSource) GetTable(ctx context.Context, req source.TableRequest) 
 	}
 
 	return &source.DynamicSourceTable{
-		TableName:           req.Name,
-		TablePrimaryKeys:    pks,
-		TableIncrementalKey: req.IncrementalKey,
-		TableStrategy:       strategy,
-		KnownSchema:         true,
+		TableName:              req.Name,
+		TablePrimaryKeys:       pks,
+		TablePrimaryKeysUnique: pksUnique,
+		TableIncrementalKey:    req.IncrementalKey,
+		TableStrategy:          strategy,
+		KnownSchema:            true,
 		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
 			return tableSchema, nil
 		},
@@ -118,17 +121,32 @@ func (s *PostgresSource) getSchema(ctx context.Context, table string) (*schema.T
 	schemaName, tableName := parseTableName(table)
 
 	query := `
+		WITH primary_keys AS (
+			SELECT kcu.column_name, kcu.ordinal_position
+			FROM information_schema.table_constraints tc
+			JOIN information_schema.key_column_usage kcu
+				ON tc.constraint_catalog = kcu.constraint_catalog
+				AND tc.constraint_schema = kcu.constraint_schema
+				AND tc.constraint_name = kcu.constraint_name
+				AND tc.table_schema = kcu.table_schema
+				AND tc.table_name = kcu.table_name
+			WHERE tc.constraint_type = 'PRIMARY KEY'
+				AND tc.table_schema = $1
+				AND tc.table_name = $2
+		)
 		SELECT
-			column_name,
-			data_type,
-			is_nullable,
-			numeric_precision,
-			numeric_scale,
-			character_maximum_length,
-			udt_name
-		FROM information_schema.columns
-		WHERE table_schema = $1 AND table_name = $2
-		ORDER BY ordinal_position
+			c.column_name,
+			c.data_type,
+			c.is_nullable,
+			c.numeric_precision,
+			c.numeric_scale,
+			c.character_maximum_length,
+			c.udt_name,
+			pk.ordinal_position
+		FROM information_schema.columns c
+		LEFT JOIN primary_keys pk ON pk.column_name = c.column_name
+		WHERE c.table_schema = $1 AND c.table_name = $2
+		ORDER BY c.ordinal_position
 	`
 
 	rows, err := s.pool.Query(ctx, query, schemaName, tableName)
@@ -138,11 +156,16 @@ func (s *PostgresSource) getSchema(ctx context.Context, table string) (*schema.T
 	defer rows.Close()
 
 	var columns []schema.Column
+	var pkColumns []struct {
+		name    string
+		ordinal int
+	}
 	for rows.Next() {
 		var columnName, dataType, isNullable, udtName string
 		var numericPrecision, numericScale, charMaxLen *int
+		var pkOrdinal *int
 
-		if err := rows.Scan(&columnName, &dataType, &isNullable, &numericPrecision, &numericScale, &charMaxLen, &udtName); err != nil {
+		if err := rows.Scan(&columnName, &dataType, &isNullable, &numericPrecision, &numericScale, &charMaxLen, &udtName, &pkOrdinal); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 
@@ -161,6 +184,13 @@ func (s *PostgresSource) getSchema(ctx context.Context, table string) (*schema.T
 			DataType:  dt,
 			Nullable:  isNullable == "YES",
 			ArrayType: arrayType,
+		}
+		if pkOrdinal != nil {
+			col.IsPrimaryKey = true
+			pkColumns = append(pkColumns, struct {
+				name    string
+				ordinal int
+			}{name: columnName, ordinal: *pkOrdinal})
 		}
 
 		if numericPrecision != nil {
@@ -190,45 +220,12 @@ func (s *PostgresSource) getSchema(ctx context.Context, table string) (*schema.T
 		return nil, fmt.Errorf("table %s not found or has no columns", table)
 	}
 
-	pkQuery := `
-		SELECT kcu.column_name
-		FROM information_schema.table_constraints tc
-		JOIN information_schema.key_column_usage kcu
-			ON tc.constraint_catalog = kcu.constraint_catalog
-			AND tc.constraint_schema = kcu.constraint_schema
-			AND tc.constraint_name = kcu.constraint_name
-			AND tc.table_schema = kcu.table_schema
-			AND tc.table_name = kcu.table_name
-		WHERE tc.constraint_type = 'PRIMARY KEY'
-			AND tc.table_schema = $1
-			AND tc.table_name = $2
-		ORDER BY kcu.ordinal_position
-	`
-
-	var primaryKeys []string
-	pkRows, err := s.pool.Query(ctx, pkQuery, schemaName, tableName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query primary keys: %w", err)
-	}
-	defer pkRows.Close()
-	for pkRows.Next() {
-		var pkName string
-		if err := pkRows.Scan(&pkName); err != nil {
-			return nil, fmt.Errorf("failed to scan primary key row: %w", err)
-		}
-		primaryKeys = append(primaryKeys, pkName)
-	}
-	if err := pkRows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating primary key rows: %w", err)
-	}
-
-	for i := range columns {
-		for _, pk := range primaryKeys {
-			if columns[i].Name == pk {
-				columns[i].IsPrimaryKey = true
-				break
-			}
-		}
+	sort.Slice(pkColumns, func(i, j int) bool {
+		return pkColumns[i].ordinal < pkColumns[j].ordinal
+	})
+	primaryKeys := make([]string, len(pkColumns))
+	for i, pk := range pkColumns {
+		primaryKeys[i] = pk.name
 	}
 
 	return &schema.TableSchema{

--- a/pkg/source/postgres_cdc/table.go
+++ b/pkg/source/postgres_cdc/table.go
@@ -205,23 +205,35 @@ func getTableSchema(ctx context.Context, pool *pgxpool.Pool, table string) (*sch
 	}
 
 	pkQuery := `
-		SELECT a.attname
-		FROM pg_index i
-		JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-		WHERE i.indrelid = ($1 || '.' || $2)::regclass
-		AND i.indisprimary
+		SELECT kcu.column_name
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+			ON tc.constraint_catalog = kcu.constraint_catalog
+			AND tc.constraint_schema = kcu.constraint_schema
+			AND tc.constraint_name = kcu.constraint_name
+			AND tc.table_schema = kcu.table_schema
+			AND tc.table_name = kcu.table_name
+		WHERE tc.constraint_type = 'PRIMARY KEY'
+			AND tc.table_schema = $1
+			AND tc.table_name = $2
+		ORDER BY kcu.ordinal_position
 	`
 
 	var primaryKeys []string
 	pkRows, err := pool.Query(ctx, pkQuery, schemaName, tableName)
-	if err == nil {
-		defer func() { pkRows.Close() }()
-		for pkRows.Next() {
-			var pkName string
-			if err := pkRows.Scan(&pkName); err == nil {
-				primaryKeys = append(primaryKeys, pkName)
-			}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query primary keys: %w", err)
+	}
+	defer func() { pkRows.Close() }()
+	for pkRows.Next() {
+		var pkName string
+		if err := pkRows.Scan(&pkName); err != nil {
+			return nil, fmt.Errorf("failed to scan primary key row: %w", err)
 		}
+		primaryKeys = append(primaryKeys, pkName)
+	}
+	if err := pkRows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating primary key rows: %w", err)
 	}
 
 	for i := range columns {

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -62,6 +62,10 @@ type SourceTable interface {
 	Read(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error)
 }
 
+type PrimaryKeyUniquenessProvider interface {
+	PrimaryKeysUnique() bool
+}
+
 // PartitionedTable is an optional interface that a SourceTable can implement
 // to declare a partition key for the destination table.
 type PartitionedTable interface {

--- a/pkg/source/sqltable.go
+++ b/pkg/source/sqltable.go
@@ -13,14 +13,15 @@ import (
 // DynamicSourceTable is a SourceTable implementation for sources
 // where metadata is queried from the database at runtime or inferred from data.
 type DynamicSourceTable struct {
-	TableName           string
-	TablePrimaryKeys    []string
-	TableIncrementalKey string
-	TableStrategy       config.IncrementalStrategy
-	TablePartitionBy    string
-	KnownSchema         bool
-	SchemaFn            func(ctx context.Context) (*schema.TableSchema, error)
-	ReadFn              func(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error)
+	TableName              string
+	TablePrimaryKeys       []string
+	TablePrimaryKeysUnique bool
+	TableIncrementalKey    string
+	TableStrategy          config.IncrementalStrategy
+	TablePartitionBy       string
+	KnownSchema            bool
+	SchemaFn               func(ctx context.Context) (*schema.TableSchema, error)
+	ReadFn                 func(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error)
 }
 
 func (t *DynamicSourceTable) Name() string {
@@ -29,6 +30,10 @@ func (t *DynamicSourceTable) Name() string {
 
 func (t *DynamicSourceTable) PrimaryKeys() []string {
 	return t.TablePrimaryKeys
+}
+
+func (t *DynamicSourceTable) PrimaryKeysUnique() bool {
+	return t.TablePrimaryKeysUnique
 }
 
 func (t *DynamicSourceTable) IncrementalKey() string {

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 )
 
 func singleBatchRecords(t *testing.T, rows ...int64) <-chan source.RecordBatchResult {
@@ -169,6 +171,167 @@ func TestReplaceStrategy_Execute_HappyPath(t *testing.T) {
 	}
 	if len(dest.waitCalls) != 0 {
 		t.Fatalf("expected no WaitForExactRowCount calls for empty write, got %v", dest.waitCalls)
+	}
+}
+
+func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 1 {
+		t.Fatalf("expected 1 PrepareTable call, got %d", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("staging table should keep primary keys on the fast path, got %v", got)
+	}
+	if len(dest.mergeCalls) != 0 {
+		t.Fatalf("expected no MergeTable calls on unique-PK fast path, got %d", len(dest.mergeCalls))
+	}
+	if len(dest.swapCalls) != 1 || dest.swapCalls[0][0] != dest.prepareCalls[0].Table {
+		t.Fatalf("expected staging table to be swapped directly, got swaps=%v prepares=%v", dest.swapCalls, dest.prepareCalls)
+	}
+}
+
+func TestReplaceStrategy_Execute_DedupsWhenUniqueSourcePrimaryKeysExcluded(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.primaryKeys = []string{"tenant_id", "id"}
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+	job.SourceSchema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected dedup path with 2 PrepareTable calls, got %d", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("raw staging table should be PK-free when part of the source PK was excluded, got %v", got)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected MergeTable call for dedup path, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_DedupsWhenPrimaryKeyRenameCollapses(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.primaryKeys = []string{"userId", "UserID"}
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+	job.Config.PrimaryKeys = []string{"user_id"}
+	job.SourceSchema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "userId", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "UserID", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"userId", "UserID"},
+	}
+	job.Schema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "user_id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"user_id"},
+	}
+	job.ColumnRenamer = transformer.NewColumnRenamer(map[string]string{
+		"userId": "user_id",
+		"UserID": "user_id",
+	})
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected dedup path with 2 PrepareTable calls, got %d", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("raw staging table should be PK-free when PK renames collapse, got %v", got)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected MergeTable call for dedup path, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_DedupsWhenNonPrimaryKeyRenamesToPrimaryKey(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+	job.SourceSchema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "ID", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	job.Schema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	job.ColumnRenamer = transformer.NewColumnRenamer(map[string]string{
+		"ID": "id",
+	})
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected dedup path with 2 PrepareTable calls, got %d", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("raw staging table should be PK-free when a non-PK renames to a PK, got %v", got)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected MergeTable call for dedup path, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_DedupsWhenPrimaryKeyIsMasked(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	masker, err := transformer.NewColumnMasker([]string{"id:redact"})
+	if err != nil {
+		t.Fatalf("NewColumnMasker returned error: %v", err)
+	}
+	job.ColumnMasker = masker
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected dedup path with 2 PrepareTable calls, got %d", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("raw staging table should be PK-free when a PK is masked, got %v", got)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected MergeTable call for dedup path, got %d", len(dest.mergeCalls))
 	}
 }
 

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
 
@@ -21,6 +23,120 @@ func replaceShouldDedup(dest destination.Destination, primaryKeys []string) bool
 	return len(primaryKeys) > 0 &&
 		dest.SupportsMergeStrategy() &&
 		dest.GetScheme() != "clickhouse"
+}
+
+func sourcePrimaryKeysSafeForReplaceFastPath(job *IngestionJob) bool {
+	return sourcePrimaryKeysGuaranteedUnique(job) &&
+		!primaryKeyValuesMayChange(job)
+}
+
+func sourcePrimaryKeysGuaranteedUnique(job *IngestionJob) bool {
+	provider, ok := job.Table.(source.PrimaryKeyUniquenessProvider)
+	if !ok || !provider.PrimaryKeysUnique() || job.SourceSchema == nil {
+		return false
+	}
+	if !slices.Equal(job.Table.PrimaryKeys(), job.SourceSchema.PrimaryKeys) {
+		return false
+	}
+
+	return slices.Equal(mappedSourcePrimaryKeys(job), job.Config.PrimaryKeys) &&
+		!nonPrimaryKeyMapsToDestinationPrimaryKey(job)
+}
+
+func mappedSourcePrimaryKeys(job *IngestionJob) []string {
+	primaryKeys := append([]string(nil), job.SourceSchema.PrimaryKeys...)
+	if job.ColumnRenamer == nil || !job.ColumnRenamer.HasRenames() {
+		return primaryKeys
+	}
+
+	mapping := job.ColumnRenamer.Mapping()
+	for i, pk := range primaryKeys {
+		if mapped, ok := mapping[pk]; ok {
+			primaryKeys[i] = mapped
+		}
+	}
+	return primaryKeys
+}
+
+func nonPrimaryKeyMapsToDestinationPrimaryKey(job *IngestionJob) bool {
+	sourcePrimaryKeys := make(map[string]bool, len(job.SourceSchema.PrimaryKeys))
+	for _, pk := range job.SourceSchema.PrimaryKeys {
+		sourcePrimaryKeys[pk] = true
+	}
+	destinationPrimaryKeys := make(map[string]bool, len(job.Config.PrimaryKeys))
+	for _, pk := range job.Config.PrimaryKeys {
+		destinationPrimaryKeys[pk] = true
+	}
+
+	var mapping map[string]string
+	if job.ColumnRenamer != nil && job.ColumnRenamer.HasRenames() {
+		mapping = job.ColumnRenamer.Mapping()
+	}
+
+	for _, col := range job.SourceSchema.Columns {
+		if sourcePrimaryKeys[col.Name] {
+			continue
+		}
+		name := col.Name
+		if mapped, ok := mapping[name]; ok {
+			name = mapped
+		}
+		if destinationPrimaryKeys[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func primaryKeyValuesMayChange(job *IngestionJob) bool {
+	if len(job.Config.PrimaryKeys) == 0 {
+		return false
+	}
+	if job.TypeCaster != nil {
+		return true
+	}
+	if job.ColumnMasker != nil && intersects(job.Config.PrimaryKeys, job.ColumnMasker.MaskedColumns()) {
+		return true
+	}
+
+	mode, err := schemaevolution.ParseContractMode(job.Config.SchemaContract)
+	if err == nil && mode == schemaevolution.ContractDiscardValue && schemaChangesTouchPrimaryKeys(job.SchemaComparison, job.Config.PrimaryKeys) {
+		return true
+	}
+	return false
+}
+
+func schemaChangesTouchPrimaryKeys(comparison *schemaevolution.SchemaComparison, primaryKeys []string) bool {
+	if comparison == nil || !comparison.HasChanges {
+		return false
+	}
+
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkSet[pk] = true
+	}
+	for _, change := range comparison.Changes {
+		if pkSet[change.ColumnName] {
+			return true
+		}
+	}
+	return false
+}
+
+func intersects(left, right []string) bool {
+	if len(left) == 0 || len(right) == 0 {
+		return false
+	}
+	set := make(map[string]bool, len(left))
+	for _, v := range left {
+		set[v] = true
+	}
+	for _, v := range right {
+		if set[v] {
+			return true
+		}
+	}
+	return false
 }
 
 // deduplicateStaging collapses duplicate primary keys from rawTable into a
@@ -98,7 +214,9 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	}
 
 	// Deduplicated replace: Load a PK-free staging table so duplicate keys can land.
-	dedup := useStaging && replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+	dedup := useStaging &&
+		!sourcePrimaryKeysSafeForReplaceFastPath(job) &&
+		replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
 	stagingPrimaryKeys := job.Config.PrimaryKeys
 	if dedup {
 		stagingPrimaryKeys = nil

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -24,12 +24,13 @@ import (
 type fakeSourceTable struct {
 	mu sync.Mutex
 
-	name           string
-	primaryKeys    []string
-	incrementalKey string
-	strategy       config.IncrementalStrategy
-	hasKnownSchema bool
-	tableSchema    *schema.TableSchema
+	name              string
+	primaryKeys       []string
+	primaryKeysUnique bool
+	incrementalKey    string
+	strategy          config.IncrementalStrategy
+	hasKnownSchema    bool
+	tableSchema       *schema.TableSchema
 
 	readCalled bool
 	readOpts   source.ReadOptions
@@ -44,6 +45,10 @@ func (t *fakeSourceTable) Name() string {
 
 func (t *fakeSourceTable) PrimaryKeys() []string {
 	return t.primaryKeys
+}
+
+func (t *fakeSourceTable) PrimaryKeysUnique() bool {
+	return t.primaryKeysUnique
 }
 
 func (t *fakeSourceTable) IncrementalKey() string {
@@ -80,14 +85,15 @@ type fakeDestination struct {
 
 	calls []string
 
-	prepareCalls []destination.PrepareOptions
-	writeCalls   []destination.WriteOptions
-	swapCalls    [][2]string
-	mergeCalls   []destination.MergeOptions
-	diCalls      []destination.DeleteInsertOptions
-	dropCalls    []string
-	execCalls    []execCall
-	waitCalls    []struct {
+	prepareCalls  []destination.PrepareOptions
+	writeCalls    []destination.WriteOptions
+	swapCalls     [][2]string
+	mergeCalls    []destination.MergeOptions
+	diCalls       []destination.DeleteInsertOptions
+	dropCalls     []string
+	execCalls     []execCall
+	truncateCalls []string
+	waitCalls     []struct {
 		Table        string
 		ExpectedRows int64
 	}
@@ -97,6 +103,7 @@ type fakeDestination struct {
 	swapErr           error
 	mergeErr          error
 	deleteInsertErr   error
+	truncateErr       error
 	waitErr           error
 	dropErrByTable    map[string]error
 	noDeleteInsert    bool
@@ -204,6 +211,15 @@ func (d *fakeDestination) DropTable(ctx context.Context, table string) error {
 	}
 	d.mu.Unlock()
 	return err
+}
+
+func (d *fakeDestination) TruncateTable(ctx context.Context, table string) error {
+	d.mu.Lock()
+	d.calls = append(d.calls, "TruncateTable")
+	d.truncateCalls = append(d.truncateCalls, table)
+	truncateErr := d.truncateErr
+	d.mu.Unlock()
+	return truncateErr
 }
 
 func (d *fakeDestination) WaitForExactRowCount(ctx context.Context, table string, expectedRows int64) error {

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -1,0 +1,32 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+)
+
+func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.primaryKeysUnique = true
+	src.readErr = errors.New("read failed")
+
+	strat := &TruncateInsertStrategy{}
+	err := strat.Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get records") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dest.truncateCalls) != 0 {
+		t.Fatalf("expected no truncate before source read succeeds, got %v", dest.truncateCalls)
+	}
+	if len(dest.writeCalls) != 0 {
+		t.Fatalf("expected no write when source read setup fails, got %d", len(dest.writeCalls))
+	}
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -269,6 +269,40 @@ func TestDuckDBWithPrimaryKeyAutoDetection(t *testing.T) {
 	validateSQLitePKResults(t, destPath, 50)
 }
 
+func TestPostgresWithPrimaryKeyAutoDetection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceURI := sharedPostgresURI(t, "source")
+	sourceSchema := uniqueSchemaName(t, "src")
+	ensurePostgresSchema(t, ctx, sourceURI, sourceSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, sourceURI, sourceSchema) })
+
+	tmpFile, err := os.CreateTemp("", "test_postgres_pk_*.db")
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	setupPostgresSourceDataWithPK(t, ctx, sourceURI, sourceSchema, "users")
+
+	cfg := &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         sourceSchema + ".users",
+		DestURI:             fmt.Sprintf("sqlite:///%s", tmpFile.Name()),
+		DestTable:           "pk_table",
+		IncrementalStrategy: "merge",
+	}
+
+	p := pipeline.New(cfg)
+	err = p.Run(ctx)
+	require.NoError(t, err, "Pipeline should auto-detect Postgres PKs and run merge")
+
+	validateSQLitePKResults(t, tmpFile.Name(), 50)
+}
+
 // TestPostgresToPostgresCamelCaseColumns reproduces a bug where the naming
 // convention renames source columns (e.g. FirstName → first_name) in-place,
 // and the renamed names are then used in the source SELECT query, causing:


### PR DESCRIPTION
## What was happening

Postgres primary key auto-detection was brittle. We were asking Postgres for PK columns through a `regclass` lookup, which worked in some simple cases but could fail or silently miss primary keys depending on how the schema/table name was resolved. When that happened, ingestr treated a table with a real database primary key as if it had no primary key, so strategies like `merge` could fail validation unless the user manually passed `--primary-key`.

While fixing that, this branch also tightens an optimization in `replace`/`truncate+insert`. If a source tells us its primary keys are already unique, we can sometimes skip the extra dedup staging merge. That shortcut is only safe when the values that reach the destination are still guaranteed unique. Column masking, type casting, schema-contract transforms, and column renames can change or collapse key values after extraction. In those cases we now keep the dedup path so destinations like BigQuery, Postgres, SQLite, and DuckDB do not fail on duplicate PKs or truncate too early.

## What changed

- Postgres and Postgres CDC now fetch primary key metadata through `information_schema` and preserve composite key order.
- Postgres source tables mark auto-detected source PKs as unique only when the user did not override them.
- `replace` only uses the unique-source-PK fast path when the effective destination PKs are still a one-to-one match after renames and are not touched by transforms.
- `truncate+insert` always stages PK loads before truncating, preserving the existing protection against source read/write failures.
- Added regression coverage for auto-detected Postgres PKs and unsafe replace fast-path cases.

## Validation

- `go test ./pkg/strategy`
- `make format`
- `make lint`
- `make test`
- Verified against real BigQuery in `bruin-ingestr-playground`:
  - `TestDestinations_Replace_DedupesByPK/bigquery`
  - `TestDestinations_TruncateInsert_Dedup/bigquery`
  - manual Postgres-with-auto-detected-PK to BigQuery `replace`