### PR TITLE
Fill unchanged TOAST columns from prior rows in the Postgres CDC decoder

### DIFF
--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -15,6 +15,13 @@ type batchAccumulator struct {
 	batches   map[string][]arrow.RecordBatch
 	rowCounts map[string]int64
 	threshold int64
+
+	// transform, when set, post-processes each merged batch just before it is
+	// sent downstream. It receives the table name and the outgoing batch and
+	// returns the batch to emit. Returning a batch different from the input
+	// transfers ownership (the original is released). The accumulator itself
+	// stays schema-agnostic; CDC-specific logic lives in the supplied function.
+	transform func(tableName string, batch arrow.RecordBatch) arrow.RecordBatch
 }
 
 func newBatchAccumulator(threshold int) *batchAccumulator {
@@ -55,24 +62,28 @@ func (a *batchAccumulator) flushTable(tableName string, results chan<- source.Re
 	delete(a.batches, tableName)
 	delete(a.rowCounts, tableName)
 
+	var out arrow.RecordBatch
 	if len(batches) == 1 {
-		results <- source.RecordBatchResult{
-			Batch:     batches[0],
-			TableName: tableName,
+		out = batches[0]
+	} else {
+		out = concatRecordBatches(batches)
+		config.Debug("[CDC] Flushed %d micro-batches into %d rows for table %s", len(batches), out.NumRows(), tableName)
+
+		// Release the originals now that the merged batch owns the data
+		for _, b := range batches {
+			b.Release()
 		}
-		return
 	}
 
-	merged := concatRecordBatches(batches)
-	config.Debug("[CDC] Flushed %d micro-batches into %d rows for table %s", len(batches), merged.NumRows(), tableName)
-
-	// Release the originals now that the merged batch owns the data
-	for _, b := range batches {
-		b.Release()
+	if a.transform != nil {
+		if transformed := a.transform(tableName, out); transformed != out {
+			out.Release()
+			out = transformed
+		}
 	}
 
 	results <- source.RecordBatchResult{
-		Batch:     merged,
+		Batch:     out,
 		TableName: tableName,
 	}
 }

--- a/pkg/source/postgres_cdc/cdc_fill.go
+++ b/pkg/source/postgres_cdc/cdc_fill.go
@@ -26,6 +26,15 @@ import (
 // flushed the destination holds its data and the _cdc_unchanged_cols target
 // fallback applies. When nothing needs filling the input batch is returned
 // unchanged (no allocation, no extra reference).
+//
+// Rows are keyed by their primary key as it appears in the staging batch, which
+// is always the new tuple's value. Limitation: a primary-key-changing UPDATE
+// that omits an unchanged TOAST column is keyed by its new PK, so it cannot be
+// linked back to the originating row under the old PK. When that INSERT and the
+// PK-changing UPDATE land in different commits of the same accumulated batch the
+// omitted value is not recovered here (it stays in _cdc_unchanged_cols and falls
+// back to the target). The within-commit decoder pass (applyIntraBatchFill) does
+// handle PK changes via the old tuple, so only the cross-commit case is affected.
 func forwardFillUnchanged(batch arrow.RecordBatch, pkNames []string) arrow.RecordBatch {
 	if batch == nil || batch.NumRows() < 2 || len(pkNames) == 0 {
 		return batch

--- a/pkg/source/postgres_cdc/cdc_fill.go
+++ b/pkg/source/postgres_cdc/cdc_fill.go
@@ -1,0 +1,271 @@
+package postgres_cdc
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// forwardFillUnchanged coalesces unchanged TOAST columns across the rows of an
+// already-assembled staging batch.
+//
+// PostgreSQL omits unchanged TOASTed values from UPDATE WAL tuples. When an
+// INSERT (or any row carrying the full value) and a later partial UPDATE for the
+// same primary key land in the same staging batch — e.g. two autocommit
+// transactions accumulated together — the partial UPDATE's omitted column is
+// filled from the most recent prior row of that key. Filled columns are dropped
+// from _cdc_unchanged_cols so the destination merge uses the staging value
+// instead of the target fallback.
+//
+// Rows are processed in array order, which the accumulator preserves as commit
+// (LSN) order. The pass is stateless across batches and bounded by one batch:
+// cross-batch coalescing is intentionally not handled because once a row is
+// flushed the destination holds its data and the _cdc_unchanged_cols target
+// fallback applies. When nothing needs filling the input batch is returned
+// unchanged (no allocation, no extra reference).
+func forwardFillUnchanged(batch arrow.RecordBatch, pkNames []string) arrow.RecordBatch {
+	if batch == nil || batch.NumRows() < 2 || len(pkNames) == 0 {
+		return batch
+	}
+
+	sc := batch.Schema()
+	nCols := int(batch.NumCols())
+	nRows := int(batch.NumRows())
+
+	pkIdx := make([]int, 0, len(pkNames))
+	for _, name := range pkNames {
+		if idxs := sc.FieldIndices(name); len(idxs) > 0 {
+			pkIdx = append(pkIdx, idxs[0])
+		}
+	}
+	if len(pkIdx) != len(pkNames) {
+		return batch
+	}
+
+	unchangedColIdx := firstFieldIndex(sc, CDCUnchangedColsColumn)
+	if unchangedColIdx < 0 {
+		return batch
+	}
+	unchangedArr, ok := batch.Column(unchangedColIdx).(*array.String)
+	if !ok {
+		return batch
+	}
+
+	var deletedArr *array.Boolean
+	if di := firstFieldIndex(sc, CDCDeletedColumn); di >= 0 {
+		deletedArr, _ = batch.Column(di).(*array.Boolean)
+	}
+
+	meta := map[string]bool{
+		CDCLSNColumn:           true,
+		CDCDeletedColumn:       true,
+		CDCSyncedAtColumn:      true,
+		CDCUnchangedColsColumn: true,
+	}
+	isSource := make([]bool, nCols)
+	for c := 0; c < nCols; c++ {
+		isSource[c] = !meta[sc.Field(c).Name]
+	}
+
+	// srcIndex[c][r] is the source row whose cell column c copies into output row
+	// r (identity unless filled). colHasFill marks columns that need rebuilding.
+	srcIndex := make([][]int, nCols)
+	colHasFill := make([]bool, nCols)
+	for c := 0; c < nCols; c++ {
+		if !isSource[c] {
+			continue
+		}
+		srcIndex[c] = make([]int, nRows)
+		for r := 0; r < nRows; r++ {
+			srcIndex[c][r] = r
+		}
+	}
+
+	newUnchanged := make([]string, nRows)
+	unchangedRewritten := false
+
+	// lastRow[pk][col] = most recent row holding an authoritative non-null value.
+	lastRow := make(map[string]map[int]int)
+
+	for r := 0; r < nRows; r++ {
+		newUnchanged[r] = stringAt(unchangedArr, r)
+
+		key, ok := pkKeyAt(batch, pkIdx, r)
+		if !ok {
+			continue
+		}
+
+		if deletedArr != nil && !deletedArr.IsNull(r) && deletedArr.Value(r) {
+			delete(lastRow, key)
+			continue
+		}
+
+		unchangedSet := unchangedNameSet(unchangedArr, r)
+		filledAny := false
+
+		for c := 0; c < nCols; c++ {
+			if !isSource[c] {
+				continue
+			}
+			name := sc.Field(c).Name
+			col := batch.Column(c)
+
+			if unchangedSet[name] && col.IsNull(r) {
+				if priors, ok := lastRow[key]; ok {
+					if sr, ok := priors[c]; ok {
+						srcIndex[c][r] = sr
+						colHasFill[c] = true
+						delete(unchangedSet, name)
+						filledAny = true
+					}
+				}
+				continue
+			}
+
+			if !col.IsNull(r) {
+				if lastRow[key] == nil {
+					lastRow[key] = make(map[int]int)
+				}
+				lastRow[key][c] = r
+			}
+		}
+
+		if filledAny {
+			if b, err := json.Marshal(remainingUnchanged(unchangedArr, r, unchangedSet)); err == nil {
+				newUnchanged[r] = string(b)
+				unchangedRewritten = true
+			}
+		}
+	}
+
+	anyFill := unchangedRewritten
+	for c := 0; c < nCols && !anyFill; c++ {
+		if colHasFill[c] {
+			anyFill = true
+		}
+	}
+	if !anyFill {
+		return batch
+	}
+
+	mem := memory.NewGoAllocator()
+	outCols := make([]arrow.Array, nCols)
+	for c := 0; c < nCols; c++ {
+		switch {
+		case isSource[c] && colHasFill[c]:
+			outCols[c] = takeArray(batch.Column(c), srcIndex[c], mem)
+		case c == unchangedColIdx && unchangedRewritten:
+			outCols[c] = buildStringArray(newUnchanged, mem)
+		default:
+			outCols[c] = batch.Column(c)
+			outCols[c].Retain()
+		}
+	}
+
+	out := array.NewRecordBatch(sc, outCols, int64(nRows))
+	for _, a := range outCols {
+		a.Release()
+	}
+	return out
+}
+
+func firstFieldIndex(sc *arrow.Schema, name string) int {
+	if idxs := sc.FieldIndices(name); len(idxs) > 0 {
+		return idxs[0]
+	}
+	return -1
+}
+
+func pkKeyAt(batch arrow.RecordBatch, pkIdx []int, row int) (string, bool) {
+	parts := make([]string, len(pkIdx))
+	for i, c := range pkIdx {
+		col := batch.Column(c)
+		if col.IsNull(row) {
+			return "", false
+		}
+		parts[i] = col.ValueStr(row)
+	}
+	return strings.Join(parts, "|"), true
+}
+
+func stringAt(arr *array.String, row int) string {
+	if arr.IsNull(row) {
+		return "[]"
+	}
+	return arr.Value(row)
+}
+
+func unchangedNameSet(arr *array.String, row int) map[string]bool {
+	names := parseUnchangedNames(arr, row)
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return set
+}
+
+// remainingUnchanged preserves the original column order minus the filled ones.
+func remainingUnchanged(arr *array.String, row int, remaining map[string]bool) []string {
+	out := make([]string, 0, len(remaining))
+	for _, n := range parseUnchangedNames(arr, row) {
+		if remaining[n] {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func parseUnchangedNames(arr *array.String, row int) []string {
+	if arr.IsNull(row) {
+		return nil
+	}
+	s := strings.TrimSpace(arr.Value(row))
+	if s == "" || s == "[]" {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(s), &names); err != nil {
+		return nil
+	}
+	return names
+}
+
+// takeArray builds a new array by copying, for each output row, the element at
+// srcIndex[row] of col. It groups maximal ascending-contiguous runs into
+// zero-copy slices and concatenates them, so unfilled stretches stay cheap and
+// values are preserved exactly (no string round-trip).
+func takeArray(col arrow.Array, srcIndex []int, mem memory.Allocator) arrow.Array {
+	runs := make([]arrow.Array, 0, 4)
+	n := len(srcIndex)
+	for i := 0; i < n; {
+		start := srcIndex[i]
+		j := i + 1
+		for j < n && srcIndex[j] == srcIndex[j-1]+1 {
+			j++
+		}
+		runs = append(runs, array.NewSlice(col, int64(start), int64(start+(j-i))))
+		i = j
+	}
+
+	out, err := array.Concatenate(runs, mem)
+	for _, r := range runs {
+		r.Release()
+	}
+	if err != nil {
+		col.Retain()
+		return col
+	}
+	return out
+}
+
+func buildStringArray(vals []string, mem memory.Allocator) arrow.Array {
+	b := array.NewStringBuilder(mem)
+	defer b.Release()
+	for _, v := range vals {
+		b.Append(v)
+	}
+	return b.NewArray()
+}

--- a/pkg/source/postgres_cdc/cdc_fill.go
+++ b/pkg/source/postgres_cdc/cdc_fill.go
@@ -114,6 +114,11 @@ func forwardFillUnchanged(batch arrow.RecordBatch, pkNames []string) arrow.Recor
 			col := batch.Column(c)
 
 			if unchangedSet[name] && col.IsNull(r) {
+				// Omitted unchanged TOAST: fill from the most recent known row
+				// for this key, even when that value is NULL (an explicit
+				// SET col = NULL upstream). The zero-copy take copies the NULL,
+				// and dropping the column from _cdc_unchanged_cols stops the
+				// destination from resurrecting the stale target value.
 				if priors, ok := lastRow[key]; ok {
 					if sr, ok := priors[c]; ok {
 						srcIndex[c][r] = sr
@@ -125,12 +130,13 @@ func forwardFillUnchanged(batch arrow.RecordBatch, pkNames []string) arrow.Recor
 				continue
 			}
 
-			if !col.IsNull(r) {
-				if lastRow[key] == nil {
-					lastRow[key] = make(map[int]int)
-				}
-				lastRow[key][c] = r
+			// Authoritative value for this row (a real value or an explicit
+			// NULL). Record it regardless of nullness so a later unchanged row
+			// can be filled with it.
+			if lastRow[key] == nil {
+				lastRow[key] = make(map[int]int)
 			}
+			lastRow[key][c] = r
 		}
 
 		if filledAny {
@@ -188,7 +194,7 @@ func pkKeyAt(batch arrow.RecordBatch, pkIdx []int, row int) (string, bool) {
 		}
 		parts[i] = col.ValueStr(row)
 	}
-	return strings.Join(parts, "|"), true
+	return encodeKeyParts(parts), true
 }
 
 func stringAt(arr *array.String, row int) string {

--- a/pkg/source/postgres_cdc/cdc_fill_test.go
+++ b/pkg/source/postgres_cdc/cdc_fill_test.go
@@ -84,6 +84,17 @@ func buildFillBatch(rows []fillRow) arrow.RecordBatch {
 
 func strPtr(s string) *string { return &s }
 
+// releaseFillOutput releases the forward-fill output only when it is a freshly
+// allocated batch. On the no-allocation path forwardFillUnchanged returns the
+// input unchanged without taking an extra reference, so releasing it there
+// would double-free the caller's single reference. This mirrors the ownership
+// contract the accumulator relies on (see batchAccumulator.flushTable).
+func releaseFillOutput(in, out arrow.RecordBatch) {
+	if out != in {
+		out.Release()
+	}
+}
+
 func configValueAt(t *testing.T, batch arrow.RecordBatch, row int) (string, bool) {
 	t.Helper()
 	col, ok := batch.Column(1).(*array.String)
@@ -112,7 +123,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 		require.NotSame(t, in, out, "fill should produce a new batch")
 
 		v, ok := configValueAt(t, out, 1)
@@ -129,7 +140,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 
 		v, ok := configValueAt(t, out, 1)
 		assert.True(t, ok)
@@ -149,7 +160,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 		require.NotSame(t, in, out, "the unchanged row should be rewritten")
 
 		_, ok := configValueAt(t, out, 1)
@@ -165,7 +176,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 		assert.Same(t, in, out, "nothing to fill should return the same batch")
 
 		_, ok := configValueAt(t, out, 1)
@@ -181,7 +192,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 		assert.Same(t, in, out, "different pk must not be filled")
 
 		_, ok := configValueAt(t, out, 1)
@@ -197,7 +208,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 
 		_, ok := configValueAt(t, out, 2)
 		assert.False(t, ok, "value before a delete must not carry past it")
@@ -213,7 +224,7 @@ func TestForwardFillUnchanged(t *testing.T) {
 		defer in.Release()
 
 		out := forwardFillUnchanged(in, pk)
-		defer out.Release()
+		defer releaseFillOutput(in, out)
 
 		v0, ok0 := configValueAt(t, out, 0)
 		assert.True(t, ok0)

--- a/pkg/source/postgres_cdc/cdc_fill_test.go
+++ b/pkg/source/postgres_cdc/cdc_fill_test.go
@@ -137,6 +137,26 @@ func TestForwardFillUnchanged(t *testing.T) {
 		assert.Equal(t, `[]`, unchangedValueAt(t, out, 1))
 	})
 
+	t.Run("explicit null carries across rows and drops unchanged flag", func(t *testing.T) {
+		// An authoritative NULL (SET config_data = NULL) in one transaction
+		// followed by an unchanged TOAST update in another. The NULL must be
+		// filled forward and the column dropped from _cdc_unchanged_cols, so the
+		// destination does not fall back to the stale (non-null) target value.
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: nil, status: "a", lsn: "0/1"},
+			{id: 1, config: nil, status: "b", lsn: "0/2", unchanged: []string{"config_data"}},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+		require.NotSame(t, in, out, "the unchanged row should be rewritten")
+
+		_, ok := configValueAt(t, out, 1)
+		assert.False(t, ok, "filled value should be NULL")
+		assert.Equal(t, `[]`, unchangedValueAt(t, out, 1), "column must be dropped from _cdc_unchanged_cols")
+	})
+
 	t.Run("no prior value keeps column unchanged", func(t *testing.T) {
 		in := buildFillBatch([]fillRow{
 			{id: 1, config: nil, status: "a", lsn: "0/1", unchanged: []string{"config_data"}},

--- a/pkg/source/postgres_cdc/cdc_fill_test.go
+++ b/pkg/source/postgres_cdc/cdc_fill_test.go
@@ -1,0 +1,209 @@
+package postgres_cdc
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fillRow describes one staging row for the forward-fill tests.
+type fillRow struct {
+	id        int64
+	config    *string // nil => null in the config_data column
+	status    string
+	lsn       string
+	deleted   bool
+	unchanged []string
+}
+
+// buildFillBatch assembles a CDC staging batch with two source columns
+// (id, config_data) plus status and the four CDC meta columns.
+func buildFillBatch(rows []fillRow) arrow.RecordBatch {
+	mem := memory.NewGoAllocator()
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "config_data", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "status", Type: arrow.BinaryTypes.String},
+		{Name: CDCLSNColumn, Type: arrow.BinaryTypes.String},
+		{Name: CDCDeletedColumn, Type: arrow.FixedWidthTypes.Boolean},
+		{Name: CDCSyncedAtColumn, Type: &arrow.TimestampType{Unit: arrow.Microsecond}},
+		{Name: CDCUnchangedColsColumn, Type: arrow.BinaryTypes.String},
+	}
+	sc := arrow.NewSchema(fields, nil)
+
+	idB := array.NewInt64Builder(mem)
+	configB := array.NewStringBuilder(mem)
+	statusB := array.NewStringBuilder(mem)
+	lsnB := array.NewStringBuilder(mem)
+	delB := array.NewBooleanBuilder(mem)
+	syncedB := array.NewTimestampBuilder(mem, &arrow.TimestampType{Unit: arrow.Microsecond})
+	unchangedB := array.NewStringBuilder(mem)
+	defer func() {
+		idB.Release()
+		configB.Release()
+		statusB.Release()
+		lsnB.Release()
+		delB.Release()
+		syncedB.Release()
+		unchangedB.Release()
+	}()
+
+	now := time.Now().UTC()
+	for i, r := range rows {
+		idB.Append(r.id)
+		if r.config == nil {
+			configB.AppendNull()
+		} else {
+			configB.Append(*r.config)
+		}
+		statusB.Append(r.status)
+		lsnB.Append(r.lsn)
+		delB.Append(r.deleted)
+		syncedB.Append(arrow.Timestamp(now.Add(time.Duration(i) * time.Microsecond).UnixMicro()))
+		b, _ := json.Marshal(r.unchanged)
+		unchangedB.Append(string(b))
+	}
+
+	cols := []arrow.Array{
+		idB.NewArray(), configB.NewArray(), statusB.NewArray(),
+		lsnB.NewArray(), delB.NewArray(), syncedB.NewArray(), unchangedB.NewArray(),
+	}
+	defer func() {
+		for _, c := range cols {
+			c.Release()
+		}
+	}()
+	return array.NewRecordBatch(sc, cols, int64(len(rows)))
+}
+
+func strPtr(s string) *string { return &s }
+
+func configValueAt(t *testing.T, batch arrow.RecordBatch, row int) (string, bool) {
+	t.Helper()
+	col, ok := batch.Column(1).(*array.String)
+	require.True(t, ok)
+	if col.IsNull(row) {
+		return "", false
+	}
+	return col.Value(row), true
+}
+
+func unchangedValueAt(t *testing.T, batch arrow.RecordBatch, row int) string {
+	t.Helper()
+	col, ok := batch.Column(6).(*array.String)
+	require.True(t, ok)
+	return col.Value(row)
+}
+
+func TestForwardFillUnchanged(t *testing.T) {
+	pk := []string{"id"}
+
+	t.Run("insert then partial update fills omitted toast", func(t *testing.T) {
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: strPtr(`{"big":true}`), status: "pending", lsn: "0/1"},
+			{id: 1, config: nil, status: "done", lsn: "0/2", unchanged: []string{"config_data"}},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+		require.NotSame(t, in, out, "fill should produce a new batch")
+
+		v, ok := configValueAt(t, out, 1)
+		assert.True(t, ok, "config_data should be filled on the partial update row")
+		assert.Equal(t, `{"big":true}`, v)
+		assert.Equal(t, `[]`, unchangedValueAt(t, out, 1), "filled column must be dropped from _cdc_unchanged_cols")
+	})
+
+	t.Run("changed then unchanged overwrites and drops unchanged flag", func(t *testing.T) {
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: strPtr(`{"v":"A"}`), status: "a", lsn: "0/1"},
+			{id: 1, config: nil, status: "b", lsn: "0/2", unchanged: []string{"config_data"}},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+
+		v, ok := configValueAt(t, out, 1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"v":"A"}`, v)
+		assert.Equal(t, `[]`, unchangedValueAt(t, out, 1))
+	})
+
+	t.Run("no prior value keeps column unchanged", func(t *testing.T) {
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: nil, status: "a", lsn: "0/1", unchanged: []string{"config_data"}},
+			{id: 1, config: nil, status: "b", lsn: "0/2", unchanged: []string{"config_data"}},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+		assert.Same(t, in, out, "nothing to fill should return the same batch")
+
+		_, ok := configValueAt(t, out, 1)
+		assert.False(t, ok)
+		assert.Equal(t, `["config_data"]`, unchangedValueAt(t, out, 1))
+	})
+
+	t.Run("does not cross primary keys", func(t *testing.T) {
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: strPtr(`{"id":1}`), status: "a", lsn: "0/1"},
+			{id: 2, config: nil, status: "b", lsn: "0/2", unchanged: []string{"config_data"}},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+		assert.Same(t, in, out, "different pk must not be filled")
+
+		_, ok := configValueAt(t, out, 1)
+		assert.False(t, ok)
+	})
+
+	t.Run("delete resets prior state", func(t *testing.T) {
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: strPtr(`{"v":1}`), status: "a", lsn: "0/1"},
+			{id: 1, config: nil, status: "", lsn: "0/2", deleted: true},
+			{id: 1, config: nil, status: "c", lsn: "0/3", unchanged: []string{"config_data"}},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+
+		_, ok := configValueAt(t, out, 2)
+		assert.False(t, ok, "value before a delete must not carry past it")
+		assert.Equal(t, `["config_data"]`, unchangedValueAt(t, out, 2))
+	})
+
+	t.Run("preserves unrelated rows exactly", func(t *testing.T) {
+		in := buildFillBatch([]fillRow{
+			{id: 1, config: strPtr(`{"big":true}`), status: "pending", lsn: "0/1"},
+			{id: 1, config: nil, status: "done", lsn: "0/2", unchanged: []string{"config_data"}},
+			{id: 2, config: strPtr(`{"other":1}`), status: "x", lsn: "0/3"},
+		})
+		defer in.Release()
+
+		out := forwardFillUnchanged(in, pk)
+		defer out.Release()
+
+		v0, ok0 := configValueAt(t, out, 0)
+		assert.True(t, ok0)
+		assert.Equal(t, `{"big":true}`, v0)
+		v2, ok2 := configValueAt(t, out, 2)
+		assert.True(t, ok2)
+		assert.Equal(t, `{"other":1}`, v2)
+
+		idCol, ok := out.Column(0).(*array.Int64)
+		require.True(t, ok)
+		assert.Equal(t, int64(2), idCol.Value(2))
+	})
+}

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -56,7 +56,6 @@ type Change struct {
 	LSN       pglogrepl.LSN
 	Values    []interface{}
 	OldValues []interface{} // For UPDATE/DELETE with replica identity
-	batchFill []interface{} // intra-batch fill for unchanged TOAST cols without old tuple
 }
 
 type Decoder struct {

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -67,7 +67,6 @@ type Decoder struct {
 	targetRelID    uint32
 	pendingChanges []Change
 	currentTxLSN   pglogrepl.LSN
-	rowFillState   map[string][]interface{}
 }
 
 func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *Decoder {
@@ -76,7 +75,6 @@ func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *
 		targetSchema: schemaName,
 		targetTable:  tableName,
 		relations:    make(map[uint32]*RelationInfo),
-		rowFillState: make(map[string][]interface{}),
 	}
 }
 
@@ -337,7 +335,7 @@ func (d *Decoder) handleDelete(data []byte) error {
 }
 
 func (d *Decoder) applyIntraBatchFill() {
-	applyIntraBatchFill(d.pendingChanges, d.tableSchema, d.rowFillState)
+	applyIntraBatchFill(d.pendingChanges, d.tableSchema)
 }
 
 func (d *Decoder) compactPendingChanges() {

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -57,6 +56,7 @@ type Change struct {
 	LSN       pglogrepl.LSN
 	Values    []interface{}
 	OldValues []interface{} // For UPDATE/DELETE with replica identity
+	batchFill []interface{} // intra-batch fill for unchanged TOAST cols without old tuple
 }
 
 type Decoder struct {
@@ -199,6 +199,7 @@ func (d *Decoder) handleCommit() (arrow.RecordBatch, error) {
 		return nil, nil
 	}
 
+	d.applyIntraBatchFill()
 	d.compactPendingChanges()
 
 	batch, err := d.changesToBatch()
@@ -333,6 +334,10 @@ func (d *Decoder) handleDelete(data []byte) error {
 	return nil
 }
 
+func (d *Decoder) applyIntraBatchFill() {
+	applyIntraBatchFill(d.pendingChanges, d.tableSchema)
+}
+
 func (d *Decoder) compactPendingChanges() {
 	if len(d.pendingChanges) < 2 {
 		return
@@ -393,21 +398,7 @@ func (d *Decoder) compactPendingChanges() {
 }
 
 func (d *Decoder) pkKey(change Change, pkIndices []int, changeIndex int) string {
-	parts := make([]string, len(pkIndices))
-	for i, idx := range pkIndices {
-		var val interface{}
-		if idx < len(change.Values) {
-			val = change.Values[idx]
-		}
-		if val == nil && idx < len(change.OldValues) {
-			val = change.OldValues[idx]
-		}
-		if val == nil {
-			return fmt.Sprintf("row-%d", changeIndex)
-		}
-		parts[i] = fmt.Sprintf("%T:%v", val, val)
-	}
-	return strings.Join(parts, "|")
+	return changePKKey(change, pkIndices, changeIndex)
 }
 
 func (d *Decoder) parseTupleData(data []byte, rel *RelationInfo) ([]interface{}, error) {

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -67,6 +67,7 @@ type Decoder struct {
 	targetRelID    uint32
 	pendingChanges []Change
 	currentTxLSN   pglogrepl.LSN
+	rowFillState   map[string][]interface{}
 }
 
 func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *Decoder {
@@ -75,6 +76,7 @@ func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *
 		targetSchema: schemaName,
 		targetTable:  tableName,
 		relations:    make(map[uint32]*RelationInfo),
+		rowFillState: make(map[string][]interface{}),
 	}
 }
 
@@ -335,7 +337,7 @@ func (d *Decoder) handleDelete(data []byte) error {
 }
 
 func (d *Decoder) applyIntraBatchFill() {
-	applyIntraBatchFill(d.pendingChanges, d.tableSchema)
+	applyIntraBatchFill(d.pendingChanges, d.tableSchema, d.rowFillState)
 }
 
 func (d *Decoder) compactPendingChanges() {
@@ -398,7 +400,7 @@ func (d *Decoder) compactPendingChanges() {
 }
 
 func (d *Decoder) pkKey(change Change, pkIndices []int, changeIndex int) string {
-	return changePKKey(change, pkIndices, changeIndex)
+	return pkKeyFromRow(change.Values, change.OldValues, pkIndices, changeIndex)
 }
 
 func (d *Decoder) parseTupleData(data []byte, rel *RelationInfo) ([]interface{}, error) {

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -319,6 +319,28 @@ func TestApplyIntraBatchFill(t *testing.T) {
 		assert.Equal(t, `[]`, unchangedColumnsJSON(changes[1], tableSchema.Columns, 3))
 	})
 
+	t.Run("explicit null then unchanged keeps the null", func(t *testing.T) {
+		// SET config_data = NULL, then a partial update that leaves it unchanged.
+		// The known value is NULL, so it must be propagated (column dropped from
+		// _cdc_unchanged_cols) rather than letting the destination resurrect the
+		// stale target value.
+		changes := []Change{
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), nil, "a"},
+				OldValues: []interface{}{int32(1)},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "b"},
+				OldValues: []interface{}{int32(1)},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Nil(t, resolveColumnValue(changes[1], 1))
+		assert.Equal(t, `[]`, unchangedColumnsJSON(changes[1], tableSchema.Columns, 3))
+	})
+
 	t.Run("unfilled unchanged column stays in unchanged cols", func(t *testing.T) {
 		// No prior value available in the commit, so the column remains unchanged
 		// and the destination must fall back to the existing target value.

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -408,6 +408,31 @@ func TestApplyIntraBatchFill(t *testing.T) {
 		}
 		applyIntraBatchFill(changes, tableSchema)
 		assert.Equal(t, `{"from":"old"}`, resolveColumnValue(changes[1], 1))
+		// The old-tuple value is authoritative, so the column must not be
+		// reported as unchanged (otherwise a matched merge would ignore it).
+		assert.Equal(t, `[]`, unchangedColumnsJSON(changes[1], tableSchema.Columns, 3))
+	})
+
+	t.Run("old-tuple resolution drops unchanged flag after same-batch change", func(t *testing.T) {
+		// An authoritative change to config, then a later unchanged update whose
+		// REPLICA IDENTITY FULL old tuple still carries the value. Compaction
+		// keeps only the latest row, so the column must be emitted (not flagged
+		// unchanged) or the destination falls back to the stale target value.
+		changes := []Change{
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), `{"v":"A"}`, "a"},
+				OldValues: []interface{}{int32(1), `{"v":"OLD"}`, "a"},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "b"},
+				OldValues: []interface{}{int32(1), `{"v":"A"}`, "a"},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Equal(t, `{"v":"A"}`, resolveColumnValue(changes[1], 1))
+		assert.Equal(t, `[]`, unchangedColumnsJSON(changes[1], tableSchema.Columns, 3))
 	})
 
 	t.Run("does not fill across separate commits", func(t *testing.T) {

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -292,9 +292,44 @@ func TestApplyIntraBatchFill(t *testing.T) {
 				OldValues: []interface{}{int32(1)},
 			},
 		}
-		applyIntraBatchFill(changes, tableSchema)
+		state := make(map[string][]interface{})
+		applyIntraBatchFill(changes, tableSchema, state)
 		assert.Equal(t, `{"big":true}`, resolveColumnValue(changes[1], 1))
 		assert.Equal(t, "done", resolveColumnValue(changes[1], 2))
+	})
+
+	t.Run("fills across separate transaction commits", func(t *testing.T) {
+		state := make(map[string][]interface{})
+		insert := []Change{{
+			Operation: "INSERT",
+			Values:    []interface{}{int32(1), `{"big":true}`, "pending"},
+		}}
+		applyIntraBatchFill(insert, tableSchema, state)
+
+		update := []Change{{
+			Operation: "UPDATE",
+			Values:    []interface{}{int32(1), tupleUnchangedMarker, "done"},
+			OldValues: []interface{}{int32(1)},
+		}}
+		applyIntraBatchFill(update, tableSchema, state)
+		assert.Equal(t, `{"big":true}`, resolveColumnValue(update[0], 1))
+	})
+
+	t.Run("pk update carries unchanged toast from old key", func(t *testing.T) {
+		state := make(map[string][]interface{})
+		insert := []Change{{
+			Operation: "INSERT",
+			Values:    []interface{}{int32(1), `{"keep":true}`, "pending"},
+		}}
+		applyIntraBatchFill(insert, tableSchema, state)
+
+		update := []Change{{
+			Operation: "UPDATE",
+			Values:    []interface{}{int32(2), tupleUnchangedMarker, "done"},
+			OldValues: []interface{}{int32(1)},
+		}}
+		applyIntraBatchFill(update, tableSchema, state)
+		assert.Equal(t, `{"keep":true}`, resolveColumnValue(update[0], 1))
 	})
 
 	t.Run("chains multiple unchanged updates", func(t *testing.T) {
@@ -314,7 +349,8 @@ func TestApplyIntraBatchFill(t *testing.T) {
 				OldValues: []interface{}{int32(1)},
 			},
 		}
-		applyIntraBatchFill(changes, tableSchema)
+		state := make(map[string][]interface{})
+		applyIntraBatchFill(changes, tableSchema, state)
 		assert.Equal(t, `{"v":1}`, resolveColumnValue(changes[2], 1))
 		assert.Equal(t, "c", resolveColumnValue(changes[2], 2))
 	})
@@ -331,7 +367,8 @@ func TestApplyIntraBatchFill(t *testing.T) {
 				OldValues: []interface{}{int32(1), `{"from":"old"}`, "pending"},
 			},
 		}
-		applyIntraBatchFill(changes, tableSchema)
+		state := make(map[string][]interface{})
+		applyIntraBatchFill(changes, tableSchema, state)
 		assert.Equal(t, `{"from":"old"}`, resolveColumnValue(changes[1], 1))
 	})
 }

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -292,44 +292,62 @@ func TestApplyIntraBatchFill(t *testing.T) {
 				OldValues: []interface{}{int32(1)},
 			},
 		}
-		state := make(map[string][]interface{})
-		applyIntraBatchFill(changes, tableSchema, state)
+		applyIntraBatchFill(changes, tableSchema)
 		assert.Equal(t, `{"big":true}`, resolveColumnValue(changes[1], 1))
 		assert.Equal(t, "done", resolveColumnValue(changes[1], 2))
 	})
 
-	t.Run("fills across separate transaction commits", func(t *testing.T) {
-		state := make(map[string][]interface{})
-		insert := []Change{{
-			Operation: "INSERT",
-			Values:    []interface{}{int32(1), `{"big":true}`, "pending"},
-		}}
-		applyIntraBatchFill(insert, tableSchema, state)
-
-		update := []Change{{
-			Operation: "UPDATE",
-			Values:    []interface{}{int32(1), tupleUnchangedMarker, "done"},
-			OldValues: []interface{}{int32(1)},
-		}}
-		applyIntraBatchFill(update, tableSchema, state)
-		assert.Equal(t, `{"big":true}`, resolveColumnValue(update[0], 1))
+	t.Run("filled column is dropped from unchanged cols", func(t *testing.T) {
+		// A changed value followed by a partial update that leaves the column
+		// unchanged, in the same commit. The latest row wins at the destination;
+		// because we now have an authoritative value in staging, the column must
+		// NOT be reported as unchanged or the merge would keep a stale target.
+		changes := []Change{
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), `{"v":"new"}`, "a"},
+				OldValues: []interface{}{int32(1)},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "b"},
+				OldValues: []interface{}{int32(1)},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Equal(t, `{"v":"new"}`, resolveColumnValue(changes[1], 1))
+		assert.Equal(t, `[]`, unchangedColumnsJSON(changes[1], tableSchema.Columns, 3))
 	})
 
-	t.Run("pk update carries unchanged toast from old key", func(t *testing.T) {
-		state := make(map[string][]interface{})
-		insert := []Change{{
-			Operation: "INSERT",
-			Values:    []interface{}{int32(1), `{"keep":true}`, "pending"},
-		}}
-		applyIntraBatchFill(insert, tableSchema, state)
+	t.Run("unfilled unchanged column stays in unchanged cols", func(t *testing.T) {
+		// No prior value available in the commit, so the column remains unchanged
+		// and the destination must fall back to the existing target value.
+		changes := []Change{
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "b"},
+				OldValues: []interface{}{int32(1)},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Nil(t, resolveColumnValue(changes[0], 1))
+		assert.Equal(t, `["config_data"]`, unchangedColumnsJSON(changes[0], tableSchema.Columns, 3))
+	})
 
-		update := []Change{{
-			Operation: "UPDATE",
-			Values:    []interface{}{int32(2), tupleUnchangedMarker, "done"},
-			OldValues: []interface{}{int32(1)},
-		}}
-		applyIntraBatchFill(update, tableSchema, state)
-		assert.Equal(t, `{"keep":true}`, resolveColumnValue(update[0], 1))
+	t.Run("pk update carries unchanged toast from old key within commit", func(t *testing.T) {
+		changes := []Change{
+			{
+				Operation: "INSERT",
+				Values:    []interface{}{int32(1), `{"keep":true}`, "pending"},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(2), tupleUnchangedMarker, "done"},
+				OldValues: []interface{}{int32(1)},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Equal(t, `{"keep":true}`, resolveColumnValue(changes[1], 1))
 	})
 
 	t.Run("chains multiple unchanged updates", func(t *testing.T) {
@@ -349,8 +367,7 @@ func TestApplyIntraBatchFill(t *testing.T) {
 				OldValues: []interface{}{int32(1)},
 			},
 		}
-		state := make(map[string][]interface{})
-		applyIntraBatchFill(changes, tableSchema, state)
+		applyIntraBatchFill(changes, tableSchema)
 		assert.Equal(t, `{"v":1}`, resolveColumnValue(changes[2], 1))
 		assert.Equal(t, "c", resolveColumnValue(changes[2], 2))
 	})
@@ -367,9 +384,27 @@ func TestApplyIntraBatchFill(t *testing.T) {
 				OldValues: []interface{}{int32(1), `{"from":"old"}`, "pending"},
 			},
 		}
-		state := make(map[string][]interface{})
-		applyIntraBatchFill(changes, tableSchema, state)
+		applyIntraBatchFill(changes, tableSchema)
 		assert.Equal(t, `{"from":"old"}`, resolveColumnValue(changes[1], 1))
+	})
+
+	t.Run("does not fill across separate commits", func(t *testing.T) {
+		// Cross-commit coalescing is handled at the staging-batch level
+		// (forwardFillUnchanged), not by the decoder. A partial UPDATE arriving
+		// in its own commit has no prior state and stays unchanged.
+		insert := []Change{{
+			Operation: "INSERT",
+			Values:    []interface{}{int32(1), `{"big":true}`, "pending"},
+		}}
+		applyIntraBatchFill(insert, tableSchema)
+
+		update := []Change{{
+			Operation: "UPDATE",
+			Values:    []interface{}{int32(1), tupleUnchangedMarker, "done"},
+			OldValues: []interface{}{int32(1)},
+		}}
+		applyIntraBatchFill(update, tableSchema)
+		assert.Nil(t, resolveColumnValue(update[0], 1))
 	})
 }
 

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -269,6 +269,82 @@ func TestUnchangedColumnsJSON(t *testing.T) {
 	assert.Equal(t, "[]", unchangedColumnsJSON(Change{Operation: "INSERT", Values: []interface{}{int32(1)}}, cols, 3))
 }
 
+func TestApplyIntraBatchFill(t *testing.T) {
+	cols := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt32},
+		{Name: "config_data", DataType: schema.TypeString},
+		{Name: "status", DataType: schema.TypeString},
+	}
+	tableSchema := &schema.TableSchema{
+		Columns:     append(cols, cdcMetaColumns()...),
+		PrimaryKeys: []string{"id"},
+	}
+
+	t.Run("insert then partial update fills unchanged from batch", func(t *testing.T) {
+		changes := []Change{
+			{
+				Operation: "INSERT",
+				Values:    []interface{}{int32(1), `{"big":true}`, "pending"},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "done"},
+				OldValues: []interface{}{int32(1)},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Equal(t, `{"big":true}`, resolveColumnValue(changes[1], 1))
+		assert.Equal(t, "done", resolveColumnValue(changes[1], 2))
+	})
+
+	t.Run("chains multiple unchanged updates", func(t *testing.T) {
+		changes := []Change{
+			{
+				Operation: "INSERT",
+				Values:    []interface{}{int32(1), `{"v":1}`, "a"},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "b"},
+				OldValues: []interface{}{int32(1)},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "c"},
+				OldValues: []interface{}{int32(1)},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Equal(t, `{"v":1}`, resolveColumnValue(changes[2], 1))
+		assert.Equal(t, "c", resolveColumnValue(changes[2], 2))
+	})
+
+	t.Run("old tuple still preferred over batch state", func(t *testing.T) {
+		changes := []Change{
+			{
+				Operation: "INSERT",
+				Values:    []interface{}{int32(1), `{"from":"insert"}`, "pending"},
+			},
+			{
+				Operation: "UPDATE",
+				Values:    []interface{}{int32(1), tupleUnchangedMarker, "done"},
+				OldValues: []interface{}{int32(1), `{"from":"old"}`, "pending"},
+			},
+		}
+		applyIntraBatchFill(changes, tableSchema)
+		assert.Equal(t, `{"from":"old"}`, resolveColumnValue(changes[1], 1))
+	})
+}
+
+func cdcMetaColumns() []schema.Column {
+	return []schema.Column{
+		{Name: CDCLSNColumn, DataType: schema.TypeString},
+		{Name: CDCDeletedColumn, DataType: schema.TypeBoolean},
+		{Name: CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+		{Name: CDCUnchangedColsColumn, DataType: schema.TypeString},
+	}
+}
+
 func TestNewDecoder(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Name:   "orders",

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -28,7 +28,6 @@ type MultiTableDecoder struct {
 	targetRelIDs   map[uint32]string // relation ID -> full table name
 	pendingChanges []TableChange
 	currentTxLSN   pglogrepl.LSN
-	rowFillState   map[string]map[string][]interface{}
 }
 
 func NewMultiTableDecoder(tables []source.SourceTableInfo) *MultiTableDecoder {
@@ -41,7 +40,6 @@ func NewMultiTableDecoder(tables []source.SourceTableInfo) *MultiTableDecoder {
 		tableSchemas: tableSchemas,
 		relations:    make(map[uint32]*RelationInfo),
 		targetRelIDs: make(map[uint32]string),
-		rowFillState: make(map[string]map[string][]interface{}),
 	}
 }
 
@@ -197,10 +195,7 @@ func (d *MultiTableDecoder) handleCommit() ([]DecodedBatch, error) {
 			continue
 		}
 
-		if d.rowFillState[tableName] == nil {
-			d.rowFillState[tableName] = make(map[string][]interface{})
-		}
-		applyIntraBatchFill(changes, tableSchema, d.rowFillState[tableName])
+		applyIntraBatchFill(changes, tableSchema)
 
 		batch, err := d.changesToBatch(changes, tableSchema)
 		if err != nil {

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -195,6 +195,8 @@ func (d *MultiTableDecoder) handleCommit() ([]DecodedBatch, error) {
 			continue
 		}
 
+		applyIntraBatchFill(changes, tableSchema)
+
 		batch, err := d.changesToBatch(changes, tableSchema)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert changes for table %s: %w", tableName, err)

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -28,6 +28,7 @@ type MultiTableDecoder struct {
 	targetRelIDs   map[uint32]string // relation ID -> full table name
 	pendingChanges []TableChange
 	currentTxLSN   pglogrepl.LSN
+	rowFillState   map[string]map[string][]interface{}
 }
 
 func NewMultiTableDecoder(tables []source.SourceTableInfo) *MultiTableDecoder {
@@ -40,6 +41,7 @@ func NewMultiTableDecoder(tables []source.SourceTableInfo) *MultiTableDecoder {
 		tableSchemas: tableSchemas,
 		relations:    make(map[uint32]*RelationInfo),
 		targetRelIDs: make(map[uint32]string),
+		rowFillState: make(map[string]map[string][]interface{}),
 	}
 }
 
@@ -195,7 +197,10 @@ func (d *MultiTableDecoder) handleCommit() ([]DecodedBatch, error) {
 			continue
 		}
 
-		applyIntraBatchFill(changes, tableSchema)
+		if d.rowFillState[tableName] == nil {
+			d.rowFillState[tableName] = make(map[string][]interface{})
+		}
+		applyIntraBatchFill(changes, tableSchema, d.rowFillState[tableName])
 
 		batch, err := d.changesToBatch(changes, tableSchema)
 		if err != nil {

--- a/pkg/source/postgres_cdc/multitable_decoder_test.go
+++ b/pkg/source/postgres_cdc/multitable_decoder_test.go
@@ -5,10 +5,33 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/jackc/pglogrepl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// User-provided merge keys (SourceTableInfo.PrimaryKeys) must be reconciled into
+// the schema so the decoder, compaction, and unchanged-TOAST fill all key off
+// them — otherwise tables without a detected database primary key silently run
+// the fill pass with no keys and lose unchanged TOAST values.
+func TestNewMultiTableCDCReaderReconcilesPrimaryKeys(t *testing.T) {
+	t.Run("user keys override empty schema keys", func(t *testing.T) {
+		withKeys := &schema.TableSchema{Name: "events", PrimaryKeys: nil}
+		NewMultiTableCDCReader(nil, []source.SourceTableInfo{
+			{Name: "events", Schema: withKeys, PrimaryKeys: []string{"event_id"}},
+		}, CDCConfig{}, nil, "")
+		assert.Equal(t, []string{"event_id"}, withKeys.PrimaryKeys)
+	})
+
+	t.Run("detected schema keys are preserved when no override", func(t *testing.T) {
+		detected := &schema.TableSchema{Name: "accounts", PrimaryKeys: []string{"id"}}
+		NewMultiTableCDCReader(nil, []source.SourceTableInfo{
+			{Name: "accounts", Schema: detected, PrimaryKeys: nil},
+		}, CDCConfig{}, nil, "")
+		assert.Equal(t, []string{"id"}, detected.PrimaryKeys)
+	})
+}
 
 func TestMultiTableDecoderChangesToBatchSequencesSyncedAt(t *testing.T) {
 	tableSchema := &schema.TableSchema{

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/jackc/pglogrepl"
@@ -276,6 +277,15 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 	}
 
 	accum := newBatchAccumulator(batchSize)
+	pkByTable := make(map[string][]string, len(r.tables))
+	for _, t := range r.tables {
+		if t.Schema != nil {
+			pkByTable[t.Name] = t.Schema.PrimaryKeys
+		}
+	}
+	accum.transform = func(tableName string, batch arrow.RecordBatch) arrow.RecordBatch {
+		return forwardFillUnchanged(batch, pkByTable[tableName])
+	}
 
 	for {
 		select {

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -24,6 +24,15 @@ type MultiTableCDCReader struct {
 }
 
 func NewMultiTableCDCReader(src *PostgresCDCSource, tables []source.SourceTableInfo, cdcConfig CDCConfig, resumeLSNs map[string]string, slotSuffix string) *MultiTableCDCReader {
+	// Reconcile each table's effective merge keys into its schema so the decoder,
+	// compaction, and unchanged-TOAST fill all key off the same keys the
+	// destination merge uses. SourceTableInfo.PrimaryKeys is authoritative and
+	// may carry user-provided keys that the schema's detected keys lack.
+	for i := range tables {
+		if len(tables[i].PrimaryKeys) > 0 && tables[i].Schema != nil {
+			tables[i].Schema.PrimaryKeys = tables[i].PrimaryKeys
+		}
+	}
 	return &MultiTableCDCReader{
 		source:        src,
 		tables:        tables,
@@ -279,9 +288,11 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 	accum := newBatchAccumulator(batchSize)
 	pkByTable := make(map[string][]string, len(r.tables))
 	for _, t := range r.tables {
-		if t.Schema != nil {
-			pkByTable[t.Name] = t.Schema.PrimaryKeys
+		pks := t.PrimaryKeys
+		if len(pks) == 0 && t.Schema != nil {
+			pks = t.Schema.PrimaryKeys
 		}
+		pkByTable[t.Name] = pks
 	}
 	accum.transform = func(tableName string, batch arrow.RecordBatch) arrow.RecordBatch {
 		return forwardFillUnchanged(batch, pkByTable[tableName])

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -120,6 +120,10 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 	}
 
 	accum := newBatchAccumulator(batchSize)
+	pkNames := r.tableSchema.PrimaryKeys
+	accum.transform = func(_ string, batch arrow.RecordBatch) arrow.RecordBatch {
+		return forwardFillUnchanged(batch, pkNames)
+	}
 
 	return streamLoop(ctx, repl, r.cdcConfig.Mode, targetLSN, batchSize, accum, results)
 }

--- a/pkg/source/postgres_cdc/table.go
+++ b/pkg/source/postgres_cdc/table.go
@@ -47,6 +47,11 @@ func NewCDCTable(src *PostgresCDCSource, req source.TableRequest) (*CDCTable, er
 	if len(pks) == 0 {
 		pks = tableSchema.PrimaryKeys
 	}
+	// Reconcile the effective merge keys into the schema so the decoder,
+	// compaction, and unchanged-TOAST fill all key off the same keys the
+	// destination merge uses (user-provided keys are otherwise ignored when the
+	// table has no database primary key).
+	tableSchema.PrimaryKeys = pks
 
 	// CDC requires merge strategy with primary keys
 	strategy := req.Strategy

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -21,8 +21,8 @@ func resolveColumnValue(change Change, colIdx int) interface{} {
 	if v := resolveColumnValueBase(change, colIdx); v != nil || !columnIsUnchanged(change, colIdx) {
 		return v
 	}
-	if change.batchFill != nil && colIdx < len(change.batchFill) {
-		return change.batchFill[colIdx]
+	if v, ok := columnFilledFromBatch(change, colIdx); ok {
+		return v
 	}
 	return nil
 }
@@ -44,8 +44,25 @@ func resolveColumnValueBase(change Change, colIdx int) interface{} {
 	return nil
 }
 
-func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema, state map[string][]interface{}) {
-	if len(changes) == 0 || tableSchema == nil || state == nil {
+// columnFilledFromBatch reports whether the column's value was supplied from the
+// within-commit fill (i.e. staging now holds an authoritative value for it).
+func columnFilledFromBatch(change Change, colIdx int) (interface{}, bool) {
+	if change.batchFill == nil || colIdx >= len(change.batchFill) {
+		return nil, false
+	}
+	v := change.batchFill[colIdx]
+	return v, v != nil
+}
+
+// applyIntraBatchFill coalesces unchanged TOAST columns within a single commit:
+// an INSERT (or full-value row) followed by a partial UPDATE of the same primary
+// key, where the UPDATE omits the unchanged TOAST value. compactPendingChanges
+// later keeps only the latest row per key, so without this the earlier full
+// value would be lost. State is local to the commit; cross-commit coalescing is
+// handled later at the staging-batch level (see forwardFillUnchanged), which is
+// where separate transactions are actually merged.
+func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
+	if len(changes) == 0 || tableSchema == nil {
 		return
 	}
 
@@ -55,6 +72,7 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema, stat
 	}
 
 	nSource := sourceColumnCount(tableSchema)
+	state := make(map[string][]interface{})
 
 	for i := range changes {
 		change := &changes[i]
@@ -80,6 +98,9 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema, stat
 
 		if change.Operation == "DELETE" {
 			delete(state, storeKey)
+			if lookupKey != storeKey {
+				delete(state, lookupKey)
+			}
 			continue
 		}
 
@@ -87,10 +108,10 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema, stat
 		for colIdx := 0; colIdx < nSource; colIdx++ {
 			resolved[colIdx] = resolveColumnValue(*change, colIdx)
 		}
-		state[storeKey] = resolved
 		if lookupKey != storeKey {
 			delete(state, lookupKey)
 		}
+		state[storeKey] = resolved
 	}
 }
 
@@ -109,8 +130,11 @@ func pkValueChanged(change Change, pkIndices []int) bool {
 	}
 	for _, idx := range pkIndices {
 		old := columnValueAt(change.OldValues, idx)
-		new := columnValueAt(change.Values, idx)
-		if fmt.Sprintf("%v", old) != fmt.Sprintf("%v", new) {
+		cur := columnValueAt(change.Values, idx)
+		if isTupleUnchanged(cur) {
+			continue
+		}
+		if fmt.Sprintf("%v", old) != fmt.Sprintf("%v", cur) {
 			return true
 		}
 	}
@@ -149,10 +173,10 @@ func pkKeyFromRow(values, oldValues []interface{}, pkIndices []int, changeIndex 
 	parts := make([]string, len(pkIndices))
 	for i, idx := range pkIndices {
 		val := columnValueAt(values, idx)
-		if val == nil {
+		if val == nil || isTupleUnchanged(val) {
 			val = columnValueAt(oldValues, idx)
 		}
-		if val == nil {
+		if val == nil || isTupleUnchanged(val) {
 			return fmt.Sprintf("row-%d", changeIndex)
 		}
 		parts[i] = fmt.Sprintf("%T:%v", val, val)
@@ -176,9 +200,17 @@ func unchangedColumnsJSON(change Change, columns []schema.Column, nSourceCols in
 	}
 	names := make([]string, 0)
 	for i := 0; i < nSourceCols && i < len(columns); i++ {
-		if columnIsUnchanged(change, i) {
-			names = append(names, columns[i].Name)
+		if !columnIsUnchanged(change, i) {
+			continue
 		}
+		// A column resolved from the cross-commit fill cache now has an
+		// authoritative value in staging, so it must NOT be reported as
+		// unchanged; otherwise the destination merge would keep the (possibly
+		// stale) target value instead of the filled one on an existing row.
+		if _, filled := columnFilledFromBatch(change, i); filled {
+			continue
+		}
+		names = append(names, columns[i].Name)
 	}
 	b, err := json.Marshal(names)
 	if err != nil {

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -78,17 +78,20 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 		lookupKey, storeKey := fillStateKeys(*change, pkIndices, i)
 		prior := state[lookupKey]
 
-		if prior != nil {
-			for colIdx := 0; colIdx < nSource && colIdx < len(prior); colIdx++ {
-				if !columnIsUnchanged(*change, colIdx) {
-					continue
-				}
-				if resolveColumnValueBase(*change, colIdx) != nil {
-					continue
-				}
-				if prior[colIdx].known {
-					setColumnValue(change, colIdx, prior[colIdx].val)
-				}
+		for colIdx := 0; colIdx < nSource; colIdx++ {
+			if !columnIsUnchanged(*change, colIdx) {
+				continue
+			}
+			if base := resolveColumnValueBase(*change, colIdx); base != nil {
+				// Authoritative old-tuple value (REPLICA IDENTITY FULL). Clear
+				// the marker so the column is emitted with its value and not
+				// reported as unchanged; otherwise a matched merge falls back to
+				// the target and discards a value set earlier in the same batch.
+				setColumnValue(change, colIdx, base)
+				continue
+			}
+			if prior != nil && colIdx < len(prior) && prior[colIdx].known {
+				setColumnValue(change, colIdx, prior[colIdx].val)
 			}
 		}
 

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -2,6 +2,8 @@ package postgres_cdc
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
@@ -16,6 +18,16 @@ func isTupleUnchanged(v interface{}) bool {
 }
 
 func resolveColumnValue(change Change, colIdx int) interface{} {
+	if v := resolveColumnValueBase(change, colIdx); v != nil || !columnIsUnchanged(change, colIdx) {
+		return v
+	}
+	if change.batchFill != nil && colIdx < len(change.batchFill) {
+		return change.batchFill[colIdx]
+	}
+	return nil
+}
+
+func resolveColumnValueBase(change Change, colIdx int) interface{} {
 	var val interface{}
 	if colIdx < len(change.Values) {
 		val = change.Values[colIdx]
@@ -30,6 +42,93 @@ func resolveColumnValue(change Change, colIdx int) interface{} {
 		}
 	}
 	return nil
+}
+
+func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
+	if len(changes) < 2 || tableSchema == nil {
+		return
+	}
+
+	pkIndices := pkColumnIndices(tableSchema.Columns, tableSchema.PrimaryKeys)
+	if len(pkIndices) == 0 {
+		return
+	}
+
+	nSource := sourceColumnCount(tableSchema)
+	state := make(map[string][]interface{})
+
+	for i := range changes {
+		change := &changes[i]
+		key := changePKKey(*change, pkIndices, i)
+
+		batchFill := make([]interface{}, nSource)
+		hasFill := false
+		for colIdx := 0; colIdx < nSource; colIdx++ {
+			if !columnIsUnchanged(*change, colIdx) {
+				continue
+			}
+			if resolveColumnValueBase(*change, colIdx) != nil {
+				continue
+			}
+			if prior, ok := state[key]; ok && colIdx < len(prior) && prior[colIdx] != nil {
+				batchFill[colIdx] = prior[colIdx]
+				hasFill = true
+			}
+		}
+		if hasFill {
+			change.batchFill = batchFill
+		}
+
+		if change.Operation == "DELETE" {
+			delete(state, key)
+			continue
+		}
+
+		resolved := make([]interface{}, nSource)
+		for colIdx := 0; colIdx < nSource; colIdx++ {
+			resolved[colIdx] = resolveColumnValue(*change, colIdx)
+		}
+		state[key] = resolved
+	}
+}
+
+func pkColumnIndices(columns []schema.Column, primaryKeys []string) []int {
+	if len(primaryKeys) == 0 {
+		return nil
+	}
+	indices := make([]int, 0, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		idx := -1
+		for colIdx, col := range columns {
+			if col.Name == pk {
+				idx = colIdx
+				break
+			}
+		}
+		if idx < 0 {
+			return nil
+		}
+		indices = append(indices, idx)
+	}
+	return indices
+}
+
+func changePKKey(change Change, pkIndices []int, changeIndex int) string {
+	parts := make([]string, len(pkIndices))
+	for i, idx := range pkIndices {
+		var val interface{}
+		if idx < len(change.Values) {
+			val = change.Values[idx]
+		}
+		if val == nil && idx < len(change.OldValues) {
+			val = change.OldValues[idx]
+		}
+		if val == nil {
+			return fmt.Sprintf("row-%d", changeIndex)
+		}
+		parts[i] = fmt.Sprintf("%T:%v", val, val)
+	}
+	return strings.Join(parts, "|")
 }
 
 func columnIsUnchanged(change Change, colIdx int) bool {

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -44,8 +44,8 @@ func resolveColumnValueBase(change Change, colIdx int) interface{} {
 	return nil
 }
 
-func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
-	if len(changes) < 2 || tableSchema == nil {
+func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema, state map[string][]interface{}) {
+	if len(changes) == 0 || tableSchema == nil || state == nil {
 		return
 	}
 
@@ -55,11 +55,10 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 	}
 
 	nSource := sourceColumnCount(tableSchema)
-	state := make(map[string][]interface{})
 
 	for i := range changes {
 		change := &changes[i]
-		key := changePKKey(*change, pkIndices, i)
+		lookupKey, storeKey := fillStateKeys(*change, pkIndices, i)
 
 		batchFill := make([]interface{}, nSource)
 		hasFill := false
@@ -70,7 +69,7 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 			if resolveColumnValueBase(*change, colIdx) != nil {
 				continue
 			}
-			if prior, ok := state[key]; ok && colIdx < len(prior) && prior[colIdx] != nil {
+			if prior, ok := state[lookupKey]; ok && colIdx < len(prior) && prior[colIdx] != nil {
 				batchFill[colIdx] = prior[colIdx]
 				hasFill = true
 			}
@@ -80,7 +79,7 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 		}
 
 		if change.Operation == "DELETE" {
-			delete(state, key)
+			delete(state, storeKey)
 			continue
 		}
 
@@ -88,8 +87,41 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 		for colIdx := 0; colIdx < nSource; colIdx++ {
 			resolved[colIdx] = resolveColumnValue(*change, colIdx)
 		}
-		state[key] = resolved
+		state[storeKey] = resolved
+		if lookupKey != storeKey {
+			delete(state, lookupKey)
+		}
 	}
+}
+
+func fillStateKeys(change Change, pkIndices []int, changeIndex int) (lookupKey, storeKey string) {
+	storeKey = pkKeyFromRow(change.Values, change.OldValues, pkIndices, changeIndex)
+	lookupKey = storeKey
+	if change.Operation == "UPDATE" && pkValueChanged(change, pkIndices) {
+		lookupKey = pkKeyFromRow(change.OldValues, change.OldValues, pkIndices, changeIndex)
+	}
+	return lookupKey, storeKey
+}
+
+func pkValueChanged(change Change, pkIndices []int) bool {
+	if change.Operation != "UPDATE" {
+		return false
+	}
+	for _, idx := range pkIndices {
+		old := columnValueAt(change.OldValues, idx)
+		new := columnValueAt(change.Values, idx)
+		if fmt.Sprintf("%v", old) != fmt.Sprintf("%v", new) {
+			return true
+		}
+	}
+	return false
+}
+
+func columnValueAt(values []interface{}, idx int) interface{} {
+	if idx < len(values) {
+		return values[idx]
+	}
+	return nil
 }
 
 func pkColumnIndices(columns []schema.Column, primaryKeys []string) []int {
@@ -113,15 +145,12 @@ func pkColumnIndices(columns []schema.Column, primaryKeys []string) []int {
 	return indices
 }
 
-func changePKKey(change Change, pkIndices []int, changeIndex int) string {
+func pkKeyFromRow(values, oldValues []interface{}, pkIndices []int, changeIndex int) string {
 	parts := make([]string, len(pkIndices))
 	for i, idx := range pkIndices {
-		var val interface{}
-		if idx < len(change.Values) {
-			val = change.Values[idx]
-		}
-		if val == nil && idx < len(change.OldValues) {
-			val = change.OldValues[idx]
+		val := columnValueAt(values, idx)
+		if val == nil {
+			val = columnValueAt(oldValues, idx)
 		}
 		if val == nil {
 			return fmt.Sprintf("row-%d", changeIndex)

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -3,6 +3,7 @@ package postgres_cdc
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -18,13 +19,7 @@ func isTupleUnchanged(v interface{}) bool {
 }
 
 func resolveColumnValue(change Change, colIdx int) interface{} {
-	if v := resolveColumnValueBase(change, colIdx); v != nil || !columnIsUnchanged(change, colIdx) {
-		return v
-	}
-	if v, ok := columnFilledFromBatch(change, colIdx); ok {
-		return v
-	}
-	return nil
+	return resolveColumnValueBase(change, colIdx)
 }
 
 func resolveColumnValueBase(change Change, colIdx int) interface{} {
@@ -44,23 +39,27 @@ func resolveColumnValueBase(change Change, colIdx int) interface{} {
 	return nil
 }
 
-// columnFilledFromBatch reports whether the column's value was supplied from the
-// within-commit fill (i.e. staging now holds an authoritative value for it).
-func columnFilledFromBatch(change Change, colIdx int) (interface{}, bool) {
-	if change.batchFill == nil || colIdx >= len(change.batchFill) {
-		return nil, false
-	}
-	v := change.batchFill[colIdx]
-	return v, v != nil
+// knownValue is a column value tracked during within-commit fill. known
+// distinguishes an authoritative NULL (an explicit SET col = NULL, which must be
+// propagated) from a column we have no information about (which must stay
+// unchanged so the destination uses its target value).
+type knownValue struct {
+	val   interface{}
+	known bool
 }
 
 // applyIntraBatchFill coalesces unchanged TOAST columns within a single commit:
 // an INSERT (or full-value row) followed by a partial UPDATE of the same primary
 // key, where the UPDATE omits the unchanged TOAST value. compactPendingChanges
-// later keeps only the latest row per key, so without this the earlier full
-// value would be lost. State is local to the commit; cross-commit coalescing is
+// later keeps only the latest row per key, so without this the earlier value
+// would be lost. State is local to the commit; cross-commit coalescing is
 // handled later at the staging-batch level (see forwardFillUnchanged), which is
 // where separate transactions are actually merged.
+//
+// A filled column's value is written directly into change.Values, replacing the
+// unchanged marker. That makes columnIsUnchanged report false for it, so it is
+// emitted with its (possibly NULL) value and excluded from _cdc_unchanged_cols —
+// which is exactly what we want, including when the known value is NULL.
 func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 	if len(changes) == 0 || tableSchema == nil {
 		return
@@ -72,28 +71,25 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 	}
 
 	nSource := sourceColumnCount(tableSchema)
-	state := make(map[string][]interface{})
+	state := make(map[string][]knownValue)
 
 	for i := range changes {
 		change := &changes[i]
 		lookupKey, storeKey := fillStateKeys(*change, pkIndices, i)
+		prior := state[lookupKey]
 
-		batchFill := make([]interface{}, nSource)
-		hasFill := false
-		for colIdx := 0; colIdx < nSource; colIdx++ {
-			if !columnIsUnchanged(*change, colIdx) {
-				continue
+		if prior != nil {
+			for colIdx := 0; colIdx < nSource && colIdx < len(prior); colIdx++ {
+				if !columnIsUnchanged(*change, colIdx) {
+					continue
+				}
+				if resolveColumnValueBase(*change, colIdx) != nil {
+					continue
+				}
+				if prior[colIdx].known {
+					setColumnValue(change, colIdx, prior[colIdx].val)
+				}
 			}
-			if resolveColumnValueBase(*change, colIdx) != nil {
-				continue
-			}
-			if prior, ok := state[lookupKey]; ok && colIdx < len(prior) && prior[colIdx] != nil {
-				batchFill[colIdx] = prior[colIdx]
-				hasFill = true
-			}
-		}
-		if hasFill {
-			change.batchFill = batchFill
 		}
 
 		if change.Operation == "DELETE" {
@@ -104,15 +100,39 @@ func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
 			continue
 		}
 
-		resolved := make([]interface{}, nSource)
+		// Carry forward prior known values, then overwrite with the columns this
+		// change resolves authoritatively (a real value, an explicit NULL, or a
+		// fill applied above).
+		next := make([]knownValue, nSource)
+		copy(next, prior)
 		for colIdx := 0; colIdx < nSource; colIdx++ {
-			resolved[colIdx] = resolveColumnValue(*change, colIdx)
+			if columnIsAuthoritative(*change, colIdx) {
+				next[colIdx] = knownValue{val: resolveColumnValue(*change, colIdx), known: true}
+			}
 		}
 		if lookupKey != storeKey {
 			delete(state, lookupKey)
 		}
-		state[storeKey] = resolved
+		state[storeKey] = next
 	}
+}
+
+// setColumnValue overwrites a column's value in place, replacing an unchanged
+// marker once we have resolved the value it stood for.
+func setColumnValue(change *Change, colIdx int, val interface{}) {
+	if colIdx < len(change.Values) {
+		change.Values[colIdx] = val
+	}
+}
+
+// columnIsAuthoritative reports whether the change carries a definite value for
+// the column — a real value, an explicit NULL, or an old-tuple value — as
+// opposed to an omitted unchanged-TOAST marker we cannot resolve.
+func columnIsAuthoritative(change Change, colIdx int) bool {
+	if !columnIsUnchanged(change, colIdx) {
+		return true
+	}
+	return resolveColumnValueBase(change, colIdx) != nil
 }
 
 func fillStateKeys(change Change, pkIndices []int, changeIndex int) (lookupKey, storeKey string) {
@@ -181,7 +201,21 @@ func pkKeyFromRow(values, oldValues []interface{}, pkIndices []int, changeIndex 
 		}
 		parts[i] = fmt.Sprintf("%T:%v", val, val)
 	}
-	return strings.Join(parts, "|")
+	return encodeKeyParts(parts)
+}
+
+// encodeKeyParts joins parts into a collision-free key by prefixing each with
+// its byte length. A plain delimiter (e.g. "|") is not injective: a value that
+// contains the delimiter could make two distinct composite keys collide and
+// cause TOAST values to be coalesced across different rows.
+func encodeKeyParts(parts []string) string {
+	var b strings.Builder
+	for _, p := range parts {
+		b.WriteString(strconv.Itoa(len(p)))
+		b.WriteByte(':')
+		b.WriteString(p)
+	}
+	return b.String()
 }
 
 func columnIsUnchanged(change Change, colIdx int) bool {
@@ -200,14 +234,11 @@ func unchangedColumnsJSON(change Change, columns []schema.Column, nSourceCols in
 	}
 	names := make([]string, 0)
 	for i := 0; i < nSourceCols && i < len(columns); i++ {
+		// applyIntraBatchFill overwrites the unchanged marker of any column it
+		// resolves (including to NULL), so columnIsUnchanged already excludes
+		// filled columns here; a column still marked unchanged is one we have no
+		// staging value for and the destination must fall back to its target.
 		if !columnIsUnchanged(change, i) {
-			continue
-		}
-		// A column resolved from the cross-commit fill cache now has an
-		// authoritative value in staging, so it must NOT be reported as
-		// unchanged; otherwise the destination merge would keep the (possibly
-		// stale) target value instead of the filled one on an existing row.
-		if _, filled := columnFilledFromBatch(change, i); filled {
 			continue
 		}
 		names = append(names, columns[i].Name)

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -660,6 +660,142 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 	assert.Equal(t, "completed", resultData)
 }
 
+// TestPostgresCDC_IntraBatchChangedThenUnchangedOverwritesExistingRow guards the
+// case adjacent to the empty-destination one: an existing destination row, then
+// within a single staging batch a changed TOAST value followed by a partial
+// UPDATE that leaves it unchanged. The latest change wins at the destination, so
+// the filled value must overwrite the stale target value rather than be dropped
+// via the _cdc_unchanged_cols target fallback.
+func TestPostgresCDC_IntraBatchChangedThenUnchangedOverwritesExistingRow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer sourcePool.Close()
+
+	oldCases := make([]int, 50)
+	for i := range oldCases {
+		oldCases[i] = i
+	}
+	oldPayload, err := json.Marshal(map[string]interface{}{
+		"testCases": oldCases,
+		"padding":   strings.Repeat("o", 8*1024),
+	})
+	require.NoError(t, err)
+
+	newCases := make([]int, 200)
+	for i := range newCases {
+		newCases[i] = i * 2
+	}
+	newPayload, err := json.Marshal(map[string]interface{}{
+		"testCases": newCases,
+		"padding":   strings.Repeat("n", 8*1024),
+	})
+	require.NoError(t, err)
+
+	_, err = sourcePool.Exec(ctx, `
+		CREATE TABLE public.test_intra_overwrite (
+			id SERIAL PRIMARY KEY,
+			config_data JSONB NOT NULL,
+			result_data TEXT NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `CREATE PUBLICATION test_intra_overwrite_pub FOR TABLE public.test_intra_overwrite`)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	// Seed the row before the first sync so the snapshot lands it on the
+	// destination with the OLD payload.
+	_, err = sourcePool.Exec(
+		ctx,
+		`INSERT INTO public.test_intra_overwrite (config_data, result_data) VALUES ($1::jsonb, 'pending')`,
+		string(oldPayload),
+	)
+	require.NoError(t, err)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_intra_overwrite_pub&mode=batch"
+	cfg := &config.IngestConfig{
+		SourceURI:           cdcSourceURI,
+		DestURI:             destConnString,
+		SourceTable:         "public.test_intra_overwrite",
+		DestTable:           "public.test_intra_overwrite_dest",
+		PrimaryKeys:         []string{"id"},
+		IncrementalStrategy: "merge",
+	}
+
+	// First sync: snapshot loads the row with the OLD payload onto the destination.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	// Same staging batch: change config_data (full value in WAL), then a partial
+	// UPDATE that leaves config_data unchanged. These are separate transactions
+	// accumulated into one downstream batch.
+	_, err = sourcePool.Exec(
+		ctx,
+		`UPDATE public.test_intra_overwrite SET config_data = $1::jsonb WHERE id = 1`,
+		string(newPayload),
+	)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `UPDATE public.test_intra_overwrite SET result_data = 'completed' WHERE id = 1`)
+	require.NoError(t, err)
+
+	// Second sync auto-resumes from the destination's max LSN.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var sourceConfig, destConfig string
+	var sourceLen, destLen int
+	err = sourcePool.QueryRow(ctx, `
+		SELECT config_data::text, jsonb_array_length(config_data->'testCases')
+		FROM public.test_intra_overwrite WHERE id = 1
+	`).Scan(&sourceConfig, &sourceLen)
+	require.NoError(t, err)
+
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	err = destPool.QueryRow(ctx, `
+		SELECT config_data::text, jsonb_array_length(config_data->'testCases')
+		FROM public.test_intra_overwrite_dest WHERE id = 1
+	`).Scan(&destConfig, &destLen)
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, sourceLen, "source should hold the NEW payload")
+	assert.Equal(t, sourceLen, destLen, "destination must reflect the changed payload, not the stale target value")
+	assert.Equal(t, sourceConfig, destConfig, "changed-then-unchanged config in one batch must overwrite the existing row")
+
+	var resultData string
+	err = destPool.QueryRow(ctx, `SELECT result_data FROM public.test_intra_overwrite_dest WHERE id = 1`).Scan(&resultData)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resultData)
+}
+
 // TestPostgresCDC_BatchModeCompletesWithActiveWrites verifies that batch mode completes
 // based on LSN rather than waiting indefinitely for inactivity. This test was added
 // to prevent regression of a bug where batch mode would wait forever if the source

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -557,6 +557,12 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 	})
 	require.NoError(t, err)
 
+	const (
+		sourceTable = "public.test_intra_batch_toast"
+		destTable   = "public.test_intra_batch_toast_dest"
+		publication = "test_intra_batch_pub"
+	)
+
 	_, err = sourcePool.Exec(ctx, `
 		CREATE TABLE public.test_intra_batch_toast (
 			id SERIAL PRIMARY KEY,
@@ -568,15 +574,6 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 	_, err = sourcePool.Exec(ctx, `CREATE PUBLICATION test_intra_batch_pub FOR TABLE public.test_intra_batch_toast`)
 	require.NoError(t, err)
 	_, err = sourcePool.Exec(ctx, `ALTER USER testuser REPLICATION`)
-	require.NoError(t, err)
-
-	_, err = sourcePool.Exec(
-		ctx,
-		`INSERT INTO public.test_intra_batch_toast (config_data, result_data) VALUES ($1::jsonb, 'pending')`,
-		string(configPayload),
-	)
-	require.NoError(t, err)
-	_, err = sourcePool.Exec(ctx, `UPDATE public.test_intra_batch_toast SET result_data = 'completed' WHERE id = 1`)
 	require.NoError(t, err)
 
 	destContainer, err := postgres.Run(
@@ -597,16 +594,43 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
 	require.NoError(t, err)
 
-	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_intra_batch_pub&mode=batch"
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=" + publication + "&mode=batch"
 	cfg := &config.IngestConfig{
 		SourceURI:           cdcSourceURI,
 		DestURI:             destConnString,
-		SourceTable:         "public.test_intra_batch_toast",
-		DestTable:           "public.test_intra_batch_toast_dest",
+		SourceTable:         sourceTable,
+		DestTable:           destTable,
 		PrimaryKeys:         []string{"id"},
 		IncrementalStrategy: "merge",
 	}
 
+	// Baseline sync on an empty table: creates the replication slot and streams
+	// to the current LSN without snapshotting any rows onto the destination.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	slotName := cdcReplicationSlotName(sourceTable, publication, cfg.CDCSlotSuffix)
+	var resumeLSN string
+	err = sourcePool.QueryRow(ctx, `
+		SELECT confirmed_flush_lsn::text
+		FROM pg_replication_slots
+		WHERE slot_name = $1
+	`, slotName).Scan(&resumeLSN)
+	require.NoError(t, err)
+	require.NotEmpty(t, resumeLSN)
+
+	// Autocommit INSERT then partial UPDATE (separate transactions). The batch
+	// accumulator merges both into one downstream batch while the destination
+	// row does not exist yet.
+	_, err = sourcePool.Exec(
+		ctx,
+		`INSERT INTO public.test_intra_batch_toast (config_data, result_data) VALUES ($1::jsonb, 'pending')`,
+		string(configPayload),
+	)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `UPDATE public.test_intra_batch_toast SET result_data = 'completed' WHERE id = 1`)
+	require.NoError(t, err)
+
+	cfg.CDCResumeLSN = resumeLSN
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
 	var sourceConfig, destConfig string
@@ -628,7 +652,7 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 	require.NoError(t, err)
 
 	assert.Equal(t, sourceLen, destLen, "testCases array length should match")
-	assert.Equal(t, sourceConfig, destConfig, "unchanged JSONB payload should be preserved when INSERT and partial UPDATE land in the same batch")
+	assert.Equal(t, sourceConfig, destConfig, "unchanged JSONB payload should be preserved when INSERT and partial UPDATE land in the same staging batch")
 
 	var resultData string
 	err = destPool.QueryRow(ctx, `SELECT result_data FROM public.test_intra_batch_toast_dest WHERE id = 1`).Scan(&resultData)
@@ -1043,4 +1067,15 @@ func TestPostgresCDC_UnawareDestination_SQLite(t *testing.T) {
 	// The staging-only column must not exist on the destination table.
 	require.NoError(t, dest.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('toast_items_dest') WHERE name = '_cdc_unchanged_cols'`).Scan(&count))
 	assert.Equal(t, 0, count, "_cdc_unchanged_cols must stay staging-only")
+}
+
+func cdcReplicationSlotName(tableName, publication, suffix string) string {
+	name := fmt.Sprintf("ingestr_%s_%s", strings.ReplaceAll(tableName, ".", "_"), publication)
+	if suffix != "" {
+		name = fmt.Sprintf("%s_%s", name, suffix)
+	}
+	if len(name) > 63 {
+		return name[:63]
+	}
+	return name
 }

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -533,6 +533,109 @@ func TestPostgresCDC_MergePreservesUnchangedJSONB(t *testing.T) {
 	assert.Equal(t, "completed", resultData)
 }
 
+func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer sourcePool.Close()
+
+	testCases := make([]int, 200)
+	for i := range testCases {
+		testCases[i] = i
+	}
+	configPayload, err := json.Marshal(map[string]interface{}{
+		"testCases": testCases,
+		"padding":   strings.Repeat("x", 8*1024),
+	})
+	require.NoError(t, err)
+
+	_, err = sourcePool.Exec(ctx, `
+		CREATE TABLE public.test_intra_batch_toast (
+			id SERIAL PRIMARY KEY,
+			config_data JSONB NOT NULL,
+			result_data TEXT NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `CREATE PUBLICATION test_intra_batch_pub FOR TABLE public.test_intra_batch_toast`)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	_, err = sourcePool.Exec(
+		ctx,
+		`INSERT INTO public.test_intra_batch_toast (config_data, result_data) VALUES ($1::jsonb, 'pending')`,
+		string(configPayload),
+	)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `UPDATE public.test_intra_batch_toast SET result_data = 'completed' WHERE id = 1`)
+	require.NoError(t, err)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_intra_batch_pub&mode=batch"
+	cfg := &config.IngestConfig{
+		SourceURI:           cdcSourceURI,
+		DestURI:             destConnString,
+		SourceTable:         "public.test_intra_batch_toast",
+		DestTable:           "public.test_intra_batch_toast_dest",
+		PrimaryKeys:         []string{"id"},
+		IncrementalStrategy: "merge",
+	}
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var sourceConfig, destConfig string
+	var sourceLen, destLen int
+	err = sourcePool.QueryRow(ctx, `
+		SELECT config_data::text, jsonb_array_length(config_data->'testCases')
+		FROM public.test_intra_batch_toast WHERE id = 1
+	`).Scan(&sourceConfig, &sourceLen)
+	require.NoError(t, err)
+
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	err = destPool.QueryRow(ctx, `
+		SELECT config_data::text, jsonb_array_length(config_data->'testCases')
+		FROM public.test_intra_batch_toast_dest WHERE id = 1
+	`).Scan(&destConfig, &destLen)
+	require.NoError(t, err)
+
+	assert.Equal(t, sourceLen, destLen, "testCases array length should match")
+	assert.Equal(t, sourceConfig, destConfig, "unchanged JSONB payload should be preserved when INSERT and partial UPDATE land in the same batch")
+
+	var resultData string
+	err = destPool.QueryRow(ctx, `SELECT result_data FROM public.test_intra_batch_toast_dest WHERE id = 1`).Scan(&resultData)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resultData)
+}
+
 // TestPostgresCDC_BatchModeCompletesWithActiveWrites verifies that batch mode completes
 // based on LSN rather than waiting indefinitely for inactivity. This test was added
 // to prevent regression of a bug where batch mode would wait forever if the source


### PR DESCRIPTION
## Summary

Fixes a CDC merge gap where INSERT + partial UPDATE (unchanged TOAST columns) in the **same staging batch** produced empty JSONB on `WHEN NOT MATCHED INSERT`.

PR #789 preserves unchanged columns on `WHEN MATCHED` via `_cdc_unchanged_cols` + target fallback. PR #786 routes data columns from the latest non-deleted staging row (`act`). For new destination rows, `act` is often the partial UPDATE with null TOAST payloads, so inserts landed without large column values (e.g. Meticulous `test_runs.config_data`).

This PR fixes that in the **Postgres CDC source** with two bounded forward-fill passes:

1. **Within-commit** (`applyIntraBatchFill`) — before compaction, walk pending WAL changes per PK and copy unchanged TOAST columns from earlier resolved rows in the same transaction when the WAL old tuple has no value.
2. **Within staging batch** (`forwardFillUnchanged`) — when the batch accumulator merges separate autocommit micro-batches, fill omitted unchanged columns from the most recent prior row for that PK in LSN order.

Filled columns are written into staging values and dropped from `_cdc_unchanged_cols` so merge uses the resolved value (including explicit NULL) instead of resurrecting a stale target. Unresolved unchanged columns still carry markers for cross-batch `WHEN MATCHED` target fallback.

Also reconciles user-provided primary keys into the table schema so decoder compaction and fill use the same keys as destination merge, and uses length-prefixed PK keys to avoid delimiter collisions.

No destination merge SQL changes. Adds unit tests in `decoder_test.go` and `cdc_fill_test.go`, plus integration coverage for same-batch INSERT→partial UPDATE (empty destination), changed-then-unchanged over an existing row, and CDC-unaware destinations (SQLite).

Fixes #805 

## Limitation

`forwardFillUnchanged` keys rows by the new PK in the staging batch. A PK-changing UPDATE that omits an unchanged TOAST column cannot be linked back to the originating row under the old PK when the INSERT and that UPDATE land in **different commits** of the same accumulated batch — the omitted value stays in `_cdc_unchanged_cols` and falls back to the target. The within-commit decoder pass handles PK changes via the old tuple; only this cross-commit case is affected.