### PR TITLE
Add SQL Server Change Tracking source

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -228,6 +228,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.DestTable = c.String("dest-table")
 	cfg.IncrementalKey = c.String("incremental-key")
 	cfg.IncrementalStrategy = config.IncrementalStrategy(c.String("incremental-strategy"))
+	cfg.IncrementalStrategyExplicit = c.IsSet("incremental-strategy")
 	cfg.PrimaryKeys = c.StringSlice("primary-key")
 	cfg.PartitionBy = c.String("partition-by")
 	cfg.Yes = c.Bool("yes")

--- a/docs/supported-sources/mssql.md
+++ b/docs/supported-sources/mssql.md
@@ -29,6 +29,34 @@ URI parameters:
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's SQL Server dialect [here](https://docs.sqlalchemy.org/en/20/core/engines.html#microsoft-sql-server).
 
+## Change Tracking
+
+ingestr can read SQL Server Change Tracking tables with the `mssql+ct://`, `sqlserver+ct://`, `azuresql+ct://`, and `azure-sql+ct://` URI schemes.
+
+```sh
+ingestr ingest \
+    --source-uri "mssql+ct://user:password@host:1433/dbname?encrypt=disable" \
+    --source-table "dbo.users" \
+    --dest-uri "duckdb:///warehouse.duckdb" \
+    --dest-table "dbo.users"
+```
+
+The destination table stores the Change Tracking cursor in `_cdc_lsn`, so later runs resume automatically from the latest loaded version. Change Tracking loads use the `merge` strategy by default and require a primary key on the source table.
+
+SQL Server setup example:
+
+```sql
+ALTER DATABASE your_database
+SET CHANGE_TRACKING = ON
+(CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
+
+ALTER TABLE dbo.users
+ENABLE CHANGE_TRACKING
+WITH (TRACK_COLUMNS_UPDATED = OFF);
+```
+
+Change Tracking returns net row changes since the last loaded version. For inserts and updates, ingestr joins the changed primary keys back to the source table and loads the current row. For deletes, SQL Server only returns the primary key, so ingestr marks the destination row as deleted with `_cdc_deleted = true` while preserving existing destination values for other columns. If a row is updated and then deleted between two ingestr runs, Change Tracking cannot reconstruct the intermediate updated values.
+
 ## Tips & Tricks
 
 If you're using Azure SQL Server, you can use `az cli` to generate access tokens to connect to SQL server. 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,10 +39,11 @@ type IngestConfig struct {
 	SourceTable string
 	DestTable   string
 
-	IncrementalStrategy IncrementalStrategy
-	IncrementalKey      string
-	IntervalStart       *time.Time
-	IntervalEnd         *time.Time
+	IncrementalStrategy         IncrementalStrategy
+	IncrementalStrategyExplicit bool
+	IncrementalKey              string
+	IntervalStart               *time.Time
+	IntervalEnd                 *time.Time
 
 	PrimaryKeys []string
 
@@ -146,6 +147,12 @@ func (c *IngestConfig) Validate() error {
 			return &ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("%q is not supported with --stream (only merge and append)", c.IncrementalStrategy)}
 		}
 	}
+	if c.IsChangeTrackingSource() && c.SQLLimit > 0 {
+		return &ValidationError{Field: "sql-limit", Message: "is not supported for SQL Server Change Tracking sources because partial snapshots cannot safely advance the resume cursor"}
+	}
+	if c.IsChangeTrackingSource() && !c.FullRefresh && c.IncrementalStrategyExplicit && c.IncrementalStrategy != StrategyMerge {
+		return &ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("must be %q for SQL Server Change Tracking sources unless full-refresh is enabled", StrategyMerge)}
+	}
 	return nil
 }
 
@@ -156,6 +163,14 @@ func (c *IngestConfig) IsCDCSource() bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(c.SourceURI[:schemeEnd]), "+cdc")
+}
+
+func (c *IngestConfig) IsChangeTrackingSource() bool {
+	schemeEnd := strings.Index(c.SourceURI, "://")
+	if schemeEnd == -1 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(c.SourceURI[:schemeEnd]), "+ct")
 }
 
 type ValidationError struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -120,3 +120,61 @@ func TestIngestConfigValidate_Stream(t *testing.T) {
 		})
 	}
 }
+
+func TestIngestConfigValidate_ChangeTrackingRejectsSQLLimit(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "mssql+ct://example:1433/app"
+	cfg.SourceTable = "dbo.users"
+	cfg.DestURI = "duckdb:///tmp/out.duckdb"
+	cfg.SQLLimit = 10
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "sql-limit") {
+		t.Fatalf("expected sql-limit validation error, got %v", err)
+	}
+}
+
+func TestIngestConfigValidate_ChangeTrackingRejectsExplicitReplace(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "mssql+ct://example:1433/app"
+	cfg.SourceTable = "dbo.users"
+	cfg.DestURI = "duckdb:///tmp/out.duckdb"
+	cfg.IncrementalStrategy = StrategyReplace
+	cfg.IncrementalStrategyExplicit = true
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "incremental-strategy") {
+		t.Fatalf("expected incremental-strategy validation error, got %v", err)
+	}
+}
+
+func TestIngestConfigValidate_ChangeTrackingAllowsDefaultReplace(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "mssql+ct://example:1433/app"
+	cfg.SourceTable = "dbo.users"
+	cfg.DestURI = "duckdb:///tmp/out.duckdb"
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestIngestConfigValidate_ChangeTrackingAllowsExplicitReplaceWithFullRefresh(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "mssql+ct://example:1433/app"
+	cfg.SourceTable = "dbo.users"
+	cfg.DestURI = "duckdb:///tmp/out.duckdb"
+	cfg.IncrementalStrategy = StrategyReplace
+	cfg.IncrementalStrategyExplicit = true
+	cfg.FullRefresh = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,6 +168,7 @@ func (s *Server) handleRunJob(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Strategy != "" {
 		cfg.IncrementalStrategy = config.IncrementalStrategy(req.Strategy)
+		cfg.IncrementalStrategyExplicit = true
 	}
 	cfg.PrimaryKeys = req.PrimaryKeys
 	cfg.IncrementalKey = req.IncrementalKey

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -440,11 +440,14 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 		)
 	}
 
-	// For CDC, upsert from the latest non-deleted change per PK so a delete
-	// followed by nothing doesn't clobber row data; deletes are applied below.
-	upsertSource := dedupSource("")
+	// For CDC, updates use the latest non-deleted change per PK so a delete
+	// followed by nothing doesn't clobber row data. Inserts use the latest
+	// change overall so delete-only keys can materialize tombstones for resume.
+	updateSource := dedupSource("")
+	insertSource := updateSource
 	if isCDC {
-		upsertSource = dedupSource(` WHERE "_cdc_deleted" = false`)
+		updateSource = dedupSource(` WHERE "_cdc_deleted" = false`)
+		insertSource = dedupSource("")
 	}
 
 	if len(nonPKColumns) > 0 {
@@ -452,7 +455,7 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 			`UPDATE %s AS target SET %s FROM %s WHERE %s`,
 			quotedTargetTable,
 			buildUpdateSet(nonPKColumns, "target", "source", applyUnchangedCols),
-			upsertSource,
+			updateSource,
 			onCondition,
 		)
 		config.Debug("[DUCKDB MERGE] Executing UPDATE: %s", updateSQL)
@@ -467,7 +470,7 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 		quotedTargetTable,
 		strings.Join(destQuoted, ", "),
 		strings.Join(destQuoted, ", "),
-		upsertSource,
+		insertSource,
 		quotedTargetTable,
 		onCondition,
 	)

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -748,7 +748,6 @@ func (d *DuckDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (str
 	defer func() { _ = stmt.Close() }()
 
 	if err := stmt.SetSqlQuery(query); err != nil {
-		// Table doesn't exist
 		if strings.Contains(err.Error(), "does not exist") ||
 			strings.Contains(err.Error(), "Catalog Error") {
 			return "", nil
@@ -758,7 +757,6 @@ func (d *DuckDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (str
 
 	reader, _, err := stmt.ExecuteQuery(ctx)
 	if err != nil {
-		// Table doesn't exist or column doesn't exist
 		if strings.Contains(err.Error(), "does not exist") ||
 			strings.Contains(err.Error(), "Catalog Error") ||
 			strings.Contains(err.Error(), "not found") {

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -726,6 +726,58 @@ func TestMergeTable(t *testing.T) {
 	assert.Equal(t, 300, value)
 }
 
+func TestMergeTable_CDCMaterializesDeleteOnlyTombstone(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	err := dest.Exec(ctx, `
+		CREATE TABLE target_table (
+			id BIGINT PRIMARY KEY,
+			name VARCHAR,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		CREATE TABLE staging_table (
+			id BIGINT,
+			name VARCHAR,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(-9223372036854775808, NULL, '00000000000000000042', true, CURRENT_TIMESTAMP)
+	`)
+	require.NoError(t, err)
+
+	err = dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		TargetTable:  "target_table",
+		PrimaryKeys:  []string{"id"},
+		Columns: []string{
+			"id",
+			"name",
+			destination.CDCLSNColumn,
+			destination.CDCDeletedColumn,
+			destination.CDCSyncedAtColumn,
+		},
+	})
+	require.NoError(t, err)
+
+	db := openDuckDB(t, ctx, path)
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM target_table WHERE "_cdc_deleted" = true AND "_cdc_lsn" = '00000000000000000042'`).Scan(&count))
+	assert.Equal(t, 1, count)
+}
+
 func TestDeleteInsertTable_DedupesStagingByPK(t *testing.T) {
 	ctx := context.Background()
 	dest, path := connectTestDuckDB(t, ctx)

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -716,11 +716,15 @@ func (d *SQLiteDestination) SupportsCDCMerge() bool { return true }
 
 // GetMaxCDCLSN returns the maximum _cdc_lsn value from the table for CDC resume.
 func (d *SQLiteDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	if err := d.ensureSchemaAttached(ctx, schemaOf(table)); err != nil {
+		return "", err
+	}
+
 	var maxLSN sql.NullString
 	query := fmt.Sprintf(`SELECT MAX("_cdc_lsn") FROM %s`, destination.QuoteTableName(table))
 	err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN)
 	if err != nil {
-		if strings.Contains(err.Error(), "no such table") {
+		if strings.Contains(err.Error(), "no such table") || strings.Contains(err.Error(), "no such column") {
 			return "", nil
 		}
 		return "", err

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -458,11 +458,14 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 		)
 	}
 
-	// For CDC, upsert from the latest non-deleted change per PK so a delete
-	// followed by nothing doesn't clobber row data; deletes are applied below.
-	upsertSource := dedupSource("")
+	// For CDC, updates use the latest non-deleted change per PK so a delete
+	// followed by nothing doesn't clobber row data. Inserts use the latest
+	// change overall so delete-only keys can materialize tombstones for resume.
+	updateSource := dedupSource("")
+	insertSource := updateSource
 	if isCDC {
-		upsertSource = dedupSource(` WHERE "_cdc_deleted" = 0`)
+		updateSource = dedupSource(` WHERE "_cdc_deleted" = 0`)
+		insertSource = dedupSource("")
 	}
 
 	// UPDATE existing records using SQLite syntax
@@ -471,7 +474,7 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 			`UPDATE %s SET %s FROM %s WHERE %s`,
 			quotedTargetTable,
 			buildUpdateSetSQLite(nonPKColumns, "source"),
-			upsertSource,
+			updateSource,
 			buildJoinConditionSQLite(opts.PrimaryKeys, quotedTargetTable, "source"),
 		)
 		config.Debug("[MERGE] Executing UPDATE: %s", updateSQL)
@@ -488,7 +491,7 @@ func (d *SQLiteDestination) MergeTable(ctx context.Context, opts destination.Mer
 		quotedTargetTable,
 		strings.Join(quotedColumns, ", "),
 		strings.Join(quotedColumns, ", "),
-		upsertSource,
+		insertSource,
 		quotedTargetTable,
 		buildJoinConditionSQLite(opts.PrimaryKeys, "target", "source"),
 	)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -62,6 +62,10 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 	ctx = annotation.WithPayload(ctx, annotations)
 
+	if err := validateManagedChangeConfig(p.config); err != nil {
+		return err
+	}
+
 	src, err := uri.DefaultRegistry.GetSource(p.config.SourceURI)
 	if err != nil {
 		return fmt.Errorf("failed to get source: %w", err)
@@ -104,11 +108,25 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		}
 	}
 
+	if isChangeTrackingSource(p.config.SourceURI) {
+		if err := validateChangeTrackingDestination(dest); err != nil {
+			return err
+		}
+	}
+
 	// For managed change sources, check if we can resume from existing data
 	if isManagedChangeSource(p.config.SourceURI) && !p.config.FullRefresh {
-		if resumeProvider, ok := dest.(destination.CDCResumeProvider); ok {
+		resumeProvider, ok := dest.(destination.CDCResumeProvider)
+		if !ok {
+			if isChangeTrackingSource(p.config.SourceURI) {
+				return fmt.Errorf("destination scheme %q does not support resume cursors required by SQL Server Change Tracking", dest.GetScheme())
+			}
+		} else {
 			maxLSN, err := resumeProvider.GetMaxCDCLSN(ctx, p.config.DestTable)
 			if err != nil {
+				if isChangeTrackingSource(p.config.SourceURI) {
+					return fmt.Errorf("failed to get SQL Server Change Tracking cursor from destination: %w", err)
+				}
 				config.Debug("[PIPELINE] Failed to get max change cursor from destination: %v", err)
 			} else if maxLSN != "" {
 				config.Debug("[PIPELINE] Found existing change data, will resume from cursor: %s", maxLSN)
@@ -127,6 +145,8 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		PrimaryKeys:    p.config.PrimaryKeys,
 		Strategy:       p.config.IncrementalStrategy,
 		Streaming:      p.config.Stream,
+		StrategySet:    p.config.IncrementalStrategyExplicit,
+		FullRefresh:    p.config.FullRefresh,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get table: %w", err)
@@ -1477,6 +1497,28 @@ func isManagedChangeSource(uri string) bool {
 	}
 	scheme := strings.ToLower(uri[:schemeEnd])
 	return strings.Contains(scheme, "+cdc") || strings.Contains(scheme, "+ct")
+}
+
+func validateManagedChangeConfig(cfg *config.IngestConfig) error {
+	if isChangeTrackingSource(cfg.SourceURI) && cfg.SQLLimit > 0 {
+		return &config.ValidationError{Field: "sql-limit", Message: "is not supported for SQL Server Change Tracking sources because partial snapshots cannot safely advance the resume cursor"}
+	}
+	return nil
+}
+
+func validateChangeTrackingDestination(dest destination.Destination) error {
+	if _, ok := dest.(destination.CDCResumeProvider); !ok {
+		return fmt.Errorf("destination scheme %q does not support resume cursors required by SQL Server Change Tracking", dest.GetScheme())
+	}
+	return nil
+}
+
+func isChangeTrackingSource(uri string) bool {
+	schemeEnd := strings.Index(uri, "://")
+	if schemeEnd == -1 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(uri[:schemeEnd]), "+ct")
 }
 
 // cdcSlotSuffix returns a 6-hex-char hash of the destination URI for use as a

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -104,17 +104,17 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		}
 	}
 
-	// For CDC sources, check if we can resume from existing data
-	if isCDCSource(p.config.SourceURI) && !p.config.FullRefresh {
+	// For managed change sources, check if we can resume from existing data
+	if isManagedChangeSource(p.config.SourceURI) && !p.config.FullRefresh {
 		if resumeProvider, ok := dest.(destination.CDCResumeProvider); ok {
 			maxLSN, err := resumeProvider.GetMaxCDCLSN(ctx, p.config.DestTable)
 			if err != nil {
-				config.Debug("[PIPELINE] Failed to get max CDC LSN from destination: %v", err)
+				config.Debug("[PIPELINE] Failed to get max change cursor from destination: %v", err)
 			} else if maxLSN != "" {
-				config.Debug("[PIPELINE] Found existing CDC data, will resume from LSN: %s", maxLSN)
+				config.Debug("[PIPELINE] Found existing change data, will resume from cursor: %s", maxLSN)
 				p.config.CDCResumeLSN = maxLSN
 			} else {
-				config.Debug("[PIPELINE] No existing CDC data found, will perform full snapshot")
+				config.Debug("[PIPELINE] No existing change data found, will perform full snapshot")
 			}
 		}
 	}
@@ -155,7 +155,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	display.PrintSummary(&preFetchConfig)
 
 	if shouldWarnCDCStrategy(p.config, preFetchStrategy) {
-		fmt.Printf("Warning: CDC source is using %q strategy instead of %q; CDC delete and update operations may not be properly reflected in the destination\n", preFetchStrategy, config.StrategyMerge)
+		fmt.Printf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", preFetchStrategy, config.StrategyMerge)
 	}
 
 	tracker, err := p.createTracker(ctx)
@@ -825,7 +825,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	}
 
 	if shouldWarnCDCStrategy(p.config, resolvedStrategy) {
-		fmt.Printf("Warning: CDC source is using %q strategy instead of %q; CDC delete and update operations may not be properly reflected in the destination\n", resolvedStrategy, config.StrategyMerge)
+		fmt.Printf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", resolvedStrategy, config.StrategyMerge)
 	}
 
 	strat, err := strategy.Get(resolvedStrategy)
@@ -1392,7 +1392,7 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 // shouldWarnCDCStrategy returns true if the user should be warned about using
 // a non-merge strategy with a CDC source.
 func shouldWarnCDCStrategy(cfg *config.IngestConfig, resolvedStrategy config.IncrementalStrategy) bool {
-	return isCDCSource(cfg.SourceURI) && !cfg.FullRefresh && resolvedStrategy != config.StrategyMerge
+	return isManagedChangeSource(cfg.SourceURI) && !cfg.FullRefresh && resolvedStrategy != config.StrategyMerge
 }
 
 func resolveStrategy(cfg *config.IngestConfig, src source.Source, table source.SourceTable) config.IncrementalStrategy {
@@ -1407,7 +1407,7 @@ func resolveStrategy(cfg *config.IngestConfig, src source.Source, table source.S
 			s = ss.DefaultStreamingStrategy()
 		}
 	}
-	if isCDCSource(cfg.SourceURI) && !cfg.FullRefresh && (s == "" || s == config.StrategyReplace) {
+	if isManagedChangeSource(cfg.SourceURI) && !cfg.FullRefresh && (s == "" || s == config.StrategyReplace) {
 		s = config.StrategyMerge
 	}
 	if cfg.FullRefresh {
@@ -1468,6 +1468,15 @@ func isCDCSource(uri string) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(uri[:schemeEnd]), "+cdc")
+}
+
+func isManagedChangeSource(uri string) bool {
+	schemeEnd := strings.Index(uri, "://")
+	if schemeEnd == -1 {
+		return false
+	}
+	scheme := strings.ToLower(uri[:schemeEnd])
+	return strings.Contains(scheme, "+cdc") || strings.Contains(scheme, "+ct")
 }
 
 // cdcSlotSuffix returns a 6-hex-char hash of the destination URI for use as a

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -17,10 +18,84 @@ import (
 type mockDestination struct {
 	destination.Destination
 	tableSchema *schema.TableSchema
+	scheme      string
 }
 
 func (m *mockDestination) GetTableSchema(_ context.Context, _ string) (*schema.TableSchema, error) {
 	return m.tableSchema, nil
+}
+
+func (m *mockDestination) GetScheme() string {
+	if m.scheme != "" {
+		return m.scheme
+	}
+	return "mock"
+}
+
+type mockCDCResumeDestination struct {
+	mockDestination
+}
+
+func (m *mockCDCResumeDestination) GetMaxCDCLSN(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func TestRunRejectsChangeTrackingSQLLimitBeforeSourceLookup(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mssql+ct://example:1433/app"
+	cfg.SourceTable = "dbo.items"
+	cfg.DestURI = "unsupported-destination://out"
+	cfg.SQLLimit = 10
+
+	err := New(cfg).Run(context.Background())
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "sql-limit") {
+		t.Fatalf("expected sql-limit validation error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "failed to get source") || strings.Contains(err.Error(), "failed to get destination") {
+		t.Fatalf("expected validation before source/destination lookup, got %v", err)
+	}
+}
+
+func TestValidateChangeTrackingDestinationAcceptsResumeProvider(t *testing.T) {
+	err := validateChangeTrackingDestination(&mockCDCResumeDestination{
+		mockDestination: mockDestination{scheme: "mock"},
+	})
+	if err != nil {
+		t.Fatalf("expected resume provider to pass validation, got %v", err)
+	}
+}
+
+func TestValidateChangeTrackingDestinationRequiresResumeProvider(t *testing.T) {
+	err := validateChangeTrackingDestination(&mockDestination{scheme: "mock"})
+
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "resume cursors") {
+		t.Fatalf("expected resume cursor error, got %v", err)
+	}
+}
+
+func TestValidateChangeTrackingDestinationRunsForFullRefreshRequirement(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mssql+ct://example:1433/app"
+	cfg.SourceTable = "dbo.items"
+	cfg.DestURI = "mock://dest"
+	cfg.FullRefresh = true
+
+	requireChangeTrackingValidation := isChangeTrackingSource(cfg.SourceURI)
+	if !requireChangeTrackingValidation {
+		t.Fatal("expected mssql+ct URI to require destination validation")
+	}
+	err := validateChangeTrackingDestination(&mockCDCResumeDestination{
+		mockDestination: mockDestination{scheme: "mock"},
+	})
+	if err != nil {
+		t.Fatalf("expected full-refresh validation to accept resume provider, got %v", err)
+	}
 }
 
 func TestSetupNamingConvention(t *testing.T) {

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -43,7 +43,7 @@ type ctVersionExpiredError struct {
 }
 
 func (e *ctVersionExpiredError) Error() string {
-	return fmt.Sprintf("SQL Server Change Tracking version %d is no longer valid for %s; minimum valid version is %d", e.version, e.table, e.minVersion)
+	return fmt.Sprintf("SQL Server Change Tracking version %d is no longer valid for %s; minimum valid version is %d; run with --full-refresh to rebuild the destination from a new snapshot", e.version, e.table, e.minVersion)
 }
 
 func NewMSSQLChangeTrackingSource() *MSSQLChangeTrackingSource {
@@ -105,6 +105,11 @@ func (s *MSSQLChangeTrackingSource) GetTable(ctx context.Context, req source.Tab
 		return nil, fmt.Errorf("custom queries are not supported for SQL Server Change Tracking sources")
 	}
 
+	strategy, err := resolveChangeTrackingStrategy(req.Strategy, req.StrategySet, req.FullRefresh)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := s.ensureTableChangeTracking(ctx, req.Name); err != nil {
 		return nil, err
 	}
@@ -124,11 +129,6 @@ func (s *MSSQLChangeTrackingSource) GetTable(ctx context.Context, req source.Tab
 
 	tableSchema.PrimaryKeys = pks
 	tableSchema = addCTColumns(tableSchema)
-
-	strategy := config.StrategyMerge
-	if req.Strategy != "" && req.Strategy != config.StrategyReplace {
-		strategy = req.Strategy
-	}
 
 	return &changeTrackingTable{
 		source:      s,
@@ -164,6 +164,13 @@ func (t *changeTrackingTable) GetSchema(ctx context.Context) (*schema.TableSchem
 }
 
 func (t *changeTrackingTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	if opts.Limit > 0 {
+		return nil, fmt.Errorf("SQL Server Change Tracking sources do not support --sql-limit because partial snapshots cannot safely advance the resume cursor")
+	}
+	if err := validateCTExcludeColumns(opts.ExcludeColumns, t.primaryKeys); err != nil {
+		return nil, err
+	}
+
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -174,27 +181,13 @@ func (t *changeTrackingTable) Read(ctx context.Context, opts source.ReadOptions)
 			tableSchema = opts.Schema
 		}
 
-		if version, ok := parseStoredCTVersion(opts.CDCResumeLSN); ok && version > 0 {
-			canResume, err := t.source.canResumeCT(ctx, t.tableName, version)
+		if version, ok := parseStoredCTVersion(opts.CDCResumeLSN); ok {
+			_, err := t.source.readCTChanges(ctx, t.tableName, tableSchema, t.primaryKeys, version, opts, results, true)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
 			}
-			if canResume {
-				err := t.source.readCTChanges(ctx, t.tableName, tableSchema, t.primaryKeys, version, opts, results)
-				if err == nil {
-					return
-				}
-				var expired *ctVersionExpiredError
-				if !errors.As(err, &expired) {
-					results <- source.RecordBatchResult{Err: err}
-					return
-				}
-				config.Debug("[MSSQL CT] Resume version %d expired while reading %s; taking a fresh snapshot", version, t.tableName)
-			}
-			if !canResume {
-				config.Debug("[MSSQL CT] Resume version %d is no longer valid for %s; taking a fresh snapshot", version, t.tableName)
-			}
+			return
 		}
 
 		snapshotVersion, err := t.source.snapshotCTTable(ctx, t.tableName, tableSchema, opts, results)
@@ -203,8 +196,14 @@ func (t *changeTrackingTable) Read(ctx context.Context, opts source.ReadOptions)
 			return
 		}
 
-		if err := t.source.readCTChanges(ctx, t.tableName, tableSchema, t.primaryKeys, snapshotVersion, opts, results); err != nil {
+		if opts.FullRefresh {
+			return
+		}
+
+		_, err = t.source.readCTChanges(ctx, t.tableName, tableSchema, t.primaryKeys, snapshotVersion, opts, results, false)
+		if err != nil {
 			results <- source.RecordBatchResult{Err: err}
+			return
 		}
 	}()
 
@@ -266,6 +265,29 @@ func (s *MSSQLChangeTrackingSource) ensureTableChangeTracking(ctx context.Contex
 	return nil
 }
 
+func resolveChangeTrackingStrategy(strategy config.IncrementalStrategy, strategySet, fullRefresh bool) (config.IncrementalStrategy, error) {
+	if fullRefresh {
+		switch strategy {
+		case "", config.StrategyReplace, config.StrategyTruncateInsert, config.StrategyAppend, config.StrategyDeleteInsert, config.StrategyMerge, config.StrategySCD2, config.StrategyNone:
+			return config.StrategyMerge, nil
+		default:
+			return "", fmt.Errorf("SQL Server Change Tracking sources require a valid incremental strategy when full-refresh is enabled; got %q", strategy)
+		}
+	}
+
+	switch strategy {
+	case "", config.StrategyMerge:
+		return config.StrategyMerge, nil
+	case config.StrategyReplace:
+		if strategySet && !fullRefresh {
+			return "", fmt.Errorf("SQL Server Change Tracking sources require %q incremental strategy unless full-refresh is enabled; got %q", config.StrategyMerge, strategy)
+		}
+		return config.StrategyMerge, nil
+	default:
+		return "", fmt.Errorf("SQL Server Change Tracking sources require %q incremental strategy; got %q", config.StrategyMerge, strategy)
+	}
+}
+
 func addCTColumns(original *schema.TableSchema) *schema.TableSchema {
 	result := *original
 	result.Columns = make([]schema.Column, 0, len(original.Columns)+len(ctMetadataColumns))
@@ -287,14 +309,6 @@ func sourceColumnsWithoutCT(tableSchema *schema.TableSchema) []schema.Column {
 
 type ctQueryer interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-}
-
-func (s *MSSQLChangeTrackingSource) canResumeCT(ctx context.Context, table string, version int64) (bool, error) {
-	minVersion, err := s.minValidCTVersion(ctx, s.db, table)
-	if err != nil {
-		return false, err
-	}
-	return version >= minVersion, nil
 }
 
 func (s *MSSQLChangeTrackingSource) minValidCTVersion(ctx context.Context, q ctQueryer, table string) (int64, error) {
@@ -342,14 +356,14 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 	}
 
 	columns := tableSchema.Columns
-	query := buildCTSnapshotQuery(table, sourceColumnsWithoutCT(tableSchema), opts, version, isolation != sql.LevelSnapshot)
+	query := buildCTSnapshotQuery(table, sourceColumnsWithoutCT(tableSchema), version, isolation != sql.LevelSnapshot)
 	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query snapshot for %s: %w", table, err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	if err := s.rowsToCTBatches(rows, columns, opts, results); err != nil {
+	if _, err := s.rowsToCTBatches(rows, columns, opts, results); err != nil {
 		return 0, err
 	}
 
@@ -360,100 +374,159 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 	return version, nil
 }
 
-func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelSnapshot)
+func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, emitHeartbeat bool) (int64, error) {
+	readThroughVersion, err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelSnapshot, emitHeartbeat)
 	if err == nil {
-		return nil
+		return readThroughVersion, nil
 	}
 	var expired *ctVersionExpiredError
 	if errors.As(err, &expired) {
-		return err
+		return 0, err
 	}
-	config.Debug("[MSSQL CT] SNAPSHOT isolation change read failed for %s: %v; retrying with read committed", table, err)
-	return s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelReadCommitted)
+	return 0, fmt.Errorf("failed to read SQL Server Change Tracking changes using SNAPSHOT isolation: %w", err)
 }
 
-func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel) error {
+func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel, emitHeartbeat bool) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if err != nil {
-		return fmt.Errorf("failed to begin Change Tracking transaction: %w", err)
+		return 0, fmt.Errorf("failed to begin Change Tracking transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	minVersion, err := s.minValidCTVersion(ctx, tx, table)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if fromVersion < minVersion {
-		return &ctVersionExpiredError{table: table, version: fromVersion, minVersion: minVersion}
+		return 0, &ctVersionExpiredError{table: table, version: fromVersion, minVersion: minVersion}
 	}
 
 	targetVersion, err := s.currentCTVersion(ctx, tx)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if targetVersion <= fromVersion {
 		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
+			return 0, fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
 		}
-		return nil
+		return fromVersion, nil
 	}
 
 	columns := tableSchema.Columns
 	query := buildCTChangesQuery(table, sourceColumnsWithoutCT(tableSchema), primaryKeys)
 	rows, err := tx.QueryContext(ctx, query, fromVersion, targetVersion)
 	if err != nil {
-		return fmt.Errorf("failed to query Change Tracking changes for %s: %w", table, err)
+		return 0, fmt.Errorf("failed to query Change Tracking changes for %s: %w", table, err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	if err := s.rowsToCTBatches(rows, columns, opts, results); err != nil {
-		return err
+	changeRows, err := s.rowsToCTBatches(rows, columns, opts, results)
+	if err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("failed to close Change Tracking rows for %s: %w", table, err)
+	}
+
+	if shouldEmitCTHeartbeat(emitHeartbeat, changeRows) {
+		if err := s.emitCTHeartbeat(ctx, tx, table, tableSchema, primaryKeys, targetVersion, opts, results); err != nil {
+			return 0, err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
+		return 0, fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
 	}
 
+	return targetVersion, nil
+}
+
+func (s *MSSQLChangeTrackingSource) emitCTHeartbeat(ctx context.Context, tx *sql.Tx, table string, tableSchema *schema.TableSchema, primaryKeys []string, targetVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	query := buildCTHeartbeatQuery(table, sourceColumnsWithoutCT(tableSchema), primaryKeys, targetVersion)
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to query Change Tracking heartbeat for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if _, err := s.rowsToCTBatches(rows, tableSchema.Columns, opts, results); err != nil {
+		return err
+	}
 	return nil
 }
 
-func (s *MSSQLChangeTrackingSource) rowsToCTBatches(rows *sql.Rows, columns []schema.Column, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func shouldEmitCTHeartbeat(emitHeartbeat bool, changeRows int64) bool {
+	return emitHeartbeat && changeRows == 0
+}
+
+func validateCTExcludeColumns(excludeColumns []string, primaryKeys []string) error {
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkSet[strings.ToLower(pk)] = true
+	}
+	for _, col := range excludeColumns {
+		if destination.IsCDCMetaColumn(col) {
+			return fmt.Errorf("SQL Server Change Tracking sources require metadata column %q; remove it from --sql-exclude-columns", col)
+		}
+		if pkSet[strings.ToLower(col)] {
+			return fmt.Errorf("SQL Server Change Tracking sources require primary key column %q; remove it from --sql-exclude-columns", col)
+		}
+	}
+	return nil
+}
+
+func (s *MSSQLChangeTrackingSource) rowsToCTBatches(rows *sql.Rows, columns []schema.Column, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int64, error) {
 	batchSize := opts.PageSize
 	if batchSize <= 0 {
 		batchSize = 100000
 	}
 	arrowSchema := buildArrowSchema(columns)
+	var totalRows int64
 
 	for {
 		record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
 		if err != nil {
-			return err
+			return totalRows, err
 		}
 		if count == 0 {
-			return nil
+			return totalRows, nil
 		}
+		totalRows += count
 		results <- source.RecordBatchResult{Batch: record}
 	}
 }
 
-func buildCTSnapshotQuery(table string, columns []schema.Column, opts source.ReadOptions, version int64, lock bool) string {
+func buildCTSnapshotQuery(table string, columns []schema.Column, version int64, lock bool) string {
 	selects := make([]string, 0, len(columns)+len(ctMetadataColumns))
 	for _, col := range columns {
 		selects = append(selects, quoteColumn(col.Name))
 	}
 	selects = append(selects, ctMetadataSelects(ctVersionExpr(strconv.FormatInt(version, 10)), "0")...)
 
-	selectClause := "SELECT"
-	if opts.Limit > 0 {
-		selectClause = fmt.Sprintf("SELECT TOP %d", opts.Limit)
-	}
-
 	hint := ""
 	if lock {
 		hint = " WITH (HOLDLOCK)"
 	}
-	return fmt.Sprintf("%s %s FROM %s%s", selectClause, strings.Join(selects, ", "), quoteTable(table), hint)
+	return fmt.Sprintf("SELECT %s FROM %s%s", strings.Join(selects, ", "), quoteTable(table), hint)
+}
+
+func buildCTHeartbeatQuery(table string, columns []schema.Column, primaryKeys []string, version int64) string {
+	selects := make([]string, 0, len(columns)+len(ctMetadataColumns))
+	for _, col := range columns {
+		selects = append(selects, quoteColumn(col.Name))
+	}
+	selects = append(selects, ctMetadataSelects(ctVersionExpr(strconv.FormatInt(version, 10)), "0")...)
+
+	orderBy := make([]string, 0, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		orderBy = append(orderBy, quoteColumn(pk))
+	}
+
+	query := fmt.Sprintf("SELECT TOP 1 %s FROM %s", strings.Join(selects, ", "), quoteTable(table))
+	if len(orderBy) > 0 {
+		query += " ORDER BY " + strings.Join(orderBy, ", ")
+	}
+	return query
 }
 
 func buildCTChangesQuery(table string, columns []schema.Column, primaryKeys []string) string {
@@ -517,8 +590,8 @@ func parseStoredCTVersion(raw string) (int64, bool) {
 
 func objectIDName(table string) string {
 	tableRef := parseMSSQLTableRef(table)
-	if len(tableRef.parts) >= 2 {
-		return tableRef.schemaName + "." + tableRef.tableName
+	if len(tableRef.parts) == 1 {
+		return quoteIdentifierPath([]string{"dbo", tableRef.tableName})
 	}
-	return "dbo." + tableRef.tableName
+	return quoteIdentifierPath(tableRef.parts)
 }

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -1,0 +1,524 @@
+package mssql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const ctVersionWidth = 20
+
+var ctMetadataColumns = []schema.Column{
+	{Name: destination.CDCLSNColumn, DataType: schema.TypeString, Nullable: false},
+	{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: false},
+	{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: false},
+}
+
+type MSSQLChangeTrackingSource struct {
+	MSSQLSource
+}
+
+type changeTrackingTable struct {
+	source      *MSSQLChangeTrackingSource
+	tableName   string
+	tableSchema *schema.TableSchema
+	primaryKeys []string
+	strategy    config.IncrementalStrategy
+}
+
+type ctVersionExpiredError struct {
+	table      string
+	version    int64
+	minVersion int64
+}
+
+func (e *ctVersionExpiredError) Error() string {
+	return fmt.Sprintf("SQL Server Change Tracking version %d is no longer valid for %s; minimum valid version is %d", e.version, e.table, e.minVersion)
+}
+
+func NewMSSQLChangeTrackingSource() *MSSQLChangeTrackingSource {
+	return &MSSQLChangeTrackingSource{}
+}
+
+func (s *MSSQLChangeTrackingSource) Schemes() []string {
+	return []string{"mssql+ct", "sqlserver+ct", "azuresql+ct", "azure-sql+ct"}
+}
+
+func (s *MSSQLChangeTrackingSource) Connect(ctx context.Context, uri string) error {
+	normalizedURI, err := normalizeChangeTrackingURI(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse SQL Server Change Tracking URI: %w", err)
+	}
+
+	connStr, driverName, err := URIToConnString(normalizedURI)
+	if err != nil {
+		return fmt.Errorf("failed to parse SQL Server URI: %w", err)
+	}
+
+	db, err := sql.Open(driverName, connStr)
+	if err != nil {
+		return fmt.Errorf("failed to open SQL Server connection: %w", err)
+	}
+
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping SQL Server: %w", err)
+	}
+
+	s.db = db
+	s.uri = uri
+	s.guidConversion = guidConversionEnabled(connStr)
+
+	if err := s.ensureDatabaseChangeTracking(ctx); err != nil {
+		_ = db.Close()
+		s.db = nil
+		return err
+	}
+
+	return nil
+}
+
+func (s *MSSQLChangeTrackingSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *MSSQLChangeTrackingSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("table name is required")
+	}
+
+	if _, ok := source.IsCustomQuery(req.Name); ok {
+		return nil, fmt.Errorf("custom queries are not supported for SQL Server Change Tracking sources")
+	}
+
+	if err := s.ensureTableChangeTracking(ctx, req.Name); err != nil {
+		return nil, err
+	}
+
+	tableSchema, err := s.getSchema(ctx, req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	pks := req.PrimaryKeys
+	if len(pks) == 0 {
+		pks = tableSchema.PrimaryKeys
+	}
+	if len(pks) == 0 {
+		return nil, fmt.Errorf("SQL Server Change Tracking table %s has no primary key; provide --primary-key or add a primary key to the source table", req.Name)
+	}
+
+	tableSchema.PrimaryKeys = pks
+	tableSchema = addCTColumns(tableSchema)
+
+	strategy := config.StrategyMerge
+	if req.Strategy != "" && req.Strategy != config.StrategyReplace {
+		strategy = req.Strategy
+	}
+
+	return &changeTrackingTable{
+		source:      s,
+		tableName:   req.Name,
+		tableSchema: tableSchema,
+		primaryKeys: pks,
+		strategy:    strategy,
+	}, nil
+}
+
+func (t *changeTrackingTable) Name() string {
+	return t.tableName
+}
+
+func (t *changeTrackingTable) PrimaryKeys() []string {
+	return t.primaryKeys
+}
+
+func (t *changeTrackingTable) IncrementalKey() string {
+	return ""
+}
+
+func (t *changeTrackingTable) Strategy() config.IncrementalStrategy {
+	return t.strategy
+}
+
+func (t *changeTrackingTable) HasKnownSchema() bool {
+	return true
+}
+
+func (t *changeTrackingTable) GetSchema(ctx context.Context) (*schema.TableSchema, error) {
+	return t.tableSchema, nil
+}
+
+func (t *changeTrackingTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		tableSchema := t.tableSchema
+		if opts.Schema != nil {
+			tableSchema = opts.Schema
+		}
+
+		if version, ok := parseStoredCTVersion(opts.CDCResumeLSN); ok && version > 0 {
+			canResume, err := t.source.canResumeCT(ctx, t.tableName, version)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+			if canResume {
+				err := t.source.readCTChanges(ctx, t.tableName, tableSchema, t.primaryKeys, version, opts, results)
+				if err == nil {
+					return
+				}
+				var expired *ctVersionExpiredError
+				if !errors.As(err, &expired) {
+					results <- source.RecordBatchResult{Err: err}
+					return
+				}
+				config.Debug("[MSSQL CT] Resume version %d expired while reading %s; taking a fresh snapshot", version, t.tableName)
+			}
+			if !canResume {
+				config.Debug("[MSSQL CT] Resume version %d is no longer valid for %s; taking a fresh snapshot", version, t.tableName)
+			}
+		}
+
+		snapshotVersion, err := t.source.snapshotCTTable(ctx, t.tableName, tableSchema, opts, results)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)}
+			return
+		}
+
+		if err := t.source.readCTChanges(ctx, t.tableName, tableSchema, t.primaryKeys, snapshotVersion, opts, results); err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func normalizeChangeTrackingURI(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+
+	switch strings.ToLower(parsed.Scheme) {
+	case "mssql+ct":
+		parsed.Scheme = "mssql"
+	case "sqlserver+ct":
+		parsed.Scheme = "sqlserver"
+	case "azuresql+ct":
+		parsed.Scheme = "azuresql"
+	case "azure-sql+ct":
+		parsed.Scheme = "azure-sql"
+	default:
+		return "", fmt.Errorf("unsupported Change Tracking scheme: %s", parsed.Scheme)
+	}
+
+	return parsed.String(), nil
+}
+
+func (s *MSSQLChangeTrackingSource) ensureDatabaseChangeTracking(ctx context.Context) error {
+	var enabled int
+	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sys.change_tracking_databases WHERE database_id = DB_ID()").Scan(&enabled)
+	if err != nil {
+		return fmt.Errorf("failed to check SQL Server Change Tracking status: %w", err)
+	}
+	if enabled == 0 {
+		return fmt.Errorf("SQL Server Change Tracking is not enabled for the current database; run ALTER DATABASE ... SET CHANGE_TRACKING = ON first")
+	}
+	return nil
+}
+
+func (s *MSSQLChangeTrackingSource) ensureTableChangeTracking(ctx context.Context, table string) error {
+	schemaName, tableName := parseTableName(table)
+
+	var enabled int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM sys.change_tracking_tables AS ctt
+		JOIN sys.tables AS t ON t.object_id = ctt.object_id
+		JOIN sys.schemas AS ss ON ss.schema_id = t.schema_id
+		WHERE ss.name = @p1
+		  AND t.name = @p2
+	`, schemaName, tableName).Scan(&enabled)
+	if err != nil {
+		return fmt.Errorf("failed to query SQL Server Change Tracking metadata for %s: %w", table, err)
+	}
+	if enabled == 0 {
+		return fmt.Errorf("table %s is not enabled for SQL Server Change Tracking", table)
+	}
+	return nil
+}
+
+func addCTColumns(original *schema.TableSchema) *schema.TableSchema {
+	result := *original
+	result.Columns = make([]schema.Column, 0, len(original.Columns)+len(ctMetadataColumns))
+	result.Columns = append(result.Columns, original.Columns...)
+	result.Columns = append(result.Columns, ctMetadataColumns...)
+	return &result
+}
+
+func sourceColumnsWithoutCT(tableSchema *schema.TableSchema) []schema.Column {
+	columns := make([]schema.Column, 0, len(tableSchema.Columns))
+	for _, col := range tableSchema.Columns {
+		if destination.IsCDCColumn(col.Name) {
+			continue
+		}
+		columns = append(columns, col)
+	}
+	return columns
+}
+
+type ctQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func (s *MSSQLChangeTrackingSource) canResumeCT(ctx context.Context, table string, version int64) (bool, error) {
+	minVersion, err := s.minValidCTVersion(ctx, s.db, table)
+	if err != nil {
+		return false, err
+	}
+	return version >= minVersion, nil
+}
+
+func (s *MSSQLChangeTrackingSource) minValidCTVersion(ctx context.Context, q ctQueryer, table string) (int64, error) {
+	var minVersion sql.NullInt64
+	err := q.QueryRowContext(ctx, "SELECT CHANGE_TRACKING_MIN_VALID_VERSION(OBJECT_ID(@p1))", objectIDName(table)).Scan(&minVersion)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get SQL Server Change Tracking minimum valid version for %s: %w", table, err)
+	}
+	if !minVersion.Valid {
+		return 0, fmt.Errorf("table %s is not enabled for SQL Server Change Tracking", table)
+	}
+	return minVersion.Int64, nil
+}
+
+func (s *MSSQLChangeTrackingSource) currentCTVersion(ctx context.Context, q ctQueryer) (int64, error) {
+	var version sql.NullInt64
+	if err := q.QueryRowContext(ctx, "SELECT CHANGE_TRACKING_CURRENT_VERSION()").Scan(&version); err != nil {
+		return 0, fmt.Errorf("failed to get SQL Server Change Tracking current version: %w", err)
+	}
+	if !version.Valid {
+		return 0, nil
+	}
+	return version.Int64, nil
+}
+
+func (s *MSSQLChangeTrackingSource) snapshotCTTable(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int64, error) {
+	version, err := s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSnapshot)
+	if err == nil {
+		return version, nil
+	}
+	config.Debug("[MSSQL CT] SNAPSHOT isolation snapshot failed for %s: %v; retrying with table lock", table, err)
+	return s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSerializable)
+}
+
+func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin snapshot transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	version, err := s.currentCTVersion(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+
+	columns := tableSchema.Columns
+	query := buildCTSnapshotQuery(table, sourceColumnsWithoutCT(tableSchema), opts, version, isolation != sql.LevelSnapshot)
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query snapshot for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if err := s.rowsToCTBatches(rows, columns, opts, results); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit snapshot transaction: %w", err)
+	}
+
+	return version, nil
+}
+
+func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelSnapshot)
+	if err == nil {
+		return nil
+	}
+	var expired *ctVersionExpiredError
+	if errors.As(err, &expired) {
+		return err
+	}
+	config.Debug("[MSSQL CT] SNAPSHOT isolation change read failed for %s: %v; retrying with read committed", table, err)
+	return s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelReadCommitted)
+}
+
+func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel) error {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
+	if err != nil {
+		return fmt.Errorf("failed to begin Change Tracking transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	minVersion, err := s.minValidCTVersion(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	if fromVersion < minVersion {
+		return &ctVersionExpiredError{table: table, version: fromVersion, minVersion: minVersion}
+	}
+
+	targetVersion, err := s.currentCTVersion(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if targetVersion <= fromVersion {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
+		}
+		return nil
+	}
+
+	columns := tableSchema.Columns
+	query := buildCTChangesQuery(table, sourceColumnsWithoutCT(tableSchema), primaryKeys)
+	rows, err := tx.QueryContext(ctx, query, fromVersion, targetVersion)
+	if err != nil {
+		return fmt.Errorf("failed to query Change Tracking changes for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if err := s.rowsToCTBatches(rows, columns, opts, results); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (s *MSSQLChangeTrackingSource) rowsToCTBatches(rows *sql.Rows, columns []schema.Column, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+	arrowSchema := buildArrowSchema(columns)
+
+	for {
+		record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
+		if err != nil {
+			return err
+		}
+		if count == 0 {
+			return nil
+		}
+		results <- source.RecordBatchResult{Batch: record}
+	}
+}
+
+func buildCTSnapshotQuery(table string, columns []schema.Column, opts source.ReadOptions, version int64, lock bool) string {
+	selects := make([]string, 0, len(columns)+len(ctMetadataColumns))
+	for _, col := range columns {
+		selects = append(selects, quoteColumn(col.Name))
+	}
+	selects = append(selects, ctMetadataSelects(ctVersionExpr(strconv.FormatInt(version, 10)), "0")...)
+
+	selectClause := "SELECT"
+	if opts.Limit > 0 {
+		selectClause = fmt.Sprintf("SELECT TOP %d", opts.Limit)
+	}
+
+	hint := ""
+	if lock {
+		hint = " WITH (HOLDLOCK)"
+	}
+	return fmt.Sprintf("%s %s FROM %s%s", selectClause, strings.Join(selects, ", "), quoteTable(table), hint)
+}
+
+func buildCTChangesQuery(table string, columns []schema.Column, primaryKeys []string) string {
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkSet[strings.ToLower(pk)] = true
+	}
+
+	selects := make([]string, 0, len(columns)+len(ctMetadataColumns))
+	for _, col := range columns {
+		if pkSet[strings.ToLower(col.Name)] {
+			selects = append(selects, fmt.Sprintf("CT.%s AS %s", quoteColumn(col.Name), quoteColumn(col.Name)))
+		} else {
+			selects = append(selects, fmt.Sprintf("T.%s AS %s", quoteColumn(col.Name), quoteColumn(col.Name)))
+		}
+	}
+	selects = append(selects, ctMetadataSelects(ctVersionExpr("CT.SYS_CHANGE_VERSION"), "CASE WHEN CT.SYS_CHANGE_OPERATION = 'D' THEN 1 ELSE 0 END")...)
+
+	joinConditions := make([]string, len(primaryKeys))
+	orderBy := []string{"CT.SYS_CHANGE_VERSION"}
+	for i, pk := range primaryKeys {
+		quoted := quoteColumn(pk)
+		joinConditions[i] = fmt.Sprintf("T.%s = CT.%s", quoted, quoted)
+		orderBy = append(orderBy, fmt.Sprintf("CT.%s", quoted))
+	}
+
+	return fmt.Sprintf(`
+		SELECT %s
+		FROM CHANGETABLE(CHANGES %s, @p1) AS CT
+		LEFT JOIN %s AS T ON %s
+		WHERE CT.SYS_CHANGE_VERSION <= @p2
+		ORDER BY %s
+	`, strings.Join(selects, ", "), quoteTable(table), quoteTable(table), strings.Join(joinConditions, " AND "), strings.Join(orderBy, ", "))
+}
+
+func ctMetadataSelects(versionExpr, deletedExpr string) []string {
+	return []string{
+		fmt.Sprintf("%s AS %s", versionExpr, quoteColumn(destination.CDCLSNColumn)),
+		fmt.Sprintf("CAST(%s AS bit) AS %s", deletedExpr, quoteColumn(destination.CDCDeletedColumn)),
+		fmt.Sprintf("SYSUTCDATETIME() AS %s", quoteColumn(destination.CDCSyncedAtColumn)),
+	}
+}
+
+func ctVersionExpr(expr string) string {
+	return fmt.Sprintf("RIGHT(REPLICATE('0', %d) + CONVERT(varchar(%d), %s), %d)", ctVersionWidth, ctVersionWidth, expr, ctVersionWidth)
+}
+
+func parseStoredCTVersion(raw string) (int64, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	raw, _, _ = strings.Cut(raw, ":")
+	raw = strings.TrimLeft(raw, "0")
+	if raw == "" {
+		return 0, true
+	}
+	version, err := strconv.ParseInt(raw, 10, 64)
+	return version, err == nil
+}
+
+func objectIDName(table string) string {
+	tableRef := parseMSSQLTableRef(table)
+	if len(tableRef.parts) >= 2 {
+		return tableRef.schemaName + "." + tableRef.tableName
+	}
+	return "dbo." + tableRef.tableName
+}

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -5,12 +5,17 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -371,6 +376,12 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 	if err != nil {
 		return 0, emittedRows, err
 	}
+	if emittedRows == 0 && !opts.FullRefresh {
+		if err := emitSyntheticCTHeartbeat(tableSchema.Columns, tableSchema.PrimaryKeys, version, results); err != nil {
+			return 0, 0, err
+		}
+		emittedRows = 1
+	}
 
 	if err := tx.Commit(); err != nil {
 		return 0, emittedRows, fmt.Errorf("failed to commit snapshot transaction: %w", err)
@@ -454,14 +465,109 @@ func (s *MSSQLChangeTrackingSource) emitCTHeartbeat(ctx context.Context, tx *sql
 	}
 	defer func() { _ = rows.Close() }()
 
-	if _, err := s.rowsToCTBatches(rows, tableSchema.Columns, opts, results); err != nil {
+	emittedRows, err := s.rowsToCTBatches(rows, tableSchema.Columns, opts, results)
+	if err != nil {
 		return err
+	}
+	if emittedRows == 0 {
+		return emitSyntheticCTHeartbeat(tableSchema.Columns, primaryKeys, targetVersion, results)
 	}
 	return nil
 }
 
 func shouldEmitCTHeartbeat(emitHeartbeat bool, changeRows int64) bool {
 	return emitHeartbeat && changeRows == 0
+}
+
+func emitSyntheticCTHeartbeat(columns []schema.Column, primaryKeys []string, targetVersion int64, results chan<- source.RecordBatchResult) error {
+	record, err := syntheticCTHeartbeatRecord(columns, primaryKeys, targetVersion)
+	if err != nil {
+		return err
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}
+
+func syntheticCTHeartbeatRecord(columns []schema.Column, primaryKeys []string, targetVersion int64) (arrow.RecordBatch, error) {
+	arrowSchema := buildArrowSchema(columns)
+	mem := memory.NewGoAllocator()
+	builders := make([]array.Builder, len(columns))
+	for i, field := range arrowSchema.Fields() {
+		builders[i] = array.NewBuilder(mem, field.Type)
+	}
+	defer func() {
+		for _, b := range builders {
+			b.Release()
+		}
+	}()
+
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkSet[strings.ToLower(pk)] = true
+	}
+
+	for i, col := range columns {
+		value := syntheticCTHeartbeatValue(col, pkSet, targetVersion)
+		if value == nil {
+			builders[i].AppendNull()
+			continue
+		}
+		arrowconv.AppendValue(builders[i], value)
+	}
+
+	arrays := make([]arrow.Array, len(builders))
+	for i, b := range builders {
+		arrays[i] = b.NewArray()
+	}
+	defer func() {
+		for _, arr := range arrays {
+			arr.Release()
+		}
+	}()
+
+	return array.NewRecordBatch(arrowSchema, arrays, 1), nil
+}
+
+func syntheticCTHeartbeatValue(col schema.Column, pkSet map[string]bool, targetVersion int64) any {
+	switch {
+	case strings.EqualFold(col.Name, destination.CDCLSNColumn):
+		return formatCTVersion(targetVersion)
+	case strings.EqualFold(col.Name, destination.CDCDeletedColumn):
+		return true
+	case strings.EqualFold(col.Name, destination.CDCSyncedAtColumn):
+		return time.Now().UTC()
+	case pkSet[strings.ToLower(col.Name)]:
+		return syntheticCTPrimaryKeyValue(col)
+	default:
+		return nil
+	}
+}
+
+func syntheticCTPrimaryKeyValue(col schema.Column) any {
+	switch col.DataType {
+	case schema.TypeBoolean:
+		return false
+	case schema.TypeInt8:
+		return int8(math.MinInt8)
+	case schema.TypeInt16:
+		return int16(math.MinInt16)
+	case schema.TypeInt32:
+		return int32(math.MinInt32)
+	case schema.TypeInt64:
+		return int64(math.MinInt64)
+	case schema.TypeFloat32, schema.TypeFloat64:
+		return float64(math.SmallestNonzeroFloat64)
+	case schema.TypeDecimal:
+		return "0"
+	case schema.TypeBinary:
+		return []byte("__ingestr_ct_heartbeat__")
+	case schema.TypeDate, schema.TypeTime, schema.TypeTimestamp, schema.TypeTimestampTZ:
+		return time.Unix(0, 0).UTC()
+	case schema.TypeUUID:
+		return "00000000-0000-0000-0000-000000000000"
+	default:
+		return "__ingestr_ct_heartbeat__"
+	}
 }
 
 func validateCTExcludeColumns(excludeColumns []string, primaryKeys []string) error {
@@ -577,6 +683,10 @@ func ctMetadataSelects(versionExpr, deletedExpr string) []string {
 
 func ctVersionExpr(expr string) string {
 	return fmt.Sprintf("RIGHT(REPLICATE('0', %d) + CONVERT(varchar(%d), %s), %d)", ctVersionWidth, ctVersionWidth, expr, ctVersionWidth)
+}
+
+func formatCTVersion(version int64) string {
+	return fmt.Sprintf("%0*d", ctVersionWidth, version)
 }
 
 func parseStoredCTVersion(raw string) (int64, bool) {

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -335,43 +335,48 @@ func (s *MSSQLChangeTrackingSource) currentCTVersion(ctx context.Context, q ctQu
 }
 
 func (s *MSSQLChangeTrackingSource) snapshotCTTable(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int64, error) {
-	version, err := s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSnapshot)
+	version, emittedRows, err := s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSnapshot)
 	if err == nil {
 		return version, nil
 	}
+	if emittedRows > 0 {
+		return 0, fmt.Errorf("SNAPSHOT isolation snapshot for %s failed after emitting %d rows; not retrying with table lock to avoid duplicate records: %w", table, emittedRows, err)
+	}
 	config.Debug("[MSSQL CT] SNAPSHOT isolation snapshot failed for %s: %v; retrying with table lock", table, err)
-	return s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSerializable)
+	version, _, err = s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSerializable)
+	return version, err
 }
 
-func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel) (int64, error) {
+func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel) (int64, int64, error) {
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if err != nil {
-		return 0, fmt.Errorf("failed to begin snapshot transaction: %w", err)
+		return 0, 0, fmt.Errorf("failed to begin snapshot transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	version, err := s.currentCTVersion(ctx, tx)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	columns := tableSchema.Columns
 	query := buildCTSnapshotQuery(table, sourceColumnsWithoutCT(tableSchema), version, isolation != sql.LevelSnapshot)
 	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query snapshot for %s: %w", table, err)
+		return 0, 0, fmt.Errorf("failed to query snapshot for %s: %w", table, err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	if _, err := s.rowsToCTBatches(rows, columns, opts, results); err != nil {
-		return 0, err
+	emittedRows, err := s.rowsToCTBatches(rows, columns, opts, results)
+	if err != nil {
+		return 0, emittedRows, err
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("failed to commit snapshot transaction: %w", err)
+		return 0, emittedRows, fmt.Errorf("failed to commit snapshot transaction: %w", err)
 	}
 
-	return version, nil
+	return version, emittedRows, nil
 }
 
 func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, emitHeartbeat bool) (int64, error) {

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -380,7 +380,7 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 }
 
 func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, emitHeartbeat bool) (int64, error) {
-	readThroughVersion, err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelSnapshot, emitHeartbeat)
+	readThroughVersion, err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelReadCommitted, emitHeartbeat)
 	if err == nil {
 		return readThroughVersion, nil
 	}
@@ -388,7 +388,7 @@ func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table str
 	if errors.As(err, &expired) {
 		return 0, err
 	}
-	return 0, fmt.Errorf("failed to read SQL Server Change Tracking changes using SNAPSHOT isolation: %w", err)
+	return 0, fmt.Errorf("failed to read SQL Server Change Tracking changes using READ COMMITTED isolation: %w", err)
 }
 
 func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel, emitHeartbeat bool) (int64, error) {

--- a/pkg/source/mssql/change_tracking_test.go
+++ b/pkg/source/mssql/change_tracking_test.go
@@ -2,12 +2,14 @@ package mssql
 
 import (
 	"errors"
+	"math"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -239,6 +241,27 @@ func TestShouldEmitCTHeartbeatOnlyWhenNoChangeRows(t *testing.T) {
 	assert.True(t, shouldEmitCTHeartbeat(true, 0))
 	assert.False(t, shouldEmitCTHeartbeat(true, 1))
 	assert.False(t, shouldEmitCTHeartbeat(false, 0))
+}
+
+func TestSyntheticCTHeartbeatRecord(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString},
+		{Name: destination.CDCLSNColumn, DataType: schema.TypeString},
+		{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+	}
+
+	record, err := syntheticCTHeartbeatRecord(columns, []string{"id"}, 42)
+	require.NoError(t, err)
+	defer record.Release()
+
+	require.EqualValues(t, 1, record.NumRows())
+	require.EqualValues(t, math.MinInt64, record.Column(0).(*array.Int64).Value(0))
+	assert.True(t, record.Column(1).IsNull(0))
+	assert.Equal(t, "00000000000000000042", record.Column(2).(*array.String).Value(0))
+	assert.True(t, record.Column(3).(*array.Boolean).Value(0))
+	assert.False(t, record.Column(4).IsNull(0))
 }
 
 func TestObjectIDNamePreservesSupportedTableRefs(t *testing.T) {

--- a/pkg/source/mssql/change_tracking_test.go
+++ b/pkg/source/mssql/change_tracking_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -87,15 +88,162 @@ func TestBuildCTSnapshotQuery(t *testing.T) {
 		{Name: "name", DataType: schema.TypeString},
 	}
 
-	got := buildCTSnapshotQuery("dbo.items", columns, sourceReadOptionsForTest(10), 123, true)
+	got := buildCTSnapshotQuery("dbo.items", columns, 123, true)
 	normalized := strings.Join(strings.Fields(got), " ")
 
-	assert.Contains(t, normalized, "SELECT TOP 10")
+	assert.Contains(t, normalized, "SELECT")
+	assert.NotContains(t, normalized, "TOP")
 	assert.Contains(t, normalized, "[id], [name]")
 	assert.Contains(t, normalized, "CONVERT(varchar(20), 123)")
 	assert.Contains(t, normalized, "FROM [dbo].[items] WITH (HOLDLOCK)")
 }
 
-func sourceReadOptionsForTest(limit int) source.ReadOptions {
-	return source.ReadOptions{Limit: limit}
+func TestBuildCTHeartbeatQuery(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString},
+	}
+
+	got := buildCTHeartbeatQuery("dbo.items", columns, []string{"id"}, 456)
+	normalized := strings.Join(strings.Fields(got), " ")
+
+	assert.Contains(t, normalized, "SELECT TOP 1")
+	assert.Contains(t, normalized, "[id], [name]")
+	assert.Contains(t, normalized, "CONVERT(varchar(20), 456)")
+	assert.Contains(t, normalized, "FROM [dbo].[items]")
+	assert.Contains(t, normalized, "ORDER BY [id]")
+}
+
+func TestChangeTrackingReadRejectsLimit(t *testing.T) {
+	table := &changeTrackingTable{}
+
+	records, err := table.Read(t.Context(), source.ReadOptions{Limit: 10})
+
+	require.Error(t, err)
+	assert.Nil(t, records)
+	assert.Contains(t, err.Error(), "--sql-limit")
+}
+
+func TestChangeTrackingReadRejectsMetadataExcludes(t *testing.T) {
+	table := &changeTrackingTable{}
+
+	records, err := table.Read(t.Context(), source.ReadOptions{ExcludeColumns: []string{destination.CDCLSNColumn}})
+
+	require.Error(t, err)
+	assert.Nil(t, records)
+	assert.Contains(t, err.Error(), "--sql-exclude-columns")
+	assert.Contains(t, err.Error(), destination.CDCLSNColumn)
+}
+
+func TestChangeTrackingReadRejectsPrimaryKeyExcludes(t *testing.T) {
+	table := &changeTrackingTable{primaryKeys: []string{"id"}}
+
+	records, err := table.Read(t.Context(), source.ReadOptions{ExcludeColumns: []string{"ID"}})
+
+	require.Error(t, err)
+	assert.Nil(t, records)
+	assert.Contains(t, err.Error(), "--sql-exclude-columns")
+	assert.Contains(t, err.Error(), "ID")
+}
+
+func TestChangeTrackingGetTableRejectsNonMergeStrategy(t *testing.T) {
+	src := &MSSQLChangeTrackingSource{}
+
+	table, err := src.GetTable(t.Context(), source.TableRequest{
+		Name:     "dbo.items",
+		Strategy: config.StrategyAppend,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, table)
+	assert.Contains(t, err.Error(), `require "merge" incremental strategy`)
+	assert.Contains(t, err.Error(), `"append"`)
+}
+
+func TestResolveChangeTrackingStrategyDistinguishesDefaultReplace(t *testing.T) {
+	strategy, err := resolveChangeTrackingStrategy(config.StrategyReplace, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, config.StrategyMerge, strategy)
+
+	strategy, err = resolveChangeTrackingStrategy(config.StrategyReplace, true, true)
+	require.NoError(t, err)
+	assert.Equal(t, config.StrategyMerge, strategy)
+
+	strategy, err = resolveChangeTrackingStrategy(config.StrategyMerge, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, config.StrategyMerge, strategy)
+
+	strategy, err = resolveChangeTrackingStrategy(config.StrategyAppend, true, true)
+	require.NoError(t, err)
+	assert.Equal(t, config.StrategyMerge, strategy)
+}
+
+func TestChangeTrackingGetTableRejectsExplicitReplaceWithoutFullRefresh(t *testing.T) {
+	src := &MSSQLChangeTrackingSource{}
+
+	table, err := src.GetTable(t.Context(), source.TableRequest{
+		Name:        "dbo.items",
+		Strategy:    config.StrategyReplace,
+		StrategySet: true,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, table)
+	assert.Contains(t, err.Error(), `require "merge" incremental strategy`)
+	assert.Contains(t, err.Error(), "full-refresh")
+	assert.Contains(t, err.Error(), `"replace"`)
+}
+
+func TestShouldEmitCTHeartbeatOnlyWhenNoChangeRows(t *testing.T) {
+	assert.True(t, shouldEmitCTHeartbeat(true, 0))
+	assert.False(t, shouldEmitCTHeartbeat(true, 1))
+	assert.False(t, shouldEmitCTHeartbeat(false, 0))
+}
+
+func TestObjectIDNamePreservesSupportedTableRefs(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		want  string
+	}{
+		{
+			name:  "unqualified table defaults dbo",
+			table: "items",
+			want:  "[dbo].[items]",
+		},
+		{
+			name:  "schema qualified table",
+			table: "sales.items",
+			want:  "[sales].[items]",
+		},
+		{
+			name:  "database qualified table",
+			table: "RemoteDB.dbo.items",
+			want:  "[RemoteDB].[dbo].[items]",
+		},
+		{
+			name:  "bracketed identifiers with dots",
+			table: "[RemoteDB].[erp.schema].[order.items]",
+			want:  "[RemoteDB].[erp.schema].[order.items]",
+		},
+		{
+			name:  "escaped bracket in identifier",
+			table: "[Remote]]DB].[dbo].[item]]table]",
+			want:  "[Remote]]DB].[dbo].[item]]table]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, objectIDName(tt.table))
+		})
+	}
+}
+
+func TestCTVersionExpiredErrorMentionsFullRefresh(t *testing.T) {
+	err := (&ctVersionExpiredError{table: "dbo.items", version: 10, minVersion: 20}).Error()
+
+	assert.Contains(t, err, "version 10")
+	assert.Contains(t, err, "minimum valid version is 20")
+	assert.Contains(t, err, "--full-refresh")
 }

--- a/pkg/source/mssql/change_tracking_test.go
+++ b/pkg/source/mssql/change_tracking_test.go
@@ -1,0 +1,101 @@
+package mssql
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeChangeTrackingURI(t *testing.T) {
+	normalized, err := normalizeChangeTrackingURI("sqlserver+ct://sa:pass@example:1433/app?encrypt=disable")
+	require.NoError(t, err)
+
+	u, err := url.Parse(normalized)
+	require.NoError(t, err)
+	assert.Equal(t, "sqlserver", u.Scheme)
+	assert.Equal(t, "disable", u.Query().Get("encrypt"))
+}
+
+func TestParseStoredCTVersion(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    int64
+		wantOK  bool
+		message string
+	}{
+		{raw: "", wantOK: false, message: "empty"},
+		{raw: "00000000000000000123", want: 123, wantOK: true, message: "padded"},
+		{raw: "00000000000000000123:ignored", want: 123, wantOK: true, message: "padded with suffix"},
+		{raw: "not-a-version", wantOK: false, message: "invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.message, func(t *testing.T) {
+			got, ok := parseStoredCTVersion(tt.raw)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAddCTColumns(t *testing.T) {
+	original := &schema.TableSchema{
+		Name: "users",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+
+	got := addCTColumns(original)
+
+	require.Len(t, got.Columns, 5)
+	assert.Equal(t, destination.CDCLSNColumn, got.Columns[2].Name)
+	assert.Equal(t, destination.CDCDeletedColumn, got.Columns[3].Name)
+	assert.Equal(t, destination.CDCSyncedAtColumn, got.Columns[4].Name)
+	assert.Len(t, original.Columns, 2, "addCTColumns must not mutate the input schema")
+}
+
+func TestBuildCTChangesQuery(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString},
+		{Name: "value", DataType: schema.TypeInt32},
+	}
+
+	got := buildCTChangesQuery("dbo.items", columns, []string{"id"})
+	normalized := strings.Join(strings.Fields(got), " ")
+
+	assert.Contains(t, normalized, "FROM CHANGETABLE(CHANGES [dbo].[items], @p1) AS CT")
+	assert.Contains(t, normalized, "LEFT JOIN [dbo].[items] AS T ON T.[id] = CT.[id]")
+	assert.Contains(t, normalized, "CT.[id] AS [id]")
+	assert.Contains(t, normalized, "T.[name] AS [name]")
+	assert.Contains(t, normalized, "CASE WHEN CT.SYS_CHANGE_OPERATION = 'D' THEN 1 ELSE 0 END")
+	assert.Contains(t, normalized, "WHERE CT.SYS_CHANGE_VERSION <= @p2")
+}
+
+func TestBuildCTSnapshotQuery(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString},
+	}
+
+	got := buildCTSnapshotQuery("dbo.items", columns, sourceReadOptionsForTest(10), 123, true)
+	normalized := strings.Join(strings.Fields(got), " ")
+
+	assert.Contains(t, normalized, "SELECT TOP 10")
+	assert.Contains(t, normalized, "[id], [name]")
+	assert.Contains(t, normalized, "CONVERT(varchar(20), 123)")
+	assert.Contains(t, normalized, "FROM [dbo].[items] WITH (HOLDLOCK)")
+}
+
+func sourceReadOptionsForTest(limit int) source.ReadOptions {
+	return source.ReadOptions{Limit: limit}
+}

--- a/pkg/source/mssql/change_tracking_test.go
+++ b/pkg/source/mssql/change_tracking_test.go
@@ -1,10 +1,13 @@
 package mssql
 
 import (
+	"errors"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -31,6 +34,7 @@ func TestParseStoredCTVersion(t *testing.T) {
 		message string
 	}{
 		{raw: "", wantOK: false, message: "empty"},
+		{raw: "00000000000000000000", want: 0, wantOK: true, message: "zero version"},
 		{raw: "00000000000000000123", want: 123, wantOK: true, message: "padded"},
 		{raw: "00000000000000000123:ignored", want: 123, wantOK: true, message: "padded with suffix"},
 		{raw: "not-a-version", wantOK: false, message: "invalid"},
@@ -62,6 +66,43 @@ func TestAddCTColumns(t *testing.T) {
 	assert.Equal(t, destination.CDCDeletedColumn, got.Columns[3].Name)
 	assert.Equal(t, destination.CDCSyncedAtColumn, got.Columns[4].Name)
 	assert.Len(t, original.Columns, 2, "addCTColumns must not mutate the input schema")
+}
+
+func TestSnapshotCTTableDoesNotRetryAfterEmittingRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+	tableSchema := &schema.TableSchema{
+		Columns: append([]schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		}, ctMetadataColumns...),
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(int64(7)))
+	mock.ExpectQuery("FROM \\[dbo\\]\\.\\[items\\]").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id",
+			destination.CDCLSNColumn,
+			destination.CDCDeletedColumn,
+			destination.CDCSyncedAtColumn,
+		}).AddRow(int64(1), "00000000000000000007", false, time.Now()))
+	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+
+	results := make(chan source.RecordBatchResult, 2)
+	_, err = src.snapshotCTTable(t.Context(), "dbo.items", tableSchema, source.ReadOptions{PageSize: 100}, results)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not retrying")
+	assert.Len(t, results, 1)
+	res := <-results
+	require.NoError(t, res.Err)
+	require.NotNil(t, res.Batch)
+	res.Batch.Release()
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestBuildCTChangesQuery(t *testing.T) {

--- a/pkg/source/mssql/register.go
+++ b/pkg/source/mssql/register.go
@@ -7,4 +7,8 @@ func init() {
 		[]string{"mssql", "sqlserver", "mssql+pyodbc", "azuresql", "azure-sql"},
 		func() interface{} { return NewMSSQLSource() },
 	)
+	registry.RegisterSource(
+		[]string{"mssql+ct", "sqlserver+ct", "azuresql+ct", "azure-sql+ct"},
+		func() interface{} { return NewMSSQLChangeTrackingSource() },
+	)
 }

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -44,6 +44,8 @@ type TableRequest struct {
 	PrimaryKeys    []string                   // User-specified PKs (used only if source doesn't define them)
 	Strategy       config.IncrementalStrategy // User-specified strategy (used only if source doesn't define it)
 	Streaming      bool                       // Table will be read in streaming mode (--stream)
+	StrategySet    bool                       // Whether strategy was explicitly supplied by the caller
+	FullRefresh    bool                       // Whether the run ignores incremental state and fully refreshes the destination
 }
 
 // Source represents a data source that can provide tables.

--- a/pkg/strategy/append.go
+++ b/pkg/strategy/append.go
@@ -61,6 +61,7 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		ExcludeColumns: job.Config.SQLExcludeColumns,
 		Parallelism:    parallelism,
 		Schema:         job.SourceSchema,
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)
@@ -149,6 +150,7 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 			Parallelism: parallelism,
 			PageSize:    job.Config.PageSize,
 			Limit:       job.Config.SQLLimit,
+			FullRefresh: job.Config.FullRefresh,
 		},
 		CDCResumeLSNs: job.CDCResumeLSNs,
 	})

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -360,6 +360,24 @@ func TestReplaceStrategy_Execute_DedupsWhenPrimaryKeyIsMasked(t *testing.T) {
 	}
 }
 
+func TestReplaceStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyReplace
+	job.Config.FullRefresh = true
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	if !src.readOpts.FullRefresh {
+		t.Fatalf("ReadOptions.FullRefresh = false, want true")
+	}
+}
+
 func TestReplaceStrategy_Execute_WriteFails_DropsStaging(t *testing.T) {
 	job, src, dest := minimalJob()
 	src.readCh = mustClosedRecords()

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -78,6 +78,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		ExcludeColumns: job.Config.SQLExcludeColumns,
 		Parallelism:    parallelism,
 		Schema:         job.SourceSchema,
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -134,6 +134,7 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		Schema:         job.SourceSchema,
 		CDCResumeLSN:   job.Config.CDCResumeLSN,  // For CDC incremental resume
 		CDCSlotSuffix:  job.Config.CDCSlotSuffix, // Destination-aware slot suffix
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)
@@ -260,6 +261,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			PageSize:      job.Config.PageSize,
 			Limit:         job.Config.SQLLimit,
 			CDCSlotSuffix: job.Config.CDCSlotSuffix,
+			FullRefresh:   job.Config.FullRefresh,
 		},
 		CDCResumeLSNs: job.CDCResumeLSNs,
 	})

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -252,6 +252,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		ExcludeColumns: job.Config.SQLExcludeColumns,
 		Parallelism:    parallelism,
 		Schema:         job.SourceSchema,
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)
@@ -420,6 +421,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 			Parallelism: parallelism,
 			PageSize:    job.Config.PageSize,
 			Limit:       job.Config.SQLLimit,
+			FullRefresh: job.Config.FullRefresh,
 		},
 		CDCResumeLSNs: job.CDCResumeLSNs,
 	})

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -87,6 +87,7 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 		ExcludeColumns: job.Config.SQLExcludeColumns,
 		Parallelism:    parallelism,
 		Schema:         job.SourceSchema,
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -121,10 +121,9 @@ func TestStreaming_CountTriggerFlushes(t *testing.T) {
 	require.Eventually(t, func() bool { return writeCallCount(dest) == 1 }, 5*time.Second, time.Millisecond)
 	require.Eventually(t, func() bool { return len(committer.committed()) == 1 }, 5*time.Second, time.Millisecond)
 
-	// Order: write to staging, merge into dest, reset staging (PrepareTable
-	// fallback since fakeDestination is not TruncateCapable), then commit.
+	// Order: write to staging, merge into dest, reset staging, then commit.
 	dest.mu.Lock()
-	assert.Equal(t, []string{"WriteParallel", "MergeTable", "PrepareTable"}, dest.calls)
+	assert.Equal(t, []string{"WriteParallel", "MergeTable", "TruncateTable"}, dest.calls)
 	assert.Equal(t, "ds.tbl_staging", dest.writeCalls[0].Table)
 	assert.True(t, dest.writeCalls[0].StagingTable)
 	assert.Equal(t, "ds.tbl_staging", dest.mergeCalls[0].StagingTable)

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -98,6 +98,7 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 		ExcludeColumns: job.Config.SQLExcludeColumns,
 		Parallelism:    parallelism,
 		Schema:         job.SourceSchema,
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)
@@ -169,6 +170,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		ExcludeColumns: job.Config.SQLExcludeColumns,
 		Parallelism:    parallelism,
 		Schema:         job.SourceSchema,
+		FullRefresh:    job.Config.FullRefresh,
 	}
 
 	records, err := job.GetRecords(ctx, readOpts)

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 )
 
+func TestTruncateInsertStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.FullRefresh = true
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.readCh = mustClosedRecords()
+
+	strat := &TruncateInsertStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	if !src.readOpts.FullRefresh {
+		t.Fatalf("ReadOptions.FullRefresh = false, want true")
+	}
+}
+
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyTruncateInsert

--- a/tests/integration/mssql_ct_test.go
+++ b/tests/integration/mssql_ct_test.go
@@ -61,6 +61,20 @@ func createMSSQLCTItemsTable(t *testing.T, ctx context.Context, db *sql.DB) {
 	require.NoError(t, err)
 }
 
+func createEmptyMSSQLCTItemsTable(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE dbo.items (
+		id INT NOT NULL PRIMARY KEY,
+		name NVARCHAR(100) NOT NULL,
+		value INT NULL
+	)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `ALTER TABLE dbo.items ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = OFF)`)
+	require.NoError(t, err)
+}
+
 func TestMSSQLChangeTracking_SnapshotAndIncremental_DuckDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -89,6 +103,15 @@ func TestMSSQLChangeTracking_SnapshotAndIncremental_DuckDB(t *testing.T) {
 		defer func() { _ = duck.Close() }()
 
 		var v int64
+		require.NoError(t, duck.QueryRow(query).Scan(&v))
+		return v
+	}
+	queryDuckString := func(query string) string {
+		duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+		require.NoError(t, err)
+		defer func() { _ = duck.Close() }()
+
+		var v string
 		require.NoError(t, duck.QueryRow(query).Scan(&v))
 		return v
 	}
@@ -124,7 +147,55 @@ func TestMSSQLChangeTracking_SnapshotAndIncremental_DuckDB(t *testing.T) {
 
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
+	var currentCTVersion int64
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT CHANGE_TRACKING_CURRENT_VERSION()`).Scan(&currentCTVersion))
+
 	assert.EqualValues(t, 4, queryDuckCount(`SELECT COUNT(*) FROM items_dest`), "insert+delete inside one CT window should not create a destination row")
 	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 3 AND name = 'item3' AND value = 300 AND "_cdc_deleted"`), "CT delete only carries PKs, so existing row data is preserved")
 	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 5`))
+	assert.Less(t, queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_dest`), fmt.Sprintf("%020d", currentCTVersion), "row-level Change Tracking cursor does not advance for changes that materialize no destination row")
+}
+
+func TestMSSQLChangeTracking_EmptyTableSnapshot_DuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCTDatabase(t, ctx)
+	createEmptyMSSQLCTItemsTable(t, ctx, db)
+
+	tmpDir, err := os.MkdirTemp("", "mssql_ct_empty_duckdb_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	duckdbPath := tmpDir + "/test.duckdb"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+ct", dbName, nil),
+		SourceTable: "dbo.items",
+		DestURI:     "duckdb:///" + duckdbPath,
+		DestTable:   "items_empty_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	queryDuckCount := func(query string) int64 {
+		duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+		require.NoError(t, err)
+		defer func() { _ = duck.Close() }()
+
+		var v int64
+		require.NoError(t, duck.QueryRow(query).Scan(&v))
+		return v
+	}
+
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest`))
+
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (1, N'item1', 100)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest`), "insert+delete on an empty table should not create a destination row")
 }

--- a/tests/integration/mssql_ct_test.go
+++ b/tests/integration/mssql_ct_test.go
@@ -150,10 +150,10 @@ func TestMSSQLChangeTracking_SnapshotAndIncremental_DuckDB(t *testing.T) {
 	var currentCTVersion int64
 	require.NoError(t, db.QueryRowContext(ctx, `SELECT CHANGE_TRACKING_CURRENT_VERSION()`).Scan(&currentCTVersion))
 
-	assert.EqualValues(t, 4, queryDuckCount(`SELECT COUNT(*) FROM items_dest`), "insert+delete inside one CT window should not create a destination row")
+	assert.EqualValues(t, 5, queryDuckCount(`SELECT COUNT(*) FROM items_dest`), "insert+delete inside one CT window should create a deleted cursor tombstone")
 	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 3 AND name = 'item3' AND value = 300 AND "_cdc_deleted"`), "CT delete only carries PKs, so existing row data is preserved")
-	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 5`))
-	assert.Less(t, queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_dest`), fmt.Sprintf("%020d", currentCTVersion), "row-level Change Tracking cursor does not advance for changes that materialize no destination row")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 5 AND "_cdc_deleted"`), "insert+delete tombstone should be materialized for cursor advancement")
+	assert.Equal(t, fmt.Sprintf("%020d", currentCTVersion), queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_dest`), "Change Tracking cursor should advance even when a window has no active row image")
 }
 
 func TestMSSQLChangeTracking_EmptyTableSnapshot_DuckDB(t *testing.T) {
@@ -187,8 +187,17 @@ func TestMSSQLChangeTracking_EmptyTableSnapshot_DuckDB(t *testing.T) {
 		require.NoError(t, duck.QueryRow(query).Scan(&v))
 		return v
 	}
+	queryDuckString := func(query string) string {
+		duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+		require.NoError(t, err)
+		defer func() { _ = duck.Close() }()
 
-	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest`))
+		var v string
+		require.NoError(t, duck.QueryRow(query).Scan(&v))
+		return v
+	}
+
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest WHERE NOT "_cdc_deleted"`))
 
 	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (1, N'item1', 100)`)
 	require.NoError(t, err)
@@ -197,5 +206,6 @@ func TestMSSQLChangeTracking_EmptyTableSnapshot_DuckDB(t *testing.T) {
 
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
-	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest`), "insert+delete on an empty table should not create a destination row")
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest WHERE NOT "_cdc_deleted"`), "insert+delete on an empty table should not create an active destination row")
+	assert.NotEmpty(t, queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_empty_dest`), "empty-table cursor tombstone should advance resume state")
 }

--- a/tests/integration/mssql_ct_test.go
+++ b/tests/integration/mssql_ct_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupMSSQLCTDatabase(t *testing.T, ctx context.Context) (string, *sql.DB) {
+	t.Helper()
+
+	if mssqlDest.uri == "" {
+		t.Skip("MSSQL container not available")
+	}
+
+	adminDB := openMSSQLTestDB(t, mssqlDest.uri)
+	t.Cleanup(func() { _ = adminDB.Close() })
+
+	dbName := fmt.Sprintf("ct_%s", uniqueSuffix())
+	_, err := adminDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE [%s]", dbName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", dbName))
+		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE [%s]", dbName))
+	})
+
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET ALLOW_SNAPSHOT_ISOLATION ON", dbName))
+	require.NoError(t, err)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON)", dbName))
+	require.NoError(t, err)
+
+	db := openMSSQLTestDB(t, mssqlURIForDatabase(t, mssqlDest.uri, "mssql", dbName, nil))
+	t.Cleanup(func() { _ = db.Close() })
+
+	return dbName, db
+}
+
+func createMSSQLCTItemsTable(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE dbo.items (
+		id INT NOT NULL PRIMARY KEY,
+		name NVARCHAR(100) NOT NULL,
+		value INT NULL
+	)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `ALTER TABLE dbo.items ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = OFF)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (1, N'item1', 100), (2, N'item2', 200), (3, N'item3', 300)`)
+	require.NoError(t, err)
+}
+
+func TestMSSQLChangeTracking_SnapshotAndIncremental_DuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCTDatabase(t, ctx)
+	createMSSQLCTItemsTable(t, ctx, db)
+
+	tmpDir, err := os.MkdirTemp("", "mssql_ct_duckdb_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	duckdbPath := tmpDir + "/test.duckdb"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+ct", dbName, nil),
+		SourceTable: "dbo.items",
+		DestURI:     "duckdb:///" + duckdbPath,
+		DestTable:   "items_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	queryDuckCount := func(query string) int64 {
+		duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+		require.NoError(t, err)
+		defer func() { _ = duck.Close() }()
+
+		var v int64
+		require.NoError(t, duck.QueryRow(query).Scan(&v))
+		return v
+	}
+
+	assert.EqualValues(t, 3, queryDuckCount(`SELECT COUNT(*) FROM items_dest`), "should have 3 rows from snapshot")
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE "_cdc_deleted"`), "no snapshot row should be deleted")
+	firstVersionCount := queryDuckCount(`SELECT COUNT(DISTINCT "_cdc_lsn") FROM items_dest`)
+	assert.EqualValues(t, 1, firstVersionCount, "snapshot rows share one Change Tracking version")
+
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (4, N'item4', 400)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET value = 150 WHERE id = 1`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 2`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.EqualValues(t, 4, queryDuckCount(`SELECT COUNT(*) FROM items_dest`))
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 1 AND value = 150 AND NOT "_cdc_deleted"`), "update should be applied")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 2 AND value = 200 AND "_cdc_deleted"`), "delete should mark existing row deleted")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 4 AND name = 'item4' AND value = 400 AND NOT "_cdc_deleted"`), "insert should be applied")
+	assert.Greater(t, queryDuckCount(`SELECT COUNT(DISTINCT "_cdc_lsn") FROM items_dest`), firstVersionCount, "Change Tracking cursor should advance after incremental sync")
+
+	_, err = db.ExecContext(ctx, `UPDATE dbo.items SET name = N'item3_final', value = 999 WHERE id = 3`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 3`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (5, N'item5', 500)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM dbo.items WHERE id = 5`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.EqualValues(t, 4, queryDuckCount(`SELECT COUNT(*) FROM items_dest`), "insert+delete inside one CT window should not create a destination row")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 3 AND name = 'item3' AND value = 300 AND "_cdc_deleted"`), "CT delete only carries PKs, so existing row data is preserved")
+	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 5`))
+}


### PR DESCRIPTION
Adds a SQL Server Change Tracking source with `mssql+ct`, `sqlserver+ct`, `azuresql+ct`, and `azure-sql+ct` schemes, using the existing merge/resume flow with `_cdc_lsn` as the cursor.

Includes docs plus unit and integration coverage for snapshots, incremental resumes, deletes, composite keys, and CT net-change behavior.

Validated with `make format`, `make lint`, `make test`, the SQL Server CT integration test, and manual SQL Server container runs up to 1M rows.
