### PR TITLE
Add Monday items source and board scoping

### DIFF
--- a/pkg/source/monday/monday.go
+++ b/pkg/source/monday/monday.go
@@ -29,6 +29,7 @@ var supportedTables = []string{
 	"account_roles",
 	"users",
 	"boards",
+	"items",
 	"workspaces",
 	"webhooks",
 	"updates",
@@ -142,6 +143,21 @@ var boardViewsFields = []schema.Column{
 	{Name: "access_level", DataType: schema.TypeString, Nullable: true},
 }
 
+var itemsFields = []schema.Column{
+	{Name: "board_id", DataType: schema.TypeString, Nullable: false},
+	{Name: "id", DataType: schema.TypeString, Nullable: false},
+	{Name: "name", DataType: schema.TypeString, Nullable: true},
+	{Name: "state", DataType: schema.TypeString, Nullable: true},
+	{Name: "created_at", DataType: schema.TypeTimestampTZ, Nullable: true},
+	{Name: "updated_at", DataType: schema.TypeTimestampTZ, Nullable: true},
+	{Name: "creator_id", DataType: schema.TypeString, Nullable: true},
+	{Name: "group_id", DataType: schema.TypeString, Nullable: true},
+	{Name: "group_title", DataType: schema.TypeString, Nullable: true},
+	// Raw cell data: a JSON array of {id, title, text, type, value} per column.
+	// Pivot downstream (join board_columns) into named columns.
+	{Name: "column_values", DataType: schema.TypeJSON, Nullable: true},
+}
+
 var workspacesFields = []schema.Column{
 	{Name: "id", DataType: schema.TypeString, Nullable: false},
 	{Name: "name", DataType: schema.TypeString, Nullable: true},
@@ -172,7 +188,9 @@ var updatesFields = []schema.Column{
 	{Name: "updated_at", DataType: schema.TypeTimestampTZ, Nullable: true},
 	{Name: "edited_at", DataType: schema.TypeTimestampTZ, Nullable: true},
 	{Name: "creator_id", DataType: schema.TypeString, Nullable: true},
+	{Name: "creator_name", DataType: schema.TypeString, Nullable: true},
 	{Name: "item_id", DataType: schema.TypeString, Nullable: true},
+	{Name: "item_name", DataType: schema.TypeString, Nullable: true},
 	{Name: "creator", DataType: schema.TypeJSON, Nullable: true},
 	{Name: "item", DataType: schema.TypeJSON, Nullable: true},
 	{Name: "assets", DataType: schema.TypeString, Nullable: true},
@@ -249,9 +267,14 @@ func ParseMondayUri(uri string) (string, error) {
 		return "", fmt.Errorf("failed to parse monday URI query: %w", err)
 	}
 
+	// Accept api_token as an alias for api_key for backward compatibility
+	// (older configs and documentation use api_token).
 	apiKey := values.Get("api_key")
 	if apiKey == "" {
-		return "", fmt.Errorf("api_key query parameter is required")
+		apiKey = values.Get("api_token")
+	}
+	if apiKey == "" {
+		return "", fmt.Errorf("api_key (or api_token) query parameter is required")
 	}
 
 	return apiKey, nil
@@ -265,7 +288,7 @@ func (s *MondaySource) Close(ctx context.Context) error {
 }
 
 func (s *MondaySource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
-	tableName := req.Name
+	tableName, _ := parseTableSpec(req.Name)
 	if !isValidTable(tableName) {
 		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", req.Name, strings.Join(supportedTables, ", "))
 	}
@@ -294,7 +317,7 @@ func (s *MondaySource) GetTable(ctx context.Context, req source.TableRequest) (s
 			return tableSchema, nil
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
-			return s.read(ctx, tableName, opts)
+			return s.read(ctx, req.Name, opts)
 		},
 	}, nil
 }
@@ -315,6 +338,9 @@ func (s *MondaySource) getSchema(ctx context.Context, table string) (*schema.Tab
 		primaryKeys = nil
 	case "boards":
 		fields = boardsFields
+		primaryKeys = []string{"id"}
+	case "items":
+		fields = itemsFields
 		primaryKeys = []string{"id"}
 	case "workspaces":
 		fields = workspacesFields
@@ -356,8 +382,30 @@ func (s *MondaySource) read(ctx context.Context, table string, opts source.ReadO
 	if !isValidTable(tableName) {
 		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", table, strings.Join(supportedTables, ", "))
 	}
+
+	// The board-aware tables accept a `:<board_id>[,<id>...]` param to scope to
+	// specific boards (empty -> all boards in the account):
+	//   items:<ids> / items:<master>:linked / updates:<ids> /
+	//   board_columns:<ids> / board_views:<ids> / boards:<ids>
+	var boardIDParams []string
+	itemsLinked := false
 	if len(params) > 0 {
-		return nil, fmt.Errorf("%s table must be in the format `%s`", tableName, tableName)
+		switch tableName {
+		case "items", "updates", "board_columns", "board_views", "boards":
+		default:
+			return nil, fmt.Errorf("%s table must be in the format `%s`", tableName, tableName)
+		}
+		if tableName == "items" && params[len(params)-1] == "linked" {
+			itemsLinked = true
+			params = params[:len(params)-1]
+		}
+		for _, p := range params {
+			for _, id := range strings.Split(p, ",") {
+				if trimmed := strings.TrimSpace(id); trimmed != "" {
+					boardIDParams = append(boardIDParams, trimmed)
+				}
+			}
+		}
 	}
 
 	results := make(chan source.RecordBatchResult, 8)
@@ -374,13 +422,15 @@ func (s *MondaySource) read(ctx context.Context, table string, opts source.ReadO
 		case "users":
 			err = s.readUsers(ctx, opts, results)
 		case "boards":
-			err = s.readBoards(ctx, opts, results)
+			err = s.readBoards(ctx, opts, results, boardIDParams)
+		case "items":
+			err = s.readItems(ctx, opts, results, boardIDParams, itemsLinked)
 		case "workspaces":
 			err = s.readWorkspaces(ctx, opts, results)
 		case "webhooks":
 			err = s.readWebhooks(ctx, opts, results)
 		case "updates":
-			err = s.readUpdates(ctx, opts, results)
+			err = s.readUpdates(ctx, opts, results, boardIDParams)
 		case "teams":
 			err = s.readTeams(ctx, opts, results)
 		case "tags":
@@ -388,9 +438,9 @@ func (s *MondaySource) read(ctx context.Context, table string, opts source.ReadO
 		case "custom_activities":
 			err = s.readCustomActivities(ctx, opts, results)
 		case "board_columns":
-			err = s.readBoardColumns(ctx, opts, results)
+			err = s.readBoardColumns(ctx, opts, results, boardIDParams)
 		case "board_views":
-			err = s.readBoardViews(ctx, opts, results)
+			err = s.readBoardViews(ctx, opts, results, boardIDParams)
 		default:
 			err = fmt.Errorf("unsupported table: %s", table)
 		}
@@ -880,8 +930,15 @@ func (s *MondaySource) readUsers(ctx context.Context, opts source.ReadOptions, r
 }
 
 // readUpdates reads updates with optional date filtering and sends them as record batches.
-func (s *MondaySource) readUpdates(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *MondaySource) readUpdates(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, boardIDs []string) error {
 	config.Debug("[Monday] Reading updates")
+
+	// Board-scoped mode: `updates:<board_id>` pulls only the given boards' item
+	// updates (Monday's top-level updates query can't filter by board, so this uses
+	// the nested boards->items->updates path) and supplies the item name.
+	if len(boardIDs) > 0 {
+		return s.readBoardScopedUpdates(ctx, opts, results, boardIDs)
+	}
 
 	pageSize := opts.PageSize
 	if pageSize <= 0 || pageSize > maxPageSize {
@@ -901,9 +958,11 @@ func (s *MondaySource) readUpdates(ctx context.Context, opts source.ReadOptions,
 			item_id
 			creator {
 				id
+				name
 			}
 			item {
 				id
+				name
 			}
 			assets {
 				id
@@ -1198,7 +1257,513 @@ func (s *MondaySource) readSimpleList(
 	return nil
 }
 
-func (s *MondaySource) readBoardColumns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+// itemFieldsFragment is the item selection shared by the first-page and
+// next-page item queries. group{} and creator{} are flattened by
+// normalizeDictionaries into group_id/group_title/creator_id; column_values
+// (a list of multi-key objects) is JSON-encoded into the column_values column.
+const itemFieldsFragment = `
+	id
+	name
+	state
+	created_at
+	updated_at
+	creator {
+		id
+	}
+	group {
+		id
+		title
+	}
+	column_values {
+		id
+		text
+		value
+		type
+		column {
+			title
+		}
+	}`
+
+func cursorString(v interface{}) string {
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// readItems streams the rows (items) of one or more boards, with cursor-based
+// items_page pagination. boardIDs empty -> every board in the account.
+// linked -> treat boardIDs as master boards and fan out to their linked sub-boards
+// (board name == master item title).
+func (s *MondaySource) readItems(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, boardIDs []string, linked bool) error {
+	config.Debug("[Monday] Reading items")
+
+	if linked {
+		if len(boardIDs) == 0 {
+			return fmt.Errorf("items:<master_board_id>:linked requires at least one master board id")
+		}
+		resolved, err := s.resolveLinkedBoardIDs(ctx, boardIDs)
+		if err != nil {
+			return err
+		}
+		config.Debug("[Monday] Resolved %d linked sub-boards from %d master board(s)", len(resolved), len(boardIDs))
+		// Include the master board(s) themselves alongside their linked sub-boards,
+		// so a single `items:<master>:linked` returns both the master's own rows and
+		// every sub-board's rows. Dedup preserves master-first ordering.
+		seen := make(map[string]struct{}, len(boardIDs)+len(resolved))
+		combined := make([]string, 0, len(boardIDs)+len(resolved))
+		for _, id := range boardIDs {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				combined = append(combined, id)
+			}
+		}
+		for _, id := range resolved {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				combined = append(combined, id)
+			}
+		}
+		boardIDs = combined
+	} else if len(boardIDs) == 0 {
+		ids, err := s.getAllBoardIDs(ctx, opts)
+		if err != nil {
+			return err
+		}
+		boardIDs = ids
+	}
+	if len(boardIDs) == 0 {
+		return nil
+	}
+
+	pageSize := opts.PageSize
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	limit := min(pageSize, maxPageSize)
+
+	firstPageQuery := `
+		query ($board_id: ID!, $limit: Int!) {
+		boards(ids: [$board_id]) {
+			items_page(limit: $limit) {
+				cursor
+				items {` + itemFieldsFragment + `
+				}
+			}
+		}
+	}
+	`
+	nextPageQuery := `
+		query ($cursor: String!, $limit: Int!) {
+		next_items_page(cursor: $cursor, limit: $limit) {
+			cursor
+			items {` + itemFieldsFragment + `
+			}
+		}
+	}
+	`
+
+	batch := make([]map[string]interface{}, 0, defaultBatchSize)
+	totalProcessed := 0
+
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, itemsFields, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to build items record: %w", err)
+		}
+		results <- source.RecordBatchResult{Batch: record}
+		batch = batch[:0]
+		return nil
+	}
+
+	emit := func(boardID string, rawItems []interface{}) error {
+		for _, raw := range rawItems {
+			itemMap, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			itemMap["board_id"] = boardID
+			batch = append(batch, normalizeDictionaries(itemMap))
+			totalProcessed++
+			if len(batch) >= defaultBatchSize {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	for _, boardID := range boardIDs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		data, err := s.executeGraphQL(ctx, firstPageQuery, map[string]interface{}{
+			"board_id": boardID,
+			"limit":    limit,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to execute items query for board %s: %w", boardID, err)
+		}
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(data, &response); err != nil {
+			return fmt.Errorf("failed to unmarshal items response: %w", err)
+		}
+
+		boards, ok := response["boards"].([]interface{})
+		if !ok || len(boards) == 0 {
+			continue
+		}
+		boardMap, ok := boards[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		itemsPage, ok := boardMap["items_page"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rawItems, _ := itemsPage["items"].([]interface{})
+		if err := emit(boardID, rawItems); err != nil {
+			return err
+		}
+
+		cursor := cursorString(itemsPage["cursor"])
+		for cursor != "" {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			data, err := s.executeGraphQL(ctx, nextPageQuery, map[string]interface{}{
+				"cursor": cursor,
+				"limit":  limit,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to execute next_items_page for board %s: %w", boardID, err)
+			}
+
+			var nextResp map[string]interface{}
+			if err := json.Unmarshal(data, &nextResp); err != nil {
+				return fmt.Errorf("failed to unmarshal next_items_page response: %w", err)
+			}
+
+			nextPage, ok := nextResp["next_items_page"].(map[string]interface{})
+			if !ok {
+				break
+			}
+			rawItems, _ := nextPage["items"].([]interface{})
+			if err := emit(boardID, rawItems); err != nil {
+				return err
+			}
+			cursor = cursorString(nextPage["cursor"])
+		}
+	}
+
+	if err := flush(); err != nil {
+		return err
+	}
+	config.Debug("[Monday] Finished reading items: %d total records", totalProcessed)
+	return nil
+}
+
+// readBoardScopedUpdates streams one row per update on each board's items (with the
+// item name), cursor-paginated. Used when `updates` is scoped to specific boards;
+// Monday's top-level updates query cannot filter by board, so it walks
+// boards -> items_page -> updates instead.
+func (s *MondaySource) readBoardScopedUpdates(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, boardIDs []string) error {
+	config.Debug("[Monday] Reading board-scoped updates for %d board(s)", len(boardIDs))
+
+	const itemUpdates = `
+				id
+				name
+				updates(limit: 100) {
+					id
+					body
+					text_body
+					created_at
+					updated_at
+					creator { id name }
+				}`
+	firstQuery := `
+		query ($board_id: ID!, $limit: Int!) {
+		boards(ids: [$board_id]) {
+			items_page(limit: $limit) {
+				cursor
+				items {` + itemUpdates + `
+				}
+			}
+		}
+	}
+	`
+	nextQuery := `
+		query ($cursor: String!, $limit: Int!) {
+		next_items_page(cursor: $cursor, limit: $limit) {
+			cursor
+			items {` + itemUpdates + `
+			}
+		}
+	}
+	`
+
+	batch := make([]map[string]interface{}, 0, defaultBatchSize)
+	totalProcessed := 0
+
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, updatesFields, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to build updates record: %w", err)
+		}
+		results <- source.RecordBatchResult{Batch: record}
+		batch = batch[:0]
+		return nil
+	}
+
+	emit := func(rawItems []interface{}) error {
+		for _, raw := range rawItems {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			updates, _ := item["updates"].([]interface{})
+			for _, u := range updates {
+				upd, ok := u.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				// Shape each update like an account-wide updates record, then let
+				// normalizeDictionaries flatten creator{id,name}/item{id,name} into
+				// creator_id/creator_name/item_id/item_name (matching updatesFields).
+				rec := map[string]interface{}{
+					"id":         upd["id"],
+					"body":       upd["body"],
+					"text_body":  upd["text_body"],
+					"created_at": upd["created_at"],
+					"updated_at": upd["updated_at"],
+					"creator":    upd["creator"],
+					"item":       map[string]interface{}{"id": item["id"], "name": item["name"]},
+				}
+				batch = append(batch, normalizeDictionaries(rec))
+				totalProcessed++
+				if len(batch) >= defaultBatchSize {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	for _, boardID := range boardIDs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		data, err := s.executeGraphQL(ctx, firstQuery, map[string]interface{}{"board_id": boardID, "limit": maxPageSize})
+		if err != nil {
+			return fmt.Errorf("failed to execute board-scoped updates query for board %s: %w", boardID, err)
+		}
+		var response map[string]interface{}
+		if err := json.Unmarshal(data, &response); err != nil {
+			return fmt.Errorf("failed to unmarshal board-scoped updates response: %w", err)
+		}
+		boards, ok := response["boards"].([]interface{})
+		if !ok || len(boards) == 0 {
+			continue
+		}
+		boardMap, ok := boards[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		itemsPage, ok := boardMap["items_page"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rawItems, _ := itemsPage["items"].([]interface{})
+		if err := emit(rawItems); err != nil {
+			return err
+		}
+		cursor := cursorString(itemsPage["cursor"])
+		for cursor != "" {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			data, err := s.executeGraphQL(ctx, nextQuery, map[string]interface{}{"cursor": cursor, "limit": maxPageSize})
+			if err != nil {
+				return fmt.Errorf("failed to execute next_items_page (board_updates) for board %s: %w", boardID, err)
+			}
+			var nextResp map[string]interface{}
+			if err := json.Unmarshal(data, &nextResp); err != nil {
+				return fmt.Errorf("failed to unmarshal next_items_page (board_updates) response: %w", err)
+			}
+			nextPage, ok := nextResp["next_items_page"].(map[string]interface{})
+			if !ok {
+				break
+			}
+			rawItems, _ := nextPage["items"].([]interface{})
+			if err := emit(rawItems); err != nil {
+				return err
+			}
+			cursor = cursorString(nextPage["cursor"])
+		}
+	}
+
+	if err := flush(); err != nil {
+		return err
+	}
+	config.Debug("[Monday] Finished reading board-scoped updates: %d total records", totalProcessed)
+	return nil
+}
+
+// resolveLinkedBoardIDs maps each master board's item titles to boards of the same
+// name (board name == master item title) and returns the deduped set of linked
+// sub-board ids.
+func (s *MondaySource) resolveLinkedBoardIDs(ctx context.Context, masterIDs []string) ([]string, error) {
+	nameToID, err := s.getBoardNameToID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	linked := make(map[string]struct{})
+	for _, master := range masterIDs {
+		names, err := s.getBoardItemNames(ctx, master)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			if id, ok := nameToID[name]; ok {
+				linked[id] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(linked))
+	for id := range linked {
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+// getBoardNameToID returns a board name -> id map for every board in the account.
+func (s *MondaySource) getBoardNameToID(ctx context.Context) (map[string]string, error) {
+	const query = `query ($limit: Int!, $page: Int!) { boards(limit: $limit, page: $page) { id name } }`
+	nameToID := make(map[string]string)
+	itemsChan, errChan := s.paginateGraphQL(ctx, query, "boards", maxPageSize, nil)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+		case board, ok := <-itemsChan:
+			if !ok {
+				return nameToID, nil
+			}
+			name, _ := board["name"].(string)
+			if id := board["id"]; name != "" && id != nil {
+				nameToID[name] = fmt.Sprint(id)
+			}
+		}
+	}
+}
+
+// getBoardItemNames returns the names of every item on a board (cursor-paginated).
+func (s *MondaySource) getBoardItemNames(ctx context.Context, boardID string) ([]string, error) {
+	const firstQuery = `
+		query ($board_id: ID!, $limit: Int!) {
+		boards(ids: [$board_id]) {
+			items_page(limit: $limit) {
+				cursor
+				items { name }
+			}
+		}
+	}
+	`
+	const nextQuery = `
+		query ($cursor: String!, $limit: Int!) {
+		next_items_page(cursor: $cursor, limit: $limit) {
+			cursor
+			items { name }
+		}
+	}
+	`
+
+	var names []string
+	collect := func(rawItems []interface{}) {
+		for _, raw := range rawItems {
+			if m, ok := raw.(map[string]interface{}); ok {
+				if name, ok := m["name"].(string); ok && name != "" {
+					names = append(names, name)
+				}
+			}
+		}
+	}
+
+	data, err := s.executeGraphQL(ctx, firstQuery, map[string]interface{}{"board_id": boardID, "limit": maxPageSize})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch items for master board %s: %w", boardID, err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	boards, ok := resp["boards"].([]interface{})
+	if !ok || len(boards) == 0 {
+		return names, nil
+	}
+	boardMap, _ := boards[0].(map[string]interface{})
+	itemsPage, ok := boardMap["items_page"].(map[string]interface{})
+	if !ok {
+		return names, nil
+	}
+	rawItems, _ := itemsPage["items"].([]interface{})
+	collect(rawItems)
+
+	cursor := cursorString(itemsPage["cursor"])
+	for cursor != "" {
+		data, err := s.executeGraphQL(ctx, nextQuery, map[string]interface{}{"cursor": cursor, "limit": maxPageSize})
+		if err != nil {
+			return nil, err
+		}
+		var nresp map[string]interface{}
+		if err := json.Unmarshal(data, &nresp); err != nil {
+			return nil, err
+		}
+		nextPage, ok := nresp["next_items_page"].(map[string]interface{})
+		if !ok {
+			break
+		}
+		rawItems, _ := nextPage["items"].([]interface{})
+		collect(rawItems)
+		cursor = cursorString(nextPage["cursor"])
+	}
+	return names, nil
+}
+
+func (s *MondaySource) readBoardColumns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, boardIDs []string) error {
 	const query = `
 		query ($board_ids: [ID!]) {
 		boards(ids: $board_ids) {
@@ -1217,9 +1782,12 @@ func (s *MondaySource) readBoardColumns(ctx context.Context, opts source.ReadOpt
 	`
 	config.Debug("[Monday] Reading board columns")
 
-	boardIDs, err := s.getAllBoardIDs(ctx, opts)
-	if err != nil {
-		return err
+	if len(boardIDs) == 0 {
+		ids, err := s.getAllBoardIDs(ctx, opts)
+		if err != nil {
+			return err
+		}
+		boardIDs = ids
 	}
 	if len(boardIDs) == 0 {
 		return nil
@@ -1302,7 +1870,7 @@ func (s *MondaySource) readBoardColumns(ctx context.Context, opts source.ReadOpt
 	return nil
 }
 
-func (s *MondaySource) readBoardViews(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *MondaySource) readBoardViews(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, boardIDs []string) error {
 	const query = `
 		query ($board_ids: [ID!]) {
 		boards(ids: $board_ids) {
@@ -1320,9 +1888,12 @@ func (s *MondaySource) readBoardViews(ctx context.Context, opts source.ReadOptio
 	`
 	config.Debug("[Monday] Reading board views")
 
-	boardIDs, err := s.getAllBoardIDs(ctx, opts)
-	if err != nil {
-		return err
+	if len(boardIDs) == 0 {
+		ids, err := s.getAllBoardIDs(ctx, opts)
+		if err != nil {
+			return err
+		}
+		boardIDs = ids
 	}
 	if len(boardIDs) == 0 {
 		return nil
@@ -1447,10 +2018,7 @@ collectLoop:
 }
 
 // readBoards reads the boards information with pagination and sends it as record batches
-func (s *MondaySource) readBoards(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	const query = `
-		query ($limit: Int!, $page: Int!) {
-		boards(limit: $limit, page: $page) {
+const boardFieldsFragment = `
 			id
 			name
 			description
@@ -1483,12 +2051,52 @@ func (s *MondaySource) readBoards(ctx context.Context, opts source.ReadOptions, 
 			}
 			tags {
 				id
-				
-			}
+			}`
+
+func (s *MondaySource) readBoards(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, boardIDs []string) error {
+	// Default: paginate all boards in the account.
+	if len(boardIDs) == 0 {
+		query := `
+		query ($limit: Int!, $page: Int!) {
+		boards(limit: $limit, page: $page) {` + boardFieldsFragment + `
 		}
 	}
 	`
-	return s.readPaginatedList(ctx, opts, results, query, "boards", boardsFields, normalizeDictionaries, "boards")
+		return s.readPaginatedList(ctx, opts, results, query, "boards", boardsFields, normalizeDictionaries, "boards")
+	}
+
+	// Scoped: only the requested boards.
+	config.Debug("[Monday] Reading %d scoped board(s)", len(boardIDs))
+	query := `
+		query ($board_ids: [ID!]) {
+		boards(ids: $board_ids) {` + boardFieldsFragment + `
+		}
+	}
+	`
+	data, err := s.executeGraphQL(ctx, query, map[string]interface{}{"board_ids": boardIDs})
+	if err != nil {
+		return fmt.Errorf("failed to execute scoped boards query: %w", err)
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return fmt.Errorf("failed to unmarshal scoped boards response: %w", err)
+	}
+	boards, ok := response["boards"].([]interface{})
+	if !ok || len(boards) == 0 {
+		return nil
+	}
+	batch := make([]map[string]interface{}, 0, len(boards))
+	for _, raw := range boards {
+		if boardMap, ok := raw.(map[string]interface{}); ok {
+			batch = append(batch, normalizeDictionaries(boardMap))
+		}
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, boardsFields, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to build scoped boards record: %w", err)
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
 }
 
 // readWorkspaces reads the workspaces information with pagination and sends it as record batches

--- a/pkg/source/monday/monday_integration_test.go
+++ b/pkg/source/monday/monday_integration_test.go
@@ -356,7 +356,9 @@ func TestMondayPipeline(t *testing.T) {
 				{Name: "updated_at", DataType: schema.TypeTimestampTZ},
 				{Name: "edited_at", DataType: schema.TypeTimestampTZ},
 				{Name: "creator_id", DataType: schema.TypeString},
+				{Name: "creator_name", DataType: schema.TypeString},
 				{Name: "item_id", DataType: schema.TypeString},
+				{Name: "item_name", DataType: schema.TypeString},
 				{Name: "assets", DataType: schema.TypeString},
 				{Name: "replies", DataType: schema.TypeString},
 				{Name: "likes", DataType: schema.TypeString},
@@ -496,6 +498,132 @@ func TestMondayPipeline(t *testing.T) {
 						"is_default_workspace": true,
 						"state":                "active",
 						"account_product_id":   "6121987",
+					},
+				},
+			},
+		},
+		// items: the new resource lands board rows with column_values as JSON.
+		// 2 + 1 + 3 + 3 items across the four boards.
+		{
+			SourceTable: "items",
+			DestTable:   "main.monday_items",
+			KeyColumn:   "id",
+			ExpectedSchema: []schema.Column{
+				{Name: "board_id", DataType: schema.TypeString},
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "name", DataType: schema.TypeString},
+				{Name: "state", DataType: schema.TypeString},
+				{Name: "created_at", DataType: schema.TypeTimestampTZ},
+				{Name: "updated_at", DataType: schema.TypeTimestampTZ},
+				{Name: "creator_id", DataType: schema.TypeString},
+				{Name: "group_id", DataType: schema.TypeString},
+				{Name: "group_title", DataType: schema.TypeString},
+				{Name: "column_values", DataType: schema.TypeJSON},
+			},
+			ExpectedRowCount: 9,
+		},
+		// items scoped to a single board -> only that board's items (items_count = 3).
+		{
+			SourceTable:      "items:5091839751",
+			DestTable:        "main.monday_items_initial",
+			KeyColumn:        "id",
+			ExpectedRowCount: 3,
+			ExpectedSchema: []schema.Column{
+				{Name: "board_id", DataType: schema.TypeString},
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "name", DataType: schema.TypeString},
+				{Name: "column_values", DataType: schema.TypeJSON},
+			},
+		},
+		// :linked returns the master board's own items plus any linked sub-boards
+		// (board name == master item title). No sub-board names match on this
+		// account, so it returns at least the master's own 3 items.
+		{
+			SourceTable:         "items:5091839751:linked",
+			DestTable:           "main.monday_items_linked",
+			KeyColumn:           "id",
+			MinExpectedRowCount: 3,
+			ExpectedSchema: []schema.Column{
+				{Name: "board_id", DataType: schema.TypeString},
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "column_values", DataType: schema.TypeJSON},
+			},
+		},
+		// board_columns scoped to a single board.
+		{
+			SourceTable:         "board_columns:5091839751",
+			DestTable:           "main.monday_board_columns_scoped",
+			KeyColumn:           "board_id || '~' || id",
+			MinExpectedRowCount: 3,
+			ExpectedSchema: []schema.Column{
+				{Name: "board_id", DataType: schema.TypeString},
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "title", DataType: schema.TypeString},
+				{Name: "type", DataType: schema.TypeString},
+			},
+			Rows: []testutil.ExpectedRow{
+				{ID: "5091839751~project_owner", Fields: map[string]any{"board_id": "5091839751", "title": "Owner", "type": "people"}},
+				{ID: "5091839751~project_status", Fields: map[string]any{"board_id": "5091839751", "title": "Status", "type": "status"}},
+				{ID: "5091839751~project_timeline", Fields: map[string]any{"board_id": "5091839751", "title": "Timeline", "type": "timeline"}},
+			},
+		},
+		// board_views scoped to a single board.
+		{
+			SourceTable:         "board_views:5091839751",
+			DestTable:           "main.monday_board_views_scoped",
+			KeyColumn:           "board_id || '~' || id",
+			MinExpectedRowCount: 1,
+			ExpectedSchema: []schema.Column{
+				{Name: "board_id", DataType: schema.TypeString},
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "name", DataType: schema.TypeString},
+				{Name: "type", DataType: schema.TypeString},
+			},
+		},
+		// boards scoped to a single board -> exactly that board.
+		{
+			SourceTable:      "boards:5091839751",
+			DestTable:        "main.monday_boards_scoped",
+			KeyColumn:        "id",
+			ExpectedRowCount: 1,
+			ExpectedSchema: []schema.Column{
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "name", DataType: schema.TypeString},
+				{Name: "items_count", DataType: schema.TypeInt64},
+			},
+			Rows: []testutil.ExpectedRow{
+				{
+					ID: "5091839751",
+					Fields: map[string]any{
+						"name":        "initial project",
+						"items_count": int64(3),
+					},
+				},
+			},
+		},
+		// updates scoped to a single board -> only updates on that board's items,
+		// enriched with item_name + creator_name. One update on the initial project board.
+		{
+			SourceTable:      "updates:5091839751",
+			DestTable:        "main.monday_updates_scoped",
+			KeyColumn:        "id",
+			ExpectedRowCount: 1,
+			ExpectedSchema: []schema.Column{
+				{Name: "id", DataType: schema.TypeString},
+				{Name: "body", DataType: schema.TypeString},
+				{Name: "creator_id", DataType: schema.TypeString},
+				{Name: "creator_name", DataType: schema.TypeString},
+				{Name: "item_id", DataType: schema.TypeString},
+				{Name: "item_name", DataType: schema.TypeString},
+			},
+			Rows: []testutil.ExpectedRow{
+				{
+					ID: "523528203",
+					Fields: map[string]any{
+						"body":         "Started working on initial task setup.",
+						"creator_id":   "99910119",
+						"creator_name": "Gong Test",
+						"item_id":      "2723610670",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Adds an `items` source to the Monday connector and makes the board-aware resources
consistently filterable by board. This is especially needed for `items` as it can produce many rows without a filter.

### New: `items`

Monday previously exposed board metadata, columns, views, updates, users, etc., but
there was no way to extract the actual **rows (items) of a board**. This adds an
`items` source that does exactly that, with each item's cell data as JSON:

- Columns: `board_id, id, name, state, created_at, updated_at, creator_id,
  group_id, group_title, column_values`.
- `column_values` is a JSON array of each cell's `{ id, title, text, type, value }`,
  so it can be pivoted into named columns downstream.
- Forms:
  - `items` — items across all boards in the account
  - `items:<board_id>[,<board_id>...]` — only the listed boards
  - `items:<board_id>:linked` — the board's own items **plus** the items of any
    boards whose name matches one of the board's item titles (a simple
    "master board → linked sub-boards" fan-out)

### Board scoping for `board_columns`, `board_views`, `boards`

These now accept an optional `:<board_id>[,<board_id>...]` suffix to scope to
specific boards (e.g. `board_columns:<id>`). With no suffix they behave exactly as
before (all boards). Previously `board_columns`/`board_views` always walked every
board in the account; scoping avoids that.

### `updates`: optional board scoping + names

- `updates:<board_id>[,<board_id>...]` scopes updates to the given boards' items.
  Monday's top-level `updates` query can't filter by board, so this walks
  `boards -> items_page -> updates`. Plain `updates` is unchanged (account-wide).
- Both paths now also fetch the creator and item names, exposed as new
  `creator_name` and `item_name` columns.

### Misc

- `api_token` is accepted as an alias for the `api_key` URI parameter. The
  documented Monday URI is `monday://?api_token=<token>` (see the supported-sources
  docs), and Bruin's Monday connection emits `api_token`, but the source currently
  only reads `api_key` — so a URI that follows the docs fails with
  "api_key ... is required". Accepting `api_token` as an alias keeps those configs
  working without a breaking change.

## Tests

Extended the Monday integration test (`pkg/source/monday`) with cases for `items`
(all / scoped / `:linked`), scoped `board_columns` / `board_views` / `boards`, and
scoped `updates`.

A few of the new expectations (exact row counts, and which board a given item/update
belongs to) were **derived from the fixtures already in the test file plus reasonable
inference**, not verified against the live test account. Please sanity-check those
counts/mappings when you run the suite against the shared Monday test account; they
may need small adjustments.

## Notes

- Built and tested locally: the new source forms were exercised against a live Monday
  workspace via the `ingestr` CLI (`items`, `items:<id>`, `items:<id>:linked`,
  `updates:<id>`, scoped `board_columns`/`board_views`/`boards`). The locally-built
  binary was also run end-to-end through Bruin via
  `bruin run --debug-ingestr-src <local checkout>` (loading `items` and
  `items:<id>:linked` into a warehouse), confirming it works as a Bruin ingestr asset.
  The integration test compiles and is `gofmt`-clean, but I did not run it here since it
  targets your shared test account.
- If you'd rather implement these features yourselves, please feel free to **close this
  PR and reimplement** — it's offered as a working starting point, not something you
  need to take as-is.
