### PR TITLE
Add pyarrow-hotfix to mitigate CVE-2023-47248 on older pyarrow

### DIFF
--- a/ingestr/_data.py
+++ b/ingestr/_data.py
@@ -671,6 +671,11 @@ def _require_pyarrow() -> Any:
             "Python data ingestion requires pyarrow. Install it with `pip install 'ingestr[sdk]'` "
             "or `pip install pyarrow`."
         ) from exc
+    try:
+        # Neutralizes CVE-2023-47248 on pyarrow <14.0.1; a no-op on patched versions.
+        import pyarrow_hotfix  # noqa: F401
+    except ImportError:
+        pass
     return pa
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Homepage = "https://github.com/bruin-data/ingestr"
 Issues = "https://github.com/bruin-data/ingestr/issues"
 
 [project.optional-dependencies]
-sdk = ["pyarrow>=10"]
+sdk = ["pyarrow>=10", "pyarrow-hotfix"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["ingestr"]

--- a/uv.lock
+++ b/uv.lock
@@ -18,10 +18,14 @@ sdk = [
     { name = "pyarrow", version = "17.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pyarrow", version = "24.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow-hotfix" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyarrow", marker = "extra == 'sdk'", specifier = ">=10" }]
+requires-dist = [
+    { name = "pyarrow", marker = "extra == 'sdk'", specifier = ">=10" },
+    { name = "pyarrow-hotfix", marker = "extra == 'sdk'" },
+]
 provides-extras = ["sdk"]
 
 [[package]]
@@ -301,4 +305,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pyarrow-hotfix"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/ed/c3e8677f7abf3981838c2af7b5ac03e3589b3ef94fcb31d575426abae904/pyarrow_hotfix-0.7.tar.gz", hash = "sha256:59399cd58bdd978b2e42816a4183a55c6472d4e33d183351b6069f11ed42661d", size = 9910, upload-time = "2025-04-25T10:17:06.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/c3/94ade4906a2f88bc935772f59c934013b4205e773bcb4239db114a6da136/pyarrow_hotfix-0.7-py3-none-any.whl", hash = "sha256:3236f3b5f1260f0e2ac070a55c1a7b339c4bb7267839bd2015e283234e758100", size = 7923, upload-time = "2025-04-25T10:17:05.224Z" },
 ]


### PR DESCRIPTION
Adds pyarrow-hotfix to the [sdk] extra and imports it in _require_pyarrow(). It neutralizes CVE-2023-47248 on pyarrow <14.0.1 (e.g. the 12.0.1 resolved for Python 3.7) and is a no-op on patched versions, so no minimum Python/pyarrow version is forced.