### PR TITLE
Fix strategy test truncate fixture

### DIFF
--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -213,7 +213,11 @@ func (d *fakeDestination) DropTable(ctx context.Context, table string) error {
 	return err
 }
 
-func (d *fakeDestination) TruncateTable(ctx context.Context, table string) error {
+type truncateCapableDestination struct {
+	*fakeDestination
+}
+
+func (d *truncateCapableDestination) TruncateTable(ctx context.Context, table string) error {
 	d.mu.Lock()
 	d.calls = append(d.calls, "TruncateTable")
 	d.truncateCalls = append(d.truncateCalls, table)

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {
 	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
 	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
 	src.primaryKeysUnique = true
 	src.readErr = errors.New("read failed")


### PR DESCRIPTION
Fixes the failing `make test` run by keeping the base strategy test fake from implementing optional truncate support.

Tests that need truncate support now opt into a dedicated wrapper.

Validated with `make format`, `make lint`, and `make test`.
