### PR TITLE
Add SharePoint source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -220,6 +220,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "S3", link: "/supported-sources/s3.md" },
               { text: "Salesforce", link: "/supported-sources/salesforce.md" },
               { text: "SFTP", link: "/supported-sources/sftp.md"},
+              { text: "SharePoint", link: "/supported-sources/sharepoint.md" },
               { text: "Shopify", link: "/supported-sources/shopify.md" },
               { text: "Slack", link: "/supported-sources/slack.md" },
               { text: "Smartsheet", link: "/supported-sources/smartsheets.md" },

--- a/docs/supported-sources/sharepoint.md
+++ b/docs/supported-sources/sharepoint.md
@@ -20,8 +20,13 @@ URI parameters:
 - `hostname`: SharePoint tenant hostname, e.g. `example.sharepoint.com`
 - `site`: server-relative site path, e.g. `sites/Example`
 - `library` (optional): document library (drive) name; defaults to the site's default **Documents** library. Set it to read from a secondary library on the same site.
+- `max_file_size` (optional): maximum bytes for any single downloaded file; the read fails if a file exceeds it. Defaults to `0` (unlimited).
+- `max_files` (optional): maximum number of files a glob may match before erroring, to guard against an over-broad recursive pattern. Defaults to `10000`; set `0` for unlimited.
 
 Authentication uses the OAuth2 **client-credentials** flow. The app registration needs application permission to read the site's files (e.g. `Sites.Read.All` or `Files.Read.All`), granted with admin consent.
+
+> [!TIP]
+> The `client_secret` travels in the URI, which can end up in shell history or process listings. Prefer supplying it from a secret store or environment variable rather than hard-coding it.
 
 To read files from a different site (a different document library), define a second connection pointing at that `site`.
 
@@ -39,7 +44,7 @@ The source table identifies a file (or a glob of files) within the site's defaul
 
 | Hint | Applies to | Meaning |
 |---|---|---|
-| `xlsx` / `csv` | all | format override (otherwise detected from the extension) |
+| `xlsx` / `csv` | all | format override (otherwise detected from the file extension) |
 | `sheet=<name>` | Excel | read a single sheet |
 | `sheets=<a>\|<b>\|<c>` | Excel | read and stack several sheets (separated by `\|`) |
 | `skip=<n>` | all | drop `n` rows before the header row |
@@ -51,6 +56,9 @@ The source table identifies a file (or a glob of files) within the site's defaul
 
 > [!NOTE]
 > Sheet names referenced in `sheet=`/`sheets=` cannot contain `|`, `,`, `=`, or `#`.
+
+> [!NOTE]
+> If a glob pattern has no file extension (e.g. `Reports/**`), each matched file's format is detected from its own extension, so one glob can span mixed `.xlsx` and `.csv` files. Add an `xlsx`/`csv` hint to force a single format for all matches.
 
 Examples:
 

--- a/docs/supported-sources/sharepoint.md
+++ b/docs/supported-sources/sharepoint.md
@@ -1,0 +1,124 @@
+# SharePoint
+
+[SharePoint Online](https://www.microsoft.com/microsoft-365/sharepoint/collaboration) is Microsoft's document management and collaboration platform. ingestr can read files (Excel and CSV) from a SharePoint document library through the [Microsoft Graph API](https://learn.microsoft.com/graph/overview).
+
+Each file (or glob of files) is landed as raw rows. Cell values are kept as text and a few extra columns are added to record each row's source file, sheet, and position.
+
+## URI format
+
+One connection corresponds to one SharePoint **site**:
+
+```
+sharepoint://?tenant_id=<id>&client_id=<id>&client_secret=<secret>&hostname=<host>&site=<site_path>
+```
+
+URI parameters:
+
+- `tenant_id`: Azure AD tenant ID of the app registration
+- `client_id`: app registration (service principal) client ID
+- `client_secret`: app registration client secret
+- `hostname`: SharePoint tenant hostname, e.g. `example.sharepoint.com`
+- `site`: server-relative site path, e.g. `sites/Example`
+- `library` (optional): document library (drive) name; defaults to the site's default **Documents** library. Set it to read from a secondary library on the same site.
+
+Authentication uses the OAuth2 **client-credentials** flow. The app registration needs application permission to read the site's files (e.g. `Sites.Read.All` or `Files.Read.All`), granted with admin consent.
+
+To read files from a different site (a different document library), define a second connection pointing at that `site`.
+
+## Source table format
+
+The source table identifies a file (or a glob of files) within the site's default document library, optionally followed by hints:
+
+```
+<path>#<format>,<key>=<value>,<key>=<value>
+```
+
+- `<path>` is the file path relative to the document library root. It may contain spaces and `&`, and may use glob wildcards: `*`, `**` (recursive), `?`, `[...]`, `{a,b}`.
+- The string is split on the **last** `#` only when the part after it parses as a valid hint list; otherwise the whole string is treated as the path. Use `%23` to embed a literal `#` in a path.
+- Hints are comma-separated. A bare token is a format override; everything else is `key=value`:
+
+| Hint | Applies to | Meaning |
+|---|---|---|
+| `xlsx` / `csv` | all | format override (otherwise detected from the extension) |
+| `sheet=<name>` | Excel | read a single sheet |
+| `sheets=<a>\|<b>\|<c>` | Excel | read and stack several sheets (separated by `\|`) |
+| `skip=<n>` | all | drop `n` rows before the header row |
+| `drop_empty` | all | skip rows whose data columns are all empty (off by default) |
+| `date_cols=<a>\|<b>` | Excel | column names whose Excel serial values are converted to ISO date strings (separated by `\|`) |
+| `raw` / `formatted` | Excel | raw values (default): unformatted numbers (dates as serial numbers unless listed in `date_cols`); or the cell's displayed/formatted text |
+| `encoding=<enc>` | CSV | input encoding, e.g. `utf-16le` |
+| `sep=<sep>` | CSV | field separator; `tab` (or `\t`) for tab-delimited |
+
+> [!NOTE]
+> Sheet names referenced in `sheet=`/`sheets=` cannot contain `|`, `,`, `=`, or `#`.
+
+Examples:
+
+```
+Reports/products.xlsx#xlsx,sheet=Sheet1
+Reports/parameters.xlsx#sheet=Forecast,skip=4
+Reports/regional data.xlsx#sheets=North|South|East|West
+Reports/monthly/*.xlsx#sheets=Jan|Feb|Mar
+Reports/export.csv#csv,encoding=utf-16le,sep=tab
+```
+
+## Added columns
+
+Every row is stamped with:
+
+| Column | Meaning |
+|---|---|
+| `_source_file` | the file path the row came from — distinguishes files in a glob |
+| `_sheet_name` | the Excel sheet tab the row came from (null for CSV) |
+| `_row_idx` | 0-based row position within the sheet/file, in read order (after `skip` and the header) |
+
+`(_sheet_name, _row_idx)` is unique within a file; add `_source_file` to make it unique across a glob. Use ingestr's `--columns` exclusion to drop any of these if you don't need them.
+
+> [!NOTE]
+> For Excel, a blank row inside the data range keeps its `_row_idx` slot (it lands as an all-empty row, or leaves a gap when `drop_empty` is set), so the original row ordering is preserved. For CSV, completely blank physical lines are skipped by the parser and do not occupy a `_row_idx` — only rows with at least one field (including all-empty rows like `,,`) are counted.
+
+## Reading the data
+
+Values are read as text. For Excel, `raw` (the default) keeps the underlying cell value (e.g. `1234.5`) rather than its display formatting (e.g. `1,234.50`); pass `formatted` to get the displayed text instead. Empty cells are emitted as empty strings, and merged cells keep their value in the top-left cell only.
+
+Excel stores dates as serial numbers. In `raw` mode (the default) a date cell therefore lands as its serial (e.g. `45306`) — readable date strings are opt-in via the `date_cols` hint, which names the columns to convert. Listed columns have their serial values turned into ISO strings by value: `2024-01-15` for a whole-number serial, `2024-01-15 13:30:00` when there is a fractional (time) part, and `13:30:00` for a fraction-only serial. Non-numeric cells in those columns (e.g. text dates) are left untouched. Columns not listed in `date_cols` keep their raw serials. In `formatted` mode the cell's own display format is used and `date_cols` has no effect.
+
+> [!NOTE]
+> `date_cols` names are matched **case-insensitively** against the landed column names (after blank/duplicate header normalization), and conversion is by value — it does not read cell number formats, which keeps reads fully streaming and low-memory on large workbooks.
+
+By default no rows are filtered — blank/spacer rows are landed as-is (matching the raw read). The `drop_empty` hint skips rows where every data column is empty; `_row_idx` retains each row's true position, so dropped rows leave gaps and the original row ordering is preserved.
+
+If no sheet is specified, the first sheet is read. A requested sheet (via `sheet=` or `sheets=`) that does not exist is an error that lists the available sheet names — sheet names are case-sensitive.
+
+## Combining sheets and files
+
+When several sheets (`sheets=`) or several files (a glob) are read into one table, columns are matched **by name** and unioned: new columns are appended in the order first seen, and rows from a sheet/file that lack a column get `NULL` there. Sheets/files do not need identical columns.
+
+## Examples
+
+Copy a single sheet into DuckDB:
+
+```sh
+ingestr ingest \
+  --source-uri 'sharepoint://?tenant_id=...&client_id=...&client_secret=...&hostname=<tenant>.sharepoint.com&site=sites/<name>' \
+  --source-table 'Reports/products.xlsx#sheet=Sheet1' \
+  --dest-uri duckdb:///sharepoint.duckdb \
+  --dest-table 'raw.products'
+```
+
+Stack every workbook in a folder, unioning three sheets each:
+
+```sh
+ingestr ingest \
+  --source-uri 'sharepoint://?tenant_id=...&client_id=...&client_secret=...&hostname=<tenant>.sharepoint.com&site=sites/<name>' \
+  --source-table 'Reports/monthly/*.xlsx#sheets=Jan|Feb|Mar' \
+  --dest-uri duckdb:///sharepoint.duckdb \
+  --dest-table 'raw.monthly'
+```
+
+## Write strategies
+
+The source honors `--incremental-strategy`, defaulting to `replace`. `append`, `merge`, and `delete+insert` are also selectable.
+
+> [!CAUTION]
+> SharePoint does not support incremental extraction — every run reads the entire file (or glob). With `append` this duplicates rows on each run by design; use `replace` (the default) unless you have a reason to accumulate.

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.42.0
 	github.com/trinodb/trino-go-client v0.333.0
 	github.com/urfave/cli/v3 v3.0.0-beta1
+	github.com/xuri/excelize/v2 v2.10.1
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.mongodb.org/mongo-driver v1.17.6
 	golang.org/x/crypto v0.50.0
@@ -255,15 +256,20 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/richardlehane/mscfb v1.0.6 // indirect
+	github.com/richardlehane/msoleps v1.0.6 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/tiendc/go-deepcopy v1.7.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/xuri/efp v0.0.1 // indirect
+	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	github.com/zeroshade/machine-id v0.0.0-20251223181436-930511047eef // indirect

--- a/go.sum
+++ b/go.sum
@@ -1344,6 +1344,10 @@ github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMu
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/richardlehane/mscfb v1.0.6 h1:eN3bvvZCp00bs7Zf52bxNwAx5lJDBK1tCuH19qq5aC8=
+github.com/richardlehane/mscfb v1.0.6/go.mod h1:pe0+IUIc0AHh0+teNzBlJCtSyZdFOGgV4ZK9bsoV+Jo=
+github.com/richardlehane/msoleps v1.0.6 h1:9BvkpjvD+iUBalUY4esMwv6uBkfOip/Lzvd93jvR9gg=
+github.com/richardlehane/msoleps v1.0.6/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -1425,6 +1429,8 @@ github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.42.0/go.mod h1:I
 github.com/testcontainers/testcontainers-go/modules/redpanda v0.42.0 h1:mcPLvf3rzvvwG46i4jcyOk7/KcapE/IKnBgwo27k68M=
 github.com/testcontainers/testcontainers-go/modules/redpanda v0.42.0/go.mod h1:Yq0WrUIIsMkJoZ2DadCJ1Zq4RFhjPPpSNYHpjRrGfDU=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tiendc/go-deepcopy v1.7.2 h1:Ut2yYR7W9tWjTQitganoIue4UGxZwCcJy3orjrrIj44=
+github.com/tiendc/go-deepcopy v1.7.2/go.mod h1:4bKjNC2r7boYOkD2IOuZpYjmlDdzjbpTRyCx+goBCJQ=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
@@ -1453,6 +1459,12 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xuri/efp v0.0.1 h1:fws5Rv3myXyYni8uwj2qKjVaRP30PdjeYe2Y6FDsCL8=
+github.com/xuri/efp v0.0.1/go.mod h1:ybY/Jr0T0GTCnYjKqmdwxyxn2BQf2RcQIIvex5QldPI=
+github.com/xuri/excelize/v2 v2.10.1 h1:V62UlqopMqha3kOpnlHy2CcRVw1V8E63jFoWUmMzxN0=
+github.com/xuri/excelize/v2 v2.10.1/go.mod h1:iG5tARpgaEeIhTqt3/fgXCGoBRt4hNXgCp3tfXKoOIc=
+github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 h1:+C0TIdyyYmzadGaL/HBLbf3WdLgC29pgyhTjAT/0nuE=
+github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
@@ -1576,6 +1588,8 @@ golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeap
 golang.org/x/image v0.0.0-20220302094943-723b81ca9867/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/image v0.5.0/go.mod h1:FVC7BI/5Ym8R25iw5OLsgshdUBbT1h5jZTpA+mvAdZ4=
 golang.org/x/image v0.6.0/go.mod h1:MXLdDR43H7cDJq5GEGXEVeeNhPgi+YYEQ2pC1byI1x0=
+golang.org/x/image v0.25.0 h1:Y6uW6rH1y5y/LK1J8BPWZtr6yZ7hrsy6hFrXjgsc2fQ=
+golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/source/sharepoint/csv.go
+++ b/pkg/source/sharepoint/csv.go
@@ -1,0 +1,116 @@
+package sharepoint
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+	csvsource "github.com/bruin-data/ingestr/pkg/source/csv"
+)
+
+// readCSV reads a CSV file from local disk and streams batches of raw string
+// rows stamped with metadata columns. _sheet_name is left null for this flat
+// format. Encoding (e.g. utf-16le) and separator (e.g. tab) honor the table
+// hints, reusing the csv source's encoding-aware decoder. The file is read in a
+// streaming fashion, never materializing the whole file in memory.
+func readCSV(ctx context.Context, filePath, localPath string, spec tableSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult, total *int) error {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", filePath, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	decoded, err := csvsource.Decode(file, spec.encoding)
+	if err != nil {
+		return fmt.Errorf("failed to set up CSV decoder for %q: %w", filePath, err)
+	}
+
+	reader := csv.NewReader(decoded)
+	reader.FieldsPerRecord = -1
+	if comma := resolveSep(spec.sep); comma != 0 {
+		reader.Comma = comma
+	}
+
+	// Drop leading rows before the header, if requested.
+	for i := 0; i < spec.skip; i++ {
+		if _, err := reader.Read(); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to skip CSV row in %q: %w", filePath, err)
+		}
+	}
+
+	rawHeaders, err := reader.Read()
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read CSV headers from %q: %w", filePath, err)
+	}
+	headers := dedupHeaders(rawHeaders)
+	cols := buildColumns(headers)
+
+	batchSize := resolveBatchSize(opts)
+	items := make([]map[string]interface{}, 0, batchSize)
+	rowIdx := 0 // true source position; advances per data row so drops leave gaps
+
+	for {
+		if rowIdx%1024 == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read CSV row in %q: %w", filePath, err)
+		}
+
+		if spec.dropEmpty && rowIsEmpty(record, len(headers)) {
+			rowIdx++
+			continue
+		}
+
+		// Empty sheet name leaves _sheet_name null for this flat format.
+		items = append(items, buildItem(filePath, "", rowIdx, headers, record))
+		rowIdx++
+
+		if len(items) >= batchSize {
+			stop, err := emitItems(ctx, results, items, cols, opts, total)
+			if err != nil {
+				return err
+			}
+			items = make([]map[string]interface{}, 0, batchSize)
+			if stop {
+				return nil
+			}
+		}
+	}
+
+	_, err = emitItems(ctx, results, items, cols, opts, total)
+	return err
+}
+
+// resolveSep maps a sep hint to a delimiter rune. "tab" (or "\t") becomes a
+// tab; a single character is used verbatim; anything else falls back to the
+// csv reader default (comma).
+func resolveSep(sep string) rune {
+	switch strings.ToLower(strings.TrimSpace(sep)) {
+	case "":
+		return 0
+	case "tab", `\t`:
+		return '\t'
+	}
+	runes := []rune(sep)
+	if len(runes) == 1 {
+		return runes[0]
+	}
+	return 0
+}

--- a/pkg/source/sharepoint/excel.go
+++ b/pkg/source/sharepoint/excel.go
@@ -4,12 +4,25 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/xuri/excelize/v2"
+)
+
+const (
+	// maxUnzipSize caps the total decompressed workbook size as a
+	// decompression-bomb guard. Generous so legitimate large workbooks are
+	// unaffected.
+	maxUnzipSize = 16 << 30 // 16 GiB
+	// unzipXMLInMemLimit is the per-part threshold above which excelize spills a
+	// decompressed worksheet / shared-string XML part to a temp file and streams
+	// it, rather than holding it in memory. This is what keeps peak memory low on
+	// large sheets; it is not a cap and never rejects a file.
+	unzipXMLInMemLimit = 16 << 20 // 16 MiB
 )
 
 // readExcel reads the requested sheets from a workbook on local disk and streams
@@ -33,7 +46,11 @@ import (
 //   - A requested sheet that does not exist is an error (listing the available
 //     sheets); when no sheet is specified, the first sheet is read.
 func readExcel(ctx context.Context, filePath, localPath string, spec tableSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult, total *int) error {
-	f, err := excelize.OpenFile(localPath)
+	f, err := excelize.OpenFile(localPath, excelize.Options{
+		UnzipSizeLimit:    maxUnzipSize,
+		UnzipXMLSizeLimit: unzipXMLInMemLimit,
+		TmpDir:            os.TempDir(),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to open Excel workbook %q: %w", filePath, err)
 	}

--- a/pkg/source/sharepoint/excel.go
+++ b/pkg/source/sharepoint/excel.go
@@ -1,0 +1,227 @@
+package sharepoint
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/xuri/excelize/v2"
+)
+
+// readExcel reads the requested sheets from a workbook on local disk and streams
+// batches of raw string rows stamped with metadata columns.
+//
+// Rows are read with excelize's streaming row iterator, so a sheet is never
+// fully materialized in memory and no per-cell style lookups are performed
+// (which would otherwise force excelize to build and cache the whole worksheet
+// model). Date conversion is opt-in via the date_cols hint: cells in those
+// columns whose raw value is an Excel serial number are converted to ISO strings
+// by value; everything else lands exactly as excelize returns it.
+//
+// Read behavior:
+//   - Cell values are read as strings. RawCellValue is enabled by default so
+//     numbers keep their underlying value (e.g. "1234.5") rather than the
+//     display format ("1,234.50"); the "formatted" hint switches to display text.
+//   - Empty cells and ragged trailing cells are emitted as "" (not null).
+//   - Merged cells carry their value in the top-left cell only; the remaining
+//     cells are blank.
+//   - skip rows are dropped before the header row is read.
+//   - A requested sheet that does not exist is an error (listing the available
+//     sheets); when no sheet is specified, the first sheet is read.
+func readExcel(ctx context.Context, filePath, localPath string, spec tableSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult, total *int) error {
+	f, err := excelize.OpenFile(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to open Excel workbook %q: %w", filePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sheets, err := resolveSheets(f, filePath, spec)
+	if err != nil {
+		return err
+	}
+
+	for _, sheet := range sheets {
+		stop, err := streamSheet(ctx, f, filePath, sheet, spec, opts, results, total)
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return nil
+}
+
+// resolveSheets validates the requested sheets and returns the list to read.
+func resolveSheets(f *excelize.File, filePath string, spec tableSpec) ([]string, error) {
+	sheetList := f.GetSheetList()
+	if len(sheetList) == 0 {
+		return nil, fmt.Errorf("workbook %q has no sheets", filePath)
+	}
+	if len(spec.sheets) == 0 {
+		return []string{sheetList[0]}, nil // no sheet specified -> first sheet
+	}
+	// Requested sheets must exist; fail explicitly rather than silently reading
+	// the wrong sheet (sheet names are case-sensitive).
+	present := make(map[string]bool, len(sheetList))
+	for _, s := range sheetList {
+		present[s] = true
+	}
+	for _, s := range spec.sheets {
+		if !present[s] {
+			return nil, fmt.Errorf("sheet %q not found in %q; available sheets: %v", s, filePath, sheetList)
+		}
+	}
+	return spec.sheets, nil
+}
+
+// streamSheet reads one sheet via excelize's streaming row iterator. It mirrors
+// excelize.GetRows row semantics (continually-blank trailing cells trimmed,
+// trailing empty rows dropped, internal blank rows preserved) so the landed row
+// set and _row_idx match a GetRows-based read, but without materializing the
+// whole sheet as a [][]string. Returns stop=true when the limit is reached.
+func streamSheet(ctx context.Context, f *excelize.File, filePath, sheet string, spec tableSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult, total *int) (bool, error) {
+	rows, err := f.Rows(sheet)
+	if err != nil {
+		return false, fmt.Errorf("failed to read sheet %q in %q: %w", sheet, filePath, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	xlOpts := excelize.Options{RawCellValue: !spec.formatted}
+	batchSize := resolveBatchSize(opts)
+	date1904 := workbookDate1904(f)
+	// Date columns are matched case-insensitively against the landed header names
+	// (destinations such as Snowflake upper-case identifiers, so users rarely know
+	// the original header casing).
+	dateCols := make(map[string]bool, len(spec.dateCols))
+	for _, c := range spec.dateCols {
+		dateCols[strings.ToLower(c)] = true
+	}
+
+	var (
+		headers   []string
+		cols      []schema.Column
+		dateIdx   []int // header indexes to convert from serial to ISO
+		headerSet bool
+		items     = make([]map[string]interface{}, 0, batchSize)
+		li        = -1 // logical row index (matches GetRows output index)
+	)
+
+	// process handles one logical row: skip rows before the header, capture the
+	// header, then emit data rows. Returns stop=true when the limit is reached.
+	process := func(cells []string) (bool, error) {
+		li++
+		switch {
+		case li < spec.skip:
+			return false, nil
+		case li == spec.skip:
+			headers = dedupHeaders(cells)
+			cols = buildColumns(headers)
+			for ci, h := range headers {
+				if dateCols[strings.ToLower(h)] {
+					dateIdx = append(dateIdx, ci)
+				}
+			}
+			headerSet = true
+			return false, nil
+		}
+
+		ri := li - spec.skip - 1
+		if spec.dropEmpty && rowIsEmpty(cells, len(headers)) {
+			return false, nil // _row_idx keeps its true position, leaving a gap
+		}
+
+		item := buildItem(filePath, sheet, ri, headers, cells)
+		for _, ci := range dateIdx {
+			if iso, ok := serialToISO(item[headers[ci]].(string), date1904); ok {
+				item[headers[ci]] = iso
+			}
+		}
+		items = append(items, item)
+
+		if len(items) >= batchSize {
+			stop, err := emitItems(ctx, results, items, cols, opts, total)
+			if err != nil {
+				return false, err
+			}
+			items = make([]map[string]interface{}, 0, batchSize)
+			return stop, nil
+		}
+		return false, nil
+	}
+
+	cur, pendingEmpty := 0, 0
+	for rows.Next() {
+		if cur%1024 == 0 {
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+		}
+		cur++
+
+		cells, err := rows.Columns(xlOpts)
+		if err != nil {
+			return false, fmt.Errorf("failed to read sheet %q in %q: %w", sheet, filePath, err)
+		}
+		if len(cells) == 0 {
+			pendingEmpty++ // a blank row: replayed only if a later row follows (trailing blanks are trimmed)
+			continue
+		}
+		for ; pendingEmpty > 0; pendingEmpty-- {
+			if stop, err := process(nil); err != nil || stop {
+				return stop, err
+			}
+		}
+		if stop, err := process(cells); err != nil || stop {
+			return stop, err
+		}
+	}
+	if err := rows.Error(); err != nil {
+		return false, fmt.Errorf("failed to read sheet %q in %q: %w", sheet, filePath, err)
+	}
+	if !headerSet {
+		return false, nil // not enough rows for a header after skipping
+	}
+	return emitItems(ctx, results, items, cols, opts, total)
+}
+
+// workbookDate1904 reports whether the workbook uses the 1904 date epoch, which
+// shifts serial-to-date conversion. Reading workbook props does not load any
+// worksheet model.
+func workbookDate1904(f *excelize.File) bool {
+	if props, err := f.GetWorkbookProps(); err == nil && props.Date1904 != nil {
+		return *props.Date1904
+	}
+	return false
+}
+
+// maxExcelSerial is the serial for 9999-12-31, the largest date Excel represents.
+const maxExcelSerial = 2958465
+
+// serialToISO converts an Excel date serial string to an ISO string. The kind is
+// inferred from the value: a fraction-only serial is a time, a whole number is a
+// date, otherwise a date-time. Values that are not a finite, in-range serial
+// (text, NaN/Inf, <=0, or beyond year 9999) return ok false so the caller leaves
+// them untouched.
+func serialToISO(raw string, date1904 bool) (string, bool) {
+	serial, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(serial) || math.IsInf(serial, 0) || serial <= 0 || serial > maxExcelSerial {
+		return "", false
+	}
+	t, err := excelize.ExcelDateToTime(serial, date1904)
+	if err != nil {
+		return "", false
+	}
+	switch {
+	case serial < 1:
+		return t.Format("15:04:05"), true
+	case serial == math.Trunc(serial):
+		return t.Format("2006-01-02"), true
+	default:
+		return t.Format("2006-01-02 15:04:05"), true
+	}
+}

--- a/pkg/source/sharepoint/graph.go
+++ b/pkg/source/sharepoint/graph.go
@@ -29,13 +29,15 @@ var graphScopes = []string{"https://graph.microsoft.com/.default"}
 // Authentication uses the OAuth2 client-credentials flow via azidentity, which
 // caches and refreshes the access token internally.
 type graphClient struct {
-	http     *httpclient.Client
-	cred     *azidentity.ClientSecretCredential
-	hostname string
-	sitePath string
-	library  string // requested document library name; empty => default drive
-	siteID   string
-	driveID  string // resolved when a non-default library is requested
+	http        *httpclient.Client
+	cred        *azidentity.ClientSecretCredential
+	hostname    string
+	sitePath    string
+	library     string // requested document library name; empty => default drive
+	siteID      string
+	driveID     string // resolved when a non-default library is requested
+	maxFileSize int64  // max bytes per downloaded file; 0 => unlimited
+	maxFiles    int    // max files a glob may match; 0 => unlimited
 }
 
 // driveItem is a single entry returned by the Graph children endpoint. The
@@ -67,11 +69,13 @@ func newGraphClient(cfg connConfig) (*graphClient, error) {
 	)
 
 	return &graphClient{
-		http:     client,
-		cred:     cred,
-		hostname: cfg.hostname,
-		sitePath: cfg.sitePath, // already trimmed in parseURI
-		library:  cfg.library,
+		http:        client,
+		cred:        cred,
+		hostname:    cfg.hostname,
+		sitePath:    cfg.sitePath, // already trimmed in parseURI
+		library:     cfg.library,
+		maxFileSize: cfg.maxFileSize,
+		maxFiles:    cfg.maxFiles,
 	}, nil
 }
 
@@ -241,12 +245,22 @@ func (g *graphClient) downloadToFile(ctx context.Context, filePath, destPath str
 	if err != nil {
 		return fmt.Errorf("failed to create local file for %q: %w", filePath, err)
 	}
-	n, copyErr := io.Copy(out, resp.Body)
+
+	// Cap the download so a huge (or malicious) file can't exhaust local disk:
+	// read at most maxFileSize+1 bytes and treat overflow as an error.
+	var body io.Reader = resp.Body
+	if g.maxFileSize > 0 {
+		body = io.LimitReader(resp.Body, g.maxFileSize+1)
+	}
+	n, copyErr := io.Copy(out, body)
 	if cerr := out.Close(); copyErr == nil {
 		copyErr = cerr
 	}
 	if copyErr != nil {
 		return fmt.Errorf("failed to write %q to disk: %w", filePath, copyErr)
+	}
+	if g.maxFileSize > 0 && n > g.maxFileSize {
+		return fmt.Errorf("file %q exceeds max_file_size of %d bytes", filePath, g.maxFileSize)
 	}
 	config.Debug("[SHAREPOINT] downloaded %d bytes from %s", n, filePath)
 	return nil
@@ -265,10 +279,14 @@ func (g *graphClient) listMatching(ctx context.Context, pattern string) ([]strin
 	recursive := strings.Contains(pattern, "**")
 
 	var matches []string
-	err := g.walk(ctx, prefix, recursive, func(p string) {
+	err := g.walk(ctx, prefix, recursive, func(p string) error {
 		if ok, _ := doublestar.Match(pattern, p); ok {
 			matches = append(matches, p)
+			if g.maxFiles > 0 && len(matches) > g.maxFiles {
+				return fmt.Errorf("glob %q matched more than max_files=%d files; narrow the pattern or raise max_files", pattern, g.maxFiles)
+			}
 		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -278,8 +296,9 @@ func (g *graphClient) listMatching(ctx context.Context, pattern string) ([]strin
 }
 
 // walk lists the files under folder, invoking emit for each file. When
-// recursive is true it descends into subfolders.
-func (g *graphClient) walk(ctx context.Context, folder string, recursive bool, emit func(string)) error {
+// recursive is true it descends into subfolders. emit may return an error to
+// stop the walk early (e.g. when a match cap is hit).
+func (g *graphClient) walk(ctx context.Context, folder string, recursive bool, emit func(string) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -300,7 +319,9 @@ func (g *graphClient) walk(ctx context.Context, folder string, recursive bool, e
 				}
 			}
 		case item.isFile():
-			emit(full)
+			if err := emit(full); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/source/sharepoint/graph.go
+++ b/pkg/source/sharepoint/graph.go
@@ -1,0 +1,366 @@
+package sharepoint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/bruin-data/ingestr/internal/config"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+)
+
+const graphBase = "https://graph.microsoft.com/v1.0"
+
+// graphScopes is the client-credentials scope for the Microsoft Graph API.
+// The ".default" scope grants the application permissions configured on the
+// Azure AD app registration.
+var graphScopes = []string{"https://graph.microsoft.com/.default"}
+
+// graphClient talks to the Microsoft Graph API for a single SharePoint site.
+// Authentication uses the OAuth2 client-credentials flow via azidentity, which
+// caches and refreshes the access token internally.
+type graphClient struct {
+	http     *httpclient.Client
+	cred     *azidentity.ClientSecretCredential
+	hostname string
+	sitePath string
+	library  string // requested document library name; empty => default drive
+	siteID   string
+	driveID  string // resolved when a non-default library is requested
+}
+
+// driveItem is a single entry returned by the Graph children endpoint. The
+// presence of the File / Folder facet distinguishes files from subfolders.
+type driveItem struct {
+	Name   string          `json:"name"`
+	File   json.RawMessage `json:"file"`
+	Folder json.RawMessage `json:"folder"`
+}
+
+func (d driveItem) isFile() bool   { return len(d.File) > 0 }
+func (d driveItem) isFolder() bool { return len(d.Folder) > 0 }
+
+type childrenResponse struct {
+	Value    []driveItem `json:"value"`
+	NextLink string      `json:"@odata.nextLink"`
+}
+
+func newGraphClient(cfg connConfig) (*graphClient, error) {
+	cred, err := azidentity.NewClientSecretCredential(cfg.tenantID, cfg.clientID, cfg.clientSecret, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SharePoint client credential: %w", err)
+	}
+
+	client := httpclient.New(
+		httpclient.WithTimeout(120*time.Second),
+		httpclient.WithRetry(5, 2*time.Second, 30*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+	)
+
+	return &graphClient{
+		http:     client,
+		cred:     cred,
+		hostname: cfg.hostname,
+		sitePath: cfg.sitePath, // already trimmed in parseURI
+		library:  cfg.library,
+	}, nil
+}
+
+func (g *graphClient) close() error {
+	if g.http != nil {
+		return g.http.Close()
+	}
+	return nil
+}
+
+// connect resolves the site id from the configured hostname + site path.
+func (g *graphClient) connect(ctx context.Context) error {
+	endpoint := fmt.Sprintf("%s/sites/%s:/%s", graphBase, g.hostname, encodePath(g.sitePath))
+	var site struct {
+		ID string `json:"id"`
+	}
+	if err := g.getJSON(ctx, endpoint, &site); err != nil {
+		return fmt.Errorf("failed to resolve SharePoint site %q on %q: %w", g.sitePath, g.hostname, err)
+	}
+	if site.ID == "" {
+		return fmt.Errorf("SharePoint site %q on %q resolved to an empty id", g.sitePath, g.hostname)
+	}
+	g.siteID = site.ID
+	config.Debug("[SHAREPOINT] resolved site id: %s", g.siteID)
+
+	// Resolve a non-default document library to its drive id. An empty or
+	// "Documents" library uses the site's default drive.
+	if g.library != "" && !strings.EqualFold(g.library, "Documents") {
+		if err := g.resolveDrive(ctx); err != nil {
+			return err
+		}
+		config.Debug("[SHAREPOINT] resolved library %q to drive %s", g.library, g.driveID)
+	}
+	return nil
+}
+
+type driveInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// resolveDrive finds the drive id for the requested document library by name.
+func (g *graphClient) resolveDrive(ctx context.Context) error {
+	endpoint := fmt.Sprintf("%s/sites/%s/drives?$select=id,name", graphBase, g.siteID)
+	var available []string
+	for endpoint != "" {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var page struct {
+			Value    []driveInfo `json:"value"`
+			NextLink string      `json:"@odata.nextLink"`
+		}
+		if err := g.getJSON(ctx, endpoint, &page); err != nil {
+			return fmt.Errorf("failed to list document libraries on site %q: %w", g.sitePath, err)
+		}
+		for _, d := range page.Value {
+			if strings.EqualFold(d.Name, g.library) {
+				g.driveID = d.ID
+				return nil
+			}
+			available = append(available, d.Name)
+		}
+		endpoint = page.NextLink
+	}
+	return fmt.Errorf("document library %q not found on site %q; available libraries: %v", g.library, g.sitePath, available)
+}
+
+// drivePath returns the Graph API base for the active drive (the resolved
+// library drive, or the site's default drive).
+func (g *graphClient) drivePath() string {
+	if g.driveID != "" {
+		return fmt.Sprintf("%s/drives/%s", graphBase, g.driveID)
+	}
+	return fmt.Sprintf("%s/sites/%s/drive", graphBase, g.siteID)
+}
+
+func (g *graphClient) token(ctx context.Context) (string, error) {
+	tok, err := g.cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: graphScopes})
+	if err != nil {
+		return "", fmt.Errorf("failed to acquire Microsoft Graph token: %w", err)
+	}
+	return tok.Token, nil
+}
+
+func (g *graphClient) getJSON(ctx context.Context, endpoint string, out interface{}) error {
+	tok, err := g.token(ctx)
+	if err != nil {
+		return err
+	}
+	resp, err := g.http.R(ctx).SetHeader("Authorization", "Bearer "+tok).Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("graph request to %s failed: %w", endpoint, err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("graph request to %s failed: %s", endpoint, graphErrorMessage(resp.StatusCode(), resp.Body()))
+	}
+	if err := json.Unmarshal(resp.Body(), out); err != nil {
+		return fmt.Errorf("failed to parse graph response from %s: %w", endpoint, err)
+	}
+	return nil
+}
+
+// graphErrorMessage turns a Graph error response into a concise, actionable
+// message. Graph returns {"error":{"code","message"}}; when present those are
+// surfaced (with hints for the common auth/path mistakes) instead of dumping the
+// raw response body.
+func graphErrorMessage(status int, body []byte) string {
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &env) == nil && env.Error.Message != "" {
+		msg := fmt.Sprintf("status %d (%s): %s", status, env.Error.Code, env.Error.Message)
+		switch status {
+		case 403:
+			msg += " — the app registration may lack the required application permission (Sites.Read.All or Files.Read.All) with admin consent"
+		case 404:
+			msg += " — check the hostname, site path, library, and file path"
+		}
+		return msg
+	}
+	return fmt.Sprintf("status %d: %s", status, truncate(string(body), 512))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// downloadToFile streams a file at a drive-root-relative path to destPath on
+// local disk. Streaming (rather than buffering the whole file in memory) keeps
+// peak memory low for large workbooks; the response body is copied in chunks.
+// On error destPath may be left partially written; the caller owns its removal.
+//
+// This goes through the raw resty client rather than the httpclient wrapper
+// because it needs SetDoNotParseResponse to stream the body; it still inherits
+// the client's retry/backoff middleware.
+func (g *graphClient) downloadToFile(ctx context.Context, filePath, destPath string) error {
+	tok, err := g.token(ctx)
+	if err != nil {
+		return err
+	}
+	endpoint := fmt.Sprintf("%s/root:/%s:/content", g.drivePath(), encodePath(filePath))
+	config.Debug("[SHAREPOINT] downloading %s", filePath)
+
+	resp, err := g.http.Resty().R().
+		SetContext(ctx).
+		SetHeader("Authorization", "Bearer "+tok).
+		SetDoNotParseResponse(true).
+		Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to download %q: %w", filePath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !resp.IsSuccess() {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		return fmt.Errorf("failed to download %q: %s", filePath, graphErrorMessage(resp.StatusCode(), body))
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("failed to create local file for %q: %w", filePath, err)
+	}
+	n, copyErr := io.Copy(out, resp.Body)
+	if cerr := out.Close(); copyErr == nil {
+		copyErr = cerr
+	}
+	if copyErr != nil {
+		return fmt.Errorf("failed to write %q to disk: %w", filePath, copyErr)
+	}
+	config.Debug("[SHAREPOINT] downloaded %d bytes from %s", n, filePath)
+	return nil
+}
+
+// listMatching returns drive-root-relative paths of files matching the pattern.
+// A pattern with no glob metacharacters is treated as a literal single file and
+// returned as-is (the download will surface a clear error if it is missing).
+func (g *graphClient) listMatching(ctx context.Context, pattern string) ([]string, error) {
+	pattern = strings.TrimPrefix(strings.TrimSpace(pattern), "/")
+	if !hasGlobMeta(pattern) {
+		return []string{pattern}, nil
+	}
+
+	prefix := strings.Trim(extractPrefix(pattern), "/")
+	recursive := strings.Contains(pattern, "**")
+
+	var matches []string
+	err := g.walk(ctx, prefix, recursive, func(p string) {
+		if ok, _ := doublestar.Match(pattern, p); ok {
+			matches = append(matches, p)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// walk lists the files under folder, invoking emit for each file. When
+// recursive is true it descends into subfolders.
+func (g *graphClient) walk(ctx context.Context, folder string, recursive bool, emit func(string)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	items, err := g.listChildren(ctx, folder)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		full := item.Name
+		if folder != "" {
+			full = folder + "/" + item.Name
+		}
+		switch {
+		case item.isFolder():
+			if recursive {
+				if err := g.walk(ctx, full, recursive, emit); err != nil {
+					return err
+				}
+			}
+		case item.isFile():
+			emit(full)
+		}
+	}
+	return nil
+}
+
+func (g *graphClient) listChildren(ctx context.Context, folder string) ([]driveItem, error) {
+	folder = strings.Trim(folder, "/")
+	var endpoint string
+	if folder == "" {
+		endpoint = fmt.Sprintf("%s/root/children", g.drivePath())
+	} else {
+		endpoint = fmt.Sprintf("%s/root:/%s:/children", g.drivePath(), encodePath(folder))
+	}
+
+	var items []driveItem
+	for endpoint != "" {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		var page childrenResponse
+		if err := g.getJSON(ctx, endpoint, &page); err != nil {
+			return nil, fmt.Errorf("failed to list folder %q: %w", folder, err)
+		}
+		items = append(items, page.Value...)
+		endpoint = page.NextLink
+	}
+	return items, nil
+}
+
+// encodePath percent-encodes each path segment while preserving the slash
+// separators required by the Graph driveItem-by-path syntax.
+func encodePath(p string) string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return ""
+	}
+	parts := strings.Split(p, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func hasGlobMeta(s string) bool {
+	return strings.ContainsAny(s, "*?[{")
+}
+
+// extractPrefix returns the literal directory prefix of a glob pattern (the
+// portion up to and including the last slash before the first metacharacter).
+func extractPrefix(pattern string) string {
+	idx := strings.IndexAny(pattern, "*?[{")
+	if idx == -1 {
+		return pattern
+	}
+	lastSlash := strings.LastIndex(pattern[:idx], "/")
+	if lastSlash == -1 {
+		return ""
+	}
+	return pattern[:lastSlash+1]
+}

--- a/pkg/source/sharepoint/register.go
+++ b/pkg/source/sharepoint/register.go
@@ -1,0 +1,10 @@
+package sharepoint
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"sharepoint"},
+		func() interface{} { return NewSharePointSource() },
+	)
+}

--- a/pkg/source/sharepoint/rows.go
+++ b/pkg/source/sharepoint/rows.go
@@ -67,27 +67,28 @@ func buildItem(filePath, sheet string, rowIdx int, headers, cells []string) map[
 }
 
 // dedupHeaders normalizes a raw header row: blank cells become column_N and
-// duplicates get a _2/_3 suffix. The seen map is pre-seeded with the
-// metadata column names so a literal header colliding with one is renamed
-// rather than overwriting the metadata value.
+// duplicates get a _2/_3 suffix. The seen set is pre-seeded with the metadata
+// column names so a literal header colliding with one is renamed rather than
+// overwriting the metadata value. A generated suffix that itself collides with
+// an existing name keeps incrementing until it is unique, so no two output
+// names ever match (which would otherwise drop a column in buildItem's map).
 func dedupHeaders(raw []string) []string {
-	seen := map[string]int{
-		colSourceFile: 1,
-		colSheetName:  1,
-		colRowIdx:     1,
+	seen := map[string]bool{
+		colSourceFile: true,
+		colSheetName:  true,
+		colRowIdx:     true,
 	}
 	headers := make([]string, len(raw))
 	for i, h := range raw {
-		name := strings.TrimSpace(h)
-		if name == "" {
-			name = fmt.Sprintf("column_%d", i)
+		base := strings.TrimSpace(h)
+		if base == "" {
+			base = fmt.Sprintf("column_%d", i)
 		}
-		if count, exists := seen[name]; exists {
-			seen[name] = count + 1
-			name = fmt.Sprintf("%s_%d", name, count+1)
-		} else {
-			seen[name] = 1
+		name := base
+		for n := 2; seen[name]; n++ {
+			name = fmt.Sprintf("%s_%d", base, n)
 		}
+		seen[name] = true
 		headers[i] = name
 	}
 	return headers

--- a/pkg/source/sharepoint/rows.go
+++ b/pkg/source/sharepoint/rows.go
@@ -1,0 +1,138 @@
+package sharepoint
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const defaultBatchSize = 10000
+
+// send delivers a result over the results channel, aborting if the context is
+// cancelled so the producer goroutine never blocks forever on a full channel
+// when the consumer has stopped draining.
+func send(ctx context.Context, results chan<- source.RecordBatchResult, r source.RecordBatchResult) error {
+	select {
+	case results <- r:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// rowIsEmpty reports whether every cell up to width (the header column count) is
+// empty or whitespace-only. Cells beyond width map to no column and are ignored.
+func rowIsEmpty(cells []string, width int) bool {
+	limit := width
+	if len(cells) < limit {
+		limit = len(cells)
+	}
+	for i := 0; i < limit; i++ {
+		if strings.TrimSpace(cells[i]) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveBatchSize(opts source.ReadOptions) int {
+	if opts.PageSize > 0 {
+		return opts.PageSize
+	}
+	return defaultBatchSize
+}
+
+// buildItem stamps the metadata columns and fills header values from cells,
+// padding short rows with "". An empty sheet leaves _sheet_name unset (null),
+// as the flat CSV format requires.
+func buildItem(filePath, sheet string, rowIdx int, headers, cells []string) map[string]interface{} {
+	item := make(map[string]interface{}, len(headers)+3)
+	item[colSourceFile] = filePath
+	if sheet != "" {
+		item[colSheetName] = sheet
+	}
+	item[colRowIdx] = rowIdx
+	for ci, h := range headers {
+		val := ""
+		if ci < len(cells) {
+			val = cells[ci]
+		}
+		item[h] = val
+	}
+	return item
+}
+
+// dedupHeaders normalizes a raw header row: blank cells become column_N and
+// duplicates get a _2/_3 suffix. The seen map is pre-seeded with the
+// metadata column names so a literal header colliding with one is renamed
+// rather than overwriting the metadata value.
+func dedupHeaders(raw []string) []string {
+	seen := map[string]int{
+		colSourceFile: 1,
+		colSheetName:  1,
+		colRowIdx:     1,
+	}
+	headers := make([]string, len(raw))
+	for i, h := range raw {
+		name := strings.TrimSpace(h)
+		if name == "" {
+			name = fmt.Sprintf("column_%d", i)
+		}
+		if count, exists := seen[name]; exists {
+			seen[name] = count + 1
+			name = fmt.Sprintf("%s_%d", name, count+1)
+		} else {
+			seen[name] = 1
+		}
+		headers[i] = name
+	}
+	return headers
+}
+
+// buildColumns produces an explicit all-VARCHAR column schema (with an int64
+// _row_idx) so the landed data stays raw strings instead of being re-typed by
+// schema inference.
+func buildColumns(headers []string) []schema.Column {
+	cols := make([]schema.Column, 0, len(headers)+3)
+	cols = append(
+		cols,
+		schema.Column{Name: colSourceFile, DataType: schema.TypeString, Nullable: false},
+		schema.Column{Name: colSheetName, DataType: schema.TypeString, Nullable: true},
+		schema.Column{Name: colRowIdx, DataType: schema.TypeInt64, Nullable: false},
+	)
+	for _, h := range headers {
+		cols = append(cols, schema.Column{Name: h, DataType: schema.TypeString, Nullable: true})
+	}
+	return cols
+}
+
+// emitItems converts items to an Arrow batch with the given column schema and
+// sends it over the results channel, honoring opts.Limit. It updates *total and returns true
+// when the limit has been reached and reading should stop.
+func emitItems(ctx context.Context, results chan<- source.RecordBatchResult, items []map[string]interface{}, cols []schema.Column, opts source.ReadOptions, total *int) (bool, error) {
+	if opts.Limit > 0 && *total >= opts.Limit {
+		return true, nil
+	}
+	if opts.Limit > 0 && *total+len(items) > opts.Limit {
+		items = items[:opts.Limit-*total]
+	}
+	if len(items) == 0 {
+		return opts.Limit > 0 && *total >= opts.Limit, nil
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cols, opts.ExcludeColumns)
+	if err != nil {
+		return false, fmt.Errorf("failed to convert rows to Arrow: %w", err)
+	}
+	if err := send(ctx, results, source.RecordBatchResult{Batch: record}); err != nil {
+		record.Release() // not delivered to the consumer; free its buffers
+		return false, err
+	}
+	*total += len(items)
+
+	return opts.Limit > 0 && *total >= opts.Limit, nil
+}

--- a/pkg/source/sharepoint/sharepoint.go
+++ b/pkg/source/sharepoint/sharepoint.go
@@ -35,6 +35,10 @@ const (
 	formatCSV     fileFormat = "csv"
 )
 
+// defaultMaxFiles bounds how many files a glob may match before erroring, to
+// guard against an over-broad recursive pattern enumerating a whole library.
+const defaultMaxFiles = 10000
+
 // connConfig holds the connection parameters parsed from the source URI.
 type connConfig struct {
 	tenantID     string
@@ -43,6 +47,8 @@ type connConfig struct {
 	hostname     string
 	sitePath     string
 	library      string // optional document library name; empty => default ("Documents")
+	maxFileSize  int64  // optional max bytes per downloaded file; 0 => unlimited
+	maxFiles     int    // optional max files a glob may match; 0 => unlimited
 }
 
 // tableSpec is the parsed form of a source-table string.
@@ -181,13 +187,21 @@ func (s *SharePointSource) readFile(ctx context.Context, path string, spec table
 		return err
 	}
 
-	switch spec.format {
+	// spec.format is set for a literal path or a glob with an extension; for an
+	// extensionless glob it is detected per matched file here.
+	format := spec.format
+	if format == formatUnknown {
+		format = detectFormat(path)
+	}
+	switch format {
 	case formatXLSX:
 		return readExcel(ctx, path, localPath, spec, opts, results, total)
 	case formatCSV:
 		return readCSV(ctx, path, localPath, spec, opts, results, total)
+	case formatXLS:
+		return fmt.Errorf("legacy .xls (BIFF) files are not supported for %q; re-save the file as .xlsx", path)
 	default:
-		return fmt.Errorf("unsupported format %q for %q", spec.format, path)
+		return fmt.Errorf("could not determine file format for %q; add a format hint such as #xlsx or #csv", path)
 	}
 }
 
@@ -209,6 +223,22 @@ func parseURI(uri string) (connConfig, error) {
 		hostname:     q.Get("hostname"),
 		sitePath:     strings.Trim(q.Get("site"), "/"),
 		library:      strings.TrimSpace(q.Get("library")),
+		maxFiles:     defaultMaxFiles,
+	}
+
+	if v := strings.TrimSpace(q.Get("max_file_size")); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || n < 0 {
+			return connConfig{}, fmt.Errorf("invalid max_file_size %q: must be a non-negative integer (bytes)", v)
+		}
+		cfg.maxFileSize = n
+	}
+	if v := strings.TrimSpace(q.Get("max_files")); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return connConfig{}, fmt.Errorf("invalid max_files %q: must be a non-negative integer (0 = unlimited)", v)
+		}
+		cfg.maxFiles = n
 	}
 
 	missing := make([]string, 0, 5)
@@ -266,7 +296,11 @@ func parseTableSpec(name string) (tableSpec, error) {
 	if spec.format == formatUnknown {
 		spec.format = detectFormat(path)
 	}
-	if spec.format == formatUnknown {
+	// A glob whose pattern has no usable extension (e.g. "Reports/**") leaves the
+	// format unknown here; detection is deferred to each matched file at read time
+	// (which also lets one glob span mixed file types). A single literal path must
+	// resolve to a format now.
+	if spec.format == formatUnknown && !hasGlobMeta(path) {
 		return tableSpec{}, fmt.Errorf("could not determine file format for %q; add a format hint such as #xlsx or #csv", path)
 	}
 	if spec.format == formatXLS {

--- a/pkg/source/sharepoint/sharepoint.go
+++ b/pkg/source/sharepoint/sharepoint.go
@@ -1,0 +1,393 @@
+// Package sharepoint implements an ingestr source that reads files (xlsx, csv)
+// from a SharePoint Online document library via the Microsoft Graph
+// API. It supports globbing, multi-sheet Excel reads, and lands raw all-VARCHAR
+// rows alongside metadata columns (_source_file, _sheet_name, _row_idx) that
+// record each row's source file, sheet, and read order.
+package sharepoint
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	gopath "path"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// Metadata columns emitted on every row.
+const (
+	colSourceFile = "_source_file" // file path within the document library
+	colSheetName  = "_sheet_name"  // Excel sheet tab name (null for csv)
+	colRowIdx     = "_row_idx"     // 0-based row position in read order, post-skip/header
+)
+
+type fileFormat string
+
+const (
+	formatUnknown fileFormat = ""
+	formatXLSX    fileFormat = "xlsx"
+	formatXLS     fileFormat = "xls"
+	formatCSV     fileFormat = "csv"
+)
+
+// connConfig holds the connection parameters parsed from the source URI.
+type connConfig struct {
+	tenantID     string
+	clientID     string
+	clientSecret string
+	hostname     string
+	sitePath     string
+	library      string // optional document library name; empty => default ("Documents")
+}
+
+// tableSpec is the parsed form of a source-table string.
+type tableSpec struct {
+	path      string
+	format    fileFormat
+	sheets    []string // empty => first-sheet fallback (Excel)
+	skip      int
+	encoding  string
+	sep       string
+	formatted bool     // Excel: use formatted cell text instead of raw values
+	dropEmpty bool     // skip rows whose data columns are all empty
+	dateCols  []string // Excel: column names whose serial values are converted to ISO dates
+}
+
+type SharePointSource struct {
+	graph *graphClient
+}
+
+func NewSharePointSource() *SharePointSource {
+	return &SharePointSource{}
+}
+
+func (s *SharePointSource) Schemes() []string {
+	return []string{"sharepoint"}
+}
+
+func (s *SharePointSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *SharePointSource) Connect(ctx context.Context, uri string) error {
+	cfg, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	g, err := newGraphClient(cfg)
+	if err != nil {
+		return err
+	}
+	if err := g.connect(ctx); err != nil {
+		return err
+	}
+
+	s.graph = g
+	config.Debug("[SHAREPOINT] connected to site %q on %q", cfg.sitePath, cfg.hostname)
+	return nil
+}
+
+func (s *SharePointSource) Close(ctx context.Context) error {
+	if s.graph != nil {
+		return s.graph.close()
+	}
+	return nil
+}
+
+func (s *SharePointSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	spec, err := parseTableSpec(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Honor the user-requested strategy; default to replace. Unlike Google
+	// Sheets, this source does not hard-code replace, so append / merge /
+	// delete+insert are all selectable. append re-reads everything each run and
+	// duplicates by design — there is no incremental filtering.
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           req.Name,
+		TablePrimaryKeys:    req.PrimaryKeys,
+		TableIncrementalKey: req.IncrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("sharepoint source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, spec, opts)
+		},
+	}, nil
+}
+
+func (s *SharePointSource) read(ctx context.Context, spec tableSpec, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		paths, err := s.graph.listMatching(ctx, spec.path)
+		if err != nil {
+			_ = send(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("failed to list files for %q: %w", spec.path, err)})
+			return
+		}
+		if len(paths) == 0 {
+			_ = send(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("no files found matching %q", spec.path)})
+			return
+		}
+
+		total := 0
+		for _, path := range paths {
+			if ctx.Err() != nil {
+				return
+			}
+
+			if err := s.readFile(ctx, path, spec, opts, results, &total); err != nil {
+				_ = send(ctx, results, source.RecordBatchResult{Err: err})
+				return
+			}
+
+			if opts.Limit > 0 && total >= opts.Limit {
+				break
+			}
+		}
+	}()
+
+	return results, nil
+}
+
+// readFile downloads one file to a local temp file and dispatches it to the
+// format-specific reader. The temp file is always removed when done.
+func (s *SharePointSource) readFile(ctx context.Context, path string, spec tableSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult, total *int) error {
+	tmp, err := os.CreateTemp("", "ingestr-sharepoint-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for %q: %w", path, err)
+	}
+	localPath := tmp.Name()
+	_ = tmp.Close() // downloadToFile re-creates it; we only needed a unique path
+	defer func() { _ = os.Remove(localPath) }()
+
+	if err := s.graph.downloadToFile(ctx, path, localPath); err != nil {
+		return err
+	}
+
+	switch spec.format {
+	case formatXLSX:
+		return readExcel(ctx, path, localPath, spec, opts, results, total)
+	case formatCSV:
+		return readCSV(ctx, path, localPath, spec, opts, results, total)
+	default:
+		return fmt.Errorf("unsupported format %q for %q", spec.format, path)
+	}
+}
+
+func parseURI(uri string) (connConfig, error) {
+	if !strings.HasPrefix(uri, "sharepoint://") {
+		return connConfig{}, fmt.Errorf("invalid sharepoint URI: must start with sharepoint://")
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return connConfig{}, fmt.Errorf("failed to parse sharepoint URI: %w", err)
+	}
+
+	q := u.Query()
+	cfg := connConfig{
+		tenantID:     q.Get("tenant_id"),
+		clientID:     q.Get("client_id"),
+		clientSecret: q.Get("client_secret"),
+		hostname:     q.Get("hostname"),
+		sitePath:     strings.Trim(q.Get("site"), "/"),
+		library:      strings.TrimSpace(q.Get("library")),
+	}
+
+	missing := make([]string, 0, 5)
+	if cfg.tenantID == "" {
+		missing = append(missing, "tenant_id")
+	}
+	if cfg.clientID == "" {
+		missing = append(missing, "client_id")
+	}
+	if cfg.clientSecret == "" {
+		missing = append(missing, "client_secret")
+	}
+	if cfg.hostname == "" {
+		missing = append(missing, "hostname")
+	}
+	if cfg.sitePath == "" {
+		missing = append(missing, "site")
+	}
+	if len(missing) > 0 {
+		return connConfig{}, fmt.Errorf("sharepoint URI is missing required parameter(s): %s", strings.Join(missing, ", "))
+	}
+
+	return cfg, nil
+}
+
+// parseTableSpec parses a source-table string of the form
+//
+//	<path>#<format>,<key>=<val>,...
+//
+// The path is literal (may contain spaces and "&") and may include glob
+// wildcards (* ? [ ] {}). The string is split on the LAST "#" only when the
+// suffix parses as a hint list; otherwise the whole string is the path. Use
+// "%23" to embed a literal "#" in the path.
+func parseTableSpec(name string) (tableSpec, error) {
+	spec := tableSpec{}
+	path := name
+
+	if idx := strings.LastIndex(name, "#"); idx != -1 {
+		suffix := name[idx+1:]
+		if looksLikeHints(suffix) {
+			path = name[:idx]
+			if err := applyHints(&spec, suffix); err != nil {
+				return tableSpec{}, err
+			}
+		}
+	}
+
+	path = strings.ReplaceAll(path, "%23", "#")
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return tableSpec{}, fmt.Errorf("sharepoint source-table path is empty")
+	}
+	spec.path = path
+
+	if spec.format == formatUnknown {
+		spec.format = detectFormat(path)
+	}
+	if spec.format == formatUnknown {
+		return tableSpec{}, fmt.Errorf("could not determine file format for %q; add a format hint such as #xlsx or #csv", path)
+	}
+	if spec.format == formatXLS {
+		return tableSpec{}, fmt.Errorf("legacy .xls (BIFF) files are not supported for %q; re-save the file as .xlsx", path)
+	}
+
+	return spec, nil
+}
+
+// looksLikeHints reports whether s (the part after the last "#") is a valid,
+// comma-separated hint list. It guards the last-"#" split so filenames that
+// legitimately contain "#" are not mistaken for hints.
+func looksLikeHints(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	for _, tok := range strings.Split(s, ",") {
+		if !isValidHint(strings.TrimSpace(tok)) {
+			return false
+		}
+	}
+	return true
+}
+
+// Recognized hints, kept as single source of truth so the validity check
+// (looksLikeHints) and the application (applyHints) cannot drift apart.
+var (
+	hintKeys  = map[string]bool{"sheet": true, "sheets": true, "skip": true, "encoding": true, "sep": true, "format": true, "date_cols": true}
+	hintFlags = map[string]bool{"xlsx": true, "xlsm": true, "xls": true, "csv": true, "raw": true, "formatted": true, "drop_empty": true}
+)
+
+func isValidHint(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	if eq := strings.Index(tok, "="); eq > 0 {
+		return hintKeys[strings.ToLower(strings.TrimSpace(tok[:eq]))]
+	}
+	return hintFlags[strings.ToLower(tok)]
+}
+
+func applyHints(spec *tableSpec, s string) error {
+	for _, raw := range strings.Split(s, ",") {
+		tok := strings.TrimSpace(raw)
+		if tok == "" {
+			continue
+		}
+
+		if eq := strings.Index(tok, "="); eq > 0 {
+			key := strings.ToLower(strings.TrimSpace(tok[:eq]))
+			val := strings.TrimSpace(tok[eq+1:])
+			switch key {
+			case "sheet":
+				if val != "" {
+					spec.sheets = []string{val}
+				}
+			case "sheets":
+				spec.sheets = splitSheets(val)
+			case "skip":
+				n, err := strconv.Atoi(val)
+				if err != nil || n < 0 {
+					return fmt.Errorf("invalid skip hint %q: must be a non-negative integer", val)
+				}
+				spec.skip = n
+			case "encoding":
+				spec.encoding = val
+			case "sep":
+				spec.sep = val
+			case "format":
+				spec.format = parseFormat(val)
+			case "date_cols":
+				spec.dateCols = splitSheets(val)
+			}
+			continue
+		}
+
+		switch strings.ToLower(tok) {
+		case "xlsx", "xlsm", "xls", "csv":
+			spec.format = parseFormat(tok)
+		case "raw":
+			spec.formatted = false
+		case "formatted":
+			spec.formatted = true
+		case "drop_empty":
+			spec.dropEmpty = true
+		}
+	}
+	return nil
+}
+
+// splitSheets splits a sheets= union on "|" (since "," separates hints).
+func splitSheets(val string) []string {
+	parts := strings.Split(val, "|")
+	sheets := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			sheets = append(sheets, p)
+		}
+	}
+	return sheets
+}
+
+func parseFormat(s string) fileFormat {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "xlsx", "xlsm":
+		return formatXLSX
+	case "xls":
+		return formatXLS
+	case "csv":
+		return formatCSV
+	default:
+		return formatUnknown
+	}
+}
+
+// detectFormat infers the format from the file extension. It still recognizes
+// .xls so parseTableSpec can emit a targeted "re-save as .xlsx" error rather
+// than a generic "unknown format" one.
+func detectFormat(p string) fileFormat {
+	return parseFormat(strings.TrimPrefix(gopath.Ext(p), "."))
+}
+
+var _ source.Source = (*SharePointSource)(nil)

--- a/pkg/source/sharepoint/sharepoint_integration_test.go
+++ b/pkg/source/sharepoint/sharepoint_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package sharepoint_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/source/sharepoint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSharePointSource reads a real workbook/file from SharePoint and validates
+// the source's structural contract: metadata columns, raw all-VARCHAR data,
+// and a monotonic _row_idx. It is gated behind credentials so CI without them
+// skips it. Point it at a known file via the env vars below; set
+// SHAREPOINT_EXPECTED_ROWS to additionally assert an exact row count.
+//
+//	SHAREPOINT_TENANT_ID
+//	SHAREPOINT_CLIENT_ID
+//	SHAREPOINT_CLIENT_SECRET
+//	SHAREPOINT_HOSTNAME       tenant hostname, e.g. <tenant>.sharepoint.com
+//	SHAREPOINT_SITE           server-relative site path, e.g. sites/<name>
+//	SHAREPOINT_TEST_TABLE     source-table string, e.g. <path>/<file>.xlsx#sheet=<name>
+//	SHAREPOINT_EXPECTED_ROWS  optional, exact total row count
+func TestSharePointSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	env := func(k string) string { return os.Getenv(k) }
+	required := []string{
+		"SHAREPOINT_TENANT_ID", "SHAREPOINT_CLIENT_ID", "SHAREPOINT_CLIENT_SECRET",
+		"SHAREPOINT_HOSTNAME", "SHAREPOINT_SITE", "SHAREPOINT_TEST_TABLE",
+	}
+	for _, k := range required {
+		if env(k) == "" {
+			t.Skipf("Set %s (and the other SHAREPOINT_* vars) to run SharePoint integration tests", k)
+		}
+	}
+
+	uri := fmt.Sprintf(
+		"sharepoint://?tenant_id=%s&client_id=%s&client_secret=%s&hostname=%s&site=%s",
+		url.QueryEscape(env("SHAREPOINT_TENANT_ID")),
+		url.QueryEscape(env("SHAREPOINT_CLIENT_ID")),
+		url.QueryEscape(env("SHAREPOINT_CLIENT_SECRET")),
+		url.QueryEscape(env("SHAREPOINT_HOSTNAME")),
+		url.QueryEscape(env("SHAREPOINT_SITE")),
+	)
+
+	ctx := context.Background()
+	src := sharepoint.NewSharePointSource()
+	require.NoError(t, src.Connect(ctx, uri))
+	defer func() { _ = src.Close(ctx) }()
+
+	table, err := src.GetTable(ctx, source.TableRequest{Name: env("SHAREPOINT_TEST_TABLE")})
+	require.NoError(t, err)
+	assert.False(t, table.HasKnownSchema())
+
+	records, err := table.Read(ctx, source.ReadOptions{})
+	require.NoError(t, err)
+
+	totalRows := 0
+	batches := 0
+	metadata := map[string]bool{"_source_file": false, "_sheet_name": false, "_row_idx": false}
+
+	for result := range records {
+		require.NoError(t, result.Err)
+		rec := result.Batch
+		batches++
+		totalRows += int(rec.NumRows())
+
+		fields := map[string]arrow.Field{}
+		for i := 0; i < int(rec.NumCols()); i++ {
+			f := rec.Schema().Field(i)
+			fields[f.Name] = f
+		}
+
+		for name := range metadata {
+			if _, ok := fields[name]; ok {
+				metadata[name] = true
+			}
+		}
+
+		// _row_idx is int64 and starts at 0 within each emitted sheet/file.
+		idxField, ok := fields["_row_idx"]
+		require.True(t, ok, "missing _row_idx column")
+		assert.Equal(t, arrow.INT64, idxField.Type.ID())
+
+		// Every non-metadata column lands as raw VARCHAR.
+		for i := 0; i < int(rec.NumCols()); i++ {
+			f := rec.Schema().Field(i)
+			if f.Name == "_row_idx" {
+				continue
+			}
+			assert.Equalf(t, arrow.STRING, f.Type.ID(), "column %q should be string", f.Name)
+		}
+
+		if rec.NumRows() > 0 {
+			if idxArr, ok := rec.Column(colIndex(rec, "_row_idx")).(*array.Int64); ok {
+				assert.GreaterOrEqual(t, idxArr.Value(0), int64(0))
+			}
+		}
+
+		rec.Release()
+	}
+
+	assert.Greater(t, batches, 0, "expected at least one batch")
+	assert.Greater(t, totalRows, 0, "expected at least one row")
+	for name, seen := range metadata {
+		assert.Truef(t, seen, "metadata column %q was not emitted", name)
+	}
+
+	if want := env("SHAREPOINT_EXPECTED_ROWS"); want != "" {
+		var n int
+		_, err := fmt.Sscanf(want, "%d", &n)
+		require.NoError(t, err)
+		assert.Equal(t, n, totalRows)
+	}
+}
+
+func colIndex(rec arrow.RecordBatch, name string) int {
+	for i := 0; i < int(rec.NumCols()); i++ {
+		if rec.Schema().Field(i).Name == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/source/sharepoint/sharepoint_test.go
+++ b/pkg/source/sharepoint/sharepoint_test.go
@@ -1,0 +1,734 @@
+package sharepoint
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/databuffer"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xuri/excelize/v2"
+)
+
+func TestParseTableSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    tableSpec
+		wantErr bool
+	}{
+		{
+			name:  "format and sheet hints",
+			input: "Reports/products.xlsx#xlsx,sheet=Sheet1",
+			want:  tableSpec{path: "Reports/products.xlsx", format: formatXLSX, sheets: []string{"Sheet1"}},
+		},
+		{
+			name:  "sheet and skip, format from extension, space in path",
+			input: "Reports/parameters file.xlsx#sheet=Forecast,skip=4",
+			want:  tableSpec{path: "Reports/parameters file.xlsx", format: formatXLSX, sheets: []string{"Forecast"}, skip: 4},
+		},
+		{
+			name:  "sheets union with ampersand in path",
+			input: "Reports/budget & forecast.xlsx#sheets=North|South|East",
+			want:  tableSpec{path: "Reports/budget & forecast.xlsx", format: formatXLSX, sheets: []string{"North", "South", "East"}},
+		},
+		{
+			name:  "glob with sheets union",
+			input: "Reports/monthly/*.xlsx#sheets=Jan|Feb|Mar",
+			want:  tableSpec{path: "Reports/monthly/*.xlsx", format: formatXLSX, sheets: []string{"Jan", "Feb", "Mar"}},
+		},
+		{
+			name:  "sheet names with spaces (single)",
+			input: "Reports/Quarterly Summary.xlsx#sheet=Dept. Summary",
+			want:  tableSpec{path: "Reports/Quarterly Summary.xlsx", format: formatXLSX, sheets: []string{"Dept. Summary"}},
+		},
+		{
+			name:  "sheet names with spaces (union)",
+			input: "Reports/Quarterly Summary.xlsx#sheets=North Region|Dept. Summary|Cost Centers",
+			want:  tableSpec{path: "Reports/Quarterly Summary.xlsx", format: formatXLSX, sheets: []string{"North Region", "Dept. Summary", "Cost Centers"}},
+		},
+		{
+			name:  "csv with encoding and tab separator",
+			input: "Reports/export.csv#csv,encoding=utf-16le,sep=tab",
+			want:  tableSpec{path: "Reports/export.csv", format: formatCSV, encoding: "utf-16le", sep: "tab"},
+		},
+		{
+			name:  "path only, format detected",
+			input: "folder/products.xlsx",
+			want:  tableSpec{path: "folder/products.xlsx", format: formatXLSX},
+		},
+		{
+			name:  "hash in filename without hints stays literal path",
+			input: "folder/Report #3.xlsx",
+			want:  tableSpec{path: "folder/Report #3.xlsx", format: formatXLSX},
+		},
+		{
+			name:  "hash in filename with a trailing hint",
+			input: "folder/Report #3.xlsx#sheet=Foo",
+			want:  tableSpec{path: "folder/Report #3.xlsx", format: formatXLSX, sheets: []string{"Foo"}},
+		},
+		{
+			name:  "escaped hash in path",
+			input: "folder/A%23B.csv",
+			want:  tableSpec{path: "folder/A#B.csv", format: formatCSV},
+		},
+		{
+			name:  "format override without extension",
+			input: "folder/export#xlsx",
+			want:  tableSpec{path: "folder/export", format: formatXLSX},
+		},
+		{
+			name:  "formatted hint disables raw values",
+			input: "a.xlsx#formatted",
+			want:  tableSpec{path: "a.xlsx", format: formatXLSX, formatted: true},
+		},
+		{
+			name:  "drop_empty hint",
+			input: "a.csv#csv,drop_empty",
+			want:  tableSpec{path: "a.csv", format: formatCSV, dropEmpty: true},
+		},
+		{
+			name:  "date_cols hint",
+			input: "a.xlsx#sheet=S,date_cols=DATE|MONTH",
+			want:  tableSpec{path: "a.xlsx", format: formatXLSX, sheets: []string{"S"}, dateCols: []string{"DATE", "MONTH"}},
+		},
+		{
+			name:    "unknown format errors",
+			input:   "folder/data.txt",
+			wantErr: true,
+		},
+		{
+			name:    "legacy xls errors",
+			input:   "folder/legacy.xls",
+			wantErr: true,
+		},
+		{
+			name:    "xls format hint errors",
+			input:   "folder/export#xls",
+			wantErr: true,
+		},
+		{
+			name:    "negative skip errors",
+			input:   "a.xlsx#skip=-1",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric skip errors",
+			input:   "a.xlsx#skip=abc",
+			wantErr: true,
+		},
+		{
+			name:    "empty path errors",
+			input:   "#xlsx",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseTableSpec(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.path, got.path)
+			assert.Equal(t, tt.want.format, got.format)
+			assert.Equal(t, tt.want.sheets, got.sheets)
+			assert.Equal(t, tt.want.skip, got.skip)
+			assert.Equal(t, tt.want.encoding, got.encoding)
+			assert.Equal(t, tt.want.sep, got.sep)
+			assert.Equal(t, tt.want.formatted, got.formatted)
+			assert.Equal(t, tt.want.dropEmpty, got.dropEmpty)
+			assert.Equal(t, tt.want.dateCols, got.dateCols)
+		})
+	}
+}
+
+func TestLooksLikeHints(t *testing.T) {
+	t.Parallel()
+	assert.True(t, looksLikeHints("xlsx,sheet=Sheet1"))
+	assert.True(t, looksLikeHints("sheets=A|B"))
+	assert.True(t, looksLikeHints("csv"))
+	assert.True(t, looksLikeHints("raw"))
+	assert.True(t, looksLikeHints("csv,drop_empty"))
+	assert.False(t, looksLikeHints("3.xlsx"))
+	assert.False(t, looksLikeHints("Sheet"))
+	assert.False(t, looksLikeHints(""))
+	assert.False(t, looksLikeHints("sheet=A,bogus=1"))
+}
+
+func TestDedupHeaders(t *testing.T) {
+	t.Parallel()
+	got := dedupHeaders([]string{"A", "", "A", "_row_idx"})
+	assert.Equal(t, []string{"A", "column_1", "A_2", "_row_idx_2"}, got)
+}
+
+func TestDetectFormat(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, formatXLSX, detectFormat("a/b.xlsx"))
+	assert.Equal(t, formatXLSX, detectFormat("a/b.XLSX"))
+	assert.Equal(t, formatXLSX, detectFormat("a/b.xlsm"))
+	assert.Equal(t, formatXLS, detectFormat("a/b.xls"))
+	assert.Equal(t, formatCSV, detectFormat("a/b.csv"))
+	assert.Equal(t, formatUnknown, detectFormat("a/b.txt"))
+}
+
+func TestSplitSheets(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"A", "B", "C"}, splitSheets("A|B| |C"))
+	assert.Empty(t, splitSheets(""))
+	// Internal spaces are preserved; only each part's leading/trailing space is trimmed.
+	assert.Equal(t, []string{"Dept. Summary", "Cost Centers"}, splitSheets("Dept. Summary | Cost Centers"))
+}
+
+func TestResolveSep(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, rune(0), resolveSep(""))
+	assert.Equal(t, '\t', resolveSep("tab"))
+	assert.Equal(t, '\t', resolveSep(`\t`))
+	assert.Equal(t, ';', resolveSep(";"))
+	assert.Equal(t, rune(0), resolveSep("||"))
+}
+
+func TestExtractPrefixAndGlobMeta(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "Team/Forecast/", extractPrefix("Team/Forecast/*.xlsx"))
+	assert.Equal(t, "Team/", extractPrefix("Team/**/x.xlsx"))
+	assert.Equal(t, "", extractPrefix("*.xlsx"))
+	assert.Equal(t, "a/b.xlsx", extractPrefix("a/b.xlsx"))
+
+	assert.True(t, hasGlobMeta("*.xlsx"))
+	assert.True(t, hasGlobMeta("a/{x,y}.xlsx"))
+	assert.True(t, hasGlobMeta("a[1].xlsx"))
+	assert.False(t, hasGlobMeta("a/b.xlsx"))
+}
+
+func TestEncodePath(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "Reports/Q1%20Data/products.xlsx", encodePath("Reports/Q1 Data/products.xlsx"))
+	assert.Equal(t, "a%23b/c%20d.xlsx", encodePath("/a#b/c d.xlsx/"))
+	assert.Equal(t, "", encodePath("/"))
+}
+
+func TestParseURI(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=example.sharepoint.com")
+	require.NoError(t, err)
+	assert.Equal(t, "t", cfg.tenantID)
+	assert.Equal(t, "c", cfg.clientID)
+	assert.Equal(t, "s", cfg.clientSecret)
+	assert.Equal(t, "example.sharepoint.com", cfg.hostname)
+	assert.Equal(t, "sites/Example", cfg.sitePath)
+	assert.Equal(t, "", cfg.library) // optional, defaults to the Documents library
+
+	cfg, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=example.sharepoint.com&library=Finance%20Docs")
+	require.NoError(t, err)
+	assert.Equal(t, "Finance Docs", cfg.library)
+
+	_, err = parseURI("sharepoint://?tenant_id=t")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_id")
+	assert.Contains(t, err.Error(), "site")
+
+	_, err = parseURI("http://example.com")
+	require.Error(t, err)
+}
+
+func TestReadCSV(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("name,amount\nfoo,1\nbar,\n")
+	rec := readAllCSV(t, "dir/x.csv", data, tableSpec{path: "dir/x.csv", format: formatCSV}, source.ReadOptions{})
+
+	require.EqualValues(t, 2, rec.NumRows())
+	cols := columnsByName(rec)
+
+	assertStringColumn(t, cols, "_source_file", []string{"dir/x.csv", "dir/x.csv"})
+	assertInt64Column(t, cols, "_row_idx", []int64{0, 1})
+	assertStringColumn(t, cols, "name", []string{"foo", "bar"})
+	// An empty cell lands as "" rather than null.
+	assertStringColumn(t, cols, "amount", []string{"1", ""})
+
+	// _sheet_name is null for flat formats.
+	sheetCol := cols["_sheet_name"].(*array.String)
+	assert.True(t, sheetCol.IsNull(0))
+	assert.True(t, sheetCol.IsNull(1))
+}
+
+func TestReadCSVSkipAndTab(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("junk line\nname\tamount\nfoo\t1\n")
+	rec := readAllCSV(t, "x.csv", data, tableSpec{path: "x.csv", format: formatCSV, sep: "tab", skip: 1}, source.ReadOptions{})
+
+	require.EqualValues(t, 1, rec.NumRows())
+	cols := columnsByName(rec)
+	assertStringColumn(t, cols, "name", []string{"foo"})
+	assertStringColumn(t, cols, "amount", []string{"1"})
+}
+
+func TestReadCSVLimit(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("name\na\nb\nc\n")
+	rec := readAllCSV(t, "x.csv", data, tableSpec{path: "x.csv", format: formatCSV}, source.ReadOptions{Limit: 2})
+	require.EqualValues(t, 2, rec.NumRows())
+}
+
+func TestReadCSVDropEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Row 1 (",") is fully empty; with drop_empty it is skipped and _row_idx
+	// keeps its true position (0, then 2 — a gap where the blank row was).
+	data := []byte("name,amount\nfoo,1\n,\nbar,2\n")
+	rec := readAllCSV(t, "x.csv", data, tableSpec{path: "x.csv", format: formatCSV, dropEmpty: true}, source.ReadOptions{})
+
+	require.EqualValues(t, 2, rec.NumRows())
+	cols := columnsByName(rec)
+	assertStringColumn(t, cols, "name", []string{"foo", "bar"})
+	assertInt64Column(t, cols, "_row_idx", []int64{0, 2})
+}
+
+func TestReadCSVMultipleBatches(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("name\na\nb\nc\n")
+	results := make(chan source.RecordBatchResult, 16)
+	total := 0
+	err := readCSV(context.Background(), "x.csv", writeTemp(t, data),
+		tableSpec{path: "x.csv", format: formatCSV}, source.ReadOptions{PageSize: 1}, results, &total)
+	close(results)
+	require.NoError(t, err)
+
+	rows, batches := 0, 0
+	for r := range results {
+		require.NoError(t, r.Err)
+		rows += int(r.Batch.NumRows())
+		batches++
+	}
+	assert.Equal(t, 3, rows)
+	assert.GreaterOrEqual(t, batches, 2, "PageSize=1 should force multiple batches")
+	assert.Equal(t, 3, total)
+}
+
+func TestReadCSVContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	data := []byte("name\na\nb\nc\n")
+	results := make(chan source.RecordBatchResult, 16)
+	total := 0
+	err := readCSV(ctx, "x.csv", writeTemp(t, data),
+		tableSpec{path: "x.csv", format: formatCSV}, source.ReadOptions{}, results, &total)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestEmitItemsContextAware proves the producer does not block forever when the
+// consumer has stopped draining: with a cancelled context and an unbuffered
+// channel with no reader, emitItems returns instead of deadlocking.
+func TestEmitItemsContextAware(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results := make(chan source.RecordBatchResult) // unbuffered, no reader
+	total := 0
+	cols := buildColumns([]string{"a"})
+	items := []map[string]interface{}{{colSourceFile: "x", colRowIdx: 0, "a": "1"}}
+
+	stop, err := emitItems(ctx, results, items, cols, source.ReadOptions{}, &total)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, stop)
+	assert.Equal(t, 0, total)
+}
+
+func TestReadExcelDatesAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	f := excelize.NewFile()
+	sheet := f.GetSheetName(0)
+	require.NoError(t, f.SetSheetRow(sheet, "A1", &[]any{"day", "amount", "label"}))
+	// row 2: a pure date, a number, text
+	require.NoError(t, f.SetCellValue(sheet, "A2", time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)))
+	require.NoError(t, f.SetCellValue(sheet, "B2", 1234.5))
+	require.NoError(t, f.SetCellValue(sheet, "C2", "hello"))
+	// row 3: a datetime, empty number, empty text
+	require.NoError(t, f.SetCellValue(sheet, "A3", time.Date(2024, 1, 15, 13, 30, 0, 0, time.UTC)))
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Write(&buf))
+	require.NoError(t, f.Close())
+
+	rec := readAllExcel(t, "dir/book.xlsx", buf.Bytes(),
+		tableSpec{path: "dir/book.xlsx", format: formatXLSX, dateCols: []string{"day"}}, source.ReadOptions{})
+	require.EqualValues(t, 2, rec.NumRows())
+	cols := columnsByName(rec)
+
+	assertStringColumn(t, cols, "_source_file", []string{"dir/book.xlsx", "dir/book.xlsx"})
+	assertStringColumn(t, cols, "_sheet_name", []string{sheet, sheet})
+	assertInt64Column(t, cols, "_row_idx", []int64{0, 1})
+	// date_cols column: serial values become ISO strings (date or date-time by value);
+	// other numeric values stay raw.
+	assertStringColumn(t, cols, "day", []string{"2024-01-15", "2024-01-15 13:30:00"})
+	assertStringColumn(t, cols, "amount", []string{"1234.5", ""})
+	assertStringColumn(t, cols, "label", []string{"hello", ""})
+}
+
+func TestReadExcelDropEmpty(t *testing.T) {
+	t.Parallel()
+
+	f := excelize.NewFile()
+	sheet := f.GetSheetName(0)
+	require.NoError(t, f.SetSheetRow(sheet, "A1", &[]any{"name", "amount"}))
+	require.NoError(t, f.SetSheetRow(sheet, "A2", &[]any{"foo", 1.0}))
+	// row 3 left entirely blank
+	require.NoError(t, f.SetSheetRow(sheet, "A4", &[]any{"bar", 2.0}))
+	var buf bytes.Buffer
+	require.NoError(t, f.Write(&buf))
+	require.NoError(t, f.Close())
+
+	rec := readAllExcel(t, "dir/book.xlsx", buf.Bytes(),
+		tableSpec{path: "dir/book.xlsx", format: formatXLSX, dropEmpty: true}, source.ReadOptions{})
+
+	require.EqualValues(t, 2, rec.NumRows())
+	cols := columnsByName(rec)
+	assertStringColumn(t, cols, "name", []string{"foo", "bar"})
+	// The blank middle row is dropped; _row_idx keeps true positions (gap at 1).
+	assertInt64Column(t, cols, "_row_idx", []int64{0, 2})
+}
+
+// TestHeterogeneousColumnsUnion proves the by-name column union that applies
+// across a glob/sheet set: differently-shaped per-file batches are unioned by
+// name (extra columns appended) and reconciled with NULL where a column was
+// absent. The union itself is performed by schemainfer + databuffer, exactly as
+// the pipeline does for a schema-less source like this one.
+func TestHeterogeneousColumnsUnion(t *testing.T) {
+	t.Parallel()
+
+	batchA := readAllCSV(t, "a.csv", []byte("name,a\nx,1\n"),
+		tableSpec{path: "a.csv", format: formatCSV}, source.ReadOptions{})
+	batchB := readAllCSV(t, "b.csv", []byte("name,b\ny,2\n"),
+		tableSpec{path: "b.csv", format: formatCSV}, source.ReadOptions{})
+
+	// Each file yields its own column set.
+	assert.ElementsMatch(t, []string{"_source_file", "_sheet_name", "_row_idx", "name", "a"}, fieldNames(batchA.Schema()))
+	assert.ElementsMatch(t, []string{"_source_file", "_sheet_name", "_row_idx", "name", "b"}, fieldNames(batchB.Schema()))
+
+	inf := schemainfer.NewSchemaInferrer()
+	require.NoError(t, inf.AddBatch(batchA))
+	require.NoError(t, inf.AddBatch(batchB))
+	union, err := inf.InferSchema()
+	require.NoError(t, err)
+
+	// Union contains both file-specific columns, appended in first-seen order.
+	assert.ElementsMatch(t, []string{"_source_file", "_sheet_name", "_row_idx", "name", "a", "b"}, fieldNames(union))
+
+	// Reconciling batch A to the union null-fills the column it lacked ("b").
+	recA, err := databuffer.CastRecordToSchema(batchA, union, true)
+	require.NoError(t, err)
+	colsA := columnsByName(recA)
+	assert.True(t, colsA["b"].IsNull(0), "column b should be null for rows from a.csv")
+	assert.False(t, colsA["a"].IsNull(0), "column a should be present for rows from a.csv")
+
+	// And batch B null-fills "a".
+	recB, err := databuffer.CastRecordToSchema(batchB, union, true)
+	require.NoError(t, err)
+	colsB := columnsByName(recB)
+	assert.True(t, colsB["a"].IsNull(0), "column a should be null for rows from b.csv")
+	assert.False(t, colsB["b"].IsNull(0), "column b should be present for rows from b.csv")
+}
+
+func fieldNames(s *arrow.Schema) []string {
+	names := make([]string, s.NumFields())
+	for i := 0; i < s.NumFields(); i++ {
+		names[i] = s.Field(i).Name
+	}
+	return names
+}
+
+func TestSerialToISO(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw  string
+		want string
+		ok   bool
+	}{
+		{"45306", "2024-01-15", true},               // whole serial -> date
+		{"45306.5625", "2024-01-15 13:30:00", true}, // fractional -> date-time
+		{"0.5", "12:00:00", true},                   // fraction only -> time
+		{"hello", "", false},                        // text -> left untouched
+		{"", "", false},                             // empty -> left untouched
+		{"0", "", false},                            // non-positive -> not a date
+		{"-3", "", false},
+		{"NaN", "", false}, // ParseFloat accepts these; must not become a date
+		{"Inf", "", false},
+		{"+Inf", "", false},
+		{"1e9", "", false},     // beyond year 9999 -> out of range
+		{"1.5e308", "", false}, // huge -> out of range
+	}
+	for _, c := range cases {
+		got, ok := serialToISO(c.raw, false)
+		assert.Equalf(t, c.ok, ok, "raw %q ok", c.raw)
+		if c.ok {
+			assert.Equalf(t, c.want, got, "raw %q value", c.raw)
+		}
+	}
+}
+
+// TestReadExcelDateColsOnly proves date conversion is opt-in: without date_cols a
+// serial lands raw; with date_cols it is converted, and only for that column.
+func TestReadExcelDateColsOnly(t *testing.T) {
+	t.Parallel()
+
+	build := func() []byte {
+		f := excelize.NewFile()
+		sheet := f.GetSheetName(0)
+		require.NoError(t, f.SetSheetRow(sheet, "A1", &[]any{"d", "n"}))
+		require.NoError(t, f.SetCellValue(sheet, "A2", 45306.0)) // serial for 2024-01-15
+		require.NoError(t, f.SetCellValue(sheet, "B2", 45306.0)) // same number, not a date column
+		var buf bytes.Buffer
+		require.NoError(t, f.Write(&buf))
+		require.NoError(t, f.Close())
+		return buf.Bytes()
+	}
+
+	// No date_cols: both columns land as the raw serial.
+	rec := readAllExcel(t, "book.xlsx", build(), tableSpec{path: "book.xlsx", format: formatXLSX}, source.ReadOptions{})
+	cols := columnsByName(rec)
+	assertStringColumn(t, cols, "d", []string{"45306"})
+	assertStringColumn(t, cols, "n", []string{"45306"})
+
+	// date_cols=D (case-insensitive match of header "d"): only "d" is converted
+	// to ISO; "n" stays raw.
+	rec = readAllExcel(t, "book.xlsx", build(),
+		tableSpec{path: "book.xlsx", format: formatXLSX, dateCols: []string{"D"}}, source.ReadOptions{})
+	cols = columnsByName(rec)
+	assertStringColumn(t, cols, "d", []string{"2024-01-15"})
+	assertStringColumn(t, cols, "n", []string{"45306"})
+}
+
+// TestReadExcelMultipleSheets covers the sheets= union: both sheets are stacked,
+// _sheet_name records each row's origin, and _row_idx restarts at 0 per sheet.
+func TestReadExcelMultipleSheets(t *testing.T) {
+	t.Parallel()
+
+	f := excelize.NewFile()
+	s1 := f.GetSheetName(0)
+	_, err := f.NewSheet("Second")
+	require.NoError(t, err)
+	require.NoError(t, f.SetSheetRow(s1, "A1", &[]any{"name"}))
+	require.NoError(t, f.SetSheetRow(s1, "A2", &[]any{"a"}))
+	require.NoError(t, f.SetSheetRow(s1, "A3", &[]any{"b"}))
+	require.NoError(t, f.SetSheetRow("Second", "A1", &[]any{"name"}))
+	require.NoError(t, f.SetSheetRow("Second", "A2", &[]any{"c"}))
+	var buf bytes.Buffer
+	require.NoError(t, f.Write(&buf))
+	require.NoError(t, f.Close())
+
+	// Each sheet emits its own batch, so collect across batches.
+	results := make(chan source.RecordBatchResult, 16)
+	total := 0
+	require.NoError(t, readExcel(context.Background(), "book.xlsx", writeTemp(t, buf.Bytes()),
+		tableSpec{path: "book.xlsx", format: formatXLSX, sheets: []string{s1, "Second"}}, source.ReadOptions{}, results, &total))
+	close(results)
+
+	var names, sheetNames []string
+	var rowIdx []int64
+	for r := range results {
+		require.NoError(t, r.Err)
+		cols := columnsByName(r.Batch)
+		nameArr := cols["name"].(*array.String)
+		sheetArr := cols["_sheet_name"].(*array.String)
+		idxArr := cols["_row_idx"].(*array.Int64)
+		for i := 0; i < nameArr.Len(); i++ {
+			names = append(names, nameArr.Value(i))
+			sheetNames = append(sheetNames, sheetArr.Value(i))
+			rowIdx = append(rowIdx, idxArr.Value(i))
+		}
+	}
+	assert.Equal(t, []string{"a", "b", "c"}, names)
+	assert.Equal(t, []string{s1, s1, "Second"}, sheetNames)
+	// _row_idx resets per sheet: 0,1 for the first, then 0 for the second.
+	assert.Equal(t, []int64{0, 1, 0}, rowIdx)
+	assert.Equal(t, 3, total)
+}
+
+// TestReadExcelSheetNameWithSpaces proves a requested sheet whose name contains
+// spaces (and a period) is resolved by exact match and selected over the first
+// sheet, with _sheet_name stamped using the spaced name.
+func TestReadExcelSheetNameWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	f := excelize.NewFile()
+	first := f.GetSheetName(0)
+	_, err := f.NewSheet("Dept. Summary")
+	require.NoError(t, err)
+	require.NoError(t, f.SetSheetRow(first, "A1", &[]any{"other"}))
+	require.NoError(t, f.SetSheetRow(first, "A2", &[]any{"x"}))
+	require.NoError(t, f.SetSheetRow("Dept. Summary", "A1", &[]any{"name", "amount"}))
+	require.NoError(t, f.SetSheetRow("Dept. Summary", "A2", &[]any{"foo", "1"}))
+	var buf bytes.Buffer
+	require.NoError(t, f.Write(&buf))
+	require.NoError(t, f.Close())
+
+	rec := readAllExcel(t, "Quarterly Summary.xlsx", buf.Bytes(),
+		tableSpec{path: "Quarterly Summary.xlsx", format: formatXLSX, sheets: []string{"Dept. Summary"}}, source.ReadOptions{})
+
+	require.EqualValues(t, 1, rec.NumRows())
+	cols := columnsByName(rec)
+	assertStringColumn(t, cols, "name", []string{"foo"})
+	assertStringColumn(t, cols, "_sheet_name", []string{"Dept. Summary"})
+}
+
+// TestReadExcelBlankRowSemantics covers the default (non-drop_empty) path: an
+// internal blank row is preserved as an all-"" row keeping its _row_idx, while
+// trailing blank rows are trimmed — mirroring excelize.GetRows.
+func TestReadExcelBlankRowSemantics(t *testing.T) {
+	t.Parallel()
+
+	f := excelize.NewFile()
+	sheet := f.GetSheetName(0)
+	require.NoError(t, f.SetSheetRow(sheet, "A1", &[]any{"name", "amount"}))
+	require.NoError(t, f.SetSheetRow(sheet, "A2", &[]any{"foo", "1"}))
+	// row 3 left blank (internal gap)
+	require.NoError(t, f.SetSheetRow(sheet, "A4", &[]any{"bar", "2"}))
+	// rows 5 and 6 left blank (trailing) — never written, so trimmed
+	var buf bytes.Buffer
+	require.NoError(t, f.Write(&buf))
+	require.NoError(t, f.Close())
+
+	rec := readAllExcel(t, "book.xlsx", buf.Bytes(),
+		tableSpec{path: "book.xlsx", format: formatXLSX}, source.ReadOptions{})
+
+	require.EqualValues(t, 3, rec.NumRows())
+	cols := columnsByName(rec)
+	// Internal blank row preserved as all-"" at its true position (row_idx 1).
+	assertStringColumn(t, cols, "name", []string{"foo", "", "bar"})
+	assertStringColumn(t, cols, "amount", []string{"1", "", "2"})
+	assertInt64Column(t, cols, "_row_idx", []int64{0, 1, 2})
+}
+
+func TestReadExcelSkip(t *testing.T) {
+	t.Parallel()
+
+	build := func() []byte {
+		f := excelize.NewFile()
+		sheet := f.GetSheetName(0)
+		require.NoError(t, f.SetSheetRow(sheet, "A1", &[]any{"junk title"}))
+		require.NoError(t, f.SetSheetRow(sheet, "A2", &[]any{"name"}))
+		require.NoError(t, f.SetSheetRow(sheet, "A3", &[]any{"foo"}))
+		var buf bytes.Buffer
+		require.NoError(t, f.Write(&buf))
+		require.NoError(t, f.Close())
+		return buf.Bytes()
+	}
+
+	// skip=1 drops the junk title; row 2 becomes the header, row 3 the data.
+	rec := readAllExcel(t, "x.xlsx", build(),
+		tableSpec{path: "x.xlsx", format: formatXLSX, skip: 1}, source.ReadOptions{})
+	require.EqualValues(t, 1, rec.NumRows())
+	assertStringColumn(t, columnsByName(rec), "name", []string{"foo"})
+
+	// skip beyond the available rows yields no header and no rows (no error).
+	results := make(chan source.RecordBatchResult, 4)
+	total := 0
+	require.NoError(t, readExcel(context.Background(), "x.xlsx", writeTemp(t, build()),
+		tableSpec{path: "x.xlsx", format: formatXLSX, skip: 10}, source.ReadOptions{}, results, &total))
+	close(results)
+	for r := range results {
+		require.NoError(t, r.Err)
+		t.Fatalf("expected no batches when skip exceeds row count")
+	}
+	assert.Equal(t, 0, total)
+}
+
+// writeTemp writes data to a temp file and returns its path; the file is removed
+// at test cleanup.
+func writeTemp(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "input")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func readAllExcel(t *testing.T, path string, data []byte, spec tableSpec, opts source.ReadOptions) arrow.RecordBatch {
+	t.Helper()
+	results := make(chan source.RecordBatchResult, 16)
+	total := 0
+	err := readExcel(context.Background(), path, writeTemp(t, data), spec, opts, results, &total)
+	close(results)
+	require.NoError(t, err)
+
+	var rec arrow.RecordBatch
+	for r := range results {
+		require.NoError(t, r.Err)
+		require.Nil(t, rec, "expected a single batch in this test")
+		rec = r.Batch
+	}
+	require.NotNil(t, rec)
+	return rec
+}
+
+// readAllCSV runs readCSV and concatenates the emitted batches into one record
+// for assertions. It expects at least one batch.
+func readAllCSV(t *testing.T, path string, data []byte, spec tableSpec, opts source.ReadOptions) arrow.RecordBatch {
+	t.Helper()
+	results := make(chan source.RecordBatchResult, 16)
+	total := 0
+	err := readCSV(context.Background(), path, writeTemp(t, data), spec, opts, results, &total)
+	close(results)
+	require.NoError(t, err)
+
+	var rec arrow.RecordBatch
+	for r := range results {
+		require.NoError(t, r.Err)
+		require.Nil(t, rec, "expected a single batch in these tests")
+		rec = r.Batch
+	}
+	require.NotNil(t, rec)
+	return rec
+}
+
+func columnsByName(rec arrow.RecordBatch) map[string]arrow.Array {
+	out := make(map[string]arrow.Array, rec.NumCols())
+	for i := 0; i < int(rec.NumCols()); i++ {
+		out[rec.Schema().Field(i).Name] = rec.Column(i)
+	}
+	return out
+}
+
+func assertStringColumn(t *testing.T, cols map[string]arrow.Array, name string, want []string) {
+	t.Helper()
+	arr, ok := cols[name].(*array.String)
+	require.True(t, ok, "column %q is not a string array", name)
+	require.Equal(t, len(want), arr.Len())
+	for i, w := range want {
+		assert.Equalf(t, w, arr.Value(i), "column %q row %d", name, i)
+	}
+}
+
+func assertInt64Column(t *testing.T, cols map[string]arrow.Array, name string, want []int64) {
+	t.Helper()
+	arr, ok := cols[name].(*array.Int64)
+	require.True(t, ok, "column %q is not an int64 array", name)
+	require.Equal(t, len(want), arr.Len())
+	for i, w := range want {
+		assert.Equalf(t, w, arr.Value(i), "column %q row %d", name, i)
+	}
+}

--- a/pkg/source/sharepoint/sharepoint_test.go
+++ b/pkg/source/sharepoint/sharepoint_test.go
@@ -103,6 +103,11 @@ func TestParseTableSpec(t *testing.T) {
 			want:  tableSpec{path: "a.xlsx", format: formatXLSX, sheets: []string{"S"}, dateCols: []string{"DATE", "MONTH"}},
 		},
 		{
+			name:  "extensionless glob defers format to matched files",
+			input: "Reports/**",
+			want:  tableSpec{path: "Reports/**", format: formatUnknown},
+		},
+		{
 			name:    "unknown format errors",
 			input:   "folder/data.txt",
 			wantErr: true,
@@ -173,6 +178,11 @@ func TestDedupHeaders(t *testing.T) {
 	t.Parallel()
 	got := dedupHeaders([]string{"A", "", "A", "_row_idx"})
 	assert.Equal(t, []string{"A", "column_1", "A_2", "_row_idx_2"}, got)
+
+	// A generated suffix that collides with a real header must be re-suffixed,
+	// not produce a duplicate (which would drop a column in buildItem's map).
+	got = dedupHeaders([]string{"col", "col_2", "col"})
+	assert.Equal(t, []string{"col", "col_2", "col_3"}, got)
 }
 
 func TestDetectFormat(t *testing.T) {
@@ -232,11 +242,24 @@ func TestParseURI(t *testing.T) {
 	assert.Equal(t, "s", cfg.clientSecret)
 	assert.Equal(t, "example.sharepoint.com", cfg.hostname)
 	assert.Equal(t, "sites/Example", cfg.sitePath)
-	assert.Equal(t, "", cfg.library) // optional, defaults to the Documents library
+	assert.Equal(t, "", cfg.library)          // optional, defaults to the Documents library
+	assert.EqualValues(t, 0, cfg.maxFileSize) // unlimited by default
+	assert.Equal(t, defaultMaxFiles, cfg.maxFiles)
 
 	cfg, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=example.sharepoint.com&library=Finance%20Docs")
 	require.NoError(t, err)
 	assert.Equal(t, "Finance Docs", cfg.library)
+
+	// optional hardening limits
+	cfg, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&max_file_size=1048576&max_files=50")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1048576, cfg.maxFileSize)
+	assert.Equal(t, 50, cfg.maxFiles)
+
+	_, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&max_file_size=-1")
+	require.Error(t, err)
+	_, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&max_files=abc")
+	require.Error(t, err)
 
 	_, err = parseURI("sharepoint://?tenant_id=t")
 	require.Error(t, err)


### PR DESCRIPTION
Adds a `sharepoint` source that reads Excel and CSV files from a SharePoint Online document library through the Microsoft Graph API.

A connection points at a single site, and the source table is the path to a file within that site's document library, optionally followed by a few hints — which sheet or sheets to read, how many rows to skip, the CSV encoding and separator, and which columns hold dates. Paths can use glob patterns to pull many files at once, and multiple Excel sheets can be stacked into one table, matched up by column name. Every row is landed as raw text along with three extra columns (`_source_file`, `_sheet_name`, `_row_idx`) that record where each row came from, so the originating file and the original row order are preserved.

Files are read in a streaming fashion, so a large multi-sheet workbook stays in the few-hundred-MB range instead of being loaded whole. Excel dates are kept as their raw serial numbers by default and only turned into ISO strings for columns named in a `date_cols` hint, which keeps the read fully streaming since it avoids per-cell style lookups. Legacy `.xls` files aren't supported and produce a clear error suggesting `.xlsx`.

Authentication is the OAuth2 client-credentials flow, so the app registration just needs read access to the site. The source supports the standard write strategies and defaults to replace. It does not do incremental extraction — each run reads the whole file or glob.

A quick example:

```
ingestr ingest \
  --source-uri 'sharepoint://?tenant_id=...&client_id=...&client_secret=...&hostname=example.sharepoint.com&site=sites/Example' \
  --source-table 'Reports/budget.xlsx#sheets=North|South,date_cols=Date' \
  --dest-uri duckdb:///out.db --dest-table raw.budget
```

I tested it end to end against a real SharePoint site loading into both Snowflake and DuckDB, comparing the output against an existing pipeline — exact parity on the simple tables and matching values on the larger multi-sheet and globbed ones. There are unit tests covering the source-table parsing, globbing, header and blank-row handling, the multi-sheet column union, date conversion, and CSV streaming, plus an integration test gated behind credentials.

A couple of things left as follow-ups: honoring the Graph `Retry-After` header when the API throttles, and parallelizing file downloads across a large glob.
