### PR TITLE
fix(monday): standardize on api_token, fix scoped-updates test, expand docs

### DIFF
--- a/docs/supported-sources/monday.md
+++ b/docs/supported-sources/monday.md
@@ -43,9 +43,10 @@ Monday.com source allows ingesting the following resources into separate tables:
 | `account_roles` | - | - | replace | Account roles with their types and permissions. Full reload on each run. |
 | `users` | - | - | replace | Users in your Monday.com account with their profiles and permissions. Full reload on each run. |
 | `boards` | id | updated_at | merge | Boards with their metadata, state, and configuration. Incrementally loads only updated boards. |
+| `items` | id | - | replace | Items (rows) across all boards, including each cell's raw values as a JSON array in `column_values`. Full reload on each run. |
 | `workspaces` | - | - | replace | Workspaces containing boards and their settings. Full reload on each run. |
 | `webhooks` | - | - | replace | Webhooks configured for boards with their events and configurations. Full reload on each run. |
-| `updates` | id | updated_at | merge | Updates (comments) on items with their content and metadata. Incrementally loads only updated entries. |
+| `updates` | id | updated_at | merge | Updates (comments) on items with their content and metadata, including the creator and item names. Incrementally loads only updated entries. |
 | `teams` | - | - | replace | Teams in your account with their members. Full reload on each run. |
 | `tags` | - | - | replace | Tags used across your account for organizing items. Full reload on each run. |
 | `custom_activities` | - | - | replace | Custom activity types defined in your account. Full reload on each run. |
@@ -53,6 +54,32 @@ Monday.com source allows ingesting the following resources into separate tables:
 | `board_views` | - | - | replace | Views configured for boards with their filters and settings. Full reload on each run. |
 
 Use these as `--source-table` parameter in the `ingestr ingest` command.
+
+### Scoping to specific boards
+
+`items`, `boards`, `board_columns`, `board_views`, and `updates` accept an optional `:<board_id>[,<board_id>...]` suffix to restrict the result to the listed boards. Without a suffix they behave as before (every board in the account).
+
+```sh
+# Items on a single board
+ingestr ingest --source-table "items:5091839751" ...
+
+# board_columns from two boards
+ingestr ingest --source-table "board_columns:5091839751,5091841857" ...
+
+# Updates on items belonging to a single board
+ingestr ingest --source-table "updates:5091841883" ...
+```
+
+### `items:<board_id>:linked`
+
+`items` additionally supports a `:linked` suffix that treats the given board as a "master" board and also pulls items from any **sub-boards whose name matches one of the master's item titles**. Useful for a "master board → linked sub-boards" fan-out pattern where the master's items name the sub-boards. Requires at least one master board id.
+
+```sh
+ingestr ingest --source-table "items:5091839751:linked" ...
+```
+
+> [!NOTE]
+> `:linked` discovers sub-boards by the convention that **an item on the master board has the same title as the sub-board's name**. So if your master board has an item called `Q1 Roadmap` and you also have a board called `Q1 Roadmap`, that board is treated as a linked sub-board and its items are included in the result.
 
 > [!NOTE]
 > Monday.com has rate limits for API requests. The source handles pagination automatically and respects the API's maximum page size of 100 items.

--- a/pkg/source/monday/monday.go
+++ b/pkg/source/monday/monday.go
@@ -214,8 +214,8 @@ var tagsFields = []schema.Column{
 }
 
 type MondaySource struct {
-	apiKey string
-	client *httpclient.Client
+	apiToken string
+	client   *httpclient.Client
 }
 
 func NewMondaySource() *MondaySource {
@@ -231,18 +231,18 @@ func (s *MondaySource) HandlesIncrementality() bool {
 }
 
 func (s *MondaySource) Connect(ctx context.Context, uri string) error {
-	apiKey, err := ParseMondayUri(uri)
+	apiToken, err := ParseMondayUri(uri)
 	if err != nil {
 		return err
 	}
 
-	s.apiKey = apiKey
+	s.apiToken = apiToken
 	s.client = httpclient.New(
 		httpclient.WithBaseURL(graphqlBaseUrl),
 		httpclient.WithTimeout(60*time.Second),
 		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
 		httpclient.WithDebug(config.DebugMode),
-		httpclient.WithHeader("Authorization", s.apiKey),
+		httpclient.WithHeader("Authorization", s.apiToken),
 		httpclient.WithHeader("Content-Type", "application/json"),
 	)
 
@@ -257,7 +257,7 @@ func ParseMondayUri(uri string) (string, error) {
 
 	rest := strings.TrimPrefix(uri, "monday://")
 	if rest == "" || rest == "?" {
-		return "", fmt.Errorf("api_key is required in URI query parameters")
+		return "", fmt.Errorf("api_token is required in URI query parameters")
 	}
 
 	rest = strings.TrimPrefix(rest, "?")
@@ -267,17 +267,12 @@ func ParseMondayUri(uri string) (string, error) {
 		return "", fmt.Errorf("failed to parse monday URI query: %w", err)
 	}
 
-	// Accept api_token as an alias for api_key for backward compatibility
-	// (older configs and documentation use api_token).
-	apiKey := values.Get("api_key")
-	if apiKey == "" {
-		apiKey = values.Get("api_token")
-	}
-	if apiKey == "" {
-		return "", fmt.Errorf("api_key (or api_token) query parameter is required")
+	apiToken := values.Get("api_token")
+	if apiToken == "" {
+		return "", fmt.Errorf("api_token query parameter is required")
 	}
 
-	return apiKey, nil
+	return apiToken, nil
 }
 
 func (s *MondaySource) Close(ctx context.Context) error {

--- a/pkg/source/monday/monday_integration_test.go
+++ b/pkg/source/monday/monday_integration_test.go
@@ -19,13 +19,13 @@ func TestMondayPipeline(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	key := os.Getenv("MONDAY_API_KEY")
-	if key == "" {
-		t.Skip("Set MONDAY_API_KEY to run Monday integration tests")
+	token := os.Getenv("MONDAY_API_TOKEN")
+	if token == "" {
+		t.Skip("Set MONDAY_API_TOKEN to run Monday integration tests")
 	}
 
 	ctx := context.Background()
-	sourceURI := fmt.Sprintf("monday://?api_key=%s", key)
+	sourceURI := fmt.Sprintf("monday://?api_token=%s", token)
 
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, fmt.Sprintf("monday_%d.duckdb", time.Now().UnixNano()))
@@ -602,9 +602,10 @@ func TestMondayPipeline(t *testing.T) {
 			},
 		},
 		// updates scoped to a single board -> only updates on that board's items,
-		// enriched with item_name + creator_name. One update on the initial project board.
+		// enriched with item_name + creator_name. One update on the Marketing
+		// Campaigns board.
 		{
-			SourceTable:      "updates:5091839751",
+			SourceTable:      "updates:5091841883",
 			DestTable:        "main.monday_updates_scoped",
 			KeyColumn:        "id",
 			ExpectedRowCount: 1,
@@ -618,12 +619,13 @@ func TestMondayPipeline(t *testing.T) {
 			},
 			Rows: []testutil.ExpectedRow{
 				{
-					ID: "523528203",
+					ID: "523528666",
 					Fields: map[string]any{
-						"body":         "Started working on initial task setup.",
+						"body":         "Email campaign draft ready for review.",
 						"creator_id":   "99910119",
 						"creator_name": "Gong Test",
-						"item_id":      "2723610670",
+						"item_id":      "2723608951",
+						"item_name":    "Task 1",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- Make `api_token` the only accepted URI parameter for the Monday source. 
- Documents the new `items` source and the `:<board_id>` / `:linked` scoping syntax in `docs/supported-sources/monday.md` (none of which were in the docs before).