### PR TITLE
[codex] Add ESPN source

### DIFF
--- a/docs/supported-sources/espn.md
+++ b/docs/supported-sources/espn.md
@@ -1,0 +1,61 @@
+# ESPN
+
+[ESPN's public site API](https://espnapi.com/) exposes unauthenticated JSON endpoints for scores, teams, standings, and news. These endpoints are unofficial and can change without notice.
+
+`ingestr` supports ESPN as a public source. The default configuration targets NFL data with `sport=football` and `league=nfl`.
+
+## URI format
+
+```plaintext
+espn://?sport=<sport-slug>&league=<league-slug>
+```
+
+URI parameters:
+
+- `sport`: ESPN sport slug. Defaults to `football`.
+- `league`: ESPN league slug. Defaults to `nfl`.
+- `dates`: Optional scoreboard date or date range, such as `20260910` or `20260910-20260912`.
+- `season`: Optional season year passed to scoreboard and standings requests.
+- `limit`: Optional request limit for scoreboard and news. Defaults to `100`.
+- `base_url`: Overrides the ESPN API base URL. Defaults to `https://site.api.espn.com`.
+
+## Example
+
+Load NFL scoreboard events into DuckDB:
+
+```sh
+ingestr ingest \
+  --source-uri 'espn://?sport=football&league=nfl&dates=20260910-20260912' \
+  --source-table 'events' \
+  --dest-uri 'duckdb:///espn.duckdb' \
+  --dest-table 'sports.events'
+```
+
+Load NBA teams:
+
+```sh
+ingestr ingest \
+  --source-uri 'espn://?sport=basketball&league=nba' \
+  --source-table 'teams' \
+  --dest-uri 'duckdb:///espn.duckdb' \
+  --dest-table 'sports.nba_teams'
+```
+
+## Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| --- | --- | --- | --- | --- |
+| `teams` | `id` | - | replace | Loads teams from `/apis/site/v2/sports/{sport}/{league}/teams`. |
+| `scoreboard` | `id` | - | replace | Loads flattened scoreboard event rows and preserves each raw event as JSON. |
+| `events` | `id` | - | replace | Alias-shaped event table for scoreboard events. |
+| `competitors` | `event_id`, `competition_id`, `team_id` | - | replace | Fans out each scoreboard event into one row per competitor/team. |
+| `standings` | `league_id`, `group_id`, `season`, `team_id` | - | replace | Loads standings from `/apis/v2/sports/{sport}/{league}/standings`. |
+| `news` | `id` | - | replace | Loads latest league news articles from `/apis/site/v2/sports/{sport}/{league}/news`. |
+
+Use these as the `--source-table` parameter in the `ingestr ingest` command.
+
+## Notes
+
+- ESPN does not require an API key for these public endpoints.
+- `--interval-start` and `--interval-end` are converted to ESPN scoreboard `dates` when the URI does not include `dates`.
+- Nested ESPN objects are preserved as JSON columns while common IDs, names, scores, status, standings, and article fields are exposed as typed columns.

--- a/docs/supported-sources/espn.md
+++ b/docs/supported-sources/espn.md
@@ -52,10 +52,3 @@ ingestr ingest \
 | `news` | `id` | - | `merge` | Loads latest league news articles from `/apis/site/v2/sports/{sport}/{league}/news`. Accumulates over runs. |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command. Pass `--incremental-strategy` to override the default for any table.
-
-## Notes
-
-- ESPN does not require an API key for these public endpoints.
-- The source preserves the raw ESPN payload — nested objects come through as JSON columns and scalar fields are typed by schema inference. Column shapes vary across sports and leagues; for example, NFL events expose `week.number` while soccer events do not.
-- For `scoreboard` and `competitors`, `--interval-start` and `--interval-end` are converted to ESPN's `dates` query parameter when the URI does not already include `dates`. The source declares that it handles its own incrementality so the pipeline does not attempt to filter again.
-- For `competitors` and `standings`, the source adds top-level `event_id` / `competition_id` / `team_id` / `league_id` / `group_id` / `season` fields so the composite primary keys are addressable directly.

--- a/docs/supported-sources/espn.md
+++ b/docs/supported-sources/espn.md
@@ -2,7 +2,7 @@
 
 ESPN exposes a set of unauthenticated JSON endpoints at `site.api.espn.com` that cover scores, teams, standings, and news. These endpoints are unofficial and can change without notice.
 
-`ingestr` supports ESPN as a public source. The default configuration targets NFL data with `sport=football` and `league=nfl`.
+`ingestr` supports ESPN as a public source. No authentication is required. The default configuration targets NFL data with `sport=football` and `league=nfl`.
 
 ## URI format
 

--- a/docs/supported-sources/espn.md
+++ b/docs/supported-sources/espn.md
@@ -1,6 +1,6 @@
 # ESPN
 
-[ESPN's public site API](https://espnapi.com/) exposes unauthenticated JSON endpoints for scores, teams, standings, and news. These endpoints are unofficial and can change without notice.
+ESPN exposes a set of unauthenticated JSON endpoints at `site.api.espn.com` that cover scores, teams, standings, and news. These endpoints are unofficial and can change without notice.
 
 `ingestr` supports ESPN as a public source. The default configuration targets NFL data with `sport=football` and `league=nfl`.
 
@@ -26,9 +26,9 @@ Load NFL scoreboard events into DuckDB:
 ```sh
 ingestr ingest \
   --source-uri 'espn://?sport=football&league=nfl&dates=20260910-20260912' \
-  --source-table 'events' \
+  --source-table 'scoreboard' \
   --dest-uri 'duckdb:///espn.duckdb' \
-  --dest-table 'sports.events'
+  --dest-table 'sports.scoreboard'
 ```
 
 Load NBA teams:
@@ -43,19 +43,19 @@ ingestr ingest \
 
 ## Tables
 
-| Table | PK | Inc Key | Inc Strategy | Details |
+| Table | PK | Inc Key | Default Strategy | Details |
 | --- | --- | --- | --- | --- |
-| `teams` | `id` | - | replace | Loads teams from `/apis/site/v2/sports/{sport}/{league}/teams`. |
-| `scoreboard` | `id` | - | replace | Loads flattened scoreboard event rows and preserves each raw event as JSON. |
-| `events` | `id` | - | replace | Alias-shaped event table for scoreboard events. |
-| `competitors` | `event_id`, `competition_id`, `team_id` | - | replace | Fans out each scoreboard event into one row per competitor/team. |
-| `standings` | `league_id`, `group_id`, `season`, `team_id` | - | replace | Loads standings from `/apis/v2/sports/{sport}/{league}/standings`. |
-| `news` | `id` | - | replace | Loads latest league news articles from `/apis/site/v2/sports/{sport}/{league}/news`. |
+| `teams` | `id` | - | `replace` | Loads teams from `/apis/site/v2/sports/{sport}/{league}/teams`. Roster snapshot. |
+| `scoreboard` | `id` | - | `merge` | Loads scoreboard events from `/apis/site/v2/sports/{sport}/{league}/scoreboard`. Use `merge` to accumulate events across interval runs. |
+| `competitors` | `event_id`, `competition_id`, `team_id` | - | `merge` | Fans out each scoreboard event into one row per competitor/team. |
+| `standings` | `league_id`, `group_id`, `season`, `team_id` | - | `replace` | Loads standings from `/apis/v2/sports/{sport}/{league}/standings`. Latest snapshot for the given season. |
+| `news` | `id` | - | `merge` | Loads latest league news articles from `/apis/site/v2/sports/{sport}/{league}/news`. Accumulates over runs. |
 
-Use these as the `--source-table` parameter in the `ingestr ingest` command.
+Use these as the `--source-table` parameter in the `ingestr ingest` command. Pass `--incremental-strategy` to override the default for any table.
 
 ## Notes
 
 - ESPN does not require an API key for these public endpoints.
-- `--interval-start` and `--interval-end` are converted to ESPN scoreboard `dates` when the URI does not include `dates`.
-- Nested ESPN objects are preserved as JSON columns while common IDs, names, scores, status, standings, and article fields are exposed as typed columns.
+- The source preserves the raw ESPN payload — nested objects come through as JSON columns and scalar fields are typed by schema inference. Column shapes vary across sports and leagues; for example, NFL events expose `week.number` while soccer events do not.
+- For `scoreboard` and `competitors`, `--interval-start` and `--interval-end` are converted to ESPN's `dates` query parameter when the URI does not already include `dates`. The source declares that it handles its own incrementality so the pipeline does not attempt to filter again.
+- For `competitors` and `standings`, the source adds top-level `event_id` / `competition_id` / `team_id` / `league_id` / `group_id` / `season` fields so the composite primary keys are addressable directly.

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -99,6 +99,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [API-Football](/supported-sources/api-football.md)
 - [BallDontLie FIFA](/supported-sources/balldontlie-fifa.md)
 - [Chess.com](/supported-sources/chess.md)
+- [ESPN](/supported-sources/espn.md)
 - [football-data.org](/supported-sources/football-data-org.md)
 - [Frankfurter](/supported-sources/frankfurter.md)
 - [Internet Society Pulse](/supported-sources/isoc-pulse.md)

--- a/pkg/source/espn/espn.go
+++ b/pkg/source/espn/espn.go
@@ -1,0 +1,889 @@
+package espn
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	defaultBaseURL = "https://site.api.espn.com"
+	defaultSport   = "football"
+	defaultLeague  = "nfl"
+	defaultLimit   = 100
+)
+
+var supportedTables = []string{"teams", "scoreboard", "events", "competitors", "standings", "news"}
+
+type tableConfig struct {
+	columns     []schema.Column
+	primaryKeys []string
+	fetch       func(context.Context, source.ReadOptions) ([]map[string]interface{}, error)
+}
+
+type ESPNSource struct {
+	client  *httpclient.Client
+	sport   string
+	league  string
+	dates   string
+	season  string
+	limit   int
+	baseURL string
+}
+
+func NewESPNSource() *ESPNSource {
+	return &ESPNSource{}
+}
+
+func (s *ESPNSource) Schemes() []string {
+	return []string{"espn"}
+}
+
+func (s *ESPNSource) Connect(ctx context.Context, uri string) error {
+	cfg, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.sport = cfg.sport
+	s.league = cfg.league
+	s.dates = cfg.dates
+	s.season = cfg.season
+	s.limit = cfg.limit
+	s.baseURL = cfg.baseURL
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(cfg.baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(10, 5),
+		httpclient.WithDebug(config.DebugMode),
+	)
+	return nil
+}
+
+type uriConfig struct {
+	sport   string
+	league  string
+	dates   string
+	season  string
+	limit   int
+	baseURL string
+}
+
+func parseURI(raw string) (uriConfig, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return uriConfig{}, fmt.Errorf("failed to parse espn URI: %w", err)
+	}
+	if parsed.Scheme != "espn" {
+		return uriConfig{}, fmt.Errorf("invalid espn URI: must start with espn://")
+	}
+
+	values := parsed.Query()
+	cfg := uriConfig{
+		sport:   strings.TrimSpace(values.Get("sport")),
+		league:  strings.TrimSpace(values.Get("league")),
+		dates:   strings.TrimSpace(values.Get("dates")),
+		season:  strings.TrimSpace(values.Get("season")),
+		limit:   defaultLimit,
+		baseURL: strings.TrimRight(values.Get("base_url"), "/"),
+	}
+	if cfg.sport == "" {
+		cfg.sport = defaultSport
+	}
+	if cfg.league == "" {
+		cfg.league = defaultLeague
+	}
+	if cfg.baseURL == "" {
+		cfg.baseURL = defaultBaseURL
+	}
+	if limit := values.Get("limit"); limit != "" {
+		parsedLimit, err := strconv.Atoi(limit)
+		if err != nil || parsedLimit <= 0 {
+			return uriConfig{}, fmt.Errorf("invalid espn URI: limit must be a positive integer")
+		}
+		cfg.limit = parsedLimit
+	}
+	return cfg, nil
+}
+
+func (s *ESPNSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *ESPNSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *ESPNSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tables := s.tables()
+	cfg, ok := tables[req.Name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported table: %s, supported tables are: %s", req.Name, strings.Join(supportedTables, ", "))
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:        req.Name,
+		TablePrimaryKeys: cfg.primaryKeys,
+		TableStrategy:    config.StrategyReplace,
+		KnownSchema:      true,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return &schema.TableSchema{
+				Name:        req.Name,
+				Columns:     cfg.columns,
+				PrimaryKeys: cfg.primaryKeys,
+			}, nil
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, cfg, opts)
+		},
+	}, nil
+}
+
+func (s *ESPNSource) tables() map[string]tableConfig {
+	return map[string]tableConfig{
+		"teams": {
+			primaryKeys: []string{"id"},
+			columns:     teamColumns,
+			fetch:       s.fetchTeams,
+		},
+		"scoreboard": {
+			primaryKeys: []string{"id"},
+			columns:     scoreboardColumns,
+			fetch:       s.fetchScoreboard,
+		},
+		"events": {
+			primaryKeys: []string{"id"},
+			columns:     eventColumns,
+			fetch:       s.fetchScoreboard,
+		},
+		"competitors": {
+			primaryKeys: []string{"event_id", "competition_id", "team_id"},
+			columns:     competitorColumns,
+			fetch:       s.fetchCompetitors,
+		},
+		"standings": {
+			primaryKeys: []string{"league_id", "group_id", "season", "team_id"},
+			columns:     standingColumns,
+			fetch:       s.fetchStandings,
+		},
+		"news": {
+			primaryKeys: []string{"id"},
+			columns:     newsColumns,
+			fetch:       s.fetchNews,
+		},
+	}
+}
+
+func (s *ESPNSource) read(ctx context.Context, cfg tableConfig, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 1)
+
+	go func() {
+		defer close(results)
+
+		items, err := cfg.fetch(ctx, opts)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+			return
+		}
+		items = selectColumns(items, cfg.columns)
+
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cfg.columns, opts.ExcludeColumns)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert espn data to Arrow: %w", err)}
+			return
+		}
+		results <- source.RecordBatchResult{Batch: record}
+	}()
+
+	return results, nil
+}
+
+func (s *ESPNSource) fetchTeams(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+	payload, err := s.get(ctx, sitePath(s.sport, s.league, "teams"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []map[string]interface{}
+	for _, sport := range interfaceSlice(payload["sports"]) {
+		sportObj, ok := sport.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, league := range interfaceSlice(sportObj["leagues"]) {
+			leagueObj, ok := league.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, rawTeam := range interfaceSlice(leagueObj["teams"]) {
+				teamItem, ok := rawTeam.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				out = append(out, flattenTeam(nestedMap(teamItem, "team")))
+				if reachedLimit(out, opts) {
+					return out, nil
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *ESPNSource) fetchScoreboard(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+	payload, err := s.fetchScoreboardPayload(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	events, err := extractEvents(payload)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]interface{}, 0, len(events))
+	for _, event := range events {
+		out = append(out, flattenEvent(event))
+		if reachedLimit(out, opts) {
+			return out, nil
+		}
+	}
+	return out, nil
+}
+
+func (s *ESPNSource) fetchCompetitors(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+	payload, err := s.fetchScoreboardPayload(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	events, err := extractEvents(payload)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]interface{}, 0)
+	for _, event := range events {
+		for _, competition := range interfaceSlice(event["competitions"]) {
+			competitionObj, ok := competition.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, competitor := range interfaceSlice(competitionObj["competitors"]) {
+				competitorObj, ok := competitor.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				out = append(out, flattenCompetitor(event, competitionObj, competitorObj))
+				if reachedLimit(out, opts) {
+					return out, nil
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *ESPNSource) fetchStandings(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+	params := map[string]string{}
+	if s.season != "" {
+		params["season"] = s.season
+	}
+	payload, err := s.get(ctx, fmt.Sprintf("/apis/v2/sports/%s/%s/standings", s.sport, s.league), params)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []map[string]interface{}
+	walkStandingsGroup(payload, payload, &out, opts)
+	return out, nil
+}
+
+func (s *ESPNSource) fetchNews(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+	limit := s.queryLimit(opts)
+	payload, err := s.get(ctx, sitePath(s.sport, s.league, "news"), map[string]string{"limit": strconv.Itoa(limit)})
+	if err != nil {
+		return nil, err
+	}
+
+	var out []map[string]interface{}
+	for _, rawArticle := range interfaceSlice(payload["articles"]) {
+		article, ok := rawArticle.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		out = append(out, flattenArticle(article))
+		if reachedLimit(out, opts) {
+			return out, nil
+		}
+	}
+	return out, nil
+}
+
+func (s *ESPNSource) fetchScoreboardPayload(ctx context.Context, opts source.ReadOptions) (map[string]interface{}, error) {
+	params := map[string]string{"limit": strconv.Itoa(s.queryLimit(opts))}
+	if dates := s.scoreboardDates(opts); dates != "" {
+		params["dates"] = dates
+	}
+	if s.season != "" {
+		params["season"] = s.season
+	}
+	return s.get(ctx, sitePath(s.sport, s.league, "scoreboard"), params)
+}
+
+func (s *ESPNSource) scoreboardDates(opts source.ReadOptions) string {
+	if s.dates != "" {
+		return s.dates
+	}
+	if opts.IntervalStart == nil && opts.IntervalEnd == nil {
+		return ""
+	}
+	if opts.IntervalStart != nil && opts.IntervalEnd != nil {
+		return opts.IntervalStart.UTC().Format("20060102") + "-" + opts.IntervalEnd.UTC().Format("20060102")
+	}
+	if opts.IntervalStart != nil {
+		return opts.IntervalStart.UTC().Format("20060102")
+	}
+	return opts.IntervalEnd.UTC().Format("20060102")
+}
+
+func (s *ESPNSource) queryLimit(opts source.ReadOptions) int {
+	if opts.Limit > 0 && opts.Limit < s.limit {
+		return opts.Limit
+	}
+	return s.limit
+}
+
+func (s *ESPNSource) get(ctx context.Context, endpoint string, params map[string]string) (map[string]interface{}, error) {
+	if s.client == nil {
+		return nil, fmt.Errorf("espn source is not connected")
+	}
+
+	var payload map[string]interface{}
+	req := s.client.R(ctx).SetResult(&payload)
+	for key, value := range params {
+		if value != "" {
+			req.SetQueryParam(key, value)
+		}
+	}
+
+	resp, err := req.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch espn endpoint %s: %w", endpoint, err)
+	}
+	if err := checkResponse(endpoint, resp); err != nil {
+		return nil, err
+	}
+	if len(payload) == 0 {
+		if err := resp.JSON(&payload); err != nil {
+			return nil, fmt.Errorf("malformed espn response from %s: %w", endpoint, err)
+		}
+	}
+	return normalizeMap(payload), nil
+}
+
+func checkResponse(endpoint string, resp *httpclient.Response) error {
+	if resp.IsSuccess() {
+		return nil
+	}
+	switch resp.StatusCode() {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("espn API access failed for %s (status %d)", endpoint, resp.StatusCode())
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("espn API rate limit exceeded for %s (status 429)", endpoint)
+	default:
+		return fmt.Errorf("espn API error for %s (status %d): %s", endpoint, resp.StatusCode(), resp.String())
+	}
+}
+
+func sitePath(sport, league, resource string) string {
+	return fmt.Sprintf("/apis/site/v2/sports/%s/%s/%s", sport, league, resource)
+}
+
+func extractEvents(payload map[string]interface{}) ([]map[string]interface{}, error) {
+	raw := interfaceSlice(payload["events"])
+	if raw == nil {
+		return nil, fmt.Errorf("missing events array")
+	}
+	events := make([]map[string]interface{}, 0, len(raw))
+	for i, rawEvent := range raw {
+		event, ok := rawEvent.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("event item %d is not an object", i)
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func flattenTeam(team map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":                 team["id"],
+		"uid":                team["uid"],
+		"slug":               team["slug"],
+		"abbreviation":       team["abbreviation"],
+		"name":               team["name"],
+		"display_name":       team["displayName"],
+		"short_display_name": team["shortDisplayName"],
+		"location":           team["location"],
+		"nickname":           team["nickname"],
+		"color":              team["color"],
+		"alternate_color":    team["alternateColor"],
+		"is_active":          team["isActive"],
+		"is_all_star":        team["isAllStar"],
+		"logo":               teamLogo(team),
+		"links":              team["links"],
+		"logos":              team["logos"],
+		"team":               team,
+	}
+	return normalizeMap(out)
+}
+
+func flattenEvent(event map[string]interface{}) map[string]interface{} {
+	competition := firstMap(event["competitions"])
+	venue := nestedMap(competition, "venue")
+	statusType := nestedMap(nestedMap(competition, "status"), "type")
+	home := findCompetitor(competition, "home")
+	away := findCompetitor(competition, "away")
+	homeTeam := nestedMap(home, "team")
+	awayTeam := nestedMap(away, "team")
+	out := map[string]interface{}{
+		"id":                     event["id"],
+		"uid":                    event["uid"],
+		"date":                   event["date"],
+		"name":                   event["name"],
+		"short_name":             event["shortName"],
+		"season_year":            nestedMap(event, "season")["year"],
+		"season_type":            nestedMap(event, "season")["type"],
+		"week_number":            nestedMap(event, "week")["number"],
+		"status_type_id":         statusType["id"],
+		"status_type_name":       statusType["name"],
+		"status_type_state":      statusType["state"],
+		"status_type_completed":  statusType["completed"],
+		"venue_id":               venue["id"],
+		"venue_name":             venue["fullName"],
+		"home_team_id":           homeTeam["id"],
+		"home_team_name":         homeTeam["displayName"],
+		"home_team_abbreviation": homeTeam["abbreviation"],
+		"home_score":             home["score"],
+		"away_team_id":           awayTeam["id"],
+		"away_team_name":         awayTeam["displayName"],
+		"away_team_abbreviation": awayTeam["abbreviation"],
+		"away_score":             away["score"],
+		"competitions":           event["competitions"],
+		"event":                  event,
+	}
+	return normalizeMap(out)
+}
+
+func flattenCompetitor(event, competition, competitor map[string]interface{}) map[string]interface{} {
+	team := nestedMap(competitor, "team")
+	out := map[string]interface{}{
+		"event_id":                event["id"],
+		"competition_id":          competition["id"],
+		"team_id":                 competitor["id"],
+		"uid":                     competitor["uid"],
+		"type":                    competitor["type"],
+		"order":                   competitor["order"],
+		"home_away":               competitor["homeAway"],
+		"winner":                  competitor["winner"],
+		"score":                   competitor["score"],
+		"curated_rank":            competitor["curatedRank"],
+		"team_uid":                team["uid"],
+		"team_location":           team["location"],
+		"team_name":               team["name"],
+		"team_display_name":       team["displayName"],
+		"team_short_display_name": team["shortDisplayName"],
+		"team_abbreviation":       team["abbreviation"],
+		"team_color":              team["color"],
+		"team_alternate_color":    team["alternateColor"],
+		"team_logo":               teamLogo(team),
+		"records":                 competitor["records"],
+		"statistics":              competitor["statistics"],
+		"linescores":              competitor["linescores"],
+		"team":                    team,
+		"competitor":              competitor,
+	}
+	return normalizeMap(out)
+}
+
+func flattenStanding(root, group, entry map[string]interface{}) map[string]interface{} {
+	team := nestedMap(entry, "team")
+	stats := statsByName(interfaceSlice(entry["stats"]))
+	out := map[string]interface{}{
+		"league_id":           root["id"],
+		"league_name":         root["name"],
+		"league_abbreviation": root["abbreviation"],
+		"group_id":            group["id"],
+		"group_name":          group["name"],
+		"group_abbreviation":  group["abbreviation"],
+		"season":              nestedMap(group, "standings")["season"],
+		"season_type":         nestedMap(group, "standings")["seasonType"],
+		"team_id":             team["id"],
+		"team_uid":            team["uid"],
+		"team_name":           team["displayName"],
+		"team_abbreviation":   team["abbreviation"],
+		"rank":                statValue(stats, "rank"),
+		"playoff_seed":        statValue(stats, "playoffSeed"),
+		"wins":                statValue(stats, "wins"),
+		"losses":              statValue(stats, "losses"),
+		"ties":                statValue(stats, "ties"),
+		"win_percent":         statValue(stats, "winPercent"),
+		"points_for":          statValue(stats, "pointsFor"),
+		"points_against":      statValue(stats, "pointsAgainst"),
+		"point_differential":  statValue(stats, "pointDifferential"),
+		"games_behind":        statValue(stats, "gamesBehind"),
+		"streak":              statDisplay(stats, "streak"),
+		"overall_record":      statDisplay(stats, "overall"),
+		"stats":               entry["stats"],
+		"team":                team,
+		"standings_group":     group,
+	}
+	return normalizeMap(out)
+}
+
+func flattenArticle(article map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":            article["id"],
+		"now_id":        article["nowId"],
+		"content_key":   article["contentKey"],
+		"type":          article["type"],
+		"headline":      article["headline"],
+		"description":   article["description"],
+		"published":     article["published"],
+		"last_modified": article["lastModified"],
+		"premium":       article["premium"],
+		"byline":        article["byline"],
+		"link":          nestedMap(nestedMap(article, "links"), "web")["href"],
+		"image":         firstImageURL(article["images"]),
+		"categories":    article["categories"],
+		"images":        article["images"],
+		"article":       article,
+	}
+	return normalizeMap(out)
+}
+
+func walkStandingsGroup(root, group map[string]interface{}, out *[]map[string]interface{}, opts source.ReadOptions) {
+	standings := nestedMap(group, "standings")
+	for _, rawEntry := range interfaceSlice(standings["entries"]) {
+		if reachedLimit(*out, opts) {
+			return
+		}
+		entry, ok := rawEntry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		*out = append(*out, flattenStanding(root, group, entry))
+	}
+	for _, rawChild := range interfaceSlice(group["children"]) {
+		if reachedLimit(*out, opts) {
+			return
+		}
+		child, ok := rawChild.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		walkStandingsGroup(root, child, out, opts)
+	}
+}
+
+func findCompetitor(competition map[string]interface{}, homeAway string) map[string]interface{} {
+	for _, rawCompetitor := range interfaceSlice(competition["competitors"]) {
+		competitor, ok := rawCompetitor.(map[string]interface{})
+		if ok && valueString(competitor["homeAway"]) == homeAway {
+			return competitor
+		}
+	}
+	return map[string]interface{}{}
+}
+
+func statsByName(raw []interface{}) map[string]map[string]interface{} {
+	out := make(map[string]map[string]interface{}, len(raw))
+	for _, rawStat := range raw {
+		stat, ok := rawStat.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name := valueString(stat["name"])
+		if name == "" {
+			name = valueString(stat["type"])
+		}
+		if name != "" {
+			out[name] = stat
+		}
+	}
+	return out
+}
+
+func statValue(stats map[string]map[string]interface{}, name string) interface{} {
+	if stat, ok := stats[name]; ok {
+		return stat["value"]
+	}
+	return nil
+}
+
+func statDisplay(stats map[string]map[string]interface{}, name string) interface{} {
+	if stat, ok := stats[name]; ok {
+		if display := stat["displayValue"]; display != nil {
+			return display
+		}
+		return stat["summary"]
+	}
+	return nil
+}
+
+func teamLogo(team map[string]interface{}) interface{} {
+	if logo := team["logo"]; logo != nil {
+		return logo
+	}
+	logos := interfaceSlice(team["logos"])
+	if len(logos) == 0 {
+		return nil
+	}
+	first, ok := logos[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return first["href"]
+}
+
+func firstImageURL(value interface{}) interface{} {
+	image := firstMap(value)
+	if image == nil {
+		return nil
+	}
+	if url := image["url"]; url != nil {
+		return url
+	}
+	return image["href"]
+}
+
+func firstMap(value interface{}) map[string]interface{} {
+	items := interfaceSlice(value)
+	if len(items) == 0 {
+		return map[string]interface{}{}
+	}
+	first, ok := items[0].(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}
+	}
+	return first
+}
+
+func nestedMap(item map[string]interface{}, key string) map[string]interface{} {
+	raw, ok := item[key].(map[string]interface{})
+	if !ok || raw == nil {
+		return map[string]interface{}{}
+	}
+	return raw
+}
+
+func interfaceSlice(value interface{}) []interface{} {
+	raw, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+	return raw
+}
+
+func normalizeMap(item map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(item))
+	for key, value := range item {
+		out[key] = normalizeValue(value)
+	}
+	return out
+}
+
+func normalizeValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case string:
+		if strings.EqualFold(strings.TrimSpace(v), "null") {
+			return nil
+		}
+		return v
+	case map[string]interface{}:
+		return normalizeMap(v)
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, item := range v {
+			out[i] = normalizeValue(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func valueString(value interface{}) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case float64:
+		return strconv.FormatInt(int64(v), 10)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func reachedLimit(items []map[string]interface{}, opts source.ReadOptions) bool {
+	return opts.Limit > 0 && len(items) >= opts.Limit
+}
+
+func selectColumns(items []map[string]interface{}, columns []schema.Column) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		selected := make(map[string]interface{}, len(columns))
+		for _, column := range columns {
+			if value, ok := item[column.Name]; ok {
+				selected[column.Name] = value
+			}
+		}
+		out = append(out, selected)
+	}
+	return out
+}
+
+func col(name string, dt schema.DataType) schema.Column {
+	return schema.Column{Name: name, DataType: dt, Nullable: true}
+}
+
+var teamColumns = []schema.Column{
+	col("id", schema.TypeInt64),
+	col("uid", schema.TypeString),
+	col("slug", schema.TypeString),
+	col("abbreviation", schema.TypeString),
+	col("name", schema.TypeString),
+	col("display_name", schema.TypeString),
+	col("short_display_name", schema.TypeString),
+	col("location", schema.TypeString),
+	col("nickname", schema.TypeString),
+	col("color", schema.TypeString),
+	col("alternate_color", schema.TypeString),
+	col("is_active", schema.TypeBoolean),
+	col("is_all_star", schema.TypeBoolean),
+	col("logo", schema.TypeString),
+	col("links", schema.TypeJSON),
+	col("logos", schema.TypeJSON),
+	col("team", schema.TypeJSON),
+}
+
+var scoreboardColumns = []schema.Column{
+	col("id", schema.TypeInt64),
+	col("uid", schema.TypeString),
+	col("date", schema.TypeTimestampTZ),
+	col("name", schema.TypeString),
+	col("short_name", schema.TypeString),
+	col("season_year", schema.TypeInt64),
+	col("season_type", schema.TypeInt64),
+	col("week_number", schema.TypeInt64),
+	col("status_type_id", schema.TypeString),
+	col("status_type_name", schema.TypeString),
+	col("status_type_state", schema.TypeString),
+	col("status_type_completed", schema.TypeBoolean),
+	col("venue_id", schema.TypeInt64),
+	col("venue_name", schema.TypeString),
+	col("home_team_id", schema.TypeInt64),
+	col("home_team_name", schema.TypeString),
+	col("home_team_abbreviation", schema.TypeString),
+	col("home_score", schema.TypeInt64),
+	col("away_team_id", schema.TypeInt64),
+	col("away_team_name", schema.TypeString),
+	col("away_team_abbreviation", schema.TypeString),
+	col("away_score", schema.TypeInt64),
+	col("competitions", schema.TypeJSON),
+	col("event", schema.TypeJSON),
+}
+
+var eventColumns = scoreboardColumns
+
+var competitorColumns = []schema.Column{
+	col("event_id", schema.TypeInt64),
+	col("competition_id", schema.TypeInt64),
+	col("team_id", schema.TypeInt64),
+	col("uid", schema.TypeString),
+	col("type", schema.TypeString),
+	col("order", schema.TypeInt64),
+	col("home_away", schema.TypeString),
+	col("winner", schema.TypeBoolean),
+	col("score", schema.TypeInt64),
+	col("curated_rank", schema.TypeInt64),
+	col("team_uid", schema.TypeString),
+	col("team_location", schema.TypeString),
+	col("team_name", schema.TypeString),
+	col("team_display_name", schema.TypeString),
+	col("team_short_display_name", schema.TypeString),
+	col("team_abbreviation", schema.TypeString),
+	col("team_color", schema.TypeString),
+	col("team_alternate_color", schema.TypeString),
+	col("team_logo", schema.TypeString),
+	col("records", schema.TypeJSON),
+	col("statistics", schema.TypeJSON),
+	col("linescores", schema.TypeJSON),
+	col("team", schema.TypeJSON),
+	col("competitor", schema.TypeJSON),
+}
+
+var standingColumns = []schema.Column{
+	col("league_id", schema.TypeInt64),
+	col("league_name", schema.TypeString),
+	col("league_abbreviation", schema.TypeString),
+	col("group_id", schema.TypeInt64),
+	col("group_name", schema.TypeString),
+	col("group_abbreviation", schema.TypeString),
+	col("season", schema.TypeInt64),
+	col("season_type", schema.TypeInt64),
+	col("team_id", schema.TypeInt64),
+	col("team_uid", schema.TypeString),
+	col("team_name", schema.TypeString),
+	col("team_abbreviation", schema.TypeString),
+	col("rank", schema.TypeFloat64),
+	col("playoff_seed", schema.TypeFloat64),
+	col("wins", schema.TypeFloat64),
+	col("losses", schema.TypeFloat64),
+	col("ties", schema.TypeFloat64),
+	col("win_percent", schema.TypeFloat64),
+	col("points_for", schema.TypeFloat64),
+	col("points_against", schema.TypeFloat64),
+	col("point_differential", schema.TypeFloat64),
+	col("games_behind", schema.TypeFloat64),
+	col("streak", schema.TypeString),
+	col("overall_record", schema.TypeString),
+	col("stats", schema.TypeJSON),
+	col("team", schema.TypeJSON),
+	col("standings_group", schema.TypeJSON),
+}
+
+var newsColumns = []schema.Column{
+	col("id", schema.TypeInt64),
+	col("now_id", schema.TypeString),
+	col("content_key", schema.TypeString),
+	col("type", schema.TypeString),
+	col("headline", schema.TypeString),
+	col("description", schema.TypeString),
+	col("published", schema.TypeTimestampTZ),
+	col("last_modified", schema.TypeTimestampTZ),
+	col("premium", schema.TypeBoolean),
+	col("byline", schema.TypeString),
+	col("link", schema.TypeString),
+	col("image", schema.TypeString),
+	col("categories", schema.TypeJSON),
+	col("images", schema.TypeJSON),
+	col("article", schema.TypeJSON),
+}

--- a/pkg/source/espn/espn.go
+++ b/pkg/source/espn/espn.go
@@ -387,7 +387,7 @@ func (s *ESPNSource) get(ctx context.Context, endpoint string, params map[string
 			return nil, fmt.Errorf("malformed espn response from %s: %w", endpoint, err)
 		}
 	}
-	return normalizeMap(payload), nil
+	return payload, nil
 }
 
 func checkResponse(endpoint string, resp *httpclient.Response) error {
@@ -476,34 +476,6 @@ func interfaceSlice(value interface{}) []interface{} {
 		return nil
 	}
 	return raw
-}
-
-func normalizeMap(item map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(item))
-	for key, value := range item {
-		out[key] = normalizeValue(value)
-	}
-	return out
-}
-
-func normalizeValue(value interface{}) interface{} {
-	switch v := value.(type) {
-	case string:
-		if strings.EqualFold(strings.TrimSpace(v), "null") {
-			return nil
-		}
-		return v
-	case map[string]interface{}:
-		return normalizeMap(v)
-	case []interface{}:
-		out := make([]interface{}, len(v))
-		for i, item := range v {
-			out[i] = normalizeValue(item)
-		}
-		return out
-	default:
-		return value
-	}
 }
 
 func reachedLimit(items []map[string]interface{}, opts source.ReadOptions) bool {

--- a/pkg/source/espn/espn.go
+++ b/pkg/source/espn/espn.go
@@ -408,11 +408,12 @@ func sitePath(sport, league, resource string) string {
 	return fmt.Sprintf("/apis/site/v2/sports/%s/%s/%s", sport, league, resource)
 }
 
+// extractEvents pulls the events array out of a scoreboard payload. A missing
+// or null `events` key is treated as zero results, not an error — ESPN omits the
+// key for off-season days, leagues without scheduled games, or alternate
+// payload shapes, and callers should produce an empty batch in those cases.
 func extractEvents(payload map[string]interface{}) ([]map[string]interface{}, error) {
 	raw := interfaceSlice(payload["events"])
-	if raw == nil {
-		return nil, fmt.Errorf("missing events array")
-	}
 	events := make([]map[string]interface{}, 0, len(raw))
 	for i, rawEvent := range raw {
 		event, ok := rawEvent.(map[string]interface{})

--- a/pkg/source/espn/espn.go
+++ b/pkg/source/espn/espn.go
@@ -23,11 +23,11 @@ const (
 	defaultLimit   = 100
 )
 
-var supportedTables = []string{"teams", "scoreboard", "events", "competitors", "standings", "news"}
+var supportedTables = []string{"teams", "scoreboard", "competitors", "standings", "news"}
 
 type tableConfig struct {
-	columns     []schema.Column
 	primaryKeys []string
+	strategy    config.IncrementalStrategy
 	fetch       func(context.Context, source.ReadOptions) ([]map[string]interface{}, error)
 }
 
@@ -123,8 +123,11 @@ func (s *ESPNSource) Close(ctx context.Context) error {
 	return nil
 }
 
+// HandlesIncrementality returns true because the source maps IntervalStart/End
+// onto the ESPN `dates` query parameter (see scoreboardDates) — the API itself
+// performs the time-window filtering, so the pipeline must not try to filter again.
 func (s *ESPNSource) HandlesIncrementality() bool {
-	return false
+	return true
 }
 
 func (s *ESPNSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
@@ -137,14 +140,10 @@ func (s *ESPNSource) GetTable(ctx context.Context, req source.TableRequest) (sou
 	return &source.DynamicSourceTable{
 		TableName:        req.Name,
 		TablePrimaryKeys: cfg.primaryKeys,
-		TableStrategy:    config.StrategyReplace,
-		KnownSchema:      true,
+		TableStrategy:    cfg.strategy,
+		KnownSchema:      false,
 		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
-			return &schema.TableSchema{
-				Name:        req.Name,
-				Columns:     cfg.columns,
-				PrimaryKeys: cfg.primaryKeys,
-			}, nil
+			return nil, fmt.Errorf("espn source does not have a predefined schema; schema inference is required")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 			return s.read(ctx, cfg, opts)
@@ -156,32 +155,27 @@ func (s *ESPNSource) tables() map[string]tableConfig {
 	return map[string]tableConfig{
 		"teams": {
 			primaryKeys: []string{"id"},
-			columns:     teamColumns,
+			strategy:    config.StrategyReplace,
 			fetch:       s.fetchTeams,
 		},
 		"scoreboard": {
 			primaryKeys: []string{"id"},
-			columns:     scoreboardColumns,
-			fetch:       s.fetchScoreboard,
-		},
-		"events": {
-			primaryKeys: []string{"id"},
-			columns:     eventColumns,
+			strategy:    config.StrategyMerge,
 			fetch:       s.fetchScoreboard,
 		},
 		"competitors": {
 			primaryKeys: []string{"event_id", "competition_id", "team_id"},
-			columns:     competitorColumns,
+			strategy:    config.StrategyMerge,
 			fetch:       s.fetchCompetitors,
 		},
 		"standings": {
 			primaryKeys: []string{"league_id", "group_id", "season", "team_id"},
-			columns:     standingColumns,
+			strategy:    config.StrategyReplace,
 			fetch:       s.fetchStandings,
 		},
 		"news": {
 			primaryKeys: []string{"id"},
-			columns:     newsColumns,
+			strategy:    config.StrategyMerge,
 			fetch:       s.fetchNews,
 		},
 	}
@@ -198,9 +192,8 @@ func (s *ESPNSource) read(ctx context.Context, cfg tableConfig, opts source.Read
 			results <- source.RecordBatchResult{Err: err}
 			return
 		}
-		items = selectColumns(items, cfg.columns)
 
-		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cfg.columns, opts.ExcludeColumns)
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert espn data to Arrow: %w", err)}
 			return
@@ -233,7 +226,7 @@ func (s *ESPNSource) fetchTeams(ctx context.Context, opts source.ReadOptions) ([
 				if !ok {
 					continue
 				}
-				out = append(out, flattenTeam(nestedMap(teamItem, "team")))
+				out = append(out, nestedMap(teamItem, "team"))
 				if reachedLimit(out, opts) {
 					return out, nil
 				}
@@ -255,7 +248,7 @@ func (s *ESPNSource) fetchScoreboard(ctx context.Context, opts source.ReadOption
 	}
 	out := make([]map[string]interface{}, 0, len(events))
 	for _, event := range events {
-		out = append(out, flattenEvent(event))
+		out = append(out, event)
 		if reachedLimit(out, opts) {
 			return out, nil
 		}
@@ -285,7 +278,11 @@ func (s *ESPNSource) fetchCompetitors(ctx context.Context, opts source.ReadOptio
 				if !ok {
 					continue
 				}
-				out = append(out, flattenCompetitor(event, competitionObj, competitorObj))
+				row := cloneMap(competitorObj)
+				row["event_id"] = event["id"]
+				row["competition_id"] = competitionObj["id"]
+				row["team_id"] = competitorObj["id"]
+				out = append(out, row)
 				if reachedLimit(out, opts) {
 					return out, nil
 				}
@@ -323,7 +320,7 @@ func (s *ESPNSource) fetchNews(ctx context.Context, opts source.ReadOptions) ([]
 		if !ok {
 			continue
 		}
-		out = append(out, flattenArticle(article))
+		out = append(out, article)
 		if reachedLimit(out, opts) {
 			return out, nil
 		}
@@ -427,153 +424,6 @@ func extractEvents(payload map[string]interface{}) ([]map[string]interface{}, er
 	return events, nil
 }
 
-func flattenTeam(team map[string]interface{}) map[string]interface{} {
-	out := map[string]interface{}{
-		"id":                 team["id"],
-		"uid":                team["uid"],
-		"slug":               team["slug"],
-		"abbreviation":       team["abbreviation"],
-		"name":               team["name"],
-		"display_name":       team["displayName"],
-		"short_display_name": team["shortDisplayName"],
-		"location":           team["location"],
-		"nickname":           team["nickname"],
-		"color":              team["color"],
-		"alternate_color":    team["alternateColor"],
-		"is_active":          team["isActive"],
-		"is_all_star":        team["isAllStar"],
-		"logo":               teamLogo(team),
-		"links":              team["links"],
-		"logos":              team["logos"],
-		"team":               team,
-	}
-	return normalizeMap(out)
-}
-
-func flattenEvent(event map[string]interface{}) map[string]interface{} {
-	competition := firstMap(event["competitions"])
-	venue := nestedMap(competition, "venue")
-	statusType := nestedMap(nestedMap(competition, "status"), "type")
-	home := findCompetitor(competition, "home")
-	away := findCompetitor(competition, "away")
-	homeTeam := nestedMap(home, "team")
-	awayTeam := nestedMap(away, "team")
-	out := map[string]interface{}{
-		"id":                     event["id"],
-		"uid":                    event["uid"],
-		"date":                   event["date"],
-		"name":                   event["name"],
-		"short_name":             event["shortName"],
-		"season_year":            nestedMap(event, "season")["year"],
-		"season_type":            nestedMap(event, "season")["type"],
-		"week_number":            nestedMap(event, "week")["number"],
-		"status_type_id":         statusType["id"],
-		"status_type_name":       statusType["name"],
-		"status_type_state":      statusType["state"],
-		"status_type_completed":  statusType["completed"],
-		"venue_id":               venue["id"],
-		"venue_name":             venue["fullName"],
-		"home_team_id":           homeTeam["id"],
-		"home_team_name":         homeTeam["displayName"],
-		"home_team_abbreviation": homeTeam["abbreviation"],
-		"home_score":             home["score"],
-		"away_team_id":           awayTeam["id"],
-		"away_team_name":         awayTeam["displayName"],
-		"away_team_abbreviation": awayTeam["abbreviation"],
-		"away_score":             away["score"],
-		"competitions":           event["competitions"],
-		"event":                  event,
-	}
-	return normalizeMap(out)
-}
-
-func flattenCompetitor(event, competition, competitor map[string]interface{}) map[string]interface{} {
-	team := nestedMap(competitor, "team")
-	out := map[string]interface{}{
-		"event_id":                event["id"],
-		"competition_id":          competition["id"],
-		"team_id":                 competitor["id"],
-		"uid":                     competitor["uid"],
-		"type":                    competitor["type"],
-		"order":                   competitor["order"],
-		"home_away":               competitor["homeAway"],
-		"winner":                  competitor["winner"],
-		"score":                   competitor["score"],
-		"curated_rank":            competitor["curatedRank"],
-		"team_uid":                team["uid"],
-		"team_location":           team["location"],
-		"team_name":               team["name"],
-		"team_display_name":       team["displayName"],
-		"team_short_display_name": team["shortDisplayName"],
-		"team_abbreviation":       team["abbreviation"],
-		"team_color":              team["color"],
-		"team_alternate_color":    team["alternateColor"],
-		"team_logo":               teamLogo(team),
-		"records":                 competitor["records"],
-		"statistics":              competitor["statistics"],
-		"linescores":              competitor["linescores"],
-		"team":                    team,
-		"competitor":              competitor,
-	}
-	return normalizeMap(out)
-}
-
-func flattenStanding(root, group, entry map[string]interface{}) map[string]interface{} {
-	team := nestedMap(entry, "team")
-	stats := statsByName(interfaceSlice(entry["stats"]))
-	out := map[string]interface{}{
-		"league_id":           root["id"],
-		"league_name":         root["name"],
-		"league_abbreviation": root["abbreviation"],
-		"group_id":            group["id"],
-		"group_name":          group["name"],
-		"group_abbreviation":  group["abbreviation"],
-		"season":              nestedMap(group, "standings")["season"],
-		"season_type":         nestedMap(group, "standings")["seasonType"],
-		"team_id":             team["id"],
-		"team_uid":            team["uid"],
-		"team_name":           team["displayName"],
-		"team_abbreviation":   team["abbreviation"],
-		"rank":                statValue(stats, "rank"),
-		"playoff_seed":        statValue(stats, "playoffSeed"),
-		"wins":                statValue(stats, "wins"),
-		"losses":              statValue(stats, "losses"),
-		"ties":                statValue(stats, "ties"),
-		"win_percent":         statValue(stats, "winPercent"),
-		"points_for":          statValue(stats, "pointsFor"),
-		"points_against":      statValue(stats, "pointsAgainst"),
-		"point_differential":  statValue(stats, "pointDifferential"),
-		"games_behind":        statValue(stats, "gamesBehind"),
-		"streak":              statDisplay(stats, "streak"),
-		"overall_record":      statDisplay(stats, "overall"),
-		"stats":               entry["stats"],
-		"team":                team,
-		"standings_group":     group,
-	}
-	return normalizeMap(out)
-}
-
-func flattenArticle(article map[string]interface{}) map[string]interface{} {
-	out := map[string]interface{}{
-		"id":            article["id"],
-		"now_id":        article["nowId"],
-		"content_key":   article["contentKey"],
-		"type":          article["type"],
-		"headline":      article["headline"],
-		"description":   article["description"],
-		"published":     article["published"],
-		"last_modified": article["lastModified"],
-		"premium":       article["premium"],
-		"byline":        article["byline"],
-		"link":          nestedMap(nestedMap(article, "links"), "web")["href"],
-		"image":         firstImageURL(article["images"]),
-		"categories":    article["categories"],
-		"images":        article["images"],
-		"article":       article,
-	}
-	return normalizeMap(out)
-}
-
 func walkStandingsGroup(root, group map[string]interface{}, out *[]map[string]interface{}, opts source.ReadOptions) {
 	standings := nestedMap(group, "standings")
 	for _, rawEntry := range interfaceSlice(standings["entries"]) {
@@ -584,7 +434,12 @@ func walkStandingsGroup(root, group map[string]interface{}, out *[]map[string]in
 		if !ok {
 			continue
 		}
-		*out = append(*out, flattenStanding(root, group, entry))
+		row := cloneMap(entry)
+		row["league_id"] = root["id"]
+		row["group_id"] = group["id"]
+		row["season"] = standings["season"]
+		row["team_id"] = nestedMap(entry, "team")["id"]
+		*out = append(*out, row)
 	}
 	for _, rawChild := range interfaceSlice(group["children"]) {
 		if reachedLimit(*out, opts) {
@@ -598,87 +453,12 @@ func walkStandingsGroup(root, group map[string]interface{}, out *[]map[string]in
 	}
 }
 
-func findCompetitor(competition map[string]interface{}, homeAway string) map[string]interface{} {
-	for _, rawCompetitor := range interfaceSlice(competition["competitors"]) {
-		competitor, ok := rawCompetitor.(map[string]interface{})
-		if ok && valueString(competitor["homeAway"]) == homeAway {
-			return competitor
-		}
-	}
-	return map[string]interface{}{}
-}
-
-func statsByName(raw []interface{}) map[string]map[string]interface{} {
-	out := make(map[string]map[string]interface{}, len(raw))
-	for _, rawStat := range raw {
-		stat, ok := rawStat.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		name := valueString(stat["name"])
-		if name == "" {
-			name = valueString(stat["type"])
-		}
-		if name != "" {
-			out[name] = stat
-		}
+func cloneMap(m map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		out[k] = v
 	}
 	return out
-}
-
-func statValue(stats map[string]map[string]interface{}, name string) interface{} {
-	if stat, ok := stats[name]; ok {
-		return stat["value"]
-	}
-	return nil
-}
-
-func statDisplay(stats map[string]map[string]interface{}, name string) interface{} {
-	if stat, ok := stats[name]; ok {
-		if display := stat["displayValue"]; display != nil {
-			return display
-		}
-		return stat["summary"]
-	}
-	return nil
-}
-
-func teamLogo(team map[string]interface{}) interface{} {
-	if logo := team["logo"]; logo != nil {
-		return logo
-	}
-	logos := interfaceSlice(team["logos"])
-	if len(logos) == 0 {
-		return nil
-	}
-	first, ok := logos[0].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	return first["href"]
-}
-
-func firstImageURL(value interface{}) interface{} {
-	image := firstMap(value)
-	if image == nil {
-		return nil
-	}
-	if url := image["url"]; url != nil {
-		return url
-	}
-	return image["href"]
-}
-
-func firstMap(value interface{}) map[string]interface{} {
-	items := interfaceSlice(value)
-	if len(items) == 0 {
-		return map[string]interface{}{}
-	}
-	first, ok := items[0].(map[string]interface{})
-	if !ok {
-		return map[string]interface{}{}
-	}
-	return first
 }
 
 func nestedMap(item map[string]interface{}, key string) map[string]interface{} {
@@ -725,165 +505,6 @@ func normalizeValue(value interface{}) interface{} {
 	}
 }
 
-func valueString(value interface{}) string {
-	switch v := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return v
-	case float64:
-		return strconv.FormatInt(int64(v), 10)
-	case int:
-		return strconv.Itoa(v)
-	case int64:
-		return strconv.FormatInt(v, 10)
-	default:
-		return fmt.Sprint(v)
-	}
-}
-
 func reachedLimit(items []map[string]interface{}, opts source.ReadOptions) bool {
 	return opts.Limit > 0 && len(items) >= opts.Limit
-}
-
-func selectColumns(items []map[string]interface{}, columns []schema.Column) []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(items))
-	for _, item := range items {
-		selected := make(map[string]interface{}, len(columns))
-		for _, column := range columns {
-			if value, ok := item[column.Name]; ok {
-				selected[column.Name] = value
-			}
-		}
-		out = append(out, selected)
-	}
-	return out
-}
-
-func col(name string, dt schema.DataType) schema.Column {
-	return schema.Column{Name: name, DataType: dt, Nullable: true}
-}
-
-var teamColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("uid", schema.TypeString),
-	col("slug", schema.TypeString),
-	col("abbreviation", schema.TypeString),
-	col("name", schema.TypeString),
-	col("display_name", schema.TypeString),
-	col("short_display_name", schema.TypeString),
-	col("location", schema.TypeString),
-	col("nickname", schema.TypeString),
-	col("color", schema.TypeString),
-	col("alternate_color", schema.TypeString),
-	col("is_active", schema.TypeBoolean),
-	col("is_all_star", schema.TypeBoolean),
-	col("logo", schema.TypeString),
-	col("links", schema.TypeJSON),
-	col("logos", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-}
-
-var scoreboardColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("uid", schema.TypeString),
-	col("date", schema.TypeTimestampTZ),
-	col("name", schema.TypeString),
-	col("short_name", schema.TypeString),
-	col("season_year", schema.TypeInt64),
-	col("season_type", schema.TypeInt64),
-	col("week_number", schema.TypeInt64),
-	col("status_type_id", schema.TypeString),
-	col("status_type_name", schema.TypeString),
-	col("status_type_state", schema.TypeString),
-	col("status_type_completed", schema.TypeBoolean),
-	col("venue_id", schema.TypeInt64),
-	col("venue_name", schema.TypeString),
-	col("home_team_id", schema.TypeInt64),
-	col("home_team_name", schema.TypeString),
-	col("home_team_abbreviation", schema.TypeString),
-	col("home_score", schema.TypeInt64),
-	col("away_team_id", schema.TypeInt64),
-	col("away_team_name", schema.TypeString),
-	col("away_team_abbreviation", schema.TypeString),
-	col("away_score", schema.TypeInt64),
-	col("competitions", schema.TypeJSON),
-	col("event", schema.TypeJSON),
-}
-
-var eventColumns = scoreboardColumns
-
-var competitorColumns = []schema.Column{
-	col("event_id", schema.TypeInt64),
-	col("competition_id", schema.TypeInt64),
-	col("team_id", schema.TypeInt64),
-	col("uid", schema.TypeString),
-	col("type", schema.TypeString),
-	col("order", schema.TypeInt64),
-	col("home_away", schema.TypeString),
-	col("winner", schema.TypeBoolean),
-	col("score", schema.TypeInt64),
-	col("curated_rank", schema.TypeInt64),
-	col("team_uid", schema.TypeString),
-	col("team_location", schema.TypeString),
-	col("team_name", schema.TypeString),
-	col("team_display_name", schema.TypeString),
-	col("team_short_display_name", schema.TypeString),
-	col("team_abbreviation", schema.TypeString),
-	col("team_color", schema.TypeString),
-	col("team_alternate_color", schema.TypeString),
-	col("team_logo", schema.TypeString),
-	col("records", schema.TypeJSON),
-	col("statistics", schema.TypeJSON),
-	col("linescores", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-	col("competitor", schema.TypeJSON),
-}
-
-var standingColumns = []schema.Column{
-	col("league_id", schema.TypeInt64),
-	col("league_name", schema.TypeString),
-	col("league_abbreviation", schema.TypeString),
-	col("group_id", schema.TypeInt64),
-	col("group_name", schema.TypeString),
-	col("group_abbreviation", schema.TypeString),
-	col("season", schema.TypeInt64),
-	col("season_type", schema.TypeInt64),
-	col("team_id", schema.TypeInt64),
-	col("team_uid", schema.TypeString),
-	col("team_name", schema.TypeString),
-	col("team_abbreviation", schema.TypeString),
-	col("rank", schema.TypeFloat64),
-	col("playoff_seed", schema.TypeFloat64),
-	col("wins", schema.TypeFloat64),
-	col("losses", schema.TypeFloat64),
-	col("ties", schema.TypeFloat64),
-	col("win_percent", schema.TypeFloat64),
-	col("points_for", schema.TypeFloat64),
-	col("points_against", schema.TypeFloat64),
-	col("point_differential", schema.TypeFloat64),
-	col("games_behind", schema.TypeFloat64),
-	col("streak", schema.TypeString),
-	col("overall_record", schema.TypeString),
-	col("stats", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-	col("standings_group", schema.TypeJSON),
-}
-
-var newsColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("now_id", schema.TypeString),
-	col("content_key", schema.TypeString),
-	col("type", schema.TypeString),
-	col("headline", schema.TypeString),
-	col("description", schema.TypeString),
-	col("published", schema.TypeTimestampTZ),
-	col("last_modified", schema.TypeTimestampTZ),
-	col("premium", schema.TypeBoolean),
-	col("byline", schema.TypeString),
-	col("link", schema.TypeString),
-	col("image", schema.TypeString),
-	col("categories", schema.TypeJSON),
-	col("images", schema.TypeJSON),
-	col("article", schema.TypeJSON),
 }

--- a/pkg/source/espn/espn_test.go
+++ b/pkg/source/espn/espn_test.go
@@ -2,13 +2,16 @@ package espn
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/registry"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
@@ -34,6 +37,41 @@ func TestESPNParseURI(t *testing.T) {
 	require.ErrorContains(t, err, "limit")
 }
 
+func TestESPNHandlesIncrementality(t *testing.T) {
+	src := NewESPNSource()
+	require.True(t, src.HandlesIncrementality())
+}
+
+func TestESPNTableDefaults(t *testing.T) {
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://"))
+
+	want := map[string]struct {
+		pks      []string
+		strategy config.IncrementalStrategy
+	}{
+		"teams":       {[]string{"id"}, config.StrategyReplace},
+		"scoreboard":  {[]string{"id"}, config.StrategyMerge},
+		"competitors": {[]string{"event_id", "competition_id", "team_id"}, config.StrategyMerge},
+		"standings":   {[]string{"league_id", "group_id", "season", "team_id"}, config.StrategyReplace},
+		"news":        {[]string{"id"}, config.StrategyMerge},
+	}
+	for name, expected := range want {
+		table, err := src.GetTable(context.Background(), source.TableRequest{Name: name})
+		require.NoError(t, err, "GetTable(%s)", name)
+		require.Equal(t, expected.pks, table.PrimaryKeys(), "%s primary keys", name)
+		require.Equal(t, expected.strategy, table.Strategy(), "%s strategy", name)
+		require.False(t, table.HasKnownSchema(), "%s should not have a known schema (uses schema inference)", name)
+	}
+}
+
+func TestESPNEventsTableRemoved(t *testing.T) {
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://"))
+	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "events"})
+	require.ErrorContains(t, err, "unsupported table")
+}
+
 func TestESPNReadTeams(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/apis/site/v2/sports/football/nfl/teams", r.URL.Path)
@@ -54,13 +92,12 @@ func TestESPNReadTeams(t *testing.T) {
 	defer result.Batch.Release()
 
 	require.EqualValues(t, 2, result.Batch.NumRows())
-	ids := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 22, ids.Value(0))
-	names := result.Batch.Column(5).(*array.String)
-	require.Equal(t, "Arizona Cardinals", names.Value(0))
+	require.Equal(t, "22", stringAt(t, result.Batch, "id", 0))
+	require.Equal(t, "Arizona Cardinals", stringAt(t, result.Batch, "displayName", 0))
+	require.Equal(t, "1", stringAt(t, result.Batch, "id", 1))
 }
 
-func TestESPNScoreboardUsesDatesAndFlattensEvents(t *testing.T) {
+func TestESPNScoreboardEmitsRawEvents(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/apis/site/v2/sports/football/nfl/scoreboard", r.URL.Path)
 		require.Equal(t, "20260910-20260912", r.URL.Query().Get("dates"))
@@ -71,7 +108,7 @@ func TestESPNScoreboardUsesDatesAndFlattensEvents(t *testing.T) {
 
 	src := NewESPNSource()
 	require.NoError(t, src.Connect(context.Background(), "espn://?dates=20260910-20260912&base_url="+url.QueryEscape(server.URL)))
-	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "events"})
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "scoreboard"})
 	require.NoError(t, err)
 
 	results, err := table.Read(context.Background(), source.ReadOptions{Limit: 1})
@@ -81,15 +118,13 @@ func TestESPNScoreboardUsesDatesAndFlattensEvents(t *testing.T) {
 	defer result.Batch.Release()
 
 	require.EqualValues(t, 1, result.Batch.NumRows())
-	eventIDs := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 401872656, eventIDs.Value(0))
-	homeTeamIDs := result.Batch.Column(14).(*array.Int64)
-	require.EqualValues(t, 26, homeTeamIDs.Value(0))
-	awayScores := result.Batch.Column(21).(*array.Int64)
-	require.EqualValues(t, 0, awayScores.Value(0))
+	require.Equal(t, "401872656", stringAt(t, result.Batch, "id", 0))
+	require.Equal(t, "New England Patriots at Seattle Seahawks", stringAt(t, result.Batch, "name", 0))
+	// nested competitions should still be present (as JSON) — schema inference will retype later.
+	require.True(t, hasField(result.Batch, "competitions"), "competitions field should exist")
 }
 
-func TestESPNCompetitorsFanOutFromScoreboard(t *testing.T) {
+func TestESPNCompetitorsFanOutAndCarryPKs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/apis/site/v2/sports/football/nfl/scoreboard", r.URL.Path)
 		_, _ = fmt.Fprint(w, scoreboardPayload())
@@ -108,15 +143,15 @@ func TestESPNCompetitorsFanOutFromScoreboard(t *testing.T) {
 	defer result.Batch.Release()
 
 	require.EqualValues(t, 2, result.Batch.NumRows())
-	teamIDs := result.Batch.Column(2).(*array.Int64)
-	require.EqualValues(t, 26, teamIDs.Value(0))
-	require.EqualValues(t, 17, teamIDs.Value(1))
-	homeAway := result.Batch.Column(6).(*array.String)
-	require.Equal(t, "home", homeAway.Value(0))
-	require.Equal(t, "away", homeAway.Value(1))
+	require.Equal(t, "401872656", stringAt(t, result.Batch, "event_id", 0))
+	require.Equal(t, "401872656", stringAt(t, result.Batch, "competition_id", 0))
+	require.Equal(t, "26", stringAt(t, result.Batch, "team_id", 0))
+	require.Equal(t, "17", stringAt(t, result.Batch, "team_id", 1))
+	require.Equal(t, "home", stringAt(t, result.Batch, "homeAway", 0))
+	require.Equal(t, "away", stringAt(t, result.Batch, "homeAway", 1))
 }
 
-func TestESPNStandingsWalksChildren(t *testing.T) {
+func TestESPNStandingsWalksChildrenAndCarriesPKs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/apis/v2/sports/football/nfl/standings", r.URL.Path)
 		require.Equal(t, "2025", r.URL.Query().Get("season"))
@@ -136,12 +171,13 @@ func TestESPNStandingsWalksChildren(t *testing.T) {
 	defer result.Batch.Release()
 
 	require.EqualValues(t, 1, result.Batch.NumRows())
-	teamIDs := result.Batch.Column(8).(*array.Int64)
-	require.EqualValues(t, 17, teamIDs.Value(0))
-	wins := result.Batch.Column(14).(*array.Float64)
-	require.EqualValues(t, 14, wins.Value(0))
-	streak := result.Batch.Column(22).(*array.String)
-	require.Equal(t, "W3", streak.Value(0))
+	require.Equal(t, "9", stringAt(t, result.Batch, "league_id", 0))
+	require.Equal(t, "8", stringAt(t, result.Batch, "group_id", 0))
+	require.Equal(t, "17", stringAt(t, result.Batch, "team_id", 0))
+	// season is a number in the payload, schema inference will store it as integer JSON.
+	require.True(t, hasField(result.Batch, "season"))
+	// stats array preserved
+	require.True(t, hasField(result.Batch, "stats"))
 }
 
 func TestESPNNews(t *testing.T) {
@@ -164,10 +200,9 @@ func TestESPNNews(t *testing.T) {
 	defer result.Batch.Release()
 
 	require.EqualValues(t, 1, result.Batch.NumRows())
-	headlines := result.Batch.Column(4).(*array.String)
-	require.Equal(t, "Are the Cowboys legit contenders this season?", headlines.Value(0))
-	links := result.Batch.Column(10).(*array.String)
-	require.Equal(t, "https://www.espn.com/video/clip/_/id/49094173/test", links.Value(0))
+	require.Equal(t, "Are the Cowboys legit contenders this season?", stringAt(t, result.Batch, "headline", 0))
+	// raw nested links preserved
+	require.True(t, hasField(result.Batch, "links"))
 }
 
 func TestESPNRegistryLookup(t *testing.T) {
@@ -182,6 +217,52 @@ func TestESPNUnsupportedTable(t *testing.T) {
 	src := NewESPNSource()
 	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "roster"})
 	require.ErrorContains(t, err, "unsupported table")
+}
+
+// hasField reports whether the record's schema contains the given field name.
+func hasField(batch arrow.RecordBatch, name string) bool {
+	for _, f := range batch.Schema().Fields() {
+		if f.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// stringAt returns the value at (column, row) as a Go string, regardless of how
+// it is stored. Values produced by ItemsToArrowRecordWithSchema(nil) use the
+// "unknown" Arrow extension type whose storage is a string of JSON-encoded data.
+// We unwrap the extension, then strip the outer quotes for JSON string values so
+// callers can compare against natural string literals.
+func stringAt(t *testing.T, batch arrow.RecordBatch, name string, row int) string {
+	t.Helper()
+	for i, f := range batch.Schema().Fields() {
+		if f.Name != name {
+			continue
+		}
+		col := batch.Column(i)
+		if ext, ok := col.(array.ExtensionArray); ok {
+			storage, sok := ext.Storage().(*array.String)
+			require.True(t, sok, "unknown ext storage should be *array.String")
+			raw := storage.Value(row)
+			if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+				var s string
+				require.NoError(t, json.Unmarshal([]byte(raw), &s))
+				return s
+			}
+			return raw
+		}
+		switch a := col.(type) {
+		case *array.String:
+			return a.Value(row)
+		case *array.LargeString:
+			return a.Value(row)
+		default:
+			return a.ValueStr(row)
+		}
+	}
+	t.Fatalf("column %q not found in schema", name)
+	return ""
 }
 
 func teamsPayload() string {

--- a/pkg/source/espn/espn_test.go
+++ b/pkg/source/espn/espn_test.go
@@ -124,6 +124,31 @@ func TestESPNScoreboardEmitsRawEvents(t *testing.T) {
 	require.True(t, hasField(result.Batch, "competitions"), "competitions field should exist")
 }
 
+func TestESPNScoreboardEmptyWhenEventsKeyMissing(t *testing.T) {
+	for _, payload := range []string{`{}`, `{"events":null}`, `{"events":[]}`} {
+		t.Run(payload, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = fmt.Fprint(w, payload)
+			}))
+			defer server.Close()
+
+			src := NewESPNSource()
+			require.NoError(t, src.Connect(context.Background(), "espn://?base_url="+url.QueryEscape(server.URL)))
+
+			for _, tbl := range []string{"scoreboard", "competitors"} {
+				table, err := src.GetTable(context.Background(), source.TableRequest{Name: tbl})
+				require.NoError(t, err)
+				results, err := table.Read(context.Background(), source.ReadOptions{})
+				require.NoError(t, err)
+				result := <-results
+				require.NoError(t, result.Err, "%s should not error on payload %s", tbl, payload)
+				require.EqualValues(t, 0, result.Batch.NumRows(), "%s should emit zero rows for payload %s", tbl, payload)
+				result.Batch.Release()
+			}
+		})
+	}
+}
+
 func TestESPNCompetitorsFanOutAndCarryPKs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/apis/site/v2/sports/football/nfl/scoreboard", r.URL.Path)

--- a/pkg/source/espn/espn_test.go
+++ b/pkg/source/espn/espn_test.go
@@ -1,0 +1,201 @@
+package espn
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/registry"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestESPNParseURI(t *testing.T) {
+	cfg, err := parseURI("espn://")
+	require.NoError(t, err)
+	require.Equal(t, defaultSport, cfg.sport)
+	require.Equal(t, defaultLeague, cfg.league)
+	require.Equal(t, defaultLimit, cfg.limit)
+	require.Equal(t, defaultBaseURL, cfg.baseURL)
+
+	cfg, err = parseURI("espn://?sport=basketball&league=nba&dates=20260101-20260131&season=2026&limit=25")
+	require.NoError(t, err)
+	require.Equal(t, "basketball", cfg.sport)
+	require.Equal(t, "nba", cfg.league)
+	require.Equal(t, "20260101-20260131", cfg.dates)
+	require.Equal(t, "2026", cfg.season)
+	require.Equal(t, 25, cfg.limit)
+
+	_, err = parseURI("espn://?limit=zero")
+	require.ErrorContains(t, err, "limit")
+}
+
+func TestESPNReadTeams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/apis/site/v2/sports/football/nfl/teams", r.URL.Path)
+		_, _ = fmt.Fprint(w, teamsPayload())
+	}))
+	defer server.Close()
+
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://?base_url="+url.QueryEscape(server.URL)))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, table.PrimaryKeys())
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	require.EqualValues(t, 2, result.Batch.NumRows())
+	ids := result.Batch.Column(0).(*array.Int64)
+	require.EqualValues(t, 22, ids.Value(0))
+	names := result.Batch.Column(5).(*array.String)
+	require.Equal(t, "Arizona Cardinals", names.Value(0))
+}
+
+func TestESPNScoreboardUsesDatesAndFlattensEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/apis/site/v2/sports/football/nfl/scoreboard", r.URL.Path)
+		require.Equal(t, "20260910-20260912", r.URL.Query().Get("dates"))
+		require.Equal(t, "1", r.URL.Query().Get("limit"))
+		_, _ = fmt.Fprint(w, scoreboardPayload())
+	}))
+	defer server.Close()
+
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://?dates=20260910-20260912&base_url="+url.QueryEscape(server.URL)))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "events"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{Limit: 1})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	require.EqualValues(t, 1, result.Batch.NumRows())
+	eventIDs := result.Batch.Column(0).(*array.Int64)
+	require.EqualValues(t, 401872656, eventIDs.Value(0))
+	homeTeamIDs := result.Batch.Column(14).(*array.Int64)
+	require.EqualValues(t, 26, homeTeamIDs.Value(0))
+	awayScores := result.Batch.Column(21).(*array.Int64)
+	require.EqualValues(t, 0, awayScores.Value(0))
+}
+
+func TestESPNCompetitorsFanOutFromScoreboard(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/apis/site/v2/sports/football/nfl/scoreboard", r.URL.Path)
+		_, _ = fmt.Fprint(w, scoreboardPayload())
+	}))
+	defer server.Close()
+
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://?base_url="+url.QueryEscape(server.URL)))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "competitors"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	require.EqualValues(t, 2, result.Batch.NumRows())
+	teamIDs := result.Batch.Column(2).(*array.Int64)
+	require.EqualValues(t, 26, teamIDs.Value(0))
+	require.EqualValues(t, 17, teamIDs.Value(1))
+	homeAway := result.Batch.Column(6).(*array.String)
+	require.Equal(t, "home", homeAway.Value(0))
+	require.Equal(t, "away", homeAway.Value(1))
+}
+
+func TestESPNStandingsWalksChildren(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/apis/v2/sports/football/nfl/standings", r.URL.Path)
+		require.Equal(t, "2025", r.URL.Query().Get("season"))
+		_, _ = fmt.Fprint(w, standingsPayload())
+	}))
+	defer server.Close()
+
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://?season=2025&base_url="+url.QueryEscape(server.URL)))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "standings"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	require.EqualValues(t, 1, result.Batch.NumRows())
+	teamIDs := result.Batch.Column(8).(*array.Int64)
+	require.EqualValues(t, 17, teamIDs.Value(0))
+	wins := result.Batch.Column(14).(*array.Float64)
+	require.EqualValues(t, 14, wins.Value(0))
+	streak := result.Batch.Column(22).(*array.String)
+	require.Equal(t, "W3", streak.Value(0))
+}
+
+func TestESPNNews(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/apis/site/v2/sports/football/nfl/news", r.URL.Path)
+		require.Equal(t, "1", r.URL.Query().Get("limit"))
+		_, _ = fmt.Fprint(w, newsPayload())
+	}))
+	defer server.Close()
+
+	src := NewESPNSource()
+	require.NoError(t, src.Connect(context.Background(), "espn://?limit=1&base_url="+url.QueryEscape(server.URL)))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "news"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	require.EqualValues(t, 1, result.Batch.NumRows())
+	headlines := result.Batch.Column(4).(*array.String)
+	require.Equal(t, "Are the Cowboys legit contenders this season?", headlines.Value(0))
+	links := result.Batch.Column(10).(*array.String)
+	require.Equal(t, "https://www.espn.com/video/clip/_/id/49094173/test", links.Value(0))
+}
+
+func TestESPNRegistryLookup(t *testing.T) {
+	constructor, err := registry.Default.GetSourceConstructor("espn")
+	require.NoError(t, err)
+	src, ok := constructor().(source.Source)
+	require.True(t, ok)
+	require.Contains(t, src.Schemes(), "espn")
+}
+
+func TestESPNUnsupportedTable(t *testing.T) {
+	src := NewESPNSource()
+	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "roster"})
+	require.ErrorContains(t, err, "unsupported table")
+}
+
+func teamsPayload() string {
+	return `{"sports":[{"id":"20","leagues":[{"id":"28","name":"National Football League","teams":[{"team":{"id":"22","uid":"s:20~l:28~t:22","slug":"arizona-cardinals","abbreviation":"ARI","name":"Cardinals","displayName":"Arizona Cardinals","shortDisplayName":"Cardinals","location":"Arizona","nickname":"Cardinals","color":"a40227","alternateColor":"ffffff","isActive":true,"isAllStar":false,"logos":[{"href":"https://example.com/ari.png"}],"links":[{"href":"https://example.com/ari"}]}},{"team":{"id":"1","uid":"s:20~l:28~t:1","slug":"atlanta-falcons","abbreviation":"ATL","name":"Falcons","displayName":"Atlanta Falcons","shortDisplayName":"Falcons","location":"Atlanta","nickname":"Falcons","isActive":true,"logos":[{"href":"https://example.com/atl.png"}]}}]}]}]}`
+}
+
+func scoreboardPayload() string {
+	return `{"events":[{"id":"401872656","uid":"s:20~l:28~e:401872656","date":"2026-09-10T00:20Z","name":"New England Patriots at Seattle Seahawks","shortName":"NE @ SEA","season":{"year":2026,"type":2},"week":{"number":1},"competitions":[{"id":"401872656","date":"2026-09-10T00:20Z","venue":{"id":"3673","fullName":"Lumen Field"},"status":{"type":{"id":"1","name":"STATUS_SCHEDULED","state":"pre","completed":false}},"competitors":[{"id":"26","uid":"s:20~l:28~t:26","type":"team","order":0,"homeAway":"home","winner":false,"score":"0","curatedRank":99,"team":{"id":"26","uid":"s:20~l:28~t:26","location":"Seattle","name":"Seahawks","abbreviation":"SEA","displayName":"Seattle Seahawks","shortDisplayName":"Seahawks","color":"002a5c","alternateColor":"69be28","logo":"https://example.com/sea.png"},"records":[{"summary":"0-0"}],"statistics":[]},{"id":"17","uid":"s:20~l:28~t:17","type":"team","order":1,"homeAway":"away","winner":false,"score":"0","curatedRank":99,"team":{"id":"17","uid":"s:20~l:28~t:17","location":"New England","name":"Patriots","abbreviation":"NE","displayName":"New England Patriots","shortDisplayName":"Patriots","color":"002a5c","alternateColor":"c60c30","logo":"https://example.com/ne.png"},"records":[{"summary":"0-0"}],"statistics":[]}]}]}]}`
+}
+
+func standingsPayload() string {
+	return `{"uid":"s:20~l:28~g:9","id":"9","name":"National Football League","abbreviation":"NFL","children":[{"uid":"s:20~l:28~g:8","id":"8","name":"American Football Conference","abbreviation":"AFC","standings":{"season":2025,"seasonType":2,"entries":[{"team":{"id":"17","uid":"s:20~l:28~t:17","displayName":"New England Patriots","abbreviation":"NE"},"stats":[{"name":"wins","value":14.0,"displayValue":"14"},{"name":"losses","value":3.0,"displayValue":"3"},{"name":"ties","value":0.0,"displayValue":"0"},{"name":"winPercent","value":0.8235294,"displayValue":".824"},{"name":"pointsFor","value":490.0,"displayValue":"490"},{"name":"pointsAgainst","value":320.0,"displayValue":"320"},{"name":"pointDifferential","value":170.0,"displayValue":"+170"},{"name":"playoffSeed","value":2.0,"displayValue":"2"},{"name":"gamesBehind","value":0.0,"displayValue":"-"},{"name":"streak","value":3.0,"displayValue":"W3"},{"id":"0","name":"overall","type":"total","summary":"14-3","displayValue":"14-3"}]}]}}]}`
+}
+
+func newsPayload() string {
+	return `{"articles":[{"id":49094173,"nowId":"1-49094173","contentKey":"49094173-1-293-1","type":"Media","headline":"Are the Cowboys legit contenders this season?","description":"Are the Cowboys legit contenders this season?","lastModified":"2026-06-17T13:21:31Z","published":"2026-06-17T13:21:31Z","premium":false,"byline":"ESPN","images":[{"url":"https://example.com/image.jpg"}],"categories":[{"type":"league","description":"NFL"}],"links":{"web":{"href":"https://www.espn.com/video/clip/_/id/49094173/test"}}}]}`
+}

--- a/pkg/source/espn/register.go
+++ b/pkg/source/espn/register.go
@@ -1,0 +1,10 @@
+package espn
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"espn"},
+		func() interface{} { return NewESPNSource() },
+	)
+}


### PR DESCRIPTION
## Summary

Adds a new `espn://` ingestion source backed by ESPN's public Site API at `site.api.espn.com`.

The source supports configurable `sport`, `league`, `dates`, `season`, `limit`, and `base_url` URI parameters. It currently exposes typed tables for `teams`, `scoreboard`/`events`, `competitors`, `standings`, and `news`, while preserving nested ESPN payloads in JSON columns for downstream inspection.

Docs were added under `docs/supported-sources/espn.md` and linked from the sports/public-data platform list.

## Validation

- `make format`
- `make lint`
- `go test ./pkg/source/espn`
- `go test -short -race ./pkg/source/espn`
- Live pipeline smoke test against FIFA World Cup data:
  - `espn://?sport=soccer&league=fifa.world&limit=10` -> `events` wrote 5 JSONL rows
  - `espn://?sport=soccer&league=fifa.world&limit=10` -> `competitors` wrote 10 JSONL rows

`make test` was attempted twice but failed in unrelated packages due the local Go toolchain mixing package metadata from `go1.25.7` with a `go1.25.5` compiler: `compile: version "go1.25.7" does not match go tool version "go1.25.5"`.