### PR TITLE
Drop dates URI param from ESPN source

### DIFF
--- a/docs/supported-sources/espn.md
+++ b/docs/supported-sources/espn.md
@@ -14,10 +14,11 @@ URI parameters:
 
 - `sport`: ESPN sport slug. Defaults to `football`.
 - `league`: ESPN league slug. Defaults to `nfl`.
-- `dates`: Optional scoreboard date or date range, such as `20260910` or `20260910-20260912`.
 - `season`: Optional season year passed to scoreboard and standings requests.
 - `limit`: Optional request limit for scoreboard and news. Defaults to `100`.
 - `base_url`: Overrides the ESPN API base URL. Defaults to `https://site.api.espn.com`.
+
+The scoreboard window comes from `--interval-start` / `--interval-end`, which the source converts to ESPN's `dates=YYYYMMDD[-YYYYMMDD]` query parameter (UTC).
 
 ## Example
 
@@ -25,8 +26,10 @@ Load NFL scoreboard events into DuckDB:
 
 ```sh
 ingestr ingest \
-  --source-uri 'espn://?sport=football&league=nfl&dates=20260910-20260912' \
+  --source-uri 'espn://?sport=football&league=nfl' \
   --source-table 'scoreboard' \
+  --interval-start 2026-09-10 \
+  --interval-end 2026-09-12 \
   --dest-uri 'duckdb:///espn.duckdb' \
   --dest-table 'sports.scoreboard'
 ```

--- a/pkg/source/espn/espn.go
+++ b/pkg/source/espn/espn.go
@@ -35,7 +35,6 @@ type ESPNSource struct {
 	client  *httpclient.Client
 	sport   string
 	league  string
-	dates   string
 	season  string
 	limit   int
 	baseURL string
@@ -57,7 +56,6 @@ func (s *ESPNSource) Connect(ctx context.Context, uri string) error {
 
 	s.sport = cfg.sport
 	s.league = cfg.league
-	s.dates = cfg.dates
 	s.season = cfg.season
 	s.limit = cfg.limit
 	s.baseURL = cfg.baseURL
@@ -73,7 +71,6 @@ func (s *ESPNSource) Connect(ctx context.Context, uri string) error {
 type uriConfig struct {
 	sport   string
 	league  string
-	dates   string
 	season  string
 	limit   int
 	baseURL string
@@ -92,7 +89,6 @@ func parseURI(raw string) (uriConfig, error) {
 	cfg := uriConfig{
 		sport:   strings.TrimSpace(values.Get("sport")),
 		league:  strings.TrimSpace(values.Get("league")),
-		dates:   strings.TrimSpace(values.Get("dates")),
 		season:  strings.TrimSpace(values.Get("season")),
 		limit:   defaultLimit,
 		baseURL: strings.TrimRight(values.Get("base_url"), "/"),
@@ -340,9 +336,6 @@ func (s *ESPNSource) fetchScoreboardPayload(ctx context.Context, opts source.Rea
 }
 
 func (s *ESPNSource) scoreboardDates(opts source.ReadOptions) string {
-	if s.dates != "" {
-		return s.dates
-	}
 	if opts.IntervalStart == nil && opts.IntervalEnd == nil {
 		return ""
 	}

--- a/pkg/source/espn/espn_test.go
+++ b/pkg/source/espn/espn_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -25,11 +26,10 @@ func TestESPNParseURI(t *testing.T) {
 	require.Equal(t, defaultLimit, cfg.limit)
 	require.Equal(t, defaultBaseURL, cfg.baseURL)
 
-	cfg, err = parseURI("espn://?sport=basketball&league=nba&dates=20260101-20260131&season=2026&limit=25")
+	cfg, err = parseURI("espn://?sport=basketball&league=nba&season=2026&limit=25")
 	require.NoError(t, err)
 	require.Equal(t, "basketball", cfg.sport)
 	require.Equal(t, "nba", cfg.league)
-	require.Equal(t, "20260101-20260131", cfg.dates)
 	require.Equal(t, "2026", cfg.season)
 	require.Equal(t, 25, cfg.limit)
 
@@ -107,11 +107,15 @@ func TestESPNScoreboardEmitsRawEvents(t *testing.T) {
 	defer server.Close()
 
 	src := NewESPNSource()
-	require.NoError(t, src.Connect(context.Background(), "espn://?dates=20260910-20260912&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "espn://?base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "scoreboard"})
 	require.NoError(t, err)
 
-	results, err := table.Read(context.Background(), source.ReadOptions{Limit: 1})
+	results, err := table.Read(context.Background(), source.ReadOptions{
+		Limit:         1,
+		IntervalStart: timePtr(t, "2026-09-10T00:00:00Z"),
+		IntervalEnd:   timePtr(t, "2026-09-12T23:59:59Z"),
+	})
 	require.NoError(t, err)
 	result := <-results
 	require.NoError(t, result.Err)
@@ -252,6 +256,13 @@ func hasField(batch arrow.RecordBatch, name string) bool {
 		}
 	}
 	return false
+}
+
+func timePtr(t *testing.T, value string) *time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+	return &parsed
 }
 
 // stringAt returns the value at (column, row) as a Go string, regardless of how


### PR DESCRIPTION
## Summary

Removes the URI-level `?dates=...` parameter from the ESPN source. The scoreboard date window is already derived from `--interval-start` / `--interval-end`, which `scoreboardDates()` converts to ESPN's `dates=YYYYMMDD[-YYYYMMDD]` query parameter (UTC). The URI override was a parallel input path with no remaining use case — Bruin Cloud and scheduled ingestr runs always supply interval flags, and the CLI can do the same.
