### PR TITLE
[codex] speed up license policy checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ VERSION ?= dev
 GO_LICENSES_MODULE ?= github.com/google/go-licenses@v1.6.0
 LICENSE_DISALLOWED_TYPES ?= forbidden,restricted,unknown
 LICENSE_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
+LICENSE_CHECK_TARGETS ?= linux/amd64
+LICENSE_INCLUDE_TESTS ?= true
+LICENSE_CHECK_INCLUDE_TESTS ?= false
 export INGESTR_DISABLE_TELEMETRY := true
 export DISABLE_TELEMETRY := true
 TELEMETRY_ENV := INGESTR_DISABLE_TELEMETRY=true DISABLE_TELEMETRY=true
@@ -13,7 +16,7 @@ NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 
-.PHONY: all clean test test-python build deps generate licenses licenses-check lint format lint-ci format-ci test-ci setup test-db2-integration
+.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration
 
 all: clean deps test build
 
@@ -40,11 +43,15 @@ generate:
 
 licenses: generate
 	@echo "$(OK_COLOR)==> Updating third-party license notices$(NO_COLOR)"
-	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_DISALLOWED_TYPES="$(LICENSE_DISALLOWED_TYPES)" LICENSE_TARGETS="$(LICENSE_TARGETS)" ./hack/update-third-party-licenses.sh
+	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_DISALLOWED_TYPES="$(LICENSE_DISALLOWED_TYPES)" LICENSE_TARGETS="$(LICENSE_TARGETS)" LICENSE_INCLUDE_TESTS="$(LICENSE_INCLUDE_TESTS)" ./hack/update-third-party-licenses.sh
 
 licenses-check: generate
+	@echo "$(OK_COLOR)==> Checking third-party license policy$(NO_COLOR)"
+	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_DISALLOWED_TYPES="$(LICENSE_DISALLOWED_TYPES)" LICENSE_TARGETS="$(LICENSE_CHECK_TARGETS)" LICENSE_INCLUDE_TESTS="$(LICENSE_CHECK_INCLUDE_TESTS)" ./hack/update-third-party-licenses.sh --policy-only
+
+licenses-notices-check: generate
 	@echo "$(OK_COLOR)==> Checking third-party license notices$(NO_COLOR)"
-	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_DISALLOWED_TYPES="$(LICENSE_DISALLOWED_TYPES)" LICENSE_TARGETS="$(LICENSE_TARGETS)" ./hack/update-third-party-licenses.sh --check
+	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_DISALLOWED_TYPES="$(LICENSE_DISALLOWED_TYPES)" LICENSE_TARGETS="$(LICENSE_TARGETS)" LICENSE_INCLUDE_TESTS="$(LICENSE_INCLUDE_TESTS)" ./hack/update-third-party-licenses.sh --check
 
 
 build: generate deps

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -29891,6 +29891,422 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===============================================================================
+github.com/richardlehane/mscfb/LICENSE.txt
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
+github.com/richardlehane/msoleps/types/LICENSE.txt
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
 github.com/rivo/uniseg/LICENSE.txt
 ===============================================================================
 
@@ -30898,6 +31314,33 @@ github.com/testcontainers/testcontainers-go/LICENSE
 The MIT License (MIT)
 
 Copyright (c) 2017-2019 Gianluca Arbezzano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+===============================================================================
+github.com/tiendc/go-deepcopy/LICENSE
+===============================================================================
+
+MIT License
+
+Copyright (c) 2023 tiendc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -31938,6 +32381,109 @@ github.com/xdg-go/stringprep/LICENSE
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
+
+===============================================================================
+github.com/xuri/efp/LICENSE
+===============================================================================
+
+BSD 3-Clause License
+
+Copyright (c) 2017 - 2025 Ri Xu All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of efp nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+===============================================================================
+github.com/xuri/excelize/v2/LICENSE
+===============================================================================
+
+BSD 3-Clause License
+
+Copyright (c) 2016-2026 The excelize Authors.
+Copyright (c) 2011-2017 Geoffrey J. Teale
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+===============================================================================
+github.com/xuri/nfp/LICENSE
+===============================================================================
+
+BSD 3-Clause License
+
+Copyright (c) 2022-2025 Ri Xu All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of nfp nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===============================================================================
 github.com/youmark/pkcs8/LICENSE

--- a/hack/update-third-party-licenses.sh
+++ b/hack/update-third-party-licenses.sh
@@ -4,20 +4,35 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 output_file="$repo_root/THIRD_PARTY_LICENSES.txt"
 check_only=0
+policy_only=0
 
-if [[ "${1:-}" == "--check" ]]; then
-	check_only=1
-	shift
-fi
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--check)
+			check_only=1
+			shift
+			;;
+		--policy-only)
+			policy_only=1
+			shift
+			;;
+		*)
+			output_file="$1"
+			shift
+			;;
+	esac
+done
 
-if [[ $# -gt 0 ]]; then
-	output_file="$1"
+if [[ "$check_only" -eq 1 && "$policy_only" -eq 1 ]]; then
+	echo "--check and --policy-only cannot be used together" >&2
+	exit 1
 fi
 
 go_licenses_module="${GO_LICENSES_MODULE:-github.com/google/go-licenses@v1.6.0}"
 disallowed_license_types="${LICENSE_DISALLOWED_TYPES:-forbidden,restricted,unknown}"
 packages="${LICENSE_PACKAGES:-./...}"
 license_targets="${LICENSE_TARGETS:-linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64}"
+include_tests="${LICENSE_INCLUDE_TESTS:-true}"
 module_path="$(cd "$repo_root" && go list -m)"
 
 tmpdir="$(mktemp -d)"
@@ -110,6 +125,42 @@ EOF
 	} >>"$out"
 }
 
+append_manual_module_licenses() {
+	local out="$1"
+
+	append_manual_module_license \
+		"github.com/segmentio/asm" \
+		"v1.2.1" \
+		"LICENSE" \
+		"MIT No Attribution" \
+		"cca993712df289a5958bdef69031a5dac0f951ac15afeb313f9eeea55ed59443" \
+		"$out"
+
+	append_manual_module_license \
+		"modernc.org/mathutil" \
+		"v1.7.1" \
+		"LICENSE" \
+		"BSD-3-Clause" \
+		"bfa9bf72a72ca009fd62a8f84fca3dca67e51d93af96352723646599898b6cf5" \
+		"$out"
+
+	append_manual_module_license \
+		"github.com/DATA-DOG/go-sqlmock" \
+		"v1.5.2" \
+		"LICENSE" \
+		"BSD-3-Clause" \
+		"e3a6ae97f6eef8ce17e44d5f22adba594c4ea2b592c4be7ee9b387c441ef34d6" \
+		"$out"
+
+	append_manual_module_license \
+		"github.com/99designs/go-keychain" \
+		"v0.0.0-20191008050251-8e49817e8af4" \
+		"LICENSE" \
+		"MIT" \
+		"039c69774070226d213bced933176be4ec396c9b101cd9a13e82a2c390c6c90a" \
+		"$out"
+}
+
 save_root="$tmpdir/go-licenses"
 generated_file="$tmpdir/THIRD_PARTY_LICENSES.txt"
 
@@ -125,6 +176,19 @@ ignore_flags=(
 	--ignore "github.com/99designs/go-keychain"
 )
 
+license_test_flags=()
+case "$include_tests" in
+	1 | true | TRUE | yes | YES)
+		license_test_flags=(--include_tests)
+		;;
+	0 | false | FALSE | no | NO | "")
+		;;
+	*)
+		echo "LICENSE_INCLUDE_TESTS must be true or false, got: $include_tests" >&2
+		exit 1
+		;;
+esac
+
 run_target() {
 	local target="$1"
 	local goos="${target%/*}"
@@ -136,7 +200,7 @@ run_target() {
 	local target_failure="$tmpdir/$label.failed"
 
 	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" GOROOT="$active_goroot" "$go_licenses_bin" check "$packages" \
-		--include_tests \
+		"${license_test_flags[@]}" \
 		"${ignore_flags[@]}" \
 		--disallowed_types="$disallowed_license_types" \
 		>"$target_out" 2>"$target_log"); then
@@ -148,8 +212,12 @@ run_target() {
 		return 1
 	fi
 
+	if [[ "$policy_only" -eq 1 ]]; then
+		return 0
+	fi
+
 	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" GOROOT="$active_goroot" "$go_licenses_bin" save "$packages" \
-		--include_tests \
+		"${license_test_flags[@]}" \
 		"${ignore_flags[@]}" \
 		--save_path "$target_save_dir" \
 		>"$target_out" 2>"$target_log"); then
@@ -180,6 +248,13 @@ if [[ "$failed" -ne 0 ]]; then
 		cat "$failure" >&2
 	done < <(find "$tmpdir" -maxdepth 1 -type f -name '*.failed' | LC_ALL=C sort)
 	exit 1
+fi
+
+if [[ "$policy_only" -eq 1 ]]; then
+	manual_license_file="$tmpdir/manual-licenses.txt"
+	: >"$manual_license_file"
+	append_manual_module_licenses "$manual_license_file"
+	exit 0
 fi
 
 {
@@ -241,37 +316,7 @@ LC_ALL=C sort "$notice_entries" | awk -F '\t' '!seen[$1]++' | while IFS=$'\t' re
 	copy_notice_file "$rel" "$file" "$generated_file"
 done
 
-append_manual_module_license \
-	"github.com/segmentio/asm" \
-	"v1.2.1" \
-	"LICENSE" \
-	"MIT No Attribution" \
-	"cca993712df289a5958bdef69031a5dac0f951ac15afeb313f9eeea55ed59443" \
-	"$generated_file"
-
-append_manual_module_license \
-	"modernc.org/mathutil" \
-	"v1.7.1" \
-	"LICENSE" \
-	"BSD-3-Clause" \
-	"bfa9bf72a72ca009fd62a8f84fca3dca67e51d93af96352723646599898b6cf5" \
-	"$generated_file"
-
-append_manual_module_license \
-	"github.com/DATA-DOG/go-sqlmock" \
-	"v1.5.2" \
-	"LICENSE" \
-	"BSD-3-Clause" \
-	"e3a6ae97f6eef8ce17e44d5f22adba594c4ea2b592c4be7ee9b387c441ef34d6" \
-	"$generated_file"
-
-append_manual_module_license \
-	"github.com/99designs/go-keychain" \
-	"v0.0.0-20191008050251-8e49817e8af4" \
-	"LICENSE" \
-	"MIT" \
-	"039c69774070226d213bced933176be4ec396c9b101cd9a13e82a2c390c6c90a" \
-	"$generated_file"
+append_manual_module_licenses "$generated_file"
 
 if [[ "$check_only" -eq 1 ]]; then
 	if ! cmp -s "$generated_file" "$output_file"; then

--- a/hack/update-third-party-licenses.sh
+++ b/hack/update-third-party-licenses.sh
@@ -24,6 +24,7 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 go_licenses_bin="$tmpdir/bin/go-licenses$(go env GOEXE)"
+active_goroot="$(go env GOROOT)"
 
 (cd "$repo_root" && GOBIN="$tmpdir/bin" go install "$go_licenses_module")
 
@@ -134,7 +135,7 @@ run_target() {
 	local target_log="$tmpdir/$label.log"
 	local target_failure="$tmpdir/$label.failed"
 
-	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" "$go_licenses_bin" check "$packages" \
+	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" GOROOT="$active_goroot" "$go_licenses_bin" check "$packages" \
 		--include_tests \
 		"${ignore_flags[@]}" \
 		--disallowed_types="$disallowed_license_types" \
@@ -147,7 +148,7 @@ run_target() {
 		return 1
 	fi
 
-	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" "$go_licenses_bin" save "$packages" \
+	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" GOROOT="$active_goroot" "$go_licenses_bin" save "$packages" \
 		--include_tests \
 		"${ignore_flags[@]}" \
 		--save_path "$target_save_dir" \

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -91,7 +91,8 @@ func writeCallCount(d *fakeDestination) int {
 }
 
 func TestStreaming_CountTriggerFlushes(t *testing.T) {
-	dest := &fakeDestination{}
+	baseDest := &fakeDestination{}
+	dest := &truncateCapableDestination{fakeDestination: baseDest}
 	committer := &fakeCommitter{}
 	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
@@ -113,22 +114,22 @@ func TestStreaming_CountTriggerFlushes(t *testing.T) {
 		}
 	}
 	// 3 batches x 4 rows = 12 rows, threshold 100 not reached yet: no flush.
-	assert.Equal(t, 0, writeCallCount(dest))
+	assert.Equal(t, 0, writeCallCount(baseDest))
 
 	big := make([]int64, 100)
 	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", big, nil), CommitToken: 3}
 
-	require.Eventually(t, func() bool { return writeCallCount(dest) == 1 }, 5*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return writeCallCount(baseDest) == 1 }, 5*time.Second, time.Millisecond)
 	require.Eventually(t, func() bool { return len(committer.committed()) == 1 }, 5*time.Second, time.Millisecond)
 
 	// Order: write to staging, merge into dest, reset staging, then commit.
-	dest.mu.Lock()
-	assert.Equal(t, []string{"WriteParallel", "MergeTable", "TruncateTable"}, dest.calls)
-	assert.Equal(t, "ds.tbl_staging", dest.writeCalls[0].Table)
-	assert.True(t, dest.writeCalls[0].StagingTable)
-	assert.Equal(t, "ds.tbl_staging", dest.mergeCalls[0].StagingTable)
-	assert.Equal(t, "ds.tbl", dest.mergeCalls[0].TargetTable)
-	dest.mu.Unlock()
+	baseDest.mu.Lock()
+	assert.Equal(t, []string{"WriteParallel", "MergeTable", "TruncateTable"}, baseDest.calls)
+	assert.Equal(t, "ds.tbl_staging", baseDest.writeCalls[0].Table)
+	assert.True(t, baseDest.writeCalls[0].StagingTable)
+	assert.Equal(t, "ds.tbl_staging", baseDest.mergeCalls[0].StagingTable)
+	assert.Equal(t, "ds.tbl", baseDest.mergeCalls[0].TargetTable)
+	baseDest.mu.Unlock()
 	// Cumulative token semantics: only the newest token is committed.
 	assert.Equal(t, []any{3}, committer.committed())
 

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestTruncateInsertStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
-	job, src, _ := minimalJob()
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
 	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
 	job.Config.FullRefresh = true
 	job.Config.PrimaryKeys = nil


### PR DESCRIPTION
## Summary

This PR splits the license workflow so PR CI runs a fast policy gate instead of regenerating and diffing the full third-party notices file.

Changes:
- `make licenses-check` now runs `go-licenses check` only, against `linux/amd64` by default.
- `licenses-check` excludes test-only imports by default via `LICENSE_CHECK_INCLUDE_TESTS=false`.
- Full notice generation remains available through `make licenses`.
- The old generated-notice verification path remains available as `make licenses-notices-check`.
- The license script keeps the active `GOROOT` fix so `go-licenses` does not misclassify stdlib packages under Go auto-toolchains.
- Stale `pkg/strategy` test fakes were updated to match truncate-capable strategy behavior so CI can pass on this branch.

## Why

The previous PR check ran every target, included test-only dependencies, saved all notices, and diffed `THIRD_PARTY_LICENSES.txt`. That made the license gate slow, noisy, and easy to break even when the actual policy result was fine.

## Validation

Passed locally:
- `make licenses-check`
- `make licenses-notices-check`
- `make format`
- `make lint`
- `go test -short -race -cover -timeout 5m ./pkg/strategy`
- `make test`