### PR TITLE
Refactor api-football source to use schema inference

### DIFF
--- a/docs/soccer-sources/api-football.md
+++ b/docs/soccer-sources/api-football.md
@@ -230,7 +230,7 @@ Recommended ingestion flow:
 - URI: `api-football://?api_key=<key>&league=1&season=2026`, with optional `timezone` and `base_url`.
 - Default `league=1` and `season=2026` for the World Cup use case.
 - Schema is inferred from the data (`KnownSchema: false`); nested objects are preserved as JSON columns and only primary-key fields are lifted to typed top-level columns.
-- Strategies: `merge` only where incremental loading is possible — `matches` (`/fixtures` `from`/`to` time filter) and `group_standings` (`standing.update` timestamp). `teams`, `stadiums`, `players`, and `match_events` have neither, so they use `replace` with a full fetch.
+- Strategies: `merge` where incremental loading is possible — `matches`, `stadiums`, and `match_events` source from `/fixtures` and honor its `from`/`to` interval; `group_standings` carries a `standing.update` timestamp. `teams` and `players` have neither, so they use `replace` with a full fetch.
 - Batches stream per response: one batch per page for `/players`, one per fixture for `match_events`.
 - Server-side interval filtering uses the `/fixtures` `from`/`to` params (applied only when both `--interval-start` and `--interval-end` are set); other endpoints have no time filter.
 - Rate limiter is set to ~80% of the free tier's 10 requests/minute (`rateLimit = 0.13` req/s, burst 5).

--- a/docs/soccer-sources/api-football.md
+++ b/docs/soccer-sources/api-football.md
@@ -17,7 +17,7 @@ Primary docs:
 | World Cup identifiers | `league=1`, `season=2026` |
 | Response envelope | `get`, `parameters`, `errors`, `results`, `paging`, `response` |
 | Pagination | Endpoint-specific. `players` uses `page`; some endpoints return one page for league/season filters. |
-| Rate limits | Plan quota based. Free is 100 requests/day; Pro 7,500/day; Ultra 75,000/day; Mega 150,000/day. |
+| Rate limits | Plan quota based. Free is 10 requests/minute and 100 requests/day; Pro 7,500/day; Ultra 75,000/day; Mega 150,000/day. |
 
 API-Football states that all plans include all competitions and endpoints, with free plans limited by available seasons. For World Cup 2026, verify actual free-plan access with a live key before promising free production coverage.
 
@@ -90,7 +90,7 @@ Recommended World Cup call:
 GET /teams?league=1&season=2026
 ```
 
-Ingestion shape: one `teams` row per `response[]`, flattening the `team` object and optionally preserving the nested `venue` fields as team-home-venue metadata. Do not treat team-home venue as World Cup match stadium without cross-checking fixtures.
+Ingestion shape: one `teams` row per `response[]`, with `id` lifted from `team.id` and the raw `team` and `venue` objects preserved as JSON columns (no field flattening). Do not treat team-home venue as World Cup match stadium without cross-checking fixtures.
 
 ### Stadiums / Venues
 
@@ -128,7 +128,7 @@ Recommended World Cup call:
 GET /standings?league=1&season=2026
 ```
 
-Ingestion shape: flatten nested `league.standings[][]` into one row per team per group, preserving `league.id`, `league.season`, `group`, `rank`, `team.id`, `points`, `goalsDiff`, `form`, `status`, `description`, and the nested `all/home/away` records if present.
+Ingestion shape: one row per team per group from `league.standings[][]`. The composite key (`league_id`, `season`, `group_name`, `team_id`) is lifted to top-level columns; the raw `standing` object (with nested `all/home/away`) and the `league` object (minus its embedded `standings` array) are preserved as JSON columns.
 
 ### Matches
 
@@ -227,9 +227,12 @@ Recommended ingestion flow:
 
 ## Implementation Notes
 
-- Proposed URI: `api-football://?api_key=<key>&league=1&season=2026`.
+- URI: `api-football://?api_key=<key>&league=1&season=2026`, with optional `timezone` and `base_url`.
 - Default `league=1` and `season=2026` for the World Cup use case.
-- Support `base_url` for tests.
-- Use `page` pagination for `/players`.
-- For live matches, respect the documented 15-second update cadence but avoid polling faster than the selected plan allows.
+- Schema is inferred from the data (`KnownSchema: false`); nested objects are preserved as JSON columns and only primary-key fields are lifted to typed top-level columns.
+- Strategies: `group_standings`, `matches`, `players`, `match_events` use `merge`; `teams` and `stadiums` use `replace`.
+- Batches stream per response: one batch per page for `/players`, one per fixture for `match_events`.
+- Server-side interval filtering uses the `/fixtures` `from`/`to` params (applied only when both `--interval-start` and `--interval-end` are set); other endpoints have no time filter.
+- Rate limiter is set to ~80% of the free tier's 10 requests/minute (`rateLimit = 0.13` req/s, burst 5).
+- Free plans cap the `/players` `page` parameter at 3, so full `players` extraction requires a paid plan.
 - Store API-Football IDs as provider IDs; do not try to normalize team/player IDs across services in the first connector.

--- a/docs/soccer-sources/api-football.md
+++ b/docs/soccer-sources/api-football.md
@@ -17,7 +17,6 @@ Primary docs:
 | World Cup identifiers | `league=1`, `season=2026` |
 | Response envelope | `get`, `parameters`, `errors`, `results`, `paging`, `response` |
 | Pagination | Endpoint-specific. `players` uses `page`; some endpoints return one page for league/season filters. |
-| Rate limits | Plan quota based. Free is 10 requests/minute and 100 requests/day; Pro 7,500/day; Ultra 75,000/day; Mega 150,000/day. |
 
 API-Football states that all plans include all competitions and endpoints, with free plans limited by available seasons. For World Cup 2026, verify actual free-plan access with a live key before promising free production coverage.
 

--- a/docs/soccer-sources/api-football.md
+++ b/docs/soccer-sources/api-football.md
@@ -230,7 +230,7 @@ Recommended ingestion flow:
 - URI: `api-football://?api_key=<key>&league=1&season=2026`, with optional `timezone` and `base_url`.
 - Default `league=1` and `season=2026` for the World Cup use case.
 - Schema is inferred from the data (`KnownSchema: false`); nested objects are preserved as JSON columns and only primary-key fields are lifted to typed top-level columns.
-- Strategies: `group_standings`, `matches`, `players`, `match_events` use `merge`; `teams` and `stadiums` use `replace`.
+- Strategies: `merge` only where incremental loading is possible — `matches` (`/fixtures` `from`/`to` time filter) and `group_standings` (`standing.update` timestamp). `teams`, `stadiums`, `players`, and `match_events` have neither, so they use `replace` with a full fetch.
 - Batches stream per response: one batch per page for `/players`, one per fixture for `match_events`.
 - Server-side interval filtering uses the `/fixtures` `from`/`to` params (applied only when both `--interval-start` and `--interval-end` are set); other endpoints have no time filter.
 - Rate limiter is set to ~80% of the free tier's 10 requests/minute (`rateLimit = 0.13` req/s, burst 5).

--- a/docs/soccer-sources/api-football.md
+++ b/docs/soccer-sources/api-football.md
@@ -224,15 +224,3 @@ Recommended ingestion flow:
 1. Fetch all World Cup fixtures.
 2. For historical or scheduled refresh, call `/fixtures/events?fixture=<id>` per fixture.
 3. For live refresh, call `/fixtures?live=all` or `/fixtures?league=1&season=2026&status=...`, then batch detail calls with `ids`.
-
-## Implementation Notes
-
-- URI: `api-football://?api_key=<key>&league=1&season=2026`, with optional `timezone` and `base_url`.
-- Default `league=1` and `season=2026` for the World Cup use case.
-- Schema is inferred from the data (`KnownSchema: false`); nested objects are preserved as JSON columns and only primary-key fields are lifted to typed top-level columns.
-- Strategies: `merge` where incremental loading is possible — `matches`, `stadiums`, and `match_events` source from `/fixtures` and honor its `from`/`to` interval; `group_standings` carries a `standing.update` timestamp. `teams` and `players` have neither, so they use `replace` with a full fetch.
-- Batches stream per response: one batch per page for `/players`, one per fixture for `match_events`.
-- Server-side interval filtering uses the `/fixtures` `from`/`to` params (applied only when both `--interval-start` and `--interval-end` are set); other endpoints have no time filter.
-- Rate limiter is set to ~80% of the free tier's 10 requests/minute (`rateLimit = 0.13` req/s, burst 5).
-- Free plans cap the `/players` `page` parameter at 3, so full `players` extraction requires a paid plan.
-- Store API-Football IDs as provider IDs; do not try to normalize team/player IDs across services in the first connector.

--- a/docs/supported-sources/api-football.md
+++ b/docs/supported-sources/api-football.md
@@ -47,11 +47,11 @@ ingestr ingest \
 | Table | PK | Inc Key | Inc Strategy | Details |
 | --- | --- | --- | --- | --- |
 | `teams` | `id` | - | replace | Loads teams from `/teams?league=<league>&season=<season>`. |
-| `stadiums` | `id` | - | replace | Derives venue IDs from fixtures and hydrates each venue through `/venues?id=<id>`. |
+| `stadiums` | `id` | - | merge | Derives venue IDs from fixtures and hydrates each venue through `/venues?id=<id>`. |
 | `group_standings` | `league_id`, `season`, `group_name`, `team_id` | - | merge | Loads group standings from `/standings`. |
 | `matches` | `id` | - | merge | Loads fixtures from `/fixtures`. |
 | `players` | `id` | - | replace | Loads paginated player rows from `/players`. |
-| `match_events` | `event_key` | - | replace | Fetches fixtures, then loads events from `/fixtures/events?fixture=<id>`. |
+| `match_events` | `event_key` | - | merge | Fetches fixtures, then loads events from `/fixtures/events?fixture=<id>`. |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
@@ -61,6 +61,6 @@ Use these as the `--source-table` parameter in the `ingestr ingest` command.
 - API-Football free plans may not expose future seasons such as `2026`; the source surfaces the provider's plan/season error when access is denied.
 - `players` follows API-Football page pagination automatically.
 - `stadiums` and `match_events` are fixture-derived because API-Football does not expose World Cup-scoped venue or all-event endpoints.
-- When `--interval-start` and `--interval-end` are both set, the fixture-derived tables (`matches`, `stadiums`, `match_events`) filter server-side via the `/fixtures` `from`/`to` parameters. The other endpoints have no time filter and always return the full league/season. With no interval, all tables fetch everything.
+- When `--interval-start` and `--interval-end` are both set, the fixture-derived tables (`matches`, `stadiums`, `match_events`) filter server-side via the `/fixtures` `from`/`to` parameters. `teams`, `group_standings`, and `players` have no time filter and always return the full league/season. With no interval, all tables fetch everything.
 - Nested provider objects are preserved as JSON columns; the schema is inferred from the data. Each table also exposes the primary-key fields (e.g. `id`, or `league_id`/`season`/`group_name`/`team_id`) as top-level typed columns so merge strategies can de-duplicate.
-- Strategy follows incremental capability: a table uses `merge` only if it can be loaded incrementally — either its endpoint accepts a time filter (`matches` via `/fixtures` `from`/`to`) or its rows carry an update timestamp (`group_standings` via `standing.update`). Tables with neither (`teams`, `stadiums`, `players`, `match_events`) use `replace` with a full fetch.
+- Strategy follows incremental capability. A table uses `merge` when its fetch honors the ingestion interval — `matches`, `stadiums`, and `match_events` all source from `/fixtures` and apply its `from`/`to` filter — or when its rows carry an update timestamp (`group_standings` via `standing.update`). `teams` and `players` have neither (their endpoints take no time filter and their rows have no update field), so they use `replace` with a full fetch.

--- a/docs/supported-sources/api-football.md
+++ b/docs/supported-sources/api-football.md
@@ -50,8 +50,8 @@ ingestr ingest \
 | `stadiums` | `id` | - | replace | Derives venue IDs from fixtures and hydrates each venue through `/venues?id=<id>`. |
 | `group_standings` | `league_id`, `season`, `group_name`, `team_id` | - | merge | Loads group standings from `/standings`. |
 | `matches` | `id` | - | merge | Loads fixtures from `/fixtures`. |
-| `players` | `id` | - | merge | Loads paginated player rows from `/players`. |
-| `match_events` | `event_key` | - | merge | Fetches fixtures, then loads events from `/fixtures/events?fixture=<id>`. |
+| `players` | `id` | - | replace | Loads paginated player rows from `/players`. |
+| `match_events` | `event_key` | - | replace | Fetches fixtures, then loads events from `/fixtures/events?fixture=<id>`. |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
@@ -63,4 +63,4 @@ Use these as the `--source-table` parameter in the `ingestr ingest` command.
 - `stadiums` and `match_events` are fixture-derived because API-Football does not expose World Cup-scoped venue or all-event endpoints.
 - When `--interval-start` and `--interval-end` are both set, the fixture-derived tables (`matches`, `stadiums`, `match_events`) filter server-side via the `/fixtures` `from`/`to` parameters. The other endpoints have no time filter and always return the full league/season. With no interval, all tables fetch everything.
 - Nested provider objects are preserved as JSON columns; the schema is inferred from the data. Each table also exposes the primary-key fields (e.g. `id`, or `league_id`/`season`/`group_name`/`team_id`) as top-level typed columns so merge strategies can de-duplicate.
-- Mutable tables (`group_standings`, `matches`, `players`, `match_events`) use the `merge` strategy keyed on their primary keys, so re-running the same league/season upserts in place and ingesting additional leagues/seasons accumulates into one table. The static reference tables (`teams`, `stadiums`) use `replace`.
+- Strategy follows incremental capability: a table uses `merge` only if it can be loaded incrementally — either its endpoint accepts a time filter (`matches` via `/fixtures` `from`/`to`) or its rows carry an update timestamp (`group_standings` via `standing.update`). Tables with neither (`teams`, `stadiums`, `players`, `match_events`) use `replace` with a full fetch.

--- a/docs/supported-sources/api-football.md
+++ b/docs/supported-sources/api-football.md
@@ -48,10 +48,10 @@ ingestr ingest \
 | --- | --- | --- | --- | --- |
 | `teams` | `id` | - | replace | Loads teams from `/teams?league=<league>&season=<season>`. |
 | `stadiums` | `id` | - | replace | Derives venue IDs from fixtures and hydrates each venue through `/venues?id=<id>`. |
-| `group_standings` | `league_id`, `season`, `group_name`, `team_id` | - | replace | Loads and flattens group standings from `/standings`. |
-| `matches` | `id` | - | replace | Loads and flattens fixtures from `/fixtures`. |
-| `players` | `id` | - | replace | Loads paginated player rows from `/players`. |
-| `match_events` | `event_key` | - | replace | Fetches fixtures, then loads events from `/fixtures/events?fixture=<id>`. |
+| `group_standings` | `league_id`, `season`, `group_name`, `team_id` | - | merge | Loads group standings from `/standings`. |
+| `matches` | `id` | - | merge | Loads fixtures from `/fixtures`. |
+| `players` | `id` | - | merge | Loads paginated player rows from `/players`. |
+| `match_events` | `event_key` | - | merge | Fetches fixtures, then loads events from `/fixtures/events?fixture=<id>`. |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
@@ -61,4 +61,6 @@ Use these as the `--source-table` parameter in the `ingestr ingest` command.
 - API-Football free plans may not expose future seasons such as `2026`; the source surfaces the provider's plan/season error when access is denied.
 - `players` follows API-Football page pagination automatically.
 - `stadiums` and `match_events` are fixture-derived because API-Football does not expose World Cup-scoped venue or all-event endpoints.
-- Nested provider objects are preserved as JSON columns while common IDs, names, scores, and status fields are exposed as typed columns.
+- When `--interval-start` and `--interval-end` are both set, the fixture-derived tables (`matches`, `stadiums`, `match_events`) filter server-side via the `/fixtures` `from`/`to` parameters. The other endpoints have no time filter and always return the full league/season. With no interval, all tables fetch everything.
+- Nested provider objects are preserved as JSON columns; the schema is inferred from the data. Each table also exposes the primary-key fields (e.g. `id`, or `league_id`/`season`/`group_name`/`team_id`) as top-level typed columns so merge strategies can de-duplicate.
+- Mutable tables (`group_standings`, `matches`, `players`, `match_events`) use the `merge` strategy keyed on their primary keys, so re-running the same league/season upserts in place and ingesting additional leagues/seasons accumulates into one table. The static reference tables (`teams`, `stadiums`) use `replace`.

--- a/docs/supported-sources/api-football.md
+++ b/docs/supported-sources/api-football.md
@@ -60,7 +60,3 @@ Use these as the `--source-table` parameter in the `ingestr ingest` command.
 - The API key is sent in the `x-apisports-key` header.
 - API-Football free plans may not expose future seasons such as `2026`; the source surfaces the provider's plan/season error when access is denied.
 - `players` follows API-Football page pagination automatically.
-- `stadiums` and `match_events` are fixture-derived because API-Football does not expose World Cup-scoped venue or all-event endpoints.
-- When `--interval-start` and `--interval-end` are both set, the fixture-derived tables (`matches`, `stadiums`, `match_events`) filter server-side via the `/fixtures` `from`/`to` parameters. `teams`, `group_standings`, and `players` have no time filter and always return the full league/season. With no interval, all tables fetch everything.
-- Nested provider objects are preserved as JSON columns; the schema is inferred from the data. Each table also exposes the primary-key fields (e.g. `id`, or `league_id`/`season`/`group_name`/`team_id`) as top-level typed columns so merge strategies can de-duplicate.
-- Strategy follows incremental capability. A table uses `merge` when its fetch honors the ingestion interval — `matches`, `stadiums`, and `match_events` all source from `/fixtures` and apply its `from`/`to` filter — or when its rows carry an update timestamp (`group_standings` via `standing.update`). `teams` and `players` have neither (their endpoints take no time filter and their rows have no update field), so they use `replace` with a full fetch.

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -179,12 +179,12 @@ func (s *APIFootballSource) tables() map[string]tableConfig {
 		},
 		"players": {
 			primaryKeys: []string{"id"},
-			strategy:    config.StrategyMerge,
+			strategy:    config.StrategyReplace,
 			read:        s.readPlayers,
 		},
 		"match_events": {
 			primaryKeys: []string{"event_key"},
-			strategy:    config.StrategyMerge,
+			strategy:    config.StrategyReplace,
 			read:        s.readMatchEvents,
 		},
 	}

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -438,13 +438,14 @@ func (s *APIFootballSource) readMatchEvents(ctx context.Context, opts source.Rea
 		}
 		out := make([]map[string]interface{}, 0, len(items))
 		for idx, item := range items {
-			row := map[string]interface{}{
-				"event_key":  makeEventKey(fixtureID, idx, item),
-				"fixture_id": fixtureObj["id"],
-			}
+			row := map[string]interface{}{}
 			for key, value := range item {
 				row[key] = value
 			}
+			// Set synthetic keys after copying so raw API fields can never
+			// overwrite the merge primary key.
+			row["event_key"] = makeEventKey(fixtureID, idx, item)
+			row["fixture_id"] = fixtureObj["id"]
 			out = append(out, row)
 		}
 		if err := sendBatch(out, opts, results); err != nil {

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -164,7 +164,7 @@ func (s *APIFootballSource) tables() map[string]tableConfig {
 		},
 		"stadiums": {
 			primaryKeys: []string{"id"},
-			strategy:    config.StrategyReplace,
+			strategy:    config.StrategyMerge,
 			read:        s.readStadiums,
 		},
 		"group_standings": {
@@ -184,7 +184,7 @@ func (s *APIFootballSource) tables() map[string]tableConfig {
 		},
 		"match_events": {
 			primaryKeys: []string{"event_key"},
-			strategy:    config.StrategyReplace,
+			strategy:    config.StrategyMerge,
 			read:        s.readMatchEvents,
 		},
 	}

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"sort"
@@ -206,7 +207,7 @@ func (s *APIFootballSource) read(ctx context.Context, cfg tableConfig, opts sour
 
 // sendBatch converts a page of items to an Arrow record and streams it to the
 // results channel. Empty pages are skipped so no zero-row batch is emitted.
-func sendBatch(items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func sendBatch(items []map[string]any, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -232,9 +233,9 @@ func (s *APIFootballSource) readTeams(ctx context.Context, opts source.ReadOptio
 		return fmt.Errorf("malformed api-football response from /teams: %w", err)
 	}
 
-	out := make([]map[string]interface{}, 0, len(items))
+	out := make([]map[string]any, 0, len(items))
 	for _, item := range items {
-		out = append(out, map[string]interface{}{
+		out = append(out, map[string]any{
 			"id":    nestedMap(item, "team")["id"],
 			"team":  item["team"],
 			"venue": item["venue"],
@@ -250,7 +251,7 @@ func (s *APIFootballSource) readStadiums(ctx context.Context, opts source.ReadOp
 		return err
 	}
 
-	fallbacks := make(map[string]map[string]interface{})
+	fallbacks := make(map[string]map[string]any)
 	ids := make([]string, 0)
 	seen := make(map[string]bool)
 	for _, fixture := range fixtures {
@@ -281,13 +282,13 @@ func (s *APIFootballSource) readStadiums(ctx context.Context, opts source.ReadOp
 		if err != nil {
 			return fmt.Errorf("malformed api-football response from /venues: %w", err)
 		}
-		var venue map[string]interface{}
+		var venue map[string]any
 		if len(items) == 0 {
 			venue = fallbacks[id]
 		} else {
 			venue = items[0]
 		}
-		if err := sendBatch([]map[string]interface{}{venue}, opts, results); err != nil {
+		if err := sendBatch([]map[string]any{venue}, opts, results); err != nil {
 			return err
 		}
 	}
@@ -308,33 +309,33 @@ func (s *APIFootballSource) readStandings(ctx context.Context, opts source.ReadO
 		return fmt.Errorf("malformed api-football response from /standings: %w", err)
 	}
 
-	out := make([]map[string]interface{}, 0)
+	out := make([]map[string]any, 0)
 	for _, item := range items {
 		league := nestedMap(item, "league")
 		// Keep the league object raw, minus the standings array it embeds
 		// (which would otherwise duplicate the whole table in every row).
-		leagueHeader := make(map[string]interface{}, len(league))
+		leagueHeader := make(map[string]any, len(league))
 		for key, value := range league {
 			if key == "standings" {
 				continue
 			}
 			leagueHeader[key] = value
 		}
-		rawStandings, ok := league["standings"].([]interface{})
+		rawStandings, ok := league["standings"].([]any)
 		if !ok {
 			continue
 		}
 		for _, rawGroup := range rawStandings {
-			group, ok := rawGroup.([]interface{})
+			group, ok := rawGroup.([]any)
 			if !ok {
 				continue
 			}
 			for _, rawStanding := range group {
-				standing, ok := rawStanding.(map[string]interface{})
+				standing, ok := rawStanding.(map[string]any)
 				if !ok {
 					continue
 				}
-				out = append(out, map[string]interface{}{
+				out = append(out, map[string]any{
 					"league_id":  league["id"],
 					"season":     league["season"],
 					"group_name": standing["group"],
@@ -354,9 +355,9 @@ func (s *APIFootballSource) readMatches(ctx context.Context, opts source.ReadOpt
 	if err != nil {
 		return err
 	}
-	out := make([]map[string]interface{}, 0, len(fixtures))
+	out := make([]map[string]any, 0, len(fixtures))
 	for _, item := range fixtures {
-		out = append(out, map[string]interface{}{
+		out = append(out, map[string]any{
 			"id":      nestedMap(item, "fixture")["id"],
 			"fixture": item["fixture"],
 			"league":  item["league"],
@@ -390,9 +391,9 @@ func (s *APIFootballSource) readPlayers(ctx context.Context, opts source.ReadOpt
 		if err != nil {
 			return fmt.Errorf("malformed api-football response from /players: %w", err)
 		}
-		out := make([]map[string]interface{}, 0, len(items))
+		out := make([]map[string]any, 0, len(items))
 		for _, item := range items {
-			out = append(out, map[string]interface{}{
+			out = append(out, map[string]any{
 				"id":         nestedMap(item, "player")["id"],
 				"player":     item["player"],
 				"statistics": item["statistics"],
@@ -436,12 +437,10 @@ func (s *APIFootballSource) readMatchEvents(ctx context.Context, opts source.Rea
 		if err != nil {
 			return fmt.Errorf("malformed api-football response from /fixtures/events: %w", err)
 		}
-		out := make([]map[string]interface{}, 0, len(items))
+		out := make([]map[string]any, 0, len(items))
 		for idx, item := range items {
-			row := map[string]interface{}{}
-			for key, value := range item {
-				row[key] = value
-			}
+			row := make(map[string]any, len(item)+2)
+			maps.Copy(row, item)
 			// Set synthetic keys after copying so raw API fields can never
 			// overwrite the merge primary key.
 			row["event_key"] = makeEventKey(fixtureID, idx, item)
@@ -455,7 +454,7 @@ func (s *APIFootballSource) readMatchEvents(ctx context.Context, opts source.Rea
 	return nil
 }
 
-func (s *APIFootballSource) fetchFixtures(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+func (s *APIFootballSource) fetchFixtures(ctx context.Context, opts source.ReadOptions) ([]map[string]any, error) {
 	params := map[string]string{
 		"league": s.league,
 		"season": s.season,
@@ -480,12 +479,12 @@ func (s *APIFootballSource) fetchFixtures(ctx context.Context, opts source.ReadO
 	return items, nil
 }
 
-func (s *APIFootballSource) get(ctx context.Context, endpoint string, params map[string]string) (map[string]interface{}, error) {
+func (s *APIFootballSource) get(ctx context.Context, endpoint string, params map[string]string) (map[string]any, error) {
 	if s.client == nil {
 		return nil, fmt.Errorf("api-football source is not connected")
 	}
 
-	var payload map[string]interface{}
+	var payload map[string]any
 	req := s.client.R(ctx).SetResult(&payload)
 	for key, value := range params {
 		if value != "" {
@@ -525,17 +524,17 @@ func checkResponse(endpoint string, resp *httpclient.Response) error {
 	}
 }
 
-func checkAPIError(endpoint string, payload map[string]interface{}) error {
+func checkAPIError(endpoint string, payload map[string]any) error {
 	errorsValue, ok := payload["errors"]
 	if !ok || errorsValue == nil {
 		return nil
 	}
 	switch v := errorsValue.(type) {
-	case []interface{}:
+	case []any:
 		if len(v) > 0 {
 			return fmt.Errorf("api-football API error for %s: %v", endpoint, v)
 		}
-	case map[string]interface{}:
+	case map[string]any:
 		if len(v) > 0 {
 			return fmt.Errorf("api-football API error for %s: %v", endpoint, v)
 		}
@@ -547,14 +546,14 @@ func checkAPIError(endpoint string, payload map[string]interface{}) error {
 	return nil
 }
 
-func extractResponse(payload map[string]interface{}) ([]map[string]interface{}, error) {
-	raw, ok := payload["response"].([]interface{})
+func extractResponse(payload map[string]any) ([]map[string]any, error) {
+	raw, ok := payload["response"].([]any)
 	if !ok {
 		return nil, fmt.Errorf("missing response array")
 	}
-	items := make([]map[string]interface{}, 0, len(raw))
+	items := make([]map[string]any, 0, len(raw))
 	for i, rawItem := range raw {
-		item, ok := rawItem.(map[string]interface{})
+		item, ok := rawItem.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("response item %d is not an object", i)
 		}
@@ -563,12 +562,12 @@ func extractResponse(payload map[string]interface{}) ([]map[string]interface{}, 
 	return items, nil
 }
 
-func paging(payload map[string]interface{}) (current, total int) {
+func paging(payload map[string]any) (current, total int) {
 	pg := nestedMap(payload, "paging")
 	return valueInt(pg["current"]), valueInt(pg["total"])
 }
 
-func makeEventKey(fixtureID string, index int, item map[string]interface{}) string {
+func makeEventKey(fixtureID string, index int, item map[string]any) string {
 	parts := []string{
 		fixtureID,
 		strconv.Itoa(index),
@@ -583,33 +582,33 @@ func makeEventKey(fixtureID string, index int, item map[string]interface{}) stri
 	return hex.EncodeToString(sum[:])
 }
 
-func nestedMap(item map[string]interface{}, key string) map[string]interface{} {
-	raw, ok := item[key].(map[string]interface{})
+func nestedMap(item map[string]any, key string) map[string]any {
+	raw, ok := item[key].(map[string]any)
 	if !ok || raw == nil {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 	return raw
 }
 
-func normalizeMap(item map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(item))
+func normalizeMap(item map[string]any) map[string]any {
+	out := make(map[string]any, len(item))
 	for key, value := range item {
 		out[key] = normalizeValue(value)
 	}
 	return out
 }
 
-func normalizeValue(value interface{}) interface{} {
+func normalizeValue(value any) any {
 	switch v := value.(type) {
 	case string:
 		if strings.EqualFold(strings.TrimSpace(v), "null") {
 			return nil
 		}
 		return v
-	case map[string]interface{}:
+	case map[string]any:
 		return normalizeMap(v)
-	case []interface{}:
-		out := make([]interface{}, len(v))
+	case []any:
+		out := make([]any, len(v))
 		for i, item := range v {
 			out[i] = normalizeValue(item)
 		}
@@ -619,7 +618,7 @@ func normalizeValue(value interface{}) interface{} {
 	}
 }
 
-func valueString(value interface{}) string {
+func valueString(value any) string {
 	switch v := value.(type) {
 	case nil:
 		return ""
@@ -636,7 +635,7 @@ func valueString(value interface{}) string {
 	}
 }
 
-func valueInt(value interface{}) int {
+func valueInt(value any) int {
 	switch v := value.(type) {
 	case float64:
 		return int(v)

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -23,9 +23,10 @@ const (
 	defaultBaseURL = "https://v3.football.api-sports.io"
 	defaultLeague  = "1"
 	defaultSeason  = "2026"
-	// api-sports.io free tier allows 10 req/min; rateLimit is ~80% of that per second.
+	// api-sports.io free tier allows 10 req/min; rateLimit is ~80% of that per
+	// second, with a burst small enough that the first minute stays under the cap.
 	rateLimit      = 0.13
-	rateLimitBurst = 5
+	rateLimitBurst = 2
 )
 
 type tableConfig struct {

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -23,12 +23,16 @@ const (
 	defaultBaseURL = "https://v3.football.api-sports.io"
 	defaultLeague  = "1"
 	defaultSeason  = "2026"
+	// api-sports.io free tier allows 10 req/min; rateLimit is ~80% of that per second.
+	rateLimit      = 0.13
+	rateLimitBurst = 5
 )
 
 type tableConfig struct {
-	columns     []schema.Column
-	primaryKeys []string
-	fetch       func(context.Context, source.ReadOptions) ([]map[string]interface{}, error)
+	primaryKeys    []string
+	incrementalKey string
+	strategy       config.IncrementalStrategy
+	read           func(context.Context, source.ReadOptions, chan<- source.RecordBatchResult) error
 }
 
 type APIFootballSource struct {
@@ -63,6 +67,7 @@ func (s *APIFootballSource) Connect(ctx context.Context, uri string) error {
 		httpclient.WithBaseURL(cfg.baseURL),
 		httpclient.WithTimeout(60*time.Second),
 		httpclient.WithHeader("x-apisports-key", cfg.apiKey),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
 		httpclient.WithDebug(config.DebugMode),
 	)
 	return nil
@@ -125,7 +130,7 @@ func (s *APIFootballSource) Close(ctx context.Context) error {
 }
 
 func (s *APIFootballSource) HandlesIncrementality() bool {
-	return false
+	return true
 }
 
 func (s *APIFootballSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
@@ -136,16 +141,13 @@ func (s *APIFootballSource) GetTable(ctx context.Context, req source.TableReques
 	}
 
 	return &source.DynamicSourceTable{
-		TableName:        req.Name,
-		TablePrimaryKeys: cfg.primaryKeys,
-		TableStrategy:    config.StrategyReplace,
-		KnownSchema:      true,
+		TableName:           req.Name,
+		TablePrimaryKeys:    cfg.primaryKeys,
+		TableIncrementalKey: cfg.incrementalKey,
+		TableStrategy:       cfg.strategy,
+		KnownSchema:         false,
 		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
-			return &schema.TableSchema{
-				Name:        req.Name,
-				Columns:     cfg.columns,
-				PrimaryKeys: cfg.primaryKeys,
-			}, nil
+			return nil, fmt.Errorf("api-football source relies on schema inference")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 			return s.read(ctx, cfg, opts)
@@ -157,33 +159,33 @@ func (s *APIFootballSource) tables() map[string]tableConfig {
 	return map[string]tableConfig{
 		"teams": {
 			primaryKeys: []string{"id"},
-			columns:     teamColumns,
-			fetch:       s.fetchTeams,
+			strategy:    config.StrategyReplace,
+			read:        s.readTeams,
 		},
 		"stadiums": {
 			primaryKeys: []string{"id"},
-			columns:     stadiumColumns,
-			fetch:       s.fetchStadiums,
+			strategy:    config.StrategyReplace,
+			read:        s.readStadiums,
 		},
 		"group_standings": {
 			primaryKeys: []string{"league_id", "season", "group_name", "team_id"},
-			columns:     standingColumns,
-			fetch:       s.fetchStandings,
+			strategy:    config.StrategyMerge,
+			read:        s.readStandings,
 		},
 		"matches": {
 			primaryKeys: []string{"id"},
-			columns:     matchColumns,
-			fetch:       s.fetchMatches,
+			strategy:    config.StrategyMerge,
+			read:        s.readMatches,
 		},
 		"players": {
 			primaryKeys: []string{"id"},
-			columns:     playerColumns,
-			fetch:       s.fetchPlayers,
+			strategy:    config.StrategyMerge,
+			read:        s.readPlayers,
 		},
 		"match_events": {
 			primaryKeys: []string{"event_key"},
-			columns:     eventColumns,
-			fetch:       s.fetchMatchEvents,
+			strategy:    config.StrategyMerge,
+			read:        s.readMatchEvents,
 		},
 	}
 }
@@ -193,52 +195,58 @@ func (s *APIFootballSource) read(ctx context.Context, cfg tableConfig, opts sour
 
 	go func() {
 		defer close(results)
-
-		items, err := cfg.fetch(ctx, opts)
-		if err != nil {
+		if err := cfg.read(ctx, opts, results); err != nil {
 			results <- source.RecordBatchResult{Err: err}
-			return
 		}
-		items = selectColumns(items, cfg.columns)
-
-		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cfg.columns, opts.ExcludeColumns)
-		if err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert api-football data to Arrow: %w", err)}
-			return
-		}
-		results <- source.RecordBatchResult{Batch: record}
 	}()
 
 	return results, nil
 }
 
-func (s *APIFootballSource) fetchTeams(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+// sendBatch converts a page of items to an Arrow record and streams it to the
+// results channel. Empty pages are skipped so no zero-row batch is emitted.
+func sendBatch(items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert api-football data to Arrow: %w", err)
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}
+
+func (s *APIFootballSource) readTeams(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[API-FOOTBALL] reading teams")
 	payload, err := s.get(ctx, "/teams", map[string]string{
 		"league": s.league,
 		"season": s.season,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	items, err := extractResponse(payload)
 	if err != nil {
-		return nil, fmt.Errorf("malformed api-football response from /teams: %w", err)
+		return fmt.Errorf("malformed api-football response from /teams: %w", err)
 	}
 
 	out := make([]map[string]interface{}, 0, len(items))
 	for _, item := range items {
-		out = append(out, flattenTeam(item))
-		if opts.Limit > 0 && len(out) >= opts.Limit {
-			return out[:opts.Limit], nil
-		}
+		out = append(out, map[string]interface{}{
+			"id":    nestedMap(item, "team")["id"],
+			"team":  item["team"],
+			"venue": item["venue"],
+		})
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *APIFootballSource) fetchStadiums(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
-	fixtures, err := s.fetchFixtures(ctx)
+func (s *APIFootballSource) readStadiums(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[API-FOOTBALL] reading stadiums")
+	fixtures, err := s.fetchFixtures(ctx, opts)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	fallbacks := make(map[string]map[string]interface{})
@@ -254,48 +262,63 @@ func (s *APIFootballSource) fetchStadiums(ctx context.Context, opts source.ReadO
 			seen[id] = true
 			ids = append(ids, id)
 		}
-		fallbacks[id] = flattenFixtureVenue(venue)
+		fallbacks[id] = venue
 	}
 	sort.Strings(ids)
 
-	out := make([]map[string]interface{}, 0, len(ids))
 	for _, id := range ids {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		payload, err := s.get(ctx, "/venues", map[string]string{"id": id})
 		if err != nil {
-			return nil, err
+			return err
 		}
 		items, err := extractResponse(payload)
 		if err != nil {
-			return nil, fmt.Errorf("malformed api-football response from /venues: %w", err)
+			return fmt.Errorf("malformed api-football response from /venues: %w", err)
 		}
+		var venue map[string]interface{}
 		if len(items) == 0 {
-			out = append(out, fallbacks[id])
+			venue = fallbacks[id]
 		} else {
-			out = append(out, flattenVenue(items[0]))
+			venue = items[0]
 		}
-		if opts.Limit > 0 && len(out) >= opts.Limit {
-			return out[:opts.Limit], nil
+		if err := sendBatch([]map[string]interface{}{venue}, opts, results); err != nil {
+			return err
 		}
 	}
-	return out, nil
+	return nil
 }
 
-func (s *APIFootballSource) fetchStandings(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+func (s *APIFootballSource) readStandings(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[API-FOOTBALL] reading group_standings")
 	payload, err := s.get(ctx, "/standings", map[string]string{
 		"league": s.league,
 		"season": s.season,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	items, err := extractResponse(payload)
 	if err != nil {
-		return nil, fmt.Errorf("malformed api-football response from /standings: %w", err)
+		return fmt.Errorf("malformed api-football response from /standings: %w", err)
 	}
 
 	out := make([]map[string]interface{}, 0)
 	for _, item := range items {
 		league := nestedMap(item, "league")
+		// Keep the league object raw, minus the standings array it embeds
+		// (which would otherwise duplicate the whole table in every row).
+		leagueHeader := make(map[string]interface{}, len(league))
+		for key, value := range league {
+			if key == "standings" {
+				continue
+			}
+			leagueHeader[key] = value
+		}
 		rawStandings, ok := league["standings"].([]interface{})
 		if !ok {
 			continue
@@ -310,53 +333,72 @@ func (s *APIFootballSource) fetchStandings(ctx context.Context, opts source.Read
 				if !ok {
 					continue
 				}
-				out = append(out, flattenStanding(league, standing))
-				if opts.Limit > 0 && len(out) >= opts.Limit {
-					return out[:opts.Limit], nil
-				}
+				out = append(out, map[string]interface{}{
+					"league_id":  league["id"],
+					"season":     league["season"],
+					"group_name": standing["group"],
+					"team_id":    nestedMap(standing, "team")["id"],
+					"league":     leagueHeader,
+					"standing":   standing,
+				})
 			}
 		}
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *APIFootballSource) fetchMatches(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
-	fixtures, err := s.fetchFixtures(ctx)
+func (s *APIFootballSource) readMatches(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[API-FOOTBALL] reading matches")
+	fixtures, err := s.fetchFixtures(ctx, opts)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	out := make([]map[string]interface{}, 0, len(fixtures))
 	for _, item := range fixtures {
-		out = append(out, flattenFixture(item))
-		if opts.Limit > 0 && len(out) >= opts.Limit {
-			return out[:opts.Limit], nil
-		}
+		out = append(out, map[string]interface{}{
+			"id":      nestedMap(item, "fixture")["id"],
+			"fixture": item["fixture"],
+			"league":  item["league"],
+			"teams":   item["teams"],
+			"goals":   item["goals"],
+			"score":   item["score"],
+		})
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *APIFootballSource) fetchPlayers(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+func (s *APIFootballSource) readPlayers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[API-FOOTBALL] reading players")
 	page := 1
-	out := make([]map[string]interface{}, 0)
 
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		payload, err := s.get(ctx, "/players", map[string]string{
 			"league": s.league,
 			"season": s.season,
 			"page":   strconv.Itoa(page),
 		})
 		if err != nil {
-			return nil, err
+			return err
 		}
 		items, err := extractResponse(payload)
 		if err != nil {
-			return nil, fmt.Errorf("malformed api-football response from /players: %w", err)
+			return fmt.Errorf("malformed api-football response from /players: %w", err)
 		}
+		out := make([]map[string]interface{}, 0, len(items))
 		for _, item := range items {
-			out = append(out, flattenPlayer(item))
-			if opts.Limit > 0 && len(out) >= opts.Limit {
-				return out[:opts.Limit], nil
-			}
+			out = append(out, map[string]interface{}{
+				"id":         nestedMap(item, "player")["id"],
+				"player":     item["player"],
+				"statistics": item["statistics"],
+			})
+		}
+		if err := sendBatch(out, opts, results); err != nil {
+			return err
 		}
 		current, total := paging(payload)
 		if total == 0 || current >= total {
@@ -364,46 +406,66 @@ func (s *APIFootballSource) fetchPlayers(ctx context.Context, opts source.ReadOp
 		}
 		page++
 	}
-	return out, nil
+	return nil
 }
 
-func (s *APIFootballSource) fetchMatchEvents(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
-	fixtures, err := s.fetchFixtures(ctx)
+func (s *APIFootballSource) readMatchEvents(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[API-FOOTBALL] reading match_events")
+	fixtures, err := s.fetchFixtures(ctx, opts)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	out := make([]map[string]interface{}, 0)
 	for _, fixture := range fixtures {
-		fixtureID := valueString(nestedMap(fixture, "fixture")["id"])
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		fixtureObj := nestedMap(fixture, "fixture")
+		fixtureID := valueString(fixtureObj["id"])
 		if fixtureID == "" {
 			continue
 		}
 		payload, err := s.get(ctx, "/fixtures/events", map[string]string{"fixture": fixtureID})
 		if err != nil {
-			return nil, err
+			return err
 		}
 		items, err := extractResponse(payload)
 		if err != nil {
-			return nil, fmt.Errorf("malformed api-football response from /fixtures/events: %w", err)
+			return fmt.Errorf("malformed api-football response from /fixtures/events: %w", err)
 		}
+		out := make([]map[string]interface{}, 0, len(items))
 		for idx, item := range items {
-			out = append(out, flattenEvent(fixtureID, idx, item))
-			if opts.Limit > 0 && len(out) >= opts.Limit {
-				return out[:opts.Limit], nil
+			row := map[string]interface{}{
+				"event_key":  makeEventKey(fixtureID, idx, item),
+				"fixture_id": fixtureObj["id"],
 			}
+			for key, value := range item {
+				row[key] = value
+			}
+			out = append(out, row)
+		}
+		if err := sendBatch(out, opts, results); err != nil {
+			return err
 		}
 	}
-	return out, nil
+	return nil
 }
 
-func (s *APIFootballSource) fetchFixtures(ctx context.Context) ([]map[string]interface{}, error) {
+func (s *APIFootballSource) fetchFixtures(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
 	params := map[string]string{
 		"league": s.league,
 		"season": s.season,
 	}
 	if s.timezone != "" {
 		params["timezone"] = s.timezone
+	}
+	// /fixtures filters server-side via from/to (YYYY-MM-DD, used together);
+	// apply the interval so fixture-derived tables stay scoped to the window.
+	if opts.IntervalStart != nil && opts.IntervalEnd != nil {
+		params["from"] = opts.IntervalStart.UTC().Format("2006-01-02")
+		params["to"] = opts.IntervalEnd.UTC().Format("2006-01-02")
 	}
 	payload, err := s.get(ctx, "/fixtures", params)
 	if err != nil {
@@ -504,239 +566,6 @@ func paging(payload map[string]interface{}) (current, total int) {
 	return valueInt(pg["current"]), valueInt(pg["total"])
 }
 
-func flattenTeam(item map[string]interface{}) map[string]interface{} {
-	team := nestedMap(item, "team")
-	venue := nestedMap(item, "venue")
-	out := map[string]interface{}{
-		"id":             team["id"],
-		"name":           team["name"],
-		"code":           team["code"],
-		"country":        team["country"],
-		"founded":        team["founded"],
-		"national":       team["national"],
-		"logo":           team["logo"],
-		"venue_id":       venue["id"],
-		"venue_name":     venue["name"],
-		"venue_address":  venue["address"],
-		"venue_city":     venue["city"],
-		"venue_capacity": venue["capacity"],
-		"venue_surface":  venue["surface"],
-		"venue_image":    venue["image"],
-		"team":           team,
-		"venue":          venue,
-	}
-	return normalizeMap(out)
-}
-
-func flattenFixtureVenue(venue map[string]interface{}) map[string]interface{} {
-	out := map[string]interface{}{
-		"id":    venue["id"],
-		"name":  venue["name"],
-		"city":  venue["city"],
-		"venue": venue,
-	}
-	return normalizeMap(out)
-}
-
-func flattenVenue(item map[string]interface{}) map[string]interface{} {
-	out := map[string]interface{}{
-		"id":       item["id"],
-		"name":     item["name"],
-		"address":  item["address"],
-		"city":     item["city"],
-		"country":  item["country"],
-		"capacity": item["capacity"],
-		"surface":  item["surface"],
-		"image":    item["image"],
-		"venue":    item,
-	}
-	return normalizeMap(out)
-}
-
-func flattenStanding(league, standing map[string]interface{}) map[string]interface{} {
-	team := nestedMap(standing, "team")
-	all := nestedMap(standing, "all")
-	home := nestedMap(standing, "home")
-	away := nestedMap(standing, "away")
-	out := map[string]interface{}{
-		"league_id":          league["id"],
-		"league_name":        league["name"],
-		"league_country":     league["country"],
-		"season":             league["season"],
-		"group_name":         standing["group"],
-		"rank":               standing["rank"],
-		"team_id":            team["id"],
-		"team_name":          team["name"],
-		"team_logo":          team["logo"],
-		"points":             standing["points"],
-		"goals_diff":         standing["goalsDiff"],
-		"form":               standing["form"],
-		"status":             standing["status"],
-		"description":        standing["description"],
-		"all_played":         all["played"],
-		"all_win":            all["win"],
-		"all_draw":           all["draw"],
-		"all_lose":           all["lose"],
-		"all_goals_for":      nestedMap(all, "goals")["for"],
-		"all_goals_against":  nestedMap(all, "goals")["against"],
-		"home_played":        home["played"],
-		"home_win":           home["win"],
-		"home_draw":          home["draw"],
-		"home_lose":          home["lose"],
-		"home_goals_for":     nestedMap(home, "goals")["for"],
-		"home_goals_against": nestedMap(home, "goals")["against"],
-		"away_played":        away["played"],
-		"away_win":           away["win"],
-		"away_draw":          away["draw"],
-		"away_lose":          away["lose"],
-		"away_goals_for":     nestedMap(away, "goals")["for"],
-		"away_goals_against": nestedMap(away, "goals")["against"],
-		"updated_at":         standing["update"],
-		"league":             league,
-		"team":               team,
-		"all":                all,
-		"home":               home,
-		"away":               away,
-	}
-	return normalizeMap(out)
-}
-
-func flattenFixture(item map[string]interface{}) map[string]interface{} {
-	fixture := nestedMap(item, "fixture")
-	league := nestedMap(item, "league")
-	teams := nestedMap(item, "teams")
-	homeTeam := nestedMap(teams, "home")
-	awayTeam := nestedMap(teams, "away")
-	goals := nestedMap(item, "goals")
-	score := nestedMap(item, "score")
-	status := nestedMap(fixture, "status")
-	venue := nestedMap(fixture, "venue")
-	out := map[string]interface{}{
-		"id":                   fixture["id"],
-		"referee":              fixture["referee"],
-		"timezone":             fixture["timezone"],
-		"date":                 fixture["date"],
-		"timestamp":            fixture["timestamp"],
-		"period_first":         nestedMap(fixture, "periods")["first"],
-		"period_second":        nestedMap(fixture, "periods")["second"],
-		"venue_id":             venue["id"],
-		"venue_name":           venue["name"],
-		"venue_city":           venue["city"],
-		"status_long":          status["long"],
-		"status_short":         status["short"],
-		"status_elapsed":       status["elapsed"],
-		"status_extra":         status["extra"],
-		"league_id":            league["id"],
-		"league_name":          league["name"],
-		"league_country":       league["country"],
-		"season":               league["season"],
-		"round":                league["round"],
-		"home_team_id":         homeTeam["id"],
-		"home_team_name":       homeTeam["name"],
-		"home_team_logo":       homeTeam["logo"],
-		"home_team_winner":     homeTeam["winner"],
-		"away_team_id":         awayTeam["id"],
-		"away_team_name":       awayTeam["name"],
-		"away_team_logo":       awayTeam["logo"],
-		"away_team_winner":     awayTeam["winner"],
-		"home_goals":           goals["home"],
-		"away_goals":           goals["away"],
-		"halftime_home_goals":  nestedMap(score, "halftime")["home"],
-		"halftime_away_goals":  nestedMap(score, "halftime")["away"],
-		"fulltime_home_goals":  nestedMap(score, "fulltime")["home"],
-		"fulltime_away_goals":  nestedMap(score, "fulltime")["away"],
-		"extratime_home_goals": nestedMap(score, "extratime")["home"],
-		"extratime_away_goals": nestedMap(score, "extratime")["away"],
-		"penalty_home_goals":   nestedMap(score, "penalty")["home"],
-		"penalty_away_goals":   nestedMap(score, "penalty")["away"],
-		"fixture":              fixture,
-		"league":               league,
-		"teams":                teams,
-		"goals":                goals,
-		"score":                score,
-	}
-	return normalizeMap(out)
-}
-
-func flattenPlayer(item map[string]interface{}) map[string]interface{} {
-	player := nestedMap(item, "player")
-	statistics := interfaceSlice(item["statistics"])
-	firstStat := map[string]interface{}{}
-	if len(statistics) > 0 {
-		if stat, ok := statistics[0].(map[string]interface{}); ok {
-			firstStat = stat
-		}
-	}
-	team := nestedMap(firstStat, "team")
-	games := nestedMap(firstStat, "games")
-	goals := nestedMap(firstStat, "goals")
-	cards := nestedMap(firstStat, "cards")
-	out := map[string]interface{}{
-		"id":              player["id"],
-		"name":            player["name"],
-		"firstname":       player["firstname"],
-		"lastname":        player["lastname"],
-		"age":             player["age"],
-		"birth_date":      nestedMap(player, "birth")["date"],
-		"birth_place":     nestedMap(player, "birth")["place"],
-		"birth_country":   nestedMap(player, "birth")["country"],
-		"nationality":     player["nationality"],
-		"height":          player["height"],
-		"weight":          player["weight"],
-		"injured":         player["injured"],
-		"photo":           player["photo"],
-		"team_id":         team["id"],
-		"team_name":       team["name"],
-		"team_logo":       team["logo"],
-		"position":        games["position"],
-		"number":          games["number"],
-		"captain":         games["captain"],
-		"appearances":     games["appearences"],
-		"lineups":         games["lineups"],
-		"minutes":         games["minutes"],
-		"rating":          games["rating"],
-		"goals_total":     goals["total"],
-		"goals_assists":   goals["assists"],
-		"goals_saves":     goals["saves"],
-		"yellow_cards":    cards["yellow"],
-		"yellowred_cards": cards["yellowred"],
-		"red_cards":       cards["red"],
-		"player":          player,
-		"team":            team,
-		"statistics":      statistics,
-	}
-	return normalizeMap(out)
-}
-
-func flattenEvent(fixtureID string, index int, item map[string]interface{}) map[string]interface{} {
-	team := nestedMap(item, "team")
-	player := nestedMap(item, "player")
-	assist := nestedMap(item, "assist")
-	eventKey := makeEventKey(fixtureID, index, item)
-	out := map[string]interface{}{
-		"event_key":   eventKey,
-		"fixture_id":  fixtureID,
-		"event_index": index,
-		"elapsed":     nestedMap(item, "time")["elapsed"],
-		"extra":       nestedMap(item, "time")["extra"],
-		"team_id":     team["id"],
-		"team_name":   team["name"],
-		"team_logo":   team["logo"],
-		"player_id":   player["id"],
-		"player_name": player["name"],
-		"assist_id":   assist["id"],
-		"assist_name": assist["name"],
-		"type":        item["type"],
-		"detail":      item["detail"],
-		"comments":    item["comments"],
-		"time":        nestedMap(item, "time"),
-		"team":        team,
-		"player":      player,
-		"assist":      assist,
-	}
-	return normalizeMap(out)
-}
-
 func makeEventKey(fixtureID string, index int, item map[string]interface{}) string {
 	parts := []string{
 		fixtureID,
@@ -756,14 +585,6 @@ func nestedMap(item map[string]interface{}, key string) map[string]interface{} {
 	raw, ok := item[key].(map[string]interface{})
 	if !ok || raw == nil {
 		return map[string]interface{}{}
-	}
-	return raw
-}
-
-func interfaceSlice(value interface{}) []interface{} {
-	raw, ok := value.([]interface{})
-	if !ok {
-		return nil
 	}
 	return raw
 }
@@ -827,196 +648,4 @@ func valueInt(value interface{}) int {
 	default:
 		return 0
 	}
-}
-
-func selectColumns(items []map[string]interface{}, columns []schema.Column) []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(items))
-	for _, item := range items {
-		selected := make(map[string]interface{}, len(columns))
-		for _, column := range columns {
-			if value, ok := item[column.Name]; ok {
-				selected[column.Name] = value
-			}
-		}
-		out = append(out, selected)
-	}
-	return out
-}
-
-func col(name string, dt schema.DataType) schema.Column {
-	return schema.Column{Name: name, DataType: dt, Nullable: true}
-}
-
-var teamColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("name", schema.TypeString),
-	col("code", schema.TypeString),
-	col("country", schema.TypeString),
-	col("founded", schema.TypeInt64),
-	col("national", schema.TypeBoolean),
-	col("logo", schema.TypeString),
-	col("venue_id", schema.TypeInt64),
-	col("venue_name", schema.TypeString),
-	col("venue_address", schema.TypeString),
-	col("venue_city", schema.TypeString),
-	col("venue_capacity", schema.TypeInt64),
-	col("venue_surface", schema.TypeString),
-	col("venue_image", schema.TypeString),
-	col("team", schema.TypeJSON),
-	col("venue", schema.TypeJSON),
-}
-
-var stadiumColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("name", schema.TypeString),
-	col("address", schema.TypeString),
-	col("city", schema.TypeString),
-	col("country", schema.TypeString),
-	col("capacity", schema.TypeInt64),
-	col("surface", schema.TypeString),
-	col("image", schema.TypeString),
-	col("venue", schema.TypeJSON),
-}
-
-var standingColumns = []schema.Column{
-	col("league_id", schema.TypeInt64),
-	col("league_name", schema.TypeString),
-	col("league_country", schema.TypeString),
-	col("season", schema.TypeInt64),
-	col("group_name", schema.TypeString),
-	col("rank", schema.TypeInt64),
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("team_logo", schema.TypeString),
-	col("points", schema.TypeInt64),
-	col("goals_diff", schema.TypeInt64),
-	col("form", schema.TypeString),
-	col("status", schema.TypeString),
-	col("description", schema.TypeString),
-	col("all_played", schema.TypeInt64),
-	col("all_win", schema.TypeInt64),
-	col("all_draw", schema.TypeInt64),
-	col("all_lose", schema.TypeInt64),
-	col("all_goals_for", schema.TypeInt64),
-	col("all_goals_against", schema.TypeInt64),
-	col("home_played", schema.TypeInt64),
-	col("home_win", schema.TypeInt64),
-	col("home_draw", schema.TypeInt64),
-	col("home_lose", schema.TypeInt64),
-	col("home_goals_for", schema.TypeInt64),
-	col("home_goals_against", schema.TypeInt64),
-	col("away_played", schema.TypeInt64),
-	col("away_win", schema.TypeInt64),
-	col("away_draw", schema.TypeInt64),
-	col("away_lose", schema.TypeInt64),
-	col("away_goals_for", schema.TypeInt64),
-	col("away_goals_against", schema.TypeInt64),
-	col("updated_at", schema.TypeTimestampTZ),
-	col("league", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-	col("all", schema.TypeJSON),
-	col("home", schema.TypeJSON),
-	col("away", schema.TypeJSON),
-}
-
-var matchColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("referee", schema.TypeString),
-	col("timezone", schema.TypeString),
-	col("date", schema.TypeTimestampTZ),
-	col("timestamp", schema.TypeTimestampTZ),
-	col("period_first", schema.TypeTimestampTZ),
-	col("period_second", schema.TypeTimestampTZ),
-	col("venue_id", schema.TypeInt64),
-	col("venue_name", schema.TypeString),
-	col("venue_city", schema.TypeString),
-	col("status_long", schema.TypeString),
-	col("status_short", schema.TypeString),
-	col("status_elapsed", schema.TypeInt64),
-	col("status_extra", schema.TypeInt64),
-	col("league_id", schema.TypeInt64),
-	col("league_name", schema.TypeString),
-	col("league_country", schema.TypeString),
-	col("season", schema.TypeInt64),
-	col("round", schema.TypeString),
-	col("home_team_id", schema.TypeInt64),
-	col("home_team_name", schema.TypeString),
-	col("home_team_logo", schema.TypeString),
-	col("home_team_winner", schema.TypeBoolean),
-	col("away_team_id", schema.TypeInt64),
-	col("away_team_name", schema.TypeString),
-	col("away_team_logo", schema.TypeString),
-	col("away_team_winner", schema.TypeBoolean),
-	col("home_goals", schema.TypeInt64),
-	col("away_goals", schema.TypeInt64),
-	col("halftime_home_goals", schema.TypeInt64),
-	col("halftime_away_goals", schema.TypeInt64),
-	col("fulltime_home_goals", schema.TypeInt64),
-	col("fulltime_away_goals", schema.TypeInt64),
-	col("extratime_home_goals", schema.TypeInt64),
-	col("extratime_away_goals", schema.TypeInt64),
-	col("penalty_home_goals", schema.TypeInt64),
-	col("penalty_away_goals", schema.TypeInt64),
-	col("fixture", schema.TypeJSON),
-	col("league", schema.TypeJSON),
-	col("teams", schema.TypeJSON),
-	col("goals", schema.TypeJSON),
-	col("score", schema.TypeJSON),
-}
-
-var playerColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("name", schema.TypeString),
-	col("firstname", schema.TypeString),
-	col("lastname", schema.TypeString),
-	col("age", schema.TypeInt64),
-	col("birth_date", schema.TypeDate),
-	col("birth_place", schema.TypeString),
-	col("birth_country", schema.TypeString),
-	col("nationality", schema.TypeString),
-	col("height", schema.TypeString),
-	col("weight", schema.TypeString),
-	col("injured", schema.TypeBoolean),
-	col("photo", schema.TypeString),
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("team_logo", schema.TypeString),
-	col("position", schema.TypeString),
-	col("number", schema.TypeInt64),
-	col("captain", schema.TypeBoolean),
-	col("appearances", schema.TypeInt64),
-	col("lineups", schema.TypeInt64),
-	col("minutes", schema.TypeInt64),
-	col("rating", schema.TypeFloat64),
-	col("goals_total", schema.TypeInt64),
-	col("goals_assists", schema.TypeInt64),
-	col("goals_saves", schema.TypeInt64),
-	col("yellow_cards", schema.TypeInt64),
-	col("yellowred_cards", schema.TypeInt64),
-	col("red_cards", schema.TypeInt64),
-	col("player", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-	col("statistics", schema.TypeJSON),
-}
-
-var eventColumns = []schema.Column{
-	col("event_key", schema.TypeString),
-	col("fixture_id", schema.TypeInt64),
-	col("event_index", schema.TypeInt64),
-	col("elapsed", schema.TypeInt64),
-	col("extra", schema.TypeInt64),
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("team_logo", schema.TypeString),
-	col("player_id", schema.TypeInt64),
-	col("player_name", schema.TypeString),
-	col("assist_id", schema.TypeInt64),
-	col("assist_name", schema.TypeString),
-	col("type", schema.TypeString),
-	col("detail", schema.TypeString),
-	col("comments", schema.TypeString),
-	col("time", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-	col("player", schema.TypeJSON),
-	col("assist", schema.TypeJSON),
 }

--- a/pkg/source/api_football/api_football_test.go
+++ b/pkg/source/api_football/api_football_test.go
@@ -8,7 +8,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 )
@@ -44,18 +46,16 @@ func TestAPIFootballReadTeamsUsesAuthLeagueAndSeason(t *testing.T) {
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"id"}, table.PrimaryKeys())
+	require.Equal(t, "replace", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table)
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	ids := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 50, ids.Value(0))
-	names := result.Batch.Column(1).(*array.String)
-	require.Equal(t, "Brazil", names.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.ElementsMatch(t, []string{"id", "team", "venue"}, columnNames(record))
+	require.Equal(t, "50", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	// Nested objects are preserved as JSON, not flattened into top-level columns.
+	team := decodeUnknown(t, record, "team", 0).(map[string]interface{})
+	require.Equal(t, "Brazil", team["name"])
 }
 
 func TestAPIFootballPlayersPaginates(t *testing.T) {
@@ -78,21 +78,21 @@ func TestAPIFootballPlayersPaginates(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "players"})
 	require.NoError(t, err)
+	require.Equal(t, "merge", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	// players streams one batch per page.
+	records := readAll(t, table)
 
 	require.Equal(t, []string{"1", "2"}, pages)
-	require.EqualValues(t, 2, result.Batch.NumRows())
-	ids := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 1, ids.Value(0))
-	require.EqualValues(t, 2, ids.Value(1))
+	require.Len(t, records, 2)
+	require.EqualValues(t, 1, records[0].NumRows())
+	require.EqualValues(t, 1, records[1].NumRows())
+	require.ElementsMatch(t, []string{"id", "player", "statistics"}, columnNames(records[0]))
+	require.Equal(t, "1", fmt.Sprint(decodeUnknown(t, records[0], "id", 0)))
+	require.Equal(t, "2", fmt.Sprint(decodeUnknown(t, records[1], "id", 0)))
 }
 
-func TestAPIFootballMatchesFlattenNestedObjects(t *testing.T) {
+func TestAPIFootballMatchesPreserveNestedObjects(t *testing.T) {
 	server := fixtureServer(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/fixtures", r.URL.Path)
 		_, _ = fmt.Fprint(w, fixturesPayload())
@@ -103,20 +103,16 @@ func TestAPIFootballMatchesFlattenNestedObjects(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&timezone=America/New_York&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
+	require.Equal(t, "merge", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table)
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	ids := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 1001, ids.Value(0))
-	venueIDs := result.Batch.Column(7).(*array.Int64)
-	require.EqualValues(t, 200, venueIDs.Value(0))
-	homeTeamIDs := result.Batch.Column(19).(*array.Int64)
-	require.EqualValues(t, 50, homeTeamIDs.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.ElementsMatch(t, []string{"id", "fixture", "league", "teams", "goals", "score"}, columnNames(record))
+	require.Equal(t, "1001", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	teams := decodeUnknown(t, record, "teams", 0).(map[string]interface{})
+	home := teams["home"].(map[string]interface{})
+	require.Equal(t, "50", fmt.Sprint(home["id"]))
 }
 
 func TestAPIFootballStadiumsDeriveFromFixturesAndHydrateVenues(t *testing.T) {
@@ -140,16 +136,12 @@ func TestAPIFootballStadiumsDeriveFromFixturesAndHydrateVenues(t *testing.T) {
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stadiums"})
 	require.NoError(t, err)
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table)
 
 	require.Len(t, requested, 2)
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	names := result.Batch.Column(1).(*array.String)
-	require.Equal(t, "MetLife Stadium", names.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.Equal(t, "200", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	require.Equal(t, "MetLife Stadium", decodeUnknown(t, record, "name", 0))
 }
 
 func TestAPIFootballMatchEventsFanOutFromFixtures(t *testing.T) {
@@ -170,24 +162,79 @@ func TestAPIFootballMatchEventsFanOutFromFixtures(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "match_events"})
 	require.NoError(t, err)
+	require.Equal(t, []string{"event_key"}, table.PrimaryKeys())
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table)
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	fixtureIDs := result.Batch.Column(1).(*array.Int64)
-	require.EqualValues(t, 1001, fixtureIDs.Value(0))
-	eventTypes := result.Batch.Column(12).(*array.String)
-	require.Equal(t, "Goal", eventTypes.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.Subset(t, columnNames(record), []string{"event_key", "fixture_id", "time", "team", "player", "assist", "type", "detail"})
+	require.Equal(t, "1001", fmt.Sprint(decodeUnknown(t, record, "fixture_id", 0)))
+	require.Equal(t, "Goal", decodeUnknown(t, record, "type", 0))
+	require.NotEmpty(t, decodeUnknown(t, record, "event_key", 0))
 }
 
 func TestAPIFootballUnsupportedTable(t *testing.T) {
 	src := NewAPIFootballSource()
 	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "odds"})
 	require.ErrorContains(t, err, "unsupported table")
+}
+
+// readAll drains every streamed batch and registers cleanup for them.
+func readAll(t *testing.T, table source.SourceTable) []arrow.RecordBatch {
+	t.Helper()
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	var records []arrow.RecordBatch
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch != nil {
+			records = append(records, result.Batch)
+		}
+	}
+	t.Cleanup(func() {
+		for _, r := range records {
+			r.Release()
+		}
+	})
+	return records
+}
+
+// readOnce drains all batches and asserts exactly one was emitted.
+func readOnce(t *testing.T, table source.SourceTable) arrow.RecordBatch {
+	t.Helper()
+	records := readAll(t, table)
+	require.Len(t, records, 1)
+	return records[0]
+}
+
+func columnNames(record arrow.RecordBatch) []string {
+	names := make([]string, 0, record.Schema().NumFields())
+	for _, f := range record.Schema().Fields() {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+// decodeUnknown reads a value from an inference-driven Unknown column, which
+// stores each value as a JSON-encoded string in extension-array storage.
+func decodeUnknown(t *testing.T, record arrow.RecordBatch, col string, row int) interface{} {
+	t.Helper()
+	idx := -1
+	for i, f := range record.Schema().Fields() {
+		if f.Name == col {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqualf(t, idx, 0, "column %q not found", col)
+
+	ext, ok := record.Column(idx).(array.ExtensionArray)
+	require.Truef(t, ok, "column %q is not an extension array", col)
+	raw, ok := schemainfer.StringValueAt(ext.Storage(), row)
+	require.Truef(t, ok, "column %q storage is not string-backed", col)
+	value, err := schemainfer.DecodeUnknownValue(raw)
+	require.NoError(t, err)
+	return value
 }
 
 func fixtureServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {

--- a/pkg/source/api_football/api_football_test.go
+++ b/pkg/source/api_football/api_football_test.go
@@ -54,7 +54,7 @@ func TestAPIFootballReadTeamsUsesAuthLeagueAndSeason(t *testing.T) {
 	require.ElementsMatch(t, []string{"id", "team", "venue"}, columnNames(record))
 	require.Equal(t, "50", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
 	// Nested objects are preserved as JSON, not flattened into top-level columns.
-	team := decodeUnknown(t, record, "team", 0).(map[string]interface{})
+	team := decodeUnknown(t, record, "team", 0).(map[string]any)
 	require.Equal(t, "Brazil", team["name"])
 }
 
@@ -110,8 +110,8 @@ func TestAPIFootballMatchesPreserveNestedObjects(t *testing.T) {
 	require.EqualValues(t, 1, record.NumRows())
 	require.ElementsMatch(t, []string{"id", "fixture", "league", "teams", "goals", "score"}, columnNames(record))
 	require.Equal(t, "1001", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
-	teams := decodeUnknown(t, record, "teams", 0).(map[string]interface{})
-	home := teams["home"].(map[string]interface{})
+	teams := decodeUnknown(t, record, "teams", 0).(map[string]any)
+	home := teams["home"].(map[string]any)
 	require.Equal(t, "50", fmt.Sprint(home["id"]))
 }
 
@@ -219,7 +219,7 @@ func columnNames(record arrow.RecordBatch) []string {
 
 // decodeUnknown reads a value from an inference-driven Unknown column, which
 // stores each value as a JSON-encoded string in extension-array storage.
-func decodeUnknown(t *testing.T, record arrow.RecordBatch, col string, row int) interface{} {
+func decodeUnknown(t *testing.T, record arrow.RecordBatch, col string, row int) any {
 	t.Helper()
 	idx := -1
 	for i, f := range record.Schema().Fields() {

--- a/pkg/source/api_football/api_football_test.go
+++ b/pkg/source/api_football/api_football_test.go
@@ -78,7 +78,7 @@ func TestAPIFootballPlayersPaginates(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "players"})
 	require.NoError(t, err)
-	require.Equal(t, "merge", string(table.Strategy()))
+	require.Equal(t, "replace", string(table.Strategy()))
 
 	// players streams one batch per page.
 	records := readAll(t, table)

--- a/pkg/source/api_football/api_football_test.go
+++ b/pkg/source/api_football/api_football_test.go
@@ -135,6 +135,7 @@ func TestAPIFootballStadiumsDeriveFromFixturesAndHydrateVenues(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stadiums"})
 	require.NoError(t, err)
+	require.Equal(t, "merge", string(table.Strategy()))
 
 	record := readOnce(t, table)
 
@@ -163,6 +164,7 @@ func TestAPIFootballMatchEventsFanOutFromFixtures(t *testing.T) {
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "match_events"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"event_key"}, table.PrimaryKeys())
+	require.Equal(t, "merge", string(table.Strategy()))
 
 	record := readOnce(t, table)
 


### PR DESCRIPTION
## What

Refactors the `api-football` source from hand-maintained column type definitions + flattened columns to **schema inference**, and makes it incremental-aware.

### Changes
- **`KnownSchema: false`** — the pipeline infers types from the data; removed all explicit column type definitions (the 6 `*Columns` blocks, `col()`, `selectColumns`).
- **No more flattening** — nested provider objects (`team`, `venue`, `fixture`, `league`, `teams`, `goals`, `score`, `player`, `statistics`, `standing`, …) are preserved as JSON columns instead of being duplicated into typed scalar columns. Only primary-key fields are lifted to top-level columns so `merge` can de-duplicate.
- **`HandlesIncrementality: true`** with per-table strategies. A table uses `merge` when it can be loaded incrementally — its fetch honors the ingestion interval, or its rows carry an update timestamp:
  - `merge`: `matches`, `stadiums`, `match_events` (all source from `/fixtures` and apply its `from`/`to` interval; `match_events` is also append-only with a stable `event_key`), and `group_standings` (`standing.update`).
  - `replace` (full fetch): `teams`, `players` (no time filter, no update field).
- **Server-side interval filtering** via the `/fixtures` `from`/`to` params, applied when both `--interval-start` and `--interval-end` are set. The fixture-derived tables (`matches`, `stadiums`, `match_events`) are scoped to the window; `teams`/`group_standings`/`players` have no time filter.
- **Streaming** — one batch per response (per page for `players`, per fixture for `match_events`) instead of buffering the whole result set, keeping memory flat.
- **Rate limiter** (~80% of the free tier's 10 req/min) and `ctx.Done()` checks in the network loops.
- Docs updated to match the new schema, strategies, and interval behavior.