### PR TITLE
fix(strategy): correct type in streaming_test flush loop

### DIFF
--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -94,7 +94,7 @@ func TestStreaming_CountTriggerFlushes(t *testing.T) {
 	baseDest := &fakeDestination{}
 	dest := &truncateCapableDestination{fakeDestination: baseDest}
 	committer := &fakeCommitter{}
-	loop := newTestLoop(&truncateCapableDestination{fakeDestination: dest}, StreamingOptions{
+	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
 		FlushRecords:  100,
 		Strategy:      config.StrategyMerge,


### PR DESCRIPTION
## What

Fixes a `go vet`/lint failure in `pkg/strategy/streaming_test.go`:

```
vet: pkg/strategy/streaming_test.go:97:67: cannot use dest (variable of type *truncateCapableDestination) as *fakeDestination value in struct literal
```

`dest` is already a `*truncateCapableDestination`, but `TestStreaming_CountTriggerFlushes` wrapped it a second time (`&truncateCapableDestination{fakeDestination: dest}`), which doesn't type-check since the field expects `*fakeDestination`. Now it passes `dest` directly, matching every other `newTestLoop` call site in the file.