### PR TITLE
Refactor football-data source to use schema inference

### DIFF
--- a/docs/soccer-sources/football-data-org.md
+++ b/docs/soccer-sources/football-data-org.md
@@ -43,7 +43,7 @@ World Cup appears in the free tier coverage list. Deep data such as lineups, sub
 | --- | --- | --- | --- | --- |
 | Teams | Yes | `GET /competitions/WC/teams?season=2026` | Free for basic team list; deep data for squads | Use `/teams/{id}` to hydrate a team and squad when plan allows. |
 | Stadiums | Partial | Match/team `venue` string fields | Free for basic strings | No dedicated stadium resource with capacity/geo fields. Treat as a derived table from matches and teams. |
-| Group standings | Yes | `GET /competitions/WC/standings?season=2026` | Free for league tables | Standings behavior differs by competition type; World Cup group tables should be flattened by `stage`, `type`, and `group`. |
+| Group standings | Yes | `GET /competitions/WC/standings?season=2026` | Free for league tables | Standings behavior differs by competition type; emitted as one row per team per standing block, keyed by `stage`, `type`, and `group`. |
 | Matches | Yes | `GET /competitions/WC/matches?season=2026` | Free for fixtures/scores; live/deep fields need paid plan | Use unfold headers for goals, bookings, substitutions, and lineups. |
 | Players | Partial | `/teams/{id}` squad, `/persons/{id}`, `/competitions/WC/scorers` | Deep data for squads/scorers | There is no league-wide players endpoint equivalent to API-Football. |
 | Match events | Partial | Unfolded match fields via `X-Unfold-*` headers | Deep data plan | Events are separate arrays for goals, bookings, substitutions, and lineups rather than one timeline endpoint. |
@@ -101,7 +101,7 @@ football-data.org does not expose a first-class stadium/venue endpoint. Build a 
 - `matches[].venue` from `/competitions/WC/matches`.
 - `team.venue` from `/competitions/WC/teams` or `/teams/{id}`.
 
-Recommended columns for a first connector: `venue_name`, `source_context` (`match` or `team`), `team_id` nullable, `match_id` nullable, and provider raw JSON for future enrichment.
+Implemented columns: `venue_key` (sha1 of the normalized venue name, primary key), `venue`, `source_context` (`team` or `match`), `team_id` (nullable), `match_id` (nullable), and `raw` (the originating team/match object kept as JSON).
 
 ### Group Standings
 
@@ -120,7 +120,7 @@ Recommended World Cup call:
 GET /competitions/WC/standings?season=2026
 ```
 
-Flatten `standings[].table[]` into one row per team per standing block, preserving `stage`, `type`, `group`, `position`, `team`, `playedGames`, `form`, `won`, `draw`, `lost`, `points`, `goalsFor`, `goalsAgainst`, and `goalDifference`.
+Emit one row per team per standing block. The composite key fields (`competition_id`, `season_id`, `stage`, `standing_type`, `group_name`, `team_id`) are surfaced as top-level columns; the full table row is kept under a `standing` JSON column, alongside `competition` and `season`. Fields are not flattened — schema inference types the scalars and preserves nested objects as JSON.
 
 ### Matches
 
@@ -201,7 +201,7 @@ Use this as a limited player-stat source for scorers/assists.
 | `season` | No | YYYY integer | Use `2026`. |
 | `matchday` | No | integer | Compare scorer lists at a matchday. |
 
-For a comprehensive `players` table, planned connector should start from `/competitions/WC/teams?season=2026`, then hydrate `/teams/{id}` and flatten the `squad` array if the selected plan includes squads.
+The implemented `players` table starts from `/competitions/WC/teams?season=2026` to enumerate team IDs, then hydrates each `/teams/{id}` for the richer squad. Each squad member becomes one row keyed by `(team_id, id)`, with the raw player object kept as a `player` JSON column (not flattened). `/teams/{id}` requires plan access, so on the free plan this errors; the basic embedded squad is available on the `teams` table's `squad` column instead.
 
 ### Match Events
 
@@ -220,11 +220,13 @@ Recommended ingestion flow:
 2. Create one normalized event row per item in `goals`, `bookings`, and `substitutions`.
 3. Store lineups separately or use them to enrich player participation, because they are not chronological events.
 
-## Implementation Notes
+## Implementation Notes (as shipped)
 
-- Proposed URI: `football-data://?api_key=<token>&competition=WC&season=2026`.
-- Use `X-Auth-Token`, not a query parameter.
-- Default competition should be `WC` for this World Cup-focused source.
-- Support `base_url` for tests.
-- Treat stadiums and match events as derived tables because the API does not provide first-class stadium or unified event resources.
-- Avoid promising player/event completeness on the free plan; mark deep player/event fields as subscription-dependent.
+- URI: `football-data://?api_key=<token>&competition=WC&season=2026`. Auth via the `X-Auth-Token` header, not a query parameter. `base_url` is supported for tests.
+- Default competition is `WC`; default season is `2026`.
+- Schema is inferred (`KnownSchema: false`) — nested provider objects are preserved as JSON columns and scalar fields are typed automatically. Fields are not flattened into per-attribute columns.
+- Strategy per table: merge where the table accepts a time filter or returns `lastUpdated` (`teams`, `matches`, `match_events`); replace otherwise (`stadiums`, `group_standings`, `players`).
+- `HandlesIncrementality()` is `true`. `matches` and `match_events` pass `--interval-start`/`--interval-end` to the API as server-side `dateFrom`/`dateTo`; explicit URI `date_from`/`date_to` take precedence. Replace tables ignore the interval and always full-fetch.
+- The HTTP client is rate-limited to ~80% of the free tier's 10 requests/minute, and responses are decoded with `json.Number` to preserve large-integer precision.
+- Stadiums and match events are derived tables because the API has no first-class stadium or unified event resource; `players` is derived from team squads.
+- Deep player/event fields are subscription-dependent: `match_events` loads 0 rows without the Deep Data plan, and `players` requires `/teams/{id}` access.

--- a/docs/soccer-sources/football-data-org.md
+++ b/docs/soccer-sources/football-data-org.md
@@ -222,7 +222,7 @@ Recommended ingestion flow:
 
 ## Implementation Notes (as shipped)
 
-- URI: `football-data://?api_key=<token>&competition=WC&season=2026`. Auth via the `X-Auth-Token` header, not a query parameter. `base_url` is supported for tests.
+- URI: `footballdata://?api_key=<token>&competition=WC&season=2026`. Auth via the `X-Auth-Token` header, not a query parameter. `base_url` is supported for tests.
 - Default competition is `WC`; default season is `2026`.
 - Schema is inferred (`KnownSchema: false`) — nested provider objects are preserved as JSON columns and scalar fields are typed automatically. Fields are not flattened into per-attribute columns.
 - Strategy per table: merge where the table accepts a time filter or returns `lastUpdated` (`teams`, `matches`, `match_events`); replace otherwise (`stadiums`, `group_standings`, `players`).

--- a/docs/supported-sources/football-data-org.md
+++ b/docs/supported-sources/football-data-org.md
@@ -9,7 +9,7 @@ For endpoint parameters, plan tiers, and implementation notes across the selecte
 ## URI format
 
 ```plaintext
-football-data://?api_key=<api-token>&competition=WC&season=2026
+footballdata://?api_key=<api-token>&competition=WC&season=2026
 ```
 
 URI parameters:
@@ -31,7 +31,7 @@ Load World Cup 2026 matches into DuckDB:
 
 ```sh
 ingestr ingest \
-  --source-uri 'football-data://?api_key=<api-token>&competition=WC&season=2026' \
+  --source-uri 'footballdata://?api_key=<api-token>&competition=WC&season=2026' \
   --source-table 'matches' \
   --dest-uri 'duckdb:///worldcup2026.duckdb' \
   --dest-table 'soccer.matches'
@@ -41,7 +41,7 @@ Load derived World Cup 2026 match events:
 
 ```sh
 ingestr ingest \
-  --source-uri 'football-data://?api_key=<api-token>&competition=WC&season=2026' \
+  --source-uri 'footballdata://?api_key=<api-token>&competition=WC&season=2026' \
   --source-table 'match_events' \
   --dest-uri 'duckdb:///worldcup2026.duckdb' \
   --dest-table 'soccer.match_events'

--- a/docs/supported-sources/football-data-org.md
+++ b/docs/supported-sources/football-data-org.md
@@ -51,12 +51,12 @@ ingestr ingest \
 
 | Table | PK | Inc Key | Inc Strategy | Details |
 | --- | --- | --- | --- | --- |
-| `teams` | `id` | - | replace | Loads teams from `/competitions/<competition>/teams?season=<season>`. |
-| `stadiums` | `venue_key` | - | replace | Derives distinct venue names from teams and matches. |
-| `group_standings` | `competition_id`, `season_id`, `stage`, `standing_type`, `group_name`, `team_id` | - | replace | Loads and flattens `/competitions/<competition>/standings`. |
-| `matches` | `id` | - | replace | Loads and flattens `/competitions/<competition>/matches`. |
-| `players` | `team_id`, `id` | - | replace | Loads competition teams, hydrates `/teams/<id>`, and flattens squad members when plan access includes squads. |
-| `match_events` | `event_key` | - | replace | Fetches matches with goal, booking, and substitution unfold headers, then normalizes those arrays into event rows. |
+| `teams` | `id` | - | merge | Loads teams from `/competitions/<competition>/teams?season=<season>`. The team's `squad` is included as a JSON column. |
+| `stadiums` | `venue_key` | - | replace | Derives distinct venue names from teams and matches; the originating object is kept under `raw`. |
+| `group_standings` | `competition_id`, `season_id`, `stage`, `standing_type`, `group_name`, `team_id` | - | replace | Loads `/competitions/<competition>/standings`; one row per standings-table entry. |
+| `matches` | `id` | - | merge | Loads `/competitions/<competition>/matches`; supports server-side date filtering. |
+| `players` | `team_id`, `id` | - | replace | Loads competition teams, then hydrates each via `/teams/<id>` for the richer squad. |
+| `match_events` | `event_key` | - | merge | Fetches matches with goal, booking, and substitution unfold headers, then normalizes those arrays into event rows. |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
@@ -64,6 +64,6 @@ Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
 - The API token is sent in the `X-Auth-Token` header.
 - football-data.org rate limits depend on the account plan; the free plan is 10 requests per minute.
-- `players` and `match_events` depend on deep-data plan access. If the token cannot access squads or unfolded match arrays, the source returns the provider's authentication or plan-access error.
+- `players` hydrates `/teams/<id>` so squad members carry the richer detail (`firstName`, `lastName`, `shirtNumber`, `marketValue`, `contract`) that the squad embedded in the `teams` response omits. This endpoint requires plan access — on the free plan it returns the provider's authentication/plan-access error. If you only need the basic squad (`id`, `name`, `position`, `dateOfBirth`, `nationality`), read it from the `teams` table's `squad` column instead.
+- `match_events` depends on Deep Data plan access. On plans without it, football-data.org returns empty goal/booking/substitution arrays, so the table loads 0 rows (no error).
 - `stadiums` is derived because football-data.org exposes venue names on team and match resources rather than a dedicated stadium endpoint.
-- Nested provider objects are preserved as JSON columns while common IDs, names, scores, and status fields are exposed as typed columns.

--- a/pkg/source/football_data_org/football_data_org.go
+++ b/pkg/source/football_data_org/football_data_org.go
@@ -371,6 +371,9 @@ func (s *FootballDataOrgSource) readStandings(ctx context.Context, opts source.R
 		}
 		table := interfaceSlice(standing["table"])
 		for _, rawRow := range table {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			row, ok := rawRow.(map[string]interface{})
 			if !ok {
 				continue
@@ -636,15 +639,16 @@ func extractArray(payload map[string]interface{}, key string) ([]map[string]inte
 }
 
 func makeEvent(matchID, eventType string, index int, event map[string]interface{}) map[string]interface{} {
-	row := map[string]interface{}{
-		"event_key":   makeEventKey(matchID, eventType, index, event),
-		"match_id":    matchID,
-		"event_type":  eventType,
-		"event_index": index,
-	}
+	row := make(map[string]interface{}, len(event)+4)
 	for key, value := range event {
 		row[key] = value
 	}
+	// Set the synthetic keys last so a raw field of the same name can't
+	// overwrite them — the primary key (event_key) must be stable.
+	row["event_key"] = makeEventKey(matchID, eventType, index, event)
+	row["match_id"] = matchID
+	row["event_type"] = eventType
+	row["event_index"] = index
 	return row
 }
 

--- a/pkg/source/football_data_org/football_data_org.go
+++ b/pkg/source/football_data_org/football_data_org.go
@@ -51,7 +51,7 @@ func NewFootballDataOrgSource() *FootballDataOrgSource {
 }
 
 func (s *FootballDataOrgSource) Schemes() []string {
-	return []string{"football-data"}
+	return []string{"footballdata"}
 }
 
 func (s *FootballDataOrgSource) Connect(ctx context.Context, uri string) error {
@@ -106,8 +106,8 @@ func parseURI(raw string) (uriConfig, error) {
 	if err != nil {
 		return uriConfig{}, fmt.Errorf("failed to parse football-data URI: %w", err)
 	}
-	if parsed.Scheme != "football-data" {
-		return uriConfig{}, fmt.Errorf("invalid football-data URI: must start with football-data://")
+	if parsed.Scheme != "footballdata" {
+		return uriConfig{}, fmt.Errorf("invalid football-data URI: must start with footballdata://")
 	}
 
 	values := parsed.Query()

--- a/pkg/source/football_data_org/football_data_org.go
+++ b/pkg/source/football_data_org/football_data_org.go
@@ -1,9 +1,11 @@
 package football_data_org
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -23,12 +25,15 @@ const (
 	defaultBaseURL     = "https://api.football-data.org/v4"
 	defaultCompetition = "WC"
 	defaultSeason      = "2026"
+	// football-data.org's free tier allows 10 requests/minute.
+	rateLimit      = (10 * 0.8) / 60.0
+	rateLimitBurst = 5
 )
 
 type tableConfig struct {
-	columns     []schema.Column
 	primaryKeys []string
-	fetch       func(context.Context, source.ReadOptions) ([]map[string]interface{}, error)
+	strategy    config.IncrementalStrategy
+	read        func(context.Context, source.ReadOptions, chan<- source.RecordBatchResult) error
 }
 
 type FootballDataOrgSource struct {
@@ -65,6 +70,7 @@ func (s *FootballDataOrgSource) Connect(ctx context.Context, uri string) error {
 		httpclient.WithBaseURL(cfg.baseURL),
 		httpclient.WithTimeout(60*time.Second),
 		httpclient.WithHeader("X-Auth-Token", cfg.apiKey),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
 		httpclient.WithDebug(config.DebugMode),
 	)
 	return nil
@@ -159,7 +165,7 @@ func (s *FootballDataOrgSource) Close(ctx context.Context) error {
 }
 
 func (s *FootballDataOrgSource) HandlesIncrementality() bool {
-	return false
+	return true
 }
 
 func (s *FootballDataOrgSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
@@ -172,14 +178,10 @@ func (s *FootballDataOrgSource) GetTable(ctx context.Context, req source.TableRe
 	return &source.DynamicSourceTable{
 		TableName:        req.Name,
 		TablePrimaryKeys: cfg.primaryKeys,
-		TableStrategy:    config.StrategyReplace,
-		KnownSchema:      true,
+		TableStrategy:    cfg.strategy,
+		KnownSchema:      false,
 		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
-			return &schema.TableSchema{
-				Name:        req.Name,
-				Columns:     cfg.columns,
-				PrimaryKeys: cfg.primaryKeys,
-			}, nil
+			return nil, fmt.Errorf("football-data source relies on schema inference")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 			return s.read(ctx, cfg, opts)
@@ -191,33 +193,33 @@ func (s *FootballDataOrgSource) tables() map[string]tableConfig {
 	return map[string]tableConfig{
 		"teams": {
 			primaryKeys: []string{"id"},
-			columns:     teamColumns,
-			fetch:       s.fetchTeams,
+			strategy:    config.StrategyMerge,
+			read:        s.readTeams,
 		},
 		"stadiums": {
 			primaryKeys: []string{"venue_key"},
-			columns:     stadiumColumns,
-			fetch:       s.fetchStadiums,
+			strategy:    config.StrategyReplace,
+			read:        s.readStadiums,
 		},
 		"group_standings": {
 			primaryKeys: []string{"competition_id", "season_id", "stage", "standing_type", "group_name", "team_id"},
-			columns:     standingColumns,
-			fetch:       s.fetchStandings,
+			strategy:    config.StrategyReplace,
+			read:        s.readStandings,
 		},
 		"matches": {
 			primaryKeys: []string{"id"},
-			columns:     matchColumns,
-			fetch:       s.fetchMatches,
+			strategy:    config.StrategyMerge,
+			read:        s.readMatches,
 		},
 		"players": {
 			primaryKeys: []string{"team_id", "id"},
-			columns:     playerColumns,
-			fetch:       s.fetchPlayers,
+			strategy:    config.StrategyReplace,
+			read:        s.readPlayers,
 		},
 		"match_events": {
 			primaryKeys: []string{"event_key"},
-			columns:     eventColumns,
-			fetch:       s.fetchMatchEvents,
+			strategy:    config.StrategyMerge,
+			read:        s.readMatchEvents,
 		},
 	}
 }
@@ -227,60 +229,68 @@ func (s *FootballDataOrgSource) read(ctx context.Context, cfg tableConfig, opts 
 
 	go func() {
 		defer close(results)
-
-		items, err := cfg.fetch(ctx, opts)
-		if err != nil {
+		if err := cfg.read(ctx, opts, results); err != nil {
 			results <- source.RecordBatchResult{Err: err}
-			return
 		}
-		items = selectColumns(items, cfg.columns)
-
-		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cfg.columns, opts.ExcludeColumns)
-		if err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert football-data data to Arrow: %w", err)}
-			return
-		}
-		results <- source.RecordBatchResult{Batch: record}
 	}()
 
 	return results, nil
 }
 
-func (s *FootballDataOrgSource) fetchTeams(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+// sendBatch converts a set of items to an Arrow record and streams it to the
+// results channel. Empty batches are skipped so no zero-row record is emitted.
+func sendBatch(items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert football-data data to Arrow: %w", err)
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}
+
+func (s *FootballDataOrgSource) readTeams(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	payload, err := s.get(ctx, competitionEndpoint(s.competition, "teams"), map[string]string{"season": s.season}, unfoldConfig{})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	items, err := extractArray(payload, "teams")
 	if err != nil {
-		return nil, fmt.Errorf("malformed football-data response from teams: %w", err)
+		return fmt.Errorf("malformed football-data response from teams: %w", err)
 	}
 
-	competition := nestedMap(payload, "competition")
-	season := nestedMap(payload, "season")
 	out := make([]map[string]interface{}, 0, len(items))
 	for _, item := range items {
-		out = append(out, flattenTeam(competition, season, item))
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		out = append(out, item)
 		if opts.Limit > 0 && len(out) >= opts.Limit {
-			return out[:opts.Limit], nil
+			out = out[:opts.Limit]
+			break
 		}
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *FootballDataOrgSource) fetchStadiums(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+func (s *FootballDataOrgSource) readStadiums(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	items := make([]map[string]interface{}, 0)
 	seen := map[string]bool{}
 
 	teamsPayload, err := s.get(ctx, competitionEndpoint(s.competition, "teams"), map[string]string{"season": s.season}, unfoldConfig{})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	teams, err := extractArray(teamsPayload, "teams")
 	if err != nil {
-		return nil, fmt.Errorf("malformed football-data response from teams: %w", err)
+		return fmt.Errorf("malformed football-data response from teams: %w", err)
 	}
 	for _, team := range teams {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		venueName := strings.TrimSpace(valueString(team["venue"]))
 		if venueName == "" {
 			continue
@@ -290,25 +300,30 @@ func (s *FootballDataOrgSource) fetchStadiums(ctx context.Context, opts source.R
 			continue
 		}
 		seen[key] = true
-		items = append(items, normalizeMap(map[string]interface{}{
+		items = append(items, map[string]interface{}{
 			"venue_key":      key,
-			"venue_name":     venueName,
+			"venue":          venueName,
 			"source_context": "team",
 			"team_id":        team["id"],
-			"team_name":      team["name"],
 			"match_id":       nil,
 			"raw":            team,
-		}))
+		})
 		if opts.Limit > 0 && len(items) >= opts.Limit {
-			return items[:opts.Limit], nil
+			return sendBatch(items[:opts.Limit], opts, results)
 		}
 	}
 
-	matches, err := s.fetchRawMatches(ctx, unfoldConfig{})
+	// stadiums uses the replace strategy, so it always derives from the full
+	// match set. Do not pass the ingestion interval through here, otherwise the
+	// snapshot would be silently scoped to the window.
+	matches, err := s.fetchRawMatches(ctx, source.ReadOptions{}, unfoldConfig{})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	for _, match := range matches {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		venueName := strings.TrimSpace(valueString(match["venue"]))
 		if venueName == "" {
 			continue
@@ -318,90 +333,112 @@ func (s *FootballDataOrgSource) fetchStadiums(ctx context.Context, opts source.R
 			continue
 		}
 		seen[key] = true
-		items = append(items, normalizeMap(map[string]interface{}{
+		items = append(items, map[string]interface{}{
 			"venue_key":      key,
-			"venue_name":     venueName,
+			"venue":          venueName,
 			"source_context": "match",
 			"team_id":        nil,
-			"team_name":      nil,
 			"match_id":       match["id"],
 			"raw":            match,
-		}))
+		})
 		if opts.Limit > 0 && len(items) >= opts.Limit {
-			return items[:opts.Limit], nil
+			return sendBatch(items[:opts.Limit], opts, results)
 		}
 	}
 
 	sort.SliceStable(items, func(i, j int) bool {
 		return valueString(items[i]["venue_key"]) < valueString(items[j]["venue_key"])
 	})
-	return items, nil
+	return sendBatch(items, opts, results)
 }
 
-func (s *FootballDataOrgSource) fetchStandings(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+func (s *FootballDataOrgSource) readStandings(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	payload, err := s.get(ctx, competitionEndpoint(s.competition, "standings"), map[string]string{"season": s.season}, unfoldConfig{})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	standings, err := extractArray(payload, "standings")
 	if err != nil {
-		return nil, fmt.Errorf("malformed football-data response from standings: %w", err)
+		return fmt.Errorf("malformed football-data response from standings: %w", err)
 	}
 
 	competition := nestedMap(payload, "competition")
 	season := nestedMap(payload, "season")
 	out := make([]map[string]interface{}, 0)
 	for _, standing := range standings {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		table := interfaceSlice(standing["table"])
 		for _, rawRow := range table {
 			row, ok := rawRow.(map[string]interface{})
 			if !ok {
 				continue
 			}
-			out = append(out, flattenStanding(competition, season, standing, row))
+			out = append(out, map[string]interface{}{
+				"competition_id": competition["id"],
+				"season_id":      season["id"],
+				"stage":          standing["stage"],
+				"standing_type":  standing["type"],
+				"group_name":     standing["group"],
+				"team_id":        nestedMap(row, "team")["id"],
+				"standing":       row,
+				"competition":    competition,
+				"season":         season,
+			})
 			if opts.Limit > 0 && len(out) >= opts.Limit {
-				return out[:opts.Limit], nil
+				return sendBatch(out[:opts.Limit], opts, results)
 			}
 		}
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *FootballDataOrgSource) fetchMatches(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
-	matches, err := s.fetchRawMatches(ctx, s.unfold)
+func (s *FootballDataOrgSource) readMatches(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	matches, err := s.fetchRawMatches(ctx, opts, s.unfold)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	out := make([]map[string]interface{}, 0, len(matches))
 	for _, match := range matches {
-		out = append(out, flattenMatch(match))
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		out = append(out, match)
 		if opts.Limit > 0 && len(out) >= opts.Limit {
-			return out[:opts.Limit], nil
+			return sendBatch(out[:opts.Limit], opts, results)
 		}
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *FootballDataOrgSource) fetchPlayers(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
+func (s *FootballDataOrgSource) readPlayers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	payload, err := s.get(ctx, competitionEndpoint(s.competition, "teams"), map[string]string{"season": s.season}, unfoldConfig{})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	teams, err := extractArray(payload, "teams")
 	if err != nil {
-		return nil, fmt.Errorf("malformed football-data response from teams: %w", err)
+		return fmt.Errorf("malformed football-data response from teams: %w", err)
 	}
 
+	// The teams table already exposes the squad embedded in the competition
+	// response. Hydrate each team through /teams/<id> instead, so players carry
+	// the richer per-player fields (firstName, lastName, shirtNumber,
+	// marketValue, contract) that the embedded squad omits.
 	out := make([]map[string]interface{}, 0)
 	for _, team := range teams {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		teamID := valueString(team["id"])
 		if teamID == "" {
 			continue
 		}
 		detail, err := s.get(ctx, "/teams/"+url.PathEscape(teamID), nil, unfoldConfig{})
 		if err != nil {
-			return nil, err
+			return err
 		}
 		squad := interfaceSlice(detail["squad"])
 		for _, rawPlayer := range squad {
@@ -409,23 +446,30 @@ func (s *FootballDataOrgSource) fetchPlayers(ctx context.Context, opts source.Re
 			if !ok {
 				continue
 			}
-			out = append(out, flattenPlayer(detail, player))
+			out = append(out, map[string]interface{}{
+				"id":      player["id"],
+				"team_id": team["id"],
+				"player":  player,
+			})
 			if opts.Limit > 0 && len(out) >= opts.Limit {
-				return out[:opts.Limit], nil
+				return sendBatch(out[:opts.Limit], opts, results)
 			}
 		}
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *FootballDataOrgSource) fetchMatchEvents(ctx context.Context, opts source.ReadOptions) ([]map[string]interface{}, error) {
-	matches, err := s.fetchRawMatches(ctx, unfoldConfig{goals: true, bookings: true, subs: true})
+func (s *FootballDataOrgSource) readMatchEvents(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	matches, err := s.fetchRawMatches(ctx, opts, unfoldConfig{goals: true, bookings: true, subs: true})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	out := make([]map[string]interface{}, 0)
 	for _, match := range matches {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		matchID := valueString(match["id"])
 		eventGroups := []struct {
 			name string
@@ -441,9 +485,9 @@ func (s *FootballDataOrgSource) fetchMatchEvents(ctx context.Context, opts sourc
 				if !ok {
 					continue
 				}
-				out = append(out, flattenEvent(matchID, group.name, idx, event))
+				out = append(out, makeEvent(matchID, group.name, idx, event))
 				if opts.Limit > 0 && len(out) >= opts.Limit {
-					return out[:opts.Limit], nil
+					return sendBatch(out[:opts.Limit], opts, results)
 				}
 			}
 		}
@@ -453,16 +497,16 @@ func (s *FootballDataOrgSource) fetchMatchEvents(ctx context.Context, opts sourc
 			if !ok {
 				continue
 			}
-			out = append(out, flattenEvent(matchID, "substitution", idx, event))
+			out = append(out, makeEvent(matchID, "substitution", idx, event))
 			if opts.Limit > 0 && len(out) >= opts.Limit {
-				return out[:opts.Limit], nil
+				return sendBatch(out[:opts.Limit], opts, results)
 			}
 		}
 	}
-	return out, nil
+	return sendBatch(out, opts, results)
 }
 
-func (s *FootballDataOrgSource) fetchRawMatches(ctx context.Context, unfold unfoldConfig) ([]map[string]interface{}, error) {
+func (s *FootballDataOrgSource) fetchRawMatches(ctx context.Context, opts source.ReadOptions, unfold unfoldConfig) ([]map[string]interface{}, error) {
 	params := map[string]string{"season": s.season}
 	if s.filters.matchday != "" {
 		params["matchday"] = s.filters.matchday
@@ -482,6 +526,13 @@ func (s *FootballDataOrgSource) fetchRawMatches(ctx context.Context, unfold unfo
 	if s.filters.group != "" {
 		params["group"] = s.filters.group
 	}
+	// The matches endpoint supports server-side date filtering via dateFrom/dateTo
+	// (YYYY-MM-DD). When the URI does not pin the window explicitly, honour the
+	// ingestion interval so matches and the tables derived from them stay scoped.
+	if s.filters.dateFrom == "" && s.filters.dateTo == "" && opts.IntervalStart != nil && opts.IntervalEnd != nil {
+		params["dateFrom"] = opts.IntervalStart.UTC().Format("2006-01-02")
+		params["dateTo"] = opts.IntervalEnd.UTC().Format("2006-01-02")
+	}
 
 	payload, err := s.get(ctx, competitionEndpoint(s.competition, "matches"), params, unfold)
 	if err != nil {
@@ -499,8 +550,7 @@ func (s *FootballDataOrgSource) get(ctx context.Context, endpoint string, params
 		return nil, fmt.Errorf("football-data source is not connected")
 	}
 
-	var payload map[string]interface{}
-	req := s.client.R(ctx).SetResult(&payload)
+	req := s.client.R(ctx)
 	for key, value := range params {
 		if value != "" {
 			req.SetQueryParam(key, value)
@@ -515,12 +565,20 @@ func (s *FootballDataOrgSource) get(ctx context.Context, endpoint string, params
 	if err := checkResponse(endpoint, resp); err != nil {
 		return nil, err
 	}
-	if len(payload) == 0 {
-		if err := resp.JSON(&payload); err != nil {
-			return nil, fmt.Errorf("malformed football-data response from %s: %w", endpoint, err)
-		}
+
+	var payload map[string]interface{}
+	if err := jsonUseNumber(resp.Body(), &payload); err != nil {
+		return nil, fmt.Errorf("malformed football-data response from %s: %w", endpoint, err)
 	}
 	return normalizeMap(payload), nil
+}
+
+// jsonUseNumber decodes JSON while preserving large integers as json.Number,
+// so IDs and counts are not silently degraded through float64.
+func jsonUseNumber(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
 }
 
 func applyUnfoldHeaders(req *httpclient.Request, unfold unfoldConfig) {
@@ -577,186 +635,17 @@ func extractArray(payload map[string]interface{}, key string) ([]map[string]inte
 	return items, nil
 }
 
-func flattenTeam(competition, season, team map[string]interface{}) map[string]interface{} {
-	area := nestedMap(team, "area")
-	out := map[string]interface{}{
-		"id":               team["id"],
-		"name":             team["name"],
-		"short_name":       team["shortName"],
-		"tla":              team["tla"],
-		"crest":            team["crest"],
-		"address":          team["address"],
-		"website":          team["website"],
-		"founded":          team["founded"],
-		"club_colors":      team["clubColors"],
-		"venue":            team["venue"],
-		"last_updated":     team["lastUpdated"],
-		"area_id":          area["id"],
-		"area_name":        area["name"],
-		"area_code":        area["code"],
-		"area_flag":        area["flag"],
-		"competition_id":   competition["id"],
-		"competition_code": competition["code"],
-		"competition_name": competition["name"],
-		"season_id":        season["id"],
-		"season_start":     season["startDate"],
-		"season_end":       season["endDate"],
-		"team":             team,
-		"area":             area,
+func makeEvent(matchID, eventType string, index int, event map[string]interface{}) map[string]interface{} {
+	row := map[string]interface{}{
+		"event_key":   makeEventKey(matchID, eventType, index, event),
+		"match_id":    matchID,
+		"event_type":  eventType,
+		"event_index": index,
 	}
-	return normalizeMap(out)
-}
-
-func flattenStanding(competition, season, standing, row map[string]interface{}) map[string]interface{} {
-	team := nestedMap(row, "team")
-	out := map[string]interface{}{
-		"competition_id":   competition["id"],
-		"competition_code": competition["code"],
-		"competition_name": competition["name"],
-		"season_id":        season["id"],
-		"season_start":     season["startDate"],
-		"season_end":       season["endDate"],
-		"stage":            standing["stage"],
-		"standing_type":    standing["type"],
-		"group_name":       standing["group"],
-		"position":         row["position"],
-		"team_id":          team["id"],
-		"team_name":        team["name"],
-		"team_short_name":  team["shortName"],
-		"team_tla":         team["tla"],
-		"team_crest":       team["crest"],
-		"played_games":     row["playedGames"],
-		"form":             row["form"],
-		"won":              row["won"],
-		"draw":             row["draw"],
-		"lost":             row["lost"],
-		"points":           row["points"],
-		"goals_for":        row["goalsFor"],
-		"goals_against":    row["goalsAgainst"],
-		"goal_difference":  row["goalDifference"],
-		"standing":         standing,
-		"team":             team,
-		"competition":      competition,
-		"season":           season,
+	for key, value := range event {
+		row[key] = value
 	}
-	return normalizeMap(out)
-}
-
-func flattenMatch(match map[string]interface{}) map[string]interface{} {
-	competition := nestedMap(match, "competition")
-	season := nestedMap(match, "season")
-	homeTeam := nestedMap(match, "homeTeam")
-	awayTeam := nestedMap(match, "awayTeam")
-	score := nestedMap(match, "score")
-	fullTime := nestedMap(score, "fullTime")
-	halfTime := nestedMap(score, "halfTime")
-	regularTime := nestedMap(score, "regularTime")
-	extraTime := nestedMap(score, "extraTime")
-	penalties := nestedMap(score, "penalties")
-	out := map[string]interface{}{
-		"id":                     match["id"],
-		"utc_date":               match["utcDate"],
-		"status":                 match["status"],
-		"minute":                 match["minute"],
-		"injury_time":            match["injuryTime"],
-		"attendance":             match["attendance"],
-		"venue":                  match["venue"],
-		"matchday":               match["matchday"],
-		"stage":                  match["stage"],
-		"group_name":             match["group"],
-		"last_updated":           match["lastUpdated"],
-		"competition_id":         competition["id"],
-		"competition_code":       competition["code"],
-		"competition_name":       competition["name"],
-		"season_id":              season["id"],
-		"season_start":           season["startDate"],
-		"season_end":             season["endDate"],
-		"home_team_id":           homeTeam["id"],
-		"home_team_name":         homeTeam["name"],
-		"home_team_short_name":   homeTeam["shortName"],
-		"home_team_tla":          homeTeam["tla"],
-		"home_team_crest":        homeTeam["crest"],
-		"away_team_id":           awayTeam["id"],
-		"away_team_name":         awayTeam["name"],
-		"away_team_short_name":   awayTeam["shortName"],
-		"away_team_tla":          awayTeam["tla"],
-		"away_team_crest":        awayTeam["crest"],
-		"winner":                 score["winner"],
-		"duration":               score["duration"],
-		"fulltime_home_goals":    fullTime["home"],
-		"fulltime_away_goals":    fullTime["away"],
-		"halftime_home_goals":    halfTime["home"],
-		"halftime_away_goals":    halfTime["away"],
-		"regulartime_home_goals": regularTime["home"],
-		"regulartime_away_goals": regularTime["away"],
-		"extratime_home_goals":   extraTime["home"],
-		"extratime_away_goals":   extraTime["away"],
-		"penalty_home_goals":     penalties["home"],
-		"penalty_away_goals":     penalties["away"],
-		"match":                  match,
-		"competition":            competition,
-		"season":                 season,
-		"home_team":              homeTeam,
-		"away_team":              awayTeam,
-		"score":                  score,
-		"referees":               interfaceSlice(match["referees"]),
-		"goals":                  interfaceSlice(match["goals"]),
-		"bookings":               interfaceSlice(match["bookings"]),
-		"substitutions":          firstNonNil(match["substitutions"], match["subs"]),
-	}
-	return normalizeMap(out)
-}
-
-func flattenPlayer(team, player map[string]interface{}) map[string]interface{} {
-	out := map[string]interface{}{
-		"team_id":       team["id"],
-		"team_name":     team["name"],
-		"team_tla":      team["tla"],
-		"id":            player["id"],
-		"name":          player["name"],
-		"first_name":    player["firstName"],
-		"last_name":     player["lastName"],
-		"date_of_birth": player["dateOfBirth"],
-		"nationality":   player["nationality"],
-		"section":       player["section"],
-		"position":      player["position"],
-		"shirt_number":  player["shirtNumber"],
-		"last_updated":  player["lastUpdated"],
-		"player":        player,
-		"team":          team,
-	}
-	return normalizeMap(out)
-}
-
-func flattenEvent(matchID, eventType string, index int, event map[string]interface{}) map[string]interface{} {
-	team := firstNestedMap(event, "team")
-	player := firstNestedMap(event, "player", "scorer")
-	assist := firstNestedMap(event, "assist")
-	playerIn := firstNestedMap(event, "playerIn")
-	playerOut := firstNestedMap(event, "playerOut")
-	out := map[string]interface{}{
-		"event_key":       makeEventKey(matchID, eventType, index, event),
-		"match_id":        matchID,
-		"event_type":      eventType,
-		"event_index":     index,
-		"minute":          firstNonNil(event["minute"], event["time"]),
-		"injury_time":     firstNonNil(event["injuryTime"], event["injury_time"]),
-		"team_id":         team["id"],
-		"team_name":       team["name"],
-		"player_id":       player["id"],
-		"player_name":     player["name"],
-		"assist_id":       assist["id"],
-		"assist_name":     assist["name"],
-		"player_in_id":    playerIn["id"],
-		"player_in_name":  playerIn["name"],
-		"player_out_id":   playerOut["id"],
-		"player_out_name": playerOut["name"],
-		"card":            firstNonNil(event["card"], event["cardType"]),
-		"detail":          firstNonNil(event["type"], event["detail"], event["description"]),
-		"score":           event["score"],
-		"raw":             event,
-	}
-	return normalizeMap(out)
+	return row
 }
 
 func competitionEndpoint(competition, resource string) string {
@@ -880,182 +769,4 @@ func parseBool(value string) bool {
 	default:
 		return false
 	}
-}
-
-func selectColumns(items []map[string]interface{}, columns []schema.Column) []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(items))
-	for _, item := range items {
-		selected := make(map[string]interface{}, len(columns))
-		for _, column := range columns {
-			if value, ok := item[column.Name]; ok {
-				selected[column.Name] = value
-			}
-		}
-		out = append(out, selected)
-	}
-	return out
-}
-
-func col(name string, dt schema.DataType) schema.Column {
-	return schema.Column{Name: name, DataType: dt, Nullable: true}
-}
-
-var teamColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("name", schema.TypeString),
-	col("short_name", schema.TypeString),
-	col("tla", schema.TypeString),
-	col("crest", schema.TypeString),
-	col("address", schema.TypeString),
-	col("website", schema.TypeString),
-	col("founded", schema.TypeInt64),
-	col("club_colors", schema.TypeString),
-	col("venue", schema.TypeString),
-	col("last_updated", schema.TypeTimestampTZ),
-	col("area_id", schema.TypeInt64),
-	col("area_name", schema.TypeString),
-	col("area_code", schema.TypeString),
-	col("area_flag", schema.TypeString),
-	col("competition_id", schema.TypeInt64),
-	col("competition_code", schema.TypeString),
-	col("competition_name", schema.TypeString),
-	col("season_id", schema.TypeInt64),
-	col("season_start", schema.TypeDate),
-	col("season_end", schema.TypeDate),
-	col("team", schema.TypeJSON),
-	col("area", schema.TypeJSON),
-}
-
-var stadiumColumns = []schema.Column{
-	col("venue_key", schema.TypeString),
-	col("venue_name", schema.TypeString),
-	col("source_context", schema.TypeString),
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("match_id", schema.TypeInt64),
-	col("raw", schema.TypeJSON),
-}
-
-var standingColumns = []schema.Column{
-	col("competition_id", schema.TypeInt64),
-	col("competition_code", schema.TypeString),
-	col("competition_name", schema.TypeString),
-	col("season_id", schema.TypeInt64),
-	col("season_start", schema.TypeDate),
-	col("season_end", schema.TypeDate),
-	col("stage", schema.TypeString),
-	col("standing_type", schema.TypeString),
-	col("group_name", schema.TypeString),
-	col("position", schema.TypeInt64),
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("team_short_name", schema.TypeString),
-	col("team_tla", schema.TypeString),
-	col("team_crest", schema.TypeString),
-	col("played_games", schema.TypeInt64),
-	col("form", schema.TypeString),
-	col("won", schema.TypeInt64),
-	col("draw", schema.TypeInt64),
-	col("lost", schema.TypeInt64),
-	col("points", schema.TypeInt64),
-	col("goals_for", schema.TypeInt64),
-	col("goals_against", schema.TypeInt64),
-	col("goal_difference", schema.TypeInt64),
-	col("standing", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-	col("competition", schema.TypeJSON),
-	col("season", schema.TypeJSON),
-}
-
-var matchColumns = []schema.Column{
-	col("id", schema.TypeInt64),
-	col("utc_date", schema.TypeTimestampTZ),
-	col("status", schema.TypeString),
-	col("minute", schema.TypeInt64),
-	col("injury_time", schema.TypeInt64),
-	col("attendance", schema.TypeInt64),
-	col("venue", schema.TypeString),
-	col("matchday", schema.TypeInt64),
-	col("stage", schema.TypeString),
-	col("group_name", schema.TypeString),
-	col("last_updated", schema.TypeTimestampTZ),
-	col("competition_id", schema.TypeInt64),
-	col("competition_code", schema.TypeString),
-	col("competition_name", schema.TypeString),
-	col("season_id", schema.TypeInt64),
-	col("season_start", schema.TypeDate),
-	col("season_end", schema.TypeDate),
-	col("home_team_id", schema.TypeInt64),
-	col("home_team_name", schema.TypeString),
-	col("home_team_short_name", schema.TypeString),
-	col("home_team_tla", schema.TypeString),
-	col("home_team_crest", schema.TypeString),
-	col("away_team_id", schema.TypeInt64),
-	col("away_team_name", schema.TypeString),
-	col("away_team_short_name", schema.TypeString),
-	col("away_team_tla", schema.TypeString),
-	col("away_team_crest", schema.TypeString),
-	col("winner", schema.TypeString),
-	col("duration", schema.TypeString),
-	col("fulltime_home_goals", schema.TypeInt64),
-	col("fulltime_away_goals", schema.TypeInt64),
-	col("halftime_home_goals", schema.TypeInt64),
-	col("halftime_away_goals", schema.TypeInt64),
-	col("regulartime_home_goals", schema.TypeInt64),
-	col("regulartime_away_goals", schema.TypeInt64),
-	col("extratime_home_goals", schema.TypeInt64),
-	col("extratime_away_goals", schema.TypeInt64),
-	col("penalty_home_goals", schema.TypeInt64),
-	col("penalty_away_goals", schema.TypeInt64),
-	col("match", schema.TypeJSON),
-	col("competition", schema.TypeJSON),
-	col("season", schema.TypeJSON),
-	col("home_team", schema.TypeJSON),
-	col("away_team", schema.TypeJSON),
-	col("score", schema.TypeJSON),
-	col("referees", schema.TypeJSON),
-	col("goals", schema.TypeJSON),
-	col("bookings", schema.TypeJSON),
-	col("substitutions", schema.TypeJSON),
-}
-
-var playerColumns = []schema.Column{
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("team_tla", schema.TypeString),
-	col("id", schema.TypeInt64),
-	col("name", schema.TypeString),
-	col("first_name", schema.TypeString),
-	col("last_name", schema.TypeString),
-	col("date_of_birth", schema.TypeDate),
-	col("nationality", schema.TypeString),
-	col("section", schema.TypeString),
-	col("position", schema.TypeString),
-	col("shirt_number", schema.TypeInt64),
-	col("last_updated", schema.TypeTimestampTZ),
-	col("player", schema.TypeJSON),
-	col("team", schema.TypeJSON),
-}
-
-var eventColumns = []schema.Column{
-	col("event_key", schema.TypeString),
-	col("match_id", schema.TypeInt64),
-	col("event_type", schema.TypeString),
-	col("event_index", schema.TypeInt64),
-	col("minute", schema.TypeInt64),
-	col("injury_time", schema.TypeInt64),
-	col("team_id", schema.TypeInt64),
-	col("team_name", schema.TypeString),
-	col("player_id", schema.TypeInt64),
-	col("player_name", schema.TypeString),
-	col("assist_id", schema.TypeInt64),
-	col("assist_name", schema.TypeString),
-	col("player_in_id", schema.TypeInt64),
-	col("player_in_name", schema.TypeString),
-	col("player_out_id", schema.TypeInt64),
-	col("player_out_name", schema.TypeString),
-	col("card", schema.TypeString),
-	col("detail", schema.TypeString),
-	col("score", schema.TypeJSON),
-	col("raw", schema.TypeJSON),
 }

--- a/pkg/source/football_data_org/football_data_org_test.go
+++ b/pkg/source/football_data_org/football_data_org_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/registry"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +32,7 @@ func TestFootballDataOrgRejectsInvalidSeasonAndMatchday(t *testing.T) {
 	require.ErrorContains(t, err, "matchday")
 }
 
-func TestFootballDataOrgReadTeamsUsesAuthCompetitionAndSeason(t *testing.T) {
+func TestFootballDataOrgReadTeamsPreservesNestedObjects(t *testing.T) {
 	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/competitions/WC/teams", r.URL.Path)
 		require.Equal(t, "2026", r.URL.Query().Get("season"))
@@ -43,20 +46,19 @@ func TestFootballDataOrgReadTeamsUsesAuthCompetitionAndSeason(t *testing.T) {
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"id"}, table.PrimaryKeys())
+	require.Equal(t, "merge", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{})
+	defer record.Release()
 
-	require.EqualValues(t, 2, result.Batch.NumRows())
-	ids := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 764, ids.Value(0))
-	names := result.Batch.Column(1).(*array.String)
-	require.Equal(t, "Brazil", names.Value(0))
-	venues := result.Batch.Column(9).(*array.String)
-	require.Equal(t, "Maracana", venues.Value(0))
+	require.EqualValues(t, 2, record.NumRows())
+	require.Equal(t, "764", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	require.Equal(t, "Brazil", decodeUnknown(t, record, "name", 0))
+	require.Equal(t, "Maracana", decodeUnknown(t, record, "venue", 0))
+	// Nested objects are preserved as JSON, not flattened into top-level columns.
+	require.NotContains(t, columnNames(record), "area_id")
+	area := decodeUnknown(t, record, "area", 0).(map[string]interface{})
+	require.Equal(t, "Brazil", area["name"])
 }
 
 func TestFootballDataOrgMatchesUsesFiltersAndOptionalUnfoldHeaders(t *testing.T) {
@@ -80,21 +82,62 @@ func TestFootballDataOrgMatchesUsesFiltersAndOptionalUnfoldHeaders(t *testing.T)
 	require.NoError(t, src.Connect(context.Background(), uri))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
+	require.Equal(t, "merge", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{})
+	defer record.Release()
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	ids := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 4001, ids.Value(0))
-	homeTeamIDs := result.Batch.Column(17).(*array.Int64)
-	require.EqualValues(t, 764, homeTeamIDs.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.Equal(t, "4001", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	require.NotContains(t, columnNames(record), "home_team_id")
+	homeTeam := decodeUnknown(t, record, "homeTeam", 0).(map[string]interface{})
+	require.Equal(t, "764", fmt.Sprint(homeTeam["id"]))
 }
 
-func TestFootballDataOrgStandingsFlattenTableRows(t *testing.T) {
+func TestFootballDataOrgMatchesAppliesIngestionInterval(t *testing.T) {
+	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/competitions/WC/matches", r.URL.Path)
+		require.Equal(t, "2026-06-11", r.URL.Query().Get("dateFrom"))
+		require.Equal(t, "2026-06-20", r.URL.Query().Get("dateTo"))
+		_, _ = fmt.Fprint(w, matchesPayload())
+	})
+	defer server.Close()
+
+	src := NewFootballDataOrgSource()
+	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
+	require.NoError(t, err)
+
+	start := time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	record := readOnce(t, table, source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	defer record.Release()
+	require.EqualValues(t, 1, record.NumRows())
+}
+
+func TestFootballDataOrgMatchesURIFiltersOverrideInterval(t *testing.T) {
+	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Explicit URI date filters take precedence over the ingestion interval.
+		require.Equal(t, "2026-07-01", r.URL.Query().Get("dateFrom"))
+		require.Equal(t, "2026-07-10", r.URL.Query().Get("dateTo"))
+		_, _ = fmt.Fprint(w, matchesPayload())
+	})
+	defer server.Close()
+
+	src := NewFootballDataOrgSource()
+	uri := "football-data://?api_key=test-token&date_from=2026-07-01&date_to=2026-07-10&base_url=" + url.QueryEscape(server.URL)
+	require.NoError(t, src.Connect(context.Background(), uri))
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
+	require.NoError(t, err)
+
+	start := time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	record := readOnce(t, table, source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	defer record.Release()
+	require.EqualValues(t, 1, record.NumRows())
+}
+
+func TestFootballDataOrgStandingsEmitsTableRowsRaw(t *testing.T) {
 	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/competitions/WC/standings", r.URL.Path)
 		_, _ = fmt.Fprint(w, standingsPayload())
@@ -105,18 +148,18 @@ func TestFootballDataOrgStandingsFlattenTableRows(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "group_standings"})
 	require.NoError(t, err)
+	require.Equal(t, "replace", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{})
+	defer record.Release()
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	groupNames := result.Batch.Column(8).(*array.String)
-	require.Equal(t, "GROUP_A", groupNames.Value(0))
-	points := result.Batch.Column(20).(*array.Int64)
-	require.EqualValues(t, 3, points.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.Equal(t, "GROUP_A", decodeUnknown(t, record, "group_name", 0))
+	require.Equal(t, "764", fmt.Sprint(decodeUnknown(t, record, "team_id", 0)))
+	// The full standing row is kept as a nested object instead of flattened.
+	require.NotContains(t, columnNames(record), "points")
+	standing := decodeUnknown(t, record, "standing", 0).(map[string]interface{})
+	require.Equal(t, "3", fmt.Sprint(standing["points"]))
 }
 
 func TestFootballDataOrgStadiumsDeriveAndDeduplicate(t *testing.T) {
@@ -136,19 +179,19 @@ func TestFootballDataOrgStadiumsDeriveAndDeduplicate(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stadiums"})
 	require.NoError(t, err)
+	require.Equal(t, "replace", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{})
+	defer record.Release()
 
-	require.EqualValues(t, 2, result.Batch.NumRows())
-	names := result.Batch.Column(1).(*array.String)
-	require.ElementsMatch(t, []string{"Maracana", "MetLife Stadium"}, []string{names.Value(0), names.Value(1)})
+	require.EqualValues(t, 2, record.NumRows())
+	require.ElementsMatch(t, []string{"Maracana", "MetLife Stadium"}, []string{
+		fmt.Sprint(decodeUnknown(t, record, "venue", 0)),
+		fmt.Sprint(decodeUnknown(t, record, "venue", 1)),
+	})
 }
 
-func TestFootballDataOrgPlayersHydrateTeamSquads(t *testing.T) {
+func TestFootballDataOrgPlayersHydrateTeamDetails(t *testing.T) {
 	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/competitions/WC/teams":
@@ -168,21 +211,24 @@ func TestFootballDataOrgPlayersHydrateTeamSquads(t *testing.T) {
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "players"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"team_id", "id"}, table.PrimaryKeys())
+	require.Equal(t, "replace", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{Limit: 1})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{Limit: 1})
+	defer record.Release()
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	teamIDs := result.Batch.Column(0).(*array.Int64)
-	require.EqualValues(t, 764, teamIDs.Value(0))
-	playerIDs := result.Batch.Column(3).(*array.Int64)
-	require.EqualValues(t, 10, playerIDs.Value(0))
+	require.EqualValues(t, 1, record.NumRows())
+	require.Equal(t, "764", fmt.Sprint(decodeUnknown(t, record, "team_id", 0)))
+	require.Equal(t, "10", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	require.NotContains(t, columnNames(record), "first_name")
+	// The raw player object is kept as JSON and carries the richer fields the
+	// /teams/<id> detail endpoint returns beyond the embedded squad.
+	player := decodeUnknown(t, record, "player", 0).(map[string]interface{})
+	require.Equal(t, "Forward One", player["name"])
+	require.Equal(t, "Forward", player["firstName"])
+	require.Equal(t, "10", fmt.Sprint(player["shirtNumber"]))
 }
 
-func TestFootballDataOrgMatchEventsUseUnfoldHeadersAndFlatten(t *testing.T) {
+func TestFootballDataOrgMatchEventsUseUnfoldHeaders(t *testing.T) {
 	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/competitions/WC/matches", r.URL.Path)
 		require.Equal(t, "true", r.Header.Get("X-Unfold-Goals"))
@@ -196,20 +242,18 @@ func TestFootballDataOrgMatchEventsUseUnfoldHeadersAndFlatten(t *testing.T) {
 	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "match_events"})
 	require.NoError(t, err)
+	require.Equal(t, []string{"event_key"}, table.PrimaryKeys())
+	require.Equal(t, "merge", string(table.Strategy()))
 
-	results, err := table.Read(context.Background(), source.ReadOptions{})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{})
+	defer record.Release()
 
-	require.EqualValues(t, 3, result.Batch.NumRows())
-	eventTypes := result.Batch.Column(2).(*array.String)
-	require.Equal(t, "goal", eventTypes.Value(0))
-	require.Equal(t, "booking", eventTypes.Value(1))
-	require.Equal(t, "substitution", eventTypes.Value(2))
-	playerIDs := result.Batch.Column(8).(*array.Int64)
-	require.EqualValues(t, 10, playerIDs.Value(0))
+	require.EqualValues(t, 3, record.NumRows())
+	require.Subset(t, columnNames(record), []string{"event_key", "match_id", "event_type", "event_index"})
+	require.Equal(t, "goal", decodeUnknown(t, record, "event_type", 0))
+	require.Equal(t, "booking", decodeUnknown(t, record, "event_type", 1))
+	require.Equal(t, "substitution", decodeUnknown(t, record, "event_type", 2))
+	require.NotEmpty(t, decodeUnknown(t, record, "event_key", 0))
 }
 
 func TestFootballDataOrgReadRespectsExcludeColumns(t *testing.T) {
@@ -223,14 +267,12 @@ func TestFootballDataOrgReadRespectsExcludeColumns(t *testing.T) {
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
 
-	results, err := table.Read(context.Background(), source.ReadOptions{Limit: 1, ExcludeColumns: []string{"team", "area"}})
-	require.NoError(t, err)
-	result := <-results
-	require.NoError(t, result.Err)
-	defer result.Batch.Release()
+	record := readOnce(t, table, source.ReadOptions{Limit: 1, ExcludeColumns: []string{"area", "lastUpdated"}})
+	defer record.Release()
 
-	require.EqualValues(t, 1, result.Batch.NumRows())
-	require.EqualValues(t, len(teamColumns)-2, int(result.Batch.NumCols()))
+	require.EqualValues(t, 1, record.NumRows())
+	require.NotContains(t, columnNames(record), "area")
+	require.NotContains(t, columnNames(record), "lastUpdated")
 }
 
 func TestFootballDataOrgReadReturnsAPIError(t *testing.T) {
@@ -265,6 +307,46 @@ func TestFootballDataOrgUnsupportedTable(t *testing.T) {
 	require.ErrorContains(t, err, "unsupported table")
 }
 
+func readOnce(t *testing.T, table source.SourceTable, opts source.ReadOptions) arrow.RecordBatch {
+	t.Helper()
+	results, err := table.Read(context.Background(), opts)
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	return result.Batch
+}
+
+func columnNames(record arrow.RecordBatch) []string {
+	names := make([]string, 0, record.Schema().NumFields())
+	for _, f := range record.Schema().Fields() {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+// decodeUnknown reads a value from an inference-driven Unknown column, which
+// stores each value as a JSON-encoded string in extension-array storage.
+func decodeUnknown(t *testing.T, record arrow.RecordBatch, col string, row int) interface{} {
+	t.Helper()
+	idx := -1
+	for i, f := range record.Schema().Fields() {
+		if f.Name == col {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqualf(t, idx, 0, "column %q not found", col)
+
+	ext, ok := record.Column(idx).(array.ExtensionArray)
+	require.Truef(t, ok, "column %q is not an extension array", col)
+	raw, ok := schemainfer.StringValueAt(ext.Storage(), row)
+	require.Truef(t, ok, "column %q storage is not string-backed", col)
+	value, err := schemainfer.DecodeUnknownValue(raw)
+	require.NoError(t, err)
+	return value
+}
+
 func footballDataServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -274,7 +356,7 @@ func footballDataServer(t *testing.T, handler http.HandlerFunc) *httptest.Server
 }
 
 func teamsPayload() string {
-	return `{"competition":{"id":2000,"name":"FIFA World Cup","code":"WC","type":"CUP","emblem":"wc.png"},"season":{"id":2026,"startDate":"2026-06-11","endDate":"2026-07-19"},"teams":[{"id":764,"name":"Brazil","shortName":"Brazil","tla":"BRA","crest":"bra.png","address":"Rio","website":"https://cbf.example","founded":1914,"clubColors":"Yellow / Green","venue":"Maracana","lastUpdated":"2025-12-01T00:00:00Z","area":{"id":2032,"name":"Brazil","code":"BRA","flag":"br.png"}},{"id":773,"name":"France","shortName":"France","tla":"FRA","crest":"fra.png","address":"Paris","website":"https://fff.example","founded":1919,"clubColors":"Blue","venue":"Maracana","lastUpdated":"2025-12-01T00:00:00Z","area":{"id":2081,"name":"France","code":"FRA","flag":"fr.png"}}]}`
+	return `{"competition":{"id":2000,"name":"FIFA World Cup","code":"WC","type":"CUP","emblem":"wc.png"},"season":{"id":2026,"startDate":"2026-06-11","endDate":"2026-07-19"},"teams":[{"id":764,"name":"Brazil","shortName":"Brazil","tla":"BRA","crest":"bra.png","address":"Rio","website":"https://cbf.example","founded":1914,"clubColors":"Yellow / Green","venue":"Maracana","lastUpdated":"2025-12-01T00:00:00Z","area":{"id":2032,"name":"Brazil","code":"BRA","flag":"br.png"},"squad":[{"id":10,"name":"Forward One","position":"Attacker","dateOfBirth":"1999-01-02","nationality":"Brazil"}]},{"id":773,"name":"France","shortName":"France","tla":"FRA","crest":"fra.png","address":"Paris","website":"https://fff.example","founded":1919,"clubColors":"Blue","venue":"Maracana","lastUpdated":"2025-12-01T00:00:00Z","area":{"id":2081,"name":"France","code":"FRA","flag":"fr.png"},"squad":[{"id":11,"name":"Forward Two","position":"Attacker","dateOfBirth":"2000-02-02","nationality":"France"}]}]}`
 }
 
 func standingsPayload() string {
@@ -285,6 +367,9 @@ func matchesPayload() string {
 	return `{"filters":{"season":"2026"},"resultSet":{"count":1},"matches":[{"id":4001,"utcDate":"2026-06-11T20:00:00Z","status":"SCHEDULED","minute":null,"injuryTime":null,"attendance":null,"venue":"MetLife Stadium","matchday":1,"stage":"GROUP_STAGE","group":"GROUP_A","lastUpdated":"2025-12-01T00:00:00Z","competition":{"id":2000,"name":"FIFA World Cup","code":"WC"},"season":{"id":2026,"startDate":"2026-06-11","endDate":"2026-07-19"},"homeTeam":{"id":764,"name":"Brazil","shortName":"Brazil","tla":"BRA","crest":"bra.png"},"awayTeam":{"id":773,"name":"France","shortName":"France","tla":"FRA","crest":"fra.png"},"score":{"winner":null,"duration":"REGULAR","fullTime":{"home":null,"away":null},"halfTime":{"home":null,"away":null},"regularTime":{"home":null,"away":null},"extraTime":{"home":null,"away":null},"penalties":{"home":null,"away":null}},"referees":[{"id":1,"name":"Ref Name","type":"REFEREE","nationality":"USA"}],"goals":[{"minute":23,"injuryTime":null,"type":"REGULAR","team":{"id":764,"name":"Brazil"},"scorer":{"id":10,"name":"Forward One"},"assist":{"id":12,"name":"Creator"},"score":{"home":1,"away":0}}],"bookings":[{"minute":40,"card":"YELLOW","team":{"id":773,"name":"France"},"player":{"id":11,"name":"Forward Two"}}],"substitutions":[{"minute":65,"team":{"id":764,"name":"Brazil"},"playerOut":{"id":10,"name":"Forward One"},"playerIn":{"id":20,"name":"Fresh Legs"}}]}]}`
 }
 
+// teamDetailPayload mirrors the /teams/<id> detail endpoint, whose squad
+// members carry richer fields (firstName, lastName, shirtNumber, ...) than the
+// squad embedded in the competition teams response.
 func teamDetailPayload(teamID int, teamName, tla string, playerID int, playerName string) string {
-	return fmt.Sprintf(`{"id":%d,"name":%q,"tla":%q,"squad":[{"id":%d,"name":%q,"firstName":"Forward","lastName":"One","dateOfBirth":"1999-01-02","nationality":%q,"section":"Offence","position":"Attacker","shirtNumber":10,"lastUpdated":"2025-12-01T00:00:00Z"}]}`, teamID, teamName, tla, playerID, playerName, teamName)
+	return fmt.Sprintf(`{"id":%d,"name":%q,"tla":%q,"squad":[{"id":%d,"name":%q,"firstName":"Forward","lastName":"One","dateOfBirth":"1999-01-02","nationality":%q,"position":"Attacker","shirtNumber":10,"marketValue":1000000,"contract":{"start":"2022-07","until":"2026-06"}}]}`, teamID, teamName, tla, playerID, playerName, teamName)
 }

--- a/pkg/source/football_data_org/football_data_org_test.go
+++ b/pkg/source/football_data_org/football_data_org_test.go
@@ -19,16 +19,16 @@ import (
 
 func TestFootballDataOrgMissingAPIKey(t *testing.T) {
 	src := NewFootballDataOrgSource()
-	err := src.Connect(context.Background(), "football-data://")
+	err := src.Connect(context.Background(), "footballdata://")
 	require.ErrorContains(t, err, "api_key")
 }
 
 func TestFootballDataOrgRejectsInvalidSeasonAndMatchday(t *testing.T) {
 	src := NewFootballDataOrgSource()
-	err := src.Connect(context.Background(), "football-data://?api_key=test&season=26")
+	err := src.Connect(context.Background(), "footballdata://?api_key=test&season=26")
 	require.ErrorContains(t, err, "season")
 
-	err = src.Connect(context.Background(), "football-data://?api_key=test&matchday=final")
+	err = src.Connect(context.Background(), "footballdata://?api_key=test&matchday=final")
 	require.ErrorContains(t, err, "matchday")
 }
 
@@ -41,7 +41,7 @@ func TestFootballDataOrgReadTeamsPreservesNestedObjects(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestFootballDataOrgMatchesUsesFiltersAndOptionalUnfoldHeaders(t *testing.T)
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	uri := "football-data://?api_key=test-token&matchday=1&status=SCHEDULED&date_from=2026-06-11&date_to=2026-06-12&stage=GROUP_STAGE&group=GROUP_A&unfold_goals=true&unfold_bookings=true&base_url=" + url.QueryEscape(server.URL)
+	uri := "footballdata://?api_key=test-token&matchday=1&status=SCHEDULED&date_from=2026-06-11&date_to=2026-06-12&stage=GROUP_STAGE&group=GROUP_A&unfold_goals=true&unfold_bookings=true&base_url=" + url.QueryEscape(server.URL)
 	require.NoError(t, src.Connect(context.Background(), uri))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestFootballDataOrgMatchesAppliesIngestionInterval(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
 
@@ -125,7 +125,7 @@ func TestFootballDataOrgMatchesURIFiltersOverrideInterval(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	uri := "football-data://?api_key=test-token&date_from=2026-07-01&date_to=2026-07-10&base_url=" + url.QueryEscape(server.URL)
+	uri := "footballdata://?api_key=test-token&date_from=2026-07-01&date_to=2026-07-10&base_url=" + url.QueryEscape(server.URL)
 	require.NoError(t, src.Connect(context.Background(), uri))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestFootballDataOrgStandingsEmitsTableRowsRaw(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "group_standings"})
 	require.NoError(t, err)
 	require.Equal(t, "replace", string(table.Strategy()))
@@ -176,7 +176,7 @@ func TestFootballDataOrgStadiumsDeriveAndDeduplicate(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stadiums"})
 	require.NoError(t, err)
 	require.Equal(t, "replace", string(table.Strategy()))
@@ -207,7 +207,7 @@ func TestFootballDataOrgPlayersHydrateTeamDetails(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "players"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"team_id", "id"}, table.PrimaryKeys())
@@ -239,7 +239,7 @@ func TestFootballDataOrgMatchEventsUseUnfoldHeaders(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "match_events"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"event_key"}, table.PrimaryKeys())
@@ -263,7 +263,7 @@ func TestFootballDataOrgReadRespectsExcludeColumns(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
 
@@ -282,7 +282,7 @@ func TestFootballDataOrgReadReturnsAPIError(t *testing.T) {
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	require.NoError(t, src.Connect(context.Background(), "football-data://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
 
@@ -293,12 +293,12 @@ func TestFootballDataOrgReadReturnsAPIError(t *testing.T) {
 }
 
 func TestFootballDataOrgRegistryLookup(t *testing.T) {
-	constructor, err := registry.Default.GetSourceConstructor("football-data")
+	constructor, err := registry.Default.GetSourceConstructor("footballdata")
 	require.NoError(t, err)
 	src, ok := constructor().(source.Source)
 	require.True(t, ok)
 	require.NotNil(t, src)
-	require.Contains(t, src.Schemes(), "football-data")
+	require.Contains(t, src.Schemes(), "footballdata")
 }
 
 func TestFootballDataOrgUnsupportedTable(t *testing.T) {

--- a/pkg/source/football_data_org/register.go
+++ b/pkg/source/football_data_org/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterSource(
-		[]string{"football-data"},
+		[]string{"footballdata"},
 		func() interface{} { return NewFootballDataOrgSource() },
 	)
 }


### PR DESCRIPTION
## Changes

- **Schema inference (`KnownSchema: false`)** — dropped all `col()` type definitions and the `flatten*` helpers. Nested provider objects (`area`, `score`, `homeTeam`, `squad`, …) are preserved as JSON columns instead of exploded into scalar fields.
- **Incremental** — `HandlesIncrementality()` now returns `true`. `matches` and `match_events` pass `--interval-start`/`--interval-end` to the API as server-side `dateFrom`/`dateTo` filters; explicit URI `date_from`/`date_to` take precedence.
- **Strategies** — merge where a table accepts a time filter or returns `lastUpdated` (`teams`, `matches`, `match_events`); replace otherwise (`stadiums`, `group_standings`, `players`).
- **Streaming** — batches are streamed via `sendBatch`; every read loop checks `ctx` cancellation.
- **Robustness** — added a rate limiter for the 10 req/min free tier, and decode with `json.Number` to preserve large-integer precision.
- Updated the docs table and notes to match.