### PR TITLE
Use apifootball scheme for api-football source

### DIFF
--- a/docs/supported-sources/api-football.md
+++ b/docs/supported-sources/api-football.md
@@ -9,7 +9,7 @@ For endpoint parameters, plan tiers, and implementation notes across the selecte
 ## URI format
 
 ```plaintext
-api-football://?api_key=<api-key>&league=1&season=2026
+apifootball://?api_key=<api-key>&league=1&season=2026
 ```
 
 URI parameters:
@@ -26,7 +26,7 @@ Load World Cup 2026 matches into DuckDB:
 
 ```sh
 ingestr ingest \
-  --source-uri 'api-football://?api_key=<api-key>&league=1&season=2026' \
+  --source-uri 'apifootball://?api_key=<api-key>&league=1&season=2026' \
   --source-table 'matches' \
   --dest-uri 'duckdb:///worldcup2026.duckdb' \
   --dest-table 'soccer.matches'
@@ -36,7 +36,7 @@ Load World Cup 2026 match events:
 
 ```sh
 ingestr ingest \
-  --source-uri 'api-football://?api_key=<api-key>&league=1&season=2026' \
+  --source-uri 'apifootball://?api_key=<api-key>&league=1&season=2026' \
   --source-table 'match_events' \
   --dest-uri 'duckdb:///worldcup2026.duckdb' \
   --dest-table 'soccer.match_events'

--- a/pkg/source/api_football/api_football.go
+++ b/pkg/source/api_football/api_football.go
@@ -51,7 +51,7 @@ func NewAPIFootballSource() *APIFootballSource {
 }
 
 func (s *APIFootballSource) Schemes() []string {
-	return []string{"api-football"}
+	return []string{"apifootball"}
 }
 
 func (s *APIFootballSource) Connect(ctx context.Context, uri string) error {
@@ -88,8 +88,8 @@ func parseURI(raw string) (uriConfig, error) {
 	if err != nil {
 		return uriConfig{}, fmt.Errorf("failed to parse api-football URI: %w", err)
 	}
-	if parsed.Scheme != "api-football" {
-		return uriConfig{}, fmt.Errorf("invalid api-football URI: must start with api-football://")
+	if parsed.Scheme != "apifootball" {
+		return uriConfig{}, fmt.Errorf("invalid api-football URI: must start with apifootball://")
 	}
 
 	values := parsed.Query()

--- a/pkg/source/api_football/api_football_test.go
+++ b/pkg/source/api_football/api_football_test.go
@@ -17,16 +17,16 @@ import (
 
 func TestAPIFootballMissingAPIKey(t *testing.T) {
 	src := NewAPIFootballSource()
-	err := src.Connect(context.Background(), "api-football://")
+	err := src.Connect(context.Background(), "apifootball://")
 	require.ErrorContains(t, err, "api_key")
 }
 
 func TestAPIFootballRejectsInvalidLeagueAndSeason(t *testing.T) {
 	src := NewAPIFootballSource()
-	err := src.Connect(context.Background(), "api-football://?api_key=test&league=worldcup")
+	err := src.Connect(context.Background(), "apifootball://?api_key=test&league=worldcup")
 	require.ErrorContains(t, err, "league")
 
-	err = src.Connect(context.Background(), "api-football://?api_key=test&season=26")
+	err = src.Connect(context.Background(), "apifootball://?api_key=test&season=26")
 	require.ErrorContains(t, err, "season")
 }
 
@@ -41,7 +41,7 @@ func TestAPIFootballReadTeamsUsesAuthLeagueAndSeason(t *testing.T) {
 	defer server.Close()
 
 	src := NewAPIFootballSource()
-	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "apifootball://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestAPIFootballPlayersPaginates(t *testing.T) {
 	defer server.Close()
 
 	src := NewAPIFootballSource()
-	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "apifootball://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "players"})
 	require.NoError(t, err)
 	require.Equal(t, "replace", string(table.Strategy()))
@@ -100,7 +100,7 @@ func TestAPIFootballMatchesPreserveNestedObjects(t *testing.T) {
 	defer server.Close()
 
 	src := NewAPIFootballSource()
-	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&timezone=America/New_York&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "apifootball://?api_key=test-key&timezone=America/New_York&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
 	require.Equal(t, "merge", string(table.Strategy()))
@@ -132,7 +132,7 @@ func TestAPIFootballStadiumsDeriveFromFixturesAndHydrateVenues(t *testing.T) {
 	defer server.Close()
 
 	src := NewAPIFootballSource()
-	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "apifootball://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "stadiums"})
 	require.NoError(t, err)
 	require.Equal(t, "merge", string(table.Strategy()))
@@ -160,7 +160,7 @@ func TestAPIFootballMatchEventsFanOutFromFixtures(t *testing.T) {
 	defer server.Close()
 
 	src := NewAPIFootballSource()
-	require.NoError(t, src.Connect(context.Background(), "api-football://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
+	require.NoError(t, src.Connect(context.Background(), "apifootball://?api_key=test-key&base_url="+url.QueryEscape(server.URL)))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "match_events"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"event_key"}, table.PrimaryKeys())

--- a/pkg/source/api_football/register.go
+++ b/pkg/source/api_football/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterSource(
-		[]string{"api-football"},
+		[]string{"apifootball"},
 		func() interface{} { return NewAPIFootballSource() },
 	)
 }


### PR DESCRIPTION
## What

Changes the api-football source's URI scheme from `api-football` to **`apifootball`** (no hyphen).

Follow-up to #826. Collapsing the scheme makes the connection key and the URI scheme identical, matching the established `appleads` / `googleads` convention, and aligns with the bruin connection that emits `apifootball://`.