### PR TITLE
Drop football-data date_from/date_to URI params in favor of the interval

### DIFF
--- a/docs/soccer-sources/football-data-org.md
+++ b/docs/soccer-sources/football-data-org.md
@@ -226,7 +226,7 @@ Recommended ingestion flow:
 - Default competition is `WC`; default season is `2026`.
 - Schema is inferred (`KnownSchema: false`) — nested provider objects are preserved as JSON columns and scalar fields are typed automatically. Fields are not flattened into per-attribute columns.
 - Strategy per table: merge where the table accepts a time filter or returns `lastUpdated` (`teams`, `matches`, `match_events`); replace otherwise (`stadiums`, `group_standings`, `players`).
-- `HandlesIncrementality()` is `true`. `matches` and `match_events` pass `--interval-start`/`--interval-end` to the API as server-side `dateFrom`/`dateTo`; explicit URI `date_from`/`date_to` take precedence. Replace tables ignore the interval and always full-fetch.
+- `HandlesIncrementality()` is `true`. `matches` and `match_events` pass `--interval-start`/`--interval-end` to the API as server-side `dateFrom`/`dateTo`. Replace tables ignore the interval and always full-fetch.
 - The HTTP client is rate-limited to ~80% of the free tier's 10 requests/minute, and responses are decoded with `json.Number` to preserve large-integer precision.
 - Stadiums and match events are derived tables because the API has no first-class stadium or unified event resource; `players` is derived from team squads.
 - Deep player/event fields are subscription-dependent: `match_events` loads 0 rows without the Deep Data plan, and `players` requires `/teams/{id}` access.

--- a/docs/supported-sources/football-data-org.md
+++ b/docs/supported-sources/football-data-org.md
@@ -19,7 +19,6 @@ URI parameters:
 - `season`: Season year. Defaults to `2026`.
 - `matchday`: Optional matchday filter for `matches`, `stadiums`, and `match_events`.
 - `status`: Optional match status filter for `matches`, `stadiums`, and `match_events`.
-- `date_from` / `date_to`: Optional date filters passed as `dateFrom` and `dateTo`.
 - `stage`: Optional match stage filter.
 - `group`: Optional group filter.
 - `unfold_goals`, `unfold_bookings`, `unfold_subs`, `unfold_lineups`: Optional `true`/`false` flags for `matches`. These require plan access when football-data.org gates deep data.

--- a/pkg/source/football_data_org/football_data_org.go
+++ b/pkg/source/football_data_org/football_data_org.go
@@ -88,8 +88,6 @@ type uriConfig struct {
 type matchFilters struct {
 	matchday string
 	status   string
-	dateFrom string
-	dateTo   string
 	stage    string
 	group    string
 }
@@ -119,8 +117,6 @@ func parseURI(raw string) (uriConfig, error) {
 		filters: matchFilters{
 			matchday: values.Get("matchday"),
 			status:   values.Get("status"),
-			dateFrom: firstNonEmpty(values.Get("date_from"), values.Get("dateFrom")),
-			dateTo:   firstNonEmpty(values.Get("date_to"), values.Get("dateTo")),
 			stage:    values.Get("stage"),
 			group:    values.Get("group"),
 		},
@@ -517,12 +513,6 @@ func (s *FootballDataOrgSource) fetchRawMatches(ctx context.Context, opts source
 	if s.filters.status != "" {
 		params["status"] = s.filters.status
 	}
-	if s.filters.dateFrom != "" {
-		params["dateFrom"] = s.filters.dateFrom
-	}
-	if s.filters.dateTo != "" {
-		params["dateTo"] = s.filters.dateTo
-	}
 	if s.filters.stage != "" {
 		params["stage"] = s.filters.stage
 	}
@@ -530,9 +520,8 @@ func (s *FootballDataOrgSource) fetchRawMatches(ctx context.Context, opts source
 		params["group"] = s.filters.group
 	}
 	// The matches endpoint supports server-side date filtering via dateFrom/dateTo
-	// (YYYY-MM-DD). When the URI does not pin the window explicitly, honour the
-	// ingestion interval so matches and the tables derived from them stay scoped.
-	if s.filters.dateFrom == "" && s.filters.dateTo == "" && opts.IntervalStart != nil && opts.IntervalEnd != nil {
+	// (YYYY-MM-DD). Date scoping is driven entirely by the ingestion interval.
+	if opts.IntervalStart != nil && opts.IntervalEnd != nil {
 		params["dateFrom"] = opts.IntervalStart.UTC().Format("2006-01-02")
 		params["dateTo"] = opts.IntervalEnd.UTC().Format("2006-01-02")
 	}
@@ -729,15 +718,6 @@ func normalizeValue(value interface{}) interface{} {
 	default:
 		return value
 	}
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 func firstNonNil(values ...interface{}) interface{} {

--- a/pkg/source/football_data_org/football_data_org_test.go
+++ b/pkg/source/football_data_org/football_data_org_test.go
@@ -67,8 +67,6 @@ func TestFootballDataOrgMatchesUsesFiltersAndOptionalUnfoldHeaders(t *testing.T)
 		require.Equal(t, "2026", r.URL.Query().Get("season"))
 		require.Equal(t, "1", r.URL.Query().Get("matchday"))
 		require.Equal(t, "SCHEDULED", r.URL.Query().Get("status"))
-		require.Equal(t, "2026-06-11", r.URL.Query().Get("dateFrom"))
-		require.Equal(t, "2026-06-12", r.URL.Query().Get("dateTo"))
 		require.Equal(t, "GROUP_STAGE", r.URL.Query().Get("stage"))
 		require.Equal(t, "GROUP_A", r.URL.Query().Get("group"))
 		require.Equal(t, "true", r.Header.Get("X-Unfold-Goals"))
@@ -78,7 +76,7 @@ func TestFootballDataOrgMatchesUsesFiltersAndOptionalUnfoldHeaders(t *testing.T)
 	defer server.Close()
 
 	src := NewFootballDataOrgSource()
-	uri := "footballdata://?api_key=test-token&matchday=1&status=SCHEDULED&date_from=2026-06-11&date_to=2026-06-12&stage=GROUP_STAGE&group=GROUP_A&unfold_goals=true&unfold_bookings=true&base_url=" + url.QueryEscape(server.URL)
+	uri := "footballdata://?api_key=test-token&matchday=1&status=SCHEDULED&stage=GROUP_STAGE&group=GROUP_A&unfold_goals=true&unfold_bookings=true&base_url=" + url.QueryEscape(server.URL)
 	require.NoError(t, src.Connect(context.Background(), uri))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
@@ -105,28 +103,6 @@ func TestFootballDataOrgMatchesAppliesIngestionInterval(t *testing.T) {
 
 	src := NewFootballDataOrgSource()
 	require.NoError(t, src.Connect(context.Background(), "footballdata://?api_key=test-token&base_url="+url.QueryEscape(server.URL)))
-	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
-	require.NoError(t, err)
-
-	start := time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC)
-	end := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
-	record := readOnce(t, table, source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
-	defer record.Release()
-	require.EqualValues(t, 1, record.NumRows())
-}
-
-func TestFootballDataOrgMatchesURIFiltersOverrideInterval(t *testing.T) {
-	server := footballDataServer(t, func(w http.ResponseWriter, r *http.Request) {
-		// Explicit URI date filters take precedence over the ingestion interval.
-		require.Equal(t, "2026-07-01", r.URL.Query().Get("dateFrom"))
-		require.Equal(t, "2026-07-10", r.URL.Query().Get("dateTo"))
-		_, _ = fmt.Fprint(w, matchesPayload())
-	})
-	defer server.Close()
-
-	src := NewFootballDataOrgSource()
-	uri := "footballdata://?api_key=test-token&date_from=2026-07-01&date_to=2026-07-10&base_url=" + url.QueryEscape(server.URL)
-	require.NoError(t, src.Connect(context.Background(), uri))
 	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "matches"})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What

Removes the redundant `date_from`/`date_to` URI parameters from the `footballdata` source. Date scoping is already handled by `--interval-start`/`--interval-end`, which `matches` and `match_events` pass through to the API as server-side `dateFrom`/`dateTo`. Having both was duplicative.