### PR TITLE
Add ingestr load timestamp column

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -166,6 +166,11 @@ func IngestCommand() *cli.Command {
 				Usage:   "Trim leading and trailing whitespace from all string column values",
 				Sources: cli.EnvVars("TRIM_WHITESPACE", "INGESTR_TRIM_WHITESPACE"),
 			},
+			&cli.BoolFlag{
+				Name:    "no-load-timestamp",
+				Usage:   "Disable adding the _ingestr_loaded_at load timestamp column",
+				Sources: cli.EnvVars("NO_LOAD_TIMESTAMP", "INGESTR_NO_LOAD_TIMESTAMP"),
+			},
 			&cli.StringFlag{
 				Name:    "pipelines-dir",
 				Usage:   "The path to store pipeline metadata",
@@ -246,6 +251,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.NoInference = c.Bool("no-inference")
 	cfg.Mask = c.StringSlice("mask")
 	cfg.TrimWhitespace = c.Bool("trim-whitespace")
+	cfg.NoLoadTimestamp = c.Bool("no-load-timestamp")
 	cfg.PipelinesDir = c.String("pipelines-dir")
 	cfg.StagingBucket = c.String("staging-bucket")
 	cfg.StagingDataset = c.String("staging-dataset")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type IngestConfig struct {
 	NoInference       bool   // Skip schema inference for unknown-schema sources and use Columns as the schema
 	Mask              []string
 	TrimWhitespace    bool
+	NoLoadTimestamp   bool
 
 	PipelinesDir   string
 	StagingBucket  string

--- a/pkg/destination/bigquery/mapper_test.go
+++ b/pkg/destination/bigquery/mapper_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -227,6 +228,27 @@ func TestBuildBigQuerySchema_DefaultNumericOmitsPrecisionScale(t *testing.T) {
 	}
 	if result[0].Scale != 0 {
 		t.Fatalf("field scale = %d, want 0 for bare NUMERIC", result[0].Scale)
+	}
+}
+
+func TestBuildBigQuerySchema_LoadTimestampIsNullable(t *testing.T) {
+	result := BuildBigQuerySchema(&schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: naming.IngestrLoadedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+		},
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(result))
+	}
+	if result[0].Name != naming.IngestrLoadedAtColumn {
+		t.Fatalf("field name = %s, want %s", result[0].Name, naming.IngestrLoadedAtColumn)
+	}
+	if result[0].Type != bigquery.TimestampFieldType {
+		t.Fatalf("field type = %v, want TimestampFieldType", result[0].Type)
+	}
+	if result[0].Required {
+		t.Fatal("load timestamp field should not be required")
 	}
 }
 

--- a/pkg/destination/scd2_columns.go
+++ b/pkg/destination/scd2_columns.go
@@ -3,6 +3,8 @@ package destination
 import (
 	"slices"
 	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/naming"
 )
 
 // SCD2 metadata column names. Strategies and destinations must agree on these.
@@ -21,9 +23,10 @@ func SCD2MetadataColumns() []string {
 // columns).
 func SCD2NonDataColumns(primaryKeys []string) []string {
 	scd := SCD2MetadataColumns()
-	out := make([]string, 0, len(primaryKeys)+len(scd))
+	out := make([]string, 0, len(primaryKeys)+len(scd)+1)
 	out = append(out, primaryKeys...)
 	out = append(out, scd...)
+	out = append(out, naming.IngestrLoadedAtColumn)
 	return out
 }
 

--- a/pkg/destination/scd2_columns_test.go
+++ b/pkg/destination/scd2_columns_test.go
@@ -32,27 +32,27 @@ func TestSCD2NonDataColumns(t *testing.T) {
 		{
 			name:        "no primary keys",
 			primaryKeys: nil,
-			expected:    []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+			expected:    []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current", "_ingestr_loaded_at"},
 		},
 		{
 			name:        "empty primary keys",
 			primaryKeys: []string{},
-			expected:    []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+			expected:    []string{"_scd_valid_from", "_scd_valid_to", "_scd_is_current", "_ingestr_loaded_at"},
 		},
 		{
 			name:        "single primary key",
 			primaryKeys: []string{"id"},
-			expected:    []string{"id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+			expected:    []string{"id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current", "_ingestr_loaded_at"},
 		},
 		{
 			name:        "multiple primary keys",
 			primaryKeys: []string{"id", "tenant_id"},
-			expected:    []string{"id", "tenant_id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+			expected:    []string{"id", "tenant_id", "_scd_valid_from", "_scd_valid_to", "_scd_is_current", "_ingestr_loaded_at"},
 		},
 		{
 			name:        "primary key overlaps scd metadata",
 			primaryKeys: []string{"_scd_valid_from"},
-			expected:    []string{"_scd_valid_from", "_scd_valid_from", "_scd_valid_to", "_scd_is_current"},
+			expected:    []string{"_scd_valid_from", "_scd_valid_from", "_scd_valid_to", "_scd_is_current", "_ingestr_loaded_at"},
 		},
 	}
 

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -309,8 +309,8 @@ func (d *TrinoDestination) SCD2Table(ctx context.Context, opts destination.SCD2O
 	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
 	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
 
-	// Build column comparison for change detection (excluding SCD columns and PKs)
-	nonPKColumns := filterSCD2Columns(opts.Columns, opts.PrimaryKeys)
+	// Build column comparison for change detection (excluding metadata columns and PKs)
+	nonPKColumns := filterSCD2Columns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
 
 	// Build PK match condition for correlated subquery (target columns reference outer table)
 	pkMatchCondition := buildSCD2PKMatchCondition(opts.PrimaryKeys)

--- a/pkg/naming/detect.go
+++ b/pkg/naming/detect.go
@@ -8,7 +8,8 @@ import (
 
 // Ingestr metadata column prefixes
 const (
-	IngestrColumnPrefix = "_dlt_"
+	IngestrColumnPrefix   = "_dlt_"
+	IngestrLoadedAtColumn = "_ingestr_loaded_at"
 )
 
 // Common ingestr metadata columns
@@ -22,7 +23,8 @@ var IngestrMetadataColumns = []string{
 
 // IsIngestrColumn returns true if the column name is an ingestr metadata column.
 func IsIngestrColumn(name string) bool {
-	return strings.HasPrefix(strings.ToLower(name), IngestrColumnPrefix)
+	return strings.HasPrefix(strings.ToLower(name), IngestrColumnPrefix) ||
+		strings.EqualFold(name, IngestrLoadedAtColumn)
 }
 
 // HasIngestrColumns returns true if the schema contains any ingestr metadata columns.

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -270,6 +270,8 @@ func TestIsIngestrColumn(t *testing.T) {
 		{"_dlt_parent_id", true},
 		{"_dlt_list_idx", true},
 		{"_dlt_root_id", true},
+		{"_ingestr_loaded_at", true},
+		{"_INGESTR_LOADED_AT", true},
 		{"_DLT_LOAD_ID", true}, // case insensitive
 		{"_Dlt_Id", true},
 		{"user_id", false},
@@ -322,13 +324,15 @@ func TestGetIngestrColumns(t *testing.T) {
 			Columns: []schema.Column{
 				{Name: "user_id"},
 				{Name: "_dlt_load_id"},
+				{Name: "_ingestr_loaded_at"},
 				{Name: "user_name"},
 				{Name: "_dlt_id"},
 			},
 		}
 		cols := GetIngestrColumns(s)
-		assert.Len(t, cols, 2)
+		assert.Len(t, cols, 3)
 		assert.Contains(t, cols, "_dlt_load_id")
+		assert.Contains(t, cols, "_ingestr_loaded_at")
 		assert.Contains(t, cols, "_dlt_id")
 	})
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -339,7 +339,9 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 	var loadTimestamp time.Time
 	if !p.config.NoLoadTimestamp {
-		loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+		if !p.config.Stream {
+			loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+		}
 		destSchema = addLoadTimestampColumn(destSchema)
 	}
 
@@ -354,7 +356,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	// Build the evolution plan but do NOT apply it here. Strategies decide when to apply.
 	var evolutionPlan *schemaevolution.EvolutionPlan
 	if resolvedStrategy != config.StrategyReplace {
-		evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, p.config.DestTable, destSchema)
+		evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, p.config.DestTable, destSchema, resolvedStrategy)
 		if err != nil {
 			return fmt.Errorf("schema evolution failed: %w", err)
 		}
@@ -372,6 +374,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 	// Staging mirrors the destination schema, with staging-only CDC columns retained.
 	ingestSchema := destination.StagingIngestSchema(fullSchema, destSchema)
+	ingestSchema = preserveSourceCDCColumnTypes(ingestSchema, fullSchema)
 
 	if inferBuffer != nil {
 		bufferTarget := p.buildBufferReaderTarget(originalSourceSchema, destSchema)
@@ -443,7 +446,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 
 	var loadTimestampTransformer *transformer.LoadTimestamp
-	if !p.config.NoLoadTimestamp {
+	if !p.config.NoLoadTimestamp && !p.config.Stream {
 		loadTimestampTransformer = transformer.NewLoadTimestamp(loadTimestampColumnForSchema(ingestSchema), loadTimestamp)
 	}
 
@@ -462,6 +465,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		ColumnMasker:        columnMasker,
 		WhitespaceTrimmer:   whitespaceTrimmer,
 		LoadTimestamp:       loadTimestampTransformer,
+		SchemaAligner:       transformer.NewSafeTypeCaster(ingestSchema.ToArrowSchema()),
 		EvolutionPlan:       evolutionPlan,
 	}
 
@@ -762,7 +766,7 @@ func arrowField(name string, col schema.Column, nullable bool) arrow.Field {
 
 func isSCD2MetadataColumn(name string) bool {
 	for _, scd := range destination.SCD2MetadataColumns() {
-		if scd == name {
+		if strings.EqualFold(scd, name) {
 			return true
 		}
 	}
@@ -853,7 +857,9 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 	var loadTimestamp time.Time
 	if !p.config.NoLoadTimestamp {
-		loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+		if !p.config.Stream {
+			loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+		}
 		for i := range tables {
 			tables[i].Schema = addLoadTimestampColumn(tables[i].Schema)
 		}
@@ -935,7 +941,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	if resolvedStrategy != config.StrategyReplace {
 		evolutionPlans = make(map[string]*schemaevolution.EvolutionPlan)
 		for _, table := range tables {
-			plan, err := p.evolveSchemaIfNeeded(ctx, tableDestNames[table.Name], table.Schema)
+			plan, err := p.evolveSchemaIfNeeded(ctx, tableDestNames[table.Name], table.Schema, resolvedStrategy)
 			if err != nil {
 				return fmt.Errorf("schema evolution failed for table %s: %w", table.Name, err)
 			}
@@ -973,7 +979,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	}
 
 	var loadTimestampTransformer *transformer.LoadTimestamp
-	if !p.config.NoLoadTimestamp {
+	if !p.config.NoLoadTimestamp && !p.config.Stream {
 		loadTimestampTransformer = transformer.NewLoadTimestamp(loadTimestampColumnForSchema(nil), loadTimestamp)
 	}
 
@@ -1013,7 +1019,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 // evolveSchemaIfNeeded inspects the destination's current schema and builds an
 // EvolutionPlan describing how it should change to accommodate sourceSchema.
-func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, sourceSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, sourceSchema *schema.TableSchema, strategy config.IncrementalStrategy) (*schemaevolution.EvolutionPlan, error) {
 	// Get destination table schema (nil if table doesn't exist)
 	destSchema, err := p.dest.GetTableSchema(ctx, destTable)
 	if err != nil {
@@ -1024,8 +1030,14 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 		return nil, nil
 	}
 
-	// Store destination schema for use by strategies
-	p.destinationSchema = destSchema
+	comparisonDestSchema := destSchema
+	if strategy == config.StrategySCD2 {
+		comparisonDestSchema = removeSCD2MetadataColumns(destSchema)
+	}
+	comparisonDestSchema = preserveSourceCDCColumnTypes(comparisonDestSchema, sourceSchema)
+
+	// Store destination schema for use by strategies.
+	p.destinationSchema = comparisonDestSchema
 
 	// Parse schema contract mode
 	contractMode, err := schemaevolution.ParseContractMode(p.config.SchemaContract)
@@ -1046,14 +1058,14 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 
 	// Compare schemas with overrides. Staging-only CDC columns are not persisted on the destination.
 	opts := &schemaevolution.CompareOptions{Overrides: overrides}
-	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), destSchema, opts)
+	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), comparisonDestSchema, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare schemas: %w", err)
 	}
 	if !comparison.HasChanges {
 		config.Debug("[SCHEMA EVOLUTION] No schema changes detected")
 		return &schemaevolution.EvolutionPlan{
-			FinalSchema: schemaevolution.BuildFinalSchema(destSchema, nil),
+			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
 			Migration:   nil,
 		}, nil
 	}
@@ -1082,7 +1094,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 		}
 		p.filteredSchemaComparison = comparison
 		return &schemaevolution.EvolutionPlan{
-			FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
 			Migration:   nil,
 		}, nil
 
@@ -1127,7 +1139,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 				HasChanges: false,
 			}
 			return &schemaevolution.EvolutionPlan{
-				FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+				FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
 				Migration:   nil,
 			}, nil
 		}
@@ -1147,7 +1159,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	if dialect == nil {
 		config.Debug("[SCHEMA EVOLUTION] No dialect registered for scheme %s, skipping", p.dest.GetScheme())
 		return &schemaevolution.EvolutionPlan{
-			FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
 			Migration:   nil,
 		}, nil
 	}
@@ -1171,7 +1183,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 
 	// Build the plan; migration is NOT applied here.
 	plan := &schemaevolution.EvolutionPlan{
-		FinalSchema: schemaevolution.BuildFinalSchema(destSchema, p.filteredSchemaComparison),
+		FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
 		Migration:   migration,
 	}
 	config.Debug("[SCHEMA EVOLUTION] Built plan with %d statements (deferred apply)", len(migration.Statements))
@@ -1238,12 +1250,12 @@ func addLoadTimestampColumn(s *schema.TableSchema) *schema.TableSchema {
 
 	for i, col := range result.Columns {
 		if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
-			result.Columns[i] = loadTimestampColumnWithName(col.Name, col.Nullable)
+			result.Columns[i] = loadTimestampColumnWithName(col.Name, true)
 			return &result
 		}
 	}
 
-	result.Columns = append(result.Columns, loadTimestampColumnWithName(naming.IngestrLoadedAtColumn, false))
+	result.Columns = append(result.Columns, loadTimestampColumnWithName(naming.IngestrLoadedAtColumn, true))
 	return &result
 }
 
@@ -1263,15 +1275,61 @@ func removeLoadTimestampColumn(s *schema.TableSchema) *schema.TableSchema {
 	return &result
 }
 
+func removeSCD2MetadataColumns(s *schema.TableSchema) *schema.TableSchema {
+	if s == nil {
+		return nil
+	}
+
+	result := *s
+	result.Columns = make([]schema.Column, 0, len(s.Columns))
+	for _, col := range s.Columns {
+		if isSCD2MetadataColumn(col.Name) {
+			continue
+		}
+		result.Columns = append(result.Columns, col)
+	}
+	return &result
+}
+
+func preserveSourceCDCColumnTypes(ingestSchema, sourceSchema *schema.TableSchema) *schema.TableSchema {
+	if ingestSchema == nil || sourceSchema == nil {
+		return ingestSchema
+	}
+
+	sourceColumns := make(map[string]schema.Column, len(sourceSchema.Columns))
+	for _, col := range sourceSchema.Columns {
+		if destination.IsCDCColumn(col.Name) || destination.IsCDCStagingOnlyColumn(col.Name) {
+			sourceColumns[strings.ToLower(col.Name)] = col
+		}
+	}
+	if len(sourceColumns) == 0 {
+		return ingestSchema
+	}
+
+	result := *ingestSchema
+	result.Columns = append([]schema.Column{}, ingestSchema.Columns...)
+	for i, col := range result.Columns {
+		sourceCol, ok := sourceColumns[strings.ToLower(col.Name)]
+		if !ok {
+			continue
+		}
+		result.Columns[i].DataType = sourceCol.DataType
+		result.Columns[i].Precision = sourceCol.Precision
+		result.Columns[i].Scale = sourceCol.Scale
+		result.Columns[i].ArrayType = sourceCol.ArrayType
+	}
+	return &result
+}
+
 func loadTimestampColumnForSchema(s *schema.TableSchema) schema.Column {
 	if s != nil {
 		for _, col := range s.Columns {
 			if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
-				return loadTimestampColumnWithName(col.Name, col.Nullable)
+				return loadTimestampColumnWithName(col.Name, true)
 			}
 		}
 	}
-	return loadTimestampColumnWithName(naming.IngestrLoadedAtColumn, false)
+	return loadTimestampColumnWithName(naming.IngestrLoadedAtColumn, true)
 }
 
 func loadTimestampColumnWithName(name string, nullable bool) schema.Column {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/annotation"
@@ -336,6 +337,12 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		}
 	}
 
+	var loadTimestamp time.Time
+	if !p.config.NoLoadTimestamp {
+		loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+		destSchema = addLoadTimestampColumn(destSchema)
+	}
+
 	// Capture the schema before evolution: on incremental runs against an
 	// existing table, evolution replaces destSchema with FinalSchema, which is
 	// built from the destination's columns and therefore drops staging-only
@@ -354,6 +361,13 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		if evolutionPlan != nil && evolutionPlan.FinalSchema != nil {
 			destSchema = evolutionPlan.FinalSchema
 		}
+	}
+	if p.config.NoLoadTimestamp {
+		destSchema = removeLoadTimestampColumn(destSchema)
+		fullSchema = removeLoadTimestampColumn(fullSchema)
+	} else {
+		destSchema = addLoadTimestampColumn(destSchema)
+		fullSchema = addLoadTimestampColumn(fullSchema)
 	}
 
 	// Staging mirrors the destination schema, with staging-only CDC columns retained.
@@ -428,6 +442,11 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		whitespaceTrimmer = transformer.NewWhitespaceTrimmer()
 	}
 
+	var loadTimestampTransformer *transformer.LoadTimestamp
+	if !p.config.NoLoadTimestamp {
+		loadTimestampTransformer = transformer.NewLoadTimestamp(loadTimestampColumnForSchema(ingestSchema), loadTimestamp)
+	}
+
 	job := &strategy.IngestionJob{
 		Config:              &resolvedConfig,
 		Table:               table,
@@ -442,6 +461,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		IngestrColumnFiller: p.ingestrColumnFiller,
 		ColumnMasker:        columnMasker,
 		WhitespaceTrimmer:   whitespaceTrimmer,
+		LoadTimestamp:       loadTimestampTransformer,
 		EvolutionPlan:       evolutionPlan,
 	}
 
@@ -831,6 +851,14 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 	config.Debug("[PIPELINE] Multi-table mode: %d tables", len(tables))
 
+	var loadTimestamp time.Time
+	if !p.config.NoLoadTimestamp {
+		loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+		for i := range tables {
+			tables[i].Schema = addLoadTimestampColumn(tables[i].Schema)
+		}
+	}
+
 	resolvedStrategy := p.config.IncrementalStrategy
 	if p.config.Stream && resolvedStrategy == "" {
 		if ss, ok := src.(source.StreamingSource); ok {
@@ -944,6 +972,11 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 		whitespaceTrimmer = transformer.NewWhitespaceTrimmer()
 	}
 
+	var loadTimestampTransformer *transformer.LoadTimestamp
+	if !p.config.NoLoadTimestamp {
+		loadTimestampTransformer = transformer.NewLoadTimestamp(loadTimestampColumnForSchema(nil), loadTimestamp)
+	}
+
 	job := &strategy.MultiTableIngestionJob{
 		Config:            &resolvedConfig,
 		Source:            src,
@@ -954,6 +987,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 		CDCResumeLSNs:     cdcResumeLSNs,
 		EvolutionPlans:    evolutionPlans,
 		WhitespaceTrimmer: whitespaceTrimmer,
+		LoadTimestamp:     loadTimestampTransformer,
 	}
 
 	if p.config.Stream {
@@ -1155,15 +1189,26 @@ func (p *Pipeline) setupIngestrColumns(ctx context.Context, sourceSchema *schema
 	}
 
 	ingestrCols := naming.GetIngestrColumns(destSchema)
-	p.ingestrColumnFiller = schemaevolution.NewIngestrColumnFiller(ingestrCols)
-	config.Debug("[INGESTR] Will fill %d ingestr columns with '-': %v", len(ingestrCols), ingestrCols)
+	legacyCols := make([]string, 0, len(ingestrCols))
+	for _, colName := range ingestrCols {
+		if strings.EqualFold(colName, naming.IngestrLoadedAtColumn) {
+			continue
+		}
+		legacyCols = append(legacyCols, colName)
+	}
+	if len(legacyCols) == 0 {
+		return nil, nil
+	}
+
+	p.ingestrColumnFiller = schemaevolution.NewIngestrColumnFiller(legacyCols)
+	config.Debug("[INGESTR] Will fill %d ingestr columns with '-': %v", len(legacyCols), legacyCols)
 
 	// Copy the source schema so the original stays clean for source SELECT queries.
 	copied := *sourceSchema
 	copied.Columns = make([]schema.Column, len(sourceSchema.Columns))
 	copy(copied.Columns, sourceSchema.Columns)
 
-	for _, colName := range ingestrCols {
+	for _, colName := range legacyCols {
 		exists := false
 		for _, col := range copied.Columns {
 			if col.Name == colName {
@@ -1181,6 +1226,60 @@ func (p *Pipeline) setupIngestrColumns(ctx context.Context, sourceSchema *schema
 	}
 
 	return &copied, nil
+}
+
+func addLoadTimestampColumn(s *schema.TableSchema) *schema.TableSchema {
+	if s == nil {
+		return nil
+	}
+
+	result := *s
+	result.Columns = append([]schema.Column{}, s.Columns...)
+
+	for i, col := range result.Columns {
+		if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
+			result.Columns[i] = loadTimestampColumnWithName(col.Name, col.Nullable)
+			return &result
+		}
+	}
+
+	result.Columns = append(result.Columns, loadTimestampColumnWithName(naming.IngestrLoadedAtColumn, false))
+	return &result
+}
+
+func removeLoadTimestampColumn(s *schema.TableSchema) *schema.TableSchema {
+	if s == nil {
+		return nil
+	}
+
+	result := *s
+	result.Columns = make([]schema.Column, 0, len(s.Columns))
+	for _, col := range s.Columns {
+		if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
+			continue
+		}
+		result.Columns = append(result.Columns, col)
+	}
+	return &result
+}
+
+func loadTimestampColumnForSchema(s *schema.TableSchema) schema.Column {
+	if s != nil {
+		for _, col := range s.Columns {
+			if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
+				return loadTimestampColumnWithName(col.Name, col.Nullable)
+			}
+		}
+	}
+	return loadTimestampColumnWithName(naming.IngestrLoadedAtColumn, false)
+}
+
+func loadTimestampColumnWithName(name string, nullable bool) schema.Column {
+	return schema.Column{
+		Name:     name,
+		DataType: schema.TypeTimestampTZ,
+		Nullable: nullable,
+	}
 }
 
 func (p *Pipeline) setupNamingConvention(ctx context.Context, sourceSchema *schema.TableSchema) error {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1327,6 +1327,48 @@ func TestBuildBufferReaderTarget_SkipsIngestrMetadataColumn(t *testing.T) {
 	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
 }
 
+func TestBuildBufferReaderTarget_SkipsLoadTimestampColumn(t *testing.T) {
+	p := &Pipeline{}
+	src := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+	)
+	dest := tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("name", schema.TypeString),
+		tcol("_ingestr_loaded_at", schema.TypeTimestampTZ),
+	)
+
+	got := p.buildBufferReaderTarget(src, dest)
+
+	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
+}
+
+func TestSetupIngestrColumnsDoesNotFillLoadTimestamp(t *testing.T) {
+	p := &Pipeline{
+		config: &config.IngestConfig{DestTable: "users"},
+		dest: &mockDestination{tableSchema: tschema(
+			"users",
+			tcol("id", schema.TypeInt64),
+			tcol("_ingestr_loaded_at", schema.TypeTimestampTZ),
+		)},
+	}
+	src := tschema("users", tcol("id", schema.TypeInt64))
+
+	got, err := p.setupIngestrColumns(context.Background(), src)
+	if err != nil {
+		t.Fatalf("setupIngestrColumns() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("setupIngestrColumns() returned schema with columns %v, want nil", got.ColumnNames())
+	}
+	if p.ingestrColumnFiller != nil {
+		t.Fatal("load timestamp column must not use IngestrColumnFiller")
+	}
+}
+
 // Case 4b: dest has a NON-ingestr column NOT in source (soft-removed under
 // evolve mode). It MUST be included in the target so the buffer reader
 // null-fills it; staging then gets the column with NULLs, MERGE inserts NULL

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1284,6 +1284,89 @@ func TestBuildBufferReaderTarget_SourceOnlyColumnIsDropped(t *testing.T) {
 	assertColumns(t, "fields", arrowFieldNames(got), []string{"id", "name"})
 }
 
+func TestRemoveSCD2MetadataColumns_CaseInsensitive(t *testing.T) {
+	got := removeSCD2MetadataColumns(tschema(
+		"users",
+		tcol("id", schema.TypeInt64),
+		tcol("_SCD_VALID_FROM", schema.TypeTimestampTZ),
+		tcol("_scd_valid_to", schema.TypeTimestampTZ),
+		tcol("_Scd_Is_Current", schema.TypeBoolean),
+		tcol("name", schema.TypeString),
+	))
+
+	assertColumns(t, "columns", got.ColumnNames(), []string{"id", "name"})
+}
+
+func TestAddLoadTimestampColumnCreatesNullableColumn(t *testing.T) {
+	got := addLoadTimestampColumn(tschema("users", tcol("id", schema.TypeInt64)))
+
+	if len(got.Columns) != 2 {
+		t.Fatalf("len(columns) = %d, want 2", len(got.Columns))
+	}
+	col := got.Columns[1]
+	if col.Name != "_ingestr_loaded_at" {
+		t.Fatalf("load timestamp column name = %q", col.Name)
+	}
+	if col.DataType != schema.TypeTimestampTZ {
+		t.Fatalf("load timestamp type = %v, want %v", col.DataType, schema.TypeTimestampTZ)
+	}
+	if !col.Nullable {
+		t.Fatal("load timestamp column should be nullable")
+	}
+}
+
+func TestAddLoadTimestampColumnKeepsExistingNameButMakesNullable(t *testing.T) {
+	existing := schema.Column{
+		Name:     "_INGESTR_LOADED_AT",
+		DataType: schema.TypeString,
+		Nullable: false,
+	}
+	got := addLoadTimestampColumn(tschema("users", tcol("id", schema.TypeInt64), existing))
+
+	col := got.Columns[1]
+	if col.Name != existing.Name {
+		t.Fatalf("load timestamp column name = %q, want %q", col.Name, existing.Name)
+	}
+	if col.DataType != schema.TypeTimestampTZ {
+		t.Fatalf("load timestamp type = %v, want %v", col.DataType, schema.TypeTimestampTZ)
+	}
+	if !col.Nullable {
+		t.Fatal("existing load timestamp column should be treated as nullable")
+	}
+}
+
+func TestPreserveSourceCDCColumnTypes(t *testing.T) {
+	ingest := tschema(
+		"items",
+		tcol("id", schema.TypeInt64),
+		tcol("_cdc_deleted", schema.TypeInt64),
+		tcol("_cdc_lsn", schema.TypeString),
+		tcol("_cdc_unchanged_cols", schema.TypeString),
+		tcol("value", schema.TypeString),
+	)
+	source := tschema(
+		"items",
+		tcol("id", schema.TypeInt64),
+		tcol("_cdc_deleted", schema.TypeBoolean),
+		tcol("_cdc_lsn", schema.TypeString),
+		tcol("_cdc_unchanged_cols", schema.TypeString),
+		tcol("value", schema.TypeInt64),
+	)
+
+	got := preserveSourceCDCColumnTypes(ingest, source)
+
+	types := map[string]schema.DataType{}
+	for _, col := range got.Columns {
+		types[col.Name] = col.DataType
+	}
+	if types["_cdc_deleted"] != schema.TypeBoolean {
+		t.Fatalf("_cdc_deleted type = %v, want %v", types["_cdc_deleted"], schema.TypeBoolean)
+	}
+	if types["value"] != schema.TypeString {
+		t.Fatalf("value type = %v, want destination-aligned string", types["value"])
+	}
+}
+
 func TestBuildBufferReaderTarget_OrderFollowsDest(t *testing.T) {
 	p := &Pipeline{}
 	src := tschema(

--- a/pkg/schemaevolution/contract.go
+++ b/pkg/schemaevolution/contract.go
@@ -3,6 +3,8 @@ package schemaevolution
 import (
 	"fmt"
 	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/naming"
 )
 
 // ContractViolation represents a schema contract violation.
@@ -57,6 +59,10 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 
 	case ContractFreeze:
 		for _, change := range comparison.Changes {
+			if isInternalAllowedChange(change) {
+				result.Allowed = append(result.Allowed, change)
+				continue
+			}
 			result.Violations = append(result.Violations, ContractViolation{
 				ColumnName:  change.ColumnName,
 				ChangeType:  change.Type,
@@ -66,7 +72,7 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 
 	case ContractDiscardRow:
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeRemoveColumn {
+			if change.Type == ChangeRemoveColumn || isInternalAllowedChange(change) {
 				result.Allowed = append(result.Allowed, change)
 			} else {
 				result.Violations = append(result.Violations, ContractViolation{
@@ -92,6 +98,10 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 	}
 
 	return result
+}
+
+func isInternalAllowedChange(change SchemaChange) bool {
+	return change.Type == ChangeAddColumn && strings.EqualFold(change.ColumnName, naming.IngestrLoadedAtColumn)
 }
 
 func describeChange(change SchemaChange) string {

--- a/pkg/schemaevolution/contract_test.go
+++ b/pkg/schemaevolution/contract_test.go
@@ -81,6 +81,33 @@ func TestApplyContract_Freeze(t *testing.T) {
 	assert.Contains(t, err.Error(), "freeze")
 }
 
+func TestApplyContract_FreezeAllowsIngestrLoadedAt(t *testing.T) {
+	comparison := &SchemaComparison{
+		HasChanges: true,
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeAddColumn,
+				ColumnName: "_ingestr_loaded_at",
+				NewColumn:  schema.Column{Name: "_ingestr_loaded_at", DataType: schema.TypeTimestampTZ},
+			},
+			{
+				Type:       ChangeAddColumn,
+				ColumnName: "new_col",
+				NewColumn:  schema.Column{Name: "new_col", DataType: schema.TypeString},
+			},
+		},
+	}
+
+	contract := SchemaContract{Mode: ContractFreeze}
+	result := ApplyContract(contract, comparison)
+
+	assert.True(t, result.HasViolations())
+	assert.Len(t, result.Allowed, 1)
+	assert.Equal(t, "_ingestr_loaded_at", result.Allowed[0].ColumnName)
+	assert.Len(t, result.Violations, 1)
+	assert.Equal(t, "new_col", result.Violations[0].ColumnName)
+}
+
 func TestApplyContract_DiscardRow(t *testing.T) {
 	comparison := &SchemaComparison{
 		HasChanges: true,

--- a/pkg/schemaevolution/transform.go
+++ b/pkg/schemaevolution/transform.go
@@ -120,6 +120,9 @@ func NewDiscardRowTransformer(sourceSchema, destSchema *schema.TableSchema, comp
 
 	if comparison != nil {
 		for _, change := range comparison.Changes {
+			if isInternalAllowedChange(change) {
+				continue
+			}
 			// Track all violations (both new columns and type mismatches)
 			transformer.violations[change.ColumnName] = true
 		}

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
@@ -60,6 +61,50 @@ func TestIngestionJob_GetRecords_AppliesTransformation(t *testing.T) {
 	names := result.Batch.Column(1).(*array.String)
 	if got := names.Value(0); got != "alice" {
 		t.Fatalf("trimmed name = %q, want alice", got)
+	}
+}
+
+func TestIngestionJob_GetRecords_AddsSameLoadTimestampToEveryBatch(t *testing.T) {
+	job, _, _ := minimalJob()
+	job.BufferedRecords = mustClosedRecords(
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil)},
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{3}, nil)},
+	)
+
+	ts := time.Date(2026, 6, 19, 10, 11, 12, 345678901, time.UTC)
+	job.LoadTimestamp = transformer.NewLoadTimestamp(schema.Column{
+		Name:     "_ingestr_loaded_at",
+		DataType: schema.TypeTimestampTZ,
+		Nullable: false,
+	}, ts)
+
+	records, err := job.GetRecords(context.Background(), source.ReadOptions{})
+	if err != nil {
+		t.Fatalf("GetRecords returned error: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		result := <-records
+		if result.Err != nil {
+			t.Fatalf("record %d returned error: %v", i, result.Err)
+		}
+		if result.Batch == nil {
+			t.Fatalf("record %d batch is nil", i)
+		}
+		if got := result.Batch.ColumnName(1); got != "_ingestr_loaded_at" {
+			t.Fatalf("record %d column 1 = %q, want _ingestr_loaded_at", i, got)
+		}
+		loadedAt := result.Batch.Column(1).(*array.Timestamp)
+		for row := 0; row < int(result.Batch.NumRows()); row++ {
+			if got := int64(loadedAt.Value(row)); got != ts.UnixMicro() {
+				t.Fatalf("record %d row %d timestamp = %d, want %d", i, row, got, ts.UnixMicro())
+			}
+		}
+		result.Batch.Release()
+	}
+
+	if _, ok := <-records; ok {
+		t.Fatal("records channel still open after two batches")
 	}
 }
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -51,6 +51,9 @@ type IngestionJob struct {
 	// WhitespaceTrimmer trims string values when --trim-whitespace is enabled.
 	WhitespaceTrimmer *transformer.WhitespaceTrimmer
 
+	// LoadTimestamp adds or replaces _ingestr_loaded_at with one timestamp for the job.
+	LoadTimestamp *transformer.LoadTimestamp
+
 	// EvolutionPlan holds the deferred schema evolution to apply on the destination.
 	EvolutionPlan *schemaevolution.EvolutionPlan
 }
@@ -101,6 +104,9 @@ type MultiTableIngestionJob struct {
 
 	// WhitespaceTrimmer trims string values when --trim-whitespace is enabled.
 	WhitespaceTrimmer *transformer.WhitespaceTrimmer
+
+	// LoadTimestamp adds or replaces _ingestr_loaded_at with one timestamp for the job.
+	LoadTimestamp *transformer.LoadTimestamp
 }
 
 // ApplyEvolutionFor applies the pending schema evolution plan for a source table.
@@ -132,6 +138,9 @@ func (j *MultiTableIngestionJob) ReadAll(ctx context.Context, opts source.MultiT
 func (j *MultiTableIngestionJob) ApplyBatchTransformation(records <-chan source.RecordBatchResult) <-chan source.RecordBatchResult {
 	if j.WhitespaceTrimmer != nil {
 		records = transformer.Wrap(records, j.WhitespaceTrimmer)
+	}
+	if j.LoadTimestamp != nil {
+		records = transformer.Wrap(records, j.LoadTimestamp)
 	}
 	return records
 }
@@ -207,6 +216,10 @@ func (j *IngestionJob) ApplyBatchTransformation(ctx context.Context, records <-c
 
 	if j.IngestrColumnFiller != nil && j.IngestrColumnFiller.HasColumns() {
 		records = schemaevolution.TransformBatchStream(ctx, records, j.IngestrColumnFiller)
+	}
+
+	if j.LoadTimestamp != nil {
+		records = transformer.Wrap(records, j.LoadTimestamp)
 	}
 
 	return records, nil

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -54,6 +54,9 @@ type IngestionJob struct {
 	// LoadTimestamp adds or replaces _ingestr_loaded_at with one timestamp for the job.
 	LoadTimestamp *transformer.LoadTimestamp
 
+	// SchemaAligner reorders and fills transformed batches to match the write schema.
+	SchemaAligner *transformer.TypeCaster
+
 	// EvolutionPlan holds the deferred schema evolution to apply on the destination.
 	EvolutionPlan *schemaevolution.EvolutionPlan
 }
@@ -139,6 +142,10 @@ func (j *MultiTableIngestionJob) ApplyBatchTransformation(records <-chan source.
 	if j.WhitespaceTrimmer != nil {
 		records = transformer.Wrap(records, j.WhitespaceTrimmer)
 	}
+	return j.ApplyLoadTimestamp(records)
+}
+
+func (j *MultiTableIngestionJob) ApplyLoadTimestamp(records <-chan source.RecordBatchResult) <-chan source.RecordBatchResult {
 	if j.LoadTimestamp != nil {
 		records = transformer.Wrap(records, j.LoadTimestamp)
 	}
@@ -220,6 +227,10 @@ func (j *IngestionJob) ApplyBatchTransformation(ctx context.Context, records <-c
 
 	if j.LoadTimestamp != nil {
 		records = transformer.Wrap(records, j.LoadTimestamp)
+	}
+
+	if j.SchemaAligner != nil {
+		records = transformer.Wrap(records, j.SchemaAligner)
 	}
 
 	return records, nil

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -138,7 +138,7 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		parallelism = 4
 	}
 
-	records, err := job.Source.ReadAll(ctx, source.MultiTableReadOptions{
+	records, err := job.ReadAll(ctx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
 			Parallelism:   parallelism,
 			PageSize:      job.Config.PageSize,

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -3,13 +3,16 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 )
 
 const (
@@ -82,11 +85,6 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
-	records, err = job.ApplyBatchTransformation(ctx, records)
-	if err != nil {
-		return fmt.Errorf("failed to apply batch transformation: %w", err)
-	}
-
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
@@ -138,7 +136,7 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		parallelism = 4
 	}
 
-	records, err := job.ReadAll(ctx, source.MultiTableReadOptions{
+	records, err := job.Source.ReadAll(ctx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
 			Parallelism:   parallelism,
 			PageSize:      job.Config.PageSize,
@@ -312,6 +310,7 @@ func (l *flushLoop) buffer(res source.RecordBatchResult) {
 // position and the merge is idempotent by primary key.
 func (l *flushLoop) flush(ctx context.Context) error {
 	start := time.Now()
+	loadTimestamp := start.UTC().Truncate(time.Microsecond)
 	var flushedRows int64
 
 	for name, st := range l.tables {
@@ -342,9 +341,12 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			writeOpts.StagingTable = true
 		}
 
-		ch := prefilledBatchChannel(batches)
-		if err := l.dest.WriteParallel(ctx, ch, writeOpts); err != nil {
-			drainAndRelease(ch)
+		records := (<-chan source.RecordBatchResult)(prefilledBatchChannel(batches))
+		if col, ok := loadTimestampColumn(st.schema); ok {
+			records = transformer.Wrap(records, transformer.NewLoadTimestamp(col, loadTimestamp))
+		}
+		if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
+			drainAndRelease(records)
 			return fmt.Errorf("streaming flush: failed to write %d rows for table %s: %w", rows, displayName, err)
 		}
 
@@ -468,6 +470,18 @@ func (l *flushLoop) parallelism() int {
 		return l.cfg.ExtractParallelism
 	}
 	return 4
+}
+
+func loadTimestampColumn(s *schema.TableSchema) (schema.Column, bool) {
+	if s == nil {
+		return schema.Column{}, false
+	}
+	for _, col := range s.Columns {
+		if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
+			return col, true
+		}
+	}
+	return schema.Column{}, false
 }
 
 // prefilledBatchChannel wraps already-buffered batches in a closed channel so

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -3,12 +3,17 @@ package strategy
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +67,52 @@ func (d *truncatingDest) TruncateTable(_ context.Context, table string) error {
 	return nil
 }
 
+type timestampCapturingDest struct {
+	*fakeDestination
+	mu              sync.Mutex
+	writeTimestamps [][]int64
+}
+
+func (d *timestampCapturingDest) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.fakeDestination.mu.Lock()
+	d.calls = append(d.calls, "WriteParallel")
+	d.writeCalls = append(d.writeCalls, opts)
+	writeErr := d.writeErr
+	d.fakeDestination.mu.Unlock()
+
+	var timestamps []int64
+	for result := range records {
+		if result.Batch != nil {
+			values, err := loadTimestampValues(result.Batch)
+			if err != nil {
+				result.Batch.Release()
+				return err
+			}
+			timestamps = append(timestamps, values...)
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+
+	d.mu.Lock()
+	d.writeTimestamps = append(d.writeTimestamps, timestamps)
+	d.mu.Unlock()
+	return writeErr
+}
+
+func (d *timestampCapturingDest) capturedTimestamps() [][]int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	out := make([][]int64, len(d.writeTimestamps))
+	for i, values := range d.writeTimestamps {
+		out[i] = append([]int64(nil), values...)
+	}
+	return out
+}
+
 func streamTestSchema() *schema.TableSchema {
 	return &schema.TableSchema{
 		Columns: []schema.Column{
@@ -69,6 +120,18 @@ func streamTestSchema() *schema.TableSchema {
 		},
 		PrimaryKeys: []string{"id"},
 	}
+}
+
+func streamTestSchemaWithLoadTimestamp() *schema.TableSchema {
+	s := streamTestSchema()
+	result := *s
+	result.Columns = append([]schema.Column{}, s.Columns...)
+	result.Columns = append(result.Columns, schema.Column{
+		Name:     naming.IngestrLoadedAtColumn,
+		DataType: schema.TypeTimestampTZ,
+		Nullable: true,
+	})
+	return &result
 }
 
 func mergeTableState(name string) *streamTableState {
@@ -88,6 +151,30 @@ func writeCallCount(d *fakeDestination) int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return len(d.writeCalls)
+}
+
+func loadTimestampValues(batch arrow.RecordBatch) ([]int64, error) {
+	idx := -1
+	for i := 0; i < int(batch.NumCols()); i++ {
+		if strings.EqualFold(batch.ColumnName(i), naming.IngestrLoadedAtColumn) {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, fmt.Errorf("missing %s column", naming.IngestrLoadedAtColumn)
+	}
+
+	col, ok := batch.Column(idx).(*array.Timestamp)
+	if !ok {
+		return nil, fmt.Errorf("%s column is %T, want *array.Timestamp", naming.IngestrLoadedAtColumn, batch.Column(idx))
+	}
+
+	values := make([]int64, int(batch.NumRows()))
+	for row := 0; row < int(batch.NumRows()); row++ {
+		values[row] = int64(col.Value(row))
+	}
+	return values, nil
 }
 
 func TestStreaming_CountTriggerFlushes(t *testing.T) {
@@ -132,6 +219,52 @@ func TestStreaming_CountTriggerFlushes(t *testing.T) {
 	baseDest.mu.Unlock()
 	// Cumulative token semantics: only the newest token is committed.
 	assert.Equal(t, []any{3}, committer.committed())
+
+	cancel()
+	close(records)
+	require.NoError(t, <-done)
+}
+
+func TestStreaming_LoadTimestampIsSetPerFlushCycle(t *testing.T) {
+	dest := &timestampCapturingDest{fakeDestination: &fakeDestination{}}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  4,
+		Strategy:      config.StrategyAppend,
+	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchemaWithLoadTimestamp()}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(ctx, records) }()
+
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil)}
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{3, 4}, nil)}
+
+	require.Eventually(t, func() bool {
+		return len(dest.capturedTimestamps()) == 1
+	}, 5*time.Second, time.Millisecond)
+
+	first := dest.capturedTimestamps()[0]
+	require.Len(t, first, 4)
+	for _, value := range first[1:] {
+		assert.Equal(t, first[0], value, "all rows in one flush should share a timestamp")
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{5, 6, 7, 8}, nil)}
+
+	require.Eventually(t, func() bool {
+		return len(dest.capturedTimestamps()) == 2
+	}, 5*time.Second, time.Millisecond)
+
+	second := dest.capturedTimestamps()[1]
+	require.Len(t, second, 4)
+	for _, value := range second[1:] {
+		assert.Equal(t, second[0], value, "all rows in one flush should share a timestamp")
+	}
+	assert.NotEqual(t, first[0], second[0], "later flushes should get a fresh load timestamp")
 
 	cancel()
 	close(records)

--- a/pkg/transformer/load_timestamp.go
+++ b/pkg/transformer/load_timestamp.go
@@ -1,0 +1,110 @@
+package transformer
+
+import (
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+type LoadTimestamp struct {
+	column    schema.Column
+	timestamp time.Time
+}
+
+func NewLoadTimestamp(column schema.Column, timestamp time.Time) *LoadTimestamp {
+	if column.DataType != schema.TypeTimestamp && column.DataType != schema.TypeTimestampTZ {
+		column.DataType = schema.TypeTimestampTZ
+	}
+	return &LoadTimestamp{
+		column:    column,
+		timestamp: timestamp.UTC().Truncate(time.Microsecond),
+	}
+}
+
+func (t *LoadTimestamp) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+	loadArray := t.timestampArray(batch.NumRows())
+	batchSchema := batch.Schema()
+
+	fields := make([]arrow.Field, 0, batchSchema.NumFields()+1)
+	columns := make([]arrow.Array, 0, batch.NumCols()+1)
+	replaced := false
+
+	for i := 0; i < int(batch.NumCols()); i++ {
+		field := batchSchema.Field(i)
+		if strings.EqualFold(field.Name, t.column.Name) {
+			if !replaced {
+				fields = append(fields, t.field())
+				columns = append(columns, loadArray)
+				replaced = true
+			}
+			continue
+		}
+
+		fields = append(fields, field)
+		col := batch.Column(i)
+		col.Retain()
+		columns = append(columns, col)
+	}
+
+	if !replaced {
+		fields = append(fields, t.field())
+		columns = append(columns, loadArray)
+	}
+
+	out := array.NewRecordBatch(arrow.NewSchema(fields, nil), columns, batch.NumRows())
+	for _, col := range columns {
+		col.Release()
+	}
+	return out, nil
+}
+
+func (t *LoadTimestamp) OutputSchema(inputSchema *arrow.Schema) *arrow.Schema {
+	fields := make([]arrow.Field, 0, inputSchema.NumFields()+1)
+	replaced := false
+
+	for i := 0; i < inputSchema.NumFields(); i++ {
+		field := inputSchema.Field(i)
+		if strings.EqualFold(field.Name, t.column.Name) {
+			if !replaced {
+				fields = append(fields, t.field())
+				replaced = true
+			}
+			continue
+		}
+		fields = append(fields, field)
+	}
+
+	if !replaced {
+		fields = append(fields, t.field())
+	}
+
+	return arrow.NewSchema(fields, nil)
+}
+
+func (t *LoadTimestamp) field() arrow.Field {
+	return arrow.Field{
+		Name:     t.column.Name,
+		Type:     schema.DataTypeToArrowType(t.column),
+		Nullable: t.column.Nullable,
+	}
+}
+
+func (t *LoadTimestamp) timestampArray(numRows int64) arrow.Array {
+	arrowType, ok := schema.DataTypeToArrowType(t.column).(*arrow.TimestampType)
+	if !ok {
+		arrowType = &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
+	}
+
+	builder := array.NewTimestampBuilder(memory.DefaultAllocator, arrowType)
+	defer builder.Release()
+
+	value := arrow.Timestamp(t.timestamp.UnixMicro())
+	for i := int64(0); i < numRows; i++ {
+		builder.Append(value)
+	}
+	return builder.NewArray()
+}

--- a/pkg/transformer/transformer_test.go
+++ b/pkg/transformer/transformer_test.go
@@ -106,6 +106,89 @@ func TestColumnAdder_OutputSchema(t *testing.T) {
 	assert.Equal(t, "new_col", outputSchema.Field(1).Name)
 }
 
+func TestLoadTimestamp_AddsSingleTimestamp(t *testing.T) {
+	allocator := memory.DefaultAllocator
+	inputSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+
+	idBuilder := array.NewInt64Builder(allocator)
+	defer idBuilder.Release()
+	idBuilder.AppendValues([]int64{1, 2, 3}, nil)
+	idArray := idBuilder.NewArray()
+	defer idArray.Release()
+
+	inputBatch := array.NewRecordBatch(inputSchema, []arrow.Array{idArray}, 3)
+	defer inputBatch.Release()
+
+	ts := time.Date(2026, 6, 19, 12, 34, 56, 123456789, time.UTC)
+	transformer := NewLoadTimestamp(schema.Column{
+		Name:     "_ingestr_loaded_at",
+		DataType: schema.TypeTimestampTZ,
+		Nullable: false,
+	}, ts)
+
+	result, err := transformer.Transform(inputBatch)
+	require.NoError(t, err)
+	defer result.Release()
+
+	assert.Equal(t, int64(2), result.NumCols())
+	assert.Equal(t, "_ingestr_loaded_at", result.ColumnName(1))
+
+	loadedAt := result.Column(1).(*array.Timestamp)
+	for i := 0; i < 3; i++ {
+		assert.False(t, loadedAt.IsNull(i))
+		assert.Equal(t, ts.UnixMicro(), int64(loadedAt.Value(i)))
+	}
+}
+
+func TestLoadTimestamp_ReplacesExistingColumnIdempotently(t *testing.T) {
+	allocator := memory.DefaultAllocator
+	inputSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "_ingestr_loaded_at", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	idBuilder := array.NewInt64Builder(allocator)
+	defer idBuilder.Release()
+	idBuilder.AppendValues([]int64{1, 2}, nil)
+	idArray := idBuilder.NewArray()
+	defer idArray.Release()
+
+	existingBuilder := array.NewStringBuilder(allocator)
+	defer existingBuilder.Release()
+	existingBuilder.AppendValues([]string{"old", "old"}, nil)
+	existingArray := existingBuilder.NewArray()
+	defer existingArray.Release()
+
+	inputBatch := array.NewRecordBatch(inputSchema, []arrow.Array{idArray, existingArray}, 2)
+	defer inputBatch.Release()
+
+	ts := time.Date(2026, 6, 19, 13, 0, 0, 987654321, time.UTC)
+	transformer := NewLoadTimestamp(schema.Column{
+		Name:     "_INGESTR_LOADED_AT",
+		DataType: schema.TypeTimestampTZ,
+		Nullable: true,
+	}, ts)
+
+	first, err := transformer.Transform(inputBatch)
+	require.NoError(t, err)
+	defer first.Release()
+
+	second, err := transformer.Transform(first)
+	require.NoError(t, err)
+	defer second.Release()
+
+	assert.Equal(t, int64(2), second.NumCols())
+	assert.Equal(t, "_INGESTR_LOADED_AT", second.ColumnName(1))
+	assert.True(t, second.Schema().Field(1).Nullable)
+
+	loadedAt := second.Column(1).(*array.Timestamp)
+	for i := 0; i < 2; i++ {
+		assert.Equal(t, ts.UnixMicro(), int64(loadedAt.Value(i)))
+	}
+}
+
 func TestChainedTransformer(t *testing.T) {
 	allocator := memory.DefaultAllocator
 

--- a/pkg/transformer/type_caster.go
+++ b/pkg/transformer/type_caster.go
@@ -9,10 +9,15 @@ import (
 // Used when --columns specifies type overrides for known-schema sources.
 type TypeCaster struct {
 	targetSchema *arrow.Schema
+	safe         bool
 }
 
 func NewTypeCaster(targetSchema *arrow.Schema) *TypeCaster {
 	return &TypeCaster{targetSchema: targetSchema}
+}
+
+func NewSafeTypeCaster(targetSchema *arrow.Schema) *TypeCaster {
+	return &TypeCaster{targetSchema: targetSchema, safe: true}
 }
 
 func (tc *TypeCaster) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, error) {
@@ -20,7 +25,7 @@ func (tc *TypeCaster) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, err
 		batch.Retain()
 		return batch, nil
 	}
-	return databuffer.CastRecordToSchema(batch, tc.targetSchema, false)
+	return databuffer.CastRecordToSchema(batch, tc.targetSchema, tc.safe)
 }
 
 func (tc *TypeCaster) OutputSchema(_ *arrow.Schema) *arrow.Schema {

--- a/tests/integration/column_overrides_postgres_test.go
+++ b/tests/integration/column_overrides_postgres_test.go
@@ -55,11 +55,13 @@ func TestColumnOverrides_CSVToPostgres_EmptySourceWithOverrides(t *testing.T) {
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
 	types := readPostgresColumnTypes(t, pgDest.uri, schemaName, "empty")
+	requireLoadTimestampColumn(t, types)
+	userTypes := withoutLoadTimestampTypes(types)
 	assert.Equal(t, "bigint", types["id"])
 	assert.Equal(t, "text", types["name"])
 	assert.Equal(t, "text", types["email"])
 	assert.Equal(t, "smallint", types["age"])
-	assert.Equal(t, 4, len(types), "table should have exactly the 4 overridden columns")
+	assert.Equal(t, 4, len(userTypes), "table should have exactly the 4 overridden user columns")
 
 	assert.Equal(t, 0, readPostgresRowCount(t, pgDest.uri, schemaName, "empty"))
 }

--- a/tests/integration/column_overrides_test.go
+++ b/tests/integration/column_overrides_test.go
@@ -65,11 +65,13 @@ func TestColumnOverrides_CSVToDuckDB(t *testing.T) {
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.users")
+	requireLoadTimestampColumn(t, types)
+	userTypes := withoutLoadTimestampTypes(types)
 	assert.Equal(t, "VARCHAR", types["id"])
 	assert.Equal(t, "VARCHAR", types["name"])
 	assert.Equal(t, "VARCHAR", types["email"])
 	assert.Equal(t, "VARCHAR", types["age"])
-	assert.Equal(t, 4, len(types))
+	assert.Equal(t, 4, len(userTypes))
 	assert.Equal(t, 3, readDuckDBRowCount(t, duckDBPath, "main.users"))
 }
 
@@ -273,11 +275,13 @@ func TestColumnOverrides_EmptyCSV_WithOverrides_TableCreatedFromOverrides(t *tes
 		"destination table should be created from --columns when source has no rows")
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.empty")
+	requireLoadTimestampColumn(t, types)
+	userTypes := withoutLoadTimestampTypes(types)
 	assert.Equal(t, "BIGINT", types["id"])
 	assert.Equal(t, "VARCHAR", types["name"])
 	assert.Equal(t, "VARCHAR", types["email"])
 	assert.Equal(t, "SMALLINT", types["age"])
-	assert.Equal(t, 4, len(types), "table should have exactly the 4 overridden columns")
+	assert.Equal(t, 4, len(userTypes), "table should have exactly the 4 overridden user columns")
 
 	assert.Equal(t, 0, readDuckDBRowCount(t, duckDBPath, "main.empty"),
 		"empty source should produce zero rows in destination")
@@ -335,10 +339,12 @@ func TestColumnOverrides_ExtraColumn_AddedWithNulls(t *testing.T) {
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.users")
+	requireLoadTimestampColumn(t, types)
+	userTypes := withoutLoadTimestampTypes(types)
 	assert.Equal(t, "BIGINT", types["id"], "id override should apply")
 	assert.Equal(t, "VARCHAR", types["does_not_exist"],
 		"override for a column not in the schema-less source should be added with NULL values")
-	assert.Equal(t, 5, len(types), "4 source columns + 1 added override column")
+	assert.Equal(t, 5, len(userTypes), "4 source columns + 1 added override column")
 
 	db := openDuckDBForTest(t, duckDBPath)
 	defer func() { _ = db.Close() }()
@@ -430,11 +436,13 @@ func TestColumnOverrides_EmptyCSV_AutoAddsPKColumn(t *testing.T) {
 	require.True(t, duckDBTableExists(t, duckDBPath, "main", "empty"))
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.empty")
+	requireLoadTimestampColumn(t, types)
+	userTypes := withoutLoadTimestampTypes(types)
 	assert.Equal(t, "BIGINT", types["id"])
 	assert.Equal(t, "VARCHAR", types["name"])
 	assert.Equal(t, "VARCHAR", types["user_uid"],
 		"PK column missing from --columns should be auto-added as VARCHAR so merge-style destinations accept the CREATE TABLE")
-	assert.Equal(t, 3, len(types), "expected id + name + user_uid (the resolved PK)")
+	assert.Equal(t, 3, len(userTypes), "expected id + name + user_uid (the resolved PK)")
 }
 
 // --- helpers ---------------------------------------------------------------

--- a/tests/integration/custom_query_test.go
+++ b/tests/integration/custom_query_test.go
@@ -105,6 +105,7 @@ func TestCustomQuery_PostgresToSQLite(t *testing.T) {
 				cols, err := rows.Columns()
 				require.NoError(t, err)
 				_ = rows.Close()
+				cols = withoutLoadTimestampColumns(cols)
 				assert.Equal(t, 2, len(cols), "should only have id and amount columns")
 
 				var minAmount float64

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -1381,7 +1381,8 @@ func validateReplaceSQL(t *testing.T, backend *sqlBackend, uri, table string) {
 		t.Skipf("Could not read schema types: %v", err)
 		return
 	}
-	assert.Equal(t, backend.expectedTypes, actualTypes)
+	requireLoadTimestampColumn(t, actualTypes)
+	assert.Equal(t, backend.expectedTypes, withoutLoadTimestampTypes(actualTypes))
 }
 
 func validateMergeSQL(t *testing.T, backend *sqlBackend, uri, table string) {

--- a/tests/integration/load_timestamp_helpers_test.go
+++ b/tests/integration/load_timestamp_helpers_test.go
@@ -1,0 +1,47 @@
+//go:build integration || local
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/naming"
+	"github.com/stretchr/testify/require"
+)
+
+func withoutLoadTimestampTypes(types map[string]string) map[string]string {
+	out := make(map[string]string, len(types))
+	for name, typ := range types {
+		if strings.EqualFold(name, naming.IngestrLoadedAtColumn) {
+			continue
+		}
+		out[name] = typ
+	}
+	return out
+}
+
+func withoutLoadTimestampColumns(cols []string) []string {
+	out := make([]string, 0, len(cols))
+	for _, col := range cols {
+		if strings.EqualFold(col, naming.IngestrLoadedAtColumn) {
+			continue
+		}
+		out = append(out, col)
+	}
+	return out
+}
+
+func requireLoadTimestampColumn(t *testing.T, types map[string]string) {
+	t.Helper()
+	_, ok := types[naming.IngestrLoadedAtColumn]
+	if !ok {
+		for name := range types {
+			if strings.EqualFold(name, naming.IngestrLoadedAtColumn) {
+				ok = true
+				break
+			}
+		}
+	}
+	require.True(t, ok, "expected %s column in %v", naming.IngestrLoadedAtColumn, types)
+}

--- a/tests/integration/mssql_confidence_test.go
+++ b/tests/integration/mssql_confidence_test.go
@@ -188,6 +188,7 @@ func TestMSSQLSource_TableToSQLite_CustomSchemaFiltersAndExcludeColumns(t *testi
 	assert.Equal(t, 2, count, "custom schema read should honor TOP limit")
 
 	cols := sqliteColumns(t, destDB, "filtered_rows")
+	cols = withoutLoadTimestampColumns(cols)
 	assert.Equal(t, []string{"id", "name", "updated_at"}, cols, "excluded MSSQL columns should be removed from the destination schema")
 
 	var minTS, maxTS string

--- a/tests/integration/override_naming_collision_test.go
+++ b/tests/integration/override_naming_collision_test.go
@@ -70,7 +70,9 @@ func TestAppLovinAssetShape_OverridesAndTypesAppliedAcrossRenames(t *testing.T) 
 	})
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.input")
-	require.Equal(t, 16, len(types), "got: %v", types)
+	requireLoadTimestampColumn(t, types)
+	userTypes := withoutLoadTimestampTypes(types)
+	require.Equal(t, 16, len(userTypes), "got: %v", types)
 	assert.Equal(t, "VARCHAR", types["ad_format"])
 	assert.Equal(t, "VARCHAR", types["ad_unit_id"])
 	assert.Equal(t, "VARCHAR", types["device_type"])
@@ -103,7 +105,8 @@ func TestSnakeCase_NoDuplicateAppended(t *testing.T) {
 				cfg.Columns = tc.override + ",country:string"
 			})
 			types := readDuckDBColumnTypes(t, duckDBPath, "main.input")
-			require.Equal(t, 2, len(types), "got: %v", types)
+			requireLoadTimestampColumn(t, types)
+			require.Equal(t, 2, len(withoutLoadTimestampTypes(types)), "got: %v", types)
 		})
 	}
 }
@@ -115,7 +118,8 @@ func TestSnakeCase_TrulyMissingOverrideColumnIsStillAppended(t *testing.T) {
 	})
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.input")
-	require.Equal(t, 3, len(types), "got: %v", types)
+	requireLoadTimestampColumn(t, types)
+	require.Equal(t, 3, len(withoutLoadTimestampTypes(types)), "got: %v", types)
 	assert.Equal(t, "VARCHAR", types["ad_format"])
 	assert.Equal(t, "VARCHAR", types["country"])
 	assert.Equal(t, "BIGINT", types["extra_col"])
@@ -129,7 +133,8 @@ func TestDirectNaming_OverrideInSourceFormStillWorks(t *testing.T) {
 	})
 
 	types := readDuckDBColumnTypes(t, duckDBPath, "main.input")
-	require.Equal(t, 3, len(types))
+	requireLoadTimestampColumn(t, types)
+	require.Equal(t, 3, len(withoutLoadTimestampTypes(types)))
 	assert.Equal(t, "DOUBLE", types["revenue"], "got: %v", types)
 }
 


### PR DESCRIPTION
Adds `_ingestr_loaded_at` to ingestr-loaded tables by default, with one timestamp shared across all batches in a load. Existing destination tables evolve automatically, and `--no-load-timestamp` keeps the old behavior. Validated with `make format`, `make lint`, `make test`, plus SQLite, DuckDB, BigQuery, and Snowflake smoke tests.