### PR TITLE
[codex] add license audit lock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,5 +138,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache-dependency-path: "go.sum"
-      - name: Check third-party license notices
+      - name: Check third-party license policy
         run: make licenses-check
+      - name: Check third-party license audit lock
+        run: make licenses-audit

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ LICENSE_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd
 LICENSE_CHECK_TARGETS ?= linux/amd64
 LICENSE_INCLUDE_TESTS ?= true
 LICENSE_CHECK_INCLUDE_TESTS ?= false
+LICENSE_AUDIT_TARGETS ?= $(LICENSE_CHECK_TARGETS)
+LICENSE_AUDIT_INCLUDE_TESTS ?= $(LICENSE_CHECK_INCLUDE_TESTS)
+LICENSE_AUDIT_NEW_STATUS ?= needs-review
 export INGESTR_DISABLE_TELEMETRY := true
 export DISABLE_TELEMETRY := true
 TELEMETRY_ENV := INGESTR_DISABLE_TELEMETRY=true DISABLE_TELEMETRY=true
@@ -16,7 +19,7 @@ NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 
-.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration
+.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration
 
 all: clean deps test build
 
@@ -48,6 +51,14 @@ licenses: generate
 licenses-check: generate
 	@echo "$(OK_COLOR)==> Checking third-party license policy$(NO_COLOR)"
 	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_DISALLOWED_TYPES="$(LICENSE_DISALLOWED_TYPES)" LICENSE_TARGETS="$(LICENSE_CHECK_TARGETS)" LICENSE_INCLUDE_TESTS="$(LICENSE_CHECK_INCLUDE_TESTS)" ./hack/update-third-party-licenses.sh --policy-only
+
+licenses-audit: generate
+	@echo "$(OK_COLOR)==> Checking third-party license audit lock$(NO_COLOR)"
+	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_AUDIT_TARGETS="$(LICENSE_AUDIT_TARGETS)" LICENSE_AUDIT_INCLUDE_TESTS="$(LICENSE_AUDIT_INCLUDE_TESTS)" ./hack/license-audit.sh --check
+
+licenses-audit-update: generate
+	@echo "$(OK_COLOR)==> Updating third-party license audit lock$(NO_COLOR)"
+	@GO_LICENSES_MODULE="$(GO_LICENSES_MODULE)" LICENSE_AUDIT_TARGETS="$(LICENSE_AUDIT_TARGETS)" LICENSE_AUDIT_INCLUDE_TESTS="$(LICENSE_AUDIT_INCLUDE_TESTS)" LICENSE_AUDIT_NEW_STATUS="$(LICENSE_AUDIT_NEW_STATUS)" ./hack/license-audit.sh --write
 
 licenses-notices-check: generate
 	@echo "$(OK_COLOR)==> Checking third-party license notices$(NO_COLOR)"

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1882,6 +1882,422 @@ cloud.google.com/go/monitoring/LICENSE
 
 
 ===============================================================================
+cloud.google.com/go/pubsub/LICENSE
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
+cloud.google.com/go/pubsub/v2/apiv1/pubsubpb/LICENSE
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
 cloud.google.com/go/spanner/LICENSE
 ===============================================================================
 
@@ -14509,6 +14925,214 @@ github.com/aws/aws-sdk-go-v2/service/s3/LICENSE.txt
 
 ===============================================================================
 github.com/aws/aws-sdk-go-v2/service/signin/LICENSE.txt
+===============================================================================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
+github.com/aws/aws-sdk-go-v2/service/sqs/LICENSE.txt
 ===============================================================================
 
 
@@ -37202,6 +37826,66 @@ SOFTWARE.
 
 
 ===============================================================================
+github.com/99designs/go-keychain/LICENSE (MIT, manually audited)
+===============================================================================
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Keybase
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+===============================================================================
+github.com/DATA-DOG/go-sqlmock/LICENSE (BSD-3-Clause, manually audited)
+===============================================================================
+
+The three clause BSD license (http://en.wikipedia.org/wiki/BSD_licenses)
+
+Copyright (c) 2013-2019, DATA-DOG team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* The name DataDog.lt may not be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===============================================================================
 github.com/segmentio/asm/LICENSE (MIT No Attribution, manually audited)
 ===============================================================================
 
@@ -37253,63 +37937,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-===============================================================================
-github.com/DATA-DOG/go-sqlmock/LICENSE (BSD-3-Clause, manually audited)
-===============================================================================
-
-The three clause BSD license (http://en.wikipedia.org/wiki/BSD_licenses)
-
-Copyright (c) 2013-2019, DATA-DOG team
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* The name DataDog.lt may not be used to endorse or promote products
-  derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-===============================================================================
-github.com/99designs/go-keychain/LICENSE (MIT, manually audited)
-===============================================================================
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Keybase
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-

--- a/cmd/licenseaudit/main.go
+++ b/cmd/licenseaudit/main.go
@@ -88,7 +88,7 @@ func run() error {
 	flag.StringVar(&csvPath, "csv", "", "go-licenses csv output")
 	flag.StringVar(&modulesPath, "modules", "", "go list -m all output")
 	flag.StringVar(&outputPath, "output", "", "output file for append-manual-notices")
-	flag.StringVar(&newStatus, "new-status", "needs-review", "status for new or changed dependencies in write mode")
+	flag.StringVar(&newStatus, "new-status", "needs-review", "fallback status for new or changed dependencies whose licenses are not default-allowed")
 	flag.StringVar(&tool, "tool", "", "scanner tool metadata for write mode")
 	flag.StringVar(&packages, "packages", "", "package pattern metadata for write mode")
 	flag.StringVar(&targets, "targets", "", "space-separated target metadata for write mode")
@@ -333,15 +333,16 @@ func mergeDependencies(existing []dependencyReview, scanned []scanEntry, newStat
 	next := make([]dependencyReview, 0, len(scanned))
 	for _, scan := range scanned {
 		old, ok := byModule[scan.Module]
-		status := newStatus
-		note := ""
+		status, note := defaultReviewStatus(scan, newStatus)
 		if ok {
 			if old.Version == scan.Version && sameStrings(old.Licenses, scan.Licenses) {
 				status = old.Status
 				note = old.Note
-			} else {
+			} else if old.Status == "manual-review" {
 				status = "needs-review"
-				note = "Version or license changed; review before setting status."
+				note = "Manual-reviewed dependency changed; review before setting status."
+			} else {
+				status, note = changedReviewStatus(scan, newStatus)
 			}
 		}
 		next = append(next, dependencyReview{
@@ -354,6 +355,57 @@ func mergeDependencies(existing []dependencyReview, scanned []scanEntry, newStat
 	}
 	sortDependencies(next)
 	return next
+}
+
+func changedReviewStatus(scan scanEntry, fallbackStatus string) (string, string) {
+	status, note := defaultReviewStatus(scan, fallbackStatus)
+	if status == "needs-review" {
+		note = "Version or license changed; review before setting status."
+	}
+	return status, note
+}
+
+func defaultReviewStatus(scan scanEntry, fallbackStatus string) (string, string) {
+	if defaultAllowedLicenses(scan.Licenses) {
+		return "allowed", ""
+	}
+	if fallbackStatus == "" {
+		fallbackStatus = "needs-review"
+	}
+	if fallbackStatus == "needs-review" {
+		return fallbackStatus, "License is not in the default allowlist; review before setting status."
+	}
+	return fallbackStatus, ""
+}
+
+func defaultAllowedLicenses(licenses []string) bool {
+	if len(licenses) == 0 {
+		return false
+	}
+	for _, license := range licenses {
+		if !defaultAllowedLicense(license) {
+			return false
+		}
+	}
+	return true
+}
+
+func defaultAllowedLicense(license string) bool {
+	switch license {
+	case "0BSD",
+		"Apache-2.0",
+		"BSD-2-Clause",
+		"BSD-3-Clause",
+		"CC0-1.0",
+		"ISC",
+		"MIT",
+		"MPL-2.0",
+		"Unlicense",
+		"Zlib":
+		return true
+	default:
+		return false
+	}
 }
 
 func appendManualNotices(audits []manualAudit, outputPath string) (err error) {

--- a/cmd/licenseaudit/main.go
+++ b/cmd/licenseaudit/main.go
@@ -304,7 +304,11 @@ func checkLock(lock *lockFile, scanned []scanEntry) error {
 			problems = append(problems, fmt.Sprintf("%s has manual audit status %q; set an accepted status after review", audit.Module, audit.Status))
 		}
 		if err := validateManualAudit(audit); err != nil {
-			problems = append(problems, err.Error())
+			if errors.Is(err, errModuleNotSelected) {
+				problems = append(problems, fmt.Sprintf("manual audit for %s is stale: module is not selected by go.mod; remove it from licenses.lock.yml", audit.Module))
+			} else {
+				problems = append(problems, err.Error())
+			}
 		}
 	}
 
@@ -339,8 +343,7 @@ func mergeDependencies(existing []dependencyReview, scanned []scanEntry, newStat
 				status = old.Status
 				note = old.Note
 			} else if old.Status == "manual-review" {
-				status = "needs-review"
-				note = "Manual-reviewed dependency changed; review before setting status."
+				status, note = manualReviewChangedStatus(scan, newStatus)
 			} else {
 				status, note = changedReviewStatus(scan, newStatus)
 			}
@@ -363,6 +366,13 @@ func changedReviewStatus(scan scanEntry, fallbackStatus string) (string, string)
 		note = "Version or license changed; review before setting status."
 	}
 	return status, note
+}
+
+func manualReviewChangedStatus(scan scanEntry, fallbackStatus string) (string, string) {
+	if fallbackStatus != "" && fallbackStatus != "needs-review" {
+		return fallbackStatus, ""
+	}
+	return "needs-review", "Manual-reviewed dependency changed; review before setting status."
 }
 
 func defaultReviewStatus(scan scanEntry, fallbackStatus string) (string, string) {
@@ -447,7 +457,7 @@ func appendManualNotices(audits []manualAudit, outputPath string) (err error) {
 var errModuleNotSelected = errors.New("module is not selected")
 
 func validateManualAudit(audit manualAudit) error {
-	if audit.Module == "" || audit.Version == "" || audit.LicenseFile == "" || audit.LicenseSHA256 == "" {
+	if audit.Module == "" || audit.Version == "" || audit.License == "" || audit.LicenseFile == "" || audit.LicenseSHA256 == "" {
 		return fmt.Errorf("manual audit for %q is incomplete", audit.Module)
 	}
 
@@ -497,7 +507,14 @@ func goListModule(module string) (string, string, bool, error) {
 	out, err := cmd.Output()
 	if err != nil {
 		if _, ok := err.(*exec.ExitError); ok {
-			return "", "", false, nil
+			stderrText := strings.TrimSpace(stderr.String())
+			if moduleNotSelected(stderrText) {
+				return "", "", false, nil
+			}
+			if stderrText == "" {
+				stderrText = err.Error()
+			}
+			return "", "", false, fmt.Errorf("go list -m %s failed: %s", module, stderrText)
 		}
 		return "", "", false, fmt.Errorf("go list -m %s: %w", module, err)
 	}
@@ -508,6 +525,10 @@ func goListModule(module string) (string, string, bool, error) {
 		dir = parts[1]
 	}
 	return version, dir, true, nil
+}
+
+func moduleNotSelected(stderr string) bool {
+	return strings.Contains(stderr, "not a known dependency")
 }
 
 func goModDownloadDir(module, version string) (string, error) {

--- a/cmd/licenseaudit/main.go
+++ b/cmd/licenseaudit/main.go
@@ -1,0 +1,554 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/csv"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type lockFile struct {
+	Version      int                `yaml:"version"`
+	Generated    generatedMetadata  `yaml:"generated,omitempty"`
+	ManualAudits []manualAudit      `yaml:"manual_audits,omitempty"`
+	Dependencies []dependencyReview `yaml:"dependencies,omitempty"`
+}
+
+type generatedMetadata struct {
+	Tool         string   `yaml:"tool,omitempty"`
+	Packages     string   `yaml:"packages,omitempty"`
+	Targets      []string `yaml:"targets,omitempty"`
+	IncludeTests bool     `yaml:"include_tests"`
+}
+
+type manualAudit struct {
+	Module        string `yaml:"module"`
+	Version       string `yaml:"version"`
+	License       string `yaml:"license"`
+	LicenseFile   string `yaml:"license_file"`
+	LicenseSHA256 string `yaml:"license_sha256"`
+	Status        string `yaml:"status"`
+	Note          string `yaml:"note,omitempty"`
+}
+
+type dependencyReview struct {
+	Module   string   `yaml:"module"`
+	Version  string   `yaml:"version"`
+	Licenses []string `yaml:"licenses"`
+	Status   string   `yaml:"status"`
+	Note     string   `yaml:"note,omitempty"`
+}
+
+type moduleInfo struct {
+	Path    string
+	Version string
+}
+
+type scanEntry struct {
+	Module   string
+	Version  string
+	Licenses []string
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "licenseaudit: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		mode         string
+		lockPath     string
+		csvPath      string
+		modulesPath  string
+		outputPath   string
+		newStatus    string
+		tool         string
+		packages     string
+		targets      string
+		includeTests bool
+	)
+
+	flag.StringVar(&mode, "mode", "check", "mode: check, write, ignored-modules, append-manual-notices")
+	flag.StringVar(&lockPath, "lock", "licenses.lock.yml", "license audit lock file")
+	flag.StringVar(&csvPath, "csv", "", "go-licenses csv output")
+	flag.StringVar(&modulesPath, "modules", "", "go list -m all output")
+	flag.StringVar(&outputPath, "output", "", "output file for append-manual-notices")
+	flag.StringVar(&newStatus, "new-status", "needs-review", "status for new or changed dependencies in write mode")
+	flag.StringVar(&tool, "tool", "", "scanner tool metadata for write mode")
+	flag.StringVar(&packages, "packages", "", "package pattern metadata for write mode")
+	flag.StringVar(&targets, "targets", "", "space-separated target metadata for write mode")
+	flag.BoolVar(&includeTests, "include-tests", false, "include test dependency metadata for write mode")
+	flag.Parse()
+
+	switch mode {
+	case "ignored-modules":
+		lock, err := readLock(lockPath, true)
+		if err != nil {
+			return err
+		}
+		for _, audit := range lock.ManualAudits {
+			if audit.Module != "" {
+				fmt.Println(audit.Module)
+			}
+		}
+		return nil
+
+	case "append-manual-notices":
+		if outputPath == "" {
+			return errors.New("-output is required for append-manual-notices")
+		}
+		lock, err := readLock(lockPath, false)
+		if err != nil {
+			return err
+		}
+		return appendManualNotices(lock.ManualAudits, outputPath)
+
+	case "check", "write":
+		if csvPath == "" || modulesPath == "" {
+			return errors.New("-csv and -modules are required")
+		}
+		lock, err := readLock(lockPath, mode == "write")
+		if err != nil {
+			return err
+		}
+		modules, err := readModules(modulesPath)
+		if err != nil {
+			return err
+		}
+		scanned, err := readScan(csvPath, modules)
+		if err != nil {
+			return err
+		}
+		if mode == "check" {
+			return checkLock(lock, scanned)
+		}
+		lock.Version = 1
+		lock.Generated = generatedMetadata{
+			Tool:         tool,
+			Packages:     packages,
+			Targets:      strings.Fields(targets),
+			IncludeTests: includeTests,
+		}
+		lock.Dependencies = mergeDependencies(lock.Dependencies, scanned, newStatus)
+		return writeLock(lockPath, lock)
+
+	default:
+		return fmt.Errorf("unknown mode %q", mode)
+	}
+}
+
+func readLock(path string, allowMissing bool) (*lockFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if allowMissing && errors.Is(err, os.ErrNotExist) {
+			return &lockFile{Version: 1}, nil
+		}
+		return nil, err
+	}
+	var lock lockFile
+	if err := yaml.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if lock.Version == 0 {
+		lock.Version = 1
+	}
+	return &lock, nil
+}
+
+func writeLock(path string, lock *lockFile) error {
+	sortManualAudits(lock.ManualAudits)
+	sortDependencies(lock.Dependencies)
+
+	data, err := yaml.Marshal(lock)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func readModules(path string) ([]moduleInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var modules []moduleInfo
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		version := ""
+		if len(fields) > 1 {
+			version = fields[1]
+		}
+		modules = append(modules, moduleInfo{Path: fields[0], Version: version})
+	}
+	sort.Slice(modules, func(i, j int) bool {
+		return len(modules[i].Path) > len(modules[j].Path)
+	})
+	return modules, nil
+}
+
+func readScan(path string, modules []moduleInfo) ([]scanEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	byModule := make(map[string]*scanEntry)
+	reader := csv.NewReader(bytes.NewReader(data))
+	reader.FieldsPerRecord = 3
+
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		library := record[0]
+		licenseName := record[2]
+		mod, ok := findModule(library, modules)
+		if !ok {
+			return nil, fmt.Errorf("no module found for scanned library %q", library)
+		}
+		entry := byModule[mod.Path]
+		if entry == nil {
+			entry = &scanEntry{Module: mod.Path, Version: mod.Version}
+			byModule[mod.Path] = entry
+		}
+		if !contains(entry.Licenses, licenseName) {
+			entry.Licenses = append(entry.Licenses, licenseName)
+		}
+	}
+
+	entries := make([]scanEntry, 0, len(byModule))
+	for _, entry := range byModule {
+		sort.Strings(entry.Licenses)
+		entries = append(entries, *entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Module < entries[j].Module
+	})
+	return entries, nil
+}
+
+func findModule(library string, modules []moduleInfo) (moduleInfo, bool) {
+	for _, mod := range modules {
+		if library == mod.Path || strings.HasPrefix(library, mod.Path+"/") {
+			return mod, true
+		}
+	}
+	return moduleInfo{}, false
+}
+
+func checkLock(lock *lockFile, scanned []scanEntry) error {
+	var problems []string
+
+	deps := make(map[string]dependencyReview, len(lock.Dependencies))
+	for _, dep := range lock.Dependencies {
+		if dep.Module == "" {
+			problems = append(problems, "lock contains a dependency with an empty module")
+			continue
+		}
+		if _, exists := deps[dep.Module]; exists {
+			problems = append(problems, fmt.Sprintf("lock contains duplicate dependency %s", dep.Module))
+			continue
+		}
+		deps[dep.Module] = dep
+		if !acceptedStatus(dep.Status) {
+			problems = append(problems, fmt.Sprintf("%s has status %q; set an accepted status after review", dep.Module, dep.Status))
+		}
+	}
+
+	seen := make(map[string]bool, len(scanned))
+	for _, scan := range scanned {
+		seen[scan.Module] = true
+		dep, ok := deps[scan.Module]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("new dependency %s@%s with licenses %s is missing from licenses.lock.yml", scan.Module, scan.Version, strings.Join(scan.Licenses, ", ")))
+			continue
+		}
+		if dep.Version != scan.Version {
+			problems = append(problems, fmt.Sprintf("%s version changed: lock has %s, scan has %s", scan.Module, dep.Version, scan.Version))
+		}
+		if !sameStrings(dep.Licenses, scan.Licenses) {
+			problems = append(problems, fmt.Sprintf("%s licenses changed: lock has %s, scan has %s", scan.Module, strings.Join(dep.Licenses, ", "), strings.Join(scan.Licenses, ", ")))
+		}
+	}
+
+	for _, dep := range lock.Dependencies {
+		if !seen[dep.Module] {
+			problems = append(problems, fmt.Sprintf("%s@%s is in licenses.lock.yml but was not found in the current scan", dep.Module, dep.Version))
+		}
+	}
+
+	for _, audit := range lock.ManualAudits {
+		if !acceptedStatus(audit.Status) {
+			problems = append(problems, fmt.Sprintf("%s has manual audit status %q; set an accepted status after review", audit.Module, audit.Status))
+		}
+		if err := validateManualAudit(audit); err != nil {
+			problems = append(problems, err.Error())
+		}
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		var b strings.Builder
+		b.WriteString("license audit failed:\n")
+		for _, problem := range problems {
+			b.WriteString("  - ")
+			b.WriteString(problem)
+			b.WriteByte('\n')
+		}
+		return errors.New(strings.TrimRight(b.String(), "\n"))
+	}
+
+	fmt.Printf("license audit passed: %d dependencies, %d manual audits\n", len(scanned), len(lock.ManualAudits))
+	return nil
+}
+
+func mergeDependencies(existing []dependencyReview, scanned []scanEntry, newStatus string) []dependencyReview {
+	byModule := make(map[string]dependencyReview, len(existing))
+	for _, dep := range existing {
+		byModule[dep.Module] = dep
+	}
+
+	next := make([]dependencyReview, 0, len(scanned))
+	for _, scan := range scanned {
+		old, ok := byModule[scan.Module]
+		status := newStatus
+		note := ""
+		if ok {
+			if old.Version == scan.Version && sameStrings(old.Licenses, scan.Licenses) {
+				status = old.Status
+				note = old.Note
+			} else {
+				status = "needs-review"
+				note = "Version or license changed; review before setting status."
+			}
+		}
+		next = append(next, dependencyReview{
+			Module:   scan.Module,
+			Version:  scan.Version,
+			Licenses: scan.Licenses,
+			Status:   status,
+			Note:     note,
+		})
+	}
+	sortDependencies(next)
+	return next
+}
+
+func appendManualNotices(audits []manualAudit, outputPath string) (err error) {
+	out, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	for _, audit := range audits {
+		if err := validateManualAudit(audit); err != nil {
+			if errors.Is(err, errModuleNotSelected) {
+				continue
+			}
+			return err
+		}
+		_, dir, ok, err := selectedModuleDir(audit)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		licensePath := filepath.Join(dir, audit.LicenseFile)
+		if _, err := fmt.Fprintf(out, "\n===============================================================================\n%s/%s (%s, manually audited)\n===============================================================================\n\n", audit.Module, audit.LicenseFile, audit.License); err != nil {
+			return err
+		}
+		if err := appendTrimmedFile(out, licensePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var errModuleNotSelected = errors.New("module is not selected")
+
+func validateManualAudit(audit manualAudit) error {
+	if audit.Module == "" || audit.Version == "" || audit.LicenseFile == "" || audit.LicenseSHA256 == "" {
+		return fmt.Errorf("manual audit for %q is incomplete", audit.Module)
+	}
+
+	version, dir, ok, err := selectedModuleDir(audit)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: %s", errModuleNotSelected, audit.Module)
+	}
+	if version != audit.Version {
+		return fmt.Errorf("manual audit for %s is pinned to %s, but go.mod selects %s", audit.Module, audit.Version, version)
+	}
+
+	licensePath := filepath.Join(dir, audit.LicenseFile)
+	hash, err := fileSHA256(licensePath)
+	if err != nil {
+		return fmt.Errorf("manual audit for %s expected %s: %w", audit.Module, audit.LicenseFile, err)
+	}
+	if hash != audit.LicenseSHA256 {
+		return fmt.Errorf("manual audit for %s expected SHA-256 %s, found %s", audit.Module, audit.LicenseSHA256, hash)
+	}
+	return nil
+}
+
+func selectedModuleDir(audit manualAudit) (string, string, bool, error) {
+	version, dir, ok, err := goListModule(audit.Module)
+	if err != nil || !ok {
+		return "", "", ok, err
+	}
+	if dir == "" || !fileExists(filepath.Join(dir, audit.LicenseFile)) {
+		downloadedDir, err := goModDownloadDir(audit.Module, audit.Version)
+		if err != nil {
+			return "", "", true, err
+		}
+		if downloadedDir != "" {
+			dir = downloadedDir
+		}
+	}
+	return version, dir, true, nil
+}
+
+func goListModule(module string) (string, string, bool, error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Version}}\t{{.Dir}}", module)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return "", "", false, nil
+		}
+		return "", "", false, fmt.Errorf("go list -m %s: %w", module, err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "\t", 2)
+	version := parts[0]
+	dir := ""
+	if len(parts) > 1 {
+		dir = parts[1]
+	}
+	return version, dir, true, nil
+}
+
+func goModDownloadDir(module, version string) (string, error) {
+	cmd := exec.Command("go", "mod", "download", "-json", module+"@"+version)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Dir string
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", err
+	}
+	return result.Dir, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func appendTrimmedFile(out io.Writer, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if i == len(lines)-1 && line == "" {
+			break
+		}
+		if _, err := fmt.Fprintln(out, strings.TrimRight(line, " \t")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func acceptedStatus(status string) bool {
+	switch status {
+	case "allowed", "manual-review":
+		return true
+	default:
+		return false
+	}
+}
+
+func contains(values []string, value string) bool {
+	for _, item := range values {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	a = append([]string(nil), a...)
+	b = append([]string(nil), b...)
+	sort.Strings(a)
+	sort.Strings(b)
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortManualAudits(audits []manualAudit) {
+	sort.Slice(audits, func(i, j int) bool {
+		return audits[i].Module < audits[j].Module
+	})
+}
+
+func sortDependencies(deps []dependencyReview) {
+	for i := range deps {
+		sort.Strings(deps[i].Licenses)
+	}
+	sort.Slice(deps, func(i, j int) bool {
+		return deps[i].Module < deps[j].Module
+	})
+}

--- a/cmd/licenseaudit/main_test.go
+++ b/cmd/licenseaudit/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestMergeDependenciesAllowsDefaultLicenses(t *testing.T) {
 	deps := mergeDependencies(nil, []scanEntry{
@@ -59,4 +62,63 @@ func TestMergeDependenciesRequiresReviewWhenManualReviewChanges(t *testing.T) {
 	if deps[0].Note == "" {
 		t.Fatal("expected review note")
 	}
+}
+
+func TestMergeDependenciesUsesFallbackForChangedUnexpectedLicense(t *testing.T) {
+	deps := mergeDependencies([]dependencyReview{
+		{Module: "example.com/lib", Version: "v1.0.0", Licenses: []string{"MIT"}, Status: "allowed"},
+	}, []scanEntry{
+		{Module: "example.com/lib", Version: "v1.1.0", Licenses: []string{"Custom"}},
+	}, "allowed")
+
+	if got, want := deps[0].Status, "allowed"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if deps[0].Note != "" {
+		t.Fatalf("note = %q, want empty", deps[0].Note)
+	}
+}
+
+func TestValidateManualAuditRequiresLicenseName(t *testing.T) {
+	err := validateManualAudit(manualAudit{
+		Module:        "example.com/lib",
+		Version:       "v1.0.0",
+		LicenseFile:   "LICENSE",
+		LicenseSHA256: "abc123",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCheckLockReportsStaleManualAudit(t *testing.T) {
+	err := checkLock(&lockFile{
+		ManualAudits: []manualAudit{{
+			Module:        "example.com/not-selected",
+			Version:       "v1.0.0",
+			License:       "MIT",
+			LicenseFile:   "LICENSE",
+			LicenseSHA256: "abc123",
+			Status:        "manual-review",
+		}},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); !containsString(got, "manual audit for example.com/not-selected is stale") {
+		t.Fatalf("error = %q, want stale manual audit message", got)
+	}
+}
+
+func TestModuleNotSelected(t *testing.T) {
+	if !moduleNotSelected("go: module example.com/not-selected: not a known dependency") {
+		t.Fatal("expected not selected error to be recognized")
+	}
+	if moduleNotSelected("go: proxy error") {
+		t.Fatal("expected unrelated error not to be treated as not selected")
+	}
+}
+
+func containsString(value, substr string) bool {
+	return strings.Contains(value, substr)
 }

--- a/cmd/licenseaudit/main_test.go
+++ b/cmd/licenseaudit/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func TestMergeDependenciesAllowsDefaultLicenses(t *testing.T) {
+	deps := mergeDependencies(nil, []scanEntry{
+		{Module: "example.com/apache", Version: "v1.0.0", Licenses: []string{"Apache-2.0"}},
+		{Module: "example.com/mixed", Version: "v1.0.0", Licenses: []string{"BSD-3-Clause", "MIT"}},
+	}, "needs-review")
+
+	for _, dep := range deps {
+		if dep.Status != "allowed" {
+			t.Fatalf("%s status = %q, want allowed", dep.Module, dep.Status)
+		}
+		if dep.Note != "" {
+			t.Fatalf("%s note = %q, want empty", dep.Module, dep.Note)
+		}
+	}
+}
+
+func TestMergeDependenciesNeedsReviewForUnexpectedLicense(t *testing.T) {
+	deps := mergeDependencies(nil, []scanEntry{
+		{Module: "example.com/custom", Version: "v1.0.0", Licenses: []string{"Custom"}},
+	}, "needs-review")
+
+	if got, want := deps[0].Status, "needs-review"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if deps[0].Note == "" {
+		t.Fatal("expected review note")
+	}
+}
+
+func TestMergeDependenciesAllowsChangedDefaultLicense(t *testing.T) {
+	deps := mergeDependencies([]dependencyReview{
+		{Module: "example.com/lib", Version: "v1.0.0", Licenses: []string{"MIT"}, Status: "allowed"},
+	}, []scanEntry{
+		{Module: "example.com/lib", Version: "v1.1.0", Licenses: []string{"Apache-2.0"}},
+	}, "needs-review")
+
+	if got, want := deps[0].Status, "allowed"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if deps[0].Note != "" {
+		t.Fatalf("note = %q, want empty", deps[0].Note)
+	}
+}
+
+func TestMergeDependenciesRequiresReviewWhenManualReviewChanges(t *testing.T) {
+	deps := mergeDependencies([]dependencyReview{
+		{Module: "example.com/lib", Version: "v1.0.0", Licenses: []string{"Custom"}, Status: "manual-review"},
+	}, []scanEntry{
+		{Module: "example.com/lib", Version: "v1.1.0", Licenses: []string{"MIT"}},
+	}, "needs-review")
+
+	if got, want := deps[0].Status, "needs-review"; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if deps[0].Note == "" {
+		t.Fatal("expected review note")
+	}
+}

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,47 @@
+# Licensing Workflow
+
+ingestr uses three separate license checks. CI runs the first two on PRs:
+
+- `make licenses-check` is the fast policy gate. It runs `go-licenses check`
+  against the canonical release target and fails on disallowed license types.
+- `make licenses-audit` is the review gate. It checks `licenses.lock.yml` and
+  fails when a scanned dependency, version, or license changes without an
+  explicit audit update.
+- `make licenses` regenerates `THIRD_PARTY_LICENSES.txt` for release notices.
+
+## Review Policy
+
+Use these statuses in `licenses.lock.yml`:
+
+- `allowed`: permissive or already accepted license metadata.
+- `manual-review`: accepted after human review, usually because the scanner
+  cannot classify the license file or the dependency has special obligations.
+- `needs-review`: generated placeholder for new or changed dependencies. Do not
+  merge with this status.
+- `blocked`: dependency must not be used.
+
+Typical default-allowed licenses are MIT, BSD, Apache-2.0, ISC, and similar
+permissive licenses. Unknown, custom, GPL, AGPL, LGPL, CDDL, or proprietary
+licenses need manual review before use.
+
+## Updating The Audit Lock
+
+When `go.mod` or `go.sum` changes:
+
+```bash
+make licenses-audit
+```
+
+If it fails because dependencies changed, regenerate the lock:
+
+```bash
+make licenses-audit-update
+```
+
+New or changed entries are written with `status: needs-review`. Review each one,
+then set the status to `allowed`, `manual-review`, or `blocked` with a short
+note when the decision is not obvious.
+
+Manual license pins live under `manual_audits` in `licenses.lock.yml`. The
+notice generator validates their selected version and license file SHA before
+including them in `THIRD_PARTY_LICENSES.txt`.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -13,16 +13,17 @@ ingestr uses three separate license checks. CI runs the first two on PRs:
 
 Use these statuses in `licenses.lock.yml`:
 
-- `allowed`: permissive or already accepted license metadata.
+- `allowed`: default-accepted or already reviewed license metadata.
 - `manual-review`: accepted after human review, usually because the scanner
   cannot classify the license file or the dependency has special obligations.
 - `needs-review`: generated placeholder for new or changed dependencies. Do not
   merge with this status.
 - `blocked`: dependency must not be used.
 
-Typical default-allowed licenses are MIT, BSD, Apache-2.0, ISC, and similar
-permissive licenses. Unknown, custom, GPL, AGPL, LGPL, CDDL, or proprietary
-licenses need manual review before use.
+Default-allowed scanner licenses are `Apache-2.0`, `BSD-2-Clause`,
+`BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`, `0BSD`, `CC0-1.0`, `Unlicense`, and
+`Zlib`. Unknown, custom, GPL, AGPL, LGPL, CDDL, or proprietary licenses need
+manual review before use.
 
 ## Updating The Audit Lock
 
@@ -38,9 +39,10 @@ If it fails because dependencies changed, regenerate the lock:
 make licenses-audit-update
 ```
 
-New or changed entries are written with `status: needs-review`. Review each one,
-then set the status to `allowed`, `manual-review`, or `blocked` with a short
-note when the decision is not obvious.
+New or changed entries with only default-allowed licenses are written with
+`status: allowed`. Everything else is written with `status: needs-review`.
+Review the lock diff, then only edit entries that need a different decision,
+such as `manual-review` or `blocked`.
 
 Manual license pins live under `manual_audits` in `licenses.lock.yml`. The
 notice generator validates their selected version and license file SHA before

--- a/hack/license-audit.sh
+++ b/hack/license-audit.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mode="check"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--write)
+			mode="write"
+			shift
+			;;
+		--check)
+			mode="check"
+			shift
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			exit 1
+			;;
+	esac
+done
+
+go_licenses_module="${GO_LICENSES_MODULE:-github.com/google/go-licenses@v1.6.0}"
+packages="${LICENSE_PACKAGES:-./...}"
+license_targets="${LICENSE_AUDIT_TARGETS:-${LICENSE_CHECK_TARGETS:-linux/amd64}}"
+include_tests="${LICENSE_AUDIT_INCLUDE_TESTS:-${LICENSE_CHECK_INCLUDE_TESTS:-false}}"
+new_status="${LICENSE_AUDIT_NEW_STATUS:-needs-review}"
+lock_file="${LICENSE_LOCK_FILE:-$repo_root/licenses.lock.yml}"
+module_path="$(cd "$repo_root" && go list -m)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+go_licenses_bin="$tmpdir/bin/go-licenses$(go env GOEXE)"
+active_goroot="$(go env GOROOT)"
+
+(cd "$repo_root" && GOBIN="$tmpdir/bin" go install "$go_licenses_module")
+
+ignore_flags=(--ignore "$module_path")
+while IFS= read -r module; do
+	if [[ -n "$module" ]]; then
+		ignore_flags+=(--ignore "$module")
+	fi
+done < <((cd "$repo_root" && go run ./cmd/licenseaudit --mode ignored-modules --lock "$lock_file"))
+
+license_test_flags=()
+case "$include_tests" in
+	1 | true | TRUE | yes | YES)
+		license_test_flags=(--include_tests)
+		;;
+	0 | false | FALSE | no | NO | "")
+		;;
+	*)
+		echo "LICENSE_AUDIT_INCLUDE_TESTS must be true or false, got: $include_tests" >&2
+		exit 1
+		;;
+esac
+
+modules_file="$tmpdir/modules.txt"
+csv_file="$tmpdir/licenses.csv"
+: >"$csv_file"
+
+(cd "$repo_root" && go list -m all >"$modules_file")
+
+for target in $license_targets; do
+	goos="${target%/*}"
+	goarch="${target#*/}"
+	label="$goos-$goarch"
+	target_out="$tmpdir/$label.csv"
+	target_log="$tmpdir/$label.log"
+
+	if ! (cd "$repo_root" && GOOS="$goos" GOARCH="$goarch" GOROOT="$active_goroot" "$go_licenses_bin" csv "$packages" \
+		"${license_test_flags[@]}" \
+		"${ignore_flags[@]}" \
+		>"$target_out" 2>"$target_log"); then
+		{
+			printf 'go-licenses csv failed for %s\n' "$target"
+			cat "$target_out"
+			cat "$target_log"
+		} >&2
+		exit 1
+	fi
+
+	cat "$target_out" >>"$csv_file"
+done
+
+(cd "$repo_root" && go run ./cmd/licenseaudit \
+	--mode "$mode" \
+	--lock "$lock_file" \
+	--csv "$csv_file" \
+	--modules "$modules_file" \
+	--new-status "$new_status" \
+	--tool "$go_licenses_module" \
+	--packages "$packages" \
+	--targets "$license_targets" \
+	--include-tests="$include_tests")

--- a/hack/update-third-party-licenses.sh
+++ b/hack/update-third-party-licenses.sh
@@ -33,6 +33,7 @@ disallowed_license_types="${LICENSE_DISALLOWED_TYPES:-forbidden,restricted,unkno
 packages="${LICENSE_PACKAGES:-./...}"
 license_targets="${LICENSE_TARGETS:-linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64}"
 include_tests="${LICENSE_INCLUDE_TESTS:-true}"
+license_lock_file="${LICENSE_LOCK_FILE:-$repo_root/licenses.lock.yml}"
 module_path="$(cd "$repo_root" && go list -m)"
 
 tmpdir="$(mktemp -d)"
@@ -42,14 +43,6 @@ go_licenses_bin="$tmpdir/bin/go-licenses$(go env GOEXE)"
 active_goroot="$(go env GOROOT)"
 
 (cd "$repo_root" && GOBIN="$tmpdir/bin" go install "$go_licenses_module")
-
-sha256_file() {
-	if command -v sha256sum >/dev/null 2>&1; then
-		sha256sum "$1" | awk '{print $1}'
-	else
-		shasum -a 256 "$1" | awk '{print $1}'
-	fi
-}
 
 copy_notice_file() {
 	local rel="$1"
@@ -66,99 +59,10 @@ copy_notice_file() {
 	} >>"$out"
 }
 
-append_manual_module_license() {
-	local module="$1"
-	local expected_version="$2"
-	local license_file="$3"
-	local license_name="$4"
-	local expected_sha256="$5"
-	local out="$6"
-
-	local module_info version dir downloaded_dir selected_sha256
-
-	if ! module_info="$(cd "$repo_root" && go list -m -f '{{.Version}}	{{.Dir}}' "$module" 2>/dev/null)"; then
-		return 0
-	fi
-
-	version="${module_info%%	*}"
-	dir="${module_info#*	}"
-
-	if [[ "$version" != "$expected_version" ]]; then
-		cat >&2 <<EOF
-Manual license audit for $module is pinned to $expected_version, but go.mod selects $version.
-Review $module's license, then update hack/update-third-party-licenses.sh and regenerate THIRD_PARTY_LICENSES.txt.
-EOF
-		return 1
-	fi
-
-	if [[ ! -f "$dir/$license_file" ]]; then
-		# go list -m can return an empty Dir in clean module caches when the
-		# package is ignored above. Download the pinned module before auditing.
-		if downloaded_dir="$(cd "$repo_root" && go mod download -json "$module@$expected_version" | awk -F '"' '$2 == "Dir" { print $4; exit }')" && [[ -n "$downloaded_dir" ]]; then
-			dir="$downloaded_dir"
-		fi
-	fi
-
-	if [[ ! -f "$dir/$license_file" ]]; then
-		cat >&2 <<EOF
-Manual license audit for $module expected $license_file, but it was not found in $dir.
-Review $module's license, then update hack/update-third-party-licenses.sh and regenerate THIRD_PARTY_LICENSES.txt.
-EOF
-		return 1
-	fi
-
-	selected_sha256="$(sha256_file "$dir/$license_file")"
-	if [[ "$selected_sha256" != "$expected_sha256" ]]; then
-		cat >&2 <<EOF
-Manual license audit for $module expected SHA-256 $expected_sha256, but found $selected_sha256.
-Review $module's license, then update hack/update-third-party-licenses.sh and regenerate THIRD_PARTY_LICENSES.txt.
-EOF
-		return 1
-	fi
-
-	{
-		printf '\n'
-		printf '===============================================================================\n'
-		printf '%s/%s (%s, manually audited)\n' "$module" "$license_file" "$license_name"
-		printf '===============================================================================\n\n'
-		sed 's/[[:blank:]]*$//' "$dir/$license_file"
-	} >>"$out"
-}
-
 append_manual_module_licenses() {
 	local out="$1"
 
-	append_manual_module_license \
-		"github.com/segmentio/asm" \
-		"v1.2.1" \
-		"LICENSE" \
-		"MIT No Attribution" \
-		"cca993712df289a5958bdef69031a5dac0f951ac15afeb313f9eeea55ed59443" \
-		"$out"
-
-	append_manual_module_license \
-		"modernc.org/mathutil" \
-		"v1.7.1" \
-		"LICENSE" \
-		"BSD-3-Clause" \
-		"bfa9bf72a72ca009fd62a8f84fca3dca67e51d93af96352723646599898b6cf5" \
-		"$out"
-
-	append_manual_module_license \
-		"github.com/DATA-DOG/go-sqlmock" \
-		"v1.5.2" \
-		"LICENSE" \
-		"BSD-3-Clause" \
-		"e3a6ae97f6eef8ce17e44d5f22adba594c4ea2b592c4be7ee9b387c441ef34d6" \
-		"$out"
-
-	append_manual_module_license \
-		"github.com/99designs/go-keychain" \
-		"v0.0.0-20191008050251-8e49817e8af4" \
-		"LICENSE" \
-		"MIT" \
-		"039c69774070226d213bced933176be4ec396c9b101cd9a13e82a2c390c6c90a" \
-		"$out"
+	(cd "$repo_root" && go run ./cmd/licenseaudit --mode append-manual-notices --lock "$license_lock_file" --output "$out")
 }
 
 save_root="$tmpdir/go-licenses"
@@ -166,15 +70,13 @@ generated_file="$tmpdir/THIRD_PARTY_LICENSES.txt"
 
 ignore_flags=(
 	--ignore "$module_path"
-	# go-licenses v1.6.0 cannot classify these current license files. Keep them
-	# pinned below so version or license text changes force a manual review.
-	--ignore "github.com/segmentio/asm"
-	--ignore "modernc.org/mathutil"
-	--ignore "github.com/DATA-DOG/go-sqlmock"
-	# This Darwin/cgo package is selected differently by host settings. Keep the
-	# required notice deterministic across local machines and CI.
-	--ignore "github.com/99designs/go-keychain"
 )
+
+while IFS= read -r module; do
+	if [[ -n "$module" ]]; then
+		ignore_flags+=(--ignore "$module")
+	fi
+done < <((cd "$repo_root" && go run ./cmd/licenseaudit --mode ignored-modules --lock "$license_lock_file"))
 
 license_test_flags=()
 case "$include_tests" in

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -1,0 +1,1373 @@
+version: 1
+generated:
+    tool: github.com/google/go-licenses@v1.6.0
+    packages: ./...
+    targets:
+        - linux/amd64
+    include_tests: false
+manual_audits:
+    - module: github.com/99designs/go-keychain
+      version: v0.0.0-20191008050251-8e49817e8af4
+      license: MIT
+      license_file: LICENSE
+      license_sha256: 039c69774070226d213bced933176be4ec396c9b101cd9a13e82a2c390c6c90a
+      status: manual-review
+      note: Darwin/cgo package selected differently by host settings; keep notice deterministic.
+    - module: github.com/DATA-DOG/go-sqlmock
+      version: v1.5.2
+      license: BSD-3-Clause
+      license_file: LICENSE
+      license_sha256: e3a6ae97f6eef8ce17e44d5f22adba594c4ea2b592c4be7ee9b387c441ef34d6
+      status: manual-review
+      note: go-licenses v1.6.0 cannot classify the current license file.
+    - module: github.com/segmentio/asm
+      version: v1.2.1
+      license: MIT No Attribution
+      license_file: LICENSE
+      license_sha256: cca993712df289a5958bdef69031a5dac0f951ac15afeb313f9eeea55ed59443
+      status: manual-review
+      note: go-licenses v1.6.0 cannot classify the current license file.
+    - module: modernc.org/mathutil
+      version: v1.7.1
+      license: BSD-3-Clause
+      license_file: LICENSE
+      license_sha256: bfa9bf72a72ca009fd62a8f84fca3dca67e51d93af96352723646599898b6cf5
+      status: manual-review
+      note: go-licenses v1.6.0 cannot classify the current license file.
+dependencies:
+    - module: cel.dev/expr
+      version: v0.25.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go
+      version: v0.123.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/auth
+      version: v0.18.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/auth/oauth2adapt
+      version: v0.2.8
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/bigquery
+      version: v1.72.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/compute/metadata
+      version: v0.9.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/iam
+      version: v1.5.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/longrunning
+      version: v0.8.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/monitoring
+      version: v1.24.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/pubsub
+      version: v1.50.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/pubsub/v2
+      version: v2.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/spanner
+      version: v1.87.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: cloud.google.com/go/storage
+      version: v1.56.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: dario.cat/mergo
+      version: v1.0.2
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: filippo.io/edwards25519
+      version: v1.1.1
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/Azure/azure-sdk-for-go/sdk/azcore
+      version: v1.21.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/Azure/azure-sdk-for-go/sdk/azidentity
+      version: v1.13.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/Azure/azure-sdk-for-go/sdk/internal
+      version: v1.12.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
+      version: v1.6.3
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake
+      version: v1.4.4
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/AzureAD/microsoft-authentication-library-for-go
+      version: v1.6.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/BurntSushi/toml
+      version: v1.4.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/ClickHouse/ch-go
+      version: v0.69.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/ClickHouse/clickhouse-go/v2
+      version: v2.42.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp
+      version: v1.5.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp
+      version: v1.30.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric
+      version: v0.53.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping
+      version: v0.53.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/InfluxCommunity/influxdb3-go/v2
+      version: v2.13.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/Masterminds/semver/v3
+      version: v3.4.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/ProtonMail/go-crypto
+      version: v1.3.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/ProtonMail/gopenpgp/v3
+      version: v3.3.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/SAP/go-hdb
+      version: v1.16.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/alecthomas/chroma/v2
+      version: v2.23.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/alibabacloud-go/debug
+      version: v1.0.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/alibabacloud-go/tea
+      version: v1.2.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aliyun/aliyun-odps-go-sdk
+      version: v0.4.22
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aliyun/credentials-go
+      version: v1.3.10
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/andybalholm/brotli
+      version: v1.2.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/apache/arrow-adbc/go/adbc
+      version: v1.9.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/apache/arrow-go/v18
+      version: v18.5.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/apache/arrow/go/v15
+      version: v15.0.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/apache/cassandra-gocql-driver/v2
+      version: v2.1.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/apache/thrift
+      version: v0.23.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/apapsch/go-jsonmerge/v2
+      version: v2.0.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/araddon/dateparse
+      version: v0.0.0-20210429162001-6b43995a97de
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/aws/aws-msk-iam-sasl-signer-go
+      version: v1.0.4
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2
+      version: v1.41.5
+      licenses:
+        - Apache-2.0
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream
+      version: v1.7.8
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/config
+      version: v1.32.6
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/credentials
+      version: v1.19.6
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue
+      version: v1.20.37
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/feature/ec2/imds
+      version: v1.18.16
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/feature/s3/manager
+      version: v1.17.11
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/internal/configsources
+      version: v1.4.21
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
+      version: v2.7.21
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/internal/ini
+      version: v1.8.4
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/internal/v4a
+      version: v1.4.22
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/athena
+      version: v1.56.4
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/dynamodb
+      version: v1.57.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/dynamodbstreams
+      version: v1.32.14
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
+      version: v1.13.7
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/internal/checksum
+      version: v1.9.13
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery
+      version: v1.11.21
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
+      version: v1.13.21
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/internal/s3shared
+      version: v1.19.21
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/kinesis
+      version: v1.43.5
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/s3
+      version: v1.97.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/signin
+      version: v1.0.4
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/sqs
+      version: v1.42.20
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/sso
+      version: v1.30.8
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/ssooidc
+      version: v1.35.12
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/aws-sdk-go-v2/service/sts
+      version: v1.41.5
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/aws/smithy-go
+      version: v1.24.2
+      licenses:
+        - Apache-2.0
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/aymanbagabas/go-osc52/v2
+      version: v2.0.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/bmatcuk/doublestar/v4
+      version: v4.9.2
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/cenkalti/backoff/v4
+      version: v4.3.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/cespare/xxhash/v2
+      version: v2.3.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/clipperhouse/displaywidth
+      version: v0.11.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/clipperhouse/uax29/v2
+      version: v2.7.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/cloudflare/circl
+      version: v1.6.3
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/cncf/xds/go
+      version: v0.0.0-20251210132809-ee656c7534f5
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/columnar-tech/dbc
+      version: v0.3.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/containerd/errdefs
+      version: v1.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/containerd/errdefs/pkg
+      version: v0.3.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/containerd/log
+      version: v0.1.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/containerd/platforms
+      version: v0.2.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/couchbase/gocb/v2
+      version: v2.12.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/couchbase/gocbcore/v10
+      version: v10.9.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/couchbase/gocbcoreps
+      version: v0.1.5-0.20260107140814-1c3a03f888f8
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/couchbase/goprotostellar
+      version: v1.0.5
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/couchbaselabs/gocbconnstr/v2
+      version: v2.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/cpuguy83/dockercfg
+      version: v0.3.2
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/databricks/databricks-sdk-go
+      version: v0.95.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/davecgh/go-spew
+      version: v1.1.2-0.20180830191138-d8f796af33cc
+      licenses:
+        - ISC
+      status: allowed
+    - module: github.com/denisbrodbeck/machineid
+      version: v1.0.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/distribution/reference
+      version: v0.6.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/dlclark/regexp2
+      version: v1.11.5
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/docker/go-connections
+      version: v0.6.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/docker/go-units
+      version: v0.5.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/dustin/go-humanize
+      version: v1.0.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/elastic/elastic-transport-go/v8
+      version: v8.8.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/elastic/go-elasticsearch/v9
+      version: v9.3.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/envoyproxy/go-control-plane/envoy
+      version: v1.36.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/envoyproxy/protoc-gen-validate
+      version: v1.3.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/fatih/color
+      version: v1.18.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/felixge/httpsnoop
+      version: v1.0.4
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/gabriel-vasile/mimetype
+      version: v1.4.7
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/go-chi/chi/v5
+      version: v5.2.3
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/go-faster/city
+      version: v1.0.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/go-faster/errors
+      version: v0.7.1
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/go-faster/jx
+      version: v1.2.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/go-faster/yaml
+      version: v0.4.6
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/go-jose/go-jose/v4
+      version: v4.1.4
+      licenses:
+        - Apache-2.0
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/go-logr/logr
+      version: v1.4.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/go-logr/stdr
+      version: v1.2.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/go-mysql-org/go-mysql
+      version: v1.13.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/go-sql-driver/mysql
+      version: v1.9.3
+      licenses:
+        - MPL-2.0
+      status: allowed
+    - module: github.com/go-viper/mapstructure/v2
+      version: v2.4.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/goccy/go-json
+      version: v0.10.5
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/golang-jwt/jwt/v5
+      version: v5.3.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/golang-sql/civil
+      version: v0.0.0-20220223132316-b832511892a9
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/golang-sql/sqlexp
+      version: v0.1.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/golang/groupcache
+      version: v0.0.0-20210331224755-41bb18bfe9da
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/golang/snappy
+      version: v1.0.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/google/flatbuffers
+      version: v25.12.19+incompatible
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/google/go-querystring
+      version: v1.1.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/google/s2a-go
+      version: v0.1.9
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/google/uuid
+      version: v1.6.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/googleapis/enterprise-certificate-proxy
+      version: v0.3.14
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/googleapis/gax-go/v2
+      version: v2.17.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/gorilla/websocket
+      version: v1.5.3
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/hamba/avro/v2
+      version: v2.31.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/hashicorp/go-uuid
+      version: v1.0.3
+      licenses:
+        - MPL-2.0
+      status: allowed
+    - module: github.com/influxdata/influxdb-client-go/v2
+      version: v2.14.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/influxdata/line-protocol
+      version: v0.0.0-20200327222509-2487e7298839
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/influxdata/line-protocol/v2
+      version: v2.2.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jackc/pgio
+      version: v1.0.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jackc/pglogrepl
+      version: v0.0.0-20251213150135-2e8d0df862c1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jackc/pgpassfile
+      version: v1.0.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jackc/pgservicefile
+      version: v0.0.0-20240606120523-5a60cdf6a761
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jackc/pgx/v5
+      version: v5.9.2
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jackc/puddle/v2
+      version: v2.2.2
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/jcmturner/aescts/v2
+      version: v2.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/jcmturner/dnsutils/v2
+      version: v2.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/jcmturner/gofork
+      version: v1.7.6
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/jcmturner/goidentity/v6
+      version: v6.0.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/jcmturner/gokrb5/v8
+      version: v8.4.4
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/jcmturner/rpc/v2
+      version: v2.0.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/json-iterator/go
+      version: v1.1.12
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/klauspost/compress
+      version: v1.18.5
+      licenses:
+        - Apache-2.0
+        - BSD-3-Clause
+        - MIT
+      status: allowed
+    - module: github.com/klauspost/cpuid/v2
+      version: v2.3.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/kr/fs
+      version: v0.1.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/kylelemons/godebug
+      version: v1.1.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/lucasb-eyer/go-colorful
+      version: v1.3.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/magiconair/properties
+      version: v1.8.10
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/mattn/go-colorable
+      version: v0.1.13
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/mattn/go-isatty
+      version: v0.0.20
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/mattn/go-runewidth
+      version: v0.0.20
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/mattn/go-sqlite3
+      version: v1.14.32
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/microsoft/go-mssqldb
+      version: v1.10.0
+      licenses:
+        - BSD-3-Clause
+        - MIT
+      status: allowed
+    - module: github.com/mitchellh/colorstring
+      version: v0.0.0-20190213212951-d06e56a500db
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/moby/docker-image-spec
+      version: v1.3.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/go-archive
+      version: v0.2.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/moby/api
+      version: v1.54.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/moby/client
+      version: v0.4.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/patternmatcher
+      version: v0.6.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/sys/sequential
+      version: v0.6.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/sys/user
+      version: v0.4.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/sys/userns
+      version: v0.1.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/moby/term
+      version: v0.5.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/modern-go/concurrent
+      version: v0.0.0-20180306012644-bacd9c7ef1dd
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/modern-go/reflect2
+      version: v1.0.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/montanaflynn/stats
+      version: v0.7.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/muesli/termenv
+      version: v0.16.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/oapi-codegen/runtime
+      version: v1.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/olekukonko/cat
+      version: v0.0.0-20250911104152-50322a0618f6
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/olekukonko/errors
+      version: v1.1.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/olekukonko/ll
+      version: v0.1.3
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/olekukonko/tablewriter
+      version: v1.1.2
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/opencontainers/go-digest
+      version: v1.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/opencontainers/image-spec
+      version: v1.1.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/paulmach/orb
+      version: v0.12.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/pelletier/go-toml/v2
+      version: v2.2.4
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/pierrec/lz4
+      version: v2.6.1+incompatible
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/pierrec/lz4/v4
+      version: v4.1.23
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/pingcap/errors
+      version: v0.11.5-0.20250318082626-8f80e5cb09ec
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/pingcap/log
+      version: v1.1.1-0.20241212030209-7e3ff8601a2a
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/pingcap/tidb/pkg/parser
+      version: v0.0.0-20250421232622-526b2c79173d
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/pkg/browser
+      version: v0.0.0-20240102092130-5ac0b6a4141c
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/pkg/errors
+      version: v0.9.1
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/pkg/sftp
+      version: v1.13.10
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/pmezard/go-difflib
+      version: v1.0.1-0.20181226105442-5d4384ee4fb2
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/rabbitmq/amqp091-go
+      version: v1.10.0
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/remyoudompheng/bigfft
+      version: v0.0.0-20230129092748-24d4a6f8daec
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/richardlehane/mscfb
+      version: v1.0.6
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/richardlehane/msoleps
+      version: v1.0.6
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/rivo/uniseg
+      version: v0.4.7
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/schollz/progressbar/v3
+      version: v3.18.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/segmentio/kafka-go
+      version: v0.4.50
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/shenzhencenter/google-ads-pb
+      version: v1.23.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/shirou/gopsutil/v4
+      version: v4.26.3
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/shopspring/decimal
+      version: v1.4.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/sijms/go-ora/v2
+      version: v2.9.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/simpleforce/simpleforce
+      version: v0.0.0-20220429021116-acf4ac67ef68
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/sirupsen/logrus
+      version: v1.9.4
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/snowflakedb/gosnowflake
+      version: v1.18.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/sourcegraph/conc
+      version: v0.3.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/spiffe/go-spiffe/v2
+      version: v2.6.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/stretchr/testify
+      version: v1.11.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/stripe/stripe-go/v81
+      version: v81.4.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/testcontainers/testcontainers-go
+      version: v0.42.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/tiendc/go-deepcopy
+      version: v1.7.2
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/tklauser/go-sysconf
+      version: v0.3.16
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/tklauser/numcpus
+      version: v0.11.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/trinodb/trino-go-client
+      version: v0.333.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/urfave/cli/v3
+      version: v3.0.0-beta1
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/xdg-go/pbkdf2
+      version: v1.0.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/xdg-go/scram
+      version: v1.1.2
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/xdg-go/stringprep
+      version: v1.0.4
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: github.com/xuri/efp
+      version: v0.0.1
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/xuri/excelize/v2
+      version: v2.10.1
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/xuri/nfp
+      version: v0.0.2-0.20250530014748-2ddeb826f9a9
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: github.com/youmark/pkcs8
+      version: v0.0.0-20240726163527-a2c0da244d78
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/zeebo/xxh3
+      version: v1.0.2
+      licenses:
+        - BSD-2-Clause
+      status: allowed
+    - module: github.com/zeroshade/machine-id
+      version: v0.0.0-20251223181436-930511047eef
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.mongodb.org/mongo-driver
+      version: v1.17.6
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opencensus.io
+      version: v0.24.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/auto/sdk
+      version: v1.2.1
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/contrib/detectors/gcp
+      version: v1.39.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+      version: v0.65.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+      version: v0.61.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/otel
+      version: v1.43.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/otel/metric
+      version: v1.43.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/otel/sdk
+      version: v1.43.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/otel/sdk/metric
+      version: v1.43.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.opentelemetry.io/otel/trace
+      version: v1.43.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: go.uber.org/atomic
+      version: v1.11.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: go.uber.org/multierr
+      version: v1.11.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: go.uber.org/zap
+      version: v1.27.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: go.yaml.in/yaml/v3
+      version: v3.0.4
+      licenses:
+        - MIT
+      status: allowed
+    - module: golang.org/x/crypto
+      version: v0.50.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/exp
+      version: v0.0.0-20251209150349-8475f28825e9
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/mod
+      version: v0.34.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/net
+      version: v0.53.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/oauth2
+      version: v0.36.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/sync
+      version: v0.20.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/sys
+      version: v0.43.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/term
+      version: v0.42.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/text
+      version: v0.36.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/time
+      version: v0.15.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: golang.org/x/xerrors
+      version: v0.0.0-20240903120638-7835f813f4da
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: google.golang.org/api
+      version: v0.271.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: google.golang.org/genproto
+      version: v0.0.0-20260203192932-546029d2fa20
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: google.golang.org/genproto/googleapis/api
+      version: v0.0.0-20260203192932-546029d2fa20
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: google.golang.org/genproto/googleapis/rpc
+      version: v0.0.0-20260226221140-a57be14db171
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: google.golang.org/grpc
+      version: v1.79.3
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: google.golang.org/protobuf
+      version: v1.36.11
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: gopkg.in/inf.v0
+      version: v0.9.1
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: gopkg.in/ini.v1
+      version: v1.67.0
+      licenses:
+        - Apache-2.0
+      status: allowed
+    - module: gopkg.in/natefinch/lumberjack.v2
+      version: v2.2.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: gopkg.in/yaml.v3
+      version: v3.0.1
+      licenses:
+        - MIT
+      status: allowed
+    - module: modernc.org/libc
+      version: v1.66.10
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: modernc.org/memory
+      version: v1.11.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: modernc.org/sqlite
+      version: v1.40.1
+      licenses:
+        - BSD-3-Clause
+      status: allowed
+    - module: resty.dev/v3
+      version: v3.0.0-beta.5
+      licenses:
+        - MIT
+      status: allowed


### PR DESCRIPTION
## Summary

- Add `licenses.lock.yml` and a `cmd/licenseaudit` helper that fails when scanned dependency, version, or license metadata changes without review.
- Add `make licenses-audit` / `make licenses-audit-update` and wire the GitHub license job to run both the existing policy check and the new audit lock check.
- Move manual license notice pins into the lock file and reuse them from the notice generator.
- Regenerate `THIRD_PARTY_LICENSES.txt` for the current connector set and document the new workflow in `docs/licensing.md`.

## Validation

- `make licenses-check`
- `make licenses-audit`
- `make licenses-notices-check`
- `make format`
- `make lint`
- `make test`