### PR TITLE
fix: restore curl in OCI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ FROM debian:bookworm-slim
 # Install minimal runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security


### PR DESCRIPTION
## Summary
- Adds `curl` back to the runtime stage of the `ghcr.io/bruin-data/ingestr` OCI image
- Restores compatibility with health-check and automation workflows that relied on `curl` being available in the v0 image (e.g. Docker Compose `healthcheck` commands)

Fixes #835

## Test plan
- [ ] Verify the Docker image builds successfully in CI
- [ ] Confirm `curl` is available in the published image: `docker run --rm ghcr.io/bruin-data/ingestr:<tag> curl --version`


Made with [Cursor](https://cursor.com)