### PR TITLE
Add MongoDB CDC source

### DIFF
--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -401,26 +401,28 @@ func (s *MongoDBCDCSource) inferCollectionSchema(ctx context.Context, ns mongoNa
 	builder := newMongoBatchBuilder(nil)
 	defer builder.Release()
 
-	findOpts := options.Find().SetLimit(int64(s.cdcConfig.SchemaSampleSize))
-	cursor, err := collection.Find(ctx, bson.D{}, findOpts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to sample collection %s.%s: %w", ns.Database, ns.Collection, err)
-	}
-	defer func() { _ = cursor.Close(ctx) }()
-
 	rows := 0
-	for cursor.Next(ctx) {
-		var doc bson.M
-		if err := cursor.Decode(&doc); err != nil {
-			return nil, fmt.Errorf("failed to decode sample document: %w", err)
+	if s.cdcConfig.SchemaSampleSize > 0 {
+		findOpts := options.Find().SetLimit(int64(s.cdcConfig.SchemaSampleSize))
+		cursor, err := collection.Find(ctx, bson.D{}, findOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sample collection %s.%s: %w", ns.Database, ns.Collection, err)
 		}
-		if err := builder.AppendDocument(doc); err != nil {
-			return nil, fmt.Errorf("failed to build sample schema: %w", err)
+		defer func() { _ = cursor.Close(ctx) }()
+
+		for cursor.Next(ctx) {
+			var doc bson.M
+			if err := cursor.Decode(&doc); err != nil {
+				return nil, fmt.Errorf("failed to decode sample document: %w", err)
+			}
+			if err := builder.AppendDocument(doc); err != nil {
+				return nil, fmt.Errorf("failed to build sample schema: %w", err)
+			}
+			rows++
 		}
-		rows++
-	}
-	if err := cursor.Err(); err != nil {
-		return nil, fmt.Errorf("sample cursor error: %w", err)
+		if err := cursor.Err(); err != nil {
+			return nil, fmt.Errorf("sample cursor error: %w", err)
+		}
 	}
 
 	var columns []schema.Column

--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -1,0 +1,938 @@
+package mongodb
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type MongoDBCDCMode string
+
+const (
+	MongoDBCDCModeBatch  MongoDBCDCMode = "batch"
+	MongoDBCDCModeStream MongoDBCDCMode = "stream"
+
+	defaultMongoDBCDCAwaitTime        = time.Second
+	defaultMongoDBCDCSchemaSampleSize = 1000
+	defaultMongoDBCDCStreamBatchSize  = 10000
+	defaultMongoDBCDCFlushInterval    = 30 * time.Second
+)
+
+var mongodbCDCColumns = []schema.Column{
+	{Name: destination.CDCLSNColumn, DataType: schema.TypeString, Nullable: false},
+	{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: false},
+	{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: false},
+}
+
+type MongoDBCDCConfig struct {
+	Mode             MongoDBCDCMode
+	DestSchema       string
+	MaxAwaitTime     time.Duration
+	SchemaSampleSize int
+}
+
+type MongoDBCDCSource struct {
+	client    *mongo.Client
+	database  string
+	uri       string
+	cdcConfig MongoDBCDCConfig
+}
+
+type mongoNamespace struct {
+	Database   string
+	Collection string
+	Name       string
+}
+
+type MongoDBCDCTable struct {
+	source      *MongoDBCDCSource
+	ns          mongoNamespace
+	tableSchema *schema.TableSchema
+	primaryKeys []string
+	strategy    config.IncrementalStrategy
+}
+
+type mongoCDCStart struct {
+	OperationTime primitive.Timestamp
+	ResumeToken   bson.Raw
+}
+
+type mongoCDCChangeEvent struct {
+	ID            bson.Raw            `bson:"_id"`
+	OperationType string              `bson:"operationType"`
+	ClusterTime   primitive.Timestamp `bson:"clusterTime"`
+	DocumentKey   bson.M              `bson:"documentKey"`
+	FullDocument  bson.M              `bson:"fullDocument"`
+}
+
+type mongoCDCEventBuffer struct {
+	tableSchema     *schema.TableSchema
+	excludeColumns  []string
+	tableName       string
+	batchSize       int
+	builder         *mongoSchemaBatchBuilder
+	rows            int
+	allowedColumns  map[string]struct{}
+	excludedColumns map[string]struct{}
+}
+
+func NewMongoDBCDCSource() *MongoDBCDCSource {
+	return &MongoDBCDCSource{}
+}
+
+func (s *MongoDBCDCSource) Schemes() []string {
+	return []string{"mongodb+cdc", "mongodb+srv+cdc"}
+}
+
+func (s *MongoDBCDCSource) Connect(ctx context.Context, rawURI string) error {
+	cdcConfig, normalizedURI, err := parseMongoDBCDCURI(rawURI)
+	if err != nil {
+		return fmt.Errorf("failed to parse MongoDB CDC URI: %w", err)
+	}
+
+	clientOpts := options.Client().ApplyURI(normalizedURI)
+	client, err := mongo.Connect(ctx, clientOpts)
+	if err != nil {
+		return fmt.Errorf("failed to connect to MongoDB: %w", err)
+	}
+
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(ctx)
+		return fmt.Errorf("failed to ping MongoDB: %w", err)
+	}
+
+	s.client = client
+	s.database = extractDatabase(normalizedURI)
+	s.uri = rawURI
+	s.cdcConfig = cdcConfig
+	config.Debug("[MONGODB CDC] Connected to database: %s", s.database)
+	return nil
+}
+
+func (s *MongoDBCDCSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Disconnect(ctx)
+	}
+	return nil
+}
+
+func (s *MongoDBCDCSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *MongoDBCDCSource) SupportsStreaming() bool {
+	return true
+}
+
+func (s *MongoDBCDCSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyMerge
+}
+
+func (s *MongoDBCDCSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("collection name is required")
+	}
+
+	ns, err := parseMongoCDCNamespace(s.database, req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	pks, err := mongoCDCPrimaryKeys(req.PrimaryKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	tableSchema, err := s.inferCollectionSchema(ctx, ns, pks)
+	if err != nil {
+		return nil, err
+	}
+
+	strategy := config.StrategyMerge
+	if req.Strategy != "" && req.Strategy != config.StrategyReplace {
+		strategy = req.Strategy
+	}
+
+	return &MongoDBCDCTable{
+		source:      s,
+		ns:          ns,
+		tableSchema: tableSchema,
+		primaryKeys: pks,
+		strategy:    strategy,
+	}, nil
+}
+
+func (s *MongoDBCDCSource) IsMultiTable() bool {
+	return true
+}
+
+func (s *MongoDBCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
+	return s.getTables(ctx, nil)
+}
+
+func (s *MongoDBCDCSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	tables, err := s.getTables(ctx, opts.Tables)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(chan source.RecordBatchResult, 16)
+	go func() {
+		defer close(results)
+
+		var wg sync.WaitGroup
+		for _, table := range tables {
+			table := table
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				ns := mongoNamespace{
+					Database:   s.database,
+					Collection: table.Name,
+					Name:       table.Name,
+				}
+				readOpts := opts.ReadOptions
+				readOpts.CDCResumeLSN = opts.CDCResumeLSNs[table.Name]
+				records, err := s.readNamespace(ctx, ns, table.Schema, readOpts, table.Name)
+				if err != nil {
+					sendMongoCDCResult(ctx, results, source.RecordBatchResult{Err: err, TableName: table.Name})
+					return
+				}
+				for res := range records {
+					if res.TableName == "" {
+						res.TableName = table.Name
+					}
+					if !sendMongoCDCResult(ctx, results, res) {
+						return
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	}()
+
+	return results, nil
+}
+
+func (t *MongoDBCDCTable) Name() string {
+	return t.ns.Name
+}
+
+func (t *MongoDBCDCTable) PrimaryKeys() []string {
+	return t.primaryKeys
+}
+
+func (t *MongoDBCDCTable) IncrementalKey() string {
+	return ""
+}
+
+func (t *MongoDBCDCTable) Strategy() config.IncrementalStrategy {
+	return t.strategy
+}
+
+func (t *MongoDBCDCTable) HasKnownSchema() bool {
+	return true
+}
+
+func (t *MongoDBCDCTable) GetSchema(ctx context.Context) (*schema.TableSchema, error) {
+	return t.tableSchema, nil
+}
+
+func (t *MongoDBCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	return t.source.readNamespace(ctx, t.ns, t.tableSchema, opts, "")
+}
+
+func parseMongoDBCDCURI(rawURI string) (MongoDBCDCConfig, string, error) {
+	cfg := MongoDBCDCConfig{
+		Mode:             MongoDBCDCModeBatch,
+		MaxAwaitTime:     defaultMongoDBCDCAwaitTime,
+		SchemaSampleSize: defaultMongoDBCDCSchemaSampleSize,
+	}
+
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return cfg, "", err
+	}
+
+	baseScheme, ok := strings.CutSuffix(strings.ToLower(parsed.Scheme), "+cdc")
+	if !ok {
+		return cfg, "", fmt.Errorf("unsupported MongoDB CDC scheme: %s", parsed.Scheme)
+	}
+	switch baseScheme {
+	case "mongodb", "mongodb+srv":
+		parsed.Scheme = baseScheme
+	default:
+		return cfg, "", fmt.Errorf("unsupported MongoDB CDC scheme: %s", parsed.Scheme)
+	}
+
+	query := parsed.Query()
+	cfg.DestSchema = query.Get("dest_schema")
+	if mode := strings.ToLower(strings.TrimSpace(query.Get("mode"))); mode != "" {
+		switch mode {
+		case string(MongoDBCDCModeBatch):
+			cfg.Mode = MongoDBCDCModeBatch
+		case string(MongoDBCDCModeStream):
+			cfg.Mode = MongoDBCDCModeStream
+		default:
+			return cfg, "", fmt.Errorf("invalid mode: %s (must be 'batch' or 'stream')", mode)
+		}
+	}
+	if maxAwait := strings.TrimSpace(query.Get("max_await_time")); maxAwait != "" {
+		d, err := time.ParseDuration(maxAwait)
+		if err != nil {
+			return cfg, "", fmt.Errorf("invalid max_await_time: %w", err)
+		}
+		if d <= 0 {
+			return cfg, "", fmt.Errorf("max_await_time must be positive")
+		}
+		cfg.MaxAwaitTime = d
+	}
+	if sampleSize := strings.TrimSpace(query.Get("schema_sample_size")); sampleSize != "" {
+		var parsedSize int
+		if _, err := fmt.Sscanf(sampleSize, "%d", &parsedSize); err != nil || parsedSize < 0 {
+			return cfg, "", fmt.Errorf("schema_sample_size must be a non-negative integer")
+		}
+		cfg.SchemaSampleSize = parsedSize
+	}
+
+	query.Del("dest_schema")
+	query.Del("mode")
+	query.Del("max_await_time")
+	query.Del("schema_sample_size")
+	parsed.RawQuery = query.Encode()
+
+	return cfg, parsed.String(), nil
+}
+
+func parseMongoCDCNamespace(defaultDB, table string) (mongoNamespace, error) {
+	if strings.Contains(table, ":") {
+		return mongoNamespace{}, fmt.Errorf("MongoDB CDC does not support aggregation pipelines in source-table")
+	}
+
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return mongoNamespace{Database: parts[0], Collection: parts[1], Name: table}, nil
+	}
+	if defaultDB == "" {
+		return mongoNamespace{}, fmt.Errorf("database not specified: provide it in the URI or use database.collection format in source_table")
+	}
+	if table == "" {
+		return mongoNamespace{}, fmt.Errorf("collection name is empty")
+	}
+	return mongoNamespace{Database: defaultDB, Collection: table, Name: table}, nil
+}
+
+func mongoCDCPrimaryKeys(pks []string) ([]string, error) {
+	if len(pks) == 0 {
+		return []string{"_id"}, nil
+	}
+	if len(pks) == 1 && pks[0] == "_id" {
+		return pks, nil
+	}
+	return nil, fmt.Errorf("MongoDB CDC currently requires _id as the primary key because delete events only include documentKey")
+}
+
+func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]source.SourceTableInfo, error) {
+	if s.database == "" {
+		return nil, fmt.Errorf("MongoDB CDC multi-table mode requires a database in the source URI")
+	}
+
+	collections, err := s.client.Database(s.database).ListCollectionNames(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collections in database %q: %w", s.database, err)
+	}
+	sort.Strings(collections)
+
+	selected := make([]source.SourceTableInfo, 0, len(collections))
+	pks := []string{"_id"}
+	for _, collection := range collections {
+		if len(filter) > 0 && !mongoCDCMatchesTable(filter, s.database, collection) {
+			continue
+		}
+		ns := mongoNamespace{Database: s.database, Collection: collection, Name: collection}
+		tableSchema, err := s.inferCollectionSchema(ctx, ns, pks)
+		if err != nil {
+			return nil, fmt.Errorf("failed to infer schema for %s: %w", collection, err)
+		}
+		selected = append(selected, source.SourceTableInfo{
+			Name:        collection,
+			Schema:      tableSchema,
+			PrimaryKeys: pks,
+			DestSchema:  s.cdcConfig.DestSchema,
+		})
+	}
+	if len(selected) == 0 {
+		if len(filter) > 0 {
+			return nil, fmt.Errorf("no MongoDB collections matched %s", strings.Join(filter, ", "))
+		}
+		return nil, fmt.Errorf("no MongoDB collections found in database %s", s.database)
+	}
+	return selected, nil
+}
+
+func mongoCDCMatchesTable(filter []string, db, collection string) bool {
+	for _, table := range filter {
+		if strings.EqualFold(table, collection) || strings.EqualFold(table, db+"."+collection) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MongoDBCDCSource) inferCollectionSchema(ctx context.Context, ns mongoNamespace, primaryKeys []string) (*schema.TableSchema, error) {
+	collection := s.client.Database(ns.Database).Collection(ns.Collection)
+	builder := newMongoBatchBuilder(nil)
+	defer builder.Release()
+
+	findOpts := options.Find().SetLimit(int64(s.cdcConfig.SchemaSampleSize))
+	cursor, err := collection.Find(ctx, bson.D{}, findOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sample collection %s.%s: %w", ns.Database, ns.Collection, err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	rows := 0
+	for cursor.Next(ctx) {
+		var doc bson.M
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("failed to decode sample document: %w", err)
+		}
+		if err := builder.AppendDocument(doc); err != nil {
+			return nil, fmt.Errorf("failed to build sample schema: %w", err)
+		}
+		rows++
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("sample cursor error: %w", err)
+	}
+
+	var columns []schema.Column
+	if rows > 0 {
+		record, err := builder.NewRecordBatch()
+		if err != nil {
+			return nil, fmt.Errorf("failed to materialize sample schema: %w", err)
+		}
+		for _, field := range record.Schema().Fields() {
+			columns = append(columns, schemainfer.ArrowFieldToColumn(field.Name, field.Type, true))
+		}
+		record.Release()
+	}
+
+	columns = ensureMongoCDCPKColumns(columns, primaryKeys)
+	tableSchema := &schema.TableSchema{
+		Name:        ns.Collection,
+		Schema:      ns.Database,
+		Columns:     columns,
+		PrimaryKeys: primaryKeys,
+	}
+	markMongoCDCPrimaryKeys(tableSchema)
+	return addMongoCDCColumns(tableSchema), nil
+}
+
+func ensureMongoCDCPKColumns(columns []schema.Column, primaryKeys []string) []schema.Column {
+	seen := make(map[string]bool, len(columns))
+	for _, col := range columns {
+		seen[strings.ToLower(col.Name)] = true
+	}
+	for _, pk := range primaryKeys {
+		if seen[strings.ToLower(pk)] {
+			continue
+		}
+		columns = append(columns, schema.Column{
+			Name:         pk,
+			DataType:     schema.TypeString,
+			Nullable:     false,
+			IsPrimaryKey: true,
+		})
+	}
+	return columns
+}
+
+func markMongoCDCPrimaryKeys(tableSchema *schema.TableSchema) {
+	pkSet := make(map[string]bool, len(tableSchema.PrimaryKeys))
+	for _, pk := range tableSchema.PrimaryKeys {
+		pkSet[strings.ToLower(pk)] = true
+	}
+	for i := range tableSchema.Columns {
+		if pkSet[strings.ToLower(tableSchema.Columns[i].Name)] {
+			tableSchema.Columns[i].IsPrimaryKey = true
+			tableSchema.Columns[i].Nullable = false
+		}
+	}
+}
+
+func addMongoCDCColumns(tableSchema *schema.TableSchema) *schema.TableSchema {
+	copied := *tableSchema
+	copied.Columns = append(append([]schema.Column{}, tableSchema.Columns...), mongodbCDCColumns...)
+	return &copied
+}
+
+func (s *MongoDBCDCSource) readNamespace(ctx context.Context, ns mongoNamespace, tableSchema *schema.TableSchema, opts source.ReadOptions, resultTable string) (<-chan source.RecordBatchResult, error) {
+	outputSchema := tableSchema
+	if opts.Schema != nil {
+		outputSchema = opts.Schema
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+	go func() {
+		defer close(results)
+
+		mode := s.cdcConfig.Mode
+		if opts.Streaming {
+			mode = MongoDBCDCModeStream
+		}
+
+		hasResume := strings.TrimSpace(opts.CDCResumeLSN) != "" && !opts.FullRefresh
+		var commandStart primitive.Timestamp
+		if mode == MongoDBCDCModeBatch || !hasResume {
+			opTime, err := s.currentOperationTime(ctx)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err, TableName: resultTable}
+				return
+			}
+			commandStart = opTime
+		}
+
+		var batchTarget *primitive.Timestamp
+		if mode == MongoDBCDCModeBatch {
+			target := commandStart
+			batchTarget = &target
+		}
+
+		start := mongoCDCStart{}
+		if hasResume {
+			parsedStart, err := parseMongoCDCLSN(opts.CDCResumeLSN)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err, TableName: resultTable}
+				return
+			}
+			start = parsedStart
+		} else {
+			start.OperationTime = commandStart
+			snapshotLSN := formatMongoCDCLSN(commandStart, nil)
+			if err := s.snapshotCollection(ctx, ns, outputSchema, opts, snapshotLSN, results, resultTable); err != nil {
+				results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed for %s.%s: %w", ns.Database, ns.Collection, err), TableName: resultTable}
+				return
+			}
+		}
+
+		if err := s.streamCollection(ctx, ns, outputSchema, opts, mode, start, batchTarget, results, resultTable); err != nil {
+			results <- source.RecordBatchResult{Err: err, TableName: resultTable}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *MongoDBCDCSource) currentOperationTime(ctx context.Context) (primitive.Timestamp, error) {
+	db := s.database
+	if db == "" {
+		db = "admin"
+	}
+
+	var result struct {
+		OperationTime primitive.Timestamp `bson:"operationTime"`
+	}
+	if err := s.client.Database(db).RunCommand(ctx, bson.D{{Key: "hello", Value: 1}}).Decode(&result); err != nil {
+		return primitive.Timestamp{}, fmt.Errorf("failed to read MongoDB operation time: %w", err)
+	}
+	if result.OperationTime.T == 0 {
+		return primitive.Timestamp{}, fmt.Errorf("MongoDB did not return operationTime; CDC requires a replica set or sharded cluster")
+	}
+	return result.OperationTime, nil
+}
+
+func (s *MongoDBCDCSource) snapshotCollection(ctx context.Context, ns mongoNamespace, tableSchema *schema.TableSchema, opts source.ReadOptions, snapshotLSN string, results chan<- source.RecordBatchResult, resultTable string) error {
+	collection := s.client.Database(ns.Database).Collection(ns.Collection)
+	findOpts := options.Find().SetBatchSize(int32(mongoCDCReadBatchSize(opts)))
+	cursor, err := collection.Find(ctx, bson.D{}, findOpts)
+	if err != nil {
+		return fmt.Errorf("failed to query snapshot: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	buffer := newMongoCDCEventBuffer(tableSchema, opts.ExcludeColumns, resultTable, mongoCDCReadBatchSize(opts))
+	defer buffer.release()
+
+	syncedAt := time.Now().UTC()
+	rowSeq := int64(0)
+	for cursor.Next(ctx) {
+		var doc bson.M
+		if err := cursor.Decode(&doc); err != nil {
+			return fmt.Errorf("failed to decode snapshot document: %w", err)
+		}
+		addMongoCDCMetadata(doc, snapshotLSN, false, syncedAt.Add(time.Duration(rowSeq)*time.Microsecond))
+		if err := buffer.append(ctx, doc, results); err != nil {
+			return err
+		}
+		rowSeq++
+	}
+	if err := cursor.Err(); err != nil {
+		return fmt.Errorf("snapshot cursor error: %w", err)
+	}
+	return buffer.flush(ctx, results)
+}
+
+func (s *MongoDBCDCSource) streamCollection(ctx context.Context, ns mongoNamespace, tableSchema *schema.TableSchema, opts source.ReadOptions, mode MongoDBCDCMode, start mongoCDCStart, batchTarget *primitive.Timestamp, results chan<- source.RecordBatchResult, resultTable string) error {
+	collection := s.client.Database(ns.Database).Collection(ns.Collection)
+	maxAwaitTime := s.cdcConfig.MaxAwaitTime
+	if opts.Streaming {
+		flushInterval := mongoCDCFlushInterval(opts)
+		if flushInterval > 0 && flushInterval < maxAwaitTime {
+			maxAwaitTime = flushInterval
+		}
+	}
+	watchOpts := options.ChangeStream().
+		SetFullDocument(options.UpdateLookup).
+		SetMaxAwaitTime(maxAwaitTime).
+		SetBatchSize(int32(mongoCDCSourceBatchSize(opts)))
+	if len(start.ResumeToken) > 0 {
+		watchOpts.SetResumeAfter(start.ResumeToken)
+	} else if start.OperationTime.T > 0 {
+		watchOpts.SetStartAtOperationTime(&start.OperationTime)
+	}
+
+	stream, err := collection.Watch(ctx, mongo.Pipeline{}, watchOpts)
+	if err != nil {
+		return fmt.Errorf("failed to open MongoDB change stream for %s.%s: %w", ns.Database, ns.Collection, err)
+	}
+	defer func() { _ = stream.Close(ctx) }()
+
+	buffer := newMongoCDCEventBuffer(tableSchema, opts.ExcludeColumns, resultTable, mongoCDCSourceBatchSize(opts))
+	defer buffer.release()
+
+	var firstBufferedAt time.Time
+	flushByInterval := func() error {
+		if !opts.Streaming || buffer.rows == 0 || firstBufferedAt.IsZero() || time.Since(firstBufferedAt) < mongoCDCFlushInterval(opts) {
+			return nil
+		}
+		if err := buffer.flush(ctx, results); err != nil {
+			return err
+		}
+		firstBufferedAt = time.Time{}
+		return nil
+	}
+
+	for {
+		if stream.TryNext(ctx) {
+			var event mongoCDCChangeEvent
+			if err := stream.Decode(&event); err != nil {
+				return fmt.Errorf("failed to decode MongoDB change event: %w", err)
+			}
+
+			clusterTime := event.ClusterTime
+			if clusterTime.T == 0 {
+				clusterTime = primitive.Timestamp{T: uint32(time.Now().Unix())}
+			}
+			if mongoCDCAfterBatchTarget(clusterTime, batchTarget) {
+				return buffer.flush(ctx, results)
+			}
+
+			doc, deleted, ok := mongoCDCEventDocument(event)
+			if !ok {
+				continue
+			}
+			token := stream.ResumeToken()
+			if len(token) == 0 {
+				token = event.ID
+			}
+			addMongoCDCMetadata(doc, formatMongoCDCLSN(clusterTime, token), deleted, time.Now().UTC())
+			wasEmpty := buffer.rows == 0
+			if err := buffer.append(ctx, doc, results); err != nil {
+				return err
+			}
+			if opts.Streaming {
+				if wasEmpty && buffer.rows > 0 {
+					firstBufferedAt = time.Now()
+				}
+				if buffer.rows == 0 {
+					firstBufferedAt = time.Time{}
+				}
+				if err := flushByInterval(); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if err := stream.Err(); err != nil {
+			if ctx.Err() != nil {
+				if opts.Streaming {
+					if flushErr := buffer.flushBlocking(results); flushErr != nil {
+						return flushErr
+					}
+				}
+				return ctx.Err()
+			}
+			return fmt.Errorf("MongoDB change stream error for %s.%s: %w", ns.Database, ns.Collection, err)
+		}
+
+		if mode == MongoDBCDCModeBatch {
+			return buffer.flush(ctx, results)
+		}
+
+		if err := flushByInterval(); err != nil {
+			return err
+		}
+
+		if ctx.Err() != nil {
+			if opts.Streaming {
+				if flushErr := buffer.flushBlocking(results); flushErr != nil {
+					return flushErr
+				}
+			}
+			return ctx.Err()
+		}
+	}
+}
+
+func mongoCDCEventDocument(event mongoCDCChangeEvent) (bson.M, bool, bool) {
+	switch event.OperationType {
+	case "insert":
+		doc := cloneBSONM(event.FullDocument)
+		if len(doc) == 0 {
+			doc = cloneBSONM(event.DocumentKey)
+		}
+		for key, value := range event.DocumentKey {
+			if _, ok := doc[key]; !ok {
+				doc[key] = value
+			}
+		}
+		return doc, false, true
+	case "replace", "update":
+		doc := cloneBSONM(event.FullDocument)
+		if len(doc) == 0 {
+			return nil, false, false
+		}
+		for key, value := range event.DocumentKey {
+			if _, ok := doc[key]; !ok {
+				doc[key] = value
+			}
+		}
+		return doc, false, true
+	case "delete":
+		return cloneBSONM(event.DocumentKey), true, true
+	default:
+		return nil, false, false
+	}
+}
+
+func cloneBSONM(in bson.M) bson.M {
+	out := make(bson.M, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func addMongoCDCMetadata(doc bson.M, lsn string, deleted bool, syncedAt time.Time) {
+	doc[destination.CDCLSNColumn] = lsn
+	doc[destination.CDCDeletedColumn] = deleted
+	doc[destination.CDCSyncedAtColumn] = syncedAt.UTC()
+}
+
+func formatMongoCDCLSN(ts primitive.Timestamp, token bson.Raw) string {
+	tokenHex := "0"
+	if len(token) > 0 {
+		tokenHex = hex.EncodeToString(token)
+	}
+	return fmt.Sprintf("%010d:%010d:%s", ts.T, ts.I, tokenHex)
+}
+
+func parseMongoCDCLSN(stored string) (mongoCDCStart, error) {
+	parts := strings.SplitN(strings.TrimSpace(stored), ":", 3)
+	if len(parts) < 2 {
+		return mongoCDCStart{}, fmt.Errorf("MongoDB CDC resume LSN %q is invalid; run with --full-refresh to rebuild the destination safely", stored)
+	}
+
+	var t, i uint32
+	if _, err := fmt.Sscanf(parts[0], "%d", &t); err != nil {
+		return mongoCDCStart{}, fmt.Errorf("MongoDB CDC resume LSN %q has invalid timestamp: %w", stored, err)
+	}
+	if _, err := fmt.Sscanf(parts[1], "%d", &i); err != nil {
+		return mongoCDCStart{}, fmt.Errorf("MongoDB CDC resume LSN %q has invalid increment: %w", stored, err)
+	}
+
+	start := mongoCDCStart{OperationTime: primitive.Timestamp{T: t, I: i}}
+	if len(parts) == 3 && parts[2] != "" && parts[2] != "0" {
+		token, err := hex.DecodeString(parts[2])
+		if err != nil {
+			return mongoCDCStart{}, fmt.Errorf("MongoDB CDC resume LSN %q has invalid resume token: %w", stored, err)
+		}
+		start.ResumeToken = bson.Raw(token)
+	}
+	return start, nil
+}
+
+func mongoCDCAfterBatchTarget(ts primitive.Timestamp, target *primitive.Timestamp) bool {
+	if target == nil {
+		return false
+	}
+	return compareMongoCDCTimestamp(ts, *target) > 0
+}
+
+func compareMongoCDCTimestamp(a, b primitive.Timestamp) int {
+	if a.T < b.T {
+		return -1
+	}
+	if a.T > b.T {
+		return 1
+	}
+	if a.I < b.I {
+		return -1
+	}
+	if a.I > b.I {
+		return 1
+	}
+	return 0
+}
+
+func newMongoCDCEventBuffer(tableSchema *schema.TableSchema, excludeColumns []string, tableName string, batchSize int) *mongoCDCEventBuffer {
+	if batchSize <= 0 {
+		batchSize = defaultMongoDBCDCStreamBatchSize
+	}
+	allowedColumns := make(map[string]struct{}, len(tableSchema.Columns))
+	for _, col := range tableSchema.Columns {
+		allowedColumns[col.Name] = struct{}{}
+	}
+	excludedColumns := make(map[string]struct{}, len(excludeColumns))
+	for _, col := range excludeColumns {
+		excludedColumns[strings.ToLower(col)] = struct{}{}
+	}
+	return &mongoCDCEventBuffer{
+		tableSchema:     tableSchema,
+		excludeColumns:  excludeColumns,
+		tableName:       tableName,
+		batchSize:       batchSize,
+		builder:         newMongoSchemaBatchBuilder(tableSchema.Columns, excludeColumns),
+		allowedColumns:  allowedColumns,
+		excludedColumns: excludedColumns,
+	}
+}
+
+func (b *mongoCDCEventBuffer) append(ctx context.Context, doc bson.M, results chan<- source.RecordBatchResult) error {
+	if unknown := b.unknownDocumentFields(doc); len(unknown) > 0 {
+		tableName := b.tableName
+		if tableName == "" && b.tableSchema != nil {
+			tableName = b.tableSchema.Name
+		}
+		return fmt.Errorf("MongoDB CDC document for %s contains fields not present in the inferred schema: %s; increase schema_sample_size so these fields are sampled before advancing the CDC cursor", tableName, strings.Join(unknown, ", "))
+	}
+	if err := b.builder.AppendDocument(doc); err != nil {
+		return fmt.Errorf("failed to build MongoDB CDC Arrow batch: %w", err)
+	}
+	b.rows++
+	if b.rows < b.batchSize {
+		return nil
+	}
+	return b.flush(ctx, results)
+}
+
+func (b *mongoCDCEventBuffer) unknownDocumentFields(doc bson.M) []string {
+	var unknown []string
+	for key := range doc {
+		if _, ok := b.allowedColumns[key]; ok {
+			continue
+		}
+		if _, ok := b.excludedColumns[strings.ToLower(key)]; ok {
+			continue
+		}
+		unknown = append(unknown, key)
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+func (b *mongoCDCEventBuffer) flush(ctx context.Context, results chan<- source.RecordBatchResult) error {
+	if b.rows == 0 {
+		return nil
+	}
+	record, err := b.builder.NewRecordBatch()
+	if err != nil {
+		return fmt.Errorf("failed to convert MongoDB CDC batch to Arrow: %w", err)
+	}
+	if !sendMongoCDCResult(ctx, results, source.RecordBatchResult{Batch: record, TableName: b.tableName}) {
+		record.Release()
+		return ctx.Err()
+	}
+	b.builder = newMongoSchemaBatchBuilder(b.tableSchema.Columns, b.excludeColumns)
+	b.rows = 0
+	return nil
+}
+
+func (b *mongoCDCEventBuffer) flushBlocking(results chan<- source.RecordBatchResult) error {
+	if b.rows == 0 {
+		return nil
+	}
+	record, err := b.builder.NewRecordBatch()
+	if err != nil {
+		return fmt.Errorf("failed to convert MongoDB CDC batch to Arrow: %w", err)
+	}
+	results <- source.RecordBatchResult{Batch: record, TableName: b.tableName}
+	b.builder = newMongoSchemaBatchBuilder(b.tableSchema.Columns, b.excludeColumns)
+	b.rows = 0
+	return nil
+}
+
+func (b *mongoCDCEventBuffer) release() {
+	if b.builder != nil {
+		b.builder.Release()
+		b.builder = nil
+	}
+}
+
+func mongoCDCSourceBatchSize(opts source.ReadOptions) int {
+	if opts.Streaming && opts.FlushRecords > 0 {
+		return opts.FlushRecords
+	}
+	return mongoCDCReadBatchSize(opts)
+}
+
+func mongoCDCFlushInterval(opts source.ReadOptions) time.Duration {
+	if opts.Streaming && opts.FlushInterval > 0 {
+		return opts.FlushInterval
+	}
+	return defaultMongoDBCDCFlushInterval
+}
+
+func mongoCDCReadBatchSize(opts source.ReadOptions) int {
+	if opts.PageSize > 0 {
+		return opts.PageSize
+	}
+	return defaultMongoDBCDCStreamBatchSize
+}
+
+func sendMongoCDCResult(ctx context.Context, results chan<- source.RecordBatchResult, result source.RecordBatchResult) bool {
+	select {
+	case results <- result:
+		return true
+	case <-ctx.Done():
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		return false
+	}
+}
+
+var (
+	_ source.Source           = (*MongoDBCDCSource)(nil)
+	_ source.StreamingSource  = (*MongoDBCDCSource)(nil)
+	_ source.MultiTableSource = (*MongoDBCDCSource)(nil)
+	_ source.SourceTable      = (*MongoDBCDCTable)(nil)
+)

--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -89,6 +89,7 @@ type mongoCDCEventBuffer struct {
 	rows            int
 	allowedColumns  map[string]struct{}
 	excludedColumns map[string]struct{}
+	warnedUnknown   map[string]struct{}
 }
 
 func NewMongoDBCDCSource() *MongoDBCDCSource {
@@ -353,7 +354,7 @@ func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]so
 		return nil, fmt.Errorf("MongoDB CDC multi-table mode requires a database in the source URI")
 	}
 
-	collections, err := s.client.Database(s.database).ListCollectionNames(ctx, bson.D{})
+	collections, err := s.client.Database(s.database).ListCollectionNames(ctx, bson.D{{Key: "type", Value: "collection"}})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list collections in database %q: %w", s.database, err)
 	}
@@ -674,7 +675,7 @@ func (s *MongoDBCDCSource) streamCollection(ctx context.Context, ns mongoNamespa
 		if err := stream.Err(); err != nil {
 			if ctx.Err() != nil {
 				if opts.Streaming {
-					if flushErr := buffer.flushBlocking(results); flushErr != nil {
+					if flushErr := buffer.flushBlocking(ctx, results); flushErr != nil {
 						return flushErr
 					}
 				}
@@ -693,7 +694,7 @@ func (s *MongoDBCDCSource) streamCollection(ctx context.Context, ns mongoNamespa
 
 		if ctx.Err() != nil {
 			if opts.Streaming {
-				if flushErr := buffer.flushBlocking(results); flushErr != nil {
+				if flushErr := buffer.flushBlocking(ctx, results); flushErr != nil {
 					return flushErr
 				}
 			}
@@ -823,16 +824,13 @@ func newMongoCDCEventBuffer(tableSchema *schema.TableSchema, excludeColumns []st
 		builder:         newMongoSchemaBatchBuilder(tableSchema.Columns, excludeColumns),
 		allowedColumns:  allowedColumns,
 		excludedColumns: excludedColumns,
+		warnedUnknown:   make(map[string]struct{}),
 	}
 }
 
 func (b *mongoCDCEventBuffer) append(ctx context.Context, doc bson.M, results chan<- source.RecordBatchResult) error {
 	if unknown := b.unknownDocumentFields(doc); len(unknown) > 0 {
-		tableName := b.tableName
-		if tableName == "" && b.tableSchema != nil {
-			tableName = b.tableSchema.Name
-		}
-		return fmt.Errorf("MongoDB CDC document for %s contains fields not present in the inferred schema: %s; increase schema_sample_size so these fields are sampled before advancing the CDC cursor", tableName, strings.Join(unknown, ", "))
+		b.debugUnknownDocumentFields(unknown)
 	}
 	if err := b.builder.AppendDocument(doc); err != nil {
 		return fmt.Errorf("failed to build MongoDB CDC Arrow batch: %w", err)
@@ -859,6 +857,25 @@ func (b *mongoCDCEventBuffer) unknownDocumentFields(doc bson.M) []string {
 	return unknown
 }
 
+func (b *mongoCDCEventBuffer) debugUnknownDocumentFields(fields []string) {
+	newFields := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if _, ok := b.warnedUnknown[field]; ok {
+			continue
+		}
+		b.warnedUnknown[field] = struct{}{}
+		newFields = append(newFields, field)
+	}
+	if len(newFields) == 0 {
+		return
+	}
+	tableName := b.tableName
+	if tableName == "" && b.tableSchema != nil {
+		tableName = b.tableSchema.Name
+	}
+	config.Debug("[MONGODB CDC] Ignoring fields not present in inferred schema for %s: %s", tableName, strings.Join(newFields, ", "))
+}
+
 func (b *mongoCDCEventBuffer) flush(ctx context.Context, results chan<- source.RecordBatchResult) error {
 	if b.rows == 0 {
 		return nil
@@ -876,7 +893,7 @@ func (b *mongoCDCEventBuffer) flush(ctx context.Context, results chan<- source.R
 	return nil
 }
 
-func (b *mongoCDCEventBuffer) flushBlocking(results chan<- source.RecordBatchResult) error {
+func (b *mongoCDCEventBuffer) flushBlocking(ctx context.Context, results chan<- source.RecordBatchResult) error {
 	if b.rows == 0 {
 		return nil
 	}
@@ -884,7 +901,10 @@ func (b *mongoCDCEventBuffer) flushBlocking(results chan<- source.RecordBatchRes
 	if err != nil {
 		return fmt.Errorf("failed to convert MongoDB CDC batch to Arrow: %w", err)
 	}
-	results <- source.RecordBatchResult{Batch: record, TableName: b.tableName}
+	if !sendMongoCDCResult(ctx, results, source.RecordBatchResult{Batch: record, TableName: b.tableName}) {
+		record.Release()
+		return ctx.Err()
+	}
 	b.builder = newMongoSchemaBatchBuilder(b.tableSchema.Columns, b.excludeColumns)
 	b.rows = 0
 	return nil

--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -389,7 +389,7 @@ func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]so
 
 func mongoCDCMatchesTable(filter []string, db, collection string) bool {
 	for _, table := range filter {
-		if strings.EqualFold(table, collection) || strings.EqualFold(table, db+"."+collection) {
+		if table == collection || table == db+"."+collection {
 			return true
 		}
 	}

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -2,6 +2,7 @@ package mongodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -476,7 +477,7 @@ func TestMongoCDCStreamingFlushOptions(t *testing.T) {
 	}
 }
 
-func TestMongoCDCEventBufferRejectsFieldsOutsideSchema(t *testing.T) {
+func TestMongoCDCEventBufferAllowsFieldsOutsideSchema(t *testing.T) {
 	tableSchema := addMongoCDCColumns(&schema.TableSchema{
 		Name: "items",
 		Columns: []schema.Column{
@@ -494,11 +495,11 @@ func TestMongoCDCEventBufferRejectsFieldsOutsideSchema(t *testing.T) {
 		"name":  "item1",
 		"value": int64(100),
 	}, nil)
-	if err == nil {
-		t.Fatal("expected unknown field error")
-	}
-	if !strings.Contains(err.Error(), "value") || !strings.Contains(err.Error(), "schema_sample_size") {
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if buffer.rows != 1 {
+		t.Fatalf("buffer rows = %d, want 1", buffer.rows)
 	}
 }
 
@@ -522,6 +523,35 @@ func TestMongoCDCEventBufferAllowsExcludedUnknownFields(t *testing.T) {
 	})
 	if len(unknown) != 0 {
 		t.Fatalf("unknown fields = %v, want none", unknown)
+	}
+}
+
+func TestMongoCDCEventBufferFlushBlockingHonorsCanceledContext(t *testing.T) {
+	tableSchema := addMongoCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "_id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"_id"},
+	})
+
+	buffer := newMongoCDCEventBuffer(tableSchema, nil, "items", 10)
+	defer buffer.release()
+
+	err := buffer.append(context.Background(), bson.M{
+		"_id":  int64(1),
+		"name": "item1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected append error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = buffer.flushBlocking(ctx, make(chan source.RecordBatchResult))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("flushBlocking error = %v, want context.Canceled", err)
 	}
 }
 

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -1,12 +1,15 @@
 package mongodb
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -315,6 +318,270 @@ func TestNormalizeBatchSize(t *testing.T) {
 				t.Fatalf("normalizeBatchSize(%d) = %d, want %d", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseMongoDBCDCURI(t *testing.T) {
+	t.Run("mongodb cdc strips cdc params and keeps driver params", func(t *testing.T) {
+		cfg, normalized, err := parseMongoDBCDCURI("mongodb+cdc://user:pass@localhost:27017/app?mode=stream&dest_schema=raw&max_await_time=2s&schema_sample_size=42&replicaSet=rs0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Mode != MongoDBCDCModeStream {
+			t.Fatalf("mode = %s, want stream", cfg.Mode)
+		}
+		if cfg.DestSchema != "raw" {
+			t.Fatalf("dest schema = %q, want raw", cfg.DestSchema)
+		}
+		if cfg.MaxAwaitTime != 2*time.Second {
+			t.Fatalf("max await = %v, want 2s", cfg.MaxAwaitTime)
+		}
+		if cfg.SchemaSampleSize != 42 {
+			t.Fatalf("sample size = %d, want 42", cfg.SchemaSampleSize)
+		}
+		if !strings.HasPrefix(normalized, "mongodb://") {
+			t.Fatalf("normalized URI = %q, want mongodb scheme", normalized)
+		}
+		if strings.Contains(normalized, "mode=") || strings.Contains(normalized, "dest_schema=") || strings.Contains(normalized, "max_await_time=") {
+			t.Fatalf("normalized URI still contains CDC-only params: %s", normalized)
+		}
+		if !strings.Contains(normalized, "replicaSet=rs0") {
+			t.Fatalf("normalized URI dropped driver param: %s", normalized)
+		}
+	})
+
+	t.Run("mongodb srv cdc keeps srv base scheme", func(t *testing.T) {
+		_, normalized, err := parseMongoDBCDCURI("mongodb+srv+cdc://cluster.example.com/app?mode=batch")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasPrefix(normalized, "mongodb+srv://") {
+			t.Fatalf("normalized URI = %q, want mongodb+srv scheme", normalized)
+		}
+	})
+
+	t.Run("invalid mode", func(t *testing.T) {
+		_, _, err := parseMongoDBCDCURI("mongodb+cdc://localhost:27017/app?mode=once")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestParseMongoCDCNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		defaultDB string
+		table     string
+		wantDB    string
+		wantColl  string
+		wantName  string
+		wantErr   bool
+	}{
+		{name: "qualified table", table: "app.users", wantDB: "app", wantColl: "users", wantName: "app.users"},
+		{name: "plain collection uses uri db", defaultDB: "app", table: "users", wantDB: "app", wantColl: "users", wantName: "users"},
+		{name: "plain collection without uri db errors", table: "users", wantErr: true},
+		{name: "aggregation pipeline rejected", defaultDB: "app", table: `users:[{"$match":{}}]`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMongoCDCNamespace(tt.defaultDB, tt.table)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Database != tt.wantDB || got.Collection != tt.wantColl || got.Name != tt.wantName {
+				t.Fatalf("got %+v, want db=%q coll=%q name=%q", got, tt.wantDB, tt.wantColl, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMongoCDCLSNRoundTrip(t *testing.T) {
+	token := bson.Raw{0x05, 0x00, 0x00, 0x00, 0x00}
+	ts := primitive.Timestamp{T: 123, I: 45}
+
+	lsn := formatMongoCDCLSN(ts, token)
+	start, err := parseMongoCDCLSN(lsn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if start.OperationTime != ts {
+		t.Fatalf("operation time = %+v, want %+v", start.OperationTime, ts)
+	}
+	if string(start.ResumeToken) != string(token) {
+		t.Fatalf("resume token = %x, want %x", []byte(start.ResumeToken), []byte(token))
+	}
+
+	snapshotLSN := formatMongoCDCLSN(ts, nil)
+	start, err = parseMongoCDCLSN(snapshotLSN)
+	if err != nil {
+		t.Fatalf("unexpected snapshot parse error: %v", err)
+	}
+	if len(start.ResumeToken) != 0 {
+		t.Fatalf("snapshot resume token = %x, want empty", []byte(start.ResumeToken))
+	}
+}
+
+func TestMongoCDCAfterBatchTarget(t *testing.T) {
+	target := primitive.Timestamp{T: 100, I: 5}
+	tests := []struct {
+		name string
+		ts   primitive.Timestamp
+		want bool
+	}{
+		{name: "before second", ts: primitive.Timestamp{T: 99, I: 99}, want: false},
+		{name: "before increment", ts: primitive.Timestamp{T: 100, I: 4}, want: false},
+		{name: "equal target", ts: primitive.Timestamp{T: 100, I: 5}, want: false},
+		{name: "after increment", ts: primitive.Timestamp{T: 100, I: 6}, want: true},
+		{name: "after second", ts: primitive.Timestamp{T: 101, I: 0}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mongoCDCAfterBatchTarget(tt.ts, &target); got != tt.want {
+				t.Fatalf("mongoCDCAfterBatchTarget() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	if mongoCDCAfterBatchTarget(primitive.Timestamp{T: 101}, nil) {
+		t.Fatal("nil target should not stop batch")
+	}
+}
+
+func TestMongoCDCStreamingFlushOptions(t *testing.T) {
+	batchOpts := source.ReadOptions{PageSize: 123}
+	if got := mongoCDCSourceBatchSize(batchOpts); got != 123 {
+		t.Fatalf("batch size = %d, want page size", got)
+	}
+
+	streamOpts := source.ReadOptions{
+		Streaming:     true,
+		PageSize:      123,
+		FlushRecords:  7,
+		FlushInterval: 250 * time.Millisecond,
+	}
+	if got := mongoCDCSourceBatchSize(streamOpts); got != 7 {
+		t.Fatalf("streaming batch size = %d, want flush records", got)
+	}
+	if got := mongoCDCFlushInterval(streamOpts); got != 250*time.Millisecond {
+		t.Fatalf("streaming flush interval = %v, want 250ms", got)
+	}
+}
+
+func TestMongoCDCEventBufferRejectsFieldsOutsideSchema(t *testing.T) {
+	tableSchema := addMongoCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "_id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"_id"},
+	})
+
+	buffer := newMongoCDCEventBuffer(tableSchema, nil, "items", 10)
+	defer buffer.release()
+
+	err := buffer.append(context.Background(), bson.M{
+		"_id":   int64(1),
+		"name":  "item1",
+		"value": int64(100),
+	}, nil)
+	if err == nil {
+		t.Fatal("expected unknown field error")
+	}
+	if !strings.Contains(err.Error(), "value") || !strings.Contains(err.Error(), "schema_sample_size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMongoCDCEventBufferAllowsExcludedUnknownFields(t *testing.T) {
+	tableSchema := addMongoCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "_id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"_id"},
+	})
+
+	buffer := newMongoCDCEventBuffer(tableSchema, []string{"value"}, "items", 10)
+	defer buffer.release()
+
+	unknown := buffer.unknownDocumentFields(bson.M{
+		"_id":   int64(1),
+		"name":  "item1",
+		"value": int64(100),
+	})
+	if len(unknown) != 0 {
+		t.Fatalf("unknown fields = %v, want none", unknown)
+	}
+}
+
+func TestMongoCDCEventDocument(t *testing.T) {
+	t.Run("update uses full document and keeps document key", func(t *testing.T) {
+		doc, deleted, ok := mongoCDCEventDocument(mongoCDCChangeEvent{
+			OperationType: "update",
+			DocumentKey:   bson.M{"_id": int64(1)},
+			FullDocument:  bson.M{"name": "alice"},
+		})
+		if !ok || deleted {
+			t.Fatalf("ok=%v deleted=%v, want ok active", ok, deleted)
+		}
+		if doc["_id"] != int64(1) || doc["name"] != "alice" {
+			t.Fatalf("unexpected doc: %#v", doc)
+		}
+	})
+
+	t.Run("delete uses document key", func(t *testing.T) {
+		doc, deleted, ok := mongoCDCEventDocument(mongoCDCChangeEvent{
+			OperationType: "delete",
+			DocumentKey:   bson.M{"_id": int64(2)},
+		})
+		if !ok || !deleted {
+			t.Fatalf("ok=%v deleted=%v, want ok deleted", ok, deleted)
+		}
+		if doc["_id"] != int64(2) {
+			t.Fatalf("unexpected doc: %#v", doc)
+		}
+	})
+
+	t.Run("update without full document ignored", func(t *testing.T) {
+		_, _, ok := mongoCDCEventDocument(mongoCDCChangeEvent{
+			OperationType: "update",
+			DocumentKey:   bson.M{"_id": int64(3)},
+		})
+		if ok {
+			t.Fatal("expected incomplete update event to be ignored")
+		}
+	})
+
+	t.Run("non data event ignored", func(t *testing.T) {
+		_, _, ok := mongoCDCEventDocument(mongoCDCChangeEvent{OperationType: "drop"})
+		if ok {
+			t.Fatal("expected non-data event to be ignored")
+		}
+	})
+}
+
+func TestMongoCDCPrimaryKeys(t *testing.T) {
+	pks, err := mongoCDCPrimaryKeys(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pks) != 1 || pks[0] != "_id" {
+		t.Fatalf("primary keys = %v, want [_id]", pks)
+	}
+
+	if _, err := mongoCDCPrimaryKeys([]string{"id"}); err == nil {
+		t.Fatal("expected custom primary key error")
 	}
 }
 

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -404,6 +404,23 @@ func TestParseMongoCDCNamespace(t *testing.T) {
 	}
 }
 
+func TestMongoCDCMatchesTableIsCaseSensitive(t *testing.T) {
+	filter := []string{"users", "app.orders"}
+
+	if !mongoCDCMatchesTable(filter, "app", "users") {
+		t.Fatal("expected exact collection match")
+	}
+	if !mongoCDCMatchesTable(filter, "app", "orders") {
+		t.Fatal("expected exact qualified collection match")
+	}
+	if mongoCDCMatchesTable(filter, "app", "Users") {
+		t.Fatal("did not expect case-insensitive collection match")
+	}
+	if mongoCDCMatchesTable(filter, "App", "orders") {
+		t.Fatal("did not expect case-insensitive database match")
+	}
+}
+
 func TestMongoCDCLSNRoundTrip(t *testing.T) {
 	token := bson.Raw{0x05, 0x00, 0x00, 0x00, 0x00}
 	ts := primitive.Timestamp{T: 123, I: 45}

--- a/pkg/source/mongodb/register.go
+++ b/pkg/source/mongodb/register.go
@@ -7,4 +7,8 @@ func init() {
 		[]string{"mongodb", "mongodb+srv"},
 		func() interface{} { return NewMongoDBSource() },
 	)
+	registry.RegisterSource(
+		[]string{"mongodb+cdc", "mongodb+srv+cdc"},
+		func() interface{} { return NewMongoDBCDCSource() },
+	)
 }

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -23,6 +23,8 @@ type ReadOptions struct {
 	FullRefresh    bool
 	Columns        string // Optional: column definitions for schema-less sources (e.g., "id:bigint,name:text")
 	Streaming      bool   // Continuous mode: never exit on caught-up/idle; attach cumulative CommitTokens
+	FlushInterval  time.Duration
+	FlushRecords   int
 }
 
 type RecordBatchResult struct {

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -77,6 +77,8 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		CDCResumeLSN:   job.Config.CDCResumeLSN,
 		CDCSlotSuffix:  job.Config.CDCSlotSuffix,
 		Streaming:      true,
+		FlushInterval:  job.Config.FlushInterval,
+		FlushRecords:   job.Config.FlushRecords,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get records: %w", err)
@@ -144,6 +146,8 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 			PageSize:      job.Config.PageSize,
 			CDCSlotSuffix: job.Config.CDCSlotSuffix,
 			Streaming:     true,
+			FlushInterval: job.Config.FlushInterval,
+			FlushRecords:  job.Config.FlushRecords,
 		},
 		CDCResumeLSNs: job.CDCResumeLSNs,
 	})

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -167,6 +167,27 @@ func TestStreaming_IntervalTriggerFlushes(t *testing.T) {
 	assert.Equal(t, 1, writeCallCount(dest))
 }
 
+func TestStreamingExecutor_PassesFlushOptionsToSource(t *testing.T) {
+	job, src, _ := minimalJob()
+	job.Config.FlushInterval = 123 * time.Millisecond
+	job.Config.FlushRecords = 7
+	src.readCh = mustClosedRecords()
+
+	exec := NewStreamingExecutor(StreamingOptions{
+		FlushInterval: job.Config.FlushInterval,
+		FlushRecords:  int64(job.Config.FlushRecords),
+		Strategy:      config.StrategyAppend,
+	})
+	require.NoError(t, exec.Execute(context.Background(), job))
+
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	require.True(t, src.readCalled)
+	assert.True(t, src.readOpts.Streaming)
+	assert.Equal(t, 123*time.Millisecond, src.readOpts.FlushInterval)
+	assert.Equal(t, 7, src.readOpts.FlushRecords)
+}
+
 func TestStreaming_EmptyCyclesSkipped(t *testing.T) {
 	dest := &fakeDestination{}
 	committer := &fakeCommitter{}

--- a/tests/integration/mongodb_cdc_test.go
+++ b/tests/integration/mongodb_cdc_test.go
@@ -182,3 +182,59 @@ func TestMongoDBCDC_MultiTableSQLite(t *testing.T) {
 	assert.Equal(t, 2, tableCount("users"))
 	assert.Equal(t, 3, tableCount("orders"))
 }
+
+func TestMongoDBCDC_ZeroSchemaSampleSQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	container, mongoURI := setupMongoDBCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Disconnect(ctx) })
+
+	coll := client.Database("cdc_zero_sample").Collection("items")
+	_, err = coll.InsertOne(ctx, bson.M{"_id": int64(1), "name": "item1", "value": int64(100)})
+	require.NoError(t, err)
+
+	sqlitePath := filepath.Join(t.TempDir(), "mongodb_cdc_zero_sample.db")
+	cfg := &config.IngestConfig{
+		SourceURI:   mongodbCDCURI(t, mongoURI, "cdc_zero_sample", map[string]string{"mode": "batch", "schema_sample_size": "0", "max_await_time": "500ms"}),
+		SourceTable: "cdc_zero_sample.items",
+		DestURI:     "sqlite:///" + sqlitePath,
+		DestTable:   "items_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	dest, err := sql.Open("sqlite3", sqlitePath)
+	require.NoError(t, err)
+	defer func() { _ = dest.Close() }()
+
+	columns := map[string]bool{}
+	rows, err := dest.Query(`PRAGMA table_info(items_dest)`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		require.NoError(t, rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk))
+		columns[name] = true
+	}
+	require.NoError(t, rows.Err())
+
+	assert.True(t, columns["_id"])
+	assert.True(t, columns["_cdc_lsn"])
+	assert.False(t, columns["name"])
+	assert.False(t, columns["value"])
+
+	var count int
+	require.NoError(t, dest.QueryRow(`SELECT COUNT(*) FROM items_dest WHERE "_cdc_deleted" = 0`).Scan(&count))
+	assert.Equal(t, 1, count)
+}

--- a/tests/integration/mongodb_cdc_test.go
+++ b/tests/integration/mongodb_cdc_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcmongo "github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func setupMongoDBCDCContainer(t *testing.T, ctx context.Context) (*tcmongo.MongoDBContainer, string) {
+	t.Helper()
+
+	container, err := tcmongo.Run(
+		ctx,
+		"mongo:7",
+		tcmongo.WithReplicaSet("rs0"),
+	)
+	require.NoError(t, err)
+
+	mongoURI, err := container.ConnectionString(ctx)
+	require.NoError(t, err)
+	u, err := url.Parse(mongoURI)
+	require.NoError(t, err)
+	q := u.Query()
+	q.Set("directConnection", "true")
+	u.RawQuery = q.Encode()
+
+	return container, u.String()
+}
+
+func mongodbCDCURI(t *testing.T, baseURI, database string, params map[string]string) string {
+	t.Helper()
+
+	u, err := url.Parse(baseURI)
+	require.NoError(t, err)
+	switch u.Scheme {
+	case "mongodb":
+		u.Scheme = "mongodb+cdc"
+	case "mongodb+srv":
+		u.Scheme = "mongodb+srv+cdc"
+	default:
+		t.Fatalf("unexpected MongoDB URI scheme: %s", u.Scheme)
+	}
+	u.Path = "/" + database
+
+	q := u.Query()
+	for key, value := range params {
+		q.Set(key, value)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func TestMongoDBCDC_SnapshotAndIncremental_SQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	container, mongoURI := setupMongoDBCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Disconnect(ctx) })
+
+	coll := client.Database("cdc").Collection("items")
+	_, err = coll.InsertMany(ctx, []any{
+		bson.M{"_id": int64(1), "name": "item1", "value": int64(100)},
+		bson.M{"_id": int64(2), "name": "item2", "value": int64(200)},
+		bson.M{"_id": int64(3), "name": "item3", "value": int64(300)},
+	})
+	require.NoError(t, err)
+
+	sqlitePath := filepath.Join(t.TempDir(), "mongodb_cdc.db")
+	cfg := &config.IngestConfig{
+		SourceURI:   mongodbCDCURI(t, mongoURI, "cdc", map[string]string{"mode": "batch", "max_await_time": "500ms"}),
+		SourceTable: "cdc.items",
+		DestURI:     "sqlite:///" + sqlitePath,
+		DestTable:   "items_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	dest, err := sql.Open("sqlite3", sqlitePath)
+	require.NoError(t, err)
+	defer func() { _ = dest.Close() }()
+
+	count := func(where string) int {
+		t.Helper()
+		query := `SELECT COUNT(*) FROM items_dest`
+		if where != "" {
+			query += ` WHERE ` + where
+		}
+		var n int
+		require.NoError(t, dest.QueryRow(query).Scan(&n))
+		return n
+	}
+
+	assert.Equal(t, 3, count(""))
+	assert.Equal(t, 3, count(`"_cdc_deleted" = 0`))
+
+	_, err = coll.InsertOne(ctx, bson.M{"_id": int64(4), "name": "item4", "value": int64(400)})
+	require.NoError(t, err)
+	_, err = coll.UpdateOne(ctx, bson.M{"_id": int64(1)}, bson.M{"$set": bson.M{"value": int64(150)}})
+	require.NoError(t, err)
+	_, err = coll.DeleteOne(ctx, bson.M{"_id": int64(2)})
+	require.NoError(t, err)
+	_, err = coll.UpdateOne(ctx, bson.M{"_id": int64(3)}, bson.M{"$set": bson.M{"name": "item3_final", "value": int64(999)}})
+	require.NoError(t, err)
+	_, err = coll.DeleteOne(ctx, bson.M{"_id": int64(3)})
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.Equal(t, 4, count(""))
+	assert.Equal(t, 1, count(`"_id" = 1 AND value = 150 AND "_cdc_deleted" = 0`))
+	assert.Equal(t, 1, count(`"_id" = 2 AND value = 200 AND "_cdc_deleted" = 1`))
+	assert.Equal(t, 1, count(`"_id" = 3 AND "_cdc_deleted" = 1`))
+	assert.Equal(t, 1, count(`"_id" = 4 AND name = 'item4' AND value = 400 AND "_cdc_deleted" = 0`))
+	assert.Greater(t, count(`"_cdc_lsn" IS NOT NULL`), 0)
+}
+
+func TestMongoDBCDC_MultiTableSQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	container, mongoURI := setupMongoDBCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Disconnect(ctx) })
+
+	db := client.Database("cdc_multi")
+	_, err = db.Collection("users").InsertMany(ctx, []any{
+		bson.M{"_id": int64(1), "email": "a@example.com"},
+		bson.M{"_id": int64(2), "email": "b@example.com"},
+	})
+	require.NoError(t, err)
+	_, err = db.Collection("orders").InsertMany(ctx, []any{
+		bson.M{"_id": int64(10), "user_id": int64(1), "total": int64(25)},
+		bson.M{"_id": int64(11), "user_id": int64(2), "total": int64(40)},
+		bson.M{"_id": int64(12), "user_id": int64(2), "total": int64(60)},
+	})
+	require.NoError(t, err)
+
+	sqlitePath := filepath.Join(t.TempDir(), "mongodb_cdc_multi.db")
+	cfg := &config.IngestConfig{
+		SourceURI: mongodbCDCURI(t, mongoURI, "cdc_multi", map[string]string{"mode": "batch", "max_await_time": "500ms"}),
+		DestURI:   "sqlite:///" + sqlitePath,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	dest, err := sql.Open("sqlite3", sqlitePath)
+	require.NoError(t, err)
+	defer func() { _ = dest.Close() }()
+
+	tableCount := func(table string) int {
+		t.Helper()
+		var n int
+		require.NoError(t, dest.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE "_cdc_deleted" = 0`, table)).Scan(&n))
+		return n
+	}
+
+	assert.Equal(t, 2, tableCount("users"))
+	assert.Equal(t, 3, tableCount("orders"))
+}

--- a/tests/mongodb_cdc_manual/run_test.sh
+++ b/tests/mongodb_cdc_manual/run_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MONGO_CONTAINER="${MONGO_CONTAINER:-ingestr_mongodb_cdc}"
+MONGO_PORT="${MONGO_PORT:-27018}"
+DB_NAME="${DB_NAME:-cdc_manual}"
+SQLITE_PATH="${SQLITE_PATH:-/tmp/ingestr_mongodb_cdc_manual.db}"
+SOURCE_URI="mongodb+cdc://localhost:${MONGO_PORT}/${DB_NAME}?directConnection=true&replicaSet=rs0&mode=batch&max_await_time=1s"
+DEST_URI="sqlite:///${SQLITE_PATH}"
+
+cleanup() {
+  docker rm -f "${MONGO_CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cleanup
+rm -f "${SQLITE_PATH}"
+
+docker run -d --name "${MONGO_CONTAINER}" -p "${MONGO_PORT}:27017" mongo:7 --replSet rs0 --bind_ip_all >/dev/null
+
+until docker exec "${MONGO_CONTAINER}" mongosh --quiet --eval 'db.adminCommand("ping").ok' >/dev/null 2>&1; do
+  sleep 1
+done
+
+docker exec "${MONGO_CONTAINER}" mongosh --quiet --eval 'rs.initiate({_id:"rs0",members:[{_id:0,host:"localhost:27017"}]})' >/dev/null || true
+until docker exec "${MONGO_CONTAINER}" mongosh --quiet --eval 'db.hello().isWritablePrimary' | grep -q true; do
+  sleep 1
+done
+
+docker exec "${MONGO_CONTAINER}" mongosh --quiet "${DB_NAME}" --eval '
+db.items.drop();
+db.items.insertMany([
+  {_id: NumberLong(1), name: "item1", value: NumberLong(100)},
+  {_id: NumberLong(2), name: "item2", value: NumberLong(200)},
+  {_id: NumberLong(3), name: "item3", value: NumberLong(300)}
+]);
+' >/dev/null
+
+make build
+
+./bin/ingestr ingest \
+  --source-uri "${SOURCE_URI}" \
+  --source-table "${DB_NAME}.items" \
+  --dest-uri "${DEST_URI}" \
+  --dest-table items_dest \
+  --yes
+
+docker exec "${MONGO_CONTAINER}" mongosh --quiet "${DB_NAME}" --eval '
+db.items.insertOne({_id: NumberLong(4), name: "item4", value: NumberLong(400)});
+db.items.updateOne({_id: NumberLong(1)}, {$set: {value: NumberLong(150)}});
+db.items.deleteOne({_id: NumberLong(2)});
+db.items.updateOne({_id: NumberLong(3)}, {$set: {name: "item3_final", value: NumberLong(999)}});
+db.items.deleteOne({_id: NumberLong(3)});
+' >/dev/null
+
+./bin/ingestr ingest \
+  --source-uri "${SOURCE_URI}" \
+  --source-table "${DB_NAME}.items" \
+  --dest-uri "${DEST_URI}" \
+  --dest-table items_dest \
+  --yes
+
+sqlite3 "${SQLITE_PATH}" <<'SQL'
+.headers on
+.mode column
+SELECT "_id", name, value, "_cdc_deleted", "_cdc_lsn" FROM items_dest ORDER BY "_id";
+SELECT
+  COUNT(*) AS total_rows,
+  SUM(CASE WHEN "_cdc_deleted" = 0 THEN 1 ELSE 0 END) AS active_rows,
+  SUM(CASE WHEN "_cdc_deleted" = 1 THEN 1 ELSE 0 END) AS deleted_rows
+FROM items_dest;
+SQL
+
+echo "Manual MongoDB CDC test complete: ${SQLITE_PATH}"


### PR DESCRIPTION
Adds a MongoDB CDC source with snapshot, resume, batch/stream modes, and multi-table support.
Registers mongodb+cdc schemes, carries streaming flush options into sources, and includes unit, integration, and manual smoke coverage.
Validated with make format, make lint, make test, focused MongoDB CDC integration tests, and the manual Docker smoke script.
