### PR TITLE
Add CLI parity to server UI

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -36,6 +36,11 @@ func ServerCommand() *cli.Command {
 				Value:   "ingestr.db",
 				Sources: cli.EnvVars("INGESTR_DB"),
 			},
+			&cli.StringFlag{
+				Name:    "ingestr-binary",
+				Usage:   "Path to the ingestr binary used by the web UI to run ingestion jobs",
+				Sources: cli.EnvVars("INGESTR_BINARY"),
+			},
 		},
 		Action: runServer,
 	}
@@ -51,10 +56,11 @@ func runServer(ctx context.Context, c *cli.Command) (err error) {
 	credsFile := c.String("creds-file")
 	logsDir := c.String("logs-dir")
 	dbPath := c.String("db")
+	binaryPath := c.String("ingestr-binary")
 
 	trackCommandRunning(ctx, "server", nil)
 
-	s, err := server.New(port, credsFile, logsDir, dbPath)
+	s, err := server.NewWithBinary(port, credsFile, logsDir, dbPath, binaryPath)
 	if err != nil {
 		return err
 	}

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -1,6 +1,9 @@
 package server
 
-import "net/url"
+import (
+	"net/url"
+	"strings"
+)
 
 type ConnectorField struct {
 	Name        string        `json:"name"`
@@ -27,11 +30,11 @@ type ConnectorType struct {
 }
 
 func GetConnectors() []ConnectorType {
-	return []ConnectorType{
+	connectors := []ConnectorType{
 		{
 			ID:            "postgres",
 			Name:          "PostgreSQL",
-			Schemes:       []string{"postgres", "postgresql"},
+			Schemes:       []string{"postgres", "postgresql", "postgresql+psycopg2"},
 			IsSource:      true,
 			IsDestination: true,
 			Fields: []ConnectorField{
@@ -52,7 +55,7 @@ func GetConnectors() []ConnectorType {
 		{
 			ID:            "mysql",
 			Name:          "MySQL",
-			Schemes:       []string{"mysql", "mariadb"},
+			Schemes:       []string{"mysql", "mysql+pymysql", "mariadb"},
 			IsSource:      true,
 			IsDestination: true,
 			Fields: []ConnectorField{
@@ -66,7 +69,7 @@ func GetConnectors() []ConnectorType {
 		{
 			ID:            "mssql",
 			Name:          "SQL Server",
-			Schemes:       []string{"mssql", "sqlserver"},
+			Schemes:       []string{"mssql", "sqlserver", "mssql+pyodbc"},
 			IsSource:      true,
 			IsDestination: true,
 			Fields: []ConnectorField{
@@ -77,6 +80,10 @@ func GetConnectors() []ConnectorType {
 				{Name: "database", Label: "Database", Type: "string", Required: true, Placeholder: "master"},
 			},
 		},
+		genericURIConnector("postgres-cdc", "PostgreSQL CDC", []string{"postgres+cdc", "postgresql+cdc"}, true, false),
+		genericURIConnector("mysql-cdc", "MySQL CDC", []string{"mysql+cdc", "mysql+pymysql+cdc", "mariadb+cdc"}, true, false),
+		genericURIConnector("mssql-cdc", "SQL Server CDC", []string{"mssql+cdc", "sqlserver+cdc", "azuresql+cdc", "azure-sql+cdc"}, true, false),
+		genericURIConnector("mssql-ct", "SQL Server Change Tracking", []string{"mssql+ct", "sqlserver+ct", "azuresql+ct", "azure-sql+ct"}, true, false),
 		{
 			ID:            "azuresql",
 			Name:          "Azure SQL",
@@ -236,6 +243,141 @@ func GetConnectors() []ConnectorType {
 			},
 		},
 	}
+
+	connectors = append(
+		connectors,
+		genericURIConnector("adjust", "Adjust", []string{"adjust"}, true, false),
+		genericURIConnector("airtable", "Airtable", []string{"airtable"}, true, false),
+		genericURIConnector("allium", "Allium", []string{"allium"}, true, false),
+		genericURIConnector("anthropic", "Anthropic", []string{"anthropic"}, true, false),
+		genericURIConnector("apifootball", "API Football", []string{"apifootball"}, true, false),
+		genericURIConnector("appleads", "Apple Ads", []string{"appleads"}, true, false),
+		genericURIConnector("applovin", "AppLovin", []string{"applovin"}, true, false),
+		genericURIConnector("applovinmax", "AppLovin MAX", []string{"applovinmax"}, true, false),
+		genericURIConnector("appsflyer", "AppsFlyer", []string{"appsflyer"}, true, false),
+		genericURIConnector("appstore", "App Store Connect", []string{"appstore"}, true, false),
+		genericURIConnector("arrowstream", "Arrow Stream", []string{"arrow-stream", "arrowstream"}, true, false),
+		genericURIConnector("asana", "Asana", []string{"asana"}, true, false),
+		genericURIConnector("athena", "Amazon Athena", []string{"athena"}, true, true),
+		genericURIConnector("attio", "Attio", []string{"attio"}, true, false),
+		genericURIConnector("avro", "Avro File", []string{"avro"}, true, false),
+		genericURIConnector("balldontlie", "balldontlie", []string{"balldontlie"}, true, false),
+		genericURIConnector("blobstore", "Object Storage", []string{"s3", "gs", "gcs", "az", "azure", "adls", "adlsgen2", "azdatalake", "abfs", "abfss"}, true, true),
+		genericURIConnector("bruin", "Bruin", []string{"bruin"}, true, false),
+		genericURIConnector("chess", "Chess.com", []string{"chess"}, true, false),
+		genericURIConnector("clickhouse", "ClickHouse", []string{"clickhouse"}, true, true),
+		genericURIConnector("clickup", "ClickUp", []string{"clickup"}, true, false),
+		genericURIConnector("couchbase", "Couchbase", []string{"couchbase"}, true, false),
+		genericURIConnector("cratedb", "CrateDB", []string{"cratedb"}, true, true),
+		genericURIConnector("cursor", "Cursor", []string{"cursor"}, true, false),
+		genericURIConnector("customerio", "Customer.io", []string{"customerio"}, true, false),
+		genericURIConnector("databricks", "Databricks", []string{"databricks"}, true, true),
+		genericURIConnector("db2", "Db2", []string{"db2", "ibmdb2"}, true, false),
+		genericURIConnector("discard", "Discard", []string{"discard"}, false, true),
+		genericURIConnector("docebo", "Docebo", []string{"docebo"}, true, false),
+		genericURIConnector("ducklake", "DuckLake", []string{"ducklake"}, true, true),
+		genericURIConnector("dune", "Dune", []string{"dune"}, true, false),
+		genericURIConnector("dynamodb", "DynamoDB", []string{"dynamodb"}, true, true),
+		genericURIConnector("elasticsearch", "Elasticsearch", []string{"elasticsearch"}, true, true),
+		genericURIConnector("espn", "ESPN", []string{"espn"}, true, false),
+		genericURIConnector("fabric", "Microsoft Fabric", []string{"fabric"}, true, true),
+		genericURIConnector("facebookads", "Facebook Ads", []string{"facebookads"}, true, false),
+		genericURIConnector("fireflies", "Fireflies", []string{"fireflies"}, true, false),
+		genericURIConnector("fluxx", "Fluxx", []string{"fluxx"}, true, false),
+		genericURIConnector("footballdata", "Football Data", []string{"footballdata"}, true, false),
+		genericURIConnector("frankfurter", "Frankfurter", []string{"frankfurter"}, true, false),
+		genericURIConnector("freshdesk", "Freshdesk", []string{"freshdesk"}, true, false),
+		genericURIConnector("fundraiseup", "Fundraise Up", []string{"fundraiseup"}, true, false),
+		genericURIConnector("g2", "G2", []string{"g2"}, true, false),
+		genericURIConnector("github", "GitHub", []string{"github"}, true, false),
+		genericURIConnector("googleanalytics", "Google Analytics", []string{"googleanalytics"}, true, false),
+		genericURIConnector("googleads", "Google Ads", []string{"googleads"}, true, false),
+		genericURIConnector("gsheets", "Google Sheets", []string{"gsheets"}, true, false),
+		genericURIConnector("gorgias", "Gorgias", []string{"gorgias"}, true, false),
+		genericURIConnector("granola", "Granola", []string{"granola"}, true, false),
+		genericURIConnector("hostaway", "Hostaway", []string{"hostaway"}, true, false),
+		genericURIConnector("http", "HTTP", []string{"http", "https"}, true, false),
+		genericURIConnector("hubspot", "HubSpot", []string{"hubspot"}, true, false),
+		genericURIConnector("indeed", "Indeed", []string{"indeed"}, true, false),
+		genericURIConnector("influxdb", "InfluxDB", []string{"influxdb"}, true, false),
+		genericURIConnector("intercom", "Intercom", []string{"intercom"}, true, false),
+		genericURIConnector("isoc-pulse", "ISOC Pulse", []string{"isoc-pulse"}, true, false),
+		genericURIConnector("jira", "Jira", []string{"jira"}, true, false),
+		genericURIConnector("jobtread", "JobTread", []string{"jobtread"}, true, false),
+		genericURIConnector("json", "JSON File", []string{"json"}, true, false),
+		genericURIConnector("kafka", "Kafka", []string{"kafka"}, true, false),
+		genericURIConnector("kalshi", "Kalshi", []string{"kalshi"}, true, false),
+		genericURIConnector("kinesis", "Kinesis", []string{"kinesis"}, true, false),
+		genericURIConnector("klaviyo", "Klaviyo", []string{"klaviyo"}, true, false),
+		genericURIConnector("linear", "Linear", []string{"linear"}, true, false),
+		genericURIConnector("linkedinads", "LinkedIn Ads", []string{"linkedinads"}, true, false),
+		genericURIConnector("mailchimp", "Mailchimp", []string{"mailchimp"}, true, false),
+		genericURIConnector("manifold", "Manifold", []string{"manifold"}, true, false),
+		genericURIConnector("maxcompute", "MaxCompute", []string{"maxcompute", "odps"}, true, true),
+		genericURIConnector("mixpanel", "Mixpanel", []string{"mixpanel"}, true, false),
+		genericURIConnector("mmap", "Memory-mapped File", []string{"mmap"}, true, false),
+		genericURIConnector("monday", "monday.com", []string{"monday"}, true, false),
+		genericURIConnector("motherduck", "MotherDuck", []string{"motherduck", "md"}, true, true),
+		genericURIConnector("notion", "Notion", []string{"notion"}, true, false),
+		genericURIConnector("onelake", "OneLake", []string{"onelake"}, false, true),
+		genericURIConnector("oracle", "Oracle", []string{"oracle", "oracle+cx_oracle"}, true, false),
+		genericURIConnector("paddle", "Paddle", []string{"paddle"}, true, false),
+		genericURIConnector("personio", "Personio", []string{"personio"}, true, false),
+		genericURIConnector("phantombuster", "PhantomBuster", []string{"phantombuster"}, true, false),
+		genericURIConnector("pinterest", "Pinterest", []string{"pinterest"}, true, false),
+		genericURIConnector("pipedrive", "Pipedrive", []string{"pipedrive"}, true, false),
+		genericURIConnector("plusvibeai", "PlusVibe AI", []string{"plusvibeai"}, true, false),
+		genericURIConnector("polymarket", "Polymarket", []string{"polymarket"}, true, false),
+		genericURIConnector("posthog", "PostHog", []string{"posthog"}, true, false),
+		genericURIConnector("primer", "Primer", []string{"primer"}, true, false),
+		genericURIConnector("pubsub", "Pub/Sub", []string{"pubsub"}, true, false),
+		genericURIConnector("quickbooks", "QuickBooks", []string{"quickbooks"}, true, false),
+		genericURIConnector("rabbitmq", "RabbitMQ", []string{"amqp", "amqps"}, true, false),
+		genericURIConnector("redshift", "Redshift", []string{"redshift", "redshift+psycopg2"}, true, true),
+		genericURIConnector("revenuecat", "RevenueCat", []string{"revenuecat"}, true, false),
+		genericURIConnector("salesforce", "Salesforce", []string{"salesforce"}, true, false),
+		genericURIConnector("sendgrid", "SendGrid", []string{"sendgrid"}, true, false),
+		genericURIConnector("sharepoint", "SharePoint", []string{"sharepoint"}, true, false),
+		genericURIConnector("shopify", "Shopify", []string{"shopify"}, true, false),
+		genericURIConnector("slack", "Slack", []string{"slack"}, true, false),
+		genericURIConnector("smartsheet", "Smartsheet", []string{"smartsheet"}, true, false),
+		genericURIConnector("snapchatads", "Snapchat Ads", []string{"snapchatads"}, true, false),
+		genericURIConnector("socrata", "Socrata", []string{"socrata"}, true, false),
+		genericURIConnector("solidgate", "Solidgate", []string{"solidgate"}, true, false),
+		genericURIConnector("spanner", "Spanner", []string{"spanner"}, true, false),
+		genericURIConnector("sqs", "SQS", []string{"sqs"}, true, false),
+		genericURIConnector("stripe", "Stripe", []string{"stripe"}, true, false),
+		genericURIConnector("surveymonkey", "SurveyMonkey", []string{"surveymonkey"}, true, false),
+		genericURIConnector("synapse", "Azure Synapse", []string{"synapse"}, false, true),
+		genericURIConnector("tiktok", "TikTok Ads", []string{"tiktok"}, true, false),
+		genericURIConnector("trino", "Trino", []string{"trino"}, true, true),
+		genericURIConnector("trustpilot", "Trustpilot", []string{"trustpilot"}, true, false),
+		genericURIConnector("wise", "Wise", []string{"wise"}, true, false),
+		genericURIConnector("wistia", "Wistia", []string{"wistia"}, true, false),
+		genericURIConnector("zendesk", "Zendesk", []string{"zendesk"}, true, false),
+		genericURIConnector("zoom", "Zoom", []string{"zoom"}, true, false),
+	)
+
+	return connectors
+}
+
+func genericURIConnector(id string, name string, schemes []string, isSource bool, isDestination bool) ConnectorType {
+	return ConnectorType{
+		ID:            id,
+		Name:          name,
+		Schemes:       schemes,
+		IsSource:      isSource,
+		IsDestination: isDestination,
+		Fields: []ConnectorField{
+			{
+				Name:        "uri",
+				Label:       "URI",
+				Type:        "string",
+				Required:    true,
+				Placeholder: schemes[0] + "://...",
+			},
+		},
+	}
 }
 
 func GetConnectorByID(id string) *ConnectorType {
@@ -248,6 +390,10 @@ func GetConnectorByID(id string) *ConnectorType {
 }
 
 func BuildURI(connectorID string, fields map[string]string) string {
+	if raw := strings.TrimSpace(fields["uri"]); raw != "" {
+		return raw
+	}
+
 	switch connectorID {
 	case "postgres":
 		return buildStandardURI("postgres", fields, "5432")

--- a/internal/server/connectors_test.go
+++ b/internal/server/connectors_test.go
@@ -2,6 +2,10 @@ package server
 
 import (
 	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -59,4 +63,104 @@ func TestBuildAzureSQLURI(t *testing.T) {
 	if got := query.Get("tenant_id"); got != "tenant-123" {
 		t.Errorf("tenant_id = %q, want tenant-123", got)
 	}
+}
+
+func TestBuildURIRawPassthrough(t *testing.T) {
+	got := BuildURI("any", map[string]string{"uri": "  trino://user:pass@host/catalog/schema  "})
+	if got != "trino://user:pass@host/catalog/schema" {
+		t.Fatalf("raw URI = %q", got)
+	}
+}
+
+func TestConnectorCatalogCoversRegisteredSchemes(t *testing.T) {
+	catalog := map[string]ConnectorType{}
+	for _, connector := range GetConnectors() {
+		for _, scheme := range connector.Schemes {
+			catalog[scheme] = connector
+		}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		dir        string
+		registerFn string
+		capable    func(ConnectorType) bool
+	}{
+		{
+			name:       "sources",
+			dir:        filepath.Join("..", "..", "pkg", "source"),
+			registerFn: "registry.RegisterSource",
+			capable:    func(c ConnectorType) bool { return c.IsSource },
+		},
+		{
+			name:       "destinations",
+			dir:        filepath.Join("..", "..", "pkg", "destination"),
+			registerFn: "registry.RegisterDestination",
+			capable:    func(c ConnectorType) bool { return c.IsDestination },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, scheme := range registeredSchemes(t, tc.dir, tc.registerFn) {
+				connector, ok := catalog[scheme]
+				if !ok {
+					t.Errorf("scheme %q is missing from connector catalog", scheme)
+					continue
+				}
+				if !tc.capable(connector) {
+					t.Errorf("scheme %q is registered but connector %q has wrong capability", scheme, connector.ID)
+				}
+			}
+		})
+	}
+}
+
+func registeredSchemes(t *testing.T, dir string, registerFn string) []string {
+	t.Helper()
+
+	files, err := filepath.Glob(filepath.Join(dir, "*", "register.go"))
+	if err != nil {
+		t.Fatalf("glob register files: %v", err)
+	}
+
+	quoted := regexp.MustCompile(`"([^"]+)"`)
+	seen := map[string]bool{}
+	var schemes []string
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		content := string(data)
+		offset := 0
+		for {
+			call := strings.Index(content[offset:], registerFn)
+			if call == -1 {
+				break
+			}
+			call += offset
+			listStart := strings.Index(content[call:], "[]string{")
+			if listStart == -1 {
+				t.Fatalf("%s has %s without a literal []string registration", file, registerFn)
+			}
+			listStart += call
+			listEnd := strings.Index(content[listStart:], "}")
+			if listEnd == -1 {
+				t.Fatalf("%s has an unterminated scheme list for %s", file, registerFn)
+			}
+			listEnd += listStart
+			matches := quoted.FindAllStringSubmatch(content[listStart:listEnd], -1)
+			if len(matches) == 0 {
+				t.Fatalf("%s has %s without quoted schemes", file, registerFn)
+			}
+			for _, match := range matches {
+				scheme := match[1]
+				if !seen[scheme] {
+					seen[scheme] = true
+					schemes = append(schemes, scheme)
+				}
+			}
+			offset = listEnd + 1
+		}
+	}
+	return schemes
 }

--- a/internal/server/ingest_request.go
+++ b/internal/server/ingest_request.go
@@ -1,0 +1,115 @@
+package server
+
+import "strconv"
+
+type RunJobRequest struct {
+	SourceCredentialID string `json:"sourceCredentialId"`
+	DestCredentialID   string `json:"destCredentialId"`
+	SourceURI          string `json:"sourceUri"`
+	DestURI            string `json:"destUri"`
+	SourceTable        string `json:"sourceTable"`
+	DestTable          string `json:"destTable"`
+
+	IncrementalStrategy string   `json:"incrementalStrategy"`
+	Strategy            string   `json:"strategy"`
+	IncrementalKey      string   `json:"incrementalKey"`
+	IntervalStart       string   `json:"intervalStart"`
+	IntervalEnd         string   `json:"intervalEnd"`
+	PrimaryKeys         []string `json:"primaryKeys"`
+
+	PartitionBy string `json:"partitionBy"`
+	ClusterBy   string `json:"clusterBy"`
+
+	FullRefresh      bool   `json:"fullRefresh"`
+	SchemaContract   string `json:"schemaContract"`
+	SchemaNaming     string `json:"schemaNaming"`
+	Progress         string `json:"progress"`
+	PageSize         int    `json:"pageSize"`
+	LoaderFileSize   int    `json:"loaderFileSize"`
+	LoaderFileFormat string `json:"loaderFileFormat"`
+
+	ExtractParallelism int      `json:"extractParallelism"`
+	SQLLimit           int      `json:"sqlLimit"`
+	SQLExcludeColumns  []string `json:"sqlExcludeColumns"`
+	SQLBackend         []string `json:"sqlBackend"`
+	Columns            string   `json:"columns"`
+	NoInference        bool     `json:"noInference"`
+	Mask               []string `json:"mask"`
+	TrimWhitespace     bool     `json:"trimWhitespace"`
+	NoLoadTimestamp    bool     `json:"noLoadTimestamp"`
+
+	PipelinesDir     string `json:"pipelinesDir"`
+	StagingBucket    string `json:"stagingBucket"`
+	StagingDataset   string `json:"stagingDataset"`
+	Debug            bool   `json:"debug"`
+	Stream           bool   `json:"stream"`
+	FlushInterval    string `json:"flushInterval"`
+	FlushRecords     int    `json:"flushRecords"`
+	QueryAnnotations string `json:"queryAnnotations"`
+}
+
+func (r RunJobRequest) IngestArgs() []string {
+	args := []string{}
+	appendString := func(name, value string) {
+		if value != "" {
+			args = append(args, "--"+name+"="+value)
+		}
+	}
+	appendInt := func(name string, value int) {
+		if value > 0 {
+			args = append(args, "--"+name+"="+strconv.Itoa(value))
+		}
+	}
+	appendBool := func(name string, value bool) {
+		if value {
+			args = append(args, "--"+name)
+		}
+	}
+	appendStringSlice := func(name string, values []string) {
+		for _, value := range values {
+			if value != "" {
+				args = append(args, "--"+name+"="+value)
+			}
+		}
+	}
+
+	appendString("source-uri", r.SourceURI)
+	appendString("dest-uri", r.DestURI)
+	appendString("source-table", r.SourceTable)
+	appendString("dest-table", r.DestTable)
+	appendString("incremental-key", r.IncrementalKey)
+	appendString("incremental-strategy", r.IncrementalStrategy)
+	appendString("interval-start", r.IntervalStart)
+	appendString("interval-end", r.IntervalEnd)
+	appendStringSlice("primary-key", r.PrimaryKeys)
+	appendString("partition-by", r.PartitionBy)
+	appendString("cluster-by", r.ClusterBy)
+	appendBool("full-refresh", r.FullRefresh)
+	appendString("schema-contract", r.SchemaContract)
+	appendString("schema-naming", r.SchemaNaming)
+	appendString("progress", r.Progress)
+	appendInt("page-size", r.PageSize)
+	appendInt("loader-file-size", r.LoaderFileSize)
+	appendString("loader-file-format", r.LoaderFileFormat)
+	appendInt("extract-parallelism", r.ExtractParallelism)
+	appendInt("sql-limit", r.SQLLimit)
+	appendStringSlice("sql-exclude-columns", r.SQLExcludeColumns)
+	appendStringSlice("sql-backend", r.SQLBackend)
+	appendString("columns", r.Columns)
+	appendBool("no-inference", r.NoInference)
+	appendStringSlice("mask", r.Mask)
+	appendBool("trim-whitespace", r.TrimWhitespace)
+	appendBool("no-load-timestamp", r.NoLoadTimestamp)
+	appendString("pipelines-dir", r.PipelinesDir)
+	appendString("staging-bucket", r.StagingBucket)
+	appendString("staging-dataset", r.StagingDataset)
+	appendBool("debug", r.Debug)
+	appendBool("stream", r.Stream)
+	appendString("flush-interval", r.FlushInterval)
+	appendInt("flush-records", r.FlushRecords)
+	appendString("query-annotations", r.QueryAnnotations)
+
+	args = append(args, "--yes")
+
+	return args
+}

--- a/internal/server/ingest_request_test.go
+++ b/internal/server/ingest_request_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRunJobRequestIngestArgs(t *testing.T) {
+	req := RunJobRequest{
+		SourceURI:           "postgres://user:pass@localhost/db",
+		DestURI:             "duckdb:///tmp/out.db",
+		SourceTable:         "public.users",
+		DestTable:           "raw.users",
+		IncrementalStrategy: "merge",
+		IncrementalKey:      "updated_at",
+		IntervalStart:       "2026-01-01",
+		IntervalEnd:         "2026-01-02",
+		PrimaryKeys:         []string{"id", "tenant_id"},
+		PartitionBy:         "created_at",
+		ClusterBy:           "tenant_id,region",
+		FullRefresh:         true,
+		SchemaContract:      "freeze",
+		SchemaNaming:        "snake_case",
+		Progress:            "log",
+		PageSize:            1000,
+		LoaderFileSize:      2000,
+		LoaderFileFormat:    "parquet",
+		ExtractParallelism:  3,
+		SQLLimit:            10,
+		SQLExcludeColumns:   []string{"password", "token"},
+		SQLBackend:          []string{"adbc"},
+		Columns:             "id:bigint,email:string",
+		NoInference:         true,
+		Mask:                []string{"email:email", "phone:phone"},
+		TrimWhitespace:      true,
+		NoLoadTimestamp:     true,
+		PipelinesDir:        ".ingestr",
+		StagingBucket:       "s3://bucket/path",
+		StagingDataset:      "staging",
+		Debug:               true,
+		Stream:              true,
+		FlushInterval:       "15s",
+		FlushRecords:        500,
+		QueryAnnotations:    `{"pipeline":"daily"}`,
+	}
+
+	got := req.IngestArgs()
+	want := []string{
+		"--source-uri=postgres://user:pass@localhost/db",
+		"--dest-uri=duckdb:///tmp/out.db",
+		"--source-table=public.users",
+		"--dest-table=raw.users",
+		"--incremental-key=updated_at",
+		"--incremental-strategy=merge",
+		"--interval-start=2026-01-01",
+		"--interval-end=2026-01-02",
+		"--primary-key=id",
+		"--primary-key=tenant_id",
+		"--partition-by=created_at",
+		"--cluster-by=tenant_id,region",
+		"--full-refresh",
+		"--schema-contract=freeze",
+		"--schema-naming=snake_case",
+		"--progress=log",
+		"--page-size=1000",
+		"--loader-file-size=2000",
+		"--loader-file-format=parquet",
+		"--extract-parallelism=3",
+		"--sql-limit=10",
+		"--sql-exclude-columns=password",
+		"--sql-exclude-columns=token",
+		"--sql-backend=adbc",
+		"--columns=id:bigint,email:string",
+		"--no-inference",
+		"--mask=email:email",
+		"--mask=phone:phone",
+		"--trim-whitespace",
+		"--no-load-timestamp",
+		"--pipelines-dir=.ingestr",
+		"--staging-bucket=s3://bucket/path",
+		"--staging-dataset=staging",
+		"--debug",
+		"--stream",
+		"--flush-interval=15s",
+		"--flush-records=500",
+		`--query-annotations={"pipeline":"daily"}`,
+		"--yes",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -1,17 +1,21 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
-	"github.com/bruin-data/ingestr/internal/config"
-	"github.com/bruin-data/ingestr/pkg/pipeline"
 	"github.com/google/uuid"
 )
 
@@ -21,6 +25,14 @@ type LogEntry struct {
 	Message   string    `json:"message"`
 }
 
+const (
+	maxBufferedLogEntries       = 10_000
+	maxPendingPersistLogEntries = 10_000
+	logChannelHeadroom          = 100
+	logStreamLagWarning         = "Log stream fell behind; some live log lines were skipped. Reconnect to replay recent buffered logs."
+	logPersistenceLagWarning    = "Log persistence fell behind; %d log line(s) were skipped in file/database logs."
+)
+
 type Job struct {
 	ID        string     `json:"id"`
 	Status    string     `json:"status"`
@@ -29,26 +41,53 @@ type Job struct {
 	Error     string     `json:"error,omitempty"`
 }
 
+type JobSpec struct {
+	Args        []string
+	SourceURI   string
+	DestURI     string
+	SourceTable string
+	DestTable   string
+	Strategy    string
+}
+
+type logSink struct {
+	mu        sync.Mutex
+	cond      *sync.Cond
+	entries   []LogEntry
+	head      int
+	dropped   int
+	droppedAt time.Time
+	closed    bool
+	done      chan struct{}
+	file      *os.File
+}
+
 type JobManager struct {
 	jobs        sync.Map
 	logSubs     sync.Map
 	logBuffers  sync.Map // jobID -> []LogEntry
 	jobFinished sync.Map // jobID -> bool
-	logFiles    sync.Map // jobID -> *os.File
+	logSinks    sync.Map // jobID -> *logSink
+	logMu       sync.Mutex
+	cancels     sync.Map // jobID -> context.CancelFunc
 	logsDir     string
 	repo        RunRepository
-	configs     sync.Map // jobID -> *config.IngestConfig (for storing run metadata)
+	binaryPath  string
 }
 
-func NewJobManager(logsDir string, repo RunRepository) *JobManager {
+func NewJobManager(logsDir string, repo RunRepository, binaryPath string) *JobManager {
 	if logsDir == "" {
 		logsDir = "logs"
 	}
 	_ = os.MkdirAll(logsDir, 0o755)
-	return &JobManager{logsDir: logsDir, repo: repo}
+	return &JobManager{logsDir: logsDir, repo: repo, binaryPath: binaryPath}
 }
 
-func (jm *JobManager) StartJob(ctx context.Context, cfg *config.IngestConfig) (string, error) {
+func (jm *JobManager) StartJob(ctx context.Context, spec JobSpec) (string, error) {
+	if len(spec.Args) == 0 {
+		return "", fmt.Errorf("job args are required")
+	}
+
 	jobID := uuid.NewString()
 	now := time.Now()
 
@@ -58,38 +97,45 @@ func (jm *JobManager) StartJob(ctx context.Context, cfg *config.IngestConfig) (s
 		StartedAt: now,
 	}
 	jm.jobs.Store(jobID, job)
-	jm.configs.Store(jobID, cfg)
 
-	// Store run in repository
 	if jm.repo != nil {
 		run := &RunRecord{
 			ID:          jobID,
 			Status:      "running",
-			SourceURI:   maskURI(cfg.SourceURI),
-			DestURI:     maskURI(cfg.DestURI),
-			SourceTable: cfg.SourceTable,
-			DestTable:   cfg.DestTable,
-			Strategy:    string(cfg.IncrementalStrategy),
+			SourceURI:   maskURI(spec.SourceURI),
+			DestURI:     maskURI(spec.DestURI),
+			SourceTable: spec.SourceTable,
+			DestTable:   spec.DestTable,
+			Strategy:    spec.Strategy,
 			StartedAt:   now,
 		}
 		_ = jm.repo.CreateRun(ctx, run)
 	}
 
-	// Create log file for this job
 	logPath := filepath.Join(jm.logsDir, jobID+".jsonl")
 	logFile, err := os.Create(logPath)
-	if err == nil {
-		jm.logFiles.Store(jobID, logFile)
+	if err == nil || jm.repo != nil {
+		jm.startLogSink(jobID, logFile)
+	}
+	if err != nil {
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "warning",
+			Message:   fmt.Sprintf("Failed to create log file: %v", err),
+		})
 	}
 
-	// Use a background context for the job since the HTTP request context
-	// will be canceled when the response is sent
-	go jm.runJob(context.Background(), jobID, cfg)
+	jobCtx, cancel := context.WithCancel(context.Background())
+	jm.cancels.Store(jobID, cancel)
+	go func() {
+		defer cancel()
+		jm.runJob(jobCtx, jobID, spec)
+	}()
 
 	return jobID, nil
 }
 
-func (jm *JobManager) runJob(ctx context.Context, jobID string, cfg *config.IngestConfig) {
+func (jm *JobManager) runJob(ctx context.Context, jobID string, spec JobSpec) {
 	defer func() {
 		if r := recover(); r != nil {
 			jm.updateJob(jobID, "failed", fmt.Sprintf("panic: %v", r))
@@ -105,30 +151,89 @@ func (jm *JobManager) runJob(ctx context.Context, jobID string, cfg *config.Inge
 	jm.broadcastLog(jobID, LogEntry{
 		Timestamp: time.Now(),
 		Level:     "info",
-		Message:   fmt.Sprintf("Starting ingestion from %s to %s", maskURI(cfg.SourceURI), maskURI(cfg.DestURI)),
+		Message:   fmt.Sprintf("Starting ingestion from %s to %s", maskURI(spec.SourceURI), maskURI(spec.DestURI)),
 	})
 	jm.broadcastLog(jobID, LogEntry{
 		Timestamp: time.Now(),
 		Level:     "info",
-		Message:   fmt.Sprintf("Source table: %s, Destination table: %s", cfg.SourceTable, cfg.DestTable),
-	})
-	jm.broadcastLog(jobID, LogEntry{
-		Timestamp: time.Now(),
-		Level:     "info",
-		Message:   fmt.Sprintf("Strategy: %s", cfg.IncrementalStrategy),
+		Message:   fmt.Sprintf("Source table: %s, Destination table: %s", spec.SourceTable, spec.DestTable),
 	})
 
-	cfg.Progress = config.ProgressLog
-
-	logWriter := &jobLogWriter{
-		jobID:   jobID,
-		manager: jm,
+	binary, err := jm.ingestrBinary()
+	if err != nil {
+		jm.updateJob(jobID, "failed", err.Error())
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   fmt.Sprintf("Job failed: %v", err),
+		})
+		return
 	}
 
-	p := pipeline.New(cfg)
-	p.SetLogWriter(logWriter)
+	commandArgs := append([]string{"ingest"}, omitURIArgs(spec.Args)...)
+	message := fmt.Sprintf("Executing: %s %s", binary, strings.Join(maskCLIArgs(commandArgs), " "))
+	if spec.SourceURI != "" || spec.DestURI != "" {
+		message += " (source/destination URI supplied via environment)"
+	}
+	jm.broadcastLog(jobID, LogEntry{
+		Timestamp: time.Now(),
+		Level:     "info",
+		Message:   message,
+	})
 
-	if err := p.Run(ctx); err != nil {
+	cmd := exec.CommandContext(ctx, binary, commandArgs...)
+	cmd.Cancel = gracefulCancel(cmd)
+	cmd.WaitDelay = 10 * time.Second
+	cmd.Env = commandEnv(spec)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		jm.updateJob(jobID, "failed", err.Error())
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   fmt.Sprintf("Job failed: %v", err),
+		})
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		jm.updateJob(jobID, "failed", err.Error())
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   fmt.Sprintf("Job failed: %v", err),
+		})
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		jm.updateJob(jobID, "failed", err.Error())
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   fmt.Sprintf("Job failed: %v", err),
+		})
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go jm.streamCommandOutput(ctx, jobID, stdout, "info", spec, &wg)
+	go jm.streamCommandOutput(ctx, jobID, stderr, "info", spec, &wg)
+
+	wg.Wait()
+	err = cmd.Wait()
+	if errors.Is(ctx.Err(), context.Canceled) {
+		jm.updateJob(jobID, "canceled", "")
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "warning",
+			Message:   "Ingestion canceled.",
+		})
+		return
+	}
+	if err != nil {
 		jm.updateJob(jobID, "failed", err.Error())
 		jm.broadcastLog(jobID, LogEntry{
 			Timestamp: time.Now(),
@@ -146,12 +251,232 @@ func (jm *JobManager) runJob(ctx context.Context, jobID string, cfg *config.Inge
 	})
 }
 
+func (jm *JobManager) ingestrBinary() (string, error) {
+	if jm.binaryPath != "" {
+		return jm.binaryPath, nil
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve current executable: %w", err)
+	}
+	return binary, nil
+}
+
+func (jm *JobManager) startLogSink(jobID string, file *os.File) {
+	sink := newLogSink(file)
+	jm.logSinks.Store(jobID, sink)
+	go jm.persistLogs(jobID, sink)
+}
+
+func newLogSink(file *os.File) *logSink {
+	sink := &logSink{
+		done: make(chan struct{}),
+		file: file,
+	}
+	sink.cond = sync.NewCond(&sink.mu)
+	return sink
+}
+
+func (jm *JobManager) persistLogs(jobID string, sink *logSink) {
+	defer close(sink.done)
+	defer func() {
+		if sink.file != nil {
+			_ = sink.file.Close()
+		}
+	}()
+
+	for {
+		entry, ok := sink.next()
+		if !ok {
+			return
+		}
+		if sink.file != nil {
+			line, _ := json.Marshal(entry)
+			_, _ = sink.file.Write(append(line, '\n'))
+		}
+
+		if jm.repo != nil {
+			logRecord := &LogRecord{
+				RunID:     jobID,
+				Timestamp: entry.Timestamp,
+				Level:     entry.Level,
+				Message:   entry.Message,
+			}
+			_ = jm.repo.AddLog(context.Background(), logRecord)
+		}
+	}
+}
+
+func (s *logSink) enqueue(entry LogEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return
+	}
+	if s.pending() >= maxPendingPersistLogEntries {
+		s.dropOldest()
+		s.dropped++
+		s.droppedAt = entry.Timestamp
+	}
+	s.entries = append(s.entries, entry)
+	s.cond.Signal()
+}
+
+func (s *logSink) next() (LogEntry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for s.pending() == 0 && s.dropped == 0 && !s.closed {
+		s.cond.Wait()
+	}
+	if s.dropped > 0 {
+		entry := LogEntry{
+			Timestamp: s.droppedAt,
+			Level:     "warning",
+			Message:   fmt.Sprintf(logPersistenceLagWarning, s.dropped),
+		}
+		if entry.Timestamp.IsZero() {
+			entry.Timestamp = time.Now()
+		}
+		s.dropped = 0
+		s.droppedAt = time.Time{}
+		return entry, true
+	}
+	if s.pending() == 0 {
+		return LogEntry{}, false
+	}
+
+	entry := s.entries[s.head]
+	s.entries[s.head] = LogEntry{}
+	s.head++
+	s.compact()
+	return entry, true
+}
+
+func (s *logSink) pending() int {
+	return len(s.entries) - s.head
+}
+
+func (s *logSink) dropOldest() {
+	if s.pending() == 0 {
+		return
+	}
+	s.entries[s.head] = LogEntry{}
+	s.head++
+	s.compact()
+}
+
+func (s *logSink) compact() {
+	if s.head > 1024 && s.head*2 >= len(s.entries) {
+		copy(s.entries, s.entries[s.head:])
+		s.entries = s.entries[:len(s.entries)-s.head]
+		s.head = 0
+	}
+}
+
+func (s *logSink) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closed = true
+	s.cond.Broadcast()
+}
+
+func (jm *JobManager) streamCommandOutput(ctx context.Context, jobID string, reader io.Reader, level string, spec JobSpec, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		message := redactCommandOutput(strings.TrimRight(scanner.Text(), "\r"), spec)
+		if strings.TrimSpace(message) == "" {
+			continue
+		}
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     level,
+			Message:   message,
+		})
+	}
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   fmt.Sprintf("failed to read command output: %v", err),
+		})
+	}
+}
+
+func redactCommandOutput(message string, spec JobSpec) string {
+	for _, rawURI := range []string{spec.SourceURI, spec.DestURI} {
+		if rawURI == "" {
+			continue
+		}
+		message = strings.ReplaceAll(message, rawURI, maskURI(rawURI))
+	}
+	return message
+}
+
+func gracefulCancel(cmd *exec.Cmd) func() error {
+	return func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if runtime.GOOS == "windows" {
+			return cmd.Process.Kill()
+		}
+		return cmd.Process.Signal(os.Interrupt)
+	}
+}
+
+func commandEnv(spec JobSpec) []string {
+	overrides := []struct {
+		key   string
+		value string
+	}{
+		{key: "DISABLE_TELEMETRY", value: "true"},
+		{key: "INGESTR_DISABLE_TELEMETRY", value: "true"},
+		{key: "SOURCE_URI", value: spec.SourceURI},
+		{key: "INGESTR_SOURCE_URI", value: spec.SourceURI},
+		{key: "DESTINATION_URI", value: spec.DestURI},
+		{key: "INGESTR_DESTINATION_URI", value: spec.DestURI},
+		{key: "NO_COLOR", value: "1"},
+	}
+
+	overrideIndex := make(map[string]int, len(overrides))
+	for i, override := range overrides {
+		overrideIndex[override.key] = i
+	}
+
+	seen := make([]bool, len(overrides))
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if index, ok := overrideIndex[key]; ok {
+			if !seen[index] {
+				env = append(env, key+"="+overrides[index].value)
+				seen[index] = true
+			}
+			continue
+		}
+		env = append(env, entry)
+	}
+	for i, override := range overrides {
+		if !seen[i] {
+			env = append(env, override.key+"="+override.value)
+		}
+	}
+	return env
+}
+
 func (jm *JobManager) updateJob(jobID string, status string, errMsg string) {
 	var endedAt *time.Time
 	if val, ok := jm.jobs.Load(jobID); ok {
-		job := val.(*Job)
+		current := val.(*Job)
+		job := *current
 		job.Status = status
-		if status == "completed" || status == "failed" {
+		if status == "completed" || status == "failed" || status == "canceled" {
 			now := time.Now()
 			job.EndedAt = &now
 			endedAt = &now
@@ -159,6 +484,7 @@ func (jm *JobManager) updateJob(jobID string, status string, errMsg string) {
 		if errMsg != "" {
 			job.Error = errMsg
 		}
+		jm.jobs.Store(jobID, &job)
 	}
 
 	// Update repository
@@ -173,31 +499,51 @@ func (jm *JobManager) updateJob(jobID string, status string, errMsg string) {
 	}
 }
 
+func (jm *JobManager) CancelJob(id string) bool {
+	val, ok := jm.cancels.Load(id)
+	if !ok {
+		return false
+	}
+	cancel := val.(context.CancelFunc)
+	cancel()
+	return true
+}
+
 func (jm *JobManager) GetJob(id string) (*Job, bool) {
 	if val, ok := jm.jobs.Load(id); ok {
-		return val.(*Job), true
+		job := *val.(*Job)
+		return &job, true
 	}
 	return nil, false
 }
 
 func (jm *JobManager) SubscribeLogs(jobID string) chan LogEntry {
-	ch := make(chan LogEntry, 100)
+	jm.logMu.Lock()
+	defer jm.logMu.Unlock()
 
-	// Send buffered logs first
+	var buffer []LogEntry
 	if val, ok := jm.logBuffers.Load(jobID); ok {
-		buffer := val.([]LogEntry)
-		for _, entry := range buffer {
-			select {
-			case ch <- entry:
-			default:
-			}
-		}
+		buffer = val.([]LogEntry)
 	}
 
-	// If job already finished, close channel immediately after sending buffered logs
+	_, jobKnown := jm.jobs.Load(jobID)
 	if _, finished := jm.jobFinished.Load(jobID); finished {
+		ch := make(chan LogEntry, len(buffer))
+		for _, entry := range buffer {
+			ch <- entry
+		}
 		close(ch)
 		return ch
+	}
+	if !jobKnown && len(buffer) == 0 {
+		ch := make(chan LogEntry)
+		close(ch)
+		return ch
+	}
+
+	ch := make(chan LogEntry, len(buffer)+logChannelHeadroom)
+	for _, entry := range buffer {
+		ch <- entry
 	}
 
 	var subs []chan LogEntry
@@ -211,6 +557,9 @@ func (jm *JobManager) SubscribeLogs(jobID string) chan LogEntry {
 }
 
 func (jm *JobManager) UnsubscribeLogs(jobID string, ch chan LogEntry) {
+	jm.logMu.Lock()
+	defer jm.logMu.Unlock()
+
 	if val, ok := jm.logSubs.Load(jobID); ok {
 		subs := val.([]chan LogEntry)
 		newSubs := make([]chan LogEntry, 0, len(subs))
@@ -224,47 +573,56 @@ func (jm *JobManager) UnsubscribeLogs(jobID string, ch chan LogEntry) {
 }
 
 func (jm *JobManager) broadcastLog(jobID string, entry LogEntry) {
-	// Always buffer the log first
+	jm.logMu.Lock()
+
 	var buffer []LogEntry
 	if val, ok := jm.logBuffers.Load(jobID); ok {
 		buffer = val.([]LogEntry)
 	}
 	buffer = append(buffer, entry)
+	if len(buffer) > maxBufferedLogEntries {
+		buffer = buffer[len(buffer)-maxBufferedLogEntries:]
+	}
 	jm.logBuffers.Store(jobID, buffer)
 
-	// Write to log file
-	if val, ok := jm.logFiles.Load(jobID); ok {
-		if f, ok := val.(*os.File); ok {
-			line, _ := json.Marshal(entry)
-			_, _ = f.Write(append(line, '\n'))
-		}
-	}
-
-	// Store in repository
-	if jm.repo != nil {
-		logRecord := &LogRecord{
-			RunID:     jobID,
-			Timestamp: entry.Timestamp,
-			Level:     entry.Level,
-			Message:   entry.Message,
-		}
-		_ = jm.repo.AddLog(context.Background(), logRecord)
-	}
-
-	// Then broadcast to any existing subscribers
 	if val, ok := jm.logSubs.Load(jobID); ok {
 		subs := val.([]chan LogEntry)
 		for _, ch := range subs {
 			select {
 			case ch <- entry:
 			default:
+				jm.sendLagWarning(ch, entry.Timestamp)
 			}
 		}
+	}
+
+	if val, ok := jm.logSinks.Load(jobID); ok {
+		val.(*logSink).enqueue(entry)
+	}
+
+	jm.logMu.Unlock()
+}
+
+func (jm *JobManager) sendLagWarning(ch chan LogEntry, timestamp time.Time) {
+	select {
+	case <-ch:
+	default:
+	}
+
+	select {
+	case ch <- LogEntry{
+		Timestamp: timestamp,
+		Level:     "warning",
+		Message:   logStreamLagWarning,
+	}:
+	default:
 	}
 }
 
 func (jm *JobManager) closeLogSubscribers(jobID string) {
-	// Mark job as finished first
+	var sink *logSink
+
+	jm.logMu.Lock()
 	jm.jobFinished.Store(jobID, true)
 
 	if val, ok := jm.logSubs.Load(jobID); ok {
@@ -275,19 +633,25 @@ func (jm *JobManager) closeLogSubscribers(jobID string) {
 		jm.logSubs.Delete(jobID)
 	}
 
-	// Close the log file
-	if val, ok := jm.logFiles.LoadAndDelete(jobID); ok {
-		if f, ok := val.(*os.File); ok {
-			_ = f.Close()
-		}
+	if val, ok := jm.logSinks.LoadAndDelete(jobID); ok {
+		sink = val.(*logSink)
+		sink.close()
 	}
+	jm.logMu.Unlock()
+
+	if sink != nil {
+		<-sink.done
+	}
+
+	jm.cancels.Delete(jobID)
 
 	// Clean up in-memory state after a delay to allow late subscribers to read buffered logs.
 	// The persistent data is still available via the repository.
 	go func() {
 		time.Sleep(5 * time.Minute)
 		jm.jobs.Delete(jobID)
-		jm.configs.Delete(jobID)
+		jm.logMu.Lock()
+		defer jm.logMu.Unlock()
 		jm.logBuffers.Delete(jobID)
 		jm.jobFinished.Delete(jobID)
 	}()
@@ -321,25 +685,61 @@ func (jm *JobManager) GetRun(ctx context.Context, id string) (*RunRecord, error)
 	return jm.repo.GetRun(ctx, id)
 }
 
-type jobLogWriter struct {
-	jobID   string
-	manager *JobManager
-}
-
-func (w *jobLogWriter) Write(p []byte) (n int, err error) {
-	msg := string(p)
-	if msg != "" && msg != "\n" {
-		w.manager.broadcastLog(w.jobID, LogEntry{
-			Timestamp: time.Now(),
-			Level:     "info",
-			Message:   msg,
-		})
-	}
-	return len(p), nil
-}
-
-var _ io.Writer = (*jobLogWriter)(nil)
-
 func maskURI(uri string) string {
-	return uri
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return "<redacted-uri>"
+	}
+	if parsed.User != nil {
+		username := parsed.User.Username()
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.UserPassword(username, "xxxxx")
+		} else {
+			parsed.User = url.User(username)
+		}
+	}
+
+	query := parsed.Query()
+	for key := range query {
+		lower := strings.ToLower(key)
+		if strings.Contains(lower, "password") ||
+			strings.Contains(lower, "pass") ||
+			strings.Contains(lower, "credential") ||
+			strings.Contains(lower, "secret") ||
+			strings.Contains(lower, "token") ||
+			strings.Contains(lower, "key") ||
+			strings.Contains(lower, "private") ||
+			strings.Contains(lower, "sas") {
+			query.Set(key, "xxxxx")
+		}
+	}
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String()
+}
+
+func omitURIArgs(args []string) []string {
+	filtered := make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--source-uri=") || strings.HasPrefix(arg, "--dest-uri=") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+func maskCLIArgs(args []string) []string {
+	masked := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--source-uri="):
+			masked = append(masked, "--source-uri="+maskURI(strings.TrimPrefix(arg, "--source-uri=")))
+		case strings.HasPrefix(arg, "--dest-uri="):
+			masked = append(masked, "--dest-uri="+maskURI(strings.TrimPrefix(arg, "--dest-uri=")))
+		default:
+			masked = append(masked, arg)
+		}
+	}
+	return masked
 }

--- a/internal/server/jobs_test.go
+++ b/internal/server/jobs_test.go
@@ -1,0 +1,485 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestJobManagerRunsIngestrCLI(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "ingestr")
+	script := `#!/bin/sh
+if [ "$1" != "ingest" ]; then exit 12; fi
+echo fake-cli "$@"
+echo legacy-source-env "$SOURCE_URI"
+echo legacy-dest-env "$DESTINATION_URI"
+echo source-env "$INGESTR_SOURCE_URI"
+echo dest-env "$INGESTR_DESTINATION_URI"
+echo stderr-line >&2
+`
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	jm := NewJobManager(filepath.Join(dir, "logs"), nil, binary)
+	t.Setenv("SOURCE_URI", "csv:///wrong.csv")
+	t.Setenv("DESTINATION_URI", "duckdb:///wrong.db")
+	jobID, err := jm.StartJob(context.Background(), JobSpec{
+		Args:        []string{"--source-uri=csv:///tmp/in.csv", "--dest-uri=duckdb:///tmp/out.db", "--source-table=users", "--yes"},
+		SourceURI:   "csv:///tmp/in.csv",
+		DestURI:     "duckdb:///tmp/out.db",
+		SourceTable: "users",
+		DestTable:   "users",
+		Strategy:    "replace",
+	})
+	if err != nil {
+		t.Fatalf("start job: %v", err)
+	}
+
+	var job *Job
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var ok bool
+		job, ok = jm.GetJob(jobID)
+		if ok && job.Status != "running" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if job == nil {
+		t.Fatal("job not found")
+	}
+	if job.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", job.Status, job.Error)
+	}
+
+	logs := jm.SubscribeLogs(jobID)
+	var messages []string
+	for entry := range logs {
+		messages = append(messages, entry.Message)
+	}
+	joined := strings.Join(messages, "\n")
+	if !strings.Contains(joined, "fake-cli ingest --source-table=users --yes") {
+		t.Fatalf("expected fake CLI output in logs, got %#v", messages)
+	}
+	if strings.Contains(joined, "fake-cli ingest --source-uri") || strings.Contains(joined, "fake-cli ingest --dest-uri") {
+		t.Fatalf("source/destination URI should not be exposed in argv logs: %#v", messages)
+	}
+	if strings.Contains(joined, "wrong") {
+		t.Fatalf("inherited source/destination URI environment should be overridden, got %#v", messages)
+	}
+	if !strings.Contains(joined, "legacy-source-env csv:///tmp/in.csv") ||
+		!strings.Contains(joined, "legacy-dest-env duckdb:///tmp/out.db") ||
+		!strings.Contains(joined, "source-env csv:///tmp/in.csv") ||
+		!strings.Contains(joined, "dest-env duckdb:///tmp/out.db") {
+		t.Fatalf("expected source/destination URI in subprocess environment, got %#v", messages)
+	}
+	if !strings.Contains(joined, "stderr-line") {
+		t.Fatalf("expected stderr to be captured, got %#v", messages)
+	}
+}
+
+func TestJobManagerCancelJob(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "ingestr")
+	script := "#!/bin/sh\nif [ \"$1\" != \"ingest\" ]; then exit 12; fi\ntrap 'echo interrupted; exit 130' INT TERM\necho started\nwhile true; do sleep 1 & wait $!; done\n"
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	jm := NewJobManager(filepath.Join(dir, "logs"), nil, binary)
+	jobID, err := jm.StartJob(context.Background(), JobSpec{
+		Args:        []string{"--source-uri=csv:///tmp/in.csv", "--dest-uri=duckdb:///tmp/out.db", "--source-table=users", "--yes"},
+		SourceURI:   "csv:///tmp/in.csv",
+		DestURI:     "duckdb:///tmp/out.db",
+		SourceTable: "users",
+		DestTable:   "users",
+		Strategy:    "replace",
+	})
+	if err != nil {
+		t.Fatalf("start job: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if !jm.CancelJob(jobID) {
+		t.Fatal("CancelJob returned false")
+	}
+
+	job := waitForJobStatus(t, jm, jobID)
+	if job.Status != "canceled" {
+		t.Fatalf("status = %q, want canceled; error=%q", job.Status, job.Error)
+	}
+}
+
+func TestJobManagerRedactsCommandOutputURIs(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "ingestr")
+	script := "#!/bin/sh\nif [ \"$1\" != \"ingest\" ]; then exit 12; fi\necho \"$INGESTR_SOURCE_URI\"\n"
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	jm := NewJobManager(filepath.Join(dir, "logs"), nil, binary)
+	jobID, err := jm.StartJob(context.Background(), JobSpec{
+		Args:        []string{"--source-uri=postgres://user:secret@localhost/db", "--dest-uri=duckdb:///tmp/out.db", "--source-table=users", "--yes"},
+		SourceURI:   "postgres://user:secret@localhost/db",
+		DestURI:     "duckdb:///tmp/out.db",
+		SourceTable: "users",
+		DestTable:   "users",
+		Strategy:    "replace",
+	})
+	if err != nil {
+		t.Fatalf("start job: %v", err)
+	}
+
+	job := waitForJobStatus(t, jm, jobID)
+	if job.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", job.Status, job.Error)
+	}
+
+	logs := jm.SubscribeLogs(jobID)
+	var messages []string
+	for entry := range logs {
+		messages = append(messages, entry.Message)
+	}
+	joined := strings.Join(messages, "\n")
+	if strings.Contains(joined, "secret") {
+		t.Fatalf("command output leaked source URI password: %#v", messages)
+	}
+	if !strings.Contains(joined, "postgres://user:xxxxx@localhost/db") {
+		t.Fatalf("command output did not include masked source URI: %#v", messages)
+	}
+}
+
+func TestJobManagerPersistsLogsToFileAndRepository(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "ingestr")
+	script := "#!/bin/sh\nif [ \"$1\" != \"ingest\" ]; then exit 12; fi\necho persisted-line\n"
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	repo, err := NewSQLiteRepository(filepath.Join(dir, "runs.db"))
+	if err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+	defer func() { _ = repo.Close() }()
+
+	logsDir := filepath.Join(dir, "logs")
+	jm := NewJobManager(logsDir, repo, binary)
+	jobID, err := jm.StartJob(context.Background(), JobSpec{
+		Args:        []string{"--source-uri=csv:///tmp/in.csv", "--dest-uri=duckdb:///tmp/out.db", "--source-table=users", "--yes"},
+		SourceURI:   "csv:///tmp/in.csv",
+		DestURI:     "duckdb:///tmp/out.db",
+		SourceTable: "users",
+		DestTable:   "users",
+		Strategy:    "replace",
+	})
+	if err != nil {
+		t.Fatalf("start job: %v", err)
+	}
+
+	job := waitForJobStatus(t, jm, jobID)
+	if job.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", job.Status, job.Error)
+	}
+	waitForJobCleanup(t, jm, jobID)
+
+	fileData, err := os.ReadFile(filepath.Join(logsDir, jobID+".jsonl"))
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if !strings.Contains(string(fileData), "persisted-line") {
+		t.Fatalf("expected CLI output in JSONL log file, got %s", string(fileData))
+	}
+
+	records, err := repo.GetLogs(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("get repo logs: %v", err)
+	}
+	var messages []string
+	for _, record := range records {
+		messages = append(messages, record.Message)
+	}
+	if !strings.Contains(strings.Join(messages, "\n"), "persisted-line") {
+		t.Fatalf("expected CLI output in repo logs, got %#v", messages)
+	}
+}
+
+func TestStreamCommandOutputSuppressesCancellationReadError(t *testing.T) {
+	jm := NewJobManager(t.TempDir(), nil, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	jm.streamCommandOutput(ctx, "canceled-job", failingReader{}, "info", JobSpec{}, &wg)
+	wg.Wait()
+
+	if val, ok := jm.logBuffers.Load("canceled-job"); ok {
+		if entries := val.([]LogEntry); len(entries) != 0 {
+			t.Fatalf("expected no cancellation read error log, got %#v", entries)
+		}
+	}
+}
+
+func TestSubscribeLogsUnknownJobCloses(t *testing.T) {
+	jm := NewJobManager(t.TempDir(), nil, "")
+	ch := jm.SubscribeLogs("missing")
+	if _, ok := <-ch; ok {
+		t.Fatal("expected unknown job subscription to be closed")
+	}
+}
+
+func TestSubscribeLogsReplaysFullBuffer(t *testing.T) {
+	jm := NewJobManager(t.TempDir(), nil, "")
+	const jobID = "job-with-many-logs"
+	const logCount = 150
+	for i := range logCount {
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "info",
+			Message:   "line " + strconv.Itoa(i),
+		})
+	}
+	jm.jobFinished.Store(jobID, true)
+
+	ch := jm.SubscribeLogs(jobID)
+	var got int
+	for range ch {
+		got++
+	}
+	if got != logCount {
+		t.Fatalf("replayed logs = %d, want %d", got, logCount)
+	}
+}
+
+func TestBroadcastLogWarnsSlowSubscriber(t *testing.T) {
+	jm := NewJobManager(t.TempDir(), nil, "")
+	const jobID = "slow-subscriber"
+
+	ch := make(chan LogEntry, 1)
+	ch <- LogEntry{Timestamp: time.Now(), Level: "info", Message: "already queued"}
+	jm.logSubs.Store(jobID, []chan LogEntry{ch})
+
+	jm.broadcastLog(jobID, LogEntry{
+		Timestamp: time.Now(),
+		Level:     "info",
+		Message:   "new line",
+	})
+
+	val, ok := jm.logSubs.Load(jobID)
+	if !ok {
+		t.Fatal("slow subscriber was removed")
+	}
+	if subs := val.([]chan LogEntry); len(subs) != 1 {
+		t.Fatalf("subscriber count = %d, want 1", len(subs))
+	}
+	got := <-ch
+	if got.Message != logStreamLagWarning {
+		t.Fatalf("slow subscriber message = %q, want lag warning", got.Message)
+	}
+}
+
+func TestBroadcastLogLagWarningDropsOnlyOldestQueuedEntry(t *testing.T) {
+	jm := NewJobManager(t.TempDir(), nil, "")
+	const jobID = "slow-subscriber-with-backlog"
+
+	ch := make(chan LogEntry, 3)
+	ch <- LogEntry{Timestamp: time.Now(), Level: "info", Message: "queued 0"}
+	ch <- LogEntry{Timestamp: time.Now(), Level: "info", Message: "queued 1"}
+	ch <- LogEntry{Timestamp: time.Now(), Level: "info", Message: "queued 2"}
+	jm.logSubs.Store(jobID, []chan LogEntry{ch})
+
+	jm.broadcastLog(jobID, LogEntry{
+		Timestamp: time.Now(),
+		Level:     "info",
+		Message:   "new line",
+	})
+
+	got := []string{(<-ch).Message, (<-ch).Message, (<-ch).Message}
+	want := []string{"queued 1", "queued 2", logStreamLagWarning}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("messages = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestLogSinkCapsPendingPersistenceQueue(t *testing.T) {
+	sink := newLogSink(nil)
+	for i := range maxPendingPersistLogEntries + 2 {
+		sink.enqueue(LogEntry{
+			Timestamp: time.Unix(int64(i), 0),
+			Level:     "info",
+			Message:   "line " + strconv.Itoa(i),
+		})
+	}
+
+	sink.mu.Lock()
+	pending := sink.pending()
+	dropped := sink.dropped
+	sink.mu.Unlock()
+
+	if pending != maxPendingPersistLogEntries {
+		t.Fatalf("pending entries = %d, want %d", pending, maxPendingPersistLogEntries)
+	}
+	if dropped != 2 {
+		t.Fatalf("dropped entries = %d, want 2", dropped)
+	}
+
+	warning, ok := sink.next()
+	if !ok {
+		t.Fatal("expected persistence lag warning")
+	}
+	if !strings.Contains(warning.Message, "2 log line(s) were skipped") {
+		t.Fatalf("warning = %q, want skipped count", warning.Message)
+	}
+
+	next, ok := sink.next()
+	if !ok {
+		t.Fatal("expected retained log entry")
+	}
+	if next.Message != "line 2" {
+		t.Fatalf("first retained entry = %q, want line 2", next.Message)
+	}
+}
+
+func TestBroadcastLogCapsReplayBuffer(t *testing.T) {
+	jm := NewJobManager(t.TempDir(), nil, "")
+	const jobID = "capped-buffer"
+
+	for i := range maxBufferedLogEntries + 3 {
+		jm.broadcastLog(jobID, LogEntry{
+			Timestamp: time.Now(),
+			Level:     "info",
+			Message:   "line " + strconv.Itoa(i),
+		})
+	}
+
+	val, ok := jm.logBuffers.Load(jobID)
+	if !ok {
+		t.Fatal("expected log buffer")
+	}
+	buffer := val.([]LogEntry)
+	if len(buffer) != maxBufferedLogEntries {
+		t.Fatalf("buffer length = %d, want %d", len(buffer), maxBufferedLogEntries)
+	}
+	if buffer[0].Message != "line 3" {
+		t.Fatalf("oldest retained log = %q, want line 3", buffer[0].Message)
+	}
+}
+
+func TestStartJobReportsLogFileCreateFailure(t *testing.T) {
+	dir := t.TempDir()
+	logsPath := filepath.Join(dir, "logs-file")
+	if err := os.WriteFile(logsPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write logs path file: %v", err)
+	}
+
+	binary := filepath.Join(dir, "ingestr")
+	script := "#!/bin/sh\nif [ \"$1\" != \"ingest\" ]; then exit 12; fi\necho ok\n"
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	jm := NewJobManager(logsPath, nil, binary)
+	jobID, err := jm.StartJob(context.Background(), JobSpec{
+		Args:        []string{"--source-uri=csv:///tmp/in.csv", "--dest-uri=duckdb:///tmp/out.db", "--source-table=users", "--yes"},
+		SourceURI:   "csv:///tmp/in.csv",
+		DestURI:     "duckdb:///tmp/out.db",
+		SourceTable: "users",
+		DestTable:   "users",
+		Strategy:    "replace",
+	})
+	if err != nil {
+		t.Fatalf("start job: %v", err)
+	}
+
+	job := waitForJobStatus(t, jm, jobID)
+	if job.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", job.Status, job.Error)
+	}
+
+	logs := jm.SubscribeLogs(jobID)
+	var messages []string
+	for entry := range logs {
+		messages = append(messages, entry.Message)
+	}
+	joined := strings.Join(messages, "\n")
+	if !strings.Contains(joined, "Failed to create log file:") {
+		t.Fatalf("expected log file warning, got %#v", messages)
+	}
+}
+
+func TestMaskURI(t *testing.T) {
+	got := maskURI("postgres://user:secret@localhost/db?api_key=abc&credentials_base64=private-json&credentials_path=/tmp/key.json&sslmode=require")
+	if strings.Contains(got, "secret") || strings.Contains(got, "abc") || strings.Contains(got, "private-json") || strings.Contains(got, "/tmp/key.json") {
+		t.Fatalf("maskURI leaked secret data: %s", got)
+	}
+	if !strings.Contains(got, "xxxxx") {
+		t.Fatalf("maskURI did not redact sensitive fields: %s", got)
+	}
+
+	if got := maskURI("http://[::1"); got != "<redacted-uri>" {
+		t.Fatalf("invalid URI mask = %q, want redacted placeholder", got)
+	}
+}
+
+func TestMaskCLIArgs(t *testing.T) {
+	got := strings.Join(maskCLIArgs([]string{
+		"ingest",
+		"--source-uri=postgres://user:secret@localhost/db",
+		"--dest-uri=duckdb:///tmp/out.db",
+	}), " ")
+	if strings.Contains(got, "secret") {
+		t.Fatalf("maskCLIArgs leaked secret data: %s", got)
+	}
+	if !strings.Contains(got, "--source-uri=postgres://user:xxxxx@localhost/db") {
+		t.Fatalf("maskCLIArgs did not redact source URI password: %s", got)
+	}
+}
+
+func waitForJobStatus(t *testing.T, jm *JobManager, jobID string) *Job {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		job, ok := jm.GetJob(jobID)
+		if ok && job.Status != "running" {
+			return job
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	job, _ := jm.GetJob(jobID)
+	if job == nil {
+		t.Fatal("job not found")
+	}
+	t.Fatalf("job still running after timeout")
+	return nil
+}
+
+func waitForJobCleanup(t *testing.T, jm *JobManager, jobID string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := jm.cancels.Load(jobID); !ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("job cleanup did not finish after timeout")
+}
+
+type failingReader struct{}
+
+func (failingReader) Read(_ []byte) (int, error) {
+	return 0, os.ErrClosed
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/webui"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -26,6 +25,10 @@ type Server struct {
 }
 
 func New(port int, credsFile string, logsDir string, dbPath string) (*Server, error) {
+	return NewWithBinary(port, credsFile, logsDir, dbPath, "")
+}
+
+func NewWithBinary(port int, credsFile string, logsDir string, dbPath string, binaryPath string) (*Server, error) {
 	repo, err := NewSQLiteRepository(dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository: %w", err)
@@ -34,7 +37,7 @@ func New(port int, credsFile string, logsDir string, dbPath string) (*Server, er
 	s := &Server{
 		port:  port,
 		creds: NewCredentialsManager(credsFile),
-		jobs:  NewJobManager(logsDir, repo),
+		jobs:  NewJobManager(logsDir, repo, binaryPath),
 		repo:  repo,
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool { return true },
@@ -56,6 +59,7 @@ func (s *Server) setupRoutes() {
 		r.Delete("/credentials/{id}", s.handleDeleteCredential)
 		r.Post("/run", s.handleRunJob)
 		r.Get("/jobs/{id}", s.handleGetJob)
+		r.Post("/jobs/{id}/cancel", s.handleCancelJob)
 		r.Get("/runs", s.handleListRuns)
 		r.Get("/runs/{id}", s.handleGetRun)
 		r.Get("/runs/{id}/logs", s.handleGetRunLogs)
@@ -141,16 +145,6 @@ func (s *Server) handleDeleteCredential(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-type RunJobRequest struct {
-	SourceURI      string   `json:"sourceUri"`
-	DestURI        string   `json:"destUri"`
-	SourceTable    string   `json:"sourceTable"`
-	DestTable      string   `json:"destTable"`
-	Strategy       string   `json:"strategy"`
-	PrimaryKeys    []string `json:"primaryKeys"`
-	IncrementalKey string   `json:"incrementalKey"`
-}
-
 func (s *Server) handleRunJob(w http.ResponseWriter, r *http.Request) {
 	var req RunJobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -158,28 +152,19 @@ func (s *Server) handleRunJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg := config.DefaultConfig()
-	cfg.SourceURI = req.SourceURI
-	cfg.DestURI = req.DestURI
-	cfg.SourceTable = req.SourceTable
-	cfg.DestTable = req.DestTable
-	if cfg.DestTable == "" {
-		cfg.DestTable = cfg.SourceTable
-	}
-	if req.Strategy != "" {
-		cfg.IncrementalStrategy = config.IncrementalStrategy(req.Strategy)
-		cfg.IncrementalStrategyExplicit = true
-	}
-	cfg.PrimaryKeys = req.PrimaryKeys
-	cfg.IncrementalKey = req.IncrementalKey
-	cfg.Yes = true
-
-	if err := cfg.Validate(); err != nil {
+	if err := s.resolveRunRequest(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	jobID, err := s.jobs.StartJob(r.Context(), cfg)
+	jobID, err := s.jobs.StartJob(r.Context(), JobSpec{
+		Args:        req.IngestArgs(),
+		SourceURI:   req.SourceURI,
+		DestURI:     req.DestURI,
+		SourceTable: req.SourceTable,
+		DestTable:   req.DestTable,
+		Strategy:    req.IncrementalStrategy,
+	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -187,6 +172,37 @@ func (s *Server) handleRunJob(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"jobId": jobID})
+}
+
+func (s *Server) resolveRunRequest(req *RunJobRequest) error {
+	if req.SourceCredentialID != "" {
+		cred, ok := s.creds.Get(req.SourceCredentialID)
+		if !ok {
+			return fmt.Errorf("source credential not found")
+		}
+		req.SourceURI = BuildURI(cred.ConnectorID, cred.Fields)
+	}
+	if req.DestCredentialID != "" {
+		cred, ok := s.creds.Get(req.DestCredentialID)
+		if !ok {
+			return fmt.Errorf("destination credential not found")
+		}
+		req.DestURI = BuildURI(cred.ConnectorID, cred.Fields)
+	}
+	if req.SourceURI == "" {
+		return fmt.Errorf("source-uri is required")
+	}
+	if req.DestURI == "" {
+		return fmt.Errorf("dest-uri is required")
+	}
+	if req.DestTable == "" {
+		req.DestTable = req.SourceTable
+	}
+	if req.IncrementalStrategy == "" && req.Strategy != "" {
+		req.IncrementalStrategy = req.Strategy
+	}
+	req.Progress = "log"
+	return nil
 }
 
 func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
@@ -199,6 +215,15 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(job)
+}
+
+func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if !s.jobs.CancelJob(id) {
+		http.Error(w, "job not found", http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleLogsWebSocket(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,53 @@
+package server
+
+import "testing"
+
+func TestResolveRunRequestResolvesCredentialIDs(t *testing.T) {
+	creds := NewCredentialsManager("")
+	creds.data.Credentials["src"] = Credential{
+		ConnectorID: "raw",
+		Fields: map[string]string{
+			"uri": "postgres://user:pass@localhost/db",
+		},
+	}
+	creds.data.Credentials["dest"] = Credential{
+		ConnectorID: "raw",
+		Fields: map[string]string{
+			"uri": "duckdb:///tmp/out.db",
+		},
+	}
+	s := &Server{creds: creds}
+
+	req := RunJobRequest{
+		SourceCredentialID: "src",
+		DestCredentialID:   "dest",
+		SourceTable:        "public.users",
+		Strategy:           "merge",
+	}
+	if err := s.resolveRunRequest(&req); err != nil {
+		t.Fatalf("resolveRunRequest: %v", err)
+	}
+	if req.SourceURI != "postgres://user:pass@localhost/db" {
+		t.Fatalf("source URI = %q", req.SourceURI)
+	}
+	if req.DestURI != "duckdb:///tmp/out.db" {
+		t.Fatalf("dest URI = %q", req.DestURI)
+	}
+	if req.DestTable != "public.users" {
+		t.Fatalf("dest table = %q, want source table default", req.DestTable)
+	}
+	if req.IncrementalStrategy != "merge" {
+		t.Fatalf("incremental strategy = %q, want legacy strategy value", req.IncrementalStrategy)
+	}
+	if req.Progress != "log" {
+		t.Fatalf("progress = %q, want log default", req.Progress)
+	}
+}
+
+func TestResolveRunRequestRejectsMissingCredential(t *testing.T) {
+	s := &Server{creds: NewCredentialsManager("")}
+	req := RunJobRequest{SourceCredentialID: "missing", DestURI: "duckdb:///tmp/out.db"}
+	if err := s.resolveRunRequest(&req); err == nil {
+		t.Fatal("expected missing source credential error")
+	}
+}

--- a/pkg/webui/dist/index.html
+++ b/pkg/webui/dist/index.html
@@ -188,6 +188,7 @@
               <div>
                 <label class="block text-xs font-medium text-gray-500 mb-1">Schema Contract</label>
                 <select v-model="schemaContract" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 bg-white">
+                  <option value="">Default</option>
                   <option value="evolve">Evolve</option>
                   <option value="freeze">Freeze</option>
                   <option value="discard_row">Discard Row</option>
@@ -205,11 +206,11 @@
               </div>
               <div>
                 <label class="block text-xs font-medium text-gray-500 mb-1">Page Size</label>
-                <input type="number" v-model.number="pageSize" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+                <input type="number" v-model.number="pageSize" placeholder="CLI default" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
               </div>
               <div>
                 <label class="block text-xs font-medium text-gray-500 mb-1">Extract Parallelism</label>
-                <input type="number" v-model.number="extractParallelism" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+                <input type="number" v-model.number="extractParallelism" placeholder="CLI default" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
               </div>
               <div>
                 <label class="block text-xs font-medium text-gray-500 mb-1">SQL Limit</label>
@@ -247,7 +248,7 @@
               </div>
               <div>
                 <label class="block text-xs font-medium text-gray-500 mb-1">Loader File Size</label>
-                <input type="number" v-model.number="loaderFileSize" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+                <input type="number" v-model.number="loaderFileSize" placeholder="CLI default" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
               </div>
               <div>
                 <label class="block text-xs font-medium text-gray-500 mb-1">Loader File Format</label>
@@ -436,12 +437,12 @@
         const partitionBy = ref('');
         const clusterBy = ref('');
         const fullRefresh = ref(false);
-        const schemaContract = ref('evolve');
+        const schemaContract = ref('');
         const schemaNaming = ref('');
-        const pageSize = ref(25000);
-        const loaderFileSize = ref(25000);
+        const pageSize = ref('');
+        const loaderFileSize = ref('');
         const loaderFileFormat = ref('');
-        const extractParallelism = ref(5);
+        const extractParallelism = ref('');
         const sqlLimit = ref('');
         const sqlExcludeColumns = ref('');
         const sqlBackend = ref('');

--- a/pkg/webui/dist/index.html
+++ b/pkg/webui/dist/index.html
@@ -31,7 +31,7 @@
 </head>
 <body class="bg-gray-50 min-h-screen text-gray-700">
   <div id="app" v-cloak>
-    <div class="container mx-auto px-4 py-6 max-w-5xl">
+    <div class="container mx-auto px-4 py-6 max-w-6xl">
       <h1 class="text-xl font-semibold text-gray-800 mb-5 tracking-tight">ingestr</h1>
 
       <!-- Tab Navigation -->
@@ -71,7 +71,7 @@
               <select v-if="field.type === 'select'" v-model="newConnFields[field.name]" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 bg-white">
                 <option v-for="opt in field.options" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
               </select>
-              <input v-else-if="field.type === 'checkbox'" type="checkbox" v-model="newConnFields[field.name]" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5">
+              <input v-else-if="field.type === 'checkbox'" type="checkbox" v-model="newConnFields[field.name]" true-value="true" false-value="false" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5">
               <input v-else :type="field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'" v-model="newConnFields[field.name]" :placeholder="field.placeholder" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
             </div>
           </div>
@@ -109,7 +109,7 @@
               </select>
             </div>
             <div>
-              <label class="block text-xs font-medium text-gray-500 mb-1">Table Name<span class="text-red-400 ml-0.5">*</span></label>
+              <label class="block text-xs font-medium text-gray-500 mb-1">Table Name</label>
               <input type="text" v-model="sourceTable" placeholder="schema.table_name" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
             </div>
           </div>
@@ -133,32 +133,180 @@
 
         <!-- Options -->
         <div class="bg-white rounded-md border border-gray-200 p-4 mb-4">
-          <h2 class="text-sm font-semibold mb-3 text-gray-700 uppercase tracking-wide">Options</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <div>
-              <label class="block text-xs font-medium text-gray-500 mb-1">Strategy</label>
-              <select v-model="strategy" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 bg-white">
-                <option value="replace">Replace</option>
-                <option value="append">Append</option>
-                <option value="merge">Merge</option>
-                <option value="delete+insert">Delete + Insert</option>
-              </select>
+          <button type="button" @click="optionsExpanded = !optionsExpanded" :aria-expanded="optionsExpanded.toString()" class="w-full flex items-center justify-between text-left">
+            <span class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Options</span>
+            <span class="inline-flex h-6 w-6 items-center justify-center rounded border border-gray-200 text-gray-400 text-sm font-medium" aria-hidden="true">{{ optionsExpanded ? '-' : '+' }}</span>
+          </button>
+          <div v-if="optionsExpanded" class="mt-3">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Strategy</label>
+                <select v-model="incrementalStrategy" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 bg-white">
+                  <option value="">Auto</option>
+                  <option value="replace">Replace</option>
+                  <option value="truncate+insert">Truncate + Insert</option>
+                  <option value="append">Append</option>
+                  <option value="delete+insert">Delete + Insert</option>
+                  <option value="merge">Merge</option>
+                  <option value="scd2">SCD2</option>
+                  <option value="none">None</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Primary Keys</label>
+                <input type="text" v-model="primaryKeys" placeholder="id, user_id" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Incremental Key</label>
+                <input type="text" v-model="incrementalKey" placeholder="updated_at" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Full Refresh</label>
+                <input type="checkbox" v-model="fullRefresh" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5 mt-2">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Interval Start</label>
+                <input type="text" v-model="intervalStart" placeholder="2026-01-01T00:00:00" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Interval End</label>
+                <input type="text" v-model="intervalEnd" placeholder="2026-01-02T00:00:00" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Partition By</label>
+                <input type="text" v-model="partitionBy" placeholder="created_at" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Cluster By</label>
+                <input type="text" v-model="clusterBy" placeholder="account_id, region" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
             </div>
-            <div>
-              <label class="block text-xs font-medium text-gray-500 mb-1">Primary Keys</label>
-              <input type="text" v-model="primaryKeys" placeholder="id, user_id" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+
+          <div class="border-t border-gray-100 mt-4 pt-4">
+            <h3 class="text-[11px] font-semibold mb-3 text-gray-400 uppercase tracking-wide">Schema and SQL</h3>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Schema Contract</label>
+                <select v-model="schemaContract" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 bg-white">
+                  <option value="evolve">Evolve</option>
+                  <option value="freeze">Freeze</option>
+                  <option value="discard_row">Discard Row</option>
+                  <option value="discard_value">Discard Value</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Schema Naming</label>
+                <select v-model="schemaNaming" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 bg-white">
+                  <option value="">Default</option>
+                  <option value="direct">Direct</option>
+                  <option value="snake_case">Snake Case</option>
+                  <option value="auto">Auto</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Page Size</label>
+                <input type="number" v-model.number="pageSize" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Extract Parallelism</label>
+                <input type="number" v-model.number="extractParallelism" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">SQL Limit</label>
+                <input type="number" v-model.number="sqlLimit" min="0" placeholder="0" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Exclude Columns</label>
+                <input type="text" v-model="sqlExcludeColumns" placeholder="col_a, col_b" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div class="md:col-span-2">
+                <label class="block text-xs font-medium text-gray-500 mb-1">Columns</label>
+                <input type="text" v-model="columns" placeholder="id:bigint,name:string:source_name" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">No Inference</label>
+                <input type="checkbox" v-model="noInference" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5 mt-2">
+              </div>
             </div>
-            <div>
-              <label class="block text-xs font-medium text-gray-500 mb-1">Incremental Key</label>
-              <input type="text" v-model="incrementalKey" placeholder="updated_at" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+          </div>
+
+          <div class="border-t border-gray-100 mt-4 pt-4">
+            <h3 class="text-[11px] font-semibold mb-3 text-gray-400 uppercase tracking-wide">Transforms and Loading</h3>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div class="md:col-span-2">
+                <label class="block text-xs font-medium text-gray-500 mb-1">Mask</label>
+                <input type="text" v-model="mask" placeholder="email:email, phone:phone" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Trim Whitespace</label>
+                <input type="checkbox" v-model="trimWhitespace" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5 mt-2">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">No Load Timestamp</label>
+                <input type="checkbox" v-model="noLoadTimestamp" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5 mt-2">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Loader File Size</label>
+                <input type="number" v-model.number="loaderFileSize" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Loader File Format</label>
+                <input type="text" v-model="loaderFileFormat" placeholder="parquet" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Staging Bucket</label>
+                <input type="text" v-model="stagingBucket" placeholder="s3://bucket/path" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Staging Dataset</label>
+                <input type="text" v-model="stagingDataset" placeholder="staging" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Pipelines Dir</label>
+                <input type="text" v-model="pipelinesDir" placeholder=".ingestr" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
             </div>
+          </div>
+
+          <div class="border-t border-gray-100 mt-4 pt-4">
+            <h3 class="text-[11px] font-semibold mb-3 text-gray-400 uppercase tracking-wide">Streaming and Debug</h3>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Stream</label>
+                <input type="checkbox" v-model="stream" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5 mt-2">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Flush Interval</label>
+                <input type="text" v-model="flushInterval" :disabled="!stream" placeholder="30s" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 disabled:bg-gray-50 disabled:text-gray-400">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Flush Records</label>
+                <input type="number" v-model.number="flushRecords" :disabled="!stream" min="1" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300 disabled:bg-gray-50 disabled:text-gray-400">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">Debug</label>
+                <input type="checkbox" v-model="debug" class="rounded border-gray-300 text-gray-700 focus:ring-gray-300 h-3.5 w-3.5 mt-2">
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-500 mb-1">SQL Backend</label>
+                <input type="text" v-model="sqlBackend" placeholder="backend" class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+              <div class="md:col-span-3">
+                <label class="block text-xs font-medium text-gray-500 mb-1">Query Annotations</label>
+                <input type="text" v-model="queryAnnotations" placeholder='{"pipeline":"daily","asset":"orders"}' class="w-full border border-gray-200 rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-300 focus:border-gray-300">
+              </div>
+            </div>
+          </div>
           </div>
         </div>
 
         <!-- Run Button -->
-        <div class="flex justify-center mb-4">
+        <div class="flex justify-center gap-2 mb-4">
           <button @click="runJob" :disabled="isRunning || !canRun" class="bg-gray-800 text-white px-5 py-2 rounded text-sm font-medium hover:bg-gray-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors">
             {{ isRunning ? 'Running...' : 'Run Ingestion' }}
+          </button>
+          <button v-if="isRunning" @click="cancelJob" class="border border-gray-300 text-gray-600 px-5 py-2 rounded text-sm font-medium hover:bg-gray-100 transition-colors">
+            Stop
           </button>
         </div>
 
@@ -204,7 +352,8 @@
                         <span :class="{
                           'bg-green-50 text-green-600 border-green-200': run.status === 'completed',
                           'bg-red-50 text-red-600 border-red-200': run.status === 'failed',
-                          'bg-amber-50 text-amber-600 border-amber-200': run.status === 'running'
+                          'bg-amber-50 text-amber-600 border-amber-200': run.status === 'running',
+                          'bg-gray-50 text-gray-500 border-gray-200': run.status === 'canceled'
                         }" class="px-1.5 py-0.5 text-[10px] rounded border font-medium">{{ run.status }}</span>
                       </td>
                       <td class="px-3 py-2 text-xs text-gray-600 font-mono">{{ run.sourceTable }}</td>
@@ -278,9 +427,37 @@
         const destFields = ref({});
         const sourceTable = ref('');
         const destTable = ref('');
-        const strategy = ref('replace');
+        const optionsExpanded = ref(false);
+        const incrementalStrategy = ref('');
         const primaryKeys = ref('');
         const incrementalKey = ref('');
+        const intervalStart = ref('');
+        const intervalEnd = ref('');
+        const partitionBy = ref('');
+        const clusterBy = ref('');
+        const fullRefresh = ref(false);
+        const schemaContract = ref('evolve');
+        const schemaNaming = ref('');
+        const pageSize = ref(25000);
+        const loaderFileSize = ref(25000);
+        const loaderFileFormat = ref('');
+        const extractParallelism = ref(5);
+        const sqlLimit = ref('');
+        const sqlExcludeColumns = ref('');
+        const sqlBackend = ref('');
+        const columns = ref('');
+        const noInference = ref(false);
+        const mask = ref('');
+        const trimWhitespace = ref(false);
+        const noLoadTimestamp = ref(false);
+        const pipelinesDir = ref('');
+        const stagingBucket = ref('');
+        const stagingDataset = ref('');
+        const debug = ref(false);
+        const stream = ref(false);
+        const flushInterval = ref('30s');
+        const flushRecords = ref(50000);
+        const queryAnnotations = ref('');
 
         // Job state
         const isRunning = ref(false);
@@ -308,11 +485,12 @@
           return credentials.value.filter(c => ids.has(c.connectorId));
         });
 
-        const canRun = computed(() => sourceTable.value.trim() !== '' && selectedSourceCred.value && selectedDestCred.value);
+        const canRun = computed(() => selectedSourceCred.value && selectedDestCred.value);
         const statusClass = computed(() => ({
           'bg-amber-500/20 text-amber-400': jobStatus.value === 'running',
           'bg-green-500/20 text-green-400': jobStatus.value === 'completed',
-          'bg-red-500/20 text-red-400': jobStatus.value === 'failed'
+          'bg-red-500/20 text-red-400': jobStatus.value === 'failed',
+          'bg-gray-500/20 text-gray-400': jobStatus.value === 'canceled'
         }));
 
         const getConnectorName = (connectorId) => {
@@ -368,7 +546,7 @@
           const cred = {
             name: newConnName.value,
             connectorId: newConnConnector.value,
-            fields: { ...newConnFields.value }
+            fields: normalizeFields(newConnFields.value)
           };
           await fetch('/api/credentials', {
             method: 'POST',
@@ -379,6 +557,14 @@
           resetNewConnFields();
           await loadData();
           alert('Connection saved!');
+        }
+
+        function normalizeFields(fields) {
+          return Object.fromEntries(Object.entries(fields).map(([key, value]) => {
+            if (value === true) return [key, 'true'];
+            if (value === false) return [key, 'false'];
+            return [key, value == null ? '' : String(value)];
+          }));
         }
 
         async function deleteConnection(id) {
@@ -401,63 +587,47 @@
           }
         }
 
-        function buildURI(connectorId, fields) {
-          const f = fields;
-          switch (connectorId) {
-            case 'postgres':
-              return `postgres://${f.user}:${f.password}@${f.host}:${f.port || '5432'}/${f.database}${f.sslmode ? '?sslmode=' + f.sslmode : ''}`;
-            case 'mysql':
-              return `mysql://${f.user}:${f.password}@${f.host}:${f.port || '3306'}/${f.database}`;
-            case 'mssql':
-              return `mssql://${f.user}:${f.password}@${f.host}:${f.port || '1433'}/${f.database}`;
-            case 'mongodb':
-              const scheme = f.srv === 'true' || f.srv === true ? 'mongodb+srv' : 'mongodb';
-              return `${scheme}://${f.user}:${f.password}@${f.host}:${f.port || '27017'}/${f.database}`;
-            case 'duckdb':
-              return `duckdb:///${f.path}`;
-            case 'sqlite':
-              return `sqlite:///${f.path}`;
-            case 'csv':
-              return `csv://${f.path}`;
-            case 'parquet':
-              return `parquet://${f.path}`;
-            case 'jsonl':
-              return `jsonl://${f.path}`;
-            case 'bigquery':
-              let uri = `bigquery://${f.project}/${f.dataset}`;
-              const params = [];
-              if (f.credentials_path) params.push(`credentials_path=${f.credentials_path}`);
-              if (f.location) params.push(`location=${f.location}`);
-              if (params.length) uri += '?' + params.join('&');
-              return uri;
-            case 'snowflake':
-              let sfUri = `snowflake://${f.user}:${f.password}@${f.account}/${f.database}`;
-              if (f.schema) sfUri += '/' + f.schema;
-              if (f.warehouse) sfUri += '?warehouse=' + f.warehouse;
-              return sfUri;
-            default:
-              return '';
-          }
-        }
-
         async function runJob() {
           logs.value = [];
           jobStatus.value = 'running';
           isRunning.value = true;
 
-          const sourceCred = credentials.value.find(c => c.id === selectedSourceCred.value);
-          const destCred = credentials.value.find(c => c.id === selectedDestCred.value);
-          const sourceUri = buildURI(sourceCred.connectorId, sourceCred.fields);
-          const destUri = buildURI(destCred.connectorId, destCred.fields);
-
           const req = {
-            sourceUri,
-            destUri,
+            sourceCredentialId: selectedSourceCred.value,
+            destCredentialId: selectedDestCred.value,
             sourceTable: sourceTable.value,
             destTable: destTable.value || sourceTable.value,
-            strategy: strategy.value,
-            primaryKeys: primaryKeys.value ? primaryKeys.value.split(',').map(s => s.trim()) : [],
-            incrementalKey: incrementalKey.value
+            incrementalStrategy: incrementalStrategy.value,
+            primaryKeys: parseList(primaryKeys.value),
+            incrementalKey: incrementalKey.value,
+            intervalStart: intervalStart.value,
+            intervalEnd: intervalEnd.value,
+            partitionBy: partitionBy.value,
+            clusterBy: clusterBy.value,
+            fullRefresh: fullRefresh.value,
+            schemaContract: schemaContract.value,
+            schemaNaming: schemaNaming.value,
+            progress: 'log',
+            pageSize: numberOrZero(pageSize.value),
+            loaderFileSize: numberOrZero(loaderFileSize.value),
+            loaderFileFormat: loaderFileFormat.value,
+            extractParallelism: numberOrZero(extractParallelism.value),
+            sqlLimit: numberOrZero(sqlLimit.value),
+            sqlExcludeColumns: parseList(sqlExcludeColumns.value),
+            sqlBackend: parseList(sqlBackend.value),
+            columns: columns.value,
+            noInference: noInference.value,
+            mask: parseList(mask.value),
+            trimWhitespace: trimWhitespace.value,
+            noLoadTimestamp: noLoadTimestamp.value,
+            pipelinesDir: pipelinesDir.value,
+            stagingBucket: stagingBucket.value,
+            stagingDataset: stagingDataset.value,
+            debug: debug.value,
+            stream: stream.value,
+            flushInterval: stream.value ? flushInterval.value : '',
+            flushRecords: stream.value ? numberOrZero(flushRecords.value) : 0,
+            queryAnnotations: queryAnnotations.value
           };
 
           try {
@@ -478,7 +648,8 @@
             const data = await res.json();
             jobId.value = data.jobId;
 
-            const ws = new WebSocket(`ws://${location.host}/api/ws/logs/${data.jobId}`);
+            const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+            const ws = new WebSocket(`${wsProtocol}//${location.host}/api/ws/logs/${data.jobId}`);
             ws.onmessage = (e) => {
               const log = JSON.parse(e.data);
               logs.value.push(log);
@@ -503,6 +674,20 @@
             jobStatus.value = 'failed';
             isRunning.value = false;
           }
+        }
+
+        function parseList(value) {
+          return value ? value.split(',').map(s => s.trim()).filter(Boolean) : [];
+        }
+
+        function numberOrZero(value) {
+          const parsed = Number(value);
+          return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+        }
+
+        async function cancelJob() {
+          if (!jobId.value) return;
+          await fetch(`/api/jobs/${jobId.value}/cancel`, { method: 'POST' });
         }
 
         async function toggleRunLogs(run) {
@@ -541,6 +726,12 @@
           }
         });
 
+        watch(stream, (enabled) => {
+          if (enabled && incrementalStrategy.value === 'replace') {
+            incrementalStrategy.value = '';
+          }
+        });
+
         onMounted(() => {
           loadData();
         });
@@ -549,13 +740,19 @@
           activeTab, connectors, credentials, runs,
           newConnConnector, newConnName, newConnFields, currentNewConnConnector,
           selectedSourceCred, selectedDestCred, sourceFields, destFields,
-          sourceTable, destTable, strategy, primaryKeys, incrementalKey,
+          sourceTable, destTable, optionsExpanded, incrementalStrategy, primaryKeys, incrementalKey,
+          intervalStart, intervalEnd, partitionBy, clusterBy, fullRefresh,
+          schemaContract, schemaNaming, pageSize, loaderFileSize,
+          loaderFileFormat, extractParallelism, sqlLimit, sqlExcludeColumns,
+          sqlBackend, columns, noInference, mask, trimWhitespace, noLoadTimestamp,
+          pipelinesDir, stagingBucket, stagingDataset, debug, stream,
+          flushInterval, flushRecords, queryAnnotations,
           isRunning, jobId, jobStatus, logs, logContainer,
           expandedRunId, selectedRunLogs, totalRuns, runsOffset, runsPerPage,
           sourceConnectors, destConnectors, sourceCredentials, destCredentials,
           canRun, statusClass,
           getConnectorName, resetNewConnFields, saveNewConnection, deleteConnection,
-          loadSourceCred, loadDestCred, runJob, toggleRunLogs, loadRuns,
+          loadSourceCred, loadDestCred, runJob, cancelJob, toggleRunLogs, loadRuns,
           prevPage, nextPage, formatTime, formatDateTime, logClass
         };
       }


### PR DESCRIPTION
Runs web UI ingestion through the ingestr CLI and maps the CLI flag surface into server requests.

Expands source/destination connector coverage, hardens subprocess logging and cancellation, and makes the options pane collapsed by default.

Validated with make format, make lint, and make test.