### PR TITLE
Fix schema evolution Arrow ownership

### DIFF
--- a/pkg/schemaevolution/transform.go
+++ b/pkg/schemaevolution/transform.go
@@ -21,6 +21,7 @@ type BatchTransformer interface {
 type DiscardValueTransformer struct {
 	violations map[string]bool // column name -> has violation
 	destSchema *schema.TableSchema
+	allocator  memory.Allocator
 }
 
 // NewDiscardValueTransformer creates a transformer for discard_value mode.
@@ -29,6 +30,7 @@ func NewDiscardValueTransformer(comparison *SchemaComparison, _ *schema.TableSch
 	transformer := &DiscardValueTransformer{
 		violations: make(map[string]bool),
 		destSchema: destSchema,
+		allocator:  memory.DefaultAllocator,
 	}
 
 	if comparison != nil {
@@ -54,6 +56,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 	// Create a copy of the schema to modify
 	batchSchema := batch.Schema()
 	columns := make([]arrow.Array, batch.NumCols())
+	allocator := allocatorOrDefault(t.allocator)
 
 	// For each column with violations, replace with NULL values
 	for colIdx := 0; colIdx < int(batch.NumCols()); colIdx++ {
@@ -73,13 +76,13 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 				}
 			}
 
-			builder := array.NewBuilder(memory.DefaultAllocator, targetType)
-			defer builder.Release()
+			builder := array.NewBuilder(allocator, targetType)
 
 			for i := 0; i < int(batch.NumRows()); i++ {
 				builder.AppendNull()
 			}
 			columns[colIdx] = builder.NewArray()
+			builder.Release()
 		} else {
 			// Keep original column
 			columns[colIdx] = batch.Column(colIdx)
@@ -100,6 +103,11 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 	}
 	newSchema := arrow.NewSchema(newFields, nil)
 	newBatch := array.NewRecordBatch(newSchema, columns, batch.NumRows())
+	for i, col := range columns {
+		if t.violations[batchSchema.Field(i).Name] {
+			col.Release()
+		}
+	}
 	return newBatch, nil
 }
 
@@ -108,6 +116,7 @@ type DiscardRowTransformer struct {
 	violations map[string]bool // column name -> has violation
 	schema     *schema.TableSchema
 	destSchema *schema.TableSchema
+	allocator  memory.Allocator
 }
 
 // NewDiscardRowTransformer creates a transformer for discard_row mode.
@@ -116,6 +125,7 @@ func NewDiscardRowTransformer(sourceSchema, destSchema *schema.TableSchema, comp
 		violations: make(map[string]bool),
 		schema:     sourceSchema,
 		destSchema: destSchema,
+		allocator:  memory.DefaultAllocator,
 	}
 
 	if comparison != nil {
@@ -150,10 +160,11 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 	if len(violationCols) == 0 {
 		return batch, nil
 	}
+	allocator := allocatorOrDefault(t.allocator)
 
 	// Create a boolean filter array: true for rows to keep, false for rows to discard
 	// Keep rows where all violation columns are NULL
-	filterBuilder := array.NewBooleanBuilder(memory.DefaultAllocator)
+	filterBuilder := array.NewBooleanBuilder(allocator)
 	defer filterBuilder.Release()
 
 	for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
@@ -176,14 +187,17 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 
 	// Apply filter using compute function
 	opts := compute.DefaultFilterOptions()
-	filtered, err := compute.FilterRecordBatch(ctx, batch, filterArray, opts)
+	filtered, err := compute.FilterRecordBatch(compute.WithAllocator(ctx, allocator), batch, filterArray, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter rows: %w", err)
 	}
 
 	if filtered == nil || filtered.NumRows() == 0 {
+		if filtered != nil {
+			filtered.Release()
+		}
 		// Return empty batch if all rows filtered out
-		return createEmptyBatch(batch), nil
+		return createEmptyBatchWithAllocator(batch, allocator), nil
 	}
 
 	return filtered, nil
@@ -197,19 +211,21 @@ func TransformBatchStream(ctx context.Context, batches <-chan source.RecordBatch
 		defer close(out)
 
 		for result := range batches {
-			// Pass through errors
-			if result.Err != nil {
+			if result.Err != nil || result.Batch == nil {
 				out <- result
 				continue
 			}
 
-			// Transform batch
 			transformed, err := transformer.Transform(ctx, result.Batch)
 			if err != nil {
+				result.Batch.Release()
 				out <- source.RecordBatchResult{Err: err, TableName: result.TableName}
 				continue
 			}
 
+			if transformed != result.Batch {
+				result.Batch.Release()
+			}
 			result.Batch = transformed
 			out <- result
 		}
@@ -221,12 +237,14 @@ func TransformBatchStream(ctx context.Context, batches <-chan source.RecordBatch
 // RemovedColumnTransformer adds NULL columns for columns that exist in destination but not in source.
 type RemovedColumnTransformer struct {
 	removedColumns []schema.Column
+	allocator      memory.Allocator
 }
 
 // NewRemovedColumnTransformer creates a transformer that adds NULL columns for removed columns.
 func NewRemovedColumnTransformer(comparison *SchemaComparison) *RemovedColumnTransformer {
 	transformer := &RemovedColumnTransformer{
 		removedColumns: make([]schema.Column, 0),
+		allocator:      memory.DefaultAllocator,
 	}
 
 	if comparison != nil {
@@ -260,6 +278,7 @@ func (t *RemovedColumnTransformer) Transform(ctx context.Context, batch arrow.Re
 	newNumCols := int(batch.NumCols()) + len(t.removedColumns)
 	newFields := make([]arrow.Field, newNumCols)
 	columns := make([]arrow.Array, newNumCols)
+	allocator := allocatorOrDefault(t.allocator)
 
 	// Copy existing columns
 	for i := 0; i < int(batch.NumCols()); i++ {
@@ -277,7 +296,7 @@ func (t *RemovedColumnTransformer) Transform(ctx context.Context, batch arrow.Re
 			Nullable: true,
 		}
 
-		builder := array.NewBuilder(memory.DefaultAllocator, arrowType)
+		builder := array.NewBuilder(allocator, arrowType)
 		for j := 0; j < int(batch.NumRows()); j++ {
 			builder.AppendNull()
 		}
@@ -286,16 +305,21 @@ func (t *RemovedColumnTransformer) Transform(ctx context.Context, batch arrow.Re
 	}
 
 	newSchema := arrow.NewSchema(newFields, nil)
-	return array.NewRecordBatch(newSchema, columns, batch.NumRows()), nil
+	newBatch := array.NewRecordBatch(newSchema, columns, batch.NumRows())
+	for i := int(batch.NumCols()); i < len(columns); i++ {
+		columns[i].Release()
+	}
+	return newBatch, nil
 }
 
 // IngestrColumnFiller adds ingestr metadata columns with "-" to each batch.
 type IngestrColumnFiller struct {
 	columnNames []string
+	allocator   memory.Allocator
 }
 
 func NewIngestrColumnFiller(columnNames []string) *IngestrColumnFiller {
-	return &IngestrColumnFiller{columnNames: columnNames}
+	return &IngestrColumnFiller{columnNames: columnNames, allocator: memory.DefaultAllocator}
 }
 
 func (t *IngestrColumnFiller) HasColumns() bool {
@@ -327,6 +351,7 @@ func (t *IngestrColumnFiller) Transform(ctx context.Context, batch arrow.RecordB
 	newNumCols := int(batch.NumCols()) + len(colsToAdd)
 	newFields := make([]arrow.Field, newNumCols)
 	columns := make([]arrow.Array, newNumCols)
+	allocator := allocatorOrDefault(t.allocator)
 
 	for i := 0; i < int(batch.NumCols()); i++ {
 		newFields[i] = batchSchema.Field(i)
@@ -341,7 +366,7 @@ func (t *IngestrColumnFiller) Transform(ctx context.Context, batch arrow.RecordB
 			Nullable: false,
 		}
 
-		builder := array.NewStringBuilder(memory.DefaultAllocator)
+		builder := array.NewStringBuilder(allocator)
 		for j := 0; j < int(batch.NumRows()); j++ {
 			builder.Append("-")
 		}
@@ -350,20 +375,36 @@ func (t *IngestrColumnFiller) Transform(ctx context.Context, batch arrow.RecordB
 	}
 
 	newSchema := arrow.NewSchema(newFields, nil)
-	return array.NewRecordBatch(newSchema, columns, batch.NumRows()), nil
+	newBatch := array.NewRecordBatch(newSchema, columns, batch.NumRows())
+	for i := int(batch.NumCols()); i < len(columns); i++ {
+		columns[i].Release()
+	}
+	return newBatch, nil
 }
 
 // Helper functions
 
-func createEmptyBatch(template arrow.RecordBatch) arrow.RecordBatch {
+func createEmptyBatchWithAllocator(template arrow.RecordBatch, allocator memory.Allocator) arrow.RecordBatch {
 	schema := template.Schema()
 	emptyColumns := make([]arrow.Array, schema.NumFields())
+	allocator = allocatorOrDefault(allocator)
 
 	for i := 0; i < schema.NumFields(); i++ {
-		builder := array.NewBuilder(memory.DefaultAllocator, schema.Field(i).Type)
-		defer builder.Release()
+		builder := array.NewBuilder(allocator, schema.Field(i).Type)
 		emptyColumns[i] = builder.NewArray()
+		builder.Release()
 	}
 
-	return array.NewRecordBatch(schema, emptyColumns, 0)
+	emptyBatch := array.NewRecordBatch(schema, emptyColumns, 0)
+	for _, col := range emptyColumns {
+		col.Release()
+	}
+	return emptyBatch
+}
+
+func allocatorOrDefault(allocator memory.Allocator) memory.Allocator {
+	if allocator != nil {
+		return allocator
+	}
+	return memory.DefaultAllocator
 }

--- a/pkg/schemaevolution/transform_test.go
+++ b/pkg/schemaevolution/transform_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,9 +160,124 @@ func TestIngestrColumnFiller_Transform(t *testing.T) {
 	})
 }
 
+func TestTransformBatchStream_ReleasesReplacedInputBatch(t *testing.T) {
+	mem := newCheckedAllocator(t)
+
+	filler := NewIngestrColumnFiller([]string{"_dlt_load_id"})
+	filler.allocator = mem
+	input := make(chan source.RecordBatchResult, 1)
+	input <- source.RecordBatchResult{
+		Batch:       createTestBatchWithAllocator(mem, []string{"id"}, 2),
+		TableName:   "public.users",
+		CommitToken: "token-1",
+	}
+	close(input)
+
+	out := TransformBatchStream(context.Background(), input, filler)
+	result := <-out
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	assert.Equal(t, "public.users", result.TableName)
+	assert.Equal(t, "token-1", result.CommitToken)
+	result.Batch.Release()
+
+	_, ok := <-out
+	assert.False(t, ok)
+}
+
+func TestTransformBatchStream_PassesNilBatchResultThrough(t *testing.T) {
+	filler := NewIngestrColumnFiller([]string{"_dlt_load_id"})
+	input := make(chan source.RecordBatchResult, 1)
+	input <- source.RecordBatchResult{CommitToken: "keepalive"}
+	close(input)
+
+	out := TransformBatchStream(context.Background(), input, filler)
+	result := <-out
+	require.NoError(t, result.Err)
+	assert.Nil(t, result.Batch)
+	assert.Equal(t, "keepalive", result.CommitToken)
+}
+
+func TestDiscardValueTransformer_ReleasesTemporaryArrays(t *testing.T) {
+	mem := newCheckedAllocator(t)
+
+	comparison := &SchemaComparison{
+		HasChanges: true,
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeWidenType,
+				ColumnName: "age",
+				OldColumn:  &schema.Column{Name: "age", DataType: schema.TypeInt64},
+				NewColumn:  schema.Column{Name: "age", DataType: schema.TypeString},
+			},
+		},
+	}
+	destSchema := &schema.TableSchema{
+		Columns: []schema.Column{{Name: "age", DataType: schema.TypeInt64, Nullable: true}},
+	}
+	transformer := NewDiscardValueTransformer(comparison, nil, destSchema)
+	transformer.allocator = mem
+
+	batch := createTestBatchWithAllocator(mem, []string{"age", "name"}, 2)
+	result, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	result.Release()
+	batch.Release()
+}
+
+func TestRemovedColumnTransformer_ReleasesTemporaryArrays(t *testing.T) {
+	mem := newCheckedAllocator(t)
+
+	transformer := NewRemovedColumnTransformer(&SchemaComparison{
+		HasChanges: true,
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeRemoveColumn,
+				ColumnName: "removed",
+				OldColumn:  &schema.Column{Name: "removed", DataType: schema.TypeString, Nullable: true},
+			},
+		},
+	})
+	transformer.allocator = mem
+
+	batch := createTestBatchWithAllocator(mem, []string{"id"}, 2)
+	result, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	result.Release()
+	batch.Release()
+}
+
+func TestDiscardRowTransformer_ReleasesFilteredEmptyBatch(t *testing.T) {
+	mem := newCheckedAllocator(t)
+
+	transformer := NewDiscardRowTransformer(nil, nil, &SchemaComparison{
+		HasChanges: true,
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeWidenType,
+				ColumnName: "id",
+				OldColumn:  &schema.Column{Name: "id", DataType: schema.TypeString, Nullable: true},
+				NewColumn:  schema.Column{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+			},
+		},
+	})
+	transformer.allocator = mem
+
+	batch := createTestBatchWithAllocator(mem, []string{"id"}, 2)
+	result, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result.NumRows())
+	result.Release()
+	batch.Release()
+}
+
 // createTestBatch creates a simple Arrow batch with string columns for testing.
 func createTestBatch(colNames []string, numRows int) arrow.RecordBatch {
 	mem := memory.DefaultAllocator
+	return createTestBatchWithAllocator(mem, colNames, numRows)
+}
+
+func createTestBatchWithAllocator(mem memory.Allocator, colNames []string, numRows int) arrow.RecordBatch {
 	fields := make([]arrow.Field, len(colNames))
 	arrays := make([]arrow.Array, len(colNames))
 
@@ -181,4 +297,14 @@ func createTestBatch(colNames []string, numRows int) arrow.RecordBatch {
 		arr.Release()
 	}
 	return batch
+}
+
+func newCheckedAllocator(t *testing.T) *memory.CheckedAllocator {
+	t.Helper()
+
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() {
+		mem.AssertSize(t, 0)
+	})
+	return mem
 }

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -357,6 +357,7 @@ func TestStreamingExecutor_PassesFlushOptionsToSource(t *testing.T) {
 	assert.Equal(t, 123*time.Millisecond, src.readOpts.FlushInterval)
 	assert.Equal(t, 7, src.readOpts.FlushRecords)
 }
+
 func TestStreaming_ExecuteAppliesBatchTransformationsOnce(t *testing.T) {
 	job, src, _ := minimalJob()
 	dest := &capturingDestination{fakeDestination: &fakeDestination{}}


### PR DESCRIPTION
Fixes Arrow batch ownership in schema evolution transforms.\n\nChecks:\n- make format\n- make lint\n- make test