### PR TITLE
Optimize MongoDB benchmark ingestion paths

### DIFF
--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -656,6 +656,17 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 	}
 
 	if !targetHasRows {
+		stagingKeysUnique, err := d.stagingPrimaryKeysUniqueLocked(ctx, opts)
+		if err != nil {
+			return fmt.Errorf("failed to check staging primary key uniqueness: %w", err)
+		}
+		if stagingKeysUnique {
+			config.Debug("[DUCKDB MERGE] Empty-target staging keys are unique; using direct INSERT")
+			insertSource = fmt.Sprintf(`%s AS source`, destination.QuoteTableName(opts.StagingTable))
+		} else {
+			config.Debug("[DUCKDB MERGE] Empty-target staging keys need deduplication")
+		}
+
 		insertSQL := fmt.Sprintf(
 			`INSERT INTO %s (%s) SELECT %s FROM %s`,
 			quotedTargetTable,
@@ -731,6 +742,96 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	config.Debug("[DUCKDB MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func (d *DuckDBDestination) stagingPrimaryKeysUniqueLocked(ctx context.Context, opts destination.MergeOptions) (bool, error) {
+	if len(opts.PrimaryKeys) == 0 {
+		return false, nil
+	}
+
+	totalExpr := "COUNT(*)"
+	nullChecks := make([]string, len(opts.PrimaryKeys))
+	for i, pk := range opts.PrimaryKeys {
+		nullChecks[i] = fmt.Sprintf("%s IS NULL", destination.QuoteIdentifier(pk))
+	}
+
+	distinctExpr := ""
+	if len(opts.PrimaryKeys) == 1 {
+		distinctExpr = fmt.Sprintf("COUNT(DISTINCT %s)", destination.QuoteIdentifier(opts.PrimaryKeys[0]))
+	} else {
+		distinctExpr = fmt.Sprintf("COUNT(DISTINCT (%s))", strings.Join(quoteColumns(opts.PrimaryKeys), ", "))
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s AS total_rows, %s AS distinct_keys, COUNT(*) FILTER (WHERE %s) AS null_keys FROM %s`,
+		totalExpr,
+		distinctExpr,
+		strings.Join(nullChecks, " OR "),
+		destination.QuoteTableName(opts.StagingTable),
+	)
+
+	stmt, err := d.conn.NewStatement()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = stmt.Close() }()
+
+	if err := stmt.SetSqlQuery(query); err != nil {
+		config.LogFailedQuery(query, err)
+		return false, err
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return false, err
+	}
+	defer reader.Release()
+
+	if !reader.Next() {
+		if err := reader.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	batch := reader.RecordBatch()
+	if batch.NumRows() == 0 || batch.NumCols() != 3 {
+		return false, fmt.Errorf("unexpected uniqueness check result shape")
+	}
+
+	total, ok := int64ValueAt(batch.Column(0), 0)
+	if !ok {
+		return false, fmt.Errorf("unexpected total row count type %s", batch.Column(0).DataType())
+	}
+	distinctKeys, ok := int64ValueAt(batch.Column(1), 0)
+	if !ok {
+		return false, fmt.Errorf("unexpected distinct key count type %s", batch.Column(1).DataType())
+	}
+	nullKeys, ok := int64ValueAt(batch.Column(2), 0)
+	if !ok {
+		return false, fmt.Errorf("unexpected null key count type %s", batch.Column(2).DataType())
+	}
+
+	return nullKeys == 0 && total == distinctKeys, nil
+}
+
+func int64ValueAt(arr arrow.Array, index int) (int64, bool) {
+	if arr.IsNull(index) {
+		return 0, false
+	}
+
+	switch col := arr.(type) {
+	case *array.Int64:
+		return col.Value(index), true
+	case *array.Uint64:
+		v := col.Value(index)
+		if v > uint64(^uint64(0)>>1) {
+			return 0, false
+		}
+		return int64(v), true
+	}
+	return 0, false
 }
 
 func (d *DuckDBDestination) tableHasRowsLocked(ctx context.Context, quotedTable string) (bool, error) {

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-adbc/go/adbc"
@@ -245,6 +246,9 @@ func (d *DuckDBDestination) writeViaADBCIngest(ctx context.Context, records <-ch
 			config.Debug("[DUCKDB] Invalid INGESTR_DUCKDB_CHECKPOINT_ROWS=%q, checkpointing disabled: %v", v, err)
 		}
 	}
+	if checkpointEvery == 0 {
+		return d.writeViaSingleADBCIngest(ctx, records, tableName, ingestOpts, startTotal)
+	}
 
 	var totalRows int64
 	var rowsSinceCheckpoint int64
@@ -294,6 +298,198 @@ func (d *DuckDBDestination) writeViaADBCIngest(ctx context.Context, records <-ch
 	config.Debug("[DUCKDB] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), totalRate)
 	return nil
 }
+
+func (d *DuckDBDestination) writeViaSingleADBCIngest(ctx context.Context, records <-chan source.RecordBatchResult, tableName string, ingestOpts adbc.IngestStreamOptions, startTotal time.Time) error {
+	first, err := nextNonEmptyRecord(ctx, records)
+	if err != nil {
+		return err
+	}
+	if first == nil {
+		config.Debug("[DUCKDB] Total: 0 rows written in %v (0 rows/sec)", time.Since(startTotal))
+		return nil
+	}
+
+	reader := newChannelRecordReader(ctx, records, first)
+	_, ingestErr := adbc.IngestStream(ctx, d.conn, reader, tableName, adbc.OptionValueIngestModeAppend, ingestOpts)
+	totalRows := reader.rowsWritten()
+	readerErr := reader.Err()
+	reader.Release()
+
+	if ingestErr != nil {
+		config.Debug("[DUCKDB] IngestStream error: %v", ingestErr)
+		return fmt.Errorf("failed to ingest batch: %w", ingestErr)
+	}
+	if readerErr != nil {
+		return readerErr
+	}
+
+	totalRate := float64(totalRows) / time.Since(startTotal).Seconds()
+	config.Debug("[DUCKDB] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), totalRate)
+	return nil
+}
+
+func nextNonEmptyRecord(ctx context.Context, records <-chan source.RecordBatchResult) (arrow.RecordBatch, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case res, ok := <-records:
+			if !ok {
+				return nil, nil
+			}
+			if res.Err != nil {
+				if res.Batch != nil {
+					res.Batch.Release()
+				}
+				return nil, res.Err
+			}
+			if res.Batch == nil {
+				continue
+			}
+			if res.Batch.NumRows() == 0 {
+				res.Batch.Release()
+				continue
+			}
+			return res.Batch, nil
+		}
+	}
+}
+
+type channelRecordReader struct {
+	refCount atomic.Int64
+	ctx      context.Context
+	records  <-chan source.RecordBatchResult
+	schema   *arrow.Schema
+	first    arrow.RecordBatch
+	current  arrow.RecordBatch
+	err      error
+	rows     atomic.Int64
+}
+
+func newChannelRecordReader(ctx context.Context, records <-chan source.RecordBatchResult, first arrow.RecordBatch) *channelRecordReader {
+	reader := &channelRecordReader{
+		ctx:     ctx,
+		records: records,
+		schema:  first.Schema(),
+		first:   first,
+	}
+	reader.refCount.Add(1)
+	return reader
+}
+
+func (r *channelRecordReader) Retain() {
+	r.refCount.Add(1)
+}
+
+func (r *channelRecordReader) Release() {
+	if r.refCount.Add(-1) != 0 {
+		return
+	}
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
+	if r.first != nil {
+		r.first.Release()
+		r.first = nil
+	}
+}
+
+func (r *channelRecordReader) Schema() *arrow.Schema {
+	return r.schema
+}
+
+func (r *channelRecordReader) Next() bool {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
+	if r.err != nil {
+		return false
+	}
+	if r.first != nil {
+		r.current = r.first
+		r.first = nil
+		r.rows.Add(r.current.NumRows())
+		return true
+	}
+
+	for {
+		select {
+		case <-r.ctx.Done():
+			r.err = r.ctx.Err()
+			return false
+		case res, ok := <-r.records:
+			if !ok {
+				return false
+			}
+			if res.Err != nil {
+				if res.Batch != nil {
+					res.Batch.Release()
+				}
+				r.err = res.Err
+				return false
+			}
+			if res.Batch == nil {
+				continue
+			}
+			if res.Batch.NumRows() == 0 {
+				res.Batch.Release()
+				continue
+			}
+			batch := res.Batch
+			if !batch.Schema().Equal(r.schema) {
+				rewrapped, ok := rewrapRecordBatchWithSchema(batch, r.schema)
+				if !ok {
+					batch.Release()
+					r.err = fmt.Errorf("record batch schema changed during DuckDB ingest")
+					return false
+				}
+				res.Batch.Release()
+				batch = rewrapped
+			}
+			r.current = batch
+			r.rows.Add(r.current.NumRows())
+			return true
+		}
+	}
+}
+
+func rewrapRecordBatchWithSchema(batch arrow.RecordBatch, target *arrow.Schema) (arrow.RecordBatch, bool) {
+	if batch.Schema().NumFields() != target.NumFields() {
+		return nil, false
+	}
+
+	cols := make([]arrow.Array, batch.NumCols())
+	for i := 0; i < int(batch.NumCols()); i++ {
+		sourceField := batch.Schema().Field(i)
+		targetField := target.Field(i)
+		if sourceField.Name != targetField.Name || !arrow.TypeEqual(sourceField.Type, targetField.Type) {
+			return nil, false
+		}
+		cols[i] = batch.Column(i)
+	}
+
+	return array.NewRecordBatch(target, cols, batch.NumRows()), true
+}
+
+func (r *channelRecordReader) RecordBatch() arrow.RecordBatch {
+	return r.current
+}
+
+func (r *channelRecordReader) Record() arrow.RecordBatch {
+	return r.RecordBatch()
+}
+
+func (r *channelRecordReader) Err() error {
+	return r.err
+}
+
+func (r *channelRecordReader) rowsWritten() int64 {
+	return r.rows.Load()
+}
+
+var _ array.RecordReader = (*channelRecordReader)(nil)
 
 func (d *DuckDBDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
 	startSwap := time.Now()

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -450,6 +450,38 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 		insertSource = dedupSource("")
 	}
 
+	targetHasRows := true
+	if !isCDC {
+		var err error
+		targetHasRows, err = d.tableHasRowsLocked(ctx, quotedTargetTable)
+		if err != nil {
+			return fmt.Errorf("failed to check target table rows: %w", err)
+		}
+	}
+
+	if !targetHasRows {
+		insertSQL := fmt.Sprintf(
+			`INSERT INTO %s (%s) SELECT %s FROM %s`,
+			quotedTargetTable,
+			strings.Join(destQuoted, ", "),
+			strings.Join(destQuoted, ", "),
+			insertSource,
+		)
+		config.Debug("[DUCKDB MERGE] Executing empty-target INSERT: %s", insertSQL)
+
+		if err := d.exec(ctx, insertSQL); err != nil {
+			return fmt.Errorf("failed to insert new records: %w", err)
+		}
+
+		if err := d.exec(ctx, "COMMIT"); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		commit = true
+
+		config.Debug("[DUCKDB MERGE] Merge completed in %v", time.Since(startMerge))
+		return nil
+	}
+
 	if len(nonPKColumns) > 0 {
 		updateSQL := fmt.Sprintf(
 			`UPDATE %s AS target SET %s FROM %s WHERE %s`,
@@ -503,6 +535,43 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 
 	config.Debug("[DUCKDB MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil
+}
+
+func (d *DuckDBDestination) tableHasRowsLocked(ctx context.Context, quotedTable string) (bool, error) {
+	stmt, err := d.conn.NewStatement()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = stmt.Close() }()
+
+	query := fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM %s LIMIT 1)", quotedTable)
+	if err := stmt.SetSqlQuery(query); err != nil {
+		config.LogFailedQuery(query, err)
+		return false, err
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return false, err
+	}
+	defer reader.Release()
+
+	if !reader.Next() {
+		if err := reader.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	batch := reader.RecordBatch()
+	if batch.NumRows() == 0 || batch.NumCols() == 0 || batch.Column(0).IsNull(0) {
+		return false, nil
+	}
+	if col, ok := batch.Column(0).(*array.Boolean); ok {
+		return col.Value(0), nil
+	}
+	return false, fmt.Errorf("unexpected EXISTS result type %s", batch.Column(0).DataType())
 }
 
 func (d *DuckDBDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -798,6 +798,86 @@ func TestTableHasRowsLocked(t *testing.T) {
 	assert.True(t, hasRows)
 }
 
+func TestChannelRecordReaderSkipsEmptyBatches(t *testing.T) {
+	ctx := context.Background()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	first := makeDuckDBRecordBatch(t, schema, []int64{1})
+	empty := makeDuckDBRecordBatch(t, schema, nil)
+	second := makeDuckDBRecordBatch(t, schema, []int64{2, 3})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: empty}
+	records <- source.RecordBatchResult{Batch: second}
+	close(records)
+
+	reader := newChannelRecordReader(ctx, records, first)
+	defer reader.Release()
+
+	require.True(t, reader.Next())
+	assert.Equal(t, int64(1), reader.RecordBatch().NumRows())
+	require.True(t, reader.Next())
+	assert.Equal(t, int64(2), reader.RecordBatch().NumRows())
+	assert.False(t, reader.Next())
+	assert.NoError(t, reader.Err())
+	assert.Equal(t, int64(3), reader.rowsWritten())
+}
+
+func TestChannelRecordReaderRewrapsCompatibleSchema(t *testing.T) {
+	ctx := context.Background()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false}}, nil)
+	nullableSchema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true}}, nil)
+	first := makeDuckDBRecordBatch(t, schema, []int64{1})
+	second := makeDuckDBRecordBatch(t, nullableSchema, []int64{2})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: second}
+	close(records)
+
+	reader := newChannelRecordReader(ctx, records, first)
+	defer reader.Release()
+
+	require.True(t, reader.Next())
+	assert.True(t, reader.RecordBatch().Schema().Equal(schema))
+	require.True(t, reader.Next())
+	assert.True(t, reader.RecordBatch().Schema().Equal(schema))
+	assert.Equal(t, int64(2), reader.rowsWritten())
+	assert.False(t, reader.Next())
+	assert.NoError(t, reader.Err())
+}
+
+func TestChannelRecordReaderReportsSchemaChange(t *testing.T) {
+	ctx := context.Background()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	otherSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	first := makeDuckDBRecordBatch(t, schema, []int64{1})
+	second := makeDuckDBRecordBatch(t, otherSchema, []int64{2})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: second}
+	close(records)
+
+	reader := newChannelRecordReader(ctx, records, first)
+	defer reader.Release()
+
+	require.True(t, reader.Next())
+	assert.False(t, reader.Next())
+	assert.ErrorContains(t, reader.Err(), "schema changed")
+}
+
+func makeDuckDBRecordBatch(t *testing.T, schema *arrow.Schema, values []int64) arrow.RecordBatch {
+	t.Helper()
+
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer builder.Release()
+	for _, value := range values {
+		builder.Append(value)
+	}
+	arr := builder.NewArray()
+	defer arr.Release()
+
+	return array.NewRecordBatch(schema, []arrow.Array{arr}, int64(len(values)))
+}
+
 func TestMergeTable_CDCMaterializesDeleteOnlyTombstone(t *testing.T) {
 	ctx := context.Background()
 	dest, path := connectTestDuckDB(t, ctx)

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -779,6 +779,106 @@ func TestMergeTable_EmptyTargetDedupesStagingByPK(t *testing.T) {
 	assert.Equal(t, 20, updatedAt)
 }
 
+func TestMergeTable_EmptyTargetUniqueStagingInsertsRows(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	err := dest.Exec(ctx, `
+		CREATE TABLE target_table (
+			id BIGINT PRIMARY KEY,
+			name VARCHAR
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		CREATE TABLE staging_table (
+			id BIGINT,
+			name VARCHAR
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(1, 'Alice'),
+			(2, 'Bob')
+	`)
+	require.NoError(t, err)
+
+	err = dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		TargetTable:  "target_table",
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name"},
+	})
+	require.NoError(t, err)
+
+	db := openDuckDB(t, ctx, path)
+	var total int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM target_table").Scan(&total))
+	assert.Equal(t, 2, total)
+
+	var nameRaw []byte
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT name FROM target_table WHERE id = 2").Scan(&nameRaw))
+	assert.Equal(t, "Bob", string(append([]byte(nil), nameRaw...)))
+}
+
+func TestStagingPrimaryKeysUniqueLocked(t *testing.T) {
+	ctx := context.Background()
+	dest, _ := connectTestDuckDB(t, ctx)
+
+	err := dest.Exec(ctx, `
+		CREATE TABLE staging_table (
+			id BIGINT,
+			part BIGINT,
+			name VARCHAR
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(1, 10, 'Alice'),
+			(2, 10, 'Bob')
+	`)
+	require.NoError(t, err)
+
+	unique, err := dest.stagingPrimaryKeysUniqueLocked(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		PrimaryKeys:  []string{"id"},
+	})
+	require.NoError(t, err)
+	assert.True(t, unique)
+
+	err = dest.Exec(ctx, `INSERT INTO staging_table VALUES (2, 20, 'Bob duplicate')`)
+	require.NoError(t, err)
+
+	unique, err = dest.stagingPrimaryKeysUniqueLocked(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		PrimaryKeys:  []string{"id"},
+	})
+	require.NoError(t, err)
+	assert.False(t, unique)
+
+	unique, err = dest.stagingPrimaryKeysUniqueLocked(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		PrimaryKeys:  []string{"id", "part"},
+	})
+	require.NoError(t, err)
+	assert.True(t, unique)
+
+	err = dest.Exec(ctx, `INSERT INTO staging_table VALUES (NULL, 30, 'No id')`)
+	require.NoError(t, err)
+
+	unique, err = dest.stagingPrimaryKeysUniqueLocked(ctx, destination.MergeOptions{
+		StagingTable: "staging_table",
+		PrimaryKeys:  []string{"id", "part"},
+	})
+	require.NoError(t, err)
+	assert.False(t, unique)
+}
+
 func TestTableHasRowsLocked(t *testing.T) {
 	ctx := context.Background()
 	dest, _ := connectTestDuckDB(t, ctx)

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -726,6 +726,78 @@ func TestMergeTable(t *testing.T) {
 	assert.Equal(t, 300, value)
 }
 
+func TestMergeTable_EmptyTargetDedupesStagingByPK(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	err := dest.Exec(ctx, `
+		CREATE TABLE target_table (
+			id BIGINT PRIMARY KEY,
+			name VARCHAR,
+			updated_at BIGINT
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		CREATE TABLE staging_table (
+			id BIGINT,
+			name VARCHAR,
+			updated_at BIGINT
+		)
+	`)
+	require.NoError(t, err)
+
+	err = dest.Exec(ctx, `
+		INSERT INTO staging_table VALUES
+			(1, 'Alice Old', 10),
+			(1, 'Alice New', 20),
+			(2, 'Bob', 15)
+	`)
+	require.NoError(t, err)
+
+	err = dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   "staging_table",
+		TargetTable:    "target_table",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "name", "updated_at"},
+		IncrementalKey: "updated_at",
+	})
+	require.NoError(t, err)
+
+	db := openDuckDB(t, ctx, path)
+	var total, id1Count int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM target_table").Scan(&total))
+	assert.Equal(t, 2, total)
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM target_table WHERE id = 1").Scan(&id1Count))
+	assert.Equal(t, 1, id1Count)
+
+	var nameRaw []byte
+	var updatedAt int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT name, updated_at FROM target_table WHERE id = 1").Scan(&nameRaw, &updatedAt))
+	assert.Equal(t, "Alice New", string(append([]byte(nil), nameRaw...)))
+	assert.Equal(t, 20, updatedAt)
+}
+
+func TestTableHasRowsLocked(t *testing.T) {
+	ctx := context.Background()
+	dest, _ := connectTestDuckDB(t, ctx)
+
+	err := dest.Exec(ctx, `CREATE TABLE target_table (id BIGINT)`)
+	require.NoError(t, err)
+
+	hasRows, err := dest.tableHasRowsLocked(ctx, destination.QuoteTableName("target_table"))
+	require.NoError(t, err)
+	assert.False(t, hasRows)
+
+	err = dest.Exec(ctx, `INSERT INTO target_table VALUES (1)`)
+	require.NoError(t, err)
+
+	hasRows, err = dest.tableHasRowsLocked(ctx, destination.QuoteTableName("target_table"))
+	require.NoError(t, err)
+	assert.True(t, hasRows)
+}
+
 func TestMergeTable_CDCMaterializesDeleteOnlyTombstone(t *testing.T) {
 	ctx := context.Background()
 	dest, path := connectTestDuckDB(t, ctx)

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -701,7 +701,7 @@ func addPrimaryKey(ctx context.Context, tx *sql.Tx, table, constraintName string
 		constraintClause = " CONSTRAINT " + quoteColumn(constraintName)
 	}
 
-	addSQL := fmt.Sprintf("ALTER TABLE %s ADD%s PRIMARY KEY (%s) WITH (SORT_IN_TEMPDB = ON, MAXDOP = 4)", quoteTable(table), constraintClause, quotedKeys)
+	addSQL := fmt.Sprintf("ALTER TABLE %s ADD%s PRIMARY KEY (%s) WITH (SORT_IN_TEMPDB = ON)", quoteTable(table), constraintClause, quotedKeys)
 	config.Debug("[MERGE] Recreating target primary key after bulk insert: %s", addSQL)
 	if _, err := tx.ExecContext(ctx, addSQL); err != nil {
 		config.LogFailedQuery(addSQL, err)

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -518,13 +518,14 @@ func (d *MSSQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 	startMerge := time.Now()
 
 	if len(opts.PrimaryKeys) > 0 && !destination.HasCDCDeletedColumn(opts.Columns) {
-		insertSQL := buildInsertDedupSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
-		inserted, err := d.insertIntoEmptyTarget(ctx, opts.TargetTable, opts.PrimaryKeys, insertSQL)
+		directInsertSQL := buildInsertDirectSQL(opts.TargetTable, opts.StagingTable, opts.Columns)
+		dedupInsertSQL := buildInsertDedupSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
+		inserted, err := d.insertIntoEmptyTarget(ctx, opts.TargetTable, opts.PrimaryKeys, directInsertSQL, dedupInsertSQL)
 		if err != nil {
 			return err
 		}
 		if inserted {
-			config.Debug("[MERGE] Deduplicated insert completed in %v", time.Since(startMerge))
+			config.Debug("[MERGE] Empty-target insert completed in %v", time.Since(startMerge))
 			return nil
 		}
 	}
@@ -558,7 +559,7 @@ func buildTableIsEmptyForUpdateSQL(table string) string {
 	return fmt.Sprintf("SELECT TOP (1) 1 FROM %s WITH (TABLOCKX, HOLDLOCK)", quoteTable(table))
 }
 
-func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTable string, primaryKeys []string, insertSQL string) (bool, error) {
+func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTable string, primaryKeys []string, directInsertSQL, dedupInsertSQL string) (bool, error) {
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to begin deduplicated insert transaction: %w", err)
@@ -578,6 +579,20 @@ func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTabl
 		return false, nil
 	}
 
+	if isNormalisedStagingTable(targetTable) {
+		inserted, err := insertDirectIntoEmptyTarget(ctx, tx, targetTable, primaryKeys, directInsertSQL)
+		if err != nil {
+			return false, err
+		}
+		if inserted {
+			if err := tx.Commit(); err != nil {
+				return false, fmt.Errorf("failed to commit direct insert transaction: %w", err)
+			}
+			committed = true
+			return true, nil
+		}
+	}
+
 	var pkName string
 	var droppedPK bool
 	if isNormalisedStagingTable(targetTable) {
@@ -587,9 +602,9 @@ func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTabl
 		}
 	}
 
-	config.Debug("[MERGE] Empty target, executing deduplicated INSERT: %s", insertSQL)
-	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
-		config.LogFailedQuery(insertSQL, err)
+	config.Debug("[MERGE] Empty target, executing deduplicated INSERT: %s", dedupInsertSQL)
+	if _, err := tx.ExecContext(ctx, dedupInsertSQL); err != nil {
+		config.LogFailedQuery(dedupInsertSQL, err)
 		return false, fmt.Errorf("failed to insert deduplicated records: %w", err)
 	}
 
@@ -603,6 +618,52 @@ func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTabl
 		return false, fmt.Errorf("failed to commit deduplicated insert transaction: %w", err)
 	}
 	committed = true
+	return true, nil
+}
+
+func insertDirectIntoEmptyTarget(ctx context.Context, tx *sql.Tx, targetTable string, primaryKeys []string, insertSQL string) (bool, error) {
+	savepoint := "bruin_direct_insert"
+	if _, err := tx.ExecContext(ctx, "SAVE TRANSACTION "+savepoint); err != nil {
+		return false, fmt.Errorf("failed to create direct insert savepoint: %w", err)
+	}
+
+	rollback := func() error {
+		_, err := tx.ExecContext(ctx, "ROLLBACK TRANSACTION "+savepoint)
+		return err
+	}
+
+	pkName, droppedPK, err := dropPrimaryKeyIfExists(ctx, tx, targetTable)
+	if err != nil {
+		if rollbackErr := rollback(); rollbackErr != nil {
+			return false, fmt.Errorf("failed to roll back direct insert: %w", rollbackErr)
+		}
+		return false, err
+	}
+	if !droppedPK {
+		if rollbackErr := rollback(); rollbackErr != nil {
+			return false, fmt.Errorf("failed to roll back direct insert: %w", rollbackErr)
+		}
+		return false, nil
+	}
+
+	config.Debug("[MERGE] Empty target, trying direct INSERT before deduplication: %s", insertSQL)
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.Debug("[MERGE] Direct INSERT failed, falling back to deduplicated insert: %v", err)
+		if rollbackErr := rollback(); rollbackErr != nil {
+			return false, fmt.Errorf("failed to roll back direct insert: %w", rollbackErr)
+		}
+		return false, nil
+	}
+
+	if err := addPrimaryKey(ctx, tx, targetTable, pkName, primaryKeys); err != nil {
+		config.Debug("[MERGE] Direct INSERT produced non-unique keys, falling back to deduplicated insert: %v", err)
+		if rollbackErr := rollback(); rollbackErr != nil {
+			return false, fmt.Errorf("failed to roll back direct insert: %w", rollbackErr)
+		}
+		return false, nil
+	}
+
+	config.Debug("[MERGE] Direct insert completed without deduplication")
 	return true, nil
 }
 
@@ -640,7 +701,7 @@ func addPrimaryKey(ctx context.Context, tx *sql.Tx, table, constraintName string
 		constraintClause = " CONSTRAINT " + quoteColumn(constraintName)
 	}
 
-	addSQL := fmt.Sprintf("ALTER TABLE %s ADD%s PRIMARY KEY (%s)", quoteTable(table), constraintClause, quotedKeys)
+	addSQL := fmt.Sprintf("ALTER TABLE %s ADD%s PRIMARY KEY (%s) WITH (SORT_IN_TEMPDB = ON, MAXDOP = 4)", quoteTable(table), constraintClause, quotedKeys)
 	config.Debug("[MERGE] Recreating target primary key after bulk insert: %s", addSQL)
 	if _, err := tx.ExecContext(ctx, addSQL); err != nil {
 		config.LogFailedQuery(addSQL, err)
@@ -666,6 +727,12 @@ func buildInsertDedupSQL(targetTable, stagingTable string, primaryKeys, columns 
 	)
 
 	return buildInsertSQL(targetTable, colList, selectClause)
+}
+
+func buildInsertDirectSQL(targetTable, stagingTable string, columns []string) string {
+	quotedColumns := quoteColumns(columns)
+	colList := strings.Join(quotedColumns, ", ")
+	return buildInsertSQL(targetTable, colList, fmt.Sprintf("SELECT %s FROM %s", colList, quoteTable(stagingTable)))
 }
 
 func buildInsertSQL(targetTable, colList, selectClause string) string {

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -27,6 +27,8 @@ type MSSQLDestination struct {
 	database string
 }
 
+var errDirectInsertRequiresRetry = errors.New("direct insert transaction cannot be reused")
+
 func NewMSSQLDestination() *MSSQLDestination {
 	return &MSSQLDestination{}
 }
@@ -560,13 +562,18 @@ func buildTableIsEmptyForUpdateSQL(table string) string {
 }
 
 func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTable string, primaryKeys []string, directInsertSQL, dedupInsertSQL string) (bool, error) {
+	return d.insertIntoEmptyTargetWithDirect(ctx, targetTable, primaryKeys, directInsertSQL, dedupInsertSQL, true)
+}
+
+func (d *MSSQLDestination) insertIntoEmptyTargetWithDirect(ctx context.Context, targetTable string, primaryKeys []string, directInsertSQL, dedupInsertSQL string, allowDirect bool) (bool, error) {
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to begin deduplicated insert transaction: %w", err)
 	}
 	committed := false
+	txClosed := false
 	defer func() {
-		if !committed {
+		if !committed && !txClosed {
 			_ = tx.Rollback()
 		}
 	}()
@@ -579,9 +586,17 @@ func (d *MSSQLDestination) insertIntoEmptyTarget(ctx context.Context, targetTabl
 		return false, nil
 	}
 
-	if isNormalisedStagingTable(targetTable) {
+	if allowDirect && isNormalisedStagingTable(targetTable) {
 		inserted, err := insertDirectIntoEmptyTarget(ctx, tx, targetTable, primaryKeys, directInsertSQL)
 		if err != nil {
+			if errors.Is(err, errDirectInsertRequiresRetry) {
+				config.Debug("[MERGE] Direct insert transaction cannot be reused, retrying deduplicated insert: %v", err)
+				if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+					return false, fmt.Errorf("failed to roll back direct insert transaction: %w", rollbackErr)
+				}
+				txClosed = true
+				return d.insertIntoEmptyTargetWithDirect(ctx, targetTable, primaryKeys, directInsertSQL, dedupInsertSQL, false)
+			}
 			return false, err
 		}
 		if inserted {
@@ -628,8 +643,10 @@ func insertDirectIntoEmptyTarget(ctx context.Context, tx *sql.Tx, targetTable st
 	}
 
 	rollback := func() error {
-		_, err := tx.ExecContext(ctx, "ROLLBACK TRANSACTION "+savepoint)
-		return err
+		if _, err := tx.ExecContext(ctx, "ROLLBACK TRANSACTION "+savepoint); err != nil {
+			return fmt.Errorf("%w: %v", errDirectInsertRequiresRetry, err)
+		}
+		return nil
 	}
 
 	pkName, droppedPK, err := dropPrimaryKeyIfExists(ctx, tx, targetTable)

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -195,7 +195,7 @@ func expectAddPrimaryKeyError(mock sqlmock.Sqlmock, table, constraintName string
 }
 
 func buildAddPrimaryKeySQLForTest(table, constraintName string) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s PRIMARY KEY ([id]) WITH (SORT_IN_TEMPDB = ON, MAXDOP = 4)", quoteTable(table), quoteColumn(constraintName))
+	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s PRIMARY KEY ([id]) WITH (SORT_IN_TEMPDB = ON)", quoteTable(table), quoteColumn(constraintName))
 }
 
 func TestDialectTypeNameUsesDestinationTypeMapping(t *testing.T) {

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -110,8 +110,9 @@ func TestInsertIntoEmptyTargetDirectSuccess(t *testing.T) {
 
 	dest := &MSSQLDestination{db: db}
 	target := "dbo.events_staging_normalised_123"
-	directSQL := buildInsertDirectSQL(target, "_bruin_staging.events_raw", []string{"id", "name"})
-	dedupSQL := buildInsertDedupSQL(target, "_bruin_staging.events_raw", []string{"id"}, []string{"id", "name"}, "")
+	staging := "_bruin_staging.events_raw"
+	directSQL := buildInsertDirectSQL(target, staging, []string{"id", "name"})
+	dedupSQL := buildInsertDedupSQL(target, staging, []string{"id"}, []string{"id", "name"}, "")
 
 	mock.ExpectBegin()
 	expectEmptyTableCheck(mock, target)
@@ -142,8 +143,9 @@ func TestInsertIntoEmptyTargetFallsBackWhenDirectPrimaryKeyFails(t *testing.T) {
 
 	dest := &MSSQLDestination{db: db}
 	target := "dbo.events_staging_normalised_123"
-	directSQL := buildInsertDirectSQL(target, "_bruin_staging.events_raw", []string{"id", "name"})
-	dedupSQL := buildInsertDedupSQL(target, "_bruin_staging.events_raw", []string{"id"}, []string{"id", "name"}, "")
+	staging := "_bruin_staging.events_raw"
+	directSQL := buildInsertDirectSQL(target, staging, []string{"id", "name"})
+	dedupSQL := buildInsertDedupSQL(target, staging, []string{"id"}, []string{"id", "name"}, "")
 
 	mock.ExpectBegin()
 	expectEmptyTableCheck(mock, target)
@@ -154,6 +156,47 @@ func TestInsertIntoEmptyTargetFallsBackWhenDirectPrimaryKeyFails(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("ROLLBACK TRANSACTION bruin_direct_insert")).WillReturnResult(sqlmock.NewResult(0, 0))
 	expectDropPrimaryKey(mock, target, "PK_events")
 	mock.ExpectExec(regexp.QuoteMeta(dedupSQL)).WillReturnResult(sqlmock.NewResult(0, 10))
+	expectAddPrimaryKey(mock, target, "PK_events")
+	mock.ExpectCommit()
+
+	inserted, err := dest.insertIntoEmptyTarget(context.Background(), target, []string{"id"}, directSQL, dedupSQL)
+	if err != nil {
+		t.Fatalf("insertIntoEmptyTarget() error = %v", err)
+	}
+	if !inserted {
+		t.Fatal("insertIntoEmptyTarget() inserted = false, want true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInsertIntoEmptyTargetRetriesDedupWhenDirectRollbackFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	dest := &MSSQLDestination{db: db}
+	target := "dbo.events_staging_normalised_123"
+	staging := "_bruin_staging.events_raw"
+	directSQL := buildInsertDirectSQL(target, staging, []string{"id", "name"})
+	dedupSQL := buildInsertDedupSQL(target, staging, []string{"id"}, []string{"id", "name"}, "")
+
+	mock.ExpectBegin()
+	expectEmptyTableCheck(mock, target)
+	mock.ExpectExec(regexp.QuoteMeta("SAVE TRANSACTION bruin_direct_insert")).WillReturnResult(sqlmock.NewResult(0, 0))
+	expectDropPrimaryKey(mock, target, "PK_events")
+	mock.ExpectExec(regexp.QuoteMeta(directSQL)).WillReturnResult(sqlmock.NewResult(0, 10))
+	expectAddPrimaryKeyError(mock, target, "PK_events", errors.New("duplicate key"))
+	mock.ExpectExec(regexp.QuoteMeta("ROLLBACK TRANSACTION bruin_direct_insert")).WillReturnError(errors.New("transaction aborted"))
+	mock.ExpectRollback()
+
+	mock.ExpectBegin()
+	expectEmptyTableCheck(mock, target)
+	expectDropPrimaryKey(mock, target, "PK_events")
+	mock.ExpectExec(regexp.QuoteMeta(dedupSQL)).WillReturnResult(sqlmock.NewResult(0, 3))
 	expectAddPrimaryKey(mock, target, "PK_events")
 	mock.ExpectCommit()
 

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -2,10 +2,16 @@ package mssql
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal"
@@ -82,6 +88,114 @@ func TestBuildInsertDedupSQLAllowsNoIncrementalKey(t *testing.T) {
 	)
 
 	assertContains(t, sql, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY (SELECT NULL))")
+}
+
+func TestBuildInsertDirectSQL(t *testing.T) {
+	sql := buildInsertDirectSQL(
+		"dbo.events",
+		"_bruin_staging.events_raw",
+		[]string{"id", "name"},
+	)
+
+	assertContains(t, sql, "INSERT INTO [dbo].[events] WITH (TABLOCK) ([id], [name])")
+	assertContains(t, sql, "SELECT [id], [name] FROM [_bruin_staging].[events_raw]")
+}
+
+func TestInsertIntoEmptyTargetDirectSuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	dest := &MSSQLDestination{db: db}
+	target := "dbo.events_staging_normalised_123"
+	directSQL := buildInsertDirectSQL(target, "_bruin_staging.events_raw", []string{"id", "name"})
+	dedupSQL := buildInsertDedupSQL(target, "_bruin_staging.events_raw", []string{"id"}, []string{"id", "name"}, "")
+
+	mock.ExpectBegin()
+	expectEmptyTableCheck(mock, target)
+	mock.ExpectExec(regexp.QuoteMeta("SAVE TRANSACTION bruin_direct_insert")).WillReturnResult(sqlmock.NewResult(0, 0))
+	expectDropPrimaryKey(mock, target, "PK_events")
+	mock.ExpectExec(regexp.QuoteMeta(directSQL)).WillReturnResult(sqlmock.NewResult(0, 10))
+	expectAddPrimaryKey(mock, target, "PK_events")
+	mock.ExpectCommit()
+
+	inserted, err := dest.insertIntoEmptyTarget(context.Background(), target, []string{"id"}, directSQL, dedupSQL)
+	if err != nil {
+		t.Fatalf("insertIntoEmptyTarget() error = %v", err)
+	}
+	if !inserted {
+		t.Fatal("insertIntoEmptyTarget() inserted = false, want true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInsertIntoEmptyTargetFallsBackWhenDirectPrimaryKeyFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	dest := &MSSQLDestination{db: db}
+	target := "dbo.events_staging_normalised_123"
+	directSQL := buildInsertDirectSQL(target, "_bruin_staging.events_raw", []string{"id", "name"})
+	dedupSQL := buildInsertDedupSQL(target, "_bruin_staging.events_raw", []string{"id"}, []string{"id", "name"}, "")
+
+	mock.ExpectBegin()
+	expectEmptyTableCheck(mock, target)
+	mock.ExpectExec(regexp.QuoteMeta("SAVE TRANSACTION bruin_direct_insert")).WillReturnResult(sqlmock.NewResult(0, 0))
+	expectDropPrimaryKey(mock, target, "PK_events")
+	mock.ExpectExec(regexp.QuoteMeta(directSQL)).WillReturnResult(sqlmock.NewResult(0, 10))
+	expectAddPrimaryKeyError(mock, target, "PK_events", errors.New("duplicate key"))
+	mock.ExpectExec(regexp.QuoteMeta("ROLLBACK TRANSACTION bruin_direct_insert")).WillReturnResult(sqlmock.NewResult(0, 0))
+	expectDropPrimaryKey(mock, target, "PK_events")
+	mock.ExpectExec(regexp.QuoteMeta(dedupSQL)).WillReturnResult(sqlmock.NewResult(0, 10))
+	expectAddPrimaryKey(mock, target, "PK_events")
+	mock.ExpectCommit()
+
+	inserted, err := dest.insertIntoEmptyTarget(context.Background(), target, []string{"id"}, directSQL, dedupSQL)
+	if err != nil {
+		t.Fatalf("insertIntoEmptyTarget() error = %v", err)
+	}
+	if !inserted {
+		t.Fatal("insertIntoEmptyTarget() inserted = false, want true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func expectEmptyTableCheck(mock sqlmock.Sqlmock, table string) {
+	mock.ExpectQuery(regexp.QuoteMeta(buildTableIsEmptyForUpdateSQL(table))).
+		WillReturnError(sql.ErrNoRows)
+}
+
+func expectDropPrimaryKey(mock sqlmock.Sqlmock, table, constraintName string) {
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT kc.name
+FROM sys.key_constraints AS kc
+WHERE kc.parent_object_id = OBJECT_ID(@p1) AND kc.[type] = 'PK'`)).
+		WithArgs(table).
+		WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(constraintName))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", quoteTable(table), quoteColumn(constraintName)))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func expectAddPrimaryKey(mock sqlmock.Sqlmock, table, constraintName string) {
+	mock.ExpectExec(regexp.QuoteMeta(buildAddPrimaryKeySQLForTest(table, constraintName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func expectAddPrimaryKeyError(mock sqlmock.Sqlmock, table, constraintName string, err error) {
+	mock.ExpectExec(regexp.QuoteMeta(buildAddPrimaryKeySQLForTest(table, constraintName))).
+		WillReturnError(err)
+}
+
+func buildAddPrimaryKeySQLForTest(table, constraintName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s PRIMARY KEY ([id]) WITH (SORT_IN_TEMPDB = ON, MAXDOP = 4)", quoteTable(table), quoteColumn(constraintName))
 }
 
 func TestDialectTypeNameUsesDestinationTypeMapping(t *testing.T) {

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
@@ -209,6 +211,7 @@ func (d *PostgresDestination) Write(ctx context.Context, records <-chan source.R
 		// Use CopyFromSlice for streaming conversion without materializing all rows
 		// Pre-allocate row buffer and reuse it for each row to reduce allocations
 		tableIdent := parseTableIdentifier(opts.Table)
+		getters := postgresValueGetters(record)
 		rowBuf := make([]any, numCols)
 		copyCount, err := d.pool.CopyFrom(
 			ctx,
@@ -216,7 +219,7 @@ func (d *PostgresDestination) Write(ctx context.Context, records <-chan source.R
 			columns,
 			pgx.CopyFromSlice(int(numRows), func(i int) ([]any, error) {
 				for j := 0; j < int(numCols); j++ {
-					rowBuf[j] = arrowutil.Value(record.Column(j), i)
+					rowBuf[j] = getters[j](i)
 				}
 				return rowBuf, nil
 			}),
@@ -294,6 +297,7 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 				// Use CopyFromSlice for streaming conversion
 				// Pre-allocate row buffer and reuse it for each row
 				tableIdent := parseTableIdentifier(opts.Table)
+				getters := postgresValueGetters(record)
 				rowBuf := make([]any, numCols)
 				copyCount, err := d.pool.CopyFrom(
 					ctx,
@@ -301,7 +305,7 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 					columns,
 					pgx.CopyFromSlice(int(numRows), func(i int) ([]any, error) {
 						for j := 0; j < int(numCols); j++ {
-							rowBuf[j] = arrowutil.Value(record.Column(j), i)
+							rowBuf[j] = getters[j](i)
 						}
 						return rowBuf, nil
 					}),
@@ -341,6 +345,155 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 
 	config.Debug("[DEST] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), float64(totalRows)/time.Since(startTotal).Seconds())
 	return nil
+}
+
+func postgresValueGetters(record arrow.RecordBatch) []func(int) any {
+	getters := make([]func(int) any, int(record.NumCols()))
+	for i := range getters {
+		getters[i] = postgresValueGetter(record.Column(i))
+	}
+	return getters
+}
+
+func postgresValueGetter(col arrow.Array) func(int) any {
+	switch a := col.(type) {
+	case *array.Boolean:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Int8:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Int16:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Int32:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Int64:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Float32:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Float64:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.String:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.LargeString:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Binary:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.LargeBinary:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i)
+		}
+	case *array.Decimal128:
+		dt := a.DataType().(*arrow.Decimal128Type)
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i).ToFloat64(dt.Scale)
+		}
+	case *array.Date32:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i).ToTime()
+		}
+	case *array.Date64:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i).ToTime()
+		}
+	case *array.Time64:
+		timeType := a.DataType().(*arrow.Time64Type)
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			v := a.Value(i)
+			var duration time.Duration
+			switch timeType.Unit {
+			case arrow.Microsecond:
+				duration = time.Duration(v) * time.Microsecond
+			case arrow.Nanosecond:
+				duration = time.Duration(v) * time.Nanosecond
+			default:
+				return nil
+			}
+			h := duration / time.Hour
+			duration %= time.Hour
+			m := duration / time.Minute
+			duration %= time.Minute
+			s := duration / time.Second
+			duration %= time.Second
+			return time.Date(0, 1, 1, int(h), int(m), int(s), int(duration), time.UTC)
+		}
+	case *array.Timestamp:
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return a.Value(i).ToTime(arrow.Microsecond)
+		}
+	case array.ExtensionArray:
+		return postgresValueGetter(a.Storage())
+	default:
+		return func(i int) any {
+			return arrowutil.Value(col, i)
+		}
+	}
 }
 
 func (d *PostgresDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -1,6 +1,18 @@
 package postgres
 
-import "testing"
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/arrowutil"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
 
 func TestBuildDeleteInsertLockSQL(t *testing.T) {
 	got := buildDeleteInsertLockSQL(`"public"."orders"`)
@@ -8,4 +20,180 @@ func TestBuildDeleteInsertLockSQL(t *testing.T) {
 	if got != want {
 		t.Fatalf("buildDeleteInsertLockSQL() = %q, want %q", got, want)
 	}
+}
+
+func TestPostgresValueGetterMatchesArrowutilValue(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	arrays := []arrow.Array{
+		buildBoolArray(mem),
+		buildInt16Array(mem),
+		buildInt32Array(mem),
+		buildInt64Array(mem),
+		buildFloat32Array(mem),
+		buildFloat64Array(mem),
+		buildStringArray(mem),
+		buildLargeStringArray(mem),
+		buildBinaryArray(mem),
+		buildDecimal128Array(mem),
+		buildDate32Array(mem),
+		buildDate64Array(mem),
+		buildTime64Array(mem),
+		buildTimestampArray(mem),
+		buildJSONExtensionArray(mem),
+		buildUint8FallbackArray(mem),
+	}
+	for _, arr := range arrays {
+		defer arr.Release()
+	}
+
+	for _, arr := range arrays {
+		get := postgresValueGetter(arr)
+		for i := 0; i < arr.Len(); i++ {
+			got := get(i)
+			want := arrowutil.Value(arr, i)
+			if !postgresTestValuesEqual(got, want) {
+				t.Fatalf("%s[%d]: postgresValueGetter = %#v (%T), arrowutil.Value = %#v (%T)", arr.DataType(), i, got, got, want, want)
+			}
+		}
+	}
+}
+
+func postgresTestValuesEqual(left, right any) bool {
+	switch l := left.(type) {
+	case []byte:
+		r, ok := right.([]byte)
+		return ok && bytes.Equal(l, r)
+	case time.Time:
+		r, ok := right.(time.Time)
+		return ok && l.Equal(r)
+	default:
+		return reflect.DeepEqual(left, right)
+	}
+}
+
+func buildBoolArray(mem memory.Allocator) arrow.Array {
+	b := array.NewBooleanBuilder(mem)
+	defer b.Release()
+	b.AppendValues([]bool{true, false}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildInt16Array(mem memory.Allocator) arrow.Array {
+	b := array.NewInt16Builder(mem)
+	defer b.Release()
+	b.AppendValues([]int16{12, 0}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildInt32Array(mem memory.Allocator) arrow.Array {
+	b := array.NewInt32Builder(mem)
+	defer b.Release()
+	b.AppendValues([]int32{34, 0}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildInt64Array(mem memory.Allocator) arrow.Array {
+	b := array.NewInt64Builder(mem)
+	defer b.Release()
+	b.AppendValues([]int64{56, 0}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildFloat32Array(mem memory.Allocator) arrow.Array {
+	b := array.NewFloat32Builder(mem)
+	defer b.Release()
+	b.AppendValues([]float32{1.25, 0}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildFloat64Array(mem memory.Allocator) arrow.Array {
+	b := array.NewFloat64Builder(mem)
+	defer b.Release()
+	b.AppendValues([]float64{2.5, 0}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildStringArray(mem memory.Allocator) arrow.Array {
+	b := array.NewStringBuilder(mem)
+	defer b.Release()
+	b.AppendValues([]string{"hello", ""}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildLargeStringArray(mem memory.Allocator) arrow.Array {
+	b := array.NewLargeStringBuilder(mem)
+	defer b.Release()
+	b.AppendValues([]string{"large", ""}, []bool{true, false})
+	return b.NewArray()
+}
+
+func buildBinaryArray(mem memory.Allocator) arrow.Array {
+	b := array.NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+	b.Append([]byte{1, 2, 3})
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildDecimal128Array(mem memory.Allocator) arrow.Array {
+	dt := &arrow.Decimal128Type{Precision: 10, Scale: 2}
+	b := array.NewDecimal128Builder(mem, dt)
+	defer b.Release()
+	b.Append(decimal128.FromI64(12345))
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildDate32Array(mem memory.Allocator) arrow.Array {
+	b := array.NewDate32Builder(mem)
+	defer b.Release()
+	b.Append(arrow.Date32FromTime(time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)))
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildDate64Array(mem memory.Allocator) arrow.Array {
+	b := array.NewDate64Builder(mem)
+	defer b.Release()
+	b.Append(arrow.Date64FromTime(time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)))
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildTime64Array(mem memory.Allocator) arrow.Array {
+	b := array.NewTime64Builder(mem, arrow.FixedWidthTypes.Time64us.(*arrow.Time64Type))
+	defer b.Release()
+	b.Append(arrow.Time64((1*3600+2*60+3)*1_000_000 + 4))
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildTimestampArray(mem memory.Allocator) arrow.Array {
+	dt := arrow.FixedWidthTypes.Timestamp_us.(*arrow.TimestampType)
+	b := array.NewTimestampBuilder(mem, dt)
+	defer b.Release()
+	ts, err := arrow.TimestampFromTime(time.Date(2021, 3, 4, 5, 6, 7, 123000, time.UTC), arrow.Microsecond)
+	if err != nil {
+		panic(err)
+	}
+	b.Append(ts)
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildJSONExtensionArray(mem memory.Allocator) arrow.Array {
+	b := schema.NewJSONBuilder(mem)
+	defer b.Release()
+	b.Append(`{"a":1}`)
+	b.AppendNull()
+	return b.NewArray()
+}
+
+func buildUint8FallbackArray(mem memory.Allocator) arrow.Array {
+	b := array.NewUint8Builder(mem)
+	defer b.Release()
+	b.AppendValues([]uint8{7, 0}, []bool{true, false})
+	return b.NewArray()
 }

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -538,23 +538,31 @@ func (s *MongoDBSource) consumeCursor(ctx context.Context, cursor *mongo.Cursor,
 		}
 
 		startBatch := time.Now()
-		var builder mongoRecordBatchBuilder = newMongoBatchBuilder(opts.ExcludeColumns)
+		var builder mongoRecordBatchBuilder = newMongoRawBatchBuilder(opts.ExcludeColumns)
 		if opts.Schema != nil {
 			builder = newMongoSchemaBatchBuilder(opts.Schema.Columns, opts.ExcludeColumns)
 		}
 		batchRows := 0
 
 		for batchRows < batchSize && cursor.Next(ctx) {
-			var doc bson.M
-			if err := cursor.Decode(&doc); err != nil {
-				builder.Release()
-				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to decode document: %w", err)}
-				return
-			}
-			if err := builder.AppendDocument(doc); err != nil {
-				builder.Release()
-				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to build Arrow batch: %w", err)}
-				return
+			if opts.Schema == nil {
+				if err := builder.AppendRawDocument(cursor.Current); err != nil {
+					builder.Release()
+					results <- source.RecordBatchResult{Err: fmt.Errorf("failed to build Arrow batch: %w", err)}
+					return
+				}
+			} else {
+				var doc bson.M
+				if err := cursor.Decode(&doc); err != nil {
+					builder.Release()
+					results <- source.RecordBatchResult{Err: fmt.Errorf("failed to decode document: %w", err)}
+					return
+				}
+				if err := builder.AppendDocument(doc); err != nil {
+					builder.Release()
+					results <- source.RecordBatchResult{Err: fmt.Errorf("failed to build Arrow batch: %w", err)}
+					return
+				}
 			}
 			batchRows++
 		}
@@ -623,6 +631,114 @@ func convertBSONValue(val any) any {
 	}
 }
 
+func convertRawBSONValue(val bson.RawValue) any {
+	switch val.Type {
+	case bson.TypeDouble:
+		if v, ok := val.DoubleOK(); ok {
+			return v
+		}
+	case bson.TypeString:
+		if v, ok := val.StringValueOK(); ok {
+			return v
+		}
+	case bson.TypeEmbeddedDocument:
+		if doc, ok := val.DocumentOK(); ok {
+			return convertRawDocument(doc)
+		}
+	case bson.TypeArray:
+		if arr, ok := val.ArrayOK(); ok {
+			return convertRawArray(arr)
+		}
+	case bson.TypeBinary:
+		if _, data, ok := val.BinaryOK(); ok {
+			return data
+		}
+	case bson.TypeObjectID:
+		if v, ok := val.ObjectIDOK(); ok {
+			return v.Hex()
+		}
+	case bson.TypeBoolean:
+		if v, ok := val.BooleanOK(); ok {
+			return v
+		}
+	case bson.TypeDateTime:
+		if v, ok := val.DateTimeOK(); ok {
+			return time.UnixMilli(v)
+		}
+	case bson.TypeRegex:
+		if pattern, _, ok := val.RegexOK(); ok {
+			return pattern
+		}
+	case bson.TypeJavaScript:
+		if v, ok := val.JavaScriptOK(); ok {
+			return primitive.JavaScript(v)
+		}
+	case bson.TypeSymbol:
+		if v, ok := val.SymbolOK(); ok {
+			return primitive.Symbol(v)
+		}
+	case bson.TypeDBPointer:
+		if ns, oid, ok := val.DBPointerOK(); ok {
+			return primitive.DBPointer{DB: ns, Pointer: oid}
+		}
+	case bson.TypeInt32:
+		if v, ok := val.Int32OK(); ok {
+			return v
+		}
+	case bson.TypeTimestamp:
+		if t, _, ok := val.TimestampOK(); ok {
+			return time.Unix(int64(t), 0)
+		}
+	case bson.TypeInt64:
+		if v, ok := val.Int64OK(); ok {
+			return v
+		}
+	case bson.TypeDecimal128:
+		if v, ok := val.Decimal128OK(); ok {
+			return v.String()
+		}
+	case bson.TypeUndefined:
+		return primitive.Undefined{}
+	case bson.TypeNull:
+		return nil
+	case bson.TypeMinKey:
+		return primitive.MinKey{}
+	case bson.TypeMaxKey:
+		return primitive.MaxKey{}
+	}
+	var decoded any
+	if err := val.Unmarshal(&decoded); err == nil {
+		return decoded
+	}
+	return val.String()
+}
+
+func convertRawDocument(doc bson.Raw) map[string]any {
+	elements, err := doc.Elements()
+	if err != nil {
+		return map[string]any{}
+	}
+
+	result := make(map[string]any, len(elements))
+	for _, elem := range elements {
+		result[elem.Key()] = convertRawBSONValue(elem.Value())
+	}
+	return result
+}
+
+func convertRawArray(arr bson.Raw) []any {
+	values, err := arr.Values()
+	if err != nil {
+		return []any{}
+	}
+
+	result := make([]any, len(values))
+	for i, value := range values {
+		result[i] = convertRawBSONValue(value)
+	}
+	return result
+}
+
 func normalizeBatchSize(size int) int {
 	if size <= 0 {
 		return defaultBatchSize
@@ -641,6 +757,7 @@ type mongoBatchBuilder struct {
 
 type mongoRecordBatchBuilder interface {
 	AppendDocument(doc bson.M) error
+	AppendRawDocument(doc bson.Raw) error
 	NewRecordBatch() (arrow.RecordBatch, error)
 	Release()
 }
@@ -687,6 +804,14 @@ func (b *mongoBatchBuilder) AppendDocument(doc bson.M) error {
 	return nil
 }
 
+func (b *mongoBatchBuilder) AppendRawDocument(doc bson.Raw) error {
+	var decoded bson.M
+	if err := bson.Unmarshal(doc, &decoded); err != nil {
+		return err
+	}
+	return b.AppendDocument(decoded)
+}
+
 func (b *mongoBatchBuilder) NewRecordBatch() (arrow.RecordBatch, error) {
 	if len(b.fieldOrder) == 0 {
 		emptySchema := arrow.NewSchema([]arrow.Field{}, nil)
@@ -723,6 +848,118 @@ func (b *mongoBatchBuilder) Release() {
 }
 
 func (b *mongoBatchBuilder) reset() {
+	b.fieldOrder = b.fieldOrder[:0]
+	b.cols = make(map[string]*typedColumnBuilder)
+	b.rowCount = 0
+}
+
+type mongoRawBatchBuilder struct {
+	mem        memory.Allocator
+	excludeMap map[string]bool
+	fieldOrder []string
+	cols       map[string]*typedColumnBuilder
+	rowCount   int
+}
+
+func newMongoRawBatchBuilder(excludeColumns []string) *mongoRawBatchBuilder {
+	excludeMap := make(map[string]bool, len(excludeColumns))
+	for _, col := range excludeColumns {
+		excludeMap[strings.ToLower(col)] = true
+	}
+
+	return &mongoRawBatchBuilder{
+		mem:        memory.NewGoAllocator(),
+		excludeMap: excludeMap,
+		fieldOrder: make([]string, 0),
+		cols:       make(map[string]*typedColumnBuilder),
+	}
+}
+
+func (b *mongoRawBatchBuilder) AppendDocument(doc bson.M) error {
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	return b.AppendRawDocument(raw)
+}
+
+func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
+	elements, err := doc.Elements()
+	if err != nil {
+		return err
+	}
+
+	values := make(map[string]bson.RawValue, len(elements))
+	keys := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		key := elem.Key()
+		if b.excludeMap[strings.ToLower(key)] {
+			continue
+		}
+		if _, ok := values[key]; !ok {
+			keys = append(keys, key)
+		}
+		values[key] = elem.Value()
+	}
+
+	for _, key := range keys {
+		col, ok := b.cols[key]
+		if !ok {
+			col = newTypedColumnBuilder(b.mem)
+			col.AppendNulls(b.rowCount)
+			b.cols[key] = col
+			b.fieldOrder = append(b.fieldOrder, key)
+		}
+		col.AppendRaw(values[key])
+	}
+
+	for _, field := range b.fieldOrder {
+		if _, ok := values[field]; ok {
+			continue
+		}
+		b.cols[field].AppendNull()
+	}
+
+	b.rowCount++
+	return nil
+}
+
+func (b *mongoRawBatchBuilder) NewRecordBatch() (arrow.RecordBatch, error) {
+	if len(b.fieldOrder) == 0 {
+		emptySchema := arrow.NewSchema([]arrow.Field{}, nil)
+		return array.NewRecordBatch(emptySchema, []arrow.Array{}, 0), nil
+	}
+
+	fieldOrder := append([]string(nil), b.fieldOrder...)
+	sort.Strings(fieldOrder)
+
+	fields := make([]arrow.Field, len(fieldOrder))
+	arrays := make([]arrow.Array, len(fieldOrder))
+	for i, name := range fieldOrder {
+		arr, field := b.cols[name].Build(b.rowCount)
+		field.Name = name
+		fields[i] = field
+		arrays[i] = arr
+	}
+
+	record := array.NewRecordBatch(arrow.NewSchema(fields, nil), arrays, int64(b.rowCount))
+
+	for _, arr := range arrays {
+		arr.Release()
+	}
+	b.reset()
+
+	return record, nil
+}
+
+func (b *mongoRawBatchBuilder) Release() {
+	for _, col := range b.cols {
+		col.Release()
+	}
+	b.reset()
+}
+
+func (b *mongoRawBatchBuilder) reset() {
 	b.fieldOrder = b.fieldOrder[:0]
 	b.cols = make(map[string]*typedColumnBuilder)
 	b.rowCount = 0
@@ -771,6 +1008,14 @@ func (b *mongoSchemaBatchBuilder) AppendDocument(doc bson.M) error {
 	}
 	b.rowCount++
 	return nil
+}
+
+func (b *mongoSchemaBatchBuilder) AppendRawDocument(doc bson.Raw) error {
+	var decoded bson.M
+	if err := bson.Unmarshal(doc, &decoded); err != nil {
+		return err
+	}
+	return b.AppendDocument(decoded)
 }
 
 func (b *mongoSchemaBatchBuilder) NewRecordBatch() (arrow.RecordBatch, error) {

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -1,6 +1,7 @@
 package mongodb
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -23,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 const defaultBatchSize = 10000
@@ -748,11 +750,12 @@ func normalizeBatchSize(size int) int {
 }
 
 type mongoBatchBuilder struct {
-	mem        memory.Allocator
-	excludeMap map[string]bool
-	fieldOrder []string
-	cols       map[string]*typedColumnBuilder
-	rowCount   int
+	mem         memory.Allocator
+	excludeMap  map[string]bool
+	hasExcludes bool
+	fieldOrder  []string
+	cols        map[string]*typedColumnBuilder
+	rowCount    int
 }
 
 type mongoRecordBatchBuilder interface {
@@ -769,17 +772,18 @@ func newMongoBatchBuilder(excludeColumns []string) *mongoBatchBuilder {
 	}
 
 	return &mongoBatchBuilder{
-		mem:        memory.NewGoAllocator(),
-		excludeMap: excludeMap,
-		fieldOrder: make([]string, 0),
-		cols:       make(map[string]*typedColumnBuilder),
+		mem:         memory.NewGoAllocator(),
+		excludeMap:  excludeMap,
+		hasExcludes: len(excludeMap) > 0,
+		fieldOrder:  make([]string, 0),
+		cols:        make(map[string]*typedColumnBuilder),
 	}
 }
 
 func (b *mongoBatchBuilder) AppendDocument(doc bson.M) error {
 	seen := make(map[string]bool, len(doc))
 	for key, value := range doc {
-		if b.excludeMap[strings.ToLower(key)] {
+		if b.isExcludedKey(key) {
 			continue
 		}
 		col, ok := b.cols[key]
@@ -854,11 +858,12 @@ func (b *mongoBatchBuilder) reset() {
 }
 
 type mongoRawBatchBuilder struct {
-	mem        memory.Allocator
-	excludeMap map[string]bool
-	fieldOrder []string
-	cols       map[string]*typedColumnBuilder
-	rowCount   int
+	mem         memory.Allocator
+	excludeMap  map[string]bool
+	hasExcludes bool
+	fieldOrder  []string
+	cols        map[string]*typedColumnBuilder
+	rowCount    int
 }
 
 func newMongoRawBatchBuilder(excludeColumns []string) *mongoRawBatchBuilder {
@@ -868,10 +873,11 @@ func newMongoRawBatchBuilder(excludeColumns []string) *mongoRawBatchBuilder {
 	}
 
 	return &mongoRawBatchBuilder{
-		mem:        memory.NewGoAllocator(),
-		excludeMap: excludeMap,
-		fieldOrder: make([]string, 0),
-		cols:       make(map[string]*typedColumnBuilder),
+		mem:         memory.NewGoAllocator(),
+		excludeMap:  excludeMap,
+		hasExcludes: len(excludeMap) > 0,
+		fieldOrder:  make([]string, 0),
+		cols:        make(map[string]*typedColumnBuilder),
 	}
 }
 
@@ -884,6 +890,18 @@ func (b *mongoRawBatchBuilder) AppendDocument(doc bson.M) error {
 }
 
 func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
+	hasDuplicate, err := b.hasDuplicateIncludedRawKey(doc)
+	if err != nil {
+		return err
+	}
+	if !hasDuplicate {
+		return b.appendRawDocumentDirect(doc)
+	}
+
+	return b.appendRawDocumentCollapsed(doc)
+}
+
+func (b *mongoRawBatchBuilder) appendRawDocumentCollapsed(doc bson.Raw) error {
 	elements, err := doc.Elements()
 	if err != nil {
 		return err
@@ -893,7 +911,7 @@ func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 	keys := make([]string, 0, len(elements))
 	for _, elem := range elements {
 		key := elem.Key()
-		if b.excludeMap[strings.ToLower(key)] {
+		if b.isExcludedKey(key) {
 			continue
 		}
 		if _, ok := values[key]; !ok {
@@ -922,6 +940,104 @@ func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 
 	b.rowCount++
 	return nil
+}
+
+func (b *mongoRawBatchBuilder) appendRawDocumentDirect(doc bson.Raw) error {
+	length, rem, ok := bsoncore.ReadLength(doc)
+	if !ok {
+		return bsoncore.NewInsufficientBytesError(doc, rem)
+	}
+	length -= 4
+
+	for length > 1 {
+		elem, next, ok := bsoncore.ReadElement(rem)
+		if !ok {
+			return bsoncore.NewInsufficientBytesError(doc, rem)
+		}
+		length -= int32(len(elem))
+		rem = next
+
+		key, err := elem.KeyErr()
+		if err != nil {
+			return err
+		}
+		if b.isExcludedKey(key) {
+			continue
+		}
+		val, err := elem.ValueErr()
+		if err != nil {
+			return err
+		}
+
+		col, ok := b.cols[key]
+		if !ok {
+			col = newTypedColumnBuilder(b.mem)
+			col.AppendNulls(b.rowCount)
+			b.cols[key] = col
+			b.fieldOrder = append(b.fieldOrder, key)
+		}
+		col.AppendRaw(rawValueFromCore(val))
+	}
+
+	for _, field := range b.fieldOrder {
+		col := b.cols[field]
+		if col.rowCount <= b.rowCount {
+			col.AppendNull()
+		}
+	}
+
+	b.rowCount++
+	return nil
+}
+
+func (b *mongoRawBatchBuilder) hasDuplicateIncludedRawKey(doc bson.Raw) (bool, error) {
+	length, rem, ok := bsoncore.ReadLength(doc)
+	if !ok {
+		return false, bsoncore.NewInsufficientBytesError(doc, rem)
+	}
+	length -= 4
+
+	var stackKeys [64][]byte
+	keys := stackKeys[:0]
+	for length > 1 {
+		elem, next, ok := bsoncore.ReadElement(rem)
+		if !ok {
+			return false, bsoncore.NewInsufficientBytesError(doc, rem)
+		}
+		length -= int32(len(elem))
+		rem = next
+
+		key, err := elem.KeyBytesErr()
+		if err != nil {
+			return false, err
+		}
+		if b.isExcludedRawKey(key) {
+			continue
+		}
+		for _, seen := range keys {
+			if bytes.Equal(seen, key) {
+				return true, nil
+			}
+		}
+		keys = append(keys, key)
+	}
+	return false, nil
+}
+
+func (b *mongoBatchBuilder) isExcludedKey(key string) bool {
+	return b.hasExcludes && b.excludeMap[strings.ToLower(key)]
+}
+
+func (b *mongoRawBatchBuilder) isExcludedKey(key string) bool {
+	return b.hasExcludes && b.excludeMap[strings.ToLower(key)]
+}
+
+func (b *mongoRawBatchBuilder) isExcludedRawKey(key []byte) bool {
+	return b.hasExcludes && b.excludeMap[strings.ToLower(string(key))]
+}
+
+func rawValueFromCore(val bsoncore.Value) bson.RawValue {
+	return bson.RawValue{Type: val.Type, Value: val.Data}
 }
 
 func (b *mongoRawBatchBuilder) NewRecordBatch() (arrow.RecordBatch, error) {

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -1,7 +1,6 @@
 package mongodb
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -866,6 +865,11 @@ type mongoRawBatchBuilder struct {
 	rowCount    int
 }
 
+type rawDocumentField struct {
+	key   string
+	value bson.RawValue
+}
+
 func newMongoRawBatchBuilder(excludeColumns []string) *mongoRawBatchBuilder {
 	excludeMap := make(map[string]bool, len(excludeColumns))
 	for _, col := range excludeColumns {
@@ -890,34 +894,65 @@ func (b *mongoRawBatchBuilder) AppendDocument(doc bson.M) error {
 }
 
 func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
-	hasDuplicate, err := b.hasDuplicateIncludedRawKey(doc)
-	if err != nil {
-		return err
+	length, rem, ok := bsoncore.ReadLength(doc)
+	if !ok {
+		return bsoncore.NewInsufficientBytesError(doc, rem)
 	}
-	if !hasDuplicate {
-		return b.appendRawDocumentDirect(doc)
-	}
+	length -= 4
 
-	return b.appendRawDocumentCollapsed(doc)
-}
+	var stackFields [64]rawDocumentField
+	fields := stackFields[:0]
+	var stackKeys [64]string
+	keys := stackKeys[:0]
+	hasDuplicate := false
 
-func (b *mongoRawBatchBuilder) appendRawDocumentCollapsed(doc bson.Raw) error {
-	elements, err := doc.Elements()
-	if err != nil {
-		return err
-	}
+	for length > 1 {
+		elem, next, ok := bsoncore.ReadElement(rem)
+		if !ok {
+			return bsoncore.NewInsufficientBytesError(doc, rem)
+		}
+		length -= int32(len(elem))
+		rem = next
 
-	values := make(map[string]bson.RawValue, len(elements))
-	keys := make([]string, 0, len(elements))
-	for _, elem := range elements {
-		key := elem.Key()
+		key, err := elem.KeyErr()
+		if err != nil {
+			return err
+		}
 		if b.isExcludedKey(key) {
 			continue
 		}
-		if _, ok := values[key]; !ok {
+		val, err := elem.ValueErr()
+		if err != nil {
+			return err
+		}
+
+		isNewKey := true
+		for _, seen := range keys {
+			if seen == key {
+				hasDuplicate = true
+				isNewKey = false
+				break
+			}
+		}
+		if isNewKey {
 			keys = append(keys, key)
 		}
-		values[key] = elem.Value()
+		fields = append(fields, rawDocumentField{
+			key:   key,
+			value: rawValueFromCore(val),
+		})
+	}
+
+	if hasDuplicate {
+		return b.appendRawFieldsCollapsed(fields, keys)
+	}
+	return b.appendRawFieldsDirect(fields)
+}
+
+func (b *mongoRawBatchBuilder) appendRawFieldsCollapsed(fields []rawDocumentField, keys []string) error {
+	values := make(map[string]bson.RawValue, len(keys))
+	for _, field := range fields {
+		values[field.key] = field.value
 	}
 
 	for _, key := range keys {
@@ -942,41 +977,16 @@ func (b *mongoRawBatchBuilder) appendRawDocumentCollapsed(doc bson.Raw) error {
 	return nil
 }
 
-func (b *mongoRawBatchBuilder) appendRawDocumentDirect(doc bson.Raw) error {
-	length, rem, ok := bsoncore.ReadLength(doc)
-	if !ok {
-		return bsoncore.NewInsufficientBytesError(doc, rem)
-	}
-	length -= 4
-
-	for length > 1 {
-		elem, next, ok := bsoncore.ReadElement(rem)
-		if !ok {
-			return bsoncore.NewInsufficientBytesError(doc, rem)
-		}
-		length -= int32(len(elem))
-		rem = next
-
-		key, err := elem.KeyErr()
-		if err != nil {
-			return err
-		}
-		if b.isExcludedKey(key) {
-			continue
-		}
-		val, err := elem.ValueErr()
-		if err != nil {
-			return err
-		}
-
-		col, ok := b.cols[key]
+func (b *mongoRawBatchBuilder) appendRawFieldsDirect(fields []rawDocumentField) error {
+	for _, field := range fields {
+		col, ok := b.cols[field.key]
 		if !ok {
 			col = newTypedColumnBuilder(b.mem)
 			col.AppendNulls(b.rowCount)
-			b.cols[key] = col
-			b.fieldOrder = append(b.fieldOrder, key)
+			b.cols[field.key] = col
+			b.fieldOrder = append(b.fieldOrder, field.key)
 		}
-		col.AppendRaw(rawValueFromCore(val))
+		col.AppendRaw(field.value)
 	}
 
 	for _, field := range b.fieldOrder {
@@ -990,50 +1000,12 @@ func (b *mongoRawBatchBuilder) appendRawDocumentDirect(doc bson.Raw) error {
 	return nil
 }
 
-func (b *mongoRawBatchBuilder) hasDuplicateIncludedRawKey(doc bson.Raw) (bool, error) {
-	length, rem, ok := bsoncore.ReadLength(doc)
-	if !ok {
-		return false, bsoncore.NewInsufficientBytesError(doc, rem)
-	}
-	length -= 4
-
-	var stackKeys [64][]byte
-	keys := stackKeys[:0]
-	for length > 1 {
-		elem, next, ok := bsoncore.ReadElement(rem)
-		if !ok {
-			return false, bsoncore.NewInsufficientBytesError(doc, rem)
-		}
-		length -= int32(len(elem))
-		rem = next
-
-		key, err := elem.KeyBytesErr()
-		if err != nil {
-			return false, err
-		}
-		if b.isExcludedRawKey(key) {
-			continue
-		}
-		for _, seen := range keys {
-			if bytes.Equal(seen, key) {
-				return true, nil
-			}
-		}
-		keys = append(keys, key)
-	}
-	return false, nil
-}
-
 func (b *mongoBatchBuilder) isExcludedKey(key string) bool {
 	return b.hasExcludes && b.excludeMap[strings.ToLower(key)]
 }
 
 func (b *mongoRawBatchBuilder) isExcludedKey(key string) bool {
 	return b.hasExcludes && b.excludeMap[strings.ToLower(key)]
-}
-
-func (b *mongoRawBatchBuilder) isExcludedRawKey(key []byte) bool {
-	return b.hasExcludes && b.excludeMap[strings.ToLower(string(key))]
 }
 
 func rawValueFromCore(val bsoncore.Value) bson.RawValue {

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -1,6 +1,8 @@
 package mongodb
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -764,6 +766,47 @@ func TestMongoRawBatchBuilder_NestedTemporalValuesMatchDecodedPath(t *testing.T)
 	}
 	if got, want := arrowutil.Value(rawRecord.Column(0), 0), arrowutil.Value(decodedRecord.Column(0), 0); got != want {
 		t.Fatalf("raw nested value = %#v, want decoded value %#v", got, want)
+	}
+}
+
+func TestAppendJSONTimeMatchesEncodingJSON(t *testing.T) {
+	tests := []time.Time{
+		time.UnixMilli(1_782_003_600_123),
+		time.Date(2026, 6, 21, 2, 0, 0, 123_000_000, time.UTC),
+		time.Date(2026, 6, 21, 2, 0, 0, 0, time.FixedZone("", -23*3600-59*60)),
+	}
+
+	for _, tt := range tests {
+		var got bytes.Buffer
+		if !appendJSONTime(&got, tt) {
+			t.Fatalf("appendJSONTime(%v) returned false", tt)
+		}
+
+		want, err := json.Marshal(tt)
+		if err != nil {
+			t.Fatalf("json.Marshal(%v) error = %v", tt, err)
+		}
+		if got.String() != string(want) {
+			t.Fatalf("appendJSONTime(%v) = %q, want %q", tt, got.String(), want)
+		}
+	}
+}
+
+func TestAppendJSONTimeInvalidRFC3339FallsBack(t *testing.T) {
+	tests := []time.Time{
+		time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 21, 2, 0, 0, 0, time.FixedZone("", 24*3600)),
+	}
+
+	for _, tt := range tests {
+		var got bytes.Buffer
+		got.WriteString("prefix")
+		if appendJSONTime(&got, tt) {
+			t.Fatalf("appendJSONTime(%v) returned true", tt)
+		}
+		if got.String() != "prefix" {
+			t.Fatalf("appendJSONTime(%v) changed buffer to %q", tt, got.String())
+		}
 	}
 }
 

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -767,6 +767,82 @@ func TestMongoRawBatchBuilder_NestedTemporalValuesMatchDecodedPath(t *testing.T)
 	}
 }
 
+func TestMongoRawBatchBuilder_NestedBenchmarkValuesMatchDecodedPath(t *testing.T) {
+	updatedAt := int64(1_782_003_600_123)
+	profile := bsoncore.NewDocumentBuilder().
+		AppendDouble("score", 123.25).
+		AppendDouble("whole_float", 1_000_000).
+		AppendDouble("small_float", 0.000001).
+		AppendDouble("large_float", 100_000_000_000_000_000_000).
+		AppendBoolean("active", true).
+		AppendDateTime("updated_at", updatedAt).
+		Build()
+	labels := bsoncore.NewArrayBuilder().
+		AppendString("tag_1").
+		AppendString("bucket_10").
+		AppendString("escape <>& \u2028").
+		AppendString("nul\x00byte").
+		Build()
+	nested := bsoncore.NewDocumentBuilder().
+		AppendDocument("profile", profile).
+		AppendArray("labels", labels).
+		Build()
+	rank := bsoncore.NewDocumentBuilder().
+		AppendInt32("rank", 42).
+		Build()
+	arrayValue := bsoncore.NewArrayBuilder().
+		AppendInt32(7).
+		AppendString("item_7").
+		AppendDocument(rank).
+		Build()
+	rawDoc := bsoncore.NewDocumentBuilder().
+		AppendDocument("nested_doc", nested).
+		AppendArray("array_val", arrayValue).
+		Build()
+
+	var decoded bson.M
+	if err := bson.Unmarshal(rawDoc, &decoded); err != nil {
+		t.Fatalf("bson.Unmarshal error = %v", err)
+	}
+
+	decodedBuilder := newMongoBatchBuilder(nil)
+	if err := decodedBuilder.AppendDocument(decoded); err != nil {
+		t.Fatalf("decoded AppendDocument error = %v", err)
+	}
+	decodedRecord, err := decodedBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("decoded NewRecordBatch error = %v", err)
+	}
+	defer decodedRecord.Release()
+
+	rawBuilder := newMongoRawBatchBuilder(nil)
+	if err := rawBuilder.AppendRawDocument(bson.Raw(rawDoc)); err != nil {
+		t.Fatalf("raw AppendRawDocument error = %v", err)
+	}
+	rawRecord, err := rawBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("raw NewRecordBatch error = %v", err)
+	}
+	defer rawRecord.Release()
+
+	if got, want := rawRecord.NumCols(), decodedRecord.NumCols(); got != want {
+		t.Fatalf("raw NumCols = %d, want decoded %d", got, want)
+	}
+	for i := 0; i < int(decodedRecord.NumCols()); i++ {
+		decodedField := decodedRecord.Schema().Field(i)
+		rawField := rawRecord.Schema().Field(i)
+		if rawField.Name != decodedField.Name {
+			t.Fatalf("field %d name = %q, want %q", i, rawField.Name, decodedField.Name)
+		}
+		if rawField.Type.String() != decodedField.Type.String() {
+			t.Fatalf("%s raw type = %s, want decoded %s", rawField.Name, rawField.Type, decodedField.Type)
+		}
+		if got, want := arrowutil.Value(rawRecord.Column(i), 0), arrowutil.Value(decodedRecord.Column(i), 0); got != want {
+			t.Fatalf("%s raw value = %#v, want decoded value %#v", rawField.Name, got, want)
+		}
+	}
+}
+
 func TestMongoSchemaBatchBuilder_UsesProvidedSchema(t *testing.T) {
 	oid, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
 	created := primitive.NewDateTimeFromTime(time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC))

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestParseTableSpec(t *testing.T) {
@@ -603,6 +604,166 @@ func TestMongoBatchBuilder_AllNullColumnEmittedAsUnknown(t *testing.T) {
 		if !isUnknownType(field.Type) {
 			t.Fatalf("all-null column b: type = %s, want unknown", field.Type)
 		}
+	}
+}
+
+func TestMongoRawBatchBuilder_LegacyBSONTypesMatchDecodedPath(t *testing.T) {
+	oid := primitive.NewObjectID()
+	scope := bsoncore.NewDocumentBuilder().AppendInt32("x", 1).Build()
+	rawDoc := bsoncore.NewDocumentBuilder().
+		AppendJavaScript("javascript", "function () { return 1; }").
+		AppendSymbol("symbol", "legacy_symbol").
+		AppendUndefined("undefined").
+		AppendDBPointer("db_pointer", "legacy.collection", oid).
+		AppendCodeWithScope("code_with_scope", "function () { return x; }", scope).
+		AppendMinKey("min_key").
+		AppendMaxKey("max_key").
+		Build()
+
+	var decoded bson.M
+	if err := bson.Unmarshal(rawDoc, &decoded); err != nil {
+		t.Fatalf("bson.Unmarshal error = %v", err)
+	}
+
+	decodedBuilder := newMongoBatchBuilder(nil)
+	if err := decodedBuilder.AppendDocument(decoded); err != nil {
+		t.Fatalf("decoded AppendDocument error = %v", err)
+	}
+	decodedRecord, err := decodedBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("decoded NewRecordBatch error = %v", err)
+	}
+	defer decodedRecord.Release()
+
+	rawBuilder := newMongoRawBatchBuilder(nil)
+	if err := rawBuilder.AppendRawDocument(bson.Raw(rawDoc)); err != nil {
+		t.Fatalf("raw AppendRawDocument error = %v", err)
+	}
+	rawRecord, err := rawBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("raw NewRecordBatch error = %v", err)
+	}
+	defer rawRecord.Release()
+
+	if got, want := rawRecord.NumCols(), decodedRecord.NumCols(); got != want {
+		t.Fatalf("raw NumCols = %d, want decoded %d", got, want)
+	}
+
+	for i := 0; i < int(decodedRecord.NumCols()); i++ {
+		decodedField := decodedRecord.Schema().Field(i)
+		rawField := rawRecord.Schema().Field(i)
+		if rawField.Name != decodedField.Name {
+			t.Fatalf("field %d name = %q, want %q", i, rawField.Name, decodedField.Name)
+		}
+		if rawField.Type.String() != decodedField.Type.String() {
+			t.Fatalf("%s raw type = %s, want decoded %s", rawField.Name, rawField.Type, decodedField.Type)
+		}
+		if !isUnknownType(rawField.Type) {
+			t.Fatalf("%s raw type = %s, want unknown", rawField.Name, rawField.Type)
+		}
+		if rawRecord.Column(i).IsNull(0) {
+			t.Fatalf("%s raw value was encoded as null", rawField.Name)
+		}
+		if got, want := arrowutil.Value(rawRecord.Column(i), 0), arrowutil.Value(decodedRecord.Column(i), 0); got != want {
+			t.Fatalf("%s raw value = %#v, want decoded value %#v", rawField.Name, got, want)
+		}
+	}
+}
+
+func TestMongoRawBatchBuilder_DuplicateKeysMatchDecodedPath(t *testing.T) {
+	duplicateRaw := bsoncore.NewDocumentBuilder().
+		AppendInt32("x", 1).
+		AppendInt32("x", 2).
+		Build()
+	secondRaw := bsoncore.NewDocumentBuilder().
+		AppendInt32("x", 3).
+		Build()
+
+	var decodedDuplicate bson.M
+	if err := bson.Unmarshal(duplicateRaw, &decodedDuplicate); err != nil {
+		t.Fatalf("bson.Unmarshal duplicate error = %v", err)
+	}
+	var decodedSecond bson.M
+	if err := bson.Unmarshal(secondRaw, &decodedSecond); err != nil {
+		t.Fatalf("bson.Unmarshal second error = %v", err)
+	}
+
+	decodedBuilder := newMongoBatchBuilder(nil)
+	for _, doc := range []bson.M{decodedDuplicate, decodedSecond} {
+		if err := decodedBuilder.AppendDocument(doc); err != nil {
+			t.Fatalf("decoded AppendDocument error = %v", err)
+		}
+	}
+	decodedRecord, err := decodedBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("decoded NewRecordBatch error = %v", err)
+	}
+	defer decodedRecord.Release()
+
+	rawBuilder := newMongoRawBatchBuilder(nil)
+	for _, doc := range []bson.Raw{bson.Raw(duplicateRaw), bson.Raw(secondRaw)} {
+		if err := rawBuilder.AppendRawDocument(doc); err != nil {
+			t.Fatalf("raw AppendRawDocument error = %v", err)
+		}
+	}
+	rawRecord, err := rawBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("raw NewRecordBatch error = %v", err)
+	}
+	defer rawRecord.Release()
+
+	if got, want := rawRecord.NumRows(), decodedRecord.NumRows(); got != want {
+		t.Fatalf("raw NumRows = %d, want decoded %d", got, want)
+	}
+	if got, want := rawRecord.Column(0).Len(), int(rawRecord.NumRows()); got != want {
+		t.Fatalf("raw column length = %d, want %d", got, want)
+	}
+	for row := 0; row < int(decodedRecord.NumRows()); row++ {
+		if got, want := arrowutil.Value(rawRecord.Column(0), row), arrowutil.Value(decodedRecord.Column(0), row); got != want {
+			t.Fatalf("row %d raw value = %#v, want decoded value %#v", row, got, want)
+		}
+	}
+}
+
+func TestMongoRawBatchBuilder_NestedTemporalValuesMatchDecodedPath(t *testing.T) {
+	nested := bsoncore.NewDocumentBuilder().
+		AppendDateTime("dt", 1_782_003_600_123).
+		AppendTimestamp("ts", 1_782_003_600, 42).
+		Build()
+	rawDoc := bsoncore.NewDocumentBuilder().
+		AppendDocument("nested", nested).
+		Build()
+
+	var decoded bson.M
+	if err := bson.Unmarshal(rawDoc, &decoded); err != nil {
+		t.Fatalf("bson.Unmarshal error = %v", err)
+	}
+
+	decodedBuilder := newMongoBatchBuilder(nil)
+	if err := decodedBuilder.AppendDocument(decoded); err != nil {
+		t.Fatalf("decoded AppendDocument error = %v", err)
+	}
+	decodedRecord, err := decodedBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("decoded NewRecordBatch error = %v", err)
+	}
+	defer decodedRecord.Release()
+
+	rawBuilder := newMongoRawBatchBuilder(nil)
+	if err := rawBuilder.AppendRawDocument(bson.Raw(rawDoc)); err != nil {
+		t.Fatalf("raw AppendRawDocument error = %v", err)
+	}
+	rawRecord, err := rawBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("raw NewRecordBatch error = %v", err)
+	}
+	defer rawRecord.Release()
+
+	if got, want := rawRecord.Schema().Field(0).Type.String(), decodedRecord.Schema().Field(0).Type.String(); got != want {
+		t.Fatalf("raw nested type = %s, want decoded %s", got, want)
+	}
+	if got, want := arrowutil.Value(rawRecord.Column(0), 0), arrowutil.Value(decodedRecord.Column(0), 0); got != want {
+		t.Fatalf("raw nested value = %#v, want decoded value %#v", got, want)
 	}
 }
 

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -672,6 +672,57 @@ func TestMongoRawBatchBuilder_LegacyBSONTypesMatchDecodedPath(t *testing.T) {
 	}
 }
 
+func TestMongoRawBatchBuilder_RawStringAndObjectIDMatchDecodedPath(t *testing.T) {
+	oid := primitive.NewObjectID()
+	rawDoc := bsoncore.NewDocumentBuilder().
+		AppendString("plain", "hello").
+		AppendString("nul", "a\x00b").
+		AppendObjectID("oid", oid).
+		Build()
+
+	var decoded bson.M
+	if err := bson.Unmarshal(rawDoc, &decoded); err != nil {
+		t.Fatalf("bson.Unmarshal error = %v", err)
+	}
+
+	decodedBuilder := newMongoBatchBuilder(nil)
+	if err := decodedBuilder.AppendDocument(decoded); err != nil {
+		t.Fatalf("decoded AppendDocument error = %v", err)
+	}
+	decodedRecord, err := decodedBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("decoded NewRecordBatch error = %v", err)
+	}
+	defer decodedRecord.Release()
+
+	rawBuilder := newMongoRawBatchBuilder(nil)
+	if err := rawBuilder.AppendRawDocument(bson.Raw(rawDoc)); err != nil {
+		t.Fatalf("raw AppendRawDocument error = %v", err)
+	}
+	rawRecord, err := rawBuilder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("raw NewRecordBatch error = %v", err)
+	}
+	defer rawRecord.Release()
+
+	if got, want := rawRecord.NumCols(), decodedRecord.NumCols(); got != want {
+		t.Fatalf("raw NumCols = %d, want decoded %d", got, want)
+	}
+	for i := 0; i < int(decodedRecord.NumCols()); i++ {
+		decodedField := decodedRecord.Schema().Field(i)
+		rawField := rawRecord.Schema().Field(i)
+		if rawField.Name != decodedField.Name {
+			t.Fatalf("field %d name = %q, want %q", i, rawField.Name, decodedField.Name)
+		}
+		if rawField.Type.String() != decodedField.Type.String() {
+			t.Fatalf("%s raw type = %s, want decoded %s", rawField.Name, rawField.Type, decodedField.Type)
+		}
+		if got, want := arrowutil.Value(rawRecord.Column(i), 0), arrowutil.Value(decodedRecord.Column(i), 0); got != want {
+			t.Fatalf("%s raw value = %#v, want decoded value %#v", rawField.Name, got, want)
+		}
+	}
+}
+
 func TestMongoRawBatchBuilder_DuplicateKeysMatchDecodedPath(t *testing.T) {
 	duplicateRaw := bsoncore.NewDocumentBuilder().
 		AppendInt32("x", 1).

--- a/pkg/source/mongodb/raw_json.go
+++ b/pkg/source/mongodb/raw_json.go
@@ -1,0 +1,275 @@
+package mongodb
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type rawBSONJSONField struct {
+	key   string
+	value bson.RawValue
+}
+
+func rawBSONValueAsJSONString(val bson.RawValue) (string, bool) {
+	var buf bytes.Buffer
+	if !appendRawBSONJSONValue(&buf, val) {
+		return "", false
+	}
+	return buf.String(), true
+}
+
+func appendRawBSONDocumentJSON(buf *bytes.Buffer, doc bson.Raw) bool {
+	elements, err := doc.Elements()
+	if err != nil {
+		return false
+	}
+
+	fields := make([]rawBSONJSONField, 0, len(elements))
+	for _, elem := range elements {
+		key := elem.Key()
+		replaced := false
+		for i := range fields {
+			if fields[i].key == key {
+				fields[i].value = elem.Value()
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			fields = append(fields, rawBSONJSONField{key: key, value: elem.Value()})
+		}
+	}
+	sort.Slice(fields, func(i, j int) bool {
+		return fields[i].key < fields[j].key
+	})
+
+	buf.WriteByte('{')
+	for i, field := range fields {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		appendJSONString(buf, field.key)
+		buf.WriteByte(':')
+		if !appendRawBSONJSONValue(buf, field.value) {
+			return false
+		}
+	}
+	buf.WriteByte('}')
+	return true
+}
+
+func appendRawBSONArrayJSON(buf *bytes.Buffer, arr bson.Raw) bool {
+	values, err := arr.Values()
+	if err != nil {
+		return false
+	}
+
+	buf.WriteByte('[')
+	for i, value := range values {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		if !appendRawBSONJSONValue(buf, value) {
+			return false
+		}
+	}
+	buf.WriteByte(']')
+	return true
+}
+
+func appendRawBSONJSONValue(buf *bytes.Buffer, val bson.RawValue) bool {
+	switch val.Type {
+	case bson.TypeDouble:
+		v, ok := val.DoubleOK()
+		if !ok || math.IsNaN(v) || math.IsInf(v, 0) {
+			return false
+		}
+		appendJSONFloat64(buf, v)
+		return true
+	case bson.TypeString:
+		v, ok := val.StringValueOK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, v)
+		return true
+	case bson.TypeEmbeddedDocument:
+		doc, ok := val.DocumentOK()
+		return ok && appendRawBSONDocumentJSON(buf, doc)
+	case bson.TypeArray:
+		arr, ok := val.ArrayOK()
+		return ok && appendRawBSONArrayJSON(buf, arr)
+	case bson.TypeBinary:
+		_, data, ok := val.BinaryOK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, base64.StdEncoding.EncodeToString(data))
+		return true
+	case bson.TypeObjectID:
+		v, ok := val.ObjectIDOK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, v.Hex())
+		return true
+	case bson.TypeBoolean:
+		v, ok := val.BooleanOK()
+		if !ok {
+			return false
+		}
+		if v {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return true
+	case bson.TypeDateTime:
+		v, ok := val.DateTimeOK()
+		return ok && appendRawJSONValue(buf, time.UnixMilli(v))
+	case bson.TypeRegex:
+		pattern, _, ok := val.RegexOK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, pattern)
+		return true
+	case bson.TypeJavaScript:
+		v, ok := val.JavaScriptOK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, v)
+		return true
+	case bson.TypeSymbol:
+		v, ok := val.SymbolOK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, v)
+		return true
+	case bson.TypeInt32:
+		v, ok := val.Int32OK()
+		if !ok {
+			return false
+		}
+		buf.WriteString(strconv.FormatInt(int64(v), 10))
+		return true
+	case bson.TypeTimestamp:
+		t, _, ok := val.TimestampOK()
+		return ok && appendRawJSONValue(buf, time.Unix(int64(t), 0))
+	case bson.TypeInt64:
+		v, ok := val.Int64OK()
+		if !ok {
+			return false
+		}
+		buf.WriteString(strconv.FormatInt(v, 10))
+		return true
+	case bson.TypeDecimal128:
+		v, ok := val.Decimal128OK()
+		if !ok {
+			return false
+		}
+		appendJSONString(buf, v.String())
+		return true
+	case bson.TypeUndefined, bson.TypeMinKey, bson.TypeMaxKey:
+		buf.WriteString("{}")
+		return true
+	case bson.TypeNull:
+		buf.WriteString("null")
+		return true
+	default:
+		return appendRawJSONValue(buf, convertRawBSONValue(val))
+	}
+}
+
+func appendJSONString(buf *bytes.Buffer, value string) {
+	if !utf8.ValidString(value) {
+		_ = appendRawJSONValue(buf, value)
+		return
+	}
+
+	start := 0
+	buf.WriteByte('"')
+	for i, c := range value {
+		if c == utf8.RuneError {
+			continue
+		}
+		if c < 0x20 || c == '\\' || c == '"' || c == '\u2028' || c == '\u2029' {
+			buf.WriteString(value[start:i])
+			switch c {
+			case '\\', '"':
+				buf.WriteByte('\\')
+				buf.WriteRune(c)
+			case '\b':
+				buf.WriteString(`\b`)
+			case '\f':
+				buf.WriteString(`\f`)
+			case '\n':
+				buf.WriteString(`\n`)
+			case '\r':
+				buf.WriteString(`\r`)
+			case '\t':
+				buf.WriteString(`\t`)
+			default:
+				switch c {
+				case '\u2028':
+					buf.WriteString(`\u2028`)
+				case '\u2029':
+					buf.WriteString(`\u2029`)
+				default:
+					buf.WriteString(`\u00`)
+					buf.WriteByte("0123456789abcdef"[byte(c)>>4])
+					buf.WriteByte("0123456789abcdef"[byte(c)&0xF])
+				}
+			}
+			start = i + utf8.RuneLen(c)
+		}
+	}
+	buf.WriteString(value[start:])
+	buf.WriteByte('"')
+}
+
+func appendJSONFloat64(buf *bytes.Buffer, value float64) {
+	format := byte('f')
+	abs := math.Abs(value)
+	if abs != 0 && (abs < 1e-6 || abs >= 1e21) {
+		format = 'e'
+	}
+
+	out := strconv.AppendFloat(nil, value, format, -1, 64)
+	if format == 'e' {
+		n := len(out)
+		if n >= 4 && out[n-4] == 'e' && out[n-3] == '-' && out[n-2] == '0' {
+			out[n-2] = out[n-1]
+			out = out[:n-1]
+		} else if n >= 4 && out[n-4] == 'e' && out[n-3] == '+' && out[n-2] == '0' {
+			out[n-2] = out[n-1]
+			out = out[:n-1]
+		}
+	}
+	buf.Write(out)
+}
+
+func appendRawJSONValue(buf *bytes.Buffer, value any) bool {
+	var encoded bytes.Buffer
+	encoder := json.NewEncoder(&encoded)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return false
+	}
+	out := encoded.Bytes()
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[:len(out)-1]
+	}
+	buf.Write(out)
+	return true
+}

--- a/pkg/source/mongodb/raw_json.go
+++ b/pkg/source/mongodb/raw_json.go
@@ -134,7 +134,7 @@ func appendRawBSONJSONValue(buf *bytes.Buffer, val bson.RawValue) bool {
 		return true
 	case bson.TypeDateTime:
 		v, ok := val.DateTimeOK()
-		return ok && appendRawJSONValue(buf, time.UnixMilli(v))
+		return ok && appendJSONTime(buf, time.UnixMilli(v))
 	case bson.TypeRegex:
 		pattern, _, ok := val.RegexOK()
 		if !ok {
@@ -165,7 +165,7 @@ func appendRawBSONJSONValue(buf *bytes.Buffer, val bson.RawValue) bool {
 		return true
 	case bson.TypeTimestamp:
 		t, _, ok := val.TimestampOK()
-		return ok && appendRawJSONValue(buf, time.Unix(int64(t), 0))
+		return ok && appendJSONTime(buf, time.Unix(int64(t), 0))
 	case bson.TypeInt64:
 		v, ok := val.Int64OK()
 		if !ok {
@@ -192,6 +192,12 @@ func appendRawBSONJSONValue(buf *bytes.Buffer, val bson.RawValue) bool {
 }
 
 func appendJSONString(buf *bytes.Buffer, value string) {
+	if stringNeedsNoEscaping(value) {
+		buf.WriteByte('"')
+		buf.WriteString(value)
+		buf.WriteByte('"')
+		return
+	}
 	if !utf8.ValidString(value) {
 		_ = appendRawJSONValue(buf, value)
 		return
@@ -238,6 +244,19 @@ func appendJSONString(buf *bytes.Buffer, value string) {
 	buf.WriteByte('"')
 }
 
+func stringNeedsNoEscaping(value string) bool {
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c < 0x20 || c == '\\' || c == '"' {
+			return false
+		}
+		if c >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
 func appendJSONFloat64(buf *bytes.Buffer, value float64) {
 	format := byte('f')
 	abs := math.Abs(value)
@@ -257,6 +276,36 @@ func appendJSONFloat64(buf *bytes.Buffer, value float64) {
 		}
 	}
 	buf.Write(out)
+}
+
+func appendJSONTime(buf *bytes.Buffer, value time.Time) bool {
+	start := buf.Len()
+	buf.WriteByte('"')
+	formatted := value.AppendFormat(buf.AvailableBuffer(), time.RFC3339Nano)
+	if !strictRFC3339Time(formatted) {
+		buf.Truncate(start)
+		return appendRawJSONValue(buf, value)
+	}
+
+	buf.Write(formatted)
+	buf.WriteByte('"')
+	return true
+}
+
+func strictRFC3339Time(value []byte) bool {
+	if len(value) <= len("9999") || value[len("9999")] != '-' {
+		return false
+	}
+	if value[len(value)-1] == 'Z' {
+		return true
+	}
+
+	c := value[len(value)-len("Z07:00")]
+	if '0' <= c && c <= '9' {
+		return false
+	}
+	zoneHour := 10*(value[len(value)-len("07:00")]-'0') + (value[len(value)-len("7:00")] - '0')
+	return zoneHour < 24
 }
 
 func appendRawJSONValue(buf *bytes.Buffer, value any) bool {

--- a/pkg/source/mongodb/typed_builder.go
+++ b/pkg/source/mongodb/typed_builder.go
@@ -1,6 +1,7 @@
 package mongodb
 
 import (
+	"encoding/hex"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -10,6 +11,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 // typedColumnBuilder lazily picks an Arrow type from the first non-null value
@@ -174,18 +176,14 @@ func (c *typedColumnBuilder) tryAppendRaw(val bson.RawValue) bool {
 	case *array.StringBuilder:
 		switch val.Type {
 		case bson.TypeString:
-			v, ok := val.StringValueOK()
-			if !ok {
+			if !appendRawStringValue(b, val) {
 				return false
 			}
-			b.Append(v)
 			return true
 		case bson.TypeObjectID:
-			v, ok := val.ObjectIDOK()
-			if !ok {
+			if !appendRawObjectIDHex(b, val) {
 				return false
 			}
-			b.Append(v.Hex())
 			return true
 		case bson.TypeDecimal128:
 			v, ok := val.Decimal128OK()
@@ -298,6 +296,26 @@ func appendRawExtensionValue(builder *array.ExtensionBuilder, val bson.RawValue)
 	default:
 		return false
 	}
+}
+
+func appendRawStringValue(builder *array.StringBuilder, val bson.RawValue) bool {
+	length, rem, ok := bsoncore.ReadLength(val.Value)
+	if !ok || length == 0 || len(val.Value[4:]) < int(length) {
+		return false
+	}
+	builder.BinaryBuilder.Append(rem[:length-1])
+	return true
+}
+
+func appendRawObjectIDHex(builder *array.StringBuilder, val bson.RawValue) bool {
+	if len(val.Value) < 12 {
+		return false
+	}
+
+	var buf [24]byte
+	hex.Encode(buf[:], val.Value[:12])
+	builder.BinaryBuilder.Append(buf[:])
+	return true
 }
 
 func (c *typedColumnBuilder) promoteToUnknown() {

--- a/pkg/source/mongodb/typed_builder.go
+++ b/pkg/source/mongodb/typed_builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -66,6 +67,26 @@ func (c *typedColumnBuilder) Append(val any) {
 
 	c.promoteToUnknown()
 	arrowconv.AppendValue(c.builder, convertBSONValue(val))
+	c.rowCount++
+}
+
+func (c *typedColumnBuilder) AppendRaw(val bson.RawValue) {
+	if val.Type == bson.TypeNull {
+		c.AppendNull()
+		return
+	}
+
+	if c.builder == nil {
+		c.materialize(inferTypeFromRawBSONValue(val))
+	}
+
+	if c.tryAppendRaw(val) {
+		c.rowCount++
+		return
+	}
+
+	c.promoteToUnknown()
+	arrowconv.AppendValue(c.builder, convertRawBSONValue(val))
 	c.rowCount++
 }
 
@@ -148,6 +169,110 @@ func (c *typedColumnBuilder) tryAppend(val any) bool {
 	return false
 }
 
+func (c *typedColumnBuilder) tryAppendRaw(val bson.RawValue) bool {
+	switch b := c.builder.(type) {
+	case *array.StringBuilder:
+		switch val.Type {
+		case bson.TypeString:
+			v, ok := val.StringValueOK()
+			if !ok {
+				return false
+			}
+			b.Append(v)
+			return true
+		case bson.TypeObjectID:
+			v, ok := val.ObjectIDOK()
+			if !ok {
+				return false
+			}
+			b.Append(v.Hex())
+			return true
+		case bson.TypeDecimal128:
+			v, ok := val.Decimal128OK()
+			if !ok {
+				return false
+			}
+			b.Append(v.String())
+			return true
+		}
+	case *array.Int64Builder:
+		switch val.Type {
+		case bson.TypeInt32:
+			v, ok := val.Int32OK()
+			if !ok {
+				return false
+			}
+			b.Append(int64(v))
+			return true
+		case bson.TypeInt64:
+			v, ok := val.Int64OK()
+			if !ok {
+				return false
+			}
+			b.Append(v)
+			return true
+		}
+	case *array.Float64Builder:
+		switch val.Type {
+		case bson.TypeDouble:
+			v, ok := val.DoubleOK()
+			if !ok {
+				return false
+			}
+			b.Append(v)
+			return true
+		case bson.TypeInt32:
+			v, ok := val.Int32OK()
+			if !ok {
+				return false
+			}
+			b.Append(float64(v))
+			return true
+		case bson.TypeInt64:
+			v, ok := val.Int64OK()
+			if !ok {
+				return false
+			}
+			b.Append(float64(v))
+			return true
+		}
+	case *array.BooleanBuilder:
+		if val.Type != bson.TypeBoolean {
+			return false
+		}
+		v, ok := val.BooleanOK()
+		if !ok {
+			return false
+		}
+		b.Append(v)
+		return true
+	case *array.TimestampBuilder:
+		if val.Type != bson.TypeDateTime {
+			return false
+		}
+		v, ok := val.DateTimeOK()
+		if !ok {
+			return false
+		}
+		b.Append(arrow.Timestamp(v * 1000))
+		return true
+	case *array.BinaryBuilder:
+		if val.Type != bson.TypeBinary {
+			return false
+		}
+		_, data, ok := val.BinaryOK()
+		if !ok {
+			return false
+		}
+		b.Append(data)
+		return true
+	case *array.ExtensionBuilder:
+		arrowconv.AppendValue(b, convertRawBSONValue(val))
+		return true
+	}
+	return false
+}
+
 func (c *typedColumnBuilder) promoteToUnknown() {
 	if isUnknownType(c.typ) {
 		return
@@ -208,6 +333,24 @@ func inferTypeFromBSONValue(val any) arrow.DataType {
 	case primitive.Decimal128:
 		return arrow.BinaryTypes.String
 	case primitive.Binary:
+		return arrow.BinaryTypes.Binary
+	}
+	return schema.UnknownArrowType
+}
+
+func inferTypeFromRawBSONValue(val bson.RawValue) arrow.DataType {
+	switch val.Type {
+	case bson.TypeString, bson.TypeObjectID, bson.TypeDecimal128:
+		return arrow.BinaryTypes.String
+	case bson.TypeInt32, bson.TypeInt64:
+		return arrow.PrimitiveTypes.Int64
+	case bson.TypeDouble:
+		return arrow.PrimitiveTypes.Float64
+	case bson.TypeBoolean:
+		return arrow.FixedWidthTypes.Boolean
+	case bson.TypeDateTime:
+		return arrow.FixedWidthTypes.Timestamp_us
+	case bson.TypeBinary:
 		return arrow.BinaryTypes.Binary
 	}
 	return schema.UnknownArrowType

--- a/pkg/source/mongodb/typed_builder.go
+++ b/pkg/source/mongodb/typed_builder.go
@@ -300,7 +300,7 @@ func appendRawExtensionValue(builder *array.ExtensionBuilder, val bson.RawValue)
 
 func appendRawStringValue(builder *array.StringBuilder, val bson.RawValue) bool {
 	length, rem, ok := bsoncore.ReadLength(val.Value)
-	if !ok || length == 0 || len(val.Value[4:]) < int(length) {
+	if !ok || length <= 0 || len(val.Value[4:]) < int(length) {
 		return false
 	}
 	builder.BinaryBuilder.Append(rem[:length-1])

--- a/pkg/source/mongodb/typed_builder.go
+++ b/pkg/source/mongodb/typed_builder.go
@@ -267,10 +267,37 @@ func (c *typedColumnBuilder) tryAppendRaw(val bson.RawValue) bool {
 		b.Append(data)
 		return true
 	case *array.ExtensionBuilder:
+		if appendRawExtensionValue(b, val) {
+			return true
+		}
 		arrowconv.AppendValue(b, convertRawBSONValue(val))
 		return true
 	}
 	return false
+}
+
+func appendRawExtensionValue(builder *array.ExtensionBuilder, val bson.RawValue) bool {
+	extType, ok := builder.Type().(arrow.ExtensionType)
+	if !ok || extType.ExtensionName() != schema.UnknownExtensionName {
+		return false
+	}
+
+	storage, ok := builder.StorageBuilder().(*array.StringBuilder)
+	if !ok {
+		return false
+	}
+
+	switch val.Type {
+	case bson.TypeEmbeddedDocument, bson.TypeArray:
+		encoded, ok := rawBSONValueAsJSONString(val)
+		if !ok {
+			return false
+		}
+		storage.Append(encoded)
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *typedColumnBuilder) promoteToUnknown() {


### PR DESCRIPTION
Optimizes the MongoDB benchmark path across source decoding and destination loading. Adds faster raw BSON handling, direct JSON encoding, DuckDB stream/merge improvements, Postgres COPY conversion, and SQL Server empty-target loading. Validated with focused package tests, full format/lint/test runs during the optimization commits, and local 1M benchmark runs.