### PR TITLE
Use target schema for DuckDB replace staging

### DIFF
--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -169,3 +169,29 @@ type ExactRowCountWaiter interface {
 type TruncateCapable interface {
 	TruncateTable(ctx context.Context, table string) error
 }
+
+// ReplaceStagingPlacement declares the default schema placement for replace
+// staging tables.
+type ReplaceStagingPlacement string
+
+const (
+	// ReplaceStagingManagedSchema stages in a destination-managed schema such as
+	// _bruin_staging.
+	ReplaceStagingManagedSchema ReplaceStagingPlacement = "managed_schema"
+	// ReplaceStagingTargetSchema stages in the target table's schema by default.
+	ReplaceStagingTargetSchema ReplaceStagingPlacement = "target_schema"
+)
+
+// ReplaceStagingPolicy declares how replace should choose staging table names
+// for a destination.
+type ReplaceStagingPolicy struct {
+	DefaultPlacement     ReplaceStagingPlacement
+	DefaultManagedSchema string
+	DefaultTargetSchema  string
+}
+
+// ReplaceStagingPolicyProvider lets a destination declare where replace
+// staging tables should live while keeping strategy orchestration generic.
+type ReplaceStagingPolicyProvider interface {
+	ReplaceStagingPolicy() ReplaceStagingPolicy
+}

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -77,6 +77,13 @@ func (d *DuckDBDestination) Schemes() []string {
 	return []string{"duckdb", "motherduck", "md"}
 }
 
+func (d *DuckDBDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:    destination.ReplaceStagingTargetSchema,
+		DefaultTargetSchema: "main",
+	}
+}
+
 func (d *DuckDBDestination) Connect(ctx context.Context, uri string) error {
 	path, err := parseDuckDBPath(uri)
 	if err != nil {
@@ -316,7 +323,7 @@ func (d *DuckDBDestination) SwapTable(ctx context.Context, opts destination.Swap
 		}
 	}()
 
-	if stagingSchema == targetSchema {
+	if duckDBSchemaEquivalent(stagingSchema, targetSchema) {
 		// Same schema: cheap rename swap.
 		oldNameCandidate := fmt.Sprintf("%s_old_%d", targetName, time.Now().UnixNano())
 		oldName := destination.ShortenIdentifier(oldNameCandidate, oldNameCandidate, destination.MaxIdentifierLength("duckdb"))
@@ -954,6 +961,17 @@ func parseSchemaTable(table string) (string, string) {
 		return parts[0], parts[1]
 	}
 	return "", table
+}
+
+func duckDBSchemaEquivalent(left, right string) bool {
+	return canonicalDuckDBSchema(left) == canonicalDuckDBSchema(right)
+}
+
+func canonicalDuckDBSchema(name string) string {
+	if name == "" {
+		return "main"
+	}
+	return name
 }
 
 func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -194,6 +194,42 @@ func TestParseSchemaTable(t *testing.T) {
 	}
 }
 
+func TestReplaceStagingPolicy(t *testing.T) {
+	dest := NewDuckDBDestination()
+
+	policy := dest.ReplaceStagingPolicy()
+	if policy.DefaultPlacement != destination.ReplaceStagingTargetSchema {
+		t.Fatalf("DefaultPlacement = %q, want %q", policy.DefaultPlacement, destination.ReplaceStagingTargetSchema)
+	}
+	if policy.DefaultTargetSchema != "main" {
+		t.Fatalf("DefaultTargetSchema = %q, want main", policy.DefaultTargetSchema)
+	}
+}
+
+func TestDuckDBSwapTable_MainSchemaStagingToUnqualifiedTargetUsesRename(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE users (id BIGINT)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO users VALUES (1)`))
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE main.users_staging (id BIGINT)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO main.users_staging VALUES (2)`))
+
+	require.NoError(t, dest.SwapTable(ctx, destination.SwapOptions{
+		StagingTable: "main.users_staging",
+		TargetTable:  "users",
+	}))
+
+	db := openDuckDB(t, ctx, path)
+	var got int64
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT id FROM users`).Scan(&got))
+	assert.Equal(t, int64(2), got)
+
+	var stagingCount int64
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM information_schema.tables WHERE table_schema = 'main' AND table_name = 'users_staging'`).Scan(&stagingCount))
+	assert.Equal(t, int64(0), stagingCount)
+}
+
 func TestQuoteColumns(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
@@ -265,6 +266,34 @@ func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing
 	}
 	if len(dest.swapCalls) != 1 || dest.swapCalls[0][0] != dest.prepareCalls[0].Table {
 		t.Fatalf("expected staging table to be swapped directly, got swaps=%v prepares=%v", dest.swapCalls, dest.prepareCalls)
+	}
+}
+
+func TestReplaceStrategy_Execute_UsesDestinationReplaceStagingPolicy(t *testing.T) {
+	job, src, dest := minimalJob()
+	provider := &fakeReplaceStagingPolicyProvider{
+		fakeDestination: dest,
+		policy: destination.ReplaceStagingPolicy{
+			DefaultPlacement: destination.ReplaceStagingTargetSchema,
+		},
+	}
+	job.Destination = provider
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	job.SourceSchema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 1 {
+		t.Fatalf("expected 1 PrepareTable call, got %d", len(dest.prepareCalls))
+	}
+	if stagingTable := dest.prepareCalls[0].Table; !strings.HasPrefix(stagingTable, "ds.tbl_staging_") {
+		t.Fatalf("PrepareTable.Table = %q, want target-schema staging prefix %q", stagingTable, "ds.tbl_staging_")
 	}
 }
 

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -183,6 +183,14 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 
 type ReplaceStrategy struct{}
 
+func replaceStagingTableName(dest destination.Destination, targetTable, stagingDataset string) string {
+	policy := defaultReplaceStagingPolicy()
+	if provider, ok := dest.(destination.ReplaceStagingPolicyProvider); ok {
+		policy = provider.ReplaceStagingPolicy()
+	}
+	return GenerateReplaceStagingTableName(targetTable, "staging", stagingDataset, policy)
+}
+
 func (s *ReplaceStrategy) Name() config.IncrementalStrategy {
 	return config.StrategyReplace
 }
@@ -207,7 +215,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	targetTable := job.Config.DestTable
 	writeTable := targetTable
 	if useStaging {
-		writeTable = GenerateStagingTableName(targetTable, "staging", job.Config.StagingDataset)
+		writeTable = replaceStagingTableName(job.Destination, targetTable, job.Config.StagingDataset)
 		fmt.Printf("[STRATEGY] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), writeTable)
 	} else {
 		config.Debug("[STRATEGY] Direct write to target (no staging): %s", writeTable)
@@ -377,7 +385,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 			destTable := job.GetDestTableName(ti.Name)
 			writeTable := destTable
 			if useStaging {
-				writeTable = GenerateStagingTableName(destTable, "staging", job.Config.StagingDataset)
+				writeTable = replaceStagingTableName(job.Destination, destTable, job.Config.StagingDataset)
 			}
 
 			prepareOpts := destination.PrepareOptions{

--- a/pkg/strategy/staging.go
+++ b/pkg/strategy/staging.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
 )
 
 const DefaultStagingSchema = "_bruin_staging"
@@ -35,6 +37,63 @@ func GenerateStagingTableName(targetTable, suffix, stagingDataset string) string
 		embeddedName = fmt.Sprintf("%s__%s", originSchema, tableName)
 	}
 
+	return buildStagingTableName(stagingSchema, embeddedName, suffix)
+}
+
+func GenerateReplaceStagingTableName(targetTable, suffix, stagingDataset string, policy destination.ReplaceStagingPolicy) string {
+	policy = normaliseReplaceStagingPolicy(policy)
+	targetSchema, tableName := splitSchemaTable(targetTable)
+
+	stagingSchema := stagingDataset
+	if stagingSchema == "" {
+		switch policy.DefaultPlacement {
+		case destination.ReplaceStagingTargetSchema:
+			stagingSchema = targetSchema
+			if stagingSchema == "" {
+				stagingSchema = policy.DefaultTargetSchema
+			}
+		default:
+			stagingSchema = policy.DefaultManagedSchema
+		}
+	}
+	if stagingSchema == "" {
+		stagingSchema = policy.DefaultManagedSchema
+	}
+
+	embeddedName := tableName
+	if targetSchema != "" && (stagingDataset != "" || stagingSchema != targetSchema) {
+		embeddedName = fmt.Sprintf("%s__%s", targetSchema, tableName)
+	}
+
+	return buildStagingTableName(stagingSchema, embeddedName, suffix)
+}
+
+func defaultReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingManagedSchema,
+		DefaultManagedSchema: DefaultStagingSchema,
+	}
+}
+
+func normaliseReplaceStagingPolicy(policy destination.ReplaceStagingPolicy) destination.ReplaceStagingPolicy {
+	if policy.DefaultPlacement == "" {
+		policy.DefaultPlacement = destination.ReplaceStagingManagedSchema
+	}
+	if policy.DefaultManagedSchema == "" {
+		policy.DefaultManagedSchema = DefaultStagingSchema
+	}
+	return policy
+}
+
+func splitSchemaTable(table string) (string, string) {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", table
+}
+
+func buildStagingTableName(stagingSchema, embeddedName, suffix string) string {
 	nano := fmt.Sprintf("%d", time.Now().UnixNano())
 	tail := fmt.Sprintf("_%s_%s", suffix, nano)
 	// If the name would exceed the per-engine identifier limit, hash the

--- a/pkg/strategy/staging.go
+++ b/pkg/strategy/staging.go
@@ -61,7 +61,7 @@ func GenerateReplaceStagingTableName(targetTable, suffix, stagingDataset string,
 	}
 
 	embeddedName := tableName
-	if targetSchema != "" && (stagingDataset != "" || stagingSchema != targetSchema) {
+	if targetSchema != "" && stagingSchema != targetSchema {
 		embeddedName = fmt.Sprintf("%s__%s", targetSchema, tableName)
 	}
 

--- a/pkg/strategy/staging_test.go
+++ b/pkg/strategy/staging_test.go
@@ -3,6 +3,8 @@ package strategy
 import (
 	"strings"
 	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
 )
 
 func TestGenerateStagingTableName(t *testing.T) {
@@ -37,6 +39,58 @@ func TestGenerateStagingTableName(t *testing.T) {
 			}
 			if strings.HasSuffix(got, "_") {
 				t.Fatalf("unexpected trailing underscore: %q", got)
+			}
+		})
+	}
+}
+
+func TestGenerateReplaceStagingTableName(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetTable    string
+		stagingDataset string
+		policy         destination.ReplaceStagingPolicy
+		wantPrefix     string
+	}{
+		{
+			name:        "default managed schema",
+			targetTable: "analytics.users",
+			wantPrefix:  "_bruin_staging.analytics__users_staging_",
+		},
+		{
+			name:        "target schema placement",
+			targetTable: "analytics.users",
+			policy: destination.ReplaceStagingPolicy{
+				DefaultPlacement: destination.ReplaceStagingTargetSchema,
+			},
+			wantPrefix: "analytics.users_staging_",
+		},
+		{
+			name:        "target schema placement with unqualified target",
+			targetTable: "users",
+			policy: destination.ReplaceStagingPolicy{
+				DefaultPlacement:    destination.ReplaceStagingTargetSchema,
+				DefaultTargetSchema: "main",
+			},
+			wantPrefix: "main.users_staging_",
+		},
+		{
+			name:           "explicit staging dataset with target policy",
+			targetTable:    "analytics.users",
+			stagingDataset: "scratch",
+			policy: destination.ReplaceStagingPolicy{
+				DefaultPlacement: destination.ReplaceStagingTargetSchema,
+			},
+			wantPrefix: "scratch.analytics__users_staging_",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateReplaceStagingTableName(tt.targetTable, "staging", tt.stagingDataset, tt.policy)
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Fatalf("GenerateReplaceStagingTableName(%q, %q) = %q, want prefix %q",
+					tt.targetTable, tt.stagingDataset, got, tt.wantPrefix)
 			}
 		})
 	}

--- a/pkg/strategy/staging_test.go
+++ b/pkg/strategy/staging_test.go
@@ -83,6 +83,15 @@ func TestGenerateReplaceStagingTableName(t *testing.T) {
 			},
 			wantPrefix: "scratch.analytics__users_staging_",
 		},
+		{
+			name:           "explicit staging dataset matching target schema",
+			targetTable:    "analytics.users",
+			stagingDataset: "analytics",
+			policy: destination.ReplaceStagingPolicy{
+				DefaultPlacement: destination.ReplaceStagingTargetSchema,
+			},
+			wantPrefix: "analytics.users_staging_",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -129,6 +129,7 @@ func (d *fakeDestination) SupportsDeleteInsertStrategy() bool { return !d.noDele
 func (d *fakeDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *fakeDestination) SupportsAtomicSwap() bool           { return true }
 func (d *fakeDestination) GetScheme() string                  { return "fake" }
+
 func (d *fakeDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	return nil, nil
 }
@@ -235,6 +236,16 @@ func (d *fakeDestination) WaitForExactRowCount(ctx context.Context, table string
 	waitErr := d.waitErr
 	d.mu.Unlock()
 	return waitErr
+}
+
+type fakeReplaceStagingPolicyProvider struct {
+	*fakeDestination
+
+	policy destination.ReplaceStagingPolicy
+}
+
+func (d *fakeReplaceStagingPolicyProvider) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	return d.policy
 }
 
 func int64RecordBatch(t *testing.T, colName string, values []int64, nullAt map[int]bool) arrow.RecordBatch {

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -357,6 +357,7 @@ func TestStreamingExecutor_PassesFlushOptionsToSource(t *testing.T) {
 	assert.Equal(t, 123*time.Millisecond, src.readOpts.FlushInterval)
 	assert.Equal(t, 7, src.readOpts.FlushRecords)
 }
+
 func TestStreaming_ExecuteAppliesBatchTransformationsOnce(t *testing.T) {
 	job, src, _ := minimalJob()
 	dest := &capturingDestination{fakeDestination: &fakeDestination{}}


### PR DESCRIPTION
Allow destinations to control replace staging placement, and make DuckDB stage replace tables in the target schema. This keeps DuckDB swaps on the rename path when the target is unqualified and the staging table is in main. Validated with make format, make lint, and make test.