### PR TITLE
chore(deps): bump mongo-driver to v1.17.7 (fixes GSSAPI heap OOB read)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/urfave/cli/v3 v3.0.0-beta1
 	github.com/xuri/excelize/v2 v2.10.1
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
-	go.mongodb.org/mongo-driver v1.17.6
+	go.mongodb.org/mongo-driver v1.17.7
 	golang.org/x/crypto v0.50.0
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9
 	golang.org/x/net v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -1492,8 +1492,8 @@ github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaD
 github.com/zeroshade/machine-id v0.0.0-20251223181436-930511047eef h1:1UOIz6tPkZ6ZBbtbk/ci1apJFAJ3EvQZNh1QVMENjuY=
 github.com/zeroshade/machine-id v0.0.0-20251223181436-930511047eef/go.mod h1:RHX47A/DYmoTfyT25mb6C+Eve7X5miOporc+RVUoRoY=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
-go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
-go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
+go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.mongodb.org/mongo-driver/v2 v2.3.0 h1:sh55yOXA2vUjW1QYw/2tRlHSQViwDyPnW61AwpZ4rtU=
 go.mongodb.org/mongo-driver/v2 v2.3.0/go.mod h1:jHeEDJHJq7tm6ZF45Issun9dbogjfnPySb1vXA7EeAI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
## What

Bumps `go.mongodb.org/mongo-driver` from `v1.17.6` → **`v1.17.7`**.

## Why

Resolves Dependabot alert [#211](https://github.com/bruin-data/ingestr/security/dependabot/211) — **heap out-of-bounds read in GSSAPI error handling** (GODRIVER-3770, fixed upstream in [mongo-go-driver#2291](https://github.com/mongodb/mongo-go-driver/pull/2291)).

The v1.17.6 GSSAPI C wrapper (`x/mongo/driver/auth/internal/gssapi/gss_wrapper.c`) assumed GSSAPI buffers were null-terminated. They aren't guaranteed to be, so the error-description and username functions read one byte past the allocated heap buffer.

`mongo-driver` is a **direct** dependency (used by the MongoDB source).

## Scope of the upstream change

`v1.17.6...v1.17.7` is a patch release (5 commits): the 4-line GSSAPI C buffer fix, a removed `MergeClientOptions` deprecation comment, a README deprecation banner, and the version bump. **No Go API changes.**

## Verification

- `go build ./...` ✅
- `go test -short ./pkg/source/mongodb/...` ✅
- `go mod tidy` clean (go.sum carries only v1.17.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)