### PR TITLE
Add MongoDB CDC schemes to server connector catalog

### DIFF
--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -84,6 +84,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("mysql-cdc", "MySQL CDC", []string{"mysql+cdc", "mysql+pymysql+cdc", "mariadb+cdc"}, true, false),
 		genericURIConnector("mssql-cdc", "SQL Server CDC", []string{"mssql+cdc", "sqlserver+cdc", "azuresql+cdc", "azure-sql+cdc"}, true, false),
 		genericURIConnector("mssql-ct", "SQL Server Change Tracking", []string{"mssql+ct", "sqlserver+ct", "azuresql+ct", "azure-sql+ct"}, true, false),
+		genericURIConnector("mongodb-cdc", "MongoDB CDC", []string{"mongodb+cdc", "mongodb+srv+cdc"}, true, false),
 		{
 			ID:            "azuresql",
 			Name:          "Azure SQL",
@@ -111,7 +112,7 @@ func GetConnectors() []ConnectorType {
 		{
 			ID:            "mongodb",
 			Name:          "MongoDB",
-			Schemes:       []string{"mongodb", "mongodb+srv", "mongodb+cdc", "mongodb+srv+cdc"},
+			Schemes:       []string{"mongodb", "mongodb+srv"},
 			IsSource:      true,
 			IsDestination: true,
 			Fields: []ConnectorField{

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -111,7 +111,7 @@ func GetConnectors() []ConnectorType {
 		{
 			ID:            "mongodb",
 			Name:          "MongoDB",
-			Schemes:       []string{"mongodb", "mongodb+srv"},
+			Schemes:       []string{"mongodb", "mongodb+srv", "mongodb+cdc", "mongodb+srv+cdc"},
 			IsSource:      true,
 			IsDestination: true,
 			Fields: []ConnectorField{


### PR DESCRIPTION
## What

The MongoDB CDC source (added in #837) registers the `mongodb+cdc` and `mongodb+srv+cdc` schemes in the source registry, but they were missing from the server connector catalog (`internal/server/connectors.go`).

This caused `TestConnectorCatalogCoversRegisteredSchemes` to fail:

```
scheme "mongodb+cdc" is missing from connector catalog
scheme "mongodb+srv+cdc" is missing from connector catalog
```