### PR TITLE
Add Twilio source

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Twilio</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Wise</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -230,6 +230,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Stripe", link: "/supported-sources/stripe.md" },
               { text: "SurveyMonkey", link: "/supported-sources/surveymonkey.md" },
               { text: "TikTok Ads", link: "/supported-sources/tiktok-ads.md" },
+              { text: "Twilio", link: "/supported-sources/twilio.md" },
               { text: "Wise", link: "/supported-sources/wise.md" },
               { text: "Wistia", link: "/supported-sources/wistia.md" },
               { text: "Zendesk", link: "/supported-sources/zendesk.md" },

--- a/docs/supported-sources/twilio.md
+++ b/docs/supported-sources/twilio.md
@@ -1,0 +1,98 @@
+# Twilio
+
+[Twilio](https://www.twilio.com/) is a cloud communications platform for messaging, voice, and phone numbers.
+
+ingestr supports Twilio as a source.
+
+## URI format
+
+The URI format for Twilio is as follows:
+
+```plaintext
+twilio://?account_sid=<account-sid>&auth_token=<auth-token>
+```
+
+URI parameters:
+
+- `account_sid` (required): Your Twilio Account SID (starts with `AC`).
+- `auth_token`: Your Twilio Auth Token. Required unless `api_key`/`api_secret` are provided.
+- `api_key` / `api_secret`: An API Key SID and Secret, used instead of the Auth Token. When `api_key` is set, `api_secret` is required.
+
+Authentication uses HTTP Basic Auth. API Key + Secret is preferred; Account SID + Auth Token is the fallback. Either way the Account SID stays in the request path.
+
+## Setting up a Twilio Integration
+
+To get your credentials:
+
+1. Log in to the [Twilio Console](https://console.twilio.com/).
+2. Find your **Account SID** and **Auth Token** in the **Account Info** panel on the dashboard.
+3. Optionally create an API Key under **Account > API keys & tokens** and use `api_key`/`api_secret` instead of the Auth Token.
+
+Once you have your credentials, here's a sample command that will copy data from Twilio into a DuckDB database:
+
+```sh
+ingestr ingest \
+  --source-uri 'twilio://?account_sid=ACxxxxxx&auth_token=xxxxxx' \
+  --source-table 'messages' \
+  --dest-uri duckdb:///twilio.duckdb \
+  --dest-table 'twilio.messages'
+```
+
+The result of this command will be a table in the `twilio.duckdb` database.
+
+## Tables
+
+Twilio source allows ingesting the following sources into separate tables:
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| ----- | -- | ------- | ------------ | ------- |
+| `messages` | `sid` | - | replace | SMS and MMS messages. |
+| `calls` | `sid` | `date_updated` | merge | Voice calls. |
+| `recordings` | `sid` | `date_updated` | merge | Call recordings, including deleted ones. |
+| `incoming_phone_numbers` | `sid` | - | replace | Phone numbers owned by the account. |
+| `usage_records` | - | - | replace | Usage totals per category over the account lifetime. Accepts an optional granularity suffix (see below). |
+
+Use one of these as the `--source-table` parameter in the `ingestr ingest` command.
+
+### Usage record granularity
+
+`usage_records` accepts an optional granularity suffix that switches to Twilio's `Daily`/`Monthly`/`Yearly` sub-resources:
+
+| Source table | Grain | Inc Key | Inc Strategy |
+| ------------ | ----- | ------- | ------------ |
+| `usage_records` | lifetime total per category | - | replace |
+| `usage_records:daily` | one row per category per day | `start_date` | merge |
+| `usage_records:monthly` | one row per category per month | `start_date` | merge |
+| `usage_records:yearly` | one row per category per year | `start_date` | merge |
+
+The granular variants load incrementally by period: past periods are loaded once and the current period is refreshed on each run.
+
+## Incremental loading
+
+When `--interval-start`/`--interval-end` are not provided, all records are loaded. When an interval is provided:
+
+- `calls`, `recordings`, and `usage_records:daily`/`:monthly`/`:yearly` load the records that fall within it (the incrementally-loaded tables).
+- `messages`, `incoming_phone_numbers`, and `usage_records` ignore the interval and always load the full table. `messages` is loaded in full because redactions (which don't change `date_updated`) and deletions can't be detected incrementally via the Twilio API.
+
+## Examples
+
+Ingest daily usage records from a given start date:
+
+```sh
+ingestr ingest \
+  --source-uri 'twilio://?account_sid=ACxxxxxx&auth_token=xxxxxx' \
+  --source-table 'usage_records:daily' \
+  --dest-uri duckdb:///twilio.duckdb \
+  --dest-table 'twilio.usage_records_daily' \
+  --interval-start 2024-01-01
+```
+
+Authenticate with an API Key + Secret instead of the Auth Token:
+
+```sh
+ingestr ingest \
+  --source-uri 'twilio://?account_sid=ACxxxxxx&api_key=SKxxxxxx&api_secret=xxxxxx' \
+  --source-table 'calls' \
+  --dest-uri duckdb:///twilio.duckdb \
+  --dest-table 'twilio.calls'
+```

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -353,6 +353,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("tiktok", "TikTok Ads", []string{"tiktok"}, true, false),
 		genericURIConnector("trino", "Trino", []string{"trino"}, true, true),
 		genericURIConnector("trustpilot", "Trustpilot", []string{"trustpilot"}, true, false),
+		genericURIConnector("twilio", "Twilio", []string{"twilio"}, true, false),
 		genericURIConnector("wise", "Wise", []string{"wise"}, true, false),
 		genericURIConnector("wistia", "Wistia", []string{"wistia"}, true, false),
 		genericURIConnector("zendesk", "Zendesk", []string{"zendesk"}, true, false),

--- a/pkg/source/twilio/register.go
+++ b/pkg/source/twilio/register.go
@@ -1,0 +1,10 @@
+package twilio
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"twilio"},
+		func() interface{} { return NewTwilioSource() },
+	)
+}

--- a/pkg/source/twilio/twilio.go
+++ b/pkg/source/twilio/twilio.go
@@ -258,8 +258,8 @@ func (s *TwilioSource) GetTable(ctx context.Context, req source.TableRequest) (s
 }
 
 func isValidTable(table string) bool {
-	_, ok := supportedTables[table]
-	return ok
+	_, err := resolveTableConfig(table)
+	return err == nil
 }
 
 func supportedTableNames() string {

--- a/pkg/source/twilio/twilio.go
+++ b/pkg/source/twilio/twilio.go
@@ -1,0 +1,435 @@
+package twilio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/araddon/dateparse"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	baseURL = "https://api.twilio.com"
+
+	// Twilio caps list responses at 1000 items per page (default 50).
+	maxPageSize = 1000
+
+	// Twilio enforces an account-level concurrency limit (no fixed rps) and
+	// returns HTTP 429 / error 20429 when exceeded; 10 rps stays safely under.
+	rateLimit      = 10.0
+	rateLimitBurst = 5
+
+	// Server-side date filters on the 2010-04-01 API accept day granularity.
+	dateParamLayout = "2006-01-02"
+)
+
+// tableConfig describes how to read and incrementally filter a Twilio resource.
+// Mutable resources filter client-side on date_updated; Twilio's list APIs have no server-side updated filter.
+type tableConfig struct {
+	resource       string // path segment under /Accounts/{sid}/, e.g. "Messages.json"
+	responseKey    string // envelope key holding the array, e.g. "messages"
+	primaryKeys    []string
+	incrementalKey string
+	strategy       config.IncrementalStrategy
+	dateField      string            // row timestamp field for exact client-side filtering ("" = none)
+	startParam     string            // server-side "on or after" query param ("" = none)
+	endParam       string            // server-side "on or before" query param ("" = none)
+	extraParams    map[string]string // static query params always sent (e.g. IncludeSoftDeleted)
+}
+
+var supportedTables = map[string]tableConfig{
+	// Redaction empties a message body without bumping date_updated, and messages can be
+	// hard-deleted, so replace re-fetches everything and mirrors Twilio's current state.
+	"messages": {
+		resource:    "Messages.json",
+		responseKey: "messages",
+		primaryKeys: []string{"sid"},
+		strategy:    config.StrategyReplace,
+	},
+	// Calls are mutable and their changes bump date_updated, so we merge filtering
+	// client-side on it. Deletions aren't reflected, but call logs are rarely deleted.
+	"calls": {
+		resource:       "Calls.json",
+		responseKey:    "calls",
+		primaryKeys:    []string{"sid"},
+		incrementalKey: "date_updated",
+		strategy:       config.StrategyMerge,
+		dateField:      "date_updated",
+	},
+	// Recordings are mutable and soft-delete: IncludeSoftDeleted surfaces deleted ones as
+	// status="deleted" with a bumped date_updated, so merge picks the deletion up.
+	"recordings": {
+		resource:       "Recordings.json",
+		responseKey:    "recordings",
+		primaryKeys:    []string{"sid"},
+		incrementalKey: "date_updated",
+		strategy:       config.StrategyMerge,
+		dateField:      "date_updated",
+		extraParams:    map[string]string{"IncludeSoftDeleted": "true"},
+	},
+	"incoming_phone_numbers": {
+		resource:    "IncomingPhoneNumbers.json",
+		responseKey: "incoming_phone_numbers",
+		primaryKeys: []string{"sid"},
+		strategy:    config.StrategyReplace,
+	},
+	// Usage records are running per-category aggregates with no per-row updated_at,
+	// so we always full-fetch the lifetime totals and replace (date scoping would
+	// rebuild the table with only one window's aggregate).
+	"usage_records": {
+		resource:    "Usage/Records.json",
+		responseKey: "usage_records",
+		strategy:    config.StrategyReplace,
+	},
+}
+
+type twilioCredentials struct {
+	accountSID string
+	authToken  string
+	apiKey     string
+	apiSecret  string
+}
+
+type TwilioSource struct {
+	client     *httpclient.Client
+	accountSID string
+}
+
+func NewTwilioSource() *TwilioSource {
+	return &TwilioSource{}
+}
+
+func (s *TwilioSource) Schemes() []string {
+	return []string{"twilio"}
+}
+
+func (s *TwilioSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *TwilioSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.accountSID = creds.accountSID
+
+	// API Key + Secret is preferred; Account SID + Auth Token is the fallback.
+	// Either way the Account SID stays in the request path.
+	var auth httpclient.Authenticator
+	if creds.apiKey != "" {
+		auth = httpclient.NewBasicAuth(creds.apiKey, creds.apiSecret)
+	} else {
+		auth = httpclient.NewBasicAuth(creds.accountSID, creds.authToken)
+	}
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(auth),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithHeader("Accept", "application/json"),
+	)
+
+	config.Debug("[TWILIO] connected for account %s", s.accountSID)
+	return nil
+}
+
+func (s *TwilioSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseURI(uri string) (twilioCredentials, error) {
+	if !strings.HasPrefix(uri, "twilio://") {
+		return twilioCredentials{}, fmt.Errorf("invalid twilio URI: must start with twilio://")
+	}
+
+	rest := strings.TrimPrefix(uri, "twilio://")
+	rest = strings.TrimPrefix(rest, "?")
+
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return twilioCredentials{}, fmt.Errorf("failed to parse twilio URI query: %w", err)
+	}
+
+	creds := twilioCredentials{
+		accountSID: values.Get("account_sid"),
+		authToken:  values.Get("auth_token"),
+		apiKey:     values.Get("api_key"),
+		apiSecret:  values.Get("api_secret"),
+	}
+
+	if creds.accountSID == "" {
+		return twilioCredentials{}, fmt.Errorf("account_sid is required in twilio URI")
+	}
+
+	// Two supported auth modes: API Key SID + Secret, or Account SID + Auth Token.
+	switch {
+	case creds.apiKey != "":
+		if creds.apiSecret == "" {
+			return twilioCredentials{}, fmt.Errorf("api_secret is required when api_key is provided in twilio URI")
+		}
+	case creds.authToken != "":
+		// ok
+	default:
+		return twilioCredentials{}, fmt.Errorf("twilio URI requires either auth_token, or api_key and api_secret")
+	}
+
+	return creds, nil
+}
+
+// usageGranularities maps a usage_records granularity modifier to its Twilio
+// sub-resource path segment.
+var usageGranularities = map[string]string{
+	"daily":   "Daily",
+	"monthly": "Monthly",
+	"yearly":  "Yearly",
+}
+
+// resolveTableConfig resolves a table name (optionally with a ":granularity"
+// modifier, e.g. "usage_records:daily") to its tableConfig. Granular usage rows
+// are tied to a fixed period, so unlike the lifetime aggregate they load
+// incrementally via merge on (account_sid, category, start_date).
+func resolveTableConfig(name string) (tableConfig, error) {
+	base, modifier, hasModifier := strings.Cut(name, ":")
+
+	cfg, ok := supportedTables[base]
+	if !ok {
+		return tableConfig{}, fmt.Errorf("unsupported table: %s (supported: %s)", name, supportedTableNames())
+	}
+	if !hasModifier {
+		return cfg, nil
+	}
+
+	if base != "usage_records" {
+		return tableConfig{}, fmt.Errorf("table %s does not support a ':' modifier", base)
+	}
+	segment, ok := usageGranularities[strings.ToLower(modifier)]
+	if !ok {
+		return tableConfig{}, fmt.Errorf("invalid usage_records granularity %q (supported: daily, monthly, yearly)", modifier)
+	}
+
+	cfg.resource = "Usage/Records/" + segment + ".json"
+	cfg.strategy = config.StrategyMerge
+	cfg.primaryKeys = []string{"account_sid", "category", "start_date"}
+	cfg.incrementalKey = "start_date"
+	cfg.startParam = "StartDate"
+	cfg.endParam = "EndDate"
+	return cfg, nil
+}
+
+func (s *TwilioSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName := req.Name
+
+	cfg, err := resolveTableConfig(tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    cfg.primaryKeys,
+		TableIncrementalKey: cfg.incrementalKey,
+		TableStrategy:       cfg.strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("twilio source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, opts)
+		},
+	}, nil
+}
+
+func isValidTable(table string) bool {
+	_, ok := supportedTables[table]
+	return ok
+}
+
+func supportedTableNames() string {
+	names := make([]string, 0, len(supportedTables))
+	for name := range supportedTables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func (s *TwilioSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		cfg, err := resolveTableConfig(table)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+			return
+		}
+
+		if err := s.paginateAndSend(ctx, cfg, opts, results); err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+// paginateAndSend walks Twilio's next_page_uri pagination, streaming one Arrow batch per page.
+// Query params are set only on the first request; Twilio embeds them in next_page_uri thereafter.
+func (s *TwilioSource) paginateAndSend(ctx context.Context, cfg tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	path := fmt.Sprintf("/2010-04-01/Accounts/%s/%s", s.accountSID, cfg.resource)
+
+	query := map[string]string{"PageSize": strconv.Itoa(maxPageSize)}
+	if cfg.startParam != "" && opts.IntervalStart != nil {
+		query[cfg.startParam] = opts.IntervalStart.UTC().Format(dateParamLayout)
+	}
+	if cfg.endParam != "" && opts.IntervalEnd != nil {
+		query[cfg.endParam] = opts.IntervalEnd.UTC().Format(dateParamLayout)
+	}
+	for k, v := range cfg.extraParams {
+		query[k] = v
+	}
+
+	first := true
+	totalSent := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx)
+		if first {
+			req = req.SetQueryParams(query)
+		}
+
+		resp, err := req.Get(path)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", cfg.resource, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("twilio API %s returned status %d: %s", cfg.resource, resp.StatusCode(), resp.String())
+		}
+
+		items, nextPageURI, err := decodeListResponse(resp.Body(), cfg.responseKey)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", cfg.resource, err)
+		}
+
+		if cfg.dateField != "" {
+			items = filterItemsByInterval(items, cfg.dateField, opts.IntervalStart, opts.IntervalEnd)
+		}
+
+		if len(items) > 0 {
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", cfg.resource, err)
+			}
+			results <- source.RecordBatchResult{Batch: record}
+			totalSent += len(items)
+			config.Debug("[TWILIO] %s: sent %d records (total: %d)", cfg.resource, len(items), totalSent)
+		}
+
+		if nextPageURI == "" {
+			break
+		}
+		path = nextPageURI
+		first = false
+	}
+
+	if totalSent == 0 {
+		config.Debug("[TWILIO] no records found for %s", cfg.resource)
+	}
+	return nil
+}
+
+func decodeListResponse(body []byte, key string) ([]map[string]interface{}, string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var raw map[string]interface{}
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, "", err
+	}
+
+	nextPageURI := ""
+	if n, ok := raw["next_page_uri"].(string); ok {
+		nextPageURI = n
+	}
+
+	arr, ok := raw[key].([]interface{})
+	if !ok {
+		return nil, nextPageURI, nil
+	}
+
+	items := make([]map[string]interface{}, 0, len(arr))
+	for _, v := range arr {
+		if m, ok := v.(map[string]interface{}); ok {
+			items = append(items, m)
+		}
+	}
+
+	return items, nextPageURI, nil
+}
+
+func filterItemsByInterval(items []map[string]interface{}, field string, start, end *time.Time) []map[string]interface{} {
+	if field == "" || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		ts, ok := parseTimestamp(item[field])
+		if !ok {
+			// Keep rows whose timestamp is missing/unparseable rather than dropping them.
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && ts.Before(start.UTC()) {
+			continue
+		}
+		if end != nil && !ts.Before(end.UTC()) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	return filtered
+}
+
+func parseTimestamp(raw interface{}) (time.Time, bool) {
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return time.Time{}, false
+		}
+		ts, err := dateparse.ParseAny(v)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return ts.UTC(), true
+	case time.Time:
+		return v.UTC(), true
+	default:
+		return time.Time{}, false
+	}
+}

--- a/pkg/source/twilio/twilio_test.go
+++ b/pkg/source/twilio/twilio_test.go
@@ -66,7 +66,7 @@ func TestParseURI(t *testing.T) {
 }
 
 func TestIsValidTable(t *testing.T) {
-	valid := []string{"messages", "calls", "recordings", "incoming_phone_numbers", "usage_records"}
+	valid := []string{"messages", "calls", "recordings", "incoming_phone_numbers", "usage_records", "usage_records:daily", "usage_records:monthly"}
 	for _, table := range valid {
 		if !isValidTable(table) {
 			t.Errorf("expected %q to be valid", table)

--- a/pkg/source/twilio/twilio_test.go
+++ b/pkg/source/twilio/twilio_test.go
@@ -1,0 +1,213 @@
+package twilio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+		want    twilioCredentials
+	}{
+		{
+			name: "account sid + auth token",
+			uri:  "twilio://?account_sid=AC123&auth_token=tok",
+			want: twilioCredentials{accountSID: "AC123", authToken: "tok"},
+		},
+		{
+			name: "api key + secret",
+			uri:  "twilio://?account_sid=AC123&api_key=SK456&api_secret=sec",
+			want: twilioCredentials{accountSID: "AC123", apiKey: "SK456", apiSecret: "sec"},
+		},
+		{
+			name:    "wrong scheme",
+			uri:     "sendgrid://?account_sid=AC123&auth_token=tok",
+			wantErr: true,
+		},
+		{
+			name:    "missing account_sid",
+			uri:     "twilio://?auth_token=tok",
+			wantErr: true,
+		},
+		{
+			name:    "no auth at all",
+			uri:     "twilio://?account_sid=AC123",
+			wantErr: true,
+		},
+		{
+			name:    "api_key without secret",
+			uri:     "twilio://?account_sid=AC123&api_key=SK456",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	valid := []string{"messages", "calls", "recordings", "incoming_phone_numbers", "usage_records"}
+	for _, table := range valid {
+		if !isValidTable(table) {
+			t.Errorf("expected %q to be valid", table)
+		}
+	}
+
+	invalid := []string{"", "Messages", "message", "unknown", "contacts"}
+	for _, table := range invalid {
+		if isValidTable(table) {
+			t.Errorf("expected %q to be invalid", table)
+		}
+	}
+}
+
+func TestResolveTableConfig(t *testing.T) {
+	// base usage_records: lifetime aggregate, replace, no date params
+	base, err := resolveTableConfig("usage_records")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if base.resource != "Usage/Records.json" || base.strategy != config.StrategyReplace || base.startParam != "" {
+		t.Errorf("base usage_records resolved wrong: %+v", base)
+	}
+
+	// granular usage_records: subresource path, merge, incremental
+	for mod, seg := range map[string]string{"daily": "Daily", "monthly": "Monthly", "yearly": "Yearly"} {
+		cfg, err := resolveTableConfig("usage_records:" + mod)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", mod, err)
+		}
+		if cfg.resource != "Usage/Records/"+seg+".json" {
+			t.Errorf("%s: resource=%q", mod, cfg.resource)
+		}
+		if cfg.strategy != config.StrategyMerge || cfg.incrementalKey != "start_date" || cfg.startParam != "StartDate" {
+			t.Errorf("%s: incremental config wrong: %+v", mod, cfg)
+		}
+	}
+
+	// case-insensitive modifier
+	if _, err := resolveTableConfig("usage_records:DAILY"); err != nil {
+		t.Errorf("expected DAILY to be valid: %v", err)
+	}
+
+	// invalid granularity
+	if _, err := resolveTableConfig("usage_records:hourly"); err == nil {
+		t.Errorf("expected error for invalid granularity")
+	}
+	// modifier on a table that doesn't support it
+	if _, err := resolveTableConfig("messages:daily"); err == nil {
+		t.Errorf("expected error for modifier on messages")
+	}
+	// unknown base
+	if _, err := resolveTableConfig("contacts"); err == nil {
+		t.Errorf("expected error for unknown table")
+	}
+}
+
+func TestDecodeListResponse(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"sid": "SM1", "body": "hi", "num_segments": 1, "subresource_uris": {"media": "/x"}},
+			{"sid": "SM2", "body": "yo"}
+		],
+		"next_page_uri": "/2010-04-01/Accounts/AC1/Messages.json?Page=1&PageToken=abc",
+		"page": 0
+	}`)
+
+	items, next, err := decodeListResponse(body, "messages")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0]["sid"] != "SM1" {
+		t.Errorf("expected first sid SM1, got %v", items[0]["sid"])
+	}
+	if next != "/2010-04-01/Accounts/AC1/Messages.json?Page=1&PageToken=abc" {
+		t.Errorf("unexpected next_page_uri: %q", next)
+	}
+}
+
+func TestDecodeListResponseLastPage(t *testing.T) {
+	// Twilio sends next_page_uri: null on the final page.
+	body := []byte(`{"calls": [{"sid": "CA1"}], "next_page_uri": null}`)
+
+	items, next, err := decodeListResponse(body, "calls")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if next != "" {
+		t.Errorf("expected empty next_page_uri on last page, got %q", next)
+	}
+}
+
+func TestDecodeListResponseUseNumber(t *testing.T) {
+	// Large IDs/counts must survive without float64 rounding.
+	body := []byte(`{"usage_records": [{"category": "sms", "count": 9007199254740993}]}`)
+
+	items, _, err := decodeListResponse(body, "usage_records")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := items[0]["count"].(interface{ String() string }).String(); got != "9007199254740993" {
+		t.Errorf("expected count preserved as 9007199254740993, got %v", got)
+	}
+}
+
+func TestFilterItemsByInterval(t *testing.T) {
+	mk := func(ts string) map[string]interface{} {
+		return map[string]interface{}{"date_sent": ts}
+	}
+	items := []map[string]interface{}{
+		mk("Mon, 01 Jan 2024 10:00:00 +0000"),
+		mk("Wed, 15 May 2024 12:00:00 +0000"),
+		mk("Sat, 22 Jun 2024 08:00:00 +0000"),
+		{"date_sent": ""}, // unparseable -> kept
+	}
+
+	start := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	got := filterItemsByInterval(items, "date_sent", &start, &end)
+	// May 15 is in range; the empty/unparseable row is kept; Jan 1 and Jun 22 excluded.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items in range, got %d", len(got))
+	}
+
+	// No interval -> all items returned untouched.
+	if all := filterItemsByInterval(items, "date_sent", nil, nil); len(all) != len(items) {
+		t.Fatalf("expected all %d items with nil interval, got %d", len(items), len(all))
+	}
+}
+
+func TestSupportedTableNames(t *testing.T) {
+	got := supportedTableNames()
+	want := "calls, incoming_phone_numbers, messages, recordings, usage_records"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Adds a **Twilio** source for the `2010-04-01` REST API.

### Tables & strategies

| Table | Strategy | Incremental key | Notes |
|---|---|---|---|
| `messages` | `replace` | — | Full mirror. Redactions (which don't bump `date_updated`) and hard-deletes can't be detected incrementally via the API. |
| `calls` | `merge` | `date_updated` | Lifecycle changes (status/duration/end_time) bump `date_updated`. |
| `recordings` | `merge` | `date_updated` | Sends `IncludeSoftDeleted=true` so deletions resurface as `status=deleted` and are merged in. |
| `incoming_phone_numbers` | `replace` | — | Small table, full mirror. |
| `usage_records` | `replace` | — | Moving lifetime aggregate per category. |
| `usage_records:daily` / `:monthly` / `:yearly` | `merge` | `start_date` | Granularity suffix → `Usage/Records/{Daily,Monthly,Yearly}`; immutable closed periods load incrementally, keyed on `(account_sid, category, start_date)`. |

### Auth
`twilio://?account_sid=AC...&auth_token=...` or `...&api_key=SK...&api_secret=...` (HTTP Basic; API Key takes precedence). Schema is inferred — nested objects land as JSON columns.