### PR TITLE
Fix Postgres UUID copy encoding

### DIFF
--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -211,7 +212,7 @@ func (d *PostgresDestination) Write(ctx context.Context, records <-chan source.R
 		// Use CopyFromSlice for streaming conversion without materializing all rows
 		// Pre-allocate row buffer and reuse it for each row to reduce allocations
 		tableIdent := parseTableIdentifier(opts.Table)
-		getters := postgresValueGetters(record)
+		getters := postgresValueGetters(record, opts.Schema)
 		rowBuf := make([]any, numCols)
 		copyCount, err := d.pool.CopyFrom(
 			ctx,
@@ -297,7 +298,7 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 				// Use CopyFromSlice for streaming conversion
 				// Pre-allocate row buffer and reuse it for each row
 				tableIdent := parseTableIdentifier(opts.Table)
-				getters := postgresValueGetters(record)
+				getters := postgresValueGetters(record, opts.Schema)
 				rowBuf := make([]any, numCols)
 				copyCount, err := d.pool.CopyFrom(
 					ctx,
@@ -347,15 +348,20 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 	return nil
 }
 
-func postgresValueGetters(record arrow.RecordBatch) []func(int) any {
+func postgresValueGetters(record arrow.RecordBatch, tableSchema *schema.TableSchema) []func(int) any {
+	columnTypes := postgresColumnTypesByName(tableSchema)
 	getters := make([]func(int) any, int(record.NumCols()))
 	for i := range getters {
-		getters[i] = postgresValueGetter(record.Column(i))
+		getters[i] = postgresValueGetterForType(record.Column(i), columnTypes[record.ColumnName(i)])
 	}
 	return getters
 }
 
 func postgresValueGetter(col arrow.Array) func(int) any {
+	return postgresValueGetterForType(col, schema.TypeUnknown)
+}
+
+func postgresValueGetterForType(col arrow.Array, dataType schema.DataType) func(int) any {
 	switch a := col.(type) {
 	case *array.Boolean:
 		return func(i int) any {
@@ -407,6 +413,14 @@ func postgresValueGetter(col arrow.Array) func(int) any {
 			return a.Value(i)
 		}
 	case *array.String:
+		if dataType == schema.TypeUUID {
+			return func(i int) any {
+				if a.IsNull(i) {
+					return nil
+				}
+				return postgresUUIDValue(a.Value(i))
+			}
+		}
 		return func(i int) any {
 			if a.IsNull(i) {
 				return nil
@@ -414,6 +428,14 @@ func postgresValueGetter(col arrow.Array) func(int) any {
 			return a.Value(i)
 		}
 	case *array.LargeString:
+		if dataType == schema.TypeUUID {
+			return func(i int) any {
+				if a.IsNull(i) {
+					return nil
+				}
+				return postgresUUIDValue(a.Value(i))
+			}
+		}
 		return func(i int) any {
 			if a.IsNull(i) {
 				return nil
@@ -488,11 +510,59 @@ func postgresValueGetter(col arrow.Array) func(int) any {
 			return a.Value(i).ToTime(arrow.Microsecond)
 		}
 	case array.ExtensionArray:
-		return postgresValueGetter(a.Storage())
+		return postgresValueGetterForType(a.Storage(), dataType)
 	default:
 		return func(i int) any {
 			return arrowutil.Value(col, i)
 		}
+	}
+}
+
+func postgresColumnTypesByName(tableSchema *schema.TableSchema) map[string]schema.DataType {
+	if tableSchema == nil {
+		return nil
+	}
+	types := make(map[string]schema.DataType, len(tableSchema.Columns))
+	for _, col := range tableSchema.Columns {
+		types[col.Name] = col.DataType
+	}
+	return types
+}
+
+func postgresUUIDValue(value any) any {
+	switch v := value.(type) {
+	case pgtype.UUID:
+		if !v.Valid {
+			return nil
+		}
+		return v
+	case string:
+		var uuid pgtype.UUID
+		if err := uuid.Scan(v); err != nil {
+			return v
+		}
+		return uuid
+	case []byte:
+		if len(v) == 16 {
+			var bytes [16]byte
+			copy(bytes[:], v)
+			return pgtype.UUID{Bytes: bytes, Valid: true}
+		}
+		var uuid pgtype.UUID
+		if err := uuid.Scan(string(v)); err != nil {
+			return v
+		}
+		return uuid
+	case [16]byte:
+		return pgtype.UUID{Bytes: v, Valid: true}
+	case fmt.Stringer:
+		var uuid pgtype.UUID
+		if err := uuid.Scan(v.String()); err != nil {
+			return value
+		}
+		return uuid
+	default:
+		return value
 	}
 }
 

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -529,41 +529,12 @@ func postgresColumnTypesByName(tableSchema *schema.TableSchema) map[string]schem
 	return types
 }
 
-func postgresUUIDValue(value any) any {
-	switch v := value.(type) {
-	case pgtype.UUID:
-		if !v.Valid {
-			return nil
-		}
-		return v
-	case string:
-		var uuid pgtype.UUID
-		if err := uuid.Scan(v); err != nil {
-			return v
-		}
-		return uuid
-	case []byte:
-		if len(v) == 16 {
-			var bytes [16]byte
-			copy(bytes[:], v)
-			return pgtype.UUID{Bytes: bytes, Valid: true}
-		}
-		var uuid pgtype.UUID
-		if err := uuid.Scan(string(v)); err != nil {
-			return v
-		}
-		return uuid
-	case [16]byte:
-		return pgtype.UUID{Bytes: v, Valid: true}
-	case fmt.Stringer:
-		var uuid pgtype.UUID
-		if err := uuid.Scan(v.String()); err != nil {
-			return value
-		}
-		return uuid
-	default:
+func postgresUUIDValue(value string) any {
+	var uuid pgtype.UUID
+	if err := uuid.Scan(value); err != nil {
 		return value
 	}
+	return uuid
 }
 
 func (d *PostgresDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func TestBuildDeleteInsertLockSQL(t *testing.T) {
@@ -57,6 +58,42 @@ func TestPostgresValueGetterMatchesArrowutilValue(t *testing.T) {
 				t.Fatalf("%s[%d]: postgresValueGetter = %#v (%T), arrowutil.Value = %#v (%T)", arr.DataType(), i, got, got, want, want)
 			}
 		}
+	}
+}
+
+func TestPostgresValueGettersConvertsUUIDColumns(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	b := array.NewStringBuilder(mem)
+	defer b.Release()
+	b.Append("0f364130-da0b-4909-b824-5413d795aa93")
+	b.AppendNull()
+	uuidArray := b.NewArray()
+	defer uuidArray.Release()
+
+	recordSchema := arrow.NewSchema([]arrow.Field{{
+		Name:     "uuid_col",
+		Type:     arrow.BinaryTypes.String,
+		Nullable: true,
+	}}, nil)
+	record := array.NewRecordBatch(recordSchema, []arrow.Array{uuidArray}, 2)
+	defer record.Release()
+
+	getters := postgresValueGetters(record, &schema.TableSchema{
+		Columns: []schema.Column{{Name: "uuid_col", DataType: schema.TypeUUID, Nullable: true}},
+	})
+
+	got := getters[0](0)
+	uuid, ok := got.(pgtype.UUID)
+	if !ok {
+		t.Fatalf("UUID getter returned %T, want pgtype.UUID", got)
+	}
+	if uuid.String() != "0f364130-da0b-4909-b824-5413d795aa93" {
+		t.Fatalf("UUID getter returned %q", uuid.String())
+	}
+	if got := getters[0](1); got != nil {
+		t.Fatalf("UUID getter null = %#v, want nil", got)
 	}
 }
 

--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -514,6 +514,9 @@ func convertValue(val interface{}, col schema.Column) interface{} {
 	if val == nil {
 		return nil
 	}
+	if col.DataType == schema.TypeUUID {
+		return convertUUIDValue(val)
+	}
 	switch v := val.(type) {
 	case pgtype.Numeric:
 		if !v.Valid || v.NaN {
@@ -541,6 +544,31 @@ func numericToBigInt(num pgtype.Numeric, targetScale int) *big.Int {
 	}
 
 	return result
+}
+
+func convertUUIDValue(val interface{}) interface{} {
+	switch v := val.(type) {
+	case pgtype.UUID:
+		if !v.Valid {
+			return nil
+		}
+		return v.String()
+	case [16]byte:
+		return pgtype.UUID{Bytes: v, Valid: true}.String()
+	case []byte:
+		if len(v) == 16 {
+			var bytes [16]byte
+			copy(bytes[:], v)
+			return pgtype.UUID{Bytes: bytes, Valid: true}.String()
+		}
+		return string(v)
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return val
+	}
 }
 
 var _ source.Source = (*PostgresSource)(nil)

--- a/pkg/source/postgres/postgres_test.go
+++ b/pkg/source/postgres/postgres_test.go
@@ -1,0 +1,33 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestConvertValueNormalizesUUID(t *testing.T) {
+	bytes := [16]byte{0x0f, 0x36, 0x41, 0x30, 0xda, 0x0b, 0x49, 0x09, 0xb8, 0x24, 0x54, 0x13, 0xd7, 0x95, 0xaa, 0x93}
+	col := schema.Column{DataType: schema.TypeUUID}
+
+	tests := []struct {
+		name string
+		val  any
+		want any
+	}{
+		{name: "pgtype uuid", val: pgtype.UUID{Bytes: bytes, Valid: true}, want: "0f364130-da0b-4909-b824-5413d795aa93"},
+		{name: "raw uuid bytes", val: bytes, want: "0f364130-da0b-4909-b824-5413d795aa93"},
+		{name: "raw uuid byte slice", val: bytes[:], want: "0f364130-da0b-4909-b824-5413d795aa93"},
+		{name: "text uuid", val: "0f364130-da0b-4909-b824-5413d795aa93", want: "0f364130-da0b-4909-b824-5413d795aa93"},
+		{name: "invalid pgtype uuid", val: pgtype.UUID{}, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := convertValue(tt.val, col); got != tt.want {
+				t.Fatalf("convertValue() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Normalizes Postgres UUID values when reading into Arrow and converts UUID string columns back to pgtype.UUID before CopyFrom.

Adds source and destination unit coverage for UUID conversion.

Validated with make format, make lint, and make test.