### PR TITLE
Add Braze source

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Braze</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Bruin</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -164,6 +164,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Attio", link: "/supported-sources/attio.md" },
               { text: "Azure Data Lake Storage Gen2", link: "/supported-sources/adls.md" },
               { text: "BallDontLie FIFA", link: "/supported-sources/balldontlie.md" },
+              { text: "Braze", link: "/supported-sources/braze.md" },
               { text: "Bruin", link: "/supported-sources/bruin.md" },
               { text: "Chess.com", link: "/supported-sources/chess.md" },
               { text: "ClickUp", link: "/supported-sources/clickup.md" },

--- a/docs/supported-sources/braze.md
+++ b/docs/supported-sources/braze.md
@@ -1,0 +1,56 @@
+# Braze
+[Braze](https://www.braze.com/) is a customer engagement platform used to orchestrate cross-channel messaging campaigns and analyze customer behavior.
+
+ingestr supports Braze as a source.
+
+## URI format
+
+```
+braze://?api_key=<rest-api-key>&endpoint=<rest-endpoint>
+```
+
+URI parameters:
+- `api_key` is a Braze REST API key with access to the relevant export endpoints. You can create one in the Braze dashboard under **Settings → APIs and Identifiers**.
+- `endpoint` is your instance's REST endpoint host, e.g. `rest.iad-01.braze.com`. Braze is multi-instance, so the host depends on which cluster your account is on — find it in the dashboard or in the [API overview](https://www.braze.com/docs/api/basics). The `https://` scheme is optional.
+
+Here's a sample command that copies campaigns from Braze into a DuckDB database:
+
+```sh
+ingestr ingest \
+  --source-uri "braze://?api_key=YOUR_REST_API_KEY&endpoint=rest.iad-01.braze.com" \
+  --source-table "campaigns" \
+  --dest-uri duckdb:///braze.duckdb \
+  --dest-table "public.campaigns"
+```
+
+## Tables
+
+Braze source allows ingesting the following resources into separate tables:
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| --- | --- | --- | --- | --- |
+| [campaigns](https://www.braze.com/docs/api/endpoints/export/campaigns/get_campaigns) | id | last_edited | merge | Marketing campaigns (including archived) with their name, tags, and API flags. |
+| [canvases](https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases) | id | last_edited | merge | Canvas (journey) definitions (including archived) with their name and tags. |
+| [segments](https://www.braze.com/docs/api/endpoints/export/segments/get_segment) | id | – | replace | Audience segments with their name and analytics-tracking flag. |
+| [events](https://www.braze.com/docs/api/endpoints/export/custom_events/get_custom_events) | event_name | – | replace | Names of the custom events tracked in the workspace. |
+| [products](https://www.braze.com/docs/api/endpoints/export/purchases/get_list_product_id) | product_id | – | replace | Product IDs seen in purchase events. |
+| [kpi_dau](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_dau_date) | time | time | merge | Daily active users by date. |
+| [kpi_mau](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_mau_30_days) | time | time | merge | Monthly active users (rolling 30-day) by date. |
+| [kpi_new_users](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_daily_new_users_date) | time | time | merge | New users by date. |
+| [kpi_uninstalls](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_uninstalls_date) | time | time | merge | App uninstalls by date. |
+
+Use these as the `--source-table` parameter in the `ingestr ingest` command.
+
+### Per-app KPIs
+
+By default the `kpi_*` tables aggregate across all apps in the workspace. To break a KPI down by app, append a comma-separated list of app identifiers (found in the Braze dashboard under **Settings → APIs and Identifiers**) to the table name:
+
+```
+--source-table "kpi_dau:app-one-id,app-two-id"
+```
+
+Each row is then tagged with an `app_id` column. This is only supported on `kpi_*` tables.
+
+## Incremental loading
+
+`campaigns`, `canvases`, and the `kpi_*` tables load incrementally — use `--interval-start` and `--interval-end` to limit the data to a time range. When no interval is provided, the list tables fetch all records and the KPI tables fetch the most recent 100 days. The `segments`, `events`, and `products` tables are always fully refreshed.

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -11,6 +11,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Apple Ads](/supported-sources/appleads.md)
 - [Applovin](/supported-sources/applovin.md)
 - [Applovin Max](/supported-sources/applovin_max.md)
+- [Braze](/supported-sources/braze.md)
 - [Facebook Ads](/supported-sources/facebook-ads.md)
 - [Google Ads](/supported-sources/google-ads.md)
 - [Klaviyo](/supported-sources/klaviyo.md)

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -264,6 +264,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("avro", "Avro File", []string{"avro"}, true, false),
 		genericURIConnector("balldontlie", "balldontlie", []string{"balldontlie"}, true, false),
 		genericURIConnector("blobstore", "Object Storage", []string{"s3", "gs", "gcs", "az", "azure", "adls", "adlsgen2", "azdatalake", "abfs", "abfss"}, true, true),
+		genericURIConnector("braze", "Braze", []string{"braze"}, true, false),
 		genericURIConnector("bruin", "Bruin", []string{"bruin"}, true, false),
 		genericURIConnector("chess", "Chess.com", []string{"chess"}, true, false),
 		genericURIConnector("clickhouse", "ClickHouse", []string{"clickhouse"}, true, true),

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -1,0 +1,562 @@
+package braze
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/araddon/dateparse"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	maxListPageSize  = 100 // campaigns, canvases, segments, products: groups of 100
+	maxEventPageSize = 250 // events/list: returns 250 event names per page
+	maxKPILength     = 100 // kpi data_series: length must be between 1 and 100 days
+	maxListPages     = 10000
+
+	// Braze's default pool (list + data_series endpoints) is 250,000 requests/hour.
+	rateLimit      = 250000 * 0.8 / 3600.0 // ~55.5 req/s
+	rateLimitBurst = 5
+
+	// /events/list and /purchases/product_list share a 1,000 requests/hour pool.
+	lowRateLimit      = 1000 * 0.8 / 3600.0 // ~0.22 req/s
+	lowRateLimitBurst = 5
+
+	// Braze expects ISO-8601 datetimes for its time filters.
+	brazeTimeLayout = "2006-01-02T15:04:05"
+)
+
+var supportedTables = []string{
+	"campaigns",
+	"canvases",
+	"segments",
+	"events",
+	"products",
+	"kpi_dau",
+	"kpi_mau",
+	"kpi_new_users",
+	"kpi_uninstalls",
+}
+
+type BrazeSource struct {
+	apiKey    string
+	endpoint  string
+	client    *httpclient.Client // default pool (list + data_series)
+	lowClient *httpclient.Client // low-limit pool (events/list, purchases/product_list)
+}
+
+func NewBrazeSource() *BrazeSource {
+	return &BrazeSource{}
+}
+
+func (s *BrazeSource) Schemes() []string {
+	return []string{"braze"}
+}
+
+func (s *BrazeSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *BrazeSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseBrazeURI(uri)
+	if err != nil {
+		return err
+	}
+	s.apiKey = creds.apiKey
+	s.endpoint = creds.endpoint
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(s.endpoint),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithAuth(httpclient.NewBearerAuth(s.apiKey)),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithHeader("Accept", "application/json"),
+	)
+	s.lowClient = httpclient.New(
+		httpclient.WithBaseURL(s.endpoint),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(lowRateLimit, lowRateLimitBurst),
+		httpclient.WithAuth(httpclient.NewBearerAuth(s.apiKey)),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithHeader("Accept", "application/json"),
+	)
+
+	config.Debug("[BRAZE] Connected to %s", s.endpoint)
+	return nil
+}
+
+func (s *BrazeSource) Close(ctx context.Context) error {
+	var err error
+	if s.client != nil {
+		err = s.client.Close()
+	}
+	if s.lowClient != nil {
+		if cerr := s.lowClient.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}
+	return err
+}
+
+type brazeCredentials struct {
+	apiKey   string
+	endpoint string
+}
+
+func parseBrazeURI(uri string) (*brazeCredentials, error) {
+	if !strings.HasPrefix(uri, "braze://") {
+		return nil, fmt.Errorf("invalid braze URI: must start with braze://")
+	}
+
+	rest := strings.TrimPrefix(uri, "braze://")
+	rest = strings.TrimPrefix(rest, "?")
+
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse braze URI query: %w", err)
+	}
+
+	apiKey := values.Get("api_key")
+	if apiKey == "" {
+		return nil, fmt.Errorf("api_key is required in braze URI")
+	}
+
+	endpoint := values.Get("endpoint")
+	if endpoint == "" {
+		return nil, fmt.Errorf("endpoint is required in braze URI (e.g. endpoint=rest.iad-01.braze.com)")
+	}
+
+	return &brazeCredentials{apiKey: apiKey, endpoint: normalizeEndpoint(endpoint)}, nil
+}
+
+// normalizeEndpoint ensures the REST endpoint has an https scheme and no trailing slash.
+func normalizeEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		endpoint = "https://" + endpoint
+	}
+	return strings.TrimRight(endpoint, "/")
+}
+
+func isValidTable(table string) bool {
+	for _, t := range supportedTables {
+		if t == table {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *BrazeSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	base, appIDs := parseTableParam(req.Name)
+
+	if !isValidTable(base) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", req.Name, strings.Join(supportedTables, ", "))
+	}
+	if len(appIDs) > 0 && !isKPITable(base) {
+		return nil, fmt.Errorf("the :app_id parameter is only supported for kpi_* tables, not %q", base)
+	}
+
+	primaryKeys, incrementalKey, strategy := tableMetadata(base)
+	// Per-app KPI rows share a date, so app_id must be part of the merge key.
+	if isKPITable(base) && len(appIDs) > 0 {
+		primaryKeys = []string{"time", "app_id"}
+	}
+	if len(req.PrimaryKeys) > 0 {
+		primaryKeys = req.PrimaryKeys
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           base,
+		TablePrimaryKeys:    primaryKeys,
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("braze source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, base, appIDs, opts)
+		},
+	}, nil
+}
+
+// tableMetadata returns the primary key(s), incremental key, and write strategy for a table.
+func tableMetadata(table string) ([]string, string, config.IncrementalStrategy) {
+	switch table {
+	case "campaigns", "canvases":
+		// list endpoints accept last_edit.time[gt]; rows carry last_edited
+		return []string{"id"}, "last_edited", config.StrategyMerge
+	case "segments":
+		return []string{"id"}, "", config.StrategyReplace
+	case "events":
+		return []string{"event_name"}, "", config.StrategyReplace
+	case "products":
+		return []string{"product_id"}, "", config.StrategyReplace
+	case "kpi_dau", "kpi_mau", "kpi_new_users", "kpi_uninstalls":
+		// daily series keyed on date; merge updates the still-changing latest day
+		return []string{"time"}, "time", config.StrategyMerge
+	default:
+		return nil, "", config.StrategyReplace
+	}
+}
+
+func (s *BrazeSource) read(ctx context.Context, table string, appIDs []string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "campaigns":
+			err = s.readCampaigns(ctx, opts, results)
+		case "canvases":
+			err = s.readCanvases(ctx, opts, results)
+		case "segments":
+			err = s.readSegments(ctx, opts, results)
+		case "events":
+			err = s.readEvents(ctx, opts, results)
+		case "products":
+			err = s.readProducts(ctx, opts, results)
+		case "kpi_dau":
+			err = s.readKPISeries(ctx, "/kpi/dau/data_series", appIDs, opts, results)
+		case "kpi_mau":
+			err = s.readKPISeries(ctx, "/kpi/mau/data_series", appIDs, opts, results)
+		case "kpi_new_users":
+			err = s.readKPISeries(ctx, "/kpi/new_users/data_series", appIDs, opts, results)
+		case "kpi_uninstalls":
+			err = s.readKPISeries(ctx, "/kpi/uninstalls/data_series", appIDs, opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", table)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+// parseTableParam splits "kpi_dau:id1,id2" into the base table and its app_id list.
+func parseTableParam(name string) (string, []string) {
+	base, param, found := strings.Cut(name, ":")
+	if !found {
+		return base, nil
+	}
+	var ids []string
+	for _, p := range strings.Split(param, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			ids = append(ids, p)
+		}
+	}
+	return base, ids
+}
+
+func isKPITable(t string) bool {
+	switch t {
+	case "kpi_dau", "kpi_mau", "kpi_new_users", "kpi_uninstalls":
+		return true
+	default:
+		return false
+	}
+}
+
+func decodeBody(b []byte, v interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+// asMap is the item converter for list endpoints that return objects.
+func asMap(v interface{}) map[string]interface{} {
+	if m, ok := v.(map[string]interface{}); ok {
+		return m
+	}
+	return nil
+}
+
+// filterItemsByInterval keeps items whose timestamp falls within [start, end).
+// Rows with no parseable timestamp are kept; empty fields or an open interval is a no-op.
+func filterItemsByInterval(items []map[string]interface{}, fields []string, start, end *time.Time) []map[string]interface{} {
+	if len(fields) == 0 || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		ts, ok := firstTimestamp(item, fields)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && ts.Before(start.UTC()) {
+			continue
+		}
+		if end != nil && !ts.Before(end.UTC()) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	return filtered
+}
+
+func firstTimestamp(item map[string]interface{}, fields []string) (time.Time, bool) {
+	for _, field := range fields {
+		raw := item[field]
+		if raw == nil {
+			continue
+		}
+		switch v := raw.(type) {
+		case string:
+			if v == "" {
+				continue
+			}
+			if ts, err := dateparse.ParseAny(v); err == nil {
+				return ts.UTC(), true
+			}
+		case time.Time:
+			return v.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// paginateList walks a page-numbered list endpoint, one Arrow batch per page.
+// pageSize 0 stops only on an empty page; filterFields applies a client-side interval filter.
+func (s *BrazeSource) paginateList(
+	ctx context.Context,
+	client *httpclient.Client,
+	endpoint, dataKey string,
+	pageSize int,
+	extraParams map[string]string,
+	itemFn func(interface{}) map[string]interface{},
+	filterFields []string,
+	opts source.ReadOptions,
+	results chan<- source.RecordBatchResult,
+) error {
+	totalSent := 0
+	for page := 0; ; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if page >= maxListPages {
+			config.Debug("[BRAZE] %s hit maxListPages guard (%d)", endpoint, maxListPages)
+			break
+		}
+
+		req := client.R(ctx).SetQueryParam("page", strconv.Itoa(page))
+		for k, v := range extraParams {
+			req.SetQueryParam(k, v)
+		}
+
+		resp, err := req.Get(endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", endpoint, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("%s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]interface{}
+		if err := decodeBody(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", endpoint, err)
+		}
+
+		raw, ok := body[dataKey].([]interface{})
+		if !ok || len(raw) == 0 {
+			break
+		}
+
+		items := make([]map[string]interface{}, 0, len(raw))
+		for _, r := range raw {
+			if item := itemFn(r); item != nil {
+				items = append(items, item)
+			}
+		}
+
+		items = filterItemsByInterval(items, filterFields, opts.IntervalStart, opts.IntervalEnd)
+
+		if len(items) > 0 {
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", endpoint, err)
+			}
+			results <- source.RecordBatchResult{Batch: record}
+			totalSent += len(items)
+			config.Debug("[BRAZE] %s page %d: sent %d (total: %d)", endpoint, page, len(items), totalSent)
+		}
+
+		if pageSize > 0 && len(raw) < pageSize {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *BrazeSource) readCampaigns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BRAZE] reading campaigns")
+	// include_archived defaults to false, so request archived campaigns too for a full export.
+	params := map[string]string{"include_archived": "true"}
+	// /campaigns/list supports only a greater-than filter on last edit time; the
+	// client-side filter on last_edited adds the interval-end bound the API lacks.
+	if opts.IntervalStart != nil {
+		params["last_edit.time[gt]"] = opts.IntervalStart.UTC().Format(brazeTimeLayout)
+	}
+	return s.paginateList(ctx, s.client, "/campaigns/list", "campaigns", maxListPageSize, params, asMap, []string{"last_edited"}, opts, results)
+}
+
+func (s *BrazeSource) readCanvases(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BRAZE] reading canvases")
+	// include_archived defaults to false, so request archived canvases too for a full export.
+	params := map[string]string{"include_archived": "true"}
+	if opts.IntervalStart != nil {
+		params["last_edit.time[gt]"] = opts.IntervalStart.UTC().Format(brazeTimeLayout)
+	}
+	return s.paginateList(ctx, s.client, "/canvas/list", "canvases", maxListPageSize, params, asMap, []string{"last_edited"}, opts, results)
+}
+
+func (s *BrazeSource) readSegments(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BRAZE] reading segments")
+	return s.paginateList(ctx, s.client, "/segments/list", "segments", maxListPageSize, nil, asMap, nil, opts, results)
+}
+
+func (s *BrazeSource) readEvents(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BRAZE] reading events")
+	// events/list returns an array of event-name strings; lift each to a record.
+	itemFn := func(v interface{}) map[string]interface{} {
+		name, ok := v.(string)
+		if !ok {
+			return nil
+		}
+		return map[string]interface{}{"event_name": name}
+	}
+	return s.paginateList(ctx, s.lowClient, "/events/list", "events", maxEventPageSize, nil, itemFn, nil, opts, results)
+}
+
+func (s *BrazeSource) readProducts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BRAZE] reading products")
+	itemFn := func(v interface{}) map[string]interface{} {
+		id, ok := v.(string)
+		if !ok {
+			return nil
+		}
+		return map[string]interface{}{"product_id": id}
+	}
+	// product_list page size is undocumented, so stop only on an empty page (pageSize 0).
+	return s.paginateList(ctx, s.lowClient, "/purchases/product_list", "products", 0, nil, itemFn, nil, opts, results)
+}
+
+// readKPISeries fetches a daily KPI series. With no app IDs it returns the
+// all-apps aggregate; with app IDs it fetches one per-app series each (tagged
+// with an app_id column).
+func (s *BrazeSource) readKPISeries(ctx context.Context, endpoint string, appIDs []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BRAZE] reading %s (apps: %d)", endpoint, len(appIDs))
+	if len(appIDs) == 0 {
+		return s.fetchKPIWindows(ctx, endpoint, "", opts, results)
+	}
+	for _, appID := range appIDs {
+		if err := s.fetchKPIWindows(ctx, endpoint, appID, opts, results); err != nil {
+			return fmt.Errorf("%s for app_id %s: %w", endpoint, appID, err)
+		}
+	}
+	return nil
+}
+
+// fetchKPIWindows walks the series in 100-day windows (length 1-100 + ending_at)
+// back to interval-start; with no interval it fetches the last 100 days. A
+// non-empty appID scopes the call and stamps each row with an app_id column.
+func (s *BrazeSource) fetchKPIWindows(ctx context.Context, endpoint, appID string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	end := time.Now().UTC()
+	if opts.IntervalEnd != nil {
+		end = opts.IntervalEnd.UTC()
+	}
+	var start *time.Time
+	if opts.IntervalStart != nil {
+		st := opts.IntervalStart.UTC()
+		start = &st
+	}
+
+	windowEnd := end
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		length := maxKPILength
+		if start != nil {
+			days := int(windowEnd.Sub(*start).Hours()/24) + 1
+			if days <= 0 {
+				break
+			}
+			if days < length {
+				length = days
+			}
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("length", strconv.Itoa(length)).
+			SetQueryParam("ending_at", windowEnd.Format(brazeTimeLayout))
+		if appID != "" {
+			req.SetQueryParam("app_id", appID)
+		}
+
+		resp, err := req.Get(endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", endpoint, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("%s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body struct {
+			Data []map[string]interface{} `json:"data"`
+		}
+		if err := decodeBody(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", endpoint, err)
+		}
+
+		if len(body.Data) > 0 {
+			if appID != "" {
+				for _, row := range body.Data {
+					row["app_id"] = appID
+				}
+			}
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(body.Data, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", endpoint, err)
+			}
+			results <- source.RecordBatchResult{Batch: record}
+			config.Debug("[BRAZE] %s window ending %s: sent %d", endpoint, windowEnd.Format(brazeTimeLayout), len(body.Data))
+		}
+
+		if start == nil {
+			break
+		}
+		windowEnd = windowEnd.AddDate(0, 0, -length)
+		if !windowEnd.After(*start) {
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -498,28 +498,16 @@ func (s *BrazeSource) fetchKPIWindows(ctx context.Context, endpoint, appID strin
 		start = &st
 	}
 
-	windowEnd := end
-	for {
+	for _, w := range planKPIWindows(start, end) {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		length := maxKPILength
-		if start != nil {
-			days := int(windowEnd.Sub(*start).Hours()/24) + 1
-			if days <= 0 {
-				break
-			}
-			if days < length {
-				length = days
-			}
-		}
-
 		req := s.client.R(ctx).
-			SetQueryParam("length", strconv.Itoa(length)).
-			SetQueryParam("ending_at", windowEnd.Format(brazeTimeLayout))
+			SetQueryParam("length", strconv.Itoa(w.length)).
+			SetQueryParam("ending_at", w.endingAt.Format(brazeTimeLayout))
 		if appID != "" {
 			req.SetQueryParam("app_id", appID)
 		}
@@ -550,17 +538,46 @@ func (s *BrazeSource) fetchKPIWindows(ctx context.Context, endpoint, appID strin
 				return fmt.Errorf("failed to convert %s to Arrow: %w", endpoint, err)
 			}
 			results <- source.RecordBatchResult{Batch: record}
-			config.Debug("[BRAZE] %s window ending %s: sent %d", endpoint, windowEnd.Format(brazeTimeLayout), len(body.Data))
+			config.Debug("[BRAZE] %s window ending %s: sent %d", endpoint, w.endingAt.Format(brazeTimeLayout), len(body.Data))
 		}
+	}
+
+	return nil
+}
+
+type kpiWindow struct {
+	length   int
+	endingAt time.Time
+}
+
+// planKPIWindows splits [start, end] into <=100-day windows ending at successively
+// earlier dates. With start nil it returns a single 100-day window ending at end.
+func planKPIWindows(start *time.Time, end time.Time) []kpiWindow {
+	var windows []kpiWindow
+	windowEnd := end
+	for {
+		length := maxKPILength
+		if start != nil {
+			days := int(windowEnd.Sub(*start).Hours()/24) + 1
+			if days <= 0 {
+				break
+			}
+			if days < length {
+				length = days
+			}
+		}
+
+		windows = append(windows, kpiWindow{length: length, endingAt: windowEnd})
 
 		if start == nil {
 			break
 		}
 		windowEnd = windowEnd.AddDate(0, 0, -length)
-		if !windowEnd.After(*start) {
+		// Stop only once we've stepped past start; landing exactly on start still
+		// needs one final 1-day window to cover the start day itself.
+		if windowEnd.Before(*start) {
 			break
 		}
 	}
-
-	return nil
+	return windows
 }

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -32,8 +33,8 @@ const (
 	lowRateLimit      = 1000 * 0.8 / 3600.0 // ~0.22 req/s
 	lowRateLimitBurst = 5
 
-	// Braze expects ISO-8601 datetimes for its time filters.
-	brazeTimeLayout = "2006-01-02T15:04:05"
+	// Braze expects ISO-8601 datetimes; the trailing Z marks the values (always UTC) as UTC.
+	brazeTimeLayout = "2006-01-02T15:04:05Z"
 )
 
 var supportedTables = []string{
@@ -97,16 +98,14 @@ func (s *BrazeSource) Connect(ctx context.Context, uri string) error {
 }
 
 func (s *BrazeSource) Close(ctx context.Context) error {
-	var err error
+	var errs []error
 	if s.client != nil {
-		err = s.client.Close()
+		errs = append(errs, s.client.Close())
 	}
 	if s.lowClient != nil {
-		if cerr := s.lowClient.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
+		errs = append(errs, s.lowClient.Close())
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 type brazeCredentials struct {
@@ -327,6 +326,11 @@ func firstTimestamp(item map[string]interface{}, fields []string) (time.Time, bo
 			}
 			if ts, err := dateparse.ParseAny(v); err == nil {
 				return ts.UTC(), true
+			}
+		case json.Number:
+			// decodeBody uses UseNumber(); treat a numeric timestamp as Unix epoch seconds.
+			if sec, err := v.Int64(); err == nil {
+				return time.Unix(sec, 0).UTC(), true
 			}
 		case time.Time:
 			return v.UTC(), true

--- a/pkg/source/braze/braze_test.go
+++ b/pkg/source/braze/braze_test.go
@@ -1,0 +1,309 @@
+package braze
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestParseURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		uri          string
+		wantErr      bool
+		wantKey      string
+		wantEndpoint string
+	}{
+		{
+			name:         "valid with bare host endpoint",
+			uri:          "braze://?api_key=abc123&endpoint=rest.iad-09.braze.com",
+			wantKey:      "abc123",
+			wantEndpoint: "https://rest.iad-09.braze.com",
+		},
+		{
+			name:         "valid with https endpoint and trailing slash",
+			uri:          "braze://?api_key=abc123&endpoint=https://rest.iad-01.braze.com/",
+			wantKey:      "abc123",
+			wantEndpoint: "https://rest.iad-01.braze.com",
+		},
+		{
+			name:    "missing api_key",
+			uri:     "braze://?endpoint=rest.iad-09.braze.com",
+			wantErr: true,
+		},
+		{
+			name:    "missing endpoint",
+			uri:     "braze://?api_key=abc123",
+			wantErr: true,
+		},
+		{
+			name:    "wrong scheme",
+			uri:     "https://?api_key=abc123&endpoint=rest.iad-09.braze.com",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			uri:     "braze://",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			creds, err := parseBrazeURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if creds.apiKey != tt.wantKey {
+				t.Errorf("apiKey = %q, want %q", creds.apiKey, tt.wantKey)
+			}
+			if creds.endpoint != tt.wantEndpoint {
+				t.Errorf("endpoint = %q, want %q", creds.endpoint, tt.wantEndpoint)
+			}
+		})
+	}
+}
+
+func TestNormalizeEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"rest.iad-09.braze.com", "https://rest.iad-09.braze.com"},
+		{"https://rest.iad-09.braze.com", "https://rest.iad-09.braze.com"},
+		{"https://rest.iad-09.braze.com/", "https://rest.iad-09.braze.com"},
+		{"  rest.iad-02.braze.com  ", "https://rest.iad-02.braze.com"},
+		{"http://localhost:8080", "http://localhost:8080"},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeEndpoint(tt.in); got != tt.want {
+			t.Errorf("normalizeEndpoint(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	t.Parallel()
+
+	for _, table := range supportedTables {
+		if !isValidTable(table) {
+			t.Errorf("isValidTable(%q) = false, want true", table)
+		}
+	}
+
+	for _, table := range []string{"", "Campaigns", "campaign", "kpi", "users", "unknown"} {
+		if isValidTable(table) {
+			t.Errorf("isValidTable(%q) = true, want false", table)
+		}
+	}
+}
+
+func TestParseTableParam(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in       string
+		wantBase string
+		wantIDs  []string
+	}{
+		{"kpi_dau", "kpi_dau", nil},
+		{"campaigns", "campaigns", nil},
+		{"kpi_dau:abc", "kpi_dau", []string{"abc"}},
+		{"kpi_dau:abc,def", "kpi_dau", []string{"abc", "def"}},
+		{"kpi_dau: abc , def ,", "kpi_dau", []string{"abc", "def"}}, // trims and drops empties
+		{"kpi_dau:", "kpi_dau", nil},                                // colon but no ids
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			base, ids := parseTableParam(tt.in)
+			if base != tt.wantBase {
+				t.Errorf("base = %q, want %q", base, tt.wantBase)
+			}
+			if len(ids) != len(tt.wantIDs) {
+				t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
+			}
+			for i := range ids {
+				if ids[i] != tt.wantIDs[i] {
+					t.Errorf("ids[%d] = %q, want %q", i, ids[i], tt.wantIDs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetTableAppIDValidation(t *testing.T) {
+	t.Parallel()
+	s := NewBrazeSource()
+	ctx := context.Background()
+
+	t.Run("app_id rejected on non-kpi table", func(t *testing.T) {
+		if _, err := s.GetTable(ctx, source.TableRequest{Name: "campaigns:abc"}); err == nil {
+			t.Error("expected error for campaigns:abc, got nil")
+		}
+	})
+
+	t.Run("kpi without app_id keeps single PK", func(t *testing.T) {
+		tbl, err := s.GetTable(ctx, source.TableRequest{Name: "kpi_dau"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pk := tbl.PrimaryKeys(); len(pk) != 1 || pk[0] != "time" {
+			t.Errorf("PrimaryKeys = %v, want [time]", pk)
+		}
+	})
+
+	t.Run("kpi with app_id uses composite PK", func(t *testing.T) {
+		tbl, err := s.GetTable(ctx, source.TableRequest{Name: "kpi_dau:a,b"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		pk := tbl.PrimaryKeys()
+		if len(pk) != 2 || pk[0] != "time" || pk[1] != "app_id" {
+			t.Errorf("PrimaryKeys = %v, want [time app_id]", pk)
+		}
+	})
+}
+
+func TestTableMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		table     string
+		wantPK    []string
+		wantIncr  string
+		wantStrat config.IncrementalStrategy
+	}{
+		{"campaigns", []string{"id"}, "last_edited", config.StrategyMerge},
+		{"canvases", []string{"id"}, "last_edited", config.StrategyMerge},
+		{"segments", []string{"id"}, "", config.StrategyReplace},
+		{"events", []string{"event_name"}, "", config.StrategyReplace},
+		{"products", []string{"product_id"}, "", config.StrategyReplace},
+		{"kpi_dau", []string{"time"}, "time", config.StrategyMerge},
+		{"kpi_mau", []string{"time"}, "time", config.StrategyMerge},
+		{"kpi_new_users", []string{"time"}, "time", config.StrategyMerge},
+		{"kpi_uninstalls", []string{"time"}, "time", config.StrategyMerge},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.table, func(t *testing.T) {
+			pk, incr, strat := tableMetadata(tt.table)
+			if len(pk) != len(tt.wantPK) || (len(pk) > 0 && pk[0] != tt.wantPK[0]) {
+				t.Errorf("primaryKeys = %v, want %v", pk, tt.wantPK)
+			}
+			if incr != tt.wantIncr {
+				t.Errorf("incrementalKey = %q, want %q", incr, tt.wantIncr)
+			}
+			if strat != tt.wantStrat {
+				t.Errorf("strategy = %q, want %q", strat, tt.wantStrat)
+			}
+		})
+	}
+}
+
+func TestFilterItemsByInterval(t *testing.T) {
+	t.Parallel()
+
+	mk := func(ts string) map[string]interface{} { return map[string]interface{}{"last_edited": ts} }
+	items := []map[string]interface{}{
+		mk("2026-01-10T00:00:00Z"),
+		mk("2026-02-10T00:00:00Z"),
+		mk("2026-03-10T00:00:00Z"),
+		{"last_edited": nil}, // unparseable → always kept
+	}
+	tm := func(s string) *time.Time {
+		v, _ := time.Parse(time.RFC3339, s)
+		return &v
+	}
+
+	t.Run("no fields is a no-op", func(t *testing.T) {
+		got := filterItemsByInterval(items, nil, tm("2026-02-01T00:00:00Z"), nil)
+		if len(got) != len(items) {
+			t.Errorf("got %d items, want %d", len(got), len(items))
+		}
+	})
+
+	t.Run("open interval is a no-op", func(t *testing.T) {
+		got := filterItemsByInterval(items, []string{"last_edited"}, nil, nil)
+		if len(got) != len(items) {
+			t.Errorf("got %d items, want %d", len(got), len(items))
+		}
+	})
+
+	t.Run("start bound drops earlier rows, keeps unparseable", func(t *testing.T) {
+		got := filterItemsByInterval(items, []string{"last_edited"}, tm("2026-02-01T00:00:00Z"), nil)
+		// Feb, Mar, and the unparseable row.
+		if len(got) != 3 {
+			t.Errorf("got %d items, want 3", len(got))
+		}
+	})
+
+	t.Run("end bound is exclusive", func(t *testing.T) {
+		got := filterItemsByInterval(items, []string{"last_edited"}, nil, tm("2026-03-10T00:00:00Z"))
+		// Jan, Feb, and the unparseable row (Mar 10 is excluded by the exclusive end).
+		if len(got) != 3 {
+			t.Errorf("got %d items, want 3", len(got))
+		}
+	})
+
+	t.Run("closed interval", func(t *testing.T) {
+		got := filterItemsByInterval(items, []string{"last_edited"}, tm("2026-02-01T00:00:00Z"), tm("2026-03-01T00:00:00Z"))
+		// Only Feb, plus the unparseable row.
+		if len(got) != 2 {
+			t.Errorf("got %d items, want 2", len(got))
+		}
+	})
+}
+
+// TestDecodeBodyUseNumber verifies large integers survive JSON decoding without
+// float64 precision loss, and that floats and invalid JSON behave as expected.
+func TestDecodeBodyUseNumber(t *testing.T) {
+	t.Parallel()
+
+	t.Run("large integer preserved", func(t *testing.T) {
+		var m map[string]interface{}
+		if err := decodeBody([]byte(`{"id": 9223372036854775807}`), &m); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		num, ok := m["id"].(json.Number)
+		if !ok {
+			t.Fatalf("id is %T, want json.Number", m["id"])
+		}
+		if num.String() != "9223372036854775807" {
+			t.Errorf("id = %s, want 9223372036854775807", num.String())
+		}
+	})
+
+	t.Run("float preserved", func(t *testing.T) {
+		var m map[string]interface{}
+		if err := decodeBody([]byte(`{"rate": 1.5}`), &m); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := m["rate"].(json.Number); !ok {
+			t.Fatalf("rate is %T, want json.Number", m["rate"])
+		}
+	})
+
+	t.Run("invalid json errors", func(t *testing.T) {
+		var m map[string]interface{}
+		if err := decodeBody([]byte(`{not json`), &m); err == nil {
+			t.Error("expected error for invalid JSON, got nil")
+		}
+	})
+}

--- a/pkg/source/braze/braze_test.go
+++ b/pkg/source/braze/braze_test.go
@@ -283,6 +283,58 @@ func TestFilterItemsByInterval(t *testing.T) {
 	})
 }
 
+func TestPlanKPIWindows(t *testing.T) {
+	t.Parallel()
+
+	end := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+
+	t.Run("no interval is a single 100-day window", func(t *testing.T) {
+		w := planKPIWindows(nil, end)
+		if len(w) != 1 || w[0].length != maxKPILength || !w[0].endingAt.Equal(end) {
+			t.Fatalf("got %+v, want one length-100 window ending at end", w)
+		}
+	})
+
+	// For each span, the union of covered days must equal [start, end] exactly —
+	// no gaps, no duplicates. Spans include exact 100-day multiples (the off-by-one).
+	for _, spanDays := range []int{0, 1, 7, 99, 100, 101, 150, 200, 250} {
+		t.Run(strconv.Itoa(spanDays)+"-day span", func(t *testing.T) {
+			start := end.AddDate(0, 0, -spanDays)
+			windows := planKPIWindows(&start, end)
+
+			covered := map[string]int{}
+			for _, w := range windows {
+				for i := 0; i < w.length; i++ {
+					day := w.endingAt.AddDate(0, 0, -i).Format("2006-01-02")
+					covered[day]++
+				}
+			}
+
+			want := map[string]bool{}
+			for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+				want[d.Format("2006-01-02")] = true
+			}
+
+			if len(covered) != len(want) {
+				t.Errorf("covered %d distinct days, want %d", len(covered), len(want))
+			}
+			for day, n := range covered {
+				if n != 1 {
+					t.Errorf("day %s covered %d times (want exactly 1)", day, n)
+				}
+				if !want[day] {
+					t.Errorf("day %s covered but outside [start,end]", day)
+				}
+			}
+			for day := range want {
+				if covered[day] == 0 {
+					t.Errorf("day %s in [start,end] but never covered", day)
+				}
+			}
+		})
+	}
+}
+
 // TestDecodeBodyUseNumber verifies large integers survive JSON decoding without
 // float64 precision loss, and that floats and invalid JSON behave as expected.
 func TestDecodeBodyUseNumber(t *testing.T) {

--- a/pkg/source/braze/braze_test.go
+++ b/pkg/source/braze/braze_test.go
@@ -3,6 +3,7 @@ package braze
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 	"time"
 
@@ -267,6 +268,17 @@ func TestFilterItemsByInterval(t *testing.T) {
 		// Only Feb, plus the unparseable row.
 		if len(got) != 2 {
 			t.Errorf("got %d items, want 2", len(got))
+		}
+	})
+
+	t.Run("json.Number epoch seconds parsed", func(t *testing.T) {
+		feb := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+		numItems := []map[string]interface{}{{"ts": json.Number(strconv.FormatInt(feb.Unix(), 10))}}
+		if got := filterItemsByInterval(numItems, []string{"ts"}, tm("2026-02-01T00:00:00Z"), tm("2026-03-01T00:00:00Z")); len(got) != 1 {
+			t.Errorf("inside interval: got %d, want 1", len(got))
+		}
+		if got := filterItemsByInterval(numItems, []string{"ts"}, tm("2026-03-01T00:00:00Z"), nil); len(got) != 0 {
+			t.Errorf("after interval: got %d, want 0", len(got))
 		}
 	})
 }

--- a/pkg/source/braze/register.go
+++ b/pkg/source/braze/register.go
@@ -1,0 +1,10 @@
+package braze
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"braze"},
+		func() interface{} { return NewBrazeSource() },
+	)
+}


### PR DESCRIPTION
## Summary
Adds a **Braze** export-API source to ingestr.

Supports 9 tables:

| Table | PK | Inc key | Strategy |
|---|---|---|---|
| campaigns | id | last_edited | merge |
| canvases | id | last_edited | merge |
| segments | id | – | replace |
| events | event_name | – | replace |
| products | product_id | – | replace |
| kpi_dau / kpi_mau / kpi_new_users / kpi_uninstalls | time | time | merge |

URI: `braze://?api_key=<rest-api-key>&endpoint=<rest-host>` (Braze is multi-instance, so the REST host — e.g. `rest.iad-01.braze.com` — depends on the account's cluster).
