### PR TITLE
Optimize BigQuery merge partition pruning

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -377,6 +377,100 @@ func partitionByClause(column string, isDateColumn bool) string {
 	return fmt.Sprintf("PARTITION BY DATE(%s)\n", quoteIdentifier(column))
 }
 
+type mergePartitionPruning struct {
+	Column string
+	IsDate bool
+}
+
+func buildMergePartitionPruning(meta *bigquery.TableMetadata, primaryKeys []string) *mergePartitionPruning {
+	if meta == nil || meta.TimePartitioning == nil || meta.TimePartitioning.Field == "" {
+		return nil
+	}
+	partitionColumn := meta.TimePartitioning.Field
+	if !containsIdentifier(primaryKeys, partitionColumn) {
+		return nil
+	}
+	fieldType, ok := partitionFieldType(meta.Schema, partitionColumn)
+	if !ok {
+		return nil
+	}
+	switch fieldType {
+	case bigquery.DateFieldType:
+		return &mergePartitionPruning{Column: partitionColumn, IsDate: true}
+	case bigquery.TimestampFieldType, bigquery.DateTimeFieldType:
+		return &mergePartitionPruning{Column: partitionColumn}
+	default:
+		return nil
+	}
+}
+
+func containsIdentifier(values []string, value string) bool {
+	for _, item := range values {
+		if strings.EqualFold(item, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCastForColumn(castMap map[string]string, column string) bool {
+	for castColumn := range castMap {
+		if strings.EqualFold(castColumn, column) {
+			return true
+		}
+	}
+	return false
+}
+
+func partitionFieldType(s bigquery.Schema, column string) (bigquery.FieldType, bool) {
+	for _, field := range s {
+		if strings.EqualFold(field.Name, column) {
+			return field.Type, true
+		}
+	}
+	return "", false
+}
+
+func mergePartitionExpr(alias, column string, isDate bool) string {
+	ref := quoteIdentifier(column)
+	if alias != "" {
+		ref = alias + "." + ref
+	}
+	if isDate {
+		return ref
+	}
+	return fmt.Sprintf("DATE(%s)", ref)
+}
+
+func mergePartitionPruningDeclarations(stagingRef string, pruning *mergePartitionPruning) string {
+	if pruning == nil {
+		return ""
+	}
+	partitionExpr := mergePartitionExpr("", pruning.Column, pruning.IsDate)
+	partitionCol := quoteIdentifier(pruning.Column)
+	return fmt.Sprintf(
+		"DECLARE _ingestr_merge_partition_min DATE DEFAULT (SELECT MIN(%s) FROM %s);\n"+
+			"DECLARE _ingestr_merge_partition_max DATE DEFAULT (SELECT MAX(%s) FROM %s);\n"+
+			"DECLARE _ingestr_merge_partition_has_null BOOL DEFAULT (SELECT COALESCE(LOGICAL_OR(%s IS NULL), FALSE) FROM %s);\n\n",
+		partitionExpr, stagingRef,
+		partitionExpr, stagingRef,
+		partitionCol, stagingRef,
+	)
+}
+
+func mergePartitionTargetPredicate(pruning *mergePartitionPruning) string {
+	if pruning == nil {
+		return ""
+	}
+	targetExpr := mergePartitionExpr("t", pruning.Column, pruning.IsDate)
+	targetCol := fmt.Sprintf("t.%s", quoteIdentifier(pruning.Column))
+	return fmt.Sprintf(
+		"(%s BETWEEN _ingestr_merge_partition_min AND _ingestr_merge_partition_max OR (_ingestr_merge_partition_has_null AND %s IS NULL))",
+		targetExpr,
+		targetCol,
+	)
+}
+
 // PrepareTable creates or recreates a table with the given schema.
 func (d *BigQueryDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
 	ctx = annotation.WithStep(ctx, annotation.StepDDL)
@@ -1330,11 +1424,29 @@ func (d *BigQueryDestination) MergeTable(ctx context.Context, opts destination.M
 		}
 	}
 
+	targetMeta, err := d.client.Dataset(targetDataset).Table(targetTableName).Metadata(ctx)
+	if err != nil {
+		config.Debug("[MERGE] Could not fetch target metadata for partition pruning: %v", err)
+	}
 	// Fetch target and staging table schemas to detect type mismatches
 	castMap := d.buildCastMap(ctx, targetDataset, targetTableName, stagingDataset, stagingTableName)
 
+	pruning := buildMergePartitionPruning(targetMeta, opts.PrimaryKeys)
+	pruningSkipReason := ""
+	if pruning != nil && hasCastForColumn(castMap, pruning.Column) {
+		pruningSkipReason = fmt.Sprintf("partition field %s requires source casting", pruning.Column)
+		pruning = nil
+	} else if pruning == nil && targetMeta != nil && targetMeta.TimePartitioning != nil && targetMeta.TimePartitioning.Field != "" {
+		pruningSkipReason = fmt.Sprintf("partition field %s is not part of the merge primary key", targetMeta.TimePartitioning.Field)
+	}
+	if pruning != nil {
+		config.Debug("[MERGE] Applying target partition pruning on %s", pruning.Column)
+	} else if pruningSkipReason != "" {
+		config.Debug("[MERGE] Skipping target partition pruning: %s", pruningSkipReason)
+	}
+
 	// Build MERGE statement
-	mergeSQL := d.buildMergeSQL(targetDataset, targetTableName, stagingDataset, stagingTableName, opts.PrimaryKeys, opts.Columns, castMap, opts.IncrementalKey)
+	mergeSQL := d.buildMergeSQLWithPartitionPruning(targetDataset, targetTableName, stagingDataset, stagingTableName, opts.PrimaryKeys, opts.Columns, castMap, opts.IncrementalKey, pruning)
 
 	config.Debug("[MERGE] Executing MERGE statement")
 	config.Debug("[MERGE] SQL: %s", mergeSQL)
@@ -1660,11 +1772,18 @@ func buildBigQueryDedupSelect(qualifiedTable string, primaryKeys []string, order
 
 // buildMergeSQL constructs a BigQuery MERGE statement
 func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string, incrementalKey string) string {
+	return d.buildMergeSQLWithPartitionPruning(targetDataset, targetTable, stagingDataset, stagingTable, primaryKeys, allColumns, castMap, incrementalKey, nil)
+}
+
+func (d *BigQueryDestination) buildMergeSQLWithPartitionPruning(targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string, incrementalKey string, pruning *mergePartitionPruning) string {
 	destColumns := destination.DestinationColumns(allColumns)
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
 		sourceCol := castSourceCol(pk, castMap)
 		onConditions[i] = fmt.Sprintf("(t.%s = %s OR (t.%s IS NULL AND %s IS NULL))", quoteIdentifier(pk), sourceCol, quoteIdentifier(pk), sourceCol)
+	}
+	if partitionPredicate := mergePartitionTargetPredicate(pruning); partitionPredicate != "" {
+		onConditions = append(onConditions, partitionPredicate)
 	}
 	onClause := strings.Join(onConditions, " AND ")
 
@@ -1705,6 +1824,8 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 	}
 
 	var sql strings.Builder
+	stagingRef := fmt.Sprintf("%s.%s.%s", quoteIdentifier(d.projectID), quoteIdentifier(stagingDataset), quoteIdentifier(stagingTable))
+	sql.WriteString(mergePartitionPruningDeclarations(stagingRef, pruning))
 	fmt.Fprintf(&sql, "MERGE %s.%s.%s AS t\n", quoteIdentifier(d.projectID), quoteIdentifier(targetDataset), quoteIdentifier(targetTable))
 
 	if hasCDCDeleted && len(primaryKeys) > 0 {
@@ -1732,7 +1853,6 @@ func (d *BigQueryDestination) buildMergeSQL(targetDataset, targetTable, stagingD
 		}
 		selectCols = append(selectCols, "act.`_cdc_lsn` IS NOT NULL AS `__ingestr_has_active`")
 
-		stagingRef := fmt.Sprintf("%s.%s.%s", quoteIdentifier(d.projectID), quoteIdentifier(stagingDataset), quoteIdentifier(stagingTable))
 		fmt.Fprintf(
 			&sql,
 			"USING (SELECT %s FROM (SELECT * FROM %s QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1) AS la LEFT JOIN (SELECT * FROM %s WHERE `_cdc_deleted` = false QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY `_cdc_lsn` DESC) = 1) AS act ON %s) AS s\n",

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1437,7 +1437,12 @@ func (d *BigQueryDestination) MergeTable(ctx context.Context, opts destination.M
 		pruningSkipReason = fmt.Sprintf("partition field %s requires source casting", pruning.Column)
 		pruning = nil
 	} else if pruning == nil && targetMeta != nil && targetMeta.TimePartitioning != nil && targetMeta.TimePartitioning.Field != "" {
-		pruningSkipReason = fmt.Sprintf("partition field %s is not part of the merge primary key", targetMeta.TimePartitioning.Field)
+		partitionField := targetMeta.TimePartitioning.Field
+		if !containsIdentifier(opts.PrimaryKeys, partitionField) {
+			pruningSkipReason = fmt.Sprintf("partition field %s is not part of the merge primary key", partitionField)
+		} else {
+			pruningSkipReason = fmt.Sprintf("partition field %s has an unsupported type or was not found in schema", partitionField)
+		}
 	}
 	if pruning != nil {
 		config.Debug("[MERGE] Applying target partition pruning on %s", pruning.Column)

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -1350,6 +1350,47 @@ func TestPartitionByClause(t *testing.T) {
 	}
 }
 
+func TestBuildMergePartitionPruning(t *testing.T) {
+	meta := &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "id", Type: bigquery.IntegerFieldType},
+			{Name: "day", Type: bigquery.DateFieldType},
+			{Name: "created_at", Type: bigquery.TimestampFieldType},
+		},
+		TimePartitioning: &bigquery.TimePartitioning{Field: "day"},
+	}
+
+	pruning := buildMergePartitionPruning(meta, []string{"id", "DAY"})
+	if pruning == nil {
+		t.Fatal("expected pruning when the partition column is part of the primary key")
+	}
+	if pruning.Column != "day" || !pruning.IsDate {
+		t.Fatalf("unexpected pruning config: %+v", pruning)
+	}
+
+	if got := buildMergePartitionPruning(meta, []string{"id"}); got != nil {
+		t.Fatalf("expected no pruning when partition column is not part of primary key, got %+v", got)
+	}
+
+	meta.TimePartitioning.Field = "created_at"
+	pruning = buildMergePartitionPruning(meta, []string{"id", "created_at"})
+	if pruning == nil {
+		t.Fatal("expected pruning for timestamp partition primary key")
+	}
+	if pruning.Column != "created_at" || pruning.IsDate {
+		t.Fatalf("unexpected timestamp pruning config: %+v", pruning)
+	}
+
+	meta.TimePartitioning.Field = ""
+	if got := buildMergePartitionPruning(meta, []string{"id", "created_at"}); got != nil {
+		t.Fatalf("expected no pruning for ingestion-time partitioned table, got %+v", got)
+	}
+
+	if !hasCastForColumn(map[string]string{"Day": "DATE"}, "day") {
+		t.Fatal("expected cast map lookup to be case-insensitive")
+	}
+}
+
 func TestBuildMergeSQL(t *testing.T) {
 	dest := NewBigQueryDestination()
 	dest.projectID = "my-project"
@@ -1490,6 +1531,42 @@ func TestBuildMergeSQL(t *testing.T) {
 
 		if contains(sql, "_cdc_unchanged_cols") {
 			t.Fatalf("sql must not reference _cdc_unchanged_cols when absent:\n%s", sql)
+		}
+	})
+
+	t.Run("date_partition_pruning_when_partition_column_is_pk", func(t *testing.T) {
+		sql := dest.buildMergeSQLWithPartitionPruning(
+			"target_ds", "target_tbl", "staging_ds", "staging_tbl",
+			[]string{"id", "day"}, []string{"id", "day", "name"}, nil, "",
+			&mergePartitionPruning{Column: "day", IsDate: true},
+		)
+
+		if !contains(sql, "DECLARE _ingestr_merge_partition_min DATE DEFAULT (SELECT MIN(`day`) FROM `my-project`.`staging_ds`.`staging_tbl`);\n") {
+			t.Fatalf("sql missing date partition min declaration:\n%s", sql)
+		}
+		if !contains(sql, "DECLARE _ingestr_merge_partition_max DATE DEFAULT (SELECT MAX(`day`) FROM `my-project`.`staging_ds`.`staging_tbl`);\n") {
+			t.Fatalf("sql missing date partition max declaration:\n%s", sql)
+		}
+		if !contains(sql, "DECLARE _ingestr_merge_partition_has_null BOOL DEFAULT (SELECT COALESCE(LOGICAL_OR(`day` IS NULL), FALSE) FROM `my-project`.`staging_ds`.`staging_tbl`);\n") {
+			t.Fatalf("sql missing partition null declaration:\n%s", sql)
+		}
+		if !contains(sql, "AND (t.`day` BETWEEN _ingestr_merge_partition_min AND _ingestr_merge_partition_max OR (_ingestr_merge_partition_has_null AND t.`day` IS NULL))\n") {
+			t.Fatalf("sql missing target partition pruning predicate:\n%s", sql)
+		}
+	})
+
+	t.Run("timestamp_partition_pruning_uses_date_expression", func(t *testing.T) {
+		sql := dest.buildMergeSQLWithPartitionPruning(
+			"target_ds", "target_tbl", "staging_ds", "staging_tbl",
+			[]string{"id", "created_at"}, []string{"id", "created_at", "name"}, nil, "",
+			&mergePartitionPruning{Column: "created_at"},
+		)
+
+		if !contains(sql, "DECLARE _ingestr_merge_partition_min DATE DEFAULT (SELECT MIN(DATE(`created_at`)) FROM `my-project`.`staging_ds`.`staging_tbl`);\n") {
+			t.Fatalf("sql missing timestamp partition min declaration:\n%s", sql)
+		}
+		if !contains(sql, "AND (DATE(t.`created_at`) BETWEEN _ingestr_merge_partition_min AND _ingestr_merge_partition_max OR (_ingestr_merge_partition_has_null AND t.`created_at` IS NULL))\n") {
+			t.Fatalf("sql missing timestamp target partition pruning predicate:\n%s", sql)
 		}
 	})
 }

--- a/tests/integration/bigquery_dedup_test.go
+++ b/tests/integration/bigquery_dedup_test.go
@@ -264,6 +264,66 @@ func TestBigQuery_MergeTable_DedupsDuplicateStagingPKs(t *testing.T) {
 	require.Equal(t, "pre-existing", rows[0][0])
 }
 
+func TestBigQuery_MergeTable_PartitionPrunedPrimaryKey(t *testing.T) {
+	dest, client, project, dataset := bqDedupSetup(t)
+	ctx := context.Background()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	stagingTbl := fmt.Sprintf("partition_merge_staging_%s", suffix)
+	targetTbl := fmt.Sprintf("partition_merge_target_%s", suffix)
+	defer bqDropTables(ctx, client, dataset, stagingTbl, targetTbl)
+	defer func() { _ = dest.Close(ctx) }()
+
+	require.NoError(t, dest.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s.%s.%s` (id INT64, day DATE, name STRING)",
+		project, dataset, stagingTbl,
+	)))
+	require.NoError(t, dest.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s.%s.%s` (id INT64, day DATE, name STRING) PARTITION BY day",
+		project, dataset, targetTbl,
+	)))
+	require.NoError(t, dest.Exec(ctx, fmt.Sprintf(`INSERT INTO `+"`%s.%s.%s`"+` VALUES
+		(1, DATE '2024-01-01', 'old'),
+		(2, DATE '2024-01-02', 'outside-window'),
+		(3, NULL, 'null-old')`, project, dataset, targetTbl)))
+	require.NoError(t, dest.Exec(ctx, fmt.Sprintf(`INSERT INTO `+"`%s.%s.%s`"+` VALUES
+		(1, DATE '2024-01-01', 'new'),
+		(4, DATE '2024-01-01', 'inserted'),
+		(3, NULL, 'null-new')`, project, dataset, stagingTbl)))
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: dataset + "." + stagingTbl,
+		TargetTable:  dataset + "." + targetTbl,
+		PrimaryKeys:  []string{"id", "day"},
+		Columns:      []string{"id", "day", "name"},
+	}))
+
+	rows := bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT COUNT(*) FROM `%s.%s.%s`", project, dataset, targetTbl,
+	))
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 4, rows[0][0], "expected updated row, untouched outside row, null-partition update, and inserted row")
+
+	rows = bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT name FROM `%s.%s.%s` WHERE id = 1 AND day = DATE '2024-01-01'", project, dataset, targetTbl,
+	))
+	require.Len(t, rows, 1)
+	require.Equal(t, "new", rows[0][0])
+
+	rows = bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT name FROM `%s.%s.%s` WHERE id = 2 AND day = DATE '2024-01-02'", project, dataset, targetTbl,
+	))
+	require.Len(t, rows, 1)
+	require.Equal(t, "outside-window", rows[0][0])
+
+	rows = bqRunQuery(t, ctx, client, fmt.Sprintf(
+		"SELECT COUNT(*), ANY_VALUE(name) FROM `%s.%s.%s` WHERE id = 3 AND day IS NULL", project, dataset, targetTbl,
+	))
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 1, rows[0][0], "NULL partition row should be updated, not duplicated")
+	require.Equal(t, "null-new", rows[0][1])
+}
+
 // TestBigQuery_DeleteInsertTable_DedupsDuplicateStagingPKs verifies that
 // DeleteInsertTable inserts one row per primary key from staging into target,
 // even when staging has duplicate PKs in the same incremental window.


### PR DESCRIPTION
Adds a safe BigQuery MERGE pruning path for partitioned targets when the partition field is part of the merge primary key. The generated SQL now bounds target partition scans from staging min/max values while preserving the existing fallback for unsafe cases. Validated with make format, make lint, make test, BigQuery conformance tests, and manual BigQuery integration.