### PR TITLE
feat(braze): add incremental series tables (event/segment/session/purchase) + richer events

### DIFF
--- a/docs/supported-sources/braze.md
+++ b/docs/supported-sources/braze.md
@@ -38,6 +38,7 @@ Braze source allows ingesting the following resources into separate tables:
 | [kpi_mau](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_mau_30_days) | time | time | merge | Monthly active users (rolling 30-day) by date. |
 | [kpi_new_users](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_daily_new_users_date) | time | time | merge | New users by date. |
 | [kpi_uninstalls](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_uninstalls_date) | time | time | merge | App uninstalls by date. |
+| [event_series](https://www.braze.com/docs/api/endpoints/export/custom_events/get_custom_events_analytics) | time, event_name | time | merge | Daily occurrence count per custom event. Fetches all events by default; an optional `event_series:<name>[,<name>]` filter limits it. |
 | [user_data](https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment) | braze_id, segment_id | – | replace | Users in a segment with their email/push subscription state and profile fields (a point-in-time snapshot). |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command.

--- a/docs/supported-sources/braze.md
+++ b/docs/supported-sources/braze.md
@@ -32,7 +32,7 @@ Braze source allows ingesting the following resources into separate tables:
 | [campaigns](https://www.braze.com/docs/api/endpoints/export/campaigns/get_campaigns) | id | last_edited | merge | Marketing campaigns (including archived) with their name, tags, and API flags. |
 | [canvases](https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases) | id | last_edited | merge | Canvas (journey) definitions (including archived) with their name and tags. |
 | [segments](https://www.braze.com/docs/api/endpoints/export/segments/get_segment) | id | – | replace | Audience segments with their name and analytics-tracking flag. |
-| [events](https://www.braze.com/docs/api/endpoints/export/custom_events/get_custom_events) | event_name | – | replace | Names of the custom events tracked in the workspace. |
+| [events](https://www.braze.com/docs/api/endpoints/export/custom_events/get_custom_events_data) | name | – | replace | Custom events catalog: name, description, status, tags, and analytics-report flag. |
 | [products](https://www.braze.com/docs/api/endpoints/export/purchases/get_list_product_id) | product_id | – | replace | Product IDs seen in purchase events. |
 | [kpi_dau](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_dau_date) | time | time | merge | Daily active users by date. |
 | [kpi_mau](https://www.braze.com/docs/api/endpoints/export/kpi/get_kpi_mau_30_days) | time | time | merge | Monthly active users (rolling 30-day) by date. |

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -24,10 +24,9 @@ import (
 )
 
 const (
-	maxListPageSize  = 100 // campaigns, canvases, segments, products: groups of 100
-	maxEventPageSize = 250 // events/list: returns 250 event names per page
-	maxKPILength     = 100 // kpi data_series: length must be between 1 and 100 days
-	maxListPages     = 10000
+	maxListPageSize = 100 // campaigns, canvases, segments, products: groups of 100
+	maxKPILength    = 100 // kpi data_series: length must be between 1 and 100 days
+	maxListPages    = 10000
 
 	// Braze's default pool (list + data_series endpoints) is 250,000 requests/hour.
 	rateLimit      = 250000 * 0.8 / 3600.0 // ~55.5 req/s
@@ -255,7 +254,8 @@ func tableMetadata(table string) ([]string, string, config.IncrementalStrategy) 
 	case "segments":
 		return []string{"id"}, "", config.StrategyReplace
 	case "events":
-		return []string{"event_name"}, "", config.StrategyReplace
+		// /events catalog objects are keyed by their name
+		return []string{"name"}, "", config.StrategyReplace
 	case "products":
 		return []string{"product_id"}, "", config.StrategyReplace
 	case "kpi_dau", "kpi_mau", "kpi_new_users", "kpi_uninstalls":
@@ -635,15 +635,71 @@ func emitSegmentExport(ctx context.Context, data []byte, segmentID string, opts 
 
 func (s *BrazeSource) readEvents(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[BRAZE] reading events")
-	// events/list returns an array of event-name strings; lift each to a record.
-	itemFn := func(v interface{}) map[string]interface{} {
-		name, ok := v.(string)
-		if !ok {
-			return nil
+	return s.paginateEvents(ctx, func(events []map[string]interface{}) error {
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(events, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert events to Arrow: %w", err)
 		}
-		return map[string]interface{}{"event_name": name}
+		results <- source.RecordBatchResult{Batch: record}
+		return nil
+	})
+}
+
+// paginateEvents pages the cursor-based GET /events catalog (rich event objects:
+// name, description, status, tag_names, ...), invoking fn for each page.
+func (s *BrazeSource) paginateEvents(ctx context.Context, fn func([]map[string]interface{}) error) error {
+	cursor := ""
+	for page := 0; page < maxListPages; page++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		req := s.lowClient.R(ctx)
+		if cursor != "" {
+			req.SetQueryParam("cursor", cursor)
+		}
+		resp, err := req.Get("/events")
+		if err != nil {
+			return fmt.Errorf("failed to fetch /events: %w", err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("/events returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+		var body struct {
+			Events []map[string]interface{} `json:"events"`
+		}
+		if err := decodeBody(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse /events response: %w", err)
+		}
+		if len(body.Events) > 0 {
+			if err := fn(body.Events); err != nil {
+				return err
+			}
+		}
+		cursor = nextCursor(resp.Header().Get("Link"))
+		if cursor == "" {
+			break
+		}
 	}
-	return s.paginateList(ctx, s.lowClient, "/events/list", "events", maxEventPageSize, nil, itemFn, nil, opts, results)
+	return nil
+}
+
+// nextCursor extracts the cursor value from a Link header's rel="next" entry.
+func nextCursor(link string) string {
+	for _, part := range strings.Split(link, ",") {
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		i := strings.Index(part, "cursor=")
+		if i < 0 {
+			return ""
+		}
+		c := part[i+len("cursor="):]
+		if j := strings.IndexAny(c, "&>"); j >= 0 {
+			c = c[:j]
+		}
+		return c
+	}
+	return ""
 }
 
 func (s *BrazeSource) readProducts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
@@ -694,35 +750,18 @@ func (s *BrazeSource) readEventSeries(ctx context.Context, eventNames []string, 
 	return nil
 }
 
-// listEventNames pages through /events/list and returns all custom event names.
+// listEventNames returns all custom event names from the /events catalog.
 func (s *BrazeSource) listEventNames(ctx context.Context) ([]string, error) {
 	var names []string
-	for page := 0; page < maxListPages; page++ {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+	err := s.paginateEvents(ctx, func(events []map[string]interface{}) error {
+		for _, e := range events {
+			if n, ok := e["name"].(string); ok {
+				names = append(names, n)
+			}
 		}
-		resp, err := s.lowClient.R(ctx).SetQueryParam("page", strconv.Itoa(page)).Get("/events/list")
-		if err != nil {
-			return nil, fmt.Errorf("failed to list events: %w", err)
-		}
-		if !resp.IsSuccess() {
-			return nil, fmt.Errorf("/events/list returned status %d: %s", resp.StatusCode(), resp.String())
-		}
-		var body struct {
-			Events []string `json:"events"`
-		}
-		if err := decodeBody(resp.Body(), &body); err != nil {
-			return nil, fmt.Errorf("failed to parse /events/list response: %w", err)
-		}
-		if len(body.Events) == 0 {
-			break
-		}
-		names = append(names, body.Events...)
-		if len(body.Events) < maxEventPageSize {
-			break
-		}
-	}
-	return names, nil
+		return nil
+	})
+	return names, err
 }
 
 // fetchKPIWindows walks the series in 100-day windows back to interval-start (last

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -697,6 +697,10 @@ func nextCursor(link string) string {
 		if j := strings.IndexAny(c, "&>"); j >= 0 {
 			c = c[:j]
 		}
+		// The header value is percent-encoded; decode so SetQueryParam re-encodes it once.
+		if decoded, err := url.QueryUnescape(c); err == nil {
+			c = decoded
+		}
 		return c
 	}
 	return ""
@@ -764,8 +768,6 @@ func (s *BrazeSource) listEventNames(ctx context.Context) ([]string, error) {
 	return names, err
 }
 
-// fetchKPIWindows walks the series in 100-day windows back to interval-start (last
-// 100 days with no interval); a non-empty appID scopes it and adds an app_id column.
 // fetchSeries walks a /*/data_series endpoint in 100-day windows. params are
 // extra query params (e.g. app_id, event); tag columns are stamped onto each row.
 func (s *BrazeSource) fetchSeries(ctx context.Context, endpoint string, params map[string]string, tag map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -52,6 +52,7 @@ var supportedTables = []string{
 	"canvases",
 	"segments",
 	"events",
+	"event_series",
 	"products",
 	"kpi_dau",
 	"kpi_mau",
@@ -215,10 +216,10 @@ func (s *BrazeSource) GetTable(ctx context.Context, req source.TableRequest) (so
 		if len(params) == 0 {
 			return nil, fmt.Errorf("user_data requires at least one segment id, e.g. user_data:<segment_id>[,<segment_id>]")
 		}
-	case isKPITable(base):
-		// app_id list is optional
+	case isKPITable(base) || base == "event_series":
+		// optional param: app_id list for kpi, event-name filter for event_series
 	case len(params) > 0:
-		return nil, fmt.Errorf("the :param suffix is only supported for kpi_* and user_data tables, not %q", base)
+		return nil, fmt.Errorf("the :param suffix is only supported for kpi_*, user_data, and event_series tables, not %q", base)
 	}
 
 	primaryKeys, incrementalKey, strategy := tableMetadata(base)
@@ -260,6 +261,9 @@ func tableMetadata(table string) ([]string, string, config.IncrementalStrategy) 
 	case "kpi_dau", "kpi_mau", "kpi_new_users", "kpi_uninstalls":
 		// daily series keyed on date; merge updates the still-changing latest day
 		return []string{"time"}, "time", config.StrategyMerge
+	case "event_series":
+		// daily count series per custom event; event_name is part of the key
+		return []string{"time", "event_name"}, "time", config.StrategyMerge
 	case "user_data":
 		// point-in-time snapshot of users (and their subscription state) per segment;
 		// segment_id is part of the key so a user can appear in multiple segments
@@ -297,6 +301,8 @@ func (s *BrazeSource) read(ctx context.Context, table string, params []string, o
 			err = s.readKPISeries(ctx, "/kpi/uninstalls/data_series", params, opts, results)
 		case "user_data":
 			err = s.readUserData(ctx, params, opts, results)
+		case "event_series":
+			err = s.readEventSeries(ctx, params, opts, results)
 		default:
 			err = fmt.Errorf("unsupported table: %s", table)
 		}
@@ -658,19 +664,72 @@ func (s *BrazeSource) readProducts(ctx context.Context, opts source.ReadOptions,
 func (s *BrazeSource) readKPISeries(ctx context.Context, endpoint string, appIDs []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[BRAZE] reading %s (apps: %d)", endpoint, len(appIDs))
 	if len(appIDs) == 0 {
-		return s.fetchKPIWindows(ctx, endpoint, "", opts, results)
+		return s.fetchSeries(ctx, endpoint, nil, nil, opts, results)
 	}
 	for _, appID := range appIDs {
-		if err := s.fetchKPIWindows(ctx, endpoint, appID, opts, results); err != nil {
+		if err := s.fetchSeries(ctx, endpoint, map[string]string{"app_id": appID}, map[string]interface{}{"app_id": appID}, opts, results); err != nil {
 			return fmt.Errorf("%s for app_id %s: %w", endpoint, appID, err)
 		}
 	}
 	return nil
 }
 
+// readEventSeries fetches the daily count series for custom events, tagging each
+// row with its event_name. With no names it first lists all events, then fetches
+// each one's series; names act as an optional filter.
+func (s *BrazeSource) readEventSeries(ctx context.Context, eventNames []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(eventNames) == 0 {
+		all, err := s.listEventNames(ctx)
+		if err != nil {
+			return err
+		}
+		eventNames = all
+	}
+	config.Debug("[BRAZE] reading /events/data_series (events: %d)", len(eventNames))
+	for _, name := range eventNames {
+		if err := s.fetchSeries(ctx, "/events/data_series", map[string]string{"event": name}, map[string]interface{}{"event_name": name}, opts, results); err != nil {
+			return fmt.Errorf("/events/data_series for event %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// listEventNames pages through /events/list and returns all custom event names.
+func (s *BrazeSource) listEventNames(ctx context.Context) ([]string, error) {
+	var names []string
+	for page := 0; page < maxListPages; page++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		resp, err := s.lowClient.R(ctx).SetQueryParam("page", strconv.Itoa(page)).Get("/events/list")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list events: %w", err)
+		}
+		if !resp.IsSuccess() {
+			return nil, fmt.Errorf("/events/list returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+		var body struct {
+			Events []string `json:"events"`
+		}
+		if err := decodeBody(resp.Body(), &body); err != nil {
+			return nil, fmt.Errorf("failed to parse /events/list response: %w", err)
+		}
+		if len(body.Events) == 0 {
+			break
+		}
+		names = append(names, body.Events...)
+		if len(body.Events) < maxEventPageSize {
+			break
+		}
+	}
+	return names, nil
+}
+
 // fetchKPIWindows walks the series in 100-day windows back to interval-start (last
 // 100 days with no interval); a non-empty appID scopes it and adds an app_id column.
-func (s *BrazeSource) fetchKPIWindows(ctx context.Context, endpoint, appID string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+// fetchSeries walks a /*/data_series endpoint in 100-day windows. params are
+// extra query params (e.g. app_id, event); tag columns are stamped onto each row.
+func (s *BrazeSource) fetchSeries(ctx context.Context, endpoint string, params map[string]string, tag map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	end := time.Now().UTC()
 	if opts.IntervalEnd != nil {
 		end = opts.IntervalEnd.UTC()
@@ -691,8 +750,8 @@ func (s *BrazeSource) fetchKPIWindows(ctx context.Context, endpoint, appID strin
 		req := s.client.R(ctx).
 			SetQueryParam("length", strconv.Itoa(w.length)).
 			SetQueryParam("ending_at", w.endingAt.Format(brazeTimeLayout))
-		if appID != "" {
-			req.SetQueryParam("app_id", appID)
+		for k, v := range params {
+			req.SetQueryParam(k, v)
 		}
 
 		resp, err := req.Get(endpoint)
@@ -711,9 +770,9 @@ func (s *BrazeSource) fetchKPIWindows(ctx context.Context, endpoint, appID strin
 		}
 
 		if len(body.Data) > 0 {
-			if appID != "" {
-				for _, row := range body.Data {
-					row["app_id"] = appID
+			for _, row := range body.Data {
+				for k, v := range tag {
+					row[k] = v
 				}
 			}
 			record, err := arrowconv.ItemsToArrowRecordWithSchema(body.Data, nil, opts.ExcludeColumns)

--- a/pkg/source/braze/braze_test.go
+++ b/pkg/source/braze/braze_test.go
@@ -203,6 +203,23 @@ func TestGetTableAppIDValidation(t *testing.T) {
 			t.Errorf("unexpected error for multiple segment ids: %v", err)
 		}
 	})
+
+	t.Run("event_series valid with no names and composite PK", func(t *testing.T) {
+		tbl, err := s.GetTable(ctx, source.TableRequest{Name: "event_series"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		pk := tbl.PrimaryKeys()
+		if len(pk) != 2 || pk[0] != "time" || pk[1] != "event_name" {
+			t.Errorf("PrimaryKeys = %v, want [time event_name]", pk)
+		}
+	})
+
+	t.Run("event_series accepts an event-name filter", func(t *testing.T) {
+		if _, err := s.GetTable(ctx, source.TableRequest{Name: "event_series:purchase,signup"}); err != nil {
+			t.Errorf("unexpected error for event names: %v", err)
+		}
+	})
 }
 
 func TestTableMetadata(t *testing.T) {

--- a/pkg/source/braze/braze_test.go
+++ b/pkg/source/braze/braze_test.go
@@ -234,7 +234,7 @@ func TestTableMetadata(t *testing.T) {
 		{"campaigns", []string{"id"}, "last_edited", config.StrategyMerge},
 		{"canvases", []string{"id"}, "last_edited", config.StrategyMerge},
 		{"segments", []string{"id"}, "", config.StrategyReplace},
-		{"events", []string{"event_name"}, "", config.StrategyReplace},
+		{"events", []string{"name"}, "", config.StrategyReplace},
 		{"products", []string{"product_id"}, "", config.StrategyReplace},
 		{"kpi_dau", []string{"time"}, "time", config.StrategyMerge},
 		{"kpi_mau", []string{"time"}, "time", config.StrategyMerge},


### PR DESCRIPTION
## Summary
Two related Braze additions, building on the merged `user_data` work (#851):

### 1. `event_series` — daily counts per custom event (incremental)
- Uses `GET /events/data_series` (the analytics endpoint), which returns a daily `{time, count}` series per event.
- **Fetches all events automatically** (lists them first, then pulls each one's series) — no need to name events. An optional filter is supported: `event_series:<name>[,<name>]`.
- Each row tagged with `event_name`; composite PK `(time, event_name)`, incremental key `time`, strategy `merge`.
- Window-walks the range in 100-day chunks (shared `fetchSeries` helper, generalized from the KPI walker).