### PR TITLE
feat(braze): user_data exports all segments when none specified

### DIFF
--- a/docs/supported-sources/braze.md
+++ b/docs/supported-sources/braze.md
@@ -45,20 +45,24 @@ Braze source allows ingesting the following resources into separate tables:
 | [sessions](https://www.braze.com/docs/api/endpoints/export/sessions/get_sessions_analytics) | time | time | merge | Daily session count. |
 | [purchase_quantity](https://www.braze.com/docs/api/endpoints/export/purchases/get_number_of_purchases) | time | time | merge | Daily total number of purchases. |
 | [purchase_revenue](https://www.braze.com/docs/api/endpoints/export/purchases/get_revenue_series) | time | time | merge | Daily total revenue. |
-| [user_data](https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment) | braze_id, segment_id | – | replace | Users in a segment with their email/push subscription state and profile fields (a point-in-time snapshot). |
+| [user_data](https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment) | braze_id, segment_id | – | replace | Segment users with their email/push subscription state and profile fields (a point-in-time snapshot). Exports all segments by default; an optional `user_data:<id>[,<id>]` filter limits it. |
 
 Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
 ### User data
 
-The `user_data` table exports the users of one or more segments along with their subscription state. At least one segment id is required and passed as a comma-separated suffix on the table name:
+The `user_data` table exports the users of one or more segments along with their subscription state. By default it exports **every** segment; pass a comma-separated list of segment ids as a suffix to limit it:
 
 ```
---source-table "user_data:<segment_id>"
---source-table "user_data:<segment_id_1>,<segment_id_2>"
+--source-table "user_data"                                  # all segments
+--source-table "user_data:<segment_id>"                     # one segment
+--source-table "user_data:<segment_id_1>,<segment_id_2>"    # specific segments
 ```
 
-You can find segment identifiers in the Braze dashboard. Each run produces a fresh full snapshot of those segments' users, and every row is tagged with the `segment_id` it came from (so the same user can appear under multiple segments). Exported fields include the subscription state (`email_subscribe`, `push_subscribe`, plus the opt-in/unsubscribe timestamps Braze returns automatically alongside them), identifiers (`braze_id`, `external_id`, `email`, `phone`), profile fields (name, country, language, time zone, …), and per-product `purchases`.
+You can find segment ids by ingesting the `segments` table (its `id` column) or in the Braze dashboard. Each run produces a fresh full snapshot, and every row is tagged with the `segment_id` it came from (so the same user can appear under multiple segments). Exported fields include the subscription state (`email_subscribe`, `push_subscribe`, plus the opt-in/unsubscribe timestamps Braze returns automatically alongside them), identifiers (`braze_id`, `external_id`, `email`, `phone`), profile fields (name, country, language, time zone, …), and per-product `purchases`.
+
+> [!WARNING]
+> Exporting all segments runs one async export per segment and can produce a very large, heavily duplicated dataset (the same user appears in every segment they belong to). Prefer naming the specific segments you need.
 
 ### Per-app KPIs
 

--- a/pkg/source/braze/braze.go
+++ b/pkg/source/braze/braze.go
@@ -218,12 +218,8 @@ func (s *BrazeSource) GetTable(ctx context.Context, req source.TableRequest) (so
 		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", req.Name, strings.Join(supportedTables, ", "))
 	}
 	switch {
-	case base == "user_data":
-		if len(params) == 0 {
-			return nil, fmt.Errorf("user_data requires at least one segment id, e.g. user_data:<segment_id>[,<segment_id>]")
-		}
-	case isKPITable(base) || isSeriesTable(base):
-		// optional param: app_id (kpi) or the dimension id/name to filter the series by
+	case isKPITable(base) || isSeriesTable(base) || base == "user_data":
+		// optional param: app_id (kpi), a series dimension id/name, or segment ids (user_data)
 	case len(params) > 0:
 		return nil, fmt.Errorf("the :param suffix is only supported for kpi_*, user_data, and *_series tables, not %q", base)
 	}
@@ -549,8 +545,17 @@ func (s *BrazeSource) readSegments(ctx context.Context, opts source.ReadOptions,
 }
 
 // readUserData exports the users of one or more segments via the async
-// /users/export/segment endpoint, tagging each row with its segment_id.
+// /users/export/segment endpoint, tagging each row with its segment_id. With no
+// ids it exports every segment; ids act as a filter.
 func (s *BrazeSource) readUserData(ctx context.Context, segmentIDs []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(segmentIDs) == 0 {
+		all, err := s.listSegmentIDs(ctx)
+		if err != nil {
+			return err
+		}
+		segmentIDs = all
+	}
+	config.Debug("[BRAZE] reading user_data (segments: %d)", len(segmentIDs))
 	for _, segmentID := range segmentIDs {
 		data, err := s.exportSegment(ctx, segmentID)
 		if err != nil {

--- a/pkg/source/braze/braze_test.go
+++ b/pkg/source/braze/braze_test.go
@@ -181,9 +181,14 @@ func TestGetTableAppIDValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("user_data requires a segment id", func(t *testing.T) {
-		if _, err := s.GetTable(ctx, source.TableRequest{Name: "user_data"}); err == nil {
-			t.Error("expected error for user_data without segment id, got nil")
+	t.Run("user_data without ids is valid (exports all segments)", func(t *testing.T) {
+		tbl, err := s.GetTable(ctx, source.TableRequest{Name: "user_data"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		pk := tbl.PrimaryKeys()
+		if len(pk) != 2 || pk[0] != "braze_id" || pk[1] != "segment_id" {
+			t.Errorf("PrimaryKeys = %v, want [braze_id segment_id]", pk)
 		}
 	})
 


### PR DESCRIPTION
## What

Makes the Braze `user_data` table consistent with the `*_series` tables: when no segment id is given it now lists and exports **every** segment; ids passed as a `user_data:<id>[,<id>]` suffix act as a filter.

Previously `user_data` required at least one segment id.