### PR TITLE
Add Reddit Ads source

### DIFF
--- a/docs/supported-sources/reddit_ads.md
+++ b/docs/supported-sources/reddit_ads.md
@@ -61,9 +61,6 @@ Reddit Ads source allows ingesting the following sources into separate tables:
 
 Use these as `--source-table` parameter in the `ingestr ingest` command.
 
-> [!NOTE]
-> The entity tables (except `funding_instruments`) are filtered client-side on their modification timestamp (`modified_at`, or `updated_at` for `saved_audiences`) when `--interval-start`/`--interval-end` are provided, and use a `merge` write disposition keyed on `id`. With no interval, all records are loaded. `funding_instruments` has no modification timestamp, so it is always fully replaced.
-
 ### Example
 
 Retrieve all campaigns:

--- a/docs/supported-sources/reddit_ads.md
+++ b/docs/supported-sources/reddit_ads.md
@@ -16,13 +16,17 @@ redditads://?access_token=<access_token>&account_ids=<account_ids>
 Reddit Ads requires an `access_token` and `account_ids` to retrieve data from the [Reddit Ads API v3](https://ads-api.reddit.com/docs/v3/). Please follow these steps to obtain the `access_token` and `account_ids`.
 
 ### Create a Reddit developer application to obtain an access token
-1. Go to [Reddit App Preferences](https://www.reddit.com/prefs/apps) and log in with your Reddit account.
-2. Click "create another app..." at the bottom of the page.
-3. Fill out the form:
-   - **Name**: Your application name
-   - **Type**: Select "web app"
-   - **Redirect URI**: A valid redirect URI for your OAuth flow (e.g., `http://localhost:8080/callback`)
-4. Click "create app" and note your **client_id** (shown under the app name) and **client_secret**.
+
+> [!IMPORTANT]
+> The Reddit Ads API only works with applications created through **Reddit Business Manager**. Legacy apps created at `reddit.com/prefs/apps` are **not** authorized for the Ads API — authorization succeeds but the token request fails with `403` when the `adsread` scope is requested.
+
+1. Go to the [Reddit Ads Dashboard](https://ads.reddit.com/) and log in with an account that has access to your ad accounts.
+2. Open **Business Manager** from the account menu, then select **Developer Applications**.
+3. Click **Create a new app** and fill out the form:
+   - **App name**: Your application name
+   - **Redirect uri**: `http://localhost:8080/callback`
+   - **Primary contact**: a business admin on the account
+4. Accept the Ads API Terms and click **Create App**, then open the app to find your **client_id** (App ID) and **client_secret**.
 
 #### Authorize your app and obtain access token
 1. Direct the user to the Reddit authorization URL:
@@ -48,18 +52,20 @@ Reddit Ads source allows ingesting the following sources into separate tables:
 
 | Table | PK | Inc Key | Inc Strategy | Details |
 | ----- | -- | ------- | ------------ | ------- |
-| [accounts](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves all ad accounts accessible by the authenticated user. |
-| [campaigns](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves campaigns for each ad account. |
-| [ad_groups](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves ad groups for each ad account. |
-| [ads](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves ads for each ad account. |
-| [posts](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves ad posts (creatives) for each ad account. |
-| [custom_audiences](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves custom audiences for targeting. |
-| [saved_audiences](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves saved audience configurations. |
-| [pixels](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves conversion tracking pixels. |
-| [funding_instruments](https://ads-api.reddit.com/docs/v3/) | id | - | replace | Retrieves funding instruments (payment methods) for each ad account. |
-| [custom](https://ads-api.reddit.com/docs/v3/) | [level_id, breakdowns] | date | merge | Custom reports allow you to retrieve performance data based on specific levels, breakdowns, and metrics. |
+| accounts | id | modified_at | merge | Retrieves the ad accounts listed in `account_ids`. |
+| campaigns | id | modified_at | merge | Retrieves campaigns for each ad account. |
+| ad_groups | id | modified_at | merge | Retrieves ad groups for each ad account. |
+| ads | id | modified_at | merge | Retrieves ads for each ad account. |
+| custom_audiences | id | modified_at | merge | Retrieves custom audiences for targeting. |
+| saved_audiences | id | updated_at | merge | Retrieves saved audience configurations. |
+| pixels | id | modified_at | merge | Retrieves conversion tracking pixels. |
+| funding_instruments | id | - | replace | Retrieves funding instruments (payment methods) for each ad account. |
+| custom | [level_id, breakdowns] | date | merge | Custom reports of performance metrics by level, breakdowns, and metrics. |
 
 Use these as `--source-table` parameter in the `ingestr ingest` command.
+
+> [!NOTE]
+> The entity tables (except `funding_instruments`) are filtered client-side on their modification timestamp (`modified_at`, or `updated_at` for `saved_audiences`) when `--interval-start`/`--interval-end` are provided, and use a `merge` write disposition keyed on `id`. With no interval, all records are loaded. `funding_instruments` has no modification timestamp, so it is always fully replaced.
 
 ### Example
 

--- a/docs/supported-sources/reddit_ads.md
+++ b/docs/supported-sources/reddit_ads.md
@@ -17,9 +17,6 @@ Reddit Ads requires an `access_token` and `account_ids` to retrieve data from th
 
 ### Create a Reddit developer application to obtain an access token
 
-> [!IMPORTANT]
-> The Reddit Ads API only works with applications created through **Reddit Business Manager**. Legacy apps created at `reddit.com/prefs/apps` are **not** authorized for the Ads API — authorization succeeds but the token request fails with `403` when the `adsread` scope is requested.
-
 1. Go to the [Reddit Ads Dashboard](https://ads.reddit.com/) and log in with an account that has access to your ad accounts.
 2. Open **Business Manager** from the account menu, then select **Developer Applications**.
 3. Click **Create a new app** and fill out the form:

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -339,6 +339,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("pubsub", "Pub/Sub", []string{"pubsub"}, true, false),
 		genericURIConnector("quickbooks", "QuickBooks", []string{"quickbooks"}, true, false),
 		genericURIConnector("rabbitmq", "RabbitMQ", []string{"amqp", "amqps"}, true, false),
+		genericURIConnector("redditads", "Reddit Ads", []string{"redditads"}, true, false),
 		genericURIConnector("redis", "Redis Streams", []string{"redis", "rediss"}, true, false),
 		genericURIConnector("redshift", "Redshift", []string{"redshift", "redshift+psycopg2"}, true, true),
 		genericURIConnector("revenuecat", "RevenueCat", []string{"revenuecat"}, true, false),

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -497,6 +498,7 @@ func joinMapKeys(m map[string]bool) string {
 	for k := range m {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	return strings.Join(keys, ", ")
 }
 

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -720,19 +720,21 @@ func (s *RedditAdsSource) fetchReport(ctx context.Context, accountID, level stri
 	// Reddit Ads API v3 reports group by "breakdowns"; the level (account/campaign/
 	// ad_group/ad) is the first breakdown dimension. Metrics go into "fields".
 	// Breakdown/field enums are uppercase (the API is case-insensitive but we
-	// normalize). Dates must be RFC3339 date-times.
+	// normalize).
 	reqBreakdowns := make([]string, 0, len(breakdowns)+1)
 	reqBreakdowns = append(reqBreakdowns, strings.ToUpper(levelIDFields[level]))
 	for _, b := range breakdowns {
 		reqBreakdowns = append(reqBreakdowns, strings.ToUpper(b))
 	}
 
+	// starts_at/ends_at must be hourly-aligned RFC3339 (YYYY-MM-DDTHH:00:00Z) — the
+	// API rejects any non-zero minute/second with 400. Truncate to the hour.
 	body := map[string]interface{}{
 		"data": map[string]interface{}{
 			"breakdowns": reqBreakdowns,
 			"fields":     metrics,
-			"starts_at":  startDate.UTC().Format("2006-01-02T15:00:00Z"),
-			"ends_at":    endDate.UTC().Format("2006-01-02T15:00:00Z"),
+			"starts_at":  startDate.UTC().Truncate(time.Hour).Format(time.RFC3339),
+			"ends_at":    endDate.UTC().Truncate(time.Hour).Format(time.RFC3339),
 		},
 	}
 

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -26,7 +26,8 @@ const (
 
 	// Reddit does not publish numeric Ads API rate limits; it returns 429 with
 	// X-RateLimit-Remaining/-Reset headers. We throttle conservatively client-side
-	// (~0.8 req/s) and rely on the shared http client's retry-on-429 as a backstop.
+	// (~0.8 req/s) and rely on the shared http client's retry-on-429 as a backstop
+	// (enabled for POST via WithAllowNonIdempotentRetry in Connect).
 	rateLimit      = 0.8
 	rateLimitBurst = 5
 
@@ -132,6 +133,10 @@ func (s *RedditAdsSource) Connect(ctx context.Context, uri string) error {
 		httpclient.WithDebug(config.DebugMode),
 		httpclient.WithAuth(httpclient.NewBearerAuth(s.accessToken)),
 		httpclient.WithUserAgent(userAgent),
+		// The reports endpoint is a POST; every request this source makes is a
+		// read with no side effects, so allow retrying POSTs (otherwise resty
+		// skips the 429/5xx retry for non-idempotent methods).
+		httpclient.WithAllowNonIdempotentRetry(),
 	)
 
 	config.Debug("[REDDITADS] Connected successfully (accounts: %s)", strings.Join(s.accountIDs, ", "))

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -243,13 +244,7 @@ func (s *RedditAdsSource) getCustomReportTable(tableName string) (source.SourceT
 	levelIDField := levelIDFields[level]
 	primaryKeys := append([]string{levelIDField}, breakdowns...)
 
-	hasDateBreakdown := false
-	for _, b := range breakdowns {
-		if b == "date" {
-			hasDateBreakdown = true
-			break
-		}
-	}
+	hasDateBreakdown := slices.Contains(breakdowns, "date")
 
 	incrementalKey := ""
 	strategy := config.StrategyMerge
@@ -273,12 +268,7 @@ func (s *RedditAdsSource) getCustomReportTable(tableName string) (source.SourceT
 }
 
 func isValidEntityTable(table string) bool {
-	for _, t := range entityTables {
-		if t == table {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(entityTables, table)
 }
 
 func (s *RedditAdsSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -325,15 +315,15 @@ func jsonUseNumber(data []byte, v any) error {
 	return dec.Decode(v)
 }
 
-func extractItems(body map[string]interface{}) []map[string]interface{} {
-	dataRaw, ok := body["data"].([]interface{})
+func extractItems(body map[string]any) []map[string]any {
+	dataRaw, ok := body["data"].([]any)
 	if !ok {
 		return nil
 	}
 
-	items := make([]map[string]interface{}, 0, len(dataRaw))
+	items := make([]map[string]any, 0, len(dataRaw))
 	for _, d := range dataRaw {
-		if item, ok := d.(map[string]interface{}); ok {
+		if item, ok := d.(map[string]any); ok {
 			items = append(items, item)
 		}
 	}
@@ -343,12 +333,12 @@ func extractItems(body map[string]interface{}) []map[string]interface{} {
 // filterItemsByInterval keeps items whose incrementalKey timestamp falls within
 // [start, end]. Items missing the key are kept (so tables without the field are
 // unaffected). A no-op when no key or no interval is set.
-func filterItemsByInterval(items []map[string]interface{}, incrementalKey string, start, end *time.Time) []map[string]interface{} {
+func filterItemsByInterval(items []map[string]any, incrementalKey string, start, end *time.Time) []map[string]any {
 	if incrementalKey == "" || (start == nil && end == nil) {
 		return items
 	}
 
-	filtered := make([]map[string]interface{}, 0, len(items))
+	filtered := make([]map[string]any, 0, len(items))
 	for _, item := range items {
 		raw, ok := item[incrementalKey]
 		if !ok || raw == nil {
@@ -372,7 +362,7 @@ func filterItemsByInterval(items []map[string]interface{}, incrementalKey string
 	return filtered
 }
 
-func parseTimestamp(v interface{}) (time.Time, bool) {
+func parseTimestamp(v any) (time.Time, bool) {
 	switch t := v.(type) {
 	case time.Time:
 		return t, true
@@ -389,27 +379,27 @@ func parseTimestamp(v interface{}) (time.Time, bool) {
 // extractReportItems pulls the rows from a v3 report response, where the
 // records live under data.metrics (unlike entity endpoints, where data is the
 // array itself).
-func extractReportItems(body map[string]interface{}) []map[string]interface{} {
-	data, ok := body["data"].(map[string]interface{})
+func extractReportItems(body map[string]any) []map[string]any {
+	data, ok := body["data"].(map[string]any)
 	if !ok {
 		return nil
 	}
-	metricsRaw, ok := data["metrics"].([]interface{})
+	metricsRaw, ok := data["metrics"].([]any)
 	if !ok {
 		return nil
 	}
 
-	items := make([]map[string]interface{}, 0, len(metricsRaw))
+	items := make([]map[string]any, 0, len(metricsRaw))
 	for _, m := range metricsRaw {
-		if item, ok := m.(map[string]interface{}); ok {
+		if item, ok := m.(map[string]any); ok {
 			items = append(items, item)
 		}
 	}
 	return items
 }
 
-func getNextURL(body map[string]interface{}) string {
-	pagination, ok := body["pagination"].(map[string]interface{})
+func getNextURL(body map[string]any) string {
+	pagination, ok := body["pagination"].(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -420,7 +410,7 @@ func getNextURL(body map[string]interface{}) string {
 	return nextURL
 }
 
-func convertMicrocurrency(items []map[string]interface{}, metrics []string) {
+func convertMicrocurrency(items []map[string]any, metrics []string) {
 	requested := make(map[string]bool)
 	for _, m := range metrics {
 		requested[strings.ToLower(m)] = true
@@ -507,7 +497,7 @@ func joinMapKeys(m map[string]bool) string {
 func (s *RedditAdsSource) readAccounts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[REDDITADS] reading accounts")
 
-	items := make([]map[string]interface{}, 0, len(s.accountIDs))
+	items := make([]map[string]any, 0, len(s.accountIDs))
 	for _, accountID := range s.accountIDs {
 		select {
 		case <-ctx.Done():
@@ -524,12 +514,12 @@ func (s *RedditAdsSource) readAccounts(ctx context.Context, opts source.ReadOpti
 			return fmt.Errorf("redditads API /ad_accounts/%s returned status %d: %s", accountID, resp.StatusCode(), resp.String())
 		}
 
-		var body map[string]interface{}
+		var body map[string]any
 		if err := jsonUseNumber(resp.Body(), &body); err != nil {
 			return fmt.Errorf("failed to parse ad account response: %w", err)
 		}
 
-		if item, ok := body["data"].(map[string]interface{}); ok {
+		if item, ok := body["data"].(map[string]any); ok {
 			items = append(items, item)
 		}
 	}
@@ -561,7 +551,14 @@ func (s *RedditAdsSource) readPerAccount(ctx context.Context, endpoint, label st
 	for _, accountID := range s.accountIDs {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			mu.Unlock()
+			// Stop spawning, but wait for already-running goroutines below so
+			// none send on results after the caller closes the channel.
+			goto done
 		default:
 		}
 
@@ -581,6 +578,7 @@ func (s *RedditAdsSource) readPerAccount(ctx context.Context, endpoint, label st
 		}(accountID)
 	}
 
+done:
 	wg.Wait()
 	return firstErr
 }
@@ -616,7 +614,7 @@ func (s *RedditAdsSource) paginateEntity(ctx context.Context, accountID, endpoin
 			return fmt.Errorf("redditads API %s returned status %d: %s", fullEndpoint, resp.StatusCode(), resp.String())
 		}
 
-		var body map[string]interface{}
+		var body map[string]any
 		if err := jsonUseNumber(resp.Body(), &body); err != nil {
 			return fmt.Errorf("failed to parse %s response: %w", label, err)
 		}
@@ -686,8 +684,14 @@ func (s *RedditAdsSource) readCustomReport(ctx context.Context, level string, br
 		for _, accountID := range s.accountIDs {
 			select {
 			case <-ctx.Done():
-				results <- source.RecordBatchResult{Err: ctx.Err()}
-				return
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = ctx.Err()
+				}
+				mu.Unlock()
+				// Stop spawning, but wait for in-flight goroutines below so none
+				// send on results after the deferred close.
+				goto done
 			default:
 			}
 
@@ -707,6 +711,7 @@ func (s *RedditAdsSource) readCustomReport(ctx context.Context, level string, br
 			}(accountID)
 		}
 
+	done:
 		wg.Wait()
 		if firstErr != nil {
 			results <- source.RecordBatchResult{Err: firstErr}
@@ -731,8 +736,8 @@ func (s *RedditAdsSource) fetchReport(ctx context.Context, accountID, level stri
 
 	// starts_at/ends_at must be hourly-aligned RFC3339 (YYYY-MM-DDTHH:00:00Z) — the
 	// API rejects any non-zero minute/second with 400. Truncate to the hour.
-	body := map[string]interface{}{
-		"data": map[string]interface{}{
+	body := map[string]any{
+		"data": map[string]any{
 			"breakdowns": reqBreakdowns,
 			"fields":     metrics,
 			"starts_at":  startDate.UTC().Truncate(time.Hour).Format(time.RFC3339),
@@ -757,7 +762,7 @@ func (s *RedditAdsSource) fetchReport(ctx context.Context, accountID, level stri
 		return fmt.Errorf("redditads API %s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
 	}
 
-	var respBody map[string]interface{}
+	var respBody map[string]any
 	if err := jsonUseNumber(resp.Body(), &respBody); err != nil {
 		return fmt.Errorf("failed to parse report response: %w", err)
 	}

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -1,0 +1,781 @@
+package redditads
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	baseURL   = "https://ads-api.reddit.com/api/v3"
+	userAgent = "ingestr/1.0"
+
+	// Reddit does not publish numeric Ads API rate limits; it returns 429 with
+	// X-RateLimit-Remaining/-Reset headers. We throttle conservatively client-side
+	// (~0.8 req/s) and rely on the shared http client's retry-on-429 as a backstop.
+	rateLimit      = 0.8
+	rateLimitBurst = 5
+
+	maxPageSize = 100
+	maxPages    = 1000
+	workerCount = 5
+)
+
+var monetaryFields = map[string]bool{
+	"spend": true,
+	"ecpm":  true,
+	"cpc":   true,
+}
+
+var entityTables = []string{
+	"accounts",
+	"campaigns",
+	"ad_groups",
+	"ads",
+	"custom_audiences",
+	"saved_audiences",
+	"pixels",
+	"funding_instruments",
+}
+
+// entityIncrementalKey maps each entity table to the timestamp field its objects
+// carry (verified against live API responses). These use client-side interval
+// filtering + merge (Reddit exposes no server-side time filter on entity
+// endpoints). saved_audiences uses updated_at; every other entity uses
+// modified_at. Tables absent here (funding_instruments has only
+// start_time/end_time) use a full replace.
+var entityIncrementalKey = map[string]string{
+	"accounts":         "modified_at",
+	"campaigns":        "modified_at",
+	"ad_groups":        "modified_at",
+	"ads":              "modified_at",
+	"custom_audiences": "modified_at",
+	"saved_audiences":  "updated_at",
+	"pixels":           "modified_at",
+}
+
+var levelIDFields = map[string]string{
+	"ACCOUNT":  "account_id",
+	"CAMPAIGN": "campaign_id",
+	"AD_GROUP": "ad_group_id",
+	"AD":       "ad_id",
+}
+
+var validLevels = map[string]bool{
+	"ACCOUNT": true, "CAMPAIGN": true, "AD_GROUP": true, "AD": true,
+}
+
+var validBreakdowns = map[string]bool{
+	"date": true, "country": true, "region": true, "community": true,
+	"placement": true, "device_os": true, "gender": true, "interest": true,
+	"keyword": true, "carousel_card": true,
+}
+
+var validMetrics = map[string]bool{
+	"IMPRESSIONS": true, "REACH": true, "CLICKS": true, "SPEND": true,
+	"ECPM": true, "CTR": true, "CPC": true, "CONVERSIONS": true,
+	"CONVERSION_ROAS": true, "TOTAL_ITEMS": true, "TOTAL_VALUE": true,
+	"AVG_VALUE": true, "REDDIT_LEADS": true, "COMMENTS_PAGE_VIEWS": true,
+	"COMMENT_UPVOTES": true, "COMMENT_DOWNVOTES": true, "VIEWER_COMMENTS": true,
+	"VIDEO_STARTED": true, "VIDEO_WATCHED_3_SECONDS": true,
+	"VIDEO_WATCHED_5_SECONDS": true, "VIDEO_WATCHED_25_PERCENT": true,
+	"VIDEO_WATCHED_50_PERCENT": true, "VIDEO_WATCHED_75_PERCENT": true,
+	"VIDEO_WATCHED_100_PERCENT": true, "VIDEO_WATCHED_6_SECONDS_RATE": true,
+	"VIDEO_WATCHED_15_SECONDS_RATE": true,
+}
+
+type RedditAdsSource struct {
+	accessToken string
+	accountIDs  []string
+	client      *httpclient.Client
+}
+
+func NewRedditAdsSource() *RedditAdsSource {
+	return &RedditAdsSource{}
+}
+
+func (s *RedditAdsSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *RedditAdsSource) Schemes() []string {
+	return []string{"redditads"}
+}
+
+func (s *RedditAdsSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.accessToken = creds.accessToken
+	s.accountIDs = creds.accountIDs
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(httpclient.NewBearerAuth(s.accessToken)),
+		httpclient.WithUserAgent(userAgent),
+	)
+
+	config.Debug("[REDDITADS] Connected successfully (accounts: %s)", strings.Join(s.accountIDs, ", "))
+	return nil
+}
+
+func (s *RedditAdsSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+type redditAdsCredentials struct {
+	accessToken string
+	accountIDs  []string
+}
+
+func parseURI(uri string) (*redditAdsCredentials, error) {
+	if !strings.HasPrefix(uri, "redditads://") {
+		return nil, fmt.Errorf("invalid redditads URI: must start with redditads://")
+	}
+
+	rest := strings.TrimPrefix(uri, "redditads://")
+	if rest == "" || rest == "?" {
+		return nil, fmt.Errorf("access_token is required in redditads URI")
+	}
+
+	rest = strings.TrimPrefix(rest, "?")
+
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse redditads URI query: %w", err)
+	}
+
+	accessToken := values.Get("access_token")
+	if accessToken == "" {
+		return nil, fmt.Errorf("access_token is required in redditads URI")
+	}
+
+	accountIDsRaw := values.Get("account_ids")
+	if accountIDsRaw == "" {
+		return nil, fmt.Errorf("account_ids is required in redditads URI")
+	}
+
+	accountIDs := splitAndTrim(accountIDsRaw, ",")
+	if len(accountIDs) == 0 {
+		return nil, fmt.Errorf("account_ids must contain at least one account ID")
+	}
+
+	return &redditAdsCredentials{
+		accessToken: accessToken,
+		accountIDs:  accountIDs,
+	}, nil
+}
+
+func splitAndTrim(s string, sep string) []string {
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func (s *RedditAdsSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName := req.Name
+
+	if strings.HasPrefix(tableName, "custom:") {
+		return s.getCustomReportTable(tableName)
+	}
+
+	if !isValidEntityTable(tableName) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s, or custom:<level>,<breakdowns>:<metrics>)", tableName, strings.Join(entityTables, ", "))
+	}
+
+	// Reddit entity endpoints expose no server-side time filter, but most objects
+	// carry a modified_at timestamp, so those tables filter client-side and merge.
+	// Tables without it (e.g. funding_instruments) fall back to a full replace.
+	strategy := config.StrategyReplace
+	incrementalKey := entityIncrementalKey[tableName]
+	if incrementalKey != "" {
+		strategy = config.StrategyMerge
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    []string{"id"},
+		TableStrategy:       strategy,
+		TableIncrementalKey: incrementalKey,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("redditads source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, opts)
+		},
+	}, nil
+}
+
+func (s *RedditAdsSource) getCustomReportTable(tableName string) (source.SourceTable, error) {
+	level, breakdowns, metrics, err := parseCustomTable(tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	levelIDField := levelIDFields[level]
+	primaryKeys := append([]string{levelIDField}, breakdowns...)
+
+	hasDateBreakdown := false
+	for _, b := range breakdowns {
+		if b == "date" {
+			hasDateBreakdown = true
+			break
+		}
+	}
+
+	incrementalKey := ""
+	strategy := config.StrategyMerge
+	if hasDateBreakdown {
+		incrementalKey = "date"
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           "custom_reports",
+		TablePrimaryKeys:    primaryKeys,
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("redditads source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.readCustomReport(ctx, level, breakdowns, metrics, opts)
+		},
+	}, nil
+}
+
+func isValidEntityTable(table string) bool {
+	for _, t := range entityTables {
+		if t == table {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *RedditAdsSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "accounts":
+			err = s.readAccounts(ctx, opts, results)
+		case "campaigns":
+			err = s.readPerAccount(ctx, "/campaigns", "campaigns", opts, results)
+		case "ad_groups":
+			err = s.readPerAccount(ctx, "/ad_groups", "ad_groups", opts, results)
+		case "ads":
+			err = s.readPerAccount(ctx, "/ads", "ads", opts, results)
+		case "custom_audiences":
+			err = s.readPerAccount(ctx, "/custom_audiences", "custom_audiences", opts, results)
+		case "saved_audiences":
+			err = s.readPerAccount(ctx, "/saved_audiences", "saved_audiences", opts, results)
+		case "pixels":
+			err = s.readPerAccount(ctx, "/pixels", "pixels", opts, results)
+		case "funding_instruments":
+			err = s.readPerAccount(ctx, "/funding_instruments", "funding_instruments", opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", table)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+// --- helpers ---
+
+func jsonUseNumber(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+func extractItems(body map[string]interface{}) []map[string]interface{} {
+	dataRaw, ok := body["data"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	items := make([]map[string]interface{}, 0, len(dataRaw))
+	for _, d := range dataRaw {
+		if item, ok := d.(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+// filterItemsByInterval keeps items whose incrementalKey timestamp falls within
+// [start, end]. Items missing the key are kept (so tables without the field are
+// unaffected). A no-op when no key or no interval is set.
+func filterItemsByInterval(items []map[string]interface{}, incrementalKey string, start, end *time.Time) []map[string]interface{} {
+	if incrementalKey == "" || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		raw, ok := item[incrementalKey]
+		if !ok || raw == nil {
+			filtered = append(filtered, item)
+			continue
+		}
+
+		t, ok := parseTimestamp(raw)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && t.Before(*start) {
+			continue
+		}
+		if end != nil && t.After(*end) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func parseTimestamp(v interface{}) (time.Time, bool) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, true
+	case string:
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			return parsed, true
+		}
+		return time.Time{}, false
+	default:
+		return time.Time{}, false
+	}
+}
+
+// extractReportItems pulls the rows from a v3 report response, where the
+// records live under data.metrics (unlike entity endpoints, where data is the
+// array itself).
+func extractReportItems(body map[string]interface{}) []map[string]interface{} {
+	data, ok := body["data"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	metricsRaw, ok := data["metrics"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	items := make([]map[string]interface{}, 0, len(metricsRaw))
+	for _, m := range metricsRaw {
+		if item, ok := m.(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func getNextURL(body map[string]interface{}) string {
+	pagination, ok := body["pagination"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	nextURL, ok := pagination["next_url"].(string)
+	if !ok {
+		return ""
+	}
+	return nextURL
+}
+
+func convertMicrocurrency(items []map[string]interface{}, metrics []string) {
+	requested := make(map[string]bool)
+	for _, m := range metrics {
+		requested[strings.ToLower(m)] = true
+	}
+
+	for _, item := range items {
+		for field := range monetaryFields {
+			if !requested[field] {
+				continue
+			}
+			val, ok := item[field]
+			if !ok || val == nil {
+				continue
+			}
+			switch v := val.(type) {
+			case json.Number:
+				f, err := v.Float64()
+				if err == nil {
+					item[field] = f / 1_000_000
+				}
+			case float64:
+				item[field] = v / 1_000_000
+			}
+		}
+	}
+}
+
+func parseCustomTable(table string) (level string, breakdowns []string, metrics []string, err error) {
+	parts := strings.Split(table, ":")
+	if len(parts) != 3 {
+		return "", nil, nil, fmt.Errorf("invalid custom table format: expected custom:<level>,<breakdowns>:<metrics>")
+	}
+
+	dimensions := splitAndTrim(parts[1], ",")
+	if len(dimensions) == 0 {
+		return "", nil, nil, fmt.Errorf("at least a level is required in the dimensions segment")
+	}
+
+	level = strings.ToUpper(dimensions[0])
+	if !validLevels[level] {
+		return "", nil, nil, fmt.Errorf("invalid level %q: must be one of ACCOUNT, CAMPAIGN, AD_GROUP, AD", level)
+	}
+
+	breakdowns = make([]string, 0, len(dimensions)-1)
+	for _, b := range dimensions[1:] {
+		b = strings.ToLower(b)
+		if !validBreakdowns[b] {
+			return "", nil, nil, fmt.Errorf("invalid breakdown %q: must be one of %s", b, joinMapKeys(validBreakdowns))
+		}
+		breakdowns = append(breakdowns, b)
+	}
+
+	if len(breakdowns) > 2 {
+		return "", nil, nil, fmt.Errorf("reddit ads supports at most 2 breakdowns per report")
+	}
+
+	metrics = make([]string, 0)
+	for _, m := range splitAndTrim(parts[2], ",") {
+		m = strings.ToUpper(m)
+		if !validMetrics[m] {
+			return "", nil, nil, fmt.Errorf("invalid metric %q: must be one of %s", m, joinMapKeys(validMetrics))
+		}
+		metrics = append(metrics, m)
+	}
+
+	if len(metrics) == 0 {
+		return "", nil, nil, fmt.Errorf("at least one metric is required")
+	}
+
+	return level, breakdowns, metrics, nil
+}
+
+func joinMapKeys(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
+}
+
+// --- entity table readers ---
+
+func (s *RedditAdsSource) readAccounts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[REDDITADS] reading accounts")
+
+	items := make([]map[string]interface{}, 0, len(s.accountIDs))
+	for _, accountID := range s.accountIDs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		resp, err := s.client.R(ctx).Get("/ad_accounts/" + accountID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch ad account %s: %w", accountID, err)
+		}
+
+		if !resp.IsSuccess() {
+			return fmt.Errorf("redditads API /ad_accounts/%s returned status %d: %s", accountID, resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]interface{}
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse ad account response: %w", err)
+		}
+
+		if item, ok := body["data"].(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+
+	items = filterItemsByInterval(items, entityIncrementalKey["accounts"], opts.IntervalStart, opts.IntervalEnd)
+	if len(items) == 0 {
+		config.Debug("[REDDITADS] No accounts found matching account_ids")
+		return nil
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert accounts to Arrow: %w", err)
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	config.Debug("[REDDITADS] accounts: sent %d records", len(items))
+	return nil
+}
+
+// readPerAccount fetches a paginated sub-resource for each account in parallel.
+func (s *RedditAdsSource) readPerAccount(ctx context.Context, endpoint, label string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[REDDITADS] reading %s", label)
+
+	sem := make(chan struct{}, workerCount)
+	var mu sync.Mutex
+	var firstErr error
+
+	var wg sync.WaitGroup
+	for _, accountID := range s.accountIDs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(acctID string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if err := s.paginateEntity(ctx, acctID, endpoint, label, opts, results); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(accountID)
+	}
+
+	wg.Wait()
+	return firstErr
+}
+
+func (s *RedditAdsSource) paginateEntity(ctx context.Context, accountID, endpoint, label string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	fullEndpoint := fmt.Sprintf("/ad_accounts/%s%s", accountID, endpoint)
+	currentURL := ""
+	page := 1
+	totalSent := 0
+
+	for page <= maxPages {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		var resp *httpclient.Response
+		var err error
+
+		if currentURL != "" {
+			resp, err = s.client.R(ctx).Get(currentURL)
+		} else {
+			resp, err = s.client.R(ctx).
+				SetQueryParam("page_size", strconv.Itoa(maxPageSize)).
+				Get(fullEndpoint)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s for account %s: %w", label, accountID, err)
+		}
+
+		if !resp.IsSuccess() {
+			return fmt.Errorf("redditads API %s returned status %d: %s", fullEndpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]interface{}
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", label, err)
+		}
+
+		items := extractItems(body)
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			item["account_id"] = accountID
+		}
+
+		// Client-side interval filtering (no server-side time filter on these
+		// endpoints). Pagination still follows the unfiltered next_url so a page
+		// with no in-range rows doesn't stop the scan early.
+		filtered := filterItemsByInterval(items, entityIncrementalKey[label], opts.IntervalStart, opts.IntervalEnd)
+		if len(filtered) > 0 {
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(filtered, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", label, err)
+			}
+
+			results <- source.RecordBatchResult{Batch: record}
+			totalSent += len(filtered)
+			config.Debug("[REDDITADS] %s (account %s) page %d: sent %d records (total: %d)", label, accountID, page, len(filtered), totalSent)
+		}
+
+		nextURL := getNextURL(body)
+		if nextURL == "" {
+			break
+		}
+		if page >= maxPages {
+			config.Debug("[REDDITADS] %s (account %s) hit maxPages cap (%d); more pages may exist", label, accountID, maxPages)
+			break
+		}
+		currentURL = nextURL
+		page++
+	}
+
+	return nil
+}
+
+// --- custom report reader ---
+
+func (s *RedditAdsSource) readCustomReport(ctx context.Context, level string, breakdowns, metrics []string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		startDate := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		endDate := time.Now().UTC()
+
+		if opts.IntervalStart != nil {
+			startDate = opts.IntervalStart.UTC()
+		}
+		if opts.IntervalEnd != nil {
+			endDate = opts.IntervalEnd.UTC()
+		}
+
+		sem := make(chan struct{}, workerCount)
+		var mu sync.Mutex
+		var firstErr error
+
+		var wg sync.WaitGroup
+		for _, accountID := range s.accountIDs {
+			select {
+			case <-ctx.Done():
+				results <- source.RecordBatchResult{Err: ctx.Err()}
+				return
+			default:
+			}
+
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(acctID string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				if err := s.fetchReport(ctx, acctID, level, breakdowns, metrics, startDate, endDate, opts, results); err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+				}
+			}(accountID)
+		}
+
+		wg.Wait()
+		if firstErr != nil {
+			results <- source.RecordBatchResult{Err: firstErr}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *RedditAdsSource) fetchReport(ctx context.Context, accountID, level string, breakdowns, metrics []string, startDate, endDate time.Time, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	endpoint := fmt.Sprintf("/ad_accounts/%s/reports", accountID)
+
+	// Reddit Ads API v3 reports group by "breakdowns"; the level (account/campaign/
+	// ad_group/ad) is the first breakdown dimension. Metrics go into "fields".
+	// Breakdown/field enums are uppercase (the API is case-insensitive but we
+	// normalize). Dates must be RFC3339 date-times.
+	reqBreakdowns := make([]string, 0, len(breakdowns)+1)
+	reqBreakdowns = append(reqBreakdowns, strings.ToUpper(levelIDFields[level]))
+	for _, b := range breakdowns {
+		reqBreakdowns = append(reqBreakdowns, strings.ToUpper(b))
+	}
+
+	body := map[string]interface{}{
+		"data": map[string]interface{}{
+			"breakdowns": reqBreakdowns,
+			"fields":     metrics,
+			"starts_at":  startDate.UTC().Format("2006-01-02T15:00:00Z"),
+			"ends_at":    endDate.UTC().Format("2006-01-02T15:00:00Z"),
+		},
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal report request: %w", err)
+	}
+
+	resp, err := s.client.R(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(jsonBody).
+		Post(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to fetch report for account %s: %w", accountID, err)
+	}
+
+	if !resp.IsSuccess() {
+		return fmt.Errorf("redditads API %s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+	}
+
+	var respBody map[string]interface{}
+	if err := jsonUseNumber(resp.Body(), &respBody); err != nil {
+		return fmt.Errorf("failed to parse report response: %w", err)
+	}
+
+	items := extractReportItems(respBody)
+	if len(items) == 0 {
+		config.Debug("[REDDITADS] No report data for account %s", accountID)
+		return nil
+	}
+
+	for _, item := range items {
+		item["account_id"] = accountID
+	}
+
+	convertMicrocurrency(items, metrics)
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert report data to Arrow: %w", err)
+	}
+
+	results <- source.RecordBatchResult{Batch: record}
+	config.Debug("[REDDITADS] report (account %s): sent %d records", accountID, len(items))
+	return nil
+}

--- a/pkg/source/redditads/redditads_test.go
+++ b/pkg/source/redditads/redditads_test.go
@@ -1,0 +1,536 @@
+package redditads
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestFilterItemsByInterval(t *testing.T) {
+	items := []map[string]interface{}{
+		{"id": "a", "modified_at": "2026-04-22T11:15:26Z"},
+		{"id": "b", "modified_at": "2020-01-01T00:00:00Z"},
+		{"id": "c"}, // no key -> always kept
+	}
+	tp := func(s string) *time.Time { v, _ := time.Parse(time.RFC3339, s); return &v }
+
+	t.Run("no key is a no-op", func(t *testing.T) {
+		if len(filterItemsByInterval(items, "", tp("2030-01-01T00:00:00Z"), nil)) != 3 {
+			t.Fatal("expected all 3")
+		}
+	})
+	t.Run("no interval is a no-op", func(t *testing.T) {
+		if len(filterItemsByInterval(items, "modified_at", nil, nil)) != 3 {
+			t.Fatal("expected all 3")
+		}
+	})
+	t.Run("start filters older rows, keeps missing-key rows", func(t *testing.T) {
+		got := filterItemsByInterval(items, "modified_at", tp("2026-01-01T00:00:00Z"), nil)
+		// a (2026) kept, b (2020) dropped, c (no key) kept
+		if len(got) != 2 {
+			t.Fatalf("expected 2, got %d", len(got))
+		}
+	})
+	t.Run("range after all data drops timestamped rows", func(t *testing.T) {
+		got := filterItemsByInterval(items, "modified_at", tp("2030-01-01T00:00:00Z"), tp("2030-12-31T00:00:00Z"))
+		// only c (no key) survives
+		if len(got) != 1 || got[0]["id"] != "c" {
+			t.Fatalf("expected only c, got %v", got)
+		}
+	})
+}
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name           string
+		uri            string
+		wantToken      string
+		wantAccountIDs []string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "valid URI with single account",
+			uri:            "redditads://?access_token=tok123&account_ids=acc1",
+			wantToken:      "tok123",
+			wantAccountIDs: []string{"acc1"},
+		},
+		{
+			name:           "valid URI with multiple accounts",
+			uri:            "redditads://?access_token=tok123&account_ids=acc1,acc2,acc3",
+			wantToken:      "tok123",
+			wantAccountIDs: []string{"acc1", "acc2", "acc3"},
+		},
+		{
+			name:           "trims whitespace in account IDs",
+			uri:            "redditads://?access_token=tok123&account_ids=acc1, acc2 , acc3",
+			wantToken:      "tok123",
+			wantAccountIDs: []string{"acc1", "acc2", "acc3"},
+		},
+		{
+			name:        "wrong scheme",
+			uri:         "clickup://?access_token=tok",
+			wantErr:     true,
+			errContains: "must start with redditads://",
+		},
+		{
+			name:        "missing access_token",
+			uri:         "redditads://?account_ids=acc1",
+			wantErr:     true,
+			errContains: "access_token is required",
+		},
+		{
+			name:        "missing account_ids",
+			uri:         "redditads://?access_token=tok123",
+			wantErr:     true,
+			errContains: "account_ids is required",
+		},
+		{
+			name:        "empty URI after scheme",
+			uri:         "redditads://",
+			wantErr:     true,
+			errContains: "access_token is required",
+		},
+		{
+			name:        "only question mark",
+			uri:         "redditads://?",
+			wantErr:     true,
+			errContains: "access_token is required",
+		},
+		{
+			name:           "token with special characters",
+			uri:            "redditads://?access_token=abc.DEF-123_456&account_ids=id1",
+			wantToken:      "abc.DEF-123_456",
+			wantAccountIDs: []string{"id1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := parseURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errContains)
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if creds.accessToken != tt.wantToken {
+				t.Fatalf("expected token %q, got %q", tt.wantToken, creds.accessToken)
+			}
+			if len(creds.accountIDs) != len(tt.wantAccountIDs) {
+				t.Fatalf("expected %d account IDs, got %d", len(tt.wantAccountIDs), len(creds.accountIDs))
+			}
+			for i, want := range tt.wantAccountIDs {
+				if creds.accountIDs[i] != want {
+					t.Fatalf("account ID[%d]: expected %q, got %q", i, want, creds.accountIDs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidEntityTable(t *testing.T) {
+	validTables := []string{
+		"accounts", "campaigns", "ad_groups", "ads",
+		"custom_audiences", "saved_audiences", "pixels", "funding_instruments",
+	}
+	for _, table := range validTables {
+		if !isValidEntityTable(table) {
+			t.Errorf("expected %q to be valid", table)
+		}
+	}
+
+	invalidTables := []string{"", "unknown", "ACCOUNTS", "Campaigns", "users", "custom:"}
+	for _, table := range invalidTables {
+		if isValidEntityTable(table) {
+			t.Errorf("expected %q to be invalid", table)
+		}
+	}
+}
+
+func TestParseCustomTable(t *testing.T) {
+	tests := []struct {
+		name           string
+		table          string
+		wantLevel      string
+		wantBreakdowns []string
+		wantMetrics    []string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "basic campaign with date breakdown",
+			table:          "custom:campaign,date:impressions,clicks,spend",
+			wantLevel:      "CAMPAIGN",
+			wantBreakdowns: []string{"date"},
+			wantMetrics:    []string{"IMPRESSIONS", "CLICKS", "SPEND"},
+		},
+		{
+			name:           "multiple breakdowns",
+			table:          "custom:ad_group,date,country:impressions",
+			wantLevel:      "AD_GROUP",
+			wantBreakdowns: []string{"date", "country"},
+			wantMetrics:    []string{"IMPRESSIONS"},
+		},
+		{
+			name:           "no breakdowns",
+			table:          "custom:account:spend,impressions",
+			wantLevel:      "ACCOUNT",
+			wantBreakdowns: []string{},
+			wantMetrics:    []string{"SPEND", "IMPRESSIONS"},
+		},
+		{
+			name:           "ad level",
+			table:          "custom:ad,date:impressions,clicks",
+			wantLevel:      "AD",
+			wantBreakdowns: []string{"date"},
+			wantMetrics:    []string{"IMPRESSIONS", "CLICKS"},
+		},
+		{
+			name:           "normalizes breakdown case",
+			table:          "custom:campaign,Date,COUNTRY:impressions",
+			wantLevel:      "CAMPAIGN",
+			wantBreakdowns: []string{"date", "country"},
+			wantMetrics:    []string{"IMPRESSIONS"},
+		},
+		{
+			name:        "too many breakdowns",
+			table:       "custom:campaign,date,country,region:impressions",
+			wantErr:     true,
+			errContains: "at most 2 breakdowns",
+		},
+		{
+			name:           "preserves breakdown order",
+			table:          "custom:campaign,country,date:impressions",
+			wantLevel:      "CAMPAIGN",
+			wantBreakdowns: []string{"country", "date"},
+			wantMetrics:    []string{"IMPRESSIONS"},
+		},
+		{
+			name:        "invalid level",
+			table:       "custom:invalid,date:impressions",
+			wantErr:     true,
+			errContains: "invalid level",
+		},
+		{
+			name:        "invalid breakdown",
+			table:       "custom:campaign,invalid_dim:impressions",
+			wantErr:     true,
+			errContains: "invalid breakdown",
+		},
+		{
+			name:        "invalid metric",
+			table:       "custom:campaign,date:IMPRESIONS",
+			wantErr:     true,
+			errContains: "invalid metric",
+		},
+		{
+			name:        "missing metrics",
+			table:       "custom:campaign,date:",
+			wantErr:     true,
+			errContains: "at least one metric",
+		},
+		{
+			name:        "too few parts",
+			table:       "custom:campaign",
+			wantErr:     true,
+			errContains: "invalid custom table format",
+		},
+		{
+			name:        "too many parts",
+			table:       "custom:campaign:impressions:extra",
+			wantErr:     true,
+			errContains: "invalid custom table format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, breakdowns, metrics, err := parseCustomTable(tt.table)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errContains)
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if level != tt.wantLevel {
+				t.Fatalf("expected level %q, got %q", tt.wantLevel, level)
+			}
+			if len(breakdowns) != len(tt.wantBreakdowns) {
+				t.Fatalf("expected %d breakdowns, got %d", len(tt.wantBreakdowns), len(breakdowns))
+			}
+			for i, want := range tt.wantBreakdowns {
+				if breakdowns[i] != want {
+					t.Fatalf("breakdown[%d]: expected %q, got %q", i, want, breakdowns[i])
+				}
+			}
+			if len(metrics) != len(tt.wantMetrics) {
+				t.Fatalf("expected %d metrics, got %d", len(tt.wantMetrics), len(metrics))
+			}
+			for i, want := range tt.wantMetrics {
+				if metrics[i] != want {
+					t.Fatalf("metric[%d]: expected %q, got %q", i, want, metrics[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConvertMicrocurrency(t *testing.T) {
+	t.Run("converts monetary fields", func(t *testing.T) {
+		items := []map[string]interface{}{
+			{"spend": json.Number("5000000"), "impressions": json.Number("100"), "ecpm": json.Number("1500000"), "cpc": json.Number("250000")},
+		}
+		convertMicrocurrency(items, []string{"SPEND", "ECPM", "CPC"})
+		if items[0]["spend"] != 5.0 {
+			t.Fatalf("expected spend=5.0, got %v", items[0]["spend"])
+		}
+		if items[0]["ecpm"] != 1.5 {
+			t.Fatalf("expected ecpm=1.5, got %v", items[0]["ecpm"])
+		}
+		if items[0]["cpc"] != 0.25 {
+			t.Fatalf("expected cpc=0.25, got %v", items[0]["cpc"])
+		}
+		if items[0]["impressions"] != json.Number("100") {
+			t.Fatalf("expected impressions unchanged, got %v", items[0]["impressions"])
+		}
+	})
+
+	t.Run("no monetary fields in metrics", func(t *testing.T) {
+		items := []map[string]interface{}{
+			{"impressions": json.Number("100"), "clicks": json.Number("10")},
+		}
+		convertMicrocurrency(items, []string{"IMPRESSIONS", "CLICKS"})
+		if items[0]["impressions"] != json.Number("100") {
+			t.Fatalf("expected impressions unchanged, got %v", items[0]["impressions"])
+		}
+	})
+
+	t.Run("handles nil values", func(t *testing.T) {
+		items := []map[string]interface{}{
+			{"spend": nil, "impressions": json.Number("100")},
+		}
+		convertMicrocurrency(items, []string{"SPEND"})
+		if items[0]["spend"] != nil {
+			t.Fatalf("expected spend=nil, got %v", items[0]["spend"])
+		}
+	})
+}
+
+func TestJsonUseNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		check   func(t *testing.T, result map[string]interface{})
+		wantErr bool
+	}{
+		{
+			name:  "large integer preserved",
+			input: `{"id": 286537310, "big_id": 9007199254740993}`,
+			check: func(t *testing.T, result map[string]interface{}) {
+				id, ok := result["id"].(json.Number)
+				if !ok {
+					t.Fatalf("expected json.Number, got %T", result["id"])
+				}
+				if id.String() != "286537310" {
+					t.Fatalf("expected 286537310, got %s", id.String())
+				}
+				bigID, ok := result["big_id"].(json.Number)
+				if !ok {
+					t.Fatalf("expected json.Number for big_id, got %T", result["big_id"])
+				}
+				if bigID.String() != "9007199254740993" {
+					t.Fatalf("expected 9007199254740993, got %s", bigID.String())
+				}
+			},
+		},
+		{
+			name:  "float preserved",
+			input: `{"score": 3.14}`,
+			check: func(t *testing.T, result map[string]interface{}) {
+				score, ok := result["score"].(json.Number)
+				if !ok {
+					t.Fatalf("expected json.Number, got %T", result["score"])
+				}
+				f, err := score.Float64()
+				if err != nil {
+					t.Fatalf("failed to convert to float64: %v", err)
+				}
+				if f != 3.14 {
+					t.Fatalf("expected 3.14, got %f", f)
+				}
+			},
+		},
+		{
+			name:    "invalid JSON returns error",
+			input:   `{"broken":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result map[string]interface{}
+			err := jsonUseNumber([]byte(tt.input), &result)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractItems(t *testing.T) {
+	t.Run("valid data array", func(t *testing.T) {
+		body := map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"id": "1"},
+				map[string]interface{}{"id": "2"},
+			},
+		}
+		items := extractItems(body)
+		if len(items) != 2 {
+			t.Fatalf("expected 2, got %d", len(items))
+		}
+	})
+
+	t.Run("missing data field", func(t *testing.T) {
+		body := map[string]interface{}{"other": "value"}
+		items := extractItems(body)
+		if items != nil {
+			t.Fatalf("expected nil, got %v", items)
+		}
+	})
+
+	t.Run("empty data array", func(t *testing.T) {
+		body := map[string]interface{}{"data": []interface{}{}}
+		items := extractItems(body)
+		if len(items) != 0 {
+			t.Fatalf("expected 0, got %d", len(items))
+		}
+	})
+}
+
+func TestExtractReportItems(t *testing.T) {
+	t.Run("metrics under data", func(t *testing.T) {
+		body := map[string]interface{}{
+			"data": map[string]interface{}{
+				"metrics": []interface{}{
+					map[string]interface{}{"impressions": 10, "spend": 5},
+					map[string]interface{}{"impressions": 20, "spend": 7},
+				},
+			},
+		}
+		if len(extractReportItems(body)) != 2 {
+			t.Fatalf("expected 2, got %d", len(extractReportItems(body)))
+		}
+	})
+
+	t.Run("empty metrics", func(t *testing.T) {
+		body := map[string]interface{}{"data": map[string]interface{}{"metrics": []interface{}{}}}
+		if len(extractReportItems(body)) != 0 {
+			t.Fatal("expected 0")
+		}
+	})
+
+	t.Run("data is array (entity shape) returns nil", func(t *testing.T) {
+		body := map[string]interface{}{"data": []interface{}{map[string]interface{}{"id": "1"}}}
+		if extractReportItems(body) != nil {
+			t.Fatal("expected nil for non-report shape")
+		}
+	})
+
+	t.Run("missing data", func(t *testing.T) {
+		if extractReportItems(map[string]interface{}{"other": 1}) != nil {
+			t.Fatal("expected nil")
+		}
+	})
+}
+
+func TestGetNextURL(t *testing.T) {
+	t.Run("has next URL", func(t *testing.T) {
+		body := map[string]interface{}{
+			"pagination": map[string]interface{}{
+				"next_url": "https://ads-api.reddit.com/api/v3/accounts?page_size=100&after=abc",
+			},
+		}
+		got := getNextURL(body)
+		if got == "" {
+			t.Fatal("expected non-empty next URL")
+		}
+	})
+
+	t.Run("no pagination field", func(t *testing.T) {
+		body := map[string]interface{}{"data": []interface{}{}}
+		if getNextURL(body) != "" {
+			t.Fatal("expected empty")
+		}
+	})
+
+	t.Run("no next_url", func(t *testing.T) {
+		body := map[string]interface{}{
+			"pagination": map[string]interface{}{},
+		}
+		if getNextURL(body) != "" {
+			t.Fatal("expected empty")
+		}
+	})
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a, b , c", []string{"a", "b", "c"}},
+		{" a ", []string{"a"}},
+		{",,", []string{}},
+		{"", []string{}},
+	}
+
+	for _, tt := range tests {
+		got := splitAndTrim(tt.input, ",")
+		if len(got) != len(tt.want) {
+			t.Fatalf("splitAndTrim(%q): expected %d items, got %d", tt.input, len(tt.want), len(got))
+		}
+		for i, want := range tt.want {
+			if got[i] != want {
+				t.Fatalf("splitAndTrim(%q)[%d]: expected %q, got %q", tt.input, i, want, got[i])
+			}
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || (len(s) > 0 && containsSubstr(s, substr)))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/source/redditads/redditads_test.go
+++ b/pkg/source/redditads/redditads_test.go
@@ -522,4 +522,3 @@ func TestSplitAndTrim(t *testing.T) {
 		}
 	}
 }
-

--- a/pkg/source/redditads/redditads_test.go
+++ b/pkg/source/redditads/redditads_test.go
@@ -2,6 +2,7 @@ package redditads
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -112,7 +113,7 @@ func TestParseURI(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.errContains)
 				}
-				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
 				}
 				return
@@ -257,7 +258,7 @@ func TestParseCustomTable(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.errContains)
 				}
-				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
 				}
 				return
@@ -522,15 +523,3 @@ func TestSplitAndTrim(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || (len(s) > 0 && containsSubstr(s, substr)))
-}
-
-func containsSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/source/redditads/register.go
+++ b/pkg/source/redditads/register.go
@@ -1,0 +1,10 @@
+package redditads
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"redditads"},
+		func() interface{} { return NewRedditAdsSource() },
+	)
+}


### PR DESCRIPTION
## Summary

Adds a **Reddit Ads** (API v3) source to ingestr.

**Tables**
- Entity tables: `accounts`, `campaigns`, `ad_groups`, `ads`, `custom_audiences`, `saved_audiences`, `pixels`, `funding_instruments`
- Custom performance reports: `custom:<level>,<breakdowns>:<metrics>` (levels: account/campaign/ad_group/ad; up to 2 breakdowns; metrics incl. impressions, clicks, spend, video/conversion metrics)

**Behavior**
- Entity tables filter client-side on their modification timestamp and `merge` on `id`. `saved_audiences` uses `updated_at`; all other entities use `modified_at` (verified against live API responses).
- `funding_instruments` exposes no modification timestamp, so it uses full `replace`.
- Custom reports `merge` on `date` when a date breakdown is present; monetary metrics (`spend`, `ecpm`, `cpc`) are converted from microcurrency.
- Per-account sub-resources are fetched in parallel with client-side rate limiting and retry-on-429.