### PR TITLE
feat(adjust): configurable attribution_types for campaigns/creatives

### DIFF
--- a/docs/supported-sources/adjust.md
+++ b/docs/supported-sources/adjust.md
@@ -48,6 +48,29 @@ ingestr ingest --source-uri 'adjust://?api_key=nr_123' \
 
 This works for `events`, `campaigns`, and `creatives` tables. For custom tables, use the `app_token__in` filter in the filters section instead (see below).
 
+### Attribution Types
+
+The `campaigns` and `creatives` tables default to `click,engaged_ad` attribution. You can override which attribution types are included with the `attribution_types` query parameter. Valid values are `click`, `impression`, and `engaged_ad`, comma-separated:
+
+> [!WARNING]
+> Adjust is changing its API-side default on **July 13, 2026** to include **all** attribution types (including `impression`). ingestr currently pins `click,engaged_ad` for these tables to preserve existing behavior. To keep your metrics stable regardless of Adjust's default, set `attribution_types` explicitly for the behavior you want.
+
+```sh
+# Include impressions as well
+ingestr ingest --source-uri 'adjust://?api_key=nr_123' \
+--source-table 'creatives?attribution_types=click,impression,engaged_ad' \
+--dest-uri duckdb:///adjust.duckdb \
+--dest-table 'adjust.output'
+
+# Combined with an app token
+ingestr ingest --source-uri 'adjust://?api_key=nr_123' \
+--source-table 'creatives?app_token=abc123&attribution_types=click,engaged_ad' \
+--dest-uri duckdb:///adjust.duckdb \
+--dest-table 'adjust.output'
+```
+
+The existing `creatives:abc123` colon form (app token only) continues to work; `attribution_types` can only be set through the query parameter. For custom tables, pass `attribution_types` in the filters section instead.
+
 ### Lookback days
 
 Adjust data may change going back, which means you'll need to change your start date to get the latest data. The `lookback_days` parameter allows you to specify how many days to go back when calculating the start date, and takes care of automatically updating the start date and getting the past data as well. It defaults to 30 days.

--- a/pkg/source/adjust/adjust.go
+++ b/pkg/source/adjust/adjust.go
@@ -13,12 +13,17 @@ import (
 	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
 )
 
 const (
 	baseURL        = "https://automate.adjust.com/reports-service"
 	rateLimit      = 10
 	rateLimitBurst = 5
+
+	// defaultAttributionTypes pins campaigns/creatives to ingestr's historical
+	// behaviour; Adjust's API-side default changes (2026-07-13) to include all types.
+	defaultAttributionTypes = "click,engaged_ad"
 )
 
 var supportedTables = []string{
@@ -71,23 +76,59 @@ func (s *AdjustSource) Close(ctx context.Context) error {
 	return nil
 }
 
-func parseTableAppToken(table string) (baseName string, appTokens string) {
+// adjustParams is the URL-style query-parameter form of the source table and
+// the single source of truth for which parameters are accepted.
+type adjustParams struct {
+	AppToken         []string `mapstructure:"app_token"`
+	AttributionTypes []string `mapstructure:"attribution_types"`
+}
+
+// parseTableSpec parses a source table in URL-style form ("creatives?app_token=abc&attribution_types=click")
+// or the legacy "creatives:<app_token>" colon form (app token only); custom tables are returned verbatim.
+func parseTableSpec(table string) (baseName, appTokens, attributionTypes string, err error) {
 	if strings.HasPrefix(table, "custom:") {
-		return table, ""
+		return table, "", "", nil
 	}
+
+	var p adjustParams
+	path, hasParams, err := tablespec.Parse(table, &p, tablespec.WithListSeparator(","))
+	if err != nil {
+		return "", "", "", err
+	}
+	if hasParams {
+		return path, strings.Join(p.AppToken, ","), strings.Join(p.AttributionTypes, ","), nil
+	}
+
 	parts := strings.SplitN(table, ":", 2)
 	baseName = parts[0]
 	if len(parts) == 2 {
 		appTokens = parts[1]
 	}
-	return baseName, appTokens
+	return baseName, appTokens, "", nil
+}
+
+// resolveAttributionTypes returns the attribution_types to send (empty = let the
+// API decide). DEPRECATED(2026-07-13): to adopt Adjust's API default, change the
+// pinned return below to `return ""`; callers already skip the param when empty.
+func resolveAttributionTypes(attributionTypes string) string {
+	if attributionTypes == "" {
+		return defaultAttributionTypes
+	}
+	return attributionTypes
 }
 
 func (s *AdjustSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
-	tableName, appTokens := parseTableAppToken(req.Name)
+	tableName, appTokens, attributionTypes, err := parseTableSpec(req.Name)
+	if err != nil {
+		return nil, err
+	}
 
 	if !isValidTable(tableName) {
 		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, strings.Join(supportedTables, ", "))
+	}
+
+	if attributionTypes != "" && tableName != "campaigns" && tableName != "creatives" {
+		return nil, fmt.Errorf("attribution_types is only supported for the campaigns and creatives tables; for custom tables pass it in the filters section")
 	}
 
 	var primaryKeys []string
@@ -136,12 +177,12 @@ func (s *AdjustSource) GetTable(ctx context.Context, req source.TableRequest) (s
 			return nil, fmt.Errorf("adjust source does not have a predefined schema; schema inference is required")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
-			return s.read(ctx, tableName, appTokens, opts)
+			return s.read(ctx, tableName, appTokens, attributionTypes, opts)
 		},
 	}, nil
 }
 
-func (s *AdjustSource) read(ctx context.Context, table string, appTokens string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+func (s *AdjustSource) read(ctx context.Context, table string, appTokens, attributionTypes string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -152,9 +193,9 @@ func (s *AdjustSource) read(ctx context.Context, table string, appTokens string,
 		case table == "events":
 			err = s.readEvents(ctx, appTokens, opts, results)
 		case table == "campaigns":
-			err = s.readCampaigns(ctx, appTokens, opts, results)
+			err = s.readCampaigns(ctx, appTokens, attributionTypes, opts, results)
 		case table == "creatives":
-			err = s.readCreatives(ctx, appTokens, opts, results)
+			err = s.readCreatives(ctx, appTokens, attributionTypes, opts, results)
 		case strings.HasPrefix(table, "custom:"):
 			err = s.readCustom(ctx, table, appTokens, opts, results)
 		default:
@@ -280,7 +321,7 @@ var defaultMetrics = []string{
 	"all_revenue_total_d21",
 }
 
-func (s *AdjustSource) readCampaigns(ctx context.Context, appTokens string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *AdjustSource) readCampaigns(ctx context.Context, appTokens, attributionTypes string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[ADJUST] Fetching campaigns")
 
 	datePeriod, err := s.buildDatePeriod(&opts)
@@ -292,6 +333,10 @@ func (s *AdjustSource) readCampaigns(ctx context.Context, appTokens string, opts
 		SetQueryParam("dimensions", strings.Join(defaultDimensions, ",")).
 		SetQueryParam("metrics", strings.Join(defaultMetrics, ",")).
 		SetQueryParam("date_period", datePeriod)
+
+	if at := resolveAttributionTypes(attributionTypes); at != "" {
+		req.SetQueryParam("attribution_types", at)
+	}
 
 	if appTokens != "" {
 		req.SetQueryParam("app_token__in", appTokens)
@@ -332,7 +377,7 @@ var creativePrimaryKeys = []string{"campaign", "day", "app", "store_type", "chan
 
 var creativeDimensions = []string{"campaign", "day", "app", "app_token", "store_type", "channel", "country", "adgroup", "creative"}
 
-func (s *AdjustSource) readCreatives(ctx context.Context, appTokens string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *AdjustSource) readCreatives(ctx context.Context, appTokens, attributionTypes string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[ADJUST] Fetching creatives")
 
 	datePeriod, err := s.buildDatePeriod(&opts)
@@ -344,6 +389,10 @@ func (s *AdjustSource) readCreatives(ctx context.Context, appTokens string, opts
 		SetQueryParam("dimensions", strings.Join(creativeDimensions, ",")).
 		SetQueryParam("metrics", strings.Join(defaultMetrics, ",")).
 		SetQueryParam("date_period", datePeriod)
+
+	if at := resolveAttributionTypes(attributionTypes); at != "" {
+		req.SetQueryParam("attribution_types", at)
+	}
 
 	if appTokens != "" {
 		req.SetQueryParam("app_token__in", appTokens)

--- a/pkg/source/adjust/adjust.go
+++ b/pkg/source/adjust/adjust.go
@@ -107,26 +107,6 @@ func parseTableSpec(table string) (baseName, appTokens, attributionTypes string,
 	return baseName, appTokens, "", nil
 }
 
-var validAttributionTypes = map[string]struct{}{
-	"click":      {},
-	"impression": {},
-	"engaged_ad": {},
-}
-
-// validateAttributionTypes rejects any value outside Adjust's allowed set so a
-// typo fails fast instead of returning an opaque API error.
-func validateAttributionTypes(attributionTypes string) error {
-	for _, t := range strings.Split(attributionTypes, ",") {
-		if t = strings.TrimSpace(t); t == "" {
-			continue
-		}
-		if _, ok := validAttributionTypes[t]; !ok {
-			return fmt.Errorf("unknown attribution_types value %q; valid values are click, impression, engaged_ad", t)
-		}
-	}
-	return nil
-}
-
 // resolveAttributionTypes returns the attribution_types to send (empty = let the
 // API decide). DEPRECATED(2026-07-13): to adopt Adjust's API default, change the
 // pinned return below to `return ""`; callers already skip the param when empty.
@@ -149,9 +129,6 @@ func (s *AdjustSource) GetTable(ctx context.Context, req source.TableRequest) (s
 
 	if attributionTypes != "" && tableName != "campaigns" && tableName != "creatives" {
 		return nil, fmt.Errorf("attribution_types is not supported for the %q table; use it on campaigns or creatives (for custom tables, pass it in the filters section)", tableName)
-	}
-	if err := validateAttributionTypes(attributionTypes); err != nil {
-		return nil, err
 	}
 
 	var primaryKeys []string

--- a/pkg/source/adjust/adjust.go
+++ b/pkg/source/adjust/adjust.go
@@ -107,6 +107,26 @@ func parseTableSpec(table string) (baseName, appTokens, attributionTypes string,
 	return baseName, appTokens, "", nil
 }
 
+var validAttributionTypes = map[string]struct{}{
+	"click":      {},
+	"impression": {},
+	"engaged_ad": {},
+}
+
+// validateAttributionTypes rejects any value outside Adjust's allowed set so a
+// typo fails fast instead of returning an opaque API error.
+func validateAttributionTypes(attributionTypes string) error {
+	for _, t := range strings.Split(attributionTypes, ",") {
+		if t = strings.TrimSpace(t); t == "" {
+			continue
+		}
+		if _, ok := validAttributionTypes[t]; !ok {
+			return fmt.Errorf("unknown attribution_types value %q; valid values are click, impression, engaged_ad", t)
+		}
+	}
+	return nil
+}
+
 // resolveAttributionTypes returns the attribution_types to send (empty = let the
 // API decide). DEPRECATED(2026-07-13): to adopt Adjust's API default, change the
 // pinned return below to `return ""`; callers already skip the param when empty.
@@ -128,7 +148,10 @@ func (s *AdjustSource) GetTable(ctx context.Context, req source.TableRequest) (s
 	}
 
 	if attributionTypes != "" && tableName != "campaigns" && tableName != "creatives" {
-		return nil, fmt.Errorf("attribution_types is only supported for the campaigns and creatives tables; for custom tables pass it in the filters section")
+		return nil, fmt.Errorf("attribution_types is not supported for the %q table; use it on campaigns or creatives (for custom tables, pass it in the filters section)", tableName)
+	}
+	if err := validateAttributionTypes(attributionTypes); err != nil {
+		return nil, err
 	}
 
 	var primaryKeys []string

--- a/pkg/source/adjust/adjust_test.go
+++ b/pkg/source/adjust/adjust_test.go
@@ -474,8 +474,7 @@ func TestGetTable_AttributionTypesGuard(t *testing.T) {
 		{"creatives accepts attribution_types", "creatives?attribution_types=click,engaged_ad", false},
 		{"events rejects attribution_types", "events?attribution_types=click", true},
 		{"events still accepts app_token", "events?app_token=abc123", false},
-		{"rejects unknown attribution_types value", "campaigns?attribution_types=impresion", true},
-		{"rejects partially unknown attribution_types", "creatives?attribution_types=click,bogus", true},
+		{"unknown attribution_types value is left to Adjust", "campaigns?attribution_types=impresion", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/source/adjust/adjust_test.go
+++ b/pkg/source/adjust/adjust_test.go
@@ -475,6 +475,7 @@ func TestGetTable_AttributionTypesGuard(t *testing.T) {
 		{"events rejects attribution_types", "events?attribution_types=click", true},
 		{"events still accepts app_token", "events?app_token=abc123", false},
 		{"unknown attribution_types value is left to Adjust", "campaigns?attribution_types=impresion", false},
+		{"custom accepts attribution_types via filters", "custom:day,campaign:installs:attribution_types=click,engaged_ad", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/source/adjust/adjust_test.go
+++ b/pkg/source/adjust/adjust_test.go
@@ -69,26 +69,39 @@ func TestParseAdjustURI(t *testing.T) {
 	}
 }
 
-func TestParseTableAppToken(t *testing.T) {
+func TestParseTableSpec(t *testing.T) {
 	tests := []struct {
-		name          string
-		table         string
-		wantBase      string
-		wantAppTokens string
+		name            string
+		table           string
+		wantBase        string
+		wantAppTokens   string
+		wantAttribution string
+		wantErr         bool
 	}{
-		{"no app_token", "campaigns", "campaigns", ""},
-		{"single token", "campaigns:abc123", "campaigns", "abc123"},
-		{"multiple tokens", "creatives:abc123,def456", "creatives", "abc123,def456"},
-		{"events with token", "events:tok1", "events", "tok1"},
-		{"custom table untouched", "custom:day:installs", "custom:day:installs", ""},
-		{"custom with filters untouched", "custom:day:installs:app_token__in=abc", "custom:day:installs:app_token__in=abc", ""},
+		{name: "no app_token", table: "campaigns", wantBase: "campaigns"},
+		{name: "single token", table: "campaigns:abc123", wantBase: "campaigns", wantAppTokens: "abc123"},
+		{name: "multiple tokens", table: "creatives:abc123,def456", wantBase: "creatives", wantAppTokens: "abc123,def456"},
+		{name: "events with token", table: "events:tok1", wantBase: "events", wantAppTokens: "tok1"},
+		{name: "colon form is app token only", table: "creatives:click", wantBase: "creatives", wantAppTokens: "click"},
+		{name: "query attribution", table: "creatives?attribution_types=click,engaged_ad", wantBase: "creatives", wantAttribution: "click,engaged_ad"},
+		{name: "query token and attribution", table: "creatives?app_token=abc123&attribution_types=click", wantBase: "creatives", wantAppTokens: "abc123", wantAttribution: "click"},
+		{name: "query repeated keys", table: "campaigns?app_token=abc&app_token=def&attribution_types=click&attribution_types=impression", wantBase: "campaigns", wantAppTokens: "abc,def", wantAttribution: "click,impression"},
+		{name: "query unknown key", table: "campaigns?foo=bar", wantErr: true},
+		{name: "custom table untouched", table: "custom:day:installs", wantBase: "custom:day:installs"},
+		{name: "custom with filters untouched", table: "custom:day:installs:app_token__in=abc", wantBase: "custom:day:installs:app_token__in=abc"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			base, tokens := parseTableAppToken(tt.table)
+			base, tokens, attribution, err := parseTableSpec(tt.table)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantBase, base)
 			assert.Equal(t, tt.wantAppTokens, tokens)
+			assert.Equal(t, tt.wantAttribution, attribution)
 		})
 	}
 }
@@ -445,6 +458,32 @@ func TestGetTable_Strategies(t *testing.T) {
 			assert.Equal(t, tt.strategy, dst.TableStrategy)
 			assert.Equal(t, tt.wantPKs, dst.TablePrimaryKeys)
 			assert.Equal(t, tt.wantKey, dst.TableIncrementalKey)
+		})
+	}
+}
+
+func TestGetTable_AttributionTypesGuard(t *testing.T) {
+	s := NewAdjustSource()
+
+	tests := []struct {
+		name    string
+		table   string
+		wantErr bool
+	}{
+		{"campaigns accepts attribution_types", "campaigns?attribution_types=click", false},
+		{"creatives accepts attribution_types", "creatives?attribution_types=click,engaged_ad", false},
+		{"events rejects attribution_types", "events?attribution_types=click", true},
+		{"events still accepts app_token", "events?app_token=abc123", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := s.GetTable(context.Background(), source.TableRequest{Name: tt.table})
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/source/adjust/adjust_test.go
+++ b/pkg/source/adjust/adjust_test.go
@@ -474,6 +474,8 @@ func TestGetTable_AttributionTypesGuard(t *testing.T) {
 		{"creatives accepts attribution_types", "creatives?attribution_types=click,engaged_ad", false},
 		{"events rejects attribution_types", "events?attribution_types=click", true},
 		{"events still accepts app_token", "events?app_token=abc123", false},
+		{"rejects unknown attribution_types value", "campaigns?attribution_types=impresion", true},
+		{"rejects partially unknown attribution_types", "creatives?attribution_types=click,bogus", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What & why

Adjust emailed that on **July 13, 2026** they are deprecating the singular `attribution_type` parameter in favor of `attribution_types`, and **changing the API-side default**: requests that send no attribution parameter currently default to `click + engaged_ad`, but afterwards will include **all** attribution types (incl. `impression`).

## Changes

- **Configurable `attribution_types`** for `campaigns` and `creatives`, parsed through the shared `pkg/tablespec` query-param helper — same pattern as `monday`/`sharepoint`:
  - `creatives?attribution_types=click,engaged_ad`
  - `creatives?app_token=abc123&attribution_types=click`
  - Legacy `creatives:abc123` (app token only) is preserved — existing users are unaffected.
- **Default pinned to `click,engaged_ad`** so behavior is unchanged across Adjust's 2026-07-13 switch. Verified against the live API that this is today's default. Deprecating later is a one-line flip (`resolveAttributionTypes` → `return ""`); the param is only sent when non-empty.