### PR TITLE
Add OAuth refresh-token auth to Reddit Ads source

### DIFF
--- a/docs/supported-sources/reddit_ads.md
+++ b/docs/supported-sources/reddit_ads.md
@@ -7,13 +7,20 @@ Ingestr supports Reddit Ads as a source.
 The URI format for Reddit Ads as a source is as follows:
 
 ```plaintext
+# Recommended: refresh-token credentials (a fresh access token is minted on each run)
+redditads://?client_id=<client_id>&client_secret=<client_secret>&refresh_token=<refresh_token>&account_ids=<account_ids>
+
+# Alternative: a pre-obtained access token (expires in ~24h, so loads will fail once it lapses)
 redditads://?access_token=<access_token>&account_ids=<account_ids>
 ```
 ## URI parameters:
-- `access_token`(required): The OAuth2 access token used for authentication with the Reddit Ads API. This token grants access to the advertising data associated with your Reddit Ads accounts.
 - `account_ids`(required): A comma-separated list of Ad Account IDs specifying the Reddit Ad Accounts for which you want to retrieve data. These IDs uniquely identify the Reddit Ad Accounts associated with your business.
+- `access_token`(optional): An OAuth2 access token for the Reddit Ads API. Access tokens expire (~24h), so prefer supplying `client_id` + `client_secret` + `refresh_token` instead, which lets ingestr mint a fresh access token automatically on each run.
+- `client_id`(optional): Your OAuth application's client ID.
+- `client_secret`(optional): Your OAuth application's client secret.
+- `refresh_token`(optional): A permanent OAuth refresh token. Provide it together with `client_id` and `client_secret` to obtain a fresh access token on every run without manual re-authentication.
 
-Reddit Ads requires an `access_token` and `account_ids` to retrieve data from the [Reddit Ads API v3](https://ads-api.reddit.com/docs/v3/). Please follow these steps to obtain the `access_token` and `account_ids`.
+You must provide **either** an `access_token`, **or** `client_id` + `client_secret` + `refresh_token` (recommended). In both cases `account_ids` is required.
 
 ### Create a Reddit developer application to obtain an access token
 
@@ -26,9 +33,13 @@ Reddit Ads requires an `access_token` and `account_ids` to retrieve data from th
 4. Accept the Ads API Terms and click **Create App**, then open the app to find your **client_id** (App ID) and **client_secret**.
 
 #### Authorize your app and obtain access token
-1. Direct the user to the Reddit authorization URL:
+1. Direct the user to the Reddit authorization URL. Make sure to include `duration=permanent` — this is what makes Reddit return a long-lived `refresh_token`:
    ```
    https://www.reddit.com/api/v1/authorize?client_id=<client_id>&response_type=code&state=<random_string>&redirect_uri=<redirect_uri>&duration=permanent&scope=adsread
+   ```
+   For example:
+   ```
+   https://www.reddit.com/api/v1/authorize?client_id=client_123&response_type=code&state=random_xyz&redirect_uri=http://localhost:8080/callback&duration=permanent&scope=adsread
    ```
 2. After authorization, Reddit redirects to your redirect URI with a `code` parameter.
 3. Exchange the code for an access token:
@@ -36,10 +47,10 @@ Reddit Ads requires an `access_token` and `account_ids` to retrieve data from th
    POST https://www.reddit.com/api/v1/access_token
    ```
    Use HTTP Basic Auth with `client_id:client_secret` and include `grant_type=authorization_code`, `code=<code>`, and `redirect_uri=<redirect_uri>` in the request body.
-4. The response includes an `access_token` and a `refresh_token`.
+4. The response includes an `access_token` and a `refresh_token`. The `duration=permanent` parameter in step 1 is what makes Reddit issue the long-lived `refresh_token`.
 
-> [!NOTE]
-> Access tokens expire after approximately 1 hour. Use the `refresh_token` with `grant_type=refresh_token` to obtain a new access token when needed.
+> [!TIP]
+> Access tokens expire after ~24 hours. Rather than pasting a short-lived `access_token`, supply `client_id`, `client_secret`, and the `refresh_token` in the URI — ingestr exchanges them for a fresh access token automatically on every run (`grant_type=refresh_token`), so you only authorize once.
 
 To find the Ad Account IDs, go to the [Reddit Ads Dashboard](https://ads.reddit.com/) and navigate to your account settings. The account ID is displayed in the URL or account details.
 
@@ -63,10 +74,10 @@ Use these as `--source-table` parameter in the `ingestr ingest` command.
 
 ### Example
 
-Retrieve all campaigns:
+Retrieve all campaigns (using refresh-token credentials, recommended):
 ```sh
 ingestr ingest \
-    --source-uri "redditads://?access_token=token_123&account_ids=id_123,id_456" \
+    --source-uri "redditads://?client_id=client_123&client_secret=secret_123&refresh_token=refresh_123&account_ids=id_123,id_456" \
     --source-table 'campaigns' \
     --dest-uri 'duckdb:///reddit.duckdb' \
     --dest-table 'dest.campaigns'

--- a/docs/supported-sources/reddit_ads.md
+++ b/docs/supported-sources/reddit_ads.md
@@ -8,19 +8,20 @@ The URI format for Reddit Ads as a source is as follows:
 
 ```plaintext
 # Recommended: refresh-token credentials (a fresh access token is minted on each run)
-redditads://?client_id=<client_id>&client_secret=<client_secret>&refresh_token=<refresh_token>&account_ids=<account_ids>
+redditads://?client_id=<client_id>&client_secret=<client_secret>&refresh_token=<refresh_token>
 
 # Alternative: a pre-obtained access token (expires in ~24h, so loads will fail once it lapses)
-redditads://?access_token=<access_token>&account_ids=<account_ids>
+redditads://?access_token=<access_token>
 ```
 ## URI parameters:
-- `account_ids`(required): A comma-separated list of Ad Account IDs specifying the Reddit Ad Accounts for which you want to retrieve data. These IDs uniquely identify the Reddit Ad Accounts associated with your business.
 - `access_token`(optional): An OAuth2 access token for the Reddit Ads API. Access tokens expire (~24h), so prefer supplying `client_id` + `client_secret` + `refresh_token` instead, which lets ingestr mint a fresh access token automatically on each run.
 - `client_id`(optional): Your OAuth application's client ID.
 - `client_secret`(optional): Your OAuth application's client secret.
 - `refresh_token`(optional): A permanent OAuth refresh token. Provide it together with `client_id` and `client_secret` to obtain a fresh access token on every run without manual re-authentication.
 
-You must provide **either** an `access_token`, **or** `client_id` + `client_secret` + `refresh_token` (recommended). In both cases `account_ids` is required.
+You must provide **either** an `access_token`, **or** `client_id` + `client_secret` + `refresh_token` (recommended).
+
+Account selection is done via the table name, not the URI: by default ingestr syncs **all** ad accounts the authenticated user can access (across every business they belong to). To restrict a table to specific accounts, append them to the `--source-table` value (e.g. `campaigns:id_123,id_456`).
 
 ### Create a Reddit developer application to obtain an access token
 
@@ -60,7 +61,7 @@ Reddit Ads source allows ingesting the following sources into separate tables:
 
 | Table | PK | Inc Key | Inc Strategy | Details |
 | ----- | -- | ------- | ------------ | ------- |
-| accounts | id | modified_at | merge | Retrieves the ad accounts listed in `account_ids`. |
+| accounts | id | modified_at | merge | Retrieves the ad accounts the authenticated user can access (or those scoped via the table name). |
 | campaigns | id | modified_at | merge | Retrieves campaigns for each ad account. |
 | ad_groups | id | modified_at | merge | Retrieves ad groups for each ad account. |
 | ads | id | modified_at | merge | Retrieves ads for each ad account. |
@@ -70,24 +71,24 @@ Reddit Ads source allows ingesting the following sources into separate tables:
 | funding_instruments | id | - | replace | Retrieves funding instruments (payment methods) for each ad account. |
 | custom | [level_id, breakdowns] | date | merge | Custom reports of performance metrics by level, breakdowns, and metrics. |
 
-Use these as `--source-table` parameter in the `ingestr ingest` command.
+Use these as `--source-table` parameter in the `ingestr ingest` command. To pull an entity table for specific accounts (instead of the connection default / all accessible accounts), append the account IDs to the table name, e.g. `--source-table 'campaigns:id_123,id_456'`.
 
 ### Example
 
-Retrieve all campaigns (using refresh-token credentials, recommended):
+Retrieve campaigns for all accessible accounts (refresh-token credentials, recommended):
 ```sh
 ingestr ingest \
-    --source-uri "redditads://?client_id=client_123&client_secret=secret_123&refresh_token=refresh_123&account_ids=id_123,id_456" \
+    --source-uri "redditads://?client_id=client_123&client_secret=secret_123&refresh_token=refresh_123" \
     --source-table 'campaigns' \
     --dest-uri 'duckdb:///reddit.duckdb' \
     --dest-table 'dest.campaigns'
 ```
 
-Retrieve all ad groups:
+Retrieve ad groups for specific accounts (scoped in the table name):
 ```sh
 ingestr ingest \
-    --source-uri "redditads://?access_token=token_123&account_ids=id_123" \
-    --source-table 'ad_groups' \
+    --source-uri "redditads://?access_token=token_123" \
+    --source-table 'ad_groups:id_123,id_456' \
     --dest-uri 'duckdb:///reddit.duckdb' \
     --dest-table 'dest.ad_groups'
 ```
@@ -117,7 +118,7 @@ custom:<level>,<breakdowns>:<metrics>
 Retrieve daily campaign performance data:
 ```sh
 ingestr ingest \
-    --source-uri "redditads://?access_token=token_123&account_ids=id_123,id_456" \
+    --source-uri "redditads://?access_token=token_123" \
     --source-table 'custom:campaign,date:impressions,clicks,spend' \
     --dest-uri 'duckdb:///reddit.duckdb' \
     --dest-table 'dest.campaign_daily'
@@ -131,7 +132,7 @@ The applied parameters for the report are:
 Retrieve ad group performance by country for a specific date range:
 ```sh
 ingestr ingest \
-    --source-uri "redditads://?access_token=token_123&account_ids=id_123" \
+    --source-uri "redditads://?access_token=token_123" \
     --source-table 'custom:ad_group,date,country:impressions,reach,ctr' \
     --dest-uri 'duckdb:///reddit.duckdb' \
     --dest-table 'dest.ad_group_country' \
@@ -147,7 +148,7 @@ The applied parameters for the report are:
 Retrieve account-level spend data:
 ```sh
 ingestr ingest \
-    --source-uri "redditads://?access_token=token_123&account_ids=id_123,id_456" \
+    --source-uri "redditads://?access_token=token_123" \
     --source-table 'custom:account,date:spend,impressions' \
     --dest-uri 'duckdb:///reddit.duckdb' \
     --dest-table 'dest.account_spend'

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -233,6 +233,9 @@ func (s *RedditAdsSource) refreshAccessToken(ctx context.Context) (string, error
 		httpclient.WithDebug(config.DebugMode),
 		httpclient.WithAuth(httpclient.NewBasicAuth(s.clientID, s.clientSecret)),
 		httpclient.WithUserAgent(userAgent),
+		// The token request is a POST; allow retrying it on 429/5xx (resty skips
+		// retries for non-idempotent methods otherwise).
+		httpclient.WithAllowNonIdempotentRetry(),
 	)
 	defer func() { _ = tokenClient.Close() }()
 

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -135,7 +135,6 @@ func (s *RedditAdsSource) Connect(ctx context.Context, uri string) error {
 	s.clientSecret = creds.clientSecret
 	s.refreshToken = creds.refreshToken
 	s.accessToken = creds.accessToken
-	s.accountIDs = creds.accountIDs
 
 	// Without a ready access token, mint one from the OAuth app credentials +
 	// refresh token. Reddit access tokens expire ~24h; the refresh token is
@@ -161,8 +160,61 @@ func (s *RedditAdsSource) Connect(ctx context.Context, uri string) error {
 		httpclient.WithAllowNonIdempotentRetry(),
 	)
 
-	config.Debug("[REDDITADS] Connected successfully (accounts: %s, oauth_app_creds: %t)", strings.Join(s.accountIDs, ", "), s.clientID != "" && s.clientSecret != "")
+	config.Debug("[REDDITADS] Connected successfully (oauth_app_creds: %t)", s.clientID != "" && s.clientSecret != "")
 	return nil
+}
+
+// discoverAccountIDs lists every ad account the authenticated user can reach by
+// walking their businesses (/me/businesses) and each business's ad accounts.
+func (s *RedditAdsSource) discoverAccountIDs(ctx context.Context) ([]string, error) {
+	businessIDs, err := s.fetchIDs(ctx, "/me/businesses")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list businesses: %w", err)
+	}
+
+	var accountIDs []string
+	for _, businessID := range businessIDs {
+		ids, err := s.fetchIDs(ctx, fmt.Sprintf("/businesses/%s/ad_accounts", businessID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to list ad accounts for business %s: %w", businessID, err)
+		}
+		accountIDs = append(accountIDs, ids...)
+	}
+	return accountIDs, nil
+}
+
+// fetchIDs collects the "id" of every item across all pages of a list endpoint.
+func (s *RedditAdsSource) fetchIDs(ctx context.Context, endpoint string) ([]string, error) {
+	var ids []string
+	currentURL := endpoint
+
+	for page := 1; page <= maxPages; page++ {
+		resp, err := s.client.R(ctx).Get(currentURL)
+		if err != nil {
+			return nil, err
+		}
+		if !resp.IsSuccess() {
+			return nil, fmt.Errorf("redditads API %s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]any
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return nil, err
+		}
+
+		for _, item := range extractItems(body) {
+			if id, ok := item["id"].(string); ok && id != "" {
+				ids = append(ids, id)
+			}
+		}
+
+		next := getNextURL(body)
+		if next == "" {
+			break
+		}
+		currentURL = next
+	}
+	return ids, nil
 }
 
 func (s *RedditAdsSource) Close(ctx context.Context) error {
@@ -177,7 +229,6 @@ type redditAdsCredentials struct {
 	clientSecret string
 	refreshToken string
 	accessToken  string
-	accountIDs   []string
 }
 
 func parseURI(uri string) (*redditAdsCredentials, error) {
@@ -204,22 +255,11 @@ func parseURI(uri string) (*redditAdsCredentials, error) {
 		return nil, fmt.Errorf("redditads requires either access_token, or client_id + client_secret + refresh_token")
 	}
 
-	accountIDsRaw := values.Get("account_ids")
-	if accountIDsRaw == "" {
-		return nil, fmt.Errorf("account_ids is required in redditads URI")
-	}
-
-	accountIDs := splitAndTrim(accountIDsRaw, ",")
-	if len(accountIDs) == 0 {
-		return nil, fmt.Errorf("account_ids must contain at least one account ID")
-	}
-
 	return &redditAdsCredentials{
 		clientID:     clientID,
 		clientSecret: clientSecret,
 		refreshToken: refreshToken,
 		accessToken:  accessToken,
-		accountIDs:   accountIDs,
 	}, nil
 }
 
@@ -276,14 +316,21 @@ func splitAndTrim(s string, sep string) []string {
 }
 
 func (s *RedditAdsSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
-	tableName := req.Name
-
-	if strings.HasPrefix(tableName, "custom:") {
-		return s.getCustomReportTable(tableName)
+	if strings.HasPrefix(req.Name, "custom:") {
+		return s.getCustomReportTable(req.Name)
 	}
+
+	// account_ids may be scoped per table via "<table>:<id1>,<id2>"; otherwise all
+	// ad accounts the authenticated user can access are used.
+	tableName, tableAccountIDs := parseEntityTableName(req.Name)
 
 	if !isValidEntityTable(tableName) {
 		return nil, fmt.Errorf("unsupported table: %s (supported: %s, or custom:<level>,<breakdowns>:<metrics>)", tableName, strings.Join(entityTables, ", "))
+	}
+
+	accountIDs, err := s.resolveAccountIDs(ctx, tableAccountIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Reddit entity endpoints expose no server-side time filter, but most objects
@@ -305,9 +352,36 @@ func (s *RedditAdsSource) GetTable(ctx context.Context, req source.TableRequest)
 			return nil, fmt.Errorf("redditads source does not have a predefined schema; schema inference is required")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
-			return s.read(ctx, tableName, opts)
+			return s.read(ctx, tableName, accountIDs, opts)
 		},
 	}, nil
+}
+
+// parseEntityTableName splits "campaigns:acc1,acc2" into ("campaigns", ["acc1","acc2"]).
+// With no colon, the account IDs slice is empty.
+func parseEntityTableName(raw string) (string, []string) {
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) == 2 {
+		return parts[0], splitAndTrim(parts[1], ",")
+	}
+	return parts[0], nil
+}
+
+// resolveAccountIDs prefers per-table account IDs (from "<table>:<ids>"); when
+// none are given it defaults to every ad account the authenticated user can
+// access, discovered once and cached.
+func (s *RedditAdsSource) resolveAccountIDs(ctx context.Context, tableAccountIDs []string) ([]string, error) {
+	if len(tableAccountIDs) > 0 {
+		return tableAccountIDs, nil
+	}
+	if len(s.accountIDs) == 0 {
+		ids, err := s.discoverAccountIDs(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover ad accounts: %w", err)
+		}
+		s.accountIDs = ids
+	}
+	return s.accountIDs, nil
 }
 
 func (s *RedditAdsSource) getCustomReportTable(tableName string) (source.SourceTable, error) {
@@ -337,7 +411,11 @@ func (s *RedditAdsSource) getCustomReportTable(tableName string) (source.SourceT
 			return nil, fmt.Errorf("redditads source does not have a predefined schema; schema inference is required")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
-			return s.readCustomReport(ctx, level, breakdowns, metrics, opts)
+			accountIDs, err := s.resolveAccountIDs(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+			return s.readCustomReport(ctx, accountIDs, level, breakdowns, metrics, opts)
 		},
 	}, nil
 }
@@ -346,7 +424,7 @@ func isValidEntityTable(table string) bool {
 	return slices.Contains(entityTables, table)
 }
 
-func (s *RedditAdsSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+func (s *RedditAdsSource) read(ctx context.Context, table string, accountIDs []string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -355,21 +433,21 @@ func (s *RedditAdsSource) read(ctx context.Context, table string, opts source.Re
 		var err error
 		switch table {
 		case "accounts":
-			err = s.readAccounts(ctx, opts, results)
+			err = s.readAccounts(ctx, accountIDs, opts, results)
 		case "campaigns":
-			err = s.readPerAccount(ctx, "/campaigns", "campaigns", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/campaigns", "campaigns", opts, results)
 		case "ad_groups":
-			err = s.readPerAccount(ctx, "/ad_groups", "ad_groups", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/ad_groups", "ad_groups", opts, results)
 		case "ads":
-			err = s.readPerAccount(ctx, "/ads", "ads", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/ads", "ads", opts, results)
 		case "custom_audiences":
-			err = s.readPerAccount(ctx, "/custom_audiences", "custom_audiences", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/custom_audiences", "custom_audiences", opts, results)
 		case "saved_audiences":
-			err = s.readPerAccount(ctx, "/saved_audiences", "saved_audiences", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/saved_audiences", "saved_audiences", opts, results)
 		case "pixels":
-			err = s.readPerAccount(ctx, "/pixels", "pixels", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/pixels", "pixels", opts, results)
 		case "funding_instruments":
-			err = s.readPerAccount(ctx, "/funding_instruments", "funding_instruments", opts, results)
+			err = s.readPerAccount(ctx, accountIDs, "/funding_instruments", "funding_instruments", opts, results)
 		default:
 			err = fmt.Errorf("unsupported table: %s", table)
 		}
@@ -569,11 +647,11 @@ func joinMapKeys(m map[string]bool) string {
 
 // --- entity table readers ---
 
-func (s *RedditAdsSource) readAccounts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *RedditAdsSource) readAccounts(ctx context.Context, accountIDs []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[REDDITADS] reading accounts")
 
-	items := make([]map[string]any, 0, len(s.accountIDs))
-	for _, accountID := range s.accountIDs {
+	items := make([]map[string]any, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -615,7 +693,7 @@ func (s *RedditAdsSource) readAccounts(ctx context.Context, opts source.ReadOpti
 }
 
 // readPerAccount fetches a paginated sub-resource for each account in parallel.
-func (s *RedditAdsSource) readPerAccount(ctx context.Context, endpoint, label string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *RedditAdsSource) readPerAccount(ctx context.Context, accountIDs []string, endpoint, label string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[REDDITADS] reading %s", label)
 
 	sem := make(chan struct{}, workerCount)
@@ -623,7 +701,7 @@ func (s *RedditAdsSource) readPerAccount(ctx context.Context, endpoint, label st
 	var firstErr error
 
 	var wg sync.WaitGroup
-	for _, accountID := range s.accountIDs {
+	for _, accountID := range accountIDs {
 		select {
 		case <-ctx.Done():
 			mu.Lock()
@@ -735,7 +813,7 @@ func (s *RedditAdsSource) paginateEntity(ctx context.Context, accountID, endpoin
 
 // --- custom report reader ---
 
-func (s *RedditAdsSource) readCustomReport(ctx context.Context, level string, breakdowns, metrics []string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+func (s *RedditAdsSource) readCustomReport(ctx context.Context, accountIDs []string, level string, breakdowns, metrics []string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -756,7 +834,7 @@ func (s *RedditAdsSource) readCustomReport(ctx context.Context, level string, br
 		var firstErr error
 
 		var wg sync.WaitGroup
-		for _, accountID := range s.accountIDs {
+		for _, accountID := range accountIDs {
 			select {
 			case <-ctx.Done():
 				mu.Lock()

--- a/pkg/source/redditads/redditads.go
+++ b/pkg/source/redditads/redditads.go
@@ -24,6 +24,11 @@ const (
 	baseURL   = "https://ads-api.reddit.com/api/v3"
 	userAgent = "ingestr/1.0"
 
+	// OAuth token endpoint used to mint a fresh access token from the OAuth app
+	// credentials + a (permanent) refresh token. Access tokens expire ~24h.
+	oauthBaseURL   = "https://www.reddit.com"
+	oauthTokenPath = "/api/v1/access_token"
+
 	// Reddit does not publish numeric Ads API rate limits; it returns 429 with
 	// X-RateLimit-Remaining/-Reset headers. We throttle conservatively client-side
 	// (~0.8 req/s) and rely on the shared http client's retry-on-429 as a backstop
@@ -100,9 +105,12 @@ var validMetrics = map[string]bool{
 }
 
 type RedditAdsSource struct {
-	accessToken string
-	accountIDs  []string
-	client      *httpclient.Client
+	clientID     string
+	clientSecret string
+	refreshToken string
+	accessToken  string
+	accountIDs   []string
+	client       *httpclient.Client
 }
 
 func NewRedditAdsSource() *RedditAdsSource {
@@ -123,8 +131,22 @@ func (s *RedditAdsSource) Connect(ctx context.Context, uri string) error {
 		return err
 	}
 
+	s.clientID = creds.clientID
+	s.clientSecret = creds.clientSecret
+	s.refreshToken = creds.refreshToken
 	s.accessToken = creds.accessToken
 	s.accountIDs = creds.accountIDs
+
+	// Without a ready access token, mint one from the OAuth app credentials +
+	// refresh token. Reddit access tokens expire ~24h; the refresh token is
+	// permanent, so this keeps the connection working without manual re-auth.
+	if s.accessToken == "" {
+		token, err := s.refreshAccessToken(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to obtain reddit access token: %w", err)
+		}
+		s.accessToken = token
+	}
 
 	s.client = httpclient.New(
 		httpclient.WithBaseURL(baseURL),
@@ -139,7 +161,7 @@ func (s *RedditAdsSource) Connect(ctx context.Context, uri string) error {
 		httpclient.WithAllowNonIdempotentRetry(),
 	)
 
-	config.Debug("[REDDITADS] Connected successfully (accounts: %s)", strings.Join(s.accountIDs, ", "))
+	config.Debug("[REDDITADS] Connected successfully (accounts: %s, oauth_app_creds: %t)", strings.Join(s.accountIDs, ", "), s.clientID != "" && s.clientSecret != "")
 	return nil
 }
 
@@ -151,8 +173,11 @@ func (s *RedditAdsSource) Close(ctx context.Context) error {
 }
 
 type redditAdsCredentials struct {
-	accessToken string
-	accountIDs  []string
+	clientID     string
+	clientSecret string
+	refreshToken string
+	accessToken  string
+	accountIDs   []string
 }
 
 func parseURI(uri string) (*redditAdsCredentials, error) {
@@ -160,12 +185,7 @@ func parseURI(uri string) (*redditAdsCredentials, error) {
 		return nil, fmt.Errorf("invalid redditads URI: must start with redditads://")
 	}
 
-	rest := strings.TrimPrefix(uri, "redditads://")
-	if rest == "" || rest == "?" {
-		return nil, fmt.Errorf("access_token is required in redditads URI")
-	}
-
-	rest = strings.TrimPrefix(rest, "?")
+	rest := strings.TrimPrefix(strings.TrimPrefix(uri, "redditads://"), "?")
 
 	values, err := url.ParseQuery(rest)
 	if err != nil {
@@ -173,8 +193,15 @@ func parseURI(uri string) (*redditAdsCredentials, error) {
 	}
 
 	accessToken := values.Get("access_token")
-	if accessToken == "" {
-		return nil, fmt.Errorf("access_token is required in redditads URI")
+	clientID := values.Get("client_id")
+	clientSecret := values.Get("client_secret")
+	refreshToken := values.Get("refresh_token")
+
+	// Auth: either a ready access_token, or the OAuth app credentials + a refresh
+	// token to mint one at connect time (access tokens expire ~24h; the refresh
+	// token is permanent).
+	if accessToken == "" && (clientID == "" || clientSecret == "" || refreshToken == "") {
+		return nil, fmt.Errorf("redditads requires either access_token, or client_id + client_secret + refresh_token")
 	}
 
 	accountIDsRaw := values.Get("account_ids")
@@ -188,9 +215,49 @@ func parseURI(uri string) (*redditAdsCredentials, error) {
 	}
 
 	return &redditAdsCredentials{
-		accessToken: accessToken,
-		accountIDs:  accountIDs,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		refreshToken: refreshToken,
+		accessToken:  accessToken,
+		accountIDs:   accountIDs,
 	}, nil
+}
+
+// refreshAccessToken exchanges the OAuth app credentials + refresh token for a
+// fresh access token via Reddit's token endpoint (grant_type=refresh_token,
+// HTTP Basic auth with client_id:client_secret).
+func (s *RedditAdsSource) refreshAccessToken(ctx context.Context) (string, error) {
+	tokenClient := httpclient.New(
+		httpclient.WithBaseURL(oauthBaseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(httpclient.NewBasicAuth(s.clientID, s.clientSecret)),
+		httpclient.WithUserAgent(userAgent),
+	)
+	defer func() { _ = tokenClient.Close() }()
+
+	var tokenData struct {
+		AccessToken string `json:"access_token"`
+	}
+
+	resp, err := tokenClient.R(ctx).
+		SetFormData(map[string]string{
+			"grant_type":    "refresh_token",
+			"refresh_token": s.refreshToken,
+		}).
+		SetResult(&tokenData).
+		Post(oauthTokenPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to request access token: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return "", fmt.Errorf("reddit token endpoint returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+	if tokenData.AccessToken == "" {
+		return "", fmt.Errorf("access_token missing in reddit token response")
+	}
+
+	return tokenData.AccessToken, nil
 }
 
 func splitAndTrim(s string, sep string) []string {

--- a/pkg/source/redditads/redditads_test.go
+++ b/pkg/source/redditads/redditads_test.go
@@ -98,8 +98,8 @@ func TestParseURI(t *testing.T) {
 		},
 		{
 			name:      "token with special characters",
-			uri:       "redditads://?access_token=abc.DEF-123_456",
-			wantToken: "abc.DEF-123_456",
+			uri:       "redditads://?access_token=tok.A-1_2",
+			wantToken: "tok.A-1_2",
 		},
 	}
 

--- a/pkg/source/redditads/redditads_test.go
+++ b/pkg/source/redditads/redditads_test.go
@@ -1,6 +1,7 @@
 package redditads
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -46,7 +47,6 @@ func TestParseURI(t *testing.T) {
 		name             string
 		uri              string
 		wantToken        string
-		wantAccountIDs   []string
 		wantClientID     string
 		wantClientSecret string
 		wantRefreshToken string
@@ -54,38 +54,23 @@ func TestParseURI(t *testing.T) {
 		errContains      string
 	}{
 		{
-			name:           "valid URI with single account",
-			uri:            "redditads://?access_token=tok123&account_ids=acc1",
-			wantToken:      "tok123",
-			wantAccountIDs: []string{"acc1"},
+			name:      "valid URI with access token",
+			uri:       "redditads://?access_token=tok123",
+			wantToken: "tok123",
 		},
 		{
-			name:             "valid URI with oauth app credentials",
-			uri:              "redditads://?client_id=cid&client_secret=csec&access_token=tok123&account_ids=acc1",
+			name:             "valid URI with oauth app credentials and access token",
+			uri:              "redditads://?client_id=cid&client_secret=csec&access_token=tok123",
 			wantToken:        "tok123",
-			wantAccountIDs:   []string{"acc1"},
 			wantClientID:     "cid",
 			wantClientSecret: "csec",
 		},
 		{
 			name:             "valid URI with refresh credentials and no access token",
-			uri:              "redditads://?client_id=cid&client_secret=csec&refresh_token=rtok&account_ids=acc1",
-			wantAccountIDs:   []string{"acc1"},
+			uri:              "redditads://?client_id=cid&client_secret=csec&refresh_token=rtok",
 			wantClientID:     "cid",
 			wantClientSecret: "csec",
 			wantRefreshToken: "rtok",
-		},
-		{
-			name:           "valid URI with multiple accounts",
-			uri:            "redditads://?access_token=tok123&account_ids=acc1,acc2,acc3",
-			wantToken:      "tok123",
-			wantAccountIDs: []string{"acc1", "acc2", "acc3"},
-		},
-		{
-			name:           "trims whitespace in account IDs",
-			uri:            "redditads://?access_token=tok123&account_ids=acc1, acc2 , acc3",
-			wantToken:      "tok123",
-			wantAccountIDs: []string{"acc1", "acc2", "acc3"},
 		},
 		{
 			name:        "wrong scheme",
@@ -95,25 +80,13 @@ func TestParseURI(t *testing.T) {
 		},
 		{
 			name:        "missing access_token and refresh credentials",
-			uri:         "redditads://?account_ids=acc1",
+			uri:         "redditads://",
 			wantErr:     true,
 			errContains: "either access_token",
 		},
 		{
 			name:        "refresh credentials missing client_secret",
-			uri:         "redditads://?client_id=cid&refresh_token=rtok&account_ids=acc1",
-			wantErr:     true,
-			errContains: "either access_token",
-		},
-		{
-			name:        "missing account_ids",
-			uri:         "redditads://?access_token=tok123",
-			wantErr:     true,
-			errContains: "account_ids is required",
-		},
-		{
-			name:        "empty URI after scheme",
-			uri:         "redditads://",
+			uri:         "redditads://?client_id=cid&refresh_token=rtok",
 			wantErr:     true,
 			errContains: "either access_token",
 		},
@@ -124,10 +97,9 @@ func TestParseURI(t *testing.T) {
 			errContains: "either access_token",
 		},
 		{
-			name:           "token with special characters",
-			uri:            "redditads://?access_token=abc.DEF-123_456&account_ids=id1",
-			wantToken:      "abc.DEF-123_456",
-			wantAccountIDs: []string{"id1"},
+			name:      "token with special characters",
+			uri:       "redditads://?access_token=abc.DEF-123_456",
+			wantToken: "abc.DEF-123_456",
 		},
 	}
 
@@ -149,14 +121,6 @@ func TestParseURI(t *testing.T) {
 			if creds.accessToken != tt.wantToken {
 				t.Fatalf("expected token %q, got %q", tt.wantToken, creds.accessToken)
 			}
-			if len(creds.accountIDs) != len(tt.wantAccountIDs) {
-				t.Fatalf("expected %d account IDs, got %d", len(tt.wantAccountIDs), len(creds.accountIDs))
-			}
-			for i, want := range tt.wantAccountIDs {
-				if creds.accountIDs[i] != want {
-					t.Fatalf("account ID[%d]: expected %q, got %q", i, want, creds.accountIDs[i])
-				}
-			}
 			if creds.clientID != tt.wantClientID {
 				t.Fatalf("expected client_id %q, got %q", tt.wantClientID, creds.clientID)
 			}
@@ -167,6 +131,60 @@ func TestParseURI(t *testing.T) {
 				t.Fatalf("expected refresh_token %q, got %q", tt.wantRefreshToken, creds.refreshToken)
 			}
 		})
+	}
+}
+
+func TestParseEntityTableName(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantTable   string
+		wantAccount []string
+	}{
+		{name: "no account override", raw: "campaigns", wantTable: "campaigns", wantAccount: nil},
+		{name: "single account", raw: "campaigns:acc1", wantTable: "campaigns", wantAccount: []string{"acc1"}},
+		{name: "multiple accounts", raw: "ads:acc1,acc2", wantTable: "ads", wantAccount: []string{"acc1", "acc2"}},
+		{name: "trims whitespace", raw: "pixels: acc1 , acc2 ", wantTable: "pixels", wantAccount: []string{"acc1", "acc2"}},
+		{name: "trailing colon no ids", raw: "campaigns:", wantTable: "campaigns", wantAccount: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table, accounts := parseEntityTableName(tt.raw)
+			if table != tt.wantTable {
+				t.Fatalf("expected table %q, got %q", tt.wantTable, table)
+			}
+			if len(accounts) != len(tt.wantAccount) {
+				t.Fatalf("expected %d accounts, got %d (%v)", len(tt.wantAccount), len(accounts), accounts)
+			}
+			for i, want := range tt.wantAccount {
+				if accounts[i] != want {
+					t.Fatalf("account[%d]: expected %q, got %q", i, want, accounts[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveAccountIDs(t *testing.T) {
+	// table-level account IDs are used as-is, without discovery
+	s := &RedditAdsSource{}
+	got, err := s.resolveAccountIDs(context.Background(), []string{"tbl1", "tbl2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "tbl1" {
+		t.Fatalf("expected table accounts [tbl1 tbl2], got %v", got)
+	}
+
+	// with no table accounts, a previously-discovered (cached) set is returned
+	// without re-discovering
+	cached := &RedditAdsSource{accountIDs: []string{"disc1"}}
+	got, err = cached.resolveAccountIDs(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "disc1" {
+		t.Fatalf("expected cached [disc1], got %v", got)
 	}
 }
 

--- a/pkg/source/redditads/redditads_test.go
+++ b/pkg/source/redditads/redditads_test.go
@@ -43,18 +43,37 @@ func TestFilterItemsByInterval(t *testing.T) {
 
 func TestParseURI(t *testing.T) {
 	tests := []struct {
-		name           string
-		uri            string
-		wantToken      string
-		wantAccountIDs []string
-		wantErr        bool
-		errContains    string
+		name             string
+		uri              string
+		wantToken        string
+		wantAccountIDs   []string
+		wantClientID     string
+		wantClientSecret string
+		wantRefreshToken string
+		wantErr          bool
+		errContains      string
 	}{
 		{
 			name:           "valid URI with single account",
 			uri:            "redditads://?access_token=tok123&account_ids=acc1",
 			wantToken:      "tok123",
 			wantAccountIDs: []string{"acc1"},
+		},
+		{
+			name:             "valid URI with oauth app credentials",
+			uri:              "redditads://?client_id=cid&client_secret=csec&access_token=tok123&account_ids=acc1",
+			wantToken:        "tok123",
+			wantAccountIDs:   []string{"acc1"},
+			wantClientID:     "cid",
+			wantClientSecret: "csec",
+		},
+		{
+			name:             "valid URI with refresh credentials and no access token",
+			uri:              "redditads://?client_id=cid&client_secret=csec&refresh_token=rtok&account_ids=acc1",
+			wantAccountIDs:   []string{"acc1"},
+			wantClientID:     "cid",
+			wantClientSecret: "csec",
+			wantRefreshToken: "rtok",
 		},
 		{
 			name:           "valid URI with multiple accounts",
@@ -75,10 +94,16 @@ func TestParseURI(t *testing.T) {
 			errContains: "must start with redditads://",
 		},
 		{
-			name:        "missing access_token",
+			name:        "missing access_token and refresh credentials",
 			uri:         "redditads://?account_ids=acc1",
 			wantErr:     true,
-			errContains: "access_token is required",
+			errContains: "either access_token",
+		},
+		{
+			name:        "refresh credentials missing client_secret",
+			uri:         "redditads://?client_id=cid&refresh_token=rtok&account_ids=acc1",
+			wantErr:     true,
+			errContains: "either access_token",
 		},
 		{
 			name:        "missing account_ids",
@@ -90,13 +115,13 @@ func TestParseURI(t *testing.T) {
 			name:        "empty URI after scheme",
 			uri:         "redditads://",
 			wantErr:     true,
-			errContains: "access_token is required",
+			errContains: "either access_token",
 		},
 		{
 			name:        "only question mark",
 			uri:         "redditads://?",
 			wantErr:     true,
-			errContains: "access_token is required",
+			errContains: "either access_token",
 		},
 		{
 			name:           "token with special characters",
@@ -131,6 +156,15 @@ func TestParseURI(t *testing.T) {
 				if creds.accountIDs[i] != want {
 					t.Fatalf("account ID[%d]: expected %q, got %q", i, want, creds.accountIDs[i])
 				}
+			}
+			if creds.clientID != tt.wantClientID {
+				t.Fatalf("expected client_id %q, got %q", tt.wantClientID, creds.clientID)
+			}
+			if creds.clientSecret != tt.wantClientSecret {
+				t.Fatalf("expected client_secret %q, got %q", tt.wantClientSecret, creds.clientSecret)
+			}
+			if creds.refreshToken != tt.wantRefreshToken {
+				t.Fatalf("expected refresh_token %q, got %q", tt.wantRefreshToken, creds.refreshToken)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Reddit Ads access tokens expire (~24h), so a connection that stores only a static `access_token` breaks daily. This adds OAuth refresh-token support so the source mints a fresh access token automatically on each run.

## Changes

- `parseURI` now accepts `client_id`, `client_secret`, `refresh_token` in addition to `access_token`. Validation requires **either** `access_token` **or** `client_id` + `client_secret` + `refresh_token` (`account_ids` still required).
- `Connect()`: when no `access_token` is supplied, it mints one via `grant_type=refresh_token` (HTTP Basic `client_id:client_secret`) against `https://www.reddit.com/api/v1/access_token`, then uses it as the Bearer token. A supplied `access_token` is still honored as a direct override.
- Docs (`docs/supported-sources/reddit_ads.md`): documented the new params, added the recommended refresh-token URI form, a worked authorize-URL example highlighting `duration=permanent`, and replaced the "manually re-exchange" note with the automatic-refresh behavior.