### PR TITLE
Add Vitess/PlanetScale support to MySQL source

### DIFF
--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -19,6 +19,11 @@ URI parameters:
 
 The same URI structure and table can be used both for sources and destinations. You can read more about SQLAlchemy's MySQL dialect [here](https://docs.sqlalchemy.org/en/20/core/engines.html#mysql).
 
+## Vitess / PlanetScale
+[Vitess](https://vitess.io/) and [PlanetScale](https://planetscale.com/) are supported out of the box — use the same `mysql://` URI as above, no extra configuration needed.
+
+By default Vitess caps queries at 100,000 rows, which would otherwise break bulk reads of larger tables. ingestr detects Vitess automatically and works around this, so large tables ingest fully.
+
 ## Change data capture
 MySQL CDC is supported with the `mysql+cdc://`, `mysql+pymysql+cdc://`, and `mariadb+cdc://` URI schemes. It reads a consistent snapshot first, then resumes from the destination table's maximum `_cdc_lsn` on subsequent runs.
 

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -19,9 +19,9 @@ import (
 )
 
 type MySQLSource struct {
-	db       *sql.DB
-	uri      string
-	database string
+	db          *sql.DB
+	uri         string
+	database    string
 	sessionInit []string
 }
 
@@ -291,8 +291,8 @@ type rowQuerier interface {
 }
 
 // querier returns something to run a query on plus a cleanup func. When the
-// source has session-init statements, it pins a dedicated connection and 
-// applies them there, since session settings do not carry across the pool. 
+// source has session-init statements, it pins a dedicated connection and
+// applies them there, since session settings do not carry across the pool.
 // Otherwise it returns the pool itself.
 func (s *MySQLSource) querier(ctx context.Context) (rowQuerier, func(), error) {
 	if len(s.sessionInit) == 0 {

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -22,6 +22,7 @@ type MySQLSource struct {
 	db       *sql.DB
 	uri      string
 	database string
+	sessionInit []string
 }
 
 func NewMySQLSource() *MySQLSource {
@@ -51,6 +52,13 @@ func (s *MySQLSource) Connect(ctx context.Context, uri string) error {
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return fmt.Errorf("failed to ping MySQL: %w", err)
+	}
+
+	if vitess, verr := isVitessServer(ctx, db); verr != nil {
+		config.Debug("[SOURCE] failed to detect server version: %v", verr)
+	} else if vitess {
+		config.Debug("[SOURCE] detected Vitess server; enabling OLAP workload")
+		s.sessionInit = []string{"SET workload = 'OLAP'"}
 	}
 
 	s.db = db
@@ -108,6 +116,14 @@ func uriToDSN(uri string) (string, string, error) {
 	}
 
 	return dsn, database, nil
+}
+
+func isVitessServer(ctx context.Context, db *sql.DB) (bool, error) {
+	var version string
+	if err := db.QueryRowContext(ctx, "SELECT @@version").Scan(&version); err != nil {
+		return false, err
+	}
+	return strings.Contains(strings.ToLower(version), "vitess"), nil
 }
 
 func (s *MySQLSource) Close(ctx context.Context) error {
@@ -269,6 +285,33 @@ func getMySQLSchema(ctx context.Context, db *sql.DB, database string, table stri
 	}, nil
 }
 
+// rowQuerier is satisfied by both *sql.DB and *sql.Conn.
+type rowQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// querier returns something to run a query on plus a cleanup func. When the
+// source has session-init statements, it pins a dedicated connection and 
+// applies them there, since session settings do not carry across the pool. 
+// Otherwise it returns the pool itself.
+func (s *MySQLSource) querier(ctx context.Context) (rowQuerier, func(), error) {
+	if len(s.sessionInit) == 0 {
+		return s.db, func() {}, nil
+	}
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	for _, stmt := range s.sessionInit {
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("failed to apply session setting %q: %w", stmt, err)
+		}
+	}
+	return conn, func() { _ = conn.Close() }, nil
+}
+
 func (s *MySQLSource) read(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	startTotal := time.Now()
 	config.Debug("[SOURCE] Starting read from %s", table)
@@ -296,8 +339,15 @@ func (s *MySQLSource) read(ctx context.Context, table string, tableSchema *schem
 
 		query := buildSelectQuery(table, columns, opts)
 
+		q, cleanup, err := s.querier(ctx)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+			return
+		}
+		defer cleanup()
+
 		startQuery := time.Now()
-		rows, err := s.db.QueryContext(ctx, query)
+		rows, err := q.QueryContext(ctx, query)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to query: %w", err)}
 			return
@@ -345,7 +395,14 @@ func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 		defer close(results)
 
 		config.Debug("[SOURCE] Executing custom query: %s", query)
-		rows, err := s.db.QueryContext(ctx, query)
+		q, cleanup, err := s.querier(ctx)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+			return
+		}
+		defer cleanup()
+
+		rows, err := q.QueryContext(ctx, query)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to execute custom query: %w", err)}
 			return

--- a/pkg/source/mysql/mysql_test.go
+++ b/pkg/source/mysql/mysql_test.go
@@ -1,12 +1,45 @@
 package mysql
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
+
+func TestIsVitessServer(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"5.7.9-vitess-14.0.0", true},
+		{"8.0.11-Vitess", true},
+		{"8.0.34", false},
+		{"5.7.40-log", false},
+		{"10.6.12-MariaDB", false},
+	}
+
+	for _, tc := range cases {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("failed to create sqlmock: %v", err)
+		}
+		mock.ExpectQuery("SELECT @@version").
+			WillReturnRows(sqlmock.NewRows([]string{"@@version"}).AddRow(tc.version))
+
+		got, err := isVitessServer(context.Background(), db)
+		if err != nil {
+			t.Fatalf("version %q: unexpected error: %v", tc.version, err)
+		}
+		if got != tc.want {
+			t.Errorf("version %q: got %v, want %v", tc.version, got, tc.want)
+		}
+		_ = db.Close()
+	}
+}
 
 func TestBuildSelectQueryPreservesColumnCasing(t *testing.T) {
 	columns := []schema.Column{

--- a/pkg/source/mysql/mysql_test.go
+++ b/pkg/source/mysql/mysql_test.go
@@ -37,6 +37,9 @@ func TestIsVitessServer(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("version %q: got %v, want %v", tc.version, got, tc.want)
 		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("version %q: unmet expectations: %v", tc.version, err)
+		}
 		_ = db.Close()
 	}
 }

--- a/tests/integration/vitess_container_test.go
+++ b/tests/integration/vitess_container_test.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // register adbc_generic for duckdb read-back
+	_ "github.com/go-sql-driver/mysql"                // register mysql driver for seeding/raw reads
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	// vttestserver exposes vtgate's MySQL protocol on basePort+3. With PORT=33574
+	// that is 33577. Vitess enforces a row-count cap per query in its default OLTP
+	// workload (10k on vttestserver), so seeding more than that lets us prove the
+	// MySQL source detects Vitess and switches to the OLAP workload to read the
+	// whole table.
+	vitessBasePort  = "33574"
+	vitessMySQLPort = "33577/tcp"
+	vitessKeyspace  = "vtdb"
+	vitessTable     = "events"
+	vitessSeedRows  = 20000
+)
+
+func startVitessContainer(ctx context.Context) (testcontainers.Container, string, string, error) {
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "vitess/vttestserver:mysql80",
+			ExposedPorts: []string{vitessMySQLPort},
+			Env: map[string]string{
+				"PORT":            vitessBasePort,
+				"KEYSPACES":       vitessKeyspace,
+				"NUM_SHARDS":      "1",
+				"MYSQL_BIND_HOST": "0.0.0.0",
+			},
+			WaitingFor: wait.ForListeningPort(vitessMySQLPort).WithStartupTimeout(240 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", "", err
+	}
+	port, err := container.MappedPort(ctx, "33577")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", "", err
+	}
+
+	uri := fmt.Sprintf("mysql://root@%s:%s/%s", host, port.Port(), vitessKeyspace)
+	return container, uri, mysqlDSN(uri), nil
+}
+
+// TestMySQLSourceReadsVitessBeyondRowCap proves the MySQL source transparently
+// handles Vitess: it seeds more rows than the OLTP row cap, confirms a plain read
+// is rejected by that cap, then verifies ingestr reads every row (only possible
+// once the source detects Vitess and enables the OLAP workload).
+func TestMySQLSourceReadsVitessBeyondRowCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, dsn, err := startVitessContainer(ctx)
+	require.NoError(t, err, "failed to start vttestserver")
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// vtgate can accept connections before it is able to serve queries; retry.
+	require.Eventually(t, func() bool {
+		return db.PingContext(ctx) == nil
+	}, 90*time.Second, 2*time.Second, "vtgate did not become query-ready")
+
+	seedVitessTable(t, ctx, db)
+
+	// Sanity check: a plain (OLTP) read must hit the Vitess row cap. This proves
+	// the cap is real here, so a later successful full read can only mean the OLAP
+	// workload kicked in.
+	requireRowCapHit(t, ctx, db)
+
+	// ingestr should detect Vitess via SELECT @@version, switch to OLAP, and read
+	// every row despite the cap.
+	duckPath := filepath.Join(t.TempDir(), "vitess.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           uri,
+		SourceTable:         fmt.Sprintf("%s.%s", vitessKeyspace, vitessTable),
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckPath),
+		DestTable:           "main." + vitessTable,
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "ingest from Vitess should succeed")
+
+	require.Equal(t, vitessSeedRows, countDuckDBRows(t, ctx, duckPath, "main."+vitessTable))
+}
+
+func seedVitessTable(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, "DROP TABLE IF EXISTS "+vitessTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, v VARCHAR(40))", vitessTable))
+	require.NoError(t, err)
+
+	const batch = 1000
+	for start := 1; start <= vitessSeedRows; start += batch {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "INSERT INTO %s (id, v) VALUES ", vitessTable)
+		for i := start; i < start+batch && i <= vitessSeedRows; i++ {
+			if i > start {
+				sb.WriteByte(',')
+			}
+			fmt.Fprintf(&sb, "(%d,'val%d')", i, i)
+		}
+		_, err := db.ExecContext(ctx, sb.String())
+		require.NoError(t, err)
+	}
+}
+
+func requireRowCapHit(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	rows, err := db.QueryContext(ctx, "SELECT id, v FROM "+vitessTable)
+	if err != nil {
+		require.Contains(t, strings.ToLower(err.Error()), "exceeded")
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var id int
+		var v string
+		if scanErr := rows.Scan(&id, &v); scanErr != nil {
+			break
+		}
+	}
+	require.Error(t, rows.Err(), "plain OLTP read should hit the Vitess row cap")
+	require.Contains(t, strings.ToLower(rows.Err().Error()), "exceeded")
+}
+
+func countDuckDBRows(t *testing.T, ctx context.Context, path, table string) int {
+	t.Helper()
+
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", path))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&n))
+	return n
+}


### PR DESCRIPTION
Detect Vitess servers via a SELECT @@version preflight on connect and switch reads to the OLAP workload (SET workload='OLAP'), bypassing the 100k-row per-query cap that Vitess enforces in its default OLTP mode. The setting is applied on a dedicated connection per read, since session settings do not carry across the pool. Stock MySQL connections are unaffected.

Closes #864