### PR TITLE
fix(postgres_cdc): confirm replication slot on successful batch run

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -497,6 +497,16 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		return fmt.Errorf("ingestion failed: %w", err)
 	}
 
+	// After a successful, durable write, let CDC sources confirm the position
+	// they caught up to (e.g. advance the replication slot's flush LSN). Safe
+	// here because the write above committed. Best-effort: a failure to confirm
+	// must not fail an otherwise-successful run.
+	if finalizer, ok := src.(source.CDCBatchFinalizer); ok {
+		if err := finalizer.FinalizeBatch(ctx); err != nil {
+			config.Debug("[PIPELINE] CDC batch finalize failed: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1008,6 +1018,16 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 	if err := mtStrat.ExecuteMultiTable(ctx, job); err != nil {
 		return fmt.Errorf("multi-table ingestion failed: %w", err)
+	}
+
+	// After a successful, durable write, let CDC sources confirm the position
+	// they caught up to (e.g. advance the replication slot's flush LSN). This is
+	// safe here because the write above has committed. Best-effort: a failure to
+	// confirm must not fail an otherwise-successful run.
+	if finalizer, ok := src.(source.CDCBatchFinalizer); ok {
+		if err := finalizer.FinalizeBatch(ctx); err != nil {
+			config.Debug("[PIPELINE] CDC batch finalize failed: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -336,6 +336,9 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 			if currentLSN >= targetLSN {
 				config.Debug("[CDC] Batch mode: reached target LSN %s (current: %s)", targetLSN, currentLSN)
 				accum.flushAll(results, token)
+				// Record the caught-up position so FinalizeBatch can confirm it
+				// to the slot once the destination write is durable.
+				r.source.recordCaughtUpLSN(currentLSN)
 				return nil
 			}
 		}

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -132,7 +132,13 @@ func (r *CDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, s
 		return forwardFillUnchanged(batch, pkNames)
 	}
 
-	return streamLoop(ctx, repl, mode, targetLSN, batchSize, accum, results, opts.Streaming)
+	err = streamLoop(ctx, repl, mode, targetLSN, batchSize, accum, results, opts.Streaming)
+	if err == nil && mode == ModeBatch {
+		// Record the caught-up position so FinalizeBatch can confirm it to the
+		// slot once the destination write is durable.
+		r.source.recordCaughtUpLSN(repl.CurrentLSN())
+	}
+	return err
 }
 
 func parseStoredPostgresLSN(raw string) (pglogrepl.LSN, error) {

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -40,10 +40,15 @@ type PostgresCDCSource struct {
 	// It is shared between the pipeline goroutine (CommitStream) and the
 	// replication goroutine (standby status updates).
 	pos *streamPosition
+	// caughtUp holds the LSN a batch run streamed up to (its targetLSN). It is
+	// sent as a final standby status update by FinalizeBatch so the slot's
+	// confirmed_flush_lsn advances even when the run catches up before the
+	// replicator's 10s standby timer fires. Stays zero in streaming mode.
+	caughtUp *streamPosition
 }
 
 func NewPostgresCDCSource() *PostgresCDCSource {
-	return &PostgresCDCSource{pos: newStreamPosition()}
+	return &PostgresCDCSource{pos: newStreamPosition(), caughtUp: newStreamPosition()}
 }
 
 func (s *PostgresCDCSource) Schemes() []string {
@@ -145,6 +150,42 @@ func (s *PostgresCDCSource) CommitStream(_ context.Context, token any) error {
 	}
 	s.pos.Commit(lsn)
 	config.Debug("[CDC] Confirmed durable LSN: %s", lsn)
+	return nil
+}
+
+// recordCaughtUpLSN records the LSN a batch run has streamed up to. It is sent
+// to the slot by FinalizeBatch once the destination write is durable.
+func (s *PostgresCDCSource) recordCaughtUpLSN(lsn pglogrepl.LSN) {
+	if s.caughtUp != nil {
+		s.caughtUp.Commit(lsn)
+	}
+}
+
+// FinalizeBatch sends a final standby status update confirming the LSN the batch
+// run caught up to. The pipeline calls it only after a successful, durable
+// write, so confirming the streamed position cannot discard WAL the destination
+// has not persisted. Without it, a batch run that catches up before the
+// replicator's 10s standby timer fires never advances the slot's
+// confirmed_flush_lsn, so lag and retained WAL grow without bound across runs.
+// Best-effort: a failure here does not fail an otherwise-successful ingest.
+func (s *PostgresCDCSource) FinalizeBatch(ctx context.Context) error {
+	if s.replConn == nil || s.caughtUp == nil {
+		return nil
+	}
+	lsn := s.caughtUp.Committed()
+	if lsn == 0 {
+		return nil
+	}
+	err := pglogrepl.SendStandbyStatusUpdate(ctx, s.replConn, pglogrepl.StandbyStatusUpdate{
+		WALWritePosition: lsn,
+		WALFlushPosition: lsn,
+		WALApplyPosition: lsn,
+	})
+	if err != nil {
+		config.Debug("[CDC] Failed to send final standby status at LSN %s: %v", lsn, err)
+		return fmt.Errorf("failed to send final standby status: %w", err)
+	}
+	config.Debug("[CDC] Sent final standby status confirming LSN %s", lsn)
 	return nil
 }
 
@@ -357,8 +398,9 @@ const (
 )
 
 var (
-	_ source.Source           = (*PostgresCDCSource)(nil)
-	_ source.MultiTableSource = (*PostgresCDCSource)(nil)
-	_ source.StreamingSource  = (*PostgresCDCSource)(nil)
-	_ source.StreamCommitter  = (*PostgresCDCSource)(nil)
+	_ source.Source            = (*PostgresCDCSource)(nil)
+	_ source.MultiTableSource  = (*PostgresCDCSource)(nil)
+	_ source.StreamingSource   = (*PostgresCDCSource)(nil)
+	_ source.StreamCommitter   = (*PostgresCDCSource)(nil)
+	_ source.CDCBatchFinalizer = (*PostgresCDCSource)(nil)
 )

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -116,6 +116,15 @@ type StreamCommitter interface {
 	CommitStream(ctx context.Context, token any) error
 }
 
+// CDCBatchFinalizer is an optional capability for CDC sources that perform a
+// final bookkeeping step after a successful batch run (e.g. confirming the
+// replication slot's flush position). The pipeline calls FinalizeBatch only
+// after the destination write is durable, so the source may safely confirm the
+// position it streamed up to.
+type CDCBatchFinalizer interface {
+	FinalizeBatch(ctx context.Context) error
+}
+
 // MultiTableSource represents a source that emits data from multiple tables.
 // This is used for CDC sources that capture changes across multiple tables.
 type MultiTableSource interface {

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -1308,3 +1308,126 @@ func cdcReplicationSlotName(tableName, publication, suffix string) string {
 	}
 	return name
 }
+
+// cdcReplicationSlotState returns the (single) ingestr replication slot's
+// confirmed_flush_lsn and the current lag in bytes (current WAL - confirmed).
+func cdcReplicationSlotState(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (confirmedFlushLSN string, lagBytes int64) {
+	t.Helper()
+	err := pool.QueryRow(ctx, `
+		SELECT confirmed_flush_lsn::text,
+		       pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::bigint
+		FROM pg_replication_slots
+		ORDER BY slot_name
+		LIMIT 1`).Scan(&confirmedFlushLSN, &lagBytes)
+	require.NoError(t, err)
+	return confirmedFlushLSN, lagBytes
+}
+
+// lsnGreater reports whether LSN a is strictly greater than LSN b.
+func lsnGreater(t *testing.T, ctx context.Context, pool *pgxpool.Pool, a, b string) bool {
+	t.Helper()
+	var greater bool
+	require.NoError(t, pool.QueryRow(ctx, "SELECT $1::pg_lsn > $2::pg_lsn", a, b).Scan(&greater))
+	return greater
+}
+
+// assertBatchRunsAdvanceSlot drives an initial snapshot run plus several resume
+// runs, each catching up a small delta well under the replicator's 10s
+// standby-status interval. Without a final standby status update on a successful
+// run the slot's confirmed_flush_lsn stays frozen and lag grows without bound;
+// this asserts the slot advances and lag shrinks after each run instead.
+func assertBatchRunsAdvanceSlot(t *testing.T, ctx context.Context, sourceConnString string, makeCfg func() *config.IngestConfig) {
+	t.Helper()
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer sourcePool.Close()
+
+	// Initial run: snapshot, creates the replication slot.
+	require.NoError(t, pipeline.New(makeCfg()).Run(ctx))
+
+	prevConf, _ := cdcReplicationSlotState(t, ctx, sourcePool)
+	require.NotEmpty(t, prevConf, "slot should exist after the snapshot run")
+
+	for i := 1; i <= 3; i++ {
+		// Generate WAL so the slot is behind before the run.
+		_, err = sourcePool.Exec(ctx,
+			`INSERT INTO public.test_cdc (name, value) SELECT 'gen' || g, g FROM generate_series(1, 200) g`)
+		require.NoError(t, err)
+
+		_, lagBefore := cdcReplicationSlotState(t, ctx, sourcePool)
+		require.Positive(t, lagBefore, "run %d: expected positive lag before catch-up", i)
+
+		require.NoError(t, pipeline.New(makeCfg()).Run(ctx))
+
+		confAfter, lagAfter := cdcReplicationSlotState(t, ctx, sourcePool)
+		assert.Truef(t, lsnGreater(t, ctx, sourcePool, confAfter, prevConf),
+			"run %d: confirmed_flush_lsn must advance (%s -> %s); the slot stays frozen without the final standby update",
+			i, prevConf, confAfter)
+		assert.Lessf(t, lagAfter, lagBefore,
+			"run %d: lag should shrink after catching up (before=%d after=%d)", i, lagBefore, lagAfter)
+		prevConf = confAfter
+	}
+}
+
+// TestPostgresCDC_BatchRunAdvancesReplicationSlot covers the full-database
+// (multi-table) path: repeated batch runs must keep advancing the replication
+// slot so lag returns toward zero across runs.
+func TestPostgresCDC_BatchRunAdvancesReplicationSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+	setupCDCSource(t, ctx, sourceConnString)
+
+	tmpDir, err := os.MkdirTemp("", "cdc_slot_mt_*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	duckdbURI := fmt.Sprintf("duckdb:///%s/test.duckdb", tmpDir)
+
+	// Full-database CDC: no SourceTable -> multi-table path.
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub&mode=batch"
+	assertBatchRunsAdvanceSlot(t, ctx, sourceConnString, func() *config.IngestConfig {
+		return &config.IngestConfig{
+			SourceURI:           cdcSourceURI,
+			DestURI:             duckdbURI,
+			IncrementalStrategy: "merge",
+		}
+	})
+}
+
+// TestPostgresCDC_SingleTableBatchRunAdvancesReplicationSlot covers the
+// single-table path (--source-table) which streams via a different reader but
+// must confirm the slot the same way.
+func TestPostgresCDC_SingleTableBatchRunAdvancesReplicationSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+	setupCDCSource(t, ctx, sourceConnString)
+
+	tmpDir, err := os.MkdirTemp("", "cdc_slot_st_*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	duckdbURI := fmt.Sprintf("duckdb:///%s/test.duckdb", tmpDir)
+
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub&mode=batch"
+	assertBatchRunsAdvanceSlot(t, ctx, sourceConnString, func() *config.IngestConfig {
+		return &config.IngestConfig{
+			SourceURI:           cdcSourceURI,
+			DestURI:             duckdbURI,
+			SourceTable:         "public.test_cdc",
+			DestTable:           "test_cdc_dest",
+			PrimaryKeys:         []string{"id"},
+			IncrementalStrategy: "merge",
+		}
+	})
+}


### PR DESCRIPTION
Batch-mode CDC runs that caught up before the replicator's 10s standby timer fired never sent a standby status update, so the slot's confirmed_flush_lsn (and restart_lsn) stayed frozen. Across repeated runs the replication lag grew without bound and WAL was retained indefinitely, even though the destination received all data correctly (resume is driven by the destination's max _cdc_lsn, independent of the slot).

Send a final standby status update confirming the caught-up LSN after a successful, durable write, via a new source.CDCBatchFinalizer hook the pipeline invokes only when the strategy succeeds. Confirming the streamed position is safe there because the write has committed; gating on success avoids advancing the slot past WAL the destination never persisted (which Postgres would otherwise skip on the next resume).

Covers both the multi-table (full-DB) and single-table paths. Adds integration tests asserting confirmed_flush_lsn advances and lag shrinks across repeated batch runs.