### PR TITLE
Handle Monday complexity budget and rate limits properly

### DIFF
--- a/docs/supported-sources/monday.md
+++ b/docs/supported-sources/monday.md
@@ -82,5 +82,5 @@ ingestr ingest --source-table "items:5091839751:linked" ...
 > `:linked` discovers sub-boards by the convention that **an item on the master board has the same title as the sub-board's name**. So if your master board has an item called `Q1 Roadmap` and you also have a board called `Q1 Roadmap`, that board is treated as a linked sub-board and its items are included in the result.
 
 > [!NOTE]
-> Monday.com has rate limits for API requests. The source handles pagination automatically and respects the API's maximum page size of 100 items.
+> Monday.com rate limits API requests, mainly by query complexity per minute. The source paginates automatically (up to the API's 100-item page size), throttles its own request rate, and retries throttled (HTTP 429) and transient (5xx) responses. It waits the time Monday asks for, whether from the `Retry-After` header or the `retry_in_seconds` field a complexity error returns instead.
 

--- a/pkg/source/monday/monday.go
+++ b/pkg/source/monday/monday.go
@@ -23,6 +23,12 @@ const (
 	defaultBatchSize = 50
 	rateLimit        = 10
 	rateLimitBurst   = 5
+
+	// maxRetries is the number of retries for 429 and 5xx responses.
+	maxRetries = 5
+	// baseRetryWait and maxRetryWait bound the retry backoff.
+	baseRetryWait = 1 * time.Second
+	maxRetryWait  = 60 * time.Second
 )
 
 var supportedTables = []string{
@@ -217,6 +223,7 @@ var tagsFields = []schema.Column{
 type MondaySource struct {
 	apiToken string
 	client   *httpclient.Client
+	baseURL  string // defaults to graphqlBaseUrl; overridden in tests
 }
 
 func NewMondaySource() *MondaySource {
@@ -238,10 +245,19 @@ func (s *MondaySource) Connect(ctx context.Context, uri string) error {
 	}
 
 	s.apiToken = apiToken
+	baseURL := s.baseURL
+	if baseURL == "" {
+		baseURL = graphqlBaseUrl
+	}
+	// GraphQL uses POST, so non-idempotent retries are enabled; mondayRetryStrategy
+	// supplies the per-attempt wait.
 	s.client = httpclient.New(
-		httpclient.WithBaseURL(graphqlBaseUrl),
+		httpclient.WithBaseURL(baseURL),
 		httpclient.WithTimeout(60*time.Second),
 		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithRetry(maxRetries, baseRetryWait, maxRetryWait),
+		httpclient.WithAllowNonIdempotentRetry(),
+		httpclient.WithRetryStrategy(mondayRetryStrategy),
 		httpclient.WithDebug(config.DebugMode),
 		httpclient.WithHeader("Authorization", s.apiToken),
 		httpclient.WithHeader("Content-Type", "application/json"),
@@ -540,6 +556,8 @@ type graphQLError struct {
 	Message string `json:"message"`
 }
 
+// executeGraphQL runs a query and returns its data. The HTTP client retries 429
+// and 5xx responses.
 func (s *MondaySource) executeGraphQL(ctx context.Context, query string, variables map[string]interface{}) (json.RawMessage, error) {
 	reqBody := graphQLRequest{
 		Query:     query,
@@ -548,11 +566,14 @@ func (s *MondaySource) executeGraphQL(ctx context.Context, query string, variabl
 
 	config.Debug("[Monday] Executing GraphQL query")
 
+	// rlErr captures a 429 body so the retry strategy can read retry_in_seconds.
 	var resp graphQLResponse
+	var rlErr mondayRetryError
 	httpResp, err := s.client.R(ctx).
 		SetHeader("Content-Type", "application/json").
 		SetBody(reqBody).
 		SetResult(&resp).
+		SetError(&rlErr).
 		Post("")
 	if err != nil {
 		return nil, fmt.Errorf("graphql request failed: %w", err)
@@ -563,7 +584,7 @@ func (s *MondaySource) executeGraphQL(ctx context.Context, query string, variabl
 	}
 
 	if len(resp.Errors) > 0 {
-		var errMsgs []string
+		errMsgs := make([]string, 0, len(resp.Errors))
 		for _, e := range resp.Errors {
 			errMsgs = append(errMsgs, e.Message)
 		}
@@ -571,6 +592,67 @@ func (s *MondaySource) executeGraphQL(ctx context.Context, query string, variabl
 	}
 
 	return resp.Data, nil
+}
+
+// Monday rate limits return HTTP 429. The minute, concurrency, and IP limits send
+// a Retry-After header, which the client honors. The complexity limit returns
+// COMPLEXITY_BUDGET_EXHAUSTED with the wait in the body's retry_in_seconds field,
+// which mondayRetryStrategy reads instead.
+// https://developer.monday.com/api-reference/docs/rate-limits
+
+// mondayRetryError holds the retry_in_seconds from a Monday error body. It is the
+// SetError target, so the client parses a 429 body into it.
+type mondayRetryError struct {
+	Errors []struct {
+		Extensions struct {
+			RetryInSeconds float64 `json:"retry_in_seconds"`
+		} `json:"extensions"`
+	} `json:"errors"`
+}
+
+// mondayRetryStrategy returns the wait before the next attempt: the body's
+// retry_in_seconds if present, otherwise exponential backoff.
+func mondayRetryStrategy(resp *httpclient.Response, _ error) (time.Duration, error) {
+	if resp != nil {
+		if d, ok := retryInSecondsFromError(resp.Error()); ok {
+			return d, nil
+		}
+		if a := resp.Attempt(); a > 0 {
+			return backoff(a), nil
+		}
+	}
+	return backoff(1), nil
+}
+
+// retryInSecondsFromError returns the largest retry_in_seconds in a parsed Monday
+// error body, if any.
+func retryInSecondsFromError(v interface{}) (time.Duration, bool) {
+	e, ok := v.(*mondayRetryError)
+	if !ok || e == nil {
+		return 0, false
+	}
+	var secs float64
+	for _, er := range e.Errors {
+		if er.Extensions.RetryInSeconds > secs {
+			secs = er.Extensions.RetryInSeconds
+		}
+	}
+	if secs <= 0 {
+		return 0, false
+	}
+	return time.Duration(secs * float64(time.Second)), true
+}
+
+// backoff returns baseRetryWait doubled per attempt, capped at maxRetryWait.
+func backoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := baseRetryWait << (attempt - 1)
+	if d <= 0 || d > maxRetryWait {
+		return maxRetryWait
+	}
+	return d
 }
 
 // readAccount reads the account information and sends it as a single record batch
@@ -929,6 +1011,15 @@ func (s *MondaySource) consumeUpdatesChan(
 			}
 		case update, ok := <-updatesCh:
 			if !ok {
+				// updatesCh closes only after all workers return, so a worker error
+				// is already buffered. Check it before treating the close as success.
+				select {
+				case err := <-errCh:
+					if err != nil {
+						return err
+					}
+				default:
+				}
 				if err := flush(); err != nil {
 					return err
 				}

--- a/pkg/source/monday/monday_test.go
+++ b/pkg/source/monday/monday_test.go
@@ -221,7 +221,8 @@ func TestRetryInSecondsFromError(t *testing.T) {
 
 	var e mondayRetryError
 	require.NoError(t, json.Unmarshal(
-		[]byte(`{"errors":[{"extensions":{"retry_in_seconds":3}},{"extensions":{"retry_in_seconds":11}}]}`), &e))
+		[]byte(`{"errors":[{"extensions":{"retry_in_seconds":3}},{"extensions":{"retry_in_seconds":11}}]}`), &e,
+	))
 	d, ok := retryInSecondsFromError(&e)
 	assert.True(t, ok)
 	assert.Equal(t, 11*time.Second, d, "uses the largest retry_in_seconds")

--- a/pkg/source/monday/monday_test.go
+++ b/pkg/source/monday/monday_test.go
@@ -1,7 +1,13 @@
 package monday
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,4 +197,159 @@ func TestParseMondaySpec(t *testing.T) {
 			assert.Equal(t, tt.wantLinked, spec.linked)
 		})
 	}
+}
+
+// newTestSource connects a MondaySource pointed at a test server.
+func newTestSource(t *testing.T, baseURL string) *MondaySource {
+	t.Helper()
+	s := &MondaySource{baseURL: baseURL}
+	require.NoError(t, s.Connect(context.Background(), "monday://?api_token=tok"))
+	return s
+}
+
+func TestRetryInSecondsFromError(t *testing.T) {
+	t.Parallel()
+
+	_, ok := retryInSecondsFromError(nil)
+	assert.False(t, ok)
+	_, ok = retryInSecondsFromError("not a monday error")
+	assert.False(t, ok)
+
+	var empty mondayRetryError
+	_, ok = retryInSecondsFromError(&empty)
+	assert.False(t, ok, "no retry_in_seconds means no server-directed wait")
+
+	var e mondayRetryError
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"errors":[{"extensions":{"retry_in_seconds":3}},{"extensions":{"retry_in_seconds":11}}]}`), &e))
+	d, ok := retryInSecondsFromError(&e)
+	assert.True(t, ok)
+	assert.Equal(t, 11*time.Second, d, "uses the largest retry_in_seconds")
+}
+
+// A 429 (POST) is retried and the request succeeds.
+func TestExecuteGraphQLRetriesRateLimitedPOST(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"Complexity budget exhausted"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"account":{"id":"42"}}}`))
+	}))
+	defer srv.Close()
+
+	s := newTestSource(t, srv.URL)
+	defer func() { _ = s.client.Close() }()
+
+	data, err := s.executeGraphQL(context.Background(), `query{account{id}}`, nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"id":"42"`)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "expected one retry after the 429")
+}
+
+// A 429 with no Retry-After header is retried, waiting the body's retry_in_seconds.
+func TestExecuteGraphQLRetriesOn429WithoutRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&hits, 1) == 1 {
+			// No Retry-After header; the wait is in the body.
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"Complexity budget exhausted","extensions":{"code":"COMPLEXITY_BUDGET_EXHAUSTED","retry_in_seconds":1}}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"account":{"id":"5"}}}`))
+	}))
+	defer srv.Close()
+
+	s := newTestSource(t, srv.URL)
+	defer func() { _ = s.client.Close() }()
+
+	start := time.Now()
+	data, err := s.executeGraphQL(context.Background(), `query{account{id}}`, nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"id":"5"`)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "429 without Retry-After must still retry")
+	assert.GreaterOrEqual(t, time.Since(start), 900*time.Millisecond, "should honor the body retry_in_seconds wait")
+}
+
+// A persistent 429 is retried maxRetries+1 times, then surfaced as an error.
+func TestExecuteGraphQLExhaustsRetriesOn429(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Complexity budget exhausted"}]}`))
+	}))
+	defer srv.Close()
+
+	s := newTestSource(t, srv.URL)
+	defer func() { _ = s.client.Close() }()
+
+	_, err := s.executeGraphQL(context.Background(), `query{account{id}}`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "429")
+	assert.Equal(t, int32(maxRetries+1), atomic.LoadInt32(&hits), "expected 1 initial + maxRetries attempts")
+}
+
+// A 500 is retried and the request succeeds.
+func TestExecuteGraphQLRetriesServerError(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"internal error"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"account":{"id":"99"}}}`))
+	}))
+	defer srv.Close()
+
+	s := newTestSource(t, srv.URL)
+	defer func() { _ = s.client.Close() }()
+
+	data, err := s.executeGraphQL(context.Background(), `query{account{id}}`, nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"id":"99"`)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "a 500 should be retried")
+}
+
+// A normal GraphQL error (HTTP 200 with errors[]) is surfaced without retrying.
+func TestExecuteGraphQLDoesNotRetryOrdinaryError(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Field 'bogus' doesn't exist"}]}`))
+	}))
+	defer srv.Close()
+
+	s := newTestSource(t, srv.URL)
+	defer func() { _ = s.client.Close() }()
+
+	_, err := s.executeGraphQL(context.Background(), `query{bogus}`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "ordinary errors must not be retried")
 }


### PR DESCRIPTION
https://developer.monday.com/api-reference/docs/rate-limits

Monday's GraphQL calls go over POST, which the HTTP client wasn't retrying, so a rate limit (429) would fail the run. Now they retry and wait however long Monday asks for.

- Retries 429 and 5xx responses, using the Retry-After header when there is one.
- The complexity limit puts the wait in the body (retry_in_seconds) instead of a header, so we read it from there.
