### PR TITLE
Decorate SharePoint User-Agent to reduce throttling

### DIFF
--- a/pkg/source/sharepoint/graph.go
+++ b/pkg/source/sharepoint/graph.go
@@ -25,6 +25,10 @@ const graphBase = "https://graph.microsoft.com/v1.0"
 // Azure AD app registration.
 var graphScopes = []string{"https://graph.microsoft.com/.default"}
 
+// userAgent decorates requests so SharePoint throttles them less.
+// Microsoft's expected format: ISV|CompanyName|AppName/Version.
+const userAgent = "ISV|Bruin|ingestr/1.0"
+
 // graphClient talks to the Microsoft Graph API for a single SharePoint site.
 // Authentication uses the OAuth2 client-credentials flow via azidentity, which
 // caches and refreshes the access token internally.
@@ -65,6 +69,7 @@ func newGraphClient(cfg connConfig) (*graphClient, error) {
 	client := httpclient.New(
 		httpclient.WithTimeout(120*time.Second),
 		httpclient.WithRetry(5, 2*time.Second, 30*time.Second),
+		httpclient.WithUserAgent(userAgent),
 		httpclient.WithDebug(config.DebugMode),
 	)
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic

SharePoint Online throttles undecorated traffic more aggressively. This sets the Graph client's User-Agent to the format Microsoft expects (ISV|CompanyName|AppName/Version) so our requests get prioritized.
