### PR TITLE
Add MQTT source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/couchbase/gocb/v2 v2.12.1
 	github.com/databricks/databricks-sdk-go v0.95.0
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/elastic/go-elasticsearch/v9 v9.3.1
 	github.com/fatih/color v1.18.0
 	github.com/go-chi/chi/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -979,6 +979,8 @@ github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 h1:8EXxF+tCLqaVk8
 github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4/go.mod h1:I5sHm0Y0T1u5YjlyqC5GVArM7aNZRUYtTjmJ8mPJFds=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2ISgCl2W7nE=
+github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
 github.com/elastic/go-elasticsearch/v9 v9.3.1 h1:v5A9uFw0nLFA0luD3xAqliBXbscfuhch409HIinfhKY=

--- a/internal/registry/imports/mqtt.go
+++ b/internal/registry/imports/mqtt.go
@@ -1,0 +1,3 @@
+package imports
+
+import _ "github.com/bruin-data/ingestr/pkg/source/mqtt"

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -323,6 +323,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("mmap", "Memory-mapped File", []string{"mmap"}, true, false),
 		genericURIConnector("monday", "monday.com", []string{"monday"}, true, false),
 		genericURIConnector("motherduck", "MotherDuck", []string{"motherduck", "md"}, true, true),
+		genericURIConnector("mqtt", "MQTT", []string{"mqtt", "mqtts"}, true, false),
 		genericURIConnector("nats", "NATS JetStream", []string{"nats"}, true, false),
 		genericURIConnector("notion", "Notion", []string{"notion"}, true, false),
 		genericURIConnector("onelake", "OneLake", []string{"onelake"}, false, true),

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -697,6 +697,12 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
+    - module: github.com/eclipse/paho.mqtt.golang
+      version: v1.5.1
+      licenses:
+        - EPL-2.0
+      status: manual-review
+      note: EPL-2.0 reviewed for the MQTT source dependency.
     - module: github.com/elastic/elastic-transport-go/v8
       version: v8.8.0
       licenses:

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -83,7 +83,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	if p.config.Stream {
 		ss, ok := src.(source.StreamingSource)
 		if !ok || !ss.SupportsStreaming() {
-			return fmt.Errorf("--stream is not supported by this source; streaming requires a CDC source (postgres+cdc, mssql+cdc) or a message broker source (kafka, amqp, sqs, pubsub, kinesis)")
+			return fmt.Errorf("--stream is not supported by this source; streaming requires a CDC source (postgres+cdc, mssql+cdc) or a message broker source (kafka, amqp, mqtt, sqs, pubsub, kinesis)")
 		}
 	}
 

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -81,7 +81,7 @@ func (s *MQTTSource) SupportsStreaming() bool {
 }
 
 func (s *MQTTSource) DefaultStreamingStrategy() config.IncrementalStrategy {
-	return config.StrategyAppend
+	return config.StrategyMerge
 }
 
 func (s *MQTTSource) Connect(ctx context.Context, rawURI string) error {
@@ -198,12 +198,10 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 	}
 
 	streaming := opts.Streaming
-	if streaming {
-		s.mu.Lock()
-		s.nextSeq = 0
-		s.pending = make(map[int64]paho.Message)
-		s.mu.Unlock()
-	}
+	s.mu.Lock()
+	s.nextSeq = 0
+	s.pending = make(map[int64]paho.Message)
+	s.mu.Unlock()
 
 	incoming := make(chan paho.Message, batchSize)
 	done := make(chan struct{})
@@ -239,7 +237,6 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 		}
 
 		batch := make([]map[string]any, 0, batchSize)
-		batchMessages := make([]paho.Message, 0, batchSize)
 		var batchSeqs []int64
 		if streaming {
 			batchSeqs = make([]int64, 0, batchSize)
@@ -277,14 +274,7 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 			}
 			results <- res
 
-			if !streaming {
-				for _, msg := range batchMessages {
-					msg.Ack()
-				}
-			}
-
 			batch = batch[:0]
-			batchMessages = batchMessages[:0]
 			if streaming {
 				batchSeqs = batchSeqs[:0]
 			}
@@ -306,17 +296,14 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 				return
 
 			case msg := <-incoming:
-				var seq int64
+				seq := s.trackMessage(msg)
 				if streaming {
-					seq = s.trackMessage(msg)
 					batch = append(batch, messageToEnvelope(msg, seq))
 					batchSeqs = append(batchSeqs, seq)
 				} else {
 					totalRead++
-					seq = totalRead
 					batch = append(batch, messageToItem(msg, seq))
 				}
-				batchMessages = append(batchMessages, msg)
 				if streaming {
 					totalRead++
 				}
@@ -378,6 +365,14 @@ func (s *MQTTSource) CommitStream(_ context.Context, token any) error {
 	return nil
 }
 
+func (s *MQTTSource) FinalizeBatch(_ context.Context) error {
+	msgs := s.pendingThrough(s.currentSeq())
+	for _, msg := range msgs {
+		msg.Ack()
+	}
+	return nil
+}
+
 func (s *MQTTSource) pendingThrough(maxSeq int64) []paho.Message {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -390,6 +385,12 @@ func (s *MQTTSource) pendingThrough(maxSeq int64) []paho.Message {
 		}
 	}
 	return msgs
+}
+
+func (s *MQTTSource) currentSeq() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nextSeq
 }
 
 func messageToItem(msg paho.Message, seq int64) map[string]any {
@@ -673,7 +674,8 @@ func sanitizeURI(raw string) string {
 }
 
 var (
-	_ source.Source          = (*MQTTSource)(nil)
-	_ source.StreamingSource = (*MQTTSource)(nil)
-	_ source.StreamCommitter = (*MQTTSource)(nil)
+	_ source.Source            = (*MQTTSource)(nil)
+	_ source.StreamingSource   = (*MQTTSource)(nil)
+	_ source.StreamCommitter   = (*MQTTSource)(nil)
+	_ source.CDCBatchFinalizer = (*MQTTSource)(nil)
 )

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -394,7 +394,7 @@ func (s *MQTTSource) currentSeq() int64 {
 }
 
 func messageToItem(msg paho.Message, seq int64) map[string]any {
-	id, numericID := mqttMsgID(msg, seq)
+	id, numericID := mqttMsgID(msg)
 	return map[string]any{
 		"msg_id":          id,
 		"message_id":      numericID,
@@ -431,16 +431,11 @@ func messageMetadata(msg paho.Message, numericID any) map[string]any {
 	}
 }
 
-func mqttMsgID(msg paho.Message, seq int64) (string, any) {
+func mqttMsgID(msg paho.Message) (string, any) {
 	if id := msg.MessageID(); id != 0 {
 		return fmt.Sprintf("%s:%d:%s", msg.Topic(), id, mqttMessageFingerprint(msg)), int64(id)
 	}
-	h := sha256.New()
-	h.Write([]byte(msg.Topic()))
-	h.Write(msg.Payload())
-	_, _ = fmt.Fprintf(h, ":%d", seq)
-	sum := h.Sum(nil)
-	return strings.TrimRight(base64.StdEncoding.EncodeToString(sum[:18]), "="), nil
+	return fmt.Sprintf("%s:%s", msg.Topic(), mqttMessageFingerprint(msg)), nil
 }
 
 func mqttMessageFingerprint(msg paho.Message) string {

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -1,0 +1,679 @@
+package mqtt
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	paho "github.com/eclipse/paho.mqtt.golang"
+)
+
+const (
+	defaultBatchSize      = 3000
+	defaultBatchTimeout   = 5 * time.Second
+	defaultConnectTimeout = 30 * time.Second
+	defaultKeepAlive      = 30 * time.Second
+	defaultQOS            = byte(1)
+	streamOrderColumn     = "_ingestr_order"
+)
+
+type mqttConfig struct {
+	BrokerURL            string
+	ClientID             string
+	Username             string
+	Password             string
+	QOS                  byte
+	CleanSession         bool
+	BatchSize            int
+	BatchTimeout         time.Duration
+	ConnectTimeout       time.Duration
+	KeepAlive            time.Duration
+	InsecureSkipVerify   bool
+	ConnectRetry         bool
+	ConnectRetryInterval time.Duration
+	AutoReconnect        bool
+}
+
+type MQTTSource struct {
+	cfg    mqttConfig
+	client paho.Client
+
+	mu       sync.Mutex
+	nextSeq  int64
+	pending  map[int64]paho.Message
+	connLost chan error
+}
+
+type mqttCommitToken struct {
+	MaxSeq int64
+}
+
+func NewMQTTSource() *MQTTSource {
+	return &MQTTSource{
+		pending: make(map[int64]paho.Message),
+	}
+}
+
+func (s *MQTTSource) Schemes() []string {
+	return []string{"mqtt", "mqtts"}
+}
+
+func (s *MQTTSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *MQTTSource) SupportsStreaming() bool {
+	return true
+}
+
+func (s *MQTTSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyAppend
+}
+
+func (s *MQTTSource) Connect(ctx context.Context, rawURI string) error {
+	cfg, err := parseMQTTURI(rawURI)
+	if err != nil {
+		return err
+	}
+
+	s.cfg = cfg
+	s.connLost = make(chan error, 1)
+	opts := clientOptions(cfg)
+	opts.SetConnectionLostHandler(func(_ paho.Client, err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case s.connLost <- fmt.Errorf("mqtt connection lost: %w", err):
+		default:
+		}
+	})
+
+	client := paho.NewClient(opts)
+	if err := waitToken(ctx, client.Connect(), cfg.ConnectTimeout, "connect to MQTT broker"); err != nil {
+		return err
+	}
+
+	s.client = client
+	config.Debug("[MQTT] Connected to %s, client_id=%s, qos=%d", sanitizeURI(cfg.BrokerURL), cfg.ClientID, cfg.QOS)
+	return nil
+}
+
+func (s *MQTTSource) Close(_ context.Context) error {
+	if s.client != nil && s.client.IsConnected() {
+		s.client.Disconnect(250)
+	}
+	return nil
+}
+
+func (s *MQTTSource) GetTable(_ context.Context, req source.TableRequest) (source.SourceTable, error) {
+	topic := req.Name
+	if topic == "" {
+		return nil, fmt.Errorf("mqtt source requires a topic filter as source-table")
+	}
+
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	if req.Streaming {
+		streamStrategy := req.Strategy
+		if streamStrategy == "" {
+			streamStrategy = s.DefaultStreamingStrategy()
+		}
+		primaryKeys := req.PrimaryKeys
+		if len(primaryKeys) == 0 {
+			primaryKeys = []string{"msg_id"}
+		}
+		return &source.DynamicSourceTable{
+			TableName:           tableNameFromTopic(topic),
+			TablePrimaryKeys:    primaryKeys,
+			TableIncrementalKey: streamOrderColumn,
+			TableStrategy:       streamStrategy,
+			KnownSchema:         true,
+			SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+				return streamingEnvelopeSchema(tableNameFromTopic(topic)), nil
+			},
+			ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+				return s.read(ctx, topic, opts)
+			},
+		}, nil
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableNameFromTopic(topic),
+		TablePrimaryKeys:    req.PrimaryKeys,
+		TableIncrementalKey: req.IncrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("mqtt source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, topic, opts)
+		},
+	}, nil
+}
+
+func streamingEnvelopeSchema(table string) *schema.TableSchema {
+	return &schema.TableSchema{
+		Name: table,
+		Columns: []schema.Column{
+			{Name: "msg_id", DataType: schema.TypeString, Nullable: false, IsPrimaryKey: true},
+			{Name: "message_id", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "data", DataType: schema.TypeJSON, Nullable: true},
+			{Name: streamOrderColumn, DataType: schema.TypeInt64, Nullable: false},
+		},
+		PrimaryKeys:    []string{"msg_id"},
+		IncrementalKey: streamOrderColumn,
+	}
+}
+
+func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	if s.client == nil || !s.client.IsConnected() {
+		return nil, fmt.Errorf("mqtt client is not connected")
+	}
+
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = s.cfg.BatchSize
+	}
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+
+	streaming := opts.Streaming
+	if streaming {
+		s.mu.Lock()
+		s.nextSeq = 0
+		s.pending = make(map[int64]paho.Message)
+		s.mu.Unlock()
+	}
+
+	incoming := make(chan paho.Message, batchSize)
+	done := make(chan struct{})
+	handler := func(_ paho.Client, msg paho.Message) {
+		select {
+		case incoming <- msg:
+		case <-ctx.Done():
+		case <-done:
+		}
+	}
+
+	if err := waitToken(ctx, s.client.Subscribe(topic, s.cfg.QOS, handler), s.cfg.ConnectTimeout, "subscribe to MQTT topic"); err != nil {
+		close(done)
+		return nil, fmt.Errorf("failed to subscribe to topic %s: %w", topic, err)
+	}
+	config.Debug("[MQTT] Subscribed to %s with qos=%d", topic, s.cfg.QOS)
+
+	results := make(chan source.RecordBatchResult, 8)
+	go func() {
+		defer close(results)
+		defer close(done)
+		if !streaming {
+			defer func() {
+				if s.client != nil && s.client.IsConnected() {
+					_ = waitToken(context.Background(), s.client.Unsubscribe(topic), s.cfg.ConnectTimeout, "unsubscribe from MQTT topic")
+				}
+			}()
+		}
+
+		var envelopeCols []schema.Column
+		if streaming {
+			envelopeCols = streamingEnvelopeSchema(tableNameFromTopic(topic)).Columns
+		}
+
+		batch := make([]map[string]any, 0, batchSize)
+		batchMessages := make([]paho.Message, 0, batchSize)
+		var batchSeqs []int64
+		if streaming {
+			batchSeqs = make([]int64, 0, batchSize)
+		}
+		totalRead := int64(0)
+		limit := int64(opts.Limit)
+		receivedSinceLastTick := false
+
+		timer := time.NewTimer(s.cfg.BatchTimeout)
+		defer timer.Stop()
+
+		resetTimer := func() {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(s.cfg.BatchTimeout)
+		}
+
+		flush := func() bool {
+			if len(batch) == 0 {
+				return true
+			}
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, envelopeCols, opts.ExcludeColumns)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert MQTT messages to Arrow: %w", err)}
+				return false
+			}
+
+			res := source.RecordBatchResult{Batch: record}
+			if streaming {
+				res.CommitToken = mqttCommitToken{MaxSeq: batchSeqs[len(batchSeqs)-1]}
+			}
+			results <- res
+
+			if !streaming {
+				for _, msg := range batchMessages {
+					msg.Ack()
+				}
+			}
+
+			batch = batch[:0]
+			batchMessages = batchMessages[:0]
+			if streaming {
+				batchSeqs = batchSeqs[:0]
+			}
+			return true
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				flush()
+				return
+
+			case err := <-s.connLost:
+				if ctx.Err() != nil {
+					flush()
+					return
+				}
+				results <- source.RecordBatchResult{Err: err}
+				return
+
+			case msg := <-incoming:
+				var seq int64
+				if streaming {
+					seq = s.trackMessage(msg)
+					batch = append(batch, messageToEnvelope(msg, seq))
+					batchSeqs = append(batchSeqs, seq)
+				} else {
+					totalRead++
+					seq = totalRead
+					batch = append(batch, messageToItem(msg, seq))
+				}
+				batchMessages = append(batchMessages, msg)
+				if streaming {
+					totalRead++
+				}
+				receivedSinceLastTick = true
+
+				if limit > 0 && totalRead >= limit {
+					flush()
+					return
+				}
+
+				if len(batch) >= batchSize {
+					if !flush() {
+						return
+					}
+					resetTimer()
+					receivedSinceLastTick = false
+				}
+
+			case <-timer.C:
+				if len(batch) > 0 {
+					if !flush() {
+						return
+					}
+					timer.Reset(s.cfg.BatchTimeout)
+					receivedSinceLastTick = false
+					continue
+				}
+				if !streaming && !receivedSinceLastTick {
+					config.Debug("[MQTT] No new messages received, finishing read (total: %d)", totalRead)
+					return
+				}
+				receivedSinceLastTick = false
+				timer.Reset(s.cfg.BatchTimeout)
+			}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *MQTTSource) trackMessage(msg paho.Message) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSeq++
+	s.pending[s.nextSeq] = msg
+	return s.nextSeq
+}
+
+func (s *MQTTSource) CommitStream(_ context.Context, token any) error {
+	tok, ok := token.(mqttCommitToken)
+	if !ok {
+		return fmt.Errorf("mqtt: unexpected commit token type %T", token)
+	}
+
+	msgs := s.pendingThrough(tok.MaxSeq)
+	for _, msg := range msgs {
+		msg.Ack()
+	}
+	return nil
+}
+
+func (s *MQTTSource) pendingThrough(maxSeq int64) []paho.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msgs := make([]paho.Message, 0)
+	for seq, msg := range s.pending {
+		if seq <= maxSeq {
+			msgs = append(msgs, msg)
+			delete(s.pending, seq)
+		}
+	}
+	return msgs
+}
+
+func messageToItem(msg paho.Message, seq int64) map[string]any {
+	id, numericID := mqttMsgID(msg, seq)
+	return map[string]any{
+		"msg_id":          id,
+		"message_id":      numericID,
+		"data":            decodePayload(msg.Payload()),
+		"metadata":        messageMetadata(msg, numericID),
+		streamOrderColumn: seq,
+	}
+}
+
+func messageToEnvelope(msg paho.Message, seq int64) map[string]any {
+	item := messageToItem(msg, seq)
+	encoded, err := json.Marshal(map[string]any{
+		"data":     item["data"],
+		"metadata": item["metadata"],
+	})
+	if err != nil {
+		encoded = fmt.Appendf(nil, "%q", string(msg.Payload()))
+	}
+	return map[string]any{
+		"msg_id":          item["msg_id"],
+		"message_id":      item["message_id"],
+		"data":            string(encoded),
+		streamOrderColumn: seq,
+	}
+}
+
+func messageMetadata(msg paho.Message, numericID any) map[string]any {
+	return map[string]any{
+		"topic":      msg.Topic(),
+		"qos":        int(msg.Qos()),
+		"retained":   msg.Retained(),
+		"duplicate":  msg.Duplicate(),
+		"message_id": numericID,
+	}
+}
+
+func mqttMsgID(msg paho.Message, seq int64) (string, any) {
+	if id := msg.MessageID(); id != 0 {
+		return fmt.Sprintf("%s:%d", msg.Topic(), id), int64(id)
+	}
+	h := sha256.New()
+	h.Write([]byte(msg.Topic()))
+	h.Write(msg.Payload())
+	_, _ = fmt.Fprintf(h, ":%d", seq)
+	sum := h.Sum(nil)
+	return strings.TrimRight(base64.StdEncoding.EncodeToString(sum[:18]), "="), nil
+}
+
+func decodePayload(payload []byte) any {
+	var decoded any
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+	if err := dec.Decode(&decoded); err == nil {
+		return decoded
+	}
+	return string(payload)
+}
+
+func clientOptions(cfg mqttConfig) *paho.ClientOptions {
+	opts := paho.NewClientOptions().
+		AddBroker(cfg.BrokerURL).
+		SetClientID(cfg.ClientID).
+		SetCleanSession(cfg.CleanSession).
+		SetAutoAckDisabled(true).
+		SetAutoReconnect(cfg.AutoReconnect).
+		SetConnectRetry(cfg.ConnectRetry).
+		SetConnectRetryInterval(cfg.ConnectRetryInterval).
+		SetConnectTimeout(cfg.ConnectTimeout).
+		SetKeepAlive(cfg.KeepAlive).
+		SetWriteTimeout(cfg.ConnectTimeout).
+		SetOrderMatters(false)
+
+	if cfg.Username != "" {
+		opts.SetUsername(cfg.Username)
+	}
+	if cfg.Password != "" {
+		opts.SetPassword(cfg.Password)
+	}
+	if strings.HasPrefix(cfg.BrokerURL, "ssl://") {
+		opts.SetTLSConfig(&tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
+		})
+	}
+	return opts
+}
+
+func parseMQTTURI(raw string) (mqttConfig, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return mqttConfig{}, fmt.Errorf("invalid mqtt URI: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "mqtt" && scheme != "mqtts" {
+		return mqttConfig{}, fmt.Errorf("invalid mqtt URI: must start with mqtt:// or mqtts://")
+	}
+	if u.Hostname() == "" {
+		return mqttConfig{}, fmt.Errorf("mqtt URI: host is required")
+	}
+
+	q := u.Query()
+	cleanSession := true
+	if rawClean := firstQuery(q, "clean_session", "clean"); rawClean != "" {
+		parsed, err := strconv.ParseBool(rawClean)
+		if err != nil {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: clean_session must be a boolean")
+		}
+		cleanSession = parsed
+	}
+
+	clientID := firstQuery(q, "client_id", "clientid")
+	if clientID == "" && !cleanSession {
+		return mqttConfig{}, fmt.Errorf("mqtt URI: client_id is required when clean_session=false")
+	}
+	if clientID == "" {
+		clientID = fmt.Sprintf("ingestr-%d-%d", os.Getpid(), time.Now().UnixNano())
+	}
+
+	username := firstQuery(q, "username", "user")
+	password := firstQuery(q, "password", "pass")
+	if u.User != nil {
+		username = u.User.Username()
+		if pwd, ok := u.User.Password(); ok {
+			password = pwd
+		}
+	}
+
+	brokerScheme := "tcp"
+	defaultPort := "1883"
+	if scheme == "mqtts" {
+		brokerScheme = "ssl"
+		defaultPort = "8883"
+	}
+	host := u.Host
+	if u.Port() == "" {
+		host = u.Hostname() + ":" + defaultPort
+	}
+
+	cfg := mqttConfig{
+		BrokerURL:            brokerScheme + "://" + host,
+		ClientID:             clientID,
+		Username:             username,
+		Password:             password,
+		QOS:                  defaultQOS,
+		CleanSession:         cleanSession,
+		BatchSize:            defaultBatchSize,
+		BatchTimeout:         defaultBatchTimeout,
+		ConnectTimeout:       defaultConnectTimeout,
+		KeepAlive:            defaultKeepAlive,
+		ConnectRetryInterval: time.Second,
+	}
+
+	if v := firstQuery(q, "qos"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 0 || parsed > 2 {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: qos must be 0, 1, or 2")
+		}
+		cfg.QOS = byte(parsed)
+	}
+	if v := firstQuery(q, "batch_size"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed <= 0 {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: batch_size must be positive")
+		}
+		cfg.BatchSize = parsed
+	}
+	if v := firstQuery(q, "batch_timeout", "batch_timeout_seconds"); v != "" {
+		parsed, err := parseDuration(v)
+		if err != nil || parsed <= 0 {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: batch_timeout must be a positive duration")
+		}
+		cfg.BatchTimeout = parsed
+	}
+	if v := firstQuery(q, "connect_timeout", "connect_timeout_seconds"); v != "" {
+		parsed, err := parseDuration(v)
+		if err != nil || parsed <= 0 {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: connect_timeout must be a positive duration")
+		}
+		cfg.ConnectTimeout = parsed
+	}
+	if v := firstQuery(q, "keep_alive", "keepalive"); v != "" {
+		parsed, err := parseDuration(v)
+		if err != nil || parsed <= 0 {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: keep_alive must be a positive duration")
+		}
+		cfg.KeepAlive = parsed
+	}
+	if v := firstQuery(q, "insecure_skip_verify", "tls_insecure_skip_verify"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: insecure_skip_verify must be a boolean")
+		}
+		cfg.InsecureSkipVerify = parsed
+	}
+	if v := firstQuery(q, "connect_retry"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: connect_retry must be a boolean")
+		}
+		cfg.ConnectRetry = parsed
+	}
+	if v := firstQuery(q, "auto_reconnect"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: auto_reconnect must be a boolean")
+		}
+		cfg.AutoReconnect = parsed
+	}
+	if v := firstQuery(q, "connect_retry_interval"); v != "" {
+		parsed, err := parseDuration(v)
+		if err != nil || parsed <= 0 {
+			return mqttConfig{}, fmt.Errorf("mqtt URI: connect_retry_interval must be a positive duration")
+		}
+		cfg.ConnectRetryInterval = parsed
+	}
+
+	return cfg, nil
+}
+
+func parseDuration(raw string) (time.Duration, error) {
+	if seconds, err := strconv.Atoi(raw); err == nil {
+		return time.Duration(seconds) * time.Second, nil
+	}
+	return time.ParseDuration(raw)
+}
+
+func firstQuery(values url.Values, keys ...string) string {
+	for _, key := range keys {
+		if v := values.Get(key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func waitToken(ctx context.Context, token paho.Token, timeout time.Duration, action string) error {
+	done := make(chan error, 1)
+	go func() {
+		token.Wait()
+		done <- token.Error()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("%s: %w", action, err)
+		}
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("%s timed out after %s", action, timeout)
+	}
+}
+
+func tableNameFromTopic(topic string) string {
+	name := strings.Trim(topic, "/")
+	if name == "" {
+		return "mqtt_messages"
+	}
+	replacer := strings.NewReplacer("/", "_", "+", "plus", "#", "all")
+	return replacer.Replace(name)
+}
+
+func sanitizeURI(raw string) string {
+	if _, after, found := strings.Cut(raw, "@"); found {
+		scheme := "mqtt"
+		if before, _, hasScheme := strings.Cut(raw, "://"); hasScheme {
+			scheme = before
+		}
+		return scheme + "://***@" + after
+	}
+	return raw
+}
+
+var (
+	_ source.Source          = (*MQTTSource)(nil)
+	_ source.StreamingSource = (*MQTTSource)(nil)
+	_ source.StreamCommitter = (*MQTTSource)(nil)
+)

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -433,7 +433,7 @@ func messageMetadata(msg paho.Message, numericID any) map[string]any {
 
 func mqttMsgID(msg paho.Message, seq int64) (string, any) {
 	if id := msg.MessageID(); id != 0 {
-		return fmt.Sprintf("%s:%d", msg.Topic(), id), int64(id)
+		return fmt.Sprintf("%s:%d:%s", msg.Topic(), id, mqttMessageFingerprint(msg)), int64(id)
 	}
 	h := sha256.New()
 	h.Write([]byte(msg.Topic()))
@@ -441,6 +441,20 @@ func mqttMsgID(msg paho.Message, seq int64) (string, any) {
 	_, _ = fmt.Fprintf(h, ":%d", seq)
 	sum := h.Sum(nil)
 	return strings.TrimRight(base64.StdEncoding.EncodeToString(sum[:18]), "="), nil
+}
+
+func mqttMessageFingerprint(msg paho.Message) string {
+	h := sha256.New()
+	h.Write([]byte(msg.Topic()))
+	h.Write([]byte{msg.Qos()})
+	if msg.Retained() {
+		h.Write([]byte{1})
+	} else {
+		h.Write([]byte{0})
+	}
+	h.Write(msg.Payload())
+	sum := h.Sum(nil)
+	return strings.TrimRight(base64.StdEncoding.EncodeToString(sum[:12]), "=")
 }
 
 func decodePayload(payload []byte) any {

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -351,7 +351,7 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 }
 
 func (s *MQTTSource) trackMessage(msg paho.Message) int64 {
-	key := mqttDeliveryKey(msg)
+	key := mqttPendingKey(msg)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -470,6 +470,13 @@ func mqttMsgID(msg paho.Message, seq int64) (string, any) {
 
 func mqttDeliveryKey(msg paho.Message) string {
 	return fmt.Sprintf("%s:%s", msg.Topic(), mqttMessageFingerprint(msg))
+}
+
+func mqttPendingKey(msg paho.Message) string {
+	if id := msg.MessageID(); id != 0 {
+		return fmt.Sprintf("%s:%d:%s", msg.Topic(), id, mqttMessageFingerprint(msg))
+	}
+	return mqttDeliveryKey(msg)
 }
 
 func numericMessageID(msg paho.Message) any {

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -52,10 +52,12 @@ type MQTTSource struct {
 	cfg    mqttConfig
 	client paho.Client
 
-	mu       sync.Mutex
-	nextSeq  int64
-	pending  map[int64]paho.Message
-	connLost chan error
+	mu           sync.Mutex
+	nextSeq      int64
+	pending      map[int64]paho.Message
+	pendingKeys  map[int64]string
+	pendingByKey map[string]int64
+	connLost     chan error
 }
 
 type mqttCommitToken struct {
@@ -64,7 +66,9 @@ type mqttCommitToken struct {
 
 func NewMQTTSource() *MQTTSource {
 	return &MQTTSource{
-		pending: make(map[int64]paho.Message),
+		pending:      make(map[int64]paho.Message),
+		pendingKeys:  make(map[int64]string),
+		pendingByKey: make(map[string]int64),
 	}
 }
 
@@ -201,6 +205,8 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 	s.mu.Lock()
 	s.nextSeq = 0
 	s.pending = make(map[int64]paho.Message)
+	s.pendingKeys = make(map[int64]string)
+	s.pendingByKey = make(map[string]int64)
 	s.mu.Unlock()
 
 	incoming := make(chan paho.Message, batchSize)
@@ -345,10 +351,29 @@ func (s *MQTTSource) read(ctx context.Context, topic string, opts source.ReadOpt
 }
 
 func (s *MQTTSource) trackMessage(msg paho.Message) int64 {
+	key := mqttDeliveryKey(msg)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.pending == nil {
+		s.pending = make(map[int64]paho.Message)
+	}
+	if s.pendingKeys == nil {
+		s.pendingKeys = make(map[int64]string)
+	}
+	if s.pendingByKey == nil {
+		s.pendingByKey = make(map[string]int64)
+	}
+	if seq, ok := s.pendingByKey[key]; ok {
+		s.pending[seq] = msg
+		return seq
+	}
+
 	s.nextSeq++
 	s.pending[s.nextSeq] = msg
+	s.pendingKeys[s.nextSeq] = key
+	s.pendingByKey[key] = s.nextSeq
 	return s.nextSeq
 }
 
@@ -382,6 +407,10 @@ func (s *MQTTSource) pendingThrough(maxSeq int64) []paho.Message {
 		if seq <= maxSeq {
 			msgs = append(msgs, msg)
 			delete(s.pending, seq)
+			if key, ok := s.pendingKeys[seq]; ok {
+				delete(s.pendingByKey, key)
+				delete(s.pendingKeys, seq)
+			}
 		}
 	}
 	return msgs
@@ -394,7 +423,7 @@ func (s *MQTTSource) currentSeq() int64 {
 }
 
 func messageToItem(msg paho.Message, seq int64) map[string]any {
-	id, numericID := mqttMsgID(msg)
+	id, numericID := mqttMsgID(msg, seq)
 	return map[string]any{
 		"msg_id":          id,
 		"message_id":      numericID,
@@ -431,11 +460,18 @@ func messageMetadata(msg paho.Message, numericID any) map[string]any {
 	}
 }
 
-func mqttMsgID(msg paho.Message) (string, any) {
+func mqttMsgID(msg paho.Message, seq int64) (string, any) {
 	if id := msg.MessageID(); id != 0 {
-		return fmt.Sprintf("%s:%d:%s", msg.Topic(), id, mqttMessageFingerprint(msg)), int64(id)
+		return fmt.Sprintf("%s:%d", mqttDeliveryKey(msg), seq), int64(id)
 	}
-	return fmt.Sprintf("%s:%s", msg.Topic(), mqttMessageFingerprint(msg)), nil
+	return mqttDeliveryKey(msg), nil
+}
+
+func mqttDeliveryKey(msg paho.Message) string {
+	if id := msg.MessageID(); id != 0 {
+		return fmt.Sprintf("%s:%d:%s", msg.Topic(), id, mqttMessageFingerprint(msg))
+	}
+	return fmt.Sprintf("%s:%s", msg.Topic(), mqttMessageFingerprint(msg))
 }
 
 func mqttMessageFingerprint(msg paho.Message) string {

--- a/pkg/source/mqtt/mqtt.go
+++ b/pkg/source/mqtt/mqtt.go
@@ -365,7 +365,7 @@ func (s *MQTTSource) trackMessage(msg paho.Message) int64 {
 	if s.pendingByKey == nil {
 		s.pendingByKey = make(map[string]int64)
 	}
-	if seq, ok := s.pendingByKey[key]; ok {
+	if seq, ok := s.pendingByKey[key]; ok && msg.Duplicate() {
 		s.pending[seq] = msg
 		return seq
 	}
@@ -461,17 +461,22 @@ func messageMetadata(msg paho.Message, numericID any) map[string]any {
 }
 
 func mqttMsgID(msg paho.Message, seq int64) (string, any) {
-	if id := msg.MessageID(); id != 0 {
-		return fmt.Sprintf("%s:%d", mqttDeliveryKey(msg), seq), int64(id)
+	numericID := numericMessageID(msg)
+	if msg.Retained() {
+		return mqttDeliveryKey(msg), numericID
 	}
-	return mqttDeliveryKey(msg), nil
+	return fmt.Sprintf("%s:%d", mqttDeliveryKey(msg), seq), numericID
 }
 
 func mqttDeliveryKey(msg paho.Message) string {
-	if id := msg.MessageID(); id != 0 {
-		return fmt.Sprintf("%s:%d:%s", msg.Topic(), id, mqttMessageFingerprint(msg))
-	}
 	return fmt.Sprintf("%s:%s", msg.Topic(), mqttMessageFingerprint(msg))
+}
+
+func numericMessageID(msg paho.Message) any {
+	if id := msg.MessageID(); id != 0 {
+		return int64(id)
+	}
+	return nil
 }
 
 func mqttMessageFingerprint(msg paho.Message) string {

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -161,9 +161,10 @@ func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
 	differentPayload := msg
 	differentPayload.payload = []byte(`{"device":"a","value":22.0}`)
 
-	msgID, numericID := mqttMsgID(msg)
-	redeliveryID, _ := mqttMsgID(redelivery)
-	otherID, _ := mqttMsgID(differentPayload)
+	msgID, numericID := mqttMsgID(msg, 7)
+	redeliveryID, _ := mqttMsgID(redelivery, 7)
+	otherID, _ := mqttMsgID(differentPayload, 8)
+	reusedPacketID, _ := mqttMsgID(msg, 8)
 
 	if numericID != int64(42) {
 		t.Fatalf("numericID = %v, want 42", numericID)
@@ -173,6 +174,9 @@ func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
 	}
 	if msgID == otherID {
 		t.Fatalf("different payload with reused packet ID produced same msg_id: %q", msgID)
+	}
+	if msgID == reusedPacketID {
+		t.Fatalf("reused packet ID after ack should produce a new msg_id: %q", msgID)
 	}
 }
 
@@ -232,6 +236,31 @@ func TestFinalizeBatchAcksPendingMessages(t *testing.T) {
 	}
 	if msg1.ackCount != 1 || msg2.ackCount != 1 {
 		t.Fatalf("second finalize ack counts = %d, %d; want 1, 1", msg1.ackCount, msg2.ackCount)
+	}
+}
+
+func TestTrackMessageReusesPendingSequenceForRedelivery(t *testing.T) {
+	src := NewMQTTSource()
+	msg := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", qos: 1, messageID: 1, payload: []byte("a")}}
+	redelivery := &ackMessage{fakeMessage: msg.fakeMessage}
+	redelivery.duplicate = true
+
+	seq := src.trackMessage(msg)
+	redeliverySeq := src.trackMessage(redelivery)
+	if seq != redeliverySeq {
+		t.Fatalf("redelivery sequence = %d, want %d", redeliverySeq, seq)
+	}
+
+	if err := src.CommitStream(context.Background(), mqttCommitToken{MaxSeq: seq}); err != nil {
+		t.Fatalf("CommitStream returned error: %v", err)
+	}
+	if msg.ackCount != 0 || redelivery.ackCount != 1 {
+		t.Fatalf("ack counts = %d, %d; want latest redelivery only", msg.ackCount, redelivery.ackCount)
+	}
+
+	reusedSeq := src.trackMessage(msg)
+	if reusedSeq == seq {
+		t.Fatalf("reused packet ID after ack kept old sequence %d", seq)
 	}
 }
 

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -250,7 +250,6 @@ func TestTrackMessageReusesPendingSequenceForRedelivery(t *testing.T) {
 	msg := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", qos: 1, messageID: 1, payload: []byte("a")}}
 	redelivery := &ackMessage{fakeMessage: msg.fakeMessage}
 	redelivery.duplicate = true
-	redelivery.messageID = 2
 
 	seq := src.trackMessage(msg)
 	redeliverySeq := src.trackMessage(redelivery)
@@ -268,6 +267,25 @@ func TestTrackMessageReusesPendingSequenceForRedelivery(t *testing.T) {
 	reusedSeq := src.trackMessage(msg)
 	if reusedSeq == seq {
 		t.Fatalf("reused packet ID after ack kept old sequence %d", seq)
+	}
+}
+
+func TestTrackMessageDistinguishesPacketIDsForPendingRedelivery(t *testing.T) {
+	src := NewMQTTSource()
+	msg1 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", qos: 1, messageID: 1, payload: []byte("a")}}
+	msg2 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", qos: 1, messageID: 2, payload: []byte("a")}}
+
+	seq1 := src.trackMessage(msg1)
+	seq2 := src.trackMessage(msg2)
+	if seq1 == seq2 {
+		t.Fatalf("different packet IDs reused pending sequence %d", seq1)
+	}
+
+	redelivery := &ackMessage{fakeMessage: msg1.fakeMessage}
+	redelivery.duplicate = true
+	redeliverySeq := src.trackMessage(redelivery)
+	if redeliverySeq != seq1 {
+		t.Fatalf("redelivery sequence = %d, want %d", redeliverySeq, seq1)
 	}
 }
 

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -1,9 +1,13 @@
 package mqtt
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	sourcepkg "github.com/bruin-data/ingestr/pkg/source"
 )
 
 func TestParseMQTTURI(t *testing.T) {
@@ -86,6 +90,24 @@ func TestParseMQTTURI(t *testing.T) {
 	}
 }
 
+func TestStreamingTableDefaultsToMerge(t *testing.T) {
+	src := NewMQTTSource()
+	table, err := src.GetTable(context.Background(), sourcepkg.TableRequest{
+		Name:      "events/#",
+		Streaming: true,
+	})
+	if err != nil {
+		t.Fatalf("GetTable returned error: %v", err)
+	}
+	if got := table.Strategy(); got != config.StrategyMerge {
+		t.Fatalf("Strategy = %q, want %q", got, config.StrategyMerge)
+	}
+	pks := table.PrimaryKeys()
+	if len(pks) != 1 || pks[0] != "msg_id" {
+		t.Fatalf("PrimaryKeys = %v, want [msg_id]", pks)
+	}
+}
+
 func TestMessageToItemPreservesMessageID(t *testing.T) {
 	msg := fakeMessage{
 		topic:     "sensors/temp",
@@ -154,6 +176,57 @@ func TestMessageToItemGeneratesIDWhenPacketIDMissing(t *testing.T) {
 	}
 }
 
+func TestFinalizeBatchAcksPendingMessages(t *testing.T) {
+	src := NewMQTTSource()
+	msg1 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", messageID: 1}}
+	msg2 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", messageID: 2}}
+
+	src.trackMessage(msg1)
+	src.trackMessage(msg2)
+	if msg1.ackCount != 0 || msg2.ackCount != 0 {
+		t.Fatalf("messages were acked before finalize: %d, %d", msg1.ackCount, msg2.ackCount)
+	}
+
+	if err := src.FinalizeBatch(context.Background()); err != nil {
+		t.Fatalf("FinalizeBatch returned error: %v", err)
+	}
+	if msg1.ackCount != 1 || msg2.ackCount != 1 {
+		t.Fatalf("ack counts = %d, %d; want 1, 1", msg1.ackCount, msg2.ackCount)
+	}
+
+	if err := src.FinalizeBatch(context.Background()); err != nil {
+		t.Fatalf("second FinalizeBatch returned error: %v", err)
+	}
+	if msg1.ackCount != 1 || msg2.ackCount != 1 {
+		t.Fatalf("second finalize ack counts = %d, %d; want 1, 1", msg1.ackCount, msg2.ackCount)
+	}
+}
+
+func TestCommitStreamAcksThroughToken(t *testing.T) {
+	src := NewMQTTSource()
+	msg1 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", messageID: 1}}
+	msg2 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", messageID: 2}}
+	msg3 := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", messageID: 3}}
+
+	src.trackMessage(msg1)
+	src.trackMessage(msg2)
+	src.trackMessage(msg3)
+
+	if err := src.CommitStream(context.Background(), mqttCommitToken{MaxSeq: 2}); err != nil {
+		t.Fatalf("CommitStream returned error: %v", err)
+	}
+	if msg1.ackCount != 1 || msg2.ackCount != 1 || msg3.ackCount != 0 {
+		t.Fatalf("ack counts = %d, %d, %d; want 1, 1, 0", msg1.ackCount, msg2.ackCount, msg3.ackCount)
+	}
+
+	if err := src.CommitStream(context.Background(), mqttCommitToken{MaxSeq: 3}); err != nil {
+		t.Fatalf("second CommitStream returned error: %v", err)
+	}
+	if msg3.ackCount != 1 {
+		t.Fatalf("msg3 ack count = %d, want 1", msg3.ackCount)
+	}
+}
+
 type fakeMessage struct {
 	topic     string
 	qos       byte
@@ -188,3 +261,12 @@ func (m fakeMessage) Payload() []byte {
 }
 
 func (m fakeMessage) Ack() {}
+
+type ackMessage struct {
+	fakeMessage
+	ackCount int
+}
+
+func (m *ackMessage) Ack() {
+	m.ackCount++
+}

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -1,0 +1,190 @@
+package mqtt
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestParseMQTTURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+		check   func(t *testing.T, cfg mqttConfig)
+	}{
+		{
+			name: "full mqtt uri",
+			uri:  "mqtt://user:pass@localhost:1883?client_id=ingestr-test&qos=2&clean_session=false&batch_size=25&batch_timeout=1500ms&connect_timeout=2&keep_alive=10s&auto_reconnect=true&connect_retry=true",
+			check: func(t *testing.T, cfg mqttConfig) {
+				if cfg.BrokerURL != "tcp://localhost:1883" {
+					t.Fatalf("BrokerURL = %q", cfg.BrokerURL)
+				}
+				if cfg.ClientID != "ingestr-test" {
+					t.Fatalf("ClientID = %q", cfg.ClientID)
+				}
+				if cfg.Username != "user" || cfg.Password != "pass" {
+					t.Fatalf("credentials = %q/%q", cfg.Username, cfg.Password)
+				}
+				if cfg.QOS != 2 {
+					t.Fatalf("QOS = %d", cfg.QOS)
+				}
+				if cfg.CleanSession {
+					t.Fatal("CleanSession should be false")
+				}
+				if cfg.BatchSize != 25 {
+					t.Fatalf("BatchSize = %d", cfg.BatchSize)
+				}
+				if cfg.BatchTimeout != 1500*time.Millisecond {
+					t.Fatalf("BatchTimeout = %s", cfg.BatchTimeout)
+				}
+				if cfg.ConnectTimeout != 2*time.Second {
+					t.Fatalf("ConnectTimeout = %s", cfg.ConnectTimeout)
+				}
+				if cfg.KeepAlive != 10*time.Second {
+					t.Fatalf("KeepAlive = %s", cfg.KeepAlive)
+				}
+				if !cfg.AutoReconnect || !cfg.ConnectRetry {
+					t.Fatal("reconnect flags should be true")
+				}
+			},
+		},
+		{
+			name: "mqtts defaults",
+			uri:  "mqtts://example.com?client_id=secure&insecure_skip_verify=true",
+			check: func(t *testing.T, cfg mqttConfig) {
+				if cfg.BrokerURL != "ssl://example.com:8883" {
+					t.Fatalf("BrokerURL = %q", cfg.BrokerURL)
+				}
+				if !cfg.InsecureSkipVerify {
+					t.Fatal("InsecureSkipVerify should be true")
+				}
+			},
+		},
+		{name: "invalid scheme", uri: "http://localhost:1883", wantErr: true},
+		{name: "missing host", uri: "mqtt://?client_id=x", wantErr: true},
+		{name: "invalid qos", uri: "mqtt://localhost:1883?client_id=x&qos=3", wantErr: true},
+		{name: "persistent session requires client id", uri: "mqtt://localhost:1883?clean_session=false", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseMQTTURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, cfg)
+			}
+		})
+	}
+}
+
+func TestMessageToItemPreservesMessageID(t *testing.T) {
+	msg := fakeMessage{
+		topic:     "sensors/temp",
+		qos:       1,
+		messageID: 42,
+		payload:   []byte(`{"device":"a","value":21.5}`),
+	}
+
+	item := messageToItem(msg, 7)
+	if item["msg_id"] != "sensors/temp:42" {
+		t.Fatalf("msg_id = %v", item["msg_id"])
+	}
+	if item["message_id"] != int64(42) {
+		t.Fatalf("message_id = %v", item["message_id"])
+	}
+	if item[streamOrderColumn] != int64(7) {
+		t.Fatalf("%s = %v", streamOrderColumn, item[streamOrderColumn])
+	}
+	data, ok := item["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data type = %T", item["data"])
+	}
+	if data["device"] != "a" {
+		t.Fatalf("device = %v", data["device"])
+	}
+
+	envelope := messageToEnvelope(msg, 7)
+	if envelope["message_id"] != int64(42) {
+		t.Fatalf("envelope message_id = %v", envelope["message_id"])
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(envelope["data"].(string)), &decoded); err != nil {
+		t.Fatalf("invalid envelope data JSON: %v", err)
+	}
+	metadata := decoded["metadata"].(map[string]any)
+	if metadata["message_id"] != float64(42) {
+		t.Fatalf("metadata message_id = %v", metadata["message_id"])
+	}
+}
+
+func TestMessageToItemGeneratesIDWhenPacketIDMissing(t *testing.T) {
+	msg := fakeMessage{
+		topic:   "sensors/temp",
+		qos:     0,
+		payload: []byte("plain"),
+	}
+
+	item := messageToItem(msg, 1)
+	if item["message_id"] != nil {
+		t.Fatalf("message_id = %v, want nil", item["message_id"])
+	}
+	if item["msg_id"] == "" {
+		t.Fatal("msg_id should be generated")
+	}
+	if item["data"] != "plain" {
+		t.Fatalf("data = %v", item["data"])
+	}
+
+	again := messageToItem(msg, 1)
+	if item["msg_id"] != again["msg_id"] {
+		t.Fatalf("generated msg_id should be deterministic for same seq: %v != %v", item["msg_id"], again["msg_id"])
+	}
+	otherSeq := messageToItem(msg, 2)
+	if item["msg_id"] == otherSeq["msg_id"] {
+		t.Fatal("generated msg_id should include sequence to avoid same-payload collisions")
+	}
+}
+
+type fakeMessage struct {
+	topic     string
+	qos       byte
+	retained  bool
+	duplicate bool
+	messageID uint16
+	payload   []byte
+}
+
+func (m fakeMessage) Duplicate() bool {
+	return m.duplicate
+}
+
+func (m fakeMessage) Qos() byte {
+	return m.qos
+}
+
+func (m fakeMessage) Retained() bool {
+	return m.retained
+}
+
+func (m fakeMessage) Topic() string {
+	return m.topic
+}
+
+func (m fakeMessage) MessageID() uint16 {
+	return m.messageID
+}
+
+func (m fakeMessage) Payload() []byte {
+	return m.payload
+}
+
+func (m fakeMessage) Ack() {}

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -161,9 +161,9 @@ func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
 	differentPayload := msg
 	differentPayload.payload = []byte(`{"device":"a","value":22.0}`)
 
-	msgID, numericID := mqttMsgID(msg, 7)
-	redeliveryID, _ := mqttMsgID(redelivery, 100)
-	otherID, _ := mqttMsgID(differentPayload, 8)
+	msgID, numericID := mqttMsgID(msg)
+	redeliveryID, _ := mqttMsgID(redelivery)
+	otherID, _ := mqttMsgID(differentPayload)
 
 	if numericID != int64(42) {
 		t.Fatalf("numericID = %v, want 42", numericID)
@@ -176,7 +176,7 @@ func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
 	}
 }
 
-func TestMessageToItemGeneratesIDWhenPacketIDMissing(t *testing.T) {
+func TestMessageToItemGeneratesStableIDWhenPacketIDMissing(t *testing.T) {
 	msg := fakeMessage{
 		topic:   "sensors/temp",
 		qos:     0,
@@ -199,8 +199,13 @@ func TestMessageToItemGeneratesIDWhenPacketIDMissing(t *testing.T) {
 		t.Fatalf("generated msg_id should be deterministic for same seq: %v != %v", item["msg_id"], again["msg_id"])
 	}
 	otherSeq := messageToItem(msg, 2)
-	if item["msg_id"] == otherSeq["msg_id"] {
-		t.Fatal("generated msg_id should include sequence to avoid same-payload collisions")
+	if item["msg_id"] != otherSeq["msg_id"] {
+		t.Fatalf("generated msg_id should be stable across reads: %v != %v", item["msg_id"], otherSeq["msg_id"])
+	}
+	otherPayload := msg
+	otherPayload.payload = []byte("other")
+	if item["msg_id"] == messageToItem(otherPayload, 2)["msg_id"] {
+		t.Fatal("generated msg_id should include payload fingerprint")
 	}
 }
 

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -3,7 +3,6 @@ package mqtt
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -118,7 +117,7 @@ func TestMessageToItemPreservesMessageID(t *testing.T) {
 	}
 
 	item := messageToItem(msg, 7)
-	if got, ok := item["msg_id"].(string); !ok || !strings.HasPrefix(got, "sensors/temp:42:") {
+	if item["msg_id"] == "" {
 		t.Fatalf("msg_id = %v", item["msg_id"])
 	}
 	if item["message_id"] != int64(42) {
@@ -149,7 +148,7 @@ func TestMessageToItemPreservesMessageID(t *testing.T) {
 	}
 }
 
-func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
+func TestMQTTMessageIDUsesFingerprintAndSequenceWhenPacketIDExists(t *testing.T) {
 	msg := fakeMessage{
 		topic:     "sensors/temp",
 		qos:       1,
@@ -182,9 +181,10 @@ func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
 
 func TestMessageToItemGeneratesStableIDWhenPacketIDMissing(t *testing.T) {
 	msg := fakeMessage{
-		topic:   "sensors/temp",
-		qos:     0,
-		payload: []byte("plain"),
+		topic:    "sensors/temp",
+		qos:      0,
+		retained: true,
+		payload:  []byte("plain"),
 	}
 
 	item := messageToItem(msg, 1)
@@ -210,6 +210,12 @@ func TestMessageToItemGeneratesStableIDWhenPacketIDMissing(t *testing.T) {
 	otherPayload.payload = []byte("other")
 	if item["msg_id"] == messageToItem(otherPayload, 2)["msg_id"] {
 		t.Fatal("generated msg_id should include payload fingerprint")
+	}
+
+	live := msg
+	live.retained = false
+	if messageToItem(live, 1)["msg_id"] == messageToItem(live, 2)["msg_id"] {
+		t.Fatal("live zero-packet-ID messages should include sequence")
 	}
 }
 
@@ -244,6 +250,7 @@ func TestTrackMessageReusesPendingSequenceForRedelivery(t *testing.T) {
 	msg := &ackMessage{fakeMessage: fakeMessage{topic: "sensors/temp", qos: 1, messageID: 1, payload: []byte("a")}}
 	redelivery := &ackMessage{fakeMessage: msg.fakeMessage}
 	redelivery.duplicate = true
+	redelivery.messageID = 2
 
 	seq := src.trackMessage(msg)
 	redeliverySeq := src.trackMessage(redelivery)

--- a/pkg/source/mqtt/mqtt_test.go
+++ b/pkg/source/mqtt/mqtt_test.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,7 +118,7 @@ func TestMessageToItemPreservesMessageID(t *testing.T) {
 	}
 
 	item := messageToItem(msg, 7)
-	if item["msg_id"] != "sensors/temp:42" {
+	if got, ok := item["msg_id"].(string); !ok || !strings.HasPrefix(got, "sensors/temp:42:") {
 		t.Fatalf("msg_id = %v", item["msg_id"])
 	}
 	if item["message_id"] != int64(42) {
@@ -145,6 +146,33 @@ func TestMessageToItemPreservesMessageID(t *testing.T) {
 	metadata := decoded["metadata"].(map[string]any)
 	if metadata["message_id"] != float64(42) {
 		t.Fatalf("metadata message_id = %v", metadata["message_id"])
+	}
+}
+
+func TestMQTTMessageIDIncludesFingerprintWhenPacketIDExists(t *testing.T) {
+	msg := fakeMessage{
+		topic:     "sensors/temp",
+		qos:       1,
+		messageID: 42,
+		payload:   []byte(`{"device":"a","value":21.5}`),
+	}
+	redelivery := msg
+	redelivery.duplicate = true
+	differentPayload := msg
+	differentPayload.payload = []byte(`{"device":"a","value":22.0}`)
+
+	msgID, numericID := mqttMsgID(msg, 7)
+	redeliveryID, _ := mqttMsgID(redelivery, 100)
+	otherID, _ := mqttMsgID(differentPayload, 8)
+
+	if numericID != int64(42) {
+		t.Fatalf("numericID = %v, want 42", numericID)
+	}
+	if msgID != redeliveryID {
+		t.Fatalf("redelivery msg_id changed: %q != %q", msgID, redeliveryID)
+	}
+	if msgID == otherID {
+		t.Fatalf("different payload with reused packet ID produced same msg_id: %q", msgID)
 	}
 }
 

--- a/pkg/source/mqtt/register.go
+++ b/pkg/source/mqtt/register.go
@@ -2,6 +2,8 @@ package mqtt
 
 import "github.com/bruin-data/ingestr/internal/registry"
 
+// internal/registry/imports/mqtt.go provides the versioned blank import that
+// activates this registration outside generated Makefile builds.
 func init() {
 	registry.RegisterSource(
 		[]string{"mqtt", "mqtts"},

--- a/pkg/source/mqtt/register.go
+++ b/pkg/source/mqtt/register.go
@@ -1,0 +1,10 @@
+package mqtt
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"mqtt", "mqtts"},
+		func() interface{} { return NewMQTTSource() },
+	)
+}

--- a/tests/integration/mqtt_container_test.go
+++ b/tests/integration/mqtt_container_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type mqttEnv struct {
+	container testcontainers.Container
+	uri       string
+}
+
+func startMQTTContainerForMain(ctx context.Context) (testcontainers.Container, string, error) {
+	req := testcontainers.ContainerRequest{
+		Image:        "eclipse-mosquitto:2.0",
+		ExposedPorts: []string{"1883/tcp"},
+		Files: []testcontainers.ContainerFile{
+			{
+				Reader: strings.NewReader(strings.Join([]string{
+					"listener 1883 0.0.0.0",
+					"allow_anonymous true",
+					"persistence false",
+					"",
+				}, "\n")),
+				ContainerFilePath: "/mosquitto/config/mosquitto.conf",
+				FileMode:          0o644,
+			},
+		},
+		WaitingFor: wait.ForListeningPort("1883/tcp").WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", err
+	}
+	port, err := container.MappedPort(ctx, "1883")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", err
+	}
+
+	return container, fmt.Sprintf("mqtt://%s:%s", host, port.Port()), nil
+}

--- a/tests/integration/mqtt_test.go
+++ b/tests/integration/mqtt_test.go
@@ -1,0 +1,212 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/mqtt"
+	paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sharedMQTTURI(t *testing.T) string {
+	t.Helper()
+	if mqttShared.uri == "" {
+		t.Skip("shared mqtt container not available")
+	}
+	return mqttShared.uri
+}
+
+func TestMQTTToSQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	mqttURI := sharedMQTTURI(t)
+	topicPrefix := fmt.Sprintf("ingestr/finite/%d", time.Now().UnixNano())
+	messageCount := 20
+
+	publishMQTTMessages(t, mqttURI, topicPrefix, 1, messageCount, true)
+	t.Cleanup(func() { clearRetainedMQTTMessages(t, mqttURI, topicPrefix, 1, messageCount) })
+
+	tmpFile, err := os.CreateTemp("", "mqtt_test_*.db")
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           mqttSourceURI(t, mqttURI, fmt.Sprintf("ingestr-finite-%d", time.Now().UnixNano())),
+		SourceTable:         topicPrefix + "/#",
+		DestURI:             fmt.Sprintf("sqlite:///%s", tmpFile.Name()),
+		DestTable:           "messages",
+		IncrementalStrategy: config.StrategyReplace,
+		Progress:            config.ProgressLog,
+	}
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	db, err := sql.Open("sqlite3", tmpFile.Name())
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var count, withMessageID, withMsgID int
+	err = db.QueryRow(`SELECT COUNT(*), COUNT(message_id), COUNT(msg_id) FROM messages`).Scan(&count, &withMessageID, &withMsgID)
+	require.NoError(t, err)
+	assert.Equal(t, messageCount, count)
+	assert.Equal(t, messageCount, withMessageID, "QoS 1 messages should carry MQTT packet ids")
+	assert.Equal(t, messageCount, withMsgID)
+}
+
+func TestMQTTStreamingToPostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	mqttURI := sharedMQTTURI(t)
+	destURI := sharedPostgresURI(t, "dest")
+	destSchema := uniqueSchemaName(t, "mqtt_stream")
+	ensurePostgresSchema(t, ctx, destURI, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, destURI, destSchema) })
+
+	topicPrefix := fmt.Sprintf("ingestr/stream/%d", time.Now().UnixNano())
+	publishMQTTMessages(t, mqttURI, topicPrefix, 1, 50, true)
+	t.Cleanup(func() { clearRetainedMQTTMessages(t, mqttURI, topicPrefix, 1, 50) })
+
+	destPool, err := pgxpool.New(ctx, destURI)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	cfg := &config.IngestConfig{
+		SourceURI:     mqttSourceURI(t, mqttURI, fmt.Sprintf("ingestr-stream-%d", time.Now().UnixNano())),
+		SourceTable:   topicPrefix + "/#",
+		DestURI:       destURI,
+		DestTable:     destSchema + ".events",
+		Stream:        true,
+		FlushInterval: time.Second,
+		FlushRecords:  20,
+		Progress:      config.ProgressLog,
+	}
+
+	rowCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %s`, pqTable(destSchema, "events"))).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return rowCount() == 50
+	}, 60*time.Second, 500*time.Millisecond, "retained MQTT messages should be ingested after subscription")
+
+	publishMQTTMessages(t, mqttURI, topicPrefix, 51, 30, false)
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			t.Fatalf("streaming pipeline exited early: %v", err)
+		default:
+		}
+		return rowCount() == 80
+	}, 60*time.Second, 500*time.Millisecond, "live MQTT messages should be ingested while streaming")
+
+	var withMessageID int
+	require.NoError(t, destPool.QueryRow(ctx, fmt.Sprintf(`SELECT COUNT(message_id) FROM %s`, pqTable(destSchema, "events"))).Scan(&withMessageID))
+	assert.Equal(t, 80, withMessageID)
+
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30s of cancellation")
+	}
+}
+
+func mqttSourceURI(t *testing.T, rawURI, clientID string) string {
+	t.Helper()
+	u, err := url.Parse(rawURI)
+	require.NoError(t, err)
+	q := u.Query()
+	q.Set("client_id", clientID)
+	q.Set("qos", "1")
+	q.Set("batch_size", "10")
+	q.Set("batch_timeout", "1s")
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func publishMQTTMessages(t *testing.T, rawURI, topicPrefix string, startID, count int, retained bool) {
+	t.Helper()
+	client := newMQTTTestClient(t, rawURI, fmt.Sprintf("ingestr-pub-%d", time.Now().UnixNano()))
+	defer client.Disconnect(250)
+
+	for i := 0; i < count; i++ {
+		id := startID + i
+		topic := fmt.Sprintf("%s/%d", topicPrefix, id)
+		payload := []byte(fmt.Sprintf(`{"seq":%d,"name":"device-%d"}`, id, id))
+		requireMQTTToken(t, client.Publish(topic, 1, retained, payload), 10*time.Second)
+	}
+	t.Logf("published %d MQTT messages (ids %d..%d) to %s", count, startID, startID+count-1, topicPrefix)
+}
+
+func clearRetainedMQTTMessages(t *testing.T, rawURI, topicPrefix string, startID, count int) {
+	t.Helper()
+	client := newMQTTTestClient(t, rawURI, fmt.Sprintf("ingestr-clear-%d", time.Now().UnixNano()))
+	defer client.Disconnect(250)
+	for i := 0; i < count; i++ {
+		topic := fmt.Sprintf("%s/%d", topicPrefix, startID+i)
+		requireMQTTToken(t, client.Publish(topic, 1, true, []byte{}), 10*time.Second)
+	}
+}
+
+func newMQTTTestClient(t *testing.T, rawURI, clientID string) paho.Client {
+	t.Helper()
+	opts := paho.NewClientOptions().
+		AddBroker(mqttBrokerURL(t, rawURI)).
+		SetClientID(clientID).
+		SetCleanSession(true).
+		SetConnectTimeout(10 * time.Second)
+	client := paho.NewClient(opts)
+	requireMQTTToken(t, client.Connect(), 10*time.Second)
+	return client
+}
+
+func mqttBrokerURL(t *testing.T, rawURI string) string {
+	t.Helper()
+	u, err := url.Parse(rawURI)
+	require.NoError(t, err)
+	require.NotEmpty(t, u.Host)
+	return "tcp://" + u.Host
+}
+
+func requireMQTTToken(t *testing.T, token paho.Token, timeout time.Duration) {
+	t.Helper()
+	if !token.WaitTimeout(timeout) {
+		t.Fatalf("MQTT token timed out after %s", timeout)
+	}
+	require.NoError(t, token.Error())
+}

--- a/tests/integration/testenv_postgres_test.go
+++ b/tests/integration/testenv_postgres_test.go
@@ -65,6 +65,7 @@ var (
 	dynamoDBDest    dynamoDBEnv
 	cassandraShared cassandraEnv
 	rabbitmqShared  rabbitmqEnv
+	mqttShared      mqttEnv
 )
 
 func TestMain(m *testing.M) {
@@ -165,6 +166,11 @@ func TestMain(m *testing.M) {
 		rabbitmqShared = rabbitmqEnv{container: rmqC, uri: rmqURI}
 	}
 
+	mqttC, mqttURI, mqttErr := startMQTTContainerForMain(ctx)
+	if mqttErr == nil {
+		mqttShared = mqttEnv{container: mqttC, uri: mqttURI}
+	}
+
 	code := m.Run()
 
 	containers := []testcontainers.Container{
@@ -186,6 +192,9 @@ func TestMain(m *testing.M) {
 	twg.Wait()
 	if rabbitmqShared.container != nil {
 		_ = rabbitmqShared.container.Terminate(ctx)
+	}
+	if mqttShared.container != nil {
+		_ = mqttShared.container.Terminate(ctx)
 	}
 	if maxcomputeDest.dbPath != "" {
 		_ = os.Remove(maxcomputeDest.dbPath)


### PR DESCRIPTION
## Summary
- add an MQTT source for `mqtt://` and `mqtts://` URIs
- include MQTT packet id in `message_id` when present and derive stable `msg_id` values
- support finite batch reads and streaming reads with manual ack after downstream commit
- add Mosquitto-backed integration tests for SQLite finite ingestion and Postgres streaming ingestion

## Ack behavior
- finite reads ack after the extracted batch is emitted to the pipeline
- streaming reads ack through `StreamCommitter` only after the streaming executor flushes the batch to the destination

## Validation
- `go test -tags integration -count=1 -run 'TestMQTT' ./tests/integration`\n- `make format`\n- `make lint`\n- `make test`