### PR TITLE
Add Oracle destination support

### DIFF
--- a/docs/supported-sources/oracle.md
+++ b/docs/supported-sources/oracle.md
@@ -1,7 +1,7 @@
 # Oracle
 Oracle is a powerful, fully integrated stack of cloud applications and platform services, known for its comprehensive capabilities in database management.
 
-ingestr supports Oracle as a source through `oracle+cx_oracle` driver. Under the hood, ingestr uses the modern `oracledb` package in thin mode, which means **no Oracle Client libraries are required** to be installed on your system.
+ingestr supports Oracle as a source and destination through the `oracle+cx_oracle`-compatible URI format. Under the hood, ingestr uses the Go Oracle driver in thin mode, which means **no Oracle Client libraries are required** to be installed on your system.
 
 ## URI format
 The URI format for Oracle is as follows:
@@ -18,3 +18,7 @@ URI parameters:
 - `dbname`: the name of the database
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's Oracle dialect [here](https://docs.sqlalchemy.org/en/20/core/engines.html#oracle).
+
+## Destination notes
+
+Oracle `replace` loads into a staging table first and then finalizes with `ALTER TABLE ... RENAME`. Oracle commits DDL implicitly, so this finalization is not transactional. If finalization fails after the existing target is renamed, ingestr keeps a backup table name in the error message so you can restore it manually with `ALTER TABLE <backup> RENAME TO <target>`.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -325,7 +325,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("nats", "NATS JetStream", []string{"nats"}, true, false),
 		genericURIConnector("notion", "Notion", []string{"notion"}, true, false),
 		genericURIConnector("onelake", "OneLake", []string{"onelake"}, false, true),
-		genericURIConnector("oracle", "Oracle", []string{"oracle", "oracle+cx_oracle"}, true, false),
+		genericURIConnector("oracle", "Oracle", []string{"oracle", "oracle+cx_oracle"}, true, true),
 		genericURIConnector("paddle", "Paddle", []string{"paddle"}, true, false),
 		genericURIConnector("personio", "Personio", []string{"personio"}, true, false),
 		genericURIConnector("phantombuster", "PhantomBuster", []string{"phantombuster"}, true, false),

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -160,11 +160,6 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
-    - module: github.com/DataDog/zstd
-      version: v1.5.0
-      licenses:
-        - BSD-3-Clause
-      status: allowed
     - module: github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp
       version: v1.5.3
       licenses:
@@ -1287,7 +1282,7 @@ dependencies:
         - Apache-2.0
       status: allowed
     - module: go.mongodb.org/mongo-driver
-      version: v1.17.6
+      version: v1.17.7
       licenses:
         - Apache-2.0
       status: allowed

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -160,6 +160,11 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
+    - module: github.com/DataDog/zstd
+      version: v1.5.0
+      licenses:
+        - BSD-3-Clause
+      status: allowed
     - module: github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp
       version: v1.5.3
       licenses:

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -212,3 +212,9 @@ type ReplaceStagingPolicy struct {
 type ReplaceStagingPolicyProvider interface {
 	ReplaceStagingPolicy() ReplaceStagingPolicy
 }
+
+// ManagedStagingPolicyProvider lets a destination declare where strategy-owned
+// staging tables should live when the user did not configure a staging dataset.
+type ManagedStagingPolicyProvider interface {
+	ManagedStagingPolicy() ReplaceStagingPolicy
+}

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -77,6 +77,7 @@ type SCD2Options struct {
 	Columns        []string  // All original columns (excluding SCD columns)
 	IncrementalKey string    // Optional: for optimization (skip soft-delete if set)
 	Timestamp      time.Time // Single timestamp for the entire operation (used for _scd_valid_from and _scd_valid_to)
+	Schema         *schema.TableSchema
 }
 
 type Destination interface {

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/mssql"
 	"github.com/bruin-data/ingestr/pkg/destination/mysql"
 	"github.com/bruin-data/ingestr/pkg/destination/onelake"
+	"github.com/bruin-data/ingestr/pkg/destination/oracle"
 	"github.com/bruin-data/ingestr/pkg/destination/postgres"
 	"github.com/bruin-data/ingestr/pkg/destination/redshift"
 	"github.com/bruin-data/ingestr/pkg/destination/snowflake"
@@ -33,6 +34,7 @@ var (
 	_ destination.Destination = (*mssql.MSSQLDestination)(nil)
 	_ destination.Destination = (*mysql.MySQLDestination)(nil)
 	_ destination.Destination = (*onelake.OneLakeDestination)(nil)
+	_ destination.Destination = (*oracle.OracleDestination)(nil)
 	_ destination.Destination = (*postgres.PostgresDestination)(nil)
 	_ destination.Destination = (*redshift.RedshiftDestination)(nil)
 	_ destination.Destination = (*snowflake.SnowflakeDestination)(nil)

--- a/pkg/destination/oracle/dialect.go
+++ b/pkg/destination/oracle/dialect.go
@@ -1,0 +1,50 @@
+package oracle
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+)
+
+func init() {
+	dialect := &Dialect{}
+	schemaevolution.RegisterDialect("oracle", dialect)
+	schemaevolution.RegisterDialect("oracle+cx_oracle", dialect)
+}
+
+type Dialect struct{}
+
+func (d *Dialect) Name() string {
+	return "Oracle"
+}
+
+func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
+	nullable := ""
+	if !col.Nullable {
+		nullable = " NOT NULL"
+	}
+	return fmt.Sprintf(
+		"ALTER TABLE %s ADD %s %s%s",
+		quoteTable(table),
+		quoteColumn(col.Name),
+		d.TypeName(col),
+		nullable,
+	)
+}
+
+func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {
+	return ""
+}
+
+func (d *Dialect) SupportsAlterType() bool {
+	return false
+}
+
+func (d *Dialect) TypeName(col schema.Column) string {
+	return mapDataTypeToOracle(col, col.IsPrimaryKey)
+}
+
+func (d *Dialect) QuoteIdentifier(name string) string {
+	return quoteColumn(name)
+}

--- a/pkg/destination/oracle/mapper.go
+++ b/pkg/destination/oracle/mapper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
-const oracleDefaultComparableStringLength = 255
+const oracleDefaultComparableStringLength = 4000
 
 func MapDataTypeToOracle(col schema.Column) string {
 	return mapDataTypeToOracle(col, false)

--- a/pkg/destination/oracle/mapper.go
+++ b/pkg/destination/oracle/mapper.go
@@ -1,0 +1,145 @@
+package oracle
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+const oracleDefaultComparableStringLength = 255
+
+func MapDataTypeToOracle(col schema.Column) string {
+	return mapDataTypeToOracle(col, false)
+}
+
+func mapDataTypeToOracle(col schema.Column, primaryKey bool) string {
+	switch col.DataType {
+	case schema.TypeBoolean:
+		return "NUMBER(1,0)"
+	case schema.TypeInt8:
+		return "NUMBER(3,0)"
+	case schema.TypeInt16:
+		return "NUMBER(5,0)"
+	case schema.TypeInt32:
+		return "NUMBER(10,0)"
+	case schema.TypeInt64:
+		return "NUMBER(19,0)"
+	case schema.TypeFloat32:
+		return "BINARY_FLOAT"
+	case schema.TypeFloat64:
+		return "BINARY_DOUBLE"
+	case schema.TypeDecimal:
+		precision := col.Precision
+		scale := col.Scale
+		if precision <= 0 {
+			precision = 38
+		}
+		if precision > 38 {
+			precision = 38
+		}
+		if scale < 0 {
+			scale = 0
+		}
+		if scale > precision {
+			scale = precision
+		}
+		return fmt.Sprintf("NUMBER(%d,%d)", precision, scale)
+	case schema.TypeString:
+		if col.MaxLength > 0 && col.MaxLength <= 4000 {
+			return fmt.Sprintf("VARCHAR2(%d CHAR)", col.MaxLength)
+		}
+		if primaryKey || strings.EqualFold(col.Name, destination.CDCLSNColumn) {
+			return fmt.Sprintf("VARCHAR2(%d CHAR)", oracleDefaultComparableStringLength)
+		}
+		return "CLOB"
+	case schema.TypeBinary:
+		if col.MaxLength > 0 && col.MaxLength <= 2000 {
+			return fmt.Sprintf("RAW(%d)", col.MaxLength)
+		}
+		return "BLOB"
+	case schema.TypeDate:
+		return "DATE"
+	case schema.TypeTime:
+		return "VARCHAR2(32 CHAR)"
+	case schema.TypeTimestamp:
+		return "TIMESTAMP(6)"
+	case schema.TypeTimestampTZ:
+		return "TIMESTAMP(6) WITH TIME ZONE"
+	case schema.TypeJSON:
+		return "CLOB"
+	case schema.TypeUUID:
+		return "VARCHAR2(36 CHAR)"
+	case schema.TypeArray:
+		return "CLOB"
+	case schema.TypeInterval:
+		return "VARCHAR2(255 CHAR)"
+	default:
+		return "CLOB"
+	}
+}
+
+func mapOracleTypeToSchema(dataType string, precision, scale, charLength *int) schema.Column {
+	upper := strings.ToUpper(strings.TrimSpace(dataType))
+	col := schema.Column{DataType: schema.TypeString, Nullable: true}
+
+	switch {
+	case upper == "NUMBER" || strings.HasPrefix(upper, "NUMBER("):
+		col.DataType = mapOracleNumberToSchema(precision, scale)
+	case upper == "BINARY_FLOAT":
+		col.DataType = schema.TypeFloat32
+	case upper == "FLOAT" || upper == "BINARY_DOUBLE" || upper == "DOUBLE PRECISION":
+		col.DataType = schema.TypeFloat64
+	case strings.Contains(upper, "TIMESTAMP") && strings.Contains(upper, "TIME ZONE"):
+		col.DataType = schema.TypeTimestampTZ
+	case strings.HasPrefix(upper, "TIMESTAMP"):
+		col.DataType = schema.TypeTimestamp
+	case upper == "DATE":
+		col.DataType = schema.TypeDate
+	case upper == "BLOB" || upper == "RAW" || upper == "LONG RAW" || upper == "BFILE":
+		col.DataType = schema.TypeBinary
+	case upper == "CLOB" || upper == "NCLOB" || upper == "LONG" || upper == "XMLTYPE":
+		col.DataType = schema.TypeString
+	case upper == "JSON":
+		col.DataType = schema.TypeJSON
+	case upper == "BOOLEAN":
+		col.DataType = schema.TypeBoolean
+	default:
+		col.DataType = schema.TypeString
+	}
+
+	if precision != nil {
+		col.Precision = *precision
+	}
+	if scale != nil {
+		col.Scale = *scale
+	}
+	if charLength != nil && col.DataType == schema.TypeString {
+		col.MaxLength = *charLength
+	}
+	return col
+}
+
+func mapOracleNumberToSchema(precision, scale *int) schema.DataType {
+	if scale != nil && *scale != 0 {
+		return schema.TypeDecimal
+	}
+	if precision == nil {
+		return schema.TypeDecimal
+	}
+	switch {
+	case *precision == 1:
+		return schema.TypeBoolean
+	case *precision <= 3:
+		return schema.TypeInt8
+	case *precision <= 5:
+		return schema.TypeInt16
+	case *precision <= 10:
+		return schema.TypeInt32
+	case *precision <= 19:
+		return schema.TypeInt64
+	default:
+		return schema.TypeDecimal
+	}
+}

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -482,6 +482,13 @@ WHERE source.%s = 1`,
 			config.LogFailedQuery(markDeletedSQL, err)
 			return fmt.Errorf("failed to mark deleted records: %w", err)
 		}
+
+		insertDeletedSQL := buildCDCDeleteTombstoneInsertSQL(opts.TargetTable, dedupSource(""), columns, opts.PrimaryKeys)
+		config.Debug("[MERGE] Executing CDC delete tombstone insert: %s", insertDeletedSQL)
+		if _, err := tx.ExecContext(ctx, insertDeletedSQL); err != nil {
+			config.LogFailedQuery(insertDeletedSQL, err)
+			return fmt.Errorf("failed to insert CDC delete tombstones: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -509,6 +516,19 @@ func buildMergeSQL(targetTable, sourceExpr string, columns, primaryKeys, updateC
 		strings.Join(sourceColumnRefs(columns, "source"), ", "),
 	)
 	return b.String()
+}
+
+func buildCDCDeleteTombstoneInsertSQL(targetTable, sourceExpr string, columns, primaryKeys []string) string {
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s WHERE source.%s = 1 AND NOT EXISTS (SELECT 1 FROM %s target WHERE %s)",
+		quoteTable(targetTable),
+		strings.Join(quoteColumns(columns), ", "),
+		strings.Join(sourceColumnRefs(columns, "source"), ", "),
+		sourceExpr,
+		quoteColumn(destination.CDCDeletedColumn),
+		quoteTable(targetTable),
+		buildJoinCondition(primaryKeys, "target", "source"),
+	)
 }
 
 func (d *OracleDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
@@ -917,8 +937,8 @@ func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryK
 
 	colDefs := make([]string, 0, len(columns)+1)
 	for _, col := range columns {
-		isPrimaryKey := col.IsPrimaryKey || primaryKeySet[strings.ToLower(col.Name)]
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), mapDataTypeToOracle(col, isPrimaryKey)))
+		isComparableString := col.IsPrimaryKey || primaryKeySet[strings.ToLower(col.Name)] || strings.EqualFold(col.Name, tableSchema.IncrementalKey)
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), mapDataTypeToOracle(col, isComparableString)))
 	}
 	if len(primaryKeys) > 0 {
 		quotedKeys := quoteColumns(primaryKeys)

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -312,7 +312,7 @@ func (d *OracleDestination) SwapTable(ctx context.Context, opts destination.Swap
 	stagingSchema, _ := parseTableName(opts.StagingTable)
 	targetSchema, targetName := parseTableName(opts.TargetTable)
 
-	if !strings.EqualFold(normalizeStagingSchema(stagingSchema), normalizeStagingSchema(targetSchema)) {
+	if !d.sameSchema(stagingSchema, targetSchema) {
 		return d.copySwapTable(ctx, opts)
 	}
 
@@ -423,6 +423,10 @@ func (d *OracleDestination) copySwapTable(ctx context.Context, opts destination.
 
 func (d *OracleDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
 	startMerge := time.Now()
+	if len(opts.PrimaryKeys) == 0 {
+		return fmt.Errorf("oracle merge requires at least one primary key")
+	}
+
 	columns := opts.Columns
 	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
 	isCDC := destination.HasCDCDeletedColumn(columns)
@@ -552,6 +556,9 @@ func (d *OracleDestination) DeleteInsertTable(ctx context.Context, opts destinat
 
 func (d *OracleDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
 	startOp := time.Now()
+	if len(opts.PrimaryKeys) == 0 {
+		return fmt.Errorf("oracle SCD2 requires at least one primary key")
+	}
 
 	tableSchema := opts.Schema
 	if tableSchema == nil {
@@ -692,6 +699,7 @@ func (d *OracleDestination) SupportsCDCMerge() bool             { return true }
 func (d *OracleDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
 	return destination.ReplaceStagingPolicy{
 		DefaultPlacement:     destination.ReplaceStagingTargetSchema,
+		DefaultTargetSchema:  d.currentUser,
 		DefaultManagedSchema: defaultOracleStagingSchema,
 	}
 }
@@ -844,18 +852,18 @@ func (d *OracleDestination) tableExists(ctx context.Context, table string) (bool
 
 func (d *OracleDestination) effectiveSchemaTable(table string) (string, string) {
 	schemaName, tableName := parseTableName(table)
-	schemaName = normalizeStagingSchema(schemaName)
-	if schemaName == "" {
-		schemaName = d.currentUser
-	}
-	return canonicalIdentifier(schemaName), canonicalIdentifier(tableName)
+	return d.effectiveSchemaName(schemaName), canonicalIdentifier(tableName)
 }
 
-func normalizeStagingSchema(schemaName string) string {
-	if strings.EqualFold(schemaName, defaultOracleStagingSchema) {
-		return ""
+func (d *OracleDestination) effectiveSchemaName(schemaName string) string {
+	if schemaName == "" {
+		return d.currentUser
 	}
-	return schemaName
+	return canonicalIdentifier(schemaName)
+}
+
+func (d *OracleDestination) sameSchema(left, right string) bool {
+	return strings.EqualFold(d.effectiveSchemaName(left), d.effectiveSchemaName(right))
 }
 
 func parseTableName(table string) (string, string) {
@@ -874,7 +882,7 @@ func extractTableName(table string) string {
 func backupTableName(schemaName, tableName string) string {
 	candidate := fmt.Sprintf("%s_OLD_%d", canonicalIdentifier(tableName), time.Now().UnixNano())
 	backupName := destination.ShortenIdentifier(candidate, candidate, destination.MaxIdentifierLength("oracle"))
-	if schemaName == "" || strings.EqualFold(schemaName, defaultOracleStagingSchema) {
+	if schemaName == "" {
 		return backupName
 	}
 	return schemaName + "." + backupName
@@ -939,9 +947,6 @@ func oracleDedupSelect(columns, primaryKeys []string, tableExpr, orderBy string,
 
 func quoteTable(table string) string {
 	parts := tablename.Split(table)
-	if len(parts) == 2 && strings.EqualFold(parts[0], defaultOracleStagingSchema) {
-		return quoteColumn(parts[1])
-	}
 	quoted := make([]string, 0, len(parts))
 	for _, part := range parts {
 		quoted = append(quoted, quoteColumn(part))

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -1,0 +1,1145 @@
+package oracle
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
+	_ "github.com/sijms/go-ora/v2"
+)
+
+const defaultOracleStagingSchema = "_bruin_staging"
+
+type OracleDestination struct {
+	db          *sql.DB
+	uri         string
+	currentUser string
+}
+
+func NewOracleDestination() *OracleDestination {
+	return &OracleDestination{}
+}
+
+func (d *OracleDestination) Schemes() []string {
+	return []string{"oracle", "oracle+cx_oracle"}
+}
+
+func (d *OracleDestination) Connect(ctx context.Context, uri string) error {
+	connStrs, err := buildConnStrings(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse Oracle URI: %w", err)
+	}
+
+	var lastErr error
+	for _, connStr := range connStrs {
+		db, err := sql.Open("oracle", connStr)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(5)
+		db.SetConnMaxLifetime(5 * time.Minute)
+
+		if err := db.PingContext(ctx); err != nil {
+			_ = db.Close()
+			lastErr = err
+			config.Debug("[ORACLE] Connection attempt failed: %v", err)
+			continue
+		}
+
+		d.db = db
+		d.uri = uri
+		if err := d.db.QueryRowContext(ctx, "SELECT USER FROM DUAL").Scan(&d.currentUser); err != nil {
+			_ = db.Close()
+			return fmt.Errorf("failed to get current Oracle user: %w", err)
+		}
+		d.currentUser = strings.ToUpper(d.currentUser)
+		config.Debug("[ORACLE] Connected as: %s", d.currentUser)
+		return nil
+	}
+
+	return fmt.Errorf("failed to connect to Oracle: %w", lastErr)
+}
+
+func buildConnStrings(uri string) ([]string, error) {
+	normalized := uri
+	if strings.HasPrefix(strings.ToLower(uri), "oracle+cx_oracle://") {
+		normalized = "oracle://" + uri[len("oracle+cx_oracle://"):]
+	}
+
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.ToLower(u.Scheme) != "oracle" {
+		return nil, fmt.Errorf("unsupported scheme: %s", u.Scheme)
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "1521"
+	}
+
+	var userInfo *url.Userinfo
+	if u.User != nil {
+		user := u.User.Username()
+		password, hasPass := u.User.Password()
+		if hasPass {
+			userInfo = url.UserPassword(user, password)
+		} else {
+			userInfo = url.User(user)
+		}
+	}
+
+	query := u.Query()
+	pathValue := strings.TrimPrefix(u.Path, "/")
+	serviceName := query.Get("service_name")
+
+	buildURL := func(path string, q url.Values) string {
+		connURL := &url.URL{
+			Scheme: "oracle",
+			Host:   fmt.Sprintf("%s:%s", host, port),
+			Path:   path,
+			User:   userInfo,
+		}
+		if len(q) > 0 {
+			connURL.RawQuery = q.Encode()
+		}
+		return connURL.String()
+	}
+
+	if serviceName != "" {
+		q := u.Query()
+		q.Del("service_name")
+		return []string{buildURL("/"+serviceName, q)}, nil
+	}
+
+	if query.Get("SID") != "" {
+		return []string{buildURL("/", query)}, nil
+	}
+
+	if pathValue != "" {
+		sidQuery := u.Query()
+		sidQuery.Set("SID", pathValue)
+		return []string{
+			buildURL("/", sidQuery),
+			buildURL("/"+pathValue, u.Query()),
+		}, nil
+	}
+
+	return []string{buildURL("/", query)}, nil
+}
+
+func (d *OracleDestination) Close(ctx context.Context) error {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}
+
+func (d *OracleDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := tablename.TwoLevel("oracle").CheckName(opts.Table); err != nil {
+		return err
+	}
+
+	if opts.DropFirst {
+		if err := d.DropTable(ctx, opts.Table); err != nil {
+			return err
+		}
+	}
+
+	if opts.Schema == nil {
+		return nil
+	}
+
+	exists, err := d.tableExists(ctx, opts.Table)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	startCreate := time.Now()
+	createSQL := buildCreateTableSQL(opts.Table, opts.Schema, opts.PrimaryKeys)
+	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+		if isOracleError(err, "00955") {
+			return nil
+		}
+		config.LogFailedQuery(createSQL, err)
+		return fmt.Errorf("failed to create table: %w", err)
+	}
+	config.Debug("[ORACLE] CREATE TABLE took %v", time.Since(startCreate))
+	return nil
+}
+
+func (d *OracleDestination) DropTable(ctx context.Context, table string) error {
+	exists, err := d.tableExists(ctx, table)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	dropSQL := fmt.Sprintf("DROP TABLE %s PURGE", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+		if isOracleError(err, "00942") {
+			return nil
+		}
+		config.LogFailedQuery(dropSQL, err)
+		return fmt.Errorf("failed to drop table %s: %w", table, err)
+	}
+	config.Debug("[ORACLE] Dropped table: %s", table)
+	return nil
+}
+
+func (d *OracleDestination) TruncateTable(ctx context.Context, table string) error {
+	truncateSQL := fmt.Sprintf("TRUNCATE TABLE %s", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate table %s: %w", table, err)
+	}
+	config.Debug("[ORACLE] Truncated table: %s", table)
+	return nil
+}
+
+func (d *OracleDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.WriteParallel(ctx, records, opts)
+}
+
+func (d *OracleDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	startTime := time.Now()
+	var totalRows int64
+	var batchNum int
+
+	config.Debug("[ORACLE] Starting write to %s", opts.Table)
+
+	for result := range records {
+		if result.Err != nil {
+			return result.Err
+		}
+		if result.Batch == nil {
+			continue
+		}
+
+		batchNum++
+		startBatch := time.Now()
+
+		rows, err := d.writeRecordBatch(ctx, result.Batch, opts.Table)
+		if err != nil {
+			result.Batch.Release()
+			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
+		}
+		result.Batch.Release()
+
+		totalRows += rows
+		config.Debug("[ORACLE] Batch %d: %d rows in %v (total: %d)", batchNum, rows, time.Since(startBatch), totalRows)
+	}
+
+	config.Debug("[ORACLE] Total: %d rows written in %v", totalRows, time.Since(startTime))
+	return nil
+}
+
+func (d *OracleDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+	numRows := record.NumRows()
+	numCols := int(record.NumCols())
+	if numRows == 0 {
+		return 0, nil
+	}
+
+	colNames := make([]string, numCols)
+	placeholders := make([]string, numCols)
+	for i := 0; i < numCols; i++ {
+		colNames[i] = quoteColumn(record.Schema().Field(i).Name)
+		placeholders[i] = fmt.Sprintf(":%d", i+1)
+	}
+
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		quoteTable(table),
+		strings.Join(colNames, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	stmt, err := tx.PrepareContext(ctx, insertSQL)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	values := make([]interface{}, numCols)
+	for rowIdx := int64(0); rowIdx < numRows; rowIdx++ {
+		for colIdx := 0; colIdx < numCols; colIdx++ {
+			values[colIdx] = extractValue(record.Column(colIdx), int(rowIdx))
+		}
+
+		if _, err := stmt.ExecContext(ctx, values...); err != nil {
+			config.LogFailedQuery(insertSQL, err)
+			_ = tx.Rollback()
+			return rowIdx, fmt.Errorf("failed to insert row %d: %w", rowIdx, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return numRows, nil
+}
+
+func (d *OracleDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	startSwap := time.Now()
+	stagingSchema, _ := parseTableName(opts.StagingTable)
+	targetSchema, targetName := parseTableName(opts.TargetTable)
+
+	if !strings.EqualFold(normalizeStagingSchema(stagingSchema), normalizeStagingSchema(targetSchema)) {
+		return d.copySwapTable(ctx, opts)
+	}
+
+	targetExists, err := d.tableExists(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	var backupTable string
+	if targetExists {
+		backupTable = backupTableName(targetSchema, targetName)
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			return err
+		}
+		renameTargetSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", quoteTable(opts.TargetTable), quoteColumn(extractTableName(backupTable)))
+		if _, err := d.db.ExecContext(ctx, renameTargetSQL); err != nil {
+			config.LogFailedQuery(renameTargetSQL, err)
+			return fmt.Errorf("failed to rename target table %s to backup %s: %w", opts.TargetTable, backupTable, err)
+		}
+	}
+
+	renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", quoteTable(opts.StagingTable), quoteColumn(targetName))
+	if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
+		config.LogFailedQuery(renameSQL, err)
+		if backupTable != "" {
+			if restoreErr := d.restoreBackup(ctx, opts.TargetTable, backupTable); restoreErr != nil {
+				return fmt.Errorf("failed to rename staging table %s to %s; target backup remains at %s and staging remains at %s; manual recovery: drop any partial %s, then ALTER TABLE %s RENAME TO %s: %w; restore failed: %v",
+					opts.StagingTable, opts.TargetTable, backupTable, opts.StagingTable, opts.TargetTable, quoteTable(backupTable), quoteColumn(targetName), err, restoreErr)
+			}
+			return fmt.Errorf("failed to rename staging table %s to %s; original target restored from backup %s: %w", opts.StagingTable, opts.TargetTable, backupTable, err)
+		}
+		return fmt.Errorf("failed to rename staging table %s to %s: %w", opts.StagingTable, opts.TargetTable, err)
+	}
+
+	if backupTable != "" {
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			config.Debug("[ORACLE] Warning: failed to drop old backup table %s after swap: %v", backupTable, err)
+		}
+	}
+
+	config.Debug("[ORACLE] Table swap completed in %v", time.Since(startSwap))
+	return nil
+}
+
+func (d *OracleDestination) copySwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if opts.Schema == nil {
+		return fmt.Errorf("cannot swap %s to %s across schemas without schema", opts.StagingTable, opts.TargetTable)
+	}
+	targetSchema, targetName := parseTableName(opts.TargetTable)
+	targetExists, err := d.tableExists(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	var backupTable string
+	if targetExists {
+		backupTable = backupTableName(targetSchema, targetName)
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			return err
+		}
+		renameTargetSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", quoteTable(opts.TargetTable), quoteColumn(extractTableName(backupTable)))
+		if _, err := d.db.ExecContext(ctx, renameTargetSQL); err != nil {
+			config.LogFailedQuery(renameTargetSQL, err)
+			return fmt.Errorf("failed to rename target table %s to backup %s: %w", opts.TargetTable, backupTable, err)
+		}
+	}
+
+	if err := d.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       opts.TargetTable,
+		Schema:      opts.Schema,
+		PrimaryKeys: opts.PrimaryKeys,
+	}); err != nil {
+		if backupTable != "" {
+			if restoreErr := d.restoreBackup(ctx, opts.TargetTable, backupTable); restoreErr != nil {
+				return fmt.Errorf("failed to create replacement table %s; target backup remains at %s and staging remains at %s: %w; restore failed: %v", opts.TargetTable, backupTable, opts.StagingTable, err, restoreErr)
+			}
+		}
+		return err
+	}
+
+	quotedColumns := quoteColumns(opts.Schema.ColumnNames())
+	colList := strings.Join(quotedColumns, ", ")
+	copySQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s",
+		quoteTable(opts.TargetTable),
+		colList,
+		colList,
+		quoteTable(opts.StagingTable),
+	)
+	if _, err := d.db.ExecContext(ctx, copySQL); err != nil {
+		config.LogFailedQuery(copySQL, err)
+		if backupTable != "" {
+			if restoreErr := d.restoreBackup(ctx, opts.TargetTable, backupTable); restoreErr != nil {
+				return fmt.Errorf("failed to copy staging rows into target; target backup remains at %s and staging remains at %s; manual recovery: drop any partial %s, then ALTER TABLE %s RENAME TO %s: %w; restore failed: %v",
+					backupTable, opts.StagingTable, opts.TargetTable, quoteTable(backupTable), quoteColumn(targetName), err, restoreErr)
+			}
+		}
+		return fmt.Errorf("failed to copy staging rows into target: %w", err)
+	}
+	if err := d.DropTable(ctx, opts.StagingTable); err != nil {
+		config.Debug("[ORACLE] Warning: failed to drop staging table %s after swap: %v", opts.StagingTable, err)
+	}
+	if backupTable != "" {
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			config.Debug("[ORACLE] Warning: failed to drop old backup table %s after swap: %v", backupTable, err)
+		}
+	}
+	return nil
+}
+
+func (d *OracleDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	startMerge := time.Now()
+	columns := opts.Columns
+	nonPKColumns := filterColumns(columns, opts.PrimaryKeys)
+	isCDC := destination.HasCDCDeletedColumn(columns)
+
+	dedupOrderBy := "1"
+	if isCDC {
+		dedupOrderBy = destination.CDCLatestOverallOrderBy(quoteColumn)
+	} else if opts.IncrementalKey != "" {
+		dedupOrderBy = quoteColumn(opts.IncrementalKey) + " DESC"
+	}
+	dedupSource := func(where string) string {
+		return oracleDedupSource(columns, opts.PrimaryKeys, quoteTable(opts.StagingTable), dedupOrderBy, where, "source")
+	}
+
+	upsertSource := dedupSource("")
+	if isCDC {
+		upsertSource = dedupSource(" WHERE " + quoteColumn(destination.CDCDeletedColumn) + " = 0")
+	}
+
+	mergeSQL := buildMergeSQL(opts.TargetTable, upsertSource, columns, opts.PrimaryKeys, nonPKColumns)
+	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to merge records: %w", err)
+	}
+
+	if isCDC {
+		markDeletedSQL := fmt.Sprintf(
+			`MERGE INTO %s target
+USING %s
+ON (%s)
+WHEN MATCHED THEN UPDATE SET target.%s = 1, target.%s = source.%s, target.%s = source.%s
+WHERE source.%s = 1`,
+			quoteTable(opts.TargetTable),
+			dedupSource(""),
+			buildJoinCondition(opts.PrimaryKeys, "target", "source"),
+			quoteColumn(destination.CDCDeletedColumn),
+			quoteColumn(destination.CDCLSNColumn),
+			quoteColumn(destination.CDCLSNColumn),
+			quoteColumn(destination.CDCSyncedAtColumn),
+			quoteColumn(destination.CDCSyncedAtColumn),
+			quoteColumn(destination.CDCDeletedColumn),
+		)
+		config.Debug("[MERGE] Executing CDC delete marking: %s", markDeletedSQL)
+		if _, err := tx.ExecContext(ctx, markDeletedSQL); err != nil {
+			config.LogFailedQuery(markDeletedSQL, err)
+			return fmt.Errorf("failed to mark deleted records: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
+
+func buildMergeSQL(targetTable, sourceExpr string, columns, primaryKeys, updateColumns []string) string {
+	var b strings.Builder
+	fmt.Fprintf(
+		&b, "MERGE INTO %s target\nUSING %s\nON (%s)\n",
+		quoteTable(targetTable),
+		sourceExpr,
+		buildJoinCondition(primaryKeys, "target", "source"),
+	)
+	if len(updateColumns) > 0 {
+		fmt.Fprintf(&b, "WHEN MATCHED THEN UPDATE SET %s\n", buildUpdateSet(updateColumns, "target", "source"))
+	}
+	fmt.Fprintf(
+		&b, "WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)",
+		strings.Join(quoteColumns(columns), ", "),
+		strings.Join(sourceColumnRefs(columns, "source"), ", "),
+	)
+	return b.String()
+}
+
+func (d *OracleDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
+	startOp := time.Now()
+	quotedColumns := quoteColumns(opts.Columns)
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deleteSQL := fmt.Sprintf(
+		"DELETE FROM %s WHERE %s >= :1 AND %s <= :2",
+		quoteTable(opts.TargetTable),
+		quoteColumn(opts.IncrementalKey),
+		quoteColumn(opts.IncrementalKey),
+	)
+	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
+	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
+		config.LogFailedQuery(deleteSQL, err)
+		return fmt.Errorf("failed to delete records: %w", err)
+	}
+
+	colList := strings.Join(quotedColumns, ", ")
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) %s",
+		quoteTable(opts.TargetTable),
+		colList,
+		oracleDedupSelect(opts.Columns, opts.PrimaryKeys, quoteTable(opts.StagingTable), quoteColumn(opts.IncrementalKey)+" DESC"),
+	)
+	config.Debug("[DELETE+INSERT] Executing INSERT: %s", insertSQL)
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert records: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	config.Debug("[DELETE+INSERT] Delete+Insert completed in %v", time.Since(startOp))
+	return nil
+}
+
+func (d *OracleDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
+	startOp := time.Now()
+
+	tableSchema := opts.Schema
+	if tableSchema == nil {
+		var err error
+		tableSchema, err = d.GetTableSchema(ctx, opts.TargetTable)
+		if err != nil {
+			return fmt.Errorf("failed to get target schema for SCD2 comparison: %w", err)
+		}
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	nonPKColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
+	onCondition := buildJoinCondition(opts.PrimaryKeys, "target", "source")
+	changeConditions := buildChangeConditions(nonPKColumns, "target", "source", tableSchema)
+
+	closeChangedSQL := fmt.Sprintf(
+		`MERGE INTO %s target
+USING %s source
+ON (%s)
+WHEN MATCHED THEN UPDATE SET target.%s = source.%s, target.%s = 0
+WHERE target.%s = 1 AND (%s)`,
+		quoteTable(opts.TargetTable),
+		quoteTable(opts.StagingTable),
+		onCondition,
+		quoteColumn(destination.SCD2ValidToColumn),
+		quoteColumn(destination.SCD2ValidFromColumn),
+		quoteColumn(destination.SCD2IsCurrentColumn),
+		quoteColumn(destination.SCD2IsCurrentColumn),
+		changeConditions,
+	)
+	config.Debug("[ORACLE SCD2] Step 1 - Close changed records: %s", closeChangedSQL)
+	if _, err := tx.ExecContext(ctx, closeChangedSQL); err != nil {
+		config.LogFailedQuery(closeChangedSQL, err)
+		return fmt.Errorf("failed to close changed records: %w", err)
+	}
+
+	if opts.IncrementalKey == "" {
+		softDeleteSQL := fmt.Sprintf(
+			`UPDATE %s target
+SET %s = :1, %s = 0
+WHERE target.%s = 1
+  AND NOT EXISTS (SELECT 1 FROM %s source WHERE %s)`,
+			quoteTable(opts.TargetTable),
+			quoteColumn(destination.SCD2ValidToColumn),
+			quoteColumn(destination.SCD2IsCurrentColumn),
+			quoteColumn(destination.SCD2IsCurrentColumn),
+			quoteTable(opts.StagingTable),
+			onCondition,
+		)
+		config.Debug("[ORACLE SCD2] Step 2 - Soft-delete missing: %s", softDeleteSQL)
+		if _, err := tx.ExecContext(ctx, softDeleteSQL, opts.Timestamp); err != nil {
+			config.LogFailedQuery(softDeleteSQL, err)
+			return fmt.Errorf("failed to soft-delete missing records: %w", err)
+		}
+	}
+
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
+	quotedColumns := quoteColumns(allColumns)
+	insertSQL := fmt.Sprintf(
+		`INSERT INTO %s (%s)
+SELECT %s FROM %s source
+WHERE NOT EXISTS (
+	SELECT 1 FROM %s target
+	WHERE %s
+	  AND target.%s = 1
+)`,
+		quoteTable(opts.TargetTable),
+		strings.Join(quotedColumns, ", "),
+		strings.Join(sourceColumnRefs(allColumns, "source"), ", "),
+		quoteTable(opts.StagingTable),
+		quoteTable(opts.TargetTable),
+		onCondition,
+		quoteColumn(destination.SCD2IsCurrentColumn),
+	)
+	config.Debug("[ORACLE SCD2] Step 3 - Insert new versions: %s", insertSQL)
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert new versions: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	config.Debug("[ORACLE SCD2] SCD2 merge completed in %v", time.Since(startOp))
+	return nil
+}
+
+func (d *OracleDestination) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	_, err := d.db.ExecContext(ctx, sql, args...)
+	if err != nil {
+		config.LogFailedQuery(sql, err)
+	}
+	return err
+}
+
+func (d *OracleDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &oracleTransaction{tx: tx}, nil
+}
+
+type oracleTransaction struct {
+	tx *sql.Tx
+}
+
+func (t *oracleTransaction) Exec(ctx context.Context, sql string, args ...interface{}) error {
+	_, err := t.tx.ExecContext(ctx, sql, args...)
+	if err != nil {
+		config.LogFailedQuery(sql, err)
+	}
+	return err
+}
+
+func (t *oracleTransaction) Commit(ctx context.Context) error {
+	return t.tx.Commit()
+}
+
+func (t *oracleTransaction) Rollback(ctx context.Context) error {
+	return t.tx.Rollback()
+}
+
+func (d *OracleDestination) SupportsReplaceStrategy() bool      { return true }
+func (d *OracleDestination) SupportsAppendStrategy() bool       { return true }
+func (d *OracleDestination) SupportsMergeStrategy() bool        { return true }
+func (d *OracleDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *OracleDestination) SupportsSCD2Strategy() bool         { return true }
+func (d *OracleDestination) SupportsAtomicSwap() bool           { return true }
+func (d *OracleDestination) SupportsCDCMerge() bool             { return true }
+
+func (d *OracleDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingTargetSchema,
+		DefaultManagedSchema: defaultOracleStagingSchema,
+	}
+}
+
+func (d *OracleDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	maxLSN, err := d.queryMaxCDCLSN(ctx, oracleMaxCDCLSNQuery(table))
+	if err != nil {
+		if isOracleError(err, "00942", "00904") {
+			return "", nil
+		}
+		if isOracleError(err, "00932") {
+			maxLSN, err = d.queryMaxCDCLSN(ctx, oracleMaxCDCLSNLobQuery(table))
+		}
+	}
+	if err != nil {
+		if isOracleError(err, "00942", "00904") {
+			return "", nil
+		}
+		return "", err
+	}
+	return maxLSN, nil
+}
+
+func (d *OracleDestination) queryMaxCDCLSN(ctx context.Context, query string) (string, error) {
+	var maxLSN sql.NullString
+	err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN)
+	if err != nil {
+		return "", err
+	}
+	if !maxLSN.Valid {
+		return "", nil
+	}
+	return maxLSN.String, nil
+}
+
+func oracleMaxCDCLSNQuery(table string) string {
+	return fmt.Sprintf("SELECT MAX(%s) FROM %s", quoteColumn(destination.CDCLSNColumn), quoteTable(table))
+}
+
+func oracleMaxCDCLSNLobQuery(table string) string {
+	return fmt.Sprintf("SELECT MAX(DBMS_LOB.SUBSTR(%s, 4000, 1)) FROM %s", quoteColumn(destination.CDCLSNColumn), quoteTable(table))
+}
+
+func (d *OracleDestination) GetScheme() string { return "oracle" }
+
+func (d *OracleDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+
+	query := `
+		SELECT COLUMN_NAME, DATA_TYPE, NULLABLE, DATA_PRECISION, DATA_SCALE, CHAR_LENGTH
+		FROM ALL_TAB_COLUMNS
+		WHERE OWNER = :1 AND TABLE_NAME = :2
+		ORDER BY COLUMN_ID`
+
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query table schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	for rows.Next() {
+		var colName, dataType, nullable string
+		var precision, scale, charLength sql.NullInt64
+
+		if err := rows.Scan(&colName, &dataType, &nullable, &precision, &scale, &charLength); err != nil {
+			return nil, fmt.Errorf("failed to scan column: %w", err)
+		}
+
+		colPrecision := nullIntPtr(precision)
+		colScale := nullIntPtr(scale)
+		colCharLength := nullIntPtr(charLength)
+		col := mapOracleTypeToSchema(dataType, colPrecision, colScale, colCharLength)
+		col.Name = colName
+		col.Nullable = nullable == "Y"
+		columns = append(columns, col)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+	if len(columns) == 0 {
+		return nil, nil
+	}
+
+	primaryKeys, err := d.getPrimaryKeys(ctx, schemaName, tableName)
+	if err != nil {
+		return nil, err
+	}
+	for i := range columns {
+		for _, pk := range primaryKeys {
+			if strings.EqualFold(columns[i].Name, pk) {
+				columns[i].IsPrimaryKey = true
+				break
+			}
+		}
+	}
+
+	return &schema.TableSchema{
+		Name:        tableName,
+		Schema:      schemaName,
+		Columns:     columns,
+		PrimaryKeys: primaryKeys,
+	}, nil
+}
+
+func (d *OracleDestination) getPrimaryKeys(ctx context.Context, schemaName, tableName string) ([]string, error) {
+	query := `
+		SELECT cc.COLUMN_NAME
+		FROM ALL_CONSTRAINTS c
+		JOIN ALL_CONS_COLUMNS cc
+			ON c.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+			AND c.OWNER = cc.OWNER
+		WHERE c.CONSTRAINT_TYPE = 'P'
+			AND c.OWNER = :1
+			AND c.TABLE_NAME = :2
+		ORDER BY cc.POSITION`
+
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query primary keys: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("failed to scan primary key: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func (d *OracleDestination) tableExists(ctx context.Context, table string) (bool, error) {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+	var count int
+	query := "SELECT COUNT(*) FROM ALL_TABLES WHERE OWNER = :1 AND TABLE_NAME = :2"
+	if err := d.db.QueryRowContext(ctx, query, schemaName, tableName).Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to check table existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (d *OracleDestination) effectiveSchemaTable(table string) (string, string) {
+	schemaName, tableName := parseTableName(table)
+	schemaName = normalizeStagingSchema(schemaName)
+	if schemaName == "" {
+		schemaName = d.currentUser
+	}
+	return canonicalIdentifier(schemaName), canonicalIdentifier(tableName)
+}
+
+func normalizeStagingSchema(schemaName string) string {
+	if strings.EqualFold(schemaName, defaultOracleStagingSchema) {
+		return ""
+	}
+	return schemaName
+}
+
+func parseTableName(table string) (string, string) {
+	parts := tablename.Split(table)
+	if len(parts) >= 2 {
+		return parts[0], parts[1]
+	}
+	return "", table
+}
+
+func extractTableName(table string) string {
+	_, tableName := parseTableName(table)
+	return tableName
+}
+
+func backupTableName(schemaName, tableName string) string {
+	candidate := fmt.Sprintf("%s_OLD_%d", canonicalIdentifier(tableName), time.Now().UnixNano())
+	backupName := destination.ShortenIdentifier(candidate, candidate, destination.MaxIdentifierLength("oracle"))
+	if schemaName == "" || strings.EqualFold(schemaName, defaultOracleStagingSchema) {
+		return backupName
+	}
+	return schemaName + "." + backupName
+}
+
+func (d *OracleDestination) restoreBackup(ctx context.Context, targetTable, backupTable string) error {
+	if err := d.DropTable(ctx, targetTable); err != nil {
+		return err
+	}
+	_, targetName := parseTableName(targetTable)
+	restoreSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", quoteTable(backupTable), quoteColumn(targetName))
+	if _, err := d.db.ExecContext(ctx, restoreSQL); err != nil {
+		config.LogFailedQuery(restoreSQL, err)
+		return err
+	}
+	return nil
+}
+
+func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryKeys []string) string {
+	columns := tableSchema.Columns
+	primaryKeySet := make(map[string]bool, len(primaryKeys)+len(tableSchema.PrimaryKeys))
+	for _, key := range primaryKeys {
+		primaryKeySet[strings.ToLower(key)] = true
+	}
+	for _, key := range tableSchema.PrimaryKeys {
+		primaryKeySet[strings.ToLower(key)] = true
+	}
+
+	colDefs := make([]string, 0, len(columns)+1)
+	for _, col := range columns {
+		isPrimaryKey := col.IsPrimaryKey || primaryKeySet[strings.ToLower(col.Name)]
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), mapDataTypeToOracle(col, isPrimaryKey)))
+	}
+	if len(primaryKeys) > 0 {
+		quotedKeys := quoteColumns(primaryKeys)
+		colDefs = append(colDefs, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(quotedKeys, ", ")))
+	}
+	return fmt.Sprintf("CREATE TABLE %s (\n  %s\n)", quoteTable(table), strings.Join(colDefs, ",\n  "))
+}
+
+func oracleDedupSource(columns, primaryKeys []string, tableExpr, orderBy, where, alias string) string {
+	return fmt.Sprintf("(%s) %s", oracleDedupSelect(columns, primaryKeys, tableExpr, orderBy, where), alias)
+}
+
+func oracleDedupSelect(columns, primaryKeys []string, tableExpr, orderBy string, where ...string) string {
+	quotedColumns := strings.Join(quoteColumns(columns), ", ")
+	if len(primaryKeys) == 0 {
+		return fmt.Sprintf("SELECT %s FROM %s%s", quotedColumns, tableExpr, strings.Join(where, ""))
+	}
+
+	whereClause := strings.Join(where, "")
+	return fmt.Sprintf(
+		"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) bruin_dedup_rn FROM %s%s) bruin_numbered WHERE bruin_dedup_rn = 1",
+		quotedColumns,
+		quotedColumns,
+		strings.Join(quoteColumns(primaryKeys), ", "),
+		orderBy,
+		tableExpr,
+		whereClause,
+	)
+}
+
+func quoteTable(table string) string {
+	parts := tablename.Split(table)
+	if len(parts) == 2 && strings.EqualFold(parts[0], defaultOracleStagingSchema) {
+		return quoteColumn(parts[1])
+	}
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		quoted = append(quoted, quoteColumn(part))
+	}
+	return strings.Join(quoted, ".")
+}
+
+func quoteColumn(col string) string {
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(canonicalIdentifier(col), `"`, `""`))
+}
+
+func quoteColumns(columns []string) []string {
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = quoteColumn(col)
+	}
+	return quoted
+}
+
+func canonicalIdentifier(name string) string {
+	return strings.ToUpper(strings.TrimSpace(name))
+}
+
+func filterColumns(columns []string, exclude []string) []string {
+	excludeMap := make(map[string]bool, len(exclude))
+	for _, col := range exclude {
+		excludeMap[strings.ToLower(col)] = true
+	}
+
+	var result []string
+	for _, col := range columns {
+		if !excludeMap[strings.ToLower(col)] {
+			result = append(result, col)
+		}
+	}
+	return result
+}
+
+func sourceColumnRefs(columns []string, alias string) []string {
+	refs := make([]string, len(columns))
+	for i, col := range columns {
+		refs[i] = alias + "." + quoteColumn(col)
+	}
+	return refs
+}
+
+func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
+	conditions := make([]string, len(keys))
+	for i, key := range keys {
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteColumn(key), sourceAlias, quoteColumn(key))
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func buildUpdateSet(columns []string, targetAlias, sourceAlias string) string {
+	sets := make([]string, len(columns))
+	for i, col := range columns {
+		sets[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteColumn(col), sourceAlias, quoteColumn(col))
+	}
+	return strings.Join(sets, ", ")
+}
+
+func buildChangeConditions(columns []string, targetAlias, sourceAlias string, tableSchema *schema.TableSchema) string {
+	if len(columns) == 0 {
+		return "0 = 1"
+	}
+	columnTypes := make(map[string]schema.Column)
+	if tableSchema != nil {
+		for _, col := range tableSchema.Columns {
+			columnTypes[strings.ToLower(col.Name)] = col
+		}
+	}
+	conditions := make([]string, len(columns))
+	for i, col := range columns {
+		target := targetAlias + "." + quoteColumn(col)
+		source := sourceAlias + "." + quoteColumn(col)
+		if oracleColumnUsesLOB(columnTypes[strings.ToLower(col)]) {
+			conditions[i] = fmt.Sprintf("(DBMS_LOB.COMPARE(%s, %s) != 0 OR (%s IS NULL AND %s IS NOT NULL) OR (%s IS NOT NULL AND %s IS NULL))",
+				target, source, target, source, target, source)
+			continue
+		}
+		conditions[i] = fmt.Sprintf("(%s <> %s OR (%s IS NULL AND %s IS NOT NULL) OR (%s IS NOT NULL AND %s IS NULL))",
+			target, source, target, source, target, source)
+	}
+	return strings.Join(conditions, " OR ")
+}
+
+func oracleColumnUsesLOB(col schema.Column) bool {
+	switch col.DataType {
+	case schema.TypeString:
+		return col.MaxLength <= 0 || col.MaxLength > 4000
+	case schema.TypeBinary:
+		return col.MaxLength <= 0 || col.MaxLength > 2000
+	case schema.TypeJSON, schema.TypeArray:
+		return true
+	default:
+		return false
+	}
+}
+
+func extractValue(arr arrow.Array, idx int) interface{} {
+	if arr.IsNull(idx) {
+		return nil
+	}
+
+	switch a := arr.(type) {
+	case *array.Boolean:
+		if a.Value(idx) {
+			return 1
+		}
+		return 0
+	case *array.Int8:
+		return a.Value(idx)
+	case *array.Int16:
+		return a.Value(idx)
+	case *array.Int32:
+		return a.Value(idx)
+	case *array.Int64:
+		return a.Value(idx)
+	case *array.Uint8:
+		return a.Value(idx)
+	case *array.Uint16:
+		return a.Value(idx)
+	case *array.Uint32:
+		return a.Value(idx)
+	case *array.Uint64:
+		return a.Value(idx)
+	case *array.Float32:
+		return a.Value(idx)
+	case *array.Float64:
+		return a.Value(idx)
+	case *array.String:
+		return a.Value(idx)
+	case *array.LargeString:
+		return a.Value(idx)
+	case *array.Binary:
+		return a.Value(idx)
+	case *array.Date32:
+		return a.Value(idx).ToTime()
+	case *array.Date64:
+		return a.Value(idx).ToTime()
+	case *array.Time32:
+		v := int64(a.Value(idx))
+		switch a.DataType().(*arrow.Time32Type).Unit {
+		case arrow.Second:
+			return formatTimeOfDay(v * int64(time.Second/time.Microsecond))
+		case arrow.Millisecond:
+			return formatTimeOfDay(v * int64(time.Millisecond/time.Microsecond))
+		default:
+			return formatTimeOfDay(v)
+		}
+	case *array.Time64:
+		micros := int64(a.Value(idx))
+		if a.DataType().(*arrow.Time64Type).Unit == arrow.Nanosecond {
+			micros /= 1000
+		}
+		return formatTimeOfDay(micros)
+	case *array.Timestamp:
+		return a.Value(idx).ToTime(a.DataType().(*arrow.TimestampType).Unit)
+	case *array.Decimal128:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case array.ListLike:
+		return a.ValueStr(idx)
+	case *array.Struct:
+		return a.ValueStr(idx)
+	case array.ExtensionArray:
+		return extractValue(a.Storage(), idx)
+	default:
+		return fmt.Sprintf("%v", arr)
+	}
+}
+
+func formatTimeOfDay(micros int64) string {
+	t := time.Duration(micros) * time.Microsecond
+	hours := int(t.Hours())
+	mins := int(t.Minutes()) % 60
+	secs := int(t.Seconds()) % 60
+	frac := micros % 1000000
+	return fmt.Sprintf("%02d:%02d:%02d.%06d", hours, mins, secs, frac)
+}
+
+func nullIntPtr(v sql.NullInt64) *int {
+	if !v.Valid {
+		return nil
+	}
+	i := int(v.Int64)
+	return &i
+}
+
+func isOracleError(err error, codes ...string) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToUpper(err.Error())
+	for _, code := range codes {
+		if strings.Contains(msg, "ORA-"+code) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -704,6 +704,10 @@ func (d *OracleDestination) ReplaceStagingPolicy() destination.ReplaceStagingPol
 	}
 }
 
+func (d *OracleDestination) ManagedStagingPolicy() destination.ReplaceStagingPolicy {
+	return d.ReplaceStagingPolicy()
+}
+
 func (d *OracleDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
 	maxLSN, err := d.queryMaxCDCLSN(ctx, oracleMaxCDCLSNQuery(table))
 	if err != nil {

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -365,6 +365,19 @@ func TestOracleDialectTypeName_PrimaryKeyStringUsesVarchar(t *testing.T) {
 	}))
 }
 
+func TestOracleDialectAddColumnSQL_StringIncrementalKeyMetadataUsesVarchar(t *testing.T) {
+	dialect := &Dialect{}
+
+	got := dialect.AddColumnSQL("users", schema.Column{
+		Name:      "cursor",
+		DataType:  schema.TypeString,
+		MaxLength: oracleDefaultComparableStringLength,
+		Nullable:  true,
+	})
+
+	assert.Equal(t, `ALTER TABLE "USERS" ADD "CURSOR" VARCHAR2(4000 CHAR)`, got)
+}
+
 func TestOracleMaxCDCLSNQueries(t *testing.T) {
 	assert.Equal(
 		t,

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -1,0 +1,319 @@
+package oracle
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildConnStrings(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "path as dbname tries SID then service name",
+			uri:  "oracle://user:pass@localhost:1521/ORCL",
+			want: []string{
+				"oracle://user:pass@localhost:1521/?SID=ORCL",
+				"oracle://user:pass@localhost:1521/ORCL",
+			},
+		},
+		{
+			name: "oracle+cx_oracle scheme",
+			uri:  "oracle+cx_oracle://user:pass@host:1521/ORCL",
+			want: []string{
+				"oracle://user:pass@host:1521/?SID=ORCL",
+				"oracle://user:pass@host:1521/ORCL",
+			},
+		},
+		{
+			name: "explicit service name",
+			uri:  "oracle://user:pass@host:1521/?service_name=XEPDB1",
+			want: []string{"oracle://user:pass@host:1521/XEPDB1"},
+		},
+		{
+			name: "explicit SID",
+			uri:  "oracle://user:pass@host:1521?SID=ORCL",
+			want: []string{"oracle://user:pass@host:1521/?SID=ORCL"},
+		},
+		{
+			name: "default port",
+			uri:  "oracle://user:pass@host/ORCL",
+			want: []string{
+				"oracle://user:pass@host:1521/?SID=ORCL",
+				"oracle://user:pass@host:1521/ORCL",
+			},
+		},
+		{
+			name:    "invalid scheme",
+			uri:     "postgres://user:pass@host/db",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildConnStrings(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestQuoteTable(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		want  string
+	}{
+		{
+			name:  "bare table",
+			table: "users",
+			want:  `"USERS"`,
+		},
+		{
+			name:  "schema table",
+			table: "hr.employees",
+			want:  `"HR"."EMPLOYEES"`,
+		},
+		{
+			name:  "generated staging schema stored in connected user",
+			table: "_bruin_staging.hr__employees_merge_123",
+			want:  `"HR__EMPLOYEES_MERGE_123"`,
+		},
+		{
+			name:  "embedded quote",
+			table: `hr.user"events`,
+			want:  `"HR"."USER""EVENTS"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, quoteTable(tt.table))
+		})
+	}
+}
+
+func TestMapDataTypeToOracle(t *testing.T) {
+	tests := []struct {
+		name string
+		col  schema.Column
+		want string
+	}{
+		{name: "boolean", col: schema.Column{DataType: schema.TypeBoolean}, want: "NUMBER(1,0)"},
+		{name: "int64", col: schema.Column{DataType: schema.TypeInt64}, want: "NUMBER(19,0)"},
+		{name: "decimal bounded", col: schema.Column{DataType: schema.TypeDecimal, Precision: 12, Scale: 2}, want: "NUMBER(12,2)"},
+		{name: "decimal capped", col: schema.Column{DataType: schema.TypeDecimal, Precision: 60, Scale: 50}, want: "NUMBER(38,38)"},
+		{name: "short string", col: schema.Column{DataType: schema.TypeString, MaxLength: 255}, want: "VARCHAR2(255 CHAR)"},
+		{name: "long string", col: schema.Column{DataType: schema.TypeString}, want: "CLOB"},
+		{name: "cdc lsn string", col: schema.Column{Name: "_cdc_lsn", DataType: schema.TypeString}, want: "VARCHAR2(255 CHAR)"},
+		{name: "timestamp tz", col: schema.Column{DataType: schema.TypeTimestampTZ}, want: "TIMESTAMP(6) WITH TIME ZONE"},
+		{name: "json", col: schema.Column{DataType: schema.TypeJSON}, want: "CLOB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MapDataTypeToOracle(tt.col))
+		})
+	}
+}
+
+func TestBuildCreateTableSQL(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "name", DataType: schema.TypeString, MaxLength: 100},
+			{Name: "created_at", DataType: schema.TypeTimestampTZ},
+		},
+	}
+
+	got := buildCreateTableSQL("analytics.users", tableSchema, []string{"id"})
+
+	assert.Equal(t, `CREATE TABLE "ANALYTICS"."USERS" (
+  "ID" NUMBER(19,0),
+  "NAME" VARCHAR2(100 CHAR),
+  "CREATED_AT" TIMESTAMP(6) WITH TIME ZONE,
+  PRIMARY KEY ("ID")
+)`, got)
+}
+
+func TestBuildCreateTableSQL_StringPrimaryKeyUsesVarchar(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeString},
+			{Name: "name", DataType: schema.TypeString},
+		},
+	}
+
+	got := buildCreateTableSQL("users", tableSchema, []string{"id"})
+
+	assert.Equal(t, `CREATE TABLE "USERS" (
+  "ID" VARCHAR2(255 CHAR),
+  "NAME" CLOB,
+  PRIMARY KEY ("ID")
+)`, got)
+}
+
+func TestBuildCreateTableSQL_SchemaPrimaryKeyUsesVarcharWithoutConstraint(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeString},
+			{Name: "name", DataType: schema.TypeString},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+
+	got := buildCreateTableSQL("users_staging", tableSchema, nil)
+
+	assert.Equal(t, `CREATE TABLE "USERS_STAGING" (
+  "ID" VARCHAR2(255 CHAR),
+  "NAME" CLOB
+)`, got)
+}
+
+func TestBuildMergeSQL(t *testing.T) {
+	source := oracleDedupSource(
+		[]string{"id", "name", "updated_at"},
+		[]string{"id"},
+		quoteTable("_bruin_staging.users_merge_123"),
+		quoteColumn("updated_at")+" DESC",
+		"",
+		"source",
+	)
+
+	got := buildMergeSQL(
+		"users",
+		source,
+		[]string{"id", "name", "updated_at"},
+		[]string{"id"},
+		[]string{"name", "updated_at"},
+	)
+
+	assert.Equal(t, `MERGE INTO "USERS" target
+USING (SELECT "ID", "NAME", "UPDATED_AT" FROM (SELECT "ID", "NAME", "UPDATED_AT", ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "UPDATED_AT" DESC) bruin_dedup_rn FROM "USERS_MERGE_123") bruin_numbered WHERE bruin_dedup_rn = 1) source
+ON (target."ID" = source."ID")
+WHEN MATCHED THEN UPDATE SET target."NAME" = source."NAME", target."UPDATED_AT" = source."UPDATED_AT"
+WHEN NOT MATCHED THEN INSERT ("ID", "NAME", "UPDATED_AT") VALUES (source."ID", source."NAME", source."UPDATED_AT")`, got)
+}
+
+func TestBuildChangeConditions_UsesLOBCompareForLOBColumns(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString},
+			{Name: "tags", DataType: schema.TypeArray},
+			{Name: "payload", DataType: schema.TypeJSON},
+			{Name: "blob_data", DataType: schema.TypeBinary},
+		},
+	}
+
+	got := buildChangeConditions([]string{"name", "tags", "payload", "blob_data"}, "target", "source", tableSchema)
+
+	assert.Contains(t, got, `DBMS_LOB.COMPARE(target."NAME", source."NAME") != 0`)
+	assert.Contains(t, got, `DBMS_LOB.COMPARE(target."TAGS", source."TAGS") != 0`)
+	assert.Contains(t, got, `DBMS_LOB.COMPARE(target."PAYLOAD", source."PAYLOAD") != 0`)
+	assert.Contains(t, got, `DBMS_LOB.COMPARE(target."BLOB_DATA", source."BLOB_DATA") != 0`)
+	assert.NotContains(t, got, "TO_CHAR")
+}
+
+func TestBuildChangeConditions_UsesDirectCompareForNonLOBColumns(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "name", DataType: schema.TypeString, MaxLength: 100},
+			{Name: "data", DataType: schema.TypeBinary, MaxLength: 100},
+		},
+	}
+
+	got := buildChangeConditions([]string{"id", "name", "data"}, "target", "source", tableSchema)
+
+	assert.Contains(t, got, `target."ID" <> source."ID"`)
+	assert.Contains(t, got, `target."NAME" <> source."NAME"`)
+	assert.Contains(t, got, `target."DATA" <> source."DATA"`)
+	assert.NotContains(t, got, "DBMS_LOB.COMPARE")
+	assert.NotContains(t, got, "TO_CHAR")
+}
+
+func TestOracleReplaceUsesStagedPath(t *testing.T) {
+	dest := NewOracleDestination()
+
+	assert.True(t, dest.SupportsAtomicSwap())
+
+	policy := dest.ReplaceStagingPolicy()
+	assert.Equal(t, destination.ReplaceStagingTargetSchema, policy.DefaultPlacement)
+	assert.Equal(t, defaultOracleStagingSchema, policy.DefaultManagedSchema)
+}
+
+func TestBackupTableName(t *testing.T) {
+	got := backupTableName("hr", "employees")
+
+	assert.True(t, strings.HasPrefix(got, "hr.EMPLOYEES_OLD_"), got)
+	_, tableName := parseTableName(got)
+	assert.LessOrEqual(t, len(tableName), destination.MaxIdentifierLength("oracle"))
+}
+
+func TestOracleDialectDoesNotSupportDirectTypeAlter(t *testing.T) {
+	dialect := &Dialect{}
+
+	assert.False(t, dialect.SupportsAlterType())
+	assert.Empty(t, dialect.AlterColumnTypeSQL("users", "age", schema.Column{
+		Name:     "age",
+		DataType: schema.TypeString,
+	}))
+}
+
+func TestOracleDialectTypeName_PrimaryKeyStringUsesVarchar(t *testing.T) {
+	dialect := &Dialect{}
+
+	assert.Equal(t, "VARCHAR2(255 CHAR)", dialect.TypeName(schema.Column{
+		Name:         "id",
+		DataType:     schema.TypeString,
+		IsPrimaryKey: true,
+	}))
+	assert.Equal(t, "CLOB", dialect.TypeName(schema.Column{
+		Name:     "description",
+		DataType: schema.TypeString,
+	}))
+}
+
+func TestOracleMaxCDCLSNQueries(t *testing.T) {
+	assert.Equal(
+		t,
+		`SELECT MAX("_CDC_LSN") FROM "USERS"`,
+		oracleMaxCDCLSNQuery("users"),
+	)
+	assert.Equal(
+		t,
+		`SELECT MAX(DBMS_LOB.SUBSTR("_CDC_LSN", 4000, 1)) FROM "USERS"`,
+		oracleMaxCDCLSNLobQuery("users"),
+	)
+}
+
+func TestExtractValue_ListUsesRowValue(t *testing.T) {
+	builder := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64)
+	values := builder.ValueBuilder().(*array.Int64Builder)
+	builder.Append(true)
+	values.AppendValues([]int64{1, 2}, nil)
+	builder.Append(true)
+	values.AppendValues([]int64{3}, nil)
+	arr := builder.NewArray()
+	defer arr.Release()
+	builder.Release()
+
+	assert.Equal(t, "[1,2]", extractValue(arr, 0))
+	assert.Equal(t, "[3]", extractValue(arr, 1))
+}

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -175,6 +175,26 @@ func TestBuildCreateTableSQL_StringPrimaryKeyUsesVarchar(t *testing.T) {
 )`, got)
 }
 
+func TestBuildCreateTableSQL_StringIncrementalKeyUsesVarchar(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "cursor", DataType: schema.TypeString},
+			{Name: "name", DataType: schema.TypeString},
+		},
+		IncrementalKey: "cursor",
+	}
+
+	got := buildCreateTableSQL("users", tableSchema, []string{"id"})
+
+	assert.Equal(t, `CREATE TABLE "USERS" (
+  "ID" NUMBER(19,0),
+  "CURSOR" VARCHAR2(4000 CHAR),
+  "NAME" CLOB,
+  PRIMARY KEY ("ID")
+)`, got)
+}
+
 func TestBuildCreateTableSQL_SchemaPrimaryKeyUsesVarcharWithoutConstraint(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{
@@ -215,6 +235,26 @@ USING (SELECT "ID", "NAME", "UPDATED_AT" FROM (SELECT "ID", "NAME", "UPDATED_AT"
 ON (target."ID" = source."ID")
 WHEN MATCHED THEN UPDATE SET target."NAME" = source."NAME", target."UPDATED_AT" = source."UPDATED_AT"
 WHEN NOT MATCHED THEN INSERT ("ID", "NAME", "UPDATED_AT") VALUES (source."ID", source."NAME", source."UPDATED_AT")`, got)
+}
+
+func TestBuildCDCDeleteTombstoneInsertSQL(t *testing.T) {
+	source := oracleDedupSource(
+		[]string{"id", "name", destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn},
+		[]string{"id"},
+		quoteTable("users_staging"),
+		destination.CDCLatestOverallOrderBy(quoteColumn),
+		"",
+		"source",
+	)
+
+	got := buildCDCDeleteTombstoneInsertSQL(
+		"users",
+		source,
+		[]string{"id", "name", destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn},
+		[]string{"id"},
+	)
+
+	assert.Equal(t, `INSERT INTO "USERS" ("ID", "NAME", "_CDC_LSN", "_CDC_DELETED", "_CDC_SYNCED_AT") SELECT source."ID", source."NAME", source."_CDC_LSN", source."_CDC_DELETED", source."_CDC_SYNCED_AT" FROM (SELECT "ID", "NAME", "_CDC_LSN", "_CDC_DELETED", "_CDC_SYNCED_AT" FROM (SELECT "ID", "NAME", "_CDC_LSN", "_CDC_DELETED", "_CDC_SYNCED_AT", ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "_CDC_LSN" DESC, "_CDC_DELETED" DESC) bruin_dedup_rn FROM "USERS_STAGING") bruin_numbered WHERE bruin_dedup_rn = 1) source WHERE source."_CDC_DELETED" = 1 AND NOT EXISTS (SELECT 1 FROM "USERS" target WHERE target."ID" = source."ID")`, got)
 }
 
 func TestMergeTableRequiresPrimaryKey(t *testing.T) {

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -91,9 +92,9 @@ func TestQuoteTable(t *testing.T) {
 			want:  `"HR"."EMPLOYEES"`,
 		},
 		{
-			name:  "generated staging schema stored in connected user",
+			name:  "generated staging schema is honored",
 			table: "_bruin_staging.hr__employees_merge_123",
-			want:  `"HR__EMPLOYEES_MERGE_123"`,
+			want:  `"_BRUIN_STAGING"."HR__EMPLOYEES_MERGE_123"`,
 		},
 		{
 			name:  "embedded quote",
@@ -121,7 +122,7 @@ func TestMapDataTypeToOracle(t *testing.T) {
 		{name: "decimal capped", col: schema.Column{DataType: schema.TypeDecimal, Precision: 60, Scale: 50}, want: "NUMBER(38,38)"},
 		{name: "short string", col: schema.Column{DataType: schema.TypeString, MaxLength: 255}, want: "VARCHAR2(255 CHAR)"},
 		{name: "long string", col: schema.Column{DataType: schema.TypeString}, want: "CLOB"},
-		{name: "cdc lsn string", col: schema.Column{Name: "_cdc_lsn", DataType: schema.TypeString}, want: "VARCHAR2(255 CHAR)"},
+		{name: "cdc lsn string", col: schema.Column{Name: "_cdc_lsn", DataType: schema.TypeString}, want: "VARCHAR2(4000 CHAR)"},
 		{name: "timestamp tz", col: schema.Column{DataType: schema.TypeTimestampTZ}, want: "TIMESTAMP(6) WITH TIME ZONE"},
 		{name: "json", col: schema.Column{DataType: schema.TypeJSON}, want: "CLOB"},
 	}
@@ -163,7 +164,7 @@ func TestBuildCreateTableSQL_StringPrimaryKeyUsesVarchar(t *testing.T) {
 	got := buildCreateTableSQL("users", tableSchema, []string{"id"})
 
 	assert.Equal(t, `CREATE TABLE "USERS" (
-  "ID" VARCHAR2(255 CHAR),
+  "ID" VARCHAR2(4000 CHAR),
   "NAME" CLOB,
   PRIMARY KEY ("ID")
 )`, got)
@@ -181,7 +182,7 @@ func TestBuildCreateTableSQL_SchemaPrimaryKeyUsesVarcharWithoutConstraint(t *tes
 	got := buildCreateTableSQL("users_staging", tableSchema, nil)
 
 	assert.Equal(t, `CREATE TABLE "USERS_STAGING" (
-  "ID" VARCHAR2(255 CHAR),
+  "ID" VARCHAR2(4000 CHAR),
   "NAME" CLOB
 )`, got)
 }
@@ -205,10 +206,28 @@ func TestBuildMergeSQL(t *testing.T) {
 	)
 
 	assert.Equal(t, `MERGE INTO "USERS" target
-USING (SELECT "ID", "NAME", "UPDATED_AT" FROM (SELECT "ID", "NAME", "UPDATED_AT", ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "UPDATED_AT" DESC) bruin_dedup_rn FROM "USERS_MERGE_123") bruin_numbered WHERE bruin_dedup_rn = 1) source
+USING (SELECT "ID", "NAME", "UPDATED_AT" FROM (SELECT "ID", "NAME", "UPDATED_AT", ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "UPDATED_AT" DESC) bruin_dedup_rn FROM "_BRUIN_STAGING"."USERS_MERGE_123") bruin_numbered WHERE bruin_dedup_rn = 1) source
 ON (target."ID" = source."ID")
 WHEN MATCHED THEN UPDATE SET target."NAME" = source."NAME", target."UPDATED_AT" = source."UPDATED_AT"
 WHEN NOT MATCHED THEN INSERT ("ID", "NAME", "UPDATED_AT") VALUES (source."ID", source."NAME", source."UPDATED_AT")`, got)
+}
+
+func TestMergeTableRequiresPrimaryKey(t *testing.T) {
+	dest := NewOracleDestination()
+
+	err := dest.MergeTable(context.Background(), destination.MergeOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "primary key")
+}
+
+func TestSCD2TableRequiresPrimaryKey(t *testing.T) {
+	dest := NewOracleDestination()
+
+	err := dest.SCD2Table(context.Background(), destination.SCD2Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "primary key")
 }
 
 func TestBuildChangeConditions_UsesLOBCompareForLOBColumns(t *testing.T) {
@@ -249,12 +268,13 @@ func TestBuildChangeConditions_UsesDirectCompareForNonLOBColumns(t *testing.T) {
 }
 
 func TestOracleReplaceUsesStagedPath(t *testing.T) {
-	dest := NewOracleDestination()
+	dest := &OracleDestination{currentUser: "INGESTR"}
 
 	assert.True(t, dest.SupportsAtomicSwap())
 
 	policy := dest.ReplaceStagingPolicy()
 	assert.Equal(t, destination.ReplaceStagingTargetSchema, policy.DefaultPlacement)
+	assert.Equal(t, "INGESTR", policy.DefaultTargetSchema)
 	assert.Equal(t, defaultOracleStagingSchema, policy.DefaultManagedSchema)
 }
 
@@ -279,7 +299,7 @@ func TestOracleDialectDoesNotSupportDirectTypeAlter(t *testing.T) {
 func TestOracleDialectTypeName_PrimaryKeyStringUsesVarchar(t *testing.T) {
 	dialect := &Dialect{}
 
-	assert.Equal(t, "VARCHAR2(255 CHAR)", dialect.TypeName(schema.Column{
+	assert.Equal(t, "VARCHAR2(4000 CHAR)", dialect.TypeName(schema.Column{
 		Name:         "id",
 		DataType:     schema.TypeString,
 		IsPrimaryKey: true,

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -92,9 +92,14 @@ func TestQuoteTable(t *testing.T) {
 			want:  `"HR"."EMPLOYEES"`,
 		},
 		{
-			name:  "generated staging schema is honored",
+			name:  "explicit staging schema is honored",
 			table: "_bruin_staging.hr__employees_merge_123",
 			want:  `"_BRUIN_STAGING"."HR__EMPLOYEES_MERGE_123"`,
+		},
+		{
+			name:  "custom staging schema is honored",
+			table: "custom_staging.hr__employees_merge_123",
+			want:  `"CUSTOM_STAGING"."HR__EMPLOYEES_MERGE_123"`,
 		},
 		{
 			name:  "embedded quote",
@@ -273,6 +278,16 @@ func TestOracleReplaceUsesStagedPath(t *testing.T) {
 	assert.True(t, dest.SupportsAtomicSwap())
 
 	policy := dest.ReplaceStagingPolicy()
+	assert.Equal(t, destination.ReplaceStagingTargetSchema, policy.DefaultPlacement)
+	assert.Equal(t, "INGESTR", policy.DefaultTargetSchema)
+	assert.Equal(t, defaultOracleStagingSchema, policy.DefaultManagedSchema)
+}
+
+func TestOracleManagedStagingUsesCurrentUserByDefault(t *testing.T) {
+	dest := &OracleDestination{currentUser: "INGESTR"}
+
+	policy := dest.ManagedStagingPolicy()
+
 	assert.Equal(t, destination.ReplaceStagingTargetSchema, policy.DefaultPlacement)
 	assert.Equal(t, "INGESTR", policy.DefaultTargetSchema)
 	assert.Equal(t, defaultOracleStagingSchema, policy.DefaultManagedSchema)

--- a/pkg/destination/oracle/register.go
+++ b/pkg/destination/oracle/register.go
@@ -1,0 +1,10 @@
+package oracle
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"oracle", "oracle+cx_oracle"},
+		func() interface{} { return NewOracleDestination() },
+	)
+}

--- a/pkg/destination/shorten.go
+++ b/pkg/destination/shorten.go
@@ -15,6 +15,8 @@ var maxIdentifierLengths = map[string]int{
 	"mysql":               64,
 	"mysql+pymysql":       64,
 	"mariadb":             64,
+	"oracle":              128,
+	"oracle+cx_oracle":    128,
 	"mssql":               128,
 	"sqlserver":           128,
 	"mssql+pyodbc":        128,

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/term"
 )
 
+const oracleComparableStringLen = 4000
+
 type Pipeline struct {
 	config                   *config.IngestConfig
 	src                      source.Source
@@ -337,6 +339,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to apply column overrides: %w", err)
 		}
 	}
+	p.applyDestinationSchemaConstraints(destSchema)
 
 	var loadTimestamp time.Time
 	if !p.config.NoLoadTimestamp {
@@ -1362,6 +1365,25 @@ func markPrimaryKeyColumns(tableSchema *schema.TableSchema) {
 	}
 	for i := range tableSchema.Columns {
 		tableSchema.Columns[i].IsPrimaryKey = primaryKeys[strings.ToLower(tableSchema.Columns[i].Name)]
+	}
+}
+
+func (p *Pipeline) applyDestinationSchemaConstraints(tableSchema *schema.TableSchema) {
+	if tableSchema == nil || tableSchema.IncrementalKey == "" || p.dest == nil {
+		return
+	}
+	if p.dest.GetScheme() != "oracle" && p.dest.GetScheme() != "oracle+cx_oracle" {
+		return
+	}
+
+	for i := range tableSchema.Columns {
+		col := &tableSchema.Columns[i]
+		if col.DataType != schema.TypeString || !strings.EqualFold(col.Name, tableSchema.IncrementalKey) {
+			continue
+		}
+		if col.MaxLength <= 0 || col.MaxLength > oracleComparableStringLen {
+			col.MaxLength = oracleComparableStringLen
+		}
 	}
 }
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -311,6 +311,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	// Shorten column names that exceed the destination's identifier length limit.
 	// Must run before schema evolution so ALTER TABLE uses shortened names.
 	p.shortenLongIdentifiers(tableSchema)
+	markPrimaryKeyColumns(tableSchema)
 
 	// setupIngestrColumns copies the schema and adds ingestr columns for the destination.
 	// The original tableSchema stays clean (used by sources for SELECT queries).
@@ -375,6 +376,9 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	// Staging mirrors the destination schema, with staging-only CDC columns retained.
 	ingestSchema := destination.StagingIngestSchema(fullSchema, destSchema)
 	ingestSchema = preserveSourceCDCColumnTypes(ingestSchema, fullSchema)
+	if strategyUsesLogicalPrimaryKeys(resolvedStrategy) {
+		ingestSchema = preserveLogicalPrimaryKeys(ingestSchema, fullSchema)
+	}
 
 	if inferBuffer != nil {
 		bufferTarget := p.buildBufferReaderTarget(originalSourceSchema, destSchema)
@@ -1155,7 +1159,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	if dialect == nil {
 		config.Debug("[SCHEMA EVOLUTION] No dialect registered for scheme %s, skipping", p.dest.GetScheme())
 		return &schemaevolution.EvolutionPlan{
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
+			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
 			Migration:   nil,
 		}, nil
 	}
@@ -1179,7 +1183,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 
 	// Build the plan; migration is NOT applied here.
 	plan := &schemaevolution.EvolutionPlan{
-		FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
+		FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, schemaevolution.MigrationFinalComparison(p.filteredSchemaComparison, dialect)),
 		Migration:   migration,
 	}
 	config.Debug("[SCHEMA EVOLUTION] Built plan with %d statements (deferred apply)", len(migration.Statements))
@@ -1315,6 +1319,39 @@ func preserveSourceCDCColumnTypes(ingestSchema, sourceSchema *schema.TableSchema
 		result.Columns[i].ArrayType = sourceCol.ArrayType
 	}
 	return &result
+}
+
+func preserveLogicalPrimaryKeys(ingestSchema, sourceSchema *schema.TableSchema) *schema.TableSchema {
+	if ingestSchema == nil || sourceSchema == nil || len(sourceSchema.PrimaryKeys) == 0 {
+		return ingestSchema
+	}
+
+	result := *ingestSchema
+	result.PrimaryKeys = append([]string{}, sourceSchema.PrimaryKeys...)
+	return &result
+}
+
+func markPrimaryKeyColumns(tableSchema *schema.TableSchema) {
+	if tableSchema == nil || len(tableSchema.PrimaryKeys) == 0 {
+		return
+	}
+
+	primaryKeys := make(map[string]bool, len(tableSchema.PrimaryKeys))
+	for _, key := range tableSchema.PrimaryKeys {
+		primaryKeys[strings.ToLower(key)] = true
+	}
+	for i := range tableSchema.Columns {
+		tableSchema.Columns[i].IsPrimaryKey = primaryKeys[strings.ToLower(tableSchema.Columns[i].Name)]
+	}
+}
+
+func strategyUsesLogicalPrimaryKeys(strategy config.IncrementalStrategy) bool {
+	switch strategy {
+	case config.StrategyMerge, config.StrategyDeleteInsert, config.StrategySCD2, config.StrategyReplace:
+		return true
+	default:
+		return false
+	}
 }
 
 func loadTimestampColumnForSchema(s *schema.TableSchema) schema.Column {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1367,6 +1367,63 @@ func TestPreserveSourceCDCColumnTypes(t *testing.T) {
 	}
 }
 
+func TestPreserveLogicalPrimaryKeys(t *testing.T) {
+	ingest := tschema(
+		"items",
+		tcol("id", schema.TypeString),
+		tcol("value", schema.TypeString),
+	)
+	source := tschema(
+		"items",
+		tcol("id", schema.TypeString),
+		tcol("value", schema.TypeString),
+	)
+	source.PrimaryKeys = []string{"id"}
+
+	got := preserveLogicalPrimaryKeys(ingest, source)
+
+	if len(got.PrimaryKeys) != 1 || got.PrimaryKeys[0] != "id" {
+		t.Fatalf("primary keys = %v, want [id]", got.PrimaryKeys)
+	}
+	if len(ingest.PrimaryKeys) != 0 {
+		t.Fatalf("input schema was mutated: %v", ingest.PrimaryKeys)
+	}
+}
+
+func TestMarkPrimaryKeyColumns(t *testing.T) {
+	tableSchema := tschema(
+		"items",
+		tcol("id", schema.TypeString),
+		tcol("value", schema.TypeString),
+	)
+	tableSchema.PrimaryKeys = []string{"id"}
+
+	markPrimaryKeyColumns(tableSchema)
+
+	if !tableSchema.Columns[0].IsPrimaryKey {
+		t.Fatal("id should be marked as primary key")
+	}
+	if tableSchema.Columns[1].IsPrimaryKey {
+		t.Fatal("non-key column should not be marked as primary key")
+	}
+}
+
+func TestStrategyUsesLogicalPrimaryKeys(t *testing.T) {
+	if strategyUsesLogicalPrimaryKeys(config.StrategyAppend) {
+		t.Fatal("append should not preserve logical primary keys for destination prepare")
+	}
+	for _, strategy := range []config.IncrementalStrategy{
+		config.StrategyReplace,
+		config.StrategyMerge,
+		config.StrategyDeleteInsert,
+		config.StrategySCD2,
+	} {
+		if !strategyUsesLogicalPrimaryKeys(strategy) {
+			t.Fatalf("%s should preserve logical primary keys", strategy)
+		}
+	}
+}
+
 func TestBuildBufferReaderTarget_OrderFollowsDest(t *testing.T) {
 	p := &Pipeline{}
 	src := tschema(

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -553,6 +553,27 @@ func TestApplyExcludedColumnsNamingAware(t *testing.T) {
 	}
 }
 
+func TestApplyDestinationSchemaConstraints_OracleStringIncrementalKey(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "cursor", DataType: schema.TypeString},
+			{Name: "payload", DataType: schema.TypeString},
+		},
+		IncrementalKey: "cursor",
+	}
+	p := &Pipeline{dest: &mockDestination{scheme: "oracle"}}
+
+	p.applyDestinationSchemaConstraints(tableSchema)
+
+	if tableSchema.Columns[1].MaxLength != oracleComparableStringLen {
+		t.Fatalf("incremental key MaxLength = %d, want %d", tableSchema.Columns[1].MaxLength, oracleComparableStringLen)
+	}
+	if tableSchema.Columns[2].MaxLength != 0 {
+		t.Fatalf("non-incremental string MaxLength = %d, want 0", tableSchema.Columns[2].MaxLength)
+	}
+}
+
 func TestNamingConsistency(t *testing.T) {
 	camelCaseSourceSchema := &schema.TableSchema{
 		Columns: []schema.Column{

--- a/pkg/schemaevolution/migrate.go
+++ b/pkg/schemaevolution/migrate.go
@@ -75,6 +75,29 @@ func GenerateMigration(comparison *SchemaComparison, dialect Dialect, table stri
 	return migration, nil
 }
 
+// MigrationFinalComparison returns the subset of changes that the generated
+// migration can make visible in the destination schema.
+func MigrationFinalComparison(comparison *SchemaComparison, dialect Dialect) *SchemaComparison {
+	if comparison == nil || !comparison.HasChanges || dialect == nil {
+		return &SchemaComparison{}
+	}
+
+	filtered := &SchemaComparison{
+		Changes: make([]SchemaChange, 0, len(comparison.Changes)),
+	}
+	for _, change := range comparison.Changes {
+		switch change.Type {
+		case ChangeWidenType, ChangeOverrideType:
+			if !dialect.SupportsAlterType() {
+				continue
+			}
+		}
+		filtered.Changes = append(filtered.Changes, change)
+	}
+	filtered.HasChanges = len(filtered.Changes) > 0
+	return filtered
+}
+
 // ApplyMigration executes the migration statements.
 func ApplyMigration(ctx context.Context, executor SQLExecutor, migration *Migration) error {
 	if migration == nil || len(migration.Statements) == 0 {

--- a/pkg/schemaevolution/migrate_test.go
+++ b/pkg/schemaevolution/migrate_test.go
@@ -115,6 +115,62 @@ func TestGenerateMigration_WidenType_NotSupported(t *testing.T) {
 	assert.Contains(t, migration.Warnings[0], "does not support")
 }
 
+func TestMigrationFinalComparison_DropsUnsupportedTypeChanges(t *testing.T) {
+	oldCol := schema.Column{Name: "age", DataType: schema.TypeInt64}
+	comparison := &SchemaComparison{
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeAddColumn,
+				ColumnName: "email",
+				NewColumn:  schema.Column{Name: "email", DataType: schema.TypeString},
+			},
+			{
+				Type:       ChangeWidenType,
+				ColumnName: "age",
+				OldColumn:  &oldCol,
+				NewColumn:  schema.Column{Name: "age", DataType: schema.TypeString},
+			},
+		},
+		HasChanges: true,
+	}
+
+	dialect := GetDialect("sqlite")
+	require.NotNil(t, dialect)
+	require.False(t, dialect.SupportsAlterType())
+
+	final := MigrationFinalComparison(comparison, dialect)
+
+	require.True(t, final.HasChanges)
+	require.Len(t, final.Changes, 1)
+	assert.Equal(t, ChangeAddColumn, final.Changes[0].Type)
+	assert.Equal(t, "email", final.Changes[0].ColumnName)
+}
+
+func TestMigrationFinalComparison_KeepsSupportedTypeChanges(t *testing.T) {
+	oldCol := schema.Column{Name: "age", DataType: schema.TypeInt64}
+	comparison := &SchemaComparison{
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeWidenType,
+				ColumnName: "age",
+				OldColumn:  &oldCol,
+				NewColumn:  schema.Column{Name: "age", DataType: schema.TypeString},
+			},
+		},
+		HasChanges: true,
+	}
+
+	dialect := GetDialect("postgres")
+	require.NotNil(t, dialect)
+	require.True(t, dialect.SupportsAlterType())
+
+	final := MigrationFinalComparison(comparison, dialect)
+
+	require.True(t, final.HasChanges)
+	require.Len(t, final.Changes, 1)
+	assert.Equal(t, ChangeWidenType, final.Changes[0].Type)
+}
+
 func TestGenerateMigration_MultipleChanges(t *testing.T) {
 	oldCol := schema.Column{Name: "score", DataType: schema.TypeInt32}
 

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -73,7 +73,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	incrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
 
 	readOpts := source.ReadOptions{
-		IncrementalKey: job.Config.IncrementalKey,
+		IncrementalKey: incrementalKey,
 		IntervalStart:  job.Config.IntervalStart,
 		IntervalEnd:    job.Config.IntervalEnd,
 		PageSize:       job.Config.PageSize,

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -70,7 +70,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		parallelism = 4
 	}
 
-	sourceIncrementalKey, _ := resolveSchemaColumn(job.SourceSchema, job.Config.IncrementalKey)
+	sourceIncrementalKey := sourceIncrementalKeyForRead(job)
 	destinationIncrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
 
 	readOpts := source.ReadOptions{
@@ -173,6 +173,22 @@ func resolveSchemaColumn(tableSchema *schema.TableSchema, columnName string) (st
 		}
 	}
 	return columnName, schema.TypeUnknown
+}
+
+func sourceIncrementalKeyForRead(job *IngestionJob) string {
+	sourceKey := job.Config.IncrementalKey
+	if job.SourceSchema != nil && job.SourceSchema.IncrementalKey != "" {
+		sourceKey = job.SourceSchema.IncrementalKey
+	} else if job.ColumnRenamer != nil && job.ColumnRenamer.HasRenames() {
+		for src, dst := range job.ColumnRenamer.Mapping() {
+			if dst == job.Config.IncrementalKey || strings.EqualFold(dst, job.Config.IncrementalKey) {
+				sourceKey = src
+				break
+			}
+		}
+	}
+	sourceKey, _ = resolveSchemaColumn(job.SourceSchema, sourceKey)
+	return sourceKey
 }
 
 func resolveIntervalBound(userProvided interface{}, autoDetected interface{}) interface{} {

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -39,7 +39,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		return fmt.Errorf("destination %s does not support delete+insert strategy", job.Destination.GetScheme())
 	}
 
-	stagingTable := GenerateStagingTableName(job.Config.DestTable, "di", job.Config.StagingDataset)
+	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "di", job.Config.StagingDataset)
 	fmt.Printf("[DELETE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -70,10 +70,11 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		parallelism = 4
 	}
 
-	incrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
+	sourceIncrementalKey, _ := resolveSchemaColumn(job.SourceSchema, job.Config.IncrementalKey)
+	destinationIncrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
 
 	readOpts := source.ReadOptions{
-		IncrementalKey: incrementalKey,
+		IncrementalKey: sourceIncrementalKey,
 		IntervalStart:  job.Config.IntervalStart,
 		IntervalEnd:    job.Config.IntervalEnd,
 		PageSize:       job.Config.PageSize,
@@ -89,7 +90,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
-	intervalTracker := NewIntervalTracker(incrementalKey)
+	intervalTracker := NewIntervalTracker(destinationIncrementalKey)
 	records = intervalTracker.Wrap(records)
 
 	if job.Tracker != nil {
@@ -138,7 +139,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	if err := job.Destination.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
 		StagingTable:       stagingTable,
 		TargetTable:        job.Config.DestTable,
-		IncrementalKey:     incrementalKey,
+		IncrementalKey:     destinationIncrementalKey,
 		IncrementalKeyType: incrementalKeyType,
 		IntervalStart:      intervalStart,
 		IntervalEnd:        intervalEnd,

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -69,6 +70,8 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		parallelism = 4
 	}
 
+	incrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
+
 	readOpts := source.ReadOptions{
 		IncrementalKey: job.Config.IncrementalKey,
 		IntervalStart:  job.Config.IntervalStart,
@@ -86,7 +89,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
-	intervalTracker := NewIntervalTracker(job.Config.IncrementalKey)
+	intervalTracker := NewIntervalTracker(incrementalKey)
 	records = intervalTracker.Wrap(records)
 
 	if job.Tracker != nil {
@@ -121,14 +124,6 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	config.Debug("[DELETE+INSERT] Interval: %v to %v", intervalStart, intervalEnd)
 	config.Debug("[DELETE+INSERT] Executing delete+insert operation")
 
-	var incrementalKeyType schema.DataType
-	for _, col := range job.Schema.Columns {
-		if col.Name == job.Config.IncrementalKey {
-			incrementalKeyType = col.DataType
-			break
-		}
-	}
-
 	// When the incremental key is DATE, convert timestamp interval bounds to date-only.
 	// This prevents type mismatches (e.g., TIMESTAMP vs DATE) in the DELETE query.
 	if incrementalKeyType == schema.TypeDate {
@@ -143,7 +138,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	if err := job.Destination.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
 		StagingTable:       stagingTable,
 		TargetTable:        job.Config.DestTable,
-		IncrementalKey:     job.Config.IncrementalKey,
+		IncrementalKey:     incrementalKey,
 		IncrementalKeyType: incrementalKeyType,
 		IntervalStart:      intervalStart,
 		IntervalEnd:        intervalEnd,
@@ -160,6 +155,23 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	}
 
 	return nil
+}
+
+func resolveSchemaColumn(tableSchema *schema.TableSchema, columnName string) (string, schema.DataType) {
+	if tableSchema == nil {
+		return columnName, schema.TypeUnknown
+	}
+	for _, col := range tableSchema.Columns {
+		if col.Name == columnName {
+			return col.Name, col.DataType
+		}
+	}
+	for _, col := range tableSchema.Columns {
+		if strings.EqualFold(col.Name, columnName) {
+			return col.Name, col.DataType
+		}
+	}
+	return columnName, schema.TypeUnknown
 }
 
 func resolveIntervalBound(userProvided interface{}, autoDetected interface{}) interface{} {

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -98,7 +98,7 @@ func (s *MergeStrategy) RequiresIncrementalKey() bool {
 
 func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	// Generate staging table name
-	stagingTable := GenerateStagingTableName(job.Config.DestTable, "merge", job.Config.StagingDataset)
+	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "merge", job.Config.StagingDataset)
 	fmt.Printf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	isCDC := hasCDCColumns(job.Schema)
 	if isCDC {
@@ -214,7 +214,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			defer wg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
-			stagingTable := GenerateStagingTableName(destTable, "merge", job.Config.StagingDataset)
+			stagingTable := managedStagingTableName(job.Destination, destTable, "merge", job.Config.StagingDataset)
 
 			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
 				errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -211,6 +211,33 @@ func TestDeleteInsertStrategy_Execute_UsesAutoDetectedInterval(t *testing.T) {
 	}
 }
 
+func TestDeleteInsertStrategy_Execute_TracksIncrementalKeyCaseInsensitive(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
+	job.Config.IncrementalKey = "id"
+	job.Schema.Columns[0].Name = "ID"
+	job.Schema.PrimaryKeys = []string{"ID"}
+
+	rec := int64RecordBatch(t, "ID", []int64{5, 10, 7}, map[int]bool{1: false})
+	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: rec})
+
+	strat := &DeleteInsertStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.diCalls) != 1 {
+		t.Fatalf("expected 1 DeleteInsertTable call, got %d", len(dest.diCalls))
+	}
+	di := dest.diCalls[0]
+	if di.IncrementalKey != "ID" {
+		t.Fatalf("DeleteInsertOptions.IncrementalKey = %q, want ID", di.IncrementalKey)
+	}
+	if di.IntervalStart != int64(5) || di.IntervalEnd != int64(10) {
+		t.Fatalf("DeleteInsertOptions interval = %v..%v, want 5..10", di.IntervalStart, di.IntervalEnd)
+	}
+}
+
 func TestDeleteInsertStrategy_Execute_UserIntervalOverridesAuto(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -215,6 +215,13 @@ func TestDeleteInsertStrategy_Execute_TracksIncrementalKeyCaseInsensitive(t *tes
 	job, src, dest := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
 	job.Config.IncrementalKey = "id"
+	job.SourceSchema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
 	job.Schema.Columns[0].Name = "ID"
 	job.Schema.PrimaryKeys = []string{"ID"}
 
@@ -236,8 +243,8 @@ func TestDeleteInsertStrategy_Execute_TracksIncrementalKeyCaseInsensitive(t *tes
 	src.mu.Lock()
 	readIncrementalKey := src.readOpts.IncrementalKey
 	src.mu.Unlock()
-	if readIncrementalKey != "ID" {
-		t.Fatalf("ReadOptions.IncrementalKey = %q, want ID", readIncrementalKey)
+	if readIncrementalKey != "id" {
+		t.Fatalf("ReadOptions.IncrementalKey = %q, want id", readIncrementalKey)
 	}
 	if di.IntervalStart != int64(5) || di.IntervalEnd != int64(10) {
 		t.Fatalf("DeleteInsertOptions interval = %v..%v, want 5..10", di.IntervalStart, di.IntervalEnd)

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 )
 
 func TestMergeStrategy_Validate(t *testing.T) {
@@ -248,6 +249,46 @@ func TestDeleteInsertStrategy_Execute_TracksIncrementalKeyCaseInsensitive(t *tes
 	}
 	if di.IntervalStart != int64(5) || di.IntervalEnd != int64(10) {
 		t.Fatalf("DeleteInsertOptions interval = %v..%v, want 5..10", di.IntervalStart, di.IntervalEnd)
+	}
+}
+
+func TestDeleteInsertStrategy_Execute_ReadsWithSourceIncrementalKeyAfterRename(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
+	job.Config.IncrementalKey = "updated_at"
+	job.Schema.Columns = []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "updated_at", DataType: schema.TypeInt64, Nullable: false},
+	}
+	job.Schema.IncrementalKey = "updated_at"
+	job.SourceSchema = &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "updatedAt", DataType: schema.TypeInt64, Nullable: false},
+		},
+		IncrementalKey: "updatedAt",
+	}
+	job.ColumnRenamer = transformer.NewColumnRenamer(map[string]string{"updatedAt": "updated_at"})
+
+	rec := int64RecordBatch(t, "updated_at", []int64{5, 10, 7}, nil)
+	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: rec})
+
+	strat := &DeleteInsertStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	src.mu.Lock()
+	readIncrementalKey := src.readOpts.IncrementalKey
+	src.mu.Unlock()
+	if readIncrementalKey != "updatedAt" {
+		t.Fatalf("ReadOptions.IncrementalKey = %q, want updatedAt", readIncrementalKey)
+	}
+	if len(dest.diCalls) != 1 {
+		t.Fatalf("expected 1 DeleteInsertTable call, got %d", len(dest.diCalls))
+	}
+	if got := dest.diCalls[0].IncrementalKey; got != "updated_at" {
+		t.Fatalf("DeleteInsertOptions.IncrementalKey = %q, want updated_at", got)
 	}
 }
 

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -233,6 +233,12 @@ func TestDeleteInsertStrategy_Execute_TracksIncrementalKeyCaseInsensitive(t *tes
 	if di.IncrementalKey != "ID" {
 		t.Fatalf("DeleteInsertOptions.IncrementalKey = %q, want ID", di.IncrementalKey)
 	}
+	src.mu.Lock()
+	readIncrementalKey := src.readOpts.IncrementalKey
+	src.mu.Unlock()
+	if readIncrementalKey != "ID" {
+		t.Fatalf("ReadOptions.IncrementalKey = %q, want ID", readIncrementalKey)
+	}
 	if di.IntervalStart != int64(5) || di.IntervalEnd != int64(10) {
 		t.Fatalf("DeleteInsertOptions interval = %v..%v, want 5..10", di.IntervalStart, di.IntervalEnd)
 	}

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -144,6 +144,7 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 		Columns:        job.Schema.ColumnNames(),
 		IncrementalKey: job.Config.IncrementalKey,
 		Timestamp:      processTimestamp,
+		Schema:         job.Schema,
 	}); err != nil {
 		return fmt.Errorf("failed to perform SCD2 merge: %w", err)
 	}
@@ -181,7 +182,7 @@ func extendSchemaWithSCDColumns(original *schema.TableSchema) *schema.TableSchem
 		Name:        original.Name,
 		Schema:      original.Schema,
 		Columns:     make([]schema.Column, len(original.Columns)+len(toAdd)),
-		PrimaryKeys: nil, // SCD2 tables don't have primary keys
+		PrimaryKeys: append([]string(nil), original.PrimaryKeys...),
 	}
 
 	copy(extended.Columns, original.Columns)

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -39,7 +39,7 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 	processTimestamp := time.Now().UTC()
 
 	// Generate staging table name
-	stagingTable := GenerateStagingTableName(job.Config.DestTable, "scd2", job.Config.StagingDataset)
+	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "scd2", job.Config.StagingDataset)
 	fmt.Printf("[SCD2] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	config.Debug("[SCD2] Using process timestamp: %s", processTimestamp.Format(time.RFC3339Nano))
 

--- a/pkg/strategy/scd2_test.go
+++ b/pkg/strategy/scd2_test.go
@@ -98,6 +98,7 @@ func TestSCD2Strategy_ExtendSchemaWithSCDColumns(t *testing.T) {
 
 	// Should have 3 additional columns
 	assert.Equal(t, 5, len(extended.Columns))
+	assert.Equal(t, []string{"id"}, extended.PrimaryKeys)
 
 	// Check SCD columns exist
 	colNames := make([]string, len(extended.Columns))

--- a/pkg/strategy/staging.go
+++ b/pkg/strategy/staging.go
@@ -34,6 +34,13 @@ func GenerateStagingTableName(targetTable, suffix, stagingDataset string) string
 	return qualifyCatalog(catalog, buildStagingTableName(stagingSchema, embeddedName, suffix))
 }
 
+func managedStagingTableName(dest destination.Destination, targetTable, suffix, stagingDataset string) string {
+	if provider, ok := dest.(destination.ManagedStagingPolicyProvider); ok {
+		return GenerateReplaceStagingTableName(targetTable, suffix, stagingDataset, provider.ManagedStagingPolicy())
+	}
+	return GenerateStagingTableName(targetTable, suffix, stagingDataset)
+}
+
 func GenerateReplaceStagingTableName(targetTable, suffix, stagingDataset string, policy destination.ReplaceStagingPolicy) string {
 	policy = normaliseReplaceStagingPolicy(policy)
 	catalog, targetSchema, tableName := splitCatalogSchemaTable(targetTable)

--- a/pkg/strategy/staging_test.go
+++ b/pkg/strategy/staging_test.go
@@ -104,3 +104,43 @@ func TestGenerateReplaceStagingTableName(t *testing.T) {
 		})
 	}
 }
+
+type fakeManagedStagingPolicyProvider struct {
+	*fakeDestination
+
+	policy destination.ReplaceStagingPolicy
+}
+
+func (d *fakeManagedStagingPolicyProvider) ManagedStagingPolicy() destination.ReplaceStagingPolicy {
+	return d.policy
+}
+
+func TestManagedStagingTableName_UsesDestinationPolicy(t *testing.T) {
+	dest := &fakeManagedStagingPolicyProvider{
+		fakeDestination: &fakeDestination{},
+		policy: destination.ReplaceStagingPolicy{
+			DefaultPlacement:    destination.ReplaceStagingTargetSchema,
+			DefaultTargetSchema: "app",
+		},
+	}
+
+	got := managedStagingTableName(dest, "users", "merge", "")
+	if !strings.HasPrefix(got, "app.users_merge_") {
+		t.Fatalf("managedStagingTableName() = %q, want prefix %q", got, "app.users_merge_")
+	}
+}
+
+func TestManagedStagingTableName_ExplicitDatasetOverridesDestinationPolicy(t *testing.T) {
+	dest := &fakeManagedStagingPolicyProvider{
+		fakeDestination: &fakeDestination{},
+		policy: destination.ReplaceStagingPolicy{
+			DefaultPlacement:    destination.ReplaceStagingTargetSchema,
+			DefaultTargetSchema: "app",
+		},
+	}
+
+	got := managedStagingTableName(dest, "analytics.users", "merge", "scratch")
+	if !strings.HasPrefix(got, "scratch.analytics__users_merge_") {
+		t.Fatalf("managedStagingTableName() = %q, want prefix %q", got, "scratch.analytics__users_merge_")
+	}
+}

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -167,7 +167,7 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.Destination, cfg *config.IngestConfig, st *streamTableState) error {
 	switch e.opts.Strategy {
 	case config.StrategyMerge:
-		st.stagingTable = GenerateStagingTableName(st.destTable, "stream", cfg.StagingDataset)
+		st.stagingTable = managedStagingTableName(dest, st.destTable, "stream", cfg.StagingDataset)
 		fmt.Printf("[STREAM] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), st.stagingTable)
 		return prepareMergeTables(ctx, dest, mergeTableParams{
 			DestTable:    st.destTable,

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -130,7 +130,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 	}
 
 	targetTable := job.Config.DestTable
-	stagingTable := GenerateStagingTableName(targetTable, "ti", job.Config.StagingDataset)
+	stagingTable := managedStagingTableName(job.Destination, targetTable, "ti", job.Config.StagingDataset)
 	fmt.Printf("[TRUNCATE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread" // registers the "azuresql" driver for Fabric
+	_ "github.com/sijms/go-ora/v2"
 	_ "github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -250,6 +251,31 @@ func destinationCases() []destCase {
 			replaceDedupCapable:    true,
 			scd2Capable:            true,
 			schemaEvolutionCapable: true,
+		},
+		{
+			name: "oracle",
+			setup: func(t *testing.T, ctx context.Context) (string, string, func()) {
+				if oracleDest.uri == "" {
+					t.Skip("shared oracle destination container not available")
+				}
+
+				table := fmt.Sprintf("CONFORMANCE_%s", uniqueSuffix())
+				cleanup := func() {
+					db, err := sql.Open("oracle", oracleSQLConnString(oracleDest.uri))
+					if err == nil {
+						_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s PURGE", quoteTableOracle(table)))
+						_ = db.Close()
+					}
+				}
+				return oracleDest.uri, table, cleanup
+			},
+			sqlBackend:             oracleBackend(),
+			mergeCapable:           true,
+			deleteInsertCapable:    true,
+			truncateInsertCapable:  true,
+			replaceDedupCapable:    true,
+			scd2Capable:            true,
+			schemaEvolutionCapable: false, // Oracle needs a data-preserving rewrite path for type changes like NUMBER -> CLOB.
 		},
 		{
 			name: "maxcompute",
@@ -1814,6 +1840,136 @@ func normalizeMySQLType(mysqlType string) string {
 	}
 }
 
+func oracleSQLConnString(rawURI string) string {
+	normalized := rawURI
+	if strings.HasPrefix(strings.ToLower(normalized), "oracle+cx_oracle://") {
+		normalized = "oracle://" + normalized[len("oracle+cx_oracle://"):]
+	}
+
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return rawURI
+	}
+
+	query := u.Query()
+	if serviceName := query.Get("service_name"); serviceName != "" {
+		query.Del("service_name")
+		u.Path = "/" + serviceName
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
+
+func oracleCurrentUser(db *sql.DB) (string, error) {
+	var user string
+	if err := db.QueryRow("SELECT USER FROM DUAL").Scan(&user); err != nil {
+		return "", err
+	}
+	return strings.ToUpper(user), nil
+}
+
+func quoteOracleIdentifier(identifier string) string {
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(identifier)), `"`, `""`))
+}
+
+func quoteTableOracle(table string) string {
+	schemaName, tableName := splitSchemaTable(table, "")
+	if schemaName != "" {
+		return quoteOracleIdentifier(schemaName) + "." + quoteOracleIdentifier(tableName)
+	}
+	return quoteOracleIdentifier(tableName)
+}
+
+func oracleBackend() *sqlBackend {
+	return &sqlBackend{
+		openDB: func(uri string) (*sql.DB, error) {
+			return sql.Open("oracle", oracleSQLConnString(uri))
+		},
+		schemaTypes: func(db *sql.DB, table string) (map[string]string, error) {
+			schemaName, tableName := splitSchemaTable(table, "")
+			if schemaName == "" {
+				currentUser, err := oracleCurrentUser(db)
+				if err != nil {
+					return nil, err
+				}
+				schemaName = currentUser
+			}
+
+			rows, err := db.Query(`
+				SELECT COLUMN_NAME, DATA_TYPE, DATA_PRECISION, DATA_SCALE
+				FROM ALL_TAB_COLUMNS
+				WHERE OWNER = :1 AND TABLE_NAME = :2
+				ORDER BY COLUMN_ID
+			`, strings.ToUpper(schemaName), strings.ToUpper(tableName))
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = rows.Close() }()
+
+			out := map[string]string{}
+			for rows.Next() {
+				var name, dataType string
+				var precision, scale sql.NullInt64
+				if err := rows.Scan(&name, &dataType, &precision, &scale); err != nil {
+					return nil, err
+				}
+				out[strings.ToLower(name)] = normalizeOracleType(dataType, precision, scale)
+			}
+			return out, rows.Err()
+		},
+		expectedTypes: map[string]string{
+			"id":     "number",
+			"name":   "clob",
+			"active": "number",
+			"score":  "binary_double",
+		},
+		countQuery: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteTableOracle(table))
+		},
+		nameByIDQuery: func(table string, id int) string {
+			return fmt.Sprintf("SELECT %s FROM %s WHERE %s=%d", quoteOracleIdentifier("name"), quoteTableOracle(table), quoteOracleIdentifier("id"), id)
+		},
+		ageByIDQuery: func(table string, id int) string {
+			return fmt.Sprintf("SELECT %s FROM %s WHERE %s=%d", quoteOracleIdentifier("age"), quoteTableOracle(table), quoteOracleIdentifier("id"), id)
+		},
+		scd2CountCurrent: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = 1", quoteTableOracle(table), quoteOracleIdentifier("_scd_is_current"))
+		},
+		scd2CountByID: func(table string, id int) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = %d", quoteTableOracle(table), quoteOracleIdentifier("id"), id)
+		},
+		scd2HistNoValidTo: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = 0 AND %s IS NULL", quoteTableOracle(table), quoteOracleIdentifier("_scd_is_current"), quoteOracleIdentifier("_scd_valid_to"))
+		},
+	}
+}
+
+func normalizeOracleType(dataType string, precision, scale sql.NullInt64) string {
+	oracleType := strings.ToUpper(strings.TrimSpace(dataType))
+	switch {
+	case oracleType == "NUMBER" || strings.HasPrefix(oracleType, "NUMBER("):
+		_ = precision
+		_ = scale
+		return "number"
+	case oracleType == "BINARY_FLOAT":
+		return "binary_float"
+	case oracleType == "BINARY_DOUBLE" || oracleType == "FLOAT":
+		return "binary_double"
+	case oracleType == "CLOB" || oracleType == "NCLOB" || oracleType == "LONG":
+		return "clob"
+	case strings.HasPrefix(oracleType, "VARCHAR2") || oracleType == "CHAR" || oracleType == "NCHAR" || oracleType == "NVARCHAR2":
+		return "varchar2"
+	case strings.HasPrefix(oracleType, "TIMESTAMP"):
+		return "timestamp"
+	case oracleType == "DATE":
+		return "date"
+	case oracleType == "BLOB" || oracleType == "RAW" || oracleType == "LONG RAW":
+		return "blob"
+	default:
+		return normalizeTypeName(oracleType)
+	}
+}
+
 func mssqlConnString(uri string) string {
 	// Convert mssql://user:pass@host:port/db to sqlserver://user:pass@host:port?database=db
 	uri = strings.TrimPrefix(uri, "mssql://")
@@ -2349,7 +2505,7 @@ func TestDestinations_SwapTableCleansUpOldTables(t *testing.T) {
 			continue
 		}
 		// Include backends that use SwapTable in replace strategy.
-		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "sqlite" || tc.name == "mssql" {
+		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "sqlite" || tc.name == "mssql" || tc.name == "oracle" {
 			swapCapableCases = append(swapCapableCases, tc)
 		}
 	}
@@ -2447,6 +2603,26 @@ func countOldTables(t *testing.T, backend *sqlBackend, uri, table string) int {
 			INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
 			WHERE s.name = '%s' AND t.name LIKE '%s_old_%%'
 		`, schemaName, tableName)
+	case strings.Contains(uri, "oracle"):
+		if schemaName == "" {
+			currentUser, err := oracleCurrentUser(db)
+			if err != nil {
+				t.Logf("Warning: failed to get Oracle current user: %v", err)
+				return 0
+			}
+			schemaName = currentUser
+		}
+		query = `
+			SELECT COUNT(*)
+			FROM ALL_TABLES
+			WHERE OWNER = :1 AND TABLE_NAME LIKE :2
+		`
+		err = db.QueryRow(query, strings.ToUpper(schemaName), strings.ToUpper(tableName)+"_OLD_%").Scan(&count)
+		if err != nil {
+			t.Logf("Warning: failed to count Oracle _old_ tables: %v", err)
+			return 0
+		}
+		return count
 	case strings.Contains(uri, "sqlite"):
 		// SQLite: query sqlite_master
 		query = fmt.Sprintf(`
@@ -2521,6 +2697,32 @@ func hasPrimaryKey(t *testing.T, backend *sqlBackend, uri, table, column string)
 			  AND tc.constraint_type = 'PRIMARY KEY'
 			  AND kcu.column_name = '%s'
 		`, schemaName, tableName, column)
+	case strings.Contains(uri, "oracle"):
+		if schemaName == "" {
+			currentUser, err := oracleCurrentUser(db)
+			if err != nil {
+				t.Logf("Warning: failed to get Oracle current user: %v", err)
+				return false
+			}
+			schemaName = currentUser
+		}
+		query = `
+			SELECT COUNT(*)
+			FROM ALL_CONSTRAINTS c
+			JOIN ALL_CONS_COLUMNS cc
+			  ON c.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+			 AND c.OWNER = cc.OWNER
+			WHERE c.CONSTRAINT_TYPE = 'P'
+			  AND c.OWNER = :1
+			  AND c.TABLE_NAME = :2
+			  AND cc.COLUMN_NAME = :3
+		`
+		var count int
+		if err := db.QueryRow(query, strings.ToUpper(schemaName), strings.ToUpper(tableName), strings.ToUpper(column)).Scan(&count); err != nil {
+			t.Logf("Warning: failed to query Oracle primary key: %v", err)
+			return false
+		}
+		return count > 0
 	case strings.Contains(uri, "sqlite"):
 		// SQLite: PRAGMA table_info reports pk > 0 for primary-key columns.
 		query = fmt.Sprintf(`SELECT COUNT(*) FROM pragma_table_info('%s') WHERE pk > 0 AND name = '%s'`, tableName, column)
@@ -2555,7 +2757,7 @@ func TestDestinations_Replace_PreservesConstraints(t *testing.T) {
 		if tc.sqlBackend == nil {
 			continue
 		}
-		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "sqlite" || tc.name == "mssql" {
+		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "sqlite" || tc.name == "mssql" || tc.name == "oracle" {
 			swapCapableCases = append(swapCapableCases, tc)
 		}
 	}
@@ -2624,7 +2826,7 @@ func TestDestinations_Replace_DedupesByPK(t *testing.T) {
 			}
 			require.NoError(t, pipeline.New(cfg).Run(ctx))
 
-			if tc.name == "duckdb" || tc.name == "sqlite" || tc.name == "postgres" || tc.name == "mssql" {
+			if tc.name == "duckdb" || tc.name == "sqlite" || tc.name == "postgres" || tc.name == "mssql" || tc.name == "oracle" {
 				assert.True(t, hasPrimaryKey(t, tc.sqlBackend, destURI, destTable, "id"),
 					"target should keep its PRIMARY KEY after a deduplicated replace")
 			}
@@ -2694,7 +2896,7 @@ func TestDestinations_Replace_DedupesByPK_NoIncrementalKey(t *testing.T) {
 			}
 			require.NoError(t, pipeline.New(cfg).Run(ctx))
 
-			if tc.name == "duckdb" || tc.name == "sqlite" || tc.name == "postgres" || tc.name == "mssql" {
+			if tc.name == "duckdb" || tc.name == "sqlite" || tc.name == "postgres" || tc.name == "mssql" || tc.name == "oracle" {
 				assert.True(t, hasPrimaryKey(t, tc.sqlBackend, destURI, destTable, "id"),
 					"target should keep its PRIMARY KEY after a deduplicated replace")
 			}

--- a/tests/integration/oracle_container_test.go
+++ b/tests/integration/oracle_container_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	oracleUser     = "ingestr"
+	oraclePassword = "TestPassword123"
+	oracleService  = "FREEPDB1"
+)
+
+func startOracleContainerRaw(ctx context.Context, name string) (testcontainers.Container, string, error) {
+	image := os.Getenv("GONG_TEST_ORACLE_IMAGE")
+	if image == "" {
+		image = "gvenzl/oracle-free:23-slim"
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        image,
+			ExposedPorts: []string{"1521/tcp"},
+			Env: map[string]string{
+				"ORACLE_PASSWORD":      oraclePassword,
+				"APP_USER":             oracleUser,
+				"APP_USER_PASSWORD":    oraclePassword,
+				"ENABLE_ARCHIVELOG":    "false",
+				"ENABLE_FORCE_LOGGING": "false",
+			},
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort("1521/tcp"),
+				wait.ForLog("DATABASE IS READY TO USE!"),
+			).WithDeadline(10 * time.Minute),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", err
+	}
+	port, err := container.MappedPort(ctx, "1521")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", err
+	}
+
+	uri := fmt.Sprintf("oracle://%s:%s@%s:%s/?service_name=%s",
+		oracleUser, oraclePassword, host, port.Port(), oracleService)
+
+	_ = name
+	return container, uri, nil
+}
+
+func startOracleContainerForMain(ctx context.Context, name string) (testcontainers.Container, string, error) {
+	container, uri, err := startOracleContainerRaw(ctx, name)
+	if err != nil {
+		return nil, "", err
+	}
+	return container, uri, nil
+}

--- a/tests/integration/testenv_postgres_test.go
+++ b/tests/integration/testenv_postgres_test.go
@@ -36,6 +36,11 @@ type mssqlEnv struct {
 	uri       string
 }
 
+type oracleEnv struct {
+	container testcontainers.Container
+	uri       string
+}
+
 type cratedbEnv struct {
 	container testcontainers.Container
 	uri       string
@@ -53,6 +58,7 @@ var (
 	chDest          clickhouseEnv
 	mysqlDest       mysqlEnv
 	mssqlDest       mssqlEnv
+	oracleDest      oracleEnv
 	cratedbDest     cratedbEnv
 	maxcomputeDest  maxcomputeEnv
 	minioShared     minioEnv
@@ -80,7 +86,7 @@ func TestMain(m *testing.M) {
 
 	var wg sync.WaitGroup
 
-	wg.Add(10)
+	wg.Add(11)
 	go func() {
 		defer wg.Done()
 		if c, uri, err := startPostgresContainerForMain(ctx, "shared-source"); err == nil {
@@ -109,6 +115,16 @@ func TestMain(m *testing.M) {
 		defer wg.Done()
 		if c, uri, err := startMSSQLContainerForMain(ctx, "shared-mssql"); err == nil {
 			mssqlDest = mssqlEnv{container: c, uri: uri}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if uri := os.Getenv("GONG_TEST_ORACLE_URI"); uri != "" {
+			oracleDest = oracleEnv{uri: uri}
+			return
+		}
+		if c, uri, err := startOracleContainerForMain(ctx, "shared-oracle"); err == nil {
+			oracleDest = oracleEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
@@ -153,7 +169,7 @@ func TestMain(m *testing.M) {
 
 	containers := []testcontainers.Container{
 		pgSource.container, pgDest.container, chDest.container,
-		mysqlDest.container, mssqlDest.container, cratedbDest.container,
+		mysqlDest.container, mssqlDest.container, oracleDest.container, cratedbDest.container,
 		maxcomputeDest.container, minioShared.container, dynamoDBDest.container,
 		cassandraShared.container,
 	}


### PR DESCRIPTION
Adds Oracle as a destination with thin driver support, write strategies, schema mapping/evolution behavior, and conformance coverage. Includes review fixes for Oracle LOB comparisons, CDC resume state, logical primary key handling, and delete+insert incremental key casing. Validated with make format, make lint, and make test.