### PR TITLE
Update license audit lock for mongo-driver v1.17.7

### DIFF
--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -1287,7 +1287,7 @@ dependencies:
         - Apache-2.0
       status: allowed
     - module: go.mongodb.org/mongo-driver
-      version: v1.17.6
+      version: v1.17.7
       licenses:
         - Apache-2.0
       status: allowed


### PR DESCRIPTION
## What

The `licenses-audit` CI check is failing because the mongo-driver bump (#843, commit bdacfcf5) updated the module to `v1.17.7` in `go.mod`, but the license audit lock still pinned `v1.17.6`:

```
licenseaudit: license audit failed:
  - go.mongodb.org/mongo-driver version changed: lock has v1.17.6, scan has v1.17.7
```

This bumps the locked version to `v1.17.7`. The license (`Apache-2.0`) and `status: allowed` are unchanged — only the version differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)