### PR TITLE
feat(square): add Square as a source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 
+# Playwright MCP page/console captures can include secrets from credential UIs.
+.playwright-mcp/
+
 # Created by https://www.toptal.com/developers/gitignore/api/goland,go,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=goland,go,macos
 

--- a/README.md
+++ b/README.md
@@ -649,6 +649,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Square</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Stripe</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -230,6 +230,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Smartsheet", link: "/supported-sources/smartsheets.md" },
               { text: "Snapchat Ads", link: "/supported-sources/snapchat-ads.md" },
               { text: "Solidgate", link: "/supported-sources/solidgate.md" },
+              { text: "Square", link: "/supported-sources/square.md" },
               { text: "Stripe", link: "/supported-sources/stripe.md" },
               { text: "SurveyMonkey", link: "/supported-sources/surveymonkey.md" },
               { text: "TikTok Ads", link: "/supported-sources/tiktok-ads.md" },

--- a/docs/supported-sources/square.md
+++ b/docs/supported-sources/square.md
@@ -1,0 +1,83 @@
+# Square
+
+[Square](https://squareup.com/) is a payments and commerce platform for businesses.
+
+ingestr supports Square as a source.
+
+## URI format
+
+The URI format for Square is as follows:
+
+```plaintext
+square://?access_token=<access-token>
+```
+
+URI parameters:
+
+- `access_token` (required): A Square access token for your application or seller account.
+- `environment`: Either `production` (default) or `sandbox`. Use `sandbox` to read from Square's developer sandbox.
+
+## Setting up a Square Integration
+
+To get an access token:
+
+1. Sign in to the [Square Developer Dashboard](https://developer.squareup.com/apps).
+2. Open an existing application or create a new one.
+3. Copy the **Access token** from the **Credentials** page. Use the **Sandbox** token together with `environment=sandbox` for testing, or the **Production** token for live data.
+
+Once you have your access token, here's a sample command that will copy data from Square into a DuckDB database:
+
+```sh
+ingestr ingest \
+  --source-uri 'square://?access_token=EAAAxxxxxx' \
+  --source-table 'payments' \
+  --dest-uri duckdb:///square.duckdb \
+  --dest-table 'square.payments'
+```
+
+The result of this command will be a table in the `square.duckdb` database.
+
+## Tables
+
+Square source allows ingesting the following sources into separate tables:
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| ----- | -- | ------- | ------------ | ------- |
+| `payments` | `id` | `updated_at` | merge | Payments taken by the account. |
+| `refunds` | `id` | `updated_at` | merge | Refunds processed against payments. |
+| `orders` | `id` | `updated_at` | merge | Orders across all of the account's locations. |
+| `customers` | `id` | `updated_at` | merge | Customer profiles. |
+| `catalog_objects` | `id` | `updated_at` | merge | All catalog objects (items, variations, categories, taxes, discounts, modifier lists, images, and more). |
+| `locations` | `id` | - | replace | The account's locations. |
+| `team_members` | `id` | `updated_at` | merge | Team members (staff). Soft-deletes appear as `status="INACTIVE"`. |
+| `team_member_wages` | `id` | - | replace | Hourly wage settings per team member. |
+| `shifts` | `id` | - | replace | Worked shifts (Labor API). |
+| `inventory` | `catalog_object_id`, `location_id`, `state` | `calculated_at` | merge | Inventory counts per catalog object, location, and state. |
+| `bank_accounts` | `id` | - | replace | Linked bank accounts. |
+| `cash_drawers` | `id` | - | replace | Cash drawer shifts across all locations. |
+| `loyalty` | `id` | - | replace | Loyalty accounts. |
+
+Use one of these as the `--source-table` parameter in the `ingestr ingest` command.
+
+## Examples
+
+Ingest orders updated within a given interval:
+
+```sh
+ingestr ingest \
+  --source-uri 'square://?access_token=EAAAxxxxxx' \
+  --source-table 'orders' \
+  --dest-uri duckdb:///square.duckdb \
+  --dest-table 'square.orders' \
+  --interval-start 2024-01-01
+```
+
+Read from the Square sandbox:
+
+```sh
+ingestr ingest \
+  --source-uri 'square://?access_token=EAAAxxxxxx&environment=sandbox' \
+  --source-table 'catalog_objects' \
+  --dest-uri duckdb:///square.duckdb \
+  --dest-table 'square.catalog_objects'
+```

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -355,6 +355,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("solidgate", "Solidgate", []string{"solidgate"}, true, false),
 		genericURIConnector("spanner", "Spanner", []string{"spanner"}, true, false),
 		genericURIConnector("sqs", "SQS", []string{"sqs"}, true, false),
+		genericURIConnector("square", "Square", []string{"square"}, true, false),
 		genericURIConnector("stripe", "Stripe", []string{"stripe"}, true, false),
 		genericURIConnector("surveymonkey", "SurveyMonkey", []string{"surveymonkey"}, true, false),
 		genericURIConnector("synapse", "Azure Synapse", []string{"synapse"}, false, true),

--- a/pkg/source/square/register.go
+++ b/pkg/source/square/register.go
@@ -1,0 +1,10 @@
+package square
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"square"},
+		func() interface{} { return NewSquareSource() },
+	)
+}

--- a/pkg/source/square/square.go
+++ b/pkg/source/square/square.go
@@ -1,0 +1,658 @@
+package square
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	productionBaseURL = "https://connect.squareup.com"
+	sandboxBaseURL    = "https://connect.squareupsandbox.com"
+
+	// Square is date-versioned and requires Square-Version on every request.
+	defaultAPIVersion = "2025-01-23"
+
+	maxPageSize = 100
+
+	// 10 rps with a small burst stays under Square's per-application QPS cap (429s).
+	rateLimit      = 10.0
+	rateLimitBurst = 5
+
+	// Bounded concurrency for per-location fan-outs (e.g. cash_drawers). The
+	// shared HTTP rate limiter handles backpressure, so this just caps in-flight.
+	locationWorkers = 5
+)
+
+type tableReadFunc func(s *SquareSource, ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error
+
+type tableConfig struct {
+	primaryKeys    []string
+	incrementalKey string
+	strategy       config.IncrementalStrategy
+	read           tableReadFunc
+}
+
+func getList(path, key string, baseQuery map[string]string) tableReadFunc {
+	return func(s *SquareSource, ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+		return s.readGetList(ctx, path, key, baseQuery, opts, results)
+	}
+}
+
+func search(path, key string, baseBody map[string]interface{}) tableReadFunc {
+	return func(s *SquareSource, ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+		return s.readSearch(ctx, path, key, baseBody, opts, results)
+	}
+}
+
+func limitQuery() map[string]string {
+	return map[string]string{"limit": strconv.Itoa(maxPageSize)}
+}
+
+var supportedTables = map[string]tableConfig{
+	"payments": {
+		primaryKeys:    []string{"id"},
+		incrementalKey: "updated_at",
+		strategy:       config.StrategyMerge,
+		read: func(s *SquareSource, ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+			return s.readUpdatedRangeList(ctx, "/v2/payments", "payments", opts, results)
+		},
+	},
+	"refunds": {
+		primaryKeys:    []string{"id"},
+		incrementalKey: "updated_at",
+		strategy:       config.StrategyMerge,
+		read: func(s *SquareSource, ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+			return s.readUpdatedRangeList(ctx, "/v2/refunds", "refunds", opts, results)
+		},
+	},
+	"orders": {
+		primaryKeys:    []string{"id"},
+		incrementalKey: "updated_at",
+		strategy:       config.StrategyMerge,
+		read:           (*SquareSource).readOrders,
+	},
+	"customers": {
+		primaryKeys:    []string{"id"},
+		incrementalKey: "updated_at",
+		strategy:       config.StrategyMerge,
+		read:           (*SquareSource).readCustomers,
+	},
+	"catalog_objects": {
+		primaryKeys:    []string{"id"},
+		incrementalKey: "updated_at",
+		strategy:       config.StrategyMerge,
+		read:           (*SquareSource).readCatalog,
+	},
+	"locations": {
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		read:        getList("/v2/locations", "locations", nil),
+	},
+	"team_members": {
+		primaryKeys:    []string{"id"},
+		incrementalKey: "updated_at",
+		strategy:       config.StrategyMerge,
+		read:           (*SquareSource).readTeamMembers,
+	},
+	"team_member_wages": {
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		read:        getList("/v2/labor/team-member-wages", "team_member_wages", limitQuery()),
+	},
+	"shifts": {
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		read: search("/v2/labor/shifts/search", "shifts", map[string]interface{}{
+			"limit": maxPageSize,
+			"query": map[string]interface{}{
+				"sort": map[string]interface{}{"field": "UPDATED_AT", "order": "ASC"},
+			},
+		}),
+	},
+	"inventory": {
+		primaryKeys:    []string{"catalog_object_id", "location_id", "state"},
+		incrementalKey: "calculated_at",
+		strategy:       config.StrategyMerge,
+		read:           (*SquareSource).readInventory,
+	},
+	"bank_accounts": {
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		read:        getList("/v2/bank-accounts", "bank_accounts", limitQuery()),
+	},
+	"cash_drawers": {
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		read:        (*SquareSource).readCashDrawerShifts,
+	},
+	"loyalty": {
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		read:        search("/v2/loyalty/accounts/search", "loyalty_accounts", map[string]interface{}{"limit": maxPageSize}),
+	},
+}
+
+type squareCredentials struct {
+	accessToken string
+	baseURL     string
+}
+
+type SquareSource struct {
+	client *httpclient.Client
+}
+
+func NewSquareSource() *SquareSource {
+	return &SquareSource{}
+}
+
+func (s *SquareSource) Schemes() []string {
+	return []string{"square"}
+}
+
+func (s *SquareSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *SquareSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(creds.baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(httpclient.NewBearerAuth(creds.accessToken)),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithHeader("Accept", "application/json"),
+		httpclient.WithHeader("Square-Version", defaultAPIVersion),
+	)
+
+	config.Debug("[SQUARE] connected (%s, version %s)", creds.baseURL, defaultAPIVersion)
+	return nil
+}
+
+func (s *SquareSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseURI(uri string) (squareCredentials, error) {
+	if !strings.HasPrefix(uri, "square://") {
+		return squareCredentials{}, fmt.Errorf("invalid square URI: must start with square://")
+	}
+
+	rest := strings.TrimPrefix(uri, "square://")
+	rest = strings.TrimPrefix(rest, "?")
+
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return squareCredentials{}, fmt.Errorf("failed to parse square URI query: %w", err)
+	}
+
+	creds := squareCredentials{
+		accessToken: values.Get("access_token"),
+		baseURL:     productionBaseURL,
+	}
+
+	if creds.accessToken == "" {
+		return squareCredentials{}, fmt.Errorf("access_token is required in square URI")
+	}
+
+	switch env := strings.ToLower(values.Get("environment")); env {
+	case "", "production":
+		creds.baseURL = productionBaseURL
+	case "sandbox":
+		creds.baseURL = sandboxBaseURL
+	default:
+		return squareCredentials{}, fmt.Errorf("invalid environment %q in square URI (supported: production, sandbox)", env)
+	}
+
+	return creds, nil
+}
+
+func (s *SquareSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName := req.Name
+
+	if !isValidTable(tableName) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, supportedTableNames())
+	}
+	cfg := supportedTables[tableName]
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    cfg.primaryKeys,
+		TableIncrementalKey: cfg.incrementalKey,
+		TableStrategy:       cfg.strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("square source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, opts)
+		},
+	}, nil
+}
+
+func isValidTable(table string) bool {
+	_, ok := supportedTables[table]
+	return ok
+}
+
+func supportedTableNames() string {
+	names := make([]string, 0, len(supportedTables))
+	for name := range supportedTables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func (s *SquareSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	cfg, ok := supportedTables[table]
+	if !ok {
+		go func() {
+			defer close(results)
+			results <- source.RecordBatchResult{Err: fmt.Errorf("unsupported table: %s", table)}
+		}()
+		return results, nil
+	}
+
+	go func() {
+		defer close(results)
+		if err := cfg.read(s, ctx, opts, results); err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+// cursor is "" on the first call and "" again once the API stops returning one.
+type fetchPageFunc func(cursor string) (items []map[string]interface{}, nextCursor string, err error)
+
+func (s *SquareSource) paginate(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, table string, fetch fetchPageFunc) error {
+	cursor := ""
+	totalSent := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		items, nextCursor, err := fetch(cursor)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", table, err)
+		}
+
+		if len(items) > 0 {
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", table, err)
+			}
+			results <- source.RecordBatchResult{Batch: record}
+			totalSent += len(items)
+			config.Debug("[SQUARE] %s: sent %d records (total: %d)", table, len(items), totalSent)
+		}
+
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	if totalSent == 0 {
+		config.Debug("[SQUARE] no records found for %s", table)
+	}
+	return nil
+}
+
+// baseQuery is sent on the first request only; Square requires subsequent pages
+// to send the cursor alone, with no other params.
+func (s *SquareSource) readGetList(ctx context.Context, path, key string, baseQuery map[string]string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	return s.paginate(ctx, opts, results, key, func(cursor string) ([]map[string]interface{}, string, error) {
+		req := s.client.R(ctx)
+		if cursor == "" {
+			if len(baseQuery) > 0 {
+				req = req.SetQueryParams(baseQuery)
+			}
+		} else {
+			req = req.SetQueryParam("cursor", cursor)
+		}
+
+		resp, err := req.Get(path)
+		if err != nil {
+			return nil, "", err
+		}
+		if !resp.IsSuccess() {
+			return nil, "", fmt.Errorf("square API %s returned status %d: %s", path, resp.StatusCode(), resp.String())
+		}
+		return decodeListResponse(resp.Body(), key)
+	})
+}
+
+// readSearchFiltered is readSearch with a per-page client-side filter on dateField,
+// used where Square's endpoint doesn't expose a matching server-side filter.
+func (s *SquareSource) readSearchFiltered(ctx context.Context, path, key string, baseBody map[string]interface{}, dateField string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if dateField == "" || (opts.IntervalStart == nil && opts.IntervalEnd == nil) {
+		return s.readSearch(ctx, path, key, baseBody, opts, results)
+	}
+	return s.paginate(ctx, opts, results, key, func(cursor string) ([]map[string]interface{}, string, error) {
+		body := make(map[string]interface{}, len(baseBody)+1)
+		for k, v := range baseBody {
+			body[k] = v
+		}
+		if cursor != "" {
+			body["cursor"] = cursor
+		}
+		resp, err := s.client.R(ctx).SetBody(body).Post(path)
+		if err != nil {
+			return nil, "", err
+		}
+		if !resp.IsSuccess() {
+			return nil, "", fmt.Errorf("square API %s returned status %d: %s", path, resp.StatusCode(), resp.String())
+		}
+		items, next, err := decodeListResponse(resp.Body(), key)
+		if err != nil {
+			return nil, "", err
+		}
+		return filterItemsByInterval(items, dateField, opts.IntervalStart, opts.IntervalEnd), next, nil
+	})
+}
+
+// Square's search endpoints require baseBody to be resent on every page.
+func (s *SquareSource) readSearch(ctx context.Context, path, key string, baseBody map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	return s.paginate(ctx, opts, results, key, func(cursor string) ([]map[string]interface{}, string, error) {
+		body := make(map[string]interface{}, len(baseBody)+1)
+		for k, v := range baseBody {
+			body[k] = v
+		}
+		if cursor != "" {
+			body["cursor"] = cursor
+		}
+
+		resp, err := s.client.R(ctx).SetBody(body).Post(path)
+		if err != nil {
+			return nil, "", err
+		}
+		if !resp.IsSuccess() {
+			return nil, "", fmt.Errorf("square API %s returned status %d: %s", path, resp.StatusCode(), resp.String())
+		}
+		return decodeListResponse(resp.Body(), key)
+	})
+}
+
+// sort_field=UPDATED_AT pairs with updated_at_{begin,end}_time so a status flip
+// gets picked up by a later run even when the row was created outside the interval.
+func (s *SquareSource) readUpdatedRangeList(ctx context.Context, path, key string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	baseQuery := map[string]string{
+		"limit":      strconv.Itoa(maxPageSize),
+		"sort_field": "UPDATED_AT",
+		"sort_order": "ASC",
+	}
+	if opts.IntervalStart != nil {
+		baseQuery["updated_at_begin_time"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+	}
+	if opts.IntervalEnd != nil {
+		baseQuery["updated_at_end_time"] = opts.IntervalEnd.UTC().Format(time.RFC3339)
+	}
+	return s.readGetList(ctx, path, key, baseQuery, opts, results)
+}
+
+// SearchOrders requires location_ids; passing the full set lets Square scope
+// to every location server-side in one cursor stream.
+func (s *SquareSource) readOrders(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	locationIDs, err := s.listLocationIDs(ctx)
+	if err != nil {
+		return err
+	}
+	if len(locationIDs) == 0 {
+		config.Debug("[SQUARE] no locations found; skipping orders")
+		return nil
+	}
+
+	query := map[string]interface{}{
+		"sort": map[string]interface{}{
+			"sort_field": "UPDATED_AT",
+			"sort_order": "ASC",
+		},
+	}
+	if opts.IntervalStart != nil || opts.IntervalEnd != nil {
+		updatedAt := map[string]interface{}{}
+		if opts.IntervalStart != nil {
+			updatedAt["start_at"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+		}
+		if opts.IntervalEnd != nil {
+			updatedAt["end_at"] = opts.IntervalEnd.UTC().Format(time.RFC3339)
+		}
+		query["filter"] = map[string]interface{}{
+			"date_time_filter": map[string]interface{}{
+				"updated_at": updatedAt,
+			},
+		}
+	}
+
+	baseBody := map[string]interface{}{
+		"location_ids": locationIDs,
+		"limit":        maxPageSize,
+		"query":        query,
+	}
+	return s.readSearch(ctx, "/v2/orders/search", "orders", baseBody, opts, results)
+}
+
+// Square caps customer sort to CREATED_AT, so paging stays creation-ordered
+// while filtering by updated_at.
+func (s *SquareSource) readCustomers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	query := map[string]interface{}{
+		"sort": map[string]interface{}{"field": "CREATED_AT", "order": "ASC"},
+	}
+	if opts.IntervalStart != nil || opts.IntervalEnd != nil {
+		updatedAt := map[string]interface{}{}
+		if opts.IntervalStart != nil {
+			updatedAt["start_at"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+		}
+		if opts.IntervalEnd != nil {
+			updatedAt["end_at"] = opts.IntervalEnd.UTC().Format(time.RFC3339)
+		}
+		query["filter"] = map[string]interface{}{"updated_at": updatedAt}
+	}
+
+	baseBody := map[string]interface{}{
+		"limit": maxPageSize,
+		"query": query,
+	}
+	return s.readSearch(ctx, "/v2/customers/search", "customers", baseBody, opts, results)
+}
+
+// team-members/search has no server-side updated_at filter, so we filter
+// client-side. Soft-deletes appear as status="INACTIVE" with a bumped updated_at.
+func (s *SquareSource) readTeamMembers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	baseBody := map[string]interface{}{"limit": maxPageSize}
+	return s.readSearchFiltered(ctx, "/v2/team-members/search", "team_members", baseBody, "updated_at", opts, results)
+}
+
+// batch-retrieve has updated_after (server-side) but no upper bound, so end
+// intervals are applied client-side on calculated_at.
+func (s *SquareSource) readInventory(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	baseBody := map[string]interface{}{}
+	if opts.IntervalStart != nil {
+		baseBody["updated_after"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+	}
+	endField := ""
+	if opts.IntervalEnd != nil {
+		endField = "calculated_at"
+	}
+	return s.readSearchFiltered(ctx, "/v2/inventory/counts/batch-retrieve", "counts", baseBody, endField, opts, results)
+}
+
+// include_deleted_objects surfaces deletions as is_deleted rows so merge applies
+// them. catalog/search has no end bound, so end is applied client-side on updated_at.
+func (s *SquareSource) readCatalog(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	baseBody := map[string]interface{}{
+		"limit": maxPageSize,
+	}
+	if opts.IntervalStart != nil {
+		baseBody["begin_time"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+		baseBody["include_deleted_objects"] = true
+	}
+	endField := ""
+	if opts.IntervalEnd != nil {
+		endField = "updated_at"
+	}
+	return s.readSearchFiltered(ctx, "/v2/catalog/search", "objects", baseBody, endField, opts, results)
+}
+
+// The endpoint requires a location_id, so iterate every location. Locations are
+// independent and fetched concurrently; the shared rate limiter throttles them.
+func (s *SquareSource) readCashDrawerShifts(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	locationIDs, err := s.listLocationIDs(ctx)
+	if err != nil {
+		return err
+	}
+	if len(locationIDs) == 0 {
+		config.Debug("[SQUARE] no locations found; skipping cash_drawers")
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := make(chan struct{}, locationWorkers)
+	errCh := make(chan error, len(locationIDs))
+	var wg sync.WaitGroup
+	for _, loc := range locationIDs {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(loc string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			query := map[string]string{"location_id": loc, "limit": strconv.Itoa(maxPageSize)}
+			if err := s.readGetList(ctx, "/v2/cash-drawers/shifts", "cash_drawer_shifts", query, opts, results); err != nil {
+				errCh <- err
+				cancel()
+			}
+		}(loc)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SquareSource) listLocationIDs(ctx context.Context) ([]string, error) {
+	resp, err := s.client.R(ctx).Get("/v2/locations")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch locations: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("square API /v2/locations returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+
+	var payload struct {
+		Locations []struct {
+			ID string `json:"id"`
+		} `json:"locations"`
+	}
+	if err := json.Unmarshal(resp.Body(), &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse locations response: %w", err)
+	}
+
+	ids := make([]string, 0, len(payload.Locations))
+	for _, loc := range payload.Locations {
+		if loc.ID != "" {
+			ids = append(ids, loc.ID)
+		}
+	}
+	return ids, nil
+}
+
+// Rows with a missing or unparseable timestamp are kept rather than dropped.
+func filterItemsByInterval(items []map[string]interface{}, field string, start, end *time.Time) []map[string]interface{} {
+	if field == "" || (start == nil && end == nil) {
+		return items
+	}
+	filtered := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		ts, ok := parseTimestamp(item[field])
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && ts.Before(start.UTC()) {
+			continue
+		}
+		if end != nil && !ts.Before(end.UTC()) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+// Square emits both RFC3339 and RFC3339Nano (with/without fractional seconds).
+func parseTimestamp(raw interface{}) (time.Time, bool) {
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func decodeListResponse(body []byte, key string) ([]map[string]interface{}, string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var raw map[string]interface{}
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, "", err
+	}
+
+	cursor := ""
+	if c, ok := raw["cursor"].(string); ok {
+		cursor = c
+	}
+
+	arr, ok := raw[key].([]interface{})
+	if !ok {
+		return nil, cursor, nil
+	}
+
+	items := make([]map[string]interface{}, 0, len(arr))
+	for _, v := range arr {
+		if m, ok := v.(map[string]interface{}); ok {
+			items = append(items, m)
+		}
+	}
+
+	return items, cursor, nil
+}

--- a/pkg/source/square/square.go
+++ b/pkg/source/square/square.go
@@ -135,7 +135,7 @@ var supportedTables = map[string]tableConfig{
 		read:        getList("/v2/bank-accounts", "bank_accounts", limitQuery()),
 	},
 	"cash_drawers": {
-		primaryKeys: []string{"id"},
+		primaryKeys: []string{"id", "location_id"},
 		strategy:    config.StrategyReplace,
 		read:        (*SquareSource).readCashDrawerShifts,
 	},
@@ -506,15 +506,16 @@ func (s *SquareSource) readInventory(ctx context.Context, opts source.ReadOption
 	return s.readSearchFiltered(ctx, "/v2/inventory/counts/batch-retrieve", "counts", baseBody, endField, opts, results)
 }
 
-// include_deleted_objects surfaces deletions as is_deleted rows so merge applies
-// them. catalog/search has no end bound, so end is applied client-side on updated_at.
+// include_deleted_objects is always set so tombstones (is_deleted=true) land on
+// every run; merge then propagates deletes even on a full refresh or end-only
+// bounded run. catalog/search has no end bound, so end is applied client-side.
 func (s *SquareSource) readCatalog(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	baseBody := map[string]interface{}{
-		"limit": maxPageSize,
+		"limit":                   maxPageSize,
+		"include_deleted_objects": true,
 	}
 	if opts.IntervalStart != nil {
 		baseBody["begin_time"] = opts.IntervalStart.UTC().Format(time.RFC3339)
-		baseBody["include_deleted_objects"] = true
 	}
 	endField := ""
 	if opts.IntervalEnd != nil {

--- a/pkg/source/square/square.go
+++ b/pkg/source/square/square.go
@@ -548,8 +548,7 @@ func (s *SquareSource) readCashDrawerShifts(ctx context.Context, opts source.Rea
 		go func(loc string) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			query := map[string]string{"location_id": loc, "limit": strconv.Itoa(maxPageSize)}
-			if err := s.readGetList(ctx, "/v2/cash-drawers/shifts", "cash_drawer_shifts", query, opts, results); err != nil {
+			if err := s.readCashDrawerShiftsForLocation(ctx, loc, opts, results); err != nil {
 				errCh <- err
 				cancel()
 			}
@@ -563,6 +562,43 @@ func (s *SquareSource) readCashDrawerShifts(ctx context.Context, opts source.Rea
 		}
 	}
 	return nil
+}
+
+// Square's CashDrawerShiftSummary doesn't include location_id in the response
+// body, so inject it per row to keep the composite PK [id, location_id] populated.
+func (s *SquareSource) readCashDrawerShiftsForLocation(ctx context.Context, loc string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	query := map[string]string{"location_id": loc, "limit": strconv.Itoa(maxPageSize)}
+	return s.paginate(ctx, opts, results, "cash_drawer_shifts", func(cursor string) ([]map[string]interface{}, string, error) {
+		req := s.client.R(ctx)
+		if cursor == "" {
+			req = req.SetQueryParams(query)
+		} else {
+			req = req.SetQueryParam("cursor", cursor)
+		}
+		resp, err := req.Get("/v2/cash-drawers/shifts")
+		if err != nil {
+			return nil, "", err
+		}
+		if !resp.IsSuccess() {
+			return nil, "", fmt.Errorf("square API /v2/cash-drawers/shifts returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+		items, next, err := decodeListResponse(resp.Body(), "cash_drawer_shifts")
+		if err != nil {
+			return nil, "", err
+		}
+		injectFieldIfMissing(items, "location_id", loc)
+		return items, next, nil
+	})
+}
+
+// Sets field to value on rows that don't already have it; existing values are
+// preserved so we never override what Square actually sent.
+func injectFieldIfMissing(items []map[string]interface{}, field string, value interface{}) {
+	for _, item := range items {
+		if _, exists := item[field]; !exists {
+			item[field] = value
+		}
+	}
 }
 
 func (s *SquareSource) listLocationIDs(ctx context.Context) ([]string, error) {

--- a/pkg/source/square/square_test.go
+++ b/pkg/source/square/square_test.go
@@ -144,6 +144,25 @@ func TestFilterItemsByInterval(t *testing.T) {
 	}
 }
 
+func TestInjectFieldIfMissing(t *testing.T) {
+	items := []map[string]interface{}{
+		{"id": "a"},                            // missing → injected
+		{"id": "b", "location_id": "existing"}, // present → preserved
+		{"id": "c", "location_id": ""},         // empty string IS present → preserved
+	}
+	injectFieldIfMissing(items, "location_id", "LOC1")
+
+	if got := items[0]["location_id"]; got != "LOC1" {
+		t.Errorf("row 0 location_id = %v, want LOC1", got)
+	}
+	if got := items[1]["location_id"]; got != "existing" {
+		t.Errorf("row 1 location_id = %v, want existing (must not override)", got)
+	}
+	if got := items[2]["location_id"]; got != "" {
+		t.Errorf("row 2 location_id = %v, want \"\" (empty string is present)", got)
+	}
+}
+
 func TestParseTimestamp(t *testing.T) {
 	cases := []struct {
 		in string

--- a/pkg/source/square/square_test.go
+++ b/pkg/source/square/square_test.go
@@ -1,0 +1,227 @@
+package square
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+		want    squareCredentials
+	}{
+		{
+			name: "access token defaults to production",
+			uri:  "square://?access_token=EAAA123",
+			want: squareCredentials{accessToken: "EAAA123", baseURL: productionBaseURL},
+		},
+		{
+			name: "sandbox environment",
+			uri:  "square://?access_token=EAAA123&environment=sandbox",
+			want: squareCredentials{accessToken: "EAAA123", baseURL: sandboxBaseURL},
+		},
+		{
+			name: "explicit production environment",
+			uri:  "square://?access_token=EAAA123&environment=production",
+			want: squareCredentials{accessToken: "EAAA123", baseURL: productionBaseURL},
+		},
+		{
+			name:    "missing access token",
+			uri:     "square://?environment=sandbox",
+			wantErr: true,
+		},
+		{
+			name:    "invalid environment",
+			uri:     "square://?access_token=EAAA123&environment=staging",
+			wantErr: true,
+		},
+		{
+			name:    "wrong scheme",
+			uri:     "stripe://?access_token=EAAA123",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportedTables(t *testing.T) {
+	cases := map[string]struct {
+		incrementalKey string
+		strategy       config.IncrementalStrategy
+	}{
+		"payments":          {"updated_at", config.StrategyMerge},
+		"refunds":           {"updated_at", config.StrategyMerge},
+		"orders":            {"updated_at", config.StrategyMerge},
+		"customers":         {"updated_at", config.StrategyMerge},
+		"catalog_objects":   {"updated_at", config.StrategyMerge},
+		"locations":         {"", config.StrategyReplace},
+		"team_members":      {"updated_at", config.StrategyMerge},
+		"team_member_wages": {"", config.StrategyReplace},
+		"shifts":            {"", config.StrategyReplace},
+		"inventory":         {"calculated_at", config.StrategyMerge},
+		"bank_accounts":     {"", config.StrategyReplace},
+		"cash_drawers":      {"", config.StrategyReplace},
+		"loyalty":           {"", config.StrategyReplace},
+	}
+
+	for name, want := range cases {
+		cfg, ok := supportedTables[name]
+		if !ok {
+			t.Fatalf("expected table %q to be supported", name)
+		}
+		if cfg.incrementalKey != want.incrementalKey {
+			t.Errorf("%s incremental key = %q, want %q", name, cfg.incrementalKey, want.incrementalKey)
+		}
+		if cfg.strategy != want.strategy {
+			t.Errorf("%s strategy = %q, want %q", name, cfg.strategy, want.strategy)
+		}
+	}
+}
+
+// TestAllTablesHaveReader guards against a table being registered without a
+// reader, which would nil-panic when GetTable's ReadFn runs.
+func TestAllTablesHaveReader(t *testing.T) {
+	for name, cfg := range supportedTables {
+		if cfg.read == nil {
+			t.Errorf("table %q has no reader", name)
+		}
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	for name := range supportedTables {
+		if !isValidTable(name) {
+			t.Errorf("expected %q to be a valid table", name)
+		}
+	}
+	for _, name := range []string{"", "Payments", "items", "unknown", "payment"} {
+		if isValidTable(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}
+
+func TestFilterItemsByInterval(t *testing.T) {
+	mk := func(ts string) map[string]interface{} { return map[string]interface{}{"updated_at": ts, "id": ts} }
+	items := []map[string]interface{}{
+		mk("2026-06-29T07:34:05.815Z"),
+		mk("2026-06-29T07:34:15.204Z"),
+		mk("2026-06-29T08:00:00Z"),
+		{"updated_at": "", "id": "no-ts"},    // unparseable → kept
+		{"id": "missing-ts"},                 // missing → kept
+		{"updated_at": "garbage", "id": "g"}, // garbage → kept
+	}
+	start := time.Date(2026, 6, 29, 7, 34, 10, 0, time.UTC)
+	end := time.Date(2026, 6, 29, 7, 34, 30, 0, time.UTC)
+	got := filterItemsByInterval(items, "updated_at", &start, &end)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 items, got %d: %v", len(got), got)
+	}
+	if got[0]["id"] != "2026-06-29T07:34:15.204Z" {
+		t.Errorf("first kept item = %v, want the 07:34:15 record", got[0]["id"])
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"2026-06-29T07:34:15.204Z", true},
+		{"2026-06-29T07:34:15Z", true},
+		{"", false},
+		{"not a date", false},
+	}
+	for _, c := range cases {
+		_, ok := parseTimestamp(c.in)
+		if ok != c.ok {
+			t.Errorf("parseTimestamp(%q) ok=%v, want %v", c.in, ok, c.ok)
+		}
+	}
+	if _, ok := parseTimestamp(42); ok {
+		t.Error("parseTimestamp(42) should be false (non-string)")
+	}
+}
+
+// TestJsonUseNumber verifies large integer IDs survive decoding without float64
+// precision loss (Square IDs and amounts can exceed 2^53).
+func TestJsonUseNumber(t *testing.T) {
+	body := []byte(`{"payments":[{"id":"p1","amount":92233720368547758}],"cursor":""}`)
+	items, _, err := decodeListResponse(body, "payments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	num, ok := items[0]["amount"].(json.Number)
+	if !ok {
+		t.Fatalf("amount = %T, want json.Number", items[0]["amount"])
+	}
+	if num.String() != "92233720368547758" {
+		t.Errorf("amount = %s, want 92233720368547758", num.String())
+	}
+
+	if _, _, err := decodeListResponse([]byte(`{not json`), "payments"); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestDecodeListResponse(t *testing.T) {
+	body := []byte(`{
+		"payments": [
+			{"id": "p1", "amount_money": {"amount": 100, "currency": "USD"}},
+			{"id": "p2", "amount_money": {"amount": 250, "currency": "USD"}}
+		],
+		"cursor": "NEXT"
+	}`)
+
+	items, cursor, err := decodeListResponse(body, "payments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor != "NEXT" {
+		t.Errorf("cursor = %q, want NEXT", cursor)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0]["id"] != "p1" {
+		t.Errorf("first item id = %v, want p1", items[0]["id"])
+	}
+}
+
+func TestDecodeListResponseEmpty(t *testing.T) {
+	items, cursor, err := decodeListResponse([]byte(`{}`), "payments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor != "" {
+		t.Errorf("cursor = %q, want empty", cursor)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(items))
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Square connector for ingestr covering **13 tables** across the Payments, Orders, Catalog, Customers, Inventory, Labor, Team, Locations, Bank Accounts, Cash Drawers and Loyalty APIs. URI is `square://?access_token=<token>[&environment=production|sandbox]`.

| Table | PK | Inc Key | Strategy |
|---|---|---|---|
| `payments` | `id` | `updated_at` | merge |
| `refunds` | `id` | `updated_at` | merge |
| `orders` | `id` | `updated_at` | merge |
| `customers` | `id` | `updated_at` | merge |
| `catalog_objects` | `id` | `updated_at` | merge (includes `is_deleted` rows) |
| `team_members` | `id` | `updated_at` | merge (soft-deletes via `status=INACTIVE`) |
| `inventory` | `catalog_object_id`, `location_id`, `state` | `calculated_at` | merge |
| `locations` | `id` | – | replace |
| `team_member_wages` | `id` | – | replace |
| `shifts` | `id` | – | replace |
| `bank_accounts` | `id` | – | replace |
| `cash_drawers` | `id` | – | replace |
| `loyalty` | `id` | – | replace |