### PR TITLE
fix(deps): bump go-chi/chi/v5 to v5.3.0 (IP spoofing advisories)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/elastic/go-elasticsearch/v9 v9.3.1
 	github.com/fatih/color v1.18.0
-	github.com/go-chi/chi/v5 v5.2.3
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-mysql-org/go-mysql v1.13.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-viper/mapstructure/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -971,6 +971,8 @@ github.com/gabriel-vasile/mimetype v1.4.7/go.mod h1:GDlAgAyIRT27BhFl53XNAFtfjzOk
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -623,7 +623,7 @@ dependencies:
         - MIT
       status: allowed
     - module: github.com/go-chi/chi/v5
-      version: v5.2.3
+      version: v5.3.0
       licenses:
         - MIT
       status: allowed


### PR DESCRIPTION
## Why

Resolves two HIGH advisories in the chi `RealIP` middleware, which trusts the `X-Forwarded-For` header without validation (potential IP spoofing / bypass of IP-based controls):

- GHSA-rjr7-jggh-pgcp — RealIP middleware allows IP spoofing via unvalidated `X-Forwarded-For`
- GHSA-9g5q-2w5x-hmxf — Potential IP spoofing via `X-Forwarded-For` in `Request.RemoteAddr` resolution