### PR TITLE
postgres-cdc: build managed publication from eligible tables only

### DIFF
--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -72,6 +72,9 @@ ingestr ingest \
 ```
 
 > [!INFO]
+> **Postgres publications.** Pass `publication=<name>` to use a publication you manage yourself. If you omit it, ingestr creates and maintains a publication named `ingestr_publication`, refreshing it on every run to include every logged table that has a replica identity (a primary key, `REPLICA IDENTITY FULL`, or a replica-identity index). Tables that are unlogged, or that lack a replica identity, are skipped with a warning — their changes either never reach the WAL or would make `UPDATE`/`DELETE` on the source fail.
+
+> [!INFO]
 > Schema changes are picked up at startup. If the source schema changes while a stream is running, restart the stream to apply the new schema. Run streaming ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after transient source/destination outages.
 
 ## General flags

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -430,14 +430,17 @@ func (s skippedTable) warning(pubName string) string {
 
 // selectPublishableTables inspects the user tables and splits them into those
 // that can be added to a logical-replication publication (logged, with a usable
-// replica identity) and those that must be skipped, along with the reason.
-// Temporary tables and system catalogs are ignored.
+// replica identity) and those that must be skipped, along with the reason. Only
+// relations that physically hold rows are considered (relkind 'r' — ordinary
+// tables and leaf partitions); partitioned parents are excluded so the
+// publication never lists a parent alongside a partition it already covers,
+// which Postgres rejects. Temporary tables and system catalogs are ignored.
 func selectPublishableTables(ctx context.Context, pool *pgxpool.Pool) (included []pgTableRef, skipped []skippedTable, err error) {
 	const q = `
 		SELECT n.nspname, c.relname, c.relpersistence::text, ` + replicaIdentityClause + ` AS has_replica_identity
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
-		WHERE c.relkind IN ('r', 'p')
+		WHERE c.relkind = 'r'
 		  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
 		ORDER BY n.nspname, c.relname
 	`
@@ -586,7 +589,7 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 			SELECT n.nspname, c.relname
 			FROM pg_class c
 			JOIN pg_namespace n ON n.oid = c.relnamespace
-			WHERE c.relkind IN ('r', 'p')
+			WHERE c.relkind = 'r'
 			  AND c.relpersistence = 'p'
 			  AND ` + replicaIdentityClause + `
 			  AND n.nspname NOT IN ('pg_catalog', 'information_schema')

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -32,6 +32,10 @@ const (
 	ModeStream CDCMode = "stream" // Continuous streaming mode
 )
 
+// defaultPublicationName is the publication ingestr creates and manages when the
+// URI does not specify one.
+const defaultPublicationName = "ingestr_publication"
+
 type CDCConfig struct {
 	Publication   string
 	SlotName      string
@@ -96,12 +100,14 @@ func (s *PostgresCDCSource) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to ping postgres: %w", err)
 	}
 
-	// Auto-create publication if not specified
+	// When no publication is specified in the URI, ingestr manages a default
+	// publication. Reconcile it on every run so it tracks the current set of
+	// logged tables; unlogged tables cannot be replicated and are skipped.
 	if cdcConfig.Publication == "" {
-		cdcConfig.Publication = "ingestr_publication"
-		if err := ensurePublicationExists(ctx, queryPool, cdcConfig.Publication); err != nil {
+		cdcConfig.Publication = defaultPublicationName
+		if err := ensureManagedPublication(ctx, queryPool, cdcConfig.Publication); err != nil {
 			queryPool.Close()
-			return fmt.Errorf("failed to create publication: %w", err)
+			return fmt.Errorf("failed to ensure publication: %w", err)
 		}
 	}
 
@@ -357,33 +363,181 @@ func parseURIConfig(uri string) (CDCConfig, string, error) {
 	return cfg, parsed.String(), nil
 }
 
-func ensurePublicationExists(ctx context.Context, pool *pgxpool.Pool, pubName string) error {
-	var exists bool
-	err := pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM pg_publication WHERE pubname = $1)", pubName).Scan(&exists)
-	if err != nil {
-		return fmt.Errorf("failed to check publication existence: %w", err)
-	}
+// pgTableRef identifies a Postgres table by schema and name.
+type pgTableRef struct {
+	schema string
+	name   string
+}
 
-	if exists {
-		config.Debug("[CDC] Publication %s already exists", pubName)
-		return nil
-	}
+// quoted returns the schema-qualified, safely quoted identifier for use in DDL.
+func (t pgTableRef) quoted() string {
+	return pgx.Identifier{t.schema, t.name}.Sanitize()
+}
 
-	config.Debug("[CDC] Creating publication %s FOR ALL TABLES", pubName)
-	// Use pgx.Identifier to safely quote the publication name - DDL statements don't support parameter placeholders
-	pubIdent := pgx.Identifier{pubName}.Sanitize()
-	_, err = pool.Exec(ctx, fmt.Sprintf("CREATE PUBLICATION %s FOR ALL TABLES", pubIdent))
+// display returns a human-readable schema.table name for log and warning output.
+func (t pgTableRef) display() string {
+	return t.schema + "." + t.name
+}
+
+// quotePublicationTables renders refs as a comma-separated, safely quoted list
+// for a CREATE/ALTER PUBLICATION ... TABLE clause.
+func quotePublicationTables(tables []pgTableRef) string {
+	parts := make([]string, len(tables))
+	for i, t := range tables {
+		parts[i] = t.quoted()
+	}
+	return strings.Join(parts, ", ")
+}
+
+// replicaIdentityClause is a SQL predicate over alias c (pg_class) that is true
+// when a table has a replica identity usable for publishing UPDATE/DELETE:
+// REPLICA IDENTITY FULL, DEFAULT backed by a primary key, or a valid USING INDEX.
+// A table failing this would raise SQLSTATE 55000 on UPDATE/DELETE once it is
+// part of a publication that publishes those operations.
+const replicaIdentityClause = `(
+	c.relreplident = 'f'
+	OR (c.relreplident = 'd' AND EXISTS (
+		SELECT 1 FROM pg_index i WHERE i.indrelid = c.oid AND i.indisprimary))
+	OR (c.relreplident = 'i' AND EXISTS (
+		SELECT 1 FROM pg_index i WHERE i.indrelid = c.oid AND i.indisreplident AND i.indisvalid))
+)`
+
+// skipReason explains why a table is excluded from the managed publication.
+type skipReason int
+
+const (
+	skipUnlogged skipReason = iota
+	skipNoReplicaIdentity
+)
+
+// skippedTable pairs an excluded table with the reason it was excluded.
+type skippedTable struct {
+	ref    pgTableRef
+	reason skipReason
+}
+
+// warning returns the user-facing message describing why the table is skipped.
+func (s skippedTable) warning(pubName string) string {
+	switch s.reason {
+	case skipUnlogged:
+		return fmt.Sprintf("table %s is unlogged and will be skipped from CDC publication %q; changes to unlogged tables are not replicated", s.ref.display(), pubName)
+	case skipNoReplicaIdentity:
+		return fmt.Sprintf("table %s has no replica identity (no primary key) and will be skipped from CDC publication %q; including it would make UPDATE/DELETE on the source fail", s.ref.display(), pubName)
+	default:
+		return fmt.Sprintf("table %s will be skipped from CDC publication %q", s.ref.display(), pubName)
+	}
+}
+
+// selectPublishableTables inspects the user tables and splits them into those
+// that can be added to a logical-replication publication (logged, with a usable
+// replica identity) and those that must be skipped, along with the reason.
+// Temporary tables and system catalogs are ignored.
+func selectPublishableTables(ctx context.Context, pool *pgxpool.Pool) (included []pgTableRef, skipped []skippedTable, err error) {
+	const q = `
+		SELECT n.nspname, c.relname, c.relpersistence::text, ` + replicaIdentityClause + ` AS has_replica_identity
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relkind IN ('r', 'p')
+		  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY n.nspname, c.relname
+	`
+	rows, err := pool.Query(ctx, q)
 	if err != nil {
-		// Handle race condition: another instance may have created the publication concurrently
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && (pgErr.Code == pgErrDuplicate || pgErr.Code == pgErrAlreadyExists) {
-			config.Debug("[CDC] Publication %s was created by another instance (concurrent race)", pubName)
-			return nil
+		return nil, nil, fmt.Errorf("failed to list tables: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			t                  pgTableRef
+			persistence        string
+			hasReplicaIdentity bool
+		)
+		if err := rows.Scan(&t.schema, &t.name, &persistence, &hasReplicaIdentity); err != nil {
+			return nil, nil, fmt.Errorf("failed to scan table: %w", err)
 		}
-		return fmt.Errorf("failed to create publication: %w", err)
+		switch {
+		case persistence == "u":
+			skipped = append(skipped, skippedTable{ref: t, reason: skipUnlogged})
+		case persistence != "p":
+			// Temporary or other non-permanent relations are not replicated.
+			continue
+		case !hasReplicaIdentity:
+			skipped = append(skipped, skippedTable{ref: t, reason: skipNoReplicaIdentity})
+		default:
+			included = append(included, t)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("error iterating tables: %w", err)
+	}
+	return included, skipped, nil
+}
+
+// ensureManagedPublication creates or updates the ingestr-managed publication so
+// it covers exactly the tables currently eligible for logical replication. It
+// runs on every connection (only when no publication is supplied in the URI), so
+// the publication tracks tables added, dropped, or changed since the previous
+// run. Tables that are unlogged or lack a usable replica identity are skipped
+// with a warning.
+func ensureManagedPublication(ctx context.Context, pool *pgxpool.Pool, pubName string) error {
+	included, skipped, err := selectPublishableTables(ctx, pool)
+	if err != nil {
+		return err
 	}
 
-	config.Debug("[CDC] Publication %s created successfully", pubName)
+	for _, s := range skipped {
+		fmt.Printf("Warning: %s\n", s.warning(pubName))
+	}
+
+	if len(included) == 0 {
+		return fmt.Errorf("no tables eligible for replication for publication %q", pubName)
+	}
+
+	tableList := quotePublicationTables(included)
+	// Use pgx.Identifier to safely quote identifiers - DDL does not support parameter placeholders.
+	pubIdent := pgx.Identifier{pubName}.Sanitize()
+
+	var pubAllTables bool
+	err = pool.QueryRow(ctx, "SELECT puballtables FROM pg_publication WHERE pubname = $1", pubName).Scan(&pubAllTables)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		config.Debug("[CDC] Creating publication %s for %d table(s)", pubName, len(included))
+		if _, err = pool.Exec(ctx, fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pubIdent, tableList)); err != nil {
+			// Another instance may have created it concurrently; fall back to
+			// reconciling its table set instead of failing the run.
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && (pgErr.Code == pgErrDuplicate || pgErr.Code == pgErrAlreadyExists) {
+				config.Debug("[CDC] Publication %s created concurrently; updating its table set", pubName)
+				return setPublicationTables(ctx, pool, pubIdent, tableList)
+			}
+			return fmt.Errorf("failed to create publication: %w", err)
+		}
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to check publication existence: %w", err)
+	case pubAllTables:
+		// A publication left over from an older ingestr as FOR ALL TABLES cannot
+		// have its table set altered, so recreate it with the explicit list.
+		config.Debug("[CDC] Recreating FOR ALL TABLES publication %s with explicit logged-table list", pubName)
+		if _, err = pool.Exec(ctx, fmt.Sprintf("DROP PUBLICATION %s", pubIdent)); err != nil {
+			return fmt.Errorf("failed to drop legacy publication: %w", err)
+		}
+		if _, err = pool.Exec(ctx, fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pubIdent, tableList)); err != nil {
+			return fmt.Errorf("failed to recreate publication: %w", err)
+		}
+		return nil
+	default:
+		config.Debug("[CDC] Updating publication %s to cover %d table(s)", pubName, len(included))
+		return setPublicationTables(ctx, pool, pubIdent, tableList)
+	}
+}
+
+// setPublicationTables replaces the table set of an existing FOR TABLE publication.
+func setPublicationTables(ctx context.Context, pool *pgxpool.Pool, pubIdent, tableList string) error {
+	if _, err := pool.Exec(ctx, fmt.Sprintf("ALTER PUBLICATION %s SET TABLE %s", pubIdent, tableList)); err != nil {
+		return fmt.Errorf("failed to update publication tables: %w", err)
+	}
 	return nil
 }
 
@@ -424,12 +578,19 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 
 	var query string
 	if pubAllTables {
-		// For "FOR ALL TABLES" publications, query all user tables directly
+		// For "FOR ALL TABLES" publications, query all user tables directly.
+		// Exclude unlogged tables (their changes never reach the WAL) and tables
+		// without a usable replica identity (publishing them would make
+		// UPDATE/DELETE on the source fail), mirroring the managed-publication path.
 		query = `
-			SELECT schemaname, tablename
-			FROM pg_tables
-			WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
-			ORDER BY schemaname, tablename
+			SELECT n.nspname, c.relname
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.relkind IN ('r', 'p')
+			  AND c.relpersistence = 'p'
+			  AND ` + replicaIdentityClause + `
+			  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+			ORDER BY n.nspname, c.relname
 		`
 	} else {
 		// For specific table publications, use pg_publication_tables

--- a/pkg/source/postgres_cdc/source_test.go
+++ b/pkg/source/postgres_cdc/source_test.go
@@ -102,6 +102,36 @@ func TestParseURIConfig(t *testing.T) {
 	}
 }
 
+func TestQuotePublicationTables(t *testing.T) {
+	tests := []struct {
+		name   string
+		tables []pgTableRef
+		want   string
+	}{
+		{
+			name:   "single public table",
+			tables: []pgTableRef{{schema: "public", name: "users"}},
+			want:   `"public"."users"`,
+		},
+		{
+			name:   "multiple schemas",
+			tables: []pgTableRef{{schema: "public", name: "users"}, {schema: "app", name: "orders"}},
+			want:   `"public"."users", "app"."orders"`,
+		},
+		{
+			name:   "identifiers needing quoting",
+			tables: []pgTableRef{{schema: "public", name: "Mixed Case"}, {schema: "public", name: `weird"name`}},
+			want:   `"public"."Mixed Case", "public"."weird""name"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, quotePublicationTables(tt.tables))
+		})
+	}
+}
+
 func TestBuildReplicationConnString(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -220,6 +220,48 @@ func TestPostgresCDC_ManagedPublicationSelectsReplicatableTables(t *testing.T) {
 	assert.ElementsMatch(t, []string{"public.logged_items", "public.logged_items_2"}, tables)
 }
 
+// TestPostgresCDC_ManagedPublicationHandlesPartitionedTables guards against
+// listing a partitioned parent together with its partitions in the publication,
+// which Postgres rejects (failing Connect). Only the leaf partition, which
+// physically holds rows, is published.
+func TestPostgresCDC_ManagedPublicationHandlesPartitionedTables(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, connString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = container.Terminate(ctx) }()
+
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	_, err = pool.Exec(ctx, `CREATE TABLE public.measurements (
+		id INT,
+		taken_on DATE,
+		PRIMARY KEY (id, taken_on)
+	) PARTITION BY RANGE (taken_on)`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `CREATE TABLE public.measurements_2024 PARTITION OF public.measurements
+		FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')`)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	cdcURI := "postgres+cdc://" + connString[len("postgres://"):] + "&mode=batch"
+
+	src := postgres_cdc.NewPostgresCDCSource()
+	require.NoError(t, src.Connect(ctx, cdcURI), "Connect must not fail when partitioned tables are present")
+	defer func() { _ = src.Close(ctx) }()
+
+	tables := publicationTables(t, ctx, pool, "ingestr_publication")
+	assert.Contains(t, tables, "public.measurements_2024", "leaf partition should be published")
+	assert.NotContains(t, tables, "public.measurements", "partitioned parent should not be listed")
+}
+
 // TestPostgresCDC_ManagedPublicationEndToEnd runs the full pipeline through the
 // auto-managed publication (no publication= in the URI) and verifies that only
 // eligible tables are replicated: a logged table with a primary key replicates

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -3,10 +3,12 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
 	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // Register ADBC driver
+	"github.com/bruin-data/ingestr/pkg/source/postgres_cdc"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,6 +97,215 @@ func setupCDCSource(t *testing.T, ctx context.Context, connString string) {
 	// Grant replication privilege
 	_, err = pool.Exec(ctx, `ALTER USER testuser REPLICATION`)
 	require.NoError(t, err)
+}
+
+// publicationTables returns the "schema.table" entries currently in the named publication.
+func publicationTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool, pub string) []string {
+	t.Helper()
+	rows, err := pool.Query(ctx, `SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = $1`, pub)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var schemaName, tableName string
+		require.NoError(t, rows.Scan(&schemaName, &tableName))
+		out = append(out, schemaName+"."+tableName)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// captureStdout runs fn while capturing everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+// assertRelationAbsent fails if schema.table exists in the destination database.
+func assertRelationAbsent(t *testing.T, ctx context.Context, db *sql.DB, schema, table string) {
+	t.Helper()
+	var present bool
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2)`,
+		schema, table).Scan(&present))
+	assert.Falsef(t, present, "table %s.%s should not have been replicated", schema, table)
+}
+
+// TestPostgresCDC_ManagedPublicationSelectsReplicatableTables verifies that when
+// no publication is supplied in the URI, ingestr builds and maintains a
+// publication containing only the tables eligible for logical replication. It
+// skips unlogged tables and tables without a replica identity (no primary key),
+// warns about each, and reconciles the table set on every connection.
+func TestPostgresCDC_ManagedPublicationSelectsReplicatableTables(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, connString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = container.Terminate(ctx) }()
+
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// logged_items: logged + primary key -> eligible.
+	_, err = pool.Exec(ctx, `CREATE TABLE public.logged_items (id SERIAL PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	// unlogged_items: unlogged (even with a primary key) -> skipped.
+	_, err = pool.Exec(ctx, `CREATE UNLOGGED TABLE public.unlogged_items (id SERIAL PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	// nopk_items: logged but no primary key -> skipped (no replica identity).
+	_, err = pool.Exec(ctx, `CREATE TABLE public.nopk_items (id INT, name TEXT)`)
+	require.NoError(t, err)
+
+	// CDC opens a replication connection, which requires the replication privilege.
+	_, err = pool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	// No publication param -> ingestr manages the default publication.
+	cdcURI := "postgres+cdc://" + connString[len("postgres://"):] + "&mode=batch"
+
+	src := postgres_cdc.NewPostgresCDCSource()
+	var connErr error
+	out := captureStdout(t, func() { connErr = src.Connect(ctx, cdcURI) })
+	require.NoError(t, connErr)
+	defer func() { _ = src.Close(ctx) }()
+
+	// Each excluded table is reported with the reason it was skipped.
+	assert.Contains(t, out, "public.unlogged_items")
+	assert.Contains(t, out, "unlogged")
+	assert.Contains(t, out, "public.nopk_items")
+	assert.Contains(t, out, "replica identity")
+
+	// The managed publication contains only the eligible table.
+	tables := publicationTables(t, ctx, pool, "ingestr_publication")
+	assert.Equal(t, []string{"public.logged_items"}, tables)
+
+	// GetTables (what the pipeline iterates) also excludes the ineligible tables.
+	infos, err := src.GetTables(ctx)
+	require.NoError(t, err)
+	var names []string
+	for _, ti := range infos {
+		names = append(names, ti.Name)
+	}
+	assert.Contains(t, names, "logged_items")
+	assert.NotContains(t, names, "unlogged_items")
+	assert.NotContains(t, names, "nopk_items")
+
+	// A logged table created after the first run is picked up on the next
+	// connection (publication is reconciled every run).
+	_, err = pool.Exec(ctx, `CREATE TABLE public.logged_items_2 (id SERIAL PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	src2 := postgres_cdc.NewPostgresCDCSource()
+	require.NoError(t, src2.Connect(ctx, cdcURI))
+	defer func() { _ = src2.Close(ctx) }()
+
+	tables = publicationTables(t, ctx, pool, "ingestr_publication")
+	assert.ElementsMatch(t, []string{"public.logged_items", "public.logged_items_2"}, tables)
+}
+
+// TestPostgresCDC_ManagedPublicationEndToEnd runs the full pipeline through the
+// auto-managed publication (no publication= in the URI) and verifies that only
+// eligible tables are replicated: a logged table with a primary key replicates
+// end-to-end (snapshot then CDC insert/update), while an unlogged table and a
+// table without a primary key are excluded entirely.
+func TestPostgresCDC_ManagedPublicationEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if pgDest.uri == "" {
+		t.Skip("shared postgres dest container not available")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	// widgets: logged + primary key -> eligible (happy path).
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.widgets (id INT PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.widgets (id, name) VALUES (1, 'alpha'), (2, 'beta')`)
+	require.NoError(t, err)
+
+	// events_unlogged: unlogged -> skipped.
+	_, err = srcPool.Exec(ctx, `CREATE UNLOGGED TABLE public.events_unlogged (id INT PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.events_unlogged (id, name) VALUES (1, 'nope')`)
+	require.NoError(t, err)
+
+	// logs_nopk: logged but no primary key -> skipped (no replica identity).
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.logs_nopk (id INT, msg TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.logs_nopk (id, msg) VALUES (1, 'nope')`)
+	require.NoError(t, err)
+
+	_, err = srcPool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	destSchema := uniqueSchemaName(t, "cdc_managed")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
+
+	// No publication= -> ingestr manages the publication itself.
+	cfg := &config.IngestConfig{
+		SourceURI: "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+			"&mode=batch&dest_schema=" + destSchema,
+		DestURI: pgDest.uri,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pg, err := sql.Open("pgx", pgDest.uri)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+
+	// Happy path: the eligible table is snapshotted to the destination.
+	var count int
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.widgets`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count, "widgets snapshot")
+
+	// The excluded tables must not have been replicated at all.
+	assertRelationAbsent(t, ctx, pg, destSchema, "events_unlogged")
+	assertRelationAbsent(t, ctx, pg, destSchema, "logs_nopk")
+
+	// Subsequent CDC: an insert and an update on the eligible table propagate.
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.widgets (id, name) VALUES (3, 'gamma')`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `UPDATE public.widgets SET name = 'alpha2' WHERE id = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.widgets`, destSchema)).Scan(&count))
+	assert.Equal(t, 3, count, "widgets after CDC insert")
+
+	var name string
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT name FROM %q.widgets WHERE id = 1`, destSchema)).Scan(&name))
+	assert.Equal(t, "alpha2", name, "widgets after CDC update")
+
+	// The excluded tables remain absent after a second run.
+	assertRelationAbsent(t, ctx, pg, destSchema, "events_unlogged")
+	assertRelationAbsent(t, ctx, pg, destSchema, "logs_nopk")
 }
 
 func TestPostgresCDC_Snapshot(t *testing.T) {


### PR DESCRIPTION
When no publication is given in the URI, ingestr manages a default publication (ingestr_publication). It was previously created once as FOR ALL TABLES, which pulls in unlogged tables (whose changes never reach the WAL) and tables without a replica identity (whose UPDATE/DELETE then fail on the source with SQLSTATE 55000).

The managed publication is now built from an explicit table list containing only logged tables that have a usable replica identity (primary key, REPLICA IDENTITY FULL, or a valid replica-identity index). It is reconciled on every run so it tracks tables added, dropped, or changed between runs, and each skipped table is reported with a warning explaining why. The GetTables FOR ALL TABLES path applies the same filter for consistency.

Adds a unit test for the table-list builder and integration tests covering the selection logic, end-to-end replication via the managed publication, and the unlogged / no-replica-identity exclusions.