### PR TITLE
Make telemetry nonblocking

### DIFF
--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/telemetry"
 )
+
+var telemetryWG sync.WaitGroup
 
 func trackCommandTriggered(ctx context.Context, command string) {
 	trackTelemetryAsync(ctx, "command_triggered", commandTelemetryProperties(command, nil))
@@ -25,6 +28,7 @@ func trackCommandFinished(ctx context.Context, command string, err error) {
 		properties["error"] = commandTelemetryError(err)
 	}
 
+	telemetryWG.Wait()
 	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, versionFlagValue())
 }
 
@@ -35,7 +39,9 @@ func trackTelemetryAsync(ctx context.Context, event string, properties map[strin
 
 	ctx = context.WithoutCancel(ctx)
 	version := versionFlagValue()
+	telemetryWG.Add(1)
 	go func() {
+		defer telemetryWG.Done()
 		telemetry.Track(ctx, event, properties, version)
 	}()
 }

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -9,11 +9,11 @@ import (
 )
 
 func trackCommandTriggered(ctx context.Context, command string) {
-	trackTelemetry(ctx, "command_triggered", commandTelemetryProperties(command, nil))
+	trackTelemetryAsync(ctx, "command_triggered", commandTelemetryProperties(command, nil))
 }
 
 func trackCommandRunning(ctx context.Context, command string, properties map[string]any) {
-	trackTelemetry(ctx, "command_running", commandTelemetryProperties(command, properties))
+	trackTelemetryAsync(ctx, "command_running", commandTelemetryProperties(command, properties))
 }
 
 func trackCommandFinished(ctx context.Context, command string, err error) {
@@ -25,10 +25,10 @@ func trackCommandFinished(ctx context.Context, command string, err error) {
 		properties["error"] = commandTelemetryError(err)
 	}
 
-	trackTelemetry(context.WithoutCancel(ctx), "command_finished", properties)
+	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, versionFlagValue())
 }
 
-func trackTelemetry(ctx context.Context, event string, properties map[string]any) {
+func trackTelemetryAsync(ctx context.Context, event string, properties map[string]any) {
 	if telemetry.Disabled() {
 		return
 	}

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -9,11 +9,11 @@ import (
 )
 
 func trackCommandTriggered(ctx context.Context, command string) {
-	telemetry.Track(ctx, "command_triggered", commandTelemetryProperties(command, nil), versionFlagValue())
+	trackTelemetry(ctx, "command_triggered", commandTelemetryProperties(command, nil))
 }
 
 func trackCommandRunning(ctx context.Context, command string, properties map[string]any) {
-	telemetry.Track(ctx, "command_running", commandTelemetryProperties(command, properties), versionFlagValue())
+	trackTelemetry(ctx, "command_running", commandTelemetryProperties(command, properties))
 }
 
 func trackCommandFinished(ctx context.Context, command string, err error) {
@@ -25,7 +25,19 @@ func trackCommandFinished(ctx context.Context, command string, err error) {
 		properties["error"] = commandTelemetryError(err)
 	}
 
-	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, versionFlagValue())
+	trackTelemetry(context.WithoutCancel(ctx), "command_finished", properties)
+}
+
+func trackTelemetry(ctx context.Context, event string, properties map[string]any) {
+	if telemetry.Disabled() {
+		return
+	}
+
+	ctx = context.WithoutCancel(ctx)
+	version := versionFlagValue()
+	go func() {
+		telemetry.Track(ctx, event, properties, version)
+	}()
 }
 
 func commandTelemetryProperties(command string, properties map[string]any) map[string]any {


### PR DESCRIPTION
Telemetry startup events now run in the background so CLI startup is not blocked by network latency.

The final command telemetry event still sends before process exit so it is not dropped.

Validation: make format, make lint, make test.