### PR TITLE
stripe: retry rate-limit 429s with exponential backoff

### DIFF
--- a/pkg/source/stripe/retry.go
+++ b/pkg/source/stripe/retry.go
@@ -1,0 +1,124 @@
+package stripe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/stripe/stripe-go/v81"
+	"github.com/stripe/stripe-go/v81/form"
+)
+
+const (
+	maxRateLimitRetries = 5
+	baseRateLimitDelay  = 1 * time.Second
+	maxRateLimitDelay   = 32 * time.Second
+)
+
+// retryBackend wraps a stripe.Backend and retries requests that fail with a
+// 429 rate-limit error. The stripe-go library retries most transient failures
+// out of the box, but deliberately does NOT retry rate-limit 429s (it only
+// retries 429s caused by lock timeouts). Stripe recommends handling rate
+// limits with exponential backoff on the client side, which is what this does.
+type retryBackend struct {
+	inner      stripe.Backend
+	baseDelay  time.Duration
+	maxDelay   time.Duration
+	maxRetries int
+}
+
+func newRetryBackend(inner stripe.Backend) *retryBackend {
+	return &retryBackend{
+		inner:      inner,
+		baseDelay:  baseRateLimitDelay,
+		maxDelay:   maxRateLimitDelay,
+		maxRetries: maxRateLimitRetries,
+	}
+}
+
+func (b *retryBackend) Call(method, path, key string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
+	return b.withRetry(paramsContext(params), func() error {
+		return b.inner.Call(method, path, key, params, v)
+	})
+}
+
+func (b *retryBackend) CallStreaming(method, path, key string, params stripe.ParamsContainer, v stripe.StreamingLastResponseSetter) error {
+	return b.withRetry(paramsContext(params), func() error {
+		return b.inner.CallStreaming(method, path, key, params, v)
+	})
+}
+
+func (b *retryBackend) CallRaw(method, path, key string, body *form.Values, params *stripe.Params, v stripe.LastResponseSetter) error {
+	return b.withRetry(paramsCtx(params), func() error {
+		return b.inner.CallRaw(method, path, key, body, params, v)
+	})
+}
+
+func (b *retryBackend) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *stripe.Params, v stripe.LastResponseSetter) error {
+	return b.withRetry(paramsCtx(params), func() error {
+		return b.inner.CallMultipart(method, path, key, boundary, body, params, v)
+	})
+}
+
+func (b *retryBackend) SetMaxNetworkRetries(maxNetworkRetries int64) {
+	b.inner.SetMaxNetworkRetries(maxNetworkRetries)
+}
+
+func (b *retryBackend) withRetry(ctx context.Context, fn func() error) error {
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil || attempt >= b.maxRetries || !isRateLimitErr(err) {
+			return err
+		}
+
+		delay := b.rateLimitBackoff(attempt)
+		config.Debug("[STRIPE] Rate limited (429), retry %d/%d after %s", attempt+1, b.maxRetries, delay)
+
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				return err
+			case <-time.After(delay):
+			}
+		} else {
+			time.Sleep(delay)
+		}
+	}
+}
+
+func isRateLimitErr(err error) bool {
+	var se *stripe.Error
+	if errors.As(err, &se) {
+		return se.HTTPStatusCode == http.StatusTooManyRequests
+	}
+	return false
+}
+
+// rateLimitBackoff returns an exponentially increasing delay with jitter,
+// capped at b.maxDelay.
+func (b *retryBackend) rateLimitBackoff(attempt int) time.Duration {
+	delay := b.baseDelay << attempt
+	if delay > b.maxDelay || delay <= 0 {
+		delay = b.maxDelay
+	}
+	jitter := time.Duration(rand.Int63n(int64(delay) / 4)) //nolint:gosec // jitter does not require crypto randomness
+	return delay - jitter
+}
+
+func paramsContext(params stripe.ParamsContainer) context.Context {
+	if params == nil {
+		return nil
+	}
+	return paramsCtx(params.GetParams())
+}
+
+func paramsCtx(params *stripe.Params) context.Context {
+	if params == nil {
+		return nil
+	}
+	return params.Context
+}

--- a/pkg/source/stripe/retry.go
+++ b/pkg/source/stripe/retry.go
@@ -40,6 +40,18 @@ func newRetryBackend(inner stripe.Backend) *retryBackend {
 	}
 }
 
+// wrapWithRetry installs a retryBackend over the given backend type. It is
+// idempotent: if the current backend is already a retryBackend (e.g. Connect
+// was called more than once in the same process), it is left untouched so
+// retries don't compound across calls.
+func wrapWithRetry(backendType stripe.SupportedBackend) {
+	current := stripe.GetBackend(backendType)
+	if _, ok := current.(*retryBackend); ok {
+		return
+	}
+	stripe.SetBackend(backendType, newRetryBackend(current))
+}
+
 func (b *retryBackend) Call(method, path, key string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
 	return b.withRetry(paramsContext(params), func() error {
 		return b.inner.Call(method, path, key, params, v)
@@ -78,6 +90,9 @@ func (b *retryBackend) withRetry(ctx context.Context, fn func() error) error {
 		delay := b.rateLimitBackoff(attempt)
 		config.Debug("[STRIPE] Rate limited (429), retry %d/%d after %s", attempt+1, b.maxRetries, delay)
 
+		// When the request params carry no context (legal for simple GET
+		// calls), there is nothing to cancel on, so the sleep is
+		// uninterruptible — but it is always bounded by maxDelay.
 		if ctx != nil {
 			select {
 			case <-ctx.Done():
@@ -105,7 +120,11 @@ func (b *retryBackend) rateLimitBackoff(attempt int) time.Duration {
 	if delay > b.maxDelay || delay <= 0 {
 		delay = b.maxDelay
 	}
-	jitter := time.Duration(rand.Int63n(int64(delay) / 4)) //nolint:gosec // jitter does not require crypto randomness
+	quarter := int64(delay) / 4
+	var jitter time.Duration
+	if quarter > 0 {
+		jitter = time.Duration(rand.Int63n(quarter)) //nolint:gosec // jitter does not require crypto randomness
+	}
 	return delay - jitter
 }
 

--- a/pkg/source/stripe/retry_test.go
+++ b/pkg/source/stripe/retry_test.go
@@ -1,0 +1,160 @@
+package stripe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stripe/stripe-go/v81"
+	"github.com/stripe/stripe-go/v81/form"
+)
+
+// fakeBackend records how many times Call is invoked and returns a queued
+// sequence of errors, one per call.
+type fakeBackend struct {
+	errs  []error
+	calls int
+}
+
+func (f *fakeBackend) Call(method, path, key string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
+	err := f.errs[f.calls]
+	f.calls++
+	return err
+}
+
+func (f *fakeBackend) CallStreaming(method, path, key string, params stripe.ParamsContainer, v stripe.StreamingLastResponseSetter) error {
+	return f.Call(method, path, key, params, nil)
+}
+
+func (f *fakeBackend) CallRaw(method, path, key string, body *form.Values, params *stripe.Params, v stripe.LastResponseSetter) error {
+	err := f.errs[f.calls]
+	f.calls++
+	return err
+}
+
+func (f *fakeBackend) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *stripe.Params, v stripe.LastResponseSetter) error {
+	err := f.errs[f.calls]
+	f.calls++
+	return err
+}
+
+func (f *fakeBackend) SetMaxNetworkRetries(maxNetworkRetries int64) {}
+
+func rateLimitError() error {
+	return &stripe.Error{HTTPStatusCode: http.StatusTooManyRequests, Code: stripe.ErrorCodeRateLimit}
+}
+
+// newTestRetryBackend builds a retryBackend with sub-millisecond delays so the
+// retry loop runs fast without real-time exponential backoff sleeps.
+func newTestRetryBackend(inner stripe.Backend) *retryBackend {
+	b := newRetryBackend(inner)
+	b.baseDelay = time.Millisecond
+	b.maxDelay = 4 * time.Millisecond
+	return b
+}
+
+func TestRetryBackendRetriesRateLimitThenSucceeds(t *testing.T) {
+	fake := &fakeBackend{errs: []error{rateLimitError(), rateLimitError(), nil}}
+	b := newTestRetryBackend(fake)
+
+	start := stripeTestNow()
+	err := b.withRetry(context.Background(), func() error {
+		return fake.Call("GET", "/v1/disputes", "key", nil, nil)
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if fake.calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", fake.calls)
+	}
+	if stripeTestNow().Sub(start) <= 0 {
+		t.Fatal("expected some backoff delay")
+	}
+}
+
+func TestRetryBackendGivesUpAfterMaxRetries(t *testing.T) {
+	errs := make([]error, maxRateLimitRetries+1)
+	for i := range errs {
+		errs[i] = rateLimitError()
+	}
+	fake := &fakeBackend{errs: errs}
+	b := newTestRetryBackend(fake)
+
+	err := b.withRetry(context.Background(), func() error {
+		return fake.Call("GET", "/v1/disputes", "key", nil, nil)
+	})
+	if !isRateLimitErr(err) {
+		t.Fatalf("expected a rate-limit error after exhausting retries, got: %v", err)
+	}
+	if fake.calls != maxRateLimitRetries+1 {
+		t.Fatalf("expected %d calls, got %d", maxRateLimitRetries+1, fake.calls)
+	}
+}
+
+func TestRetryBackendDoesNotRetryNonRateLimit(t *testing.T) {
+	fake := &fakeBackend{errs: []error{&stripe.Error{HTTPStatusCode: http.StatusBadRequest}}}
+	b := newTestRetryBackend(fake)
+
+	err := b.withRetry(context.Background(), func() error {
+		return fake.Call("GET", "/v1/disputes", "key", nil, nil)
+	})
+	if err == nil {
+		t.Fatal("expected the original error to be returned")
+	}
+	if fake.calls != 1 {
+		t.Fatalf("expected exactly 1 call, got %d", fake.calls)
+	}
+}
+
+func TestRetryBackendStopsOnContextCancel(t *testing.T) {
+	errs := make([]error, maxRateLimitRetries+1)
+	for i := range errs {
+		errs[i] = rateLimitError()
+	}
+	fake := &fakeBackend{errs: errs}
+	b := newTestRetryBackend(fake)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := b.withRetry(ctx, func() error {
+		return fake.Call("GET", "/v1/disputes", "key", nil, nil)
+	})
+	if !isRateLimitErr(err) {
+		t.Fatalf("expected rate-limit error, got: %v", err)
+	}
+	// First call returns 429, then ctx is already cancelled so we bail before retrying.
+	if fake.calls != 1 {
+		t.Fatalf("expected 1 call before context cancel, got %d", fake.calls)
+	}
+}
+
+func TestIsRateLimitErr(t *testing.T) {
+	if !isRateLimitErr(rateLimitError()) {
+		t.Fatal("expected 429 stripe error to be a rate-limit error")
+	}
+	if isRateLimitErr(errors.New("boom")) {
+		t.Fatal("plain error should not be a rate-limit error")
+	}
+	if isRateLimitErr(&stripe.Error{HTTPStatusCode: http.StatusInternalServerError}) {
+		t.Fatal("500 should not be a rate-limit error")
+	}
+}
+
+func TestRateLimitBackoffCapped(t *testing.T) {
+	b := newRetryBackend(nil)
+	for attempt := range 20 {
+		d := b.rateLimitBackoff(attempt)
+		if d <= 0 {
+			t.Fatalf("attempt %d: backoff must be positive, got %s", attempt, d)
+		}
+		if d > b.maxDelay {
+			t.Fatalf("attempt %d: backoff %s exceeds cap %s", attempt, d, b.maxDelay)
+		}
+	}
+}
+
+func stripeTestNow() time.Time { return time.Now() }

--- a/pkg/source/stripe/retry_test.go
+++ b/pkg/source/stripe/retry_test.go
@@ -157,4 +157,34 @@ func TestRateLimitBackoffCapped(t *testing.T) {
 	}
 }
 
+func TestRateLimitBackoffNoPanicOnTinyDelay(t *testing.T) {
+	b := newRetryBackend(nil)
+	b.baseDelay = time.Nanosecond
+	b.maxDelay = 2 * time.Nanosecond
+	// delay/4 rounds to 0; jitter must be skipped rather than panic.
+	if got := b.rateLimitBackoff(0); got <= 0 {
+		t.Fatalf("expected positive backoff, got %s", got)
+	}
+}
+
+func TestWrapWithRetryIsIdempotent(t *testing.T) {
+	original := stripe.GetBackend(stripe.APIBackend)
+	t.Cleanup(func() { stripe.SetBackend(stripe.APIBackend, original) })
+
+	wrapWithRetry(stripe.APIBackend)
+	first, ok := stripe.GetBackend(stripe.APIBackend).(*retryBackend)
+	if !ok {
+		t.Fatal("expected backend to be wrapped in a retryBackend")
+	}
+
+	wrapWithRetry(stripe.APIBackend)
+	second := stripe.GetBackend(stripe.APIBackend).(*retryBackend)
+	if second != first {
+		t.Fatal("second wrap should be a no-op, not stack another retryBackend")
+	}
+	if _, stacked := second.inner.(*retryBackend); stacked {
+		t.Fatal("retryBackend was wrapped around another retryBackend")
+	}
+}
+
 func stripeTestNow() time.Time { return time.Now() }

--- a/pkg/source/stripe/stripe.go
+++ b/pkg/source/stripe/stripe.go
@@ -86,6 +86,12 @@ func (s *StripeSource) Connect(ctx context.Context, uri string) error {
 	}
 	s.apiKey = apiKey
 	stripe.Key = apiKey
+
+	// Wrap the default backends so rate-limit (429) responses are retried with
+	// exponential backoff. stripe-go does not retry rate-limit 429s on its own.
+	stripe.SetBackend(stripe.APIBackend, newRetryBackend(stripe.GetBackend(stripe.APIBackend)))
+	stripe.SetBackend(stripe.UploadsBackend, newRetryBackend(stripe.GetBackend(stripe.UploadsBackend)))
+
 	config.Debug("[STRIPE] Connected successfully")
 	return nil
 }

--- a/pkg/source/stripe/stripe.go
+++ b/pkg/source/stripe/stripe.go
@@ -89,8 +89,8 @@ func (s *StripeSource) Connect(ctx context.Context, uri string) error {
 
 	// Wrap the default backends so rate-limit (429) responses are retried with
 	// exponential backoff. stripe-go does not retry rate-limit 429s on its own.
-	stripe.SetBackend(stripe.APIBackend, newRetryBackend(stripe.GetBackend(stripe.APIBackend)))
-	stripe.SetBackend(stripe.UploadsBackend, newRetryBackend(stripe.GetBackend(stripe.UploadsBackend)))
+	wrapWithRetry(stripe.APIBackend)
+	wrapWithRetry(stripe.UploadsBackend)
 
 	config.Debug("[STRIPE] Connected successfully")
 	return nil


### PR DESCRIPTION
## Problem

A Stripe ingestion was failing immediately on the first rate-limit error:

```
Error: failed to infer schema: error reading batch: failed to fetch dispute:
{"code":"rate_limit", ... "status":429, ... "type":"rate_limit_error"}
```

The cause is in `stripe-go` itself: it retries most transient failures out of the box (network errors, 409s, 500/503s, **lock-timeout** 429s), but **deliberately does NOT retry rate-limit 429s** — its own comment says retrying rate limits "would likely contribute to more contention problems." 

Stripe's official guidance is to handle rate limits with client-side exponential backoff — which is what this PR adds.

## Change

Wrapping the `Backend` is the single chokepoint every API call already flows through, so one wrap covers all call sites (list iterators, `.Get()`, event re-fetch, every parallel worker) without touching the ~40 read functions individually.