### PR TITLE
feat(source): add StarRocks source with lakehouse catalog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>✅</td>
     </tr>
     <tr>
+        <td>StarRocks</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Synapse</td>
         <td>-</td>
         <td>✅</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -135,6 +135,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Snowflake", link: "/supported-sources/snowflake.md" },
               { text: "Socrata", link: "/supported-sources/socrata.md" },
               { text: "SQLite", link: "/supported-sources/sqlite.md" },
+              { text: "StarRocks", link: "/supported-sources/starrocks.md" },
               {
                 text: "Experimental",
                 items: [

--- a/docs/supported-sources/starrocks.md
+++ b/docs/supported-sources/starrocks.md
@@ -1,0 +1,95 @@
+# StarRocks
+
+[StarRocks](https://www.starrocks.io/) is a high-performance analytical (OLAP) database. Alongside its own internal storage, StarRocks can query open lakehouse table formats — such as **Apache Iceberg**, **Apache Hudi**, **Apache Hive**, and **Delta Lake** — through external catalogs.
+
+ingestr supports StarRocks as a source, including tables exposed through external lakehouse catalogs.
+
+## URI format
+The URI format for StarRocks is as follows:
+
+```plaintext
+starrocks://<username>:<password>@<host>:<port>/<database>
+starrocks://<username>:<password>@<host>:<port>/<catalog>/<database>
+```
+
+URI parameters:
+- `username`: the StarRocks user (required)
+- `password`: the password for the user (optional, depending on authentication)
+- `host`: the StarRocks FE (frontend) hostname or IP address
+- `port`: the FE query port that speaks the MySQL protocol (default: `9030`)
+- `path`: the default catalog and database for unqualified table names. A single segment (`/<database>`) sets the default database and leaves the catalog at `default_catalog`; two segments (`/<catalog>/<database>`) set both. Anything specified in the source table name takes priority over these defaults.
+- `ssl` (query parameter, optional): enable a TLS-encrypted connection. Use `ssl=true` to connect over TLS and verify the server certificate (recommended for managed/cloud StarRocks), or `ssl=skip-verify` to use TLS without certificate verification.
+
+StarRocks speaks the MySQL wire protocol, so it is reached through the FE query port (`9030` by default), not the HTTP port.
+
+Example with TLS:
+
+```plaintext
+starrocks://<username>:<password>@<host>:<port>/<database>?ssl=true
+```
+
+## Table naming
+StarRocks organizes tables as `catalog.database.table`. You can specify a source table in any of these forms:
+
+```plaintext
+table                       # uses the default catalog and database from the URI
+database.table              # uses the default catalog from the URI; database overrides the URI default
+catalog.database.table      # fully qualified; overrides the URI defaults entirely
+```
+
+The table name always takes priority over the catalog/database defaults from the URI.
+
+- `default_catalog` is StarRocks' built-in internal storage.
+- Any other catalog name refers to an [external catalog](https://docs.starrocks.io/docs/data_source/catalog/catalog_overview/) you have created in StarRocks (Iceberg, Hudi, Hive, Delta Lake, JDBC, ...).
+
+## Examples
+
+### Read an internal table into DuckDB
+```bash
+ingestr ingest \
+    --source-uri 'starrocks://root:pass@localhost:9030/analytics' \
+    --source-table 'analytics.events' \
+    --dest-uri 'duckdb:///output.db' \
+    --dest-table 'main.events'
+```
+
+### Read an Iceberg table via an external catalog
+Given an Iceberg catalog named `iceberg_catalog` configured in StarRocks:
+
+```bash
+ingestr ingest \
+    --source-uri 'starrocks://root:pass@localhost:9030/analytics' \
+    --source-table 'iceberg_catalog.lakehouse.trips' \
+    --dest-uri 'postgresql://user:pass@localhost:5432/warehouse' \
+    --dest-table 'public.trips'
+```
+
+### Read a Hudi table via an external catalog
+```bash
+ingestr ingest \
+    --source-uri 'starrocks://root:pass@localhost:9030/analytics' \
+    --source-table 'hudi_catalog.lakehouse.payments' \
+    --dest-uri 'bigquery://my-project/analytics' \
+    --dest-table 'analytics.payments'
+```
+
+## Incremental loading
+StarRocks supports incremental loads. Provide an incremental key column (e.g. an event timestamp) together with `--interval-start`/`--interval-end` so each run only pulls rows in that window, and use `merge` with a primary key to upsert them:
+
+```bash
+ingestr ingest \
+    --source-uri 'starrocks://root:pass@localhost:9030/analytics' \
+    --source-table 'analytics.events' \
+    --dest-uri 'duckdb:///output.db' \
+    --dest-table 'main.events' \
+    --incremental-strategy merge \
+    --incremental-key updated_at \
+    --primary-key id \
+    --interval-start 2024-01-01 \
+    --interval-end 2024-02-01
+```
+
+The interval flags are optional. If you omit them, ingestr reads all rows and `merge` upserts them on the primary key — an idempotent full refresh rather than a windowed incremental pull.
+
+## Custom queries
+You can read the result of an arbitrary SQL query instead of a table. See [Custom Queries](/supported-sources/custom_queries.md) for details.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -356,6 +356,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("solidgate", "Solidgate", []string{"solidgate"}, true, false),
 		genericURIConnector("spanner", "Spanner", []string{"spanner"}, true, false),
 		genericURIConnector("sqs", "SQS", []string{"sqs"}, true, false),
+		genericURIConnector("starrocks", "StarRocks", []string{"starrocks"}, true, false),
 		genericURIConnector("square", "Square", []string{"square"}, true, false),
 		genericURIConnector("stripe", "Stripe", []string{"stripe"}, true, false),
 		genericURIConnector("surveymonkey", "SurveyMonkey", []string{"surveymonkey"}, true, false),

--- a/pkg/source/starrocks/mapper.go
+++ b/pkg/source/starrocks/mapper.go
@@ -9,7 +9,9 @@ import (
 )
 
 var (
-	decimalPrecisionRegex = regexp.MustCompile(`(?i)(?:decimal|decimalv2|decimal32|decimal64|decimal128|numeric)\(\s*(\d+)(?:\s*,\s*(\d+))?\s*\)`)
+	// Anchored to the start so it does not match a decimal nested inside a
+	// composite type (e.g. array<decimal(10,2)>), which must map to TypeArray.
+	decimalPrecisionRegex = regexp.MustCompile(`(?i)^(?:decimal|decimalv2|decimal32|decimal64|decimal128|numeric)\(\s*(\d+)(?:\s*,\s*(\d+))?\s*\)`)
 	arrayTypeRegex        = regexp.MustCompile(`(?i)^array<\s*(.+)\s*>$`)
 )
 

--- a/pkg/source/starrocks/mapper.go
+++ b/pkg/source/starrocks/mapper.go
@@ -1,0 +1,92 @@
+package starrocks
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+var (
+	decimalPrecisionRegex = regexp.MustCompile(`(?i)(?:decimal|decimalv2|decimal32|decimal64|decimal128|numeric)\(\s*(\d+)(?:\s*,\s*(\d+))?\s*\)`)
+	arrayTypeRegex        = regexp.MustCompile(`(?i)^array<\s*(.+)\s*>$`)
+)
+
+// MapStarRocksToDataType maps a StarRocks type to the internal DataType, taking
+// both bare wire names ("BIGINT") and parameterised forms ("decimal(10,2)").
+func MapStarRocksToDataType(starrocksType string) (schema.DataType, int, int, schema.DataType) {
+	t := strings.TrimSpace(starrocksType)
+	upper := strings.ToUpper(t)
+
+	if matches := decimalPrecisionRegex.FindStringSubmatch(t); len(matches) >= 2 {
+		precision, _ := strconv.Atoi(matches[1])
+		scale := 0
+		if len(matches) >= 3 && matches[2] != "" {
+			scale, _ = strconv.Atoi(matches[2])
+		}
+		return schema.TypeDecimal, precision, scale, schema.TypeUnknown
+	}
+
+	if matches := arrayTypeRegex.FindStringSubmatch(t); len(matches) == 2 {
+		elemType, _, _, _ := MapStarRocksToDataType(matches[1])
+		return schema.TypeArray, 0, 0, elemType
+	}
+
+	baseType := upper
+	if idx := strings.IndexAny(upper, "(<"); idx != -1 {
+		baseType = upper[:idx]
+	}
+	baseType = strings.TrimSpace(strings.TrimSuffix(baseType, " UNSIGNED"))
+
+	switch baseType {
+	case "BOOLEAN", "BOOL":
+		return schema.TypeBoolean, 0, 0, schema.TypeUnknown
+
+	case "TINYINT", "SMALLINT":
+		return schema.TypeInt16, 0, 0, schema.TypeUnknown
+	case "INT", "INTEGER":
+		return schema.TypeInt32, 0, 0, schema.TypeUnknown
+	case "BIGINT":
+		return schema.TypeInt64, 0, 0, schema.TypeUnknown
+	// LARGEINT is 128-bit; carry it as a string to avoid lossy truncation.
+	case "LARGEINT":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+
+	case "FLOAT":
+		return schema.TypeFloat32, 0, 0, schema.TypeUnknown
+	case "DOUBLE", "REAL":
+		return schema.TypeFloat64, 0, 0, schema.TypeUnknown
+
+	case "DECIMAL", "DECIMALV2", "DECIMAL32", "DECIMAL64", "DECIMAL128", "NUMERIC":
+		return schema.TypeDecimal, 38, 9, schema.TypeUnknown
+
+	case "CHAR", "VARCHAR", "STRING", "TEXT":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+
+	// StarRocks BINARY/VARBINARY columns are reported as BLOB over the MySQL wire.
+	case "BINARY", "VARBINARY", "BLOB", "TINYBLOB", "MEDIUMBLOB", "LONGBLOB":
+		return schema.TypeBinary, 0, 0, schema.TypeUnknown
+
+	case "DATE":
+		return schema.TypeDate, 0, 0, schema.TypeUnknown
+	case "DATETIME", "TIMESTAMP":
+		return schema.TypeTimestamp, 0, 0, schema.TypeUnknown
+
+	case "JSON":
+		return schema.TypeJSON, 0, 0, schema.TypeUnknown
+
+	// MAP and STRUCT come back as serialized text; expose them as JSON.
+	case "MAP", "STRUCT":
+		return schema.TypeJSON, 0, 0, schema.TypeUnknown
+	case "ARRAY":
+		return schema.TypeArray, 0, 0, schema.TypeString
+
+	// HLL/BITMAP/PERCENTILE are opaque aggregate types; surface them as strings.
+	case "HLL", "BITMAP", "PERCENTILE":
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+
+	default:
+		return schema.TypeString, 0, 0, schema.TypeUnknown
+	}
+}

--- a/pkg/source/starrocks/register.go
+++ b/pkg/source/starrocks/register.go
@@ -1,0 +1,10 @@
+package starrocks
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"starrocks"},
+		func() interface{} { return NewStarRocksSource() },
+	)
+}

--- a/pkg/source/starrocks/starrocks.go
+++ b/pkg/source/starrocks/starrocks.go
@@ -420,18 +420,20 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		}
 	}
 
-	if rowCount == 0 {
-		for _, b := range builders {
-			b.Release()
-		}
-		return nil, 0, nil
-	}
-
+	// Check rows.Err() before the empty-result return: a mid-stream error makes
+	// rows.Next() report false, which is otherwise indistinguishable from EOF.
 	if err := rows.Err(); err != nil {
 		for _, b := range builders {
 			b.Release()
 		}
 		return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if rowCount == 0 {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, nil
 	}
 
 	arrays := make([]arrow.Array, len(builders))

--- a/pkg/source/starrocks/starrocks.go
+++ b/pkg/source/starrocks/starrocks.go
@@ -1,0 +1,543 @@
+package starrocks
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// defaultCatalog is StarRocks' internal catalog; external lakehouse catalogs
+// (Iceberg/Hudi/Hive) are named as the leading part of a catalog.database.table.
+const defaultCatalog = "default_catalog"
+
+// maxDecimal128Precision is the largest precision Arrow's Decimal128 can hold.
+const maxDecimal128Precision = 38
+
+// StarRocksSource reads from StarRocks over the MySQL wire protocol. Table names
+// may be catalog.database.table; the URI path sets defaults the name overrides.
+type StarRocksSource struct {
+	db       *sql.DB
+	catalog  string
+	database string
+}
+
+func NewStarRocksSource() *StarRocksSource {
+	return &StarRocksSource{}
+}
+
+func (s *StarRocksSource) Schemes() []string {
+	return []string{"starrocks"}
+}
+
+func (s *StarRocksSource) Connect(ctx context.Context, uri string) error {
+	dsn, catalog, database, err := parseStarRocksURI(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse StarRocks URI: %w", err)
+	}
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return fmt.Errorf("failed to open StarRocks connection: %w", err)
+	}
+
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping StarRocks: %w", err)
+	}
+
+	s.db = db
+	s.catalog = catalog
+	s.database = database
+	config.Debug("[STARROCKS] Connected (catalog: %s, database: %s)", catalog, database)
+	return nil
+}
+
+func (s *StarRocksSource) Close(ctx context.Context) error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+func (s *StarRocksSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *StarRocksSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if _, ok := source.IsCustomQuery(req.Name); ok {
+		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+	}
+
+	tableSchema, err := s.getSchema(ctx, req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	pks := req.PrimaryKeys
+	if len(pks) == 0 {
+		pks = tableSchema.PrimaryKeys
+	}
+
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	tableName := req.Name
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    pks,
+		TableIncrementalKey: req.IncrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         true,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return tableSchema, nil
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, tableSchema, opts)
+		},
+	}, nil
+}
+
+// getSchema reads column metadata from a zero-row SELECT, which (unlike
+// information_schema) works for external lakehouse tables too.
+func (s *StarRocksSource) getSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	catalog, database, tableName := s.parseTableName(table)
+	if database == "" {
+		return nil, fmt.Errorf("no database resolved for table %q: provide a default in the URI path "+
+			"(starrocks://.../<database> or starrocks://.../<catalog>/<database>) "+
+			"or qualify the table name (database.table or catalog.database.table)", table)
+	}
+	fqn := buildFQN(catalog, database, tableName)
+
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0", fqn))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query schema for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	columns, err := columnsFromTypes(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("table %s not found or has no columns", table)
+	}
+
+	return &schema.TableSchema{
+		Name:    tableName,
+		Schema:  database,
+		Columns: columns,
+	}, nil
+}
+
+func columnsFromTypes(rows *sql.Rows) ([]schema.Column, error) {
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get column types: %w", err)
+	}
+
+	columns := make([]schema.Column, len(colTypes))
+	for i, ct := range colTypes {
+		dt, precision, scale, arrayType := MapStarRocksToDataType(ct.DatabaseTypeName())
+		nullable, ok := ct.Nullable()
+		if !ok {
+			nullable = true
+		}
+
+		col := schema.Column{
+			Name:      ct.Name(),
+			DataType:  dt,
+			Nullable:  nullable,
+			Precision: precision,
+			Scale:     scale,
+			ArrayType: arrayType,
+		}
+
+		if dt == schema.TypeDecimal {
+			if p, sc, ok := ct.DecimalSize(); ok {
+				col.Precision = int(p)
+				col.Scale = int(sc)
+			}
+			// StarRocks reports wider precision for aggregates (SUM) and DECIMAL256;
+			// clamp so the Decimal128 builder does not overflow its bound.
+			if col.Precision > maxDecimal128Precision {
+				col.Precision = maxDecimal128Precision
+			}
+			if col.Scale > col.Precision {
+				col.Scale = col.Precision
+			}
+		}
+		if length, ok := ct.Length(); ok && length > 0 && length < 1<<31 {
+			col.MaxLength = int(length)
+		}
+
+		columns[i] = col
+	}
+	return columns, nil
+}
+
+func (s *StarRocksSource) read(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	startTotal := time.Now()
+	config.Debug("[STARROCKS] Starting read from %s", table)
+
+	schemaToUse := tableSchema
+	if opts.Schema != nil {
+		schemaToUse = opts.Schema
+	}
+
+	columns := filterColumns(schemaToUse.Columns, opts.ExcludeColumns)
+	arrowSchema := buildArrowSchema(columns)
+
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		query := s.buildSelectQuery(table, columns, opts)
+		config.Debug("[STARROCKS] Query: %s", query)
+
+		startQuery := time.Now()
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to query: %w", err)}
+			return
+		}
+		defer func() { _ = rows.Close() }()
+		config.Debug("[STARROCKS] Query started in %v", time.Since(startQuery))
+
+		batchNum := 0
+		totalRows := int64(0)
+
+		for {
+			startBatch := time.Now()
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+
+			if count == 0 {
+				break
+			}
+
+			batchNum++
+			totalRows += count
+			config.Debug("[STARROCKS] Batch %d: %d rows read in %v (total: %d)", batchNum, count, time.Since(startBatch), totalRows)
+
+			results <- source.RecordBatchResult{Batch: record}
+		}
+
+		config.Debug("[STARROCKS] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
+	}()
+
+	return results, nil
+}
+
+func (s *StarRocksSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		config.Debug("[STARROCKS] Executing custom query: %s", query)
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to execute custom query: %w", err)}
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		columns, err := columnsFromTypes(rows)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+			return
+		}
+		arrowSchema := buildArrowSchema(columns)
+
+		for {
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+			if count == 0 {
+				break
+			}
+			results <- source.RecordBatchResult{Batch: record}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *StarRocksSource) parseTableName(table string) (catalog, database, tableName string) {
+	tn, err := tablename.StarRocks.Parse(table, tablename.Defaults{Catalog: s.catalog, Schema: s.database})
+	if err != nil {
+		return s.catalog, s.database, table
+	}
+	return tn.Catalog, tn.Schema, tn.Table
+}
+
+func quoteIdentifier(name string) string {
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
+}
+
+// buildFQN renders a backtick-quoted table reference, omitting empty leading
+// components so an unqualified table still produces valid SQL.
+func buildFQN(catalog, database, table string) string {
+	parts := make([]string, 0, 3)
+	if catalog != "" {
+		parts = append(parts, quoteIdentifier(catalog))
+	}
+	if database != "" {
+		parts = append(parts, quoteIdentifier(database))
+	}
+	parts = append(parts, quoteIdentifier(table))
+	return strings.Join(parts, ".")
+}
+
+func (s *StarRocksSource) buildSelectQuery(table string, columns []schema.Column, opts source.ReadOptions) string {
+	colNames := make([]string, len(columns))
+	for i, col := range columns {
+		colNames[i] = quoteIdentifier(col.Name)
+	}
+
+	catalog, database, tableName := s.parseTableName(table)
+	fqn := buildFQN(catalog, database, tableName)
+
+	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), fqn)
+
+	var conditions []string
+	if opts.IncrementalKey != "" {
+		if opts.IntervalStart != nil {
+			conditions = append(conditions, fmt.Sprintf("%s >= '%s'", quoteIdentifier(opts.IncrementalKey), opts.IntervalStart.Format("2006-01-02 15:04:05")))
+		}
+		if opts.IntervalEnd != nil {
+			conditions = append(conditions, fmt.Sprintf("%s <= '%s'", quoteIdentifier(opts.IncrementalKey), opts.IntervalEnd.Format("2006-01-02 15:04:05")))
+		}
+	}
+
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	if opts.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	return query
+}
+
+func filterColumns(columns []schema.Column, exclude []string) []schema.Column {
+	if len(exclude) == 0 {
+		return columns
+	}
+
+	excludeMap := make(map[string]bool)
+	for _, col := range exclude {
+		excludeMap[strings.ToLower(col)] = true
+	}
+
+	var filtered []schema.Column
+	for _, col := range columns {
+		if !excludeMap[strings.ToLower(col.Name)] {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered
+}
+
+func buildArrowSchema(columns []schema.Column) *arrow.Schema {
+	fields := make([]arrow.Field, len(columns))
+	for i, col := range columns {
+		fields[i] = arrow.Field{
+			Name:     col.Name,
+			Type:     schema.DataTypeToArrowType(col),
+			Nullable: col.Nullable,
+		}
+	}
+	return arrow.NewSchema(fields, nil)
+}
+
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+	mem := memory.NewGoAllocator()
+	builders := make([]array.Builder, len(columns))
+
+	for i, field := range arrowSchema.Fields() {
+		builders[i] = array.NewBuilder(mem, field.Type)
+	}
+
+	scanDest := make([]interface{}, len(columns))
+	for i := range columns {
+		scanDest[i] = new(interface{})
+	}
+
+	var rowCount int64
+	for rows.Next() {
+		if err := rows.Scan(scanDest...); err != nil {
+			for _, b := range builders {
+				b.Release()
+			}
+			return nil, 0, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		for i, dest := range scanDest {
+			val := *dest.(*interface{})
+			arrowconv.AppendValue(builders[i], convertValue(val))
+		}
+		rowCount++
+
+		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+	}
+
+	if rowCount == 0 {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, nil
+	}
+
+	if err := rows.Err(); err != nil {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	arrays := make([]arrow.Array, len(builders))
+	for i, b := range builders {
+		arrays[i] = b.NewArray()
+		b.Release()
+	}
+
+	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
+
+	for _, arr := range arrays {
+		arr.Release()
+	}
+
+	return record, rowCount, nil
+}
+
+func convertValue(val interface{}) interface{} {
+	switch v := val.(type) {
+	case []byte:
+		return string(v)
+	default:
+		return val
+	}
+}
+
+// parseStarRocksURI converts a starrocks:// URI to a go-sql-driver/mysql DSN.
+// Path [catalog/]database: one segment is the database, two are catalog/database.
+func parseStarRocksURI(uri string) (dsn, catalog, database string, err error) {
+	u, parseErr := url.Parse(uri)
+	if parseErr != nil {
+		return "", "", "", parseErr
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	port := u.Port()
+	if port == "" {
+		// StarRocks FE MySQL protocol (query) port.
+		port = "9030"
+	}
+
+	var user, password string
+	if u.User != nil {
+		user = u.User.Username()
+		password, _ = u.User.Password()
+	}
+
+	catalog = defaultCatalog
+	if trimmed := strings.Trim(u.Path, "/"); trimmed != "" {
+		parts := strings.Split(trimmed, "/")
+		if len(parts) == 1 {
+			database = parts[0]
+		} else {
+			catalog = parts[0]
+			database = parts[1]
+		}
+	}
+
+	query := u.Query()
+	if tlsErr := applyTLSParams(query); tlsErr != nil {
+		return "", "", "", tlsErr
+	}
+
+	dsn = ""
+	if user != "" {
+		dsn = user
+		if password != "" {
+			dsn += ":" + password
+		}
+		dsn += "@"
+	}
+	// Omit the database from the DSN: pinning it makes the driver run USE <db> on
+	// connect, which fails for databases that live in external catalogs.
+	dsn += fmt.Sprintf("tcp(%s:%s)/", host, port)
+
+	query.Set("parseTime", "true")
+	dsn += "?" + query.Encode()
+
+	return dsn, catalog, database, nil
+}
+
+// applyTLSParams maps a user-facing `ssl` parameter to go-sql-driver's `tls`
+// (a raw `tls` passes through). Unknown values are rejected, not downgraded.
+func applyTLSParams(query url.Values) error {
+	if query.Has("tls") {
+		query.Del("ssl")
+		return nil
+	}
+
+	ssl := strings.ToLower(strings.TrimSpace(query.Get("ssl")))
+	query.Del("ssl")
+
+	switch ssl {
+	case "", "false", "0", "disable", "disabled":
+		// plaintext; nothing to set
+	case "true", "1", "enable", "enabled", "require", "required":
+		query.Set("tls", "true")
+	case "skip-verify", "skip_verify", "insecure":
+		query.Set("tls", "skip-verify")
+	default:
+		return fmt.Errorf("invalid ssl value %q: use true, false, or skip-verify", ssl)
+	}
+	return nil
+}
+
+var _ source.Source = (*StarRocksSource)(nil)

--- a/pkg/source/starrocks/starrocks_test.go
+++ b/pkg/source/starrocks/starrocks_test.go
@@ -1,0 +1,239 @@
+package starrocks
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestParseStarRocksURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantDSN      string
+		wantCatalog  string
+		wantDatabase string
+	}{
+		{
+			name:         "database only path",
+			uri:          "starrocks://root:pass@fe-host:9030/analytics",
+			wantDSN:      "root:pass@tcp(fe-host:9030)/?parseTime=true",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "analytics",
+		},
+		{
+			name:         "catalog and database path",
+			uri:          "starrocks://root:pass@host:9030/iceberg_catalog/lake",
+			wantDSN:      "root:pass@tcp(host:9030)/?parseTime=true",
+			wantCatalog:  "iceberg_catalog",
+			wantDatabase: "lake",
+		},
+		{
+			name:         "no path leaves both empty/default",
+			uri:          "starrocks://root@host:9030/",
+			wantDSN:      "root@tcp(host:9030)/?parseTime=true",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "",
+		},
+		{
+			name:         "default port",
+			uri:          "starrocks://root@localhost/db",
+			wantDSN:      "root@tcp(localhost:9030)/?parseTime=true",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "db",
+		},
+		{
+			name:         "ssl true maps to tls verify",
+			uri:          "starrocks://root@host:9030/db?ssl=true",
+			wantDSN:      "root@tcp(host:9030)/?parseTime=true&tls=true",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "db",
+		},
+		{
+			name:         "ssl skip-verify maps to tls skip-verify",
+			uri:          "starrocks://root@host:9030/db?ssl=skip-verify",
+			wantDSN:      "root@tcp(host:9030)/?parseTime=true&tls=skip-verify",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "db",
+		},
+		{
+			name:         "explicit tls param passes through",
+			uri:          "starrocks://root@host:9030/db?tls=custom",
+			wantDSN:      "root@tcp(host:9030)/?parseTime=true&tls=custom",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "db",
+		},
+		{
+			name:         "ssl false leaves connection plaintext",
+			uri:          "starrocks://root@host:9030/db?ssl=false",
+			wantDSN:      "root@tcp(host:9030)/?parseTime=true",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn, catalog, database, err := parseStarRocksURI(tt.uri)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dsn != tt.wantDSN {
+				t.Errorf("dsn: got %q want %q", dsn, tt.wantDSN)
+			}
+			if catalog != tt.wantCatalog {
+				t.Errorf("catalog: got %q want %q", catalog, tt.wantCatalog)
+			}
+			if database != tt.wantDatabase {
+				t.Errorf("database: got %q want %q", database, tt.wantDatabase)
+			}
+		})
+	}
+}
+
+func TestParseStarRocksURIInvalidSSL(t *testing.T) {
+	_, _, _, err := parseStarRocksURI("starrocks://root@host:9030/db?ssl=yes")
+	if err == nil {
+		t.Fatal("expected an error for an invalid ssl value")
+	}
+	if !strings.Contains(err.Error(), "invalid ssl value") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseTableName(t *testing.T) {
+	tests := []struct {
+		name         string
+		srcCatalog   string
+		srcDatabase  string
+		table        string
+		wantCatalog  string
+		wantDatabase string
+		wantTable    string
+	}{
+		// URI defaults applied to unqualified names.
+		{"bare name uses uri defaults", defaultCatalog, "analytics", "events", defaultCatalog, "analytics", "events"},
+		// Two-part name overrides the database, keeps the URI catalog.
+		{"db.table overrides database", defaultCatalog, "analytics", "sales.orders", defaultCatalog, "sales", "orders"},
+		// Three-part name overrides everything.
+		{"full name overrides all", defaultCatalog, "analytics", "iceberg_catalog.lake.trips", "iceberg_catalog", "lake", "trips"},
+		// URI carries a catalog default; a bare name inherits it.
+		{"bare name inherits uri catalog", "iceberg_catalog", "lake", "trips", "iceberg_catalog", "lake", "trips"},
+		// URI catalog default with a two-part name: catalog from URI, db from name.
+		{"db.table under uri catalog", "iceberg_catalog", "lake", "other.trips", "iceberg_catalog", "other", "trips"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StarRocksSource{catalog: tt.srcCatalog, database: tt.srcDatabase}
+			catalog, database, table := s.parseTableName(tt.table)
+			if catalog != tt.wantCatalog || database != tt.wantDatabase || table != tt.wantTable {
+				t.Errorf("got (%q, %q, %q) want (%q, %q, %q)",
+					catalog, database, table, tt.wantCatalog, tt.wantDatabase, tt.wantTable)
+			}
+		})
+	}
+}
+
+func TestGetSchemaRequiresDatabase(t *testing.T) {
+	// No URI database and a bare table name: the database cannot be resolved, so
+	// getSchema must fail early with a clear message instead of issuing malformed
+	// SQL. The guard fires before any DB call, so a nil connection is fine.
+	s := &StarRocksSource{catalog: defaultCatalog, database: ""}
+	_, err := s.getSchema(context.Background(), "events")
+	if err == nil {
+		t.Fatal("expected an error when no database can be resolved")
+	}
+	if !strings.Contains(err.Error(), "no database resolved") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildSelectQuery(t *testing.T) {
+	s := &StarRocksSource{catalog: defaultCatalog, database: "analytics"}
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "created_at", DataType: schema.TypeTimestamp},
+	}
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 31, 23, 59, 59, 0, time.UTC)
+	opts := source.ReadOptions{IncrementalKey: "created_at", IntervalStart: &start, IntervalEnd: &end}
+
+	got := s.buildSelectQuery("iceberg_catalog.lake.trips", columns, opts)
+	want := "SELECT `id`, `created_at` FROM `iceberg_catalog`.`lake`.`trips` " +
+		"WHERE `created_at` >= '2024-01-01 00:00:00' AND `created_at` <= '2024-01-31 23:59:59'"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestBuildSelectQueryLimit(t *testing.T) {
+	s := &StarRocksSource{catalog: defaultCatalog, database: "analytics"}
+	columns := []schema.Column{{Name: "id", DataType: schema.TypeInt64}}
+	got := s.buildSelectQuery("events", columns, source.ReadOptions{Limit: 10})
+	want := "SELECT `id` FROM `default_catalog`.`analytics`.`events` LIMIT 10"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestMapStarRocksToDataType(t *testing.T) {
+	tests := []struct {
+		in        string
+		want      schema.DataType
+		precision int
+		scale     int
+		arrayType schema.DataType
+	}{
+		{"BOOLEAN", schema.TypeBoolean, 0, 0, schema.TypeUnknown},
+		{"TINYINT", schema.TypeInt16, 0, 0, schema.TypeUnknown},
+		{"INT", schema.TypeInt32, 0, 0, schema.TypeUnknown},
+		{"BIGINT", schema.TypeInt64, 0, 0, schema.TypeUnknown},
+		{"LARGEINT", schema.TypeString, 0, 0, schema.TypeUnknown},
+		{"FLOAT", schema.TypeFloat32, 0, 0, schema.TypeUnknown},
+		{"DOUBLE", schema.TypeFloat64, 0, 0, schema.TypeUnknown},
+		{"decimal(18,4)", schema.TypeDecimal, 18, 4, schema.TypeUnknown},
+		{"DECIMAL", schema.TypeDecimal, 38, 9, schema.TypeUnknown},
+		{"VARCHAR(255)", schema.TypeString, 0, 0, schema.TypeUnknown},
+		{"STRING", schema.TypeString, 0, 0, schema.TypeUnknown},
+		{"DATE", schema.TypeDate, 0, 0, schema.TypeUnknown},
+		{"DATETIME", schema.TypeTimestamp, 0, 0, schema.TypeUnknown},
+		{"VARBINARY", schema.TypeBinary, 0, 0, schema.TypeUnknown},
+		{"BLOB", schema.TypeBinary, 0, 0, schema.TypeUnknown},
+		{"JSON", schema.TypeJSON, 0, 0, schema.TypeUnknown},
+		{"array<int>", schema.TypeArray, 0, 0, schema.TypeInt32},
+		{"map<string,int>", schema.TypeJSON, 0, 0, schema.TypeUnknown},
+		{"struct<a:int>", schema.TypeJSON, 0, 0, schema.TypeUnknown},
+		{"HLL", schema.TypeString, 0, 0, schema.TypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			dt, precision, scale, arrayType := MapStarRocksToDataType(tt.in)
+			if dt != tt.want || precision != tt.precision || scale != tt.scale || arrayType != tt.arrayType {
+				t.Errorf("got (%v, %d, %d, %v) want (%v, %d, %d, %v)",
+					dt, precision, scale, arrayType, tt.want, tt.precision, tt.scale, tt.arrayType)
+			}
+		})
+	}
+}
+
+func TestBuildFQN(t *testing.T) {
+	if got := buildFQN("", "", "t"); got != "`t`" {
+		t.Errorf("bare table: got %q", got)
+	}
+	if got := buildFQN("", "db", "t"); got != "`db`.`t`" {
+		t.Errorf("db.table: got %q", got)
+	}
+	if got := buildFQN("cat", "db", "t"); got != "`cat`.`db`.`t`" {
+		t.Errorf("cat.db.table: got %q", got)
+	}
+	if got := buildFQN("cat", "db", "a`b"); !strings.Contains(got, "`a``b`") {
+		t.Errorf("escaping: got %q", got)
+	}
+}

--- a/pkg/source/starrocks/starrocks_test.go
+++ b/pkg/source/starrocks/starrocks_test.go
@@ -207,6 +207,7 @@ func TestMapStarRocksToDataType(t *testing.T) {
 		{"BLOB", schema.TypeBinary, 0, 0, schema.TypeUnknown},
 		{"JSON", schema.TypeJSON, 0, 0, schema.TypeUnknown},
 		{"array<int>", schema.TypeArray, 0, 0, schema.TypeInt32},
+		{"array<decimal(10,2)>", schema.TypeArray, 0, 0, schema.TypeDecimal},
 		{"map<string,int>", schema.TypeJSON, 0, 0, schema.TypeUnknown},
 		{"struct<a:int>", schema.TypeJSON, 0, 0, schema.TypeUnknown},
 		{"HLL", schema.TypeString, 0, 0, schema.TypeUnknown},

--- a/pkg/tablename/capabilities.go
+++ b/pkg/tablename/capabilities.go
@@ -41,6 +41,13 @@ var (
 		Labels: [3]string{"catalog", "schema", "table"}, FormatDesc: "catalog.schema.table",
 	}
 
+	// StarRocks: catalog.database.table (catalog selects the internal store or an
+	// external lakehouse catalog such as Iceberg/Hudi/Hive).
+	StarRocks = Capability{
+		Platform: "starrocks", MinComponents: 1, MaxComponents: 3,
+		Labels: [3]string{"catalog", "database", "table"}, FormatDesc: "catalog.database.table",
+	}
+
 	// DuckDB / MotherDuck: catalog.schema.table (catalog = attached database).
 	DuckDB = Capability{
 		Platform: "duckdb", MinComponents: 1, MaxComponents: 3,

--- a/tests/integration/starrocks_container_test.go
+++ b/tests/integration/starrocks_container_test.go
@@ -1,0 +1,209 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// Runs as part of `make test-integration`. The all-in-one image is slow to boot,
+// so this test manages its own container instead of the shared TestMain.
+func startStarRocksContainer(ctx context.Context, t *testing.T) (dsn, uri string) {
+	t.Helper()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "starrocks/allin1-ubuntu:3.3-latest",
+			ExposedPorts: []string{"9030/tcp"},
+			WaitingFor:   wait.ForListeningPort("9030/tcp").WithStartupTimeout(300 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "9030")
+	require.NoError(t, err)
+
+	dsn = fmt.Sprintf("root@tcp(%s:%s)/", host, port.Port())
+	uri = fmt.Sprintf("starrocks://root@%s:%s/", host, port.Port())
+	return dsn, uri
+}
+
+// waitForStarRocksBackend blocks until a backend reports Alive=true; the FE
+// accepts connections before the BE registers, and writes fail until it does.
+func waitForStarRocksBackend(t *testing.T, dsn string) {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	deadline := time.Now().Add(180 * time.Second)
+	for time.Now().Before(deadline) {
+		if starRocksBackendAlive(db) {
+			return
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatal("StarRocks backend did not become alive within the deadline")
+}
+
+func starRocksBackendAlive(db *sql.DB) bool {
+	rows, err := db.Query("SHOW BACKENDS")
+	if err != nil {
+		return false
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return false
+	}
+	aliveIdx := -1
+	for i, c := range cols {
+		if strings.EqualFold(c, "Alive") {
+			aliveIdx = i
+		}
+	}
+	if aliveIdx == -1 {
+		return false
+	}
+
+	for rows.Next() {
+		cells := make([]sql.RawBytes, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range cells {
+			ptrs[i] = &cells[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return false
+		}
+		if strings.EqualFold(string(cells[aliveIdx]), "true") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestStarRocksToSQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dsn, baseURI := startStarRocksContainer(ctx, t)
+	waitForStarRocksBackend(t, dsn)
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec("CREATE DATABASE IF NOT EXISTS analytics")
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE analytics.events (
+		id BIGINT, name VARCHAR(100), active BOOLEAN, score DOUBLE,
+		amount DECIMAL(18,4), big LARGEINT, created_date DATE, updated_at DATETIME
+	) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num'='1')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO analytics.events VALUES
+		(1,'alpha',true,9.5,100.2500,170141183460469231731687303715884105727,'2024-01-01','2024-01-01 08:30:00'),
+		(2,'beta',false,3.25,50.0000,-12345,'2024-01-15','2024-01-15 12:00:00'),
+		(3,'gamma',true,0.0,0.0001,42,'2024-02-01','2024-02-01 23:59:59')`)
+	require.NoError(t, err)
+
+	tmp, err := os.CreateTemp("", "sr_*.db")
+	require.NoError(t, err)
+	_ = tmp.Close()
+	t.Cleanup(func() { _ = os.Remove(tmp.Name()) })
+	destURI := fmt.Sprintf("sqlite:///%s", tmp.Name())
+
+	t.Run("full table", func(t *testing.T) {
+		cfg := &config.IngestConfig{
+			SourceURI:           baseURI,
+			SourceTable:         "analytics.events",
+			DestURI:             destURI,
+			DestTable:           "events",
+			IncrementalStrategy: config.StrategyReplace,
+		}
+		require.NoError(t, cfg.Validate())
+		require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+		sq, err := sql.Open("sqlite3", tmp.Name())
+		require.NoError(t, err)
+		defer func() { _ = sq.Close() }()
+
+		var count int
+		require.NoError(t, sq.QueryRow("SELECT COUNT(*) FROM events").Scan(&count))
+		assert.Equal(t, 3, count)
+
+		var name, big string
+		var amount float64
+		require.NoError(t, sq.QueryRow("SELECT name, amount, big FROM events WHERE id=1").Scan(&name, &amount, &big))
+		assert.Equal(t, "alpha", name)
+		assert.InDelta(t, 100.25, amount, 0.0001)
+		// LARGEINT exceeds int64/float64 range and must round-trip as a string.
+		assert.Equal(t, "170141183460469231731687303715884105727", big)
+	})
+
+	t.Run("three part name and custom query", func(t *testing.T) {
+		cfg := &config.IngestConfig{
+			SourceURI:           baseURI,
+			SourceTable:         "query:SELECT active, count(*) AS cnt, sum(amount) AS total FROM default_catalog.analytics.events GROUP BY active",
+			DestURI:             destURI,
+			DestTable:           "by_active",
+			IncrementalStrategy: config.StrategyReplace,
+		}
+		require.NoError(t, cfg.Validate())
+		require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+		sq, err := sql.Open("sqlite3", tmp.Name())
+		require.NoError(t, err)
+		defer func() { _ = sq.Close() }()
+
+		var groups int
+		require.NoError(t, sq.QueryRow("SELECT COUNT(*) FROM by_active").Scan(&groups))
+		assert.Equal(t, 2, groups)
+	})
+
+	t.Run("incremental by interval", func(t *testing.T) {
+		janStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		janEnd := time.Date(2024, 1, 31, 23, 59, 59, 0, time.UTC)
+		cfg := &config.IngestConfig{
+			SourceURI:           baseURI,
+			SourceTable:         "analytics.events",
+			DestURI:             destURI,
+			DestTable:           "events_incr",
+			IncrementalStrategy: config.StrategyMerge,
+			IncrementalKey:      "updated_at",
+			PrimaryKeys:         []string{"id"},
+			IntervalStart:       &janStart,
+			IntervalEnd:         &janEnd,
+		}
+		require.NoError(t, cfg.Validate())
+		require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+		sq, err := sql.Open("sqlite3", tmp.Name())
+		require.NoError(t, err)
+		defer func() { _ = sq.Close() }()
+
+		var count int
+		require.NoError(t, sq.QueryRow("SELECT COUNT(*) FROM events_incr").Scan(&count))
+		assert.Equal(t, 2, count) // only the two January rows fall in the window
+	})
+}

--- a/tests/integration/starrocks_container_test.go
+++ b/tests/integration/starrocks_container_test.go
@@ -29,7 +29,13 @@ func startStarRocksContainer(ctx context.Context, t *testing.T) (dsn, uri string
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "starrocks/allin1-ubuntu:3.3-latest",
 			ExposedPorts: []string{"9030/tcp"},
-			WaitingFor:   wait.ForListeningPort("9030/tcp").WithStartupTimeout(300 * time.Second),
+			// Relax the backend disk-flood thresholds before startup: the defaults
+			// (~1 GiB free / <95% used) mark the BE unavailable for tablet placement
+			// on disk-constrained CI runners, so CREATE TABLE finds no usable backend.
+			Cmd: []string{"/bin/sh", "-c", "echo 'storage_flood_stage_usage_percent=99' >> /data/deploy/starrocks/be/conf/be.conf && " +
+				"echo 'storage_flood_stage_left_capacity_bytes=104857600' >> /data/deploy/starrocks/be/conf/be.conf && " +
+				"cd /data/deploy && ./entrypoint.sh"},
+			WaitingFor: wait.ForListeningPort("9030/tcp").WithStartupTimeout(300 * time.Second),
 		},
 		Started: true,
 	})
@@ -101,6 +107,22 @@ func starRocksBackendAlive(db *sql.DB) bool {
 	return false
 }
 
+// execEventually runs stmt, retrying until it succeeds or the deadline passes.
+func execEventually(t *testing.T, db *sql.DB, stmt string) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if _, err := db.Exec(stmt); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("statement did not succeed within deadline: %v\nstatement: %s", lastErr, stmt)
+}
+
 func TestStarRocksToSQLite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -114,13 +136,13 @@ func TestStarRocksToSQLite(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	_, err = db.Exec("CREATE DATABASE IF NOT EXISTS analytics")
-	require.NoError(t, err)
-	_, err = db.Exec(`CREATE TABLE analytics.events (
+	execEventually(t, db, "CREATE DATABASE IF NOT EXISTS analytics")
+	// CREATE TABLE can briefly fail with "no available backend" right after the
+	// BE reports alive but before its disk capacity propagates to the FE.
+	execEventually(t, db, `CREATE TABLE IF NOT EXISTS analytics.events (
 		id BIGINT, name VARCHAR(100), active BOOLEAN, score DOUBLE,
 		amount DECIMAL(18,4), big LARGEINT, created_date DATE, updated_at DATETIME
 	) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num'='1')`)
-	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO analytics.events VALUES
 		(1,'alpha',true,9.5,100.2500,170141183460469231731687303715884105727,'2024-01-01','2024-01-01 08:30:00'),
 		(2,'beta',false,3.25,50.0000,-12345,'2024-01-15','2024-01-15 12:00:00'),


### PR DESCRIPTION
## Summary

Adds **StarRocks** as a source (issue #867), including its ability to federate open lakehouse table formats — **Apache Iceberg, Hudi, Hive, and Delta Lake** — through external catalogs.

StarRocks speaks the MySQL wire protocol, so the source reuses the `go-sql-driver/mysql` transport, but the source logic is StarRocks-specific (catalogs, type system, schema discovery).

## What it does

- **Lakehouse via external catalogs**: tables are addressed as `catalog.database.table`. `default_catalog` is the internal store; any other catalog is an external Iceberg/Hudi/Hive/Delta catalog configured in StarRocks.
- **Schema discovery** via a zero-row `SELECT` probe — works uniformly for internal and external-catalog tables, where `information_schema` is not reliably populated.
- **Type mapping**: `LARGEINT`/`HLL`/`BITMAP`/`PERCENTILE` → string (no lossy truncation), `ARRAY`/`MAP`/`STRUCT`/`JSON` → JSON, decimals clamped to Arrow `Decimal128`'s max precision (38) so aggregate/`DECIMAL256` widening can't overflow.
- **URI**: `starrocks://user:pass@host:9030/[catalog/]database`. The path sets optional catalog/database defaults; the table name overrides them. Optional `?ssl=true|skip-verify` for TLS (managed/cloud StarRocks).
- Incremental (`merge` + interval), custom queries, and column exclusion supported.