### PR TITLE
feat: add --progress json structured output mode

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
@@ -102,7 +104,7 @@ func IngestCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "progress",
-				Usage:   "The progress display type (interactive, log)",
+				Usage:   "The progress display type (interactive, log, json)",
 				Value:   "interactive",
 				Sources: cli.EnvVars("PROGRESS", "INGESTR_PROGRESS"),
 			},
@@ -221,10 +223,16 @@ func IngestCommand() *cli.Command {
 func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	trackCommandTriggered(ctx, "ingest")
 	defer func() {
+		output.EnsureTerminal(err)
 		trackCommandFinished(ctx, "ingest", err)
 	}()
 
 	config.DebugMode = c.Bool("debug")
+	outputMode := output.ModeText
+	if config.ProgressMode(c.String("progress")) == config.ProgressJSON {
+		outputMode = output.ModeJSON
+	}
+	output.Init(os.Stdout, os.Stderr, outputMode)
 	cfg := config.DefaultConfig()
 
 	cfg.SourceURI = c.String("source-uri")
@@ -319,13 +327,17 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 		// In streaming mode, cancellation (SIGINT/SIGTERM) is the normal way to
 		// stop; the pipeline has already flushed pending data.
 		if cfg.Stream {
-			color.Green("Streaming ingestion stopped.")
+			if !output.IsJSON() {
+				color.Green("Streaming ingestion stopped.")
+			}
 			return nil
 		}
 		return ctx.Err()
 	}
 
-	color.Green("Ingestion completed successfully!")
+	if !output.IsJSON() {
+		color.Green("Ingestion completed successfully!")
+	}
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/bruin-data/ingestr/internal/output"
 )
 
 var DebugMode bool
 
-func Debug(format string, args ...interface{}) {
+func Debug(format string, args ...any) {
 	if DebugMode {
-		fmt.Printf("%s\tDEBUG\t%s\n", time.Now().Format("2006-01-02T15:04:05.000Z0700"), fmt.Sprintf(format, args...))
+		line := fmt.Sprintf("%s\tDEBUG\t%s\n", time.Now().Format("2006-01-02T15:04:05.000Z0700"), fmt.Sprintf(format, args...))
+		output.WriteDebug(line)
 	}
 }
 
@@ -31,6 +34,7 @@ type ProgressMode string
 const (
 	ProgressInteractive ProgressMode = "interactive"
 	ProgressLog         ProgressMode = "log"
+	ProgressJSON        ProgressMode = "json"
 )
 
 type IngestConfig struct {

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -5,12 +5,27 @@ import (
 	"strings"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/fatih/color"
 )
 
 func PrintSummary(cfg *config.IngestConfig) {
+	if output.IsJSON() {
+		output.EventStart(output.StartInfo{
+			SourceType:     displayFromURI(cfg.SourceURI)[0],
+			DestType:       displayFromURI(cfg.DestURI)[0],
+			SourceTable:    cfg.SourceTable,
+			DestTable:      cfg.DestTable,
+			Strategy:       string(cfg.IncrementalStrategy),
+			IncrementalKey: cfg.IncrementalKey,
+			PrimaryKey:     cfg.PrimaryKeys,
+			SchemaNaming:   cfg.SchemaNaming,
+		})
+		return
+	}
+
 	green := color.New(color.FgGreen, color.Bold).SprintFunc()
 	yellow := color.New(color.FgYellow, color.Bold).SprintFunc()
 	magenta := color.New(color.FgMagenta).SprintFunc()

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,218 @@
+// Package output centralizes all user-facing process output for the ingestr CLI.
+//
+// It exposes a single seam through which warnings, informational lines, lifecycle
+// events, and debug logging flow. In text mode (the default) it reproduces the
+// historical fmt/color behavior verbatim. In JSON mode it emits one structured
+// JSON object per line to stdout via log/slog, so jq pipelines and orchestrators
+// can consume a clean, machine-readable stream. Debug output goes to stderr in
+// JSON mode so stdout stays pure JSON.
+//
+// This package is a leaf: it imports only the standard library so that lower-level
+// packages (e.g. internal/config) can delegate to it without creating an import
+// cycle. It deliberately defines its own Mode type rather than referencing
+// config.ProgressMode.
+package output
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// Mode selects how output is rendered.
+type Mode int
+
+const (
+	// ModeText renders human-readable output (the historical behavior).
+	ModeText Mode = iota
+	// ModeJSON renders one JSON object per line to stdout.
+	ModeJSON
+)
+
+// Event discriminator values written as the "event" attribute of every JSON record.
+const (
+	eventStart    = "start"
+	eventProgress = "progress"
+	eventEnd      = "end"
+	eventLog      = "log"
+)
+
+var (
+	stdoutW io.Writer = os.Stdout
+	stderrW io.Writer = os.Stderr
+	mode              = ModeText
+	logger            = newJSONLogger(os.Stdout)
+
+	// terminalEmitted guards the "exactly one terminal end event" invariant.
+	terminalEmitted atomic.Bool
+)
+
+// newJSONLogger builds a slog logger that writes JSON lines to w, renaming the
+// built-in "time" attribute to "ts". No buffering, so os.Exit cannot drop a line.
+func newJSONLogger(w io.Writer) *slog.Logger {
+	h := slog.NewJSONHandler(w, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) == 0 && a.Key == slog.TimeKey {
+				a.Key = "ts"
+			}
+			return a
+		},
+	})
+	return slog.New(h)
+}
+
+// Init configures the output writers and mode. It must be called once, early,
+// before any concurrent output is produced. Tests inject buffers via this entry
+// point. If Init is never called (e.g. the server command), the package defaults
+// to text mode on os.Stdout/os.Stderr.
+func Init(stdout, stderr io.Writer, m Mode) {
+	stdoutW = stdout
+	stderrW = stderr
+	mode = m
+	logger = newJSONLogger(stdout)
+	terminalEmitted.Store(false)
+}
+
+// IsJSON reports whether output is in JSON mode.
+func IsJSON() bool { return mode == ModeJSON }
+
+// Warnf reports a warning. Text mode: written verbatim to stdout. JSON mode: a
+// {"event":"log","level":"WARN",...} record.
+func Warnf(format string, args ...any) { emitLog(slog.LevelWarn, fmt.Sprintf(format, args...)) }
+
+// Infof reports an informational line (e.g. a schema-change notice).
+func Infof(format string, args ...any) { emitLog(slog.LevelInfo, fmt.Sprintf(format, args...)) }
+
+// Errorf reports an error line.
+func Errorf(format string, args ...any) { emitLog(slog.LevelError, fmt.Sprintf(format, args...)) }
+
+// Statusf reports decorative status chatter (e.g. staging-table messages). Text
+// mode: written verbatim to stdout. JSON mode: suppressed, since the structured
+// lifecycle events already convey progress.
+func Statusf(format string, args ...any) {
+	if mode == ModeJSON {
+		return
+	}
+	_, _ = fmt.Fprintf(stdoutW, format, args...)
+}
+
+func emitLog(level slog.Level, msg string) {
+	if mode != ModeJSON {
+		_, _ = fmt.Fprint(stdoutW, msg)
+		return
+	}
+	logger.LogAttrs(context.Background(), level, strings.TrimRight(msg, "\n"),
+		slog.String("event", eventLog))
+}
+
+// StartInfo carries the fields of the start event. Primitive types only, so this
+// package stays a leaf.
+type StartInfo struct {
+	SourceType     string
+	DestType       string
+	SourceTable    string
+	DestTable      string
+	Strategy       string
+	IncrementalKey string
+	PrimaryKey     []string
+	SchemaNaming   string
+}
+
+// EventStart emits the start event (JSON mode only).
+func EventStart(i StartInfo) {
+	if mode != ModeJSON {
+		return
+	}
+	attrs := []slog.Attr{
+		slog.String("event", eventStart),
+		slog.String("source_type", i.SourceType),
+		slog.String("dest_type", i.DestType),
+		slog.String("source_table", i.SourceTable),
+		slog.String("dest_table", i.DestTable),
+		slog.String("strategy", i.Strategy),
+	}
+	if i.IncrementalKey != "" {
+		attrs = append(attrs, slog.String("incremental_key", i.IncrementalKey))
+	}
+	if len(i.PrimaryKey) > 0 {
+		attrs = append(attrs, slog.Any("primary_key", i.PrimaryKey))
+	}
+	if i.SchemaNaming != "" {
+		attrs = append(attrs, slog.String("schema_naming", i.SchemaNaming))
+	}
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "ingestion started", attrs...)
+}
+
+// EventProgress emits a periodic progress event (JSON mode only).
+func EventProgress(rows, batches int64, rowsPerSec, elapsedSec, cpuPercent, memMB float64) {
+	if mode != ModeJSON {
+		return
+	}
+	logger.LogAttrs(
+		context.Background(), slog.LevelInfo, "progress",
+		slog.String("event", eventProgress),
+		slog.Int64("rows", rows),
+		slog.Int64("batches", batches),
+		slog.Float64("rows_per_sec", rowsPerSec),
+		slog.Float64("elapsed_sec", elapsedSec),
+		slog.Float64("cpu_percent", cpuPercent),
+		slog.Float64("mem_mb", memMB),
+	)
+}
+
+// EventEnd emits the terminal end event (JSON mode only) and records that a
+// terminal event has been emitted. A non-nil err makes the event ERROR-level
+// with status "error"; otherwise it is INFO-level with status "success".
+func EventEnd(status string, rows, batches int64, durationSec float64, err error) {
+	if mode != ModeJSON {
+		return
+	}
+	level := slog.LevelInfo
+	msg := "ingestion completed"
+	var errVal any
+	if err != nil {
+		level = slog.LevelError
+		msg = "ingestion failed"
+		errVal = err.Error()
+	}
+	logger.LogAttrs(
+		context.Background(), level, msg,
+		slog.String("event", eventEnd),
+		slog.String("status", status),
+		slog.Int64("rows", rows),
+		slog.Int64("batches", batches),
+		slog.Float64("duration_sec", durationSec),
+		slog.Any("error", errVal),
+	)
+	terminalEmitted.Store(true)
+}
+
+// EnsureTerminal emits a terminal end event only if none has been emitted yet.
+// It covers exit paths that occur before a progress tracker exists (config
+// validation, source/destination connection, zero-table runs). It is idempotent
+// and a no-op in text mode.
+func EnsureTerminal(err error) {
+	if mode != ModeJSON || terminalEmitted.Load() {
+		return
+	}
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	EventEnd(status, 0, 0, 0, err)
+}
+
+// WriteDebug writes a preformatted debug line: to stderr in JSON mode (keeping
+// stdout pure JSON), to stdout otherwise. Callers are responsible for gating on
+// whether debug is enabled.
+func WriteDebug(line string) {
+	if mode == ModeJSON {
+		_, _ = fmt.Fprint(stderrW, line)
+		return
+	}
+	_, _ = fmt.Fprint(stdoutW, line)
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,236 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseLines splits buffered output into parsed JSON records, asserting that
+// every non-empty line is valid JSON (the contract jq pipelines depend on).
+func parseLines(t *testing.T, out *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &m), "line should be valid JSON: %s", line)
+		records = append(records, m)
+	}
+	return records
+}
+
+func initJSON(t *testing.T) (out, errb *bytes.Buffer) {
+	t.Helper()
+	out = &bytes.Buffer{}
+	errb = &bytes.Buffer{}
+	Init(out, errb, ModeJSON)
+	return out, errb
+}
+
+func TestWarnfJSON(t *testing.T) {
+	out, _ := initJSON(t)
+	Warnf("Warning: table %q produced no rows", "users")
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "log", recs[0]["event"])
+	assert.Equal(t, "WARN", recs[0]["level"])
+	assert.Equal(t, `Warning: table "users" produced no rows`, recs[0]["msg"])
+}
+
+func TestInfofJSON(t *testing.T) {
+	out, _ := initJSON(t)
+	Infof("Naming convention: %s", "snake_case")
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "log", recs[0]["event"])
+	assert.Equal(t, "INFO", recs[0]["level"])
+	assert.Equal(t, "Naming convention: snake_case", recs[0]["msg"])
+}
+
+func TestStatusfSuppressedInJSON(t *testing.T) {
+	out, _ := initJSON(t)
+	Statusf("[MERGE] %s | Using staging table: %s\n", "14:00:00", "stg_users")
+	assert.Empty(t, out.String(), "decorative status chatter must not appear in JSON output")
+}
+
+func TestTextModeVerbatim(t *testing.T) {
+	var out, errb bytes.Buffer
+	Init(&out, &errb, ModeText)
+
+	Warnf("Warning: x\n")
+	Infof("Naming: y\n")
+	Statusf("[MERGE] %s | z\n", "14:00:00")
+
+	assert.Equal(t, "Warning: x\nNaming: y\n[MERGE] 14:00:00 | z\n", out.String())
+	assert.Empty(t, errb.String())
+}
+
+func TestWriteDebugRouting(t *testing.T) {
+	// JSON mode: debug goes to stderr so stdout stays pure JSON.
+	out, errb := initJSON(t)
+	WriteDebug("2026-06-30T00:00:00.000Z\tDEBUG\thello\n")
+	assert.Empty(t, out.String())
+	assert.Contains(t, errb.String(), "DEBUG\thello")
+
+	// Text mode: debug goes to stdout (historical behavior).
+	var o2, e2 bytes.Buffer
+	Init(&o2, &e2, ModeText)
+	WriteDebug("dbg\n")
+	assert.Equal(t, "dbg\n", o2.String())
+	assert.Empty(t, e2.String())
+}
+
+func TestTimestampRenamedToTS(t *testing.T) {
+	out, _ := initJSON(t)
+	Infof("hello")
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	assert.Contains(t, recs[0], "ts")
+	assert.NotContains(t, recs[0], "time")
+}
+
+func TestEventStart(t *testing.T) {
+	out, _ := initJSON(t)
+	EventStart(StartInfo{
+		SourceType:     "postgres",
+		DestType:       "bigquery",
+		SourceTable:    "public.users",
+		DestTable:      "users",
+		Strategy:       "merge",
+		IncrementalKey: "updated_at",
+		PrimaryKey:     []string{"id"},
+		SchemaNaming:   "default",
+	})
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	r := recs[0]
+	assert.Equal(t, "start", r["event"])
+	assert.Equal(t, "postgres", r["source_type"])
+	assert.Equal(t, "bigquery", r["dest_type"])
+	assert.Equal(t, "public.users", r["source_table"])
+	assert.Equal(t, "users", r["dest_table"])
+	assert.Equal(t, "merge", r["strategy"])
+	assert.Equal(t, "updated_at", r["incremental_key"])
+	assert.Equal(t, []any{"id"}, r["primary_key"])
+}
+
+func TestEventStartOmitsEmptyOptionals(t *testing.T) {
+	out, _ := initJSON(t)
+	EventStart(StartInfo{SourceType: "csv", DestType: "duckdb", Strategy: "replace"})
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	assert.NotContains(t, recs[0], "incremental_key")
+	assert.NotContains(t, recs[0], "primary_key")
+	assert.NotContains(t, recs[0], "schema_naming")
+}
+
+func TestEventProgress(t *testing.T) {
+	out, _ := initJSON(t)
+	EventProgress(12345, 12, 4200, 2.9, 35.2, 512)
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	r := recs[0]
+	assert.Equal(t, "progress", r["event"])
+	assert.EqualValues(t, 12345, r["rows"])
+	assert.EqualValues(t, 12, r["batches"])
+	assert.EqualValues(t, 4200, r["rows_per_sec"])
+	assert.EqualValues(t, 2.9, r["elapsed_sec"])
+	assert.NotContains(t, r, "error")
+}
+
+func TestEventEndSuccess(t *testing.T) {
+	out, _ := initJSON(t)
+	EventEnd("success", 50000, 50, 11.8, nil)
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	r := recs[0]
+	assert.Equal(t, "end", r["event"])
+	assert.Equal(t, "success", r["status"])
+	assert.Equal(t, "INFO", r["level"])
+	assert.EqualValues(t, 50000, r["rows"])
+	assert.Nil(t, r["error"])
+}
+
+func TestEventEndError(t *testing.T) {
+	out, _ := initJSON(t)
+	EventEnd("error", 123, 1, 3.1, errors.New("boom"))
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	r := recs[0]
+	assert.Equal(t, "end", r["event"])
+	assert.Equal(t, "error", r["status"])
+	assert.Equal(t, "ERROR", r["level"])
+	assert.Equal(t, "boom", r["error"])
+}
+
+func TestEnsureTerminalIdempotent(t *testing.T) {
+	out, _ := initJSON(t)
+	EventEnd("success", 10, 1, 1.0, nil)
+	EnsureTerminal(nil)
+
+	recs := parseLines(t, out)
+	ends := 0
+	for _, r := range recs {
+		if r["event"] == "end" {
+			ends++
+		}
+	}
+	assert.Equal(t, 1, ends, "EnsureTerminal must not emit a second end event")
+}
+
+func TestEnsureTerminalEmitsWhenNone(t *testing.T) {
+	out, _ := initJSON(t)
+	EnsureTerminal(errors.New("validation failed"))
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "end", recs[0]["event"])
+	assert.Equal(t, "error", recs[0]["status"])
+	assert.Equal(t, "validation failed", recs[0]["error"])
+}
+
+func TestEnsureTerminalNoopInTextMode(t *testing.T) {
+	var out, errb bytes.Buffer
+	Init(&out, &errb, ModeText)
+	EnsureTerminal(errors.New("boom"))
+	assert.Empty(t, out.String())
+	assert.Empty(t, errb.String())
+}
+
+// TestEveryLineIsJSON is the contract guard: a realistic mixed sequence must
+// produce a stdout stream where every line parses as JSON and carries an event
+// discriminator, and decorative Statusf output is absent.
+func TestEveryLineIsJSON(t *testing.T) {
+	out, _ := initJSON(t)
+	EventStart(StartInfo{SourceType: "pg", DestType: "bq", Strategy: "merge"})
+	Warnf("Warning: heads up\n")
+	EventProgress(10, 1, 5, 1, 0, 0)
+	EventProgress(20, 2, 5, 2, 0, 0)
+	Statusf("decorative chatter\n")
+	EventEnd("success", 20, 2, 2.0, nil)
+
+	recs := parseLines(t, out)
+	require.Len(t, recs, 5) // start, log, progress, progress, end — Statusf produced nothing
+	for _, r := range recs {
+		assert.Contains(t, r, "event")
+	}
+	assert.Equal(t, "start", recs[0]["event"])
+	assert.Equal(t, "log", recs[1]["event"])
+	assert.Equal(t, "end", recs[4]["event"])
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bruin-data/ingestr/cmd"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/fatih/color"
 )
 
@@ -26,10 +27,14 @@ func main() {
 
 	if err := cmd.Run(ctx, os.Args); err != nil {
 		if errors.Is(err, context.Canceled) {
-			color.Red("\nPipeline cancelled.")
+			if !output.IsJSON() {
+				color.Red("\nPipeline cancelled.")
+			}
 			os.Exit(1)
 		}
-		color.Red("Error: %v", err)
+		if !output.IsJSON() {
+			color.Red("Error: %v", err)
+		}
 		config.PrintFailedQuery()
 		os.Exit(1)
 	}

--- a/pkg/destination/bigquery/mapper.go
+++ b/pkg/destination/bigquery/mapper.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -105,7 +106,7 @@ func BuildTableMetadata(tableSchema *schema.TableSchema, primaryKeys []string, l
 		// The constraint is NOT ENFORCED (informational only), and MERGE SQL
 		// keys on the in-memory PK list independently, so skipping it here is safe.
 		if len(primaryKeys) > bigQueryMaxPKColumns {
-			fmt.Printf("[WARNING] BigQuery supports at most %d primary key columns; "+
+			output.Warnf("[WARNING] BigQuery supports at most %d primary key columns; "+
 				"creating table without PRIMARY KEY constraint (got %d cols)\n",
 				bigQueryMaxPKColumns, len(primaryKeys))
 		} else {

--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -18,6 +18,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -780,7 +781,7 @@ func validateEngineType(engineType string, hasPrimaryKeys bool) (string, bool) {
 			valid = append(valid, k)
 		}
 		sort.Strings(valid)
-		fmt.Printf("[WARNING] unsupported ClickHouse engine %q, defaulting based on primary keys (valid: %s)\n", engineType, strings.Join(valid, ", "))
+		output.Warnf("[WARNING] unsupported ClickHouse engine %q, defaulting based on primary keys (valid: %s)\n", engineType, strings.Join(valid, ", "))
 	}
 	if hasPrimaryKeys {
 		return "ReplacingMergeTree()", true

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -17,6 +17,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	sfauth "github.com/bruin-data/ingestr/pkg/snowflake"
@@ -430,7 +431,7 @@ func (d *SnowflakeDestination) SwapTable(ctx context.Context, opts destination.S
 
 	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", stagingFull)
 	if _, dropErr := d.db.ExecContext(ctx, dropSQL); dropErr != nil {
-		fmt.Printf("[DEST] Warning: failed to drop old staging table after swap: %v\n", dropErr)
+		output.Warnf("[DEST] Warning: failed to drop old staging table after swap: %v\n", dropErr)
 	}
 
 	config.Debug("[DEST] Table swap completed in %v", time.Since(startSwap))

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/display"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/databuffer"
 	"github.com/bruin-data/ingestr/pkg/destination"
@@ -54,7 +55,7 @@ func (p *Pipeline) SetLogWriter(w io.Writer) {
 	p.logWriter = w
 }
 
-func (p *Pipeline) Run(ctx context.Context) error {
+func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	// Parse query annotations once and carry the base payload on the context.
 	// Destinations read it (plus a per-operation step) to annotate queries for
 	// cost attribution. Absent caller annotations just means ingestr's own keys
@@ -159,7 +160,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	// GetTable. Only warn if the user's --incremental-key was actually dropped;
 	// a source that adopts it (resolved key matches) needs no warning.
 	if src.HandlesIncrementality() && p.config.IncrementalKey != "" && table.IncrementalKey() != p.config.IncrementalKey {
-		fmt.Printf("Warning: source handles incrementality internally, ignoring --incremental-key=%s\n", p.config.IncrementalKey)
+		output.Warnf("Warning: source handles incrementality internally, ignoring --incremental-key=%s\n", p.config.IncrementalKey)
 	}
 
 	if table.Name() == source.CustomQueryTableName {
@@ -178,7 +179,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	display.PrintSummary(&preFetchConfig)
 
 	if shouldWarnCDCStrategy(p.config, preFetchStrategy) {
-		fmt.Printf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", preFetchStrategy, config.StrategyMerge)
+		output.Warnf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", preFetchStrategy, config.StrategyMerge)
 	}
 
 	tracker, err := p.createTracker(ctx)
@@ -186,7 +187,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		return err
 	}
 	if tracker != nil {
-		defer tracker.Stop()
+		defer func() { tracker.Stop(retErr) }()
 	}
 
 	// Check if source has known schema or needs inference
@@ -242,10 +243,10 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 				tableSchema = synthetic
 				bufferedRecords = emptyRecordChannel()
-				fmt.Printf("Warning: table %q produced no rows; creating destination table from --columns\n", table.Name())
+				output.Warnf("Warning: table %q produced no rows; creating destination table from --columns\n", table.Name())
 				config.Debug("[PIPELINE] Built synthetic schema with %d columns from --columns", len(synthetic.Columns))
 			} else {
-				fmt.Printf("Warning: table %q has no inferred columns; skipping ingestion\n", table.Name())
+				output.Warnf("Warning: table %q has no inferred columns; skipping ingestion\n", table.Name())
 				return nil
 			}
 		}
@@ -423,7 +424,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Println("\nStarting data ingestion...")
+	output.Statusf("\nStarting data ingestion...\n")
 
 	// Don't pass tracker to the job when bufferedRecords is set,
 	// because the tracker already counted rows during schema inference.
@@ -607,6 +608,8 @@ func (p *Pipeline) createTracker(ctx context.Context) (progress.Tracker, error) 
 		display = progress.NewWriterLogDisplay(p.logWriter)
 	} else {
 		switch progressMode {
+		case config.ProgressJSON:
+			display = progress.NewJSONDisplay()
 		case config.ProgressInteractive:
 			display = progress.NewInteractiveDisplay()
 		case config.ProgressLog:
@@ -859,7 +862,7 @@ func (p *Pipeline) applyExcludedColumnsToSchema(tableSchema *schema.TableSchema,
 	return &filtered
 }
 
-func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSource) error {
+func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSource) (retErr error) {
 	tables, err := src.GetTables(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get tables from multi-table source: %w", err)
@@ -896,7 +899,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	}
 
 	if shouldWarnCDCStrategy(p.config, resolvedStrategy) {
-		fmt.Printf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", resolvedStrategy, config.StrategyMerge)
+		output.Warnf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", resolvedStrategy, config.StrategyMerge)
 	}
 
 	strat, err := strategy.Get(resolvedStrategy)
@@ -927,7 +930,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 		return err
 	}
 	if tracker != nil {
-		defer tracker.Stop()
+		defer func() { tracker.Stop(retErr) }()
 	}
 
 	tableDestNames := make(map[string]string)
@@ -1098,7 +1101,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	// Log warnings for removed columns (Fivetran-style soft removal)
 	for _, change := range comparison.Changes {
 		if change.Type == schemaevolution.ChangeRemoveColumn {
-			fmt.Printf("Warning: Column %q no longer exists in source, future values will be NULL\n", change.ColumnName)
+			output.Warnf("Warning: Column %q no longer exists in source, future values will be NULL\n", change.ColumnName)
 		}
 	}
 
@@ -1124,7 +1127,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	case schemaevolution.ContractDiscardRow:
 		if contractResult.HasViolations() {
 			for _, v := range contractResult.Violations {
-				fmt.Printf("Warning: %s - rows with schema violations will be discarded\n", v.Description)
+				output.Warnf("Warning: %s - rows with schema violations will be discarded\n", v.Description)
 			}
 			config.Debug("[SCHEMA EVOLUTION] Discard row mode will filter out incompatible rows during ingestion")
 		}
@@ -1134,7 +1137,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	case schemaevolution.ContractDiscardValue:
 		if contractResult.HasViolations() {
 			for _, v := range contractResult.Violations {
-				fmt.Printf("Warning: %s - non-conforming values will be set to NULL\n", v.Description)
+				output.Warnf("Warning: %s - non-conforming values will be set to NULL\n", v.Description)
 			}
 			config.Debug("[SCHEMA EVOLUTION] Discard value mode will NULL out incompatible values during ingestion")
 
@@ -1196,7 +1199,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 
 	// Log warnings
 	for _, w := range migration.Warnings {
-		fmt.Printf("Warning: %s\n", w)
+		output.Warnf("Warning: %s\n", w)
 	}
 
 	// Log SQL statements in debug mode
@@ -1470,7 +1473,7 @@ func (p *Pipeline) applyNamingConvention(sourceSchema *schema.TableSchema, namin
 	for src, dest := range columnMapping {
 		config.Debug("[NAMING] Column rename: %s -> %s", src, dest)
 	}
-	fmt.Printf("Naming convention: %s (%d columns will be renamed)\n", namingConv.Name(), len(columnMapping))
+	output.Infof("Naming convention: %s (%d columns will be renamed)\n", namingConv.Name(), len(columnMapping))
 
 	p.namingMapping = columnMapping
 	p.applyColumnMapping(sourceSchema, columnMapping)
@@ -1483,7 +1486,7 @@ func (p *Pipeline) shortenLongIdentifiers(sourceSchema *schema.TableSchema) {
 	if len(mapping) == 0 {
 		return
 	}
-	fmt.Printf("Identifier shortening: %d column(s) shortened to fit %d-byte limit\n", len(mapping), maxLen)
+	output.Infof("Identifier shortening: %d column(s) shortened to fit %d-byte limit\n", len(mapping), maxLen)
 	p.applyColumnMapping(sourceSchema, mapping)
 }
 
@@ -1616,7 +1619,7 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 		if override.DataType != schema.TypeUnknown {
 			newCol := override.ApplyToColumn(col)
 			if col.DataType != newCol.DataType || col.Precision != newCol.Precision || col.Scale != newCol.Scale {
-				fmt.Printf("Column override: %q type changed from %s(p=%v,s=%v) to %s(p=%v,s=%v)\n",
+				output.Infof("Column override: %q type changed from %s(p=%v,s=%v) to %s(p=%v,s=%v)\n",
 					col.Name, col.DataType, col.Precision, col.Scale, newCol.DataType, newCol.Precision, newCol.Scale)
 			}
 			sourceSchema.Columns[i] = newCol
@@ -1626,7 +1629,7 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 
 		if override.RenameTo != "" && override.RenameTo != sourceSchema.Columns[i].Name {
 			renameMap[sourceSchema.Columns[i].Name] = override.RenameTo
-			fmt.Printf("Column rename: %q -> %q (from --columns)\n", sourceSchema.Columns[i].Name, override.RenameTo)
+			output.Infof("Column rename: %q -> %q (from --columns)\n", sourceSchema.Columns[i].Name, override.RenameTo)
 		}
 	}
 

--- a/pkg/pipeline/progress_json_test.go
+++ b/pkg/pipeline/progress_json_test.go
@@ -1,0 +1,43 @@
+package pipeline
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTrackerJSONMode verifies that ProgressJSON selects the JSON display:
+// stopping the tracker emits a terminal end event as JSON (the log/interactive
+// displays would not).
+func TestCreateTrackerJSONMode(t *testing.T) {
+	var out, errb bytes.Buffer
+	output.Init(&out, &errb, output.ModeJSON)
+	t.Cleanup(func() { output.Init(os.Stdout, os.Stderr, output.ModeText) })
+
+	p := New(&config.IngestConfig{Progress: config.ProgressJSON})
+	tr, err := p.createTracker(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, tr)
+	tr.Stop(nil)
+
+	line := strings.TrimSpace(out.String())
+	require.NotEmpty(t, line)
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &rec))
+	assert.Equal(t, "end", rec["event"])
+	assert.Equal(t, "success", rec["status"])
+}
+
+func TestCreateTrackerUnknownModeErrors(t *testing.T) {
+	p := New(&config.IngestConfig{Progress: config.ProgressMode("bogus")})
+	_, err := p.createTracker(context.Background())
+	require.Error(t, err)
+}

--- a/pkg/progress/interactive.go
+++ b/pkg/progress/interactive.go
@@ -133,7 +133,7 @@ func (d *InteractiveDisplay) Start(ctx context.Context, collector *MetricsCollec
 }
 
 // Stop halts the display and shows the final summary.
-func (d *InteractiveDisplay) Stop(metrics Metrics) {
+func (d *InteractiveDisplay) Stop(metrics Metrics, _ error) {
 	if d.spinner.ticker != nil {
 		d.spinner.ticker.Stop()
 	}

--- a/pkg/progress/json.go
+++ b/pkg/progress/json.go
@@ -1,0 +1,72 @@
+package progress
+
+import (
+	"context"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+)
+
+// JSONDisplay emits progress and lifecycle events as structured JSON records via
+// the output package. The start event is emitted separately by the pipeline
+// banner (display.PrintSummary); this display owns the periodic progress events
+// and the terminal end event.
+type JSONDisplay struct {
+	interval time.Duration
+	ticker   *time.Ticker
+	done     chan struct{}
+}
+
+// NewJSONDisplay creates a JSON progress display that emits a progress event
+// every second. Output is routed through the output package, which must be in
+// JSON mode for records to be written.
+func NewJSONDisplay() Display {
+	return &JSONDisplay{
+		interval: 1 * time.Second,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start begins emitting periodic progress events.
+func (d *JSONDisplay) Start(ctx context.Context, collector *MetricsCollector) {
+	d.ticker = time.NewTicker(d.interval)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-d.done:
+				return
+			case <-d.ticker.C:
+				d.emit(collector.Snapshot())
+			}
+		}
+	}()
+
+	config.Debug("[PROGRESS] JSON display started")
+}
+
+// Stop halts progress emission and writes the terminal end event. A non-nil err
+// makes the end event report status "error".
+func (d *JSONDisplay) Stop(metrics Metrics, err error) {
+	if d.ticker != nil {
+		d.ticker.Stop()
+	}
+	close(d.done)
+
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	output.EventEnd(status, metrics.TotalRows, metrics.TotalBatches, metrics.Duration().Seconds(), err)
+
+	config.Debug("[PROGRESS] JSON display stopped")
+}
+
+// emit writes a single progress event. It is the deterministic seam exercised by
+// tests directly, without the ticker.
+func (d *JSONDisplay) emit(m Metrics) {
+	output.EventProgress(m.TotalRows, m.TotalBatches, m.CurrentRowsPerSec, m.Duration().Seconds(), m.CPUPercent, m.MemoryMB)
+}

--- a/pkg/progress/json_test.go
+++ b/pkg/progress/json_test.go
@@ -1,0 +1,98 @@
+package progress
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseJSONLines(t *testing.T, out *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &m), "line should be valid JSON: %s", line)
+		records = append(records, m)
+	}
+	return records
+}
+
+// TestJSONDisplayEmit exercises the deterministic per-tick seam directly with a
+// hand-built Metrics value, avoiding both the ticker and a real collector.
+func TestJSONDisplayEmit(t *testing.T) {
+	var out, errb bytes.Buffer
+	output.Init(&out, &errb, output.ModeJSON)
+
+	d := &JSONDisplay{interval: time.Hour, done: make(chan struct{})}
+	d.emit(Metrics{TotalRows: 100, TotalBatches: 2, CurrentRowsPerSec: 50, StartTime: time.Now()})
+
+	recs := parseJSONLines(t, &out)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "progress", recs[0]["event"])
+	assert.EqualValues(t, 100, recs[0]["rows"])
+	assert.EqualValues(t, 2, recs[0]["batches"])
+}
+
+// TestJSONDisplaySequence verifies the display emits progress events then a
+// terminal end event, and notably does NOT emit a start event (the pipeline
+// banner owns start).
+func TestJSONDisplaySequence(t *testing.T) {
+	var out, errb bytes.Buffer
+	output.Init(&out, &errb, output.ModeJSON)
+
+	d := NewJSONDisplay().(*JSONDisplay)
+	d.emit(Metrics{TotalRows: 10, StartTime: time.Now()})
+	d.emit(Metrics{TotalRows: 20, StartTime: time.Now()})
+	d.Stop(Metrics{TotalRows: 20, TotalBatches: 2, StartTime: time.Now().Add(-time.Second)}, nil)
+
+	recs := parseJSONLines(t, &out)
+	require.Len(t, recs, 3)
+	assert.Equal(t, "progress", recs[0]["event"])
+	assert.Equal(t, "progress", recs[1]["event"])
+	assert.Equal(t, "end", recs[2]["event"])
+	assert.Equal(t, "success", recs[2]["status"])
+}
+
+func TestJSONDisplayStopError(t *testing.T) {
+	var out, errb bytes.Buffer
+	output.Init(&out, &errb, output.ModeJSON)
+
+	d := NewJSONDisplay().(*JSONDisplay)
+	d.Stop(Metrics{TotalRows: 5, StartTime: time.Now()}, errors.New("boom"))
+
+	recs := parseJSONLines(t, &out)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "end", recs[0]["event"])
+	assert.Equal(t, "error", recs[0]["status"])
+	assert.Equal(t, "boom", recs[0]["error"])
+}
+
+// TestJSONDisplayNoSpuriousProgress drives the full Start/Stop lifecycle with a
+// long ticker interval so no tick fires, proving the lifecycle yields exactly
+// one terminal event and no stray progress lines.
+func TestJSONDisplayNoSpuriousProgress(t *testing.T) {
+	var out, errb bytes.Buffer
+	output.Init(&out, &errb, output.ModeJSON)
+
+	collector, err := NewMetricsCollector()
+	require.NoError(t, err)
+
+	d := &JSONDisplay{interval: time.Hour, done: make(chan struct{})}
+	d.Start(context.Background(), collector)
+	d.Stop(Metrics{StartTime: time.Now()}, nil)
+
+	recs := parseJSONLines(t, &out)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "end", recs[0]["event"])
+}

--- a/pkg/progress/log.go
+++ b/pkg/progress/log.go
@@ -49,7 +49,7 @@ func (d *LogDisplay) Start(ctx context.Context, collector *MetricsCollector) {
 }
 
 // Stop halts the display and shows the final summary.
-func (d *LogDisplay) Stop(metrics Metrics) {
+func (d *LogDisplay) Stop(metrics Metrics, _ error) {
 	if d.ticker != nil {
 		d.ticker.Stop()
 	}

--- a/pkg/progress/tracker.go
+++ b/pkg/progress/tracker.go
@@ -37,13 +37,13 @@ func (t *DefaultTracker) Start(ctx context.Context) {
 }
 
 // Stop halts progress tracking and displays the final summary.
-func (t *DefaultTracker) Stop() {
+func (t *DefaultTracker) Stop(err error) {
 	if t.cancel != nil {
 		t.cancel()
 	}
 
 	metrics := t.collector.Snapshot()
-	t.display.Stop(metrics)
+	t.display.Stop(metrics, err)
 	config.Debug("[PROGRESS] Tracker stopped")
 }
 

--- a/pkg/progress/types.go
+++ b/pkg/progress/types.go
@@ -17,8 +17,9 @@ type Tracker interface {
 	// Start begins progress tracking and display updates.
 	Start(ctx context.Context)
 
-	// Stop halts progress tracking and displays the final summary.
-	Stop()
+	// Stop halts progress tracking and displays the final summary. A non-nil err
+	// indicates the ingestion failed and is surfaced by error-aware displays.
+	Stop(err error)
 
 	// GetMetrics returns the current metrics snapshot.
 	GetMetrics() Metrics
@@ -31,8 +32,9 @@ type Display interface {
 	// Updates are throttled based on the display implementation (500ms interactive, 1s log).
 	Start(ctx context.Context, collector *MetricsCollector)
 
-	// Stop halts display updates and shows the final summary.
-	Stop(metrics Metrics)
+	// Stop halts display updates and shows the final summary. A non-nil err
+	// indicates the ingestion failed.
+	Stop(metrics Metrics, err error)
 }
 
 // Metrics contains all progress tracking data collected during ingestion.

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -44,7 +44,7 @@ func (d *WriterLogDisplay) Start(ctx context.Context, collector *MetricsCollecto
 	config.Debug("[PROGRESS] Writer display started")
 }
 
-func (d *WriterLogDisplay) Stop(metrics Metrics) {
+func (d *WriterLogDisplay) Stop(metrics Metrics, _ error) {
 	if d.ticker != nil {
 		d.ticker.Stop()
 	}

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/araddon/dateparse"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -191,12 +192,12 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 			if incrementalKey != "" && startTime != nil {
 				incValue, ok := row[incrementalKey].(string)
 				if !ok {
-					fmt.Printf("[CSV] Row %d: skipping row with empty incremental key '%s'\n", lineNum, incrementalKey)
+					output.Warnf("[CSV] Row %d: skipping row with empty incremental key '%s'\n", lineNum, incrementalKey)
 					continue
 				}
 				incTime, err := dateparse.ParseAny(incValue)
 				if err != nil {
-					fmt.Printf("[CSV] Row %d: skipping row with unparseable incremental key value '%s'\n", lineNum, incValue)
+					output.Warnf("[CSV] Row %d: skipping row with unparseable incremental key value '%s'\n", lineNum, incValue)
 					continue
 				}
 				if incTime.Before(*startTime) {

--- a/pkg/source/google_sheets/google_sheets.go
+++ b/pkg/source/google_sheets/google_sheets.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -188,7 +189,7 @@ func (s *GoogleSheetsSource) readSheet(ctx context.Context, spreadsheetID, sheet
 		if count, exists := seen[str]; exists {
 			seen[str] = count + 1
 			renamed := fmt.Sprintf("%s_%d", str, count+1)
-			fmt.Printf("Warning: duplicate header %q found in sheet %s, renaming to %q\n", str, sheetName, renamed)
+			output.Warnf("Warning: duplicate header %q found in sheet %s, renaming to %q\n", str, sheetName, renamed)
 			str = renamed
 		} else {
 			seen[str] = 1

--- a/pkg/source/hostaway/hostaway.go
+++ b/pkg/source/hostaway/hostaway.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -361,7 +362,7 @@ func filterByInterval(item map[string]any, field string, start, end *time.Time) 
 	if !ok || raw == nil || raw == "" {
 		if start != nil || end != nil {
 			id := item["id"]
-			fmt.Printf("[HOSTAWAY] WARNING: skipping record (id=%v) with null/missing %s field\n", id, field)
+			output.Warnf("[HOSTAWAY] WARNING: skipping record (id=%v) with null/missing %s field\n", id, field)
 			return false
 		}
 		return true
@@ -371,7 +372,7 @@ func filterByInterval(item map[string]any, field string, start, end *time.Time) 
 	if !ok {
 		if start != nil || end != nil {
 			id := item["id"]
-			fmt.Printf("[HOSTAWAY] WARNING: skipping record (id=%v) with unparseable %s field: %v\n", id, field, raw)
+			output.Warnf("[HOSTAWAY] WARNING: skipping record (id=%v) with unparseable %s field: %v\n", id, field, raw)
 			return false
 		}
 		return true
@@ -382,7 +383,7 @@ func filterByInterval(item map[string]any, field string, start, end *time.Time) 
 		t, err = time.Parse("2006-01-02 15:04:05", ts)
 		if err != nil {
 			id := item["id"]
-			fmt.Printf("[HOSTAWAY] WARNING: skipping record (id=%v) with unparseable %s value: %q\n", id, field, ts)
+			output.Warnf("[HOSTAWAY] WARNING: skipping record (id=%v) with unparseable %s value: %q\n", id, field, ts)
 			return false
 		}
 	}

--- a/pkg/source/hubspot/hubspot.go
+++ b/pkg/source/hubspot/hubspot.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -708,7 +709,7 @@ func (s *Hubspotsource) readPipelines(ctx context.Context, opts source.ReadOptio
 	}
 
 	if len(scopeSkipped) > 0 {
-		fmt.Printf("\n[HUBSPOT] pipelines skipped (insufficient scopes): %s\n", strings.Join(scopeSkipped, ", "))
+		output.Warnf("\n[HUBSPOT] pipelines skipped (insufficient scopes): %s\n", strings.Join(scopeSkipped, ", "))
 	}
 
 	if len(rows) == 0 {
@@ -752,7 +753,7 @@ func (s *Hubspotsource) readPipelineStages(ctx context.Context, opts source.Read
 	}
 
 	if len(scopeSkipped) > 0 {
-		fmt.Printf("\n[HUBSPOT] pipeline_stages skipped (insufficient scopes): %s\n", strings.Join(scopeSkipped, ", "))
+		output.Warnf("\n[HUBSPOT] pipeline_stages skipped (insufficient scopes): %s\n", strings.Join(scopeSkipped, ", "))
 	}
 
 	if len(rows) == 0 {

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -221,7 +222,7 @@ func (s *KafkaSource) readStreaming(ctx context.Context, topic string, opts sour
 	}
 
 	if opts.IntervalStart != nil {
-		fmt.Printf("Warning: --interval-start is ignored for streaming Kafka; the consumer group's committed offsets determine the start position\n")
+		output.Warnf("Warning: --interval-start is ignored for streaming Kafka; the consumer group's committed offsets determine the start position\n")
 	}
 
 	reader := kafkago.NewReader(kafkago.ReaderConfig{
@@ -711,7 +712,7 @@ func (s *KafkaSource) getPartitions(ctx context.Context, dialer *kafkago.Dialer,
 func (s *KafkaSource) offsetForTime(_ context.Context, conn *kafkago.Conn, t time.Time) (int64, error) {
 	offset, err := conn.ReadOffset(t)
 	if err != nil {
-		fmt.Printf("Warning: could not resolve offset for time %v: %v, falling back to last offset\n", t, err)
+		output.Warnf("Warning: could not resolve offset for time %v: %v, falling back to last offset\n", t, err)
 		last, lastErr := conn.ReadLastOffset()
 		if lastErr != nil {
 			return 0, fmt.Errorf("failed to read offset for time %v: %w", t, err)

--- a/pkg/source/mixpanel/mixpanel.go
+++ b/pkg/source/mixpanel/mixpanel.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -364,7 +365,7 @@ func (s *MixpanelSource) flattenProperties(event map[string]interface{}) {
 		key = naming.ToSnakeCase(key)
 		if str, ok := value.(string); ok && (str == "undefined" || str == "<null>") {
 			s.nullWarningOnce.Do(func() {
-				fmt.Printf("\nWarning: Mixpanel returns \"undefined\" and \"<null>\" as string literals for missing values, these will be converted to NULL\n")
+				output.Warnf("\nWarning: Mixpanel returns \"undefined\" and \"<null>\" as string literals for missing values, these will be converted to NULL\n")
 			})
 			value = nil
 		}

--- a/pkg/source/salesforce/salesforce.go
+++ b/pkg/source/salesforce/salesforce.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/araddon/dateparse"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -457,7 +458,7 @@ func (s *salesforceSource) getRecords(ctx context.Context, sobject string, lastS
 	if s.useBulkAPI {
 		err := s.getRecordsBulk(ctx, sobject, query, dateFields, opts, results)
 		if err == nil {
-			fmt.Printf("\n[SALESFORCE] Fetched %s using Bulk API\n", sobject)
+			output.Statusf("\n[SALESFORCE] Fetched %s using Bulk API\n", sobject)
 			return nil
 		}
 		s.useBulkAPI = false
@@ -468,7 +469,7 @@ func (s *salesforceSource) getRecords(ctx context.Context, sobject string, lastS
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\n[SALESFORCE] Fetched %s using REST API, since your account does not have Bulk API enabled\n", sobject)
+	output.Statusf("\n[SALESFORCE] Fetched %s using REST API, since your account does not have Bulk API enabled\n", sobject)
 	return nil
 }
 

--- a/pkg/source/stripe/stripe.go
+++ b/pkg/source/stripe/stripe.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -419,7 +420,7 @@ func (s *StripeSource) read(ctx context.Context, table string, opts source.ReadO
 			}
 
 			if hoursSince := time.Since(*intervalStart).Hours(); hoursSince > 30*24 {
-				fmt.Printf("Warning: interval-start is %.0f days ago, but the Stripe Events API only retains 30 days of history. Falling back to sync incremental mode. To use the events endpoint, set interval-start to within the last 30 days.\n", hoursSince/24)
+				output.Warnf("Warning: interval-start is %.0f days ago, but the Stripe Events API only retains 30 days of history. Falling back to sync incremental mode. To use the events endpoint, set interval-start to within the last 30 days.\n", hoursSince/24)
 				mode = modeSyncIncremental
 			} else {
 				intervalEnd := opts.IntervalEnd

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -40,7 +41,7 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	}
 
 	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "di", job.Config.StagingDataset)
-	fmt.Printf("[DELETE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+	output.Statusf("[DELETE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:       job.Config.DestTable,

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -73,7 +74,7 @@ func mergeStagingInto(ctx context.Context, dest destination.Destination, staging
 // destination that can't process deletes during merge.
 func warnIfCDCMergeUnsupported(dest destination.Destination) {
 	if cdcAware, ok := dest.(destination.CDCMergeAware); !ok || !cdcAware.SupportsCDCMerge() {
-		fmt.Printf("Warning: CDC data detected but the destination does not support CDC-aware merge; deleted rows will be inserted as regular data with _cdc_deleted=true instead of being processed as deletes\n")
+		output.Warnf("Warning: CDC data detected but the destination does not support CDC-aware merge; deleted rows will be inserted as regular data with _cdc_deleted=true instead of being processed as deletes\n")
 	}
 }
 
@@ -99,7 +100,7 @@ func (s *MergeStrategy) RequiresIncrementalKey() bool {
 func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	// Generate staging table name
 	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "merge", job.Config.StagingDataset)
-	fmt.Printf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+	output.Statusf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	isCDC := hasCDCColumns(job.Schema)
 	if isCDC {
 		warnIfCDCMergeUnsupported(job.Destination)

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -216,7 +217,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	writeTable := targetTable
 	if useStaging {
 		writeTable = replaceStagingTableName(job.Destination, targetTable, job.Config.StagingDataset)
-		fmt.Printf("[STRATEGY] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), writeTable)
+		output.Statusf("[STRATEGY] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), writeTable)
 	} else {
 		config.Debug("[STRATEGY] Direct write to target (no staging): %s", writeTable)
 	}

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -40,7 +41,7 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 
 	// Generate staging table name
 	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "scd2", job.Config.StagingDataset)
-	fmt.Printf("[SCD2] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+	output.Statusf("[SCD2] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	config.Debug("[SCD2] Using process timestamp: %s", processTimestamp.Format(time.RFC3339Nano))
 
 	// Extend schema with SCD columns

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -168,7 +169,7 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 	switch e.opts.Strategy {
 	case config.StrategyMerge:
 		st.stagingTable = managedStagingTableName(dest, st.destTable, "stream", cfg.StagingDataset)
-		fmt.Printf("[STREAM] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), st.stagingTable)
+		output.Statusf("[STREAM] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), st.stagingTable)
 		return prepareMergeTables(ctx, dest, mergeTableParams{
 			DestTable:    st.destTable,
 			StagingTable: st.stagingTable,
@@ -375,7 +376,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 
 	l.cycles++
 	if flushedRows > 0 {
-		fmt.Printf("[STREAM] %s | cycle %d: flushed %d rows in %s\n", time.Now().Format("15:04:05"), l.cycles, flushedRows, time.Since(start).Round(time.Millisecond))
+		output.Statusf("[STREAM] %s | cycle %d: flushed %d rows in %s\n", time.Now().Format("15:04:05"), l.cycles, flushedRows, time.Since(start).Round(time.Millisecond))
 	}
 	return nil
 }

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
@@ -131,7 +132,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 
 	targetTable := job.Config.DestTable
 	stagingTable := managedStagingTableName(job.Destination, targetTable, "ti", job.Config.StagingDataset)
-	fmt.Printf("[TRUNCATE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+	output.Statusf("[TRUNCATE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:       targetTable,

--- a/tests/integration/progress_json_test.go
+++ b/tests/integration/progress_json_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+// End-to-end test for --progress json. CSV → DuckDB is fully in-process (no
+// container), so it cheaply exercises the real pipeline and asserts the stdout
+// stream is clean, machine-readable JSONL.
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProgressJSON_CSVToDuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	csvPath := filepath.Join(tmpDir, "users.csv")
+	require.NoError(t, os.WriteFile(csvPath, []byte(csvWithRows), 0o644))
+
+	var out, errb bytes.Buffer
+	output.Init(&out, &errb, output.ModeJSON)
+	t.Cleanup(func() { output.Init(os.Stdout, os.Stderr, output.ModeText) })
+
+	duckDBPath := filepath.Join(tmpDir, "out.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:           fmt.Sprintf("csv://%s", csvPath),
+		SourceTable:         "users",
+		DestURI:             fmt.Sprintf("duckdb:///%s", duckDBPath),
+		DestTable:           "main.users",
+		IncrementalStrategy: config.StrategyReplace,
+		Progress:            config.ProgressJSON,
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var events []string
+	var startRec, endRec map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &rec), "non-JSON line on stdout: %s", line)
+		ev, ok := rec["event"].(string)
+		require.Truef(t, ok && ev != "", "record missing event discriminator: %s", line)
+		events = append(events, ev)
+		assert.NotContainsf(t, line, "Using staging table", "decorative chatter leaked into JSON: %s", line)
+		switch ev {
+		case "start":
+			startRec = rec
+		case "end":
+			endRec = rec
+		}
+	}
+
+	require.NotEmpty(t, events)
+	assert.Equal(t, "start", events[0], "first event should be start")
+	assert.Equal(t, "end", events[len(events)-1], "last event should be end")
+
+	ends := 0
+	for _, e := range events {
+		if e == "end" {
+			ends++
+		}
+	}
+	assert.Equal(t, 1, ends, "exactly one terminal end event")
+
+	require.NotNil(t, startRec)
+	assert.Equal(t, "csv", startRec["source_type"])
+	assert.Equal(t, "duckdb", startRec["dest_type"])
+	assert.Equal(t, "users", startRec["source_table"])
+
+	require.NotNil(t, endRec)
+	assert.Equal(t, "success", endRec["status"])
+	assert.EqualValues(t, 3, endRec["rows"], "all three CSV rows counted")
+}


### PR DESCRIPTION
Add a `json` value to --progress that emits one JSON object per line to stdout (start / progress / end events, plus warnings as log records) for CI, jq pipelines, and orchestrators. --debug and decorative status chatter are kept off the JSON stream so it stays cleanly parseable. https://github.com/bruin-data/ingestr/issues/882

- internal/output: slog-based JSON/text output seam (leaf package; own Mode type, ts rename, EnsureTerminal one-terminal-event guard)
- pkg/progress: JSONDisplay (4th Display); Display.Stop/Tracker.Stop gain an error param so the end event can report failures
- route warnings/info/status through output across pipeline, strategies, cmd, main, and 11 source/destination connectors
- tests: output + progress + pipeline unit tests and a csv->duckdb integration test asserting every stdout line is valid JSON