### PR TITLE
Remove command_running telemetry

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -220,8 +220,9 @@ func IngestCommand() *cli.Command {
 
 func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	trackCommandTriggered(ctx, "ingest")
+	var finishedProperties map[string]any
 	defer func() {
-		trackCommandFinished(ctx, "ingest", err)
+		trackCommandFinished(ctx, "ingest", err, finishedProperties)
 	}()
 
 	config.DebugMode = c.Bool("debug")
@@ -259,6 +260,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.Stream = c.Bool("stream")
 	cfg.FlushInterval = c.Duration("flush-interval")
 	cfg.FlushRecords = int(c.Int("flush-records"))
+	finishedProperties = ingestTelemetryProperties(cfg)
 
 	if !cfg.Stream && (c.IsSet("flush-interval") || c.IsSet("flush-records")) {
 		return fmt.Errorf("--flush-interval and --flush-records are only valid together with --stream")
@@ -308,8 +310,6 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 		}
 	}
 
-	trackCommandRunning(ctx, "ingest", ingestTelemetryProperties(cfg))
-
 	p := pipeline.New(cfg)
 	if err := p.Run(ctx); err != nil {
 		return err
@@ -332,10 +332,10 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 func ingestTelemetryProperties(cfg *config.IngestConfig) map[string]any {
 	properties := map[string]any{}
 	if sourceType := telemetryScheme(cfg.SourceURI); sourceType != "" {
-		properties["source_type"] = sourceType
+		properties["source_platform"] = sourceType
 	}
 	if destinationType := telemetryScheme(cfg.DestURI); destinationType != "" {
-		properties["destination_type"] = destinationType
+		properties["destination_platform"] = destinationType
 	}
 	return properties
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,7 +49,7 @@ func ServerCommand() *cli.Command {
 func runServer(ctx context.Context, c *cli.Command) (err error) {
 	trackCommandTriggered(ctx, "server")
 	defer func() {
-		trackCommandFinished(ctx, "server", err)
+		trackCommandFinished(ctx, "server", err, nil)
 	}()
 
 	port := int(c.Int("port"))
@@ -57,8 +57,6 @@ func runServer(ctx context.Context, c *cli.Command) (err error) {
 	logsDir := c.String("logs-dir")
 	dbPath := c.String("db")
 	binaryPath := c.String("ingestr-binary")
-
-	trackCommandRunning(ctx, "server", nil)
 
 	s, err := server.NewWithBinary(port, credsFile, logsDir, dbPath, binaryPath)
 	if err != nil {

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -15,19 +15,19 @@ func trackCommandTriggered(ctx context.Context, command string) {
 	trackTelemetryAsync(ctx, "command_triggered", commandTelemetryProperties(command, nil))
 }
 
-func trackCommandRunning(ctx context.Context, command string, properties map[string]any) {
-	trackTelemetryAsync(ctx, "command_running", commandTelemetryProperties(command, properties))
-}
-
-func trackCommandFinished(ctx context.Context, command string, err error) {
-	properties := commandTelemetryProperties(command, map[string]any{
+func trackCommandFinished(ctx context.Context, command string, err error, additionalProperties map[string]any) {
+	finishedProperties := map[string]any{
 		"status": "success",
-	})
+	}
+	for key, value := range additionalProperties {
+		finishedProperties[key] = value
+	}
 	if err != nil {
-		properties["status"] = "failed"
-		properties["error"] = commandTelemetryError(err)
+		finishedProperties["status"] = "failed"
+		finishedProperties["error"] = commandTelemetryError(err)
 	}
 
+	properties := commandTelemetryProperties(command, finishedProperties)
 	telemetryWG.Wait()
 	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, versionFlagValue())
 }

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -16,12 +16,11 @@ func trackCommandTriggered(ctx context.Context, command string) {
 }
 
 func trackCommandFinished(ctx context.Context, command string, err error, additionalProperties map[string]any) {
-	finishedProperties := map[string]any{
-		"status": "success",
-	}
+	finishedProperties := map[string]any{}
 	for key, value := range additionalProperties {
 		finishedProperties[key] = value
 	}
+	finishedProperties["status"] = "success"
 	if err != nil {
 		finishedProperties["status"] = "failed"
 		finishedProperties["error"] = commandTelemetryError(err)

--- a/cmd/telemetry_test.go
+++ b/cmd/telemetry_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,13 +13,23 @@ func TestCommandTelemetryPropertiesIncludeVersionFlagValue(t *testing.T) {
 	t.Cleanup(func() { Version = originalVersion })
 
 	properties := commandTelemetryProperties("ingest", map[string]any{
-		"source_type": "postgres",
-		"version":     "stale",
+		"source_platform": "postgres",
+		"version":         "stale",
 	})
 
 	require.Equal(t, "ingest", properties["command"])
-	require.Equal(t, "postgres", properties["source_type"])
+	require.Equal(t, "postgres", properties["source_platform"])
 	require.Equal(t, "v9.8.7", properties["version"])
+}
+
+func TestIngestTelemetryPropertiesIncludeConnectorSchemes(t *testing.T) {
+	properties := ingestTelemetryProperties(&config.IngestConfig{
+		SourceURI: "postgres://user:pass@localhost:5432/db",
+		DestURI:   "bigquery://project/dataset",
+	})
+
+	require.Equal(t, "postgres", properties["source_platform"])
+	require.Equal(t, "bigquery", properties["destination_platform"])
 }
 
 func TestNewAppUsesVersionFlagValue(t *testing.T) {


### PR DESCRIPTION
Removes the command_running telemetry event.
Keeps ingest connector context on command_finished as source_platform and destination_platform.
Checks: make format, make lint, make test.