### PR TITLE
feat(destination): add StarRocks destination via Stream Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Pull requests are welcome. However, please open an issue first to discuss what y
     <tr>
         <td>StarRocks</td>
         <td>✅</td>
-        <td>-</td>
+        <td>✅</td>
     </tr>
     <tr>
         <td>Synapse</td>

--- a/docs/supported-sources/starrocks.md
+++ b/docs/supported-sources/starrocks.md
@@ -137,7 +137,7 @@ Destination URI parameters:
 - `ssl` (optional): same TLS handling as the source (applies to the query-port connection).
 
 ### Supported write dispositions
-- `replace` — loads into a staging table, then atomically replaces the target's data with `INSERT OVERWRITE`. StarRocks loads into temporary partitions and swaps them in only on success, so a failed load leaves the existing target data intact. (`SWAP WITH`/`RENAME` aren't used because they can't cross databases, and ingestr stages in a separate database.)
+- `replace` — atomically replaces the target's data. A failed load leaves the existing data intact.
 - `append` — loads rows into the existing table.
 - `merge` — upserts by primary key (the table is created as a StarRocks primary-key table). Requires `--primary-key`.
 

--- a/docs/supported-sources/starrocks.md
+++ b/docs/supported-sources/starrocks.md
@@ -137,7 +137,7 @@ Destination URI parameters:
 - `ssl` (optional): same TLS handling as the source (applies to the query-port connection).
 
 ### Supported write dispositions
-- `replace` — recreates the table and loads the data (write directly to the target; not an atomic swap, since StarRocks cannot swap tables across databases).
+- `replace` — loads into a staging table, then atomically replaces the target's data with `INSERT OVERWRITE`. StarRocks loads into temporary partitions and swaps them in only on success, so a failed load leaves the existing target data intact. (`SWAP WITH`/`RENAME` aren't used because they can't cross databases, and ingestr stages in a separate database.)
 - `append` — loads rows into the existing table.
 - `merge` — upserts by primary key (the table is created as a StarRocks primary-key table). Requires `--primary-key`.
 

--- a/docs/supported-sources/starrocks.md
+++ b/docs/supported-sources/starrocks.md
@@ -2,7 +2,7 @@
 
 [StarRocks](https://www.starrocks.io/) is a high-performance analytical (OLAP) database. Alongside its own internal storage, StarRocks can query open lakehouse table formats — such as **Apache Iceberg**, **Apache Hudi**, **Apache Hive**, and **Delta Lake** — through external catalogs.
 
-ingestr supports StarRocks as a source, including tables exposed through external lakehouse catalogs.
+ingestr supports StarRocks as a source (including tables exposed through external lakehouse catalogs) and as a destination.
 
 ## URI format
 The URI format for StarRocks is as follows:
@@ -117,3 +117,28 @@ The interval flags are optional. If you omit them, ingestr reads all rows and `m
 
 ## Custom queries
 You can read the result of an arbitrary SQL query instead of a table. See [Custom Queries](/supported-sources/custom_queries.md) for details.
+
+## Using StarRocks as a destination
+StarRocks can also be a destination. ingestr creates the table (a duplicate-key table, or a primary-key table when a primary key is given) and loads rows through StarRocks' [Stream Load](https://docs.starrocks.io/docs/loading/StreamLoad/) HTTP API.
+
+Stream Load uses the FE HTTP port (default `8030`), which is separate from the query port (`9030`). Set it with the `http_port` query parameter if it differs:
+
+```bash
+ingestr ingest \
+    --source-uri 'postgresql://user:pass@localhost:5432/sourcedb' \
+    --source-table 'public.events' \
+    --dest-uri 'starrocks://root:pass@localhost:9030/analytics?http_port=8030' \
+    --dest-table 'analytics.events'
+```
+
+Destination URI parameters:
+- `http_port` (optional): the FE HTTP port used for Stream Load. Defaults to `8030`.
+- `replication_num` (optional): the replica count for created tables. If omitted, the cluster default is used; set it to `1` for single-backend clusters.
+- `ssl` (optional): same TLS handling as the source (applies to the query-port connection).
+
+### Supported write dispositions
+- `replace` — recreates the table and loads the data (write directly to the target; not an atomic swap, since StarRocks cannot swap tables across databases).
+- `append` — loads rows into the existing table.
+- `merge` — upserts by primary key (the table is created as a StarRocks primary-key table). Requires `--primary-key`.
+
+`delete+insert` and `scd2` are not currently supported for StarRocks destinations.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -357,7 +357,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("solidgate", "Solidgate", []string{"solidgate"}, true, false),
 		genericURIConnector("spanner", "Spanner", []string{"spanner"}, true, false),
 		genericURIConnector("sqs", "SQS", []string{"sqs"}, true, false),
-		genericURIConnector("starrocks", "StarRocks", []string{"starrocks"}, true, false),
+		genericURIConnector("starrocks", "StarRocks", []string{"starrocks"}, true, true),
 		genericURIConnector("square", "Square", []string{"square"}, true, false),
 		genericURIConnector("stripe", "Stripe", []string{"stripe"}, true, false),
 		genericURIConnector("surveymonkey", "SurveyMonkey", []string{"surveymonkey"}, true, false),

--- a/pkg/destination/starrocks/helpers.go
+++ b/pkg/destination/starrocks/helpers.go
@@ -100,6 +100,9 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return a.Value(idx).ToTime().Format("2006-01-02")
 	case *array.Time64:
 		micros := int64(a.Value(idx))
+		if a.DataType().(*arrow.Time64Type).Unit == arrow.Nanosecond {
+			micros /= 1_000
+		}
 		secs := micros / 1_000_000
 		return fmt.Sprintf("%02d:%02d:%02d.%06d", secs/3600, (secs%3600)/60, secs%60, micros%1_000_000)
 	case *array.Timestamp:
@@ -118,7 +121,9 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		}
 		return val
 	default:
-		return fmt.Sprintf("%v", arr)
+		// ValueStr returns the value at idx for any Arrow type; never format the
+		// whole array (which would corrupt every row for uncovered types).
+		return arr.ValueStr(idx)
 	}
 }
 

--- a/pkg/destination/starrocks/helpers.go
+++ b/pkg/destination/starrocks/helpers.go
@@ -125,6 +125,12 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.000000")
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.List:
+		start, end := a.ValueOffsets(idx)
+		return listElements(a.ListValues(), int(start), int(end))
+	case *array.LargeList:
+		start, end := a.ValueOffsets(idx)
+		return listElements(a.ListValues(), int(start), int(end))
 	case array.ExtensionArray:
 		storage := a.Storage()
 		val := extractValue(storage, idx)
@@ -140,6 +146,16 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		// whole array (which would corrupt every row for uncovered types).
 		return arr.ValueStr(idx)
 	}
+}
+
+// listElements converts an Arrow list slice into a Go slice so it serializes as
+// a JSON array (not a quoted string) into a StarRocks JSON column.
+func listElements(values arrow.Array, start, end int) []interface{} {
+	out := make([]interface{}, 0, end-start)
+	for j := start; j < end; j++ {
+		out = append(out, extractValue(values, j))
+	}
+	return out
 }
 
 func mapStarRocksTypeToSchema(dataType string) schema.DataType {

--- a/pkg/destination/starrocks/helpers.go
+++ b/pkg/destination/starrocks/helpers.go
@@ -1,0 +1,156 @@
+package starrocks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+func quoteColumn(name string) string {
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
+}
+
+func quoteColumns(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = quoteColumn(n)
+	}
+	return out
+}
+
+func quoteTable(table string) string {
+	db, name := splitDatabaseTable(table)
+	if db != "" {
+		return quoteColumn(db) + "." + quoteColumn(name)
+	}
+	return quoteColumn(name)
+}
+
+func splitDatabaseTable(table string) (string, string) {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", table
+}
+
+// recordBatchToJSON encodes an Arrow record batch as a JSON array of row
+// objects (keyed by column name) for Stream Load. Returns the body and the row
+// count.
+func recordBatchToJSON(record arrow.RecordBatch) ([]byte, int64, error) {
+	numRows := record.NumRows()
+	if numRows == 0 {
+		return nil, 0, nil
+	}
+	numCols := int(record.NumCols())
+	fields := record.Schema().Fields()
+
+	rows := make([]map[string]interface{}, 0, numRows)
+	for r := int64(0); r < numRows; r++ {
+		row := make(map[string]interface{}, numCols)
+		for c := 0; c < numCols; c++ {
+			row[fields[c].Name] = extractValue(record.Column(c), int(r))
+		}
+		rows = append(rows, row)
+	}
+
+	body, err := json.Marshal(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return body, numRows, nil
+}
+
+// extractValue converts an Arrow value to a JSON-serializable Go value that
+// StarRocks Stream Load accepts (decimals/dates/timestamps as strings, JSON as
+// raw JSON).
+func extractValue(arr arrow.Array, idx int) interface{} {
+	if arr.IsNull(idx) {
+		return nil
+	}
+
+	switch a := arr.(type) {
+	case *array.Boolean:
+		return a.Value(idx)
+	case *array.Int8:
+		return a.Value(idx)
+	case *array.Int16:
+		return a.Value(idx)
+	case *array.Int32:
+		return a.Value(idx)
+	case *array.Int64:
+		return a.Value(idx)
+	case *array.Float32:
+		return a.Value(idx)
+	case *array.Float64:
+		return a.Value(idx)
+	case *array.String:
+		return a.Value(idx)
+	case *array.LargeString:
+		return a.Value(idx)
+	case *array.Binary:
+		return string(a.Value(idx))
+	case *array.Date32:
+		return a.Value(idx).ToTime().Format("2006-01-02")
+	case *array.Date64:
+		return a.Value(idx).ToTime().Format("2006-01-02")
+	case *array.Time64:
+		micros := int64(a.Value(idx))
+		secs := micros / 1_000_000
+		return fmt.Sprintf("%02d:%02d:%02d.%06d", secs/3600, (secs%3600)/60, secs%60, micros%1_000_000)
+	case *array.Timestamp:
+		ts := a.Value(idx)
+		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.000000")
+	case *array.Decimal128:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case array.ExtensionArray:
+		storage := a.Storage()
+		val := extractValue(storage, idx)
+		// JSON columns must be embedded as raw JSON, not a quoted string.
+		if a.DataType().(arrow.ExtensionType).ExtensionName() == schema.JSONExtensionName {
+			if s, ok := val.(string); ok && json.Valid([]byte(s)) {
+				return json.RawMessage(s)
+			}
+		}
+		return val
+	default:
+		return fmt.Sprintf("%v", arr)
+	}
+}
+
+func mapStarRocksTypeToSchema(dataType string) schema.DataType {
+	switch strings.ToLower(dataType) {
+	case "boolean", "bool":
+		return schema.TypeBoolean
+	case "tinyint", "smallint":
+		return schema.TypeInt16
+	case "int", "integer":
+		return schema.TypeInt32
+	case "bigint":
+		return schema.TypeInt64
+	case "largeint":
+		return schema.TypeString
+	case "float":
+		return schema.TypeFloat32
+	case "double":
+		return schema.TypeFloat64
+	case "decimal", "decimalv2", "decimal32", "decimal64", "decimal128":
+		return schema.TypeDecimal
+	case "char", "varchar", "string":
+		return schema.TypeString
+	case "varbinary", "binary":
+		return schema.TypeBinary
+	case "date":
+		return schema.TypeDate
+	case "datetime", "timestamp":
+		return schema.TypeTimestamp
+	case "json":
+		return schema.TypeJSON
+	default:
+		return schema.TypeString
+	}
+}

--- a/pkg/destination/starrocks/helpers.go
+++ b/pkg/destination/starrocks/helpers.go
@@ -14,6 +14,21 @@ func quoteColumn(name string) string {
 	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
 }
 
+// tlsParam maps a user-facing `ssl` value to go-sql-driver/mysql's `tls` DSN
+// value (empty = plaintext). Mirrors the StarRocks source's handling.
+func tlsParam(ssl string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(ssl)) {
+	case "", "false", "0", "disable", "disabled":
+		return "", nil
+	case "true", "1", "enable", "enabled", "require", "required":
+		return "true", nil
+	case "skip-verify", "skip_verify", "insecure":
+		return "skip-verify", nil
+	default:
+		return "", fmt.Errorf("invalid ssl value %q: use true, false, or skip-verify", ssl)
+	}
+}
+
 func quoteColumns(names []string) []string {
 	out := make([]string, len(names))
 	for i, n := range names {

--- a/pkg/destination/starrocks/helpers.go
+++ b/pkg/destination/starrocks/helpers.go
@@ -1,6 +1,7 @@
 package starrocks
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -54,15 +55,23 @@ func splitDatabaseTable(table string) (string, string) {
 }
 
 // recordBatchToJSON encodes an Arrow record batch as a JSON array of row
-// objects (keyed by column name) for Stream Load. Returns the body and the row
-// count.
-func recordBatchToJSON(record arrow.RecordBatch) ([]byte, int64, error) {
+// objects (keyed by column name) for Stream Load. It returns the body, the row
+// count, and the names of binary columns (base64-encoded in the body, so the
+// loader must decode them server-side).
+func recordBatchToJSON(record arrow.RecordBatch) ([]byte, int64, []string, error) {
 	numRows := record.NumRows()
 	if numRows == 0 {
-		return nil, 0, nil
+		return nil, 0, nil, nil
 	}
 	numCols := int(record.NumCols())
 	fields := record.Schema().Fields()
+
+	var binaryCols []string
+	for c := 0; c < numCols; c++ {
+		if id := fields[c].Type.ID(); id == arrow.BINARY || id == arrow.LARGE_BINARY {
+			binaryCols = append(binaryCols, fields[c].Name)
+		}
+	}
 
 	rows := make([]map[string]interface{}, 0, numRows)
 	for r := int64(0); r < numRows; r++ {
@@ -75,9 +84,28 @@ func recordBatchToJSON(record arrow.RecordBatch) ([]byte, int64, error) {
 
 	body, err := json.Marshal(rows)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
-	return body, numRows, nil
+	return body, numRows, binaryCols, nil
+}
+
+// columnsHeader builds the Stream Load `columns` value that decodes base64
+// binary columns back to their raw bytes, or "" when there are none. It lists
+// every batch column in order, then a from_base64() transform for each binary
+// column.
+func columnsHeader(sc *arrow.Schema, binaryCols []string) string {
+	if len(binaryCols) == 0 {
+		return ""
+	}
+	fields := sc.Fields()
+	parts := make([]string, 0, len(fields)+len(binaryCols))
+	for _, f := range fields {
+		parts = append(parts, f.Name)
+	}
+	for _, name := range binaryCols {
+		parts = append(parts, fmt.Sprintf("%s=from_base64(%s)", name, name))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // extractValue converts an Arrow value to a JSON-serializable Go value that
@@ -108,7 +136,11 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 	case *array.LargeString:
 		return a.Value(idx)
 	case *array.Binary:
-		return string(a.Value(idx))
+		// base64 keeps the bytes valid UTF-8 for JSON; the loader adds a
+		// from_base64() transform so StarRocks stores the original bytes.
+		return base64.StdEncoding.EncodeToString(a.Value(idx))
+	case *array.LargeBinary:
+		return base64.StdEncoding.EncodeToString(a.Value(idx))
 	case *array.Date32:
 		return a.Value(idx).ToTime().Format("2006-01-02")
 	case *array.Date64:

--- a/pkg/destination/starrocks/helpers_test.go
+++ b/pkg/destination/starrocks/helpers_test.go
@@ -24,7 +24,8 @@ func TestRecordBatchToJSONList(t *testing.T) {
 
 	rec := array.NewRecordBatch(
 		arrow.NewSchema([]arrow.Field{{Name: "c", Type: arr.DataType()}}, nil),
-		[]arrow.Array{arr}, 2)
+		[]arrow.Array{arr}, 2,
+	)
 	defer rec.Release()
 
 	body, n, err := recordBatchToJSON(rec)

--- a/pkg/destination/starrocks/helpers_test.go
+++ b/pkg/destination/starrocks/helpers_test.go
@@ -8,6 +8,37 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 )
 
+// Binary columns are base64-encoded in the body (so json.Marshal can't mangle
+// non-UTF-8 bytes) and reported so the loader can add a from_base64 transform.
+func TestRecordBatchToJSONBinary(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	bb := array.NewBinaryBuilder(pool, arrow.BinaryTypes.Binary)
+	bb.Append([]byte{0xFF, 0xFE, 0x00})
+	arr := bb.NewBinaryArray()
+	defer arr.Release()
+
+	sc := arrow.NewSchema([]arrow.Field{{Name: "data", Type: arrow.BinaryTypes.Binary}}, nil)
+	rec := array.NewRecordBatch(sc, []arrow.Array{arr}, 1)
+	defer rec.Release()
+
+	body, n, binaryCols, err := recordBatchToJSON(rec)
+	if err != nil || n != 1 {
+		t.Fatalf("n=%d err=%v", n, err)
+	}
+	if want := `[{"data":"//4A"}]`; string(body) != want {
+		t.Fatalf("body: got %s want %s", string(body), want)
+	}
+	if len(binaryCols) != 1 || binaryCols[0] != "data" {
+		t.Fatalf("binaryCols: got %v", binaryCols)
+	}
+	if got, want := columnsHeader(sc, binaryCols), "data, data=from_base64(data)"; got != want {
+		t.Fatalf("columnsHeader: got %q want %q", got, want)
+	}
+	if columnsHeader(sc, nil) != "" {
+		t.Fatalf("columnsHeader should be empty without binary columns")
+	}
+}
+
 // A list column maps to a StarRocks JSON column, so it must serialize as a JSON
 // array (not a quoted string) and null elements must survive.
 func TestRecordBatchToJSONList(t *testing.T) {
@@ -28,7 +59,7 @@ func TestRecordBatchToJSONList(t *testing.T) {
 	)
 	defer rec.Release()
 
-	body, n, err := recordBatchToJSON(rec)
+	body, n, _, err := recordBatchToJSON(rec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/destination/starrocks/helpers_test.go
+++ b/pkg/destination/starrocks/helpers_test.go
@@ -1,0 +1,41 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// A list column maps to a StarRocks JSON column, so it must serialize as a JSON
+// array (not a quoted string) and null elements must survive.
+func TestRecordBatchToJSONList(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	lb := array.NewListBuilder(pool, arrow.PrimitiveTypes.Int32)
+	vb := lb.ValueBuilder().(*array.Int32Builder)
+	lb.Append(true)
+	vb.AppendValues([]int32{1, 2, 3}, nil)
+	lb.Append(true)
+	vb.Append(9)
+	vb.AppendNull()
+	arr := lb.NewListArray()
+	defer arr.Release()
+
+	rec := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "c", Type: arr.DataType()}}, nil),
+		[]arrow.Array{arr}, 2)
+	defer rec.Release()
+
+	body, n, err := recordBatchToJSON(rec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("rows: got %d want 2", n)
+	}
+	want := `[{"c":[1,2,3]},{"c":[9,null]}]`
+	if string(body) != want {
+		t.Fatalf("body: got %s want %s", string(body), want)
+	}
+}

--- a/pkg/destination/starrocks/mapper.go
+++ b/pkg/destination/starrocks/mapper.go
@@ -58,9 +58,36 @@ func MapDataTypeToStarRocks(col schema.Column) string {
 	case schema.TypeTimestamp, schema.TypeTimestampTZ:
 		// StarRocks DATETIME has no time zone; it stores the wall-clock value.
 		return "DATETIME"
-	case schema.TypeJSON, schema.TypeArray:
+	case schema.TypeArray:
+		if elem, ok := starRocksArrayElement(col); ok {
+			return fmt.Sprintf("ARRAY<%s>", elem)
+		}
+		// Fall back to JSON for element types a StarRocks ARRAY can't hold
+		// (binary, JSON, nested arrays, or an unknown element type).
+		return "JSON"
+	case schema.TypeJSON:
 		return "JSON"
 	default:
 		return "VARCHAR(65533)"
+	}
+}
+
+// starRocksArrayElement returns the DDL for an ARRAY's element type, or false
+// when a StarRocks ARRAY can't hold that element (so the caller uses JSON). The
+// element carries the column's precision/scale, matching the schema layer's
+// convention for array columns.
+func starRocksArrayElement(col schema.Column) (string, bool) {
+	switch col.ArrayType {
+	case schema.TypeBoolean, schema.TypeInt8, schema.TypeInt16, schema.TypeInt32,
+		schema.TypeInt64, schema.TypeFloat32, schema.TypeFloat64, schema.TypeDecimal,
+		schema.TypeString, schema.TypeUUID, schema.TypeInterval, schema.TypeDate,
+		schema.TypeTime, schema.TypeTimestamp, schema.TypeTimestampTZ:
+		return MapDataTypeToStarRocks(schema.Column{
+			DataType:  col.ArrayType,
+			Precision: col.Precision,
+			Scale:     col.Scale,
+		}), true
+	default:
+		return "", false
 	}
 }

--- a/pkg/destination/starrocks/mapper.go
+++ b/pkg/destination/starrocks/mapper.go
@@ -1,0 +1,66 @@
+package starrocks
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+const maxDecimal128Precision = 38
+
+// MapDataTypeToStarRocks maps an internal schema.Column to a StarRocks DDL type.
+func MapDataTypeToStarRocks(col schema.Column) string {
+	switch col.DataType {
+	case schema.TypeBoolean:
+		return "BOOLEAN"
+	case schema.TypeInt8:
+		return "TINYINT"
+	case schema.TypeInt16:
+		return "SMALLINT"
+	case schema.TypeInt32:
+		return "INT"
+	case schema.TypeInt64:
+		return "BIGINT"
+	case schema.TypeFloat32:
+		return "FLOAT"
+	case schema.TypeFloat64:
+		return "DOUBLE"
+	case schema.TypeDecimal:
+		precision := col.Precision
+		scale := col.Scale
+		if precision <= 0 {
+			precision, scale = 38, 9
+		}
+		if precision > maxDecimal128Precision {
+			precision = maxDecimal128Precision
+		}
+		if scale < 0 {
+			scale = 0
+		}
+		if scale > precision {
+			scale = precision
+		}
+		return fmt.Sprintf("DECIMAL(%d, %d)", precision, scale)
+	case schema.TypeString, schema.TypeUUID, schema.TypeInterval:
+		// VARCHAR is usable as a key column; STRING (1 MB) is not. Bound the
+		// length so the column can serve as a primary/distribution key.
+		if col.MaxLength > 0 && col.MaxLength <= 65533 {
+			return fmt.Sprintf("VARCHAR(%d)", col.MaxLength)
+		}
+		return "VARCHAR(65533)"
+	case schema.TypeBinary:
+		return "VARBINARY"
+	case schema.TypeDate:
+		return "DATE"
+	case schema.TypeTime:
+		// StarRocks has no standalone TIME type; carry it as a string.
+		return "VARCHAR(64)"
+	case schema.TypeTimestamp, schema.TypeTimestampTZ:
+		// StarRocks DATETIME has no time zone; it stores the wall-clock value.
+		return "DATETIME"
+	case schema.TypeJSON, schema.TypeArray:
+		return "JSON"
+	default:
+		return "VARCHAR(65533)"
+	}
+}

--- a/pkg/destination/starrocks/register.go
+++ b/pkg/destination/starrocks/register.go
@@ -1,0 +1,10 @@
+package starrocks
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"starrocks"},
+		func() interface{} { return NewStarRocksDestination() },
+	)
+}

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -69,6 +69,11 @@ func (d *StarRocksDestination) Connect(ctx context.Context, uri string) error {
 	}
 	d.replicationNum = query.Get("replication_num")
 
+	tls, err := tlsParam(query.Get("ssl"))
+	if err != nil {
+		return err
+	}
+
 	dsn := ""
 	if user != "" {
 		dsn = user
@@ -80,6 +85,9 @@ func (d *StarRocksDestination) Connect(ctx context.Context, uri string) error {
 	// The database is omitted from the DSN: it may not exist yet (the destination
 	// creates it), and pinning it would make the driver USE it on connect.
 	dsn += fmt.Sprintf("tcp(%s:%s)/?parseTime=true", host, port)
+	if tls != "" {
+		dsn += "&tls=" + tls
+	}
 
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -236,11 +236,43 @@ func (d *StarRocksDestination) nextLabel(table string) string {
 	return fmt.Sprintf("ingestr_%s_%d_%d", safe, time.Now().UnixNano(), n)
 }
 
-// SwapTable is unused: StarRocks SWAP WITH / RENAME are single-database only,
-// but ingestr stages into a separate database. SupportsAtomicSwap returns false
-// so the replace strategy writes directly to the target instead.
+// SwapTable atomically replaces the target's data from staging. StarRocks
+// SWAP WITH / RENAME are single-database only (and ingestr stages into a
+// separate database), so instead it uses INSERT OVERWRITE: StarRocks loads into
+// temporary partitions and swaps them in only on success, leaving the target's
+// existing data intact if the load fails.
 func (d *StarRocksDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
-	return fmt.Errorf("starrocks: atomic swap is not supported; replace writes directly to the target")
+	if db, _ := splitDatabaseTable(opts.TargetTable); db != "" {
+		createDB := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteColumn(db))
+		if _, err := d.db.ExecContext(ctx, createDB); err != nil {
+			config.LogFailedQuery(createDB, err)
+			return fmt.Errorf("failed to ensure target database: %w", err)
+		}
+	}
+	if opts.Schema != nil {
+		createSQL := d.buildCreateTableSQL(opts.TargetTable, opts.Schema.Columns, opts.PrimaryKeys)
+		if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+			config.LogFailedQuery(createSQL, err)
+			return fmt.Errorf("failed to create target table: %w", err)
+		}
+	}
+
+	overwriteSQL := fmt.Sprintf("INSERT OVERWRITE %s SELECT * FROM %s",
+		quoteTable(opts.TargetTable), quoteTable(opts.StagingTable))
+	if opts.Schema != nil && len(opts.Schema.Columns) > 0 {
+		cols := make([]string, len(opts.Schema.Columns))
+		for i, c := range opts.Schema.Columns {
+			cols[i] = quoteColumn(c.Name)
+		}
+		list := strings.Join(cols, ", ")
+		overwriteSQL = fmt.Sprintf("INSERT OVERWRITE %s (%s) SELECT %s FROM %s",
+			quoteTable(opts.TargetTable), list, list, quoteTable(opts.StagingTable))
+	}
+	if _, err := d.db.ExecContext(ctx, overwriteSQL); err != nil {
+		config.LogFailedQuery(overwriteSQL, err)
+		return fmt.Errorf("failed to overwrite target table: %w", err)
+	}
+	return d.DropTable(ctx, opts.StagingTable)
 }
 
 func (d *StarRocksDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
@@ -352,6 +384,6 @@ func (d *StarRocksDestination) SupportsAppendStrategy() bool       { return true
 func (d *StarRocksDestination) SupportsMergeStrategy() bool        { return true }
 func (d *StarRocksDestination) SupportsDeleteInsertStrategy() bool { return false }
 func (d *StarRocksDestination) SupportsSCD2Strategy() bool         { return false }
-func (d *StarRocksDestination) SupportsAtomicSwap() bool           { return false }
+func (d *StarRocksDestination) SupportsAtomicSwap() bool           { return true }
 
 var _ destination.Destination = (*StarRocksDestination)(nil)

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -153,6 +153,36 @@ func (d *StarRocksDestination) PrepareTable(ctx context.Context, opts destinatio
 // buildCreateTableSQL renders StarRocks DDL. With primary keys it creates a
 // PRIMARY KEY table (key columns declared first and NOT NULL, hash-distributed
 // on the keys); otherwise a duplicate-key table with random distribution.
+// isStarRocksKeyable reports whether a column type may be a StarRocks key (and
+// therefore the leading column of a duplicate-key table).
+func isStarRocksKeyable(col schema.Column) bool {
+	switch col.DataType {
+	case schema.TypeFloat32, schema.TypeFloat64, schema.TypeBinary, schema.TypeJSON, schema.TypeArray:
+		return false
+	default:
+		return true
+	}
+}
+
+// keyableFirst returns columns with the first keyable column moved to the front
+// when the leading column isn't keyable, leaving order unchanged otherwise. If
+// no column is keyable the input is returned as-is.
+func keyableFirst(columns []schema.Column) []schema.Column {
+	if len(columns) == 0 || isStarRocksKeyable(columns[0]) {
+		return columns
+	}
+	for i, c := range columns {
+		if isStarRocksKeyable(c) {
+			out := make([]schema.Column, 0, len(columns))
+			out = append(out, c)
+			out = append(out, columns[:i]...)
+			out = append(out, columns[i+1:]...)
+			return out
+		}
+	}
+	return columns
+}
+
 func (d *StarRocksDestination) buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
 	pkSet := make(map[string]bool, len(primaryKeys))
 	for _, k := range primaryKeys {
@@ -185,7 +215,12 @@ func (d *StarRocksDestination) buildCreateTableSQL(table string, columns []schem
 			}
 		}
 	} else {
-		for _, c := range columns {
+		// A duplicate-key table's leading column becomes the sort key, which
+		// StarRocks rejects for non-keyable types (FLOAT/DOUBLE/ARRAY/JSON/
+		// VARBINARY). Move the first keyable column to the front so table
+		// creation succeeds; Stream Load and the swap/merge SQL map by name, so
+		// column order is not otherwise significant.
+		for _, c := range keyableFirst(columns) {
 			colDefs = append(colDefs, colDef(c, false))
 		}
 	}

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -77,7 +77,9 @@ func (d *StarRocksDestination) Connect(ctx context.Context, uri string) error {
 		}
 		dsn += "@"
 	}
-	dsn += fmt.Sprintf("tcp(%s:%s)/%s?parseTime=true", host, port, d.database)
+	// The database is omitted from the DSN: it may not exist yet (the destination
+	// creates it), and pinning it would make the driver USE it on connect.
+	dsn += fmt.Sprintf("tcp(%s:%s)/?parseTime=true", host, port)
 
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -277,14 +277,15 @@ func (d *StarRocksDestination) WriteParallel(ctx context.Context, records <-chan
 		}
 		batchNum++
 
-		body, rows, err := recordBatchToJSON(result.Batch)
+		body, rows, binaryCols, err := recordBatchToJSON(result.Batch)
 		if err != nil {
 			result.Batch.Release()
 			return fmt.Errorf("failed to encode batch %d: %w", batchNum, err)
 		}
 		if rows > 0 {
 			label := d.nextLabel(table)
-			if err := d.loader.load(ctx, db, table, label, body); err != nil {
+			columns := columnsHeader(result.Batch.Schema(), binaryCols)
+			if err := d.loader.load(ctx, db, table, label, body, columns); err != nil {
 				result.Batch.Release()
 				return fmt.Errorf("failed to stream load batch %d: %w", batchNum, err)
 			}

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -58,7 +58,13 @@ func (d *StarRocksDestination) Connect(ctx context.Context, uri string) error {
 		user = u.User.Username()
 		password, _ = u.User.Password()
 	}
-	d.database = strings.TrimPrefix(u.Path, "/")
+	// Accept a [catalog/]database path: a connection shared with the source may
+	// carry a catalog, but the destination writes to the native catalog, so use
+	// the last path segment as the database.
+	if trimmed := strings.Trim(u.Path, "/"); trimmed != "" {
+		parts := strings.Split(trimmed, "/")
+		d.database = parts[len(parts)-1]
+	}
 
 	query := u.Query()
 	httpPort := defaultHTTPPort

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -20,6 +20,10 @@ import (
 
 const defaultHTTPPort = 8030
 
+// syntheticSortKeyColumn is added as an auto-increment key only when a table
+// has no column StarRocks can use as a sort key (all columns non-keyable).
+const syntheticSortKeyColumn = "__ingestr_sort_key"
+
 // StarRocksDestination loads data into StarRocks. DDL and table swaps go over
 // the MySQL protocol (FE query port); row data is loaded via the Stream Load
 // HTTP API (FE http port).
@@ -198,6 +202,7 @@ func (d *StarRocksDestination) buildCreateTableSQL(table string, columns []schem
 	}
 
 	var colDefs []string
+	syntheticKey := false
 	if len(primaryKeys) > 0 {
 		// Key columns must be declared first, in key order, and NOT NULL.
 		byName := make(map[string]schema.Column, len(columns))
@@ -220,18 +225,29 @@ func (d *StarRocksDestination) buildCreateTableSQL(table string, columns []schem
 		// VARBINARY). Move the first keyable column to the front so table
 		// creation succeeds; Stream Load and the swap/merge SQL map by name, so
 		// column order is not otherwise significant.
-		for _, c := range keyableFirst(columns) {
+		ordered := keyableFirst(columns)
+		if len(ordered) > 0 && !isStarRocksKeyable(ordered[0]) {
+			// No column can be a sort key, so synthesize an auto-increment key.
+			// Stream Load fills it automatically since it isn't in the batch.
+			syntheticKey = true
+			colDefs = append(colDefs, quoteColumn(syntheticSortKeyColumn)+" BIGINT AUTO_INCREMENT")
+		}
+		for _, c := range ordered {
 			colDefs = append(colDefs, colDef(c, false))
 		}
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)", quoteTable(table), strings.Join(colDefs, ",\n  "))
 
-	if len(primaryKeys) > 0 {
+	switch {
+	case len(primaryKeys) > 0:
 		keys := quoteColumns(primaryKeys)
 		joined := strings.Join(keys, ", ")
 		sql += fmt.Sprintf("\nPRIMARY KEY (%s)\nDISTRIBUTED BY HASH (%s)", joined, joined)
-	} else {
+	case syntheticKey:
+		k := quoteColumn(syntheticSortKeyColumn)
+		sql += fmt.Sprintf("\nDUPLICATE KEY (%s)\nDISTRIBUTED BY HASH (%s)", k, k)
+	default:
 		sql += "\nDISTRIBUTED BY RANDOM"
 	}
 

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -1,0 +1,357 @@
+package starrocks
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const defaultHTTPPort = 8030
+
+// StarRocksDestination loads data into StarRocks. DDL and table swaps go over
+// the MySQL protocol (FE query port); row data is loaded via the Stream Load
+// HTTP API (FE http port).
+type StarRocksDestination struct {
+	db             *sql.DB
+	loader         *streamLoader
+	database       string
+	replicationNum string // empty => use the cluster default
+	labelCounter   int64
+}
+
+func NewStarRocksDestination() *StarRocksDestination {
+	return &StarRocksDestination{}
+}
+
+func (d *StarRocksDestination) Schemes() []string { return []string{"starrocks"} }
+
+func (d *StarRocksDestination) GetScheme() string { return "starrocks" }
+
+func (d *StarRocksDestination) Connect(ctx context.Context, uri string) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse StarRocks URI: %w", err)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	port := u.Port()
+	if port == "" {
+		port = "9030"
+	}
+	var user, password string
+	if u.User != nil {
+		user = u.User.Username()
+		password, _ = u.User.Password()
+	}
+	d.database = strings.TrimPrefix(u.Path, "/")
+
+	query := u.Query()
+	httpPort := defaultHTTPPort
+	if v := query.Get("http_port"); v != "" {
+		if p, convErr := strconv.Atoi(v); convErr == nil {
+			httpPort = p
+		}
+	}
+	d.replicationNum = query.Get("replication_num")
+
+	dsn := ""
+	if user != "" {
+		dsn = user
+		if password != "" {
+			dsn += ":" + password
+		}
+		dsn += "@"
+	}
+	dsn += fmt.Sprintf("tcp(%s:%s)/%s?parseTime=true", host, port, d.database)
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return fmt.Errorf("failed to open StarRocks connection: %w", err)
+	}
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping StarRocks: %w", err)
+	}
+
+	d.db = db
+	d.loader = newStreamLoader(host, httpPort, user, password)
+	config.Debug("[STARROCKS] Connected (database: %s, http_port: %d)", d.database, httpPort)
+	return nil
+}
+
+func (d *StarRocksDestination) Close(ctx context.Context) error {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}
+
+func (d *StarRocksDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := tablename.TwoLevel("starrocks").CheckName(opts.Table); err != nil {
+		return err
+	}
+	if db, _ := splitDatabaseTable(opts.Table); db != "" {
+		createDB := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteColumn(db))
+		if _, err := d.db.ExecContext(ctx, createDB); err != nil {
+			config.LogFailedQuery(createDB, err)
+			return fmt.Errorf("failed to ensure database %s: %w", db, err)
+		}
+	}
+
+	if opts.DropFirst {
+		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", quoteTable(opts.Table))
+		if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+			config.LogFailedQuery(dropSQL, err)
+			return fmt.Errorf("failed to drop table: %w", err)
+		}
+	}
+
+	if opts.Schema != nil {
+		createSQL := d.buildCreateTableSQL(opts.Table, opts.Schema.Columns, opts.PrimaryKeys)
+		if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+			config.LogFailedQuery(createSQL, err)
+			return fmt.Errorf("failed to create table: %w", err)
+		}
+	}
+	return nil
+}
+
+// buildCreateTableSQL renders StarRocks DDL. With primary keys it creates a
+// PRIMARY KEY table (key columns declared first and NOT NULL, hash-distributed
+// on the keys); otherwise a duplicate-key table with random distribution.
+func (d *StarRocksDestination) buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, k := range primaryKeys {
+		pkSet[strings.ToLower(k)] = true
+	}
+
+	colDef := func(col schema.Column, forceNotNull bool) string {
+		def := fmt.Sprintf("%s %s", quoteColumn(col.Name), MapDataTypeToStarRocks(col))
+		if forceNotNull {
+			def += " NOT NULL"
+		}
+		return def
+	}
+
+	var colDefs []string
+	if len(primaryKeys) > 0 {
+		// Key columns must be declared first, in key order, and NOT NULL.
+		byName := make(map[string]schema.Column, len(columns))
+		for _, c := range columns {
+			byName[strings.ToLower(c.Name)] = c
+		}
+		for _, k := range primaryKeys {
+			if c, ok := byName[strings.ToLower(k)]; ok {
+				colDefs = append(colDefs, colDef(c, true))
+			}
+		}
+		for _, c := range columns {
+			if !pkSet[strings.ToLower(c.Name)] {
+				colDefs = append(colDefs, colDef(c, false))
+			}
+		}
+	} else {
+		for _, c := range columns {
+			colDefs = append(colDefs, colDef(c, false))
+		}
+	}
+
+	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)", quoteTable(table), strings.Join(colDefs, ",\n  "))
+
+	if len(primaryKeys) > 0 {
+		keys := quoteColumns(primaryKeys)
+		joined := strings.Join(keys, ", ")
+		sql += fmt.Sprintf("\nPRIMARY KEY (%s)\nDISTRIBUTED BY HASH (%s)", joined, joined)
+	} else {
+		sql += "\nDISTRIBUTED BY RANDOM"
+	}
+
+	if d.replicationNum != "" {
+		sql += fmt.Sprintf("\nPROPERTIES (\"replication_num\" = \"%s\")", d.replicationNum)
+	}
+	return sql
+}
+
+func (d *StarRocksDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.WriteParallel(ctx, records, opts)
+}
+
+func (d *StarRocksDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	startTime := time.Now()
+	var totalRows int64
+	var batchNum int
+
+	db, table := splitDatabaseTable(opts.Table)
+	if db == "" {
+		db = d.database
+	}
+
+	for result := range records {
+		if result.Err != nil {
+			return result.Err
+		}
+		batchNum++
+
+		body, rows, err := recordBatchToJSON(result.Batch)
+		if err != nil {
+			result.Batch.Release()
+			return fmt.Errorf("failed to encode batch %d: %w", batchNum, err)
+		}
+		if rows > 0 {
+			label := d.nextLabel(table)
+			if err := d.loader.load(ctx, db, table, label, body); err != nil {
+				result.Batch.Release()
+				return fmt.Errorf("failed to stream load batch %d: %w", batchNum, err)
+			}
+			totalRows += rows
+		}
+		result.Batch.Release()
+	}
+
+	config.Debug("[STARROCKS] Wrote %d rows in %d batches in %v", totalRows, batchNum, time.Since(startTime))
+	return nil
+}
+
+func (d *StarRocksDestination) nextLabel(table string) string {
+	n := atomic.AddInt64(&d.labelCounter, 1)
+	safe := strings.NewReplacer(".", "_", "`", "", "-", "_").Replace(table)
+	return fmt.Sprintf("ingestr_%s_%d_%d", safe, time.Now().UnixNano(), n)
+}
+
+// SwapTable is unused: StarRocks SWAP WITH / RENAME are single-database only,
+// but ingestr stages into a separate database. SupportsAtomicSwap returns false
+// so the replace strategy writes directly to the target instead.
+func (d *StarRocksDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	return fmt.Errorf("starrocks: atomic swap is not supported; replace writes directly to the target")
+}
+
+func (d *StarRocksDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	cols := quoteColumns(opts.Columns)
+	colList := strings.Join(cols, ", ")
+	// The target is a PRIMARY KEY table, so INSERT upserts on the key.
+	mergeSQL := fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s",
+		quoteTable(opts.TargetTable), colList, colList, quoteTable(opts.StagingTable))
+	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to merge into table: %w", err)
+	}
+	return nil
+}
+
+func (d *StarRocksDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
+	return fmt.Errorf("starrocks: delete+insert strategy is not supported")
+}
+
+func (d *StarRocksDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
+	return fmt.Errorf("starrocks: scd2 strategy is not supported")
+}
+
+func (d *StarRocksDestination) DropTable(ctx context.Context, table string) error {
+	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+		config.LogFailedQuery(dropSQL, err)
+		return fmt.Errorf("failed to drop table %s: %w", table, err)
+	}
+	return nil
+}
+
+func (d *StarRocksDestination) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := d.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (d *StarRocksDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
+	// StarRocks has no general multi-statement DML transactions; statements run
+	// directly (auto-committed). Only delete+insert needs a real transaction,
+	// and that strategy is unsupported here.
+	return &starRocksTransaction{db: d.db}, nil
+}
+
+type starRocksTransaction struct {
+	db *sql.DB
+}
+
+func (t *starRocksTransaction) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := t.db.ExecContext(ctx, query, args...)
+	return err
+}
+func (t *starRocksTransaction) Commit(ctx context.Context) error   { return nil }
+func (t *starRocksTransaction) Rollback(ctx context.Context) error { return nil }
+
+func (d *StarRocksDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	db, tableName := splitDatabaseTable(table)
+	if db == "" {
+		db = d.database
+	}
+
+	query := `
+		SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, NUMERIC_PRECISION, NUMERIC_SCALE, CHARACTER_MAXIMUM_LENGTH
+		FROM information_schema.columns
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+		ORDER BY ORDINAL_POSITION`
+
+	rows, err := d.db.QueryContext(ctx, query, db, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query table schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	for rows.Next() {
+		var colName, dataType, isNullable string
+		var numPrecision, numScale, charMaxLen *int
+		if err := rows.Scan(&colName, &dataType, &isNullable, &numPrecision, &numScale, &charMaxLen); err != nil {
+			return nil, fmt.Errorf("failed to scan column: %w", err)
+		}
+		col := schema.Column{
+			Name:     colName,
+			DataType: mapStarRocksTypeToSchema(dataType),
+			Nullable: strings.EqualFold(isNullable, "YES"),
+		}
+		if numPrecision != nil {
+			col.Precision = *numPrecision
+		}
+		if numScale != nil {
+			col.Scale = *numScale
+		}
+		if charMaxLen != nil {
+			col.MaxLength = *charMaxLen
+		}
+		columns = append(columns, col)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+	if len(columns) == 0 {
+		return nil, nil
+	}
+	return &schema.TableSchema{Name: tableName, Schema: db, Columns: columns}, nil
+}
+
+func (d *StarRocksDestination) SupportsReplaceStrategy() bool      { return true }
+func (d *StarRocksDestination) SupportsAppendStrategy() bool       { return true }
+func (d *StarRocksDestination) SupportsMergeStrategy() bool        { return true }
+func (d *StarRocksDestination) SupportsDeleteInsertStrategy() bool { return false }
+func (d *StarRocksDestination) SupportsSCD2Strategy() bool         { return false }
+func (d *StarRocksDestination) SupportsAtomicSwap() bool           { return false }
+
+var _ destination.Destination = (*StarRocksDestination)(nil)

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -105,6 +105,24 @@ func TestBuildCreateTableSQL_ReordersNonKeyableFirstColumn(t *testing.T) {
 	}
 }
 
+func TestBuildCreateTableSQL_SyntheticKeyWhenNoKeyableColumn(t *testing.T) {
+	d := &StarRocksDestination{replicationNum: "1"}
+	cols := []schema.Column{
+		{Name: "f", DataType: schema.TypeFloat64},
+		{Name: "arr", DataType: schema.TypeArray, ArrayType: schema.TypeInt64},
+	}
+	got := d.buildCreateTableSQL("db.t", cols, nil)
+	for _, want := range []string{
+		"`__ingestr_sort_key` BIGINT AUTO_INCREMENT",
+		"DUPLICATE KEY (`__ingestr_sort_key`)",
+		"DISTRIBUTED BY HASH (`__ingestr_sort_key`)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestKeyableFirstLeavesKeyableLeadUntouched(t *testing.T) {
 	cols := []schema.Column{
 		{Name: "id", DataType: schema.TypeInt64},

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -125,7 +125,10 @@ func TestStrategySupport(t *testing.T) {
 	if !d.SupportsReplaceStrategy() || !d.SupportsAppendStrategy() || !d.SupportsMergeStrategy() {
 		t.Error("replace/append/merge should be supported")
 	}
-	if d.SupportsDeleteInsertStrategy() || d.SupportsSCD2Strategy() || d.SupportsAtomicSwap() {
-		t.Error("delete+insert / scd2 / atomic swap should not be supported")
+	if !d.SupportsAtomicSwap() {
+		t.Error("atomic swap should be supported (INSERT OVERWRITE)")
+	}
+	if d.SupportsDeleteInsertStrategy() || d.SupportsSCD2Strategy() {
+		t.Error("delete+insert / scd2 should not be supported")
 	}
 }

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -120,6 +120,34 @@ func TestNextLabelUnique(t *testing.T) {
 	}
 }
 
+func TestTLSParam(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"false", "", false},
+		{"true", "true", false},
+		{"require", "true", false},
+		{"skip-verify", "skip-verify", false},
+		{"insecure", "skip-verify", false},
+		{"yes", "", true},
+	}
+	for _, c := range cases {
+		got, err := tlsParam(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("tlsParam(%q): expected error", c.in)
+			}
+			continue
+		}
+		if err != nil || got != c.want {
+			t.Errorf("tlsParam(%q) = (%q,%v) want (%q,nil)", c.in, got, err, c.want)
+		}
+	}
+}
+
 func TestStrategySupport(t *testing.T) {
 	d := NewStarRocksDestination()
 	if !d.SupportsReplaceStrategy() || !d.SupportsAppendStrategy() || !d.SupportsMergeStrategy() {

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -88,6 +88,34 @@ func TestBuildCreateTableSQL_PrimaryKey(t *testing.T) {
 	}
 }
 
+func TestBuildCreateTableSQL_ReordersNonKeyableFirstColumn(t *testing.T) {
+	d := &StarRocksDestination{replicationNum: "1"}
+	cols := []schema.Column{
+		{Name: "tags", DataType: schema.TypeArray, ArrayType: schema.TypeString},
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "score", DataType: schema.TypeFloat64},
+	}
+	got := d.buildCreateTableSQL("db.t", cols, nil)
+	// The non-keyable array must not be the first column; the keyable id moves up.
+	if strings.Index(got, "`id`") > strings.Index(got, "`tags`") {
+		t.Errorf("keyable column should be declared first:\n%s", got)
+	}
+	if !strings.Contains(got, "DISTRIBUTED BY RANDOM") {
+		t.Errorf("expected duplicate-key layout:\n%s", got)
+	}
+}
+
+func TestKeyableFirstLeavesKeyableLeadUntouched(t *testing.T) {
+	cols := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "tags", DataType: schema.TypeArray},
+	}
+	got := keyableFirst(cols)
+	if got[0].Name != "id" || got[1].Name != "tags" {
+		t.Errorf("order should be unchanged when the first column is keyable: %+v", got)
+	}
+}
+
 func TestSplitDatabaseTable(t *testing.T) {
 	cases := []struct{ in, db, tbl string }{
 		{"db.t", "db", "t"},

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -1,0 +1,131 @@
+package starrocks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+func TestMapDataTypeToStarRocks(t *testing.T) {
+	tests := []struct {
+		name string
+		col  schema.Column
+		want string
+	}{
+		{"bool", schema.Column{DataType: schema.TypeBoolean}, "BOOLEAN"},
+		{"int32", schema.Column{DataType: schema.TypeInt32}, "INT"},
+		{"int64", schema.Column{DataType: schema.TypeInt64}, "BIGINT"},
+		{"double", schema.Column{DataType: schema.TypeFloat64}, "DOUBLE"},
+		{"decimal", schema.Column{DataType: schema.TypeDecimal, Precision: 18, Scale: 4}, "DECIMAL(18, 4)"},
+		{"decimal default", schema.Column{DataType: schema.TypeDecimal}, "DECIMAL(38, 9)"},
+		{"decimal clamp", schema.Column{DataType: schema.TypeDecimal, Precision: 40, Scale: 4}, "DECIMAL(38, 4)"},
+		{"string default", schema.Column{DataType: schema.TypeString}, "VARCHAR(65533)"},
+		{"string bounded", schema.Column{DataType: schema.TypeString, MaxLength: 100}, "VARCHAR(100)"},
+		{"date", schema.Column{DataType: schema.TypeDate}, "DATE"},
+		{"time", schema.Column{DataType: schema.TypeTime}, "VARCHAR(64)"},
+		{"timestamp", schema.Column{DataType: schema.TypeTimestamp}, "DATETIME"},
+		{"timestamptz", schema.Column{DataType: schema.TypeTimestampTZ}, "DATETIME"},
+		{"json", schema.Column{DataType: schema.TypeJSON}, "JSON"},
+		{"binary", schema.Column{DataType: schema.TypeBinary}, "VARBINARY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MapDataTypeToStarRocks(tt.col); got != tt.want {
+				t.Errorf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCreateTableSQL_DuplicateKey(t *testing.T) {
+	d := &StarRocksDestination{replicationNum: "1"}
+	cols := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString},
+	}
+	got := d.buildCreateTableSQL("db.t", cols, nil)
+	for _, want := range []string{
+		"CREATE TABLE IF NOT EXISTS `db`.`t`",
+		"`id` BIGINT",
+		"`name` VARCHAR(65533)",
+		"DISTRIBUTED BY RANDOM",
+		`PROPERTIES ("replication_num" = "1")`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "PRIMARY KEY") {
+		t.Errorf("duplicate-key table should not declare PRIMARY KEY:\n%s", got)
+	}
+}
+
+func TestBuildCreateTableSQL_PrimaryKey(t *testing.T) {
+	d := &StarRocksDestination{}
+	cols := []schema.Column{
+		{Name: "name", DataType: schema.TypeString},
+		{Name: "id", DataType: schema.TypeInt64},
+	}
+	got := d.buildCreateTableSQL("db.t", cols, []string{"id"})
+	// Key column must be declared first and NOT NULL.
+	if !strings.Contains(got, "`id` BIGINT NOT NULL") {
+		t.Errorf("primary key column should be NOT NULL:\n%s", got)
+	}
+	if idx, name := strings.Index(got, "`id`"), strings.Index(got, "`name`"); idx > name {
+		t.Errorf("primary key column should be declared before non-key columns:\n%s", got)
+	}
+	for _, want := range []string{"PRIMARY KEY (`id`)", "DISTRIBUTED BY HASH (`id`)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestSplitDatabaseTable(t *testing.T) {
+	cases := []struct{ in, db, tbl string }{
+		{"db.t", "db", "t"},
+		{"t", "", "t"},
+		{"a.b.c", "a", "b.c"},
+	}
+	for _, c := range cases {
+		db, tbl := splitDatabaseTable(c.in)
+		if db != c.db || tbl != c.tbl {
+			t.Errorf("splitDatabaseTable(%q) = (%q,%q) want (%q,%q)", c.in, db, tbl, c.db, c.tbl)
+		}
+	}
+}
+
+func TestQuoteTable(t *testing.T) {
+	if got := quoteTable("db.t"); got != "`db`.`t`" {
+		t.Errorf("got %q", got)
+	}
+	if got := quoteTable("t"); got != "`t`" {
+		t.Errorf("got %q", got)
+	}
+	if got := quoteTable("d.a`b"); !strings.Contains(got, "`a``b`") {
+		t.Errorf("escaping: got %q", got)
+	}
+}
+
+func TestNextLabelUnique(t *testing.T) {
+	d := &StarRocksDestination{}
+	a := d.nextLabel("db.events")
+	b := d.nextLabel("db.events")
+	if a == b {
+		t.Errorf("labels should be unique: %q == %q", a, b)
+	}
+	if strings.ContainsAny(a, ".`") {
+		t.Errorf("label should be sanitized: %q", a)
+	}
+}
+
+func TestStrategySupport(t *testing.T) {
+	d := NewStarRocksDestination()
+	if !d.SupportsReplaceStrategy() || !d.SupportsAppendStrategy() || !d.SupportsMergeStrategy() {
+		t.Error("replace/append/merge should be supported")
+	}
+	if d.SupportsDeleteInsertStrategy() || d.SupportsSCD2Strategy() || d.SupportsAtomicSwap() {
+		t.Error("delete+insert / scd2 / atomic swap should not be supported")
+	}
+}

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -28,6 +28,12 @@ func TestMapDataTypeToStarRocks(t *testing.T) {
 		{"timestamptz", schema.Column{DataType: schema.TypeTimestampTZ}, "DATETIME"},
 		{"json", schema.Column{DataType: schema.TypeJSON}, "JSON"},
 		{"binary", schema.Column{DataType: schema.TypeBinary}, "VARBINARY"},
+		{"array of int", schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeInt64}, "ARRAY<BIGINT>"},
+		{"array of string", schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeString}, "ARRAY<VARCHAR(65533)>"},
+		{"array of decimal", schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 10, Scale: 2}, "ARRAY<DECIMAL(10, 2)>"},
+		{"array of unknown element falls back to json", schema.Column{DataType: schema.TypeArray}, "JSON"},
+		{"array of binary falls back to json", schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeBinary}, "JSON"},
+		{"array of json falls back to json", schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeJSON}, "JSON"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/destination/starrocks/streamload.go
+++ b/pkg/destination/starrocks/streamload.go
@@ -1,0 +1,104 @@
+package starrocks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// streamLoader loads JSON batches into StarRocks via the Stream Load HTTP API.
+type streamLoader struct {
+	endpoint string // host:httpPort of the FE
+	user     string
+	password string
+	client   *http.Client
+}
+
+func newStreamLoader(host string, httpPort int, user, password string) *streamLoader {
+	return &streamLoader{
+		endpoint: fmt.Sprintf("%s:%d", host, httpPort),
+		user:     user,
+		password: password,
+		// Don't auto-follow redirects: the FE redirects to a BE and Go would drop
+		// the Authorization header and body on the cross-host hop, so we re-issue
+		// the request ourselves (see load).
+		client: &http.Client{
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+type streamLoadResponse struct {
+	Status           string `json:"Status"`
+	Message          string `json:"Message"`
+	NumberLoadedRows int64  `json:"NumberLoadedRows"`
+	NumberTotalRows  int64  `json:"NumberTotalRows"`
+	ErrorURL         string `json:"ErrorURL"`
+}
+
+// load streams a JSON-array body into db.table, following the FE -> BE redirect
+// manually so the Authorization header and body survive the hop.
+func (s *streamLoader) load(ctx context.Context, db, table, label string, body []byte) error {
+	url := fmt.Sprintf("http://%s/api/%s/%s/_stream_load", s.endpoint, db, table)
+
+	resp, err := s.put(ctx, url, label, body)
+	if err != nil {
+		return err
+	}
+	for hop := 0; hop < 3 && isRedirect(resp.StatusCode); hop++ {
+		loc := resp.Header.Get("Location")
+		_ = resp.Body.Close()
+		if loc == "" {
+			return fmt.Errorf("stream load redirect without a Location header")
+		}
+		if resp, err = s.put(ctx, loc, label, body); err != nil {
+			return err
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read stream load response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("stream load returned HTTP %d: %s", resp.StatusCode, string(data))
+	}
+
+	var slResp streamLoadResponse
+	if err := json.Unmarshal(data, &slResp); err != nil {
+		return fmt.Errorf("failed to parse stream load response: %w (body: %s)", err, string(data))
+	}
+	if slResp.Status != "Success" {
+		msg := slResp.Message
+		if slResp.ErrorURL != "" {
+			msg += " (details: " + slResp.ErrorURL + ")"
+		}
+		return fmt.Errorf("stream load failed (%s): %s", slResp.Status, msg)
+	}
+	return nil
+}
+
+func (s *streamLoader) put(ctx context.Context, url, label string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(s.user, s.password)
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Expect", "100-continue")
+	req.Header.Set("format", "json")
+	req.Header.Set("strip_outer_array", "true")
+	req.Header.Set("label", label)
+	return s.client.Do(req)
+}
+
+func isRedirect(code int) bool {
+	return code == http.StatusTemporaryRedirect || code == http.StatusPermanentRedirect ||
+		code == http.StatusMovedPermanently || code == http.StatusFound
+}

--- a/pkg/destination/starrocks/streamload.go
+++ b/pkg/destination/starrocks/streamload.go
@@ -43,10 +43,10 @@ type streamLoadResponse struct {
 
 // load streams a JSON-array body into db.table, following the FE -> BE redirect
 // manually so the Authorization header and body survive the hop.
-func (s *streamLoader) load(ctx context.Context, db, table, label string, body []byte) error {
+func (s *streamLoader) load(ctx context.Context, db, table, label string, body []byte, columns string) error {
 	url := fmt.Sprintf("http://%s/api/%s/%s/_stream_load", s.endpoint, db, table)
 
-	resp, err := s.put(ctx, url, label, body)
+	resp, err := s.put(ctx, url, label, columns, body)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (s *streamLoader) load(ctx context.Context, db, table, label string, body [
 		if loc == "" {
 			return fmt.Errorf("stream load redirect without a Location header")
 		}
-		if resp, err = s.put(ctx, loc, label, body); err != nil {
+		if resp, err = s.put(ctx, loc, label, columns, body); err != nil {
 			return err
 		}
 	}
@@ -86,7 +86,7 @@ func (s *streamLoader) load(ctx context.Context, db, table, label string, body [
 	return nil
 }
 
-func (s *streamLoader) put(ctx context.Context, url, label string, body []byte) (*http.Response, error) {
+func (s *streamLoader) put(ctx context.Context, url, label, columns string, body []byte) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -97,6 +97,9 @@ func (s *streamLoader) put(ctx context.Context, url, label string, body []byte) 
 	req.Header.Set("format", "json")
 	req.Header.Set("strip_outer_array", "true")
 	req.Header.Set("label", label)
+	if columns != "" {
+		req.Header.Set("columns", columns)
+	}
 	return s.client.Do(req)
 }
 

--- a/pkg/destination/starrocks/streamload.go
+++ b/pkg/destination/starrocks/streamload.go
@@ -74,7 +74,9 @@ func (s *streamLoader) load(ctx context.Context, db, table, label string, body [
 	if err := json.Unmarshal(data, &slResp); err != nil {
 		return fmt.Errorf("failed to parse stream load response: %w (body: %s)", err, string(data))
 	}
-	if slResp.Status != "Success" {
+	// "Publish Timeout" means the data was loaded and is durable — StarRocks
+	// says not to retry — so it is a success, not a failure.
+	if slResp.Status != "Success" && slResp.Status != "Publish Timeout" {
 		msg := slResp.Message
 		if slResp.ErrorURL != "" {
 			msg += " (details: " + slResp.ErrorURL + ")"


### PR DESCRIPTION
## Summary

Adds **StarRocks as a destination** (follow-up to the StarRocks source). StarRocks is an OLAP engine, so this is modeled on the ClickHouse destination rather than mirroring MySQL.

- **DDL / metadata / merge** go over the **MySQL protocol** (query port `9030`).
- **Row loading** goes over **Stream Load** — the StarRocks-native bulk HTTP loader (FE http port, default `8030`), one JSON batch per Arrow record batch. The FE→BE redirect is followed manually because Go drops the `Authorization` header and body on cross-host redirects.

## URI

`starrocks://user:pass@host:9030/<database>?http_port=8030&replication_num=1` — `http_port` (default 8030) and `replication_num` are destination-only params.