### PR TITLE
feat(mysql/vitess): support TLS for the Vitess CDC VStream connection

### DIFF
--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -19,8 +19,20 @@ URI parameters:
 
 The same URI structure and table can be used both for sources and destinations. You can read more about SQLAlchemy's MySQL dialect [here](https://docs.sqlalchemy.org/en/20/core/engines.html#mysql).
 
+## TLS / SSL
+Servers that require encrypted connections (for example PlanetScale, or any vtgate started with `--mysql_server_require_secure_transport`) reject plain connections with `server does not allow insecure connections, client must use SSL/TLS`. Enable TLS with the `tls` query parameter:
+
+```plaintext
+mysql://user:password@host:port/dbname?tls=true
+```
+
+Accepted values:
+- `tls=true`: connect over TLS and verify the server certificate against the system roots (use this for PlanetScale and any server with a publicly trusted certificate).
+- `tls=skip-verify`: connect over TLS but skip certificate verification (use for self-signed certificates).
+- `tls=preferred`: use TLS if the server offers it, otherwise fall back to plaintext.
+
 ## Vitess / PlanetScale
-[Vitess](https://vitess.io/) and [PlanetScale](https://planetscale.com/) are supported out of the box — use the same `mysql://` URI as above, no extra configuration needed.
+[Vitess](https://vitess.io/) and [PlanetScale](https://planetscale.com/) are supported out of the box — use the same `mysql://` URI as above. PlanetScale (and any TLS-only vtgate) requires `?tls=true`; see [TLS / SSL](#tls-ssl) above.
 
 By default Vitess caps queries at 100,000 rows, which would otherwise break bulk reads of larger tables. ingestr detects Vitess automatically and works around this, so large tables ingest fully.
 
@@ -70,6 +82,8 @@ VStream performs a consistent copy-phase snapshot first, then streams changes. P
 
 VStream uses vtgate's **gRPC** port, which is different from the MySQL protocol port and cannot be derived from it, so you must supply it with `grpc_port`. The database in the URI is the Vitess keyspace.
 
+CDC over Vitess opens two connections: the MySQL protocol (for schema discovery) and the vtgate gRPC port (for the change stream). A single `tls=true` secures **both** — the gRPC connection inherits the `tls` setting — so PlanetScale CDC needs only `?grpc_port=<port>&tls=true`. To control the gRPC side independently, use `grpc_tls` (see below).
+
 ```shell
 ingestr ingest \
   --source-uri "mysql+cdc://user:password@host:3306/keyspace?grpc_port=15991&mode=batch" \
@@ -81,6 +95,7 @@ ingestr ingest \
 Vitess CDC URI parameters:
 - `grpc_port`: **required** — the vtgate gRPC port (for example `15991`). The run fails with a clear error if it is missing on a Vitess server.
 - `grpc_host`: optional vtgate gRPC host; defaults to the host in the URI.
+- `grpc_tls`: optional override for the gRPC connection's TLS, independent of `tls`. `true` verifies the server certificate, `skip-verify` skips verification, `false` forces plaintext. When omitted, the gRPC connection inherits `tls` (`true`/`skip-verify` enable it; `preferred` and custom CA names do not).
 - `mode`: `batch`; defaults to `batch`.
 - `dest_schema`: optional destination schema for multi-table CDC runs.
 

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -394,9 +394,12 @@ func parseMySQLCDCURI(rawURI string) (MySQLCDCConfig, string, mysqlCDCConnInfo, 
 	query.Del("flavor")
 	query.Del("mode")
 	query.Del("server_id")
-	// Vitess-only parameters: irrelevant to (and rejected by) the MySQL DSN.
+	// Vitess-only parameters: irrelevant to (and rejected by) the MySQL DSN. The
+	// tls parameter is deliberately kept — it secures the MySQL-protocol probe and
+	// is also inherited by the VStream gRPC connection.
 	query.Del("grpc_port")
 	query.Del("grpc_host")
+	query.Del("grpc_tls")
 	parsed.RawQuery = query.Encode()
 
 	normalizedURI := parsed.String()

--- a/pkg/source/mysql/vitess_cdc.go
+++ b/pkg/source/mysql/vitess_cdc.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"encoding/base64"
 	"errors"
@@ -18,14 +19,17 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/grpcclient"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
-	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn" // registers the "grpc" dialer used by vtgateconn.Dial
-	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+	vtgateservicepb "vitess.io/vitess/go/vt/proto/vtgateservice"
 )
 
 // VitessCDCSource captures changes from a Vitess keyspace using the VStream gRPC
@@ -44,6 +48,7 @@ type VitessCDCSource struct {
 	keyspace   string
 	destSchema string
 	grpcTarget string
+	grpcCreds  credentials.TransportCredentials
 }
 
 func NewVitessCDCSource() *VitessCDCSource {
@@ -64,6 +69,11 @@ func (s *VitessCDCSource) Connect(ctx context.Context, uri string) error {
 	}
 
 	grpcTarget, err := vitessGRPCTarget(uri, connInfo.Host)
+	if err != nil {
+		return err
+	}
+
+	grpcCreds, err := vitessGRPCTLSCredentials(uri)
 	if err != nil {
 		return err
 	}
@@ -90,6 +100,7 @@ func (s *VitessCDCSource) Connect(ctx context.Context, uri string) error {
 	s.keyspace = database
 	s.destSchema = cfg.DestSchema
 	s.grpcTarget = grpcTarget
+	s.grpcCreds = grpcCreds
 	return nil
 }
 
@@ -325,13 +336,25 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 	}
 
 	flags := &vtgatepb.VStreamFlags{HeartbeatInterval: 1, StopOnReshard: false}
-	gconn, err := vtgateconn.Dial(ctx, s.grpcTarget)
+
+	// vtgateconn.Dial is unusable for TLS: its registered gRPC dialer appends an
+	// insecure transport credential that overrides whatever we pass, so a TLS-only
+	// vtgate (e.g. PlanetScale) is unreachable through it. Dial the vtgate service
+	// directly with the resolved credentials. grpcclient.DialContext is reused so
+	// the connection keeps Vitess's tuned defaults (16MB max message size,
+	// keepalive), which matter for large copy-phase VStream messages.
+	cc, err := grpcclient.DialContext(ctx, s.grpcTarget, grpcclient.FailFast(false), grpc.WithTransportCredentials(s.grpcCreds))
 	if err != nil {
 		return fmt.Errorf("failed to connect to vtgate gRPC at %s: %w", s.grpcTarget, err)
 	}
-	defer gconn.Close()
+	defer func() { _ = cc.Close() }()
 
-	reader, err := gconn.VStream(ctx, topodatapb.TabletType_PRIMARY, startVGtid, &binlogdatapb.Filter{Rules: rules}, flags)
+	reader, err := vtgateservicepb.NewVitessClient(cc).VStream(ctx, &vtgatepb.VStreamRequest{
+		TabletType: topodatapb.TabletType_PRIMARY,
+		Vgtid:      startVGtid,
+		Filter:     &binlogdatapb.Filter{Rules: rules},
+		Flags:      flags,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to start Vitess VStream: %w", err)
 	}
@@ -373,7 +396,7 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 		default:
 		}
 
-		events, err := reader.Recv()
+		resp, err := reader.Recv()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				if ferr := flushTxn(); ferr != nil {
@@ -387,7 +410,7 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 			return fmt.Errorf("vstream receive failed: %w", err)
 		}
 
-		for _, ev := range events {
+		for _, ev := range resp.Events {
 			switch ev.Type {
 			case binlogdatapb.VEventType_FIELD:
 				fe := ev.FieldEvent
@@ -665,6 +688,36 @@ func vitessGRPCTarget(rawURI string, defaultHost string) (string, error) {
 		host = "127.0.0.1"
 	}
 	return net.JoinHostPort(host, port), nil
+}
+
+// vitessGRPCTLSCredentials resolves the transport credentials for the VStream
+// gRPC connection. grpc_tls, when set, takes precedence; otherwise the gRPC side
+// inherits the MySQL-protocol tls parameter so a single tls=true secures both
+// connections. Only true and skip-verify enable TLS (skip-verify skips
+// certificate verification); false, preferred, a custom go-sql-driver TLS config
+// name, or an unset value leave the gRPC connection plaintext.
+func vitessGRPCTLSCredentials(rawURI string) (credentials.TransportCredentials, error) {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+
+	mode := strings.TrimSpace(strings.ToLower(q.Get("grpc_tls")))
+	if mode == "" {
+		mode = strings.TrimSpace(strings.ToLower(q.Get("tls")))
+	}
+
+	switch mode {
+	case "true", "skip-verify":
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		if mode == "skip-verify" {
+			cfg.InsecureSkipVerify = true
+		}
+		return credentials.NewTLS(cfg), nil
+	default:
+		return insecure.NewCredentials(), nil
+	}
 }
 
 var vitessLSNRegex = regexp.MustCompile(`^(\d{20}):(\d{6}):(.+)$`)

--- a/pkg/source/mysql/vitess_cdc_test.go
+++ b/pkg/source/mysql/vitess_cdc_test.go
@@ -102,9 +102,10 @@ func TestVitessGRPCTarget(t *testing.T) {
 }
 
 // The MySQL DSN must never carry the Vitess-only gRPC params, otherwise the
-// go-sql-driver rejects them as unknown.
+// go-sql-driver rejects them as unknown. The tls param, by contrast, is a real
+// driver param and must be retained.
 func TestMySQLCDCURIStripsGRPCParams(t *testing.T) {
-	_, normalizedURI, _, err := parseMySQLCDCURI("mysql+cdc://root@db.example:3307/ks?grpc_port=15991&grpc_host=vtgate")
+	_, normalizedURI, _, err := parseMySQLCDCURI("mysql+cdc://root@db.example:3307/ks?grpc_port=15991&grpc_host=vtgate&grpc_tls=true&tls=true")
 	if err != nil {
 		t.Fatalf("parseMySQLCDCURI: %v", err)
 	}
@@ -112,8 +113,44 @@ func TestMySQLCDCURIStripsGRPCParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("uriToDSN: %v", err)
 	}
-	if strings.Contains(dsn, "grpc_port") || strings.Contains(dsn, "grpc_host") {
+	if strings.Contains(dsn, "grpc_port") || strings.Contains(dsn, "grpc_host") || strings.Contains(dsn, "grpc_tls") {
 		t.Errorf("DSN must not contain gRPC params: %q", dsn)
+	}
+	if !strings.Contains(dsn, "tls=true") {
+		t.Errorf("DSN must retain the MySQL tls param: %q", dsn)
+	}
+}
+
+// vitessGRPCTLSCredentials must turn the user-facing tls/grpc_tls knobs into the
+// right transport security: a single tls=true secures both connections, while
+// grpc_tls overrides the gRPC side independently.
+func TestVitessGRPCTLSCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		uri     string
+		wantTLS bool
+	}{
+		{"no params is plaintext", "mysql+cdc://root@h:3307/ks?grpc_port=15991", false},
+		{"tls=true is inherited", "mysql+cdc://root@h:3307/ks?grpc_port=15991&tls=true", true},
+		{"tls=skip-verify is inherited", "mysql+cdc://root@h:3307/ks?grpc_port=15991&tls=skip-verify", true},
+		{"tls=false stays plaintext", "mysql+cdc://root@h:3307/ks?grpc_port=15991&tls=false", false},
+		{"tls=preferred does not map to gRPC", "mysql+cdc://root@h:3307/ks?grpc_port=15991&tls=preferred", false},
+		{"tls=customCA does not map to gRPC", "mysql+cdc://root@h:3307/ks?grpc_port=15991&tls=mycustomca", false},
+		{"grpc_tls=true overrides", "mysql+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=true", true},
+		{"grpc_tls=false overrides tls=true", "mysql+cdc://root@h:3307/ks?grpc_port=15991&tls=true&grpc_tls=false", false},
+		{"grpc_tls=skip-verify overrides", "mysql+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=skip-verify", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			creds, err := vitessGRPCTLSCredentials(tc.uri)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotTLS := creds.Info().SecurityProtocol == "tls"
+			if gotTLS != tc.wantTLS {
+				t.Errorf("got SecurityProtocol=%q (tls=%v), want tls=%v", creds.Info().SecurityProtocol, gotTLS, tc.wantTLS)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Vitess CDC opened the vtgate VStream gRPC connection through vtgateconn.Dial, whose registered dialer appends an insecure transport credential that overrides any caller-supplied TLS. A TLS-only vtgate (e.g. PlanetScale) was therefore unreachable for CDC even with tls=true on the URI, failing with "server does not allow insecure connections".

Dial the vtgate service directly with resolved credentials instead, reusing grpcclient.DialContext so the connection keeps Vitess's tuned defaults (16MB max message size, keepalive) that large copy-phase VStream messages rely on.

A single tls=true now secures both the MySQL-protocol probe and the VStream gRPC connection (the gRPC side inherits tls). grpc_tls overrides the gRPC side independently: true / skip-verify enable TLS, false forces plaintext; preferred and custom CA names do not map to gRPC.