### PR TITLE
fix(postgres-cdc): preserve array columns and surface BigQuery load errors

### DIFF
--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -653,6 +653,9 @@ func (d *BigQueryDestination) runCombinedGCSLoadJob(
 		return fmt.Errorf("combined load job failed (job %s): %w", jobRef(job), err)
 	}
 	if err := status.Err(); err != nil {
+		if details := loadJobErrorDetails(status); details != "" {
+			return fmt.Errorf("combined load job error (job %s): %w; details: %s", jobRef(job), err, details)
+		}
 		return fmt.Errorf("combined load job error (job %s): %w", jobRef(job), err)
 	}
 
@@ -725,6 +728,9 @@ func (d *BigQueryDestination) runSingleLoadJob(
 				}
 				continue
 			}
+			if details := loadJobErrorDetails(status); details != "" {
+				return fmt.Errorf("load job error for chunk %d (job %s): %w; details: %s", chunk.index+1, jobRef(job), err, details)
+			}
 			return fmt.Errorf("load job error for chunk %d (job %s): %w", chunk.index+1, jobRef(job), err)
 		}
 
@@ -733,6 +739,31 @@ func (d *BigQueryDestination) runSingleLoadJob(
 	}
 
 	return fmt.Errorf("load job error for chunk %d: exhausted retries", chunk.index+1)
+}
+
+// loadJobErrorDetails formats the per-row/per-field errors that BigQuery records
+// in JobStatus.Errors. JobStatus.Err() only returns the top-level summary (e.g.
+// "JSON table encountered too many errors"); the actual cause (the field or row
+// that failed) lives in the Errors slice the summary tells you to inspect.
+func loadJobErrorDetails(status *gcbq.JobStatus) string {
+	if status == nil || len(status.Errors) == 0 {
+		return ""
+	}
+	const maxDetails = 5
+	parts := make([]string, 0, min(len(status.Errors), maxDetails))
+	for _, e := range status.Errors {
+		if e == nil {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("[reason=%s location=%q] %s", e.Reason, e.Location, e.Message))
+		if len(parts) >= maxDetails {
+			if remaining := len(status.Errors) - maxDetails; remaining > 0 {
+				parts = append(parts, fmt.Sprintf("... and %d more error(s)", remaining))
+			}
+			break
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 func isRetryableLoadJobError(err error) bool {
@@ -1191,6 +1222,13 @@ func writeRecordBatchAsJSONL(writer *bufio.Writer, record arrow.RecordBatch) (in
 
 func extractJSONLValue(arr arrow.Array, idx int) any {
 	if arr.IsNull(idx) {
+		// BigQuery REPEATED fields cannot be null: a JSON null is rejected with
+		// "Repeated field must be imported as a JSON array". A null array column
+		// must therefore serialize as an empty array, not null.
+		switch arr.(type) {
+		case *array.List, *array.LargeList, *array.FixedSizeList:
+			return []any{}
+		}
 		return nil
 	}
 

--- a/pkg/source/postgres_cdc/array_literal.go
+++ b/pkg/source/postgres_cdc/array_literal.go
@@ -1,0 +1,92 @@
+package postgres_cdc
+
+import "strings"
+
+// arrayElement is one element of a parsed Postgres array literal. A NULL element
+// (the unquoted token NULL) is distinguished from the string "NULL", which
+// Postgres always emits quoted.
+type arrayElement struct {
+	value  string
+	isNull bool
+}
+
+// parsePostgresArrayLiteral parses the text output of a one-dimensional Postgres
+// array (array_out format) into its elements: e.g. `{a,b}`, `{"x,y",NULL}`, or
+// `{}` for an empty array. It returns ok=false when the input is not a
+// brace-delimited array literal.
+//
+// Logical replication delivers array columns (jsonb[], text[], int[], ...) in
+// this format, not as JSON arrays, so the streaming decoder must parse it to
+// recover the elements. Quoted elements are unescaped (\" -> ", \\ -> \), so a
+// jsonb[] element is returned as standalone JSON ready for per-element typing.
+func parsePostgresArrayLiteral(s string) ([]arrayElement, bool) {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || s[0] != '{' || s[len(s)-1] != '}' {
+		return nil, false
+	}
+
+	inner := s[1 : len(s)-1]
+	elems := make([]arrayElement, 0)
+	if strings.TrimSpace(inner) == "" {
+		return elems, true
+	}
+
+	i, n := 0, len(inner)
+	for i < n {
+		for i < n && (inner[i] == ' ' || inner[i] == '\t') {
+			i++
+		}
+		if i >= n {
+			break
+		}
+
+		if inner[i] == '"' {
+			i++
+			var b strings.Builder
+			for i < n {
+				c := inner[i]
+				if c == '\\' && i+1 < n {
+					b.WriteByte(inner[i+1])
+					i += 2
+					continue
+				}
+				if c == '"' {
+					i++
+					break
+				}
+				b.WriteByte(c)
+				i++
+			}
+			elems = append(elems, arrayElement{value: b.String()})
+			for i < n && inner[i] != ',' {
+				i++
+			}
+			if i < n {
+				i++
+			}
+			continue
+		}
+
+		start := i
+		// A bare '{' signals a nested/multidimensional array, which this
+		// one-dimensional parser cannot handle. Return ok=false so the caller
+		// falls back to nil instead of producing garbled elements.
+		if inner[i] == '{' {
+			return nil, false
+		}
+		for i < n && inner[i] != ',' {
+			i++
+		}
+		raw := strings.TrimSpace(inner[start:i])
+		if i < n {
+			i++
+		}
+		if strings.EqualFold(raw, "NULL") {
+			elems = append(elems, arrayElement{isNull: true})
+		} else {
+			elems = append(elems, arrayElement{value: raw})
+		}
+	}
+
+	return elems, true
+}

--- a/pkg/source/postgres_cdc/array_literal_test.go
+++ b/pkg/source/postgres_cdc/array_literal_test.go
@@ -1,0 +1,61 @@
+package postgres_cdc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePostgresArrayLiteral(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []arrayElement
+		ok    bool
+	}{
+		{"empty array", "{}", []arrayElement{}, true},
+		{"single text", "{a}", []arrayElement{{value: "a"}}, true},
+		{"two text", "{snap-a,snap-b}", []arrayElement{{value: "snap-a"}, {value: "snap-b"}}, true},
+		{
+			"quoted with embedded comma",
+			`{x,"has,comma"}`,
+			[]arrayElement{{value: "x"}, {value: "has,comma"}},
+			true,
+		},
+		{
+			"sql null vs quoted NULL string",
+			`{NULL,"NULL"}`,
+			[]arrayElement{{isNull: true}, {value: "NULL"}},
+			true,
+		},
+		{
+			"jsonb elements are unescaped",
+			`{"{\"error\": \"boom\"}","{\"a\": 1}"}`,
+			[]arrayElement{{value: `{"error": "boom"}`}, {value: `{"a": 1}`}},
+			true,
+		},
+		{
+			"escaped quote and backslash",
+			`{"a\"b","c\\d"}`,
+			[]arrayElement{{value: `a"b`}, {value: `c\d`}},
+			true,
+		},
+		{"multidimensional array unsupported", "{{1,2},{3,4}}", nil, false},
+		{"not an array literal", "boom", nil, false},
+		{"empty string", "", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parsePostgresArrayLiteral(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -631,6 +631,26 @@ func convertTextValue(text string, col schema.Column) interface{} {
 		return nil
 	case schema.TypeDecimal:
 		return text // Keep as string for decimal handling
+	case schema.TypeArray:
+		// Logical replication delivers arrays as Postgres array literals
+		// ({a,b}), not JSON arrays, so parse the literal and convert each
+		// element by the element type. Returning a []interface{} lets the list
+		// builder populate the array; the snapshot path produces the same shape
+		// via pgx, keeping streaming and snapshot consistent.
+		elems, ok := parsePostgresArrayLiteral(text)
+		if !ok {
+			return nil
+		}
+		elemCol := schema.Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale}
+		out := make([]interface{}, len(elems))
+		for i, e := range elems {
+			if e.isNull {
+				out[i] = nil
+				continue
+			}
+			out[i] = convertTextValue(e.value, elemCol)
+		}
+		return out
 	default:
 		return text
 	}


### PR DESCRIPTION
Postgres CDC array columns (jsonb[], text[], int[], ...) were silently lost during streaming. Logical replication delivers arrays as Postgres array literals ({a,b}), but convertTextValue had no TypeArray case and passed the literal straight to the list builder, which only accepts JSON [...] arrays. The literal failed to parse and the column became NULL, overwriting the (correct) snapshot value on the next change.

Parse the array literal in convertTextValue and convert each element by its element type, so streaming produces the same []interface{} shape the snapshot path already gets from pgx.

Also fixes the BigQuery JSONL load that surfaced this: BigQuery REPEATED fields reject JSON null ("Repeated field must be imported as a JSON array"), so a null array column now serializes as [] instead of null. And load-job errors now include JobStatus.Errors detail (the errors[] collection) plus a --debug dump of the record schema and first row, which the generic top-level message omits.

Verified end-to-end against a local Postgres logical replication stream: streamed INSERT/UPDATE of jsonb[]/text[] columns (incl. NULL, empty array, embedded comma, and literal "NULL" string) now arrive intact.