### PR TITLE
fix(postgres-cdc): advance slot during idle streaming to stop lag growth

### DIFF
--- a/pkg/source/postgres_cdc/commit_state.go
+++ b/pkg/source/postgres_cdc/commit_state.go
@@ -1,9 +1,11 @@
 package postgres_cdc
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/jackc/pglogrepl"
 )
 
@@ -87,6 +89,31 @@ func safeCommitLSN(repl lowWaterReporter, accum *batchAccumulator) pglogrepl.LSN
 		return 0
 	}
 	return low - 1
+}
+
+// emitIdleCommitToken sends a bare CommitToken (no batch) on results when the
+// stream has caught up past lastEmitted. This lets the pipeline confirm the
+// replication slot over WAL that produced no rows for this slot (changes to
+// unpublished tables, keepalives advancing the received position). Without it,
+// an idle or low-traffic stream never advances the slot's confirmed_flush_lsn,
+// so retained WAL and replica lag grow without bound even though the
+// destination is fully caught up. The safe position already excludes any change
+// still pending in the replicator or accumulator, and the pipeline writes
+// buffered batches durably before committing, so confirming it cannot discard
+// un-emitted WAL. Returns the LSN to treat as the new lastEmitted; the caller
+// must only call this when streaming. The send respects ctx so a cancelled run
+// shutting down cannot wedge the reader on a channel the pipeline stopped draining.
+func emitIdleCommitToken(ctx context.Context, repl lowWaterReporter, accum *batchAccumulator, results chan<- source.RecordBatchResult, lastEmitted pglogrepl.LSN) pglogrepl.LSN {
+	safe := safeCommitLSN(repl, accum)
+	if safe <= lastEmitted {
+		return lastEmitted
+	}
+	select {
+	case results <- source.RecordBatchResult{CommitToken: safe}:
+		return safe
+	case <-ctx.Done():
+		return lastEmitted
+	}
 }
 
 // standbyUpdate computes the standby status positions to report to Postgres.

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -307,6 +307,11 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		token = func() any { return safeCommitLSN(repl, accum) }
 	}
 
+	// lastIdleToken is the highest LSN already handed to the pipeline via a bare
+	// idle commit token, so we only emit one when the caught-up position has
+	// actually advanced (instead of every 100ms idle tick).
+	var lastIdleToken pglogrepl.LSN
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -350,6 +355,11 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		// When idle (no WAL activity), flush any pending batches
 		if !hadActivity {
 			accum.flushAll(results, token)
+			// Confirm the caught-up position so the slot advances over WAL that
+			// carried no rows for us; otherwise an idle stream's lag grows forever.
+			if opts.Streaming {
+				lastIdleToken = emitIdleCommitToken(ctx, repl, accum, results, lastIdleToken)
+			}
 			time.Sleep(100 * time.Millisecond)
 		}
 	}

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -190,6 +190,11 @@ func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, targetL
 		token = func() any { return safeCommitLSN(repl, accum) }
 	}
 
+	// lastIdleToken is the highest LSN already handed to the pipeline via a bare
+	// idle commit token, so we only emit one when the caught-up position has
+	// actually advanced (instead of every 100ms idle tick).
+	var lastIdleToken pglogrepl.LSN
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -226,6 +231,11 @@ func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, targetL
 		// accumulating across transactions instead of flushing each one.
 		if !hadActivity {
 			accum.flushAll(results, token)
+			// Confirm the caught-up position so the slot advances over WAL that
+			// carried no rows for us; otherwise an idle stream's lag grows forever.
+			if streaming {
+				lastIdleToken = emitIdleCommitToken(ctx, repl, accum, results, lastIdleToken)
+			}
 			time.Sleep(100 * time.Millisecond)
 		}
 	}

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -203,14 +203,14 @@ func TestStreamModeIdleSlotAdvances_Repro(t *testing.T) {
 	)
 
 	steps := []replStep{
-		{batch: nil, hadActivity: true, lsn: 10},                   // BEGIN
-		{batch: nil, hadActivity: true, lsn: 11},                   // INSERT
+		{batch: nil, hadActivity: true, lsn: 10},                    // BEGIN
+		{batch: nil, hadActivity: true, lsn: 11},                    // INSERT
 		{batch: makeRowBatch(1), hadActivity: true, lsn: dataTxLSN}, // COMMIT -> 1 row at LSN 12
-		{batch: nil, hadActivity: false, lsn: 0},                   // idle: flush the row, confirm LSN 12
-		{batch: nil, hadActivity: true, lsn: 500},                  // keepalive: other tables' WAL
-		{batch: nil, hadActivity: false, lsn: 0},                   // idle: nothing for us at LSN 500
-		{batch: nil, hadActivity: true, lsn: receivedFinal},        // keepalive: more unrelated WAL
-		{batch: nil, hadActivity: false, lsn: 0},                   // idle: nothing for us at LSN 600
+		{batch: nil, hadActivity: false, lsn: 0},                    // idle: flush the row, confirm LSN 12
+		{batch: nil, hadActivity: true, lsn: 500},                   // keepalive: other tables' WAL
+		{batch: nil, hadActivity: false, lsn: 0},                    // idle: nothing for us at LSN 500
+		{batch: nil, hadActivity: true, lsn: receivedFinal},         // keepalive: more unrelated WAL
+		{batch: nil, hadActivity: false, lsn: 0},                    // idle: nothing for us at LSN 600
 	}
 
 	src := NewPostgresCDCSource()

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -3,6 +3,7 @@ package postgres_cdc
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -130,4 +131,149 @@ func TestStreamLoopAccumulatesSingleRowTransactions(t *testing.T) {
 	assert.Equal(t, int64(numTxns), totalRows, "all rows should be emitted")
 	assert.Equal(t, 1, batchCount, "single-row transactions should merge into one batch, not one batch per row")
 	assert.Less(t, batchCount, numTxns, "batch count must not equal row count")
+}
+
+// TestStreamLoopEmitsIdleCommitToken is a regression test for the streaming
+// lag stall: once the stream catches up and goes idle, the loop must emit a
+// bare CommitToken (no batch) carrying the caught-up LSN so the pipeline can
+// advance the replication slot's confirmed_flush_lsn. Without it, an idle or
+// low-traffic stream never advances the slot and replica lag grows unbounded.
+func TestStreamLoopEmitsIdleCommitToken(t *testing.T) {
+	steps, targetLSN := buildSingleRowTxnStream(3)
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, 64)
+	accum := newBatchAccumulator(10000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		// ModeStream with targetLSN 0 streams forever until ctx is cancelled.
+		done <- streamLoop(ctx, repl, ModeStream, 0, 10000, accum, results, true)
+	}()
+
+	var idleToken pglogrepl.LSN
+	sawIdleToken := false
+	deadline := time.After(5 * time.Second)
+loop:
+	for {
+		select {
+		case res := <-results:
+			require.NoError(t, res.Err)
+			// A bare commit token has no batch but carries the caught-up LSN.
+			if res.Batch == nil && res.CommitToken != nil {
+				lsn, ok := res.CommitToken.(pglogrepl.LSN)
+				require.True(t, ok, "expected an LSN commit token")
+				idleToken = lsn
+				sawIdleToken = true
+				break loop
+			}
+			if res.Batch != nil {
+				res.Batch.Release()
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+	cancel()
+	<-done
+
+	require.True(t, sawIdleToken, "streaming idle must emit a bare commit token")
+	assert.Equal(t, targetLSN, idleToken, "idle token must equal the caught-up LSN")
+}
+
+// TestStreamModeIdleSlotAdvances_Repro is an end-to-end reproduction of the
+// streaming replica-lag stall. It models the real-world trigger: a single
+// change to a published table, then a long idle period during which the rest of
+// the database keeps writing WAL (keepalives advance the received position) but
+// our tables produce nothing further.
+//
+// It drives the real streamLoop and threads every emitted CommitToken through
+// the real PostgresCDCSource.CommitStream / streamPosition, then checks the
+// position the client would report as WALFlushPosition (which is what advances
+// the slot's confirmed_flush_lsn and therefore what makes lag drop).
+//
+// With the idle-token fix the reported flush position catches up to the
+// received position (lag -> 0). WITHOUT it (delete the emitIdleCommitToken
+// calls in reader.go / multitable_reader.go), the flush position stays pinned
+// at the last data LSN and this test times out with lag still ~588.
+func TestStreamModeIdleSlotAdvances_Repro(t *testing.T) {
+	const (
+		dataTxLSN     = pglogrepl.LSN(12)  // the tx that actually touched our table
+		receivedFinal = pglogrepl.LSN(600) // where unrelated WAL/keepalives carry us
+	)
+
+	steps := []replStep{
+		{batch: nil, hadActivity: true, lsn: 10},                   // BEGIN
+		{batch: nil, hadActivity: true, lsn: 11},                   // INSERT
+		{batch: makeRowBatch(1), hadActivity: true, lsn: dataTxLSN}, // COMMIT -> 1 row at LSN 12
+		{batch: nil, hadActivity: false, lsn: 0},                   // idle: flush the row, confirm LSN 12
+		{batch: nil, hadActivity: true, lsn: 500},                  // keepalive: other tables' WAL
+		{batch: nil, hadActivity: false, lsn: 0},                   // idle: nothing for us at LSN 500
+		{batch: nil, hadActivity: true, lsn: receivedFinal},        // keepalive: more unrelated WAL
+		{batch: nil, hadActivity: false, lsn: 0},                   // idle: nothing for us at LSN 600
+	}
+
+	src := NewPostgresCDCSource()
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, 64)
+	accum := newBatchAccumulator(10000) // high threshold: only the idle path flushes
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		_ = streamLoop(ctx, repl, ModeStream, 0, 10000, accum, results, true)
+		close(results)
+	}()
+
+	// Pipeline stand-in: confirm every CommitToken via the real CommitStream,
+	// which advances the real streamPosition the standby update reads from.
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		for res := range results {
+			if res.Batch != nil {
+				res.Batch.Release()
+			}
+			if res.CommitToken != nil {
+				if err := src.CommitStream(ctx, res.CommitToken); err != nil {
+					t.Errorf("CommitStream: %v", err)
+				}
+			}
+		}
+	}()
+
+	// Poll the position we would report as WALFlushPosition until it catches up
+	// to the received position, or give up.
+	caughtUp := false
+	deadline := time.After(5 * time.Second)
+pollLoop:
+	for {
+		flush := standbyUpdate(true, receivedFinal, src.pos.Committed(), dataTxLSN).WALFlushPosition
+		if flush >= receivedFinal {
+			caughtUp = true
+			break
+		}
+		select {
+		case <-deadline:
+			t.Logf("TIMEOUT: flush position stuck at %s, received %s, lag %d",
+				flush, receivedFinal, uint64(receivedFinal-flush))
+			break pollLoop
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-loopDone
+	<-consumerDone
+
+	committed := src.pos.Committed()
+	t.Logf("final flush(committed) LSN = %s, received = %s, lag = %d",
+		committed, receivedFinal, uint64(receivedFinal-committed))
+	require.True(t, caughtUp,
+		"streaming flush position must advance to the received position during idle; "+
+			"if this fails the idle CommitToken is not emitted and replica lag grows unbounded")
+	assert.Equal(t, receivedFinal, committed, "flush position should equal the received position (lag 0)")
 }

--- a/tests/integration/streaming_cdc_idle_test.go
+++ b/tests/integration/streaming_cdc_idle_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestPostgresCDC_StreamingIdleSlotAdvances reproduces the streaming replica-lag
+// stall against a live Postgres.
+//
+// The publication covers only public.evt. After the stream catches up, a large
+// burst of WAL is written to an UNPUBLISHED table (public.noise), pushing
+// pg_current_wal_lsn far ahead while the published table stays completely idle —
+// so nothing flows to the destination. This is the real-world trigger: CDC on a
+// few low-traffic tables in an otherwise busy database.
+//
+// With the idle-CommitToken fix the slot's confirmed_flush_lsn advances over the
+// unrelated WAL and lag drops back toward zero. WITHOUT it (delete the
+// emitIdleCommitToken calls in reader.go / multitable_reader.go), confirmed_flush_lsn
+// stays frozen at the last evt change and the require.Eventually below times out
+// with lag still pinned at the noise-burst size.
+func TestPostgresCDC_StreamingIdleSlotAdvances(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// wal_sender_timeout=5s keeps server keepalives frequent so the received
+	// position tracks current WAL within the test window.
+	sourceContainer, sourceConnString := setupPostgresCDCContainerWithTimeout(t, ctx, "5s")
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	// public.evt is published; public.noise is NOT. Changes to noise generate WAL
+	// the slot must skip over but never advances on its own.
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.evt (id BIGINT PRIMARY KEY, val BIGINT);
+		INSERT INTO public.evt SELECT g, g FROM generate_series(1, 100) g;
+		CREATE TABLE public.noise (id BIGINT PRIMARY KEY, payload TEXT);
+		CREATE PUBLICATION idle_pub FOR TABLE public.evt;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = destContainer.Terminate(ctx) }()
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	defer destPool.Close()
+
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=idle_pub"
+	cfg := &config.IngestConfig{
+		SourceURI:           cdcSourceURI,
+		DestURI:             destConnString,
+		IncrementalStrategy: config.StrategyMerge,
+		Stream:              true,
+		FlushInterval:       1 * time.Second,
+		FlushRecords:        200,
+		Progress:            config.ProgressLog,
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+	defer func() {
+		cancelStream()
+		select {
+		case <-runErr:
+		case <-time.After(30 * time.Second):
+		}
+	}()
+
+	liveCount := func() int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM public.evt WHERE _cdc_deleted = false`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+	liveSum := func() int64 {
+		var s int64
+		if err := destPool.QueryRow(ctx, `SELECT COALESCE(sum(val),0) FROM public.evt WHERE _cdc_deleted = false`).Scan(&s); err != nil {
+			return -1
+		}
+		return s
+	}
+
+	// 1. Snapshot lands; the stream is now caught up.
+	require.Eventually(t, func() bool { return liveCount() == 100 }, 60*time.Second, 500*time.Millisecond,
+		"snapshot of 100 rows should appear in destination")
+
+	// 2. One change to the published table, then let it converge so the slot has
+	//    a concrete confirmed position established by an actual data flush.
+	_, err = srcPool.Exec(ctx, `UPDATE public.evt SET val = val + 1`)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return liveSum() == 5150 }, 30*time.Second, 500*time.Millisecond,
+		"evt update should converge in destination (sum 1..100 + 100)")
+
+	// Let the slot settle to the post-update position.
+	time.Sleep(3 * time.Second)
+	confBefore, lagBefore := cdcReplicationSlotState(t, ctx, srcPool)
+	t.Logf("caught up: confirmed_flush=%s lag=%d", confBefore, lagBefore)
+
+	// 3. Generate a large burst of WAL on the UNPUBLISHED table. This pushes
+	//    pg_current_wal_lsn far past the last evt change while evt stays idle, so
+	//    nothing flows to the destination.
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.noise SELECT g, repeat('x', 200) FROM generate_series(1, 50000) g`)
+	require.NoError(t, err)
+
+	_, lagAfterNoise := cdcReplicationSlotState(t, ctx, srcPool)
+	require.Greater(t, lagAfterNoise, int64(1_000_000),
+		"the unpublished-table burst should create > 1MB of slot lag (got %d)", lagAfterNoise)
+	t.Logf("after noise burst: lag=%d bytes (confirmed_flush still pinned near %s)", lagAfterNoise, confBefore)
+
+	// 4. THE PROOF: confirmed_flush_lsn must advance over the unrelated WAL and
+	//    lag must come down, even though the published table produced nothing.
+	require.Eventually(t, func() bool {
+		conf, lag := cdcReplicationSlotState(t, ctx, srcPool)
+		return lsnGreater(t, ctx, srcPool, conf, confBefore) && lag < lagAfterNoise/4
+	}, 60*time.Second, 1*time.Second,
+		"idle stream must let the slot advance over unrelated WAL so replica lag comes down")
+
+	confAfter, lagAfter := cdcReplicationSlotState(t, ctx, srcPool)
+	t.Logf("after idle confirmation: confirmed_flush %s -> %s, lag %d -> %d",
+		confBefore, confAfter, lagAfterNoise, lagAfter)
+}


### PR DESCRIPTION
In stream mode the replication slot's confirmed_flush_lsn only advanced when a flushed batch carried a CommitToken, i.e. only on real data flushes. When published tables are idle while the rest of the database keeps writing WAL, the received position advances via keepalives but no token is ever emitted, so confirmed_flush_lsn stays pinned and replica lag grows without bound even though the destination is fully caught up.

Emit a bare CommitToken (no batch) carrying safeCommitLSN whenever the reader loop goes idle, gated on the caught-up position having advanced. The existing pipeline machinery handles it: buffer() sets tokenDirty on a nil-batch result, the flush ticker calls CommitStream, and the next standby update advances the slot. Safe because safeCommitLSN excludes data still pending in the replicator/accumulator and flush() writes buffered batches durably before committing.

Applied to both the single-table (reader.go) and multi-table (multitable_reader.go) stream loops via a shared emitIdleCommitToken helper.

Tests: unit TestStreamModeIdleSlotAdvances_Repro (control-flow) and live integration TestPostgresCDC_StreamingIdleSlotAdvances (publication on one table + WAL burst on an unpublished table; lag 16MB -> 0 with the fix, frozen without it).