### PR TITLE
fix(starrocks): strip destination-only params from the source DSN

### DIFF
--- a/pkg/source/starrocks/starrocks.go
+++ b/pkg/source/starrocks/starrocks.go
@@ -499,6 +499,10 @@ func parseStarRocksURI(uri string) (dsn, catalog, database string, err error) {
 	if tlsErr := applyTLSParams(query); tlsErr != nil {
 		return "", "", "", tlsErr
 	}
+	// Drop destination-only params so a connection shared with the StarRocks
+	// destination doesn't leak them into the go-sql-driver DSN.
+	query.Del("http_port")
+	query.Del("replication_num")
 
 	dsn = ""
 	if user != "" {

--- a/pkg/source/starrocks/starrocks_test.go
+++ b/pkg/source/starrocks/starrocks_test.go
@@ -74,6 +74,13 @@ func TestParseStarRocksURI(t *testing.T) {
 			wantCatalog:  defaultCatalog,
 			wantDatabase: "db",
 		},
+		{
+			name:         "destination-only params are stripped from the DSN",
+			uri:          "starrocks://root@host:9030/db?http_port=8030&replication_num=1",
+			wantDSN:      "root@tcp(host:9030)/?parseTime=true",
+			wantCatalog:  defaultCatalog,
+			wantDatabase: "db",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

A single Bruin connection produces **one** URI that gets used for both the source and destination roles. The StarRocks *destination* adds `http_port` and `replication_num` query params to that URI. 

This drops `http_port` and `replication_num` when building the source DSN, so a shared connection works transparently as a source.