### PR TITLE
mysql: support Vitess and PlanetScale as write destinations

### DIFF
--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -38,6 +38,12 @@ By default Vitess caps queries at 100,000 rows, which would otherwise break bulk
 
 Change data capture is also supported for Vitess. See [Change data capture](#change-data-capture) below.
 
+### Vitess as a destination
+Vitess is also supported as a destination over the same `mysql://` URI, and ingestr detects Vitess automatically. Two things differ from plain MySQL:
+
+- **The target keyspace must already exist.** `CREATE DATABASE` is not supported through vtgate, so ingestr never creates keyspaces — create the keyspace via your Vitess control plane first. Staging tables for the `replace`, `merge`, `delete+insert`, and `scd2` strategies are created inside the target keyspace rather than in a separate `_bruin_staging` database.
+- **Only unsharded (single-shard) keyspaces are supported.** If the target keyspace is sharded, ingestr fails fast at connect with a clear error instead of producing a broken load. Sharded keyspaces are unsupported because auto-created tables need a Primary Vindex to be routable, the `merge`/`delete+insert`/`scd2` strategies use `UPDATE … JOIN` / `INSERT … SELECT … WHERE NOT EXISTS` statements that Vitess rejects across shards, and the atomic `RENAME` swap used by `replace` is not atomic across shards. To load a sharded keyspace, pre-create the tables (with vindexes) and manage the load outside ingestr.
+
 [PlanetScale](/supported-sources/planetscale.md) is documented separately: it uses the same MySQL-compatible connector but has its own change-data-capture path (`psdbconnect`) and PlanetScale-specific TLS guidance.
 
 ## Change data capture

--- a/docs/supported-sources/planetscale.md
+++ b/docs/supported-sources/planetscale.md
@@ -7,7 +7,7 @@ ingestr supports PlanetScale as both a source and destination through the MySQL 
 The URI format for PlanetScale is as follows:
 
 ```plaintext
-mysql://user:password@host:port/database?tls=true
+mysql://user:password@host:port/database
 ```
 
 URI parameters:
@@ -16,40 +16,52 @@ URI parameters:
 - `host`: the PlanetScale database host
 - `port`: the MySQL protocol port, usually 3306
 - `database`: the PlanetScale database name
-- `tls=true`: required for PlanetScale connections
 
 Use the same URI structure for sources and destinations. PlanetScale uses the MySQL wire protocol, so the URI scheme remains `mysql://`.
+
+## TLS
+PlanetScale requires encrypted connections and rejects plaintext ones with `server does not allow insecure connections, client must use SSL/TLS`. ingestr enables TLS automatically for `*.psdb.cloud` hosts — for **both source and destination** connections (and the MySQL-protocol probe the CDC path uses for schema discovery) — so you do not need to add `?tls=true` yourself.
+
+You can still set `tls` explicitly when you need to:
+- `tls=true`: connect over TLS and verify the server certificate against the system roots (this is the auto-enabled default).
+- `tls=skip-verify`: connect over TLS without verifying the certificate.
+- For a custom domain or private endpoint that does not end in `.psdb.cloud`, add `?tls=true` yourself — auto-enable only keys off the `*.psdb.cloud` host suffix.
 
 Example:
 
 ```shell
 ingestr ingest \
-  --source-uri "mysql://user:password@host:3306/database?tls=true" \
+  --source-uri "mysql://user:password@aws.connect.psdb.cloud:3306/database" \
   --dest-uri "duckdb:///tmp/planetscale.duckdb" \
   --source-table "orders" \
   --dest-table "orders"
 ```
 
-To load into PlanetScale, use the PlanetScale URI as the destination:
+To load into PlanetScale, use the PlanetScale URI as the destination (TLS is enabled automatically for the `*.psdb.cloud` host):
 
 ```shell
 ingestr ingest \
   --source-uri "postgresql://user:password@host:5432/app" \
-  --dest-uri "mysql://user:password@host:3306/database?tls=true" \
+  --dest-uri "mysql://user:password@aws.connect.psdb.cloud:3306/database" \
   --source-table "public.orders" \
   --dest-table "orders"
 ```
 
+When loading into PlanetScale, keep two things in mind:
+
+- **Direct DDL must be allowed on the target branch.** The `replace` strategy and any table creation issue `CREATE` / `RENAME` statements. On a branch with safe migrations enabled, PlanetScale rejects these with `ERROR 1105 (HY000): direct DDL is disabled` — load into a development branch (or a branch with safe migrations off) instead, or pre-create the tables and use `append`/`merge`. The PlanetScale database (keyspace) must already exist; ingestr does not create it.
+- **Only unsharded keyspaces are supported** as destinations. A sharded keyspace is detected at connect and rejected with a clear error. See [Vitess as a destination](/supported-sources/mysql.md#vitess-as-a-destination) for the underlying reasons.
+
 ## Change data capture
 PlanetScale change data capture uses the `mysql+cdc://` URI scheme. PlanetScale does not expose vtgate's VStream gRPC port to external clients, so ingestr streams changes through PlanetScale's hosted `psdbconnect` API on the database host over TLS (port 443). It authenticates with the **database credentials already in the URI** — the same `user:password` used for the MySQL connection — so no separate token is required.
 
-ingestr selects this path automatically when the host ends in `.psdb.cloud`; for private endpoints or custom domains, force it with `cdc_backend=planetscale`. Keep `tls=true` (required for both the MySQL-protocol schema discovery and the psdbconnect endpoint). The database in the URI is the PlanetScale keyspace. Unlike self-hosted Vitess, there is no `grpc_port` — the psdbconnect endpoint is always the database host on port 443.
+ingestr selects this path automatically when the host ends in `.psdb.cloud`; for private endpoints or custom domains, force it with `cdc_backend=planetscale`. TLS is required, and ingestr enables it automatically for `*.psdb.cloud` hosts (see [TLS](#tls)), so you don't need to add `tls=true` — the psdbconnect endpoint always uses TLS on port 443 regardless. The database in the URI is the PlanetScale keyspace. Unlike self-hosted Vitess, there is no `grpc_port` — the psdbconnect endpoint is always the database host on port 443.
 
 Example:
 
 ```shell
 ingestr ingest \
-  --source-uri "mysql+cdc://user:password@host.connect.psdb.cloud:3306/database?tls=true" \
+  --source-uri "mysql+cdc://user:password@aws.connect.psdb.cloud:3306/database" \
   --dest-uri "duckdb:///tmp/planetscale_cdc.duckdb" \
   --source-table "orders" \
   --dest-table "orders"
@@ -58,7 +70,7 @@ ingestr ingest \
 psdbconnect performs a per-shard snapshot first (resumable by primary key) and then streams inserts, updates, and deletes. Position is tracked per shard and serialized into `_cdc_lsn`, and subsequent runs resume from the destination table's maximum `_cdc_lsn` for both unsharded and sharded keyspaces. If the stored `_cdc_lsn` is invalid, the run fails instead of taking a partial snapshot — run with `--full-refresh` to rebuild the destination from a fresh snapshot. Incremental runs use the `merge` strategy so updates and deletes are applied by primary key. (PlanetScale delivers only the primary keys of deleted rows; the destination marks them deleted without disturbing the other columns.)
 
 CDC URI parameters:
-- `tls`: keep `tls=true` — required for the connection.
+- `tls`: auto-enabled for `*.psdb.cloud` hosts; set it explicitly only for a custom domain or to choose a different mode (see [TLS](#tls)).
 - `cdc_backend`: optional override — `planetscale` forces the psdbconnect path (for example on a custom domain or private endpoint), `vstream` forces the self-hosted Vitess VStream path.
 - `dest_schema`: optional destination schema for multi-table CDC runs.
 

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -23,6 +23,7 @@ type MySQLDestination struct {
 	db       *sql.DB
 	uri      string
 	database string
+	isVitess bool
 }
 
 func NewMySQLDestination() *MySQLDestination {
@@ -53,11 +54,69 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to ping MySQL: %w", err)
 	}
 
+	// Vitess (including PlanetScale) speaks the MySQL wire protocol via vtgate but
+	// differs in ways that matter for writes: CREATE DATABASE is unsupported, and
+	// sharded keyspaces cannot be written to safely. Detect it once here so those
+	// paths can adapt.
+	isVitess := detectVitess(ctx, db)
+	if isVitess {
+		config.Debug("[MYSQL] Detected Vitess/PlanetScale server (vtgate)")
+		if sharded, err := isShardedKeyspace(ctx, db, database); err != nil {
+			config.Debug("[MYSQL] Could not determine sharding for keyspace %q (assuming unsharded): %v", database, err)
+		} else if sharded {
+			_ = db.Close()
+			return fmt.Errorf("keyspace %q is sharded; ingestr supports only unsharded (single-shard) Vitess/PlanetScale keyspaces as a destination", database)
+		}
+	}
+
 	d.db = db
 	d.uri = uri
 	d.database = database
+	d.isVitess = isVitess
 	config.Debug("[MYSQL] Connected to database: %s", database)
 	return nil
+}
+
+// detectVitess reports whether the server identifies as Vitess (this also covers
+// PlanetScale, which is built on Vitess). On any probe error it returns false so
+// the destination behaves as plain MySQL, matching the source dispatcher's fallback.
+func detectVitess(ctx context.Context, db *sql.DB) bool {
+	var version string
+	if err := db.QueryRowContext(ctx, "SELECT @@version").Scan(&version); err != nil {
+		config.Debug("[MYSQL] Vitess detection failed (assuming plain MySQL): %v", err)
+		return false
+	}
+	return strings.Contains(strings.ToLower(version), "vitess")
+}
+
+// isShardedKeyspace reports whether the given Vitess keyspace has more than one
+// shard. SHOW VITESS_SHARDS lists shards as "<keyspace>/<shard>"; an unsharded
+// keyspace has exactly one shard (named "0" or "-").
+func isShardedKeyspace(ctx context.Context, db *sql.DB, keyspace string) (bool, error) {
+	if keyspace == "" {
+		return false, nil
+	}
+	rows, err := db.QueryContext(ctx, "SHOW VITESS_SHARDS")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	prefix := keyspace + "/"
+	var count int
+	for rows.Next() {
+		var shard string
+		if err := rows.Scan(&shard); err != nil {
+			return false, err
+		}
+		if strings.HasPrefix(shard, prefix) {
+			count++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return count > 1, nil
 }
 
 func uriToDSN(uri string) (string, string, error) {
@@ -98,6 +157,12 @@ func uriToDSN(uri string) (string, string, error) {
 	query := u.Query()
 	query.Set("parseTime", "true")
 	query.Set("allowNativePasswords", "true")
+	// PlanetScale requires TLS on MySQL-wire connections and rejects plaintext with
+	// "client must use SSL/TLS". Enable it automatically for *.psdb.cloud hosts unless
+	// the caller already set a tls value, so tls=skip-verify or a custom config still wins.
+	if !query.Has("tls") && strings.HasSuffix(strings.ToLower(host), ".psdb.cloud") {
+		query.Set("tls", "true")
+	}
 	dsn += "?" + query.Encode()
 
 	return dsn, database, nil
@@ -158,6 +223,12 @@ func (d *MySQLDestination) ensureDatabaseExists(ctx context.Context, database st
 	}
 	if exists {
 		return nil
+	}
+	// vtgate does not support CREATE DATABASE by default (it errors with "create
+	// database not allowed", and does not ignore IF NOT EXISTS). Keyspaces must be
+	// created out-of-band via the Vitess/PlanetScale control plane.
+	if d.isVitess {
+		return fmt.Errorf("keyspace %q does not exist; create it via your Vitess/PlanetScale control plane (CREATE DATABASE is not supported through vtgate)", database)
 	}
 	escaped := strings.ReplaceAll(database, "`", "``")
 	createSQL := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", escaped)
@@ -678,6 +749,29 @@ func (t *mysqlTransaction) Commit(ctx context.Context) error {
 
 func (t *mysqlTransaction) Rollback(ctx context.Context) error {
 	return t.tx.Rollback()
+}
+
+// ReplaceStagingPolicy governs where replace stages its intermediate table. Plain
+// MySQL uses the managed _bruin_staging database (auto-created on demand). Vitess and
+// PlanetScale cannot auto-create that keyspace (CREATE DATABASE is unsupported via
+// vtgate), so staging goes into the target keyspace instead.
+func (d *MySQLDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	if d.isVitess {
+		return destination.ReplaceStagingPolicy{
+			DefaultPlacement:    destination.ReplaceStagingTargetSchema,
+			DefaultTargetSchema: d.database,
+		}
+	}
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingManagedSchema,
+		DefaultManagedSchema: "_bruin_staging",
+	}
+}
+
+// ManagedStagingPolicy governs merge / delete-insert / scd2 staging placement; it
+// follows the same rule as ReplaceStagingPolicy.
+func (d *MySQLDestination) ManagedStagingPolicy() destination.ReplaceStagingPolicy {
+	return d.ReplaceStagingPolicy()
 }
 
 func (d *MySQLDestination) SupportsReplaceStrategy() bool      { return true }

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -62,7 +63,7 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 	if isVitess {
 		config.Debug("[MYSQL] Detected Vitess/PlanetScale server (vtgate)")
 		if sharded, err := isShardedKeyspace(ctx, db, database); err != nil {
-			config.Debug("[MYSQL] Could not determine sharding for keyspace %q (assuming unsharded): %v", database, err)
+			output.Warnf("[WARNING] could not verify whether Vitess/PlanetScale keyspace %q is sharded (%v); proceeding as unsharded, but a sharded keyspace will fail mid-load — ingestr supports only unsharded keyspaces as a destination\n", database, err)
 		} else if sharded {
 			_ = db.Close()
 			return fmt.Errorf("keyspace %q is sharded; ingestr supports only unsharded (single-shard) Vitess/PlanetScale keyspaces as a destination", database)

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -104,6 +104,12 @@ func uriToDSN(uri string) (string, string, error) {
 	// Add query parameters
 	query := u.Query()
 	query.Set("parseTime", "true") // Always parse time
+	// PlanetScale requires TLS on MySQL-wire connections; enable it automatically for
+	// *.psdb.cloud hosts unless the caller already set a tls value. Mirrors the MySQL
+	// destination so a PlanetScale source works without an explicit ?tls=true.
+	if !query.Has("tls") && strings.HasSuffix(strings.ToLower(host), ".psdb.cloud") {
+		query.Set("tls", "true")
+	}
 	if len(query) > 0 {
 		dsn += "?" + query.Encode()
 	}

--- a/tests/integration/vitess_destination_test.go
+++ b/tests/integration/vitess_destination_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/go-sql-driver/mysql" // register mysql driver for read-back
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const shardedVitessKeyspace = "shardedks"
+
+// TestVitessDestination_ReplaceAndMerge proves ingestr can write to an unsharded
+// Vitess keyspace. The replace load exercises CREATE TABLE + staging (inside the
+// target keyspace, since _bruin_staging can't be auto-created on Vitess) + the RENAME
+// swap; the follow-up merge load exercises the UPDATE...JOIN + INSERT...NOT EXISTS path.
+func TestVitessDestination_ReplaceAndMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, dsn, err := startVitessContainer(ctx)
+	require.NoError(t, err, "failed to start vttestserver")
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// vtgate can accept connections before it is able to serve queries; retry.
+	require.Eventually(t, func() bool {
+		return db.PingContext(ctx) == nil
+	}, 90*time.Second, 2*time.Second, "vtgate did not become query-ready")
+
+	sourceURI := jsonlURI(t, "testdata/conformance.jsonl")
+	destTable := vitessKeyspace + ".dest_conformance"
+
+	replaceCfg := &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         "events",
+		DestURI:             uri,
+		DestTable:           destTable,
+		PrimaryKeys:         []string{"id"},
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	require.NoError(t, pipeline.New(replaceCfg).Run(ctx), "replace ingest into Vitess should succeed")
+	require.Equal(t, 10, countVitessRows(t, ctx, db, destTable))
+	require.Equal(t, "alpha", vitessRowName(t, ctx, db, destTable, 1))
+
+	// Re-ingesting the same data with merge upserts by primary key; the row set is
+	// unchanged, but it exercises the merge SQL against Vitess with staging in-keyspace.
+	mergeCfg := &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         "events",
+		DestURI:             uri,
+		DestTable:           destTable,
+		PrimaryKeys:         []string{"id"},
+		IncrementalStrategy: config.StrategyMerge,
+	}
+	require.NoError(t, pipeline.New(mergeCfg).Run(ctx), "merge ingest into Vitess should succeed")
+	require.Equal(t, 10, countVitessRows(t, ctx, db, destTable))
+	require.Equal(t, "alpha", vitessRowName(t, ctx, db, destTable, 1))
+}
+
+// TestVitessDestination_ShardedRejected proves that a sharded keyspace is detected at
+// connect and rejected with a clear error, rather than surfacing a cryptic vtgate error
+// partway through a run.
+func TestVitessDestination_ShardedRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, dsn, err := startVitessContainerSharded(ctx)
+	require.NoError(t, err, "failed to start sharded vttestserver")
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	require.Eventually(t, func() bool {
+		return db.PingContext(ctx) == nil
+	}, 120*time.Second, 2*time.Second, "vtgate did not become query-ready")
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance.jsonl"),
+		SourceTable:         "events",
+		DestURI:             uri,
+		DestTable:           shardedVitessKeyspace + ".dest_conformance",
+		PrimaryKeys:         []string{"id"},
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	err = pipeline.New(cfg).Run(ctx)
+	require.Error(t, err, "writing to a sharded keyspace should fail")
+	require.Contains(t, err.Error(), "sharded")
+}
+
+// startVitessContainerSharded mirrors startVitessContainer but provisions a sharded
+// keyspace (NUM_SHARDS=2) so SHOW VITESS_SHARDS reports more than one shard.
+func startVitessContainerSharded(ctx context.Context) (testcontainers.Container, string, string, error) {
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "vitess/vttestserver:mysql80",
+			ExposedPorts: []string{vitessMySQLPort},
+			Env: map[string]string{
+				"PORT":            vitessBasePort,
+				"KEYSPACES":       shardedVitessKeyspace,
+				"NUM_SHARDS":      "2",
+				"MYSQL_BIND_HOST": "0.0.0.0",
+			},
+			WaitingFor: wait.ForListeningPort(vitessMySQLPort).WithStartupTimeout(240 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", "", err
+	}
+	port, err := container.MappedPort(ctx, "33577")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, "", "", err
+	}
+
+	uri := fmt.Sprintf("mysql://root@%s:%s/%s", host, port.Port(), shardedVitessKeyspace)
+	return container, uri, mysqlDSN(uri), nil
+}
+
+func countVitessRows(t *testing.T, ctx context.Context, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&n))
+	return n
+}
+
+func vitessRowName(t *testing.T, ctx context.Context, db *sql.DB, table string, id int) string {
+	t.Helper()
+	var name string
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT name FROM %s WHERE id = ?", table), id).Scan(&name))
+	return name
+}


### PR DESCRIPTION
Vitess and PlanetScale were already supported as sources behind the mysql:// scheme via runtime detection; extend the MySQL destination to write to them over the same scheme.

Vitess speaks the MySQL wire protocol, so on an unsharded keyspace the existing SQL write path works as-is once a few differences are handled:

  - PlanetScale requires TLS: auto-enable tls=true for *.psdb.cloud hosts in both the source and destination uriToDSN, so a plain URI works without an explicit ?tls=true.
  - CREATE DATABASE is unsupported via vtgate: detect Vitess with SELECT @@version and return a clear error when the target keyspace is missing instead of issuing an unsupported statement.
  - Strategies stage into a _bruin_staging database that Vitess cannot auto-create; declare a staging policy so replace/merge/delete-insert/ scd2 stage inside the target keyspace on Vitess (plain MySQL keeps the managed _bruin_staging schema, with byte-identical names).
  - Sharded keyspaces cannot be written to safely (unroutable tables without a vindex, cross-shard-illegal merge SQL, non-atomic RENAME swap); detect them via SHOW VITESS_SHARDS and fail fast at connect.

Add an integration test covering unsharded replace/merge and the sharded-rejection path, and document the behavior and limitations on the MySQL and PlanetScale pages. Verified end-to-end against a live PlanetScale instance (replace, merge, read-back).