### PR TITLE
mysql: rework Vitess/PlanetScale CDC and rename planetscale scheme to ps_mysql

### DIFF
--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -35,7 +35,7 @@ Accepted values:
 Vitess and PlanetScale speak the MySQL wire protocol but are selected with their own URI schemes so ingestr uses the correct read, write, and CDC paths:
 
 - **Vitess** — use the `vitess://` scheme. See [Vitess](/supported-sources/vitess.md).
-- **PlanetScale** — use the `planetscale://` scheme. See [PlanetScale](/supported-sources/planetscale.md).
+- **PlanetScale** — use the `ps_mysql://` scheme. See [PlanetScale](/supported-sources/planetscale.md).
 
 Pointing a `mysql://` URI at a Vitess or PlanetScale server fails fast with a message telling you to switch to the dedicated scheme.
 

--- a/docs/supported-sources/planetscale.md
+++ b/docs/supported-sources/planetscale.md
@@ -1,13 +1,13 @@
 # PlanetScale
 PlanetScale is a managed MySQL-compatible database built on Vitess.
 
-ingestr supports PlanetScale as both a source and destination through its dedicated `planetscale://` scheme. PlanetScale change data capture is also supported, through PlanetScale's hosted `psdbconnect` API.
+ingestr supports PlanetScale as both a source and destination through its dedicated `ps_mysql://` scheme. PlanetScale change data capture is also supported, through PlanetScale's hosted `psdbconnect` API.
 
 ## URI format
 The URI format for PlanetScale is as follows:
 
 ```plaintext
-planetscale://user:password@host:port/database
+ps_mysql://user:password@host:port/database
 ```
 
 URI parameters:
@@ -17,10 +17,10 @@ URI parameters:
 - `port`: the MySQL protocol port, usually 3306
 - `database`: the PlanetScale database name (keyspace)
 
-Use the same URI structure for sources and destinations. PlanetScale speaks the MySQL wire protocol, but it is selected with the `planetscale://` scheme (not `mysql://`) so ingestr uses the PlanetScale-aware read, write, and CDC paths. Pointing a `mysql://` URI at a PlanetScale server fails fast with a message telling you to use `planetscale://`.
+Use the same URI structure for sources and destinations. PlanetScale speaks the MySQL wire protocol, but it is selected with the `ps_mysql://` scheme (not `mysql://`) so ingestr uses the PlanetScale-aware read, write, and CDC paths. Pointing a `mysql://` URI at a PlanetScale server fails fast with a message telling you to use `ps_mysql://`.
 
 ## TLS
-PlanetScale requires encrypted connections and rejects plaintext ones with `server does not allow insecure connections, client must use SSL/TLS`. ingestr enables TLS automatically for the `planetscale://` scheme — for **both source and destination** connections (and the MySQL-protocol connection the CDC path uses for schema discovery) — so you do not need to add `?tls=true` yourself.
+PlanetScale requires encrypted connections and rejects plaintext ones with `server does not allow insecure connections, client must use SSL/TLS`. ingestr enables TLS automatically for the `ps_mysql://` scheme — for **both source and destination** connections (and the MySQL-protocol connection the CDC path uses for schema discovery) — so you do not need to add `?tls=true` yourself.
 
 You can still set `tls` explicitly when you need to:
 - `tls=true`: connect over TLS and verify the server certificate against the system roots (this is the auto-enabled default).
@@ -30,7 +30,7 @@ Example:
 
 ```shell
 ingestr ingest \
-  --source-uri "planetscale://user:password@aws.connect.psdb.cloud:3306/database" \
+  --source-uri "ps_mysql://user:password@aws.connect.psdb.cloud:3306/database" \
   --dest-uri "duckdb:///tmp/planetscale.duckdb" \
   --source-table "orders" \
   --dest-table "orders"
@@ -41,7 +41,7 @@ To load into PlanetScale, use the PlanetScale URI as the destination (TLS is ena
 ```shell
 ingestr ingest \
   --source-uri "postgresql://user:password@host:5432/app" \
-  --dest-uri "planetscale://user:password@aws.connect.psdb.cloud:3306/database" \
+  --dest-uri "ps_mysql://user:password@aws.connect.psdb.cloud:3306/database" \
   --source-table "public.orders" \
   --dest-table "orders"
 ```
@@ -52,15 +52,15 @@ When loading into PlanetScale, keep two things in mind:
 - **Only unsharded keyspaces are supported** as destinations. A sharded keyspace is detected at connect and rejected with a clear error. See [Vitess as a destination](/supported-sources/vitess.md#vitess-as-a-destination) for the underlying reasons.
 
 ## Change data capture
-PlanetScale change data capture uses the `planetscale+cdc://` URI scheme. PlanetScale does not expose vtgate's VStream gRPC port to external clients, so ingestr streams changes through PlanetScale's hosted `psdbconnect` API on the database host over TLS (port 443). It authenticates with the **database credentials already in the URI** — the same `user:password` used for the MySQL connection — so no separate token is required.
+PlanetScale change data capture uses the `ps_mysql+cdc://` URI scheme. PlanetScale does not expose vtgate's VStream gRPC port to external clients, so ingestr streams changes through PlanetScale's hosted `psdbconnect` API on the database host over TLS (port 443). It authenticates with the **database credentials already in the URI** — the same `user:password` used for the MySQL connection — so no separate token is required.
 
-TLS is required, and ingestr enables it automatically for the `planetscale://` scheme (see [TLS](#tls)), so you don't need to add `tls=true` — the psdbconnect endpoint always uses TLS on port 443 regardless. The database in the URI is the PlanetScale keyspace. Unlike self-hosted Vitess, there is no `grpc_port` — the psdbconnect endpoint is always the database host on port 443.
+TLS is required, and ingestr enables it automatically for the `ps_mysql://` scheme (see [TLS](#tls)), so you don't need to add `tls=true` — the psdbconnect endpoint always uses TLS on port 443 regardless. The database in the URI is the PlanetScale keyspace. Unlike self-hosted Vitess, there is no `grpc_port` — the psdbconnect endpoint is always the database host on port 443.
 
 Example:
 
 ```shell
 ingestr ingest \
-  --source-uri "planetscale+cdc://user:password@aws.connect.psdb.cloud:3306/database" \
+  --source-uri "ps_mysql+cdc://user:password@aws.connect.psdb.cloud:3306/database" \
   --dest-uri "duckdb:///tmp/planetscale_cdc.duckdb" \
   --source-table "orders" \
   --dest-table "orders"
@@ -69,7 +69,7 @@ ingestr ingest \
 psdbconnect performs a per-shard snapshot first (resumable by primary key) and then streams inserts, updates, and deletes. Position is tracked per shard and serialized into `_cdc_lsn`, and subsequent runs resume from the destination table's maximum `_cdc_lsn` for both unsharded and sharded keyspaces. If the stored `_cdc_lsn` is invalid, the run fails instead of taking a partial snapshot — run with `--full-refresh` to rebuild the destination from a fresh snapshot. Incremental runs use the `merge` strategy so updates and deletes are applied by primary key. (PlanetScale delivers only the primary keys of deleted rows; the destination marks them deleted without disturbing the other columns.)
 
 CDC URI parameters:
-- `tls`: auto-enabled for the `planetscale://` scheme; set it explicitly only to choose a different mode (see [TLS](#tls)).
+- `tls`: auto-enabled for the `ps_mysql://` scheme; set it explicitly only to choose a different mode (see [TLS](#tls)).
 - `dest_schema`: optional destination schema for multi-table CDC runs.
 
 Requirements:

--- a/docs/supported-sources/vitess.md
+++ b/docs/supported-sources/vitess.md
@@ -4,7 +4,7 @@
 Vitess speaks the MySQL wire protocol, but it is selected with its own `vitess://` scheme (not `mysql://`) so ingestr uses the Vitess-aware read, write, and CDC paths. Pointing a `mysql://` URI at a Vitess server fails fast with a message telling you to use `vitess://`.
 
 > [!NOTE]
-> [PlanetScale](/supported-sources/planetscale.md) is managed Vitess, but it has its own hosted CDC path and is documented separately under the `planetscale://` scheme.
+> [PlanetScale](/supported-sources/planetscale.md) is managed Vitess, but it has its own hosted CDC path and is documented separately under the `ps_mysql://` scheme.
 
 ## URI format
 ```plaintext

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -81,9 +81,9 @@ func GetConnectors() []ConnectorType {
 			},
 		},
 		{
-			ID:            "planetscale",
-			Name:          "PlanetScale",
-			Schemes:       []string{"planetscale"},
+			ID:            "ps_mysql",
+			Name:          "PlanetScale MySQL",
+			Schemes:       []string{"ps_mysql"},
 			IsSource:      true,
 			IsDestination: true,
 			Fields: []ConnectorField{
@@ -111,7 +111,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("postgres-cdc", "PostgreSQL CDC", []string{"postgres+cdc", "postgresql+cdc"}, true, false),
 		genericURIConnector("mysql-cdc", "MySQL CDC", []string{"mysql+cdc", "mysql+pymysql+cdc", "mariadb+cdc"}, true, false),
 		genericURIConnector("vitess-cdc", "Vitess CDC", []string{"vitess+cdc"}, true, false),
-		genericURIConnector("planetscale-cdc", "PlanetScale CDC", []string{"planetscale+cdc"}, true, false),
+		genericURIConnector("ps_mysql-cdc", "PlanetScale MySQL CDC", []string{"ps_mysql+cdc"}, true, false),
 		genericURIConnector("mssql-cdc", "SQL Server CDC", []string{"mssql+cdc", "sqlserver+cdc", "azuresql+cdc", "azure-sql+cdc"}, true, false),
 		genericURIConnector("mssql-ct", "SQL Server Change Tracking", []string{"mssql+ct", "sqlserver+ct", "azuresql+ct", "azure-sql+ct"}, true, false),
 		genericURIConnector("mongodb-cdc", "MongoDB CDC", []string{"mongodb+cdc", "mongodb+srv+cdc"}, true, false),
@@ -447,8 +447,8 @@ func BuildURI(connectorID string, fields map[string]string) string {
 		return buildStandardURI("mysql", fields, "3306")
 	case "vitess":
 		return buildStandardURI("vitess", fields, "3306")
-	case "planetscale":
-		return buildStandardURI("planetscale", fields, "3306")
+	case "ps_mysql":
+		return buildStandardURI("ps_mysql", fields, "3306")
 	case "mssql":
 		return buildStandardURI("mssql", fields, "1433")
 	case "azuresql":

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bruin-data/ingestr/pkg/mysqluri"
 	"github.com/google/uuid"
 )
 
@@ -686,7 +687,9 @@ func (jm *JobManager) GetRun(ctx context.Context, id string) (*RunRecord, error)
 }
 
 func maskURI(uri string) string {
-	parsed, err := url.Parse(uri)
+	// mysqluri.ParseURL tolerates scheme characters url.Parse rejects (e.g. the
+	// underscore in ps_mysql) so those URIs are masked instead of fully redacted.
+	parsed, err := mysqluri.ParseURL(uri)
 	if err != nil {
 		return "<redacted-uri>"
 	}

--- a/internal/uri/parser.go
+++ b/internal/uri/parser.go
@@ -42,13 +42,12 @@ func Parse(rawURI string) (*ParsedURI, error) {
 		}, nil
 	}
 
+	// The scheme was already extracted above, so parse the rest under a
+	// placeholder: url.Parse rejects scheme characters ingestr allows, such as
+	// the underscore in ps_mysql.
 	normalizedURI := rawURI
-	if strings.Contains(scheme, "+") {
-		parts := strings.SplitN(rawURI, "://", 2)
-		if len(parts) == 2 {
-			baseScheme := strings.Split(scheme, "+")[0]
-			normalizedURI = baseScheme + "://" + parts[1]
-		}
+	if parts := strings.SplitN(rawURI, "://", 2); len(parts) == 2 {
+		normalizedURI = "scheme://" + parts[1]
 	}
 
 	parsed, err := url.Parse(normalizedURI)

--- a/internal/uri/parser_test.go
+++ b/internal/uri/parser_test.go
@@ -1,0 +1,70 @@
+package uri
+
+import "testing"
+
+// url.Parse rejects scheme characters ingestr allows (the underscore in
+// ps_mysql), so Parse extracts the scheme itself and must handle compound and
+// underscore schemes alike.
+func TestParseSchemeVariants(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantScheme string
+		wantHost   string
+		wantDB     string
+		wantParams map[string]string
+	}{
+		{
+			name:       "plain scheme",
+			uri:        "mysql://user:pass@localhost:3306/testdb",
+			wantScheme: "mysql",
+			wantHost:   "localhost",
+			wantDB:     "testdb",
+		},
+		{
+			name:       "compound scheme",
+			uri:        "mysql+pymysql://user:pass@localhost:3306/testdb",
+			wantScheme: "mysql+pymysql",
+			wantHost:   "localhost",
+			wantDB:     "testdb",
+		},
+		{
+			name:       "underscore scheme",
+			uri:        "ps_mysql://user:pass@aws.connect.psdb.cloud:3306/mydb",
+			wantScheme: "ps_mysql",
+			wantHost:   "aws.connect.psdb.cloud",
+			wantDB:     "mydb",
+		},
+		{
+			name:       "underscore compound scheme with params",
+			uri:        "ps_mysql+cdc://user:pass@aws.connect.psdb.cloud:3306/mydb?mode=batch",
+			wantScheme: "ps_mysql+cdc",
+			wantHost:   "aws.connect.psdb.cloud",
+			wantDB:     "mydb",
+			wantParams: map[string]string{"mode": "batch"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := Parse(tt.uri)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.uri, err)
+			}
+			if parsed.Scheme != tt.wantScheme {
+				t.Errorf("Scheme: got %q want %q", parsed.Scheme, tt.wantScheme)
+			}
+			if parsed.Host != tt.wantHost {
+				t.Errorf("Host: got %q want %q", parsed.Host, tt.wantHost)
+			}
+			if parsed.Database != tt.wantDB {
+				t.Errorf("Database: got %q want %q", parsed.Database, tt.wantDB)
+			}
+			for k, v := range tt.wantParams {
+				if parsed.Params[k] != v {
+					t.Errorf("Params[%q]: got %q want %q", k, parsed.Params[k], v)
+				}
+			}
+		})
+	}
+}

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -3,9 +3,9 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"hash/fnv"
-	"net/url"
 	"strings"
 	"time"
 
@@ -14,10 +14,11 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/mysqluri"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/tablename"
-	_ "github.com/go-sql-driver/mysql"
+	mysqldriver "github.com/go-sql-driver/mysql"
 )
 
 type MySQLDestination struct {
@@ -32,7 +33,7 @@ func NewMySQLDestination() *MySQLDestination {
 }
 
 func (d *MySQLDestination) Schemes() []string {
-	return []string{"mysql", "mysql+pymysql", "mariadb", "vitess", "planetscale"}
+	return []string{"mysql", "mysql+pymysql", "mariadb", "vitess", "ps_mysql"}
 }
 
 func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
@@ -55,15 +56,15 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to ping MySQL: %w", err)
 	}
 
-	// Routing is by scheme: vitess:// and planetscale:// select the Vitess-aware
+	// Routing is by scheme: vitess:// and ps_mysql:// select the Vitess-aware
 	// write paths (CREATE DATABASE is unsupported via vtgate, and sharded keyspaces
 	// cannot be written to safely). A mysql:// URI pointed at a Vitess server is a
 	// mistake, so fail fast with a clear message rather than misbehaving mid-load.
 	scheme := ""
-	if u, err := url.Parse(uri); err == nil {
-		scheme = strings.ToLower(u.Scheme)
+	if u, err := mysqluri.ParseURL(uri); err == nil {
+		scheme = u.Scheme
 	}
-	isVitess := scheme == "vitess" || scheme == "planetscale"
+	isVitess := scheme == "vitess" || scheme == "ps_mysql"
 	if isVitess {
 		config.Debug("[MYSQL] Vitess/PlanetScale destination (scheme=%s)", scheme)
 		if sharded, err := isShardedKeyspace(ctx, db, database); err != nil {
@@ -74,7 +75,7 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 		}
 	} else if detectVitess(ctx, db) {
 		_ = db.Close()
-		return fmt.Errorf("server for keyspace %q identifies as Vitess/PlanetScale; use the vitess:// or planetscale:// scheme instead", database)
+		return fmt.Errorf("server for keyspace %q identifies as Vitess/PlanetScale; use the vitess:// or ps_mysql:// scheme instead", database)
 	}
 
 	d.db = db
@@ -127,54 +128,11 @@ func isShardedKeyspace(ctx context.Context, db *sql.DB, keyspace string) (bool, 
 	return count > 1, nil
 }
 
+// uriToDSN converts a MySQL-family URI to the DSN format expected by
+// go-sql-driver/mysql, returning the DSN and the database name. The conversion
+// lives in pkg/mysqluri, shared with the MySQL source.
 func uriToDSN(uri string) (string, string, error) {
-	u, err := url.Parse(uri)
-	if err != nil {
-		return "", "", err
-	}
-
-	scheme := strings.ToLower(u.Scheme)
-	if !strings.HasPrefix(scheme, "mysql") && scheme != "mariadb" && scheme != "vitess" && scheme != "planetscale" {
-		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
-	}
-
-	host := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		port = "3306"
-	}
-
-	var user, password string
-	if u.User != nil {
-		user = u.User.Username()
-		password, _ = u.User.Password()
-	}
-
-	database := strings.TrimPrefix(u.Path, "/")
-
-	dsn := ""
-	if user != "" {
-		dsn = user
-		if password != "" {
-			dsn += ":" + password
-		}
-		dsn += "@"
-	}
-	dsn += fmt.Sprintf("tcp(%s:%s)/%s", host, port, database)
-
-	query := u.Query()
-	query.Set("parseTime", "true")
-	query.Set("allowNativePasswords", "true")
-	// PlanetScale requires TLS on MySQL-wire connections and rejects plaintext with
-	// "client must use SSL/TLS". Enable it automatically for the planetscale scheme
-	// and *.psdb.cloud hosts unless the caller already set a tls value, so
-	// tls=skip-verify or a custom config still wins.
-	if !query.Has("tls") && (scheme == "planetscale" || strings.HasSuffix(strings.ToLower(host), ".psdb.cloud")) {
-		query.Set("tls", "true")
-	}
-	dsn += "?" + query.Encode()
-
-	return dsn, database, nil
+	return mysqluri.ToDSN(uri)
 }
 
 func (d *MySQLDestination) Close(ctx context.Context) error {
@@ -797,7 +755,7 @@ func (d *MySQLDestination) GetMaxCDCLSN(ctx context.Context, table string) (stri
 	query := fmt.Sprintf("SELECT MAX(`_cdc_lsn`) FROM %s", quoteTable(table))
 	err := d.db.QueryRowContext(ctx, query).Scan(&maxLSN)
 	if err != nil {
-		if strings.Contains(err.Error(), "doesn't exist") {
+		if isMySQLMissingTableError(err) {
 			return "", nil
 		}
 		return "", err
@@ -808,20 +766,35 @@ func (d *MySQLDestination) GetMaxCDCLSN(ctx context.Context, table string) (stri
 	return maxLSN.String, nil
 }
 
+// isMySQLMissingTableError reports whether err means the queried table does not
+// exist. Plain MySQL raises errno 1146 ("... doesn't exist"); vtgate raises
+// errno 1146 or 1051 with "table ... does not exist" (VT05004/VT05005).
+func isMySQLMissingTableError(err error) bool {
+	var myErr *mysqldriver.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == 1146 || myErr.Number == 1051
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "does not exist")
+}
+
 func (d *MySQLDestination) GetScheme() string { return "mysql" }
 
 func (d *MySQLDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
-	tableName := extractTableName(table)
+	database, tableName := splitDatabaseTable(table)
+	if database == "" {
+		database = d.database
+	}
 
 	query := `
 		SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE,
 		       NUMERIC_PRECISION, NUMERIC_SCALE, CHARACTER_MAXIMUM_LENGTH,
 		       COLUMN_TYPE
 		FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+		WHERE TABLE_SCHEMA = ` + mysqlSchemaFilterExpr(database) + ` AND TABLE_NAME = ?
 		ORDER BY ORDINAL_POSITION`
 
-	rows, err := d.db.QueryContext(ctx, query, tableName)
+	rows, err := d.db.QueryContext(ctx, query, mysqlSchemaFilterArgs(database, tableName)...)
 	if err != nil {
 		config.LogFailedQuery(query, err)
 		return nil, fmt.Errorf("failed to query table schema: %w", err)
@@ -866,9 +839,27 @@ func (d *MySQLDestination) GetTableSchema(ctx context.Context, table string) (*s
 
 	return &schema.TableSchema{
 		Name:    tableName,
-		Schema:  d.database,
+		Schema:  database,
 		Columns: columns,
 	}, nil
+}
+
+// mysqlSchemaFilterExpr and mysqlSchemaFilterArgs build the TABLE_SCHEMA filter
+// for information_schema lookups. Destination tables can be qualified with a
+// database other than the connection default (e.g. multi-table CDC with
+// dest_schema), so the qualifier must win over DATABASE().
+func mysqlSchemaFilterExpr(database string) string {
+	if database == "" {
+		return "DATABASE()"
+	}
+	return "?"
+}
+
+func mysqlSchemaFilterArgs(database, tableName string) []interface{} {
+	if database == "" {
+		return []interface{}{tableName}
+	}
+	return []interface{}{database, tableName}
 }
 
 // isMySQLTextFamily reports whether dataType is a TEXT-family column.

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -1,9 +1,11 @@
 package mysql
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,43 +20,57 @@ func TestUriToDSN(t *testing.T) {
 		{
 			name:         "basic mysql uri",
 			uri:          "mysql://user:pass@localhost:3306/testdb",
-			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?allowNativePasswords=true&parseTime=true",
+			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?parseTime=true",
 			wantDatabase: "testdb",
 			wantErr:      false,
 		},
 		{
 			name:         "mysql uri with default port",
 			uri:          "mysql://user:pass@localhost/testdb",
-			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?allowNativePasswords=true&parseTime=true",
+			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?parseTime=true",
 			wantDatabase: "testdb",
 			wantErr:      false,
 		},
 		{
 			name:         "mysql uri without password",
 			uri:          "mysql://user@localhost:3306/testdb",
-			wantDSN:      "user@tcp(localhost:3306)/testdb?allowNativePasswords=true&parseTime=true",
+			wantDSN:      "user@tcp(localhost:3306)/testdb?parseTime=true",
 			wantDatabase: "testdb",
 			wantErr:      false,
 		},
 		{
 			name:         "mariadb scheme",
 			uri:          "mariadb://user:pass@localhost:3306/testdb",
-			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?allowNativePasswords=true&parseTime=true",
+			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?parseTime=true",
 			wantDatabase: "testdb",
 			wantErr:      false,
 		},
 		{
 			name:         "mysql+pymysql scheme",
 			uri:          "mysql+pymysql://user:pass@localhost:3306/testdb",
-			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?allowNativePasswords=true&parseTime=true",
+			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?parseTime=true",
 			wantDatabase: "testdb",
 			wantErr:      false,
 		},
 		{
 			name:         "uri with query parameters",
 			uri:          "mysql://user:pass@localhost:3306/testdb?charset=utf8mb4",
-			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?allowNativePasswords=true&charset=utf8mb4&parseTime=true",
+			wantDSN:      "user:pass@tcp(localhost:3306)/testdb?charset=utf8mb4&parseTime=true",
 			wantDatabase: "testdb",
+			wantErr:      false,
+		},
+		{
+			name:         "ps_mysql scheme enables tls",
+			uri:          "ps_mysql://user:pass@aws.connect.psdb.cloud/mydb",
+			wantDSN:      "user:pass@tcp(aws.connect.psdb.cloud:3306)/mydb?parseTime=true&tls=true",
+			wantDatabase: "mydb",
+			wantErr:      false,
+		},
+		{
+			name:         "ps_mysql tls override wins",
+			uri:          "ps_mysql://user:pass@localhost:3306/mydb?tls=skip-verify",
+			wantDSN:      "user:pass@tcp(localhost:3306)/mydb?parseTime=true&tls=skip-verify",
+			wantDatabase: "mydb",
 			wantErr:      false,
 		},
 		{
@@ -275,6 +291,41 @@ func TestBuildUpdateSet(t *testing.T) {
 	}
 }
 
+// isMySQLMissingTableError must recognize both plain MySQL ("doesn't exist",
+// errno 1146) and vtgate (VT05004/VT05005 "does not exist", errno 1146/1051)
+// forms, so a first CDC run against a Vitess/PlanetScale destination is treated
+// as "no cursor yet" rather than an error.
+func TestIsMySQLMissingTableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"mysql errno 1146", &mysqldriver.MySQLError{Number: 1146, Message: "Table 'db.t' doesn't exist"}, true},
+		{"vtgate errno 1051", &mysqldriver.MySQLError{Number: 1051, Message: "VT05004: table 't' does not exist"}, true},
+		{"vtgate text without errno", errors.New("target: db.0.primary: vttablet: table 't' does not exist in keyspace 'db'"), true},
+		{"plain mysql text without errno", errors.New("Error 1146: Table 'db.t' doesn't exist"), true},
+		{"other mysql error", &mysqldriver.MySQLError{Number: 1045, Message: "Access denied"}, false},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isMySQLMissingTableError(tt.err))
+		})
+	}
+}
+
+// The information_schema filter must honor the table's database qualifier:
+// destination tables can live outside the connection's default database (e.g.
+// multi-table CDC with dest_schema).
+func TestMySQLSchemaFilter(t *testing.T) {
+	assert.Equal(t, "?", mysqlSchemaFilterExpr("otherdb"))
+	assert.Equal(t, []interface{}{"otherdb", "users"}, mysqlSchemaFilterArgs("otherdb", "users"))
+
+	assert.Equal(t, "DATABASE()", mysqlSchemaFilterExpr(""))
+	assert.Equal(t, []interface{}{"users"}, mysqlSchemaFilterArgs("", "users"))
+}
+
 func TestExtractTableName(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -381,7 +432,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 func TestMySQLDestination_Schemes(t *testing.T) {
 	dest := NewMySQLDestination()
 	schemes := dest.Schemes()
-	expected := []string{"mysql", "mysql+pymysql", "mariadb", "vitess", "planetscale"}
+	expected := []string{"mysql", "mysql+pymysql", "mariadb", "vitess", "ps_mysql"}
 	assert.Equal(t, expected, schemes)
 }
 

--- a/pkg/destination/mysql/register.go
+++ b/pkg/destination/mysql/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterDestination(
-		[]string{"mysql", "mysql+pymysql", "mariadb", "vitess", "planetscale"},
+		[]string{"mysql", "mysql+pymysql", "mariadb", "vitess", "ps_mysql"},
 		func() interface{} { return NewMySQLDestination() },
 	)
 }

--- a/pkg/mysqluri/mysqluri.go
+++ b/pkg/mysqluri/mysqluri.go
@@ -1,0 +1,93 @@
+// Package mysqluri converts ingestr's MySQL-family URIs (mysql, mariadb,
+// vitess, ps_mysql) into go-sql-driver DSNs. It is shared by the MySQL
+// source and destination so scheme handling and the PlanetScale TLS default
+// cannot drift between the two.
+package mysqluri
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// IsMySQLFamilyScheme reports whether scheme names a MySQL-wire connector:
+// MySQL/MariaDB, Vitess, or PlanetScale MySQL.
+func IsMySQLFamilyScheme(scheme string) bool {
+	switch {
+	case strings.HasPrefix(scheme, "mysql"), scheme == "mariadb", scheme == "vitess", scheme == "ps_mysql":
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseURL parses a MySQL-family URI. url.Parse rejects scheme characters
+// ingestr allows (the underscore in ps_mysql), so the scheme is split off
+// manually, the remainder is parsed under a placeholder, and the original
+// scheme is restored on the result.
+func ParseURL(rawURI string) (*url.URL, error) {
+	idx := strings.Index(rawURI, "://")
+	if idx == -1 {
+		return url.Parse(rawURI)
+	}
+	u, err := url.Parse("scheme" + rawURI[idx:])
+	if err != nil {
+		return nil, err
+	}
+	u.Scheme = strings.ToLower(rawURI[:idx])
+	return u, nil
+}
+
+// ToDSN converts a MySQL-family URI to the DSN format expected by
+// go-sql-driver/mysql and returns the DSN and the database name.
+//
+//	URI format: mysql://user:pass@host:port/database?params
+//	DSN format: user:pass@tcp(host:port)/database?params
+func ToDSN(uri string) (string, string, error) {
+	u, err := ParseURL(uri)
+	if err != nil {
+		return "", "", err
+	}
+
+	scheme := u.Scheme
+	if !IsMySQLFamilyScheme(scheme) {
+		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "3306"
+	}
+
+	var user, password string
+	if u.User != nil {
+		user = u.User.Username()
+		password, _ = u.User.Password()
+	}
+
+	database := strings.TrimPrefix(u.Path, "/")
+
+	dsn := ""
+	if user != "" {
+		dsn = user
+		if password != "" {
+			dsn += ":" + password
+		}
+		dsn += "@"
+	}
+	dsn += fmt.Sprintf("tcp(%s:%s)/%s", host, port, database)
+
+	query := u.Query()
+	query.Set("parseTime", "true")
+	// PlanetScale requires TLS on MySQL-wire connections and rejects plaintext
+	// with "client must use SSL/TLS". Enable it automatically for the ps_mysql
+	// scheme and *.psdb.cloud hosts unless the caller already set a tls value, so
+	// tls=skip-verify or a custom config still wins.
+	if !query.Has("tls") && (scheme == "ps_mysql" || strings.HasSuffix(strings.ToLower(host), ".psdb.cloud")) {
+		query.Set("tls", "true")
+	}
+	dsn += "?" + query.Encode()
+
+	return dsn, database, nil
+}

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/url"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -22,6 +21,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/mysqluri"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
@@ -138,7 +138,7 @@ func (s *MySQLCDCSource) Connect(ctx context.Context, rawURI string) error {
 
 	if isVitess, _ := isVitessServer(ctx, db); isVitess {
 		_ = db.Close()
-		return fmt.Errorf("server for database %q identifies as Vitess/PlanetScale, which has no MySQL binlog; use the vitess+cdc:// or planetscale+cdc:// scheme instead", database)
+		return fmt.Errorf("server for database %q identifies as Vitess/PlanetScale, which has no MySQL binlog; use the vitess+cdc:// or ps_mysql+cdc:// scheme instead", database)
 	}
 
 	if err := checkMySQLBinlogSettings(ctx, db); err != nil {
@@ -350,7 +350,7 @@ func parseMySQLCDCURI(rawURI string) (MySQLCDCConfig, string, mysqlCDCConnInfo, 
 		Flavor:   gomysql.MySQLFlavor,
 	}
 
-	parsed, err := url.Parse(rawURI)
+	parsed, err := mysqluri.ParseURL(rawURI)
 	if err != nil {
 		return cfg, "", mysqlCDCConnInfo{}, err
 	}
@@ -360,7 +360,7 @@ func parseMySQLCDCURI(rawURI string) (MySQLCDCConfig, string, mysqlCDCConnInfo, 
 		return cfg, "", mysqlCDCConnInfo{}, fmt.Errorf("unsupported MySQL CDC scheme: %s", parsed.Scheme)
 	}
 	switch baseScheme {
-	case "mysql", "mysql+pymysql", "vitess", "planetscale":
+	case "mysql", "mysql+pymysql", "vitess", "ps_mysql":
 		parsed.Scheme = baseScheme
 	case "mariadb":
 		parsed.Scheme = "mariadb"
@@ -426,7 +426,7 @@ func mysqlCDCConnInfoFromURI(normalizedURI string) (mysqlCDCConnInfo, error) {
 	if err != nil {
 		return mysqlCDCConnInfo{}, fmt.Errorf("failed to parse MySQL CDC connection parameters: %w", err)
 	}
-	parsed, err := url.Parse(normalizedURI)
+	parsed, err := mysqluri.ParseURL(normalizedURI)
 	if err != nil {
 		return mysqlCDCConnInfo{}, err
 	}

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/mysqluri"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	_ "github.com/go-sql-driver/mysql"
@@ -64,7 +64,7 @@ func (s *MySQLSource) Connect(ctx context.Context, uri string) error {
 		s.sessionInit = []string{"SET workload = 'OLAP'"}
 	} else if isVitess, _ := isVitessServer(ctx, db); isVitess {
 		_ = db.Close()
-		return fmt.Errorf("server for database %q identifies as Vitess/PlanetScale; use the vitess:// or planetscale:// scheme instead", database)
+		return fmt.Errorf("server for database %q identifies as Vitess/PlanetScale; use the vitess:// or ps_mysql:// scheme instead", database)
 	}
 
 	s.db = db
@@ -73,72 +73,11 @@ func (s *MySQLSource) Connect(ctx context.Context, uri string) error {
 	return nil
 }
 
-// uriToDSN converts a MySQL URI to the DSN format expected by go-sql-driver/mysql
-// URI format: mysql://user:pass@host:port/database?params
-// DSN format: user:pass@tcp(host:port)/database?params
-// Returns: dsn, database name, error
+// uriToDSN converts a MySQL-family URI to the DSN format expected by
+// go-sql-driver/mysql, returning the DSN and the database name. The conversion
+// lives in pkg/mysqluri, shared with the MySQL destination.
 func uriToDSN(uri string) (string, string, error) {
-	u, err := url.Parse(uri)
-	if err != nil {
-		return "", "", err
-	}
-
-	// Normalize scheme
-	scheme := strings.ToLower(u.Scheme)
-	if !isMySQLFamilyScheme(scheme) {
-		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
-	}
-
-	host := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		port = "3306"
-	}
-
-	var user, password string
-	if u.User != nil {
-		user = u.User.Username()
-		password, _ = u.User.Password()
-	}
-
-	database := strings.TrimPrefix(u.Path, "/")
-
-	// Build DSN
-	dsn := ""
-	if user != "" {
-		dsn = user
-		if password != "" {
-			dsn += ":" + password
-		}
-		dsn += "@"
-	}
-	dsn += fmt.Sprintf("tcp(%s:%s)/%s", host, port, database)
-
-	// Add query parameters
-	query := u.Query()
-	query.Set("parseTime", "true") // Always parse time
-	// PlanetScale requires TLS on MySQL-wire connections; enable it automatically for
-	// the planetscale scheme and *.psdb.cloud hosts unless the caller already set a
-	// tls value, so tls=skip-verify or a custom config still wins.
-	if !query.Has("tls") && (scheme == "planetscale" || strings.HasSuffix(strings.ToLower(host), ".psdb.cloud")) {
-		query.Set("tls", "true")
-	}
-	if len(query) > 0 {
-		dsn += "?" + query.Encode()
-	}
-
-	return dsn, database, nil
-}
-
-// isMySQLFamilyScheme reports whether scheme names a MySQL-wire connector handled
-// by this package: MySQL/MariaDB, Vitess, or PlanetScale.
-func isMySQLFamilyScheme(scheme string) bool {
-	switch {
-	case strings.HasPrefix(scheme, "mysql"), scheme == "mariadb", scheme == "vitess", scheme == "planetscale":
-		return true
-	default:
-		return false
-	}
+	return mysqluri.ToDSN(uri)
 }
 
 func isVitessServer(ctx context.Context, db *sql.DB) (bool, error) {

--- a/pkg/source/mysql/planetscale_cdc.go
+++ b/pkg/source/mysql/planetscale_cdc.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 	psdbconnect "github.com/bruin-data/ingestr/pkg/source/mysql/internal/psdbconnect"
 	"google.golang.org/protobuf/proto"
-	vreplication "vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -46,7 +45,7 @@ func NewPlanetScaleCDCSource() *PlanetScaleCDCSource {
 }
 
 func (s *PlanetScaleCDCSource) Schemes() []string {
-	return []string{"planetscale+cdc"}
+	return []string{"ps_mysql+cdc"}
 }
 
 func (s *PlanetScaleCDCSource) Connect(ctx context.Context, uri string) error {
@@ -273,6 +272,27 @@ func (t *PlanetScaleCDCTable) Read(ctx context.Context, opts source.ReadOptions)
 	return results, nil
 }
 
+const (
+	// psdbRecvStallTimeout bounds how long a Sync stream may go without any
+	// response before the run fails with a diagnosable error instead of hanging.
+	// PlanetScale's vttablet heartbeat writes advance every shard's GTID about
+	// once a second, so a healthy stream always produces cursor updates well
+	// within this window even when the captured table itself is idle.
+	psdbRecvStallTimeout = 2 * time.Minute
+	// psdbPeekTimeout bounds the short-lived "current position" Sync used to
+	// establish the batch-capture stop boundary.
+	psdbPeekTimeout = 30 * time.Second
+)
+
+// psdbResumeHint suggests --full-refresh on stream errors for resumed cursors,
+// which is how a purged/expired GTID position typically surfaces.
+func psdbResumeHint(start *psdbconnect.TableCursor) string {
+	if start.GetPosition() == "" && start.GetLastKnownPk() == nil {
+		return ""
+	}
+	return "; if the stored resume position is no longer available on the server, run with --full-refresh to rebuild the destination safely"
+}
+
 type psdbCDCTarget struct {
 	bareName   string              // table name as passed to the psdbconnect Sync RPC
 	resultName string              // RecordBatchResult.TableName tag ("" for single-table)
@@ -414,7 +434,7 @@ func (s *PlanetScaleCDCSource) streamTable(ctx context.Context, client *psdbconn
 		// A resumed shard with no pending snapshot that has already reached the
 		// current position has nothing to stream; skip it (and avoid blocking on
 		// an idle stream that would never return).
-		if start.GetLastKnownPk() == nil && start.GetPosition() != "" && psdbAtLeast(start.GetPosition(), stopPos) {
+		if start.GetLastKnownPk() == nil && start.GetPosition() != "" && gtidAtLeast(start.GetPosition(), stopPos) {
 			config.Debug("[SOURCE] PlanetScale CDC: %s shard=%q already caught up; skipping", t.bareName, shard)
 			continue
 		}
@@ -427,7 +447,10 @@ func (s *PlanetScaleCDCSource) streamTable(ctx context.Context, client *psdbconn
 }
 
 func (s *PlanetScaleCDCSource) streamShard(ctx context.Context, client *psdbconnect.Client, t psdbCDCTarget, shard string, start *psdbconnect.TableCursor, stopPos string, sourceCols []schema.Column, pkPositions []int, ordinal *uint64, state *psdbCursorState, batchSize int, buffers map[string]*mysqlCDCChangeBuffer, results chan<- source.RecordBatchResult) error {
-	stream, err := client.Sync(ctx, &psdbconnect.SyncRequest{
+	sctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := client.Sync(sctx, &psdbconnect.SyncRequest{
 		TableName:      t.bareName,
 		Cursor:         start,
 		TabletType:     psdbconnect.TabletType_primary,
@@ -436,8 +459,35 @@ func (s *PlanetScaleCDCSource) streamShard(ctx context.Context, client *psdbconn
 		IncludeDeletes: true,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to start psdbconnect Sync for %s/%s: %w", t.bareName, shard, err)
+		return fmt.Errorf("failed to start psdbconnect Sync for %s/%s: %w%s", t.bareName, shard, err, psdbResumeHint(start))
 	}
+
+	// Recv runs in its own goroutine so the loop can bound how long it waits: the
+	// server never half-closes an idle stream, so a shard whose GTID stops
+	// advancing (e.g. no heartbeat writes on a non-PlanetScale psdbconnect
+	// endpoint) would otherwise block Recv forever. Canceling sctx unblocks and
+	// ends the reader goroutine.
+	type recvResult struct {
+		resp *psdbconnect.SyncResponse
+		err  error
+	}
+	recvCh := make(chan recvResult)
+	go func() {
+		for {
+			resp, err := stream.Recv()
+			select {
+			case recvCh <- recvResult{resp: resp, err: err}:
+			case <-sctx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	stall := time.NewTimer(psdbRecvStallTimeout)
+	defer stall.Stop()
 
 	cursor := start
 	// A fresh stream (empty position) or a resumed pending snapshot must run the
@@ -448,23 +498,32 @@ func (s *PlanetScaleCDCSource) streamShard(ctx context.Context, client *psdbconn
 	pendingCopyStart := -1
 	var copyCheckpoint *mysqlCDCChange
 	for {
+		var resp *psdbconnect.SyncResponse
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-		}
-
-		resp, err := stream.Recv()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				config.Debug("[SOURCE] PlanetScale CDC: %s/%s stream EOF", t.bareName, shard)
-				return nil
+		case <-stall.C:
+			return fmt.Errorf("psdbconnect Sync for %s/%s made no progress for %v (position %q, stop %q, copy done: %v); the shard may be idle without heartbeat writes to advance its GTID — retry, or run with --full-refresh to rebuild the destination safely", t.bareName, shard, psdbRecvStallTimeout, cursor.GetPosition(), stopPos, copyDone)
+		case rr := <-recvCh:
+			if rr.err != nil {
+				if errors.Is(rr.err, io.EOF) {
+					config.Debug("[SOURCE] PlanetScale CDC: %s/%s stream EOF", t.bareName, shard)
+					return nil
+				}
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				return fmt.Errorf("psdbconnect Sync receive failed for %s/%s: %w%s", t.bareName, shard, rr.err, psdbResumeHint(start))
 			}
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			return fmt.Errorf("psdbconnect Sync receive failed for %s/%s: %w", t.bareName, shard, err)
+			resp = rr.resp
 		}
+		if !stall.Stop() {
+			select {
+			case <-stall.C:
+			default:
+			}
+		}
+		stall.Reset(psdbRecvStallTimeout)
 		if rpcErr := resp.GetError(); rpcErr != nil && rpcErr.GetCode() != vtrpcpb.Code_OK {
 			return fmt.Errorf("psdbconnect Sync error for %s/%s: %s", t.bareName, shard, rpcErr.GetMessage())
 		}
@@ -579,7 +638,7 @@ func psdbCopyFinished(sawLastPk bool, pos, anchor string, hasLastPk bool) bool {
 // every later shard). Callers emit the current response's changes before
 // checking this, so stopping here loses nothing.
 func psdbReachedStop(copyDone, hasLastPk bool, pos, stopPos string) bool {
-	return copyDone && !hasLastPk && psdbAtLeast(pos, stopPos)
+	return copyDone && !hasLastPk && gtidAtLeast(pos, stopPos)
 }
 
 func psdbRewriteBufferedLSNs(buffers map[string]*mysqlCDCChangeBuffer, key string, start int, ordinal uint64, payload string) bool {
@@ -599,7 +658,7 @@ func psdbRewriteBufferedLSNs(buffers map[string]*mysqlCDCChangeBuffer, key strin
 // peekPosition opens a short-lived Sync at the special "current" position to read
 // the shard's latest VGTID, used as the stop boundary for batch capture.
 func (s *PlanetScaleCDCSource) peekPosition(ctx context.Context, client *psdbconnect.Client, table, shard string) (string, error) {
-	pctx, cancel := context.WithCancel(ctx)
+	pctx, cancel := context.WithTimeout(ctx, psdbPeekTimeout)
 	defer cancel()
 
 	stream, err := client.Sync(pctx, &psdbconnect.SyncRequest{
@@ -729,26 +788,6 @@ func psdbPKChanged(before, after []interface{}, pkPositions []int) bool {
 		}
 	}
 	return false
-}
-
-// psdbAtLeast reports whether position pos is at or beyond stop, comparing as
-// Vitess GTID sets and falling back to string equality when unparseable.
-func psdbAtLeast(pos, stop string) bool {
-	if pos == "" || stop == "" {
-		return false
-	}
-	if pos == stop {
-		return true
-	}
-	posSet, err := vreplication.DecodePosition(pos)
-	if err != nil {
-		return false
-	}
-	stopSet, err := vreplication.DecodePosition(stop)
-	if err != nil {
-		return false
-	}
-	return posSet.AtLeast(stopSet)
 }
 
 var (

--- a/pkg/source/mysql/planetscale_cdc_test.go
+++ b/pkg/source/mysql/planetscale_cdc_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestParseMySQLCDCURIPlanetScaleParams(t *testing.T) {
-	uri := "planetscale+cdc://user:pscale_pw_secret@abc.connect.psdb.cloud:3306/mydb"
+	uri := "ps_mysql+cdc://user:pscale_pw_secret@abc.connect.psdb.cloud:3306/mydb"
 
 	_, normalized, connInfo, err := parseMySQLCDCURI(uri)
 	if err != nil {
@@ -32,10 +32,10 @@ func TestParseMySQLCDCURIPlanetScaleParams(t *testing.T) {
 		t.Errorf("credentials: got %q:%q", connInfo.User, connInfo.Password)
 	}
 
-	// The +cdc suffix is stripped, leaving the planetscale scheme so uriToDSN can
+	// The +cdc suffix is stripped, leaving the ps_mysql scheme so uriToDSN can
 	// auto-enable TLS for the underlying MySQL connection.
-	if !strings.HasPrefix(normalized, "planetscale://") {
-		t.Errorf("normalized URI must keep the planetscale scheme: %s", normalized)
+	if !strings.HasPrefix(normalized, "ps_mysql://") {
+		t.Errorf("normalized URI must keep the ps_mysql scheme: %s", normalized)
 	}
 }
 
@@ -48,10 +48,10 @@ func TestCDCSchemeRouting(t *testing.T) {
 	}{
 		{"mysql", (*MySQLSource)(nil)},
 		{"vitess", (*VitessSource)(nil)},
-		{"planetscale", (*VitessSource)(nil)},
+		{"ps_mysql", (*VitessSource)(nil)},
 		{"mysql+cdc", (*MySQLCDCSource)(nil)},
 		{"vitess+cdc", (*VitessCDCSource)(nil)},
-		{"planetscale+cdc", (*PlanetScaleCDCSource)(nil)},
+		{"ps_mysql+cdc", (*PlanetScaleCDCSource)(nil)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.scheme, func(t *testing.T) {
@@ -257,8 +257,8 @@ func TestPsdbAtLeast(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := psdbAtLeast(tc.pos, tc.stop); got != tc.want {
-				t.Errorf("psdbAtLeast(%q, %q) = %v, want %v", tc.pos, tc.stop, got, tc.want)
+			if got := gtidAtLeast(tc.pos, tc.stop); got != tc.want {
+				t.Errorf("gtidAtLeast(%q, %q) = %v, want %v", tc.pos, tc.stop, got, tc.want)
 			}
 		})
 	}

--- a/pkg/source/mysql/register.go
+++ b/pkg/source/mysql/register.go
@@ -12,7 +12,7 @@ func init() {
 		func() interface{} { return NewMySQLSource() },
 	)
 	registry.RegisterSource(
-		[]string{"vitess", "planetscale"},
+		[]string{"vitess", "ps_mysql"},
 		func() interface{} { return NewVitessSource() },
 	)
 	registry.RegisterSource(
@@ -24,7 +24,7 @@ func init() {
 		func() interface{} { return NewVitessCDCSource() },
 	)
 	registry.RegisterSource(
-		[]string{"planetscale+cdc"},
+		[]string{"ps_mysql+cdc"},
 		func() interface{} { return NewPlanetScaleCDCSource() },
 	)
 }

--- a/pkg/source/mysql/vitess.go
+++ b/pkg/source/mysql/vitess.go
@@ -3,8 +3,8 @@ package mysql
 // VitessSource reads from a Vitess keyspace over vtgate's MySQL protocol. It is
 // identical to MySQLSource except that it runs in the OLAP workload, which lifts
 // the per-query row-count cap Vitess enforces in its default OLTP workload. It
-// serves both the vitess:// and planetscale:// schemes (PlanetScale is managed
-// Vitess); TLS for PlanetScale is enabled in uriToDSN.
+// serves both the vitess:// and ps_mysql:// schemes (PlanetScale MySQL is
+// managed Vitess); TLS for PlanetScale is enabled in uriToDSN.
 type VitessSource struct {
 	*MySQLSource
 }
@@ -16,5 +16,5 @@ func NewVitessSource() *VitessSource {
 }
 
 func (s *VitessSource) Schemes() []string {
-	return []string{"vitess", "planetscale"}
+	return []string{"vitess", "ps_mysql"}
 }

--- a/pkg/source/mysql/vitess_cdc.go
+++ b/pkg/source/mysql/vitess_cdc.go
@@ -17,12 +17,14 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
+	vreplication "vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -303,23 +305,26 @@ type vitessTxnRow struct {
 	deleted  bool
 }
 
-// runVStream opens a single VStream covering all target tables and drives the
-// copy + streaming phases, emitting CDC batches via the shared change buffers.
-// In batch mode it stops once caught up: heartbeats are only emitted when the
-// stream is idle, so the first heartbeat after the copy phase completes (or
-// immediately, when resuming) signals that everything up to "now" was streamed.
+// vitessPeekTimeout bounds the short-lived "current position" VStream used to
+// establish the batch-capture stop boundary.
+const vitessPeekTimeout = 30 * time.Second
+
+// runVStream captures all selected tables in batch mode. A single VStream has a
+// single start position, so tables with a stored resume cursor and tables
+// without one cannot share a stream. Targets are therefore partitioned: tables
+// without a cursor (new tables) get a fresh stream with a consistent copy phase,
+// and tables with cursors resume from the oldest stored VGTID (re-delivery to
+// tables whose cursor is newer is idempotent via merge). Discarding the stored
+// cursors and re-copying everything instead would silently miss deletes that
+// happened since those cursors were written.
 func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTarget, resumeByBare map[string]string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	if len(targets) == 0 {
 		return nil
 	}
 
-	schemaByTable := make(map[string]*schema.TableSchema, len(targets))
-	resultByTable := make(map[string]string, len(targets))
-	rules := make([]*binlogdatapb.Rule, 0, len(targets))
-	for _, t := range targets {
-		schemaByTable[t.bareName] = t.schema
-		resultByTable[t.bareName] = t.resultName
-		rules = append(rules, &binlogdatapb.Rule{Match: t.bareName, Filter: "select * from " + t.bareName})
+	plan, err := planVitessStart(targets, resumeByBare)
+	if err != nil {
+		return err
 	}
 
 	shards, err := s.listShards(ctx)
@@ -329,13 +334,6 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 	if len(shards) == 0 {
 		return fmt.Errorf("no shards found for keyspace %s", s.keyspace)
 	}
-
-	startVGtid, ordinal, fromResume, err := s.resolveVitessStart(targets, resumeByBare, shards)
-	if err != nil {
-		return err
-	}
-
-	flags := &vtgatepb.VStreamFlags{HeartbeatInterval: 1, StopOnReshard: false}
 
 	// vtgateconn.Dial is unusable for TLS: its registered gRPC dialer appends an
 	// insecure transport credential that overrides whatever we pass, so a TLS-only
@@ -349,11 +347,65 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 	}
 	defer func() { _ = cc.Close() }()
 
+	if len(plan.fresh) > 0 && len(plan.resume) > 0 {
+		names := make([]string, 0, len(plan.fresh))
+		for _, t := range plan.fresh {
+			names = append(names, t.bareName)
+		}
+		output.Warnf("[WARNING] tables without a stored CDC cursor will be copied fresh: %s; previously synced tables resume from their cursors\n", strings.Join(names, ", "))
+	}
+
+	ordinal := plan.ordinal
+	if len(plan.fresh) > 0 {
+		if err := s.streamVGroup(ctx, cc, plan.fresh, freshVitessVGtid(s.keyspace, shards), false, &ordinal, shards, opts, results); err != nil {
+			return err
+		}
+	}
+	if len(plan.resume) > 0 {
+		if err := s.streamVGroup(ctx, cc, plan.resume, plan.resumeVGtid, true, &ordinal, shards, opts, results); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// streamVGroup opens one VStream for a group of tables sharing a start position
+// and drives the copy + streaming phases, emitting CDC batches via the shared
+// change buffers. Batch semantics: the current per-shard positions are captured
+// up front as the stop boundary, and the stream ends at the first transaction
+// boundary at which the copy phase (if any) has completed and every shard has
+// reached that boundary — so a run processes everything up to its start moment
+// and then stops, even under sustained write traffic (microbatches).
+func (s *VitessCDCSource) streamVGroup(ctx context.Context, cc *grpc.ClientConn, targets []vitessCDCTarget, startVGtid *binlogdatapb.VGtid, fromResume bool, ordinal *uint64, shards []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	schemaByTable := make(map[string]*schema.TableSchema, len(targets))
+	resultByTable := make(map[string]string, len(targets))
+	rules := make([]*binlogdatapb.Rule, 0, len(targets))
+	for _, t := range targets {
+		schemaByTable[t.bareName] = t.schema
+		resultByTable[t.bareName] = t.resultName
+		rules = append(rules, &binlogdatapb.Rule{Match: t.bareName, Filter: "select * from " + t.bareName})
+	}
+
+	stopByShard, err := s.peekVitessPositions(ctx, cc, rules, shards)
+	if err != nil {
+		return err
+	}
+	copyPending := vitessPendingCopyShards(startVGtid, fromResume, shards)
+	config.Debug("[SOURCE] Vitess CDC: group tables=%d fromResume=%v stop=%v copyPending=%d", len(targets), fromResume, stopByShard, len(copyPending))
+
+	// A resumed group with no interrupted copy that already sits at or beyond the
+	// stop boundary has nothing to stream; skip it rather than wait out an idle
+	// heartbeat interval.
+	if fromResume && len(copyPending) == 0 && vitessCaughtUp(startVGtid, stopByShard, s.keyspace) {
+		config.Debug("[SOURCE] Vitess CDC: resume group already caught up; skipping")
+		return nil
+	}
+
 	reader, err := vtgateservicepb.NewVitessClient(cc).VStream(ctx, &vtgatepb.VStreamRequest{
 		TabletType: topodatapb.TabletType_PRIMARY,
 		Vgtid:      startVGtid,
 		Filter:     &binlogdatapb.Filter{Rules: rules},
-		Flags:      flags,
+		Flags:      &vtgatepb.VStreamFlags{HeartbeatInterval: 1, StopOnReshard: false},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start Vitess VStream: %w", err)
@@ -362,13 +414,16 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 	batchSize := mysqlCDCStreamBatchSize(opts)
 	buffers := make(map[string]*mysqlCDCChangeBuffer, len(targets))
 	fieldsByTable := make(map[string]*vitessFieldInfo)
-	var latestVGtid *binlogdatapb.VGtid
+	latestVGtid := startVGtid
 	var txnRows []vitessTxnRow
-	readyToStop := fromResume // resume runs have no copy phase to wait for
+	idleHeartbeat := false
 
 	flushTxn := func() error {
-		if len(txnRows) == 0 || latestVGtid == nil {
+		if len(txnRows) == 0 {
 			return nil
+		}
+		if latestVGtid == nil {
+			return fmt.Errorf("vstream delivered %d rows before any VGTID; cannot assign resume positions", len(txnRows))
 		}
 		payload, err := encodeVitessVGtid(latestVGtid)
 		if err != nil {
@@ -377,14 +432,14 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 		for i, r := range txnRows {
 			change := mysqlCDCChange{
 				values:  r.values,
-				lsn:     formatVitessLSN(ordinal, i, payload),
+				lsn:     formatVitessLSN(*ordinal, i, payload),
 				deleted: r.deleted,
 			}
 			if err := appendMySQLCDCBufferedChanges(buffers, r.bareName, schemaByTable[r.bareName], resultByTable[r.bareName], []mysqlCDCChange{change}, batchSize, results); err != nil {
 				return err
 			}
 		}
-		ordinal++
+		(*ordinal)++
 		txnRows = txnRows[:0]
 		return nil
 	}
@@ -460,82 +515,207 @@ func (s *VitessCDCSource) runVStream(ctx context.Context, targets []vitessCDCTar
 				}
 
 			case binlogdatapb.VEventType_COPY_COMPLETED:
-				readyToStop = true
+				// vtgate emits one COPY_COMPLETED per shard (Keyspace/Shard set)
+				// and a final keyspace-level event with both empty once every
+				// shard finished. Stopping on the first per-shard event would end
+				// the run while other shards are still copying.
+				if ev.Keyspace == "" && ev.Shard == "" {
+					copyPending = map[string]bool{}
+				} else {
+					delete(copyPending, ev.Shard)
+				}
 
 			case binlogdatapb.VEventType_HEARTBEAT:
 				if ev.Vgtid != nil {
 					latestVGtid = ev.Vgtid
 				}
-				if readyToStop {
-					if err := flushTxn(); err != nil {
-						return err
-					}
-					return flushMySQLCDCChangeBuffers(buffers, results)
-				}
+				idleHeartbeat = true
 			}
 		}
+
+		// Stop at a transaction boundary once the copy phase has completed on
+		// every shard and the stream has caught up to the stop boundary. Under
+		// sustained write traffic the position check is what terminates the run
+		// (heartbeats are suppressed while events flow). The heartbeat is the
+		// fallback for streams that never surface a comparable position (e.g. a
+		// fresh copy of an empty table on an idle keyspace emits no VGTID):
+		// vtgate sends it only when nothing was delivered for a full interval,
+		// which after a completed copy means the stream is fully caught up.
+		if len(copyPending) == 0 && len(txnRows) == 0 && (idleHeartbeat || vitessCaughtUp(latestVGtid, stopByShard, s.keyspace)) {
+			config.Debug("[SOURCE] Vitess CDC: caught up to stop boundary; finishing batch")
+			return flushMySQLCDCChangeBuffers(buffers, results)
+		}
+		idleHeartbeat = false
 	}
 }
 
-// resolveVitessStart determines the VStream start position and seeds the LSN
-// ordinal from stored resume cursors. VStream's VGTID is cumulative (every
-// commit carries the latest GTID for all shards), so persisting and resuming the
-// whole VGTID handles both unsharded and sharded keyspaces with one cursor.
-func (s *VitessCDCSource) resolveVitessStart(targets []vitessCDCTarget, resumeByBare map[string]string, shards []string) (*binlogdatapb.VGtid, uint64, bool, error) {
-	haveAll := true
-	anyResume := false
+// vitessStartPlan partitions targets by resume-cursor availability and carries
+// the resume start position and the seed for the LSN ordinal.
+type vitessStartPlan struct {
+	fresh       []vitessCDCTarget
+	resume      []vitessCDCTarget
+	resumeVGtid *binlogdatapb.VGtid // oldest stored VGTID among resume targets
+	ordinal     uint64              // max stored ordinal + 1 (0 when nothing resumes)
+}
+
+// planVitessStart validates stored cursors and splits targets into a fresh-copy
+// group and a resume group. VStream's VGTID is cumulative (every commit carries
+// the latest GTID for all shards), so resuming the resume group from the oldest
+// stored VGTID handles both unsharded and sharded keyspaces with one cursor;
+// merge makes re-delivery to tables with newer cursors idempotent.
+func planVitessStart(targets []vitessCDCTarget, resumeByBare map[string]string) (vitessStartPlan, error) {
+	var plan vitessStartPlan
 	var minOrdinal uint64 = math.MaxUint64
 	var maxOrdinal uint64
-	var oldest *binlogdatapb.VGtid
 
 	for _, t := range targets {
 		lsn := strings.TrimSpace(resumeByBare[t.bareName])
 		if lsn == "" {
-			haveAll = false
+			plan.fresh = append(plan.fresh, t)
 			continue
 		}
 		ord, payload, ok := parseVitessLSN(lsn)
 		if !ok {
-			return nil, 0, false, fmt.Errorf("resume position %q for %s is invalid; run with --full-refresh to rebuild the destination safely", lsn, t.bareName)
+			return plan, fmt.Errorf("resume position %q for %s is invalid; run with --full-refresh to rebuild the destination safely", lsn, t.bareName)
 		}
 		vgtid, err := decodeVitessVGtid(payload)
 		if err != nil {
-			return nil, 0, false, fmt.Errorf("resume position for %s is invalid: %w; run with --full-refresh to rebuild the destination safely", t.bareName, err)
+			return plan, fmt.Errorf("resume position for %s is invalid: %w; run with --full-refresh to rebuild the destination safely", t.bareName, err)
 		}
-		anyResume = true
+		plan.resume = append(plan.resume, t)
 		if ord < minOrdinal {
 			minOrdinal = ord
-			oldest = vgtid
+			plan.resumeVGtid = vgtid
 		}
 		if ord > maxOrdinal {
 			maxOrdinal = ord
 		}
 	}
-
-	ordinal := uint64(0)
-	if anyResume {
-		ordinal = maxOrdinal + 1
+	if len(plan.resume) > 0 {
+		plan.ordinal = maxOrdinal + 1
 	}
+	return plan, nil
+}
 
-	// Resume the whole stream only when every selected table has a cursor; merge
-	// makes any re-delivery to already-advanced tables idempotent.
-	if anyResume && haveAll {
-		return oldest, ordinal, true, nil
-	}
-	if anyResume && !haveAll {
-		config.Debug("[SOURCE] Vitess CDC: some selected tables lack a resume cursor; performing a fresh copy for all selected tables")
-	}
-
-	// Fresh (or mixed) run: empty Gtid triggers VStream's consistent copy phase.
-	// Shards are listed explicitly (one ShardGtid each) rather than relying on the
-	// empty-Shard "all shards" expansion, which vtcombo resolves unreliably. An
-	// unsharded keyspace has a single shard named "-".
+// freshVitessVGtid builds the start position for a fresh run: empty Gtid
+// triggers VStream's consistent copy phase. Shards are listed explicitly (one
+// ShardGtid each) rather than relying on the empty-Shard "all shards" expansion,
+// which vtcombo resolves unreliably. An unsharded keyspace has a single shard
+// named "-".
+func freshVitessVGtid(keyspace string, shards []string) *binlogdatapb.VGtid {
 	shardGtids := make([]*binlogdatapb.ShardGtid, 0, len(shards))
 	for _, sh := range shards {
-		shardGtids = append(shardGtids, &binlogdatapb.ShardGtid{Keyspace: s.keyspace, Shard: sh, Gtid: ""})
+		shardGtids = append(shardGtids, &binlogdatapb.ShardGtid{Keyspace: keyspace, Shard: sh, Gtid: ""})
 	}
-	fresh := &binlogdatapb.VGtid{ShardGtids: shardGtids}
-	return fresh, ordinal, false, nil
+	return &binlogdatapb.VGtid{ShardGtids: shardGtids}
+}
+
+// vitessPendingCopyShards reports which shards still owe a copy phase. A fresh
+// run copies on every shard. A resumed run normally has none — unless the stored
+// VGTID carries TablePKs, i.e. the previous run was interrupted mid-copy, in
+// which case VStream continues that shard's copy and the run must not stop until
+// it completes.
+func vitessPendingCopyShards(start *binlogdatapb.VGtid, fromResume bool, shards []string) map[string]bool {
+	pending := make(map[string]bool, len(shards))
+	if !fromResume {
+		for _, sh := range shards {
+			pending[sh] = true
+		}
+		return pending
+	}
+	for _, sg := range start.GetShardGtids() {
+		if len(sg.GetTablePKs()) > 0 {
+			pending[sg.GetShard()] = true
+		}
+	}
+	return pending
+}
+
+// gtidAtLeast reports whether position pos is at or beyond stop, comparing as
+// Vitess GTID sets and falling back to string equality when unparseable. Shared
+// by the Vitess VStream and PlanetScale psdbconnect stop-boundary checks.
+func gtidAtLeast(pos, stop string) bool {
+	if pos == "" || stop == "" {
+		return false
+	}
+	if pos == stop {
+		return true
+	}
+	posSet, err := vreplication.DecodePosition(pos)
+	if err != nil {
+		return false
+	}
+	stopSet, err := vreplication.DecodePosition(stop)
+	if err != nil {
+		return false
+	}
+	return posSet.AtLeast(stopSet)
+}
+
+// vitessCaughtUp reports whether the latest VGTID has reached or passed the stop
+// boundary on every shard.
+func vitessCaughtUp(latest *binlogdatapb.VGtid, stopByShard map[string]string, keyspace string) bool {
+	if latest == nil || len(stopByShard) == 0 {
+		return false
+	}
+	posByShard := make(map[string]string, len(latest.GetShardGtids()))
+	for _, sg := range latest.GetShardGtids() {
+		if sg.GetKeyspace() == keyspace {
+			posByShard[sg.GetShard()] = sg.GetGtid()
+		}
+	}
+	for shard, stop := range stopByShard {
+		if !gtidAtLeast(posByShard[shard], stop) {
+			return false
+		}
+	}
+	return true
+}
+
+// peekVitessPositions opens a short-lived VStream at the special "current"
+// position and reads events until every shard's GTID is resolved, returning the
+// per-shard stop boundary for batch capture.
+func (s *VitessCDCSource) peekVitessPositions(ctx context.Context, cc *grpc.ClientConn, rules []*binlogdatapb.Rule, shards []string) (map[string]string, error) {
+	pctx, cancel := context.WithTimeout(ctx, vitessPeekTimeout)
+	defer cancel()
+
+	shardGtids := make([]*binlogdatapb.ShardGtid, 0, len(shards))
+	for _, sh := range shards {
+		shardGtids = append(shardGtids, &binlogdatapb.ShardGtid{Keyspace: s.keyspace, Shard: sh, Gtid: "current"})
+	}
+	reader, err := vtgateservicepb.NewVitessClient(cc).VStream(pctx, &vtgatepb.VStreamRequest{
+		TabletType: topodatapb.TabletType_PRIMARY,
+		Vgtid:      &binlogdatapb.VGtid{ShardGtids: shardGtids},
+		Filter:     &binlogdatapb.Filter{Rules: rules},
+		Flags:      &vtgatepb.VStreamFlags{HeartbeatInterval: 1},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read current Vitess position: %w", err)
+	}
+
+	for {
+		resp, err := reader.Recv()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read current Vitess position: %w", err)
+		}
+		for _, ev := range resp.Events {
+			if ev.Vgtid == nil {
+				continue
+			}
+			out := make(map[string]string, len(shards))
+			for _, sg := range ev.Vgtid.GetShardGtids() {
+				if sg.GetKeyspace() != s.keyspace {
+					continue
+				}
+				if g := sg.GetGtid(); g != "" && g != "current" {
+					out[sg.GetShard()] = g
+				}
+			}
+			if len(out) >= len(shards) {
+				return out, nil
+			}
+		}
+	}
 }
 
 // listShards returns the shard names of the keyspace (e.g. ["-"] when unsharded,
@@ -700,9 +880,12 @@ func vitessGRPCTarget(rawURI string, defaultHost string) (string, error) {
 // vitessGRPCTLSCredentials resolves the transport credentials for the VStream
 // gRPC connection. grpc_tls, when set, takes precedence; otherwise the gRPC side
 // inherits the MySQL-protocol tls parameter so a single tls=true secures both
-// connections. Only true and skip-verify enable TLS (skip-verify skips
-// certificate verification); false, preferred, a custom go-sql-driver TLS config
-// name, or an unset value leave the gRPC connection plaintext.
+// connections. true and skip-verify enable TLS (skip-verify skips certificate
+// verification); false or an unset value leave the gRPC connection plaintext. A
+// tls value that only makes sense to the MySQL driver (preferred, or a custom
+// registered TLS config name) cannot be mapped to a gRPC transport, so it is an
+// error unless grpc_tls says explicitly what the gRPC side should do — silently
+// falling back to plaintext would betray a user who asked for TLS.
 func vitessGRPCTLSCredentials(rawURI string) (credentials.TransportCredentials, error) {
 	u, err := url.Parse(rawURI)
 	if err != nil {
@@ -711,8 +894,10 @@ func vitessGRPCTLSCredentials(rawURI string) (credentials.TransportCredentials, 
 	q := u.Query()
 
 	mode := strings.TrimSpace(strings.ToLower(q.Get("grpc_tls")))
+	inherited := false
 	if mode == "" {
 		mode = strings.TrimSpace(strings.ToLower(q.Get("tls")))
+		inherited = mode != ""
 	}
 
 	switch mode {
@@ -722,8 +907,13 @@ func vitessGRPCTLSCredentials(rawURI string) (credentials.TransportCredentials, 
 			cfg.InsecureSkipVerify = true
 		}
 		return credentials.NewTLS(cfg), nil
-	default:
+	case "", "false":
 		return insecure.NewCredentials(), nil
+	default:
+		if inherited {
+			return nil, fmt.Errorf("cannot infer gRPC transport security from tls=%q; set grpc_tls=true, grpc_tls=skip-verify, or grpc_tls=false explicitly on the source URI", mode)
+		}
+		return nil, fmt.Errorf("invalid grpc_tls=%q; use true, skip-verify, or false", mode)
 	}
 }
 

--- a/pkg/source/mysql/vitess_cdc_test.go
+++ b/pkg/source/mysql/vitess_cdc_test.go
@@ -123,26 +123,40 @@ func TestMySQLCDCURIStripsGRPCParams(t *testing.T) {
 
 // vitessGRPCTLSCredentials must turn the user-facing tls/grpc_tls knobs into the
 // right transport security: a single tls=true secures both connections, while
-// grpc_tls overrides the gRPC side independently.
+// grpc_tls overrides the gRPC side independently. A tls value only the MySQL
+// driver understands (preferred, custom config name) must be an explicit error,
+// never a silent plaintext downgrade.
 func TestVitessGRPCTLSCredentials(t *testing.T) {
 	cases := []struct {
 		name    string
 		uri     string
 		wantTLS bool
+		wantErr bool
 	}{
-		{"no params is plaintext", "vitess+cdc://root@h:3307/ks?grpc_port=15991", false},
-		{"tls=true is inherited", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=true", true},
-		{"tls=skip-verify is inherited", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=skip-verify", true},
-		{"tls=false stays plaintext", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=false", false},
-		{"tls=preferred does not map to gRPC", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=preferred", false},
-		{"tls=customCA does not map to gRPC", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=mycustomca", false},
-		{"grpc_tls=true overrides", "vitess+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=true", true},
-		{"grpc_tls=false overrides tls=true", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=true&grpc_tls=false", false},
-		{"grpc_tls=skip-verify overrides", "vitess+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=skip-verify", true},
+		{"no params is plaintext", "vitess+cdc://root@h:3307/ks?grpc_port=15991", false, false},
+		{"tls=true is inherited", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=true", true, false},
+		{"tls=skip-verify is inherited", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=skip-verify", true, false},
+		{"tls=false stays plaintext", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=false", false, false},
+		{"tls=preferred requires explicit grpc_tls", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=preferred", false, true},
+		{"tls=customCA requires explicit grpc_tls", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=mycustomca", false, true},
+		{"tls=customCA with explicit grpc_tls=true", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=mycustomca&grpc_tls=true", true, false},
+		{"grpc_tls=true overrides", "vitess+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=true", true, false},
+		{"grpc_tls=false overrides tls=true", "vitess+cdc://root@h:3307/ks?grpc_port=15991&tls=true&grpc_tls=false", false, false},
+		{"grpc_tls=skip-verify overrides", "vitess+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=skip-verify", true, false},
+		{"invalid grpc_tls errors", "vitess+cdc://root@h:3307/ks?grpc_port=15991&grpc_tls=maybe", false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			creds, err := vitessGRPCTLSCredentials(tc.uri)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got credentials %v", creds.Info().SecurityProtocol)
+				}
+				if !strings.Contains(err.Error(), "grpc_tls") {
+					t.Errorf("error should point at grpc_tls: %v", err)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -151,6 +165,132 @@ func TestVitessGRPCTLSCredentials(t *testing.T) {
 				t.Errorf("got SecurityProtocol=%q (tls=%v), want tls=%v", creds.Info().SecurityProtocol, gotTLS, tc.wantTLS)
 			}
 		})
+	}
+}
+
+// planVitessStart must partition targets by cursor availability instead of
+// discarding valid cursors when some tables lack one: a full re-copy would
+// silently miss deletes that happened since those cursors were written.
+func TestPlanVitessStart(t *testing.T) {
+	vgtidAt := func(gtid string) string {
+		payload, err := encodeVitessVGtid(&binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+			{Keyspace: "vtdb", Shard: "-", Gtid: gtid},
+		}})
+		if err != nil {
+			t.Fatalf("encodeVitessVGtid: %v", err)
+		}
+		return payload
+	}
+	targets := []vitessCDCTarget{{bareName: "old1"}, {bareName: "old2"}, {bareName: "brandnew"}}
+
+	t.Run("mixed cursors partition into resume and fresh", func(t *testing.T) {
+		plan, err := planVitessStart(targets, map[string]string{
+			"old1": formatVitessLSN(3, 0, vgtidAt("MySQL56/abc:1-30")),
+			"old2": formatVitessLSN(7, 0, vgtidAt("MySQL56/abc:1-70")),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(plan.resume) != 2 || len(plan.fresh) != 1 || plan.fresh[0].bareName != "brandnew" {
+			t.Fatalf("partition mismatch: resume=%+v fresh=%+v", plan.resume, plan.fresh)
+		}
+		if plan.ordinal != 8 {
+			t.Errorf("ordinal should seed past the max stored ordinal: got %d want 8", plan.ordinal)
+		}
+		// The resume stream must start from the OLDEST cursor so the most-behind
+		// table misses nothing; re-delivery to newer tables is idempotent.
+		if got := plan.resumeVGtid.ShardGtids[0].Gtid; got != "MySQL56/abc:1-30" {
+			t.Errorf("resume VGTID should be the oldest cursor, got %q", got)
+		}
+	})
+
+	t.Run("all fresh", func(t *testing.T) {
+		plan, err := planVitessStart(targets, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(plan.fresh) != 3 || len(plan.resume) != 0 || plan.ordinal != 0 {
+			t.Fatalf("expected all-fresh plan, got %+v", plan)
+		}
+	})
+
+	t.Run("invalid cursor errors with full-refresh guidance", func(t *testing.T) {
+		_, err := planVitessStart(targets, map[string]string{"old1": "garbage"})
+		if err == nil || !strings.Contains(err.Error(), "--full-refresh") {
+			t.Fatalf("expected full-refresh guidance, got %v", err)
+		}
+	})
+}
+
+// vitessPendingCopyShards: a fresh run copies on every shard; a resume run only
+// owes a copy on shards whose stored VGTID carries TablePKs (interrupted copy).
+func TestVitessPendingCopyShards(t *testing.T) {
+	shards := []string{"-80", "80-"}
+
+	fresh := vitessPendingCopyShards(freshVitessVGtid("vtdb", shards), false, shards)
+	if len(fresh) != 2 || !fresh["-80"] || !fresh["80-"] {
+		t.Errorf("fresh run should owe a copy on all shards: %v", fresh)
+	}
+
+	clean := vitessPendingCopyShards(&binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+		{Keyspace: "vtdb", Shard: "-80", Gtid: "MySQL56/a:1-5"},
+		{Keyspace: "vtdb", Shard: "80-", Gtid: "MySQL56/b:1-5"},
+	}}, true, shards)
+	if len(clean) != 0 {
+		t.Errorf("clean resume should owe no copy: %v", clean)
+	}
+
+	interrupted := vitessPendingCopyShards(&binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+		{Keyspace: "vtdb", Shard: "-80", Gtid: "MySQL56/a:1-5"},
+		{Keyspace: "vtdb", Shard: "80-", Gtid: "MySQL56/b:1-5", TablePKs: []*binlogdatapb.TableLastPK{{TableName: "items"}}},
+	}}, true, shards)
+	if len(interrupted) != 1 || !interrupted["80-"] {
+		t.Errorf("resume with TablePKs should owe a copy on that shard: %v", interrupted)
+	}
+}
+
+// vitessCaughtUp gates batch-mode termination: every shard must have reached the
+// stop boundary captured at stream start.
+func TestVitessCaughtUp(t *testing.T) {
+	const uuid = "3e11fa47-71ca-11e1-9e33-c80aa9429562"
+	stop := map[string]string{
+		"-80": "MySQL56/" + uuid + ":1-50",
+		"80-": "MySQL56/" + uuid + ":1-70",
+	}
+	vgtid := func(a, b string) *binlogdatapb.VGtid {
+		return &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+			{Keyspace: "vtdb", Shard: "-80", Gtid: a},
+			{Keyspace: "vtdb", Shard: "80-", Gtid: b},
+		}}
+	}
+
+	if vitessCaughtUp(nil, stop, "vtdb") {
+		t.Error("nil VGTID is never caught up")
+	}
+	if vitessCaughtUp(vgtid("", ""), stop, "vtdb") {
+		t.Error("fresh (empty) positions are not caught up")
+	}
+	if vitessCaughtUp(vgtid("MySQL56/"+uuid+":1-50", "MySQL56/"+uuid+":1-60"), stop, "vtdb") {
+		t.Error("one shard behind must not report caught up")
+	}
+	if !vitessCaughtUp(vgtid("MySQL56/"+uuid+":1-50", "MySQL56/"+uuid+":1-70"), stop, "vtdb") {
+		t.Error("all shards exactly at stop should be caught up")
+	}
+	if !vitessCaughtUp(vgtid("MySQL56/"+uuid+":1-99", "MySQL56/"+uuid+":1-99"), stop, "vtdb") {
+		t.Error("all shards beyond stop should be caught up")
+	}
+
+	// ShardGtids from other keyspaces must not satisfy this keyspace's boundary.
+	other := &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+		{Keyspace: "otherks", Shard: "-80", Gtid: "MySQL56/" + uuid + ":1-99"},
+		{Keyspace: "otherks", Shard: "80-", Gtid: "MySQL56/" + uuid + ":1-99"},
+	}}
+	if vitessCaughtUp(other, stop, "vtdb") {
+		t.Error("positions from another keyspace must not count")
+	}
+
+	if vitessCaughtUp(vgtid("MySQL56/"+uuid+":1-99", "MySQL56/"+uuid+":1-99"), map[string]string{}, "vtdb") {
+		t.Error("an empty stop boundary must never report caught up")
 	}
 }
 

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -1750,7 +1750,7 @@ func mysqlDSN(uri string) string {
 	uri = strings.TrimPrefix(uri, "mysql://")
 	uri = strings.TrimPrefix(uri, "mariadb://")
 	uri = strings.TrimPrefix(uri, "vitess://")
-	uri = strings.TrimPrefix(uri, "planetscale://")
+	uri = strings.TrimPrefix(uri, "ps_mysql://")
 
 	// Find the @ to split user:pass from host
 	atIdx := strings.Index(uri, "@")

--- a/tests/integration/vitess_cdc_batch_test.go
+++ b/tests/integration/vitess_cdc_batch_test.go
@@ -1,0 +1,351 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // register adbc_generic for duckdb read-back
+	_ "github.com/go-sql-driver/mysql"                // register mysql driver for seeding/raw reads
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// vitessCDCEnv is a running vttestserver plus the handles the batch CDC tests
+// need: a raw MySQL connection for seeding and the URIs for ingestr.
+type vitessCDCEnv struct {
+	db        *sql.DB
+	cdcURI    string
+	mysqlPort string
+	grpcPort  string
+	host      string
+}
+
+// startVitessCDCEnv boots a vttestserver with the given shard count and waits
+// until vtgate serves queries.
+func startVitessCDCEnv(t *testing.T, ctx context.Context, numShards string) *vitessCDCEnv {
+	t.Helper()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "vitess/vttestserver:mysql80",
+			ExposedPorts: []string{vitessCDCMySQLPort, vitessCDCGRPCPort},
+			Env: map[string]string{
+				"PORT":              vitessCDCBasePort,
+				"KEYSPACES":         vitessCDCKeyspace,
+				"NUM_SHARDS":        numShards,
+				"MYSQL_BIND_HOST":   "0.0.0.0",
+				"VTCOMBO_BIND_HOST": "0.0.0.0",
+			},
+			WaitingFor: wait.ForListeningPort(vitessCDCMySQLPort).WithStartupTimeout(240 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err, "failed to start vttestserver")
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	mysqlPort, err := container.MappedPort(ctx, "33577")
+	require.NoError(t, err)
+	grpcPort, err := container.MappedPort(ctx, "33575")
+	require.NoError(t, err)
+
+	mysqlURI := fmt.Sprintf("mysql://root@%s:%s/%s", host, mysqlPort.Port(), vitessCDCKeyspace)
+	db, err := sql.Open("mysql", mysqlDSN(mysqlURI))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// vtgate can accept connections before it can serve queries; retry.
+	require.Eventually(t, func() bool {
+		return db.PingContext(ctx) == nil
+	}, 120*time.Second, 2*time.Second, "vtgate did not become query-ready")
+
+	return &vitessCDCEnv{
+		db:        db,
+		cdcURI:    fmt.Sprintf("vitess+cdc://root@%s:%s/%s?grpc_port=%s&mode=batch", host, mysqlPort.Port(), vitessCDCKeyspace, grpcPort.Port()),
+		mysqlPort: mysqlPort.Port(),
+		grpcPort:  grpcPort.Port(),
+		host:      host,
+	}
+}
+
+func duckQueryInt(t *testing.T, ctx context.Context, duckPath, query string) int64 {
+	t.Helper()
+	duck, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", duckPath))
+	require.NoError(t, err)
+	defer func() { _ = duck.Close() }()
+	var v int64
+	require.NoError(t, duck.QueryRowContext(ctx, query).Scan(&v))
+	return v
+}
+
+// TestVitessCDC_BusyKeyspaceBatchStops proves batch-mode microbatch semantics:
+// the run captures the stop boundary when it starts, processes events up to that
+// point, and stops — even while writes keep arriving faster than the heartbeat
+// interval, which suppresses vtgate's idle heartbeats entirely. Before the stop
+// boundary existed, this run would never terminate.
+func TestVitessCDC_BusyKeyspaceBatchStops(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	env := startVitessCDCEnv(t, ctx, "1")
+
+	_, err := env.db.ExecContext(ctx, "DROP TABLE IF EXISTS busy_items")
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, `CREATE TABLE busy_items (id INT NOT NULL PRIMARY KEY, v VARCHAR(40) NOT NULL)`)
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, `INSERT INTO busy_items (id, v) VALUES (1,'a'),(2,'b'),(3,'c')`)
+	require.NoError(t, err)
+
+	duckPath := filepath.Join(t.TempDir(), "vitess_busy.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:   env.cdcURI,
+		SourceTable: vitessCDCKeyspace + ".busy_items",
+		DestURI:     fmt.Sprintf("duckdb:///%s", duckPath),
+		DestTable:   "main.busy_dest",
+	}
+
+	// Snapshot run to establish a cursor.
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "snapshot run should succeed")
+	require.EqualValues(t, 3, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.busy_dest`))
+
+	// Hammer the captured table from a background writer so the VStream never
+	// idles: with >1 write/sec, vtgate emits no heartbeats at all.
+	writerCtx, stopWriter := context.WithCancel(ctx)
+	defer stopWriter()
+	var written atomic.Int64
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		id := 1000
+		for {
+			select {
+			case <-writerCtx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			if _, err := env.db.ExecContext(writerCtx, "INSERT INTO busy_items (id, v) VALUES (?, 'w')", id); err != nil {
+				return
+			}
+			written.Add(1)
+			id++
+		}
+	}()
+
+	// Let the writer build up sustained traffic, then record how many rows exist
+	// before the incremental run starts: everything up to that point must land.
+	time.Sleep(2 * time.Second)
+	writtenAtStart := written.Load()
+	require.Greater(t, writtenAtStart, int64(10), "writer should be producing sustained traffic")
+
+	incCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	start := time.Now()
+	err = pipeline.New(cfg).Run(incCtx)
+	elapsed := time.Since(start)
+
+	stopWriter()
+	<-writerDone
+	require.NoError(t, err, "batch run under sustained writes must stop on its own (took %v)", elapsed)
+	require.NoError(t, incCtx.Err(), "batch run must finish well before the safety deadline")
+
+	got := duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.busy_dest WHERE NOT "_cdc_deleted"`)
+	require.GreaterOrEqual(t, got, 3+writtenAtStart, "everything written before the run started must be captured")
+	t.Logf("batch run finished in %v; captured %d rows (%d written before start, %d total)", elapsed, got, writtenAtStart, written.Load())
+}
+
+// TestVitessCDC_ShardedKeyspaceCopy proves the copy phase of a sharded keyspace
+// completes on every shard before the batch run stops. vtgate emits one
+// COPY_COMPLETED per shard and an aggregated one at the end; stopping on the
+// first per-shard event used to truncate the snapshot to whichever shard
+// finished first.
+func TestVitessCDC_ShardedKeyspaceCopy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	env := startVitessCDCEnv(t, ctx, "2")
+
+	_, err := env.db.ExecContext(ctx, `CREATE TABLE sharded_items (id INT NOT NULL PRIMARY KEY, v VARCHAR(40) NOT NULL)`)
+	require.NoError(t, err)
+	// A sharded keyspace routes writes through a vindex; vttestserver authorizes
+	// vschema DDL, so declare a hash primary vindex for the table.
+	_, err = env.db.ExecContext(ctx, "ALTER VSCHEMA ON "+vitessCDCKeyspace+".sharded_items ADD VINDEX `hash`(id) USING `hash`")
+	require.NoError(t, err)
+
+	const seedRows = 500
+	for start := 1; start <= seedRows; start += 100 {
+		q := "INSERT INTO sharded_items (id, v) VALUES "
+		for i := start; i < start+100 && i <= seedRows; i++ {
+			if i > start {
+				q += ","
+			}
+			q += fmt.Sprintf("(%d,'v%d')", i, i)
+		}
+		_, err = env.db.ExecContext(ctx, q)
+		require.NoError(t, err)
+	}
+
+	// Sanity check both shards actually hold data, otherwise the test proves nothing.
+	var shards []string
+	rows, err := env.db.QueryContext(ctx, "SHOW VITESS_SHARDS")
+	require.NoError(t, err)
+	for rows.Next() {
+		var shard string
+		require.NoError(t, rows.Scan(&shard))
+		shards = append(shards, shard)
+	}
+	require.NoError(t, rows.Err())
+	_ = rows.Close()
+	require.Len(t, shards, 2, "expected a 2-shard keyspace")
+	for _, shard := range shards {
+		conn, err := env.db.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("USE `%s`", shard))
+		require.NoError(t, err)
+		var count int
+		require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM sharded_items").Scan(&count))
+		// Reset shard targeting before the conn goes back to the pool, otherwise
+		// later pool queries silently run against a single shard.
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("USE `%s`", vitessCDCKeyspace))
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+		require.Greater(t, count, 0, "shard %s must hold seeded rows", shard)
+	}
+
+	duckPath := filepath.Join(t.TempDir(), "vitess_sharded.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:   env.cdcURI,
+		SourceTable: vitessCDCKeyspace + ".sharded_items",
+		DestURI:     fmt.Sprintf("duckdb:///%s", duckPath),
+		DestTable:   "main.sharded_dest",
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	require.NoError(t, pipeline.New(cfg).Run(runCtx), "sharded snapshot run should succeed")
+	require.EqualValues(t, seedRows, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.sharded_dest`),
+		"the snapshot must contain every row from every shard")
+
+	// Incremental pass across shards: update, delete, insert.
+	_, err = env.db.ExecContext(ctx, "UPDATE sharded_items SET v = 'updated' WHERE id = 1")
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, "DELETE FROM sharded_items WHERE id = 2")
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, fmt.Sprintf("INSERT INTO sharded_items (id, v) VALUES (%d,'new')", seedRows+1))
+	require.NoError(t, err)
+
+	incCtx, cancelInc := context.WithTimeout(ctx, 90*time.Second)
+	defer cancelInc()
+	require.NoError(t, pipeline.New(cfg).Run(incCtx), "sharded incremental run should succeed")
+
+	require.EqualValues(t, 1, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.sharded_dest WHERE id = 1 AND v = 'updated' AND NOT "_cdc_deleted"`))
+	require.EqualValues(t, 1, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.sharded_dest WHERE id = 2 AND "_cdc_deleted"`))
+	require.EqualValues(t, 1, duckQueryInt(t, ctx, duckPath, fmt.Sprintf(`SELECT COUNT(*) FROM main.sharded_dest WHERE id = %d AND NOT "_cdc_deleted"`, seedRows+1)))
+}
+
+// TestVitessCDC_MixedResumeKeepsDeletes proves that adding a new table to a
+// multi-table CDC sync does not silently drop deletes on already-synced tables.
+// The old behavior discarded every stored cursor when any table lacked one and
+// re-copied everything fresh — a fresh copy re-upserts current rows but never
+// tombstones rows deleted since the cursor, so the delete below would have been
+// lost. The fix resumes cursor-holding tables and copies only the new table.
+func TestVitessCDC_MixedResumeKeepsDeletes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	env := startVitessCDCEnv(t, ctx, "1")
+
+	_, err := env.db.ExecContext(ctx, `CREATE TABLE t_old (id INT NOT NULL PRIMARY KEY, v VARCHAR(40) NOT NULL)`)
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, `INSERT INTO t_old (id, v) VALUES (1,'one'),(2,'two'),(3,'three')`)
+	require.NoError(t, err)
+
+	duckPath := filepath.Join(t.TempDir(), "vitess_mixed.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:   env.cdcURI,
+		SourceTable: "", // multi-table mode: sync the whole keyspace
+		DestURI:     fmt.Sprintf("duckdb:///%s", duckPath),
+		DestTable:   "main",
+	}
+
+	run1Ctx, cancel1 := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel1()
+	require.NoError(t, pipeline.New(cfg).Run(run1Ctx), "initial multi-table run should succeed")
+	require.EqualValues(t, 3, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.t_old`))
+
+	// Between runs: delete a row from the synced table AND introduce a brand-new
+	// table, so the second run is a mixed resume (t_old has a cursor, t_new not).
+	_, err = env.db.ExecContext(ctx, "DELETE FROM t_old WHERE id = 2")
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, "INSERT INTO t_old (id, v) VALUES (4,'four')")
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, `CREATE TABLE t_new (id INT NOT NULL PRIMARY KEY, v VARCHAR(40) NOT NULL)`)
+	require.NoError(t, err)
+	_, err = env.db.ExecContext(ctx, `INSERT INTO t_new (id, v) VALUES (10,'ten'),(11,'eleven')`)
+	require.NoError(t, err)
+
+	run2Ctx, cancel2 := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel2()
+	require.NoError(t, pipeline.New(cfg).Run(run2Ctx), "mixed-resume run should succeed")
+
+	// The new table is fully copied.
+	require.EqualValues(t, 2, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.t_new WHERE NOT "_cdc_deleted"`))
+	// The delete on the previously synced table must be tombstoned — this is the
+	// regression assertion: a discarded-cursor fresh copy leaves id=2 alive.
+	require.EqualValues(t, 1, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.t_old WHERE id = 2 AND "_cdc_deleted"`),
+		"delete during the cursor gap must be tombstoned, not lost to a fresh re-copy")
+	require.EqualValues(t, 1, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.t_old WHERE id = 4 AND NOT "_cdc_deleted"`))
+	require.EqualValues(t, 3, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.t_old WHERE NOT "_cdc_deleted"`))
+}
+
+// TestVitessCDC_EmptyTableBatchCompletes proves a fresh batch run over an empty
+// table terminates: with no rows the copy phase emits no VGTID to compare
+// against the stop boundary, so termination rides on the idle-heartbeat
+// fallback. A follow-up run picks up rows inserted later.
+func TestVitessCDC_EmptyTableBatchCompletes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	env := startVitessCDCEnv(t, ctx, "1")
+
+	_, err := env.db.ExecContext(ctx, `CREATE TABLE empty_items (id INT NOT NULL PRIMARY KEY, v VARCHAR(40) NOT NULL)`)
+	require.NoError(t, err)
+
+	duckPath := filepath.Join(t.TempDir(), "vitess_empty.duckdb")
+	cfg := &config.IngestConfig{
+		SourceURI:   env.cdcURI,
+		SourceTable: vitessCDCKeyspace + ".empty_items",
+		DestURI:     fmt.Sprintf("duckdb:///%s", duckPath),
+		DestTable:   "main.empty_dest",
+	}
+
+	run1Ctx, cancel1 := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel1()
+	require.NoError(t, pipeline.New(cfg).Run(run1Ctx), "batch run over an empty table must terminate")
+
+	_, err = env.db.ExecContext(ctx, `INSERT INTO empty_items (id, v) VALUES (1,'late'),(2,'later')`)
+	require.NoError(t, err)
+
+	run2Ctx, cancel2 := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel2()
+	require.NoError(t, pipeline.New(cfg).Run(run2Ctx), "follow-up run should succeed")
+	require.EqualValues(t, 2, duckQueryInt(t, ctx, duckPath, `SELECT COUNT(*) FROM main.empty_dest WHERE NOT "_cdc_deleted"`))
+}


### PR DESCRIPTION
This reworks the Vitess and PlanetScale CDC sources: batch runs now stop reliably (per-shard COPY_COMPLETED handling, a stop boundary that holds under sustained writes), mixed resumes no longer drop deletes when a new table joins a multi-table sync, and PlanetScale streams get stall detection with per-shard cursor state. Shared MySQL-family URI handling moves into pkg/mysqluri so the source and destination can't drift. The planetscale:// and planetscale+cdc:// schemes are renamed to ps_mysql:// and ps_mysql+cdc:// to leave room for a PlanetScale Postgres connector later; the old schemes now fail with a clear error pointing at the new ones. Since url.Parse rejects underscores in schemes, URI parsing now extracts the scheme manually before parsing the rest. Adds integration tests covering the batch stop boundary, sharded keyspace copy, mixed resume, and empty-table runs.