### PR TITLE
Add Iceberg incremental strategies

### DIFF
--- a/docs/supported-sources/iceberg.md
+++ b/docs/supported-sources/iceberg.md
@@ -120,9 +120,29 @@ For nested namespaces, use dot-separated identifiers such as `lake.analytics.eve
 
 ## Supported write dispositions
 
-Iceberg supports `append` and `replace`.
+Iceberg supports `append`, `replace`, `merge`, `delete+insert`, `truncate+insert`, and `scd2`.
 
-`replace` writes a new Iceberg overwrite snapshot for the destination table. `merge`, `delete+insert`, and `scd2` are not supported by the generic Iceberg destination.
+`replace` writes a new Iceberg overwrite snapshot for the destination table. The incremental strategies are implemented natively: each run stages the incoming rows in a temporary Iceberg table and then commits a single atomic snapshot with the changes.
+
+- `merge` upserts by primary key: rows with duplicate primary keys are deduplicated (the highest `--incremental-key` value wins when one is set), existing rows are updated in place, and net-new rows are inserted. CDC streams are merged with delete awareness.
+- `delete+insert` deletes the rows whose incremental key falls inside the loaded interval and inserts the staged rows (deduplicated by primary key when one is set).
+- `truncate+insert` empties the table in place (keeping schema, partition spec, and history) and reloads it.
+- `scd2` maintains slowly-changing-dimension history with `_scd_valid_from`, `_scd_valid_to`, and `_scd_is_current` columns.
+
+### Merge modes and memory usage
+
+`merge` and `scd2` default to **merge-on-read** on format v2 tables: the affected keys are superseded by an Iceberg equality delete file and the replacement rows are appended, in one atomic snapshot. Rows stream through disk-backed sorts for primary-key deduplication, so memory usage stays constant regardless of increment size. `delete+insert` streams the staged rows into a copy-on-write overwrite whose delete predicate is just the interval bounds, so it is constant-memory as well.
+
+Merge-on-read requires readers that understand Iceberg v2 equality deletes (Spark, Trino, Flink, and DuckDB all do), and read amplification grows until the table is compacted. Set `table.write.merge.mode=copy-on-write` on the destination URI to force copy-on-write snapshots instead.
+
+Some situations fall back to the copy-on-write join automatically because they must read the matched target rows:
+
+- CDC merges (deletes mark `_cdc_deleted` while preserving the row's data),
+- targets with destination-only columns (columns removed from the source keep their values on updated rows),
+- tables partitioned by a column outside the merge key (equality deletes are partition-routed, so a row that changed partitions would otherwise be missed),
+- format v1 tables and `write.merge.mode=copy-on-write`.
+
+These fallback paths materialize the staged rows and the target rows they affect in memory, so their memory usage grows with the increment size.
 
 ## Data type handling
 

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -259,6 +262,9 @@ func (d *Destination) createTable(ctx context.Context, ident icebergtable.Identi
 		createOpts = append(createOpts, icebergcatalog.WithPartitionSpec(&spec))
 	}
 
+	if err := d.ensureLocalTableDirs(ident); err != nil {
+		return err
+	}
 	if _, err := d.catalog.CreateTable(ctx, ident, iceSchema, createOpts...); err != nil {
 		if errors.Is(err, icebergcatalog.ErrTableAlreadyExists) {
 			return nil
@@ -446,6 +452,45 @@ func renderTableLocation(template string, ident icebergtable.Identifier) string 
 		"{identifier_dot}", strings.Join(ident, "."),
 	)
 	return replacer.Replace(template)
+}
+
+func (d *Destination) ensureLocalTableDirs(ident icebergtable.Identifier) error {
+	location, ok := d.localTableLocation(ident)
+	if !ok {
+		return nil
+	}
+	for _, dir := range []string{location, filepath.Join(location, "data"), filepath.Join(location, "metadata")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("iceberg: failed to create local table directory %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func (d *Destination) localTableLocation(ident icebergtable.Identifier) (string, bool) {
+	if d.cfg.TableLocation != "" {
+		return localFilesystemPath(renderTableLocation(d.cfg.TableLocation, ident))
+	}
+	warehouse, ok := localFilesystemPath(d.cfg.Properties.Get("warehouse", ""))
+	if !ok || warehouse == "" {
+		return "", false
+	}
+	parts := append([]string{warehouse}, ident...)
+	return filepath.Join(parts...), true
+}
+
+func localFilesystemPath(location string) (string, bool) {
+	if location == "" {
+		return "", false
+	}
+	if !strings.Contains(location, "://") {
+		return location, true
+	}
+	parsed, err := url.Parse(location)
+	if err != nil || parsed.Scheme != "file" {
+		return "", false
+	}
+	return parsed.Path, parsed.Path != ""
 }
 
 func tableSchemaWithPrimaryKeys(s *schema.TableSchema, primaryKeys []string) *schema.TableSchema {

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -175,18 +175,6 @@ func (d *Destination) SwapTable(ctx context.Context, opts destination.SwapOption
 	return nil
 }
 
-func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
-	return errors.New("delete+insert strategy is not supported for iceberg destination")
-}
-
-func (d *Destination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
-	return errors.New("merge strategy is not supported for iceberg destination")
-}
-
-func (d *Destination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
-	return errors.New("scd2 strategy is not supported for iceberg destination")
-}
-
 func (d *Destination) DropTable(ctx context.Context, table string) error {
 	if d.catalog == nil {
 		return errors.New("iceberg destination not connected")
@@ -241,10 +229,12 @@ func (d *Destination) GetScheme() string {
 
 func (d *Destination) SupportsReplaceStrategy() bool      { return true }
 func (d *Destination) SupportsAppendStrategy() bool       { return true }
-func (d *Destination) SupportsMergeStrategy() bool        { return false }
-func (d *Destination) SupportsDeleteInsertStrategy() bool { return false }
-func (d *Destination) SupportsSCD2Strategy() bool         { return false }
+func (d *Destination) SupportsMergeStrategy() bool        { return true }
+func (d *Destination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *Destination) SupportsSCD2Strategy() bool         { return true }
 func (d *Destination) SupportsAtomicSwap() bool           { return false }
+func (d *Destination) SupportsCDCMerge() bool             { return true }
+func (d *Destination) SupportsCDCUnchangedCols() bool     { return true }
 
 func (d *Destination) createTable(ctx context.Context, ident icebergtable.Identifier, opts destination.PrepareOptions) error {
 	iceSchema, err := icebergSchemaFromTableSchema(opts.Schema)

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -459,9 +460,22 @@ func (d *Destination) ensureLocalTableDirs(ident icebergtable.Identifier) error 
 	if !ok {
 		return nil
 	}
+	mode := fs.FileMode(0o755)
+	forceMode := false
+	if d.cfg.Properties.Get("type", "") == "rest" {
+		// A local REST warehouse is shared by the catalog server and this process,
+		// which may run as different UIDs.
+		mode = 0o777
+		forceMode = true
+	}
 	for _, dir := range []string{location, filepath.Join(location, "data"), filepath.Join(location, "metadata")} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, mode); err != nil {
 			return fmt.Errorf("iceberg: failed to create local table directory %s: %w", dir, err)
+		}
+		if forceMode {
+			if err := os.Chmod(dir, mode); err != nil {
+				return fmt.Errorf("iceberg: failed to set local table directory permissions %s: %w", dir, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -364,11 +364,22 @@ func TestDestinationWritesAppendAndReplaceWithHadoopCatalog(t *testing.T) {
 	require.Empty(t, icebergPartitionFieldNames(ctx, t, dest, tableName))
 }
 
-func TestDestinationMergeUnsupported(t *testing.T) {
+func TestDestinationStrategySupport(t *testing.T) {
 	dest := NewDestination()
 
-	require.False(t, dest.SupportsMergeStrategy())
-	require.ErrorContains(t, dest.MergeTable(context.Background(), destination.MergeOptions{}), "merge strategy is not supported")
+	require.True(t, dest.SupportsReplaceStrategy())
+	require.True(t, dest.SupportsAppendStrategy())
+	require.True(t, dest.SupportsMergeStrategy())
+	require.True(t, dest.SupportsDeleteInsertStrategy())
+	require.True(t, dest.SupportsSCD2Strategy())
+	require.True(t, dest.SupportsCDCMerge())
+	require.True(t, dest.SupportsCDCUnchangedCols())
+	require.False(t, dest.SupportsAtomicSwap())
+
+	require.ErrorContains(t, dest.MergeTable(context.Background(), destination.MergeOptions{PrimaryKeys: []string{"id"}}), "not connected")
+	require.ErrorContains(t, dest.DeleteInsertTable(context.Background(), destination.DeleteInsertOptions{IncrementalKey: "id"}), "not connected")
+	require.ErrorContains(t, dest.SCD2Table(context.Background(), destination.SCD2Options{PrimaryKeys: []string{"id"}}), "not connected")
+	require.ErrorContains(t, dest.TruncateTable(context.Background(), "ns.t"), "not connected")
 }
 
 func TestDestinationApplySchemaEvolutionPromotesColumnType(t *testing.T) {

--- a/pkg/destination/iceberg/row_delta.go
+++ b/pkg/destination/iceberg/row_delta.go
@@ -398,9 +398,11 @@ func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string)
 		return nil, fmt.Errorf("iceberg: column %q not found in staging table", destination.SCD2ValidFromColumn)
 	}
 	if opts.IncrementalKey != "" {
-		if idx, ok := stagingIdx[opts.IncrementalKey]; ok {
-			j.incrementalIdx = idx
+		idx, err := incrementalKeyIndex(stagingCols, opts.IncrementalKey, opts.StagingTable)
+		if err != nil {
+			return nil, err
 		}
+		j.incrementalIdx = idx
 	}
 	if idx, ok := targetIdx[destination.SCD2ValidToColumn]; ok {
 		j.validToIdx = idx

--- a/pkg/destination/iceberg/row_delta.go
+++ b/pkg/destination/iceberg/row_delta.go
@@ -1,0 +1,586 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+)
+
+const (
+	writeMergeModeProperty = "write.merge.mode"
+	mergeModeCopyOnWrite   = "copy-on-write"
+)
+
+// useRowDeltaMerge decides whether an operation can run as a merge-on-read
+// row delta (equality delete files + appended data files, constant memory)
+// instead of the copy-on-write join path. Equality deletes are routed by
+// partition value, so every partition source column must be part of the
+// delete key — otherwise a row whose partition value changed would not be
+// deleted from its old partition.
+func useRowDeltaMerge(tbl *icebergtable.Table, deleteKeyColumns []string) bool {
+	if strings.EqualFold(tbl.Metadata().Properties().Get(writeMergeModeProperty, ""), mergeModeCopyOnWrite) {
+		return false
+	}
+	if tbl.Metadata().Version() < 2 {
+		return false
+	}
+	allowed := make(map[string]bool, len(deleteKeyColumns))
+	for _, col := range deleteKeyColumns {
+		allowed[col] = true
+	}
+	spec := tbl.Metadata().PartitionSpec()
+	for _, field := range spec.Fields() {
+		name, ok := tbl.Schema().FindColumnName(field.SourceID())
+		if !ok || !allowed[name] {
+			return false
+		}
+	}
+	return true
+}
+
+// stagingCoversTarget reports whether every target column also exists in
+// staging. Row-delta merge replaces rows wholesale, so destination-only
+// columns (which the copy-on-write path preserves) rule it out.
+func stagingCoversTarget(target, staging *iceberggo.Schema) bool {
+	stagingCols := make(map[string]bool, staging.NumFields())
+	for _, field := range staging.Fields() {
+		stagingCols[field.Name] = true
+	}
+	for _, field := range target.Fields() {
+		if !stagingCols[field.Name] {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldIDsByName(iceSchema *iceberggo.Schema, names []string) ([]int, error) {
+	ids := make([]int, len(names))
+	for i, name := range names {
+		field, ok := iceSchema.FindFieldByName(name)
+		if !ok {
+			return nil, fmt.Errorf("iceberg: column %q not found in table schema", name)
+		}
+		ids[i] = field.ID
+	}
+	return ids, nil
+}
+
+func equalityDeleteArrowSchema(iceSchema *iceberggo.Schema, names []string) (*arrow.Schema, error) {
+	selected, err := iceSchema.Select(true, names...)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to project delete schema: %w", err)
+	}
+	arrowSchema, err := icebergtable.SchemaToArrowSchema(selected, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to build delete schema: %w", err)
+	}
+	return arrowSchema, nil
+}
+
+func arrowSchemaColumnNames(schema *arrow.Schema) []string {
+	names := make([]string, len(schema.Fields()))
+	for i, field := range schema.Fields() {
+		names[i] = field.Name
+	}
+	return names
+}
+
+// rowEmit receives composed output rows: row values laid out per the given
+// projection's source column order.
+type rowEmit func(proj *rowProjection, row []any) error
+
+// batchStream converts a row-producing function into a record batch iterator
+// with bounded buffering. When consumerReleases is false the batches are
+// released after the consumer's yield returns (WriteEqualityDeletes borrows
+// batches); WriteRecords releases consumed batches itself.
+func batchStream(writeSchema *arrow.Schema, consumerReleases bool, produce func(emit rowEmit) error) iter.Seq2[arrow.RecordBatch, error] {
+	return func(yield func(arrow.RecordBatch, error) bool) {
+		builder := array.NewRecordBuilder(memory.DefaultAllocator, writeSchema)
+		defer builder.Release()
+
+		rows := 0
+		stopped := false
+		flush := func() error {
+			if rows == 0 {
+				return nil
+			}
+			batch := builder.NewRecordBatch()
+			rows = 0
+			ok := yield(batch, nil)
+			if !consumerReleases {
+				batch.Release()
+			}
+			if !ok {
+				stopped = true
+				return errStreamStopped
+			}
+			return nil
+		}
+
+		err := produce(func(proj *rowProjection, row []any) error {
+			if err := proj.appendRow(builder, row); err != nil {
+				return err
+			}
+			rows++
+			if rows >= batchBuildRows {
+				return flush()
+			}
+			return nil
+		})
+		if err == nil {
+			err = flush()
+		}
+		if err != nil && !stopped {
+			yield(nil, err)
+		}
+	}
+}
+
+var errStreamStopped = fmt.Errorf("iceberg: batch stream consumer stopped")
+
+// commitRowDelta writes the data and delete files produced by the two
+// streaming passes and commits them as one atomic snapshot.
+func commitRowDelta(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	operation string,
+	writeSchema *arrow.Schema,
+	produceData func(emit rowEmit) error,
+	deleteKeyColumns []string,
+	produceDeletes func(emit rowEmit) error,
+) error {
+	txn := tbl.NewTransaction()
+
+	var dataFiles []iceberggo.DataFile
+	for df, err := range icebergtable.WriteRecords(ctx, tbl, writeSchema, batchStream(writeSchema, true, produceData)) {
+		if err != nil {
+			return fmt.Errorf("iceberg: %s failed to write data files: %w", operation, err)
+		}
+		dataFiles = append(dataFiles, df)
+	}
+
+	var deleteFiles []iceberggo.DataFile
+	if produceDeletes != nil && tbl.CurrentSnapshot() != nil {
+		deleteFieldIDs, err := fieldIDsByName(tbl.Schema(), deleteKeyColumns)
+		if err != nil {
+			return err
+		}
+		deleteSchema, err := equalityDeleteArrowSchema(tbl.Schema(), deleteKeyColumns)
+		if err != nil {
+			return err
+		}
+		deleteFiles, err = txn.WriteEqualityDeletes(ctx, deleteFieldIDs, batchStream(deleteSchema, false, produceDeletes))
+		if err != nil {
+			return fmt.Errorf("iceberg: %s failed to write delete files: %w", operation, err)
+		}
+	}
+
+	if len(dataFiles) == 0 && len(deleteFiles) == 0 {
+		return nil
+	}
+
+	rowDelta := txn.NewRowDelta(snapshotProps(operation)).AddRows(dataFiles...).AddDeletes(deleteFiles...)
+	if err := rowDelta.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: %s failed to stage row delta: %w", operation, err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
+	}
+	return nil
+}
+
+// mergeRowDelta merges the staging table using merge-on-read: an equality
+// delete file supersedes the affected keys and the winning staging rows are
+// appended, in one snapshot. Memory is bounded by the spill run size.
+func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *icebergtable.Table, opts destination.MergeOptions) error {
+	stagingSchema, err := tableWriteSchema(staging)
+	if err != nil {
+		return err
+	}
+	stagingCols := arrowSchemaColumnNames(stagingSchema)
+
+	sorter, err := newSpillSorter(stagingSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer sorter.Close()
+
+	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, sorter.Add); err != nil {
+		return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
+	}
+	if sorter.Len() == 0 {
+		return nil
+	}
+
+	incrementalIdx := -1
+	if opts.IncrementalKey != "" {
+		for i, col := range stagingCols {
+			if col == opts.IncrementalKey {
+				incrementalIdx = i
+				break
+			}
+		}
+	}
+
+	writeSchema, err := tableWriteSchema(target)
+	if err != nil {
+		return err
+	}
+	dataProjection := newRowProjection(writeSchema, stagingCols)
+
+	emitWinners := func(proj *rowProjection) func(emit rowEmit) error {
+		return func(emit rowEmit) error {
+			it, err := sorter.Iter()
+			if err != nil {
+				return err
+			}
+			defer it.Close()
+			for it.NextGroup() {
+				winner := selectGroupWinner(it, incrementalIdx)
+				if err := emit(proj, winner); err != nil {
+					return err
+				}
+			}
+			return it.Err()
+		}
+	}
+
+	deleteSchema, err := equalityDeleteArrowSchema(target.Schema(), opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	deleteProjection := newRowProjection(deleteSchema, stagingCols)
+
+	config.Debug("[ICEBERG MERGE] Row-delta merge of %d staged row(s) into %s", sorter.Len(), opts.TargetTable)
+	return commitRowDelta(
+		ctx, target, "merge", writeSchema,
+		emitWinners(dataProjection),
+		opts.PrimaryKeys,
+		emitWinners(deleteProjection),
+	)
+}
+
+// scd2RowDelta maintains SCD2 history via merge-on-read: current versions of
+// changed or vanished keys are superseded by an equality delete on
+// (primary keys, _scd_is_current) and replaced by closed copies, while new
+// versions and net-new keys are appended — all in one snapshot. Both sides of
+// the change-detection join stream through disk-backed sorts, so memory stays
+// bounded by the spill run size.
+func (d *Destination) scd2RowDelta(ctx context.Context, target, staging *icebergtable.Table, opts destination.SCD2Options, deleteKeyColumns []string) error {
+	stagingSchema, err := tableWriteSchema(staging)
+	if err != nil {
+		return err
+	}
+	stagingCols := arrowSchemaColumnNames(stagingSchema)
+	writeSchema, err := tableWriteSchema(target)
+	if err != nil {
+		return err
+	}
+	targetCols := arrowSchemaColumnNames(writeSchema)
+
+	stagingSorter, err := newSpillSorter(stagingSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer stagingSorter.Close()
+	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, stagingSorter.Add); err != nil {
+		return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
+	}
+
+	isCurrentField, _ := target.Schema().FindFieldByName(destination.SCD2IsCurrentColumn)
+	currentFilter, err := equalityPredicate(isCurrentField, true)
+	if err != nil {
+		return err
+	}
+	currentSorter, err := newSpillSorter(writeSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer currentSorter.Close()
+	if err := forEachScannedRow(ctx, target, currentFilter, currentSorter.Add); err != nil {
+		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
+	}
+
+	join, err := newSCD2Join(opts, stagingCols, targetCols)
+	if err != nil {
+		return err
+	}
+
+	deleteSchema, err := equalityDeleteArrowSchema(target.Schema(), deleteKeyColumns)
+	if err != nil {
+		return err
+	}
+
+	stagingProjection := newRowProjection(writeSchema, stagingCols)
+	targetProjection := newRowProjection(writeSchema, targetCols)
+	deleteProjection := newRowProjection(deleteSchema, deleteKeyColumns)
+
+	config.Debug("[ICEBERG SCD2] Row-delta SCD2 of %d staged row(s) into %s", stagingSorter.Len(), opts.TargetTable)
+	return commitRowDelta(
+		ctx, target, "scd2", writeSchema,
+		func(emit rowEmit) error {
+			return join.run(stagingSorter, currentSorter, scd2Emitters{
+				newRow:    func(row []any) error { return emit(stagingProjection, row) },
+				closedRow: func(row []any) error { return emit(targetProjection, row) },
+			})
+		},
+		deleteKeyColumns,
+		func(emit rowEmit) error {
+			return join.run(stagingSorter, currentSorter, scd2Emitters{
+				deleteKey: func(keyVals []any) error { return emit(deleteProjection, append(keyVals, true)) },
+			})
+		},
+	)
+}
+
+// scd2Emitters receives the join outputs; nil callbacks are skipped so the
+// two streaming passes (data files, delete files) can share one join.
+type scd2Emitters struct {
+	newRow    func(row []any) error
+	closedRow func(row []any) error
+	deleteKey func(keyVals []any) error
+}
+
+func (e scd2Emitters) emitNew(row []any) error {
+	if e.newRow == nil {
+		return nil
+	}
+	return e.newRow(row)
+}
+
+func (e scd2Emitters) emitClosed(row []any) error {
+	if e.closedRow == nil {
+		return nil
+	}
+	return e.closedRow(row)
+}
+
+func (e scd2Emitters) emitDelete(keyVals []any) error {
+	if e.deleteKey == nil {
+		return nil
+	}
+	return e.deleteKey(keyVals)
+}
+
+type scd2Join struct {
+	opts         destination.SCD2Options
+	keyIdxTarget []int
+	validFromIdx int
+	validToIdx   int
+	isCurrentIdx int
+	changePairs  [][2]int // staging column index, target column index
+}
+
+func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string) (*scd2Join, error) {
+	stagingIdx := make(map[string]int, len(stagingCols))
+	for i, col := range stagingCols {
+		stagingIdx[col] = i
+	}
+	targetIdx := make(map[string]int, len(targetCols))
+	for i, col := range targetCols {
+		targetIdx[col] = i
+	}
+
+	j := &scd2Join{opts: opts, validFromIdx: -1, validToIdx: -1, isCurrentIdx: -1}
+	if idx, ok := stagingIdx[destination.SCD2ValidFromColumn]; ok {
+		j.validFromIdx = idx
+	} else {
+		return nil, fmt.Errorf("iceberg: column %q not found in staging table", destination.SCD2ValidFromColumn)
+	}
+	if idx, ok := targetIdx[destination.SCD2ValidToColumn]; ok {
+		j.validToIdx = idx
+	} else {
+		return nil, fmt.Errorf("iceberg: column %q not found in target table", destination.SCD2ValidToColumn)
+	}
+	if idx, ok := targetIdx[destination.SCD2IsCurrentColumn]; ok {
+		j.isCurrentIdx = idx
+	} else {
+		return nil, fmt.Errorf("iceberg: column %q not found in target table", destination.SCD2IsCurrentColumn)
+	}
+
+	for _, pk := range opts.PrimaryKeys {
+		idx, ok := targetIdx[pk]
+		if !ok {
+			return nil, fmt.Errorf("iceberg: primary key column %q not found in target table", pk)
+		}
+		j.keyIdxTarget = append(j.keyIdxTarget, idx)
+	}
+
+	excluded := make(map[string]bool)
+	for _, col := range destination.SCD2NonDataColumns(opts.PrimaryKeys) {
+		excluded[strings.ToLower(col)] = true
+	}
+	for _, col := range opts.Columns {
+		if excluded[strings.ToLower(col)] {
+			continue
+		}
+		sIdx, sOK := stagingIdx[col]
+		tIdx, tOK := targetIdx[col]
+		if sOK && tOK {
+			j.changePairs = append(j.changePairs, [2]int{sIdx, tIdx})
+		}
+	}
+	return j, nil
+}
+
+// run merge-joins the key-sorted staging winners against the key-sorted
+// current target rows and emits the SCD2 outcome per key.
+func (j *scd2Join) run(stagingSorter, currentSorter *spillSorter, emitters scd2Emitters) error {
+	stagingIt, err := stagingSorter.Iter()
+	if err != nil {
+		return err
+	}
+	defer stagingIt.Close()
+	currentIt, err := currentSorter.Iter()
+	if err != nil {
+		return err
+	}
+	defer currentIt.Close()
+
+	stagingOK := stagingIt.NextGroup()
+	currentOK := currentIt.NextGroup()
+	for stagingOK || currentOK {
+		switch {
+		case stagingOK && (!currentOK || stagingIt.Key() < currentIt.Key()):
+			// Net-new key: insert the staged version as current.
+			if err := emitters.emitNew(lastGroupRow(stagingIt)); err != nil {
+				return err
+			}
+			stagingOK = stagingIt.NextGroup()
+
+		case currentOK && (!stagingOK || currentIt.Key() < stagingIt.Key()):
+			// Key vanished from the source: soft-delete on full snapshots.
+			if err := j.softDelete(currentIt, emitters); err != nil {
+				return err
+			}
+			currentOK = currentIt.NextGroup()
+
+		default:
+			if err := j.matchKey(stagingIt, currentIt, emitters); err != nil {
+				return err
+			}
+			stagingOK = stagingIt.NextGroup()
+			currentOK = currentIt.NextGroup()
+		}
+	}
+	if err := stagingIt.Err(); err != nil {
+		return err
+	}
+	return currentIt.Err()
+}
+
+func (j *scd2Join) softDelete(currentIt *spillIter, emitters scd2Emitters) error {
+	if j.opts.IncrementalKey != "" {
+		return nil
+	}
+	softDeleteAt := j.opts.Timestamp.UTC().UnixMicro()
+	first := true
+	for currentIt.NextRow() {
+		row := currentIt.Row()
+		if first {
+			if err := emitters.emitDelete(j.targetKeyValues(row)); err != nil {
+				return err
+			}
+			first = false
+		}
+		if err := emitters.emitClosed(j.closeRow(row, softDeleteAt)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *scd2Join) matchKey(stagingIt, currentIt *spillIter, emitters scd2Emitters) error {
+	stagingRow := lastGroupRow(stagingIt)
+	currentRows := collectGroupRows(currentIt)
+	if len(currentRows) == 0 {
+		return emitters.emitNew(stagingRow)
+	}
+
+	changed := false
+	latestCurrent := currentRows[len(currentRows)-1]
+	for _, pair := range j.changePairs {
+		if !valuesEqual(stagingRow[pair[0]], latestCurrent[pair[1]]) {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	if err := emitters.emitDelete(j.targetKeyValues(latestCurrent)); err != nil {
+		return err
+	}
+	validFrom := stagingRow[j.validFromIdx]
+	for _, row := range currentRows {
+		if err := emitters.emitClosed(j.closeRow(row, validFrom)); err != nil {
+			return err
+		}
+	}
+	return emitters.emitNew(stagingRow)
+}
+
+func (j *scd2Join) targetKeyValues(row []any) []any {
+	keyVals := make([]any, 0, len(j.keyIdxTarget)+1)
+	for _, idx := range j.keyIdxTarget {
+		keyVals = append(keyVals, row[idx])
+	}
+	return keyVals
+}
+
+func (j *scd2Join) closeRow(row []any, validTo any) []any {
+	closed := append([]any(nil), row...)
+	closed[j.validToIdx] = validTo
+	closed[j.isCurrentIdx] = false
+	return closed
+}
+
+func lastGroupRow(it *spillIter) []any {
+	var last []any
+	for it.NextRow() {
+		last = it.Row()
+	}
+	return last
+}
+
+func collectGroupRows(it *spillIter) [][]any {
+	var rows [][]any
+	for it.NextRow() {
+		rows = append(rows, it.Row())
+	}
+	return rows
+}
+
+// selectGroupWinner consumes the current group and returns the winning row:
+// the highest incremental key value when one is tracked (arrival order breaks
+// ties), otherwise the last row.
+func selectGroupWinner(it *spillIter, incrementalIdx int) []any {
+	var winner []any
+	var winnerVal any
+	for it.NextRow() {
+		row := it.Row()
+		if incrementalIdx < 0 || winner == nil {
+			winner = row
+			if incrementalIdx >= 0 {
+				winnerVal = row[incrementalIdx]
+			}
+			continue
+		}
+		if cmp, comparable := compareOrdered(row[incrementalIdx], winnerVal); !comparable || cmp >= 0 {
+			winner = row
+			winnerVal = row[incrementalIdx]
+		}
+	}
+	return winner
+}

--- a/pkg/destination/iceberg/row_delta.go
+++ b/pkg/destination/iceberg/row_delta.go
@@ -224,12 +224,11 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 
 	incrementalIdx := -1
 	if opts.IncrementalKey != "" {
-		for i, col := range stagingCols {
-			if col == opts.IncrementalKey {
-				incrementalIdx = i
-				break
-			}
+		idx, err := incrementalKeyIndex(stagingCols, opts.IncrementalKey, opts.StagingTable)
+		if err != nil {
+			return err
 		}
+		incrementalIdx = idx
 	}
 
 	writeSchema, err := tableWriteSchema(target)

--- a/pkg/destination/iceberg/row_delta.go
+++ b/pkg/destination/iceberg/row_delta.go
@@ -372,12 +372,13 @@ func (e scd2Emitters) emitDelete(keyVals []any) error {
 }
 
 type scd2Join struct {
-	opts         destination.SCD2Options
-	keyIdxTarget []int
-	validFromIdx int
-	validToIdx   int
-	isCurrentIdx int
-	changePairs  [][2]int // staging column index, target column index
+	opts           destination.SCD2Options
+	keyIdxTarget   []int
+	validFromIdx   int
+	validToIdx     int
+	isCurrentIdx   int
+	incrementalIdx int
+	changePairs    [][2]int // staging column index, target column index
 }
 
 func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string) (*scd2Join, error) {
@@ -390,11 +391,16 @@ func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string)
 		targetIdx[col] = i
 	}
 
-	j := &scd2Join{opts: opts, validFromIdx: -1, validToIdx: -1, isCurrentIdx: -1}
+	j := &scd2Join{opts: opts, validFromIdx: -1, validToIdx: -1, isCurrentIdx: -1, incrementalIdx: -1}
 	if idx, ok := stagingIdx[destination.SCD2ValidFromColumn]; ok {
 		j.validFromIdx = idx
 	} else {
 		return nil, fmt.Errorf("iceberg: column %q not found in staging table", destination.SCD2ValidFromColumn)
+	}
+	if opts.IncrementalKey != "" {
+		if idx, ok := stagingIdx[opts.IncrementalKey]; ok {
+			j.incrementalIdx = idx
+		}
 	}
 	if idx, ok := targetIdx[destination.SCD2ValidToColumn]; ok {
 		j.validToIdx = idx
@@ -452,7 +458,7 @@ func (j *scd2Join) run(stagingSorter, currentSorter *spillSorter, emitters scd2E
 		switch {
 		case stagingOK && (!currentOK || stagingIt.Key() < currentIt.Key()):
 			// Net-new key: insert the staged version as current.
-			if err := emitters.emitNew(lastGroupRow(stagingIt)); err != nil {
+			if err := emitters.emitNew(selectGroupWinner(stagingIt, j.incrementalIdx)); err != nil {
 				return err
 			}
 			stagingOK = stagingIt.NextGroup()
@@ -500,7 +506,7 @@ func (j *scd2Join) softDelete(currentIt *spillIter, emitters scd2Emitters) error
 }
 
 func (j *scd2Join) matchKey(stagingIt, currentIt *spillIter, emitters scd2Emitters) error {
-	stagingRow := lastGroupRow(stagingIt)
+	stagingRow := selectGroupWinner(stagingIt, j.incrementalIdx)
 	currentRows := collectGroupRows(currentIt)
 	if len(currentRows) == 0 {
 		return emitters.emitNew(stagingRow)
@@ -543,14 +549,6 @@ func (j *scd2Join) closeRow(row []any, validTo any) []any {
 	closed[j.validToIdx] = validTo
 	closed[j.isCurrentIdx] = false
 	return closed
-}
-
-func lastGroupRow(it *spillIter) []any {
-	var last []any
-	for it.NextRow() {
-		last = it.Row()
-	}
-	return last
 }
 
 func collectGroupRows(it *spillIter) [][]any {

--- a/pkg/destination/iceberg/row_delta_test.go
+++ b/pkg/destination/iceberg/row_delta_test.go
@@ -282,6 +282,28 @@ func TestSCD2TableRowDeltaDedupesByIncrementalKey(t *testing.T) {
 	requireEqualityDeletes(t, dest, target)
 }
 
+func TestSCD2TableRowDeltaRequiresStagingIncrementalKey(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.mor.scd2_missing_key_target"
+	staging := "lake.mor.scd2_missing_key_staging"
+	t1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "active", 1.0, micros(t1)),
+	})
+
+	err := dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score"},
+		IncrementalKey: "updated_at",
+		Timestamp:      t1,
+	})
+	require.ErrorContains(t, err, `iceberg: incremental key column "updated_at" not found in staging table lake.mor.scd2_missing_key_staging`)
+}
+
 func TestDeleteInsertSpilledRuns(t *testing.T) {
 	withSpillRunRows(t, 4)
 

--- a/pkg/destination/iceberg/row_delta_test.go
+++ b/pkg/destination/iceberg/row_delta_test.go
@@ -240,6 +240,48 @@ func TestSCD2TableUsesRowDeltaByDefault(t *testing.T) {
 	requireEqualityDeletes(t, dest, target)
 }
 
+func TestSCD2TableRowDeltaDedupesByIncrementalKey(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.mor.scd2_inc_target"
+	staging := "lake.mor.scd2_inc_staging"
+	schema := scd2IncrementalTestSchema()
+	t1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+
+	writeTableRows(t, dest, target, schema, false, nil)
+	writeTableRows(t, dest, staging, schema, true, [][]any{
+		scd2IncrementalRow(1, "active", 1.0, micros(t1), micros(t1)),
+	})
+	require.NoError(t, dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score", "updated_at"},
+		IncrementalKey: "updated_at",
+		Timestamp:      t1,
+	}))
+
+	writeTableRows(t, dest, staging, schema, true, [][]any{
+		scd2IncrementalRow(1, "newer", 3.0, micros(t3), micros(t3)),
+		scd2IncrementalRow(1, "older", 2.0, micros(t2), micros(t2)),
+	})
+	require.NoError(t, dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score", "updated_at"},
+		IncrementalKey: "updated_at",
+		Timestamp:      t3,
+	}))
+
+	got := readTableRows(t, dest, target)
+	current := currentSCD2Row(t, got, 1)
+	require.Equal(t, "newer", got.Value(current, "status"))
+	require.Equal(t, micros(t3), got.Value(current, "updated_at"))
+	requireEqualityDeletes(t, dest, target)
+}
+
 func TestDeleteInsertSpilledRuns(t *testing.T) {
 	withSpillRunRows(t, 4)
 

--- a/pkg/destination/iceberg/row_delta_test.go
+++ b/pkg/destination/iceberg/row_delta_test.go
@@ -1,0 +1,289 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// latestSnapshotSummary returns the summary properties of the table's current
+// snapshot, used to detect whether an operation committed equality delete
+// files (merge-on-read) or rewrote data files (copy-on-write).
+func latestSnapshotSummary(t *testing.T, dest *Destination, table string) map[string]string {
+	t.Helper()
+
+	tbl, err := dest.loadIcebergTable(context.Background(), table)
+	require.NoError(t, err)
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.Summary)
+	return snap.Summary.Properties
+}
+
+func requireEqualityDeletes(t *testing.T, dest *Destination, table string) {
+	t.Helper()
+	summary := latestSnapshotSummary(t, dest, table)
+	require.NotEmpty(t, summary["added-equality-delete-files"], "expected a merge-on-read snapshot with equality delete files, summary: %v", summary)
+}
+
+func requireNoEqualityDeletes(t *testing.T, dest *Destination, table string) {
+	t.Helper()
+	summary := latestSnapshotSummary(t, dest, table)
+	require.Empty(t, summary["added-equality-delete-files"], "expected a copy-on-write snapshot without equality delete files, summary: %v", summary)
+}
+
+func runBasicMerge(t *testing.T, dest *Destination, target, staging string) {
+	t.Helper()
+	ctx := context.Background()
+	ts := micros(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "alpha", 1.5, ts},
+		{int64(2), "bravo", 2.5, ts},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(2), "bravo-updated", 22.5, ts + 1},
+		{int64(3), "charlie", 3.5, ts + 1},
+	})
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "alpha", rows[int64(1)][1])
+	require.Equal(t, "bravo-updated", rows[int64(2)][1])
+	require.Equal(t, "charlie", rows[int64(3)][1])
+}
+
+func TestMergeTableUsesRowDeltaByDefault(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.mor.merge_target"
+	runBasicMerge(t, dest, target, "lake.mor.merge_staging")
+	requireEqualityDeletes(t, dest, target)
+}
+
+func TestMergeTableHonorsCopyOnWriteProperty(t *testing.T) {
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.merge.mode=copy-on-write"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+
+	target := "lake.cow.merge_target"
+	runBasicMerge(t, dest, target, "lake.cow.merge_staging")
+	requireNoEqualityDeletes(t, dest, target)
+}
+
+func TestMergeTablePartitionedByPrimaryKeyUsesRowDelta(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.mor.part_pk_target"
+	staging := "lake.mor.part_pk_staging"
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       target,
+		Schema:      mergeTestSchema(),
+		PartitionBy: "id",
+	}))
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "alpha", 1.5, nil},
+		{int64(2), "bravo", 2.5, nil},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(2), "bravo-updated", 22.5, nil},
+		{int64(3), "charlie", 3.5, nil},
+	})
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "bravo-updated", rows[int64(2)][1])
+	requireEqualityDeletes(t, dest, target)
+}
+
+func TestMergeTablePartitionedOutsidePrimaryKeyFallsBack(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow.part_other_target"
+	staging := "lake.cow.part_other_staging"
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       target,
+		Schema:      mergeTestSchema(),
+		PartitionBy: "name",
+	}))
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "alpha", 1.5, nil},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		// The row moves partitions ("alpha" -> "alpha-moved"); equality deletes
+		// would be routed to the new partition and miss the old row, so this
+		// must run copy-on-write.
+		{int64(1), "alpha-moved", 11.5, nil},
+	})
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 1)
+	require.Equal(t, "alpha-moved", rows[int64(1)][1], "partition-crossing update must not leave the old row behind")
+	requireNoEqualityDeletes(t, dest, target)
+}
+
+func TestMergeTableSpilledRuns(t *testing.T) {
+	withSpillRunRows(t, 8)
+
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.mor.spill_target"
+	staging := "lake.mor.spill_staging"
+	base := micros(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(0), "seed-0", 0.0, base - 1},
+		{int64(1), "seed-1", 0.0, base - 1},
+	})
+
+	// 60 staged rows over 20 keys, three versions each, interleaved so
+	// duplicates land in different spill runs. The highest updated_at wins.
+	stagingRows := make([][]any, 0, 60)
+	for version := range 3 {
+		for key := range 20 {
+			stagingRows = append(stagingRows, []any{
+				int64(key),
+				fmt.Sprintf("k%02d-v%d", key, version),
+				float64(version),
+				base + int64(version),
+			})
+		}
+	}
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, stagingRows)
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "name", "score", "updated_at"},
+		IncrementalKey: "updated_at",
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 20)
+	for key := range 20 {
+		require.Equal(t, fmt.Sprintf("k%02d-v2", key), rows[int64(key)][1], "latest version by incremental key must win for key %d", key)
+	}
+	requireEqualityDeletes(t, dest, target)
+}
+
+func TestSCD2TableUsesRowDeltaByDefault(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.mor.scd2_target"
+	staging := "lake.mor.scd2_staging"
+	t1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "active", 1.0, micros(t1)),
+		scd2Row(2, "active", 2.0, micros(t1)),
+	})
+	runSCD2(t, dest, target, staging, t1, "")
+
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "inactive", 1.0, micros(t2)),
+		scd2Row(2, "active", 2.0, micros(t2)),
+	})
+	runSCD2(t, dest, target, staging, t2, "")
+
+	got := readTableRows(t, dest, target)
+	require.Len(t, got.Rows, 3, "changed key gains a closed version, unchanged key stays single")
+	requireEqualityDeletes(t, dest, target)
+}
+
+func TestDeleteInsertSpilledRuns(t *testing.T) {
+	withSpillRunRows(t, 4)
+
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.di.spill_target"
+	staging := "lake.di.spill_staging"
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, nil)
+	stagingRows := make([][]any, 0, 30)
+	for version := range 3 {
+		for key := range 10 {
+			stagingRows = append(stagingRows, []any{int64(key), fmt.Sprintf("k%02d-v%d", key, version), 0.0, nil})
+		}
+	}
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, stagingRows)
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		IncrementalKey: "id",
+		IntervalStart:  int64(0),
+		IntervalEnd:    int64(9),
+		Columns:        []string{"id", "name", "score", "updated_at"},
+		PrimaryKeys:    []string{"id"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 10)
+	for key := range 10 {
+		require.Equal(t, fmt.Sprintf("k%02d-v2", key), rows[int64(key)][1], "arrival order must break dedup ties for key %d", key)
+	}
+}
+
+// TestSchemaMergeCompatibility ensures a merge after schema evolution (target
+// widened, staging matching) still routes correctly.
+func TestMergeTableWithDestinationOnlyColumnStillFallsBack(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.cow.destonly2_target"
+	staging := "lake.cow.destonly2_staging"
+	ctx := context.Background()
+
+	targetSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "legacy", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+	stagingSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{{int64(1), "alpha", "keep"}})
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{{int64(1), "alpha-updated"}})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Equal(t, "keep", rows[int64(1)][2], "destination-only column must survive, forcing the copy-on-write path")
+	requireNoEqualityDeletes(t, dest, target)
+}

--- a/pkg/destination/iceberg/row_delta_test.go
+++ b/pkg/destination/iceberg/row_delta_test.go
@@ -193,6 +193,28 @@ func TestMergeTableSpilledRuns(t *testing.T) {
 	requireEqualityDeletes(t, dest, target)
 }
 
+func TestMergeTableRequiresStagingIncrementalKeyWhenDedupingRowDelta(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.mor.missing_key_target"
+	staging := "lake.mor.missing_key_staging"
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, nil)
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(1), "first", 1.0, nil},
+		{int64(1), "second", 2.0, nil},
+	})
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "name", "score", "updated_at"},
+		IncrementalKey: "missing_key",
+	})
+	require.ErrorContains(t, err, `iceberg: incremental key column "missing_key" not found in staging table lake.mor.missing_key_staging`)
+}
+
 func TestSCD2TableUsesRowDeltaByDefault(t *testing.T) {
 	dest := newHadoopDestination(t)
 	target := "lake.mor.scd2_target"

--- a/pkg/destination/iceberg/rows.go
+++ b/pkg/destination/iceberg/rows.go
@@ -1,0 +1,941 @@
+package iceberg
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+)
+
+// decimalVal and uuidVal keep decimals and UUIDs distinct from plain strings in
+// the normalized row representation, so ordering and predicate building can
+// treat them by their logical type.
+type (
+	decimalVal string
+	uuidVal    string
+)
+
+// scannedTable holds a fully materialized read of an Iceberg table. Rows are
+// normalized Go values aligned to Columns order.
+type scannedTable struct {
+	Columns []string
+	ColIdx  map[string]int
+	Rows    [][]any
+}
+
+func (s *scannedTable) HasColumn(name string) bool {
+	_, ok := s.ColIdx[name]
+	return ok
+}
+
+func (s *scannedTable) Value(row []any, column string) any {
+	idx, ok := s.ColIdx[column]
+	if !ok {
+		return nil
+	}
+	return row[idx]
+}
+
+// scanTableRows reads all rows matching filter into memory.
+func scanTableRows(ctx context.Context, tbl *icebergtable.Table, filter iceberggo.BooleanExpression) (*scannedTable, error) {
+	out := &scannedTable{ColIdx: make(map[string]int)}
+	for _, field := range tbl.Schema().Fields() {
+		out.ColIdx[field.Name] = len(out.Columns)
+		out.Columns = append(out.Columns, field.Name)
+	}
+	if tbl.CurrentSnapshot() == nil {
+		return out, nil
+	}
+
+	batchSchema, itr, err := tbl.Scan(icebergtable.WithRowFilter(filter)).ToArrowRecords(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to scan table: %w", err)
+	}
+
+	positions := make([]int, len(batchSchema.Fields()))
+	for i, field := range batchSchema.Fields() {
+		idx, ok := out.ColIdx[field.Name]
+		if !ok {
+			return nil, fmt.Errorf("iceberg: scan returned unknown column %q", field.Name)
+		}
+		positions[i] = idx
+	}
+
+	for batch, err := range itr {
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: failed to read table rows: %w", err)
+		}
+		numRows := int(batch.NumRows())
+		numCols := int(batch.NumCols())
+		for r := range numRows {
+			row := make([]any, len(out.Columns))
+			for c := range numCols {
+				value, err := rowValue(batch.Column(c), r)
+				if err != nil {
+					batch.Release()
+					return nil, fmt.Errorf("iceberg: column %q: %w", batchSchema.Field(c).Name, err)
+				}
+				row[positions[c]] = value
+			}
+			out.Rows = append(out.Rows, row)
+		}
+		batch.Release()
+	}
+	return out, nil
+}
+
+// rowValue extracts a normalized Go value: nil, bool, int64 (integers, date
+// days, time/timestamp micros), float64, string, []byte, decimalVal, uuidVal
+// or []any for lists.
+func rowValue(arr arrow.Array, i int) (any, error) {
+	if arr.IsNull(i) {
+		return nil, nil
+	}
+	switch a := arr.(type) {
+	case *array.Boolean:
+		return a.Value(i), nil
+	case *array.Int8:
+		return int64(a.Value(i)), nil
+	case *array.Int16:
+		return int64(a.Value(i)), nil
+	case *array.Int32:
+		return int64(a.Value(i)), nil
+	case *array.Int64:
+		return a.Value(i), nil
+	case *array.Uint8:
+		return int64(a.Value(i)), nil
+	case *array.Uint16:
+		return int64(a.Value(i)), nil
+	case *array.Uint32:
+		return int64(a.Value(i)), nil
+	case *array.Uint64:
+		return int64(a.Value(i)), nil
+	case *array.Float32:
+		return float64(a.Value(i)), nil
+	case *array.Float64:
+		return a.Value(i), nil
+	case *array.String:
+		return a.Value(i), nil
+	case *array.LargeString:
+		return a.Value(i), nil
+	case *array.Binary:
+		return bytes.Clone(a.Value(i)), nil
+	case *array.LargeBinary:
+		return bytes.Clone(a.Value(i)), nil
+	case *array.FixedSizeBinary:
+		return bytes.Clone(a.Value(i)), nil
+	case *array.Date32:
+		return int64(a.Value(i)), nil
+	case *array.Date64:
+		return int64(a.Value(i)) / 86400000, nil
+	case *array.Time32:
+		dt := a.DataType().(*arrow.Time32Type)
+		return timeToMicros(int64(a.Value(i)), dt.Unit), nil
+	case *array.Time64:
+		dt := a.DataType().(*arrow.Time64Type)
+		return timeToMicros(int64(a.Value(i)), dt.Unit), nil
+	case *array.Timestamp:
+		dt := a.DataType().(*arrow.TimestampType)
+		return timeToMicros(int64(a.Value(i)), dt.Unit), nil
+	case *array.Decimal128:
+		dt := a.DataType().(*arrow.Decimal128Type)
+		return decimalVal(normalizeDecimalString(a.Value(i).ToString(dt.Scale))), nil
+	case *array.Decimal256:
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return decimalVal(normalizeDecimalString(a.Value(i).ToString(dt.Scale))), nil
+	case *extensions.UUIDArray:
+		return uuidVal(a.Value(i).String()), nil
+	case *array.List:
+		return listValues(a.ListValues(), int(a.Offsets()[i]), int(a.Offsets()[i+1]))
+	case *array.LargeList:
+		return listValues(a.ListValues(), int(a.Offsets()[i]), int(a.Offsets()[i+1]))
+	case array.ExtensionArray:
+		return rowValue(a.Storage(), i)
+	case *array.Null:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported value type %s", arr.DataType())
+	}
+}
+
+func listValues(values arrow.Array, start, end int) (any, error) {
+	out := make([]any, 0, end-start)
+	for i := start; i < end; i++ {
+		v, err := rowValue(values, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func timeToMicros(v int64, unit arrow.TimeUnit) int64 {
+	switch unit {
+	case arrow.Second:
+		return v * 1_000_000
+	case arrow.Millisecond:
+		return v * 1_000
+	case arrow.Microsecond:
+		return v
+	case arrow.Nanosecond:
+		return v / 1_000
+	default:
+		return v
+	}
+}
+
+func microsToUnit(v int64, unit arrow.TimeUnit) int64 {
+	switch unit {
+	case arrow.Second:
+		return v / 1_000_000
+	case arrow.Millisecond:
+		return v / 1_000
+	case arrow.Microsecond:
+		return v
+	case arrow.Nanosecond:
+		return v * 1_000
+	default:
+		return v
+	}
+}
+
+// normalizeDecimalString trims insignificant fraction zeros so equal decimals
+// compare equal regardless of the scale they were stored with.
+func normalizeDecimalString(s string) string {
+	if !strings.Contains(s, ".") {
+		return s
+	}
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimSuffix(s, ".")
+	switch s {
+	case "", "-":
+		return "0"
+	default:
+		return s
+	}
+}
+
+// appendValue writes a normalized value into a builder for the write schema.
+func appendValue(b array.Builder, v any) error {
+	if v == nil {
+		b.AppendNull()
+		return nil
+	}
+	switch bldr := b.(type) {
+	case *array.BooleanBuilder:
+		val, ok := v.(bool)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.Int8Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(int8(val))
+	case *array.Int16Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(int16(val))
+	case *array.Int32Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(int32(val))
+	case *array.Int64Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.Float32Builder:
+		val, ok := asFloat64(v)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(float32(val))
+	case *array.Float64Builder:
+		val, ok := asFloat64(v)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.StringBuilder:
+		val, ok := asString(v)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.LargeStringBuilder:
+		val, ok := asString(v)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.BinaryBuilder:
+		val, ok := v.([]byte)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.FixedSizeBinaryBuilder:
+		val, ok := v.([]byte)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(val)
+	case *array.Date32Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(arrow.Date32(val))
+	case *array.Time32Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		dt := bldr.Type().(*arrow.Time32Type)
+		bldr.Append(arrow.Time32(microsToUnit(val, dt.Unit)))
+	case *array.Time64Builder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		dt := bldr.Type().(*arrow.Time64Type)
+		bldr.Append(arrow.Time64(microsToUnit(val, dt.Unit)))
+	case *array.TimestampBuilder:
+		val, ok := v.(int64)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		dt := bldr.Type().(*arrow.TimestampType)
+		bldr.Append(arrow.Timestamp(microsToUnit(val, dt.Unit)))
+	case *array.Decimal128Builder:
+		val, ok := asString(v)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		dt := bldr.Type().(*arrow.Decimal128Type)
+		num, err := decimal128.FromString(val, dt.Precision, dt.Scale)
+		if err != nil {
+			return fmt.Errorf("cannot convert %q to %s: %w", val, dt, err)
+		}
+		bldr.Append(num)
+	case *extensions.UUIDBuilder:
+		switch val := v.(type) {
+		case uuidVal:
+			return bldr.AppendValueFromString(string(val))
+		case string:
+			return bldr.AppendValueFromString(val)
+		case []byte:
+			parsed, err := uuid.FromBytes(val)
+			if err != nil {
+				return fmt.Errorf("cannot convert bytes to uuid: %w", err)
+			}
+			bldr.Append(parsed)
+		default:
+			return typeMismatch(b, v)
+		}
+	case *array.ListBuilder:
+		vals, ok := v.([]any)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(true)
+		for _, elem := range vals {
+			if err := appendValue(bldr.ValueBuilder(), elem); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported builder type %s", b.Type())
+	}
+	return nil
+}
+
+func typeMismatch(b array.Builder, v any) error {
+	return fmt.Errorf("cannot write value of type %T into column type %s", v, b.Type())
+}
+
+func asFloat64(v any) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case int64:
+		return float64(val), true
+	default:
+		return 0, false
+	}
+}
+
+func asString(v any) (string, bool) {
+	switch val := v.(type) {
+	case string:
+		return val, true
+	case decimalVal:
+		return string(val), true
+	case uuidVal:
+		return string(val), true
+	default:
+		return "", false
+	}
+}
+
+// buildRecordBatches converts normalized rows into Arrow record batches
+// matching the write schema.
+func buildRecordBatches(writeSchema *arrow.Schema, rows [][]any) ([]arrow.RecordBatch, error) {
+	const chunkSize = 4096
+
+	batches := make([]arrow.RecordBatch, 0, len(rows)/chunkSize+1)
+	release := func() {
+		for _, b := range batches {
+			b.Release()
+		}
+	}
+
+	for start := 0; start < len(rows); start += chunkSize {
+		end := min(start+chunkSize, len(rows))
+
+		builder := array.NewRecordBuilder(memory.DefaultAllocator, writeSchema)
+		for _, row := range rows[start:end] {
+			for c := range writeSchema.Fields() {
+				if err := appendValue(builder.Field(c), row[c]); err != nil {
+					builder.Release()
+					release()
+					return nil, fmt.Errorf("iceberg: column %q: %w", writeSchema.Field(c).Name, err)
+				}
+			}
+		}
+		batches = append(batches, builder.NewRecordBatch())
+		builder.Release()
+	}
+	return batches, nil
+}
+
+func releaseBatches(batches []arrow.RecordBatch) {
+	for _, b := range batches {
+		b.Release()
+	}
+}
+
+// valuesEqual compares two normalized values null-safely (both-nil is equal,
+// mirroring IS NOT DISTINCT FROM in the SQL merge implementations).
+func valuesEqual(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	switch av := a.(type) {
+	case []byte:
+		bv, ok := b.([]byte)
+		return ok && bytes.Equal(av, bv)
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !valuesEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a == b
+	}
+}
+
+// compareOrdered orders two normalized values; ok is false when the values are
+// not comparable (callers treat that as a tie).
+func compareOrdered(a, b any) (int, bool) {
+	if a == nil || b == nil {
+		switch {
+		case a == nil && b == nil:
+			return 0, true
+		case a == nil:
+			return -1, true
+		default:
+			return 1, true
+		}
+	}
+	switch av := a.(type) {
+	case int64:
+		switch bv := b.(type) {
+		case int64:
+			return cmpInt(av, bv), true
+		case float64:
+			return cmpFloat(float64(av), bv), true
+		}
+	case float64:
+		switch bv := b.(type) {
+		case float64:
+			return cmpFloat(av, bv), true
+		case int64:
+			return cmpFloat(av, float64(bv)), true
+		}
+	case string:
+		if bv, ok := b.(string); ok {
+			return strings.Compare(av, bv), true
+		}
+	case bool:
+		if bv, ok := b.(bool); ok {
+			return cmpBool(av, bv), true
+		}
+	case []byte:
+		if bv, ok := b.([]byte); ok {
+			return bytes.Compare(av, bv), true
+		}
+	case uuidVal:
+		if bv, ok := b.(uuidVal); ok {
+			return strings.Compare(string(av), string(bv)), true
+		}
+	case decimalVal:
+		if bv, ok := b.(decimalVal); ok {
+			ra, okA := new(big.Rat).SetString(string(av))
+			rb, okB := new(big.Rat).SetString(string(bv))
+			if okA && okB {
+				return ra.Cmp(rb), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func cmpInt(a, b int64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func cmpFloat(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func cmpBool(a, b bool) int {
+	switch {
+	case a == b:
+		return 0
+	case b:
+		return -1
+	default:
+		return 1
+	}
+}
+
+// encodeRowKey builds an unambiguous composite key from primary key values.
+func encodeRowKey(values []any) (string, error) {
+	var sb strings.Builder
+	for i, v := range values {
+		if i > 0 {
+			sb.WriteByte(0x1f)
+		}
+		switch val := v.(type) {
+		case nil:
+			return "", fmt.Errorf("primary key value is NULL")
+		case bool:
+			sb.WriteString("b:")
+			sb.WriteString(strconv.FormatBool(val))
+		case int64:
+			sb.WriteString("i:")
+			sb.WriteString(strconv.FormatInt(val, 10))
+		case string:
+			sb.WriteString("s:")
+			sb.WriteString(strconv.Itoa(len(val)))
+			sb.WriteByte(':')
+			sb.WriteString(val)
+		case []byte:
+			sb.WriteString("x:")
+			sb.WriteString(hex.EncodeToString(val))
+		case uuidVal:
+			sb.WriteString("u:")
+			sb.WriteString(string(val))
+		case decimalVal:
+			sb.WriteString("d:")
+			sb.WriteString(string(val))
+		default:
+			return "", fmt.Errorf("unsupported primary key value type %T", v)
+		}
+	}
+	return sb.String(), nil
+}
+
+type predicateOp int
+
+const (
+	opEqual predicateOp = iota
+	opGreaterThanEqual
+	opLessThanEqual
+)
+
+func typedPredicate[T iceberggo.LiteralType](op predicateOp, ref iceberggo.UnboundTerm, v T) iceberggo.BooleanExpression {
+	switch op {
+	case opGreaterThanEqual:
+		return iceberggo.GreaterThanEqual(ref, v)
+	case opLessThanEqual:
+		return iceberggo.LessThanEqual(ref, v)
+	default:
+		return iceberggo.EqualTo(ref, v)
+	}
+}
+
+// equalityPredicate builds field = value for a normalized value, using the
+// Iceberg column type to pick the literal type.
+func equalityPredicate(field iceberggo.NestedField, v any) (iceberggo.BooleanExpression, error) {
+	return columnPredicate(opEqual, field, v)
+}
+
+// columnPredicate builds field <op> value for a normalized value, using the
+// Iceberg column type to pick the literal type.
+func columnPredicate(op predicateOp, field iceberggo.NestedField, v any) (iceberggo.BooleanExpression, error) {
+	ref := iceberggo.Reference(field.Name)
+	switch field.Type.(type) {
+	case iceberggo.BooleanType:
+		val, ok := v.(bool)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, val), nil
+	case iceberggo.Int32Type:
+		val, ok := v.(int64)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, int32(val)), nil
+	case iceberggo.Int64Type:
+		val, ok := v.(int64)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, val), nil
+	case iceberggo.Float32Type, iceberggo.Float64Type:
+		val, ok := asFloat64(v)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, val), nil
+	case iceberggo.StringType:
+		val, ok := asString(v)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, val), nil
+	case iceberggo.DateType:
+		val, ok := v.(int64)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, iceberggo.Date(val)), nil
+	case iceberggo.TimestampType, iceberggo.TimestampTzType:
+		val, ok := v.(int64)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, iceberggo.Timestamp(val)), nil
+	case iceberggo.TimeType:
+		val, ok := v.(int64)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, iceberggo.Time(val)), nil
+	case iceberggo.UUIDType:
+		val, ok := asString(v)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		parsed, err := uuid.Parse(val)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: invalid uuid value for column %q: %w", field.Name, err)
+		}
+		return typedPredicate(op, ref, parsed), nil
+	case iceberggo.BinaryType, iceberggo.FixedType:
+		val, ok := v.([]byte)
+		if !ok {
+			return nil, predicateTypeErr(field, v)
+		}
+		return typedPredicate(op, ref, val), nil
+	case iceberggo.DecimalType:
+		dec, err := decimalLiteral(field, v)
+		if err != nil {
+			return nil, err
+		}
+		return typedPredicate(op, ref, dec), nil
+	default:
+		return nil, fmt.Errorf("iceberg: unsupported predicate column type %s for column %q", field.Type, field.Name)
+	}
+}
+
+// normalizeBoundValue converts an interval bound supplied by the strategy
+// layer (time.Time, date strings, numbers) into the normalized representation
+// expected by columnPredicate for the given column.
+func normalizeBoundValue(field iceberggo.NestedField, v any) (any, error) {
+	switch val := v.(type) {
+	case nil:
+		return nil, fmt.Errorf("iceberg: interval bound for column %q is nil", field.Name)
+	case time.Time:
+		if _, isDate := field.Type.(iceberggo.DateType); isDate {
+			return val.UTC().Truncate(24*time.Hour).Unix() / 86400, nil
+		}
+		return val.UTC().UnixMicro(), nil
+	case int:
+		return int64(val), nil
+	case int8:
+		return int64(val), nil
+	case int16:
+		return int64(val), nil
+	case int32:
+		return int64(val), nil
+	case int64:
+		return val, nil
+	case uint:
+		return int64(val), nil
+	case uint32:
+		return int64(val), nil
+	case uint64:
+		return int64(val), nil
+	case float32:
+		return float64(val), nil
+	case float64:
+		return val, nil
+	case bool:
+		return val, nil
+	case []byte:
+		return val, nil
+	case string:
+		return normalizeStringBound(field, val)
+	default:
+		return nil, fmt.Errorf("iceberg: unsupported interval bound type %T for column %q", v, field.Name)
+	}
+}
+
+func normalizeStringBound(field iceberggo.NestedField, val string) (any, error) {
+	switch field.Type.(type) {
+	case iceberggo.DateType:
+		parsed, err := time.Parse("2006-01-02", val)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: invalid date bound %q for column %q: %w", val, field.Name, err)
+		}
+		return parsed.Unix() / 86400, nil
+	case iceberggo.TimestampType, iceberggo.TimestampTzType:
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999", "2006-01-02 15:04:05", "2006-01-02"} {
+			if parsed, err := time.Parse(layout, val); err == nil {
+				return parsed.UTC().UnixMicro(), nil
+			}
+		}
+		return nil, fmt.Errorf("iceberg: invalid timestamp bound %q for column %q", val, field.Name)
+	case iceberggo.Int32Type, iceberggo.Int64Type:
+		parsed, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: invalid integer bound %q for column %q: %w", val, field.Name, err)
+		}
+		return parsed, nil
+	case iceberggo.Float32Type, iceberggo.Float64Type:
+		parsed, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: invalid float bound %q for column %q: %w", val, field.Name, err)
+		}
+		return parsed, nil
+	case iceberggo.DecimalType:
+		return decimalVal(normalizeDecimalString(val)), nil
+	default:
+		return val, nil
+	}
+}
+
+func predicateTypeErr(field iceberggo.NestedField, v any) error {
+	return fmt.Errorf("iceberg: cannot build predicate on column %q (%s) from value of type %T", field.Name, field.Type, v)
+}
+
+func decimalLiteral(field iceberggo.NestedField, v any) (iceberggo.Decimal, error) {
+	dt, ok := field.Type.(iceberggo.DecimalType)
+	if !ok {
+		return iceberggo.Decimal{}, predicateTypeErr(field, v)
+	}
+	str, ok := asString(v)
+	if !ok {
+		if f, isNum := asFloat64(v); isNum {
+			str = strconv.FormatFloat(f, 'f', -1, 64)
+		} else {
+			return iceberggo.Decimal{}, predicateTypeErr(field, v)
+		}
+	}
+	num, err := decimal128.FromString(str, int32(dt.Precision()), int32(dt.Scale()))
+	if err != nil {
+		return iceberggo.Decimal{}, fmt.Errorf("iceberg: invalid decimal value %q for column %q: %w", str, field.Name, err)
+	}
+	return iceberggo.Decimal{Val: num, Scale: dt.Scale()}, nil
+}
+
+// keyMatchFilter builds an expression matching rows whose primary key values
+// appear in keys. Single-column keys use an IN set; composite keys expand into
+// OR-of-AND equality chains.
+func keyMatchFilter(iceSchema *iceberggo.Schema, primaryKeys []string, keys [][]any) (iceberggo.BooleanExpression, error) {
+	if len(keys) == 0 {
+		return iceberggo.AlwaysFalse{}, nil
+	}
+	fields := make([]iceberggo.NestedField, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		field, ok := iceSchema.FindFieldByName(pk)
+		if !ok {
+			return nil, fmt.Errorf("iceberg: primary key column %q not found in table schema", pk)
+		}
+		fields[i] = field
+	}
+
+	if len(primaryKeys) == 1 {
+		return singleKeyInFilter(fields[0], keys)
+	}
+
+	keyExprs := make([]iceberggo.BooleanExpression, 0, len(keys))
+	for _, key := range keys {
+		preds := make([]iceberggo.BooleanExpression, 0, len(fields))
+		for i, field := range fields {
+			pred, err := equalityPredicate(field, key[i])
+			if err != nil {
+				return nil, err
+			}
+			preds = append(preds, pred)
+		}
+		keyExprs = append(keyExprs, andAll(preds))
+	}
+	return orAll(keyExprs), nil
+}
+
+// orAll and andAll build balanced expression trees so large key sets don't
+// produce recursion-deep left-leaning chains in binding and evaluation.
+func orAll(exprs []iceberggo.BooleanExpression) iceberggo.BooleanExpression {
+	switch len(exprs) {
+	case 0:
+		return iceberggo.AlwaysFalse{}
+	case 1:
+		return exprs[0]
+	default:
+		mid := len(exprs) / 2
+		return iceberggo.NewOr(orAll(exprs[:mid]), orAll(exprs[mid:]))
+	}
+}
+
+func andAll(exprs []iceberggo.BooleanExpression) iceberggo.BooleanExpression {
+	switch len(exprs) {
+	case 0:
+		return iceberggo.AlwaysTrue{}
+	case 1:
+		return exprs[0]
+	default:
+		mid := len(exprs) / 2
+		return iceberggo.NewAnd(andAll(exprs[:mid]), andAll(exprs[mid:]))
+	}
+}
+
+func singleKeyInFilter(field iceberggo.NestedField, keys [][]any) (iceberggo.BooleanExpression, error) {
+	ref := iceberggo.Reference(field.Name)
+	switch field.Type.(type) {
+	case iceberggo.Int32Type:
+		vals, err := collectKeyValues(field, keys, func(v any) (int32, bool) {
+			i, ok := v.(int64)
+			return int32(i), ok
+		})
+		if err != nil {
+			return nil, err
+		}
+		return iceberggo.IsIn(ref, vals...), nil
+	case iceberggo.Int64Type:
+		vals, err := collectKeyValues(field, keys, func(v any) (int64, bool) {
+			i, ok := v.(int64)
+			return i, ok
+		})
+		if err != nil {
+			return nil, err
+		}
+		return iceberggo.IsIn(ref, vals...), nil
+	case iceberggo.StringType:
+		vals, err := collectKeyValues(field, keys, asString)
+		if err != nil {
+			return nil, err
+		}
+		return iceberggo.IsIn(ref, vals...), nil
+	case iceberggo.DateType:
+		vals, err := collectKeyValues(field, keys, func(v any) (iceberggo.Date, bool) {
+			i, ok := v.(int64)
+			return iceberggo.Date(i), ok
+		})
+		if err != nil {
+			return nil, err
+		}
+		return iceberggo.IsIn(ref, vals...), nil
+	case iceberggo.TimestampType, iceberggo.TimestampTzType:
+		vals, err := collectKeyValues(field, keys, func(v any) (iceberggo.Timestamp, bool) {
+			i, ok := v.(int64)
+			return iceberggo.Timestamp(i), ok
+		})
+		if err != nil {
+			return nil, err
+		}
+		return iceberggo.IsIn(ref, vals...), nil
+	case iceberggo.UUIDType:
+		vals, err := collectKeyValues(field, keys, func(v any) (uuid.UUID, bool) {
+			s, ok := asString(v)
+			if !ok {
+				return uuid.UUID{}, false
+			}
+			parsed, err := uuid.Parse(s)
+			return parsed, err == nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return iceberggo.IsIn(ref, vals...), nil
+	default:
+		// Fall back to OR-of-equality for less common key types.
+		preds := make([]iceberggo.BooleanExpression, 0, len(keys))
+		for _, key := range keys {
+			pred, err := equalityPredicate(field, key[0])
+			if err != nil {
+				return nil, err
+			}
+			preds = append(preds, pred)
+		}
+		return orAll(preds), nil
+	}
+}
+
+func collectKeyValues[T any](field iceberggo.NestedField, keys [][]any, convert func(any) (T, bool)) ([]T, error) {
+	vals := make([]T, 0, len(keys))
+	for _, key := range keys {
+		v, ok := convert(key[0])
+		if !ok {
+			return nil, predicateTypeErr(field, key[0])
+		}
+		vals = append(vals, v)
+	}
+	return vals, nil
+}

--- a/pkg/destination/iceberg/rows.go
+++ b/pkg/destination/iceberg/rows.go
@@ -701,6 +701,11 @@ func normalizeBoundValue(field iceberggo.NestedField, v any) (any, error) {
 	switch val := v.(type) {
 	case nil:
 		return nil, fmt.Errorf("iceberg: interval bound for column %q is nil", field.Name)
+	case *time.Time:
+		if val == nil {
+			return nil, fmt.Errorf("iceberg: interval bound for column %q is nil", field.Name)
+		}
+		return normalizeBoundValue(field, *val)
 	case time.Time:
 		if _, isDate := field.Type.(iceberggo.DateType); isDate {
 			return val.UTC().Truncate(24*time.Hour).Unix() / 86400, nil

--- a/pkg/destination/iceberg/rows_test.go
+++ b/pkg/destination/iceberg/rows_test.go
@@ -1,0 +1,106 @@
+package iceberg
+
+import (
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeRowKeyUnambiguous(t *testing.T) {
+	a, err := encodeRowKey([]any{"ab", "c"})
+	require.NoError(t, err)
+	b, err := encodeRowKey([]any{"a", "bc"})
+	require.NoError(t, err)
+	require.NotEqual(t, a, b, "composite string keys must not collide")
+
+	c, err := encodeRowKey([]any{int64(12), "3"})
+	require.NoError(t, err)
+	d, err := encodeRowKey([]any{int64(1), "23"})
+	require.NoError(t, err)
+	require.NotEqual(t, c, d)
+
+	_, err = encodeRowKey([]any{nil})
+	require.ErrorContains(t, err, "NULL")
+}
+
+func TestValuesEqual(t *testing.T) {
+	require.True(t, valuesEqual(nil, nil))
+	require.False(t, valuesEqual(nil, int64(1)))
+	require.False(t, valuesEqual(int64(1), nil))
+	require.True(t, valuesEqual(int64(5), int64(5)))
+	require.False(t, valuesEqual(int64(5), float64(5)))
+	require.True(t, valuesEqual([]byte{1, 2}, []byte{1, 2}))
+	require.False(t, valuesEqual([]byte{1, 2}, []byte{1, 3}))
+	require.True(t, valuesEqual([]any{int64(1), "a"}, []any{int64(1), "a"}))
+	require.False(t, valuesEqual([]any{int64(1)}, []any{int64(1), "a"}))
+	require.True(t, valuesEqual(decimalVal("1.5"), decimalVal("1.5")))
+}
+
+func TestCompareOrdered(t *testing.T) {
+	cmp, ok := compareOrdered(int64(1), int64(2))
+	require.True(t, ok)
+	require.Equal(t, -1, cmp)
+
+	cmp, ok = compareOrdered(2.5, int64(2))
+	require.True(t, ok)
+	require.Equal(t, 1, cmp)
+
+	cmp, ok = compareOrdered("a", "b")
+	require.True(t, ok)
+	require.Equal(t, -1, cmp)
+
+	cmp, ok = compareOrdered(decimalVal("10"), decimalVal("9.5"))
+	require.True(t, ok)
+	require.Equal(t, 1, cmp, "decimals must compare numerically, not lexically")
+
+	cmp, ok = compareOrdered(nil, int64(1))
+	require.True(t, ok)
+	require.Equal(t, -1, cmp)
+
+	_, ok = compareOrdered("a", int64(1))
+	require.False(t, ok)
+}
+
+func TestNormalizeDecimalString(t *testing.T) {
+	require.Equal(t, "1.5", normalizeDecimalString("1.50"))
+	require.Equal(t, "1", normalizeDecimalString("1.000"))
+	require.Equal(t, "0", normalizeDecimalString("0.0"))
+	require.Equal(t, "-2.25", normalizeDecimalString("-2.250"))
+	require.Equal(t, "42", normalizeDecimalString("42"))
+}
+
+func TestNormalizeBoundValue(t *testing.T) {
+	tsField := iceberggo.NestedField{Name: "ts", Type: iceberggo.TimestampTzType{}}
+	dateField := iceberggo.NestedField{Name: "d", Type: iceberggo.DateType{}}
+	intField := iceberggo.NestedField{Name: "i", Type: iceberggo.Int64Type{}}
+
+	at := time.Date(2026, 5, 1, 12, 30, 0, 0, time.UTC)
+	got, err := normalizeBoundValue(tsField, at)
+	require.NoError(t, err)
+	require.Equal(t, at.UnixMicro(), got)
+
+	got, err = normalizeBoundValue(dateField, "2026-05-01")
+	require.NoError(t, err)
+	require.Equal(t, at.Truncate(24*time.Hour).Unix()/86400, got)
+
+	got, err = normalizeBoundValue(dateField, at)
+	require.NoError(t, err)
+	require.Equal(t, at.Truncate(24*time.Hour).Unix()/86400, got)
+
+	got, err = normalizeBoundValue(intField, 42)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), got)
+
+	got, err = normalizeBoundValue(intField, "42")
+	require.NoError(t, err)
+	require.Equal(t, int64(42), got)
+
+	got, err = normalizeBoundValue(tsField, "2026-05-01T12:30:00Z")
+	require.NoError(t, err)
+	require.Equal(t, at.UnixMicro(), got)
+
+	_, err = normalizeBoundValue(intField, nil)
+	require.ErrorContains(t, err, "nil")
+}

--- a/pkg/destination/iceberg/rows_test.go
+++ b/pkg/destination/iceberg/rows_test.go
@@ -101,6 +101,16 @@ func TestNormalizeBoundValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, at.UnixMicro(), got)
 
+	// The strategy layer passes interval bounds as *time.Time; ensure the
+	// pointer is dereferenced rather than rejected as an unsupported type.
+	got, err = normalizeBoundValue(tsField, &at)
+	require.NoError(t, err)
+	require.Equal(t, at.UnixMicro(), got)
+
+	var nilTime *time.Time
+	_, err = normalizeBoundValue(tsField, nilTime)
+	require.ErrorContains(t, err, "nil")
+
 	_, err = normalizeBoundValue(intField, nil)
 	require.ErrorContains(t, err, "nil")
 }

--- a/pkg/destination/iceberg/spill.go
+++ b/pkg/destination/iceberg/spill.go
@@ -1,0 +1,540 @@
+package iceberg
+
+import (
+	"container/heap"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// spillRunRows bounds how many rows a spillSorter holds in memory before
+// writing a sorted run to disk. Memory usage is O(spillRunRows × row width)
+// regardless of how many rows pass through. Variable so tests can force
+// multi-run merges with small datasets.
+var spillRunRows = 32 * 1024
+
+// spillMergeFanIn caps how many runs are merged at once. Each open run holds
+// one read batch in memory, so without a cap the k-way merge would grow with
+// the number of runs; runs beyond the cap are first compacted into larger
+// sorted runs in multiple passes. Variable so tests can force multi-pass
+// merging.
+var spillMergeFanIn = 64
+
+const (
+	spillKeyColumn = "__ingestr_spill_key"
+	spillSeqColumn = "__ingestr_spill_seq"
+)
+
+// spillSorter externally sorts rows by their encoded primary key. Rows are
+// buffered up to spillRunRows, sorted, and flushed as Arrow IPC runs on disk;
+// iteration k-way merges the runs so rows stream back grouped by key in
+// arrival order within each key.
+type spillSorter struct {
+	schema   *arrow.Schema
+	runFile  *arrow.Schema
+	keyIdx   []int
+	tmpDir   string
+	runs     []string
+	buf      []spillRow
+	seq      int64
+	finished bool
+}
+
+type spillRow struct {
+	key  string
+	seq  int64
+	vals []any
+}
+
+// newSpillSorter sorts rows laid out per schema by the key columns.
+func newSpillSorter(schema *arrow.Schema, keyColumns []string) (*spillSorter, error) {
+	keyIdx := make([]int, len(keyColumns))
+	for i, col := range keyColumns {
+		indices := schema.FieldIndices(col)
+		if len(indices) == 0 {
+			return nil, fmt.Errorf("iceberg: sort key column %q not found", col)
+		}
+		keyIdx[i] = indices[0]
+	}
+
+	fields := append([]arrow.Field{}, schema.Fields()...)
+	fields = append(
+		fields,
+		arrow.Field{Name: spillKeyColumn, Type: arrow.BinaryTypes.String},
+		arrow.Field{Name: spillSeqColumn, Type: arrow.PrimitiveTypes.Int64},
+	)
+
+	return &spillSorter{
+		schema:  schema,
+		runFile: arrow.NewSchema(fields, nil),
+		keyIdx:  keyIdx,
+	}, nil
+}
+
+func (s *spillSorter) Add(vals []any) error {
+	if s.finished {
+		return errors.New("iceberg: spill sorter already finalized")
+	}
+	keyVals := make([]any, len(s.keyIdx))
+	for i, idx := range s.keyIdx {
+		if vals[idx] == nil {
+			return fmt.Errorf("primary key column %q contains NULL", s.schema.Field(idx).Name)
+		}
+		keyVals[i] = vals[idx]
+	}
+	key, err := encodeRowKey(keyVals)
+	if err != nil {
+		return err
+	}
+
+	s.buf = append(s.buf, spillRow{key: key, seq: s.seq, vals: vals})
+	s.seq++
+	if len(s.buf) >= spillRunRows {
+		return s.flushRun()
+	}
+	return nil
+}
+
+func (s *spillSorter) Len() int64 { return s.seq }
+
+func sortSpillRows(rows []spillRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if c := strings.Compare(rows[i].key, rows[j].key); c != 0 {
+			return c < 0
+		}
+		return rows[i].seq < rows[j].seq
+	})
+}
+
+func (s *spillSorter) flushRun() error {
+	if len(s.buf) == 0 {
+		return nil
+	}
+	sortSpillRows(s.buf)
+
+	if s.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "ingestr-iceberg-spill-")
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to create spill directory: %w", err)
+		}
+		s.tmpDir = dir
+	}
+
+	f, err := os.CreateTemp(s.tmpDir, "run-*.arrow")
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to create spill run: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	writer := ipc.NewWriter(f, ipc.WithSchema(s.runFile))
+	numFields := len(s.schema.Fields())
+	for start := 0; start < len(s.buf); start += batchBuildRows {
+		end := min(start+batchBuildRows, len(s.buf))
+		builder := array.NewRecordBuilder(memory.DefaultAllocator, s.runFile)
+		for _, row := range s.buf[start:end] {
+			for c := range numFields {
+				if err := appendValue(builder.Field(c), row.vals[c]); err != nil {
+					builder.Release()
+					_ = writer.Close()
+					return fmt.Errorf("iceberg: spill column %q: %w", s.schema.Field(c).Name, err)
+				}
+			}
+			builder.Field(numFields).(*array.StringBuilder).Append(row.key)
+			builder.Field(numFields + 1).(*array.Int64Builder).Append(row.seq)
+		}
+		batch := builder.NewRecordBatch()
+		builder.Release()
+		err := writer.Write(batch)
+		batch.Release()
+		if err != nil {
+			_ = writer.Close()
+			return fmt.Errorf("iceberg: failed to write spill run: %w", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("iceberg: failed to finish spill run: %w", err)
+	}
+
+	s.runs = append(s.runs, f.Name())
+	s.buf = s.buf[:0]
+	return nil
+}
+
+// finalize seals the sorter for iteration. When runs were spilled, the
+// remaining buffer becomes a final run and runs beyond the merge fan-in are
+// compacted into larger sorted runs; otherwise the buffer is sorted in place
+// and iterated from memory.
+func (s *spillSorter) finalize() error {
+	if s.finished {
+		return nil
+	}
+	if len(s.runs) > 0 {
+		if err := s.flushRun(); err != nil {
+			return err
+		}
+		for len(s.runs) > spillMergeFanIn {
+			merged, err := s.mergeRuns(s.runs[:spillMergeFanIn])
+			if err != nil {
+				return err
+			}
+			for _, run := range s.runs[:spillMergeFanIn] {
+				_ = os.Remove(run)
+			}
+			s.runs = append(s.runs[spillMergeFanIn:], merged)
+		}
+	} else {
+		sortSpillRows(s.buf)
+	}
+	s.finished = true
+	return nil
+}
+
+// mergeRuns k-way merges the given sorted runs into one larger sorted run.
+func (s *spillSorter) mergeRuns(runs []string) (path string, err error) {
+	numFields := len(s.schema.Fields())
+
+	var cursors runHeap
+	defer func() {
+		for _, c := range cursors {
+			c.Close()
+		}
+	}()
+	for _, run := range runs {
+		cursor, cErr := newRunCursor(run, numFields)
+		if cErr != nil {
+			return "", cErr
+		}
+		if cursor.advance() {
+			cursors = append(cursors, cursor)
+			continue
+		}
+		cErr = cursor.err
+		cursor.Close()
+		if cErr != nil {
+			return "", cErr
+		}
+	}
+	heap.Init(&cursors)
+
+	f, err := os.CreateTemp(s.tmpDir, "run-*.arrow")
+	if err != nil {
+		return "", fmt.Errorf("iceberg: failed to create spill run: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	writer := ipc.NewWriter(f, ipc.WithSchema(s.runFile))
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, s.runFile)
+	defer builder.Release()
+
+	rows := 0
+	flush := func() error {
+		if rows == 0 {
+			return nil
+		}
+		batch := builder.NewRecordBatch()
+		rows = 0
+		wErr := writer.Write(batch)
+		batch.Release()
+		return wErr
+	}
+
+	for len(cursors) > 0 {
+		cursor := cursors[0]
+		for c := range numFields {
+			if err := appendValue(builder.Field(c), cursor.vals[c]); err != nil {
+				_ = writer.Close()
+				return "", fmt.Errorf("iceberg: spill column %q: %w", s.schema.Field(c).Name, err)
+			}
+		}
+		builder.Field(numFields).(*array.StringBuilder).Append(cursor.key)
+		builder.Field(numFields + 1).(*array.Int64Builder).Append(cursor.seq)
+		rows++
+		if rows >= batchBuildRows {
+			if err := flush(); err != nil {
+				_ = writer.Close()
+				return "", fmt.Errorf("iceberg: failed to write spill run: %w", err)
+			}
+		}
+
+		if cursor.advance() {
+			heap.Fix(&cursors, 0)
+		} else {
+			heap.Pop(&cursors)
+			cErr := cursor.err
+			cursor.Close()
+			if cErr != nil {
+				_ = writer.Close()
+				return "", cErr
+			}
+		}
+	}
+	if err := flush(); err != nil {
+		_ = writer.Close()
+		return "", fmt.Errorf("iceberg: failed to write spill run: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("iceberg: failed to finish spill run: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func (s *spillSorter) Close() {
+	s.buf = nil
+	if s.tmpDir != "" {
+		_ = os.RemoveAll(s.tmpDir)
+		s.tmpDir = ""
+	}
+	s.runs = nil
+}
+
+// Iter returns a fresh cursor over all rows grouped by key. It may be called
+// multiple times; each call re-merges the spilled runs.
+func (s *spillSorter) Iter() (*spillIter, error) {
+	if err := s.finalize(); err != nil {
+		return nil, err
+	}
+	it := &spillIter{}
+	if len(s.runs) == 0 {
+		it.mem = s.buf
+		return it, nil
+	}
+
+	for _, run := range s.runs {
+		cursor, err := newRunCursor(run, len(s.schema.Fields()))
+		if err != nil {
+			it.Close()
+			return nil, err
+		}
+		if cursor.advance() {
+			it.heap = append(it.heap, cursor)
+		} else if cursor.err != nil {
+			err := cursor.err
+			cursor.Close()
+			it.Close()
+			return nil, err
+		} else {
+			cursor.Close()
+		}
+	}
+	heap.Init(&it.heap)
+	return it, nil
+}
+
+// spillIter iterates rows grouped by key:
+//
+//	for it.NextGroup() {
+//		key := it.Key()
+//		for it.NextRow() {
+//			row := it.Row()
+//		}
+//	}
+//	if err := it.Err(); err != nil { ... }
+type spillIter struct {
+	// in-memory mode
+	mem []spillRow
+	pos int
+
+	// spilled mode
+	heap runHeap
+
+	groupKey string
+	current  []any
+	started  bool
+	err      error
+}
+
+func (it *spillIter) Close() {
+	for _, c := range it.heap {
+		c.Close()
+	}
+	it.heap = nil
+	it.mem = nil
+}
+
+func (it *spillIter) Err() error { return it.err }
+
+func (it *spillIter) Key() string { return it.groupKey }
+
+func (it *spillIter) Row() []any { return it.current }
+
+// NextGroup advances to the next key group, skipping any unconsumed rows of
+// the current group.
+func (it *spillIter) NextGroup() bool {
+	if it.err != nil {
+		return false
+	}
+	if it.started {
+		for it.hasNext() && it.peekKey() == it.groupKey {
+			if !it.pop() {
+				return false
+			}
+		}
+	} else {
+		it.started = true
+	}
+	if it.err != nil || !it.hasNext() {
+		return false
+	}
+	it.groupKey = it.peekKey()
+	return true
+}
+
+// NextRow advances within the current group.
+func (it *spillIter) NextRow() bool {
+	if it.err != nil {
+		return false
+	}
+	if !it.hasNext() || it.peekKey() != it.groupKey {
+		return false
+	}
+	return it.pop()
+}
+
+func (it *spillIter) hasNext() bool {
+	if it.mem != nil || it.heap == nil {
+		return it.pos < len(it.mem)
+	}
+	return len(it.heap) > 0
+}
+
+func (it *spillIter) peekKey() string {
+	if it.mem != nil || it.heap == nil {
+		if it.pos < len(it.mem) {
+			return it.mem[it.pos].key
+		}
+		return ""
+	}
+	if len(it.heap) > 0 {
+		return it.heap[0].key
+	}
+	return ""
+}
+
+func (it *spillIter) pop() bool {
+	if it.mem != nil || it.heap == nil {
+		if it.pos >= len(it.mem) {
+			return false
+		}
+		it.current = it.mem[it.pos].vals
+		it.pos++
+		return true
+	}
+
+	if len(it.heap) == 0 {
+		return false
+	}
+	cursor := it.heap[0]
+	it.current = cursor.vals
+	if cursor.advance() {
+		heap.Fix(&it.heap, 0)
+	} else {
+		heap.Pop(&it.heap)
+		if cursor.err != nil {
+			it.err = cursor.err
+		}
+		cursor.Close()
+	}
+	return true
+}
+
+// runCursor streams one sorted run file.
+type runCursor struct {
+	file      *os.File
+	rdr       *ipc.Reader
+	batch     arrow.RecordBatch
+	batchPos  int
+	numFields int
+
+	key  string
+	seq  int64
+	vals []any
+	err  error
+}
+
+func newRunCursor(path string, numFields int) (*runCursor, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to open spill run: %w", err)
+	}
+	rdr, err := ipc.NewReader(f)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("iceberg: failed to read spill run: %w", err)
+	}
+	return &runCursor{file: f, rdr: rdr, numFields: numFields}, nil
+}
+
+func (c *runCursor) Close() {
+	if c.batch != nil {
+		c.batch.Release()
+		c.batch = nil
+	}
+	if c.rdr != nil {
+		c.rdr.Release()
+		c.rdr = nil
+	}
+	if c.file != nil {
+		_ = c.file.Close()
+		c.file = nil
+	}
+}
+
+// advance loads the next row into key/seq/vals. Returns false at the end of
+// the run or on error (recorded in c.err).
+func (c *runCursor) advance() bool {
+	for c.batch == nil || c.batchPos >= int(c.batch.NumRows()) {
+		if c.batch != nil {
+			c.batch.Release()
+			c.batch = nil
+		}
+		if !c.rdr.Next() {
+			c.err = c.rdr.Err()
+			return false
+		}
+		c.batch = c.rdr.RecordBatch()
+		c.batch.Retain()
+		c.batchPos = 0
+	}
+
+	row := make([]any, c.numFields)
+	for i := range c.numFields {
+		v, err := rowValue(c.batch.Column(i), c.batchPos)
+		if err != nil {
+			c.err = fmt.Errorf("iceberg: failed to read spill run: %w", err)
+			return false
+		}
+		row[i] = v
+	}
+	c.key = c.batch.Column(c.numFields).(*array.String).Value(c.batchPos)
+	c.seq = c.batch.Column(c.numFields + 1).(*array.Int64).Value(c.batchPos)
+	c.vals = row
+	c.batchPos++
+	return true
+}
+
+type runHeap []*runCursor
+
+func (h runHeap) Len() int { return len(h) }
+func (h runHeap) Less(i, j int) bool {
+	if c := strings.Compare(h[i].key, h[j].key); c != 0 {
+		return c < 0
+	}
+	return h[i].seq < h[j].seq
+}
+func (h runHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *runHeap) Push(x any)   { *h = append(*h, x.(*runCursor)) }
+func (h *runHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	return item
+}

--- a/pkg/destination/iceberg/spill_test.go
+++ b/pkg/destination/iceberg/spill_test.go
@@ -1,0 +1,187 @@
+package iceberg
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+)
+
+func withSpillRunRows(t *testing.T, n int) {
+	t.Helper()
+	prev := spillRunRows
+	spillRunRows = n
+	t.Cleanup(func() { spillRunRows = prev })
+}
+
+func spillTestSchema() *arrow.Schema {
+	return arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+}
+
+func TestSpillSorterMultiRunGroups(t *testing.T) {
+	withSpillRunRows(t, 4)
+
+	sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
+	require.NoError(t, err)
+	defer sorter.Close()
+
+	// 18 rows across 3 keys, duplicates interleaved so every run contains a
+	// mix and groups span run boundaries.
+	for i := range 18 {
+		key := int64(i % 3)
+		require.NoError(t, sorter.Add([]any{key, fmt.Sprintf("k%d-v%02d", key, i)}))
+	}
+	require.EqualValues(t, 18, sorter.Len())
+
+	readGroups := func() map[int64][]string {
+		it, err := sorter.Iter()
+		require.NoError(t, err)
+		defer it.Close()
+
+		groups := make(map[int64][]string)
+		var order []int64
+		for it.NextGroup() {
+			var key int64
+			first := true
+			for it.NextRow() {
+				row := it.Row()
+				if first {
+					key = row[0].(int64)
+					order = append(order, key)
+					first = false
+				}
+				groups[key] = append(groups[key], row[1].(string))
+			}
+		}
+		require.NoError(t, it.Err())
+		require.Len(t, order, 3, "each key must appear as exactly one group")
+		return groups
+	}
+
+	groups := readGroups()
+	for key := int64(0); key < 3; key++ {
+		require.Len(t, groups[key], 6)
+		for i := 1; i < len(groups[key]); i++ {
+			require.Less(t, groups[key][i-1], groups[key][i], "rows within a group must keep arrival order")
+		}
+	}
+
+	// Iter must be repeatable (the row-delta paths run two passes).
+	again := readGroups()
+	require.Equal(t, groups, again)
+
+	require.Greater(t, len(sorter.runs), 1, "test must exercise multi-run merging")
+	tmpDir := sorter.tmpDir
+	sorter.Close()
+	_, err = os.Stat(tmpDir)
+	require.True(t, os.IsNotExist(err), "Close must remove spill files")
+}
+
+func TestSpillSorterInMemorySmallInput(t *testing.T) {
+	sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
+	require.NoError(t, err)
+	defer sorter.Close()
+
+	require.NoError(t, sorter.Add([]any{int64(2), "b"}))
+	require.NoError(t, sorter.Add([]any{int64(1), "a"}))
+	require.NoError(t, sorter.Add([]any{int64(2), "b2"}))
+
+	it, err := sorter.Iter()
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.Empty(t, sorter.runs, "small inputs must not spill")
+
+	var keys []int64
+	var rows []string
+	for it.NextGroup() {
+		for it.NextRow() {
+			row := it.Row()
+			keys = append(keys, row[0].(int64))
+			rows = append(rows, row[1].(string))
+		}
+	}
+	require.NoError(t, it.Err())
+	require.Equal(t, []int64{1, 2, 2}, keys)
+	require.Equal(t, []string{"a", "b", "b2"}, rows)
+}
+
+func TestSpillSorterMultiPassMerge(t *testing.T) {
+	withSpillRunRows(t, 2)
+	prevFanIn := spillMergeFanIn
+	spillMergeFanIn = 2
+	t.Cleanup(func() { spillMergeFanIn = prevFanIn })
+
+	sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
+	require.NoError(t, err)
+	defer sorter.Close()
+
+	// 24 rows over 6 keys in 12 runs of 2; fan-in 2 forces several compaction
+	// passes before the final merge.
+	for i := range 24 {
+		key := int64(i % 6)
+		require.NoError(t, sorter.Add([]any{key, fmt.Sprintf("k%d-v%02d", key, i)}))
+	}
+
+	it, err := sorter.Iter()
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.LessOrEqual(t, len(sorter.runs), 2, "finalize must compact runs down to the fan-in limit")
+
+	groups := make(map[int64][]string)
+	prevKey := ""
+	for it.NextGroup() {
+		require.Greater(t, it.Key(), prevKey, "groups must arrive in key order")
+		prevKey = it.Key()
+		for it.NextRow() {
+			row := it.Row()
+			groups[row[0].(int64)] = append(groups[row[0].(int64)], row[1].(string))
+		}
+	}
+	require.NoError(t, it.Err())
+	require.Len(t, groups, 6)
+	for key := int64(0); key < 6; key++ {
+		require.Len(t, groups[key], 4)
+		for i := 1; i < len(groups[key]); i++ {
+			require.Less(t, groups[key][i-1], groups[key][i], "arrival order must survive multi-pass merging")
+		}
+	}
+}
+
+func TestSpillSorterRejectsNullKeys(t *testing.T) {
+	sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
+	require.NoError(t, err)
+	defer sorter.Close()
+
+	err = sorter.Add([]any{nil, "x"})
+	require.ErrorContains(t, err, "contains NULL")
+}
+
+func TestSpillSorterGroupSkipping(t *testing.T) {
+	sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
+	require.NoError(t, err)
+	defer sorter.Close()
+
+	require.NoError(t, sorter.Add([]any{int64(1), "a1"}))
+	require.NoError(t, sorter.Add([]any{int64(1), "a2"}))
+	require.NoError(t, sorter.Add([]any{int64(2), "b1"}))
+
+	it, err := sorter.Iter()
+	require.NoError(t, err)
+	defer it.Close()
+
+	// Consume no rows from group 1; NextGroup must still land on group 2.
+	require.True(t, it.NextGroup())
+	require.True(t, it.NextGroup())
+	require.True(t, it.NextRow())
+	require.Equal(t, "b1", it.Row()[1])
+	require.False(t, it.NextRow())
+	require.False(t, it.NextGroup())
+	require.NoError(t, it.Err())
+}

--- a/pkg/destination/iceberg/strategies.go
+++ b/pkg/destination/iceberg/strategies.go
@@ -203,6 +203,9 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 				break
 			}
 		}
+		if incrementalIdx < 0 {
+			return fmt.Errorf("iceberg: incremental key column %q not found in staging table %s", opts.IncrementalKey, opts.StagingTable)
+		}
 
 		produce = func(sink func(arrow.RecordBatch) error) error {
 			it, err := sorter.Iter()

--- a/pkg/destination/iceberg/strategies.go
+++ b/pkg/destination/iceberg/strategies.go
@@ -88,7 +88,7 @@ func (d *Destination) mergeCopyOnWrite(ctx context.Context, target, staging *ice
 		return nil
 	}
 
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable)
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable, true)
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func (d *Destination) scd2CopyOnWrite(ctx context.Context, target, staging *iceb
 		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
 	}
 
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, "", opts.StagingTable)
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable, false)
 	if err != nil {
 		return err
 	}
@@ -525,19 +525,22 @@ func incrementalKeyIndex(columns []string, incrementalKey, stagingTable string) 
 // the latest change by LSN wins (with the latest non-delete tracked
 // separately); otherwise the highest incremental key value wins, with arrival
 // order breaking ties.
-func dedupeStagingRows(staging *scannedTable, primaryKeys []string, incrementalKey, stagingTable string) (*dedupedStaging, error) {
+func dedupeStagingRows(staging *scannedTable, primaryKeys []string, incrementalKey, stagingTable string, requireIncrementalKey bool) (*dedupedStaging, error) {
 	out := &dedupedStaging{
 		entries: make(map[string]*mergeEntry),
 		isCDC:   staging.HasColumn(destination.CDCDeletedColumn),
 	}
 
 	incrementalIdx := -1
-	if !out.isCDC {
+	if !out.isCDC && incrementalKey != "" {
 		idx, err := incrementalKeyIndex(staging.Columns, incrementalKey, stagingTable)
 		if err != nil {
-			return nil, err
+			if requireIncrementalKey {
+				return nil, err
+			}
+		} else {
+			incrementalIdx = idx
 		}
-		incrementalIdx = idx
 	}
 
 	for _, row := range staging.Rows {

--- a/pkg/destination/iceberg/strategies.go
+++ b/pkg/destination/iceberg/strategies.go
@@ -88,7 +88,7 @@ func (d *Destination) mergeCopyOnWrite(ctx context.Context, target, staging *ice
 		return nil
 	}
 
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey)
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable)
 	if err != nil {
 		return err
 	}
@@ -196,15 +196,9 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 			return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
 		}
 
-		incrementalIdx := -1
-		for i, col := range stagingCols {
-			if col == opts.IncrementalKey {
-				incrementalIdx = i
-				break
-			}
-		}
-		if incrementalIdx < 0 {
-			return fmt.Errorf("iceberg: incremental key column %q not found in staging table %s", opts.IncrementalKey, opts.StagingTable)
+		incrementalIdx, err := incrementalKeyIndex(stagingCols, opts.IncrementalKey, opts.StagingTable)
+		if err != nil {
+			return err
 		}
 
 		produce = func(sink func(arrow.RecordBatch) error) error {
@@ -322,7 +316,7 @@ func (d *Destination) scd2CopyOnWrite(ctx context.Context, target, staging *iceb
 		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
 	}
 
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, "")
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, "", opts.StagingTable)
 	if err != nil {
 		return err
 	}
@@ -515,21 +509,35 @@ func requireColumns(rows *scannedTable, columns []string, table string) error {
 	return nil
 }
 
+func incrementalKeyIndex(columns []string, incrementalKey, stagingTable string) (int, error) {
+	if incrementalKey == "" {
+		return -1, nil
+	}
+	for i, col := range columns {
+		if col == incrementalKey {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("iceberg: incremental key column %q not found in staging table %s", incrementalKey, stagingTable)
+}
+
 // dedupeStagingRows keeps a single winning row per primary key. For CDC data
 // the latest change by LSN wins (with the latest non-delete tracked
 // separately); otherwise the highest incremental key value wins, with arrival
 // order breaking ties.
-func dedupeStagingRows(staging *scannedTable, primaryKeys []string, incrementalKey string) (*dedupedStaging, error) {
+func dedupeStagingRows(staging *scannedTable, primaryKeys []string, incrementalKey, stagingTable string) (*dedupedStaging, error) {
 	out := &dedupedStaging{
 		entries: make(map[string]*mergeEntry),
 		isCDC:   staging.HasColumn(destination.CDCDeletedColumn),
 	}
 
 	incrementalIdx := -1
-	if !out.isCDC && incrementalKey != "" {
-		if idx, ok := staging.ColIdx[incrementalKey]; ok {
-			incrementalIdx = idx
+	if !out.isCDC {
+		idx, err := incrementalKeyIndex(staging.Columns, incrementalKey, stagingTable)
+		if err != nil {
+			return nil, err
 		}
+		incrementalIdx = idx
 	}
 
 	for _, row := range staging.Rows {

--- a/pkg/destination/iceberg/strategies.go
+++ b/pkg/destination/iceberg/strategies.go
@@ -1,0 +1,749 @@
+package iceberg
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+)
+
+// The Iceberg destination implements the incremental strategies natively.
+// Staging tables are regular Iceberg tables. merge and scd2 default to
+// merge-on-read row deltas (see row_delta.go) which stream with bounded
+// memory; delete+insert streams into a copy-on-write overwrite whose filter
+// is just the interval bounds. The copy-on-write join paths in this file
+// remain for the cases that must read matched target rows (CDC merges,
+// destination-only columns) or where equality deletes cannot apply — they
+// materialize the staged rows and the target rows they affect in memory.
+
+// mergeEntry tracks the winning staging row(s) per primary key.
+type mergeEntry struct {
+	keyValues []any
+
+	// latest is the winning row overall: for CDC ordered by LSN (deletes win
+	// ties), otherwise by incremental key (arrival order breaks ties).
+	latest         []any
+	latestLSN      string
+	latestDeleted  bool
+	incrementalVal any
+
+	// latestNonDeleted is the newest non-delete change (CDC only). Updates to
+	// existing rows use it so a trailing delete doesn't clobber column values.
+	latestNonDeleted    []any
+	latestNonDeletedLSN string
+}
+
+type dedupedStaging struct {
+	keys    []string
+	entries map[string]*mergeEntry
+	isCDC   bool
+}
+
+func (d *Destination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	if len(opts.PrimaryKeys) == 0 {
+		return errors.New("iceberg: merge requires at least one primary key")
+	}
+
+	target, err := d.loadIcebergTable(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	staging, err := d.loadIcebergTable(ctx, opts.StagingTable)
+	if err != nil {
+		return err
+	}
+
+	// The row-delta path streams with bounded memory but replaces matched
+	// rows wholesale; fall back to the copy-on-write join when old row values
+	// must be read (CDC delete handling, destination-only columns) or when
+	// equality deletes cannot apply (v1 tables, partition keys outside the
+	// primary key, explicit write.merge.mode=copy-on-write).
+	_, isCDC := staging.Schema().FindFieldByName(destination.CDCDeletedColumn)
+	if !isCDC && stagingCoversTarget(target.Schema(), staging.Schema()) && useRowDeltaMerge(target, opts.PrimaryKeys) {
+		return d.mergeRowDelta(ctx, target, staging, opts)
+	}
+	return d.mergeCopyOnWrite(ctx, target, staging, opts)
+}
+
+func (d *Destination) mergeCopyOnWrite(ctx context.Context, target, staging *icebergtable.Table, opts destination.MergeOptions) error {
+	stagingRows, err := scanTableRows(ctx, staging, iceberggo.AlwaysTrue{})
+	if err != nil {
+		return err
+	}
+	if err := requireColumns(stagingRows, opts.PrimaryKeys, opts.StagingTable); err != nil {
+		return err
+	}
+	if len(stagingRows.Rows) == 0 {
+		return nil
+	}
+
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey)
+	if err != nil {
+		return err
+	}
+
+	keyValues := make([][]any, 0, len(deduped.keys))
+	for _, key := range deduped.keys {
+		keyValues = append(keyValues, deduped.entries[key].keyValues)
+	}
+	filter, err := keyMatchFilter(target.Schema(), opts.PrimaryKeys, keyValues)
+	if err != nil {
+		return err
+	}
+
+	targetRows, err := scanTableRows(ctx, target, filter)
+	if err != nil {
+		return err
+	}
+	existingByKey, err := indexRowsByKey(targetRows, opts.PrimaryKeys)
+	if err != nil {
+		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
+	}
+
+	outRows := make([][]any, 0, len(deduped.keys))
+	for _, key := range deduped.keys {
+		entry := deduped.entries[key]
+		existing := lastRow(existingByKey[key])
+		var row []any
+		if deduped.isCDC {
+			row, err = composeCDCMergeRow(targetRows.Columns, stagingRows, entry, existing)
+			if err != nil {
+				return err
+			}
+		} else {
+			row = projectRow(targetRows.Columns, stagingRows, entry.latest, existing)
+		}
+		outRows = append(outRows, row)
+	}
+
+	config.Debug("[ICEBERG MERGE] Overwriting %d key(s) in %s", len(deduped.keys), opts.TargetTable)
+	return d.overwriteRows(ctx, target, outRows, filter, "merge")
+}
+
+func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	if opts.IncrementalKey == "" {
+		return errors.New("iceberg: delete+insert requires an incremental key")
+	}
+
+	target, err := d.loadIcebergTable(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	staging, err := d.loadIcebergTable(ctx, opts.StagingTable)
+	if err != nil {
+		return err
+	}
+
+	field, ok := target.Schema().FindFieldByName(opts.IncrementalKey)
+	if !ok {
+		return fmt.Errorf("iceberg: incremental key column %q not found in table %s", opts.IncrementalKey, opts.TargetTable)
+	}
+	start, err := normalizeBoundValue(field, opts.IntervalStart)
+	if err != nil {
+		return err
+	}
+	end, err := normalizeBoundValue(field, opts.IntervalEnd)
+	if err != nil {
+		return err
+	}
+	lower, err := columnPredicate(opGreaterThanEqual, field, start)
+	if err != nil {
+		return err
+	}
+	upper, err := columnPredicate(opLessThanEqual, field, end)
+	if err != nil {
+		return err
+	}
+	filter := iceberggo.NewAnd(lower, upper)
+
+	writeSchema, err := tableWriteSchema(target)
+	if err != nil {
+		return err
+	}
+	stagingSchema, err := tableWriteSchema(staging)
+	if err != nil {
+		return err
+	}
+	stagingCols := arrowSchemaColumnNames(stagingSchema)
+	projection := newRowProjection(writeSchema, stagingCols)
+
+	// The staging rows stream straight into the overwrite: iceberg-go rewrites
+	// the files matching the interval filter one at a time, so memory stays
+	// bounded regardless of increment size. With primary keys, rows pass
+	// through a disk-backed sort first so duplicates collapse to one row each.
+	var produce func(sink func(arrow.RecordBatch) error) error
+	if len(opts.PrimaryKeys) > 0 {
+		sorter, err := newSpillSorter(stagingSchema, opts.PrimaryKeys)
+		if err != nil {
+			return err
+		}
+		defer sorter.Close()
+		if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, sorter.Add); err != nil {
+			return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
+		}
+
+		incrementalIdx := -1
+		for i, col := range stagingCols {
+			if col == opts.IncrementalKey {
+				incrementalIdx = i
+				break
+			}
+		}
+
+		produce = func(sink func(arrow.RecordBatch) error) error {
+			it, err := sorter.Iter()
+			if err != nil {
+				return err
+			}
+			defer it.Close()
+			emitter := newBatchEmitter(projection, sink)
+			defer emitter.release()
+			for it.NextGroup() {
+				if err := emitter.add(selectGroupWinner(it, incrementalIdx)); err != nil {
+					return err
+				}
+			}
+			if err := it.Err(); err != nil {
+				return err
+			}
+			return emitter.flushBatch()
+		}
+	} else {
+		produce = func(sink func(arrow.RecordBatch) error) error {
+			emitter := newBatchEmitter(projection, sink)
+			defer emitter.release()
+			if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, emitter.add); err != nil {
+				return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
+			}
+			return emitter.flushBatch()
+		}
+	}
+
+	config.Debug("[ICEBERG DELETE+INSERT] Replacing interval [%v, %v] on %q from %s", opts.IntervalStart, opts.IntervalEnd, opts.IncrementalKey, opts.StagingTable)
+
+	reader := streamingReader(writeSchema, produce)
+	defer reader.Release()
+
+	txn := target.NewTransaction()
+	if err := txn.Overwrite(ctx, reader, snapshotProps("delete+insert"), icebergtable.WithOverwriteFilter(filter)); err != nil {
+		return fmt.Errorf("iceberg: delete+insert failed on table %s: %w", opts.TargetTable, err)
+	}
+	if err := reader.Err(); err != nil {
+		return fmt.Errorf("iceberg: delete+insert failed on table %s: %w", opts.TargetTable, err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to commit delete+insert on table %s: %w", opts.TargetTable, err)
+	}
+	return nil
+}
+
+func (d *Destination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	if len(opts.PrimaryKeys) == 0 {
+		return errors.New("iceberg: scd2 requires at least one primary key")
+	}
+
+	target, err := d.loadIcebergTable(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	staging, err := d.loadIcebergTable(ctx, opts.StagingTable)
+	if err != nil {
+		return err
+	}
+
+	required := append([]string{}, opts.PrimaryKeys...)
+	required = append(required, destination.SCD2ValidFromColumn)
+	for _, col := range required {
+		if _, ok := staging.Schema().FindFieldByName(col); !ok {
+			return fmt.Errorf("iceberg: column %q not found in table %s", col, opts.StagingTable)
+		}
+	}
+	for _, col := range []string{destination.SCD2IsCurrentColumn, destination.SCD2ValidToColumn} {
+		if _, ok := target.Schema().FindFieldByName(col); !ok {
+			return fmt.Errorf("iceberg: column %q not found in table %s", col, opts.TargetTable)
+		}
+	}
+
+	// Closing a row only rewrites the current version, so the equality delete
+	// key is (primary keys, _scd_is_current): historical rows keep their
+	// older sequence numbers untouched.
+	deleteKeyColumns := append(append([]string{}, opts.PrimaryKeys...), destination.SCD2IsCurrentColumn)
+	if useRowDeltaMerge(target, deleteKeyColumns) {
+		return d.scd2RowDelta(ctx, target, staging, opts, deleteKeyColumns)
+	}
+	return d.scd2CopyOnWrite(ctx, target, staging, opts)
+}
+
+func (d *Destination) scd2CopyOnWrite(ctx context.Context, target, staging *icebergtable.Table, opts destination.SCD2Options) error {
+	stagingRows, err := scanTableRows(ctx, staging, iceberggo.AlwaysTrue{})
+	if err != nil {
+		return err
+	}
+	required := append([]string{}, opts.PrimaryKeys...)
+	required = append(required, destination.SCD2ValidFromColumn)
+	if err := requireColumns(stagingRows, required, opts.StagingTable); err != nil {
+		return err
+	}
+
+	isCurrentField, ok := target.Schema().FindFieldByName(destination.SCD2IsCurrentColumn)
+	if !ok {
+		return fmt.Errorf("iceberg: column %q not found in table %s", destination.SCD2IsCurrentColumn, opts.TargetTable)
+	}
+	currentFilter, err := equalityPredicate(isCurrentField, true)
+	if err != nil {
+		return err
+	}
+	targetRows, err := scanTableRows(ctx, target, currentFilter)
+	if err != nil {
+		return err
+	}
+	currentByKey, err := indexRowsByKey(targetRows, opts.PrimaryKeys)
+	if err != nil {
+		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
+	}
+
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, "")
+	if err != nil {
+		return err
+	}
+
+	changeCols := scd2ChangeColumns(opts, stagingRows, targetRows)
+	validToIdx, hasValidTo := targetRows.ColIdx[destination.SCD2ValidToColumn]
+	isCurrentIdx := targetRows.ColIdx[destination.SCD2IsCurrentColumn]
+	if !hasValidTo {
+		return fmt.Errorf("iceberg: column %q not found in table %s", destination.SCD2ValidToColumn, opts.TargetTable)
+	}
+
+	var outRows [][]any
+	var affectedKeys [][]any
+	for _, key := range deduped.keys {
+		entry := deduped.entries[key]
+		current := currentByKey[key]
+		if len(current) == 0 {
+			outRows = append(outRows, projectRow(targetRows.Columns, stagingRows, entry.latest, nil))
+			continue
+		}
+
+		if !scd2RowChanged(changeCols, stagingRows, entry.latest, targetRows, current[len(current)-1]) {
+			continue
+		}
+
+		affectedKeys = append(affectedKeys, entry.keyValues)
+		validFrom := stagingRows.Value(entry.latest, destination.SCD2ValidFromColumn)
+		for _, cur := range current {
+			closed := append([]any(nil), cur...)
+			closed[validToIdx] = validFrom
+			closed[isCurrentIdx] = false
+			outRows = append(outRows, closed)
+		}
+		outRows = append(outRows, projectRow(targetRows.Columns, stagingRows, entry.latest, nil))
+	}
+
+	if opts.IncrementalKey == "" {
+		softDeleteAt := opts.Timestamp.UTC().UnixMicro()
+		for _, key := range targetRows.keyOrder(opts.PrimaryKeys) {
+			if _, inStaging := deduped.entries[key]; inStaging {
+				continue
+			}
+			current := currentByKey[key]
+			if len(current) == 0 {
+				continue
+			}
+			keyVals, err := rowKeyValues(targetRows, current[0], opts.PrimaryKeys)
+			if err != nil {
+				return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
+			}
+			affectedKeys = append(affectedKeys, keyVals)
+			for _, cur := range current {
+				closed := append([]any(nil), cur...)
+				closed[validToIdx] = softDeleteAt
+				closed[isCurrentIdx] = false
+				outRows = append(outRows, closed)
+			}
+		}
+	}
+
+	if len(outRows) == 0 {
+		return nil
+	}
+
+	config.Debug("[ICEBERG SCD2] Closing %d key(s), writing %d row(s) to %s", len(affectedKeys), len(outRows), opts.TargetTable)
+	if len(affectedKeys) == 0 {
+		return d.appendRows(ctx, target, outRows, "scd2")
+	}
+
+	keyFilter, err := keyMatchFilter(target.Schema(), opts.PrimaryKeys, affectedKeys)
+	if err != nil {
+		return err
+	}
+	filter := iceberggo.NewAnd(currentFilter, keyFilter)
+	return d.overwriteRows(ctx, target, outRows, filter, "scd2")
+}
+
+// TruncateTable empties the table in place, keeping schema, partition spec and
+// table history intact.
+func (d *Destination) TruncateTable(ctx context.Context, table string) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	tbl, err := d.loadIcebergTable(ctx, table)
+	if err != nil {
+		return err
+	}
+	if tbl.CurrentSnapshot() == nil {
+		return nil
+	}
+	txn := tbl.NewTransaction()
+	if err := txn.Delete(ctx, iceberggo.AlwaysTrue{}, snapshotProps("truncate")); err != nil {
+		return fmt.Errorf("iceberg: failed to truncate table %s: %w", table, err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to commit truncate of table %s: %w", table, err)
+	}
+	return nil
+}
+
+func (d *Destination) loadIcebergTable(ctx context.Context, table string) (*icebergtable.Table, error) {
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return nil, err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to load table %s: %w", table, err)
+	}
+	return tbl, nil
+}
+
+func snapshotProps(operation string) iceberggo.Properties {
+	return iceberggo.Properties{
+		"ingestr.destination": "iceberg",
+		"ingestr.operation":   operation,
+	}
+}
+
+// overwriteRows atomically deletes the rows matching filter and appends rows
+// in a single snapshot commit.
+func (d *Destination) overwriteRows(ctx context.Context, tbl *icebergtable.Table, rows [][]any, filter iceberggo.BooleanExpression, operation string) error {
+	writeSchema, err := tableWriteSchema(tbl)
+	if err != nil {
+		return err
+	}
+	batches, err := buildRecordBatches(writeSchema, rows)
+	if err != nil {
+		return err
+	}
+	defer releaseBatches(batches)
+
+	rdr, err := array.NewRecordReader(writeSchema, batches)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to create record reader: %w", err)
+	}
+	defer rdr.Release()
+
+	txn := tbl.NewTransaction()
+	if err := txn.Overwrite(ctx, rdr, snapshotProps(operation), icebergtable.WithOverwriteFilter(filter)); err != nil {
+		return fmt.Errorf("iceberg: %s failed on table %s: %w", operation, tbl.Identifier(), err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
+	}
+	return nil
+}
+
+func (d *Destination) appendRows(ctx context.Context, tbl *icebergtable.Table, rows [][]any, operation string) error {
+	writeSchema, err := tableWriteSchema(tbl)
+	if err != nil {
+		return err
+	}
+	batches, err := buildRecordBatches(writeSchema, rows)
+	if err != nil {
+		return err
+	}
+	defer releaseBatches(batches)
+
+	rdr, err := array.NewRecordReader(writeSchema, batches)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to create record reader: %w", err)
+	}
+	defer rdr.Release()
+
+	txn := tbl.NewTransaction()
+	if err := txn.Append(ctx, rdr, snapshotProps(operation)); err != nil {
+		return fmt.Errorf("iceberg: %s failed on table %s: %w", operation, tbl.Identifier(), err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
+	}
+	return nil
+}
+
+func tableWriteSchema(tbl *icebergtable.Table) (*arrow.Schema, error) {
+	tableSchema, err := tableSchemaFromIceberg(strings.Join(tbl.Identifier(), "."), tbl.Schema())
+	if err != nil {
+		return nil, err
+	}
+	return icebergArrowSchema(tableSchema), nil
+}
+
+func requireColumns(rows *scannedTable, columns []string, table string) error {
+	for _, col := range columns {
+		if !rows.HasColumn(col) {
+			return fmt.Errorf("iceberg: column %q not found in table %s", col, table)
+		}
+	}
+	return nil
+}
+
+// dedupeStagingRows keeps a single winning row per primary key. For CDC data
+// the latest change by LSN wins (with the latest non-delete tracked
+// separately); otherwise the highest incremental key value wins, with arrival
+// order breaking ties.
+func dedupeStagingRows(staging *scannedTable, primaryKeys []string, incrementalKey string) (*dedupedStaging, error) {
+	out := &dedupedStaging{
+		entries: make(map[string]*mergeEntry),
+		isCDC:   staging.HasColumn(destination.CDCDeletedColumn),
+	}
+
+	incrementalIdx := -1
+	if !out.isCDC && incrementalKey != "" {
+		if idx, ok := staging.ColIdx[incrementalKey]; ok {
+			incrementalIdx = idx
+		}
+	}
+
+	for _, row := range staging.Rows {
+		keyValues, err := rowKeyValues(staging, row, primaryKeys)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: staging data: %w", err)
+		}
+		key, err := encodeRowKey(keyValues)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: staging data: %w", err)
+		}
+
+		entry, ok := out.entries[key]
+		if !ok {
+			entry = &mergeEntry{keyValues: keyValues}
+			out.entries[key] = entry
+			out.keys = append(out.keys, key)
+		}
+
+		switch {
+		case out.isCDC:
+			lsn, _ := asString(staging.Value(row, destination.CDCLSNColumn))
+			deleted, _ := staging.Value(row, destination.CDCDeletedColumn).(bool)
+			if entry.latest == nil || destination.CDCSupersedes(lsn, deleted, entry.latestLSN, entry.latestDeleted) {
+				entry.latest = row
+				entry.latestLSN = lsn
+				entry.latestDeleted = deleted
+			}
+			if !deleted && (entry.latestNonDeleted == nil || lsn >= entry.latestNonDeletedLSN) {
+				entry.latestNonDeleted = row
+				entry.latestNonDeletedLSN = lsn
+			}
+		case incrementalIdx >= 0:
+			if entry.latest == nil {
+				entry.latest = row
+				entry.incrementalVal = row[incrementalIdx]
+				continue
+			}
+			cmp, comparable := compareOrdered(row[incrementalIdx], entry.incrementalVal)
+			if !comparable || cmp >= 0 {
+				entry.latest = row
+				entry.incrementalVal = row[incrementalIdx]
+			}
+		default:
+			entry.latest = row
+		}
+	}
+	return out, nil
+}
+
+func rowKeyValues(rows *scannedTable, row []any, primaryKeys []string) ([]any, error) {
+	values := make([]any, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		idx, ok := rows.ColIdx[pk]
+		if !ok {
+			return nil, fmt.Errorf("primary key column %q not found", pk)
+		}
+		if row[idx] == nil {
+			return nil, fmt.Errorf("primary key column %q contains NULL", pk)
+		}
+		values[i] = row[idx]
+	}
+	return values, nil
+}
+
+func indexRowsByKey(rows *scannedTable, primaryKeys []string) (map[string][][]any, error) {
+	out := make(map[string][][]any, len(rows.Rows))
+	for _, row := range rows.Rows {
+		values, err := rowKeyValues(rows, row, primaryKeys)
+		if err != nil {
+			return nil, err
+		}
+		key, err := encodeRowKey(values)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = append(out[key], row)
+	}
+	return out, nil
+}
+
+// keyOrder returns encoded keys in first-encounter row order.
+func (s *scannedTable) keyOrder(primaryKeys []string) []string {
+	seen := make(map[string]struct{}, len(s.Rows))
+	keys := make([]string, 0, len(s.Rows))
+	for _, row := range s.Rows {
+		values, err := rowKeyValues(s, row, primaryKeys)
+		if err != nil {
+			continue
+		}
+		key, err := encodeRowKey(values)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func lastRow(rows [][]any) []any {
+	if len(rows) == 0 {
+		return nil
+	}
+	return rows[len(rows)-1]
+}
+
+// projectRow maps a staging row onto the target column layout. Columns missing
+// from staging keep the existing row's value (or NULL for new rows), mirroring
+// the SQL merge behavior where destination-only columns are left untouched.
+func projectRow(targetCols []string, staging *scannedTable, stagingRow []any, existing []any) []any {
+	out := make([]any, len(targetCols))
+	for i, col := range targetCols {
+		if idx, ok := staging.ColIdx[col]; ok {
+			out[i] = stagingRow[idx]
+		} else if existing != nil {
+			out[i] = existing[i]
+		}
+	}
+	return out
+}
+
+// composeCDCMergeRow mirrors the SQL CDC merge: existing rows are updated from
+// the latest non-delete change (respecting _cdc_unchanged_cols), new keys
+// materialize the latest change overall (including tombstones), and keys whose
+// latest change is a delete keep their data with _cdc_deleted marked true.
+func composeCDCMergeRow(targetCols []string, staging *scannedTable, entry *mergeEntry, existing []any) ([]any, error) {
+	src := entry.latestNonDeleted
+	if existing == nil && src == nil {
+		src = entry.latest
+	}
+
+	unchanged, err := cdcUnchangedColumns(staging, src, existing != nil)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, len(targetCols))
+	for i, col := range targetCols {
+		stagingIdx, inStaging := staging.ColIdx[col]
+		switch {
+		case !inStaging:
+			if existing != nil {
+				out[i] = existing[i]
+			}
+		case src == nil:
+			// Existing row whose only new changes are deletes: keep the data.
+			out[i] = existing[i]
+		case existing != nil && unchanged[col] && !destination.IsCDCMetaColumn(col):
+			out[i] = existing[i]
+		default:
+			out[i] = src[stagingIdx]
+		}
+	}
+
+	if entry.latestDeleted {
+		setColumn(targetCols, out, destination.CDCDeletedColumn, true)
+		setColumn(targetCols, out, destination.CDCLSNColumn, staging.Value(entry.latest, destination.CDCLSNColumn))
+		setColumn(targetCols, out, destination.CDCSyncedAtColumn, staging.Value(entry.latest, destination.CDCSyncedAtColumn))
+	}
+	return out, nil
+}
+
+func cdcUnchangedColumns(staging *scannedTable, src []any, hasExisting bool) (map[string]bool, error) {
+	if src == nil || !hasExisting || !staging.HasColumn(destination.CDCUnchangedColsColumn) {
+		return nil, nil
+	}
+	raw, ok := asString(staging.Value(src, destination.CDCUnchangedColsColumn))
+	if !ok || raw == "" {
+		return nil, nil
+	}
+	var cols []string
+	if err := json.Unmarshal([]byte(raw), &cols); err != nil {
+		return nil, fmt.Errorf("iceberg: invalid %s value %q: %w", destination.CDCUnchangedColsColumn, raw, err)
+	}
+	out := make(map[string]bool, len(cols))
+	for _, col := range cols {
+		out[col] = true
+	}
+	return out, nil
+}
+
+func setColumn(cols []string, row []any, name string, value any) {
+	for i, col := range cols {
+		if col == name {
+			row[i] = value
+			return
+		}
+	}
+}
+
+func scd2ChangeColumns(opts destination.SCD2Options, staging, target *scannedTable) []string {
+	excluded := make(map[string]bool)
+	for _, col := range destination.SCD2NonDataColumns(opts.PrimaryKeys) {
+		excluded[strings.ToLower(col)] = true
+	}
+	out := make([]string, 0, len(opts.Columns))
+	for _, col := range opts.Columns {
+		if excluded[strings.ToLower(col)] {
+			continue
+		}
+		if !staging.HasColumn(col) || !target.HasColumn(col) {
+			continue
+		}
+		out = append(out, col)
+	}
+	return out
+}
+
+func scd2RowChanged(changeCols []string, staging *scannedTable, stagingRow []any, target *scannedTable, targetRow []any) bool {
+	for _, col := range changeCols {
+		if !valuesEqual(staging.Value(stagingRow, col), target.Value(targetRow, col)) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/destination/iceberg/strategies.go
+++ b/pkg/destination/iceberg/strategies.go
@@ -316,7 +316,7 @@ func (d *Destination) scd2CopyOnWrite(ctx context.Context, target, staging *iceb
 		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
 	}
 
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable, false)
+	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/destination/iceberg/strategies_test.go
+++ b/pkg/destination/iceberg/strategies_test.go
@@ -151,6 +151,35 @@ func TestMergeTableDedupesByIncrementalKey(t *testing.T) {
 	require.Equal(t, "new-late", rows[int64(2)][1])
 }
 
+func TestMergeTableRequiresStagingIncrementalKeyWhenDedupingCopyOnWrite(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.missing_key_cow_target"
+	staging := "lake.merge.missing_key_cow_staging"
+	stagingSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeFloat64, Nullable: true},
+		},
+	}
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, nil)
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), "first", 1.0},
+		{int64(1), "second", 2.0},
+	})
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "name", "score"},
+		IncrementalKey: "updated_at",
+	})
+	require.ErrorContains(t, err, `iceberg: incremental key column "updated_at" not found in staging table lake.merge.missing_key_cow_staging`)
+}
+
 func TestMergeTableDedupesWithoutIncrementalKey(t *testing.T) {
 	dest := newHadoopDestination(t)
 	ctx := context.Background()

--- a/pkg/destination/iceberg/strategies_test.go
+++ b/pkg/destination/iceberg/strategies_test.go
@@ -516,6 +516,37 @@ func scd2Row(id int64, status string, score float64, validFrom int64) []any {
 	return []any{id, status, score, validFrom, nil, true}
 }
 
+func scd2IncrementalTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "status", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeFloat64, Nullable: true},
+			{Name: "updated_at", DataType: schema.TypeTimestampTZ, Nullable: false},
+			{Name: destination.SCD2ValidFromColumn, DataType: schema.TypeTimestampTZ, Nullable: false},
+			{Name: destination.SCD2ValidToColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+			{Name: destination.SCD2IsCurrentColumn, DataType: schema.TypeBoolean, Nullable: false},
+		},
+	}
+}
+
+func scd2IncrementalRow(id int64, status string, score float64, updatedAt, validFrom int64) []any {
+	return []any{id, status, score, updatedAt, validFrom, nil, true}
+}
+
+func currentSCD2Row(t *testing.T, rows *scannedTable, id int64) []any {
+	t.Helper()
+	var current []any
+	for _, row := range rowsByKey(t, rows, "id")[id] {
+		if rows.Value(row, destination.SCD2IsCurrentColumn) == true {
+			require.Nil(t, current, "expected one current row for id=%d", id)
+			current = row
+		}
+	}
+	require.NotNil(t, current, "expected current row for id=%d", id)
+	return current
+}
+
 func runSCD2(t *testing.T, dest *Destination, target, staging string, ts time.Time, incrementalKey string) {
 	t.Helper()
 	require.NoError(t, dest.SCD2Table(context.Background(), destination.SCD2Options{
@@ -618,6 +649,52 @@ func TestSCD2TableIncrementalKeySkipsSoftDelete(t *testing.T) {
 	require.Len(t, byID[int64(2)], 1)
 	require.Equal(t, true, got.Value(byID[int64(2)][0], destination.SCD2IsCurrentColumn), "incremental SCD2 must not soft-delete missing keys")
 	require.Nil(t, got.Value(byID[int64(2)][0], destination.SCD2ValidToColumn))
+}
+
+func TestSCD2TableCopyOnWriteDedupesByIncrementalKey(t *testing.T) {
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.merge.mode=copy-on-write"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+
+	target := "lake.scd2.inc_cow_target"
+	staging := "lake.scd2.inc_cow_staging"
+	schema := scd2IncrementalTestSchema()
+	t1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)
+
+	writeTableRows(t, dest, target, schema, false, nil)
+	writeTableRows(t, dest, staging, schema, true, [][]any{
+		scd2IncrementalRow(1, "active", 1.0, micros(t1), micros(t1)),
+	})
+	require.NoError(t, dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score", "updated_at"},
+		IncrementalKey: "updated_at",
+		Timestamp:      t1,
+	}))
+
+	writeTableRows(t, dest, staging, schema, true, [][]any{
+		scd2IncrementalRow(1, "newer", 3.0, micros(t3), micros(t3)),
+		scd2IncrementalRow(1, "older", 2.0, micros(t2), micros(t2)),
+	})
+	require.NoError(t, dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score", "updated_at"},
+		IncrementalKey: "updated_at",
+		Timestamp:      t3,
+	}))
+
+	got := readTableRows(t, dest, target)
+	current := currentSCD2Row(t, got, 1)
+	require.Equal(t, "newer", got.Value(current, "status"))
+	require.Equal(t, micros(t3), got.Value(current, "updated_at"))
+	requireNoEqualityDeletes(t, dest, target)
 }
 
 func TestTruncateTable(t *testing.T) {

--- a/pkg/destination/iceberg/strategies_test.go
+++ b/pkg/destination/iceberg/strategies_test.go
@@ -627,19 +627,20 @@ func TestSCD2TableIncrementalKeySkipsSoftDelete(t *testing.T) {
 	dest := newHadoopDestination(t)
 	target := "lake.scd2.inc_target"
 	staging := "lake.scd2.inc_staging"
+	schema := scd2IncrementalTestSchema()
 	t1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
 
-	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
-	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
-		scd2Row(1, "active", 1.0, micros(t1)),
-		scd2Row(2, "active", 2.0, micros(t1)),
+	writeTableRows(t, dest, target, schema, false, nil)
+	writeTableRows(t, dest, staging, schema, true, [][]any{
+		scd2IncrementalRow(1, "active", 1.0, micros(t1), micros(t1)),
+		scd2IncrementalRow(2, "active", 2.0, micros(t1), micros(t1)),
 	})
 	runSCD2(t, dest, target, staging, t1, "updated_at")
 
 	// Incremental update containing only id=1; id=2 must stay current.
-	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
-		scd2Row(1, "inactive", 1.0, micros(t2)),
+	writeTableRows(t, dest, staging, schema, true, [][]any{
+		scd2IncrementalRow(1, "inactive", 1.0, micros(t2), micros(t2)),
 	})
 	runSCD2(t, dest, target, staging, t2, "updated_at")
 
@@ -695,6 +696,32 @@ func TestSCD2TableCopyOnWriteDedupesByIncrementalKey(t *testing.T) {
 	require.Equal(t, "newer", got.Value(current, "status"))
 	require.Equal(t, micros(t3), got.Value(current, "updated_at"))
 	requireNoEqualityDeletes(t, dest, target)
+}
+
+func TestSCD2TableCopyOnWriteRequiresStagingIncrementalKey(t *testing.T) {
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.merge.mode=copy-on-write"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+
+	target := "lake.scd2.missing_key_cow_target"
+	staging := "lake.scd2.missing_key_cow_staging"
+	t1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "active", 1.0, micros(t1)),
+	})
+
+	err := dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score"},
+		IncrementalKey: "updated_at",
+		Timestamp:      t1,
+	})
+	require.ErrorContains(t, err, `iceberg: incremental key column "updated_at" not found in staging table lake.scd2.missing_key_cow_staging`)
 }
 
 func TestTruncateTable(t *testing.T) {

--- a/pkg/destination/iceberg/strategies_test.go
+++ b/pkg/destination/iceberg/strategies_test.go
@@ -1,0 +1,609 @@
+package iceberg
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func newHadoopDestination(t *testing.T) *Destination {
+	t.Helper()
+
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(context.Background(), "iceberg+hadoop://?warehouse="+url.QueryEscape(t.TempDir())))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	return dest
+}
+
+func writeTableRows(t *testing.T, dest *Destination, table string, tableSchema *schema.TableSchema, dropFirst bool, rows [][]any) {
+	t.Helper()
+	ctx := context.Background()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:     table,
+		Schema:    tableSchema,
+		DropFirst: dropFirst,
+	}))
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), rows)
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table:  table,
+		Schema: tableSchema,
+	}))
+}
+
+func readTableRows(t *testing.T, dest *Destination, table string) *scannedTable {
+	t.Helper()
+
+	tbl, err := dest.loadIcebergTable(context.Background(), table)
+	require.NoError(t, err)
+	rows, err := scanTableRows(context.Background(), tbl, iceberggo.AlwaysTrue{})
+	require.NoError(t, err)
+	return rows
+}
+
+func rowsByKey(t *testing.T, rows *scannedTable, keyColumn string) map[any][][]any {
+	t.Helper()
+
+	out := make(map[any][][]any)
+	idx, ok := rows.ColIdx[keyColumn]
+	require.True(t, ok, "column %q missing", keyColumn)
+	for _, row := range rows.Rows {
+		out[row[idx]] = append(out[row[idx]], row)
+	}
+	return out
+}
+
+func singleRowByKey(t *testing.T, rows *scannedTable, keyColumn string) map[any][]any {
+	t.Helper()
+
+	grouped := rowsByKey(t, rows, keyColumn)
+	out := make(map[any][]any, len(grouped))
+	for key, group := range grouped {
+		require.Len(t, group, 1, "expected one row for key %v", key)
+		out[key] = group[0]
+	}
+	return out
+}
+
+func mergeTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeFloat64, Nullable: true},
+			{Name: "updated_at", DataType: schema.TypeTimestampTZ, Nullable: true},
+		},
+	}
+}
+
+func micros(t time.Time) int64 { return t.UTC().UnixMicro() }
+
+func TestMergeTableUpsert(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.upsert_target"
+	staging := "lake.merge.upsert_staging"
+	ts := micros(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "alpha", 1.5, ts},
+		{int64(2), "bravo", 2.5, ts},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(2), "bravo-updated", 22.5, ts + 1},
+		{int64(3), "charlie", 3.5, ts + 1},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "alpha", rows[int64(1)][1])
+	require.Equal(t, 1.5, rows[int64(1)][2])
+	require.Equal(t, "bravo-updated", rows[int64(2)][1])
+	require.Equal(t, 22.5, rows[int64(2)][2])
+	require.Equal(t, ts+1, rows[int64(2)][3])
+	require.Equal(t, "charlie", rows[int64(3)][1])
+}
+
+func TestMergeTableDedupesByIncrementalKey(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.dedup_target"
+	staging := "lake.merge.dedup_staging"
+	base := micros(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "old", 0.0, base - 10},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(1), "middle", 1.0, base + 5},
+		{int64(1), "latest", 2.0, base + 9},
+		{int64(1), "earliest", 3.0, base + 1},
+		{int64(2), "new-early", 4.0, base + 1},
+		{int64(2), "new-late", 5.0, base + 2},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "name", "score", "updated_at"},
+		IncrementalKey: "updated_at",
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "latest", rows[int64(1)][1])
+	require.Equal(t, "new-late", rows[int64(2)][1])
+}
+
+func TestMergeTableDedupesWithoutIncrementalKey(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.dedup_noinc_target"
+	staging := "lake.merge.dedup_noinc_staging"
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, nil)
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(1), "first", 1.0, nil},
+		{int64(1), "last", 2.0, nil},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 1)
+	require.Equal(t, "last", rows[int64(1)][1])
+}
+
+func TestMergeTableCompositeKeys(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.composite_target"
+	staging := "lake.merge.composite_staging"
+	compositeSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "tenant", DataType: schema.TypeString, Nullable: false},
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+
+	writeTableRows(t, dest, target, compositeSchema, false, [][]any{
+		{"acme", int64(1), "acme-1"},
+		{"acme", int64(2), "acme-2"},
+		{"globex", int64(1), "globex-1"},
+	})
+	writeTableRows(t, dest, staging, compositeSchema, true, [][]any{
+		{"acme", int64(2), "acme-2-updated"},
+		{"globex", int64(2), "globex-2-new"},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"tenant", "id"},
+		Columns:      []string{"tenant", "id", "name"},
+	}))
+
+	rows := readTableRows(t, dest, target)
+	require.Len(t, rows.Rows, 4)
+	names := make(map[string]string)
+	for _, row := range rows.Rows {
+		names[row[0].(string)+"/"+string(rune('0'+row[1].(int64)))] = row[2].(string)
+	}
+	require.Equal(t, map[string]string{
+		"acme/1":   "acme-1",
+		"acme/2":   "acme-2-updated",
+		"globex/1": "globex-1",
+		"globex/2": "globex-2-new",
+	}, names)
+}
+
+func TestMergeTablePreservesDestinationOnlyColumns(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.destonly_target"
+	staging := "lake.merge.destonly_staging"
+
+	targetSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "legacy", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+	stagingSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{
+		{int64(1), "alpha", "keep-me"},
+	})
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), "alpha-updated"},
+		{int64(2), "bravo-new"},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "alpha-updated", rows[int64(1)][1])
+	require.Equal(t, "keep-me", rows[int64(1)][2], "destination-only column must keep its value for existing rows")
+	require.Equal(t, "bravo-new", rows[int64(2)][1])
+	require.Nil(t, rows[int64(2)][2], "destination-only column must be NULL for new rows")
+}
+
+func cdcSchema(withUnchangedCols bool) *schema.TableSchema {
+	cols := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+		{Name: "payload", DataType: schema.TypeString, Nullable: true},
+		{Name: destination.CDCLSNColumn, DataType: schema.TypeString, Nullable: true},
+		{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: true},
+		{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+	}
+	if withUnchangedCols {
+		cols = append(cols, schema.Column{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true})
+	}
+	return &schema.TableSchema{Columns: cols}
+}
+
+func TestMergeTableCDC(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.cdc_target"
+	staging := "lake.merge.cdc_staging"
+	syncedAt := micros(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	writeTableRows(t, dest, target, cdcSchema(false), false, [][]any{
+		{int64(1), "alpha", "payload-1", "0/100", false, syncedAt - 10},
+		{int64(2), "bravo", "payload-2", "0/100", false, syncedAt - 10},
+		{int64(3), "charlie", "payload-3", "0/100", false, syncedAt - 10},
+	})
+	writeTableRows(t, dest, staging, cdcSchema(true), true, [][]any{
+		// id=1: update then delete -> data preserved from update, tombstone marked.
+		{int64(1), "alpha-updated", "payload-1b", "0/200", false, syncedAt, nil},
+		{int64(1), nil, nil, "0/300", true, syncedAt + 1, nil},
+		// id=2: update with TOAST-style unchanged payload column.
+		{int64(2), "bravo-updated", nil, "0/210", false, syncedAt, `["payload"]`},
+		// id=4: net-new insert.
+		{int64(4), "delta", "payload-4", "0/220", false, syncedAt, nil},
+		// id=5: delete-only key materializes a tombstone for resume.
+		{int64(5), nil, nil, "0/230", true, syncedAt, nil},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name", "payload", destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn, destination.CDCUnchangedColsColumn},
+	}))
+
+	got := readTableRows(t, dest, target)
+	require.NotContains(t, got.ColIdx, destination.CDCUnchangedColsColumn)
+	rows := singleRowByKey(t, got, "id")
+	require.Len(t, rows, 5)
+
+	value := func(id int64, col string) any { return got.Value(rows[id], col) }
+
+	// id=1: latest non-delete change applied, tombstone marked with the delete's LSN.
+	require.Equal(t, "alpha-updated", value(1, "name"))
+	require.Equal(t, "payload-1b", value(1, "payload"))
+	require.Equal(t, true, value(1, destination.CDCDeletedColumn))
+	require.Equal(t, "0/300", value(1, destination.CDCLSNColumn))
+	require.Equal(t, syncedAt+1, value(1, destination.CDCSyncedAtColumn))
+
+	// id=2: unchanged TOAST column keeps the target value.
+	require.Equal(t, "bravo-updated", value(2, "name"))
+	require.Equal(t, "payload-2", value(2, "payload"))
+	require.Equal(t, false, value(2, destination.CDCDeletedColumn))
+	require.Equal(t, "0/210", value(2, destination.CDCLSNColumn))
+
+	// id=3: untouched.
+	require.Equal(t, "charlie", value(3, "name"))
+	require.Equal(t, "0/100", value(3, destination.CDCLSNColumn))
+
+	// id=4: inserted.
+	require.Equal(t, "delta", value(4, "name"))
+
+	// id=5: tombstone row inserted so CDC resume sees the delete LSN.
+	require.Equal(t, true, value(5, destination.CDCDeletedColumn))
+	require.Equal(t, "0/230", value(5, destination.CDCLSNColumn))
+	require.Nil(t, value(5, "name"))
+}
+
+func TestDeleteInsertTable(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.di.int_target"
+	staging := "lake.di.int_staging"
+
+	seed := make([][]any, 0, 10)
+	for i := int64(1); i <= 10; i++ {
+		seed = append(seed, []any{i, "v1", 0.0, nil})
+	}
+	writeTableRows(t, dest, target, mergeTestSchema(), false, seed)
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(3), "v2", 0.0, nil},
+		{int64(4), "v2", 0.0, nil},
+		{int64(7), "v2", 0.0, nil},
+	})
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		IncrementalKey: "id",
+		IntervalStart:  int64(3),
+		IntervalEnd:    int64(7),
+		Columns:        []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 8, "ids 5 and 6 must be deleted")
+	require.Equal(t, "v1", rows[int64(2)][1])
+	require.Equal(t, "v1", rows[int64(10)][1])
+	require.Equal(t, "v2", rows[int64(3)][1])
+	require.Equal(t, "v2", rows[int64(4)][1])
+	require.Equal(t, "v2", rows[int64(7)][1])
+	require.NotContains(t, rows, int64(5))
+	require.NotContains(t, rows, int64(6))
+}
+
+func TestDeleteInsertTableTimestampInterval(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.di.ts_target"
+	staging := "lake.di.ts_staging"
+	day := func(d int) time.Time { return time.Date(2026, 3, d, 0, 0, 0, 0, time.UTC) }
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "v1", 0.0, micros(day(1))},
+		{int64(2), "v1", 0.0, micros(day(5))},
+		{int64(3), "v1", 0.0, micros(day(9))},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(4), "v2", 0.0, micros(day(6))},
+	})
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		IncrementalKey: "updated_at",
+		IntervalStart:  day(4),
+		IntervalEnd:    day(7),
+		Columns:        []string{"id", "name", "score", "updated_at"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 3)
+	require.Contains(t, rows, int64(1))
+	require.NotContains(t, rows, int64(2), "row inside the timestamp interval must be deleted")
+	require.Contains(t, rows, int64(3))
+	require.Contains(t, rows, int64(4))
+}
+
+func TestDeleteInsertTableDedupesStagingByPK(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.di.dedup_target"
+	staging := "lake.di.dedup_staging"
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, nil)
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{
+		{int64(1), "first", 0.0, nil},
+		{int64(1), "second", 0.0, nil},
+		{int64(2), "only", 0.0, nil},
+	})
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		IncrementalKey: "id",
+		IntervalStart:  int64(1),
+		IntervalEnd:    int64(2),
+		Columns:        []string{"id", "name", "score", "updated_at"},
+		PrimaryKeys:    []string{"id"},
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "second", rows[int64(1)][1], "duplicate PKs must collapse, highest incremental key wins (arrival order on ties)")
+}
+
+func scd2TestSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "status", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeFloat64, Nullable: true},
+			{Name: destination.SCD2ValidFromColumn, DataType: schema.TypeTimestampTZ, Nullable: false},
+			{Name: destination.SCD2ValidToColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+			{Name: destination.SCD2IsCurrentColumn, DataType: schema.TypeBoolean, Nullable: false},
+		},
+	}
+}
+
+func scd2Row(id int64, status string, score float64, validFrom int64) []any {
+	return []any{id, status, score, validFrom, nil, true}
+}
+
+func runSCD2(t *testing.T, dest *Destination, target, staging string, ts time.Time, incrementalKey string) {
+	t.Helper()
+	require.NoError(t, dest.SCD2Table(context.Background(), destination.SCD2Options{
+		StagingTable:   staging,
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "status", "score"},
+		IncrementalKey: incrementalKey,
+		Timestamp:      ts,
+	}))
+}
+
+func TestSCD2Table(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.scd2.target"
+	staging := "lake.scd2.staging"
+	t1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+
+	// Initial load: empty target, all staging rows are net-new (append path).
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "active", 1.0, micros(t1)),
+		scd2Row(2, "active", 2.0, micros(t1)),
+		scd2Row(3, "active", 3.0, micros(t1)),
+	})
+	runSCD2(t, dest, target, staging, t1, "")
+
+	rows := readTableRows(t, dest, target)
+	require.Len(t, rows.Rows, 3)
+	for _, row := range rows.Rows {
+		require.Equal(t, true, rows.Value(row, destination.SCD2IsCurrentColumn))
+		require.Nil(t, rows.Value(row, destination.SCD2ValidToColumn))
+	}
+
+	// Update load: id=1 changed, id=2 unchanged, id=3 missing (soft delete), id=4 new.
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "inactive", 1.0, micros(t2)),
+		scd2Row(2, "active", 2.0, micros(t2)),
+		scd2Row(4, "active", 4.0, micros(t2)),
+	})
+	runSCD2(t, dest, target, staging, t2, "")
+
+	got := readTableRows(t, dest, target)
+	require.Len(t, got.Rows, 5, "3 current + 1 closed version + 1 soft-deleted")
+	byID := rowsByKey(t, got, "id")
+
+	require.Len(t, byID[int64(1)], 2, "changed key keeps history")
+	var closed, current []any
+	for _, row := range byID[int64(1)] {
+		if got.Value(row, destination.SCD2IsCurrentColumn) == true {
+			current = row
+		} else {
+			closed = row
+		}
+	}
+	require.NotNil(t, current)
+	require.NotNil(t, closed)
+	require.Equal(t, "inactive", got.Value(current, "status"))
+	require.Equal(t, micros(t2), got.Value(current, destination.SCD2ValidFromColumn))
+	require.Equal(t, "active", got.Value(closed, "status"))
+	require.Equal(t, micros(t1), got.Value(closed, destination.SCD2ValidFromColumn))
+	require.Equal(t, micros(t2), got.Value(closed, destination.SCD2ValidToColumn), "closed version must end where the new one starts")
+
+	require.Len(t, byID[int64(2)], 1, "unchanged key must not produce a new version")
+	require.Equal(t, true, got.Value(byID[int64(2)][0], destination.SCD2IsCurrentColumn))
+	require.Nil(t, got.Value(byID[int64(2)][0], destination.SCD2ValidToColumn))
+
+	require.Len(t, byID[int64(3)], 1)
+	require.Equal(t, false, got.Value(byID[int64(3)][0], destination.SCD2IsCurrentColumn), "missing key must be soft-deleted")
+	require.Equal(t, micros(t2), got.Value(byID[int64(3)][0], destination.SCD2ValidToColumn))
+
+	require.Len(t, byID[int64(4)], 1)
+	require.Equal(t, true, got.Value(byID[int64(4)][0], destination.SCD2IsCurrentColumn))
+}
+
+func TestSCD2TableIncrementalKeySkipsSoftDelete(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.scd2.inc_target"
+	staging := "lake.scd2.inc_staging"
+	t1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "active", 1.0, micros(t1)),
+		scd2Row(2, "active", 2.0, micros(t1)),
+	})
+	runSCD2(t, dest, target, staging, t1, "updated_at")
+
+	// Incremental update containing only id=1; id=2 must stay current.
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "inactive", 1.0, micros(t2)),
+	})
+	runSCD2(t, dest, target, staging, t2, "updated_at")
+
+	got := readTableRows(t, dest, target)
+	byID := rowsByKey(t, got, "id")
+	require.Len(t, byID[int64(1)], 2)
+	require.Len(t, byID[int64(2)], 1)
+	require.Equal(t, true, got.Value(byID[int64(2)][0], destination.SCD2IsCurrentColumn), "incremental SCD2 must not soft-delete missing keys")
+	require.Nil(t, got.Value(byID[int64(2)][0], destination.SCD2ValidToColumn))
+}
+
+func TestTruncateTable(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.truncate.events"
+
+	writeTableRows(t, dest, table, mergeTestSchema(), false, [][]any{
+		{int64(1), "alpha", 1.0, nil},
+		{int64(2), "bravo", 2.0, nil},
+	})
+	require.NoError(t, dest.TruncateTable(ctx, table))
+
+	rows := readTableRows(t, dest, table)
+	require.Empty(t, rows.Rows)
+
+	gotSchema, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, []string{"id", "name", "score", "updated_at"}, gotSchema.ColumnNames(), "truncate must preserve the schema")
+
+	// Truncating an empty (or never-written) table is a no-op.
+	require.NoError(t, dest.TruncateTable(ctx, table))
+}
+
+func TestMergeTableRejectsNullPrimaryKeys(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.merge.nullpk_target"
+	staging := "lake.merge.nullpk_staging"
+	nullableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+
+	writeTableRows(t, dest, target, nullableSchema, false, nil)
+	writeTableRows(t, dest, staging, nullableSchema, true, [][]any{
+		{nil, "broken"},
+	})
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "name"},
+	})
+	require.ErrorContains(t, err, "contains NULL")
+}

--- a/pkg/destination/iceberg/strategies_test.go
+++ b/pkg/destination/iceberg/strategies_test.go
@@ -439,6 +439,37 @@ func TestDeleteInsertTableDedupesStagingByPK(t *testing.T) {
 	require.Equal(t, "second", rows[int64(1)][1], "duplicate PKs must collapse, highest incremental key wins (arrival order on ties)")
 }
 
+func TestDeleteInsertTableRequiresStagingIncrementalKeyWhenDeduping(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.di.missing_key_target"
+	staging := "lake.di.missing_key_staging"
+	stagingSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeFloat64, Nullable: true},
+		},
+	}
+
+	writeTableRows(t, dest, target, mergeTestSchema(), false, nil)
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), "first", 0.0},
+		{int64(1), "second", 0.0},
+	})
+
+	err := dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable:   staging,
+		TargetTable:    target,
+		IncrementalKey: "updated_at",
+		IntervalStart:  int64(1),
+		IntervalEnd:    int64(2),
+		Columns:        []string{"id", "name", "score"},
+		PrimaryKeys:    []string{"id"},
+	})
+	require.ErrorContains(t, err, `iceberg: incremental key column "updated_at" not found in staging table lake.di.missing_key_staging`)
+}
+
 func scd2TestSchema() *schema.TableSchema {
 	return &schema.TableSchema{
 		Columns: []schema.Column{

--- a/pkg/destination/iceberg/stream.go
+++ b/pkg/destination/iceberg/stream.go
@@ -1,0 +1,229 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+)
+
+// batchBuildRows bounds how many rows are buffered when composing output
+// record batches from normalized rows.
+const batchBuildRows = 4096
+
+// forEachScannedRow streams the table rows matching filter, invoking fn with
+// each row as normalized values aligned to the table schema field order.
+// Memory usage is bounded by a single scan batch.
+func forEachScannedRow(ctx context.Context, tbl *icebergtable.Table, filter iceberggo.BooleanExpression, fn func(vals []any) error) error {
+	if tbl.CurrentSnapshot() == nil {
+		return nil
+	}
+	batchSchema, itr, err := tbl.Scan(icebergtable.WithRowFilter(filter)).ToArrowRecords(ctx)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to scan table: %w", err)
+	}
+
+	tableFields := tbl.Schema().Fields()
+	positions := make([]int, len(batchSchema.Fields()))
+	for i, field := range batchSchema.Fields() {
+		positions[i] = -1
+		for j, tf := range tableFields {
+			if tf.Name == field.Name {
+				positions[i] = j
+				break
+			}
+		}
+		if positions[i] < 0 {
+			return fmt.Errorf("iceberg: scan returned unknown column %q", field.Name)
+		}
+	}
+
+	for batch, err := range itr {
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to read table rows: %w", err)
+		}
+		numRows := int(batch.NumRows())
+		numCols := int(batch.NumCols())
+		for r := range numRows {
+			row := make([]any, len(tableFields))
+			for c := range numCols {
+				value, err := rowValue(batch.Column(c), r)
+				if err != nil {
+					batch.Release()
+					return fmt.Errorf("iceberg: column %q: %w", batchSchema.Field(c).Name, err)
+				}
+				row[positions[c]] = value
+			}
+			if err := fn(row); err != nil {
+				batch.Release()
+				return err
+			}
+		}
+		batch.Release()
+	}
+	return nil
+}
+
+// rowProjection maps rows laid out per source column order onto a target
+// write schema, filling columns absent from the source with NULL.
+type rowProjection struct {
+	writeSchema *arrow.Schema
+	sourceIdx   []int // per target column: index in the source row, or -1
+}
+
+func newRowProjection(writeSchema *arrow.Schema, sourceColumns []string) *rowProjection {
+	byName := make(map[string]int, len(sourceColumns))
+	for i, col := range sourceColumns {
+		byName[col] = i
+	}
+	sourceIdx := make([]int, len(writeSchema.Fields()))
+	for i, field := range writeSchema.Fields() {
+		if idx, ok := byName[field.Name]; ok {
+			sourceIdx[i] = idx
+		} else {
+			sourceIdx[i] = -1
+		}
+	}
+	return &rowProjection{writeSchema: writeSchema, sourceIdx: sourceIdx}
+}
+
+func (p *rowProjection) appendRow(builder *array.RecordBuilder, row []any) error {
+	for c, srcIdx := range p.sourceIdx {
+		var v any
+		if srcIdx >= 0 {
+			v = row[srcIdx]
+		}
+		if err := appendValue(builder.Field(c), v); err != nil {
+			return fmt.Errorf("iceberg: column %q: %w", p.writeSchema.Field(c).Name, err)
+		}
+	}
+	return nil
+}
+
+// batchEmitter accumulates projected rows and emits record batches of bounded
+// size through the sink. Callers must call flush at the end.
+type batchEmitter struct {
+	projection *rowProjection
+	builder    *array.RecordBuilder
+	rows       int
+	sink       func(arrow.RecordBatch) error
+}
+
+func newBatchEmitter(projection *rowProjection, sink func(arrow.RecordBatch) error) *batchEmitter {
+	return &batchEmitter{
+		projection: projection,
+		builder:    array.NewRecordBuilder(memory.DefaultAllocator, projection.writeSchema),
+		sink:       sink,
+	}
+}
+
+func (e *batchEmitter) add(row []any) error {
+	if err := e.projection.appendRow(e.builder, row); err != nil {
+		return err
+	}
+	e.rows++
+	if e.rows >= batchBuildRows {
+		return e.flushBatch()
+	}
+	return nil
+}
+
+func (e *batchEmitter) flushBatch() error {
+	if e.rows == 0 {
+		return nil
+	}
+	batch := e.builder.NewRecordBatch()
+	e.rows = 0
+	err := e.sink(batch)
+	if err != nil {
+		batch.Release()
+		return err
+	}
+	return nil
+}
+
+func (e *batchEmitter) release() {
+	e.builder.Release()
+}
+
+// chanRecordReader adapts a channel of record batches into an
+// array.RecordReader so streaming producers can feed iceberg-go writers
+// without materializing all batches. Ownership of received batches passes to
+// the reader.
+type chanRecordReader struct {
+	schema   *arrow.Schema
+	batches  <-chan arrow.RecordBatch
+	errp     *error
+	current  arrow.RecordBatch
+	refCount atomic.Int64
+}
+
+func newChanRecordReader(schema *arrow.Schema, batches <-chan arrow.RecordBatch, errp *error) *chanRecordReader {
+	r := &chanRecordReader{schema: schema, batches: batches, errp: errp}
+	r.refCount.Store(1)
+	return r
+}
+
+func (r *chanRecordReader) Retain() { r.refCount.Add(1) }
+
+func (r *chanRecordReader) Release() {
+	if r.refCount.Add(-1) != 0 {
+		return
+	}
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
+	for batch := range r.batches {
+		batch.Release()
+	}
+}
+
+func (r *chanRecordReader) Schema() *arrow.Schema { return r.schema }
+
+func (r *chanRecordReader) Next() bool {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
+	batch, ok := <-r.batches
+	if !ok {
+		return false
+	}
+	r.current = batch
+	return true
+}
+
+func (r *chanRecordReader) RecordBatch() arrow.RecordBatch { return r.current }
+func (r *chanRecordReader) Record() arrow.RecordBatch      { return r.current }
+
+// Err returns the producer's error after the stream is drained.
+func (r *chanRecordReader) Err() error {
+	if r.errp != nil {
+		return *r.errp
+	}
+	return nil
+}
+
+// streamingReader runs produce in a goroutine, feeding batches to the
+// returned RecordReader. produce must send batches to the sink it is given
+// and return; the reader's Err() reflects the producer error once drained.
+func streamingReader(schema *arrow.Schema, produce func(sink func(arrow.RecordBatch) error) error) *chanRecordReader {
+	batches := make(chan arrow.RecordBatch, 2)
+	var produceErr error
+	reader := newChanRecordReader(schema, batches, &produceErr)
+
+	go func() {
+		defer close(batches)
+		produceErr = produce(func(batch arrow.RecordBatch) error {
+			batches <- batch
+			return nil
+		})
+	}()
+	return reader
+}

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -44,3 +44,10 @@ var (
 	_ destination.Destination = (*synapse.SynapseDestination)(nil)
 	_ destination.Destination = (*trino.TrinoDestination)(nil)
 )
+
+// Optional strategy interfaces the Iceberg destination implements natively.
+var (
+	_ destination.TruncateCapable       = (*iceberg.Destination)(nil)
+	_ destination.CDCMergeAware         = (*iceberg.Destination)(nil)
+	_ destination.CDCUnchangedColsAware = (*iceberg.Destination)(nil)
+)

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -423,10 +423,33 @@ func destinationCases() []destCase {
 			validateNonSQL:       validateAthenaReplace,
 			validateAppendNonSQL: validateAthenaAppend,
 		},
+		{
+			// Merge, delete+insert, truncate+insert and SCD2 cannot be
+			// validated through sqlBackend (no database/sql driver for
+			// Iceberg); they run in iceberg_strategies_test.go against the
+			// same fixtures and expectations.
+			name: "iceberg",
+			setup: func(t *testing.T, _ context.Context) (string, string, func()) {
+				return icebergConformanceDestURI(t), icebergConformanceTable(), func() {}
+			},
+			validateNonSQL:       validateIcebergReplace,
+			validateAppendNonSQL: validateIcebergAppend,
+		},
 		// DynamoDB is tested separately in dynamodb_test.go because it always
 		// requires primary keys in the config, which the generic conformance
 		// tests don't provide.
 	}
+}
+
+func validateIcebergReplace(t *testing.T, destURI, destTable string) {
+	rows := readIcebergRows(t, context.Background(), destURI, destTable)
+	require.Len(t, rows, replaceFixtureRows)
+}
+
+func validateIcebergAppend(t *testing.T, destURI, destTable string) {
+	rows := readIcebergRows(t, context.Background(), destURI, destTable)
+	require.Len(t, rows, appendAfterRows)
+	assert.Equal(t, "kilo", icebergNameByID(t, rows, 11))
 }
 
 // TestDestinations_Replace validates:

--- a/tests/integration/iceberg_destination_test.go
+++ b/tests/integration/iceberg_destination_test.go
@@ -205,6 +205,18 @@ func exerciseIcebergDestination(t *testing.T, ctx context.Context, destURI, tabl
 	summary = loadIcebergTableSummary(t, ctx, destURI, tableName)
 	assert.EqualValues(t, 1, summary.rows)
 	assert.True(t, summary.fields["age"])
+
+	mergeRows := writeIcebergJSONL(
+		t, "merge.jsonl",
+		`{"id":9,"name":"replace-merged","active":false,"score":9.5,"age":56}`,
+		`{"id":10,"name":"merged-new","active":true,"score":10.5,"age":20}`,
+	)
+	runIcebergPipeline(t, ctx, mergeRows, destURI, tableName, ingestconfig.StrategyMerge)
+
+	rows := readIcebergRows(t, ctx, destURI, tableName)
+	assert.Len(t, rows, 2)
+	assert.Equal(t, "replace-merged", icebergNameByID(t, rows, 9), "merge should update the existing row in place")
+	assert.Equal(t, "merged-new", icebergNameByID(t, rows, 10), "merge should insert net-new rows")
 }
 
 func icebergSQLMinioDestinationURI(t *testing.T, minioEndpoint, bucket string) string {

--- a/tests/integration/iceberg_strategies_test.go
+++ b/tests/integration/iceberg_strategies_test.go
@@ -1,0 +1,360 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The Iceberg destination cannot be validated through the shared sqlBackend
+// helpers (there is no database/sql driver for Iceberg), so these tests mirror
+// the destination conformance suite — same fixtures, same expectations — and
+// validate by scanning the Iceberg tables directly.
+
+func icebergConformanceDestURI(t *testing.T) string {
+	t.Helper()
+	return "iceberg+hadoop://" + t.TempDir() + "?" + url.Values{
+		"table.write.format.default": {"parquet"},
+	}.Encode()
+}
+
+func icebergConformanceTable() string {
+	return "lake.conformance_" + uniqueSuffix()
+}
+
+func readIcebergRows(t *testing.T, ctx context.Context, destURI, tableName string) []map[string]any {
+	t.Helper()
+
+	props, err := parseIcebergTestURI(destURI)
+	require.NoError(t, err)
+	if parsed, err := url.Parse(destURI); err == nil && parsed.Scheme == "iceberg+hadoop" {
+		if parsed.Path != "" && parsed.Path != "/" {
+			props["warehouse"] = parsed.Path
+		}
+	}
+
+	cat, err := icebergcatalog.Load(ctx, icebergTestCatalogName(destURI), props)
+	require.NoError(t, err)
+
+	tbl, err := cat.LoadTable(ctx, icebergcatalog.ToIdentifier(strings.Split(tableName, ".")...))
+	require.NoError(t, err)
+
+	if tbl.CurrentSnapshot() == nil {
+		return nil
+	}
+	arrowTable, err := tbl.Scan().ToArrowTable(ctx)
+	require.NoError(t, err)
+	defer arrowTable.Release()
+
+	rows := make([]map[string]any, arrowTable.NumRows())
+	for i := range rows {
+		rows[i] = make(map[string]any, int(arrowTable.NumCols()))
+	}
+
+	for c := 0; c < int(arrowTable.NumCols()); c++ {
+		name := arrowTable.Schema().Field(c).Name
+		offset := 0
+		for _, chunk := range arrowTable.Column(c).Data().Chunks() {
+			for i := 0; i < chunk.Len(); i++ {
+				rows[offset+i][name] = icebergTestValue(t, chunk, i)
+			}
+			offset += chunk.Len()
+		}
+	}
+	return rows
+}
+
+func icebergTestValue(t *testing.T, arr arrow.Array, i int) any {
+	t.Helper()
+	if arr.IsNull(i) {
+		return nil
+	}
+	switch a := arr.(type) {
+	case *array.Boolean:
+		return a.Value(i)
+	case *array.Int32:
+		return int64(a.Value(i))
+	case *array.Int64:
+		return a.Value(i)
+	case *array.Float32:
+		return float64(a.Value(i))
+	case *array.Float64:
+		return a.Value(i)
+	case *array.String:
+		return a.Value(i)
+	case *array.LargeString:
+		return a.Value(i)
+	case *array.Timestamp:
+		return int64(a.Value(i))
+	case array.ExtensionArray:
+		return icebergTestValue(t, a.Storage(), i)
+	default:
+		t.Fatalf("unsupported arrow type %s in iceberg validation", arr.DataType())
+		return nil
+	}
+}
+
+func icebergRowsByID(rows []map[string]any) map[int64][]map[string]any {
+	out := make(map[int64][]map[string]any)
+	for _, row := range rows {
+		id, ok := row["id"].(int64)
+		if !ok {
+			continue
+		}
+		out[id] = append(out[id], row)
+	}
+	return out
+}
+
+func icebergNameByID(t *testing.T, rows []map[string]any, id int64) string {
+	t.Helper()
+	group := icebergRowsByID(rows)[id]
+	require.Lenf(t, group, 1, "expected exactly one row for id=%d", id)
+	name, _ := group[0]["name"].(string)
+	return name
+}
+
+func TestIcebergConformance_Merge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "merge_source",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	cfg.SourceURI = jsonlURI(t, "testdata/conformance_merge_update.jsonl")
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	assert.Len(t, rows, mergeAfterRows)
+	assert.Equal(t, "alpha-updated", icebergNameByID(t, rows, 1))
+	assert.Equal(t, "foxtrot-new", icebergNameByID(t, rows, 6))
+}
+
+func TestIcebergConformance_DeleteInsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_deleteinsert_initial.jsonl"),
+		SourceTable:         "deleteinsert_seed",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	cfg.SourceURI = jsonlURI(t, "testdata/conformance_deleteinsert_interval.jsonl")
+	cfg.SourceTable = "deleteinsert_interval"
+	cfg.IncrementalStrategy = config.StrategyDeleteInsert
+	cfg.IncrementalKey = "id"
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	assert.Len(t, rows, deleteInsertAfterRows)
+	assert.Equal(t, "v1-2", icebergNameByID(t, rows, 2), "rows outside the interval must be unchanged")
+	assert.Equal(t, "v1-10", icebergNameByID(t, rows, 10), "rows outside the interval must be unchanged")
+	assert.Equal(t, "v2-3", icebergNameByID(t, rows, 3), "rows inside the interval must be replaced")
+	assert.Equal(t, "v2-7", icebergNameByID(t, rows, 7), "net-new rows inside the interval must be inserted")
+}
+
+func TestIcebergConformance_DeleteInsert_DedupesStagingByPK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_deleteinsert_dedup.jsonl"),
+		SourceTable:         "deleteinsert_dedup",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyDeleteInsert,
+		IncrementalKey:      "id",
+		PrimaryKeys:         []string{"id"},
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	assert.Len(t, readIcebergRows(t, ctx, destURI, destTable), 3, "duplicate primary keys in staging should collapse to one row per key")
+
+	cfg.SourceURI = jsonlURI(t, "testdata/conformance_deleteinsert_dedup_interval.jsonl")
+	cfg.SourceTable = "deleteinsert_dedup_interval"
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	assert.Len(t, rows, 4, "interval delete+insert should replace id=3 and add net-new id=4")
+	assert.Equal(t, "v2-3", icebergNameByID(t, rows, 3))
+	assert.Equal(t, "v2-4", icebergNameByID(t, rows, 4))
+}
+
+func TestIcebergConformance_TruncateInsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	seedCfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_append_initial.jsonl"),
+		SourceTable:         "truncate_seed",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	require.NoError(t, pipeline.New(seedCfg).Run(ctx))
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance.jsonl"),
+		SourceTable:         "truncate_source",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyTruncateInsert,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	assert.Len(t, rows, replaceFixtureRows, "old rows must be gone, not appended")
+	assert.Equal(t, "juliet", icebergNameByID(t, rows, 10))
+}
+
+func TestIcebergConformance_TruncateInsert_Dedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_truncate_dupes.jsonl"),
+		SourceTable:         "truncate_dupes",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyTruncateInsert,
+		PrimaryKeys:         []string{"id"},
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	assert.Len(t, rows, 5, "expected 5 distinct ids after dedup")
+}
+
+func TestIcebergConformance_SCD2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_scd2_initial.jsonl"),
+		SourceTable:         "scd2_initial",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategySCD2,
+		PrimaryKeys:         []string{"id"},
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "Initial SCD2 load should succeed")
+
+	cfg.SourceURI = jsonlURI(t, "testdata/conformance_scd2_update.jsonl")
+	cfg.SourceTable = "scd2_update"
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "SCD2 update load should succeed")
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	assert.Len(t, rows, scd2TotalRows)
+
+	current := 0
+	historicalMissingValidTo := 0
+	for _, row := range rows {
+		if row["_scd_is_current"] == true {
+			current++
+			assert.Nil(t, row["_scd_valid_to"], "current rows must have open validity")
+			continue
+		}
+		if row["_scd_valid_to"] == nil {
+			historicalMissingValidTo++
+		}
+	}
+	assert.Equal(t, scd2CurrentRows, current, "current row count")
+	assert.Zero(t, historicalMissingValidTo, "all historical records should have valid_to set")
+
+	byID := icebergRowsByID(rows)
+	assert.Len(t, byID[1], 2, "id=1 should have 2 rows (changed record)")
+	assert.Len(t, byID[3], 1, "id=3 should have 1 row (unchanged)")
+	assert.Len(t, byID[6], 1, "id=6 should have 1 row (net-new)")
+
+	for _, row := range byID[4] {
+		assert.Equal(t, false, row["_scd_is_current"], "id=4 was removed from the source and must be soft-deleted")
+		assert.NotNil(t, row["_scd_valid_to"])
+	}
+}
+
+// TestIcebergConformance_MergeIdempotent re-runs the same merge input twice and
+// asserts the second run does not change row counts or values.
+func TestIcebergConformance_MergeIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_merge_initial.jsonl"),
+		SourceTable:         "merge_source",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	first := readIcebergRows(t, ctx, destURI, destTable)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	second := readIcebergRows(t, ctx, destURI, destTable)
+
+	require.Len(t, second, len(first))
+	firstByID := icebergRowsByID(first)
+	for id, group := range icebergRowsByID(second) {
+		require.Len(t, group, 1)
+		require.Len(t, firstByID[id], 1)
+		for _, col := range []string{"name", "active", "score"} {
+			assert.Equalf(t, firstByID[id][0][col], group[0][col], "column %s for id=%d changed on idempotent re-merge", col, id)
+		}
+	}
+}


### PR DESCRIPTION
Adds native Iceberg support for merge, delete+insert, truncate+insert, and SCD2 strategies.
Uses merge-on-read row deltas where possible and copy-on-write fallbacks where target rows must be read.
Adds unit and integration coverage plus updates the Iceberg docs.

Checks: make format, make lint, make test.