### PR TITLE
Pre-stage BigQuery loads during schema inference

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -144,6 +144,12 @@ func IngestCommand() *cli.Command {
 				Usage:   "The width for each extract partition window: duration (1h, 7d), integer step (10000), or auto. Defaults to auto when extract-partition-by is set",
 				Sources: cli.EnvVars("EXTRACT_PARTITION_INTERVAL", "INGESTR_EXTRACT_PARTITION_INTERVAL"),
 			},
+			&cli.BoolFlag{
+				Name:    "disable-prestaging",
+				Usage:   "Disable extract-time load-file staging for schema-inferred sources",
+				Hidden:  true,
+				Sources: cli.EnvVars("INGESTR_DISABLE_PRESTAGING"),
+			},
 			&cli.IntFlag{
 				Name:    "sql-limit",
 				Usage:   "The limit to use when fetching data from the source",
@@ -267,6 +273,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.LoaderFileFormat = c.String("loader-file-format")
 	cfg.ExtractParallelism = int(c.Int("extract-parallelism"))
 	cfg.ExtractPartitionBy = c.String("extract-partition-by")
+	cfg.DisablePreStaging = c.Bool("disable-prestaging")
 	cfg.SQLLimit = int(c.Int("sql-limit"))
 	cfg.SQLExcludeColumns = c.StringSlice("sql-exclude-columns")
 	cfg.Columns = c.String("columns")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ type IngestConfig struct {
 	ExtractPartitionInterval        time.Duration
 	ExtractPartitionNumericInterval int64
 	ExtractPartitionAuto            bool
+	DisablePreStaging               bool // Skip extract-time load-file staging for schema-inferred sources
 
 	SQLLimit          int
 	SQLExcludeColumns []string

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -850,6 +850,14 @@ func (d *BigQueryDestination) WriteParallel(ctx context.Context, records <-chan 
 		}
 	}
 
+	if opts.PreStaged != nil {
+		ps, ok := opts.PreStaged.(*preStagedLoadSet)
+		if !ok || d.effectiveLoadMethod() != loadMethodLoadJob {
+			return fmt.Errorf("pre-staged data is not compatible with this BigQuery configuration")
+		}
+		return d.writePreStaged(ctx, project, dataset, table, records, ps, opts)
+	}
+
 	if d.effectiveLoadMethod() == loadMethodLoadJob {
 		if d.loadJobWriter != nil {
 			return d.loadJobWriter(ctx, dataset, table, records, opts)

--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -978,13 +978,16 @@ func (s *chunkStager) closeChunk() error {
 	if s.chunkWriter == nil {
 		return nil
 	}
-	if err := s.chunkWriter.Close(); err != nil {
-		return err
-	}
+
+	chunkWriter := s.chunkWriter
 	s.chunks = append(s.chunks, s.chunkMeta)
 	s.chunkWriter = nil
 	s.currentRows = 0
 	s.part++
+
+	if err := chunkWriter.Close(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1066,7 +1069,7 @@ func (s *chunkStager) finish() ([]stagedLoadChunk, int64, error) {
 		return s.chunks, s.totalRows, nil
 	}
 	if err := s.closeChunk(); err != nil {
-		return nil, s.totalRows, fmt.Errorf("failed to finalize %s staging writer: %w", s.format, err)
+		return s.chunks, s.totalRows, fmt.Errorf("failed to finalize %s staging writer: %w", s.format, err)
 	}
 	return s.chunks, s.totalRows, nil
 }
@@ -1100,7 +1103,7 @@ func (d *BigQueryDestination) writeLoadJobChunks(
 		err := stager.writeRecord(ctx, record)
 		record.Release()
 		if err != nil {
-			return nil, stager.totalRows, err
+			return stager.chunks, stager.totalRows, err
 		}
 	}
 

--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	gcbq "cloud.google.com/go/bigquery"
@@ -58,6 +59,10 @@ type stagedLoadSet struct {
 	tempDir string
 	format  loadJobFileFormat
 	chunks  []stagedLoadChunk
+
+	// ignoreUnknownValues is set for pre-staged files, which may carry columns
+	// that schema inference later dropped (all-null unknown columns).
+	ignoreUnknownValues bool
 }
 
 type loadJobChunkWriter interface {
@@ -165,7 +170,7 @@ func (d *BigQueryDestination) writeWithLoadJob(
 			table,
 		)
 	}
-	if err := d.runLoadJobs(ctx, project, dataset, table, staged, loadParallelism); err != nil {
+	if _, err := d.runLoadJobs(ctx, project, dataset, table, staged, loadParallelism); err != nil {
 		return err
 	}
 
@@ -293,6 +298,7 @@ func (d *BigQueryDestination) stageLoadJobFilesToGCS(
 func (d *BigQueryDestination) buildLoadSource(
 	format loadJobFileFormat,
 	chunk stagedLoadChunk,
+	ignoreUnknownValues bool,
 ) (gcbq.LoadSource, func(), error) {
 	if chunk.localPath != "" {
 		file, err := os.Open(chunk.localPath)
@@ -302,6 +308,7 @@ func (d *BigQueryDestination) buildLoadSource(
 
 		src := gcbq.NewReaderSource(file)
 		src.SourceFormat = format.bigQuerySourceFormat()
+		src.IgnoreUnknownValues = ignoreUnknownValues
 		if format == loadJobFormatParquet {
 			src.ParquetOptions = &gcbq.ParquetOptions{EnableListInference: true}
 		}
@@ -310,6 +317,7 @@ func (d *BigQueryDestination) buildLoadSource(
 
 	src := gcbq.NewGCSReference(chunk.gcsURI)
 	src.SourceFormat = format.bigQuerySourceFormat()
+	src.IgnoreUnknownValues = ignoreUnknownValues
 	if format == loadJobFormatParquet {
 		src.ParquetOptions = &gcbq.ParquetOptions{EnableListInference: true}
 	}
@@ -555,6 +563,9 @@ func buildStagingGCSObjectAttrs(format loadJobFileFormat) gcsstorage.ObjectAttrs
 	}
 }
 
+// runLoadJobs executes the load jobs for a staged set and returns the total
+// number of rows BigQuery reported loading, or -1 when the count could not be
+// determined from the job statistics.
 func (d *BigQueryDestination) runLoadJobs(
 	ctx context.Context,
 	project string,
@@ -562,13 +573,13 @@ func (d *BigQueryDestination) runLoadJobs(
 	table string,
 	staged *stagedLoadSet,
 	parallelism int,
-) error {
+) (int64, error) {
 	if staged == nil || len(staged.chunks) == 0 {
-		return nil
+		return 0, nil
 	}
 	if staged.hasOnlyGCSObjects() {
 		config.Debug("[DEST] Loading %d staged %s chunk(s) into %s.%s with a single multi-URI load job", len(staged.chunks), staged.format, dataset, table)
-		return d.runCombinedGCSLoadJob(ctx, project, dataset, table, staged.format, staged.chunks)
+		return d.runCombinedGCSLoadJob(ctx, project, dataset, table, staged, staged.chunks)
 	}
 	if parallelism <= 0 {
 		parallelism = 1
@@ -584,19 +595,28 @@ func (d *BigQueryDestination) runLoadJobs(
 	work := make(chan stagedLoadChunk)
 	errCh := make(chan error, 1)
 
+	var outputRows atomic.Int64
+	var outputRowsUnknown atomic.Bool
+
 	var wg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for chunk := range work {
-				if err := d.runSingleLoadJob(loadCtx, project, dataset, table, staged.format, chunk); err != nil {
+				rows, err := d.runSingleLoadJob(loadCtx, project, dataset, table, staged, chunk)
+				if err != nil {
 					select {
 					case errCh <- err:
 						cancel()
 					default:
 					}
 					return
+				}
+				if rows < 0 {
+					outputRowsUnknown.Store(true)
+				} else {
+					outputRows.Add(rows)
 				}
 			}
 		}()
@@ -615,12 +635,15 @@ dispatch:
 
 	select {
 	case err := <-errCh:
-		return err
+		return -1, err
 	default:
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return -1, ctx.Err()
 		}
-		return nil
+		if outputRowsUnknown.Load() {
+			return -1, nil
+		}
+		return outputRows.Load(), nil
 	}
 }
 
@@ -629,12 +652,12 @@ func (d *BigQueryDestination) runCombinedGCSLoadJob(
 	project string,
 	dataset string,
 	table string,
-	format loadJobFileFormat,
+	staged *stagedLoadSet,
 	chunks []stagedLoadChunk,
-) error {
-	loadSource, err := d.buildCombinedGCSLoadSource(format, chunks)
+) (int64, error) {
+	loadSource, err := d.buildCombinedGCSLoadSource(staged.format, chunks, staged.ignoreUnknownValues)
 	if err != nil {
-		return err
+		return -1, err
 	}
 
 	tableRef := d.client.DatasetInProject(project, dataset).Table(table)
@@ -645,22 +668,35 @@ func (d *BigQueryDestination) runCombinedGCSLoadJob(
 	config.Debug("[DEST] Starting combined load job for %d GCS chunk(s) into %s.%s", len(chunks), dataset, table)
 	job, err := loader.Run(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to start combined load job: %w", err)
+		return -1, fmt.Errorf("failed to start combined load job: %w", err)
 	}
 
 	status, err := job.Wait(ctx)
 	if err != nil {
-		return fmt.Errorf("combined load job failed (job %s): %w", jobRef(job), err)
+		return -1, fmt.Errorf("combined load job failed (job %s): %w", jobRef(job), err)
 	}
 	if err := status.Err(); err != nil {
 		if details := loadJobErrorDetails(status); details != "" {
-			return fmt.Errorf("combined load job error (job %s): %w; details: %s", jobRef(job), err, details)
+			return -1, fmt.Errorf("combined load job error (job %s): %w; details: %s", jobRef(job), err, details)
 		}
-		return fmt.Errorf("combined load job error (job %s): %w", jobRef(job), err)
+		return -1, fmt.Errorf("combined load job error (job %s): %w", jobRef(job), err)
 	}
 
 	config.Debug("[DEST] Combined load job finished for %s.%s", dataset, table)
-	return nil
+	return loadJobOutputRows(status), nil
+}
+
+// loadJobOutputRows extracts the loaded row count from a completed load job's
+// statistics, returning -1 when unavailable.
+func loadJobOutputRows(status *gcbq.JobStatus) int64 {
+	if status == nil || status.Statistics == nil {
+		return -1
+	}
+	details, ok := status.Statistics.Details.(*gcbq.LoadStatistics)
+	if !ok || details == nil {
+		return -1
+	}
+	return details.OutputRows
 }
 
 func (d *BigQueryDestination) runSingleLoadJob(
@@ -668,9 +704,9 @@ func (d *BigQueryDestination) runSingleLoadJob(
 	project string,
 	dataset string,
 	table string,
-	format loadJobFileFormat,
+	staged *stagedLoadSet,
 	chunk stagedLoadChunk,
-) error {
+) (int64, error) {
 	maxAttempts := loadJobMaxAttempts
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -683,9 +719,9 @@ func (d *BigQueryDestination) runSingleLoadJob(
 			attempt,
 			maxAttempts,
 		)
-		loadSource, cleanup, err := d.buildLoadSource(format, chunk)
+		loadSource, cleanup, err := d.buildLoadSource(staged.format, chunk, staged.ignoreUnknownValues)
 		if err != nil {
-			return err
+			return -1, err
 		}
 
 		tableRef := d.client.DatasetInProject(project, dataset).Table(table)
@@ -700,11 +736,11 @@ func (d *BigQueryDestination) runSingleLoadJob(
 				backoff := time.Duration(attempt) * time.Second
 				config.Debug("[DEST] Retrying load job for chunk %d after start error: %v", chunk.index+1, err)
 				if err := sleepWithContextForLoadJob(ctx, backoff); err != nil {
-					return err
+					return -1, err
 				}
 				continue
 			}
-			return fmt.Errorf("failed to start load job for chunk %d: %w", chunk.index+1, err)
+			return -1, fmt.Errorf("failed to start load job for chunk %d: %w", chunk.index+1, err)
 		}
 
 		status, err := job.Wait(ctx)
@@ -713,32 +749,32 @@ func (d *BigQueryDestination) runSingleLoadJob(
 				backoff := time.Duration(attempt) * time.Second
 				config.Debug("[DEST] Retrying load job for chunk %d after wait error: %v", chunk.index+1, err)
 				if err := sleepWithContextForLoadJob(ctx, backoff); err != nil {
-					return err
+					return -1, err
 				}
 				continue
 			}
-			return fmt.Errorf("load job failed for chunk %d (job %s): %w", chunk.index+1, jobRef(job), err)
+			return -1, fmt.Errorf("load job failed for chunk %d (job %s): %w", chunk.index+1, jobRef(job), err)
 		}
 		if err := status.Err(); err != nil {
 			if attempt < maxAttempts && isRetryableLoadJobError(err) {
 				backoff := time.Duration(attempt) * time.Second
 				config.Debug("[DEST] Retrying load job for chunk %d after job error: %v", chunk.index+1, err)
 				if err := sleepWithContextForLoadJob(ctx, backoff); err != nil {
-					return err
+					return -1, err
 				}
 				continue
 			}
 			if details := loadJobErrorDetails(status); details != "" {
-				return fmt.Errorf("load job error for chunk %d (job %s): %w; details: %s", chunk.index+1, jobRef(job), err, details)
+				return -1, fmt.Errorf("load job error for chunk %d (job %s): %w; details: %s", chunk.index+1, jobRef(job), err, details)
 			}
-			return fmt.Errorf("load job error for chunk %d (job %s): %w", chunk.index+1, jobRef(job), err)
+			return -1, fmt.Errorf("load job error for chunk %d (job %s): %w", chunk.index+1, jobRef(job), err)
 		}
 
 		config.Debug("[DEST] Load job finished for chunk %d into %s.%s", chunk.index+1, dataset, table)
-		return nil
+		return loadJobOutputRows(status), nil
 	}
 
-	return fmt.Errorf("load job error for chunk %d: exhausted retries", chunk.index+1)
+	return -1, fmt.Errorf("load job error for chunk %d: exhausted retries", chunk.index+1)
 }
 
 // loadJobErrorDetails formats the per-row/per-field errors that BigQuery records
@@ -871,6 +907,7 @@ func sleepWithContextForLoadJob(ctx context.Context, d time.Duration) error {
 func (d *BigQueryDestination) buildCombinedGCSLoadSource(
 	format loadJobFileFormat,
 	chunks []stagedLoadChunk,
+	ignoreUnknownValues bool,
 ) (gcbq.LoadSource, error) {
 	uris := make([]string, 0, len(chunks))
 	for _, chunk := range chunks {
@@ -882,6 +919,7 @@ func (d *BigQueryDestination) buildCombinedGCSLoadSource(
 
 	src := gcbq.NewGCSReference(uris...)
 	src.SourceFormat = format.bigQuerySourceFormat()
+	src.IgnoreUnknownValues = ignoreUnknownValues
 	if format == loadJobFormatParquet {
 		src.ParquetOptions = &gcbq.ParquetOptions{EnableListInference: true}
 	}
@@ -917,6 +955,122 @@ func (d *BigQueryDestination) writeParquetStream(
 	return d.writeLoadJobStream(ctx, records, loadJobFormatParquet, openWriter)
 }
 
+// chunkStager writes record batches into a sequence of load-file chunks,
+// rotating files every maxRowsPerFile rows. It is push-based so that both the
+// channel-consuming write path and the extract-time pre-staging path share
+// the same chunking logic.
+type chunkStager struct {
+	format         loadJobFileFormat
+	maxRowsPerFile int64
+	targetSchema   *arrow.Schema
+	rowOpts        jsonlRowOptions
+	openWriter     func(part int) (stagedLoadChunk, io.WriteCloser, error)
+
+	chunks      []stagedLoadChunk
+	totalRows   int64
+	currentRows int64
+	part        int
+	chunkMeta   stagedLoadChunk
+	chunkWriter loadJobChunkWriter
+}
+
+func (s *chunkStager) closeChunk() error {
+	if s.chunkWriter == nil {
+		return nil
+	}
+	if err := s.chunkWriter.Close(); err != nil {
+		return err
+	}
+	s.chunks = append(s.chunks, s.chunkMeta)
+	s.chunkWriter = nil
+	s.currentRows = 0
+	s.part++
+	return nil
+}
+
+func (s *chunkStager) abort(cause error) {
+	if s.chunkWriter == nil {
+		return
+	}
+	s.chunkWriter.Abort(cause)
+	s.chunkWriter = nil
+}
+
+func (s *chunkStager) openChunk() error {
+	meta, writer, err := s.openWriter(s.part)
+	if err != nil {
+		return err
+	}
+	s.chunkMeta = meta
+	s.chunkMeta.index = s.part
+	s.chunkWriter = newLoadJobChunkWriter(s.format, writer, s.targetSchema, s.rowOpts)
+	s.currentRows = 0
+	return nil
+}
+
+// writeRecord appends a record batch, rotating chunk files as needed.
+// The caller retains ownership of the record.
+func (s *chunkStager) writeRecord(ctx context.Context, record arrow.RecordBatch) error {
+	for start := int64(0); start < record.NumRows(); {
+		if err := ctx.Err(); err != nil {
+			s.abort(err)
+			return err
+		}
+
+		if s.chunkWriter == nil {
+			if err := s.openChunk(); err != nil {
+				return fmt.Errorf("failed to open %s staging writer: %w", s.format, err)
+			}
+		}
+
+		end := record.NumRows()
+		if s.maxRowsPerFile > 0 {
+			remainingCapacity := s.maxRowsPerFile - s.currentRows
+			if remainingCapacity <= 0 {
+				if err := s.closeChunk(); err != nil {
+					return fmt.Errorf("failed to finalize %s staging writer: %w", s.format, err)
+				}
+				continue
+			}
+			if span := start + remainingCapacity; span < end {
+				end = span
+			}
+		}
+
+		slice := record.NewSlice(start, end)
+		err := s.chunkWriter.WriteRecord(slice)
+		slice.Release()
+		if err != nil {
+			s.abort(err)
+			return fmt.Errorf("failed to write %s staging batch: %w", s.format, err)
+		}
+
+		rowsWritten := end - start
+		s.totalRows += rowsWritten
+		s.currentRows += rowsWritten
+		s.chunkMeta.rows += rowsWritten
+		start = end
+
+		if s.maxRowsPerFile > 0 && s.currentRows >= s.maxRowsPerFile {
+			if err := s.closeChunk(); err != nil {
+				return fmt.Errorf("failed to finalize %s staging writer: %w", s.format, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *chunkStager) finish() ([]stagedLoadChunk, int64, error) {
+	if s.chunkWriter == nil {
+		return s.chunks, s.totalRows, nil
+	}
+	if err := s.closeChunk(); err != nil {
+		return nil, s.totalRows, fmt.Errorf("failed to finalize %s staging writer: %w", s.format, err)
+	}
+	return s.chunks, s.totalRows, nil
+}
+
 func (d *BigQueryDestination) writeLoadJobChunks(
 	ctx context.Context,
 	records <-chan source.RecordBatchResult,
@@ -925,53 +1079,17 @@ func (d *BigQueryDestination) writeLoadJobChunks(
 	targetSchema *arrow.Schema,
 	openWriter func(part int) (stagedLoadChunk, io.WriteCloser, error),
 ) ([]stagedLoadChunk, int64, error) {
-	var (
-		chunks      []stagedLoadChunk
-		totalRows   int64
-		currentRows int64
-		part        int
-		chunkMeta   stagedLoadChunk
-		chunkWriter loadJobChunkWriter
-	)
-
-	closeChunk := func() error {
-		if chunkWriter == nil {
-			return nil
-		}
-		if err := chunkWriter.Close(); err != nil {
-			return err
-		}
-		chunks = append(chunks, chunkMeta)
-		chunkWriter = nil
-		currentRows = 0
-		part++
-		return nil
-	}
-
-	abortChunk := func(cause error) {
-		if chunkWriter == nil {
-			return
-		}
-		chunkWriter.Abort(cause)
-		chunkWriter = nil
-	}
-
-	openChunk := func() error {
-		meta, writer, err := openWriter(part)
-		if err != nil {
-			return err
-		}
-		chunkMeta = meta
-		chunkMeta.index = part
-		chunkWriter = newLoadJobChunkWriter(format, writer, targetSchema)
-		currentRows = 0
-		return nil
+	stager := &chunkStager{
+		format:         format,
+		maxRowsPerFile: maxRowsPerFile,
+		targetSchema:   targetSchema,
+		openWriter:     openWriter,
 	}
 
 	for result := range records {
 		if result.Err != nil {
-			abortChunk(result.Err)
-			return nil, totalRows, result.Err
+			stager.abort(result.Err)
+			return nil, stager.totalRows, result.Err
 		}
 
 		record := result.Batch
@@ -979,77 +1097,32 @@ func (d *BigQueryDestination) writeLoadJobChunks(
 			continue
 		}
 
-		for start := int64(0); start < record.NumRows(); {
-			if err := ctx.Err(); err != nil {
-				record.Release()
-				abortChunk(err)
-				return nil, totalRows, err
-			}
-
-			if chunkWriter == nil {
-				if err := openChunk(); err != nil {
-					record.Release()
-					return nil, totalRows, fmt.Errorf("failed to open %s staging writer: %w", format, err)
-				}
-			}
-
-			end := record.NumRows()
-			if maxRowsPerFile > 0 {
-				remainingCapacity := maxRowsPerFile - currentRows
-				if remainingCapacity <= 0 {
-					if err := closeChunk(); err != nil {
-						record.Release()
-						return nil, totalRows, fmt.Errorf("failed to finalize %s staging writer: %w", format, err)
-					}
-					continue
-				}
-				if span := start + remainingCapacity; span < end {
-					end = span
-				}
-			}
-
-			slice := record.NewSlice(start, end)
-			err := chunkWriter.WriteRecord(slice)
-			slice.Release()
-			if err != nil {
-				record.Release()
-				abortChunk(err)
-				return nil, totalRows, fmt.Errorf("failed to write %s staging batch: %w", format, err)
-			}
-
-			rowsWritten := end - start
-			totalRows += rowsWritten
-			currentRows += rowsWritten
-			chunkMeta.rows += rowsWritten
-			start = end
-
-			if maxRowsPerFile > 0 && currentRows >= maxRowsPerFile {
-				if err := closeChunk(); err != nil {
-					record.Release()
-					return nil, totalRows, fmt.Errorf("failed to finalize %s staging writer: %w", format, err)
-				}
-			}
-		}
-
+		err := stager.writeRecord(ctx, record)
 		record.Release()
+		if err != nil {
+			return nil, stager.totalRows, err
+		}
 	}
 
-	if chunkWriter == nil {
-		return chunks, totalRows, nil
-	}
-	if err := closeChunk(); err != nil {
-		return nil, totalRows, fmt.Errorf("failed to finalize %s staging writer: %w", format, err)
-	}
-
-	return chunks, totalRows, nil
+	return stager.finish()
 }
 
-func newLoadJobChunkWriter(format loadJobFileFormat, writer io.WriteCloser, targetSchema *arrow.Schema) loadJobChunkWriter {
+// jsonlRowOptions customizes JSONL row serialization for extract-time
+// pre-staging: keys are renamed to the destination column names assumed at
+// extract time and the load timestamp column is injected into every row.
+type jsonlRowOptions struct {
+	keyTransform        func(string) string
+	loadTimestampColumn string
+	loadTimestampValue  string
+}
+
+func newLoadJobChunkWriter(format loadJobFileFormat, writer io.WriteCloser, targetSchema *arrow.Schema, rowOpts jsonlRowOptions) loadJobChunkWriter {
 	switch format {
 	case loadJobFormatJSONL:
 		return &jsonlChunkWriter{
 			stageWriter: writer,
 			bufferedW:   bufio.NewWriterSize(writer, stagedGCSBufferSize),
+			rowOpts:     rowOpts,
 		}
 	default:
 		return &parquetChunkWriter{
@@ -1070,10 +1143,11 @@ func newLoadJobChunkWriter(format loadJobFileFormat, writer io.WriteCloser, targ
 type jsonlChunkWriter struct {
 	stageWriter io.WriteCloser
 	bufferedW   *bufio.Writer
+	rowOpts     jsonlRowOptions
 }
 
 func (w *jsonlChunkWriter) WriteRecord(record arrow.RecordBatch) error {
-	_, err := writeRecordBatchAsJSONL(w.bufferedW, record)
+	_, err := writeRecordBatchAsJSONLWithOpts(w.bufferedW, record, w.rowOpts)
 	return err
 }
 
@@ -1198,7 +1272,7 @@ func closeParquetFileWriter(writer *pqarrow.FileWriter) (err error) {
 	return writer.Close()
 }
 
-func writeRecordBatchAsJSONL(writer *bufio.Writer, record arrow.RecordBatch) (int64, error) {
+func writeRecordBatchAsJSONLWithOpts(writer *bufio.Writer, record arrow.RecordBatch, opts jsonlRowOptions) (int64, error) {
 	encoder := json.NewEncoder(writer)
 	encoder.SetEscapeHTML(false)
 
@@ -1206,10 +1280,22 @@ func writeRecordBatchAsJSONL(writer *bufio.Writer, record arrow.RecordBatch) (in
 	numCols := int(record.NumCols())
 	arrowSchema := record.Schema()
 
+	keys := make([]string, numCols)
+	for colIdx := 0; colIdx < numCols; colIdx++ {
+		name := arrowSchema.Field(colIdx).Name
+		if opts.keyTransform != nil {
+			name = opts.keyTransform(name)
+		}
+		keys[colIdx] = name
+	}
+
 	for rowIdx := int64(0); rowIdx < numRows; rowIdx++ {
-		row := make(map[string]any, numCols)
+		row := make(map[string]any, numCols+1)
 		for colIdx := 0; colIdx < numCols; colIdx++ {
-			row[arrowSchema.Field(colIdx).Name] = extractJSONLValue(record.Column(colIdx), int(rowIdx))
+			row[keys[colIdx]] = extractJSONLValue(record.Column(colIdx), int(rowIdx))
+		}
+		if opts.loadTimestampColumn != "" {
+			row[opts.loadTimestampColumn] = opts.loadTimestampValue
 		}
 
 		if err := encoder.Encode(row); err != nil {

--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -995,6 +995,7 @@ func (s *chunkStager) abort(cause error) {
 	if s.chunkWriter == nil {
 		return
 	}
+	s.chunks = append(s.chunks, s.chunkMeta)
 	s.chunkWriter.Abort(cause)
 	s.chunkWriter = nil
 }
@@ -1092,7 +1093,7 @@ func (d *BigQueryDestination) writeLoadJobChunks(
 	for result := range records {
 		if result.Err != nil {
 			stager.abort(result.Err)
-			return nil, stager.totalRows, result.Err
+			return stager.chunks, stager.totalRows, result.Err
 		}
 
 		record := result.Batch

--- a/pkg/destination/bigquery/load_job_test.go
+++ b/pkg/destination/bigquery/load_job_test.go
@@ -424,7 +424,7 @@ func TestBuildCombinedGCSLoadSourceUsesAllChunkURIs(t *testing.T) {
 		{index: 1, gcsURI: "gs://bucket/prefix/part-000002.parquet"},
 	}
 
-	src, err := dest.buildCombinedGCSLoadSource(loadJobFormatParquet, chunks)
+	src, err := dest.buildCombinedGCSLoadSource(loadJobFormatParquet, chunks, false)
 	if err != nil {
 		t.Fatalf("buildCombinedGCSLoadSource returned error: %v", err)
 	}

--- a/pkg/destination/bigquery/load_job_test.go
+++ b/pkg/destination/bigquery/load_job_test.go
@@ -42,6 +42,16 @@ func (t *trackingWriteCloser) Close() error {
 	return nil
 }
 
+type closeErrorWriteCloser struct {
+	bytes.Buffer
+	closeCount int
+}
+
+func (c *closeErrorWriteCloser) Close() error {
+	c.closeCount++
+	return errors.New("close failed")
+}
+
 type shortWriteCloser struct{}
 
 func (s shortWriteCloser) Write([]byte) (int, error) { return 0, nil }
@@ -293,6 +303,38 @@ func TestWriteLoadJobChunksSplitsJSONLByLoaderFileSize(t *testing.T) {
 		if len(lines) != int(wantRows[i]) {
 			t.Fatalf("writer %d line count = %d, want %d", i, len(lines), wantRows[i])
 		}
+	}
+}
+
+func TestWriteLoadJobChunksReturnsFailedChunkOnCloseError(t *testing.T) {
+	dest := &BigQueryDestination{}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: makeTestRecordBatch(t, 1)}
+	close(records)
+
+	writer := &closeErrorWriteCloser{}
+	chunks, rowsWritten, err := dest.writeLoadJobChunks(context.Background(), records, loadJobFormatJSONL, 0, nil, func(part int) (stagedLoadChunk, io.WriteCloser, error) {
+		return stagedLoadChunk{
+			index:     part,
+			gcsBucket: "bucket",
+			gcsObject: "prefix/part-000001.jsonl",
+			gcsURI:    "gs://bucket/prefix/part-000001.jsonl",
+		}, writer, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("expected close error, got %v", err)
+	}
+	if rowsWritten != 1 {
+		t.Fatalf("rowsWritten = %d, want 1", rowsWritten)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("len(chunks) = %d, want 1", len(chunks))
+	}
+	if chunks[0].gcsURI != "gs://bucket/prefix/part-000001.jsonl" {
+		t.Fatalf("chunk gcsURI = %q", chunks[0].gcsURI)
+	}
+	if writer.closeCount != 1 {
+		t.Fatalf("writer closeCount = %d, want 1", writer.closeCount)
 	}
 }
 

--- a/pkg/destination/bigquery/load_job_test.go
+++ b/pkg/destination/bigquery/load_job_test.go
@@ -338,6 +338,40 @@ func TestWriteLoadJobChunksReturnsFailedChunkOnCloseError(t *testing.T) {
 	}
 }
 
+func TestWriteLoadJobChunksReturnsActiveChunkOnSourceError(t *testing.T) {
+	dest := &BigQueryDestination{}
+	sourceErr := errors.New("source failed")
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: makeTestRecordBatch(t, 1)}
+	records <- source.RecordBatchResult{Err: sourceErr}
+	close(records)
+
+	writer := &trackingWriteCloser{}
+	chunks, rowsWritten, err := dest.writeLoadJobChunks(context.Background(), records, loadJobFormatJSONL, 0, nil, func(part int) (stagedLoadChunk, io.WriteCloser, error) {
+		return stagedLoadChunk{
+			index:     part,
+			gcsBucket: "bucket",
+			gcsObject: "prefix/part-000001.jsonl",
+			gcsURI:    "gs://bucket/prefix/part-000001.jsonl",
+		}, writer, nil
+	})
+	if !errors.Is(err, sourceErr) {
+		t.Fatalf("error = %v, want %v", err, sourceErr)
+	}
+	if rowsWritten != 1 {
+		t.Fatalf("rowsWritten = %d, want 1", rowsWritten)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("len(chunks) = %d, want 1", len(chunks))
+	}
+	if chunks[0].gcsURI != "gs://bucket/prefix/part-000001.jsonl" {
+		t.Fatalf("chunk gcsURI = %q", chunks[0].gcsURI)
+	}
+	if writer.closeCount != 1 {
+		t.Fatalf("writer closeCount = %d, want 1", writer.closeCount)
+	}
+}
+
 func TestWriteLoadJobChunksSplitsParquetByLoaderFileSize(t *testing.T) {
 	dest := &BigQueryDestination{}
 	records := make(chan source.RecordBatchResult, 1)

--- a/pkg/destination/bigquery/prestage.go
+++ b/pkg/destination/bigquery/prestage.go
@@ -173,6 +173,8 @@ func (d *BigQueryDestination) writePreStaged(
 	ps *preStagedLoadSet,
 	opts destination.WriteOptions,
 ) error {
+	defer ps.Close()
+
 	for result := range records {
 		if result.Batch != nil {
 			result.Batch.Release()
@@ -196,7 +198,6 @@ func (d *BigQueryDestination) writePreStaged(
 		return fmt.Errorf("pre-staged load mismatch: BigQuery loaded %d rows but %d rows were staged", outputRows, ps.rows)
 	}
 
-	ps.Close()
 	config.Debug("[DEST] Pre-staged load completed for %s.%s", dataset, table)
 	return nil
 }

--- a/pkg/destination/bigquery/prestage.go
+++ b/pkg/destination/bigquery/prestage.go
@@ -1,0 +1,204 @@
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// NewPreStageWriter implements destination.PreStager. It stages JSONL load
+// files while the source extract is still running so the write phase can skip
+// the buffer-replay pipeline entirely and only run load jobs.
+func (d *BigQueryDestination) NewPreStageWriter(ctx context.Context, opts destination.PreStageOptions) (destination.PreStageWriter, error) {
+	if d.effectiveLoadMethod() != loadMethodLoadJob {
+		return nil, destination.ErrPreStageUnsupported
+	}
+	// Pre-staged files are always JSONL: unlike Parquet, JSONL does not embed a
+	// schema, so files written before inference finishes still load correctly.
+	// An explicit parquet loader format is honored by not pre-staging.
+	if strings.EqualFold(strings.TrimSpace(opts.LoaderFileFormat), string(loadJobFormatParquet)) {
+		return nil, destination.ErrPreStageUnsupported
+	}
+	if _, err := resolveLoadJobFileFormat(opts.LoaderFileFormat); err != nil {
+		return nil, destination.ErrPreStageUnsupported
+	}
+
+	rowOpts := jsonlRowOptions{keyTransform: opts.KeyTransform}
+	if opts.LoadTimestampColumn != "" {
+		rowOpts.loadTimestampColumn = opts.LoadTimestampColumn
+		rowOpts.loadTimestampValue = opts.LoadTimestamp.UTC().Format(time.RFC3339Nano)
+	}
+
+	maxRowsPerFile := opts.LoaderFileSize
+	if !opts.StagingTable && opts.StagingBucket == "" {
+		maxRowsPerFile = 0
+	}
+
+	writer := &preStageWriter{dest: d}
+
+	if opts.StagingBucket != "" {
+		bucket, prefix, err := parseGCSBucketURI(opts.StagingBucket)
+		if err != nil {
+			return nil, err
+		}
+		if err := d.ensureGCSClient(ctx); err != nil {
+			return nil, err
+		}
+		objectPrefix := buildGCSLoadObjectPrefix(prefix, opts.Table)
+		writer.stager = &chunkStager{
+			format:         loadJobFormatJSONL,
+			maxRowsPerFile: resolveLoadJobRowsPerFile(maxRowsPerFile),
+			rowOpts:        rowOpts,
+			openWriter: func(part int) (stagedLoadChunk, io.WriteCloser, error) {
+				objectName := buildGCSLoadObjectName(objectPrefix, loadJobFormatJSONL, part)
+				w := d.gcsClient.Bucket(bucket).Object(objectName).NewWriter(ctx)
+				w.ChunkSize = stagedGCSObjectChunkSize
+				attrs := buildStagingGCSObjectAttrs(loadJobFormatJSONL)
+				w.ContentType = attrs.ContentType
+				w.CacheControl = attrs.CacheControl
+				w.CustomTime = attrs.CustomTime
+				w.Metadata = attrs.Metadata
+				return stagedLoadChunk{
+					index:     part,
+					gcsBucket: bucket,
+					gcsObject: objectName,
+					gcsURI:    "gs://" + bucket + "/" + objectName,
+				}, newBufferedWriteCloser(w), nil
+			},
+		}
+		return writer, nil
+	}
+
+	tempDir, err := os.MkdirTemp("", "ingestr-bq-prestage-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir for pre-staged load files: %w", err)
+	}
+	writer.tempDir = tempDir
+	writer.stager = &chunkStager{
+		format:         loadJobFormatJSONL,
+		maxRowsPerFile: resolveLoadJobRowsPerFile(maxRowsPerFile),
+		rowOpts:        rowOpts,
+		openWriter: func(part int) (stagedLoadChunk, io.WriteCloser, error) {
+			path := buildLocalLoadFilePath(tempDir, opts.Table, loadJobFormatJSONL, part)
+			f, err := os.Create(path)
+			if err != nil {
+				return stagedLoadChunk{}, nil, err
+			}
+			return stagedLoadChunk{index: part, localPath: path}, f, nil
+		},
+	}
+	return writer, nil
+}
+
+type preStageWriter struct {
+	dest    *BigQueryDestination
+	stager  *chunkStager
+	tempDir string
+}
+
+func (w *preStageWriter) Append(ctx context.Context, batch arrow.RecordBatch) error {
+	if batch == nil {
+		return nil
+	}
+	return w.stager.writeRecord(ctx, batch)
+}
+
+func (w *preStageWriter) stagedSet() *stagedLoadSet {
+	return &stagedLoadSet{
+		tempDir:             w.tempDir,
+		format:              loadJobFormatJSONL,
+		chunks:              w.stager.chunks,
+		ignoreUnknownValues: true,
+	}
+}
+
+func (w *preStageWriter) Finish() (destination.PreStagedData, error) {
+	chunks, rows, err := w.stager.finish()
+	if err != nil {
+		w.Discard()
+		return nil, err
+	}
+	staged := w.stagedSet()
+	staged.chunks = chunks
+	if rows == 0 {
+		staged.cleanupLocal()
+		staged.cleanupRemote(context.Background(), w.dest.gcsClient)
+		return nil, nil
+	}
+	return &preStagedLoadSet{dest: w.dest, staged: staged, rows: rows}, nil
+}
+
+func (w *preStageWriter) Discard() {
+	w.stager.abort(errors.New("pre-staging discarded"))
+	staged := w.stagedSet()
+	staged.cleanupLocal()
+	staged.cleanupRemote(context.Background(), w.dest.gcsClient)
+}
+
+// preStagedLoadSet implements destination.PreStagedData for BigQuery.
+type preStagedLoadSet struct {
+	dest   *BigQueryDestination
+	staged *stagedLoadSet
+	rows   int64
+}
+
+func (p *preStagedLoadSet) RowCount() int64 {
+	return p.rows
+}
+
+func (p *preStagedLoadSet) Close() {
+	p.staged.cleanupLocal()
+	p.staged.cleanupRemote(context.Background(), p.dest.gcsClient)
+}
+
+// writePreStaged loads pre-staged JSONL files instead of consuming the record
+// stream. The records channel is drained defensively: it must be empty, and
+// receiving an actual batch indicates a wiring bug that would otherwise lose
+// data silently.
+func (d *BigQueryDestination) writePreStaged(
+	ctx context.Context,
+	project string,
+	dataset string,
+	table string,
+	records <-chan source.RecordBatchResult,
+	ps *preStagedLoadSet,
+	opts destination.WriteOptions,
+) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+			return errors.New("pre-staged write received unexpected record batches from the source")
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+
+	staged := ps.staged
+	config.Debug("[DEST] Loading %d pre-staged %s chunk(s) (%d rows) into %s.%s", len(staged.chunks), staged.format, ps.rows, dataset, table)
+	logStagedLoadSet(dataset, table, staged)
+
+	parallelism := d.resolveLoadJobParallelism(dataset, table, staged, opts)
+	outputRows, err := d.runLoadJobs(ctx, project, dataset, table, staged, parallelism)
+	if err != nil {
+		return err
+	}
+	if outputRows >= 0 && outputRows != ps.rows {
+		return fmt.Errorf("pre-staged load mismatch: BigQuery loaded %d rows but %d rows were staged", outputRows, ps.rows)
+	}
+
+	ps.Close()
+	config.Debug("[DEST] Pre-staged load completed for %s.%s", dataset, table)
+	return nil
+}
+
+var _ destination.PreStager = (*BigQueryDestination)(nil)

--- a/pkg/destination/bigquery/prestage_test.go
+++ b/pkg/destination/bigquery/prestage_test.go
@@ -227,8 +227,21 @@ func TestWritePreStagedRejectsUnexpectedBatches(t *testing.T) {
 
 func TestWritePreStagedDetectsRowCountMismatch(t *testing.T) {
 	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	tempDir := t.TempDir()
+	leftoverPath := filepath.Join(tempDir, "part-000001.jsonl")
+	if err := os.WriteFile(leftoverPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	// Zero staged chunks load zero rows; the writer expected 5.
-	ps := &preStagedLoadSet{dest: d, staged: &stagedLoadSet{format: loadJobFormatJSONL}, rows: 5}
+	ps := &preStagedLoadSet{
+		dest: d,
+		staged: &stagedLoadSet{
+			tempDir: tempDir,
+			format:  loadJobFormatJSONL,
+		},
+		rows: 5,
+	}
 
 	ch := make(chan source.RecordBatchResult)
 	close(ch)
@@ -236,6 +249,9 @@ func TestWritePreStagedDetectsRowCountMismatch(t *testing.T) {
 	err := d.writePreStaged(context.Background(), "p", "ds", "t", ch, ps, destination.WriteOptions{})
 	if err == nil || !strings.Contains(err.Error(), "mismatch") {
 		t.Fatalf("expected row count mismatch error, got %v", err)
+	}
+	if _, statErr := os.Stat(tempDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected temp dir %s to be removed after mismatch", tempDir)
 	}
 }
 

--- a/pkg/destination/bigquery/prestage_test.go
+++ b/pkg/destination/bigquery/prestage_test.go
@@ -1,0 +1,262 @@
+package bigquery
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func buildPreStageTestRecord(t *testing.T, ids []int64, names []string) arrow.RecordBatch {
+	t.Helper()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "userName", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer builder.Release()
+	builder.Field(0).(*array.Int64Builder).AppendValues(ids, nil)
+	builder.Field(1).(*array.StringBuilder).AppendValues(names, nil)
+
+	return builder.NewRecordBatch()
+}
+
+func snakeUpperTransform(name string) string {
+	if name == "userName" {
+		return "user_name"
+	}
+	return name
+}
+
+func TestNewPreStageWriterRejectsStorageWriteMethod(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodStorageWrite}
+	_, err := d.NewPreStageWriter(context.Background(), destination.PreStageOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected ErrPreStageUnsupported, got %v", err)
+	}
+}
+
+func TestNewPreStageWriterRejectsExplicitParquet(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	_, err := d.NewPreStageWriter(context.Background(), destination.PreStageOptions{LoaderFileFormat: "parquet"})
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected ErrPreStageUnsupported for parquet, got %v", err)
+	}
+}
+
+func TestPreStageWriterStagesJSONLWithTransformAndTimestamp(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	loadTS := time.Date(2026, 7, 2, 10, 30, 0, 123456000, time.UTC)
+
+	writer, err := d.NewPreStageWriter(context.Background(), destination.PreStageOptions{
+		Table:               "ds.users",
+		KeyTransform:        snakeUpperTransform,
+		LoadTimestampColumn: "_ingestr_loaded_at",
+		LoadTimestamp:       loadTS,
+		StagingTable:        true,
+		LoaderFileSize:      2,
+	})
+	if err != nil {
+		t.Fatalf("NewPreStageWriter: %v", err)
+	}
+
+	record := buildPreStageTestRecord(t, []int64{1, 2, 3, 4, 5}, []string{"a", "b", "c", "d", "e"})
+	if err := writer.Append(context.Background(), record); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	record.Release()
+
+	data, err := writer.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected pre-staged data, got nil")
+	}
+	defer data.Close()
+
+	if data.RowCount() != 5 {
+		t.Fatalf("RowCount = %d, want 5", data.RowCount())
+	}
+
+	ps, ok := data.(*preStagedLoadSet)
+	if !ok {
+		t.Fatalf("unexpected PreStagedData type %T", data)
+	}
+	if !ps.staged.ignoreUnknownValues {
+		t.Fatal("pre-staged load set must set ignoreUnknownValues")
+	}
+	if len(ps.staged.chunks) != 3 {
+		t.Fatalf("chunk count = %d, want 3 (5 rows / 2 rows per file)", len(ps.staged.chunks))
+	}
+
+	var rows []map[string]any
+	for _, chunk := range ps.staged.chunks {
+		f, err := os.Open(chunk.localPath)
+		if err != nil {
+			t.Fatalf("open chunk: %v", err)
+		}
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			var row map[string]any
+			if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
+				t.Fatalf("invalid JSONL row: %v", err)
+			}
+			rows = append(rows, row)
+		}
+		_ = f.Close()
+	}
+
+	if len(rows) != 5 {
+		t.Fatalf("row count in files = %d, want 5", len(rows))
+	}
+	first := rows[0]
+	if _, hasOriginal := first["userName"]; hasOriginal {
+		t.Fatal("expected key transform to rename userName")
+	}
+	if first["user_name"] != "a" {
+		t.Fatalf("user_name = %v, want a", first["user_name"])
+	}
+	if first["id"] != float64(1) {
+		t.Fatalf("id = %v, want 1", first["id"])
+	}
+	wantTS := loadTS.Format(time.RFC3339Nano)
+	if first["_ingestr_loaded_at"] != wantTS {
+		t.Fatalf("_ingestr_loaded_at = %v, want %s", first["_ingestr_loaded_at"], wantTS)
+	}
+}
+
+func TestPreStageWriterFinishWithNoRowsReturnsNil(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	writer, err := d.NewPreStageWriter(context.Background(), destination.PreStageOptions{Table: "ds.empty"})
+	if err != nil {
+		t.Fatalf("NewPreStageWriter: %v", err)
+	}
+
+	data, err := writer.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil PreStagedData for empty extract, got %v", data)
+	}
+
+	tempDir := writer.(*preStageWriter).tempDir
+	if _, statErr := os.Stat(tempDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected temp dir %s to be removed", tempDir)
+	}
+}
+
+func TestPreStageWriterDiscardRemovesFiles(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	writer, err := d.NewPreStageWriter(context.Background(), destination.PreStageOptions{
+		Table:          "ds.users",
+		StagingTable:   true,
+		LoaderFileSize: 100,
+	})
+	if err != nil {
+		t.Fatalf("NewPreStageWriter: %v", err)
+	}
+
+	record := buildPreStageTestRecord(t, []int64{1}, []string{"a"})
+	if err := writer.Append(context.Background(), record); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	record.Release()
+
+	tempDir := writer.(*preStageWriter).tempDir
+	writer.Discard()
+
+	if _, statErr := os.Stat(tempDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected temp dir %s to be removed after Discard", tempDir)
+	}
+}
+
+func TestPreStagedDataCloseIsIdempotent(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "part-000001.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ps := &preStagedLoadSet{
+		dest: d,
+		staged: &stagedLoadSet{
+			tempDir: tempDir,
+			format:  loadJobFormatJSONL,
+			chunks:  []stagedLoadChunk{{index: 0, localPath: path, rows: 1}},
+		},
+		rows: 1,
+	}
+
+	ps.Close()
+	ps.Close()
+
+	if _, statErr := os.Stat(tempDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected temp dir %s to be removed", tempDir)
+	}
+}
+
+func TestWritePreStagedRejectsUnexpectedBatches(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	ps := &preStagedLoadSet{dest: d, staged: &stagedLoadSet{format: loadJobFormatJSONL}, rows: 1}
+
+	record := buildPreStageTestRecord(t, []int64{1}, []string{"a"})
+	ch := make(chan source.RecordBatchResult, 1)
+	ch <- source.RecordBatchResult{Batch: record}
+	close(ch)
+
+	err := d.writePreStaged(context.Background(), "p", "ds", "t", ch, ps, destination.WriteOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unexpected record batches") {
+		t.Fatalf("expected unexpected-batches error, got %v", err)
+	}
+}
+
+func TestWritePreStagedDetectsRowCountMismatch(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodLoadJob}
+	// Zero staged chunks load zero rows; the writer expected 5.
+	ps := &preStagedLoadSet{dest: d, staged: &stagedLoadSet{format: loadJobFormatJSONL}, rows: 5}
+
+	ch := make(chan source.RecordBatchResult)
+	close(ch)
+
+	err := d.writePreStaged(context.Background(), "p", "ds", "t", ch, ps, destination.WriteOptions{})
+	if err == nil || !strings.Contains(err.Error(), "mismatch") {
+		t.Fatalf("expected row count mismatch error, got %v", err)
+	}
+}
+
+func TestWriteParallelRejectsForeignPreStagedData(t *testing.T) {
+	d := &BigQueryDestination{loadMethod: loadMethodStorageWrite, projectID: "p"}
+	ps := &preStagedLoadSet{dest: d, staged: &stagedLoadSet{format: loadJobFormatJSONL}, rows: 1}
+
+	ch := make(chan source.RecordBatchResult)
+	close(ch)
+
+	err := d.WriteParallel(context.Background(), ch, destination.WriteOptions{
+		Table:     "ds.t",
+		PreStaged: ps,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not compatible") {
+		t.Fatalf("expected incompatibility error, got %v", err)
+	}
+}
+
+func TestLoadJobOutputRowsNilSafety(t *testing.T) {
+	if got := loadJobOutputRows(nil); got != -1 {
+		t.Fatalf("loadJobOutputRows(nil) = %d, want -1", got)
+	}
+}

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -32,6 +32,11 @@ type WriteOptions struct {
 	StagingBucket    string
 	LoaderFileSize   int
 	LoaderFileFormat string
+
+	// PreStaged holds load files written during extract by a PreStager
+	// destination. When set, the destination loads these files instead of
+	// consuming the records channel (which will be empty).
+	PreStaged PreStagedData
 }
 
 type Transaction interface {

--- a/pkg/destination/prestage.go
+++ b/pkg/destination/prestage.go
@@ -1,0 +1,67 @@
+package destination
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// ErrPreStageUnsupported is returned by PreStager.NewPreStageWriter when the
+// destination cannot pre-stage load files for the current configuration
+// (e.g. BigQuery configured with the storage_write load method).
+var ErrPreStageUnsupported = errors.New("pre-staging is not supported for this configuration")
+
+// PreStageOptions configures extract-time load-file staging.
+type PreStageOptions struct {
+	// Table is the destination table name, used only for load-file naming.
+	Table string
+
+	// KeyTransform maps a source column name to the destination column name
+	// assumed at extract time. The pipeline verifies the assumption after
+	// schema inference and discards the pre-staged files on mismatch.
+	KeyTransform func(string) string
+
+	// LoadTimestampColumn, when non-empty, is injected into every staged row
+	// with LoadTimestamp as its value.
+	LoadTimestampColumn string
+	LoadTimestamp       time.Time
+
+	// StagingTable indicates the write phase targets a fresh staging table.
+	// Destinations may use it to pick file chunking policies.
+	StagingTable bool
+
+	StagingBucket    string
+	LoaderFileSize   int
+	LoaderFileFormat string
+	Parallelism      int
+}
+
+// PreStagedData is an opaque handle to load files staged during extract.
+// It is passed back to the destination through WriteOptions.PreStaged.
+type PreStagedData interface {
+	// RowCount reports the number of rows staged.
+	RowCount() int64
+	// Close removes the staged files. Safe to call multiple times.
+	Close()
+}
+
+// PreStageWriter consumes record batches during extract and stages them as
+// destination-native load files. Append must not retain the batch.
+type PreStageWriter interface {
+	Append(ctx context.Context, batch arrow.RecordBatch) error
+	// Finish finalizes the staged files. It returns nil data when no rows
+	// were staged.
+	Finish() (PreStagedData, error)
+	// Discard aborts staging and removes any files written so far.
+	Discard()
+}
+
+// PreStager is an optional destination interface: destinations that can load
+// from pre-staged files (written concurrently with the source extract) allow
+// the pipeline to skip the buffer-replay write path for schema-inferred
+// sources.
+type PreStager interface {
+	NewPreStageWriter(ctx context.Context, opts PreStageOptions) (PreStageWriter, error)
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -196,10 +196,21 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		defer func() { tracker.Stop(retErr) }()
 	}
 
+	// The load timestamp is chosen before extract so that pre-staged load
+	// files (written during extract) and the replay path stamp the same value.
+	var loadTimestamp time.Time
+	if !p.config.NoLoadTimestamp && !p.config.Stream {
+		loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
+	}
+
 	// Check if source has known schema or needs inference
 	var tableSchema *schema.TableSchema
 	var bufferedRecords <-chan source.RecordBatchResult
 	var inferBuffer *databuffer.FileBuffer
+	var preStagedData destination.PreStagedData
+	var preStageRpt *preStageReport
+	var preStageKeyTransform func(string) string
+	var preStagedForJob destination.PreStagedData
 
 	if table.HasKnownSchema() {
 		tableSchema, err = table.GetSchema(ctx)
@@ -215,7 +226,14 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	} else {
 		// Schema inference path: read all data first. Buffer is opened later
 		config.Debug("[PIPELINE] Source has unknown schema, inferring from data...")
-		tableSchema, inferBuffer, err = p.inferSchemaFromData(ctx, table, tracker)
+		var preStage destination.PreStageWriter
+		preStage, preStageKeyTransform = p.maybeStartPreStage(ctx, preFetchStrategy, preFetchConfig.PrimaryKeys, loadTimestamp)
+		tableSchema, inferBuffer, preStagedData, preStageRpt, err = p.inferSchemaFromData(ctx, table, tracker, preStage)
+		defer func() {
+			if preStagedData != nil && preStagedForJob == nil {
+				preStagedData.Close()
+			}
+		}()
 		if err != nil {
 			return fmt.Errorf("failed to infer schema: %w", err)
 		}
@@ -356,11 +374,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	}
 	p.applyDestinationSchemaConstraints(destSchema)
 
-	var loadTimestamp time.Time
 	if !p.config.NoLoadTimestamp {
-		if !p.config.Stream {
-			loadTimestamp = time.Now().UTC().Truncate(time.Microsecond)
-		}
 		destSchema = addLoadTimestampColumn(destSchema)
 	}
 
@@ -399,12 +413,25 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	}
 
 	if inferBuffer != nil {
-		bufferTarget := p.buildBufferReaderTarget(originalSourceSchema, destSchema)
-		bufferedRecords, err = inferBuffer.Reader(ctx, bufferTarget)
-		if err != nil {
-			return fmt.Errorf("failed to open buffer reader: %w", err)
+		if preStagedData != nil && p.preStagedUsable(preStageRpt, preStageKeyTransform, originalSourceSchema, ingestSchema) {
+			config.Debug("[PIPELINE] Using %d rows of pre-staged load files; skipping buffer replay", preStagedData.RowCount())
+			bufferedRecords = emptyRecordChannel()
+			preStagedForJob = preStagedData
+			_ = inferBuffer.Close()
+			inferBuffer = nil
+		} else {
+			if preStagedData != nil {
+				config.Debug("[PIPELINE] Discarding pre-staged load files; replaying from buffer")
+				preStagedData.Close()
+				preStagedData = nil
+			}
+			bufferTarget := p.buildBufferReaderTarget(originalSourceSchema, destSchema)
+			bufferedRecords, err = inferBuffer.Reader(ctx, bufferTarget)
+			if err != nil {
+				return fmt.Errorf("failed to open buffer reader: %w", err)
+			}
+			inferBuffer = nil
 		}
-		inferBuffer = nil
 	}
 
 	strat, err := strategy.Get(resolvedStrategy)
@@ -480,6 +507,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		SourceSchema:        originalSourceSchema,
 		Tracker:             jobTracker,
 		BufferedRecords:     bufferedRecords,
+		PreStaged:           preStagedForJob,
 		SchemaComparison:    p.schemaComparison,
 		DestinationSchema:   p.destinationSchema,
 		ColumnRenamer:       p.columnRenamer,
@@ -642,12 +670,20 @@ func (p *Pipeline) createTracker(ctx context.Context) (progress.Tracker, error) 
 	return tracker, nil
 }
 
-func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceTable, tracker progress.Tracker) (*schema.TableSchema, *databuffer.FileBuffer, error) {
+func (p *Pipeline) inferSchemaFromData(
+	ctx context.Context,
+	table source.SourceTable,
+	tracker progress.Tracker,
+	preStage destination.PreStageWriter,
+) (*schema.TableSchema, *databuffer.FileBuffer, destination.PreStagedData, *preStageReport, error) {
 	// Create schema inferrer and file-backed data buffer
 	inferrer := schemainfer.NewSchemaInferrer()
 	buffer, err := databuffer.NewFileBuffer()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create buffer: %w", err)
+		if preStage != nil {
+			preStage.Discard()
+		}
+		return nil, nil, nil, nil, fmt.Errorf("failed to create buffer: %w", err)
 	}
 
 	// Read all data from source
@@ -675,7 +711,10 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 	records, err := table.Read(ctx, readOpts)
 	if err != nil {
 		_ = buffer.Close()
-		return nil, nil, fmt.Errorf("failed to read from source: %w", err)
+		if preStage != nil {
+			preStage.Discard()
+		}
+		return nil, nil, nil, nil, fmt.Errorf("failed to read from source: %w", err)
 	}
 
 	// Wrap records with progress tracker for Extract logging
@@ -683,15 +722,19 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 		records = tracker.Wrap(records)
 	}
 
-	// Feed all records to inferrer and buffer in parallel
+	// Feed all records to the inferrer, the replay buffer, and (when active)
+	// the destination's pre-stage writer in parallel.
 	for result := range records {
 		if result.Err != nil {
 			_ = buffer.Close()
-			return nil, nil, fmt.Errorf("error reading batch: %w", result.Err)
+			if preStage != nil {
+				preStage.Discard()
+			}
+			return nil, nil, nil, nil, fmt.Errorf("error reading batch: %w", result.Err)
 		}
 
 		var wg sync.WaitGroup
-		var inferErr, bufErr error
+		var inferErr, bufErr, preErr error
 
 		wg.Add(2)
 		go func() {
@@ -702,24 +745,68 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 			defer wg.Done()
 			bufErr = buffer.Append(ctx, result.Batch)
 		}()
+		if preStage != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				preErr = preStage.Append(ctx, result.Batch)
+			}()
+		}
 		wg.Wait()
 
 		result.Batch.Release()
 
 		if inferErr != nil {
 			_ = buffer.Close()
-			return nil, nil, fmt.Errorf("failed to infer schema from batch: %w", inferErr)
+			if preStage != nil {
+				preStage.Discard()
+			}
+			return nil, nil, nil, nil, fmt.Errorf("failed to infer schema from batch: %w", inferErr)
 		}
 		if bufErr != nil {
 			_ = buffer.Close()
-			return nil, nil, fmt.Errorf("failed to buffer batch: %w", bufErr)
+			if preStage != nil {
+				preStage.Discard()
+			}
+			return nil, nil, nil, nil, fmt.Errorf("failed to buffer batch: %w", bufErr)
+		}
+		if preErr != nil {
+			// Pre-staging is an optimization: a write failure (e.g. a value JSON
+			// cannot encode) only cancels it, the extract continues.
+			config.Debug("[PIPELINE] Pre-staging disabled after write error: %v", preErr)
+			preStage.Discard()
+			preStage = nil
+		}
+	}
+
+	// Finalize pre-staged files and capture the inference facts needed to
+	// judge them once the final schema and column names are resolved.
+	var preStaged destination.PreStagedData
+	var report *preStageReport
+	if preStage != nil {
+		data, finishErr := preStage.Finish()
+		if finishErr != nil {
+			config.Debug("[PIPELINE] Pre-staging finalize failed: %v", finishErr)
+		} else if data != nil {
+			preStaged = data
+			report = &preStageReport{
+				typeUnstableColumns:   inferrer.TypeUnstableColumns(),
+				unknownStorageColumns: inferrer.UnknownStorageColumns(),
+			}
+		}
+	}
+
+	cleanup := func() {
+		_ = buffer.Close()
+		if preStaged != nil {
+			preStaged.Close()
 		}
 	}
 
 	// Protect columns specified via --columns from being dropped as all-null
 	if err := inferrer.ProtectColumnOverrides(p.config.Columns); err != nil {
-		_ = buffer.Close()
-		return nil, nil, err
+		cleanup()
+		return nil, nil, nil, nil, err
 	}
 
 	if partitionCol := resolvePartitionBy(p.config, table); partitionCol != "" {
@@ -729,13 +816,13 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 	// Infer schema
 	tableSchema, err := inferrer.ToTableSchema(table.Name())
 	if err != nil {
-		_ = buffer.Close()
-		return nil, nil, fmt.Errorf("failed to build schema: %w", err)
+		cleanup()
+		return nil, nil, nil, nil, fmt.Errorf("failed to build schema: %w", err)
 	}
 
 	if tableSchema == nil {
-		_ = buffer.Close()
-		return nil, nil, nil
+		cleanup()
+		return nil, nil, nil, nil, nil
 	}
 
 	p.droppedColumns = inferrer.DroppedColumns()
@@ -746,18 +833,18 @@ func (p *Pipeline) inferSchemaFromData(ctx context.Context, table source.SourceT
 	// Apply column type overrides before creating the buffer reader,
 	// so the reader casts data to match the overridden types.
 	if err := p.applyColumnOverrides(tableSchema); err != nil {
-		_ = buffer.Close()
-		return nil, nil, fmt.Errorf("failed to apply column overrides: %w", err)
+		cleanup()
+		return nil, nil, nil, nil, fmt.Errorf("failed to apply column overrides: %w", err)
 	}
 
 	// For schema-less sources, also append override columns that were never seen
 	// in the data — the buffer reader will fill them with nulls.
 	if err := schemainfer.AppendMissingOverrideColumns(tableSchema, p.config.Columns, p.config.SchemaNaming); err != nil {
-		_ = buffer.Close()
-		return nil, nil, fmt.Errorf("failed to append missing override columns: %w", err)
+		cleanup()
+		return nil, nil, nil, nil, fmt.Errorf("failed to append missing override columns: %w", err)
 	}
 
-	return tableSchema, buffer, nil
+	return tableSchema, buffer, preStaged, report, nil
 }
 
 // buildBufferReaderTarget builds the Arrow schema for buffer.Reader:

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -230,7 +230,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		preStage, preStageKeyTransform = p.maybeStartPreStage(ctx, preFetchStrategy, preFetchConfig.PrimaryKeys, loadTimestamp)
 		tableSchema, inferBuffer, preStagedData, preStageRpt, err = p.inferSchemaFromData(ctx, table, tracker, preStage)
 		defer func() {
-			if preStagedData != nil && preStagedForJob == nil {
+			if preStagedData != nil {
 				preStagedData.Close()
 			}
 		}()

--- a/pkg/pipeline/prestage.go
+++ b/pkg/pipeline/prestage.go
@@ -1,0 +1,209 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/naming"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+// preStageReport captures the inference facts needed to decide whether
+// pre-staged load files (written with raw, pre-inference values) are safe to
+// load into the final schema.
+type preStageReport struct {
+	typeUnstableColumns   []string
+	unknownStorageColumns map[string]bool
+}
+
+// preStageStrategies are the write strategies whose write phase consumes the
+// record stream verbatim (no strategy-injected columns and no data-dependent
+// bookkeeping such as interval tracking), so an empty stream plus pre-staged
+// files is equivalent.
+func preStageStrategyAllowed(strategy config.IncrementalStrategy) bool {
+	switch strategy {
+	case config.StrategyMerge, config.StrategyReplace, config.StrategyAppend, config.StrategyTruncateInsert:
+		return true
+	default:
+		return false
+	}
+}
+
+// maybeStartPreStage starts extract-time load-file staging when the
+// destination supports it and the run configuration guarantees that batches
+// need no replay-time transformation the pre-stage writer cannot apply.
+// It returns nil when pre-staging should not be attempted.
+func (p *Pipeline) maybeStartPreStage(
+	ctx context.Context,
+	strategy config.IncrementalStrategy,
+	primaryKeys []string,
+	loadTimestamp time.Time,
+) (destination.PreStageWriter, func(string) string) {
+	if p.config.DisablePreStaging {
+		return nil, nil
+	}
+
+	prestager, ok := p.dest.(destination.PreStager)
+	if !ok {
+		return nil, nil
+	}
+
+	if p.config.Stream || !preStageStrategyAllowed(strategy) {
+		return nil, nil
+	}
+	if len(p.config.Mask) > 0 || p.config.TrimWhitespace {
+		return nil, nil
+	}
+	if strings.TrimSpace(p.config.Columns) != "" {
+		return nil, nil
+	}
+	if contract := strings.TrimSpace(p.config.SchemaContract); contract != "" && contract != "evolve" {
+		return nil, nil
+	}
+
+	keyTransform := p.resolvePreStageKeyTransform(ctx)
+	if keyTransform == nil {
+		return nil, nil
+	}
+
+	loadTimestampColumn := ""
+	if !p.config.NoLoadTimestamp {
+		loadTimestampColumn = naming.IngestrLoadedAtColumn
+	}
+
+	usesStagingTable := strategy == config.StrategyMerge ||
+		strategy == config.StrategyReplace ||
+		(strategy == config.StrategyTruncateInsert && len(primaryKeys) > 0)
+
+	writer, err := prestager.NewPreStageWriter(ctx, destination.PreStageOptions{
+		Table:               p.config.DestTable,
+		KeyTransform:        keyTransform,
+		LoadTimestampColumn: loadTimestampColumn,
+		LoadTimestamp:       loadTimestamp,
+		StagingTable:        usesStagingTable,
+		StagingBucket:       p.config.StagingBucket,
+		LoaderFileSize:      p.config.LoaderFileSize,
+		LoaderFileFormat:    p.config.LoaderFileFormat,
+		Parallelism:         p.config.ExtractParallelism,
+	})
+	if err != nil {
+		if !errors.Is(err, destination.ErrPreStageUnsupported) {
+			config.Debug("[PIPELINE] Pre-staging unavailable: %v", err)
+		}
+		return nil, nil
+	}
+
+	config.Debug("[PIPELINE] Pre-staging load files during extract")
+	return writer, keyTransform
+}
+
+// resolvePreStageKeyTransform returns the column-name transform the naming
+// convention will apply, when that is already determined before the source
+// schema is known. It mirrors resolveNamingConvention: an explicit convention
+// is fixed, and "auto" resolves to snake_case unless the destination table
+// already exists (in which case detection depends on the inferred schema and
+// pre-staging is skipped).
+func (p *Pipeline) resolvePreStageKeyTransform(ctx context.Context) func(string) string {
+	convention, err := naming.ParseConvention(p.config.SchemaNaming)
+	if err != nil {
+		return nil
+	}
+
+	if convention == naming.Auto {
+		destSchema, err := p.dest.GetTableSchema(ctx, p.config.DestTable)
+		if err == nil && destSchema != nil {
+			return nil
+		}
+		convention = naming.SnakeCase
+	}
+
+	return naming.Get(convention).Normalize
+}
+
+// preStagedUsable verifies, after inference and name resolution, that the
+// assumptions the pre-stage writer made at extract time hold:
+//   - no column needed type promotion across batches (raw early values might
+//     not coerce into the promoted type),
+//   - no unknown-storage column resolved to a temporal type (ingestr's date
+//     parsing is more lenient than BigQuery's load-time parsing),
+//   - the assumed key transform produced exactly the final column names, with
+//     no collisions, and no legacy ingestr metadata columns need filling,
+//   - no source column collides with the injected load-timestamp column.
+func (p *Pipeline) preStagedUsable(
+	report *preStageReport,
+	keyTransform func(string) string,
+	originalSourceSchema *schema.TableSchema,
+	writeSchema *schema.TableSchema,
+) bool {
+	if report == nil || keyTransform == nil || originalSourceSchema == nil || writeSchema == nil {
+		return false
+	}
+
+	if len(report.typeUnstableColumns) > 0 {
+		config.Debug("[PIPELINE] Pre-staged files unusable: type promotion on columns %v", report.typeUnstableColumns)
+		return false
+	}
+
+	if p.ingestrColumnFiller != nil && p.ingestrColumnFiller.HasColumns() {
+		config.Debug("[PIPELINE] Pre-staged files unusable: legacy ingestr columns need filling")
+		return false
+	}
+
+	var renames map[string]string
+	if p.columnRenamer != nil && p.columnRenamer.HasRenames() {
+		renames = p.columnRenamer.Mapping()
+	}
+	finalName := func(original string) string {
+		if renamed, ok := renames[original]; ok {
+			return renamed
+		}
+		return original
+	}
+
+	seen := make(map[string]bool, len(originalSourceSchema.Columns))
+	for _, col := range originalSourceSchema.Columns {
+		if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
+			config.Debug("[PIPELINE] Pre-staged files unusable: source column %q collides with the load timestamp column", col.Name)
+			return false
+		}
+		final := finalName(col.Name)
+		if keyTransform(col.Name) != final {
+			config.Debug("[PIPELINE] Pre-staged files unusable: column %q resolved to %q, staged as %q", col.Name, final, keyTransform(col.Name))
+			return false
+		}
+		lower := strings.ToLower(final)
+		if seen[lower] {
+			config.Debug("[PIPELINE] Pre-staged files unusable: column name collision on %q", final)
+			return false
+		}
+		seen[lower] = true
+	}
+
+	if len(report.unknownStorageColumns) > 0 {
+		finalTypes := make(map[string]schema.DataType, len(writeSchema.Columns))
+		for _, col := range writeSchema.Columns {
+			finalTypes[strings.ToLower(col.Name)] = col.DataType
+		}
+		for name := range report.unknownStorageColumns {
+			dt, ok := finalTypes[strings.ToLower(finalName(name))]
+			if !ok {
+				continue // dropped column; IgnoreUnknownValues handles it
+			}
+			switch dt {
+			// Temporal: ingestr's date parsing accepts formats BigQuery's
+			// load-time parsing rejects. String: an unknown column can resolve
+			// to string via a merge conflict (mixed scalar types), leaving raw
+			// JSON numbers in the staged files that won't coerce to STRING.
+			case schema.TypeTimestamp, schema.TypeTimestampTZ, schema.TypeDate, schema.TypeTime, schema.TypeString:
+				config.Debug("[PIPELINE] Pre-staged files unusable: column %q resolved to %s from JSON-encoded values", name, dt)
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/pkg/pipeline/prestage_test.go
+++ b/pkg/pipeline/prestage_test.go
@@ -1,0 +1,308 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/naming"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/transformer"
+)
+
+type mockPreStageWriter struct {
+	discarded bool
+}
+
+func (m *mockPreStageWriter) Append(_ context.Context, _ arrow.RecordBatch) error {
+	return nil
+}
+
+func (m *mockPreStageWriter) Finish() (destination.PreStagedData, error) {
+	return nil, nil
+}
+
+func (m *mockPreStageWriter) Discard() {
+	m.discarded = true
+}
+
+type mockPreStageDestination struct {
+	mockDestination
+	writer   destination.PreStageWriter
+	err      error
+	lastOpts *destination.PreStageOptions
+}
+
+func (m *mockPreStageDestination) NewPreStageWriter(_ context.Context, opts destination.PreStageOptions) (destination.PreStageWriter, error) {
+	m.lastOpts = &opts
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.writer, nil
+}
+
+func preStageTestPipeline(cfg *config.IngestConfig, dest destination.Destination) *Pipeline {
+	p := New(cfg)
+	p.dest = dest
+	return p
+}
+
+func baselinePreStageConfig() *config.IngestConfig {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mongodb://localhost/db"
+	cfg.DestURI = "bigquery://project"
+	cfg.SourceTable = "db.users"
+	cfg.DestTable = "ds.users"
+	return cfg
+}
+
+func TestMaybeStartPreStageHappyPath(t *testing.T) {
+	cfg := baselinePreStageConfig()
+	dest := &mockPreStageDestination{writer: &mockPreStageWriter{}}
+	p := preStageTestPipeline(cfg, dest)
+
+	ts := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	writer, transform := p.maybeStartPreStage(context.Background(), config.StrategyMerge, []string{"_id"}, ts)
+	if writer == nil || transform == nil {
+		t.Fatal("expected pre-staging to start")
+	}
+	if transform("userName") != "user_name" {
+		t.Fatalf("transform(userName) = %q, want user_name (snake_case default)", transform("userName"))
+	}
+	if dest.lastOpts == nil || !dest.lastOpts.StagingTable {
+		t.Fatal("merge strategy must pre-stage with staging-table chunking")
+	}
+	if dest.lastOpts.LoadTimestampColumn != naming.IngestrLoadedAtColumn {
+		t.Fatalf("LoadTimestampColumn = %q", dest.lastOpts.LoadTimestampColumn)
+	}
+	if !dest.lastOpts.LoadTimestamp.Equal(ts) {
+		t.Fatalf("LoadTimestamp = %v, want %v", dest.lastOpts.LoadTimestamp, ts)
+	}
+}
+
+func TestMaybeStartPreStageGates(t *testing.T) {
+	ts := time.Now()
+
+	cases := []struct {
+		name     string
+		mutate   func(*config.IngestConfig)
+		strategy config.IncrementalStrategy
+	}{
+		{"disabled by flag", func(c *config.IngestConfig) { c.DisablePreStaging = true }, config.StrategyMerge},
+		{"scd2 strategy", func(c *config.IngestConfig) {}, config.StrategySCD2},
+		{"delete+insert strategy", func(c *config.IngestConfig) {}, config.StrategyDeleteInsert},
+		{"stream mode", func(c *config.IngestConfig) { c.Stream = true }, config.StrategyMerge},
+		{"masking", func(c *config.IngestConfig) { c.Mask = []string{"email:hash"} }, config.StrategyMerge},
+		{"trim whitespace", func(c *config.IngestConfig) { c.TrimWhitespace = true }, config.StrategyMerge},
+		{"column overrides", func(c *config.IngestConfig) { c.Columns = "id:int64" }, config.StrategyMerge},
+		{"discard contract", func(c *config.IngestConfig) { c.SchemaContract = "discard_row" }, config.StrategyMerge},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baselinePreStageConfig()
+			tc.mutate(cfg)
+			dest := &mockPreStageDestination{writer: &mockPreStageWriter{}}
+			p := preStageTestPipeline(cfg, dest)
+
+			writer, _ := p.maybeStartPreStage(context.Background(), tc.strategy, []string{"_id"}, ts)
+			if writer != nil {
+				t.Fatal("expected pre-staging to be skipped")
+			}
+		})
+	}
+}
+
+func TestMaybeStartPreStageSkipsNonPreStagerDestination(t *testing.T) {
+	cfg := baselinePreStageConfig()
+	p := preStageTestPipeline(cfg, &mockDestination{})
+
+	writer, _ := p.maybeStartPreStage(context.Background(), config.StrategyMerge, nil, time.Now())
+	if writer != nil {
+		t.Fatal("expected pre-staging to be skipped for non-PreStager destination")
+	}
+}
+
+func TestMaybeStartPreStageSkipsWhenUnsupported(t *testing.T) {
+	cfg := baselinePreStageConfig()
+	dest := &mockPreStageDestination{err: destination.ErrPreStageUnsupported}
+	p := preStageTestPipeline(cfg, dest)
+
+	writer, _ := p.maybeStartPreStage(context.Background(), config.StrategyMerge, nil, time.Now())
+	if writer != nil {
+		t.Fatal("expected pre-staging to be skipped when destination reports unsupported")
+	}
+}
+
+func TestResolvePreStageKeyTransform(t *testing.T) {
+	t.Run("explicit direct", func(t *testing.T) {
+		cfg := baselinePreStageConfig()
+		cfg.SchemaNaming = "direct"
+		p := preStageTestPipeline(cfg, &mockDestination{})
+		transform := p.resolvePreStageKeyTransform(context.Background())
+		if transform == nil {
+			t.Fatal("expected transform for direct naming")
+		}
+		if transform("userName") != "userName" {
+			t.Fatal("direct naming must not rename")
+		}
+	})
+
+	t.Run("auto with existing destination table", func(t *testing.T) {
+		cfg := baselinePreStageConfig()
+		p := preStageTestPipeline(cfg, &mockDestination{tableSchema: &schema.TableSchema{Name: "users"}})
+		if transform := p.resolvePreStageKeyTransform(context.Background()); transform != nil {
+			t.Fatal("auto naming with an existing table depends on the inferred schema; transform must be nil")
+		}
+	})
+
+	t.Run("auto without destination table", func(t *testing.T) {
+		cfg := baselinePreStageConfig()
+		p := preStageTestPipeline(cfg, &mockDestination{})
+		transform := p.resolvePreStageKeyTransform(context.Background())
+		if transform == nil {
+			t.Fatal("expected snake_case transform when destination table does not exist")
+		}
+		if transform("userName") != "user_name" {
+			t.Fatalf("transform(userName) = %q", transform("userName"))
+		}
+	})
+}
+
+func identityTransform(name string) string { return name }
+
+func simpleSchema(cols ...schema.Column) *schema.TableSchema {
+	return &schema.TableSchema{Name: "users", Columns: cols}
+}
+
+func TestPreStagedUsableHappyPath(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+
+	src := simpleSchema(
+		schema.Column{Name: "_id", DataType: schema.TypeString},
+		schema.Column{Name: "value", DataType: schema.TypeInt64},
+	)
+	write := simpleSchema(
+		schema.Column{Name: "_id", DataType: schema.TypeString},
+		schema.Column{Name: "value", DataType: schema.TypeInt64},
+	)
+
+	if !p.preStagedUsable(&preStageReport{}, identityTransform, src, write) {
+		t.Fatal("expected pre-staged data to be usable")
+	}
+}
+
+func TestPreStagedUsableRejectsTypePromotion(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+	report := &preStageReport{typeUnstableColumns: []string{"value"}}
+
+	if p.preStagedUsable(report, identityTransform, simpleSchema(), simpleSchema()) {
+		t.Fatal("expected rejection for type-promoted columns")
+	}
+}
+
+func TestPreStagedUsableRejectsRenameMismatch(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+	// The renamer decided on a different final name than the transform assumed.
+	p.columnRenamer = transformer.NewColumnRenamer(map[string]string{"userName": "user_name_2"})
+
+	src := simpleSchema(schema.Column{Name: "userName", DataType: schema.TypeString})
+	if p.preStagedUsable(&preStageReport{}, naming.Get(naming.SnakeCase).Normalize, src, simpleSchema()) {
+		t.Fatal("expected rejection when renamer output differs from staged keys")
+	}
+}
+
+func TestPreStagedUsableAcceptsMatchingRenames(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+	p.columnRenamer = transformer.NewColumnRenamer(map[string]string{"userName": "user_name"})
+
+	src := simpleSchema(
+		schema.Column{Name: "userName", DataType: schema.TypeString},
+		schema.Column{Name: "_id", DataType: schema.TypeString},
+	)
+	write := simpleSchema(
+		schema.Column{Name: "user_name", DataType: schema.TypeString},
+		schema.Column{Name: "_id", DataType: schema.TypeString},
+	)
+
+	if !p.preStagedUsable(&preStageReport{}, naming.Get(naming.SnakeCase).Normalize, src, write) {
+		t.Fatal("expected matching renames to be usable")
+	}
+}
+
+func TestPreStagedUsableRejectsNameCollision(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+
+	src := simpleSchema(
+		schema.Column{Name: "userName", DataType: schema.TypeString},
+		schema.Column{Name: "user_name", DataType: schema.TypeString},
+	)
+	if p.preStagedUsable(&preStageReport{}, naming.Get(naming.SnakeCase).Normalize, src, simpleSchema()) {
+		t.Fatal("expected rejection when two source columns collide after renaming")
+	}
+}
+
+func TestPreStagedUsableRejectsLoadTimestampCollision(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+
+	src := simpleSchema(schema.Column{Name: "_INGESTR_LOADED_AT", DataType: schema.TypeString})
+	if p.preStagedUsable(&preStageReport{}, identityTransform, src, simpleSchema()) {
+		t.Fatal("expected rejection when a source column collides with the load timestamp column")
+	}
+}
+
+func TestPreStagedUsableRejectsLegacyIngestrColumns(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+	p.ingestrColumnFiller = schemaevolution.NewIngestrColumnFiller([]string{"_ingestr_extracted_at"})
+
+	if p.preStagedUsable(&preStageReport{}, identityTransform, simpleSchema(), simpleSchema()) {
+		t.Fatal("expected rejection when legacy ingestr columns must be filled")
+	}
+}
+
+func TestPreStagedUsableUnknownStorageColumns(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+
+	cases := []struct {
+		name     string
+		dataType schema.DataType
+		want     bool
+	}{
+		{"json is fine", schema.TypeJSON, true},
+		{"int64 is fine", schema.TypeInt64, true},
+		{"float64 is fine", schema.TypeFloat64, true},
+		{"boolean is fine", schema.TypeBoolean, true},
+		{"timestamp rejected", schema.TypeTimestampTZ, false},
+		{"date rejected", schema.TypeDate, false},
+		{"string rejected", schema.TypeString, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			report := &preStageReport{unknownStorageColumns: map[string]bool{"payload": true}}
+			src := simpleSchema(schema.Column{Name: "payload", DataType: tc.dataType})
+			write := simpleSchema(schema.Column{Name: "payload", DataType: tc.dataType})
+
+			got := p.preStagedUsable(report, identityTransform, src, write)
+			if got != tc.want {
+				t.Fatalf("preStagedUsable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPreStagedUsableAllowsDroppedUnknownColumns(t *testing.T) {
+	p := preStageTestPipeline(baselinePreStageConfig(), &mockDestination{})
+
+	report := &preStageReport{unknownStorageColumns: map[string]bool{"dropped_col": true}}
+	src := simpleSchema(schema.Column{Name: "_id", DataType: schema.TypeString})
+	write := simpleSchema(schema.Column{Name: "_id", DataType: schema.TypeString})
+
+	if !p.preStagedUsable(report, identityTransform, src, write) {
+		t.Fatal("expected dropped unknown columns to be allowed (IgnoreUnknownValues)")
+	}
+}

--- a/pkg/schemainfer/infer.go
+++ b/pkg/schemainfer/infer.go
@@ -17,12 +17,13 @@ import (
 
 // FieldInfo tracks information about a field observed during schema inference.
 type FieldInfo struct {
-	Name      string
-	Type      arrow.DataType
-	Nullable  bool
-	SeenNull  bool             // Whether a null value was observed
-	HasData   bool             // Whether at least one non-null value was observed
-	SeenTypes []arrow.DataType // All types observed for type conflict detection
+	Name              string
+	Type              arrow.DataType
+	Nullable          bool
+	SeenNull          bool             // Whether a null value was observed
+	HasData           bool             // Whether at least one non-null value was observed
+	SeenTypes         []arrow.DataType // All types observed for type conflict detection
+	SawUnknownStorage bool             // Whether the field ever arrived as the unknown extension type
 }
 
 // SchemaInferrer collects Arrow schemas from record batches and produces
@@ -62,7 +63,8 @@ func (i *SchemaInferrer) AddBatch(batch arrow.RecordBatch) error {
 		effectiveType := field.Type
 		hasNulls := col.NullN() > 0
 		hasNonNull := col.Len()-col.NullN() > 0
-		if isUnknownType(field.Type) {
+		fromUnknown := isUnknownType(field.Type)
+		if fromUnknown {
 			inferred, ok := inferUnknownColumnType(col)
 			if ok {
 				effectiveType = inferred
@@ -77,12 +79,13 @@ func (i *SchemaInferrer) AddBatch(batch arrow.RecordBatch) error {
 		if !exists {
 			// First time seeing this field
 			i.seenFields[field.Name] = &FieldInfo{
-				Name:      field.Name,
-				Type:      effectiveType,
-				Nullable:  field.Nullable || hasNulls,
-				SeenNull:  hasNulls,
-				HasData:   hasNonNull,
-				SeenTypes: []arrow.DataType{effectiveType},
+				Name:              field.Name,
+				Type:              effectiveType,
+				Nullable:          field.Nullable || hasNulls,
+				SeenNull:          hasNulls,
+				HasData:           hasNonNull,
+				SeenTypes:         []arrow.DataType{effectiveType},
+				SawUnknownStorage: fromUnknown,
 			}
 			i.fieldOrder = append(i.fieldOrder, field.Name)
 		} else {
@@ -90,6 +93,7 @@ func (i *SchemaInferrer) AddBatch(batch arrow.RecordBatch) error {
 			existing.Nullable = existing.Nullable || field.Nullable || hasNulls
 			existing.SeenNull = existing.SeenNull || hasNulls
 			existing.HasData = existing.HasData || hasNonNull
+			existing.SawUnknownStorage = existing.SawUnknownStorage || fromUnknown
 
 			// Check if type is different
 			if !arrow.TypeEqual(existing.Type, effectiveType) {
@@ -205,6 +209,34 @@ type InferStats struct {
 	BatchCount int64
 	RowCount   int64
 	FieldCount int
+}
+
+// TypeUnstableColumns returns the names of fields that were observed with more
+// than one effective type across batches (i.e. the final type required
+// promotion). Raw values staged before inference finished may not match the
+// promoted type for these columns.
+func (i *SchemaInferrer) TypeUnstableColumns() []string {
+	var unstable []string
+	for _, name := range i.fieldOrder {
+		if len(i.seenFields[name].SeenTypes) > 1 {
+			unstable = append(unstable, name)
+		}
+	}
+	return unstable
+}
+
+// UnknownStorageColumns returns the fields that ever arrived as the unknown
+// extension type. Their raw values are JSON-encoded text whose interpretation
+// (e.g. lenient date parsing) may be more permissive than a destination's
+// native load-time coercion.
+func (i *SchemaInferrer) UnknownStorageColumns() map[string]bool {
+	result := make(map[string]bool)
+	for name, info := range i.seenFields {
+		if info.SawUnknownStorage {
+			result[name] = true
+		}
+	}
+	return result
 }
 
 // TODO (cagin): if table already existed, compare existing column types against opts.Schema

--- a/pkg/schemainfer/prestage_report_test.go
+++ b/pkg/schemainfer/prestage_report_test.go
@@ -1,0 +1,102 @@
+package schemainfer
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func buildSingleColumnRecord(t *testing.T, name string, arr arrow.Array) arrow.RecordBatch {
+	t.Helper()
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: name, Type: arr.DataType(), Nullable: true}}, nil)
+	return array.NewRecordBatch(arrowSchema, []arrow.Array{arr}, int64(arr.Len()))
+}
+
+func buildInt64Array(t *testing.T, values []int64) arrow.Array {
+	t.Helper()
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer builder.Release()
+	builder.AppendValues(values, nil)
+	return builder.NewArray()
+}
+
+func buildStringArray(t *testing.T, values []string) arrow.Array {
+	t.Helper()
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer builder.Release()
+	builder.AppendValues(values, nil)
+	return builder.NewArray()
+}
+
+func TestTypeUnstableColumnsDetectsPromotion(t *testing.T) {
+	inferrer := NewSchemaInferrer()
+
+	intArr := buildInt64Array(t, []int64{1, 2})
+	rec1 := buildSingleColumnRecord(t, "value", intArr)
+	if err := inferrer.AddBatch(rec1); err != nil {
+		t.Fatal(err)
+	}
+	rec1.Release()
+	intArr.Release()
+
+	strArr := buildStringArray(t, []string{"a"})
+	rec2 := buildSingleColumnRecord(t, "value", strArr)
+	if err := inferrer.AddBatch(rec2); err != nil {
+		t.Fatal(err)
+	}
+	rec2.Release()
+	strArr.Release()
+
+	unstable := inferrer.TypeUnstableColumns()
+	if len(unstable) != 1 || unstable[0] != "value" {
+		t.Fatalf("TypeUnstableColumns = %v, want [value]", unstable)
+	}
+}
+
+func TestTypeUnstableColumnsEmptyForStableTypes(t *testing.T) {
+	inferrer := NewSchemaInferrer()
+
+	for range 2 {
+		arr := buildInt64Array(t, []int64{1})
+		rec := buildSingleColumnRecord(t, "value", arr)
+		if err := inferrer.AddBatch(rec); err != nil {
+			t.Fatal(err)
+		}
+		rec.Release()
+		arr.Release()
+	}
+
+	if unstable := inferrer.TypeUnstableColumns(); len(unstable) != 0 {
+		t.Fatalf("TypeUnstableColumns = %v, want empty", unstable)
+	}
+}
+
+func TestUnknownStorageColumnsTracked(t *testing.T) {
+	inferrer := NewSchemaInferrer()
+
+	unknownArr := mustBuildUnknownArray(t, []string{`{"a":1}`}, []bool{true})
+	rec1 := buildSingleColumnRecord(t, "payload", unknownArr)
+	if err := inferrer.AddBatch(rec1); err != nil {
+		t.Fatal(err)
+	}
+	rec1.Release()
+	unknownArr.Release()
+
+	intArr := buildInt64Array(t, []int64{5})
+	rec2 := buildSingleColumnRecord(t, "count", intArr)
+	if err := inferrer.AddBatch(rec2); err != nil {
+		t.Fatal(err)
+	}
+	rec2.Release()
+	intArr.Release()
+
+	unknown := inferrer.UnknownStorageColumns()
+	if !unknown["payload"] {
+		t.Fatal("expected payload to be tracked as unknown storage")
+	}
+	if unknown["count"] {
+		t.Fatal("count arrived typed; it must not be tracked as unknown storage")
+	}
+}

--- a/pkg/strategy/append.go
+++ b/pkg/strategy/append.go
@@ -84,6 +84,7 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		StagingBucket:    job.Config.StagingBucket,
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
+		PreStaged:        job.PreStaged,
 	}); err != nil {
 		return fmt.Errorf("failed to write data: %w", err)
 	}

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -180,6 +180,7 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		StagingBucket:    job.Config.StagingBucket,
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
+		PreStaged:        job.PreStaged,
 	}); err != nil {
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -287,6 +287,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		StagingBucket:    job.Config.StagingBucket,
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
+		PreStaged:        job.PreStaged,
 	}
 	if useStaging {
 		if atomicWriter, ok := job.Destination.(destination.AtomicCommitWriter); ok && atomicWriter.SupportsAtomicCommitWrites() {
@@ -295,7 +296,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	}
 
 	var countedRows atomic.Int64
-	if !writeOpts.AtomicCommit {
+	if !writeOpts.AtomicCommit && writeOpts.PreStaged == nil {
 		records = wrapWithRowCount(records, &countedRows)
 	}
 
@@ -313,6 +314,9 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		if !writeOpts.AtomicCommit {
 			if verifier, ok := job.Destination.(destination.ExactRowCountWaiter); ok {
 				expectedRows := countedRows.Load()
+				if writeOpts.PreStaged != nil {
+					expectedRows = writeOpts.PreStaged.RowCount()
+				}
 				if expectedRows > 0 {
 					if err := verifier.WaitForExactRowCount(ctx, writeTable, expectedRows); err != nil {
 						if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -26,6 +26,11 @@ type IngestionJob struct {
 	// If non-nil, GetRecords() transforms this stream instead of reading from Table.
 	BufferedRecords <-chan source.RecordBatchResult
 
+	// PreStaged holds destination-native load files written during extract.
+	// When set, BufferedRecords is an empty stream and the destination loads
+	// the pre-staged files directly.
+	PreStaged destination.PreStagedData
+
 	// SchemaComparison contains the result of comparing source and destination schemas.
 	// Used for runtime batch transformation in discard_row and discard_value modes.
 	SchemaComparison *schemaevolution.SchemaComparison

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -122,6 +122,7 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 		StagingBucket:    job.Config.StagingBucket,
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
+		PreStaged:        job.PreStaged,
 	}); err != nil {
 		return fmt.Errorf("failed to write data: %w", err)
 	}
@@ -199,6 +200,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		StagingBucket:    job.Config.StagingBucket,
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
+		PreStaged:        job.PreStaged,
 	}); err != nil {
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}

--- a/tests/integration/bigquery_prestage_test.go
+++ b/tests/integration/bigquery_prestage_test.go
@@ -1,0 +1,351 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iterator"
+)
+
+// The pre-staging tests validate that BigQuery loads fed from extract-time
+// pre-staged JSONL files produce byte-identical tables to the buffer-replay
+// path, and that configurations the pre-stager cannot handle fall back to
+// replay with correct results.
+
+type bqPreStageEnv struct {
+	uri     string
+	project string
+	dataset string
+}
+
+func bigqueryPreStageEnv(t *testing.T) bqPreStageEnv {
+	t.Helper()
+	uri := os.Getenv("GONG_TEST_BIGQUERY_URI")
+	project := os.Getenv("GONG_TEST_BIGQUERY_PROJECT")
+	dataset := os.Getenv("GONG_TEST_BIGQUERY_DATASET")
+	if uri == "" || project == "" || dataset == "" {
+		t.Skip("Set GONG_TEST_BIGQUERY_URI, GONG_TEST_BIGQUERY_PROJECT and GONG_TEST_BIGQUERY_DATASET to run BigQuery pre-staging tests")
+	}
+	return bqPreStageEnv{uri: uri, project: project, dataset: dataset}
+}
+
+func writeJSONLFixture(t *testing.T, lines []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture.jsonl")
+	content := ""
+	for _, line := range lines {
+		content += line + "\n"
+	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+	return fmt.Sprintf("jsonl://%s", abs)
+}
+
+func dropBQTable(ctx context.Context, t *testing.T, env bqPreStageEnv, table string) {
+	t.Helper()
+	client, err := bigquery.NewClient(ctx, env.project)
+	if err != nil {
+		return
+	}
+	defer func() { _ = client.Close() }()
+	_ = client.Dataset(env.dataset).Table(table).Delete(ctx)
+}
+
+// bqRowsWithoutLoadTS returns all rows as JSON maps ordered by the given
+// column, asserting every row carries a non-empty _ingestr_loaded_at and
+// removing it so two runs at different times compare equal.
+func bqRowsWithoutLoadTS(ctx context.Context, t *testing.T, env bqPreStageEnv, table, orderBy string) []map[string]any {
+	t.Helper()
+	client, err := bigquery.NewClient(ctx, env.project)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	q := client.Query(fmt.Sprintf(
+		"SELECT TO_JSON_STRING(t) AS j FROM `%s.%s.%s` AS t ORDER BY %s",
+		env.project, env.dataset, table, orderBy,
+	))
+	it, err := q.Read(ctx)
+	require.NoError(t, err)
+
+	var rows []map[string]any
+	for {
+		var row struct {
+			J string
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal([]byte(row.J), &decoded))
+		loadedAt, ok := decoded["_ingestr_loaded_at"].(string)
+		require.True(t, ok, "row missing _ingestr_loaded_at: %s", row.J)
+		require.NotEmpty(t, loadedAt)
+		delete(decoded, "_ingestr_loaded_at")
+		rows = append(rows, decoded)
+	}
+	return rows
+}
+
+func runBQIngest(ctx context.Context, t *testing.T, cfg *config.IngestConfig) {
+	t.Helper()
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+}
+
+// preStageMergeFixture exercises the common MongoDB-shaped payloads: camelCase
+// keys (snake_case renames), nested documents and arrays (JSON columns), a
+// column that first appears mid-extract, an always-null column (dropped by
+// inference), booleans, floats, and integers. PageSize=2 forces multiple
+// batches so the late column genuinely appears after staging has started.
+var preStageMergeFixture = []string{
+	`{"id": 1, "userName": "alice", "isActive": true, "score": 1.5, "payload": {"a": 1, "b": ["x", "y"]}, "ghost": null}`,
+	`{"id": 2, "userName": "bob", "isActive": false, "score": 2.0, "payload": {"a": 2}, "ghost": null}`,
+	`{"id": 3, "userName": "carol", "isActive": true, "score": 3.25, "payload": [1, 2, 3], "ghost": null}`,
+	`{"id": 4, "userName": "dave", "isActive": false, "score": 4.0, "payload": {"nested": {"deep": true}}, "lateCol": "first", "ghost": null}`,
+	`{"id": 5, "userName": "erin", "isActive": true, "score": 5.5, "lateCol": "second", "ghost": null}`,
+}
+
+func TestBigQueryPreStage_MergeMatchesReplayPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+	sourceURI := writeJSONLFixture(t, preStageMergeFixture)
+
+	suffix := uniqueSuffix()
+	tables := map[bool]string{
+		false: "prestage_merge_on_" + suffix,
+		true:  "prestage_merge_off_" + suffix,
+	}
+
+	for disable, table := range tables {
+		t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+		runBQIngest(ctx, t, &config.IngestConfig{
+			SourceURI:           sourceURI,
+			SourceTable:         "prestage_source",
+			DestURI:             env.uri,
+			DestTable:           env.dataset + "." + table,
+			IncrementalStrategy: config.StrategyMerge,
+			PrimaryKeys:         []string{"id"},
+			PageSize:            2,
+			LoaderFileSize:      2,
+			DisablePreStaging:   disable,
+		})
+	}
+
+	preStagedRows := bqRowsWithoutLoadTS(ctx, t, env, tables[false], "id")
+	replayRows := bqRowsWithoutLoadTS(ctx, t, env, tables[true], "id")
+
+	require.Len(t, preStagedRows, len(preStageMergeFixture))
+	require.Equal(t, replayRows, preStagedRows, "pre-staged path must produce the same table as the replay path")
+
+	// The always-null column must have been dropped by inference on both paths.
+	for _, row := range preStagedRows {
+		_, exists := row["ghost"]
+		require.False(t, exists, "all-null column must be dropped")
+	}
+	// camelCase keys must be renamed to snake_case on both paths.
+	require.Contains(t, preStagedRows[0], "user_name")
+	require.Contains(t, preStagedRows[3], "late_col")
+}
+
+func TestBigQueryPreStage_ReplaceAndAppendMatchReplayPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+	sourceURI := writeJSONLFixture(t, preStageMergeFixture)
+
+	for _, strategy := range []config.IncrementalStrategy{config.StrategyReplace, config.StrategyAppend} {
+		t.Run(string(strategy), func(t *testing.T) {
+			suffix := uniqueSuffix()
+			tables := map[bool]string{
+				false: fmt.Sprintf("prestage_%s_on_%s", strategy, suffix),
+				true:  fmt.Sprintf("prestage_%s_off_%s", strategy, suffix),
+			}
+
+			for disable, table := range tables {
+				t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+				runBQIngest(ctx, t, &config.IngestConfig{
+					SourceURI:           sourceURI,
+					SourceTable:         "prestage_source",
+					DestURI:             env.uri,
+					DestTable:           env.dataset + "." + table,
+					IncrementalStrategy: strategy,
+					PageSize:            2,
+					LoaderFileSize:      2,
+					DisablePreStaging:   disable,
+				})
+			}
+
+			preStagedRows := bqRowsWithoutLoadTS(ctx, t, env, tables[false], "id")
+			replayRows := bqRowsWithoutLoadTS(ctx, t, env, tables[true], "id")
+			require.Len(t, preStagedRows, len(preStageMergeFixture))
+			require.Equal(t, replayRows, preStagedRows)
+		})
+	}
+}
+
+// Type promotion mid-extract (int64 → string) must disable the pre-staged
+// files (early files carry raw JSON numbers that cannot load into a STRING
+// column) and fall back to the replay path transparently.
+func TestBigQueryPreStage_TypePromotionFallsBackCorrectly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+
+	sourceURI := writeJSONLFixture(t, []string{
+		`{"id": 1, "value": 100}`,
+		`{"id": 2, "value": 200}`,
+		`{"id": 3, "value": "not-a-number"}`,
+	})
+
+	table := "prestage_promotion_" + uniqueSuffix()
+	t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+
+	runBQIngest(ctx, t, &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         "prestage_source",
+		DestURI:             env.uri,
+		DestTable:           env.dataset + "." + table,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		PageSize:            2,
+	})
+
+	rows := bqRowsWithoutLoadTS(ctx, t, env, table, "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "100", rows[0]["value"])
+	require.Equal(t, "200", rows[1]["value"])
+	require.Equal(t, "not-a-number", rows[2]["value"])
+}
+
+// Date-like strings resolve to TIMESTAMP columns through ingestr's lenient
+// parser; the raw strings in pre-staged files may not be BigQuery-parseable,
+// so this configuration must fall back to replay and still load correctly.
+func TestBigQueryPreStage_TemporalStringsFallBackCorrectly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+
+	sourceURI := writeJSONLFixture(t, []string{
+		`{"id": 1, "seenAt": "2026-07-01T10:00:00Z"}`,
+		`{"id": 2, "seenAt": "2026-07-01 11:30:00"}`,
+	})
+
+	table := "prestage_temporal_" + uniqueSuffix()
+	t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+
+	runBQIngest(ctx, t, &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         "prestage_source",
+		DestURI:             env.uri,
+		DestTable:           env.dataset + "." + table,
+		IncrementalStrategy: config.StrategyReplace,
+		PageSize:            1,
+	})
+
+	rows := bqRowsWithoutLoadTS(ctx, t, env, table, "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "2026-07-01T10:00:00Z", rows[0]["seen_at"])
+	require.Equal(t, "2026-07-01T11:30:00Z", rows[1]["seen_at"])
+}
+
+// A second merge run against an existing destination table skips pre-staging
+// (auto naming detection needs the inferred schema) and must upsert correctly
+// through the replay path.
+func TestBigQueryPreStage_IncrementalMergeSecondRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+
+	table := "prestage_incr_" + uniqueSuffix()
+	t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+
+	initial := writeJSONLFixture(t, []string{
+		`{"id": 1, "userName": "alice", "version": 1}`,
+		`{"id": 2, "userName": "bob", "version": 1}`,
+	})
+	update := writeJSONLFixture(t, []string{
+		`{"id": 2, "userName": "bob-updated", "version": 2}`,
+		`{"id": 3, "userName": "carol", "version": 1}`,
+	})
+
+	baseCfg := func(sourceURI string) *config.IngestConfig {
+		return &config.IngestConfig{
+			SourceURI:           sourceURI,
+			SourceTable:         "prestage_source",
+			DestURI:             env.uri,
+			DestTable:           env.dataset + "." + table,
+			IncrementalStrategy: config.StrategyMerge,
+			PrimaryKeys:         []string{"id"},
+			PageSize:            2,
+		}
+	}
+
+	runBQIngest(ctx, t, baseCfg(initial))
+	runBQIngest(ctx, t, baseCfg(update))
+
+	rows := bqRowsWithoutLoadTS(ctx, t, env, table, "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "alice", rows[0]["user_name"])
+	require.Equal(t, "bob-updated", rows[1]["user_name"])
+	require.Equal(t, float64(2), rows[1]["version"])
+	require.Equal(t, "carol", rows[2]["user_name"])
+}
+
+// GCS staging bucket variant: pre-staged files are written directly to GCS
+// during extract. Requires GONG_TEST_BIGQUERY_STAGING_BUCKET (gs://...).
+func TestBigQueryPreStage_GCSStagingBucket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+	bucket := os.Getenv("GONG_TEST_BIGQUERY_STAGING_BUCKET")
+	if bucket == "" {
+		t.Skip("Set GONG_TEST_BIGQUERY_STAGING_BUCKET to run the GCS pre-staging test")
+	}
+
+	sourceURI := writeJSONLFixture(t, preStageMergeFixture)
+	table := "prestage_gcs_" + uniqueSuffix()
+	t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+
+	runBQIngest(ctx, t, &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTable:         "prestage_source",
+		DestURI:             env.uri,
+		DestTable:           env.dataset + "." + table,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+		PageSize:            2,
+		LoaderFileSize:      2,
+		StagingBucket:       bucket,
+	})
+
+	rows := bqRowsWithoutLoadTS(ctx, t, env, table, "id")
+	require.Len(t, rows, len(preStageMergeFixture))
+	require.Equal(t, "alice", rows[0]["user_name"])
+}

--- a/tests/integration/mongodb_bigquery_prestage_test.go
+++ b/tests/integration/mongodb_bigquery_prestage_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcmongo "github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestMongoDBToBigQuery_PreStageEquivalence runs the full user-facing path:
+// a schema-less MongoDB collection with realistic document shapes (ObjectIDs,
+// nested documents, arrays, BSON datetimes, missing fields) merged into
+// BigQuery, once with extract-time pre-staging and once with the replay path,
+// asserting identical results.
+func TestMongoDBToBigQuery_PreStageEquivalence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := bigqueryPreStageEnv(t)
+
+	mc, err := tcmongo.Run(
+		ctx, "mongo:7",
+		tcmongo.WithUsername("admin"),
+		tcmongo.WithPassword("admin"),
+	)
+	require.NoError(t, err, "start mongo container")
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(mc) })
+
+	mongoURI, err := mc.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Disconnect(ctx) })
+
+	coll := client.Database("prestage").Collection("policies")
+	baseTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	docs := make([]any, 0, 10)
+	for i := 1; i <= 10; i++ {
+		doc := bson.M{
+			"_id":        primitive.NewObjectID(),
+			"policyId":   int64(i),
+			"holderName": fmt.Sprintf("holder-%d", i),
+			"premium":    float64(i) * 10.5,
+			"active":     i%2 == 0,
+			"createdAt":  primitive.NewDateTimeFromTime(baseTime.Add(time.Duration(i) * time.Hour)),
+			"details": bson.M{
+				"tier":    i % 3,
+				"regions": bson.A{"eu", "us"},
+			},
+		}
+		if i > 7 {
+			doc["riskScore"] = float64(i) / 2 // column appears mid-extract
+		}
+		docs = append(docs, doc)
+	}
+	_, err = coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+
+	suffix := uniqueSuffix()
+	tables := map[bool]string{
+		false: "prestage_mongo_on_" + suffix,
+		true:  "prestage_mongo_off_" + suffix,
+	}
+
+	for disable, table := range tables {
+		t.Cleanup(func() { dropBQTable(ctx, t, env, table) })
+		runBQIngest(ctx, t, &config.IngestConfig{
+			SourceURI:           mongoURI,
+			SourceTable:         "prestage.policies",
+			DestURI:             env.uri,
+			DestTable:           env.dataset + "." + table,
+			IncrementalStrategy: config.StrategyMerge,
+			PrimaryKeys:         []string{"_id"},
+			PageSize:            3, // several batches; riskScore appears in a later batch
+			LoaderFileSize:      3,
+			DisablePreStaging:   disable,
+		})
+	}
+
+	preStagedRows := bqRowsWithoutLoadTS(ctx, t, env, tables[false], "policy_id")
+	replayRows := bqRowsWithoutLoadTS(ctx, t, env, tables[true], "policy_id")
+
+	require.Len(t, preStagedRows, 10)
+	require.Equal(t, replayRows, preStagedRows, "MongoDB pre-staged load must match the replay path")
+
+	first := preStagedRows[0]
+	require.Contains(t, first, "holder_name")
+	require.Equal(t, "holder-1", first["holder_name"])
+	require.Contains(t, first, "created_at")
+	require.NotEmpty(t, first["created_at"])
+	require.Contains(t, first, "details")
+
+	last := preStagedRows[9]
+	require.Equal(t, float64(5), last["risk_score"])
+	if _, hasEarlyRisk := first["risk_score"]; hasEarlyRisk {
+		require.Nil(t, first["risk_score"], "early rows must have NULL risk_score")
+	}
+}


### PR DESCRIPTION
Adds an extract-time BigQuery JSONL pre-staging path for schema-inferred sources so eligible runs can skip buffer replay and load staged files directly.
The pipeline only uses pre-staged files when inferred schema and naming assumptions remain safe; otherwise it falls back to the existing replay path.
Covers BigQuery pre-staging, pipeline eligibility, schema-inference reporting, and MongoDB-to-BigQuery integration scenarios.
Validated with `make format`, `make lint`, and `make test`.