### PR TITLE
Fix Snowflake multi-table write deadlock from connection pool exhaustion

### DIFF
--- a/pkg/destination/multitable/writer_test.go
+++ b/pkg/destination/multitable/writer_test.go
@@ -3,6 +3,7 @@ package multitable
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -187,6 +188,74 @@ func TestWriteRouterDeadlock(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Write deadlocked: router blocked on failed table's channel, starving healthy table")
+	}
+}
+
+// TestWriteDoesNotDeadlockWithScarceSharedResourceScopedPerBatch models the
+// Snowflake connection-pool exhaustion deadlock generically: many tables
+// each spawn several workers (numTables * parallelism exceeds the size of a
+// shared bounded resource, e.g. a connection pool), and each worker acquires
+// that resource only for the duration of processing a single batch,
+// releasing it before waiting on the next one. This proves the router design
+// doesn't deadlock as long as consumers never hold a scarce shared resource
+// while idle - which is the property the Snowflake destination fix restores.
+func TestWriteDoesNotDeadlockWithScarceSharedResourceScopedPerBatch(t *testing.T) {
+	const numTables = 5
+	const parallelism = 4 // numTables * parallelism (20) far exceeds the resource pool below
+	const batchesPerTable = 20
+
+	pool := make(chan struct{}, 3) // shared "connection pool" smaller than numTables*parallelism
+
+	dest := &fakeDestination{
+		writeFn: func(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+			for result := range records {
+				if result.Err != nil {
+					return result.Err
+				}
+				select {
+				case pool <- struct{}{}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				<-pool
+			}
+			return nil
+		},
+	}
+
+	tableConfigs := make(map[string]destination.TableWriteConfig, numTables)
+	tableNames := make([]string, 0, numTables)
+	for i := 0; i < numTables; i++ {
+		name := "table_" + strconv.Itoa(i)
+		tableNames = append(tableNames, name)
+		tableConfigs[name] = destination.TableWriteConfig{DestTable: "dataset." + name}
+	}
+
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(records)
+		for j := 0; j < batchesPerTable; j++ {
+			for _, name := range tableNames {
+				records <- source.RecordBatchResult{TableName: name}
+			}
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Write(context.Background(), dest, records, destination.MultiTableWriteOptions{
+			TableConfigs: tableConfigs,
+			Parallelism:  parallelism,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Write returned error = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Write deadlocked: a worker likely held the shared resource while idle instead of releasing it between batches")
 	}
 }
 

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -241,14 +241,6 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 		go func(workerID int) {
 			defer uploadWg.Done()
 
-			// Each worker gets its own connection for parallel uploads
-			conn, err := d.db.Conn(ctx)
-			if err != nil {
-				uploadResults <- uploadResult{err: fmt.Errorf("failed to get connection: %w", err)}
-				return
-			}
-			defer func() { _ = conn.Close() }()
-
 			for result := range records {
 				myBatch := int(atomic.AddInt64(&batchNum, 1))
 
@@ -296,14 +288,18 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 
 				fileName := fmt.Sprintf("batch_%d_%d.parquet", workerID, myBatch)
 
-				// Upload to stage using dedicated connection
+				// Acquire a connection from the shared pool for just this PUT, so
+				// it's released back to the pool immediately afterward instead of
+				// being held for the worker's entire lifetime. This lets the pool
+				// (bounded by SetMaxOpenConns) be shared safely across all tables
+				// in a multi-table write, regardless of numTables * parallelism.
 				uploadCtx := sf.WithFileStream(ctx, buf)
 				uploadCtx = sf.WithFileTransferOptions(uploadCtx, &sf.SnowflakeFileTransferOptions{
 					RaisePutGetError: true,
 				})
 
 				putSQL := fmt.Sprintf("PUT file://data.parquet @%s/%s/%s AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=NONE OVERWRITE=TRUE", stageName, loadID, fileName)
-				_, err = conn.ExecContext(uploadCtx, putSQL)
+				_, err = d.db.ExecContext(uploadCtx, putSQL)
 				if err != nil {
 					config.LogFailedQuery(putSQL, err)
 					uploadResults <- uploadResult{batchNum: myBatch, err: fmt.Errorf("failed to PUT file to stage: %w", err)}

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -2,9 +2,12 @@ package snowflake
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -12,7 +15,10 @@ import (
 	pqfile "github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	pqschema "github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -302,4 +308,89 @@ func TestMapDataTypeToSnowflake(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func newSingleRowRecordBatch() arrow.RecordBatch {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer builder.Release()
+	builder.Field(0).(*array.Int64Builder).Append(1)
+	return builder.NewRecordBatch()
+}
+
+// TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure reproduces the
+// exact multi-table merge deadlock reported in production: several tables
+// are written concurrently (via multitable.Write, using the real Router)
+// through the same *SnowflakeDestination/*sql.DB, with combined worker
+// parallelism (numTables * Parallelism) exceeding the connection pool size,
+// and records interleaved across tables the way a real multi-table CDC
+// source would emit them.
+//
+// With the old behavior (one connection pinned per worker for its entire
+// lifetime, acquired before the worker ever looks at its channel), this
+// deadlocks: a minority of workers monopolize the pool and then idle waiting
+// for more data, while the Router's single goroutine blocks forever trying
+// to deliver to a starved table whose workers can never acquire a
+// connection. Acquiring a connection only for the duration of each PUT (this
+// fix) lets the shared pool be time-shared safely regardless of numTables *
+// Parallelism, so the write completes instead of hanging.
+func TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.MatchExpectationsInOrder(false)
+
+	const maxOpenConns = 2
+	db.SetMaxOpenConns(maxOpenConns)
+
+	const numTables = 3
+	const parallelismPerTable = 3 // numTables * parallelismPerTable (9) > maxOpenConns (2)
+	const batchesPerTable = 12    // > router's per-table channel buffer (8), forces backpressure
+
+	tableConfigs := make(map[string]destination.TableWriteConfig, numTables)
+	tableNames := make([]string, 0, numTables)
+	for i := 0; i < numTables; i++ {
+		name := fmt.Sprintf("table_%d", i)
+		tableNames = append(tableNames, name)
+		tableConfigs[name] = destination.TableWriteConfig{DestTable: fmt.Sprintf("public.%s", name)}
+
+		for j := 0; j < batchesPerTable; j++ {
+			mock.ExpectExec("PUT file://data.parquet").WillReturnResult(sqlmock.NewResult(0, 0))
+		}
+		mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+
+	dest := &SnowflakeDestination{db: db}
+
+	// Feed batches interleaved round-robin across tables through a single,
+	// unbuffered shared channel, mimicking how a real multi-table source
+	// streams records for many tables through one channel.
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(records)
+		for j := 0; j < batchesPerTable; j++ {
+			for _, name := range tableNames {
+				records <- source.RecordBatchResult{TableName: name, Batch: newSingleRowRecordBatch()}
+			}
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- multitable.Write(context.Background(), dest, records, destination.MultiTableWriteOptions{
+			TableConfigs: tableConfigs,
+			Parallelism:  parallelismPerTable,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("multitable.Write deadlocked: workers likely held pooled connections beyond a single batch's upload")
+	}
+
+	assert.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary

Multi-table Snowflake writes (e.g. Postgres CDC with `source_table: "*"` and `incremental_strategy: merge`) could hang indefinitely with zero `PUT`/`COPY` activity once `numTables * ExtractParallelism` exceeded the Snowflake connection pool size (`SetMaxOpenConns(16)`).

**Root cause:** `WriteParallel` acquired a dedicated `*sql.Conn` per upload worker *before* the worker touched its input channel, and held that connection for the worker's entire lifetime — including while idle. With enough tables/workers, some workers permanently starved the pool while sitting idle waiting for data, and the multi-table `Router`'s single goroutine would then block forever trying to deliver to a table whose workers could never get a connection — a circular deadlock with no error surfaced.

**Fix:** stop pinning a connection per worker. Each batch's `PUT` now goes through `d.db.ExecContext(uploadCtx, putSQL)` directly, so `database/sql` acquires a connection from the shared pool only for the duration of that single statement and releases it immediately after. This lets the existing pool be safely time-shared across any number of tables/workers without needing to cap parallelism based on table count.

Fixes #916.

## Changes

- `pkg/destination/snowflake/snowflake.go`: removed the per-worker `db.Conn()`/`defer conn.Close()`; `PUT` uploads now use `d.db.ExecContext` per batch.
- `pkg/destination/snowflake/snowflake_test.go`: added `TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure`, an end-to-end repro using the real `multitable.Write`/`Router` with a `sqlmock`-backed pool smaller than `numTables * Parallelism` — verified this fails/times out against the old code and passes with the fix.
- `pkg/destination/multitable/writer_test.go`: added `TestWriteDoesNotDeadlockWithScarceSharedResourceScopedPerBatch`, a generic regression test documenting that the router design is safe as long as a scarce shared resource is only held per-batch, never while idle.