### PR TITLE
Fix mmap Arrow slice timestamp corruption

### DIFF
--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -254,6 +254,14 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 		return arr, nil
 	}
 
+	arr, releaseArr, err := normalizeArrayOffset(arr)
+	if err != nil {
+		return nil, err
+	}
+	if releaseArr {
+		defer arr.Release()
+	}
+
 	if isUnknownType(arr.DataType()) {
 		return castUnknownArray(arr, target)
 	}
@@ -282,7 +290,6 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 	}
 
 	var casted arrow.Array
-	var err error
 	if safe {
 		casted, err = compute.CastArray(ctx, arr, compute.SafeCastOptions(target))
 	} else if (arr.DataType().ID() == arrow.DECIMAL128 || arr.DataType().ID() == arrow.DECIMAL256) && isIntegerType(target) {
@@ -313,6 +320,18 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 	}
 
 	return nil, err
+}
+
+func normalizeArrayOffset(arr arrow.Array) (arrow.Array, bool, error) {
+	if arr == nil || arr.Data().Offset() == 0 {
+		return arr, false, nil
+	}
+
+	normalized, err := array.Concatenate([]arrow.Array{arr}, memory.DefaultAllocator)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to normalize sliced array offset: %w", err)
+	}
+	return normalized, true, nil
 }
 
 func castStringArrayViaAppendValue(arr arrow.Array, target arrow.DataType) (arrow.Array, error) {

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -1080,6 +1080,43 @@ func TestUnsafeCast(t *testing.T) {
 		assert.Contains(t, col.Value(0), "2024")
 	})
 
+	t.Run("sliced timestamp offset is honored when casting", func(t *testing.T) {
+		sourceType := &arrow.TimestampType{Unit: arrow.Nanosecond}
+		targetType := &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
+		sourceSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "val", Type: sourceType, Nullable: true},
+		}, nil)
+		targetSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "val", Type: targetType, Nullable: true},
+		}, nil)
+
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		builder := array.NewTimestampBuilder(mem, sourceType)
+		for i := 0; i < 9; i++ {
+			builder.Append(arrow.Timestamp(base.Add(time.Duration(i) * time.Hour).UnixNano()))
+		}
+		arr := builder.NewArray()
+		builder.Release()
+
+		record := array.NewRecordBatch(sourceSchema, []arrow.Array{arr}, 9)
+		arr.Release()
+		defer record.Release()
+
+		sliced := record.NewSlice(3, 7)
+		defer sliced.Release()
+		require.Equal(t, 3, sliced.Column(0).Data().Offset())
+
+		casted, err := CastRecordToSchema(sliced, targetSchema, false)
+		require.NoError(t, err)
+		defer casted.Release()
+
+		col := casted.Column(0).(*array.Timestamp)
+		for i := 0; i < int(casted.NumRows()); i++ {
+			want := base.Add(time.Duration(i+3) * time.Hour).UnixMicro()
+			assert.EqualValues(t, want, col.Value(i), "row %d", i)
+		}
+	})
+
 	t.Run("float64 to string", func(t *testing.T) {
 		sourceSchema := arrow.NewSchema([]arrow.Field{
 			{Name: "val", Type: arrow.PrimitiveTypes.Float64, Nullable: true},

--- a/pkg/source/mmap/mmap_pipeline_test.go
+++ b/pkg/source/mmap/mmap_pipeline_test.go
@@ -1,0 +1,116 @@
+package mmap_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	_ "github.com/bruin-data/ingestr/pkg/destination/duckdb"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	_ "github.com/bruin-data/ingestr/pkg/source/mmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMMapPipelineColumnOverridePreservesSlicedTimestamps(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sourcePath := filepath.Join(t.TempDir(), "rows.arrow")
+	writeTimestampRowsArrowFile(t, sourcePath, 11)
+
+	cases := []struct {
+		name    string
+		columns string
+	}{
+		{name: "without columns"},
+		{name: "with timestamp override", columns: "id:bigint,timestamp:timestamp,expected_epoch:double"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			destPath := filepath.Join(t.TempDir(), "repro.duckdb")
+			cfg := config.DefaultConfig()
+			cfg.SourceURI = "mmap://" + sourcePath
+			cfg.SourceTable = "asset_data"
+			cfg.DestURI = "duckdb:///" + destPath
+			cfg.DestTable = "raw.rows"
+			cfg.Columns = tc.columns
+			cfg.PageSize = 3
+			cfg.Yes = true
+			cfg.Progress = config.ProgressLog
+
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			requireDuckDBEpochsMatch(t, ctx, destPath, "raw.rows", 11)
+		})
+	}
+}
+
+func writeTimestampRowsArrowFile(t *testing.T, path string, rows int) {
+	t.Helper()
+
+	tsType := &arrow.TimestampType{Unit: arrow.Nanosecond}
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "timestamp", Type: tsType, Nullable: false},
+		{Name: "expected_epoch", Type: arrow.PrimitiveTypes.Float64, Nullable: false},
+	}, nil)
+
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	timestampBuilder := builder.Field(1).(*array.TimestampBuilder)
+	epochBuilder := builder.Field(2).(*array.Float64Builder)
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < rows; i++ {
+		ts := base.Add(time.Duration(i) * time.Hour)
+		idBuilder.Append(int64(i))
+		timestampBuilder.Append(arrow.Timestamp(ts.UnixNano()))
+		epochBuilder.Append(float64(ts.Unix()))
+	}
+
+	record := builder.NewRecordBatch()
+	defer record.Release()
+
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+
+	writer, err := ipc.NewFileWriter(file, ipc.WithSchema(arrowSchema))
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+}
+
+func requireDuckDBEpochsMatch(t *testing.T, ctx context.Context, path, table string, rows int) {
+	t.Helper()
+
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", path))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count))
+	require.Equal(t, rows, count)
+
+	var mismatches int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT COUNT(*)
+		FROM %s
+		WHERE "timestamp" IS NULL OR epoch("timestamp") != expected_epoch
+	`, table)).Scan(&mismatches))
+	require.Zero(t, mismatches)
+}


### PR DESCRIPTION
## Summary
- normalize non-zero-offset Arrow arrays before type casting
- add a cast regression for sliced timestamp arrays
- add an mmap-to-DuckDB regression with page-size 3, with and without column overrides

## Tests
- Not run after PR request per user instruction; CI should run the suite.

Closes https://github.com/bruin-data/bruin/issues/2310