### PR TITLE
onelake: skip managed lakehouse path prefixes

### DIFF
--- a/internal/adlsutil/adlsutil_test.go
+++ b/internal/adlsutil/adlsutil_test.go
@@ -96,10 +96,11 @@ func TestDirectoryPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:               "skip onelake managed item and area",
+			name:               "skip onelake managed item",
 			path:               "lakehouse.Lakehouse/Tables/staff/_delta_log",
-			skipPrefixSegments: 2,
+			skipPrefixSegments: 1,
 			want: []string{
+				"lakehouse.Lakehouse/Tables",
 				"lakehouse.Lakehouse/Tables/staff",
 				"lakehouse.Lakehouse/Tables/staff/_delta_log",
 			},

--- a/internal/adlsutil/adlsutil_test.go
+++ b/internal/adlsutil/adlsutil_test.go
@@ -76,3 +76,50 @@ func TestPathURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://myaccount.dfs.core.windows.net/filesystem/records/users/file%201.parquet", got)
 }
+
+func TestDirectoryPrefixes(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		skipPrefixSegments int
+		want               []string
+	}{
+		{
+			name:               "all prefixes",
+			path:               "lakehouse.Lakehouse/Tables/staff/_delta_log",
+			skipPrefixSegments: 0,
+			want: []string{
+				"lakehouse.Lakehouse",
+				"lakehouse.Lakehouse/Tables",
+				"lakehouse.Lakehouse/Tables/staff",
+				"lakehouse.Lakehouse/Tables/staff/_delta_log",
+			},
+		},
+		{
+			name:               "skip onelake managed item and area",
+			path:               "lakehouse.Lakehouse/Tables/staff/_delta_log",
+			skipPrefixSegments: 2,
+			want: []string{
+				"lakehouse.Lakehouse/Tables/staff",
+				"lakehouse.Lakehouse/Tables/staff/_delta_log",
+			},
+		},
+		{
+			name:               "skip more than path length",
+			path:               "lakehouse.Lakehouse/Tables",
+			skipPrefixSegments: 3,
+			want:               []string{},
+		},
+		{
+			name:               "empty path",
+			path:               "",
+			skipPrefixSegments: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, directoryPrefixes(tt.path, tt.skipPrefixSegments))
+		})
+	}
+}

--- a/internal/adlsutil/datalake.go
+++ b/internal/adlsutil/datalake.go
@@ -78,7 +78,13 @@ func (c *DataLakeClient) pathURL(fileSystem, path string) (string, error) {
 // UploadBuffer writes data to fileSystem/path, creating parent directories first
 // and replacing the file if it already exists.
 func (c *DataLakeClient) UploadBuffer(ctx context.Context, fileSystem, path string, data []byte) error {
-	if err := c.EnsureDirectories(ctx, fileSystem, parentDir(path)); err != nil {
+	return c.UploadBufferSkippingPrefix(ctx, fileSystem, path, data, 0)
+}
+
+// UploadBufferSkippingPrefix writes data while treating the first
+// skipPrefixSegments path segments as existing managed directories.
+func (c *DataLakeClient) UploadBufferSkippingPrefix(ctx context.Context, fileSystem, path string, data []byte, skipPrefixSegments int) error {
+	if err := c.EnsureDirectoriesSkippingPrefix(ctx, fileSystem, parentDir(path), skipPrefixSegments); err != nil {
 		return err
 	}
 
@@ -104,22 +110,13 @@ func (c *DataLakeClient) UploadBuffer(ctx context.Context, fileSystem, path stri
 
 // EnsureDirectories creates each directory segment in dirPath if missing.
 func (c *DataLakeClient) EnsureDirectories(ctx context.Context, fileSystem, dirPath string) error {
-	dirPath = strings.Trim(dirPath, "/")
-	if dirPath == "" {
-		return nil
-	}
+	return c.EnsureDirectoriesSkippingPrefix(ctx, fileSystem, dirPath, 0)
+}
 
-	var current string
-	for _, part := range strings.Split(dirPath, "/") {
-		if part == "" {
-			continue
-		}
-		if current == "" {
-			current = part
-		} else {
-			current += "/" + part
-		}
-
+// EnsureDirectoriesSkippingPrefix creates directory segments after the managed
+// prefix. The skipped prefix must already exist.
+func (c *DataLakeClient) EnsureDirectoriesSkippingPrefix(ctx context.Context, fileSystem, dirPath string, skipPrefixSegments int) error {
+	for _, current := range directoryPrefixes(dirPath, skipPrefixSegments) {
 		pathURL, err := c.pathURL(fileSystem, current)
 		if err != nil {
 			return err
@@ -136,6 +133,36 @@ func (c *DataLakeClient) EnsureDirectories(ctx context.Context, fileSystem, dirP
 	}
 
 	return nil
+}
+
+func directoryPrefixes(dirPath string, skipPrefixSegments int) []string {
+	dirPath = strings.Trim(dirPath, "/")
+	if dirPath == "" {
+		return nil
+	}
+	if skipPrefixSegments < 0 {
+		skipPrefixSegments = 0
+	}
+
+	var current string
+	segmentsSeen := 0
+	prefixes := make([]string, 0)
+	for _, part := range strings.Split(dirPath, "/") {
+		if part == "" {
+			continue
+		}
+		if current == "" {
+			current = part
+		} else {
+			current += "/" + part
+		}
+		segmentsSeen++
+		if segmentsSeen <= skipPrefixSegments {
+			continue
+		}
+		prefixes = append(prefixes, current)
+	}
+	return prefixes
 }
 
 // Download reads the full contents of fileSystem/path into memory.

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -36,6 +36,7 @@ const (
 const (
 	defaultLayout          = "{load_id}.{file_id}.{ext}"
 	maxDeltaCommitAttempts = 5
+	managedPrefixSegments  = 2
 )
 
 var errDeltaCommitConflict = errors.New("delta commit version already exists")
@@ -310,7 +311,7 @@ func (d *OneLakeDestination) WriteParallel(ctx context.Context, records <-chan s
 func (d *OneLakeDestination) writeFilesMode(ctx context.Context, data []byte) error {
 	fileName := d.renderLayout(uuid.New().String()[:8], 0)
 	fullPath := d.filesDir() + "/" + fileName
-	if err := d.client.UploadBuffer(ctx, d.workspace, fullPath, data); err != nil {
+	if err := d.uploadBuffer(ctx, fullPath, data); err != nil {
 		return fmt.Errorf("failed to upload %s: %w", fullPath, err)
 	}
 	config.Debug("[ONELAKE] Wrote %d bytes to %s", len(data), fullPath)
@@ -321,7 +322,7 @@ func (d *OneLakeDestination) writeTablesMode(ctx context.Context, data []byte) e
 	tableDir := d.tableDir()
 	dataFile := fmt.Sprintf("part-00000-%s.c000.snappy.parquet", uuid.New().String())
 
-	if err := d.client.UploadBuffer(ctx, d.workspace, tableDir+"/"+dataFile, data); err != nil {
+	if err := d.uploadBuffer(ctx, tableDir+"/"+dataFile, data); err != nil {
 		return fmt.Errorf("failed to upload data file: %w", err)
 	}
 
@@ -366,12 +367,12 @@ func (d *OneLakeDestination) writeTablesMode(ctx context.Context, data []byte) e
 
 func (d *OneLakeDestination) uploadDeltaCommit(ctx context.Context, logDir string, version int64, commit []byte) error {
 	commitPath := logDir + "/" + commitFileName(version)
-	if err := d.client.EnsureDirectories(ctx, d.workspace, logDir); err != nil {
+	if err := d.ensureDirectories(ctx, logDir); err != nil {
 		return fmt.Errorf("failed to prepare delta log directory: %w", err)
 	}
 
 	tempPath := deltaCommitTempPath(logDir)
-	if err := d.client.UploadBuffer(ctx, d.workspace, tempPath, commit); err != nil {
+	if err := d.uploadBuffer(ctx, tempPath, commit); err != nil {
 		return fmt.Errorf("failed to upload temporary delta commit %s: %w", tempPath, err)
 	}
 
@@ -404,6 +405,14 @@ func (d *OneLakeDestination) newOneLakeFileClient(path string) (*datalakefile.Cl
 		return nil, fmt.Errorf("OneLake destination is not connected")
 	}
 	return datalakefile.NewClient(pathURL, d.cred, nil)
+}
+
+func (d *OneLakeDestination) uploadBuffer(ctx context.Context, path string, data []byte) error {
+	return d.client.UploadBufferSkippingPrefix(ctx, d.workspace, path, data, managedPrefixSegments)
+}
+
+func (d *OneLakeDestination) ensureDirectories(ctx context.Context, path string) error {
+	return d.client.EnsureDirectoriesSkippingPrefix(ctx, d.workspace, path, managedPrefixSegments)
 }
 
 func deltaCommitRenameOptions() *datalakefile.RenameOptions {
@@ -607,7 +616,7 @@ func (d *OneLakeDestination) uploadRewriteData(ctx context.Context, tableDir, da
 	if err != nil {
 		return nil, err
 	}
-	if err := d.client.UploadBuffer(ctx, d.workspace, tableDir+"/"+dataFile, data); err != nil {
+	if err := d.uploadBuffer(ctx, tableDir+"/"+dataFile, data); err != nil {
 		return nil, fmt.Errorf("failed to upload data file: %w", err)
 	}
 

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -36,7 +36,7 @@ const (
 const (
 	defaultLayout          = "{load_id}.{file_id}.{ext}"
 	maxDeltaCommitAttempts = 5
-	managedPrefixSegments  = 2
+	managedPrefixSegments  = 1
 )
 
 var errDeltaCommitConflict = errors.New("delta commit version already exists")


### PR DESCRIPTION
Summary:
- Skip OneLake-managed item and area prefixes when creating ADLS directories.
- Route OneLake uploads and Delta log setup through the prefix-aware helper.
- Add focused prefix path coverage.
