### PR TITLE
feat(annotation): tag CDC resume-cursor lookup with ingestr_step

### DIFF
--- a/internal/annotation/annotation.go
+++ b/internal/annotation/annotation.go
@@ -33,6 +33,7 @@ const ingestrType = "ingestr"
 // ingestr_step values, one per distinct operation.
 const (
 	StepExtract      = "extract"       // source read (SELECT) — only meaningful for warehouse sources
+	StepCDCResume    = "cdc_resume"    // GetMaxCDCLSN: read the destination's max _cdc_lsn to resume a CDC stream
 	StepDDL          = "ddl"           // PrepareTable: create target/staging tables
 	StepEvolve       = "evolve"        // ApplyEvolution: ALTER existing table to match new source schema
 	StepLoad         = "load"          // Write/WriteParallel: bulk-load rows
@@ -46,7 +47,8 @@ const (
 
 // ingestr classifies each query by ETL phase via the "type" value:
 //
-//	ingestr_extract   — read from the source: the SELECT a warehouse source runs
+//	ingestr_extract   — read to drive extraction: the SELECT a warehouse source
+//	                    runs, and the CDC resume-cursor lookup on the destination
 //	ingestr_load      — move data in:   ddl, evolve, load, swap, truncate, cleanup
 //	ingestr_transform — apply strategy: merge, delete_insert, scd2
 const (
@@ -58,7 +60,7 @@ const (
 // typeForStep classifies an ingestr_step into its ETL-phase type.
 func typeForStep(step string) string {
 	switch step {
-	case StepExtract:
+	case StepExtract, StepCDCResume:
 		return typeIngestrExtract
 	case StepMerge, StepDeleteInsert, StepSCD2:
 		return typeIngestrTransform

--- a/internal/annotation/annotation_test.go
+++ b/internal/annotation/annotation_test.go
@@ -101,6 +101,7 @@ func TestPrepend_noStepOmitsStepKey(t *testing.T) {
 func TestTypeForStep(t *testing.T) {
 	cases := map[string]string{
 		StepExtract:      typeIngestrExtract,
+		StepCDCResume:    typeIngestrExtract,
 		StepLoad:         typeIngestrLoad,
 		StepDDL:          typeIngestrLoad,
 		StepEvolve:       typeIngestrLoad,

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -2242,7 +2242,9 @@ func (d *BigQueryDestination) GetMaxCDCLSN(ctx context.Context, table string) (s
 		return "", errors.New("dataset must be specified in table name (dataset.table) or URI path")
 	}
 
-	query := d.client.Query(fmt.Sprintf("SELECT MAX(`_cdc_lsn`) FROM %s.%s.%s", quoteIdentifier(project), quoteIdentifier(dataset), quoteIdentifier(tableName)))
+	ctx = annotation.WithStep(ctx, annotation.StepCDCResume)
+	sql := fmt.Sprintf("SELECT MAX(`_cdc_lsn`) FROM %s.%s.%s", quoteIdentifier(project), quoteIdentifier(dataset), quoteIdentifier(tableName))
+	query := d.client.Query(annotation.Prepend(ctx, sql))
 	if d.location != "" {
 		query.Location = d.location
 	}

--- a/pkg/destination/bigquery/bigquery_annotation_test.go
+++ b/pkg/destination/bigquery/bigquery_annotation_test.go
@@ -41,6 +41,19 @@ func TestAnnotatedQueryComment(t *testing.T) {
 		}
 	})
 
+	t.Run("cdc resume lookup carries the cdc_resume extract step", func(t *testing.T) {
+		ctx := annotation.WithStep(base, annotation.StepCDCResume)
+		got := annotation.Prepend(ctx, "SELECT MAX(`_cdc_lsn`) FROM `p`.`raw`.`orders`")
+
+		wantComment := `-- @bruin.config: {"asset":"raw.orders","ingestr_step":"cdc_resume","pipeline":"shopify","type":"ingestr_extract"}`
+		if !strings.HasPrefix(got, wantComment+"\n") {
+			t.Fatalf("missing/incorrect annotation comment\n got: %q\nwant prefix: %q", got, wantComment)
+		}
+		if !strings.Contains(got, "SELECT MAX(`_cdc_lsn`)") {
+			t.Fatalf("original query body was dropped: %q", got)
+		}
+	})
+
 	t.Run("no caller annotation still carries ingestr's own keys", func(t *testing.T) {
 		ctx := annotation.WithStep(context.Background(), annotation.StepMerge)
 		const sql = "MERGE INTO `p`.`raw`.`orders` ..."

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -861,6 +861,7 @@ func (d *SnowflakeDestination) SupportsAtomicSwap() bool           { return true
 func (d *SnowflakeDestination) GetScheme() string { return "snowflake" }
 
 func (d *SnowflakeDestination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	ctx = d.annotate(ctx, annotation.StepCDCResume)
 	fullTable := quoteFQN(sfTable(table))
 	query := fmt.Sprintf("SELECT MAX(%s) FROM %s", quoteIdentifier("_cdc_lsn"), fullTable)
 


### PR DESCRIPTION
## What

Extends the `--query-annotations` cost-attribution metadata (the `-- @bruin.config: {...}` comment bruin reads to attribute warehouse cost per pipeline/asset/step) to cover the **CDC path**.