### PR TITLE
Fix OneLake managed directory creation

### DIFF
--- a/internal/adlsutil/adlsutil_test.go
+++ b/internal/adlsutil/adlsutil_test.go
@@ -96,11 +96,20 @@ func TestDirectoryPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:               "skip onelake managed item",
+			name:               "skip one prefix",
 			path:               "lakehouse.Lakehouse/Tables/staff/_delta_log",
 			skipPrefixSegments: 1,
 			want: []string{
 				"lakehouse.Lakehouse/Tables",
+				"lakehouse.Lakehouse/Tables/staff",
+				"lakehouse.Lakehouse/Tables/staff/_delta_log",
+			},
+		},
+		{
+			name:               "skip onelake managed item and area",
+			path:               "lakehouse.Lakehouse/Tables/staff/_delta_log",
+			skipPrefixSegments: OneLakeManagedPrefixSegments,
+			want: []string{
 				"lakehouse.Lakehouse/Tables/staff",
 				"lakehouse.Lakehouse/Tables/staff/_delta_log",
 			},

--- a/internal/adlsutil/datalake.go
+++ b/internal/adlsutil/datalake.go
@@ -23,6 +23,10 @@ const OneLakeDNSSuffix = ".dfs.fabric.microsoft.com"
 // OneLakeAccountName is the fixed storage account used by OneLake.
 const OneLakeAccountName = "onelake"
 
+// OneLakeManagedPrefixSegments is the number of path segments Fabric manages
+// before user-created folders begin, e.g. "<item>.Lakehouse/Tables".
+const OneLakeManagedPrefixSegments = 2
+
 // DataLakeClient is an ADLS Gen2 client that can talk to any DFS endpoint
 // (standard Azure storage or OneLake) by varying the DNS suffix. It bundles the
 // file/directory/filesystem client factories together with the upload, directory

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -36,7 +36,6 @@ const (
 const (
 	defaultLayout          = "{load_id}.{file_id}.{ext}"
 	maxDeltaCommitAttempts = 5
-	managedPrefixSegments  = 1
 )
 
 var errDeltaCommitConflict = errors.New("delta commit version already exists")
@@ -408,11 +407,11 @@ func (d *OneLakeDestination) newOneLakeFileClient(path string) (*datalakefile.Cl
 }
 
 func (d *OneLakeDestination) uploadBuffer(ctx context.Context, path string, data []byte) error {
-	return d.client.UploadBufferSkippingPrefix(ctx, d.workspace, path, data, managedPrefixSegments)
+	return d.client.UploadBufferSkippingPrefix(ctx, d.workspace, path, data, adlsutil.OneLakeManagedPrefixSegments)
 }
 
 func (d *OneLakeDestination) ensureDirectories(ctx context.Context, path string) error {
-	return d.client.EnsureDirectoriesSkippingPrefix(ctx, d.workspace, path, managedPrefixSegments)
+	return d.client.EnsureDirectoriesSkippingPrefix(ctx, d.workspace, path, adlsutil.OneLakeManagedPrefixSegments)
 }
 
 func deltaCommitRenameOptions() *datalakefile.RenameOptions {


### PR DESCRIPTION
## Summary
- skip Fabric-managed OneLake item and area path segments when creating directories
- share the OneLake managed prefix count from adlsutil
- cover the Lakehouse/Tables prefix behavior in directory-prefix tests

## Why
Fabric only allows writes under managed Lakehouse areas such as Tables and Files. Creating the Lakehouse item or area folder through ADLS returns OperationNotAllowedOnThePath.

This follows Microsoft OneLake API parity docs, which describe the item folder and first-level Files/Tables folders as Fabric-managed, with CRUD allowed inside those managed folders:
- https://learn.microsoft.com/en-us/fabric/onelake/onelake-api-parity#managed-onelake-folders
- https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-overview#automatic-table-discovery-and-registration