### PR TITLE
iceberg: apply URI S3 credentials to the AWS env for the write path

### DIFF
--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -76,8 +76,9 @@ func applyS3EnvFromProperties(props iceberggo.Properties) {
 	setenvIfEmpty("AWS_SECRET_ACCESS_KEY", props["s3.secret-access-key"])
 	setenvIfEmpty("AWS_SESSION_TOKEN", props["s3.session-token"])
 	setenvIfEmpty("AWS_S3_ENDPOINT", props["s3.endpoint"])
-	if props["s3.access-key-id"] != "" {
-		// Explicit keys were supplied; skip the slow EC2 metadata (IMDS) probe.
+	if props["s3.access-key-id"] != "" && props["s3.secret-access-key"] != "" {
+		// Complete static keys supplied; skip the slow EC2 metadata (IMDS) probe.
+		// Partial keys must NOT disable IMDS, or instance-role fallback breaks.
 		setenvIfEmpty("AWS_EC2_METADATA_DISABLED", "true")
 	}
 }

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 
@@ -53,6 +54,8 @@ func (d *Destination) Connect(ctx context.Context, rawURI string) error {
 		return err
 	}
 
+	applyS3EnvFromProperties(cfg.Properties)
+
 	cat, err := icebergcatalog.Load(ctx, cfg.CatalogName, cfg.Properties)
 	if err != nil {
 		return fmt.Errorf("iceberg: failed to load catalog: %w", err)
@@ -63,6 +66,27 @@ func (d *Destination) Connect(ctx context.Context, rawURI string) error {
 	d.prepared = make(map[string]preparedTable)
 	config.Debug("[ICEBERG] Connected catalog type=%s name=%s", cat.CatalogType(), cfg.CatalogName)
 	return nil
+}
+
+// applyS3EnvFromProperties bridges URI-parsed S3 creds into AWS SDK env, because
+// iceberg-go's write FileIO reads the default AWS chain, not the catalog's s3.* props.
+func applyS3EnvFromProperties(props iceberggo.Properties) {
+	setenvIfEmpty("AWS_REGION", props["s3.region"])
+	setenvIfEmpty("AWS_ACCESS_KEY_ID", props["s3.access-key-id"])
+	setenvIfEmpty("AWS_SECRET_ACCESS_KEY", props["s3.secret-access-key"])
+	setenvIfEmpty("AWS_SESSION_TOKEN", props["s3.session-token"])
+	setenvIfEmpty("AWS_S3_ENDPOINT", props["s3.endpoint"])
+	if props["s3.access-key-id"] != "" {
+		// Explicit keys were supplied; skip the slow EC2 metadata (IMDS) probe.
+		setenvIfEmpty("AWS_EC2_METADATA_DISABLED", "true")
+	}
+}
+
+func setenvIfEmpty(key, value string) {
+	if value == "" || os.Getenv(key) != "" {
+		return
+	}
+	_ = os.Setenv(key, value)
 }
 
 func (d *Destination) Close(ctx context.Context) error {

--- a/tests/integration/iceberg_destination_test.go
+++ b/tests/integration/iceberg_destination_test.go
@@ -609,3 +609,61 @@ func joinIcebergObjectPrefix(parts ...string) string {
 	}
 	return strings.Join(joined, "/") + "/"
 }
+
+// TestIcebergDestinationCredentialsFromURIOnly is a regression guard: an S3-backed
+// Iceberg write must succeed with credentials supplied ONLY in the destination URI.
+// The other Iceberg tests set AWS_* via setIcebergMinioEnv, which would mask a
+// regression where the write path ignores the URI's s3.* credentials.
+func TestIcebergDestinationCredentialsFromURIOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	clearAWSEnvForURIOnlyTest(t)
+
+	ctx := context.Background()
+
+	minio := getMinioEnv(t)
+	client := createMinioClient(t, minio.endpoint)
+	bucket := "iceberg-" + uniqueSuffix()
+	createIcebergBucket(t, ctx, client, bucket)
+
+	destURI := icebergSQLMinioDestinationURI(t, minio.endpoint, bucket)
+	namespace := "it_" + uniqueSuffix()
+	tableName := namespace + ".events"
+
+	rows := writeIcebergJSONL(t, "uri_only.jsonl",
+		`{"id":1,"name":"alpha"}`,
+		`{"id":2,"name":"bravo"}`,
+	)
+	runIcebergPipeline(t, ctx, rows, destURI, tableName, ingestconfig.StrategyReplace)
+
+	// Data + metadata landed in S3 using only the URI credentials.
+	tablePrefix := joinIcebergObjectPrefix("", namespace, "events")
+	assert.Greater(t, countMinioObjects(t, ctx, client, bucket, tablePrefix+"data/"), 0)
+	assert.Greater(t, countMinioObjects(t, ctx, client, bucket, tablePrefix+"metadata/"), 0)
+}
+
+// clearAWSEnvForURIOnlyTest removes every AWS_* input and points the SDK's config
+// files at nonexistent paths, so the destination URI is the only possible source
+// of S3 credentials/region. Originals are restored on cleanup.
+func clearAWSEnvForURIOnlyTest(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN", "AWS_S3_ENDPOINT", "AWS_EC2_METADATA_DISABLED", "AWS_PROFILE",
+		"AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE",
+	} {
+		orig, had := os.LookupEnv(key)
+		require.NoError(t, os.Unsetenv(key))
+		t.Cleanup(func() {
+			if had {
+				_ = os.Setenv(key, orig)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+	}
+	require.NoError(t, os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "no-credentials")))
+	require.NoError(t, os.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "no-config")))
+}


### PR DESCRIPTION
## Problem

Writing to the Iceberg destination on S3 fails with:

```
operation error S3: PutObject, resolve auth scheme: resolve endpoint:
endpoint rule error, Invalid region: region was not a valid DNS name.
```

unless the user *also* exports `AWS_REGION` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_S3_ENDPOINT`, even though those values are already present in the destination URI (`region=`, `access_key_id=`, `secret_access_key=`, `endpoint=`).

## Root cause

`parseIcebergConfig` correctly maps the URI params into iceberg-go properties (`s3.region`, `s3.access-key-id`, `s3.secret-access-key`, `s3.endpoint`) — this is unit-tested. Reads use these props. But the **write/commit** path builds its FileIO from the **AWS default credential chain** (env → shared config → IMDS), *not* from the catalog's `s3.*` properties, so the URI credentials never reach it. With no env vars, region/creds resolve to nothing and the S3 write fails (and, with partial env, it hangs ~9s probing EC2 IMDS at `169.254.169.254`).

This affects **every catalog** when `storage=s3` (postgres, sqlite, rest, hive). Local-filesystem storage is unaffected (no S3 client).

## Fix

Bridge the parsed `s3.*` properties into the AWS SDK environment in `Destination.Connect()`, before any catalog/FileIO use (same process, so it's read at write time):

- `setenvIfEmpty` — **user-set env always wins**, so this only fills gaps.
- Local-FS destinations are untouched (the `s3.*` props are empty).
- `AWS_EC2_METADATA_DISABLED` is set only when explicit keys were supplied, to skip the slow/pointless IMDS probe; when no keys are given (instance-role auth) IMDS stays enabled.

This mirrors how the DuckLake/DuckDB path already injects URI credentials into its engine, and it keeps callers' "credentials go in the URI" model intact (including Bruin, which runs ingestr as a subprocess and passes creds via the URI).

## Testing

- `go build` / `go vet` / `go test ./pkg/destination/iceberg/` — pass
- `golangci-lint run ./pkg/destination/iceberg/` — 0 issues
- **New integration test** `TestIcebergDestinationCredentialsFromURIOnly` — clears every `AWS_*` env var (and points the SDK config files at nonexistent paths), then writes to an S3-backed Iceberg table with credentials supplied **only** in the URI. Passes with this fix; would fail without it. (`go test -tags integration` — pass, ~103s.)
- Manual e2e (Postgres catalog + MinIO): the exact command that previously required `AWS_*` exports now succeeds with credentials supplied only via the URI — verified readable via DuckDB `iceberg_scan`.

## Follow-up (not in this PR)

Longer term, the cleanest fix is upstream in iceberg-go so the table write FileIO inherits the catalog's `s3.*` properties (the same ones the read path uses), removing the need to touch process env at all. This PR is the pragmatic in-repo fix that works today for both the CLI and Bruin.