### PR TITLE
fabric: add write_strategy and default to bulk copy

### DIFF
--- a/docs/supported-sources/fabric.md
+++ b/docs/supported-sources/fabric.md
@@ -19,6 +19,7 @@ URI parameters:
 - `warehouse`: the name of the warehouse to connect to
 - `tenant_id`: the Microsoft Entra tenant ID the service principal belongs to
 - `fedauth` (optional): the Microsoft Entra authentication workflow to use (see below)
+- `write_strategy` (optional, destination only): how rows are written to Fabric — `copy` (default) or `insert` (see [Write strategies](#write-strategies))
 
 ## Authentication
 
@@ -53,6 +54,27 @@ ingestr ingest \
     --dest-uri "duckdb:///local.db" \
     --dest-table "main.users"
 ```
+
+## Write strategies
+
+When Fabric is used as a **destination**, the `write_strategy` query parameter controls how rows are sent to the warehouse:
+
+- `copy` (**default**): rows are streamed through the TDS **bulk-copy** path (the same mechanism as SQL Server's `BULK INSERT`). It is the fastest option, especially for **wide tables** (many columns) or **high-row-count** loads where the parameterised insert path is limited by the ~2100 parameter cap per statement.
+- `insert`: rows are written with batched, parameterised `INSERT ... VALUES` statements. Use it if you need to fall back from the bulk-copy path.
+
+Both strategies write directly over the connection — `copy` does **not** stage files in OneLake or blob storage; it uses the bulk-copy path built into the TDS protocol.
+
+Override the default on the destination URI:
+
+```bash
+ingestr ingest \
+    --source-uri "sqlite:///source.db" \
+    --source-table "main.events" \
+    --dest-uri "fabric://$CLIENT_ID:$CLIENT_SECRET@myworkspace.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=$TENANT_ID&write_strategy=insert" \
+    --dest-table "dbo.events"
+```
+
+The `write_strategy` value only affects how data is loaded; it is independent of `--incremental-strategy`, which controls the merge/replace/append semantics of the ingestion.
 
 ## Notes & limitations
 

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 	"time"
@@ -14,7 +15,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
-	_ "github.com/microsoft/go-mssqldb"         // registers the "sqlserver" driver
+	mssqldb "github.com/microsoft/go-mssqldb"   // also registers the "sqlserver" driver
 	_ "github.com/microsoft/go-mssqldb/azuread" // registers the "azuresql" driver (Microsoft Entra auth)
 )
 
@@ -23,10 +24,20 @@ import (
 // at exactly 2100, so we batch to stay strictly below it.
 const maxParamLimit = 2100
 
+// Write modes selected via the fabric:// URI's write_strategy query parameter.
+// copy (the default) streams rows through the TDS bulk-copy path (mssqldb.CopyIn)
+// and is faster for wide or high-row tables; insert builds parameterised
+// INSERT ... VALUES batches.
+const (
+	writeModeInsert = "insert"
+	writeModeCopy   = "copy"
+)
+
 type FabricDestination struct {
-	db       *sql.DB
-	uri      string
-	database string
+	db        *sql.DB
+	uri       string
+	database  string
+	writeMode string
 }
 
 func NewFabricDestination() *FabricDestination {
@@ -38,7 +49,7 @@ func (d *FabricDestination) Schemes() []string {
 }
 
 func (d *FabricDestination) Connect(ctx context.Context, uri string) error {
-	connStr, database, err := uriToConnString(uri)
+	connStr, database, writeMode, err := uriToConnString(uri)
 	if err != nil {
 		return fmt.Errorf("failed to parse Fabric URI: %w", err)
 	}
@@ -63,7 +74,8 @@ func (d *FabricDestination) Connect(ctx context.Context, uri string) error {
 	d.db = db
 	d.uri = uri
 	d.database = database
-	config.Debug("[Fabric] Connected to warehouse: %s", database)
+	d.writeMode = writeMode
+	config.Debug("[Fabric] Connected to warehouse: %s (write mode: %s)", database, writeMode)
 	return nil
 }
 
@@ -76,14 +88,14 @@ func (d *FabricDestination) Connect(ctx context.Context, uri string) error {
 // id is supplied, otherwise ActiveDirectoryDefault; an explicit ?fedauth= always
 // wins (so e.g. ActiveDirectoryManagedIdentity or
 // ActiveDirectoryServicePrincipalAccessToken work without code changes).
-func uriToConnString(uri string) (string, string, error) {
+func uriToConnString(uri string) (string, string, string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	if scheme := strings.ToLower(u.Scheme); scheme != "fabric" {
-		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
+		return "", "", "", fmt.Errorf("unsupported scheme: %s", scheme)
 	}
 
 	host := u.Hostname()
@@ -105,6 +117,21 @@ func uriToConnString(uri string) (string, string, error) {
 
 	tenantID := query.Get("tenant_id")
 	query.Del("tenant_id")
+
+	// write_strategy selects the write path; it is ingestr-specific and must not
+	// leak into the SQL Server DSN handed to the driver.
+	writeMode := writeModeCopy
+	if ws := query.Get("write_strategy"); ws != "" {
+		switch strings.ToLower(ws) {
+		case writeModeInsert:
+			writeMode = writeModeInsert
+		case writeModeCopy:
+			writeMode = writeModeCopy
+		default:
+			return "", "", "", fmt.Errorf("invalid write_strategy %q: must be %q or %q", ws, writeModeInsert, writeModeCopy)
+		}
+	}
+	query.Del("write_strategy")
 
 	if query.Get("fedauth") == "" {
 		if clientID != "" {
@@ -147,7 +174,7 @@ func uriToConnString(uri string) (string, string, error) {
 
 	connURL.RawQuery = query.Encode()
 
-	return connURL.String(), database, nil
+	return connURL.String(), database, writeMode, nil
 }
 
 func (d *FabricDestination) Close(ctx context.Context) error {
@@ -249,7 +276,13 @@ func (d *FabricDestination) WriteParallel(ctx context.Context, records <-chan so
 		batchNum++
 		startBatch := time.Now()
 
-		rows, err := d.writeRecordBatch(ctx, result.Batch, opts.Table)
+		var rows int64
+		var err error
+		if d.writeMode == writeModeCopy {
+			rows, err = d.writeRecordBatchCopy(ctx, result.Batch, opts.Table, opts.Schema)
+		} else {
+			rows, err = d.writeRecordBatchInsert(ctx, result.Batch, opts.Table)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
 		}
@@ -267,7 +300,7 @@ func (d *FabricDestination) WriteParallel(ctx context.Context, records <-chan so
 	return nil
 }
 
-func (d *FabricDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+func (d *FabricDestination) writeRecordBatchInsert(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
 	numRows := record.NumRows()
 	numCols := int(record.NumCols())
 
@@ -329,6 +362,99 @@ func (d *FabricDestination) writeRecordBatch(ctx context.Context, record arrow.R
 	}
 
 	return numRows, nil
+}
+
+// writeRecordBatchCopy streams the batch through Fabric's TDS bulk-copy path
+// (mssqldb.CopyIn) instead of parameterised INSERT ... VALUES. It keeps the same
+// one-transaction-per-Arrow-batch boundary as the insert path.
+func (d *FabricDestination) writeRecordBatchCopy(ctx context.Context, record arrow.RecordBatch, table string, tableSchema *schema.TableSchema) (int64, error) {
+	numRows := record.NumRows()
+	numCols := int(record.NumCols())
+
+	if numRows == 0 || numCols == 0 {
+		return 0, nil
+	}
+
+	colNames := make([]string, numCols)
+	for i := 0; i < numCols; i++ {
+		colNames[i] = record.Schema().Field(i).Name
+	}
+	columnTypes := columnsForRecord(record, tableSchema)
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, mssqldb.CopyIn(quoteTable(table), mssqldb.BulkOptions{
+		RowsPerBatch: int(numRows),
+		Tablock:      true,
+	}, colNames...))
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare bulk copy: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	values := make([]interface{}, numCols)
+	for rowIdx := int64(0); rowIdx < numRows; rowIdx++ {
+		for colIdx := 0; colIdx < numCols; colIdx++ {
+			value, err := extractCopyValue(record.Column(colIdx), int(rowIdx), columnTypes[colIdx])
+			if err != nil {
+				return rowIdx, fmt.Errorf("failed to convert column %s row %d: %w", colNames[colIdx], rowIdx, err)
+			}
+			values[colIdx] = value
+		}
+
+		if _, err := stmt.ExecContext(ctx, values...); err != nil {
+			return rowIdx, fmt.Errorf("failed to bulk copy row %d: %w", rowIdx, err)
+		}
+	}
+
+	result, err := stmt.ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to flush bulk copy: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		rowsAffected = numRows
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+
+	return rowsAffected, nil
+}
+
+// columnsForRecord aligns the record's fields with the destination table schema
+// by case-insensitive name, so extractCopyValue can consult per-column metadata
+// (chiefly to convert UUID strings into mssqldb.UniqueIdentifier). Fields with no
+// matching schema column map to nil.
+func columnsForRecord(record arrow.RecordBatch, tableSchema *schema.TableSchema) []*schema.Column {
+	columns := make([]*schema.Column, int(record.NumCols()))
+	if tableSchema == nil {
+		return columns
+	}
+
+	byName := make(map[string]int, len(tableSchema.Columns))
+	for i, col := range tableSchema.Columns {
+		byName[strings.ToLower(col.Name)] = i
+	}
+
+	for i, field := range record.Schema().Fields() {
+		if idx, ok := byName[strings.ToLower(field.Name)]; ok {
+			columns[i] = &tableSchema.Columns[idx]
+		}
+	}
+	return columns
 }
 
 // SwapTable is intentionally unsupported for Fabric. SupportsAtomicSwap returns
@@ -829,4 +955,109 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 	default:
 		return arr.ValueStr(idx)
 	}
+}
+
+// extractCopyValue converts an Arrow value into the driver-native shape the TDS
+// bulk-copy path expects: booleans as bool, dates/timestamps/times as time.Time,
+// UUID strings (per the destination schema) as mssqldb.UniqueIdentifier, decimals
+// and nested arrays/structs as strings. This mirrors the SQL Server destination's
+// bulk-copy conversion and is deliberately separate from extractValue, which the
+// parameterised insert path still uses unchanged.
+func extractCopyValue(arr arrow.Array, idx int, col *schema.Column) (interface{}, error) {
+	if arr.IsNull(idx) {
+		return nil, nil
+	}
+
+	switch a := arr.(type) {
+	case *array.Boolean:
+		return a.Value(idx), nil
+	case *array.Int8:
+		return int32(a.Value(idx)), nil
+	case *array.Int16:
+		return int32(a.Value(idx)), nil
+	case *array.Int32:
+		return a.Value(idx), nil
+	case *array.Int64:
+		return a.Value(idx), nil
+	case *array.Uint8:
+		return int32(a.Value(idx)), nil
+	case *array.Uint16:
+		return int32(a.Value(idx)), nil
+	case *array.Uint32:
+		return int64(a.Value(idx)), nil
+	case *array.Uint64:
+		value := a.Value(idx)
+		if value > math.MaxInt64 {
+			return nil, fmt.Errorf("uint64 value %d overflows BIGINT", value)
+		}
+		return int64(value), nil
+	case *array.Float16:
+		return a.Value(idx).Float32(), nil
+	case *array.Float32:
+		return a.Value(idx), nil
+	case *array.Float64:
+		return a.Value(idx), nil
+	case *array.String:
+		return convertCopyStringValue(a.Value(idx), col)
+	case *array.LargeString:
+		return convertCopyStringValue(a.Value(idx), col)
+	case *array.Binary:
+		return a.Value(idx), nil
+	case *array.LargeBinary:
+		return a.Value(idx), nil
+	case *array.FixedSizeBinary:
+		return a.Value(idx), nil
+	case *array.Date32:
+		return a.Value(idx).ToTime(), nil
+	case *array.Date64:
+		return a.Value(idx).ToTime(), nil
+	case *array.Time32:
+		return timeFromArrowTime(int64(a.Value(idx)), a.DataType().(*arrow.Time32Type).Unit), nil
+	case *array.Time64:
+		return timeFromArrowTime(int64(a.Value(idx)), a.DataType().(*arrow.Time64Type).Unit), nil
+	case *array.Timestamp:
+		ts := a.Value(idx)
+		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit), nil
+	case *array.Decimal128:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale)), nil
+	case *array.Decimal256:
+		return a.ValueStr(idx), nil
+	case array.ListLike:
+		return a.ValueStr(idx), nil
+	case *array.Struct:
+		return a.ValueStr(idx), nil
+	case array.ExtensionArray:
+		return extractCopyValue(a.Storage(), idx, col)
+	default:
+		return arr.ValueStr(idx), nil
+	}
+}
+
+func convertCopyStringValue(value string, col *schema.Column) (interface{}, error) {
+	if col == nil || col.DataType != schema.TypeUUID {
+		return value, nil
+	}
+
+	var uuid mssqldb.UniqueIdentifier
+	if err := uuid.Scan(value); err != nil {
+		return nil, fmt.Errorf("invalid UUID %q: %w", value, err)
+	}
+	return uuid, nil
+}
+
+// timeFromArrowTime renders an Arrow time-of-day value as a time.Time anchored at
+// the zero date, which the driver encodes as SQL Server's TIME type.
+func timeFromArrowTime(value int64, unit arrow.TimeUnit) time.Time {
+	var duration time.Duration
+	switch unit {
+	case arrow.Second:
+		duration = time.Duration(value) * time.Second
+	case arrow.Millisecond:
+		duration = time.Duration(value) * time.Millisecond
+	case arrow.Nanosecond:
+		duration = time.Duration(value) * time.Nanosecond
+	default:
+		duration = time.Duration(value) * time.Microsecond
+	}
+	return time.Date(1, 1, 1, int(duration/time.Hour), int(duration/time.Minute)%60, int(duration/time.Second)%60, int(duration%time.Second), time.UTC)
 }

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -1050,21 +1050,36 @@ func convertCopyStringValue(value string, col *schema.Column) (interface{}, erro
 // outside [00:00:00, 24:00:00) are rejected so a malformed source value fails the
 // batch instead of silently wrapping the excess hours into the next day (which
 // would store a wrong time-of-day rather than erroring, unlike the insert path
-// where the server rejects the out-of-range literal).
+// where the server rejects the out-of-range literal). The raw value is range
+// checked against the unit-specific limit before the multiplication so a huge
+// value cannot overflow int64 and wrap back into an in-range duration.
 func timeFromArrowTime(value int64, unit arrow.TimeUnit) (time.Time, error) {
+	outOfRange := func() error {
+		return fmt.Errorf("time-of-day value out of range [00:00:00, 24:00:00): %d %s", value, unit)
+	}
+
 	var duration time.Duration
 	switch unit {
 	case arrow.Second:
+		if value < 0 || value >= int64((24*time.Hour)/time.Second) {
+			return time.Time{}, outOfRange()
+		}
 		duration = time.Duration(value) * time.Second
 	case arrow.Millisecond:
+		if value < 0 || value >= int64((24*time.Hour)/time.Millisecond) {
+			return time.Time{}, outOfRange()
+		}
 		duration = time.Duration(value) * time.Millisecond
 	case arrow.Nanosecond:
+		if value < 0 || value >= int64(24*time.Hour) {
+			return time.Time{}, outOfRange()
+		}
 		duration = time.Duration(value) * time.Nanosecond
 	default:
+		if value < 0 || value >= int64((24*time.Hour)/time.Microsecond) {
+			return time.Time{}, outOfRange()
+		}
 		duration = time.Duration(value) * time.Microsecond
-	}
-	if duration < 0 || duration >= 24*time.Hour {
-		return time.Time{}, fmt.Errorf("time-of-day value out of range [00:00:00, 24:00:00): %v", duration)
 	}
 	return time.Date(1, 1, 1, int(duration/time.Hour), int(duration/time.Minute)%60, int(duration/time.Second)%60, int(duration%time.Second), time.UTC), nil
 }

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -1012,9 +1012,9 @@ func extractCopyValue(arr arrow.Array, idx int, col *schema.Column) (interface{}
 	case *array.Date64:
 		return a.Value(idx).ToTime(), nil
 	case *array.Time32:
-		return timeFromArrowTime(int64(a.Value(idx)), a.DataType().(*arrow.Time32Type).Unit), nil
+		return timeFromArrowTime(int64(a.Value(idx)), a.DataType().(*arrow.Time32Type).Unit)
 	case *array.Time64:
-		return timeFromArrowTime(int64(a.Value(idx)), a.DataType().(*arrow.Time64Type).Unit), nil
+		return timeFromArrowTime(int64(a.Value(idx)), a.DataType().(*arrow.Time64Type).Unit)
 	case *array.Timestamp:
 		ts := a.Value(idx)
 		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit), nil
@@ -1046,8 +1046,12 @@ func convertCopyStringValue(value string, col *schema.Column) (interface{}, erro
 }
 
 // timeFromArrowTime renders an Arrow time-of-day value as a time.Time anchored at
-// the zero date, which the driver encodes as SQL Server's TIME type.
-func timeFromArrowTime(value int64, unit arrow.TimeUnit) time.Time {
+// the zero date, which the driver encodes as SQL Server's TIME type. Values
+// outside [00:00:00, 24:00:00) are rejected so a malformed source value fails the
+// batch instead of silently wrapping the excess hours into the next day (which
+// would store a wrong time-of-day rather than erroring, unlike the insert path
+// where the server rejects the out-of-range literal).
+func timeFromArrowTime(value int64, unit arrow.TimeUnit) (time.Time, error) {
 	var duration time.Duration
 	switch unit {
 	case arrow.Second:
@@ -1059,5 +1063,8 @@ func timeFromArrowTime(value int64, unit arrow.TimeUnit) time.Time {
 	default:
 		duration = time.Duration(value) * time.Microsecond
 	}
-	return time.Date(1, 1, 1, int(duration/time.Hour), int(duration/time.Minute)%60, int(duration/time.Second)%60, int(duration%time.Second), time.UTC)
+	if duration < 0 || duration >= 24*time.Hour {
+		return time.Time{}, fmt.Errorf("time-of-day value out of range [00:00:00, 24:00:00): %v", duration)
+	}
+	return time.Date(1, 1, 1, int(duration/time.Hour), int(duration/time.Minute)%60, int(duration/time.Second)%60, int(duration%time.Second), time.UTC), nil
 }

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -336,7 +336,7 @@ func TestColumnsForRecordMapsByCaseInsensitiveName(t *testing.T) {
 	defer strArray.Release()
 	strBuilder.Release()
 
-	record := array.NewRecord(arrowSchema, []arrow.Array{idArray, strArray}, 1)
+	record := array.NewRecordBatch(arrowSchema, []arrow.Array{idArray, strArray}, 1)
 	defer record.Release()
 
 	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -244,16 +244,22 @@ func TestExtractCopyValueReturnsDriverNativeTypes(t *testing.T) {
 }
 
 func TestExtractCopyValueRejectsOutOfRangeTime(t *testing.T) {
-	// 25 hours in microseconds — a valid int64 but not a valid time-of-day.
-	time64Type := &arrow.Time64Type{Unit: arrow.Microsecond}
-	builder := array.NewTime64Builder(memory.DefaultAllocator, time64Type)
-	builder.Append(arrow.Time64(25 * 60 * 60 * 1_000_000))
-	arr := builder.NewArray()
-	defer arr.Release()
-	builder.Release()
+	// 25 hours in microseconds — a valid int64 but not a valid time-of-day. A
+	// second case uses the max int64 microsecond value, which would overflow and
+	// wrap into a small in-range duration if the range check ran after the
+	// multiplication by 1000.
+	for _, value := range []arrow.Time64{25 * 60 * 60 * 1_000_000, 9223372036854775807} {
+		time64Type := &arrow.Time64Type{Unit: arrow.Microsecond}
+		builder := array.NewTime64Builder(memory.DefaultAllocator, time64Type)
+		builder.Append(value)
+		arr := builder.NewArray()
 
-	if _, err := extractCopyValue(arr, 0, nil); err == nil {
-		t.Fatal("expected out-of-range time error")
+		if _, err := extractCopyValue(arr, 0, nil); err == nil {
+			t.Fatalf("expected out-of-range time error for value %d", value)
+		}
+
+		arr.Release()
+		builder.Release()
 	}
 }
 

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -243,6 +243,20 @@ func TestExtractCopyValueReturnsDriverNativeTypes(t *testing.T) {
 	}
 }
 
+func TestExtractCopyValueRejectsOutOfRangeTime(t *testing.T) {
+	// 25 hours in microseconds — a valid int64 but not a valid time-of-day.
+	time64Type := &arrow.Time64Type{Unit: arrow.Microsecond}
+	builder := array.NewTime64Builder(memory.DefaultAllocator, time64Type)
+	builder.Append(arrow.Time64(25 * 60 * 60 * 1_000_000))
+	arr := builder.NewArray()
+	defer arr.Release()
+	builder.Release()
+
+	if _, err := extractCopyValue(arr, 0, nil); err == nil {
+		t.Fatal("expected out-of-range time error")
+	}
+}
+
 func TestExtractCopyValueConvertsUUIDStrings(t *testing.T) {
 	builder := array.NewStringBuilder(memory.DefaultAllocator)
 	builder.Append("01234567-89ab-cdef-0123-456789abcdef")

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -4,26 +4,35 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	mssqldb "github.com/microsoft/go-mssqldb"
 )
 
 func TestURIToConnString(t *testing.T) {
 	tests := []struct {
-		name         string
-		uri          string
-		wantErr      bool
-		wantDatabase string
-		wantHost     string
-		wantUser     string // expected decoded user-id ("" means no userinfo)
-		wantPassword string
-		wantQuery    map[string]string
+		name          string
+		uri           string
+		wantErr       bool
+		wantDatabase  string
+		wantHost      string
+		wantUser      string // expected decoded user-id ("" means no userinfo)
+		wantPassword  string
+		wantQuery     map[string]string
+		wantWriteMode string
 	}{
 		{
-			name:         "service principal with tenant",
-			uri:          "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=tenant-123",
-			wantDatabase: "MyWarehouse",
-			wantHost:     "abc.datawarehouse.fabric.microsoft.com:1433",
-			wantUser:     "client-id@tenant-123",
-			wantPassword: "s3cr3t",
+			name:          "service principal with tenant defaults to copy",
+			uri:           "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/MyWarehouse?tenant_id=tenant-123",
+			wantDatabase:  "MyWarehouse",
+			wantHost:      "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:      "client-id@tenant-123",
+			wantPassword:  "s3cr3t",
+			wantWriteMode: writeModeCopy,
 			wantQuery: map[string]string{
 				"fedauth":  "ActiveDirectoryServicePrincipal",
 				"database": "MyWarehouse",
@@ -31,11 +40,12 @@ func TestURIToConnString(t *testing.T) {
 			},
 		},
 		{
-			name:         "no credentials defaults to ActiveDirectoryDefault",
-			uri:          "fabric://abc.datawarehouse.fabric.microsoft.com/wh",
-			wantDatabase: "wh",
-			wantHost:     "abc.datawarehouse.fabric.microsoft.com:1433",
-			wantUser:     "",
+			name:          "no credentials defaults to ActiveDirectoryDefault and copy",
+			uri:           "fabric://abc.datawarehouse.fabric.microsoft.com/wh",
+			wantDatabase:  "wh",
+			wantHost:      "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:      "",
+			wantWriteMode: writeModeCopy,
 			wantQuery: map[string]string{
 				"fedauth":  "ActiveDirectoryDefault",
 				"database": "wh",
@@ -43,17 +53,51 @@ func TestURIToConnString(t *testing.T) {
 			},
 		},
 		{
-			name:         "explicit fedauth and port are preserved",
-			uri:          "fabric://client-id:token@host.example.com:1234/wh?fedauth=ActiveDirectoryServicePrincipalAccessToken&tenant_id=t1",
-			wantDatabase: "wh",
-			wantHost:     "host.example.com:1234",
-			wantUser:     "client-id@t1",
-			wantPassword: "token",
+			name:          "explicit fedauth and port are preserved",
+			uri:           "fabric://client-id:token@host.example.com:1234/wh?fedauth=ActiveDirectoryServicePrincipalAccessToken&tenant_id=t1",
+			wantDatabase:  "wh",
+			wantHost:      "host.example.com:1234",
+			wantUser:      "client-id@t1",
+			wantPassword:  "token",
+			wantWriteMode: writeModeCopy,
 			wantQuery: map[string]string{
 				"fedauth":  "ActiveDirectoryServicePrincipalAccessToken",
 				"database": "wh",
 				"encrypt":  "true",
 			},
+		},
+		{
+			name:          "write_strategy copy is accepted",
+			uri:           "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/wh?tenant_id=t1&write_strategy=copy",
+			wantDatabase:  "wh",
+			wantHost:      "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:      "client-id@t1",
+			wantPassword:  "s3cr3t",
+			wantWriteMode: writeModeCopy,
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryServicePrincipal",
+				"database": "wh",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:          "write_strategy insert is accepted",
+			uri:           "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/wh?tenant_id=t1&write_strategy=INSERT",
+			wantDatabase:  "wh",
+			wantHost:      "abc.datawarehouse.fabric.microsoft.com:1433",
+			wantUser:      "client-id@t1",
+			wantPassword:  "s3cr3t",
+			wantWriteMode: writeModeInsert,
+			wantQuery: map[string]string{
+				"fedauth":  "ActiveDirectoryServicePrincipal",
+				"database": "wh",
+				"encrypt":  "true",
+			},
+		},
+		{
+			name:    "invalid write_strategy errors",
+			uri:     "fabric://client-id:s3cr3t@abc.datawarehouse.fabric.microsoft.com/wh?tenant_id=t1&write_strategy=bulk",
+			wantErr: true,
 		},
 		{
 			name:    "wrong scheme errors",
@@ -64,7 +108,7 @@ func TestURIToConnString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			connStr, database, err := uriToConnString(tt.uri)
+			connStr, database, writeMode, err := uriToConnString(tt.uri)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (connStr=%q)", connStr)
@@ -77,6 +121,10 @@ func TestURIToConnString(t *testing.T) {
 
 			if database != tt.wantDatabase {
 				t.Errorf("database = %q, want %q", database, tt.wantDatabase)
+			}
+
+			if writeMode != tt.wantWriteMode {
+				t.Errorf("writeMode = %q, want %q", writeMode, tt.wantWriteMode)
 			}
 
 			u, perr := url.Parse(connStr)
@@ -114,6 +162,10 @@ func TestURIToConnString(t *testing.T) {
 			if q.Has("tenant_id") {
 				t.Errorf("tenant_id should not appear in DSN query, got %q", q.Get("tenant_id"))
 			}
+			// write_strategy is ingestr-specific and must not leak into the DSN.
+			if q.Has("write_strategy") {
+				t.Errorf("write_strategy should not appear in DSN query, got %q", q.Get("write_strategy"))
+			}
 		})
 	}
 }
@@ -126,5 +178,157 @@ func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
 	}
 	if !strings.Contains(sql, "[updated_at] >= @p1") || !strings.Contains(sql, "[updated_at] <= @p2") {
 		t.Fatalf("delete SQL missing interval predicate: %s", sql)
+	}
+}
+
+func mustExtractCopyValue(t *testing.T, arr arrow.Array, col *schema.Column) interface{} {
+	t.Helper()
+	value, err := extractCopyValue(arr, 0, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func TestExtractCopyValueReturnsDriverNativeTypes(t *testing.T) {
+	pool := memory.DefaultAllocator
+
+	boolBuilder := array.NewBooleanBuilder(pool)
+	boolBuilder.Append(true)
+	boolArray := boolBuilder.NewArray()
+	defer boolArray.Release()
+	boolBuilder.Release()
+
+	if got := mustExtractCopyValue(t, boolArray, nil); got != true {
+		t.Fatalf("expected bool true, got %T %v", got, got)
+	}
+
+	tsType := &arrow.TimestampType{Unit: arrow.Microsecond}
+	tsBuilder := array.NewTimestampBuilder(pool, tsType)
+	want := time.Date(2024, 1, 2, 3, 4, 5, 123456000, time.UTC)
+	tsBuilder.Append(arrow.Timestamp(want.UnixMicro()))
+	tsArray := tsBuilder.NewArray()
+	defer tsArray.Release()
+	tsBuilder.Release()
+
+	got := mustExtractCopyValue(t, tsArray, nil)
+	gotTime, ok := got.(time.Time)
+	if !ok {
+		t.Fatalf("expected time.Time, got %T %v", got, got)
+	}
+	if !gotTime.Equal(want) {
+		t.Fatalf("expected timestamp %v, got %v", want, gotTime)
+	}
+
+	dateBuilder := array.NewDate32Builder(pool)
+	dateBuilder.Append(arrow.Date32FromTime(time.Date(2024, 5, 6, 0, 0, 0, 0, time.UTC)))
+	dateArray := dateBuilder.NewArray()
+	defer dateArray.Release()
+	dateBuilder.Release()
+
+	if _, ok := mustExtractCopyValue(t, dateArray, nil).(time.Time); !ok {
+		t.Fatalf("expected date to convert to time.Time")
+	}
+
+	time64Type := &arrow.Time64Type{Unit: arrow.Microsecond}
+	time64Builder := array.NewTime64Builder(pool, time64Type)
+	time64Builder.Append(arrow.Time64(3723456789))
+	time64Array := time64Builder.NewArray()
+	defer time64Array.Release()
+	time64Builder.Release()
+
+	wantTime := time.Date(1, 1, 1, 1, 2, 3, 456789000, time.UTC)
+	if got := mustExtractCopyValue(t, time64Array, nil); !got.(time.Time).Equal(wantTime) {
+		t.Fatalf("expected time64 %v, got %T %v", wantTime, got, got)
+	}
+}
+
+func TestExtractCopyValueConvertsUUIDStrings(t *testing.T) {
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	builder.Append("01234567-89ab-cdef-0123-456789abcdef")
+	arr := builder.NewArray()
+	defer arr.Release()
+	builder.Release()
+
+	got := mustExtractCopyValue(t, arr, &schema.Column{DataType: schema.TypeUUID})
+	uuid, ok := got.(mssqldb.UniqueIdentifier)
+	if !ok {
+		t.Fatalf("expected UniqueIdentifier, got %T %v", got, got)
+	}
+	if uuid.String() != "01234567-89AB-CDEF-0123-456789ABCDEF" {
+		t.Fatalf("unexpected UUID value: %s", uuid.String())
+	}
+}
+
+func TestExtractCopyValueLeavesNonUUIDStringsUntouched(t *testing.T) {
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	builder.Append("01234567-89ab-cdef-0123-456789abcdef")
+	arr := builder.NewArray()
+	defer arr.Release()
+	builder.Release()
+
+	// Without a UUID-typed column, the value must stay a plain string.
+	if got := mustExtractCopyValue(t, arr, &schema.Column{DataType: schema.TypeString}); got != "01234567-89ab-cdef-0123-456789abcdef" {
+		t.Fatalf("expected untouched string, got %T %v", got, got)
+	}
+}
+
+func TestExtractCopyValueRejectsInvalidUUIDStrings(t *testing.T) {
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	builder.Append("not-a-uuid")
+	arr := builder.NewArray()
+	defer arr.Release()
+	builder.Release()
+
+	if _, err := extractCopyValue(arr, 0, &schema.Column{DataType: schema.TypeUUID}); err == nil {
+		t.Fatal("expected invalid UUID error")
+	}
+}
+
+func TestExtractCopyValueReturnsNilForNulls(t *testing.T) {
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	builder.AppendNull()
+	arr := builder.NewArray()
+	defer arr.Release()
+	builder.Release()
+
+	if got := mustExtractCopyValue(t, arr, nil); got != nil {
+		t.Fatalf("expected nil, got %T %v", got, got)
+	}
+}
+
+func TestColumnsForRecordMapsByCaseInsensitiveName(t *testing.T) {
+	pool := memory.DefaultAllocator
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "unmatched", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	idBuilder := array.NewInt64Builder(pool)
+	idBuilder.Append(1)
+	idArray := idBuilder.NewArray()
+	defer idArray.Release()
+	idBuilder.Release()
+
+	strBuilder := array.NewStringBuilder(pool)
+	strBuilder.Append("x")
+	strArray := strBuilder.NewArray()
+	defer strArray.Release()
+	strBuilder.Release()
+
+	record := array.NewRecord(arrowSchema, []arrow.Array{idArray, strArray}, 1)
+	defer record.Release()
+
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	cols := columnsForRecord(record, tableSchema)
+
+	if len(cols) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(cols))
+	}
+	if cols[0] == nil || cols[0].DataType != schema.TypeInt64 {
+		t.Fatalf("expected first column mapped to id (int64), got %+v", cols[0])
+	}
+	if cols[1] != nil {
+		t.Fatalf("expected unmatched column to map to nil, got %+v", cols[1])
 	}
 }


### PR DESCRIPTION
## What

Adds a `write_strategy` query parameter to the `fabric://` destination URI to choose how rows are written to a Fabric Warehouse:

- **`copy` (new default)**: streams rows through the TDS bulk-copy path via `mssqldb.CopyIn` (`BulkOptions{RowsPerBatch, Tablock: true}`), mirroring the SQL Server destination.
- **`insert`**: the previous parameterised `INSERT ... VALUES` batching behaviour, retained as a fallback.

`write_strategy` is validated at connect time (invalid values error) and stripped from the generated SQL Server DSN so it never reaches the driver. It is independent of `--incremental-strategy`.

## Why

The insert path binds one parameter per cell and is capped at ~2100 parameters per statement, so wide or high-row-count tables are batched into many small statements and load slowly. The bulk-copy path streams rows over the same connection (no file staging in OneLake/blob) and is substantially faster for those loads, so it becomes the default.

## Details

- The copy path adds `extractCopyValue`, which converts Arrow values into driver-native shapes: `bool` for booleans, `time.Time` for dates/timestamps/times, `mssqldb.UniqueIdentifier` for UUID-typed columns, and strings for decimals/arrays/structs. It uses the destination table schema (matched to record fields by case-insensitive name) for type-sensitive conversion, chiefly the UUID case.
- The existing insert writer and its `extractValue` are left unchanged; the writer is only renamed to `writeRecordBatchInsert`.
- Bulk copy works over Fabric's Entra-auth `azuresql` driver: it produces the same `*mssql.Conn`, whose `PrepareContext` recognises the `CopyIn` statement.

## Tests

- URI parsing: default is `copy`, both `write_strategy=copy` and `write_strategy=insert` are accepted, invalid values error, and neither `write_strategy` nor `tenant_id` leaks into the DSN.
- Value conversion: `extractCopyValue` for booleans, timestamps, dates, times, UUID → `UniqueIdentifier`, non-UUID strings untouched, invalid UUID errors, null → nil; plus `columnsForRecord` case-insensitive mapping.

## Docs

Documents `write_strategy` and a new "Write strategies" section in `docs/supported-sources/fabric.md`.