### PR TITLE
onelake: accept period-separated Delta table targets

### DIFF
--- a/docs/supported-sources/onelake.md
+++ b/docs/supported-sources/onelake.md
@@ -25,6 +25,8 @@ The **mode and table** come from `--dest-table`, mirroring OneLake's path layout
 - `Files/<path>` → raw Parquet files
 - a bare name with no prefix defaults to `Tables/`
 
+For Delta tables, `.` and `/` are interchangeable separators and the leading `Tables` segment is optional, so `users`, `schema.name`, `Tables.schema.name` and `Tables/schema/name` are all valid (the last two are equivalent). Period-separated names are convenient because Fabric table and schema names cannot contain a period. Files targets must use the explicit `Files/<path>` form — periods there are left untouched so file extensions are preserved.
+
 The final object path is:
 `https://onelake.dfs.fabric.microsoft.com/<workspace>/<lakehouse>.Lakehouse/<Tables|Files>/<rest>`
 

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -162,19 +162,24 @@ func (d *OneLakeDestination) filesDir() string {
 	return d.itemPath() + "/Files/" + strings.Trim(d.relPath, "/")
 }
 
-// parseTarget splits a dest-table into a write mode and relative path. A leading
-// "Tables/" or "Files/" segment selects the mode; anything else defaults to a
-// Delta table.
+// parseTarget splits a dest-table into a write mode and relative path. A "Files/"
+// prefix selects Files mode and takes the remainder verbatim (periods intact, so
+// file extensions survive). Everything else is a Delta table, where "." and "/"
+// are interchangeable separators and a leading "Tables" segment is optional — so
+// "schema.name", "Tables.schema.name" and "Tables/schema/name" all map to
+// "schema/name". Periods are unambiguous here because Fabric table and schema
+// names cannot contain them.
 func parseTarget(table string) (writeMode, string) {
 	t := strings.Trim(table, "/")
-	switch {
-	case strings.HasPrefix(strings.ToLower(t), "tables/"):
-		return modeTables, t[len("tables/"):]
-	case strings.HasPrefix(strings.ToLower(t), "files/"):
+	if strings.HasPrefix(strings.ToLower(t), "files/") {
 		return modeFiles, t[len("files/"):]
-	default:
-		return modeTables, t
 	}
+
+	parts := strings.FieldsFunc(t, func(r rune) bool { return r == '.' || r == '/' })
+	if len(parts) > 0 && strings.EqualFold(parts[0], "tables") {
+		parts = parts[1:]
+	}
+	return modeTables, strings.Join(parts, "/")
 }
 
 func (d *OneLakeDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -172,8 +172,7 @@ func (d *OneLakeDestination) filesDir() string {
 // names cannot contain them.
 func parseTarget(table string) (writeMode, string, error) {
 	t := strings.Trim(table, "/")
-	if strings.HasPrefix(strings.ToLower(t), "files/") {
-		rel := t[len("files/"):]
+	if head, rel, _ := strings.Cut(t, "/"); strings.EqualFold(head, "files") {
 		if rel == "" {
 			return modeFiles, "", fmt.Errorf("dest-table %q is missing a path after \"Files/\"", table)
 		}

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -169,17 +170,30 @@ func (d *OneLakeDestination) filesDir() string {
 // "schema.name", "Tables.schema.name" and "Tables/schema/name" all map to
 // "schema/name". Periods are unambiguous here because Fabric table and schema
 // names cannot contain them.
-func parseTarget(table string) (writeMode, string) {
+func parseTarget(table string) (writeMode, string, error) {
 	t := strings.Trim(table, "/")
 	if strings.HasPrefix(strings.ToLower(t), "files/") {
-		return modeFiles, t[len("files/"):]
+		rel := t[len("files/"):]
+		if rel == "" {
+			return modeFiles, "", fmt.Errorf("dest-table %q is missing a path after \"Files/\"", table)
+		}
+		return modeFiles, rel, nil
 	}
 
-	parts := strings.FieldsFunc(t, func(r rune) bool { return r == '.' || r == '/' })
-	if len(parts) > 0 && strings.EqualFold(parts[0], "tables") {
-		parts = parts[1:]
+	// Split on "." and "/" keeping empty components, so malformed targets such as
+	// "schema..name" or a bare "Tables" are rejected rather than silently
+	// collapsing to a different (or area-root) path.
+	segs := strings.Split(strings.ReplaceAll(t, ".", "/"), "/")
+	if strings.EqualFold(segs[0], "tables") {
+		segs = segs[1:]
 	}
-	return modeTables, strings.Join(parts, "/")
+	if len(segs) == 0 {
+		return modeTables, "", fmt.Errorf("dest-table %q has no table path", table)
+	}
+	if slices.Contains(segs, "") {
+		return modeTables, "", fmt.Errorf("dest-table %q has an empty path segment", table)
+	}
+	return modeTables, strings.Join(segs, "/"), nil
 }
 
 func (d *OneLakeDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
@@ -191,11 +205,11 @@ func (d *OneLakeDestination) PrepareTable(ctx context.Context, opts destination.
 		d.arrowSchema = opts.Schema.ToArrowSchema()
 	}
 	d.dropFirst = opts.DropFirst
-	d.mode, d.relPath = parseTarget(opts.Table)
-
-	if d.relPath == "" {
-		return fmt.Errorf("dest-table is required for OneLake")
+	mode, relPath, err := parseTarget(opts.Table)
+	if err != nil {
+		return err
 	}
+	d.mode, d.relPath = mode, relPath
 
 	if d.mode == modeTables && opts.PartitionBy != "" {
 		config.Debug("[ONELAKE] partition_by is not supported for Delta tables yet; ignoring %q", opts.PartitionBy)
@@ -512,12 +526,12 @@ func (d *OneLakeDestination) SwapTable(ctx context.Context, opts destination.Swa
 // rejecting Files-mode targets (the copy-on-write strategies only apply to
 // Delta tables).
 func (d *OneLakeDestination) tableDirForTables(table, op string) (string, error) {
-	mode, rel := parseTarget(table)
+	mode, rel, err := parseTarget(table)
+	if err != nil {
+		return "", err
+	}
 	if mode != modeTables {
 		return "", fmt.Errorf("%s strategy requires a Tables/ destination, got %q", op, table)
-	}
-	if rel == "" {
-		return "", fmt.Errorf("invalid table for %s: %q", op, table)
 	}
 	return d.itemPath() + "/Tables/" + strings.Trim(rel, "/"), nil
 }
@@ -732,7 +746,10 @@ func writeBatchesToParquet(batches []arrow.RecordBatch) ([]byte, *arrow.Schema, 
 }
 
 func (d *OneLakeDestination) DropTable(ctx context.Context, table string) error {
-	mode, relPath := parseTarget(table)
+	mode, relPath, err := parseTarget(table)
+	if err != nil {
+		return err
+	}
 	area := "Tables"
 	if mode == modeFiles {
 		area = "Files"

--- a/pkg/destination/onelake/onelake_test.go
+++ b/pkg/destination/onelake/onelake_test.go
@@ -85,8 +85,12 @@ func TestParseTarget(t *testing.T) {
 		{"tables/schema/users", modeTables, "schema/users"},
 		{"Files/exports/users", modeFiles, "exports/users"},
 		{"FILES/raw", modeFiles, "raw"},
+		{"Files/data.parquet", modeFiles, "data.parquet"},
 		{"users", modeTables, "users"},
 		{"/Tables/users/", modeTables, "users"},
+		{"schema.name", modeTables, "schema/name"},
+		{"Tables.schema.name", modeTables, "schema/name"},
+		{"Tables.users", modeTables, "users"},
 	}
 	for _, c := range cases {
 		mode, path := parseTarget(c.table)

--- a/pkg/destination/onelake/onelake_test.go
+++ b/pkg/destination/onelake/onelake_test.go
@@ -93,9 +93,15 @@ func TestParseTarget(t *testing.T) {
 		{"Tables.users", modeTables, "users"},
 	}
 	for _, c := range cases {
-		mode, path := parseTarget(c.table)
+		mode, path, err := parseTarget(c.table)
+		require.NoError(t, err, c.table)
 		assert.Equal(t, c.wantMode, mode, c.table)
 		assert.Equal(t, c.wantPath, path, c.table)
+	}
+
+	for _, bad := range []string{"", "Tables", "tables", "schema..users", ".users", "Files/"} {
+		_, _, err := parseTarget(bad)
+		assert.Error(t, err, bad)
 	}
 }
 


### PR DESCRIPTION
## What

The OneLake destination previously accepted only slash-separated `--dest-table` values (`Tables/schema/name`). This adds periods as an equivalent separator for Delta table targets:

| `--dest-table` | Resolves to |
|---|---|
| `name` | `Tables/name` |
| `schema.name` | `Tables/schema/name` |
| `Tables.schema.name` | `Tables/schema/name` |
| `Tables/schema/name` (existing) | `Tables/schema/name` |

`.` and `/` are interchangeable separators and the leading `Tables` segment is optional.

## Why

Period-separated names are a natural way to express `schema.table` and are unambiguous here because Fabric table and schema names cannot contain a period.

## Files mode

Unchanged. Files targets still require the explicit `Files/<path>` slash form, and the remainder is taken verbatim (no period conversion) so file extensions such as `data.parquet` are preserved.

## Scope notes

- All existing callers (`tableDir`, `tableDirForTables`, `DropTable`) inherit the new parsing via `parseTarget`.
- No deep-nesting validation: Fabric supports a single schema level, but `Tables.a.b.c` maps literally to `a/b/c` rather than erroring.
- A schema literally named `tables` (`tables.x`) collapses to `Tables/x`, consistent with the existing `Tables/` prefix handling.

Tests cover the new period forms and lock the no-conversion behavior for Files. Docs updated.