### PR TITLE
Support new tables in Postgres CDC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 
-.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration
+.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration cdc-postgres-stress-test
 
 all: clean deps test build
 
@@ -94,6 +94,12 @@ test-python:
 test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
 	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -p 64 -parallel 64 -timeout 20m ./tests/integration/...
+
+# High-volume PostgreSQL CDC accuracy test (~6 minutes of sustained load and
+# verification). Gated behind the `stress` build tag so CI never runs it.
+cdc-postgres-stress-test: generate
+	@echo "$(OK_COLOR)==> Running PostgreSQL CDC stress test (sustained load, ~6m)$(NO_COLOR)"
+	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run TestPostgresCDC_StressHighVolume ./tests/integration/
 
 test-db2-integration: generate
 	@echo "$(OK_COLOR)==> Running Db2 integration tests$(NO_COLOR)"

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -75,7 +75,10 @@ ingestr ingest \
 > **Postgres publications.** Pass `publication=<name>` to use a publication you manage yourself. If you omit it, ingestr creates and maintains a publication named `ingestr_publication`, refreshing it on every run to include every logged table that has a replica identity (a primary key, `REPLICA IDENTITY FULL`, or a replica-identity index). Tables that are unlogged, or that lack a replica identity, are skipped with a warning — their changes either never reach the WAL or would make `UPDATE`/`DELETE` on the source fail.
 
 > [!INFO]
-> Schema changes are picked up at startup. If the source schema changes while a stream is running, restart the stream to apply the new schema. Run streaming ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after transient source/destination outages.
+> **New tables.** Postgres CDC picks up tables created after ingestion started. A batch run detects them at startup; a stream additionally re-checks the source on an interval (`discover_interval` URI parameter, default `30s`). When a new table is found, ingestr adds it to the managed publication (user-managed publications are respected: add the table to your publication yourself), snapshots its existing rows through a temporary replication slot so nothing is missed, creates the destination table, and then streams its changes live — all without restarting the stream or disturbing the other tables. See the [Postgres CDC documentation](../supported-sources/postgres.md#change-data-capture-postgrescdc) for details.
+
+> [!INFO]
+> Column-level schema changes are picked up at startup. If a table's columns change while a stream is running, restart the stream to apply the new schema. Run streaming ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after transient source/destination outages.
 
 ## General flags
 

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -19,3 +19,31 @@ URI parameters:
 - `sslmode`: optional, the SSL mode to use when connecting to the database
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's Postgres dialect [here](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html).
+
+## Change Data Capture (postgres+cdc)
+
+The `postgres+cdc://` scheme reads changes through PostgreSQL logical replication instead of querying tables: an initial snapshot of each table followed by every insert, update, and delete, applied to the destination with the `merge` strategy. It requires `wal_level=logical` on the source and a user with the `REPLICATION` privilege.
+
+```plaintext
+postgres+cdc://<username>:<password>@<host>:<port>/<database-name>?publication=<name>&slot=<name>&mode=<batch|stream>&discover_interval=<duration>
+```
+
+CDC-specific URI parameters (all optional):
+- `publication`: the logical-replication publication to read from. When omitted, ingestr creates and maintains a publication named `ingestr_publication` covering every logged table with a usable replica identity, reconciling it on every run.
+- `slot`: the replication slot name. When omitted, ingestr derives a stable name from the publication.
+- `mode`: `batch` (default) runs until it catches up with the current WAL position and exits; `stream` runs continuously. The `--stream` CLI flag forces continuous mode regardless of this parameter.
+- `dest_schema`: a schema/dataset prefix for destination table names.
+- `discover_interval`: how often a running stream re-checks the source for new tables (default `30s`, e.g. `1m`, `10s`). Set to `0` or `off` to disable mid-stream discovery.
+
+Without `--source-table`, CDC runs in multi-table mode and replicates every table in the publication. Deletes are soft: rows are kept in the destination with `_cdc_deleted = true`.
+
+### New tables
+
+Tables created on the source after CDC has been set up are picked up automatically:
+
+- **Batch mode**: the next run detects tables that have no state in the destination, snapshots their existing rows through a temporary replication slot (the main slot's position is untouched), and then streams their changes alongside the other tables.
+- **Stream mode**: the running stream re-checks the source every `discover_interval`. When a new table appears, ingestr adds it to the managed publication, backfills its existing rows, creates the destination table on the fly, and continues streaming — the other tables are not interrupted, and no data is lost while the stream rebuilds (the replication slot retains WAL during the pause).
+
+With a user-managed publication (`publication=` supplied), ingestr never alters the publication: a new table is picked up after you run `ALTER PUBLICATION ... ADD TABLE` yourself (or immediately, if the publication was created `FOR ALL TABLES`).
+
+The backfill-plus-stream handoff is safe under the `merge` strategy: changes that fall in the overlap between the snapshot and the WAL stream are applied idempotently by primary key. Tables without a primary key (or replica identity) cannot be part of logical replication and are skipped with a warning.

--- a/pkg/source/postgres_cdc/commit_state.go
+++ b/pkg/source/postgres_cdc/commit_state.go
@@ -18,6 +18,16 @@ import (
 // spinning forever on a 100ms read timeout that masks the dead socket.
 const deadConnectionTimeout = 2 * time.Minute
 
+// silenceProbeAfter is how long the server may stay silent before the next
+// standby status update requests an explicit reply. The server only sends
+// keepalives on its own when the standby has been quiet for
+// wal_sender_timeout/2, and we send status every 10s — so a healthy connection
+// to a quiet database receives nothing at all, indefinitely. Probing
+// distinguishes quiet from dead: a live server answers immediately (resetting
+// the silence clock), so deadConnectionTimeout only fires on connections that
+// stay silent even when asked to reply.
+const silenceProbeAfter = 30 * time.Second
+
 // receiveTimeout bounds a single ReceiveMessage call. It governs how quickly the
 // loop reacts to context cancellation and flushes idle batches. It must not be
 // too small: churning the replication connection's read deadline every few

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -89,7 +89,7 @@ func (d *Decoder) Decode(data []byte, lsn pglogrepl.LSN) (arrow.RecordBatch, err
 	case msgTypeRelation:
 		return nil, d.handleRelation(data)
 	case msgTypeBegin:
-		return nil, d.handleBegin(data, lsn)
+		return nil, d.handleBegin(data)
 	case msgTypeCommit:
 		return d.handleCommit()
 	case msgTypeInsert:
@@ -187,9 +187,15 @@ func (d *Decoder) handleRelation(data []byte) error {
 	return nil
 }
 
-func (d *Decoder) handleBegin(data []byte, lsn pglogrepl.LSN) error {
+// handleBegin stamps the transaction with the commit ("final") LSN from the
+// Begin payload; see MultiTableDecoder.handleBegin for why the Begin record's
+// own WAL position must not be used.
+func (d *Decoder) handleBegin(data []byte) error {
 	d.pendingChanges = nil
-	d.currentTxLSN = lsn
+	if len(data) < 8 {
+		return fmt.Errorf("begin message too short")
+	}
+	d.currentTxLSN = pglogrepl.LSN(binary.BigEndian.Uint64(data[:8]))
 	return nil
 }
 

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -211,9 +211,10 @@ func TestDecoderBeginAndCommit(t *testing.T) {
 
 	decoder := NewDecoder(tableSchema, "public", "test_table")
 
-	// Begin a transaction
-	beginData := make([]byte, 8+8+4) // LSN + timestamp + xid
-	err := decoder.handleBegin(beginData, pglogrepl.LSN(100))
+	// Begin a transaction; the Begin payload carries the commit ("final") LSN.
+	beginData := make([]byte, 8+8+4) // final LSN + timestamp + xid
+	binary.BigEndian.PutUint64(beginData[:8], 100)
+	err := decoder.handleBegin(beginData)
 	require.NoError(t, err)
 	assert.Equal(t, pglogrepl.LSN(100), decoder.currentTxLSN)
 	assert.Nil(t, decoder.pendingChanges)

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -63,7 +63,7 @@ func (d *MultiTableDecoder) Decode(data []byte, lsn pglogrepl.LSN) ([]DecodedBat
 	case msgTypeRelation:
 		return nil, d.handleRelation(data)
 	case msgTypeBegin:
-		return nil, d.handleBegin(data, lsn)
+		return nil, d.handleBegin(data)
 	case msgTypeCommit:
 		return d.handleCommit()
 	case msgTypeInsert:
@@ -170,9 +170,22 @@ func (d *MultiTableDecoder) handleRelation(data []byte) error {
 	return nil
 }
 
-func (d *MultiTableDecoder) handleBegin(data []byte, lsn pglogrepl.LSN) error {
+// handleBegin stamps the transaction with the commit ("final") LSN carried in
+// the Begin payload, NOT the Begin record's WAL position. The walsender
+// delivers transactions in commit order, but under concurrent writers their
+// Begin positions interleave arbitrarily: a transaction that began earlier can
+// commit — and be delivered — after one that began later. A begin-position
+// stamp is therefore non-monotonic across delivered transactions, and the
+// per-table LSN filter (ShouldFilterChange) would treat such a late-committing
+// transaction as already processed and silently drop it. Commit LSNs are
+// strictly increasing in delivery order, which is exactly what the filter,
+// resume state, and slot-confirmation low-water logic require.
+func (d *MultiTableDecoder) handleBegin(data []byte) error {
 	d.pendingChanges = nil
-	d.currentTxLSN = lsn
+	if len(data) < 8 {
+		return fmt.Errorf("begin message too short")
+	}
+	d.currentTxLSN = pglogrepl.LSN(binary.BigEndian.Uint64(data[:8]))
 	return nil
 }
 

--- a/pkg/source/postgres_cdc/multitable_decoder_test.go
+++ b/pkg/source/postgres_cdc/multitable_decoder_test.go
@@ -1,6 +1,7 @@
 package postgres_cdc
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -71,4 +72,97 @@ func TestMultiTableDecoderChangesToBatchSequencesSyncedAt(t *testing.T) {
 	assert.Equal(t, "00000000/0000002A", batch.Column(2).(*array.String).Value(1))
 	assert.False(t, batch.Column(3).(*array.Boolean).Value(0))
 	assert.True(t, batch.Column(3).(*array.Boolean).Value(1))
+}
+
+// pgoutput message builders (payloads include the leading type byte, as fed to
+// Decode from XLogData).
+
+func pgoRelationMsg(relID uint32, namespace, table string) []byte {
+	data := []byte{'R'}
+	data = binary.BigEndian.AppendUint32(data, relID)
+	data = append(data, []byte(namespace+"\x00")...)
+	data = append(data, []byte(table+"\x00")...)
+	data = append(data, 'd')                      // replica identity
+	data = binary.BigEndian.AppendUint16(data, 1) // one column
+	data = append(data, 0x01)                     // flags: part of key
+	data = append(data, []byte("id\x00")...)
+	data = binary.BigEndian.AppendUint32(data, 23)         // int4 OID
+	data = binary.BigEndian.AppendUint32(data, 0xFFFFFFFF) // typemod -1
+	return data
+}
+
+func pgoBeginMsg(finalLSN uint64) []byte {
+	data := []byte{'B'}
+	data = binary.BigEndian.AppendUint64(data, finalLSN)
+	data = binary.BigEndian.AppendUint64(data, 0) // commit timestamp
+	data = binary.BigEndian.AppendUint32(data, 1) // xid
+	return data
+}
+
+func pgoInsertMsg(relID uint32, idText string) []byte {
+	data := []byte{'I'}
+	data = binary.BigEndian.AppendUint32(data, relID)
+	data = append(data, 'N')
+	data = binary.BigEndian.AppendUint16(data, 1) // one column
+	data = append(data, 't')
+	data = binary.BigEndian.AppendUint32(data, uint32(len(idText)))
+	data = append(data, []byte(idText)...)
+	return data
+}
+
+func pgoCommitMsg(commitLSN uint64) []byte {
+	data := []byte{'C', 0}
+	data = binary.BigEndian.AppendUint64(data, commitLSN)
+	data = binary.BigEndian.AppendUint64(data, commitLSN)
+	data = binary.BigEndian.AppendUint64(data, 0) // commit timestamp
+	return data
+}
+
+// Transactions are delivered in commit order, but their Begin records'
+// positions interleave under concurrent writers: a transaction that began
+// earlier can commit later. Batches must be stamped with the Begin payload's
+// final (commit) LSN — stamping the Begin record's WAL position makes the
+// delivered LSN sequence non-monotonic, and the per-table filter
+// (ShouldFilterChange keeps only changeLSN >= lastProcessed) would silently
+// drop the later transaction's data.
+func TestMultiTableDecoderStampsCommitLSN(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Name:   "t",
+		Schema: "public",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt32},
+			{Name: CDCLSNColumn, DataType: schema.TypeString},
+			{Name: CDCDeletedColumn, DataType: schema.TypeBoolean},
+			{Name: CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+			{Name: CDCUnchangedColsColumn, DataType: schema.TypeString},
+		},
+	}
+	d := NewMultiTableDecoder([]source.SourceTableInfo{{Name: "t", Schema: tableSchema}})
+
+	_, err := d.Decode(pgoRelationMsg(1, "public", "t"), 10)
+	require.NoError(t, err)
+
+	// Transaction B: began at WAL position 150, commits first at 300.
+	_, err = d.Decode(pgoBeginMsg(300), 150)
+	require.NoError(t, err)
+	_, err = d.Decode(pgoInsertMsg(1, "7"), 160)
+	require.NoError(t, err)
+	batches, err := d.Decode(pgoCommitMsg(300), 300)
+	require.NoError(t, err)
+	require.Len(t, batches, 1)
+	assert.Equal(t, pglogrepl.LSN(300), batches[0].LSN)
+	batches[0].Batch.Release()
+
+	// Transaction A: began EARLIER (WAL position 100) but commits later at 400.
+	// With begin-position stamping its LSN would be 100 < 300 and the filter
+	// would drop it as already processed.
+	_, err = d.Decode(pgoBeginMsg(400), 100)
+	require.NoError(t, err)
+	_, err = d.Decode(pgoInsertMsg(1, "8"), 110)
+	require.NoError(t, err)
+	batches, err = d.Decode(pgoCommitMsg(400), 400)
+	require.NoError(t, err)
+	require.Len(t, batches, 1)
+	assert.Equal(t, pglogrepl.LSN(400), batches[0].LSN)
+	batches[0].Batch.Release()
 }

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -3,6 +3,8 @@ package postgres_cdc
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,15 +26,7 @@ type MultiTableCDCReader struct {
 }
 
 func NewMultiTableCDCReader(src *PostgresCDCSource, tables []source.SourceTableInfo, cdcConfig CDCConfig, resumeLSNs map[string]string, slotSuffix string) *MultiTableCDCReader {
-	// Reconcile each table's effective merge keys into its schema so the decoder,
-	// compaction, and unchanged-TOAST fill all key off the same keys the
-	// destination merge uses. SourceTableInfo.PrimaryKeys is authoritative and
-	// may carry user-provided keys that the schema's detected keys lack.
-	for i := range tables {
-		if len(tables[i].PrimaryKeys) > 0 && tables[i].Schema != nil {
-			tables[i].Schema.PrimaryKeys = tables[i].PrimaryKeys
-		}
-	}
+	reconcileTableKeys(tables)
 	return &MultiTableCDCReader{
 		source:        src,
 		tables:        tables,
@@ -40,6 +34,18 @@ func NewMultiTableCDCReader(src *PostgresCDCSource, tables []source.SourceTableI
 		resumeLSNs:    resumeLSNs,
 		processedLSNs: make(map[string]pglogrepl.LSN),
 		slotSuffix:    slotSuffix,
+	}
+}
+
+// reconcileTableKeys folds each table's effective merge keys into its schema so
+// the decoder, compaction, and unchanged-TOAST fill all key off the same keys
+// the destination merge uses. SourceTableInfo.PrimaryKeys is authoritative and
+// may carry user-provided keys that the schema's detected keys lack.
+func reconcileTableKeys(tables []source.SourceTableInfo) {
+	for i := range tables {
+		if len(tables[i].PrimaryKeys) > 0 && tables[i].Schema != nil {
+			tables[i].Schema.PrimaryKeys = tables[i].PrimaryKeys
+		}
 	}
 }
 
@@ -85,17 +91,13 @@ func (r *MultiTableCDCReader) Read(ctx context.Context, opts source.MultiTableRe
 			}
 		}
 
+		var startLSN pglogrepl.LSN
 		if needsSnapshot {
 			config.Debug("[CDC] Multi-table: performing full snapshot (some tables have no existing data)")
 			if err := r.executeSnapshot(ctx, results, opts); err != nil {
 				results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)}
 				return
 			}
-		}
-
-		var startLSN pglogrepl.LSN
-		if needsSnapshot {
-			// After snapshot, we need to get the slot's current LSN
 			var err error
 			startLSN, err = r.getSlotLSN(ctx, slotName)
 			if err != nil {
@@ -104,6 +106,15 @@ func (r *MultiTableCDCReader) Read(ctx context.Context, opts source.MultiTableRe
 			}
 		} else {
 			startLSN = minResumeLSN
+			// Tables without resume state are not covered by the resumed stream:
+			// their pre-existing rows were never snapshotted (typically tables
+			// created since the previous run). Backfill them before streaming.
+			if newTables := r.tablesWithoutResumeState(); len(newTables) > 0 {
+				if err := r.backfillTables(ctx, slotName, newTables, results, opts); err != nil {
+					results <- source.RecordBatchResult{Err: fmt.Errorf("backfill failed: %w", err)}
+					return
+				}
+			}
 		}
 
 		// For batch mode, get the current WAL LSN as our target.
@@ -119,22 +130,210 @@ func (r *MultiTableCDCReader) Read(ctx context.Context, opts source.MultiTableRe
 			config.Debug("[CDC] Batch mode: will stream until LSN %s", targetLSN)
 		}
 
-		if err := r.streamChanges(ctx, startLSN, targetLSN, slotName, results, opts); err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("streaming failed: %w", err)}
-			return
+		for {
+			newTables, err := r.streamChanges(ctx, startLSN, targetLSN, slotName, results, opts)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: fmt.Errorf("streaming failed: %w", err)}
+				return
+			}
+			if len(newTables) == 0 {
+				return
+			}
+			startLSN, err = r.rebuildForNewTables(ctx, slotName, newTables, results, opts)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to add new tables to stream: %w", err)}
+				return
+			}
 		}
 	}()
 
 	return results, nil
 }
 
+// tablesWithoutResumeState returns tables that have neither a resume LSN nor an
+// in-memory processed LSN — on a resumed run, tables with no state in the
+// destination, typically created since the previous run. A table that was
+// merely empty at the original snapshot re-snapshots as empty, so backfilling
+// the whole set is idempotent.
+func (r *MultiTableCDCReader) tablesWithoutResumeState() []source.SourceTableInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []source.SourceTableInfo
+	for _, t := range r.tables {
+		if _, ok := r.resumeLSNs[t.Name]; ok {
+			continue
+		}
+		if _, ok := r.processedLSNs[t.Name]; ok {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// backfillTables snapshots tables that joined the stream after the main slot
+// was created. A temporary replication slot on a dedicated connection provides
+// the consistent point and an exported snapshot: rows existing before that
+// point are read here, and the main stream delivers changes at or after it
+// (ShouldFilterChange drops the already-snapshotted overlap; the boundary
+// transaction is re-emitted and absorbed by the idempotent merge). The
+// temporary slot vanishes when the connection closes. Backfill batches carry
+// no commit tokens — the temporary slot's consistent point is ahead of the
+// main slot, so confirming it would skip WAL not yet streamed.
+func (r *MultiTableCDCReader) backfillTables(ctx context.Context, slotName string, tables []source.SourceTableInfo, results chan<- source.RecordBatchResult, opts source.MultiTableReadOptions) error {
+	conn, err := r.source.openReplicationConn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	tempSlot := backfillSlotName(slotName)
+	created, err := pglogrepl.CreateReplicationSlot(
+		ctx,
+		conn,
+		tempSlot,
+		"pgoutput",
+		pglogrepl.CreateReplicationSlotOptions{
+			Temporary:      true,
+			SnapshotAction: "EXPORT_SNAPSHOT",
+			Mode:           pglogrepl.LogicalReplication,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create backfill slot: %w", err)
+	}
+
+	snapshotLSN, err := pglogrepl.ParseLSN(created.ConsistentPoint)
+	if err != nil {
+		return fmt.Errorf("failed to parse backfill LSN: %w", err)
+	}
+
+	config.Debug("[CDC] Backfill slot %s created at LSN %s (snapshot %s) for %d table(s)",
+		tempSlot, created.ConsistentPoint, created.SnapshotName, len(tables))
+
+	for i := range tables {
+		table := tables[i]
+		fmt.Printf("Backfilling new table %s before streaming its changes\n", table.Name)
+		if opts.Streaming {
+			// Announce the table so a consumer that prepared its per-table state
+			// upfront can provision the destination before data arrives.
+			results <- source.RecordBatchResult{TableName: table.Name, TableInfo: &tables[i]}
+		}
+		if err := r.snapshotTable(ctx, table, created.SnapshotName, snapshotLSN, true, results, opts); err != nil {
+			return fmt.Errorf("failed to backfill table %s: %w", table.Name, err)
+		}
+		r.updateProcessedLSN(table.Name, snapshotLSN)
+	}
+	return nil
+}
+
+// backfillSlotName derives a temporary-slot name that cannot collide with the
+// main slot even after truncation to Postgres's 63-character limit.
+func backfillSlotName(slotName string) string {
+	const suffix = "_bf"
+	if len(slotName) > 63-len(suffix) {
+		slotName = slotName[:63-len(suffix)]
+	}
+	return slotName + suffix
+}
+
+// rebuildForNewTables incorporates tables that appeared mid-stream: reconcile
+// the managed publication so Postgres starts publishing them, refresh the
+// table set, backfill the newcomers, and reopen the replication connection for
+// a fresh StartReplication on the same persistent slot. Returns the LSN to
+// resume streaming from — the slot's confirmed position; transactions above it
+// that were already emitted are filtered per table by ShouldFilterChange.
+func (r *MultiTableCDCReader) rebuildForNewTables(ctx context.Context, slotName string, newNames []string, results chan<- source.RecordBatchResult, opts source.MultiTableReadOptions) (pglogrepl.LSN, error) {
+	fmt.Printf("New table(s) detected on source: %s; adding to CDC stream\n", strings.Join(newNames, ", "))
+
+	if err := r.source.reconcilePublication(ctx); err != nil {
+		return 0, fmt.Errorf("failed to reconcile publication: %w", err)
+	}
+
+	tables, err := r.source.GetTables(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to refresh table list: %w", err)
+	}
+	reconcileTableKeys(tables)
+
+	known := make(map[string]struct{}, len(r.tables))
+	for _, t := range r.tables {
+		known[t.Name] = struct{}{}
+	}
+	var added []source.SourceTableInfo
+	for _, t := range tables {
+		if _, ok := known[t.Name]; !ok {
+			added = append(added, t)
+		}
+	}
+	r.tables = tables
+
+	if len(added) > 0 {
+		if err := r.backfillTables(ctx, slotName, added, results, opts); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := r.source.reconnectReplication(ctx); err != nil {
+		return 0, err
+	}
+	r.waitSlotReleased(ctx, slotName)
+	return r.getSlotLSN(ctx, slotName)
+}
+
+// waitSlotReleased waits for the server to mark the slot inactive after the
+// previous replication connection was closed; claiming a still-active slot
+// makes StartReplication fail. Best-effort with a bounded wait — if the slot
+// stays active the subsequent StartReplication surfaces the real error.
+func (r *MultiTableCDCReader) waitSlotReleased(ctx context.Context, slotName string) {
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var active bool
+		err := r.source.queryPool.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name = $1", slotName).Scan(&active)
+		if err != nil || !active {
+			return
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// detectNewTables lists the tables the stream should currently cover and
+// returns those missing from the active table set.
+func (r *MultiTableCDCReader) detectNewTables(ctx context.Context) ([]string, error) {
+	eligible, err := r.source.listEligibleTableNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return diffNewTables(r.tables, eligible), nil
+}
+
+// diffNewTables returns the names in eligible that are missing from current,
+// sorted for deterministic output.
+func diffNewTables(current []source.SourceTableInfo, eligible map[string]struct{}) []string {
+	known := make(map[string]struct{}, len(current))
+	for _, t := range current {
+		known[t.Name] = struct{}{}
+	}
+	var out []string
+	for name := range eligible {
+		if _, ok := known[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // determineResumeStrategy determines if we need a full snapshot or can resume.
 // Returns (needsSnapshot, minLSN).
 //
 // Only requires that at least one table has a resume LSN. Tables missing from
-// the resume map (e.g. empty tables that produced no data during snapshot) will
-// accept all WAL changes via ShouldFilterChange, which returns false for
-// unknown tables.
+// the resume map (created since the previous run, or empty ever since the
+// original snapshot) are backfilled via a temporary-slot snapshot before
+// streaming starts; see tablesWithoutResumeState.
 func (r *MultiTableCDCReader) determineResumeStrategy() (bool, pglogrepl.LSN) {
 	if len(r.resumeLSNs) == 0 {
 		return true, 0 // No resume LSNs = full snapshot
@@ -161,12 +360,9 @@ func (r *MultiTableCDCReader) determineResumeStrategy() (bool, pglogrepl.LSN) {
 		r.processedLSNs[tableName] = lsn
 	}
 
-	// Log tables without resume LSNs. These were likely empty during the
-	// previous snapshot. ShouldFilterChange returns false for tables not in
-	// processedLSNs, so all WAL changes for them will be accepted.
 	for _, table := range r.tables {
 		if _, ok := r.resumeLSNs[table.Name]; !ok {
-			config.Debug("[CDC] Table %s has no resume LSN (empty in destination), will accept all WAL changes", table.Name)
+			config.Debug("[CDC] Table %s has no resume LSN (no destination state), will backfill before streaming", table.Name)
 		}
 	}
 
@@ -222,7 +418,7 @@ func (r *MultiTableCDCReader) executeSnapshot(ctx context.Context, results chan<
 	// Snapshot each table using the exported snapshot
 	for _, table := range r.tables {
 		config.Debug("[CDC] Snapshotting table: %s", table.Name)
-		if err := r.snapshotTable(ctx, table, result.SnapshotName, snapshotLSN, results, opts); err != nil {
+		if err := r.snapshotTable(ctx, table, result.SnapshotName, snapshotLSN, false, results, opts); err != nil {
 			return fmt.Errorf("failed to snapshot table %s: %w", table.Name, err)
 		}
 		// Initialize processed LSN for this table
@@ -233,12 +429,13 @@ func (r *MultiTableCDCReader) executeSnapshot(ctx context.Context, results chan<
 }
 
 // snapshotTable reads all data from a single table using the snapshot.
-func (r *MultiTableCDCReader) snapshotTable(ctx context.Context, table source.SourceTableInfo, snapshotName string, lsn pglogrepl.LSN, results chan<- source.RecordBatchResult, opts source.MultiTableReadOptions) error {
+func (r *MultiTableCDCReader) snapshotTable(ctx context.Context, table source.SourceTableInfo, snapshotName string, lsn pglogrepl.LSN, noCommitToken bool, results chan<- source.RecordBatchResult, opts source.MultiTableReadOptions) error {
 	snapshot := &Snapshot{
-		source:      r.source,
-		tableName:   table.Name,
-		tableSchema: table.Schema,
-		cdcConfig:   r.cdcConfig,
+		source:        r.source,
+		tableName:     table.Name,
+		tableSchema:   table.Schema,
+		cdcConfig:     r.cdcConfig,
+		noCommitToken: noCommitToken,
 	}
 
 	// Create a wrapper channel that adds TableName to results
@@ -268,7 +465,12 @@ func (r *MultiTableCDCReader) snapshotTable(ctx context.Context, table source.So
 // Small WAL transactions (single-row changes) are accumulated per-table and
 // flushed as larger batches to avoid overwhelming the destination with
 // single-row writes.
-func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, targetLSN pglogrepl.LSN, slotName string, results chan<- source.RecordBatchResult, opts source.MultiTableReadOptions) error {
+//
+// In streaming mode it periodically re-checks the source for tables the stream
+// should cover but doesn't. When new tables appear it flushes what it has and
+// returns their names so the caller can rebuild the stream around the enlarged
+// table set; a nil slice means normal termination.
+func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogrepl.LSN, targetLSN pglogrepl.LSN, slotName string, results chan<- source.RecordBatchResult, opts source.MultiTableReadOptions) ([]string, error) {
 	config.Debug("[CDC] Multi-table streaming from LSN: %s", startLSN)
 
 	cdcConfigWithSlot := r.cdcConfig
@@ -277,7 +479,7 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 	// Create multi-table replicator
 	repl, err := NewMultiTableReplicator(r.source, r.tables, cdcConfigWithSlot, startLSN, r, opts.Streaming)
 	if err != nil {
-		return fmt.Errorf("failed to create replicator: %w", err)
+		return nil, fmt.Errorf("failed to create replicator: %w", err)
 	}
 	defer func() { _ = repl.Close(ctx) }()
 
@@ -312,20 +514,44 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 	// actually advanced (instead of every 100ms idle tick).
 	var lastIdleToken pglogrepl.LSN
 
+	// New-table discovery runs on a timer in streaming mode only: a batch run
+	// picks up new tables at its next start, where Connect has already
+	// reconciled the publication.
+	discover := opts.Streaming && r.cdcConfig.DiscoverInterval > 0
+	lastDiscover := time.Now()
+
 	for {
 		select {
 		case <-ctx.Done():
 			config.Debug("[CDC] Context cancelled, stopping stream")
 			accum.flushAll(results, token)
-			return ctx.Err()
+			return nil, ctx.Err()
 		default:
+		}
+
+		if discover && time.Since(lastDiscover) >= r.cdcConfig.DiscoverInterval {
+			lastDiscover = time.Now()
+			newNames, derr := r.detectNewTables(ctx)
+			switch {
+			case derr != nil:
+				// Discovery is best-effort; a transient catalog query failure
+				// must not kill the stream.
+				config.Debug("[CDC] New-table discovery failed: %v", derr)
+			case len(newNames) > 0:
+				// Flush emitted work, drop batches still buffered inside the
+				// replicator (the slot cannot have confirmed past them, so the
+				// rebuilt stream re-decodes them), and hand off for a rebuild.
+				accum.flushAll(results, token)
+				repl.releasePending()
+				return newNames, nil
+			}
 		}
 
 		// Get next batch (may be from any table)
 		batch, tableName, lsn, hadActivity, err := repl.NextBatch(ctx, batchSize)
 		if err != nil {
 			accum.flushAll(results, token)
-			return fmt.Errorf("failed to get next batch: %w", err)
+			return nil, fmt.Errorf("failed to get next batch: %w", err)
 		}
 
 		if batch != nil && batch.NumRows() > 0 {
@@ -348,7 +574,7 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 				// results channel. FinalizeBatch will stop it before sending
 				// the final WALFlush-bearing standby update.
 				r.source.startKeepalive(ctx, currentLSN)
-				return nil
+				return nil, nil
 			}
 		}
 

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -171,10 +171,12 @@ func (r *MultiTableReplicator) NextBatch(ctx context.Context, batchSize int) (ar
 	// Send standby status periodically. A send failure means the replication
 	// connection is broken, so surface it rather than spinning on dead reads.
 	if time.Since(r.standbyTimer) > 10*time.Second {
+		status := r.standbyStatus()
+		status.ReplyRequested = time.Since(r.lastMessageAt) > silenceProbeAfter
 		err := pglogrepl.SendStandbyStatusUpdate(
 			ctx,
 			r.source.replConn,
-			r.standbyStatus(),
+			status,
 		)
 		if err != nil {
 			return nil, "", 0, false, fmt.Errorf("failed to send standby status (replication connection lost): %w", err)

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -126,6 +126,19 @@ func (r *MultiTableReplicator) Close(ctx context.Context) error {
 	return nil
 }
 
+// releasePending drops batches decoded but not yet emitted. Used when a
+// streaming rebuild abandons this replicator: the slot's confirmed position is
+// below these transactions (commit tokens never advance past pending data), so
+// the restarted stream re-decodes them.
+func (r *MultiTableReplicator) releasePending() {
+	for _, b := range r.pendingBatches {
+		if b.Batch != nil {
+			b.Batch.Release()
+		}
+	}
+	r.pendingBatches = nil
+}
+
 func (r *MultiTableReplicator) CurrentLSN() pglogrepl.LSN {
 	return r.clientXLogPos
 }

--- a/pkg/source/postgres_cdc/new_table_test.go
+++ b/pkg/source/postgres_cdc/new_table_test.go
@@ -1,0 +1,134 @@
+package postgres_cdc
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURIConfigDiscoverInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name: "default when absent",
+			uri:  "postgres+cdc://user:pass@localhost:5432/mydb",
+			want: defaultDiscoverInterval,
+		},
+		{
+			name: "explicit duration",
+			uri:  "postgres+cdc://user:pass@localhost:5432/mydb?discover_interval=5s",
+			want: 5 * time.Second,
+		},
+		{
+			name: "disabled with zero",
+			uri:  "postgres+cdc://user:pass@localhost:5432/mydb?discover_interval=0",
+			want: 0,
+		},
+		{
+			name: "disabled with off",
+			uri:  "postgres+cdc://user:pass@localhost:5432/mydb?discover_interval=off",
+			want: 0,
+		},
+		{
+			name:    "invalid duration",
+			uri:     "postgres+cdc://user:pass@localhost:5432/mydb?discover_interval=bogus",
+			wantErr: true,
+		},
+		{
+			name:    "negative duration",
+			uri:     "postgres+cdc://user:pass@localhost:5432/mydb?discover_interval=-5s",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, normalizedURI, err := parseURIConfig(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.DiscoverInterval)
+			assert.NotContains(t, normalizedURI, "discover_interval=")
+		})
+	}
+}
+
+func TestBackfillSlotName(t *testing.T) {
+	assert.Equal(t, "ingestr_mt_pub_bf", backfillSlotName("ingestr_mt_pub"))
+
+	long := strings.Repeat("x", 70)
+	got := backfillSlotName(long)
+	assert.LessOrEqual(t, len(got), 63)
+	assert.True(t, strings.HasSuffix(got, "_bf"))
+
+	// A main slot name already at the 63-char limit must still produce a
+	// distinct backfill name.
+	atLimit := strings.Repeat("y", 63)
+	assert.NotEqual(t, atLimit, backfillSlotName(atLimit))
+}
+
+func TestPublicationTableFullName(t *testing.T) {
+	assert.Equal(t, "users", publicationTableFullName("public", "users"))
+	assert.Equal(t, "app.orders", publicationTableFullName("app", "orders"))
+}
+
+func TestDiffNewTables(t *testing.T) {
+	current := []source.SourceTableInfo{
+		{Name: "users"},
+		{Name: "app.orders"},
+	}
+
+	assert.Empty(t, diffNewTables(current, map[string]struct{}{
+		"users":      {},
+		"app.orders": {},
+	}))
+
+	got := diffNewTables(current, map[string]struct{}{
+		"users":      {},
+		"app.orders": {},
+		"products":   {},
+		"app.events": {},
+	})
+	assert.Equal(t, []string{"app.events", "products"}, got)
+
+	// Tables that disappeared from the source are not reported.
+	assert.Empty(t, diffNewTables(current, map[string]struct{}{"users": {}}))
+}
+
+func TestTablesWithoutResumeState(t *testing.T) {
+	tables := []source.SourceTableInfo{
+		{Name: "users"},
+		{Name: "orders"},
+		{Name: "products"},
+	}
+
+	r := NewMultiTableCDCReader(nil, tables, CDCConfig{}, map[string]string{
+		"users": "00000000/000000A0",
+	}, "")
+
+	// orders and products lack resume LSNs and processed LSNs → backfill.
+	got := r.tablesWithoutResumeState()
+	names := make([]string, len(got))
+	for i, tbl := range got {
+		names[i] = tbl.Name
+	}
+	assert.Equal(t, []string{"orders", "products"}, names)
+
+	// A table with an in-memory processed LSN (e.g. just backfilled) is not
+	// backfilled again.
+	r.updateProcessedLSN("orders", pglogrepl.LSN(100))
+	got = r.tablesWithoutResumeState()
+	require.Len(t, got, 1)
+	assert.Equal(t, "products", got[0].Name)
+}

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -120,10 +120,12 @@ func (r *Replicator) NextBatch(ctx context.Context, batchSize int) (arrow.Record
 	// Send standby status periodically. A send failure means the replication
 	// connection is broken, so surface it rather than spinning on dead reads.
 	if time.Since(r.standbyTimer) > 10*time.Second {
+		status := r.standbyStatus()
+		status.ReplyRequested = time.Since(r.lastMessageAt) > silenceProbeAfter
 		err := pglogrepl.SendStandbyStatusUpdate(
 			ctx,
 			r.source.replConn,
-			r.standbyStatus(),
+			status,
 		)
 		if err != nil {
 			return nil, 0, false, fmt.Errorf("failed to send standby status (replication connection lost): %w", err)

--- a/pkg/source/postgres_cdc/snapshot.go
+++ b/pkg/source/postgres_cdc/snapshot.go
@@ -26,6 +26,12 @@ type Snapshot struct {
 	tableSchema *schema.TableSchema
 	cdcConfig   CDCConfig
 	slotName    string
+
+	// noCommitToken suppresses CommitTokens on emitted batches. Backfill
+	// snapshots read via a temporary slot must set it: their consistent point is
+	// ahead of the main slot's position, so confirming it on the main slot would
+	// skip WAL that has not been streamed yet.
+	noCommitToken bool
 }
 
 func NewSnapshot(src *PostgresCDCSource, tableName string, tableSchema *schema.TableSchema, cdcConfig CDCConfig, slotSuffix string) (*Snapshot, error) {
@@ -189,10 +195,11 @@ func (s *Snapshot) readWithSnapshot(ctx context.Context, snapshotName string, ls
 	syncedAt := time.Now().UTC()
 
 	// In streaming mode, snapshot batches carry the snapshot's consistent-point
-	// LSN as a commit token. It is always safe to confirm: streaming begins from
-	// this LSN, so nothing earlier remains to be read.
+	// LSN as a commit token. It is always safe to confirm when the snapshot was
+	// taken on the main slot: streaming begins from this LSN, so nothing earlier
+	// remains to be read. Backfill snapshots (temporary slot) suppress it.
 	var commitToken any
-	if opts.Streaming {
+	if opts.Streaming && !s.noCommitToken {
 		commitToken = lsn
 	}
 

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -36,19 +36,33 @@ const (
 // URI does not specify one.
 const defaultPublicationName = "ingestr_publication"
 
+// defaultDiscoverInterval is how often a streaming run re-checks the source for
+// tables that appeared after the stream started.
+const defaultDiscoverInterval = 30 * time.Second
+
 type CDCConfig struct {
 	Publication   string
 	SlotName      string
 	Mode          CDCMode
 	ResumeFromLSN string // If set, skip snapshot and resume streaming from this LSN
 	DestSchema    string // If set, prepend this schema to destination table names (e.g. "dataset" for BigQuery)
+
+	// DiscoverInterval is how often streaming mode checks for new tables on the
+	// source. Zero disables mid-stream discovery.
+	DiscoverInterval time.Duration
 }
 
 type PostgresCDCSource struct {
 	queryPool *pgxpool.Pool  // Regular connection pool for queries
 	replConn  *pgconn.PgConn // Replication connection
 	uri       string
-	cdcConfig CDCConfig
+	// normalizedURI is the URI with the +cdc scheme suffix and CDC-specific query
+	// params stripped; extra replication connections are derived from it.
+	normalizedURI string
+	// managedPublication is true when ingestr owns the publication (none was
+	// supplied in the URI) and may reconcile its table set.
+	managedPublication bool
+	cdcConfig          CDCConfig
 	// pos holds the LSN the pipeline has confirmed durable in streaming mode.
 	// It is shared between the pipeline goroutine (CommitStream) and the
 	// replication goroutine (standby status updates).
@@ -103,7 +117,8 @@ func (s *PostgresCDCSource) Connect(ctx context.Context, uri string) error {
 	// When no publication is specified in the URI, ingestr manages a default
 	// publication. Reconcile it on every run so it tracks the current set of
 	// logged tables; unlogged tables cannot be replicated and are skipped.
-	if cdcConfig.Publication == "" {
+	managedPublication := cdcConfig.Publication == ""
+	if managedPublication {
 		cdcConfig.Publication = defaultPublicationName
 		if err := ensureManagedPublication(ctx, queryPool, cdcConfig.Publication); err != nil {
 			queryPool.Close()
@@ -122,8 +137,37 @@ func (s *PostgresCDCSource) Connect(ctx context.Context, uri string) error {
 	s.queryPool = queryPool
 	s.replConn = replConn
 	s.uri = uri
+	s.normalizedURI = normalizedURI
+	s.managedPublication = managedPublication
 	s.cdcConfig = cdcConfig
 
+	return nil
+}
+
+// openReplicationConn opens an additional replication connection, e.g. for a
+// temporary snapshot slot that must not disturb the main replication stream.
+func (s *PostgresCDCSource) openReplicationConn(ctx context.Context) (*pgconn.PgConn, error) {
+	conn, err := pgconn.Connect(ctx, buildReplicationConnString(s.normalizedURI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open replication connection: %w", err)
+	}
+	return conn, nil
+}
+
+// reconnectReplication replaces the main replication connection with a fresh
+// one. Needed after a streaming rebuild: once StartReplication has put a
+// connection into CopyBoth mode there is no clean way back, so a new
+// StartReplication requires a new connection. The persistent slot is untouched.
+func (s *PostgresCDCSource) reconnectReplication(ctx context.Context) error {
+	if s.replConn != nil {
+		_ = s.replConn.Close(ctx)
+		s.replConn = nil
+	}
+	conn, err := s.openReplicationConn(ctx)
+	if err != nil {
+		return err
+	}
+	s.replConn = conn
 	return nil
 }
 
@@ -353,11 +397,26 @@ func parseURIConfig(uri string) (CDCConfig, string, error) {
 		}
 	}
 
+	cfg.DiscoverInterval = defaultDiscoverInterval
+	if raw := query.Get("discover_interval"); raw != "" {
+		switch raw {
+		case "0", "off":
+			cfg.DiscoverInterval = 0
+		default:
+			d, err := time.ParseDuration(raw)
+			if err != nil || d < 0 {
+				return cfg, "", fmt.Errorf("invalid discover_interval: %s (must be a duration like '30s', or '0'/'off' to disable)", raw)
+			}
+			cfg.DiscoverInterval = d
+		}
+	}
+
 	// Remove CDC-specific params from connection string
 	query.Del("publication")
 	query.Del("slot")
 	query.Del("mode")
 	query.Del("dest_schema")
+	query.Del("discover_interval")
 	parsed.RawQuery = query.Encode()
 
 	return cfg, parsed.String(), nil
@@ -623,10 +682,7 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 
-		fullName := tableName
-		if schemaName != "public" {
-			fullName = schemaName + "." + tableName
-		}
+		fullName := publicationTableFullName(schemaName, tableName)
 
 		// Get schema for this table
 		tableSchema, err := getTableSchema(ctx, s.queryPool, fullName)
@@ -658,6 +714,86 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 
 	config.Debug("[CDC] Found %d tables in publication %s", len(tables), s.cdcConfig.Publication)
 	return tables, nil
+}
+
+// publicationTableFullName renders a table name the way GetTables and the WAL
+// decoder key tables: bare name for public, schema-qualified otherwise.
+func publicationTableFullName(schemaName, tableName string) string {
+	if schemaName == "public" {
+		return tableName
+	}
+	return schemaName + "." + tableName
+}
+
+// listEligibleTableNames returns the names of the tables the CDC stream should
+// currently cover, without fetching schemas. For the ingestr-managed
+// publication this is the set of publishable tables (the publication is
+// reconciled to it); for a user-supplied publication it is the publication's
+// membership (or all eligible tables for FOR ALL TABLES publications).
+func (s *PostgresCDCSource) listEligibleTableNames(ctx context.Context) (map[string]struct{}, error) {
+	names := make(map[string]struct{})
+
+	if s.managedPublication {
+		included, _, err := selectPublishableTables(ctx, s.queryPool)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range included {
+			names[publicationTableFullName(t.schema, t.name)] = struct{}{}
+		}
+		return names, nil
+	}
+
+	var pubAllTables bool
+	err := s.queryPool.QueryRow(ctx, "SELECT puballtables FROM pg_publication WHERE pubname = $1", s.cdcConfig.Publication).Scan(&pubAllTables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check publication type: %w", err)
+	}
+
+	var rows pgx.Rows
+	if pubAllTables {
+		rows, err = s.queryPool.Query(ctx, `
+			SELECT n.nspname, c.relname
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.relkind = 'r'
+			  AND c.relpersistence = 'p'
+			  AND `+replicaIdentityClause+`
+			  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		`)
+	} else {
+		rows, err = s.queryPool.Query(ctx, `
+			SELECT schemaname, tablename
+			FROM pg_publication_tables
+			WHERE pubname = $1
+		`, s.cdcConfig.Publication)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list publication tables: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaName, tableName string
+		if err := rows.Scan(&schemaName, &tableName); err != nil {
+			return nil, fmt.Errorf("failed to scan table name: %w", err)
+		}
+		names[publicationTableFullName(schemaName, tableName)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating table names: %w", err)
+	}
+	return names, nil
+}
+
+// reconcilePublication refreshes the managed publication's table set so tables
+// created after the stream started become part of it. No-op for user-supplied
+// publications, whose membership the user controls.
+func (s *PostgresCDCSource) reconcilePublication(ctx context.Context) error {
+	if !s.managedPublication {
+		return nil
+	}
+	return ensureManagedPublication(ctx, s.queryPool, s.cdcConfig.Publication)
 }
 
 // ReadAll reads CDC changes from all tables in the publication.

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -36,6 +36,12 @@ type RecordBatchResult struct {
 	// Committing a token via StreamCommitter acknowledges everything emitted up
 	// to and including the batch that carried it. Nil means no feedback needed.
 	CommitToken any
+
+	// TableInfo announces a table that appeared after the read started (e.g. a
+	// table created on the source mid-stream). Consumers that prepared their
+	// per-table state upfront use it to provision the destination before any
+	// batches for the table arrive. Batch may be nil on an announcement.
+	TableInfo *SourceTableInfo
 }
 
 // TableRequest contains user-provided configuration for table instantiation.

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -159,8 +159,62 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	}
 
 	loop := newFlushLoop(job.Destination, job.Config, e.opts, tables)
+	// CDC sources can discover tables created on the source mid-stream; they
+	// announce each one (with schema) before emitting its batches so the
+	// destination can be provisioned on the fly.
+	loop.prepareNewTable = func(ctx context.Context, ti source.SourceTableInfo) (*streamTableState, error) {
+		if !job.Config.NoLoadTimestamp {
+			ti.Schema = withLoadTimestampColumn(ti.Schema)
+		}
+		st := &streamTableState{
+			destTable:      multiTableDestName(job.Destination, ti),
+			schema:         ti.Schema,
+			primaryKeys:    ti.PrimaryKeys,
+			incrementalKey: ti.Schema.IncrementalKey,
+			isCDC:          hasCDCColumns(ti.Schema),
+		}
+		if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
+			return nil, err
+		}
+		if job.TableDestNames == nil {
+			job.TableDestNames = make(map[string]string)
+		}
+		job.TableDestNames[ti.Name] = st.destTable
+		return st, nil
+	}
 	defer loop.cleanup(ctx)
 	return loop.run(ctx, records)
+}
+
+// multiTableDestName computes the destination table name for a source table
+// discovered mid-stream, matching the pipeline's upfront naming.
+func multiTableDestName(dest destination.Destination, ti source.SourceTableInfo) string {
+	if namer, ok := dest.(destination.MultiTableNamer); ok {
+		return namer.DestTableName(ti.DestSchema, ti.Name)
+	}
+	return destination.DefaultMultiTableName(ti.DestSchema, ti.Name)
+}
+
+// withLoadTimestampColumn mirrors the pipeline's schema decoration for tables
+// discovered mid-stream: startup tables get _ingestr_loaded_at added by the
+// pipeline before the executor sees them, so late arrivals must match or their
+// destination tables would be created without the column the flush fills.
+func withLoadTimestampColumn(s *schema.TableSchema) *schema.TableSchema {
+	if s == nil {
+		return nil
+	}
+	for _, col := range s.Columns {
+		if strings.EqualFold(col.Name, naming.IngestrLoadedAtColumn) {
+			return s
+		}
+	}
+	out := *s
+	out.Columns = append(append([]schema.Column{}, s.Columns...), schema.Column{
+		Name:     naming.IngestrLoadedAtColumn,
+		DataType: schema.TypeTimestampTZ,
+		Nullable: true,
+	})
+	return &out
 }
 
 // prepareTable sets up the destination (and staging, for merge) tables for one
@@ -223,6 +277,11 @@ type flushLoop struct {
 	opts   StreamingOptions
 	tables map[string]*streamTableState // key = RecordBatchResult.TableName ("" for single-table)
 
+	// prepareNewTable provisions state for a table announced by the source
+	// after the stream started (RecordBatchResult.TableInfo). Nil means dynamic
+	// tables are unsupported and announcements are ignored.
+	prepareNewTable func(ctx context.Context, ti source.SourceTableInfo) (*streamTableState, error)
+
 	buffered int64 // rows buffered across all tables
 
 	// lastToken is the newest CommitToken seen; tokenDirty marks that it has
@@ -263,6 +322,11 @@ func (l *flushLoop) run(ctx context.Context, records <-chan source.RecordBatchRe
 				}
 				return fmt.Errorf("source error: %w", res.Err)
 			}
+			if res.TableInfo != nil {
+				if err := l.ensureTable(ctx, *res.TableInfo); err != nil {
+					return err
+				}
+			}
 			l.buffer(res)
 			if l.buffered >= l.opts.FlushRecords {
 				if err := l.flush(ctx); err != nil {
@@ -283,6 +347,26 @@ func (l *flushLoop) run(ctx context.Context, records <-chan source.RecordBatchRe
 			return l.shutdown(ctx, records)
 		}
 	}
+}
+
+// ensureTable provisions per-table state for a table announced mid-stream.
+// Announcements for tables already known (e.g. re-sent by a source-side
+// rebuild) are ignored.
+func (l *flushLoop) ensureTable(ctx context.Context, ti source.SourceTableInfo) error {
+	if _, ok := l.tables[ti.Name]; ok {
+		return nil
+	}
+	if l.prepareNewTable == nil {
+		config.Debug("[STREAM] Ignoring new-table announcement for %q (dynamic tables unsupported here)", ti.Name)
+		return nil
+	}
+	st, err := l.prepareNewTable(ctx, ti)
+	if err != nil {
+		return fmt.Errorf("failed to prepare newly discovered table %s: %w", ti.Name, err)
+	}
+	l.tables[ti.Name] = st
+	output.Statusf("[STREAM] %s | New table %s added to stream (dest: %s)\n", time.Now().Format("15:04:05"), ti.Name, st.destTable)
+	return nil
 }
 
 func (l *flushLoop) buffer(res source.RecordBatchResult) {

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -166,6 +166,9 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		if !job.Config.NoLoadTimestamp {
 			ti.Schema = withLoadTimestampColumn(ti.Schema)
 		}
+		if ti.Schema == nil {
+			return nil, fmt.Errorf("newly discovered table %s has no schema", ti.Name)
+		}
 		st := &streamTableState{
 			destTable:      multiTableDestName(job.Destination, ti),
 			schema:         ti.Schema,

--- a/pkg/strategy/streaming_newtable_test.go
+++ b/pkg/strategy/streaming_newtable_test.go
@@ -22,6 +22,33 @@ func newTableInfo(name string) source.SourceTableInfo {
 	}
 }
 
+type announcingMultiTableSource struct {
+	tables  []source.SourceTableInfo
+	records <-chan source.RecordBatchResult
+}
+
+func (s *announcingMultiTableSource) Schemes() []string { return nil }
+
+func (s *announcingMultiTableSource) Connect(ctx context.Context, uri string) error { return nil }
+
+func (s *announcingMultiTableSource) Close(ctx context.Context) error { return nil }
+
+func (s *announcingMultiTableSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *announcingMultiTableSource) HandlesIncrementality() bool { return false }
+
+func (s *announcingMultiTableSource) IsMultiTable() bool { return true }
+
+func (s *announcingMultiTableSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
+	return s.tables, nil
+}
+
+func (s *announcingMultiTableSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	return s.records, nil
+}
+
 func TestStreaming_NewTableAnnouncementPreparesAndRoutes(t *testing.T) {
 	dest := &fakeDestination{}
 	loop := newTestLoop(dest, StreamingOptions{
@@ -115,6 +142,35 @@ func TestStreaming_NewTablePrepareFailureAborts(t *testing.T) {
 	err := loop.run(context.Background(), records)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "public.products")
+}
+
+func TestStreaming_NewTableAnnouncementWithoutSchemaReturnsError(t *testing.T) {
+	records := make(chan source.RecordBatchResult, 1)
+	info := source.SourceTableInfo{Name: "public.products"}
+	records <- source.RecordBatchResult{TableName: "public.products", TableInfo: &info}
+	close(records)
+
+	src := &announcingMultiTableSource{
+		tables:  []source.SourceTableInfo{newTableInfo("public.users")},
+		records: records,
+	}
+	exec := NewStreamingExecutor(StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	})
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{FlushInterval: time.Hour, FlushRecords: 1},
+		Source:         src,
+		Destination:    &fakeDestination{},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{"public.users": "users"},
+	}
+
+	err := exec.ExecuteMultiTable(context.Background(), job)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "public.products")
+	assert.Contains(t, err.Error(), "no schema")
 }
 
 func TestWithLoadTimestampColumn(t *testing.T) {

--- a/pkg/strategy/streaming_newtable_test.go
+++ b/pkg/strategy/streaming_newtable_test.go
@@ -1,0 +1,138 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/naming"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTableInfo(name string) source.SourceTableInfo {
+	return source.SourceTableInfo{
+		Name:        name,
+		Schema:      streamTestSchema(),
+		PrimaryKeys: []string{"id"},
+	}
+}
+
+func TestStreaming_NewTableAnnouncementPreparesAndRoutes(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.users": mergeTableState("ds.users")})
+
+	var prepared []string
+	loop.prepareNewTable = func(_ context.Context, ti source.SourceTableInfo) (*streamTableState, error) {
+		prepared = append(prepared, ti.Name)
+		return mergeTableState("ds.products"), nil
+	}
+
+	info := newTableInfo("public.products")
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.products", TableInfo: &info}
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil), TableName: "public.products"}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+
+	assert.Equal(t, []string{"public.products"}, prepared)
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.writeCalls, 1)
+	assert.Equal(t, "ds.products_staging", dest.writeCalls[0].Table)
+	require.Len(t, dest.mergeCalls, 1)
+	assert.Equal(t, "ds.products", dest.mergeCalls[0].TargetTable)
+}
+
+func TestStreaming_AnnouncementForKnownTableIgnored(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.users": mergeTableState("ds.users")})
+
+	loop.prepareNewTable = func(_ context.Context, ti source.SourceTableInfo) (*streamTableState, error) {
+		t.Fatalf("prepareNewTable called for already-known table %s", ti.Name)
+		return nil, nil
+	}
+
+	info := newTableInfo("public.users")
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.users", TableInfo: &info}
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.users"}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+	assert.Equal(t, 1, writeCallCount(dest))
+}
+
+func TestStreaming_AnnouncementWithoutPreparerDropsBatches(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.users": mergeTableState("ds.users")})
+
+	info := newTableInfo("public.products")
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.products", TableInfo: &info}
+	// The CheckedAllocator cleanup in int64RecordBatch verifies this gets released.
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.products"}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+	assert.Equal(t, 0, writeCallCount(dest))
+}
+
+func TestStreaming_NewTablePrepareFailureAborts(t *testing.T) {
+	dest := &fakeDestination{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{})
+
+	loop.prepareNewTable = func(_ context.Context, _ source.SourceTableInfo) (*streamTableState, error) {
+		return nil, errors.New("boom")
+	}
+
+	info := newTableInfo("public.products")
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: "public.products", TableInfo: &info}
+	close(records)
+
+	err := loop.run(context.Background(), records)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "public.products")
+}
+
+func TestWithLoadTimestampColumn(t *testing.T) {
+	s := streamTestSchema()
+	got := withLoadTimestampColumn(s)
+	require.Len(t, got.Columns, len(s.Columns)+1)
+	assert.Equal(t, naming.IngestrLoadedAtColumn, got.Columns[len(got.Columns)-1].Name)
+	assert.Equal(t, schema.TypeTimestampTZ, got.Columns[len(got.Columns)-1].DataType)
+
+	// Idempotent when the column is already present.
+	again := withLoadTimestampColumn(got)
+	assert.Len(t, again.Columns, len(got.Columns))
+
+	assert.Nil(t, withLoadTimestampColumn(nil))
+}
+
+func TestMultiTableDestName(t *testing.T) {
+	dest := &fakeDestination{}
+	assert.Equal(t, "products", multiTableDestName(dest, source.SourceTableInfo{Name: "products"}))
+	assert.Equal(t, "ds.app_orders", multiTableDestName(dest, source.SourceTableInfo{Name: "app.orders", DestSchema: "ds"}))
+}

--- a/tests/integration/postgres_cdc_new_table_test.go
+++ b/tests/integration/postgres_cdc_new_table_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func setupNewTableDest(t *testing.T, ctx context.Context) (string, *pgxpool.Pool) {
+	t.Helper()
+	destContainer, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = destContainer.Terminate(ctx) })
+
+	destConnString, err := destContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	destPool, err := pgxpool.New(ctx, destConnString)
+	require.NoError(t, err)
+	t.Cleanup(destPool.Close)
+	return destConnString, destPool
+}
+
+// TestPostgresCDC_NewTableBetweenBatchRuns verifies that a table created on the
+// source between two batch runs is picked up by the next run with a full
+// backfill of its pre-existing rows, while the original table keeps resuming
+// incrementally.
+func TestPostgresCDC_NewTableBetweenBatchRuns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.orders (id BIGINT PRIMARY KEY, amount BIGINT);
+		INSERT INTO public.orders SELECT g, g * 10 FROM generate_series(1, 50) g;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	destConnString, destPool := setupNewTableDest(t, ctx)
+
+	// No publication= -> ingestr manages the publication and reconciles it on
+	// every run.
+	cfg := &config.IngestConfig{
+		SourceURI: "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&mode=batch",
+		DestURI:   destConnString,
+	}
+
+	// Run 1: snapshot of orders.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var count int
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT count(*) FROM orders WHERE _cdc_deleted = false`).Scan(&count))
+	require.Equal(t, 50, count)
+
+	// A new table appears, with pre-existing rows that only a backfill can
+	// deliver; the original table also gets an incremental change.
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.customers (id BIGINT PRIMARY KEY, name TEXT);
+		INSERT INTO public.customers SELECT g, 'customer-' || g FROM generate_series(1, 30) g;
+		INSERT INTO public.orders VALUES (51, 510);
+	`)
+	require.NoError(t, err)
+
+	// Run 2: resumes orders, backfills customers.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT count(*) FROM customers WHERE _cdc_deleted = false`).Scan(&count))
+	assert.Equal(t, 30, count, "new table should be fully backfilled")
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT count(*) FROM orders WHERE _cdc_deleted = false`).Scan(&count))
+	assert.Equal(t, 51, count, "original table should keep resuming")
+
+	// Run 3: subsequent changes to the new table flow incrementally (no
+	// re-snapshot: the destination now has resume state for customers).
+	_, err = srcPool.Exec(ctx, `
+		INSERT INTO public.customers VALUES (31, 'customer-31');
+		UPDATE public.customers SET name = 'renamed' WHERE id = 1;
+		DELETE FROM public.customers WHERE id = 2;
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT count(*) FROM customers WHERE _cdc_deleted = false`).Scan(&count))
+	assert.Equal(t, 30, count, "31 rows minus 1 delete")
+
+	var name string
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT name FROM customers WHERE id = 1`).Scan(&name))
+	assert.Equal(t, "renamed", name)
+
+	var deleted bool
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT _cdc_deleted FROM customers WHERE id = 2`).Scan(&deleted))
+	assert.True(t, deleted, "delete should be reflected via merge")
+}
+
+// TestPostgresCDC_StreamingNewTableDetection verifies that a table created on
+// the source while a stream is running is detected, added to the managed
+// publication, backfilled, and then replicated live — without restarting the
+// stream and without disturbing the original table.
+func TestPostgresCDC_StreamingNewTableDetection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.evt (id BIGINT PRIMARY KEY, val BIGINT);
+		INSERT INTO public.evt SELECT g, 0 FROM generate_series(1, 100) g;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	destConnString, destPool := setupNewTableDest(t, ctx)
+
+	// Managed publication + fast discovery so the test observes a mid-stream
+	// rebuild quickly.
+	cfg := &config.IngestConfig{
+		SourceURI:           "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&discover_interval=1s",
+		DestURI:             destConnString,
+		IncrementalStrategy: config.StrategyMerge,
+		Stream:              true,
+		FlushInterval:       1 * time.Second,
+		FlushRecords:        50,
+		Progress:            config.ProgressLog,
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	tableCount := func(table string) int {
+		var n int
+		if err := destPool.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE _cdc_deleted = false`).Scan(&n); err != nil {
+			return -1
+		}
+		return n
+	}
+
+	// 1. Snapshot of the original table lands.
+	require.Eventually(t, func() bool { return tableCount("evt") == 100 }, 60*time.Second, 500*time.Millisecond,
+		"snapshot of evt should appear in destination")
+
+	// 2. A new table appears mid-stream with pre-existing rows.
+	_, err = srcPool.Exec(ctx, `
+		CREATE TABLE public.late (id BIGINT PRIMARY KEY, val BIGINT);
+		INSERT INTO public.late SELECT g, g FROM generate_series(1, 40) g;
+	`)
+	require.NoError(t, err)
+
+	// 3. It is detected, provisioned in the destination, and backfilled.
+	require.Eventually(t, func() bool { return tableCount("late") == 40 }, 60*time.Second, 500*time.Millisecond,
+		"new table should be backfilled mid-stream, got %d rows", tableCount("late"))
+
+	// 4. Live changes on both the new and the original table keep flowing.
+	_, err = srcPool.Exec(ctx, `
+		INSERT INTO public.late SELECT g, g FROM generate_series(41, 60) g;
+		UPDATE public.late SET val = -1 WHERE id = 1;
+		DELETE FROM public.late WHERE id = 2;
+		INSERT INTO public.evt SELECT g, g FROM generate_series(101, 120) g;
+	`)
+	require.NoError(t, err)
+
+	// 40 backfilled + 20 inserted - 1 deleted = 59 live rows.
+	require.Eventually(t, func() bool {
+		return tableCount("late") == 59 && tableCount("evt") == 120
+	}, 60*time.Second, 500*time.Millisecond,
+		"live changes should replicate after the rebuild (late=%d, evt=%d)", tableCount("late"), tableCount("evt"))
+
+	var val int64
+	require.NoError(t, destPool.QueryRow(ctx, `SELECT val FROM late WHERE id = 1`).Scan(&val))
+	assert.Equal(t, int64(-1), val)
+
+	// 5. Graceful shutdown.
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30s of cancellation")
+	}
+}

--- a/tests/integration/postgres_cdc_stress_test.go
+++ b/tests/integration/postgres_cdc_stress_test.go
@@ -1,0 +1,559 @@
+//go:build stress
+
+// High-volume PostgreSQL CDC accuracy test. It is intentionally excluded from
+// the regular integration suite (build tag `stress`, not `integration`) so it
+// never slows down CI; run it with `make cdc-postgres-stress-test`.
+//
+// Scenario: a streaming CDC pipeline replicates from one Postgres container to
+// another while parallel workers apply ~1000 inserts/updates per second for
+// three minutes, and a new table (with pre-existing rows) is created on the
+// source every minute mid-stream. Afterwards the destination must converge to
+// the exact source state, verified first by per-table count/sum aggregates and
+// then by a parallel row-by-row content comparison.
+package integration
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/testutil"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	stressInitialTables   = 2
+	stressSeedRows        = 5000
+	stressLateSeedRows    = 2000
+	stressCompareChunk    = 20000
+	stressCompareParallel = 8
+	stressConvergeTimeout = 4 * time.Minute
+)
+
+// Overridable for local iteration and heavier soak runs, e.g.
+// STRESS_OPS_PER_SEC=5000 STRESS_LOAD_DURATION=5m make cdc-postgres-stress-test.
+var (
+	stressTargetOpsPerSec = envInt("STRESS_OPS_PER_SEC", 1000)
+	stressLoadDuration    = envDuration("STRESS_LOAD_DURATION", 3*time.Minute)
+	stressNewTableEvery   = envDuration("STRESS_NEW_TABLE_EVERY", 1*time.Minute)
+	stressWorkers         = envInt("STRESS_WORKERS", 12)
+)
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+func envDuration(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
+
+type stressTable struct {
+	name      string
+	nextID    atomic.Int64
+	insertSQL string
+	updateSQL string
+}
+
+func newStressTable(name string, seeded int64) *stressTable {
+	t := &stressTable{
+		name:      name,
+		insertSQL: fmt.Sprintf(`INSERT INTO public.%s (id, val, payload, updated_at) VALUES ($1, $2, $3, now())`, name),
+		updateSQL: fmt.Sprintf(`UPDATE public.%s SET val = val + 1, payload = $2, updated_at = now() WHERE id = $1`, name),
+	}
+	t.nextID.Store(seeded)
+	return t
+}
+
+type stressTableSet struct {
+	mu     sync.RWMutex
+	tables []*stressTable
+}
+
+func (s *stressTableSet) add(t *stressTable) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tables = append(s.tables, t)
+}
+
+func (s *stressTableSet) pick(rng *rand.Rand) *stressTable {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tables[rng.Intn(len(s.tables))]
+}
+
+func (s *stressTableSet) snapshot() []*stressTable {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*stressTable, len(s.tables))
+	copy(out, s.tables)
+	return out
+}
+
+func stressTableName(i int) string {
+	return fmt.Sprintf("stress_%02d", i)
+}
+
+func stressCreateAndSeed(ctx context.Context, pool *pgxpool.Pool, name string, rows int) error {
+	_, err := pool.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE public.%[1]s (
+			id BIGINT PRIMARY KEY,
+			val BIGINT NOT NULL,
+			payload TEXT NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL
+		);
+		INSERT INTO public.%[1]s
+		SELECT g, g, 'seed-' || g, now() FROM generate_series(1, %[2]d) g;
+	`, name, rows))
+	return err
+}
+
+func stressSourceContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string) {
+	t.Helper()
+	req := testcontainers.ContainerRequest{
+		Image: "postgres:16-alpine",
+		Env: map[string]string{
+			"POSTGRES_USER":     "testuser",
+			"POSTGRES_PASSWORD": "testpass",
+			"POSTGRES_DB":       "testdb",
+		},
+		ExposedPorts: []string{"5432/tcp"},
+		Cmd: []string{
+			"postgres",
+			"-c", "wal_level=logical",
+			"-c", "max_replication_slots=10",
+			"-c", "max_wal_senders=10",
+			"-c", "max_connections=120",
+			// Throwaway load-generator container: skip the per-commit WAL fsync
+			// wait so single-row autocommit transactions aren't capped by disk
+			// flush latency. Does not change logical decoding semantics.
+			"-c", "synchronous_commit=off",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+	return container, fmt.Sprintf("postgres://testuser:testpass@%s:%s/testdb?sslmode=disable", host, port.Port())
+}
+
+func stressDestContainer(t *testing.T, ctx context.Context) (string, *pgxpool.Pool) {
+	t.Helper()
+	container, err := postgres.Run(
+		ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("destdb"),
+		postgres.WithUsername("destuser"),
+		postgres.WithPassword("destpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	connString, err := container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return connString, pool
+}
+
+func TestPostgresCDC_StressHighVolume(t *testing.T) {
+	ctx := context.Background()
+	if !testutil.DockerProviderHealthy(ctx) {
+		t.Skip("skipping stress test: Docker provider is not available/healthy")
+	}
+
+	sourceContainer, sourceConnString := stressSourceContainer(t, ctx)
+	destConnString, destPool := stressDestContainer(t, ctx)
+
+	srcPool, err := pgxpool.New(ctx, fmt.Sprintf("%s&pool_max_conns=%d", sourceConnString, max(32, stressWorkers+8)))
+	require.NoError(t, err)
+	t.Cleanup(srcPool.Close)
+
+	tables := &stressTableSet{}
+	for i := 0; i < stressInitialTables; i++ {
+		name := stressTableName(i)
+		require.NoError(t, stressCreateAndSeed(ctx, srcPool, name, stressSeedRows))
+		tables.add(newStressTable(name, stressSeedRows))
+	}
+	_, err = srcPool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	cfg := &config.IngestConfig{
+		SourceURI:           "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&discover_interval=5s",
+		DestURI:             destConnString,
+		IncrementalStrategy: config.StrategyMerge,
+		Stream:              true,
+		FlushInterval:       2 * time.Second,
+		FlushRecords:        25000,
+		Progress:            config.ProgressLog,
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	runErr := make(chan error, 1)
+	go func() { runErr <- pipeline.New(cfg).Run(streamCtx) }()
+
+	t.Logf("load phase: %v at ~%d ops/sec across %d workers, new table every %v",
+		stressLoadDuration, stressTargetOpsPerSec, stressWorkers, stressNewTableEvery)
+
+	loadCtx, stopLoad := context.WithTimeout(ctx, stressLoadDuration)
+	defer stopLoad()
+
+	var inserts, updates, opErrors atomic.Int64
+	var firstOpErr atomic.Value
+	recordOpErr := func(err error) {
+		opErrors.Add(1)
+		firstOpErr.CompareAndSwap(nil, err)
+	}
+
+	// Each worker paces itself at target/workers so the aggregate rate scales
+	// past what a single shared ticker channel can hand out.
+	workerInterval := time.Duration(stressWorkers) * time.Second / time.Duration(stressTargetOpsPerSec)
+
+	var wg sync.WaitGroup
+	for w := 0; w < stressWorkers; w++ {
+		wg.Add(1)
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			ticker := time.NewTicker(workerInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-loadCtx.Done():
+					return
+				case <-ticker.C:
+				}
+				tbl := tables.pick(rng)
+				if rng.Intn(2) == 0 {
+					id := tbl.nextID.Add(1)
+					// ctx, not loadCtx: every issued op runs to completion so
+					// the post-load source state is settled when workers exit.
+					if _, err := srcPool.Exec(ctx, tbl.insertSQL, id, id, fmt.Sprintf("ins-%d-%d", seed, id)); err != nil {
+						recordOpErr(fmt.Errorf("insert %s id=%d: %w", tbl.name, id, err))
+					}
+					inserts.Add(1)
+				} else {
+					id := rng.Int63n(tbl.nextID.Load()) + 1
+					if _, err := srcPool.Exec(ctx, tbl.updateSQL, id, fmt.Sprintf("upd-%d-%d", seed, id)); err != nil {
+						recordOpErr(fmt.Errorf("update %s id=%d: %w", tbl.name, id, err))
+					}
+					updates.Add(1)
+				}
+			}
+		}(int64(w + 1))
+	}
+
+	lateTables := max(int(stressLoadDuration/stressNewTableEvery)-1, 0)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < lateTables; i++ {
+			select {
+			case <-loadCtx.Done():
+				return
+			case <-time.After(stressNewTableEvery):
+			}
+			name := stressTableName(stressInitialTables + i)
+			if err := stressCreateAndSeed(ctx, srcPool, name, stressLateSeedRows); err != nil {
+				recordOpErr(fmt.Errorf("create late table %s: %w", name, err))
+				return
+			}
+			tables.add(newStressTable(name, stressLateSeedRows))
+			t.Logf("created new table %s mid-stream with %d pre-existing rows", name, stressLateSeedRows)
+		}
+	}()
+
+	loadDone := make(chan struct{})
+	go func() { wg.Wait(); close(loadDone) }()
+	status := time.NewTicker(15 * time.Second)
+	defer status.Stop()
+	started := time.Now()
+	for running := true; running; {
+		select {
+		case <-loadDone:
+			running = false
+		case err := <-runErr:
+			stopLoad()
+			<-loadDone
+			t.Fatalf("stream exited during load phase: %v", err)
+		case <-status.C:
+			t.Logf("t=%v: %d inserts, %d updates, %d op errors",
+				time.Since(started).Round(time.Second), inserts.Load(), updates.Load(), opErrors.Load())
+		}
+	}
+
+	if n := opErrors.Load(); n > 0 {
+		t.Fatalf("%d load operations failed, first error: %v", n, firstOpErr.Load())
+	}
+	totalOps := inserts.Load() + updates.Load()
+	achieved := float64(totalOps) / stressLoadDuration.Seconds()
+	t.Logf("load complete: %d ops (%d inserts, %d updates), %.0f ops/sec achieved", totalOps, inserts.Load(), updates.Load(), achieved)
+	require.GreaterOrEqual(t, achieved, float64(stressTargetOpsPerSec)/2,
+		"load generator could not sustain enough pressure for the test to be meaningful")
+	finalTables := tables.snapshot()
+	require.Len(t, finalTables, stressInitialTables+lateTables, "all late tables should have been created")
+
+	// The source is now quiescent; capture the ground truth.
+	type truth struct{ count, sum int64 }
+	truths := make(map[string]truth, len(finalTables))
+	for _, tbl := range finalTables {
+		var tr truth
+		require.NoError(t, srcPool.QueryRow(ctx,
+			fmt.Sprintf(`SELECT count(*), COALESCE(sum(val), 0) FROM public.%s`, tbl.name)).Scan(&tr.count, &tr.sum))
+		truths[tbl.name] = tr
+		t.Logf("source truth %s: count=%d sum=%d", tbl.name, tr.count, tr.sum)
+	}
+
+	destAgg := func(table string) (truth, error) {
+		var tr truth
+		err := destPool.QueryRow(ctx,
+			fmt.Sprintf(`SELECT count(*), COALESCE(sum(val), 0) FROM %s WHERE _cdc_deleted = false`, table)).Scan(&tr.count, &tr.sum)
+		return tr, err
+	}
+
+	dumpDiagnostics := func() {
+		stressDumpReplicationState(t, ctx, srcPool)
+		for _, tbl := range finalTables {
+			got, err := destAgg(tbl.name)
+			t.Logf("  %s: want %+v, got %+v (err=%v)", tbl.name, truths[tbl.name], got, err)
+		}
+		if err := stressCompareAll(ctx, srcPool, destPool, finalTables); err != nil {
+			t.Logf("  first content mismatch: %v", err)
+		}
+		stressDumpContainerLogs(t, ctx, sourceContainer, 120)
+	}
+
+	deadline := time.Now().Add(stressConvergeTimeout)
+	lastProgressLog := time.Now()
+	for {
+		select {
+		case err := <-runErr:
+			dumpDiagnostics()
+			t.Fatalf("stream exited during convergence: %v", err)
+		default:
+		}
+		pending := ""
+		for _, tbl := range finalTables {
+			got, err := destAgg(tbl.name)
+			if err != nil || got != truths[tbl.name] {
+				pending = fmt.Sprintf("%s: want %+v, got %+v (err=%v)", tbl.name, truths[tbl.name], got, err)
+				break
+			}
+		}
+		if pending == "" {
+			break
+		}
+		if time.Since(lastProgressLog) > 20*time.Second {
+			lastProgressLog = time.Now()
+			t.Logf("convergence pending: %s", pending)
+		}
+		if time.Now().After(deadline) {
+			dumpDiagnostics()
+			t.Fatalf("destination did not converge within %v; still pending: %s", stressConvergeTimeout, pending)
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Log("destination converged on count/sum aggregates for all tables")
+
+	// Aggregates can match while a final merge is still landing payload
+	// updates, so retry the deep comparison briefly before declaring failure.
+	var compareErr error
+	for attempt := 1; attempt <= 6; attempt++ {
+		if compareErr = stressCompareAll(ctx, srcPool, destPool, finalTables); compareErr == nil {
+			break
+		}
+		t.Logf("deep comparison attempt %d: %v", attempt, compareErr)
+		time.Sleep(5 * time.Second)
+	}
+	require.NoError(t, compareErr, "row-by-row content comparison failed")
+	t.Log("row-by-row content comparison passed for all tables")
+
+	for _, tbl := range finalTables {
+		var deleted int
+		require.NoError(t, destPool.QueryRow(ctx,
+			fmt.Sprintf(`SELECT count(*) FROM %s WHERE _cdc_deleted = true`, tbl.name)).Scan(&deleted))
+		require.Zero(t, deleted, "no deletes were issued, %s should have no soft-deleted rows", tbl.name)
+	}
+
+	cancelStream()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 60s of cancellation")
+	}
+}
+
+func stressDumpReplicationState(t *testing.T, ctx context.Context, srcPool *pgxpool.Pool) {
+	t.Helper()
+	rows, err := srcPool.Query(ctx, `
+		SELECT slot_name, active, COALESCE(active_pid, 0),
+		       COALESCE(restart_lsn::text, '-'), COALESCE(confirmed_flush_lsn::text, '-'),
+		       pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)
+		FROM pg_replication_slots`)
+	if err != nil {
+		t.Logf("replication slot dump failed: %v", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, restart, confirmed string
+		var active bool
+		var pid int
+		var lag int64
+		if err := rows.Scan(&name, &active, &pid, &restart, &confirmed, &lag); err == nil {
+			t.Logf("  slot %s: active=%t pid=%d restart=%s confirmed=%s lag=%d bytes", name, active, pid, restart, confirmed, lag)
+		}
+	}
+
+	var walLSN string
+	if err := srcPool.QueryRow(ctx, `SELECT pg_current_wal_lsn()::text`).Scan(&walLSN); err == nil {
+		t.Logf("  pg_current_wal_lsn=%s", walLSN)
+	}
+}
+
+func stressDumpContainerLogs(t *testing.T, ctx context.Context, container testcontainers.Container, lastN int) {
+	t.Helper()
+	reader, err := container.Logs(ctx)
+	if err != nil {
+		t.Logf("container log fetch failed: %v", err)
+		return
+	}
+	defer func() { _ = reader.Close() }()
+	var lines []string
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+		if len(lines) > lastN {
+			lines = lines[1:]
+		}
+	}
+	t.Logf("source container logs (last %d lines):", len(lines))
+	for _, l := range lines {
+		t.Logf("  %s", l)
+	}
+}
+
+type stressRow struct {
+	id        int64
+	val       int64
+	payload   string
+	updatedAt time.Time
+}
+
+func stressFetchChunk(ctx context.Context, pool *pgxpool.Pool, table, extraWhere string, lo, hi int64) ([]stressRow, error) {
+	rows, err := pool.Query(ctx, fmt.Sprintf(
+		`SELECT id, val, payload, updated_at FROM %s WHERE id >= $1 AND id < $2%s ORDER BY id`, table, extraWhere,
+	), lo, hi)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []stressRow
+	for rows.Next() {
+		var r stressRow
+		if err := rows.Scan(&r.id, &r.val, &r.payload, &r.updatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func stressCompareChunkRange(ctx context.Context, src, dst *pgxpool.Pool, table string, lo, hi int64) error {
+	srcRows, err := stressFetchChunk(ctx, src, "public."+table, "", lo, hi)
+	if err != nil {
+		return fmt.Errorf("%s [%d,%d): source fetch: %w", table, lo, hi, err)
+	}
+	dstRows, err := stressFetchChunk(ctx, dst, table, " AND _cdc_deleted = false", lo, hi)
+	if err != nil {
+		return fmt.Errorf("%s [%d,%d): destination fetch: %w", table, lo, hi, err)
+	}
+	if len(srcRows) != len(dstRows) {
+		return fmt.Errorf("%s [%d,%d): row count mismatch: source=%d destination=%d", table, lo, hi, len(srcRows), len(dstRows))
+	}
+	for i := range srcRows {
+		s, d := srcRows[i], dstRows[i]
+		if s.id != d.id || s.val != d.val || s.payload != d.payload || !s.updatedAt.Equal(d.updatedAt) {
+			return fmt.Errorf("%s: content mismatch at id=%d: source={val:%d payload:%q updated_at:%v} destination={id:%d val:%d payload:%q updated_at:%v}",
+				table, s.id, s.val, s.payload, s.updatedAt, d.id, d.val, d.payload, d.updatedAt)
+		}
+	}
+	return nil
+}
+
+// stressCompareAll compares every table's full content in parallel, chunked by
+// primary-key range so large tables are verified by concurrent scans.
+func stressCompareAll(ctx context.Context, src, dst *pgxpool.Pool, tables []*stressTable) error {
+	type chunk struct {
+		table  string
+		lo, hi int64
+	}
+	var chunks []chunk
+	for _, tbl := range tables {
+		maxID := tbl.nextID.Load()
+		for lo := int64(1); lo <= maxID; lo += stressCompareChunk {
+			chunks = append(chunks, chunk{table: tbl.name, lo: lo, hi: min(lo+stressCompareChunk, maxID+1)})
+		}
+	}
+
+	sem := make(chan struct{}, stressCompareParallel)
+	errCh := make(chan error, len(chunks))
+	var wg sync.WaitGroup
+	for _, c := range chunks {
+		wg.Add(1)
+		go func(c chunk) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			if err := stressCompareChunkRange(ctx, src, dst, c.table, c.lo, c.hi); err != nil {
+				errCh <- err
+			}
+		}(c)
+	}
+	wg.Wait()
+	close(errCh)
+	return <-errCh
+}


### PR DESCRIPTION
## Summary

This adds Postgres CDC support for tables that appear after ingestion has already been set up.

- Backfills tables that have no destination CDC resume state on a later batch run.
- Adds streaming discovery via `discover_interval`, reconciles the managed publication, backfills newly discovered tables through a temporary replication slot, and restarts the stream on the existing persistent slot.
- Lets streaming multi-table consumers provision destination state from source table announcements before late-table batches arrive.
- Documents `postgres+cdc` URI options and the new-table behavior.

## Validation

- `make format`
- `make lint`
- `make test`
- `go test -tags integration -v -run 'TestPostgresCDC_(NewTableBetweenBatchRuns|StreamingNewTableDetection)$' ./tests/integration/...`