### PR TITLE
Optimize MySQL destination loading

### DIFF
--- a/pkg/destination/mysql/mapper.go
+++ b/pkg/destination/mysql/mapper.go
@@ -32,7 +32,7 @@ func MapDataTypeToMySQL(col schema.Column) string {
 		}
 		return "DECIMAL(38,9)"
 	case schema.TypeString:
-		if col.MaxLength > 0 && col.MaxLength <= 65535 {
+		if col.MaxLength > 0 && col.MaxLength <= 16383 {
 			return fmt.Sprintf("VARCHAR(%d)", col.MaxLength)
 		}
 		return "TEXT"

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -287,6 +287,9 @@ func (d *MySQLDestination) Write(ctx context.Context, records <-chan source.Reco
 }
 
 func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	writeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	parallelism := mysqlWriteParallelism(opts.Parallelism)
 	startTime := time.Now()
 
@@ -302,6 +305,7 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 	results := make(chan writeResult, parallelism*2)
 	var wg sync.WaitGroup
 	var batchNum int64
+	var stopWrites atomic.Bool
 
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)
@@ -311,18 +315,28 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 			for result := range records {
 				myBatch := int(atomic.AddInt64(&batchNum, 1))
 				if result.Err != nil {
+					stopWrites.Store(true)
+					cancel()
 					results <- writeResult{batchNum: myBatch, err: result.Err}
-					return
+					continue
 				}
 
 				record := result.Batch
 				if record == nil {
 					continue
 				}
+				if stopWrites.Load() {
+					record.Release()
+					continue
+				}
 
 				startBatch := time.Now()
-				rows, err := d.writeRecordBatch(ctx, record, opts.Table)
+				rows, err := d.writeRecordBatch(writeCtx, record, opts.Table)
 				record.Release()
+				if err != nil {
+					stopWrites.Store(true)
+					cancel()
+				}
 
 				results <- writeResult{
 					batchNum: myBatch,
@@ -619,12 +633,17 @@ func writeEscapedLoadDataBytes(w io.Writer, value []byte) error {
 
 func isLoadDataLocalDisabledError(err error) bool {
 	var myErr *mysqldriver.MySQLError
-	if errors.As(err, &myErr) && myErr.Number == 3948 {
-		return true
+	if errors.As(err, &myErr) {
+		switch myErr.Number {
+		case 3948, 1148:
+			return true
+		}
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "loading local data is disabled") ||
-		strings.Contains(msg, "local infile") && strings.Contains(msg, "disabled")
+		strings.Contains(msg, "used command is not allowed") ||
+		strings.Contains(msg, "local infile") &&
+			(strings.Contains(msg, "disabled") || strings.Contains(msg, "not allowed"))
 }
 
 func (d *MySQLDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -280,7 +280,7 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 	writeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	parallelism := mysqlWriteParallelism(opts.Parallelism)
+	parallelism := mysqlWriteParallelismForOptions(opts)
 	startTime := time.Now()
 
 	config.Debug("[MYSQL] Starting parallel write to %s with %d workers", opts.Table, parallelism)
@@ -379,6 +379,13 @@ func mysqlWriteParallelism(requested int) int {
 	return requested
 }
 
+func mysqlWriteParallelismForOptions(opts destination.WriteOptions) int {
+	if !opts.StagingTable {
+		return 1
+	}
+	return mysqlWriteParallelism(opts.Parallelism)
+}
+
 func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
 	if d.useLoadData {
 		rows, err := d.writeRecordBatchLoadData(ctx, record, table)
@@ -414,6 +421,11 @@ func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record ar
 
 	rowsWritten := int64(0)
 	for start := int64(0); start < numRows; start += mysqlInsertRowsPerStatement {
+		if err := ctx.Err(); err != nil {
+			_ = tx.Rollback()
+			return rowsWritten, fmt.Errorf("write canceled before insert: %w", err)
+		}
+
 		end := min(start+mysqlInsertRowsPerStatement, numRows)
 		chunkRows := int(end - start)
 		insertSQL := buildMultiRowInsertSQL(table, colNames, chunkRows)
@@ -431,6 +443,11 @@ func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record ar
 			return rowsWritten, fmt.Errorf("failed to insert rows %d-%d: %w", start, end-1, err)
 		}
 		rowsWritten += int64(chunkRows)
+	}
+
+	if err := ctx.Err(); err != nil {
+		_ = tx.Rollback()
+		return rowsWritten, fmt.Errorf("write canceled before commit: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -277,6 +277,10 @@ func (d *MySQLDestination) Write(ctx context.Context, records <-chan source.Reco
 }
 
 func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if !opts.StagingTable {
+		return d.writeSequential(ctx, records, opts)
+	}
+
 	writeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -362,6 +366,42 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 
 	if firstErr != nil {
 		return fmt.Errorf("parallel write failed: %w", firstErr)
+	}
+
+	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
+	config.Debug("[MYSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTime), totalRate)
+	return nil
+}
+
+func (d *MySQLDestination) writeSequential(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	startTime := time.Now()
+	var totalRows int64
+	var batchNum int
+
+	config.Debug("[MYSQL] Starting sequential write to %s", opts.Table)
+
+	for result := range records {
+		if result.Err != nil {
+			return result.Err
+		}
+
+		record := result.Batch
+		if record == nil {
+			continue
+		}
+
+		batchNum++
+		startBatch := time.Now()
+		rows, err := d.writeRecordBatch(ctx, record, opts.Table)
+		record.Release()
+		if err != nil {
+			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
+		}
+
+		totalRows += rows
+		rate := float64(rows) / time.Since(startBatch).Seconds()
+		config.Debug("[MYSQL] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
+			batchNum, rows, time.Since(startBatch), rate, totalRows)
 	}
 
 	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
@@ -476,10 +516,23 @@ func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record 
 	})
 	defer mysqldriver.DeregisterReaderHandler(handlerName)
 
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
 	loadSQL := buildLoadDataSQL(table, colNames, handlerName)
-	if _, err := d.db.ExecContext(ctx, loadSQL); err != nil {
+	if _, err := tx.ExecContext(ctx, loadSQL); err != nil {
 		config.LogFailedQuery(loadSQL, err)
+		_ = tx.Rollback()
 		return 0, fmt.Errorf("failed to load rows with LOAD DATA LOCAL INFILE: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = tx.Rollback()
+		return 0, fmt.Errorf("write canceled before commit: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return numRows, nil

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -37,9 +36,7 @@ type MySQLDestination struct {
 }
 
 const (
-	mysqlInsertRowsPerStatement  = 1000
-	mysqlDefaultWriteParallelism = 4
-	mysqlMaxWriteParallelism     = 8
+	mysqlInsertRowsPerStatement = 1000
 )
 
 var mysqlLoadDataReaderID uint64
@@ -277,156 +274,7 @@ func (d *MySQLDestination) Write(ctx context.Context, records <-chan source.Reco
 }
 
 func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
-	if !opts.StagingTable {
-		return d.writeSequential(ctx, records, opts)
-	}
-
-	writeCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	commitGate := newMySQLWriteCommitGate(cancel)
-
-	parallelism := mysqlWriteParallelismForOptions(opts)
-	startTime := time.Now()
-
-	config.Debug("[MYSQL] Starting parallel write to %s with %d workers", opts.Table, parallelism)
-
-	type writeResult struct {
-		batchNum int
-		rows     int64
-		duration time.Duration
-		err      error
-	}
-
-	results := make(chan writeResult, parallelism*2)
-	var wg sync.WaitGroup
-	var batchNum int64
-	var stopWrites atomic.Bool
-
-	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			for result := range records {
-				myBatch := int(atomic.AddInt64(&batchNum, 1))
-				if result.Err != nil {
-					stopWrites.Store(true)
-					commitGate.cancel()
-					results <- writeResult{batchNum: myBatch, err: result.Err}
-					continue
-				}
-
-				record := result.Batch
-				if record == nil {
-					continue
-				}
-				if stopWrites.Load() {
-					record.Release()
-					continue
-				}
-
-				startBatch := time.Now()
-				rows, err := d.writeRecordBatch(writeCtx, record, opts.Table, commitGate)
-				record.Release()
-				if err != nil {
-					stopWrites.Store(true)
-					commitGate.cancel()
-				}
-
-				results <- writeResult{
-					batchNum: myBatch,
-					rows:     rows,
-					duration: time.Since(startBatch),
-					err:      err,
-				}
-			}
-		}()
-	}
-
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	var totalRows int64
-	var firstErr error
-	for res := range results {
-		if res.err != nil {
-			if firstErr == nil {
-				firstErr = res.err
-			}
-			config.Debug("[MYSQL] Worker error on batch %d: %v", res.batchNum, res.err)
-			continue
-		}
-
-		totalRows += res.rows
-		rate := float64(res.rows) / res.duration.Seconds()
-		config.Debug("[MYSQL] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
-			res.batchNum, res.rows, res.duration, rate, totalRows)
-	}
-
-	if firstErr != nil {
-		return fmt.Errorf("parallel write failed: %w", firstErr)
-	}
-
-	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
-	config.Debug("[MYSQL] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTime), totalRate)
-	return nil
-}
-
-type mysqlWriteCommitGate struct {
-	mu         sync.Mutex
-	cancelFunc context.CancelFunc
-	closed     bool
-}
-
-func newMySQLWriteCommitGate(cancel context.CancelFunc) *mysqlWriteCommitGate {
-	return &mysqlWriteCommitGate{cancelFunc: cancel}
-}
-
-func (g *mysqlWriteCommitGate) cancel() {
-	g.mu.Lock()
-	g.closed = true
-	g.cancelFunc()
-	g.mu.Unlock()
-}
-
-func (g *mysqlWriteCommitGate) commit(ctx context.Context, tx *sql.Tx) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	if err := mysqlWriteCanceledError(ctx, g.closed); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-	return nil
-}
-
-func commitMySQLTransaction(ctx context.Context, tx *sql.Tx, commitGate *mysqlWriteCommitGate) error {
-	if commitGate != nil {
-		return commitGate.commit(ctx, tx)
-	}
-	if err := mysqlWriteCanceledError(ctx, false); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-	return nil
-}
-
-func mysqlWriteCanceledError(ctx context.Context, closed bool) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("write canceled before commit: %w", err)
-	}
-	if closed {
-		return fmt.Errorf("write canceled before commit: %w", context.Canceled)
-	}
-	return nil
+	return d.writeSequential(ctx, records, opts)
 }
 
 func (d *MySQLDestination) writeSequential(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
@@ -448,7 +296,7 @@ func (d *MySQLDestination) writeSequential(ctx context.Context, records <-chan s
 
 		batchNum++
 		startBatch := time.Now()
-		rows, err := d.writeRecordBatch(ctx, record, opts.Table, nil)
+		rows, err := d.writeRecordBatch(ctx, record, opts.Table)
 		record.Release()
 		if err != nil {
 			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
@@ -465,39 +313,22 @@ func (d *MySQLDestination) writeSequential(ctx context.Context, records <-chan s
 	return nil
 }
 
-func mysqlWriteParallelism(requested int) int {
-	if requested <= 0 {
-		return mysqlDefaultWriteParallelism
-	}
-	if requested > mysqlMaxWriteParallelism {
-		return mysqlMaxWriteParallelism
-	}
-	return requested
-}
-
-func mysqlWriteParallelismForOptions(opts destination.WriteOptions) int {
-	if !opts.StagingTable {
-		return 1
-	}
-	return mysqlWriteParallelism(opts.Parallelism)
-}
-
-func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string, commitGate *mysqlWriteCommitGate) (int64, error) {
+func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
 	if d.useLoadData {
-		rows, err := d.writeRecordBatchLoadData(ctx, record, table, commitGate)
+		rows, err := d.writeRecordBatchLoadData(ctx, record, table)
 		if err == nil {
 			return rows, nil
 		}
 		if isLoadDataLocalDisabledError(err) {
 			output.Warnf("[WARNING] MySQL LOAD DATA LOCAL INFILE is unavailable (%v); falling back to multi-row INSERT for this batch\n", err)
-			return d.writeRecordBatchInsert(ctx, record, table, commitGate)
+			return d.writeRecordBatchInsert(ctx, record, table)
 		}
 		return rows, err
 	}
-	return d.writeRecordBatchInsert(ctx, record, table, commitGate)
+	return d.writeRecordBatchInsert(ctx, record, table)
 }
 
-func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record arrow.RecordBatch, table string, commitGate *mysqlWriteCommitGate) (int64, error) {
+func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
 	numRows := record.NumRows()
 	numCols := int(record.NumCols())
 
@@ -541,14 +372,19 @@ func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record ar
 		rowsWritten += int64(chunkRows)
 	}
 
-	if err := commitMySQLTransaction(ctx, tx, commitGate); err != nil {
-		return rowsWritten, err
+	if err := ctx.Err(); err != nil {
+		_ = tx.Rollback()
+		return rowsWritten, fmt.Errorf("write canceled before commit: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return numRows, nil
 }
 
-func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record arrow.RecordBatch, table string, commitGate *mysqlWriteCommitGate) (int64, error) {
+func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
 	numRows := record.NumRows()
 	numCols := int(record.NumCols())
 
@@ -578,8 +414,12 @@ func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record 
 		_ = tx.Rollback()
 		return 0, fmt.Errorf("failed to load rows with LOAD DATA LOCAL INFILE: %w", err)
 	}
-	if err := commitMySQLTransaction(ctx, tx, commitGate); err != nil {
-		return 0, err
+	if err := ctx.Err(); err != nil {
+		_ = tx.Rollback()
+		return 0, fmt.Errorf("write canceled before commit: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return numRows, nil

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -36,10 +36,6 @@ type MySQLDestination struct {
 	scheme        string
 }
 
-type VitessDestination struct {
-	*MySQLDestination
-}
-
 const (
 	mysqlInsertRowsPerStatement  = 1000
 	mysqlDefaultWriteParallelism = 4
@@ -55,22 +51,16 @@ func NewMySQLDestination() *MySQLDestination {
 	}
 }
 
-func NewVitessDestination() *VitessDestination {
-	return &VitessDestination{
-		MySQLDestination: &MySQLDestination{
-			isVitess:      true,
-			vitessBackend: true,
-			scheme:        "vitess",
-		},
+func NewVitessCompatibleDestination(defaultScheme string) *MySQLDestination {
+	return &MySQLDestination{
+		isVitess:      true,
+		vitessBackend: true,
+		scheme:        defaultScheme,
 	}
 }
 
 func (d *MySQLDestination) Schemes() []string {
 	return []string{"mysql", "mysql+pymysql", "mariadb"}
-}
-
-func (d *VitessDestination) Schemes() []string {
-	return []string{"vitess", "ps_mysql"}
 }
 
 func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -283,6 +283,7 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 
 	writeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	commitGate := newMySQLWriteCommitGate(cancel)
 
 	parallelism := mysqlWriteParallelismForOptions(opts)
 	startTime := time.Now()
@@ -310,7 +311,7 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 				myBatch := int(atomic.AddInt64(&batchNum, 1))
 				if result.Err != nil {
 					stopWrites.Store(true)
-					cancel()
+					commitGate.cancel()
 					results <- writeResult{batchNum: myBatch, err: result.Err}
 					continue
 				}
@@ -325,11 +326,11 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 				}
 
 				startBatch := time.Now()
-				rows, err := d.writeRecordBatch(writeCtx, record, opts.Table)
+				rows, err := d.writeRecordBatch(writeCtx, record, opts.Table, commitGate)
 				record.Release()
 				if err != nil {
 					stopWrites.Store(true)
-					cancel()
+					commitGate.cancel()
 				}
 
 				results <- writeResult{
@@ -373,6 +374,61 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 	return nil
 }
 
+type mysqlWriteCommitGate struct {
+	mu         sync.Mutex
+	cancelFunc context.CancelFunc
+	closed     bool
+}
+
+func newMySQLWriteCommitGate(cancel context.CancelFunc) *mysqlWriteCommitGate {
+	return &mysqlWriteCommitGate{cancelFunc: cancel}
+}
+
+func (g *mysqlWriteCommitGate) cancel() {
+	g.mu.Lock()
+	g.closed = true
+	g.cancelFunc()
+	g.mu.Unlock()
+}
+
+func (g *mysqlWriteCommitGate) commit(ctx context.Context, tx *sql.Tx) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if err := mysqlWriteCanceledError(ctx, g.closed); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+func commitMySQLTransaction(ctx context.Context, tx *sql.Tx, commitGate *mysqlWriteCommitGate) error {
+	if commitGate != nil {
+		return commitGate.commit(ctx, tx)
+	}
+	if err := mysqlWriteCanceledError(ctx, false); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+func mysqlWriteCanceledError(ctx context.Context, closed bool) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write canceled before commit: %w", err)
+	}
+	if closed {
+		return fmt.Errorf("write canceled before commit: %w", context.Canceled)
+	}
+	return nil
+}
+
 func (d *MySQLDestination) writeSequential(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	startTime := time.Now()
 	var totalRows int64
@@ -392,7 +448,7 @@ func (d *MySQLDestination) writeSequential(ctx context.Context, records <-chan s
 
 		batchNum++
 		startBatch := time.Now()
-		rows, err := d.writeRecordBatch(ctx, record, opts.Table)
+		rows, err := d.writeRecordBatch(ctx, record, opts.Table, nil)
 		record.Release()
 		if err != nil {
 			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
@@ -426,22 +482,22 @@ func mysqlWriteParallelismForOptions(opts destination.WriteOptions) int {
 	return mysqlWriteParallelism(opts.Parallelism)
 }
 
-func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string, commitGate *mysqlWriteCommitGate) (int64, error) {
 	if d.useLoadData {
-		rows, err := d.writeRecordBatchLoadData(ctx, record, table)
+		rows, err := d.writeRecordBatchLoadData(ctx, record, table, commitGate)
 		if err == nil {
 			return rows, nil
 		}
 		if isLoadDataLocalDisabledError(err) {
 			output.Warnf("[WARNING] MySQL LOAD DATA LOCAL INFILE is unavailable (%v); falling back to multi-row INSERT for this batch\n", err)
-			return d.writeRecordBatchInsert(ctx, record, table)
+			return d.writeRecordBatchInsert(ctx, record, table, commitGate)
 		}
 		return rows, err
 	}
-	return d.writeRecordBatchInsert(ctx, record, table)
+	return d.writeRecordBatchInsert(ctx, record, table, commitGate)
 }
 
-func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record arrow.RecordBatch, table string, commitGate *mysqlWriteCommitGate) (int64, error) {
 	numRows := record.NumRows()
 	numCols := int(record.NumCols())
 
@@ -485,19 +541,14 @@ func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record ar
 		rowsWritten += int64(chunkRows)
 	}
 
-	if err := ctx.Err(); err != nil {
-		_ = tx.Rollback()
-		return rowsWritten, fmt.Errorf("write canceled before commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	if err := commitMySQLTransaction(ctx, tx, commitGate); err != nil {
+		return rowsWritten, err
 	}
 
 	return numRows, nil
 }
 
-func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record arrow.RecordBatch, table string, commitGate *mysqlWriteCommitGate) (int64, error) {
 	numRows := record.NumRows()
 	numCols := int(record.NumCols())
 
@@ -527,12 +578,8 @@ func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record 
 		_ = tx.Rollback()
 		return 0, fmt.Errorf("failed to load rows with LOAD DATA LOCAL INFILE: %w", err)
 	}
-	if err := ctx.Err(); err != nil {
-		_ = tx.Rollback()
-		return 0, fmt.Errorf("write canceled before commit: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	if err := commitMySQLTransaction(ctx, tx, commitGate); err != nil {
+		return 0, err
 	}
 
 	return numRows, nil

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -1,12 +1,17 @@
 package mysql
 
 import (
+	"bufio"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -22,18 +27,50 @@ import (
 )
 
 type MySQLDestination struct {
-	db       *sql.DB
-	uri      string
-	database string
-	isVitess bool
+	db            *sql.DB
+	uri           string
+	database      string
+	isVitess      bool
+	vitessBackend bool
+	useLoadData   bool
+	scheme        string
 }
 
+type VitessDestination struct {
+	*MySQLDestination
+}
+
+const (
+	mysqlInsertRowsPerStatement  = 1000
+	mysqlDefaultWriteParallelism = 4
+	mysqlMaxWriteParallelism     = 8
+)
+
+var mysqlLoadDataReaderID uint64
+
 func NewMySQLDestination() *MySQLDestination {
-	return &MySQLDestination{}
+	return &MySQLDestination{
+		useLoadData: true,
+		scheme:      "mysql",
+	}
+}
+
+func NewVitessDestination() *VitessDestination {
+	return &VitessDestination{
+		MySQLDestination: &MySQLDestination{
+			isVitess:      true,
+			vitessBackend: true,
+			scheme:        "vitess",
+		},
+	}
 }
 
 func (d *MySQLDestination) Schemes() []string {
-	return []string{"mysql", "mysql+pymysql", "mariadb", "vitess", "ps_mysql"}
+	return []string{"mysql", "mysql+pymysql", "mariadb"}
+}
+
+func (d *VitessDestination) Schemes() []string {
+	return []string{"vitess", "ps_mysql"}
 }
 
 func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
@@ -56,16 +93,21 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to ping MySQL: %w", err)
 	}
 
-	// Routing is by scheme: vitess:// and ps_mysql:// select the Vitess-aware
-	// write paths (CREATE DATABASE is unsupported via vtgate, and sharded keyspaces
-	// cannot be written to safely). A mysql:// URI pointed at a Vitess server is a
-	// mistake, so fail fast with a clear message rather than misbehaving mid-load.
 	scheme := ""
 	if u, err := mysqluri.ParseURL(uri); err == nil {
 		scheme = u.Scheme
 	}
-	isVitess := scheme == "vitess" || scheme == "ps_mysql"
-	if isVitess {
+	isVitessScheme := scheme == "vitess" || scheme == "ps_mysql"
+	if d.vitessBackend && !isVitessScheme {
+		_ = db.Close()
+		return fmt.Errorf("Vitess/PlanetScale destination requires the vitess:// or ps_mysql:// scheme")
+	}
+	if !d.vitessBackend && isVitessScheme {
+		_ = db.Close()
+		return fmt.Errorf("regular MySQL destination does not accept the %s:// scheme", scheme)
+	}
+
+	if d.vitessBackend {
 		config.Debug("[MYSQL] Vitess/PlanetScale destination (scheme=%s)", scheme)
 		if sharded, err := isShardedKeyspace(ctx, db, database); err != nil {
 			output.Warnf("[WARNING] could not verify whether Vitess/PlanetScale keyspace %q is sharded (%v); proceeding as unsharded, but a sharded keyspace will fail mid-load — ingestr supports only unsharded keyspaces as a destination\n", database, err)
@@ -81,7 +123,11 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 	d.db = db
 	d.uri = uri
 	d.database = database
-	d.isVitess = isVitess
+	d.isVitess = d.vitessBackend
+	d.useLoadData = !d.vitessBackend
+	if scheme != "" {
+		d.scheme = scheme
+	}
 	config.Debug("[MYSQL] Connected to database: %s", database)
 	return nil
 }
@@ -241,31 +287,77 @@ func (d *MySQLDestination) Write(ctx context.Context, records <-chan source.Reco
 }
 
 func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	parallelism := mysqlWriteParallelism(opts.Parallelism)
 	startTime := time.Now()
+
+	config.Debug("[MYSQL] Starting parallel write to %s with %d workers", opts.Table, parallelism)
+
+	type writeResult struct {
+		batchNum int
+		rows     int64
+		duration time.Duration
+		err      error
+	}
+
+	results := make(chan writeResult, parallelism*2)
+	var wg sync.WaitGroup
+	var batchNum int64
+
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for result := range records {
+				myBatch := int(atomic.AddInt64(&batchNum, 1))
+				if result.Err != nil {
+					results <- writeResult{batchNum: myBatch, err: result.Err}
+					return
+				}
+
+				record := result.Batch
+				if record == nil {
+					continue
+				}
+
+				startBatch := time.Now()
+				rows, err := d.writeRecordBatch(ctx, record, opts.Table)
+				record.Release()
+
+				results <- writeResult{
+					batchNum: myBatch,
+					rows:     rows,
+					duration: time.Since(startBatch),
+					err:      err,
+				}
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
 	var totalRows int64
-	var batchNum int
-
-	config.Debug("[MYSQL] Starting write to %s", opts.Table)
-
-	for result := range records {
-		if result.Err != nil {
-			return result.Err
+	var firstErr error
+	for res := range results {
+		if res.err != nil {
+			if firstErr == nil {
+				firstErr = res.err
+			}
+			config.Debug("[MYSQL] Worker error on batch %d: %v", res.batchNum, res.err)
+			continue
 		}
 
-		batchNum++
-		startBatch := time.Now()
-
-		rows, err := d.writeRecordBatch(ctx, result.Batch, opts.Table)
-		if err != nil {
-			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
-		}
-
-		totalRows += rows
-		rate := float64(rows) / time.Since(startBatch).Seconds()
+		totalRows += res.rows
+		rate := float64(res.rows) / res.duration.Seconds()
 		config.Debug("[MYSQL] Batch %d: %d rows in %v (%.0f rows/sec, total: %d)",
-			batchNum, rows, time.Since(startBatch), rate, totalRows)
+			res.batchNum, res.rows, res.duration, rate, totalRows)
+	}
 
-		result.Batch.Release()
+	if firstErr != nil {
+		return fmt.Errorf("parallel write failed: %w", firstErr)
 	}
 
 	totalRate := float64(totalRows) / time.Since(startTime).Seconds()
@@ -273,7 +365,32 @@ func (d *MySQLDestination) WriteParallel(ctx context.Context, records <-chan sou
 	return nil
 }
 
+func mysqlWriteParallelism(requested int) int {
+	if requested <= 0 {
+		return mysqlDefaultWriteParallelism
+	}
+	if requested > mysqlMaxWriteParallelism {
+		return mysqlMaxWriteParallelism
+	}
+	return requested
+}
+
 func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+	if d.useLoadData {
+		rows, err := d.writeRecordBatchLoadData(ctx, record, table)
+		if err == nil {
+			return rows, nil
+		}
+		if isLoadDataLocalDisabledError(err) {
+			output.Warnf("[WARNING] MySQL LOAD DATA LOCAL INFILE is unavailable (%v); falling back to multi-row INSERT for this batch\n", err)
+			return d.writeRecordBatchInsert(ctx, record, table)
+		}
+		return rows, err
+	}
+	return d.writeRecordBatchInsert(ctx, record, table)
+}
+
+func (d *MySQLDestination) writeRecordBatchInsert(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
 	numRows := record.NumRows()
 	numCols := int(record.NumCols())
 
@@ -282,42 +399,34 @@ func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.Re
 	}
 
 	colNames := make([]string, numCols)
-	placeholders := make([]string, numCols)
 	for i := 0; i < numCols; i++ {
 		colNames[i] = quoteColumn(record.Schema().Field(i).Name)
-		placeholders[i] = "?"
 	}
-
-	insertSQL := fmt.Sprintf(
-		"INSERT INTO %s (%s) VALUES (%s)",
-		quoteTable(table),
-		strings.Join(colNames, ", "),
-		strings.Join(placeholders, ", "),
-	)
 
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	stmt, err := tx.PrepareContext(ctx, insertSQL)
-	if err != nil {
-		_ = tx.Rollback()
-		return 0, fmt.Errorf("failed to prepare statement: %w", err)
-	}
-	defer func() { _ = stmt.Close() }()
+	rowsWritten := int64(0)
+	for start := int64(0); start < numRows; start += mysqlInsertRowsPerStatement {
+		end := min(start+mysqlInsertRowsPerStatement, numRows)
+		chunkRows := int(end - start)
+		insertSQL := buildMultiRowInsertSQL(table, colNames, chunkRows)
 
-	for rowIdx := int64(0); rowIdx < numRows; rowIdx++ {
-		values := make([]interface{}, numCols)
-		for colIdx := 0; colIdx < numCols; colIdx++ {
-			values[colIdx] = extractValue(record.Column(colIdx), int(rowIdx))
+		values := make([]interface{}, 0, chunkRows*numCols)
+		for rowIdx := start; rowIdx < end; rowIdx++ {
+			for colIdx := 0; colIdx < numCols; colIdx++ {
+				values = append(values, extractValue(record.Column(colIdx), int(rowIdx)))
+			}
 		}
 
-		if _, err := stmt.ExecContext(ctx, values...); err != nil {
+		if _, err := tx.ExecContext(ctx, insertSQL, values...); err != nil {
 			config.LogFailedQuery(insertSQL, err)
 			_ = tx.Rollback()
-			return rowIdx, fmt.Errorf("failed to insert row %d: %w", rowIdx, err)
+			return rowsWritten, fmt.Errorf("failed to insert rows %d-%d: %w", start, end-1, err)
 		}
+		rowsWritten += int64(chunkRows)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -325,6 +434,197 @@ func (d *MySQLDestination) writeRecordBatch(ctx context.Context, record arrow.Re
 	}
 
 	return numRows, nil
+}
+
+func (d *MySQLDestination) writeRecordBatchLoadData(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+	numRows := record.NumRows()
+	numCols := int(record.NumCols())
+
+	if numRows == 0 {
+		return 0, nil
+	}
+
+	colNames := make([]string, numCols)
+	for i := 0; i < numCols; i++ {
+		colNames[i] = quoteColumn(record.Schema().Field(i).Name)
+	}
+
+	handlerName := fmt.Sprintf("ingestr_load_%d", atomic.AddUint64(&mysqlLoadDataReaderID, 1))
+	mysqldriver.RegisterReaderHandler(handlerName, func() io.Reader {
+		return newLoadDataRecordReader(record)
+	})
+	defer mysqldriver.DeregisterReaderHandler(handlerName)
+
+	loadSQL := buildLoadDataSQL(table, colNames, handlerName)
+	if _, err := d.db.ExecContext(ctx, loadSQL); err != nil {
+		config.LogFailedQuery(loadSQL, err)
+		return 0, fmt.Errorf("failed to load rows with LOAD DATA LOCAL INFILE: %w", err)
+	}
+
+	return numRows, nil
+}
+
+func buildMultiRowInsertSQL(table string, colNames []string, rows int) string {
+	placeholders := make([]string, len(colNames))
+	for i := range colNames {
+		placeholders[i] = "?"
+	}
+	rowPlaceholder := "(" + strings.Join(placeholders, ", ") + ")"
+
+	rowPlaceholders := make([]string, rows)
+	for i := range rowPlaceholders {
+		rowPlaceholders[i] = rowPlaceholder
+	}
+
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES %s",
+		quoteTable(table),
+		strings.Join(colNames, ", "),
+		strings.Join(rowPlaceholders, ", "),
+	)
+}
+
+func buildLoadDataSQL(table string, colNames []string, handlerName string) string {
+	return fmt.Sprintf(
+		"LOAD DATA LOCAL INFILE %s INTO TABLE %s FIELDS TERMINATED BY '\\t' ESCAPED BY '\\\\' LINES TERMINATED BY '\\n' (%s)",
+		quoteStringLiteral("Reader::"+handlerName),
+		quoteTable(table),
+		strings.Join(colNames, ", "),
+	)
+}
+
+func quoteStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+func newLoadDataRecordReader(record arrow.RecordBatch) io.Reader {
+	reader, writer := io.Pipe()
+	go func() {
+		buf := bufio.NewWriter(writer)
+		err := writeRecordBatchTSV(buf, record)
+		if flushErr := buf.Flush(); err == nil {
+			err = flushErr
+		}
+		_ = writer.CloseWithError(err)
+	}()
+	return reader
+}
+
+func writeRecordBatchTSV(w io.Writer, record arrow.RecordBatch) error {
+	numRows := record.NumRows()
+	numCols := int(record.NumCols())
+
+	for rowIdx := int64(0); rowIdx < numRows; rowIdx++ {
+		for colIdx := 0; colIdx < numCols; colIdx++ {
+			if colIdx > 0 {
+				if _, err := io.WriteString(w, "\t"); err != nil {
+					return err
+				}
+			}
+			if err := writeLoadDataField(w, extractValue(record.Column(colIdx), int(rowIdx))); err != nil {
+				return err
+			}
+		}
+		if _, err := io.WriteString(w, "\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeLoadDataField(w io.Writer, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		_, err := io.WriteString(w, `\N`)
+		return err
+	case []byte:
+		return writeEscapedLoadDataBytes(w, v)
+	case string:
+		return writeEscapedLoadDataString(w, v)
+	case int:
+		_, err := io.WriteString(w, strconv.Itoa(v))
+		return err
+	case int8:
+		_, err := io.WriteString(w, strconv.FormatInt(int64(v), 10))
+		return err
+	case int16:
+		_, err := io.WriteString(w, strconv.FormatInt(int64(v), 10))
+		return err
+	case int32:
+		_, err := io.WriteString(w, strconv.FormatInt(int64(v), 10))
+		return err
+	case int64:
+		_, err := io.WriteString(w, strconv.FormatInt(v, 10))
+		return err
+	case uint:
+		_, err := io.WriteString(w, strconv.FormatUint(uint64(v), 10))
+		return err
+	case uint8:
+		_, err := io.WriteString(w, strconv.FormatUint(uint64(v), 10))
+		return err
+	case uint16:
+		_, err := io.WriteString(w, strconv.FormatUint(uint64(v), 10))
+		return err
+	case uint32:
+		_, err := io.WriteString(w, strconv.FormatUint(uint64(v), 10))
+		return err
+	case uint64:
+		_, err := io.WriteString(w, strconv.FormatUint(v, 10))
+		return err
+	case float32:
+		_, err := io.WriteString(w, strconv.FormatFloat(float64(v), 'g', -1, 32))
+		return err
+	case float64:
+		_, err := io.WriteString(w, strconv.FormatFloat(v, 'g', -1, 64))
+		return err
+	case time.Time:
+		return writeEscapedLoadDataString(w, v.Format("2006-01-02 15:04:05.000000"))
+	default:
+		return writeEscapedLoadDataString(w, fmt.Sprintf("%v", v))
+	}
+}
+
+func writeEscapedLoadDataString(w io.Writer, value string) error {
+	return writeEscapedLoadDataBytes(w, []byte(value))
+}
+
+func writeEscapedLoadDataBytes(w io.Writer, value []byte) error {
+	for _, b := range value {
+		var s string
+		switch b {
+		case 0:
+			s = `\0`
+		case '\t':
+			s = `\t`
+		case '\n':
+			s = `\n`
+		case '\r':
+			s = `\r`
+		case '\\':
+			s = `\\`
+		case 26:
+			s = `\Z`
+		default:
+			if _, err := w.Write([]byte{b}); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := io.WriteString(w, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isLoadDataLocalDisabledError(err error) bool {
+	var myErr *mysqldriver.MySQLError
+	if errors.As(err, &myErr) && myErr.Number == 3948 {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "loading local data is disabled") ||
+		strings.Contains(msg, "local infile") && strings.Contains(msg, "disabled")
 }
 
 func (d *MySQLDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
@@ -778,7 +1078,12 @@ func isMySQLMissingTableError(err error) bool {
 	return strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "does not exist")
 }
 
-func (d *MySQLDestination) GetScheme() string { return "mysql" }
+func (d *MySQLDestination) GetScheme() string {
+	if d.scheme != "" {
+		return d.scheme
+	}
+	return "mysql"
+}
 
 func (d *MySQLDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	database, tableName := splitDatabaseTable(table)

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -499,13 +499,6 @@ func TestMySQLDestination_Schemes(t *testing.T) {
 	assert.Equal(t, expected, schemes)
 }
 
-func TestVitessDestination_Schemes(t *testing.T) {
-	dest := NewVitessDestination()
-	schemes := dest.Schemes()
-	expected := []string{"vitess", "ps_mysql"}
-	assert.Equal(t, expected, schemes)
-}
-
 func TestMySQLDestination_StrategySupport(t *testing.T) {
 	dest := NewMySQLDestination()
 

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -352,6 +353,12 @@ func TestMySQLWriteParallelism(t *testing.T) {
 	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(-1))
 	assert.Equal(t, 2, mysqlWriteParallelism(2))
 	assert.Equal(t, mysqlMaxWriteParallelism, mysqlWriteParallelism(mysqlMaxWriteParallelism+1))
+}
+
+func TestMySQLWriteParallelismForOptions(t *testing.T) {
+	assert.Equal(t, 1, mysqlWriteParallelismForOptions(destination.WriteOptions{}))
+	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelismForOptions(destination.WriteOptions{StagingTable: true}))
+	assert.Equal(t, 2, mysqlWriteParallelismForOptions(destination.WriteOptions{StagingTable: true, Parallelism: 2}))
 }
 
 // isMySQLMissingTableError must recognize both plain MySQL ("doesn't exist",

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -304,6 +304,12 @@ func TestBuildLoadDataSQL(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestMapDataTypeToMySQLStringLength(t *testing.T) {
+	assert.Equal(t, "VARCHAR(16383)", MapDataTypeToMySQL(schema.Column{DataType: schema.TypeString, MaxLength: 16383}))
+	assert.Equal(t, "TEXT", MapDataTypeToMySQL(schema.Column{DataType: schema.TypeString, MaxLength: 16384}))
+	assert.Equal(t, "TEXT", MapDataTypeToMySQL(schema.Column{DataType: schema.TypeString, MaxLength: 65535}))
+}
+
 func TestWriteLoadDataFieldEscaping(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -346,19 +345,6 @@ func TestIsLoadDataLocalDisabledError(t *testing.T) {
 			assert.Equal(t, tt.want, isLoadDataLocalDisabledError(tt.err))
 		})
 	}
-}
-
-func TestMySQLWriteParallelism(t *testing.T) {
-	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(0))
-	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(-1))
-	assert.Equal(t, 2, mysqlWriteParallelism(2))
-	assert.Equal(t, mysqlMaxWriteParallelism, mysqlWriteParallelism(mysqlMaxWriteParallelism+1))
-}
-
-func TestMySQLWriteParallelismForOptions(t *testing.T) {
-	assert.Equal(t, 1, mysqlWriteParallelismForOptions(destination.WriteOptions{}))
-	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelismForOptions(destination.WriteOptions{StagingTable: true}))
-	assert.Equal(t, 2, mysqlWriteParallelismForOptions(destination.WriteOptions{StagingTable: true, Parallelism: 2}))
 }
 
 // isMySQLMissingTableError must recognize both plain MySQL ("doesn't exist",

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -291,6 +292,47 @@ func TestBuildUpdateSet(t *testing.T) {
 	}
 }
 
+func TestBuildMultiRowInsertSQL(t *testing.T) {
+	got := buildMultiRowInsertSQL("analytics.users", []string{"`id`", "`name`"}, 3)
+	want := "INSERT INTO `analytics`.`users` (`id`, `name`) VALUES (?, ?), (?, ?), (?, ?)"
+	assert.Equal(t, want, got)
+}
+
+func TestBuildLoadDataSQL(t *testing.T) {
+	got := buildLoadDataSQL("analytics.users", []string{"`id`", "`name`"}, "ingestr_load_1")
+	want := "LOAD DATA LOCAL INFILE 'Reader::ingestr_load_1' INTO TABLE `analytics`.`users` FIELDS TERMINATED BY '\\t' ESCAPED BY '\\\\' LINES TERMINATED BY '\\n' (`id`, `name`)"
+	assert.Equal(t, want, got)
+}
+
+func TestWriteLoadDataFieldEscaping(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{name: "null", value: nil, want: `\N`},
+		{name: "string escapes", value: "a\tb\nc\rd\\e\x00\x1a", want: `a\tb\nc\rd\\e\0\Z`},
+		{name: "bytes escapes", value: []byte("bytes\tvalue"), want: `bytes\tvalue`},
+		{name: "integer", value: int64(42), want: "42"},
+		{name: "float", value: 12.5, want: "12.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got strings.Builder
+			assert.NoError(t, writeLoadDataField(&got, tt.value))
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestMySQLWriteParallelism(t *testing.T) {
+	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(0))
+	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(-1))
+	assert.Equal(t, 2, mysqlWriteParallelism(2))
+	assert.Equal(t, mysqlMaxWriteParallelism, mysqlWriteParallelism(mysqlMaxWriteParallelism+1))
+}
+
 // isMySQLMissingTableError must recognize both plain MySQL ("doesn't exist",
 // errno 1146) and vtgate (VT05004/VT05005 "does not exist", errno 1146/1051)
 // forms, so a first CDC run against a Vitess/PlanetScale destination is treated
@@ -432,7 +474,14 @@ func TestBuildCreateTableSQL(t *testing.T) {
 func TestMySQLDestination_Schemes(t *testing.T) {
 	dest := NewMySQLDestination()
 	schemes := dest.Schemes()
-	expected := []string{"mysql", "mysql+pymysql", "mariadb", "vitess", "ps_mysql"}
+	expected := []string{"mysql", "mysql+pymysql", "mariadb"}
+	assert.Equal(t, expected, schemes)
+}
+
+func TestVitessDestination_Schemes(t *testing.T) {
+	dest := NewVitessDestination()
+	schemes := dest.Schemes()
+	expected := []string{"vitess", "ps_mysql"}
 	assert.Equal(t, expected, schemes)
 }
 

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -326,6 +326,27 @@ func TestWriteLoadDataFieldEscaping(t *testing.T) {
 	}
 }
 
+func TestIsLoadDataLocalDisabledError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"mysql 3948", &mysqldriver.MySQLError{Number: 3948, Message: "Loading local data is disabled"}, true},
+		{"mysql 1148", &mysqldriver.MySQLError{Number: 1148, Message: "The used command is not allowed with this MySQL version"}, true},
+		{"text disabled", errors.New("loading local data is disabled; enable local_infile"), true},
+		{"text not allowed", errors.New("The used command is not allowed with this MySQL version"), true},
+		{"other mysql error", &mysqldriver.MySQLError{Number: 1062, Message: "Duplicate entry"}, false},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isLoadDataLocalDisabledError(tt.err))
+		})
+	}
+}
+
 func TestMySQLWriteParallelism(t *testing.T) {
 	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(0))
 	assert.Equal(t, mysqlDefaultWriteParallelism, mysqlWriteParallelism(-1))

--- a/pkg/destination/mysql/register.go
+++ b/pkg/destination/mysql/register.go
@@ -4,7 +4,11 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterDestination(
-		[]string{"mysql", "mysql+pymysql", "mariadb", "vitess", "ps_mysql"},
+		[]string{"mysql", "mysql+pymysql", "mariadb"},
 		func() interface{} { return NewMySQLDestination() },
+	)
+	registry.RegisterDestination(
+		[]string{"vitess", "ps_mysql"},
+		func() interface{} { return NewVitessDestination() },
 	)
 }

--- a/pkg/destination/mysql/register.go
+++ b/pkg/destination/mysql/register.go
@@ -7,8 +7,4 @@ func init() {
 		[]string{"mysql", "mysql+pymysql", "mariadb"},
 		func() interface{} { return NewMySQLDestination() },
 	)
-	registry.RegisterDestination(
-		[]string{"vitess", "ps_mysql"},
-		func() interface{} { return NewVitessDestination() },
-	)
 }

--- a/pkg/destination/planetscale/planetscale.go
+++ b/pkg/destination/planetscale/planetscale.go
@@ -1,0 +1,17 @@
+package planetscale
+
+import "github.com/bruin-data/ingestr/pkg/destination/mysql"
+
+type Destination struct {
+	*mysql.MySQLDestination
+}
+
+func NewDestination() *Destination {
+	return &Destination{
+		MySQLDestination: mysql.NewVitessCompatibleDestination("ps_mysql"),
+	}
+}
+
+func (d *Destination) Schemes() []string {
+	return []string{"ps_mysql"}
+}

--- a/pkg/destination/planetscale/planetscale_test.go
+++ b/pkg/destination/planetscale/planetscale_test.go
@@ -1,0 +1,19 @@
+package planetscale
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDestinationImplementsDestination(t *testing.T) {
+	var _ destination.Destination = NewDestination()
+}
+
+func TestDestinationSchemes(t *testing.T) {
+	dest := NewDestination()
+
+	assert.Equal(t, []string{"ps_mysql"}, dest.Schemes())
+	assert.Equal(t, "ps_mysql", dest.GetScheme())
+}

--- a/pkg/destination/planetscale/register.go
+++ b/pkg/destination/planetscale/register.go
@@ -1,0 +1,10 @@
+package planetscale
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"ps_mysql"},
+		func() interface{} { return NewDestination() },
+	)
+}

--- a/pkg/destination/vitess/register.go
+++ b/pkg/destination/vitess/register.go
@@ -1,0 +1,10 @@
+package vitess
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"vitess"},
+		func() interface{} { return NewDestination() },
+	)
+}

--- a/pkg/destination/vitess/vitess.go
+++ b/pkg/destination/vitess/vitess.go
@@ -1,0 +1,17 @@
+package vitess
+
+import "github.com/bruin-data/ingestr/pkg/destination/mysql"
+
+type Destination struct {
+	*mysql.MySQLDestination
+}
+
+func NewDestination() *Destination {
+	return &Destination{
+		MySQLDestination: mysql.NewVitessCompatibleDestination("vitess"),
+	}
+}
+
+func (d *Destination) Schemes() []string {
+	return []string{"vitess"}
+}

--- a/pkg/destination/vitess/vitess_test.go
+++ b/pkg/destination/vitess/vitess_test.go
@@ -1,0 +1,19 @@
+package vitess
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDestinationImplementsDestination(t *testing.T) {
+	var _ destination.Destination = NewDestination()
+}
+
+func TestDestinationSchemes(t *testing.T) {
+	dest := NewDestination()
+
+	assert.Equal(t, []string{"vitess"}, dest.Schemes())
+	assert.Equal(t, "vitess", dest.GetScheme())
+}


### PR DESCRIPTION
Splits Vitess/PlanetScale destination registration from regular MySQL/MariaDB so standard MySQL can use LOAD DATA LOCAL INFILE while ps_mysql/vitess keep chunked parallel INSERT.
Adds streaming reader handling and fallback to multi-row INSERT when local infile is disabled, plus tests for scheme split and load-data escaping.
Validated with make format, make lint, make test, and 100k-row local MySQL/PlanetScale benchmarks.