### PR TITLE
Preserve Snowflake decimal metadata

### DIFF
--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -911,11 +912,9 @@ func (d *SnowflakeDestination) GetTableSchema(ctx context.Context, table string)
 			return nil, fmt.Errorf("failed to scan column: %w", err)
 		}
 
-		col := schema.Column{
-			Name:     colName,
-			DataType: mapSnowflakeTypeToSchema(dataType),
-			Nullable: isNullable == "Y",
-		}
+		col := mapSnowflakeTypeToColumn(dataType)
+		col.Name = colName
+		col.Nullable = isNullable == "Y"
 
 		columns = append(columns, col)
 	}
@@ -935,48 +934,85 @@ func (d *SnowflakeDestination) GetTableSchema(ctx context.Context, table string)
 	}, nil
 }
 
-func mapSnowflakeTypeToSchema(dataType string) schema.DataType {
-	dataType = strings.ToUpper(dataType)
+func mapSnowflakeTypeToColumn(dataType string) schema.Column {
+	dataType = strings.ToUpper(strings.TrimSpace(dataType))
 
 	if strings.HasPrefix(dataType, "NUMBER") || strings.HasPrefix(dataType, "DECIMAL") || strings.HasPrefix(dataType, "NUMERIC") {
-		return schema.TypeDecimal
+		col := schema.Column{DataType: schema.TypeDecimal}
+		params := parseSnowflakeTypeParams(dataType)
+		if len(params) > 0 {
+			col.Precision = params[0]
+		}
+		if len(params) > 1 {
+			col.Scale = params[1]
+		}
+		return col
 	}
-	if strings.HasPrefix(dataType, "VARCHAR") || strings.HasPrefix(dataType, "TEXT") {
-		return schema.TypeString
+	if strings.HasPrefix(dataType, "VARCHAR") || strings.HasPrefix(dataType, "TEXT") || strings.HasPrefix(dataType, "STRING") || strings.HasPrefix(dataType, "CHAR") {
+		col := schema.Column{DataType: schema.TypeString}
+		params := parseSnowflakeTypeParams(dataType)
+		if len(params) > 0 {
+			col.MaxLength = params[0]
+		}
+		return col
 	}
 	if strings.HasPrefix(dataType, "TIMESTAMP_NTZ") {
-		return schema.TypeTimestamp
+		return schema.Column{DataType: schema.TypeTimestamp}
 	}
 	if strings.HasPrefix(dataType, "TIMESTAMP_TZ") || strings.HasPrefix(dataType, "TIMESTAMP_LTZ") {
-		return schema.TypeTimestampTZ
+		return schema.Column{DataType: schema.TypeTimestampTZ}
+	}
+	if strings.HasPrefix(dataType, "TIME") {
+		return schema.Column{DataType: schema.TypeTime}
+	}
+	if strings.HasPrefix(dataType, "BINARY") || strings.HasPrefix(dataType, "VARBINARY") {
+		return schema.Column{DataType: schema.TypeBinary}
 	}
 
 	switch dataType {
 	case "BOOLEAN":
-		return schema.TypeBoolean
+		return schema.Column{DataType: schema.TypeBoolean}
 	case "SMALLINT":
-		return schema.TypeInt16
+		return schema.Column{DataType: schema.TypeInt16}
 	case "INTEGER", "INT":
-		return schema.TypeInt32
+		return schema.Column{DataType: schema.TypeInt32}
 	case "BIGINT":
-		return schema.TypeInt64
+		return schema.Column{DataType: schema.TypeInt64}
 	case "FLOAT", "FLOAT4", "FLOAT8":
-		return schema.TypeFloat64
+		return schema.Column{DataType: schema.TypeFloat64}
 	case "DOUBLE", "DOUBLE PRECISION", "REAL":
-		return schema.TypeFloat64
-	case "BINARY", "VARBINARY":
-		return schema.TypeBinary
+		return schema.Column{DataType: schema.TypeFloat64}
 	case "DATE":
-		return schema.TypeDate
-	case "TIME":
-		return schema.TypeTime
+		return schema.Column{DataType: schema.TypeDate}
 	case "VARIANT", "OBJECT":
-		return schema.TypeJSON
+		return schema.Column{DataType: schema.TypeJSON}
 	case "ARRAY":
-		return schema.TypeArray
+		return schema.Column{DataType: schema.TypeArray}
 	default:
-		return schema.TypeString
+		return schema.Column{DataType: schema.TypeString}
 	}
+}
+
+func parseSnowflakeTypeParams(dataType string) []int {
+	start := strings.IndexByte(dataType, '(')
+	if start == -1 {
+		return nil
+	}
+	end := strings.IndexByte(dataType[start+1:], ')')
+	if end == -1 {
+		return nil
+	}
+
+	rawParams := strings.Split(dataType[start+1:start+1+end], ",")
+	params := make([]int, 0, len(rawParams))
+	for _, raw := range rawParams {
+		value, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil {
+			return params
+		}
+		params = append(params, value)
+	}
+	return params
 }
 
 // sfTable parses a possibly database-qualified Snowflake table name

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -938,7 +938,7 @@ func mapSnowflakeTypeToColumn(dataType string) schema.Column {
 	dataType = strings.ToUpper(strings.TrimSpace(dataType))
 
 	if strings.HasPrefix(dataType, "NUMBER") || strings.HasPrefix(dataType, "DECIMAL") || strings.HasPrefix(dataType, "NUMERIC") {
-		col := schema.Column{DataType: schema.TypeDecimal}
+		col := schema.Column{DataType: schema.TypeDecimal, Precision: 38}
 		params := parseSnowflakeTypeParams(dataType)
 		if len(params) > 0 {
 			col.Precision = params[0]

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -15,6 +15,7 @@ import (
 	pqfile "github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	pqschema "github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/bruin-data/ingestr/pkg/databuffer"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -273,6 +274,96 @@ func TestSnowflakeParquetWriterTimestampLogicalTypes(t *testing.T) {
 	require.True(t, ok, "synced_at logical type = %T", syncedAt.LogicalType())
 	assert.Equal(t, pqschema.TimeUnitMicros, syncedAtLogical.TimeUnit())
 	assert.True(t, syncedAtLogical.IsAdjustedToUTC())
+}
+
+func TestGetTableSchemaPreservesSnowflakeTypeMetadata(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows([]string{"name", "type", "null?"}).
+		AddRow("ID", "NUMBER(38,0)", "N").
+		AddRow("BUDGET", "NUMBER(20,2)", "Y").
+		AddRow("NAME", "VARCHAR(255)", "Y")
+	mock.ExpectQuery("DESCRIBE TABLE").WillReturnRows(rows)
+
+	dest := &SnowflakeDestination{db: db}
+	got, err := dest.GetTableSchema(context.Background(), "public.campaigns")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Columns, 3)
+
+	assert.Equal(t, schema.TypeDecimal, got.Columns[0].DataType)
+	assert.Equal(t, 38, got.Columns[0].Precision)
+	assert.Equal(t, 0, got.Columns[0].Scale)
+	assert.False(t, got.Columns[0].Nullable)
+
+	assert.Equal(t, schema.TypeDecimal, got.Columns[1].DataType)
+	assert.Equal(t, 20, got.Columns[1].Precision)
+	assert.Equal(t, 2, got.Columns[1].Scale)
+	assert.True(t, got.Columns[1].Nullable)
+
+	assert.Equal(t, schema.TypeString, got.Columns[2].DataType)
+	assert.Equal(t, 255, got.Columns[2].MaxLength)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMapSnowflakeTypeToColumn(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantType  schema.DataType
+		precision int
+		scale     int
+		maxLength int
+	}{
+		{name: "number_with_precision_scale", input: "NUMBER(20,2)", wantType: schema.TypeDecimal, precision: 20, scale: 2},
+		{name: "decimal_with_precision_only", input: "DECIMAL(18)", wantType: schema.TypeDecimal, precision: 18},
+		{name: "numeric_with_spaces", input: "NUMERIC( 12, 4 )", wantType: schema.TypeDecimal, precision: 12, scale: 4},
+		{name: "varchar_length", input: "VARCHAR(1024)", wantType: schema.TypeString, maxLength: 1024},
+		{name: "timestamp_precision", input: "TIMESTAMP_NTZ(9)", wantType: schema.TypeTimestamp},
+		{name: "timestamp_tz_precision", input: "TIMESTAMP_TZ(9)", wantType: schema.TypeTimestampTZ},
+		{name: "time_precision", input: "TIME(9)", wantType: schema.TypeTime},
+		{name: "binary_length", input: "BINARY(8388608)", wantType: schema.TypeBinary},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSnowflakeTypeToColumn(tt.input)
+			assert.Equal(t, tt.wantType, got.DataType)
+			assert.Equal(t, tt.precision, got.Precision)
+			assert.Equal(t, tt.scale, got.Scale)
+			assert.Equal(t, tt.maxLength, got.MaxLength)
+		})
+	}
+}
+
+func TestEmptyDecimalBatchAlignsToSnowflakeDescribedScale(t *testing.T) {
+	decimalType := &arrow.Decimal128Type{Precision: 20, Scale: 2}
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "BUDGET", Type: decimalType, Nullable: true},
+	}, nil)
+
+	builder := array.NewDecimal128Builder(memory.DefaultAllocator, decimalType)
+	decimalArray := builder.NewArray()
+	builder.Release()
+
+	record := array.NewRecordBatch(arrowSchema, []arrow.Array{decimalArray}, 0)
+	decimalArray.Release()
+	defer record.Release()
+
+	targetCol := mapSnowflakeTypeToColumn("NUMBER(20,2)")
+	targetCol.Name = "BUDGET"
+	targetCol.Nullable = true
+	targetSchema := (&schema.TableSchema{Columns: []schema.Column{targetCol}}).ToArrowSchema()
+
+	got, err := databuffer.CastRecordToSchema(record, targetSchema, true)
+	require.NoError(t, err)
+	defer got.Release()
+
+	assert.Equal(t, int64(0), got.NumRows())
+	assert.True(t, got.Schema().Equal(targetSchema))
 }
 
 func TestMapDataTypeToSnowflake(t *testing.T) {

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -318,6 +318,7 @@ func TestMapSnowflakeTypeToColumn(t *testing.T) {
 		scale     int
 		maxLength int
 	}{
+		{name: "bare_number", input: "NUMBER", wantType: schema.TypeDecimal, precision: 38},
 		{name: "number_with_precision_scale", input: "NUMBER(20,2)", wantType: schema.TypeDecimal, precision: 20, scale: 2},
 		{name: "decimal_with_precision_only", input: "DECIMAL(18)", wantType: schema.TypeDecimal, precision: 18},
 		{name: "numeric_with_spaces", input: "NUMERIC( 12, 4 )", wantType: schema.TypeDecimal, precision: 12, scale: 4},


### PR DESCRIPTION
Fixes #938.

Snowflake schema introspection now preserves decimal precision/scale and varchar length so merge reruns do not align NUMBER(20,2) to decimal(38,0).

Tests: make format && make lint && make test