### PR TITLE
Reduce BigQuery merge costs with default primary key clustering

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -486,6 +486,39 @@ func mergePartitionPruningDeclarations(stagingRef string, pruning *mergePartitio
 	)
 }
 
+// nonNullablePKColumns returns the lower-cased primary key columns guaranteed
+// non-NULL on at least one side of the merge join — REQUIRED in the target
+// table, or NOT NULL in the ingestion schema (so staging holds no NULL keys).
+// For these a bare equality join is equivalent to the null-safe one.
+func nonNullablePKColumns(targetMeta *bigquery.TableMetadata, tableSchema *schema.TableSchema, primaryKeys []string) map[string]bool {
+	nonNullable := make(map[string]bool)
+	if targetMeta != nil {
+		for _, f := range targetMeta.Schema {
+			if f.Required {
+				nonNullable[strings.ToLower(f.Name)] = true
+			}
+		}
+	}
+	if tableSchema != nil {
+		for _, col := range tableSchema.Columns {
+			if !col.Nullable {
+				nonNullable[strings.ToLower(col.Name)] = true
+			}
+		}
+	}
+
+	result := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		if nonNullable[strings.ToLower(pk)] {
+			result[strings.ToLower(pk)] = true
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
 func mergePartitionTargetPredicate(pruning *mergePartitionPruning) string {
 	if pruning == nil {
 		return ""
@@ -1465,6 +1498,8 @@ func (d *BigQueryDestination) MergeTable(ctx context.Context, opts destination.M
 	// Fetch target and staging table schemas to detect type mismatches
 	castMap := d.buildCastMap(ctx, project, targetDataset, targetTableName, stagingDataset, stagingTableName)
 
+	nonNullablePKs := nonNullablePKColumns(targetMeta, opts.Schema, opts.PrimaryKeys)
+
 	pruning := buildMergePartitionPruning(targetMeta, opts.PrimaryKeys)
 	pruningSkipReason := ""
 	if pruning != nil && hasCastForColumn(castMap, pruning.Column) {
@@ -1485,7 +1520,7 @@ func (d *BigQueryDestination) MergeTable(ctx context.Context, opts destination.M
 	}
 
 	// Build MERGE statement
-	mergeSQL := d.buildMergeSQLWithPartitionPruning(project, targetDataset, targetTableName, stagingDataset, stagingTableName, opts.PrimaryKeys, opts.Columns, castMap, opts.IncrementalKey, pruning)
+	mergeSQL := d.buildMergeSQLWithPartitionPruning(project, targetDataset, targetTableName, stagingDataset, stagingTableName, opts.PrimaryKeys, opts.Columns, castMap, opts.IncrementalKey, nonNullablePKs, pruning)
 
 	config.Debug("[MERGE] Executing MERGE statement")
 	config.Debug("[MERGE] SQL: %s", mergeSQL)
@@ -1811,15 +1846,21 @@ func buildBigQueryDedupSelect(qualifiedTable string, primaryKeys []string, order
 
 // buildMergeSQL constructs a BigQuery MERGE statement
 func (d *BigQueryDestination) buildMergeSQL(project, targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string, incrementalKey string) string {
-	return d.buildMergeSQLWithPartitionPruning(project, targetDataset, targetTable, stagingDataset, stagingTable, primaryKeys, allColumns, castMap, incrementalKey, nil)
+	return d.buildMergeSQLWithPartitionPruning(project, targetDataset, targetTable, stagingDataset, stagingTable, primaryKeys, allColumns, castMap, incrementalKey, nil, nil)
 }
 
-func (d *BigQueryDestination) buildMergeSQLWithPartitionPruning(project, targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string, incrementalKey string, pruning *mergePartitionPruning) string {
+func (d *BigQueryDestination) buildMergeSQLWithPartitionPruning(project, targetDataset, targetTable, stagingDataset, stagingTable string, primaryKeys, allColumns []string, castMap map[string]string, incrementalKey string, nonNullablePKs map[string]bool, pruning *mergePartitionPruning) string {
 	destColumns := destination.DestinationColumns(allColumns)
 	onConditions := make([]string, len(primaryKeys))
 	for i, pk := range primaryKeys {
 		sourceCol := castSourceCol(pk, castMap)
-		onConditions[i] = fmt.Sprintf("(t.%s = %s OR (t.%s IS NULL AND %s IS NULL))", quoteIdentifier(pk), sourceCol, quoteIdentifier(pk), sourceCol)
+		// The null-safe OR disables clustered block pruning, so use bare
+		// equality when either join side is provably never NULL.
+		if nonNullablePKs[strings.ToLower(pk)] {
+			onConditions[i] = fmt.Sprintf("t.%s = %s", quoteIdentifier(pk), sourceCol)
+		} else {
+			onConditions[i] = fmt.Sprintf("(t.%s = %s OR (t.%s IS NULL AND %s IS NULL))", quoteIdentifier(pk), sourceCol, quoteIdentifier(pk), sourceCol)
+		}
 	}
 	if partitionPredicate := mergePartitionTargetPredicate(pruning); partitionPredicate != "" {
 		onConditions = append(onConditions, partitionPredicate)

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -1556,11 +1556,18 @@ func TestBuildMergeSQL(t *testing.T) {
 			map[string]bool{"id": true}, nil,
 		)
 
-		if !contains(sql, "ON t.`id` = s.`id`\n") {
-			t.Fatalf("sql missing bare equality on clause for required pk:\n%s", sql)
-		}
-		if contains(sql, "IS NULL") {
-			t.Fatalf("sql should not include null-safe join for required pk:\n%s", sql)
+		want := strings.Join([]string{
+			"MERGE `my-project`.`target_ds`.`target_tbl` AS t",
+			"USING (SELECT * FROM `my-project`.`staging_ds`.`staging_tbl` QUALIFY ROW_NUMBER() OVER (PARTITION BY `id`) = 1) AS s",
+			"ON t.`id` = s.`id`",
+			"WHEN MATCHED THEN",
+			"  UPDATE SET t.`name` = s.`name`",
+			"WHEN NOT MATCHED THEN",
+			"  INSERT (`id`, `name`)",
+			"  VALUES (s.`id`, s.`name`)",
+		}, "\n")
+		if sql != want {
+			t.Fatalf("unexpected merge SQL:\ngot:\n%s\n\nwant:\n%s", sql, want)
 		}
 	})
 
@@ -1571,9 +1578,18 @@ func TestBuildMergeSQL(t *testing.T) {
 			map[string]bool{"tenant_id": true}, nil,
 		)
 
-		expected := "ON t.`tenant_id` = s.`tenant_id` AND (t.`user_id` = s.`user_id` OR (t.`user_id` IS NULL AND s.`user_id` IS NULL))\n"
-		if !contains(sql, expected) {
-			t.Fatalf("sql missing mixed on clause:\n%s", sql)
+		want := strings.Join([]string{
+			"MERGE `my-project`.`target_ds`.`target_tbl` AS t",
+			"USING (SELECT * FROM `my-project`.`staging_ds`.`staging_tbl` QUALIFY ROW_NUMBER() OVER (PARTITION BY `tenant_id`, `user_id`) = 1) AS s",
+			"ON t.`tenant_id` = s.`tenant_id` AND (t.`user_id` = s.`user_id` OR (t.`user_id` IS NULL AND s.`user_id` IS NULL))",
+			"WHEN MATCHED THEN",
+			"  UPDATE SET t.`value` = s.`value`",
+			"WHEN NOT MATCHED THEN",
+			"  INSERT (`tenant_id`, `user_id`, `value`)",
+			"  VALUES (s.`tenant_id`, s.`user_id`, s.`value`)",
+		}, "\n")
+		if sql != want {
+			t.Fatalf("unexpected merge SQL:\ngot:\n%s\n\nwant:\n%s", sql, want)
 		}
 	})
 
@@ -1584,8 +1600,18 @@ func TestBuildMergeSQL(t *testing.T) {
 			map[string]bool{"id": true}, nil,
 		)
 
-		if !contains(sql, "ON t.`ID` = s.`ID`\n") {
-			t.Fatalf("sql missing bare equality on clause for cased required pk:\n%s", sql)
+		want := strings.Join([]string{
+			"MERGE `my-project`.`target_ds`.`target_tbl` AS t",
+			"USING (SELECT * FROM `my-project`.`staging_ds`.`staging_tbl` QUALIFY ROW_NUMBER() OVER (PARTITION BY `ID`) = 1) AS s",
+			"ON t.`ID` = s.`ID`",
+			"WHEN MATCHED THEN",
+			"  UPDATE SET t.`name` = s.`name`",
+			"WHEN NOT MATCHED THEN",
+			"  INSERT (`ID`, `name`)",
+			"  VALUES (s.`ID`, s.`name`)",
+		}, "\n")
+		if sql != want {
+			t.Fatalf("unexpected merge SQL:\ngot:\n%s\n\nwant:\n%s", sql, want)
 		}
 	})
 

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -1447,6 +1447,42 @@ func TestBuildMergePartitionPruning(t *testing.T) {
 	}
 }
 
+func TestNonNullablePKColumns(t *testing.T) {
+	targetMeta := &bigquery.TableMetadata{Schema: bigquery.Schema{
+		{Name: "ID", Type: bigquery.IntegerFieldType, Required: true},
+		{Name: "tenant_id", Type: bigquery.StringFieldType, Required: true},
+		{Name: "region", Type: bigquery.StringFieldType},
+	}}
+
+	got := nonNullablePKColumns(targetMeta, nil, []string{"id", "tenant_id", "region"})
+	if !got["id"] || !got["tenant_id"] {
+		t.Fatalf("expected required PK columns id and tenant_id, got %v", got)
+	}
+	if got["region"] {
+		t.Fatalf("nullable PK column must not be reported as non-nullable, got %v", got)
+	}
+
+	if got := nonNullablePKColumns(targetMeta, nil, []string{"region"}); got != nil {
+		t.Fatalf("expected nil when no PK column is required, got %v", got)
+	}
+	if got := nonNullablePKColumns(nil, nil, []string{"id"}); got != nil {
+		t.Fatalf("expected nil for missing schema, got %v", got)
+	}
+
+	// A relaxed (all-NULLABLE) target must still qualify when the ingestion
+	// schema declares the key NOT NULL — staging then holds no NULL keys.
+	relaxedMeta := &bigquery.TableMetadata{Schema: bigquery.Schema{
+		{Name: "id", Type: bigquery.IntegerFieldType},
+	}}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64, Nullable: false},
+	}}
+	got = nonNullablePKColumns(relaxedMeta, tableSchema, []string{"id"})
+	if !got["id"] {
+		t.Fatalf("expected NOT NULL ingestion schema column to qualify, got %v", got)
+	}
+}
+
 func TestBuildMergeSQL(t *testing.T) {
 	dest := NewBigQueryDestination()
 	dest.projectID = "my-project"
@@ -1510,6 +1546,46 @@ func TestBuildMergeSQL(t *testing.T) {
 		}
 		if contains(sql, "ON t.`tenant_id` = s.`tenant_id` AND t.`user_id` = s.`user_id`\n") {
 			t.Fatalf("sql should not use bare equality composite ON clause:\n%s", sql)
+		}
+	})
+
+	t.Run("bare_equality_for_required_pk", func(t *testing.T) {
+		sql := dest.buildMergeSQLWithPartitionPruning(
+			"my-project", "target_ds", "target_tbl", "staging_ds", "staging_tbl",
+			[]string{"id"}, []string{"id", "name"}, nil, "",
+			map[string]bool{"id": true}, nil,
+		)
+
+		if !contains(sql, "ON t.`id` = s.`id`\n") {
+			t.Fatalf("sql missing bare equality on clause for required pk:\n%s", sql)
+		}
+		if contains(sql, "IS NULL") {
+			t.Fatalf("sql should not include null-safe join for required pk:\n%s", sql)
+		}
+	})
+
+	t.Run("mixed_required_and_nullable_pks", func(t *testing.T) {
+		sql := dest.buildMergeSQLWithPartitionPruning(
+			"my-project", "target_ds", "target_tbl", "staging_ds", "staging_tbl",
+			[]string{"tenant_id", "user_id"}, []string{"tenant_id", "user_id", "value"}, nil, "",
+			map[string]bool{"tenant_id": true}, nil,
+		)
+
+		expected := "ON t.`tenant_id` = s.`tenant_id` AND (t.`user_id` = s.`user_id` OR (t.`user_id` IS NULL AND s.`user_id` IS NULL))\n"
+		if !contains(sql, expected) {
+			t.Fatalf("sql missing mixed on clause:\n%s", sql)
+		}
+	})
+
+	t.Run("required_pk_lookup_is_case_insensitive", func(t *testing.T) {
+		sql := dest.buildMergeSQLWithPartitionPruning(
+			"my-project", "target_ds", "target_tbl", "staging_ds", "staging_tbl",
+			[]string{"ID"}, []string{"ID", "name"}, nil, "",
+			map[string]bool{"id": true}, nil,
+		)
+
+		if !contains(sql, "ON t.`ID` = s.`ID`\n") {
+			t.Fatalf("sql missing bare equality on clause for cased required pk:\n%s", sql)
 		}
 	})
 
@@ -1593,7 +1669,7 @@ func TestBuildMergeSQL(t *testing.T) {
 	t.Run("date_partition_pruning_when_partition_column_is_pk", func(t *testing.T) {
 		sql := dest.buildMergeSQLWithPartitionPruning(
 			"my-project", "target_ds", "target_tbl", "staging_ds", "staging_tbl",
-			[]string{"id", "day"}, []string{"id", "day", "name"}, nil, "",
+			[]string{"id", "day"}, []string{"id", "day", "name"}, nil, "", nil,
 			&mergePartitionPruning{Column: "day", IsDate: true},
 		)
 
@@ -1614,7 +1690,7 @@ func TestBuildMergeSQL(t *testing.T) {
 	t.Run("timestamp_partition_pruning_uses_date_expression", func(t *testing.T) {
 		sql := dest.buildMergeSQLWithPartitionPruning(
 			"my-project", "target_ds", "target_tbl", "staging_ds", "staging_tbl",
-			[]string{"id", "created_at"}, []string{"id", "created_at", "name"}, nil, "",
+			[]string{"id", "created_at"}, []string{"id", "created_at", "name"}, nil, "", nil,
 			&mergePartitionPruning{Column: "created_at"},
 		)
 

--- a/pkg/destination/bigquery/mapper.go
+++ b/pkg/destination/bigquery/mapper.go
@@ -3,6 +3,7 @@ package bigquery
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -12,6 +13,46 @@ import (
 
 // bigQueryMaxPKColumns is BigQuery's hard limit on PRIMARY KEY column count.
 const bigQueryMaxPKColumns = 16
+
+// bigQueryMaxClusteringColumns is BigQuery's hard limit on clustering column count.
+const bigQueryMaxClusteringColumns = 4
+
+// clusterableFieldTypes lists the BigQuery types allowed as clustering columns;
+// notably FLOAT, BYTES, TIME and JSON are not.
+var clusterableFieldTypes = map[bigquery.FieldType]bool{
+	bigquery.StringFieldType:     true,
+	bigquery.IntegerFieldType:    true,
+	bigquery.NumericFieldType:    true,
+	bigquery.BigNumericFieldType: true,
+	bigquery.DateFieldType:       true,
+	bigquery.DateTimeFieldType:   true,
+	bigquery.TimestampFieldType:  true,
+	bigquery.BooleanFieldType:    true,
+	bigquery.GeographyFieldType:  true,
+	bigquery.RangeFieldType:      true,
+}
+
+// defaultClusteringFromPrimaryKeys picks up to 4 clusterable primary key columns
+// so MERGE joins on the PK can prune clustered blocks instead of scanning the table.
+func defaultClusteringFromPrimaryKeys(bqSchema bigquery.Schema, primaryKeys []string) []string {
+	fieldsByName := make(map[string]*bigquery.FieldSchema, len(bqSchema))
+	for _, f := range bqSchema {
+		fieldsByName[strings.ToLower(f.Name)] = f
+	}
+
+	var fields []string
+	for _, pk := range primaryKeys {
+		f, ok := fieldsByName[strings.ToLower(pk)]
+		if !ok || f.Repeated || !clusterableFieldTypes[f.Type] {
+			continue
+		}
+		fields = append(fields, f.Name)
+		if len(fields) == bigQueryMaxClusteringColumns {
+			break
+		}
+	}
+	return fields
+}
 
 // MapDataTypeToBigQuery maps internal DataType to BigQuery FieldType.
 func MapDataTypeToBigQuery(col schema.Column) bigquery.FieldType {
@@ -128,6 +169,9 @@ func BuildTableMetadata(tableSchema *schema.TableSchema, primaryKeys []string, l
 		}
 	}
 
+	if len(clusterBy) == 0 {
+		clusterBy = defaultClusteringFromPrimaryKeys(metadata.Schema, primaryKeys)
+	}
 	if len(clusterBy) > 0 {
 		metadata.Clustering = &bigquery.Clustering{
 			Fields: clusterBy,

--- a/pkg/destination/bigquery/mapper_test.go
+++ b/pkg/destination/bigquery/mapper_test.go
@@ -360,6 +360,85 @@ func TestBuildTableMetadata(t *testing.T) {
 	})
 }
 
+func TestBuildTableMetadataDefaultClustering(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "score", DataType: schema.TypeFloat64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+
+	t.Run("defaults_to_primary_keys", func(t *testing.T) {
+		metadata := BuildTableMetadata(tableSchema, []string{"id"}, "", "", nil, 0)
+
+		if metadata.Clustering == nil {
+			t.Fatal("expected default clustering from primary keys")
+		}
+		if len(metadata.Clustering.Fields) != 1 || metadata.Clustering.Fields[0] != "id" {
+			t.Fatalf("clustering fields = %v, want [id]", metadata.Clustering.Fields)
+		}
+	})
+
+	t.Run("explicit_cluster_by_wins", func(t *testing.T) {
+		metadata := BuildTableMetadata(tableSchema, []string{"id"}, "", "", []string{"name"}, 0)
+
+		if metadata.Clustering == nil || len(metadata.Clustering.Fields) != 1 || metadata.Clustering.Fields[0] != "name" {
+			t.Fatalf("clustering fields = %+v, want [name]", metadata.Clustering)
+		}
+	})
+
+	t.Run("no_primary_keys_no_clustering", func(t *testing.T) {
+		metadata := BuildTableMetadata(tableSchema, nil, "", "", nil, 0)
+
+		if metadata.Clustering != nil {
+			t.Fatalf("expected no clustering, got %+v", metadata.Clustering)
+		}
+	})
+
+	t.Run("unclusterable_pk_columns_are_skipped", func(t *testing.T) {
+		metadata := BuildTableMetadata(tableSchema, []string{"score", "id"}, "", "", nil, 0)
+
+		if metadata.Clustering == nil || len(metadata.Clustering.Fields) != 1 || metadata.Clustering.Fields[0] != "id" {
+			t.Fatalf("clustering fields = %+v, want [id] (FLOAT pk skipped)", metadata.Clustering)
+		}
+	})
+
+	t.Run("caps_at_four_columns", func(t *testing.T) {
+		cols := make([]schema.Column, 6)
+		pks := make([]string, 6)
+		for i := range cols {
+			name := fmt.Sprintf("pk_%d", i)
+			cols[i] = schema.Column{Name: name, DataType: schema.TypeString}
+			pks[i] = name
+		}
+		metadata := BuildTableMetadata(&schema.TableSchema{Columns: cols}, pks, "", "", nil, 0)
+
+		if metadata.Clustering == nil || len(metadata.Clustering.Fields) != bigQueryMaxClusteringColumns {
+			t.Fatalf("clustering fields = %+v, want first %d PKs", metadata.Clustering, bigQueryMaxClusteringColumns)
+		}
+		if metadata.Clustering.Fields[3] != "pk_3" {
+			t.Fatalf("clustering fields = %v, want PK order preserved", metadata.Clustering.Fields)
+		}
+	})
+
+	t.Run("pk_name_matches_schema_case_insensitively", func(t *testing.T) {
+		metadata := BuildTableMetadata(tableSchema, []string{"ID"}, "", "", nil, 0)
+
+		if metadata.Clustering == nil || len(metadata.Clustering.Fields) != 1 || metadata.Clustering.Fields[0] != "id" {
+			t.Fatalf("clustering fields = %+v, want schema-cased [id]", metadata.Clustering)
+		}
+	})
+
+	t.Run("pk_missing_from_schema_no_clustering", func(t *testing.T) {
+		metadata := BuildTableMetadata(tableSchema, []string{"unknown_col"}, "", "", nil, 0)
+
+		if metadata.Clustering != nil {
+			t.Fatalf("expected no clustering for unknown PK column, got %+v", metadata.Clustering)
+		}
+	})
+}
+
 func TestParseTableName(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -47,6 +47,7 @@ type MergeOptions struct {
 	PrimaryKeys    []string
 	Columns        []string
 	IncrementalKey string
+	Schema         *schema.TableSchema
 }
 
 // DeleteInsertOptions contains parameters for delete+insert operations.

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -68,6 +68,7 @@ func mergeStagingInto(ctx context.Context, dest destination.Destination, staging
 		PrimaryKeys:    primaryKeys,
 		Columns:        destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
 		IncrementalKey: mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
+		Schema:         tableSchema,
 	})
 }
 

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -168,6 +168,7 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 		PrimaryKeys:    primaryKeys,
 		Columns:        tableSchema.ColumnNames(),
 		IncrementalKey: incrementalKey,
+		Schema:         tableSchema,
 	}); err != nil {
 		for _, t := range []string{rawTable, normalised} {
 			if dropErr := dest.DropTable(ctx, t); dropErr != nil {

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -218,6 +218,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		PrimaryKeys:    job.Config.PrimaryKeys,
 		Columns:        job.Schema.ColumnNames(),
 		IncrementalKey: mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+		Schema:         job.Schema,
 	}); err != nil {
 		return fmt.Errorf("failed to insert from staging: %w", err)
 	}


### PR DESCRIPTION
BigQuery MERGE was billing a full target scan on every merge sync, even for tiny deltas — merging 500 rows into a 543 MB table billed the full 543 MB.

This clusters newly created tables on up to 4 primary key columns when no explicit cluster-by is given, so the MERGE join prunes clustered blocks. Benchmarked on a 2M-row / 543 MB table: billed bytes dropped ~84% (543 MB → 84 MB) for key-local deltas. An explicit --cluster-by still takes precedence, and PK columns with unclusterable types are skipped.

It also uses a bare equality merge join when a PK column can't be NULL on either side (REQUIRED in the target, or NOT NULL in the ingestion schema — plumbed via a new MergeOptions.Schema field), keeping the null-safe join only where it's semantically needed.