### PR TITLE
Expose replication lag over HTTP via expvar in stream mode

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/metrics"
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -223,6 +224,11 @@ func IngestCommand() *cli.Command {
 				Sources: cli.EnvVars("INGESTR_FLUSH_RECORDS"),
 			},
 			&cli.StringFlag{
+				Name:    "metrics-addr",
+				Usage:   "Serve streaming metrics (expvar at /debug/vars) on this address, e.g. 127.0.0.1:6060. Only valid together with --stream",
+				Sources: cli.EnvVars("INGESTR_METRICS_ADDR"),
+			},
+			&cli.StringFlag{
 				Name:    "query-annotations",
 				Usage:   "JSON object of caller annotation keys (e.g. {\"pipeline\":\"p\",\"asset\":\"a\"}) merged into the '-- @bruin.config' comment on destination queries (QUERY_TAG on Snowflake) for cost attribution. ingestr always annotates with its own keys (type, ingestr_step); this flag adds the caller's keys on top.",
 				Sources: cli.EnvVars("INGESTR_QUERY_ANNOTATIONS"),
@@ -286,6 +292,10 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	if !cfg.Stream && (c.IsSet("flush-interval") || c.IsSet("flush-records")) {
 		return fmt.Errorf("--flush-interval and --flush-records are only valid together with --stream")
 	}
+	metricsAddr := c.String("metrics-addr")
+	if !cfg.Stream && metricsAddr != "" {
+		return fmt.Errorf("--metrics-addr is only valid together with --stream")
+	}
 	// In streaming mode the source decides the default strategy (merge for CDC,
 	// append for brokers); only treat the strategy as a user override when the
 	// flag was explicitly set, since it defaults to "replace".
@@ -332,6 +342,17 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	if cfg.IncrementalStrategy != "" {
 		if _, err := strategy.Get(cfg.IncrementalStrategy); err != nil {
 			return err
+		}
+	}
+
+	if metricsAddr != "" {
+		boundAddr, stop, err := metrics.Serve(metricsAddr)
+		if err != nil {
+			return fmt.Errorf("failed to start metrics server: %w", err)
+		}
+		defer stop()
+		if !output.IsJSON() {
+			color.Green("Serving metrics on http://%s/debug/vars", boundAddr)
 		}
 	}
 

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -35,6 +35,7 @@ ingestr ingest \
 - `--stream`: Runs continuous (streaming) ingestion instead of a one-shot load. Supported by CDC sources (`postgres+cdc`, `mssql+cdc`) and message brokers (`kafka`, `amqp`). The process runs until interrupted (SIGINT/SIGTERM), flushing buffered records to the destination on an interval or record-count trigger. See [Streaming ingestion](#streaming-ingestion) below.
 - `--flush-interval`: In streaming mode, flush buffered records to the destination at least this often. Defaults to `30s`. Only valid with `--stream`.
 - `--flush-records`: In streaming mode, flush when this many records have been buffered. Defaults to `50000`. Only valid with `--stream`.
+- `--metrics-addr`: In streaming mode, serve replication lag and throughput metrics over HTTP on this address (e.g. `127.0.0.1:6060`). Disabled unless set. Only valid with `--stream`. See [Monitoring a stream](#monitoring-a-stream) below.
 
 The `interval-start` and `interval-end` options support various datetime formats, here are some examples:
 - `%Y-%m-%d`: `2023-01-31`
@@ -79,6 +80,40 @@ ingestr ingest \
 
 > [!INFO]
 > Column-level schema changes are picked up at startup. If a table's columns change while a stream is running, restart the stream to apply the new schema. Run streaming ingestion under a supervisor (systemd, Kubernetes, etc.) so it restarts after transient source/destination outages.
+
+### Monitoring a stream
+
+Passing `--metrics-addr` starts a small HTTP server for the lifetime of the stream that exposes Go [expvar](https://pkg.go.dev/expvar) metrics at `/debug/vars`. It is off unless the flag is set, and the address is bound before ingestion starts, so a port conflict fails immediately rather than half-way through a run.
+
+```bash
+ingestr ingest \
+   --source-uri 'postgres+cdc://user:pass@localhost:5432/mydb' \
+   --dest-uri 'bigquery://my_project?credentials_path=/path/to/sa.json' \
+   --stream \
+   --metrics-addr 127.0.0.1:6060
+
+curl -s localhost:6060/debug/vars | jq '.ingestr_replication, .ingestr_stream_tables'
+```
+
+Alongside Go's standard `cmdline` and `memstats`, ingestr publishes:
+
+| Key | Meaning |
+|---|---|
+| `ingestr_replication` | Replication lag for the current source (see below). `{"streaming": false}` when the source cannot report lag. |
+| `ingestr_stream_rows_synced` | Cumulative rows written **and** confirmed durable since the process started. |
+| `ingestr_stream_flush_cycles` | Number of completed flush cycles. |
+| `ingestr_stream_last_synced_unix` | Unix time of the last successful commit. |
+| `ingestr_stream_tables` | The same row counts and timestamp, broken out per destination table. |
+
+The row counters advance only after a flush's destination write **and** its source-position commit have both succeeded, so they count durable rows rather than merely written ones. `ingestr_stream_last_synced_unix` also advances on cycles that commit a position without writing rows, which is what makes it usable as a staleness alarm: if it stops moving, the stream is stuck.
+
+What `ingestr_replication` contains depends on the engine, because "lag" is not the same quantity everywhere:
+
+- **Postgres** (`postgres+cdc`) reports `bytes_behind`: the distance between the server's WAL head and the position ingestr has confirmed durable. This is the same number as `pg_current_wal_lsn() - confirmed_flush_lsn` for the replication slot, so it is what predicts unbounded WAL growth on the source. It is the value to alert on.
+- **MongoDB** (`mongodb+cdc`) reports `seconds_behind`: the gap between the server's `operationTime` and the cluster time of the last processed change event. Both clocks are server-side, so an idle collection converges to zero instead of drifting upward.
+- **SQL Server** (`mssql+cdc`) reports `seconds_behind`: the change time between the processed LSN and the capture watermark, via `sys.fn_cdc_map_lsn_to_time`. SQL Server's `binary(10)` LSNs are ordered but their difference is not a log distance, so no `bytes_behind` is published.
+
+Fields that an engine cannot express are omitted rather than reported as a misleading zero. Postgres, for instance, has no per-LSN timestamp, so it publishes no `seconds_behind`. Message-broker sources report no lag block at all.
 
 ## General flags
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,147 @@
+// Package metrics exposes streaming ingestion metrics over HTTP via expvar.
+//
+// It is opt-in: nothing is served unless the caller invokes Serve. The exported
+// vars are published once at init because expvar panics on duplicate publish.
+package metrics
+
+import (
+	"expvar"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// reporter holds the active source's lag reporter. It is a package global
+// because expvar's registry is process-global and ingestr runs one stream per
+// process; a hypothetical concurrent pipeline would overwrite it.
+var reporter atomic.Pointer[source.LagReporter]
+
+var (
+	rowsSynced   = expvar.NewInt("ingestr_stream_rows_synced")
+	flushCycles  = expvar.NewInt("ingestr_stream_flush_cycles")
+	lastSyncedTS = expvar.NewInt("ingestr_stream_last_synced_unix")
+)
+
+var (
+	tablesMu sync.Mutex
+	tables   = map[string]*tableStat{}
+)
+
+type tableStat struct {
+	RowsSynced     int64 `json:"rows_synced"`
+	LastFlushRows  int64 `json:"last_flush_rows"`
+	LastSyncedUnix int64 `json:"last_synced_unix"`
+}
+
+type lagVars struct {
+	Streaming       bool     `json:"streaming"`
+	Source          string   `json:"source,omitempty"`
+	BytesBehind     *uint64  `json:"bytes_behind,omitempty"`
+	SecondsBehind   *float64 `json:"seconds_behind,omitempty"`
+	ServerPosition  string   `json:"server_position,omitempty"`
+	DurablePosition string   `json:"durable_position,omitempty"`
+	CaughtUp        bool     `json:"caught_up"`
+	UpdatedAtUnix   int64    `json:"updated_at_unix,omitempty"`
+}
+
+func init() {
+	expvar.Publish("ingestr_replication", expvar.Func(replicationVars))
+	expvar.Publish("ingestr_stream_tables", expvar.Func(tableVars))
+}
+
+func replicationVars() any {
+	rp := reporter.Load()
+	if rp == nil {
+		return lagVars{}
+	}
+	s, ok := (*rp).ReplicationLag()
+	if !ok {
+		return lagVars{}
+	}
+	v := lagVars{
+		Streaming:       true,
+		Source:          s.Source,
+		BytesBehind:     s.BytesBehind,
+		SecondsBehind:   s.SecondsBehind,
+		ServerPosition:  s.ServerPosition,
+		DurablePosition: s.DurablePosition,
+		CaughtUp:        s.CaughtUp,
+	}
+	if !s.UpdatedAt.IsZero() {
+		v.UpdatedAtUnix = s.UpdatedAt.Unix()
+	}
+	return v
+}
+
+// tableVars returns a copy: expvar encodes the returned value after this
+// function has released the lock.
+func tableVars() any {
+	tablesMu.Lock()
+	defer tablesMu.Unlock()
+	out := make(map[string]tableStat, len(tables))
+	for name, st := range tables {
+		out[name] = *st
+	}
+	return out
+}
+
+// SetLagReporter installs the source whose lag is published. Pass nil to clear.
+func SetLagReporter(r source.LagReporter) {
+	if r == nil {
+		reporter.Store(nil)
+		return
+	}
+	reporter.Store(&r)
+}
+
+// RecordSync accounts one successfully committed flush cycle. Callers must
+// invoke it only after the source position is committed, so the counters mean
+// "durable in the destination" rather than merely "written".
+func RecordSync(perTable map[string]int64, at time.Time) {
+	unix := at.Unix()
+	var total int64
+
+	tablesMu.Lock()
+	for name, rows := range perTable {
+		st, ok := tables[name]
+		if !ok {
+			st = &tableStat{}
+			tables[name] = st
+		}
+		st.RowsSynced += rows
+		st.LastFlushRows = rows
+		st.LastSyncedUnix = unix
+		total += rows
+	}
+	tablesMu.Unlock()
+
+	rowsSynced.Add(total)
+	flushCycles.Add(1)
+	lastSyncedTS.Set(unix)
+}
+
+// Serve starts an HTTP server exposing expvar at /debug/vars. The listener is
+// bound synchronously so an unusable address fails fast, and the resolved
+// address is returned so a port of 0 can be used. The returned stop closes the
+// server immediately rather than draining: this is a read-only endpoint, and an
+// immediate close guarantees the CLI never hangs on exit.
+func Serve(addr string) (boundAddr string, stop func(), err error) {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// A dedicated mux, never http.DefaultServeMux: importing expvar registers
+	// /debug/vars there, and that must not leak into the web UI server.
+	mux := http.NewServeMux()
+	mux.Handle("/debug/vars", expvar.Handler())
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+
+	return ln.Addr().String(), func() { _ = srv.Close() }, nil
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,253 @@
+package metrics
+
+import (
+	"encoding/json"
+	"expvar"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+type fakeReporter struct {
+	snap source.LagSnapshot
+	ok   bool
+}
+
+func (f fakeReporter) ReplicationLag() (source.LagSnapshot, bool) { return f.snap, f.ok }
+
+func scrapeReplication(t *testing.T) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(expvar.Get("ingestr_replication").String()), &out); err != nil {
+		t.Fatalf("failed to decode ingestr_replication: %v", err)
+	}
+	return out
+}
+
+func scrapeTables(t *testing.T) map[string]map[string]any {
+	t.Helper()
+	var out map[string]map[string]any
+	if err := json.Unmarshal([]byte(expvar.Get("ingestr_stream_tables").String()), &out); err != nil {
+		t.Fatalf("failed to decode ingestr_stream_tables: %v", err)
+	}
+	return out
+}
+
+// resetState clears the package globals so each test starts clean. expvar has
+// no deregister, so the vars themselves are reused across tests.
+func resetState(t *testing.T) {
+	t.Helper()
+	SetLagReporter(nil)
+	tablesMu.Lock()
+	tables = map[string]*tableStat{}
+	tablesMu.Unlock()
+	rowsSynced.Set(0)
+	flushCycles.Set(0)
+	lastSyncedTS.Set(0)
+	t.Cleanup(func() { SetLagReporter(nil) })
+}
+
+func TestReplicationVarsWithoutReporter(t *testing.T) {
+	resetState(t)
+
+	got := scrapeReplication(t)
+	if got["streaming"] != false {
+		t.Fatalf("expected streaming=false with no reporter, got %v", got)
+	}
+	if _, ok := got["bytes_behind"]; ok {
+		t.Fatalf("expected no bytes_behind with no reporter, got %v", got)
+	}
+}
+
+func TestReplicationVarsReporterNotReady(t *testing.T) {
+	resetState(t)
+	SetLagReporter(fakeReporter{ok: false})
+
+	if got := scrapeReplication(t); got["streaming"] != false {
+		t.Fatalf("expected streaming=false when reporter is not ready, got %v", got)
+	}
+}
+
+func TestReplicationVarsBytesBehind(t *testing.T) {
+	resetState(t)
+	behind := uint64(4096)
+	SetLagReporter(fakeReporter{
+		ok: true,
+		snap: source.LagSnapshot{
+			Source:          "postgres_cdc",
+			BytesBehind:     &behind,
+			ServerPosition:  "0/1A2B3C0",
+			DurablePosition: "0/1A2A3C0",
+			UpdatedAt:       time.Unix(1700000000, 0),
+		},
+	})
+
+	got := scrapeReplication(t)
+	if got["streaming"] != true {
+		t.Fatalf("expected streaming=true, got %v", got)
+	}
+	if got["bytes_behind"] != float64(4096) {
+		t.Fatalf("expected bytes_behind=4096, got %v", got["bytes_behind"])
+	}
+	if got["caught_up"] != false {
+		t.Fatalf("expected caught_up=false, got %v", got["caught_up"])
+	}
+	if got["server_position"] != "0/1A2B3C0" {
+		t.Fatalf("unexpected server_position: %v", got["server_position"])
+	}
+	// seconds_behind is not applicable to Postgres and must be omitted rather
+	// than reported as a misleading zero.
+	if _, ok := got["seconds_behind"]; ok {
+		t.Fatalf("expected seconds_behind to be omitted, got %v", got)
+	}
+}
+
+func TestReplicationVarsSecondsBehindOnly(t *testing.T) {
+	resetState(t)
+	secs := 12.0
+	SetLagReporter(fakeReporter{
+		ok:   true,
+		snap: source.LagSnapshot{Source: "mongodb", SecondsBehind: &secs},
+	})
+
+	got := scrapeReplication(t)
+	if got["seconds_behind"] != float64(12) {
+		t.Fatalf("expected seconds_behind=12, got %v", got["seconds_behind"])
+	}
+	if _, ok := got["bytes_behind"]; ok {
+		t.Fatalf("expected bytes_behind to be omitted for mongodb, got %v", got)
+	}
+}
+
+func TestRecordSyncAccumulates(t *testing.T) {
+	resetState(t)
+
+	RecordSync(map[string]int64{"public.users": 100, "public.orders": 50}, time.Unix(1000, 0))
+	RecordSync(map[string]int64{"public.users": 25, "public.items": 7}, time.Unix(2000, 0))
+
+	if got := rowsSynced.Value(); got != 182 {
+		t.Fatalf("expected 182 rows synced in total, got %d", got)
+	}
+	if got := flushCycles.Value(); got != 2 {
+		t.Fatalf("expected 2 flush cycles, got %d", got)
+	}
+	if got := lastSyncedTS.Value(); got != 2000 {
+		t.Fatalf("expected last synced 2000, got %d", got)
+	}
+
+	tbl := scrapeTables(t)
+
+	// rows_synced accumulates across cycles; last_flush_rows is replaced.
+	if tbl["public.users"]["rows_synced"] != float64(125) {
+		t.Fatalf("expected users rows_synced=125, got %v", tbl["public.users"]["rows_synced"])
+	}
+	if tbl["public.users"]["last_flush_rows"] != float64(25) {
+		t.Fatalf("expected users last_flush_rows=25, got %v", tbl["public.users"]["last_flush_rows"])
+	}
+
+	// A table absent from cycle 2 keeps its totals and its older timestamp.
+	if tbl["public.orders"]["rows_synced"] != float64(50) {
+		t.Fatalf("expected orders rows_synced=50, got %v", tbl["public.orders"]["rows_synced"])
+	}
+	if tbl["public.orders"]["last_synced_unix"] != float64(1000) {
+		t.Fatalf("expected orders to keep last_synced_unix=1000, got %v", tbl["public.orders"]["last_synced_unix"])
+	}
+
+	// A table first seen in cycle 2 appears.
+	if tbl["public.items"]["rows_synced"] != float64(7) {
+		t.Fatalf("expected items rows_synced=7, got %v", tbl["public.items"]["rows_synced"])
+	}
+}
+
+// An idle commit cycle confirms the source position without writing rows; it
+// must still advance last_synced so a staleness alarm does not misfire.
+func TestRecordSyncIdleCycleAdvancesTimestamp(t *testing.T) {
+	resetState(t)
+
+	RecordSync(map[string]int64{}, time.Unix(500, 0))
+
+	if got := rowsSynced.Value(); got != 0 {
+		t.Fatalf("expected no rows synced, got %d", got)
+	}
+	if got := lastSyncedTS.Value(); got != 500 {
+		t.Fatalf("expected last synced 500, got %d", got)
+	}
+}
+
+func TestRecordSyncConcurrentWithScrape(t *testing.T) {
+	resetState(t)
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Go(func() {
+			RecordSync(map[string]int64{fmt.Sprintf("t%d", i%3): 1}, time.Unix(int64(i), 0))
+		})
+		wg.Go(func() {
+			_ = expvar.Get("ingestr_stream_tables").String()
+		})
+	}
+	wg.Wait()
+
+	if got := rowsSynced.Value(); got != 8 {
+		t.Fatalf("expected 8 rows synced, got %d", got)
+	}
+}
+
+func TestServeExposesDebugVars(t *testing.T) {
+	resetState(t)
+	RecordSync(map[string]int64{"public.users": 3}, time.Unix(1234, 0))
+
+	addr, stop, err := Serve("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Serve failed: %v", err)
+	}
+	t.Cleanup(stop)
+
+	resp, err := http.Get("http://" + addr + "/debug/vars")
+	if err != nil {
+		t.Fatalf("could not reach metrics server: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("expvar output is not valid JSON: %v", err)
+	}
+	if _, ok := out["ingestr_stream_rows_synced"]; !ok {
+		t.Fatalf("expected ingestr_stream_rows_synced in /debug/vars, got keys %v", out)
+	}
+}
+
+func TestServeStopDoesNotHang(t *testing.T) {
+	_, stop, err := Serve("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Serve failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop() hung; the CLI would not exit")
+	}
+}
+
+func TestServeRejectsBadAddress(t *testing.T) {
+	if _, _, err := Serve("not-an-address"); err == nil {
+		t.Fatal("expected Serve to fail fast on an unusable address")
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/display"
+	"github.com/bruin-data/ingestr/internal/metrics"
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/databuffer"
@@ -85,6 +86,10 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		ss, ok := src.(source.StreamingSource)
 		if !ok || !ss.SupportsStreaming() {
 			return fmt.Errorf("--stream is not supported by this source; streaming requires a CDC source (postgres+cdc, mssql+cdc) or a message broker source (kafka, amqp, mqtt, sqs, pubsub, kinesis)")
+		}
+		if lr, ok := src.(source.LagReporter); ok {
+			metrics.SetLagReporter(lr)
+			defer metrics.SetLagReporter(nil)
 		}
 	}
 

--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -31,6 +33,10 @@ const (
 	defaultMongoDBCDCSchemaSampleSize = 1000
 	defaultMongoDBCDCStreamBatchSize  = 10000
 	defaultMongoDBCDCFlushInterval    = 30 * time.Second
+
+	// mongoLagRefreshInterval throttles the operationTime round-trip taken on
+	// the idle path to keep the reported lag from drifting upward.
+	mongoLagRefreshInterval = 5 * time.Second
 )
 
 var mongodbCDCColumns = []schema.Column{
@@ -51,6 +57,38 @@ type MongoDBCDCSource struct {
 	database  string
 	uri       string
 	cdcConfig MongoDBCDCConfig
+	lag       *mongoLagState
+}
+
+// mongoLagState tracks the cluster time of the last processed change event
+// against the server's own operationTime. Both clocks are server-side, so the
+// difference is immune to client clock skew. Written by the change-stream
+// goroutine, read by the metrics scraper.
+type mongoLagState struct {
+	lastEventUnix atomic.Int64
+	serverOpUnix  atomic.Int64
+	streaming     atomic.Bool
+}
+
+func newMongoLagState() *mongoLagState {
+	return &mongoLagState{}
+}
+
+func (l *mongoLagState) noteEvent(ts primitive.Timestamp) {
+	storeMaxInt64(&l.lastEventUnix, int64(ts.T))
+}
+
+func (l *mongoLagState) noteServerTime(ts primitive.Timestamp) {
+	storeMaxInt64(&l.serverOpUnix, int64(ts.T))
+}
+
+func storeMaxInt64(dst *atomic.Int64, v int64) {
+	for {
+		cur := dst.Load()
+		if v <= cur || dst.CompareAndSwap(cur, v) {
+			return
+		}
+	}
 }
 
 type mongoNamespace struct {
@@ -93,7 +131,37 @@ type mongoCDCEventBuffer struct {
 }
 
 func NewMongoDBCDCSource() *MongoDBCDCSource {
-	return &MongoDBCDCSource{}
+	return &MongoDBCDCSource{lag: newMongoLagState()}
+}
+
+var _ source.LagReporter = (*MongoDBCDCSource)(nil)
+
+// ReplicationLag reports how many seconds of change events the destination
+// still trails the source by. Both timestamps come from the server, so an idle
+// collection converges to zero rather than growing as "time since last change".
+func (s *MongoDBCDCSource) ReplicationLag() (source.LagSnapshot, bool) {
+	if s.lag == nil || !s.lag.streaming.Load() {
+		return source.LagSnapshot{}, false
+	}
+	server := s.lag.serverOpUnix.Load()
+	lastEvent := s.lag.lastEventUnix.Load()
+	if server == 0 || lastEvent == 0 {
+		return source.LagSnapshot{}, false
+	}
+
+	behind := float64(0)
+	if server > lastEvent {
+		behind = float64(server - lastEvent)
+	}
+
+	return source.LagSnapshot{
+		Source:          "mongodb",
+		SecondsBehind:   &behind,
+		ServerPosition:  strconv.FormatInt(server, 10),
+		DurablePosition: strconv.FormatInt(lastEvent, 10),
+		CaughtUp:        behind == 0,
+		UpdatedAt:       time.Now(),
+	}, true
 }
 
 func (s *MongoDBCDCSource) Schemes() []string {
@@ -620,6 +688,24 @@ func (s *MongoDBCDCSource) streamCollection(ctx context.Context, ns mongoNamespa
 	buffer := newMongoCDCEventBuffer(tableSchema, opts.ExcludeColumns, resultTable, mongoCDCSourceBatchSize(opts))
 	defer buffer.release()
 
+	s.lag.streaming.Store(opts.Streaming)
+	if start.OperationTime.T > 0 {
+		s.lag.noteEvent(start.OperationTime)
+		s.lag.noteServerTime(start.OperationTime)
+	}
+	// Refreshing the server clock costs a command round-trip, so only do it on
+	// the idle path and no more than once per interval.
+	var lastServerTimeRefresh time.Time
+	refreshServerTime := func() {
+		if !opts.Streaming || time.Since(lastServerTimeRefresh) < mongoLagRefreshInterval {
+			return
+		}
+		lastServerTimeRefresh = time.Now()
+		if ts, err := s.currentOperationTime(ctx); err == nil {
+			s.lag.noteServerTime(ts)
+		}
+	}
+
 	var firstBufferedAt time.Time
 	flushByInterval := func() error {
 		if !opts.Streaming || buffer.rows == 0 || firstBufferedAt.IsZero() || time.Since(firstBufferedAt) < mongoCDCFlushInterval(opts) {
@@ -646,6 +732,10 @@ func (s *MongoDBCDCSource) streamCollection(ctx context.Context, ns mongoNamespa
 			if mongoCDCAfterBatchTarget(clusterTime, batchTarget) {
 				return buffer.flush(ctx, results)
 			}
+			// Only noteEvent here: advancing the server clock to the event's
+			// own cluster time would make lag read zero while a backlog drains.
+			s.lag.noteEvent(clusterTime)
+			refreshServerTime()
 
 			doc, deleted, ok := mongoCDCEventDocument(event)
 			if !ok {
@@ -689,6 +779,8 @@ func (s *MongoDBCDCSource) streamCollection(ctx context.Context, ns mongoNamespa
 		if mode == MongoDBCDCModeBatch {
 			return buffer.flush(ctx, results)
 		}
+
+		refreshServerTime()
 
 		if err := flushByInterval(); err != nil {
 			return err

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -153,7 +153,8 @@ func (s *MSSQLCDCSource) noteLag(ctx context.Context, processed, target string) 
 	}
 
 	var secs sql.NullFloat64
-	err := s.db.QueryRowContext(ctx,
+	err := s.db.QueryRowContext(
+		ctx,
 		`SELECT DATEDIFF(second,
 			sys.fn_cdc_map_lsn_to_time(CONVERT(binary(10), @p1, 2)),
 			sys.fn_cdc_map_lsn_to_time(CONVERT(binary(10), @p2, 2)))`,

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -30,6 +30,11 @@ const (
 	ModeStream CDCMode = "stream"
 
 	defaultPollInterval = 1 * time.Second
+
+	// mssqlLagRefreshInterval throttles the sys.fn_cdc_map_lsn_to_time
+	// round-trip taken while behind, so lag reporting cannot add latency to
+	// each poll cycle of a catch-up.
+	mssqlLagRefreshInterval = 5 * time.Second
 )
 
 var mssqlCDCColumns = []schema.Column{
@@ -64,12 +69,23 @@ type mssqlLagState struct {
 	secondsBehind float64
 	hasSeconds    bool
 	updatedAt     time.Time
+	lastQueryAt   time.Time
 
 	streaming atomic.Bool
 }
 
 func newMSSQLLagState() *mssqlLagState {
 	return &mssqlLagState{}
+}
+
+// observePositions records the watermark without touching the seconds reading,
+// for cycles that skip the LSN-to-time query.
+func (l *mssqlLagState) observePositions(processed, target string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.processed = processed
+	l.target = target
+	l.updatedAt = time.Now()
 }
 
 func (l *mssqlLagState) observe(processed, target string, secondsBehind float64, hasSeconds bool) {
@@ -80,6 +96,18 @@ func (l *mssqlLagState) observe(processed, target string, secondsBehind float64,
 	l.secondsBehind = secondsBehind
 	l.hasSeconds = hasSeconds
 	l.updatedAt = time.Now()
+}
+
+// shouldQuery reports whether enough time has passed to spend another
+// LSN-to-time round-trip, and claims the slot if so.
+func (l *mssqlLagState) shouldQuery(now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if now.Sub(l.lastQueryAt) < mssqlLagRefreshInterval {
+		return false
+	}
+	l.lastQueryAt = now
+	return true
 }
 
 type tableMetadata struct {
@@ -149,6 +177,14 @@ func (s *MSSQLCDCSource) noteLag(ctx context.Context, processed, target string) 
 
 	if compareLSNHex(processed, target) >= 0 {
 		s.lag.observe(processed, target, 0, true)
+		return
+	}
+
+	// Behind: mapping LSNs to times costs a round-trip to a server that is
+	// already busy shipping us the backlog, so throttle it. The watermark
+	// itself is free and stays current.
+	if !s.lag.shouldQuery(time.Now()) {
+		s.lag.observePositions(processed, target)
 		return
 	}
 

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -47,6 +49,37 @@ type MSSQLCDCSource struct {
 	db        *sql.DB
 	uri       string
 	cdcConfig CDCConfig
+	lag       *mssqlLagState
+}
+
+// mssqlLagState holds the last observed capture watermark and how far behind the
+// processed position is in wall-clock terms. SQL Server LSNs are binary(10)
+// values whose difference is not a log distance, so lag is expressed in seconds
+// via sys.fn_cdc_map_lsn_to_time. The mutex is only ever held to copy small
+// fields, never across a query, so a metrics scrape cannot stall the poll loop.
+type mssqlLagState struct {
+	mu            sync.Mutex
+	processed     string
+	target        string
+	secondsBehind float64
+	hasSeconds    bool
+	updatedAt     time.Time
+
+	streaming atomic.Bool
+}
+
+func newMSSQLLagState() *mssqlLagState {
+	return &mssqlLagState{}
+}
+
+func (l *mssqlLagState) observe(processed, target string, secondsBehind float64, hasSeconds bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.processed = processed
+	l.target = target
+	l.secondsBehind = secondsBehind
+	l.hasSeconds = hasSeconds
+	l.updatedAt = time.Now()
 }
 
 type tableMetadata struct {
@@ -67,7 +100,76 @@ type CDCTable struct {
 }
 
 func NewMSSQLCDCSource() *MSSQLCDCSource {
-	return &MSSQLCDCSource{}
+	return &MSSQLCDCSource{lag: newMSSQLLagState()}
+}
+
+var _ source.LagReporter = (*MSSQLCDCSource)(nil)
+
+// ReplicationLag reports how far the processed CDC position trails the capture
+// watermark, in seconds.
+func (s *MSSQLCDCSource) ReplicationLag() (source.LagSnapshot, bool) {
+	if s.lag == nil || !s.lag.streaming.Load() {
+		return source.LagSnapshot{}, false
+	}
+
+	s.lag.mu.Lock()
+	processed, target := s.lag.processed, s.lag.target
+	secs, hasSecs, updatedAt := s.lag.secondsBehind, s.lag.hasSeconds, s.lag.updatedAt
+	s.lag.mu.Unlock()
+
+	if processed == "" || target == "" {
+		return source.LagSnapshot{}, false
+	}
+
+	snap := source.LagSnapshot{
+		Source:          "mssql_cdc",
+		ServerPosition:  target,
+		DurablePosition: processed,
+		CaughtUp:        compareLSNHex(processed, target) >= 0,
+		UpdatedAt:       updatedAt,
+	}
+	if hasSecs {
+		snap.SecondsBehind = &secs
+	}
+	return snap, true
+}
+
+// noteLag records the current watermark and asks the server how much change
+// time separates the processed LSN from it. Lag is measured against the capture
+// watermark rather than wall-clock now: on an idle database the two LSNs are
+// equal and lag is zero, whereas "now minus the time of the last change" would
+// climb forever with nothing actually behind.
+//
+// A mapping failure (an LSN the capture job has aged out, or one never
+// committed) is not an error: lag simply goes unreported for this cycle.
+func (s *MSSQLCDCSource) noteLag(ctx context.Context, processed, target string) {
+	if !s.lag.streaming.Load() || processed == "" || target == "" {
+		return
+	}
+
+	if compareLSNHex(processed, target) >= 0 {
+		s.lag.observe(processed, target, 0, true)
+		return
+	}
+
+	var secs sql.NullFloat64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT DATEDIFF(second,
+			sys.fn_cdc_map_lsn_to_time(CONVERT(binary(10), @p1, 2)),
+			sys.fn_cdc_map_lsn_to_time(CONVERT(binary(10), @p2, 2)))`,
+		processed, target,
+	).Scan(&secs)
+	if err != nil {
+		config.Debug("[MSSQL CDC] Failed to map LSNs %s..%s to time: %v", processed, target, err)
+		s.lag.observe(processed, target, 0, false)
+		return
+	}
+
+	value := secs.Float64
+	if value < 0 {
+		value = 0
+	}
+	s.lag.observe(processed, target, value, secs.Valid)
 }
 
 func (s *MSSQLCDCSource) Schemes() []string {
@@ -743,7 +845,23 @@ func (s *MSSQLCDCSource) minLSN(ctx context.Context, meta tableMetadata) (string
 	return normalizeLSNHex(lsn.String), nil
 }
 
+// lowestLSN returns the least-advanced position across tables, ignoring tables
+// that have no position yet. Empty when no table has one.
+func lowestLSN(byTable map[string]string) string {
+	lowest := ""
+	for _, lsn := range byTable {
+		if lsn == "" {
+			continue
+		}
+		if lowest == "" || compareLSNHex(lsn, lowest) < 0 {
+			lowest = lsn
+		}
+	}
+	return lowest
+}
+
 func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.SourceTableInfo, metas map[string]tableMetadata, startByTable map[string]string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	s.lag.streaming.Store(opts.Streaming)
 	for {
 		targetLSN, err := s.maxLSN(ctx)
 		if err != nil {
@@ -762,6 +880,10 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 			}
 		}
 
+		// The laggiest table defines the backlog: sample before processing,
+		// while the gap to the watermark is still open.
+		s.noteLag(ctx, lowestLSN(startByTable), targetLSN)
+
 		for _, table := range tables {
 			start := startByTable[table.Name]
 			if start == "" || compareLSNHex(start, targetLSN) >= 0 {
@@ -779,6 +901,8 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 			return nil
 		}
 
+		s.noteLag(ctx, targetLSN, targetLSN)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -788,12 +912,14 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 }
 
 func (s *MSSQLCDCSource) streamTable(ctx context.Context, meta tableMetadata, tableSchema *schema.TableSchema, startLSN string, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) error {
+	s.lag.streaming.Store(opts.Streaming)
 	current := startLSN
 	for {
 		targetLSN, err := s.maxLSN(ctx)
 		if err != nil {
 			return err
 		}
+		s.noteLag(ctx, current, targetLSN)
 		if targetLSN != "" && current != "" && compareLSNHex(current, targetLSN) < 0 {
 			if err := s.readChanges(ctx, meta, tableSchema, current, targetLSN, opts, results, resultTable); err != nil {
 				return err
@@ -804,6 +930,8 @@ func (s *MSSQLCDCSource) streamTable(ctx context.Context, meta tableMetadata, ta
 		if s.cdcConfig.Mode == ModeBatch {
 			return nil
 		}
+
+		s.noteLag(ctx, current, targetLSN)
 
 		select {
 		case <-ctx.Done():

--- a/pkg/source/postgres_cdc/commit_state.go
+++ b/pkg/source/postgres_cdc/commit_state.go
@@ -74,7 +74,6 @@ func (p *streamPosition) Committed() pglogrepl.LSN {
 // goroutine and read by the metrics scraper, so every field is atomic.
 type lagState struct {
 	serverHead atomic.Uint64
-	received   atomic.Uint64
 	streaming  atomic.Bool
 }
 
@@ -82,9 +81,8 @@ func newLagState() *lagState {
 	return &lagState{}
 }
 
-func (l *lagState) observe(serverWALEnd, received pglogrepl.LSN) {
+func (l *lagState) observe(serverWALEnd pglogrepl.LSN) {
 	storeMax(&l.serverHead, uint64(serverWALEnd))
-	storeMax(&l.received, uint64(received))
 }
 
 func storeMax(dst *atomic.Uint64, v uint64) {

--- a/pkg/source/postgres_cdc/commit_state.go
+++ b/pkg/source/postgres_cdc/commit_state.go
@@ -66,6 +66,36 @@ func (p *streamPosition) Committed() pglogrepl.LSN {
 	return pglogrepl.LSN(p.committed.Load())
 }
 
+// lagState tracks the server's WAL head so replication lag can be reported as
+// serverHead - pos.Committed(), which is what the slot's
+// pg_current_wal_lsn() - confirmed_flush_lsn shows. It lives on the source, not
+// the replicator: replicators are rebuilt on reconnect and on new-table
+// discovery, which would otherwise reset the head. Written by the replication
+// goroutine and read by the metrics scraper, so every field is atomic.
+type lagState struct {
+	serverHead atomic.Uint64
+	received   atomic.Uint64
+	streaming  atomic.Bool
+}
+
+func newLagState() *lagState {
+	return &lagState{}
+}
+
+func (l *lagState) observe(serverWALEnd, received pglogrepl.LSN) {
+	storeMax(&l.serverHead, uint64(serverWALEnd))
+	storeMax(&l.received, uint64(received))
+}
+
+func storeMax(dst *atomic.Uint64, v uint64) {
+	for {
+		cur := dst.Load()
+		if v <= cur || dst.CompareAndSwap(cur, v) {
+			return
+		}
+	}
+}
+
 // lowWaterReporter exposes the in-flight position state needed to compute a
 // safe commit LSN. Both the single- and multi-table replicators implement it.
 type lowWaterReporter interface {

--- a/pkg/source/postgres_cdc/lag_test.go
+++ b/pkg/source/postgres_cdc/lag_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestReplicationLagNotStreaming(t *testing.T) {
 	s := NewPostgresCDCSource()
-	s.lag.observe(pglogrepl.LSN(5000), pglogrepl.LSN(5000))
+	s.lag.observe(pglogrepl.LSN(5000))
 
 	// Batch runs never call CommitStream, so pos stays 0 and reporting
 	// serverHead-0 would claim the whole WAL as lag.
@@ -29,7 +29,7 @@ func TestReplicationLagNoServerPositionYet(t *testing.T) {
 func TestReplicationLagBytesBehind(t *testing.T) {
 	s := NewPostgresCDCSource()
 	s.lag.streaming.Store(true)
-	s.lag.observe(pglogrepl.LSN(9000), pglogrepl.LSN(9000))
+	s.lag.observe(pglogrepl.LSN(9000))
 	s.pos.Commit(pglogrepl.LSN(8000))
 
 	snap, ok := s.ReplicationLag()
@@ -53,7 +53,7 @@ func TestReplicationLagBytesBehind(t *testing.T) {
 func TestReplicationLagCaughtUp(t *testing.T) {
 	s := NewPostgresCDCSource()
 	s.lag.streaming.Store(true)
-	s.lag.observe(pglogrepl.LSN(9000), pglogrepl.LSN(9000))
+	s.lag.observe(pglogrepl.LSN(9000))
 	s.pos.Commit(pglogrepl.LSN(9000))
 
 	snap, ok := s.ReplicationLag()
@@ -70,7 +70,7 @@ func TestReplicationLagCaughtUp(t *testing.T) {
 func TestReplicationLagCommittedAheadOfHeadSaturates(t *testing.T) {
 	s := NewPostgresCDCSource()
 	s.lag.streaming.Store(true)
-	s.lag.observe(pglogrepl.LSN(100), pglogrepl.LSN(100))
+	s.lag.observe(pglogrepl.LSN(100))
 	s.pos.Commit(pglogrepl.LSN(500))
 
 	snap, ok := s.ReplicationLag()
@@ -89,13 +89,10 @@ func TestReplicationLagCommittedAheadOfHeadSaturates(t *testing.T) {
 // must not follow it backwards.
 func TestLagStateObserveIsMonotonic(t *testing.T) {
 	l := newLagState()
-	l.observe(pglogrepl.LSN(9000), pglogrepl.LSN(8000))
-	l.observe(pglogrepl.LSN(500), pglogrepl.LSN(400))
+	l.observe(pglogrepl.LSN(9000))
+	l.observe(pglogrepl.LSN(500))
 
 	if got := l.serverHead.Load(); got != 9000 {
 		t.Fatalf("expected stale server head to be ignored, got %d", got)
-	}
-	if got := l.received.Load(); got != 8000 {
-		t.Fatalf("expected stale received position to be ignored, got %d", got)
 	}
 }

--- a/pkg/source/postgres_cdc/lag_test.go
+++ b/pkg/source/postgres_cdc/lag_test.go
@@ -1,0 +1,101 @@
+package postgres_cdc
+
+import (
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+)
+
+func TestReplicationLagNotStreaming(t *testing.T) {
+	s := NewPostgresCDCSource()
+	s.lag.observe(pglogrepl.LSN(5000), pglogrepl.LSN(5000))
+
+	// Batch runs never call CommitStream, so pos stays 0 and reporting
+	// serverHead-0 would claim the whole WAL as lag.
+	if _, ok := s.ReplicationLag(); ok {
+		t.Fatal("expected no lag snapshot outside streaming mode")
+	}
+}
+
+func TestReplicationLagNoServerPositionYet(t *testing.T) {
+	s := NewPostgresCDCSource()
+	s.lag.streaming.Store(true)
+
+	if _, ok := s.ReplicationLag(); ok {
+		t.Fatal("expected no lag snapshot before any server position is observed")
+	}
+}
+
+func TestReplicationLagBytesBehind(t *testing.T) {
+	s := NewPostgresCDCSource()
+	s.lag.streaming.Store(true)
+	s.lag.observe(pglogrepl.LSN(9000), pglogrepl.LSN(9000))
+	s.pos.Commit(pglogrepl.LSN(8000))
+
+	snap, ok := s.ReplicationLag()
+	if !ok {
+		t.Fatal("expected a lag snapshot")
+	}
+	if snap.BytesBehind == nil || *snap.BytesBehind != 1000 {
+		t.Fatalf("expected 1000 bytes behind, got %v", snap.BytesBehind)
+	}
+	if snap.CaughtUp {
+		t.Fatal("expected caught_up=false while behind")
+	}
+	if snap.SecondsBehind != nil {
+		t.Fatal("postgres cannot express seconds behind; it must be omitted")
+	}
+	if snap.ServerPosition != pglogrepl.LSN(9000).String() {
+		t.Fatalf("unexpected server position %q", snap.ServerPosition)
+	}
+}
+
+func TestReplicationLagCaughtUp(t *testing.T) {
+	s := NewPostgresCDCSource()
+	s.lag.streaming.Store(true)
+	s.lag.observe(pglogrepl.LSN(9000), pglogrepl.LSN(9000))
+	s.pos.Commit(pglogrepl.LSN(9000))
+
+	snap, ok := s.ReplicationLag()
+	if !ok {
+		t.Fatal("expected a lag snapshot")
+	}
+	if *snap.BytesBehind != 0 || !snap.CaughtUp {
+		t.Fatalf("expected caught up with 0 bytes behind, got %d / %v", *snap.BytesBehind, snap.CaughtUp)
+	}
+}
+
+// LSN is a uint64: a committed position ahead of the observed head must clamp
+// to zero rather than wrapping to ~1.8e19.
+func TestReplicationLagCommittedAheadOfHeadSaturates(t *testing.T) {
+	s := NewPostgresCDCSource()
+	s.lag.streaming.Store(true)
+	s.lag.observe(pglogrepl.LSN(100), pglogrepl.LSN(100))
+	s.pos.Commit(pglogrepl.LSN(500))
+
+	snap, ok := s.ReplicationLag()
+	if !ok {
+		t.Fatal("expected a lag snapshot")
+	}
+	if *snap.BytesBehind != 0 {
+		t.Fatalf("expected saturating subtraction to yield 0, got %d", *snap.BytesBehind)
+	}
+	if !snap.CaughtUp {
+		t.Fatal("expected caught_up=true when committed is ahead of the head")
+	}
+}
+
+// A replicator rebuilt on reconnect restarts at an older position; the head
+// must not follow it backwards.
+func TestLagStateObserveIsMonotonic(t *testing.T) {
+	l := newLagState()
+	l.observe(pglogrepl.LSN(9000), pglogrepl.LSN(8000))
+	l.observe(pglogrepl.LSN(500), pglogrepl.LSN(400))
+
+	if got := l.serverHead.Load(); got != 9000 {
+		t.Fatalf("expected stale server head to be ignored, got %d", got)
+	}
+	if got := l.received.Load(); got != 8000 {
+		t.Fatalf("expected stale received position to be ignored, got %d", got)
+	}
+}

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -45,6 +45,8 @@ type MultiTableReplicator struct {
 func NewMultiTableReplicator(src *PostgresCDCSource, tables []source.SourceTableInfo, cdcConfig CDCConfig, startLSN pglogrepl.LSN, lsnFilter LSNUpdater, streaming bool) (*MultiTableReplicator, error) {
 	decoder := NewMultiTableDecoder(tables)
 
+	src.lag.streaming.Store(streaming)
+
 	return &MultiTableReplicator{
 		source:        src,
 		tables:        tables,
@@ -122,7 +124,7 @@ func (r *MultiTableReplicator) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start replication: %w", err)
 	}
 
-	r.recv = startWALReceiver(ctx, r.source.replConn, r.streaming, r.startLSN, r.source.pos)
+	r.recv = startWALReceiver(ctx, r.source.replConn, r.streaming, r.startLSN, r.source.pos, r.source.lag)
 	r.started = true
 	config.Debug("[CDC] Multi-table replication started successfully")
 	return nil

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -30,6 +30,8 @@ func NewReplicator(src *PostgresCDCSource, tableName string, tableSchema *schema
 
 	decoder := NewDecoder(tableSchema, schemaName, tblName)
 
+	src.lag.streaming.Store(streaming)
+
 	return &Replicator{
 		source:        src,
 		tableName:     tableName,
@@ -179,6 +181,7 @@ func (r *Replicator) NextChanges(ctx context.Context) ([]Change, pglogrepl.LSN, 
 			if pkm.ServerWALEnd > r.clientXLogPos {
 				r.clientXLogPos = pkm.ServerWALEnd
 			}
+			r.source.lag.observe(pkm.ServerWALEnd, r.clientXLogPos)
 
 		case pglogrepl.XLogDataByteID:
 			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
@@ -194,6 +197,9 @@ func (r *Replicator) NextChanges(ctx context.Context) ([]Change, pglogrepl.LSN, 
 			if xld.WALStart > r.clientXLogPos {
 				r.clientXLogPos = xld.WALStart
 			}
+			// ServerWALEnd, not WALStart: during a long burst with no
+			// interleaved keepalive it is the only fresh view of the head.
+			r.source.lag.observe(xld.ServerWALEnd, r.clientXLogPos)
 
 			return changes, r.decoder.CurrentTxLSN(), true, nil
 		}

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -181,7 +181,7 @@ func (r *Replicator) NextChanges(ctx context.Context) ([]Change, pglogrepl.LSN, 
 			if pkm.ServerWALEnd > r.clientXLogPos {
 				r.clientXLogPos = pkm.ServerWALEnd
 			}
-			r.source.lag.observe(pkm.ServerWALEnd, r.clientXLogPos)
+			r.source.lag.observe(pkm.ServerWALEnd)
 
 		case pglogrepl.XLogDataByteID:
 			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
@@ -199,7 +199,7 @@ func (r *Replicator) NextChanges(ctx context.Context) ([]Change, pglogrepl.LSN, 
 			}
 			// ServerWALEnd, not WALStart: during a long burst with no
 			// interleaved keepalive it is the only fresh view of the head.
-			r.source.lag.observe(xld.ServerWALEnd, r.clientXLogPos)
+			r.source.lag.observe(xld.ServerWALEnd)
 
 			return changes, r.decoder.CurrentTxLSN(), true, nil
 		}

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -83,6 +83,9 @@ type PostgresCDCSource struct {
 	// replicator's 10s standby timer fires. Stays zero in streaming mode.
 	caughtUp *streamPosition
 
+	// lag tracks the server's WAL head for replication-lag reporting.
+	lag *lagState
+
 	// keepalive coordinates a goroutine that periodically pings the
 	// walsender with a WALWritePosition-only standby update during the
 	// destination-write phase. Without it, a write that outlasts
@@ -95,8 +98,10 @@ type PostgresCDCSource struct {
 }
 
 func NewPostgresCDCSource() *PostgresCDCSource {
-	return &PostgresCDCSource{pos: newStreamPosition(), caughtUp: newStreamPosition()}
+	return &PostgresCDCSource{pos: newStreamPosition(), caughtUp: newStreamPosition(), lag: newLagState()}
 }
+
+var _ source.LagReporter = (*PostgresCDCSource)(nil)
 
 func (s *PostgresCDCSource) Schemes() []string {
 	return []string{"postgres+cdc", "postgresql+cdc"}
@@ -334,6 +339,37 @@ func (s *PostgresCDCSource) CommitStream(_ context.Context, token any) error {
 	s.pos.Commit(lsn)
 	config.Debug("[CDC] Confirmed durable LSN: %s", lsn)
 	return nil
+}
+
+// ReplicationLag reports how many WAL bytes the durable destination position
+// trails the server's WAL head. It is only meaningful while streaming: batch
+// runs never call CommitStream, so pos stays zero and the difference would
+// report the entire WAL as lag.
+func (s *PostgresCDCSource) ReplicationLag() (source.LagSnapshot, bool) {
+	if s.lag == nil || s.pos == nil || !s.lag.streaming.Load() {
+		return source.LagSnapshot{}, false
+	}
+	head := s.lag.serverHead.Load()
+	if head == 0 {
+		return source.LagSnapshot{}, false
+	}
+	committed := uint64(s.pos.Committed())
+
+	// Saturating: LSN is a uint64, and committed briefly exceeding head after a
+	// reconnect would otherwise wrap to ~1.8e19.
+	var behind uint64
+	if head > committed {
+		behind = head - committed
+	}
+
+	return source.LagSnapshot{
+		Source:          "postgres_cdc",
+		BytesBehind:     &behind,
+		ServerPosition:  pglogrepl.LSN(head).String(),
+		DurablePosition: pglogrepl.LSN(committed).String(),
+		CaughtUp:        behind == 0,
+		UpdatedAt:       time.Now(),
+	}, true
 }
 
 // recordCaughtUpLSN records the LSN a batch run has streamed up to. It is sent

--- a/pkg/source/postgres_cdc/wal_receiver.go
+++ b/pkg/source/postgres_cdc/wal_receiver.go
@@ -47,6 +47,7 @@ type walReceiver struct {
 	streaming bool
 	startLSN  pglogrepl.LSN
 	pos       *streamPosition
+	lag       *lagState
 
 	received atomic.Uint64 // highest LSN received from the server
 
@@ -60,14 +61,14 @@ type walReceiver struct {
 	savedErr error
 }
 
-func startWALReceiver(ctx context.Context, conn *pgconn.PgConn, streaming bool, startLSN pglogrepl.LSN, pos *streamPosition) *walReceiver {
+func startWALReceiver(ctx context.Context, conn *pgconn.PgConn, streaming bool, startLSN pglogrepl.LSN, pos *streamPosition, lag *lagState) *walReceiver {
 	return startWALReceiverFuncs(
 		ctx,
 		conn.ReceiveMessage,
 		func(ctx context.Context, ssu pglogrepl.StandbyStatusUpdate) error {
 			return pglogrepl.SendStandbyStatusUpdate(ctx, conn, ssu)
 		},
-		streaming, startLSN, pos,
+		streaming, startLSN, pos, lag,
 	)
 }
 
@@ -78,6 +79,7 @@ func startWALReceiverFuncs(
 	streaming bool,
 	startLSN pglogrepl.LSN,
 	pos *streamPosition,
+	lag *lagState,
 ) *walReceiver {
 	rctx, cancel := context.WithCancel(ctx)
 	r := &walReceiver{
@@ -86,6 +88,7 @@ func startWALReceiverFuncs(
 		streaming:        streaming,
 		startLSN:         startLSN,
 		pos:              pos,
+		lag:              lag,
 		msgs:             make(chan walMessage, walReceiveBuffer),
 		errc:             make(chan error, 1),
 		done:             make(chan struct{}),
@@ -204,6 +207,7 @@ func (r *walReceiver) run(ctx context.Context) {
 				return
 			}
 			r.noteReceived(pkm.ServerWALEnd)
+			r.lag.observe(pkm.ServerWALEnd, r.receivedLSN())
 			if pkm.ReplyRequested {
 				if err := r.sendStatus(ctx, false); err != nil {
 					r.fail(fmt.Errorf("failed to send standby status (replication connection lost): %w", err))
@@ -222,6 +226,9 @@ func (r *walReceiver) run(ctx context.Context) {
 				return
 			}
 			r.noteReceived(xld.WALStart)
+			// ServerWALEnd, not WALStart: during a long burst with no
+			// interleaved keepalive it is the only fresh view of the head.
+			r.lag.observe(xld.ServerWALEnd, r.receivedLSN())
 			// Copy: pgconn's message buffer is only valid until the next
 			// receive, and this payload sits in the channel while the socket
 			// keeps draining.

--- a/pkg/source/postgres_cdc/wal_receiver.go
+++ b/pkg/source/postgres_cdc/wal_receiver.go
@@ -207,7 +207,7 @@ func (r *walReceiver) run(ctx context.Context) {
 				return
 			}
 			r.noteReceived(pkm.ServerWALEnd)
-			r.lag.observe(pkm.ServerWALEnd, r.receivedLSN())
+			r.lag.observe(pkm.ServerWALEnd)
 			if pkm.ReplyRequested {
 				if err := r.sendStatus(ctx, false); err != nil {
 					r.fail(fmt.Errorf("failed to send standby status (replication connection lost): %w", err))
@@ -228,7 +228,7 @@ func (r *walReceiver) run(ctx context.Context) {
 			r.noteReceived(xld.WALStart)
 			// ServerWALEnd, not WALStart: during a long burst with no
 			// interleaved keepalive it is the only fresh view of the head.
-			r.lag.observe(xld.ServerWALEnd, r.receivedLSN())
+			r.lag.observe(xld.ServerWALEnd)
 			// Copy: pgconn's message buffer is only valid until the next
 			// receive, and this payload sits in the channel while the socket
 			// keeps draining.

--- a/pkg/source/postgres_cdc/wal_receiver_test.go
+++ b/pkg/source/postgres_cdc/wal_receiver_test.go
@@ -82,7 +82,7 @@ func (c *scriptedConn) statusUpdates() []pglogrepl.StandbyStatusUpdate {
 
 func startTestReceiver(t *testing.T, conn *scriptedConn, streaming bool, startLSN pglogrepl.LSN) *walReceiver {
 	t.Helper()
-	recv := startWALReceiverFuncs(context.Background(), conn.receive, conn.sendStatus, streaming, startLSN, newStreamPosition())
+	recv := startWALReceiverFuncs(context.Background(), conn.receive, conn.sendStatus, streaming, startLSN, newStreamPosition(), newLagState())
 	t.Cleanup(recv.stop)
 	return recv
 }

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -159,6 +159,29 @@ type CDCBatchFinalizer interface {
 	FinalizeBatch(ctx context.Context) error
 }
 
+// LagReporter is an optional capability for streaming sources that can report
+// how far the durable destination position trails the source's latest change.
+// Implementations must answer from lock-free atomics: the metrics layer polls
+// this on every scrape, concurrently with the replication loop.
+type LagReporter interface {
+	// ReplicationLag returns a point-in-time snapshot. ok is false when lag is
+	// not yet meaningful (not streaming, or no server position observed).
+	ReplicationLag() (LagSnapshot, bool)
+}
+
+// LagSnapshot is a self-consistent lag reading. BytesBehind and SecondsBehind
+// are nil when the engine cannot express that dimension: Postgres exposes no
+// per-LSN timestamp, and MongoDB/SQL Server logs have no comparable byte offset.
+type LagSnapshot struct {
+	Source          string
+	BytesBehind     *uint64
+	SecondsBehind   *float64
+	ServerPosition  string
+	DurablePosition string
+	CaughtUp        bool
+	UpdatedAt       time.Time
+}
+
 // MultiTableSource represents a source that emits data from multiple tables.
 // This is used for CDC sources that capture changes across multiple tables.
 type MultiTableSource interface {

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/metrics"
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -500,6 +501,18 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		}
 	}
 	l.tokenDirty = false
+
+	// Only after the commit: the counters mean "durable in the destination and
+	// acknowledged to the source", not merely "written".
+	perTable := make(map[string]int64, len(work))
+	for _, w := range work {
+		name := w.name
+		if name == "" {
+			name = w.st.destTable // single-table streams key l.tables on ""
+		}
+		perTable[name] = w.rows
+	}
+	metrics.RecordSync(perTable, time.Now())
 
 	l.cycles++
 	if flushedRows > 0 {

--- a/pkg/strategy/streaming_metrics_test.go
+++ b/pkg/strategy/streaming_metrics_test.go
@@ -1,0 +1,85 @@
+package strategy
+
+import (
+	"context"
+	"encoding/json"
+	"expvar"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rowsSyncedValue(t *testing.T) int64 {
+	t.Helper()
+	v, ok := expvar.Get("ingestr_stream_rows_synced").(*expvar.Int)
+	require.True(t, ok, "ingestr_stream_rows_synced is not an expvar.Int")
+	return v.Value()
+}
+
+func lastSyncedValue(t *testing.T) int64 {
+	t.Helper()
+	v, ok := expvar.Get("ingestr_stream_last_synced_unix").(*expvar.Int)
+	require.True(t, ok, "ingestr_stream_last_synced_unix is not an expvar.Int")
+	return v.Value()
+}
+
+func tableRowsSynced(t *testing.T, table string) float64 {
+	t.Helper()
+	var out map[string]map[string]float64
+	require.NoError(t, json.Unmarshal([]byte(expvar.Get("ingestr_stream_tables").String()), &out))
+	return out[table]["rows_synced"]
+}
+
+func TestStreaming_FlushRecordsRowsSynced(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyAppend,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchema()}})
+
+	before := rowsSyncedValue(t)
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:       int64RecordBatch(t, "id", []int64{1, 2, 3, 4}, nil),
+		CommitToken: 7,
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	assert.Equal(t, int64(4), rowsSyncedValue(t)-before)
+	// Single-table loops key l.tables on "", so the metric must fall back to
+	// the destination table name rather than publishing an empty key.
+	assert.Positive(t, tableRowsSynced(t, "ds.tbl"))
+	assert.NotZero(t, lastSyncedValue(t))
+}
+
+// A write that lands but whose source position fails to commit is not durable:
+// re-delivery will replay those rows, so counting them would double-count.
+func TestStreaming_FailedCommitDoesNotRecordRowsSynced(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{err: assert.AnError}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyAppend,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchema()}})
+
+	before := rowsSyncedValue(t)
+	beforeTS := lastSyncedValue(t)
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:       int64RecordBatch(t, "id", []int64{1, 2, 3, 4}, nil),
+		CommitToken: 7,
+	})
+	require.Error(t, loop.flush(context.Background()))
+
+	assert.Equal(t, before, rowsSyncedValue(t), "rows must not be counted when the commit fails")
+	assert.Equal(t, beforeTS, lastSyncedValue(t), "last synced must not advance when the commit fails")
+}


### PR DESCRIPTION
## What

Adds an opt-in `--metrics-addr` flag to `ingestr ingest --stream`. When set, the process serves Go [expvar](https://pkg.go.dev/expvar) metrics at `/debug/vars` for the lifetime of the stream, reporting replication lag, rows synced, and the last synced timestamp.

```bash
ingestr ingest --stream --metrics-addr 127.0.0.1:6060 \
  --source-uri 'postgres+cdc://...' --dest-uri 'bigquery://...'

curl -s localhost:6060/debug/vars | jq '.ingestr_replication, .ingestr_stream_tables'
```

Nothing is served unless the flag is set, so there is no new open port by default and no behavior change for existing runs. The listener binds before ingestion starts, so a port conflict fails immediately rather than half-way through a run, and teardown is by `defer` so it fires on every exit path — including the SIGINT that normally ends a stream.

## Why

A streaming ingest is currently a black box: there is no metrics surface anywhere in the repo, and nothing reports how far the destination trails the source. The failure mode this addresses is a replication slot that stops advancing while WAL accumulates on the source — invisible from inside the process until the source database runs out of disk.

## Replication lag

Sources opt in through a new `source.LagReporter` capability. Sources that do not implement it publish `{"streaming": false}`.

Lag is not the same quantity on every engine, so the snapshot carries optional dimensions instead of forcing a single number. Fields an engine cannot express are **omitted** rather than reported as a misleading zero.

| Source | Metric | Basis |
|---|---|---|
| `postgres+cdc` | `bytes_behind` | server WAL head − confirmed durable LSN |
| `mongodb+cdc` | `seconds_behind` | server `operationTime` − last event `clusterTime` |
| `mssql+cdc` | `seconds_behind` | processed LSN → capture watermark, via `sys.fn_cdc_map_lsn_to_time` |

**Postgres** compares against the *committed* LSN, not the received one. `clientXLogPos` is snapped up to `ServerWALEnd` on every keepalive, so `head − received` reads ~0 on any healthy stream and tells you nothing. `head − committed` is what ingestr actually sends as `WALFlushPosition`, so it equals the slot's `pg_current_wal_lsn() - confirmed_flush_lsn` — the number that predicts unbounded WAL growth. The head is tracked on the source rather than the replicator, because replicators are rebuilt on reconnect and on new-table discovery. Subtraction saturates: `pglogrepl.LSN` is a `uint64`, and a committed position transiently ahead of the head would otherwise wrap to ~1.8e19.

**MongoDB** and **MSSQL** both had to avoid the same trap — a lag metric that climbs forever on an idle database with nothing actually behind. MongoDB compares two server-side clocks (so it is also immune to client skew) rather than measuring time since the last change event; MSSQL measures to the capture watermark rather than to wall-clock `now`. Both converge to zero when caught up.

MySQL, Vitess and PlanetScale CDC do not implement `SupportsStreaming()` and cannot run under `--stream` at all, so they have no lag to report and are not covered.

## Rows synced and last synced

Published per destination table and process-wide, from the shared flush loop — so all thirteen streaming connectors get them, not just the three CDC sources.

| Key | Meaning |
|---|---|
| `ingestr_stream_rows_synced` | Cumulative rows written **and** confirmed durable |
| `ingestr_stream_flush_cycles` | Completed flush cycles |
| `ingestr_stream_last_synced_unix` | Time of the last successful commit |
| `ingestr_stream_tables` | The same, broken out per table |

Both counters advance only after the destination write **and** the source-position commit have succeeded, so they count durable rows rather than merely written ones; a flush whose commit fails leaves them untouched, because those rows will be re-delivered. `last_synced_unix` also advances on cycles that confirm a position without writing rows, which is what makes it usable as a staleness alarm: if it stops moving, the stream is stuck.

The per-table breakdown exists because a full-DB CDC stream can have one table stalled behind healthy aggregate numbers.

## Notes

- expvar vars are published once at `init()`; expvar panics on duplicate publish, which would otherwise break repeated test runs.
- The metrics server uses its own `ServeMux`, never `http.DefaultServeMux` — importing `expvar` auto-registers `/debug/vars` there, and that must not leak into the `ingestr server` web UI.
- Lag values are computed lazily inside `expvar.Func` on scrape, from lock-free atomics, so polling never blocks a replication loop.

## Tests

Unit tests for the metrics package (lag encoding, omitted fields, saturating subtraction, concurrent `RecordSync` + scrape under `-race`, `Serve` bind/stop), the Postgres lag state (monotonic head across reconnects, batch-mode gating, saturation), and the flush loop (rows counted on success; **not** counted when the commit fails).