### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,29 @@
-## Summary
+## What
+<!-- What does this PR change and why? Keep it concise. -->
 
+## Changes
+<!-- List the files/areas affected and what was done in each. -->
+-
 
+## How to test
+<!-- Steps a reviewer can follow to verify the change. -->
+1.
 
-## Risk
+## Risk & rollback
+- **Risk:** <!-- low / medium / high — and why -->
+- **Rollback:** Revert the merge commit. <!-- Note any extra steps if applicable. -->
 
-- [ ] Security-relevant (credentials, connection strings, secrets)
-- [ ] Data impact (how data is read, written, or transformed)
-- [ ] Breaking change
-- [ ] None of the above
+## Checklist
+- [ ] Unit tests added or updated (`make test`)
+- [ ] Format and lint pass (`make format`, `make lint`)
+- [ ] Integration tests pass if affected (`make test-integration`)
+- [ ] No unrelated changes included
+- [ ] Tested locally
 
-## Tests
+## Security
+- [ ] No secrets, credentials, or PII in this change
+- [ ] No new dependencies with known vulnerabilities
+- [ ] Security implications considered (if applicable)
 
-- [ ] `make format`
-- [ ] `make lint`
-- [ ] `make test`
-
-## Rollback
-
-Revert the merge commit.
+## Related issues
+<!-- Link the issue(s) this PR closes, e.g. Closes #1234 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+
+
+## Risk
+
+- [ ] Security-relevant (credentials, connection strings, secrets)
+- [ ] Data impact (how data is read, written, or transformed)
+- [ ] Breaking change
+- [ ] None of the above
+
+## Tests
+
+- [ ] `make format`
+- [ ] `make lint`
+- [ ] `make test`
+
+## Rollback
+
+Revert the merge commit.


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md` to standardize PRs for SOC 2 change-management.

Sections: what/changes/how-to-test, a two-line risk & rollback note, a repo-specific test/lint checklist (`make test`, `make format`, `make lint`, `make test-integration`), a security review checklist, and related issues.