### PR TITLE
Wait for Postgres CDC slots before resume

### DIFF
--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -88,6 +88,7 @@ func (r *MultiTableCDCReader) Read(ctx context.Context, opts source.MultiTableRe
 				config.Debug("[CDC] Multi-table: replication slot %s not found, falling back to full snapshot", slotName)
 				needsSnapshot = true
 			} else {
+				waitReplicationSlotReleased(ctx, r.source.queryPool, slotName)
 				config.Debug("[CDC] Multi-table: resuming from LSN %s with per-table filtering", minResumeLSN)
 			}
 		}
@@ -298,27 +299,8 @@ func (r *MultiTableCDCReader) rebuildForNewTables(ctx context.Context, slotName 
 	if err := r.source.reconnectReplication(ctx); err != nil {
 		return 0, err
 	}
-	r.waitSlotReleased(ctx, slotName)
+	waitReplicationSlotReleased(ctx, r.source.queryPool, slotName)
 	return r.getSlotLSN(ctx, slotName)
-}
-
-// waitSlotReleased waits for the server to mark the slot inactive after the
-// previous replication connection was closed; claiming a still-active slot
-// makes StartReplication fail. Best-effort with a bounded wait — if the slot
-// stays active the subsequent StartReplication surfaces the real error.
-func (r *MultiTableCDCReader) waitSlotReleased(ctx context.Context, slotName string) {
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		var active bool
-		err := r.source.queryPool.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name = $1", slotName).Scan(&active)
-		if err != nil || !active {
-			return
-		}
-		if time.Now().After(deadline) || ctx.Err() != nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
 }
 
 // detectNewTables lists the tables the stream should currently cover and

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -43,6 +43,7 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 
 			// Verify the slot still exists before trying to resume
 			if _, exists, _ := checkSlotExists(ctx, r.source.queryPool, slotName); exists {
+				waitReplicationSlotReleased(ctx, r.source.queryPool, slotName)
 				config.Debug("[CDC] Resuming from LSN: %s (skipping snapshot)", opts.CDCResumeLSN)
 				resumeLSN, err := parseStoredPostgresLSN(opts.CDCResumeLSN)
 				if err != nil {

--- a/pkg/source/postgres_cdc/snapshot.go
+++ b/pkg/source/postgres_cdc/snapshot.go
@@ -140,6 +140,25 @@ func checkSlotExists(ctx context.Context, pool *pgxpool.Pool, slotName string) (
 	return *confirmedLSN, true, nil
 }
 
+// waitReplicationSlotReleased waits for PostgreSQL to mark a slot inactive
+// after the previous replication connection was closed. Claiming a still-active
+// slot makes StartReplication fail. This is best-effort with a bounded wait; if
+// the slot stays active, the subsequent StartReplication returns the real error.
+func waitReplicationSlotReleased(ctx context.Context, pool *pgxpool.Pool, slotName string) {
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var active bool
+		err := pool.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name = $1", slotName).Scan(&active)
+		if err != nil || !active {
+			return
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
 // dropSlot drops the replication slot
 func (s *Snapshot) dropSlot(ctx context.Context) error {
 	_, err := s.source.queryPool.Exec(ctx, "SELECT pg_drop_replication_slot($1)", s.slotName)


### PR DESCRIPTION
Wait for existing Postgres CDC replication slots to become inactive before resuming from them. This prevents batch retries or back-to-back runs from racing Postgres slot cleanup and failing with an active-slot error. Also reuses the same wait helper for the multi-table stream rebuild path.\n\nValidated with `go test ./pkg/source/postgres_cdc`, the targeted Postgres CDC integration test, `make format`, `make lint`, and `make test`.