### PR TITLE
feat(bigquery): reconcile partition/cluster changes and normalize partition names

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -415,6 +415,11 @@ func (d *BigQueryDestination) partitionOrClusterMismatch(meta *bigquery.TableMet
 		if meta.TimePartitioning == nil || !strings.EqualFold(meta.TimePartitioning.Field, d.partitionBy) {
 			return true
 		}
+		// Compare the partition type against what we would create; ingestr builds
+		// only Field, so the desired type is BigQuery's default.
+		if effectivePartitionType(meta.TimePartitioning) != effectivePartitionType(&bigquery.TimePartitioning{Field: d.partitionBy}) {
+			return true
+		}
 	} else if meta.TimePartitioning != nil {
 		return true
 	}
@@ -432,6 +437,15 @@ func (d *BigQueryDestination) partitionOrClusterMismatch(meta *bigquery.TableMet
 		}
 	}
 	return false
+}
+
+// effectivePartitionType returns the time-partitioning type, resolving the unset
+// value to BigQuery's default (DAY) so a stored type compares equal to an unset one.
+func effectivePartitionType(tp *bigquery.TimePartitioning) bigquery.TimePartitioningType {
+	if tp == nil || tp.Type == "" {
+		return bigquery.DayPartitioningType
+	}
+	return tp.Type
 }
 
 type mergePartitionPruning struct {

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -405,6 +405,35 @@ func partitionByClause(column string, isDateColumn bool) string {
 	return fmt.Sprintf("PARTITION BY DATE(%s)\n", quoteIdentifier(column))
 }
 
+// partitionOrClusterMismatch reports whether the table's partition/cluster spec
+// differs from the configured partitionBy/clusterBy (range partitioning always mismatches).
+func (d *BigQueryDestination) partitionOrClusterMismatch(meta *bigquery.TableMetadata) bool {
+	if meta.RangePartitioning != nil {
+		return true
+	}
+	if d.partitionBy != "" {
+		if meta.TimePartitioning == nil || !strings.EqualFold(meta.TimePartitioning.Field, d.partitionBy) {
+			return true
+		}
+	} else if meta.TimePartitioning != nil {
+		return true
+	}
+
+	var existingCluster []string
+	if meta.Clustering != nil {
+		existingCluster = meta.Clustering.Fields
+	}
+	if len(existingCluster) != len(d.clusterBy) {
+		return true
+	}
+	for i := range existingCluster {
+		if !strings.EqualFold(existingCluster[i], d.clusterBy[i]) {
+			return true
+		}
+	}
+	return false
+}
+
 type mergePartitionPruning struct {
 	Column string
 	IsDate bool
@@ -1023,6 +1052,20 @@ func (d *BigQueryDestination) SwapTable(ctx context.Context, opts destination.Sw
 	// auto-create the dataset — they fail with "Not found: Dataset ...".
 	if err := d.ensureDatasetExists(ctx, targetProject, targetDataset); err != nil {
 		return fmt.Errorf("failed to ensure target dataset exists: %w", err)
+	}
+
+	// BigQuery can't ALTER partitioning/clustering, so drop a target whose spec
+	// differs; safe here because replace (SwapTable's only caller) overwrites it.
+	targetRef := d.client.DatasetInProject(targetProject, targetDataset).Table(targetTableName)
+	if meta, err := targetRef.Metadata(ctx); err == nil {
+		if d.partitionOrClusterMismatch(meta) {
+			config.Debug("[DEST] Target %s partition/cluster spec changed; dropping to recreate", targetTable)
+			if err := targetRef.Delete(ctx); err != nil && !isNotFoundError(err) {
+				return fmt.Errorf("failed to drop target table for repartitioning: %w", err)
+			}
+		}
+	} else if !isNotFoundError(err) {
+		return fmt.Errorf("failed to check target table metadata: %w", err)
 	}
 
 	stagingRef := d.client.DatasetInProject(stagingProject, stagingDataset).Table(stagingTableName)

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -1979,7 +1979,7 @@ func TestPartitionOrClusterMismatch(t *testing.T) {
 			want:        true,
 		},
 
-		// --- partition: type/granularity is ignored (ingestr only emits DAY column partitioning) ---
+		// --- partition: type compared against what ingestr creates (DAY default) ---
 		{
 			name:        "same field, table has explicit DAY type",
 			partitionBy: "d1",
@@ -1990,7 +1990,13 @@ func TestPartitionOrClusterMismatch(t *testing.T) {
 			name:        "same field, table has HOUR type",
 			partitionBy: "ts",
 			meta:        &bigquery.TableMetadata{TimePartitioning: &bigquery.TimePartitioning{Field: "ts", Type: bigquery.HourPartitioningType}},
-			want:        false,
+			want:        true,
+		},
+		{
+			name:        "same field, table has MONTH type",
+			partitionBy: "ts",
+			meta:        &bigquery.TableMetadata{TimePartitioning: &bigquery.TimePartitioning{Field: "ts", Type: bigquery.MonthPartitioningType}},
+			want:        true,
 		},
 
 		// --- partition: range partitioning always mismatches ---

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -1885,3 +1885,240 @@ func TestIsNotFoundError_Wrapped(t *testing.T) {
 		t.Fatalf("expected isNotFoundError to return true for wrapped error: %v", wrapped)
 	}
 }
+
+func TestPartitionOrClusterMismatch(t *testing.T) {
+	tp := func(field string) *bigquery.TimePartitioning { return &bigquery.TimePartitioning{Field: field} }
+	cl := func(fields ...string) *bigquery.Clustering { return &bigquery.Clustering{Fields: fields} }
+
+	tests := []struct {
+		name        string
+		partitionBy string
+		clusterBy   []string
+		meta        *bigquery.TableMetadata
+		want        bool
+	}{
+		// --- partition: neither side partitioned ---
+		{
+			name: "no partition either side",
+			meta: &bigquery.TableMetadata{},
+			want: false,
+		},
+		{
+			name: "no partition, empty TimePartitioning pointer is nil",
+			meta: &bigquery.TableMetadata{TimePartitioning: nil},
+			want: false,
+		},
+
+		// --- partition: field name matching ---
+		{
+			name:        "same partition field",
+			partitionBy: "d1",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1")},
+			want:        false,
+		},
+		{
+			name:        "same partition field, config uppercase",
+			partitionBy: "D1",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1")},
+			want:        false,
+		},
+		{
+			name:        "same partition field, table uppercase",
+			partitionBy: "created_at",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("CREATED_AT")},
+			want:        false,
+		},
+		{
+			name:        "same partition field, mixed case",
+			partitionBy: "EventDate",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("eventdate")},
+			want:        false,
+		},
+		{
+			name:        "partition field changed",
+			partitionBy: "d2",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1")},
+			want:        true,
+		},
+		{
+			name:        "partition field differs only by underscore",
+			partitionBy: "created_at",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("createdat")},
+			want:        true,
+		},
+		{
+			name:        "partition field is prefix of other",
+			partitionBy: "date",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("date2")},
+			want:        true,
+		},
+
+		// --- partition: presence vs absence ---
+		{
+			name:        "want partition but table has none",
+			partitionBy: "d1",
+			meta:        &bigquery.TableMetadata{},
+			want:        true,
+		},
+		{
+			name:        "want no partition but table is column-partitioned",
+			partitionBy: "",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1")},
+			want:        true,
+		},
+		{
+			name:        "want no partition but table is ingestion-time partitioned",
+			partitionBy: "",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("")},
+			want:        true,
+		},
+		{
+			name:        "want column partition but table is ingestion-time partitioned",
+			partitionBy: "d1",
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("")},
+			want:        true,
+		},
+
+		// --- partition: type/granularity is ignored (ingestr only emits DAY column partitioning) ---
+		{
+			name:        "same field, table has explicit DAY type",
+			partitionBy: "d1",
+			meta:        &bigquery.TableMetadata{TimePartitioning: &bigquery.TimePartitioning{Field: "d1", Type: bigquery.DayPartitioningType}},
+			want:        false,
+		},
+		{
+			name:        "same field, table has HOUR type",
+			partitionBy: "ts",
+			meta:        &bigquery.TableMetadata{TimePartitioning: &bigquery.TimePartitioning{Field: "ts", Type: bigquery.HourPartitioningType}},
+			want:        false,
+		},
+
+		// --- partition: range partitioning always mismatches ---
+		{
+			name: "range partitioning, want none",
+			meta: &bigquery.TableMetadata{RangePartitioning: &bigquery.RangePartitioning{Field: "n"}},
+			want: true,
+		},
+		{
+			name:        "range partitioning, want column partition",
+			partitionBy: "d1",
+			meta:        &bigquery.TableMetadata{RangePartitioning: &bigquery.RangePartitioning{Field: "n"}},
+			want:        true,
+		},
+		{
+			name:        "range partitioning wins even if time field would match",
+			partitionBy: "d1",
+			meta: &bigquery.TableMetadata{
+				TimePartitioning:  tp("d1"),
+				RangePartitioning: &bigquery.RangePartitioning{Field: "n"},
+			},
+			want: true,
+		},
+
+		// --- clustering only (partition matched on both sides as none) ---
+		{
+			name:      "cluster: neither side clustered",
+			clusterBy: nil,
+			meta:      &bigquery.TableMetadata{},
+			want:      false,
+		},
+		{
+			name:      "cluster: table has empty Clustering, config none",
+			clusterBy: nil,
+			meta:      &bigquery.TableMetadata{Clustering: &bigquery.Clustering{}},
+			want:      false,
+		},
+		{
+			name:      "cluster: same single field",
+			clusterBy: []string{"a"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("a")},
+			want:      false,
+		},
+		{
+			name:      "cluster: same multi field same order",
+			clusterBy: []string{"a", "b", "c"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("a", "b", "c")},
+			want:      false,
+		},
+		{
+			name:      "cluster: case-insensitive match",
+			clusterBy: []string{"Country", "REGION"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("country", "region")},
+			want:      false,
+		},
+		{
+			name:      "cluster: order changed",
+			clusterBy: []string{"a", "b"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("b", "a")},
+			want:      true,
+		},
+		{
+			name:      "cluster: added (config has, table none)",
+			clusterBy: []string{"a"},
+			meta:      &bigquery.TableMetadata{},
+			want:      true,
+		},
+		{
+			name:      "cluster: removed (table has, config none)",
+			clusterBy: nil,
+			meta:      &bigquery.TableMetadata{Clustering: cl("a")},
+			want:      true,
+		},
+		{
+			name:      "cluster: subset fewer fields",
+			clusterBy: []string{"a"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("a", "b")},
+			want:      true,
+		},
+		{
+			name:      "cluster: same fields but extra config field",
+			clusterBy: []string{"a", "b", "c"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("a", "b")},
+			want:      true,
+		},
+		{
+			name:      "cluster: one field differs",
+			clusterBy: []string{"a", "b"},
+			meta:      &bigquery.TableMetadata{Clustering: cl("a", "x")},
+			want:      true,
+		},
+
+		// --- combined partition + clustering ---
+		{
+			name:        "combined: partition and cluster both match",
+			partitionBy: "d1",
+			clusterBy:   []string{"a", "b"},
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1"), Clustering: cl("a", "b")},
+			want:        false,
+		},
+		{
+			name:        "combined: partition matches, cluster differs",
+			partitionBy: "d1",
+			clusterBy:   []string{"a", "b"},
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1"), Clustering: cl("a")},
+			want:        true,
+		},
+		{
+			name:        "combined: partition differs, cluster matches",
+			partitionBy: "d2",
+			clusterBy:   []string{"a"},
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1"), Clustering: cl("a")},
+			want:        true,
+		},
+		{
+			name:        "combined: both differ",
+			partitionBy: "d2",
+			clusterBy:   []string{"a"},
+			meta:        &bigquery.TableMetadata{TimePartitioning: tp("d1"), Clustering: cl("b")},
+			want:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &BigQueryDestination{partitionBy: tt.partitionBy, clusterBy: tt.clusterBy}
+			if got := d.partitionOrClusterMismatch(tt.meta); got != tt.want {
+				t.Fatalf("partitionOrClusterMismatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/naming/partition_naming_matrix_test.go
+++ b/pkg/naming/partition_naming_matrix_test.go
@@ -1,0 +1,49 @@
+package naming
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPartitionColumnNamingMatrix documents and locks the contract the pipeline
+// relies on: partition_by/cluster_by are normalized with the SAME convention as
+// the destination columns, so they resolve to the same destination column name.
+//
+// destColumn = Normalize(sourceColumn)   (what applyColumnMapping produces)
+// partition  = Normalize(partitionBy)    (what the pipeline passes to the dest)
+// BigQuery resolves the partition field against columns case-insensitively.
+func TestPartitionColumnNamingMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		partitionBy   string
+		sourceColumn  string
+		convention    Convention
+		wantPartition string // normalized value handed to the destination
+		wantMatch     bool   // whether it matches the destination column (success)
+	}{
+		{"camel/camel/snake", "updatedAt", "updatedAt", SnakeCase, "updated_at", true},
+		{"camel/camel/direct", "updatedAt", "updatedAt", Direct, "updatedAt", true},
+		{"snake/snake/snake", "updated_at", "updated_at", SnakeCase, "updated_at", true},
+		{"snake/snake/direct", "updated_at", "updated_at", Direct, "updated_at", true},
+		{"camel/snake/snake", "updatedAt", "updated_at", SnakeCase, "updated_at", true},
+		{"camel/snake/direct", "updatedAt", "updated_at", Direct, "updatedAt", false},
+		{"snake/camel/snake", "updated_at", "updatedAt", SnakeCase, "updated_at", true},
+		{"snake/camel/direct", "updated_at", "updatedAt", Direct, "updated_at", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := Get(tt.convention)
+			gotPartition := conv.Normalize(tt.partitionBy)
+			if gotPartition != tt.wantPartition {
+				t.Fatalf("Normalize(%q) under %s = %q, want %q",
+					tt.partitionBy, tt.convention, gotPartition, tt.wantPartition)
+			}
+			destColumn := conv.Normalize(tt.sourceColumn)
+			gotMatch := strings.EqualFold(gotPartition, destColumn)
+			if gotMatch != tt.wantMatch {
+				t.Fatalf("match(partition=%q, destColumn=%q) = %v, want %v",
+					gotPartition, destColumn, gotMatch, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -429,7 +429,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	case resolvedConfig.PartitionBy != "":
 		resolvedConfig.PartitionBy = namingConv.Normalize(resolvedConfig.PartitionBy)
 	case tableSchema.PartitionBy != "":
-		resolvedConfig.PartitionBy = tableSchema.PartitionBy
+		resolvedConfig.PartitionBy = namingConv.Normalize(tableSchema.PartitionBy)
 	}
 	if len(resolvedConfig.ClusterBy) > 0 {
 		clusterBy := make([]string, len(resolvedConfig.ClusterBy))

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -423,8 +423,20 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	resolvedConfig.IncrementalKey = tableSchema.IncrementalKey
 	resolvedConfig.IncrementalStrategy = resolvedStrategy
 
-	if resolvedConfig.PartitionBy == "" && tableSchema.PartitionBy != "" {
+	// partition_by/cluster_by name destination columns, so apply the same naming
+	// convention that renamed the columns (e.g. snake_case); no-op for direct naming.
+	switch {
+	case resolvedConfig.PartitionBy != "":
+		resolvedConfig.PartitionBy = namingConv.Normalize(resolvedConfig.PartitionBy)
+	case tableSchema.PartitionBy != "":
 		resolvedConfig.PartitionBy = tableSchema.PartitionBy
+	}
+	if len(resolvedConfig.ClusterBy) > 0 {
+		clusterBy := make([]string, len(resolvedConfig.ClusterBy))
+		for i, col := range resolvedConfig.ClusterBy {
+			clusterBy[i] = namingConv.Normalize(col)
+		}
+		resolvedConfig.ClusterBy = clusterBy
 	}
 
 	// Primary key columns must be NOT NULL


### PR DESCRIPTION
## What 

`SwapTable` now drops a target whose partition/cluster spec differs from the requested one before recreating it. This is safe because `SwapTable` is only reached from the **replace** strategy, which fully overwrites the target anyway — so no data is lost beyond what replace already discards, and merge/append never reach this code.

New helper `partitionOrClusterMismatch` compares the live table's `TimePartitioning.Field` / `Clustering.Fields` against the configured `partitionBy` / `clusterBy` (case-insensitive; range-partitioned tables always mismatch since ingestr never creates them).
