### PR TITLE
Run secret-scan on PRs and pin gitleaks version

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,5 +1,8 @@
 name: secrets_scan
-on: [push, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 env:
   INGESTR_DISABLE_TELEMETRY: "true"
@@ -10,8 +13,8 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: scan for secrets (gitleaks)
-        run: docker run -v $PWD:/code -w /code ghcr.io/gitleaks/gitleaks:latest dir -v --baseline-path /code/gitleaks-baseline.json
+        run: docker run -v "$PWD:/code" -w /code ghcr.io/gitleaks/gitleaks:v8.30.1 dir -v --baseline-path /code/gitleaks-baseline.json


### PR DESCRIPTION
Upgrades the existing secret-scan workflow: also runs on `pull_request` (was push/manual only) and pins gitleaks to v8.30.1 instead of `latest` for reproducible CI. Baseline unchanged.