### PR TITLE
Avoid no-op string schema migrations

### DIFF
--- a/pkg/schemaevolution/compare.go
+++ b/pkg/schemaevolution/compare.go
@@ -112,7 +112,9 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 			}
 
 			// For string length widening, keep TypeString but grow the length.
-			isStringLengthWidening := widenedType == schema.TypeString && destCol.DataType == schema.TypeString
+			isStringLengthWidening := widenedType == schema.TypeString &&
+				destCol.DataType == schema.TypeString &&
+				stringNeedsWidening(srcCol.MaxLength, destCol.MaxLength)
 			if isStringLengthWidening {
 				newCol.MaxLength = WidenedStringLength(srcCol.MaxLength, destCol.MaxLength)
 			}

--- a/pkg/schemaevolution/stringwiden_test.go
+++ b/pkg/schemaevolution/stringwiden_test.go
@@ -96,3 +96,21 @@ func TestCompare_DecimalToExistingUnboundedString_NoSpuriousChange(t *testing.T)
 	assert.False(t, cmp.HasChanges)
 	assert.Empty(t, cmp.Changes)
 }
+
+func TestCompare_DecimalToExistingBoundedString_WidensString(t *testing.T) {
+	src := &schema.TableSchema{Columns: []schema.Column{{
+		Name:      "all_revenue_total_d90",
+		DataType:  schema.TypeDecimal,
+		Precision: 38,
+		Scale:     9,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{strCol("all_revenue_total_d90", 50)}}
+
+	cmp, err := Compare(src, dest, nil)
+	require.NoError(t, err)
+	require.True(t, cmp.HasChanges)
+	require.Len(t, cmp.Changes, 1)
+	assert.Equal(t, ChangeWidenType, cmp.Changes[0].Type)
+	assert.Equal(t, schema.TypeString, cmp.Changes[0].NewColumn.DataType)
+	assert.Zero(t, cmp.Changes[0].NewColumn.MaxLength)
+}

--- a/pkg/schemaevolution/stringwiden_test.go
+++ b/pkg/schemaevolution/stringwiden_test.go
@@ -81,3 +81,18 @@ func TestCompare_StringStable_NoSpuriousChange(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cmp.HasChanges)
 }
+
+func TestCompare_DecimalToExistingUnboundedString_NoSpuriousChange(t *testing.T) {
+	src := &schema.TableSchema{Columns: []schema.Column{{
+		Name:      "all_revenue_total_d90",
+		DataType:  schema.TypeDecimal,
+		Precision: 38,
+		Scale:     9,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{strCol("all_revenue_total_d90", 0)}}
+
+	cmp, err := Compare(src, dest, nil)
+	require.NoError(t, err)
+	assert.False(t, cmp.HasChanges)
+	assert.Empty(t, cmp.Changes)
+}


### PR DESCRIPTION
Fix schema comparison so a resolved string type only counts as a length widening when the destination length actually needs to grow.

This prevents no-op `ALTER STRING → STRING` migrations when decimal Adjust metrics meet existing unbounded string columns. Includes a regression test for `all_revenue_total_d90`; `make format`, `make lint`, and `make test` pass.
