### PR TITLE
Speed up and fix CSV-to-DuckDB ingestion

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,15 +5,33 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"runtime/pprof"
+	"sync"
 	"syscall"
 
 	"github.com/bruin-data/ingestr/cmd"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/fatih/color"
+	"github.com/urfave/cli/v3"
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	stopProfile, profiling := startCPUProfile()
+	defer stopProfile()
+	if profiling {
+		originalExiter := cli.OsExiter
+		cli.OsExiter = func(code int) {
+			stopProfile()
+			originalExiter(code)
+		}
+		defer func() { cli.OsExiter = originalExiter }()
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -30,12 +48,37 @@ func main() {
 			if !output.IsJSON() {
 				color.Red("\nPipeline cancelled.")
 			}
-			os.Exit(1)
+			return 1
 		}
 		if !output.IsJSON() {
 			color.Red("Error: %v", err)
 		}
 		config.PrintFailedQuery()
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+func startCPUProfile() (func(), bool) {
+	path := os.Getenv("INGESTR_CPUPROFILE")
+	if path == "" {
+		return func() {}, false
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return func() {}, false
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return func() {}, false
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			pprof.StopCPUProfile()
+			_ = f.Close()
+		})
+	}, true
 }

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -603,6 +603,8 @@ func AppendValue(builder array.Builder, val interface{}) {
 			v = strings.TrimSpace(v)
 			if v == "" {
 				b.AppendNull()
+			} else if num, ok := parseDecimal128Fast(v, dt.Precision, dt.Scale); ok {
+				b.Append(num)
 			} else {
 				num, err := decimal128.FromString(v, dt.Precision, dt.Scale)
 				if err != nil {
@@ -724,6 +726,85 @@ func AppendValue(builder array.Builder, val interface{}) {
 	default:
 		builder.AppendNull()
 	}
+}
+
+var pow10 = [19]int64{
+	1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000,
+	1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000,
+	100000000000000, 1000000000000000, 10000000000000000, 100000000000000000,
+	1000000000000000000,
+}
+
+// parseDecimal128Fast parses plain decimal strings ([+-]digits[.digits]) whose
+// unscaled value fits in an int64 and whose fractional digits do not exceed
+// the target scale. Anything else (exponents, rounding, huge values) reports
+// false so the caller can use decimal128.FromString.
+func parseDecimal128Fast(s string, precision, scale int32) (decimal128.Num, bool) {
+	if scale < 0 || int(scale) >= len(pow10) {
+		return decimal128.Num{}, false
+	}
+
+	i := 0
+	neg := false
+	if i < len(s) && (s[i] == '+' || s[i] == '-') {
+		neg = s[i] == '-'
+		i++
+	}
+
+	var v int64
+	nDigits := 0
+	hasDigit := false
+	seenDot := false
+	fracDigits := int32(0)
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c == '.' {
+			if seenDot {
+				return decimal128.Num{}, false
+			}
+			seenDot = true
+			continue
+		}
+		if c < '0' || c > '9' {
+			return decimal128.Num{}, false
+		}
+		hasDigit = true
+		if seenDot {
+			if fracDigits == scale {
+				return decimal128.Num{}, false
+			}
+			fracDigits++
+		}
+		if v == 0 && c == '0' {
+			continue
+		}
+		if nDigits == 18 {
+			return decimal128.Num{}, false
+		}
+		v = v*10 + int64(c-'0')
+		nDigits++
+	}
+	if !hasDigit {
+		return decimal128.Num{}, false
+	}
+
+	for pad := scale - fracDigits; pad > 0; pad-- {
+		if v != 0 {
+			if nDigits == 18 {
+				return decimal128.Num{}, false
+			}
+			nDigits++
+		}
+		v *= 10
+	}
+
+	if int(precision) < len(pow10) && v >= pow10[precision] {
+		return decimal128.Num{}, false
+	}
+	if neg {
+		v = -v
+	}
+	return decimal128.FromI64(v), true
 }
 
 func appendListValue(b *array.ListBuilder, val interface{}) {

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -425,3 +425,45 @@ func TestAppendValue_Decimal128_JSONNumber(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDecimal128Fast_MatchesFromString(t *testing.T) {
+	inputs := []string{
+		"0", "1", "-1", "+5", "15716.10", "0.02", "-0.08", "1234567890.99",
+		"9999999999999.99", "0.10", ".5", "5.", "-123.45", "00042.10",
+	}
+	for _, s := range inputs {
+		got, ok := parseDecimal128Fast(s, 15, 2)
+		if !ok {
+			t.Errorf("parseDecimal128Fast(%q) unexpectedly fell back", s)
+			continue
+		}
+		want, err := decimal128.FromString(s, 15, 2)
+		if err != nil {
+			t.Fatalf("FromString(%q) error: %v", s, err)
+		}
+		if got != want {
+			t.Errorf("parseDecimal128Fast(%q) = %v; want %v", s, got, want)
+		}
+	}
+}
+
+func TestParseDecimal128Fast_FallsBack(t *testing.T) {
+	inputs := []string{
+		"",                    // no digits
+		"-",                   // sign only
+		".",                   // dot only
+		"1e5",                 // exponent
+		"1.234",               // more fractional digits than scale → needs rounding
+		"abc",                 // not a number
+		"1.2.3",               // double dot
+		"1234567890123456789", // > 18 digits
+		"10000000000000.00",   // exceeds precision 15 after scaling
+		"999999999999999",     // 15 digits + scale-2 padding exceeds precision 15
+		"nan",
+	}
+	for _, s := range inputs {
+		if _, ok := parseDecimal128Fast(s, 15, 2); ok {
+			t.Errorf("parseDecimal128Fast(%q) should have fallen back", s)
+		}
+	}
+}

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -54,9 +54,7 @@ func (d *DuckDBDestination) recordSchema(table string, sch *schema.TableSchema, 
 		return
 	}
 	clone := *sch
-	if len(pks) > 0 {
-		clone.PrimaryKeys = pks
-	}
+	clone.PrimaryKeys = append([]string(nil), pks...)
 	d.schemasMu.Lock()
 	defer d.schemasMu.Unlock()
 	if d.schemas == nil {
@@ -174,8 +172,6 @@ func (d *DuckDBDestination) PrepareTable(ctx context.Context, opts destination.P
 		return fmt.Errorf("schema is required")
 	}
 
-	d.recordSchema(opts.Table, opts.Schema, opts.PrimaryKeys)
-
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -198,6 +194,14 @@ func (d *DuckDBDestination) PrepareTable(ctx context.Context, opts destination.P
 	if err := d.exec(ctx, createSQL); err != nil {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
+	preparedSchema, err := d.getTableSchemaLocked(ctx, opts.Table)
+	if err != nil {
+		return fmt.Errorf("failed to inspect prepared table: %w", err)
+	}
+	if preparedSchema == nil {
+		return fmt.Errorf("prepared table %s was not found", opts.Table)
+	}
+	d.recordSchema(opts.Table, opts.Schema, preparedSchema.PrimaryKeys)
 	config.Debug("[DUCKDB] CREATE TABLE took %v", time.Since(startCreate))
 
 	return nil
@@ -327,7 +331,9 @@ func (d *DuckDBDestination) writeViaADBCIngest(ctx context.Context, records <-ch
 // with primary keys, where concurrent index appends can raise transaction
 // conflicts.
 func (d *DuckDBDestination) ingestConnections(opts destination.WriteOptions) int {
-	if strings.HasPrefix(d.filePath, "md:") || len(opts.PrimaryKeys) > 0 {
+	preparedSchema := d.lookupSchema(opts.Table)
+	if strings.HasPrefix(d.filePath, "md:") || len(opts.PrimaryKeys) > 0 ||
+		(preparedSchema != nil && len(preparedSchema.PrimaryKeys) > 0) {
 		return 1
 	}
 	if v := os.Getenv("INGESTR_DUCKDB_INGEST_CONNS"); v != "" {
@@ -1244,10 +1250,13 @@ func (d *DuckDBDestination) GetMaxCDCLSN(ctx context.Context, table string) (str
 
 // GetTableSchema returns the current schema of a table, or nil if table doesn't exist.
 func (d *DuckDBDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
-	schemaName, tableName := parseSchemaTable(table)
-
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	return d.getTableSchemaLocked(ctx, table)
+}
+
+func (d *DuckDBDestination) getTableSchemaLocked(ctx context.Context, table string) (*schema.TableSchema, error) {
+	schemaName, tableName := parseSchemaTable(table)
 
 	query := fmt.Sprintf("DESCRIBE %s", destination.QuoteTableName(table))
 	stmt, err := d.conn.NewStatement()
@@ -1275,21 +1284,32 @@ func (d *DuckDBDestination) GetTableSchema(ctx context.Context, table string) (*
 	defer reader.Release()
 
 	var columns []schema.Column
+	var primaryKeys []string
 	for reader.Next() {
 		batch := reader.RecordBatch()
 		for i := int64(0); i < batch.NumRows(); i++ {
-			colName := batch.Column(0).(*array.String).Value(int(i))
+			row := int(i)
+			colName := batch.Column(0).(*array.String).Value(row)
 			colType := batch.Column(1).(*array.String).Value(int(i))
 			nullable := true
 			if batch.NumCols() > 2 {
-				nullStr := batch.Column(2).(*array.String).Value(int(i))
+				nullStr := batch.Column(2).(*array.String).Value(row)
 				nullable = nullStr == "YES"
+			}
+			isPrimaryKey := false
+			if batch.NumCols() > 3 && !batch.Column(3).IsNull(row) {
+				key := batch.Column(3).(*array.String).Value(row)
+				isPrimaryKey = key == "PRI"
+			}
+			if isPrimaryKey {
+				primaryKeys = append(primaryKeys, strings.Clone(colName))
 			}
 
 			columns = append(columns, schema.Column{
-				Name:     strings.Clone(colName),
-				DataType: mapDuckDBTypeToSchema(colType),
-				Nullable: nullable,
+				Name:         strings.Clone(colName),
+				DataType:     mapDuckDBTypeToSchema(colType),
+				Nullable:     nullable,
+				IsPrimaryKey: isPrimaryKey,
 			})
 		}
 	}
@@ -1299,9 +1319,10 @@ func (d *DuckDBDestination) GetTableSchema(ctx context.Context, table string) (*
 	}
 
 	return &schema.TableSchema{
-		Name:    tableName,
-		Schema:  schemaName,
-		Columns: columns,
+		Name:        tableName,
+		Schema:      schemaName,
+		Columns:     columns,
+		PrimaryKeys: primaryKeys,
 	}, nil
 }
 

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 	srcduckdb "github.com/bruin-data/ingestr/pkg/source/duckdb"
 	"github.com/bruin-data/ingestr/pkg/tablename"
+	"golang.org/x/sync/errgroup"
 )
 
 type DuckDBDestination struct {
@@ -263,6 +265,9 @@ func (d *DuckDBDestination) writeViaADBCIngest(ctx context.Context, records <-ch
 		}
 	}
 	if checkpointEvery == 0 {
+		if conns := d.ingestConnections(opts); conns > 1 {
+			return d.writeViaParallelADBCIngest(ctx, records, tableName, ingestOpts, startTotal, conns)
+		}
 		return d.writeViaSingleADBCIngest(ctx, records, tableName, ingestOpts, startTotal)
 	}
 
@@ -312,6 +317,74 @@ func (d *DuckDBDestination) writeViaADBCIngest(ctx context.Context, records <-ch
 
 	totalRate := float64(totalRows) / time.Since(startTotal).Seconds()
 	config.Debug("[DUCKDB] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), totalRate)
+	return nil
+}
+
+// ingestConnections decides how many connections to spread an ingest over.
+// The single-threaded Arrow-stream push through the driver is the bottleneck
+// for wide tables, and DuckDB handles concurrent appends to the same table
+// transactionally. Kept at 1 for MotherDuck (remote sessions) and for tables
+// with primary keys, where concurrent index appends can raise transaction
+// conflicts.
+func (d *DuckDBDestination) ingestConnections(opts destination.WriteOptions) int {
+	if strings.HasPrefix(d.filePath, "md:") || len(opts.PrimaryKeys) > 0 {
+		return 1
+	}
+	if v := os.Getenv("INGESTR_DUCKDB_INGEST_CONNS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			return n
+		}
+		config.Debug("[DUCKDB] Ignoring invalid INGESTR_DUCKDB_INGEST_CONNS=%q", v)
+	}
+	return min(4, runtime.GOMAXPROCS(0))
+}
+
+// writeViaParallelADBCIngest runs several IngestStream appenders against the
+// same table, each on its own connection, all pulling batches from the shared
+// channel. Row order across workers is not preserved, which append semantics
+// do not require.
+func (d *DuckDBDestination) writeViaParallelADBCIngest(ctx context.Context, records <-chan source.RecordBatchResult, tableName string, ingestOpts adbc.IngestStreamOptions, startTotal time.Time, conns int) error {
+	g, gctx := errgroup.WithContext(ctx)
+	var totalRows atomic.Int64
+
+	for range conns {
+		g.Go(func() error {
+			first, err := nextNonEmptyRecord(gctx, records)
+			if err != nil {
+				return err
+			}
+			if first == nil {
+				return nil
+			}
+
+			conn, err := d.db.Open(gctx)
+			if err != nil {
+				first.Release()
+				return fmt.Errorf("failed to open ingest connection: %w", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			reader := newChannelRecordReader(gctx, records, first)
+			_, ingestErr := adbc.IngestStream(gctx, conn, reader, tableName, adbc.OptionValueIngestModeAppend, ingestOpts)
+			totalRows.Add(reader.rowsWritten())
+			readerErr := reader.Err()
+			reader.Release()
+
+			if ingestErr != nil {
+				config.Debug("[DUCKDB] IngestStream error: %v", ingestErr)
+				return fmt.Errorf("failed to ingest batch: %w", ingestErr)
+			}
+			return readerErr
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	rows := totalRows.Load()
+	totalRate := float64(rows) / time.Since(startTotal).Seconds()
+	config.Debug("[DUCKDB] Total: %d rows written in %v across %d connections (%.0f rows/sec)", rows, time.Since(startTotal), conns, totalRate)
 	return nil
 }
 

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -688,6 +688,36 @@ func TestWrite_BasicData(t *testing.T) {
 	}
 }
 
+func TestIngestConnections_UsePreparedTableConstraints(t *testing.T) {
+	t.Setenv("INGESTR_DUCKDB_INGEST_CONNS", "4")
+
+	ctx := context.Background()
+	dest, _ := connectTestDuckDB(t, ctx)
+	tableSchema := &schema.TableSchema{
+		Columns:     []schema.Column{{Name: "id", DataType: schema.TypeInt64}},
+		PrimaryKeys: []string{"id"},
+	}
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       "target",
+		Schema:      tableSchema,
+		DropFirst:   true,
+		PrimaryKeys: []string{"id"},
+	}))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:  "target",
+		Schema: tableSchema,
+	}))
+	assert.Equal(t, 1, dest.ingestConnections(destination.WriteOptions{Table: "target"}))
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:     "staging",
+		Schema:    tableSchema,
+		DropFirst: true,
+	}))
+	assert.Equal(t, 4, dest.ingestConnections(destination.WriteOptions{Table: "staging"}))
+}
+
 func TestMergeTable(t *testing.T) {
 	ctx := context.Background()
 	dest, path := connectTestDuckDB(t, ctx)

--- a/pkg/schemainfer/unknown.go
+++ b/pkg/schemainfer/unknown.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -60,7 +61,24 @@ func inferUnknownColumnType(arr arrow.Array) (arrow.DataType, bool) {
 }
 
 // DecodeUnknownValue decodes a JSON-encoded string from Unknown type storage.
+// Plain strings without escapes decode without going through encoding/json,
+// which matters on hot paths like casting CSV batches.
 func DecodeUnknownValue(raw string) (any, error) {
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		inner := raw[1 : len(raw)-1]
+		if isPlainJSONString(inner) {
+			return inner, nil
+		}
+	}
+	switch raw {
+	case "null":
+		return nil, nil
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+
 	dec := json.NewDecoder(bytes.NewBufferString(raw))
 	dec.UseNumber()
 	var v any
@@ -68,6 +86,18 @@ func DecodeUnknownValue(raw string) (any, error) {
 		return nil, err
 	}
 	return v, nil
+}
+
+func isPlainJSONString(s string) bool {
+	if !utf8.ValidString(s) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' || s[i] == '"' || s[i] < 0x20 {
+			return false
+		}
+	}
+	return true
 }
 
 // StringValueAt extracts a string value from an arrow array at the given index.

--- a/pkg/schemainfer/unknown_test.go
+++ b/pkg/schemainfer/unknown_test.go
@@ -214,3 +214,37 @@ func mustBuildUnknownArray(t *testing.T, values []string, valid []bool) arrow.Ar
 
 	return arr
 }
+
+func TestDecodeUnknownValue_ScalarFastPaths(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want any
+	}{
+		{`"hello"`, "hello"},
+		{`"123"`, "123"},
+		{`""`, ""},
+		{`"with \"escaped\" quotes"`, `with "escaped" quotes`},
+		{`"tab\there"`, "tab\there"},
+		{`null`, nil},
+		{`true`, true},
+		{`false`, false},
+		{`42`, json.Number("42")},
+		{`-1.5`, json.Number("-1.5")},
+	}
+	for _, tt := range tests {
+		got, err := DecodeUnknownValue(tt.raw)
+		if err != nil {
+			t.Fatalf("DecodeUnknownValue(%q) error: %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Errorf("DecodeUnknownValue(%q) = %#v; want %#v", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestDecodeUnknownValue_MalformedStringReturnsError(t *testing.T) {
+	_, err := DecodeUnknownValue("\"line\nbreak\"")
+	if err == nil {
+		t.Fatal("expected an error for a JSON string containing an unescaped newline")
+	}
+}

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -1,15 +1,21 @@
 package csv
 
 import (
+	"bufio"
 	"context"
 	"encoding/csv"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/araddon/dateparse"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
@@ -137,6 +143,7 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 
 		csvReader := csv.NewReader(decoded)
 		csvReader.FieldsPerRecord = -1
+		csvReader.ReuseRecord = true
 
 		headers, err := csvReader.Read()
 		if err != nil {
@@ -148,6 +155,7 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to extract headers from the CSV, are you sure the given file contains a header row?")}
 			return
 		}
+		headers = append([]string(nil), headers...)
 
 		incrementalKey := opts.IncrementalKey
 		if incrementalKey != "" && !containsHeader(headers, incrementalKey) {
@@ -161,10 +169,28 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 			startTime = &t
 		}
 
-		rows := make([]map[string]interface{}, 0, batchSize)
+		builder := newBatchBuilder(headers, opts.ExcludeColumns)
+		defer builder.rb.Release()
+		incIdx := headerIndexes(headers, incrementalKey)
+
 		batchNum := 0
 		totalRows := 0
 		lineNum := 1
+
+		flush := func() bool {
+			rec := builder.finish()
+			batchNum++
+			totalRows += int(rec.NumRows())
+			config.Debug("[CSV] Batch %d: %d rows (total: %d)", batchNum, rec.NumRows(), totalRows)
+
+			select {
+			case results <- source.RecordBatchResult{Batch: rec}:
+				return true
+			case <-ctx.Done():
+				rec.Release()
+				return false
+			}
+		}
 
 		for {
 			select {
@@ -187,10 +213,8 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 				continue
 			}
 
-			row := removeEmptyValues(headers, record)
-
 			if incrementalKey != "" && startTime != nil {
-				incValue, ok := row[incrementalKey].(string)
+				incValue, ok := lastNonEmptyValue(record, incIdx)
 				if !ok {
 					output.Warnf("[CSV] Row %d: skipping row with empty incremental key '%s'\n", lineNum, incrementalKey)
 					continue
@@ -205,42 +229,127 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 				}
 			}
 
-			rows = append(rows, row)
+			builder.appendRow(record)
 
-			if len(rows) >= batchSize {
-				rec, err := arrowconv.ItemsToArrowRecordWithSchema(rows, nil, opts.ExcludeColumns)
-				if err != nil {
-					results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert CSV to Arrow: %w", err)}
+			if builder.rows >= batchSize {
+				if !flush() {
 					return
 				}
-
-				batchNum++
-				totalRows += len(rows)
-				config.Debug("[CSV] Batch %d: %d rows (total: %d)", batchNum, len(rows), totalRows)
-
-				results <- source.RecordBatchResult{Batch: rec}
-				rows = make([]map[string]interface{}, 0, batchSize)
 			}
 		}
 
-		if len(rows) > 0 {
-			rec, err := arrowconv.ItemsToArrowRecordWithSchema(rows, nil, opts.ExcludeColumns)
-			if err != nil {
-				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert CSV to Arrow: %w", err)}
+		if builder.rows > 0 {
+			if !flush() {
 				return
 			}
-
-			batchNum++
-			totalRows += len(rows)
-			config.Debug("[CSV] Batch %d: %d rows (total: %d)", batchNum, len(rows), totalRows)
-
-			results <- source.RecordBatchResult{Batch: rec}
 		}
 
 		config.Debug("[CSV] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
 	}()
 
 	return results, nil
+}
+
+// batchBuilder builds record batches of Unknown-typed columns (one per CSV
+// header) directly from CSV records, bypassing per-row maps. Values are stored
+// JSON-encoded, matching what arrowconv.AppendUnknownValue produces, so schema
+// inference and downstream casting behave identically.
+type batchBuilder struct {
+	schema *arrow.Schema
+	rb     *array.RecordBuilder
+	// srcIdx[i] contains the CSV field indexes feeding output column i.
+	srcIdx [][]int
+	buf    []byte
+	rows   int
+}
+
+func newBatchBuilder(headers []string, excludeColumns []string) *batchBuilder {
+	exclude := make(map[string]bool, len(excludeColumns))
+	for _, col := range excludeColumns {
+		exclude[strings.ToLower(col)] = true
+	}
+
+	fields := make([]arrow.Field, 0, len(headers))
+	srcIdx := make([][]int, 0, len(headers))
+	seen := make(map[string]int, len(headers))
+	for i, h := range headers {
+		if exclude[strings.ToLower(h)] {
+			continue
+		}
+		if pos, ok := seen[h]; ok {
+			srcIdx[pos] = append(srcIdx[pos], i)
+			continue
+		}
+		seen[h] = len(fields)
+		fields = append(fields, arrow.Field{Name: h, Type: schema.UnknownArrowType, Nullable: true})
+		srcIdx = append(srcIdx, []int{i})
+	}
+
+	arrowSchema := arrow.NewSchema(fields, nil)
+	return &batchBuilder{
+		schema: arrowSchema,
+		rb:     array.NewRecordBuilder(memory.NewGoAllocator(), arrowSchema),
+		srcIdx: srcIdx,
+	}
+}
+
+func (b *batchBuilder) appendRow(record []string) {
+	for i, sources := range b.srcIdx {
+		sb := b.rb.Field(i).(*array.ExtensionBuilder).StorageBuilder().(*array.StringBuilder)
+		value, ok := lastNonEmptyValue(record, sources)
+		if !ok {
+			sb.AppendNull()
+			continue
+		}
+		b.appendJSONString(sb, value)
+	}
+	b.rows++
+}
+
+// appendJSONString appends the JSON encoding of s. Values needing escapes take
+// the arrowconv fallback, which produces identical bytes to the old path.
+func (b *batchBuilder) appendJSONString(sb *array.StringBuilder, s string) {
+	if !utf8.ValidString(s) {
+		arrowconv.AppendUnknownValue(sb, s)
+		return
+	}
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c == '"' || c == '\\' || c < 0x20 {
+			arrowconv.AppendUnknownValue(sb, s)
+			return
+		}
+	}
+	buf := append(b.buf[:0], '"')
+	buf = append(buf, s...)
+	buf = append(buf, '"')
+	b.buf = buf
+	sb.BinaryBuilder.Append(buf)
+}
+
+func (b *batchBuilder) finish() arrow.RecordBatch {
+	rec := b.rb.NewRecordBatch()
+	b.rows = 0
+	return rec
+}
+
+func headerIndexes(headers []string, name string) []int {
+	var indexes []int
+	for i, h := range headers {
+		if h == name {
+			indexes = append(indexes, i)
+		}
+	}
+	return indexes
+}
+
+func lastNonEmptyValue(record []string, indexes []int) (string, bool) {
+	for i := len(indexes) - 1; i >= 0; i-- {
+		idx := indexes[i]
+		if idx < len(record) && strings.TrimSpace(record[idx]) != "" {
+			return record[idx], true
+		}
+	}
+	return "", false
 }
 
 func isAllEmpty(record []string) bool {
@@ -252,27 +361,8 @@ func isAllEmpty(record []string) bool {
 	return true
 }
 
-func removeEmptyValues(headers []string, record []string) map[string]interface{} {
-	row := make(map[string]interface{})
-	for i, h := range headers {
-		if i < len(record) {
-			val := record[i]
-			if strings.TrimSpace(val) == "" {
-				continue
-			}
-			row[h] = val
-		}
-	}
-	return row
-}
-
 func containsHeader(headers []string, key string) bool {
-	for _, h := range headers {
-		if h == key {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(headers, key)
 }
 
 var _ source.Source = (*CSVSource)(nil)
@@ -285,7 +375,38 @@ func Decode(r io.Reader, encName string) (io.Reader, error) {
 		}
 		return transform.NewReader(r, enc.NewDecoder()), nil
 	}
-	return transform.NewReader(r, unicode.BOMOverride(transform.Nop)), nil
+
+	// transform.Reader copies every byte through a small internal buffer; for
+	// the common no-BOM (or UTF-8 BOM) case skip it and read directly.
+	br := bufio.NewReaderSize(r, 256<<10)
+	head, err := br.Peek(4)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if hasUTF16or32BOM(head) {
+		return transform.NewReader(br, unicode.BOMOverride(transform.Nop)), nil
+	}
+	if len(head) >= 3 && head[0] == 0xEF && head[1] == 0xBB && head[2] == 0xBF {
+		_, _ = br.Discard(3)
+	}
+	return br, nil
+}
+
+func hasUTF16or32BOM(head []byte) bool {
+	if len(head) >= 4 {
+		if head[0] == 0xFF && head[1] == 0xFE && head[2] == 0x00 && head[3] == 0x00 {
+			return true
+		}
+		if head[0] == 0x00 && head[1] == 0x00 && head[2] == 0xFE && head[3] == 0xFF {
+			return true
+		}
+	}
+	if len(head) >= 2 {
+		if (head[0] == 0xFF && head[1] == 0xFE) || (head[0] == 0xFE && head[1] == 0xFF) {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveEncoding(name string) (encoding.Encoding, error) {

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -129,6 +129,15 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 		return nil, fmt.Errorf("failed to open CSV file: %w", err)
 	}
 
+	if skip, size, ok := parallelEligible(f, s.encoding); ok {
+		ch, err := s.readParallel(ctx, opts, f, skip, size, batchSize)
+		if err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		return ch, nil
+	}
+
 	results := make(chan source.RecordBatchResult, 8)
 
 	decoded, decodeErr := Decode(f, s.encoding)

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -178,7 +178,7 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 			startTime = &t
 		}
 
-		builder := newBatchBuilder(headers, opts.ExcludeColumns)
+		builder := newBatchBuilder(headers, opts.ExcludeColumns, opts.Schema)
 		defer builder.rb.Release()
 		incIdx := headerIndexes(headers, incrementalKey)
 
@@ -259,23 +259,32 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 	return results, nil
 }
 
-// batchBuilder builds record batches of Unknown-typed columns (one per CSV
-// header) directly from CSV records, bypassing per-row maps. Values are stored
-// JSON-encoded, matching what arrowconv.AppendUnknownValue produces, so schema
-// inference and downstream casting behave identically.
+// batchBuilder builds record batches directly from CSV records, bypassing
+// per-row maps. In the default (unknown) mode every column is Unknown-typed
+// with JSON-encoded storage, matching what arrowconv.AppendUnknownValue
+// produces, so schema inference and downstream casting behave identically.
+// When the caller already knows the schema (--columns with inference off),
+// typed mode parses values straight into typed builders with the same
+// arrowconv.AppendValue semantics the downstream caster would apply, skipping
+// the JSON encode/decode round-trip entirely.
 type batchBuilder struct {
 	schema *arrow.Schema
 	rb     *array.RecordBuilder
 	// srcIdx[i] contains the CSV field indexes feeding output column i.
 	srcIdx [][]int
+	typed  bool
 	buf    []byte
 	rows   int
 }
 
-func newBatchBuilder(headers []string, excludeColumns []string) *batchBuilder {
+func newBatchBuilder(headers []string, excludeColumns []string, tableSchema *schema.TableSchema) *batchBuilder {
 	exclude := make(map[string]bool, len(excludeColumns))
 	for _, col := range excludeColumns {
 		exclude[strings.ToLower(col)] = true
+	}
+
+	if tableSchema != nil && len(tableSchema.Columns) > 0 {
+		return newTypedBatchBuilder(headers, exclude, tableSchema)
 	}
 
 	fields := make([]arrow.Field, 0, len(headers))
@@ -302,7 +311,52 @@ func newBatchBuilder(headers []string, excludeColumns []string) *batchBuilder {
 	}
 }
 
+// newTypedBatchBuilder emits batches shaped by the announced schema: one
+// column per schema column (CSV headers matched case-insensitively, duplicate
+// headers resolved to the last non-empty value, columns missing from the CSV
+// all-null, CSV columns absent from the schema dropped) — the same shape the
+// downstream TypeCaster would otherwise produce from Unknown columns.
+func newTypedBatchBuilder(headers []string, exclude map[string]bool, tableSchema *schema.TableSchema) *batchBuilder {
+	headerIdx := make(map[string][]int, len(headers))
+	for i, h := range headers {
+		key := strings.ToLower(h)
+		headerIdx[key] = append(headerIdx[key], i)
+	}
+
+	fields := make([]arrow.Field, 0, len(tableSchema.Columns))
+	srcIdx := make([][]int, 0, len(tableSchema.Columns))
+	for _, col := range tableSchema.Columns {
+		if exclude[strings.ToLower(col.Name)] {
+			continue
+		}
+		fields = append(fields, arrow.Field{Name: col.Name, Type: schema.DataTypeToArrowType(col), Nullable: col.Nullable})
+		srcIdx = append(srcIdx, headerIdx[strings.ToLower(col.Name)])
+	}
+
+	arrowSchema := arrow.NewSchema(fields, nil)
+	return &batchBuilder{
+		schema: arrowSchema,
+		rb:     array.NewRecordBuilder(memory.NewGoAllocator(), arrowSchema),
+		srcIdx: srcIdx,
+		typed:  true,
+	}
+}
+
 func (b *batchBuilder) appendRow(record []string) {
+	if b.typed {
+		for i, sources := range b.srcIdx {
+			fb := b.rb.Field(i)
+			value, ok := lastNonEmptyValue(record, sources)
+			if !ok {
+				fb.AppendNull()
+				continue
+			}
+			arrowconv.AppendValue(fb, value)
+		}
+		b.rows++
+		return
+	}
+
 	for i, sources := range b.srcIdx {
 		sb := b.rb.Field(i).(*array.ExtensionBuilder).StorageBuilder().(*array.StringBuilder)
 		value, ok := lastNonEmptyValue(record, sources)

--- a/pkg/source/csv/csv_test.go
+++ b/pkg/source/csv/csv_test.go
@@ -2,9 +2,16 @@ package csv
 
 import (
 	"bytes"
+	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/source"
 )
 
 func TestExtractFilePath(t *testing.T) {
@@ -87,5 +94,107 @@ func assertDecodes(t *testing.T, input []byte, encName, want string) {
 	}
 	if string(got) != want {
 		t.Errorf("Decode(_, %q) = %q; want %q", encName, got, want)
+	}
+}
+
+func TestDecode_NoEncoding_BOMHandling(t *testing.T) {
+	t.Run("utf-8 BOM stripped", func(t *testing.T) {
+		assertDecodes(t, []byte{0xEF, 0xBB, 0xBF, 'a', ',', 'b'}, "", "a,b")
+	})
+	t.Run("plain passthrough", func(t *testing.T) {
+		assertDecodes(t, []byte("a,b\n1,2\n"), "", "a,b\n1,2\n")
+	})
+	t.Run("utf-16le BOM decoded", func(t *testing.T) {
+		assertDecodes(t, []byte{0xFF, 0xFE, 'h', 0x00, 'i', 0x00}, "", "hi")
+	})
+	t.Run("utf-16be BOM decoded", func(t *testing.T) {
+		assertDecodes(t, []byte{0xFE, 0xFF, 0x00, 'h', 0x00, 'i'}, "", "hi")
+	})
+	t.Run("short file", func(t *testing.T) {
+		assertDecodes(t, []byte("x"), "", "x")
+	})
+	t.Run("empty file", func(t *testing.T) {
+		assertDecodes(t, []byte{}, "", "")
+	})
+}
+
+func TestRead_BuildsBatchesDirectly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.csv")
+	content := "id,name,score,name\n" + // duplicate header: last occurrence wins
+		"1,alice,3.5,alice2\n" +
+		",  ,skipé,\n" + // empty id and whitespace name become NULLs
+		"   ,,,\n" + // all-empty row is skipped entirely
+		"3,\"quo\"\"ted\",7,x\n" +
+		"4,short\n" // short row: the earlier duplicate value survives
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := NewCSVSource()
+	if err := src.Connect(context.Background(), "csv://"+path); err != nil {
+		t.Fatal(err)
+	}
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := table.Read(context.Background(), source.ReadOptions{PageSize: 100, ExcludeColumns: []string{"SCORE"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var batches []arrow.RecordBatch
+	for res := range ch {
+		if res.Err != nil {
+			t.Fatal(res.Err)
+		}
+		batches = append(batches, res.Batch)
+	}
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+	rec := batches[0]
+	defer rec.Release()
+
+	if rec.NumCols() != 2 {
+		t.Fatalf("expected 2 columns (score excluded, name deduped), got %d: %v", rec.NumCols(), rec.Schema())
+	}
+	if rec.ColumnName(0) != "id" || rec.ColumnName(1) != "name" {
+		t.Fatalf("unexpected columns: %s, %s", rec.ColumnName(0), rec.ColumnName(1))
+	}
+	if rec.NumRows() != 4 {
+		t.Fatalf("expected 4 rows, got %d", rec.NumRows())
+	}
+
+	valueAt := func(col, row int) (string, bool) {
+		arr := rec.Column(col)
+		if arr.IsNull(row) {
+			return "", false
+		}
+		storage := arr.(array.ExtensionArray).Storage().(*array.String)
+		return storage.Value(row), true
+	}
+
+	// Duplicate headers use the last non-empty field, matching the old map-based
+	// behavior; values are stored JSON-encoded.
+	wantID := []struct {
+		val  string
+		null bool
+	}{{`"1"`, false}, {"", true}, {`"3"`, false}, {`"4"`, false}}
+	wantName := []struct {
+		val  string
+		null bool
+	}{{`"alice2"`, false}, {"", true}, {`"x"`, false}, {`"short"`, false}}
+
+	for i := range wantID {
+		got, ok := valueAt(0, i)
+		if ok == wantID[i].null || (ok && got != wantID[i].val) {
+			t.Errorf("id[%d] = (%q, notnull=%v); want (%q, notnull=%v)", i, got, ok, wantID[i].val, !wantID[i].null)
+		}
+		got, ok = valueAt(1, i)
+		if ok == wantName[i].null || (ok && got != wantName[i].val) {
+			t.Errorf("name[%d] = (%q, notnull=%v); want (%q, notnull=%v)", i, got, ok, wantName[i].val, !wantName[i].null)
+		}
 	}
 }

--- a/pkg/source/csv/parallel.go
+++ b/pkg/source/csv/parallel.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/araddon/dateparse"
@@ -89,11 +90,14 @@ func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f
 	jobs := make(chan segmentJob, workers)
 	pending := make(chan chan []source.RecordBatchResult, workers)
 	segCtx, cancel := context.WithCancel(ctx)
+	var workerWG sync.WaitGroup
 
 	// Reader: split the data section into segments cut at record boundaries.
 	go func() {
-		defer close(jobs)
-		defer close(pending)
+		defer func() {
+			close(jobs)
+			close(pending)
+		}()
 		defer func() { _ = f.Close() }()
 		err := splitSegments(segCtx, f, dataStart, size, func(seg csvSegment) bool {
 			slot := make(chan []source.RecordBatchResult, 1)
@@ -102,12 +106,10 @@ func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f
 			case <-segCtx.Done():
 				return false
 			}
-			select {
-			case pending <- slot:
-			case <-segCtx.Done():
-				return false
-			}
-			return true
+			// Once a job is dispatched, always register its slot so the merger can
+			// release its batches even if cancellation races with this handoff.
+			pending <- slot
+			return segCtx.Err() == nil
 		})
 		if err != nil && segCtx.Err() == nil {
 			slot := make(chan []source.RecordBatchResult, 1)
@@ -119,20 +121,13 @@ func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f
 		}
 	}()
 
+	workerWG.Add(workers)
 	for range workers {
 		go func() {
+			defer workerWG.Done()
 			parser := newSegmentParser(headers, opts, batchSize)
-			for {
-				var job segmentJob
-				var ok bool
-				select {
-				case job, ok = <-jobs:
-					if !ok {
-						return
-					}
-				case <-segCtx.Done():
-					return
-				}
+			defer parser.builder.rb.Release()
+			for job := range jobs {
 				job.slot <- parser.parse(job.seg)
 			}
 		}()
@@ -149,15 +144,7 @@ func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f
 		batchNum := 0
 		failed := false
 		for slot := range pending {
-			var segResults []source.RecordBatchResult
-			select {
-			case segResults = <-slot:
-			case <-segCtx.Done():
-				select {
-				case segResults = <-slot:
-				default:
-				}
-			}
+			segResults := <-slot
 			for _, res := range segResults {
 				if failed {
 					if res.Batch != nil {
@@ -186,6 +173,7 @@ func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f
 				cancel()
 			}
 		}
+		workerWG.Wait()
 		config.Debug("[CSV] Total: %d rows in %d batches, read time: %v (parallel)", totalRows, batchNum, time.Since(startTotal))
 	}()
 
@@ -213,7 +201,10 @@ func splitSegments(ctx context.Context, f *os.File, start, size int64, emit func
 		block := make([]byte, len(carry)+int(readLen))
 		copy(block, carry)
 		n, err := io.ReadFull(io.NewSectionReader(f, offset, readLen), block[len(carry):])
-		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return io.ErrUnexpectedEOF
+		}
+		if err != nil {
 			return err
 		}
 		block = block[:len(carry)+n]

--- a/pkg/source/csv/parallel.go
+++ b/pkg/source/csv/parallel.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -85,7 +86,12 @@ func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f
 	}
 	dataStart := skip + headerReader.InputOffset()
 
-	workers := min(runtime.GOMAXPROCS(0), 8)
+	workers := min(runtime.GOMAXPROCS(0), 16)
+	if v := os.Getenv("INGESTR_CSV_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			workers = n
+		}
+	}
 	results := make(chan source.RecordBatchResult, 8)
 	jobs := make(chan segmentJob, workers)
 	pending := make(chan chan []source.RecordBatchResult, workers)
@@ -280,7 +286,7 @@ func newSegmentParser(headers []string, opts source.ReadOptions, batchSize int) 
 	p := &segmentParser{
 		opts:      opts,
 		batchSize: batchSize,
-		builder:   newBatchBuilder(headers, opts.ExcludeColumns),
+		builder:   newBatchBuilder(headers, opts.ExcludeColumns, opts.Schema),
 		incIdx:    headerIndexes(headers, opts.IncrementalKey),
 	}
 	if opts.IntervalStart != nil {

--- a/pkg/source/csv/parallel.go
+++ b/pkg/source/csv/parallel.go
@@ -1,0 +1,353 @@
+package csv
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/araddon/dateparse"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// Vars instead of consts so tests can shrink them to force many segments.
+var (
+	// parallelBlockSize is the target byte size of each independently parsed
+	// file segment.
+	parallelBlockSize int64 = 8 << 20
+	// parallelMinFileSize gates the parallel reader; smaller files parse
+	// sequentially in well under the worker startup cost.
+	parallelMinFileSize int64 = 16 << 20
+)
+
+// parallelEligible reports whether the file can be split into byte-range
+// segments and parsed concurrently. Only plain single-byte-newline encodings
+// qualify: an explicit encoding or a UTF-16/32 BOM requires the sequential
+// transform path. skip is the number of leading bytes (UTF-8 BOM) to drop.
+func parallelEligible(f *os.File, declaredEncoding string) (skip, size int64, ok bool) {
+	if declaredEncoding != "" {
+		return 0, 0, false
+	}
+	info, err := f.Stat()
+	if err != nil || info.Size() < parallelMinFileSize {
+		return 0, 0, false
+	}
+
+	var head [4]byte
+	n, err := f.ReadAt(head[:], 0)
+	if err != nil && err != io.EOF {
+		return 0, 0, false
+	}
+	if hasUTF16or32BOM(head[:n]) {
+		return 0, 0, false
+	}
+	if n >= 3 && head[0] == 0xEF && head[1] == 0xBB && head[2] == 0xBF {
+		skip = 3
+	}
+	return skip, info.Size(), true
+}
+
+type csvSegment struct {
+	data []byte
+	// startRecord is the 1-based index of the segment's first record counted
+	// the way the sequential reader counts lineNum (the header row is record
+	// 1, the first data row is 2). Used for warning and error messages.
+	startRecord int
+}
+
+type segmentJob struct {
+	seg  csvSegment
+	slot chan []source.RecordBatchResult
+}
+
+func (s *CSVSource) readParallel(ctx context.Context, opts source.ReadOptions, f *os.File, skip, size int64, batchSize int) (<-chan source.RecordBatchResult, error) {
+	startTotal := time.Now()
+
+	headerReader := csv.NewReader(bufio.NewReaderSize(io.NewSectionReader(f, skip, size-skip), 64<<10))
+	headerReader.FieldsPerRecord = -1
+	headers, err := headerReader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV headers: %w", err)
+	}
+	if len(headers) == 0 {
+		return nil, fmt.Errorf("failed to extract headers from the CSV, are you sure the given file contains a header row?")
+	}
+	if opts.IncrementalKey != "" && !containsHeader(headers, opts.IncrementalKey) {
+		return nil, fmt.Errorf("incremental_key '%s' not found in the CSV file", opts.IncrementalKey)
+	}
+	dataStart := skip + headerReader.InputOffset()
+
+	workers := min(runtime.GOMAXPROCS(0), 8)
+	results := make(chan source.RecordBatchResult, 8)
+	jobs := make(chan segmentJob, workers)
+	pending := make(chan chan []source.RecordBatchResult, workers)
+	segCtx, cancel := context.WithCancel(ctx)
+
+	// Reader: split the data section into segments cut at record boundaries.
+	go func() {
+		defer close(jobs)
+		defer close(pending)
+		defer func() { _ = f.Close() }()
+		err := splitSegments(segCtx, f, dataStart, size, func(seg csvSegment) bool {
+			slot := make(chan []source.RecordBatchResult, 1)
+			select {
+			case jobs <- segmentJob{seg: seg, slot: slot}:
+			case <-segCtx.Done():
+				return false
+			}
+			select {
+			case pending <- slot:
+			case <-segCtx.Done():
+				return false
+			}
+			return true
+		})
+		if err != nil && segCtx.Err() == nil {
+			slot := make(chan []source.RecordBatchResult, 1)
+			slot <- []source.RecordBatchResult{{Err: fmt.Errorf("failed to read CSV file: %w", err)}}
+			select {
+			case pending <- slot:
+			case <-segCtx.Done():
+			}
+		}
+	}()
+
+	for range workers {
+		go func() {
+			parser := newSegmentParser(headers, opts, batchSize)
+			for {
+				var job segmentJob
+				var ok bool
+				select {
+				case job, ok = <-jobs:
+					if !ok {
+						return
+					}
+				case <-segCtx.Done():
+					return
+				}
+				job.slot <- parser.parse(job.seg)
+			}
+		}()
+	}
+
+	// Merger: forward per-segment results in file order. After an error (or
+	// downstream cancellation) remaining slots are drained and released so no
+	// batch leaks and no worker stays blocked.
+	go func() {
+		defer close(results)
+		defer cancel()
+
+		totalRows := 0
+		batchNum := 0
+		failed := false
+		for slot := range pending {
+			var segResults []source.RecordBatchResult
+			select {
+			case segResults = <-slot:
+			case <-segCtx.Done():
+				select {
+				case segResults = <-slot:
+				default:
+				}
+			}
+			for _, res := range segResults {
+				if failed {
+					if res.Batch != nil {
+						res.Batch.Release()
+					}
+					continue
+				}
+				if res.Err == nil && res.Batch != nil {
+					batchNum++
+					totalRows += int(res.Batch.NumRows())
+					config.Debug("[CSV] Batch %d: %d rows (total: %d)", batchNum, res.Batch.NumRows(), totalRows)
+				}
+				select {
+				case results <- res:
+					if res.Err != nil {
+						failed = true
+					}
+				case <-ctx.Done():
+					if res.Batch != nil {
+						res.Batch.Release()
+					}
+					failed = true
+				}
+			}
+			if failed {
+				cancel()
+			}
+		}
+		config.Debug("[CSV] Total: %d rows in %d batches, read time: %v (parallel)", totalRows, batchNum, time.Since(startTotal))
+	}()
+
+	return results, nil
+}
+
+// splitSegments reads the byte range [start, size) of f in blocks and invokes
+// emit with consecutive segments that always end on a record boundary. Every
+// segment starts at a record boundary, where the cumulative quote count is
+// even, so each block (carry + fresh bytes) can be scanned independently.
+// Returns early when emit returns false.
+func splitSegments(ctx context.Context, f *os.File, start, size int64, emit func(csvSegment) bool) error {
+	offset := start
+	var carry []byte
+	nextRecord := 2 // record 1 is the header row
+
+	for offset < size {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		readLen := min(parallelBlockSize, size-offset)
+		block := make([]byte, len(carry)+int(readLen))
+		copy(block, carry)
+		n, err := io.ReadFull(io.NewSectionReader(f, offset, readLen), block[len(carry):])
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			return err
+		}
+		block = block[:len(carry)+n]
+		offset += int64(n)
+
+		cut, records := lastRecordBoundary(block)
+		if cut < 0 {
+			// No boundary in the block (huge record or open quote): grow the
+			// carry and read more.
+			carry = block
+			continue
+		}
+
+		seg := csvSegment{data: block[:cut], startRecord: nextRecord}
+		nextRecord += records
+		carry = append([]byte(nil), block[cut:]...)
+		if !emit(seg) {
+			return nil
+		}
+	}
+
+	if len(carry) > 0 {
+		emit(csvSegment{data: carry, startRecord: nextRecord})
+	}
+	return nil
+}
+
+// lastRecordBoundary returns the index just past the last newline that lies
+// at even cumulative quote parity (i.e. outside any quoted field, per RFC
+// 4180: inside a quoted field the count is odd and escaped "" pairs preserve
+// parity), plus the number of records before that cut. The block must start
+// at a record boundary. Returns cut = -1 when the block holds no complete
+// record.
+func lastRecordBoundary(block []byte) (cut, records int) {
+	if bytes.IndexByte(block, '"') < 0 {
+		last := bytes.LastIndexByte(block, '\n')
+		if last < 0 {
+			return -1, 0
+		}
+		return last + 1, bytes.Count(block[:last+1], []byte{'\n'})
+	}
+
+	cut = -1
+	parity := 0
+	for i, c := range block {
+		switch c {
+		case '"':
+			parity ^= 1
+		case '\n':
+			if parity == 0 {
+				records++
+				cut = i + 1
+			}
+		}
+	}
+	if cut < 0 {
+		return -1, 0
+	}
+	return cut, records
+}
+
+// segmentParser parses file segments into record batches. Each worker owns
+// one parser; the builder resets between batches via finish().
+type segmentParser struct {
+	opts      source.ReadOptions
+	batchSize int
+	builder   *batchBuilder
+	incIdx    []int
+	startTime *time.Time
+}
+
+func newSegmentParser(headers []string, opts source.ReadOptions, batchSize int) *segmentParser {
+	p := &segmentParser{
+		opts:      opts,
+		batchSize: batchSize,
+		builder:   newBatchBuilder(headers, opts.ExcludeColumns),
+		incIdx:    headerIndexes(headers, opts.IncrementalKey),
+	}
+	if opts.IntervalStart != nil {
+		t := *opts.IntervalStart
+		p.startTime = &t
+	}
+	return p
+}
+
+func (p *segmentParser) parse(seg csvSegment) []source.RecordBatchResult {
+	var out []source.RecordBatchResult
+
+	cr := csv.NewReader(bytes.NewReader(seg.data))
+	cr.FieldsPerRecord = -1
+	cr.ReuseRecord = true
+
+	recordNum := seg.startRecord - 1
+	for {
+		record, err := cr.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if p.builder.rows > 0 {
+				out = append(out, source.RecordBatchResult{Batch: p.builder.finish()})
+			}
+			return append(out, source.RecordBatchResult{Err: fmt.Errorf("failed to read CSV row %d: %w", recordNum+1, err)})
+		}
+		recordNum++
+
+		if isAllEmpty(record) {
+			continue
+		}
+
+		if p.opts.IncrementalKey != "" && p.startTime != nil {
+			incValue, ok := lastNonEmptyValue(record, p.incIdx)
+			if !ok {
+				output.Warnf("[CSV] Row %d: skipping row with empty incremental key '%s'\n", recordNum, p.opts.IncrementalKey)
+				continue
+			}
+			incTime, err := dateparse.ParseAny(incValue)
+			if err != nil {
+				output.Warnf("[CSV] Row %d: skipping row with unparseable incremental key value '%s'\n", recordNum, incValue)
+				continue
+			}
+			if incTime.Before(*p.startTime) {
+				continue
+			}
+		}
+
+		p.builder.appendRow(record)
+		if p.builder.rows >= p.batchSize {
+			out = append(out, source.RecordBatchResult{Batch: p.builder.finish()})
+		}
+	}
+
+	if p.builder.rows > 0 {
+		out = append(out, source.RecordBatchResult{Batch: p.builder.finish()})
+	}
+	return out
+}

--- a/pkg/source/csv/parallel_test.go
+++ b/pkg/source/csv/parallel_test.go
@@ -1,0 +1,169 @@
+package csv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// readAllValues drains the source and flattens the given column into decoded
+// string values ("" for NULL), so parallel and sequential output can be
+// compared row by row.
+func readAllValues(t *testing.T, path string, opts source.ReadOptions, col int) []string {
+	t.Helper()
+
+	src := NewCSVSource()
+	if err := src.Connect(context.Background(), "csv://"+path); err != nil {
+		t.Fatal(err)
+	}
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := table.Read(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var values []string
+	for res := range ch {
+		if res.Err != nil {
+			t.Fatal(res.Err)
+		}
+		storage := res.Batch.Column(col).(array.ExtensionArray).Storage().(*array.String)
+		for i := 0; i < storage.Len(); i++ {
+			if storage.IsNull(i) {
+				values = append(values, "")
+			} else {
+				values = append(values, storage.Value(i))
+			}
+		}
+		res.Batch.Release()
+	}
+	return values
+}
+
+func TestReadParallel_MatchesSequential(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tricky.csv")
+
+	var sb strings.Builder
+	sb.WriteString("id,payload,note\n")
+	rows := 5000
+	for i := 0; i < rows; i++ {
+		switch i % 5 {
+		case 0:
+			// Quoted field with embedded newlines and escaped quotes: record
+			// boundaries must not be detected inside these.
+			fmt.Fprintf(&sb, "%d,\"multi\nline \"\"quoted\"\" value %d\",plain\n", i, i)
+		case 1:
+			fmt.Fprintf(&sb, "%d,,empty-payload\n", i)
+		case 2:
+			// All-empty row: skipped entirely by both paths.
+			sb.WriteString(",,\n")
+		case 3:
+			fmt.Fprintf(&sb, "%d,short-row-%d\n", i, i)
+		default:
+			fmt.Fprintf(&sb, "%d,value %d,note %d\n", i, i, i)
+		}
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := source.ReadOptions{PageSize: 137}
+
+	sequential := readAllValues(t, path, opts, 1)
+
+	origBlock, origMin := parallelBlockSize, parallelMinFileSize
+	parallelBlockSize, parallelMinFileSize = 4096, 1
+	defer func() { parallelBlockSize, parallelMinFileSize = origBlock, origMin }()
+
+	parallel := readAllValues(t, path, opts, 1)
+
+	if len(parallel) != len(sequential) {
+		t.Fatalf("row count mismatch: parallel=%d sequential=%d", len(parallel), len(sequential))
+	}
+	for i := range parallel {
+		if parallel[i] != sequential[i] {
+			t.Fatalf("row %d mismatch:\nparallel:   %q\nsequential: %q", i, parallel[i], sequential[i])
+		}
+	}
+}
+
+func TestReadParallel_ParseErrorSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.csv")
+
+	var sb strings.Builder
+	sb.WriteString("a,b\n")
+	for i := 0; i < 2000; i++ {
+		fmt.Fprintf(&sb, "%d,ok\n", i)
+	}
+	sb.WriteString("1,\"unterminated\n") // quote never closes: parse error
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origBlock, origMin := parallelBlockSize, parallelMinFileSize
+	parallelBlockSize, parallelMinFileSize = 1024, 1
+	defer func() { parallelBlockSize, parallelMinFileSize = origBlock, origMin }()
+
+	src := NewCSVSource()
+	if err := src.Connect(context.Background(), "csv://"+path); err != nil {
+		t.Fatal(err)
+	}
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := table.Read(context.Background(), source.ReadOptions{PageSize: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sawErr := false
+	for res := range ch {
+		if res.Err != nil {
+			sawErr = true
+			continue
+		}
+		res.Batch.Release()
+		if sawErr {
+			t.Fatal("received a batch after an error result")
+		}
+	}
+	if !sawErr {
+		t.Fatal("expected a parse error to surface")
+	}
+}
+
+func TestLastRecordBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		block       string
+		wantCut     int
+		wantRecords int
+	}{
+		{"no newline", "abc", -1, 0},
+		{"simple", "a,b\nc,d\ne", 8, 2},
+		{"newline inside quotes ignored", "a,\"x\ny\"\nb", 8, 1},
+		{"escaped quotes keep parity", "a,\"x\"\"\ny\"\nb,c\n", 14, 2},
+		{"open quote no boundary", "a,\"open\nnever closed", -1, 0},
+		{"trailing complete", "a,b\n", 4, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cut, records := lastRecordBoundary([]byte(tt.block))
+			if cut != tt.wantCut || records != tt.wantRecords {
+				t.Errorf("lastRecordBoundary(%q) = (%d, %d); want (%d, %d)", tt.block, cut, records, tt.wantCut, tt.wantRecords)
+			}
+		})
+	}
+}

--- a/pkg/source/csv/parallel_test.go
+++ b/pkg/source/csv/parallel_test.go
@@ -2,11 +2,14 @@ package csv
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -141,6 +144,71 @@ func TestReadParallel_ParseErrorSurfaces(t *testing.T) {
 	}
 	if !sawErr {
 		t.Fatal("expected a parse error to surface")
+	}
+}
+
+func TestReadParallel_CancellationClosesResults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cancel.csv")
+
+	var sb strings.Builder
+	sb.WriteString("id,payload\n")
+	for i := 0; i < 10000; i++ {
+		fmt.Fprintf(&sb, "%d,value-%d\n", i, i)
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origBlock, origMin := parallelBlockSize, parallelMinFileSize
+	parallelBlockSize, parallelMinFileSize = 1024, 1
+	defer func() { parallelBlockSize, parallelMinFileSize = origBlock, origMin }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	src := NewCSVSource()
+	if err := src.Connect(ctx, "csv://"+path); err != nil {
+		t.Fatal(err)
+	}
+	table, err := src.GetTable(ctx, source.TableRequest{Name: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := table.Read(ctx, source.ReadOptions{PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	for res := range ch {
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+	}
+}
+
+func TestSplitSegments_TruncatedFileReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "truncated.csv")
+	if err := os.WriteFile(path, []byte("a,b\n1,2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- splitSegments(context.Background(), f, 0, 1024, func(csvSegment) bool { return true })
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected unexpected EOF, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("splitSegments did not return after the file was truncated")
 	}
 }
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -247,9 +247,11 @@ func Get(name config.IncrementalStrategy) (WriteStrategy, error) {
 // ApplyBatchTransformation wraps record batches with contract-based transformation if needed.
 // Also applies column renaming if a naming convention is configured.
 func (j *IngestionJob) ApplyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult) (<-chan source.RecordBatchResult, error) {
-	// Cast column types first (for --columns type overrides on known-schema sources)
+	// Cast column types first (for --columns type overrides on known-schema sources).
+	// Casting parses every value (decimals, dates), so it is the CPU-heaviest
+	// stage of the stream; fan it out across batches.
 	if j.TypeCaster != nil {
-		records = transformer.Wrap(records, j.TypeCaster)
+		records = transformer.WrapParallel(records, j.TypeCaster, transformer.ParallelWorkers())
 	}
 
 	// Apply column renaming (if configured)

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -1,6 +1,8 @@
 package transformer
 
 import (
+	"runtime"
+
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -21,6 +23,83 @@ type RecordTransformer interface {
 // sources that rebuild their stream around DDL.
 type SchemaRetargeter interface {
 	RetargetSchema(s *schema.TableSchema)
+}
+
+// WrapParallel is Wrap with the Transform calls spread across a bounded worker
+// pool. Output order is preserved. The transformer must be safe for concurrent
+// Transform calls on distinct batches; schema retargeting announcements act as
+// a barrier (all in-flight batches finish first), so RetargetSchema never runs
+// concurrently with Transform.
+func WrapParallel(records <-chan source.RecordBatchResult, t RecordTransformer, workers int) <-chan source.RecordBatchResult {
+	if workers <= 1 {
+		return Wrap(records, t)
+	}
+
+	out := make(chan source.RecordBatchResult)
+	pending := make(chan chan source.RecordBatchResult, workers)
+	sem := make(chan struct{}, workers)
+
+	transform := func(result source.RecordBatchResult) source.RecordBatchResult {
+		transformed, err := t.Transform(result.Batch)
+		result.Batch.Release()
+		if err != nil {
+			result.Err = err
+			result.Batch = nil
+		} else {
+			result.Batch = transformed
+		}
+		return result
+	}
+
+	go func() {
+		defer close(pending)
+		for result := range records {
+			slot := make(chan source.RecordBatchResult, 1)
+
+			isAnnouncement := result.Err == nil && result.TableInfo != nil && result.TableInfo.Schema != nil
+			switch {
+			case isAnnouncement:
+				for range workers {
+					sem <- struct{}{}
+				}
+				if r, ok := t.(SchemaRetargeter); ok {
+					r.RetargetSchema(result.TableInfo.Schema)
+				}
+				if result.Batch != nil {
+					result = transform(result)
+				}
+				slot <- result
+				for range workers {
+					<-sem
+				}
+			case result.Batch != nil && result.Err == nil:
+				sem <- struct{}{}
+				go func(result source.RecordBatchResult) {
+					defer func() { <-sem }()
+					slot <- transform(result)
+				}(result)
+			default:
+				slot <- result
+			}
+
+			pending <- slot
+		}
+	}()
+
+	go func() {
+		defer close(out)
+		for slot := range pending {
+			out <- <-slot
+		}
+	}()
+
+	return out
+}
+
+// ParallelWorkers returns the worker count for WrapParallel, bounded to keep
+// per-batch memory amplification in check.
+func ParallelWorkers() int {
+	return min(runtime.GOMAXPROCS(0), 8)
 }
 
 // Wrap wraps a record channel with transformation.

--- a/pkg/transformer/transformer_test.go
+++ b/pkg/transformer/transformer_test.go
@@ -1,6 +1,8 @@
 package transformer
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -268,5 +270,64 @@ func TestWrap(t *testing.T) {
 	assert.Equal(t, "added", result.Batch.ColumnName(1))
 
 	_, ok := <-output
+	assert.False(t, ok)
+}
+
+type delayedTransformer struct {
+	delays []time.Duration
+	calls  atomic.Int64
+}
+
+func (d *delayedTransformer) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+	n := d.calls.Add(1) - 1
+	if int(n) < len(d.delays) {
+		time.Sleep(d.delays[n])
+	}
+	batch.Retain()
+	return batch, nil
+}
+
+func (d *delayedTransformer) OutputSchema(in *arrow.Schema) *arrow.Schema { return in }
+
+func TestWrapParallel_PreservesOrderAndErrors(t *testing.T) {
+	allocator := memory.DefaultAllocator
+	inputSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+
+	makeBatch := func(v int64) arrow.RecordBatch {
+		b := array.NewInt64Builder(allocator)
+		defer b.Release()
+		b.Append(v)
+		arr := b.NewArray()
+		defer arr.Release()
+		return array.NewRecordBatch(inputSchema, []arrow.Array{arr}, 1)
+	}
+
+	const n = 20
+	input := make(chan source.RecordBatchResult, n+1)
+	for i := range n {
+		input <- source.RecordBatchResult{Batch: makeBatch(int64(i))}
+	}
+	wantErr := errors.New("mid-stream failure")
+	input <- source.RecordBatchResult{Err: wantErr}
+	close(input)
+
+	// First batch is the slowest so out-of-order completion is guaranteed.
+	delays := make([]time.Duration, n)
+	delays[0] = 50 * time.Millisecond
+	out := WrapParallel(input, &delayedTransformer{delays: delays}, 4)
+
+	for i := range n {
+		result := <-out
+		require.NoError(t, result.Err)
+		require.NotNil(t, result.Batch)
+		got := result.Batch.Column(0).(*array.Int64).Value(0)
+		assert.Equal(t, int64(i), got)
+		result.Batch.Release()
+	}
+	result := <-out
+	assert.Equal(t, wantErr, result.Err)
+	_, ok := <-out
 	assert.False(t, ok)
 }


### PR DESCRIPTION
Speeds CSV-to-DuckDB ingestion with parallel CSV parsing, type conversion, and DuckDB appends. Preserves output order while safely handling cancellations and malformed or truncated CSVs. Disables concurrent DuckDB appends for tables with primary-key constraints.