### PR TITLE
Iceberg stack 1/11: normalize nested Arrow values as JSON

### DIFF
--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -1,9 +1,11 @@
 package databuffer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/bitutil"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -265,9 +268,14 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 	if isUnknownType(arr.DataType()) {
 		return castUnknownArray(arr, target)
 	}
+	if target.ID() == arrow.LIST {
+		if values, ok := arr.(array.VarLenListLike); ok {
+			return castVariableListToList(ctx, values, target.(*arrow.ListType), safe)
+		}
+	}
 
 	if isJSONType(target) {
-		return castArrayToJSON(ctx, arr, target)
+		return castArrayToJSON(arr, target)
 	}
 
 	if isJSONType(arr.DataType()) && target.ID() == arrow.STRING {
@@ -320,6 +328,66 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 	}
 
 	return nil, err
+}
+
+func castVariableListToList(ctx context.Context, values array.VarLenListLike, target *arrow.ListType, safe bool) (arrow.Array, error) {
+	validity := make([]byte, bitutil.BytesForBits(int64(values.Len())))
+	offsets := make([]int32, values.Len()+1)
+	slices := make([]arrow.Array, 0, values.Len())
+	defer func() {
+		for _, value := range slices {
+			value.Release()
+		}
+	}()
+
+	var total int64
+	nullCount := 0
+	items := values.ListValues()
+	for i := 0; i < values.Len(); i++ {
+		if values.IsNull(i) {
+			nullCount++
+			offsets[i+1] = int32(total)
+			continue
+		}
+		bitutil.SetBit(validity, i)
+		start, end := values.ValueOffsets(i)
+		if start < 0 || end < start || end > int64(items.Len()) {
+			return nil, fmt.Errorf("invalid list offsets [%d:%d] for %d values", start, end, items.Len())
+		}
+		total += end - start
+		if total > math.MaxInt32 {
+			return nil, fmt.Errorf("list contains %d values, exceeding the int32 offset limit", total)
+		}
+		offsets[i+1] = int32(total)
+		if end > start {
+			slices = append(slices, array.NewSlice(items, start, end))
+		}
+	}
+
+	var flattened arrow.Array
+	var err error
+	if len(slices) == 0 {
+		flattened = array.NewSlice(items, 0, 0)
+	} else {
+		flattened, err = array.Concatenate(slices, memory.DefaultAllocator)
+		if err != nil {
+			return nil, fmt.Errorf("failed to concatenate list values: %w", err)
+		}
+	}
+	defer flattened.Release()
+	castedValues, err := castArrayToType(ctx, flattened, target.Elem(), safe)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cast list values from %s to %s: %w", flattened.DataType(), target.Elem(), err)
+	}
+	defer castedValues.Release()
+
+	validityBuffer := memory.NewBufferBytes(validity)
+	defer validityBuffer.Release()
+	offsetBuffer := memory.NewBufferBytes(arrow.Int32Traits.CastToBytes(offsets))
+	defer offsetBuffer.Release()
+	data := array.NewData(target, values.Len(), []*memory.Buffer{validityBuffer, offsetBuffer}, []arrow.ArrayData{castedValues.Data()}, nullCount, 0)
+	defer data.Release()
+	return array.NewListData(data), nil
 }
 
 func normalizeArrayOffset(arr arrow.Array) (arrow.Array, bool, error) {
@@ -432,20 +500,200 @@ func castUnknownArrayToJSON(ext array.ExtensionArray, target arrow.DataType) (ar
 	return array.NewExtensionArrayWithStorage(extType, storageArr), nil
 }
 
-func castArrayToJSON(ctx context.Context, arr arrow.Array, target arrow.DataType) (arrow.Array, error) {
+func castArrayToJSON(arr arrow.Array, target arrow.DataType) (arrow.Array, error) {
 	extType, ok := target.(arrow.ExtensionType)
 	if !ok {
 		return nil, fmt.Errorf("target type is not an extension type")
 	}
 
-	strArr, err := castArrayToString(ctx, arr)
-	if err != nil {
-		return nil, err
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer builder.Release()
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+		value, err := marshalArrowJSONValue(arr, i)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode row %d as JSON: %w", i, err)
+		}
+		builder.Append(string(value))
 	}
 
-	extArr := array.NewExtensionArrayWithStorage(extType, strArr)
-	strArr.Release()
-	return extArr, nil
+	storage := builder.NewArray()
+	defer storage.Release()
+	return array.NewExtensionArrayWithStorage(extType, storage), nil
+}
+
+func marshalArrowJSONValue(arr arrow.Array, i int) ([]byte, error) {
+	if i < 0 || i >= arr.Len() {
+		return nil, fmt.Errorf("array index %d is out of range", i)
+	}
+	if arr.IsNull(i) {
+		return []byte("null"), nil
+	}
+
+	switch values := arr.(type) {
+	case *array.Struct:
+		return marshalArrowStructJSON(values, i)
+	case *array.Map:
+		return marshalArrowMapJSON(values, i)
+	case array.ListLike:
+		return marshalArrowListJSON(values, i)
+	case array.ExtensionArray:
+		if isJSONType(values.DataType()) {
+			raw, ok := schemainfer.StringValueAt(values.Storage(), i)
+			if !ok || !json.Valid([]byte(raw)) {
+				return nil, fmt.Errorf("JSON extension contains invalid JSON")
+			}
+			return []byte(raw), nil
+		}
+		return marshalArrowJSONValue(values.Storage(), i)
+	case *array.Dictionary:
+		return marshalArrowJSONValue(values.Dictionary(), values.GetValueIndex(i))
+	case *array.RunEndEncoded:
+		return marshalArrowJSONValue(values.Values(), values.GetPhysicalIndex(i))
+	case interface{ Value(int) []byte }:
+		return json.Marshal(values.Value(i))
+	}
+
+	raw := arr.ValueStr(i)
+	switch arr.DataType().ID() {
+	case arrow.STRING, arrow.LARGE_STRING, arrow.STRING_VIEW,
+		arrow.DATE32, arrow.DATE64, arrow.TIME32, arrow.TIME64, arrow.TIMESTAMP,
+		arrow.DURATION, arrow.INTERVAL_MONTHS, arrow.INTERVAL_DAY_TIME, arrow.INTERVAL_MONTH_DAY_NANO:
+		return json.Marshal(raw)
+	default:
+		if !json.Valid([]byte(raw)) {
+			return nil, fmt.Errorf("arrow %s value %q has no lossless JSON representation", arr.DataType(), raw)
+		}
+		return []byte(raw), nil
+	}
+}
+
+func marshalArrowStructJSON(values *array.Struct, i int) ([]byte, error) {
+	fields := values.DataType().(*arrow.StructType).Fields()
+	seen := make(map[string]struct{}, len(fields))
+	var result bytes.Buffer
+	result.WriteByte('{')
+	for fieldIndex, field := range fields {
+		if _, ok := seen[field.Name]; ok {
+			return nil, fmt.Errorf("struct contains duplicate field %q", field.Name)
+		}
+		seen[field.Name] = struct{}{}
+		if fieldIndex > 0 {
+			result.WriteByte(',')
+		}
+		name, _ := json.Marshal(field.Name)
+		result.Write(name)
+		result.WriteByte(':')
+		value, err := marshalArrowJSONValue(values.Field(fieldIndex), i)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", field.Name, err)
+		}
+		result.Write(value)
+	}
+	result.WriteByte('}')
+	return result.Bytes(), nil
+}
+
+func marshalArrowListJSON(values array.ListLike, i int) ([]byte, error) {
+	start, end := values.ValueOffsets(i)
+	items := values.ListValues()
+	if start < 0 || end < start || end > int64(items.Len()) {
+		return nil, fmt.Errorf("invalid list offsets [%d:%d] for %d values", start, end, items.Len())
+	}
+	var result bytes.Buffer
+	result.WriteByte('[')
+	for itemIndex := start; itemIndex < end; itemIndex++ {
+		if itemIndex > start {
+			result.WriteByte(',')
+		}
+		value, err := marshalArrowJSONValue(items, int(itemIndex))
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", itemIndex-start, err)
+		}
+		result.Write(value)
+	}
+	result.WriteByte(']')
+	return result.Bytes(), nil
+}
+
+func marshalArrowMapJSON(values *array.Map, i int) ([]byte, error) {
+	start, end := values.ValueOffsets(i)
+	keys, items := values.Keys(), values.Items()
+	if start < 0 || end < start || end > int64(keys.Len()) || end > int64(items.Len()) {
+		return nil, fmt.Errorf("invalid map offsets [%d:%d] for %d keys and %d values", start, end, keys.Len(), items.Len())
+	}
+	if !arrowMapKeysUseJSONObject(keys.DataType()) {
+		return marshalArrowMapEntriesJSON(keys, items, start, end)
+	}
+	seen := make(map[string]struct{}, end-start)
+	var result bytes.Buffer
+	result.WriteByte('{')
+	for itemIndex := start; itemIndex < end; itemIndex++ {
+		keyJSON, err := marshalArrowJSONValue(keys, int(itemIndex))
+		if err != nil {
+			return nil, fmt.Errorf("map key %d: %w", itemIndex-start, err)
+		}
+		key := string(keyJSON)
+		if len(keyJSON) > 0 && keyJSON[0] == '"' {
+			if err := json.Unmarshal(keyJSON, &key); err != nil {
+				return nil, fmt.Errorf("map key %d: %w", itemIndex-start, err)
+			}
+		}
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("map contains duplicate JSON key %q", key)
+		}
+		seen[key] = struct{}{}
+		if itemIndex > start {
+			result.WriteByte(',')
+		}
+		encodedKey, _ := json.Marshal(key)
+		result.Write(encodedKey)
+		result.WriteByte(':')
+		value, err := marshalArrowJSONValue(items, int(itemIndex))
+		if err != nil {
+			return nil, fmt.Errorf("map value for key %q: %w", key, err)
+		}
+		result.Write(value)
+	}
+	result.WriteByte('}')
+	return result.Bytes(), nil
+}
+
+func marshalArrowMapEntriesJSON(keys, items arrow.Array, start, end int64) ([]byte, error) {
+	var result bytes.Buffer
+	result.WriteByte('[')
+	for itemIndex := start; itemIndex < end; itemIndex++ {
+		if itemIndex > start {
+			result.WriteByte(',')
+		}
+		key, err := marshalArrowJSONValue(keys, int(itemIndex))
+		if err != nil {
+			return nil, fmt.Errorf("map key %d: %w", itemIndex-start, err)
+		}
+		value, err := marshalArrowJSONValue(items, int(itemIndex))
+		if err != nil {
+			return nil, fmt.Errorf("map value %d: %w", itemIndex-start, err)
+		}
+		result.WriteString(`{"key":`)
+		result.Write(key)
+		result.WriteString(`,"value":`)
+		result.Write(value)
+		result.WriteByte('}')
+	}
+	result.WriteByte(']')
+	return result.Bytes(), nil
+}
+
+func arrowMapKeysUseJSONObject(dt arrow.DataType) bool {
+	switch typed := dt.(type) {
+	case *arrow.DictionaryType:
+		return arrowMapKeysUseJSONObject(typed.ValueType)
+	default:
+		return dt.ID() == arrow.STRING || dt.ID() == arrow.LARGE_STRING || dt.ID() == arrow.STRING_VIEW
+	}
 }
 
 func castArrayToString(ctx context.Context, arr arrow.Array) (arrow.Array, error) {

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -753,6 +753,180 @@ func TestCastRecordToSchema_UnknownToJSONEncodesScalarStrings(t *testing.T) {
 	assert.True(t, storageCol.IsNull(4))
 }
 
+func TestCastRecordToSchema_NestedArrowValuesBecomeJSON(t *testing.T) {
+	structType := arrow.StructOf(
+		arrow.Field{Name: "label", Type: arrow.BinaryTypes.String, Nullable: false},
+		arrow.Field{Name: "ids", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64), Nullable: true},
+		arrow.Field{Name: "attributes", Type: arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String), Nullable: true},
+		arrow.Field{Name: "blob", Type: arrow.BinaryTypes.Binary, Nullable: true},
+	)
+	builder := array.NewStructBuilder(memory.DefaultAllocator, structType)
+	labelBuilder := builder.FieldBuilder(0).(*array.StringBuilder)
+	idsBuilder := builder.FieldBuilder(1).(*array.ListBuilder)
+	idBuilder := idsBuilder.ValueBuilder().(*array.Int64Builder)
+	attributesBuilder := builder.FieldBuilder(2).(*array.MapBuilder)
+	attributeKeyBuilder := attributesBuilder.KeyBuilder().(*array.StringBuilder)
+	attributeValueBuilder := attributesBuilder.ItemBuilder().(*array.StringBuilder)
+	blobBuilder := builder.FieldBuilder(3).(*array.BinaryBuilder)
+
+	builder.Append(true)
+	labelBuilder.Append("true")
+	idsBuilder.Append(true)
+	idBuilder.Append(1)
+	idBuilder.AppendNull()
+	attributesBuilder.Append(true)
+	attributeKeyBuilder.Append("active")
+	attributeValueBuilder.Append("true")
+	attributeKeyBuilder.Append("count")
+	attributeValueBuilder.Append("2")
+	blobBuilder.Append([]byte{0xff, 0x00})
+
+	builder.Append(true)
+	labelBuilder.Append("null")
+	idsBuilder.Append(true)
+	attributesBuilder.Append(true)
+	blobBuilder.Append([]byte{})
+
+	builder.AppendNull()
+	values := builder.NewStructArray()
+	builder.Release()
+	defer values.Release()
+
+	sourceSchema := arrow.NewSchema([]arrow.Field{{Name: "payload", Type: structType, Nullable: true}}, nil)
+	targetSchema := arrow.NewSchema([]arrow.Field{{Name: "payload", Type: schema.JSONArrowType, Nullable: true}}, nil)
+	record := array.NewRecordBatch(sourceSchema, []arrow.Array{values}, 3)
+	defer record.Release()
+
+	casted, err := CastRecordToSchema(record, targetSchema, true)
+	require.NoError(t, err)
+	defer casted.Release()
+
+	jsonValues := casted.Column(0).(array.ExtensionArray).Storage().(*array.String)
+	assert.Equal(t, `{"label":"true","ids":[1,null],"attributes":{"active":"true","count":"2"},"blob":"/wA="}`, jsonValues.Value(0))
+	assert.Equal(t, `{"label":"null","ids":[],"attributes":{},"blob":""}`, jsonValues.Value(1))
+	assert.True(t, jsonValues.IsNull(2))
+}
+
+func TestCastRecordToSchema_NestedArrowJSONPreservesSlicedOffsets(t *testing.T) {
+	builder := array.NewListBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String)
+	items := builder.ValueBuilder().(*array.StringBuilder)
+	builder.Append(true)
+	items.Append("discard")
+	builder.Append(true)
+	items.Append("true")
+	items.Append("null")
+	builder.Append(false)
+	full := builder.NewListArray()
+	builder.Release()
+	defer full.Release()
+
+	sliced := array.NewSlice(full, 1, 3)
+	defer sliced.Release()
+	sourceSchema := arrow.NewSchema([]arrow.Field{{Name: "items", Type: full.DataType(), Nullable: true}}, nil)
+	targetSchema := arrow.NewSchema([]arrow.Field{{Name: "items", Type: schema.JSONArrowType, Nullable: true}}, nil)
+	record := array.NewRecordBatch(sourceSchema, []arrow.Array{sliced}, 2)
+	defer record.Release()
+
+	casted, err := CastRecordToSchema(record, targetSchema, true)
+	require.NoError(t, err)
+	defer casted.Release()
+	jsonValues := casted.Column(0).(array.ExtensionArray).Storage().(*array.String)
+	assert.Equal(t, `["true","null"]`, jsonValues.Value(0))
+	assert.True(t, jsonValues.IsNull(1))
+}
+
+func TestCastRecordToSchema_PrimitiveVariableListsRemainArrays(t *testing.T) {
+	for _, sourceType := range []arrow.DataType{
+		arrow.ListOf(arrow.PrimitiveTypes.Int32),
+		arrow.LargeListOf(arrow.PrimitiveTypes.Int32),
+		arrow.ListViewOf(arrow.PrimitiveTypes.Int32),
+		arrow.LargeListViewOf(arrow.PrimitiveTypes.Int32),
+	} {
+		t.Run(sourceType.Name(), func(t *testing.T) {
+			builder := array.NewBuilder(memory.DefaultAllocator, sourceType)
+			require.NoError(t, builder.AppendValueFromString(`[0]`))
+			require.NoError(t, builder.AppendValueFromString(`[1,null,2]`))
+			builder.AppendNull()
+			require.NoError(t, builder.AppendValueFromString(`[]`))
+			full := builder.NewArray()
+			builder.Release()
+			defer full.Release()
+
+			sliced := array.NewSlice(full, 1, 4)
+			defer sliced.Release()
+			sourceSchema := arrow.NewSchema([]arrow.Field{{Name: "numbers", Type: sourceType, Nullable: true}}, nil)
+			targetSchema := arrow.NewSchema([]arrow.Field{{Name: "numbers", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64), Nullable: true}}, nil)
+			record := array.NewRecordBatch(sourceSchema, []arrow.Array{sliced}, 3)
+			defer record.Release()
+
+			casted, err := CastRecordToSchema(record, targetSchema, true)
+			require.NoError(t, err)
+			defer casted.Release()
+			numbers := casted.Column(0).(*array.List)
+			assert.False(t, numbers.IsNull(0))
+			assert.True(t, numbers.IsNull(1))
+			assert.False(t, numbers.IsNull(2))
+			start, end := numbers.ValueOffsets(0)
+			assert.Equal(t, int64(0), start)
+			assert.Equal(t, int64(3), end)
+			start, end = numbers.ValueOffsets(2)
+			assert.Equal(t, int64(3), start)
+			assert.Equal(t, int64(3), end)
+			values := numbers.ListValues().(*array.Int64)
+			assert.Equal(t, int64(1), values.Value(0))
+			assert.True(t, values.IsNull(1))
+			assert.Equal(t, int64(2), values.Value(2))
+		})
+	}
+}
+
+func TestCastRecordToSchema_RejectsDuplicateArrowMapKeys(t *testing.T) {
+	builder := array.NewMapBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int64, false)
+	keys := builder.KeyBuilder().(*array.StringBuilder)
+	items := builder.ItemBuilder().(*array.Int64Builder)
+	builder.Append(true)
+	keys.Append("duplicate")
+	items.Append(1)
+	keys.Append("duplicate")
+	items.Append(2)
+	values := builder.NewMapArray()
+	builder.Release()
+	defer values.Release()
+
+	sourceSchema := arrow.NewSchema([]arrow.Field{{Name: "attributes", Type: values.DataType(), Nullable: true}}, nil)
+	targetSchema := arrow.NewSchema([]arrow.Field{{Name: "attributes", Type: schema.JSONArrowType, Nullable: true}}, nil)
+	record := array.NewRecordBatch(sourceSchema, []arrow.Array{values}, 1)
+	defer record.Release()
+
+	_, err := CastRecordToSchema(record, targetSchema, true)
+	require.ErrorContains(t, err, `map contains duplicate JSON key "duplicate"`)
+}
+
+func TestCastRecordToSchema_NonStringArrowMapKeysUseEntries(t *testing.T) {
+	builder := array.NewMapBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64, arrow.BinaryTypes.String, false)
+	keys := builder.KeyBuilder().(*array.Int64Builder)
+	items := builder.ItemBuilder().(*array.StringBuilder)
+	builder.Append(true)
+	keys.Append(1)
+	items.Append("one")
+	builder.Append(true)
+	values := builder.NewMapArray()
+	builder.Release()
+	defer values.Release()
+
+	sourceSchema := arrow.NewSchema([]arrow.Field{{Name: "attributes", Type: values.DataType(), Nullable: true}}, nil)
+	targetSchema := arrow.NewSchema([]arrow.Field{{Name: "attributes", Type: schema.JSONArrowType, Nullable: true}}, nil)
+	record := array.NewRecordBatch(sourceSchema, []arrow.Array{values}, 2)
+	defer record.Release()
+
+	casted, err := CastRecordToSchema(record, targetSchema, true)
+	require.NoError(t, err)
+	defer casted.Release()
+	jsonValues := casted.Column(0).(array.ExtensionArray).Storage().(*array.String)
+	assert.Equal(t, `[{"key":1,"value":"one"}]`, jsonValues.Value(0))
+	assert.Equal(t, `[]`, jsonValues.Value(1))
+}
+
 // ============================================================================
 // Unsafe Cast Tests (safe=false, user column overrides)
 // ============================================================================

--- a/pkg/schemainfer/merge.go
+++ b/pkg/schemainfer/merge.go
@@ -38,6 +38,10 @@ var typePriority = map[arrow.Type]int{
 // MergeArrowTypes merges two Arrow types using promotion rules.
 // When types conflict, the result is promoted to a type that can hold both.
 func MergeArrowTypes(existing, new arrow.DataType) (arrow.DataType, error) {
+	if nestedArrowTypeUsesJSON(existing) || nestedArrowTypeUsesJSON(new) {
+		return schema.JSONArrowType, nil
+	}
+
 	// Same type - no merge needed
 	if arrow.TypeEqual(existing, new) {
 		return existing, nil
@@ -49,6 +53,22 @@ func MergeArrowTypes(existing, new arrow.DataType) (arrow.DataType, error) {
 	}
 	if isUnknownType(new) {
 		return existing, nil
+	}
+
+	existingList, existingIsList := existing.(arrow.VarLenListLikeType)
+	newList, newIsList := new.(arrow.VarLenListLikeType)
+	if existingIsList || newIsList {
+		if !existingIsList || !newIsList {
+			return schema.JSONArrowType, nil
+		}
+		elem, err := MergeArrowTypes(existingList.Elem(), newList.Elem())
+		if err != nil {
+			return nil, err
+		}
+		if nestedArrowTypeUsesJSON(elem) || isJSONType(elem) {
+			return schema.JSONArrowType, nil
+		}
+		return arrow.ListOf(elem), nil
 	}
 
 	// Handle JSON extension types - two JSON types merge to JSON
@@ -268,12 +288,21 @@ func ArrowFieldToColumn(name string, dt arrow.DataType, nullable bool) schema.Co
 		} else {
 			col.DataType = schema.TypeTimestamp
 		}
-	case arrow.LIST, arrow.LARGE_LIST:
-		col.DataType = schema.TypeArray
-		if listType, ok := dt.(*arrow.ListType); ok {
-			elemCol := ArrowFieldToColumn("", listType.Elem(), true)
-			col.ArrayType = elemCol.DataType
+	case arrow.LIST, arrow.LARGE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+		listType, ok := dt.(arrow.ListLikeType)
+		if !ok {
+			col.DataType = schema.TypeJSON
+			break
 		}
+		elemCol := ArrowFieldToColumn("", listType.Elem(), true)
+		if elemCol.DataType == schema.TypeJSON || elemCol.DataType == schema.TypeArray || elemCol.DataType == schema.TypeUnknown {
+			col.DataType = schema.TypeJSON
+			break
+		}
+		col.DataType = schema.TypeArray
+		col.ArrayType = elemCol.DataType
+	case arrow.FIXED_SIZE_LIST, arrow.STRUCT, arrow.MAP:
+		col.DataType = schema.TypeJSON
 	case arrow.EXTENSION:
 		// Check if it's a JSON extension type
 		if isJSONType(dt) {
@@ -289,6 +318,18 @@ func ArrowFieldToColumn(name string, dt arrow.DataType, nullable bool) schema.Co
 	}
 
 	return col
+}
+
+func nestedArrowTypeUsesJSON(dt arrow.DataType) bool {
+	switch dt.ID() {
+	case arrow.STRUCT, arrow.MAP, arrow.FIXED_SIZE_LIST:
+		return true
+	case arrow.LIST, arrow.LARGE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+		listType, ok := dt.(arrow.ListLikeType)
+		return !ok || nestedArrowTypeUsesJSON(listType.Elem()) || isJSONType(listType.Elem())
+	default:
+		return false
+	}
 }
 
 // ArrowTypeToDataType converts an Arrow DataType to internal schema.DataType.

--- a/pkg/schemainfer/merge_test.go
+++ b/pkg/schemainfer/merge_test.go
@@ -402,6 +402,78 @@ func TestArrowFieldToColumn_List(t *testing.T) {
 	}
 }
 
+func TestArrowFieldToColumn_NestedTypesUseJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		type_ arrow.DataType
+	}{
+		{name: "struct", type_: arrow.StructOf(arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int64})},
+		{name: "map", type_: arrow.MapOf(arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int64)},
+		{name: "list of structs", type_: arrow.ListOf(arrow.StructOf(arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int64}))},
+		{name: "nested list", type_: arrow.ListOf(arrow.ListOf(arrow.PrimitiveTypes.Int64))},
+		{name: "fixed size list", type_: arrow.FixedSizeListOf(2, arrow.PrimitiveTypes.Int64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := ArrowFieldToColumn("payload", tt.type_, true)
+			if col.DataType != schema.TypeJSON {
+				t.Fatalf("expected TypeJSON, got %v", col.DataType)
+			}
+		})
+	}
+}
+
+func TestArrowFieldToColumn_PrimitiveVariableListsRemainArrays(t *testing.T) {
+	for _, dt := range []arrow.DataType{
+		arrow.ListOf(arrow.PrimitiveTypes.Int64),
+		arrow.LargeListOf(arrow.PrimitiveTypes.Int64),
+		arrow.ListViewOf(arrow.PrimitiveTypes.Int64),
+		arrow.LargeListViewOf(arrow.PrimitiveTypes.Int64),
+	} {
+		col := ArrowFieldToColumn("numbers", dt, true)
+		if col.DataType != schema.TypeArray || col.ArrayType != schema.TypeInt64 {
+			t.Fatalf("expected array<int64> for %s, got %s<%s>", dt, col.DataType, col.ArrayType)
+		}
+	}
+}
+
+func TestMergeArrowTypes_NestedTypesUseJSON(t *testing.T) {
+	structA := arrow.StructOf(arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int64})
+	structB := arrow.StructOf(arrow.Field{Name: "name", Type: arrow.BinaryTypes.String})
+
+	for _, pair := range [][2]arrow.DataType{
+		{structA, structA},
+		{structA, structB},
+		{arrow.ListOf(structA), arrow.ListOf(structA)},
+	} {
+		merged, err := MergeArrowTypes(pair[0], pair[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !isJSONType(merged) {
+			t.Fatalf("expected JSON when merging %s and %s, got %s", pair[0], pair[1], merged)
+		}
+	}
+}
+
+func TestMergeArrowTypes_PreservesPrimitiveVariableLists(t *testing.T) {
+	unknown := arrow.ListOf(schema.UnknownArrowType)
+	int32s := arrow.ListOf(arrow.PrimitiveTypes.Int32)
+	int64s := arrow.LargeListOf(arrow.PrimitiveTypes.Int64)
+
+	for _, pair := range [][2]arrow.DataType{{unknown, int64s}, {int32s, int64s}} {
+		merged, err := MergeArrowTypes(pair[0], pair[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		col := ArrowFieldToColumn("numbers", merged, true)
+		if col.DataType != schema.TypeArray || col.ArrayType != schema.TypeInt64 {
+			t.Fatalf("expected array<int64> when merging %s and %s, got %s<%s>", pair[0], pair[1], col.DataType, col.ArrayType)
+		}
+	}
+}
+
 func TestValidateSchema(t *testing.T) {
 	// Valid schema
 	valid := &schema.TableSchema{


### PR DESCRIPTION
## Summary

Makes nested Arrow values load reliably by using the existing JSON type instead of treating nested data as strings or introducing native recursive destination schemas.

This affects sources such as Parquet, Arrow, and schema-less connectors that can emit real Arrow structs, maps, or nested lists.

## What was broken before

The following behavior was reproduced against the pre-PR commit with real Arrow batches:

| Arrow input | Previous behavior | Behavior after this PR |
| --- | --- | --- |
| `struct<name:string, age:int64>` | Inferred as `string` and stored as JSON-looking text | Stored using the destination's existing JSON mapping |
| `map<string,int64>` | Inferred as `string` and stored as a key/value-entry array | Stored as a JSON object |
| `list<struct>` | Failed because Arrow has no struct-to-string cast kernel | Stored as a JSON array of objects |
| `list<list<int64>>` | Failed while casting nested elements to `unknown` | Stored as JSON |
| `large_list<int64>` | Failed while casting elements to `unknown` | Preserved as a typed primitive array |
| `list<int32>` merged with `large_list<int64>` | The inferred schema degraded to `string` | Promoted to `array<int64>` |

Concrete examples:

```text
struct<name:string, age:int64>

Before: string column containing {"age":42,"name":"Ada"}
After:  JSON column containing   {"name":"Ada","age":42}
```

```text
map<string,int64>

Before: string column containing [{"key":"x","value":1}]
After:  JSON column containing   {"x":1}
```

```text
list<struct<name:string, age:int64>>

Before: ingestion error: no cast kernel from struct to string
After:  JSON value [{"name":"Ada","age":42}]
```

## Resulting type policy

- Arrow structs, maps, fixed-size lists, arrays of objects, and recursively nested collections use `TypeJSON`.
- Primitive variable-length lists remain typed arrays and their element types can be promoted safely.
- Non-string-key maps use JSON key/value entries so the original key type is preserved.
- Nulls, empty collections, sliced arrays, binary values, dictionary values, and run-end encoded values are serialized explicitly rather than through Arrow's display-string fallback.
- This does not add destination-native struct fields or schema evolution inside JSON values.

## Compatibility note

String-key Arrow maps intentionally change representation from a string containing entry objects:

```json
[{"key":"x","value":1}]
```

to a JSON object:

```json
{"x":1}
```

Consumers that parsed the previous string representation must account for this shape change. The other nested collection cases covered here previously failed ingestion.

## Stack

Part 1 of 11. Review and merge bottom-up. This PR is based on `main`; GitHub therefore shows only this layer's delta.

Previous: `main` · Next: https://github.com/bruin-data/ingestr/pull/960

## Validation

- `make format`
- `make lint`
- `GOFLAGS=-p=1 make test`
- focused schema inference and data-buffer tests across struct, map, list, large-list, list-view, large-list-view, null/empty/sliced data, binary data, duplicate keys, and element promotion
- pre-PR behavior reproduced against commit `0289d076` with real Arrow batches
- Codex `gpt-5.6-terra` high review loop: clean after fixes
