### PR TITLE
Iceberg stack 2/11: stronger schema evolution contracts

### DIFF
--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -123,6 +123,12 @@ type Destination interface {
 	SupportsAtomicSwap() bool
 }
 
+// SchemaEvolutionColumnNormalizer lets a destination compare logical source
+// types using the canonical types it can recover from its physical schema.
+type SchemaEvolutionColumnNormalizer interface {
+	NormalizeSchemaEvolutionColumn(schema.Column) schema.Column
+}
+
 // TableWriteConfig contains per-table write configuration for multi-table writes.
 type TableWriteConfig struct {
 	DestTable   string

--- a/pkg/destination/iceberg/evolve.go
+++ b/pkg/destination/iceberg/evolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	iceberggo "github.com/apache/iceberg-go"
 	icebergtable "github.com/apache/iceberg-go/table"
@@ -68,6 +69,13 @@ func (d *Destination) stageSchemaComparisonUpdate(txn *icebergtable.Transaction,
 				return false, err
 			}
 			changed = changed || applied
+
+		case schemaevolution.ChangeRemoveColumn, schemaevolution.ChangeRelaxNullability:
+			applied, err := stageIcebergRelaxColumn(update, tbl, change.ColumnName)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || applied
 		}
 	}
 
@@ -102,13 +110,25 @@ func stageIcebergUpdateColumn(update *icebergtable.UpdateSchema, tbl *icebergtab
 
 	changed := false
 	if !field.Type.Equals(targetType) {
-		if _, err := iceberggo.PromoteType(field.Type, targetType); err != nil {
-			return false, fmt.Errorf("iceberg: column %q type change from %s to %s is not supported: %w", colName, field.Type, targetType, err)
+		oldList, oldIsList := field.Type.(*iceberggo.ListType)
+		newList, newIsList := targetType.(*iceberggo.ListType)
+		if oldIsList && newIsList {
+			if _, err := iceberggo.PromoteType(oldList.Element, newList.Element); err != nil {
+				return false, fmt.Errorf("iceberg: column %q array element change from %s to %s is not supported: %w", colName, oldList.Element, newList.Element, err)
+			}
+			update.UpdateColumn([]string{colName, "element"}, icebergtable.ColumnUpdate{
+				FieldType: iceberggo.Optional[iceberggo.Type]{Valid: true, Val: newList.Element},
+			})
+			changed = true
+		} else {
+			if _, err := iceberggo.PromoteType(field.Type, targetType); err != nil {
+				return false, fmt.Errorf("iceberg: column %q type change from %s to %s is not supported: %w", colName, field.Type, targetType, err)
+			}
+			update.UpdateColumn([]string{colName}, icebergtable.ColumnUpdate{
+				FieldType: iceberggo.Optional[iceberggo.Type]{Valid: true, Val: targetType},
+			})
+			changed = true
 		}
-		update.UpdateColumn([]string{colName}, icebergtable.ColumnUpdate{
-			FieldType: iceberggo.Optional[iceberggo.Type]{Valid: true, Val: targetType},
-		})
-		changed = true
 	}
 	if field.Required && col.Nullable {
 		update.UpdateColumn([]string{colName}, icebergtable.ColumnUpdate{
@@ -117,4 +137,18 @@ func stageIcebergUpdateColumn(update *icebergtable.UpdateSchema, tbl *icebergtab
 		changed = true
 	}
 	return changed, nil
+}
+
+func stageIcebergRelaxColumn(update *icebergtable.UpdateSchema, tbl *icebergtable.Table, colName string) (bool, error) {
+	field, ok := tbl.Schema().FindFieldByName(colName)
+	if !ok || !field.Required {
+		return false, nil
+	}
+	if slices.Contains(tbl.Schema().IdentifierFieldIDs, field.ID) {
+		return false, fmt.Errorf("iceberg: cannot relax identifier column %q", colName)
+	}
+	update.UpdateColumn([]string{colName}, icebergtable.ColumnUpdate{
+		Required: iceberggo.Optional[bool]{Valid: true, Val: false},
+	})
+	return true, nil
 }

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -418,6 +418,60 @@ func TestDestinationApplySchemaEvolutionPromotesColumnType(t *testing.T) {
 	require.True(t, icebergColumn(t, gotSchema, "id").Nullable)
 }
 
+func TestDestinationApplySchemaEvolutionPromotesArrayElementType(t *testing.T) {
+	ctx := context.Background()
+	tableName := "lake.analytics.promoted_array_events"
+	initial := schema.Column{Name: "values", DataType: schema.TypeArray, ArrayType: schema.TypeInt32, Nullable: true}
+
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, "iceberg+hadoop://?warehouse="+url.QueryEscape(t.TempDir())))
+	defer func() { require.NoError(t, dest.Close(ctx)) }()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: &schema.TableSchema{Columns: []schema.Column{initial}},
+	}))
+
+	_, err := dest.ApplySchemaEvolution(ctx, tableName, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeWidenType, ColumnName: "values", OldColumn: &initial,
+			NewColumn: schema.Column{Name: "values", DataType: schema.TypeArray, ArrayType: schema.TypeInt64, Nullable: true},
+		}},
+	})
+	require.NoError(t, err)
+
+	got, err := dest.GetTableSchema(ctx, tableName)
+	require.NoError(t, err)
+	require.Equal(t, schema.TypeInt64, icebergColumn(t, got, "values").ArrayType)
+}
+
+func TestDestinationApplySchemaEvolutionRelaxesRequiredColumns(t *testing.T) {
+	ctx := context.Background()
+	tableName := "lake.analytics.relaxed_events"
+	relaxed := schema.Column{Name: "relaxed", DataType: schema.TypeString, Nullable: false}
+	removed := schema.Column{Name: "removed", DataType: schema.TypeString, Nullable: false}
+
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, "iceberg+hadoop://?warehouse="+url.QueryEscape(t.TempDir())))
+	defer func() { require.NoError(t, dest.Close(ctx)) }()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: &schema.TableSchema{Columns: []schema.Column{relaxed, removed}},
+	}))
+
+	_, err := dest.ApplySchemaEvolution(ctx, tableName, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{
+			{Type: schemaevolution.ChangeRelaxNullability, ColumnName: "relaxed", OldColumn: &relaxed},
+			{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "removed", OldColumn: &removed},
+		},
+	})
+	require.NoError(t, err)
+
+	got, err := dest.GetTableSchema(ctx, tableName)
+	require.NoError(t, err)
+	require.True(t, icebergColumn(t, got, "relaxed").Nullable)
+	require.True(t, icebergColumn(t, got, "removed").Nullable)
+}
+
 func TestDestinationAppendReturnsSourceErrorAfterBatch(t *testing.T) {
 	ctx := context.Background()
 	tableName := "lake.analytics.failed_append_events"

--- a/pkg/destination/iceberg/mapper.go
+++ b/pkg/destination/iceberg/mapper.go
@@ -106,6 +106,16 @@ func icebergArrowType(col schema.Column) arrow.DataType {
 }
 
 func icebergTypeForColumn(col schema.Column) (iceberggo.Type, error) {
+	if col.DataType == schema.TypeArray {
+		arrowSchema := arrow.NewSchema([]arrow.Field{{
+			Name: col.Name, Type: icebergArrowType(col), Nullable: col.Nullable,
+		}}, nil)
+		iceSchema, err := icebergtable.ArrowSchemaToIcebergWithFreshIDs(arrowSchema, false)
+		if err != nil {
+			return nil, err
+		}
+		return iceSchema.Field(0).Type, nil
+	}
 	return icebergtable.ArrowTypeToIceberg(icebergArrowType(col), false)
 }
 

--- a/pkg/destination/postgres/dialect.go
+++ b/pkg/destination/postgres/dialect.go
@@ -41,6 +41,11 @@ func (d *Dialect) SupportsAlterType() bool {
 	return true
 }
 
+func (d *Dialect) RelaxColumnNullabilitySQL(table, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL",
+		destination.QuoteTableName(table), d.QuoteIdentifier(colName))
+}
+
 func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -1364,10 +1364,12 @@ func (d *PostgresDestination) GetTableSchema(ctx context.Context, table string) 
 			return nil, fmt.Errorf("failed to scan column: %w", err)
 		}
 
+		columnType, arrayType := mapPostgresColumnType(dataType, udtName)
 		col := schema.Column{
-			Name:     colName,
-			DataType: mapPostgresTypeToSchema(dataType, udtName),
-			Nullable: isNullable == "YES",
+			Name:      colName,
+			DataType:  columnType,
+			ArrayType: arrayType,
+			Nullable:  isNullable == "YES",
 		}
 
 		if numPrecision != nil {
@@ -1399,22 +1401,22 @@ func (d *PostgresDestination) GetTableSchema(ctx context.Context, table string) 
 }
 
 func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
-	switch dataType {
-	case "boolean":
+	switch strings.ToLower(strings.TrimSpace(dataType)) {
+	case "boolean", "bool":
 		return schema.TypeBoolean
-	case "smallint":
+	case "smallint", "int2":
 		return schema.TypeInt16
-	case "integer":
+	case "integer", "int", "int4":
 		return schema.TypeInt32
-	case "bigint":
+	case "bigint", "int8":
 		return schema.TypeInt64
-	case "real":
+	case "real", "float4":
 		return schema.TypeFloat32
-	case "double precision":
+	case "double precision", "float8":
 		return schema.TypeFloat64
 	case "numeric", "decimal":
 		return schema.TypeDecimal
-	case "character varying", "varchar", "character", "char", "text":
+	case "character varying", "varchar", "character", "char", "text", "bpchar", "name":
 		return schema.TypeString
 	case "bytea":
 		return schema.TypeBinary
@@ -1424,7 +1426,7 @@ func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
 		return schema.TypeTime
 	case "timestamp", "timestamp without time zone":
 		return schema.TypeTimestamp
-	case "timestamp with time zone":
+	case "timestamp with time zone", "timestamptz":
 		return schema.TypeTimestampTZ
 	case "interval":
 		return schema.TypeInterval
@@ -1432,7 +1434,7 @@ func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
 		return schema.TypeJSON
 	case "uuid":
 		return schema.TypeUUID
-	case "ARRAY":
+	case "array":
 		return schema.TypeArray
 	default:
 		if strings.HasPrefix(udtName, "_") {
@@ -1440,6 +1442,20 @@ func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
 		}
 		return schema.TypeString
 	}
+}
+
+func mapPostgresColumnType(dataType, udtName string) (schema.DataType, schema.DataType) {
+	columnType := mapPostgresTypeToSchema(dataType, udtName)
+	if columnType != schema.TypeArray {
+		return columnType, schema.TypeUnknown
+	}
+
+	elementTypeName := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(udtName)), "_")
+	elementType := mapPostgresTypeToSchema(elementTypeName, elementTypeName)
+	if elementType == schema.TypeArray {
+		elementType = schema.TypeString
+	}
+	return columnType, elementType
 }
 
 // quoteColumns returns column names wrapped in double quotes.

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -89,6 +89,50 @@ func TestValidatePostgresClaimTargetAcceptsIdentifierLimit(t *testing.T) {
 	}
 }
 
+func TestMapPostgresColumnTypePreservesArrayElementType(t *testing.T) {
+	tests := []struct {
+		udt  string
+		want schema.DataType
+	}{
+		{"_bool", schema.TypeBoolean},
+		{"_int2", schema.TypeInt16},
+		{"_int4", schema.TypeInt32},
+		{"_int8", schema.TypeInt64},
+		{"_float4", schema.TypeFloat32},
+		{"_float8", schema.TypeFloat64},
+		{"_numeric", schema.TypeDecimal},
+		{"_text", schema.TypeString},
+		{"_varchar", schema.TypeString},
+		{"_bpchar", schema.TypeString},
+		{"_bytea", schema.TypeBinary},
+		{"_date", schema.TypeDate},
+		{"_time", schema.TypeTime},
+		{"_timestamp", schema.TypeTimestamp},
+		{"_timestamptz", schema.TypeTimestampTZ},
+		{"_interval", schema.TypeInterval},
+		{"_json", schema.TypeJSON},
+		{"_jsonb", schema.TypeJSON},
+		{"_uuid", schema.TypeUUID},
+		{"_custom_enum", schema.TypeString},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.udt, func(t *testing.T) {
+			dataType, arrayType := mapPostgresColumnType("ARRAY", tt.udt)
+			if dataType != schema.TypeArray || arrayType != tt.want {
+				t.Fatalf("mapPostgresColumnType(ARRAY, %q) = (%v, %v), want (%v, %v)", tt.udt, dataType, arrayType, schema.TypeArray, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapPostgresColumnTypeScalarHasNoArrayElement(t *testing.T) {
+	dataType, arrayType := mapPostgresColumnType("integer", "int4")
+	if dataType != schema.TypeInt32 || arrayType != schema.TypeUnknown {
+		t.Fatalf("mapPostgresColumnType(integer, int4) = (%v, %v), want (%v, %v)", dataType, arrayType, schema.TypeInt32, schema.TypeUnknown)
+	}
+}
+
 func TestResolvedMultiTableNameFitsPostgresClaimLimit(t *testing.T) {
 	sourceTable := strings.Repeat("s", 40) + "." + strings.Repeat("t", 40)
 	resolved := destination.ResolveMultiTableName("postgres", nil, "landing", sourceTable)
@@ -166,6 +210,14 @@ func TestPostgresValueGetterMatchesArrowutilValue(t *testing.T) {
 				t.Fatalf("%s[%d]: postgresValueGetter = %#v (%T), arrowutil.Value = %#v (%T)", arr.DataType(), i, got, got, want, want)
 			}
 		}
+	}
+}
+
+func TestDialectRelaxColumnNullabilitySQL(t *testing.T) {
+	got := (&Dialect{}).RelaxColumnNullabilitySQL("public.events", "Payload")
+	want := `ALTER TABLE "public"."events" ALTER COLUMN "Payload" DROP NOT NULL`
+	if got != want {
+		t.Fatalf("RelaxColumnNullabilitySQL() = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/destination/schema_evolution.go
+++ b/pkg/destination/schema_evolution.go
@@ -42,6 +42,13 @@ type BatchColumnTypeAlterer interface {
 	BatchAlterColumnTypesSQL(table string, cols []schema.Column) string
 }
 
+// NullabilityRelaxer renders DDL that changes an existing required column to
+// optional. Dialects without this capability must fail evolution before data
+// is written whenever nullable source rows could reach a required column.
+type NullabilityRelaxer interface {
+	RelaxColumnNullabilitySQL(table, colName string) string
+}
+
 // BuildMigration turns an abstract schema comparison into the concrete DDL
 // statements (and human-readable warnings) for a dialect. It is dialect-
 // agnostic orchestration shared by SQL destinations; the dialect supplies the
@@ -85,6 +92,14 @@ func BuildMigration(dialect Dialect, table string, comparison *schemaevolution.S
 					warnings = append(warnings, fmt.Sprintf("column %q: %s", change.ColumnName, warning))
 				}
 			}
+
+		case schemaevolution.ChangeRelaxNullability:
+			appendNullabilityRelaxation(dialect, table, change.ColumnName, &statements, &warnings)
+
+		case schemaevolution.ChangeRemoveColumn:
+			if change.OldColumn != nil && !change.OldColumn.Nullable {
+				appendNullabilityRelaxation(dialect, table, change.ColumnName, &statements, &warnings)
+			}
 		}
 	}
 
@@ -103,9 +118,45 @@ func BuildMigration(dialect Dialect, table string, comparison *schemaevolution.S
 	return statements, warnings
 }
 
+func appendNullabilityRelaxation(dialect Dialect, table, column string, statements, warnings *[]string) {
+	if relaxer, ok := dialect.(NullabilityRelaxer); ok {
+		if sql := relaxer.RelaxColumnNullabilitySQL(table, column); sql != "" {
+			*statements = append(*statements, sql)
+			return
+		}
+	}
+	*warnings = append(*warnings, fmt.Sprintf(
+		"column %q nullability relaxation skipped: %s does not expose nullability evolution",
+		column, dialect.Name(),
+	))
+}
+
 // ApplyEvolution renders the abstract schema-change plan into dialect-specific
 // DDL and executes each statement against the destination.
 func ApplyEvolution(ctx context.Context, dest Destination, dialect Dialect, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
+	if comparison != nil {
+		for _, change := range comparison.Changes {
+			if change.Type == schemaevolution.ChangeWidenType || change.Type == schemaevolution.ChangeOverrideType {
+				if !dialect.SupportsAlterType() || dialect.AlterColumnTypeSQL(table, change.ColumnName, change.NewColumn) == "" {
+					return nil, fmt.Errorf(
+						"apply schema evolution: column %q requires a type change, which generic %s DDL does not support",
+						change.ColumnName, dialect.Name(),
+					)
+				}
+			}
+			needsRelaxation := change.Type == schemaevolution.ChangeRelaxNullability ||
+				(change.Type == schemaevolution.ChangeRemoveColumn && change.OldColumn != nil && !change.OldColumn.Nullable)
+			if needsRelaxation {
+				relaxer, ok := dialect.(NullabilityRelaxer)
+				if !ok || relaxer.RelaxColumnNullabilitySQL(table, change.ColumnName) == "" {
+					return nil, fmt.Errorf(
+						"apply schema evolution: column %q requires nullability relaxation, which generic %s DDL does not support",
+						change.ColumnName, dialect.Name(),
+					)
+				}
+			}
+		}
+	}
 	statements, warnings := BuildMigration(dialect, table, comparison)
 	for _, stmt := range statements {
 		if err := dest.Exec(ctx, stmt); err != nil {

--- a/pkg/destination/schema_evolution_test.go
+++ b/pkg/destination/schema_evolution_test.go
@@ -1,6 +1,7 @@
 package destination_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,6 +12,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeExecDestination struct {
+	destination.Destination
+	statements []string
+}
+
+func (d *fakeExecDestination) Exec(_ context.Context, stmt string, _ ...interface{}) error {
+	d.statements = append(d.statements, stmt)
+	return nil
+}
 
 // fakeDialect is a minimal destination.Dialect for exercising BuildMigration.
 type fakeDialect struct {
@@ -77,9 +88,85 @@ func widenComparison() *schemaevolution.SchemaComparison {
 		Changes: []schemaevolution.SchemaChange{
 			{Type: schemaevolution.ChangeAddColumn, ColumnName: "added", NewColumn: schema.Column{Name: "added", DataType: schema.TypeString, Nullable: true}},
 			{Type: schemaevolution.ChangeWidenType, ColumnName: "val", OldColumn: &schema.Column{Name: "val", DataType: schema.TypeInt32}, NewColumn: schema.Column{Name: "val", DataType: schema.TypeInt64, Nullable: true}},
-			{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "gone", OldColumn: &schema.Column{Name: "gone", DataType: schema.TypeString}},
+			{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "gone", OldColumn: &schema.Column{Name: "gone", DataType: schema.TypeString, Nullable: true}},
 		},
 	}
+}
+
+type fakeNullableDialect struct{ fakeDialect }
+
+func (d *fakeNullableDialect) RelaxColumnNullabilitySQL(table, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL", table, d.QuoteIdentifier(colName))
+}
+
+func TestBuildMigrationRelaxesNullabilityAndSoftRemovedRequiredColumns(t *testing.T) {
+	required := schema.Column{Name: "removed", DataType: schema.TypeString, Nullable: false}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional"},
+		{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "removed", OldColumn: &required},
+	}}
+	statements, warnings := destination.BuildMigration(&fakeNullableDialect{}, "events", comparison)
+	require.Empty(t, warnings)
+	require.Equal(t, []string{
+		`ALTER TABLE events ALTER COLUMN "optional" DROP NOT NULL`,
+		`ALTER TABLE events ALTER COLUMN "removed" DROP NOT NULL`,
+	}, statements)
+}
+
+func TestBuildMigrationWarnsWhenNullabilityRelaxationIsUnsupported(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional",
+	}}}
+	statements, warnings := destination.BuildMigration(&fakeDialect{}, "events", comparison)
+	require.Empty(t, statements)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "does not expose nullability evolution")
+}
+
+func TestApplyEvolutionRejectsUnsupportedNullabilityBeforeExecutingDDL(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{Type: schemaevolution.ChangeAddColumn, ColumnName: "new_col", NewColumn: schema.Column{Name: "new_col", DataType: schema.TypeString}},
+		{Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional"},
+	}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeDialect{}, "events", comparison)
+	require.ErrorContains(t, err, "requires nullability relaxation")
+	require.Empty(t, dest.statements, "validation must fail before an earlier add-column statement executes")
+}
+
+func TestApplyEvolutionExecutesSupportedNullabilityRelaxation(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional",
+	}}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeNullableDialect{}, "events", comparison)
+	require.NoError(t, err)
+	require.Equal(t, []string{`ALTER TABLE events ALTER COLUMN "optional" DROP NOT NULL`}, dest.statements)
+}
+
+func TestApplyEvolutionRejectsUnsupportedTypeChangeBeforeExecutingDDL(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{Type: schemaevolution.ChangeAddColumn, ColumnName: "new_col", NewColumn: schema.Column{Name: "new_col", DataType: schema.TypeString}},
+		{Type: schemaevolution.ChangeWidenType, ColumnName: "value", NewColumn: schema.Column{Name: "value", DataType: schema.TypeInt64}},
+	}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeDialect{supportsAlter: false}, "events", comparison)
+	require.ErrorContains(t, err, "requires a type change")
+	require.Empty(t, dest.statements, "validation must reject the complete migration before ADD COLUMN executes")
+}
+
+type emptyAlterDialect struct{ fakeDialect }
+
+func (*emptyAlterDialect) AlterColumnTypeSQL(string, string, schema.Column) string { return "" }
+
+func TestApplyEvolutionRejectsEmptyTypeAlterationBeforeExecutingDDL(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeOverrideType, ColumnName: "value", NewColumn: schema.Column{Name: "value", DataType: schema.TypeString},
+	}}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &emptyAlterDialect{fakeDialect{supportsAlter: true}}, "events", comparison)
+	require.ErrorContains(t, err, "requires a type change")
+	require.Empty(t, dest.statements)
 }
 
 func TestBuildMigration_NoChanges(t *testing.T) {

--- a/pkg/destination/sqlite/dialect.go
+++ b/pkg/destination/sqlite/dialect.go
@@ -31,31 +31,7 @@ func (d *Dialect) SupportsAlterType() bool {
 }
 
 func (d *Dialect) TypeName(col schema.Column) string {
-	switch col.DataType {
-	case schema.TypeBoolean:
-		return "INTEGER"
-	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
-		return "INTEGER"
-	case schema.TypeFloat32, schema.TypeFloat64:
-		return "REAL"
-	case schema.TypeDecimal:
-		return "REAL"
-	case schema.TypeString, schema.TypeJSON, schema.TypeUUID:
-		if col.DataType == schema.TypeString && col.MaxLength > 0 {
-			return fmt.Sprintf("VARCHAR(%d)", col.MaxLength)
-		}
-		return "TEXT"
-	case schema.TypeBinary:
-		return "BLOB"
-	case schema.TypeDate, schema.TypeTime, schema.TypeTimestamp, schema.TypeTimestampTZ:
-		return "TEXT"
-	case schema.TypeInterval:
-		return "TEXT"
-	case schema.TypeArray:
-		return "TEXT"
-	default:
-		return "TEXT"
-	}
+	return MapDataTypeToSQLite(col)
 }
 
 func (d *Dialect) QuoteIdentifier(name string) string {

--- a/pkg/destination/sqlite/mapper.go
+++ b/pkg/destination/sqlite/mapper.go
@@ -36,3 +36,21 @@ func MapDataTypeToSQLite(col schema.Column) string {
 		return "TEXT"
 	}
 }
+
+func (d *SQLiteDestination) NormalizeSchemaEvolutionColumn(col schema.Column) schema.Column {
+	switch col.DataType {
+	case schema.TypeBoolean, schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+		col.DataType = schema.TypeInt64
+	case schema.TypeFloat32, schema.TypeFloat64, schema.TypeDecimal:
+		col.DataType = schema.TypeFloat64
+	case schema.TypeBinary:
+		col.DataType = schema.TypeBinary
+	default:
+		col.DataType = schema.TypeString
+	}
+	col.Precision = 0
+	col.Scale = 0
+	col.MaxLength = 0
+	col.ArrayType = schema.TypeUnknown
+	return col
+}

--- a/pkg/destination/sqlite/mapper_test.go
+++ b/pkg/destination/sqlite/mapper_test.go
@@ -1,0 +1,159 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+)
+
+func TestDialectTypeNameMatchesTableCreationMapping(t *testing.T) {
+	dialect := &Dialect{}
+	for dataType := schema.TypeUnknown; dataType <= schema.TypeArray; dataType++ {
+		col := schema.Column{Name: "value", DataType: dataType, Precision: 12, Scale: 2, MaxLength: 64, ArrayType: schema.TypeInt32}
+		if got, want := dialect.TypeName(col), MapDataTypeToSQLite(col); got != want {
+			t.Errorf("TypeName(%v) = %q, want %q", dataType, got, want)
+		}
+	}
+}
+
+func TestNormalizeSchemaEvolutionColumnUsesRecoverableSQLiteTypes(t *testing.T) {
+	tests := []struct {
+		input schema.DataType
+		want  schema.DataType
+	}{
+		{schema.TypeBoolean, schema.TypeInt64},
+		{schema.TypeInt8, schema.TypeInt64},
+		{schema.TypeInt64, schema.TypeInt64},
+		{schema.TypeFloat32, schema.TypeFloat64},
+		{schema.TypeDecimal, schema.TypeFloat64},
+		{schema.TypeString, schema.TypeString},
+		{schema.TypeUUID, schema.TypeString},
+		{schema.TypeDate, schema.TypeString},
+		{schema.TypeTime, schema.TypeString},
+		{schema.TypeTimestamp, schema.TypeString},
+		{schema.TypeTimestampTZ, schema.TypeString},
+		{schema.TypeInterval, schema.TypeString},
+		{schema.TypeArray, schema.TypeString},
+		{schema.TypeBinary, schema.TypeBinary},
+		{schema.TypeJSON, schema.TypeString},
+	}
+	dest := NewSQLiteDestination()
+	for _, tt := range tests {
+		t.Run(tt.input.String(), func(t *testing.T) {
+			input := schema.Column{Name: "value", DataType: tt.input, Precision: 12, Scale: 2, MaxLength: 64, ArrayType: schema.TypeInt32}
+			got := dest.NormalizeSchemaEvolutionColumn(input)
+			if got.DataType != tt.want {
+				t.Fatalf("normalized type = %v, want %v", got.DataType, tt.want)
+			}
+			if got.Precision != 0 || got.Scale != 0 || got.MaxLength != 0 || got.ArrayType != schema.TypeUnknown {
+				t.Fatalf("normalized metadata was not cleared: %+v", got)
+			}
+			if input.DataType != tt.input || input.Precision != 12 {
+				t.Fatalf("normalization mutated input: %+v", input)
+			}
+		})
+	}
+}
+
+func TestSchemaEvolutionComparisonUsesSQLiteStorageTypes(t *testing.T) {
+	dest := NewSQLiteDestination()
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeBoolean}}}
+	stored := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeInt64}}}
+
+	comparison, err := schemaevolution.Compare(source, stored, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparison.HasChanges {
+		t.Fatalf("boolean stored as INTEGER produced changes: %+v", comparison.Changes)
+	}
+
+	source.Columns[0].DataType = schema.TypeString
+	comparison, err = schemaevolution.Compare(source, stored, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !comparison.HasChanges {
+		t.Fatal("genuine TEXT versus INTEGER change was suppressed")
+	}
+}
+
+func TestSchemaEvolutionComparisonAcceptsLegacyJSONTextColumn(t *testing.T) {
+	dest := NewSQLiteDestination()
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "payload", DataType: schema.TypeJSON}}}
+	legacyStored := &schema.TableSchema{Columns: []schema.Column{{Name: "payload", DataType: schema.TypeString}}}
+
+	comparison, err := schemaevolution.Compare(source, legacyStored, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparison.HasChanges {
+		t.Fatalf("JSON stored by the legacy ADD COLUMN path as TEXT produced changes: %+v", comparison.Changes)
+	}
+}
+
+func TestGetTableSchemaRecognizesLegacyTypeDeclarations(t *testing.T) {
+	dest := NewSQLiteDestination()
+	path := filepath.Join(t.TempDir(), "legacy-types.db")
+	if err := dest.Connect(t.Context(), "sqlite://"+path); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dest.Close(t.Context()) }()
+	if err := dest.Exec(t.Context(), `CREATE TABLE legacy_types (
+		active BOOLEAN,
+		enabled BOOL,
+		small_value INT2,
+		large_value INT8,
+		ratio DOUBLE PRECISION,
+		label VARCHAR(32),
+		payload JSON
+	)`); err != nil {
+		t.Fatal(err)
+	}
+
+	stored, err := dest.GetTableSchema(t.Context(), "legacy_types")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []schema.DataType{
+		schema.TypeBoolean,
+		schema.TypeBoolean,
+		schema.TypeInt64,
+		schema.TypeInt64,
+		schema.TypeFloat64,
+		schema.TypeString,
+		schema.TypeJSON,
+	}
+	for i, col := range stored.Columns {
+		if col.DataType != want[i] {
+			t.Errorf("column %s type = %v, want %v", col.Name, col.DataType, want[i])
+		}
+	}
+
+	source := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "active", DataType: schema.TypeBoolean, Nullable: true},
+		{Name: "enabled", DataType: schema.TypeBoolean, Nullable: true},
+		{Name: "small_value", DataType: schema.TypeInt16, Nullable: true},
+		{Name: "large_value", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "ratio", DataType: schema.TypeFloat64, Nullable: true},
+		{Name: "label", DataType: schema.TypeString, MaxLength: 32, Nullable: true},
+		{Name: "payload", DataType: schema.TypeJSON, Nullable: true},
+	}}
+	comparison, err := schemaevolution.Compare(source, stored, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparison.HasChanges {
+		t.Fatalf("legacy declarations produced changes: %+v", comparison.Changes)
+	}
+}

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -1132,16 +1132,20 @@ func (d *SQLiteDestination) GetTableSchema(ctx context.Context, table string) (*
 }
 
 func mapSQLiteTypeToSchema(colType string) schema.DataType {
-	colType = strings.ToUpper(colType)
+	colType = strings.ToUpper(strings.TrimSpace(colType))
 
 	switch {
-	case colType == "INTEGER" || colType == "INT" || colType == "BIGINT" || colType == "SMALLINT" || colType == "TINYINT":
-		return schema.TypeInt64
-	case colType == "REAL" || colType == "DOUBLE" || colType == "FLOAT":
-		return schema.TypeFloat64
-	case colType == "TEXT" || colType == "VARCHAR" || strings.HasPrefix(colType, "VARCHAR"):
+	case colType == "BOOLEAN" || colType == "BOOL":
+		return schema.TypeBoolean
+	case colType == "INTERVAL":
 		return schema.TypeString
-	case colType == "BLOB":
+	case strings.Contains(colType, "INT"):
+		return schema.TypeInt64
+	case strings.Contains(colType, "REAL") || strings.Contains(colType, "FLOA") || strings.Contains(colType, "DOUB"):
+		return schema.TypeFloat64
+	case strings.Contains(colType, "CHAR") || strings.Contains(colType, "CLOB") || strings.Contains(colType, "TEXT"):
+		return schema.TypeString
+	case strings.Contains(colType, "BLOB"):
 		return schema.TypeBinary
 	case colType == "NUMERIC" || strings.HasPrefix(colType, "DECIMAL"):
 		return schema.TypeDecimal

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1588,7 +1588,10 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	}
 
 	// Compare schemas with overrides. Staging-only CDC columns are not persisted on the destination.
-	opts := &schemaevolution.CompareOptions{Overrides: overrides}
+	opts := &schemaevolution.CompareOptions{Overrides: overrides, PrimaryKeys: sourceSchema.PrimaryKeys}
+	if normalizer, ok := p.dest.(destination.SchemaEvolutionColumnNormalizer); ok {
+		opts.NormalizeColumn = normalizer.NormalizeSchemaEvolutionColumn
+	}
 	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), comparisonDestSchema, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare schemas: %w", err)
@@ -1983,6 +1986,7 @@ func (p *Pipeline) normalizeMultiTableInfo(ctx context.Context, table source.Sou
 	if len(normalized.PrimaryKeys) == 0 && len(normalized.Schema.PrimaryKeys) > 0 {
 		normalized.PrimaryKeys = append([]string(nil), normalized.Schema.PrimaryKeys...)
 	}
+	normalized.Schema.PrimaryKeys = append([]string(nil), normalized.PrimaryKeys...)
 	markPrimaryKeyColumns(normalized.Schema)
 
 	if len(combined) == 0 {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -927,6 +927,17 @@ type mockSchemaEvolutionDestination struct {
 	mockDestination
 }
 
+type normalizingMockSchemaEvolutionDestination struct {
+	*mockSchemaEvolutionDestination
+}
+
+func (m *normalizingMockSchemaEvolutionDestination) NormalizeSchemaEvolutionColumn(col schema.Column) schema.Column {
+	if col.DataType == schema.TypeBoolean {
+		col.DataType = schema.TypeInt64
+	}
+	return col
+}
+
 func (m *mockSchemaEvolutionDestination) ApplySchemaEvolution(_ context.Context, _ string, _ *schemaevolution.SchemaComparison) ([]string, error) {
 	return nil, nil
 }
@@ -1613,6 +1624,42 @@ func TestEvolveSchemaIfNeededBuildsAbstractPlanForSchemaEvolver(t *testing.T) {
 
 	gotColumns := plan.FinalSchema.ColumnNames()
 	assertColumns(t, "columns", gotColumns, []string{"id", "age"})
+}
+
+func TestEvolveSchemaIfNeededDoesNotRelaxPrimaryKeyNullability(t *testing.T) {
+	destSchema := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "ID", DataType: schema.TypeInt64, Nullable: false,
+	}}}
+	sourceSchema := &schema.TableSchema{
+		Columns:     []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: true}},
+		PrimaryKeys: []string{"id"},
+	}
+	p := &Pipeline{
+		config: &config.IngestConfig{DestTable: "events"},
+		dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+			tableSchema: destSchema,
+			scheme:      "schema_evolver_without_dialect",
+		}},
+	}
+
+	plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyMerge)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.False(t, plan.HasChanges())
+}
+
+func TestEvolveSchemaIfNeededUsesDestinationTypeNormalization(t *testing.T) {
+	destSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeInt64}}}
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeBoolean}}}
+	dest := &normalizingMockSchemaEvolutionDestination{mockSchemaEvolutionDestination: &mockSchemaEvolutionDestination{
+		mockDestination: mockDestination{tableSchema: destSchema, scheme: "normalizing"},
+	}}
+	p := &Pipeline{config: &config.IngestConfig{DestTable: "events"}, dest: dest}
+
+	plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyAppend)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.False(t, plan.HasChanges())
 }
 
 func TestNamingConsistency(t *testing.T) {
@@ -2980,6 +3027,27 @@ func TestNormalizeMultiTableInfoComposesNamingAndShortening(t *testing.T) {
 	require.Equal(t, "config_data", transformed.Schema().Field(0).Name)
 	require.Equal(t, finalLong, transformed.Schema().Field(1).Name)
 	require.Equal(t, fmt.Sprintf(`["config_data","%s"]`, finalLong), transformed.Column(2).(*array.String).Value(0))
+}
+
+func TestNormalizeMultiTableInfoPropagatesRenamedPrimaryKeysToSchema(t *testing.T) {
+	p := &Pipeline{
+		config: &config.IngestConfig{SchemaNaming: "snake_case"},
+		dest:   &mockDestination{scheme: "postgres"},
+	}
+	original := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "eventId", DataType: schema.TypeInt64},
+		{Name: "payload", DataType: schema.TypeString},
+	}}
+
+	normalized, _, err := p.normalizeMultiTableInfo(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: original, PrimaryKeys: []string{"eventId"},
+	}, "public.events")
+	require.NoError(t, err)
+	require.Equal(t, []string{"event_id"}, normalized.PrimaryKeys)
+	require.Equal(t, []string{"event_id"}, normalized.Schema.PrimaryKeys)
+	require.True(t, normalized.Schema.Columns[0].IsPrimaryKey)
+	require.Empty(t, original.PrimaryKeys)
+	require.False(t, original.Columns[0].IsPrimaryKey)
 }
 
 func TestNormalizeMultiTableInfoRejectsCDCMetadataCollision(t *testing.T) {

--- a/pkg/schemaevolution/array_compare_test.go
+++ b/pkg/schemaevolution/array_compare_test.go
@@ -1,0 +1,175 @@
+package schemaevolution
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareWidensPrimitiveArrayElements(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "values", DataType: schema.TypeArray, ArrayType: schema.TypeInt64,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "Values", DataType: schema.TypeArray, ArrayType: schema.TypeInt32,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	change := comparison.Changes[0]
+	require.Equal(t, ChangeWidenType, change.Type)
+	require.Equal(t, "Values", change.ColumnName)
+	require.Equal(t, "Values", change.NewColumn.Name)
+	require.Equal(t, schema.TypeArray, change.NewColumn.DataType)
+	require.Equal(t, schema.TypeInt64, change.NewColumn.ArrayType)
+	require.Equal(t, schema.TypeInt64, BuildFinalSchema(dest, comparison).Columns[0].ArrayType)
+}
+
+func TestCompareDoesNotNarrowPrimitiveArrayElements(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "values", DataType: schema.TypeArray, ArrayType: schema.TypeInt32,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "values", DataType: schema.TypeArray, ArrayType: schema.TypeInt64,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.False(t, comparison.HasChanges)
+}
+
+func TestCompareMergesDecimalArrayElementPrecision(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amounts", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 20, Scale: 8,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amounts", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 18, Scale: 2,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, 24, comparison.Changes[0].NewColumn.Precision)
+	require.Equal(t, 8, comparison.Changes[0].NewColumn.Scale)
+
+	source.Columns[0].Precision = 38
+	source.Columns[0].Scale = 38
+	dest.Columns[0].Precision = 38
+	dest.Columns[0].Scale = 0
+	_, err = Compare(source, dest, nil)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+}
+
+func TestCompareWidensStringArrayElementLength(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString, MaxLength: 120,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString, MaxLength: 40,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, 120, comparison.Changes[0].NewColumn.MaxLength)
+}
+
+func TestCompareRejectsUnrepresentableScalarDecimalWidening(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 38,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 0,
+	}}}
+
+	_, err := Compare(source, dest, nil)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+}
+
+func TestComparePreservesDecimalIntegerDigits(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 18, Scale: 2,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 20, Scale: 8,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, 24, comparison.Changes[0].NewColumn.Precision)
+	require.Equal(t, 8, comparison.Changes[0].NewColumn.Scale)
+}
+
+func TestCompareDecimalWideningIncludesIntegerCapacity(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 2,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeInt64,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, schema.TypeDecimal, comparison.Changes[0].NewColumn.DataType)
+	require.Equal(t, 21, comparison.Changes[0].NewColumn.Precision)
+	require.Equal(t, 2, comparison.Changes[0].NewColumn.Scale)
+}
+
+func TestCompareTreatsUnspecifiedDecimalPrecisionAsDecimal38(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 2,
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.Nil(t, comparison)
+}
+
+func TestCompareUsesUnboundedStringForCrossTypeWidening(t *testing.T) {
+	tests := []struct {
+		name   string
+		source schema.Column
+		dest   schema.Column
+	}{
+		{
+			name:   "bounded string and integer",
+			source: schema.Column{Name: "value", DataType: schema.TypeString, MaxLength: 5},
+			dest:   schema.Column{Name: "value", DataType: schema.TypeInt64},
+		},
+		{
+			name:   "decimal and float",
+			source: schema.Column{Name: "value", DataType: schema.TypeDecimal, Precision: 18, Scale: 4},
+			dest:   schema.Column{Name: "value", DataType: schema.TypeFloat64},
+		},
+		{
+			name:   "array decimal and float",
+			source: schema.Column{Name: "value", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 18, Scale: 4},
+			dest:   schema.Column{Name: "value", DataType: schema.TypeArray, ArrayType: schema.TypeFloat64},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comparison, err := Compare(
+				&schema.TableSchema{Columns: []schema.Column{tt.source}},
+				&schema.TableSchema{Columns: []schema.Column{tt.dest}}, nil,
+			)
+			require.NoError(t, err)
+			require.Len(t, comparison.Changes, 1)
+			newColumn := comparison.Changes[0].NewColumn
+			if newColumn.DataType == schema.TypeArray {
+				require.Equal(t, schema.TypeString, newColumn.ArrayType)
+			} else {
+				require.Equal(t, schema.TypeString, newColumn.DataType)
+			}
+			require.Zero(t, newColumn.MaxLength)
+		})
+	}
+}

--- a/pkg/schemaevolution/compare.go
+++ b/pkg/schemaevolution/compare.go
@@ -1,6 +1,7 @@
 package schemaevolution
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -9,7 +10,9 @@ import (
 
 // CompareOptions contains optional parameters for schema comparison.
 type CompareOptions struct {
-	Overrides ColumnOverrides
+	Overrides       ColumnOverrides
+	PrimaryKeys     []string
+	NormalizeColumn func(schema.Column) schema.Column
 }
 
 // Compare compares source and destination schemas and returns the differences.
@@ -23,8 +26,16 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 	}
 
 	var overrides ColumnOverrides
+	normalizeColumn := func(col schema.Column) schema.Column { return col }
+	primaryKeys := make(map[string]struct{})
 	if opts != nil {
 		overrides = opts.Overrides
+		if opts.NormalizeColumn != nil {
+			normalizeColumn = opts.NormalizeColumn
+		}
+		for _, key := range opts.PrimaryKeys {
+			primaryKeys[strings.ToLower(key)] = struct{}{}
+		}
 	}
 
 	destColumnMap := make(map[string]schema.Column)
@@ -39,32 +50,57 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 
 	var changes []SchemaChange
 
-	for _, srcCol := range source.Columns {
-		lowerName := strings.ToLower(srcCol.Name)
-		destCol, exists := destColumnMap[lowerName]
+	for _, sourceColumn := range source.Columns {
+		srcCol := normalizeColumn(sourceColumn)
+		lowerName := strings.ToLower(sourceColumn.Name)
+		destColumn, exists := destColumnMap[lowerName]
+		destCol := normalizeColumn(destColumn)
 
 		// Check for user override first
-		if override, hasOverride := overrides.Get(srcCol.Name); hasOverride {
-			newCol := override.ApplyToColumn(srcCol)
-			newCol.Nullable = true
+		if override, hasOverride := overrides.Get(sourceColumn.Name); hasOverride {
+			newCol := override.ApplyToColumn(sourceColumn)
+			comparisonCol := normalizeColumn(newCol)
+			if exists {
+				newCol.Name = destColumn.Name
+				comparisonCol.Name = destCol.Name
+				_, isPrimaryKey := primaryKeys[lowerName]
+				relaxNullability := sourceColumn.Nullable && !destColumn.Nullable && !isPrimaryKey
+				newCol.Nullable = destColumn.Nullable || relaxNullability
+				if relaxNullability {
+					old := destColumn
+					relaxed := destColumn
+					relaxed.Nullable = true
+					changes = append(changes, SchemaChange{
+						Type: ChangeRelaxNullability, ColumnName: destColumn.Name,
+						OldColumn: &old, NewColumn: relaxed,
+					})
+				}
+			} else {
+				newCol.Nullable = true
+			}
 
 			// If destination exists and matches override, no change needed
-			if exists && destCol.DataType == newCol.DataType {
-				switch newCol.DataType {
+			if exists && destCol.DataType == comparisonCol.DataType {
+				switch comparisonCol.DataType {
 				case schema.TypeDecimal:
-					// For decimal, check integer digits and scale separately
-					destIntDigits := destCol.Precision - destCol.Scale
-					newIntDigits := newCol.Precision - newCol.Scale
-					if destIntDigits >= newIntDigits && destCol.Scale >= newCol.Scale {
+					precision, scale, err := MergeDecimalPrecisionChecked(
+						normalizedDecimal(comparisonCol), normalizedDecimal(destCol),
+					)
+					if err != nil {
+						return nil, fmt.Errorf("column %s: %w", destColumn.Name, err)
+					}
+					if precision == normalizedDecimal(destCol).Precision && scale == destCol.Scale {
 						continue
 					}
+					newCol.Precision = precision
+					newCol.Scale = scale
 				case schema.TypeString:
 					// Only evolve when the override widens the length; never
 					// narrow an existing column (that would truncate data).
-					if !stringNeedsWidening(newCol.MaxLength, destCol.MaxLength) {
+					if !stringNeedsWidening(comparisonCol.MaxLength, destCol.MaxLength) {
 						continue
 					}
-					newCol.MaxLength = WidenedStringLength(newCol.MaxLength, destCol.MaxLength)
+					newCol.MaxLength = WidenedStringLength(comparisonCol.MaxLength, destCol.MaxLength)
 				default:
 					continue
 				}
@@ -77,12 +113,12 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 
 			var oldCol *schema.Column
 			if exists {
-				oldCol = &destCol
+				oldCol = &destColumn
 			}
 
 			changes = append(changes, SchemaChange{
 				Type:       changeType,
-				ColumnName: srcCol.Name,
+				ColumnName: newCol.Name,
 				OldColumn:  oldCol,
 				NewColumn:  newCol,
 			})
@@ -92,39 +128,35 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 		if !exists {
 			changes = append(changes, SchemaChange{
 				Type:       ChangeAddColumn,
-				ColumnName: srcCol.Name,
+				ColumnName: sourceColumn.Name,
 				OldColumn:  nil,
-				NewColumn:  makeNullable(srcCol),
+				NewColumn:  makeNullable(sourceColumn),
 			})
 			continue
 		}
+		_, isPrimaryKey := primaryKeys[lowerName]
+		if sourceColumn.Nullable && !destColumn.Nullable && !isPrimaryKey {
+			old := destColumn
+			newCol := sourceColumn
+			newCol.Name = destColumn.Name
+			changes = append(changes, SchemaChange{
+				Type: ChangeRelaxNullability, ColumnName: destColumn.Name,
+				OldColumn: &old, NewColumn: newCol,
+			})
+		}
 
 		if needsWidening(srcCol, destCol) {
-			widenedType, _ := GetWidenedType(srcCol.DataType, destCol.DataType)
-			newCol := srcCol
-			newCol.DataType = widenedType
-			newCol.Nullable = true
-
-			// For decimal precision/scale widening, keep TypeDecimal but merge precision
-			isDecimalPrecisionWidening := srcCol.DataType == schema.TypeDecimal && destCol.DataType == schema.TypeDecimal
-			if isDecimalPrecisionWidening {
-				newCol.Precision, newCol.Scale = MergeDecimalPrecision(srcCol, destCol)
+			newCol, err := widenedColumn(srcCol, destCol)
+			if err != nil {
+				return nil, fmt.Errorf("column %s: %w", destColumn.Name, err)
 			}
+			newCol.Nullable = destColumn.Nullable || (sourceColumn.Nullable && !isPrimaryKey)
 
-			// For string length widening, keep TypeString but grow the length.
-			isStringLengthWidening := widenedType == schema.TypeString &&
-				destCol.DataType == schema.TypeString &&
-				stringNeedsWidening(srcCol.MaxLength, destCol.MaxLength)
-			if isStringLengthWidening {
-				newCol.MaxLength = WidenedStringLength(srcCol.MaxLength, destCol.MaxLength)
-			}
-
-			// Only add change if type is different OR precision/length needs widening
-			if widenedType != destCol.DataType || isDecimalPrecisionWidening || isStringLengthWidening {
+			if !sameColumnTypeShape(newCol, destCol) {
 				changes = append(changes, SchemaChange{
 					Type:       ChangeWidenType,
-					ColumnName: srcCol.Name,
-					OldColumn:  &destCol,
+					ColumnName: destColumn.Name,
+					OldColumn:  &destColumn,
 					NewColumn:  newCol,
 				})
 			}
@@ -156,6 +188,71 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 	}, nil
 }
 
+func widenedColumn(src, dest schema.Column) (schema.Column, error) {
+	result := src
+	result.Name = dest.Name
+	result.DataType, _ = GetWidenedType(src.DataType, dest.DataType)
+	result.Nullable = src.Nullable || dest.Nullable
+	if result.DataType == schema.TypeArray && src.DataType == schema.TypeArray && dest.DataType == schema.TypeArray {
+		result.ArrayType, _ = GetWidenedType(src.ArrayType, dest.ArrayType)
+		if result.ArrayType == schema.TypeDecimal && (isFloatingType(src.ArrayType) || isFloatingType(dest.ArrayType)) {
+			result.ArrayType = schema.TypeString
+			result.Precision = 0
+			result.Scale = 0
+			result.MaxLength = 0
+			return result, nil
+		}
+		if result.ArrayType == dest.ArrayType {
+			result.Precision = dest.Precision
+			result.Scale = dest.Scale
+			result.MaxLength = dest.MaxLength
+		}
+		if result.ArrayType == schema.TypeDecimal {
+			var err error
+			result.Precision, result.Scale, err = mergeDecimalTypesChecked(
+				arrayElementColumn(src), arrayElementColumn(dest),
+			)
+			if err != nil {
+				return schema.Column{}, err
+			}
+		}
+		if result.ArrayType == schema.TypeString {
+			if src.ArrayType == schema.TypeString && dest.ArrayType == schema.TypeString {
+				result.MaxLength = WidenedStringLength(src.MaxLength, dest.MaxLength)
+			} else {
+				result.MaxLength = 0
+			}
+		}
+		return result, nil
+	}
+	if result.DataType == schema.TypeDecimal && (isFloatingType(src.DataType) || isFloatingType(dest.DataType)) {
+		result.DataType = schema.TypeString
+		result.Precision = 0
+		result.Scale = 0
+		result.MaxLength = 0
+		return result, nil
+	}
+	if result.DataType == schema.TypeDecimal {
+		var err error
+		result.Precision, result.Scale, err = mergeDecimalTypesChecked(src, dest)
+		if err != nil {
+			return schema.Column{}, err
+		}
+	}
+	if result.DataType == schema.TypeString {
+		if src.DataType == schema.TypeString && dest.DataType == schema.TypeString {
+			result.MaxLength = WidenedStringLength(src.MaxLength, dest.MaxLength)
+		} else {
+			result.MaxLength = 0
+		}
+	}
+	return result, nil
+}
+
+func isFloatingType(dataType schema.DataType) bool {
+	return dataType == schema.TypeFloat32 || dataType == schema.TypeFloat64
+}
+
 func makeNullable(col schema.Column) schema.Column {
 	col.Nullable = true
 	return col
@@ -165,11 +262,100 @@ func needsWidening(src, dest schema.Column) bool {
 	if src.DataType == dest.DataType {
 		switch src.DataType {
 		case schema.TypeDecimal:
-			return src.Precision > dest.Precision || src.Scale > dest.Scale
+			return decimalNeedsWidening(src, dest)
 		case schema.TypeString:
 			return stringNeedsWidening(src.MaxLength, dest.MaxLength)
+		case schema.TypeArray:
+			if src.ArrayType != dest.ArrayType {
+				return true
+			}
+			switch src.ArrayType {
+			case schema.TypeDecimal:
+				return decimalNeedsWidening(src, dest)
+			case schema.TypeString:
+				return stringNeedsWidening(src.MaxLength, dest.MaxLength)
+			default:
+				return false
+			}
 		default:
 			return false
+		}
+	}
+	return true
+}
+
+func decimalNeedsWidening(src, dest schema.Column) bool {
+	src = normalizedDecimal(src)
+	dest = normalizedDecimal(dest)
+	return src.Precision-src.Scale > dest.Precision-dest.Scale || src.Scale > dest.Scale
+}
+
+func arrayElementColumn(col schema.Column) schema.Column {
+	return schema.Column{
+		DataType:  col.ArrayType,
+		Precision: col.Precision,
+		Scale:     col.Scale,
+		MaxLength: col.MaxLength,
+	}
+}
+
+func mergeDecimalTypesChecked(src, dest schema.Column) (int, int, error) {
+	srcDecimal, srcOK := decimalRepresentation(src)
+	destDecimal, destOK := decimalRepresentation(dest)
+	if !srcOK || !destOK {
+		if src.DataType == schema.TypeDecimal {
+			return src.Precision, src.Scale, nil
+		}
+		return dest.Precision, dest.Scale, nil
+	}
+	return MergeDecimalPrecisionChecked(srcDecimal, destDecimal)
+}
+
+func decimalRepresentation(col schema.Column) (schema.Column, bool) {
+	if col.DataType == schema.TypeDecimal {
+		return normalizedDecimal(col), true
+	}
+	var digits int
+	switch col.DataType {
+	case schema.TypeInt8:
+		digits = 3
+	case schema.TypeInt16:
+		digits = 5
+	case schema.TypeInt32:
+		digits = 10
+	case schema.TypeInt64:
+		digits = 19
+	default:
+		return schema.Column{}, false
+	}
+	return schema.Column{DataType: schema.TypeDecimal, Precision: digits}, true
+}
+
+func normalizedDecimal(col schema.Column) schema.Column {
+	if col.Precision == 0 {
+		col.Precision = 38
+	}
+	return col
+}
+
+func sameColumnTypeShape(a, b schema.Column) bool {
+	if a.DataType != b.DataType {
+		return false
+	}
+	switch a.DataType {
+	case schema.TypeDecimal:
+		return a.Precision == b.Precision && a.Scale == b.Scale
+	case schema.TypeString:
+		return a.MaxLength == b.MaxLength
+	case schema.TypeArray:
+		if a.ArrayType != b.ArrayType {
+			return false
+		}
+		switch a.ArrayType {
+		case schema.TypeDecimal:
+			return a.Precision == b.Precision && a.Scale == b.Scale
+		case schema.TypeString:
+			return a.MaxLength == b.MaxLength
 		}
 	}
 	return true

--- a/pkg/schemaevolution/compare_test.go
+++ b/pkg/schemaevolution/compare_test.go
@@ -176,6 +176,8 @@ func TestCompare_TypeWidening_IntToFloat(t *testing.T) {
 	change := result.Changes[0]
 	assert.Equal(t, ChangeWidenType, change.Type)
 	assert.Equal(t, schema.TypeFloat64, change.NewColumn.DataType)
+	assert.False(t, change.NewColumn.Nullable)
+	assert.False(t, BuildFinalSchema(dest, result).Columns[0].Nullable)
 }
 
 func TestCompare_TypeWidening_ToString(t *testing.T) {
@@ -424,7 +426,26 @@ func TestCompare_SameTypeDifferentNullability(t *testing.T) {
 
 	result, err := Compare(source, dest, nil)
 	require.NoError(t, err)
-	assert.False(t, result.HasChanges, "nullability difference alone should not trigger widening")
+	require.True(t, result.HasChanges)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, ChangeRelaxNullability, result.Changes[0].Type)
+}
+
+func TestCompare_IgnoresInferredNullabilityForConfiguredPrimaryKeys(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	dest := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: false},
+	}}
+
+	result, err := Compare(source, dest, &CompareOptions{PrimaryKeys: []string{"ID"}})
+	require.NoError(t, err)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, ChangeRelaxNullability, result.Changes[0].Type)
+	assert.Equal(t, "value", result.Changes[0].ColumnName)
 }
 
 func TestMakeNullable(t *testing.T) {
@@ -639,4 +660,75 @@ func TestCompare_IntegerOverride_WidensInt32(t *testing.T) {
 	require.True(t, result.HasChanges)
 	require.Len(t, result.Changes, 1)
 	assert.Equal(t, schema.TypeInt64, result.Changes[0].NewColumn.DataType)
+}
+
+func TestCompare_NormalizesPhysicalTypeAliases(t *testing.T) {
+	normalize := func(col schema.Column) schema.Column {
+		if col.DataType == schema.TypeBoolean {
+			col.DataType = schema.TypeInt64
+		}
+		return col
+	}
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeBoolean}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeInt64}}}
+
+	result, err := Compare(source, dest, &CompareOptions{NormalizeColumn: normalize})
+	require.NoError(t, err)
+	assert.False(t, result.HasChanges)
+	assert.Equal(t, schema.TypeBoolean, source.Columns[0].DataType, "comparison must not mutate source schema")
+}
+
+func TestCompare_NormalizesOverrides(t *testing.T) {
+	normalize := func(col schema.Column) schema.Column {
+		if col.DataType == schema.TypeBoolean {
+			col.DataType = schema.TypeInt64
+		}
+		return col
+	}
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeString}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeInt64}}}
+	overrides, err := ParseColumnOverrides("active:boolean")
+	require.NoError(t, err)
+
+	result, err := Compare(source, dest, &CompareOptions{Overrides: overrides, NormalizeColumn: normalize})
+	require.NoError(t, err)
+	assert.False(t, result.HasChanges)
+}
+
+func TestCompare_NormalizationDoesNotChangeOverrideDDLType(t *testing.T) {
+	normalize := func(col schema.Column) schema.Column {
+		if col.DataType == schema.TypeBoolean {
+			col.DataType = schema.TypeInt64
+		}
+		return col
+	}
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeString}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeBinary}}}
+	overrides, err := ParseColumnOverrides("active:boolean")
+	require.NoError(t, err)
+
+	result, err := Compare(source, dest, &CompareOptions{Overrides: overrides, NormalizeColumn: normalize})
+	require.NoError(t, err)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, ChangeOverrideType, result.Changes[0].Type)
+	assert.Equal(t, schema.TypeBoolean, result.Changes[0].NewColumn.DataType)
+}
+
+func TestCompare_NormalizationDoesNotChangeAddedColumnDDLType(t *testing.T) {
+	normalize := func(col schema.Column) schema.Column {
+		if col.DataType == schema.TypeJSON {
+			col.DataType = schema.TypeString
+			col.MaxLength = 0
+		}
+		return col
+	}
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "payload", DataType: schema.TypeJSON, MaxLength: 64}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+
+	result, err := Compare(source, dest, &CompareOptions{NormalizeColumn: normalize})
+	require.NoError(t, err)
+	require.Len(t, result.Changes, 2)
+	assert.Equal(t, ChangeAddColumn, result.Changes[0].Type)
+	assert.Equal(t, schema.TypeJSON, result.Changes[0].NewColumn.DataType)
+	assert.Equal(t, 64, result.Changes[0].NewColumn.MaxLength)
 }

--- a/pkg/schemaevolution/contract.go
+++ b/pkg/schemaevolution/contract.go
@@ -72,7 +72,7 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 
 	case ContractDiscardRow:
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeRemoveColumn || isInternalAllowedChange(change) {
+			if isDiscardRowAllowedChange(change) {
 				result.Allowed = append(result.Allowed, change)
 			} else {
 				result.Violations = append(result.Violations, ContractViolation{
@@ -85,7 +85,7 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 
 	case ContractDiscardValue:
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeAddColumn || change.Type == ChangeRemoveColumn {
+			if change.Type == ChangeAddColumn || change.Type == ChangeRemoveColumn || change.Type == ChangeRelaxNullability {
 				result.Allowed = append(result.Allowed, change)
 			} else {
 				result.Violations = append(result.Violations, ContractViolation{
@@ -104,6 +104,10 @@ func isInternalAllowedChange(change SchemaChange) bool {
 	return change.Type == ChangeAddColumn && strings.EqualFold(change.ColumnName, naming.IngestrLoadedAtColumn)
 }
 
+func isDiscardRowAllowedChange(change SchemaChange) bool {
+	return change.Type == ChangeRemoveColumn || change.Type == ChangeRelaxNullability || isInternalAllowedChange(change)
+}
+
 func describeChange(change SchemaChange) string {
 	switch change.Type {
 	case ChangeAddColumn:
@@ -120,6 +124,8 @@ func describeChange(change SchemaChange) string {
 		return fmt.Sprintf("type override to %s", change.NewColumn.DataType)
 	case ChangeRemoveColumn:
 		return "column removed from source (future values will be NULL)"
+	case ChangeRelaxNullability:
+		return "column changed from required to optional"
 	default:
 		return "unknown change"
 	}

--- a/pkg/schemaevolution/contract_test.go
+++ b/pkg/schemaevolution/contract_test.go
@@ -149,6 +149,47 @@ func TestApplyContract_DiscardValue(t *testing.T) {
 	assert.Equal(t, "amount", result.Violations[0].ColumnName)
 }
 
+func TestApplyContractDiscardValueAllowsNullabilityRelaxation(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{
+		{Type: ChangeRelaxNullability, ColumnName: "optional"},
+		{Type: ChangeWidenType, ColumnName: "amount"},
+	}}
+	result := ApplyContract(SchemaContract{Mode: ContractDiscardValue}, comparison)
+	require.Len(t, result.Allowed, 1)
+	require.Equal(t, ChangeRelaxNullability, result.Allowed[0].Type)
+	require.Len(t, result.Violations, 1)
+	require.Equal(t, ChangeWidenType, result.Violations[0].ChangeType)
+}
+
+func TestApplyContractDiscardRowAllowsNullabilityRelaxation(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{
+		{Type: ChangeRelaxNullability, ColumnName: "optional"},
+		{Type: ChangeWidenType, ColumnName: "amount"},
+	}}
+	result := ApplyContract(SchemaContract{Mode: ContractDiscardRow}, comparison)
+	require.Len(t, result.Allowed, 1)
+	require.Equal(t, ChangeRelaxNullability, result.Allowed[0].Type)
+	require.Len(t, result.Violations, 1)
+	require.Equal(t, ChangeWidenType, result.Violations[0].ChangeType)
+}
+
+func TestApplyContract_DiscardValueDoesNotViolateConfiguredPrimaryKeyNullability(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "age", DataType: schema.TypeString, Nullable: true},
+	}}
+	dest := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "age", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison, err := Compare(source, dest, &CompareOptions{PrimaryKeys: []string{"id"}})
+	require.NoError(t, err)
+
+	result := ApplyContract(SchemaContract{Mode: ContractDiscardValue}, comparison)
+	require.Len(t, result.Violations, 1)
+	assert.Equal(t, "age", result.Violations[0].ColumnName)
+}
+
 func TestApplyContract_NoChanges(t *testing.T) {
 	comparison := &SchemaComparison{
 		HasChanges: false,

--- a/pkg/schemaevolution/evolve.go
+++ b/pkg/schemaevolution/evolve.go
@@ -26,8 +26,8 @@ type SchemaEvolver interface {
 
 // ApplicableComparison returns the subset of changes that will actually be
 // reflected in the destination schema given whether the destination supports
-// column type changes. Add/remove changes always apply; type changes only
-// apply when supportsTypeChanges is true.
+// column type changes. Add/remove/nullability changes always apply; type
+// changes only apply when supportsTypeChanges is true.
 func ApplicableComparison(comparison *SchemaComparison, supportsTypeChanges bool) *SchemaComparison {
 	if comparison == nil || !comparison.HasChanges {
 		return &SchemaComparison{}

--- a/pkg/schemaevolution/evolve_test.go
+++ b/pkg/schemaevolution/evolve_test.go
@@ -46,6 +46,17 @@ func TestApplicableComparison_KeepsTypeChangesWhenSupported(t *testing.T) {
 	require.Len(t, got.Changes, 3)
 }
 
+func TestApplicableComparisonKeepsNullabilityRelaxationWithoutTypeChanges(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{
+		{Type: ChangeWidenType, ColumnName: "value"},
+		{Type: ChangeRelaxNullability, ColumnName: "optional"},
+	}}
+	got := ApplicableComparison(comparison, false)
+	require.True(t, got.HasChanges)
+	require.Len(t, got.Changes, 1)
+	require.Equal(t, ChangeRelaxNullability, got.Changes[0].Type)
+}
+
 func TestApplicableComparison_NilAndEmpty(t *testing.T) {
 	assert.False(t, ApplicableComparison(nil, true).HasChanges)
 	assert.False(t, ApplicableComparison(&SchemaComparison{}, true).HasChanges)
@@ -78,6 +89,7 @@ func TestBuildFinalSchema_AppliesApplicableChanges(t *testing.T) {
 	assert.Equal(t, schema.TypeInt64, byName["val"].DataType)
 	assert.Contains(t, byName, "added")
 	assert.Contains(t, byName, "gone")
+	assert.True(t, byName["gone"].Nullable, "soft-removed columns must accept NULL in future rows")
 
 	// Without type-change support: val keeps its original type.
 	finalNoType := BuildFinalSchema(dest, ApplicableComparison(widenComparison(), false))

--- a/pkg/schemaevolution/override.go
+++ b/pkg/schemaevolution/override.go
@@ -11,12 +11,13 @@ import (
 
 // ColumnOverride represents a user-specified column type override.
 type ColumnOverride struct {
-	Name      string
-	RenameTo  string
-	DataType  schema.DataType
-	Precision int
-	Scale     int
-	MaxLength int
+	Name           string
+	RenameTo       string
+	DataType       schema.DataType
+	Precision      int
+	Scale          int
+	ScaleSpecified bool
+	MaxLength      int
 }
 
 // ColumnOverrides is a map of column name (lowercase) to its override.
@@ -217,21 +218,28 @@ func parseColumnOverride(pair string) (ColumnOverride, error) {
 
 		switch dataType {
 		case schema.TypeDecimal:
-			// Handle precision/scale for decimal
-			if len(params) >= 1 {
-				p, err := strconv.Atoi(strings.TrimSpace(params[0]))
-				if err != nil {
-					return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': %w", typeSpec, err)
-				}
-				override.Precision = p
+			if len(params) < 1 || len(params) > 2 {
+				return ColumnOverride{}, fmt.Errorf("invalid decimal parameters in '%s': expected decimal(precision) or decimal(precision,scale)", typeSpec)
 			}
-			if len(params) >= 2 {
+			p, err := strconv.Atoi(strings.TrimSpace(params[0]))
+			if err != nil {
+				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': %w", typeSpec, err)
+			}
+			if p < 1 || p > 38 {
+				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': must be between 1 and 38", typeSpec)
+			}
+			override.Precision = p
+			if len(params) == 2 {
 				s, err := strconv.Atoi(strings.TrimSpace(params[1]))
 				if err != nil {
 					return ColumnOverride{}, fmt.Errorf("invalid scale in '%s': %w", typeSpec, err)
 				}
+				if s < 0 || s > p {
+					return ColumnOverride{}, fmt.Errorf("invalid scale in '%s': must be between 0 and precision %d", typeSpec, p)
+				}
 				override.Scale = s
 			}
+			override.ScaleSpecified = true
 		case schema.TypeString:
 			// Sized string types take exactly one length parameter, e.g. varchar(50).
 			if len(params) != 1 {
@@ -315,7 +323,7 @@ func (o ColumnOverride) ApplyToColumn(col schema.Column) schema.Column {
 	if o.Precision > 0 {
 		col.Precision = o.Precision
 	}
-	if o.Scale > 0 {
+	if o.ScaleSpecified || o.Scale > 0 {
 		col.Scale = o.Scale
 	}
 	if o.MaxLength > 0 {

--- a/pkg/schemaevolution/override_test.go
+++ b/pkg/schemaevolution/override_test.go
@@ -75,6 +75,39 @@ func TestParseColumnOverrides_DecimalWithPrecisionOnly(t *testing.T) {
 	assert.Equal(t, schema.TypeDecimal, amount.DataType)
 	assert.Equal(t, 18, amount.Precision)
 	assert.Equal(t, 0, amount.Scale)
+	assert.True(t, amount.ScaleSpecified)
+
+	result := amount.ApplyToColumn(schema.Column{DataType: schema.TypeDecimal, Precision: 10, Scale: 4})
+	assert.Equal(t, 18, result.Precision)
+	assert.Zero(t, result.Scale)
+}
+
+func TestParseColumnOverrides_DecimalValidationAndExplicitZeroScale(t *testing.T) {
+	overrides, err := ParseColumnOverrides("amount:decimal(18,0)")
+	require.NoError(t, err)
+	amount, ok := overrides.Get("amount")
+	require.True(t, ok)
+	require.True(t, amount.ScaleSpecified)
+	require.Zero(t, amount.Scale)
+
+	result := amount.ApplyToColumn(schema.Column{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 4,
+	})
+	require.Equal(t, 18, result.Precision)
+	require.Zero(t, result.Scale)
+
+	for _, spec := range []string{
+		"amount:decimal(0,0)",
+		"amount:decimal(39,2)",
+		"amount:decimal(10,-1)",
+		"amount:decimal(10,11)",
+		"amount:decimal(10,2,1)",
+	} {
+		t.Run(spec, func(t *testing.T) {
+			_, err := ParseColumnOverrides(spec)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestParseColumnOverrides_SizedString(t *testing.T) {
@@ -446,6 +479,46 @@ func TestCompare_OverrideMatchesDestination(t *testing.T) {
 	assert.False(t, result.HasChanges)
 }
 
+func TestCompare_RequiredOverrideDoesNotClaimNullabilityRelaxation(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: false}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: false}}}
+	overrides, err := ParseColumnOverrides("value:bigint")
+	require.NoError(t, err)
+
+	comparison, err := Compare(source, dest, &CompareOptions{Overrides: overrides})
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, ChangeOverrideType, comparison.Changes[0].Type)
+	require.False(t, comparison.Changes[0].NewColumn.Nullable)
+	require.False(t, BuildFinalSchema(dest, comparison).Columns[0].Nullable)
+}
+
+func TestCompare_OverrideStillEmitsNullabilityRelaxation(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		changes  []ChangeType
+	}{
+		{name: "override matches destination", override: "value:integer", changes: []ChangeType{ChangeRelaxNullability}},
+		{name: "override changes type", override: "value:double", changes: []ChangeType{ChangeRelaxNullability, ChangeOverrideType}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: true}}}
+			dest := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt64, Nullable: false}}}
+			overrides, err := ParseColumnOverrides(tt.override)
+			require.NoError(t, err)
+			comparison, err := Compare(source, dest, &CompareOptions{Overrides: overrides})
+			require.NoError(t, err)
+			require.Len(t, comparison.Changes, len(tt.changes))
+			for i, changeType := range tt.changes {
+				require.Equal(t, changeType, comparison.Changes[i].Type)
+			}
+			require.True(t, BuildFinalSchema(dest, comparison).Columns[0].Nullable)
+		})
+	}
+}
+
 func TestCompare_DecimalOverrideWithPrecision(t *testing.T) {
 	source := &schema.TableSchema{
 		Name: "orders",
@@ -474,6 +547,23 @@ func TestCompare_DecimalOverrideWithPrecision(t *testing.T) {
 	assert.Equal(t, schema.TypeDecimal, change.NewColumn.DataType)
 	assert.Equal(t, 18, change.NewColumn.Precision)
 	assert.Equal(t, 4, change.NewColumn.Scale)
+}
+
+func TestCompare_DecimalOverrideDoesNotNarrowExistingValues(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 18, Scale: 2,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 20, Scale: 8,
+	}}}
+	overrides, err := ParseColumnOverrides("amount:decimal(18,2)")
+	require.NoError(t, err)
+
+	comparison, err := Compare(source, dest, &CompareOptions{Overrides: overrides})
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, 24, comparison.Changes[0].NewColumn.Precision)
+	require.Equal(t, 8, comparison.Changes[0].NewColumn.Scale)
 }
 
 func TestColumnOverrides_GetForColumn_SnakeCase(t *testing.T) {

--- a/pkg/schemaevolution/plan.go
+++ b/pkg/schemaevolution/plan.go
@@ -1,6 +1,8 @@
 package schemaevolution
 
 import (
+	"strings"
+
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -34,7 +36,7 @@ func BuildFinalSchema(destSchema *schema.TableSchema, comparison *SchemaComparis
 	}
 
 	result := *destSchema
-	result.Columns = append([]schema.Column{}, destSchema.Columns...)
+	result.Columns = append([]schema.Column(nil), destSchema.Columns...)
 	result.PrimaryKeys = append([]string{}, destSchema.PrimaryKeys...)
 
 	if comparison == nil || !comparison.HasChanges {
@@ -47,17 +49,29 @@ func BuildFinalSchema(destSchema *schema.TableSchema, comparison *SchemaComparis
 			result.Columns = append(result.Columns, change.NewColumn)
 
 		case ChangeWidenType, ChangeOverrideType:
-			for i, col := range result.Columns {
-				if col.Name == change.ColumnName {
-					result.Columns[i] = change.NewColumn
-					break
-				}
-			}
+			applyColumnChange(result.Columns, change.ColumnName, func(col *schema.Column) {
+				name := col.Name
+				*col = change.NewColumn
+				col.Name = name
+			})
 
 		case ChangeRemoveColumn:
-			// Soft remove: dest keeps the column, future rows have NULL there.
+			applyColumnChange(result.Columns, change.ColumnName, func(col *schema.Column) { col.Nullable = true })
+		case ChangeRelaxNullability:
+			applyColumnChange(result.Columns, change.ColumnName, func(col *schema.Column) { col.Nullable = true })
 		}
 	}
 
 	return &result
+}
+
+func applyColumnChange(columns []schema.Column, name string, apply func(*schema.Column)) bool {
+	for i := range columns {
+		if !strings.EqualFold(columns[i].Name, name) {
+			continue
+		}
+		apply(&columns[i])
+		return true
+	}
+	return false
 }

--- a/pkg/schemaevolution/transform.go
+++ b/pkg/schemaevolution/transform.go
@@ -3,6 +3,7 @@ package schemaevolution
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -35,12 +36,11 @@ func NewDiscardValueTransformer(comparison *SchemaComparison, _ *schema.TableSch
 
 	if comparison != nil {
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeAddColumn {
-				// New columns are allowed in discard_value mode, keep their values.
+			if change.Type == ChangeAddColumn || change.Type == ChangeRemoveColumn || change.Type == ChangeRelaxNullability {
 				continue
 			}
 			// Track type incompatibilities to NULL out values.
-			transformer.violations[change.ColumnName] = true
+			transformer.violations[strings.ToLower(change.ColumnName)] = true
 		}
 	}
 
@@ -61,7 +61,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 	// For each column with violations, replace with NULL values
 	for colIdx := 0; colIdx < int(batch.NumCols()); colIdx++ {
 		colName := batchSchema.Field(colIdx).Name
-		if t.violations[colName] {
+		if t.violations[strings.ToLower(colName)] {
 			// Violation: discard value (set to NULL)
 			// If the column exists in destination schema, use destination type (to satisfy strict typing)
 			// Otherwise use source type (e.g. for rejected new columns)
@@ -69,7 +69,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 			targetType := field.Type
 			if t.destSchema != nil {
 				for _, destCol := range t.destSchema.Columns {
-					if destCol.Name == colName {
+					if strings.EqualFold(destCol.Name, colName) {
 						targetType = schema.DataTypeToArrowType(destCol)
 						break
 					}
@@ -104,7 +104,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 	newSchema := arrow.NewSchema(newFields, nil)
 	newBatch := array.NewRecordBatch(newSchema, columns, batch.NumRows())
 	for i, col := range columns {
-		if t.violations[batchSchema.Field(i).Name] {
+		if t.violations[strings.ToLower(batchSchema.Field(i).Name)] {
 			col.Release()
 		}
 	}
@@ -113,28 +113,22 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 
 // DiscardRowTransformer filters out rows with incompatible values.
 type DiscardRowTransformer struct {
-	violations map[string]bool // column name -> has violation
-	schema     *schema.TableSchema
-	destSchema *schema.TableSchema
+	violations map[string]bool
 	allocator  memory.Allocator
 }
 
 // NewDiscardRowTransformer creates a transformer for discard_row mode.
-func NewDiscardRowTransformer(sourceSchema, destSchema *schema.TableSchema, comparison *SchemaComparison) *DiscardRowTransformer {
+func NewDiscardRowTransformer(_, _ *schema.TableSchema, comparison *SchemaComparison) *DiscardRowTransformer {
 	transformer := &DiscardRowTransformer{
 		violations: make(map[string]bool),
-		schema:     sourceSchema,
-		destSchema: destSchema,
 		allocator:  memory.DefaultAllocator,
 	}
-
 	if comparison != nil {
 		for _, change := range comparison.Changes {
-			if isInternalAllowedChange(change) {
+			if isDiscardRowAllowedChange(change) {
 				continue
 			}
-			// Track all violations (both new columns and type mismatches)
-			transformer.violations[change.ColumnName] = true
+			transformer.violations[strings.ToLower(change.ColumnName)] = true
 		}
 	}
 
@@ -147,19 +141,6 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 		return batch, nil
 	}
 
-	// Find column indices that have violations
-	violationCols := make(map[int]string)
-	schema := batch.Schema()
-	for i := 0; i < schema.NumFields(); i++ {
-		colName := schema.Field(i).Name
-		if t.violations[colName] {
-			violationCols[i] = colName
-		}
-	}
-
-	if len(violationCols) == 0 {
-		return batch, nil
-	}
 	allocator := allocatorOrDefault(t.allocator)
 
 	// Create a boolean filter array: true for rows to keep, false for rows to discard
@@ -170,11 +151,8 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 	for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
 		keepRow := true
 
-		// Check if any violation column has a non-NULL value
-		for colIdx := range violationCols {
-			col := batch.Column(colIdx)
-			if col.IsValid(rowIdx) {
-				// This row has data in a violation column, discard it
+		for colIdx, field := range batch.Schema().Fields() {
+			if t.violations[strings.ToLower(field.Name)] && batch.Column(colIdx).IsValid(rowIdx) {
 				keepRow = false
 				break
 			}

--- a/pkg/schemaevolution/transform_test.go
+++ b/pkg/schemaevolution/transform_test.go
@@ -73,6 +73,89 @@ func TestDiscardValueTransformer_AllowsNewColumns(t *testing.T) {
 	assert.Equal(t, "beta", newCol.Value(1))
 }
 
+func TestDiscardValueTransformer_PreservesConfiguredPrimaryKey(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "age", DataType: schema.TypeString, Nullable: true},
+	}}
+	destSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "age", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison, err := Compare(sourceSchema, destSchema, &CompareOptions{PrimaryKeys: []string{"id"}})
+	require.NoError(t, err)
+	transformer := NewDiscardValueTransformer(comparison, sourceSchema, destSchema)
+
+	idBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	idBuilder.AppendValues([]int64{10, 20}, nil)
+	idColumn := idBuilder.NewArray()
+	idBuilder.Release()
+	ageBuilder := array.NewStringBuilder(memory.DefaultAllocator)
+	ageBuilder.AppendValues([]string{"old", "young"}, nil)
+	ageColumn := ageBuilder.NewArray()
+	ageBuilder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "age", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil), []arrow.Array{idColumn, ageColumn}, 2)
+	idColumn.Release()
+	ageColumn.Release()
+	defer batch.Release()
+
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer transformed.Release()
+	ids := transformed.Column(0).(*array.Int64)
+	assert.Equal(t, int64(10), ids.Value(0))
+	assert.Equal(t, int64(20), ids.Value(1))
+	assert.Zero(t, ids.NullN())
+	assert.Equal(t, 2, transformed.Column(1).NullN())
+}
+
+func TestDiscardValueTransformerPreservesConformingValuesForNullabilityChange(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRelaxNullability, ColumnName: "value",
+	}}}
+	transformer := NewDiscardValueTransformer(comparison, nil, nil)
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(7)
+	builder.AppendNull()
+	values := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: true,
+	}}, nil), []arrow.Array{values}, 2)
+	values.Release()
+	defer batch.Release()
+
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	require.Same(t, batch, transformed)
+	require.Equal(t, int64(7), transformed.Column(0).(*array.Int64).Value(0))
+	require.True(t, transformed.Column(0).IsNull(1))
+}
+
+func TestDiscardRowTransformerPreservesRowsAfterTopLevelNullabilityRelaxation(t *testing.T) {
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(7)
+	builder.AppendNull()
+	values := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: true,
+	}}, nil), []arrow.Array{values}, 2)
+	values.Release()
+	defer batch.Release()
+
+	transformer := NewDiscardRowTransformer(nil, nil, &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRelaxNullability, ColumnName: "value",
+	}}})
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	require.Same(t, batch, transformed)
+	require.EqualValues(t, 2, transformed.NumRows())
+}
+
 func TestIngestrColumnFiller_HasColumns(t *testing.T) {
 	t.Run("EmptyColumns", func(t *testing.T) {
 		filler := NewIngestrColumnFiller(nil)

--- a/pkg/schemaevolution/types.go
+++ b/pkg/schemaevolution/types.go
@@ -51,6 +51,7 @@ const (
 	ChangeWidenType
 	ChangeOverrideType // User-specified type override
 	ChangeRemoveColumn // Column exists in destination but not in source
+	ChangeRelaxNullability
 )
 
 // SchemaChange represents a single schema change operation.

--- a/pkg/schemaevolution/widen.go
+++ b/pkg/schemaevolution/widen.go
@@ -1,6 +1,8 @@
 package schemaevolution
 
 import (
+	"fmt"
+
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -110,13 +112,13 @@ func GetWidenedType(src, dest schema.DataType) (schema.DataType, string) {
 }
 
 // MergeDecimalPrecision determines the precision and scale for merged decimal types.
-// Uses the larger precision and scale from both columns.
+// Preserves the maximum integer digits and scale, even when that exceeds the
+// supported precision; callers that need an enforceable schema use the checked variant.
 func MergeDecimalPrecision(src, dest schema.Column) (precision, scale int) {
 	precision = src.Precision
 	if dest.Precision > precision {
 		precision = dest.Precision
 	}
-
 	scale = src.Scale
 	if dest.Scale > scale {
 		scale = dest.Scale
@@ -137,9 +139,17 @@ func MergeDecimalPrecision(src, dest schema.Column) (precision, scale int) {
 	}
 
 	precision = intDigits + scale
+	return precision, scale
+}
+
+func MergeDecimalPrecisionChecked(src, dest schema.Column) (precision, scale int, err error) {
+	precision, scale = MergeDecimalPrecision(src, dest)
 	if precision > 38 {
-		precision = 38
+		return 0, 0, fmt.Errorf(
+			"decimal widening requires precision %d (integer digits %d + scale %d), maximum supported precision is 38",
+			precision, precision-scale, scale,
+		)
 	}
 
-	return precision, scale
+	return precision, scale, nil
 }

--- a/pkg/schemaevolution/widen_test.go
+++ b/pkg/schemaevolution/widen_test.go
@@ -331,12 +331,12 @@ func TestMergeDecimalPrecision_DefaultPrecision(t *testing.T) {
 	assert.Equal(t, 2, scale)
 }
 
-func TestMergeDecimalPrecision_MaxPrecisionCap(t *testing.T) {
+func TestMergeDecimalPrecision_ReportsRequiredPrecisionAboveMaximum(t *testing.T) {
 	src := schema.Column{DataType: schema.TypeDecimal, Precision: 35, Scale: 10}
 	dest := schema.Column{DataType: schema.TypeDecimal, Precision: 30, Scale: 15}
 
 	precision, scale := MergeDecimalPrecision(src, dest)
-	assert.LessOrEqual(t, precision, 38, "precision should not exceed 38")
+	assert.Equal(t, 40, precision, "must not silently discard integer digits")
 	assert.Equal(t, 15, scale, "should use larger scale")
 }
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -162,7 +162,17 @@ func evolveDestinationTable(ctx context.Context, dest destination.Destination, d
 		return fmt.Errorf("failed to parse column overrides: %w", err)
 	}
 
-	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), destSchema, &schemaevolution.CompareOptions{Overrides: overrides})
+	primaryKeys := cfg.PrimaryKeys
+	if len(primaryKeys) == 0 {
+		primaryKeys = sourceSchema.PrimaryKeys
+	}
+	compareOptions := &schemaevolution.CompareOptions{
+		Overrides: overrides, PrimaryKeys: primaryKeys,
+	}
+	if normalizer, ok := dest.(destination.SchemaEvolutionColumnNormalizer); ok {
+		compareOptions.NormalizeColumn = normalizer.NormalizeSchemaEvolutionColumn
+	}
+	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), destSchema, compareOptions)
 	if err != nil {
 		return fmt.Errorf("failed to compare schemas: %w", err)
 	}

--- a/pkg/strategy/stream_schema_change_test.go
+++ b/pkg/strategy/stream_schema_change_test.go
@@ -130,6 +130,64 @@ func TestFlushLoopRefreshHonorsFreezeContract(t *testing.T) {
 	assert.Empty(t, dest.execCalls)
 }
 
+func TestEvolveDestinationTableDoesNotRelaxPrimaryKeyNullability(t *testing.T) {
+	dest := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{"dest_items": {Columns: []schema.Column{{
+		Name: "ID", DataType: schema.TypeInt64, Nullable: false,
+	}}}}}
+	sourceSchema := &schema.TableSchema{
+		Columns:     []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: true}},
+		PrimaryKeys: []string{"id"},
+	}
+
+	err := evolveDestinationTable(context.Background(), dest, "dest_items", sourceSchema, &config.IngestConfig{
+		PrimaryKeys: []string{"id"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, dest.execCalls)
+}
+
+type normalizingFakeDestination struct {
+	*fakeDestination
+}
+
+func (d *normalizingFakeDestination) NormalizeSchemaEvolutionColumn(col schema.Column) schema.Column {
+	if col.DataType == schema.TypeBoolean {
+		col.DataType = schema.TypeInt64
+	}
+	return col
+}
+
+func TestEvolveDestinationTableUsesDestinationTypeNormalization(t *testing.T) {
+	dest := &normalizingFakeDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"dest_items": {Columns: []schema.Column{{
+			Name: "active", DataType: schema.TypeInt64,
+		}}}},
+	}}
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "active", DataType: schema.TypeBoolean}}}
+
+	err := evolveDestinationTable(context.Background(), dest, "dest_items", sourceSchema, &config.IngestConfig{})
+	require.NoError(t, err)
+	require.Empty(t, dest.execCalls)
+}
+
+func TestFlushLoopRefreshDetectsNullabilityOnlyChange(t *testing.T) {
+	loop, dest, st := streamSchemaChangeFixture(&schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt32, Nullable: false},
+		{Name: "status", DataType: schema.TypeString, Nullable: false},
+	}})
+	st.schema.Columns[1].Nullable = false
+	newSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt32, Nullable: false},
+		{Name: "status", DataType: schema.TypeString, Nullable: true},
+	}}
+
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	require.NoError(t, err)
+	require.Len(t, dest.execCalls, 1)
+	require.True(t, st.schema.Columns[1].Nullable)
+	require.Len(t, dest.prepareCalls, 1)
+}
+
 // Staging-only CDC columns are not persisted on the destination; a refresh
 // must not try to ADD them there, and the CDC metadata columns must not be
 // flagged as type changes.

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -709,7 +709,7 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	if !l.cfg.NoLoadTimestamp {
 		newSchema = withLoadTimestampColumn(newSchema)
 	}
-	if st.schema.SameColumnShape(newSchema) {
+	if st.schema.SameColumnShape(newSchema) && sameColumnNullability(st.schema, newSchema) {
 		return nil
 	}
 
@@ -753,6 +753,18 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	}
 	output.Statusf("[STREAM] %s | Schema change applied for %s (dest: %s)\n", time.Now().Format("15:04:05"), ti.Name, st.destTable)
 	return nil
+}
+
+func sameColumnNullability(left, right *schema.TableSchema) bool {
+	if left == nil || right == nil || len(left.Columns) != len(right.Columns) {
+		return left == right
+	}
+	for i := range left.Columns {
+		if left.Columns[i].Nullable != right.Columns[i].Nullable {
+			return false
+		}
+	}
+	return true
 }
 
 func (l *flushLoop) buffer(res source.RecordBatchResult) {

--- a/tests/integration/postgres_nullability_evolution_test.go
+++ b/tests/integration/postgres_nullability_evolution_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresSchemaEvolutionRelaxesNullability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceURI := sharedPostgresURI(t, "source")
+	destURI := sharedPostgresURI(t, "dest")
+	sourceSchema := uniqueSchemaName(t, "src_nullability")
+	destSchema := uniqueSchemaName(t, "dst_nullability")
+	ensurePostgresSchema(t, ctx, sourceURI, sourceSchema)
+	ensurePostgresSchema(t, ctx, destURI, destSchema)
+	t.Cleanup(func() {
+		dropPostgresSchema(t, ctx, sourceURI, sourceSchema)
+		dropPostgresSchema(t, ctx, destURI, destSchema)
+	})
+
+	sourceDB, err := sql.Open("pgx", sourceURI)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sourceDB.Close()) }()
+	_, err = sourceDB.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.events (id BIGINT PRIMARY KEY, payload TEXT NULL);
+		INSERT INTO %s.events VALUES (1, 'ready')`, sourceSchema, sourceSchema))
+	require.NoError(t, err)
+
+	destDB, err := sql.Open("pgx", destURI)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, destDB.Close()) }()
+	_, err = destDB.ExecContext(ctx, fmt.Sprintf(
+		`CREATE TABLE %s.events (id BIGINT PRIMARY KEY, payload TEXT NOT NULL)`, destSchema,
+	))
+	require.NoError(t, err)
+
+	err = pipeline.New(&config.IngestConfig{
+		SourceURI: sourceURI, SourceTable: sourceSchema + ".events",
+		DestURI: destURI, DestTable: destSchema + ".events",
+		IncrementalStrategy: config.StrategyAppend,
+		PrimaryKeys:         []string{"id"}, NoLoadTimestamp: true,
+	}).Run(ctx)
+	require.NoError(t, err)
+
+	var nullable string
+	err = destDB.QueryRowContext(ctx, `
+		SELECT is_nullable FROM information_schema.columns
+		WHERE table_schema = $1 AND table_name = 'events' AND column_name = 'payload'`, destSchema).Scan(&nullable)
+	require.NoError(t, err)
+	require.Equal(t, "YES", nullable)
+}


### PR DESCRIPTION
## Summary

Strengthens top-level schema evolution while keeping nested objects represented as JSON:

- relaxes nullable columns safely, including soft-removal of required columns
- protects primary-key nullability and rejects unsupported migrations before issuing partial DDL
- widens decimals, strings, and primitive array elements without narrowing or precision loss
- preserves destination column casing and applies contract transforms case-insensitively
- detects nullability-only changes during streaming/CDC schema refreshes
- adds Iceberg list-element promotion and required-field relaxation

## Stack

Part 2 of 11. Review and merge bottom-up. The previous layer has been merged, so this PR is now based directly on `main`.

Previous: https://github.com/bruin-data/ingestr/pull/959 (merged) · Next: https://github.com/bruin-data/ingestr/pull/961

## Validation

- `make format`
- `make lint`
- `GOFLAGS=-p=1 make test`
- focused schema evolution, destination, pipeline, and strategy package tests
- real PostgreSQL container: `TestPostgresSchemaEvolutionRelaxesNullability`
- two independent `gpt-5.6-terra` high review passes; final result `CLEAN`
