### PR TITLE
Make Iceberg data columns nullable by default

### DIFF
--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -88,7 +88,7 @@ func (d *Destination) PrepareTable(ctx context.Context, opts destination.Prepare
 	if opts.Schema == nil {
 		return errors.New("iceberg destination requires schema")
 	}
-	tableSchema := tableSchemaWithPrimaryKeys(opts.Schema, opts.PrimaryKeys)
+	tableSchema := prepareTableSchema(opts.Schema, opts.PrimaryKeys)
 
 	ident, err := parseIdentifier(opts.Table)
 	if err != nil {
@@ -507,12 +507,22 @@ func localFilesystemPath(location string) (string, bool) {
 	return parsed.Path, parsed.Path != ""
 }
 
-func tableSchemaWithPrimaryKeys(s *schema.TableSchema, primaryKeys []string) *schema.TableSchema {
-	if len(primaryKeys) == 0 {
-		return s
-	}
+func prepareTableSchema(s *schema.TableSchema, primaryKeys []string) *schema.TableSchema {
 	out := *s
-	out.PrimaryKeys = append([]string(nil), primaryKeys...)
+	out.Columns = append([]schema.Column(nil), s.Columns...)
+	out.PrimaryKeys = append([]string(nil), s.PrimaryKeys...)
+	if len(primaryKeys) > 0 {
+		out.PrimaryKeys = append([]string(nil), primaryKeys...)
+	}
+
+	identifierFields := make(map[string]struct{}, len(out.PrimaryKeys))
+	for _, primaryKey := range out.PrimaryKeys {
+		identifierFields[primaryKey] = struct{}{}
+	}
+	for i := range out.Columns {
+		_, identifier := identifierFields[out.Columns[i].Name]
+		out.Columns[i].Nullable = !identifier
+	}
 	return &out
 }
 

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -500,7 +500,34 @@ func TestDestinationAppendReturnsSourceErrorAfterBatch(t *testing.T) {
 	require.ErrorIs(t, err, writeErr)
 }
 
-func TestDestinationReplaceAddsNewRequiredColumns(t *testing.T) {
+func TestDestinationMakesNonIdentifierColumnsOptional(t *testing.T) {
+	ctx := context.Background()
+	tableName := "lake.analytics.optional_events"
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "event_name", DataType: schema.TypeString, Nullable: false},
+		},
+	}
+
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, "iceberg+hadoop://?warehouse="+url.QueryEscape(t.TempDir())))
+	defer func() { require.NoError(t, dest.Close(ctx)) }()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       tableName,
+		Schema:      tableSchema,
+		PrimaryKeys: []string{"id"},
+	}))
+
+	gotSchema, err := dest.GetTableSchema(ctx, tableName)
+	require.NoError(t, err)
+	require.False(t, icebergColumn(t, gotSchema, "id").Nullable)
+	require.True(t, icebergColumn(t, gotSchema, "event_name").Nullable)
+	require.False(t, tableSchema.Columns[1].Nullable, "PrepareTable must not mutate the caller schema")
+}
+
+func TestDestinationReplaceAddsNewOptionalColumns(t *testing.T) {
 	ctx := context.Background()
 	tableName := "lake.analytics.required_events"
 	initialSchema := &schema.TableSchema{
@@ -537,7 +564,7 @@ func TestDestinationReplaceAddsNewRequiredColumns(t *testing.T) {
 
 	gotSchema, err := dest.GetTableSchema(ctx, tableName)
 	require.NoError(t, err)
-	require.False(t, icebergColumn(t, gotSchema, "event_name").Nullable)
+	require.True(t, icebergColumn(t, gotSchema, "event_name").Nullable)
 }
 
 func TestDestinationReplaceWriteFailureDoesNotMutateExistingMetadata(t *testing.T) {

--- a/tests/integration/iceberg_destination_test.go
+++ b/tests/integration/iceberg_destination_test.go
@@ -186,6 +186,10 @@ func exerciseIcebergDestination(t *testing.T, ctx context.Context, destURI, tabl
 	assert.True(t, summary.fields["name"])
 	assert.True(t, summary.fields["active"])
 	assert.True(t, summary.fields["score"])
+	assert.True(t, summary.requiredFields["id"], "primary key should remain required")
+	assert.False(t, summary.requiredFields["name"], "inferred destination columns should be nullable")
+	assert.False(t, summary.requiredFields["active"], "inferred destination columns should be nullable")
+	assert.False(t, summary.requiredFields["score"], "inferred destination columns should be nullable")
 
 	appendRows := writeIcebergJSONL(
 		t, "append.jsonl",
@@ -197,6 +201,7 @@ func exerciseIcebergDestination(t *testing.T, ctx context.Context, destURI, tabl
 	summary = loadIcebergTableSummary(t, ctx, destURI, tableName)
 	assert.EqualValues(t, 4, summary.rows)
 	assert.True(t, summary.fields["age"], "append should evolve the Iceberg table schema")
+	assert.False(t, summary.requiredFields["age"], "new inferred columns should be nullable")
 
 	replacement := writeIcebergJSONL(
 		t, "replacement.jsonl",
@@ -478,9 +483,10 @@ func startIcebergMinioContainer(t *testing.T, ctx context.Context, networkName s
 }
 
 type icebergTableSummary struct {
-	rows        int64
-	fields      map[string]bool
-	primaryKeys []string
+	rows           int64
+	fields         map[string]bool
+	requiredFields map[string]bool
+	primaryKeys    []string
 }
 
 func loadIcebergTableSummary(t *testing.T, ctx context.Context, destURI, tableName string) icebergTableSummary {
@@ -504,8 +510,10 @@ func loadIcebergTableSummary(t *testing.T, ctx context.Context, destURI, tableNa
 	}
 
 	fields := make(map[string]bool)
+	requiredFields := make(map[string]bool)
 	for _, field := range tbl.Schema().Fields() {
 		fields[field.Name] = true
+		requiredFields[field.Name] = field.Required
 	}
 
 	idNames := make([]string, 0, len(tbl.Schema().IdentifierFieldIDs))
@@ -516,9 +524,10 @@ func loadIcebergTableSummary(t *testing.T, ctx context.Context, destURI, tableNa
 	}
 
 	return icebergTableSummary{
-		rows:        rows,
-		fields:      fields,
-		primaryKeys: idNames,
+		rows:           rows,
+		fields:         fields,
+		requiredFields: requiredFields,
+		primaryKeys:    idNames,
 	}
 }
 


### PR DESCRIPTION
## What this fixes

Iceberg tables previously preserved source or inferred requiredness for ordinary data columns. A schema inferred from rows that happened to contain no nulls could therefore create required Iceberg fields, and a later valid null would fail ingestion.

## Scope and behavior

- This change is confined to the Iceberg destination.
- Every non-identifier field is made optional at the Iceberg PrepareTable boundary.
- Primary-key fields remain required because Iceberg identifier fields require that invariant.
- The caller-owned source schema is copied and is never mutated.
- New table creation and replace flows persist optional non-identifier fields.
- Append schema evolution adds new fields as optional.
- Existing Iceberg metadata is not proactively rewritten merely by preparing an ordinary append, keeping this change deliberately conservative.
- Shared pipeline and strategy behavior is unchanged.
- Every non-Iceberg destination is unchanged.

Practical example: inference sees rows where event_name is always present and reports it as required. Iceberg now creates event_name as optional, so a later record with event_name = null is accepted. An id primary key remains required.

## Validation

- make format
- make lint
- make test
- Iceberg unit tests for optional non-identifier fields, required identifier fields, caller-schema immutability, and replace behavior.
- Real Iceberg integration coverage across SQLite SQL catalog + MinIO, PostgreSQL SQL catalog + MinIO, REST catalog + local warehouse, and REST catalog + MinIO.
- The integration matrix covers replace, append with schema evolution, replace again, and merge while asserting requiredness in Iceberg metadata.
- Independent Codex gpt-5.6-terra high-reasoning review completed with no actionable findings.

Stack: based directly on main now that #960 is merged. #962 remains the next PR.