### PR TITLE
Iceberg stack 4/11: durable ingestion commit contracts

### DIFF
--- a/pkg/destination/cdc_truncate.go
+++ b/pkg/destination/cdc_truncate.go
@@ -200,6 +200,9 @@ func applyCDCInputTruncate(ctx context.Context, dest Destination, opts WriteOpti
 	if opts.StagingTable {
 		return ApplyTruncate(ctx, dest, opts.Table)
 	}
+	if opts.CDCExpectedIncarnation != "" {
+		return ApplyCDCTruncateIfIncarnation(ctx, dest, opts.Table, opts.CDCExpectedIncarnation)
+	}
 	return ApplyCDCTruncate(ctx, dest, opts.Table)
 }
 
@@ -222,4 +225,18 @@ func ApplyCDCTruncate(ctx context.Context, dest Destination, table string) error
 		return nil
 	}
 	return ApplyTruncate(ctx, dest, table)
+}
+
+func ApplyCDCTruncateIfIncarnation(ctx context.Context, dest Destination, table, expectedIncarnation string) error {
+	if expectedIncarnation == "" {
+		return fmt.Errorf("cannot conditionally truncate %s without a bound destination incarnation", table)
+	}
+	truncater, ok := dest.(CDCConditionalTruncater)
+	if !ok {
+		return fmt.Errorf("destination scheme %q cannot conditionally truncate managed CDC targets", dest.GetScheme())
+	}
+	if err := truncater.TruncateCDCTableIfIncarnation(ctx, table, expectedIncarnation); err != nil {
+		return fmt.Errorf("failed to conditionally truncate %s: %w", table, err)
+	}
+	return nil
 }

--- a/pkg/destination/cdc_truncate_test.go
+++ b/pkg/destination/cdc_truncate_test.go
@@ -3,6 +3,7 @@ package destination
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,26 @@ import (
 type boundaryWriteDestination struct {
 	Destination
 	write func(context.Context, <-chan source.RecordBatchResult, WriteOptions) error
+}
+
+type conditionalBoundaryDestination struct {
+	*boundaryWriteDestination
+	currentIncarnation string
+	unconditionalCalls atomic.Int64
+	conditionalCalls   atomic.Int64
+}
+
+func (d *conditionalBoundaryDestination) TruncateCDCTable(context.Context, string) error {
+	d.unconditionalCalls.Add(1)
+	return nil
+}
+
+func (d *conditionalBoundaryDestination) TruncateCDCTableIfIncarnation(_ context.Context, _, expected string) error {
+	d.conditionalCalls.Add(1)
+	if expected != d.currentIncarnation {
+		return errors.New("target incarnation changed")
+	}
+	return nil
 }
 
 func (d *boundaryWriteDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error {
@@ -156,6 +177,34 @@ func TestWriteWithTruncateBoundariesReturnsWhenCanceledProducerNeverCloses(t *te
 	}
 	if got := releases.Load(); got != 1 {
 		t.Fatalf("batch release count = %d, want 1", got)
+	}
+}
+
+func TestWriteWithTruncateBoundariesRefusesRecreatedManagedTarget(t *testing.T) {
+	dest := &conditionalBoundaryDestination{
+		boundaryWriteDestination: &boundaryWriteDestination{write: func(_ context.Context, records <-chan source.RecordBatchResult, _ WriteOptions) error {
+			for result := range records {
+				releaseCDCResult(result)
+			}
+			return nil
+		}},
+		currentIncarnation: "replacement-uuid",
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Truncate: true, CDCWALTruncate: true}
+	close(records)
+
+	_, err := WriteWithTruncateBoundaries(context.Background(), dest, records, WriteOptions{
+		Table: "items", CDCExpectedIncarnation: "bound-original-uuid",
+	})
+	if err == nil || !strings.Contains(err.Error(), "target incarnation changed") {
+		t.Fatalf("WriteWithTruncateBoundaries() error = %v, want incarnation change", err)
+	}
+	if got := dest.unconditionalCalls.Load(); got != 0 {
+		t.Fatalf("unconditional truncate calls = %d, want 0", got)
+	}
+	if got := dest.conditionalCalls.Load(); got != 1 {
+		t.Fatalf("conditional truncate calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -16,14 +16,17 @@ import (
 const ManagedStagingTTL = 24 * time.Hour
 
 type PrepareOptions struct {
-	Table        string
-	Schema       *schema.TableSchema
-	DropFirst    bool
-	PrimaryKeys  []string
-	PartitionBy  string   // Column to partition by (BigQuery)
-	ClusterBy    []string // Columns to cluster by (BigQuery)
-	CDCMode      bool     // If true, make non-PK columns nullable for staging tables (CDC delete handling)
-	ExpiresAfter time.Duration
+	Table                  string
+	Schema                 *schema.TableSchema
+	DropFirst              bool
+	PrimaryKeys            []string
+	PartitionBy            string   // Column to partition by (BigQuery)
+	ClusterBy              []string // Columns to cluster by (BigQuery)
+	CDCMode                bool     // If true, make non-PK columns nullable for staging tables (CDC delete handling)
+	ExpiresAfter           time.Duration
+	PreserveExistingLayout bool // Leave an existing table's properties, partition spec, and sort order unchanged.
+	TableProperties        map[string]string
+	OwnershipToken         string
 }
 
 type WriteOptions struct {
@@ -36,6 +39,26 @@ type WriteOptions struct {
 	StagingBucket    string
 	LoaderFileSize   int
 	LoaderFileFormat string
+	// CommitToken identifies the exact payload in this write. Destinations that
+	// support durable token commits use it to make exact replays idempotent.
+	CommitToken source.DurableID
+	// CDCResumeLSN is the source position made durable by this write. It must
+	// become visible atomically with the data commit.
+	CDCResumeLSN string
+	// SkipCDCResume prevents destinations from inferring a resume cursor from
+	// CDC columns. It is used for durable snapshot chunks that are individually
+	// idempotent but cannot safely advance the source checkpoint yet.
+	SkipCDCResume bool
+	// CDCExpectedIncarnation fences a managed CDC write to the physical target
+	// that was bound before the source read began.
+	CDCExpectedIncarnation string
+	// DeduplicatePrimaryKeys requests one output row per configured primary
+	// key. IncrementalKey selects the greatest value; arrival order breaks ties.
+	DeduplicatePrimaryKeys bool
+	IncrementalKey         string
+	// AtomicSnapshotAttemptID identifies the logical snapshot attempt. It must
+	// remain stable across retries of that attempt.
+	AtomicSnapshotAttemptID string
 
 	// PreStaged holds load files written during extract by a PreStager
 	// destination. When set, the destination loads these files instead of
@@ -58,6 +81,13 @@ type MergeOptions struct {
 	IncrementalKey       string
 	IncrementalPredicate string
 	Schema               *schema.TableSchema
+	CommitToken          source.DurableID
+	CDCResumeLSN         string
+	SkipCDCResume        bool
+	// CDCExpectedIncarnation fences a managed CDC merge to the physical target
+	// that was bound before the source read began.
+	CDCExpectedIncarnation string
+	Parallelism            int
 }
 
 // DeleteInsertOptions contains parameters for delete+insert operations.
@@ -73,11 +103,13 @@ type DeleteInsertOptions struct {
 }
 
 type SwapOptions struct {
-	StagingTable   string
-	TargetTable    string
-	PrimaryKeys    []string
-	IncrementalKey string
-	Schema         *schema.TableSchema
+	StagingTable                  string
+	TargetTable                   string
+	PrimaryKeys                   []string
+	IncrementalKey                string
+	Schema                        *schema.TableSchema
+	CDCExpectedIncarnation        string
+	CDCExpectedStagingIncarnation string
 }
 
 // SCD2Options contains parameters for SCD2 (Slowly Changing Dimensions Type 2) operations.
@@ -139,9 +171,13 @@ type SchemaEvolutionColumnNormalizer interface {
 
 // TableWriteConfig contains per-table write configuration for multi-table writes.
 type TableWriteConfig struct {
-	DestTable   string
-	Schema      *schema.TableSchema
-	PrimaryKeys []string
+	DestTable              string
+	Schema                 *schema.TableSchema
+	PrimaryKeys            []string
+	DeduplicatePrimaryKeys bool
+	IncrementalKey         string
+	SkipCDCResume          bool
+	CDCExpectedIncarnation string
 }
 
 // MultiTableWriteOptions configures multi-table write behavior.
@@ -155,13 +191,17 @@ type MultiTableWriteOptions struct {
 	// CancelSource stops the producer when a per-table writer fails. The writer
 	// drains records after invoking it so producer-owned resources can unwind.
 	CancelSource context.CancelFunc
+	// TableWriter overrides the destination's per-table write path. Its boolean
+	// result reports whether it applied at least one source truncate boundary.
+	TableWriter func(context.Context, string, <-chan source.RecordBatchResult, WriteOptions) (bool, error)
 }
 
 // CDCResumeProvider is an optional interface that destinations can implement
 // to support CDC resume functionality. If implemented, the pipeline will query
-// the destination for the max CDC LSN to resume from.
+// the destination for its latest durable CDC position.
 type CDCResumeProvider interface {
-	// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table, or empty string if none found.
+	// GetMaxCDCLSN returns the latest durable CDC cursor, or an empty string if
+	// no CDC data or checkpoint has committed.
 	GetMaxCDCLSN(ctx context.Context, table string) (string, error)
 }
 
@@ -262,6 +302,13 @@ type CDCConditionalTruncater interface {
 	TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error
 }
 
+// CDCConditionalSwapCapable advertises that SwapTable enforces both expected
+// target and staging incarnations in the same atomic operation that replaces
+// the target.
+type CDCConditionalSwapCapable interface {
+	SupportsCDCConditionalSwap() bool
+}
+
 // CDCTargetIncarnationInitializer establishes destination-specific physical
 // identity metadata after a target claim succeeds. It must not be called while
 // validating an unclaimed target.
@@ -308,6 +355,75 @@ type CDCStatePruneBatchSizer interface {
 	CDCStatePruneBatchSize() int
 }
 
+// DurableCommitTokenWriter is an optional interface for destinations that can
+// durably record a source flush token without changing table rows. Streaming
+// uses it when a source position advances during an otherwise empty flush.
+type DurableCommitTokenWriter interface {
+	CommitWriteToken(ctx context.Context, table string, commitToken source.DurableID, cdcResumeLSN string) error
+}
+
+// IdempotentCommitTokenWriter is implemented by destinations whose row-write
+// path atomically records WriteOptions.CommitToken and skips the rows when the
+// same token is retried. Keyless CDC streaming requires this because it has no
+// row identity with which to deduplicate a replayed transaction.
+type IdempotentCommitTokenWriter interface {
+	SupportsIdempotentCommitTokenWrites() bool
+}
+
+// AtomicSnapshotOptions describes a streamed source snapshot whose pages must
+// remain hidden until its final durable source position is available.
+type AtomicSnapshotOptions struct {
+	Table         string
+	Schema        *schema.TableSchema
+	TargetSchema  *schema.TableSchema
+	PrimaryKeys   []string
+	PartitionBy   string
+	ClusterBy     []string
+	Parallelism   int
+	CommitToken   source.DurableID
+	CDCResumeLSN  string
+	SkipCDCResume bool
+	// CDCExpectedIncarnation fences publication to the physical target that was
+	// bound before the source snapshot began.
+	CDCExpectedIncarnation string
+	// AttemptID must be non-empty and stable across every retry of one logical
+	// snapshot. A new logical snapshot must use a new value.
+	AttemptID string
+}
+
+// AtomicSnapshotPublisher is implemented by destinations that can durably
+// stage snapshot pages and publish the completed snapshot in one table commit.
+// It does not provide atomic publication across multiple destination tables.
+// Streaming falls back to its historical truncate-and-page behavior when this
+// interface is not implemented. Begin, write, and publish must be idempotent for
+// one AttemptID. Once publication becomes durable, retrying publish for that
+// AttemptID must report success without duplicating rows or replacing a newer
+// attempt, including when the original success response was lost.
+type AtomicSnapshotPublisher interface {
+	BeginAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+	EvolveAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+	WriteAtomicSnapshot(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
+	PublishAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+}
+
+// AtomicSnapshotAborter reclaims an owned snapshot stage only when the caller
+// knows publication was never attempted. It is separate from
+// AtomicSnapshotPublisher so existing publishers remain compatible.
+type AtomicSnapshotAborter interface {
+	AbortAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+}
+
+type OwnedTableDropper interface {
+	DropTableIfOwned(ctx context.Context, table, ownershipToken string) error
+}
+
+// ConnectionChecker is an optional end-to-end connection check. Unlike
+// Connect, it verifies that the destination can create, write, read, and clean
+// up data using the configured credentials and storage.
+type ConnectionChecker interface {
+	CheckConnection(ctx context.Context) error
+}
+
 // CDCMergeAware is an optional interface that destinations can implement
 // to indicate they handle CDC deletes during merge operations.
 type CDCMergeAware interface {
@@ -318,6 +434,13 @@ type CDCMergeAware interface {
 // write atomically visible after the write phase completes.
 type AtomicCommitWriter interface {
 	SupportsAtomicCommitWrites() bool
+}
+
+// DirectReplaceDeduplicator is implemented by destinations that can collapse
+// duplicate primary keys as part of a direct replace write. Destinations must
+// not opt in unless the deduplication and data replacement commit atomically.
+type DirectReplaceDeduplicator interface {
+	SupportsDirectReplaceDeduplication() bool
 }
 
 // MultiTableNamer is an optional interface for destinations that need full
@@ -363,6 +486,19 @@ type CDCTruncateCapable interface {
 	TruncateCDCTable(ctx context.Context, table string) error
 }
 
+// AtomicTruncateInsertWriter replaces all table rows in one destination
+// commit. Strategies prefer it over a separate truncate followed by writes so
+// readers never observe an empty or partially reloaded target.
+type AtomicTruncateInsertWriter interface {
+	TruncateInsertRecords(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
+}
+
+// AtomicTruncateInsertSchemaEvolver marks an atomic truncate+insert writer that
+// commits supported schema evolution and the replacement rows together.
+type AtomicTruncateInsertSchemaEvolver interface {
+	EvolvesTruncateInsertSchemaAtomically() bool
+}
+
 // ConcurrentFlusher is an optional interface for destinations whose
 // write+merge cycles for *different* tables can safely run concurrently
 // (connection-pool backed databases, where each cycle uses its own
@@ -371,6 +507,12 @@ type CDCTruncateCapable interface {
 // it — or returning a value < 2 — are flushed one table at a time.
 type ConcurrentFlusher interface {
 	MaxConcurrentFlushes() int
+}
+
+// DirectMergeWriter atomically merges record batches into a target without a
+// remote staging-table write/read round trip.
+type DirectMergeWriter interface {
+	MergeRecords(ctx context.Context, records <-chan source.RecordBatchResult, writeOpts WriteOptions, mergeOpts MergeOptions) error
 }
 
 // ReplaceStagingPlacement declares the default schema placement for replace

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -120,6 +120,7 @@ type ReadOptions struct {
 	CDCSlotSuffix                   string              // Optional: suffix for auto-generated replication slot names (dest-aware)
 	CDCLegacySlotSuffix             string              // Optional: prior auto-slot suffix used only for upgrade resume
 	CDCSnapshotReplace              bool                // Consumer can apply a full-snapshot replacement boundary
+	CDCStableDataBatches            bool                // Consumer requires source-stable CDC data-write identities
 	FullRefresh                     bool
 	Columns                         string // Optional: column definitions for schema-less sources (e.g., "id:bigint,name:text")
 	Streaming                       bool   // Continuous mode: never exit on caught-up/idle; attach cumulative CommitTokens
@@ -137,6 +138,10 @@ func RecordBatchBufferSize(opts ReadOptions, defaultSize int) int {
 	return defaultSize
 }
 
+// DurableID is an exact, replay-stable payload or checkpoint identity. The
+// empty value means that the result has no durable identity.
+type DurableID string
+
 type RecordBatchResult struct {
 	Batch     arrow.RecordBatch
 	Err       error
@@ -151,6 +156,31 @@ type RecordBatchResult struct {
 	// to and including the batch that carried it. Nil means no feedback needed.
 	CommitToken any
 
+	// DurableCommitID identifies the exact data payload carried by this result.
+	// It must be stable when that payload is replayed across processes and
+	// reconnects. Cumulative watermarks and connection-local acknowledgement
+	// handles must leave it empty.
+	DurableCommitID DurableID
+
+	// DurableCommitPosition is the resumable source position made durable by
+	// DurableCommitID. It is separate because a payload identity may include a
+	// kind/table prefix that is not a valid source cursor.
+	DurableCommitPosition string
+
+	// DurableCheckpointID and DurableCheckpointPosition identify a global
+	// source low-watermark that is safe to persist for tables without rows in
+	// the current flush. They may differ from this batch's payload identity.
+	// DurableCheckpointTable limits the checkpoint to one source table; an
+	// empty value means the checkpoint is safe for every table in the stream.
+	DurableCheckpointID       DurableID
+	DurableCheckpointPosition string
+	DurableCheckpointTable    string
+
+	// SnapshotReset marks the start of a fresh snapshot attempt for TableName.
+	// Consumers must empty the destination table before accepting subsequent
+	// snapshot rows so an interrupted older attempt cannot contaminate it.
+	SnapshotReset bool
+
 	// TableInfo announces a table that appeared after the read started (e.g. a
 	// table created on the source mid-stream). Consumers that prepared their
 	// per-table state upfront use it to provision the destination before any
@@ -164,18 +194,22 @@ type RecordBatchResult struct {
 }
 
 type CDCSnapshotInvalidation struct {
-	TableName   string
-	Incarnation string
+	TableName         string
+	Incarnation       string
+	SchemaFingerprint string
 }
 
 // CDCStateCommitToken carries destination-managed CDC state alongside the
 // source's native acknowledgement token. Position is the latest globally safe
-// source position. SnapshotPositions marks source tables whose full snapshot is
-// included in all preceding results; the matching incarnation and schema maps
-// bind those snapshots to the exact source table shape.
+// source position. DataBatchID is an optional source-stable identity for the
+// exact data batch carried by the result. SnapshotPositions marks source tables
+// whose full snapshot is included in all preceding results; the matching
+// incarnation and schema maps bind those snapshots to the exact source table
+// shape.
 type CDCStateCommitToken struct {
 	SourceCommitToken    any
 	Position             string
+	DataBatchID          DurableID
 	SnapshotPositions    map[string]string
 	SnapshotIncarnations map[string]string
 	SnapshotSchemas      map[string]string
@@ -289,6 +323,12 @@ type SourceTable interface {
 
 type PrimaryKeyUniquenessProvider interface {
 	PrimaryKeysUnique() bool
+}
+
+// SnapshotResetEmitter identifies sources whose record stream can begin a
+// fresh snapshot with SnapshotReset control records.
+type SnapshotResetEmitter interface {
+	EmitsSnapshotResets() bool
 }
 
 // PartitionedTable is an optional interface that a SourceTable can implement


### PR DESCRIPTION
## Summary

Defines the durability and atomic-write contracts needed by the following Iceberg strategy/runtime layers.

It also adds an incarnation-fenced CDC truncate helper. When a managed CDC caller supplies the physical target incarnation, truncation fails closed if the table was dropped and recreated before the operation.

## Before and after

Before this layer:

- record batches could not distinguish an exact replay-stable payload identity from a resumable checkpoint or a connection-local acknowledgement handle;
- strategies and destinations had no shared contracts for idempotent commits, atomic snapshot publication, atomic truncate+insert with schema evolution, direct merge, or owned cleanup;
- truncate-boundary handling had no generic way to require the originally bound physical table.

After this layer:

- exact payload identities and resumable checkpoints have separate, strongly typed fields and explicit semantics;
- destinations can opt into the new capabilities without changing existing destination behavior;
- managed CDC truncate callers can require a raw target incarnation and receive an error instead of truncating a replacement table.

Atomic snapshot attempts have an explicit retry contract: the attempt ID stays stable across retries, and begin/write/publish must be idempotent for that ID, including when publication committed but its success response was lost.

Kafka, NATS, and Redis cumulative watermarks intentionally remain connection-local acknowledgement tokens. They are not exposed as exact durable payload IDs because retry batch boundaries can change; their existing `msg_id` primary-key merge behavior remains the replay-safety mechanism.

## Stack boundary

This PR intentionally introduces the contracts only. [#963](https://github.com/bruin-data/ingestr/pull/963) consumes them in the strategy layer: it propagates raw target incarnations through streaming and merge paths, carries exact durable IDs into data and token-only commits, and adds crash/retry coverage. The later Iceberg runtime layer implements the destination-side capabilities.

Previous: [#961](https://github.com/bruin-data/ingestr/pull/961) (merged) · Next: [#963](https://github.com/bruin-data/ingestr/pull/963)

## Validation

- `make format`
- `make lint`
- `make test`
- `go test -tags integration ./pkg/destination/postgres -run '^TestLateCDCTargetAtomicCreateAndConditionalTruncate$' -count=1 -v`
