### PR TITLE
Iceberg stack 5/11: schema-safe and retry-safe strategies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-python:
 
 test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -p 64 -parallel 64 -timeout 20m ./tests/integration/...
+	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -p 64 -parallel 64 -timeout 30m ./tests/integration/...
 
 # High-volume PostgreSQL CDC accuracy and schema-churn test (~6 minutes with
 # the default profile). Covers late tables, add/drop/rename/type DDL, JSONB,

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -2979,12 +2979,13 @@ COMMIT TRANSACTION;`, quotedClaimTable, quotedClaimTable, quotedClaimTable)
 }
 
 func (d *BigQueryDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
-	project, dataset, tableName, err := d.parseTable(table)
+	project, dataset, tableName, _, err := d.resolveTable(table)
 	if err != nil {
 		return "", false, err
 	}
-	if dataset == "" {
-		dataset = d.datasetID
+	project, dataset, tableName, _, err = d.resolvePhysicalCDCTarget(ctx, project, dataset, tableName)
+	if err != nil {
+		return "", false, err
 	}
 	metadata, err := d.client.DatasetInProject(project, dataset).Table(tableName).Metadata(ctx)
 	if err != nil {
@@ -3003,29 +3004,45 @@ func bigQueryTableIncarnation(project, dataset, table string, creationTime time.
 	return destination.CDCTargetKey(project, dataset, table, strconv.FormatInt(creationTime.UnixNano(), 10))
 }
 
-func (d *BigQueryDestination) canonicalCDCTarget(ctx context.Context, project, dataset, table string) (string, error) {
+func (d *BigQueryDestination) resolveDatasetCase(ctx context.Context, project, dataset string) (bigQueryDatasetCase, error) {
 	key := project + "." + dataset
 	d.datasetCaseMu.Lock()
 	datasetCase, cached := d.datasetCase[key]
 	d.datasetCaseMu.Unlock()
-	if !cached {
-		metadata, err := d.client.DatasetInProject(project, dataset).Metadata(ctx)
-		provisional := false
-		if err != nil {
-			if !isNotFoundError(err) {
-				return "", fmt.Errorf("failed to read BigQuery dataset metadata for CDC target %s: %w", key, err)
-			}
-			// A first load may resolve its connector identity before PrepareTable
-			// creates the dataset. New datasets use BigQuery's case-sensitive default.
-			metadata = &bigquery.DatasetMetadata{}
-			provisional = true
+	if cached {
+		return datasetCase, nil
+	}
+	metadata, err := d.client.DatasetInProject(project, dataset).Metadata(ctx)
+	provisional := false
+	if err != nil {
+		if !isNotFoundError(err) {
+			return bigQueryDatasetCase{}, fmt.Errorf("failed to read BigQuery dataset metadata for CDC target %s: %w", key, err)
 		}
-		datasetCase = bigQueryDatasetCase{caseInsensitive: metadata.IsCaseInsensitive, provisional: provisional}
-		d.cacheDatasetCase(key, datasetCase.caseInsensitive, datasetCase.provisional)
+		// A first load may resolve its connector identity before PrepareTable
+		// creates the dataset. New datasets use BigQuery's case-sensitive default.
+		metadata = &bigquery.DatasetMetadata{}
+		provisional = true
+	}
+	datasetCase = bigQueryDatasetCase{caseInsensitive: metadata.IsCaseInsensitive, provisional: provisional}
+	d.cacheDatasetCase(key, datasetCase.caseInsensitive, datasetCase.provisional)
+	return datasetCase, nil
+}
+
+func (d *BigQueryDestination) resolvePhysicalCDCTarget(ctx context.Context, project, dataset, table string) (string, string, string, bool, error) {
+	datasetCase, err := d.resolveDatasetCase(ctx, project, dataset)
+	if err != nil {
+		return "", "", "", false, err
 	}
 	if datasetCase.caseInsensitive {
-		dataset = strings.ToLower(dataset)
 		table = strings.ToLower(table)
+	}
+	return project, dataset, table, datasetCase.caseInsensitive, nil
+}
+
+func (d *BigQueryDestination) canonicalCDCTarget(ctx context.Context, project, dataset, table string) (string, error) {
+	project, dataset, table, _, err := d.resolvePhysicalCDCTarget(ctx, project, dataset, table)
+	if err != nil {
+		return "", err
 	}
 	return destination.CDCTargetKey(project, dataset, table), nil
 }

--- a/pkg/destination/bigquery/bigquery_test.go
+++ b/pkg/destination/bigquery/bigquery_test.go
@@ -239,7 +239,7 @@ func TestCanonicalCDCTargetHonorsDatasetCaseSensitivity(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		metadataCalls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		caseInsensitive := strings.Contains(r.URL.Path, "/datasets/insensitive")
+		caseInsensitive := strings.Contains(strings.ToLower(r.URL.Path), "/datasets/insensitive")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"datasetReference":  map[string]string{"projectId": "test-project", "datasetId": "dataset"},
 			"isCaseInsensitive": caseInsensitive,
@@ -253,15 +253,15 @@ func TestCanonicalCDCTargetHonorsDatasetCaseSensitivity(t *testing.T) {
 	defer func() { _ = client.Close() }()
 	dest := &BigQueryDestination{client: client}
 
-	got, err := dest.canonicalCDCTarget(t.Context(), "test-project", "insensitive", "Orders")
-	if err != nil || got != destination.CDCTargetKey("test-project", "insensitive", "orders") {
+	got, err := dest.canonicalCDCTarget(t.Context(), "test-project", "Insensitive", "Orders")
+	if err != nil || got != destination.CDCTargetKey("test-project", "Insensitive", "orders") {
 		t.Fatalf("case-insensitive target = %q, %v", got, err)
 	}
 	got, err = dest.canonicalCDCTarget(t.Context(), "test-project", "sensitive", "Orders")
 	if err != nil || got != destination.CDCTargetKey("test-project", "sensitive", "Orders") {
 		t.Fatalf("case-sensitive target = %q, %v", got, err)
 	}
-	if _, err := dest.canonicalCDCTarget(t.Context(), "test-project", "insensitive", "Other"); err != nil {
+	if _, err := dest.canonicalCDCTarget(t.Context(), "test-project", "Insensitive", "Other"); err != nil {
 		t.Fatal(err)
 	}
 	if metadataCalls.Load() != 2 {

--- a/pkg/destination/cdc_truncate_test.go
+++ b/pkg/destination/cdc_truncate_test.go
@@ -24,6 +24,18 @@ type conditionalBoundaryDestination struct {
 	conditionalCalls   atomic.Int64
 }
 
+type unconditionalBoundaryDestination struct {
+	*boundaryWriteDestination
+	unconditionalCalls atomic.Int64
+}
+
+func (d *unconditionalBoundaryDestination) GetScheme() string { return "unconditional" }
+
+func (d *unconditionalBoundaryDestination) TruncateCDCTable(context.Context, string) error {
+	d.unconditionalCalls.Add(1)
+	return nil
+}
+
 func (d *conditionalBoundaryDestination) TruncateCDCTable(context.Context, string) error {
 	d.unconditionalCalls.Add(1)
 	return nil
@@ -205,6 +217,30 @@ func TestWriteWithTruncateBoundariesRefusesRecreatedManagedTarget(t *testing.T) 
 	}
 	if got := dest.conditionalCalls.Load(); got != 1 {
 		t.Fatalf("conditional truncate calls = %d, want 1", got)
+	}
+}
+
+func TestWriteWithTruncateBoundariesRejectsUnsupportedManagedTruncateWithoutMutation(t *testing.T) {
+	dest := &unconditionalBoundaryDestination{boundaryWriteDestination: &boundaryWriteDestination{
+		write: func(_ context.Context, records <-chan source.RecordBatchResult, _ WriteOptions) error {
+			for result := range records {
+				releaseCDCResult(result)
+			}
+			return nil
+		},
+	}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Truncate: true, CDCWALTruncate: true}
+	close(records)
+
+	_, err := WriteWithTruncateBoundaries(context.Background(), dest, records, WriteOptions{
+		Table: "items", CDCExpectedIncarnation: "bound-original-uuid",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot conditionally truncate managed CDC targets") {
+		t.Fatalf("WriteWithTruncateBoundaries() error = %v, want unsupported conditional truncate", err)
+	}
+	if got := dest.unconditionalCalls.Load(); got != 0 {
+		t.Fatalf("unconditional truncate calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -30,8 +30,11 @@ type PrepareOptions struct {
 }
 
 type WriteOptions struct {
-	Table            string
-	Schema           *schema.TableSchema
+	Table  string
+	Schema *schema.TableSchema
+	// TargetSchema is the visible schema produced by an atomic replacement when
+	// Schema contains staging-only columns needed while processing the input.
+	TargetSchema     *schema.TableSchema
 	PrimaryKeys      []string
 	Parallelism      int
 	AtomicCommit     bool
@@ -176,6 +179,8 @@ type TableWriteConfig struct {
 	PrimaryKeys            []string
 	DeduplicatePrimaryKeys bool
 	IncrementalKey         string
+	IncrementalPredicate   string
+	CDCMode                bool
 	SkipCDCResume          bool
 	CDCExpectedIncarnation string
 }
@@ -190,7 +195,8 @@ type MultiTableWriteOptions struct {
 	LoaderFileFormat string
 	// CancelSource stops the producer when a per-table writer fails. The writer
 	// drains records after invoking it so producer-owned resources can unwind.
-	CancelSource context.CancelFunc
+	CancelSource       context.CancelFunc
+	CancelDrainTimeout time.Duration
 	// TableWriter overrides the destination's per-table write path. Its boolean
 	// result reports whether it applied at least one source truncate boundary.
 	TableWriter func(context.Context, string, <-chan source.RecordBatchResult, WriteOptions) (bool, error)
@@ -330,6 +336,14 @@ type CDCTargetIncarnationProvider interface {
 	CDCTargetIncarnation(ctx context.Context, table string) (incarnation string, exists bool, err error)
 }
 
+// ManagedCDCWriteFencer is implemented by destinations whose row writes,
+// merges, and table swaps atomically reject a stale CDCExpectedIncarnation.
+// Reading the target incarnation separately is not sufficient because the
+// target can be replaced between that read and the DML commit.
+type ManagedCDCWriteFencer interface {
+	SupportsManagedCDCWriteFencing() bool
+}
+
 // ManagedCDCStateValidator checks destination-specific durability requirements
 // before a managed CDC run acquires a lease or mutates destination state.
 type ManagedCDCStateValidator interface {
@@ -395,22 +409,37 @@ type AtomicSnapshotOptions struct {
 // stage snapshot pages and publish the completed snapshot in one table commit.
 // It does not provide atomic publication across multiple destination tables.
 // Streaming falls back to its historical truncate-and-page behavior when this
-// interface is not implemented. Begin, write, and publish must be idempotent for
-// one AttemptID. Once publication becomes durable, retrying publish for that
-// AttemptID must report success without duplicating rows or replacing a newer
-// attempt, including when the original success response was lost.
+// interface is not implemented. Begin and write must durably finish before
+// returning success and be idempotent for one AttemptID. Publish retries for a
+// sealed attempt use the original commit token, source boundary, and target
+// incarnation fence. Once publication becomes durable, retrying publish for
+// that AttemptID must return the original published incarnation without
+// duplicating rows or replacing a newer attempt, including when the original
+// success response was lost.
 type AtomicSnapshotPublisher interface {
 	BeginAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
 	EvolveAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
 	WriteAtomicSnapshot(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
-	PublishAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+	// PublishAtomicSnapshot returns the exact physical incarnation made visible
+	// by the commit. Managed CDC uses it to bind state without trusting a
+	// post-publication identity lookup that could race with an external replace.
+	PublishAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) (publishedIncarnation string, err error)
 }
 
 // AtomicSnapshotAborter reclaims an owned snapshot stage only when the caller
-// knows publication was never attempted. It is separate from
-// AtomicSnapshotPublisher so existing publishers remain compatible.
+// knows publication was never attempted. Abort must be idempotent because a
+// successful response can be lost before the durable attempt is retired. It is
+// separate from AtomicSnapshotPublisher so existing publishers remain compatible.
 type AtomicSnapshotAborter interface {
 	AbortAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+}
+
+// AtomicSnapshotDiscarder retires an obsolete sealed attempt whose publish
+// result may have been lost. It must delete only an unpublished stage and must
+// be an idempotent no-op when that AttemptID was already published. It must
+// never remove or replace a visible target.
+type AtomicSnapshotDiscarder interface {
+	DiscardAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
 }
 
 type OwnedTableDropper interface {
@@ -491,6 +520,19 @@ type CDCTruncateCapable interface {
 // readers never observe an empty or partially reloaded target.
 type AtomicTruncateInsertWriter interface {
 	TruncateInsertRecords(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
+}
+
+// AtomicTruncateInsertBoundaryAware acknowledges that TruncateInsertRecords
+// treats every Truncate marker as a replacement boundary: rows received before
+// the marker must not be present in the final atomic commit.
+type AtomicTruncateInsertBoundaryAware interface {
+	SupportsTruncateInsertBoundaries() bool
+}
+
+// AtomicTruncateInsertStagingAware acknowledges that TruncateInsertRecords
+// can consume staging-only input columns while publishing only TargetSchema.
+type AtomicTruncateInsertStagingAware interface {
+	SupportsTruncateInsertStagingColumns() bool
 }
 
 // AtomicTruncateInsertSchemaEvolver marks an atomic truncate+insert writer that

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -2,6 +2,8 @@ package duckdb
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -1417,14 +1419,44 @@ func canonicalDuckDBTarget(tn tablename.TableName) string {
 }
 
 func (d *DuckDBDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
-	tn := duckTable(table)
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	return d.cdcTargetIncarnationLocked(ctx, table)
+}
+
+const duckDBCDCIncarnationMarkerPrefix = "\n\n[bruin managed CDC incarnation:"
+
+type duckDBTableIncarnation struct {
+	catalog string
+	schema  string
+	table   string
+	comment string
+	marker  string
+}
+
+func (d *DuckDBDestination) cdcTargetIncarnationLocked(ctx context.Context, table string) (string, bool, error) {
+	incarnation, exists, err := d.duckDBTableIncarnationLocked(ctx, table)
+	if err != nil || !exists {
+		return "", exists, err
+	}
+	if incarnation.marker == "" {
+		return "", true, nil
+	}
+	return destination.CDCTargetKey(
+		strings.ToLower(incarnation.catalog),
+		strings.ToLower(incarnation.schema),
+		strings.ToLower(incarnation.table),
+		incarnation.marker,
+	), true, nil
+}
+
+func (d *DuckDBDestination) duckDBTableIncarnationLocked(ctx context.Context, table string) (duckDBTableIncarnation, bool, error) {
+	tn := duckTable(table)
 	if tn.Catalog == "" {
 		if d.catalog == "" {
 			catalog, err := d.currentCatalog(ctx)
 			if err != nil {
-				return "", false, err
+				return duckDBTableIncarnation{}, false, err
 			}
 			d.catalog = catalog
 		}
@@ -1432,39 +1464,145 @@ func (d *DuckDBDestination) CDCTargetIncarnation(ctx context.Context, table stri
 	}
 	tn.Schema = canonicalDuckDBSchema(tn.Schema)
 	literal := func(value string) string { return strings.ReplaceAll(value, "'", "''") }
-	query := fmt.Sprintf(`SELECT CAST(database_oid AS VARCHAR), CAST(table_oid AS VARCHAR)
+	query := fmt.Sprintf(`SELECT database_name, schema_name, table_name, comment
 		FROM duckdb_tables()
 		WHERE lower(database_name) = lower('%s') AND lower(schema_name) = lower('%s') AND lower(table_name) = lower('%s')`,
 		literal(tn.Catalog), literal(tn.Schema), literal(tn.Table))
 	stmt, err := d.conn.NewStatement()
 	if err != nil {
-		return "", false, err
+		return duckDBTableIncarnation{}, false, err
 	}
 	defer func() { _ = stmt.Close() }()
 	if err := stmt.SetSqlQuery(query); err != nil {
-		return "", false, err
+		return duckDBTableIncarnation{}, false, err
 	}
 	reader, _, err := stmt.ExecuteQuery(ctx)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to read DuckDB CDC target incarnation for %s: %w", table, err)
+		return duckDBTableIncarnation{}, false, fmt.Errorf("failed to read DuckDB CDC target incarnation for %s: %w", table, err)
 	}
 	defer reader.Release()
 	if !reader.Next() {
 		if err := reader.Err(); err != nil {
-			return "", false, err
+			return duckDBTableIncarnation{}, false, err
 		}
-		return "", false, nil
+		return duckDBTableIncarnation{}, false, nil
 	}
 	batch := reader.RecordBatch()
 	if batch.NumRows() == 0 {
-		return "", false, nil
+		return duckDBTableIncarnation{}, false, nil
 	}
-	databaseOIDs, databaseOK := batch.Column(0).(*array.String)
-	tableOIDs, tableOK := batch.Column(1).(*array.String)
-	if !databaseOK || !tableOK {
-		return "", false, fmt.Errorf("unexpected DuckDB CDC target incarnation column types")
+	catalogs, catalogOK := batch.Column(0).(*array.String)
+	schemas, schemaOK := batch.Column(1).(*array.String)
+	tables, tableOK := batch.Column(2).(*array.String)
+	comments, commentOK := batch.Column(3).(*array.String)
+	if !catalogOK || !schemaOK || !tableOK || !commentOK {
+		return duckDBTableIncarnation{}, false, fmt.Errorf("unexpected DuckDB CDC target incarnation column types")
 	}
-	return destination.CDCTargetKey(databaseOIDs.Value(0), tableOIDs.Value(0)), true, nil
+	result := duckDBTableIncarnation{
+		catalog: strings.Clone(catalogs.Value(0)),
+		schema:  strings.Clone(schemas.Value(0)),
+		table:   strings.Clone(tables.Value(0)),
+	}
+	if !comments.IsNull(0) {
+		result.comment = strings.Clone(comments.Value(0))
+		result.marker = duckDBCDCIncarnationMarker(result.comment)
+	}
+	return result, true, reader.Err()
+}
+
+func duckDBCDCIncarnationMarker(comment string) string {
+	if !strings.HasSuffix(comment, "]") {
+		return ""
+	}
+	markerStart := strings.LastIndex(comment, duckDBCDCIncarnationMarkerPrefix)
+	if markerStart < 0 {
+		return ""
+	}
+	marker := comment[markerStart+len(duckDBCDCIncarnationMarkerPrefix) : len(comment)-1]
+	if len(marker) != 32 {
+		return ""
+	}
+	if _, err := hex.DecodeString(marker); err != nil {
+		return ""
+	}
+	return marker
+}
+
+func (d *DuckDBDestination) EnsureCDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.exec(ctx, "BEGIN"); err != nil {
+		return "", false, fmt.Errorf("failed to begin DuckDB CDC incarnation initialization: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = d.exec(ctx, "ROLLBACK")
+		}
+	}()
+	incarnation, exists, err := d.duckDBTableIncarnationLocked(ctx, table)
+	if err != nil || !exists {
+		return "", exists, err
+	}
+	if incarnation.marker == "" {
+		token := make([]byte, 16)
+		if _, err := rand.Read(token); err != nil {
+			return "", false, fmt.Errorf("failed to create DuckDB CDC incarnation marker: %w", err)
+		}
+		incarnation.marker = hex.EncodeToString(token)
+		comment := incarnation.comment + duckDBCDCIncarnationMarkerPrefix + incarnation.marker + "]"
+		commentLiteral := strings.ReplaceAll(comment, "'", "''")
+		qualifiedTable := strings.Join([]string{
+			destination.QuoteIdentifier(incarnation.catalog),
+			destination.QuoteIdentifier(incarnation.schema),
+			destination.QuoteIdentifier(incarnation.table),
+		}, ".")
+		if err := d.exec(ctx, fmt.Sprintf("COMMENT ON TABLE %s IS '%s'", qualifiedTable, commentLiteral)); err != nil {
+			return "", false, fmt.Errorf("failed to initialize DuckDB CDC target incarnation for %s: %w", table, err)
+		}
+	}
+	if err := d.exec(ctx, "COMMIT"); err != nil {
+		return "", false, fmt.Errorf("failed to commit DuckDB CDC incarnation initialization: %w", err)
+	}
+	committed = true
+	return destination.CDCTargetKey(
+		strings.ToLower(incarnation.catalog),
+		strings.ToLower(incarnation.schema),
+		strings.ToLower(incarnation.table),
+		incarnation.marker,
+	), true, nil
+}
+
+func (d *DuckDBDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
+	if expectedIncarnation == "" {
+		return fmt.Errorf("cannot conditionally truncate DuckDB table %q without a bound incarnation", table)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.exec(ctx, "BEGIN"); err != nil {
+		return fmt.Errorf("failed to begin conditional DuckDB truncate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = d.exec(ctx, "ROLLBACK")
+		}
+	}()
+	current, exists, err := d.cdcTargetIncarnationLocked(ctx, table)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expectedIncarnation {
+		return fmt.Errorf("DuckDB CDC target %q physical incarnation changed", table)
+	}
+	if err := d.exec(ctx, fmt.Sprintf("TRUNCATE TABLE %s", destination.QuoteTableName(table))); err != nil {
+		return fmt.Errorf("failed to truncate DuckDB CDC target %s: %w", table, err)
+	}
+	if err := d.exec(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("failed to commit conditional DuckDB truncate: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func (d *DuckDBDestination) currentCatalog(ctx context.Context) (string, error) {

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -52,6 +52,18 @@ func TestNewDuckDBDestination(t *testing.T) {
 	}
 }
 
+func TestDuckLakeManagedCDCTargetIncarnationFailsClosed(t *testing.T) {
+	dest := NewDuckLakeDestination()
+
+	require.ErrorContains(t, dest.ValidateManagedCDCState(), "not supported for DuckLake")
+	require.ErrorContains(t, dest.ValidateManagedCDCTarget(t.Context(), "events"), "not supported for DuckLake")
+	_, _, err := dest.CDCTargetIncarnation(t.Context(), "events")
+	require.ErrorContains(t, err, "not supported for DuckLake")
+	_, _, err = dest.EnsureCDCTargetIncarnation(t.Context(), "events")
+	require.ErrorContains(t, err, "not supported for DuckLake")
+	require.ErrorContains(t, dest.TruncateCDCTableIfIncarnation(t.Context(), "events", "marker"), "not supported for DuckLake")
+}
+
 func TestSchemes(t *testing.T) {
 	dest := NewDuckDBDestination()
 	schemes := dest.Schemes()
@@ -119,30 +131,136 @@ func TestClaimCDCTargetCanonicalizesCurrentCatalog(t *testing.T) {
 	require.NoError(t, dest.ClaimCDCTarget(t.Context(), "_bruin_staging.cdc_targets", claim("customers", "connector-b")))
 }
 
-func TestCDCTargetIncarnationStableAcrossDMLAndChangesOnRecreate(t *testing.T) {
+func TestCDCTargetIncarnationProbeDoesNotMutateUnclaimedTable(t *testing.T) {
 	dest, _ := connectTestDuckDB(t, t.Context())
-	if err := dest.Exec(t.Context(), `CREATE TABLE events (id BIGINT)`); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, dest.Exec(t.Context(), `CREATE TABLE events (id BIGINT)`))
+	require.NoError(t, dest.Exec(t.Context(), `COMMENT ON TABLE events IS 'customer-owned comment'`))
 
-	first, exists, err := dest.CDCTargetIncarnation(t.Context(), "events")
+	before, exists, err := dest.duckDBTableIncarnationLockedForTest(t.Context(), "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, "customer-owned comment", before.comment)
+
+	incarnation, exists, err := dest.CDCTargetIncarnation(t.Context(), "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Empty(t, incarnation)
+
+	after, exists, err := dest.duckDBTableIncarnationLockedForTest(t.Context(), "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, before.comment, after.comment)
+	require.Empty(t, after.marker)
+}
+
+func TestCDCTargetIncarnationPersistsAcrossReopenAndPreservesComment(t *testing.T) {
+	ctx := t.Context()
+	dest, path := connectTestDuckDB(t, ctx)
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE events (id BIGINT)`))
+	require.NoError(t, dest.Exec(ctx, `COMMENT ON TABLE events IS 'customer-owned comment'`))
+
+	first, exists, err := dest.EnsureCDCTargetIncarnation(ctx, "events")
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.NotEmpty(t, first)
-	require.NoError(t, dest.Exec(t.Context(), `INSERT INTO events VALUES (1)`))
-	stable, exists, err := dest.CDCTargetIncarnation(t.Context(), "main.events")
+	marked, exists, err := dest.duckDBTableIncarnationLockedForTest(ctx, "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.True(t, strings.HasPrefix(marked.comment, "customer-owned comment"))
+	require.NotEmpty(t, marked.marker)
+	require.NoError(t, dest.Exec(ctx, `ALTER TABLE events ADD COLUMN payload VARCHAR`))
+	stable, exists, err := dest.CDCTargetIncarnation(ctx, "events")
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.Equal(t, first, stable)
-	require.NoError(t, dest.Exec(t.Context(), `DROP TABLE events`))
-	_, exists, err = dest.CDCTargetIncarnation(t.Context(), "events")
-	require.NoError(t, err)
-	require.False(t, exists)
-	require.NoError(t, dest.Exec(t.Context(), `CREATE TABLE events (id BIGINT)`))
-	recreated, exists, err := dest.CDCTargetIncarnation(t.Context(), "events")
+
+	require.NoError(t, dest.Close(ctx))
+	reopened := NewDuckDBDestination()
+	require.NoError(t, reopened.Connect(ctx, fmt.Sprintf("duckdb:///%s", path)))
+	t.Cleanup(func() { _ = reopened.Close(ctx) })
+
+	stable, exists, err = reopened.CDCTargetIncarnation(ctx, "main.events")
 	require.NoError(t, err)
 	require.True(t, exists)
-	require.NotEqual(t, first, recreated)
+	require.Equal(t, first, stable)
+	require.NoError(t, reopened.Exec(ctx, `INSERT INTO events (id) VALUES (1)`))
+	stable, exists, err = reopened.EnsureCDCTargetIncarnation(ctx, "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, first, stable)
+}
+
+func TestCDCTargetIncarnationMarkerRemovedOnRecreate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		statements []string
+	}{
+		{name: "drop and recreate", statements: []string{`DROP TABLE events`, `CREATE TABLE events (id BIGINT)`}},
+		{name: "create or replace", statements: []string{`CREATE OR REPLACE TABLE events (id BIGINT)`}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dest, _ := connectTestDuckDB(t, t.Context())
+			require.NoError(t, dest.Exec(t.Context(), `CREATE TABLE events (id BIGINT)`))
+			first, exists, err := dest.EnsureCDCTargetIncarnation(t.Context(), "events")
+			require.NoError(t, err)
+			require.True(t, exists)
+
+			for _, statement := range tc.statements {
+				require.NoError(t, dest.Exec(t.Context(), statement))
+			}
+			recreated, exists, err := dest.CDCTargetIncarnation(t.Context(), "events")
+			require.NoError(t, err)
+			require.True(t, exists)
+			require.Empty(t, recreated)
+			recreated, exists, err = dest.EnsureCDCTargetIncarnation(t.Context(), "events")
+			require.NoError(t, err)
+			require.True(t, exists)
+			require.NotEmpty(t, recreated)
+			require.NotEqual(t, first, recreated)
+		})
+	}
+}
+
+func TestTruncateCDCTableIfIncarnation(t *testing.T) {
+	dest, _ := connectTestDuckDB(t, t.Context())
+	rowCount := func() int64 {
+		stmt, err := dest.conn.NewStatement()
+		require.NoError(t, err)
+		defer func() { _ = stmt.Close() }()
+		require.NoError(t, stmt.SetSqlQuery(`SELECT count(*) FROM events`))
+		reader, _, err := stmt.ExecuteQuery(t.Context())
+		require.NoError(t, err)
+		defer reader.Release()
+		require.True(t, reader.Next())
+		count, ok := int64ValueAt(reader.RecordBatch().Column(0), 0)
+		require.True(t, ok)
+		return count
+	}
+	require.NoError(t, dest.Exec(t.Context(), `CREATE TABLE events (id BIGINT)`))
+	require.NoError(t, dest.Exec(t.Context(), `INSERT INTO events VALUES (1), (2)`))
+
+	expected, exists, err := dest.EnsureCDCTargetIncarnation(t.Context(), "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.TruncateCDCTableIfIncarnation(t.Context(), "events", expected))
+
+	require.Zero(t, rowCount())
+	stable, exists, err := dest.CDCTargetIncarnation(t.Context(), "events")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, expected, stable)
+
+	require.NoError(t, dest.Exec(t.Context(), `DROP TABLE events`))
+	require.NoError(t, dest.Exec(t.Context(), `CREATE TABLE events (id BIGINT)`))
+	require.NoError(t, dest.Exec(t.Context(), `INSERT INTO events VALUES (3)`))
+	require.ErrorContains(t, dest.TruncateCDCTableIfIncarnation(t.Context(), "events", expected), "physical incarnation changed")
+	require.Equal(t, int64(1), rowCount())
+}
+
+func (d *DuckDBDestination) duckDBTableIncarnationLockedForTest(ctx context.Context, table string) (duckDBTableIncarnation, bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.duckDBTableIncarnationLocked(ctx, table)
 }
 
 func TestParseDuckDBPath(t *testing.T) {

--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -19,6 +19,26 @@ func NewDuckLakeDestination() *DuckLakeDestination {
 func (d *DuckLakeDestination) Schemes() []string { return []string{"ducklake"} }
 func (d *DuckLakeDestination) GetScheme() string { return "ducklake" }
 
+func (d *DuckLakeDestination) ValidateManagedCDCState() error {
+	return fmt.Errorf("managed CDC target incarnation fencing is not supported for DuckLake")
+}
+
+func (d *DuckLakeDestination) ValidateManagedCDCTarget(context.Context, string) error {
+	return fmt.Errorf("managed CDC target incarnation fencing is not supported for DuckLake")
+}
+
+func (d *DuckLakeDestination) CDCTargetIncarnation(context.Context, string) (string, bool, error) {
+	return "", false, fmt.Errorf("managed CDC target incarnation fencing is not supported for DuckLake")
+}
+
+func (d *DuckLakeDestination) EnsureCDCTargetIncarnation(context.Context, string) (string, bool, error) {
+	return "", false, fmt.Errorf("managed CDC target incarnation fencing is not supported for DuckLake")
+}
+
+func (d *DuckLakeDestination) TruncateCDCTableIfIncarnation(context.Context, string, string) error {
+	return fmt.Errorf("managed CDC target incarnation fencing is not supported for DuckLake")
+}
+
 func (d *DuckLakeDestination) Connect(ctx context.Context, uri string) error {
 	cfg, err := srcduckdb.ParseLakehouseURI(uri)
 	if err != nil {

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -1,6 +1,8 @@
 package destination_test
 
 import (
+	"testing"
+
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/athena"
 	"github.com/bruin-data/ingestr/pkg/destination/bigquery"
@@ -25,9 +27,27 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/vitess"
 )
 
+func TestBigQueryDoesNotAdvertiseUnsafeConditionalCDCTruncate(t *testing.T) {
+	if _, ok := any(&bigquery.BigQueryDestination{}).(destination.CDCConditionalTruncater); ok {
+		t.Fatal("BigQuery must not advertise conditional CDC truncate without an atomic table-incarnation fence")
+	}
+}
+
+func TestOnlyFencedDestinationsAdvertiseManagedCDCWriteFencing(t *testing.T) {
+	if !(&postgres.PostgresDestination{}).SupportsManagedCDCWriteFencing() {
+		t.Fatal("PostgreSQL must advertise its transactionally enforced CDC write fence")
+	}
+	if _, ok := any(&sqlite.SQLiteDestination{}).(destination.ManagedCDCWriteFencer); ok {
+		t.Fatal("SQLite must not advertise managed CDC write fencing until its DML paths enforce the incarnation")
+	}
+}
+
 // Destinations eligible for destination-managed PostgreSQL CDC state must
 // support one connector-scoped read from the shared state table.
 var (
+	_ destination.ManagedCDCWriteFencer = (*postgres.PostgresDestination)(nil)
+	_ destination.OwnedTableDropper     = (*postgres.PostgresDestination)(nil)
+
 	_ destination.CDCStateReader = (*bigquery.BigQueryDestination)(nil)
 	_ destination.CDCStateReader = (*duckdb.DuckDBDestination)(nil)
 	_ destination.CDCStateReader = (*duckdb.DuckLakeDestination)(nil)
@@ -57,6 +77,7 @@ var (
 
 var (
 	_ destination.CDCStateWriter                 = (*bigquery.BigQueryDestination)(nil)
+	_ destination.ManagedCDCStateValidator       = (*duckdb.DuckLakeDestination)(nil)
 	_ destination.ManagedCDCStateValidator       = (*mysql.MySQLDestination)(nil)
 	_ destination.ManagedCDCStateValidator       = (*planetscale.Destination)(nil)
 	_ destination.ManagedCDCStateValidator       = (*redshift.RedshiftDestination)(nil)
@@ -90,6 +111,16 @@ var (
 	_ destination.CDCTargetIncarnationProvider = (*redshift.RedshiftDestination)(nil)
 	_ destination.CDCTargetIncarnationProvider = (*sqlite.SQLiteDestination)(nil)
 	_ destination.CDCTargetIncarnationProvider = (*vitess.Destination)(nil)
+)
+
+var (
+	_ destination.CDCConditionalTruncater = (*duckdb.DuckDBDestination)(nil)
+	_ destination.CDCConditionalTruncater = (*duckdb.DuckLakeDestination)(nil)
+	_ destination.CDCConditionalTruncater = (*mssql.MSSQLDestination)(nil)
+	_ destination.CDCConditionalTruncater = (*mysql.MySQLDestination)(nil)
+	_ destination.CDCConditionalTruncater = (*oracle.OracleDestination)(nil)
+	_ destination.CDCConditionalTruncater = (*postgres.PostgresDestination)(nil)
+	_ destination.CDCConditionalTruncater = (*sqlite.SQLiteDestination)(nil)
 )
 
 var (

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -1217,14 +1217,14 @@ func (d *MSSQLDestination) ValidateManagedCDCTarget(ctx context.Context, table s
 	if err != nil {
 		return err
 	}
+	if identity.server != "" && !strings.EqualFold(identity.server, d.server) {
+		return fmt.Errorf("managed CDC does not support linked SQL Server target %q without distributed transactions", table)
+	}
 	if strings.EqualFold(identity.server, d.server) && strings.EqualFold(identity.database, d.database) {
 		return d.ValidateManagedCDCState()
 	}
 
 	catalog := quoteColumn("master") + ".sys.databases"
-	if !strings.EqualFold(identity.server, d.server) {
-		catalog = quoteColumn(identity.server) + "." + catalog
-	}
 	var compatibilityLevel int
 	query := fmt.Sprintf("SELECT [compatibility_level] FROM %s WHERE [name] = @p1", catalog)
 	if err := d.db.QueryRowContext(ctx, query, identity.database).Scan(&compatibilityLevel); err != nil {
@@ -1316,6 +1316,19 @@ func (d *MSSQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 	if err != nil {
 		return "", false, err
 	}
+	return d.mssqlTargetIncarnation(ctx, d.db, table, identity)
+}
+
+type mssqlIncarnationQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (d *MSSQLDestination) mssqlTargetIncarnation(
+	ctx context.Context,
+	queryer mssqlIncarnationQueryer,
+	table string,
+	identity mssqlTargetIdentity,
+) (string, bool, error) {
 	prefix := identity.catalogPrefix(d.server)
 	if prefix == "" {
 		return "", false, fmt.Errorf("cannot resolve SQL Server catalog for CDC target %q", table)
@@ -1326,7 +1339,7 @@ func (d *MSSQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 		WHERE s.name = @p1 AND t.name = @p2`, prefix, prefix)
 	var objectID int64
 	var createdAt string
-	err = d.db.QueryRowContext(ctx, query, identity.schema, identity.table).Scan(&objectID, &createdAt)
+	err := queryer.QueryRowContext(ctx, query, identity.schema, identity.table).Scan(&objectID, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", false, nil
 	}
@@ -1334,6 +1347,43 @@ func (d *MSSQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 		return "", false, fmt.Errorf("failed to read SQL Server CDC target incarnation for %s: %w", table, err)
 	}
 	return destination.CDCTargetKey(identity.server, identity.database, strconv.FormatInt(objectID, 10), createdAt), true, nil
+}
+
+func (d *MSSQLDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
+	if expectedIncarnation == "" {
+		return fmt.Errorf("cannot conditionally truncate SQL Server table %q without a bound incarnation", table)
+	}
+	identity, err := d.resolveTargetIdentity(ctx, table)
+	if err != nil {
+		return err
+	}
+	if identity.server != "" && !strings.EqualFold(identity.server, d.server) {
+		return fmt.Errorf("cannot conditionally truncate linked SQL Server CDC target %q without a distributed transaction", table)
+	}
+	resolvedTable := quoteTable(identity.qualifiedTable(d.server))
+	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT TOP (1) 1 FROM %s WITH (TABLOCKX, HOLDLOCK)", resolvedTable))
+	if err != nil {
+		return fmt.Errorf("failed to lock SQL Server CDC target %s: %w", table, err)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	current, exists, err := d.mssqlTargetIncarnation(ctx, tx, table, identity)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expectedIncarnation {
+		return fmt.Errorf("SQL Server CDC target %q physical incarnation changed", table)
+	}
+	if _, err := tx.ExecContext(ctx, "TRUNCATE TABLE "+resolvedTable); err != nil {
+		return fmt.Errorf("failed to truncate SQL Server CDC target %s: %w", table, err)
+	}
+	return tx.Commit()
 }
 
 type mssqlTargetIdentity struct {

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -73,6 +73,69 @@ func TestValidateManagedCDCTargetChecksCrossDatabaseCompatibility(t *testing.T) 
 	}
 }
 
+func TestValidateManagedCDCTargetRejectsLinkedServer(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	dest := &MSSQLDestination{db: db, server: "local", database: "default", compatibilityLevel: 160}
+
+	err = dest.ValidateManagedCDCTarget(t.Context(), "linked.legacy.dbo.items")
+	if err == nil || !strings.Contains(err.Error(), "does not support linked SQL Server target") {
+		t.Fatalf("linked-server validation error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTruncateCDCTableIfIncarnation(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		objectID   int64
+		wantErr    string
+		wantCommit bool
+	}{
+		{name: "matching", objectID: 42, wantCommit: true},
+		{name: "recreated", objectID: 43, wantErr: "physical incarnation changed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			dest := &MSSQLDestination{db: db, server: "local", database: "app"}
+			createdAt := "2026-07-17T12:00:00.0000000"
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT TOP (1) 1 FROM [app].[dbo].[events] WITH (TABLOCKX, HOLDLOCK)")).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}))
+			mock.ExpectQuery("SELECT CAST\\(t.object_id AS BIGINT\\), CONVERT\\(NVARCHAR\\(33\\), t.create_date, 126\\)").
+				WithArgs("dbo", "events").
+				WillReturnRows(sqlmock.NewRows([]string{"object_id", "create_date"}).AddRow(tc.objectID, createdAt))
+			if tc.wantCommit {
+				mock.ExpectExec(regexp.QuoteMeta("TRUNCATE TABLE [app].[dbo].[events]")).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectCommit()
+			} else {
+				mock.ExpectRollback()
+			}
+			expected := destination.CDCTargetKey("local", "app", "42", createdAt)
+			err = dest.TruncateCDCTableIfIncarnation(t.Context(), "dbo.events", expected)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("TruncateCDCTableIfIncarnation() error = %v, want %q", err, tc.wantErr)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestCanonicalCDCTargetUsesConnectedDefaultSchema(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/pkg/destination/multitable/router.go
+++ b/pkg/destination/multitable/router.go
@@ -20,6 +20,7 @@ type Router struct {
 	done          chan struct{}
 	err           error
 	errMu         sync.RWMutex
+	drainTimeout  time.Duration
 }
 
 // NewRouter creates a router for the specified tables.
@@ -32,6 +33,7 @@ func NewRouter(tables []string, bufferSize int) *Router {
 		tableChannels: make(map[string]chan source.RecordBatchResult),
 		bufferSize:    bufferSize,
 		done:          make(chan struct{}),
+		drainTimeout:  routerDrainTimeout,
 	}
 
 	for _, table := range tables {
@@ -44,7 +46,7 @@ func NewRouter(tables []string, bufferSize int) *Router {
 // Route starts routing batches from the input channel to per-table channels.
 // This method should be called once and runs asynchronously.
 // It closes all table channels when the input channel is exhausted or an error occurs.
-func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResult, drainOnCancel bool) {
+func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResult, drainOnCancel ...bool) {
 	r.mu.Lock()
 	if r.started {
 		r.mu.Unlock()
@@ -52,6 +54,7 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 	}
 	r.started = true
 	r.mu.Unlock()
+	shouldDrain := len(drainOnCancel) > 0 && drainOnCancel[0]
 
 	go func() {
 		aborted := false
@@ -63,7 +66,7 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 			case <-ctx.Done():
 				aborted = true
 				r.setError(ctx.Err())
-				if drainOnCancel {
+				if shouldDrain {
 					r.drainInput(input)
 				}
 				return
@@ -73,11 +76,10 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 				}
 
 				if result.Err != nil {
-					aborted = true
 					r.setError(result.Err)
-					r.broadcastError(result.Err)
+					r.broadcastError(ctx, result.Err)
 					releaseResult(result)
-					if drainOnCancel {
+					if shouldDrain {
 						r.drainInput(input)
 					}
 					return
@@ -95,7 +97,7 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 					aborted = true
 					r.setError(ctx.Err())
 					releaseResult(result)
-					if drainOnCancel {
+					if shouldDrain {
 						r.drainInput(input)
 					}
 					return
@@ -133,11 +135,12 @@ func (r *Router) setError(err error) {
 	r.errMu.Unlock()
 }
 
-func (r *Router) broadcastError(err error) {
+func (r *Router) broadcastError(ctx context.Context, err error) {
 	for _, ch := range r.tableChannels {
 		select {
 		case ch <- source.RecordBatchResult{Err: err}:
-		default:
+		case <-ctx.Done():
+			return
 		}
 	}
 }
@@ -156,7 +159,7 @@ func (r *Router) closeChannels(drain bool) {
 }
 
 func (r *Router) drainInput(input <-chan source.RecordBatchResult) {
-	timer := time.NewTimer(routerDrainTimeout)
+	timer := time.NewTimer(r.drainTimeout)
 	defer timer.Stop()
 	for {
 		select {

--- a/pkg/destination/multitable/router_test.go
+++ b/pkg/destination/multitable/router_test.go
@@ -1,0 +1,89 @@
+package multitable
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestRouterDeliversSourceErrorToFullTableChannels(t *testing.T) {
+	sourceErr := errors.New("source failed")
+	input := make(chan source.RecordBatchResult, 3)
+	input <- source.RecordBatchResult{TableName: "users"}
+	input <- source.RecordBatchResult{TableName: "orders"}
+	input <- source.RecordBatchResult{Err: sourceErr}
+	close(input)
+
+	router := NewRouter([]string{"users", "orders"}, 1)
+	router.Route(context.Background(), input)
+
+	deadline := time.Now().Add(time.Second)
+	for router.Err() == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !errors.Is(router.Err(), sourceErr) {
+		t.Fatalf("Router.Err() = %v, want source error", router.Err())
+	}
+
+	select {
+	case <-router.done:
+		t.Fatal("router completed before it could deliver the source error to full channels")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	users := router.GetChannel("users")
+	orders := router.GetChannel("orders")
+	if result := <-users; result.Err != nil {
+		t.Fatalf("first users result error = %v, want data result", result.Err)
+	}
+	if result := <-orders; result.Err != nil {
+		t.Fatalf("first orders result error = %v, want data result", result.Err)
+	}
+
+	usersErr, usersOpen := <-users
+	ordersErr, ordersOpen := <-orders
+	if !usersOpen || !errors.Is(usersErr.Err, sourceErr) {
+		t.Fatalf("users terminal result = (%+v, open=%v), want source error", usersErr, usersOpen)
+	}
+	if !ordersOpen || !errors.Is(ordersErr.Err, sourceErr) {
+		t.Fatalf("orders terminal result = (%+v, open=%v), want source error", ordersErr, ordersOpen)
+	}
+
+	router.Wait()
+	if _, open := <-users; open {
+		t.Fatal("users channel remained open after terminal error")
+	}
+	if _, open := <-orders; open {
+		t.Fatal("orders channel remained open after terminal error")
+	}
+}
+
+func TestRouterReleasesBatchForUnknownTable(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	builder := array.NewInt64Builder(mem)
+	builder.Append(1)
+	values := builder.NewArray()
+	record := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil),
+		[]arrow.Array{values},
+		1,
+	)
+	values.Release()
+	builder.Release()
+
+	input := make(chan source.RecordBatchResult, 1)
+	input <- source.RecordBatchResult{TableName: "unknown", Batch: record}
+	close(input)
+
+	router := NewRouter([]string{"known"}, 1)
+	router.Route(context.Background(), input)
+	router.Wait()
+}

--- a/pkg/destination/multitable/writer.go
+++ b/pkg/destination/multitable/writer.go
@@ -64,6 +64,9 @@ func WriteWithResult(
 	}
 
 	router := NewRouter(tables, 8)
+	if opts.CancelDrainTimeout > 0 {
+		router.drainTimeout = opts.CancelDrainTimeout
+	}
 	router.Route(writeCtx, records, opts.CancelSource != nil)
 
 	var wg sync.WaitGroup
@@ -84,24 +87,49 @@ func WriteWithResult(
 			if ch == nil {
 				return
 			}
+			defer drainAndRelease(ch)
 
-			truncated, err := destination.WriteWithTruncateBoundariesAfterCancel(writeCtx, dest, ch, destination.WriteOptions{
-				Table:            tableConfig.DestTable,
-				Schema:           tableConfig.Schema,
-				PrimaryKeys:      tableConfig.PrimaryKeys,
-				Parallelism:      parallelism,
-				StagingTable:     opts.StagingTable,
-				StagingBucket:    opts.StagingBucket,
-				LoaderFileSize:   opts.LoaderFileSize,
-				LoaderFileFormat: opts.LoaderFileFormat,
-			}, cancelInput)
+			cancelAfterWriteError := func() {
+				if router.Err() == nil {
+					cancelInput()
+				}
+			}
+			writeOpts := destination.WriteOptions{
+				Table:                  tableConfig.DestTable,
+				Schema:                 tableConfig.Schema,
+				PrimaryKeys:            tableConfig.PrimaryKeys,
+				Parallelism:            parallelism,
+				StagingTable:           opts.StagingTable,
+				StagingBucket:          opts.StagingBucket,
+				LoaderFileSize:         opts.LoaderFileSize,
+				LoaderFileFormat:       opts.LoaderFileFormat,
+				DeduplicatePrimaryKeys: tableConfig.DeduplicatePrimaryKeys,
+				IncrementalKey:         tableConfig.IncrementalKey,
+				SkipCDCResume:          tableConfig.SkipCDCResume,
+				CDCExpectedIncarnation: tableConfig.CDCExpectedIncarnation,
+			}
+			var truncated bool
+			var err error
+			if opts.TableWriter != nil {
+				truncated, err = opts.TableWriter(writeCtx, table, ch, writeOpts)
+			} else if tableConfig.CDCMode {
+				truncated, err = destination.WriteWithTruncateBoundariesAfterCancel(writeCtx, dest, ch, writeOpts, cancelAfterWriteError)
+			} else {
+				err = dest.WriteParallel(writeCtx, ch, writeOpts)
+				if err != nil {
+					cancelAfterWriteError()
+				}
+			}
 			if truncated {
 				resultMu.Lock()
 				result.TruncatedTables[table] = true
 				resultMu.Unlock()
 			}
 			if err != nil {
-				cancelInput()
+				routerErr := router.Err()
+				if routerErr == nil || !errors.Is(err, routerErr) {
+					cancelInput()
+				}
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return
 				}
@@ -132,4 +160,12 @@ func WriteWithResult(
 
 	config.Debug("[MULTITABLE] Multi-table write completed in %v", time.Since(startTotal))
 	return result, nil
+}
+
+func drainAndRelease(records <-chan source.RecordBatchResult) {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
 }

--- a/pkg/destination/multitable/writer_test.go
+++ b/pkg/destination/multitable/writer_test.go
@@ -3,6 +3,7 @@ package multitable
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -153,6 +154,36 @@ func TestWriteCancelsOtherTablesOnFirstError(t *testing.T) {
 	}
 }
 
+func TestWritePropagatesSkipCDCResume(t *testing.T) {
+	var got destination.WriteOptions
+	dest := &fakeDestination{writeFn: func(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+		got = opts
+		for result := range records {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+		}
+		return nil
+	}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+
+	_, err := WriteWithResult(t.Context(), dest, records, destination.MultiTableWriteOptions{
+		TableConfigs: map[string]destination.TableWriteConfig{
+			"events": {DestTable: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "bound-table-uuid"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.SkipCDCResume {
+		t.Fatal("managed multi-table write did not propagate SkipCDCResume")
+	}
+	if got.CDCExpectedIncarnation != "bound-table-uuid" {
+		t.Fatalf("managed multi-table expected incarnation = %q, want bound-table-uuid", got.CDCExpectedIncarnation)
+	}
+}
+
 // TestWriteRouterDeadlock reproduces the exact deadlock pattern:
 // interleaved records for two tables, one writer fails after first record.
 // Without cancellation propagation, the router blocks sending to the failed
@@ -291,6 +322,69 @@ func TestWriteFailureReturnsWhenCanceledProducerNeverCloses(t *testing.T) {
 	}
 }
 
+func TestWriteDeliversSourceErrorToEveryFullTableChannel(t *testing.T) {
+	sourceErr := errors.New("source failed")
+	startReading := make(chan struct{})
+
+	dest := &fakeDestination{
+		writeFn: func(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+			select {
+			case <-startReading:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			for result := range records {
+				if result.Err != nil {
+					return fmt.Errorf("source stream: %w", result.Err)
+				}
+			}
+			return nil
+		},
+	}
+
+	records := make(chan source.RecordBatchResult, 17)
+	for range 8 {
+		records <- source.RecordBatchResult{TableName: "users"}
+		records <- source.RecordBatchResult{TableName: "orders"}
+	}
+	records <- source.RecordBatchResult{Err: sourceErr}
+	close(records)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Write(context.Background(), dest, records, destination.MultiTableWriteOptions{
+			TableConfigs: map[string]destination.TableWriteConfig{
+				"users":  {DestTable: "dataset.users"},
+				"orders": {DestTable: "dataset.orders"},
+			},
+		})
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for len(records) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(records) != 0 {
+		t.Fatal("router did not reach the source error while table channels were full")
+	}
+	time.Sleep(20 * time.Millisecond)
+	close(startReading)
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), sourceErr.Error()) {
+			t.Fatalf("Write error = %v, want source error", err)
+		}
+		for _, table := range []string{"users", "orders"} {
+			if !strings.Contains(err.Error(), "table "+table+":") {
+				t.Errorf("Write error = %v, want source error from table %s", err, table)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write deadlocked while delivering a source error to full table channels")
+	}
+}
+
 // TestWriteDoesNotDeadlockWithScarceSharedResourceScopedPerBatch models the
 // Snowflake connection-pool exhaustion deadlock generically: many tables
 // each spawn several workers (numTables * parallelism exceeds the size of a
@@ -407,7 +501,7 @@ func TestWriteWithResultSplitsTableAtTruncate(t *testing.T) {
 
 	result, err := WriteWithResult(context.Background(), dest, records, destination.MultiTableWriteOptions{
 		TableConfigs: map[string]destination.TableWriteConfig{
-			"items": {DestTable: "raw.items"},
+			"items": {DestTable: "raw.items", CDCMode: true},
 		},
 	})
 	if err != nil {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -1135,6 +1135,14 @@ func (d *MySQLDestination) ClaimCDCTarget(ctx context.Context, claimTable string
 }
 
 func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	return d.mysqlTargetIncarnation(ctx, d.db, table)
+}
+
+type mysqlIncarnationQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (d *MySQLDestination) mysqlTargetIncarnation(ctx context.Context, queryer mysqlIncarnationQueryer, table string) (string, bool, error) {
 	if d.isVitess {
 		return "", false, errors.New("vitess and planetscale do not expose a durable physical table incarnation")
 	}
@@ -1143,7 +1151,7 @@ func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 		database = d.database
 	}
 	var engine string
-	err := d.db.QueryRowContext(ctx, `SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?`, database, tableName).Scan(&engine)
+	err := queryer.QueryRowContext(ctx, `SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?`, database, tableName).Scan(&engine)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", false, nil
 	}
@@ -1160,9 +1168,9 @@ func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 	}
 	internalName := database + "/" + tableName
 	var tableID uint64
-	err = d.db.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
-	if err != nil {
-		err = d.db.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_SYS_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
+	err = queryer.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
+	if isMySQLMissingInnoDBDictionaryTableError(err) {
+		err = queryer.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_SYS_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
 	}
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", false, nil
@@ -1171,6 +1179,38 @@ func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 		return "", false, fmt.Errorf("failed to read durable InnoDB table identity for %s: %w", table, err)
 	}
 	return mysqlTableIncarnation(database, tableName, tableID), true, nil
+}
+
+func (d *MySQLDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
+	if expectedIncarnation == "" {
+		return fmt.Errorf("cannot conditionally truncate MySQL table %q without a bound incarnation", table)
+	}
+	if d.isVitess {
+		return errors.New("vitess and planetscale do not expose a durable physical table incarnation")
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT 1 FROM %s LIMIT 1 FOR UPDATE", quoteTable(table)))
+	if err != nil {
+		return fmt.Errorf("failed to lock MySQL CDC target %s: %w", table, err)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	current, exists, err := d.mysqlTargetIncarnation(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expectedIncarnation {
+		return fmt.Errorf("MySQL CDC target %q physical incarnation changed", table)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", quoteTable(table))); err != nil {
+		return fmt.Errorf("failed to truncate MySQL CDC target %s: %w", table, err)
+	}
+	return tx.Commit()
 }
 
 func mysqlTableIncarnation(database, table string, tableID uint64) string {
@@ -1182,6 +1222,44 @@ func (d *MySQLDestination) ValidateManagedCDCState() error {
 		return errors.New("vitess and planetscale do not expose a durable physical table incarnation")
 	}
 	return nil
+}
+
+func (d *MySQLDestination) ValidateManagedCDCTarget(ctx context.Context, table string) error {
+	if err := d.ValidateManagedCDCState(); err != nil {
+		return err
+	}
+	if d.db == nil {
+		return errors.New("MySQL destination is not connected")
+	}
+	_, _, err := d.mysqlTargetIncarnation(ctx, d.db, table)
+	if err == nil {
+		return nil
+	}
+	if isMySQLInnoDBDictionaryPermissionError(err) {
+		return fmt.Errorf("managed CDC cannot read durable InnoDB table identity; grant the global MySQL PROCESS privilege if this server requires it: %w", err)
+	}
+	return err
+}
+
+func isMySQLMissingInnoDBDictionaryTableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var myErr *mysqldriver.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == 1109 || myErr.Number == 1146
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unknown table") || strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "does not exist")
+}
+
+func isMySQLInnoDBDictionaryPermissionError(err error) bool {
+	var myErr *mysqldriver.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == 1044 || myErr.Number == 1142 || myErr.Number == 1227
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "access denied") || strings.Contains(msg, "command denied") || strings.Contains(msg, "process privilege")
 }
 
 func canonicalMySQLTarget(database, table string, lowerCaseTableNames int) string {
@@ -1240,16 +1318,16 @@ func (d *MySQLDestination) DeleteCDCStateEvents(ctx context.Context, table, conn
 	return err
 }
 
-// isMySQLMissingTableError reports whether err means the queried table does not
-// exist. Plain MySQL raises errno 1146 ("... doesn't exist"); vtgate raises
-// errno 1146 or 1051 with "table ... does not exist" (VT05004/VT05005).
+// isMySQLMissingTableError reports whether the queried table or its database
+// does not exist. Managed CDC reads its state before PrepareTable creates the
+// _bruin_staging database on a first run.
 func isMySQLMissingTableError(err error) bool {
 	var myErr *mysqldriver.MySQLError
 	if errors.As(err, &myErr) {
-		return myErr.Number == 1146 || myErr.Number == 1051
+		return myErr.Number == 1146 || myErr.Number == 1051 || myErr.Number == 1049
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "does not exist")
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "does not exist") || strings.Contains(msg, "unknown database")
 }
 
 func (d *MySQLDestination) GetScheme() string {

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -115,9 +115,151 @@ func TestCDCTruncatePreservesInnoDBPhysicalIdentityWithoutChangingBatchTruncate(
 	}
 }
 
+func TestTruncateCDCTableIfIncarnation(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		currentID  uint64
+		wantErr    string
+		wantDelete bool
+	}{
+		{name: "matching", currentID: 42, wantDelete: true},
+		{name: "recreated", currentID: 43, wantErr: "physical incarnation changed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			assert.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			dest := &MySQLDestination{db: db, database: "app"}
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM `app`.`events` LIMIT 1 FOR UPDATE")).
+				WillReturnRows(sqlmock.NewRows([]string{"1"}))
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+				WithArgs("app", "events").
+				WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+				WithArgs("app/events").
+				WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(tc.currentID))
+			if tc.wantDelete {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `app`.`events`")).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectCommit()
+			} else {
+				mock.ExpectRollback()
+			}
+
+			err = dest.TruncateCDCTableIfIncarnation(t.Context(), "app.events", mysqlTableIncarnation("app", "events", 42))
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func TestVitessManagedCDCStateFailsWithoutDurableIncarnation(t *testing.T) {
 	dest := NewVitessCompatibleDestination("vitess")
 	assert.ErrorContains(t, dest.ValidateManagedCDCState(), "do not expose a durable physical table incarnation")
+	assert.ErrorContains(t, dest.ValidateManagedCDCTarget(t.Context(), "events"), "do not expose a durable physical table incarnation")
+}
+
+func TestValidateManagedCDCTargetChecksInnoDBDictionaryAccess(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		queryErr error
+		wantErr  string
+	}{
+		{name: "allowed"},
+		{
+			name:     "process privilege missing",
+			queryErr: &mysqldriver.MySQLError{Number: 1227, Message: "Access denied; you need (at least one of) the PROCESS privilege(s) for this operation"},
+			wantErr:  "grant the global MySQL PROCESS privilege if this server requires it",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			assert.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			dest := &MySQLDestination{db: db, database: "app"}
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+				WithArgs("app", "events").
+				WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+			expectation := mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+				WithArgs("app/events")
+			if tc.queryErr != nil {
+				expectation.WillReturnError(tc.queryErr)
+			} else {
+				expectation.WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(42)))
+			}
+
+			err = dest.ValidateManagedCDCTarget(t.Context(), "app.events")
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestValidateManagedCDCTargetFallsBackToMariaDBDictionary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnError(&mysqldriver.MySQLError{Number: 1109, Message: "Unknown table 'INNODB_TABLES' in information_schema"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_SYS_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(42)))
+
+	assert.NoError(t, dest.ValidateManagedCDCTarget(t.Context(), "app.events"))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCDCTargetIncarnationDoesNotHideDictionaryPermissionErrorBehindLegacyFallback(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	denied := &mysqldriver.MySQLError{Number: 1227, Message: "PROCESS privilege required"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnError(denied)
+
+	_, _, err = dest.CDCTargetIncarnation(t.Context(), "events")
+	assert.ErrorIs(t, err, denied)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCDCTargetIncarnationFallsBackWhenCurrentDictionaryTableIsUnavailable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnError(&mysqldriver.MySQLError{Number: 1109, Message: "Unknown table 'INNODB_TABLES' in information_schema"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_SYS_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(42)))
+
+	got, exists, err := dest.CDCTargetIncarnation(t.Context(), "events")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, mysqlTableIncarnation("app", "events", 42), got)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestCDCTargetClaimTableUsesBinaryCollation(t *testing.T) {
@@ -530,20 +672,18 @@ func TestIsLoadDataLocalDisabledError(t *testing.T) {
 	}
 }
 
-// isMySQLMissingTableError must recognize both plain MySQL ("doesn't exist",
-// errno 1146) and vtgate (VT05004/VT05005 "does not exist", errno 1146/1051)
-// forms, so a first CDC run against a Vitess/PlanetScale destination is treated
-// as "no cursor yet" rather than an error.
 func TestIsMySQLMissingTableError(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
 		want bool
 	}{
+		{"mysql unknown database", &mysqldriver.MySQLError{Number: 1049, Message: "Unknown database '_bruin_staging'"}, true},
 		{"mysql errno 1146", &mysqldriver.MySQLError{Number: 1146, Message: "Table 'db.t' doesn't exist"}, true},
 		{"vtgate errno 1051", &mysqldriver.MySQLError{Number: 1051, Message: "VT05004: table 't' does not exist"}, true},
 		{"vtgate text without errno", errors.New("target: db.0.primary: vttablet: table 't' does not exist in keyspace 'db'"), true},
 		{"plain mysql text without errno", errors.New("Error 1146: Table 'db.t' doesn't exist"), true},
+		{"unknown database text without errno", errors.New("Unknown database '_bruin_staging'"), true},
 		{"other mysql error", &mysqldriver.MySQLError{Number: 1045, Message: "Access denied"}, false},
 		{"unrelated error", errors.New("connection refused"), false},
 	}

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -816,9 +816,17 @@ func (d *OracleDestination) ClaimCDCTarget(ctx context.Context, claimTable strin
 }
 
 func (d *OracleDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	return d.oracleTargetIncarnation(ctx, d.db, table)
+}
+
+type oracleIncarnationQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (d *OracleDestination) oracleTargetIncarnation(ctx context.Context, queryer oracleIncarnationQueryer, table string) (string, bool, error) {
 	owner, tableName := d.effectiveSchemaTable(table)
 	var objectID int64
-	err := d.db.QueryRowContext(ctx, `SELECT OBJECT_ID FROM ALL_OBJECTS
+	err := queryer.QueryRowContext(ctx, `SELECT OBJECT_ID FROM ALL_OBJECTS
 		WHERE OWNER = :1 AND OBJECT_NAME = :2 AND OBJECT_TYPE = 'TABLE'`, owner, tableName).Scan(&objectID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", false, nil
@@ -827,6 +835,32 @@ func (d *OracleDestination) CDCTargetIncarnation(ctx context.Context, table stri
 		return "", false, fmt.Errorf("failed to read Oracle CDC target incarnation for %s: %w", table, err)
 	}
 	return destination.CDCTargetKey(owner, strconv.FormatInt(objectID, 10)), true, nil
+}
+
+func (d *OracleDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
+	if expectedIncarnation == "" {
+		return fmt.Errorf("cannot conditionally truncate Oracle table %q without a bound incarnation", table)
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	quotedTable := quoteTable(table)
+	if _, err := tx.ExecContext(ctx, "LOCK TABLE "+quotedTable+" IN EXCLUSIVE MODE"); err != nil {
+		return fmt.Errorf("failed to lock Oracle CDC target %s: %w", table, err)
+	}
+	current, exists, err := d.oracleTargetIncarnation(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expectedIncarnation {
+		return fmt.Errorf("oracle CDC target %q physical incarnation changed", table)
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM "+quotedTable); err != nil {
+		return fmt.Errorf("failed to truncate Oracle CDC target %s: %w", table, err)
+	}
+	return tx.Commit()
 }
 
 func (d *OracleDestination) canonicalCDCTarget(table string) string {

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -196,7 +196,7 @@ func TestOracleStagingNamesEncodeQuotedTableDots(t *testing.T) {
 			require.Len(t, parts, 2)
 			require.Equal(t, `"appUser"`, parts[0])
 			require.NotContains(t, parts[1], ".")
-			require.Contains(t, quoteTable(staging), `"appUser"."_INGESTR_HEX_`)
+			require.Contains(t, quoteTable(staging), `"appUser"."INGESTR_HEX_`)
 		})
 	}
 }
@@ -233,6 +233,43 @@ func TestCDCTargetIncarnationChangesWithOracleObjectIdentity(t *testing.T) {
 	require.True(t, exists)
 	require.NotEqual(t, first, second)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTruncateCDCTableIfIncarnation(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		objectID   int64
+		wantErr    string
+		wantCommit bool
+	}{
+		{name: "matching", objectID: 10, wantCommit: true},
+		{name: "recreated", objectID: 11, wantErr: "physical incarnation changed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			dest := &OracleDestination{db: db, currentUser: "APP"}
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(`LOCK TABLE "APP"."EVENTS" IN EXCLUSIVE MODE`)).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectQuery(`SELECT OBJECT_ID FROM ALL_OBJECTS`).WithArgs("APP", "EVENTS").
+				WillReturnRows(sqlmock.NewRows([]string{"object_id"}).AddRow(tc.objectID))
+			if tc.wantCommit {
+				mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "APP"."EVENTS"`)).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectCommit()
+			} else {
+				mock.ExpectRollback()
+			}
+			err = dest.TruncateCDCTableIfIncarnation(t.Context(), "APP.EVENTS", destination.CDCTargetKey("APP", "10"))
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
 }
 
 func TestGetTableSchemaPreservesQuotedCaseDistinctPrimaryKeyIdentity(t *testing.T) {

--- a/pkg/destination/postgres/evolve.go
+++ b/pkg/destination/postgres/evolve.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -17,6 +18,50 @@ func (d *PostgresDestination) ApplySchemaEvolution(ctx context.Context, table st
 		d.pool.Reset()
 	}
 	return warnings, err
+}
+
+func (d *PostgresDestination) ApplySchemaEvolutionIfIncarnation(
+	ctx context.Context,
+	table string,
+	comparison *schemaevolution.SchemaComparison,
+	expectedIncarnation string,
+) ([]string, error) {
+	if expectedIncarnation == "" {
+		return nil, fmt.Errorf("cannot conditionally evolve PostgreSQL table %q without a bound incarnation", table)
+	}
+	statements, warnings := destination.BuildMigration(&Dialect{}, table, comparison)
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return warnings, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	schemaName, tableName, err := d.resolveSchemaTable(ctx, tx, table)
+	if err != nil {
+		return warnings, err
+	}
+	tableRef := quotePostgresTable(schemaName, tableName)
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+tableRef+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+		return warnings, fmt.Errorf("failed to lock managed CDC target %s before schema evolution: %w", table, err)
+	}
+	current, exists, err := d.postgresTargetIncarnation(ctx, tx, tableRef)
+	if err != nil {
+		return warnings, err
+	}
+	if !exists || current != expectedIncarnation {
+		return warnings, fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed before schema evolution", table)
+	}
+	for _, statement := range statements {
+		if _, err := tx.Exec(ctx, statement); err != nil {
+			return warnings, fmt.Errorf("apply schema evolution: %s: %w", statement, err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return warnings, err
+	}
+	if comparison != nil && comparison.HasChanges {
+		d.pool.Reset()
+	}
+	return warnings, nil
 }
 
 // SupportsColumnTypeChanges reports whether this destination can change a column's type.

--- a/pkg/destination/postgres/late_target_integration_test.go
+++ b/pkg/destination/postgres/late_target_integration_test.go
@@ -8,8 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -72,6 +77,77 @@ func TestLateCDCTargetAtomicCreateAndConditionalTruncate(t *testing.T) {
 	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.events`).Scan(&count))
 	require.Equal(t, 1, count)
 
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE public.write_fence (id bigint)`))
+	writeIncarnation, exists, err := dest.CDCTargetIncarnation(ctx, "public.write_fence")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.WriteParallel(ctx, postgresInt64RecordBatches(2, 3), destination.WriteOptions{
+		Table:                  "public.write_fence",
+		Schema:                 opts.Schema,
+		Parallelism:            1,
+		CDCExpectedIncarnation: writeIncarnation,
+	}))
+	var values []int64
+	rows, err := dest.pool.Query(ctx, `SELECT id FROM public.write_fence ORDER BY id`)
+	require.NoError(t, err)
+	for rows.Next() {
+		var value int64
+		require.NoError(t, rows.Scan(&value))
+		values = append(values, value)
+	}
+	require.NoError(t, rows.Err())
+	rows.Close()
+	require.Equal(t, []int64{2, 3}, values)
+	require.NoError(t, dest.Exec(ctx, `DROP TABLE public.write_fence; CREATE TABLE public.write_fence (id bigint); INSERT INTO public.write_fence VALUES (7)`))
+	err = dest.WriteParallel(ctx, postgresInt64RecordBatches(9), destination.WriteOptions{
+		Table:                  "public.write_fence",
+		Schema:                 opts.Schema,
+		Parallelism:            1,
+		CDCExpectedIncarnation: writeIncarnation,
+	})
+	require.ErrorContains(t, err, "physical incarnation changed before write")
+	values = nil
+	rows, err = dest.pool.Query(ctx, `SELECT id FROM public.write_fence ORDER BY id`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var value int64
+		require.NoError(t, rows.Scan(&value))
+		values = append(values, value)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []int64{7}, values)
+
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE public.evolve_fence (id bigint)`))
+	evolutionIncarnation, exists, err := dest.CDCTargetIncarnation(ctx, "public.evolve_fence")
+	require.NoError(t, err)
+	require.True(t, exists)
+	_, err = dest.ApplySchemaEvolutionIfIncarnation(
+		ctx,
+		"public.evolve_fence",
+		postgresAddColumnComparison("fresh_column"),
+		evolutionIncarnation,
+	)
+	require.NoError(t, err)
+	require.NoError(t, dest.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = 'evolve_fence' AND column_name = 'fresh_column'
+	`).Scan(&count))
+	require.Equal(t, 1, count)
+	require.NoError(t, dest.Exec(ctx, `DROP TABLE public.evolve_fence; CREATE TABLE public.evolve_fence (id bigint)`))
+	_, err = dest.ApplySchemaEvolutionIfIncarnation(
+		ctx,
+		"public.evolve_fence",
+		postgresAddColumnComparison("replacement_column"),
+		evolutionIncarnation,
+	)
+	require.ErrorContains(t, err, "physical incarnation changed before schema evolution")
+	require.NoError(t, dest.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = 'evolve_fence' AND column_name = 'replacement_column'
+	`).Scan(&count))
+	require.Zero(t, count)
+
 	require.NoError(t, dest.Exec(ctx, `CREATE TABLE public.external_events (id bigint)`))
 	claim.DestinationTable = "public.external_events"
 	claim.SourceTable = "public.external_events"
@@ -79,4 +155,34 @@ func TestLateCDCTargetAtomicCreateAndConditionalTruncate(t *testing.T) {
 	require.Error(t, err)
 	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT COUNT(*) FROM _bruin_staging.cdc_targets WHERE destination_table = $1`, destination.CDCTargetKey("public", "external_events")).Scan(&count))
 	require.Zero(t, count)
+}
+
+func postgresInt64RecordBatches(values ...int64) <-chan source.RecordBatchResult {
+	records := make(chan source.RecordBatchResult, len(values))
+	for _, value := range values {
+		builder := array.NewInt64Builder(memory.DefaultAllocator)
+		builder.Append(value)
+		column := builder.NewArray()
+		builder.Release()
+		record := array.NewRecordBatch(
+			arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil),
+			[]arrow.Array{column},
+			1,
+		)
+		column.Release()
+		records <- source.RecordBatchResult{Batch: record}
+	}
+	close(records)
+	return records
+}
+
+func postgresAddColumnComparison(name string) *schemaevolution.SchemaComparison {
+	return &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type:       schemaevolution.ChangeAddColumn,
+			ColumnName: name,
+			NewColumn:  schema.Column{Name: name, DataType: schema.TypeString, Nullable: true},
+		}},
+	}
 }

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +30,8 @@ type PostgresDestination struct {
 	pool *pgxpool.Pool
 	uri  string
 }
+
+const postgresOwnedTableCommentPrefix = "ingestr:ownership:"
 
 type postgresStatementDescriber interface {
 	Prepare(context.Context, string, string, []uint32) (*pgconn.StatementDescription, error)
@@ -104,6 +107,9 @@ func (d *PostgresDestination) PrepareTable(ctx context.Context, opts destination
 	if err := d.ensureSchemaExists(ctx, schemaName); err != nil {
 		return fmt.Errorf("failed to ensure schema exists: %w", err)
 	}
+	if opts.OwnershipToken != "" {
+		return d.prepareOwnedTable(ctx, resolvedTable, opts)
+	}
 
 	if opts.DropFirst {
 		startDrop := time.Now()
@@ -136,6 +142,40 @@ func (d *PostgresDestination) PrepareTable(ctx context.Context, opts destination
 	}
 
 	return nil
+}
+
+func (d *PostgresDestination) prepareOwnedTable(ctx context.Context, table string, opts destination.PrepareOptions) error {
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin owned table creation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	createSQL := strings.Replace(
+		buildCreateTableSQL(destination.QuoteTableName(table), opts.Schema.Columns, opts.PrimaryKeys),
+		"CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1,
+	)
+	if _, err := tx.Exec(ctx, createSQL); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && (pgErr.Code == "42P07" || pgErr.Code == "23505") {
+			return fmt.Errorf("destination table %s appeared concurrently while preparing an owned target: %w", table, err)
+		}
+		config.LogFailedQuery(createSQL, err)
+		return fmt.Errorf("failed to create owned table: %w", err)
+	}
+
+	commentSQL := fmt.Sprintf("COMMENT ON TABLE %s IS '%s'", destination.QuoteTableName(table), postgresOwnedTableComment(opts.OwnershipToken))
+	if _, err := tx.Exec(ctx, commentSQL); err != nil {
+		return fmt.Errorf("failed to mark owned table: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit owned table creation: %w", err)
+	}
+	return nil
+}
+
+func postgresOwnedTableComment(token string) string {
+	return fmt.Sprintf("%s%x", postgresOwnedTableCommentPrefix, sha256.Sum256([]byte(token)))
 }
 
 func (d *PostgresDestination) ensurePrimaryKey(ctx context.Context, table string, primaryKeys []string) error {
@@ -363,12 +403,28 @@ func (d *PostgresDestination) copyRecord(ctx context.Context, record arrow.Recor
 	}
 	defer conn.Release()
 	pgxConn := conn.Conn()
-
-	plan, err := copyPlans.get(ctx, pgxConn.PgConn(), record, opts.Table)
+	tableIdent, tx, err := d.beginPostgresWrite(ctx, pgxConn, opts)
 	if err != nil {
 		return 0, err
 	}
-	return copyPostgresRecord(ctx, pgxConn, record, opts.Schema, plan)
+	if tx != nil {
+		defer func() { _ = tx.Rollback(ctx) }()
+	}
+
+	plan, err := copyPlans.getForIdentifier(ctx, pgxConn.PgConn(), record, tableIdent)
+	if err != nil {
+		return 0, err
+	}
+	count, err := copyPostgresRecord(ctx, pgxConn, tx, record, opts.Schema, plan)
+	if err != nil {
+		return 0, err
+	}
+	if tx != nil {
+		if err := tx.Commit(ctx); err != nil {
+			return 0, err
+		}
+	}
+	return count, nil
 }
 
 func (d *PostgresDestination) copyRecordGroup(ctx context.Context, record arrow.RecordBatch, records <-chan source.RecordBatchResult, opts destination.WriteOptions, copyPlans postgresCopyPlanCache) (int64, int, *source.RecordBatchResult, error) {
@@ -380,15 +436,32 @@ func (d *PostgresDestination) copyRecordGroup(ctx context.Context, record arrow.
 	defer conn.Release()
 	pgxConn := conn.Conn()
 
-	plan, err := copyPlans.get(ctx, pgxConn.PgConn(), record, opts.Table)
+	tableIdent, tx, err := d.beginPostgresWrite(ctx, pgxConn, opts)
+	if err != nil {
+		record.Release()
+		return 0, 0, nil, err
+	}
+	if tx != nil {
+		defer func() { _ = tx.Rollback(ctx) }()
+	}
+
+	plan, err := copyPlans.getForIdentifier(ctx, pgxConn.PgConn(), record, tableIdent)
 	if err != nil {
 		record.Release()
 		return 0, 0, nil, err
 	}
 	if !recordSupportsDirectPostgresCopy(record, plan.oids) {
 		defer record.Release()
-		rows, err := copyPostgresRecord(ctx, pgxConn, record, opts.Schema, plan)
-		return rows, 1, nil, err
+		rows, err := copyPostgresRecord(ctx, pgxConn, tx, record, opts.Schema, plan)
+		if err != nil {
+			return 0, 1, nil, err
+		}
+		if tx != nil {
+			if err := tx.Commit(ctx); err != nil {
+				return 0, 1, nil, err
+			}
+		}
+		return rows, 1, nil, nil
 	}
 
 	stream, err := newPostgresRecordCopyStream(ctx, records, record, opts.Schema, pgxConn.TypeMap(), plan.oids)
@@ -397,20 +470,64 @@ func (d *PostgresDestination) copyRecordGroup(ctx context.Context, record arrow.
 	}
 	defer stream.Close()
 	tag, err := pgxConn.PgConn().CopyFrom(ctx, stream, plan.copySQL)
-	return tag.RowsAffected(), stream.Batches(), stream.Pending(), err
+	if err != nil {
+		return 0, stream.Batches(), stream.Pending(), err
+	}
+	if tx != nil {
+		if err := tx.Commit(ctx); err != nil {
+			return 0, stream.Batches(), stream.Pending(), err
+		}
+	}
+	return tag.RowsAffected(), stream.Batches(), stream.Pending(), nil
 }
 
-func copyPostgresRecord(ctx context.Context, pgxConn *pgx.Conn, record arrow.RecordBatch, tableSchema *schema.TableSchema, plan *postgresCopyPlan) (int64, error) {
+func (d *PostgresDestination) beginPostgresWrite(ctx context.Context, pgxConn *pgx.Conn, opts destination.WriteOptions) (pgx.Identifier, pgx.Tx, error) {
+	tableIdent := parseTableIdentifier(opts.Table)
+	if opts.CDCExpectedIncarnation == "" {
+		return tableIdent, nil, nil
+	}
+
+	tx, err := pgxConn.Begin(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	fail := func(err error) (pgx.Identifier, pgx.Tx, error) {
+		_ = tx.Rollback(ctx)
+		return nil, nil, err
+	}
+	schemaName, tableName, err := d.resolveSchemaTable(ctx, tx, opts.Table)
+	if err != nil {
+		return fail(err)
+	}
+	targetRef := quotePostgresTable(schemaName, tableName)
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+targetRef+" IN ROW EXCLUSIVE MODE"); err != nil {
+		return fail(fmt.Errorf("failed to lock managed CDC target %s before write: %w", opts.Table, err))
+	}
+	current, exists, err := d.postgresTargetIncarnation(ctx, tx, targetRef)
+	if err != nil {
+		return fail(err)
+	}
+	if !exists || current != opts.CDCExpectedIncarnation {
+		return fail(fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed before write", opts.Table))
+	}
+	return pgx.Identifier{schemaName, tableName}, tx, nil
+}
+
+func copyPostgresRecord(ctx context.Context, pgxConn *pgx.Conn, tx pgx.Tx, record arrow.RecordBatch, tableSchema *schema.TableSchema, plan *postgresCopyPlan) (int64, error) {
 	reader, ok := newArrowCopyReader(record, tableSchema, pgxConn.TypeMap(), plan.oids)
 	if !ok {
 		getters := postgresValueGetters(record, tableSchema)
 		values := make([]any, record.NumCols())
-		return pgxConn.CopyFrom(ctx, plan.tableIdent, plan.columns, pgx.CopyFromSlice(int(record.NumRows()), func(row int) ([]any, error) {
+		source := pgx.CopyFromSlice(int(record.NumRows()), func(row int) ([]any, error) {
 			for column := range values {
 				values[column] = getters[column](row)
 			}
 			return values, nil
-		}))
+		})
+		if tx != nil {
+			return tx.CopyFrom(ctx, plan.tableIdent, plan.columns, source)
+		}
+		return pgxConn.CopyFrom(ctx, plan.tableIdent, plan.columns, source)
 	}
 
 	tag, err := pgxConn.PgConn().CopyFrom(ctx, reader, plan.copySQL)
@@ -421,6 +538,10 @@ func copyPostgresRecord(ctx context.Context, pgxConn *pgx.Conn, record arrow.Rec
 }
 
 func (c postgresCopyPlanCache) get(ctx context.Context, describer postgresStatementDescriber, record arrow.RecordBatch, table string) (*postgresCopyPlan, error) {
+	return c.getForIdentifier(ctx, describer, record, parseTableIdentifier(table))
+}
+
+func (c postgresCopyPlanCache) getForIdentifier(ctx context.Context, describer postgresStatementDescriber, record arrow.RecordBatch, tableIdent pgx.Identifier) (*postgresCopyPlan, error) {
 	if plan := c[record.Schema()]; plan != nil {
 		return plan, nil
 	}
@@ -432,7 +553,6 @@ func (c postgresCopyPlanCache) get(ctx context.Context, describer postgresStatem
 		quotedColumns[i] = destination.QuoteIdentifier(columns[i])
 	}
 
-	tableIdent := parseTableIdentifier(table)
 	selectSQL := fmt.Sprintf("select %s from %s", strings.Join(quotedColumns, ", "), tableIdent.Sanitize())
 	description, err := describePostgresStatement(ctx, describer, selectSQL)
 	if err != nil {
@@ -676,6 +796,35 @@ func (d *PostgresDestination) SwapTable(ctx context.Context, opts destination.Sw
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	if opts.CDCExpectedIncarnation != "" {
+		if opts.CDCExpectedStagingIncarnation == "" {
+			return fmt.Errorf("cannot conditionally swap managed CDC target %s without a bound staging incarnation", targetTable)
+		}
+		lockRefs := []string{targetRef, stagingRef}
+		slices.Sort(lockRefs)
+		if _, err := tx.Exec(ctx, "LOCK TABLE "+strings.Join(lockRefs, ", ")+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+			return fmt.Errorf("failed to lock managed CDC target and staging tables before swap: %w", err)
+		}
+		for _, expected := range []struct {
+			table       string
+			ref         string
+			incarnation string
+			role        string
+		}{
+			{table: targetTable, ref: targetRef, incarnation: opts.CDCExpectedIncarnation, role: "target"},
+			{table: stagingTable, ref: stagingRef, incarnation: opts.CDCExpectedStagingIncarnation, role: "staging table"},
+		} {
+			current, exists, err := d.postgresTargetIncarnation(ctx, tx, expected.ref)
+			if err != nil {
+				return err
+			}
+			if !exists || current != expected.incarnation {
+				return fmt.Errorf("PostgreSQL CDC %s %q physical incarnation changed before swap", expected.role, expected.table)
+			}
+		}
+	} else if opts.CDCExpectedStagingIncarnation != "" {
+		return fmt.Errorf("cannot conditionally swap staging table without a bound target incarnation")
+	}
 
 	// Postgres' ALTER TABLE … RENAME TO … is same-schema only. If staging lives in a
 	// different schema (the new _bruin_staging design), move it into the target's
@@ -830,6 +979,23 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
+	if opts.CDCExpectedIncarnation != "" {
+		targetSchema, targetName, err := d.resolveSchemaTable(ctx, tx, opts.TargetTable)
+		if err != nil {
+			return err
+		}
+		quotedTargetTable = quotePostgresTable(targetSchema, targetName)
+		if _, err := tx.Exec(ctx, "LOCK TABLE "+quotedTargetTable+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+			return fmt.Errorf("failed to lock managed CDC target %s before merge: %w", opts.TargetTable, err)
+		}
+		current, exists, err := d.postgresTargetIncarnation(ctx, tx, quotedTargetTable)
+		if err != nil {
+			return err
+		}
+		if !exists || current != opts.CDCExpectedIncarnation {
+			return fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed before merge", opts.TargetTable)
+		}
+	}
 
 	if hasCDCDeleted {
 		// CDC mode: dedupe within the staging table and apply changes deterministically.
@@ -1112,6 +1278,56 @@ func (d *PostgresDestination) DropTable(ctx context.Context, table string) error
 	return nil
 }
 
+func (d *PostgresDestination) DropTableIfOwned(ctx context.Context, table, ownershipToken string) error {
+	if ownershipToken == "" {
+		return fmt.Errorf("cannot conditionally drop PostgreSQL table %q without an ownership token", table)
+	}
+	if err := tablename.TwoLevel("postgres").CheckName(table); err != nil {
+		return err
+	}
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin owned table cleanup: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	schemaName, tableName, err := d.resolveSchemaTable(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	qualifiedTable := quotePostgresTable(schemaName, tableName)
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+qualifiedTable+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+			return nil
+		}
+		return fmt.Errorf("failed to lock owned table %s for cleanup: %w", table, err)
+	}
+
+	var comment *string
+	if err := tx.QueryRow(ctx, `
+		SELECT obj_description(c.oid, 'pg_class')
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1 AND c.relname = $2
+	`, schemaName, tableName).Scan(&comment); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("failed to inspect PostgreSQL table ownership: %w", err)
+	}
+	if comment == nil || *comment != postgresOwnedTableComment(ownershipToken) {
+		return nil
+	}
+	if _, err := tx.Exec(ctx, "DROP TABLE "+qualifiedTable); err != nil {
+		return fmt.Errorf("failed to drop owned PostgreSQL table %s: %w", table, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit owned PostgreSQL table cleanup: %w", err)
+	}
+	return nil
+}
+
 // TruncateTable empties a table while preserving its definition and dependents.
 func (d *PostgresDestination) TruncateTable(ctx context.Context, table string) error {
 	truncateSQL := fmt.Sprintf("TRUNCATE TABLE %s", destination.QuoteTableName(table))
@@ -1146,6 +1362,14 @@ func (d *PostgresDestination) SupportsSCD2Strategy() bool { return true }
 
 // SupportsAtomicSwap returns true as PostgreSQL supports atomic table renames.
 func (d *PostgresDestination) SupportsAtomicSwap() bool { return true }
+
+func (d *PostgresDestination) SupportsCDCConditionalSwap() bool {
+	return true
+}
+
+func (d *PostgresDestination) SupportsManagedCDCWriteFencing() bool {
+	return true
+}
 
 // GetScheme returns the primary URI scheme for PostgreSQL.
 func (d *PostgresDestination) GetScheme() string { return "postgres" }
@@ -1214,7 +1438,7 @@ func (d *PostgresDestination) postgresTargetIncarnation(ctx context.Context, que
 	if err != nil {
 		return "", false, err
 	}
-	resolvedTable := destination.QuoteTableName(schemaName + "." + tableName)
+	resolvedTable := quotePostgresTable(schemaName, tableName)
 	var databaseOID, relationOID, relationKind string
 	err = queryer.QueryRow(ctx, `
 		SELECT d.oid::text, c.oid::text, c.relkind::text
@@ -1276,13 +1500,13 @@ func (d *PostgresDestination) ClaimAndPrepareEmptyCDCTarget(
 		return "", fmt.Errorf("destination table %q is already claimed by CDC connector %q", canonicalTarget, owner)
 	}
 	createSQL := strings.Replace(
-		buildCreateTableSQL(destination.QuoteTableName(schemaName+"."+tableName), opts.Schema.Columns, opts.PrimaryKeys),
+		buildCreateTableSQL(quotePostgresTable(schemaName, tableName), opts.Schema.Columns, opts.PrimaryKeys),
 		"CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1,
 	)
 	if _, err := tx.Exec(ctx, createSQL); err != nil {
 		return "", fmt.Errorf("failed to exclusively create CDC target: %w", err)
 	}
-	incarnation, exists, err := d.postgresTargetIncarnation(ctx, tx, schemaName+"."+tableName)
+	incarnation, exists, err := d.postgresTargetIncarnation(ctx, tx, quotePostgresTable(schemaName, tableName))
 	if err != nil {
 		return "", err
 	}
@@ -1305,18 +1529,18 @@ func (d *PostgresDestination) TruncateCDCTableIfIncarnation(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	resolved := schemaName + "." + tableName
-	if _, err := tx.Exec(ctx, "LOCK TABLE "+destination.QuoteTableName(resolved)+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+	resolvedRef := quotePostgresTable(schemaName, tableName)
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+resolvedRef+" IN ACCESS EXCLUSIVE MODE"); err != nil {
 		return err
 	}
-	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolved)
+	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolvedRef)
 	if err != nil {
 		return err
 	}
 	if !exists || current != expectedIncarnation {
 		return fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed", table)
 	}
-	if _, err := tx.Exec(ctx, "TRUNCATE TABLE "+destination.QuoteTableName(resolved)); err != nil {
+	if _, err := tx.Exec(ctx, "TRUNCATE TABLE "+resolvedRef); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/pkg/destination/postgres/swap_integration_test.go
+++ b/pkg/destination/postgres/swap_integration_test.go
@@ -65,4 +65,81 @@ func TestSwapTablePreservesQuotedDottedTargetBoundary(t *testing.T) {
 	require.Equal(t, int64(99), sentinelID)
 	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'order.events_old_%'`).Scan(&oldCount))
 	require.Zero(t, oldCount)
+
+	expected, exists, err := dest.CDCTargetIncarnation(ctx, `"public"."order.events"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.Exec(ctx, `
+		DROP TABLE "public"."order.events";
+		CREATE TABLE "public"."order.events" (id bigint);
+		INSERT INTO "public"."order.events" VALUES (3);
+		CREATE TABLE "public"."stale_swap_staging" (id bigint);
+		INSERT INTO "public"."stale_swap_staging" VALUES (4);
+	`))
+	expectedStaging, exists, err := dest.CDCTargetIncarnation(ctx, `"public"."stale_swap_staging"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	err = dest.SwapTable(ctx, destination.SwapOptions{
+		StagingTable:                  `"public"."stale_swap_staging"`,
+		TargetTable:                   `"public"."order.events"`,
+		CDCExpectedIncarnation:        expected,
+		CDCExpectedStagingIncarnation: expectedStaging,
+	})
+	require.ErrorContains(t, err, "physical incarnation changed before swap")
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id FROM "public"."order.events"`).Scan(&targetID))
+	require.Equal(t, int64(3), targetID)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE "public"."swap_target" (id bigint);
+		INSERT INTO "public"."swap_target" VALUES (10);
+		CREATE TABLE "public"."swap_staging" (id bigint);
+		INSERT INTO "public"."swap_staging" VALUES (20);
+	`))
+	expectedTarget, exists, err := dest.CDCTargetIncarnation(ctx, `"public"."swap_target"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	expectedStaging, exists, err = dest.CDCTargetIncarnation(ctx, `"public"."swap_staging"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.Exec(ctx, `
+		DROP TABLE "public"."swap_staging";
+		CREATE TABLE "public"."swap_staging" (id bigint);
+		INSERT INTO "public"."swap_staging" VALUES (30);
+	`))
+	err = dest.SwapTable(ctx, destination.SwapOptions{
+		StagingTable:                  `"public"."swap_staging"`,
+		TargetTable:                   `"public"."swap_target"`,
+		CDCExpectedIncarnation:        expectedTarget,
+		CDCExpectedStagingIncarnation: expectedStaging,
+	})
+	require.ErrorContains(t, err, "staging table")
+	require.ErrorContains(t, err, "physical incarnation changed before swap")
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id FROM "public"."swap_target"`).Scan(&targetID))
+	require.Equal(t, int64(10), targetID)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE "public"."merge_target" (id bigint PRIMARY KEY, value text);
+		INSERT INTO "public"."merge_target" VALUES (1, 'original');
+		CREATE TABLE "public"."merge_staging" (id bigint, value text);
+		INSERT INTO "public"."merge_staging" VALUES (1, 'ingestr');
+	`))
+	expectedTarget, exists, err = dest.CDCTargetIncarnation(ctx, `"public"."merge_target"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.Exec(ctx, `
+		DROP TABLE "public"."merge_target";
+		CREATE TABLE "public"."merge_target" (id bigint PRIMARY KEY, value text);
+		INSERT INTO "public"."merge_target" VALUES (1, 'external');
+	`))
+	err = dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:           `"public"."merge_staging"`,
+		TargetTable:            `"public"."merge_target"`,
+		PrimaryKeys:            []string{"id"},
+		Columns:                []string{"id", "value"},
+		CDCExpectedIncarnation: expectedTarget,
+	})
+	require.ErrorContains(t, err, "physical incarnation changed before merge")
+	var value string
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT value FROM "public"."merge_target" WHERE id = 1`).Scan(&value))
+	require.Equal(t, "external", value)
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2571,6 +2571,15 @@ func validateDestinationManagedCDCState(dest destination.Destination) error {
 	if _, ok := dest.(destination.CDCTargetIncarnationProvider); !ok {
 		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: destination-table incarnation checks are not supported", dest.GetScheme())
 	}
+	if validator, ok := dest.(destination.ManagedCDCStateValidator); ok {
+		if err := validator.ValidateManagedCDCState(); err != nil {
+			return fmt.Errorf("destination scheme %q cannot safely use managed CDC state: %w", dest.GetScheme(), err)
+		}
+	}
+	writeFencer, ok := dest.(destination.ManagedCDCWriteFencer)
+	if !ok || !writeFencer.SupportsManagedCDCWriteFencing() {
+		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: atomic destination write, merge, and swap fencing is not supported", dest.GetScheme())
+	}
 	cdcMerge, ok := dest.(destination.CDCMergeAware)
 	if !ok || !cdcMerge.SupportsCDCMerge() {
 		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: CDC-aware merge is not supported", dest.GetScheme())
@@ -2578,13 +2587,6 @@ func validateDestinationManagedCDCState(dest destination.Destination) error {
 	unchangedCols, ok := dest.(destination.CDCUnchangedColsAware)
 	if !ok || !unchangedCols.SupportsCDCUnchangedCols() {
 		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: preserving unchanged TOAST columns is not supported", dest.GetScheme())
-	}
-	validator, ok := dest.(destination.ManagedCDCStateValidator)
-	if !ok {
-		return nil
-	}
-	if err := validator.ValidateManagedCDCState(); err != nil {
-		return fmt.Errorf("destination scheme %q cannot safely use managed CDC state: %w", dest.GetScheme(), err)
 	}
 	return nil
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	internalregistry "github.com/bruin-data/ingestr/internal/registry"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -469,14 +470,82 @@ func (m *mockManagedCDCStateDestination) SupportsCDCMerge() bool { return true }
 
 func (m *mockManagedCDCStateDestination) SupportsCDCUnchangedCols() bool { return true }
 
+func (m *mockManagedCDCStateDestination) SupportsManagedCDCWriteFencing() bool { return true }
+
+func (m *mockManagedCDCStateDestination) Write(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	return m.WriteParallel(ctx, records, opts)
+}
+
+func (m *mockManagedCDCStateDestination) WriteParallel(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	if err := validateMockManagedCDCIncarnation(opts.Table, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+func (m *mockManagedCDCStateDestination) MergeTable(_ context.Context, opts destination.MergeOptions) error {
+	return validateMockManagedCDCIncarnation(opts.TargetTable, opts.CDCExpectedIncarnation)
+}
+
+func (m *mockManagedCDCStateDestination) SwapTable(_ context.Context, opts destination.SwapOptions) error {
+	if opts.CDCExpectedIncarnation == "" {
+		if opts.CDCExpectedStagingIncarnation != "" {
+			return errors.New("cannot conditionally swap staging table without a bound target incarnation")
+		}
+		return nil
+	}
+	if opts.CDCExpectedStagingIncarnation == "" {
+		return errors.New("cannot conditionally swap a managed CDC target without a bound staging incarnation")
+	}
+	if err := validateMockManagedCDCIncarnation(opts.TargetTable, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	return validateMockManagedCDCIncarnation(opts.StagingTable, opts.CDCExpectedStagingIncarnation)
+}
+
 type mockUnsafeToastCDCStateDestination struct {
+	mockManagedCDCStateDestination
+}
+
+type mockUnsafeDMLFenceCDCStateDestination struct {
 	mockManagedCDCStateDestination
 }
 
 func (m *mockUnsafeToastCDCStateDestination) SupportsCDCUnchangedCols() bool { return false }
 
+func (m *mockUnsafeDMLFenceCDCStateDestination) SupportsManagedCDCWriteFencing() bool {
+	return false
+}
+
 func (m *mockManagedCDCStateDestination) CDCTargetIncarnation(_ context.Context, table string) (string, bool, error) {
-	return "incarnation:" + table, true, nil
+	return mockManagedCDCIncarnation(table), true, nil
+}
+
+func mockManagedCDCIncarnation(table string) string {
+	return "incarnation:" + table
+}
+
+func validateMockManagedCDCIncarnation(table, expected string) error {
+	if expected != "" && expected != mockManagedCDCIncarnation(table) {
+		return fmt.Errorf("managed CDC target %q physical incarnation changed", table)
+	}
+	return nil
 }
 
 type canonicalIdentityDestination struct {
@@ -902,6 +971,10 @@ func (m *mockManagedCDCStateDestination) TruncateTable(_ context.Context, _ stri
 	return nil
 }
 
+func (m *mockManagedCDCStateDestination) TruncateCDCTableIfIncarnation(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (m *mockManagedCDCStateDestination) LoadCDCState(_ context.Context, _, _ string) ([]destination.CDCStateEntry, error) {
 	return nil, nil
 }
@@ -1043,6 +1116,9 @@ func TestValidateDestinationManagedCDCState(t *testing.T) {
 	if err := validateDestinationManagedCDCState(&mockManagedCDCStateDestination{}); err != nil {
 		t.Fatalf("destination without validator was rejected: %v", err)
 	}
+	if err := validateDestinationManagedCDCState(&mockUnsafeDMLFenceCDCStateDestination{}); err == nil || !strings.Contains(err.Error(), "atomic destination write") {
+		t.Fatalf("destination without atomic DML fencing validation error = %v", err)
+	}
 	if err := validateDestinationManagedCDCState(&mockUnsafeToastCDCStateDestination{}); err == nil || !strings.Contains(err.Error(), "unchanged TOAST") {
 		t.Fatalf("destination without unchanged-TOAST merge support validation error = %v", err)
 	}
@@ -1053,6 +1129,51 @@ func TestValidateDestinationManagedCDCState(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "consistency ONE is unsafe") {
 		t.Fatalf("validation error = %v, want consistency rejection", err)
 	}
+	duckLake := duckdb.NewDuckLakeDestination()
+	err = validateDestinationManagedCDCState(duckLake)
+	if err == nil || !strings.Contains(err.Error(), "target incarnation fencing is not supported for DuckLake") {
+		t.Fatalf("DuckLake managed CDC validation error = %v", err)
+	}
+}
+
+func TestMockManagedCDCStateDestinationEnforcesWriteFences(t *testing.T) {
+	dest := &mockManagedCDCStateDestination{}
+	emptyRecords := func() <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult)
+		close(records)
+		return records
+	}
+
+	require.NoError(t, dest.WriteParallel(t.Context(), emptyRecords(), destination.WriteOptions{
+		Table:                  "raw.items",
+		CDCExpectedIncarnation: mockManagedCDCIncarnation("raw.items"),
+	}))
+	require.ErrorContains(t, dest.WriteParallel(t.Context(), emptyRecords(), destination.WriteOptions{
+		Table:                  "raw.items",
+		CDCExpectedIncarnation: "stale",
+	}), "physical incarnation changed")
+
+	require.NoError(t, dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable:            "raw.items",
+		CDCExpectedIncarnation: mockManagedCDCIncarnation("raw.items"),
+	}))
+	require.ErrorContains(t, dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable:            "raw.items",
+		CDCExpectedIncarnation: "stale",
+	}), "physical incarnation changed")
+
+	require.NoError(t, dest.SwapTable(t.Context(), destination.SwapOptions{
+		TargetTable:                   "raw.items",
+		StagingTable:                  "raw.items_staging",
+		CDCExpectedIncarnation:        mockManagedCDCIncarnation("raw.items"),
+		CDCExpectedStagingIncarnation: mockManagedCDCIncarnation("raw.items_staging"),
+	}))
+	require.ErrorContains(t, dest.SwapTable(t.Context(), destination.SwapOptions{
+		TargetTable:                   "raw.items",
+		StagingTable:                  "raw.items_staging",
+		CDCExpectedIncarnation:        mockManagedCDCIncarnation("raw.items"),
+		CDCExpectedStagingIncarnation: "stale",
+	}), "physical incarnation changed")
 }
 
 func TestValidateChangeTrackingDestinationRequiresResumeProvider(t *testing.T) {

--- a/pkg/schemaevolution/evolve.go
+++ b/pkg/schemaevolution/evolve.go
@@ -24,6 +24,18 @@ type SchemaEvolver interface {
 	SupportsColumnTypeChanges() bool
 }
 
+// IncarnationFencedSchemaEvolver applies schema changes only while the
+// destination table still has the expected physical identity. The identity
+// check, table lock, and DDL must share one destination transaction.
+type IncarnationFencedSchemaEvolver interface {
+	ApplySchemaEvolutionIfIncarnation(
+		ctx context.Context,
+		table string,
+		comparison *SchemaComparison,
+		expectedIncarnation string,
+	) ([]string, error)
+}
+
 // ApplicableComparison returns the subset of changes that will actually be
 // reflected in the destination schema given whether the destination supports
 // column type changes. Add/remove/nullability changes always apply; type

--- a/pkg/schemaevolution/plan.go
+++ b/pkg/schemaevolution/plan.go
@@ -17,6 +17,10 @@ type EvolutionPlan struct {
 	// Comparison is the set of schema changes the destination should apply.
 	// It is nil or empty when no migration is required.
 	Comparison *SchemaComparison
+	// TransformComparison retains the logical source-to-destination differences
+	// used by runtime contract transforms, including changes the destination
+	// cannot or must not apply physically.
+	TransformComparison *SchemaComparison
 	// FinalSchema is what the destination table will look like once the
 	// applicable changes have been applied.
 	FinalSchema *schema.TableSchema

--- a/pkg/schemainfer/merge.go
+++ b/pkg/schemainfer/merge.go
@@ -350,6 +350,18 @@ func ValidateSchema(s *schema.TableSchema) error {
 		if col.Name == "" {
 			return fmt.Errorf("column %d has empty name", i)
 		}
+		if col.DataType == schema.TypeDecimal || (col.DataType == schema.TypeArray && col.ArrayType == schema.TypeDecimal) {
+			precision := col.Precision
+			if precision == 0 {
+				precision = 38
+			}
+			if precision < 1 || precision > 38 {
+				return fmt.Errorf("column %q decimal precision %d is invalid: maximum supported precision is 38", col.Name, col.Precision)
+			}
+			if col.Scale < 0 || col.Scale > precision {
+				return fmt.Errorf("column %q decimal scale %d is invalid for precision %d", col.Name, col.Scale, precision)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 	"unsafe"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -13,6 +14,15 @@ import (
 )
 
 const accumulatorTableOverhead = int64(1024)
+
+// These limits are part of the pgcdc-keyless-v1 durable ID contract. The
+// namespace predates keyed append support and is retained for replay
+// compatibility. They must not track decoder tuning constants; changing either
+// requires a new identity version.
+const (
+	keylessDataBatchWindowChanges uint64 = 1024
+	keylessDataBatchWindowBytes   int64  = 8 << 20
+)
 
 var (
 	changeStructBytes = int64(unsafe.Sizeof(Change{}))
@@ -36,16 +46,30 @@ type batchAccumulator struct {
 	totalBytes int64
 	threshold  int
 	byteLimit  int64
+	// blockedKeyless contains tables whose newest transaction sequence window
+	// has not closed yet. Its historical name is retained because the identity
+	// contract originated with keyless CDC.
+	blockedKeyless map[string]bool
+	stableSpills   map[string]*stableWindowSpill
+	stableAll      bool
+}
+
+type stableWindowSpill struct {
+	lsn    pglogrepl.LSN
+	window uint64
+	spool  *changeSpool[Change]
 }
 
 func newBatchAccumulator(threshold int, schemas map[string]*schema.TableSchema) *batchAccumulator {
 	return &batchAccumulator{
-		schemas:   schemas,
-		changes:   make(map[string][]Change),
-		minLSN:    make(map[string]pglogrepl.LSN),
-		bytes:     make(map[string]int64),
-		threshold: threshold,
-		byteLimit: defaultDecoderMemoryBytes,
+		schemas:        schemas,
+		changes:        make(map[string][]Change),
+		minLSN:         make(map[string]pglogrepl.LSN),
+		bytes:          make(map[string]int64),
+		threshold:      threshold,
+		byteLimit:      defaultDecoderMemoryBytes,
+		blockedKeyless: make(map[string]bool),
+		stableSpills:   make(map[string]*stableWindowSpill),
 	}
 }
 
@@ -149,16 +173,110 @@ func (a *batchAccumulator) minPendingLSN() (pglogrepl.LSN, bool) {
 }
 
 func (a *batchAccumulator) discard() {
+	for _, spill := range a.stableSpills {
+		_ = spill.spool.Close()
+	}
 	a.changes = make(map[string][]Change)
 	a.minLSN = make(map[string]pglogrepl.LSN)
 	a.bytes = make(map[string]int64)
 	a.totalBytes = 0
+	a.blockedKeyless = make(map[string]bool)
+	a.stableSpills = make(map[string]*stableWindowSpill)
 }
 
 // tokenFunc computes the CommitToken to attach to a flushed batch. It is
 // evaluated after the flushed table's changes have been removed from the
 // accumulator, so it reflects only data that remains un-emitted.
 type tokenFunc func() any
+
+type keylessBatchWindowState struct {
+	window  uint64
+	changes uint64
+	bytes   int64
+}
+
+func (s *keylessBatchWindowState) assign(change *Change) {
+	size := stableChangeBytes(*change)
+	if s.changes > 0 && (s.changes >= keylessDataBatchWindowChanges || s.bytes+size > keylessDataBatchWindowBytes) {
+		s.window++
+		s.changes = 0
+		s.bytes = 0
+	}
+	change.DataBatchWindow = s.window
+	s.changes++
+	s.bytes += size
+}
+
+func stableChangeBytes(change Change) int64 {
+	size := int64(32 + len(change.Operation))
+	for _, values := range [][]interface{}{change.Values, change.OldValues} {
+		size += 8
+		for _, value := range values {
+			size += stableValueBytes(reflect.ValueOf(value))
+		}
+	}
+	return size
+}
+
+func stableValueBytes(value reflect.Value) int64 {
+	if !value.IsValid() {
+		return 1
+	}
+	if value.Type() == reflect.TypeOf(time.Time{}) {
+		return 16
+	}
+	if value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return 1
+		}
+		return 1 + stableValueBytes(value.Elem())
+	}
+	switch value.Kind() {
+	case reflect.Bool:
+		return 1
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+		return int64(value.Type().Bits() / 8)
+	case reflect.String:
+		return 8 + int64(value.Len())
+	case reflect.Slice, reflect.Array:
+		size := int64(8)
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			return size + int64(value.Len())
+		}
+		for i := 0; i < value.Len(); i++ {
+			size += stableValueBytes(value.Index(i))
+		}
+		return size
+	case reflect.Map:
+		size := int64(8)
+		iter := value.MapRange()
+		for iter.Next() {
+			size += stableValueBytes(iter.Key()) + stableValueBytes(iter.Value())
+		}
+		return size
+	case reflect.Struct:
+		size := int64(8)
+		for i := 0; i < value.NumField(); i++ {
+			size += stableValueBytes(value.Field(i))
+		}
+		return size
+	default:
+		return 8
+	}
+}
+
+func transactionDataBatchID(tableName string, changes []Change) source.DurableID {
+	first := changes[0]
+	return source.DurableID(fmt.Sprintf(
+		"pgcdc-keyless-v1:%d:%s:%s:%d",
+		len(tableName),
+		tableName,
+		FormatLSN(first.LSN),
+		first.DataBatchWindow,
+	))
+}
 
 // flushReady sends merged batches for tables that have accumulated enough rows.
 func (a *batchAccumulator) flushReady(results chan<- source.RecordBatchResult, token tokenFunc) error {
@@ -167,6 +285,9 @@ func (a *batchAccumulator) flushReady(results chan<- source.RecordBatchResult, t
 
 func (a *batchAccumulator) flushReadyContext(ctx context.Context, results chan<- source.RecordBatchResult, token tokenFunc) error {
 	for tableName, changes := range a.changes {
+		if a.blockedKeyless[tableName] {
+			continue
+		}
 		if len(changes) >= a.threshold || lastTruncateIndex(changes) >= 0 {
 			if err := a.flushTableContext(ctx, tableName, results, token); err != nil {
 				return err
@@ -176,7 +297,14 @@ func (a *batchAccumulator) flushReadyContext(ctx context.Context, results chan<-
 	for a.byteLimit > 0 && a.totalBytes >= a.byteLimit {
 		tableName, ok := a.largestTable()
 		if !ok {
-			break
+			tableName, ok = a.largestBlockedTable()
+			if !ok {
+				return fmt.Errorf("CDC accumulator exceeded its memory limit with no flushable or spillable table")
+			}
+			if err := a.spillBlockedStableWindow(tableName); err != nil {
+				return err
+			}
+			continue
 		}
 		if err := a.flushTableContext(ctx, tableName, results, token); err != nil {
 			return err
@@ -185,11 +313,31 @@ func (a *batchAccumulator) flushReadyContext(ctx context.Context, results chan<-
 	return nil
 }
 
+func (a *batchAccumulator) largestBlockedTable() (string, bool) {
+	var largest string
+	var largestBytes int64
+	found := false
+	for tableName, size := range a.bytes {
+		if !a.blockedKeyless[tableName] || len(a.changes[tableName]) == 0 {
+			continue
+		}
+		if !found || size > largestBytes {
+			largest = tableName
+			largestBytes = size
+			found = true
+		}
+	}
+	return largest, found
+}
+
 func (a *batchAccumulator) largestTable() (string, bool) {
 	var largest string
 	var largestBytes int64
 	found := false
 	for tableName, size := range a.bytes {
+		if a.blockedKeyless[tableName] {
+			continue
+		}
 		if !found || size > largestBytes {
 			largest = tableName
 			largestBytes = size
@@ -206,6 +354,9 @@ func (a *batchAccumulator) flushAll(results chan<- source.RecordBatchResult, tok
 
 func (a *batchAccumulator) flushAllContext(ctx context.Context, results chan<- source.RecordBatchResult, token tokenFunc) error {
 	for tableName := range a.changes {
+		if a.blockedKeyless[tableName] {
+			continue
+		}
 		if err := a.flushTableContext(ctx, tableName, results, token); err != nil {
 			return err
 		}
@@ -213,16 +364,162 @@ func (a *batchAccumulator) flushAllContext(ctx context.Context, results chan<- s
 	return nil
 }
 
-func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName string, results chan<- source.RecordBatchResult, token tokenFunc) error {
-	if err := source.ConnectorLeaseLoss(ctx); err != nil {
-		a.discard()
-		return err
+// flushStableKeylessContext emits CDC data in fixed transaction-local sequence
+// windows. pendingLow is the decoder's oldest transaction that has not been
+// fully handed to this accumulator. A window is safe to emit when a later
+// window for the same table has arrived, or when its transaction is no longer
+// pending in the decoder. The historical name is retained because this replay
+// contract originated with keyless CDC.
+func (a *batchAccumulator) flushStableKeylessContext(
+	ctx context.Context,
+	results chan<- source.RecordBatchResult,
+	token tokenFunc,
+	pendingLow pglogrepl.LSN,
+	pending bool,
+) error {
+	tables := make(map[string]struct{}, len(a.changes)+len(a.stableSpills))
+	for tableName := range a.changes {
+		tables[tableName] = struct{}{}
 	}
+	for tableName := range a.stableSpills {
+		tables[tableName] = struct{}{}
+	}
+	for tableName := range tables {
+		tableSchema := a.schemas[tableName]
+		if tableSchema == nil || !a.stableAll {
+			continue
+		}
+		if spill := a.stableSpills[tableName]; spill != nil {
+			changes := a.changes[tableName]
+			prefix := 0
+			for prefix < len(changes) && changes[prefix].LSN == spill.lsn && changes[prefix].DataBatchWindow == spill.window {
+				prefix++
+			}
+			if prefix > 0 {
+				if err := a.appendResidentChangesToStableSpill(tableName, prefix); err != nil {
+					return err
+				}
+			}
+			transactionComplete := !pending || spill.lsn < pendingLow
+			windowClosed := len(a.changes[tableName]) > 0
+			if !transactionComplete && !windowClosed {
+				a.blockedKeyless[tableName] = true
+				continue
+			}
+			delete(a.blockedKeyless, tableName)
+			if err := a.restoreStableWindowSpill(tableName); err != nil {
+				return err
+			}
+		}
+		for {
+			changes := a.changes[tableName]
+			if len(changes) == 0 {
+				delete(a.blockedKeyless, tableName)
+				break
+			}
+			lsn := changes[0].LSN
+			window := changes[0].DataBatchWindow
+			end := 1
+			for end < len(changes) && changes[end].LSN == lsn && changes[end].DataBatchWindow == window {
+				end++
+			}
+			transactionComplete := !pending || lsn < pendingLow
+			windowClosed := end < len(changes)
+			if !transactionComplete && !windowClosed {
+				a.blockedKeyless[tableName] = true
+				break
+			}
+			delete(a.blockedKeyless, tableName)
+			if err := a.flushTablePrefixContext(ctx, tableName, end, results, token); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (a *batchAccumulator) spillBlockedStableWindow(tableName string) error {
 	changes := a.changes[tableName]
 	if len(changes) == 0 {
+		return fmt.Errorf("blocked stable CDC window for %s has no resident changes", tableName)
+	}
+	lsn := changes[0].LSN
+	window := changes[0].DataBatchWindow
+	for i := 1; i < len(changes); i++ {
+		if changes[i].LSN != lsn || changes[i].DataBatchWindow != window {
+			return fmt.Errorf("blocked stable CDC window for %s contains multiple durable identities", tableName)
+		}
+	}
+	spill := a.stableSpills[tableName]
+	if spill == nil {
+		spill = &stableWindowSpill{lsn: lsn, window: window, spool: newChangeSpool[Change](1)}
+		a.stableSpills[tableName] = spill
+	} else if spill.lsn != lsn || spill.window != window {
+		return fmt.Errorf("blocked stable CDC window for %s changed identity before its spill was emitted", tableName)
+	}
+	if err := a.appendResidentChangesToStableSpill(tableName, len(changes)); err != nil {
+		if spill.spool.Len() == 0 {
+			_ = spill.spool.Close()
+			delete(a.stableSpills, tableName)
+		}
+		return err
+	}
+	return nil
+}
+
+func (a *batchAccumulator) appendResidentChangesToStableSpill(tableName string, count int) error {
+	spill := a.stableSpills[tableName]
+	changes := a.changes[tableName]
+	if spill == nil || count < 1 || count > len(changes) {
+		return fmt.Errorf("invalid stable CDC spill prefix for %s", tableName)
+	}
+	for i := 0; i < count; i++ {
+		if changes[i].LSN != spill.lsn || changes[i].DataBatchWindow != spill.window {
+			return fmt.Errorf("stable CDC spill prefix for %s changed durable identity", tableName)
+		}
+		if err := spill.spool.Append(changes[i]); err != nil {
+			return fmt.Errorf("failed to spill stable CDC window for %s: %w", tableName, err)
+		}
+	}
+	remainder := changes[count:]
+	a.removeResidentTable(tableName)
+	if len(remainder) > 0 {
+		a.add(tableName, remainder, remainder[0].LSN)
+	}
+	if current, exists := a.minLSN[tableName]; !exists || spill.lsn < current {
+		a.minLSN[tableName] = spill.lsn
+	}
+	return nil
+}
+
+func (a *batchAccumulator) restoreStableWindowSpill(tableName string) error {
+	spill := a.stableSpills[tableName]
+	if spill == nil {
 		return nil
 	}
+	remainder := a.changes[tableName]
+	a.removeResidentTable(tableName)
+	if err := spill.spool.Seal(); err != nil {
+		return fmt.Errorf("failed to seal stable CDC spill for %s: %w", tableName, err)
+	}
+	restored := make([]Change, 0, spill.spool.Len()+len(remainder))
+	for spill.spool.Len() > 0 {
+		changes, err := spill.spool.Drain(defaultCommittedDrainChanges)
+		if err != nil {
+			return fmt.Errorf("failed to restore stable CDC spill for %s: %w", tableName, err)
+		}
+		restored = append(restored, changes...)
+	}
+	if err := spill.spool.Close(); err != nil {
+		return fmt.Errorf("failed to remove stable CDC spill for %s: %w", tableName, err)
+	}
+	delete(a.stableSpills, tableName)
+	restored = append(restored, remainder...)
+	a.add(tableName, restored, spill.lsn)
+	return nil
+}
 
+func (a *batchAccumulator) removeResidentTable(tableName string) {
 	delete(a.changes, tableName)
 	delete(a.minLSN, tableName)
 	a.totalBytes -= a.bytes[tableName]
@@ -230,6 +527,31 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 		a.totalBytes = 0
 	}
 	delete(a.bytes, tableName)
+}
+
+func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName string, results chan<- source.RecordBatchResult, token tokenFunc) error {
+	return a.flushTablePrefixContext(ctx, tableName, len(a.changes[tableName]), results, token)
+}
+
+func (a *batchAccumulator) flushTablePrefixContext(ctx context.Context, tableName string, count int, results chan<- source.RecordBatchResult, token tokenFunc) error {
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		a.discard()
+		return err
+	}
+	bufferedChanges := a.changes[tableName]
+	if len(bufferedChanges) == 0 || count <= 0 {
+		return nil
+	}
+	if count > len(bufferedChanges) {
+		count = len(bufferedChanges)
+	}
+	changes := bufferedChanges[:count:count]
+	remainder := bufferedChanges[count:]
+
+	a.removeResidentTable(tableName)
+	if len(remainder) > 0 {
+		a.add(tableName, remainder, remainder[0].LSN)
+	}
 
 	truncateIndex := lastTruncateIndex(changes)
 	if truncateIndex >= 0 {
@@ -279,6 +601,37 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	if len(changes) == 0 {
 		return nil
 	}
+	if a.stableAll && len(tableSchema.PrimaryKeys) == 0 {
+		for start := 0; start < len(changes); {
+			end := start + 1
+			for end < len(changes) && changes[end].LSN == changes[start].LSN {
+				end++
+			}
+			transactionToken := commitToken
+			if stateToken, ok := transactionToken.(source.CDCStateCommitToken); ok {
+				stateToken.DataBatchID = transactionDataBatchID(tableName, changes[start:end])
+				transactionToken = stateToken
+			}
+			batch, err := changesToBatch(changes[start:end], tableSchema)
+			if err != nil {
+				return fmt.Errorf("failed to materialize transaction batch for table %s: %w", tableName, err)
+			}
+			if err := source.ConnectorLeaseLoss(ctx); err != nil {
+				batch.Release()
+				a.discard()
+				return err
+			}
+			if err := sendResult(ctx, results, source.RecordBatchResult{
+				Batch: batch, TableName: tableName, CommitToken: transactionToken,
+			}); err != nil {
+				a.discard()
+				return err
+			}
+			start = end
+		}
+		config.Debug("[CDC] Flushed %d buffered changes as transaction batches for keyless table %s", buffered, tableName)
+		return nil
+	}
 
 	batch, err := changesToBatch(changes, tableSchema)
 	if err != nil {
@@ -291,11 +644,16 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	}
 
 	config.Debug("[CDC] Flushed %d buffered changes (%d rows after compaction) for table %s", buffered, len(changes), tableName)
+	batchToken := commitToken
+	if stateToken, ok := batchToken.(source.CDCStateCommitToken); ok && a.stableAll {
+		stateToken.DataBatchID = transactionDataBatchID(tableName, changes)
+		batchToken = stateToken
+	}
 
 	if err := sendResult(ctx, results, source.RecordBatchResult{
 		Batch:       batch,
 		TableName:   tableName,
-		CommitToken: commitToken,
+		CommitToken: batchToken,
 	}); err != nil {
 		a.discard()
 		return err

--- a/pkg/source/postgres_cdc/correctness_regression_test.go
+++ b/pkg/source/postgres_cdc/correctness_regression_test.go
@@ -3,6 +3,8 @@ package postgres_cdc
 import (
 	"context"
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -55,6 +57,238 @@ func TestBatchAccumulatorFlushesOnByteLimitBelowRowThreshold(t *testing.T) {
 	assert.Zero(t, a.totalBytes)
 }
 
+func TestBatchAccumulatorEmitsStableUniqueDataBatchIdentity(t *testing.T) {
+	for schemaName, tableSchema := range map[string]*schema.TableSchema{
+		"keyless": keylessTestSchema(),
+		"keyed":   keyedTestSchema(),
+	} {
+		for _, tableName := range []string{"", "public.events"} {
+			t.Run(schemaName+"/"+tableName, func(t *testing.T) {
+				flushWindows := func(windows [][]Change) []source.CDCStateCommitToken {
+					a := newBatchAccumulator(100, map[string]*schema.TableSchema{tableName: tableSchema})
+					a.stableAll = true
+					results := make(chan source.RecordBatchResult, 16)
+					for _, window := range windows {
+						a.add(tableName, window, window[0].LSN)
+						require.NoError(t, a.flushStableKeylessContext(t.Context(), results, func() any {
+							return source.CDCStateCommitToken{Position: "00000000/00000100"}
+						}, 0, false))
+						require.NoError(t, a.flushAllContext(t.Context(), results, func() any {
+							return source.CDCStateCommitToken{Position: "00000000/00000100"}
+						}))
+					}
+					close(results)
+					var tokens []source.CDCStateCommitToken
+					for result := range results {
+						require.NotNil(t, result.Batch)
+						result.Batch.Release()
+						token, ok := result.CommitToken.(source.CDCStateCommitToken)
+						require.True(t, ok)
+						tokens = append(tokens, token)
+					}
+					return tokens
+				}
+
+				c1 := Change{Operation: "INSERT", LSN: 0x110, Sequence: 2, Values: []interface{}{int32(1), "same"}}
+				c2 := Change{Operation: "INSERT", LSN: 0x120, Sequence: 2, Values: []interface{}{int32(1), "same"}}
+				c3 := Change{Operation: "INSERT", LSN: 0x130, Sequence: 2, Values: []interface{}{int32(1), "same"}}
+				firstGrouping := flushWindows([][]Change{{c1, c2}, {c3}})
+				retryGrouping := flushWindows([][]Change{{c1, c2, c3}})
+
+				require.Len(t, firstGrouping, 3)
+				require.Equal(t, firstGrouping, retryGrouping, "accumulator window regrouping must not change transaction write identities")
+				require.NotEqual(t, firstGrouping[0].DataBatchID, firstGrouping[1].DataBatchID, "duplicate payloads from distinct transactions need distinct identities")
+				require.NotEqual(t, firstGrouping[1].DataBatchID, firstGrouping[2].DataBatchID)
+			})
+		}
+	}
+}
+
+func TestDataBatchIdentityIsTableScoped(t *testing.T) {
+	changes := []Change{{LSN: 0x110, Sequence: 2}}
+	require.NotEqual(t, transactionDataBatchID("public.events", changes), transactionDataBatchID("public.audit", changes))
+	require.True(t, strings.HasPrefix(string(transactionDataBatchID("public.events", changes)), "pgcdc-keyless-v1:"))
+}
+
+func TestIncompleteKeylessSequenceWindowIsNotFlushedOnErrorPath(t *testing.T) {
+	tableSchema := keylessTestSchema()
+	accum := newBatchAccumulator(1, map[string]*schema.TableSchema{"public.events": tableSchema})
+	accum.stableAll = true
+	accum.add("public.events", []Change{{
+		Operation: "INSERT", LSN: 0x900, Sequence: 2, Values: []interface{}{int32(1), "same"},
+	}}, 0x900)
+	results := make(chan source.RecordBatchResult, 1)
+	token := func() any { return source.CDCStateCommitToken{Position: "00000000/000008FF"} }
+
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, token, 0x900, true))
+	require.NoError(t, accum.flushReadyContext(t.Context(), results, token))
+	require.NoError(t, accum.flushAllContext(t.Context(), results, token))
+	require.Empty(t, results, "a partial deterministic window must be replayed, not emitted with a drain-dependent identity")
+
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, token, 0, false))
+	result := <-results
+	require.NotNil(t, result.Batch)
+	result.Batch.Release()
+}
+
+func TestKeylessDataBatchWindowIsByteBoundedAndCapacityIndependent(t *testing.T) {
+	compactValues := []interface{}{strings.Repeat("x", 128)}
+	spareValues := make([]interface{}, 1, 64)
+	spareValues[0] = compactValues[0]
+	compact := Change{Operation: "INSERT", Values: compactValues}
+	spare := Change{Operation: "INSERT", Values: spareValues}
+	require.Equal(t, stableChangeBytes(compact), stableChangeBytes(spare))
+
+	large := Change{Operation: "INSERT", Values: []interface{}{strings.Repeat("x", int(keylessDataBatchWindowBytes/2)+1)}}
+	state := keylessBatchWindowState{}
+	state.assign(&large)
+	require.Equal(t, uint64(0), large.DataBatchWindow)
+	second := large
+	state.assign(&second)
+	require.Equal(t, uint64(1), second.DataBatchWindow)
+}
+
+func TestExpandedKeylessUpdateRetainsDataBatchWindow(t *testing.T) {
+	changes := expandUpdates([]Change{{
+		Operation: "UPDATE", LSN: 0x900, Sequence: 8, DataBatchWindow: 3,
+		Values: []interface{}{int32(2)}, OldValues: []interface{}{int32(1)},
+	}}, keylessTestSchema())
+	require.Len(t, changes, 2)
+	require.Equal(t, uint64(3), changes[0].DataBatchWindow)
+	require.Equal(t, uint64(3), changes[1].DataBatchWindow)
+}
+
+func TestLargeKeylessTransactionFragmentsHaveStableUniqueIdentities(t *testing.T) {
+	const changeCount = defaultCommittedDrainChanges*2 + 2
+	run := func(drainLimit int) ([]source.DurableID, int64) {
+		tableSchema := keylessTestSchema()
+		decoder := NewDecoder(tableSchema, "public", "events")
+		decoder.currentTxLSN = 0x900
+		for i := 0; i < changeCount; i++ {
+			require.NoError(t, decoder.appendChange(Change{
+				Operation: "INSERT", LSN: decoder.currentTxLSN, Values: []interface{}{int32(i), "same"},
+			}))
+		}
+		require.NoError(t, decoder.pendingChanges.Seal())
+		decoder.committed = decoder.pendingChanges
+		decoder.pendingChanges = newChangeSpoolWithBudget[Change](defaultTransactionMemoryBytes, decoder.memoryBudget, nil)
+		accum := newBatchAccumulator(changeCount+1, map[string]*schema.TableSchema{"": tableSchema})
+		accum.stableAll = true
+		results := make(chan source.RecordBatchResult, 8)
+		flush := func(changes []Change) {
+			accum.add("", changes, decoder.currentTxLSN)
+			pendingLow, pending := decoder.CommittedLowWater()
+			require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, func() any {
+				return source.CDCStateCommitToken{Position: "00000000/00000800"}
+			}, pendingLow, pending))
+		}
+		for decoder.HasCommitted() {
+			fragment, err := decoder.DrainCommitted(drainLimit)
+			require.NoError(t, err)
+			flush(fragment)
+		}
+		require.NoError(t, decoder.Close())
+		close(results)
+		var ids []source.DurableID
+		var rows int64
+		for result := range results {
+			token := result.CommitToken.(source.CDCStateCommitToken)
+			ids = append(ids, token.DataBatchID)
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		return ids, rows
+	}
+
+	firstIDs, firstRows := run(257)
+	replayIDs, replayRows := run(defaultCommittedDrainChanges + 333)
+	require.EqualValues(t, changeCount, firstRows)
+	require.Equal(t, firstRows, replayRows)
+	require.Len(t, firstIDs, 3)
+	require.Equal(t, firstIDs, replayIDs)
+	require.Len(t, map[source.DurableID]struct{}{firstIDs[0]: {}, firstIDs[1]: {}, firstIDs[2]: {}}, 3)
+}
+
+func TestLargeMultiTableKeylessTransactionFragmentsHaveStableUniqueIdentities(t *testing.T) {
+	const changesPerTable = defaultCommittedDrainChanges*2 + 2
+	run := func(drainLimit int, blockedInterleaving bool) ([]string, int64) {
+		tableSchema := keylessTestSchema()
+		tables := []source.SourceTableInfo{{Name: "public.events", Schema: tableSchema}, {Name: "public.audit", Schema: tableSchema}}
+		decoder := NewMultiTableDecoder(tables)
+		decoder.currentTxLSN = 0x900
+		appendTableChange := func(table string, value int) {
+			require.NoError(t, decoder.appendChange(TableChange{TableName: table, Change: Change{
+				Operation: "INSERT", Values: []interface{}{int32(value), "same"},
+			}}))
+		}
+		if blockedInterleaving {
+			for _, table := range tables {
+				for i := 0; i < changesPerTable; i++ {
+					appendTableChange(table.Name, i)
+				}
+			}
+		} else {
+			for i := 0; i < changesPerTable; i++ {
+				for _, table := range tables {
+					appendTableChange(table.Name, i)
+				}
+			}
+		}
+		require.NoError(t, decoder.pendingChanges.Seal())
+		decoder.committed = decoder.pendingChanges
+		decoder.committedLSN = decoder.currentTxLSN
+		decoder.committedTableSequences = make(map[string]uint64)
+		decoder.pendingChanges = newChangeSpoolWithBudget[streamedChange](defaultTransactionMemoryBytes, decoder.memoryBudget, streamedChangeXID)
+		schemas := map[string]*schema.TableSchema{tables[0].Name: tableSchema, tables[1].Name: tableSchema}
+		accum := newBatchAccumulator(changesPerTable*len(tables)+1, schemas)
+		accum.stableAll = true
+		accum.byteLimit = 12 << 10
+		defer accum.discard()
+		results := make(chan source.RecordBatchResult, 16)
+		flush := func(groups []DecodedChanges) {
+			for _, group := range groups {
+				accum.add(group.TableName, group.Changes, group.LSN)
+			}
+			pendingLow, pending := decoder.CommittedLowWater()
+			require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, func() any {
+				return source.CDCStateCommitToken{Position: "00000000/00000800"}
+			}, pendingLow, pending))
+			require.NoError(t, accum.flushReadyContext(t.Context(), results, func() any {
+				return source.CDCStateCommitToken{Position: "00000000/00000800"}
+			}))
+		}
+		for decoder.HasCommitted() {
+			groups, err := decoder.DrainCommitted(drainLimit)
+			require.NoError(t, err)
+			flush(groups)
+		}
+		require.NoError(t, decoder.Close())
+		close(results)
+		var ids []string
+		var rows int64
+		for result := range results {
+			token := result.CommitToken.(source.CDCStateCommitToken)
+			ids = append(ids, string(token.DataBatchID))
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		sort.Strings(ids)
+		return ids, rows
+	}
+
+	firstIDs, firstRows := run(317, false)
+	replayIDs, replayRows := run(defaultCommittedDrainChanges+471, true)
+	require.EqualValues(t, changesPerTable*2, firstRows)
+	require.Equal(t, firstRows, replayRows)
+	require.Len(t, firstIDs, 6)
+	require.Equal(t, firstIDs, replayIDs)
+	unique := make(map[string]struct{}, len(firstIDs))
+	for _, id := range firstIDs {
+		unique[id] = struct{}{}
+	}
+	require.Len(t, unique, len(firstIDs))
+}
+
 func TestBatchAccumulatorByteLimitIsGlobalAcrossTables(t *testing.T) {
 	tables := []string{"one", "two", "three", "four", "five"}
 	schemas := make(map[string]*schema.TableSchema, len(tables))
@@ -90,6 +324,91 @@ func TestBatchAccumulatorByteLimitIsGlobalAcrossTables(t *testing.T) {
 		result.Batch.Release()
 	}
 	assert.Positive(t, flushed)
+}
+
+func TestStableBatchAccumulatorSpillsBlockedWindowsUnderGlobalMemoryPressure(t *testing.T) {
+	tables := map[string]*schema.TableSchema{
+		"public.keyed_a":   keyedTestSchema(),
+		"public.keyless_a": keylessTestSchema(),
+		"public.keyed_b":   keyedTestSchema(),
+		"public.keyless_b": keylessTestSchema(),
+	}
+	accum := newBatchAccumulator(25_000, tables)
+	accum.byteLimit = 6 << 10
+	accum.stableAll = true
+	t.Cleanup(accum.discard)
+	for tableName := range tables {
+		accum.add(tableName, []Change{{
+			Operation: "INSERT", LSN: 0x900, Sequence: 2, DataBatchWindow: 0,
+			Values: []interface{}{int32(1), strings.Repeat(tableName, 80)},
+		}}, 0x900)
+	}
+	require.GreaterOrEqual(t, accum.totalBytes, accum.byteLimit)
+
+	results := make(chan source.RecordBatchResult, 32)
+	token := func() any { return source.CDCStateCommitToken{Position: "0/8FF"} }
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, token, 0x900, true))
+	require.NoError(t, accum.flushReadyContext(t.Context(), results, token))
+	require.Less(t, accum.totalBytes, accum.byteLimit)
+	require.NotEmpty(t, accum.stableSpills)
+	require.Empty(t, results, "incomplete durable windows must spill, not flush")
+
+	spillPaths := make([]string, 0, len(accum.stableSpills))
+	for _, spill := range accum.stableSpills {
+		require.NotNil(t, spill.spool.file)
+		spillPaths = append(spillPaths, spill.spool.file.Name())
+	}
+	for tableName := range tables {
+		accum.add(tableName, []Change{{
+			Operation: "INSERT", LSN: 0x900, Sequence: 4, DataBatchWindow: 0,
+			Values: []interface{}{int32(2), tableName},
+		}}, 0x900)
+	}
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, token, 0, false))
+	require.NoError(t, accum.flushAllContext(t.Context(), results, token))
+	require.Empty(t, accum.stableSpills)
+	close(results)
+
+	seen := make(map[string]source.CDCStateCommitToken, len(tables))
+	for result := range results {
+		require.NotNil(t, result.Batch)
+		require.EqualValues(t, 2, result.Batch.NumRows())
+		commit, ok := result.CommitToken.(source.CDCStateCommitToken)
+		require.True(t, ok)
+		seen[result.TableName] = commit
+		result.Batch.Release()
+	}
+	require.Len(t, seen, len(tables))
+	for tableName, commit := range seen {
+		require.Equal(t, transactionDataBatchID(tableName, []Change{{LSN: 0x900}}), commit.DataBatchID)
+	}
+	for _, path := range spillPaths {
+		_, err := os.Stat(path)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func TestStableBatchAccumulatorDiscardRemovesOversizedWindowSpill(t *testing.T) {
+	const tableName = "public.oversized"
+	accum := newBatchAccumulator(25_000, map[string]*schema.TableSchema{tableName: keylessTestSchema()})
+	accum.byteLimit = 1024
+	accum.stableAll = true
+	accum.add(tableName, []Change{{
+		Operation: "INSERT", LSN: 0x900, Sequence: 2,
+		Values: []interface{}{int32(1), strings.Repeat("x", 16<<10)},
+	}}, 0x900)
+	results := make(chan source.RecordBatchResult, 1)
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, nil, 0x900, true))
+	require.NoError(t, accum.flushReadyContext(t.Context(), results, nil))
+	require.Zero(t, accum.totalBytes)
+	require.Empty(t, results)
+	spill := accum.stableSpills[tableName]
+	require.NotNil(t, spill)
+	path := spill.spool.file.Name()
+
+	accum.discard()
+	_, err := os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestBatchAccumulatorAccountsForManyTableContainerMemory(t *testing.T) {

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -43,26 +43,28 @@ const (
 )
 
 type Change struct {
-	Operation string // "INSERT", "UPDATE", "DELETE", "TRUNCATE"
-	LSN       pglogrepl.LSN
-	Sequence  uint64 // 1-based order within the committing transaction
-	Values    []interface{}
-	OldValues []interface{} // For UPDATE/DELETE with replica identity
+	Operation       string // "INSERT", "UPDATE", "DELETE", "TRUNCATE"
+	LSN             pglogrepl.LSN
+	Sequence        uint64 // 1-based order within the committing transaction
+	DataBatchWindow uint64
+	Values          []interface{}
+	OldValues       []interface{} // For UPDATE/DELETE with replica identity
 }
 
 type Decoder struct {
-	tableSchema    *schema.TableSchema
-	targetSchema   string
-	targetTable    string
-	relations      map[uint32]*RelationInfo
-	targetRelID    uint32
-	expectedRelID  uint32
-	pendingChanges *changeSpool[Change]
-	committed      *changeSpool[Change]
-	currentTxLSN   pglogrepl.LSN
-	typeMap        *pgtype.Map
-	allowedUnknown map[string]struct{}
-	memoryBudget   *byteBudget
+	tableSchema          *schema.TableSchema
+	targetSchema         string
+	targetTable          string
+	relations            map[uint32]*RelationInfo
+	targetRelID          uint32
+	expectedRelID        uint32
+	pendingChanges       *changeSpool[Change]
+	committed            *changeSpool[Change]
+	committedBatchWindow keylessBatchWindowState
+	currentTxLSN         pglogrepl.LSN
+	typeMap              *pgtype.Map
+	allowedUnknown       map[string]struct{}
+	memoryBudget         *byteBudget
 }
 
 func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *Decoder {
@@ -257,6 +259,7 @@ func (d *Decoder) handleCommit() ([]Change, error) {
 		return nil, err
 	}
 	d.committed = d.pendingChanges
+	d.committedBatchWindow = keylessBatchWindowState{}
 	d.pendingChanges = newChangeSpoolWithBudget[Change](defaultTransactionMemoryBytes, d.memoryBudget, nil)
 	return d.DrainCommitted(defaultCommittedDrainChanges)
 }
@@ -276,6 +279,9 @@ func (d *Decoder) DrainCommitted(limit int) ([]Change, error) {
 	changes, err := d.committed.Drain(limit)
 	if err != nil {
 		return nil, err
+	}
+	for i := range changes {
+		d.committedBatchWindow.assign(&changes[i])
 	}
 	if d.committed.Len() == 0 {
 		err = d.committed.Close()

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -35,18 +35,20 @@ func streamedChangeXID(change streamedChange) uint32 { return change.XID }
 // (Stream Start/Stop/Commit/Abort) and, when the stream runs with the
 // `binary 'true'` option, binary-format tuple data.
 type MultiTableDecoder struct {
-	tableSchemas   map[string]*schema.TableSchema // schema name.table name -> schema
-	expectedRelIDs map[string]uint32              // full table name -> connect-time relation ID
-	relations      map[uint32]*RelationInfo
-	targetRelIDs   map[uint32]string // relation ID -> full table name
-	pendingChanges *changeSpool[streamedChange]
-	committed      *changeSpool[streamedChange]
-	committedLSN   pglogrepl.LSN
-	currentTxLSN   pglogrepl.LSN
-	typeMap        *pgtype.Map
-	allowedUnknown map[string]map[string]struct{}
-	historicalIDs  map[string]map[uint32]struct{}
-	memoryBudget   *byteBudget
+	tableSchemas            map[string]*schema.TableSchema // schema name.table name -> schema
+	expectedRelIDs          map[string]uint32              // full table name -> connect-time relation ID
+	relations               map[uint32]*RelationInfo
+	targetRelIDs            map[uint32]string // relation ID -> full table name
+	pendingChanges          *changeSpool[streamedChange]
+	committed               *changeSpool[streamedChange]
+	committedLSN            pglogrepl.LSN
+	committedTableSequences map[string]uint64
+	committedBatchWindows   map[string]*keylessBatchWindowState
+	currentTxLSN            pglogrepl.LSN
+	typeMap                 *pgtype.Map
+	allowedUnknown          map[string]map[string]struct{}
+	historicalIDs           map[string]map[uint32]struct{}
+	memoryBudget            *byteBudget
 
 	// Protocol v2 streaming state. Between Stream Start and Stream Stop,
 	// change messages carry a subtransaction xid and are buffered per
@@ -216,6 +218,8 @@ func (d *MultiTableDecoder) handleStreamCommit(data []byte) ([]DecodedChanges, e
 	}
 	d.committed = buffered
 	d.committedLSN = commitLSN
+	d.committedTableSequences = make(map[string]uint64)
+	d.committedBatchWindows = make(map[string]*keylessBatchWindowState)
 	return d.DrainCommitted(defaultCommittedDrainChanges)
 }
 
@@ -396,6 +400,8 @@ func (d *MultiTableDecoder) handleCommit() ([]DecodedChanges, error) {
 	}
 	d.committed = d.pendingChanges
 	d.committedLSN = d.currentTxLSN
+	d.committedTableSequences = make(map[string]uint64)
+	d.committedBatchWindows = make(map[string]*keylessBatchWindowState)
 	d.pendingChanges = newChangeSpoolWithBudget[streamedChange](defaultTransactionMemoryBytes, d.memoryBudget, streamedChangeXID)
 	return d.DrainCommitted(defaultCommittedDrainChanges)
 }
@@ -412,6 +418,12 @@ func (d *MultiTableDecoder) DrainCommitted(limit int) ([]DecodedChanges, error) 
 	if !d.HasCommitted() {
 		return nil, nil
 	}
+	if d.committedTableSequences == nil {
+		d.committedTableSequences = make(map[string]uint64)
+	}
+	if d.committedBatchWindows == nil {
+		d.committedBatchWindows = make(map[string]*keylessBatchWindowState)
+	}
 	buffered, err := d.committed.Drain(limit)
 	if err != nil {
 		return nil, err
@@ -424,6 +436,14 @@ func (d *MultiTableDecoder) DrainCommitted(limit int) ([]DecodedChanges, error) 
 			continue
 		}
 		tc.Change.LSN = d.committedLSN
+		d.committedTableSequences[tc.TableName]++
+		tc.Change.Sequence = d.committedTableSequences[tc.TableName] * 2
+		window := d.committedBatchWindows[tc.TableName]
+		if window == nil {
+			window = &keylessBatchWindowState{}
+			d.committedBatchWindows[tc.TableName] = window
+		}
+		window.assign(&tc.Change)
 		idx, ok := groupIdx[tc.TableName]
 		if !ok {
 			idx = len(groups)

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -285,7 +285,7 @@ func (r *MultiTableCDCReader) backfillTables(ctx context.Context, slotName strin
 			if opts.Streaming {
 				if _, replacement := replacements[table.Name]; replacement {
 					if err := sendResult(gctx, results, source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
-						TableName: table.Name, Incarnation: table.Incarnation,
+						TableName: table.Name, Incarnation: table.Incarnation, SchemaFingerprint: table.SchemaFingerprint,
 					}}); err != nil {
 						return err
 					}
@@ -817,12 +817,15 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		schemas[t.Name] = t.Schema
 	}
 	accum := newBatchAccumulator(batchSize, schemas)
+	accum.stableAll = opts.CDCStableDataBatches
+	defer accum.discard()
 
-	// In streaming mode, batches carry a CommitToken (safe LSN) so the pipeline
-	// confirms the slot only after the data is durable. barrierNonce is empty in
-	// streaming mode, so the barrier exit below never triggers.
+	// Every batch carries its safe source position. Streaming confirms the slot
+	// from it; managed batch ingestion uses it to identify transaction fragments.
+	// barrierNonce is empty in streaming mode, so the barrier exit below never
+	// triggers.
 	var token tokenFunc
-	if opts.Streaming {
+	if opts.Streaming || accum.stableAll {
 		token = func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
 	}
 
@@ -918,6 +921,10 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		}
 		for _, g := range groups {
 			accum.add(g.TableName, g.Changes, g.LSN)
+		}
+		pendingLow, pending := repl.PendingLowWater()
+		if err := accum.flushStableKeylessContext(ctx, results, token, pendingLow, pending); err != nil {
+			return nil, err
 		}
 
 		// Flush tables that have accumulated enough rows

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -121,7 +121,7 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 		// Full mode: Phase 1: Snapshot
 		if replacementSnapshot && opts.Streaming {
 			if err := sendResult(ctx, results, source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
-				TableName: r.tableName, Incarnation: incarnation,
+				TableName: r.tableName, Incarnation: incarnation, SchemaFingerprint: fingerprint,
 			}}); err != nil {
 				return
 			}
@@ -245,6 +245,7 @@ func (r *CDCReader) runStream(ctx context.Context, startLSN pglogrepl.LSN, slotN
 	}
 
 	accum := newBatchAccumulator(batchSize, map[string]*schema.TableSchema{"": r.tableSchema})
+	accum.stableAll = opts.CDCStableDataBatches
 
 	err = streamLoop(ctx, repl, batchSize, accum, results, opts.Streaming)
 	if err == nil && !opts.Streaming {
@@ -336,7 +337,7 @@ func (r *CDCReader) resnapshotTable(ctx context.Context, slotName string, table 
 		return 0, fmt.Errorf("failed to parse schema backfill LSN: %w", err)
 	}
 	if err := sendResult(ctx, results, source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
-		TableName: table.Name, Incarnation: table.Incarnation,
+		TableName: table.Name, Incarnation: table.Incarnation, SchemaFingerprint: table.SchemaFingerprint,
 	}}); err != nil {
 		return 0, err
 	}
@@ -415,11 +416,13 @@ type singleTableChangeFilter interface {
 // transaction and defeat accumulation entirely (see hadActivity in
 // Replicator.NextChanges).
 //
-// When streaming, each flushed batch carries a CommitToken (a safe LSN) so the
-// pipeline can confirm the replication slot only after the data is durable.
+// Each flushed batch carries its safe source position. Streaming uses it to
+// confirm the replication slot; managed batch ingestion uses it to identify
+// transaction fragments durably.
 func streamLoop(ctx context.Context, repl batchReplicator, batchSize int, accum *batchAccumulator, results chan<- source.RecordBatchResult, streaming bool) error {
+	defer accum.discard()
 	var token tokenFunc
-	if streaming {
+	if streaming || accum.stableAll {
 		token = func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
 	}
 
@@ -462,6 +465,10 @@ func streamLoop(ctx context.Context, repl batchReplicator, batchSize int, accum 
 			changes = nil
 		}
 		accum.add("", changes, lsn)
+		pendingLow, pending := repl.PendingLowWater()
+		if err := accum.flushStableKeylessContext(ctx, results, token, pendingLow, pending); err != nil {
+			return err
+		}
 
 		if err := accum.flushReadyContext(ctx, results, token); err != nil {
 			return err

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -1397,7 +1397,9 @@ func (s *PostgresCDCSource) ReadAll(ctx context.Context, opts source.MultiTableR
 		}
 		if resumeMetadataChanged(opts.CDCResumeIncarnations[table.Name], opts.CDCResumeSchemaFingerprints[table.Name], table.Incarnation, table.SchemaFingerprint) {
 			delete(resumeLSNs, table.Name)
-			invalidations = append(invalidations, source.CDCSnapshotInvalidation{TableName: table.Name, Incarnation: table.Incarnation})
+			invalidations = append(invalidations, source.CDCSnapshotInvalidation{
+				TableName: table.Name, Incarnation: table.Incarnation, SchemaFingerprint: table.SchemaFingerprint,
+			})
 		}
 	}
 	reader := NewMultiTableCDCReader(s, tables, s.cdcConfig, resumeLSNs, opts.CDCSlotSuffix)

--- a/pkg/source/postgres_cdc/stable_data_batch_integration_test.go
+++ b/pkg/source/postgres_cdc/stable_data_batch_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package postgres_cdc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresCDCStableDataBatchIDsReplay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	container, connString := startConnectorLeasePostgres(t, ctx)
+	defer func() { _ = container.Terminate(context.Background()) }()
+
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE public.stable_keyed (id bigint PRIMARY KEY, value text);
+		CREATE TABLE public.stable_keyless (id bigint, value text);
+		ALTER TABLE public.stable_keyless REPLICA IDENTITY FULL;
+		CREATE PUBLICATION stable_batch_pub FOR TABLE public.stable_keyed, public.stable_keyless;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	cdcURI := strings.Replace(connString, "postgres://", "postgres+cdc://", 1) + "&publication=stable_batch_pub"
+	for _, tc := range []struct {
+		name  string
+		table string
+		seed  func()
+	}{
+		{
+			name:  "keyed_append",
+			table: "public.stable_keyed",
+			seed: func() {
+				for _, statement := range []string{
+					"INSERT INTO public.stable_keyed VALUES (1, 'same')",
+					"INSERT INTO public.stable_keyed VALUES (2, 'same')",
+					"INSERT INTO public.stable_keyed SELECT g, 'large' FROM generate_series(3, 1104) g",
+				} {
+					_, execErr := pool.Exec(ctx, statement)
+					require.NoError(t, execErr)
+				}
+			},
+		},
+		{
+			name:  "keyless",
+			table: "public.stable_keyless",
+			seed: func() {
+				for _, statement := range []string{
+					"INSERT INTO public.stable_keyless VALUES (1, 'same')",
+					"INSERT INTO public.stable_keyless VALUES (1, 'same')",
+					"INSERT INTO public.stable_keyless SELECT 2, 'large' FROM generate_series(1, 1102)",
+				} {
+					_, execErr := pool.Exec(ctx, statement)
+					require.NoError(t, execErr)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			suffix := "stable_" + tc.name
+			resume, incarnation, fingerprint := createEmptyCDCSnapshot(t, ctx, cdcURI, tc.table, suffix)
+			tc.seed()
+
+			first := readStableCDCReplay(t, ctx, cdcURI, tc.table, suffix, resume, incarnation, fingerprint, 1)
+			second := readStableCDCReplay(t, ctx, cdcURI, tc.table, suffix, resume, incarnation, fingerprint, 10000)
+			require.Equal(t, first, second, "replay identities changed with page size and connector restart")
+			require.Len(t, first, 4, "two small transactions and two fixed windows from the large transaction must be distinct")
+
+			seen := make(map[source.DurableID]struct{}, len(first))
+			var rows int64
+			for _, batch := range first {
+				require.NotEmpty(t, batch.id)
+				require.NotEmpty(t, batch.position)
+				_, duplicate := seen[batch.id]
+				require.False(t, duplicate, "distinct transaction windows shared durable identity %q", batch.id)
+				seen[batch.id] = struct{}{}
+				rows += batch.rows
+			}
+			require.EqualValues(t, 1104, rows)
+		})
+	}
+}
+
+type stableCDCReplayBatch struct {
+	id       source.DurableID
+	position string
+	rows     int64
+}
+
+func createEmptyCDCSnapshot(
+	t *testing.T,
+	ctx context.Context,
+	cdcURI, tableName, slotSuffix string,
+) (string, string, string) {
+	t.Helper()
+	src := NewPostgresCDCSource()
+	require.NoError(t, src.Connect(ctx, cdcURI))
+	t.Cleanup(func() { _ = src.Close(context.Background()) })
+	table, err := src.GetTable(ctx, source.TableRequest{
+		Name: tableName, Strategy: config.StrategyAppend, StrategySet: true,
+	})
+	require.NoError(t, err)
+	records, err := table.Read(ctx, source.ReadOptions{
+		PageSize: 7, CDCSlotSuffix: slotSuffix, CDCStableDataBatches: true,
+	})
+	require.NoError(t, err)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		require.NoError(t, result.Err)
+	}
+	state := src.CDCState()
+	resume := state.SnapshotPositions[tableName]
+	require.NotEmpty(t, resume)
+	incarnation, err := src.TableIncarnation(ctx, tableName)
+	require.NoError(t, err)
+	fingerprint, err := src.TableSchemaFingerprint(ctx, tableName)
+	require.NoError(t, err)
+	require.NoError(t, src.Close(context.Background()))
+	return resume, incarnation, fingerprint
+}
+
+func readStableCDCReplay(
+	t *testing.T,
+	ctx context.Context,
+	cdcURI, tableName, slotSuffix, resume, incarnation, fingerprint string,
+	pageSize int,
+) []stableCDCReplayBatch {
+	t.Helper()
+	src := NewPostgresCDCSource()
+	require.NoError(t, src.Connect(ctx, cdcURI))
+	table, err := src.GetTable(ctx, source.TableRequest{
+		Name: tableName, Strategy: config.StrategyAppend, StrategySet: true,
+	})
+	require.NoError(t, err)
+	records, err := table.Read(ctx, source.ReadOptions{
+		PageSize:                   pageSize,
+		CDCResumeLSN:               resume,
+		CDCResumeIncarnation:       incarnation,
+		CDCResumeSchemaFingerprint: fingerprint,
+		CDCSlotSuffix:              slotSuffix,
+		CDCStableDataBatches:       true,
+	})
+	require.NoError(t, err)
+
+	var batches []stableCDCReplayBatch
+	for result := range records {
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			require.NoError(t, result.Err)
+		}
+		if result.Batch == nil {
+			continue
+		}
+		token, ok := result.CommitToken.(source.CDCStateCommitToken)
+		rows := result.Batch.NumRows()
+		result.Batch.Release()
+		require.True(t, ok, "WAL data result carried token %T", result.CommitToken)
+		require.NotEmpty(t, token.DataBatchID)
+		require.NotEmpty(t, token.Position)
+		batches = append(batches, stableCDCReplayBatch{id: token.DataBatchID, position: token.Position, rows: rows})
+	}
+	require.NoError(t, src.Close(context.Background()), fmt.Sprintf("close replay source for %s", tableName))
+	return batches
+}

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -183,6 +183,49 @@ func TestStreamLoopAccumulatesSingleRowTransactions(t *testing.T) {
 	assert.Less(t, batchCount, numTxns, "batch count must not equal row count")
 }
 
+func TestBatchStreamLoopEmitsStableKeylessBatchIdentity(t *testing.T) {
+	steps, _ := buildSingleRowTxnStream(1)
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, len(steps)+1)
+	tableSchema := testStreamSchema()
+	tableSchema.PrimaryKeys = nil
+	accum := newBatchAccumulator(10000, map[string]*schema.TableSchema{"": tableSchema})
+	accum.stableAll = true
+
+	require.NoError(t, streamLoop(t.Context(), repl, 10000, accum, results, false))
+	close(results)
+	result := <-results
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+	token, ok := result.CommitToken.(source.CDCStateCommitToken)
+	require.True(t, ok)
+	require.NotEmpty(t, token.Position)
+	require.NotEmpty(t, token.DataBatchID)
+}
+
+func TestBatchStreamLoopEmitsStableKeyedBatchIdentity(t *testing.T) {
+	steps, _ := buildSingleRowTxnStream(2)
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, len(steps)+1)
+	accum := newBatchAccumulator(10000, map[string]*schema.TableSchema{"": testStreamSchema()})
+	accum.stableAll = true
+
+	require.NoError(t, streamLoop(t.Context(), repl, 10000, accum, results, false))
+	close(results)
+	var ids []source.DurableID
+	for result := range results {
+		require.NotNil(t, result.Batch)
+		token, ok := result.CommitToken.(source.CDCStateCommitToken)
+		require.True(t, ok)
+		require.NotEmpty(t, token.Position)
+		require.NotEmpty(t, token.DataBatchID)
+		ids = append(ids, token.DataBatchID)
+		result.Batch.Release()
+	}
+	require.Len(t, ids, 2)
+	require.NotEqual(t, ids[0], ids[1])
+}
+
 func TestStreamLoopLeaseLossDiscardsAccumulatorWithoutMaterializing(t *testing.T) {
 	lease := &readerTestLease{done: make(chan struct{}), err: errors.New("lease backend terminated")}
 	ctx := source.WithConnectorLeaseGuard(context.Background(), source.NewConnectorLeaseGuard(lease))

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -167,9 +167,15 @@ func expandUpdates(changes []Change, tableSchema *schema.TableSchema) []Change {
 		if deleteSequence > 0 {
 			deleteSequence--
 		}
-		out = append(out, Change{Operation: "DELETE", LSN: c.LSN, Sequence: deleteSequence, Values: c.OldValues})
+		out = append(out, Change{
+			Operation: "DELETE", LSN: c.LSN, Sequence: deleteSequence,
+			DataBatchWindow: c.DataBatchWindow, Values: c.OldValues,
+		})
 		if keyless {
-			out = append(out, Change{Operation: "INSERT", LSN: c.LSN, Sequence: c.Sequence, Values: resolvedNewImage(c)})
+			out = append(out, Change{
+				Operation: "INSERT", LSN: c.LSN, Sequence: c.Sequence,
+				DataBatchWindow: c.DataBatchWindow, Values: resolvedNewImage(c),
+			})
 		} else {
 			out = append(out, c)
 		}

--- a/pkg/strategy/append.go
+++ b/pkg/strategy/append.go
@@ -3,11 +3,14 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
 
@@ -40,6 +43,16 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if isCDC {
 		prepSchema = job.Schema
 	}
+	if publisher, ok := job.Destination.(destination.AtomicSnapshotPublisher); ok &&
+		job.CDCStateManager != nil && isCDC && !job.Config.Stream &&
+		(job.Config.FullRefresh || strings.TrimSpace(job.Config.CDCResumeLSN) == "") {
+		return s.executeAtomicSnapshot(ctx, job, publisher, prepSchema)
+	}
+	if isCDC && job.CDCStateManager != nil {
+		if err := requireIdempotentCommitTokenWrites(job.Destination, "managed CDC append"); err != nil {
+			return err
+		}
+	}
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:       job.Config.DestTable,
@@ -52,14 +65,19 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	}); err != nil {
 		return fmt.Errorf("failed to prepare table: %w", err)
 	}
-
-	if err := job.ApplyEvolution(ctx); err != nil {
-		return fmt.Errorf("failed to apply schema evolution: %w", err)
-	}
+	expectedIncarnation := ""
 	if job.CDCStateManager != nil {
 		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
 			return fmt.Errorf("failed to bind CDC destination before append: %w", err)
 		}
+		var err error
+		expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable)
+		if err != nil {
+			return err
+		}
+	}
+	if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -86,10 +104,13 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		CDCSlotSuffix:                   job.Config.CDCSlotSuffix,
 		CDCLegacySlotSuffix:             job.Config.CDCLegacySlotSuffix,
 		CDCSnapshotReplace:              isCDC && supportsCDCSnapshotReplace(job.Destination),
+		CDCStableDataBatches:            isCDC && job.CDCStateManager != nil,
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
 		return fmt.Errorf("failed to get records: %w", err)
 	}
@@ -106,24 +127,227 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
+		SkipCDCResume:    job.CDCStateManager != nil,
+	}
+	if job.CDCStateManager != nil {
+		writeOpts.CDCExpectedIncarnation = expectedIncarnation
 	}
 	var writeErr error
-	if isCDC {
-		_, writeErr = destination.WriteWithTruncateBoundaries(ctx, job.Destination, records, writeOpts)
+	if isCDC && job.CDCStateManager != nil {
+		_, writeErr = writeDurableCDCAppendRecords(readCtx, job.Destination, records, writeOpts, job.Config.SourceTable, job.CDCStateManager)
+	} else if isCDC {
+		_, writeErr = destination.WriteWithTruncateBoundaries(readCtx, job.Destination, records, writeOpts)
 	} else {
-		writeErr = job.Destination.WriteParallel(ctx, records, writeOpts)
+		writeErr = job.Destination.WriteParallel(readCtx, records, writeOpts)
 	}
 	if writeErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write data: %w", writeErr)
 	}
 
 	return nil
 }
 
+func (s *AppendStrategy) executeAtomicSnapshot(
+	ctx context.Context,
+	job *IngestionJob,
+	publisher destination.AtomicSnapshotPublisher,
+	targetSchema *schema.TableSchema,
+) error {
+	if _, recovered, err := recoverManagedAtomicSnapshotBeforeRead(
+		ctx, job.Destination, publisher, job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable,
+	); err != nil {
+		return err
+	} else if recovered {
+		return nil
+	}
+	existingSchema, err := job.Destination.GetTableSchema(ctx, job.Config.DestTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before atomic append snapshot: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+	if !targetExisted && ownershipToken == "" {
+		return fmt.Errorf("destination %s cannot safely clean up a failed atomic append target", job.Destination.GetScheme())
+	}
+	cleanupNewTarget := !targetExisted && ownershipToken != ""
+	defer func() {
+		if cleanupNewTarget {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, job.Config.DestTable, true, ownershipToken)
+		}
+	}()
+	if !targetExisted {
+		if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+			Table: job.Config.DestTable, Schema: targetSchema, PrimaryKeys: job.Schema.PrimaryKeys,
+			PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy, CDCMode: true,
+			OwnershipToken: ownershipToken,
+		}); err != nil {
+			return fmt.Errorf("failed to prepare owned target for atomic append snapshot: %w", err)
+		}
+	}
+	if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
+		return fmt.Errorf("failed to bind CDC destination before atomic append snapshot: %w", err)
+	}
+	expectedIncarnation := job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+	if expectedIncarnation == "" {
+		return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", job.Config.DestTable)
+	}
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, source.ReadOptions{
+		IncrementalKey: job.Config.IncrementalKey, IntervalStart: job.Config.IntervalStart, IntervalEnd: job.Config.IntervalEnd,
+		ExtractPartitionBy: job.Config.ExtractPartitionBy, ExtractPartitionInterval: job.Config.ExtractPartitionInterval,
+		ExtractPartitionNumericInterval: job.Config.ExtractPartitionNumericInterval, ExtractPartitionAuto: job.Config.ExtractPartitionAuto,
+		PageSize: job.Config.PageSize, Limit: job.Config.SQLLimit, ExcludeColumns: job.Config.SQLExcludeColumns,
+		Parallelism: parallelism, Schema: job.SourceSchema, CDCResumeLSN: job.Config.CDCResumeLSN,
+		CDCResumeIncarnation: job.Config.CDCResumeIncarnation, CDCResumeSchemaFingerprint: job.Config.CDCResumeSchemaFingerprint,
+		CDCSlotSuffix: job.Config.CDCSlotSuffix, CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
+		CDCSnapshotReplace: true, FullRefresh: job.Config.FullRefresh,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get atomic append snapshot records: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+	if err := consumeAtomicSnapshotBoundary(readCtx, job, records); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return err
+	}
+	boundary := &atomicBatchSnapshotBoundary{}
+	attemptID, err := atomicSnapshotAttemptID(ctx, job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable)
+	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to establish durable atomic append snapshot attempt: %w", err)
+	}
+	opts := destination.AtomicSnapshotOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, TargetSchema: targetSchema,
+		PrimaryKeys: job.Schema.PrimaryKeys, PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy,
+		Parallelism: parallelism, AttemptID: attemptID, SkipCDCResume: true,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}
+	if err := publisher.BeginAtomicSnapshot(ctx, opts); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		abortAtomicAppendSnapshot(ctx, job.Destination, opts)
+		return fmt.Errorf("failed to begin atomic append snapshot: %w", err)
+	}
+	records = observeAtomicBatchSnapshot(readCtx, records, boundary)
+	publishAttempted := false
+	sealAttempted := false
+	defer func() {
+		if !publishAttempted && !sealAttempted {
+			abortAtomicAppendSnapshot(ctx, job.Destination, opts)
+		}
+	}()
+	if err := publisher.WriteAtomicSnapshot(readCtx, records, destination.WriteOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, PrimaryKeys: job.Schema.PrimaryKeys,
+		Parallelism: parallelism, AtomicSnapshotAttemptID: attemptID, SkipCDCResume: true,
+		CDCExpectedIncarnation: expectedIncarnation, PreStaged: job.PreStaged,
+	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to stage atomic append snapshot: %w", err)
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	opts.CommitToken = atomicSnapshotCommitID(opts.AttemptID)
+	opts.CDCResumeLSN = boundary.positionValue()
+	sealAttempted = true
+	cleanupNewTarget = false
+	if err := job.CDCStateManager.SealAtomicSnapshotAttempt(
+		ctx, job.Config.SourceTable, job.Config.DestTable, attemptID, opts.CDCResumeLSN, expectedIncarnation,
+	); err != nil {
+		return fmt.Errorf("failed to seal durable atomic append snapshot attempt: %w", err)
+	}
+	publishAttempted = true
+	cleanupNewTarget = false
+	publishedIncarnation, err := publisher.PublishAtomicSnapshot(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to publish atomic append snapshot: %w", err)
+	}
+	if publishedIncarnation == "" {
+		return fmt.Errorf("atomic append publication returned no physical incarnation")
+	}
+	if err := job.CDCStateManager.BindPublishedDestinationIncarnation(
+		ctx, job.Config.SourceTable, job.Config.DestTable, expectedIncarnation, publishedIncarnation,
+	); err != nil {
+		return fmt.Errorf("failed to revalidate published append snapshot: %w", err)
+	}
+	if err := completeAtomicSnapshotAttempt(
+		ctx, job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable, attemptID,
+	); err != nil {
+		return fmt.Errorf("failed to complete durable atomic append snapshot attempt: %w", err)
+	}
+	return nil
+}
+
+func abortAtomicAppendSnapshot(ctx context.Context, dest destination.Destination, opts destination.AtomicSnapshotOptions) {
+	aborter, ok := dest.(destination.AtomicSnapshotAborter)
+	if !ok {
+		return
+	}
+	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	_ = aborter.AbortAtomicSnapshot(abortCtx, opts)
+}
+
 // ExecuteMultiTable implements multi-table append strategy for CDC sources.
 func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIngestionJob) error {
 	if len(job.Tables) == 0 {
 		return nil
+	}
+	if publisher, canPublish := job.Destination.(destination.AtomicSnapshotPublisher); canPublish && job.CDCStateManager != nil && !job.Config.Stream {
+		needsSnapshot := job.Config.FullRefresh
+		for _, table := range job.Tables {
+			if hasCDCColumns(table.Schema) && strings.TrimSpace(job.CDCResumeLSNs[table.Name]) == "" {
+				needsSnapshot = true
+			}
+		}
+		if needsSnapshot {
+			direct, canWriteDirect := job.Destination.(destination.DirectMergeWriter)
+			if !canWriteDirect {
+				return fmt.Errorf("destination %s cannot safely combine atomic append snapshots with resumed multi-table writes", job.Destination.GetScheme())
+			}
+			appendJob := MultiTableIngestionJob{
+				Config:             job.Config,
+				Source:             job.Source,
+				Destination:        job.Destination,
+				Tables:             append([]source.SourceTableInfo(nil), job.Tables...),
+				TableDestNames:     job.TableDestNames,
+				Tracker:            job.Tracker,
+				CDCResumeLSNs:      job.CDCResumeLSNs,
+				EvolutionPlans:     job.EvolutionPlans,
+				CDCStateManager:    job.CDCStateManager,
+				WhitespaceTrimmer:  job.WhitespaceTrimmer,
+				LoadTimestamp:      job.LoadTimestamp,
+				ColumnRenamers:     job.ColumnRenamers,
+				NormalizeTableInfo: job.NormalizeTableInfo,
+			}
+			for i := range appendJob.Tables {
+				appendJob.Tables[i].PrimaryKeys = nil
+			}
+			return (&MergeStrategy{}).executeAtomicMultiTableBatch(ctx, &appendJob, publisher, direct)
+		}
+	}
+	if job.CDCStateManager != nil {
+		for _, table := range job.Tables {
+			if !hasCDCColumns(table.Schema) {
+				continue
+			}
+			if err := requireIdempotentCommitTokenWrites(job.Destination, "managed multi-table CDC append"); err != nil {
+				return err
+			}
+			break
+		}
 	}
 
 	config.Debug("[STRATEGY] Multi-table append with %d tables", len(job.Tables))
@@ -141,17 +365,20 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 
 			destTable := job.GetDestTableName(ti.Name)
 
-			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
-				errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
-				return
+			if job.CDCStateManager == nil {
+				if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+					errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+					return
+				}
 			}
 
 			// See Execute: CDC change batches land directly and carry the
 			// staging-only _cdc_unchanged_cols column.
-			isCDC := hasCDCColumns(ti.Schema)
-			prepSchema := destination.DestinationTableSchema(ti.Schema)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
+			isCDC := hasCDCColumns(writeSchema)
+			prepSchema := destination.DestinationTableSchema(writeSchema)
 			if isCDC {
-				prepSchema = ti.Schema
+				prepSchema = writeSchema
 			}
 
 			if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
@@ -171,11 +398,27 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 				}
 			}
 
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				var err error
+				expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, ti.Name, destTable)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if err := job.ApplyEvolutionForIfIncarnation(ctx, ti.Name, expectedIncarnation); err != nil {
+					errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+					return
+				}
+			}
 			mu.Lock()
 			tableConfigs[ti.Name] = destination.TableWriteConfig{
-				DestTable:   destTable,
-				Schema:      ti.Schema,
-				PrimaryKeys: ti.PrimaryKeys,
+				DestTable:              destTable,
+				Schema:                 writeSchema,
+				PrimaryKeys:            ti.PrimaryKeys,
+				CDCMode:                isCDC,
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: expectedIncarnation,
 			}
 			mu.Unlock()
 		}(tableInfo)
@@ -206,13 +449,14 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
 	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
-			Parallelism:         parallelism,
-			PageSize:            job.Config.PageSize,
-			Limit:               job.Config.SQLLimit,
-			CDCSlotSuffix:       job.Config.CDCSlotSuffix,
-			CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
-			CDCSnapshotReplace:  anyTableHasCDC && supportsCDCSnapshotReplace(job.Destination),
-			FullRefresh:         job.Config.FullRefresh,
+			Parallelism:          parallelism,
+			PageSize:             job.Config.PageSize,
+			Limit:                job.Config.SQLLimit,
+			CDCSlotSuffix:        job.Config.CDCSlotSuffix,
+			CDCLegacySlotSuffix:  job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace:   anyTableHasCDC && supportsCDCSnapshotReplace(job.Destination),
+			CDCStableDataBatches: anyTableHasCDC && job.CDCStateManager != nil,
+			FullRefresh:          job.Config.FullRefresh,
 		},
 		CDCResumeLSNs:               job.CDCResumeLSNs,
 		CDCResumeIncarnations:       resumeIncarnations,
@@ -225,17 +469,122 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	records = applyMultiTableSnapshotInvalidations(readCtx, job, records)
 
-	if err := multitable.Write(ctx, job.Destination, records, destination.MultiTableWriteOptions{
-		TableConfigs:     tableConfigs,
-		Parallelism:      job.Config.EffectiveDestinationParallelism(),
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		CancelSource:     cancelRead,
-	}); err != nil {
+	writeOptions := destination.MultiTableWriteOptions{
+		TableConfigs:       tableConfigs,
+		Parallelism:        job.Config.EffectiveDestinationParallelism(),
+		StagingBucket:      job.Config.StagingBucket,
+		LoaderFileSize:     job.Config.LoaderFileSize,
+		LoaderFileFormat:   job.Config.LoaderFileFormat,
+		CancelSource:       cancelRead,
+		CancelDrainTimeout: canceledSourceDrainTimeout,
+	}
+	if job.CDCStateManager != nil {
+		writeOptions.TableWriter = func(
+			writeCtx context.Context,
+			sourceTable string,
+			tableRecords <-chan source.RecordBatchResult,
+			opts destination.WriteOptions,
+		) (bool, error) {
+			if !tableConfigs[sourceTable].CDCMode {
+				return false, job.Destination.WriteParallel(writeCtx, tableRecords, opts)
+			}
+			return writeDurableCDCAppendRecords(writeCtx, job.Destination, tableRecords, opts, sourceTable, job.CDCStateManager)
+		}
+	}
+	if err := multitable.Write(ctx, job.Destination, records, writeOptions); err != nil {
 		return fmt.Errorf("failed to write multi-table data: %w", err)
 	}
 
 	return nil
+}
+
+func writeDurableCDCAppendRecords(
+	ctx context.Context,
+	dest destination.Destination,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+	sourceTable string,
+	stateManager *CDCStateManager,
+) (bool, error) {
+	truncated := false
+	for {
+		var result source.RecordBatchResult
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return truncated, ctx.Err()
+		case result, ok = <-records:
+			if !ok {
+				return truncated, nil
+			}
+		}
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return truncated, result.Err
+		}
+		if result.SnapshotInvalidation != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return truncated, fmt.Errorf("unexpected snapshot invalidation for %s after CDC append routing", sourceTable)
+		}
+		if result.Truncate {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			if !result.CDCWALTruncate {
+				return truncated, fmt.Errorf("managed CDC append replacement snapshots for table %s require atomic snapshot publication", opts.Table)
+			}
+			if stateManager == nil {
+				return truncated, fmt.Errorf("managed CDC append truncate for table %s has no destination state manager", opts.Table)
+			}
+			if err := stateManager.InvalidateSnapshotPreservingDestination(ctx, sourceTable, opts.Table, ""); err != nil {
+				return truncated, fmt.Errorf("failed to invalidate CDC state before source truncate for %s: %w", sourceTable, err)
+			}
+			if err := destination.ApplyCDCTruncateIfIncarnation(ctx, dest, opts.Table, opts.CDCExpectedIncarnation); err != nil {
+				return truncated, err
+			}
+			truncated = true
+			if token, ok := result.CommitToken.(source.CDCStateCommitToken); ok && token.Position != "" {
+				stateManager.RecordBatchSnapshotCompletion(sourceTable, token.Position)
+			}
+			continue
+		}
+		if result.TableName == "" {
+			result.TableName = sourceTable
+		}
+		if truncated {
+			token, ok := result.CommitToken.(source.CDCStateCommitToken)
+			if !ok || token.Position == "" {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return truncated, fmt.Errorf("post-truncate CDC batch for table %s has no typed source position", opts.Table)
+			}
+			writeOpts := opts
+			writeOpts.CommitToken = ""
+			writeOpts.CDCResumeLSN = ""
+			writeOpts.SkipCDCResume = true
+			batch := make(chan source.RecordBatchResult, 1)
+			batch <- source.RecordBatchResult{Batch: result.Batch}
+			close(batch)
+			if err := dest.WriteParallel(ctx, batch, writeOpts); err != nil {
+				drainAndRelease(batch)
+				return truncated, fmt.Errorf("failed to reapply post-truncate CDC batch to table %s: %w", opts.Table, err)
+			}
+			stateManager.RecordBatchSnapshotCompletion(sourceTable, token.Position)
+			continue
+		}
+		batch := make(chan source.RecordBatchResult, 1)
+		batch <- result
+		close(batch)
+		if err := writeDurableKeylessCDCRecords(ctx, dest, batch, opts); err != nil {
+			drainAndRelease(batch)
+			return truncated, err
+		}
+	}
 }

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,15 +14,259 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 	"github.com/stretchr/testify/require"
 )
 
+type contractCaptureReplaceDestination struct {
+	*fakeDestination
+	muCapture sync.Mutex
+	types     []arrow.DataType
+	nulls     []int
+	rows      []int64
+	schemas   []*schema.TableSchema
+	fields    [][]string
+}
+
+type directContractCaptureReplaceDestination struct {
+	*contractCaptureReplaceDestination
+}
+
+func (d *directContractCaptureReplaceDestination) SupportsAtomicSwap() bool { return false }
+
+func (d *contractCaptureReplaceDestination) WriteParallel(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	for result := range records {
+		if result.Batch != nil {
+			d.muCapture.Lock()
+			if result.Batch.NumCols() > 1 {
+				d.types = append(d.types, result.Batch.Column(1).DataType())
+				d.nulls = append(d.nulls, result.Batch.Column(1).NullN())
+			}
+			d.rows = append(d.rows, result.Batch.NumRows())
+			d.schemas = append(d.schemas, opts.Schema)
+			fields := make([]string, result.Batch.NumCols())
+			for i, field := range result.Batch.Schema().Fields() {
+				fields[i] = field.Name
+			}
+			d.fields = append(d.fields, fields)
+			d.muCapture.Unlock()
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
 func singleBatchRecords(t *testing.T, rows ...int64) <-chan source.RecordBatchResult {
 	t.Helper()
 	batch := int64RecordBatch(t, "id", rows, nil)
 	return mustClosedRecords(source.RecordBatchResult{Batch: batch})
+}
+
+func TestReplaceStrategyAppliesDiscardValueContractToRecreatedTable(t *testing.T) {
+	job, src, base := minimalJob()
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job.Destination = dest
+	job.Config.SchemaContract = "discard_value"
+	job.Schema = finalSchema
+	job.SourceSchema = sourceSchema
+	job.SchemaComparison = comparison
+	job.DestinationSchema = finalSchema
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	})
+
+	require.NoError(t, (&ReplaceStrategy{}).Execute(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Len(t, dest.types, 1)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.types[0]))
+	require.Equal(t, []int{1}, dest.nulls)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestReplaceStrategyAppliesDiscardRowContractToRecreatedTable(t *testing.T) {
+	job, src, base := minimalJob()
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job.Destination = dest
+	job.Config.SchemaContract = "discard_row"
+	job.Schema = finalSchema
+	job.SourceSchema = sourceSchema
+	job.SchemaComparison = comparison
+	job.DestinationSchema = finalSchema
+	job.SchemaAligner = transformer.NewSafeTypeCaster(finalSchema.ToArrowSchema())
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	})
+
+	require.NoError(t, (&ReplaceStrategy{}).Execute(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, []int64{0}, dest.rows)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestMultiTableReplaceUsesContractFinalSchemaAndTransformation(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	table := source.SourceTableInfo{Name: "public.events", Schema: sourceSchema}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	}
+	close(records)
+	dest := &contractCaptureReplaceDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace, SchemaContract: "discard_value"},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+		},
+	}
+
+	require.NoError(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Len(t, dest.types, 1)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.types[0]))
+	require.Equal(t, []int{1}, dest.nulls)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+	require.Equal(t, schema.TypeInt64, dest.prepareCalls[0].Schema.Columns[1].DataType)
+}
+
+func TestMultiTableReplaceDiscardRowFiltersViolations(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	table := source.SourceTableInfo{Name: "public.events", Schema: sourceSchema}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	}
+	close(records)
+	dest := &contractCaptureReplaceDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace, SchemaContract: "discard_row"},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+		},
+	}
+
+	require.NoError(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, []int64{0}, dest.rows)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestReplaceNeverPublishesStagingOnlyCDCColumns(t *testing.T) {
+	for _, direct := range []bool{false, true} {
+		name := "staging"
+		if direct {
+			name = "direct"
+		}
+		t.Run(name, func(t *testing.T) {
+			job, src, base := minimalJob()
+			fullSchema := &schema.TableSchema{Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true},
+			}}
+			capture := &contractCaptureReplaceDestination{fakeDestination: base}
+			if direct {
+				job.Destination = &directContractCaptureReplaceDestination{contractCaptureReplaceDestination: capture}
+			} else {
+				job.Destination = capture
+			}
+			job.Schema = fullSchema
+			job.SourceSchema = fullSchema
+			src.readCh = mustClosedRecords(source.RecordBatchResult{
+				Batch: intStringRecordBatch(t, "id", []int64{1}, "_cdc_unchanged_cols", []string{"value"}),
+			})
+
+			require.NoError(t, (&ReplaceStrategy{}).Execute(context.Background(), job))
+			capture.muCapture.Lock()
+			defer capture.muCapture.Unlock()
+			require.Equal(t, [][]string{{"id"}}, capture.fields)
+			require.Equal(t, []string{"id"}, capture.schemas[0].ColumnNames())
+			require.Equal(t, []string{"id"}, base.prepareCalls[0].Schema.ColumnNames())
+			if !direct {
+				require.Len(t, base.swapOptions, 1)
+				require.Equal(t, []string{"id"}, base.swapOptions[0].Schema.ColumnNames())
+			}
+		})
+	}
+}
+
+func TestMultiTableReplaceNeverPublishesStagingOnlyCDCColumns(t *testing.T) {
+	fullSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true},
+	}}
+	table := source.SourceTableInfo{Name: "events", Schema: fullSchema}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "_cdc_unchanged_cols", []string{"value"}),
+	}
+	close(records)
+	base := &fakeDestination{}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+	}
+
+	require.NoError(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, [][]string{{"id"}}, dest.fields)
+	require.Equal(t, []string{"id"}, dest.schemas[0].ColumnNames())
+	require.Equal(t, []string{"id"}, base.prepareCalls[0].Schema.ColumnNames())
+	require.Equal(t, []string{"id"}, base.swapOptions[0].Schema.ColumnNames())
 }
 
 func TestIngestionJob_GetRecords_UsesBuffered(t *testing.T) {
@@ -337,6 +582,52 @@ func TestReplaceStrategy_Execute_HappyPath(t *testing.T) {
 	}
 }
 
+func TestReplaceStrategyManagedCDCDoesNotDelegateTargetCursor(t *testing.T) {
+	job, src, _ := minimalJob()
+	dest := &replaceCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "managed-replace", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.Destination = dest
+	job.Config.IncrementalStrategy = config.StrategyReplace
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords()
+	require.NoError(t, (&ReplaceStrategy{}).Execute(t.Context(), job))
+	require.Len(t, dest.writeCalls, 1)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+	require.Len(t, dest.mergeCalls, 1)
+	require.True(t, dest.mergeCalls[0].SkipCDCResume)
+	dest.stateMu.Lock()
+	dest.incarnations[job.Config.DestTable] = "externally-replaced"
+	dest.stateMu.Unlock()
+	err = manager.Persist(t.Context(), source.CDCStateCommitToken{
+		Position: "0/20", SnapshotPositions: map[string]string{job.Config.SourceTable: "0/10"},
+		SnapshotIncarnations: map[string]string{job.Config.SourceTable: "source-v1"},
+	})
+	require.ErrorContains(t, err, "was replaced during its snapshot")
+}
+
+func TestManagedReplaceFailsClosedWithoutConditionalSwap(t *testing.T) {
+	job, src, _ := minimalJob()
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "managed-replace-unsupported-swap", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.Destination = dest
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords()
+	prepareCalls := len(dest.prepareCalls)
+	writeCalls := len(dest.writeCalls)
+
+	err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "cannot atomically fence managed CDC table replacement")
+	require.Len(t, dest.prepareCalls, prepareCalls)
+	require.Len(t, dest.writeCalls, writeCalls)
+	require.Empty(t, dest.swapCalls)
+}
+
 func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing.T) {
 	job, src, dest := minimalJob()
 	src.primaryKeysUnique = true
@@ -359,6 +650,899 @@ func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing
 	if len(dest.swapCalls) != 1 || dest.swapCalls[0][0] != dest.prepareCalls[0].Table {
 		t.Fatalf("expected staging table to be swapped directly, got swaps=%v prepares=%v", dest.swapCalls, dest.prepareCalls)
 	}
+}
+
+func TestReplaceStrategy_Execute_SkipsDedupWhenWhitespaceTrimmingCannotChangeNumericPrimaryKey(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.WhitespaceTrimmer = transformer.NewWhitespaceTrimmer()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 1 {
+		t.Fatalf("expected unique numeric primary key to keep fast path, got %d PrepareTable calls", len(dest.prepareCalls))
+	}
+	if len(dest.mergeCalls) != 0 {
+		t.Fatalf("expected no MergeTable call for numeric primary key, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_DedupsWhenWhitespaceTrimmingCanCollapseStringPrimaryKeys(t *testing.T) {
+	job, src, dest := minimalJob()
+	stringPrimaryKeySchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeString, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	job.Schema = stringPrimaryKeySchema
+	job.SourceSchema = stringPrimaryKeySchema
+	job.WhitespaceTrimmer = transformer.NewWhitespaceTrimmer()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected trim-sensitive primary key to use dedup path, got %d PrepareTable calls", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("raw staging table should be PK-free after whitespace trimming, got %v", got)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected MergeTable call after whitespace trimming, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_RequestsDirectAtomicDeduplication(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &directReplaceDestination{fakeDestination: dest}
+	job.Config.IncrementalKey = "id"
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 1 || dest.prepareCalls[0].Table != job.Config.DestTable {
+		t.Fatalf("direct replace should prepare the target once, got %+v", dest.prepareCalls)
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("direct target should retain its primary key metadata, got %v", got)
+	}
+	if len(dest.writeCalls) != 1 {
+		t.Fatalf("expected one direct write, got %d", len(dest.writeCalls))
+	}
+	if !dest.writeCalls[0].DeduplicatePrimaryKeys {
+		t.Fatal("direct replace did not request primary-key deduplication")
+	}
+	if got := dest.writeCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("WriteOptions.PrimaryKeys = %v, want [id]", got)
+	}
+	if dest.writeCalls[0].IncrementalKey != "id" {
+		t.Fatalf("WriteOptions.IncrementalKey = %q, want id", dest.writeCalls[0].IncrementalKey)
+	}
+	if len(dest.mergeCalls) != 0 || len(dest.swapCalls) != 0 {
+		t.Fatalf("direct replace should not stage/merge/swap, merge=%v swap=%v", dest.mergeCalls, dest.swapCalls)
+	}
+}
+
+type directReplaceDestination struct {
+	*fakeDestination
+}
+
+func (d *directReplaceDestination) SupportsAtomicSwap() bool { return false }
+func (d *directReplaceDestination) SupportsDirectReplaceDeduplication() bool {
+	return true
+}
+
+type replaceCDCStateDestination struct{ *cdcStateDestination }
+
+func (*replaceCDCStateDestination) SupportsCDCConditionalSwap() bool { return true }
+
+func (d *replaceCDCStateDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.fakeDestination.WriteParallel(ctx, records, opts)
+}
+
+func (d *replaceCDCStateDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	targetIncarnation, _, _ := d.CDCTargetIncarnation(ctx, opts.TargetTable)
+	if opts.CDCExpectedIncarnation != targetIncarnation {
+		return errors.New("destination target incarnation changed before staged replacement publish")
+	}
+	stagingIncarnation, _, _ := d.CDCTargetIncarnation(ctx, opts.StagingTable)
+	if opts.CDCExpectedStagingIncarnation != stagingIncarnation {
+		return errors.New("destination staging incarnation changed before staged replacement publish")
+	}
+	if err := d.fakeDestination.SwapTable(ctx, opts); err != nil {
+		return err
+	}
+	d.stateMu.Lock()
+	d.incarnations[opts.TargetTable] = stagingIncarnation
+	d.stateMu.Unlock()
+	return nil
+}
+
+type managedDirectReplaceDestination struct{ *replaceCDCStateDestination }
+
+func (*managedDirectReplaceDestination) SupportsAtomicSwap() bool { return false }
+func (*managedDirectReplaceDestination) SupportsDirectReplaceDeduplication() bool {
+	return true
+}
+
+type recreatingDirectReplaceDestination struct {
+	*managedDirectReplaceDestination
+	recreateTable string
+}
+
+func (d *recreatingDirectReplaceDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.stateMu.Lock()
+	d.incarnations[d.recreateTable] = "external-v2"
+	d.stateMu.Unlock()
+	current, _, _ := d.CDCTargetIncarnation(ctx, d.recreateTable)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	if opts.CDCExpectedIncarnation != current {
+		return errors.New("destination incarnation changed before direct replacement write")
+	}
+	return nil
+}
+
+type recreatingStagedReplaceDestination struct {
+	*replaceCDCStateDestination
+	recreateTable string
+}
+
+type recreatingAfterStagedReplaceDestination struct {
+	*replaceCDCStateDestination
+}
+
+type recreatingStagingAtSwapDestination struct {
+	*replaceCDCStateDestination
+}
+
+func (d *recreatingStagingAtSwapDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	d.stateMu.Lock()
+	d.incarnations[opts.StagingTable] = "unrelated-staging-recreation"
+	d.stateMu.Unlock()
+	return d.replaceCDCStateDestination.SwapTable(ctx, opts)
+}
+
+func (d *recreatingAfterStagedReplaceDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if err := d.replaceCDCStateDestination.SwapTable(ctx, opts); err != nil {
+		return err
+	}
+	d.stateMu.Lock()
+	d.incarnations[opts.TargetTable] = "unrelated-recreation"
+	d.stateMu.Unlock()
+	return nil
+}
+
+func (d *recreatingStagedReplaceDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if err := d.fakeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	d.stateMu.Lock()
+	d.incarnations[d.recreateTable] = "external-v2"
+	d.stateMu.Unlock()
+	return nil
+}
+
+func (d *recreatingStagedReplaceDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	current, _, _ := d.CDCTargetIncarnation(ctx, opts.TargetTable)
+	if opts.CDCExpectedIncarnation != current {
+		return errors.New("destination incarnation changed before staged replacement publish")
+	}
+	return d.replaceCDCStateDestination.SwapTable(ctx, opts)
+}
+
+func TestManagedReplaceRejectsTargetRecreationDuringExtraction(t *testing.T) {
+	for _, staged := range []bool{false, true} {
+		name := "direct"
+		if staged {
+			name = "staged"
+		}
+		t.Run(name, func(t *testing.T) {
+			job, src, _ := minimalJob()
+			stateDest := newCDCStateDestination()
+			stateDest.incarnations[job.Config.DestTable] = "target-v1"
+			base := &replaceCDCStateDestination{cdcStateDestination: stateDest}
+			if staged {
+				job.Destination = &recreatingStagedReplaceDestination{replaceCDCStateDestination: base, recreateTable: job.Config.DestTable}
+			} else {
+				job.Destination = &recreatingDirectReplaceDestination{
+					managedDirectReplaceDestination: &managedDirectReplaceDestination{replaceCDCStateDestination: base},
+					recreateTable:                   job.Config.DestTable,
+				}
+			}
+			manager, err := NewCDCStateManager(job.Destination, "replace-recreation-"+name, job.Config.DestTable, "")
+			require.NoError(t, err)
+			require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+			require.NoError(t, manager.BeginRun(t.Context(), true))
+			job.CDCStateManager = manager
+			src.readCh = singleBatchRecords(t, 1)
+
+			err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+			require.ErrorContains(t, err, "incarnation changed")
+		})
+	}
+}
+
+func TestManagedReplaceRejectsRecreationAfterFencedPublication(t *testing.T) {
+	job, src, _ := minimalJob()
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &recreatingAfterStagedReplaceDestination{replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest}}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "replace-post-publication-recreation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	src.readCh = singleBatchRecords(t, 1)
+
+	err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "changed after its fenced replacement")
+}
+
+func TestManagedReplaceRejectsStagingRecreationBeforeFencedPublication(t *testing.T) {
+	job, src, _ := minimalJob()
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &recreatingStagingAtSwapDestination{replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest}}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "replace-staging-recreation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	src.readCh = singleBatchRecords(t, 1)
+
+	err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "staging incarnation changed")
+	current, exists, incarnationErr := dest.CDCTargetIncarnation(t.Context(), job.Config.DestTable)
+	require.NoError(t, incarnationErr)
+	require.True(t, exists)
+	require.Equal(t, "target-v1", current)
+}
+
+func TestManagedMultiTableReplaceRejectsTargetRecreationDuringExtraction(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := mustClosedRecords(source.RecordBatchResult{
+		TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	})
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["users"] = "target-v1"
+	dest := &recreatingDirectReplaceDestination{
+		managedDirectReplaceDestination: &managedDirectReplaceDestination{
+			replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest},
+		},
+		recreateTable: "users",
+	}
+	manager, err := NewCDCStateManager(dest, "multi-replace-recreation", "users", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "users", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "users"},
+		CDCStateManager: manager,
+	}
+
+	err = (&ReplaceStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed")
+}
+
+func TestManagedMultiTableReplaceBindFailureCleansOnlyUnpublishedStaging(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{TableName: tables[0].Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{TableName: tables[1].Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+	)
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["users"] = "users-v1"
+	stateDest.incarnations["orders"] = "orders-v1"
+	dest := &recreatingAfterStagedReplaceDestination{replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest}}
+	manager, err := NewCDCStateManager(dest, "multi-replace-bind-failure", "users", "")
+	require.NoError(t, err)
+	for _, table := range tables {
+		require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, strings.TrimPrefix(table.Name, "public."), "source-v1"))
+	}
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{}, Source: &announcingMultiTableSource{tables: tables, records: records},
+		Destination: dest, Tables: tables,
+		TableDestNames:  map[string]string{"public.users": "users", "public.orders": "orders"},
+		CDCStateManager: manager,
+	}
+
+	err = (&ReplaceStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "changed after its fenced replacement")
+	var stagingTables []string
+	for _, call := range stateDest.prepareCalls {
+		if call.ExpiresAfter == destination.ManagedStagingTTL {
+			stagingTables = append(stagingTables, call.Table)
+		}
+	}
+	require.GreaterOrEqual(t, len(stagingTables), 2)
+	require.Len(t, stateDest.swapCalls, 1)
+	publishedStaging := stateDest.swapCalls[0][0]
+	var unpublishedStaging []string
+	for _, stagingTable := range stagingTables {
+		if stagingTable != publishedStaging {
+			unpublishedStaging = append(unpublishedStaging, stagingTable)
+		}
+	}
+	require.ElementsMatch(t, unpublishedStaging, stateDest.dropCalls)
+	require.NotContains(t, stateDest.dropCalls, publishedStaging)
+	require.NotContains(t, stateDest.dropCalls, "users")
+}
+
+type directReplaceWithoutDedupDestination struct {
+	*fakeDestination
+}
+
+func (d *directReplaceWithoutDedupDestination) SupportsAtomicSwap() bool { return false }
+
+func TestReplaceStrategy_Execute_DoesNotRequestDirectDeduplicationWithoutCapability(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &directReplaceWithoutDedupDestination{fakeDestination: dest}
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.writeCalls) != 1 {
+		t.Fatalf("expected one direct write, got %d", len(dest.writeCalls))
+	}
+	if dest.writeCalls[0].DeduplicatePrimaryKeys {
+		t.Fatal("direct replace requested deduplication from a destination without the capability")
+	}
+	if got := dest.writeCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("WriteOptions.PrimaryKeys = %v, want [id]", got)
+	}
+}
+
+func TestReplaceStrategy_DirectFailurePreservesUnownedTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*fakeSourceTable, *fakeDestination)
+	}{
+		{
+			name: "read start failure",
+			configure: func(src *fakeSourceTable, _ *fakeDestination) {
+				src.readErr = errors.New("source unavailable")
+			},
+		},
+		{
+			name: "write failure",
+			configure: func(src *fakeSourceTable, dest *fakeDestination) {
+				src.readCh = mustClosedRecords()
+				dest.writeErr = errors.New("catalog rejected write")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job, src, dest := minimalJob()
+			job.Destination = &directReplaceDestination{fakeDestination: dest}
+			tc.configure(src, dest)
+
+			err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+			if err == nil {
+				t.Fatal("expected direct replace to fail")
+			}
+			require.Empty(t, dest.dropCalls, "an unowned target may have been created by another writer")
+		})
+	}
+}
+
+func TestReplaceStrategy_DirectFailurePreservesPreexistingTarget(t *testing.T) {
+	job, src, dest := minimalJob()
+	dest.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: job.Schema}
+	job.Destination = &directReplaceDestination{fakeDestination: dest}
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("catalog rejected write")
+
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected direct replace to fail")
+	}
+	if len(dest.dropCalls) != 0 {
+		t.Fatalf("preexisting target must survive failed direct replace, got drops %v", dest.dropCalls)
+	}
+}
+
+func TestReplaceStrategy_ReadSetupFailureDropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.readErr = errors.New("source unavailable")
+
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected read setup failure")
+	}
+	staging := dest.prepareCalls[0].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
+	}
+}
+
+func TestReplaceStrategy_WriterFailureBoundsNonclosingSourceDrain(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailStagedMergeDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	if time.Since(started) > time.Second {
+		t.Fatal("replace waited indefinitely for a nonclosing source")
+	}
+	close(records)
+	if len(base.dropCalls) != 1 {
+		t.Fatalf("expected failed replace staging cleanup, got %v", base.dropCalls)
+	}
+}
+
+func TestReplaceStrategy_ExecuteMultiTable_PropagatesDirectDeduplicationConfiguration(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tableSchema.IncrementalKey = "id"
+	table := source.SourceTableInfo{
+		Name:        "public.users",
+		Schema:      tableSchema,
+		PrimaryKeys: []string{"id"},
+	}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	stateDest := newCDCStateDestination()
+	replaceDest := &replaceCDCStateDestination{cdcStateDestination: stateDest}
+	managedDest := &managedDirectReplaceDestination{replaceCDCStateDestination: replaceDest}
+	manager, err := NewCDCStateManager(managedDest, "managed-multi-replace", "users", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "users", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	dest := stateDest.fakeDestination
+	job := &MultiTableIngestionJob{
+		Config:          &config.IngestConfig{},
+		Source:          src,
+		Destination:     managedDest,
+		Tables:          src.tables,
+		TableDestNames:  map[string]string{"public.users": "users"},
+		CDCStateManager: manager,
+	}
+
+	if err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job); err != nil {
+		t.Fatalf("ExecuteMultiTable returned error: %v", err)
+	}
+
+	if len(dest.writeCalls) != 1 {
+		t.Fatalf("expected one table write, got %d", len(dest.writeCalls))
+	}
+	write := dest.writeCalls[0]
+	if !write.DeduplicatePrimaryKeys {
+		t.Fatal("multi-table direct replace did not request primary-key deduplication")
+	}
+	if got := write.PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("WriteOptions.PrimaryKeys = %v, want [id]", got)
+	}
+	if write.IncrementalKey != "id" {
+		t.Fatalf("WriteOptions.IncrementalKey = %q, want id", write.IncrementalKey)
+	}
+	if !write.SkipCDCResume {
+		t.Fatal("managed multi-table direct replace delegated the CDC cursor to the destination")
+	}
+	stateDest.stateMu.Lock()
+	stateDest.incarnations["users"] = "externally-replaced"
+	stateDest.stateMu.Unlock()
+	err = manager.Persist(t.Context(), source.CDCStateCommitToken{
+		Position: "0/20", SnapshotPositions: map[string]string{table.Name: "0/10"},
+		SnapshotIncarnations: map[string]string{table.Name: "source-v1"},
+	})
+	require.ErrorContains(t, err, "was replaced during its snapshot")
+}
+
+func TestReplaceStrategy_MultiTableDirectWriteFailurePreservesAttemptedTargets(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Err: errors.New("source stream failed")}
+	close(records)
+	src := &announcingMultiTableSource{tables: tables, records: records}
+	base := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{
+		"users": tableSchema,
+	}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
+		Source:      src,
+		Destination: &directReplaceDestination{fakeDestination: base},
+		Tables:      tables,
+		TableDestNames: map[string]string{
+			"public.users":  "users",
+			"public.orders": "orders",
+		},
+	}
+
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected multi-table direct replace to fail")
+	}
+	require.Empty(t, base.dropCalls, "multi-table write errors may follow durable writes")
+}
+
+func TestReplaceStrategy_MultiTableSwapFailureCleansActiveStages(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tableSchema.IncrementalKey = "id"
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	dest := &fakeDestination{swapErr: errors.New("swap failed")}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    dest,
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected swap failure")
+	}
+	if len(dest.dropCalls) < 2 {
+		t.Fatalf("expected raw and normalised stage cleanup, got %v", dest.dropCalls)
+	}
+	normalised := dest.prepareCalls[len(dest.prepareCalls)-1].Table
+	if dest.dropCalls[len(dest.dropCalls)-1] != normalised {
+		t.Fatalf("expected active normalised stage %q to be cleaned, got %v", normalised, dest.dropCalls)
+	}
+}
+
+func TestAppendStrategy_WriterFailureBoundsNonclosingSource(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailStagedMergeDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&AppendStrategy{}).Execute(context.Background(), job)
+	if err == nil || time.Since(started) > time.Second {
+		t.Fatalf("append did not return promptly after writer failure: %v", err)
+	}
+	close(records)
+}
+
+type cancelAwareMultiTableSource struct {
+	*announcingMultiTableSource
+	done chan struct{}
+}
+
+func (s *cancelAwareMultiTableSource) ReadAll(ctx context.Context, _ source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(s.done)
+		defer close(records)
+		for {
+			select {
+			case records <- source.RecordBatchResult{TableName: s.tables[0].Name}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return records, nil
+}
+
+type immediateFailMultiTableDestination struct {
+	*directReplaceDestination
+}
+
+type ownedDirectReplaceDestination struct {
+	*directReplaceDestination
+	preparedToken string
+	dropTokens    []string
+	ownerChanged  bool
+}
+
+type uncertainPrepareOwnedDestination struct {
+	*directReplaceDestination
+	preparedToken string
+	dropTokens    []string
+}
+
+func (d *uncertainPrepareOwnedDestination) PrepareTable(_ context.Context, opts destination.PrepareOptions) error {
+	d.preparedToken = opts.OwnershipToken
+	return errors.New("prepare response lost after target creation")
+}
+
+func (d *uncertainPrepareOwnedDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	return nil
+}
+
+type contextAwareDropDestination struct {
+	*fakeDestination
+	successfulDrops []string
+}
+
+type uncertainManagedStagingPrepareDestination struct {
+	*contextAwareDropDestination
+}
+
+func (d *uncertainManagedStagingPrepareDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := d.contextAwareDropDestination.PrepareTable(ctx, opts); err != nil {
+		return err
+	}
+	if opts.ExpiresAfter > 0 {
+		return errors.New("managed staging prepare response lost after create")
+	}
+	return nil
+}
+
+func (d *contextAwareDropDestination) DropTable(ctx context.Context, table string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d.successfulDrops = append(d.successfulDrops, table)
+	return d.fakeDestination.DropTable(ctx, table)
+}
+
+func (d *ownedDirectReplaceDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	d.preparedToken = opts.OwnershipToken
+	return d.directReplaceDestination.PrepareTable(ctx, opts)
+}
+
+func (d *ownedDirectReplaceDestination) WriteParallel(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	d.ownerChanged = true
+	return errors.New("write failed after replacement owner appeared")
+}
+
+func (d *ownedDirectReplaceDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	if d.ownerChanged {
+		return errors.New("ownership changed")
+	}
+	return nil
+}
+
+func TestDirectReplaceWriteFailurePreservesOwnedTarget(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	dest := &ownedDirectReplaceDestination{
+		directReplaceDestination: &directReplaceDestination{fakeDestination: base},
+	}
+	job.Destination = dest
+
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "ownership does not prove a failed write was uncommitted")
+	if len(base.dropCalls) != 0 {
+		t.Fatalf("unconditional cleanup deleted a replacement owner: %v", base.dropCalls)
+	}
+}
+
+func TestMultiTableDirectReplaceWriteFailurePreservesOwnedTarget(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &ownedDirectReplaceDestination{
+		directReplaceDestination: &directReplaceDestination{fakeDestination: base},
+	}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	require.Error(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "ownership does not prove a failed write was uncommitted")
+	require.Empty(t, base.dropCalls, "unconditional cleanup must not delete the replacement owner")
+}
+
+func TestDirectReplaceUncertainPrepareFailureCleansRegisteredOwnedTarget(t *testing.T) {
+	job, _, base := minimalJob()
+	dest := &uncertainPrepareOwnedDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).Execute(context.Background(), job), "prepare response lost")
+	require.NotEmpty(t, dest.preparedToken)
+	require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+	require.Empty(t, base.dropCalls)
+}
+
+func TestFailedOwnedDirectCleanupRequiresDestinationEnforcedOwnership(t *testing.T) {
+	dest := &fakeDestination{}
+
+	cleanupFailedOwnedDirectReplace(context.Background(), dest, "concurrent_target", true, "untrusted-token")
+
+	require.Empty(t, dest.dropCalls)
+}
+
+func TestMultiTableDirectReplaceUncertainPrepareFailureCleansRegisteredOwnedTarget(t *testing.T) {
+	table := source.SourceTableInfo{Name: "users", Schema: streamTestSchema()}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &uncertainPrepareOwnedDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job), "prepare response lost")
+	require.NotEmpty(t, dest.preparedToken)
+	require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+	require.Empty(t, base.dropCalls)
+}
+
+func TestReplaceFailureUsesDetachedStagingCleanupContext(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	base.swapErr = errors.New("swap failed")
+	dest := &contextAwareDropDestination{fakeDestination: base}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := (&ReplaceStrategy{}).Execute(ctx, job)
+	if err == nil {
+		t.Fatal("expected replace failure")
+	}
+	if len(dest.successfulDrops) != 2 {
+		t.Fatalf("staging cleanup inherited canceled caller context: %v", dest.successfulDrops)
+	}
+}
+
+func TestMultiTableReplaceLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	table := source.SourceTableInfo{Name: "users", Schema: streamTestSchema()}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "users"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).ExecuteMultiTable(ctx, job), "prepare response lost")
+	require.Len(t, dest.successfulDrops, 1)
+	require.Equal(t, base.prepareCalls[0].Table, dest.successfulDrops[0])
+}
+
+func TestReplaceLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 1)
+	require.Equal(t, []string{base.prepareCalls[0].Table}, dest.successfulDrops)
+}
+
+func TestDeduplicateStagingLostNormalisedPrepareCleansBothStagesDetached(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	rawTable := "lake.events_raw"
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := deduplicateStaging(ctx, dest, rawTable, "lake.events", "", "", streamTestSchema(), []string{"id"}, "", nil, false)
+	require.ErrorContains(t, err, "prepare response lost")
+	require.Len(t, base.prepareCalls, 1)
+	require.ElementsMatch(t, []string{rawTable, base.prepareCalls[0].Table}, dest.successfulDrops)
+}
+
+func (d *immediateFailMultiTableDestination) WriteParallel(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	return errors.New("writer failed")
+}
+
+func TestReplaceStrategy_MultiTableWriterFailureCancelsSource(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema}
+	done := make(chan struct{})
+	src := &cancelAwareMultiTableSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		done:                       done,
+	}
+	base := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    &immediateFailMultiTableDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("source producer remained blocked after writer failure")
+	}
+}
+
+func TestReplaceStrategy_MultiTableWriterFailureBoundsNonclosingSourceDrain(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema}
+	records := make(chan source.RecordBatchResult)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	base := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    &immediateFailMultiTableDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	started := time.Now()
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	if time.Since(started) > time.Second {
+		t.Fatal("replace waited indefinitely for a nonclosing source")
+	}
+	close(records)
 }
 
 func TestReplaceStrategy_Execute_UsesDestinationReplaceStagingPolicy(t *testing.T) {

--- a/pkg/strategy/cdc_schema_evolution_fence_test.go
+++ b/pkg/strategy/cdc_schema_evolution_fence_test.go
@@ -1,0 +1,301 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type recreatingSchemaEvolutionDestination struct {
+	*cdcStateDestination
+
+	evolutionMu          sync.Mutex
+	fencedCalls          int
+	unfencedCalls        int
+	expectedIncarnations []string
+	recreateBeforeFenced bool
+	writeTokenMu         sync.Mutex
+	committedWriteTokens map[source.DurableID]struct{}
+}
+
+func (*recreatingSchemaEvolutionDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+func (d *recreatingSchemaEvolutionDestination) WriteParallel(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.writeTokenMu.Lock()
+	defer d.writeTokenMu.Unlock()
+	if d.committedWriteTokens == nil {
+		d.committedWriteTokens = make(map[source.DurableID]struct{})
+	}
+	if _, duplicate := d.committedWriteTokens[opts.CommitToken]; opts.CommitToken != "" && duplicate {
+		drainAndRelease(records)
+		return nil
+	}
+	if err := d.fakeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	if opts.CommitToken != "" {
+		d.committedWriteTokens[opts.CommitToken] = struct{}{}
+	}
+	return nil
+}
+
+func (d *recreatingSchemaEvolutionDestination) ApplySchemaEvolution(
+	ctx context.Context,
+	table string,
+	comparison *schemaevolution.SchemaComparison,
+) ([]string, error) {
+	d.evolutionMu.Lock()
+	d.unfencedCalls++
+	d.evolutionMu.Unlock()
+	return d.fakeDestination.ApplySchemaEvolution(ctx, table, comparison)
+}
+
+func (d *recreatingSchemaEvolutionDestination) ApplySchemaEvolutionIfIncarnation(
+	ctx context.Context,
+	table string,
+	comparison *schemaevolution.SchemaComparison,
+	expectedIncarnation string,
+) ([]string, error) {
+	d.evolutionMu.Lock()
+	d.fencedCalls++
+	d.expectedIncarnations = append(d.expectedIncarnations, expectedIncarnation)
+	recreate := d.recreateBeforeFenced
+	d.recreateBeforeFenced = false
+	d.evolutionMu.Unlock()
+
+	d.stateMu.Lock()
+	if recreate {
+		d.incarnations[table] = "target-v2"
+	}
+	currentIncarnation := d.incarnations[table]
+	d.stateMu.Unlock()
+	if currentIncarnation != expectedIncarnation {
+		return nil, fmt.Errorf("destination physical incarnation changed before schema evolution")
+	}
+	return d.fakeDestination.ApplySchemaEvolution(ctx, table, comparison)
+}
+
+func managedEvolutionPlan(table string) *schemaevolution.EvolutionPlan {
+	return &schemaevolution.EvolutionPlan{
+		Table: table,
+		Comparison: &schemaevolution.SchemaComparison{
+			HasChanges: true,
+			Changes: []schemaevolution.SchemaChange{{
+				Type:       schemaevolution.ChangeAddColumn,
+				ColumnName: "new_column",
+				NewColumn: schema.Column{
+					Name: "new_column", DataType: schema.TypeString, Nullable: true,
+				},
+			}},
+		},
+	}
+}
+
+func managedEvolutionSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+}
+
+func newRecreatingEvolutionDestination(destTable string) *recreatingSchemaEvolutionDestination {
+	base := newCDCStateDestination()
+	base.incarnations[destTable] = "target-v1"
+	return &recreatingSchemaEvolutionDestination{
+		cdcStateDestination:  base,
+		recreateBeforeFenced: true,
+	}
+}
+
+func newManagedEvolutionStateManager(
+	t *testing.T,
+	dest *recreatingSchemaEvolutionDestination,
+	sourceTable string,
+	destTable string,
+) *CDCStateManager {
+	t.Helper()
+	manager, err := NewCDCStateManager(dest, "managed-schema-evolution", destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(t.Context(), sourceTable, destTable, "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	return manager
+}
+
+func managedEvolutionJob(t *testing.T) (*IngestionJob, *fakeSourceTable, *recreatingSchemaEvolutionDestination) {
+	t.Helper()
+	job, src, _ := minimalJob()
+	job.Schema = managedEvolutionSchema()
+	job.SourceSchema = job.Schema
+	job.Config.PrimaryKeys = []string{"id"}
+	job.EvolutionPlan = managedEvolutionPlan(job.Config.DestTable)
+	dest := newRecreatingEvolutionDestination(job.Config.DestTable)
+	job.Destination = dest
+	job.CDCStateManager = newManagedEvolutionStateManager(t, dest, job.Config.SourceTable, job.Config.DestTable)
+	return job, src, dest
+}
+
+func requireRejectedRecreatedEvolution(t *testing.T, dest *recreatingSchemaEvolutionDestination) {
+	t.Helper()
+	dest.evolutionMu.Lock()
+	defer dest.evolutionMu.Unlock()
+	require.Equal(t, 1, dest.fencedCalls)
+	require.Zero(t, dest.unfencedCalls)
+	require.Equal(t, []string{"target-v1"}, dest.expectedIncarnations)
+	require.Empty(t, dest.execCalls)
+}
+
+func TestRecreatingSchemaEvolutionDestinationDeduplicatesCommitTokens(t *testing.T) {
+	dest := newRecreatingEvolutionDestination("raw.items")
+	opts := destination.WriteOptions{Table: "raw.items", CommitToken: "data:0/10"}
+	records := func() <-chan source.RecordBatchResult {
+		return mustClosedRecords(source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)})
+	}
+
+	require.NoError(t, dest.WriteParallel(t.Context(), records(), opts))
+	require.NoError(t, dest.WriteParallel(t.Context(), records(), opts))
+	require.Len(t, dest.writeCalls, 1)
+}
+
+func TestManagedCDCEvolutionWithoutChangesDoesNotRequireFencedEvolver(t *testing.T) {
+	dest := &fakeDestination{}
+	plan := &schemaevolution.EvolutionPlan{
+		Table:      "raw.items",
+		Comparison: &schemaevolution.SchemaComparison{},
+	}
+
+	require.NoError(t, applyEvolutionPlanIfIncarnation(t.Context(), dest, plan, "target-v1"))
+	require.Empty(t, dest.execCalls)
+}
+
+func TestManagedCDCAppendRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	job, src, dest := managedEvolutionJob(t)
+
+	err := (&AppendStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.False(t, src.readCalled)
+	requireRejectedRecreatedEvolution(t, dest)
+}
+
+func TestManagedCDCMergeRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	job, src, dest := managedEvolutionJob(t)
+	src.readCh = mustClosedRecords()
+
+	err := (&MergeStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.True(t, src.readCalled)
+	require.Empty(t, dest.mergeCalls)
+	requireRejectedRecreatedEvolution(t, dest)
+}
+
+func managedMultiTableEvolutionJob(t *testing.T) (*MultiTableIngestionJob, *announcingMultiTableSource, *recreatingSchemaEvolutionDestination) {
+	t.Helper()
+	sourceTable := "public.items"
+	destTable := "raw.items"
+	tableSchema := managedEvolutionSchema()
+	table := source.SourceTableInfo{Name: sourceTable, Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	dest := newRecreatingEvolutionDestination(destTable)
+	manager := newManagedEvolutionStateManager(t, dest, sourceTable, destTable)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: mustClosedRecords()}
+	return &MultiTableIngestionJob{
+		Config:          &config.IngestConfig{NoLoadTimestamp: true},
+		Source:          src,
+		Destination:     dest,
+		Tables:          []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{sourceTable: destTable},
+		EvolutionPlans:  map[string]*schemaevolution.EvolutionPlan{sourceTable: managedEvolutionPlan(destTable)},
+		CDCStateManager: manager,
+	}, src, dest
+}
+
+func TestManagedCDCMultiTableAppendRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	job, src, dest := managedMultiTableEvolutionJob(t)
+
+	err := (&AppendStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.Empty(t, src.readOpts.KnownTables)
+	requireRejectedRecreatedEvolution(t, dest)
+}
+
+func TestManagedCDCMultiTableMergeRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	job, src, dest := managedMultiTableEvolutionJob(t)
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.Empty(t, src.readOpts.KnownTables)
+	requireRejectedRecreatedEvolution(t, dest)
+}
+
+func TestManagedCDCStreamingStartupRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	job, src, dest := managedEvolutionJob(t)
+	job.Config.Stream = true
+
+	err := NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: job.CDCStateManager,
+	}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.False(t, src.readCalled)
+	requireRejectedRecreatedEvolution(t, dest)
+}
+
+func TestManagedCDCMultiTableStreamingStartupRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	job, src, dest := managedMultiTableEvolutionJob(t)
+	job.Config.Stream = true
+
+	err := NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: job.CDCStateManager,
+	}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.Empty(t, src.readOpts.KnownTables)
+	requireRejectedRecreatedEvolution(t, dest)
+}
+
+func TestManagedCDCStreamingReannouncementRejectsSchemaEvolutionAfterTargetRecreation(t *testing.T) {
+	sourceTable := "public.items"
+	destTable := "raw.items"
+	dest := newRecreatingEvolutionDestination(destTable)
+	manager := newManagedEvolutionStateManager(t, dest, sourceTable, destTable)
+	require.NoError(t, manager.BindDestinationIncarnation(t.Context(), sourceTable, destTable))
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}, PrimaryKeys: []string{"id"}}
+	refreshedSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "new_column", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	st := &streamTableState{
+		destTable: destTable, stagingTable: "raw.items_staging", schema: initialSchema, primaryKeys: []string{"id"},
+	}
+	loop := newFlushLoop(dest, &config.IngestConfig{NoLoadTimestamp: true}, StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: manager, FlushInterval: time.Hour,
+	}, map[string]*streamTableState{sourceTable: st})
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error {
+		t.Fatal("managed CDC re-announcement called the unfenced evolution callback")
+		return nil
+	}
+	prepareCallsBeforeRefresh := len(dest.prepareCalls)
+
+	err := loop.refreshTableSchema(t.Context(), source.SourceTableInfo{
+		Name: sourceTable, Schema: refreshedSchema, PrimaryKeys: []string{"id"}, Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+	}, st)
+	require.ErrorContains(t, err, "incarnation changed before schema evolution")
+	require.Len(t, dest.prepareCalls, prepareCallsBeforeRefresh)
+	requireRejectedRecreatedEvolution(t, dest)
+}

--- a/pkg/strategy/cdc_state.go
+++ b/pkg/strategy/cdc_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -30,8 +31,10 @@ const (
 	cdcStateKindCheckpoint    = "checkpoint"
 	cdcStateKindSnapshot      = "snapshot"
 	cdcStateKindDestination   = "destination"
+	cdcStateKindAtomicAttempt = "atomic_snapshot"
 	cdcStateKindRun           = "run"
 	cdcStateStatusInProgress  = "in_progress"
+	cdcStateStatusReady       = "ready"
 	zeroCDCPosition           = "00000000/00000000"
 	cdcStatePruneThreshold    = 100
 	cdcStatePruneBatchSize    = 900
@@ -51,7 +54,7 @@ var cdcStateSchema = &schema.TableSchema{Columns: []schema.Column{
 	{Name: "state_kind", DataType: schema.TypeString, MaxLength: 32, Nullable: false},
 	{Name: "state_generation", DataType: schema.TypeInt64, Nullable: false},
 	{Name: "state_status", DataType: schema.TypeString, MaxLength: 32, Nullable: false},
-	{Name: "_cdc_lsn", DataType: schema.TypeString, MaxLength: 64, Nullable: false},
+	{Name: "_cdc_lsn", DataType: schema.TypeString, MaxLength: 1024, Nullable: false},
 	{Name: "recorded_at", DataType: schema.TypeTimestampTZ, Nullable: false},
 }}
 
@@ -103,6 +106,7 @@ type CDCStateManager struct {
 	targetPrepared      bool
 	loaded              bool
 	started             bool
+	fullRefresh         bool
 	generation          int64
 	runID               string
 	runEventID          string
@@ -116,6 +120,10 @@ type CDCStateManager struct {
 	knownSchemas        map[string]string
 	knownDestinations   map[string]string
 	boundDestinations   map[string]string
+	boundDestinationRaw map[string]string
+	batchSnapshots      map[string]string
+	atomicAttempts      map[string]atomicSnapshotJournalEntry
+	atomicSequences     map[string]uint64
 	lateTargetModes     map[string]lateTargetMode
 	lateTargetRaw       map[string]string
 	snapshotEpochs      map[string]uint64
@@ -124,6 +132,18 @@ type CDCStateManager struct {
 }
 
 type lateTargetMode uint8
+
+type atomicSnapshotJournalEntry struct {
+	attemptID               string
+	sequence                uint64
+	snapshotEpoch           uint64
+	ready                   bool
+	resumeLSN               string
+	expectedIncarnation     string
+	sourceMetadataKnown     bool
+	sourceIncarnation       string
+	sourceSchemaFingerprint string
+}
 
 const (
 	lateTargetNone lateTargetMode = iota
@@ -187,6 +207,10 @@ func newCDCStateManager(dest destination.Destination, connectorID, stateTable st
 		knownSchemas:        make(map[string]string),
 		knownDestinations:   make(map[string]string),
 		boundDestinations:   make(map[string]string),
+		boundDestinationRaw: make(map[string]string),
+		batchSnapshots:      make(map[string]string),
+		atomicAttempts:      make(map[string]atomicSnapshotJournalEntry),
+		atomicSequences:     make(map[string]uint64),
 		lateTargetModes:     make(map[string]lateTargetMode),
 		lateTargetRaw:       make(map[string]string),
 		snapshotEpochs:      make(map[string]uint64),
@@ -225,13 +249,17 @@ func (m *CDCStateManager) RegisterTableState(ctx context.Context, sourceTable, d
 // this returns, an older completed epoch can no longer make the table
 // resumable, even if the process crashes during truncate or backfill.
 func (m *CDCStateManager) InvalidateSnapshot(ctx context.Context, sourceTable, destTable, incarnation string) error {
+	return m.InvalidateSnapshotState(ctx, sourceTable, destTable, incarnation, "")
+}
+
+func (m *CDCStateManager) InvalidateSnapshotState(ctx context.Context, sourceTable, destTable, incarnation, schemaFingerprint string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if err := m.claimTarget(ctx, sourceTable, destTable); err != nil {
 		return err
 	}
-	if err := m.registerTable(ctx, sourceTable, destTable, incarnation, ""); err != nil {
+	if err := m.registerTable(ctx, sourceTable, destTable, incarnation, schemaFingerprint); err != nil {
 		return err
 	}
 	if incarnation == "" {
@@ -251,6 +279,7 @@ func (m *CDCStateManager) InvalidateSnapshot(ctx context.Context, sourceTable, d
 	delete(m.knownSchemas, sourceTable)
 	delete(m.knownDestinations, sourceTable)
 	delete(m.boundDestinations, sourceTable)
+	delete(m.boundDestinationRaw, sourceTable)
 	return nil
 }
 
@@ -270,7 +299,7 @@ func (m *CDCStateManager) BindDestinationIncarnation(ctx context.Context, source
 			return fmt.Errorf("CDC destination table %q disappeared before snapshot write", destTable)
 		}
 	}
-	current, exists, err := m.currentDestinationIncarnation(ctx, sourceTable)
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
 	if err != nil {
 		return err
 	}
@@ -280,7 +309,287 @@ func (m *CDCStateManager) BindDestinationIncarnation(ctx context.Context, source
 	if bound := m.boundDestinations[sourceTable]; bound != "" && current != bound {
 		return fmt.Errorf("CDC destination table %q was replaced during its snapshot", destTable)
 	}
+	if known := m.knownDestinations[sourceTable]; known != "" && current != known {
+		return fmt.Errorf("CDC destination table %q was replaced after its resume position was selected", destTable)
+	}
 	m.boundDestinations[sourceTable] = current
+	m.boundDestinationRaw[sourceTable] = raw
+	return nil
+}
+
+func (m *CDCStateManager) BoundDestinationIncarnation(sourceTable string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.boundDestinationRaw[sourceTable]
+}
+
+// AtomicSnapshotAttempt returns the durable identity of the current snapshot
+// publication. An incomplete attempt is carried into the next run so an
+// ambiguous successful publish is retried with the same idempotency key.
+func (m *CDCStateManager) AtomicSnapshotAttempt(ctx context.Context, sourceTable, destTable string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.started || m.generation == 0 {
+		return "", fmt.Errorf("CDC state run has not started")
+	}
+	registered, ok := m.destTables[sourceTable]
+	if !ok || registered != destTable {
+		return "", fmt.Errorf("CDC state is not registered for source table %q and destination %q", sourceTable, destTable)
+	}
+	if attempt, exists := m.atomicAttempts[sourceTable]; exists {
+		if attempt.ready {
+			return "", fmt.Errorf("sealed atomic snapshot attempt for %s must be recovered before source read", sourceTable)
+		}
+		return attempt.attemptID, nil
+	}
+	attemptID, err := newCDCStateRunID()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate atomic snapshot attempt for %s: %w", sourceTable, err)
+	}
+	sequence := m.atomicSequences[sourceTable] + 1
+	attempt := atomicSnapshotJournalEntry{
+		attemptID:     attemptID,
+		sequence:      sequence,
+		snapshotEpoch: m.snapshotEpochs[sourceTable],
+	}
+	if err := m.writeState(
+		ctx,
+		sourceTable,
+		destTable,
+		cdcStateKindAtomicAttempt,
+		m.generation,
+		cdcStateStatusInProgress,
+		encodeAtomicSnapshotAttempt(attempt),
+	); err != nil {
+		return "", fmt.Errorf("failed to persist atomic snapshot attempt for %s: %w", sourceTable, err)
+	}
+	m.atomicAttempts[sourceTable] = attempt
+	m.atomicSequences[sourceTable] = sequence
+	return attemptID, nil
+}
+
+func (m *CDCStateManager) SealAtomicSnapshotAttempt(
+	ctx context.Context,
+	sourceTable, destTable, attemptID, resumeLSN, expectedIncarnation string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	attempt, exists := m.atomicAttempts[sourceTable]
+	if !m.started || !exists || attemptID == "" || attempt.attemptID != attemptID {
+		return fmt.Errorf("atomic snapshot attempt for %s does not match the active durable attempt", sourceTable)
+	}
+	if m.destTables[sourceTable] != destTable {
+		return fmt.Errorf("CDC state destination for %s is %q, not %q", sourceTable, m.destTables[sourceTable], destTable)
+	}
+	if !cdcStatePositionValid(resumeLSN) || expectedIncarnation == "" {
+		return fmt.Errorf("atomic snapshot attempt for %s has an invalid durable boundary or publication fence", sourceTable)
+	}
+	attempt.ready = true
+	attempt.resumeLSN = resumeLSN
+	attempt.expectedIncarnation = expectedIncarnation
+	attempt.sourceMetadataKnown = true
+	attempt.sourceIncarnation = m.currentIncarnations[sourceTable]
+	attempt.sourceSchemaFingerprint = m.currentSchemas[sourceTable]
+	if err := m.writeState(
+		ctx,
+		sourceTable,
+		destTable,
+		cdcStateKindAtomicAttempt,
+		m.generation,
+		cdcStateStatusReady,
+		encodeAtomicSnapshotAttempt(attempt),
+	); err != nil {
+		return fmt.Errorf("failed to seal atomic snapshot attempt for %s: %w", sourceTable, err)
+	}
+	m.atomicAttempts[sourceTable] = attempt
+	return nil
+}
+
+func (m *CDCStateManager) PendingAtomicSnapshotAttempt(sourceTable, destTable string) (atomicSnapshotJournalEntry, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	attempt, exists := m.atomicAttempts[sourceTable]
+	if !exists {
+		return atomicSnapshotJournalEntry{}, false, nil
+	}
+	if m.destTables[sourceTable] != destTable {
+		return atomicSnapshotJournalEntry{}, false, fmt.Errorf(
+			"CDC state destination for %s is %q, not %q",
+			sourceTable,
+			m.destTables[sourceTable],
+			destTable,
+		)
+	}
+	return attempt, true, nil
+}
+
+func (m *CDCStateManager) FullRefresh() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.fullRefresh
+}
+
+func (m *CDCStateManager) CompleteAtomicSnapshotAttempt(ctx context.Context, sourceTable, destTable, attemptID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.started || m.generation == 0 {
+		return fmt.Errorf("CDC state run has not started")
+	}
+	attempt, exists := m.atomicAttempts[sourceTable]
+	if !exists || attemptID == "" || attempt.attemptID != attemptID {
+		return fmt.Errorf("atomic snapshot attempt for %s does not match the active durable attempt", sourceTable)
+	}
+	if registered := m.destTables[sourceTable]; registered != destTable {
+		return fmt.Errorf("CDC state destination for %s is %q, not %q", sourceTable, registered, destTable)
+	}
+	if err := m.writeState(
+		ctx,
+		sourceTable,
+		destTable,
+		cdcStateKindAtomicAttempt,
+		m.generation,
+		destination.CDCStateStatusComplete,
+		encodeAtomicSnapshotAttempt(attempt),
+	); err != nil {
+		return fmt.Errorf("failed to complete atomic snapshot attempt for %s: %w", sourceTable, err)
+	}
+	delete(m.atomicAttempts, sourceTable)
+	return nil
+}
+
+func (m *CDCStateManager) AbandonAtomicSnapshotAttempt(ctx context.Context, sourceTable, destTable, attemptID string) error {
+	return m.CompleteAtomicSnapshotAttempt(ctx, sourceTable, destTable, attemptID)
+}
+
+func (m *CDCStateManager) DestinationIncarnationForPublication(ctx context.Context, destTable string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	raw, _, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return "", err
+	}
+	if !exists || raw == "" {
+		return "", fmt.Errorf("CDC replacement table %q has no stable physical incarnation", destTable)
+	}
+	return raw, nil
+}
+
+// BindPublishedDestinationIncarnation accepts the physical incarnation created
+// by a destination-fenced replacement. The caller must provide the incarnation
+// that guarded publication so an unrelated or stale run cannot rebind state.
+func (m *CDCStateManager) BindPublishedDestinationIncarnation(
+	ctx context.Context,
+	sourceTable, destTable, expectedPrevious, expectedPublished string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if expectedPrevious == "" || expectedPublished == "" || m.boundDestinationRaw[sourceTable] != expectedPrevious {
+		return fmt.Errorf("CDC destination table %q replacement was not fenced by its bound incarnation", destTable)
+	}
+	if err := m.registerTable(ctx, sourceTable, destTable, "", ""); err != nil {
+		return err
+	}
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || raw != expectedPublished {
+		return fmt.Errorf("CDC destination table %q changed after its fenced replacement was published", destTable)
+	}
+	m.boundDestinations[sourceTable] = current
+	m.boundDestinationRaw[sourceTable] = raw
+	return nil
+}
+
+func (m *CDCStateManager) BindRecoveredPublishedDestinationIncarnation(
+	ctx context.Context,
+	sourceTable, destTable, expectedPublished string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if expectedPublished == "" {
+		return fmt.Errorf("CDC destination table %q recovered publication has no physical incarnation", destTable)
+	}
+	if err := m.registerTable(ctx, sourceTable, destTable, "", ""); err != nil {
+		return err
+	}
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || raw != expectedPublished {
+		return fmt.Errorf("CDC destination table %q changed after its recovered fenced replacement was published", destTable)
+	}
+	m.boundDestinations[sourceTable] = current
+	m.boundDestinationRaw[sourceTable] = raw
+	return nil
+}
+
+func (m *CDCStateManager) CurrentSourceMetadata(sourceTable string) (incarnation, schemaFingerprint string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentIncarnations[sourceTable], m.currentSchemas[sourceTable]
+}
+
+func (m *CDCStateManager) InvalidateSnapshotPreservingDestination(ctx context.Context, sourceTable, destTable, incarnation string) error {
+	return m.InvalidateSnapshotStatePreservingDestination(ctx, sourceTable, destTable, incarnation, "")
+}
+
+func (m *CDCStateManager) InvalidateSnapshotStatePreservingDestination(ctx context.Context, sourceTable, destTable, incarnation, schemaFingerprint string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.claimTarget(ctx, sourceTable, destTable); err != nil {
+		return err
+	}
+	if err := m.registerTable(ctx, sourceTable, destTable, incarnation, schemaFingerprint); err != nil {
+		return err
+	}
+	if incarnation == "" {
+		incarnation = m.currentIncarnations[sourceTable]
+	}
+	if !m.started || m.generation == 0 {
+		return fmt.Errorf("CDC state run has not started")
+	}
+	expected := m.boundDestinations[sourceTable]
+	if expected == "" {
+		expected = m.knownDestinations[sourceTable]
+	}
+	if expected == "" {
+		return fmt.Errorf("CDC destination table %q has no previously verified physical incarnation", destTable)
+	}
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expected {
+		return fmt.Errorf("CDC destination table %q was replaced after its prior snapshot boundary", destTable)
+	}
+	epoch := m.snapshotEpochs[sourceTable] + 1
+	position := encodeCDCStatePositionWithSchema(zeroCDCPosition, incarnation, m.currentSchemas[sourceTable], epoch)
+	if err := m.writeState(ctx, sourceTable, destTable, cdcStateKindSnapshot, m.generation, cdcStateStatusInProgress, position); err != nil {
+		return fmt.Errorf("failed to invalidate CDC snapshot for %s: %w", sourceTable, err)
+	}
+	_, afterWrite, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || afterWrite != expected {
+		return fmt.Errorf("CDC destination table %q changed while invalidating its prior snapshot boundary", destTable)
+	}
+	m.snapshotEpochs[sourceTable] = epoch
+	delete(m.knownComplete, sourceTable)
+	delete(m.knownIncarnations, sourceTable)
+	delete(m.knownSchemas, sourceTable)
+	delete(m.knownDestinations, sourceTable)
+	m.boundDestinations[sourceTable] = expected
+	m.boundDestinationRaw[sourceTable] = raw
 	return nil
 }
 
@@ -345,6 +654,7 @@ func (m *CDCStateManager) ClaimLateDiscoveredTarget(
 		m.lateTargetModes[sourceTable] = lateTargetCreatedEmpty
 		m.lateTargetRaw[sourceTable] = createdIncarnation
 		m.boundDestinations[sourceTable] = cdcDestinationIncarnationDigest(createdIncarnation)
+		m.boundDestinationRaw[sourceTable] = createdIncarnation
 		return nil
 	}
 	if !allowReplacement {
@@ -370,11 +680,10 @@ func (m *CDCStateManager) ClaimLateDiscoveredTarget(
 	if err := m.claimTarget(ctx, sourceTable, destTable); err != nil {
 		return err
 	}
-	if !allowReplacement {
-		m.lateTargetModes[sourceTable] = lateTargetConditionalReplace
-		m.lateTargetRaw[sourceTable] = rawDestinationIncarnation
-		m.boundDestinations[sourceTable] = destinationIncarnation
-	}
+	m.lateTargetModes[sourceTable] = lateTargetConditionalReplace
+	m.lateTargetRaw[sourceTable] = rawDestinationIncarnation
+	m.boundDestinations[sourceTable] = destinationIncarnation
+	m.boundDestinationRaw[sourceTable] = rawDestinationIncarnation
 	return nil
 }
 
@@ -516,6 +825,14 @@ func (m *CDCStateManager) validateTarget(ctx context.Context, destTable string) 
 // needs no truncate; an existing target is truncated only by an incarnation
 // compare-and-swap operation supplied by the destination.
 func (m *CDCStateManager) ApplyLateSnapshotBoundary(ctx context.Context, sourceTable, destTable string) (bool, error) {
+	return m.applyLateSnapshotBoundary(ctx, sourceTable, destTable, true)
+}
+
+func (m *CDCStateManager) BindLateAtomicSnapshotBoundary(ctx context.Context, sourceTable, destTable string) (bool, error) {
+	return m.applyLateSnapshotBoundary(ctx, sourceTable, destTable, false)
+}
+
+func (m *CDCStateManager) applyLateSnapshotBoundary(ctx context.Context, sourceTable, destTable string, truncateVisibleTarget bool) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -536,7 +853,7 @@ func (m *CDCStateManager) ApplyLateSnapshotBoundary(ctx context.Context, sourceT
 		return true, fmt.Errorf("CDC destination table %q was replaced after its late-target claim", destTable)
 	}
 
-	if mode == lateTargetConditionalReplace {
+	if mode == lateTargetConditionalReplace && truncateVisibleTarget {
 		truncater, ok := m.dest.(destination.CDCConditionalTruncater)
 		if !ok {
 			return true, fmt.Errorf("destination scheme %q cannot conditionally truncate late-discovered CDC targets", m.dest.GetScheme())
@@ -546,6 +863,7 @@ func (m *CDCStateManager) ApplyLateSnapshotBoundary(ctx context.Context, sourceT
 		}
 	}
 	m.boundDestinations[sourceTable] = expectedDigest
+	m.boundDestinationRaw[sourceTable] = expectedRaw
 	delete(m.lateTargetModes, sourceTable)
 	delete(m.lateTargetRaw, sourceTable)
 	return true, nil
@@ -726,6 +1044,77 @@ func (m *CDCStateManager) StateEmpty(ctx context.Context) (bool, error) {
 	return len(m.entries) == 0, nil
 }
 
+type atomicSnapshotAttemptCandidate struct {
+	entry     atomicSnapshotJournalEntry
+	destTable string
+	terminal  bool
+}
+
+func (m *CDCStateManager) recoverAtomicSnapshotAttempts() (
+	map[string]atomicSnapshotJournalEntry,
+	map[string]uint64,
+	error,
+) {
+	candidates := make(map[string]*atomicSnapshotAttemptCandidate)
+	for _, entry := range m.entries {
+		if entry.StateKind != cdcStateKindAtomicAttempt {
+			continue
+		}
+		journal, valid := decodeAtomicSnapshotAttempt(entry.Position)
+		if !valid {
+			continue
+		}
+		candidate := candidates[entry.SourceTable]
+		if candidate == nil || journal.sequence > candidate.entry.sequence {
+			candidate = &atomicSnapshotAttemptCandidate{entry: journal, destTable: entry.DestinationTable}
+			candidates[entry.SourceTable] = candidate
+		}
+		if journal.sequence != candidate.entry.sequence {
+			continue
+		}
+		if journal.attemptID != candidate.entry.attemptID ||
+			journal.snapshotEpoch != candidate.entry.snapshotEpoch ||
+			entry.DestinationTable != candidate.destTable {
+			return nil, nil, fmt.Errorf(
+				"CDC source table %q has conflicting atomic snapshot attempt sequence %d",
+				entry.SourceTable,
+				journal.sequence,
+			)
+		}
+		if journal.ready {
+			if candidate.entry.ready &&
+				(journal.resumeLSN != candidate.entry.resumeLSN ||
+					journal.expectedIncarnation != candidate.entry.expectedIncarnation ||
+					journal.sourceMetadataKnown != candidate.entry.sourceMetadataKnown ||
+					journal.sourceIncarnation != candidate.entry.sourceIncarnation ||
+					journal.sourceSchemaFingerprint != candidate.entry.sourceSchemaFingerprint) {
+				return nil, nil, fmt.Errorf(
+					"CDC source table %q has conflicting sealed atomic snapshot attempt %q",
+					entry.SourceTable,
+					journal.attemptID,
+				)
+			}
+			candidate.entry = journal
+		}
+		candidate.terminal = candidate.terminal || entry.Status == destination.CDCStateStatusComplete
+	}
+
+	recovered := make(map[string]atomicSnapshotJournalEntry)
+	sequences := make(map[string]uint64)
+	for sourceTable, candidate := range candidates {
+		sequences[sourceTable] = candidate.entry.sequence
+		if candidate.terminal {
+			continue
+		}
+		destTable, registered := m.destTables[sourceTable]
+		if !registered || candidate.destTable != destTable {
+			continue
+		}
+		recovered[sourceTable] = candidate.entry
+	}
+	return recovered, sequences, nil
+}
+
 // BeginRun appends an in-progress marker for every registered source table at
 // a new connector generation. A crash leaves that generation incomplete, so
 // older completed rows cannot make a partial target resumable.
@@ -745,13 +1134,26 @@ func (m *CDCStateManager) BeginRun(ctx context.Context, fullRefresh bool) error 
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
+	recoveredAttempts, recoveredSequences, err := m.recoverAtomicSnapshotAttempts()
+	if err != nil {
+		return err
+	}
 	if fullRefresh {
 		m.knownComplete = make(map[string]string)
 		m.knownIncarnations = make(map[string]string)
 		m.knownDestinations = make(map[string]string)
 	}
 	m.boundDestinations = make(map[string]string)
+	m.boundDestinationRaw = make(map[string]string)
+	m.batchSnapshots = make(map[string]string)
+	m.atomicAttempts = make(map[string]atomicSnapshotJournalEntry, len(recoveredAttempts))
+	m.atomicSequences = recoveredSequences
 	m.snapshotEpochs = make(map[string]uint64)
+	m.fullRefresh = fullRefresh
+	for sourceTable, recovered := range recoveredAttempts {
+		m.atomicAttempts[sourceTable] = recovered
+		m.snapshotEpochs[sourceTable] = recovered.snapshotEpoch
+	}
 	m.generation++
 	runID, err := newCDCStateRunID()
 	if err != nil {
@@ -778,9 +1180,23 @@ func (m *CDCStateManager) BeginRun(ctx context.Context, fullRefresh bool) error 
 		tables = append(tables, table)
 	}
 	sort.Strings(tables)
-	events := make([]cdcStateWriteEvent, 0, len(tables))
+	events := make([]cdcStateWriteEvent, 0, len(tables)+len(recoveredAttempts))
 	for _, sourceTable := range tables {
 		events = append(events, m.newStateWriteEvent(sourceTable, m.destTables[sourceTable], cdcStateKindSnapshot, m.generation, cdcStateStatusInProgress, zeroCDCPosition))
+		if attempt, exists := m.atomicAttempts[sourceTable]; exists {
+			status := cdcStateStatusInProgress
+			if attempt.ready {
+				status = cdcStateStatusReady
+			}
+			events = append(events, m.newStateWriteEvent(
+				sourceTable,
+				m.destTables[sourceTable],
+				cdcStateKindAtomicAttempt,
+				m.generation,
+				status,
+				encodeAtomicSnapshotAttempt(attempt),
+			))
+		}
 	}
 	if err := m.writeStateEvents(ctx, events); err != nil {
 		return err
@@ -801,6 +1217,18 @@ func (m *CDCStateManager) Persist(ctx context.Context, token source.CDCStateComm
 
 	if !m.started || m.generation == 0 {
 		return fmt.Errorf("CDC state run has not started")
+	}
+	token.SnapshotPositions = cloneStringMap(token.SnapshotPositions)
+	token.SnapshotIncarnations = cloneStringMap(token.SnapshotIncarnations)
+	token.SnapshotSchemas = cloneStringMap(token.SnapshotSchemas)
+	for table, position := range m.batchSnapshots {
+		if position == "" {
+			position = token.Position
+		}
+		if position == "" {
+			return fmt.Errorf("completed batch snapshot for %s has no durable source position", table)
+		}
+		token.SnapshotPositions[table] = position
 	}
 	if token.Position != "" && !cdcStatePositionValid(token.Position) {
 		return fmt.Errorf("invalid CDC checkpoint position %q", token.Position)
@@ -942,15 +1370,167 @@ func (m *CDCStateManager) Persist(ctx context.Context, token source.CDCStateComm
 			return fmt.Errorf("CDC destination table %q changed while its state was being persisted", m.destTables[sourceTable])
 		}
 		m.knownDestinations[sourceTable] = expected
-		if _, freshSnapshot := token.SnapshotPositions[sourceTable]; freshSnapshot {
-			delete(m.boundDestinations, sourceTable)
-		}
 	}
 	m.pruneSuperseded(ctx)
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
+	m.batchSnapshots = make(map[string]string)
 	return nil
+}
+
+func (m *CDCStateManager) RecordBatchSnapshotCompletion(sourceTable, position string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.batchSnapshots == nil {
+		m.batchSnapshots = make(map[string]string)
+	}
+	m.batchSnapshots[sourceTable] = position
+}
+
+func applyMultiTableSnapshotInvalidations(
+	ctx context.Context,
+	job *MultiTableIngestionJob,
+	records <-chan source.RecordBatchResult,
+) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult)
+	drainTimeout := canceledSourceDrainTimeout
+	go func() {
+		defer close(out)
+		knownTables := make(map[string]struct{}, len(job.Tables))
+		for _, table := range job.Tables {
+			knownTables[table.Name] = struct{}{}
+		}
+		pending := make(map[string]source.CDCSnapshotInvalidation)
+		fail := func(result source.RecordBatchResult, err error) {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			select {
+			case out <- source.RecordBatchResult{Err: err}:
+			case <-ctx.Done():
+			}
+			<-startBoundedRecordDrain(records, drainTimeout)
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				<-startBoundedRecordDrain(records, drainTimeout)
+				return
+			case result, ok := <-records:
+				if !ok {
+					if len(pending) > 0 {
+						tables := make([]string, 0, len(pending))
+						for table := range pending {
+							tables = append(tables, table)
+						}
+						sort.Strings(tables)
+						fail(source.RecordBatchResult{}, fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", tables[0]))
+					}
+					return
+				}
+				if result.Err != nil {
+					fail(result, result.Err)
+					return
+				}
+				if result.SnapshotInvalidation != nil {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					invalidation := *result.SnapshotInvalidation
+					if _, known := knownTables[invalidation.TableName]; !known {
+						fail(source.RecordBatchResult{}, fmt.Errorf("source requested snapshot invalidation for unknown table %q", invalidation.TableName))
+						return
+					}
+					if _, exists := pending[invalidation.TableName]; exists {
+						fail(source.RecordBatchResult{}, fmt.Errorf("source repeated snapshot invalidation for %s before its replacement boundary", invalidation.TableName))
+						return
+					}
+					pending[invalidation.TableName] = invalidation
+					continue
+				}
+				if invalidation, waiting := pending[result.TableName]; waiting {
+					if !result.Truncate || result.CDCWALTruncate {
+						if result.Batch == nil && result.TableInfo != nil {
+							merged, err := mergeSnapshotInvalidationMetadata(invalidation, result.TableInfo)
+							if err != nil {
+								fail(result, err)
+								return
+							}
+							pending[result.TableName] = merged
+							select {
+							case out <- result:
+							case <-ctx.Done():
+								<-startBoundedRecordDrain(records, drainTimeout)
+								return
+							}
+							continue
+						}
+						fail(result, fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", result.TableName))
+						return
+					}
+					if job.CDCStateManager == nil {
+						fail(result, fmt.Errorf("source requested snapshot invalidation without destination-managed CDC state"))
+						return
+					}
+					if err := job.CDCStateManager.InvalidateSnapshotStatePreservingDestination(
+						ctx, invalidation.TableName, job.GetDestTableName(invalidation.TableName),
+						invalidation.Incarnation, invalidation.SchemaFingerprint,
+					); err != nil {
+						fail(result, err)
+						return
+					}
+					delete(pending, result.TableName)
+				}
+				select {
+				case out <- result:
+				case <-ctx.Done():
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					<-startBoundedRecordDrain(records, drainTimeout)
+					return
+				}
+			}
+		}
+	}()
+	return out
+}
+
+func mergeSnapshotInvalidationMetadata(
+	invalidation source.CDCSnapshotInvalidation,
+	table *source.SourceTableInfo,
+) (source.CDCSnapshotInvalidation, error) {
+	if table == nil {
+		return invalidation, nil
+	}
+	if table.Name != "" && table.Name != invalidation.TableName {
+		return invalidation, fmt.Errorf(
+			"source snapshot invalidation for %s was followed by metadata for %s",
+			invalidation.TableName, table.Name,
+		)
+	}
+	if invalidation.Incarnation != "" && table.Incarnation != "" && invalidation.Incarnation != table.Incarnation {
+		return invalidation, fmt.Errorf("source snapshot invalidation for %s has conflicting incarnation metadata", invalidation.TableName)
+	}
+	if invalidation.SchemaFingerprint != "" && table.SchemaFingerprint != "" && invalidation.SchemaFingerprint != table.SchemaFingerprint {
+		return invalidation, fmt.Errorf("source snapshot invalidation for %s has conflicting schema metadata", invalidation.TableName)
+	}
+	if invalidation.Incarnation == "" {
+		invalidation.Incarnation = table.Incarnation
+	}
+	if invalidation.SchemaFingerprint == "" {
+		invalidation.SchemaFingerprint = table.SchemaFingerprint
+	}
+	return invalidation, nil
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (m *CDCStateManager) prepareTable(ctx context.Context) error {
@@ -1309,6 +1889,9 @@ func (m *CDCStateManager) supersededEventIDs() []string {
 		if !cdcStateEntryPositionValid(entry) {
 			continue
 		}
+		if entry.StateKind == cdcStateKindAtomicAttempt {
+			continue
+		}
 		runID, ok := cdcStateRunID(entry.EventID, m.connectorID)
 		if !ok || entry.Generation != m.generation || runID != m.runID {
 			continue
@@ -1324,6 +1907,9 @@ func (m *CDCStateManager) supersededEventIDs() []string {
 	for _, entry := range keep {
 		keepIDs[entry.EventID] = struct{}{}
 	}
+	for eventID := range m.atomicSnapshotJournalKeepIDs() {
+		keepIDs[eventID] = struct{}{}
+	}
 	stale := make([]string, 0, len(m.entries)-len(keepIDs))
 	for _, entry := range m.entries {
 		if _, ok := keepIDs[entry.EventID]; !ok && entry.EventID != "" && cdcStateEntryPositionValid(entry) {
@@ -1333,9 +1919,102 @@ func (m *CDCStateManager) supersededEventIDs() []string {
 	return stale
 }
 
+func (m *CDCStateManager) atomicSnapshotJournalKeepIDs() map[string]struct{} {
+	type candidate struct {
+		entry   destination.CDCStateEntry
+		attempt atomicSnapshotJournalEntry
+	}
+	candidates := make(map[string]candidate)
+	for _, entry := range m.entries {
+		if entry.StateKind != cdcStateKindAtomicAttempt || entry.EventID == "" {
+			continue
+		}
+		attempt, valid := decodeAtomicSnapshotAttempt(entry.Position)
+		if !valid {
+			continue
+		}
+		current, exists := candidates[entry.SourceTable]
+		if !exists || preferAtomicSnapshotJournalAnchor(entry, attempt, current.entry, current.attempt) {
+			candidates[entry.SourceTable] = candidate{entry: entry, attempt: attempt}
+		}
+	}
+	conflicted := make(map[string]bool)
+	for _, entry := range m.entries {
+		if entry.StateKind != cdcStateKindAtomicAttempt {
+			continue
+		}
+		attempt, valid := decodeAtomicSnapshotAttempt(entry.Position)
+		selected, exists := candidates[entry.SourceTable]
+		if !valid || !exists || attempt.sequence != selected.attempt.sequence {
+			continue
+		}
+		if atomicSnapshotJournalEntriesConflict(entry, attempt, selected.entry, selected.attempt) {
+			conflicted[entry.SourceTable] = true
+		}
+	}
+	keep := make(map[string]struct{}, len(candidates))
+	for sourceTable, candidate := range candidates {
+		if !conflicted[sourceTable] {
+			keep[candidate.entry.EventID] = struct{}{}
+		}
+	}
+	if len(conflicted) > 0 {
+		for _, entry := range m.entries {
+			if entry.StateKind == cdcStateKindAtomicAttempt && conflicted[entry.SourceTable] {
+				keep[entry.EventID] = struct{}{}
+			}
+		}
+	}
+	return keep
+}
+
+func atomicSnapshotJournalEntriesConflict(
+	left destination.CDCStateEntry,
+	leftAttempt atomicSnapshotJournalEntry,
+	right destination.CDCStateEntry,
+	rightAttempt atomicSnapshotJournalEntry,
+) bool {
+	if leftAttempt.attemptID != rightAttempt.attemptID ||
+		leftAttempt.snapshotEpoch != rightAttempt.snapshotEpoch ||
+		left.DestinationTable != right.DestinationTable {
+		return true
+	}
+	return leftAttempt.ready && rightAttempt.ready &&
+		(leftAttempt.resumeLSN != rightAttempt.resumeLSN ||
+			leftAttempt.expectedIncarnation != rightAttempt.expectedIncarnation ||
+			leftAttempt.sourceMetadataKnown != rightAttempt.sourceMetadataKnown ||
+			leftAttempt.sourceIncarnation != rightAttempt.sourceIncarnation ||
+			leftAttempt.sourceSchemaFingerprint != rightAttempt.sourceSchemaFingerprint)
+}
+
+func preferAtomicSnapshotJournalAnchor(
+	candidate destination.CDCStateEntry,
+	candidateAttempt atomicSnapshotJournalEntry,
+	current destination.CDCStateEntry,
+	currentAttempt atomicSnapshotJournalEntry,
+) bool {
+	if candidateAttempt.sequence != currentAttempt.sequence {
+		return candidateAttempt.sequence > currentAttempt.sequence
+	}
+	candidateTerminal := candidate.Status == destination.CDCStateStatusComplete
+	currentTerminal := current.Status == destination.CDCStateStatusComplete
+	if candidateTerminal != currentTerminal {
+		return candidateTerminal
+	}
+	if candidateAttempt.ready != currentAttempt.ready {
+		return candidateAttempt.ready
+	}
+	if candidate.Generation != current.Generation {
+		return candidate.Generation > current.Generation
+	}
+	return candidate.EventID > current.EventID
+}
+
 func preferCDCStateEntry(candidate, current destination.CDCStateEntry) bool {
 	if candidate.StateKind == current.StateKind &&
-		(candidate.StateKind == cdcStateKindSnapshot || candidate.StateKind == cdcStateKindDestination) {
+		(candidate.StateKind == cdcStateKindSnapshot ||
+			candidate.StateKind == cdcStateKindDestination ||
+			candidate.StateKind == cdcStateKindAtomicAttempt) {
 		_, _, candidateEpoch, _ := decodeCDCStateEntry(candidate)
 		_, _, currentEpoch, _ := decodeCDCStateEntry(current)
 		if candidateEpoch != currentEpoch {
@@ -1372,6 +2051,10 @@ func decodeCDCStateEntry(entry destination.CDCStateEntry) (position, incarnation
 	if entry.StateKind == cdcStateKindDestination {
 		position, incarnation, epoch, valid = decodeCDCDestinationState(entry.Position)
 		return position, incarnation, epoch, valid
+	}
+	if entry.StateKind == cdcStateKindAtomicAttempt {
+		attempt, valid := decodeAtomicSnapshotAttempt(entry.Position)
+		return zeroCDCPosition, attempt.attemptID, attempt.sequence, valid
 	}
 	position, incarnation, epoch = decodeCDCStatePosition(entry.Position)
 	return position, incarnation, epoch, cdcStatePositionValid(entry.Position)
@@ -1501,4 +2184,86 @@ func decodeCDCDestinationState(encoded string) (position, incarnation string, sn
 		return "", "", 0, false
 	}
 	return parts[2], parts[1], epoch, true
+}
+
+func encodeAtomicSnapshotAttempt(attempt atomicSnapshotJournalEntry) string {
+	ready := "0"
+	if attempt.ready {
+		ready = "1"
+	}
+	parts := []string{
+		"a2",
+		strconv.FormatUint(attempt.sequence, 16),
+		strconv.FormatUint(attempt.snapshotEpoch, 16),
+		attempt.attemptID,
+		ready,
+		attempt.resumeLSN,
+		base64.RawURLEncoding.EncodeToString([]byte(attempt.expectedIncarnation)),
+		base64.RawURLEncoding.EncodeToString([]byte(attempt.sourceIncarnation)),
+		base64.RawURLEncoding.EncodeToString([]byte(attempt.sourceSchemaFingerprint)),
+	}
+	if attempt.ready && !attempt.sourceMetadataKnown {
+		parts = parts[:7]
+		parts[0] = "a1"
+	}
+	return strings.Join(parts, ":")
+}
+
+func decodeAtomicSnapshotAttempt(encoded string) (atomicSnapshotJournalEntry, bool) {
+	parts := strings.Split(encoded, ":")
+	legacy := len(parts) == 7 && parts[0] == "a1"
+	current := len(parts) == 9 && parts[0] == "a2"
+	if (!legacy && !current) || len(parts[3]) != 32 {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	sequence, err := strconv.ParseUint(parts[1], 16, 64)
+	if err != nil || sequence == 0 {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	epoch, err := strconv.ParseUint(parts[2], 16, 64)
+	if err != nil {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	if _, err := hex.DecodeString(parts[3]); err != nil {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	incarnation, err := base64.RawURLEncoding.DecodeString(parts[6])
+	if err != nil {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	var sourceIncarnation, sourceSchemaFingerprint []byte
+	if parts[0] == "a2" {
+		sourceIncarnation, err = base64.RawURLEncoding.DecodeString(parts[7])
+		if err != nil {
+			return atomicSnapshotJournalEntry{}, false
+		}
+		sourceSchemaFingerprint, err = base64.RawURLEncoding.DecodeString(parts[8])
+		if err != nil {
+			return atomicSnapshotJournalEntry{}, false
+		}
+	}
+	attempt := atomicSnapshotJournalEntry{
+		attemptID:               parts[3],
+		sequence:                sequence,
+		snapshotEpoch:           epoch,
+		ready:                   parts[4] == "1",
+		resumeLSN:               parts[5],
+		expectedIncarnation:     string(incarnation),
+		sourceMetadataKnown:     parts[0] == "a2" && parts[4] == "1",
+		sourceIncarnation:       string(sourceIncarnation),
+		sourceSchemaFingerprint: string(sourceSchemaFingerprint),
+	}
+	if parts[4] != "0" && parts[4] != "1" {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	if attempt.ready && (!cdcStatePositionValid(attempt.resumeLSN) || attempt.expectedIncarnation == "") {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	if !attempt.ready && (attempt.resumeLSN != "" ||
+		attempt.expectedIncarnation != "" ||
+		attempt.sourceIncarnation != "" ||
+		attempt.sourceSchemaFingerprint != "") {
+		return atomicSnapshotJournalEntry{}, false
+	}
+	return attempt, true
 }

--- a/pkg/strategy/cdc_state_test.go
+++ b/pkg/strategy/cdc_state_test.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 )
@@ -45,6 +47,35 @@ type cdcStateDestination struct {
 
 type caseCanonicalCDCStateDestination struct {
 	*cdcStateDestination
+}
+
+type nonConditionalCDCStateDestination struct {
+	*fakeDestination
+}
+
+func (*nonConditionalCDCStateDestination) LoadCDCState(context.Context, string, string) ([]destination.CDCStateEntry, error) {
+	return nil, nil
+}
+
+func (*nonConditionalCDCStateDestination) LoadCDCStateFence(context.Context, string, string) (destination.CDCStateFence, error) {
+	return destination.CDCStateFence{}, nil
+}
+
+func (*nonConditionalCDCStateDestination) DeleteCDCStateEvents(context.Context, string, string, []string) error {
+	return nil
+}
+
+func (*nonConditionalCDCStateDestination) WriteCDCState(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	return nil
+}
+
+func (*nonConditionalCDCStateDestination) ClaimCDCTarget(context.Context, string, destination.CDCTargetClaim) error {
+	return nil
 }
 
 func (d *caseCanonicalCDCStateDestination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {
@@ -101,6 +132,24 @@ func (d *cdcStateDestination) CDCTargetIncarnation(_ context.Context, table stri
 	return incarnation, true, nil
 }
 
+func (d *cdcStateDestination) ApplySchemaEvolutionIfIncarnation(
+	ctx context.Context,
+	table string,
+	comparison *schemaevolution.SchemaComparison,
+	expectedIncarnation string,
+) ([]string, error) {
+	d.stateMu.Lock()
+	incarnation := d.incarnations[table]
+	if incarnation == "" {
+		incarnation = "incarnation:" + table
+	}
+	d.stateMu.Unlock()
+	if incarnation != expectedIncarnation {
+		return nil, fmt.Errorf("destination physical incarnation changed before schema evolution")
+	}
+	return d.ApplySchemaEvolution(ctx, table, comparison)
+}
+
 func newCDCStateDestination() *cdcStateDestination {
 	return &cdcStateDestination{
 		fakeDestination: &fakeDestination{},
@@ -108,6 +157,13 @@ func newCDCStateDestination() *cdcStateDestination {
 		targets:         make(map[string]string),
 		incarnations:    make(map[string]string),
 	}
+}
+
+func TestNewCDCStateManagerAllowsDestinationWithoutConditionalTruncate(t *testing.T) {
+	dest := &nonConditionalCDCStateDestination{fakeDestination: &fakeDestination{}}
+	manager, err := NewCDCStateManager(dest, "missing-conditional-truncate", "raw.orders", "")
+	require.NoError(t, err)
+	require.NotNil(t, manager)
 }
 
 func (d *cdcStateDestination) ClaimCDCTarget(_ context.Context, _ string, claim destination.CDCTargetClaim) error {
@@ -221,6 +277,262 @@ func TestCDCStateRequiresMatchingSourceTableIncarnation(t *testing.T) {
 	}
 }
 
+func TestCDCStateReusesIncompleteAtomicSnapshotAttemptAcrossRestart(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const (
+		connectorID = "atomic-attempt-restart"
+		sourceTable = "public.orders"
+		destTable   = "raw.orders"
+	)
+
+	first, err := NewCDCStateManager(dest, connectorID, destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-v1"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	firstAttempt, err := first.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstAttempt)
+	journal, pending, err := first.PendingAtomicSnapshotAttempt(sourceTable, destTable)
+	require.NoError(t, err)
+	require.True(t, pending)
+	require.False(t, journal.sourceMetadataKnown)
+	require.Empty(t, journal.sourceIncarnation)
+	require.Empty(t, journal.sourceSchemaFingerprint)
+
+	restarted, err := NewCDCStateManager(dest, connectorID, destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-v1"))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	retriedAttempt, err := restarted.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.Equal(t, firstAttempt, retriedAttempt)
+	require.NoError(t, restarted.CompleteAtomicSnapshotAttempt(ctx, sourceTable, destTable, retriedAttempt))
+
+	nextRun, err := NewCDCStateManager(dest, connectorID, destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, nextRun.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-v1"))
+	require.NoError(t, nextRun.BeginRun(ctx, false))
+	nextAttempt, err := nextRun.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.NotEqual(t, firstAttempt, nextAttempt)
+}
+
+func TestCDCStateSealCapturesFinalSourceMetadataAfterSchemaRefresh(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const (
+		sourceTable = "public.orders"
+		destTable   = "raw.orders"
+	)
+	manager, err := NewCDCStateManager(dest, "atomic-seal-final-metadata", destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-before"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	attemptID, err := manager.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-after-refresh"))
+	require.NoError(t, manager.SealAtomicSnapshotAttempt(ctx, sourceTable, destTable, attemptID, "0/900", "destination-v1"))
+
+	attempt, pending, err := manager.PendingAtomicSnapshotAttempt(sourceTable, destTable)
+	require.NoError(t, err)
+	require.True(t, pending)
+	require.True(t, attempt.sourceMetadataKnown)
+	require.Equal(t, "source-v1", attempt.sourceIncarnation)
+	require.Equal(t, "schema-after-refresh", attempt.sourceSchemaFingerprint)
+
+	restarted, err := NewCDCStateManager(dest, "atomic-seal-final-metadata", destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-after-refresh"))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	recovered, pending, err := restarted.PendingAtomicSnapshotAttempt(sourceTable, destTable)
+	require.NoError(t, err)
+	require.True(t, pending)
+	require.Equal(t, attempt, recovered)
+}
+
+func TestCDCStateAbandonedAtomicAttemptDoesNotSurviveNewSnapshotEpoch(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const (
+		connectorID = "atomic-attempt-abandon"
+		sourceTable = "public.orders"
+		destTable   = "raw.orders"
+	)
+
+	manager, err := NewCDCStateManager(dest, connectorID, destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTable(ctx, sourceTable, destTable))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	abandoned, err := manager.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.NoError(t, manager.AbandonAtomicSnapshotAttempt(ctx, sourceTable, destTable, abandoned))
+	require.NoError(t, manager.InvalidateSnapshot(ctx, sourceTable, destTable, "source-v2"))
+	active, err := manager.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.NotEqual(t, abandoned, active)
+
+	restarted, err := NewCDCStateManager(dest, connectorID, destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTable(ctx, sourceTable, destTable))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	retried, err := restarted.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.Equal(t, active, retried)
+	require.Equal(t, uint64(1), restarted.snapshotEpochs[sourceTable])
+}
+
+func TestCDCStatePruningKeepsOnlyNewestAtomicAttemptRecoveryAnchor(t *testing.T) {
+	const (
+		connectorID = "atomic-prune"
+		runID       = "00000000000000000000000000000001"
+		sourceTable = "public.orders"
+		destTable   = "raw.orders"
+	)
+	eventID := func(suffix string) string { return connectorID + "-" + runID + "-" + suffix }
+	first := atomicSnapshotJournalEntry{attemptID: "00000000000000000000000000000011", sequence: 1}
+	second := atomicSnapshotJournalEntry{
+		attemptID: "00000000000000000000000000000022", sequence: 2, ready: true,
+		resumeLSN: "0/200", expectedIncarnation: "destination-v1",
+		sourceMetadataKnown: true, sourceIncarnation: "source-v1", sourceSchemaFingerprint: "schema-v1",
+	}
+	manager := &CDCStateManager{
+		connectorID: connectorID,
+		runID:       runID,
+		generation:  1,
+		runs:        map[string]struct{}{runID: {}},
+		entries: []destination.CDCStateEntry{
+			{EventID: eventID("run"), StateKind: cdcStateKindRun, Generation: 1, Position: zeroCDCPosition},
+			{EventID: eventID("attempt-open"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 1, Status: cdcStateStatusInProgress, Position: encodeAtomicSnapshotAttempt(first)},
+			{EventID: eventID("attempt-terminal"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 1, Status: destination.CDCStateStatusComplete, Position: encodeAtomicSnapshotAttempt(first)},
+			{EventID: eventID("attempt-next-open"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 1, Status: cdcStateStatusInProgress, Position: encodeAtomicSnapshotAttempt(atomicSnapshotJournalEntry{
+				attemptID: second.attemptID, sequence: second.sequence,
+			})},
+			{EventID: eventID("attempt-next-ready"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 2, Status: cdcStateStatusReady, Position: encodeAtomicSnapshotAttempt(second)},
+		},
+	}
+
+	stale := manager.supersededEventIDs()
+	require.Contains(t, stale, eventID("attempt-open"))
+	require.Contains(t, stale, eventID("attempt-terminal"))
+	require.Contains(t, stale, eventID("attempt-next-open"))
+	require.NotContains(t, stale, eventID("attempt-next-ready"))
+
+	for _, deletedID := range stale {
+		kept := manager.entries[:0]
+		for _, entry := range manager.entries {
+			if entry.EventID != deletedID {
+				kept = append(kept, entry)
+			}
+		}
+		manager.entries = kept
+		manager.destTables = map[string]string{sourceTable: destTable}
+		recovered, sequences, err := manager.recoverAtomicSnapshotAttempts()
+		require.NoError(t, err)
+		require.Equal(t, second, recovered[sourceTable])
+		require.Equal(t, second.sequence, sequences[sourceTable])
+	}
+}
+
+func TestCDCStatePruningRetainsTerminalAtomicAttemptAnchor(t *testing.T) {
+	const (
+		connectorID = "atomic-terminal-prune"
+		runID       = "00000000000000000000000000000001"
+		sourceTable = "public.orders"
+		destTable   = "raw.orders"
+	)
+	eventID := func(suffix string) string { return connectorID + "-" + runID + "-" + suffix }
+	attempt := atomicSnapshotJournalEntry{
+		attemptID: "00000000000000000000000000000011", sequence: 1, ready: true,
+		resumeLSN: "0/100", expectedIncarnation: "destination-v1", sourceMetadataKnown: true,
+		sourceIncarnation: "source-v1", sourceSchemaFingerprint: "schema-v1",
+	}
+	manager := &CDCStateManager{
+		connectorID: connectorID,
+		runID:       runID,
+		generation:  1,
+		runs:        map[string]struct{}{runID: {}},
+		destTables:  map[string]string{sourceTable: destTable},
+		entries: []destination.CDCStateEntry{
+			{EventID: eventID("run"), StateKind: cdcStateKindRun, Generation: 1, Position: zeroCDCPosition},
+			{EventID: eventID("open"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 1, Status: cdcStateStatusInProgress, Position: encodeAtomicSnapshotAttempt(atomicSnapshotJournalEntry{attemptID: attempt.attemptID, sequence: attempt.sequence})},
+			{EventID: eventID("ready"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 1, Status: cdcStateStatusReady, Position: encodeAtomicSnapshotAttempt(attempt)},
+			{EventID: eventID("terminal"), SourceTable: sourceTable, DestinationTable: destTable, StateKind: cdcStateKindAtomicAttempt, Generation: 2, Status: destination.CDCStateStatusComplete, Position: encodeAtomicSnapshotAttempt(attempt)},
+		},
+	}
+
+	stale := manager.supersededEventIDs()
+	require.Contains(t, stale, eventID("open"))
+	require.Contains(t, stale, eventID("ready"))
+	require.NotContains(t, stale, eventID("terminal"))
+	for _, deletedID := range stale {
+		kept := manager.entries[:0]
+		for _, entry := range manager.entries {
+			if entry.EventID != deletedID {
+				kept = append(kept, entry)
+			}
+		}
+		manager.entries = kept
+		recovered, sequences, err := manager.recoverAtomicSnapshotAttempts()
+		require.NoError(t, err)
+		require.Empty(t, recovered)
+		require.Equal(t, attempt.sequence, sequences[sourceTable])
+	}
+}
+
+func TestCDCStateAtomicAttemptJournalRemainsBoundedAcrossRestarts(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	dest.pruneBatchSize = 1
+	const (
+		connectorID = "atomic-restart-pruning"
+		sourceTable = "public.orders"
+		destTable   = "raw.orders"
+	)
+	var manager *CDCStateManager
+	var attemptID string
+	for run := 0; run < 2*cdcStatePruneThreshold+5; run++ {
+		var err error
+		manager, err = NewCDCStateManager(dest, connectorID, destTable, "")
+		require.NoError(t, err)
+		require.NoError(t, manager.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-v1"))
+		require.NoError(t, manager.BeginRun(ctx, false))
+		current, err := manager.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+		require.NoError(t, err)
+		if attemptID == "" {
+			attemptID = current
+		}
+		require.Equal(t, attemptID, current)
+	}
+	require.NoError(t, manager.CompleteAtomicSnapshotAttempt(ctx, sourceTable, destTable, attemptID))
+
+	restarted, err := NewCDCStateManager(dest, connectorID, destTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, sourceTable, destTable, "source-v1", "schema-v1"))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	_, pending, err := restarted.PendingAtomicSnapshotAttempt(sourceTable, destTable)
+	require.NoError(t, err)
+	require.False(t, pending)
+
+	dest.stateMu.Lock()
+	atomicRows := 0
+	for _, state := range dest.states[restarted.stateTable] {
+		if state.connectorID == connectorID && state.entry.StateKind == cdcStateKindAtomicAttempt {
+			atomicRows++
+		}
+	}
+	dest.stateMu.Unlock()
+	require.LessOrEqual(t, atomicRows, 2, "journal should retain only its terminal recovery anchor and a bounded tail")
+
+	nextID, err := restarted.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	require.NoError(t, err)
+	require.NotEqual(t, attemptID, nextID)
+	next, pending, err := restarted.PendingAtomicSnapshotAttempt(sourceTable, destTable)
+	require.NoError(t, err)
+	require.True(t, pending)
+	require.Equal(t, uint64(2), next.sequence)
+}
+
 func TestCDCStateRequiresMatchingSourceSchemaFingerprint(t *testing.T) {
 	ctx := t.Context()
 	dest := newCDCStateDestination()
@@ -293,6 +605,189 @@ func TestCDCStateWALTruncatePreservesRegisteredSourceIncarnation(t *testing.T) {
 	require.Equal(t, "00000000/00000030", position)
 }
 
+func TestMultiTableSnapshotInvalidationIsDurableBeforeNonAtomicTruncate(t *testing.T) {
+	ctx := t.Context()
+	dest := &orderedCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.items"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-invalidation", "raw.items", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.items", "raw.items", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.items", "raw.items"))
+	dest.resetOrder()
+	job := &MultiTableIngestionJob{
+		Tables:          []source.SourceTableInfo{{Name: "public.items"}},
+		TableDestNames:  map[string]string{"public.items": "raw.items"},
+		CDCStateManager: manager,
+	}
+	records := make(chan source.RecordBatchResult, 4)
+	records <- source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+		TableName: "public.items",
+	}}
+	records <- source.RecordBatchResult{TableName: "public.items", TableInfo: &source.SourceTableInfo{
+		Name: "public.items", Incarnation: "source-v2",
+	}}
+	records <- source.RecordBatchResult{TableName: "public.items", TableInfo: &source.SourceTableInfo{
+		Name: "public.items", SchemaFingerprint: "schema-v2",
+	}}
+	records <- source.RecordBatchResult{TableName: "public.items", Truncate: true}
+	close(records)
+
+	_, err = destination.WriteWithTruncateBoundaries(ctx, dest, applyMultiTableSnapshotInvalidations(ctx, job, records), destination.WriteOptions{
+		Table: "raw.items", CDCExpectedIncarnation: "target-v1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"state", "truncate"}, dest.recordedOrder())
+	incarnation, fingerprint := manager.CurrentSourceMetadata("public.items")
+	require.Equal(t, "source-v2", incarnation)
+	require.Equal(t, "schema-v2", fingerprint)
+}
+
+func TestMergeSnapshotInvalidationMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		invalidation source.CDCSnapshotInvalidation
+		table        source.SourceTableInfo
+		want         source.CDCSnapshotInvalidation
+		wantErr      string
+	}{
+		{
+			name:         "fills incarnation",
+			invalidation: source.CDCSnapshotInvalidation{TableName: "public.items", SchemaFingerprint: "schema-v2"},
+			table:        source.SourceTableInfo{Name: "public.items", Incarnation: "source-v2"},
+			want: source.CDCSnapshotInvalidation{
+				TableName: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+			},
+		},
+		{
+			name:         "fills schema",
+			invalidation: source.CDCSnapshotInvalidation{TableName: "public.items", Incarnation: "source-v2"},
+			table:        source.SourceTableInfo{Name: "public.items", SchemaFingerprint: "schema-v2"},
+			want: source.CDCSnapshotInvalidation{
+				TableName: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+			},
+		},
+		{
+			name:         "keeps empty metadata empty",
+			invalidation: source.CDCSnapshotInvalidation{TableName: "public.items"},
+			table:        source.SourceTableInfo{Name: "public.items"},
+			want:         source.CDCSnapshotInvalidation{TableName: "public.items"},
+		},
+		{
+			name:         "rejects mismatched table",
+			invalidation: source.CDCSnapshotInvalidation{TableName: "public.items"},
+			table:        source.SourceTableInfo{Name: "public.orders"},
+			wantErr:      "followed by metadata for public.orders",
+		},
+		{
+			name:         "rejects conflicting incarnation",
+			invalidation: source.CDCSnapshotInvalidation{TableName: "public.items", Incarnation: "source-v2"},
+			table:        source.SourceTableInfo{Name: "public.items", Incarnation: "source-v3"},
+			wantErr:      "conflicting incarnation metadata",
+		},
+		{
+			name: "rejects conflicting schema",
+			invalidation: source.CDCSnapshotInvalidation{
+				TableName: "public.items", SchemaFingerprint: "schema-v2",
+			},
+			table:   source.SourceTableInfo{Name: "public.items", SchemaFingerprint: "schema-v3"},
+			wantErr: "conflicting schema metadata",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mergeSnapshotInvalidationMetadata(tc.invalidation, &tc.table)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMultiTableSnapshotInvalidationRejectsConflictingAnnouncementMetadata(t *testing.T) {
+	records := mustClosedRecords(
+		source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+			TableName: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+		}},
+		source.RecordBatchResult{TableName: "public.items", TableInfo: &source.SourceTableInfo{
+			Name: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v3",
+		}},
+	)
+	job := &MultiTableIngestionJob{Tables: []source.SourceTableInfo{{Name: "public.items"}}}
+
+	var gotErr error
+	for result := range applyMultiTableSnapshotInvalidations(t.Context(), job, records) {
+		if result.Err != nil {
+			gotErr = result.Err
+		}
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	require.ErrorContains(t, gotErr, "conflicting schema metadata")
+}
+
+func TestMultiTableSnapshotInvalidationWithoutBoundaryPreservesPriorState(t *testing.T) {
+	ctx := t.Context()
+	dest := &orderedCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.items"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-missing-boundary", "raw.items", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.items", "raw.items", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.items", "raw.items"))
+	dest.resetOrder()
+	job := &MultiTableIngestionJob{
+		Tables:          []source.SourceTableInfo{{Name: "public.items"}},
+		TableDestNames:  map[string]string{"public.items": "raw.items"},
+		CDCStateManager: manager,
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+		TableName: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+	}}
+	close(records)
+
+	var gotErr error
+	for result := range applyMultiTableSnapshotInvalidations(ctx, job, records) {
+		gotErr = result.Err
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	require.ErrorContains(t, gotErr, "was not followed by a replacement boundary")
+	require.Empty(t, dest.recordedOrder())
+}
+
+func TestMultiTableSnapshotInvalidationCancellationDrainsUpstream(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	batch := &singleReleaseCountingRecordBatch{RecordBatch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records := make(chan source.RecordBatchResult)
+	out := applyMultiTableSnapshotInvalidations(ctx, &MultiTableIngestionJob{}, records)
+	producerDone := make(chan struct{})
+	go func() {
+		records <- source.RecordBatchResult{Batch: batch}
+		close(records)
+		close(producerDone)
+	}()
+
+	for result := range out {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	select {
+	case <-producerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("snapshot invalidation wrapper stranded its upstream producer after cancellation")
+	}
+	require.EqualValues(t, 1, batch.releases.Load())
+}
+
 func TestCDCStateRequiresMatchingDestinationTableIncarnation(t *testing.T) {
 	ctx := t.Context()
 	dest := newCDCStateDestination()
@@ -326,6 +821,37 @@ func TestCDCStateRequiresMatchingDestinationTableIncarnation(t *testing.T) {
 	if got, err := restarted.ResumePosition(ctx, "public.orders"); err != nil || got != "" {
 		t.Fatalf("recreated destination resume = %q, %v; want forced snapshot", got, err)
 	}
+}
+
+func TestCDCStateRejectsReplacementAfterResumeBeforeBind(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	dest.incarnations["raw.orders"] = "destination-v1"
+	first, err := NewCDCStateManager(dest, "resume-bind-incarnation", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableIncarnation(ctx, "public.orders", "raw.orders", "source-v1"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.BindDestinationIncarnation(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:             "00000000/00000020",
+		SnapshotPositions:    map[string]string{"public.orders": "00000000/00000010"},
+		SnapshotIncarnations: map[string]string{"public.orders": "source-v1"},
+	}))
+
+	restarted, err := NewCDCStateManager(dest, "resume-bind-incarnation", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableIncarnation(ctx, "public.orders", "raw.orders", "source-v1"))
+	position, err := restarted.ResumePosition(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", position)
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	dest.stateMu.Lock()
+	dest.incarnations["raw.orders"] = "destination-v2"
+	dest.stateMu.Unlock()
+
+	err = restarted.BindDestinationIncarnation(ctx, "public.orders", "raw.orders")
+	require.ErrorContains(t, err, "replaced after its resume position was selected")
+	require.Empty(t, restarted.BoundDestinationIncarnation("public.orders"))
 }
 
 func TestCDCStateRejectsDestinationReplacementBeforeCheckpoint(t *testing.T) {
@@ -1425,6 +1951,26 @@ func TestCDCStateRequiresLatestGenerationCompletedSnapshot(t *testing.T) {
 	if manager.stateTable != "_bruin_staging.cdc_state" {
 		t.Fatalf("unexpected shared state table: %s", manager.stateTable)
 	}
+}
+
+func TestCDCStateBatchSnapshotCompletionUsesFinalCheckpoint(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "batch-truncate-completion", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.orders", "raw.orders", "source-v1", "schema-v1"))
+	require.NoError(t, manager.ClaimTarget(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	manager.RecordBatchSnapshotCompletion("public.orders", "")
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "00000000/00000020"}))
+
+	restarted, err := NewCDCStateManager(dest, "batch-truncate-completion", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, "public.orders", "raw.orders", "source-v1", "schema-v1"))
+	position, err := restarted.ResumePosition(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", position)
 }
 
 func TestCDCStateConnectorsShareTableWithoutSharingRows(t *testing.T) {

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -56,6 +56,9 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	}); err != nil {
 		return fmt.Errorf("failed to prepare destination table: %w", err)
 	}
+	if !job.Config.KeepStaging {
+		defer dropManagedStagingDetached(ctx, job.Destination, stagingTable, "DELETE+INSERT")
+	}
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:        stagingTable,
@@ -120,13 +123,12 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	intervalStart := resolveIntervalBound(job.Config.IntervalStart, intervalTracker.Min)
 	intervalEnd := resolveIntervalBound(job.Config.IntervalEnd, intervalTracker.Max)
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	if intervalStart == nil || intervalEnd == nil {
 		config.Debug("[DELETE+INSERT] No interval detected (empty data?), skipping delete+insert")
-		if !job.Config.KeepStaging {
-			if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-				config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
-			}
-		}
 		return nil
 	}
 
@@ -140,10 +142,6 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		intervalEnd = toDateOnly(intervalEnd)
 	}
 
-	if err := job.ApplyEvolution(ctx); err != nil {
-		return fmt.Errorf("failed to apply schema evolution: %w", err)
-	}
-
 	if err := job.Destination.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
 		StagingTable:       stagingTable,
 		TargetTable:        job.Config.DestTable,
@@ -151,16 +149,10 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		IncrementalKeyType: incrementalKeyType,
 		IntervalStart:      intervalStart,
 		IntervalEnd:        intervalEnd,
-		Columns:            job.Schema.ColumnNames(),
+		Columns:            destination.DestinationColumns(job.Schema.ColumnNames()),
 		PrimaryKeys:        job.Config.PrimaryKeys,
 	}); err != nil {
 		return fmt.Errorf("failed to delete+insert data: %w", err)
-	}
-
-	if !job.Config.KeepStaging {
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
-		}
 	}
 
 	return nil

--- a/pkg/strategy/direct_merge_test.go
+++ b/pkg/strategy/direct_merge_test.go
@@ -1,0 +1,431 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type directMergeCall struct {
+	write destination.WriteOptions
+	merge destination.MergeOptions
+}
+
+type directMergeDestination struct {
+	*fakeDestination
+	directMu    sync.Mutex
+	directCalls []directMergeCall
+}
+
+type durableDirectMergeDestination struct {
+	*directMergeDestination
+	tokenMu         sync.Mutex
+	tokenCalls      []durableTokenCall
+	committedTokens map[source.DurableID]struct{}
+}
+
+func (*durableDirectMergeDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+type idempotentDirectMergeDestination struct {
+	*directMergeDestination
+	tokenMu         sync.Mutex
+	committedTokens map[source.DurableID]struct{}
+}
+
+func (*idempotentDirectMergeDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+func (d *durableDirectMergeDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.tokenMu.Lock()
+	defer d.tokenMu.Unlock()
+	if d.committedTokens == nil {
+		d.committedTokens = make(map[source.DurableID]struct{})
+	}
+	if _, duplicate := d.committedTokens[opts.CommitToken]; opts.CommitToken != "" && duplicate {
+		drainAndRelease(records)
+		return nil
+	}
+	if err := d.directMergeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	if opts.CommitToken != "" {
+		d.committedTokens[opts.CommitToken] = struct{}{}
+	}
+	return nil
+}
+
+func (d *idempotentDirectMergeDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.tokenMu.Lock()
+	defer d.tokenMu.Unlock()
+	if d.committedTokens == nil {
+		d.committedTokens = make(map[source.DurableID]struct{})
+	}
+	_, duplicate := d.committedTokens[opts.CommitToken]
+	if opts.CommitToken != "" && duplicate {
+		drainAndRelease(records)
+		return nil
+	}
+	if err := d.directMergeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	if opts.CommitToken != "" {
+		d.committedTokens[opts.CommitToken] = struct{}{}
+	}
+	return nil
+}
+
+type failAfterOneDirectMergeDestination struct {
+	*fakeDestination
+	err error
+}
+
+func (d *failAfterOneDirectMergeDestination) MergeRecords(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions, _ destination.MergeOptions) error {
+	result, ok := <-records
+	if ok && result.Batch != nil {
+		result.Batch.Release()
+	}
+	return d.err
+}
+
+func (d *durableDirectMergeDestination) CommitWriteToken(_ context.Context, table string, token source.DurableID, cdcResumeLSN string) error {
+	d.tokenMu.Lock()
+	defer d.tokenMu.Unlock()
+	d.tokenCalls = append(d.tokenCalls, durableTokenCall{table: table, token: token, cdcResumeLSN: cdcResumeLSN})
+	return nil
+}
+
+func (d *directMergeDestination) MergeRecords(ctx context.Context, records <-chan source.RecordBatchResult, write destination.WriteOptions, merge destination.MergeOptions) error {
+	d.directMu.Lock()
+	d.directCalls = append(d.directCalls, directMergeCall{write: write, merge: merge})
+	d.directMu.Unlock()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case result, ok := <-records:
+			if !ok {
+				return nil
+			}
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			if result.Err != nil {
+				return result.Err
+			}
+		}
+	}
+}
+
+func (d *directMergeDestination) callsSnapshot() []directMergeCall {
+	d.directMu.Lock()
+	defer d.directMu.Unlock()
+	return append([]directMergeCall(nil), d.directCalls...)
+}
+
+func TestMergeStrategyUsesDirectMergeWithoutStaging(t *testing.T) {
+	job, src, base := minimalJob()
+	dest := &directMergeDestination{fakeDestination: base}
+	job.Destination = dest
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.IncrementalPredicate = "t.updated_at >= DATE '2026-07-01'"
+	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil)})
+
+	require.NoError(t, (&MergeStrategy{}).Execute(context.Background(), job))
+	require.Len(t, base.prepareCalls, 1)
+	require.Equal(t, job.Config.DestTable, base.prepareCalls[0].Table)
+	require.Empty(t, base.writeCalls)
+	require.Empty(t, base.mergeCalls)
+	require.Empty(t, base.dropCalls)
+
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 1)
+	require.Equal(t, job.Config.DestTable, calls[0].merge.TargetTable)
+	require.Equal(t, []string{"id"}, calls[0].merge.PrimaryKeys)
+	require.Equal(t, job.Config.ExtractParallelism, calls[0].write.Parallelism)
+	require.Equal(t, job.Config.IncrementalPredicate, calls[0].merge.IncrementalPredicate)
+}
+
+func TestStreamingDirectMergeFlushesTargetAndTokenWithoutStaging(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &directMergeDestination{fakeDestination: base}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+	state := &streamTableState{
+		destTable:            "ds.events",
+		schema:               streamTestSchema(),
+		primaryKeys:          []string{"id"},
+		incrementalKey:       "id",
+		incrementalPredicate: "t.id >= 100",
+	}
+	cfg := &config.IngestConfig{ExtractParallelism: 3}
+	require.NoError(t, executor.prepareTable(context.Background(), dest, cfg, state))
+	require.True(t, state.directMerge)
+	require.Empty(t, state.stagingTable)
+	require.Len(t, base.prepareCalls, 1)
+
+	committer := &fakeCommitter{}
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		Strategy: config.StrategyMerge, Committer: committer, FlushInterval: time.Hour,
+	}, map[string]*streamTableState{"": state})
+	loop.buffer(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{7}, nil), CommitToken: "0/70",
+		DurableCommitID: "0/70", DurableCommitPosition: "0/70",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 1)
+	require.Equal(t, "ds.events", calls[0].merge.TargetTable)
+	require.Equal(t, source.DurableID("0/70"), calls[0].merge.CommitToken)
+	require.Equal(t, state.incrementalPredicate, calls[0].merge.IncrementalPredicate)
+	require.Empty(t, base.writeCalls)
+	require.Empty(t, base.mergeCalls)
+	require.Equal(t, []any{"0/70"}, committer.committed())
+}
+
+func TestStreamingDirectMergeDoesNotMislabelCombinedFlushWithLastPayloadID(t *testing.T) {
+	dest := &directMergeDestination{fakeDestination: &fakeDestination{}}
+	state := &streamTableState{
+		destTable: "ds.events", schema: streamTestSchema(), primaryKeys: []string{"id"}, directMerge: true,
+	}
+	loop := newFlushLoop(dest, &config.IngestConfig{ExtractParallelism: 2}, StreamingOptions{
+		Strategy: config.StrategyMerge, FlushInterval: time.Hour,
+	}, map[string]*streamTableState{"": state})
+	loop.buffer(source.RecordBatchResult{
+		Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "payload-a", DurableCommitPosition: "0/10",
+	})
+	loop.buffer(source.RecordBatchResult{
+		Batch:           int64RecordBatch(t, "id", []int64{2}, nil),
+		DurableCommitID: "payload-b", DurableCommitPosition: "0/20",
+	})
+
+	require.NoError(t, loop.flush(t.Context()))
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 1)
+	require.Empty(t, calls[0].merge.CommitToken, "a combined commit cannot use only its final payload identity")
+	require.Equal(t, "0/20", calls[0].merge.CDCResumeLSN)
+}
+
+func TestWriteDirectMultiTableMergeRoutesEachTable(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &directMergeDestination{fakeDestination: base}
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	configs := map[string]destination.TableWriteConfig{
+		"public.users": {
+			DestTable: "lake.users", Schema: tableSchema, PrimaryKeys: []string{"id"}, IncrementalKey: "id",
+			IncrementalPredicate: "t.id >= 100", SkipCDCResume: true, CDCExpectedIncarnation: "users-v1",
+		},
+		"public.orders": {DestTable: "lake.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}, IncrementalKey: "id"},
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{TableName: "public.orders", Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+	)
+	require.NoError(t, writeDirectMultiTableMerge(context.Background(), func() {}, dest, dest, records, tables, configs, 2))
+
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 2)
+	seen := map[string]bool{}
+	for _, call := range calls {
+		seen[call.merge.TargetTable] = true
+		if call.merge.TargetTable == "lake.users" {
+			require.True(t, call.write.SkipCDCResume)
+			require.True(t, call.merge.SkipCDCResume)
+			require.Equal(t, "users-v1", call.write.CDCExpectedIncarnation)
+			require.Equal(t, "id", call.merge.IncrementalKey)
+			require.Equal(t, "t.id >= 100", call.merge.IncrementalPredicate)
+		}
+	}
+	require.Equal(t, map[string]bool{"lake.users": true, "lake.orders": true}, seen)
+}
+
+func TestWriteDirectMultiTableMergeCommitsKeylessCDCByDurableTransaction(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &idempotentDirectMergeDestination{directMergeDestination: &directMergeDestination{fakeDestination: base}}
+	tableSchema := keylessCDCSchema()
+	tables := []source.SourceTableInfo{{Name: "public.events", Schema: tableSchema}}
+	configs := map[string]destination.TableWriteConfig{
+		"public.events": {DestTable: "lake.events", Schema: tableSchema},
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "wal:public.events:0/10", DurableCommitPosition: "0/10",
+		},
+		source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+			DurableCommitID: "wal:public.events:0/20", DurableCommitPosition: "0/20",
+		},
+	)
+
+	require.NoError(t, writeDirectMultiTableMerge(context.Background(), func() {}, dest, dest, records, tables, configs, 2))
+	replay := mustClosedRecords(
+		source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "wal:public.events:0/10", DurableCommitPosition: "0/10",
+		},
+		source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+			DurableCommitID: "wal:public.events:0/20", DurableCommitPosition: "0/20",
+		},
+	)
+	require.NoError(t, writeDirectMultiTableMerge(context.Background(), func() {}, dest, dest, replay, tables, configs, 2))
+	require.Empty(t, dest.callsSnapshot(), "keyless CDC must append rather than merge")
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	require.Len(t, base.writeCalls, 2, "replayed WAL transactions must not be appended twice")
+	require.Equal(t, source.DurableID("wal:public.events:0/10"), base.writeCalls[0].CommitToken)
+	require.Equal(t, "0/10", base.writeCalls[0].CDCResumeLSN)
+	require.False(t, base.writeCalls[0].SkipCDCResume)
+	require.Equal(t, source.DurableID("wal:public.events:0/20"), base.writeCalls[1].CommitToken)
+	require.Equal(t, "0/20", base.writeCalls[1].CDCResumeLSN)
+}
+
+func TestWriteDirectMultiTableMergeDrainsBlockingProducerAfterCancellation(t *testing.T) {
+	mergeErr := errors.New("merge failed")
+	dest := &failAfterOneDirectMergeDestination{fakeDestination: &fakeDestination{}, err: mergeErr}
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}}
+	configs := map[string]destination.TableWriteConfig{
+		"public.users": {DestTable: "lake.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+
+	records := make(chan source.RecordBatchResult, 1)
+	trigger := source.RecordBatchResult{
+		TableName: "public.users",
+		Batch:     int64RecordBatch(t, "id", []int64{0}, nil),
+	}
+	pending := []source.RecordBatchResult{
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{3}, nil)},
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{4}, nil)},
+	}
+	canceled := make(chan struct{})
+	firstPendingSent := make(chan struct{})
+	resumeProducer := make(chan struct{})
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		records <- trigger
+		<-canceled
+		records <- pending[0]
+		close(firstPendingSent)
+		<-resumeProducer
+		for _, result := range pending[1:] {
+			records <- result
+		}
+		close(records)
+	}()
+	go func() {
+		<-firstPendingSent
+		time.Sleep(25 * time.Millisecond)
+		close(resumeProducer)
+	}()
+
+	var cancelOnce sync.Once
+	err := writeDirectMultiTableMerge(context.Background(), func() {
+		cancelOnce.Do(func() { close(canceled) })
+	}, dest, dest, records, tables, configs, 1)
+	require.ErrorIs(t, err, mergeErr)
+
+	select {
+	case <-producerDone:
+	case <-time.After(time.Second):
+		go drainAndRelease(records)
+		<-producerDone
+		t.Fatal("source producer remained blocked after cancellation")
+	}
+}
+
+func TestStartBoundedRecordDrainStopsForNonclosingSource(t *testing.T) {
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+
+	done := startBoundedRecordDrain(records, 20*time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("bounded source drain did not stop at its deadline")
+	}
+	close(records)
+}
+
+func TestWriteDurableKeylessCDCRecordsPersistsEmptySnapshotCheckpoint(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &durableDirectMergeDestination{
+		directMergeDestination: &directMergeDestination{fakeDestination: base},
+	}
+	records := mustClosedRecords(source.RecordBatchResult{
+		DurableCommitID: "snapshot:0/30:empty", DurableCommitPosition: "0/30",
+	})
+
+	require.NoError(t, writeDurableKeylessCDCRecords(context.Background(), dest, records, destination.WriteOptions{
+		Table: "lake.empty_events", Schema: keylessCDCSchema(),
+	}))
+	require.Empty(t, base.writeCalls)
+	dest.tokenMu.Lock()
+	defer dest.tokenMu.Unlock()
+	require.Equal(t, []durableTokenCall{{
+		table: "lake.empty_events", token: "snapshot:0/30:empty", cdcResumeLSN: "0/30",
+	}}, dest.tokenCalls)
+}
+
+func TestWriteDurableKeylessCDCRecordsManagedWriteSkipsTargetCursor(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &durableDirectMergeDestination{directMergeDestination: &directMergeDestination{fakeDestination: base}}
+	records := mustClosedRecords(
+		source.RecordBatchResult{
+			Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "wal:0/20", DurableCommitPosition: "0/20",
+		},
+		source.RecordBatchResult{DurableCommitID: "wal:0/21", DurableCommitPosition: "0/21"},
+	)
+
+	require.NoError(t, writeDurableKeylessCDCRecords(t.Context(), dest, records, destination.WriteOptions{
+		Table: "lake.events", Schema: keylessCDCSchema(), SkipCDCResume: true,
+	}))
+	require.Len(t, base.writeCalls, 1)
+	require.True(t, base.writeCalls[0].SkipCDCResume)
+	require.Empty(t, base.writeCalls[0].CDCResumeLSN)
+	dest.tokenMu.Lock()
+	require.Empty(t, dest.tokenCalls)
+	dest.tokenMu.Unlock()
+}
+
+func TestWriteDurableKeylessCDCRecordsUsesManagedBatchIdentity(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &durableDirectMergeDestination{directMergeDestination: &directMergeDestination{fakeDestination: base}}
+	records := mustClosedRecords(source.RecordBatchResult{
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+		TableName: "public.events",
+		CommitToken: source.CDCStateCommitToken{
+			Position: "0/20", DataBatchID: "public.events:0/20/1:0/20/1",
+		},
+	})
+
+	require.NoError(t, writeDurableKeylessCDCRecords(t.Context(), dest, records, destination.WriteOptions{
+		Table: "lake.events", Schema: keylessCDCSchema(), SkipCDCResume: true,
+	}))
+	require.Len(t, base.writeCalls, 1)
+	require.Equal(t, managedCDCDataWriteID("public.events", "public.events:0/20/1:0/20/1"), base.writeCalls[0].CommitToken)
+	require.True(t, base.writeCalls[0].SkipCDCResume)
+	require.Empty(t, base.writeCalls[0].CDCResumeLSN)
+}
+
+var (
+	_ destination.DirectMergeWriter        = (*directMergeDestination)(nil)
+	_ destination.DirectMergeWriter        = (*failAfterOneDirectMergeDestination)(nil)
+	_ destination.DurableCommitTokenWriter = (*durableDirectMergeDestination)(nil)
+)

--- a/pkg/strategy/keyless_cdc_test.go
+++ b/pkg/strategy/keyless_cdc_test.go
@@ -2,6 +2,8 @@ package strategy
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,12 +40,190 @@ func schemaHasColumn(s *schema.TableSchema, name string) bool {
 	return false
 }
 
+type idempotentCommitTokenDestination struct {
+	*fakeDestination
+	tokenMu         sync.Mutex
+	committedTokens map[source.DurableID]struct{}
+}
+
+func (*idempotentCommitTokenDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+func (d *idempotentCommitTokenDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.tokenMu.Lock()
+	defer d.tokenMu.Unlock()
+	if d.committedTokens == nil {
+		d.committedTokens = make(map[source.DurableID]struct{})
+	}
+	if _, duplicate := d.committedTokens[opts.CommitToken]; opts.CommitToken != "" && duplicate {
+		drainAndRelease(records)
+		return nil
+	}
+	if err := d.fakeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	if opts.CommitToken != "" {
+		d.committedTokens[opts.CommitToken] = struct{}{}
+	}
+	return nil
+}
+
+type managedKeylessDestination struct {
+	*cdcStateDestination
+	dataMu             sync.Mutex
+	dataWrites         []destination.WriteOptions
+	committedData      map[source.DurableID]struct{}
+	visibleRows        int64
+	truncates          int
+	failStateAfterData bool
+}
+
+type emptyIncarnationManagedKeylessDestination struct {
+	*managedKeylessDestination
+}
+
+func (*emptyIncarnationManagedKeylessDestination) CDCTargetIncarnation(context.Context, string) (string, bool, error) {
+	return "", true, nil
+}
+
+type replacingManagedKeylessDestination struct {
+	*managedKeylessDestination
+	writes int
+}
+
+type recreateDuringInvalidationManagedKeylessDestination struct {
+	*managedKeylessDestination
+	recreateMu sync.Mutex
+	armed      bool
+}
+
+type managedAtomicKeylessDestination struct {
+	*managedKeylessDestination
+}
+
+func (d *recreateDuringInvalidationManagedKeylessDestination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if err := d.managedKeylessDestination.WriteCDCState(ctx, records, opts); err != nil {
+		return err
+	}
+	d.recreateMu.Lock()
+	armed := d.armed
+	d.armed = false
+	d.recreateMu.Unlock()
+	if armed {
+		d.stateMu.Lock()
+		d.incarnations["raw.events"] = "replacement-incarnation"
+		d.stateMu.Unlock()
+	}
+	return nil
+}
+
+func (d *replacingManagedKeylessDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	current, exists, err := d.CDCTargetIncarnation(ctx, opts.Table)
+	if err != nil {
+		drainAndRelease(records)
+		return err
+	}
+	if !exists || opts.CDCExpectedIncarnation == "" || opts.CDCExpectedIncarnation != current {
+		drainAndRelease(records)
+		return errors.New("destination was replaced before managed keyless write")
+	}
+	if err := d.managedKeylessDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	d.writes++
+	if d.writes == 1 {
+		d.stateMu.Lock()
+		d.incarnations[opts.Table] = "replacement-incarnation"
+		d.stateMu.Unlock()
+	}
+	return nil
+}
+
+func (*managedAtomicKeylessDestination) BeginAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return nil
+}
+
+func (*managedAtomicKeylessDestination) EvolveAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return nil
+}
+
+func (*managedAtomicKeylessDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions) error {
+	drainAndRelease(records)
+	return nil
+}
+
+func (*managedAtomicKeylessDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	return opts.CDCExpectedIncarnation, nil
+}
+
+func (*managedAtomicKeylessDestination) MergeRecords(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions, _ destination.MergeOptions) error {
+	drainAndRelease(records)
+	return nil
+}
+
+func (*managedKeylessDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+func (d *managedKeylessDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expected string) error {
+	if err := d.cdcStateDestination.TruncateCDCTableIfIncarnation(ctx, table, expected); err != nil {
+		return err
+	}
+	d.dataMu.Lock()
+	d.visibleRows = 0
+	d.truncates++
+	d.dataMu.Unlock()
+	return nil
+}
+
+func (d *managedKeylessDestination) WriteParallel(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	var rows int64
+	for result := range records {
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.dataMu.Lock()
+	d.dataWrites = append(d.dataWrites, opts)
+	if token := opts.CommitToken; token != "" {
+		if d.committedData == nil {
+			d.committedData = make(map[source.DurableID]struct{})
+		}
+		if _, exists := d.committedData[token]; !exists {
+			d.committedData[token] = struct{}{}
+			d.visibleRows += rows
+		}
+	} else {
+		d.visibleRows += rows
+	}
+	d.dataMu.Unlock()
+	return nil
+}
+
+func (d *managedKeylessDestination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.dataMu.Lock()
+	fail := d.failStateAfterData && len(d.dataWrites) > 0
+	if fail {
+		d.failStateAfterData = false
+	}
+	d.dataMu.Unlock()
+	if fail {
+		drainAndRelease(records)
+		return errors.New("injected state persistence failure")
+	}
+	return d.cdcStateDestination.WriteCDCState(ctx, records, opts)
+}
+
 func TestMergeStrategy_MultiTableKeylessCDCLandsAppendOnly(t *testing.T) {
 	dest := &fakeDestination{}
 	table := source.SourceTableInfo{Name: "public.events", Schema: keylessCDCSchema()}
 
 	records := make(chan source.RecordBatchResult, 1)
-	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.events"}
+	records <- source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.events",
+		DurableCommitID: "wal:public.events:0/10", DurableCommitPosition: "0/10",
+	}
 	close(records)
 
 	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
@@ -105,7 +285,7 @@ func TestMergeStrategy_MultiTableMixedKeyedAndKeyless(t *testing.T) {
 }
 
 func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
-	dest := &fakeDestination{}
+	dest := &idempotentCommitTokenDestination{fakeDestination: &fakeDestination{}}
 	exec := NewStreamingExecutor(StreamingOptions{
 		FlushInterval: time.Hour,
 		FlushRecords:  1,
@@ -138,7 +318,10 @@ func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
 	}, map[string]*streamTableState{"public.events": st})
 
 	records := make(chan source.RecordBatchResult, 1)
-	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.events"}
+	records <- source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.events",
+		DurableCommitID: "wal:public.events:0/10", DurableCommitPosition: "0/10",
+	}
 	close(records)
 
 	require.NoError(t, loop.run(context.Background(), records))
@@ -149,4 +332,1009 @@ func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
 	assert.Equal(t, "events", dest.writeCalls[0].Table)
 	assert.False(t, dest.writeCalls[0].StagingTable)
 	assert.Empty(t, dest.mergeCalls)
+}
+
+func TestIdempotentCommitTokenDestinationSuppressesReplay(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &idempotentCommitTokenDestination{fakeDestination: base}
+	opts := destination.WriteOptions{Table: "events", CommitToken: "wal:0/10"}
+	records := func() <-chan source.RecordBatchResult {
+		return mustClosedRecords(source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)})
+	}
+
+	require.NoError(t, dest.WriteParallel(t.Context(), records(), opts))
+	require.NoError(t, dest.WriteParallel(t.Context(), records(), opts))
+	require.Len(t, base.writeCalls, 1)
+}
+
+func TestManagedCDCDataWriteTokenIsStableAndTableScoped(t *testing.T) {
+	token := func(table, batchID string) source.DurableID {
+		return managedCDCDataWriteID(table, source.DurableID(batchID))
+	}
+	require.Equal(t, token("public.events", "tx-1"), token("public.events", "tx-1"))
+	require.NotEqual(t, token("public.events", "tx-1"), token("public.audit", "tx-1"))
+	require.NotEqual(t, token("public.events", "tx-1"), token("public.events", "tx-2"))
+}
+
+func TestStreamingManagedKeylessMergeRequestsStableDataBatches(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "stream-keyless-contract", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	job, src, _ := minimalJob()
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Config.PrimaryKeys = nil
+	job.Config.NoLoadTimestamp = true
+	job.Schema = keylessCDCSchema()
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: manager, FlushInterval: time.Hour,
+	}).Execute(ctx, job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+}
+
+func TestStreamingMultiTableManagedKeylessMergeRequestsStableDataBatches(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "stream-multi-keyless-contract", "raw.events", "")
+	require.NoError(t, err)
+	keyedSchema := keylessCDCSchema()
+	keyedSchema.PrimaryKeys = []string{"id"}
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: keyedSchema, PrimaryKeys: []string{"id"}, Incarnation: "users-v1"},
+		{Name: "public.events", Schema: keylessCDCSchema(), Incarnation: "events-v1"},
+	}
+	for _, table := range tables {
+		require.NoError(t, manager.RegisterTableIncarnation(ctx, table.Name, "raw."+table.Name[len("public."):], table.Incarnation))
+	}
+	require.NoError(t, manager.BeginRun(ctx, false))
+	src := &announcingMultiTableSource{tables: tables, records: mustClosedRecords()}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: src, Destination: dest, Tables: tables,
+		TableDestNames:  map[string]string{"public.users": "raw.users", "public.events": "raw.events"},
+		CDCStateManager: manager,
+	}
+
+	require.NoError(t, NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: manager, FlushInterval: time.Hour,
+	}).ExecuteMultiTable(ctx, job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+}
+
+func TestStreamingManagedFullRefreshRequestsStableDataBatchesForLateKeylessTable(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "stream-late-keyless-contract", "raw.users", "")
+	require.NoError(t, err)
+	keyedSchema := keylessCDCSchema()
+	keyedSchema.PrimaryKeys = []string{"id"}
+	table := source.SourceTableInfo{
+		Name: "public.users", Schema: keyedSchema, PrimaryKeys: []string{"id"}, Incarnation: "users-v1",
+	}
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, table.Name, "raw.users", table.Incarnation))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: mustClosedRecords()}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{
+			IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true, FullRefresh: true,
+		},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "raw.users"}, CDCStateManager: manager,
+	}
+
+	require.NoError(t, NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: manager, FlushInterval: time.Hour,
+	}).ExecuteMultiTable(ctx, job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+}
+
+func TestStreamingManagedKeylessCDCReplayUsesDataTokenWithoutResumeAuthority(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	require.Equal(t, "incarnation:raw.events", manager.BoundDestinationIncarnation("public.events"))
+
+	newLoop := func(flushRecords int64) *flushLoop {
+		st := &streamTableState{
+			destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+			incarnation: "100", schemaFingerprint: "schema-v1",
+		}
+		cfg := config.DefaultConfig()
+		cfg.NoLoadTimestamp = true
+		return newFlushLoop(dest, cfg, StreamingOptions{
+			FlushInterval: time.Hour,
+			FlushRecords:  flushRecords,
+			Strategy:      config.StrategyMerge,
+			StateManager:  manager,
+		}, map[string]*streamTableState{"public.events": st})
+	}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position:    position,
+				DataBatchID: "public.events:1:0/110/2:0/110/2",
+			},
+		}
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position:    position,
+				DataBatchID: "public.events:1:0/120/2:0/120/2",
+			},
+		}
+		close(records)
+		return records
+	}
+
+	err = newLoop(100).run(ctx, newRecords("0/100"))
+	require.ErrorContains(t, err, "injected state persistence failure")
+	require.NoError(t, newLoop(1).run(ctx, newRecords("0/105")))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	first, second := dest.dataWrites[0], dest.dataWrites[1]
+	replayFirst, replaySecond := dest.dataWrites[2], dest.dataWrites[3]
+	dest.dataMu.Unlock()
+	firstToken := first.CommitToken
+	secondToken := second.CommitToken
+	require.Equal(t, managedCDCDataWriteID("public.events", "public.events:1:0/110/2:0/110/2"), firstToken)
+	require.Equal(t, managedCDCDataWriteID("public.events", "public.events:1:0/120/2:0/120/2"), secondToken)
+	require.NotEqual(t, firstToken, secondToken, "duplicate-content batches at the same globally safe position must not collide")
+	require.Equal(t, first.CommitToken, replayFirst.CommitToken, "global safe position changes must not perturb a source batch's data-write identity")
+	require.Equal(t, second.CommitToken, replaySecond.CommitToken, "global safe position changes must not perturb a source batch's data-write identity")
+	require.Equal(t, "incarnation:raw.events", first.CDCExpectedIncarnation)
+	require.Equal(t, first.CDCExpectedIncarnation, second.CDCExpectedIncarnation)
+	require.Equal(t, first.CDCExpectedIncarnation, replayFirst.CDCExpectedIncarnation)
+	require.Equal(t, first.CDCExpectedIncarnation, replaySecond.CDCExpectedIncarnation)
+	require.True(t, first.SkipCDCResume)
+	require.True(t, second.SkipCDCResume)
+	require.True(t, replayFirst.SkipCDCResume)
+	require.True(t, replaySecond.SkipCDCResume)
+	require.Empty(t, first.CDCResumeLSN)
+	require.Empty(t, second.CDCResumeLSN)
+	require.Empty(t, replayFirst.CDCResumeLSN)
+	require.Empty(t, replaySecond.CDCResumeLSN)
+}
+
+func TestStreamingStandaloneKeylessCDCWithoutDurableIdentityUsesLegacyBatchWrite(t *testing.T) {
+	dest := &fakeDestination{}
+	st := &streamTableState{
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+	}
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events",
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+
+	require.NoError(t, loop.run(t.Context(), records))
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 1)
+	require.Empty(t, dest.writeCalls[0].CommitToken)
+	dest.mu.Unlock()
+}
+
+func TestStreamingManagedKeyedAppendReplayUsesDataTokenWithoutResumeAuthority(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	manager, err := NewCDCStateManager(dest, "managed-keyed-append-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+
+	tableSchema := keylessCDCSchema()
+	tableSchema.PrimaryKeys = []string{"id"}
+	newLoop := func() *flushLoop {
+		st := &streamTableState{
+			destTable: "raw.events", schema: tableSchema, primaryKeys: []string{"id"}, isCDC: true,
+			incarnation: "100", schemaFingerprint: "schema-v1",
+		}
+		cfg := config.DefaultConfig()
+		cfg.NoLoadTimestamp = true
+		return newFlushLoop(dest, cfg, StreamingOptions{
+			FlushInterval: time.Hour,
+			FlushRecords:  100,
+			Strategy:      config.StrategyAppend,
+			StateManager:  manager,
+		}, map[string]*streamTableState{"public.events": st})
+	}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				TableName: "public.events",
+				Batch:     int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: source.DurableID(batchID),
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+
+	require.ErrorContains(t, newLoop().run(ctx, newRecords("0/100")), "injected state persistence failure")
+	require.NoError(t, newLoop().run(ctx, newRecords("0/105")))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	for _, writeOpts := range dest.dataWrites {
+		require.True(t, writeOpts.SkipCDCResume)
+		require.Empty(t, writeOpts.CDCResumeLSN)
+		require.Equal(t, "incarnation:raw.events", writeOpts.CDCExpectedIncarnation)
+	}
+	dest.dataMu.Unlock()
+}
+
+func TestBatchAppendManagedCDCReplayUsesStableDataToken(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "batch-append-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyAppend
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Config.CDCResumeLSN = "0/10"
+	job.Schema = keylessCDCSchema()
+	job.Schema.PrimaryKeys = []string{"id"}
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: source.DurableID(batchID),
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+
+	src.readCh = newRecords("0/20")
+	require.NoError(t, (&AppendStrategy{}).Execute(ctx, job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	require.ErrorContains(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/20"}), "injected state persistence failure")
+	src.readCh = newRecords("0/25")
+	require.NoError(t, (&AppendStrategy{}).Execute(ctx, job))
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/25"}))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	dest.dataMu.Unlock()
+}
+
+func TestManagedCDCAppendRejectsNonIdempotentDestinationBeforeMutation(t *testing.T) {
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "non-idempotent-append", "raw.events", "")
+	require.NoError(t, err)
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyAppend
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Schema = keylessCDCSchema()
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+
+	err = (&AppendStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "managed CDC append requires destination support for idempotent commit-token writes")
+	require.Empty(t, dest.prepareCalls)
+	require.Empty(t, dest.writeCalls)
+	require.False(t, src.readCalled)
+}
+
+func TestMultiTableManagedCDCAppendRejectsNonIdempotentDestinationBeforeMutation(t *testing.T) {
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "non-idempotent-multi-append", "raw.events", "")
+	require.NoError(t, err)
+	table := source.SourceTableInfo{Name: "public.events", Schema: keylessCDCSchema()}
+	job := &MultiTableIngestionJob{
+		Config:          &config.IngestConfig{IncrementalStrategy: config.StrategyAppend},
+		Source:          &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		Destination:     dest,
+		Tables:          []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{table.Name: "raw.events"},
+		CDCStateManager: manager,
+	}
+
+	err = (&AppendStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "managed multi-table CDC append requires destination support for idempotent commit-token writes")
+	require.Empty(t, dest.prepareCalls)
+	require.Empty(t, dest.writeCalls)
+}
+
+func TestMultiTableManagedKeylessCDCMergeRejectsNonIdempotentDestinationBeforeMutation(t *testing.T) {
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "non-idempotent-keyless-merge", "raw.events", "")
+	require.NoError(t, err)
+	table := source.SourceTableInfo{Name: "public.events", Schema: keylessCDCSchema()}
+	job := &MultiTableIngestionJob{
+		Config:          &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source:          &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		Destination:     dest,
+		Tables:          []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{table.Name: "raw.events"},
+		CDCStateManager: manager,
+	}
+
+	err = (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "managed keyless CDC merge requires destination support for idempotent commit-token writes")
+	require.Empty(t, dest.prepareCalls)
+	require.Empty(t, dest.writeCalls)
+}
+
+func TestManagedStreamingAppendRejectsNonIdempotentDestinationBeforeMutation(t *testing.T) {
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "non-idempotent-streaming-append", "raw.events", "")
+	require.NoError(t, err)
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyAppend, StateManager: manager})
+	st := &streamTableState{destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true}
+
+	err = executor.prepareTable(t.Context(), dest, &config.IngestConfig{}, st)
+	require.ErrorContains(t, err, "managed streaming CDC append requires destination support for idempotent commit-token writes")
+	require.Empty(t, dest.prepareCalls)
+	require.Empty(t, dest.writeCalls)
+}
+
+func TestDurableKeylessCDCWriteRejectsNonIdempotentDestinationBeforeConsuming(t *testing.T) {
+	dest := &fakeDestination{}
+	records := mustClosedRecords(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), DurableCommitID: "wal:0/20",
+	})
+
+	err := writeDurableKeylessCDCRecords(t.Context(), dest, records, destination.WriteOptions{Table: "raw.events"})
+	require.ErrorContains(t, err, "durable keyless CDC writes requires destination support for idempotent commit-token writes")
+	require.Empty(t, dest.writeCalls)
+	drainAndRelease(records)
+}
+
+func TestMultiTableBatchAppendManagedCDCReplayUsesStableDataToken(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "multi-batch-append-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	table.Schema.PrimaryKeys = []string{"id"}
+	table.PrimaryKeys = []string{"id"}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: source.DurableID(batchID),
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+	newJob := func(position string) *MultiTableIngestionJob {
+		return &MultiTableIngestionJob{
+			Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+			Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: newRecords(position)},
+			Destination: dest, Tables: []source.SourceTableInfo{table},
+			TableDestNames:  map[string]string{table.Name: "raw.events"},
+			CDCResumeLSNs:   map[string]string{table.Name: "0/10"},
+			CDCStateManager: manager,
+		}
+	}
+
+	firstJob := newJob("0/20")
+	require.NoError(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, firstJob))
+	require.True(t, firstJob.Source.(*announcingMultiTableSource).readOpts.CDCStableDataBatches)
+	require.ErrorContains(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/20"}), "injected state persistence failure")
+	require.NoError(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, newJob("0/25")))
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/25"}))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	dest.dataMu.Unlock()
+}
+
+func TestMultiTableBatchMergeManagedKeylessCDCReplayUsesStableDataToken(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "multi-batch-merge-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: source.DurableID(batchID),
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+	newJob := func(position string) *MultiTableIngestionJob {
+		return &MultiTableIngestionJob{
+			Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+			Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: newRecords(position)},
+			Destination: dest, Tables: []source.SourceTableInfo{table},
+			TableDestNames:  map[string]string{table.Name: "raw.events"},
+			CDCResumeLSNs:   map[string]string{table.Name: "0/10"},
+			CDCStateManager: manager,
+		}
+	}
+
+	firstJob := newJob("0/20")
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, firstJob))
+	require.True(t, firstJob.Source.(*announcingMultiTableSource).readOpts.CDCStableDataBatches)
+	require.ErrorContains(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/20"}), "injected state persistence failure")
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, newJob("0/25")))
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/25"}))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	require.False(t, dest.dataWrites[0].StagingTable)
+	dest.dataMu.Unlock()
+}
+
+func TestAtomicMultiTableBatchMergeManagedKeylessCDCRequestsStableDataBatches(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	base.incarnations["raw.events"] = "target-v1"
+	dest := &managedAtomicKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "atomic-keyless-merge-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	newJob := func() *MultiTableIngestionJob {
+		records := make(chan source.RecordBatchResult, 1)
+		records <- source.RecordBatchResult{
+			TableName: table.Name,
+			Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position: "0/20", DataBatchID: "public.events:tx-1",
+			},
+		}
+		close(records)
+		return &MultiTableIngestionJob{
+			Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+			Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+			Destination: dest, Tables: []source.SourceTableInfo{table},
+			TableDestNames:  map[string]string{table.Name: "raw.events"},
+			CDCResumeLSNs:   map[string]string{table.Name: "0/10"},
+			CDCStateManager: manager,
+		}
+	}
+
+	firstJob := newJob()
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, firstJob))
+	require.True(t, firstJob.Source.(*announcingMultiTableSource).readOpts.CDCStableDataBatches)
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, newJob()))
+
+	base.dataMu.Lock()
+	require.Len(t, base.dataWrites, 2)
+	require.EqualValues(t, 1, base.visibleRows)
+	require.Equal(t, base.dataWrites[0].CommitToken, base.dataWrites[1].CommitToken)
+	base.dataMu.Unlock()
+}
+
+func TestManagedAtomicAppendRejectsPublisherWithoutAbortBeforeMutation(t *testing.T) {
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &managedAtomicKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "non-abortable-atomic-append", "raw.events", "")
+	require.NoError(t, err)
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyAppend
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Schema = keylessCDCSchema()
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+
+	err = (&AppendStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "cannot safely recover an open managed atomic snapshot attempt")
+	require.False(t, src.readCalled)
+	require.Empty(t, base.prepareCalls)
+	require.Empty(t, base.dataWrites)
+}
+
+func TestBatchAppendManagedCDCRejectsNonAtomicSnapshotBeforeTruncate(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	opts := destination.WriteOptions{
+		Table: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "target-v1",
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+
+	truncated, err := writeDurableCDCAppendRecords(ctx, dest, records, opts, "public.events", nil)
+	require.False(t, truncated)
+	require.ErrorContains(t, err, "require atomic snapshot publication")
+	drainAndRelease(records)
+
+	dest.dataMu.Lock()
+	require.Empty(t, dest.dataWrites)
+	require.Zero(t, dest.visibleRows)
+	dest.dataMu.Unlock()
+}
+
+func TestAppendStrategyManagedCDCRejectsNonAtomicSnapshot(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-append", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyAppend
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Schema = keylessCDCSchema()
+	job.Schema.PrimaryKeys = []string{"id"}
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	src.readCh = records
+
+	require.ErrorContains(t, (&AppendStrategy{}).Execute(ctx, job), "require atomic snapshot publication")
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	dest.dataMu.Lock()
+	require.Empty(t, dest.dataWrites)
+	dest.dataMu.Unlock()
+}
+
+func TestMultiTableAppendStrategyManagedCDCRejectsNonAtomicSnapshot(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-multi-append", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), PrimaryKeys: []string{"id"},
+		Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	table.Schema.PrimaryKeys = []string{"id"}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "raw.events"}, CDCStateManager: manager,
+	}
+
+	require.ErrorContains(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, job), "require atomic snapshot publication")
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	dest.dataMu.Lock()
+	require.Empty(t, dest.dataWrites)
+	dest.dataMu.Unlock()
+}
+
+func TestBatchAppendManagedCDCWALTruncateStillRequiresTypedSourcePosition(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "wal-truncate-missing-id", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true, CDCWALTruncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+
+	truncated, err := writeDurableCDCAppendRecords(ctx, dest, records, destination.WriteOptions{
+		Table: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "target-v1",
+	}, "public.events", manager)
+	require.True(t, truncated)
+	require.ErrorContains(t, err, "has no typed source position")
+}
+
+func TestBatchAppendManagedCDCWALTruncateReplayReappliesPostTruncateRows(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination(), visibleRows: 7}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "wal-truncate-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+
+	newRecords := func() <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		records <- source.RecordBatchResult{
+			TableName: "public.events", Truncate: true, CDCWALTruncate: true,
+		}
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position: "0/20", DataBatchID: "public.events:0/20",
+			},
+		}
+		close(records)
+		return records
+	}
+	opts := destination.WriteOptions{
+		Table: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "target-v1",
+	}
+
+	truncated, err := writeDurableCDCAppendRecords(ctx, dest, newRecords(), opts, "public.events", manager)
+	require.NoError(t, err)
+	require.True(t, truncated)
+	truncated, err = writeDurableCDCAppendRecords(ctx, dest, newRecords(), opts, "public.events", manager)
+	require.NoError(t, err)
+	require.True(t, truncated)
+
+	dest.dataMu.Lock()
+	require.Equal(t, 2, dest.truncates)
+	require.EqualValues(t, 1, dest.visibleRows)
+	require.Len(t, dest.dataWrites, 2)
+	require.Empty(t, dest.dataWrites[0].CommitToken)
+	require.Empty(t, dest.dataWrites[1].CommitToken)
+	dest.dataMu.Unlock()
+}
+
+func TestBatchAppendManagedCDCWALTruncateCompletesNewSnapshotBoundary(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+
+	first, err := NewCDCStateManager(dest, "wal-truncate-completion", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableIncarnation(ctx, "public.events", "raw.events", "source-v1"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:             "0/10",
+		SnapshotPositions:    map[string]string{"public.events": "0/10"},
+		SnapshotIncarnations: map[string]string{"public.events": "source-v1"},
+	}))
+
+	manager, err := NewCDCStateManager(dest, "wal-truncate-completion", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "source-v1"))
+	position, err := manager.ResumePosition(ctx, "public.events")
+	require.NoError(t, err)
+	require.Equal(t, "0/10", position)
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Truncate: true, CDCWALTruncate: true,
+	}
+	records <- source.RecordBatchResult{
+		TableName: "public.events",
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: source.CDCStateCommitToken{
+			Position: "0/20", DataBatchID: "public.events:0/20",
+		},
+	}
+	close(records)
+	truncated, err := writeDurableCDCAppendRecords(ctx, dest, records, destination.WriteOptions{
+		Table: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "target-v1",
+	}, "public.events", manager)
+	require.NoError(t, err)
+	require.True(t, truncated)
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/20"}))
+
+	restarted, err := NewCDCStateManager(dest, "wal-truncate-completion", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableIncarnation(ctx, "public.events", "raw.events", "source-v1"))
+	position, err = restarted.ResumePosition(ctx, "public.events")
+	require.NoError(t, err)
+	require.Equal(t, "0/20", position)
+}
+
+func TestStreamingManagedKeylessCDCRejectsEmptyDestinationIncarnation(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &emptyIncarnationManagedKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-empty-incarnation", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	st := &streamTableState{
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+		incarnation: "100", schemaFingerprint: "schema-v1",
+	}
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, StateManager: manager,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events",
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: source.CDCStateCommitToken{
+			Position: "0/100", DataBatchID: "public.events:1:0/110/2:0/110/2",
+		},
+	}
+	close(records)
+
+	require.ErrorContains(t, loop.run(ctx, records), "has no previously verified physical incarnation")
+	base.dataMu.Lock()
+	require.Empty(t, base.dataWrites)
+	base.dataMu.Unlock()
+}
+
+func TestStreamingManagedKeylessCDCRejectsTargetRecreatedBetweenBoundaries(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &replacingManagedKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-recreated", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	st := &streamTableState{
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+		incarnation: "100", schemaFingerprint: "schema-v1",
+	}
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, StateManager: manager,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 2)
+	for i, batchID := range []string{"public.events:1:0/110/2:0/110/2", "public.events:1:0/120/2:0/120/2"} {
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position: "0/100", DataBatchID: source.DurableID(batchID),
+			},
+		}
+	}
+	close(records)
+
+	require.ErrorContains(t, loop.run(ctx, records), "destination was replaced before managed keyless write")
+	base.dataMu.Lock()
+	require.Len(t, base.dataWrites, 1)
+	require.Equal(t, "incarnation:raw.events", base.dataWrites[0].CDCExpectedIncarnation)
+	require.EqualValues(t, 1, base.visibleRows)
+	base.dataMu.Unlock()
+}
+
+func TestStreamingManagedKeylessCDCRejectsTargetRecreatedBetweenFlushes(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-between-flushes", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	newLoop := func() *flushLoop {
+		cfg := config.DefaultConfig()
+		cfg.NoLoadTimestamp = true
+		return newFlushLoop(dest, cfg, StreamingOptions{
+			FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge, StateManager: manager,
+		}, map[string]*streamTableState{"public.events": {
+			destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+			incarnation: "100", schemaFingerprint: "schema-v1",
+		}})
+	}
+	records := func(batchID string, value int64) <-chan source.RecordBatchResult {
+		ch := make(chan source.RecordBatchResult, 1)
+		ch <- source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{value}, nil),
+			CommitToken: source.CDCStateCommitToken{Position: "0/100", DataBatchID: source.DurableID(batchID)},
+		}
+		close(ch)
+		return ch
+	}
+	require.NoError(t, newLoop().run(ctx, records("public.events:0/110", 1)))
+	dest.stateMu.Lock()
+	dest.incarnations["raw.events"] = "replacement-incarnation"
+	dest.stateMu.Unlock()
+
+	require.ErrorContains(t, newLoop().run(ctx, records("public.events:0/120", 2)), "was replaced after its prior snapshot boundary")
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 1)
+	require.EqualValues(t, 1, dest.visibleRows)
+	dest.dataMu.Unlock()
+}
+
+func TestStreamingManagedKeylessCDCInvalidationRaceReleasesAllMovedBatchesOnce(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &recreateDuringInvalidationManagedKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-invalidation-race", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	dest.recreateMu.Lock()
+	dest.armed = true
+	dest.recreateMu.Unlock()
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, StateManager: manager,
+	}, map[string]*streamTableState{"public.events": {
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+		incarnation: "100", schemaFingerprint: "schema-v1",
+	}})
+	batch := &singleReleaseCountingRecordBatch{RecordBatch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: batch,
+		CommitToken: source.CDCStateCommitToken{Position: "0/100", DataBatchID: "public.events:0/110"},
+	}
+	close(records)
+
+	require.ErrorContains(t, loop.run(ctx, records), "changed while invalidating its prior snapshot boundary")
+	require.EqualValues(t, 1, batch.releases.Load())
+	base.dataMu.Lock()
+	require.Empty(t, base.dataWrites)
+	base.dataMu.Unlock()
+}
+
+func TestBatchManagedCDCStagingSkipsDestinationResumeAuthority(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "managed-staging", "raw.events", "")
+	require.NoError(t, err)
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.CDCResumeLSN = "0/100"
+	job.CDCStateManager = manager
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	})
+
+	require.NoError(t, (&MergeStrategy{}).Execute(ctx, job))
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 1)
+	require.True(t, dest.dataWrites[0].SkipCDCResume)
+	dest.dataMu.Unlock()
+	dest.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.True(t, dest.mergeCalls[0].SkipCDCResume)
+	dest.mu.Unlock()
+}
+
+func TestStreaming_PrepareTableRejectsUnsafeKeylessCDCDestination(t *testing.T) {
+	dest := &fakeDestination{}
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+	st := &streamTableState{
+		destTable: "events",
+		schema:    keylessCDCSchema(),
+		isCDC:     true,
+	}
+
+	err := exec.prepareTable(context.Background(), dest, &config.IngestConfig{}, st)
+	require.ErrorContains(t, err, "requires destination support for idempotent commit-token writes")
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Empty(t, dest.prepareCalls, "unsafe destination must fail before creating a table")
+}
+
+func TestStreamingSchemaRefreshRejectsPrimaryKeyModeChangeWithoutSnapshot(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &idempotentCommitTokenDestination{fakeDestination: base}
+	st := &streamTableState{
+		destTable: "events", stagingTable: "events_staging", schema: keylessCDCSchema(),
+		primaryKeys: []string{"id"}, isCDC: true,
+	}
+	st.schema.PrimaryKeys = []string{"id"}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	refreshed := *st.schema
+	refreshed.PrimaryKeys = nil
+
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &refreshed, PrimaryKeys: nil,
+	}, st)
+	require.ErrorContains(t, err, "requires a new snapshot")
+	require.Equal(t, []string{"id"}, st.primaryKeys)
+	require.Equal(t, "events_staging", st.stagingTable)
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	require.Empty(t, base.dropCalls)
+	require.Empty(t, base.prepareCalls)
 }

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -2,30 +2,38 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/databuffer"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 )
 
 type MergeStrategy struct{}
 
+var canceledSourceDrainTimeout = time.Second
+
 // mergeTableParams describes one dest/staging table pair for a merge.
 type mergeTableParams struct {
-	DestTable    string
-	StagingTable string
-	Schema       *schema.TableSchema
-	PrimaryKeys  []string
-	PartitionBy  string
-	ClusterBy    []string
-	IsCDC        bool
+	DestTable      string
+	StagingTable   string
+	Schema         *schema.TableSchema
+	PrimaryKeys    []string
+	PartitionBy    string
+	ClusterBy      []string
+	IsCDC          bool
+	OwnershipToken string
 }
 
 // prepareMergeTables ensures the destination table exists (without dropping it)
@@ -34,23 +42,13 @@ func prepareMergeTables(ctx context.Context, dest destination.Destination, p mer
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       p.DestTable,
-		Schema:      destination.DestinationTableSchema(p.Schema),
-		DropFirst:   false,
-		PrimaryKeys: p.PrimaryKeys,
-		PartitionBy: p.PartitionBy,
-		ClusterBy:   p.ClusterBy,
-	}); err != nil {
-		return fmt.Errorf("failed to prepare destination table %s: %w", p.DestTable, err)
+	if err := prepareMergeTarget(ctx, dest, p); err != nil {
+		return err
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	if err := source.ConnectorLeaseLoss(ctx); err != nil {
-		return err
-	}
 	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
 		Table:        p.StagingTable,
 		Schema:       p.Schema,
@@ -70,18 +68,34 @@ func prepareMergeTables(ctx context.Context, dest destination.Destination, p mer
 	return nil
 }
 
-// mergeStagingInto merges the staging table into the target table by primary
-// key. A non-empty incrementalKey makes the per-PK dedup keep the row with the
-// highest value of that key (latest wins) instead of an arbitrary one.
-func mergeStagingInto(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey, incrementalPredicate string) error {
+func prepareMergeTarget(ctx context.Context, dest destination.Destination, p mergeTableParams) error {
+	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:          p.DestTable,
+		Schema:         destination.DestinationTableSchema(p.Schema),
+		DropFirst:      false,
+		PrimaryKeys:    p.PrimaryKeys,
+		PartitionBy:    p.PartitionBy,
+		ClusterBy:      p.ClusterBy,
+		OwnershipToken: p.OwnershipToken,
+	}); err != nil {
+		return fmt.Errorf("failed to prepare destination table %s: %w", p.DestTable, err)
+	}
+	return nil
+}
+
+func mergeStagingIntoWithCommit(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey, incrementalPredicate string, commitToken source.DurableID, cdcResumeLSN string, skipCDCResume bool, expectedIncarnation string) error {
 	return dest.MergeTable(ctx, destination.MergeOptions{
-		StagingTable:         stagingTable,
-		TargetTable:          targetTable,
-		PrimaryKeys:          primaryKeys,
-		Columns:              destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
-		IncrementalKey:       mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
-		IncrementalPredicate: incrementalPredicate,
-		Schema:               tableSchema,
+		StagingTable:           stagingTable,
+		TargetTable:            targetTable,
+		PrimaryKeys:            primaryKeys,
+		Columns:                destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
+		IncrementalKey:         mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
+		IncrementalPredicate:   incrementalPredicate,
+		Schema:                 tableSchema,
+		CommitToken:            commitToken,
+		CDCResumeLSN:           cdcResumeLSN,
+		SkipCDCResume:          skipCDCResume,
+		CDCExpectedIncarnation: expectedIncarnation,
 	})
 }
 
@@ -118,11 +132,16 @@ func isAppendOnlyCDCTable(ti source.SourceTableInfo) bool {
 // change batches carry it, and CDCMode relaxes NOT NULL since rows are change
 // events rather than complete entities.
 func prepareAppendOnlyCDCTable(ctx context.Context, dest destination.Destination, table string, tableSchema *schema.TableSchema) error {
+	return prepareAppendOnlyCDCTableOwned(ctx, dest, table, tableSchema, "")
+}
+
+func prepareAppendOnlyCDCTableOwned(ctx context.Context, dest destination.Destination, table string, tableSchema *schema.TableSchema, ownershipToken string) error {
 	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
-		Table:     table,
-		Schema:    tableSchema,
-		DropFirst: false,
-		CDCMode:   true,
+		Table:          table,
+		Schema:         tableSchema,
+		DropFirst:      false,
+		CDCMode:        true,
+		OwnershipToken: ownershipToken,
 	}); err != nil {
 		return fmt.Errorf("failed to prepare append-only change-log table %s: %w", table, err)
 	}
@@ -138,6 +157,9 @@ func warnIfCDCMergeUnsupported(dest destination.Destination) {
 }
 
 func supportsCDCSnapshotReplace(dest destination.Destination) bool {
+	if _, ok := dest.(destination.AtomicSnapshotPublisher); ok {
+		return true
+	}
 	_, ok := dest.(destination.TruncateCapable)
 	return ok
 }
@@ -164,13 +186,17 @@ func (s *MergeStrategy) RequiresIncrementalKey() bool {
 func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	// Generate staging table name
 	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "merge", job.Config.StagingDataset)
-	output.Statusf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	isCDC := hasCDCColumns(job.Schema)
 	if isCDC {
 		warnIfCDCMergeUnsupported(job.Destination)
 	}
+	if isCDC && !job.Config.Stream && (job.Config.FullRefresh || strings.TrimSpace(job.Config.CDCResumeLSN) == "") {
+		if publisher, ok := job.Destination.(destination.AtomicSnapshotPublisher); ok && supportsCDCSnapshotReplace(job.Destination) {
+			return s.executeAtomicBatchSnapshot(ctx, job, publisher)
+		}
+	}
 
-	if err := prepareMergeTables(ctx, job.Destination, mergeTableParams{
+	params := mergeTableParams{
 		DestTable:    job.Config.DestTable,
 		StagingTable: stagingTable,
 		Schema:       job.Schema,
@@ -178,12 +204,41 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		PartitionBy:  job.Config.PartitionBy,
 		ClusterBy:    job.Config.ClusterBy,
 		IsCDC:        isCDC,
-	}); err != nil {
-		return err
 	}
+	direct, directMerge := job.Destination.(destination.DirectMergeWriter)
+	directMerge = directMerge && !isCDC
+	if !directMerge && !job.Config.KeepStaging {
+		defer dropMergeStagingDetached(ctx, job.Destination, stagingTable)
+	}
+	var prepareErr error
+	if directMerge {
+		prepareErr = prepareMergeTarget(ctx, job.Destination, params)
+	} else {
+		output.Statusf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+		prepareErr = prepareMergeTables(ctx, job.Destination, params)
+	}
+	if prepareErr != nil {
+		return prepareErr
+	}
+	if directMerge && job.CDCStateManager == nil {
+		if err := job.ApplyEvolution(ctx); err != nil {
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
+	}
+	expectedIncarnation := ""
 	if job.CDCStateManager != nil {
 		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
 			return fmt.Errorf("failed to bind CDC destination before merge: %w", err)
+		}
+		var err error
+		expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable)
+		if err != nil {
+			return err
+		}
+		if directMerge {
+			if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
+				return fmt.Errorf("failed to apply schema evolution: %w", err)
+			}
 		}
 	}
 
@@ -215,7 +270,9 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
 		return fmt.Errorf("failed to get records: %w", err)
 	}
@@ -224,10 +281,34 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	if directMerge {
+		if err := direct.MergeRecords(readCtx, records, destination.WriteOptions{
+			Table:                  job.Config.DestTable,
+			Schema:                 job.Schema,
+			Parallelism:            job.Config.EffectiveDestinationParallelism(),
+			StagingBucket:          job.Config.StagingBucket,
+			LoaderFileSize:         job.Config.LoaderFileSize,
+			LoaderFileFormat:       job.Config.LoaderFileFormat,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}, destination.MergeOptions{
+			TargetTable:            job.Config.DestTable,
+			PrimaryKeys:            job.Config.PrimaryKeys,
+			Columns:                destination.MergeColumnsFor(job.Destination, job.Schema.ColumnNames()),
+			IncrementalKey:         mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+			IncrementalPredicate:   job.Config.IncrementalPredicate,
+			Schema:                 job.Schema,
+			Parallelism:            job.Config.EffectiveDestinationParallelism(),
+			SkipCDCResume:          job.CDCStateManager != nil,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}); err != nil {
+			cancelRead()
+			<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+			return fmt.Errorf("failed to merge records directly: %w", err)
+		}
+		return nil
+	}
 
-	// Write to staging table using parallel writes. Source TRUNCATE controls
-	// split the input into ordered segments and clear earlier staged changes.
-	sourceTruncated, err := destination.WriteWithTruncateBoundaries(ctx, job.Destination, records, destination.WriteOptions{
+	writeOpts := destination.WriteOptions{
 		Table:            stagingTable,
 		Schema:           job.Schema,
 		Parallelism:      job.Config.EffectiveDestinationParallelism(),
@@ -236,18 +317,26 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
-	})
+		SkipCDCResume:    job.CDCStateManager != nil,
+	}
+	var sourceTruncated bool
+	if isCDC {
+		// Source TRUNCATE controls split CDC into ordered segments and clear
+		// earlier staged changes.
+		sourceTruncated, err = destination.WriteWithTruncateBoundariesAfterCancel(readCtx, job.Destination, records, writeOpts, cancelRead)
+	} else {
+		err = job.Destination.WriteParallel(readCtx, records, writeOpts)
+	}
 	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	if err := source.ConnectorLeaseLoss(ctx); err != nil {
-		return err
-	}
-	if err := job.ApplyEvolution(ctx); err != nil {
+	if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -262,8 +351,19 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
 		}
-		if err := destination.ApplyCDCTruncate(ctx, job.Destination, job.Config.DestTable); err != nil {
-			return err
+		var truncateErr error
+		if job.CDCStateManager != nil {
+			truncateErr = destination.ApplyCDCTruncateIfIncarnation(
+				ctx,
+				job.Destination,
+				job.Config.DestTable,
+				job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable),
+			)
+		} else {
+			truncateErr = destination.ApplyCDCTruncate(ctx, job.Destination, job.Config.DestTable)
+		}
+		if truncateErr != nil {
+			return truncateErr
 		}
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
@@ -272,27 +372,223 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := mergeStagingInto(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, job.Config.IncrementalKey, job.Config.IncrementalPredicate); err != nil {
+	if err := mergeStagingIntoWithCommit(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, job.Config.IncrementalKey, job.Config.IncrementalPredicate,
+		"", "", job.CDCStateManager != nil, expectedIncarnation); err != nil {
 		return fmt.Errorf("failed to merge data: %w", err)
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	// Drop staging table (skip when KeepStaging is set for test inspection).
-	if !job.Config.KeepStaging {
-		if err := source.ConnectorLeaseLoss(ctx); err != nil {
-			return err
+	// The deferred cleanup uses a detached, lease-fenced context so cancellation
+	// cannot strand a managed staging table.
+	return nil
+}
+
+func (s *MergeStrategy) executeAtomicBatchSnapshot(
+	ctx context.Context,
+	job *IngestionJob,
+	publisher destination.AtomicSnapshotPublisher,
+) error {
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	if _, recovered, err := recoverManagedAtomicSnapshotBeforeRead(
+		ctx, job.Destination, publisher, job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable,
+	); err != nil {
+		return err
+	} else if recovered {
+		return nil
+	}
+	existingSchema, err := job.Destination.GetTableSchema(ctx, job.Config.DestTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before atomic batch snapshot: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+	cleanupNewTarget := !targetExisted && ownershipToken != ""
+	defer func() {
+		if cleanupNewTarget {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, job.Config.DestTable, true, ownershipToken)
 		}
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[MERGE] Warning: failed to drop staging table: %v", err)
+	}()
+	if err := prepareMergeTarget(ctx, job.Destination, mergeTableParams{
+		DestTable: job.Config.DestTable, Schema: job.Schema, PrimaryKeys: job.Config.PrimaryKeys,
+		PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy, IsCDC: hasCDCColumns(job.Schema),
+		OwnershipToken: ownershipToken,
+	}); err != nil {
+		return err
+	}
+	expectedIncarnation := ""
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
+			return fmt.Errorf("failed to bind CDC destination before atomic snapshot: %w", err)
 		}
-		if err := source.ConnectorLeaseLoss(ctx); err != nil {
-			return err
+		expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if expectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", job.Config.DestTable)
 		}
 	}
 
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, source.ReadOptions{
+		IncrementalKey: job.Config.IncrementalKey, IntervalStart: job.Config.IntervalStart, IntervalEnd: job.Config.IntervalEnd,
+		PageSize: job.Config.PageSize, Limit: job.Config.SQLLimit, ExcludeColumns: job.Config.SQLExcludeColumns,
+		Parallelism: parallelism, Schema: job.SourceSchema, CDCResumeLSN: job.Config.CDCResumeLSN,
+		CDCResumeIncarnation: job.Config.CDCResumeIncarnation, CDCResumeSchemaFingerprint: job.Config.CDCResumeSchemaFingerprint,
+		CDCSlotSuffix: job.Config.CDCSlotSuffix, CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
+		CDCSnapshotReplace: true, FullRefresh: job.Config.FullRefresh,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get atomic snapshot records: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+	if err := consumeAtomicSnapshotBoundary(readCtx, job, records); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return err
+	}
+	boundary := &atomicBatchSnapshotBoundary{}
+
+	attemptID, err := atomicSnapshotAttemptID(ctx, job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable)
+	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to establish durable atomic batch snapshot attempt: %w", err)
+	}
+	targetSchema := destination.DestinationTableSchema(job.Schema)
+	if job.EvolutionPlan != nil && job.EvolutionPlan.FinalSchema != nil {
+		targetSchema = job.EvolutionPlan.FinalSchema
+	}
+	opts := destination.AtomicSnapshotOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, TargetSchema: targetSchema,
+		PrimaryKeys: job.Config.PrimaryKeys, PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy,
+		Parallelism: job.Config.EffectiveDestinationParallelism(), AttemptID: attemptID, SkipCDCResume: job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}
+	if err := publisher.BeginAtomicSnapshot(ctx, opts); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		if aborter, ok := job.Destination.(destination.AtomicSnapshotAborter); ok {
+			abortBase, detachCancel := source.WithoutCancelWithConnectorLease(ctx)
+			defer detachCancel()
+			abortCtx, cancel := context.WithTimeout(abortBase, 30*time.Second)
+			defer cancel()
+			_ = aborter.AbortAtomicSnapshot(abortCtx, opts)
+		}
+		return fmt.Errorf("failed to begin atomic batch snapshot: %w", err)
+	}
+	records = observeAtomicBatchSnapshot(readCtx, records, boundary)
+	publishAttempted := false
+	sealAttempted := false
+	defer func() {
+		if publishAttempted || sealAttempted {
+			return
+		}
+		if aborter, ok := job.Destination.(destination.AtomicSnapshotAborter); ok {
+			abortBase, detachCancel := source.WithoutCancelWithConnectorLease(ctx)
+			defer detachCancel()
+			abortCtx, cancel := context.WithTimeout(abortBase, 30*time.Second)
+			defer cancel()
+			_ = aborter.AbortAtomicSnapshot(abortCtx, opts)
+		}
+	}()
+	if err := publisher.WriteAtomicSnapshot(readCtx, records, destination.WriteOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, PrimaryKeys: job.Config.PrimaryKeys,
+		Parallelism: job.Config.EffectiveDestinationParallelism(), AtomicSnapshotAttemptID: attemptID, SkipCDCResume: job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to stage atomic batch snapshot: %w", err)
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	opts.CommitToken = atomicSnapshotCommitID(opts.AttemptID)
+	opts.CDCResumeLSN = boundary.positionValue()
+	if job.CDCStateManager != nil {
+		sealAttempted = true
+		cleanupNewTarget = false
+		if err := job.CDCStateManager.SealAtomicSnapshotAttempt(
+			ctx, job.Config.SourceTable, job.Config.DestTable, attemptID, opts.CDCResumeLSN, expectedIncarnation,
+		); err != nil {
+			return fmt.Errorf("failed to seal durable atomic batch snapshot attempt: %w", err)
+		}
+	}
+	publishAttempted = true
+	cleanupNewTarget = false
+	publishedIncarnation, err := publisher.PublishAtomicSnapshot(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to publish atomic batch snapshot: %w", err)
+	}
+	if job.CDCStateManager != nil {
+		if publishedIncarnation == "" {
+			return fmt.Errorf("atomic batch publication returned no physical incarnation")
+		}
+		if err := job.CDCStateManager.BindPublishedDestinationIncarnation(
+			ctx, job.Config.SourceTable, job.Config.DestTable, expectedIncarnation, publishedIncarnation,
+		); err != nil {
+			return fmt.Errorf("failed to bind published CDC destination: %w", err)
+		}
+		if err := completeAtomicSnapshotAttempt(
+			ctx, job.CDCStateManager, job.Config.SourceTable, job.Config.DestTable, attemptID,
+		); err != nil {
+			return fmt.Errorf("failed to complete durable atomic batch snapshot attempt: %w", err)
+		}
+	}
 	return nil
+}
+
+func consumeAtomicSnapshotBoundary(ctx context.Context, job *IngestionJob, records <-chan source.RecordBatchResult) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case result, ok := <-records:
+			if !ok {
+				return fmt.Errorf("CDC snapshot ended before its replacement boundary")
+			}
+			if result.Err != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return result.Err
+			}
+			if result.SnapshotInvalidation != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				if job.CDCStateManager == nil {
+					return fmt.Errorf("source requested snapshot invalidation without destination-managed CDC state")
+				}
+				if err := job.CDCStateManager.InvalidateSnapshotState(
+					ctx, job.Config.SourceTable, job.Config.DestTable,
+					result.SnapshotInvalidation.Incarnation, result.SnapshotInvalidation.SchemaFingerprint,
+				); err != nil {
+					return err
+				}
+				continue
+			}
+			if result.Truncate && !result.CDCWALTruncate {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return nil
+			}
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return fmt.Errorf("CDC snapshot did not begin with a replacement boundary")
+		}
+	}
 }
 
 // ExecuteMultiTable implements multi-table merge strategy for CDC sources.
@@ -304,18 +600,36 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	config.Debug("[STRATEGY] Multi-table merge with %d tables", len(job.Tables))
 
 	anyTableHasCDC := false
+	managedAppendOnlyTables := make(map[string]struct{})
 	for _, tableInfo := range job.Tables {
 		if hasCDCColumns(tableInfo.Schema) {
 			anyTableHasCDC = true
-			break
+		}
+		if job.CDCStateManager != nil && isAppendOnlyCDCTable(tableInfo) {
+			managedAppendOnlyTables[tableInfo.Name] = struct{}{}
 		}
 	}
 	if anyTableHasCDC {
 		warnIfCDCMergeUnsupported(job.Destination)
 	}
+	if anyTableHasCDC && !job.Config.Stream {
+		publisher, canPublish := job.Destination.(destination.AtomicSnapshotPublisher)
+		direct, canMergeDirectly := job.Destination.(destination.DirectMergeWriter)
+		if canPublish && canMergeDirectly {
+			return s.executeAtomicMultiTableBatch(ctx, job, publisher, direct)
+		}
+	}
+	if len(managedAppendOnlyTables) > 0 {
+		if err := requireIdempotentCommitTokenWrites(job.Destination, "managed keyless CDC merge"); err != nil {
+			return err
+		}
+	}
 
 	stagingTables := make(map[string]string)
 	tableConfigs := make(map[string]destination.TableWriteConfig)
+	targetIncarnations := make(map[string]string)
+	direct, directMerge := job.Destination.(destination.DirectMergeWriter)
+	directMerge = directMerge && !anyTableHasCDC
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
@@ -327,14 +641,17 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			defer wg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
 
 			if err := source.ConnectorLeaseLoss(ctx); err != nil {
 				errChan <- err
 				return
 			}
-			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
-				errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
-				return
+			if job.CDCStateManager == nil {
+				if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+					errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+					return
+				}
 			}
 			if err := source.ConnectorLeaseLoss(ctx); err != nil {
 				errChan <- err
@@ -346,7 +663,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					errChan <- err
 					return
 				}
-				if err := prepareAppendOnlyCDCTable(ctx, job.Destination, destTable, ti.Schema); err != nil {
+				if err := prepareAppendOnlyCDCTable(ctx, job.Destination, destTable, writeSchema); err != nil {
 					errChan <- err
 					return
 				}
@@ -360,23 +677,84 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					errChan <- err
 					return
 				}
+				expectedIncarnation := ""
+				if job.CDCStateManager != nil {
+					var err error
+					expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, ti.Name, destTable)
+					if err != nil {
+						errChan <- err
+						return
+					}
+					if err := job.ApplyEvolutionForIfIncarnation(ctx, ti.Name, expectedIncarnation); err != nil {
+						errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+						return
+					}
+				}
+				mu.Lock()
+				targetIncarnations[ti.Name] = expectedIncarnation
+				tableConfigs[ti.Name] = destination.TableWriteConfig{
+					DestTable:              destTable,
+					Schema:                 writeSchema,
+					CDCMode:                true,
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: expectedIncarnation,
+				}
+				mu.Unlock()
+				return
+			}
+			if directMerge {
+				if err := prepareMergeTarget(ctx, job.Destination, mergeTableParams{
+					DestTable:   destTable,
+					Schema:      writeSchema,
+					PrimaryKeys: ti.PrimaryKeys,
+					IsCDC:       hasCDCColumns(writeSchema),
+				}); err != nil {
+					errChan <- err
+					return
+				}
+				expectedIncarnation := ""
+				if job.CDCStateManager != nil {
+					if err := job.CDCStateManager.BindDestinationIncarnation(ctx, ti.Name, destTable); err != nil {
+						errChan <- fmt.Errorf("failed to bind CDC destination table %s: %w", ti.Name, err)
+						return
+					}
+					var err error
+					expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, ti.Name, destTable)
+					if err != nil {
+						errChan <- err
+						return
+					}
+					if err := job.ApplyEvolutionForIfIncarnation(ctx, ti.Name, expectedIncarnation); err != nil {
+						errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+						return
+					}
+				}
 				mu.Lock()
 				tableConfigs[ti.Name] = destination.TableWriteConfig{
-					DestTable: destTable,
-					Schema:    ti.Schema,
+					DestTable:              destTable,
+					Schema:                 writeSchema,
+					PrimaryKeys:            ti.PrimaryKeys,
+					IncrementalKey:         ti.Schema.IncrementalKey,
+					IncrementalPredicate:   job.Config.IncrementalPredicate,
+					CDCMode:                hasCDCColumns(writeSchema),
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: expectedIncarnation,
 				}
 				mu.Unlock()
 				return
 			}
 
 			stagingTable := managedStagingTableName(job.Destination, destTable, "merge", job.Config.StagingDataset)
+			mu.Lock()
+			stagingTables[ti.Name] = stagingTable
+			mu.Unlock()
 
 			if err := prepareMergeTables(ctx, job.Destination, mergeTableParams{
 				DestTable:    destTable,
 				StagingTable: stagingTable,
-				Schema:       ti.Schema,
+				Schema:       writeSchema,
 				PrimaryKeys:  ti.PrimaryKeys,
-				IsCDC:        hasCDCColumns(ti.Schema), // Make non-PK columns nullable for CDC staging tables
+				IsCDC:        hasCDCColumns(writeSchema), // Make non-PK columns nullable for CDC staging tables
 			}); err != nil {
 				errChan <- err
 				return
@@ -387,13 +765,28 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					return
 				}
 			}
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				var err error
+				expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, ti.Name, destTable)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if err := job.ApplyEvolutionForIfIncarnation(ctx, ti.Name, expectedIncarnation); err != nil {
+					errChan <- fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+					return
+				}
+			}
 
 			mu.Lock()
-			stagingTables[ti.Name] = stagingTable
+			targetIncarnations[ti.Name] = expectedIncarnation
 			tableConfigs[ti.Name] = destination.TableWriteConfig{
-				DestTable:   stagingTable,
-				Schema:      ti.Schema,
-				PrimaryKeys: nil,
+				DestTable:     stagingTable,
+				Schema:        writeSchema,
+				PrimaryKeys:   nil,
+				CDCMode:       hasCDCColumns(writeSchema),
+				SkipCDCResume: job.CDCStateManager != nil,
 			}
 			mu.Unlock()
 		}(tableInfo)
@@ -402,7 +795,10 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	wg.Wait()
 	close(errChan)
 
-	for err := range errChan {
+	if err := <-errChan; err != nil {
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
+		}
 		return err
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -419,26 +815,22 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
 	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
-			Parallelism:         parallelism,
-			PageSize:            job.Config.PageSize,
-			Limit:               job.Config.SQLLimit,
-			CDCSlotSuffix:       job.Config.CDCSlotSuffix,
-			CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
-			CDCSnapshotReplace:  anyTableHasCDC && supportsCDCSnapshotReplace(job.Destination),
-			FullRefresh:         job.Config.FullRefresh,
+			Parallelism:          parallelism,
+			PageSize:             job.Config.PageSize,
+			Limit:                job.Config.SQLLimit,
+			CDCSlotSuffix:        job.Config.CDCSlotSuffix,
+			CDCLegacySlotSuffix:  job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace:   anyTableHasCDC && supportsCDCSnapshotReplace(job.Destination),
+			CDCStableDataBatches: len(managedAppendOnlyTables) > 0,
+			FullRefresh:          job.Config.FullRefresh,
 		},
 		CDCResumeLSNs:               job.CDCResumeLSNs,
 		CDCResumeIncarnations:       resumeIncarnations,
 		CDCResumeSchemaFingerprints: resumeSchemas,
 	})
 	if err != nil {
-		if source.ConnectorLeaseLoss(ctx) == nil {
-			for _, stagingTable := range stagingTables {
-				if source.ConnectorLeaseLoss(ctx) != nil {
-					break
-				}
-				_ = job.Destination.DropTable(ctx, stagingTable)
-			}
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 		}
 		return fmt.Errorf("failed to read from multi-table source: %w", err)
 	}
@@ -446,23 +838,57 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	records = applyMultiTableSnapshotInvalidations(readCtx, job, records)
+	if directMerge {
+		return writeDirectMultiTableMerge(
+			readCtx,
+			cancelRead,
+			direct,
+			job.Destination,
+			records,
+			job.Tables,
+			tableConfigs,
+			job.Config.EffectiveDestinationParallelism(),
+		)
+	}
 
-	writeResult, err := multitable.WriteWithResult(ctx, job.Destination, records, destination.MultiTableWriteOptions{
-		TableConfigs:     tableConfigs,
-		Parallelism:      job.Config.EffectiveDestinationParallelism(),
-		StagingTable:     true,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		CancelSource:     cancelRead,
-	})
+	writeOptions := destination.MultiTableWriteOptions{
+		TableConfigs:       tableConfigs,
+		Parallelism:        job.Config.EffectiveDestinationParallelism(),
+		StagingTable:       true,
+		StagingBucket:      job.Config.StagingBucket,
+		LoaderFileSize:     job.Config.LoaderFileSize,
+		LoaderFileFormat:   job.Config.LoaderFileFormat,
+		CancelSource:       cancelRead,
+		CancelDrainTimeout: canceledSourceDrainTimeout,
+	}
+	if len(managedAppendOnlyTables) > 0 {
+		writeOptions.TableWriter = func(
+			writeCtx context.Context,
+			sourceTable string,
+			tableRecords <-chan source.RecordBatchResult,
+			opts destination.WriteOptions,
+		) (bool, error) {
+			if _, appendOnly := managedAppendOnlyTables[sourceTable]; appendOnly {
+				opts.StagingTable = false
+				return writeDurableCDCAppendRecords(writeCtx, job.Destination, tableRecords, opts, sourceTable, job.CDCStateManager)
+			}
+			if tableConfigs[sourceTable].CDCMode {
+				return destination.WriteWithTruncateBoundaries(writeCtx, job.Destination, tableRecords, opts)
+			}
+			return false, job.Destination.WriteParallel(writeCtx, tableRecords, opts)
+		}
+	}
+	writeResult, err := multitable.WriteWithResult(readCtx, job.Destination, records, writeOptions)
 	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		if source.ConnectorLeaseLoss(ctx) == nil {
 			for _, stagingTable := range stagingTables {
 				if source.ConnectorLeaseLoss(ctx) != nil {
 					break
 				}
-				_ = job.Destination.DropTable(ctx, stagingTable)
+				dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 			}
 		}
 		return fmt.Errorf("failed to write multi-table data: %w", err)
@@ -480,6 +906,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			defer mergeWg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
 			stagingTable, ok := stagingTables[ti.Name]
 			if !ok {
 				// Append-only change-log table: rows were written directly.
@@ -494,8 +921,19 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					mergeErrChan <- err
 					return
 				}
-				if err := destination.ApplyCDCTruncate(ctx, job.Destination, destTable); err != nil {
-					mergeErrChan <- fmt.Errorf("failed to reset CDC target %s: %w", ti.Name, err)
+				var truncateErr error
+				if job.CDCStateManager != nil {
+					truncateErr = destination.ApplyCDCTruncateIfIncarnation(
+						ctx,
+						job.Destination,
+						destTable,
+						targetIncarnations[ti.Name],
+					)
+				} else {
+					truncateErr = destination.ApplyCDCTruncate(ctx, job.Destination, destTable)
+				}
+				if truncateErr != nil {
+					mergeErrChan <- fmt.Errorf("failed to reset CDC target %s: %w", ti.Name, truncateErr)
 					return
 				}
 				if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -507,7 +945,16 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 				mergeErrChan <- err
 				return
 			}
-			if err := mergeStagingInto(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, ti.Schema, "", ""); err != nil {
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				expectedIncarnation = targetIncarnations[ti.Name]
+				if expectedIncarnation == "" {
+					mergeErrChan <- fmt.Errorf("managed CDC destination table %s has no bound physical incarnation", ti.Name)
+					return
+				}
+			}
+			if err := mergeStagingIntoWithCommit(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, writeSchema, ti.Schema.IncrementalKey, job.Config.IncrementalPredicate,
+				"", "", job.CDCStateManager != nil, expectedIncarnation); err != nil {
 				mergeErrChan <- fmt.Errorf("failed to merge table %s: %w", ti.Name, err)
 				return
 			}
@@ -517,16 +964,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			}
 
 			if !job.Config.KeepStaging {
-				if err := source.ConnectorLeaseLoss(ctx); err != nil {
-					mergeErrChan <- err
-					return
-				}
-				if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-					config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, err)
-				}
-				if err := source.ConnectorLeaseLoss(ctx); err != nil {
-					mergeErrChan <- err
-				}
+				dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 			}
 		}(tableInfo)
 	}
@@ -542,20 +980,1092 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	}
 
 	if mergeErr != nil {
-		if source.ConnectorLeaseLoss(ctx) == nil {
-			for _, stagingTable := range stagingTables {
-				if source.ConnectorLeaseLoss(ctx) != nil {
-					break
-				}
-				if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-					config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, err)
-				}
-			}
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 		}
 		return mergeErr
 	}
 
 	return nil
+}
+
+type atomicMultiTableBatchState struct {
+	info                 source.SourceTableInfo
+	destTable            string
+	writeSchema          *schema.TableSchema
+	targetSchema         *schema.TableSchema
+	expectedIncarnation  string
+	targetExisted        bool
+	ownershipToken       string
+	targetPrepared       bool
+	records              chan source.RecordBatchResult
+	snapshot             bool
+	walTruncate          bool
+	attempt              destination.AtomicSnapshotOptions
+	boundary             atomicBatchSnapshotBoundary
+	publishAttempted     bool
+	sealAttempted        bool
+	directWriteAttempted bool
+}
+
+type atomicBatchSnapshotBoundary struct {
+	mu       sync.Mutex
+	position string
+}
+
+func (b *atomicBatchSnapshotBoundary) observe(result source.RecordBatchResult) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if result.DurableCommitID != "" && result.DurableCommitPosition != "" {
+		b.position = result.DurableCommitPosition
+		return
+	}
+	if token, ok := result.CommitToken.(source.CDCStateCommitToken); ok {
+		position := token.Position
+		if len(token.SnapshotPositions) == 1 {
+			for _, snapshotPosition := range token.SnapshotPositions {
+				position = snapshotPosition
+			}
+		}
+		if position != "" {
+			b.position = position
+		}
+	}
+}
+
+func (b *atomicBatchSnapshotBoundary) positionValue() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.position
+}
+
+func atomicSnapshotCommitID(attemptID string) source.DurableID {
+	if attemptID == "" {
+		return ""
+	}
+	return source.DurableID("atomic-snapshot-v1:" + destination.CDCTargetKey(attemptID))
+}
+
+func atomicSnapshotAttemptID(
+	ctx context.Context,
+	manager *CDCStateManager,
+	sourceTable, destTable string,
+) (string, error) {
+	if manager != nil && manager.dest != nil {
+		return manager.AtomicSnapshotAttempt(ctx, sourceTable, destTable)
+	}
+	return uuid.NewString(), nil
+}
+
+func completeAtomicSnapshotAttempt(
+	ctx context.Context,
+	manager *CDCStateManager,
+	sourceTable, destTable, attemptID string,
+) error {
+	if manager == nil || manager.dest == nil {
+		return nil
+	}
+	return manager.CompleteAtomicSnapshotAttempt(ctx, sourceTable, destTable, attemptID)
+}
+
+func recoverManagedAtomicSnapshotBeforeRead(
+	ctx context.Context,
+	dest destination.Destination,
+	publisher destination.AtomicSnapshotPublisher,
+	manager *CDCStateManager,
+	sourceTable, destTable string,
+) (position string, recovered bool, err error) {
+	if manager == nil {
+		return "", false, nil
+	}
+	if err := requireManagedAtomicSnapshotAbort(dest, manager); err != nil {
+		return "", false, err
+	}
+	attempt, exists, err := manager.PendingAtomicSnapshotAttempt(sourceTable, destTable)
+	if err != nil || !exists {
+		return "", false, err
+	}
+	fullRefresh := manager.FullRefresh()
+	currentIncarnation, currentSchemaFingerprint := manager.CurrentSourceMetadata(sourceTable)
+	metadataChanged := !attempt.sourceMetadataKnown ||
+		attempt.sourceIncarnation != currentIncarnation ||
+		attempt.sourceSchemaFingerprint != currentSchemaFingerprint
+	if !attempt.ready {
+		aborter, ok := dest.(destination.AtomicSnapshotAborter)
+		if !ok {
+			return "", false, fmt.Errorf("destination %s cannot recover an open atomic snapshot attempt", dest.GetScheme())
+		}
+		abortCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := aborter.AbortAtomicSnapshot(abortCtx, destination.AtomicSnapshotOptions{
+			Table: destTable, AttemptID: attempt.attemptID,
+		}); err != nil {
+			return "", false, fmt.Errorf("failed to abort open atomic snapshot attempt for %s: %w", sourceTable, err)
+		}
+		if err := manager.AbandonAtomicSnapshotAttempt(ctx, sourceTable, destTable, attempt.attemptID); err != nil {
+			return "", false, fmt.Errorf("failed to retire open atomic snapshot attempt for %s: %w", sourceTable, err)
+		}
+		return "", false, nil
+	}
+	if fullRefresh || metadataChanged {
+		discarder, ok := dest.(destination.AtomicSnapshotDiscarder)
+		if !ok {
+			return "", false, fmt.Errorf("destination %s cannot safely discard a sealed atomic snapshot attempt", dest.GetScheme())
+		}
+		discardCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := discarder.DiscardAtomicSnapshot(discardCtx, destination.AtomicSnapshotOptions{
+			Table: destTable, AttemptID: attempt.attemptID,
+		}); err != nil {
+			return "", false, fmt.Errorf("failed to discard stale sealed atomic snapshot attempt for %s: %w", sourceTable, err)
+		}
+		if err := manager.AbandonAtomicSnapshotAttempt(ctx, sourceTable, destTable, attempt.attemptID); err != nil {
+			return "", false, fmt.Errorf("failed to retire discarded sealed atomic snapshot attempt for %s: %w", sourceTable, err)
+		}
+		return "", false, nil
+	}
+
+	publishedIncarnation, err := publisher.PublishAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+		Table:                  destTable,
+		AttemptID:              attempt.attemptID,
+		CommitToken:            atomicSnapshotCommitID(attempt.attemptID),
+		CDCResumeLSN:           attempt.resumeLSN,
+		SkipCDCResume:          true,
+		CDCExpectedIncarnation: attempt.expectedIncarnation,
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("failed to recover sealed atomic snapshot publication for %s: %w", sourceTable, err)
+	}
+	if publishedIncarnation == "" {
+		return "", false, fmt.Errorf("recovered atomic snapshot publication for %s returned no physical incarnation", sourceTable)
+	}
+	if err := manager.BindRecoveredPublishedDestinationIncarnation(
+		ctx, sourceTable, destTable, publishedIncarnation,
+	); err != nil {
+		return "", false, err
+	}
+	if err := manager.CompleteAtomicSnapshotAttempt(ctx, sourceTable, destTable, attempt.attemptID); err != nil {
+		return "", false, fmt.Errorf("failed to complete recovered atomic snapshot attempt for %s: %w", sourceTable, err)
+	}
+	if err := manager.Persist(ctx, source.CDCStateCommitToken{
+		SnapshotPositions:    map[string]string{sourceTable: attempt.resumeLSN},
+		SnapshotIncarnations: map[string]string{sourceTable: attempt.sourceIncarnation},
+		SnapshotSchemas:      map[string]string{sourceTable: attempt.sourceSchemaFingerprint},
+	}); err != nil {
+		return "", false, fmt.Errorf("failed to persist recovered atomic snapshot state for %s: %w", sourceTable, err)
+	}
+	return attempt.resumeLSN, true, nil
+}
+
+func requireManagedAtomicSnapshotAbort(dest destination.Destination, manager *CDCStateManager) error {
+	if manager == nil {
+		return nil
+	}
+	if _, ok := dest.(destination.AtomicSnapshotAborter); !ok {
+		return fmt.Errorf("destination %s cannot safely recover an open managed atomic snapshot attempt", dest.GetScheme())
+	}
+	return nil
+}
+
+func observeAtomicBatchSnapshot(ctx context.Context, records <-chan source.RecordBatchResult, boundary *atomicBatchSnapshotBoundary) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult, cap(records))
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case result, ok := <-records:
+				if !ok {
+					return
+				}
+				boundary.observe(result)
+				select {
+				case out <- result:
+				case <-ctx.Done():
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+					return
+				}
+			case <-ctx.Done():
+				startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+				return
+			}
+		}
+	}()
+	return out
+}
+
+type multiTableSpoolEntry struct {
+	result   source.RecordBatchResult
+	hasBatch bool
+}
+
+type multiTableRecordSpool struct {
+	entries       []multiTableSpoolEntry
+	buffers       map[string]*databuffer.FileBuffer
+	invalidations []source.CDCSnapshotInvalidation
+}
+
+type atomicBatchSnapshotReset struct {
+	marker              source.RecordBatchResult
+	walTruncate         bool
+	replacementBoundary bool
+}
+
+func spoolMultiTableRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	states map[string]*atomicMultiTableBatchState,
+) (*multiTableRecordSpool, map[string]atomicBatchSnapshotReset, error) {
+	spool := &multiTableRecordSpool{buffers: make(map[string]*databuffer.FileBuffer)}
+	resetTables := make(map[string]atomicBatchSnapshotReset)
+	pendingInvalidations := make(map[string]int)
+	for {
+		select {
+		case <-ctx.Done():
+			_ = spool.Close()
+			return nil, nil, context.Cause(ctx)
+		case result, ok := <-records:
+			if !ok {
+				if len(pendingInvalidations) > 0 {
+					tables := make([]string, 0, len(pendingInvalidations))
+					for tableName := range pendingInvalidations {
+						tables = append(tables, tableName)
+					}
+					sort.Strings(tables)
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", tables[0])
+				}
+				return spool, resetTables, nil
+			}
+			if result.Err != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				_ = spool.Close()
+				return nil, nil, result.Err
+			}
+			if result.SnapshotInvalidation != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				invalidation := *result.SnapshotInvalidation
+				if _, known := states[invalidation.TableName]; !known {
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("source requested snapshot invalidation for unknown table %q", invalidation.TableName)
+				}
+				if _, exists := pendingInvalidations[invalidation.TableName]; exists {
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("source repeated snapshot invalidation for %s before its replacement boundary", invalidation.TableName)
+				}
+				spool.invalidations = append(spool.invalidations, invalidation)
+				pendingInvalidations[invalidation.TableName] = len(spool.invalidations) - 1
+				continue
+			}
+			if invalidationIndex, waiting := pendingInvalidations[result.TableName]; waiting {
+				announcement := result.Batch == nil && result.TableInfo != nil
+				if !announcement && (!result.Truncate || result.CDCWALTruncate) {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", result.TableName)
+				}
+				if announcement {
+					merged, err := mergeSnapshotInvalidationMetadata(spool.invalidations[invalidationIndex], result.TableInfo)
+					if err != nil {
+						_ = spool.Close()
+						return nil, nil, err
+					}
+					spool.invalidations[invalidationIndex] = merged
+				} else {
+					delete(pendingInvalidations, result.TableName)
+				}
+			}
+			if result.Truncate {
+				if _, known := states[result.TableName]; !known {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					continue
+				}
+				reset := resetTables[result.TableName]
+				reset.marker = result
+				reset.walTruncate = result.CDCWALTruncate
+				reset.replacementBoundary = reset.replacementBoundary || !result.CDCWALTruncate
+				resetTables[result.TableName] = reset
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				if buffer := spool.buffers[result.TableName]; buffer != nil {
+					if err := buffer.Close(); err != nil {
+						_ = spool.Close()
+						return nil, nil, fmt.Errorf("failed to reset multi-table CDC spool for %s: %w", result.TableName, err)
+					}
+					delete(spool.buffers, result.TableName)
+				}
+				entries := spool.entries[:0]
+				for _, entry := range spool.entries {
+					if entry.result.TableName != result.TableName {
+						entries = append(entries, entry)
+					}
+				}
+				spool.entries = entries
+				continue
+			}
+			entry := multiTableSpoolEntry{result: result, hasBatch: result.Batch != nil}
+			entry.result.Batch = nil
+			if result.Batch != nil {
+				if _, known := states[result.TableName]; !known {
+					result.Batch.Release()
+					continue
+				}
+				buffer := spool.buffers[result.TableName]
+				if buffer == nil {
+					var err error
+					buffer, err = databuffer.NewFileBuffer()
+					if err != nil {
+						result.Batch.Release()
+						_ = spool.Close()
+						return nil, nil, fmt.Errorf("failed to create multi-table CDC spool for %s: %w", result.TableName, err)
+					}
+					spool.buffers[result.TableName] = buffer
+				}
+				if err := buffer.Append(ctx, result.Batch); err != nil {
+					result.Batch.Release()
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("failed to spool multi-table CDC batch for %s: %w", result.TableName, err)
+				}
+				result.Batch.Release()
+			}
+			spool.entries = append(spool.entries, entry)
+		}
+	}
+}
+
+func (s *multiTableRecordSpool) Replay(ctx context.Context, states map[string]*atomicMultiTableBatchState) (<-chan source.RecordBatchResult, error) {
+	readers := make(map[string]<-chan source.RecordBatchResult, len(s.buffers))
+	for table, buffer := range s.buffers {
+		reader, err := buffer.Reader(ctx, states[table].writeSchema.ToArrowSchema())
+		if err != nil {
+			return nil, fmt.Errorf("failed to replay multi-table CDC spool for %s: %w", table, err)
+		}
+		readers[table] = reader
+	}
+	out := make(chan source.RecordBatchResult, 16)
+	go func() {
+		defer close(out)
+		defer func() {
+			for _, reader := range readers {
+				drainAndRelease(reader)
+			}
+		}()
+		for _, entry := range s.entries {
+			result := entry.result
+			if entry.hasBatch {
+				batchResult, ok := <-readers[result.TableName]
+				if !ok {
+					result.Err = fmt.Errorf("multi-table CDC spool ended early for %s", result.TableName)
+				} else if batchResult.Err != nil {
+					result.Err = batchResult.Err
+				} else {
+					result.Batch = batchResult.Batch
+				}
+			}
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (s *multiTableRecordSpool) Close() error {
+	var err error
+	for _, buffer := range s.buffers {
+		err = errors.Join(err, buffer.Close())
+	}
+	return err
+}
+
+func (s *MergeStrategy) executeAtomicMultiTableBatch(
+	ctx context.Context,
+	job *MultiTableIngestionJob,
+	publisher destination.AtomicSnapshotPublisher,
+	direct destination.DirectMergeWriter,
+) error {
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	states := make(map[string]*atomicMultiTableBatchState, len(job.Tables))
+	for _, info := range job.Tables {
+		destTable := job.GetDestTableName(info.Name)
+		writeSchema := job.WriteSchemaFor(info.Name, info.Schema)
+		targetSchema := destination.DestinationTableSchema(writeSchema)
+		if job.Config.IncrementalStrategy == config.StrategyAppend && hasCDCColumns(writeSchema) {
+			targetSchema = writeSchema
+		} else if plan := job.EvolutionPlans[info.Name]; plan != nil && plan.FinalSchema != nil {
+			targetSchema = plan.FinalSchema
+		}
+		states[info.Name] = &atomicMultiTableBatchState{info: info, destTable: destTable, writeSchema: writeSchema, targetSchema: targetSchema}
+	}
+	plannedSnapshotTables := make(map[string]struct{})
+	for _, info := range job.Tables {
+		if !hasCDCColumns(info.Schema) {
+			continue
+		}
+		if job.Config.FullRefresh || strings.TrimSpace(job.CDCResumeLSNs[info.Name]) == "" {
+			plannedSnapshotTables[info.Name] = struct{}{}
+		}
+	}
+	plannedTables := make([]string, 0, len(plannedSnapshotTables))
+	for tableName := range plannedSnapshotTables {
+		plannedTables = append(plannedTables, tableName)
+	}
+	sort.Strings(plannedTables)
+	for _, tableName := range plannedTables {
+		st := states[tableName]
+		position, recovered, err := recoverManagedAtomicSnapshotBeforeRead(
+			ctx, job.Destination, publisher, job.CDCStateManager, tableName, st.destTable,
+		)
+		if err != nil {
+			return err
+		}
+		if !recovered {
+			continue
+		}
+		if job.CDCResumeLSNs == nil {
+			job.CDCResumeLSNs = make(map[string]string)
+		}
+		job.CDCResumeLSNs[tableName] = position
+		delete(plannedSnapshotTables, tableName)
+	}
+	if job.CDCStateManager != nil {
+		operation := "managed keyless CDC merge"
+		if job.Config.IncrementalStrategy == config.StrategyAppend {
+			operation = "managed multi-table CDC append"
+		}
+		for _, info := range job.Tables {
+			if !isAppendOnlyCDCTable(info) {
+				continue
+			}
+			if _, snapshot := plannedSnapshotTables[info.Name]; snapshot {
+				continue
+			}
+			if err := requireIdempotentCommitTokenWrites(job.Destination, operation); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	jobSucceeded := false
+	defer func() {
+		if jobSucceeded {
+			return
+		}
+		aborter, canAbort := job.Destination.(destination.AtomicSnapshotAborter)
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cleanupCancel()
+		for _, st := range states {
+			if st.snapshot && !st.publishAttempted && !st.sealAttempted && canAbort && st.attempt.AttemptID != "" {
+				_ = aborter.AbortAtomicSnapshot(cleanupCtx, st.attempt)
+			}
+			neverMutatedTarget := st.snapshot && !st.publishAttempted && !st.sealAttempted || !st.snapshot && !st.directWriteAttempted
+			if st.targetPrepared && neverMutatedTarget && st.ownershipToken != "" {
+				cleanupFailedOwnedDirectReplace(cleanupCtx, job.Destination, st.destTable, !st.targetExisted, st.ownershipToken)
+			}
+		}
+	}()
+	for _, info := range job.Tables {
+		st := states[info.Name]
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		_, snapshot := plannedSnapshotTables[info.Name]
+		if !snapshot && job.CDCStateManager == nil {
+			if err := job.ApplyEvolutionFor(ctx, info.Name); err != nil {
+				return fmt.Errorf("failed to evolve destination table %s before source read: %w", info.Name, err)
+			}
+		}
+		existingSchema, err := job.Destination.GetTableSchema(ctx, st.destTable)
+		if err != nil {
+			return fmt.Errorf("failed to inspect destination table %s before multi-table CDC: %w", st.destTable, err)
+		}
+		st.targetExisted = existingSchema != nil
+		st.ownershipToken = newTargetOwnershipToken(job.Destination, st.targetExisted)
+		st.targetPrepared = !st.targetExisted && st.ownershipToken != ""
+		if isAppendOnlyCDCTable(info) {
+			if !st.targetExisted {
+				if st.ownershipToken == "" {
+					return fmt.Errorf("destination %s cannot safely clean up a failed atomic append target", job.Destination.GetScheme())
+				}
+				if err := prepareAppendOnlyCDCTableOwned(ctx, job.Destination, st.destTable, st.writeSchema, st.ownershipToken); err != nil {
+					return err
+				}
+				st.targetPrepared = true
+			}
+		} else if err := prepareMergeTarget(ctx, job.Destination, mergeTableParams{
+			DestTable: st.destTable, Schema: st.writeSchema, PrimaryKeys: info.PrimaryKeys, IsCDC: hasCDCColumns(st.writeSchema),
+			OwnershipToken: st.ownershipToken,
+		}); err != nil {
+			return err
+		} else {
+			st.targetPrepared = true
+		}
+		if job.CDCStateManager != nil && job.CDCStateManager.dest != nil {
+			if err := job.CDCStateManager.BindDestinationIncarnation(ctx, info.Name, st.destTable); err != nil {
+				return fmt.Errorf("failed to bind CDC destination table %s before source read: %w", info.Name, err)
+			}
+			st.expectedIncarnation, err = boundDestinationIncarnation(job.CDCStateManager, info.Name, st.destTable)
+			if err != nil {
+				return err
+			}
+			if !snapshot {
+				if err := job.ApplyEvolutionForIfIncarnation(ctx, info.Name, st.expectedIncarnation); err != nil {
+					return fmt.Errorf("failed to evolve destination table %s before source read: %w", info.Name, err)
+				}
+			}
+		}
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
+	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
+		ReadOptions: source.ReadOptions{
+			Parallelism: parallelism, PageSize: job.Config.PageSize, Limit: job.Config.SQLLimit,
+			CDCSlotSuffix: job.Config.CDCSlotSuffix, CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace: true, FullRefresh: job.Config.FullRefresh,
+			CDCStableDataBatches: managedMultiTableStableDataBatches(job),
+		},
+		CDCResumeLSNs:               job.CDCResumeLSNs,
+		CDCResumeIncarnations:       resumeIncarnations,
+		CDCResumeSchemaFingerprints: resumeSchemas,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to read from multi-table source: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+
+	spool, resetTables, err := spoolMultiTableRecords(readCtx, records, states)
+	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to preflight multi-table CDC records: %w", err)
+	}
+	defer func() { _ = spool.Close() }()
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	for _, invalidation := range spool.invalidations {
+		reset, ok := resetTables[invalidation.TableName]
+		if !ok || !reset.replacementBoundary {
+			return fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", invalidation.TableName)
+		}
+	}
+	for _, invalidation := range spool.invalidations {
+		if job.CDCStateManager == nil {
+			return fmt.Errorf("source requested snapshot invalidation without destination-managed CDC state")
+		}
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		st := states[invalidation.TableName]
+		if err := job.CDCStateManager.InvalidateSnapshotStatePreservingDestination(
+			ctx, invalidation.TableName, st.destTable, invalidation.Incarnation, invalidation.SchemaFingerprint,
+		); err != nil {
+			return err
+		}
+	}
+	for tableName, reset := range resetTables {
+		plannedSnapshotTables[tableName] = struct{}{}
+		if st, ok := states[tableName]; ok {
+			st.walTruncate = reset.walTruncate
+			st.boundary.observe(reset.marker)
+		}
+	}
+	records, err = spool.Replay(readCtx, states)
+	if err != nil {
+		return err
+	}
+	for tableName := range plannedSnapshotTables {
+		if st, ok := states[tableName]; ok {
+			attemptID, err := atomicSnapshotAttemptID(ctx, job.CDCStateManager, tableName, st.destTable)
+			if err != nil {
+				return fmt.Errorf("failed to establish durable atomic snapshot attempt for %s: %w", tableName, err)
+			}
+			st.snapshot = true
+			st.attempt = destination.AtomicSnapshotOptions{
+				Table: st.destTable, Schema: st.writeSchema, TargetSchema: st.targetSchema,
+				PrimaryKeys: st.info.PrimaryKeys, Parallelism: job.Config.EffectiveDestinationParallelism(), AttemptID: attemptID,
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: st.expectedIncarnation,
+			}
+		}
+	}
+	snapshotTables := make([]string, 0, len(plannedSnapshotTables))
+	for tableName := range plannedSnapshotTables {
+		snapshotTables = append(snapshotTables, tableName)
+	}
+	sort.Strings(snapshotTables)
+	for _, tableName := range snapshotTables {
+		st := states[tableName]
+		if !st.snapshot {
+			continue
+		}
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		if err := publisher.BeginAtomicSnapshot(ctx, st.attempt); err != nil {
+			return fmt.Errorf("failed to begin snapshot table %s: %w", tableName, err)
+		}
+	}
+
+	g, gctx := errgroup.WithContext(readCtx)
+	startWorker := func(st *atomicMultiTableBatchState) error {
+		st.records = make(chan source.RecordBatchResult, 8)
+		g.Go(func() error {
+			if st.snapshot {
+				observed := observeAtomicBatchSnapshot(gctx, st.records, &st.boundary)
+				if err := publisher.WriteAtomicSnapshot(gctx, observed, destination.WriteOptions{
+					Table: st.destTable, Schema: st.writeSchema, PrimaryKeys: st.info.PrimaryKeys,
+					Parallelism: job.Config.EffectiveDestinationParallelism(), AtomicSnapshotAttemptID: st.attempt.AttemptID,
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: st.expectedIncarnation,
+				}); err != nil {
+					drainAndRelease(observed)
+					return fmt.Errorf("failed to stage snapshot table %s: %w", st.info.Name, err)
+				}
+				return nil
+			}
+			st.directWriteAttempted = true
+			if isAppendOnlyCDCTable(st.info) {
+				return writeDurableKeylessCDCRecords(gctx, job.Destination, st.records, destination.WriteOptions{
+					Table: st.destTable, Schema: st.writeSchema, Parallelism: job.Config.EffectiveDestinationParallelism(),
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: st.expectedIncarnation,
+				})
+			}
+			return direct.MergeRecords(gctx, st.records, destination.WriteOptions{
+				Table: st.destTable, Schema: st.writeSchema, Parallelism: job.Config.EffectiveDestinationParallelism(),
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: st.expectedIncarnation,
+			}, destination.MergeOptions{
+				TargetTable: st.destTable, PrimaryKeys: st.info.PrimaryKeys,
+				Columns:              destination.MergeColumnsFor(job.Destination, st.writeSchema.ColumnNames()),
+				IncrementalKey:       mergeIncrementalKeyForSchema(st.writeSchema, st.writeSchema.IncrementalKey),
+				IncrementalPredicate: job.Config.IncrementalPredicate,
+				Schema:               st.writeSchema, Parallelism: job.Config.EffectiveDestinationParallelism(),
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: st.expectedIncarnation,
+			})
+		})
+		return nil
+	}
+
+	var dispatchErr error
+dispatch:
+	for {
+		select {
+		case <-gctx.Done():
+			dispatchErr = context.Cause(gctx)
+			break dispatch
+		case result, ok := <-records:
+			if !ok {
+				break dispatch
+			}
+			if result.Err != nil && result.TableName == "" {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				dispatchErr = result.Err
+				break dispatch
+			}
+			st, known := states[result.TableName]
+			if !known {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				continue
+			}
+			if result.Truncate {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				dispatchErr = fmt.Errorf("unexpected snapshot reset for table %s after multi-table CDC preflight", result.TableName)
+				break dispatch
+			}
+			if st.records == nil {
+				if err := startWorker(st); err != nil {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					dispatchErr = err
+					break dispatch
+				}
+			}
+			select {
+			case st.records <- result:
+			case <-gctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				dispatchErr = context.Cause(gctx)
+				break dispatch
+			}
+		}
+	}
+	if dispatchErr != nil {
+		for _, st := range states {
+			if st.records == nil {
+				continue
+			}
+			select {
+			case st.records <- source.RecordBatchResult{Err: dispatchErr}:
+			case <-gctx.Done():
+			}
+		}
+	}
+	for _, st := range states {
+		if st.records != nil {
+			close(st.records)
+		}
+	}
+	groupErr := g.Wait()
+	for _, st := range states {
+		if st.records != nil {
+			drainAndRelease(st.records)
+		}
+	}
+	if dispatchErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return dispatchErr
+	}
+	if groupErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return groupErr
+	}
+
+	for _, tableName := range snapshotTables {
+		st := states[tableName]
+		if !st.snapshot {
+			continue
+		}
+		st.attempt.CommitToken = atomicSnapshotCommitID(st.attempt.AttemptID)
+		st.attempt.CDCResumeLSN = st.boundary.positionValue()
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		if job.CDCStateManager != nil && job.CDCStateManager.dest != nil {
+			st.sealAttempted = true
+			if err := job.CDCStateManager.SealAtomicSnapshotAttempt(
+				ctx, tableName, st.destTable, st.attempt.AttemptID, st.attempt.CDCResumeLSN, st.expectedIncarnation,
+			); err != nil {
+				return fmt.Errorf("failed to seal durable atomic snapshot attempt for %s: %w", tableName, err)
+			}
+		}
+		st.publishAttempted = true
+		publishedIncarnation, err := publisher.PublishAtomicSnapshot(ctx, st.attempt)
+		if err != nil {
+			return fmt.Errorf("failed to publish snapshot table %s: %w", tableName, err)
+		}
+		if job.CDCStateManager != nil && job.CDCStateManager.dest != nil {
+			if publishedIncarnation == "" {
+				return fmt.Errorf("atomic publication for table %s returned no physical incarnation", tableName)
+			}
+			if err := job.CDCStateManager.BindPublishedDestinationIncarnation(
+				ctx, tableName, st.destTable, st.expectedIncarnation, publishedIncarnation,
+			); err != nil {
+				return fmt.Errorf("failed to revalidate published CDC destination table %s: %w", tableName, err)
+			}
+			if err := completeAtomicSnapshotAttempt(
+				ctx, job.CDCStateManager, tableName, st.destTable, st.attempt.AttemptID,
+			); err != nil {
+				return fmt.Errorf("failed to complete durable atomic snapshot attempt for %s: %w", tableName, err)
+			}
+		}
+	}
+	if job.CDCStateManager != nil {
+		for _, tableName := range snapshotTables {
+			st := states[tableName]
+			if !st.walTruncate {
+				continue
+			}
+			job.CDCStateManager.RecordBatchSnapshotCompletion(tableName, st.boundary.positionValue())
+		}
+	}
+	jobSucceeded = true
+	return nil
+}
+
+func managedMultiTableStableDataBatches(job *MultiTableIngestionJob) bool {
+	if job.CDCStateManager == nil {
+		return false
+	}
+	if job.Config.IncrementalStrategy == config.StrategyAppend {
+		return true
+	}
+	for _, table := range job.Tables {
+		if isAppendOnlyCDCTable(table) {
+			return true
+		}
+	}
+	return false
+}
+
+func dropMergeStagingDetached(ctx context.Context, dest destination.Destination, table string) {
+	if source.ConnectorLeaseLoss(ctx) != nil {
+		return
+	}
+	cleanupBase, detachCancel := source.WithoutCancelWithConnectorLease(ctx)
+	defer detachCancel()
+	cleanupCtx, cancel := context.WithTimeout(cleanupBase, 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", table, err)
+	}
+}
+
+func writeDirectMultiTableMerge(
+	ctx context.Context,
+	cancelSource context.CancelFunc,
+	direct destination.DirectMergeWriter,
+	dest destination.Destination,
+	records <-chan source.RecordBatchResult,
+	tables []source.SourceTableInfo,
+	configs map[string]destination.TableWriteConfig,
+	parallelism int,
+) error {
+	channels := make(map[string]chan source.RecordBatchResult, len(configs))
+	g, gctx := errgroup.WithContext(ctx)
+	for _, ti := range tables {
+		cfg, ok := configs[ti.Name]
+		if !ok {
+			continue
+		}
+		ch := make(chan source.RecordBatchResult, 2)
+		channels[ti.Name] = ch
+		if isAppendOnlyCDCTable(ti) {
+			g.Go(func() error {
+				return writeDurableKeylessCDCRecords(gctx, dest, ch, destination.WriteOptions{
+					Table: cfg.DestTable, Schema: cfg.Schema, Parallelism: parallelism,
+					SkipCDCResume: cfg.SkipCDCResume, CDCExpectedIncarnation: cfg.CDCExpectedIncarnation,
+				})
+			})
+			continue
+		}
+		g.Go(func() error {
+			return direct.MergeRecords(gctx, ch, destination.WriteOptions{
+				Table: cfg.DestTable, Schema: cfg.Schema, Parallelism: parallelism,
+				SkipCDCResume: cfg.SkipCDCResume, CDCExpectedIncarnation: cfg.CDCExpectedIncarnation,
+			}, destination.MergeOptions{
+				TargetTable:            cfg.DestTable,
+				PrimaryKeys:            ti.PrimaryKeys,
+				Columns:                destination.MergeColumnsFor(dest, cfg.Schema.ColumnNames()),
+				IncrementalKey:         mergeIncrementalKeyForSchema(cfg.Schema, cfg.IncrementalKey),
+				IncrementalPredicate:   cfg.IncrementalPredicate,
+				Schema:                 cfg.Schema,
+				Parallelism:            parallelism,
+				SkipCDCResume:          cfg.SkipCDCResume,
+				CDCExpectedIncarnation: cfg.CDCExpectedIncarnation,
+			})
+		})
+	}
+
+	var dispatchErr error
+	var sourceFailed bool
+dispatch:
+	for {
+		var result source.RecordBatchResult
+		var ok bool
+		select {
+		case result, ok = <-records:
+			if !ok {
+				break dispatch
+			}
+		case <-gctx.Done():
+			dispatchErr = context.Cause(gctx)
+			cancelSource()
+			break dispatch
+		}
+		if result.Err != nil && result.TableName == "" {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			dispatchErr = result.Err
+			sourceFailed = true
+			break
+		}
+		ch, ok := channels[result.TableName]
+		if !ok {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			continue
+		}
+		select {
+		case ch <- result:
+		case <-gctx.Done():
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			dispatchErr = context.Cause(gctx)
+			break dispatch
+		}
+	}
+	for _, ch := range channels {
+		close(ch)
+	}
+	var sourceDrainDone <-chan struct{}
+	if dispatchErr != nil {
+		cancelSource()
+		sourceDrainDone = startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+	}
+	groupErr := g.Wait()
+	for _, ch := range channels {
+		drainAndRelease(ch)
+	}
+	if sourceDrainDone != nil {
+		<-sourceDrainDone
+	}
+	// A source failure cancels the merge goroutines, so their context-canceled
+	// group error must not mask the actual failure.
+	if sourceFailed {
+		return dispatchErr
+	}
+	if groupErr != nil {
+		return fmt.Errorf("failed to merge multi-table data directly: %w", groupErr)
+	}
+	return dispatchErr
+}
+
+// writeDurableKeylessCDCRecords commits each source transaction independently.
+// A keyless change log cannot deduplicate by row identity, so retry safety comes
+// from the stable per-transaction DurableCommitID emitted by the CDC source.
+func writeDurableKeylessCDCRecords(
+	ctx context.Context,
+	dest destination.Destination,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	if err := requireIdempotentCommitTokenWrites(dest, "durable keyless CDC writes"); err != nil {
+		return err
+	}
+	for {
+		var result source.RecordBatchResult
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case result, ok = <-records:
+			if !ok {
+				return nil
+			}
+		}
+
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return result.Err
+		}
+		commitID := result.DurableCommitID
+		commitPosition := result.DurableCommitPosition
+		if opts.SkipCDCResume {
+			if token, ok := result.CommitToken.(source.CDCStateCommitToken); ok && token.DataBatchID != "" {
+				commitID = managedCDCDataWriteID(result.TableName, token.DataBatchID)
+				commitPosition = token.Position
+			}
+		}
+		if commitID == "" {
+			if result.Batch == nil {
+				continue
+			}
+			result.Batch.Release()
+			return fmt.Errorf("keyless CDC batch for table %s has no durable transaction identifier", opts.Table)
+		}
+
+		if result.Batch == nil {
+			if opts.SkipCDCResume {
+				continue
+			}
+			writer, ok := dest.(destination.DurableCommitTokenWriter)
+			if !ok {
+				return fmt.Errorf("destination %s cannot persist an empty keyless CDC checkpoint", dest.GetScheme())
+			}
+			if err := writer.CommitWriteToken(ctx, opts.Table, commitID, commitPosition); err != nil {
+				return fmt.Errorf("failed to persist keyless CDC checkpoint for table %s: %w", opts.Table, err)
+			}
+			continue
+		}
+
+		writeOpts := opts
+		writeOpts.CommitToken = commitID
+		writeOpts.CDCResumeLSN = commitPosition
+		if opts.SkipCDCResume {
+			writeOpts.CDCResumeLSN = ""
+		}
+		writeOpts.SkipCDCResume = opts.SkipCDCResume || commitPosition == ""
+		batch := make(chan source.RecordBatchResult, 1)
+		batch <- source.RecordBatchResult{Batch: result.Batch}
+		close(batch)
+		if err := dest.WriteParallel(ctx, batch, writeOpts); err != nil {
+			drainAndRelease(batch)
+			return fmt.Errorf("failed to write durable keyless CDC batch to table %s: %w", opts.Table, err)
+		}
+	}
+}
+
+func requireIdempotentCommitTokenWrites(dest destination.Destination, operation string) error {
+	idempotent, ok := dest.(destination.IdempotentCommitTokenWriter)
+	if !ok || !idempotent.SupportsIdempotentCommitTokenWrites() {
+		return fmt.Errorf("%s requires destination support for idempotent commit-token writes", operation)
+	}
+	return nil
+}
+
+// startBoundedRecordDrain lets a canceled source finish sends that were
+// already in flight. Some source producers use blocking sends, so consuming
+// only the records immediately available can strand them between sends. The
+// deadline also prevents an uncooperative source from blocking shutdown.
+func startBoundedRecordDrain(records <-chan source.RecordBatchResult, timeout time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				return
+			default:
+			}
+
+			select {
+			case result, ok := <-records:
+				if !ok {
+					return
+				}
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+			case <-timer.C:
+				return
+			}
+		}
+	}()
+	return done
 }
 
 // hasCDCColumns checks if a schema has CDC columns (specifically _cdc_deleted).

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -3,7 +3,9 @@ package strategy
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,10 +14,155 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/stretchr/testify/require"
 )
+
+type recreatingStagedMergeDestination struct {
+	*cdcStateDestination
+	target                string
+	recreateAfterStage    bool
+	recreateAfterTruncate bool
+	mu                    sync.Mutex
+	mergeAttempts         []destination.MergeOptions
+	externalRows          int
+}
+
+func (d *recreatingStagedMergeDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if err := d.fakeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	if opts.StagingTable && d.recreateAfterStage {
+		d.stateMu.Lock()
+		d.incarnations[d.target] = "external-v2"
+		d.stateMu.Unlock()
+	}
+	return nil
+}
+
+func (d *recreatingStagedMergeDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expected string) error {
+	if err := d.cdcStateDestination.TruncateCDCTableIfIncarnation(ctx, table, expected); err != nil {
+		return err
+	}
+	d.mu.Lock()
+	d.externalRows = 0
+	d.mu.Unlock()
+	if d.recreateAfterTruncate {
+		d.stateMu.Lock()
+		d.incarnations[table] = "external-v2"
+		d.stateMu.Unlock()
+		d.mu.Lock()
+		d.externalRows = 99
+		d.mu.Unlock()
+	}
+	return nil
+}
+
+func (d *recreatingStagedMergeDestination) TruncateTable(_ context.Context, table string) error {
+	d.fakeDestination.mu.Lock()
+	d.truncateCalls = append(d.truncateCalls, table)
+	err := d.truncateErr
+	d.fakeDestination.mu.Unlock()
+	return err
+}
+
+func (d *recreatingStagedMergeDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	d.mu.Lock()
+	d.mergeAttempts = append(d.mergeAttempts, opts)
+	d.mu.Unlock()
+	current, exists, err := d.CDCTargetIncarnation(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	if !exists || opts.CDCExpectedIncarnation == "" || current != opts.CDCExpectedIncarnation {
+		return errors.New("destination was replaced before managed staged merge")
+	}
+	d.mu.Lock()
+	d.externalRows++
+	d.mu.Unlock()
+	return d.cdcStateDestination.MergeTable(ctx, opts)
+}
+
+func managedStagedMergeJob(t *testing.T, dest *recreatingStagedMergeDestination, records ...source.RecordBatchResult) *IngestionJob {
+	t.Helper()
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.SourceSchema = job.Schema
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.PrimaryKeys = []string{"id"}
+	dest.target = job.Config.DestTable
+	dest.externalRows = 99
+	dest.incarnations[dest.target] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "staged-recreation-"+strings.ReplaceAll(t.Name(), "/", "-"), dest.target, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, dest.target, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords(records...)
+	return job
+}
+
+func TestManagedStagedMergeRejectsTargetRecreationAfterStagingWrite(t *testing.T) {
+	dest := &recreatingStagedMergeDestination{
+		cdcStateDestination: newCDCStateDestination(), recreateAfterStage: true,
+	}
+	job := managedStagedMergeJob(t, dest, source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	})
+
+	err := (&MergeStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "replaced before managed staged merge")
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeAttempts, 1)
+	require.Equal(t, "target-v1", dest.mergeAttempts[0].CDCExpectedIncarnation)
+	require.Equal(t, 99, dest.externalRows)
+	require.Empty(t, dest.mergeCalls)
+}
+
+func TestManagedStagedMergeRejectsRecreationBeforeConditionalSourceTruncate(t *testing.T) {
+	dest := &recreatingStagedMergeDestination{
+		cdcStateDestination: newCDCStateDestination(), recreateAfterStage: true,
+	}
+	job := managedStagedMergeJob(
+		t, dest,
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{Truncate: true, CDCWALTruncate: true},
+	)
+
+	err := (&MergeStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Empty(t, dest.mergeAttempts)
+	require.Equal(t, 99, dest.externalRows)
+	require.Empty(t, dest.mergeCalls)
+}
+
+func TestManagedStagedMergeRejectsRecreationBetweenConditionalTruncateAndMerge(t *testing.T) {
+	dest := &recreatingStagedMergeDestination{
+		cdcStateDestination: newCDCStateDestination(), recreateAfterTruncate: true,
+	}
+	job := managedStagedMergeJob(
+		t, dest,
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{Truncate: true, CDCWALTruncate: true},
+	)
+
+	err := (&MergeStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "replaced before managed staged merge")
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeAttempts, 1)
+	require.Equal(t, "target-v1", dest.mergeAttempts[0].CDCExpectedIncarnation)
+	require.Equal(t, 99, dest.externalRows, "the externally recreated target must remain untouched")
+	require.Empty(t, dest.mergeCalls)
+}
 
 func TestMergeStrategy_Validate(t *testing.T) {
 	strat := &MergeStrategy{}
@@ -29,6 +176,100 @@ func TestMergeStrategy_Validate(t *testing.T) {
 	if err := strat.Validate(cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestMultiTableMergeReadFailureUsesDetachedStagingCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func() (context.Context, context.CancelFunc)
+	}{
+		{name: "canceled", ctx: func() (context.Context, context.CancelFunc) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			return ctx, func() {}
+		}},
+		{name: "deadline", ctx: func() (context.Context, context.CancelFunc) {
+			return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			table := source.SourceTableInfo{Name: "events", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+			src := &readAllSetupErrorSource{
+				announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+				err:                        errors.New("read setup failed"),
+			}
+			base := &fakeDestination{}
+			dest := &contextAwareDropDestination{fakeDestination: base}
+			job := &MultiTableIngestionJob{
+				Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest,
+				Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+			}
+			ctx, cancel := tc.ctx()
+			defer cancel()
+
+			if err := (&MergeStrategy{}).ExecuteMultiTable(ctx, job); err == nil {
+				t.Fatal("expected read setup failure")
+			}
+			if len(dest.successfulDrops) != 1 {
+				t.Fatalf("managed staging cleanup inherited %s context: %v", tc.name, dest.successfulDrops)
+			}
+			if !strings.Contains(dest.successfulDrops[0], "_merge_") {
+				t.Fatalf("unexpected staging cleanup table: %v", dest.successfulDrops)
+			}
+		})
+	}
+}
+
+func TestMultiTableMergeLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	table := source.SourceTableInfo{Name: "events", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(ctx, job)
+	if err == nil || !strings.Contains(err.Error(), "prepare response lost") {
+		t.Fatalf("expected lost staging prepare response, got %v", err)
+	}
+	if len(dest.successfulDrops) != 1 {
+		t.Fatalf("lost staging prepare was not detached-cleaned: %v", dest.successfulDrops)
+	}
+	if dest.successfulDrops[0] != base.prepareCalls[1].Table {
+		t.Fatalf("cleaned %q, want prepared staging %q", dest.successfulDrops[0], base.prepareCalls[1].Table)
+	}
+}
+
+func TestMergeLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.PrimaryKeys = []string{"id"}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func TestDeleteInsertLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.IncrementalKey = "id"
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&DeleteInsertStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
 }
 
 func TestMergeStrategy_Execute_HappyPath(t *testing.T) {
@@ -181,7 +422,7 @@ func TestMergeStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema(t *testi
 	}
 }
 
-func TestMergeStrategy_Execute_GetRecordsFails_LeavesStagingForDebugging(t *testing.T) {
+func TestMergeStrategy_Execute_GetRecordsFails_DropsManagedStaging(t *testing.T) {
 	job, src, dest := minimalJob()
 	src.readErr = errors.New("read failed")
 
@@ -197,9 +438,122 @@ func TestMergeStrategy_Execute_GetRecordsFails_LeavesStagingForDebugging(t *test
 	if len(dest.prepareCalls) != 2 {
 		t.Fatalf("expected 2 PrepareTable calls, got %d", len(dest.prepareCalls))
 	}
-	if len(dest.dropCalls) != 0 {
-		t.Fatalf("expected staging table to be left for debugging, got %d DropTable calls", len(dest.dropCalls))
+	staging := dest.prepareCalls[1].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
 	}
+}
+
+func TestMergeStrategy_Execute_WriteFails_DropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("write failed")
+
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	staging := dest.prepareCalls[1].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
+	}
+}
+
+func TestMergeStrategy_WriterFailureBoundsNonclosingSource(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailStagedMergeDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	if err == nil || time.Since(started) > time.Second {
+		t.Fatalf("merge did not return promptly after writer failure: %v", err)
+	}
+	close(records)
+}
+
+type immediateFailStagedMergeDestination struct {
+	*fakeDestination
+}
+
+func (d *immediateFailStagedMergeDestination) WriteParallel(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	return errors.New("writer failed")
+}
+
+func TestMergeStrategy_MultiTableWriterFailureCancelsAndDrainsSource(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	done := make(chan struct{})
+	src := &cancelAwareMultiTableSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		done:                       done,
+	}
+	base := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    &immediateFailStagedMergeDestination{fakeDestination: base},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("source producer remained blocked after staged writer failure")
+	}
+	if len(base.dropCalls) != 1 {
+		t.Fatalf("expected failed staged merge cleanup, got %v", base.dropCalls)
+	}
+}
+
+func TestMergeStrategy_PartialMultiTableSetupCleansCreatedStages(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	base := &fakeDestination{}
+	base.prepareHook = func(opts destination.PrepareOptions) error {
+		if strings.Contains(opts.Table, "users_merge_") {
+			return errors.New("prepare failed")
+		}
+		return nil
+	}
+	src := &announcingMultiTableSource{tables: tables, records: mustClosedRecords()}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
+		Source:      src,
+		Destination: base,
+		Tables:      tables,
+		TableDestNames: map[string]string{
+			"public.users": "users", "public.orders": "orders",
+		},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatalf("expected partial setup failure, prepare calls: %+v", base.prepareCalls)
+	}
+	require.Len(t, base.dropCalls, 2)
+	require.Condition(t, func() bool {
+		return slices.ContainsFunc(base.dropCalls, func(table string) bool { return strings.Contains(table, "orders_merge_") })
+	}, "expected orders staging cleanup, got %v", base.dropCalls)
+	require.Condition(t, func() bool {
+		return slices.ContainsFunc(base.dropCalls, func(table string) bool { return strings.Contains(table, "users_merge_") })
+	}, "expected uncertain users staging cleanup, got %v", base.dropCalls)
 }
 
 func TestDeleteInsertStrategy_Validate(t *testing.T) {
@@ -247,10 +601,33 @@ func TestDeleteInsertStrategy_Execute_RejectsUnsupportedDestinationBeforeStaging
 	}
 }
 
+func TestDeleteInsertStrategy_FailureDropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
+	job.Config.IncrementalKey = "id"
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("write failed")
+
+	err := (&DeleteInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	staging := dest.prepareCalls[1].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
+	}
+}
+
 func TestDeleteInsertStrategy_Execute_SkipsWhenNoIntervalDetected(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
 	job.Config.IncrementalKey = "id"
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable,
+		Comparison: &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeAddColumn, ColumnName: "new_column", NewColumn: schema.Column{Name: "new_column", DataType: schema.TypeInt64},
+		}}},
+	}
 
 	rec := int64RecordBatch(t, "other", []int64{1, 2, 3}, nil)
 	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: rec})
@@ -271,6 +648,9 @@ func TestDeleteInsertStrategy_Execute_SkipsWhenNoIntervalDetected(t *testing.T) 
 	if len(dest.diCalls) != 0 {
 		t.Fatalf("expected DeleteInsertTable not to be called, got %+v", dest.diCalls)
 	}
+	if len(dest.execCalls) != 1 {
+		t.Fatalf("empty delete+insert must still apply schema evolution, got %d calls", len(dest.execCalls))
+	}
 
 	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
 		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
@@ -282,6 +662,7 @@ func TestDeleteInsertStrategy_Execute_UsesAutoDetectedInterval(t *testing.T) {
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
 	job.Config.IncrementalKey = "id"
 	job.Config.LoaderFileSize = 111
+	job.Schema.Columns = append(job.Schema.Columns, schema.Column{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true})
 
 	rec := int64RecordBatch(t, "id", []int64{5, 10, 7}, map[int]bool{1: false})
 	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: rec})
@@ -310,6 +691,11 @@ func TestDeleteInsertStrategy_Execute_UsesAutoDetectedInterval(t *testing.T) {
 	}
 	if di.IncrementalKey != "id" {
 		t.Fatalf("DeleteInsertOptions.IncrementalKey = %q", di.IncrementalKey)
+	}
+	for _, column := range di.Columns {
+		if column == "_cdc_unchanged_cols" {
+			t.Fatalf("staging-only CDC column leaked into delete+insert target columns: %v", di.Columns)
+		}
 	}
 	if di.IntervalStart != int64(5) || di.IntervalEnd != int64(10) {
 		t.Fatalf("DeleteInsertOptions interval = %v..%v, want 5..10", di.IntervalStart, di.IntervalEnd)

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -15,6 +15,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/google/uuid"
 )
 
 // replaceShouldDedup reports whether deduplicated replace applies for the
@@ -24,6 +26,11 @@ func replaceShouldDedup(dest destination.Destination, primaryKeys []string) bool
 	return len(primaryKeys) > 0 &&
 		dest.SupportsMergeStrategy() &&
 		dest.GetScheme() != "clickhouse"
+}
+
+func directReplaceShouldDedup(dest destination.Destination, primaryKeys []string) bool {
+	provider, ok := dest.(destination.DirectReplaceDeduplicator)
+	return ok && provider.SupportsDirectReplaceDeduplication() && replaceShouldDedup(dest, primaryKeys)
 }
 
 func sourcePrimaryKeysSafeForReplaceFastPath(job *IngestionJob) bool {
@@ -99,10 +106,30 @@ func primaryKeyValuesMayChange(job *IngestionJob) bool {
 	if job.ColumnMasker != nil && intersects(job.Config.PrimaryKeys, job.ColumnMasker.MaskedColumns()) {
 		return true
 	}
+	if whitespaceTrimmerMayChangePrimaryKeys(job) {
+		return true
+	}
 
 	mode, err := schemaevolution.ParseContractMode(job.Config.SchemaContract)
 	if err == nil && mode == schemaevolution.ContractDiscardValue && schemaChangesTouchPrimaryKeys(job.SchemaComparison, job.Config.PrimaryKeys) {
 		return true
+	}
+	return false
+}
+
+func whitespaceTrimmerMayChangePrimaryKeys(job *IngestionJob) bool {
+	if job.WhitespaceTrimmer == nil || job.Schema == nil {
+		return false
+	}
+
+	primaryKeys := make(map[string]bool, len(job.Config.PrimaryKeys))
+	for _, key := range job.Config.PrimaryKeys {
+		primaryKeys[key] = true
+	}
+	for _, column := range job.Schema.Columns {
+		if primaryKeys[column.Name] && (column.DataType == schema.TypeString || column.DataType == schema.TypeUUID) {
+			return true
+		}
 	}
 	return false
 }
@@ -146,7 +173,7 @@ func intersects(left, right []string) bool {
 // nil primary keys, since it already carries the PK and lives in the target's
 // schema (so the swap is a same-schema atomic rename rather than a second
 // recreate+copy). Staging tables are cleaned up on error.
-func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTable, targetTable, stagingDataset, incrementalKey string, tableSchema *schema.TableSchema, primaryKeys []string, partitionBy string, clusterBy []string) (string, error) {
+func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTable, targetTable, stagingDataset, incrementalKey string, tableSchema *schema.TableSchema, primaryKeys []string, partitionBy string, clusterBy []string, skipCDCResume bool) (string, error) {
 	normalised := GenerateNormalisedStagingTableName(targetTable, stagingDataset)
 	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
 		Table:        normalised,
@@ -157,8 +184,8 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 		ClusterBy:    clusterBy,
 		ExpiresAfter: destination.ManagedStagingTTL,
 	}); err != nil {
-		if dropErr := dest.DropTable(ctx, rawTable); dropErr != nil {
-			config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
+		for _, table := range []string{rawTable, normalised} {
+			dropReplaceStagingDetached(ctx, dest, table)
 		}
 		return "", fmt.Errorf("failed to prepare normalised staging table: %w", err)
 	}
@@ -169,21 +196,23 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 		Columns:        tableSchema.ColumnNames(),
 		IncrementalKey: incrementalKey,
 		Schema:         tableSchema,
+		SkipCDCResume:  skipCDCResume,
 	}); err != nil {
 		for _, t := range []string{rawTable, normalised} {
-			if dropErr := dest.DropTable(ctx, t); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-			}
+			dropReplaceStagingDetached(ctx, dest, t)
 		}
 		return "", fmt.Errorf("failed to deduplicate staging table: %w", err)
 	}
-	if dropErr := dest.DropTable(ctx, rawTable); dropErr != nil {
-		config.Debug("[REPLACE] Warning: failed to drop raw staging table: %v", dropErr)
-	}
+	dropReplaceStagingDetached(ctx, dest, rawTable)
 	return normalised, nil
 }
 
 type ReplaceStrategy struct{}
+
+type ownedPreparedTarget struct {
+	table          string
+	ownershipToken string
+}
 
 func replaceStagingTableName(dest destination.Destination, targetTable, stagingDataset string) string {
 	policy := defaultReplaceStagingPolicy()
@@ -213,39 +242,92 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	// Check if destination supports atomic swap (staging pattern)
 	// File-based destinations like CSV, Parquet, and Blobstore write directly to target
 	useStaging := job.Destination.SupportsAtomicSwap()
+	if useStaging && job.CDCStateManager != nil {
+		capability, ok := job.Destination.(destination.CDCConditionalSwapCapable)
+		if !ok || !capability.SupportsCDCConditionalSwap() {
+			return fmt.Errorf("destination scheme %q cannot atomically fence managed CDC table replacement", job.Destination.GetScheme())
+		}
+	}
 
 	targetTable := job.Config.DestTable
+	replaceSchema := destination.DestinationTableSchema(job.Schema)
 	writeTable := targetTable
+	targetExisted := true
 	if useStaging {
 		writeTable = replaceStagingTableName(job.Destination, targetTable, job.Config.StagingDataset)
 		output.Statusf("[STRATEGY] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), writeTable)
 	} else {
 		config.Debug("[STRATEGY] Direct write to target (no staging): %s", writeTable)
+		existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+		if err != nil {
+			return fmt.Errorf("failed to inspect destination table before replace: %w", err)
+		}
+		targetExisted = existingSchema != nil
 	}
 
 	// Deduplicated replace: Load a PK-free staging table so duplicate keys can land.
-	dedup := useStaging &&
-		!sourcePrimaryKeysSafeForReplaceFastPath(job) &&
-		replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+	dedup := false
+	if !sourcePrimaryKeysSafeForReplaceFastPath(job) {
+		if useStaging {
+			dedup = replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+		} else {
+			dedup = directReplaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+		}
+	}
 	stagingPrimaryKeys := job.Config.PrimaryKeys
-	if dedup {
+	if useStaging && dedup {
 		stagingPrimaryKeys = nil
+	}
+	ownershipToken := ""
+	if !useStaging && !targetExisted {
+		if _, ok := job.Destination.(destination.OwnedTableDropper); ok {
+			ownershipToken = uuid.NewString()
+		}
 	}
 
 	prepareOpts := destination.PrepareOptions{
-		Table:       writeTable,
-		Schema:      job.Schema,
-		DropFirst:   true,
-		PrimaryKeys: stagingPrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:          writeTable,
+		Schema:         replaceSchema,
+		DropFirst:      true,
+		PrimaryKeys:    stagingPrimaryKeys,
+		PartitionBy:    job.Config.PartitionBy,
+		ClusterBy:      job.Config.ClusterBy,
+		OwnershipToken: ownershipToken,
 	}
 	if useStaging {
 		prepareOpts.ExpiresAfter = destination.ManagedStagingTTL
 	}
+	cleanupStaging := useStaging && !job.Config.KeepStaging
+	cleanupTable := writeTable
+	defer func() {
+		if cleanupStaging {
+			dropReplaceStagingDetached(ctx, job.Destination, cleanupTable)
+		}
+	}()
 
 	if err := job.Destination.PrepareTable(ctx, prepareOpts); err != nil {
+		if !useStaging && ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		}
 		return fmt.Errorf("failed to prepare table: %w", err)
+	}
+	if useStaging && job.CDCStateManager != nil {
+		if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+			Table: targetTable, Schema: replaceSchema, DropFirst: false,
+			PrimaryKeys: job.Config.PrimaryKeys, PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy,
+		}); err != nil {
+			return fmt.Errorf("failed to prepare managed replacement target: %w", err)
+		}
+	}
+	expectedIncarnation := ""
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+			return fmt.Errorf("failed to bind replacement destination before extraction: %w", err)
+		}
+		expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if expectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", targetTable)
+		}
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -275,6 +357,9 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	defer cancelRead()
 	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
+		if !useStaging {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		}
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
@@ -282,16 +367,24 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	records = transformer.Wrap(records, transformer.NewSafeTypeCaster(replaceSchema.ToArrowSchema()))
 
 	writeOpts := destination.WriteOptions{
-		Table:            writeTable,
-		Schema:           job.Schema,
-		Parallelism:      job.Config.EffectiveDestinationParallelism(),
-		StagingTable:     useStaging,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		PreStaged:        job.PreStaged,
+		Table:                  writeTable,
+		Schema:                 replaceSchema,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		Parallelism:            job.Config.EffectiveDestinationParallelism(),
+		StagingTable:           useStaging,
+		StagingBucket:          job.Config.StagingBucket,
+		LoaderFileSize:         job.Config.LoaderFileSize,
+		LoaderFileFormat:       job.Config.LoaderFileFormat,
+		PreStaged:              job.PreStaged,
+		DeduplicatePrimaryKeys: dedup && !useStaging,
+		IncrementalKey:         job.Config.IncrementalKey,
+		SkipCDCResume:          job.CDCStateManager != nil,
+	}
+	if !useStaging {
+		writeOpts.CDCExpectedIncarnation = expectedIncarnation
 	}
 	if useStaging {
 		if atomicWriter, ok := job.Destination.(destination.AtomicCommitWriter); ok && atomicWriter.SupportsAtomicCommitWrites() {
@@ -301,18 +394,18 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 
 	var countedRows atomic.Int64
 	if !writeOpts.AtomicCommit && writeOpts.PreStaged == nil {
-		records = wrapWithRowCount(records, &countedRows)
+		records = wrapWithRowCount(readCtx, records, &countedRows)
 	}
 
-	if err := job.Destination.WriteParallel(ctx, records, writeOpts); err != nil {
+	if err := job.Destination.WriteParallel(readCtx, records, writeOpts); err != nil {
 		cancelRead()
-		drainAndReleaseUntil(records, streamAbortDrainTimeout)
-		if useStaging {
-			if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-			}
-		}
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write data: %w", err)
+	}
+	if !useStaging && job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+			return fmt.Errorf("failed to bind replaced destination table: %w", err)
+		}
 	}
 
 	// Only swap tables if using staging pattern
@@ -325,9 +418,6 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 				}
 				if expectedRows > 0 {
 					if err := verifier.WaitForExactRowCount(ctx, writeTable, expectedRows); err != nil {
-						if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {
-							config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-						}
 						return fmt.Errorf("failed to verify staging table row count: %w", err)
 					}
 				}
@@ -336,42 +426,127 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		swapTable := writeTable
 		swapPrimaryKeys := job.Config.PrimaryKeys
 		if dedup {
+			cleanupStaging = false
 			normalised, err := deduplicateStaging(ctx, job.Destination, writeTable, targetTable,
-				job.Config.StagingDataset, job.Config.IncrementalKey, job.Schema,
-				job.Config.PrimaryKeys, job.Config.PartitionBy, job.Config.ClusterBy)
+				job.Config.StagingDataset, job.Config.IncrementalKey, replaceSchema,
+				job.Config.PrimaryKeys, job.Config.PartitionBy, job.Config.ClusterBy, job.CDCStateManager != nil)
 			if err != nil {
 				return err
 			}
 			swapTable = normalised
 			swapPrimaryKeys = nil
+			cleanupTable = normalised
+			cleanupStaging = !job.Config.KeepStaging
+		}
+		publishedIncarnation := ""
+		if job.CDCStateManager != nil {
+			publishedIncarnation, err = job.CDCStateManager.DestinationIncarnationForPublication(ctx, swapTable)
+			if err != nil {
+				return fmt.Errorf("failed to identify replacement table before publication: %w", err)
+			}
 		}
 
 		if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-			StagingTable:   swapTable,
-			TargetTable:    targetTable,
-			PrimaryKeys:    swapPrimaryKeys,
-			IncrementalKey: job.Config.IncrementalKey,
-			Schema:         job.Schema,
+			StagingTable:                  swapTable,
+			TargetTable:                   targetTable,
+			PrimaryKeys:                   swapPrimaryKeys,
+			IncrementalKey:                job.Config.IncrementalKey,
+			Schema:                        replaceSchema,
+			CDCExpectedIncarnation:        expectedIncarnation,
+			CDCExpectedStagingIncarnation: publishedIncarnation,
 		}); err != nil {
-			if dropErr := job.Destination.DropTable(ctx, swapTable); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-			}
 			return fmt.Errorf("failed to swap tables: %w", err)
 		}
+		if job.CDCStateManager != nil {
+			if err := job.CDCStateManager.BindPublishedDestinationIncarnation(ctx, job.Config.SourceTable, targetTable, expectedIncarnation, publishedIncarnation); err != nil {
+				return fmt.Errorf("failed to bind replaced destination table: %w", err)
+			}
+		}
+		cleanupStaging = false
 	}
 
 	return nil
 }
 
-func wrapWithRowCount(records <-chan source.RecordBatchResult, totalRows *atomic.Int64) <-chan source.RecordBatchResult {
+func dropReplaceStagingDetached(ctx context.Context, dest destination.Destination, table string) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[REPLACE] Warning: failed to drop staging table %s: %v", table, err)
+	}
+}
+
+func cleanupFailedDirectReplace(ctx context.Context, dest destination.Destination, table string, createdByRun bool) {
+	if !createdByRun {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[REPLACE] Warning: failed to remove target created by unsuccessful replace: %v", err)
+	}
+}
+
+func newTargetOwnershipToken(dest destination.Destination, targetExisted bool) string {
+	if targetExisted {
+		return ""
+	}
+	if _, ok := dest.(destination.OwnedTableDropper); ok {
+		return uuid.NewString()
+	}
+	return ""
+}
+
+func cleanupFailedOwnedDirectReplace(
+	ctx context.Context,
+	dest destination.Destination,
+	table string,
+	createdByRun bool,
+	ownershipToken string,
+) {
+	if !createdByRun || ownershipToken == "" {
+		return
+	}
+	dropper, ok := dest.(destination.OwnedTableDropper)
+	if !ok {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dropper.DropTableIfOwned(cleanupCtx, table, ownershipToken); err != nil {
+		config.Debug("[REPLACE] Warning: refused or failed owned target cleanup: %v", err)
+	}
+}
+
+func wrapWithRowCount(ctx context.Context, records <-chan source.RecordBatchResult, totalRows *atomic.Int64) <-chan source.RecordBatchResult {
 	out := make(chan source.RecordBatchResult, cap(records))
+	drainTimeout := canceledSourceDrainTimeout
 	go func() {
 		defer close(out)
-		for result := range records {
+		for {
+			var result source.RecordBatchResult
+			var ok bool
+			select {
+			case result, ok = <-records:
+				if !ok {
+					return
+				}
+			case <-ctx.Done():
+				<-startBoundedRecordDrain(records, drainTimeout)
+				return
+			}
 			if result.Err == nil && result.Batch != nil {
 				totalRows.Add(result.Batch.NumRows())
 			}
-			out <- result
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				<-startBoundedRecordDrain(records, drainTimeout)
+				return
+			}
 		}
 	}()
 	return out
@@ -384,10 +559,18 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 	}
 
 	useStaging := job.Destination.SupportsAtomicSwap()
+	if useStaging && job.CDCStateManager != nil {
+		capability, ok := job.Destination.(destination.CDCConditionalSwapCapable)
+		if !ok || !capability.SupportsCDCConditionalSwap() {
+			return fmt.Errorf("destination scheme %q cannot atomically fence managed CDC table replacement", job.Destination.GetScheme())
+		}
+	}
 	config.Debug("[STRATEGY] Multi-table replace with %d tables, staging=%v", len(job.Tables), useStaging)
 
 	stagingTables := make(map[string]string)
 	tableConfigs := make(map[string]destination.TableWriteConfig)
+	expectedIncarnations := make(map[string]string)
+	createdDirectTargets := make(map[string]ownedPreparedTarget)
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
@@ -399,31 +582,89 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 			defer wg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
 			writeTable := destTable
 			if useStaging {
 				writeTable = replaceStagingTableName(job.Destination, destTable, job.Config.StagingDataset)
 			}
+			targetExisted := true
+			if !useStaging {
+				existingSchema, err := job.Destination.GetTableSchema(ctx, destTable)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to inspect destination table %s before replace: %w", ti.Name, err)
+					return
+				}
+				targetExisted = existingSchema != nil
+			}
+			ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+
+			dedup := replaceShouldDedup(job.Destination, ti.PrimaryKeys)
+			if !useStaging {
+				dedup = directReplaceShouldDedup(job.Destination, ti.PrimaryKeys)
+			}
 
 			prepareOpts := destination.PrepareOptions{
-				Table:     writeTable,
-				Schema:    ti.Schema,
-				DropFirst: true,
+				Table:          writeTable,
+				Schema:         writeSchema,
+				DropFirst:      true,
+				PrimaryKeys:    ti.PrimaryKeys,
+				OwnershipToken: ownershipToken,
+			}
+			if useStaging && dedup {
+				prepareOpts.PrimaryKeys = nil
 			}
 			if useStaging {
 				prepareOpts.ExpiresAfter = destination.ManagedStagingTTL
+				mu.Lock()
+				stagingTables[ti.Name] = writeTable
+				mu.Unlock()
+			}
+			if !useStaging && !targetExisted && ownershipToken != "" {
+				mu.Lock()
+				createdDirectTargets[ti.Name] = ownedPreparedTarget{table: writeTable, ownershipToken: ownershipToken}
+				mu.Unlock()
 			}
 
 			if err := job.Destination.PrepareTable(ctx, prepareOpts); err != nil {
 				errChan <- fmt.Errorf("failed to prepare table %s: %w", ti.Name, err)
 				return
 			}
+			if useStaging && job.CDCStateManager != nil {
+				if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+					Table: destTable, Schema: writeSchema, DropFirst: false, PrimaryKeys: ti.PrimaryKeys,
+				}); err != nil {
+					errChan <- fmt.Errorf("failed to prepare managed replacement target %s: %w", ti.Name, err)
+					return
+				}
+			}
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				if err := job.CDCStateManager.BindDestinationIncarnation(ctx, ti.Name, destTable); err != nil {
+					errChan <- fmt.Errorf("failed to bind replacement destination table %s before extraction: %w", ti.Name, err)
+					return
+				}
+				expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(ti.Name)
+				if expectedIncarnation == "" {
+					errChan <- fmt.Errorf("managed CDC destination table %s has no bound physical incarnation", ti.Name)
+					return
+				}
+			}
 
 			mu.Lock()
-			stagingTables[ti.Name] = writeTable
-			tableConfigs[ti.Name] = destination.TableWriteConfig{
-				DestTable: writeTable,
-				Schema:    ti.Schema,
+			if !useStaging && !targetExisted && ownershipToken == "" {
+				createdDirectTargets[ti.Name] = ownedPreparedTarget{table: writeTable}
 			}
+			tableConfigs[ti.Name] = destination.TableWriteConfig{
+				DestTable:              writeTable,
+				Schema:                 writeSchema,
+				PrimaryKeys:            ti.PrimaryKeys,
+				DeduplicatePrimaryKeys: !useStaging && dedup,
+				IncrementalKey:         writeSchema.IncrementalKey,
+				CDCMode:                hasCDCColumns(writeSchema),
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: expectedIncarnation,
+			}
+			expectedIncarnations[ti.Name] = expectedIncarnation
 			mu.Unlock()
 		}(tableInfo)
 	}
@@ -432,6 +673,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 	close(errChan)
 
 	for err := range errChan {
+		cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 		return err
 	}
 
@@ -454,56 +696,108 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 		CDCResumeLSNs: job.CDCResumeLSNs,
 	})
 	if err != nil {
+		cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 		return fmt.Errorf("failed to read from multi-table source: %w", err)
 	}
 
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	if !useStaging {
+		// Once writers are launched, any error can be a lost response after a
+		// durable direct replacement. Ownership alone cannot distinguish that
+		// from a pre-commit failure, so preserve all attempted targets.
+		createdDirectTargets = nil
+	}
 
-	if err := multitable.Write(ctx, job.Destination, records, destination.MultiTableWriteOptions{
-		TableConfigs:     tableConfigs,
-		Parallelism:      job.Config.EffectiveDestinationParallelism(),
-		StagingTable:     useStaging,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		CancelSource:     cancelRead,
+	if err := multitable.Write(readCtx, job.Destination, records, destination.MultiTableWriteOptions{
+		TableConfigs:       tableConfigs,
+		Parallelism:        job.Config.EffectiveDestinationParallelism(),
+		StagingTable:       useStaging,
+		StagingBucket:      job.Config.StagingBucket,
+		LoaderFileSize:     job.Config.LoaderFileSize,
+		LoaderFileFormat:   job.Config.LoaderFileFormat,
+		CancelSource:       cancelRead,
+		CancelDrainTimeout: canceledSourceDrainTimeout,
 	}); err != nil {
-		for _, stagingTable := range stagingTables {
-			if dropErr := job.Destination.DropTable(ctx, stagingTable); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table %s: %v", stagingTable, dropErr)
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
+		return fmt.Errorf("failed to write multi-table data: %w", err)
+	}
+	if !useStaging && job.CDCStateManager != nil {
+		for _, tableInfo := range job.Tables {
+			if err := job.CDCStateManager.BindDestinationIncarnation(ctx, tableInfo.Name, job.GetDestTableName(tableInfo.Name)); err != nil {
+				return fmt.Errorf("failed to bind replaced destination table %s: %w", tableInfo.Name, err)
 			}
 		}
-		return fmt.Errorf("failed to write multi-table data: %w", err)
 	}
 
 	if useStaging {
 		for _, tableInfo := range job.Tables {
+			writeSchema := job.WriteSchemaFor(tableInfo.Name, tableInfo.Schema)
 			destTable := job.GetDestTableName(tableInfo.Name)
 			stagingTable := stagingTables[tableInfo.Name]
 			swapTable := stagingTable
 			swapPrimaryKeys := tableInfo.PrimaryKeys
 			if replaceShouldDedup(job.Destination, tableInfo.PrimaryKeys) {
 				normalised, err := deduplicateStaging(ctx, job.Destination, stagingTable, destTable,
-					job.Config.StagingDataset, tableInfo.Schema.IncrementalKey, tableInfo.Schema, tableInfo.PrimaryKeys, "", nil)
+					job.Config.StagingDataset, writeSchema.IncrementalKey, writeSchema, tableInfo.PrimaryKeys, "", nil, job.CDCStateManager != nil)
 				if err != nil {
+					cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 					return fmt.Errorf("failed to deduplicate table %s: %w", tableInfo.Name, err)
 				}
 				swapTable = normalised
 				swapPrimaryKeys = nil
+				stagingTables[tableInfo.Name] = normalised
+			}
+			publishedIncarnation := ""
+			if job.CDCStateManager != nil {
+				publishedIncarnation, err = job.CDCStateManager.DestinationIncarnationForPublication(ctx, swapTable)
+				if err != nil {
+					cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
+					return fmt.Errorf("failed to identify replacement table %s before publication: %w", tableInfo.Name, err)
+				}
 			}
 
 			if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-				StagingTable: swapTable,
-				TargetTable:  destTable,
-				PrimaryKeys:  swapPrimaryKeys,
-				Schema:       tableInfo.Schema,
+				StagingTable:                  swapTable,
+				TargetTable:                   destTable,
+				PrimaryKeys:                   swapPrimaryKeys,
+				Schema:                        writeSchema,
+				CDCExpectedIncarnation:        expectedIncarnations[tableInfo.Name],
+				CDCExpectedStagingIncarnation: publishedIncarnation,
 			}); err != nil {
+				cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 				return fmt.Errorf("failed to swap table %s: %w", tableInfo.Name, err)
+			}
+			delete(stagingTables, tableInfo.Name)
+			if job.CDCStateManager != nil {
+				if err := job.CDCStateManager.BindPublishedDestinationIncarnation(ctx, tableInfo.Name, destTable, expectedIncarnations[tableInfo.Name], publishedIncarnation); err != nil {
+					cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
+					return fmt.Errorf("failed to bind replaced destination table %s: %w", tableInfo.Name, err)
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+func cleanupFailedMultiTableReplace(
+	ctx context.Context,
+	dest destination.Destination,
+	useStaging bool,
+	stagingTables map[string]string,
+	createdDirectTargets map[string]ownedPreparedTarget,
+) {
+	if useStaging {
+		for _, table := range stagingTables {
+			cleanupFailedDirectReplace(ctx, dest, table, true)
+		}
+		return
+	}
+	for _, target := range createdDirectTargets {
+		cleanupFailedOwnedDirectReplace(ctx, dest, target.table, true, target.ownershipToken)
+	}
 }

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -65,6 +65,9 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 	}); err != nil {
 		return fmt.Errorf("failed to prepare destination table: %w", err)
 	}
+	if !job.Config.KeepStaging {
+		defer dropManagedStagingDetached(ctx, job.Destination, stagingTable, "SCD2")
+	}
 
 	// Create staging table with same extended schema
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
@@ -152,19 +155,12 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 		StagingTable:   stagingTable,
 		TargetTable:    job.Config.DestTable,
 		PrimaryKeys:    job.Config.PrimaryKeys,
-		Columns:        job.Schema.ColumnNames(),
+		Columns:        destination.DestinationColumns(job.Schema.ColumnNames()),
 		IncrementalKey: job.Config.IncrementalKey,
 		Timestamp:      processTimestamp,
 		Schema:         job.Schema,
 	}); err != nil {
 		return fmt.Errorf("failed to perform SCD2 merge: %w", err)
-	}
-
-	// Drop staging table (skip when KeepStaging is set for test inspection).
-	if !job.Config.KeepStaging {
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[SCD2] Warning: failed to drop staging table: %v", err)
-		}
 	}
 
 	return nil

--- a/pkg/strategy/scd2_test.go
+++ b/pkg/strategy/scd2_test.go
@@ -55,6 +55,7 @@ func TestSCD2Strategy_Execute_BasicFlow(t *testing.T) {
 		Columns: []schema.Column{
 			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
 			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true},
 		},
 		PrimaryKeys: []string{"id"},
 	}
@@ -98,6 +99,8 @@ func TestSCD2Strategy_Execute_BasicFlow(t *testing.T) {
 
 	// Should have called SCD2Table
 	assert.Contains(t, dest.calls, "SCD2Table")
+	require.Len(t, dest.scdCalls, 1)
+	assert.NotContains(t, dest.scdCalls[0].Columns, "_cdc_unchanged_cols")
 
 	// Should have called DropTable for staging cleanup
 	assert.Contains(t, dest.calls, "DropTable")
@@ -113,6 +116,19 @@ func TestSCD2Strategy_RejectsCDCBeforeDestinationOrSourceWork(t *testing.T) {
 	require.Empty(t, dest.prepareCalls)
 	require.Empty(t, dest.writeCalls)
 	require.False(t, src.readCalled)
+}
+
+func TestSCD2LostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.PrimaryKeys = []string{"id"}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&SCD2Strategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
 }
 
 func TestSCD2Strategy_ExtendSchemaWithSCDColumns(t *testing.T) {

--- a/pkg/strategy/snapshot_reset_test.go
+++ b/pkg/strategy/snapshot_reset_test.go
@@ -1,0 +1,3329 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type atomicSnapshotDestination struct {
+	*fakeDestination
+	atomicMu                sync.Mutex
+	begins                  []destination.AtomicSnapshotOptions
+	writes                  []destination.WriteOptions
+	publishes               []destination.AtomicSnapshotOptions
+	evolves                 []destination.AtomicSnapshotOptions
+	aborts                  []destination.AtomicSnapshotOptions
+	beginErr                error
+	writeErr                error
+	preparedOwnershipTokens []string
+	ownedDropTokens         []string
+	ownedDropErr            error
+	mergeErr                error
+	mergeRows               []int64
+	mergeNulls              []int
+	writeTypes              []arrow.DataType
+	writeNulls              []int
+	writeRows               []int64
+}
+
+type unownedAtomicSnapshotDestination struct {
+	*fakeDestination
+	beginErr error
+}
+
+type immediateFailAtomicMultiDestination struct{ *atomicSnapshotDestination }
+
+type leaseLossAfterAtomicWriteDestination struct {
+	*atomicSnapshotDestination
+	loseLease func()
+}
+
+type failNthPublishAtomicDestination struct {
+	*atomicSnapshotDestination
+	failAt int
+	calls  int
+}
+
+type ambiguousPublishAtomicDestination struct {
+	*atomicSnapshotDestination
+	publishCalls int
+}
+
+type incarnationFencedAtomicDestination struct {
+	*incarnationTrackingAtomicSnapshotDestination
+}
+
+type externallyReplacedAfterAtomicPublishDestination struct {
+	*incarnationTrackingAtomicSnapshotDestination
+	externalIncarnation string
+}
+
+type ambiguousManagedAtomicSnapshotDestination struct {
+	*incarnationTrackingAtomicSnapshotDestination
+	publishMu       sync.Mutex
+	attempts        []string
+	options         []destination.AtomicSnapshotOptions
+	lostResponseFor string
+}
+
+type beforeReadSourceTable struct {
+	source.SourceTable
+	beforeRead func()
+}
+
+type beforeReadAllSnapshotSource struct {
+	*snapshotResetMultiSource
+	beforeRead func()
+}
+
+type trackingMultiTableSource struct {
+	*announcingMultiTableSource
+	readCalled bool
+}
+
+type lateDiscoveryFilteringSource struct {
+	*announcingMultiTableSource
+	late         source.SourceTableInfo
+	includedLate bool
+}
+
+func (s *lateDiscoveryFilteringSource) ReadAll(_ context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	s.readOpts = opts
+	known := make(map[string]struct{}, len(opts.KnownTables))
+	for _, table := range opts.KnownTables {
+		known[table] = struct{}{}
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	for _, table := range s.tables {
+		records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	}
+	if _, frozen := known[s.late.Name]; !frozen && len(opts.KnownTables) == 0 {
+		s.includedLate = true
+		records <- source.RecordBatchResult{TableName: s.late.Name, Truncate: true}
+	}
+	close(records)
+	return records, nil
+}
+
+func (d *failNthPublishAtomicDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	d.calls++
+	if d.calls == d.failAt {
+		return "", errors.New("injected multi-table publish failure")
+	}
+	return d.atomicSnapshotDestination.PublishAtomicSnapshot(context.Background(), opts)
+}
+
+func (d *leaseLossAfterAtomicWriteDestination) WriteAtomicSnapshot(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	if err := d.atomicSnapshotDestination.WriteAtomicSnapshot(ctx, records, opts); err != nil {
+		return err
+	}
+	d.loseLease()
+	return nil
+}
+
+func (d *ambiguousPublishAtomicDestination) PublishAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	incarnation, err := d.atomicSnapshotDestination.PublishAtomicSnapshot(ctx, opts)
+	if err != nil {
+		return "", err
+	}
+	d.atomicMu.Lock()
+	d.publishCalls++
+	call := d.publishCalls
+	d.atomicMu.Unlock()
+	if call == 1 {
+		return "", errors.New("injected lost publish response")
+	}
+	return incarnation, nil
+}
+
+func (d *incarnationFencedAtomicDestination) MergeRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	_ destination.WriteOptions,
+	opts destination.MergeOptions,
+) error {
+	drainAndRelease(records)
+	d.stateMu.Lock()
+	current := d.incarnations[opts.TargetTable]
+	d.stateMu.Unlock()
+	d.mu.Lock()
+	d.mergeCalls = append(d.mergeCalls, opts)
+	d.mu.Unlock()
+	if opts.CDCExpectedIncarnation == "" || current != opts.CDCExpectedIncarnation {
+		return fmt.Errorf("destination table %q physical incarnation changed", opts.TargetTable)
+	}
+	return nil
+}
+
+func (s *beforeReadSourceTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	s.beforeRead()
+	return s.SourceTable.Read(ctx, opts)
+}
+
+func (s *beforeReadAllSnapshotSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	s.beforeRead()
+	return s.snapshotResetMultiSource.ReadAll(ctx, opts)
+}
+
+func (s *trackingMultiTableSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	s.readCalled = true
+	return s.announcingMultiTableSource.ReadAll(ctx, opts)
+}
+
+func (*immediateFailAtomicMultiDestination) MergeRecords(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+	destination.MergeOptions,
+) error {
+	return errors.New("direct worker failed before draining")
+}
+
+func (d *unownedAtomicSnapshotDestination) BeginAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return d.beginErr
+}
+
+func (*unownedAtomicSnapshotDestination) EvolveAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return nil
+}
+
+func (*unownedAtomicSnapshotDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions) error {
+	drainAndRelease(records)
+	return nil
+}
+
+func (*unownedAtomicSnapshotDestination) PublishAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) (string, error) {
+	return "", nil
+}
+
+func (*unownedAtomicSnapshotDestination) MergeRecords(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions, _ destination.MergeOptions) error {
+	drainAndRelease(records)
+	return nil
+}
+
+type snapshotReplacementTrackingDestination struct {
+	*atomicSnapshotDestination
+	rowsMu  sync.Mutex
+	visible map[int64]struct{}
+	staged  map[string][]int64
+}
+
+func (d *snapshotReplacementTrackingDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	var rows []int64
+	for result := range records {
+		if result.Batch != nil {
+			values := result.Batch.Column(0).(*array.Int64)
+			for i := 0; i < values.Len(); i++ {
+				if !values.IsNull(i) {
+					rows = append(rows, values.Value(i))
+				}
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.rowsMu.Lock()
+	d.staged[opts.AtomicSnapshotAttemptID] = rows
+	d.rowsMu.Unlock()
+	return nil
+}
+
+func (d *snapshotReplacementTrackingDestination) PublishAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	incarnation, err := d.atomicSnapshotDestination.PublishAtomicSnapshot(ctx, opts)
+	if err != nil {
+		return "", err
+	}
+	d.rowsMu.Lock()
+	d.visible = make(map[int64]struct{}, len(d.staged[opts.AttemptID]))
+	for _, id := range d.staged[opts.AttemptID] {
+		d.visible[id] = struct{}{}
+	}
+	d.rowsMu.Unlock()
+	return incarnation, nil
+}
+
+type incarnationTrackingAtomicSnapshotDestination struct {
+	*cdcStateDestination
+	publishedIncarnation string
+	incarnationMu        sync.Mutex
+	incarnationReads     int
+	begunOpts            []destination.AtomicSnapshotOptions
+	evolvedOpts          []destination.AtomicSnapshotOptions
+	writtenOpts          []destination.WriteOptions
+	publishedOpts        []destination.AtomicSnapshotOptions
+	abortedOpts          []destination.AtomicSnapshotOptions
+	discardedOpts        []destination.AtomicSnapshotOptions
+}
+
+type idempotentIncarnationTrackingAtomicSnapshotDestination struct {
+	*incarnationTrackingAtomicSnapshotDestination
+	tokenMu         sync.Mutex
+	committedTokens map[source.DurableID]struct{}
+}
+
+func (*idempotentIncarnationTrackingAtomicSnapshotDestination) SupportsIdempotentCommitTokenWrites() bool {
+	return true
+}
+
+func (d *idempotentIncarnationTrackingAtomicSnapshotDestination) WriteParallel(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.tokenMu.Lock()
+	defer d.tokenMu.Unlock()
+	if d.committedTokens == nil {
+		d.committedTokens = make(map[source.DurableID]struct{})
+	}
+	_, duplicate := d.committedTokens[opts.CommitToken]
+	if opts.CommitToken != "" && duplicate {
+		drainAndRelease(records)
+		return nil
+	}
+	if err := d.cdcStateDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	if opts.CommitToken != "" {
+		d.committedTokens[opts.CommitToken] = struct{}{}
+	}
+	return nil
+}
+
+func (*incarnationTrackingAtomicSnapshotDestination) MergeRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	_ destination.WriteOptions,
+	_ destination.MergeOptions,
+) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) BeginAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.incarnationMu.Lock()
+	d.begunOpts = append(d.begunOpts, opts)
+	d.incarnationMu.Unlock()
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) AbortAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.incarnationMu.Lock()
+	d.abortedOpts = append(d.abortedOpts, opts)
+	d.incarnationMu.Unlock()
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) DiscardAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.incarnationMu.Lock()
+	d.discardedOpts = append(d.discardedOpts, opts)
+	d.incarnationMu.Unlock()
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) EvolveAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.incarnationMu.Lock()
+	d.evolvedOpts = append(d.evolvedOpts, opts)
+	d.incarnationMu.Unlock()
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	incarnation, exists, err := d.cdcStateDestination.CDCTargetIncarnation(ctx, table)
+	d.incarnationMu.Lock()
+	d.incarnationReads++
+	d.incarnationMu.Unlock()
+	return incarnation, exists, err
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) WriteAtomicSnapshot(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.incarnationMu.Lock()
+	d.writtenOpts = append(d.writtenOpts, opts)
+	d.incarnationMu.Unlock()
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	d.stateMu.Lock()
+	current := d.incarnations[opts.Table]
+	if current == "" {
+		current = "incarnation:" + opts.Table
+	}
+	if opts.CDCExpectedIncarnation != "" && current != opts.CDCExpectedIncarnation {
+		d.stateMu.Unlock()
+		return "", fmt.Errorf("destination table %q physical incarnation changed before atomic publication", opts.Table)
+	}
+	d.incarnations[opts.Table] = d.publishedIncarnation
+	d.stateMu.Unlock()
+	d.incarnationMu.Lock()
+	d.publishedOpts = append(d.publishedOpts, opts)
+	d.incarnationMu.Unlock()
+	return d.publishedIncarnation, nil
+}
+
+func (d *externallyReplacedAfterAtomicPublishDestination) PublishAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	published, err := d.incarnationTrackingAtomicSnapshotDestination.PublishAtomicSnapshot(ctx, opts)
+	if err != nil {
+		return "", err
+	}
+	d.stateMu.Lock()
+	d.incarnations[opts.Table] = d.externalIncarnation
+	d.stateMu.Unlock()
+	return published, nil
+}
+
+func (d *ambiguousManagedAtomicSnapshotDestination) PublishAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	d.publishMu.Lock()
+	d.attempts = append(d.attempts, opts.AttemptID)
+	d.options = append(d.options, opts)
+	first := d.lostResponseFor == ""
+	if first {
+		d.lostResponseFor = opts.AttemptID
+	}
+	retryingLost := opts.AttemptID == d.lostResponseFor
+	d.publishMu.Unlock()
+
+	if first {
+		if _, err := d.incarnationTrackingAtomicSnapshotDestination.PublishAtomicSnapshot(ctx, opts); err != nil {
+			return "", err
+		}
+		return "", errors.New("injected lost atomic publication response")
+	}
+	if retryingLost {
+		return d.publishedIncarnation, nil
+	}
+	return d.incarnationTrackingAtomicSnapshotDestination.PublishAtomicSnapshot(ctx, opts)
+}
+
+func (d *atomicSnapshotDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	d.atomicMu.Lock()
+	d.preparedOwnershipTokens = append(d.preparedOwnershipTokens, opts.OwnershipToken)
+	d.atomicMu.Unlock()
+	return d.fakeDestination.PrepareTable(ctx, opts)
+}
+
+func (d *atomicSnapshotDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.ownedDropTokens = append(d.ownedDropTokens, token)
+	return d.ownedDropErr
+}
+
+func (*atomicSnapshotDestination) CDCTargetIncarnation(context.Context, string) (string, bool, error) {
+	return "target-v1", true, nil
+}
+
+func (d *atomicSnapshotDestination) AbortAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.aborts = append(d.aborts, opts)
+	return nil
+}
+
+func (d *atomicSnapshotDestination) MergeRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	_ destination.WriteOptions,
+	opts destination.MergeOptions,
+) error {
+	var rows int64
+	var nulls int
+	for result := range records {
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			if result.Batch.NumCols() > 1 {
+				nulls += result.Batch.Column(1).NullN()
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.mu.Lock()
+	d.mergeCalls = append(d.mergeCalls, opts)
+	d.mu.Unlock()
+	d.atomicMu.Lock()
+	d.mergeRows = append(d.mergeRows, rows)
+	d.mergeNulls = append(d.mergeNulls, nulls)
+	d.atomicMu.Unlock()
+	return d.mergeErr
+}
+
+type snapshotResetSourceTable struct{ *fakeSourceTable }
+
+func (*snapshotResetSourceTable) EmitsSnapshotResets() bool { return true }
+
+type snapshotResetMultiSource struct{ *announcingMultiTableSource }
+
+func (*snapshotResetMultiSource) EmitsSnapshotResets() bool { return true }
+
+type truncateCapableFakeDestination struct{ *fakeDestination }
+
+func (d *truncateCapableFakeDestination) TruncateTable(_ context.Context, table string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.truncateCalls = append(d.truncateCalls, table)
+	return d.truncateErr
+}
+
+func snapshotStateToken(table, position string) source.CDCStateCommitToken {
+	return source.CDCStateCommitToken{SnapshotPositions: map[string]string{table: position}}
+}
+
+func testCDCSchema(base *schema.TableSchema) *schema.TableSchema {
+	result := *base
+	result.Columns = append([]schema.Column(nil), base.Columns...)
+	result.PrimaryKeys = append([]string(nil), base.PrimaryKeys...)
+	result.Columns = append(
+		result.Columns,
+		schema.Column{Name: destination.CDCLSNColumn, DataType: schema.TypeString},
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		schema.Column{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+		schema.Column{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString},
+	)
+	return &result
+}
+
+func (l *flushLoop) handleSnapshotReset(ctx context.Context, table string) error {
+	return l.handleResult(ctx, source.RecordBatchResult{TableName: table, Truncate: true})
+}
+
+func (d *atomicSnapshotDestination) BeginAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.begins = append(d.begins, opts)
+	return d.beginErr
+}
+
+func TestStreamingAtomicSnapshotBeginFailureAbortsOwnedAttempt(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}, beginErr: errors.New("begin failed after stage creation")}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+
+	err := loop.handleSnapshotReset(context.Background(), "public.events")
+	require.Error(t, err)
+	loop.cleanup(context.Background())
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.aborts, 1)
+	require.Equal(t, dest.begins[0].AttemptID, dest.aborts[0].AttemptID)
+}
+
+func TestStreamingAppendAtomicPreparationDoesNotMutateExistingTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": tableSchema},
+	}}
+	st := &streamTableState{destTable: "lake.events", schema: tableSchema, isCDC: true}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyAppend})
+
+	require.NoError(t, executor.prepareTable(t.Context(), dest, &config.IngestConfig{}, st))
+	require.Empty(t, dest.prepareCalls)
+	require.False(t, st.targetCreatedByRun)
+}
+
+func TestStreamingAppendAtomicPreparationCleansOwnedNewTargetOnFailure(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := &streamTableState{destTable: "lake.events", schema: tableSchema, isCDC: true}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyAppend})
+
+	require.NoError(t, executor.prepareTable(t.Context(), dest, &config.IngestConfig{}, st))
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyAppend}, map[string]*streamTableState{"public.events": st})
+	loop.cleanup(t.Context())
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+}
+
+func TestStreamingRepeatedSnapshotResetAbortsPreviousAttempt(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	firstAttempt := st.snapshotAttemptID
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	require.NotEqual(t, firstAttempt, st.snapshotAttemptID)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.aborts, 1)
+	require.Equal(t, firstAttempt, dest.aborts[0].AttemptID)
+	require.Len(t, dest.begins, 2)
+}
+
+func TestStreamingAtomicRefreshRebuildsDiscardValueTransformer(t *testing.T) {
+	current := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": current},
+	}}
+	st := &streamTableState{destTable: "lake.events", schema: current, primaryKeys: []string{"id"}, isCDC: true}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.cfg.SchemaContract = "discard_value"
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	refreshed := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	require.NoError(t, loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: refreshed, PrimaryKeys: []string{"id"},
+	}, st))
+	require.NotNil(t, st.schemaAligner)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, st.schemaAligner.OutputSchema(nil).Field(1).Type))
+	id := array.NewInt64Builder(memory.DefaultAllocator)
+	value := array.NewStringBuilder(memory.DefaultAllocator)
+	id.Append(1)
+	value.Append("not-an-integer")
+	idArray, valueArray := id.NewArray(), value.NewArray()
+	id.Release()
+	value.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "value", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: batch,
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.writeTypes, 1)
+	require.Truef(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.writeTypes[0]), "got type %s", dest.writeTypes[0])
+	require.Equal(t, []int{1}, dest.writeNulls)
+	require.Equal(t, schema.TypeInt64, dest.writes[0].Schema.Columns[1].DataType)
+}
+
+func TestBatchSnapshotMergePreservesTargetOnSourceFailure(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	snapshotSource := &snapshotResetSourceTable{fakeSourceTable: src}
+	job.Table = snapshotSource
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{Err: errors.New("snapshot extraction failed")}
+	close(records)
+	src.readCh = records
+
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	require.Empty(t, dest.truncateCalls)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.publishes)
+	require.Len(t, dest.aborts, 1)
+}
+
+func TestBatchSnapshotFailureConditionallyRemovesOnlyOwnedNewTarget(t *testing.T) {
+	dest := &atomicSnapshotDestination{
+		fakeDestination: &fakeDestination{},
+		writeErr:        errors.New("snapshot staging failed after replacement owner appeared"),
+		ownedDropErr:    errors.New("ownership changed"),
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+	)
+
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.dropCalls, "unconditional cleanup must not delete a replacement owner")
+	require.Empty(t, dest.publishes)
+	require.Len(t, dest.aborts, 1)
+}
+
+func TestBatchSnapshotLostPrepareResponseCleansOwnedTarget(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareHook: func(destination.PrepareOptions) error { return errors.New("prepare response lost after create") },
+	}}
+	job, _, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: job.Table.(*fakeSourceTable)}
+
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(context.Background(), job), "prepare response lost")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+}
+
+func TestBatchEmptySnapshotPublishesBatchlessDurablePosition(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/900"}
+	close(records)
+	src.readCh = records
+
+	require.NoError(t, (&MergeStrategy{}).Execute(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.publishes[0].AttemptID), dest.publishes[0].CommitToken)
+	require.Equal(t, "0/900", dest.publishes[0].CDCResumeLSN)
+}
+
+func TestAtomicSnapshotBeginFailureDrainsUnreadArrowBatches(t *testing.T) {
+	for _, strategyName := range []string{"merge", "append"} {
+		t.Run(strategyName, func(t *testing.T) {
+			pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+			previousAllocator := memory.DefaultAllocator
+			memory.DefaultAllocator = pool
+			t.Cleanup(func() {
+				memory.DefaultAllocator = previousAllocator
+				pool.AssertSize(t, 0)
+			})
+
+			dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}, beginErr: errors.New("begin failed")}
+			job, src, _ := minimalJob()
+			job.Destination = dest
+			job.Schema = testCDCSchema(job.Schema)
+			job.SourceSchema = job.Schema
+			job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+			src.readCh = mustClosedRecords(
+				source.RecordBatchResult{Truncate: true},
+				source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+			)
+
+			var err error
+			if strategyName == "merge" {
+				err = (&MergeStrategy{}).Execute(t.Context(), job)
+			} else {
+				job.CDCStateManager = &CDCStateManager{
+					dest: dest, incarnation: dest, connectorID: "test", runID: "00000000000000000000000000000001",
+					started: true, generation: 1, runs: map[string]struct{}{}, states: map[cdcStateKey]reducedCDCState{},
+					destTables:          map[string]string{job.Config.SourceTable: job.Config.DestTable},
+					currentIncarnations: map[string]string{}, currentSchemas: map[string]string{},
+					boundDestinations: map[string]string{}, boundDestinationRaw: map[string]string{},
+					atomicAttempts: map[string]atomicSnapshotJournalEntry{}, atomicSequences: map[string]uint64{},
+					snapshotEpochs: map[string]uint64{},
+				}
+				err = (&AppendStrategy{}).executeAtomicSnapshot(t.Context(), job, dest, destination.DestinationTableSchema(job.Schema))
+			}
+			require.ErrorContains(t, err, "failed to begin")
+			if strategyName == "append" {
+				dest.atomicMu.Lock()
+				require.Len(t, dest.preparedOwnershipTokens, 1)
+				require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+				require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+				dest.atomicMu.Unlock()
+			}
+		})
+	}
+}
+
+func TestBatchAtomicSnapshotBindsPublishedDestinationIncarnation(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "destination-after-publication",
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before-publication"
+	manager, err := NewCDCStateManager(dest, "batch-published-incarnation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-incarnation"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job.CDCStateManager = manager
+	dest.incarnationMu.Lock()
+	readsBeforeExecute := dest.incarnationReads
+	dest.incarnationMu.Unlock()
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/900"},
+	)
+
+	require.NoError(t, (&MergeStrategy{}).Execute(t.Context(), job))
+	require.Equal(
+		t,
+		cdcDestinationIncarnationDigest(dest.publishedIncarnation),
+		manager.boundDestinations[job.Config.SourceTable],
+	)
+	dest.incarnationMu.Lock()
+	readsAfterExecute := dest.incarnationReads
+	require.Len(t, dest.writtenOpts, 1)
+	require.Equal(t, "destination-before-publication", dest.writtenOpts[0].CDCExpectedIncarnation)
+	require.Len(t, dest.publishedOpts, 1)
+	require.True(t, dest.publishedOpts[0].SkipCDCResume)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, readsBeforeExecute+2, readsAfterExecute, "atomic batch snapshot must fence before publication and rebind after it")
+}
+
+func TestBatchAtomicSnapshotRejectsExternalReplacementAfterPublication(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "destination-published",
+	}
+	dest := &externallyReplacedAfterAtomicPublishDestination{
+		incarnationTrackingAtomicSnapshotDestination: base,
+		externalIncarnation:                          "destination-external",
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before"
+	manager, err := NewCDCStateManager(dest, "batch-publish-race", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/900"},
+	)
+
+	err = (&MergeStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "changed after its fenced replacement was published")
+	require.Equal(t, cdcDestinationIncarnationDigest("destination-before"), manager.boundDestinations[job.Config.SourceTable])
+}
+
+func TestIncarnationTrackingAtomicPublicationRejectsReplacementBeforeCommit(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "external-replacement"
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "snapshot-publication",
+	}
+
+	_, err := dest.PublishAtomicSnapshot(t.Context(), destination.AtomicSnapshotOptions{
+		Table: "lake.events", AttemptID: "attempt-1", CDCExpectedIncarnation: "original-target",
+	})
+	require.ErrorContains(t, err, "physical incarnation changed before atomic publication")
+	require.Equal(t, "external-replacement", stateDest.incarnations["lake.events"])
+	require.Empty(t, dest.publishedOpts)
+}
+
+func TestBatchAtomicSnapshotReusesDurableAttemptAfterAmbiguousPublicationRestart(t *testing.T) {
+	ctx := t.Context()
+	stateDest := newCDCStateDestination()
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "destination-published",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before"
+
+	first, err := NewCDCStateManager(dest, "batch-ambiguous-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	job.CDCStateManager = first
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/900"},
+	)
+	err = (&MergeStrategy{}).Execute(ctx, job)
+	require.ErrorContains(t, err, "lost atomic publication response")
+
+	restarted, err := NewCDCStateManager(dest, "batch-ambiguous-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	job.CDCStateManager = restarted
+	src.mu.Lock()
+	src.readCalled = false
+	src.readErr = errors.New("source must not be reread while recovering sealed snapshot")
+	src.mu.Unlock()
+	require.NoError(t, (&MergeStrategy{}).Execute(ctx, job))
+
+	dest.publishMu.Lock()
+	require.Len(t, dest.attempts, 2)
+	require.Equal(t, dest.attempts[0], dest.attempts[1])
+	require.Equal(t, "0/900", dest.options[1].CDCResumeLSN)
+	require.Equal(t, "destination-before", dest.options[1].CDCExpectedIncarnation)
+	dest.publishMu.Unlock()
+	src.mu.Lock()
+	require.False(t, src.readCalled)
+	src.mu.Unlock()
+	require.Empty(t, restarted.atomicAttempts)
+	verified, err := NewCDCStateManager(dest, "batch-ambiguous-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, verified.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	position, err := verified.ResumePosition(ctx, job.Config.SourceTable)
+	require.NoError(t, err)
+	require.Equal(t, "0/900", position)
+}
+
+func TestBatchAtomicSnapshotDiscardsSealedAttemptWhenSourceMetadataChanges(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		sourceIncarnation string
+		schemaFingerprint string
+		legacyJournal     bool
+	}{
+		{name: "source incarnation", sourceIncarnation: "source-v2", schemaFingerprint: "schema-v1"},
+		{name: "schema fingerprint", sourceIncarnation: "source-v1", schemaFingerprint: "schema-v2"},
+		{name: "legacy journal", sourceIncarnation: "source-v1", schemaFingerprint: "schema-v1", legacyJournal: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertBatchAtomicSnapshotDiscardsSealedAttemptWhenSourceMetadataChanges(
+				t, tc.sourceIncarnation, tc.schemaFingerprint, tc.legacyJournal,
+			)
+		})
+	}
+}
+
+func TestBatchAtomicSnapshotFullRefreshDiscardsSealedAttemptAndReadsFreshSnapshot(t *testing.T) {
+	ctx := t.Context()
+	stateDest := newCDCStateDestination()
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "destination-published",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before"
+
+	first, err := NewCDCStateManager(dest, "batch-full-refresh-sealed-attempt", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableState(
+		ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1", "schema-v1",
+	))
+	require.NoError(t, first.BeginRun(ctx, false))
+	job.CDCStateManager = first
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:v1", DurableCommitPosition: "0/900"},
+	)
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(ctx, job), "lost atomic publication response")
+
+	restarted, err := NewCDCStateManager(dest, "batch-full-refresh-sealed-attempt", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(
+		ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1", "schema-v1",
+	))
+	require.NoError(t, restarted.BeginRun(ctx, true))
+	job.CDCStateManager = restarted
+	job.Config.FullRefresh = true
+	src.mu.Lock()
+	src.readCalled = false
+	src.readErr = nil
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:v2", DurableCommitPosition: "0/A00"},
+	)
+	src.mu.Unlock()
+	require.NoError(t, (&MergeStrategy{}).Execute(ctx, job))
+
+	dest.publishMu.Lock()
+	require.Len(t, dest.attempts, 2)
+	require.NotEqual(t, dest.attempts[0], dest.attempts[1])
+	require.Equal(t, "0/A00", dest.options[1].CDCResumeLSN)
+	dest.publishMu.Unlock()
+	dest.incarnationMu.Lock()
+	require.Empty(t, dest.abortedOpts)
+	require.Len(t, dest.discardedOpts, 1)
+	require.Equal(t, dest.attempts[0], dest.discardedOpts[0].AttemptID)
+	dest.incarnationMu.Unlock()
+	src.mu.Lock()
+	require.True(t, src.readCalled)
+	src.mu.Unlock()
+	require.Empty(t, restarted.atomicAttempts)
+}
+
+func assertBatchAtomicSnapshotDiscardsSealedAttemptWhenSourceMetadataChanges(
+	t *testing.T,
+	sourceIncarnation, schemaFingerprint string,
+	legacyJournal bool,
+) {
+	ctx := t.Context()
+	stateDest := newCDCStateDestination()
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "destination-published",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before"
+
+	first, err := NewCDCStateManager(dest, "batch-stale-sealed-attempt", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableState(
+		ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1", "schema-v1",
+	))
+	require.NoError(t, first.BeginRun(ctx, false))
+	job.CDCStateManager = first
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:v1", DurableCommitPosition: "0/900"},
+	)
+	err = (&MergeStrategy{}).Execute(ctx, job)
+	require.ErrorContains(t, err, "lost atomic publication response")
+	if legacyJournal {
+		legacyFound := false
+		stateDest.stateMu.Lock()
+		for table, states := range stateDest.states {
+			for i := range states {
+				entry := &states[i].entry
+				if entry.StateKind != cdcStateKindAtomicAttempt || entry.Status != cdcStateStatusReady {
+					continue
+				}
+				attempt, valid := decodeAtomicSnapshotAttempt(entry.Position)
+				if !valid {
+					continue
+				}
+				attempt.sourceMetadataKnown = false
+				attempt.sourceIncarnation = ""
+				attempt.sourceSchemaFingerprint = ""
+				entry.Position = encodeAtomicSnapshotAttempt(attempt)
+				legacyFound = true
+			}
+			stateDest.states[table] = states
+		}
+		stateDest.stateMu.Unlock()
+		require.True(t, legacyFound)
+	}
+
+	restarted, err := NewCDCStateManager(dest, "batch-stale-sealed-attempt", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(
+		ctx, job.Config.SourceTable, job.Config.DestTable, sourceIncarnation, schemaFingerprint,
+	))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	job.CDCStateManager = restarted
+	src.mu.Lock()
+	src.readCalled = false
+	src.readErr = nil
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:v2", DurableCommitPosition: "0/A00"},
+	)
+	src.mu.Unlock()
+	require.NoError(t, (&MergeStrategy{}).Execute(ctx, job))
+
+	dest.publishMu.Lock()
+	require.Len(t, dest.attempts, 2)
+	require.NotEqual(t, dest.attempts[0], dest.attempts[1])
+	require.Equal(t, "0/A00", dest.options[1].CDCResumeLSN)
+	dest.publishMu.Unlock()
+	dest.incarnationMu.Lock()
+	require.Empty(t, dest.abortedOpts)
+	require.NotEmpty(t, dest.discardedOpts)
+	require.Equal(t, dest.attempts[0], dest.discardedOpts[0].AttemptID)
+	dest.incarnationMu.Unlock()
+	src.mu.Lock()
+	require.True(t, src.readCalled)
+	src.mu.Unlock()
+}
+
+func TestBatchAtomicSnapshotAbortsOpenAttemptBeforeCreatingReplacement(t *testing.T) {
+	ctx := t.Context()
+	stateDest := newCDCStateDestination()
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "destination-published",
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before"
+
+	first, err := NewCDCStateManager(dest, "batch-open-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	openAttempt, err := first.AtomicSnapshotAttempt(ctx, job.Config.SourceTable, job.Config.DestTable)
+	require.NoError(t, err)
+
+	restarted, err := NewCDCStateManager(dest, "batch-open-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	job.CDCStateManager = restarted
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/A00"},
+	)
+	require.NoError(t, (&MergeStrategy{}).Execute(ctx, job))
+
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.abortedOpts, 1)
+	require.Equal(t, openAttempt, dest.abortedOpts[0].AttemptID)
+	require.Len(t, dest.begunOpts, 1)
+	require.NotEqual(t, openAttempt, dest.begunOpts[0].AttemptID)
+	dest.incarnationMu.Unlock()
+
+	next, err := NewCDCStateManager(dest, "batch-open-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, next.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, next.BeginRun(ctx, false))
+	_, pending, err := next.PendingAtomicSnapshotAttempt(job.Config.SourceTable, job.Config.DestTable)
+	require.NoError(t, err)
+	require.False(t, pending)
+}
+
+func TestManagedAppendSnapshotPublishesAtomically(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "target-v2",
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.SourceSchema = job.Schema
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "managed-append-atomic", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{
+			Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "snapshot:append", DurableCommitPosition: "0/900",
+		},
+	)
+
+	require.NoError(t, (&AppendStrategy{}).Execute(t.Context(), job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	for _, prepare := range stateDest.prepareCalls {
+		require.NotEqual(t, job.Config.DestTable, prepare.Table, "existing atomic append target must not be prepared before publication")
+	}
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.publishedOpts[0].AttemptID), dest.publishedOpts[0].CommitToken)
+	require.Equal(t, "0/900", dest.publishedOpts[0].CDCResumeLSN)
+	require.True(t, dest.publishedOpts[0].SkipCDCResume)
+	require.Equal(t, "target-v1", dest.publishedOpts[0].CDCExpectedIncarnation)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, cdcDestinationIncarnationDigest("target-v2"), manager.boundDestinations[job.Config.SourceTable])
+}
+
+func TestManagedMultiTableAppendSnapshotPublishesAtomically(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "snapshot:multi-append", DurableCommitPosition: "0/901",
+		}),
+	}}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{cdcStateDestination: stateDest, publishedIncarnation: "target-v2"}
+	manager, err := NewCDCStateManager(dest, "managed-multi-append-atomic", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "lake.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"}, CDCStateManager: manager,
+	}
+
+	require.NoError(t, (&AppendStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	stateDest.mu.Lock()
+	for _, prepare := range stateDest.prepareCalls {
+		require.NotEqual(t, "lake.events", prepare.Table, "existing atomic multi-table append target must not be prepared before publication")
+	}
+	stateDest.mu.Unlock()
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.begunOpts, 1)
+	require.Contains(t, dest.begunOpts[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.publishedOpts[0].AttemptID), dest.publishedOpts[0].CommitToken)
+	require.Empty(t, dest.publishedOpts[0].PrimaryKeys, "append snapshots must not acquire merge semantics")
+	require.Equal(t, "target-v1", dest.publishedOpts[0].CDCExpectedIncarnation)
+	require.Contains(t, dest.publishedOpts[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, cdcDestinationIncarnationDigest("target-v2"), manager.boundDestinations[table.Name])
+}
+
+func TestStreamingDynamicManagedKeylessSnapshotPublishesAtomically(t *testing.T) {
+	startup := newTableInfo("public.users")
+	startup.DestSchema = "landing"
+	late := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), DestSchema: "landing",
+		Incarnation: "source-events-v1", SchemaFingerprint: "schema-events-v1",
+	}
+	stateDest := newCDCStateDestination()
+	dest := &idempotentIncarnationTrackingAtomicSnapshotDestination{
+		incarnationTrackingAtomicSnapshotDestination: &incarnationTrackingAtomicSnapshotDestination{
+			cdcStateDestination: stateDest, publishedIncarnation: "target-events-v2",
+		},
+	}
+	startupTarget := multiTableDestName(dest, startup)
+	lateTarget := multiTableDestName(dest, late)
+	stateDest.incarnations[startupTarget] = "target-users-v1"
+	stateDest.incarnations[lateTarget] = "target-events-v1"
+	manager, err := NewCDCStateManager(dest, "dynamic-keyless-atomic", startupTarget, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), startup.Name, startupTarget, "source-users-v1"))
+	require.NoError(t, manager.ClaimTarget(t.Context(), startup.Name, startupTarget))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	records := mustClosedRecords(
+		source.RecordBatchResult{TableName: late.Name, TableInfo: &late},
+		source.RecordBatchResult{TableName: late.Name, Truncate: true},
+		source.RecordBatchResult{
+			TableName: late.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: snapshotStateToken(late.Name, "0/50"),
+		},
+	)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{startup}, records: records}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{
+			IncrementalStrategy: config.StrategyMerge, FullRefresh: true, NoLoadTimestamp: true,
+			FlushInterval: time.Hour, FlushRecords: 1,
+		},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{startup},
+		TableDestNames: map[string]string{startup.Name: startupTarget}, CDCStateManager: manager,
+	}
+
+	require.NoError(t, NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, StateManager: manager, FlushInterval: time.Hour, FlushRecords: 1,
+	}).ExecuteMultiTable(t.Context(), job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.begunOpts, 1)
+	require.Equal(t, lateTarget, dest.begunOpts[0].Table)
+	require.Equal(t, "target-events-v1", dest.begunOpts[0].CDCExpectedIncarnation)
+	require.Len(t, dest.writtenOpts, 1)
+	require.Equal(t, lateTarget, dest.writtenOpts[0].Table)
+	require.Equal(t, "target-events-v1", dest.writtenOpts[0].CDCExpectedIncarnation)
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, lateTarget, dest.publishedOpts[0].Table)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, cdcDestinationIncarnationDigest("target-events-v2"), manager.boundDestinations[late.Name])
+}
+
+func TestBatchCDCResumeWithoutResetUsesDirectMerge(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.CDCResumeLSN = "0/900"
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch:           int64RecordBatch(t, "id", []int64{4}, nil),
+		DurableCommitID: "wal:resume", DurableCommitPosition: "0/901",
+	})
+
+	require.NoError(t, (&MergeStrategy{}).Execute(context.Background(), job))
+	dest.atomicMu.Lock()
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.publishes)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+}
+
+func TestBatchCDCResumeLostMergeResponsePreservesOwnedTarget(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{mergeErr: errors.New("merge response lost after commit")}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.CDCResumeLSN = "0/900"
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{4}, nil), DurableCommitID: "wal:resume", DurableCommitPosition: "0/901",
+	})
+
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(context.Background(), job), "merge response lost")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Empty(t, dest.ownedDropTokens, "a merge error may be a lost response after a durable commit")
+}
+
+func TestAtomicMultiTableInitialCDCSnapshotWithoutBoundaryReplacesStaleRows(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	dest := &snapshotReplacementTrackingDestination{
+		atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+			tableSchemas: map[string]*schema.TableSchema{"lake.events": destination.DestinationTableSchema(tableSchema)},
+		}},
+		visible: map[int64]struct{}{99: {}},
+		staged:  make(map[string][]int64),
+	}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{
+			table.Name: "lake.events",
+		},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	dest.rowsMu.Lock()
+	require.Equal(t, map[int64]struct{}{1: {}}, dest.visible)
+	dest.rowsMu.Unlock()
+	dest.atomicMu.Lock()
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.publishes, 1)
+	require.Empty(t, dest.mergeRows)
+	dest.atomicMu.Unlock()
+}
+
+func TestAtomicMultiTableManagedSnapshotAndReplaySkipDestinationCursor(t *testing.T) {
+	t.Run("snapshot", func(t *testing.T) {
+		tableSchema := testCDCSchema(streamTestSchema())
+		table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+		records := mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		})
+		dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+		job := &MultiTableIngestionJob{
+			Config: &config.IngestConfig{NoLoadTimestamp: true}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+			Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "lake.events"},
+			CDCStateManager: &CDCStateManager{},
+		}
+
+		require.NoError(t, (&MergeStrategy{}).executeAtomicMultiTableBatch(t.Context(), job, dest, dest))
+		dest.atomicMu.Lock()
+		require.Len(t, dest.writes, 1)
+		require.True(t, dest.writes[0].SkipCDCResume)
+		require.Len(t, dest.publishes, 1)
+		require.True(t, dest.publishes[0].SkipCDCResume)
+		dest.atomicMu.Unlock()
+	})
+
+	t.Run("incremental_replay", func(t *testing.T) {
+		tableSchema := testCDCSchema(streamTestSchema())
+		table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+		records := mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		})
+		dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+		job := &MultiTableIngestionJob{
+			Config: &config.IngestConfig{NoLoadTimestamp: true}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+			Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "lake.events"},
+			CDCResumeLSNs: map[string]string{table.Name: "0/100"}, CDCStateManager: &CDCStateManager{},
+		}
+
+		require.NoError(t, (&MergeStrategy{}).executeAtomicMultiTableBatch(t.Context(), job, dest, dest))
+		dest.mu.Lock()
+		require.Len(t, dest.mergeCalls, 1)
+		require.True(t, dest.mergeCalls[0].SkipCDCResume)
+		dest.mu.Unlock()
+	})
+}
+
+func TestManagedMultiTableInitialSnapshotUsesAtomicPublicationAndLegacySlot(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(
+			source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+			source.RecordBatchResult{TableName: table.Name, DurableCommitID: "snapshot:public.events", DurableCommitPosition: "0/100"},
+		),
+	}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "target-v1",
+	}
+	manager, err := NewCDCStateManager(dest, "managed-multi-atomic", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "lake.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{
+			IncrementalStrategy: config.StrategyMerge,
+			NoLoadTimestamp:     true,
+			CDCSlotSuffix:       "current-slot",
+			CDCLegacySlotSuffix: "legacy-slot",
+		},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{table.Name: "lake.events"},
+		CDCStateManager: manager,
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.Equal(t, "current-slot", src.readOpts.CDCSlotSuffix)
+	require.Equal(t, "legacy-slot", src.readOpts.CDCLegacySlotSuffix)
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.publishedOpts, 1)
+	require.True(t, dest.publishedOpts[0].SkipCDCResume)
+	require.Equal(t, "target-v1", dest.publishedOpts[0].CDCExpectedIncarnation)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, "target-v1", manager.BoundDestinationIncarnation(table.Name))
+}
+
+func TestManagedMultiTableRecoversPublishedTableAndRestartsOnlyOpenAttempt(t *testing.T) {
+	ctx := t.Context()
+	tableSchema := testCDCSchema(streamTestSchema())
+	firstTable := source.SourceTableInfo{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "source-first"}
+	secondTable := source.SourceTableInfo{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "source-second"}
+	tables := []source.SourceTableInfo{firstTable, secondTable}
+	tableDestNames := map[string]string{firstTable.Name: "lake.first", secondTable.Name: "lake.second"}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.first"] = "first-before"
+	stateDest.incarnations["lake.second"] = "second-before"
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "published-after",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	firstSource := &announcingMultiTableSource{
+		tables: tables,
+		records: mustClosedRecords(
+			source.RecordBatchResult{TableName: firstTable.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+			source.RecordBatchResult{TableName: firstTable.Name, DurableCommitID: "snapshot:first", DurableCommitPosition: "0/100"},
+			source.RecordBatchResult{TableName: secondTable.Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+			source.RecordBatchResult{TableName: secondTable.Name, DurableCommitID: "snapshot:second", DurableCommitPosition: "0/200"},
+		),
+	}
+	manager, err := NewCDCStateManager(dest, "multi-ambiguous-restart", "lake.first", "")
+	require.NoError(t, err)
+	for _, table := range tables {
+		require.NoError(t, manager.RegisterTableIncarnation(ctx, table.Name, tableDestNames[table.Name], table.Incarnation))
+	}
+	require.NoError(t, manager.BeginRun(ctx, false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: firstSource, Destination: dest, Tables: tables, TableDestNames: tableDestNames,
+		CDCStateManager: manager,
+	}
+	err = (&MergeStrategy{}).ExecuteMultiTable(ctx, job)
+	require.ErrorContains(t, err, "lost atomic publication response")
+
+	restarted, err := NewCDCStateManager(dest, "multi-ambiguous-restart", "lake.first", "")
+	require.NoError(t, err)
+	for _, table := range tables {
+		require.NoError(t, restarted.RegisterTableIncarnation(ctx, table.Name, tableDestNames[table.Name], table.Incarnation))
+	}
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	secondSource := &announcingMultiTableSource{
+		tables: tables,
+		records: mustClosedRecords(
+			source.RecordBatchResult{TableName: firstTable.Name, Batch: int64RecordBatch(t, "id", []int64{3}, nil)},
+			source.RecordBatchResult{TableName: secondTable.Name, Batch: int64RecordBatch(t, "id", []int64{4}, nil)},
+			source.RecordBatchResult{TableName: secondTable.Name, DurableCommitID: "snapshot:second-retry", DurableCommitPosition: "0/300"},
+		),
+	}
+	job.Source = secondSource
+	job.CDCStateManager = restarted
+	job.CDCResumeLSNs = nil
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, job))
+
+	require.Equal(t, "0/100", secondSource.readOpts.CDCResumeLSNs[firstTable.Name])
+	require.Empty(t, secondSource.readOpts.CDCResumeLSNs[secondTable.Name])
+	dest.publishMu.Lock()
+	require.GreaterOrEqual(t, len(dest.options), 3)
+	require.Equal(t, dest.options[0].AttemptID, dest.options[1].AttemptID)
+	dest.publishMu.Unlock()
+	dest.incarnationMu.Lock()
+	require.NotEmpty(t, dest.abortedOpts)
+	for _, aborted := range dest.abortedOpts {
+		require.Equal(t, "lake.second", aborted.Table)
+		require.Equal(t, dest.abortedOpts[0].AttemptID, aborted.AttemptID)
+	}
+	dest.incarnationMu.Unlock()
+}
+
+func TestManagedMultiTableAppendRecoveryRejectsUnsafeResumedWritesBeforeRead(t *testing.T) {
+	ctx := t.Context()
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(),
+		Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-before"
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "target-published",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	manager, err := NewCDCStateManager(dest, "multi-append-recovery-gate", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, table.Name, "lake.events", table.Incarnation, table.SchemaFingerprint))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	firstSource := &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(
+			source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+			source.RecordBatchResult{TableName: table.Name, DurableCommitID: "snapshot:events", DurableCommitPosition: "0/100"},
+		),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+		Source: firstSource, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"}, CDCStateManager: manager,
+	}
+	require.ErrorContains(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, job), "lost atomic publication response")
+
+	restarted, err := NewCDCStateManager(dest, "multi-append-recovery-gate", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, table.Name, "lake.events", table.Incarnation, table.SchemaFingerprint))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	secondSource := &trackingMultiTableSource{announcingMultiTableSource: &announcingMultiTableSource{
+		tables:  []source.SourceTableInfo{table},
+		records: mustClosedRecords(),
+	}}
+	job.Source = secondSource
+	job.CDCStateManager = restarted
+	job.CDCResumeLSNs = nil
+	stateDest.mu.Lock()
+	prepareCallsBefore := len(stateDest.prepareCalls)
+	stateDest.mu.Unlock()
+
+	err = (&AppendStrategy{}).ExecuteMultiTable(ctx, job)
+	require.ErrorContains(t, err, "managed multi-table CDC append requires destination support for idempotent commit-token writes")
+	require.False(t, secondSource.readCalled, "unsafe resumed append read from the source")
+	stateDest.mu.Lock()
+	require.Len(t, stateDest.prepareCalls, prepareCallsBefore, "unsafe resumed append prepared a destination table")
+	stateDest.mu.Unlock()
+}
+
+func TestManagedMultiTableFullRefreshDiscardsSealedAttemptAndReadsFreshSnapshot(t *testing.T) {
+	ctx := t.Context()
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"},
+		Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-before"
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "target-published",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	firstSource := &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(
+			source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+			source.RecordBatchResult{TableName: table.Name, DurableCommitID: "snapshot:v1", DurableCommitPosition: "0/100"},
+		),
+	}
+	manager, err := NewCDCStateManager(dest, "multi-full-refresh-sealed-attempt", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, table.Name, "lake.events", table.Incarnation, table.SchemaFingerprint))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: firstSource, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"}, CDCStateManager: manager,
+	}
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, job), "lost atomic publication response")
+
+	restarted, err := NewCDCStateManager(dest, "multi-full-refresh-sealed-attempt", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, table.Name, "lake.events", table.Incarnation, table.SchemaFingerprint))
+	require.NoError(t, restarted.BeginRun(ctx, true))
+	secondSource := &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(
+			source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+			source.RecordBatchResult{TableName: table.Name, DurableCommitID: "snapshot:v2", DurableCommitPosition: "0/200"},
+		),
+	}
+	job.Config.FullRefresh = true
+	job.Source = secondSource
+	job.CDCStateManager = restarted
+	job.CDCResumeLSNs = nil
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(ctx, job))
+
+	require.Empty(t, secondSource.readOpts.CDCResumeLSNs[table.Name])
+	dest.publishMu.Lock()
+	require.Len(t, dest.attempts, 2)
+	require.NotEqual(t, dest.attempts[0], dest.attempts[1])
+	require.Equal(t, "0/200", dest.options[1].CDCResumeLSN)
+	dest.publishMu.Unlock()
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.discardedOpts, 1)
+	require.Equal(t, dest.attempts[0], dest.discardedOpts[0].AttemptID)
+	dest.incarnationMu.Unlock()
+	require.Empty(t, restarted.atomicAttempts)
+}
+
+func TestAtomicCapableMultiTableResumeAppliesSchemaContract(t *testing.T) {
+	for _, tc := range []struct {
+		mode      string
+		wantRows  int64
+		wantNulls int
+	}{
+		{mode: "discard_value", wantRows: 1, wantNulls: 1},
+		{mode: "discard_row", wantRows: 0, wantNulls: 0},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "value", DataType: schema.TypeString, Nullable: true},
+			}, PrimaryKeys: []string{"id"}}
+			finalSchema := &schema.TableSchema{Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+			}, PrimaryKeys: []string{"id"}}
+			comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+				Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+			}}}
+			ids := array.NewInt64Builder(memory.DefaultAllocator)
+			values := array.NewStringBuilder(memory.DefaultAllocator)
+			ids.Append(1)
+			values.Append("invalid")
+			idArray, valueArray := ids.NewArray(), values.NewArray()
+			ids.Release()
+			values.Release()
+			batch := array.NewRecordBatch(sourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+			idArray.Release()
+			valueArray.Release()
+			table := source.SourceTableInfo{Name: "public.events", Schema: sourceSchema, PrimaryKeys: []string{"id"}}
+			records := make(chan source.RecordBatchResult, 1)
+			records <- source.RecordBatchResult{TableName: table.Name, Batch: batch}
+			close(records)
+			dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+			job := &MultiTableIngestionJob{
+				Config:      &config.IngestConfig{SchemaContract: tc.mode, NoLoadTimestamp: true},
+				Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+				Destination: dest, Tables: []source.SourceTableInfo{table},
+				TableDestNames: map[string]string{table.Name: "lake.events"},
+				CDCResumeLSNs:  map[string]string{table.Name: "0/10"},
+				EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+					table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+				},
+			}
+
+			executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 100})
+			require.NoError(t, executor.ExecuteMultiTable(context.Background(), job))
+			dest.atomicMu.Lock()
+			defer dest.atomicMu.Unlock()
+			if tc.wantRows == 0 {
+				require.Empty(t, dest.mergeRows)
+				require.Empty(t, dest.mergeNulls)
+			} else {
+				require.Equal(t, []int64{tc.wantRows}, dest.mergeRows)
+				require.Equal(t, []int{tc.wantNulls}, dest.mergeNulls)
+			}
+			require.Empty(t, dest.publishes)
+		})
+	}
+}
+
+func TestAtomicCapableSingleTableSnapshotAppliesDiscardRowContract(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	ids := array.NewInt64Builder(memory.DefaultAllocator)
+	values := array.NewStringBuilder(memory.DefaultAllocator)
+	ids.Append(1)
+	values.Append("invalid")
+	idArray, valueArray := ids.NewArray(), values.NewArray()
+	ids.Release()
+	values.Release()
+	batch := array.NewRecordBatch(sourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	records := mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{
+			Batch: batch,
+			CommitToken: source.CDCStateCommitToken{SnapshotPositions: map[string]string{
+				"public.events": "0/20",
+			}},
+		},
+	)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &IngestionJob{
+		Config: &config.IngestConfig{
+			SourceTable: "public.events", DestTable: "lake.events", SchemaContract: "discard_row", NoLoadTimestamp: true,
+		},
+		Table:             &snapshotResetSourceTable{fakeSourceTable: &fakeSourceTable{readCh: records}},
+		Destination:       dest,
+		Schema:            sourceSchema,
+		SourceSchema:      sourceSchema,
+		SchemaComparison:  comparison,
+		DestinationSchema: finalSchema,
+		EvolutionPlan: &schemaevolution.EvolutionPlan{
+			TransformComparison: comparison,
+			FinalSchema:         finalSchema,
+		},
+	}
+
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 100})
+	require.NoError(t, executor.Execute(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.writeRows)
+	require.Len(t, dest.publishes, 1)
+}
+
+func TestAtomicCapableMultiTableSnapshotAppliesDiscardRowContract(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	ids := array.NewInt64Builder(memory.DefaultAllocator)
+	values := array.NewStringBuilder(memory.DefaultAllocator)
+	ids.Append(1)
+	values.Append("invalid")
+	idArray, valueArray := ids.NewArray(), values.NewArray()
+	ids.Release()
+	values.Release()
+	batch := array.NewRecordBatch(sourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	table := source.SourceTableInfo{Name: "public.events", Schema: testCDCSchema(sourceSchema), PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: table.Name,
+		Batch:     batch,
+		CommitToken: source.CDCStateCommitToken{SnapshotPositions: map[string]string{
+			table.Name: "0/20",
+		}},
+	}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{SchemaContract: "discard_row", NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+		},
+	}
+
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 100})
+	require.NoError(t, executor.ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.writeRows)
+	require.Len(t, dest.publishes, 1)
+}
+
+func TestMultiTableBatchPublishesMultipleResetSnapshotsAfterAllStagesSucceed(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	tables := []source.SourceTableInfo{
+		{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "first-v1", SchemaFingerprint: "first-schema-v1"},
+		{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "second-v1", SchemaFingerprint: "second-schema-v1"},
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	for _, table := range tables {
+		records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	}
+	close(records)
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{tables: tables, records: records}}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest, Tables: tables,
+		TableDestNames: map[string]string{"public.first": "lake.first", "public.second": "lake.second"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	require.ElementsMatch(t, []string{"public.first", "public.second"}, src.readOpts.KnownTables)
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	require.Equal(t, "first-v1", src.readOpts.CDCResumeIncarnations["public.first"])
+	require.Equal(t, "second-schema-v1", src.readOpts.CDCResumeSchemaFingerprints["public.second"])
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.publishes, 2)
+	require.Equal(t, "lake.first", dest.publishes[0].Table)
+	require.Equal(t, "lake.second", dest.publishes[1].Table)
+	require.Len(t, dest.begins, 2)
+	require.Empty(t, dest.aborts)
+	require.Empty(t, dest.truncateCalls)
+}
+
+func TestAtomicMultiTableReadFreezesTablesDiscoveredBeforeSourceRead(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	known := source.SourceTableInfo{Name: "public.known", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "known-v1", SchemaFingerprint: "known-schema-v1"}
+	late := source.SourceTableInfo{Name: "public.late", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &lateDiscoveryFilteringSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{known}},
+		late:                       late,
+	}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source:         src,
+		Destination:    dest,
+		Tables:         []source.SourceTableInfo{known},
+		TableDestNames: map[string]string{known.Name: "lake.known"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.Equal(t, []string{known.Name}, src.readOpts.KnownTables)
+	require.False(t, src.includedLate, "a table discovered after the pipeline froze its target set must wait for the next run")
+	require.Equal(t, "known-v1", src.readOpts.CDCResumeIncarnations[known.Name])
+	require.Equal(t, "known-schema-v1", src.readOpts.CDCResumeSchemaFingerprints[known.Name])
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+}
+
+func TestMultiTableBatchPartialPublicationIsReplayableWithoutCheckpoint(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	tables := []source.SourceTableInfo{
+		{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	dest := &failNthPublishAtomicDestination{
+		atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{}},
+		failAt:                    2,
+	}
+	newJob := func() *MultiTableIngestionJob {
+		records := make(chan source.RecordBatchResult, 4)
+		for i, table := range tables {
+			records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+			records <- source.RecordBatchResult{
+				TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{SnapshotPositions: map[string]string{table.Name: "0/20"}},
+			}
+		}
+		close(records)
+		return &MultiTableIngestionJob{
+			Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+			Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+				tables: tables, records: records,
+			}},
+			Destination: dest,
+			Tables:      tables,
+			TableDestNames: map[string]string{
+				tables[0].Name: "lake.first", tables[1].Name: "lake.second",
+			},
+		}
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), newJob()), "injected multi-table publish failure")
+	dest.atomicMu.Lock()
+	require.Len(t, dest.begins, 2, "every replacement must be staged before publication begins")
+	require.Len(t, dest.publishes, 1, "the first per-table commit may be visible, but no source state is acknowledged")
+	dest.atomicMu.Unlock()
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), newJob()))
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 3, "replay must republish the complete target set after an incomplete generation")
+	require.Equal(t, "lake.first", dest.publishes[1].Table)
+	require.Equal(t, "lake.second", dest.publishes[2].Table)
+	dest.atomicMu.Unlock()
+}
+
+func TestMultiTableBatchSpoolKeepsOnlyRowsAfterEachReset(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	first := source.SourceTableInfo{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	second := source.SourceTableInfo{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 8)
+	records <- source.RecordBatchResult{TableName: first.Name, Batch: int64RecordBatch(t, "id", []int64{91}, nil)}
+	records <- source.RecordBatchResult{TableName: second.Name, Batch: int64RecordBatch(t, "id", []int64{92}, nil)}
+	records <- source.RecordBatchResult{TableName: first.Name, Truncate: true}
+	records <- source.RecordBatchResult{TableName: first.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records <- source.RecordBatchResult{TableName: second.Name, Truncate: true}
+	records <- source.RecordBatchResult{TableName: second.Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil)}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{first, second}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{first, second},
+		TableDestNames: map[string]string{
+			first.Name: "lake.first", second.Name: "lake.second",
+		},
+		CDCResumeLSNs: map[string]string{first.Name: "0/10", second.Name: "0/10"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 2)
+	require.Len(t, dest.publishes, 2)
+	require.ElementsMatch(t, []int64{1, 1}, dest.writeRows)
+}
+
+func TestMultiTableBatchWALTruncateUsesFencedAtomicReplacement(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	truncated := source.SourceTableInfo{Name: "public.truncated", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	unchanged := source.SourceTableInfo{Name: "public.unchanged", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 5)
+	records <- source.RecordBatchResult{TableName: truncated.Name, Batch: int64RecordBatch(t, "id", []int64{98}, nil)}
+	records <- source.RecordBatchResult{TableName: truncated.Name, Truncate: true, CDCWALTruncate: true}
+	records <- source.RecordBatchResult{
+		TableName: truncated.Name, Batch: int64RecordBatch(t, "id", []int64{7}, nil),
+		CommitToken: source.CDCStateCommitToken{Position: "0/20"},
+	}
+	records <- source.RecordBatchResult{TableName: unchanged.Name, Batch: int64RecordBatch(t, "id", []int64{8}, nil)}
+	close(records)
+	dest := &snapshotReplacementTrackingDestination{
+		atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+			tableSchemas: map[string]*schema.TableSchema{
+				"lake.truncated": destination.DestinationTableSchema(tableSchema),
+				"lake.unchanged": destination.DestinationTableSchema(tableSchema),
+			},
+		}},
+		visible: map[int64]struct{}{99: {}},
+		staged:  make(map[string][]int64),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{truncated, unchanged}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{truncated, unchanged},
+		TableDestNames: map[string]string{
+			truncated.Name: "lake.truncated", unchanged.Name: "lake.unchanged",
+		},
+		CDCResumeLSNs: map[string]string{truncated.Name: "0/10", unchanged.Name: "0/10"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	dest.rowsMu.Lock()
+	require.Equal(t, map[int64]struct{}{7: {}}, dest.visible)
+	dest.rowsMu.Unlock()
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "lake.truncated", dest.publishes[0].Table)
+	require.Equal(t, "0/20", dest.publishes[0].CDCResumeLSN)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.unchanged", dest.mergeCalls[0].TargetTable)
+	dest.mu.Unlock()
+}
+
+func TestMultiTableBatchFailureConditionallyRemovesOwnedUnpublishedSnapshotTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}}
+	dest := &atomicSnapshotDestination{
+		fakeDestination: &fakeDestination{}, writeErr: errors.New("snapshot staging failed"), ownedDropErr: errors.New("ownership changed"),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest,
+		Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.Error(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Len(t, dest.aborts, 1)
+	require.Empty(t, dest.publishes)
+	require.Empty(t, dest.dropCalls, "unconditional cleanup must not delete a replacement owner")
+}
+
+func TestAtomicMultiTableBatchLeaseLossDuringSpoolCleansPreparedTargetBeforePublication(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease lost during atomic preflight spool")}
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+		close(lease.done)
+		close(records)
+	}()
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(guardedStreamingContext(lease), job)
+	require.ErrorContains(t, err, "lease lost during atomic preflight spool")
+	dest.atomicMu.Lock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.publishes)
+	dest.atomicMu.Unlock()
+}
+
+func TestAtomicMultiTableBatchLeaseLossAfterStagingAbortsUnpublishedAttempt(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease lost after atomic staging")}
+	base := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	var once sync.Once
+	dest := &leaseLossAfterAtomicWriteDestination{
+		atomicSnapshotDestination: base,
+		loseLease: func() {
+			once.Do(func() { close(lease.done) })
+		},
+	}
+	records := mustClosedRecords(source.RecordBatchResult{
+		TableName: table.Name,
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+	})
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(guardedStreamingContext(lease), job)
+	require.ErrorContains(t, err, "lease lost after atomic staging")
+	base.atomicMu.Lock()
+	require.Empty(t, base.publishes)
+	require.Len(t, base.aborts, 1)
+	require.Equal(t, base.begins[0].AttemptID, base.aborts[0].AttemptID)
+	base.atomicMu.Unlock()
+}
+
+func TestAtomicMultiTableFailureNeverDropsUnownedPreparedTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	dest := &unownedAtomicSnapshotDestination{
+		fakeDestination: &fakeDestination{},
+		beginErr:        errors.New("atomic begin failed after external replacement"),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: mustClosedRecords(),
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job), "atomic begin failed")
+	require.Empty(t, dest.dropCalls, "without destination-enforced ownership, cleanup must preserve a possible external replacement")
+}
+
+func TestAtomicMultiTableDirectWorkerFailureReleasesDispatchedReplayBatches(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	previousAllocator := memory.DefaultAllocator
+	memory.DefaultAllocator = pool
+	t.Cleanup(func() {
+		memory.DefaultAllocator = previousAllocator
+		pool.AssertSize(t, 0)
+	})
+
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.resume", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 16)
+	for i := int64(0); i < 16; i++ {
+		records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{i}, nil)}
+	}
+	close(records)
+	dest := &immediateFailAtomicMultiDestination{atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.resume": destination.DestinationTableSchema(tableSchema)},
+	}}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.resume"},
+		CDCResumeLSNs:  map[string]string{table.Name: "0/10"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job), "direct worker failed")
+}
+
+func TestAtomicMultiTablePreflightFailureDrainsUnreadArrowBatches(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	previousAllocator := memory.DefaultAllocator
+	memory.DefaultAllocator = pool
+	t.Cleanup(func() {
+		memory.DefaultAllocator = previousAllocator
+		pool.AssertSize(t, 0)
+	})
+
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 18)
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records <- source.RecordBatchResult{
+		TableName: table.Name,
+		Batch:     int64RecordBatch(t, "id", []int64{2}, nil),
+		Err:       errors.New("source failed during atomic preflight"),
+	}
+	for i := int64(3); i < 19; i++ {
+		records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{i}, nil)}
+	}
+	close(records)
+
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job), "source failed during atomic preflight")
+}
+
+func TestAtomicMultiTablePreflightAppliesSnapshotInvalidationBeforePublication(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{
+		Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"},
+		Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+			TableName: table.Name, Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+		}},
+		source.RecordBatchResult{TableName: table.Name, Truncate: true},
+		source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{0}, nil),
+		},
+		source.RecordBatchResult{TableName: table.Name, Truncate: true, CDCWALTruncate: true},
+		source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "snapshot:metadata-v2", DurableCommitPosition: "0/20",
+		},
+	)
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.snapshot"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "target-v2",
+	}
+	manager, err := NewCDCStateManager(dest, "metadata-change-atomic", "lake.snapshot", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(t.Context(), table.Name, "lake.snapshot", table.Incarnation, table.SchemaFingerprint))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{table.Name: "lake.snapshot"},
+		CDCResumeLSNs:   map[string]string{table.Name: "0/10"},
+		CDCStateManager: manager,
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.NoError(t, manager.Persist(t.Context(), source.CDCStateCommitToken{
+		Position:             "0/20",
+		SnapshotPositions:    map[string]string{table.Name: "0/20"},
+		SnapshotIncarnations: map[string]string{table.Name: "source-v2"},
+		SnapshotSchemas:      map[string]string{table.Name: "schema-v2"},
+	}))
+	restarted, err := NewCDCStateManager(dest, "metadata-change-atomic", "lake.snapshot", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(t.Context(), table.Name, "lake.snapshot", "source-v2", "schema-v2"))
+	position, err := restarted.ResumePosition(t.Context(), table.Name)
+	require.NoError(t, err)
+	require.Equal(t, "0/20", position)
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.publishedOpts[0].AttemptID), dest.publishedOpts[0].CommitToken)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, cdcDestinationIncarnationDigest("target-v2"), manager.boundDestinations[table.Name])
+}
+
+func TestAtomicMultiTablePreflightRequiresOrderedSnapshotInvalidationBoundary(t *testing.T) {
+	const tableName = "public.snapshot"
+	states := map[string]*atomicMultiTableBatchState{tableName: {}}
+	invalidation := func() source.RecordBatchResult {
+		return source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+			TableName: tableName, Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+		}}
+	}
+	for _, tc := range []struct {
+		name    string
+		records func(*testing.T) <-chan source.RecordBatchResult
+		wantErr string
+	}{
+		{
+			name: "boundary before invalidation",
+			records: func(*testing.T) <-chan source.RecordBatchResult {
+				return mustClosedRecords(
+					source.RecordBatchResult{TableName: tableName, Truncate: true},
+					invalidation(),
+				)
+			},
+			wantErr: "was not followed by a replacement boundary",
+		},
+		{
+			name: "duplicate invalidation",
+			records: func(*testing.T) <-chan source.RecordBatchResult {
+				return mustClosedRecords(invalidation(), invalidation())
+			},
+			wantErr: "repeated snapshot invalidation",
+		},
+		{
+			name: "data before boundary",
+			records: func(t *testing.T) <-chan source.RecordBatchResult {
+				return mustClosedRecords(
+					invalidation(),
+					source.RecordBatchResult{TableName: tableName, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+				)
+			},
+			wantErr: "was not followed by a replacement boundary",
+		},
+		{
+			name: "WAL truncate is not a replacement boundary",
+			records: func(*testing.T) <-chan source.RecordBatchResult {
+				return mustClosedRecords(
+					invalidation(),
+					source.RecordBatchResult{TableName: tableName, Truncate: true, CDCWALTruncate: true},
+				)
+			},
+			wantErr: "was not followed by a replacement boundary",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spool, _, err := spoolMultiTableRecords(t.Context(), tc.records(t), states)
+			if spool != nil {
+				require.NoError(t, spool.Close())
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestAtomicMultiTablePreflightAllowsPerTableInterleavingAndAnnouncementBeforeBoundary(t *testing.T) {
+	const tableName = "public.snapshot"
+	const otherTable = "public.other"
+	states := map[string]*atomicMultiTableBatchState{tableName: {}, otherTable: {}}
+	tableInfo := source.SourceTableInfo{
+		Name: tableName, Schema: streamTestSchema(), Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+			TableName: tableName,
+		}},
+		source.RecordBatchResult{TableName: otherTable, Batch: int64RecordBatch(t, "id", []int64{7}, nil)},
+		source.RecordBatchResult{TableName: tableName, TableInfo: &tableInfo},
+		source.RecordBatchResult{TableName: tableName, Truncate: true},
+	)
+
+	spool, resets, err := spoolMultiTableRecords(t.Context(), records, states)
+	require.NoError(t, err)
+	require.NotNil(t, spool)
+	require.NoError(t, spool.Close())
+	require.Len(t, spool.invalidations, 1)
+	require.Equal(t, "source-v2", spool.invalidations[0].Incarnation)
+	require.Equal(t, "schema-v2", spool.invalidations[0].SchemaFingerprint)
+	require.Contains(t, resets, tableName)
+}
+
+func TestAtomicMultiTablePreflightRejectsConflictingAnnouncementMetadata(t *testing.T) {
+	const tableName = "public.snapshot"
+	states := map[string]*atomicMultiTableBatchState{tableName: {}}
+	tableInfo := source.SourceTableInfo{
+		Name: tableName, Schema: streamTestSchema(), Incarnation: "source-v2", SchemaFingerprint: "schema-v3",
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+			TableName: tableName, Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+		}},
+		source.RecordBatchResult{TableName: tableName, TableInfo: &tableInfo},
+	)
+
+	spool, _, err := spoolMultiTableRecords(t.Context(), records, states)
+	if spool != nil {
+		require.NoError(t, spool.Close())
+	}
+	require.ErrorContains(t, err, "conflicting schema metadata")
+}
+
+func TestMultiTableBatchLaterPrepareFailureCleansEarlierOwnedSnapshotTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	snapshotTable := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	resumeTable := source.SourceTableInfo{Name: "public.resume", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: snapshotTable.Name, Truncate: true}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareErrByTable: map[string]error{"lake.resume": errors.New("prepare failed")},
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{snapshotTable, resumeTable}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{snapshotTable, resumeTable},
+		TableDestNames: map[string]string{
+			snapshotTable.Name: "lake.snapshot", resumeTable.Name: "lake.resume",
+		},
+		CDCResumeLSNs: map[string]string{resumeTable.Name: "0/19"},
+	}
+
+	require.Error(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 2)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.ElementsMatch(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.publishes)
+}
+
+func TestMultiTableBatchLostPrepareResponseCleansItsOwnedTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareErrByTable: map[string]error{"lake.snapshot": errors.New("prepare response lost after create")},
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job), "prepare response lost")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+}
+
+func TestMultiTableBatchLaterPrepareFailureCleansNeverWrittenResumedTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	first := source.SourceTableInfo{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	second := source.SourceTableInfo{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareErrByTable: map[string]error{"lake.second": errors.New("prepare failed")},
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{first, second}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{first, second},
+		TableDestNames: map[string]string{
+			first.Name: "lake.first", second.Name: "lake.second",
+		},
+		CDCResumeLSNs: map[string]string{first.Name: "0/10", second.Name: "0/10"},
+	}
+
+	require.Error(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 2)
+	require.ElementsMatch(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.mergeRows)
+}
+
+func TestMultiTableBatchPreservesResumedTargetAfterDirectWriteError(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}, mergeErr: errors.New("lost direct-write response")}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		CDCResumeLSNs:  map[string]string{table.Name: "0/10"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job), "lost direct-write response")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.mergeRows, 1)
+	require.Empty(t, dest.ownedDropTokens, "a direct-write error may be a lost success response")
+}
+
+func TestMultiTableBatchRoutesResetToPublishAndResumeToMerge(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	resetTable := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	resumeTable := source.SourceTableInfo{Name: "public.resume", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	tables := []source.SourceTableInfo{resetTable, resumeTable}
+	records := make(chan source.RecordBatchResult, 4)
+	records <- source.RecordBatchResult{TableName: resetTable.Name, Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: resetTable.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "snapshot:final", DurableCommitPosition: "0/20",
+	}
+	records <- source.RecordBatchResult{
+		TableName: resumeTable.Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		DurableCommitID: "wal:resume", DurableCommitPosition: "0/21",
+	}
+	close(records)
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{tables: tables, records: records}}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, IncrementalPredicate: "id >= 100"}, Source: src, Destination: dest, Tables: tables,
+		TableDestNames: map[string]string{resetTable.Name: "lake.snapshot", resumeTable.Name: "lake.resume"},
+		CDCResumeLSNs:  map[string]string{resumeTable.Name: "0/19"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "lake.snapshot", dest.publishes[0].Table)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.resume", dest.mergeCalls[0].TargetTable)
+	require.Equal(t, "id >= 100", dest.mergeCalls[0].IncrementalPredicate)
+}
+
+func TestManagedStreamingBindsDestinationBeforeSourceRead(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["ds.tbl"] = "target-v1"
+	dest := &incarnationFencedAtomicDestination{incarnationTrackingAtomicSnapshotDestination: &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest,
+	}}
+	manager, err := NewCDCStateManager(dest, "stream-bind-before-read", "ds.tbl", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), "src_table", "ds.tbl", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.SourceSchema = job.Schema
+	job.Config.CDCResumeLSN = "0/10"
+	job.Config.FlushRecords = 1
+	job.Config.FlushInterval = time.Hour
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch:       int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: source.CDCStateCommitToken{Position: "0/11"},
+	})
+	job.Table = &beforeReadSourceTable{SourceTable: src, beforeRead: func() {
+		require.Equal(t, "target-v1", manager.BoundDestinationIncarnation(job.Config.SourceTable))
+		stateDest.stateMu.Lock()
+		stateDest.incarnations[job.Config.DestTable] = "target-v2"
+		stateDest.stateMu.Unlock()
+	}}
+
+	err = NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, FlushRecords: 1, FlushInterval: time.Hour, StateManager: manager,
+	}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	stateDest.mu.Lock()
+	require.Len(t, stateDest.mergeCalls, 1)
+	require.Equal(t, "target-v1", stateDest.mergeCalls[0].CDCExpectedIncarnation)
+	stateDest.mu.Unlock()
+}
+
+func TestManagedMultiTableStreamingBindsDestinationsBeforeSourceRead(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "source-v1"}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationFencedAtomicDestination{incarnationTrackingAtomicSnapshotDestination: &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest,
+	}}
+	manager, err := NewCDCStateManager(dest, "multi-stream-bind-before-read", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "lake.events", table.Incarnation))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+
+	baseSource := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{Position: "0/11"},
+		}),
+	}}
+	src := &beforeReadAllSnapshotSource{snapshotResetMultiSource: baseSource, beforeRead: func() {
+		require.Equal(t, "target-v1", manager.BoundDestinationIncarnation(table.Name))
+		stateDest.stateMu.Lock()
+		stateDest.incarnations["lake.events"] = "target-v2"
+		stateDest.stateMu.Unlock()
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{
+			IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true,
+			FlushRecords: 1, FlushInterval: time.Hour,
+		},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		CDCResumeLSNs:  map[string]string{table.Name: "0/10"}, CDCStateManager: manager,
+	}
+
+	err = NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, FlushRecords: 1, FlushInterval: time.Hour, StateManager: manager,
+	}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	stateDest.mu.Lock()
+	require.Len(t, stateDest.mergeCalls, 1)
+	require.Equal(t, "target-v1", stateDest.mergeCalls[0].CDCExpectedIncarnation)
+	stateDest.mu.Unlock()
+}
+
+func TestManagedAtomicMultiTableBatchBindsDestinationsBeforeSourceRead(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "source-v1"}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationFencedAtomicDestination{incarnationTrackingAtomicSnapshotDestination: &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest,
+	}}
+	manager, err := NewCDCStateManager(dest, "multi-batch-bind-before-read", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "lake.events", table.Incarnation))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+
+	baseSource := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "wal:resume", DurableCommitPosition: "0/11",
+		}),
+	}}
+	src := &beforeReadAllSnapshotSource{snapshotResetMultiSource: baseSource, beforeRead: func() {
+		require.Equal(t, "target-v1", manager.BoundDestinationIncarnation(table.Name))
+		stateDest.stateMu.Lock()
+		stateDest.incarnations["lake.events"] = "target-v2"
+		stateDest.stateMu.Unlock()
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		CDCResumeLSNs:  map[string]string{table.Name: "0/10"}, CDCStateManager: manager,
+	}
+
+	err = (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	stateDest.mu.Lock()
+	require.Len(t, stateDest.mergeCalls, 1)
+	require.Equal(t, "target-v1", stateDest.mergeCalls[0].CDCExpectedIncarnation)
+	stateDest.mu.Unlock()
+}
+
+func (d *atomicSnapshotDestination) EvolveAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.evolves = append(d.evolves, opts)
+	return nil
+}
+
+func (d *atomicSnapshotDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	var types []arrow.DataType
+	var nulls []int
+	var rows int64
+	for result := range records {
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			if result.Batch.NumCols() > 1 {
+				types = append(types, result.Batch.Column(1).DataType())
+				nulls = append(nulls, result.Batch.Column(1).NullN())
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.writes = append(d.writes, opts)
+	d.writeTypes = append(d.writeTypes, types...)
+	d.writeNulls = append(d.writeNulls, nulls...)
+	d.writeRows = append(d.writeRows, rows)
+	return d.writeErr
+}
+
+func (d *atomicSnapshotDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) (string, error) {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.publishes = append(d.publishes, opts)
+	return "target-v1", nil
+}
+
+func TestStreamingGetRecordsLeavesSnapshotResetForFlushLoop(t *testing.T) {
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &IngestionJob{
+		Config:      &config.IngestConfig{Stream: true, DestTable: "lake.events"},
+		Table:       &snapshotResetSourceTable{fakeSourceTable: &fakeSourceTable{readCh: records}},
+		Destination: dest,
+		Schema:      streamTestSchema(),
+	}
+
+	out, err := job.GetRecords(context.Background(), source.ReadOptions{Streaming: true})
+	require.NoError(t, err)
+	result, ok := <-out
+	require.True(t, ok)
+	require.True(t, result.Truncate)
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.prepareCalls)
+}
+
+func TestStreamingHandlesDynamicSnapshotResetBeforeRows(t *testing.T) {
+	dest := &truncateCapableFakeDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName:                 "public.events",
+		Batch:                     int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID:           "snapshot:final",
+		DurableCommitPosition:     "0/100",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.events",
+	}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Contains(t, dest.truncateCalls, "lake.events")
+	require.Len(t, dest.writeCalls, 1)
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "0/100", dest.mergeCalls[0].CDCResumeLSN)
+}
+
+func TestStreamingUnknownTableBatchIsNotAcknowledged(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{
+		"public.known": mergeTableState("lake.known"),
+	})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName:       "public.missing",
+		Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken:     "must-not-commit",
+		DurableCommitID: "must-not-commit",
+	}
+	close(records)
+	err := loop.run(context.Background(), records)
+	require.ErrorContains(t, err, `unknown table "public.missing"`)
+	require.Empty(t, committer.committed())
+	require.Empty(t, dest.writeCalls)
+}
+
+func TestStreamingShutdownProcessesSnapshotResetBeforeFinalRows(t *testing.T) {
+	dest := &truncateCapableFakeDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName:             "public.events",
+		Batch:                 int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID:       "snapshot:page-1",
+		DurableCommitPosition: "",
+	}
+	close(records)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, loop.shutdown(ctx, records))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Contains(t, dest.truncateCalls, "lake.events")
+	require.Len(t, dest.writeCalls, 1)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+}
+
+func TestStreamingShutdownAbandonsActiveAtomicSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	records := make(chan source.RecordBatchResult, 1)
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		defer close(records)
+		for i := 0; i < 32; i++ {
+			records <- source.RecordBatchResult{
+				TableName:       "public.events",
+				Batch:           int64RecordBatch(t, "id", []int64{int64(i)}, nil),
+				DurableCommitID: "snapshot:unpublished-page",
+			}
+		}
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	require.ErrorIs(t, loop.shutdown(ctx, records), context.Canceled)
+	loop.cleanup(ctx)
+	require.Less(t, time.Since(started), time.Second)
+	require.Eventually(t, func() bool {
+		select {
+		case <-producerDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Empty(t, dest.writes)
+	require.Empty(t, dest.publishes)
+	require.Len(t, dest.aborts, 1)
+	require.Equal(t, dest.begins[0].AttemptID, dest.aborts[0].AttemptID)
+}
+
+func TestStreamingCleanupDoesNotAbortAfterPublicationAttempt(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.atomicSnapshot = true
+	st.snapshotAttemptID = "unknown-publication"
+	st.atomicPublishAttempted = true
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+
+	loop.cleanup(context.Background())
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.aborts)
+}
+
+func TestStreamingCanceledClosedChannelDoesNotPublishActiveAtomicSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName:   "public.events",
+		Batch:       int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("public.events", "0/123"),
+	})
+
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, loop.run(ctx, records), context.Canceled)
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Empty(t, dest.writes)
+	require.Empty(t, dest.publishes)
+}
+
+func TestStreamingAtomicSnapshotStagesPagesUntilFinalBoundary(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "snapshot:page-1",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.writes, 1)
+	require.Empty(t, dest.publishes)
+	dest.atomicMu.Unlock()
+	require.Empty(t, dest.prepareCalls, "atomic reset must not truncate or recreate the visible target")
+
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.writes, 2)
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.begins[0].AttemptID), dest.publishes[0].CommitToken)
+	require.Equal(t, "0/100", dest.publishes[0].CDCResumeLSN)
+	require.False(t, st.atomicSnapshot)
+}
+
+func TestStreamingAtomicSnapshotCombinedPagesDoNotUseFinalPageIdentity(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(t.Context(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "snapshot-page-a",
+	})
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		DurableCommitID: "snapshot-page-b", DurableCommitPosition: "0/100",
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	})
+	require.NoError(t, loop.flush(t.Context()))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.writes, 1)
+	require.Empty(t, dest.writes[0].CommitToken, "two staged pages cannot use only the final page identity")
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.begins[0].AttemptID), dest.publishes[0].CommitToken)
+	require.Equal(t, "0/100", dest.publishes[0].CDCResumeLSN)
+}
+
+func TestStreamingAtomicSnapshotRetriesAmbiguousPublishWithSameIdentity(t *testing.T) {
+	base := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	dest := &ambiguousPublishAtomicDestination{atomicSnapshotDestination: base}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, Committer: committer,
+	}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(t.Context(), "public.events"))
+	attemptID := st.snapshotAttemptID
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "snapshot-page-final", DurableCommitPosition: "0/100",
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	})
+
+	err := loop.flush(t.Context())
+	require.ErrorContains(t, err, "lost publish response")
+	require.True(t, st.atomicSnapshot)
+	require.True(t, st.atomicPublishAttempted)
+	require.Equal(t, attemptID, st.snapshotAttemptID)
+	require.Empty(t, committer.committed())
+	loop.cleanup(t.Context())
+	base.atomicMu.Lock()
+	require.Empty(t, base.aborts, "an attempted publication has an ambiguous outcome and must never be aborted")
+	base.atomicMu.Unlock()
+
+	require.NoError(t, loop.flush(t.Context()))
+	require.False(t, st.atomicSnapshot)
+	require.False(t, st.atomicPublishAttempted)
+	require.Equal(t, []any{snapshotStateToken("public.events", "0/100")}, committer.committed())
+	base.atomicMu.Lock()
+	defer base.atomicMu.Unlock()
+	require.Len(t, base.writes, 1, "retrying publication must not restage pages")
+	require.Len(t, base.publishes, 2)
+	for _, publish := range base.publishes {
+		require.Equal(t, attemptID, publish.AttemptID)
+		require.Equal(t, atomicSnapshotCommitID(attemptID), publish.CommitToken)
+	}
+}
+
+func TestStreamingManagedAtomicSnapshotRecoversSealedPublicationBeforeResumeRead(t *testing.T) {
+	ctx := t.Context()
+	stateDest := newCDCStateDestination()
+	base := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "destination-published",
+	}
+	dest := &ambiguousManagedAtomicSnapshotDestination{incarnationTrackingAtomicSnapshotDestination: base}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.SourceSchema = job.Schema
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.FlushInterval = time.Hour
+	job.Config.FlushRecords = 100
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before"
+
+	first, err := NewCDCStateManager(dest, "stream-ambiguous-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	job.CDCStateManager = first
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{
+			Batch:                 int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID:       "snapshot-page-final",
+			DurableCommitPosition: "0/900",
+			CommitToken:           snapshotStateToken(job.Config.SourceTable, "0/900"),
+		},
+	)
+	executor := NewStreamingExecutor(StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		StateManager:  first,
+	})
+	err = executor.Execute(ctx, job)
+	require.ErrorContains(t, err, "lost atomic publication response")
+
+	restarted, err := NewCDCStateManager(dest, "stream-ambiguous-restart", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, restarted.BeginRun(ctx, false))
+	job.CDCStateManager = restarted
+	job.Config.CDCResumeLSN = ""
+	src.mu.Lock()
+	src.readCalled = false
+	src.readErr = nil
+	src.readCh = mustClosedRecords()
+	src.mu.Unlock()
+	executor = NewStreamingExecutor(StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		StateManager:  restarted,
+	})
+	require.NoError(t, executor.Execute(ctx, job))
+
+	src.mu.Lock()
+	require.True(t, src.readCalled)
+	require.Equal(t, "0/900", src.readOpts.CDCResumeLSN)
+	src.mu.Unlock()
+	dest.publishMu.Lock()
+	require.Len(t, dest.options, 2)
+	require.Equal(t, dest.options[0].AttemptID, dest.options[1].AttemptID)
+	dest.publishMu.Unlock()
+}
+
+func TestStreamingAtomicSnapshotPublishesEmptySnapshotImmediately(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.empty_events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", CommitToken: snapshotStateToken("public.events", "0/200"),
+	}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Empty(t, dest.writes)
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.begins[0].AttemptID), dest.publishes[0].CommitToken)
+}
+
+func TestStreamingAtomicSnapshotPublishesSmallFinalBatchBeforeFollowingWAL(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(context.Background(), records) }()
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	}
+	require.Eventually(t, func() bool {
+		dest.atomicMu.Lock()
+		defer dest.atomicMu.Unlock()
+		return len(dest.publishes) == 1
+	}, time.Second, time.Millisecond, "final snapshot rows must publish before waiting for another result")
+
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken: source.CDCStateCommitToken{Position: "0/101"},
+	}
+	close(records)
+	require.NoError(t, <-done)
+
+	dest.atomicMu.Lock()
+	require.Len(t, dest.writes, 1, "only the snapshot batch is written through hidden atomic staging")
+	require.Equal(t, atomicSnapshotCommitID(dest.begins[0].AttemptID), dest.publishes[0].CommitToken)
+	require.Equal(t, "0/100", dest.publishes[0].CDCResumeLSN)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 1, "following WAL batch uses the normal merge staging path")
+	require.Empty(t, dest.writeCalls[0].CommitToken)
+	dest.mu.Unlock()
+}
+
+func TestStreamingAtomicSnapshotsPublishIndependentlyPerTable(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	first := mergeTableState("lake.first")
+	first.isCDC = true
+	second := mergeTableState("lake.second")
+	second.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.first": first, "public.second": second})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.first"))
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.second"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.first", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("public.first", "0/300"),
+	})
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.second", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		DurableCommitID: "second:page-1",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "lake.first", dest.publishes[0].Table)
+	dest.atomicMu.Unlock()
+	require.False(t, first.atomicSnapshot)
+	require.True(t, second.atomicSnapshot)
+}
+
+func TestStreamingAtomicSnapshotSchemaRefreshRestartsHiddenSnapshot(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "target-v2",
+	}
+	manager, err := NewCDCStateManager(dest, "streaming-schema-refresh-fence", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(t.Context(), "public.events", "lake.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		StateManager:  manager,
+	}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	evolveCalls := 0
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error {
+		evolveCalls++
+		return nil
+	}
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "old-shape-page",
+	})
+	newSchema := *st.schema
+	newSchema.Columns = append(append([]schema.Column{}, st.schema.Columns...), schema.Column{
+		Name: "added", DataType: schema.TypeString, Nullable: true,
+	})
+	require.NoError(t, loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &newSchema, PrimaryKeys: []string{"id"},
+	}, st))
+
+	dest.incarnationMu.Lock()
+	defer dest.incarnationMu.Unlock()
+	require.Len(t, dest.writtenOpts, 1, "old-shape pages are durably consumed before restarting")
+	require.Equal(t, "target-v1", dest.writtenOpts[0].CDCExpectedIncarnation)
+	require.Len(t, dest.begunOpts, 1)
+	require.Equal(t, "target-v1", dest.begunOpts[0].CDCExpectedIncarnation)
+	require.Len(t, dest.evolvedOpts, 1, "schema refresh must evolve hidden staging without changing the target")
+	require.Equal(t, "target-v1", dest.evolvedOpts[0].CDCExpectedIncarnation)
+	require.Empty(t, dest.publishedOpts)
+	require.Equal(t, "added", dest.evolvedOpts[0].Schema.Columns[len(dest.evolvedOpts[0].Schema.Columns)-1].Name)
+	require.Zero(t, evolveCalls, "visible target schema must change with final snapshot publication")
+	require.True(t, st.atomicSnapshot)
+}
+
+func TestStreamingAtomicSnapshotSchemaRefreshHonorsFreezeContract(t *testing.T) {
+	current := streamTestSchema()
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": current},
+	}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.cfg.SchemaContract = "freeze"
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	newSchema := *current
+	newSchema.Columns = append(append([]schema.Column{}, current.Columns...), schema.Column{
+		Name: "forbidden", DataType: schema.TypeString, Nullable: true,
+	})
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &newSchema, PrimaryKeys: []string{"id"},
+	}, st)
+	require.ErrorContains(t, err, "schema contract violation")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.evolves)
+	require.NotContains(t, st.schema.ColumnNames(), "forbidden")
+}
+
+func TestStreamingAtomicSnapshotRejectsDiscardRowSchemaRefresh(t *testing.T) {
+	current := streamTestSchema()
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": current},
+	}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.cfg.SchemaContract = "discard_row"
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	newSchema := *current
+	newSchema.Columns = append(append([]schema.Column{}, current.Columns...), schema.Column{
+		Name: "violating", DataType: schema.TypeString, Nullable: true,
+	})
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &newSchema, PrimaryKeys: []string{"id"},
+	}, st)
+	require.ErrorContains(t, err, "unsupported with discard_row")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.evolves)
+	require.NotContains(t, st.schema.ColumnNames(), "violating")
+}
+
+func TestStreamingAtomicAppendSnapshotKeepsCDCChangelogColumns(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := &streamTableState{destTable: "lake.events", schema: keylessCDCSchema(), isCDC: true}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyAppend,
+	}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Contains(t, dest.begins[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+}
+
+func TestStreamingAtomicSnapshotDefersSharedSourceAckUntilAllTablesPublish(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	first := mergeTableState("lake.first")
+	second := mergeTableState("lake.second")
+	first.isCDC, second.isCDC = true, true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge, Committer: committer,
+	}, map[string]*streamTableState{"first": first, "second": second})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "first"))
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "second"))
+
+	loop.buffer(source.RecordBatchResult{
+		TableName: "first", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("first", "0/500"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+	require.Empty(t, committer.committed(), "shared source cursor cannot advance while another snapshot table is hidden")
+
+	loop.buffer(source.RecordBatchResult{
+		TableName: "second", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken: snapshotStateToken("second", "0/500"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+	require.Equal(t, []any{snapshotStateToken("second", "0/500")}, committer.committed())
+}
+
+func TestStreamingFinalFlushPublishesPendingEmptyAtomicSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.empty")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge}, map[string]*streamTableState{"events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "events"))
+	require.NoError(t, loop.bufferResult(source.RecordBatchResult{
+		TableName: "events", CommitToken: snapshotStateToken("events", "0/600"),
+	}))
+	require.NoError(t, loop.finalFlush(context.Background()))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, atomicSnapshotCommitID(dest.begins[0].AttemptID), dest.publishes[0].CommitToken)
+}
+
+func TestStreamingAtomicSnapshotDefersEvolutionUntilPublication(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	evolutions := 0
+	st.deferredEvolution = func(context.Context) error { evolutions++; return nil }
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge}, map[string]*streamTableState{"events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "events"))
+	batch := int64RecordBatch(t, "id", []int64{1}, nil)
+	defer batch.Release()
+	require.NoError(t, loop.applyDeferredEvolution(context.Background(), source.RecordBatchResult{
+		TableName: "events", Batch: batch,
+	}))
+	require.Zero(t, evolutions)
+}
+
+func TestStreamingWithoutSnapshotAppliesDeferredEvolutionBeforeData(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	evolutions := 0
+	st.deferredEvolution = func(context.Context) error { evolutions++; return nil }
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge}, map[string]*streamTableState{"events": st})
+	batch := int64RecordBatch(t, "id", []int64{1}, nil)
+	defer batch.Release()
+	require.NoError(t, loop.applyDeferredEvolution(context.Background(), source.RecordBatchResult{TableName: "events", Batch: batch}))
+	require.Equal(t, 1, evolutions)
+}

--- a/pkg/strategy/staging.go
+++ b/pkg/strategy/staging.go
@@ -18,7 +18,10 @@ const DefaultStagingSchema = "_bruin_staging"
 // identifiers don't collide via silent truncation and don't fail on MySQL.
 const maxStagingTableNameLen = 60
 
-const encodedStagingIdentifierPrefix = "_ingestr_hex_"
+const (
+	encodedStagingIdentifierPrefix       = "ingestr_hex_"
+	legacyEncodedStagingIdentifierPrefix = "_ingestr_hex_"
+)
 
 func GenerateStagingTableName(targetTable, suffix, stagingDataset string) string {
 	catalog, originSchema, tableName := splitCatalogSchemaTable(targetTable)
@@ -183,7 +186,7 @@ func syntheticStagingIdentifier(parts ...string) string {
 }
 
 func isUnambiguousLegacyStagingIdentifier(candidate string, parts []string) bool {
-	if strings.HasPrefix(candidate, encodedStagingIdentifierPrefix) {
+	if strings.HasPrefix(candidate, encodedStagingIdentifierPrefix) || strings.HasPrefix(candidate, legacyEncodedStagingIdentifierPrefix) {
 		return false
 	}
 	for _, part := range parts {

--- a/pkg/strategy/staging_test.go
+++ b/pkg/strategy/staging_test.go
@@ -54,6 +54,7 @@ func TestSyntheticStagingIdentifierEncodesQualificationAndAmbiguity(t *testing.T
 		{"sales.schema", "order.events"},
 		{"analytics__users"},
 		{"_ingestr_hex_616263"},
+		{"ingestr_hex_616263"},
 		{"Case Schema", "orders"},
 	}
 	seen := map[string]bool{"analytics__users": true}
@@ -69,6 +70,28 @@ func TestSyntheticStagingIdentifierEncodesQualificationAndAmbiguity(t *testing.T
 			t.Fatalf("synthetic staging identifier collision for %q: %q", parts, got)
 		}
 		seen[got] = true
+	}
+}
+
+func TestManagedStagingNameIsValidForS3Tables(t *testing.T) {
+	policy := destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingManagedSchema,
+		DefaultManagedSchema: "bruin_staging",
+	}
+	for _, target := range []string{"analytics.orders", "analytics.foo__bar"} {
+		parts := tablename.Split(GenerateReplaceStagingTableName(target, "merge", "", policy))
+		if len(parts) != 2 || parts[0] != "bruin_staging" {
+			t.Fatalf("managed staging table for %q = %q, want bruin_staging.table", target, parts)
+		}
+		if strings.HasPrefix(parts[1], "_") {
+			t.Fatalf("S3 Tables staging identifier starts with an underscore: %q", parts[1])
+		}
+		for _, r := range parts[1] {
+			if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' {
+				continue
+			}
+			t.Fatalf("S3 Tables staging identifier contains invalid character %q: %q", r, parts[1])
+		}
 	}
 }
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -4,16 +4,27 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/progress"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 )
+
+func dropManagedStagingDetached(ctx context.Context, dest destination.Destination, table, strategy string) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[%s] Warning: failed to drop staging table %s: %v", strategy, table, err)
+	}
+}
 
 type IngestionJob struct {
 	Config       *config.IngestConfig
@@ -71,6 +82,14 @@ type IngestionJob struct {
 
 // GetRecords returns the transformed record stream for this job.
 func (j *IngestionJob) GetRecords(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	return j.getRecords(ctx, opts, false)
+}
+
+func (j *IngestionJob) getStreamingRecords(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	return j.getRecords(ctx, opts, true)
+}
+
+func (j *IngestionJob) getRecords(ctx context.Context, opts source.ReadOptions, dynamicSchema bool) (<-chan source.RecordBatchResult, error) {
 	var records <-chan source.RecordBatchResult
 	if j.BufferedRecords != nil {
 		records = j.BufferedRecords
@@ -81,7 +100,7 @@ func (j *IngestionJob) GetRecords(ctx context.Context, opts source.ReadOptions) 
 			return nil, err
 		}
 	}
-	return j.ApplyBatchTransformation(ctx, records)
+	return j.applyBatchTransformation(ctx, records, dynamicSchema)
 }
 
 // ApplyEvolution applies the pending schema evolution plan to the destination.
@@ -89,6 +108,10 @@ func (j *IngestionJob) GetRecords(ctx context.Context, opts source.ReadOptions) 
 // strategy layer only decides when the plan runs.
 func (j *IngestionJob) ApplyEvolution(ctx context.Context) error {
 	return applyEvolutionPlan(ctx, j.Destination, j.EvolutionPlan)
+}
+
+func (j *IngestionJob) ApplyEvolutionIfIncarnation(ctx context.Context, expectedIncarnation string) error {
+	return applyEvolutionPlanIfIncarnation(ctx, j.Destination, j.EvolutionPlan, expectedIncarnation)
 }
 
 type WriteStrategy interface {
@@ -138,28 +161,75 @@ func (j *MultiTableIngestionJob) ApplyEvolutionFor(ctx context.Context, sourceTa
 	return applyEvolutionPlan(ctx, j.Destination, j.EvolutionPlans[sourceTable])
 }
 
+func (j *MultiTableIngestionJob) ApplyEvolutionForIfIncarnation(ctx context.Context, sourceTable, expectedIncarnation string) error {
+	return applyEvolutionPlanIfIncarnation(ctx, j.Destination, j.EvolutionPlans[sourceTable], expectedIncarnation)
+}
+
+func (j *MultiTableIngestionJob) WriteSchemaFor(sourceTable string, sourceSchema *schema.TableSchema) *schema.TableSchema {
+	plan := j.EvolutionPlans[sourceTable]
+	writeSchema := sourceSchema
+	if plan != nil && plan.FinalSchema != nil {
+		writeSchema = destination.StagingIngestSchema(sourceSchema, plan.FinalSchema)
+		writeSchema = destination.PreserveSourceCDCColumnTypes(writeSchema, sourceSchema)
+	}
+	if j.Config != nil && j.Config.IncrementalStrategy == config.StrategyReplace {
+		return destination.DestinationTableSchema(writeSchema)
+	}
+	return writeSchema
+}
+
 // evolveDestinationTable builds and applies a fresh schema evolution plan for
 // one table against the destination's current shape, honoring the configured
 // schema contract. It is the mid-stream counterpart of the pipeline's startup
 // evolution, used when a CDC source re-announces a table whose source schema
 // changed while streaming.
 func evolveDestinationTable(ctx context.Context, dest destination.Destination, destTable string, sourceSchema *schema.TableSchema, cfg *config.IngestConfig) error {
+	_, err := evolveDestinationTablePlan(ctx, dest, destTable, sourceSchema, cfg)
+	return err
+}
+
+func evolveDestinationTablePlan(ctx context.Context, dest destination.Destination, destTable string, sourceSchema *schema.TableSchema, cfg *config.IngestConfig) (*schemaevolution.EvolutionPlan, error) {
+	return evolveDestinationTablePlanIfIncarnation(ctx, dest, destTable, sourceSchema, cfg, "")
+}
+
+func evolveDestinationTablePlanIfIncarnation(
+	ctx context.Context,
+	dest destination.Destination,
+	destTable string,
+	sourceSchema *schema.TableSchema,
+	cfg *config.IngestConfig,
+	expectedIncarnation string,
+) (*schemaevolution.EvolutionPlan, error) {
+	plan, err := planDestinationSchemaEvolution(ctx, dest, destTable, sourceSchema, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyEvolutionPlanIfIncarnation(ctx, dest, plan, expectedIncarnation); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func planDestinationSchemaEvolution(ctx context.Context, dest destination.Destination, destTable string, sourceSchema *schema.TableSchema, cfg *config.IngestConfig) (*schemaevolution.EvolutionPlan, error) {
+	if err := schemainfer.ValidateSchema(sourceSchema); err != nil {
+		return nil, fmt.Errorf("invalid source schema for destination table %s: %w", destTable, err)
+	}
 	destSchema, err := dest.GetTableSchema(ctx, destTable)
 	if err != nil {
-		return fmt.Errorf("failed to get destination schema: %w", err)
+		return nil, fmt.Errorf("failed to get destination schema: %w", err)
 	}
 	if destSchema == nil {
-		return nil
+		return &schemaevolution.EvolutionPlan{Table: destTable, FinalSchema: destination.DestinationTableSchema(sourceSchema)}, nil
 	}
 	destSchema = destination.PreserveSourceCDCColumnTypes(destSchema, sourceSchema)
 
 	contractMode, err := schemaevolution.ParseContractMode(cfg.SchemaContract)
 	if err != nil {
-		return fmt.Errorf("failed to parse schema contract: %w", err)
+		return nil, fmt.Errorf("failed to parse schema contract: %w", err)
 	}
 	overrides, err := schemaevolution.ParseColumnOverrides(cfg.Columns)
 	if err != nil {
-		return fmt.Errorf("failed to parse column overrides: %w", err)
+		return nil, fmt.Errorf("failed to parse column overrides: %w", err)
 	}
 
 	primaryKeys := cfg.PrimaryKeys
@@ -174,31 +244,59 @@ func evolveDestinationTable(ctx context.Context, dest destination.Destination, d
 	}
 	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), destSchema, compareOptions)
 	if err != nil {
-		return fmt.Errorf("failed to compare schemas: %w", err)
+		return nil, fmt.Errorf("failed to compare schemas: %w", err)
 	}
 	if !comparison.HasChanges {
-		return nil
+		return &schemaevolution.EvolutionPlan{Table: destTable, Comparison: comparison, TransformComparison: comparison, FinalSchema: destSchema}, nil
 	}
 
 	contractResult := schemaevolution.ApplyContract(schemaevolution.SchemaContract{Mode: contractMode}, comparison)
 	if contractMode == schemaevolution.ContractFreeze && contractResult.HasViolations() {
-		return contractResult.ViolationError()
+		return nil, contractResult.ViolationError()
 	}
 	filtered := &schemaevolution.SchemaComparison{
 		Changes:    contractResult.Allowed,
 		HasChanges: len(contractResult.Allowed) > 0,
 	}
-	return applyEvolutionPlan(ctx, dest, &schemaevolution.EvolutionPlan{
-		Table:       destTable,
-		Comparison:  filtered,
-		FinalSchema: schemaevolution.BuildFinalSchema(destSchema, filtered),
-	})
+	evolver, ok := dest.(schemaevolution.SchemaEvolver)
+	if !ok {
+		return &schemaevolution.EvolutionPlan{
+			Table:               destTable,
+			Comparison:          &schemaevolution.SchemaComparison{},
+			TransformComparison: comparison,
+			FinalSchema:         schemaevolution.BuildFinalSchema(destSchema, nil),
+		}, nil
+	}
+	applicable := schemaevolution.ApplicableComparison(filtered, evolver.SupportsColumnTypeChanges())
+	return &schemaevolution.EvolutionPlan{
+		Table:               destTable,
+		Comparison:          applicable,
+		TransformComparison: comparison,
+		FinalSchema:         schemaevolution.BuildFinalSchema(destSchema, applicable),
+	}, nil
 }
 
 // applyEvolutionPlan asks the destination to apply an abstract evolution plan.
 // Destinations that cannot evolve schemas (do not implement SchemaEvolver) are
 // silently skipped, matching the previous no-dialect behavior.
 func applyEvolutionPlan(ctx context.Context, dest destination.Destination, plan *schemaevolution.EvolutionPlan) error {
+	return applyEvolutionPlanIfIncarnation(ctx, dest, plan, "")
+}
+
+func boundDestinationIncarnation(manager *CDCStateManager, sourceTable, destTable string) (string, error) {
+	expectedIncarnation := manager.BoundDestinationIncarnation(sourceTable)
+	if expectedIncarnation == "" {
+		return "", fmt.Errorf("managed CDC destination %s has no bound physical incarnation", destTable)
+	}
+	return expectedIncarnation, nil
+}
+
+func applyEvolutionPlanIfIncarnation(
+	ctx context.Context,
+	dest destination.Destination,
+	plan *schemaevolution.EvolutionPlan,
+	expectedIncarnation string,
+) error {
 	if plan == nil || !plan.HasChanges() {
 		return nil
 	}
@@ -207,7 +305,20 @@ func applyEvolutionPlan(ctx context.Context, dest destination.Destination, plan 
 		return nil
 	}
 	ctx = annotation.WithStep(ctx, annotation.StepEvolve)
-	warnings, err := evolver.ApplySchemaEvolution(ctx, plan.Table, plan.Comparison)
+	var warnings []string
+	var err error
+	if expectedIncarnation == "" {
+		warnings, err = evolver.ApplySchemaEvolution(ctx, plan.Table, plan.Comparison)
+	} else if fenced, ok := dest.(schemaevolution.IncarnationFencedSchemaEvolver); ok {
+		warnings, err = fenced.ApplySchemaEvolutionIfIncarnation(
+			ctx, plan.Table, plan.Comparison, expectedIncarnation,
+		)
+	} else {
+		return fmt.Errorf(
+			"destination scheme %q cannot fence managed CDC schema evolution to a physical table incarnation",
+			dest.GetScheme(),
+		)
+	}
 	if err != nil {
 		return err
 	}
@@ -230,6 +341,14 @@ func (j *MultiTableIngestionJob) GetDestTableName(sourceTable string) string {
 }
 
 func (j *MultiTableIngestionJob) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	return j.readAll(ctx, opts, false)
+}
+
+func (j *MultiTableIngestionJob) readAllStreaming(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	return j.readAll(ctx, opts, true)
+}
+
+func (j *MultiTableIngestionJob) readAll(ctx context.Context, opts source.MultiTableReadOptions, dynamicSchema bool) (<-chan source.RecordBatchResult, error) {
 	if opts.KnownTables == nil {
 		opts.KnownTables = make([]string, 0, len(j.Tables))
 		for _, table := range j.Tables {
@@ -240,17 +359,63 @@ func (j *MultiTableIngestionJob) ReadAll(ctx context.Context, opts source.MultiT
 	if err != nil {
 		return nil, err
 	}
-	return j.ApplyBatchTransformation(ctx, records), nil
+	return j.applyBatchTransformation(ctx, records, dynamicSchema)
 }
 
-func (j *MultiTableIngestionJob) ApplyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult) <-chan source.RecordBatchResult {
+func (j *MultiTableIngestionJob) ApplyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult) (<-chan source.RecordBatchResult, error) {
+	return j.applyBatchTransformation(ctx, records, false)
+}
+
+func (j *MultiTableIngestionJob) applyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult, dynamicSchema bool) (<-chan source.RecordBatchResult, error) {
 	if len(j.ColumnRenamers) > 0 || j.NormalizeTableInfo != nil {
 		records = j.applyColumnRenaming(ctx, records)
 	}
 	if j.WhitespaceTrimmer != nil {
 		records = transformer.Wrap(records, j.WhitespaceTrimmer)
 	}
-	return j.ApplyLoadTimestamp(records)
+
+	if dynamicSchema {
+		return j.ApplyLoadTimestamp(records), nil
+	}
+
+	contract := ""
+	if j.Config != nil {
+		contract = j.Config.SchemaContract
+	}
+	mode, err := schemaevolution.ParseContractMode(contract)
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema contract mode: %w", err)
+	}
+	contractTransformers := make(map[string]schemaevolution.BatchTransformer)
+	aligners := make(map[string]*transformer.TypeCaster)
+	for _, table := range j.Tables {
+		plan := j.EvolutionPlans[table.Name]
+		writeSchema := j.WriteSchemaFor(table.Name, table.Schema)
+		if writeSchema != nil {
+			aligners[table.Name] = transformer.NewSafeTypeCaster(writeSchema.ToArrowSchema())
+		}
+		if plan == nil || plan.FinalSchema == nil {
+			continue
+		}
+		comparison := plan.TransformComparison
+		if comparison == nil {
+			comparison = plan.Comparison
+		}
+		switch mode {
+		case schemaevolution.ContractDiscardValue:
+			contractTransformers[table.Name] = schemaevolution.NewDiscardValueTransformer(comparison, table.Schema, plan.FinalSchema)
+		case schemaevolution.ContractDiscardRow:
+			contractTransformers[table.Name] = schemaevolution.NewDiscardRowTransformer(table.Schema, plan.FinalSchema, comparison)
+		}
+	}
+	if len(contractTransformers) > 0 {
+		records = transformMultiTableContractBatches(ctx, records, contractTransformers)
+	}
+	records = j.ApplyLoadTimestamp(records)
+	if len(aligners) > 0 {
+		records = transformMultiTableAlignedBatches(ctx, records, aligners)
+	}
+	return records, nil
 }
 
 func (j *MultiTableIngestionJob) ApplyLoadTimestamp(records <-chan source.RecordBatchResult) <-chan source.RecordBatchResult {
@@ -299,6 +464,7 @@ func (j *MultiTableIngestionJob) applyColumnRenaming(ctx context.Context, record
 				if result.Batch != nil {
 					result.Batch.Release()
 				}
+				drainAndRelease(records)
 				return
 			}
 		}
@@ -325,6 +491,55 @@ func (j *MultiTableIngestionJob) setColumnRenamer(table string, renamer *transfo
 	j.ColumnRenamers[table] = renamer
 }
 
+func transformMultiTableContractBatches(ctx context.Context, records <-chan source.RecordBatchResult, transforms map[string]schemaevolution.BatchTransformer) <-chan source.RecordBatchResult {
+	return transformMultiTableBatches(ctx, records, func(table string, batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+		if transform := transforms[table]; transform != nil {
+			return transform.Transform(ctx, batch)
+		}
+		batch.Retain()
+		return batch, nil
+	})
+}
+
+func transformMultiTableAlignedBatches(ctx context.Context, records <-chan source.RecordBatchResult, aligners map[string]*transformer.TypeCaster) <-chan source.RecordBatchResult {
+	return transformMultiTableBatches(ctx, records, func(table string, batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+		if aligner := aligners[table]; aligner != nil {
+			return aligner.Transform(batch)
+		}
+		batch.Retain()
+		return batch, nil
+	})
+}
+
+func transformMultiTableBatches(ctx context.Context, records <-chan source.RecordBatchResult, transform func(string, arrow.RecordBatch) (arrow.RecordBatch, error)) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(out)
+		for result := range records {
+			if result.Err == nil && result.Batch != nil {
+				transformed, err := transform(result.TableName, result.Batch)
+				result.Batch.Release()
+				if err != nil {
+					result.Batch = nil
+					result.Err = err
+				} else {
+					result.Batch = transformed
+				}
+			}
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				drainAndRelease(records)
+				return
+			}
+		}
+	}()
+	return out
+}
+
 // MultiTableStrategy extends WriteStrategy for multi-table sources.
 // Strategies that support multi-table CDC should implement this interface.
 type MultiTableStrategy interface {
@@ -349,6 +564,10 @@ func Get(name config.IncrementalStrategy) (WriteStrategy, error) {
 // ApplyBatchTransformation wraps record batches with contract-based transformation if needed.
 // Also applies column renaming if a naming convention is configured.
 func (j *IngestionJob) ApplyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult) (<-chan source.RecordBatchResult, error) {
+	return j.applyBatchTransformation(ctx, records, false)
+}
+
+func (j *IngestionJob) applyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult, dynamicSchema bool) (<-chan source.RecordBatchResult, error) {
 	// Cast column types first (for --columns type overrides on known-schema sources).
 	// Casting parses every value (decimals, dates), so it is the CPU-heaviest
 	// stage of the stream; fan it out across batches.
@@ -368,6 +587,18 @@ func (j *IngestionJob) ApplyBatchTransformation(ctx context.Context, records <-c
 	// Apply column masking
 	if j.ColumnMasker != nil && j.ColumnMasker.HasMasks() {
 		records = transformer.Wrap(records, j.ColumnMasker)
+	}
+
+	// Dynamic streams apply contract transformations inside the flush loop so
+	// table re-announcements can retarget them to the refreshed schema.
+	if dynamicSchema {
+		if j.IngestrColumnFiller != nil && j.IngestrColumnFiller.HasColumns() {
+			records = schemaevolution.TransformBatchStream(ctx, records, j.IngestrColumnFiller)
+		}
+		if j.LoadTimestamp != nil {
+			records = transformer.Wrap(records, j.LoadTimestamp)
+		}
+		return records, nil
 	}
 
 	// Determine if schema contract transformation is needed

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -46,6 +46,7 @@ type fakeSourceTable struct {
 func TestMultiTableColumnRenamingRewritesCDCMarkers(t *testing.T) {
 	ctx := context.Background()
 	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{},
 		ColumnRenamers: map[string]*transformer.ColumnRenamer{
 			"public.items": transformer.NewColumnRenamer(map[string]string{"configData": "config_data"}),
 		},
@@ -54,7 +55,9 @@ func TestMultiTableColumnRenamingRewritesCDCMarkers(t *testing.T) {
 	records <- source.RecordBatchResult{TableName: "public.items", Batch: cdcRenameRecordBatch(t, "configData", nil, `["configData"]`)}
 	close(records)
 
-	result := <-job.ApplyBatchTransformation(ctx, records)
+	out, err := job.ApplyBatchTransformation(ctx, records)
+	require.NoError(t, err)
+	result := <-out
 	require.NoError(t, result.Err)
 	require.NotNil(t, result.Batch)
 	defer result.Batch.Release()
@@ -65,6 +68,7 @@ func TestMultiTableColumnRenamingRewritesCDCMarkers(t *testing.T) {
 func TestMultiTableDynamicAnnouncementInstallsColumnRenamer(t *testing.T) {
 	ctx := context.Background()
 	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
 		Destination: &fakeDestination{},
 		NormalizeTableInfo: func(_ context.Context, table source.SourceTableInfo, _ string) (source.SourceTableInfo, *transformer.ColumnRenamer, error) {
 			table.Schema = &schema.TableSchema{Columns: []schema.Column{
@@ -83,7 +87,8 @@ func TestMultiTableDynamicAnnouncementInstallsColumnRenamer(t *testing.T) {
 	records <- source.RecordBatchResult{TableName: rawInfo.Name, Batch: cdcRenameRecordBatch(t, "configData", nil, `["configData"]`)}
 	close(records)
 
-	out := job.ApplyBatchTransformation(ctx, records)
+	out, err := job.ApplyBatchTransformation(ctx, records)
+	require.NoError(t, err)
 	announcement := <-out
 	require.NoError(t, announcement.Err)
 	require.Equal(t, "config_data", announcement.TableInfo.Schema.Columns[0].Name)
@@ -166,8 +171,10 @@ type fakeDestination struct {
 	prepareCalls  []destination.PrepareOptions
 	writeCalls    []destination.WriteOptions
 	swapCalls     [][2]string
+	swapOptions   []destination.SwapOptions
 	mergeCalls    []destination.MergeOptions
 	diCalls       []destination.DeleteInsertOptions
+	scdCalls      []destination.SCD2Options
 	dropCalls     []string
 	execCalls     []execCall
 	truncateCalls []string
@@ -177,6 +184,7 @@ type fakeDestination struct {
 	}
 
 	prepareErrByTable map[string]error
+	prepareHook       func(destination.PrepareOptions) error
 	writeErr          error
 	swapErr           error
 	mergeErr          error
@@ -250,6 +258,9 @@ func (d *fakeDestination) PrepareTable(ctx context.Context, opts destination.Pre
 	if d.prepareErrByTable != nil {
 		err = d.prepareErrByTable[opts.Table]
 	}
+	if err == nil && d.prepareHook != nil {
+		err = d.prepareHook(opts)
+	}
 	d.mu.Unlock()
 	return err
 }
@@ -276,6 +287,7 @@ func (d *fakeDestination) SwapTable(ctx context.Context, opts destination.SwapOp
 	d.mu.Lock()
 	d.calls = append(d.calls, "SwapTable")
 	d.swapCalls = append(d.swapCalls, [2]string{opts.StagingTable, opts.TargetTable})
+	d.swapOptions = append(d.swapOptions, opts)
 	swapErr := d.swapErr
 	d.mu.Unlock()
 	return swapErr
@@ -302,6 +314,7 @@ func (d *fakeDestination) DeleteInsertTable(ctx context.Context, opts destinatio
 func (d *fakeDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
 	d.mu.Lock()
 	d.calls = append(d.calls, "SCD2Table")
+	d.scdCalls = append(d.scdCalls, opts)
 	d.mu.Unlock()
 	return nil
 }
@@ -321,6 +334,21 @@ func (d *fakeDestination) DropTable(ctx context.Context, table string) error {
 type truncateCapableDestination struct {
 	*fakeDestination
 }
+
+type nonEvolvingPlanDestination struct {
+	destination.Destination
+	tableSchema *schema.TableSchema
+}
+
+func (d *nonEvolvingPlanDestination) GetTableSchema(context.Context, string) (*schema.TableSchema, error) {
+	return d.tableSchema, nil
+}
+
+func (d *nonEvolvingPlanDestination) GetScheme() string { return "non-evolving" }
+
+type noTypeEvolutionDestination struct{ *fakeDestination }
+
+func (d *noTypeEvolutionDestination) SupportsColumnTypeChanges() bool { return false }
 
 func (d *truncateCapableDestination) TruncateTable(ctx context.Context, table string) error {
 	d.mu.Lock()
@@ -576,6 +604,108 @@ func TestApplyEvolution_NoMigrationDoesNothing(t *testing.T) {
 	job.EvolutionPlan = &schemaevolution.EvolutionPlan{Comparison: &schemaevolution.SchemaComparison{}}
 	require.NoError(t, job.ApplyEvolution(context.Background()))
 	assert.Empty(t, dest.execCalls)
+}
+
+func TestMidStreamEvolutionPlanRespectsDestinationCapabilities(t *testing.T) {
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: true}}}
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt64, Nullable: true}}}
+	cfg := &config.IngestConfig{}
+
+	t.Run("capable", func(t *testing.T) {
+		dest := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{"events": destinationSchema}}
+		plan, err := planDestinationSchemaEvolution(context.Background(), dest, "events", sourceSchema, cfg)
+		require.NoError(t, err)
+		require.Len(t, plan.Comparison.Changes, 1)
+		require.Equal(t, schema.TypeInt64, plan.FinalSchema.Columns[0].DataType)
+	})
+
+	t.Run("unsupported type change", func(t *testing.T) {
+		dest := &noTypeEvolutionDestination{fakeDestination: &fakeDestination{
+			tableSchemas: map[string]*schema.TableSchema{"events": destinationSchema},
+		}}
+		plan, err := planDestinationSchemaEvolution(context.Background(), dest, "events", sourceSchema, cfg)
+		require.NoError(t, err)
+		require.Empty(t, plan.Comparison.Changes)
+		require.Equal(t, schema.TypeInt32, plan.FinalSchema.Columns[0].DataType)
+		st := &streamTableState{}
+		configureStreamingContractState(cfg, sourceSchema, plan, st)
+		require.Equal(t, schema.TypeInt32, st.schema.Columns[0].DataType)
+		require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int32, st.schemaAligner.OutputSchema(nil).Field(0).Type))
+	})
+
+	t.Run("non evolver", func(t *testing.T) {
+		dest := &nonEvolvingPlanDestination{tableSchema: destinationSchema}
+		plan, err := planDestinationSchemaEvolution(context.Background(), dest, "events", sourceSchema, cfg)
+		require.NoError(t, err)
+		require.Empty(t, plan.Comparison.Changes)
+		require.Equal(t, schema.TypeInt32, plan.FinalSchema.Columns[0].DataType)
+		st := &streamTableState{}
+		configureStreamingContractState(cfg, sourceSchema, plan, st)
+		require.Equal(t, schema.TypeInt32, st.schema.Columns[0].DataType)
+		require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int32, st.schemaAligner.OutputSchema(nil).Field(0).Type))
+	})
+}
+
+func TestMultiTableBatchTransformationUsesPerTableContractAndFinalSchema(t *testing.T) {
+	sourceChanged := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	sourceStable := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalChanged := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+		OldColumn: &schema.Column{Name: "value", DataType: schema.TypeInt64},
+		NewColumn: schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{SchemaContract: "discard_value"},
+		Tables: []source.SourceTableInfo{
+			{Name: "changed", Schema: sourceChanged},
+			{Name: "stable", Schema: sourceStable},
+		},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			"changed": {TransformComparison: comparison, FinalSchema: finalChanged},
+		},
+	}
+
+	makeBatch := func(value string) arrow.RecordBatch {
+		ids := array.NewInt64Builder(memory.DefaultAllocator)
+		values := array.NewStringBuilder(memory.DefaultAllocator)
+		ids.Append(1)
+		values.Append(value)
+		idArray, valueArray := ids.NewArray(), values.NewArray()
+		ids.Release()
+		values.Release()
+		batch := array.NewRecordBatch(sourceChanged.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+		idArray.Release()
+		valueArray.Release()
+		return batch
+	}
+	in := make(chan source.RecordBatchResult, 2)
+	in <- source.RecordBatchResult{TableName: "changed", Batch: makeBatch("invalid")}
+	in <- source.RecordBatchResult{TableName: "stable", Batch: makeBatch("preserved")}
+	close(in)
+
+	out, err := job.ApplyBatchTransformation(context.Background(), in)
+	require.NoError(t, err)
+	changed := <-out
+	require.NoError(t, changed.Err)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, changed.Batch.Column(1).DataType()))
+	require.True(t, changed.Batch.Column(1).IsNull(0))
+	changed.Batch.Release()
+	stable := <-out
+	require.NoError(t, stable.Err)
+	require.True(t, arrow.TypeEqual(arrow.BinaryTypes.String, stable.Batch.Column(1).DataType()))
+	require.Equal(t, "preserved", stable.Batch.Column(1).(*array.String).Value(0))
+	stable.Batch.Release()
+	require.Equal(t, finalChanged.ColumnNames(), job.WriteSchemaFor("changed", sourceChanged).ColumnNames())
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/pkg/strategy/stream_schema_change_test.go
+++ b/pkg/strategy/stream_schema_change_test.go
@@ -5,10 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +52,7 @@ func TestFlushLoopRefreshEvolvesDestinationOnNewColumn(t *testing.T) {
 		{Name: "status", DataType: schema.TypeString},
 		{Name: "priority", DataType: schema.TypeInt64},
 	}}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema, PrimaryKeys: []string{"id"}})
 	require.NoError(t, err)
 
 	require.Len(t, dest.execCalls, 1)
@@ -63,6 +68,133 @@ func TestFlushLoopRefreshEvolvesDestinationOnNewColumn(t *testing.T) {
 	assert.Equal(t, "priority", st.schema.Columns[2].Name)
 }
 
+func TestStreamingRefreshRetainsContractFinalSchemaAndAlignsNewBatches(t *testing.T) {
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	newSourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value",
+	}}}
+	dest := &fakeDestination{}
+	st := &streamTableState{destTable: "dest_items", stagingTable: "stg_items", schema: finalSchema, primaryKeys: []string{"id"}}
+	loop := newFlushLoop(dest, &config.IngestConfig{NoLoadTimestamp: true, SchemaContract: "discard_value"}, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.items": st})
+	loop.evolveTablePlan = func(context.Context, string, *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		return &schemaevolution.EvolutionPlan{TransformComparison: comparison, FinalSchema: finalSchema}, nil
+	}
+
+	require.NoError(t, loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.items", Schema: newSourceSchema, PrimaryKeys: []string{"id"},
+	}, st))
+	require.Equal(t, schema.TypeInt64, st.schema.Columns[1].DataType)
+	require.NotNil(t, st.batchTransformer)
+	require.NotNil(t, st.schemaAligner)
+	require.Equal(t, schema.TypeInt64, dest.prepareCalls[0].Schema.Columns[1].DataType)
+
+	ids := array.NewInt64Builder(memory.DefaultAllocator)
+	values := array.NewStringBuilder(memory.DefaultAllocator)
+	ids.Append(1)
+	values.Append("invalid")
+	idArray, valueArray := ids.NewArray(), values.NewArray()
+	ids.Release()
+	values.Release()
+	batch := array.NewRecordBatch(newSourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	defer batch.Release()
+	contracted, err := st.batchTransformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer contracted.Release()
+	aligned, err := st.schemaAligner.Transform(contracted)
+	require.NoError(t, err)
+	defer aligned.Release()
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, aligned.Column(1).DataType()))
+	require.True(t, aligned.Column(1).IsNull(0))
+}
+
+func TestDynamicStreamingTransformationsPreserveRefreshedBatchShape(t *testing.T) {
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	refreshed := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "segment", DataType: schema.TypeString},
+	}}
+	newBatch := func() arrow.RecordBatch {
+		ids := array.NewInt64Builder(memory.DefaultAllocator)
+		segments := array.NewStringBuilder(memory.DefaultAllocator)
+		ids.Append(1)
+		segments.Append("segment-1")
+		idValues, segmentValues := ids.NewArray(), segments.NewArray()
+		ids.Release()
+		segments.Release()
+		batch := array.NewRecordBatch(refreshed.ToArrowSchema(), []arrow.Array{idValues, segmentValues}, 1)
+		idValues.Release()
+		segmentValues.Release()
+		return batch
+	}
+
+	t.Run("single table", func(t *testing.T) {
+		records := make(chan source.RecordBatchResult, 1)
+		records <- source.RecordBatchResult{Batch: newBatch()}
+		close(records)
+		job := &IngestionJob{
+			Config:        &config.IngestConfig{},
+			SchemaAligner: transformer.NewSafeTypeCaster(initial.ToArrowSchema()),
+		}
+		out, err := job.applyBatchTransformation(t.Context(), records, true)
+		require.NoError(t, err)
+		result := <-out
+		require.NoError(t, result.Err)
+		require.Equal(t, int64(2), result.Batch.NumCols())
+		require.Equal(t, "segment", result.Batch.ColumnName(1))
+		result.Batch.Release()
+	})
+
+	t.Run("multi table", func(t *testing.T) {
+		records := make(chan source.RecordBatchResult, 1)
+		records <- source.RecordBatchResult{TableName: "public.items", Batch: newBatch()}
+		close(records)
+		job := &MultiTableIngestionJob{
+			Config: &config.IngestConfig{},
+			Tables: []source.SourceTableInfo{{Name: "public.items", Schema: initial}},
+		}
+		out, err := job.applyBatchTransformation(t.Context(), records, true)
+		require.NoError(t, err)
+		result := <-out
+		require.NoError(t, result.Err)
+		require.Equal(t, int64(2), result.Batch.NumCols())
+		require.Equal(t, "segment", result.Batch.ColumnName(1))
+		result.Batch.Release()
+	})
+}
+
+func TestStreamingRefreshRejectsUnsupportedDecimalBeforeMutation(t *testing.T) {
+	current := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 2,
+	}}}
+	dest := &fakeDestination{}
+	st := &streamTableState{destTable: "dest_items", stagingTable: "stg_items", schema: current}
+	loop := newFlushLoop(dest, &config.IngestConfig{NoLoadTimestamp: true}, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.items": st})
+	plannerCalled := false
+	loop.evolveTablePlan = func(context.Context, string, *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		plannerCalled = true
+		return nil, nil
+	}
+	invalid := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2,
+	}}}
+
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: invalid}, st)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "public.items")
+	require.False(t, plannerCalled)
+	require.Empty(t, dest.prepareCalls)
+	require.Equal(t, 38, st.schema.Columns[0].Precision)
+}
+
 // A re-announcement with an unchanged schema (e.g. after a new-table rebuild)
 // must stay a no-op.
 func TestFlushLoopRefreshIgnoresUnchangedSchema(t *testing.T) {
@@ -72,7 +204,7 @@ func TestFlushLoopRefreshIgnoresUnchangedSchema(t *testing.T) {
 	}})
 
 	sameSchema := &schema.TableSchema{Columns: append([]schema.Column{}, st.schema.Columns...)}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: sameSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: sameSchema, PrimaryKeys: []string{"id"}})
 	require.NoError(t, err)
 
 	assert.Empty(t, dest.execCalls)
@@ -92,7 +224,7 @@ func TestFlushLoopRefreshHandlesTypeChange(t *testing.T) {
 		{Name: "id", DataType: schema.TypeInt64},
 		{Name: "status", DataType: schema.TypeString},
 	}}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema, PrimaryKeys: []string{"id"}})
 	require.NoError(t, err)
 
 	require.Len(t, dest.execCalls, 1)
@@ -125,7 +257,7 @@ func TestFlushLoopRefreshHonorsFreezeContract(t *testing.T) {
 		{Name: "id", DataType: schema.TypeInt32},
 		{Name: "extra", DataType: schema.TypeString},
 	}}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema, PrimaryKeys: []string{"id"}})
 	require.Error(t, err)
 	assert.Empty(t, dest.execCalls)
 }
@@ -181,7 +313,9 @@ func TestFlushLoopRefreshDetectsNullabilityOnlyChange(t *testing.T) {
 		{Name: "status", DataType: schema.TypeString, Nullable: true},
 	}}
 
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{
+		Name: "public.items", Schema: newSchema, PrimaryKeys: []string{"id"},
+	})
 	require.NoError(t, err)
 	require.Len(t, dest.execCalls, 1)
 	require.True(t, st.schema.Columns[1].Nullable)

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -13,6 +13,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 	"golang.org/x/sync/errgroup"
@@ -55,8 +57,16 @@ func NewStreamingExecutor(opts StreamingOptions) *StreamingExecutor {
 }
 
 func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) error {
-	if err := job.ApplyEvolution(ctx); err != nil {
-		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	_, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher)
+	if atomicSnapshots {
+		if err := requireManagedAtomicSnapshotAbort(job.Destination, e.opts.StateManager); err != nil {
+			return err
+		}
+	}
+	if !atomicSnapshots && e.opts.StateManager == nil {
+		if err := job.ApplyEvolution(ctx); err != nil {
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
 	}
 
 	st := &streamTableState{
@@ -69,8 +79,83 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		partitionBy:          job.Config.PartitionBy,
 		clusterBy:            job.Config.ClusterBy,
 	}
+	if err := e.requireSafeDirectCDCWrites(job.Destination, st); err != nil {
+		return err
+	}
+	configureStreamingContractState(job.Config, job.Schema, job.EvolutionPlan, st)
+	if atomicSnapshots {
+		if e.opts.StateManager == nil {
+			st.deferredEvolution = job.ApplyEvolution
+		} else {
+			st.deferredEvolution = func(ctx context.Context) error {
+				expectedIncarnation, err := boundDestinationIncarnation(e.opts.StateManager, job.Config.SourceTable, st.destTable)
+				if err != nil {
+					return err
+				}
+				return job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation)
+			}
+		}
+		if job.EvolutionPlan != nil && job.EvolutionPlan.FinalSchema != nil {
+			configureAtomicStreamingContractState(job.Config, job.Schema, job.EvolutionPlan, st)
+		} else if job.DestinationSchema != nil {
+			st.atomicTargetSchema = job.DestinationSchema
+			mode, _ := schemaevolution.ParseContractMode(job.Config.SchemaContract)
+			switch mode {
+			case schemaevolution.ContractDiscardValue:
+				st.atomicBatchTransformer = schemaevolution.NewDiscardValueTransformer(job.SchemaComparison, job.Schema, st.atomicTargetSchema)
+			case schemaevolution.ContractDiscardRow:
+				st.atomicBatchTransformer = schemaevolution.NewDiscardRowTransformer(job.Schema, st.atomicTargetSchema, job.SchemaComparison)
+			}
+			if st.atomicBatchTransformer != nil {
+				st.atomicWriteSchema = st.atomicTargetSchema
+				st.schemaAligner = transformer.NewSafeTypeCaster(st.atomicWriteSchema.ToArrowSchema())
+			}
+		}
+	}
+	loop := newFlushLoop(job.Destination, job.Config, e.opts, map[string]*streamTableState{"": st})
+	defer loop.cleanup(ctx)
+	if publisher, ok := job.Destination.(destination.AtomicSnapshotPublisher); ok && e.opts.StateManager != nil {
+		position, recovered, err := recoverManagedAtomicSnapshotBeforeRead(
+			ctx, job.Destination, publisher, e.opts.StateManager, job.Config.SourceTable, st.destTable,
+		)
+		if err != nil {
+			return err
+		}
+		if recovered {
+			job.Config.CDCResumeLSN = position
+			job.Config.CDCResumeIncarnation, job.Config.CDCResumeSchemaFingerprint = e.opts.StateManager.CurrentSourceMetadata(job.Config.SourceTable)
+		}
+	}
 	if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
 		return err
+	}
+	if e.opts.StateManager != nil {
+		if err := e.opts.StateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, st.destTable); err != nil {
+			return fmt.Errorf("failed to bind CDC destination before starting stream: %w", err)
+		}
+		if e.opts.StateManager.BoundDestinationIncarnation(job.Config.SourceTable) == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+		}
+	}
+	if !atomicSnapshots && e.opts.StateManager != nil {
+		expectedIncarnation, err := boundDestinationIncarnation(e.opts.StateManager, job.Config.SourceTable, st.destTable)
+		if err != nil {
+			return err
+		}
+		if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
+	}
+	if atomicSnapshots && strings.TrimSpace(job.Config.CDCResumeLSN) != "" && !job.Config.FullRefresh && st.deferredEvolution != nil {
+		if err := st.deferredEvolution(ctx); err != nil {
+			return fmt.Errorf("failed to apply schema evolution before resuming stream: %w", err)
+		}
+		st.evolutionApplied = true
+		if e.opts.StateManager != nil {
+			if err := e.opts.StateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, st.destTable); err != nil {
+				return fmt.Errorf("failed to revalidate CDC destination after schema evolution: %w", err)
+			}
+		}
 	}
 	parallelism := job.Config.ExtractParallelism
 	if parallelism <= 0 {
@@ -79,7 +164,7 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 
 	readCtx, cancelRead := context.WithCancel(ctx)
 	defer cancelRead()
-	records, err := job.GetRecords(readCtx, source.ReadOptions{
+	records, err := job.getStreamingRecords(readCtx, source.ReadOptions{
 		IncrementalKey:             job.Config.IncrementalKey,
 		IntervalStart:              job.Config.IntervalStart,
 		PageSize:                   job.Config.PageSize,
@@ -92,6 +177,7 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		CDCSlotSuffix:              job.Config.CDCSlotSuffix,
 		CDCLegacySlotSuffix:        job.Config.CDCLegacySlotSuffix,
 		CDCSnapshotReplace:         st.isCDC && supportsCDCSnapshotReplace(job.Destination),
+		CDCStableDataBatches:       managedStreamingNeedsStableDataBatches(e.opts, map[string]*streamTableState{"": st}, false),
 		Streaming:                  true,
 		FlushInterval:              job.Config.FlushInterval,
 		FlushRecords:               job.Config.FlushRecords,
@@ -104,7 +190,6 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		records = job.Tracker.Wrap(records)
 	}
 
-	loop := newFlushLoop(job.Destination, job.Config, e.opts, map[string]*streamTableState{"": st})
 	// CDC sources re-announce their table (with its refreshed schema) after
 	// rebuilding their stream around mid-stream DDL; evolve the destination
 	// before the new-shape batches arrive. Sources that never announce
@@ -112,7 +197,9 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 	loop.evolveTable = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error {
 		return evolveDestinationTable(ctx, job.Destination, destTable, newSchema, job.Config)
 	}
-	defer loop.cleanup(ctx)
+	loop.evolveTablePlan = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		return evolveDestinationTablePlan(ctx, job.Destination, destTable, newSchema, job.Config)
+	}
 	err = loop.run(ctx, records)
 	if err != nil {
 		cancelRead()
@@ -123,6 +210,11 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 
 // ExecuteMultiTable runs the streaming loop over a multi-table source (CDC).
 func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTableIngestionJob) error {
+	if _, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher); atomicSnapshots {
+		if err := requireManagedAtomicSnapshotAbort(job.Destination, e.opts.StateManager); err != nil {
+			return err
+		}
+	}
 	anyTableHasCDC := false
 	for _, ti := range job.Tables {
 		if hasCDCColumns(ti.Schema) {
@@ -135,26 +227,91 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	}
 
 	tables := make(map[string]*streamTableState, len(job.Tables))
+	loop := newFlushLoop(job.Destination, job.Config, e.opts, tables)
+	defer loop.cleanup(ctx)
 	for _, ti := range job.Tables {
+		sourceSchema := ti.Schema
 		st := &streamTableState{
-			destTable:         job.GetDestTableName(ti.Name),
-			schema:            ti.Schema,
-			primaryKeys:       ti.PrimaryKeys,
-			incrementalKey:    ti.Schema.IncrementalKey,
-			isCDC:             hasCDCColumns(ti.Schema),
-			incarnation:       ti.Incarnation,
-			schemaFingerprint: ti.SchemaFingerprint,
+			destTable:            job.GetDestTableName(ti.Name),
+			schema:               ti.Schema,
+			primaryKeys:          ti.PrimaryKeys,
+			incrementalKey:       ti.Schema.IncrementalKey,
+			incrementalPredicate: job.Config.IncrementalPredicate,
+			isCDC:                hasCDCColumns(ti.Schema),
+			incarnation:          ti.Incarnation,
+			schemaFingerprint:    ti.SchemaFingerprint,
 		}
-
-		if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
-			return fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+		if err := e.requireSafeDirectCDCWrites(job.Destination, st); err != nil {
+			return err
 		}
+		configureStreamingContractState(job.Config, sourceSchema, job.EvolutionPlans[ti.Name], st)
+		if _, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher); atomicSnapshots {
+			sourceTable := ti.Name
+			if e.opts.StateManager == nil {
+				st.deferredEvolution = func(ctx context.Context) error { return job.ApplyEvolutionFor(ctx, sourceTable) }
+			} else {
+				st.deferredEvolution = func(ctx context.Context) error {
+					expectedIncarnation, err := boundDestinationIncarnation(e.opts.StateManager, sourceTable, st.destTable)
+					if err != nil {
+						return err
+					}
+					return job.ApplyEvolutionForIfIncarnation(ctx, sourceTable, expectedIncarnation)
+				}
+			}
+			configureAtomicStreamingContractState(job.Config, sourceSchema, job.EvolutionPlans[sourceTable], st)
+		} else if e.opts.StateManager == nil {
+			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+				return fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+			}
+		}
+		if publisher, ok := job.Destination.(destination.AtomicSnapshotPublisher); ok && e.opts.StateManager != nil {
+			position, recovered, err := recoverManagedAtomicSnapshotBeforeRead(
+				ctx, job.Destination, publisher, e.opts.StateManager, ti.Name, st.destTable,
+			)
+			if err != nil {
+				return err
+			}
+			if recovered {
+				if job.CDCResumeLSNs == nil {
+					job.CDCResumeLSNs = make(map[string]string)
+				}
+				job.CDCResumeLSNs[ti.Name] = position
+			}
+		}
+		tables[ti.Name] = st
 		if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
 			return err
 		}
-		tables[ti.Name] = st
+		if e.opts.StateManager != nil {
+			if err := e.opts.StateManager.BindDestinationIncarnation(ctx, ti.Name, st.destTable); err != nil {
+				return fmt.Errorf("failed to bind CDC destination for %s before starting stream: %w", ti.Name, err)
+			}
+			if e.opts.StateManager.BoundDestinationIncarnation(ti.Name) == "" {
+				return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+			}
+		}
+		if _, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher); !atomicSnapshots && e.opts.StateManager != nil {
+			expectedIncarnation, err := boundDestinationIncarnation(e.opts.StateManager, ti.Name, st.destTable)
+			if err != nil {
+				return err
+			}
+			if err := job.ApplyEvolutionForIfIncarnation(ctx, ti.Name, expectedIncarnation); err != nil {
+				return fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+			}
+		}
+		if _, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher); atomicSnapshots &&
+			strings.TrimSpace(job.CDCResumeLSNs[ti.Name]) != "" && !job.Config.FullRefresh && st.deferredEvolution != nil {
+			if err := st.deferredEvolution(ctx); err != nil {
+				return fmt.Errorf("failed to apply schema evolution before resuming stream for %s: %w", ti.Name, err)
+			}
+			st.evolutionApplied = true
+			if e.opts.StateManager != nil {
+				if err := e.opts.StateManager.BindDestinationIncarnation(ctx, ti.Name, st.destTable); err != nil {
+					return fmt.Errorf("failed to revalidate CDC destination for %s after schema evolution: %w", ti.Name, err)
+				}
+			}
+		}
 	}
-
 	parallelism := job.Config.ExtractParallelism
 	if parallelism <= 0 {
 		parallelism = 4
@@ -167,16 +324,17 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		knownTables = append(knownTables, table.Name)
 	}
 	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
-	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
+	records, err := job.readAllStreaming(readCtx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
-			Parallelism:         parallelism,
-			PageSize:            job.Config.PageSize,
-			CDCSlotSuffix:       job.Config.CDCSlotSuffix,
-			CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
-			CDCSnapshotReplace:  (anyTableHasCDC || e.opts.StateManager != nil) && supportsCDCSnapshotReplace(job.Destination),
-			Streaming:           true,
-			FlushInterval:       job.Config.FlushInterval,
-			FlushRecords:        job.Config.FlushRecords,
+			Parallelism:          parallelism,
+			PageSize:             job.Config.PageSize,
+			CDCSlotSuffix:        job.Config.CDCSlotSuffix,
+			CDCLegacySlotSuffix:  job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace:   (anyTableHasCDC || e.opts.StateManager != nil) && supportsCDCSnapshotReplace(job.Destination),
+			CDCStableDataBatches: managedStreamingNeedsStableDataBatches(e.opts, tables, job.Config.FullRefresh),
+			Streaming:            true,
+			FlushInterval:        job.Config.FlushInterval,
+			FlushRecords:         job.Config.FlushRecords,
 		},
 		KnownTables:                 knownTables,
 		CDCResumeLSNs:               job.CDCResumeLSNs,
@@ -186,12 +344,10 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	if err != nil {
 		return fmt.Errorf("failed to read from multi-table source: %w", err)
 	}
-
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
 
-	loop := newFlushLoop(job.Destination, job.Config, e.opts, tables)
 	// CDC sources announce tables created mid-stream before emitting their
 	// batches. Normal runs stop at that boundary so a restart can include the
 	// table in the startup set; explicit full refresh retains dynamic handling.
@@ -206,13 +362,41 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 			return nil, fmt.Errorf("newly discovered table %s has no schema", ti.Name)
 		}
 		st := &streamTableState{
-			destTable:         multiTableDestName(job.Destination, ti),
-			schema:            ti.Schema,
-			primaryKeys:       ti.PrimaryKeys,
-			incrementalKey:    ti.Schema.IncrementalKey,
-			isCDC:             hasCDCColumns(ti.Schema),
-			incarnation:       ti.Incarnation,
-			schemaFingerprint: ti.SchemaFingerprint,
+			destTable:            multiTableDestName(job.Destination, ti),
+			schema:               ti.Schema,
+			primaryKeys:          ti.PrimaryKeys,
+			incrementalKey:       ti.Schema.IncrementalKey,
+			incrementalPredicate: job.Config.IncrementalPredicate,
+			isCDC:                hasCDCColumns(ti.Schema),
+			incarnation:          ti.Incarnation,
+			schemaFingerprint:    ti.SchemaFingerprint,
+		}
+		if err := e.requireSafeDirectCDCWrites(job.Destination, st); err != nil {
+			return nil, err
+		}
+		plan, err := planDestinationSchemaEvolution(ctx, job.Destination, st.destTable, ti.Schema, job.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate schema contract for newly discovered table %s: %w", ti.Name, err)
+		}
+		configureStreamingContractState(job.Config, ti.Schema, plan, st)
+		_, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher)
+		if atomicSnapshots {
+			if e.opts.StateManager == nil {
+				st.deferredEvolution = func(ctx context.Context) error { return applyEvolutionPlan(ctx, job.Destination, plan) }
+			} else {
+				st.deferredEvolution = func(ctx context.Context) error {
+					expectedIncarnation, err := boundDestinationIncarnation(e.opts.StateManager, ti.Name, st.destTable)
+					if err != nil {
+						return err
+					}
+					return applyEvolutionPlanIfIncarnation(ctx, job.Destination, plan, expectedIncarnation)
+				}
+			}
+			configureAtomicStreamingContractState(job.Config, ti.Schema, plan, st)
+		} else if e.opts.StateManager == nil {
+			if err := applyEvolutionPlan(ctx, job.Destination, plan); err != nil {
+				return nil, fmt.Errorf("failed to evolve newly discovered table %s: %w", ti.Name, err)
+			}
 		}
 		for sourceTable, destTable := range job.TableDestNames {
 			if sourceTable != ti.Name && destTable == st.destTable {
@@ -233,12 +417,16 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 			}
 		}
 		pendingSafeBoundary := e.opts.StateManager != nil && e.opts.StateManager.HasPendingLateSnapshotBoundary(ti.Name)
-		if pendingSafeBoundary {
+		if pendingSafeBoundary && !atomicSnapshots {
 			if err := e.prepareLateStagingTable(ctx, job.Destination, job.Config, st); err != nil {
+				cleanupUnregisteredStreamTable(ctx, job.Destination, st)
 				return nil, err
 			}
-		} else if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
-			return nil, err
+		} else if !pendingSafeBoundary {
+			if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
+				cleanupUnregisteredStreamTable(ctx, job.Destination, st)
+				return nil, err
+			}
 		}
 		if job.TableDestNames == nil {
 			job.TableDestNames = make(map[string]string)
@@ -246,9 +434,25 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		job.TableDestNames[ti.Name] = st.destTable
 		if e.opts.StateManager != nil {
 			if err := e.opts.StateManager.RegisterTableState(ctx, ti.Name, st.destTable, ti.Incarnation, ti.SchemaFingerprint); err != nil {
+				cleanupUnregisteredStreamTable(ctx, job.Destination, st)
 				return nil, err
 			}
+			if !atomicSnapshots {
+				expectedIncarnation, err := boundDestinationIncarnation(e.opts.StateManager, ti.Name, st.destTable)
+				if err != nil {
+					cleanupUnregisteredStreamTable(ctx, job.Destination, st)
+					return nil, err
+				}
+				if err := applyEvolutionPlanIfIncarnation(ctx, job.Destination, plan, expectedIncarnation); err != nil {
+					cleanupUnregisteredStreamTable(ctx, job.Destination, st)
+					return nil, fmt.Errorf("failed to evolve newly discovered table %s: %w", ti.Name, err)
+				}
+			}
 		}
+		if job.EvolutionPlans == nil {
+			job.EvolutionPlans = make(map[string]*schemaevolution.EvolutionPlan)
+		}
+		job.EvolutionPlans[ti.Name] = plan
 		return st, nil
 	}
 	// CDC sources also re-announce a table (with its refreshed schema) after
@@ -258,13 +462,36 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	loop.evolveTable = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error {
 		return evolveDestinationTable(ctx, job.Destination, destTable, newSchema, job.Config)
 	}
-	defer loop.cleanup(ctx)
+	loop.evolveTablePlan = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		return evolveDestinationTablePlan(ctx, job.Destination, destTable, newSchema, job.Config)
+	}
 	err = loop.run(ctx, records)
 	if err != nil {
 		cancelRead()
 		drainAndReleaseUntil(records, streamAbortDrainTimeout)
 	}
 	return err
+}
+
+func cleanupUnregisteredStreamTable(ctx context.Context, dest destination.Destination, st *streamTableState) {
+	if st == nil || connectorLeaseLoss(ctx) != nil {
+		return
+	}
+	if st.targetCreatedByRun && !st.atomicPublishAttempted {
+		cleanupFailedOwnedDirectReplace(ctx, dest, st.destTable, true, st.targetOwnershipToken)
+		st.targetCreatedByRun = false
+	}
+	if st.stagingTable == "" {
+		return
+	}
+	cleanupCtx, cancel := detachedLeaseContext(ctx, streamFinalFlushTimeout)
+	defer cancel()
+	if connectorLeaseLoss(cleanupCtx) != nil {
+		return
+	}
+	if err := dest.DropTable(cleanupCtx, st.stagingTable); err != nil {
+		config.Debug("[STREAM] Warning: failed to drop unregistered staging table %s: %v", st.stagingTable, err)
+	}
 }
 
 func (e *StreamingExecutor) lateTargetPrepareOptions(st *streamTableState) destination.PrepareOptions {
@@ -309,6 +536,52 @@ func (e *StreamingExecutor) prepareLateStagingTable(ctx context.Context, dest de
 	return connectorLeaseLoss(ctx)
 }
 
+func configureStreamingContractState(cfg *config.IngestConfig, sourceSchema *schema.TableSchema, plan *schemaevolution.EvolutionPlan, st *streamTableState) {
+	if plan == nil || plan.FinalSchema == nil {
+		st.schema = sourceSchema
+		st.batchTransformer = nil
+		st.schemaAligner = nil
+		return
+	}
+	st.schema = destination.StagingIngestSchema(sourceSchema, plan.FinalSchema)
+	st.schema = destination.PreserveSourceCDCColumnTypes(st.schema, sourceSchema)
+	comparison := plan.TransformComparison
+	if comparison == nil {
+		comparison = plan.Comparison
+	}
+	mode, _ := schemaevolution.ParseContractMode(cfg.SchemaContract)
+	switch mode {
+	case schemaevolution.ContractDiscardValue:
+		st.batchTransformer = schemaevolution.NewDiscardValueTransformer(comparison, sourceSchema, plan.FinalSchema)
+	case schemaevolution.ContractDiscardRow:
+		st.batchTransformer = schemaevolution.NewDiscardRowTransformer(sourceSchema, plan.FinalSchema, comparison)
+	default:
+		st.batchTransformer = nil
+	}
+	st.schemaAligner = transformer.NewSafeTypeCaster(st.schema.ToArrowSchema())
+}
+
+func configureAtomicStreamingContractState(cfg *config.IngestConfig, sourceSchema *schema.TableSchema, plan *schemaevolution.EvolutionPlan, st *streamTableState) {
+	if plan == nil || plan.FinalSchema == nil {
+		return
+	}
+	st.atomicTargetSchema = plan.FinalSchema
+	mode, _ := schemaevolution.ParseContractMode(cfg.SchemaContract)
+	if mode != schemaevolution.ContractDiscardValue && mode != schemaevolution.ContractDiscardRow {
+		return
+	}
+	comparison := plan.TransformComparison
+	if comparison == nil {
+		comparison = plan.Comparison
+	}
+	st.atomicWriteSchema = st.schema
+	if mode == schemaevolution.ContractDiscardValue {
+		st.atomicBatchTransformer = schemaevolution.NewDiscardValueTransformer(comparison, sourceSchema, plan.FinalSchema)
+	} else {
+		st.atomicBatchTransformer = schemaevolution.NewDiscardRowTransformer(sourceSchema, plan.FinalSchema, comparison)
+	}
+}
+
 // multiTableDestName computes the destination table name for a source table
 // discovered mid-stream, matching the pipeline's upfront naming.
 func multiTableDestName(dest destination.Destination, ti source.SourceTableInfo) string {
@@ -341,6 +614,9 @@ func withLoadTimestampColumn(s *schema.TableSchema) *schema.TableSchema {
 // prepareTable sets up the destination (and staging, for merge) tables for one
 // stream table and records the staging name on the state.
 func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.Destination, cfg *config.IngestConfig, st *streamTableState) error {
+	if err := e.requireSafeDirectCDCWrites(dest, st); err != nil {
+		return err
+	}
 	switch e.opts.Strategy {
 	case config.StrategyMerge:
 		if st.isCDC && len(st.primaryKeys) == 0 {
@@ -348,6 +624,17 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 			// directly in the destination table and flush skips the merge
 			// (stagingTable stays empty). See isAppendOnlyCDCTable in merge.go.
 			return prepareAppendOnlyCDCTable(ctx, dest, st.destTable, st.schema)
+		}
+		if _, ok := dest.(destination.DirectMergeWriter); ok {
+			st.directMerge = true
+			return prepareMergeTarget(ctx, dest, mergeTableParams{
+				DestTable:   st.destTable,
+				Schema:      st.schema,
+				PrimaryKeys: st.primaryKeys,
+				PartitionBy: st.partitionBy,
+				ClusterBy:   st.clusterBy,
+				IsCDC:       st.isCDC,
+			})
 		}
 		st.stagingTable = managedStagingTableName(dest, st.destTable, "stream", cfg.StagingDataset)
 		output.Statusf("[STREAM] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), st.stagingTable)
@@ -374,14 +661,33 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 		if st.isCDC {
 			prepSchema = st.schema
 		}
+		if _, atomicSnapshots := dest.(destination.AtomicSnapshotPublisher); atomicSnapshots && st.isCDC {
+			existingSchema, err := dest.GetTableSchema(ctx, st.destTable)
+			if err != nil {
+				return fmt.Errorf("failed to inspect destination table %s before atomic append streaming: %w", st.destTable, err)
+			}
+			if existingSchema != nil {
+				return nil
+			}
+			st.targetOwnershipToken = newTargetOwnershipToken(dest, false)
+			if st.targetOwnershipToken == "" {
+				return fmt.Errorf("destination %s cannot safely clean up a failed atomic append target", dest.GetScheme())
+			}
+			st.targetCreatedByRun = true
+			prepSchema = st.schema
+			if st.atomicTargetSchema != nil {
+				prepSchema = st.atomicTargetSchema
+			}
+		}
 		if err := dest.PrepareTable(ctx, destination.PrepareOptions{
-			Table:       st.destTable,
-			Schema:      prepSchema,
-			DropFirst:   false,
-			PrimaryKeys: nil,
-			PartitionBy: st.partitionBy,
-			ClusterBy:   st.clusterBy,
-			CDCMode:     st.isCDC,
+			Table:          st.destTable,
+			Schema:         prepSchema,
+			DropFirst:      false,
+			PrimaryKeys:    nil,
+			PartitionBy:    st.partitionBy,
+			ClusterBy:      st.clusterBy,
+			CDCMode:        st.isCDC,
+			OwnershipToken: st.targetOwnershipToken,
 		}); err != nil {
 			return fmt.Errorf("failed to prepare destination table %s: %w", st.destTable, err)
 		}
@@ -391,23 +697,57 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 	}
 }
 
+func (e *StreamingExecutor) requireSafeDirectCDCWrites(dest destination.Destination, st *streamTableState) error {
+	if st == nil || !st.isCDC {
+		return nil
+	}
+	if e.opts.StateManager != nil && e.opts.Strategy == config.StrategyAppend {
+		return requireIdempotentCommitTokenWrites(dest, "managed streaming CDC append")
+	}
+	if e.opts.Strategy == config.StrategyMerge && len(st.primaryKeys) == 0 {
+		if err := requireIdempotentCommitTokenWrites(dest, "streaming merge for keyless CDC table "+st.destTable); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // streamTableState tracks one destination table's buffered batches across
 // flush cycles. stagingTable is empty in append mode.
 type streamTableState struct {
-	destTable            string
-	stagingTable         string
-	schema               *schema.TableSchema
-	primaryKeys          []string
-	incrementalKey       string
-	incrementalPredicate string
-	isCDC                bool
-	partitionBy          string
-	clusterBy            []string
-	incarnation          string
-	schemaFingerprint    string
+	sourceTable            string
+	destTable              string
+	stagingTable           string
+	schema                 *schema.TableSchema
+	primaryKeys            []string
+	incrementalKey         string
+	incrementalPredicate   string
+	isCDC                  bool
+	partitionBy            string
+	clusterBy              []string
+	incarnation            string
+	schemaFingerprint      string
+	directMerge            bool
+	atomicSnapshot         bool
+	atomicTargetSchema     *schema.TableSchema
+	atomicWriteSchema      *schema.TableSchema
+	atomicBatchTransformer schemaevolution.BatchTransformer
+	batchTransformer       schemaevolution.BatchTransformer
+	schemaAligner          *transformer.TypeCaster
+	snapshotAttemptID      string
+	atomicPublishAttempted bool
+	targetCreatedByRun     bool
+	targetOwnershipToken   string
+	snapshotStarted        bool
+	deferredEvolution      func(context.Context) error
+	evolutionApplied       bool
 
-	pending     []arrow.RecordBatch
-	pendingRows int64
+	pending           []arrow.RecordBatch
+	pendingBoundaries []dataWriteBoundary
+	pendingRows       int64
+
+	checkpointID       source.DurableID
+	checkpointPosition string
 }
 
 type flushLoop struct {
@@ -425,7 +765,8 @@ type flushLoop struct {
 	// source schema changed mid-stream (the source re-announces it with the
 	// refreshed schema after rebuilding its stream). Nil means mid-stream
 	// schema changes are unsupported and re-announcements are ignored.
-	evolveTable func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error
+	evolveTable     func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error
+	evolveTablePlan func(ctx context.Context, destTable string, newSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error)
 
 	buffered int64 // rows buffered across all tables
 
@@ -435,6 +776,9 @@ type flushLoop struct {
 	lastToken    any
 	tokenDirty   bool
 	pendingState source.CDCStateCommitToken
+
+	lastDurableCommitID       source.DurableID
+	lastDurableCommitPosition string
 	// pendingTruncates contains source tables whose previous snapshot marker was
 	// invalidated before applying a replicated WAL TRUNCATE. The next durable
 	// source position completes the new empty-table snapshot boundary.
@@ -442,6 +786,41 @@ type flushLoop struct {
 	legacyFinalized  bool
 
 	cycles int64
+}
+
+type dataWriteBoundary struct {
+	SourceTable string
+	Token       source.DurableID
+	Position    string
+}
+
+func managedCDCDataWriteID(sourceTable string, batchID source.DurableID) source.DurableID {
+	if sourceTable == "" || batchID == "" {
+		return ""
+	}
+	return source.DurableID("managed-cdc-data-v1:" + destination.CDCTargetKey(sourceTable, string(batchID)))
+}
+
+func combinedCommitMetadata(boundaries []dataWriteBoundary) (source.DurableID, string) {
+	var position string
+	for _, boundary := range boundaries {
+		if boundary.Position != "" {
+			position = boundary.Position
+		}
+	}
+	if len(boundaries) == 1 {
+		return boundaries[0].Token, position
+	}
+	return "", position
+}
+
+func hasExactDataWriteBoundary(boundaries []dataWriteBoundary) bool {
+	for _, boundary := range boundaries {
+		if boundary.Token != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func newFlushLoop(dest destination.Destination, cfg *config.IngestConfig, opts StreamingOptions, tables map[string]*streamTableState) *flushLoop {
@@ -469,6 +848,9 @@ func (l *flushLoop) run(ctx context.Context, records <-chan source.RecordBatchRe
 			if !ok {
 				// Source ended on its own (e.g. its context was cancelled and
 				// it closed the channel before we observed ctx.Done).
+				if ctx.Err() != nil && l.hasActiveAtomicSnapshot() {
+					return ctx.Err()
+				}
 				return l.finalFlush(ctx)
 			}
 			if res.Err != nil {
@@ -542,11 +924,57 @@ func (l *flushLoop) processResult(ctx context.Context, res source.RecordBatchRes
 			return err
 		}
 	}
+	if err := l.applyDeferredEvolution(ctx, res); err != nil {
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+		return err
+	}
+	if err := l.transformResultBatch(ctx, &res); err != nil {
+		return err
+	}
 	if err := l.handleResult(ctx, res); err != nil {
 		return err
 	}
 	if token, ok := res.CommitToken.(source.CDCStateCommitToken); ok && len(token.SnapshotPositions) > 0 && (l.buffered > 0 || l.tokenDirty) {
 		return l.flush(ctx)
+	}
+	return nil
+}
+
+func (l *flushLoop) transformResultBatch(ctx context.Context, res *source.RecordBatchResult) error {
+	if res.Batch == nil || res.Err != nil {
+		return nil
+	}
+	st, ok := l.tableState(res.TableName)
+	if !ok {
+		return nil
+	}
+
+	batchTransformer := st.batchTransformer
+	if st.atomicSnapshot {
+		batchTransformer = st.atomicBatchTransformer
+	}
+	if batchTransformer != nil {
+		transformed, err := batchTransformer.Transform(ctx, res.Batch)
+		if err != nil {
+			res.Batch.Release()
+			res.Batch = nil
+			return fmt.Errorf("streaming contract transformation failed for table %s: %w", st.destTable, err)
+		}
+		if transformed != res.Batch {
+			res.Batch.Release()
+			res.Batch = transformed
+		}
+	}
+	if st.schemaAligner != nil {
+		transformed, err := st.schemaAligner.Transform(res.Batch)
+		res.Batch.Release()
+		if err != nil {
+			res.Batch = nil
+			return fmt.Errorf("streaming schema alignment failed for table %s: %w", st.destTable, err)
+		}
+		res.Batch = transformed
 	}
 	return nil
 }
@@ -567,7 +995,17 @@ func (l *flushLoop) invalidateSnapshot(ctx context.Context, invalidation source.
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := l.opts.StateManager.InvalidateSnapshot(ctx, invalidation.TableName, st.destTable, invalidation.Incarnation); err != nil {
+	if st.atomicSnapshot {
+		if st.atomicPublishAttempted {
+			return fmt.Errorf("cannot invalidate snapshot for table %s while atomic publication outcome is unknown", st.destTable)
+		}
+		if err := l.abortUnpublishedAtomicSnapshot(ctx, invalidation.TableName, st); err != nil {
+			return fmt.Errorf("failed to abort stale atomic snapshot for table %s: %w", st.destTable, err)
+		}
+	}
+	if err := l.opts.StateManager.InvalidateSnapshotStatePreservingDestination(
+		ctx, invalidation.TableName, st.destTable, invalidation.Incarnation, invalidation.SchemaFingerprint,
+	); err != nil {
 		return err
 	}
 	st.incarnation = invalidation.Incarnation
@@ -586,8 +1024,14 @@ func (l *flushLoop) tableState(sourceTable string) (*streamTableState, bool) {
 
 func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResult) error {
 	if !res.Truncate {
-		l.buffer(res)
-		return nil
+		return l.bufferResult(res)
+	}
+	if !res.CDCWALTruncate {
+		if _, atomicSnapshots := l.dest.(destination.AtomicSnapshotPublisher); atomicSnapshots {
+			if err := requireManagedAtomicSnapshotAbort(l.dest, l.opts.StateManager); err != nil {
+				return err
+			}
+		}
 	}
 
 	if l.buffered > 0 || l.tokenDirty {
@@ -603,36 +1047,89 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 		return fmt.Errorf("source requested truncate for unknown table %q", res.TableName)
 	}
 	stateTable := ""
+	lateSnapshotBoundaryHandled := false
 	if l.opts.StateManager != nil {
 		stateTable = l.stateSourceTable(res.TableName)
 		if stateTable == "" {
 			return fmt.Errorf("cannot resolve source table for CDC truncate")
 		}
 		if res.CDCWALTruncate {
-			if err := l.opts.StateManager.InvalidateSnapshot(ctx, stateTable, st.destTable, st.incarnation); err != nil {
+			if err := l.opts.StateManager.InvalidateSnapshotPreservingDestination(ctx, stateTable, st.destTable, st.incarnation); err != nil {
 				return fmt.Errorf("failed to invalidate CDC state before source truncate for %s: %w", stateTable, err)
 			}
 		}
 		if !res.CDCWALTruncate {
-			handled, err := l.opts.StateManager.ApplyLateSnapshotBoundary(ctx, stateTable, st.destTable)
+			var handled bool
+			var err error
+			if _, atomicSnapshots := l.dest.(destination.AtomicSnapshotPublisher); atomicSnapshots {
+				handled, err = l.opts.StateManager.BindLateAtomicSnapshotBoundary(ctx, stateTable, st.destTable)
+			} else {
+				handled, err = l.opts.StateManager.ApplyLateSnapshotBoundary(ctx, stateTable, st.destTable)
+			}
 			if err != nil {
 				return err
 			}
-			if handled {
-				l.buffer(res)
-				return nil
-			}
+			lateSnapshotBoundaryHandled = handled
 		}
-		if err := l.opts.StateManager.BindDestinationIncarnation(ctx, stateTable, st.destTable); err != nil {
-			return fmt.Errorf("failed to bind CDC destination before source truncate for %s: %w", stateTable, err)
+		if !res.CDCWALTruncate && !lateSnapshotBoundaryHandled {
+			if err := l.opts.StateManager.BindDestinationIncarnation(ctx, stateTable, st.destTable); err != nil {
+				return fmt.Errorf("failed to bind CDC destination before source truncate for %s: %w", stateTable, err)
+			}
 		}
 	}
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
+	if !res.CDCWALTruncate {
+		if publisher, ok := l.dest.(destination.AtomicSnapshotPublisher); ok {
+			if st.snapshotStarted && st.snapshotAttemptID != "" {
+				if st.atomicPublishAttempted {
+					return fmt.Errorf("cannot restart atomic snapshot for table %s while publication outcome is unknown", st.destTable)
+				}
+				if err := l.abortUnpublishedAtomicSnapshot(ctx, stateTable, st); err != nil {
+					return fmt.Errorf("failed to abort previous atomic snapshot for table %s: %w", st.destTable, err)
+				}
+			}
+			attemptID, err := atomicSnapshotAttemptID(ctx, l.opts.StateManager, stateTable, st.destTable)
+			if err != nil {
+				return fmt.Errorf("failed to establish durable atomic snapshot attempt for %s: %w", st.destTable, err)
+			}
+			st.snapshotStarted = true
+			st.snapshotAttemptID = attemptID
+			st.atomicPublishAttempted = false
+			expectedIncarnation := ""
+			if l.opts.StateManager != nil && l.opts.StateManager.dest != nil {
+				expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(stateTable)
+				if expectedIncarnation == "" {
+					return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+				}
+			}
+			if err := publisher.BeginAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+				Table: st.destTable, Schema: l.atomicSnapshotWriteSchema(st), TargetSchema: l.atomicSnapshotTargetSchema(st), PrimaryKeys: st.primaryKeys,
+				PartitionBy: st.partitionBy, ClusterBy: st.clusterBy, Parallelism: l.cfg.EffectiveDestinationParallelism(), AttemptID: st.snapshotAttemptID,
+				CDCExpectedIncarnation: expectedIncarnation,
+			}); err != nil {
+				return fmt.Errorf("failed to begin atomic snapshot for table %s: %w", st.destTable, err)
+			}
+			st.atomicSnapshot = true
+			return l.bufferResult(res)
+		}
+		if lateSnapshotBoundaryHandled {
+			return l.bufferResult(res)
+		}
+	}
 	var truncateErr error
 	if res.CDCWALTruncate {
-		truncateErr = destination.ApplyCDCTruncate(ctx, l.dest, st.destTable)
+		if l.opts.StateManager != nil {
+			truncateErr = destination.ApplyCDCTruncateIfIncarnation(
+				ctx,
+				l.dest,
+				st.destTable,
+				l.opts.StateManager.BoundDestinationIncarnation(stateTable),
+			)
+		} else {
+			truncateErr = destination.ApplyCDCTruncate(ctx, l.dest, st.destTable)
+		}
 	} else {
 		truncateErr = destination.ApplyTruncate(ctx, l.dest, st.destTable)
 	}
@@ -645,8 +1142,7 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 	if stateTable != "" && res.CDCWALTruncate {
 		l.pendingTruncates[stateTable] = st.incarnation
 	}
-	l.buffer(res)
-	return nil
+	return l.bufferResult(res)
 }
 
 func (l *flushLoop) stateSourceTable(recordTable string) string {
@@ -657,11 +1153,54 @@ func (l *flushLoop) stateSourceTable(recordTable string) string {
 		return l.cfg.SourceTable
 	}
 	if len(l.tables) == 1 {
-		for table := range l.tables {
+		for table, st := range l.tables {
+			if table == "" && st.sourceTable != "" {
+				return st.sourceTable
+			}
 			return table
 		}
 	}
 	return ""
+}
+
+func (l *flushLoop) abortUnpublishedAtomicSnapshot(ctx context.Context, sourceTable string, st *streamTableState) error {
+	aborter, ok := l.dest.(destination.AtomicSnapshotAborter)
+	if !ok {
+		return fmt.Errorf("destination %s cannot abort owned atomic snapshot attempts", l.dest.GetScheme())
+	}
+	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), streamFinalFlushTimeout)
+	defer cancel()
+	if err := aborter.AbortAtomicSnapshot(abortCtx, destination.AtomicSnapshotOptions{
+		Table: st.destTable, AttemptID: st.snapshotAttemptID,
+	}); err != nil {
+		return err
+	}
+	if l.opts.StateManager != nil {
+		if err := l.opts.StateManager.AbandonAtomicSnapshotAttempt(
+			ctx, sourceTable, st.destTable, st.snapshotAttemptID,
+		); err != nil {
+			return fmt.Errorf("failed to abandon durable atomic snapshot attempt: %w", err)
+		}
+	}
+	st.atomicSnapshot = false
+	st.snapshotStarted = false
+	st.snapshotAttemptID = ""
+	return nil
+}
+
+func (l *flushLoop) applyDeferredEvolution(ctx context.Context, res source.RecordBatchResult) error {
+	if res.Batch == nil {
+		return nil
+	}
+	st, ok := l.tableState(res.TableName)
+	if !ok || st.deferredEvolution == nil || st.evolutionApplied || st.snapshotStarted {
+		return nil
+	}
+	if err := st.deferredEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply deferred schema evolution for table %s: %w", st.destTable, err)
+	}
+	st.evolutionApplied = true
+	return nil
 }
 
 // ensureTable provisions per-table state for a table announced mid-stream.
@@ -704,12 +1243,25 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	}
 	st.incarnation = ti.Incarnation
 	st.schemaFingerprint = ti.SchemaFingerprint
-	if l.evolveTable == nil || ti.Schema == nil {
+	if ti.Schema == nil {
+		return nil
+	}
+	if err := schemainfer.ValidateSchema(ti.Schema); err != nil {
+		return fmt.Errorf("invalid refreshed schema for source table %s: %w", ti.Name, err)
+	}
+	if l.evolveTable == nil && l.evolveTablePlan == nil {
 		return nil
 	}
 	newSchema := ti.Schema
 	if !l.cfg.NoLoadTimestamp {
 		newSchema = withLoadTimestampColumn(newSchema)
+	}
+	keysChanged := !equalFoldedStrings(st.primaryKeys, ti.PrimaryKeys)
+	if keysChanged {
+		return fmt.Errorf(
+			"streaming primary-key change for table %s from %v to %v requires a new snapshot; stop the stream and run a full refresh",
+			st.destTable, st.primaryKeys, ti.PrimaryKeys,
+		)
 	}
 	if st.schema.SameColumnShape(newSchema) && sameColumnNullability(st.schema, newSchema) {
 		return nil
@@ -721,18 +1273,81 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := l.evolveTable(ctx, st.destTable, newSchema); err != nil {
+	if publisher, ok := l.dest.(destination.AtomicSnapshotPublisher); ok && st.atomicSnapshot {
+		contractMode, err := schemaevolution.ParseContractMode(l.cfg.SchemaContract)
+		if err != nil {
+			return fmt.Errorf("failed to parse schema contract for atomic snapshot refresh: %w", err)
+		}
+		if contractMode == schemaevolution.ContractDiscardRow {
+			return fmt.Errorf("atomic snapshot schema refresh for table %s is unsupported with discard_row because refreshed rows cannot be published without contract filtering", st.destTable)
+		}
+		plan, err := planDestinationSchemaEvolution(ctx, l.dest, st.destTable, newSchema, l.cfg)
+		if err != nil {
+			return fmt.Errorf("failed to validate atomic snapshot schema change for table %s: %w", st.destTable, err)
+		}
+		configureStreamingContractState(l.cfg, newSchema, plan, st)
+		st.atomicTargetSchema = plan.FinalSchema
+		st.atomicWriteSchema = nil
+		st.atomicBatchTransformer = nil
+		if contractMode == schemaevolution.ContractDiscardValue {
+			st.atomicWriteSchema = st.schema
+			st.atomicBatchTransformer = schemaevolution.NewDiscardValueTransformer(plan.TransformComparison, newSchema, plan.FinalSchema)
+		}
+		st.schemaAligner = transformer.NewSafeTypeCaster(l.atomicSnapshotWriteSchema(st).ToArrowSchema())
+		st.isCDC = hasCDCColumns(newSchema)
+		st.primaryKeys = append([]string(nil), ti.PrimaryKeys...)
+		_, supportsDirectMerge := l.dest.(destination.DirectMergeWriter)
+		st.directMerge = len(st.primaryKeys) > 0 && supportsDirectMerge
+		expectedIncarnation := ""
+		if l.opts.StateManager != nil && l.opts.StateManager.dest != nil {
+			expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(l.stateSourceTable(ti.Name))
+			if expectedIncarnation == "" {
+				return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+			}
+		}
+		if err := publisher.EvolveAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+			Table: st.destTable, Schema: l.atomicSnapshotWriteSchema(st), TargetSchema: l.atomicSnapshotTargetSchema(st), PrimaryKeys: st.primaryKeys,
+			PartitionBy: st.partitionBy, ClusterBy: st.clusterBy, Parallelism: l.cfg.EffectiveDestinationParallelism(), AttemptID: st.snapshotAttemptID,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}); err != nil {
+			return fmt.Errorf("failed to evolve atomic snapshot staging for table %s after schema change: %w", st.destTable, err)
+		}
+		if err := connectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		output.Statusf("[STREAM] %s | Snapshot schema change staged for %s (dest: %s)\n", time.Now().Format("15:04:05"), ti.Name, st.destTable)
+		return nil
+	}
+	var plan *schemaevolution.EvolutionPlan
+	if l.opts.StateManager != nil {
+		expectedIncarnation, err := boundDestinationIncarnation(
+			l.opts.StateManager,
+			l.stateSourceTable(ti.Name),
+			st.destTable,
+		)
+		if err != nil {
+			return err
+		}
+		plan, err = evolveDestinationTablePlanIfIncarnation(ctx, l.dest, st.destTable, newSchema, l.cfg, expectedIncarnation)
+		if err != nil {
+			return fmt.Errorf("failed to evolve destination table %s: %w", st.destTable, err)
+		}
+	} else if l.evolveTablePlan != nil {
+		var err error
+		plan, err = l.evolveTablePlan(ctx, st.destTable, newSchema)
+		if err != nil {
+			return fmt.Errorf("failed to evolve destination table %s: %w", st.destTable, err)
+		}
+	} else if err := l.evolveTable(ctx, st.destTable, newSchema); err != nil {
 		return fmt.Errorf("failed to evolve destination table %s: %w", st.destTable, err)
 	}
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	st.schema = newSchema
+	configureStreamingContractState(l.cfg, newSchema, plan, st)
 	st.isCDC = hasCDCColumns(newSchema)
-	if len(ti.PrimaryKeys) > 0 {
-		st.primaryKeys = ti.PrimaryKeys
-	}
+	st.primaryKeys = append([]string(nil), ti.PrimaryKeys...)
 	if st.stagingTable != "" {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
@@ -769,7 +1384,41 @@ func sameColumnNullability(left, right *schema.TableSchema) bool {
 	return true
 }
 
+func equalFoldedStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !strings.EqualFold(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (l *flushLoop) buffer(res source.RecordBatchResult) {
+	if err := l.transformResultBatch(context.Background(), &res); err != nil {
+		panic(err)
+	}
+	if err := l.bufferResult(res); err != nil {
+		panic(err)
+	}
+}
+
+func (l *flushLoop) bufferResult(res source.RecordBatchResult) error {
+	var st *streamTableState
+	if res.Batch != nil && res.Batch.NumRows() > 0 {
+		var ok bool
+		st, ok = l.tableState(res.TableName)
+		if !ok {
+			rows := res.Batch.NumRows()
+			res.Batch.Release()
+			return fmt.Errorf("streaming received %d row(s) for unknown table %q", rows, res.TableName)
+		}
+		if res.TableName != "" {
+			st.sourceTable = res.TableName
+		}
+	}
 	if res.CommitToken != nil {
 		l.lastToken = res.CommitToken
 		l.tokenDirty = true
@@ -816,22 +1465,52 @@ func (l *flushLoop) buffer(res source.RecordBatchResult) {
 			}
 		}
 	}
+	if l.opts.StateManager == nil && res.DurableCheckpointID != "" {
+		if res.DurableCheckpointTable == "" {
+			l.lastDurableCommitID = res.DurableCheckpointID
+			l.lastDurableCommitPosition = res.DurableCheckpointPosition
+		} else if checkpointState, ok := l.tableState(res.DurableCheckpointTable); ok {
+			checkpointState.checkpointID = res.DurableCheckpointID
+			checkpointState.checkpointPosition = res.DurableCheckpointPosition
+		} else {
+			config.Debug("[STREAM] Ignoring checkpoint for unknown table %q", res.DurableCheckpointTable)
+		}
+	}
+	if res.Batch != nil && res.Batch.NumRows() == 0 {
+		res.Batch.Release()
+		res.Batch = nil
+	}
 	if res.Batch == nil {
-		return
+		if l.opts.StateManager == nil && res.DurableCheckpointID == "" && res.DurableCommitID != "" {
+			if checkpointState, ok := l.tableState(res.TableName); ok && res.TableName != "" {
+				checkpointState.checkpointID = res.DurableCommitID
+				checkpointState.checkpointPosition = res.DurableCommitPosition
+			} else {
+				l.lastDurableCommitID = res.DurableCommitID
+				l.lastDurableCommitPosition = res.DurableCommitPosition
+			}
+		}
+		return nil
 	}
-	if res.Batch.NumRows() == 0 {
-		res.Batch.Release()
-		return
+	boundary := dataWriteBoundary{
+		SourceTable: l.stateSourceTable(res.TableName),
+		Token:       res.DurableCommitID,
+		Position:    res.DurableCommitPosition,
 	}
-	st, ok := l.tableState(res.TableName)
-	if !ok {
-		config.Debug("[STREAM] Dropping batch for unknown table %q (%d rows)", res.TableName, res.Batch.NumRows())
-		res.Batch.Release()
-		return
+	if l.managedCDCNeedsDataWriteIdentity(st) {
+		token, ok := res.CommitToken.(source.CDCStateCommitToken)
+		if !ok || token.Position == "" || token.DataBatchID == "" {
+			res.Batch.Release()
+			return fmt.Errorf("managed CDC data batch for table %s has no typed source position and stable data batch identity", res.TableName)
+		}
+		boundary.Token = managedCDCDataWriteID(boundary.SourceTable, token.DataBatchID)
+		boundary.Position = token.Position
 	}
 	st.pending = append(st.pending, res.Batch)
+	st.pendingBoundaries = append(st.pendingBoundaries, boundary)
 	st.pendingRows += res.Batch.NumRows()
 	l.buffered += res.Batch.NumRows()
+	return nil
 }
 
 // flush writes all buffered batches to the destination (one write+merge cycle
@@ -856,18 +1535,21 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			if !ok {
 				return fmt.Errorf("CDC snapshot state references unknown table %q", sourceTable)
 			}
+			if st.atomicSnapshot {
+				continue
+			}
 			if err := l.opts.StateManager.BindDestinationIncarnation(ctx, sourceTable, st.destTable); err != nil {
 				return fmt.Errorf("streaming flush: failed to bind CDC destination for %s: %w", sourceTable, err)
 			}
 		}
 	}
-
 	type flushWork struct {
 		name string
 		st   *streamTableState
 
-		batches []arrow.RecordBatch
-		rows    int64
+		batches    []arrow.RecordBatch
+		boundaries []dataWriteBoundary
+		rows       int64
 	}
 
 	var work []flushWork
@@ -875,10 +1557,18 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if st.pendingRows == 0 {
 			continue
 		}
-		work = append(work, flushWork{name: name, st: st, batches: st.pending, rows: st.pendingRows})
+		work = append(work, flushWork{name: name, st: st, batches: st.pending, boundaries: st.pendingBoundaries, rows: st.pendingRows})
 		l.buffered -= st.pendingRows
 		st.pending = nil
+		st.pendingBoundaries = nil
 		st.pendingRows = 0
+	}
+	releaseWork := func() {
+		for _, pending := range work {
+			for _, batch := range pending.batches {
+				batch.Release()
+			}
+		}
 	}
 	keylessSnapshots := make(map[string]*streamTableState)
 	if l.opts.StateManager != nil && l.pendingState.Position != "" {
@@ -890,7 +1580,8 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			if _, freshSnapshot := l.pendingState.SnapshotPositions[sourceTable]; freshSnapshot {
 				continue
 			}
-			if err := l.opts.StateManager.InvalidateSnapshot(ctx, sourceTable, w.st.destTable, w.st.incarnation); err != nil {
+			if err := l.opts.StateManager.InvalidateSnapshotPreservingDestination(ctx, sourceTable, w.st.destTable, w.st.incarnation); err != nil {
+				releaseWork()
 				return fmt.Errorf("streaming flush: failed to invalidate keyless CDC state for %s: %w", sourceTable, err)
 			}
 			keylessSnapshots[sourceTable] = w.st
@@ -903,6 +1594,87 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if displayName == "" {
 			displayName = st.destTable
 		}
+		managedBoundaryWrites := l.managedCDCNeedsDataWriteIdentity(st)
+		preserveExactBoundaries := l.opts.StateManager == nil &&
+			hasExactDataWriteBoundary(w.boundaries) &&
+			((st.isCDC && len(st.primaryKeys) == 0) || l.opts.Strategy == config.StrategyAppend)
+		if managedBoundaryWrites || preserveExactBoundaries {
+			if len(w.boundaries) != len(w.batches) {
+				for _, batch := range w.batches {
+					batch.Release()
+				}
+				return fmt.Errorf("streaming flush: table %s lost source write boundaries", displayName)
+			}
+			sourceTable := ""
+			expectedIncarnation := ""
+			if managedBoundaryWrites {
+				sourceTable = l.stateSourceTable(w.name)
+				if sourceTable == "" {
+					for _, batch := range w.batches {
+						batch.Release()
+					}
+					return fmt.Errorf("streaming flush: managed CDC table %s has no source table identity", displayName)
+				}
+				expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(sourceTable)
+				if expectedIncarnation == "" {
+					for _, batch := range w.batches {
+						batch.Release()
+					}
+					return fmt.Errorf("streaming flush: managed CDC table %s has no bound destination incarnation", displayName)
+				}
+			}
+			for i, batch := range w.batches {
+				boundary := w.boundaries[i]
+				writeToken := boundary.Token
+				if managedBoundaryWrites && boundary.SourceTable != sourceTable {
+					for _, unstarted := range w.batches[i:] {
+						unstarted.Release()
+					}
+					return fmt.Errorf("streaming flush: managed CDC table %s has inconsistent source write identity", displayName)
+				}
+				if st.isCDC && len(st.primaryKeys) == 0 && writeToken == "" {
+					for _, unstarted := range w.batches[i:] {
+						unstarted.Release()
+					}
+					return fmt.Errorf("streaming flush: keyless CDC table %s has no durable data batch identity", displayName)
+				}
+				writeOpts := destination.WriteOptions{
+					Table: st.destTable, Schema: st.schema, Parallelism: l.cfg.EffectiveDestinationParallelism(), CDCExpectedIncarnation: expectedIncarnation,
+					StagingBucket: l.cfg.StagingBucket, LoaderFileSize: l.cfg.LoaderFileSize, LoaderFileFormat: l.cfg.LoaderFileFormat,
+					CommitToken: writeToken, CDCResumeLSN: boundary.Position,
+					SkipCDCResume: managedBoundaryWrites || (writeToken != "" && boundary.Position == ""),
+				}
+				if managedBoundaryWrites {
+					writeOpts.CDCResumeLSN = ""
+				}
+				records := (<-chan source.RecordBatchResult)(prefilledBatchChannel([]arrow.RecordBatch{batch}))
+				if col, ok := loadTimestampColumn(st.schema); ok {
+					records = transformer.Wrap(records, transformer.NewLoadTimestamp(col, loadTimestamp))
+				}
+				if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
+					drainAndRelease(records)
+					for _, unstarted := range w.batches[i+1:] {
+						unstarted.Release()
+					}
+					return fmt.Errorf("streaming flush: failed to write managed CDC boundary for table %s at %s: %w", displayName, boundary.Position, err)
+				}
+				if err := connectorLeaseLoss(ctx); err != nil {
+					for _, unstarted := range w.batches[i+1:] {
+						unstarted.Release()
+					}
+					return err
+				}
+			}
+			return nil
+		}
+
+		managedCDC := l.opts.StateManager != nil
+		commitToken, cdcResumeLSN := combinedCommitMetadata(w.boundaries)
+		skipCDCResume := commitToken != "" && cdcResumeLSN == ""
+		if managedCDC {
+			cdcResumeLSN = ""
+			skipCDCResume = true
+		}
 
 		writeOpts := destination.WriteOptions{
 			Table:            st.destTable,
@@ -911,10 +1683,32 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			StagingBucket:    l.cfg.StagingBucket,
 			LoaderFileSize:   l.cfg.LoaderFileSize,
 			LoaderFileFormat: l.cfg.LoaderFileFormat,
+			CommitToken:      commitToken,
+			CDCResumeLSN:     cdcResumeLSN,
+			SkipCDCResume:    skipCDCResume,
 		}
-		if st.stagingTable != "" {
+		expectedIncarnation := ""
+		if managedCDC && l.opts.StateManager.dest != nil {
+			expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(l.stateSourceTable(w.name))
+			if expectedIncarnation == "" {
+				for _, batch := range w.batches {
+					batch.Release()
+				}
+				return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+			}
+		}
+		if st.atomicSnapshot {
+			writeOpts.Schema = l.atomicSnapshotWriteSchema(st)
+			writeOpts.CDCExpectedIncarnation = expectedIncarnation
+		}
+		if st.stagingTable != "" && !st.atomicSnapshot {
 			writeOpts.Table = st.stagingTable
 			writeOpts.StagingTable = true
+			writeOpts.CommitToken = ""
+			writeOpts.CDCResumeLSN = ""
+			writeOpts.SkipCDCResume = true
+		} else if !st.atomicSnapshot {
+			writeOpts.CDCExpectedIncarnation = expectedIncarnation
 		}
 
 		if err := connectorLeaseLoss(ctx); err != nil {
@@ -927,7 +1721,32 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if col, ok := loadTimestampColumn(st.schema); ok {
 			records = transformer.Wrap(records, transformer.NewLoadTimestamp(col, loadTimestamp))
 		}
-		if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
+		if st.atomicSnapshot {
+			publisher := l.dest.(destination.AtomicSnapshotPublisher)
+			writeOpts.AtomicSnapshotAttemptID = st.snapshotAttemptID
+			if err := publisher.WriteAtomicSnapshot(ctx, records, writeOpts); err != nil {
+				drainAndRelease(records)
+				return fmt.Errorf("streaming flush: failed to stage %d snapshot rows for table %s: %w", w.rows, displayName, err)
+			}
+		} else if st.directMerge {
+			direct := l.dest.(destination.DirectMergeWriter)
+			if err := direct.MergeRecords(ctx, records, writeOpts, destination.MergeOptions{
+				TargetTable:            st.destTable,
+				PrimaryKeys:            st.primaryKeys,
+				Columns:                destination.MergeColumnsFor(l.dest, st.schema.ColumnNames()),
+				IncrementalKey:         mergeIncrementalKeyForSchema(st.schema, st.incrementalKey),
+				IncrementalPredicate:   st.incrementalPredicate,
+				Schema:                 st.schema,
+				Parallelism:            writeOpts.Parallelism,
+				CommitToken:            commitToken,
+				CDCResumeLSN:           cdcResumeLSN,
+				SkipCDCResume:          skipCDCResume,
+				CDCExpectedIncarnation: expectedIncarnation,
+			}); err != nil {
+				drainAndRelease(records)
+				return fmt.Errorf("streaming flush: failed to merge %d rows directly for table %s: %w", w.rows, displayName, err)
+			}
+		} else if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
 			drainAndRelease(records)
 			return fmt.Errorf("streaming flush: failed to write %d rows for table %s: %w", w.rows, displayName, err)
 		}
@@ -935,11 +1754,12 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			return err
 		}
 
-		if st.stagingTable != "" {
+		if st.stagingTable != "" && !st.atomicSnapshot {
 			if err := connectorLeaseLoss(ctx); err != nil {
 				return err
 			}
-			if err := mergeStagingInto(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey, st.incrementalPredicate); err != nil {
+			if err := mergeStagingIntoWithCommit(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey, st.incrementalPredicate,
+				commitToken, cdcResumeLSN, skipCDCResume, expectedIncarnation); err != nil {
 				return fmt.Errorf("streaming flush: failed to merge table %s: %w", displayName, err)
 			}
 			if err := connectorLeaseLoss(ctx); err != nil {
@@ -966,12 +1786,12 @@ func (l *flushLoop) flush(ctx context.Context) error {
 	} else {
 		for i, w := range work {
 			if err := flushOne(ctx, w); err != nil {
-				for _, unstarted := range work[i+1:] {
-					for _, batch := range unstarted.batches {
+				flushErr = err
+				for _, pending := range work[i+1:] {
+					for _, batch := range pending.batches {
 						batch.Release()
 					}
 				}
-				flushErr = err
 				break
 			}
 		}
@@ -997,12 +1817,103 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		return err
 	}
 
+	for tableName, st := range l.tables {
+		if !st.atomicSnapshot {
+			continue
+		}
+		sourceTable := l.stateSourceTable(tableName)
+		position, complete := l.pendingState.SnapshotPositions[sourceTable]
+		if !complete {
+			continue
+		}
+		publisher := l.dest.(destination.AtomicSnapshotPublisher)
+		expectedIncarnation := ""
+		if l.opts.StateManager != nil && l.opts.StateManager.dest != nil {
+			expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(sourceTable)
+			if expectedIncarnation == "" {
+				return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+			}
+		}
+		publishOpts := destination.AtomicSnapshotOptions{
+			Table: st.destTable, Schema: st.schema, TargetSchema: l.atomicSnapshotTargetSchema(st), PrimaryKeys: st.primaryKeys,
+			PartitionBy: st.partitionBy, ClusterBy: st.clusterBy, Parallelism: l.cfg.EffectiveDestinationParallelism(),
+			CommitToken: atomicSnapshotCommitID(st.snapshotAttemptID), CDCResumeLSN: position, SkipCDCResume: l.opts.StateManager != nil, AttemptID: st.snapshotAttemptID,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}
+		st.atomicPublishAttempted = true
+		if l.opts.StateManager != nil {
+			if err := l.opts.StateManager.SealAtomicSnapshotAttempt(
+				ctx, sourceTable, st.destTable, st.snapshotAttemptID, position, expectedIncarnation,
+			); err != nil {
+				return fmt.Errorf("streaming flush: failed to seal durable atomic snapshot attempt for %s: %w", sourceTable, err)
+			}
+		}
+		publishedIncarnation, err := publisher.PublishAtomicSnapshot(ctx, publishOpts)
+		if err != nil {
+			return fmt.Errorf("streaming flush: failed to publish snapshot for table %s: %w", st.destTable, err)
+		}
+		if l.opts.StateManager != nil {
+			if publishedIncarnation == "" {
+				return fmt.Errorf("streaming flush: atomic publication for %s returned no physical incarnation", st.destTable)
+			}
+			if err := l.opts.StateManager.BindPublishedDestinationIncarnation(
+				ctx, sourceTable, st.destTable, expectedIncarnation, publishedIncarnation,
+			); err != nil {
+				return fmt.Errorf("streaming flush: failed to bind published CDC destination for %s: %w", sourceTable, err)
+			}
+			if err := completeAtomicSnapshotAttempt(
+				ctx, l.opts.StateManager, sourceTable, st.destTable, st.snapshotAttemptID,
+			); err != nil {
+				return fmt.Errorf("streaming flush: failed to complete durable atomic snapshot attempt for %s: %w", sourceTable, err)
+			}
+		}
+		st.atomicSnapshot = false
+		st.snapshotStarted = false
+		st.snapshotAttemptID = ""
+		st.atomicPublishAttempted = false
+		st.targetCreatedByRun = false
+	}
+
+	ackBlocked := l.hasActiveAtomicSnapshot()
+	if l.opts.StateManager == nil && !ackBlocked {
+		if tokenWriter, ok := l.dest.(destination.DurableCommitTokenWriter); ok {
+			workedTables := make(map[*streamTableState]struct{}, len(work))
+			for _, w := range work {
+				workedTables[w.st] = struct{}{}
+			}
+			for _, st := range l.tables {
+				if st.atomicSnapshot {
+					continue
+				}
+				if _, wroteRows := workedTables[st]; wroteRows {
+					continue
+				}
+				checkpointID := st.checkpointID
+				checkpointPosition := st.checkpointPosition
+				if checkpointID == "" {
+					checkpointID = l.lastDurableCommitID
+					checkpointPosition = l.lastDurableCommitPosition
+				}
+				if checkpointID == "" {
+					continue
+				}
+				cdcResumeLSN := ""
+				if st.isCDC {
+					cdcResumeLSN = checkpointPosition
+				}
+				if err := tokenWriter.CommitWriteToken(ctx, st.destTable, checkpointID, cdcResumeLSN); err != nil {
+					return fmt.Errorf("streaming flush: failed to persist source position for table %s: %w", st.destTable, err)
+				}
+			}
+		}
+	}
+
 	var flushedRows int64
 	for _, w := range work {
 		flushedRows += w.rows
 	}
 
-	if l.opts.StateManager != nil && l.tokenDirty {
+	if l.opts.StateManager != nil && l.tokenDirty && !ackBlocked {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -1013,7 +1924,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			return err
 		}
 	}
-	if l.opts.Committer != nil && l.tokenDirty {
+	if l.opts.Committer != nil && l.tokenDirty && !ackBlocked {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -1024,7 +1935,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			return err
 		}
 	}
-	if l.opts.StateManager != nil && l.opts.LegacyFinalizer != nil && l.tokenDirty && !l.legacyFinalized {
+	if l.opts.StateManager != nil && l.opts.LegacyFinalizer != nil && l.tokenDirty && !ackBlocked && !l.legacyFinalized {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -1036,8 +1947,16 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		}
 		l.legacyFinalized = true
 	}
-	l.tokenDirty = false
-	l.pendingState = source.CDCStateCommitToken{}
+	if !ackBlocked {
+		l.tokenDirty = false
+		l.pendingState = source.CDCStateCommitToken{}
+		l.lastDurableCommitID = ""
+		l.lastDurableCommitPosition = ""
+		for _, st := range l.tables {
+			st.checkpointID = ""
+			st.checkpointPosition = ""
+		}
+	}
 
 	// Only after the commit: the counters mean "durable in the destination and
 	// acknowledged to the source", not merely "written".
@@ -1056,6 +1975,58 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		output.Statusf("[STREAM] %s | cycle %d: flushed %d rows in %s\n", time.Now().Format("15:04:05"), l.cycles, flushedRows, time.Since(start).Round(time.Millisecond))
 	}
 	return nil
+}
+
+func (l *flushLoop) managedCDCNeedsDataWriteIdentity(st *streamTableState) bool {
+	if l.opts.StateManager == nil || st == nil || !st.isCDC || st.atomicSnapshot {
+		return false
+	}
+	return l.opts.Strategy == config.StrategyAppend || len(st.primaryKeys) == 0
+}
+
+func managedStreamingNeedsStableDataBatches(
+	opts StreamingOptions,
+	tables map[string]*streamTableState,
+	allowLateTables bool,
+) bool {
+	if opts.StateManager == nil {
+		return false
+	}
+	if allowLateTables && (opts.Strategy == config.StrategyAppend || opts.Strategy == config.StrategyMerge) {
+		return true
+	}
+	for _, st := range tables {
+		if st != nil && st.isCDC && (opts.Strategy == config.StrategyAppend || len(st.primaryKeys) == 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *flushLoop) atomicSnapshotTargetSchema(st *streamTableState) *schema.TableSchema {
+	if st.atomicTargetSchema != nil {
+		return st.atomicTargetSchema
+	}
+	if l.opts.Strategy == config.StrategyAppend && st.isCDC {
+		return st.schema
+	}
+	return destination.DestinationTableSchema(st.schema)
+}
+
+func (l *flushLoop) atomicSnapshotWriteSchema(st *streamTableState) *schema.TableSchema {
+	if st.atomicWriteSchema != nil {
+		return st.atomicWriteSchema
+	}
+	return st.schema
+}
+
+func (l *flushLoop) hasActiveAtomicSnapshot() bool {
+	for _, st := range l.tables {
+		if st.atomicSnapshot {
+			return true
+		}
+	}
+	return false
 }
 
 // flushConcurrency returns how many tables may flush at once: destinations
@@ -1095,6 +2066,13 @@ func (l *flushLoop) resetStaging(ctx context.Context, st *streamTableState) erro
 func (l *flushLoop) shutdown(ctx context.Context, records <-chan source.RecordBatchResult) error {
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return l.abortLeaseLoss(records, err)
+	}
+	// A partially staged atomic snapshot must never be flushed during shutdown.
+	// Its hidden attempt is safe to reclaim on restart; returning promptly also
+	// prevents a canceled source snapshot from being drained into durable pages.
+	if l.hasActiveAtomicSnapshot() {
+		startBoundedRecordDrain(records, streamDrainTimeout)
+		return ctx.Err()
 	}
 	deadline := time.NewTimer(streamDrainTimeout)
 	defer deadline.Stop()
@@ -1138,7 +2116,6 @@ drain:
 			break drain
 		}
 	}
-
 	return l.finalFlush(ctx)
 }
 
@@ -1152,12 +2129,36 @@ func (l *flushLoop) finalFlush(ctx context.Context) error {
 	}
 	flushCtx, cancel := detachedLeaseContext(ctx, streamFinalFlushTimeout)
 	defer cancel()
+	for _, st := range l.tables {
+		if st.deferredEvolution == nil || st.evolutionApplied || st.snapshotStarted {
+			continue
+		}
+		if err := st.deferredEvolution(flushCtx); err != nil {
+			return fmt.Errorf("failed to apply deferred schema evolution for table %s: %w", st.destTable, err)
+		}
+		st.evolutionApplied = true
+	}
 
-	if l.buffered == 0 && !l.tokenDirty {
+	if l.buffered == 0 && !l.tokenDirty && !l.hasPendingDurableCheckpoint() {
 		return nil
 	}
 	config.Debug("[STREAM] Final flush: %d buffered rows", l.buffered)
 	return l.flush(flushCtx)
+}
+
+func (l *flushLoop) hasPendingDurableCheckpoint() bool {
+	if l.opts.StateManager != nil {
+		return false
+	}
+	if l.lastDurableCommitID != "" {
+		return true
+	}
+	for _, st := range l.tables {
+		if st.checkpointID != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanup drops staging tables (best-effort) regardless of how the loop ended.
@@ -1173,6 +2174,19 @@ func (l *flushLoop) cleanup(ctx context.Context) {
 	for _, st := range l.tables {
 		if connectorLeaseLoss(dropCtx) != nil {
 			return
+		}
+		if st.snapshotStarted && !st.atomicPublishAttempted && st.snapshotAttemptID != "" {
+			if aborter, ok := l.dest.(destination.AtomicSnapshotAborter); ok {
+				if err := aborter.AbortAtomicSnapshot(dropCtx, destination.AtomicSnapshotOptions{
+					Table: st.destTable, AttemptID: st.snapshotAttemptID,
+				}); err != nil {
+					config.Debug("[STREAM] Warning: failed to abort atomic snapshot stage for %s: %v", st.destTable, err)
+				}
+			}
+		}
+		if st.targetCreatedByRun && !st.atomicPublishAttempted {
+			cleanupFailedOwnedDirectReplace(dropCtx, l.dest, st.destTable, true, st.targetOwnershipToken)
+			st.targetCreatedByRun = false
 		}
 		if st.stagingTable == "" {
 			continue
@@ -1193,6 +2207,7 @@ func (l *flushLoop) releasePending() {
 		}
 		l.buffered -= st.pendingRows
 		st.pending = nil
+		st.pendingBoundaries = nil
 		st.pendingRows = 0
 	}
 }

--- a/pkg/strategy/streaming_commit_token_test.go
+++ b/pkg/strategy/streaming_commit_token_test.go
@@ -1,0 +1,352 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type durableTokenCall struct {
+	table        string
+	token        source.DurableID
+	cdcResumeLSN string
+}
+
+type durableTokenDestination struct {
+	*fakeDestination
+
+	mu    sync.Mutex
+	calls []durableTokenCall
+	err   error
+}
+
+func (d *durableTokenDestination) CommitWriteToken(_ context.Context, table string, token source.DurableID, cdcResumeLSN string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls = append(d.calls, durableTokenCall{table: table, token: token, cdcResumeLSN: cdcResumeLSN})
+	return d.err
+}
+
+func TestStreamingFlushPassesCommitMetadataToWriteAndMerge(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), CommitToken: stringerToken("00000000/00000020"),
+		DurableCommitID: "payload:00000000/00000020", DurableCommitPosition: "00000000/00000020",
+	}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 1)
+	require.Empty(t, dest.writeCalls[0].CommitToken, "staging writes must not claim the target payload identity")
+	require.Empty(t, dest.writeCalls[0].CDCResumeLSN)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, source.DurableID("payload:00000000/00000020"), dest.mergeCalls[0].CommitToken)
+	require.Equal(t, "00000000/00000020", dest.mergeCalls[0].CDCResumeLSN)
+	dest.mu.Unlock()
+	require.Equal(t, []any{stringerToken("00000000/00000020")}, committer.committed())
+}
+
+func TestStreamingSnapshotChunksDoNotAdvanceCDCResumeBeforeFinalChunk(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken:     "snapshot-page-1",
+		DurableCommitID: "snapshot-page-1",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:                 int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken:           "snapshot-page-final",
+		DurableCommitID:       "snapshot-page-final",
+		DurableCommitPosition: "0/100",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 2)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+	require.Empty(t, dest.writeCalls[0].CDCResumeLSN)
+	require.True(t, dest.writeCalls[1].SkipCDCResume)
+	require.Empty(t, dest.writeCalls[1].CDCResumeLSN)
+	require.Len(t, dest.mergeCalls, 2)
+	require.True(t, dest.mergeCalls[0].SkipCDCResume)
+	require.Empty(t, dest.mergeCalls[0].CDCResumeLSN)
+	require.False(t, dest.mergeCalls[1].SkipCDCResume)
+	require.Equal(t, "0/100", dest.mergeCalls[1].CDCResumeLSN)
+	dest.mu.Unlock()
+	require.Equal(t, []any{"snapshot-page-1", "snapshot-page-final"}, committer.committed())
+}
+
+func TestStreamingFlushPersistsTokenOnlyCDCPositionBeforeAcknowledgingSource(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		CommitToken: "00000000/00000030", DurableCheckpointID: "00000000/00000030", DurableCheckpointPosition: "00000000/00000030",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.events",
+		token:        "00000000/00000030",
+		cdcResumeLSN: "00000000/00000030",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	require.Equal(t, []any{"00000000/00000030"}, committer.committed())
+	require.False(t, loop.tokenDirty)
+}
+
+func TestStreamingFlushPersistsZeroRowBatchPositionBeforeAcknowledgingSource(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{}, nil), CommitToken: "00000000/00000031",
+		DurableCommitID: "00000000/00000031", DurableCommitPosition: "00000000/00000031",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.events",
+		token:        "00000000/00000031",
+		cdcResumeLSN: "00000000/00000031",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	dest.fakeDestination.mu.Lock()
+	require.Empty(t, dest.writeCalls)
+	dest.fakeDestination.mu.Unlock()
+	require.Equal(t, []any{"00000000/00000031"}, committer.committed())
+}
+
+func TestStreamingFlushPersistsGlobalPositionForIdleTables(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	active := mergeTableState("lake.active")
+	active.isCDC = true
+	idle := mergeTableState("lake.idle")
+	idle.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{
+		"public.active": active,
+		"public.idle":   idle,
+	})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.active", CommitToken: "00000000/00000040",
+		DurableCommitID: "00000000/00000040", DurableCommitPosition: "00000000/00000040",
+		DurableCheckpointID: "00000000/00000040", DurableCheckpointPosition: "00000000/00000040",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.fakeDestination.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.active", dest.mergeCalls[0].TargetTable)
+	require.Equal(t, "00000000/00000040", dest.mergeCalls[0].CDCResumeLSN)
+	dest.fakeDestination.mu.Unlock()
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.idle",
+		token:        "00000000/00000040",
+		cdcResumeLSN: "00000000/00000040",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	require.Equal(t, []any{"00000000/00000040"}, committer.committed())
+}
+
+func TestStreamingSnapshotCheckpointDoesNotAdvanceOtherTables(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	first := mergeTableState("lake.first")
+	first.isCDC = true
+	second := mergeTableState("lake.second")
+	second.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{
+		"public.first":  first,
+		"public.second": second,
+	})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:                     int64RecordBatch(t, "id", []int64{1}, nil),
+		TableName:                 "public.first",
+		CommitToken:               "0/100",
+		DurableCommitID:           "snapshot:first:final",
+		DurableCommitPosition:     "0/100",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.first",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.fakeDestination.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.first", dest.mergeCalls[0].TargetTable)
+	require.Equal(t, "0/100", dest.mergeCalls[0].CDCResumeLSN)
+	dest.fakeDestination.mu.Unlock()
+	dest.mu.Lock()
+	require.Empty(t, dest.calls, "an unfinished table must not receive another table's snapshot cursor")
+	dest.mu.Unlock()
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:                     int64RecordBatch(t, "id", []int64{2}, nil),
+		TableName:                 "public.second",
+		CommitToken:               "0/100",
+		DurableCommitID:           "snapshot:second:final",
+		DurableCommitPosition:     "0/100",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.second",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.fakeDestination.mu.Lock()
+	require.Len(t, dest.mergeCalls, 2)
+	require.Equal(t, "lake.second", dest.mergeCalls[1].TargetTable)
+	require.Equal(t, "0/100", dest.mergeCalls[1].CDCResumeLSN)
+	dest.fakeDestination.mu.Unlock()
+	dest.mu.Lock()
+	require.Empty(t, dest.calls)
+	dest.mu.Unlock()
+}
+
+func TestStreamingEmptySnapshotCheckpointOnlyAdvancesItsTable(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	first := mergeTableState("lake.first")
+	first.isCDC = true
+	second := mergeTableState("lake.second")
+	second.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{
+		"public.first":  first,
+		"public.second": second,
+	})
+
+	loop.buffer(source.RecordBatchResult{
+		TableName:                 "public.first",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.first",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.first",
+		token:        "checkpoint:0/100",
+		cdcResumeLSN: "0/100",
+	}}, dest.calls)
+	dest.mu.Unlock()
+}
+
+func TestStreamingFinalFlushPersistsTokenlessTableCheckpoint(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events", DurableCommitID: "empty-snapshot", DurableCommitPosition: "0/200",
+	}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table: "lake.events", token: "empty-snapshot", cdcResumeLSN: "0/200",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	require.False(t, loop.hasPendingDurableCheckpoint())
+}
+
+func TestStreamingCheckpointFailureDoesNotAcknowledgeSource(t *testing.T) {
+	checkpointErr := errors.New("checkpoint commit failed")
+	dest := &durableTokenDestination{
+		fakeDestination: &fakeDestination{},
+		err:             checkpointErr,
+	}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		CommitToken: "00000000/00000050", DurableCheckpointID: "00000000/00000050", DurableCheckpointPosition: "00000000/00000050",
+	})
+	err := loop.flush(context.Background())
+	require.ErrorIs(t, err, checkpointErr)
+	require.Empty(t, committer.committed())
+	require.True(t, loop.tokenDirty)
+}
+
+type stringerToken string
+
+func (t stringerToken) String() string { return string(t) }
+
+var _ destination.DurableCommitTokenWriter = (*durableTokenDestination)(nil)

--- a/pkg/strategy/streaming_newtable_test.go
+++ b/pkg/strategy/streaming_newtable_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -227,7 +228,7 @@ func TestStreaming_AnnouncementForKnownTableIgnored(t *testing.T) {
 	assert.Equal(t, 1, writeCallCount(dest))
 }
 
-func TestStreaming_AnnouncementWithoutPreparerDropsBatches(t *testing.T) {
+func TestStreaming_AnnouncementWithoutPreparerFailsClosed(t *testing.T) {
 	dest := &fakeDestination{}
 	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
@@ -242,7 +243,7 @@ func TestStreaming_AnnouncementWithoutPreparerDropsBatches(t *testing.T) {
 	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.products"}
 	close(records)
 
-	require.NoError(t, loop.run(context.Background(), records))
+	require.EqualError(t, loop.run(context.Background(), records), `streaming received 1 row(s) for unknown table "public.products"`)
 	assert.Equal(t, 0, writeCallCount(dest))
 }
 
@@ -503,6 +504,53 @@ func TestStreaming_NewTableAbsentTargetCanBeClaimedAndPrepared(t *testing.T) {
 	require.False(t, dest.missing[target])
 }
 
+func TestStreaming_NewManagedCDCAppendRejectsNonIdempotentDestinationBeforeClaim(t *testing.T) {
+	const (
+		startup = "public.users"
+		late    = "public.events"
+		target  = "landing.public_events"
+	)
+	dest := newLateTableCDCStateDestination()
+	dest.missing[target] = true
+	manager, err := NewCDCStateManager(dest, "connector-a", "landing.public_users", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTable(t.Context(), startup, "landing.public_users"))
+	require.NoError(t, manager.ClaimTarget(t.Context(), startup, "landing.public_users"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	dest.stateMu.Lock()
+	stateWritesBefore := dest.cdcWrites
+	dest.stateMu.Unlock()
+
+	info := source.SourceTableInfo{
+		Name: late, Schema: keylessCDCSchema(), DestSchema: "landing",
+		Incarnation: "100", SchemaFingerprint: "schema-a",
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: late, TableInfo: &info}
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{newTableInfo(startup)}, records: records}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{FullRefresh: true, NoLoadTimestamp: true, FlushInterval: time.Hour, FlushRecords: 1},
+		Source:         src,
+		Destination:    dest,
+		Tables:         src.tables,
+		TableDestNames: map[string]string{startup: "landing.public_users"},
+	}
+
+	err = NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyAppend, FlushInterval: time.Hour, StateManager: manager,
+	}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "managed streaming CDC append requires destination support for idempotent commit-token writes")
+	require.Empty(t, dest.targets[target], "unsafe late target was claimed")
+	require.True(t, dest.missing[target], "unsafe late target was created")
+	dest.stateMu.Lock()
+	require.Equal(t, stateWritesBefore, dest.cdcWrites, "unsafe late discovery wrote CDC state")
+	dest.stateMu.Unlock()
+	for _, call := range dest.prepareCalls {
+		require.NotEqual(t, target, call.Table, "unsafe late target was prepared")
+	}
+}
+
 func TestCDCStateLateDiscoveredTargetClaimIsAtomicAcrossConnectors(t *testing.T) {
 	const target = "landing.public_products"
 	dest := newLateTableCDCStateDestination()
@@ -674,6 +722,95 @@ func seedLateCompletedState(t *testing.T, dest *lateTableCDCStateDestination, co
 		SnapshotIncarnations: map[string]string{sourceName: "100"},
 		SnapshotSchemas:      map[string]string{sourceName: "schema-a"},
 	}))
+}
+
+func TestStreamingDynamicTableFreezeRejectsBeforePrepare(t *testing.T) {
+	initial := newTableInfo("users")
+	dynamicSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	dynamic := source.SourceTableInfo{Name: "products", Schema: dynamicSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	close(records)
+	dest := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{
+		"users": initial.Schema, "products": destinationSchema,
+	}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{SchemaContract: "freeze", NoLoadTimestamp: true, FullRefresh: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{"users": "users"},
+	}
+
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1})
+	err := exec.ExecuteMultiTable(context.Background(), job)
+	require.ErrorContains(t, err, "schema contract violation")
+	for _, call := range dest.prepareCalls {
+		require.NotEqual(t, "products", call.Table)
+		require.NotContains(t, call.Table, "products")
+	}
+}
+
+func TestStreamingDynamicTableDiscardValueUsesFinalSchemaAndTransforms(t *testing.T) {
+	initial := newTableInfo("users")
+	dynamicSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	dynamic := source.SourceTableInfo{Name: "products", Schema: dynamicSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	records <- source.RecordBatchResult{
+		TableName: dynamic.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	}
+	close(records)
+	base := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{
+		"users": initial.Schema, "products": destinationSchema,
+	}}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{SchemaContract: "discard_value", NoLoadTimestamp: true, FullRefresh: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{"users": "users"},
+	}
+
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1})
+	require.NoError(t, exec.ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, []int64{1}, dest.rows)
+	require.Equal(t, []int{1}, dest.nulls)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.types[0]))
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestStreamingDynamicTableRejectsUnsupportedDecimalBeforePrepare(t *testing.T) {
+	initial := newTableInfo("users")
+	dynamic := source.SourceTableInfo{Name: "products", Schema: &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2,
+	}}}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	close(records)
+	dest := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{NoLoadTimestamp: true, FullRefresh: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{"users": "users"},
+	}
+
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1})
+	err := exec.ExecuteMultiTable(context.Background(), job)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "products")
+	for _, call := range dest.prepareCalls {
+		require.NotContains(t, call.Table, "products")
+	}
 }
 
 func TestWithLoadTimestampColumn(t *testing.T) {

--- a/pkg/strategy/streaming_snapshot_invalidation_test.go
+++ b/pkg/strategy/streaming_snapshot_invalidation_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,16 +16,30 @@ import (
 
 type orderedCDCStateDestination struct {
 	*cdcStateDestination
-	orderMu           sync.Mutex
-	order             []string
-	replaceAfterWrite bool
+	orderMu                          sync.Mutex
+	order                            []string
+	replaceAfterWrite                bool
+	replaceDuringStateInvalidation   bool
+	replaceBeforeConditionalTruncate bool
 }
 
 func (d *orderedCDCStateDestination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	d.orderMu.Lock()
 	d.order = append(d.order, "state")
 	d.orderMu.Unlock()
-	return d.cdcStateDestination.WriteCDCState(ctx, records, opts)
+	if err := d.cdcStateDestination.WriteCDCState(ctx, records, opts); err != nil {
+		return err
+	}
+	d.orderMu.Lock()
+	replace := d.replaceDuringStateInvalidation
+	d.replaceDuringStateInvalidation = false
+	d.orderMu.Unlock()
+	if replace {
+		d.stateMu.Lock()
+		d.incarnations["raw.items"] = "externally-replaced"
+		d.stateMu.Unlock()
+	}
+	return nil
 }
 
 func (d *orderedCDCStateDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
@@ -47,6 +62,21 @@ func (d *orderedCDCStateDestination) TruncateTable(_ context.Context, table stri
 	d.truncateCalls = append(d.truncateCalls, table)
 	d.mu.Unlock()
 	return nil
+}
+
+func (d *orderedCDCStateDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expected string) error {
+	d.orderMu.Lock()
+	d.order = append(d.order, "truncate")
+	d.orderMu.Unlock()
+	d.mu.Lock()
+	d.truncateCalls = append(d.truncateCalls, table)
+	d.mu.Unlock()
+	if d.replaceBeforeConditionalTruncate {
+		d.stateMu.Lock()
+		d.incarnations[table] = "externally-replaced"
+		d.stateMu.Unlock()
+	}
+	return d.cdcStateDestination.TruncateCDCTableIfIncarnation(ctx, table, expected)
 }
 
 func (d *orderedCDCStateDestination) resetOrder() {
@@ -80,6 +110,9 @@ func replacementSnapshotLoop(t *testing.T) (*flushLoop, *orderedCDCStateDestinat
 		SnapshotPositions:    map[string]string{"public.items": "00000000/00000010"},
 		SnapshotIncarnations: map[string]string{"public.items": "100"},
 	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.BindDestinationIncarnation(ctx, "public.items", "raw.items"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,6 +179,19 @@ func TestStreamingSnapshotInvalidationFailurePreventsTruncate(t *testing.T) {
 	}
 }
 
+func TestStreamingSnapshotInvalidationRejectsTargetRecreatedDuringStateWrite(t *testing.T) {
+	loop, dest, _, _ := replacementSnapshotLoop(t)
+	dest.replaceDuringStateInvalidation = true
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{TableName: "public.items", Incarnation: "101"}}
+	close(records)
+
+	err := loop.run(t.Context(), records)
+	require.ErrorContains(t, err, "changed while invalidating its prior snapshot boundary")
+	require.Equal(t, []string{"state"}, dest.recordedOrder())
+	require.Empty(t, dest.truncateCalls)
+}
+
 func TestStreamingWALTruncateCompletesStableDestinationIncarnation(t *testing.T) {
 	loop, dest, _, _ := replacementSnapshotLoop(t)
 	token := source.CDCStateCommitToken{Position: "00000000/00000030"}
@@ -175,6 +221,43 @@ func TestStreamingWALTruncateCompletesStableDestinationIncarnation(t *testing.T)
 	if got, err := restarted.ResumePosition(t.Context(), "public.items"); err != nil || got != token.Position {
 		t.Fatalf("resume after completed WAL truncate = %q, %v; want %s", got, err, token.Position)
 	}
+}
+
+func TestStreamingWALTruncateRefusesTargetRecreatedAfterBinding(t *testing.T) {
+	loop, dest, _, _ := replacementSnapshotLoop(t)
+	dest.replaceBeforeConditionalTruncate = true
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName:      "public.items",
+		Truncate:       true,
+		CDCWALTruncate: true,
+		CommitToken:    source.CDCStateCommitToken{Position: "00000000/00000030"},
+	}
+	close(records)
+
+	err := loop.run(t.Context(), records)
+	if err == nil || !strings.Contains(err.Error(), "physical incarnation changed") {
+		t.Fatalf("streaming WAL truncate error = %v, want incarnation change", err)
+	}
+	if got := dest.recordedOrder(); len(got) != 2 || got[0] != "state" || got[1] != "truncate" {
+		t.Fatalf("WAL truncate replacement ordering = %v, want [state truncate]", got)
+	}
+}
+
+func TestStreamingWALTruncateRejectsTargetRecreatedDuringInvalidation(t *testing.T) {
+	loop, dest, _, _ := replacementSnapshotLoop(t)
+	dest.replaceDuringStateInvalidation = true
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.items", Truncate: true, CDCWALTruncate: true,
+		CommitToken: source.CDCStateCommitToken{Position: "00000000/00000030"},
+	}
+	close(records)
+
+	err := loop.run(t.Context(), records)
+	require.ErrorContains(t, err, "changed while invalidating its prior snapshot boundary")
+	require.Equal(t, []string{"state"}, dest.recordedOrder())
+	require.Empty(t, dest.truncateCalls)
 }
 
 func TestStreamingFreshSnapshotRejectsDestinationReplacementAfterWrite(t *testing.T) {
@@ -221,7 +304,8 @@ func TestStreamingKeylessAppendCrashBeforeStateForcesReplacement(t *testing.T) {
 		TableName: "public.items",
 		Batch:     int64RecordBatch(t, "id", []int64{7}, nil),
 		CommitToken: source.CDCStateCommitToken{
-			Position: "00000000/00000030",
+			Position:    "00000000/00000030",
+			DataBatchID: "public.items:1:00000000/00000030/0000000000000001:00000000/00000030/0000000000000001",
 		},
 	})
 	require.Error(t, loop.flush(t.Context()))

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -24,6 +24,131 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type readAllSetupErrorSource struct {
+	*announcingMultiTableSource
+	err error
+}
+
+type cancelOnNthManagedStagingPrepareDestination struct {
+	*contextAwareDropDestination
+	cancel  context.CancelFunc
+	failAt  int
+	managed int
+}
+
+func (d *cancelOnNthManagedStagingPrepareDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := d.contextAwareDropDestination.PrepareTable(ctx, opts); err != nil {
+		return err
+	}
+	if opts.ExpiresAfter > 0 {
+		d.managed++
+		if d.managed == d.failAt {
+			d.cancel()
+			return errors.New("managed staging prepare response lost after create")
+		}
+	}
+	return nil
+}
+
+func TestStreamingLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge}).Execute(ctx, job)
+	require.ErrorContains(t, err, "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func TestStreamingMultiTableLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	table := source.SourceTableInfo{Name: "events", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}}, Destination: dest,
+		Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge}).ExecuteMultiTable(ctx, job)
+	require.ErrorContains(t, err, "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func TestStreamingDynamicTableLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	initial := source.SourceTableInfo{Name: "users", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	dynamic := source.SourceTableInfo{Name: "products", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	close(records)
+	base := &fakeDestination{}
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := &cancelOnNthManagedStagingPrepareDestination{
+		contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}, cancel: cancel, failAt: 2,
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{NoLoadTimestamp: true, FullRefresh: true},
+		Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records}, Destination: dest,
+		Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{initial.Name: initial.Name},
+	}
+
+	err := NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1,
+	}).ExecuteMultiTable(ctx, job)
+	require.ErrorContains(t, err, "prepare response lost")
+	var managedStages []string
+	for _, call := range base.prepareCalls {
+		if call.ExpiresAfter > 0 {
+			managedStages = append(managedStages, call.Table)
+		}
+	}
+	require.Len(t, managedStages, 2)
+	require.ElementsMatch(t, managedStages, dest.successfulDrops)
+}
+
+func (s *readAllSetupErrorSource) ReadAll(context.Context, source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	return nil, s.err
+}
+
+func TestStreamingReadSetupFailureDropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.readErr = errors.New("stream read setup failed")
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+
+	err := executor.Execute(context.Background(), job)
+	require.Error(t, err)
+	require.Len(t, dest.dropCalls, 1)
+	require.Contains(t, dest.dropCalls[0], "_stream_")
+}
+
+func TestStreamingMultiTableReadSetupFailureDropsManagedStaging(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &readAllSetupErrorSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		err:                        errors.New("stream read-all setup failed"),
+	}
+	dest := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    dest,
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+
+	err := executor.ExecuteMultiTable(context.Background(), job)
+	require.Error(t, err)
+	require.Len(t, dest.dropCalls, 1)
+	require.Contains(t, dest.dropCalls[0], "_stream_")
+}
+
 type fakeCommitter struct {
 	mu     sync.Mutex
 	tokens []any
@@ -48,6 +173,17 @@ type cancelAwareSourceTable struct {
 	*fakeSourceTable
 	batches []arrow.RecordBatch
 	done    chan struct{}
+}
+
+type singleReleaseCountingRecordBatch struct {
+	arrow.RecordBatch
+	releases atomic.Int64
+}
+
+func (b *singleReleaseCountingRecordBatch) Release() {
+	if b.releases.Add(1) == 1 {
+		b.RecordBatch.Release()
+	}
 }
 
 func (t *cancelAwareSourceTable) Read(ctx context.Context, _ source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -81,6 +217,28 @@ func (c *fakeCommitter) committed() []any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]any(nil), c.tokens...)
+}
+
+func TestStreamingSequentialFlushFailureReleasesEveryBatchOnce(t *testing.T) {
+	dest := &fakeDestination{writeErr: errors.New("injected write failure")}
+	tables := map[string]*streamTableState{
+		"public.first":  {destTable: "first", schema: streamTestSchema()},
+		"public.second": {destTable: "second", schema: streamTestSchema()},
+		"public.third":  {destTable: "third", schema: streamTestSchema()},
+	}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyAppend}, tables)
+
+	batches := make([]*singleReleaseCountingRecordBatch, 0, len(tables))
+	for table := range tables {
+		batch := &singleReleaseCountingRecordBatch{RecordBatch: int64RecordBatch(t, "id", []int64{1}, nil)}
+		batches = append(batches, batch)
+		loop.buffer(source.RecordBatchResult{TableName: table, Batch: batch})
+	}
+
+	require.ErrorContains(t, loop.flush(t.Context()), "injected write failure")
+	for _, batch := range batches {
+		require.EqualValues(t, 1, batch.releases.Load(), "every started or unstarted batch must have exactly one owner release it")
+	}
 }
 
 // ctxRecordingDest records the context error observed at each WriteParallel
@@ -763,6 +921,7 @@ func TestStreaming_LeaseLossDuringStatePersistSkipsSourceCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, manager.RegisterTable(context.Background(), "public.items", "raw.items"))
 	require.NoError(t, manager.BeginRun(context.Background(), false))
+	require.NoError(t, manager.BindDestinationIncarnation(context.Background(), "public.items", "raw.items"))
 	stateDest.block = true
 
 	committer := &fakeCommitter{}
@@ -773,6 +932,7 @@ func TestStreaming_LeaseLossDuringStatePersistSkipsSourceCommit(t *testing.T) {
 		Committer:     committer,
 		StateManager:  manager,
 	}, map[string]*streamTableState{"": mergeTableState("raw.items")})
+	loop.cfg.SourceTable = "public.items"
 	loop.buffer(source.RecordBatchResult{
 		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
 		CommitToken: source.CDCStateCommitToken{
@@ -798,6 +958,7 @@ func TestStreamingFinalizesLegacySlotAfterDurableStateAndSourceCommit(t *testing
 	require.NoError(t, err)
 	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), "public.items", "raw.items", "100"))
 	require.NoError(t, manager.BeginRun(t.Context(), false))
+	require.NoError(t, manager.BindDestinationIncarnation(t.Context(), "public.items", "raw.items"))
 
 	committer := &fakeCommitter{}
 	finalizer := &fakeLegacySlotFinalizer{committer: committer}
@@ -809,6 +970,7 @@ func TestStreamingFinalizesLegacySlotAfterDurableStateAndSourceCommit(t *testing
 		StateManager:    manager,
 		LegacyFinalizer: finalizer,
 	}, map[string]*streamTableState{"": mergeTableState("raw.items")})
+	loop.cfg.SourceTable = "public.items"
 	loop.buffer(source.RecordBatchResult{
 		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
 		CommitToken: source.CDCStateCommitToken{
@@ -939,7 +1101,7 @@ func TestStreaming_MultiTableRouting(t *testing.T) {
 	assert.ElementsMatch(t, []string{"ds.users", "ds.orders"}, mergedTables)
 }
 
-func TestStreaming_UnknownTableBatchDropped(t *testing.T) {
+func TestStreaming_UnknownTableBatchFailsClosed(t *testing.T) {
 	dest := &fakeDestination{}
 	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
@@ -952,7 +1114,7 @@ func TestStreaming_UnknownTableBatchDropped(t *testing.T) {
 	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.unknown"}
 	close(records)
 
-	require.NoError(t, loop.run(context.Background(), records))
+	require.EqualError(t, loop.run(context.Background(), records), `streaming received 1 row(s) for unknown table "public.unknown"`)
 	assert.Equal(t, 0, writeCallCount(dest))
 }
 

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 )
 
 // TruncateInsertStrategy empties the destination table in place and writes new
@@ -22,12 +25,14 @@ import (
 // once (e.g., page-based pagination over a live table). Without PKs, dedup is
 // not possible and rows are written directly into the truncated target.
 //
-// Tradeoffs the user has already accepted by opting in:
-//   - Non-atomic: the target is empty between TRUNCATE and the final insert,
-//     so concurrent readers may see an empty result set.
-//   - No rollback: if the insert fails after truncate, the target is left empty.
-//   - Schema drift: the existing table's schema is preserved as-is; this
-//     strategy does not drop and recreate to pick up schema changes.
+// Destinations implementing AtomicTruncateInsertWriter replace schema and rows
+// together. Other destinations retain the traditional truncate-then-write
+// behavior, where readers may observe an empty table and failures cannot roll
+// back the truncate.
+//
+// Additional tradeoffs:
+//   - Schema evolution is applied in place before rows are replaced, preserving
+//     dependent objects while allowing supported column additions and widening.
 //   - ClickHouse caveat: ClickHouse's merge implementation relies on
 //     ReplacingMergeTree semantics for dedup rather than pre-filtering, so
 //     duplicate PKs in staging will only be collapsed if the target table is
@@ -51,6 +56,9 @@ func (s *TruncateInsertStrategy) RequiresIncrementalKey() bool {
 }
 
 func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob) error {
+	if atomicWriter, ok := job.Destination.(destination.AtomicTruncateInsertWriter); ok {
+		return s.executeAtomic(ctx, job, atomicWriter)
+	}
 	truncator, ok := job.Destination.(destination.TruncateCapable)
 	if !ok {
 		return fmt.Errorf("destination does not support truncate+insert strategy; use replace instead")
@@ -62,27 +70,175 @@ func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob)
 	return s.executeDirect(ctx, job, truncator)
 }
 
-func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *IngestionJob, truncator destination.TruncateCapable) error {
+func (s *TruncateInsertStrategy) executeAtomic(ctx context.Context, job *IngestionJob, writer destination.AtomicTruncateInsertWriter) error {
 	targetTable := job.Config.DestTable
-	config.Debug("[TRUNCATE+INSERT] Target table: %s (direct path, no PKs)", targetTable)
+	isCDC := hasCDCColumns(job.Schema)
+	hasStagingColumns := destination.HasCDCUnchangedColsColumn(job.Schema.ColumnNames())
+	if isCDC {
+		boundaryAware, ok := writer.(destination.AtomicTruncateInsertBoundaryAware)
+		if !ok || !boundaryAware.SupportsTruncateInsertBoundaries() {
+			return fmt.Errorf("destination atomic truncate+insert writer cannot preserve CDC truncate boundaries")
+		}
+	}
+	if hasStagingColumns {
+		stagingAware, ok := writer.(destination.AtomicTruncateInsertStagingAware)
+		if !ok || !stagingAware.SupportsTruncateInsertStagingColumns() {
+			return fmt.Errorf("destination atomic truncate+insert writer cannot keep staging-only CDC columns out of the target")
+		}
+	}
+	targetSchema := destination.DestinationTableSchema(job.Schema)
+	existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before truncate+insert: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       targetTable,
-		Schema:      destination.DestinationTableSchema(job.Schema),
-		DropFirst:   false,
-		PrimaryKeys: job.Config.PrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:                  targetTable,
+		Schema:                 targetSchema,
+		DropFirst:              false,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		PartitionBy:            job.Config.PartitionBy,
+		ClusterBy:              job.Config.ClusterBy,
+		PreserveExistingLayout: true,
+		OwnershipToken:         ownershipToken,
 	}); err != nil {
+		if ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, true, ownershipToken)
+		}
 		return fmt.Errorf("failed to prepare table: %w", err)
 	}
 
-	if err := job.ApplyEvolution(ctx); err != nil {
-		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	expectedIncarnation, err := bindTruncateInsertDestination(ctx, job, targetTable)
+	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	atomicEvolution, ok := job.Destination.(destination.AtomicTruncateInsertSchemaEvolver)
+	if !ok || !atomicEvolution.EvolvesTruncateInsertSchemaAtomically() {
+		if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+			return err
+		}
 	}
 
-	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
-		return fmt.Errorf("failed to truncate table: %w", err)
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, source.ReadOptions{
+		IncrementalKey:                  job.Config.IncrementalKey,
+		IntervalStart:                   job.Config.IntervalStart,
+		IntervalEnd:                     job.Config.IntervalEnd,
+		ExtractPartitionBy:              job.Config.ExtractPartitionBy,
+		ExtractPartitionInterval:        job.Config.ExtractPartitionInterval,
+		ExtractPartitionNumericInterval: job.Config.ExtractPartitionNumericInterval,
+		ExtractPartitionAuto:            job.Config.ExtractPartitionAuto,
+		PageSize:                        job.Config.PageSize,
+		Limit:                           job.Config.SQLLimit,
+		ExcludeColumns:                  job.Config.SQLExcludeColumns,
+		Parallelism:                     parallelism,
+		Schema:                          job.SourceSchema,
+		CDCSlotSuffix:                   job.Config.CDCSlotSuffix,
+		CDCLegacySlotSuffix:             job.Config.CDCLegacySlotSuffix,
+		FullRefresh:                     job.Config.FullRefresh,
+		CDCSnapshotReplace:              isCDC,
+	})
+	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return fmt.Errorf("failed to get records: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+
+	if err := writer.TruncateInsertRecords(readCtx, records, destination.WriteOptions{
+		Table:                  targetTable,
+		Schema:                 job.Schema,
+		TargetSchema:           targetSchema,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		Parallelism:            job.Config.EffectiveDestinationParallelism(),
+		StagingBucket:          job.Config.StagingBucket,
+		LoaderFileSize:         job.Config.LoaderFileSize,
+		LoaderFileFormat:       job.Config.LoaderFileFormat,
+		PreStaged:              job.PreStaged,
+		DeduplicatePrimaryKeys: len(job.Config.PrimaryKeys) > 0,
+		IncrementalKey:         mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+		SkipCDCResume:          job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to atomically truncate and insert data: %w", err)
+	}
+	if err := revalidateTruncateInsertDestination(ctx, job, targetTable); err != nil {
+		cleanupPublishedOwnedTruncateInsertTarget(
+			ctx, job.Destination, targetTable, !targetExisted, ownershipToken,
+		)
+		return err
+	}
+	return nil
+}
+
+func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *IngestionJob, truncator destination.TruncateCapable) error {
+	targetTable := job.Config.DestTable
+	isCDC := hasCDCColumns(job.Schema)
+	config.Debug("[TRUNCATE+INSERT] Target table: %s (direct path, no PKs)", targetTable)
+	existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before truncate+insert: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+
+	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+		Table:          targetTable,
+		Schema:         destination.DestinationTableSchema(job.Schema),
+		DropFirst:      false,
+		PrimaryKeys:    job.Config.PrimaryKeys,
+		PartitionBy:    job.Config.PartitionBy,
+		ClusterBy:      job.Config.ClusterBy,
+		OwnershipToken: ownershipToken,
+	}); err != nil {
+		if ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, true, ownershipToken)
+		}
+		return fmt.Errorf("failed to prepare table: %w", err)
+	}
+
+	expectedIncarnation, err := bindTruncateInsertDestination(ctx, job, targetTable)
+	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -105,30 +261,66 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 		Schema:                          job.SourceSchema,
 		CDCSlotSuffix:                   job.Config.CDCSlotSuffix,
 		CDCLegacySlotSuffix:             job.Config.CDCLegacySlotSuffix,
+		CDCSnapshotReplace:              isCDC,
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
-
-	if err := job.Destination.WriteParallel(ctx, records, destination.WriteOptions{
-		Table:            targetTable,
-		Schema:           job.Schema,
-		Parallelism:      job.Config.EffectiveDestinationParallelism(),
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		PreStaged:        job.PreStaged,
-	}); err != nil {
-		return fmt.Errorf("failed to write data: %w", err)
+	writeSchema := destination.DestinationTableSchema(job.Schema)
+	if destination.HasCDCUnchangedColsColumn(job.Schema.ColumnNames()) {
+		records = transformer.Wrap(records, destinationColumnProjector{})
 	}
 
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := truncateInsertTarget(ctx, job.Destination, truncator, targetTable, isCDC, expectedIncarnation); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to truncate table: %w", err)
+	}
+
+	writeOpts := destination.WriteOptions{
+		Table:                  targetTable,
+		Schema:                 writeSchema,
+		Parallelism:            job.Config.EffectiveDestinationParallelism(),
+		StagingBucket:          job.Config.StagingBucket,
+		LoaderFileSize:         job.Config.LoaderFileSize,
+		LoaderFileFormat:       job.Config.LoaderFileFormat,
+		PreStaged:              job.PreStaged,
+		SkipCDCResume:          job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}
+	var writeErr error
+	if isCDC {
+		_, writeErr = destination.WriteWithTruncateBoundariesAfterCancel(readCtx, job.Destination, records, writeOpts, cancelRead)
+	} else {
+		writeErr = job.Destination.WriteParallel(readCtx, records, writeOpts)
+	}
+	if writeErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to write data: %w", writeErr)
+	}
+	if err := revalidateTruncateInsertDestination(ctx, job, targetTable); err != nil {
+		cleanupPublishedOwnedTruncateInsertTarget(
+			ctx, job.Destination, targetTable, !targetExisted, ownershipToken,
+		)
+		return err
+	}
 	return nil
 }
 
@@ -138,18 +330,32 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 	}
 
 	targetTable := job.Config.DestTable
+	isCDC := hasCDCColumns(job.Schema)
 	stagingTable := managedStagingTableName(job.Destination, targetTable, "ti", job.Config.StagingDataset)
 	output.Statusf("[TRUNCATE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+	existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before truncate+insert: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       targetTable,
-		Schema:      destination.DestinationTableSchema(job.Schema),
-		DropFirst:   false,
-		PrimaryKeys: job.Config.PrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:          targetTable,
+		Schema:         destination.DestinationTableSchema(job.Schema),
+		DropFirst:      false,
+		PrimaryKeys:    job.Config.PrimaryKeys,
+		PartitionBy:    job.Config.PartitionBy,
+		ClusterBy:      job.Config.ClusterBy,
+		OwnershipToken: ownershipToken,
 	}); err != nil {
+		if ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, true, ownershipToken)
+		}
 		return fmt.Errorf("failed to prepare destination table: %w", err)
+	}
+	if !job.Config.KeepStaging {
+		defer dropManagedStagingDetached(ctx, job.Destination, stagingTable, "TRUNCATE+INSERT")
 	}
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
@@ -161,7 +367,17 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		ClusterBy:    job.Config.ClusterBy,
 		ExpiresAfter: destination.ManagedStagingTTL,
 	}); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to prepare staging table: %w", err)
+	}
+	expectedIncarnation, err := bindTruncateInsertDestination(ctx, job, targetTable)
+	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -184,11 +400,15 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		Schema:                          job.SourceSchema,
 		CDCSlotSuffix:                   job.Config.CDCSlotSuffix,
 		CDCLegacySlotSuffix:             job.Config.CDCLegacySlotSuffix,
+		CDCSnapshotReplace:              isCDC,
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
@@ -196,7 +416,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		records = job.Tracker.Wrap(records)
 	}
 
-	if err := job.Destination.WriteParallel(ctx, records, destination.WriteOptions{
+	writeOpts := destination.WriteOptions{
 		Table:            stagingTable,
 		Schema:           job.Schema,
 		Parallelism:      job.Config.EffectiveDestinationParallelism(),
@@ -205,35 +425,143 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
-	}); err != nil {
-		return fmt.Errorf("failed to write to staging: %w", err)
+		SkipCDCResume:    job.CDCStateManager != nil,
+	}
+	var writeErr error
+	if isCDC {
+		_, writeErr = destination.WriteWithTruncateBoundariesAfterCancel(readCtx, job.Destination, records, writeOpts, cancelRead)
+	} else {
+		writeErr = job.Destination.WriteParallel(readCtx, records, writeOpts)
+	}
+	if writeErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return fmt.Errorf("failed to write to staging: %w", writeErr)
 	}
 
-	if err := job.ApplyEvolution(ctx); err != nil {
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := job.ApplyEvolutionIfIncarnation(ctx, expectedIncarnation); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
-
-	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return err
+	}
+	if err := truncateInsertTarget(ctx, job.Destination, truncator, targetTable, isCDC, expectedIncarnation); err != nil {
 		return fmt.Errorf("failed to truncate target: %w", err)
 	}
 
 	config.Debug("[TRUNCATE+INSERT] Executing deduplicated insert via merge from staging")
 	if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
-		StagingTable:   stagingTable,
-		TargetTable:    targetTable,
-		PrimaryKeys:    job.Config.PrimaryKeys,
-		Columns:        job.Schema.ColumnNames(),
-		IncrementalKey: mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
-		Schema:         job.Schema,
+		StagingTable:           stagingTable,
+		TargetTable:            targetTable,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		Columns:                destination.MergeColumnsFor(job.Destination, job.Schema.ColumnNames()),
+		IncrementalKey:         mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+		Schema:                 job.Schema,
+		SkipCDCResume:          job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
 	}); err != nil {
 		return fmt.Errorf("failed to insert from staging: %w", err)
 	}
+	if err := revalidateTruncateInsertDestination(ctx, job, targetTable); err != nil {
+		cleanupPublishedOwnedTruncateInsertTarget(
+			ctx, job.Destination, targetTable, !targetExisted, ownershipToken,
+		)
+		return err
+	}
+	return nil
+}
 
-	if !job.Config.KeepStaging {
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[TRUNCATE+INSERT] Warning: failed to drop staging table: %v", err)
+func bindTruncateInsertDestination(ctx context.Context, job *IngestionJob, targetTable string) (string, error) {
+	if job.CDCStateManager == nil {
+		return "", nil
+	}
+	if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+		return "", fmt.Errorf("failed to bind CDC destination before truncate+insert extraction: %w", err)
+	}
+	expected := job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+	if expected == "" {
+		return "", fmt.Errorf("managed CDC destination %s has no bound physical incarnation", targetTable)
+	}
+	return expected, nil
+}
+
+func revalidateTruncateInsertDestination(ctx context.Context, job *IngestionJob, targetTable string) error {
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	if job.CDCStateManager == nil {
+		return nil
+	}
+	if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+		return fmt.Errorf("failed to revalidate CDC destination after truncate+insert: %w", err)
+	}
+	return nil
+}
+
+func cleanupPublishedOwnedTruncateInsertTarget(
+	ctx context.Context,
+	dest destination.Destination,
+	table string,
+	createdByRun bool,
+	ownershipToken string,
+) {
+	if ownershipToken == "" {
+		return
+	}
+	cleanupFailedOwnedDirectReplace(ctx, dest, table, createdByRun, ownershipToken)
+}
+
+func truncateInsertTarget(
+	ctx context.Context,
+	dest destination.Destination,
+	truncator destination.TruncateCapable,
+	targetTable string,
+	isCDC bool,
+	expectedIncarnation string,
+) error {
+	if expectedIncarnation != "" {
+		return destination.ApplyCDCTruncateIfIncarnation(ctx, dest, targetTable, expectedIncarnation)
+	}
+	if isCDC {
+		return destination.ApplyCDCTruncate(ctx, dest, targetTable)
+	}
+	return truncator.TruncateTable(ctx, targetTable)
+}
+
+type destinationColumnProjector struct{}
+
+func (destinationColumnProjector) Transform(batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+	fields := make([]arrow.Field, 0, batch.NumCols())
+	columns := make([]arrow.Array, 0, batch.NumCols())
+	for i, field := range batch.Schema().Fields() {
+		if destination.IsCDCStagingOnlyColumn(field.Name) {
+			continue
+		}
+		column := batch.Column(i)
+		column.Retain()
+		fields = append(fields, field)
+		columns = append(columns, column)
+	}
+	result := array.NewRecordBatch(arrow.NewSchema(fields, nil), columns, batch.NumRows())
+	for _, column := range columns {
+		column.Release()
+	}
+	return result, nil
+}
+
+func (destinationColumnProjector) OutputSchema(input *arrow.Schema) *arrow.Schema {
+	fields := make([]arrow.Field, 0, input.NumFields())
+	for _, field := range input.Fields() {
+		if !destination.IsCDCStagingOnlyColumn(field.Name) {
+			fields = append(fields, field)
 		}
 	}
-
-	return nil
+	return arrow.NewSchema(fields, nil)
 }

--- a/pkg/strategy/truncate_insert_postgres_integration_test.go
+++ b/pkg/strategy/truncate_insert_postgres_integration_test.go
@@ -1,0 +1,334 @@
+//go:build integration
+
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/destination/postgres"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type racingTargetPostgresDestination struct {
+	*postgres.PostgresDestination
+	target        string
+	beforePrepare func(context.Context) error
+	afterPrepare  func(context.Context) error
+}
+
+func (d *racingTargetPostgresDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if opts.Table == d.target && d.beforePrepare != nil {
+		if err := d.beforePrepare(ctx); err != nil {
+			return err
+		}
+	}
+	if err := d.PostgresDestination.PrepareTable(ctx, opts); err != nil {
+		return err
+	}
+	if opts.Table == d.target && d.afterPrepare != nil {
+		return d.afterPrepare(ctx)
+	}
+	return nil
+}
+
+func TestPostgresOwnedTargetCleanup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	postgresDest, db := newPostgresTruncateInsertHarness(t, ctx)
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+
+	run := func(t *testing.T, dest destination.Destination, target string) error {
+		t.Helper()
+		src := &fakeSourceTable{
+			name: "public.events", hasKnownSchema: true, tableSchema: tableSchema,
+			readErr: errors.New("source became unavailable"),
+		}
+		job := &IngestionJob{
+			Config: &config.IngestConfig{
+				SourceTable: "public.events", DestTable: target,
+				IncrementalStrategy: config.StrategyTruncateInsert,
+			},
+			Table: src, Destination: dest, Schema: tableSchema, SourceSchema: tableSchema,
+		}
+		return (&TruncateInsertStrategy{}).Execute(ctx, job)
+	}
+	tableExists := func(t *testing.T, table string) bool {
+		t.Helper()
+		var exists bool
+		require.NoError(t, db.QueryRow(ctx, `SELECT to_regclass($1) IS NOT NULL`, table).Scan(&exists))
+		return exists
+	}
+	createSentinel := func(ctx context.Context, table string) error {
+		if _, err := db.Exec(ctx, "CREATE TABLE "+destination.QuoteTableName(table)+" (id bigint)"); err != nil {
+			return err
+		}
+		_, err := db.Exec(ctx, "INSERT INTO "+destination.QuoteTableName(table)+" (id) VALUES (99)")
+		return err
+	}
+	assertSentinel := func(t *testing.T, table string) {
+		t.Helper()
+		var id int64
+		require.NoError(t, db.QueryRow(ctx, "SELECT id FROM "+destination.QuoteTableName(table)).Scan(&id))
+		require.Equal(t, int64(99), id)
+	}
+
+	t.Run("removes target created by failed run", func(t *testing.T) {
+		target := "public.owned_failed_target"
+		require.ErrorContains(t, run(t, postgresDest, target), "source became unavailable")
+		require.False(t, tableExists(t, target))
+	})
+
+	t.Run("handles arbitrary ownership token", func(t *testing.T) {
+		target := "public.arbitrary_token_target"
+		token := `untrusted\'; DROP TABLE public.arbitrary_token_target; --`
+		require.NoError(t, postgresDest.PrepareTable(ctx, destination.PrepareOptions{
+			Table: target, Schema: tableSchema, OwnershipToken: token,
+		}))
+		require.True(t, tableExists(t, target))
+		require.NoError(t, postgresDest.DropTableIfOwned(ctx, target, token))
+		require.False(t, tableExists(t, target))
+	})
+
+	t.Run("preserves target created before owned prepare", func(t *testing.T) {
+		target := "public.concurrent_target"
+		dest := &racingTargetPostgresDestination{
+			PostgresDestination: postgresDest,
+			target:              target,
+			beforePrepare: func(ctx context.Context) error {
+				return createSentinel(ctx, target)
+			},
+		}
+		require.ErrorContains(t, run(t, dest, target), "appeared concurrently")
+		assertSentinel(t, target)
+	})
+
+	t.Run("preserves replacement after owned prepare", func(t *testing.T) {
+		target := "public.replaced_owned_target"
+		dest := &racingTargetPostgresDestination{
+			PostgresDestination: postgresDest,
+			target:              target,
+			afterPrepare: func(ctx context.Context) error {
+				if _, err := db.Exec(ctx, "DROP TABLE "+destination.QuoteTableName(target)); err != nil {
+					return err
+				}
+				return createSentinel(ctx, target)
+			},
+		}
+		require.ErrorContains(t, run(t, dest, target), "source became unavailable")
+		assertSentinel(t, target)
+	})
+}
+
+func TestKeylessCDCTruncateInsertProjectsStagingOnlyColumnsPostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dest, db := newPostgresTruncateInsertHarness(t, ctx)
+
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "payload", DataType: schema.TypeString},
+		{Name: destination.CDCLSNColumn, DataType: schema.TypeString},
+		{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+		{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true},
+	}}
+	records := make(chan source.RecordBatchResult, 3)
+	records <- source.RecordBatchResult{Batch: postgresCDCRecordBatch(tableSchema, []postgresCDCRow{
+		{id: 1, payload: "before-boundary", lsn: "0/01", unchangedCols: `[]`},
+	})}
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{Batch: keylessCDCRecordBatch(tableSchema)}
+	close(records)
+	src := &fakeSourceTable{
+		name: "public.events", hasKnownSchema: true, tableSchema: tableSchema, readCh: records,
+	}
+	job := &IngestionJob{
+		Config: &config.IngestConfig{
+			SourceTable: "public.events", DestTable: "public.keyless_events", FullRefresh: true,
+			IncrementalStrategy: config.StrategyTruncateInsert, ExtractParallelism: 2,
+		},
+		Table: src, Destination: dest, Schema: tableSchema, SourceSchema: tableSchema,
+	}
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(ctx, job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	var id int64
+	var payload, lsn string
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT id, payload, _cdc_lsn
+		FROM public.keyless_events
+	`).Scan(&id, &payload, &lsn))
+	require.Equal(t, int64(42), id)
+	require.Equal(t, "snapshot", payload)
+	require.Equal(t, "0/10", lsn)
+	var preBoundaryRows int
+	require.NoError(t, db.QueryRow(ctx, `SELECT COUNT(*) FROM public.keyless_events WHERE id = 1`).Scan(&preBoundaryRows))
+	require.Zero(t, preBoundaryRows)
+	var markerColumns int
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'keyless_events'
+		  AND column_name = $1
+	`, destination.CDCUnchangedColsColumn).Scan(&markerColumns))
+	require.Zero(t, markerColumns)
+}
+
+func TestPKCDCTruncateInsertDiscardsPreBoundaryStagingRowsPostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dest, db := newPostgresTruncateInsertHarness(t, ctx)
+
+	tableSchema := &schema.TableSchema{
+		PrimaryKeys: []string{"id"},
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "payload", DataType: schema.TypeString},
+			{Name: destination.CDCLSNColumn, DataType: schema.TypeString},
+			{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+			{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+			{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true},
+		},
+	}
+	records := make(chan source.RecordBatchResult, 3)
+	records <- source.RecordBatchResult{Batch: postgresCDCRecordBatch(tableSchema, []postgresCDCRow{
+		{id: 1, payload: "before-boundary", lsn: "0/10", unchangedCols: `["payload"]`},
+	})}
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{Batch: postgresCDCRecordBatch(tableSchema, []postgresCDCRow{
+		{id: 2, payload: "older-post-boundary", lsn: "0/20", unchangedCols: `[]`},
+		{id: 2, payload: "latest-post-boundary", lsn: "0/21", unchangedCols: `["payload"]`},
+	})}
+	close(records)
+	src := &fakeSourceTable{
+		name:              "public.events",
+		primaryKeys:       []string{"id"},
+		primaryKeysUnique: true,
+		hasKnownSchema:    true,
+		tableSchema:       tableSchema,
+		readCh:            records,
+	}
+	job := &IngestionJob{
+		Config: &config.IngestConfig{
+			SourceTable: "public.events", DestTable: "public.pk_events", FullRefresh: true,
+			PrimaryKeys: []string{"id"}, IncrementalStrategy: config.StrategyTruncateInsert,
+			ExtractParallelism: 2,
+		},
+		Table: src, Destination: dest, Schema: tableSchema, SourceSchema: tableSchema,
+	}
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(ctx, job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+
+	var preBoundaryRows int
+	require.NoError(t, db.QueryRow(ctx, `SELECT COUNT(*) FROM public.pk_events WHERE id = 1`).Scan(&preBoundaryRows))
+	require.Zero(t, preBoundaryRows)
+	var id int64
+	var payload, lsn string
+	var deleted bool
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT id, payload, _cdc_lsn, _cdc_deleted
+		FROM public.pk_events
+	`).Scan(&id, &payload, &lsn, &deleted))
+	require.Equal(t, int64(2), id)
+	require.Equal(t, "latest-post-boundary", payload)
+	require.Equal(t, "0/21", lsn)
+	require.False(t, deleted)
+	var markerColumns int
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'pk_events'
+		  AND column_name = $1
+	`, destination.CDCUnchangedColsColumn).Scan(&markerColumns))
+	require.Zero(t, markerColumns)
+}
+
+func newPostgresTruncateInsertHarness(
+	t *testing.T,
+	ctx context.Context,
+) (*postgres.PostgresDestination, *pgxpool.Pool) {
+	t.Helper()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image: "postgres:16-alpine",
+			Env: map[string]string{
+				"POSTGRES_USER": "testuser", "POSTGRES_PASSWORD": "testpass", "POSTGRES_DB": "testdb",
+			},
+			ExposedPorts: []string{"5432/tcp"},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+
+	connString := fmt.Sprintf(
+		"postgres://testuser:testpass@%s:%s/testdb?sslmode=disable", host, port.Port(),
+	)
+	dest := postgres.NewPostgresDestination()
+	require.NoError(t, dest.Connect(ctx, connString))
+	t.Cleanup(func() { _ = dest.Close(context.Background()) })
+	db, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+	return dest, db
+}
+
+type postgresCDCRow struct {
+	id            int64
+	payload       string
+	lsn           string
+	deleted       bool
+	unchangedCols string
+}
+
+func postgresCDCRecordBatch(tableSchema *schema.TableSchema, rows []postgresCDCRow) arrow.RecordBatch {
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, tableSchema.ToArrowSchema())
+	defer builder.Release()
+	for _, row := range rows {
+		builder.Field(0).(*array.Int64Builder).Append(row.id)
+		builder.Field(1).(*array.StringBuilder).Append(row.payload)
+		builder.Field(2).(*array.StringBuilder).Append(row.lsn)
+		builder.Field(3).(*array.BooleanBuilder).Append(row.deleted)
+		builder.Field(4).(*array.TimestampBuilder).Append(arrow.Timestamp(time.Now().UTC().UnixMicro()))
+		builder.Field(5).(*array.StringBuilder).Append(row.unchangedCols)
+	}
+	return builder.NewRecordBatch()
+}
+
+func keylessCDCRecordBatch(tableSchema *schema.TableSchema) arrow.RecordBatch {
+	return postgresCDCRecordBatch(tableSchema, []postgresCDCRow{
+		{id: 42, payload: "snapshot", lsn: "0/10", unchangedCols: `["payload"]`},
+	})
+}

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -5,10 +5,901 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 )
+
+type atomicTruncateInsertDestination struct {
+	*fakeDestination
+	calls           []destination.WriteOptions
+	receivedIDs     []int64
+	receivedColumns [][]string
+	err             error
+}
+
+type atomicSchemaEvolvingTruncateDestination struct {
+	*atomicTruncateInsertDestination
+}
+
+type immediateFailAtomicTruncateDestination struct {
+	*fakeDestination
+}
+
+type boundaryOnlyAtomicTruncateDestination struct {
+	*immediateFailAtomicTruncateDestination
+}
+
+type ownedAtomicTruncateDestination struct {
+	*atomicTruncateInsertDestination
+	preparedToken string
+	dropTokens    []string
+}
+
+type leaseLosingOwnedAtomicDestination struct {
+	*ownedAtomicTruncateDestination
+	lease *streamingTestLease
+}
+
+type recreatingAtomicTruncateDestination struct {
+	*cdcStateDestination
+	calls []destination.WriteOptions
+}
+
+type leaseLosingReadSource struct {
+	*fakeSourceTable
+	lease *streamingTestLease
+}
+
+type leaseLosingOwnedTruncateDestination struct {
+	*ownedTruncateDestination
+	lease          *streamingTestLease
+	loseAfterWrite bool
+	loseAfterMerge bool
+}
+
+func (s *leaseLosingReadSource) Read(
+	ctx context.Context,
+	opts source.ReadOptions,
+) (<-chan source.RecordBatchResult, error) {
+	records, err := s.fakeSourceTable.Read(ctx, opts)
+	close(s.lease.done)
+	return records, err
+}
+
+func (d *leaseLosingOwnedTruncateDestination) WriteParallel(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	err := d.ownedTruncateDestination.WriteParallel(ctx, records, opts)
+	if err == nil && d.loseAfterWrite {
+		close(d.lease.done)
+	}
+	return err
+}
+
+func (d *leaseLosingOwnedTruncateDestination) MergeTable(
+	ctx context.Context,
+	opts destination.MergeOptions,
+) error {
+	err := d.ownedTruncateDestination.MergeTable(ctx, opts)
+	if err == nil && d.loseAfterMerge {
+		close(d.lease.done)
+	}
+	return err
+}
+
+type conditionalTruncateCall struct {
+	table       string
+	incarnation string
+}
+
+type managedTruncateInsertDestination struct {
+	*cdcStateDestination
+	dataWrites             []destination.WriteOptions
+	dataColumns            [][]string
+	merges                 []destination.MergeOptions
+	truncates              []string
+	conditionalTruncates   []conditionalTruncateCall
+	replaceBeforeEvolution bool
+}
+
+func (d *managedTruncateInsertDestination) WriteParallel(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.dataWrites = append(d.dataWrites, opts)
+	for result := range records {
+		if result.Batch != nil {
+			columns := make([]string, result.Batch.NumCols())
+			for i := range columns {
+				columns[i] = result.Batch.ColumnName(i)
+			}
+			d.dataColumns = append(d.dataColumns, columns)
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+func (d *managedTruncateInsertDestination) MergeTable(_ context.Context, opts destination.MergeOptions) error {
+	d.merges = append(d.merges, opts)
+	return nil
+}
+
+func (d *managedTruncateInsertDestination) TruncateTable(_ context.Context, table string) error {
+	d.truncates = append(d.truncates, table)
+	return nil
+}
+
+func (d *managedTruncateInsertDestination) TruncateCDCTableIfIncarnation(
+	ctx context.Context,
+	table string,
+	expected string,
+) error {
+	d.conditionalTruncates = append(d.conditionalTruncates, conditionalTruncateCall{
+		table:       table,
+		incarnation: expected,
+	})
+	return d.cdcStateDestination.TruncateCDCTableIfIncarnation(ctx, table, expected)
+}
+
+func (*managedTruncateInsertDestination) SupportsCDCUnchangedCols() bool {
+	return true
+}
+
+func (d *managedTruncateInsertDestination) ApplySchemaEvolutionIfIncarnation(
+	ctx context.Context,
+	table string,
+	comparison *schemaevolution.SchemaComparison,
+	expected string,
+) ([]string, error) {
+	d.stateMu.Lock()
+	if d.replaceBeforeEvolution {
+		d.incarnations[table] = "replacement-v2"
+		d.replaceBeforeEvolution = false
+	}
+	current := d.incarnations[table]
+	d.stateMu.Unlock()
+	if current != expected {
+		return nil, errors.New("destination physical incarnation changed before schema evolution")
+	}
+	return d.ApplySchemaEvolution(ctx, table, comparison)
+}
+
+func managedTruncateInsertJob(t *testing.T, withPrimaryKey bool) (*IngestionJob, *fakeSourceTable, *managedTruncateInsertDestination) {
+	t.Helper()
+	job, src, _ := minimalJob()
+	job.Config.FullRefresh = true
+	job.Schema.Columns = append(
+		job.Schema.Columns,
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: false},
+		schema.Column{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true},
+	)
+	job.SourceSchema = job.Schema
+	if !withPrimaryKey {
+		job.Config.PrimaryKeys = nil
+		job.Schema.PrimaryKeys = nil
+		src.primaryKeys = nil
+	}
+
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &managedTruncateInsertDestination{cdcStateDestination: stateDest}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "managed-truncate-insert", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(
+		t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1", "schema-v1",
+	))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	return job, src, dest
+}
+
+func managedTruncateInsertRecords(t *testing.T) <-chan source.RecordBatchResult {
+	t.Helper()
+	first := "one"
+	second := "two"
+	return mustClosedRecords(
+		source.RecordBatchResult{Batch: cdcRenameRecordBatch(t, "name", &first, `["name"]`)},
+		source.RecordBatchResult{Truncate: true, CDCWALTruncate: true},
+		source.RecordBatchResult{Batch: cdcRenameRecordBatch(t, "name", &second, `[]`)},
+	)
+}
+
+func TestManagedDirectTruncateInsertFencesWritesAndSourceTruncates(t *testing.T) {
+	job, src, dest := managedTruncateInsertJob(t, false)
+	src.readCh = managedTruncateInsertRecords(t)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	require.Equal(t, []conditionalTruncateCall{
+		{table: job.Config.DestTable, incarnation: "target-v1"},
+		{table: job.Config.DestTable, incarnation: "target-v1"},
+	}, dest.conditionalTruncates)
+	require.Len(t, dest.dataWrites, 2)
+	for _, opts := range dest.dataWrites {
+		require.Equal(t, job.Config.DestTable, opts.Table)
+		require.Equal(t, "target-v1", opts.CDCExpectedIncarnation)
+		require.True(t, opts.SkipCDCResume)
+		require.False(t, opts.StagingTable)
+	}
+	require.Equal(t, [][]string{{"name"}, {"name"}}, dest.dataColumns)
+	require.Empty(t, dest.truncates)
+}
+
+func TestManagedStagedTruncateInsertPreservesCDCMarkersAndFencesPublication(t *testing.T) {
+	job, src, dest := managedTruncateInsertJob(t, true)
+	src.readCh = managedTruncateInsertRecords(t)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	require.Equal(t, []conditionalTruncateCall{
+		{table: job.Config.DestTable, incarnation: "target-v1"},
+	}, dest.conditionalTruncates)
+	require.Len(t, dest.dataWrites, 2)
+	stagingTable := dest.dataWrites[0].Table
+	require.NotEqual(t, job.Config.DestTable, stagingTable)
+	for _, opts := range dest.dataWrites {
+		require.Equal(t, stagingTable, opts.Table)
+		require.Empty(t, opts.CDCExpectedIncarnation)
+		require.True(t, opts.SkipCDCResume)
+		require.True(t, opts.StagingTable)
+	}
+	for _, columns := range dest.dataColumns {
+		require.Contains(t, columns, destination.CDCUnchangedColsColumn)
+	}
+	require.Equal(t, []string{stagingTable}, dest.truncates)
+	require.Len(t, dest.merges, 1)
+	require.Equal(t, "target-v1", dest.merges[0].CDCExpectedIncarnation)
+	require.True(t, dest.merges[0].SkipCDCResume)
+	require.Contains(t, dest.merges[0].Columns, destination.CDCUnchangedColsColumn)
+}
+
+func TestTruncateInsertLeaseLossCleansOwnedTargetBeforeMutation(t *testing.T) {
+	for _, withPrimaryKey := range []bool{false, true} {
+		t.Run(map[bool]string{false: "direct", true: "staged"}[withPrimaryKey], func(t *testing.T) {
+			job, src, base := minimalJob()
+			job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+				Table: job.Config.DestTable,
+				Comparison: &schemaevolution.SchemaComparison{
+					HasChanges: true,
+					Changes: []schemaevolution.SchemaChange{{
+						Type: schemaevolution.ChangeAddColumn, ColumnName: "must_not_be_added",
+					}},
+				},
+			}
+			if !withPrimaryKey {
+				job.Config.PrimaryKeys = nil
+				job.Schema.PrimaryKeys = nil
+				src.primaryKeys = nil
+			}
+			src.readCh = mustClosedRecords()
+			dest := &ownedTruncateDestination{
+				truncateCapableDestination: &truncateCapableDestination{fakeDestination: base},
+			}
+			job.Destination = dest
+			lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease connection lost")}
+			close(lease.done)
+
+			err := (&TruncateInsertStrategy{}).Execute(guardedStreamingContext(lease), job)
+			require.ErrorIs(t, err, source.ErrConnectorLeaseLost)
+			require.NotEmpty(t, dest.preparedToken)
+			require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			require.Empty(t, base.truncateCalls)
+			require.Empty(t, base.execCalls)
+		})
+	}
+}
+
+func TestTruncateInsertAtomicLeaseLossBeforeEvolutionSkipsDDLAndPublication(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable,
+		Comparison: &schemaevolution.SchemaComparison{
+			HasChanges: true,
+			Changes: []schemaevolution.SchemaChange{{
+				Type: schemaevolution.ChangeAddColumn, ColumnName: "must_not_be_added",
+			}},
+		},
+	}
+	src.readCh = mustClosedRecords()
+	lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease connection lost")}
+	close(lease.done)
+
+	err := (&TruncateInsertStrategy{}).Execute(guardedStreamingContext(lease), job)
+	require.ErrorIs(t, err, source.ErrConnectorLeaseLost)
+	require.Empty(t, base.execCalls)
+	require.Empty(t, atomic.calls)
+	require.False(t, src.readCalled)
+}
+
+func TestTruncateInsertLeaseLossAfterPublicationCleansOwnedNewTarget(t *testing.T) {
+	t.Run("atomic", func(t *testing.T) {
+		job, src, base := minimalJob()
+		src.readCh = singleBatchRecords(t, 1)
+		lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease connection lost")}
+		owned := &ownedAtomicTruncateDestination{atomicTruncateInsertDestination: &atomicTruncateInsertDestination{
+			fakeDestination: base,
+		}}
+		dest := &leaseLosingOwnedAtomicDestination{ownedAtomicTruncateDestination: owned, lease: lease}
+		job.Destination = dest
+
+		err := (&TruncateInsertStrategy{}).Execute(guardedStreamingContext(lease), job)
+		require.ErrorIs(t, err, source.ErrConnectorLeaseLost)
+		require.Equal(t, []string{owned.preparedToken}, owned.dropTokens)
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		job, src, base := minimalJob()
+		job.Config.PrimaryKeys = nil
+		job.Schema.PrimaryKeys = nil
+		src.primaryKeys = nil
+		src.readCh = singleBatchRecords(t, 1)
+		lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease connection lost")}
+		owned := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+		dest := &leaseLosingOwnedTruncateDestination{
+			ownedTruncateDestination: owned, lease: lease, loseAfterWrite: true,
+		}
+		job.Destination = dest
+
+		err := (&TruncateInsertStrategy{}).Execute(guardedStreamingContext(lease), job)
+		require.ErrorIs(t, err, source.ErrConnectorLeaseLost)
+		require.Equal(t, []string{owned.preparedToken}, owned.dropTokens)
+	})
+
+	t.Run("staged", func(t *testing.T) {
+		job, src, base := minimalJob()
+		src.readCh = singleBatchRecords(t, 1)
+		lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease connection lost")}
+		owned := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+		dest := &leaseLosingOwnedTruncateDestination{
+			ownedTruncateDestination: owned, lease: lease, loseAfterMerge: true,
+		}
+		job.Destination = dest
+
+		err := (&TruncateInsertStrategy{}).Execute(guardedStreamingContext(lease), job)
+		require.ErrorIs(t, err, source.ErrConnectorLeaseLost)
+		require.Equal(t, []string{owned.preparedToken}, owned.dropTokens)
+	})
+}
+
+func TestManagedTruncateInsertFencesSchemaEvolution(t *testing.T) {
+	for _, withPrimaryKey := range []bool{false, true} {
+		t.Run(map[bool]string{false: "direct", true: "staged"}[withPrimaryKey], func(t *testing.T) {
+			job, src, dest := managedTruncateInsertJob(t, withPrimaryKey)
+			if withPrimaryKey {
+				src.readCh = mustClosedRecords()
+			}
+			job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+				Table: job.Config.DestTable,
+				Comparison: &schemaevolution.SchemaComparison{
+					HasChanges: true,
+					Changes: []schemaevolution.SchemaChange{{
+						Type:       schemaevolution.ChangeAddColumn,
+						ColumnName: "new_column",
+						NewColumn: schema.Column{
+							Name: "new_column", DataType: schema.TypeString, Nullable: true,
+						},
+					}},
+				},
+			}
+			dest.replaceBeforeEvolution = true
+
+			err := (&TruncateInsertStrategy{}).Execute(t.Context(), job)
+			require.ErrorContains(t, err, "incarnation changed before schema evolution")
+			require.Equal(t, withPrimaryKey, src.readCalled)
+			require.Empty(t, dest.execCalls)
+			if withPrimaryKey {
+				require.Len(t, dest.dataWrites, 1)
+				require.True(t, dest.dataWrites[0].StagingTable)
+			} else {
+				require.Empty(t, dest.dataWrites)
+			}
+			require.Empty(t, dest.conditionalTruncates)
+		})
+	}
+}
+
+func (d *recreatingAtomicTruncateDestination) TruncateInsertRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.calls = append(d.calls, opts)
+	d.stateMu.Lock()
+	d.incarnations[opts.Table] = "external-v2"
+	d.stateMu.Unlock()
+	current, _, _ := d.CDCTargetIncarnation(ctx, opts.Table)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	if opts.CDCExpectedIncarnation != current {
+		return errors.New("destination incarnation changed before atomic truncate+insert")
+	}
+	return nil
+}
+
+func TestManagedAtomicTruncateInsertRejectsTargetRecreationDuringExtraction(t *testing.T) {
+	job, src, _ := minimalJob()
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &recreatingAtomicTruncateDestination{cdcStateDestination: stateDest}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "truncate-insert-recreation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	src.readCh = singleBatchRecords(t, 1)
+
+	err = (&TruncateInsertStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed")
+	require.Len(t, dest.calls, 1)
+	require.Equal(t, "target-v1", dest.calls[0].CDCExpectedIncarnation)
+	require.True(t, dest.calls[0].SkipCDCResume)
+}
+
+func (d *ownedAtomicTruncateDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if opts.Table != "" && opts.OwnershipToken != "" {
+		d.preparedToken = opts.OwnershipToken
+	}
+	return d.atomicTruncateInsertDestination.PrepareTable(ctx, opts)
+}
+
+func (d *ownedAtomicTruncateDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	return errors.New("ownership changed")
+}
+
+func (d *leaseLosingOwnedAtomicDestination) TruncateInsertRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	err := d.ownedAtomicTruncateDestination.TruncateInsertRecords(ctx, records, opts)
+	if err == nil {
+		close(d.lease.done)
+	}
+	return err
+}
+
+type ownedTruncateDestination struct {
+	*truncateCapableDestination
+	preparedToken string
+	dropTokens    []string
+}
+
+type uncertainStagingTruncateDestination struct {
+	*uncertainManagedStagingPrepareDestination
+}
+
+func (d *uncertainStagingTruncateDestination) TruncateTable(context.Context, string) error {
+	return nil
+}
+
+func (d *ownedTruncateDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if opts.OwnershipToken != "" {
+		d.preparedToken = opts.OwnershipToken
+	}
+	return d.truncateCapableDestination.PrepareTable(ctx, opts)
+}
+
+func TestTruncateInsertLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.PrimaryKeys = []string{"id"}
+	dest := &uncertainStagingTruncateDestination{uncertainManagedStagingPrepareDestination: &uncertainManagedStagingPrepareDestination{
+		contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base},
+	}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&TruncateInsertStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func (d *ownedTruncateDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	return errors.New("ownership changed")
+}
+
+func (d *immediateFailAtomicTruncateDestination) TruncateInsertRecords(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	return errors.New("atomic writer failed")
+}
+
+func (d *atomicSchemaEvolvingTruncateDestination) EvolvesTruncateInsertSchemaAtomically() bool {
+	return true
+}
+
+func (d *atomicTruncateInsertDestination) TruncateInsertRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.calls = append(d.calls, opts)
+	for result := range records {
+		if result.Truncate {
+			d.receivedIDs = nil
+		}
+		if result.Batch != nil {
+			columns := make([]string, result.Batch.NumCols())
+			for column := range columns {
+				columns[column] = result.Batch.ColumnName(column)
+			}
+			d.receivedColumns = append(d.receivedColumns, columns)
+			if result.Batch.NumCols() > 0 {
+				if values, ok := result.Batch.Column(0).(*array.Int64); ok {
+					for row := 0; row < values.Len(); row++ {
+						if !values.IsNull(row) {
+							d.receivedIDs = append(d.receivedIDs, values.Value(row))
+						}
+					}
+				}
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return d.err
+}
+
+func (*atomicTruncateInsertDestination) SupportsTruncateInsertBoundaries() bool {
+	return true
+}
+
+func (*atomicTruncateInsertDestination) SupportsTruncateInsertStagingColumns() bool {
+	return true
+}
+
+func (*boundaryOnlyAtomicTruncateDestination) SupportsTruncateInsertBoundaries() bool {
+	return true
+}
+
+func TestTruncateInsertStrategy_PrefersAtomicWriter(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.readCh = singleBatchRecords(t, 1, 1, 2)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	if len(atomic.calls) != 1 {
+		t.Fatalf("expected one atomic write, got %d", len(atomic.calls))
+	}
+	if !atomic.calls[0].DeduplicatePrimaryKeys {
+		t.Fatal("atomic truncate+insert did not request primary-key deduplication")
+	}
+	require.Len(t, base.prepareCalls, 1)
+	require.True(t, base.prepareCalls[0].PreserveExistingLayout)
+	if len(base.truncateCalls) != 0 || len(base.mergeCalls) != 0 {
+		t.Fatalf("atomic path must not truncate or merge separately: truncate=%v merge=%v", base.truncateCalls, base.mergeCalls)
+	}
+}
+
+func TestTruncateInsertStrategy_AtomicWriterForwardsCDCSlotSuffixes(t *testing.T) {
+	job, src, base := minimalJob()
+	job.Destination = &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.CDCSlotSuffix = "current-destination-slot"
+	job.Config.CDCLegacySlotSuffix = "legacy-destination-slot"
+	job.Schema.Columns = append(
+		job.Schema.Columns,
+		schema.Column{Name: destination.CDCLSNColumn, DataType: schema.TypeString},
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		schema.Column{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+	)
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.Equal(t, job.Config.CDCSlotSuffix, src.readOpts.CDCSlotSuffix)
+	require.Equal(t, job.Config.CDCLegacySlotSuffix, src.readOpts.CDCLegacySlotSuffix)
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+}
+
+func TestTruncateInsertStrategy_AtomicWriterDiscardsRowsBeforeCDCTruncateBoundary(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.Schema.Columns = append(
+		job.Schema.Columns,
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+	)
+	job.SourceSchema = job.Schema
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{Truncate: true, CDCWALTruncate: true},
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+	)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	require.Equal(t, []int64{2}, atomic.receivedIDs)
+}
+
+func TestTruncateInsertStrategy_RejectsAtomicCDCWriterWithoutBoundarySupport(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Destination = &immediateFailAtomicTruncateDestination{fakeDestination: base}
+	job.Schema.Columns = append(
+		job.Schema.Columns,
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+	)
+
+	err := (&TruncateInsertStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "cannot preserve CDC truncate boundaries")
+	require.Empty(t, base.prepareCalls)
+}
+
+func TestTruncateInsertStrategy_AtomicWriterSeparatesStagingAndTargetSchemas(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.Schema.Columns = append(
+		job.Schema.Columns,
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		schema.Column{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true},
+	)
+	job.SourceSchema = job.Schema
+	name := "value"
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: cdcRenameRecordBatch(t, "name", &name, `["name"]`),
+	})
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.Len(t, atomic.calls, 1)
+	require.Contains(t, atomic.calls[0].Schema.ColumnNames(), destination.CDCUnchangedColsColumn)
+	require.NotContains(t, atomic.calls[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+	require.Len(t, atomic.receivedColumns, 1)
+	require.Contains(t, atomic.receivedColumns[0], destination.CDCUnchangedColsColumn)
+}
+
+func TestTruncateInsertStrategy_RejectsAtomicWriterWithoutStagingColumnSupport(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Destination = &boundaryOnlyAtomicTruncateDestination{
+		immediateFailAtomicTruncateDestination: &immediateFailAtomicTruncateDestination{fakeDestination: base},
+	}
+	job.Schema.Columns = append(
+		job.Schema.Columns,
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		schema.Column{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true},
+	)
+
+	err := (&TruncateInsertStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "cannot keep staging-only CDC columns out of the target")
+	require.Empty(t, base.prepareCalls)
+}
+
+func TestTruncateInsertStrategy_AtomicLeaseLossAfterReadSkipsPublication(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	src.readCh = mustClosedRecords()
+	lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease connection lost")}
+	job.Table = &leaseLosingReadSource{fakeSourceTable: src, lease: lease}
+
+	err := (&TruncateInsertStrategy{}).Execute(guardedStreamingContext(lease), job)
+	require.ErrorIs(t, err, source.ErrConnectorLeaseLost)
+	require.True(t, src.readCalled)
+	require.Empty(t, atomic.calls)
+}
+
+// Atomic writers without AtomicTruncateInsertSchemaEvolver still rely on the
+// strategy to apply the pending evolution plan before writing.
+func TestTruncateInsertStrategy_AtomicWriterAppliesEvolution(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	base.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: job.Schema}
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable,
+		Comparison: &schemaevolution.SchemaComparison{
+			HasChanges: true,
+			Changes: []schemaevolution.SchemaChange{{
+				Type:       schemaevolution.ChangeAddColumn,
+				ColumnName: "new_column",
+			}},
+		},
+	}
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Len(t, base.execCalls, 1)
+	require.Contains(t, base.execCalls[0].sql, "ADD COLUMN new_column")
+	require.Nil(t, job.EvolutionPlan.Comparison, "the evolution plan must be applied before the atomic write")
+}
+
+func TestTruncateInsertStrategy_AtomicSchemaEvolverOwnsEvolution(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicSchemaEvolvingTruncateDestination{
+		atomicTruncateInsertDestination: &atomicTruncateInsertDestination{fakeDestination: base},
+	}
+	job.Destination = atomic
+	base.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: job.Schema}
+	comparison := &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeAddColumn, ColumnName: "new_column",
+		}},
+	}
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{Table: job.Config.DestTable, Comparison: comparison}
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Empty(t, base.execCalls)
+	require.Same(t, comparison, job.EvolutionPlan.Comparison)
+	require.Len(t, atomic.calls, 1)
+}
+
+func TestTruncateInsertStrategy_AtomicSchemaEvolverSoftensRemovedRequiredColumn(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicSchemaEvolvingTruncateDestination{
+		atomicTruncateInsertDestination: &atomicTruncateInsertDestination{fakeDestination: base},
+	}
+	job.Destination = atomic
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "legacy", DataType: schema.TypeString, Nullable: false},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRemoveColumn, ColumnName: "legacy",
+		OldColumn: &destinationSchema.Columns[1],
+	}}}
+	job.Schema = schemaevolution.BuildFinalSchema(destinationSchema, comparison)
+	job.SourceSchema = &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable, Comparison: comparison, FinalSchema: job.Schema,
+	}
+	base.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: destinationSchema}
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Len(t, atomic.calls, 1)
+	require.Len(t, atomic.calls[0].Schema.Columns, 2)
+	require.Equal(t, "legacy", atomic.calls[0].Schema.Columns[1].Name)
+	require.True(t, atomic.calls[0].Schema.Columns[1].Nullable)
+}
+
+func TestTruncateInsertStrategy_AtomicWriterSkipsMissingOrderingKey(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.IncrementalKey = "missing_ordering_column"
+	src.readCh = singleBatchRecords(t, 1, 1, 2)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Len(t, atomic.calls, 1)
+	require.Empty(t, atomic.calls[0].IncrementalKey)
+}
+
+func TestTruncateInsertStrategy_AtomicFailurePreservesNewTargetForOutcomeReconciliation(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{
+		fakeDestination: base,
+		err:             errors.New("atomic commit failed"),
+	}
+	job.Destination = atomic
+	src.readCh = mustClosedRecords()
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected atomic truncate+insert to fail")
+	}
+	require.Empty(t, base.dropCalls, "atomic write errors may be lost success responses and must preserve the target")
+}
+
+func TestTruncateInsertStrategy_AtomicFailureDoesNotAttemptCleanupAfterPossibleCommit(t *testing.T) {
+	job, src, base := minimalJob()
+	dest := &ownedAtomicTruncateDestination{atomicTruncateInsertDestination: &atomicTruncateInsertDestination{
+		fakeDestination: base,
+		err:             errors.New("atomic commit failed after replacement"),
+	}}
+	job.Destination = dest
+	src.readCh = mustClosedRecords()
+
+	require.Error(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "conditional ownership is insufficient after a possibly successful commit")
+	require.Empty(t, base.dropCalls, "unconditional cleanup must not delete a replacement owner")
+}
+
+func TestTruncateInsertStrategy_LostPrepareResponseCleansOwnedTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		make   func(*fakeDestination) destination.Destination
+		assert func(*testing.T, destination.Destination)
+	}{
+		{
+			name: "atomic",
+			make: func(base *fakeDestination) destination.Destination {
+				return &ownedAtomicTruncateDestination{atomicTruncateInsertDestination: &atomicTruncateInsertDestination{fakeDestination: base}}
+			},
+			assert: func(t *testing.T, raw destination.Destination) {
+				dest := raw.(*ownedAtomicTruncateDestination)
+				require.NotEmpty(t, dest.preparedToken)
+				require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			},
+		},
+		{
+			name: "direct",
+			make: func(base *fakeDestination) destination.Destination {
+				return &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+			},
+			assert: func(t *testing.T, raw destination.Destination) {
+				dest := raw.(*ownedTruncateDestination)
+				require.NotEmpty(t, dest.preparedToken)
+				require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			},
+		},
+		{
+			name: "staged",
+			make: func(base *fakeDestination) destination.Destination {
+				return &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+			},
+			assert: func(t *testing.T, raw destination.Destination) {
+				dest := raw.(*ownedTruncateDestination)
+				require.NotEmpty(t, dest.preparedToken)
+				require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job, src, base := minimalJob()
+			base.prepareHook = func(destination.PrepareOptions) error { return errors.New("prepare response lost after create") }
+			if tc.name == "direct" {
+				job.Config.PrimaryKeys = nil
+				job.Schema.PrimaryKeys = nil
+				src.primaryKeys = nil
+			}
+			raw := tc.make(base)
+			job.Destination = raw
+
+			require.ErrorContains(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job), "prepare response lost")
+			tc.assert(t, raw)
+			require.Empty(t, base.dropCalls)
+		})
+	}
+}
+
+func TestTruncateInsertStrategy_AtomicWriterFailureBoundsNonclosingSource(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailAtomicTruncateDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil || time.Since(started) > time.Second {
+		t.Fatalf("truncate+insert did not return promptly after writer failure: %v", err)
+	}
+	close(records)
+}
 
 func TestTruncateInsertStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
 	job, src, dest := minimalJob()
@@ -64,6 +955,7 @@ func TestTruncateInsertStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema
 	job.Destination = &truncateCapableDestination{fakeDestination: dest}
 	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
 	job.Config.IncrementalKey = "updated_at"
+	job.Schema.Columns = append(job.Schema.Columns, schema.Column{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true})
 	src.readCh = mustClosedRecords()
 
 	strat := &TruncateInsertStrategy{}
@@ -77,6 +969,7 @@ func TestTruncateInsertStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema
 	if dest.mergeCalls[0].IncrementalKey != "" {
 		t.Fatalf("MergeOptions.IncrementalKey = %q, want empty for missing staging column", dest.mergeCalls[0].IncrementalKey)
 	}
+	require.NotContains(t, dest.mergeCalls[0].Columns, "_cdc_unchanged_cols")
 }
 
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {
@@ -100,4 +993,126 @@ func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t
 	if len(dest.writeCalls) != 0 {
 		t.Fatalf("expected no write when source read setup fails, got %d", len(dest.writeCalls))
 	}
+	require.Equal(t, []string{dest.prepareCalls[1].Table}, dest.dropCalls)
+}
+
+func TestTruncateInsertStrategy_DirectReadSetupFailurePreservesConcurrentUnownedTarget(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readErr = errors.New("read setup failed")
+	dest.prepareHook = func(opts destination.PrepareOptions) error {
+		if opts.Table == job.Config.DestTable {
+			dest.tableSchemas = map[string]*schema.TableSchema{opts.Table: job.Schema}
+		}
+		return nil
+	}
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected read setup failure")
+	}
+	if len(dest.truncateCalls) != 0 {
+		t.Fatalf("target was truncated before source setup succeeded: %v", dest.truncateCalls)
+	}
+	require.NotNil(t, dest.tableSchemas[job.Config.DestTable])
+	require.Empty(t, dest.dropCalls, "an unowned target may have been created by another writer")
+}
+
+func TestTruncateInsertStrategy_StagingFailureDropsManagedTable(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("write failed")
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable,
+		Comparison: &schemaevolution.SchemaComparison{
+			HasChanges: true,
+			Changes: []schemaevolution.SchemaChange{{
+				Type: schemaevolution.ChangeAddColumn, ColumnName: "must_not_be_added",
+			}},
+		},
+	}
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	staging := dest.prepareCalls[1].Table
+	require.Equal(t, []string{staging}, dest.dropCalls)
+	require.Empty(t, dest.execCalls, "target schema must not evolve before staging succeeds")
+}
+
+func TestTruncateInsertStrategy_DirectTruncateFailurePreservesNewTarget(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+	dest.truncateErr = errors.New("truncate failed")
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	require.Empty(t, dest.dropCalls, "truncate errors may be lost responses after a durable truncate")
+}
+
+func TestTruncateInsertStrategy_DirectFailurePreservesReplacementOwner(t *testing.T) {
+	job, src, base := minimalJob()
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+	base.writeErr = errors.New("write failed after replacement")
+	dest := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.Error(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "write errors may follow durable truncate/insert work")
+	require.Empty(t, base.dropCalls, "unconditional cleanup must not delete a replacement owner")
+}
+
+func TestTruncateInsertStrategy_StagedMergeFailurePreservesTargetAndDropsStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	src.readCh = mustClosedRecords()
+	dest.mergeErr = errors.New("merge failed")
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	require.NotContains(t, dest.dropCalls, job.Config.DestTable)
+	require.Equal(t, []string{dest.prepareCalls[1].Table}, dest.dropCalls)
+}
+
+func TestTruncateInsertStrategy_StagedTruncateLostResponsePreservesTargetAndDropsStaging(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	base.truncateErr = errors.New("truncate response lost after commit")
+	dest := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.ErrorContains(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job), "truncate response lost")
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens)
+	require.NotContains(t, base.dropCalls, job.Config.DestTable)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, base.dropCalls)
+}
+
+func TestTruncateInsertStrategy_StagedFailurePreservesReplacementOwner(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	base.mergeErr = errors.New("merge failed after replacement")
+	dest := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.Error(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "merge errors may follow a durable target mutation")
+	require.NotContains(t, base.dropCalls, job.Config.DestTable)
+	require.Contains(t, base.dropCalls, base.prepareCalls[1].Table, "owned staging table should still be reclaimed")
 }

--- a/tests/integration/cdc_conditional_truncate_test.go
+++ b/tests/integration/cdc_conditional_truncate_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination/mssql"
+	"github.com/bruin-data/ingestr/pkg/destination/mysql"
+	"github.com/bruin-data/ingestr/pkg/destination/oracle"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMSSQLConditionalCDCTruncateFencesRecreatedTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mssqlDest.uri == "" {
+		t.Skip("shared SQL Server destination container not available")
+	}
+
+	ctx := context.Background()
+	table := "cdc_fence_" + uniqueSuffix()
+	qualifiedTable := "[dbo].[" + table + "]"
+	db := openMSSQLTestDB(t, mssqlDest.uri)
+	defer func() { _ = db.Close() }()
+	defer func() { _, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS "+qualifiedTable) }()
+	_, err := db.ExecContext(ctx, "CREATE TABLE "+qualifiedTable+" ([id] BIGINT NOT NULL); INSERT INTO "+qualifiedTable+" VALUES (1), (2)")
+	require.NoError(t, err)
+
+	dest := mssql.NewMSSQLDestination()
+	require.NoError(t, dest.Connect(ctx, mssqlDest.uri))
+	defer func() { _ = dest.Close(ctx) }()
+	expected, exists, err := dest.CDCTargetIncarnation(ctx, "dbo."+table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.TruncateCDCTableIfIncarnation(ctx, "dbo."+table, expected))
+	requireTableRowCount(t, db, qualifiedTable, 0)
+	stable, exists, err := dest.CDCTargetIncarnation(ctx, "dbo."+table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, expected, stable)
+
+	_, err = db.ExecContext(ctx, "DROP TABLE "+qualifiedTable+"; CREATE TABLE "+qualifiedTable+" ([id] BIGINT NOT NULL); INSERT INTO "+qualifiedTable+" VALUES (99)")
+	require.NoError(t, err)
+	err = dest.TruncateCDCTableIfIncarnation(ctx, "dbo."+table, expected)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	requireTableRowCount(t, db, qualifiedTable, 1)
+}
+
+func TestMySQLConditionalCDCTruncateFencesRecreatedTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if mysqlDest.uri == "" {
+		t.Skip("shared MySQL destination container not available")
+	}
+
+	ctx := context.Background()
+	table := "cdc_fence_" + uniqueSuffix()
+	quotedTable := "`" + table + "`"
+	db, err := sql.Open("mysql", mysqlDSN(mysqlDest.uri))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	defer func() { _, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS "+quotedTable) }()
+	_, err = db.ExecContext(ctx, "CREATE TABLE "+quotedTable+" (`id` BIGINT NOT NULL) ENGINE=InnoDB")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO "+quotedTable+" VALUES (1), (2)")
+	require.NoError(t, err)
+
+	dest := mysql.NewMySQLDestination()
+	require.NoError(t, dest.Connect(ctx, mysqlDest.uri))
+	defer func() { _ = dest.Close(ctx) }()
+	expected, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.TruncateCDCTableIfIncarnation(ctx, table, expected))
+	requireTableRowCount(t, db, quotedTable, 0)
+	stable, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, expected, stable)
+
+	_, err = db.ExecContext(ctx, "DROP TABLE "+quotedTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CREATE TABLE "+quotedTable+" (`id` BIGINT NOT NULL) ENGINE=InnoDB")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO "+quotedTable+" VALUES (99)")
+	require.NoError(t, err)
+	err = dest.TruncateCDCTableIfIncarnation(ctx, table, expected)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	requireTableRowCount(t, db, quotedTable, 1)
+}
+
+func TestOracleConditionalCDCTruncateFencesRecreatedTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if oracleDest.uri == "" {
+		t.Skip("shared Oracle destination container not available")
+	}
+
+	ctx := context.Background()
+	table := "cdc_fence_" + uniqueSuffix()
+	db, err := sql.Open("oracle", oracleSQLConnString(oracleDest.uri))
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
+	defer func() { _ = db.Close() }()
+	defer func() { _, _ = db.ExecContext(ctx, "DROP TABLE "+table+" PURGE") }()
+	_, err = db.ExecContext(ctx, "CREATE TABLE "+table+" (id NUMBER(19) NOT NULL)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO "+table+" VALUES (1)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO "+table+" VALUES (2)")
+	require.NoError(t, err)
+
+	dest := oracle.NewOracleDestination()
+	require.NoError(t, dest.Connect(ctx, oracleDest.uri))
+	defer func() { _ = dest.Close(ctx) }()
+	expected, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.TruncateCDCTableIfIncarnation(ctx, table, expected))
+	requireTableRowCount(t, db, table, 0)
+	stable, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, expected, stable)
+
+	_, err = db.ExecContext(ctx, "DROP TABLE "+table+" PURGE")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CREATE TABLE "+table+" (id NUMBER(19) NOT NULL)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO "+table+" VALUES (99)")
+	require.NoError(t, err)
+	err = dest.TruncateCDCTableIfIncarnation(ctx, table, expected)
+	require.ErrorContains(t, err, "physical incarnation changed")
+	requireTableRowCount(t, db, table, 1)
+}
+
+func requireTableRowCount(t *testing.T, db *sql.DB, table string, want int) {
+	t.Helper()
+	var got int
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&got))
+	require.Equal(t, want, got)
+}

--- a/tests/integration/postgres_cdc_keepalive_test.go
+++ b/tests/integration/postgres_cdc_keepalive_test.go
@@ -6,44 +6,43 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/registry"
 	"github.com/bruin-data/ingestr/pkg/destination"
-	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
+	pgdestination "github.com/bruin-data/ingestr/pkg/destination/postgres"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-// slowDuckDBDestination wraps a real DuckDB destination and sleeps for a
+// slowPostgresDestination wraps a real PostgreSQL destination and sleeps for a
 // configurable duration before each Write / WriteParallel. It exists only to
 // drive the destination-write phase of a CDC batch run past the source's
 // wal_sender_timeout so the keepalive goroutine in postgres_cdc.Source can be
 // regression-tested.
-type slowDuckDBDestination struct {
-	*duckdb.DuckDBDestination
+type slowPostgresDestination struct {
+	*pgdestination.PostgresDestination
 	writeDelay time.Duration
 }
 
-func newSlowDuckDB() *slowDuckDBDestination {
-	return &slowDuckDBDestination{DuckDBDestination: duckdb.NewDuckDBDestination()}
+func newSlowPostgres() *slowPostgresDestination {
+	return &slowPostgresDestination{PostgresDestination: pgdestination.NewPostgresDestination()}
 }
 
-func (s *slowDuckDBDestination) Schemes() []string { return []string{"slowduckdb"} }
+func (s *slowPostgresDestination) Schemes() []string { return []string{"slowpostgres"} }
 
-func (s *slowDuckDBDestination) GetScheme() string { return "duckdb" }
+func (s *slowPostgresDestination) GetScheme() string { return "postgres" }
 
 // Connect parses our scheme's `delay` query param, then forwards to the
-// embedded DuckDB destination with a rewritten `duckdb://` URI.
-func (s *slowDuckDBDestination) Connect(ctx context.Context, uri string) error {
+// embedded PostgreSQL destination with a rewritten `postgres://` URI.
+func (s *slowPostgresDestination) Connect(ctx context.Context, uri string) error {
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return fmt.Errorf("invalid slowduckdb URI: %w", err)
+		return fmt.Errorf("invalid slowpostgres URI: %w", err)
 	}
 	q := parsed.Query()
 	if raw := q.Get("delay"); raw != "" {
@@ -54,26 +53,26 @@ func (s *slowDuckDBDestination) Connect(ctx context.Context, uri string) error {
 		s.writeDelay = d
 		q.Del("delay")
 	}
-	parsed.Scheme = "duckdb"
+	parsed.Scheme = "postgres"
 	parsed.RawQuery = q.Encode()
-	return s.DuckDBDestination.Connect(ctx, parsed.String())
+	return s.PostgresDestination.Connect(ctx, parsed.String())
 }
 
-func (s *slowDuckDBDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+func (s *slowPostgresDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	if err := s.sleep(ctx); err != nil {
 		return err
 	}
-	return s.DuckDBDestination.Write(ctx, records, opts)
+	return s.PostgresDestination.Write(ctx, records, opts)
 }
 
-func (s *slowDuckDBDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+func (s *slowPostgresDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	if err := s.sleep(ctx); err != nil {
 		return err
 	}
-	return s.DuckDBDestination.WriteParallel(ctx, records, opts)
+	return s.PostgresDestination.WriteParallel(ctx, records, opts)
 }
 
-func (s *slowDuckDBDestination) sleep(ctx context.Context) error {
+func (s *slowPostgresDestination) sleep(ctx context.Context) error {
 	if s.writeDelay <= 0 {
 		return nil
 	}
@@ -86,7 +85,7 @@ func (s *slowDuckDBDestination) sleep(ctx context.Context) error {
 }
 
 func init() {
-	registry.Default.RegisterDestination([]string{"slowduckdb"}, func() interface{} { return newSlowDuckDB() })
+	registry.Default.RegisterDestination([]string{"slowpostgres"}, func() interface{} { return newSlowPostgres() })
 }
 
 // setupPostgresCDCContainerWithTimeout is a variant of setupPostgresCDCContainer
@@ -138,7 +137,7 @@ func setupPostgresCDCContainerWithTimeout(t *testing.T, ctx context.Context, wal
 // grows across "successful" runs.
 //
 // This test forces that scenario deterministically: wal_sender_timeout=8s on
-// the source, and slowduckdb with delay=10s on the destination. The
+// the source, and slowpostgres with delay=10s on the destination. The
 // destination phase outlasts the source's timeout; without the keepalive
 // goroutine, assertBatchRunsAdvanceSlot fails on the first resume run
 // because confirmed_flush_lsn stays frozen at the snapshot LSN. The timeout
@@ -150,24 +149,36 @@ func TestPostgresCDC_BatchRunAdvancesSlotWithSlowWrites(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	if pgDest.uri == "" {
+		t.Skip("shared PostgreSQL destination container not available")
+	}
 
 	sourceContainer, sourceConnString := setupPostgresCDCContainerWithTimeout(t, ctx, "8s")
 	defer func() { _ = sourceContainer.Terminate(ctx) }()
 	setupCDCSource(t, ctx, sourceConnString)
 
-	tmpDir, err := os.MkdirTemp("", "cdc_slot_keepalive_*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	destSchema := uniqueSchemaName(t, "cdc_slot_keepalive")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
 
-	// slowduckdb adds a 10s sleep before each Write/WriteParallel call,
+	parsedDestURI, err := url.Parse(pgDest.uri)
+	require.NoError(t, err)
+	parsedDestURI.Scheme = "slowpostgres"
+	query := parsedDestURI.Query()
+	query.Set("delay", "10s")
+	parsedDestURI.RawQuery = query.Encode()
+
+	// slowpostgres adds a 10s sleep before each Write/WriteParallel call,
 	// pushing the destination phase past the 8s wal_sender_timeout above.
-	destURI := fmt.Sprintf("slowduckdb:///%s/test.duckdb?delay=10s", tmpDir)
 	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub&mode=batch"
 
 	assertBatchRunsAdvanceSlot(t, ctx, sourceConnString, func() *config.IngestConfig {
 		return &config.IngestConfig{
 			SourceURI:           cdcSourceURI,
-			DestURI:             destURI,
+			DestURI:             parsedDestURI.String(),
+			SourceTable:         "public.test_cdc",
+			DestTable:           destSchema + ".test_cdc_dest",
+			PrimaryKeys:         []string{"id"},
 			IncrementalStrategy: "merge",
 		}
 	})

--- a/tests/integration/postgres_cdc_new_table_test.go
+++ b/tests/integration/postgres_cdc_new_table_test.go
@@ -29,7 +29,7 @@ func setupNewTableDest(t *testing.T, ctx context.Context) (string, *pgxpool.Pool
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -558,7 +558,7 @@ func TestPostgresCDC_Snapshot(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -682,7 +682,7 @@ func TestPostgresCDC_IncrementalResume(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -817,7 +817,7 @@ func TestPostgresCDC_DestinationStateTruncateAndSnapshotRecovery(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -938,7 +938,7 @@ func TestPostgresCDC_LegacyAutoSlotCutoverRequiresSuccessfulDurability(t *testin
 		postgres.WithDatabase("destdb"),
 		postgres.WithUsername("destuser"),
 		postgres.WithPassword("destpass"),
-		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(30*time.Second)),
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
 	)
 	require.NoError(t, err)
 	defer func() { _ = destContainer.Terminate(ctx) }()
@@ -997,7 +997,7 @@ func TestPostgresCDC_LegacyAutoSlotCutoverRequiresSuccessfulDurability(t *testin
 	require.Positive(t, completedState, "legacy slot must only be removed after v2 state is durable")
 }
 
-func TestPostgresCDC_SharedStateMySQL(t *testing.T) {
+func TestPostgresCDC_RejectsUnfencedMySQLDestination(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1020,35 +1020,17 @@ func TestPostgresCDC_SharedStateMySQL(t *testing.T) {
 		PrimaryKeys:         []string{"id"},
 		IncrementalStrategy: config.StrategyMerge,
 	}
-	require.NoError(t, pipeline.New(cfg).Run(ctx))
-
-	sourcePool, err := pgxpool.New(ctx, sourceConnString)
-	require.NoError(t, err)
-	defer sourcePool.Close()
-	_, err = sourcePool.Exec(ctx, `DELETE FROM public.test_cdc WHERE id = 1; INSERT INTO public.test_cdc (name, value) VALUES ('mysql-state', 901)`)
-	require.NoError(t, err)
-	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	err := pipeline.New(cfg).Run(ctx)
+	require.ErrorContains(t, err, "atomic destination write, merge, and swap fencing is not supported")
 
 	db, err := sql.Open("mysql", mysqlDSN(mysqlDest.uri))
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
-	defer func() { _, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS `"+target+"`") }()
-
-	var stateTables int
+	var targetTables int
 	require.NoError(t, db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM information_schema.tables
-		WHERE table_schema = '_bruin_staging' AND table_name = 'cdc_state'`).Scan(&stateTables))
-	assert.Equal(t, 1, stateTables)
-	var generation int64
-	require.NoError(t, db.QueryRowContext(ctx, `
-		SELECT MAX(state_generation) FROM _bruin_staging.cdc_state
-		WHERE destination_table = ? AND state_kind = 'snapshot' AND state_status = 'complete'`, target).Scan(&generation))
-	assert.Equal(t, int64(2), generation)
-	var activeRows, deletedRows int
-	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM `"+target+"` WHERE `_cdc_deleted` = 0").Scan(&activeRows))
-	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM `"+target+"` WHERE `_cdc_deleted` = 1").Scan(&deletedRows))
-	assert.Equal(t, 3, activeRows)
-	assert.Equal(t, 1, deletedRows)
+		WHERE table_schema = DATABASE() AND table_name = ?`, target).Scan(&targetTables))
+	require.Zero(t, targetTables, "admission failure must happen before creating the CDC target")
 }
 
 func postgresCDCStateTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) []string {
@@ -1094,7 +1076,7 @@ func TestPostgresCDC_DuplicatePKWithinBatch(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -1212,7 +1194,7 @@ func TestPostgresCDC_MergePreservesUnchangedJSONB(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -1321,7 +1303,7 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -1456,7 +1438,7 @@ func TestPostgresCDC_IntraBatchChangedThenUnchangedOverwritesExistingRow(t *test
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -1548,7 +1530,7 @@ func TestPostgresCDC_BatchModeCompletesWithActiveWrites(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -1663,20 +1645,16 @@ func TestPostgresCDC_BatchModeCompletesWithActiveWrites(t *testing.T) {
 	t.Logf("Final row count: %d (initial: %d, background writes: %d)", finalCount, initialCount, writtenCount)
 }
 
-func TestPostgresCDC_IncrementalResume_DuckDB(t *testing.T) {
+func TestPostgresCDC_RejectsUnfencedDuckDBDestination(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 
 	ctx := context.Background()
-
-	// Setup source PostgreSQL with logical replication
 	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
 	defer func() { _ = sourceContainer.Terminate(ctx) }()
-
 	setupCDCSource(t, ctx, sourceConnString)
 
-	// Create temp path for DuckDB destination (don't create the file - DuckDB will create it)
 	tmpDir, err := os.MkdirTemp("", "cdc_test_*")
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
@@ -1684,8 +1662,6 @@ func TestPostgresCDC_IncrementalResume_DuckDB(t *testing.T) {
 	duckdbPath := fmt.Sprintf("%s/test.duckdb", tmpDir)
 	duckdbURI := fmt.Sprintf("duckdb:///%s", duckdbPath)
 	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub&mode=batch"
-
-	// Run the first CDC pipeline (full snapshot)
 	cfg := &config.IngestConfig{
 		SourceURI:           cdcSourceURI,
 		DestURI:             duckdbURI,
@@ -1695,79 +1671,15 @@ func TestPostgresCDC_IncrementalResume_DuckDB(t *testing.T) {
 		IncrementalStrategy: "merge",
 	}
 
-	p := pipeline.New(cfg)
-	err = p.Run(ctx)
+	err = pipeline.New(cfg).Run(ctx)
+	require.ErrorContains(t, err, "atomic destination write, merge, and swap fencing is not supported")
+
+	db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", duckdbPath))
 	require.NoError(t, err)
-
-	// Query DuckDB to verify initial data
-	verifyDuckDB := func(query string) (interface{}, error) {
-		db, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", duckdbPath))
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = db.Close() }()
-
-		var result interface{}
-		err = db.QueryRow(query).Scan(&result)
-		return result, err
-	}
-
-	// Verify initial count
-	count, err := verifyDuckDB("SELECT COUNT(*) FROM test_cdc_dest")
-	require.NoError(t, err)
-	assert.Equal(t, int64(3), count, "Should have 3 rows from initial snapshot")
-
-	// Get max LSN from first run
-	firstMaxLSN, err := verifyDuckDB(`SELECT MAX("_cdc_lsn") FROM test_cdc_dest`)
-	require.NoError(t, err)
-	assert.NotNil(t, firstMaxLSN, "Should have a max LSN after first run")
-	t.Logf("First run max LSN: %v", firstMaxLSN)
-
-	// Make changes to source
-	sourcePool, err := pgxpool.New(ctx, sourceConnString)
-	require.NoError(t, err)
-	defer sourcePool.Close()
-
-	_, err = sourcePool.Exec(ctx, `INSERT INTO public.test_cdc (name, value) VALUES ('item4', 400)`)
-	require.NoError(t, err)
-
-	_, err = sourcePool.Exec(ctx, `UPDATE public.test_cdc SET value = 150 WHERE id = 1`)
-	require.NoError(t, err)
-
-	// Run the second CDC pipeline (should resume from LSN)
-	cfg2 := &config.IngestConfig{
-		SourceURI:           cdcSourceURI,
-		DestURI:             duckdbURI,
-		SourceTable:         "public.test_cdc",
-		DestTable:           "test_cdc_dest",
-		PrimaryKeys:         []string{"id"},
-		IncrementalStrategy: "merge",
-	}
-
-	p2 := pipeline.New(cfg2)
-	err = p2.Run(ctx)
-	require.NoError(t, err)
-
-	// Verify incremental changes were captured
-	count, err = verifyDuckDB("SELECT COUNT(*) FROM test_cdc_dest")
-	require.NoError(t, err)
-	assert.Equal(t, int64(4), count, "Should have 4 rows after incremental sync")
-
-	// Verify new record (use EqualValues for type-agnostic comparison)
-	item4Value, err := verifyDuckDB(`SELECT value FROM test_cdc_dest WHERE name = 'item4'`)
-	require.NoError(t, err)
-	assert.EqualValues(t, 400, item4Value, "item4 should have value 400")
-
-	// Verify update
-	item1Value, err := verifyDuckDB(`SELECT value FROM test_cdc_dest WHERE id = 1`)
-	require.NoError(t, err)
-	assert.EqualValues(t, 150, item1Value, "item1 should be updated to value 150")
-
-	// Verify LSN advanced
-	secondMaxLSN, err := verifyDuckDB(`SELECT MAX("_cdc_lsn") FROM test_cdc_dest`)
-	require.NoError(t, err)
-	assert.NotEqual(t, firstMaxLSN, secondMaxLSN, "LSN should have advanced after incremental sync")
-	t.Logf("Second run max LSN: %v", secondMaxLSN)
+	defer func() { _ = db.Close() }()
+	var targetTables int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'test_cdc_dest'`).Scan(&targetTables))
+	require.Zero(t, targetTables, "admission failure must happen before creating the CDC target")
 }
 
 // TestPostgresCDC_MultiTable_SchemaEvolution reproduces issue #766: a column
@@ -1949,12 +1861,7 @@ func TestPostgresCDC_MultiTableTrimWhitespace(t *testing.T) {
 	assert.False(t, rows[1].note.Valid)
 }
 
-// TestPostgresCDC_UnawareDestination_SQLite pins the contract that the
-// staging-only _cdc_unchanged_cols column never reaches the merge SQL of
-// destinations that don't consume it. A TOAST-sized payload forces the
-// decoder to emit unchanged markers; without column filtering the SQLite
-// merge would reference a column the target table doesn't have.
-func TestPostgresCDC_UnawareDestination_SQLite(t *testing.T) {
+func TestPostgresCDC_RejectsUnfencedSQLiteDestination(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1997,30 +1904,16 @@ func TestPostgresCDC_UnawareDestination_SQLite(t *testing.T) {
 		PrimaryKeys:         []string{"id"},
 		IncrementalStrategy: "merge",
 	}
-	require.NoError(t, pipeline.New(cfg).Run(ctx))
-
-	// Partial update: config_data stays TOASTed-unchanged, so the change row
-	// carries an unchanged marker for it.
-	_, err = srcPool.Exec(ctx, `UPDATE public.toast_items SET status = 'completed' WHERE id = 1`)
-	require.NoError(t, err)
-
-	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	err = pipeline.New(cfg).Run(ctx)
+	require.ErrorContains(t, err, "atomic destination write, merge, and swap fencing is not supported")
 
 	dest, err := sql.Open("sqlite3", sqlitePath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = dest.Close() })
 
-	var status string
-	require.NoError(t, dest.QueryRow(`SELECT status FROM toast_items_dest WHERE id = 1`).Scan(&status))
-	assert.Equal(t, "completed", status, "changed column must be applied")
-
-	var count int
-	require.NoError(t, dest.QueryRow(`SELECT COUNT(*) FROM toast_items_dest`).Scan(&count))
-	assert.Equal(t, 1, count)
-
-	// The staging-only column must not exist on the destination table.
-	require.NoError(t, dest.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('toast_items_dest') WHERE name = '_cdc_unchanged_cols'`).Scan(&count))
-	assert.Equal(t, 0, count, "_cdc_unchanged_cols must stay staging-only")
+	var targetTables int
+	require.NoError(t, dest.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'toast_items_dest'`).Scan(&targetTables))
+	require.Zero(t, targetTables, "admission failure must happen before creating the CDC target")
 }
 
 func cdcReplicationSlotName(tableName, publication, suffix string) string {
@@ -2105,6 +1998,9 @@ func TestPostgresCDC_BatchRunAdvancesReplicationSlot(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	if pgDest.uri == "" {
+		t.Skip("shared PostgreSQL destination container not available")
+	}
 
 	ctx := context.Background()
 
@@ -2112,17 +2008,17 @@ func TestPostgresCDC_BatchRunAdvancesReplicationSlot(t *testing.T) {
 	defer func() { _ = sourceContainer.Terminate(ctx) }()
 	setupCDCSource(t, ctx, sourceConnString)
 
-	tmpDir, err := os.MkdirTemp("", "cdc_slot_mt_*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-	duckdbURI := fmt.Sprintf("duckdb:///%s/test.duckdb", tmpDir)
+	destSchema := uniqueSchemaName(t, "cdc_slot_mt")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
 
 	// Full-database CDC: no SourceTable -> multi-table path.
-	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub&mode=batch"
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+		"&publication=test_pub&mode=batch&dest_schema=" + destSchema
 	assertBatchRunsAdvanceSlot(t, ctx, sourceConnString, func() *config.IngestConfig {
 		return &config.IngestConfig{
 			SourceURI:           cdcSourceURI,
-			DestURI:             duckdbURI,
+			DestURI:             pgDest.uri,
 			IncrementalStrategy: "merge",
 		}
 	})
@@ -2135,6 +2031,9 @@ func TestPostgresCDC_SingleTableBatchRunAdvancesReplicationSlot(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	if pgDest.uri == "" {
+		t.Skip("shared PostgreSQL destination container not available")
+	}
 
 	ctx := context.Background()
 
@@ -2142,18 +2041,17 @@ func TestPostgresCDC_SingleTableBatchRunAdvancesReplicationSlot(t *testing.T) {
 	defer func() { _ = sourceContainer.Terminate(ctx) }()
 	setupCDCSource(t, ctx, sourceConnString)
 
-	tmpDir, err := os.MkdirTemp("", "cdc_slot_st_*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-	duckdbURI := fmt.Sprintf("duckdb:///%s/test.duckdb", tmpDir)
+	destSchema := uniqueSchemaName(t, "cdc_slot_st")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
 
 	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub&mode=batch"
 	assertBatchRunsAdvanceSlot(t, ctx, sourceConnString, func() *config.IngestConfig {
 		return &config.IngestConfig{
 			SourceURI:           cdcSourceURI,
-			DestURI:             duckdbURI,
+			DestURI:             pgDest.uri,
 			SourceTable:         "public.test_cdc",
-			DestTable:           "test_cdc_dest",
+			DestTable:           destSchema + ".test_cdc_dest",
 			PrimaryKeys:         []string{"id"},
 			IncrementalStrategy: "merge",
 		}

--- a/tests/integration/restricted_permissions_test.go
+++ b/tests/integration/restricted_permissions_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	mysqldest "github.com/bruin-data/ingestr/pkg/destination/mysql"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -197,6 +198,25 @@ func TestMySQLDestination_RestrictedPermissions(t *testing.T) {
 		require.NoError(t, adminDB.QueryRowContext(ctx,
 			fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s`", defaultDB, targetTable)).Scan(&count))
 		assert.Equal(t, replaceFixtureRows, count)
+	})
+
+	t.Run("managed_cdc_identity_requires_process_privilege", func(t *testing.T) {
+		target := fmt.Sprintf("%s.%s", defaultDB, targetTable)
+		deniedDest := mysqldest.NewMySQLDestination()
+		require.NoError(t, deniedDest.Connect(ctx, restrictedURI))
+		require.ErrorContains(t, deniedDest.ValidateManagedCDCTarget(ctx, target), "global MySQL PROCESS privilege")
+		require.NoError(t, deniedDest.Close(ctx))
+
+		_, err := adminDB.ExecContext(ctx, fmt.Sprintf("GRANT PROCESS ON *.* TO '%s'@'%%'", user))
+		require.NoError(t, err)
+		dest := mysqldest.NewMySQLDestination()
+		require.NoError(t, dest.Connect(ctx, restrictedURI))
+		defer func() { _ = dest.Close(ctx) }()
+		require.NoError(t, dest.ValidateManagedCDCTarget(ctx, target))
+		incarnation, exists, err := dest.CDCTargetIncarnation(ctx, target)
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.NotEmpty(t, incarnation)
 	})
 }
 

--- a/tests/integration/streaming_cdc_idle_test.go
+++ b/tests/integration/streaming_cdc_idle_test.go
@@ -66,7 +66,7 @@ func TestPostgresCDC_StreamingIdleSlotAdvances(t *testing.T) {
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)

--- a/tests/integration/streaming_cdc_test.go
+++ b/tests/integration/streaming_cdc_test.go
@@ -54,7 +54,7 @@ func TestPostgresCDC_Streaming(t *testing.T) {
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestPostgresCDC_StreamingResume(t *testing.T) {
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)

--- a/tests/integration/streaming_kafka_test.go
+++ b/tests/integration/streaming_kafka_test.go
@@ -55,7 +55,7 @@ func TestKafka_Streaming(t *testing.T) {
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)

--- a/tests/integration/streaming_mssql_cdc_test.go
+++ b/tests/integration/streaming_mssql_cdc_test.go
@@ -40,7 +40,7 @@ func TestMSSQLCDC_Streaming(t *testing.T) {
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)

--- a/tests/integration/streaming_rabbitmq_test.go
+++ b/tests/integration/streaming_rabbitmq_test.go
@@ -45,7 +45,7 @@ func TestRabbitMQ_Streaming(t *testing.T) {
 		postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestRabbitMQ_StreamingShutdownFlushesPending(t *testing.T) {
 		"postgres:16-alpine",
 		postgres.WithDatabase("destdb"), postgres.WithUsername("destuser"), postgres.WithPassword("destpass"),
 		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(30*time.Second),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	require.NoError(t, err)

--- a/tests/integration/vitess_cdc_batch_test.go
+++ b/tests/integration/vitess_cdc_batch_test.go
@@ -68,7 +68,7 @@ func startVitessCDCEnv(t *testing.T, ctx context.Context, numShards string) *vit
 	// vtgate can accept connections before it can serve queries; retry.
 	require.Eventually(t, func() bool {
 		return db.PingContext(ctx) == nil
-	}, 120*time.Second, 2*time.Second, "vtgate did not become query-ready")
+	}, vitessQueryReadyTimeout, 2*time.Second, "vtgate did not become query-ready")
 
 	return &vitessCDCEnv{
 		db:        db,

--- a/tests/integration/vitess_cdc_test.go
+++ b/tests/integration/vitess_cdc_test.go
@@ -94,7 +94,7 @@ func TestVitessCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
 	// vtgate can accept connections before it can serve queries; retry.
 	require.Eventually(t, func() bool {
 		return db.PingContext(ctx) == nil
-	}, 90*time.Second, 2*time.Second, "vtgate did not become query-ready")
+	}, vitessQueryReadyTimeout, 2*time.Second, "vtgate did not become query-ready")
 
 	_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS items")
 	require.NoError(t, err)

--- a/tests/integration/vitess_container_test.go
+++ b/tests/integration/vitess_container_test.go
@@ -26,11 +26,12 @@ const (
 	// workload (10k on vttestserver), so seeding more than that lets us prove the
 	// MySQL source detects Vitess and switches to the OLAP workload to read the
 	// whole table.
-	vitessBasePort  = "33574"
-	vitessMySQLPort = "33577/tcp"
-	vitessKeyspace  = "vtdb"
-	vitessTable     = "events"
-	vitessSeedRows  = 20000
+	vitessBasePort          = "33574"
+	vitessMySQLPort         = "33577/tcp"
+	vitessKeyspace          = "vtdb"
+	vitessTable             = "events"
+	vitessSeedRows          = 20000
+	vitessQueryReadyTimeout = 180 * time.Second
 )
 
 func startVitessContainer(ctx context.Context) (testcontainers.Container, string, string, error) {
@@ -89,7 +90,7 @@ func TestVitessSourceReadsBeyondRowCap(t *testing.T) {
 	// vtgate can accept connections before it is able to serve queries; retry.
 	require.Eventually(t, func() bool {
 		return db.PingContext(ctx) == nil
-	}, 90*time.Second, 2*time.Second, "vtgate did not become query-ready")
+	}, vitessQueryReadyTimeout, 2*time.Second, "vtgate did not become query-ready")
 
 	seedVitessTable(t, ctx, db)
 
@@ -132,7 +133,7 @@ func TestMySQLSchemeRejectsVitess(t *testing.T) {
 	defer func() { _ = db.Close() }()
 	require.Eventually(t, func() bool {
 		return db.PingContext(ctx) == nil
-	}, 90*time.Second, 2*time.Second, "vtgate did not become query-ready")
+	}, vitessQueryReadyTimeout, 2*time.Second, "vtgate did not become query-ready")
 
 	// The connect-time probe fails before any table is read, so no seeding is needed.
 	mysqlURI := strings.Replace(uri, "vitess://", "mysql://", 1)

--- a/tests/integration/vitess_destination_test.go
+++ b/tests/integration/vitess_destination_test.go
@@ -41,7 +41,7 @@ func TestVitessDestination_ReplaceAndMerge(t *testing.T) {
 	// vtgate can accept connections before it is able to serve queries; retry.
 	require.Eventually(t, func() bool {
 		return db.PingContext(ctx) == nil
-	}, 90*time.Second, 2*time.Second, "vtgate did not become query-ready")
+	}, vitessQueryReadyTimeout, 2*time.Second, "vtgate did not become query-ready")
 
 	sourceURI := jsonlURI(t, "testdata/conformance.jsonl")
 	destTable := vitessKeyspace + ".dest_conformance"
@@ -93,7 +93,7 @@ func TestVitessDestination_ShardedRejected(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return db.PingContext(ctx) == nil
-	}, 120*time.Second, 2*time.Second, "vtgate did not become query-ready")
+	}, vitessQueryReadyTimeout, 2*time.Second, "vtgate did not become query-ready")
 
 	cfg := &config.IngestConfig{
 		SourceURI:           jsonlURI(t, "testdata/conformance.jsonl"),


### PR DESCRIPTION
## Summary

Makes ingestion strategies schema-safe and retry-safe, with the strongest guarantees applied to destination-managed CDC and atomic snapshot publication.

## What this fixes

- Applies schema evolution before writes across append, replace, merge, truncate-insert, and streaming paths, while keeping contract transformations aligned with the final write schema.
- Fences managed CDC writes, truncates, merges, and swaps against the exact physical destination-table incarnation so a concurrent recreation fails closed instead of mutating the wrong table.
- Gives atomic snapshots durable attempt IDs and an OPEN → READY → terminal journal. Ambiguous publication responses recover with the same idempotency key; stale source metadata and `--full-refresh` discard the sealed stage and read a fresh snapshot.
- Prunes completed atomic-attempt history while retaining a recovery anchor across partial bounded deletes and repeated restarts.
- Preserves exact snapshot invalidation ordering and metadata in single- and multi-table flows, including replacement boundaries followed by later WAL truncates.
- Makes managed keyed and keyless PostgreSQL CDC batches replay-stable across page sizes, decoder drain sizes, restarts, and multi-table interleaving. Stable transaction windows spill to disk under memory pressure without splitting a durable batch ID.
- Invalidates managed append state on source WAL truncation and keeps snapshot completion, commit-token publication, cancellation cleanup, and connector-lease checks ordered around durable writes.
- Propagates incremental predicates through staged and direct merge paths and hardens quoted/dotted PostgreSQL swap targets and conditional incarnation checks.
- Makes failed direct-target cleanup ownership-safe. PostgreSQL creates and marks owned targets atomically, removes only a matching owned incarnation under an exclusive lock, and preserves concurrently created or replaced tables.

## Fail-closed capability rules

- Managed CDC append and keyless direct-write paths require destination-supported atomic token deduplication.
- Managed atomic snapshot publishers must support aborting unpublished attempts.
- Managed PostgreSQL CDC destinations must fence DML against the bound target incarnation. PostgreSQL opts in here; unfenced MySQL, SQLite, and DuckDB destinations are rejected before mutation.
- A destination target is cleaned after a pre-write failure only when the destination can verify the exact ownership token. Generated staging tables retain their existing cleanup behavior.

## Stack

Part 5 of 11. PR #962 is merged, so this PR is now based directly on `main`.

Previous: https://github.com/bruin-data/ingestr/pull/962 · Next: https://github.com/bruin-data/ingestr/pull/964

## Validation

- `make format`
- `make lint`
- `GOFLAGS=-p=1 make test` — all Go race tests and Python SDK tests passed
- `GOFLAGS=-p=1 make test-integration` — full real-container matrix passed in 1219.301s, including MySQL, PostgreSQL/MSSQL/Mongo/Vitess CDC, destination conformance, schema contracts, Kafka/RabbitMQ/SQS/Kinesis/PubSub, and Iceberg coverage
- `go test -race -count=1 ./pkg/strategy`
- PostgreSQL 16 ownership integration: own failed target removed; concurrent creation fails closed; physical replacement preserved; arbitrary public ownership token handled safely
- PostgreSQL 16 truncate-insert integration: keyed and keyless CDC truncate boundaries and staging-only column projection
- Repeated independent `gpt-5.6-terra` high-reasoning review loops; final review reported no findings
