### PR TITLE
Iceberg stack 6/11: pipeline schema evolution routing

### DIFF
--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -722,6 +722,25 @@ func AppendValue(builder array.Builder, val interface{}) {
 
 	case *array.ListBuilder:
 		appendListValue(b, val)
+	case *array.FixedSizeListBuilder:
+		appendFixedSizeListValue(b, val)
+	case *array.StructBuilder:
+		appendStructValue(b, val)
+	case *array.MapBuilder:
+		appendMapValue(b, val)
+	case *array.FixedSizeBinaryBuilder:
+		var data []byte
+		switch v := val.(type) {
+		case []byte:
+			data = v
+		case string:
+			data = []byte(v)
+		}
+		if len(data) != b.Type().(*arrow.FixedSizeBinaryType).ByteWidth {
+			b.AppendNull()
+		} else {
+			b.Append(data)
+		}
 
 	default:
 		builder.AppendNull()
@@ -805,6 +824,111 @@ func parseDecimal128Fast(s string, precision, scale int32) (decimal128.Num, bool
 		v = -v
 	}
 	return decimal128.FromI64(v), true
+}
+
+func appendFixedSizeListValue(b *array.FixedSizeListBuilder, val interface{}) {
+	rv := reflect.ValueOf(val)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		b.AppendNull()
+		return
+	}
+	if rv.Len() != int(b.Type().(*arrow.FixedSizeListType).Len()) {
+		b.AppendNull()
+		return
+	}
+	b.Append(true)
+	for i := 0; i < rv.Len(); i++ {
+		elem, ok := listElementValue(rv.Index(i))
+		if !ok {
+			b.ValueBuilder().AppendNull()
+		} else {
+			AppendValue(b.ValueBuilder(), elem)
+		}
+	}
+}
+
+func appendStructValue(b *array.StructBuilder, val interface{}) {
+	values := make([]interface{}, b.NumField())
+	matched := false
+	switch v := val.(type) {
+	case map[string]interface{}:
+		matched = true
+		fields := b.Type().(*arrow.StructType).Fields()
+		for i, field := range fields {
+			for key, value := range v {
+				if strings.EqualFold(key, field.Name) {
+					values[i] = value
+					break
+				}
+			}
+		}
+	default:
+		rv := reflect.ValueOf(val)
+		if rv.Kind() == reflect.Pointer && !rv.IsNil() {
+			rv = rv.Elem()
+		}
+		if rv.IsValid() && rv.Kind() == reflect.Map && rv.Type().Key().Kind() == reflect.String {
+			matched = true
+			fields := b.Type().(*arrow.StructType).Fields()
+			for _, key := range rv.MapKeys() {
+				for i, field := range fields {
+					if strings.EqualFold(key.String(), field.Name) {
+						values[i] = rv.MapIndex(key).Interface()
+						break
+					}
+				}
+			}
+		} else if rv.IsValid() && rv.Kind() == reflect.Struct {
+			matched = true
+			fields := b.Type().(*arrow.StructType).Fields()
+			for i := 0; i < rv.NumField(); i++ {
+				if !rv.Field(i).CanInterface() {
+					continue
+				}
+				inputName := rv.Type().Field(i).Name
+				for _, tag := range []string{"json", "bson"} {
+					if tagged := strings.Split(rv.Type().Field(i).Tag.Get(tag), ",")[0]; tagged != "" && tagged != "-" {
+						inputName = tagged
+						break
+					}
+				}
+				for fieldIndex, field := range fields {
+					if strings.EqualFold(inputName, field.Name) {
+						values[fieldIndex] = rv.Field(i).Interface()
+						break
+					}
+				}
+			}
+		} else if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) && rv.Len() == b.NumField() {
+			for i := range values {
+				values[i] = rv.Index(i).Interface()
+			}
+			matched = true
+		}
+	}
+	if !matched {
+		b.AppendNull()
+		return
+	}
+	b.Append(true)
+	for i, value := range values {
+		AppendValue(b.FieldBuilder(i), value)
+	}
+}
+
+func appendMapValue(b *array.MapBuilder, val interface{}) {
+	rv := reflect.ValueOf(val)
+	if !rv.IsValid() || rv.Kind() != reflect.Map {
+		b.AppendNull()
+		return
+	}
+	keys := rv.MapKeys()
+	sort.Slice(keys, func(i, j int) bool { return fmt.Sprint(keys[i].Interface()) < fmt.Sprint(keys[j].Interface()) })
+	b.Append(true)
+	for _, key := range keys {
+		AppendValue(b.KeyBuilder(), key.Interface())
+		AppendValue(b.ItemBuilder(), rv.MapIndex(key).Interface())
+	}
 }
 
 func appendListValue(b *array.ListBuilder, val interface{}) {

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -467,3 +467,48 @@ func TestParseDecimal128Fast_FallsBack(t *testing.T) {
 		}
 	}
 }
+
+func TestAppendValueRecursiveAndFixedBuilders(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	structType := arrow.StructOf(
+		arrow.Field{Name: "Name", Type: arrow.BinaryTypes.String, Nullable: true},
+		arrow.Field{Name: "count", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	)
+	structBuilder := array.NewStructBuilder(mem, structType)
+	AppendValue(structBuilder, map[string]interface{}{"name": "alpha", "count": int64(7)})
+	structArray := structBuilder.NewStructArray()
+	structBuilder.Release()
+	require.Equal(t, "alpha", structArray.Field(0).(*array.String).Value(0))
+	require.Equal(t, int64(7), structArray.Field(1).(*array.Int64).Value(0))
+	structArray.Release()
+
+	mapBuilder := array.NewMapBuilder(mem, arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int64, false)
+	AppendValue(mapBuilder, map[string]int64{"b": 2, "a": 1})
+	mapArray := mapBuilder.NewMapArray()
+	mapBuilder.Release()
+	require.Equal(t, []string{"a", "b"}, []string{mapArray.Keys().(*array.String).Value(0), mapArray.Keys().(*array.String).Value(1)})
+	require.Equal(t, []int64{1, 2}, []int64{mapArray.Items().(*array.Int64).Value(0), mapArray.Items().(*array.Int64).Value(1)})
+	mapArray.Release()
+
+	fixedBinaryBuilder := array.NewFixedSizeBinaryBuilder(mem, &arrow.FixedSizeBinaryType{ByteWidth: 4})
+	AppendValue(fixedBinaryBuilder, []byte{1, 2, 3, 4})
+	AppendValue(fixedBinaryBuilder, []byte{1, 2})
+	fixedBinary := fixedBinaryBuilder.NewFixedSizeBinaryArray()
+	fixedBinaryBuilder.Release()
+	require.Equal(t, []byte{1, 2, 3, 4}, fixedBinary.Value(0))
+	require.True(t, fixedBinary.IsNull(1))
+	fixedBinary.Release()
+
+	fixedListBuilder := array.NewFixedSizeListBuilder(mem, 2, arrow.PrimitiveTypes.Int64)
+	AppendValue(fixedListBuilder, []int64{3, 4})
+	AppendValue(fixedListBuilder, []int64{5})
+	fixedList := fixedListBuilder.NewListArray()
+	fixedListBuilder.Release()
+	require.False(t, fixedList.IsNull(0))
+	require.True(t, fixedList.IsNull(1))
+	values := fixedList.ListValues().(*array.Int64)
+	require.Equal(t, []int64{3, 4}, []int64{values.Value(0), values.Value(1)})
+	fixedList.Release()
+}

--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -266,6 +266,10 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 		return castUnknownArray(arr, target)
 	}
 
+	if aligned, handled, err := alignNestedArray(ctx, arr, target, safe); handled {
+		return aligned, err
+	}
+
 	if isJSONType(target) {
 		return castArrayToJSON(ctx, arr, target)
 	}
@@ -320,6 +324,95 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 	}
 
 	return nil, err
+}
+
+func alignNestedArray(ctx context.Context, arr arrow.Array, target arrow.DataType, safe bool) (arrow.Array, bool, error) {
+	switch targetType := target.(type) {
+	case *arrow.StructType:
+		source, ok := arr.(*array.Struct)
+		if !ok {
+			return nil, false, nil
+		}
+		result, err := alignStructArray(ctx, source, targetType, safe)
+		return result, true, err
+	case *arrow.MapType:
+		source, ok := arr.(*array.Map)
+		if !ok {
+			return nil, false, nil
+		}
+		keys, err := castArrayToType(ctx, source.Keys(), targetType.KeyType(), safe)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to align map key: %w", err)
+		}
+		defer keys.Release()
+		items, err := castArrayToType(ctx, source.Items(), targetType.ItemType(), safe)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to align map value: %w", err)
+		}
+		defer items.Release()
+
+		entriesType := targetType.Elem().(*arrow.StructType)
+		entriesData := array.NewData(entriesType, keys.Len(), []*memory.Buffer{nil}, []arrow.ArrayData{keys.Data(), items.Data()}, 0, 0)
+		defer entriesData.Release()
+		return rebuildNestedArray(arr, target, []arrow.ArrayData{entriesData}), true, nil
+	case arrow.ListLikeType:
+		if arr.DataType().ID() != target.ID() {
+			return nil, false, nil
+		}
+		source, ok := arr.(array.ListLike)
+		if !ok {
+			return nil, false, nil
+		}
+		values, err := castArrayToType(ctx, source.ListValues(), targetType.Elem(), safe)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to align list element: %w", err)
+		}
+		defer values.Release()
+		return rebuildNestedArray(arr, target, []arrow.ArrayData{values.Data()}), true, nil
+	}
+
+	return nil, false, nil
+}
+
+func alignStructArray(ctx context.Context, source *array.Struct, target *arrow.StructType, safe bool) (arrow.Array, error) {
+	sourceType := source.DataType().(*arrow.StructType)
+	sourceFields := make(map[string]int, sourceType.NumFields())
+	for i, field := range sourceType.Fields() {
+		sourceFields[strings.ToLower(field.Name)] = i
+	}
+
+	children := make([]arrow.Array, target.NumFields())
+	defer func() {
+		for _, child := range children {
+			if child != nil {
+				child.Release()
+			}
+		}
+	}()
+
+	childData := make([]arrow.ArrayData, target.NumFields())
+	for i, field := range target.Fields() {
+		sourceIndex, ok := sourceFields[strings.ToLower(field.Name)]
+		var err error
+		if ok {
+			children[i], err = castArrayToType(ctx, source.Field(sourceIndex), field.Type, safe)
+		} else {
+			children[i], err = makeNullArray(memory.DefaultAllocator, field.Type, source.Len())
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to align struct field %s: %w", field.Name, err)
+		}
+		childData[i] = children[i].Data()
+	}
+
+	return rebuildNestedArray(source, target, childData), nil
+}
+
+func rebuildNestedArray(source arrow.Array, target arrow.DataType, children []arrow.ArrayData) arrow.Array {
+	data := source.Data()
+	resultData := array.NewData(target, source.Len(), data.Buffers(), children, source.NullN(), data.Offset())
+	defer resultData.Release()
+	return array.MakeFromData(resultData)
 }
 
 func normalizeArrayOffset(arr arrow.Array) (arrow.Array, bool, error) {

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -704,6 +704,105 @@ func TestCastRecordToSchema(t *testing.T) {
 	})
 }
 
+func TestFileBuffer_AlignsNestedSchemaEvolution(t *testing.T) {
+	profileSource := arrow.StructOf(
+		arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		arrow.Field{Name: "removed", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	)
+	profileTarget := arrow.StructOf(
+		arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		arrow.Field{Name: "active", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	)
+	eventSource := arrow.StructOf(
+		arrow.Field{Name: "code", Type: arrow.BinaryTypes.String, Nullable: true},
+		arrow.Field{Name: "removed", Type: arrow.BinaryTypes.String, Nullable: true},
+	)
+	eventTarget := arrow.StructOf(
+		arrow.Field{Name: "code", Type: arrow.BinaryTypes.String, Nullable: true},
+		arrow.Field{Name: "count", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	)
+	mapValueSource := arrow.StructOf(
+		arrow.Field{Name: "score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		arrow.Field{Name: "removed", Type: arrow.BinaryTypes.String, Nullable: true},
+	)
+	mapValueTarget := arrow.StructOf(
+		arrow.Field{Name: "score", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		arrow.Field{Name: "label", Type: arrow.BinaryTypes.String, Nullable: true},
+	)
+
+	sourcePayload := arrow.StructOf(
+		arrow.Field{Name: "profile", Type: profileSource, Nullable: true},
+		arrow.Field{Name: "events", Type: arrow.ListOf(eventSource), Nullable: true},
+		arrow.Field{Name: "lookup", Type: arrow.MapOf(arrow.BinaryTypes.String, mapValueSource), Nullable: true},
+	)
+	targetPayload := arrow.StructOf(
+		arrow.Field{Name: "profile", Type: profileTarget, Nullable: true},
+		arrow.Field{Name: "events", Type: arrow.ListOf(eventTarget), Nullable: true},
+		arrow.Field{Name: "lookup", Type: arrow.MapOf(arrow.BinaryTypes.String, mapValueTarget), Nullable: true},
+		arrow.Field{Name: "added", Type: arrow.BinaryTypes.String, Nullable: true},
+	)
+	sourceSchema := arrow.NewSchema([]arrow.Field{{Name: "payload", Type: sourcePayload, Nullable: true}}, nil)
+	targetSchema := arrow.NewSchema([]arrow.Field{{Name: "payload", Type: targetPayload, Nullable: true}}, nil)
+
+	builder := array.NewBuilder(memory.DefaultAllocator, sourcePayload)
+	arrowconv.AppendValue(builder, map[string]interface{}{
+		"profile": map[string]interface{}{"name": "Ada", "removed": int64(9)},
+		"events":  []interface{}{map[string]interface{}{"code": "created", "removed": "old"}},
+		"lookup":  map[string]interface{}{"primary": map[string]interface{}{"score": int32(7), "removed": "old"}},
+	})
+	builder.AppendNull()
+	payload := builder.NewArray()
+	builder.Release()
+	record := array.NewRecordBatch(sourceSchema, []arrow.Array{payload}, 2)
+	payload.Release()
+	defer record.Release()
+
+	assertAligned := func(t *testing.T, result arrow.RecordBatch) {
+		t.Helper()
+		require.True(t, result.Schema().Equal(targetSchema))
+		outer := result.Column(0).(*array.Struct)
+		assert.True(t, outer.IsValid(0))
+		assert.True(t, outer.IsNull(1))
+
+		profile := outer.Field(0).(*array.Struct)
+		assert.Equal(t, "Ada", profile.Field(0).(*array.String).Value(0))
+		assert.True(t, profile.Field(1).IsNull(0), "new struct field must be null-filled")
+
+		events := outer.Field(1).(*array.List)
+		eventValues := events.ListValues().(*array.Struct)
+		assert.Equal(t, "created", eventValues.Field(0).(*array.String).Value(0))
+		assert.True(t, eventValues.Field(1).IsNull(0), "new list element field must be null-filled")
+
+		lookup := outer.Field(2).(*array.Map)
+		assert.Equal(t, "primary", lookup.Keys().(*array.String).Value(0))
+		mapValues := lookup.Items().(*array.Struct)
+		assert.Equal(t, int64(7), mapValues.Field(0).(*array.Int64).Value(0))
+		assert.True(t, mapValues.Field(1).IsNull(0), "new map value field must be null-filled")
+		assert.True(t, outer.Field(3).IsNull(0), "new outer field must be null-filled")
+	}
+
+	t.Run("direct cast", func(t *testing.T) {
+		result, err := CastRecordToSchema(record, targetSchema, true)
+		require.NoError(t, err)
+		defer result.Release()
+		assertAligned(t, result)
+	})
+
+	t.Run("file round trip", func(t *testing.T) {
+		buf, err := NewFileBuffer()
+		require.NoError(t, err)
+		defer func() { _ = buf.Close() }()
+		require.NoError(t, buf.Append(context.Background(), record))
+
+		ch, err := buf.Reader(context.Background(), targetSchema)
+		require.NoError(t, err)
+		batches := readAllBatches(t, ch)
+		defer releaseBatches(batches)
+		require.Len(t, batches, 1)
+		assertAligned(t, batches[0])
+	})
+}
+
 func TestCastRecordToSchema_UnknownToJSONEncodesScalarStrings(t *testing.T) {
 	mem := memory.DefaultAllocator
 

--- a/pkg/destination/cassandra/cassandra.go
+++ b/pkg/destination/cassandra/cassandra.go
@@ -425,7 +425,7 @@ func (d *CassandraDestination) mergeCDC(ctx context.Context, targetRef, selectSQ
 			entry.latestLSN = lsn
 			entry.latestDeleted = deleted
 		}
-		if !deleted && (entry.active == nil || lsn > entry.activeLSN) {
+		if !deleted && (entry.active == nil || destination.CompareCDCPositions(lsn, entry.activeLSN) > 0) {
 			entry.active = row
 			entry.activeLSN = lsn
 		}

--- a/pkg/destination/cdc.go
+++ b/pkg/destination/cdc.go
@@ -1,6 +1,9 @@
 package destination
 
-import "strings"
+import (
+	"math/big"
+	"strings"
+)
 
 func HasCDCDeletedColumn(columns []string) bool {
 	for _, col := range columns {
@@ -40,10 +43,53 @@ func CDCLatestOverallOrderBy(quote func(string) string) string {
 // It mirrors CDCLatestOverallOrderBy for destinations that compose changes in
 // Go instead of SQL.
 func CDCSupersedes(lsn string, deleted bool, prevLSN string, prevDeleted bool) bool {
-	if lsn != prevLSN {
-		return lsn > prevLSN
+	if comparison := CompareCDCPositions(lsn, prevLSN); comparison != 0 {
+		return comparison > 0
 	}
 	return deleted && !prevDeleted
+}
+
+// CompareCDCPositions compares decimal cursors, PostgreSQL X/Y hexadecimal
+// LSNs, and finally opaque strings.
+func CompareCDCPositions(left, right string) int {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == right {
+		return 0
+	}
+	if left == "" {
+		return -1
+	}
+	if right == "" {
+		return 1
+	}
+	if leftLSN, ok := postgresLSNValue(left); ok {
+		if rightLSN, rightOK := postgresLSNValue(right); rightOK {
+			return leftLSN.Cmp(rightLSN)
+		}
+	}
+	if leftInt, ok := new(big.Int).SetString(left, 10); ok {
+		if rightInt, rightOK := new(big.Int).SetString(right, 10); rightOK {
+			return leftInt.Cmp(rightInt)
+		}
+	}
+	return strings.Compare(left, right)
+}
+
+func postgresLSNValue(value string) (*big.Int, bool) {
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 {
+		return nil, false
+	}
+	high, ok := new(big.Int).SetString(parts[0], 16)
+	if !ok {
+		return nil, false
+	}
+	low, ok := new(big.Int).SetString(parts[1], 16)
+	if !ok || low.BitLen() > 32 {
+		return nil, false
+	}
+	return new(big.Int).Add(new(big.Int).Lsh(high, 32), low), true
 }
 
 func CDCDataColumns(columns, primaryKeys []string) []string {

--- a/pkg/destination/cdc_regression_test.go
+++ b/pkg/destination/cdc_regression_test.go
@@ -1,0 +1,31 @@
+package destination
+
+import "testing"
+
+func TestCompareCDCPositionsOrdersPostgresLSNNumerically(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  int
+	}{
+		{name: "low word crosses hexadecimal width", left: "0/100", right: "0/FF", want: 1},
+		{name: "low word reverse ordering", left: "0/FF", right: "0/100", want: -1},
+		{name: "high word carries past the maximum low word", left: "1/0", right: "0/FFFFFFFF", want: 1},
+		{name: "padding does not change the position", left: "00000000/00000100", right: "0/100", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompareCDCPositions(tt.left, tt.right)
+			switch {
+			case tt.want < 0 && got >= 0:
+				t.Fatalf("CompareCDCPositions(%q, %q) = %d, want a negative result", tt.left, tt.right, got)
+			case tt.want == 0 && got != 0:
+				t.Fatalf("CompareCDCPositions(%q, %q) = %d, want zero", tt.left, tt.right, got)
+			case tt.want > 0 && got <= 0:
+				t.Fatalf("CompareCDCPositions(%q, %q) = %d, want a positive result", tt.left, tt.right, got)
+			}
+		})
+	}
+}

--- a/pkg/destination/cdc_truncate.go
+++ b/pkg/destination/cdc_truncate.go
@@ -200,6 +200,9 @@ func applyCDCInputTruncate(ctx context.Context, dest Destination, opts WriteOpti
 	if opts.StagingTable {
 		return ApplyTruncate(ctx, dest, opts.Table)
 	}
+	if opts.CDCExpectedIncarnation != "" {
+		return ApplyCDCTruncateIfIncarnation(ctx, dest, opts.Table, opts.CDCExpectedIncarnation)
+	}
 	return ApplyCDCTruncate(ctx, dest, opts.Table)
 }
 
@@ -222,4 +225,18 @@ func ApplyCDCTruncate(ctx context.Context, dest Destination, table string) error
 		return nil
 	}
 	return ApplyTruncate(ctx, dest, table)
+}
+
+func ApplyCDCTruncateIfIncarnation(ctx context.Context, dest Destination, table, expectedIncarnation string) error {
+	if expectedIncarnation == "" {
+		return fmt.Errorf("cannot conditionally truncate %s without a bound destination incarnation", table)
+	}
+	truncater, ok := dest.(CDCConditionalTruncater)
+	if !ok {
+		return fmt.Errorf("destination scheme %q cannot conditionally truncate managed CDC targets", dest.GetScheme())
+	}
+	if err := truncater.TruncateCDCTableIfIncarnation(ctx, table, expectedIncarnation); err != nil {
+		return fmt.Errorf("failed to conditionally truncate %s: %w", table, err)
+	}
+	return nil
 }

--- a/pkg/destination/cdc_truncate_test.go
+++ b/pkg/destination/cdc_truncate_test.go
@@ -3,6 +3,7 @@ package destination
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,26 @@ import (
 type boundaryWriteDestination struct {
 	Destination
 	write func(context.Context, <-chan source.RecordBatchResult, WriteOptions) error
+}
+
+type conditionalBoundaryDestination struct {
+	*boundaryWriteDestination
+	currentIncarnation string
+	unconditionalCalls atomic.Int64
+	conditionalCalls   atomic.Int64
+}
+
+func (d *conditionalBoundaryDestination) TruncateCDCTable(context.Context, string) error {
+	d.unconditionalCalls.Add(1)
+	return nil
+}
+
+func (d *conditionalBoundaryDestination) TruncateCDCTableIfIncarnation(_ context.Context, _, expected string) error {
+	d.conditionalCalls.Add(1)
+	if expected != d.currentIncarnation {
+		return errors.New("target incarnation changed")
+	}
+	return nil
 }
 
 func (d *boundaryWriteDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error {
@@ -156,6 +177,34 @@ func TestWriteWithTruncateBoundariesReturnsWhenCanceledProducerNeverCloses(t *te
 	}
 	if got := releases.Load(); got != 1 {
 		t.Fatalf("batch release count = %d, want 1", got)
+	}
+}
+
+func TestWriteWithTruncateBoundariesRefusesRecreatedManagedTarget(t *testing.T) {
+	dest := &conditionalBoundaryDestination{
+		boundaryWriteDestination: &boundaryWriteDestination{write: func(_ context.Context, records <-chan source.RecordBatchResult, _ WriteOptions) error {
+			for result := range records {
+				releaseCDCResult(result)
+			}
+			return nil
+		}},
+		currentIncarnation: "replacement-uuid",
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Truncate: true, CDCWALTruncate: true}
+	close(records)
+
+	_, err := WriteWithTruncateBoundaries(context.Background(), dest, records, WriteOptions{
+		Table: "items", CDCExpectedIncarnation: "bound-original-uuid",
+	})
+	if err == nil || !strings.Contains(err.Error(), "target incarnation changed") {
+		t.Fatalf("WriteWithTruncateBoundaries() error = %v, want incarnation change", err)
+	}
+	if got := dest.unconditionalCalls.Load(); got != 0 {
+		t.Fatalf("unconditional truncate calls = %d, want 0", got)
+	}
+	if got := dest.conditionalCalls.Load(); got != 1 {
+		t.Fatalf("conditional truncate calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -663,7 +663,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := mapDataTypeToCrateDB(col)
-		colDefs = append(colDefs, fmt.Sprintf(`%s %s`, destination.QuoteIdentifier(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf(`%s %s%s`, destination.QuoteIdentifier(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", table, strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/cratedb/cratedb_test.go
+++ b/pkg/destination/cratedb/cratedb_test.go
@@ -78,17 +78,18 @@ func TestParseSchemaTable(t *testing.T) {
 func TestBuildCreateTableSQL(t *testing.T) {
 	t.Parallel()
 	columns := []schema.Column{
-		{Name: "id", DataType: schema.TypeInt64},
-		{Name: "name", DataType: schema.TypeString},
-		{Name: "active", DataType: schema.TypeBoolean},
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+		{Name: "active", DataType: schema.TypeBoolean, Nullable: false},
 	}
 
 	sql := buildCreateTableSQL(`"doc"."users"`, columns, []string{"id"})
-	assert.Contains(t, sql, `CREATE TABLE IF NOT EXISTS "doc"."users"`)
-	assert.Contains(t, sql, `"id" BIGINT`)
-	assert.Contains(t, sql, `"name" TEXT`)
-	assert.Contains(t, sql, `"active" BOOLEAN`)
-	assert.Contains(t, sql, `PRIMARY KEY ("id")`)
+	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "doc"."users" (
+  "id" BIGINT NOT NULL,
+  "name" TEXT,
+  "active" BOOLEAN NOT NULL,
+  PRIMARY KEY ("id")
+)`, sql)
 }
 
 func TestBuildCreateTableSQLNoPrimaryKey(t *testing.T) {

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -604,7 +604,11 @@ func (d *DatabricksDestination) buildCreateTableSQL(fullTable string, columns []
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToDatabricks(col)
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf("%s %s%s", quoteIdentifier(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)", fullTable, strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/databricks/databricks_test.go
+++ b/pkg/destination/databricks/databricks_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
+func TestBuildCreateTableSQLPreservesRequiredness(t *testing.T) {
+	dest := &DatabricksDestination{}
+	got := dest.buildCreateTableSQL("`main`.`raw`.`events`", []schema.Column{
+		{Name: "required", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "optional", DataType: schema.TypeString, Nullable: true},
+	}, nil)
+	want := "CREATE TABLE IF NOT EXISTS `main`.`raw`.`events` (\n  `required` BIGINT NOT NULL,\n  `optional` STRING\n)"
+	if got != want {
+		t.Fatalf("buildCreateTableSQL() = %q, want %q", got, want)
+	}
+}
+
 func TestMapDataTypeToDatabricks_SizedString(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -160,6 +160,7 @@ type TableWriteConfig struct {
 	PrimaryKeys            []string
 	DeduplicatePrimaryKeys bool
 	IncrementalKey         string
+	CDCMode                bool
 	SkipCDCResume          bool
 	CDCExpectedIncarnation string
 }
@@ -174,8 +175,9 @@ type MultiTableWriteOptions struct {
 	LoaderFileFormat string
 	// CancelSource stops the producer when a per-table writer fails. The writer
 	// drains records after invoking it so producer-owned resources can unwind.
-	CancelSource context.CancelFunc
-	TableWriter  func(context.Context, string, <-chan source.RecordBatchResult, WriteOptions) (bool, error)
+	CancelSource       context.CancelFunc
+	CancelDrainTimeout time.Duration
+	TableWriter        func(context.Context, string, <-chan source.RecordBatchResult, WriteOptions) (bool, error)
 }
 
 // CDCResumeProvider is an optional interface that destinations can implement

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -16,14 +16,17 @@ import (
 const ManagedStagingTTL = 24 * time.Hour
 
 type PrepareOptions struct {
-	Table        string
-	Schema       *schema.TableSchema
-	DropFirst    bool
-	PrimaryKeys  []string
-	PartitionBy  string   // Column to partition by (BigQuery)
-	ClusterBy    []string // Columns to cluster by (BigQuery)
-	CDCMode      bool     // If true, make non-PK columns nullable for staging tables (CDC delete handling)
-	ExpiresAfter time.Duration
+	Table                  string
+	Schema                 *schema.TableSchema
+	DropFirst              bool
+	PrimaryKeys            []string
+	PartitionBy            string   // Column to partition by (BigQuery)
+	ClusterBy              []string // Columns to cluster by (BigQuery)
+	CDCMode                bool     // If true, make non-PK columns nullable for staging tables (CDC delete handling)
+	ExpiresAfter           time.Duration
+	PreserveExistingLayout bool // Leave an existing table's properties, partition spec, and sort order unchanged.
+	TableProperties        map[string]string
+	OwnershipToken         string
 }
 
 type WriteOptions struct {
@@ -36,6 +39,24 @@ type WriteOptions struct {
 	StagingBucket    string
 	LoaderFileSize   int
 	LoaderFileFormat string
+	// CommitToken identifies one source flush. Destinations that support
+	// durable token commits use it to make retries idempotent.
+	CommitToken any
+	// CDCResumeLSN is the source position made durable by this write. It must
+	// become visible atomically with the data commit.
+	CDCResumeLSN string
+	// SkipCDCResume prevents destinations from inferring a resume cursor from
+	// CDC columns. It is used for durable snapshot chunks that are individually
+	// idempotent but cannot safely advance the source checkpoint yet.
+	SkipCDCResume bool
+	// CDCExpectedIncarnation fences a managed CDC write to the physical target
+	// that was bound before the source read began.
+	CDCExpectedIncarnation string
+	// DeduplicatePrimaryKeys requests one output row per configured primary
+	// key. IncrementalKey selects the greatest value; arrival order breaks ties.
+	DeduplicatePrimaryKeys  bool
+	IncrementalKey          string
+	AtomicSnapshotAttemptID string
 
 	// PreStaged holds load files written during extract by a PreStager
 	// destination. When set, the destination loads these files instead of
@@ -57,6 +78,13 @@ type MergeOptions struct {
 	Columns        []string
 	IncrementalKey string
 	Schema         *schema.TableSchema
+	CommitToken    any
+	CDCResumeLSN   string
+	SkipCDCResume  bool
+	// CDCExpectedIncarnation fences a managed CDC merge to the physical target
+	// that was bound before the source read began.
+	CDCExpectedIncarnation string
+	Parallelism            int
 }
 
 // DeleteInsertOptions contains parameters for delete+insert operations.
@@ -72,11 +100,13 @@ type DeleteInsertOptions struct {
 }
 
 type SwapOptions struct {
-	StagingTable   string
-	TargetTable    string
-	PrimaryKeys    []string
-	IncrementalKey string
-	Schema         *schema.TableSchema
+	StagingTable                  string
+	TargetTable                   string
+	PrimaryKeys                   []string
+	IncrementalKey                string
+	Schema                        *schema.TableSchema
+	CDCExpectedIncarnation        string
+	CDCExpectedStagingIncarnation string
 }
 
 // SCD2Options contains parameters for SCD2 (Slowly Changing Dimensions Type 2) operations.
@@ -125,9 +155,13 @@ type Destination interface {
 
 // TableWriteConfig contains per-table write configuration for multi-table writes.
 type TableWriteConfig struct {
-	DestTable   string
-	Schema      *schema.TableSchema
-	PrimaryKeys []string
+	DestTable              string
+	Schema                 *schema.TableSchema
+	PrimaryKeys            []string
+	DeduplicatePrimaryKeys bool
+	IncrementalKey         string
+	SkipCDCResume          bool
+	CDCExpectedIncarnation string
 }
 
 // MultiTableWriteOptions configures multi-table write behavior.
@@ -141,13 +175,15 @@ type MultiTableWriteOptions struct {
 	// CancelSource stops the producer when a per-table writer fails. The writer
 	// drains records after invoking it so producer-owned resources can unwind.
 	CancelSource context.CancelFunc
+	TableWriter  func(context.Context, string, <-chan source.RecordBatchResult, WriteOptions) (bool, error)
 }
 
 // CDCResumeProvider is an optional interface that destinations can implement
 // to support CDC resume functionality. If implemented, the pipeline will query
-// the destination for the max CDC LSN to resume from.
+// the destination for its latest durable CDC position.
 type CDCResumeProvider interface {
-	// GetMaxCDCLSN returns the maximum _cdc_lsn value from the table, or empty string if none found.
+	// GetMaxCDCLSN returns the latest durable CDC cursor, or an empty string if
+	// no CDC data or checkpoint has committed.
 	GetMaxCDCLSN(ctx context.Context, table string) (string, error)
 }
 
@@ -248,6 +284,13 @@ type CDCConditionalTruncater interface {
 	TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error
 }
 
+// CDCConditionalSwapCapable advertises that SwapTable enforces both expected
+// target and staging incarnations in the same atomic operation that replaces
+// the target.
+type CDCConditionalSwapCapable interface {
+	SupportsCDCConditionalSwap() bool
+}
+
 // CDCTargetIncarnationInitializer establishes destination-specific physical
 // identity metadata after a target claim succeeds. It must not be called while
 // validating an unclaimed target.
@@ -294,6 +337,70 @@ type CDCStatePruneBatchSizer interface {
 	CDCStatePruneBatchSize() int
 }
 
+// DurableCommitTokenWriter is an optional interface for destinations that can
+// durably record a source flush token without changing table rows. Streaming
+// uses it when a source position advances during an otherwise empty flush.
+type DurableCommitTokenWriter interface {
+	CommitWriteToken(ctx context.Context, table string, commitToken any, cdcResumeLSN string) error
+}
+
+// IdempotentCommitTokenWriter is implemented by destinations whose row-write
+// path atomically records WriteOptions.CommitToken and skips the rows when the
+// same token is retried. Keyless CDC streaming requires this because it has no
+// row identity with which to deduplicate a replayed transaction.
+type IdempotentCommitTokenWriter interface {
+	SupportsIdempotentCommitTokenWrites() bool
+}
+
+// AtomicSnapshotOptions describes a streamed source snapshot whose pages must
+// remain hidden until its final durable source position is available.
+type AtomicSnapshotOptions struct {
+	Table         string
+	Schema        *schema.TableSchema
+	TargetSchema  *schema.TableSchema
+	PrimaryKeys   []string
+	PartitionBy   string
+	ClusterBy     []string
+	Parallelism   int
+	CommitToken   any
+	CDCResumeLSN  string
+	SkipCDCResume bool
+	// CDCExpectedIncarnation fences publication to the physical target that was
+	// bound before the source snapshot began.
+	CDCExpectedIncarnation string
+	AttemptID              string
+}
+
+// AtomicSnapshotPublisher is implemented by destinations that can durably
+// stage snapshot pages and publish the completed snapshot in one table commit.
+// It does not provide atomic publication across multiple destination tables.
+// Streaming falls back to its historical truncate-and-page behavior when this
+// interface is not implemented.
+type AtomicSnapshotPublisher interface {
+	BeginAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+	EvolveAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+	WriteAtomicSnapshot(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
+	PublishAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+}
+
+// AtomicSnapshotAborter reclaims an owned snapshot stage only when the caller
+// knows publication was never attempted. It is separate from
+// AtomicSnapshotPublisher so existing publishers remain compatible.
+type AtomicSnapshotAborter interface {
+	AbortAtomicSnapshot(ctx context.Context, opts AtomicSnapshotOptions) error
+}
+
+type OwnedTableDropper interface {
+	DropTableIfOwned(ctx context.Context, table, ownershipToken string) error
+}
+
+// ConnectionChecker is an optional end-to-end connection check. Unlike
+// Connect, it verifies that the destination can create, write, read, and clean
+// up data using the configured credentials and storage.
+type ConnectionChecker interface {
+	CheckConnection(ctx context.Context) error
+}
+
 // CDCMergeAware is an optional interface that destinations can implement
 // to indicate they handle CDC deletes during merge operations.
 type CDCMergeAware interface {
@@ -304,6 +411,13 @@ type CDCMergeAware interface {
 // write atomically visible after the write phase completes.
 type AtomicCommitWriter interface {
 	SupportsAtomicCommitWrites() bool
+}
+
+// DirectReplaceDeduplicator is implemented by destinations that can collapse
+// duplicate primary keys as part of a direct replace write. Destinations must
+// not opt in unless the deduplication and data replacement commit atomically.
+type DirectReplaceDeduplicator interface {
+	SupportsDirectReplaceDeduplication() bool
 }
 
 // MultiTableNamer is an optional interface for destinations that need full
@@ -349,6 +463,19 @@ type CDCTruncateCapable interface {
 	TruncateCDCTable(ctx context.Context, table string) error
 }
 
+// AtomicTruncateInsertWriter replaces all table rows in one destination
+// commit. Strategies prefer it over a separate truncate followed by writes so
+// readers never observe an empty or partially reloaded target.
+type AtomicTruncateInsertWriter interface {
+	TruncateInsertRecords(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
+}
+
+// AtomicTruncateInsertSchemaEvolver marks an atomic truncate+insert writer that
+// commits supported schema evolution and the replacement rows together.
+type AtomicTruncateInsertSchemaEvolver interface {
+	EvolvesTruncateInsertSchemaAtomically() bool
+}
+
 // ConcurrentFlusher is an optional interface for destinations whose
 // write+merge cycles for *different* tables can safely run concurrently
 // (connection-pool backed databases, where each cycle uses its own
@@ -357,6 +484,12 @@ type CDCTruncateCapable interface {
 // it — or returning a value < 2 — are flushed one table at a time.
 type ConcurrentFlusher interface {
 	MaxConcurrentFlushes() int
+}
+
+// DirectMergeWriter atomically merges record batches into a target without a
+// remote staging-table write/read round trip.
+type DirectMergeWriter interface {
+	MergeRecords(ctx context.Context, records <-chan source.RecordBatchResult, writeOpts WriteOptions, mergeOpts MergeOptions) error
 }
 
 // ReplaceStagingPlacement declares the default schema placement for replace

--- a/pkg/destination/duckdb/dialect.go
+++ b/pkg/destination/duckdb/dialect.go
@@ -15,10 +15,13 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
-		destination.QuoteTableName(table),
-		d.QuoteIdentifier(col.Name),
-		d.TypeName(col))
+	quotedTable := destination.QuoteTableName(table)
+	quotedColumn := d.QuoteIdentifier(col.Name)
+	add := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", quotedTable, quotedColumn, d.TypeName(col))
+	if col.Nullable {
+		return add
+	}
+	return fmt.Sprintf("%s; ALTER TABLE %s ALTER COLUMN %s SET NOT NULL", add, quotedTable, quotedColumn)
 }
 
 func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -1768,7 +1768,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToDuckDB(col)
-		colDefs = append(colDefs, fmt.Sprintf(`%s %s`, quoteIdentifier(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf(`%s %s%s`, quoteIdentifier(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", table, strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -498,8 +498,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 			primaryKeys: nil,
 			validate: func(t *testing.T, sql string) {
 				assert.Contains(t, sql, "CREATE TABLE IF NOT EXISTS users")
-				assert.Contains(t, sql, `"id" BIGINT`)
-				assert.NotContains(t, sql, `NOT NULL`)
+				assert.Contains(t, sql, `"id" BIGINT NOT NULL`)
 				assert.Contains(t, sql, `"name" VARCHAR`)
 				assert.NotContains(t, sql, "PRIMARY KEY")
 			},
@@ -552,6 +551,37 @@ func TestBuildCreateTableSQL(t *testing.T) {
 			tt.validate(t, sql)
 		})
 	}
+}
+
+func TestDuckDBDialectAddColumnPreservesRequiredness(t *testing.T) {
+	dialect := &Dialect{}
+	require.Equal(
+		t,
+		`ALTER TABLE "main"."events" ADD COLUMN "required" BIGINT; ALTER TABLE "main"."events" ALTER COLUMN "required" SET NOT NULL`,
+		dialect.AddColumnSQL("main.events", schema.Column{Name: "required", DataType: schema.TypeInt64}),
+	)
+	require.Equal(
+		t,
+		`ALTER TABLE "main"."events" ADD COLUMN "optional" BIGINT`,
+		dialect.AddColumnSQL("main.events", schema.Column{Name: "optional", DataType: schema.TypeInt64, Nullable: true}),
+	)
+}
+
+func TestDuckDBDialectRequiredAddColumnExecutes(t *testing.T) {
+	ctx := context.Background()
+	dest, path := connectTestDuckDB(t, ctx)
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE required_add (id BIGINT)`))
+	require.NoError(t, dest.Exec(ctx, (&Dialect{}).AddColumnSQL("required_add", schema.Column{
+		Name: "required_value", DataType: schema.TypeInt64, Nullable: false,
+	})))
+
+	db := openDuckDB(t, ctx, path)
+	var nullable string
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT is_nullable FROM information_schema.columns
+		WHERE table_name='required_add' AND column_name='required_value'
+	`).Scan(&nullable))
+	require.Equal(t, "NO", nullable)
 }
 
 func TestStrategySupport(t *testing.T) {
@@ -620,6 +650,19 @@ func TestPrepareTable_CreateTable(t *testing.T) {
 	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'test_table'").Scan(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "table should exist")
+	var required, optional string
+	err = db.QueryRowContext(ctx, `
+		SELECT is_nullable FROM information_schema.columns
+		WHERE table_name = 'test_table' AND column_name = 'id'
+	`).Scan(&required)
+	require.NoError(t, err)
+	err = db.QueryRowContext(ctx, `
+		SELECT is_nullable FROM information_schema.columns
+		WHERE table_name = 'test_table' AND column_name = 'name'
+	`).Scan(&optional)
+	require.NoError(t, err)
+	assert.Equal(t, "NO", required)
+	assert.Equal(t, "YES", optional)
 }
 
 func TestPrepareTable_DropFirst(t *testing.T) {

--- a/pkg/destination/dynamodb/dynamodb.go
+++ b/pkg/destination/dynamodb/dynamodb.go
@@ -540,7 +540,7 @@ func (d *DynamoDBDestination) mergeCDC(ctx context.Context, opts destination.Mer
 				entry.latestLSN = lsn
 				entry.latestDeleted = deleted
 			}
-			if !deleted && (entry.active == nil || lsn > entry.activeLSN) {
+			if !deleted && (entry.active == nil || destination.CompareCDCPositions(lsn, entry.activeLSN) > 0) {
 				entry.active = item
 				entry.activeLSN = lsn
 			}

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -880,7 +880,11 @@ func escapeTableName(table string) string {
 func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
 	var colDefs []string
 	for _, col := range columns {
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), MapDataTypeToFabric(col)))
+		colDef := fmt.Sprintf("%s %s", quoteColumn(col.Name), MapDataTypeToFabric(col))
+		if !col.Nullable {
+			colDef += " NOT NULL"
+		}
+		colDefs = append(colDefs, colDef)
 	}
 
 	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -13,6 +13,21 @@ import (
 	mssqldb "github.com/microsoft/go-mssqldb"
 )
 
+func TestBuildCreateTableSQLPreservesRequiredness(t *testing.T) {
+	got := buildCreateTableSQL("dbo.events", []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}, []string{"id"})
+
+	want := "IF OBJECT_ID('dbo.events', 'U') IS NULL CREATE TABLE [dbo].[events] (\n" +
+		"  [id] BIGINT NOT NULL,\n" +
+		"  [name] VARCHAR(MAX),\n" +
+		"  PRIMARY KEY NONCLUSTERED ([id]) NOT ENFORCED\n)"
+	if got != want {
+		t.Fatalf("buildCreateTableSQL() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestURIToConnString(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -1705,7 +1705,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := mapColumnTypeForCreate(col, primaryKeySet[col.Name])
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
+		colDef := fmt.Sprintf("%s %s", quoteColumn(col.Name), colType)
+		if !col.Nullable {
+			colDef += " NOT NULL"
+		}
+		colDefs = append(colDefs, colDef)
 	}
 
 	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -536,6 +536,21 @@ func TestFilterColumnsRetainsOrdinaryCaseInsensitiveMSSQLMatching(t *testing.T) 
 	}
 }
 
+func TestBuildCreateTableSQL_PreservesRequiredness(t *testing.T) {
+	got := buildCreateTableSQL("dbo.events", []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}, []string{"id"})
+
+	want := "IF OBJECT_ID('[dbo].[events]', 'U') IS NULL CREATE TABLE [dbo].[events] (\n" +
+		"  [id] BIGINT NOT NULL,\n" +
+		"  [name] NVARCHAR(MAX),\n" +
+		"  PRIMARY KEY ([id])\n)"
+	if got != want {
+		t.Fatalf("buildCreateTableSQL() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
 	sql := buildDeleteInsertDeleteSQL("dbo.events", "updated_at")
 

--- a/pkg/destination/multitable/router.go
+++ b/pkg/destination/multitable/router.go
@@ -20,6 +20,7 @@ type Router struct {
 	done          chan struct{}
 	err           error
 	errMu         sync.RWMutex
+	drainTimeout  time.Duration
 }
 
 // NewRouter creates a router for the specified tables.
@@ -32,6 +33,7 @@ func NewRouter(tables []string, bufferSize int) *Router {
 		tableChannels: make(map[string]chan source.RecordBatchResult),
 		bufferSize:    bufferSize,
 		done:          make(chan struct{}),
+		drainTimeout:  routerDrainTimeout,
 	}
 
 	for _, table := range tables {
@@ -44,7 +46,7 @@ func NewRouter(tables []string, bufferSize int) *Router {
 // Route starts routing batches from the input channel to per-table channels.
 // This method should be called once and runs asynchronously.
 // It closes all table channels when the input channel is exhausted or an error occurs.
-func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResult, drainOnCancel bool) {
+func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResult, drainOnCancel ...bool) {
 	r.mu.Lock()
 	if r.started {
 		r.mu.Unlock()
@@ -52,6 +54,7 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 	}
 	r.started = true
 	r.mu.Unlock()
+	shouldDrain := len(drainOnCancel) > 0 && drainOnCancel[0]
 
 	go func() {
 		aborted := false
@@ -63,7 +66,7 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 			case <-ctx.Done():
 				aborted = true
 				r.setError(ctx.Err())
-				if drainOnCancel {
+				if shouldDrain {
 					r.drainInput(input)
 				}
 				return
@@ -73,11 +76,10 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 				}
 
 				if result.Err != nil {
-					aborted = true
 					r.setError(result.Err)
-					r.broadcastError(result.Err)
+					r.broadcastError(ctx, result.Err)
 					releaseResult(result)
-					if drainOnCancel {
+					if shouldDrain {
 						r.drainInput(input)
 					}
 					return
@@ -95,7 +97,7 @@ func (r *Router) Route(ctx context.Context, input <-chan source.RecordBatchResul
 					aborted = true
 					r.setError(ctx.Err())
 					releaseResult(result)
-					if drainOnCancel {
+					if shouldDrain {
 						r.drainInput(input)
 					}
 					return
@@ -133,11 +135,12 @@ func (r *Router) setError(err error) {
 	r.errMu.Unlock()
 }
 
-func (r *Router) broadcastError(err error) {
+func (r *Router) broadcastError(ctx context.Context, err error) {
 	for _, ch := range r.tableChannels {
 		select {
 		case ch <- source.RecordBatchResult{Err: err}:
-		default:
+		case <-ctx.Done():
+			return
 		}
 	}
 }
@@ -156,7 +159,7 @@ func (r *Router) closeChannels(drain bool) {
 }
 
 func (r *Router) drainInput(input <-chan source.RecordBatchResult) {
-	timer := time.NewTimer(routerDrainTimeout)
+	timer := time.NewTimer(r.drainTimeout)
 	defer timer.Stop()
 	for {
 		select {

--- a/pkg/destination/multitable/router_test.go
+++ b/pkg/destination/multitable/router_test.go
@@ -1,0 +1,89 @@
+package multitable
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestRouterDeliversSourceErrorToFullTableChannels(t *testing.T) {
+	sourceErr := errors.New("source failed")
+	input := make(chan source.RecordBatchResult, 3)
+	input <- source.RecordBatchResult{TableName: "users"}
+	input <- source.RecordBatchResult{TableName: "orders"}
+	input <- source.RecordBatchResult{Err: sourceErr}
+	close(input)
+
+	router := NewRouter([]string{"users", "orders"}, 1)
+	router.Route(context.Background(), input)
+
+	deadline := time.Now().Add(time.Second)
+	for router.Err() == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !errors.Is(router.Err(), sourceErr) {
+		t.Fatalf("Router.Err() = %v, want source error", router.Err())
+	}
+
+	select {
+	case <-router.done:
+		t.Fatal("router completed before it could deliver the source error to full channels")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	users := router.GetChannel("users")
+	orders := router.GetChannel("orders")
+	if result := <-users; result.Err != nil {
+		t.Fatalf("first users result error = %v, want data result", result.Err)
+	}
+	if result := <-orders; result.Err != nil {
+		t.Fatalf("first orders result error = %v, want data result", result.Err)
+	}
+
+	usersErr, usersOpen := <-users
+	ordersErr, ordersOpen := <-orders
+	if !usersOpen || !errors.Is(usersErr.Err, sourceErr) {
+		t.Fatalf("users terminal result = (%+v, open=%v), want source error", usersErr, usersOpen)
+	}
+	if !ordersOpen || !errors.Is(ordersErr.Err, sourceErr) {
+		t.Fatalf("orders terminal result = (%+v, open=%v), want source error", ordersErr, ordersOpen)
+	}
+
+	router.Wait()
+	if _, open := <-users; open {
+		t.Fatal("users channel remained open after terminal error")
+	}
+	if _, open := <-orders; open {
+		t.Fatal("orders channel remained open after terminal error")
+	}
+}
+
+func TestRouterReleasesBatchForUnknownTable(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	builder := array.NewInt64Builder(mem)
+	builder.Append(1)
+	values := builder.NewArray()
+	record := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil),
+		[]arrow.Array{values},
+		1,
+	)
+	values.Release()
+	builder.Release()
+
+	input := make(chan source.RecordBatchResult, 1)
+	input <- source.RecordBatchResult{TableName: "unknown", Batch: record}
+	close(input)
+
+	router := NewRouter([]string{"known"}, 1)
+	router.Route(context.Background(), input)
+	router.Wait()
+}

--- a/pkg/destination/multitable/writer.go
+++ b/pkg/destination/multitable/writer.go
@@ -64,6 +64,9 @@ func WriteWithResult(
 	}
 
 	router := NewRouter(tables, 8)
+	if opts.CancelDrainTimeout > 0 {
+		router.drainTimeout = opts.CancelDrainTimeout
+	}
 	router.Route(writeCtx, records, opts.CancelSource != nil)
 
 	var wg sync.WaitGroup
@@ -84,24 +87,49 @@ func WriteWithResult(
 			if ch == nil {
 				return
 			}
+			defer drainAndRelease(ch)
 
-			truncated, err := destination.WriteWithTruncateBoundariesAfterCancel(writeCtx, dest, ch, destination.WriteOptions{
-				Table:            tableConfig.DestTable,
-				Schema:           tableConfig.Schema,
-				PrimaryKeys:      tableConfig.PrimaryKeys,
-				Parallelism:      parallelism,
-				StagingTable:     opts.StagingTable,
-				StagingBucket:    opts.StagingBucket,
-				LoaderFileSize:   opts.LoaderFileSize,
-				LoaderFileFormat: opts.LoaderFileFormat,
-			}, cancelInput)
+			cancelAfterWriteError := func() {
+				if router.Err() == nil {
+					cancelInput()
+				}
+			}
+			writeOpts := destination.WriteOptions{
+				Table:                  tableConfig.DestTable,
+				Schema:                 tableConfig.Schema,
+				PrimaryKeys:            tableConfig.PrimaryKeys,
+				Parallelism:            parallelism,
+				StagingTable:           opts.StagingTable,
+				StagingBucket:          opts.StagingBucket,
+				LoaderFileSize:         opts.LoaderFileSize,
+				LoaderFileFormat:       opts.LoaderFileFormat,
+				DeduplicatePrimaryKeys: tableConfig.DeduplicatePrimaryKeys,
+				IncrementalKey:         tableConfig.IncrementalKey,
+				SkipCDCResume:          tableConfig.SkipCDCResume,
+				CDCExpectedIncarnation: tableConfig.CDCExpectedIncarnation,
+			}
+			var truncated bool
+			var err error
+			if opts.TableWriter != nil {
+				truncated, err = opts.TableWriter(writeCtx, table, ch, writeOpts)
+			} else if tableConfig.CDCMode {
+				truncated, err = destination.WriteWithTruncateBoundariesAfterCancel(writeCtx, dest, ch, writeOpts, cancelAfterWriteError)
+			} else {
+				err = dest.WriteParallel(writeCtx, ch, writeOpts)
+				if err != nil {
+					cancelAfterWriteError()
+				}
+			}
 			if truncated {
 				resultMu.Lock()
 				result.TruncatedTables[table] = true
 				resultMu.Unlock()
 			}
 			if err != nil {
-				cancelInput()
+				routerErr := router.Err()
+				if routerErr == nil || !errors.Is(err, routerErr) {
+					cancelInput()
+				}
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return
 				}
@@ -132,4 +160,12 @@ func WriteWithResult(
 
 	config.Debug("[MULTITABLE] Multi-table write completed in %v", time.Since(startTotal))
 	return result, nil
+}
+
+func drainAndRelease(records <-chan source.RecordBatchResult) {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
 }

--- a/pkg/destination/multitable/writer_test.go
+++ b/pkg/destination/multitable/writer_test.go
@@ -3,6 +3,7 @@ package multitable
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -153,6 +154,36 @@ func TestWriteCancelsOtherTablesOnFirstError(t *testing.T) {
 	}
 }
 
+func TestWritePropagatesSkipCDCResume(t *testing.T) {
+	var got destination.WriteOptions
+	dest := &fakeDestination{writeFn: func(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+		got = opts
+		for result := range records {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+		}
+		return nil
+	}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+
+	_, err := WriteWithResult(t.Context(), dest, records, destination.MultiTableWriteOptions{
+		TableConfigs: map[string]destination.TableWriteConfig{
+			"events": {DestTable: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "bound-table-uuid"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.SkipCDCResume {
+		t.Fatal("managed multi-table write did not propagate SkipCDCResume")
+	}
+	if got.CDCExpectedIncarnation != "bound-table-uuid" {
+		t.Fatalf("managed multi-table expected incarnation = %q, want bound-table-uuid", got.CDCExpectedIncarnation)
+	}
+}
+
 // TestWriteRouterDeadlock reproduces the exact deadlock pattern:
 // interleaved records for two tables, one writer fails after first record.
 // Without cancellation propagation, the router blocks sending to the failed
@@ -291,6 +322,69 @@ func TestWriteFailureReturnsWhenCanceledProducerNeverCloses(t *testing.T) {
 	}
 }
 
+func TestWriteDeliversSourceErrorToEveryFullTableChannel(t *testing.T) {
+	sourceErr := errors.New("source failed")
+	startReading := make(chan struct{})
+
+	dest := &fakeDestination{
+		writeFn: func(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+			select {
+			case <-startReading:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			for result := range records {
+				if result.Err != nil {
+					return fmt.Errorf("source stream: %w", result.Err)
+				}
+			}
+			return nil
+		},
+	}
+
+	records := make(chan source.RecordBatchResult, 17)
+	for range 8 {
+		records <- source.RecordBatchResult{TableName: "users"}
+		records <- source.RecordBatchResult{TableName: "orders"}
+	}
+	records <- source.RecordBatchResult{Err: sourceErr}
+	close(records)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Write(context.Background(), dest, records, destination.MultiTableWriteOptions{
+			TableConfigs: map[string]destination.TableWriteConfig{
+				"users":  {DestTable: "dataset.users"},
+				"orders": {DestTable: "dataset.orders"},
+			},
+		})
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for len(records) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(records) != 0 {
+		t.Fatal("router did not reach the source error while table channels were full")
+	}
+	time.Sleep(20 * time.Millisecond)
+	close(startReading)
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), sourceErr.Error()) {
+			t.Fatalf("Write error = %v, want source error", err)
+		}
+		for _, table := range []string{"users", "orders"} {
+			if !strings.Contains(err.Error(), "table "+table+":") {
+				t.Errorf("Write error = %v, want source error from table %s", err, table)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write deadlocked while delivering a source error to full table channels")
+	}
+}
+
 // TestWriteDoesNotDeadlockWithScarceSharedResourceScopedPerBatch models the
 // Snowflake connection-pool exhaustion deadlock generically: many tables
 // each spawn several workers (numTables * parallelism exceeds the size of a
@@ -407,7 +501,7 @@ func TestWriteWithResultSplitsTableAtTruncate(t *testing.T) {
 
 	result, err := WriteWithResult(context.Background(), dest, records, destination.MultiTableWriteOptions{
 		TableConfigs: map[string]destination.TableWriteConfig{
-			"items": {DestTable: "raw.items"},
+			"items": {DestTable: "raw.items", CDCMode: true},
 		},
 	})
 	if err != nil {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -1493,7 +1493,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 		if binaryClaimKey && col.Name == "destination_table" {
 			colType += " CHARACTER SET ascii COLLATE ascii_bin"
 		}
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf("%s %s%s", quoteColumn(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -612,7 +612,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 				{Name: "name", DataType: schema.TypeString, Nullable: true},
 			},
 			primaryKeys: nil,
-			want:        "CREATE TABLE IF NOT EXISTS `users` (\n  `id` BIGINT,\n  `name` TEXT\n)",
+			want:        "CREATE TABLE IF NOT EXISTS `users` (\n  `id` BIGINT NOT NULL,\n  `name` TEXT\n)",
 		},
 		{
 			name:  "table with primary key",
@@ -622,7 +622,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 				{Name: "name", DataType: schema.TypeString, Nullable: true},
 			},
 			primaryKeys: []string{"id"},
-			want:        "CREATE TABLE IF NOT EXISTS `users` (\n  `id` BIGINT,\n  `name` TEXT,\n  PRIMARY KEY (`id`)\n)",
+			want:        "CREATE TABLE IF NOT EXISTS `users` (\n  `id` BIGINT NOT NULL,\n  `name` TEXT,\n  PRIMARY KEY (`id`)\n)",
 		},
 		{
 			name:  "table with composite primary key",
@@ -633,7 +633,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 				{Name: "created_at", DataType: schema.TypeTimestamp, Nullable: true},
 			},
 			primaryKeys: []string{"user_id", "post_id"},
-			want:        "CREATE TABLE IF NOT EXISTS `user_posts` (\n  `user_id` BIGINT,\n  `post_id` BIGINT,\n  `created_at` DATETIME(6),\n  PRIMARY KEY (`user_id`, `post_id`)\n)",
+			want:        "CREATE TABLE IF NOT EXISTS `user_posts` (\n  `user_id` BIGINT NOT NULL,\n  `post_id` BIGINT NOT NULL,\n  `created_at` DATETIME(6),\n  PRIMARY KEY (`user_id`, `post_id`)\n)",
 		},
 		{
 			name:  "schema qualified table",
@@ -642,7 +642,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 				{Name: "id", DataType: schema.TypeInt64, Nullable: false},
 			},
 			primaryKeys: nil,
-			want:        "CREATE TABLE IF NOT EXISTS `mydb`.`users` (\n  `id` BIGINT\n)",
+			want:        "CREATE TABLE IF NOT EXISTS `mydb`.`users` (\n  `id` BIGINT NOT NULL\n)",
 		},
 		{
 			name:  "table with various types",
@@ -656,7 +656,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 				{Name: "created_at", DataType: schema.TypeTimestampTZ, Nullable: true},
 			},
 			primaryKeys: []string{"id"},
-			want:        "CREATE TABLE IF NOT EXISTS `test_table` (\n  `id` BIGINT,\n  `name` TEXT,\n  `active` BOOLEAN,\n  `score` DOUBLE,\n  `amount` DECIMAL(10,2),\n  `created_at` TIMESTAMP(6),\n  PRIMARY KEY (`id`)\n)",
+			want:        "CREATE TABLE IF NOT EXISTS `test_table` (\n  `id` BIGINT NOT NULL,\n  `name` TEXT,\n  `active` BOOLEAN NOT NULL,\n  `score` DOUBLE,\n  `amount` DECIMAL(10,2),\n  `created_at` TIMESTAMP(6),\n  PRIMARY KEY (`id`)\n)",
 		},
 	}
 

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -1078,7 +1078,11 @@ func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryK
 	colDefs := make([]string, 0, len(columns)+1)
 	for _, col := range columns {
 		isComparableString := col.IsPrimaryKey || comparableColumns[col.Name]
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), mapDataTypeToOracle(col, isComparableString)))
+		colDef := fmt.Sprintf("%s %s", quoteColumn(col.Name), mapDataTypeToOracle(col, isComparableString))
+		if !col.Nullable {
+			colDef += " NOT NULL"
+		}
+		colDefs = append(colDefs, colDef)
 	}
 	if len(primaryKeys) > 0 {
 		quotedKeys := quoteColumns(primaryKeys)

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -196,7 +196,7 @@ func TestOracleStagingNamesEncodeQuotedTableDots(t *testing.T) {
 			require.Len(t, parts, 2)
 			require.Equal(t, `"appUser"`, parts[0])
 			require.NotContains(t, parts[1], ".")
-			require.Contains(t, quoteTable(staging), `"appUser"."_INGESTR_HEX_`)
+			require.Contains(t, quoteTable(staging), `"appUser"."INGESTR_HEX_`)
 		})
 	}
 }

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -307,9 +307,9 @@ func TestMapDataTypeToOracle(t *testing.T) {
 func TestBuildCreateTableSQL(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{
-			{Name: "id", DataType: schema.TypeInt64},
-			{Name: "name", DataType: schema.TypeString, MaxLength: 100},
-			{Name: "created_at", DataType: schema.TypeTimestampTZ},
+			{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, MaxLength: 100, Nullable: true},
+			{Name: "created_at", DataType: schema.TypeTimestampTZ, Nullable: true},
 		},
 	}
 
@@ -323,11 +323,26 @@ func TestBuildCreateTableSQL(t *testing.T) {
 )`, got)
 }
 
+func TestBuildCreateTableSQLPreservesRequiredness(t *testing.T) {
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}}
+
+	got := buildCreateTableSQL("analytics.users", tableSchema, []string{"id"})
+
+	assert.Equal(t, `CREATE TABLE "ANALYTICS"."USERS" (
+  "ID" NUMBER(19,0) NOT NULL,
+  "NAME" CLOB,
+  PRIMARY KEY ("ID")
+)`, got)
+}
+
 func TestBuildCreateTableSQL_StringPrimaryKeyUsesVarchar(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{
-			{Name: "id", DataType: schema.TypeString},
-			{Name: "name", DataType: schema.TypeString},
+			{Name: "id", DataType: schema.TypeString, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
 		},
 	}
 
@@ -343,9 +358,9 @@ func TestBuildCreateTableSQL_StringPrimaryKeyUsesVarchar(t *testing.T) {
 func TestBuildCreateTableSQL_StringIncrementalKeyUsesVarchar(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{
-			{Name: "id", DataType: schema.TypeInt64},
-			{Name: "cursor", DataType: schema.TypeString},
-			{Name: "name", DataType: schema.TypeString},
+			{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "cursor", DataType: schema.TypeString, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
 		},
 		IncrementalKey: "cursor",
 	}
@@ -363,8 +378,8 @@ func TestBuildCreateTableSQL_StringIncrementalKeyUsesVarchar(t *testing.T) {
 func TestBuildCreateTableSQL_SchemaPrimaryKeyUsesVarcharWithoutConstraint(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{
-			{Name: "id", DataType: schema.TypeString},
-			{Name: "name", DataType: schema.TypeString},
+			{Name: "id", DataType: schema.TypeString, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
 		},
 		PrimaryKeys: []string{"id"},
 	}

--- a/pkg/destination/postgres/dialect.go
+++ b/pkg/destination/postgres/dialect.go
@@ -20,10 +20,15 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+	nullability := ""
+	if !col.Nullable {
+		nullability = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s%s",
 		destination.QuoteTableName(table),
 		d.QuoteIdentifier(col.Name),
-		d.TypeName(col))
+		d.TypeName(col),
+		nullability)
 }
 
 func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {
@@ -39,6 +44,11 @@ func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Colum
 
 func (d *Dialect) SupportsAlterType() bool {
 	return true
+}
+
+func (d *Dialect) RelaxColumnNullabilitySQL(table, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL",
+		destination.QuoteTableName(table), d.QuoteIdentifier(colName))
 }
 
 func (d *Dialect) TypeName(col schema.Column) string {
@@ -69,6 +79,8 @@ func (d *Dialect) TypeName(col schema.Column) string {
 		return "TEXT"
 	case schema.TypeBinary:
 		return "BYTEA"
+	case schema.TypeFixedBinary:
+		return "BYTEA"
 	case schema.TypeDate:
 		return "DATE"
 	case schema.TypeTime:
@@ -84,8 +96,7 @@ func (d *Dialect) TypeName(col schema.Column) string {
 	case schema.TypeUUID:
 		return "UUID"
 	case schema.TypeArray:
-		elemCol := schema.Column{DataType: col.ArrayType}
-		return d.TypeName(elemCol) + "[]"
+		return d.TypeName(postgresArrayElementColumn(col)) + "[]"
 	default:
 		return "TEXT"
 	}

--- a/pkg/destination/postgres/mapper.go
+++ b/pkg/destination/postgres/mapper.go
@@ -35,6 +35,8 @@ func MapDataTypeToPostgres(col schema.Column) string {
 		return "TEXT"
 	case schema.TypeBinary:
 		return "BYTEA"
+	case schema.TypeFixedBinary:
+		return "BYTEA"
 	case schema.TypeDate:
 		return "DATE"
 	case schema.TypeTime:
@@ -50,9 +52,18 @@ func MapDataTypeToPostgres(col schema.Column) string {
 	case schema.TypeUUID:
 		return "UUID"
 	case schema.TypeArray:
-		elemCol := schema.Column{DataType: col.ArrayType}
-		return MapDataTypeToPostgres(elemCol) + "[]"
+		return MapDataTypeToPostgres(postgresArrayElementColumn(col)) + "[]"
 	default:
 		return "TEXT"
+	}
+}
+
+func postgresArrayElementColumn(col schema.Column) schema.Column {
+	if col.Element != nil {
+		return *col.Element
+	}
+	return schema.Column{
+		DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale,
+		MaxLength: col.MaxLength, FixedLength: col.FixedLength, Nullable: true,
 	}
 }

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -1369,6 +1369,9 @@ func (d *PostgresDestination) GetTableSchema(ctx context.Context, table string) 
 			DataType: mapPostgresTypeToSchema(dataType, udtName),
 			Nullable: isNullable == "YES",
 		}
+		if col.DataType == schema.TypeArray {
+			col.ArrayType = mapPostgresArrayElementTypeToSchema(udtName)
+		}
 
 		if numPrecision != nil {
 			col.Precision = *numPrecision
@@ -1399,22 +1402,22 @@ func (d *PostgresDestination) GetTableSchema(ctx context.Context, table string) 
 }
 
 func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
-	switch dataType {
-	case "boolean":
+	switch strings.ToLower(strings.TrimSpace(dataType)) {
+	case "boolean", "bool":
 		return schema.TypeBoolean
-	case "smallint":
+	case "smallint", "int2":
 		return schema.TypeInt16
-	case "integer":
+	case "integer", "int", "int4":
 		return schema.TypeInt32
-	case "bigint":
+	case "bigint", "int8":
 		return schema.TypeInt64
-	case "real":
+	case "real", "float4":
 		return schema.TypeFloat32
-	case "double precision":
+	case "double precision", "float8":
 		return schema.TypeFloat64
 	case "numeric", "decimal":
 		return schema.TypeDecimal
-	case "character varying", "varchar", "character", "char", "text":
+	case "character varying", "varchar", "character", "char", "text", "bpchar", "name":
 		return schema.TypeString
 	case "bytea":
 		return schema.TypeBinary
@@ -1424,7 +1427,7 @@ func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
 		return schema.TypeTime
 	case "timestamp", "timestamp without time zone":
 		return schema.TypeTimestamp
-	case "timestamp with time zone":
+	case "timestamp with time zone", "timestamptz":
 		return schema.TypeTimestampTZ
 	case "interval":
 		return schema.TypeInterval
@@ -1432,7 +1435,7 @@ func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
 		return schema.TypeJSON
 	case "uuid":
 		return schema.TypeUUID
-	case "ARRAY":
+	case "array":
 		return schema.TypeArray
 	default:
 		if strings.HasPrefix(udtName, "_") {
@@ -1440,6 +1443,11 @@ func mapPostgresTypeToSchema(dataType, udtName string) schema.DataType {
 		}
 		return schema.TypeString
 	}
+}
+
+func mapPostgresArrayElementTypeToSchema(udtName string) schema.DataType {
+	elementType := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(udtName)), "_")
+	return mapPostgresTypeToSchema(elementType, "")
 }
 
 // quoteColumns returns column names wrapped in double quotes.
@@ -1532,7 +1540,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToPostgres(col)
-		colDefs = append(colDefs, fmt.Sprintf(`%s %s`, destination.QuoteIdentifier(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf(`%s %s%s`, destination.QuoteIdentifier(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", table, strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -586,6 +586,35 @@ func (d *PostgresDestination) SwapTable(ctx context.Context, opts destination.Sw
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	if opts.CDCExpectedIncarnation != "" {
+		if opts.CDCExpectedStagingIncarnation == "" {
+			return fmt.Errorf("cannot conditionally swap managed CDC target %s without a bound staging incarnation", targetTable)
+		}
+		lockRefs := []string{targetRef, stagingRef}
+		slices.Sort(lockRefs)
+		if _, err := tx.Exec(ctx, "LOCK TABLE "+strings.Join(lockRefs, ", ")+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+			return fmt.Errorf("failed to lock managed CDC target and staging tables before swap: %w", err)
+		}
+		for _, expected := range []struct {
+			table       string
+			ref         string
+			incarnation string
+			role        string
+		}{
+			{table: targetTable, ref: targetRef, incarnation: opts.CDCExpectedIncarnation, role: "target"},
+			{table: stagingTable, ref: stagingRef, incarnation: opts.CDCExpectedStagingIncarnation, role: "staging table"},
+		} {
+			current, exists, err := d.postgresTargetIncarnation(ctx, tx, expected.ref)
+			if err != nil {
+				return err
+			}
+			if !exists || current != expected.incarnation {
+				return fmt.Errorf("PostgreSQL CDC %s %q physical incarnation changed before swap", expected.role, expected.table)
+			}
+		}
+	} else if opts.CDCExpectedStagingIncarnation != "" {
+		return fmt.Errorf("cannot conditionally swap staging table without a bound target incarnation")
+	}
 
 	// Postgres' ALTER TABLE … RENAME TO … is same-schema only. If staging lives in a
 	// different schema (the new _bruin_staging design), move it into the target's
@@ -740,6 +769,23 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
+	if opts.CDCExpectedIncarnation != "" {
+		targetSchema, targetName, err := d.resolveSchemaTable(ctx, tx, opts.TargetTable)
+		if err != nil {
+			return err
+		}
+		quotedTargetTable = quotePostgresTable(targetSchema, targetName)
+		if _, err := tx.Exec(ctx, "LOCK TABLE "+quotedTargetTable+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+			return fmt.Errorf("failed to lock managed CDC target %s before merge: %w", opts.TargetTable, err)
+		}
+		current, exists, err := d.postgresTargetIncarnation(ctx, tx, quotedTargetTable)
+		if err != nil {
+			return err
+		}
+		if !exists || current != opts.CDCExpectedIncarnation {
+			return fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed before merge", opts.TargetTable)
+		}
+	}
 
 	if hasCDCDeleted {
 		// CDC mode: dedupe within the staging table and apply changes deterministically.
@@ -1057,6 +1103,10 @@ func (d *PostgresDestination) SupportsSCD2Strategy() bool { return true }
 // SupportsAtomicSwap returns true as PostgreSQL supports atomic table renames.
 func (d *PostgresDestination) SupportsAtomicSwap() bool { return true }
 
+func (d *PostgresDestination) SupportsCDCConditionalSwap() bool {
+	return true
+}
+
 // GetScheme returns the primary URI scheme for PostgreSQL.
 func (d *PostgresDestination) GetScheme() string { return "postgres" }
 
@@ -1124,7 +1174,7 @@ func (d *PostgresDestination) postgresTargetIncarnation(ctx context.Context, que
 	if err != nil {
 		return "", false, err
 	}
-	resolvedTable := destination.QuoteTableName(schemaName + "." + tableName)
+	resolvedTable := quotePostgresTable(schemaName, tableName)
 	var databaseOID, relationOID, relationKind string
 	err = queryer.QueryRow(ctx, `
 		SELECT d.oid::text, c.oid::text, c.relkind::text
@@ -1186,13 +1236,13 @@ func (d *PostgresDestination) ClaimAndPrepareEmptyCDCTarget(
 		return "", fmt.Errorf("destination table %q is already claimed by CDC connector %q", canonicalTarget, owner)
 	}
 	createSQL := strings.Replace(
-		buildCreateTableSQL(destination.QuoteTableName(schemaName+"."+tableName), opts.Schema.Columns, opts.PrimaryKeys),
+		buildCreateTableSQL(quotePostgresTable(schemaName, tableName), opts.Schema.Columns, opts.PrimaryKeys),
 		"CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1,
 	)
 	if _, err := tx.Exec(ctx, createSQL); err != nil {
 		return "", fmt.Errorf("failed to exclusively create CDC target: %w", err)
 	}
-	incarnation, exists, err := d.postgresTargetIncarnation(ctx, tx, schemaName+"."+tableName)
+	incarnation, exists, err := d.postgresTargetIncarnation(ctx, tx, quotePostgresTable(schemaName, tableName))
 	if err != nil {
 		return "", err
 	}
@@ -1215,18 +1265,18 @@ func (d *PostgresDestination) TruncateCDCTableIfIncarnation(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	resolved := schemaName + "." + tableName
-	if _, err := tx.Exec(ctx, "LOCK TABLE "+destination.QuoteTableName(resolved)+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+	resolvedRef := quotePostgresTable(schemaName, tableName)
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+resolvedRef+" IN ACCESS EXCLUSIVE MODE"); err != nil {
 		return err
 	}
-	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolved)
+	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolvedRef)
 	if err != nil {
 		return err
 	}
 	if !exists || current != expectedIncarnation {
 		return fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed", table)
 	}
-	if _, err := tx.Exec(ctx, "TRUNCATE TABLE "+destination.QuoteTableName(resolved)); err != nil {
+	if _, err := tx.Exec(ctx, "TRUNCATE TABLE "+resolvedRef); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -131,6 +131,78 @@ func TestPostgresSwapRejectsOverQualifiedNames(t *testing.T) {
 	}
 }
 
+func TestMapPostgresArrayElementTypeToSchema(t *testing.T) {
+	tests := []struct {
+		udtName string
+		want    schema.DataType
+	}{
+		{udtName: "_int4", want: schema.TypeInt32},
+		{udtName: "_text", want: schema.TypeString},
+		{udtName: "_numeric", want: schema.TypeDecimal},
+		{udtName: "_uuid", want: schema.TypeUUID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.udtName, func(t *testing.T) {
+			if got := mapPostgresArrayElementTypeToSchema(tt.udtName); got != tt.want {
+				t.Fatalf("mapPostgresArrayElementTypeToSchema(%q) = %v, want %v", tt.udtName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgresArrayDDLPreservesElementShape(t *testing.T) {
+	tests := []struct {
+		name string
+		col  schema.Column
+		want string
+	}{
+		{name: "bounded varchar", col: schema.Column{DataType: schema.TypeArray, Element: &schema.Column{DataType: schema.TypeString, MaxLength: 12}}, want: "VARCHAR(12)[]"},
+		{name: "decimal", col: schema.Column{DataType: schema.TypeArray, Element: &schema.Column{DataType: schema.TypeDecimal, Precision: 10, Scale: 2}}, want: "NUMERIC(10,2)[]"},
+		{name: "nested", col: schema.Column{DataType: schema.TypeArray, Element: &schema.Column{DataType: schema.TypeArray, Element: &schema.Column{DataType: schema.TypeInt32}}}, want: "INTEGER[][]"},
+		{name: "fixed binary", col: schema.Column{DataType: schema.TypeArray, Element: &schema.Column{DataType: schema.TypeFixedBinary, FixedLength: 16}}, want: "BYTEA[]"},
+		{name: "legacy decimal", col: schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 8, Scale: 3}, want: "NUMERIC(8,3)[]"},
+	}
+	dialect := &Dialect{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dialect.TypeName(tt.col); got != tt.want {
+				t.Fatalf("Dialect.TypeName() = %q, want %q", got, tt.want)
+			}
+			if got := MapDataTypeToPostgres(tt.col); got != tt.want {
+				t.Fatalf("MapDataTypeToPostgres() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgresDialectRelaxesNullability(t *testing.T) {
+	got := (&Dialect{}).RelaxColumnNullabilitySQL("public.events", "payload")
+	want := `ALTER TABLE "public"."events" ALTER COLUMN "payload" DROP NOT NULL`
+	if got != want {
+		t.Fatalf("RelaxColumnNullabilitySQL() = %q, want %q", got, want)
+	}
+}
+
+func TestPostgresRequirednessDDL(t *testing.T) {
+	got := buildCreateTableSQL(`"public"."events"`, []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "payload", DataType: schema.TypeString, Nullable: true},
+	}, nil)
+	want := "CREATE TABLE IF NOT EXISTS \"public\".\"events\" (\n  \"id\" BIGINT NOT NULL,\n  \"payload\" TEXT\n)"
+	if got != want {
+		t.Fatalf("buildCreateTableSQL() = %q, want %q", got, want)
+	}
+
+	dialect := &Dialect{}
+	if got := dialect.AddColumnSQL("public.events", schema.Column{Name: "required", DataType: schema.TypeInt64}); got != `ALTER TABLE "public"."events" ADD COLUMN "required" BIGINT NOT NULL` {
+		t.Fatalf("required AddColumnSQL() = %q", got)
+	}
+	if got := dialect.AddColumnSQL("public.events", schema.Column{Name: "optional", DataType: schema.TypeInt64, Nullable: true}); got != `ALTER TABLE "public"."events" ADD COLUMN "optional" BIGINT` {
+		t.Fatalf("optional AddColumnSQL() = %q", got)
+	}
+}
+
 func TestPostgresValueGetterMatchesArrowutilValue(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	t.Cleanup(func() { mem.AssertSize(t, 0) })

--- a/pkg/destination/postgres/swap_integration_test.go
+++ b/pkg/destination/postgres/swap_integration_test.go
@@ -65,4 +65,81 @@ func TestSwapTablePreservesQuotedDottedTargetBoundary(t *testing.T) {
 	require.Equal(t, int64(99), sentinelID)
 	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'order.events_old_%'`).Scan(&oldCount))
 	require.Zero(t, oldCount)
+
+	expected, exists, err := dest.CDCTargetIncarnation(ctx, `"public"."order.events"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.Exec(ctx, `
+		DROP TABLE "public"."order.events";
+		CREATE TABLE "public"."order.events" (id bigint);
+		INSERT INTO "public"."order.events" VALUES (3);
+		CREATE TABLE "public"."stale_swap_staging" (id bigint);
+		INSERT INTO "public"."stale_swap_staging" VALUES (4);
+	`))
+	expectedStaging, exists, err := dest.CDCTargetIncarnation(ctx, `"public"."stale_swap_staging"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	err = dest.SwapTable(ctx, destination.SwapOptions{
+		StagingTable:                  `"public"."stale_swap_staging"`,
+		TargetTable:                   `"public"."order.events"`,
+		CDCExpectedIncarnation:        expected,
+		CDCExpectedStagingIncarnation: expectedStaging,
+	})
+	require.ErrorContains(t, err, "physical incarnation changed before swap")
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id FROM "public"."order.events"`).Scan(&targetID))
+	require.Equal(t, int64(3), targetID)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE "public"."swap_target" (id bigint);
+		INSERT INTO "public"."swap_target" VALUES (10);
+		CREATE TABLE "public"."swap_staging" (id bigint);
+		INSERT INTO "public"."swap_staging" VALUES (20);
+	`))
+	expectedTarget, exists, err := dest.CDCTargetIncarnation(ctx, `"public"."swap_target"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	expectedStaging, exists, err = dest.CDCTargetIncarnation(ctx, `"public"."swap_staging"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.Exec(ctx, `
+		DROP TABLE "public"."swap_staging";
+		CREATE TABLE "public"."swap_staging" (id bigint);
+		INSERT INTO "public"."swap_staging" VALUES (30);
+	`))
+	err = dest.SwapTable(ctx, destination.SwapOptions{
+		StagingTable:                  `"public"."swap_staging"`,
+		TargetTable:                   `"public"."swap_target"`,
+		CDCExpectedIncarnation:        expectedTarget,
+		CDCExpectedStagingIncarnation: expectedStaging,
+	})
+	require.ErrorContains(t, err, "staging table")
+	require.ErrorContains(t, err, "physical incarnation changed before swap")
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id FROM "public"."swap_target"`).Scan(&targetID))
+	require.Equal(t, int64(10), targetID)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE "public"."merge_target" (id bigint PRIMARY KEY, value text);
+		INSERT INTO "public"."merge_target" VALUES (1, 'original');
+		CREATE TABLE "public"."merge_staging" (id bigint, value text);
+		INSERT INTO "public"."merge_staging" VALUES (1, 'ingestr');
+	`))
+	expectedTarget, exists, err = dest.CDCTargetIncarnation(ctx, `"public"."merge_target"`)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, dest.Exec(ctx, `
+		DROP TABLE "public"."merge_target";
+		CREATE TABLE "public"."merge_target" (id bigint PRIMARY KEY, value text);
+		INSERT INTO "public"."merge_target" VALUES (1, 'external');
+	`))
+	err = dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:           `"public"."merge_staging"`,
+		TargetTable:            `"public"."merge_target"`,
+		PrimaryKeys:            []string{"id"},
+		Columns:                []string{"id", "value"},
+		CDCExpectedIncarnation: expectedTarget,
+	})
+	require.ErrorContains(t, err, "physical incarnation changed before merge")
+	var value string
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT value FROM "public"."merge_target" WHERE id = 1`).Scan(&value))
+	require.Equal(t, "external", value)
 }

--- a/pkg/destination/redshift/dialect.go
+++ b/pkg/destination/redshift/dialect.go
@@ -16,10 +16,15 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+	nullability := ""
+	if !col.Nullable {
+		nullability = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s%s",
 		destination.QuoteTableName(table),
 		d.QuoteIdentifier(col.Name),
-		d.TypeName(col))
+		d.TypeName(col),
+		nullability)
 }
 
 func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {

--- a/pkg/destination/redshift/redshift_test.go
+++ b/pkg/destination/redshift/redshift_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,6 +15,16 @@ func TestValidateManagedCDCStateFailsClosed(t *testing.T) {
 	dest := NewRedshiftDestination()
 
 	require.ErrorContains(t, dest.ValidateManagedCDCState(), "does not support destination-managed PostgreSQL CDC state")
+}
+
+func TestRedshiftDialectAddColumnPreservesRequiredness(t *testing.T) {
+	dialect := &Dialect{}
+	if got, want := dialect.AddColumnSQL("public.events", schema.Column{Name: "required", DataType: schema.TypeInt64}), `ALTER TABLE "public"."events" ADD COLUMN "required" BIGINT NOT NULL`; got != want {
+		t.Fatalf("required AddColumnSQL() = %q, want %q", got, want)
+	}
+	if got, want := dialect.AddColumnSQL("public.events", schema.Column{Name: "optional", DataType: schema.TypeInt64, Nullable: true}), `ALTER TABLE "public"."events" ADD COLUMN "optional" BIGINT`; got != want {
+		t.Fatalf("optional AddColumnSQL() = %q, want %q", got, want)
+	}
 }
 
 type testRecord struct {

--- a/pkg/destination/schema_evolution.go
+++ b/pkg/destination/schema_evolution.go
@@ -42,6 +42,13 @@ type BatchColumnTypeAlterer interface {
 	BatchAlterColumnTypesSQL(table string, cols []schema.Column) string
 }
 
+// NullabilityRelaxer renders DDL that changes an existing required column to
+// optional. Dialects without this capability must fail evolution before data
+// is written whenever nullable source rows could reach a required column.
+type NullabilityRelaxer interface {
+	RelaxColumnNullabilitySQL(table, colName string) string
+}
+
 // BuildMigration turns an abstract schema comparison into the concrete DDL
 // statements (and human-readable warnings) for a dialect. It is dialect-
 // agnostic orchestration shared by SQL destinations; the dialect supplies the
@@ -57,6 +64,13 @@ func BuildMigration(dialect Dialect, table string, comparison *schemaevolution.S
 	var typeChangeColumns []schema.Column
 
 	for _, change := range comparison.Changes {
+		if len(change.ColumnPath) > 1 {
+			warnings = append(warnings, fmt.Sprintf(
+				"nested column change %q skipped: %s does not expose nested schema evolution",
+				change.ColumnName, dialect.Name(),
+			))
+			continue
+		}
 		switch change.Type {
 		case schemaevolution.ChangeAddColumn:
 			if canBatchAdd {
@@ -85,6 +99,14 @@ func BuildMigration(dialect Dialect, table string, comparison *schemaevolution.S
 					warnings = append(warnings, fmt.Sprintf("column %q: %s", change.ColumnName, warning))
 				}
 			}
+
+		case schemaevolution.ChangeRelaxNullability:
+			appendNullabilityRelaxation(dialect, table, change.ColumnName, &statements, &warnings)
+
+		case schemaevolution.ChangeRemoveColumn:
+			if change.OldColumn != nil && !change.OldColumn.Nullable {
+				appendNullabilityRelaxation(dialect, table, change.ColumnName, &statements, &warnings)
+			}
 		}
 	}
 
@@ -103,9 +125,51 @@ func BuildMigration(dialect Dialect, table string, comparison *schemaevolution.S
 	return statements, warnings
 }
 
+func appendNullabilityRelaxation(dialect Dialect, table, column string, statements, warnings *[]string) {
+	if relaxer, ok := dialect.(NullabilityRelaxer); ok {
+		if sql := relaxer.RelaxColumnNullabilitySQL(table, column); sql != "" {
+			*statements = append(*statements, sql)
+			return
+		}
+	}
+	*warnings = append(*warnings, fmt.Sprintf(
+		"column %q nullability relaxation skipped: %s does not expose nullability evolution",
+		column, dialect.Name(),
+	))
+}
+
 // ApplyEvolution renders the abstract schema-change plan into dialect-specific
 // DDL and executes each statement against the destination.
 func ApplyEvolution(ctx context.Context, dest Destination, dialect Dialect, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
+	if comparison != nil {
+		for _, change := range comparison.Changes {
+			if len(change.ColumnPath) > 1 {
+				return nil, fmt.Errorf(
+					"apply schema evolution: nested column change %q is not supported by generic %s DDL",
+					change.ColumnName, dialect.Name(),
+				)
+			}
+			if change.Type == schemaevolution.ChangeWidenType || change.Type == schemaevolution.ChangeOverrideType {
+				if !dialect.SupportsAlterType() || dialect.AlterColumnTypeSQL(table, change.ColumnName, change.NewColumn) == "" {
+					return nil, fmt.Errorf(
+						"apply schema evolution: column %q requires a type change, which generic %s DDL does not support",
+						change.ColumnName, dialect.Name(),
+					)
+				}
+			}
+			needsRelaxation := change.Type == schemaevolution.ChangeRelaxNullability ||
+				(change.Type == schemaevolution.ChangeRemoveColumn && change.OldColumn != nil && !change.OldColumn.Nullable)
+			if needsRelaxation {
+				relaxer, ok := dialect.(NullabilityRelaxer)
+				if !ok || relaxer.RelaxColumnNullabilitySQL(table, change.ColumnName) == "" {
+					return nil, fmt.Errorf(
+						"apply schema evolution: column %q requires nullability relaxation, which generic %s DDL does not support",
+						change.ColumnName, dialect.Name(),
+					)
+				}
+			}
+		}
+	}
 	statements, warnings := BuildMigration(dialect, table, comparison)
 	for _, stmt := range statements {
 		if err := dest.Exec(ctx, stmt); err != nil {

--- a/pkg/destination/schema_evolution_test.go
+++ b/pkg/destination/schema_evolution_test.go
@@ -1,6 +1,7 @@
 package destination_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,6 +12,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeExecDestination struct {
+	destination.Destination
+	statements []string
+}
+
+func (d *fakeExecDestination) Exec(_ context.Context, stmt string, _ ...interface{}) error {
+	d.statements = append(d.statements, stmt)
+	return nil
+}
 
 // fakeDialect is a minimal destination.Dialect for exercising BuildMigration.
 type fakeDialect struct {
@@ -77,9 +88,85 @@ func widenComparison() *schemaevolution.SchemaComparison {
 		Changes: []schemaevolution.SchemaChange{
 			{Type: schemaevolution.ChangeAddColumn, ColumnName: "added", NewColumn: schema.Column{Name: "added", DataType: schema.TypeString, Nullable: true}},
 			{Type: schemaevolution.ChangeWidenType, ColumnName: "val", OldColumn: &schema.Column{Name: "val", DataType: schema.TypeInt32}, NewColumn: schema.Column{Name: "val", DataType: schema.TypeInt64, Nullable: true}},
-			{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "gone", OldColumn: &schema.Column{Name: "gone", DataType: schema.TypeString}},
+			{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "gone", OldColumn: &schema.Column{Name: "gone", DataType: schema.TypeString, Nullable: true}},
 		},
 	}
+}
+
+type fakeNullableDialect struct{ fakeDialect }
+
+func (d *fakeNullableDialect) RelaxColumnNullabilitySQL(table, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL", table, d.QuoteIdentifier(colName))
+}
+
+func TestBuildMigrationRelaxesNullabilityAndSoftRemovedRequiredColumns(t *testing.T) {
+	required := schema.Column{Name: "removed", DataType: schema.TypeString, Nullable: false}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional"},
+		{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "removed", OldColumn: &required},
+	}}
+	statements, warnings := destination.BuildMigration(&fakeNullableDialect{}, "events", comparison)
+	require.Empty(t, warnings)
+	require.Equal(t, []string{
+		`ALTER TABLE events ALTER COLUMN "optional" DROP NOT NULL`,
+		`ALTER TABLE events ALTER COLUMN "removed" DROP NOT NULL`,
+	}, statements)
+}
+
+func TestBuildMigrationWarnsWhenNullabilityRelaxationIsUnsupported(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional",
+	}}}
+	statements, warnings := destination.BuildMigration(&fakeDialect{}, "events", comparison)
+	require.Empty(t, statements)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "does not expose nullability evolution")
+}
+
+func TestApplyEvolutionRejectsUnsupportedNullabilityBeforeExecutingDDL(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{Type: schemaevolution.ChangeAddColumn, ColumnName: "new_col", NewColumn: schema.Column{Name: "new_col", DataType: schema.TypeString}},
+		{Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional"},
+	}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeDialect{}, "events", comparison)
+	require.ErrorContains(t, err, "requires nullability relaxation")
+	require.Empty(t, dest.statements, "validation must fail before an earlier add-column statement executes")
+}
+
+func TestApplyEvolutionExecutesSupportedNullabilityRelaxation(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRelaxNullability, ColumnName: "optional",
+	}}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeNullableDialect{}, "events", comparison)
+	require.NoError(t, err)
+	require.Equal(t, []string{`ALTER TABLE events ALTER COLUMN "optional" DROP NOT NULL`}, dest.statements)
+}
+
+func TestApplyEvolutionRejectsUnsupportedTypeChangeBeforeExecutingDDL(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{Type: schemaevolution.ChangeAddColumn, ColumnName: "new_col", NewColumn: schema.Column{Name: "new_col", DataType: schema.TypeString}},
+		{Type: schemaevolution.ChangeWidenType, ColumnName: "value", NewColumn: schema.Column{Name: "value", DataType: schema.TypeInt64}},
+	}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeDialect{supportsAlter: false}, "events", comparison)
+	require.ErrorContains(t, err, "requires a type change")
+	require.Empty(t, dest.statements, "validation must reject the complete migration before ADD COLUMN executes")
+}
+
+type emptyAlterDialect struct{ fakeDialect }
+
+func (*emptyAlterDialect) AlterColumnTypeSQL(string, string, schema.Column) string { return "" }
+
+func TestApplyEvolutionRejectsEmptyTypeAlterationBeforeExecutingDDL(t *testing.T) {
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeOverrideType, ColumnName: "value", NewColumn: schema.Column{Name: "value", DataType: schema.TypeString},
+	}}}
+	dest := &fakeExecDestination{}
+	_, err := destination.ApplyEvolution(context.Background(), dest, &emptyAlterDialect{fakeDialect{supportsAlter: true}}, "events", comparison)
+	require.ErrorContains(t, err, "requires a type change")
+	require.Empty(t, dest.statements)
 }
 
 func TestBuildMigration_NoChanges(t *testing.T) {

--- a/pkg/destination/snowflake/dialect.go
+++ b/pkg/destination/snowflake/dialect.go
@@ -15,10 +15,15 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+	nullability := ""
+	if !col.Nullable {
+		nullability = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s%s",
 		table,
 		d.QuoteIdentifier(col.Name),
-		d.TypeName(col))
+		d.TypeName(col),
+		nullability)
 }
 
 func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -1108,7 +1108,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToSnowflake(col)
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
+		colDef := fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType)
+		if !col.Nullable {
+			colDef += " NOT NULL"
+		}
+		colDefs = append(colDefs, colDef)
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", table, strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -24,6 +24,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildCreateTableSQLPreservesRequiredness(t *testing.T) {
+	got := buildCreateTableSQL(`"DB"."PUBLIC"."EVENTS"`, []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}, []string{"id"})
+
+	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "DB"."PUBLIC"."EVENTS" (
+  "ID" BIGINT NOT NULL,
+  "NAME" VARCHAR,
+  PRIMARY KEY ("ID")
+)`, got)
+}
+
 func TestBuildMergeSQL(t *testing.T) {
 	t.Run("non_cdc", func(t *testing.T) {
 		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, []string{"id", "name", "updated_at"}, "")
@@ -116,6 +129,14 @@ func TestBuildMergeSQL(t *testing.T) {
 		assert.Contains(t, sql, `WHEN MATCHED AND source."_CDC_DELETED" = true THEN`)
 		assert.Contains(t, sql, `WHEN NOT MATCHED AND (source."_CDC_DELETED" = false OR source."__ingestr_has_active") THEN`)
 	})
+}
+
+func TestSnowflakeDialectAddColumnPreservesRequiredness(t *testing.T) {
+	dialect := &Dialect{}
+	require.Equal(t, `ALTER TABLE DB.SCHEMA.EVENTS ADD COLUMN "REQUIRED" BIGINT NOT NULL`,
+		dialect.AddColumnSQL("DB.SCHEMA.EVENTS", schema.Column{Name: "required", DataType: schema.TypeInt64}))
+	require.Equal(t, `ALTER TABLE DB.SCHEMA.EVENTS ADD COLUMN "OPTIONAL" BIGINT`,
+		dialect.AddColumnSQL("DB.SCHEMA.EVENTS", schema.Column{Name: "optional", DataType: schema.TypeInt64, Nullable: true}))
 }
 
 func TestParseSchemaTable(t *testing.T) {

--- a/pkg/destination/sqlite/dialect.go
+++ b/pkg/destination/sqlite/dialect.go
@@ -16,10 +16,15 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+	nullability := ""
+	if !col.Nullable {
+		nullability = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s%s",
 		destination.QuoteTableName(table),
 		d.QuoteIdentifier(col.Name),
-		d.TypeName(col))
+		d.TypeName(col),
+		nullability)
 }
 
 func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {

--- a/pkg/destination/sqlite/requiredness_test.go
+++ b/pkg/destination/sqlite/requiredness_test.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+func TestSQLiteRequirednessDDL(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "required", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "optional", DataType: schema.TypeString, Nullable: true},
+	}
+	if got, want := buildCreateTableSQL(`"events"`, columns, nil), "CREATE TABLE IF NOT EXISTS \"events\" (\n  \"required\" INTEGER NOT NULL,\n  \"optional\" TEXT\n)"; got != want {
+		t.Fatalf("buildCreateTableSQL() = %q, want %q", got, want)
+	}
+	dialect := &Dialect{}
+	if got, want := dialect.AddColumnSQL("events", columns[0]), `ALTER TABLE "events" ADD COLUMN "required" INTEGER NOT NULL`; got != want {
+		t.Fatalf("required AddColumnSQL() = %q, want %q", got, want)
+	}
+	if got, want := dialect.AddColumnSQL("events", columns[1]), `ALTER TABLE "events" ADD COLUMN "optional" TEXT`; got != want {
+		t.Fatalf("optional AddColumnSQL() = %q, want %q", got, want)
+	}
+}
+
+func TestSQLiteRequirednessPersisted(t *testing.T) {
+	ctx := context.Background()
+	dest := NewSQLiteDestination()
+	path := filepath.Join(t.TempDir(), "requiredness.db")
+	if err := dest.Connect(ctx, "sqlite:///"+path); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = dest.Close(context.Background()) })
+	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: "events",
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "required", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "optional", DataType: schema.TypeString, Nullable: true},
+		}},
+		DropFirst: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.Exec(ctx, (&Dialect{}).AddColumnSQL("events", schema.Column{
+		Name: "added_required", DataType: schema.TypeInt64, Nullable: false,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := dest.db.QueryContext(ctx, `PRAGMA table_info("events")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	want := map[string]int{"required": 1, "optional": 0, "added_required": 1}
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, dataType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		if expected, ok := want[name]; ok {
+			if notNull != expected {
+				t.Errorf("column %s notnull = %d, want %d", name, notNull, expected)
+			}
+			delete(want, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing columns in PRAGMA table_info: %v", want)
+	}
+}

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -1258,7 +1258,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToSQLite(col)
-		colDefs = append(colDefs, fmt.Sprintf(`%s %s`, destination.QuoteIdentifier(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf(`%s %s%s`, destination.QuoteIdentifier(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", table, strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/starrocks/starrocks.go
+++ b/pkg/destination/starrocks/starrocks.go
@@ -195,7 +195,7 @@ func (d *StarRocksDestination) buildCreateTableSQL(table string, columns []schem
 
 	colDef := func(col schema.Column, forceNotNull bool) string {
 		def := fmt.Sprintf("%s %s", quoteColumn(col.Name), MapDataTypeToStarRocks(col))
-		if forceNotNull {
+		if forceNotNull || !col.Nullable {
 			def += " NOT NULL"
 		}
 		return def

--- a/pkg/destination/starrocks/starrocks_test.go
+++ b/pkg/destination/starrocks/starrocks_test.go
@@ -88,6 +88,24 @@ func TestBuildCreateTableSQL_PrimaryKey(t *testing.T) {
 	}
 }
 
+func TestBuildCreateTableSQL_PreservesRequiredNonKeyColumns(t *testing.T) {
+	d := &StarRocksDestination{replicationNum: "1"}
+	got := d.buildCreateTableSQL("db.events", []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "required_value", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "optional_value", DataType: schema.TypeString, Nullable: true},
+	}, []string{"id"})
+	want := "CREATE TABLE IF NOT EXISTS `db`.`events` (\n" +
+		"  `id` BIGINT NOT NULL,\n" +
+		"  `required_value` BIGINT NOT NULL,\n" +
+		"  `optional_value` VARCHAR(65533)\n)\n" +
+		"PRIMARY KEY (`id`)\nDISTRIBUTED BY HASH (`id`)\n" +
+		"PROPERTIES (\"replication_num\" = \"1\")"
+	if got != want {
+		t.Fatalf("buildCreateTableSQL() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestBuildCreateTableSQL_ReordersNonKeyableFirstColumn(t *testing.T) {
 	d := &StarRocksDestination{replicationNum: "1"}
 	cols := []schema.Column{

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -816,7 +816,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToSynapse(col)
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
+		colDef := fmt.Sprintf("%s %s", quoteColumn(col.Name), colType)
+		if !col.Nullable {
+			colDef += " NOT NULL"
+		}
+		colDefs = append(colDefs, colDef)
 	}
 
 	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))

--- a/pkg/destination/synapse/synapse_test.go
+++ b/pkg/destination/synapse/synapse_test.go
@@ -3,7 +3,25 @@ package synapse
 import (
 	"strings"
 	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
 )
+
+func TestBuildCreateTableSQLPreservesRequiredness(t *testing.T) {
+	got := buildCreateTableSQL("dbo.events", []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}, []string{"id"})
+
+	want := "IF OBJECT_ID('dbo.events', 'U') IS NULL\nBEGIN\n  CREATE TABLE [dbo].[events] (\n" +
+		"  [id] BIGINT NOT NULL,\n" +
+		"  [name] NVARCHAR(4000),\n" +
+		"  PRIMARY KEY NONCLUSTERED ([id]) NOT ENFORCED\n)\n" +
+		"WITH (\n  DISTRIBUTION = ROUND_ROBIN,\n  CLUSTERED COLUMNSTORE INDEX\n)\nEND"
+	if got != want {
+		t.Fatalf("buildCreateTableSQL() =\n%s\nwant:\n%s", got, want)
+	}
+}
 
 func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
 	sql := buildDeleteInsertDeleteSQL("dbo.events", "updated_at")

--- a/pkg/destination/trino/dialect.go
+++ b/pkg/destination/trino/dialect.go
@@ -15,10 +15,15 @@ func (d *Dialect) Name() string {
 }
 
 func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
-	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+	nullability := ""
+	if !col.Nullable {
+		nullability = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s%s",
 		table,
 		d.QuoteIdentifier(col.Name),
-		d.TypeName(col))
+		d.TypeName(col),
+		nullability)
 }
 
 func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -537,7 +537,11 @@ func buildCreateTableSQL(catalog, schemaName, table string, columns []schema.Col
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToTrino(col)
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
+		nullability := ""
+		if !col.Nullable {
+			nullability = " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf("%s %s%s", quoteIdentifier(col.Name), colType, nullability))
 	}
 
 	sql := fmt.Sprintf(

--- a/pkg/destination/trino/trino_test.go
+++ b/pkg/destination/trino/trino_test.go
@@ -6,7 +6,25 @@ import (
 	"testing"
 
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
 )
+
+func TestTrinoRequirednessDDL(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "required", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "optional", DataType: schema.TypeString, Nullable: true},
+	}
+	if got, want := buildCreateTableSQL("iceberg", "raw", "events", columns), "CREATE TABLE IF NOT EXISTS \"iceberg\".\"raw\".\"events\" (\n  \"required\" BIGINT NOT NULL,\n  \"optional\" VARCHAR\n)"; got != want {
+		t.Fatalf("buildCreateTableSQL() = %q, want %q", got, want)
+	}
+	dialect := &Dialect{}
+	if got, want := dialect.AddColumnSQL(`"iceberg"."raw"."events"`, columns[0]), `ALTER TABLE "iceberg"."raw"."events" ADD COLUMN "required" BIGINT NOT NULL`; got != want {
+		t.Fatalf("required AddColumnSQL() = %q, want %q", got, want)
+	}
+	if got, want := dialect.AddColumnSQL(`"iceberg"."raw"."events"`, columns[1]), `ALTER TABLE "iceberg"."raw"."events" ADD COLUMN "optional" VARCHAR`; got != want {
+		t.Fatalf("optional AddColumnSQL() = %q, want %q", got, want)
+	}
+}
 
 func TestParseTrinoURI(t *testing.T) {
 	tests := []struct {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/strategy"
+	"github.com/bruin-data/ingestr/pkg/tablename"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 	"golang.org/x/term"
 )
@@ -88,6 +89,9 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	if err := src.Connect(ctx, p.config.SourceURI); err != nil {
 		return fmt.Errorf("failed to connect to source: %w", err)
 	}
+	if isPostgresCDCSource(p.config.SourceURI) && p.config.SourceTable != "" {
+		p.config.SourceTable = canonicalPostgresCDCSourceTable(p.config.SourceTable)
+	}
 	defer func() {
 		closeCtx, cancel := resourceCloseContext(cleanupBaseCtx)
 		defer cancel()
@@ -143,9 +147,10 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	}()
 
 	destinationTarget := ""
+	destinationIdentity := ""
 	if isPostgresCDCSource(p.config.SourceURI) {
 		destinationTarget = managedCDCDestinationTarget(p.config, dest)
-		destinationIdentity, err := managedCDCDestinationIdentity(ctx, dest, destinationTarget)
+		destinationIdentity, err = managedCDCDestinationIdentity(ctx, dest, destinationTarget)
 		if err != nil {
 			return fmt.Errorf("failed to resolve PostgreSQL CDC destination identity: %w", err)
 		}
@@ -158,7 +163,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 
 	// For CDC sources, compute a destination-aware slot suffix
 	if isCDCSource(p.config.SourceURI) {
-		p.config.CDCSlotSuffix = cdcSlotSuffix(canonicalCDCStateURI(p.config.DestURI) + "\x00" + p.cdcConnectorID)
+		p.config.CDCSlotSuffix = cdcSlotSuffix(cdcSlotIdentity(p.config.DestURI, destinationIdentity, p.cdcConnectorID))
 		p.config.CDCLegacySlotSuffix = legacyCDCSlotSuffix(p.config.DestURI)
 		config.Debug("[PIPELINE] CDC slot suffix: %s", p.config.CDCSlotSuffix)
 	}
@@ -374,9 +379,9 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	var preStagedForJob destination.PreStagedData
 
 	if table.HasKnownSchema() {
-		tableSchema, err = table.GetSchema(ctx)
+		tableSchema, err = getAndValidateKnownSourceSchema(ctx, table)
 		if err != nil {
-			return fmt.Errorf("failed to get schema: %w", err)
+			return err
 		}
 	} else if p.config.NoInference {
 		tableSchema, err = p.schemaFromColumnOverrides(table)
@@ -408,6 +413,9 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		} else {
 			config.Debug("[PIPELINE] Inferred schema is nil")
 			if fallback, err := table.GetSchema(ctx); err == nil && fallback != nil && len(fallback.Columns) > 0 {
+				if err := validateKnownSourceSchema(table.Name(), fallback); err != nil {
+					return err
+				}
 				tableSchema = fallback
 				config.Debug("[PIPELINE] Using source-provided schema (%d columns) for empty extract", len(fallback.Columns))
 			} else if synthetic, err := schemainfer.TableSchemaFromColumnOverrides(p.config.Columns, table.Name(), p.config.SchemaNaming); err != nil {
@@ -546,17 +554,16 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	// re-appends them from this snapshot so staging keeps carrying them.
 	fullSchema := destSchema
 
-	// Schema contract handling: evolve destination schema if needed (skip for replace strategy)
+	// Schema contract handling applies to replace as well: replacement changes
+	// how the table is published, not whether freeze/discard rules are enforced.
 	// Build the evolution plan but do NOT apply it here. Strategies decide when to apply.
 	var evolutionPlan *schemaevolution.EvolutionPlan
-	if resolvedStrategy != config.StrategyReplace {
-		evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, p.config.DestTable, destSchema, resolvedStrategy)
-		if err != nil {
-			return fmt.Errorf("schema evolution failed: %w", err)
-		}
-		if evolutionPlan != nil && evolutionPlan.FinalSchema != nil {
-			destSchema = evolutionPlan.FinalSchema
-		}
+	evolutionPlan, err = p.evolveSchemaIfNeeded(ctx, p.config.DestTable, destSchema, resolvedStrategy)
+	if err != nil {
+		return fmt.Errorf("schema evolution failed: %w", err)
+	}
+	if evolutionPlan != nil && evolutionPlan.FinalSchema != nil {
+		destSchema = evolutionPlan.FinalSchema
 	}
 	if p.config.NoLoadTimestamp {
 		destSchema = removeLoadTimestampColumn(destSchema)
@@ -566,9 +573,15 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		fullSchema = addLoadTimestampColumn(fullSchema)
 	}
 
-	// Staging mirrors the destination schema, with staging-only CDC columns retained.
-	ingestSchema := destination.StagingIngestSchema(fullSchema, destSchema)
-	ingestSchema = destination.PreserveSourceCDCColumnTypes(ingestSchema, fullSchema)
+	// Replace publishes its write table, so staging-only CDC columns must be
+	// removed before buffering/pre-staging as well as at the strategy boundary.
+	var ingestSchema *schema.TableSchema
+	if resolvedStrategy == config.StrategyReplace {
+		ingestSchema = destination.DestinationTableSchema(destSchema)
+	} else {
+		ingestSchema = destination.StagingIngestSchema(fullSchema, destSchema)
+		ingestSchema = destination.PreserveSourceCDCColumnTypes(ingestSchema, fullSchema)
+	}
 	if strategyUsesLogicalPrimaryKeys(resolvedStrategy) {
 		ingestSchema = preserveLogicalPrimaryKeys(ingestSchema, fullSchema)
 	}
@@ -1249,7 +1262,6 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 			return nil
 		}
 	}
-
 	config.Debug("[PIPELINE] Multi-table mode: %d tables", len(tables))
 
 	namer, _ := p.dest.(destination.MultiTableNamer)
@@ -1401,22 +1413,22 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 			}
 		}
 	}
+	if err := validateKnownSourceTables(tables); err != nil {
+		return err
+	}
 
-	// Schema contract handling: build a per-table evolution plan so destination
-	// tables gain columns added at the source (skip for replace, which drops and
-	// recreates). Plans are built sequentially because evolveSchemaIfNeeded
-	// keeps comparison state on the pipeline; strategies apply them per table.
-	var evolutionPlans map[string]*schemaevolution.EvolutionPlan
-	if resolvedStrategy != config.StrategyReplace {
-		evolutionPlans = make(map[string]*schemaevolution.EvolutionPlan)
-		for _, table := range tables {
-			plan, err := p.evolveSchemaIfNeeded(ctx, tableDestNames[table.Name], table.Schema, resolvedStrategy)
-			if err != nil {
-				return fmt.Errorf("schema evolution failed for table %s: %w", table.Name, err)
-			}
-			if plan != nil {
-				evolutionPlans[table.Name] = plan
-			}
+	// Schema contract handling applies to replace as well: replacement changes
+	// how each table is published, not whether freeze/discard rules are enforced.
+	// Plans are built sequentially because evolveSchemaIfNeeded keeps comparison
+	// state on the pipeline; strategies apply them per table.
+	evolutionPlans := make(map[string]*schemaevolution.EvolutionPlan)
+	for _, table := range tables {
+		plan, err := p.evolveSchemaIfNeeded(ctx, tableDestNames[table.Name], table.Schema, resolvedStrategy)
+		if err != nil {
+			return fmt.Errorf("schema evolution failed for table %s: %w", table.Name, err)
+		}
+		if plan != nil {
+			evolutionPlans[table.Name] = plan
 		}
 	}
 	var whitespaceTrimmer *transformer.WhitespaceTrimmer
@@ -1548,6 +1560,33 @@ func multiTableDestinationNames(tables []source.SourceTableInfo, scheme string, 
 	return destinations, nil
 }
 
+func getAndValidateKnownSourceSchema(ctx context.Context, table source.SourceTable) (*schema.TableSchema, error) {
+	tableSchema, err := table.GetSchema(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema for source table %q: %w", table.Name(), err)
+	}
+	if err := validateKnownSourceSchema(table.Name(), tableSchema); err != nil {
+		return nil, err
+	}
+	return tableSchema, nil
+}
+
+func validateKnownSourceSchema(tableName string, tableSchema *schema.TableSchema) error {
+	if err := schemainfer.ValidateSchema(tableSchema); err != nil {
+		return fmt.Errorf("invalid known schema for source table %q: %w", tableName, err)
+	}
+	return nil
+}
+
+func validateKnownSourceTables(tables []source.SourceTableInfo) error {
+	for _, table := range tables {
+		if err := validateKnownSourceSchema(table.Name, table.Schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // evolveSchemaIfNeeded inspects the destination's current schema and builds an
 // EvolutionPlan describing how it should change to accommodate sourceSchema.
 func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, sourceSchema *schema.TableSchema, strategy config.IncrementalStrategy) (*schemaevolution.EvolutionPlan, error) {
@@ -1588,7 +1627,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	}
 
 	// Compare schemas with overrides. Staging-only CDC columns are not persisted on the destination.
-	opts := &schemaevolution.CompareOptions{Overrides: overrides}
+	opts := &schemaevolution.CompareOptions{Overrides: overrides, PrimaryKeys: sourceSchema.PrimaryKeys}
 	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), comparisonDestSchema, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare schemas: %w", err)
@@ -1596,8 +1635,9 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	if !comparison.HasChanges {
 		config.Debug("[SCHEMA EVOLUTION] No schema changes detected")
 		return &schemaevolution.EvolutionPlan{
-			Table:       destTable,
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
+			Table:               destTable,
+			TransformComparison: comparison,
+			FinalSchema:         schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
 		}, nil
 	}
 
@@ -1625,8 +1665,9 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 		}
 		p.filteredSchemaComparison = comparison
 		return &schemaevolution.EvolutionPlan{
-			Table:       destTable,
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
+			Table:               destTable,
+			TransformComparison: comparison,
+			FinalSchema:         schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
 		}, nil
 
 	case schemaevolution.ContractDiscardRow:
@@ -1651,6 +1692,23 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 			// enabling correct INSERT INTO ... SELECT behavior on strict DBs like Postgres
 			for _, change := range comparison.Changes {
 				if change.Type == schemaevolution.ChangeWidenType && change.OldColumn != nil {
+					if len(change.ColumnPath) > 1 {
+						topLevel := change.ColumnPath[0]
+						for _, destCol := range comparisonDestSchema.Columns {
+							if !strings.EqualFold(destCol.Name, topLevel) {
+								continue
+							}
+							for i := range sourceSchema.Columns {
+								if strings.EqualFold(sourceSchema.Columns[i].Name, topLevel) {
+									sourceSchema.Columns[i] = destCol
+									sourceSchema.Columns[i].Nullable = true
+									break
+								}
+							}
+							break
+						}
+						continue
+					}
 					// Find column in sourceSchema and revert it to OldColumn (Dest Type)
 					for i, col := range sourceSchema.Columns {
 						if col.Name == change.ColumnName {
@@ -1670,8 +1728,9 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 				HasChanges: false,
 			}
 			return &schemaevolution.EvolutionPlan{
-				Table:       destTable,
-				FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
+				Table:               destTable,
+				TransformComparison: comparison,
+				FinalSchema:         schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
 			}, nil
 		}
 		// For migration, only apply allowed changes (new columns) for discard_value mode
@@ -1693,8 +1752,9 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	if !ok {
 		config.Debug("[SCHEMA EVOLUTION] Destination %s does not support schema evolution, skipping", p.dest.GetScheme())
 		return &schemaevolution.EvolutionPlan{
-			Table:       destTable,
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
+			Table:               destTable,
+			TransformComparison: comparison,
+			FinalSchema:         schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
 		}, nil
 	}
 
@@ -1704,9 +1764,10 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	applicable := schemaevolution.ApplicableComparison(p.filteredSchemaComparison, evolver.SupportsColumnTypeChanges())
 
 	plan := &schemaevolution.EvolutionPlan{
-		Table:       destTable,
-		Comparison:  p.filteredSchemaComparison,
-		FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, applicable),
+		Table:               destTable,
+		Comparison:          p.filteredSchemaComparison,
+		TransformComparison: comparison,
+		FinalSchema:         schemaevolution.BuildFinalSchema(comparisonDestSchema, applicable),
 	}
 	config.Debug("[SCHEMA EVOLUTION] Built plan with %d changes (deferred apply)", len(p.filteredSchemaComparison.Changes))
 	return plan, nil
@@ -2265,7 +2326,7 @@ func resolveStrategy(cfg *config.IngestConfig, src source.Source, table source.S
 	if cfg.FullRefresh {
 		s = config.StrategyReplace
 	}
-	return rewriteReplaceForPostgres(s, cfg.DestURI)
+	return rewriteReplaceForPostgres(s, cfg.DestURI, isPostgresCDCSource(cfg.SourceURI) && cfg.FullRefresh)
 }
 
 func resolveIncrementalKey(cfg *config.IngestConfig, src source.Source, table source.SourceTable) string {
@@ -2325,8 +2386,11 @@ func validateExtractPartitionStrategy(cfg *config.IngestConfig, resolvedStrategy
 // the destination is Postgres. Replace drops and recreates the table, which
 // breaks dependent views, grants, and foreign keys; truncate+insert preserves
 // the table definition.
-func rewriteReplaceForPostgres(strat config.IncrementalStrategy, destURI string) config.IncrementalStrategy {
+func rewriteReplaceForPostgres(strat config.IncrementalStrategy, destURI string, requireFencedReplace bool) config.IncrementalStrategy {
 	if strat != config.StrategyReplace {
+		return strat
+	}
+	if requireFencedReplace {
 		return strat
 	}
 	scheme, err := uri.ExtractScheme(destURI)
@@ -2357,12 +2421,20 @@ func isPostgresCDCSource(rawURI string) bool {
 	return scheme == "postgres+cdc" || scheme == "postgresql+cdc"
 }
 
+func canonicalPostgresCDCSourceTable(table string) string {
+	table = strings.TrimSpace(table)
+	if table == "" || len(tablename.SplitRaw(table)) != 1 {
+		return table
+	}
+	return "public." + table
+}
+
 func resolvedCDCStateConnectorID(cfg *config.IngestConfig, identity source.ConnectorIdentity, destinationIdentity string) string {
 	if parsed, err := url.Parse(cfg.SourceURI); err == nil {
 		if stateID := parsed.Query().Get("state_id"); stateID != "" {
 			seed := "explicit:" + stateID + "\x00" + identity.Database
 			if destinationIdentity != "" {
-				seed += "\x00" + destinationIdentity
+				seed += "\x00" + cdcDestinationLocation(cfg.DestURI, destinationIdentity)
 			}
 			sum := sha256.Sum256([]byte(seed))
 			return fmt.Sprintf("%x", sum[:8])
@@ -2370,18 +2442,52 @@ func resolvedCDCStateConnectorID(cfg *config.IngestConfig, identity source.Conne
 	}
 
 	destinationTarget := cfg.DestTable
+	destinationLocation := cdcDestinationLocation(cfg.DestURI, destinationIdentity)
+	sourceTable := cfg.SourceTable
+	if isPostgresCDCSource(cfg.SourceURI) {
+		sourceTable = canonicalPostgresCDCSourceTable(sourceTable)
+	}
 	if destinationIdentity != "" {
 		destinationTarget = destinationIdentity
 	}
 	identityParts := []string{
 		identity.Connector,
-		canonicalCDCStateURI(cfg.DestURI),
-		cfg.SourceTable,
+		destinationLocation,
+		sourceTable,
 		destinationTarget,
 	}
 	connectorIdentity := strings.Join(identityParts, "\x00")
 	sum := sha256.Sum256([]byte(connectorIdentity))
 	return fmt.Sprintf("%x", sum[:8])
+}
+
+func cdcSlotIdentity(rawDestURI, destinationIdentity, connectorID string) string {
+	return cdcDestinationLocation(rawDestURI, destinationIdentity) + "\x00" + connectorID
+}
+
+func cdcDestinationLocation(rawDestURI, destinationIdentity string) string {
+	if destinationIdentity == "" {
+		return canonicalCDCStateURI(rawDestURI)
+	}
+	parsed, err := url.Parse(rawDestURI)
+	if err == nil && strings.HasPrefix(strings.ToLower(parsed.Scheme), "iceberg") {
+		return "canonical-destination:" + destinationIdentity
+	}
+	return canonicalDestinationRoutingURI(rawDestURI) + "\x00canonical-destination:" + destinationIdentity
+}
+
+func canonicalDestinationRoutingURI(rawURI string) string {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return rawURI
+	}
+	normalizePostgresURI(parsed)
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	return parsed.String()
 }
 
 func managedCDCDestinationIdentity(ctx context.Context, dest destination.Destination, target string) (string, error) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -894,6 +894,10 @@ func (m *mockManagedCDCStateDestination) TruncateTable(_ context.Context, _ stri
 	return nil
 }
 
+func (m *mockManagedCDCStateDestination) TruncateCDCTableIfIncarnation(context.Context, string, string) error {
+	return nil
+}
+
 func (m *mockManagedCDCStateDestination) LoadCDCState(_ context.Context, _, _ string) ([]destination.CDCStateEntry, error) {
 	return nil, nil
 }
@@ -925,6 +929,75 @@ func (m *mockManagedCDCStateDestination) DeleteCDCStateEvents(_ context.Context,
 
 type mockSchemaEvolutionDestination struct {
 	mockDestination
+}
+
+func TestKnownSourceSchemasAreValidatedBeforeUse(t *testing.T) {
+	tests := []struct {
+		name    string
+		column  schema.Column
+		path    string
+		wantErr bool
+	}{
+		{
+			name: "top-level decimal256", path: "amount", wantErr: true,
+			column: schema.Column{Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2},
+		},
+		{
+			name: "nested decimal256", path: "payload.amount", wantErr: true,
+			column: schema.Column{Name: "payload", DataType: schema.TypeStruct, StructFields: &schema.TableSchema{Columns: []schema.Column{{
+				Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2,
+			}}}},
+		},
+		{
+			name: "decimal256 map key", path: "lookup.key", wantErr: true,
+			column: schema.Column{
+				Name: "lookup", DataType: schema.TypeMap,
+				MapKey:   &schema.Column{Name: "key", DataType: schema.TypeDecimal, Precision: 50, Scale: 2},
+				MapValue: &schema.Column{Name: "value", DataType: schema.TypeString},
+			},
+		},
+		{
+			name: "supported decimal128 precision", column: schema.Column{
+				Name: "lookup", DataType: schema.TypeMap,
+				MapKey: &schema.Column{Name: "key", DataType: schema.TypeDecimal, Precision: 38, Scale: 2},
+				MapValue: &schema.Column{Name: "value", DataType: schema.TypeStruct, StructFields: &schema.TableSchema{Columns: []schema.Column{{
+					Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 2,
+				}}}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := &source.DynamicSourceTable{
+				TableName: "payments", KnownSchema: true,
+				SchemaFn: func(context.Context) (*schema.TableSchema, error) {
+					return &schema.TableSchema{Columns: []schema.Column{tt.column}}, nil
+				},
+			}
+			_, err := getAndValidateKnownSourceSchema(context.Background(), table)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, `invalid known schema for source table "payments"`)
+			require.ErrorContains(t, err, tt.path)
+			require.ErrorContains(t, err, "maximum supported precision is 38")
+		})
+	}
+}
+
+func TestKnownMultiTableSchemasAreValidated(t *testing.T) {
+	tables := []source.SourceTableInfo{
+		{Name: "public.valid", Schema: &schema.TableSchema{Columns: []schema.Column{{
+			Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 2,
+		}}}},
+		{Name: "public.invalid", Schema: &schema.TableSchema{Columns: []schema.Column{{
+			Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2,
+		}}}},
+	}
+	err := validateKnownSourceTables(tables)
+	require.ErrorContains(t, err, `source table "public.invalid"`)
+	require.ErrorContains(t, err, "decimal precision 50")
 }
 
 func (m *mockSchemaEvolutionDestination) ApplySchemaEvolution(_ context.Context, _ string, _ *schemaevolution.SchemaComparison) ([]string, error) {
@@ -1613,6 +1686,192 @@ func TestEvolveSchemaIfNeededBuildsAbstractPlanForSchemaEvolver(t *testing.T) {
 
 	gotColumns := plan.FinalSchema.ColumnNames()
 	assertColumns(t, "columns", gotColumns, []string{"id", "age"})
+}
+
+func TestDiscardValuePlanAppliesNullabilityRelaxation(t *testing.T) {
+	destSchema := tschema("events", schema.Column{Name: "payload", DataType: schema.TypeString, Nullable: false})
+	sourceSchema := tschema("events", schema.Column{Name: "payload", DataType: schema.TypeString, Nullable: true})
+	p := &Pipeline{
+		config: &config.IngestConfig{DestTable: "events", SchemaContract: "discard_value"},
+		dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+			tableSchema: destSchema, scheme: "schema_evolver",
+		}},
+	}
+
+	plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyAppend)
+	if err != nil {
+		t.Fatalf("evolveSchemaIfNeeded() error = %v", err)
+	}
+	if plan == nil || !plan.HasChanges() {
+		t.Fatal("expected nullability evolution plan")
+	}
+	if len(plan.Comparison.Changes) != 1 || plan.Comparison.Changes[0].Type != schemaevolution.ChangeRelaxNullability {
+		t.Fatalf("unexpected comparison: %#v", plan.Comparison)
+	}
+	if !plan.FinalSchema.Columns[0].Nullable {
+		t.Fatal("final schema must accept source NULL values")
+	}
+}
+
+func TestDiscardRowPlanAppliesNullabilityRelaxation(t *testing.T) {
+	tests := []struct {
+		name   string
+		source *schema.TableSchema
+		dest   *schema.TableSchema
+		path   []string
+	}{
+		{
+			name:   "top-level",
+			source: tschema("events", schema.Column{Name: "payload", DataType: schema.TypeString, Nullable: true}),
+			dest:   tschema("events", schema.Column{Name: "payload", DataType: schema.TypeString, Nullable: false}),
+			path:   []string{"payload"},
+		},
+		{
+			name: "nested",
+			source: tschema("events", schema.Column{
+				Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+				StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: true}}},
+			}),
+			dest: tschema("events", schema.Column{
+				Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+				StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: false}}},
+			}),
+			path: []string{"profile", "name"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pipeline{
+				config: &config.IngestConfig{DestTable: "events", SchemaContract: "discard_row"},
+				dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+					tableSchema: tt.dest, scheme: "schema_evolver",
+				}},
+			}
+			plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", tt.source, config.StrategyAppend)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+			require.Len(t, plan.Comparison.Changes, 1)
+			require.Equal(t, schemaevolution.ChangeRelaxNullability, plan.Comparison.Changes[0].Type)
+			require.Equal(t, tt.path, plan.Comparison.Changes[0].ColumnPath)
+			if len(tt.path) == 1 {
+				require.True(t, plan.FinalSchema.Columns[0].Nullable)
+			} else {
+				require.True(t, plan.FinalSchema.Columns[0].StructFields.Columns[0].Nullable)
+			}
+		})
+	}
+}
+
+func TestReplaceSchemaContractPlanningRejectsFreezeAndRetainsDiscardTransforms(t *testing.T) {
+	destinationSchema := tschema("events", schema.Column{Name: "value", DataType: schema.TypeInt64, Nullable: true})
+
+	t.Run("freeze", func(t *testing.T) {
+		p := &Pipeline{
+			config: &config.IngestConfig{DestTable: "events", SchemaContract: "freeze"},
+			dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+				tableSchema: destinationSchema, scheme: "schema_evolver",
+			}},
+		}
+		sourceSchema := tschema("events", schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true})
+
+		_, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyReplace)
+		require.ErrorContains(t, err, "schema contract violation")
+	})
+
+	for _, mode := range []string{"discard_value", "discard_row"} {
+		t.Run(mode, func(t *testing.T) {
+			p := &Pipeline{
+				config: &config.IngestConfig{DestTable: "events", SchemaContract: mode},
+				dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+					tableSchema: destinationSchema, scheme: "schema_evolver",
+				}},
+			}
+			sourceSchema := tschema("events", schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true})
+
+			plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyReplace)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+			require.NotNil(t, plan.TransformComparison)
+			require.True(t, plan.TransformComparison.HasChanges)
+			require.NotNil(t, plan.FinalSchema)
+			if mode == "discard_value" {
+				require.Equal(t, schema.TypeInt64, plan.FinalSchema.Columns[0].DataType)
+			}
+		})
+	}
+}
+
+func TestDiscardValuePlanAppliesNullabilityRelaxationWithOverride(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		columns string
+	}{
+		{name: "matching override", columns: "payload:string"},
+		{name: "type-changing override", columns: "payload:bigint"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			destSchema := tschema("events", schema.Column{Name: "payload", DataType: schema.TypeString, Nullable: false})
+			sourceSchema := tschema("events", schema.Column{Name: "payload", DataType: schema.TypeString, Nullable: true})
+			p := &Pipeline{
+				config: &config.IngestConfig{DestTable: "events", SchemaContract: "discard_value", Columns: tt.columns},
+				dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+					tableSchema: destSchema, scheme: "schema_evolver",
+				}},
+			}
+
+			plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyAppend)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+			require.Len(t, plan.Comparison.Changes, 1)
+			require.Equal(t, schemaevolution.ChangeRelaxNullability, plan.Comparison.Changes[0].Type)
+			require.True(t, plan.FinalSchema.Columns[0].Nullable)
+		})
+	}
+}
+
+func TestApplyColumnOverridesDecimalValidationAndZeroScale(t *testing.T) {
+	p := &Pipeline{config: &config.IngestConfig{Columns: "amount:decimal(18)"}}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 4,
+	}}}
+	require.NoError(t, p.applyColumnOverrides(tableSchema))
+	require.Equal(t, 18, tableSchema.Columns[0].Precision)
+	require.Zero(t, tableSchema.Columns[0].Scale)
+
+	for _, columns := range []string{"amount:decimal(50,2)", "amount:decimal(10,-1)", "amount:decimal(10,11)"} {
+		p.config.Columns = columns
+		require.Error(t, p.applyColumnOverrides(tableSchema), columns)
+	}
+}
+
+func TestEvolutionPlanTypeChangesPreserveRequiredDestinationColumns(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		sourceType schema.DataType
+		destType   schema.DataType
+		columns    string
+	}{
+		{name: "automatic widening", sourceType: schema.TypeInt64, destType: schema.TypeInt32},
+		{name: "type override", sourceType: schema.TypeInt32, destType: schema.TypeInt32, columns: "value:bigint"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceSchema := tschema("events", schema.Column{Name: "value", DataType: tt.sourceType, Nullable: false})
+			destSchema := tschema("events", schema.Column{Name: "value", DataType: tt.destType, Nullable: false})
+			p := &Pipeline{
+				config: &config.IngestConfig{DestTable: "events", Columns: tt.columns},
+				dest: &mockSchemaEvolutionDestination{mockDestination: mockDestination{
+					tableSchema: destSchema, scheme: "schema_evolver",
+				}},
+			}
+
+			plan, err := p.evolveSchemaIfNeeded(context.Background(), "events", sourceSchema, config.StrategyAppend)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+			require.Len(t, plan.Comparison.Changes, 1)
+			require.False(t, plan.Comparison.Changes[0].NewColumn.Nullable)
+			require.False(t, plan.FinalSchema.Columns[0].Nullable)
+		})
+	}
 }
 
 func TestNamingConsistency(t *testing.T) {
@@ -2307,6 +2566,95 @@ func TestCDCStateConnectorID(t *testing.T) {
 	if resolvedCDCStateConnectorID(&implicitDestAlice, resolved, "") == resolvedCDCStateConnectorID(&implicitDestBob, resolved, "") {
 		t.Fatal("destination URIs with different implicit PostgreSQL databases share a connector ID")
 	}
+
+	unqualified := *base
+	unqualified.SourceTable = "orders"
+	qualified := unqualified
+	qualified.SourceTable = "public.orders"
+	require.Equal(t, "public.orders", canonicalPostgresCDCSourceTable(unqualified.SourceTable))
+	require.Equal(t,
+		resolvedCDCStateConnectorID(&unqualified, resolved, "canonical-target"),
+		resolvedCDCStateConnectorID(&qualified, resolved, "canonical-target"),
+		"equivalent PostgreSQL source-table spellings must retain connector ownership")
+	require.Equal(t,
+		cdcSlotSuffix(cdcSlotIdentity(unqualified.DestURI, "canonical-target", resolvedCDCStateConnectorID(&unqualified, resolved, "canonical-target"))),
+		cdcSlotSuffix(cdcSlotIdentity(qualified.DestURI, "canonical-target", resolvedCDCStateConnectorID(&qualified, resolved, "canonical-target"))),
+		"equivalent PostgreSQL source-table spellings must retain the automatic slot")
+}
+
+func TestPostgresManagedCDCFullRefreshKeepsFencedReplace(t *testing.T) {
+	require.Equal(t, config.StrategyReplace,
+		rewriteReplaceForPostgres(config.StrategyReplace, "postgres://localhost/app", true))
+	require.Equal(t, config.StrategyTruncateInsert,
+		rewriteReplaceForPostgres(config.StrategyReplace, "postgres://localhost/app", false))
+	require.Equal(t, config.StrategyReplace,
+		rewriteReplaceForPostgres(config.StrategyReplace, "iceberg://catalog/warehouse", false))
+}
+
+func TestManagedCDCConnectorAndSlotIdentityIgnoreDestinationCredentialRotation(t *testing.T) {
+	base := &config.IngestConfig{
+		SourceURI:   "postgres+cdc://reader@source.example/app?publication=pub",
+		DestURI:     "iceberg+rest://catalog.example/iceberg?warehouse=prod&oauth_client_id=client&oauth_client_secret=old&secret_access_key=old-key&session_token=old-session",
+		SourceTable: "public.orders",
+		DestTable:   "lake.orders",
+	}
+	rotated := *base
+	rotated.DestURI = "iceberg+rest://catalog.example/iceberg?session_token=new-session&secret_access_key=new-key&oauth_client_secret=new&oauth_client_id=client&warehouse=prod"
+	identity := source.ConnectorIdentity{Database: "source-db", Connector: "source-connector"}
+	const destinationIdentity = "canonical-iceberg-target"
+
+	baseID := resolvedCDCStateConnectorID(base, identity, destinationIdentity)
+	rotatedID := resolvedCDCStateConnectorID(&rotated, identity, destinationIdentity)
+	require.Equal(t, baseID, rotatedID)
+	require.Equal(
+		t,
+		cdcSlotSuffix(cdcSlotIdentity(base.DestURI, destinationIdentity, baseID)),
+		cdcSlotSuffix(cdcSlotIdentity(rotated.DestURI, destinationIdentity, rotatedID)),
+	)
+	claims := &caseFoldingManagedDestination{owners: make(map[string]string)}
+	claim := destination.CDCTargetClaim{SourceTable: base.SourceTable, DestinationTable: base.DestTable, ConnectorID: baseID}
+	require.NoError(t, claims.ClaimCDCTarget(t.Context(), "", claim))
+	claim.ConnectorID = rotatedID
+	require.NoError(t, claims.ClaimCDCTarget(t.Context(), "", claim),
+		"credential rotation must retain durable target ownership")
+	require.NotEqual(
+		t,
+		resolvedCDCStateConnectorID(base, identity, ""),
+		resolvedCDCStateConnectorID(&rotated, identity, ""),
+		"destinations without a canonical identity must retain their configuration isolation",
+	)
+}
+
+func TestManagedCDCConnectorAndSlotIdentityRetainDestinationServerIsolation(t *testing.T) {
+	base := &config.IngestConfig{
+		SourceURI:   "postgres+cdc://reader@source.example/app?publication=pub",
+		DestURI:     "postgres://loader:old@warehouse-a.example/analytics?sslmode=require&application_name=first",
+		SourceTable: "public.orders",
+		DestTable:   "lake.orders",
+	}
+	rotated := *base
+	rotated.DestURI = "postgres://other:new@warehouse-a.example:5432/analytics?sslmode=verify-full&application_name=second"
+	otherServer := *base
+	otherServer.DestURI = "postgres://loader:old@warehouse-b.example/analytics?sslmode=require"
+	identity := source.ConnectorIdentity{Database: "source-db", Connector: "source-connector"}
+	const destinationIdentity = "analytics-schema-orders"
+
+	baseID := resolvedCDCStateConnectorID(base, identity, destinationIdentity)
+	rotatedID := resolvedCDCStateConnectorID(&rotated, identity, destinationIdentity)
+	otherID := resolvedCDCStateConnectorID(&otherServer, identity, destinationIdentity)
+	require.Equal(t, baseID, rotatedID, "credentials and transport settings changed destination ownership")
+	require.NotEqual(t, baseID, otherID, "different destination servers share connector ownership")
+	require.Equal(
+		t,
+		cdcSlotSuffix(cdcSlotIdentity(base.DestURI, destinationIdentity, baseID)),
+		cdcSlotSuffix(cdcSlotIdentity(rotated.DestURI, destinationIdentity, rotatedID)),
+	)
+	require.NotEqual(
+		t,
+		cdcSlotSuffix(cdcSlotIdentity(base.DestURI, destinationIdentity, baseID)),
+		cdcSlotSuffix(cdcSlotIdentity(otherServer.DestURI, destinationIdentity, otherID)),
+		"different destination servers share an automatic PostgreSQL slot",
+	)
 }
 
 func TestCDCStateConnectorIDDistinguishesEffectiveUnqualifiedDestination(t *testing.T) {
@@ -2378,9 +2726,28 @@ func TestMultiTableCDCConnectorIDIncludesNormalizedDestinationNamespace(t *testi
 	idB := resolvedCDCStateConnectorID(&other, identity, canonicalB)
 	require.NotEqual(t, idA, idB, "different dest_schema mappings must not share connector state or slots")
 	require.NotEqual(t,
-		cdcSlotSuffix(canonicalCDCStateURI(base.DestURI)+"\x00"+idA),
-		cdcSlotSuffix(canonicalCDCStateURI(other.DestURI)+"\x00"+idB),
+		cdcSlotSuffix(cdcSlotIdentity(base.DestURI, canonicalA, idA)),
+		cdcSlotSuffix(cdcSlotIdentity(other.DestURI, canonicalB, idB)),
 		"different dest_schema mappings must not share automatic PostgreSQL slots")
+
+	discoveries := [][]source.SourceTableInfo{
+		{{Name: "public.orders"}, {Name: "public.customers"}},
+		{{Name: "public.customers"}, {Name: "public.orders"}},
+		{{Name: "public.orders"}, {Name: "public.customers"}, {Name: "public.invoices"}},
+	}
+	for _, discovered := range discoveries {
+		_, err := multiTableDestinationNames(discovered, dest.GetScheme(), dest)
+		require.NoError(t, err)
+		target := managedCDCDestinationTarget(base, dest)
+		canonical, err := managedCDCDestinationIdentity(t.Context(), dest, target)
+		require.NoError(t, err)
+		require.Equal(t, idA, resolvedCDCStateConnectorID(base, identity, canonical),
+			"discovery order or growth changed the multi-table connector owner")
+		require.Equal(t,
+			cdcSlotSuffix(cdcSlotIdentity(base.DestURI, canonicalA, idA)),
+			cdcSlotSuffix(cdcSlotIdentity(base.DestURI, canonical, resolvedCDCStateConnectorID(base, identity, canonical))),
+			"discovery order or growth changed the multi-table slot")
+	}
 }
 
 func TestDroppedColumnsPKFiltering(t *testing.T) {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -28,6 +28,9 @@ const (
 	TypeJSON
 	TypeUUID
 	TypeArray
+	TypeStruct
+	TypeMap
+	TypeFixedBinary
 )
 
 func (d DataType) String() string {
@@ -68,20 +71,33 @@ func (d DataType) String() string {
 		return "uuid"
 	case TypeArray:
 		return "array"
+	case TypeStruct:
+		return "struct"
+	case TypeMap:
+		return "map"
+	case TypeFixedBinary:
+		return "fixed_binary"
 	default:
 		return "unknown"
 	}
 }
 
 type Column struct {
-	Name         string
-	DataType     DataType
-	Nullable     bool
-	Precision    int
-	Scale        int
-	MaxLength    int
-	IsPrimaryKey bool
-	ArrayType    DataType
+	Name           string
+	DataType       DataType
+	Nullable       bool
+	Precision      int
+	Scale          int
+	MaxLength      int
+	IsPrimaryKey   bool
+	ArrayType      DataType
+	ArrayLength    int32
+	ArrayDelimiter string
+	Element        *Column
+	StructFields   *TableSchema
+	MapKey         *Column
+	MapValue       *Column
+	FixedLength    int
 }
 
 type TableSchema struct {
@@ -115,8 +131,8 @@ func (ts *TableSchema) ColumnNames() []string {
 
 // SameColumnShape reports whether two schemas describe the same column layout
 // for ingestion purposes (name, type, array element type, precision, scale,
-// and declared character length).
-// Metadata like primary-key flags and nullability is ignored.
+// declared character length, nested shape, and nullability).
+// Primary-key flags are ignored; nullability is part of the write shape.
 func (ts *TableSchema) SameColumnShape(other *TableSchema) bool {
 	if ts == nil || other == nil {
 		return ts == other
@@ -126,12 +142,52 @@ func (ts *TableSchema) SameColumnShape(other *TableSchema) bool {
 	}
 	for i := range ts.Columns {
 		a, b := ts.Columns[i], other.Columns[i]
-		if !strings.EqualFold(a.Name, b.Name) || a.DataType != b.DataType ||
-			a.ArrayType != b.ArrayType || a.Precision != b.Precision || a.Scale != b.Scale || a.MaxLength != b.MaxLength {
+		if !strings.EqualFold(a.Name, b.Name) || !sameColumnTypeShape(a, b, true) {
 			return false
 		}
 	}
 	return true
+}
+
+func sameColumnTypeShape(a, b Column, compareNullable bool) bool {
+	if a.DataType != b.DataType || a.ArrayType != b.ArrayType || a.ArrayLength != b.ArrayLength || a.Precision != b.Precision ||
+		a.Scale != b.Scale || a.MaxLength != b.MaxLength || a.FixedLength != b.FixedLength ||
+		compareNullable && a.Nullable != b.Nullable {
+		return false
+	}
+	switch a.DataType {
+	case TypeArray:
+		aElem := a.Element
+		if aElem == nil {
+			aElem = &Column{DataType: a.ArrayType, Precision: a.Precision, Scale: a.Scale, MaxLength: a.MaxLength, FixedLength: a.FixedLength, Nullable: true}
+		}
+		bElem := b.Element
+		if bElem == nil {
+			bElem = &Column{DataType: b.ArrayType, Precision: b.Precision, Scale: b.Scale, MaxLength: b.MaxLength, FixedLength: b.FixedLength, Nullable: true}
+		}
+		return sameColumnTypeShape(*aElem, *bElem, true)
+	case TypeStruct:
+		if a.StructFields == nil || b.StructFields == nil {
+			return a.StructFields == nil && b.StructFields == nil
+		}
+		if len(a.StructFields.Columns) != len(b.StructFields.Columns) {
+			return false
+		}
+		for i := range a.StructFields.Columns {
+			af, bf := a.StructFields.Columns[i], b.StructFields.Columns[i]
+			if !strings.EqualFold(af.Name, bf.Name) || !sameColumnTypeShape(af, bf, true) {
+				return false
+			}
+		}
+		return true
+	case TypeMap:
+		if a.MapKey == nil || b.MapKey == nil || a.MapValue == nil || b.MapValue == nil {
+			return a.MapKey == nil && b.MapKey == nil && a.MapValue == nil && b.MapValue == nil
+		}
+		return sameColumnTypeShape(*a.MapKey, *b.MapKey, true) && sameColumnTypeShape(*a.MapValue, *b.MapValue, true)
+	default:
+		return true
+	}
 }
 
 func DataTypeToArrowType(col Column) arrow.DataType {
@@ -174,8 +230,39 @@ func DataTypeToArrowType(col Column) arrow.DataType {
 	case TypeTimestampTZ:
 		return &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
 	case TypeArray:
-		elemType := DataTypeToArrowType(Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale})
-		return arrow.ListOf(elemType)
+		elem := col.Element
+		if elem == nil {
+			elem = &Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale, MaxLength: col.MaxLength, FixedLength: col.FixedLength, Nullable: true}
+		}
+		elemField := arrow.Field{Name: "element", Type: DataTypeToArrowType(*elem), Nullable: elem.Nullable}
+		if col.ArrayLength > 0 {
+			return arrow.FixedSizeListOfField(col.ArrayLength, elemField)
+		}
+		return arrow.ListOfField(elemField)
+	case TypeStruct:
+		if col.StructFields == nil {
+			return arrow.StructOf()
+		}
+		fields := make([]arrow.Field, len(col.StructFields.Columns))
+		for i, field := range col.StructFields.Columns {
+			fields[i] = arrow.Field{Name: field.Name, Type: DataTypeToArrowType(field), Nullable: field.Nullable}
+		}
+		return arrow.StructOf(fields...)
+	case TypeMap:
+		key := Column{DataType: TypeString, Nullable: false}
+		if col.MapKey != nil {
+			key = *col.MapKey
+		}
+		value := Column{DataType: TypeUnknown, Nullable: true}
+		if col.MapValue != nil {
+			value = *col.MapValue
+		}
+		return arrow.MapOfFields(
+			arrow.Field{Name: "key", Type: DataTypeToArrowType(key), Nullable: false},
+			arrow.Field{Name: "value", Type: DataTypeToArrowType(value), Nullable: value.Nullable},
+		)
+	case TypeFixedBinary:
+		return &arrow.FixedSizeBinaryType{ByteWidth: col.FixedLength}
 	default:
 		return arrow.BinaryTypes.String
 	}

--- a/pkg/schemaevolution/compare.go
+++ b/pkg/schemaevolution/compare.go
@@ -1,6 +1,7 @@
 package schemaevolution
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -9,7 +10,8 @@ import (
 
 // CompareOptions contains optional parameters for schema comparison.
 type CompareOptions struct {
-	Overrides ColumnOverrides
+	Overrides   ColumnOverrides
+	PrimaryKeys []string
 }
 
 // Compare compares source and destination schemas and returns the differences.
@@ -23,8 +25,12 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 	}
 
 	var overrides ColumnOverrides
+	primaryKeys := make(map[string]struct{})
 	if opts != nil {
 		overrides = opts.Overrides
+		for _, key := range opts.PrimaryKeys {
+			primaryKeys[strings.ToLower(key)] = struct{}{}
+		}
 	}
 
 	destColumnMap := make(map[string]schema.Column)
@@ -46,7 +52,23 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 		// Check for user override first
 		if override, hasOverride := overrides.Get(srcCol.Name); hasOverride {
 			newCol := override.ApplyToColumn(srcCol)
-			newCol.Nullable = true
+			if exists {
+				newCol.Name = destCol.Name
+				_, isPrimaryKey := primaryKeys[lowerName]
+				relaxNullability := srcCol.Nullable && !destCol.Nullable && !isPrimaryKey
+				newCol.Nullable = destCol.Nullable || relaxNullability
+				if relaxNullability {
+					old := destCol
+					relaxed := destCol
+					relaxed.Nullable = true
+					changes = append(changes, SchemaChange{
+						Type: ChangeRelaxNullability, ColumnName: destCol.Name, ColumnPath: []string{destCol.Name},
+						OldColumn: &old, NewColumn: relaxed,
+					})
+				}
+			} else {
+				newCol.Nullable = true
+			}
 
 			// If destination exists and matches override, no change needed
 			if exists && destCol.DataType == newCol.DataType {
@@ -82,7 +104,8 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 
 			changes = append(changes, SchemaChange{
 				Type:       changeType,
-				ColumnName: srcCol.Name,
+				ColumnName: newCol.Name,
+				ColumnPath: []string{newCol.Name},
 				OldColumn:  oldCol,
 				NewColumn:  newCol,
 			})
@@ -98,17 +121,44 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 			})
 			continue
 		}
+		if srcCol.DataType != destCol.DataType && (nestedColumnType(srcCol.DataType) || nestedColumnType(destCol.DataType)) {
+			return nil, fmt.Errorf("unsupported nested schema change at %s: %s to %s", srcCol.Name, destCol.DataType, srcCol.DataType)
+		}
+		if nestedColumnType(srcCol.DataType) && srcCol.DataType == destCol.DataType {
+			_, isPrimaryKey := primaryKeys[lowerName]
+			nestedChanges, err := compareColumnRecursive([]string{destCol.Name}, srcCol, destCol, isPrimaryKey)
+			if err != nil {
+				return nil, err
+			}
+			changes = append(changes, nestedChanges...)
+			continue
+		}
+		_, isPrimaryKey := primaryKeys[lowerName]
+		if srcCol.Nullable && !destCol.Nullable && !isPrimaryKey {
+			old := destCol
+			newCol := srcCol
+			newCol.Name = destCol.Name
+			changes = append(changes, SchemaChange{
+				Type: ChangeRelaxNullability, ColumnName: destCol.Name, ColumnPath: []string{destCol.Name},
+				OldColumn: &old, NewColumn: newCol,
+			})
+		}
 
 		if needsWidening(srcCol, destCol) {
 			widenedType, _ := GetWidenedType(srcCol.DataType, destCol.DataType)
 			newCol := srcCol
+			newCol.Name = destCol.Name
 			newCol.DataType = widenedType
-			newCol.Nullable = true
+			newCol.Nullable = destCol.Nullable || (srcCol.Nullable && !isPrimaryKey)
 
 			// For decimal precision/scale widening, keep TypeDecimal but merge precision
 			isDecimalPrecisionWidening := srcCol.DataType == schema.TypeDecimal && destCol.DataType == schema.TypeDecimal
 			if isDecimalPrecisionWidening {
-				newCol.Precision, newCol.Scale = MergeDecimalPrecision(srcCol, destCol)
+				var err error
+				newCol.Precision, newCol.Scale, err = MergeDecimalPrecisionChecked(srcCol, destCol)
+				if err != nil {
+					return nil, fmt.Errorf("column %s: %w", destCol.Name, err)
+				}
 			}
 
 			// For string length widening, keep TypeString but grow the length.
@@ -120,10 +170,12 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 			}
 
 			// Only add change if type is different OR precision/length needs widening
-			if widenedType != destCol.DataType || isDecimalPrecisionWidening || isStringLengthWidening {
+			isNestedShapeChange := srcCol.DataType == destCol.DataType && nestedColumnType(srcCol.DataType)
+			if widenedType != destCol.DataType || isDecimalPrecisionWidening || isStringLengthWidening || isNestedShapeChange {
 				changes = append(changes, SchemaChange{
 					Type:       ChangeWidenType,
-					ColumnName: srcCol.Name,
+					ColumnName: destCol.Name,
+					ColumnPath: []string{destCol.Name},
 					OldColumn:  &destCol,
 					NewColumn:  newCol,
 				})
@@ -156,6 +208,148 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 	}, nil
 }
 
+func compareColumnRecursive(path []string, src, dest schema.Column, ignoreNullability bool) ([]SchemaChange, error) {
+	var changes []SchemaChange
+	name := strings.Join(path, ".")
+	if src.Nullable && !dest.Nullable && !ignoreNullability {
+		old := dest
+		newColumn := src
+		newColumn.Name = dest.Name
+		changes = append(changes, SchemaChange{
+			Type: ChangeRelaxNullability, ColumnName: name, ColumnPath: append([]string(nil), path...),
+			OldColumn: &old, NewColumn: newColumn,
+		})
+	}
+	if src.DataType != dest.DataType {
+		if nestedColumnType(src.DataType) || nestedColumnType(dest.DataType) {
+			return nil, fmt.Errorf("unsupported nested schema change at %s: %s to %s", name, dest.DataType, src.DataType)
+		}
+		old := dest
+		newColumn, err := widenedColumn(src, dest)
+		if err != nil {
+			return nil, fmt.Errorf("column %s: %w", name, err)
+		}
+		return append(changes, SchemaChange{
+			Type: ChangeWidenType, ColumnName: name, ColumnPath: append([]string(nil), path...),
+			OldColumn: &old, NewColumn: newColumn,
+		}), nil
+	}
+	switch src.DataType {
+	case schema.TypeStruct:
+		if src.StructFields == nil || dest.StructFields == nil {
+			if src.StructFields == nil && dest.StructFields == nil {
+				return changes, nil
+			}
+			return nil, fmt.Errorf("unsupported incomplete struct schema at %s", name)
+		}
+		destFields := make(map[string]schema.Column, len(dest.StructFields.Columns))
+		sourceFields := make(map[string]struct{}, len(src.StructFields.Columns))
+		for _, field := range dest.StructFields.Columns {
+			destFields[strings.ToLower(field.Name)] = field
+		}
+		for _, field := range src.StructFields.Columns {
+			sourceFields[strings.ToLower(field.Name)] = struct{}{}
+			old, ok := destFields[strings.ToLower(field.Name)]
+			childName := field.Name
+			if ok {
+				childName = old.Name
+			}
+			childPath := append(append([]string(nil), path...), childName)
+			if !ok {
+				added := makeNullable(field)
+				changes = append(changes, SchemaChange{
+					Type: ChangeAddColumn, ColumnName: strings.Join(childPath, "."), ColumnPath: childPath,
+					NewColumn: added,
+				})
+				continue
+			}
+			childChanges, err := compareColumnRecursive(childPath, field, old, false)
+			if err != nil {
+				return nil, err
+			}
+			changes = append(changes, childChanges...)
+		}
+		for _, old := range dest.StructFields.Columns {
+			if _, ok := sourceFields[strings.ToLower(old.Name)]; ok || old.Nullable {
+				continue
+			}
+			childPath := append(append([]string(nil), path...), old.Name)
+			oldCopy := old
+			changes = append(changes, SchemaChange{
+				Type: ChangeRemoveColumn, ColumnName: strings.Join(childPath, "."), ColumnPath: childPath,
+				OldColumn: &oldCopy,
+			})
+		}
+	case schema.TypeArray:
+		if src.ArrayLength != dest.ArrayLength {
+			return nil, fmt.Errorf("unsupported list cardinality change at %s: %d to %d", name, dest.ArrayLength, src.ArrayLength)
+		}
+		srcElem := normalizedArrayElement(src)
+		destElem := normalizedArrayElement(dest)
+		child, err := compareColumnRecursive(append(append([]string(nil), path...), "element"), srcElem, destElem, false)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, child...)
+	case schema.TypeMap:
+		if src.MapKey == nil || dest.MapKey == nil || src.MapValue == nil || dest.MapValue == nil {
+			return nil, fmt.Errorf("unsupported incomplete map schema at %s", name)
+		}
+		if schema.DataTypeToArrowType(*src.MapKey).Fingerprint() != schema.DataTypeToArrowType(*dest.MapKey).Fingerprint() {
+			return nil, fmt.Errorf("unsupported map key change at %s.key", name)
+		}
+		child, err := compareColumnRecursive(append(append([]string(nil), path...), "value"), *src.MapValue, *dest.MapValue, false)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, child...)
+	default:
+		if src.DataType == schema.TypeFixedBinary && dest.DataType == schema.TypeFixedBinary && src.FixedLength != dest.FixedLength {
+			return nil, fmt.Errorf("unsupported fixed-binary width change at %s: %d to %d", name, dest.FixedLength, src.FixedLength)
+		}
+		if needsWidening(src, dest) {
+			old := dest
+			newColumn, err := widenedColumn(src, dest)
+			if err != nil {
+				return nil, fmt.Errorf("column %s: %w", name, err)
+			}
+			changes = append(changes, SchemaChange{
+				Type: ChangeWidenType, ColumnName: name, ColumnPath: append([]string(nil), path...),
+				OldColumn: &old, NewColumn: newColumn,
+			})
+		}
+	}
+	return changes, nil
+}
+
+func widenedColumn(src, dest schema.Column) (schema.Column, error) {
+	result := src
+	result.Name = dest.Name
+	result.DataType, _ = GetWidenedType(src.DataType, dest.DataType)
+	result.Nullable = src.Nullable || dest.Nullable
+	if result.DataType == schema.TypeDecimal && src.DataType == schema.TypeDecimal && dest.DataType == schema.TypeDecimal {
+		var err error
+		result.Precision, result.Scale, err = MergeDecimalPrecisionChecked(src, dest)
+		if err != nil {
+			return schema.Column{}, err
+		}
+	}
+	if result.DataType == schema.TypeString && src.DataType == schema.TypeString && dest.DataType == schema.TypeString {
+		result.MaxLength = WidenedStringLength(src.MaxLength, dest.MaxLength)
+	}
+	return result, nil
+}
+
+func normalizedArrayElement(col schema.Column) schema.Column {
+	if col.Element != nil {
+		return *col.Element
+	}
+	return schema.Column{
+		Name: "element", DataType: col.ArrayType, Nullable: true,
+		Precision: col.Precision, Scale: col.Scale, MaxLength: col.MaxLength, FixedLength: col.FixedLength,
+	}
+}
+
 func makeNullable(col schema.Column) schema.Column {
 	col.Nullable = true
 	return col
@@ -168,11 +362,22 @@ func needsWidening(src, dest schema.Column) bool {
 			return src.Precision > dest.Precision || src.Scale > dest.Scale
 		case schema.TypeString:
 			return stringNeedsWidening(src.MaxLength, dest.MaxLength)
+		case schema.TypeArray, schema.TypeStruct, schema.TypeMap, schema.TypeFixedBinary:
+			return schema.DataTypeToArrowType(src).Fingerprint() != schema.DataTypeToArrowType(dest).Fingerprint()
 		default:
 			return false
 		}
 	}
 	return true
+}
+
+func nestedColumnType(dataType schema.DataType) bool {
+	switch dataType {
+	case schema.TypeArray, schema.TypeStruct, schema.TypeMap, schema.TypeFixedBinary:
+		return true
+	default:
+		return false
+	}
 }
 
 // stringNeedsWidening reports whether a bounded string column must grow to hold

--- a/pkg/schemaevolution/compare_test.go
+++ b/pkg/schemaevolution/compare_test.go
@@ -176,6 +176,8 @@ func TestCompare_TypeWidening_IntToFloat(t *testing.T) {
 	change := result.Changes[0]
 	assert.Equal(t, ChangeWidenType, change.Type)
 	assert.Equal(t, schema.TypeFloat64, change.NewColumn.DataType)
+	assert.False(t, change.NewColumn.Nullable)
+	assert.False(t, BuildFinalSchema(dest, result).Columns[0].Nullable)
 }
 
 func TestCompare_TypeWidening_ToString(t *testing.T) {
@@ -424,7 +426,26 @@ func TestCompare_SameTypeDifferentNullability(t *testing.T) {
 
 	result, err := Compare(source, dest, nil)
 	require.NoError(t, err)
-	assert.False(t, result.HasChanges, "nullability difference alone should not trigger widening")
+	require.True(t, result.HasChanges)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, ChangeRelaxNullability, result.Changes[0].Type)
+}
+
+func TestCompare_IgnoresInferredNullabilityForConfiguredPrimaryKeys(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	dest := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: false},
+	}}
+
+	result, err := Compare(source, dest, &CompareOptions{PrimaryKeys: []string{"ID"}})
+	require.NoError(t, err)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, ChangeRelaxNullability, result.Changes[0].Type)
+	assert.Equal(t, "value", result.Changes[0].ColumnName)
 }
 
 func TestMakeNullable(t *testing.T) {

--- a/pkg/schemaevolution/contract.go
+++ b/pkg/schemaevolution/contract.go
@@ -72,7 +72,7 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 
 	case ContractDiscardRow:
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeRemoveColumn || isInternalAllowedChange(change) {
+			if isDiscardRowAllowedChange(change) {
 				result.Allowed = append(result.Allowed, change)
 			} else {
 				result.Violations = append(result.Violations, ContractViolation{
@@ -85,7 +85,7 @@ func ApplyContract(contract SchemaContract, comparison *SchemaComparison) *Contr
 
 	case ContractDiscardValue:
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeAddColumn || change.Type == ChangeRemoveColumn {
+			if change.Type == ChangeAddColumn || change.Type == ChangeRemoveColumn || change.Type == ChangeRelaxNullability {
 				result.Allowed = append(result.Allowed, change)
 			} else {
 				result.Violations = append(result.Violations, ContractViolation{
@@ -104,6 +104,10 @@ func isInternalAllowedChange(change SchemaChange) bool {
 	return change.Type == ChangeAddColumn && strings.EqualFold(change.ColumnName, naming.IngestrLoadedAtColumn)
 }
 
+func isDiscardRowAllowedChange(change SchemaChange) bool {
+	return change.Type == ChangeRemoveColumn || change.Type == ChangeRelaxNullability || isInternalAllowedChange(change)
+}
+
 func describeChange(change SchemaChange) string {
 	switch change.Type {
 	case ChangeAddColumn:
@@ -120,6 +124,8 @@ func describeChange(change SchemaChange) string {
 		return fmt.Sprintf("type override to %s", change.NewColumn.DataType)
 	case ChangeRemoveColumn:
 		return "column removed from source (future values will be NULL)"
+	case ChangeRelaxNullability:
+		return "column changed from required to optional"
 	default:
 		return "unknown change"
 	}

--- a/pkg/schemaevolution/contract_test.go
+++ b/pkg/schemaevolution/contract_test.go
@@ -149,6 +149,47 @@ func TestApplyContract_DiscardValue(t *testing.T) {
 	assert.Equal(t, "amount", result.Violations[0].ColumnName)
 }
 
+func TestApplyContractDiscardValueAllowsNullabilityRelaxation(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{
+		{Type: ChangeRelaxNullability, ColumnName: "optional"},
+		{Type: ChangeWidenType, ColumnName: "amount"},
+	}}
+	result := ApplyContract(SchemaContract{Mode: ContractDiscardValue}, comparison)
+	require.Len(t, result.Allowed, 1)
+	require.Equal(t, ChangeRelaxNullability, result.Allowed[0].Type)
+	require.Len(t, result.Violations, 1)
+	require.Equal(t, ChangeWidenType, result.Violations[0].ChangeType)
+}
+
+func TestApplyContractDiscardRowAllowsNullabilityRelaxation(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{
+		{Type: ChangeRelaxNullability, ColumnName: "optional"},
+		{Type: ChangeWidenType, ColumnName: "amount"},
+	}}
+	result := ApplyContract(SchemaContract{Mode: ContractDiscardRow}, comparison)
+	require.Len(t, result.Allowed, 1)
+	require.Equal(t, ChangeRelaxNullability, result.Allowed[0].Type)
+	require.Len(t, result.Violations, 1)
+	require.Equal(t, ChangeWidenType, result.Violations[0].ChangeType)
+}
+
+func TestApplyContract_DiscardValueDoesNotViolateConfiguredPrimaryKeyNullability(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "age", DataType: schema.TypeString, Nullable: true},
+	}}
+	dest := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "age", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison, err := Compare(source, dest, &CompareOptions{PrimaryKeys: []string{"id"}})
+	require.NoError(t, err)
+
+	result := ApplyContract(SchemaContract{Mode: ContractDiscardValue}, comparison)
+	require.Len(t, result.Violations, 1)
+	assert.Equal(t, "age", result.Violations[0].ColumnName)
+}
+
 func TestApplyContract_NoChanges(t *testing.T) {
 	comparison := &SchemaComparison{
 		HasChanges: false,

--- a/pkg/schemaevolution/evolve.go
+++ b/pkg/schemaevolution/evolve.go
@@ -26,8 +26,8 @@ type SchemaEvolver interface {
 
 // ApplicableComparison returns the subset of changes that will actually be
 // reflected in the destination schema given whether the destination supports
-// column type changes. Add/remove changes always apply; type changes only
-// apply when supportsTypeChanges is true.
+// column type changes. Add/remove/nullability changes always apply; type
+// changes only apply when supportsTypeChanges is true.
 func ApplicableComparison(comparison *SchemaComparison, supportsTypeChanges bool) *SchemaComparison {
 	if comparison == nil || !comparison.HasChanges {
 		return &SchemaComparison{}

--- a/pkg/schemaevolution/evolve_test.go
+++ b/pkg/schemaevolution/evolve_test.go
@@ -46,6 +46,17 @@ func TestApplicableComparison_KeepsTypeChangesWhenSupported(t *testing.T) {
 	require.Len(t, got.Changes, 3)
 }
 
+func TestApplicableComparisonKeepsNullabilityRelaxationWithoutTypeChanges(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{
+		{Type: ChangeWidenType, ColumnName: "value"},
+		{Type: ChangeRelaxNullability, ColumnName: "optional"},
+	}}
+	got := ApplicableComparison(comparison, false)
+	require.True(t, got.HasChanges)
+	require.Len(t, got.Changes, 1)
+	require.Equal(t, ChangeRelaxNullability, got.Changes[0].Type)
+}
+
 func TestApplicableComparison_NilAndEmpty(t *testing.T) {
 	assert.False(t, ApplicableComparison(nil, true).HasChanges)
 	assert.False(t, ApplicableComparison(&SchemaComparison{}, true).HasChanges)
@@ -78,6 +89,7 @@ func TestBuildFinalSchema_AppliesApplicableChanges(t *testing.T) {
 	assert.Equal(t, schema.TypeInt64, byName["val"].DataType)
 	assert.Contains(t, byName, "added")
 	assert.Contains(t, byName, "gone")
+	assert.True(t, byName["gone"].Nullable, "soft-removed columns must accept NULL in future rows")
 
 	// Without type-change support: val keeps its original type.
 	finalNoType := BuildFinalSchema(dest, ApplicableComparison(widenComparison(), false))

--- a/pkg/schemaevolution/nested_compare_test.go
+++ b/pkg/schemaevolution/nested_compare_test.go
@@ -1,0 +1,271 @@
+package schemaevolution
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareDetectsRecursiveNullabilityRelaxationAndStructAddition(t *testing.T) {
+	requiredString := &schema.Column{Name: "element", DataType: schema.TypeString, Nullable: false}
+	optionalString := &schema.Column{Name: "element", DataType: schema.TypeString, Nullable: true}
+	dest := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "top", DataType: schema.TypeString, Nullable: false},
+		{Name: "items", DataType: schema.TypeArray, Element: requiredString, Nullable: true},
+		{
+			Name: "attributes", DataType: schema.TypeMap,
+			MapKey:   &schema.Column{Name: "key", DataType: schema.TypeString, Nullable: false},
+			MapValue: &schema.Column{Name: "value", DataType: schema.TypeString, Nullable: false}, Nullable: true,
+		},
+		{Name: "profile", DataType: schema.TypeStruct, StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: false},
+		}}, Nullable: true},
+	}}
+	source := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "top", DataType: schema.TypeString, Nullable: true},
+		{Name: "items", DataType: schema.TypeArray, Element: optionalString, Nullable: true},
+		{
+			Name: "attributes", DataType: schema.TypeMap,
+			MapKey:   &schema.Column{Name: "key", DataType: schema.TypeString, Nullable: false},
+			MapValue: &schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true}, Nullable: true,
+		},
+		{Name: "profile", DataType: schema.TypeStruct, StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "timezone", DataType: schema.TypeString, Nullable: false},
+		}}, Nullable: true},
+	}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.True(t, comparison.HasChanges)
+	paths := make(map[string]ChangeType)
+	for _, change := range comparison.Changes {
+		paths[change.ColumnName] = change.Type
+	}
+	require.Equal(t, ChangeRelaxNullability, paths["top"])
+	require.Equal(t, ChangeRelaxNullability, paths["items.element"])
+	require.Equal(t, ChangeRelaxNullability, paths["attributes.value"])
+	require.Equal(t, ChangeRelaxNullability, paths["profile.name"])
+	require.Equal(t, ChangeAddColumn, paths["profile.timezone"])
+	for _, change := range comparison.Changes {
+		if change.ColumnName == "profile.timezone" {
+			require.True(t, change.NewColumn.Nullable, "nested additions to existing rows must be optional")
+		}
+	}
+}
+
+func TestComparePrimaryKeySuppressionPreservesNestedChildNullability(t *testing.T) {
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: false,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: false}}},
+	}}}
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: true}}},
+	}}}
+
+	comparison, err := Compare(source, dest, &CompareOptions{PrimaryKeys: []string{"PROFILE"}})
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, ChangeRelaxNullability, comparison.Changes[0].Type)
+	require.Equal(t, []string{"profile", "name"}, comparison.Changes[0].ColumnPath)
+}
+
+func TestCompareRejectsNestedContainerReplacement(t *testing.T) {
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "nested", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeString}}},
+	}}}
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "nested", DataType: schema.TypeMap,
+		MapKey: &schema.Column{DataType: schema.TypeString}, MapValue: &schema.Column{DataType: schema.TypeString},
+	}}}
+	_, err := Compare(source, dest, nil)
+	require.ErrorContains(t, err, "unsupported nested schema change")
+}
+
+func TestCompareUsesExistingDestinationCaseForNestedPaths(t *testing.T) {
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "Profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "DisplayName", DataType: schema.TypeString, Nullable: false}}},
+	}}}
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "displayname", DataType: schema.TypeString, Nullable: true}}},
+	}}}
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, []string{"Profile", "DisplayName"}, comparison.Changes[0].ColumnPath)
+}
+
+func TestBuildFinalSchemaDoesNotMutateNestedDestination(t *testing.T) {
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: false}}},
+	}}}
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRelaxNullability, ColumnName: "profile.name", ColumnPath: []string{"profile", "name"},
+		NewColumn: schema.Column{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}}}
+	final := BuildFinalSchema(dest, comparison)
+	require.True(t, final.Columns[0].StructFields.Columns[0].Nullable)
+	require.False(t, dest.Columns[0].StructFields.Columns[0].Nullable)
+}
+
+func TestCompareSoftRemovesRequiredDestinationOnlyStructField(t *testing.T) {
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "legacy", DataType: schema.TypeString, Nullable: false},
+		}},
+	}}}
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: true}}},
+	}}}
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, ChangeRemoveColumn, comparison.Changes[0].Type)
+	require.Equal(t, []string{"profile", "legacy"}, comparison.Changes[0].ColumnPath)
+	final := BuildFinalSchema(dest, comparison)
+	require.True(t, final.Columns[0].StructFields.Columns[1].Nullable)
+}
+
+func TestCompareNestedScalarMismatchUsesCommonWidening(t *testing.T) {
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "count", DataType: schema.TypeInt64}}},
+	}}}
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "count", DataType: schema.TypeInt32}}},
+	}}}
+
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, []string{"profile", "count"}, comparison.Changes[0].ColumnPath)
+	require.Equal(t, schema.TypeInt64, comparison.Changes[0].NewColumn.DataType)
+
+	final := BuildFinalSchema(dest, comparison)
+	require.Equal(t, schema.TypeInt64, final.Columns[0].StructFields.Columns[0].DataType)
+}
+
+func TestCompareRejectsListCardinalityMismatch(t *testing.T) {
+	element := &schema.Column{Name: "element", DataType: schema.TypeInt64, Nullable: false}
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "items", DataType: schema.TypeArray, ArrayLength: 3, Element: element,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "items", DataType: schema.TypeArray, Element: element,
+	}}}
+	_, err := Compare(source, dest, nil)
+	require.ErrorContains(t, err, "unsupported list cardinality change")
+}
+
+func TestCompareUsesCanonicalDestinationNameForTopLevelChanges(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: true}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt32, Nullable: false}}}
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 2)
+	for _, change := range comparison.Changes {
+		require.Equal(t, "ID", change.ColumnName)
+		require.Equal(t, []string{"ID"}, change.ColumnPath)
+		require.Equal(t, "ID", change.NewColumn.Name)
+	}
+	final := BuildFinalSchema(dest, comparison)
+	require.Len(t, final.Columns, 1)
+	require.Equal(t, "ID", final.Columns[0].Name)
+	require.Equal(t, schema.TypeInt64, final.Columns[0].DataType)
+	require.True(t, final.Columns[0].Nullable)
+}
+
+func TestCompareNormalizesLegacyArrayElementMetadata(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amounts", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal,
+		Precision: 20, Scale: 2, Nullable: true,
+	}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amounts", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal,
+		Precision: 10, Scale: 2, Nullable: true,
+	}}}
+	comparison, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, []string{"amounts", "element"}, comparison.Changes[0].ColumnPath)
+	require.Equal(t, 20, comparison.Changes[0].NewColumn.Precision)
+	require.Equal(t, 2, comparison.Changes[0].NewColumn.Scale)
+	final := BuildFinalSchema(dest, comparison)
+	require.Equal(t, 20, final.Columns[0].Precision)
+	require.Equal(t, 2, final.Columns[0].Scale)
+	require.NotNil(t, final.Columns[0].Element)
+	require.Equal(t, 20, final.Columns[0].Element.Precision)
+}
+
+func TestCompareNormalizesLegacyArrayLengthAndElementNullability(t *testing.T) {
+	t.Run("bounded string length", func(t *testing.T) {
+		source := &schema.TableSchema{Columns: []schema.Column{{
+			Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString, MaxLength: 20,
+		}}}
+		dest := &schema.TableSchema{Columns: []schema.Column{{
+			Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString, MaxLength: 10,
+		}}}
+		comparison, err := Compare(source, dest, nil)
+		require.NoError(t, err)
+		require.Len(t, comparison.Changes, 1)
+		require.Equal(t, 20, comparison.Changes[0].NewColumn.MaxLength)
+		require.Equal(t, 20, BuildFinalSchema(dest, comparison).Columns[0].MaxLength)
+	})
+
+	t.Run("legacy nullable element against explicit required element", func(t *testing.T) {
+		source := &schema.TableSchema{Columns: []schema.Column{{
+			Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString,
+		}}}
+		dest := &schema.TableSchema{Columns: []schema.Column{{
+			Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString,
+			Element: &schema.Column{Name: "element", DataType: schema.TypeString, Nullable: false},
+		}}}
+		comparison, err := Compare(source, dest, nil)
+		require.NoError(t, err)
+		require.Len(t, comparison.Changes, 1)
+		require.Equal(t, ChangeRelaxNullability, comparison.Changes[0].Type)
+		require.Equal(t, []string{"labels", "element"}, comparison.Changes[0].ColumnPath)
+	})
+
+	t.Run("fixed binary width", func(t *testing.T) {
+		source := &schema.TableSchema{Columns: []schema.Column{{
+			Name: "digests", DataType: schema.TypeArray, ArrayType: schema.TypeFixedBinary, FixedLength: 16,
+		}}}
+		dest := &schema.TableSchema{Columns: []schema.Column{{
+			Name: "digests", DataType: schema.TypeArray, ArrayType: schema.TypeFixedBinary, FixedLength: 8,
+		}}}
+		_, err := Compare(source, dest, nil)
+		require.ErrorContains(t, err, "unsupported fixed-binary width change")
+	})
+}
+
+func TestCompareRejectsFixedBinaryWidthEvolution(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "digest", DataType: schema.TypeFixedBinary, FixedLength: 16}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "digest", DataType: schema.TypeFixedBinary, FixedLength: 8}}}
+	_, err := Compare(source, dest, nil)
+	require.ErrorContains(t, err, "unsupported fixed-binary width change")
+	require.ErrorContains(t, err, "8 to 16")
+}
+
+func TestCompareRejectsUnrepresentableDecimalWidening(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 38}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 0}}}
+	_, err := Compare(source, dest, nil)
+	require.ErrorContains(t, err, "decimal widening requires precision 76")
+
+	source.Columns[0] = schema.Column{Name: "payload", DataType: schema.TypeStruct, StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 38}}}}
+	dest.Columns[0] = schema.Column{Name: "payload", DataType: schema.TypeStruct, StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 0}}}}
+	_, err = Compare(source, dest, nil)
+	require.ErrorContains(t, err, "payload.amount")
+	require.ErrorContains(t, err, "decimal widening requires precision 76")
+}

--- a/pkg/schemaevolution/override.go
+++ b/pkg/schemaevolution/override.go
@@ -11,12 +11,13 @@ import (
 
 // ColumnOverride represents a user-specified column type override.
 type ColumnOverride struct {
-	Name      string
-	RenameTo  string
-	DataType  schema.DataType
-	Precision int
-	Scale     int
-	MaxLength int
+	Name           string
+	RenameTo       string
+	DataType       schema.DataType
+	Precision      int
+	Scale          int
+	ScaleSpecified bool
+	MaxLength      int
 }
 
 // ColumnOverrides is a map of column name (lowercase) to its override.
@@ -217,21 +218,28 @@ func parseColumnOverride(pair string) (ColumnOverride, error) {
 
 		switch dataType {
 		case schema.TypeDecimal:
-			// Handle precision/scale for decimal
-			if len(params) >= 1 {
-				p, err := strconv.Atoi(strings.TrimSpace(params[0]))
-				if err != nil {
-					return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': %w", typeSpec, err)
-				}
-				override.Precision = p
+			if len(params) < 1 || len(params) > 2 {
+				return ColumnOverride{}, fmt.Errorf("invalid decimal parameters in '%s': expected decimal(precision) or decimal(precision,scale)", typeSpec)
 			}
-			if len(params) >= 2 {
+			p, err := strconv.Atoi(strings.TrimSpace(params[0]))
+			if err != nil {
+				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': %w", typeSpec, err)
+			}
+			if p < 1 || p > 38 {
+				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': must be between 1 and 38", typeSpec)
+			}
+			override.Precision = p
+			if len(params) == 2 {
 				s, err := strconv.Atoi(strings.TrimSpace(params[1]))
 				if err != nil {
 					return ColumnOverride{}, fmt.Errorf("invalid scale in '%s': %w", typeSpec, err)
 				}
+				if s < 0 || s > p {
+					return ColumnOverride{}, fmt.Errorf("invalid scale in '%s': must be between 0 and precision %d", typeSpec, p)
+				}
 				override.Scale = s
 			}
+			override.ScaleSpecified = true
 		case schema.TypeString:
 			// Sized string types take exactly one length parameter, e.g. varchar(50).
 			if len(params) != 1 {
@@ -315,7 +323,7 @@ func (o ColumnOverride) ApplyToColumn(col schema.Column) schema.Column {
 	if o.Precision > 0 {
 		col.Precision = o.Precision
 	}
-	if o.Scale > 0 {
+	if o.ScaleSpecified || o.Scale > 0 {
 		col.Scale = o.Scale
 	}
 	if o.MaxLength > 0 {

--- a/pkg/schemaevolution/override_test.go
+++ b/pkg/schemaevolution/override_test.go
@@ -75,6 +75,39 @@ func TestParseColumnOverrides_DecimalWithPrecisionOnly(t *testing.T) {
 	assert.Equal(t, schema.TypeDecimal, amount.DataType)
 	assert.Equal(t, 18, amount.Precision)
 	assert.Equal(t, 0, amount.Scale)
+	assert.True(t, amount.ScaleSpecified)
+
+	result := amount.ApplyToColumn(schema.Column{DataType: schema.TypeDecimal, Precision: 10, Scale: 4})
+	assert.Equal(t, 18, result.Precision)
+	assert.Zero(t, result.Scale)
+}
+
+func TestParseColumnOverrides_DecimalValidationAndExplicitZeroScale(t *testing.T) {
+	overrides, err := ParseColumnOverrides("amount:decimal(18,0)")
+	require.NoError(t, err)
+	amount, ok := overrides.Get("amount")
+	require.True(t, ok)
+	require.True(t, amount.ScaleSpecified)
+	require.Zero(t, amount.Scale)
+
+	result := amount.ApplyToColumn(schema.Column{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 4,
+	})
+	require.Equal(t, 18, result.Precision)
+	require.Zero(t, result.Scale)
+
+	for _, spec := range []string{
+		"amount:decimal(0,0)",
+		"amount:decimal(39,2)",
+		"amount:decimal(10,-1)",
+		"amount:decimal(10,11)",
+		"amount:decimal(10,2,1)",
+	} {
+		t.Run(spec, func(t *testing.T) {
+			_, err := ParseColumnOverrides(spec)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestParseColumnOverrides_SizedString(t *testing.T) {
@@ -444,6 +477,46 @@ func TestCompare_OverrideMatchesDestination(t *testing.T) {
 	result, err := Compare(source, dest, opts)
 	require.NoError(t, err)
 	assert.False(t, result.HasChanges)
+}
+
+func TestCompare_RequiredOverrideDoesNotClaimNullabilityRelaxation(t *testing.T) {
+	source := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: false}}}
+	dest := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: false}}}
+	overrides, err := ParseColumnOverrides("value:bigint")
+	require.NoError(t, err)
+
+	comparison, err := Compare(source, dest, &CompareOptions{Overrides: overrides})
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, ChangeOverrideType, comparison.Changes[0].Type)
+	require.False(t, comparison.Changes[0].NewColumn.Nullable)
+	require.False(t, BuildFinalSchema(dest, comparison).Columns[0].Nullable)
+}
+
+func TestCompare_OverrideStillEmitsNullabilityRelaxation(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		changes  []ChangeType
+	}{
+		{name: "override matches destination", override: "value:integer", changes: []ChangeType{ChangeRelaxNullability}},
+		{name: "override changes type", override: "value:double", changes: []ChangeType{ChangeRelaxNullability, ChangeOverrideType}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: true}}}
+			dest := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt64, Nullable: false}}}
+			overrides, err := ParseColumnOverrides(tt.override)
+			require.NoError(t, err)
+			comparison, err := Compare(source, dest, &CompareOptions{Overrides: overrides})
+			require.NoError(t, err)
+			require.Len(t, comparison.Changes, len(tt.changes))
+			for i, changeType := range tt.changes {
+				require.Equal(t, changeType, comparison.Changes[i].Type)
+			}
+			require.True(t, BuildFinalSchema(dest, comparison).Columns[0].Nullable)
+		})
+	}
 }
 
 func TestCompare_DecimalOverrideWithPrecision(t *testing.T) {

--- a/pkg/schemaevolution/plan.go
+++ b/pkg/schemaevolution/plan.go
@@ -15,6 +15,9 @@ type EvolutionPlan struct {
 	// Comparison is the set of schema changes the destination should apply.
 	// It is nil or empty when no migration is required.
 	Comparison *SchemaComparison
+	// TransformComparison retains contract-rejected changes needed by runtime
+	// discard transformations; Comparison contains only destination mutations.
+	TransformComparison *SchemaComparison
 	// FinalSchema is what the destination table will look like once the
 	// applicable changes have been applied.
 	FinalSchema *schema.TableSchema
@@ -34,7 +37,7 @@ func BuildFinalSchema(destSchema *schema.TableSchema, comparison *SchemaComparis
 	}
 
 	result := *destSchema
-	result.Columns = append([]schema.Column{}, destSchema.Columns...)
+	result.Columns = cloneColumns(destSchema.Columns)
 	result.PrimaryKeys = append([]string{}, destSchema.PrimaryKeys...)
 
 	if comparison == nil || !comparison.HasChanges {
@@ -44,20 +47,119 @@ func BuildFinalSchema(destSchema *schema.TableSchema, comparison *SchemaComparis
 	for _, change := range comparison.Changes {
 		switch change.Type {
 		case ChangeAddColumn:
-			result.Columns = append(result.Columns, change.NewColumn)
-
-		case ChangeWidenType, ChangeOverrideType:
-			for i, col := range result.Columns {
-				if col.Name == change.ColumnName {
-					result.Columns[i] = change.NewColumn
-					break
-				}
+			if len(change.ColumnPath) <= 1 {
+				result.Columns = append(result.Columns, change.NewColumn)
+			} else {
+				applyNestedColumnChange(result.Columns, change.ColumnPath[:len(change.ColumnPath)-1], func(parent *schema.Column) {
+					if parent.StructFields != nil {
+						parent.StructFields.Columns = append(parent.StructFields.Columns, change.NewColumn)
+					}
+				})
 			}
 
+		case ChangeWidenType, ChangeOverrideType:
+			path := change.ColumnPath
+			if len(path) == 0 {
+				path = []string{change.ColumnName}
+			}
+			applyNestedColumnChange(result.Columns, path, func(col *schema.Column) {
+				name := col.Name
+				*col = change.NewColumn
+				if col.Name == "" {
+					col.Name = name
+				}
+			})
+
 		case ChangeRemoveColumn:
-			// Soft remove: dest keeps the column, future rows have NULL there.
+			if len(change.ColumnPath) > 1 {
+				applyNestedColumnChange(result.Columns, change.ColumnPath, func(col *schema.Column) { col.Nullable = true })
+			}
+			// Soft remove: destination keeps the column; future values are NULL.
+			path := change.ColumnPath
+			if len(path) == 0 {
+				path = []string{change.ColumnName}
+			}
+			applyNestedColumnChange(result.Columns, path, func(col *schema.Column) { col.Nullable = true })
+		case ChangeRelaxNullability:
+			path := change.ColumnPath
+			if len(path) == 0 {
+				path = []string{change.ColumnName}
+			}
+			applyNestedColumnChange(result.Columns, path, func(col *schema.Column) { col.Nullable = true })
 		}
 	}
 
 	return &result
+}
+
+func cloneColumns(columns []schema.Column) []schema.Column {
+	out := make([]schema.Column, len(columns))
+	for i := range columns {
+		out[i] = columns[i]
+		if columns[i].Element != nil {
+			element := cloneColumns([]schema.Column{*columns[i].Element})[0]
+			out[i].Element = &element
+		}
+		if columns[i].StructFields != nil {
+			fields := *columns[i].StructFields
+			fields.Columns = cloneColumns(columns[i].StructFields.Columns)
+			out[i].StructFields = &fields
+		}
+		if columns[i].MapKey != nil {
+			key := cloneColumns([]schema.Column{*columns[i].MapKey})[0]
+			out[i].MapKey = &key
+		}
+		if columns[i].MapValue != nil {
+			value := cloneColumns([]schema.Column{*columns[i].MapValue})[0]
+			out[i].MapValue = &value
+		}
+	}
+	return out
+}
+
+func applyNestedColumnChange(columns []schema.Column, path []string, apply func(*schema.Column)) bool {
+	if len(path) == 0 {
+		return false
+	}
+	for i := range columns {
+		if columns[i].Name != path[0] {
+			continue
+		}
+		return applyNestedColumn(&columns[i], path[1:], apply)
+	}
+	return false
+}
+
+func applyNestedColumn(col *schema.Column, path []string, apply func(*schema.Column)) bool {
+	if len(path) == 0 {
+		apply(col)
+		return true
+	}
+	switch col.DataType {
+	case schema.TypeStruct:
+		if col.StructFields != nil {
+			return applyNestedColumnChange(col.StructFields.Columns, path, apply)
+		}
+	case schema.TypeArray:
+		if path[0] == "element" {
+			if col.Element == nil {
+				element := normalizedArrayElement(*col)
+				col.Element = &element
+			}
+			changed := applyNestedColumn(col.Element, path[1:], apply)
+			if changed {
+				col.ArrayType = col.Element.DataType
+				col.Precision = col.Element.Precision
+				col.Scale = col.Element.Scale
+				col.MaxLength = col.Element.MaxLength
+				col.FixedLength = col.Element.FixedLength
+			}
+			return changed
+		}
+	case schema.TypeMap:
+		if path[0] == "value" && col.MapValue != nil {
+			return applyNestedColumn(col.MapValue, path[1:], apply)
+		}
+	}
+	return false
 }

--- a/pkg/schemaevolution/transform.go
+++ b/pkg/schemaevolution/transform.go
@@ -3,6 +3,7 @@ package schemaevolution
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -35,12 +36,17 @@ func NewDiscardValueTransformer(comparison *SchemaComparison, _ *schema.TableSch
 
 	if comparison != nil {
 		for _, change := range comparison.Changes {
-			if change.Type == ChangeAddColumn {
+			if change.Type == ChangeAddColumn || change.Type == ChangeRemoveColumn || change.Type == ChangeRelaxNullability {
 				// New columns are allowed in discard_value mode, keep their values.
+				// Removed source fields are filled during schema alignment; they do not
+				// invalidate conforming siblings in the same nested parent.
+				// Nullability relaxation is applied as schema evolution because NULL
+				// cannot be transformed into a value accepted by a required column.
 				continue
 			}
 			// Track type incompatibilities to NULL out values.
-			transformer.violations[change.ColumnName] = true
+			path := changePath(change)
+			transformer.violations[strings.ToLower(path[0])] = true
 		}
 	}
 
@@ -61,7 +67,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 	// For each column with violations, replace with NULL values
 	for colIdx := 0; colIdx < int(batch.NumCols()); colIdx++ {
 		colName := batchSchema.Field(colIdx).Name
-		if t.violations[colName] {
+		if t.violations[strings.ToLower(colName)] {
 			// Violation: discard value (set to NULL)
 			// If the column exists in destination schema, use destination type (to satisfy strict typing)
 			// Otherwise use source type (e.g. for rejected new columns)
@@ -69,7 +75,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 			targetType := field.Type
 			if t.destSchema != nil {
 				for _, destCol := range t.destSchema.Columns {
-					if destCol.Name == colName {
+					if strings.EqualFold(destCol.Name, colName) {
 						targetType = schema.DataTypeToArrowType(destCol)
 						break
 					}
@@ -104,7 +110,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 	newSchema := arrow.NewSchema(newFields, nil)
 	newBatch := array.NewRecordBatch(newSchema, columns, batch.NumRows())
 	for i, col := range columns {
-		if t.violations[batchSchema.Field(i).Name] {
+		if t.violations[strings.ToLower(batchSchema.Field(i).Name)] {
 			col.Release()
 		}
 	}
@@ -113,7 +119,7 @@ func (t *DiscardValueTransformer) Transform(ctx context.Context, batch arrow.Rec
 
 // DiscardRowTransformer filters out rows with incompatible values.
 type DiscardRowTransformer struct {
-	violations map[string]bool // column name -> has violation
+	violations []SchemaChange
 	schema     *schema.TableSchema
 	destSchema *schema.TableSchema
 	allocator  memory.Allocator
@@ -122,7 +128,7 @@ type DiscardRowTransformer struct {
 // NewDiscardRowTransformer creates a transformer for discard_row mode.
 func NewDiscardRowTransformer(sourceSchema, destSchema *schema.TableSchema, comparison *SchemaComparison) *DiscardRowTransformer {
 	transformer := &DiscardRowTransformer{
-		violations: make(map[string]bool),
+		violations: make([]SchemaChange, 0),
 		schema:     sourceSchema,
 		destSchema: destSchema,
 		allocator:  memory.DefaultAllocator,
@@ -130,11 +136,11 @@ func NewDiscardRowTransformer(sourceSchema, destSchema *schema.TableSchema, comp
 
 	if comparison != nil {
 		for _, change := range comparison.Changes {
-			if isInternalAllowedChange(change) {
+			if isDiscardRowAllowedChange(change) {
 				continue
 			}
 			// Track all violations (both new columns and type mismatches)
-			transformer.violations[change.ColumnName] = true
+			transformer.violations = append(transformer.violations, change)
 		}
 	}
 
@@ -147,19 +153,6 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 		return batch, nil
 	}
 
-	// Find column indices that have violations
-	violationCols := make(map[int]string)
-	schema := batch.Schema()
-	for i := 0; i < schema.NumFields(); i++ {
-		colName := schema.Field(i).Name
-		if t.violations[colName] {
-			violationCols[i] = colName
-		}
-	}
-
-	if len(violationCols) == 0 {
-		return batch, nil
-	}
 	allocator := allocatorOrDefault(t.allocator)
 
 	// Create a boolean filter array: true for rows to keep, false for rows to discard
@@ -170,11 +163,13 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 	for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
 		keepRow := true
 
-		// Check if any violation column has a non-NULL value
-		for colIdx := range violationCols {
-			col := batch.Column(colIdx)
-			if col.IsValid(rowIdx) {
-				// This row has data in a violation column, discard it
+		for _, violation := range t.violations {
+			path := changePath(violation)
+			colIdx := fieldIndexFold(batch.Schema(), path[0])
+			if colIdx < 0 {
+				continue
+			}
+			if rowViolatesChange(batch.Column(colIdx), path[1:], rowIdx) {
 				keepRow = false
 				break
 			}
@@ -201,6 +196,88 @@ func (t *DiscardRowTransformer) Transform(ctx context.Context, batch arrow.Recor
 	}
 
 	return filtered, nil
+}
+
+func changePath(change SchemaChange) []string {
+	if len(change.ColumnPath) > 0 {
+		return change.ColumnPath
+	}
+	return strings.Split(change.ColumnName, ".")
+}
+
+func fieldIndexFold(sc *arrow.Schema, name string) int {
+	for i, field := range sc.Fields() {
+		if strings.EqualFold(field.Name, name) {
+			return i
+		}
+	}
+	return -1
+}
+
+func rowViolatesChange(values arrow.Array, path []string, row int) bool {
+	if len(path) == 0 {
+		return values.IsValid(row)
+	}
+	if values.IsNull(row) {
+		return false
+	}
+
+	switch nested := values.(type) {
+	case *array.Struct:
+		structType := nested.DataType().(*arrow.StructType)
+		for i, field := range structType.Fields() {
+			if strings.EqualFold(field.Name, path[0]) {
+				return rowViolatesChange(nested.Field(i), path[1:], row)
+			}
+		}
+	case *array.List:
+		if path[0] != "element" {
+			return false
+		}
+		start, end := nested.ValueOffsets(row)
+		for i := start; i < end; i++ {
+			if rowViolatesChange(nested.ListValues(), path[1:], int(i)) {
+				return true
+			}
+		}
+	case *array.LargeList:
+		if path[0] != "element" {
+			return false
+		}
+		start, end := nested.ValueOffsets(row)
+		for i := start; i < end; i++ {
+			if rowViolatesChange(nested.ListValues(), path[1:], int(i)) {
+				return true
+			}
+		}
+	case *array.FixedSizeList:
+		if path[0] != "element" {
+			return false
+		}
+		start, end := nested.ValueOffsets(row)
+		for i := start; i < end; i++ {
+			if rowViolatesChange(nested.ListValues(), path[1:], int(i)) {
+				return true
+			}
+		}
+	case *array.Map:
+		start, end := nested.ValueOffsets(row)
+		var child arrow.Array
+		switch path[0] {
+		case "key":
+			child = nested.Keys()
+		case "value":
+			child = nested.Items()
+		default:
+			return false
+		}
+		for i := start; i < end; i++ {
+			if rowViolatesChange(child, path[1:], int(i)) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // TransformBatchStream wraps a batch channel and applies transformation to each batch.

--- a/pkg/schemaevolution/transform_test.go
+++ b/pkg/schemaevolution/transform_test.go
@@ -73,6 +73,198 @@ func TestDiscardValueTransformer_AllowsNewColumns(t *testing.T) {
 	assert.Equal(t, "beta", newCol.Value(1))
 }
 
+func TestDiscardValueTransformer_PreservesConfiguredPrimaryKey(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "age", DataType: schema.TypeString, Nullable: true},
+	}}
+	destSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "age", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison, err := Compare(sourceSchema, destSchema, &CompareOptions{PrimaryKeys: []string{"id"}})
+	require.NoError(t, err)
+	transformer := NewDiscardValueTransformer(comparison, sourceSchema, destSchema)
+
+	idBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	idBuilder.AppendValues([]int64{10, 20}, nil)
+	idColumn := idBuilder.NewArray()
+	idBuilder.Release()
+	ageBuilder := array.NewStringBuilder(memory.DefaultAllocator)
+	ageBuilder.AppendValues([]string{"old", "young"}, nil)
+	ageColumn := ageBuilder.NewArray()
+	ageBuilder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "age", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil), []arrow.Array{idColumn, ageColumn}, 2)
+	idColumn.Release()
+	ageColumn.Release()
+	defer batch.Release()
+
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer transformed.Release()
+	ids := transformed.Column(0).(*array.Int64)
+	assert.Equal(t, int64(10), ids.Value(0))
+	assert.Equal(t, int64(20), ids.Value(1))
+	assert.Zero(t, ids.NullN())
+	assert.Equal(t, 2, transformed.Column(1).NullN())
+}
+
+func TestDiscardValueTransformerPreservesConformingValuesForNullabilityChange(t *testing.T) {
+	comparison := &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRelaxNullability, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	transformer := NewDiscardValueTransformer(comparison, nil, nil)
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(7)
+	builder.AppendNull()
+	values := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: true,
+	}}, nil), []arrow.Array{values}, 2)
+	values.Release()
+	defer batch.Release()
+
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	require.Same(t, batch, transformed)
+	require.Equal(t, int64(7), transformed.Column(0).(*array.Int64).Value(0))
+	require.True(t, transformed.Column(0).IsNull(1))
+}
+
+func TestDiscardRowTransformerPreservesRowsAfterNestedNullabilityRelaxation(t *testing.T) {
+	structType := arrow.StructOf(arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true})
+	builder := array.NewStructBuilder(memory.DefaultAllocator, structType)
+	nameBuilder := builder.FieldBuilder(0).(*array.StringBuilder)
+	builder.Append(true)
+	nameBuilder.Append("keep")
+	builder.Append(true)
+	nameBuilder.AppendNull()
+	profiles := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "profile", Type: structType, Nullable: true,
+	}}, nil), []arrow.Array{profiles}, 2)
+	profiles.Release()
+	defer batch.Release()
+
+	transformer := NewDiscardRowTransformer(nil, nil, &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRelaxNullability, ColumnName: "profile.name", ColumnPath: []string{"profile", "name"},
+	}}})
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer transformed.Release()
+	require.EqualValues(t, 2, transformed.NumRows())
+	profile := transformed.Column(0).(*array.Struct)
+	require.Equal(t, "keep", profile.Field(0).(*array.String).Value(0))
+	require.True(t, profile.Field(0).IsNull(1))
+}
+
+func TestDiscardRowTransformerPreservesRowsAfterTopLevelNullabilityRelaxation(t *testing.T) {
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(7)
+	builder.AppendNull()
+	values := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: true,
+	}}, nil), []arrow.Array{values}, 2)
+	values.Release()
+	defer batch.Release()
+
+	transformer := NewDiscardRowTransformer(nil, nil, &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRelaxNullability, ColumnName: "value", ColumnPath: []string{"value"},
+	}}})
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	require.Same(t, batch, transformed)
+	require.EqualValues(t, 2, transformed.NumRows())
+}
+
+func TestDiscardRowTransformerChecksFixedSizeListElements(t *testing.T) {
+	builder := array.NewFixedSizeListBuilder(memory.DefaultAllocator, 2, arrow.PrimitiveTypes.Int64)
+	valuesBuilder := builder.ValueBuilder().(*array.Int64Builder)
+	builder.Append(true)
+	valuesBuilder.AppendNull()
+	valuesBuilder.AppendNull()
+	builder.Append(true)
+	valuesBuilder.AppendNull()
+	valuesBuilder.Append(9)
+	builder.AppendNull()
+	items := builder.NewListArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "items", Type: items.DataType(), Nullable: true,
+	}}, nil), []arrow.Array{items}, 3)
+	items.Release()
+	defer batch.Release()
+
+	transformer := NewDiscardRowTransformer(nil, nil, &SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeWidenType, ColumnName: "items.element", ColumnPath: []string{"items", "element"},
+	}}})
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer transformed.Release()
+	require.EqualValues(t, 2, transformed.NumRows())
+
+	got := transformed.Column(0).(*array.FixedSizeList)
+	require.True(t, got.IsValid(0), "all-null fixed-size list is non-violating")
+	start, end := got.ValueOffsets(0)
+	for i := start; i < end; i++ {
+		require.True(t, got.ListValues().IsNull(int(i)))
+	}
+	require.True(t, got.IsNull(1), "null parent list is non-violating")
+}
+
+func TestDiscardValueTransformerMatchesNestedChangeToParentField(t *testing.T) {
+	structType := arrow.StructOf(arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true})
+	builder := array.NewStructBuilder(memory.DefaultAllocator, structType)
+	builder.Append(true)
+	builder.FieldBuilder(0).(*array.StringBuilder).Append("invalid")
+	profiles := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "profile", Type: structType, Nullable: true,
+	}}, nil), []arrow.Array{profiles}, 1)
+	profiles.Release()
+	defer batch.Release()
+
+	transformer := NewDiscardValueTransformer(&SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeWidenType, ColumnName: "profile.name", ColumnPath: []string{"profile", "name"},
+	}}}, nil, nil)
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer transformed.Release()
+	require.True(t, transformed.Column(0).IsNull(0))
+}
+
+func TestDiscardValueTransformerPreservesNestedSiblingsForRemovedField(t *testing.T) {
+	structType := arrow.StructOf(arrow.Field{Name: "kept", Type: arrow.BinaryTypes.String, Nullable: true})
+	builder := array.NewStructBuilder(memory.DefaultAllocator, structType)
+	builder.Append(true)
+	builder.FieldBuilder(0).(*array.StringBuilder).Append("preserved")
+	profiles := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{
+		Name: "profile", Type: structType, Nullable: true,
+	}}, nil), []arrow.Array{profiles}, 1)
+	profiles.Release()
+	defer batch.Release()
+
+	transformer := NewDiscardValueTransformer(&SchemaComparison{HasChanges: true, Changes: []SchemaChange{{
+		Type: ChangeRemoveColumn, ColumnName: "profile.removed", ColumnPath: []string{"profile", "removed"},
+		OldColumn: &schema.Column{Name: "removed", DataType: schema.TypeString},
+	}}}, nil, nil)
+	transformed, err := transformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	require.Same(t, batch, transformed)
+	profile := transformed.Column(0).(*array.Struct)
+	require.Equal(t, "preserved", profile.Field(0).(*array.String).Value(0))
+}
+
 func TestIngestrColumnFiller_HasColumns(t *testing.T) {
 	t.Run("EmptyColumns", func(t *testing.T) {
 		filler := NewIngestrColumnFiller(nil)

--- a/pkg/schemaevolution/types.go
+++ b/pkg/schemaevolution/types.go
@@ -51,12 +51,14 @@ const (
 	ChangeWidenType
 	ChangeOverrideType // User-specified type override
 	ChangeRemoveColumn // Column exists in destination but not in source
+	ChangeRelaxNullability
 )
 
 // SchemaChange represents a single schema change operation.
 type SchemaChange struct {
 	Type       ChangeType
 	ColumnName string
+	ColumnPath []string
 	OldColumn  *schema.Column // nil for ADD
 	NewColumn  schema.Column
 }

--- a/pkg/schemaevolution/widen.go
+++ b/pkg/schemaevolution/widen.go
@@ -1,6 +1,8 @@
 package schemaevolution
 
 import (
+	"fmt"
+
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -110,13 +112,13 @@ func GetWidenedType(src, dest schema.DataType) (schema.DataType, string) {
 }
 
 // MergeDecimalPrecision determines the precision and scale for merged decimal types.
-// Uses the larger precision and scale from both columns.
+// Preserves the maximum integer digits and scale, even when that exceeds the
+// supported precision; callers that need an enforceable schema use the checked variant.
 func MergeDecimalPrecision(src, dest schema.Column) (precision, scale int) {
 	precision = src.Precision
 	if dest.Precision > precision {
 		precision = dest.Precision
 	}
-
 	scale = src.Scale
 	if dest.Scale > scale {
 		scale = dest.Scale
@@ -137,9 +139,17 @@ func MergeDecimalPrecision(src, dest schema.Column) (precision, scale int) {
 	}
 
 	precision = intDigits + scale
+	return precision, scale
+}
+
+func MergeDecimalPrecisionChecked(src, dest schema.Column) (precision, scale int, err error) {
+	precision, scale = MergeDecimalPrecision(src, dest)
 	if precision > 38 {
-		precision = 38
+		return 0, 0, fmt.Errorf(
+			"decimal widening requires precision %d (integer digits %d + scale %d), maximum supported precision is 38",
+			precision, precision-scale, scale,
+		)
 	}
 
-	return precision, scale
+	return precision, scale, nil
 }

--- a/pkg/schemaevolution/widen_test.go
+++ b/pkg/schemaevolution/widen_test.go
@@ -331,12 +331,12 @@ func TestMergeDecimalPrecision_DefaultPrecision(t *testing.T) {
 	assert.Equal(t, 2, scale)
 }
 
-func TestMergeDecimalPrecision_MaxPrecisionCap(t *testing.T) {
+func TestMergeDecimalPrecision_ReportsRequiredPrecisionAboveMaximum(t *testing.T) {
 	src := schema.Column{DataType: schema.TypeDecimal, Precision: 35, Scale: 10}
 	dest := schema.Column{DataType: schema.TypeDecimal, Precision: 30, Scale: 15}
 
 	precision, scale := MergeDecimalPrecision(src, dest)
-	assert.LessOrEqual(t, precision, 38, "precision should not exceed 38")
+	assert.Equal(t, 40, precision, "must not silently discard integer digits")
 	assert.Equal(t, 15, scale, "should use larger scale")
 }
 

--- a/pkg/schemainfer/infer.go
+++ b/pkg/schemainfer/infer.go
@@ -182,12 +182,16 @@ func (i *SchemaInferrer) ToTableSchema(tableName string) (*schema.TableSchema, e
 		return nil, nil
 	}
 
-	return &schema.TableSchema{
+	result := &schema.TableSchema{
 		Name:        tblName,
 		Schema:      schemaName,
 		Columns:     columns,
 		PrimaryKeys: nil, // Cannot infer PKs from data
-	}, nil
+	}
+	if err := ValidateSchema(result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // DroppedColumns returns columns that were dropped during inference (all-null nullable columns).

--- a/pkg/schemainfer/merge.go
+++ b/pkg/schemainfer/merge.go
@@ -2,6 +2,7 @@ package schemainfer
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -62,6 +63,47 @@ func MergeArrowTypes(existing, new arrow.DataType) (arrow.DataType, error) {
 		return schema.JSONArrowType, nil
 	}
 
+	if isListArrowType(existing.ID()) && isListArrowType(new.ID()) {
+		aElem, aNullable := listElement(existing)
+		bElem, bNullable := listElement(new)
+		elem, err := MergeArrowTypes(aElem, bElem)
+		if err != nil {
+			return nil, fmt.Errorf("merge list element types: %w", err)
+		}
+		field := arrow.Field{
+			Name: "element", Type: elem, Nullable: aNullable || bNullable,
+		}
+		aFixed, aIsFixed := existing.(*arrow.FixedSizeListType)
+		bFixed, bIsFixed := new.(*arrow.FixedSizeListType)
+		if aIsFixed && bIsFixed {
+			if aFixed.Len() != bFixed.Len() {
+				return nil, fmt.Errorf("incompatible fixed-size list lengths %d and %d", aFixed.Len(), bFixed.Len())
+			}
+			return arrow.FixedSizeListOfField(aFixed.Len(), field), nil
+		}
+		return arrow.ListOfField(field), nil
+	}
+	if existing.ID() == arrow.STRUCT && new.ID() == arrow.STRUCT {
+		return mergeStructTypes(existing.(*arrow.StructType), new.(*arrow.StructType))
+	}
+	if existing.ID() == arrow.MAP && new.ID() == arrow.MAP {
+		a, b := existing.(*arrow.MapType), new.(*arrow.MapType)
+		if !arrow.TypeEqual(a.KeyType(), b.KeyType()) {
+			return nil, fmt.Errorf("incompatible map key types %s and %s", a.KeyType(), b.KeyType())
+		}
+		item, err := MergeArrowTypes(a.ItemType(), b.ItemType())
+		if err != nil {
+			return nil, fmt.Errorf("merge map value types: %w", err)
+		}
+		return arrow.MapOfFields(
+			arrow.Field{Name: "key", Type: a.KeyType(), Nullable: false},
+			arrow.Field{Name: "value", Type: item, Nullable: a.ItemField().Nullable || b.ItemField().Nullable},
+		), nil
+	}
+	if nestedArrowType(existing.ID()) || nestedArrowType(new.ID()) {
+		return nil, fmt.Errorf("incompatible nested types %s and %s", existing, new)
+	}
+
 	existingPriority, existingOk := typePriority[existing.ID()]
 	newPriority, newOk := typePriority[new.ID()]
 
@@ -99,6 +141,65 @@ func MergeArrowTypes(existing, new arrow.DataType) (arrow.DataType, error) {
 
 	// Default: promote to string for safety
 	return arrow.BinaryTypes.String, nil
+}
+
+func isListArrowType(id arrow.Type) bool {
+	return id == arrow.LIST || id == arrow.LARGE_LIST || id == arrow.FIXED_SIZE_LIST
+}
+
+func listElement(dataType arrow.DataType) (arrow.DataType, bool) {
+	switch list := dataType.(type) {
+	case *arrow.ListType:
+		return list.Elem(), list.ElemField().Nullable
+	case *arrow.LargeListType:
+		return list.Elem(), list.ElemField().Nullable
+	case *arrow.FixedSizeListType:
+		return list.Elem(), list.ElemField().Nullable
+	default:
+		panic("listElement called with non-list type")
+	}
+}
+
+func mergeStructTypes(existing, incoming *arrow.StructType) (arrow.DataType, error) {
+	fields := existing.Fields()
+	index := make(map[string]int, len(fields))
+	incomingNames := make(map[string]struct{}, incoming.NumFields())
+	for _, field := range incoming.Fields() {
+		incomingNames[strings.ToLower(field.Name)] = struct{}{}
+	}
+	for i, field := range fields {
+		folded := strings.ToLower(field.Name)
+		index[folded] = i
+		if _, ok := incomingNames[folded]; !ok {
+			fields[i].Nullable = true
+		}
+	}
+	for _, field := range incoming.Fields() {
+		folded := strings.ToLower(field.Name)
+		i, ok := index[folded]
+		if !ok {
+			field.Nullable = true
+			fields = append(fields, field)
+			index[folded] = len(fields) - 1
+			continue
+		}
+		merged, err := MergeArrowTypes(fields[i].Type, field.Type)
+		if err != nil {
+			return nil, fmt.Errorf("merge struct field %q: %w", field.Name, err)
+		}
+		fields[i].Type = merged
+		fields[i].Nullable = fields[i].Nullable || field.Nullable
+	}
+	return arrow.StructOf(fields...), nil
+}
+
+func nestedArrowType(id arrow.Type) bool {
+	switch id {
+	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.STRUCT, arrow.MAP:
+		return true
+	default:
+		return false
+	}
 }
 
 // isNumericType returns true if the type is a numeric type.
@@ -250,7 +351,11 @@ func ArrowFieldToColumn(name string, dt arrow.DataType, nullable bool) schema.Co
 		col.DataType = schema.TypeFloat64
 	case arrow.DECIMAL128, arrow.DECIMAL256:
 		col.DataType = schema.TypeDecimal
-		if decType, ok := dt.(*arrow.Decimal128Type); ok {
+		switch decType := dt.(type) {
+		case *arrow.Decimal128Type:
+			col.Precision = int(decType.Precision)
+			col.Scale = int(decType.Scale)
+		case *arrow.Decimal256Type:
 			col.Precision = int(decType.Precision)
 			col.Scale = int(decType.Scale)
 		}
@@ -258,6 +363,9 @@ func ArrowFieldToColumn(name string, dt arrow.DataType, nullable bool) schema.Co
 		col.DataType = schema.TypeString
 	case arrow.BINARY, arrow.LARGE_BINARY:
 		col.DataType = schema.TypeBinary
+	case arrow.FIXED_SIZE_BINARY:
+		col.DataType = schema.TypeFixedBinary
+		col.FixedLength = dt.(*arrow.FixedSizeBinaryType).ByteWidth
 	case arrow.DATE32, arrow.DATE64:
 		col.DataType = schema.TypeDate
 	case arrow.TIME32, arrow.TIME64:
@@ -268,12 +376,34 @@ func ArrowFieldToColumn(name string, dt arrow.DataType, nullable bool) schema.Co
 		} else {
 			col.DataType = schema.TypeTimestamp
 		}
-	case arrow.LIST, arrow.LARGE_LIST:
+	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST:
 		col.DataType = schema.TypeArray
-		if listType, ok := dt.(*arrow.ListType); ok {
-			elemCol := ArrowFieldToColumn("", listType.Elem(), true)
+		if listType, ok := dt.(arrow.ListLikeType); ok {
+			elemField := listType.ElemField()
+			elemCol := ArrowFieldToColumn(elemField.Name, elemField.Type, elemField.Nullable)
 			col.ArrayType = elemCol.DataType
+			col.Element = &elemCol
 		}
+		if fixed, ok := dt.(*arrow.FixedSizeListType); ok {
+			col.ArrayLength = fixed.Len()
+		}
+	case arrow.STRUCT:
+		col.DataType = schema.TypeStruct
+		structType := dt.(*arrow.StructType)
+		fields := make([]schema.Column, structType.NumFields())
+		for i, field := range structType.Fields() {
+			fields[i] = ArrowFieldToColumn(field.Name, field.Type, field.Nullable)
+		}
+		col.StructFields = &schema.TableSchema{Columns: fields}
+	case arrow.MAP:
+		col.DataType = schema.TypeMap
+		mapType := dt.(*arrow.MapType)
+		keyField := mapType.KeyField()
+		valueField := mapType.ItemField()
+		key := ArrowFieldToColumn(keyField.Name, keyField.Type, false)
+		value := ArrowFieldToColumn(valueField.Name, valueField.Type, valueField.Nullable)
+		col.MapKey = &key
+		col.MapValue = &value
 	case arrow.EXTENSION:
 		// Check if it's a JSON extension type
 		if isJSONType(dt) {
@@ -308,6 +438,43 @@ func ValidateSchema(s *schema.TableSchema) error {
 	for i, col := range s.Columns {
 		if col.Name == "" {
 			return fmt.Errorf("column %d has empty name", i)
+		}
+		if err := validateInferredColumn(col, col.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateInferredColumn(col schema.Column, path string) error {
+	if col.DataType == schema.TypeDecimal && col.Precision > 38 {
+		return fmt.Errorf("column %s has decimal precision %d; maximum supported precision is 38", path, col.Precision)
+	}
+	switch col.DataType {
+	case schema.TypeArray:
+		if col.Element != nil {
+			return validateInferredColumn(*col.Element, path+".element")
+		}
+		return validateInferredColumn(schema.Column{
+			Name: "element", DataType: col.ArrayType, Nullable: true,
+			Precision: col.Precision, Scale: col.Scale, MaxLength: col.MaxLength, FixedLength: col.FixedLength,
+		}, path+".element")
+	case schema.TypeStruct:
+		if col.StructFields != nil {
+			for _, field := range col.StructFields.Columns {
+				if err := validateInferredColumn(field, path+"."+field.Name); err != nil {
+					return err
+				}
+			}
+		}
+	case schema.TypeMap:
+		if col.MapKey != nil {
+			if err := validateInferredColumn(*col.MapKey, path+".key"); err != nil {
+				return err
+			}
+		}
+		if col.MapValue != nil {
+			return validateInferredColumn(*col.MapValue, path+".value")
 		}
 	}
 	return nil

--- a/pkg/schemainfer/merge_test.go
+++ b/pkg/schemainfer/merge_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeArrowTypes_SameType(t *testing.T) {
@@ -400,6 +401,41 @@ func TestArrowFieldToColumn_List(t *testing.T) {
 	if col.ArrayType != schema.TypeInt64 {
 		t.Errorf("expected array element type TypeInt64, got %v", col.ArrayType)
 	}
+}
+
+func TestArrowFieldToColumnFixedSizeList(t *testing.T) {
+	listType := arrow.FixedSizeListOfField(3, arrow.Field{
+		Name: "item", Type: arrow.PrimitiveTypes.Int32, Nullable: false,
+	})
+	col := ArrowFieldToColumn("coordinates", listType, true)
+	require.Equal(t, schema.TypeArray, col.DataType)
+	require.Equal(t, schema.TypeInt32, col.ArrayType)
+	require.NotNil(t, col.Element)
+	require.Equal(t, schema.TypeInt32, col.Element.DataType)
+	require.False(t, col.Element.Nullable)
+	require.EqualValues(t, 3, col.ArrayLength)
+	roundTrip := schema.DataTypeToArrowType(col)
+	fixed, ok := roundTrip.(*arrow.FixedSizeListType)
+	require.True(t, ok)
+	require.EqualValues(t, 3, fixed.Len())
+}
+
+func TestMergeArrowTypesFixedSizeLists(t *testing.T) {
+	left := arrow.FixedSizeListOf(3, arrow.PrimitiveTypes.Int32)
+	widerElement := arrow.FixedSizeListOf(3, arrow.PrimitiveTypes.Int64)
+	merged, err := MergeArrowTypes(left, widerElement)
+	require.NoError(t, err)
+	fixed, ok := merged.(*arrow.FixedSizeListType)
+	require.True(t, ok)
+	require.EqualValues(t, 3, fixed.Len())
+	require.Equal(t, arrow.PrimitiveTypes.Int64, fixed.Elem())
+
+	variable, err := MergeArrowTypes(left, arrow.ListOf(arrow.PrimitiveTypes.Int64))
+	require.NoError(t, err)
+	require.IsType(t, &arrow.ListType{}, variable)
+
+	_, err = MergeArrowTypes(left, arrow.FixedSizeListOf(4, arrow.PrimitiveTypes.Int32))
+	require.ErrorContains(t, err, "incompatible fixed-size list lengths")
 }
 
 func TestValidateSchema(t *testing.T) {

--- a/pkg/schemainfer/nested_merge_test.go
+++ b/pkg/schemainfer/nested_merge_test.go
@@ -1,0 +1,121 @@
+package schemainfer
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeArrowTypesRecursivelyMergesNestedTypes(t *testing.T) {
+	first := arrow.StructOf(
+		arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		arrow.Field{Name: "tags", Type: arrow.ListOfField(arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false})},
+	)
+	second := arrow.StructOf(
+		arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		arrow.Field{Name: "tags", Type: arrow.ListOfField(arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int64, Nullable: true})},
+		arrow.Field{Name: "extra", Type: arrow.BinaryTypes.String, Nullable: false},
+	)
+	merged, err := MergeArrowTypes(first, second)
+	require.NoError(t, err)
+	structType := merged.(*arrow.StructType)
+	require.Equal(t, arrow.INT64, structType.Field(0).Type.ID())
+	require.True(t, structType.Field(0).Nullable)
+	tags := structType.Field(1).Type.(*arrow.ListType)
+	require.Equal(t, arrow.INT64, tags.Elem().ID())
+	require.True(t, tags.ElemField().Nullable)
+	require.True(t, structType.Field(2).Nullable, "a field absent from an earlier batch must be optional")
+}
+
+func TestMergeArrowTypesRecursivelyMergesMapValues(t *testing.T) {
+	first := arrow.MapOfFields(
+		arrow.Field{Name: "key", Type: arrow.BinaryTypes.String},
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	)
+	second := arrow.MapOfFields(
+		arrow.Field{Name: "key", Type: arrow.BinaryTypes.String},
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	)
+	merged, err := MergeArrowTypes(first, second)
+	require.NoError(t, err)
+	mapType := merged.(*arrow.MapType)
+	require.Equal(t, arrow.INT64, mapType.ItemType().ID())
+	require.True(t, mapType.ItemField().Nullable)
+}
+
+func TestMergeArrowTypesRejectsStructuredScalarConflict(t *testing.T) {
+	_, err := MergeArrowTypes(arrow.StructOf(arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int64}), arrow.BinaryTypes.String)
+	require.ErrorContains(t, err, "incompatible nested types")
+}
+
+func TestMergeArrowTypesNormalizesLargeAndRegularLists(t *testing.T) {
+	large := arrow.LargeListOfField(arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false})
+	regular := arrow.ListOfField(arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int64, Nullable: true})
+	merged, err := MergeArrowTypes(large, regular)
+	require.NoError(t, err)
+	list := merged.(*arrow.ListType)
+	require.Equal(t, arrow.INT64, list.Elem().ID())
+	require.True(t, list.ElemField().Nullable)
+}
+
+func TestMergeStructTypesMatchesFieldsCaseInsensitively(t *testing.T) {
+	first := arrow.StructOf(arrow.Field{Name: "Name", Type: arrow.PrimitiveTypes.Int32, Nullable: false})
+	second := arrow.StructOf(arrow.Field{Name: "name", Type: arrow.PrimitiveTypes.Int64, Nullable: true})
+	merged, err := MergeArrowTypes(first, second)
+	require.NoError(t, err)
+	fields := merged.(*arrow.StructType).Fields()
+	require.Len(t, fields, 1)
+	require.Equal(t, "Name", fields[0].Name)
+	require.Equal(t, arrow.PrimitiveTypes.Int64, fields[0].Type)
+	require.True(t, fields[0].Nullable)
+}
+
+func TestArrowFieldToColumnDecimal256AndValidation(t *testing.T) {
+	col := ArrowFieldToColumn("amount", &arrow.Decimal256Type{Precision: 38, Scale: 7}, true)
+	require.Equal(t, schema.TypeDecimal, col.DataType)
+	require.Equal(t, 38, col.Precision)
+	require.Equal(t, 7, col.Scale)
+
+	tooWide := ArrowFieldToColumn("amount", &arrow.Decimal256Type{Precision: 50, Scale: 7}, true)
+	err := ValidateSchema(&schema.TableSchema{Columns: []schema.Column{{
+		Name: "payload", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{tooWide}},
+	}}})
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "payload.amount")
+}
+
+func TestToTableSchemaRejectsDecimal256AboveSupportedPrecision(t *testing.T) {
+	inferrer := NewSchemaInferrer()
+	inferrer.fieldOrder = []string{"amount"}
+	inferrer.seenFields["amount"] = &FieldInfo{
+		Name: "amount", Type: &arrow.Decimal256Type{Precision: 50, Scale: 7}, HasData: true,
+	}
+
+	_, err := inferrer.ToTableSchema("payments")
+	require.ErrorContains(t, err, "decimal precision 50")
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+}
+
+func TestValidateSchemaRejectsUnsupportedDecimalMapKey(t *testing.T) {
+	lookup := ArrowFieldToColumn("lookup", arrow.MapOf(
+		&arrow.Decimal256Type{Precision: 50, Scale: 2}, arrow.BinaryTypes.String,
+	), true)
+	err := ValidateSchema(&schema.TableSchema{Columns: []schema.Column{lookup}})
+	require.ErrorContains(t, err, "lookup.key")
+	require.ErrorContains(t, err, "decimal precision 50")
+}
+
+func TestValidateSchemaChecksLegacyDecimalArrayElement(t *testing.T) {
+	legacy := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amounts", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 76, Scale: 38,
+	}}}
+	err := ValidateSchema(legacy)
+	require.ErrorContains(t, err, "amounts.element")
+	require.ErrorContains(t, err, "decimal precision 76")
+
+	legacy.Columns[0].Precision = 38
+	require.NoError(t, ValidateSchema(legacy))
+}

--- a/pkg/source/arrowstream/arrowstream.go
+++ b/pkg/source/arrowstream/arrowstream.go
@@ -58,9 +58,14 @@ func (s *ArrowStreamSource) Connect(ctx context.Context, uri string) error {
 		reader.Release()
 		return fmt.Errorf("arrow stream has no schema")
 	}
+	knownSchema := schemaFromArrow(arrowSchema, "")
+	if err := schemainfer.ValidateSchema(knownSchema); err != nil {
+		reader.Release()
+		return fmt.Errorf("invalid arrow stream schema: %w", err)
+	}
 
 	s.reader = reader
-	s.knownSchema = schemaFromArrow(arrowSchema, "")
+	s.knownSchema = knownSchema
 	config.Debug("[ARROW-STREAM] Connected to Arrow IPC stream with %d columns", len(s.knownSchema.Columns))
 	return nil
 }

--- a/pkg/source/arrowstream/arrowstream_test.go
+++ b/pkg/source/arrowstream/arrowstream_test.go
@@ -113,6 +113,25 @@ func TestArrowStreamSourceSkipsBatchesWhenAllColumnsExcluded(t *testing.T) {
 	assert.Zero(t, batches)
 }
 
+func TestArrowStreamSourceRejectsUnsupportedDecimal256Schema(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	arrowSchema := arrow.NewSchema([]arrow.Field{{
+		Name: "payload", Type: arrow.StructOf(arrow.Field{
+			Name: "amount", Type: &arrow.Decimal256Type{Precision: 50, Scale: 2}, Nullable: true,
+		}), Nullable: true,
+	}}, nil)
+	writer := ipc.NewWriter(&buf, ipc.WithSchema(arrowSchema), ipc.WithAllocator(memory.DefaultAllocator))
+	require.NoError(t, writer.Close())
+
+	src := NewArrowStreamSourceWithReader(&buf)
+	err := src.Connect(context.Background(), "arrow-stream://-")
+	require.ErrorContains(t, err, "invalid arrow stream schema")
+	require.ErrorContains(t, err, "payload.amount")
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+}
+
 func writeTestStream(t *testing.T, buf *bytes.Buffer) {
 	t.Helper()
 

--- a/pkg/source/bigquery/dialect.go
+++ b/pkg/source/bigquery/dialect.go
@@ -337,7 +337,11 @@ func mapBigQueryFieldToDataType(field *bigquery.FieldSchema) (schema.DataType, i
 		return schema.TypeDecimal, int(field.Precision), int(field.Scale), schema.TypeUnknown
 
 	case bigquery.BigNumericFieldType:
-		return schema.TypeDecimal, int(field.Precision), int(field.Scale), schema.TypeUnknown
+		precision, scale := int(field.Precision), int(field.Scale)
+		if precision == 0 {
+			precision, scale = 76, 38
+		}
+		return schema.TypeDecimal, precision, scale, schema.TypeUnknown
 
 	case bigquery.StringFieldType:
 		return schema.TypeString, 0, 0, schema.TypeUnknown

--- a/pkg/source/bigquery/mapper_test.go
+++ b/pkg/source/bigquery/mapper_test.go
@@ -1,0 +1,58 @@
+package bigquery
+
+import (
+	"testing"
+
+	cloudbigquery "cloud.google.com/go/bigquery"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapBigQueryFieldDecimalDefaults(t *testing.T) {
+	tests := []struct {
+		name               string
+		field              *cloudbigquery.FieldSchema
+		precision, scale   int
+		wantValidationFail bool
+	}{
+		{
+			name:      "unconstrained bignumeric uses effective bounds",
+			field:     &cloudbigquery.FieldSchema{Type: cloudbigquery.BigNumericFieldType},
+			precision: 76, scale: 38, wantValidationFail: true,
+		},
+		{
+			name:      "constrained bignumeric preserves metadata",
+			field:     &cloudbigquery.FieldSchema{Type: cloudbigquery.BigNumericFieldType, Precision: 50, Scale: 12},
+			precision: 50, scale: 12, wantValidationFail: true,
+		},
+		{
+			name:      "numeric mapping remains unchanged",
+			field:     &cloudbigquery.FieldSchema{Type: cloudbigquery.NumericFieldType},
+			precision: 0, scale: 0,
+		},
+		{
+			name:      "constrained numeric remains supported",
+			field:     &cloudbigquery.FieldSchema{Type: cloudbigquery.NumericFieldType, Precision: 38, Scale: 9},
+			precision: 38, scale: 9,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataType, precision, scale, arrayType := mapBigQueryFieldToDataType(tt.field)
+			require.Equal(t, schema.TypeDecimal, dataType)
+			require.Equal(t, tt.precision, precision)
+			require.Equal(t, tt.scale, scale)
+			require.Equal(t, schema.TypeUnknown, arrayType)
+
+			err := schemainfer.ValidateSchema(&schema.TableSchema{Columns: []schema.Column{{
+				Name: "amount", DataType: dataType, Precision: precision, Scale: scale,
+			}}})
+			if tt.wantValidationFail {
+				require.ErrorContains(t, err, "maximum supported precision is 38")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/source/clickhouse/mapper_test.go
+++ b/pkg/source/clickhouse/mapper_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
@@ -89,6 +90,20 @@ func TestMapClickHouseToDataType_ArrayWrappers(t *testing.T) {
 			require.Equal(t, tt.wantArray, gotArray)
 		})
 	}
+}
+
+func TestMapClickHouseDecimal256ArrayFailsSchemaValidation(t *testing.T) {
+	dataType, precision, scale, arrayType := MapClickHouseToDataType("Array(Decimal256(76,38))")
+	require.Equal(t, schema.TypeArray, dataType)
+	require.Equal(t, schema.TypeDecimal, arrayType)
+	require.Equal(t, 76, precision)
+	require.Equal(t, 38, scale)
+
+	err := schemainfer.ValidateSchema(&schema.TableSchema{Columns: []schema.Column{{
+		Name: "amounts", DataType: dataType, ArrayType: arrayType, Precision: precision, Scale: scale,
+	}}})
+	require.ErrorContains(t, err, "amounts.element")
+	require.ErrorContains(t, err, "decimal precision 76")
 }
 
 func TestNativeScanTarget_ArrayWrappers(t *testing.T) {

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -265,7 +265,7 @@ func (s *KafkaSource) readStreaming(ctx context.Context, topic string, opts sour
 			for p, m := range latest {
 				token[p] = kafkago.Message{Topic: m.Topic, Partition: m.Partition, Offset: m.Offset}
 			}
-			results <- source.RecordBatchResult{Batch: record, CommitToken: token}
+			results <- source.RecordBatchResult{Batch: record, CommitToken: token, DurableCommitID: token}
 			batch = batch[:0]
 			return true
 		}

--- a/pkg/source/mmap/mmap.go
+++ b/pkg/source/mmap/mmap.go
@@ -54,10 +54,14 @@ func (s *MMapSource) Connect(ctx context.Context, uri string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read mmap arrow schema: %w", err)
 	}
+	knownSchema := schemaFromArrow(arrowSchema, "")
+	if err := schemainfer.ValidateSchema(knownSchema); err != nil {
+		return fmt.Errorf("invalid mmap arrow schema: %w", err)
+	}
 
 	s.filePaths = filePaths
 	s.arrowSchema = arrowSchema
-	s.knownSchema = schemaFromArrow(arrowSchema, "")
+	s.knownSchema = knownSchema
 
 	config.Debug("[MMAP] Connected to %d Arrow file(s), first: %s", len(filePaths), filePaths[0])
 	return nil

--- a/pkg/source/mmap/mmap_test.go
+++ b/pkg/source/mmap/mmap_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -14,6 +17,53 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMMapSourceConnectValidatesNestedDecimalPrecision(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		precision int32
+		wantError bool
+	}{
+		{name: "maximum supported precision", precision: 38},
+		{name: "unsupported precision", precision: 50, wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "nested.arrow")
+			arrowSchema := arrow.NewSchema([]arrow.Field{{
+				Name: "payload",
+				Type: arrow.StructOf(arrow.Field{
+					Name:     "amount",
+					Type:     &arrow.Decimal256Type{Precision: tt.precision, Scale: 4},
+					Nullable: true,
+				}),
+				Nullable: true,
+			}}, nil)
+			writeArrowSchemaFile(t, path, arrowSchema)
+
+			src := NewMMapSource()
+			err := src.Connect(context.Background(), "mmap://"+path)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "payload.amount")
+				assert.Contains(t, err.Error(), "precision 50")
+				assert.Empty(t, src.filePaths)
+				return
+			}
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = src.Close(context.Background()) })
+		})
+	}
+}
+
+func writeArrowSchemaFile(t *testing.T, path string, arrowSchema *arrow.Schema) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	w, err := ipc.NewFileWriter(f, ipc.WithSchema(arrowSchema))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+}
 
 func TestMMapSourceSingleFile(t *testing.T) {
 	t.Parallel()

--- a/pkg/source/nats/nats.go
+++ b/pkg/source/nats/nats.go
@@ -382,7 +382,9 @@ func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOp
 			}
 			res := source.RecordBatchResult{Batch: record}
 			if opts.Streaming {
-				res.CommitToken = natsCommitToken{MaxSeq: maxSeq}
+				token := natsCommitToken{MaxSeq: maxSeq}
+				res.CommitToken = token
+				res.DurableCommitID = token
 			}
 			results <- res
 			for _, msg := range ackNow {

--- a/pkg/source/parquet/parquet.go
+++ b/pkg/source/parquet/parquet.go
@@ -52,10 +52,14 @@ func (s *ParquetSource) Connect(ctx context.Context, uri string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read parquet schema: %w", err)
 	}
+	knownSchema := schemaFromArrow(arrowSchema, "")
+	if err := schemainfer.ValidateSchema(knownSchema); err != nil {
+		return fmt.Errorf("invalid parquet arrow schema: %w", err)
+	}
 
 	s.filePaths = paths
 	s.arrowSchema = arrowSchema
-	s.knownSchema = schemaFromArrow(arrowSchema, "")
+	s.knownSchema = knownSchema
 
 	config.Debug("[PARQUET-SRC] Connected to %d parquet file(s), first: %s", len(paths), paths[0])
 	return nil

--- a/pkg/source/parquet/parquet_test.go
+++ b/pkg/source/parquet/parquet_test.go
@@ -46,6 +46,52 @@ func TestExtractFilePath(t *testing.T) {
 	}
 }
 
+func TestParquetSourceConnectValidatesNestedDecimalPrecision(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		precision int32
+		wantError bool
+	}{
+		{name: "maximum supported precision", precision: 38},
+		{name: "unsupported precision", precision: 50, wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "nested.parquet")
+			arrowSchema := arrow.NewSchema([]arrow.Field{{
+				Name: "payload",
+				Type: arrow.StructOf(arrow.Field{
+					Name:     "amount",
+					Type:     &arrow.Decimal256Type{Precision: tt.precision, Scale: 4},
+					Nullable: true,
+				}),
+				Nullable: true,
+			}}, nil)
+			writeParquetSchema(t, path, arrowSchema)
+
+			src := NewParquetSource()
+			err := src.Connect(context.Background(), "parquet://"+path)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "payload.amount")
+				assert.Contains(t, err.Error(), "precision 50")
+				assert.Empty(t, src.filePaths)
+				return
+			}
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = src.Close(context.Background()) })
+		})
+	}
+}
+
+func writeParquetSchema(t *testing.T, path string, arrowSchema *arrow.Schema) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	w, err := pqarrow.NewFileWriter(arrowSchema, f, pqgo.NewWriterProperties(), pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+}
+
 func TestParquetSource_ReadsFile(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/source/redis/redis.go
+++ b/pkg/source/redis/redis.go
@@ -281,7 +281,9 @@ func (s *RedisSource) read(ctx context.Context, stream string, opts source.ReadO
 			}
 			res := source.RecordBatchResult{Batch: record}
 			if opts.Streaming {
-				res.CommitToken = redisCommitToken{Stream: stream, MaxID: maxID}
+				token := redisCommitToken{Stream: stream, MaxID: maxID}
+				res.CommitToken = token
+				res.DurableCommitID = token
 			}
 			results <- res
 			batch = batch[:0]

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -120,6 +120,7 @@ type ReadOptions struct {
 	CDCSlotSuffix                   string              // Optional: suffix for auto-generated replication slot names (dest-aware)
 	CDCLegacySlotSuffix             string              // Optional: prior auto-slot suffix used only for upgrade resume
 	CDCSnapshotReplace              bool                // Consumer can apply a full-snapshot replacement boundary
+	CDCStableDataBatches            bool                // Consumer requires source-stable CDC data-write identities
 	FullRefresh                     bool
 	Columns                         string // Optional: column definitions for schema-less sources (e.g., "id:bigint,name:text")
 	Streaming                       bool   // Continuous mode: never exit on caught-up/idle; attach cumulative CommitTokens
@@ -151,6 +152,30 @@ type RecordBatchResult struct {
 	// to and including the batch that carried it. Nil means no feedback needed.
 	CommitToken any
 
+	// DurableCommitID is a source position whose identity is stable across
+	// processes and reconnects. Destinations may persist it for idempotent
+	// commits. It must remain nil for connection-local acknowledgement handles.
+	DurableCommitID any
+
+	// DurableCommitPosition is the resumable source position made durable by
+	// DurableCommitID. It is separate because a payload identity may include a
+	// kind/table prefix that is not a valid source cursor.
+	DurableCommitPosition string
+
+	// DurableCheckpointID and DurableCheckpointPosition identify a global
+	// source low-watermark that is safe to persist for tables without rows in
+	// the current flush. They may differ from this batch's payload identity.
+	// DurableCheckpointTable limits the checkpoint to one source table; an
+	// empty value means the checkpoint is safe for every table in the stream.
+	DurableCheckpointID       any
+	DurableCheckpointPosition string
+	DurableCheckpointTable    string
+
+	// SnapshotReset marks the start of a fresh snapshot attempt for TableName.
+	// Consumers must empty the destination table before accepting subsequent
+	// snapshot rows so an interrupted older attempt cannot contaminate it.
+	SnapshotReset bool
+
 	// TableInfo announces a table that appeared after the read started (e.g. a
 	// table created on the source mid-stream). Consumers that prepared their
 	// per-table state upfront use it to provision the destination before any
@@ -164,18 +189,22 @@ type RecordBatchResult struct {
 }
 
 type CDCSnapshotInvalidation struct {
-	TableName   string
-	Incarnation string
+	TableName         string
+	Incarnation       string
+	SchemaFingerprint string
 }
 
 // CDCStateCommitToken carries destination-managed CDC state alongside the
 // source's native acknowledgement token. Position is the latest globally safe
-// source position. SnapshotPositions marks source tables whose full snapshot is
-// included in all preceding results; the matching incarnation and schema maps
-// bind those snapshots to the exact source table shape.
+// source position. DataBatchID is an optional source-stable identity for the
+// exact data batch carried by the result. SnapshotPositions marks source tables
+// whose full snapshot is included in all preceding results; the matching
+// incarnation and schema maps bind those snapshots to the exact source table
+// shape.
 type CDCStateCommitToken struct {
 	SourceCommitToken    any
 	Position             string
+	DataBatchID          string
 	SnapshotPositions    map[string]string
 	SnapshotIncarnations map[string]string
 	SnapshotSchemas      map[string]string
@@ -289,6 +318,12 @@ type SourceTable interface {
 
 type PrimaryKeyUniquenessProvider interface {
 	PrimaryKeysUnique() bool
+}
+
+// SnapshotResetEmitter identifies sources whose record stream can begin a
+// fresh snapshot with SnapshotReset control records.
+type SnapshotResetEmitter interface {
+	EmitsSnapshotResets() bool
 }
 
 // PartitionedTable is an optional interface that a SourceTable can implement

--- a/pkg/strategy/append.go
+++ b/pkg/strategy/append.go
@@ -3,12 +3,16 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
 )
 
 type AppendStrategy struct{}
@@ -40,6 +44,11 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if isCDC {
 		prepSchema = job.Schema
 	}
+	if publisher, ok := job.Destination.(destination.AtomicSnapshotPublisher); ok &&
+		job.CDCStateManager != nil && isCDC && !job.Config.Stream &&
+		(job.Config.FullRefresh || strings.TrimSpace(job.Config.CDCResumeLSN) == "") {
+		return s.executeAtomicSnapshot(ctx, job, publisher, prepSchema)
+	}
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:       job.Config.DestTable,
@@ -52,7 +61,6 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	}); err != nil {
 		return fmt.Errorf("failed to prepare table: %w", err)
 	}
-
 	if err := job.ApplyEvolution(ctx); err != nil {
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
@@ -86,10 +94,13 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		CDCSlotSuffix:                   job.Config.CDCSlotSuffix,
 		CDCLegacySlotSuffix:             job.Config.CDCLegacySlotSuffix,
 		CDCSnapshotReplace:              isCDC && supportsCDCSnapshotReplace(job.Destination),
+		CDCStableDataBatches:            isCDC && job.CDCStateManager != nil,
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
 		return fmt.Errorf("failed to get records: %w", err)
 	}
@@ -106,24 +117,187 @@ func (s *AppendStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
+		SkipCDCResume:    job.CDCStateManager != nil,
+	}
+	if job.CDCStateManager != nil {
+		writeOpts.CDCExpectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if writeOpts.CDCExpectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", job.Config.DestTable)
+		}
 	}
 	var writeErr error
-	if isCDC {
-		_, writeErr = destination.WriteWithTruncateBoundaries(ctx, job.Destination, records, writeOpts)
+	if isCDC && job.CDCStateManager != nil {
+		_, writeErr = writeDurableCDCAppendRecords(readCtx, job.Destination, records, writeOpts, job.Config.SourceTable)
+	} else if isCDC {
+		_, writeErr = destination.WriteWithTruncateBoundaries(readCtx, job.Destination, records, writeOpts)
 	} else {
-		writeErr = job.Destination.WriteParallel(ctx, records, writeOpts)
+		writeErr = job.Destination.WriteParallel(readCtx, records, writeOpts)
 	}
 	if writeErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write data: %w", writeErr)
 	}
 
 	return nil
 }
 
+func (s *AppendStrategy) executeAtomicSnapshot(
+	ctx context.Context,
+	job *IngestionJob,
+	publisher destination.AtomicSnapshotPublisher,
+	targetSchema *schema.TableSchema,
+) error {
+	existingSchema, err := job.Destination.GetTableSchema(ctx, job.Config.DestTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before atomic append snapshot: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+	if !targetExisted && ownershipToken == "" {
+		return fmt.Errorf("destination %s cannot safely clean up a failed atomic append target", job.Destination.GetScheme())
+	}
+	cleanupNewTarget := !targetExisted && ownershipToken != ""
+	defer func() {
+		if cleanupNewTarget {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, job.Config.DestTable, true, ownershipToken)
+		}
+	}()
+	if !targetExisted {
+		if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+			Table: job.Config.DestTable, Schema: targetSchema, PrimaryKeys: job.Schema.PrimaryKeys,
+			PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy, CDCMode: true,
+			OwnershipToken: ownershipToken,
+		}); err != nil {
+			return fmt.Errorf("failed to prepare owned target for atomic append snapshot: %w", err)
+		}
+	}
+	if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
+		return fmt.Errorf("failed to bind CDC destination before atomic append snapshot: %w", err)
+	}
+	expectedIncarnation := job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+	if expectedIncarnation == "" {
+		return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", job.Config.DestTable)
+	}
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, source.ReadOptions{
+		IncrementalKey: job.Config.IncrementalKey, IntervalStart: job.Config.IntervalStart, IntervalEnd: job.Config.IntervalEnd,
+		ExtractPartitionBy: job.Config.ExtractPartitionBy, ExtractPartitionInterval: job.Config.ExtractPartitionInterval,
+		ExtractPartitionNumericInterval: job.Config.ExtractPartitionNumericInterval, ExtractPartitionAuto: job.Config.ExtractPartitionAuto,
+		PageSize: job.Config.PageSize, Limit: job.Config.SQLLimit, ExcludeColumns: job.Config.SQLExcludeColumns,
+		Parallelism: parallelism, Schema: job.SourceSchema, CDCResumeLSN: job.Config.CDCResumeLSN,
+		CDCResumeIncarnation: job.Config.CDCResumeIncarnation, CDCResumeSchemaFingerprint: job.Config.CDCResumeSchemaFingerprint,
+		CDCSlotSuffix: job.Config.CDCSlotSuffix, CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
+		CDCSnapshotReplace: true, FullRefresh: job.Config.FullRefresh,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get atomic append snapshot records: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+	if err := consumeAtomicSnapshotBoundary(readCtx, job, records); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return err
+	}
+	boundary := &atomicBatchSnapshotBoundary{}
+	attemptID := uuid.NewString()
+	opts := destination.AtomicSnapshotOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, TargetSchema: targetSchema,
+		PrimaryKeys: job.Schema.PrimaryKeys, PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy,
+		Parallelism: parallelism, AttemptID: attemptID, SkipCDCResume: true,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}
+	if err := publisher.BeginAtomicSnapshot(ctx, opts); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		abortAtomicAppendSnapshot(ctx, job.Destination, opts)
+		return fmt.Errorf("failed to begin atomic append snapshot: %w", err)
+	}
+	records = observeAtomicBatchSnapshot(readCtx, records, boundary)
+	publishAttempted := false
+	defer func() {
+		if !publishAttempted {
+			abortAtomicAppendSnapshot(ctx, job.Destination, opts)
+		}
+	}()
+	if err := publisher.WriteAtomicSnapshot(readCtx, records, destination.WriteOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, PrimaryKeys: job.Schema.PrimaryKeys,
+		Parallelism: parallelism, AtomicSnapshotAttemptID: attemptID, SkipCDCResume: true,
+		CDCExpectedIncarnation: expectedIncarnation, PreStaged: job.PreStaged,
+	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to stage atomic append snapshot: %w", err)
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	opts.CommitToken, opts.CDCResumeLSN = boundary.values()
+	publishAttempted = true
+	cleanupNewTarget = false
+	if err := publisher.PublishAtomicSnapshot(ctx, opts); err != nil {
+		return fmt.Errorf("failed to publish atomic append snapshot: %w", err)
+	}
+	if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
+		return fmt.Errorf("failed to revalidate published append snapshot: %w", err)
+	}
+	return nil
+}
+
+func abortAtomicAppendSnapshot(ctx context.Context, dest destination.Destination, opts destination.AtomicSnapshotOptions) {
+	aborter, ok := dest.(destination.AtomicSnapshotAborter)
+	if !ok {
+		return
+	}
+	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	_ = aborter.AbortAtomicSnapshot(abortCtx, opts)
+}
+
 // ExecuteMultiTable implements multi-table append strategy for CDC sources.
 func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIngestionJob) error {
 	if len(job.Tables) == 0 {
 		return nil
+	}
+	if publisher, canPublish := job.Destination.(destination.AtomicSnapshotPublisher); canPublish && job.CDCStateManager != nil && !job.Config.Stream {
+		needsSnapshot := job.Config.FullRefresh
+		for _, table := range job.Tables {
+			if hasCDCColumns(table.Schema) && strings.TrimSpace(job.CDCResumeLSNs[table.Name]) == "" {
+				needsSnapshot = true
+			}
+		}
+		if needsSnapshot {
+			direct, canWriteDirect := job.Destination.(destination.DirectMergeWriter)
+			if !canWriteDirect {
+				return fmt.Errorf("destination %s cannot safely combine atomic append snapshots with resumed multi-table writes", job.Destination.GetScheme())
+			}
+			appendJob := MultiTableIngestionJob{
+				Config:             job.Config,
+				Source:             job.Source,
+				Destination:        job.Destination,
+				Tables:             append([]source.SourceTableInfo(nil), job.Tables...),
+				TableDestNames:     job.TableDestNames,
+				Tracker:            job.Tracker,
+				CDCResumeLSNs:      job.CDCResumeLSNs,
+				EvolutionPlans:     job.EvolutionPlans,
+				CDCStateManager:    job.CDCStateManager,
+				WhitespaceTrimmer:  job.WhitespaceTrimmer,
+				LoadTimestamp:      job.LoadTimestamp,
+				ColumnRenamers:     job.ColumnRenamers,
+				NormalizeTableInfo: job.NormalizeTableInfo,
+			}
+			for i := range appendJob.Tables {
+				appendJob.Tables[i].PrimaryKeys = nil
+			}
+			return (&MergeStrategy{}).executeAtomicMultiTableBatch(ctx, &appendJob, publisher, direct)
+		}
 	}
 
 	config.Debug("[STRATEGY] Multi-table append with %d tables", len(job.Tables))
@@ -148,10 +322,11 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 
 			// See Execute: CDC change batches land directly and carry the
 			// staging-only _cdc_unchanged_cols column.
-			isCDC := hasCDCColumns(ti.Schema)
-			prepSchema := destination.DestinationTableSchema(ti.Schema)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
+			isCDC := hasCDCColumns(writeSchema)
+			prepSchema := destination.DestinationTableSchema(writeSchema)
 			if isCDC {
-				prepSchema = ti.Schema
+				prepSchema = writeSchema
 			}
 
 			if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
@@ -171,11 +346,22 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 				}
 			}
 
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(ti.Name)
+				if expectedIncarnation == "" {
+					errChan <- fmt.Errorf("managed CDC destination table %s has no bound physical incarnation", ti.Name)
+					return
+				}
+			}
 			mu.Lock()
 			tableConfigs[ti.Name] = destination.TableWriteConfig{
-				DestTable:   destTable,
-				Schema:      ti.Schema,
-				PrimaryKeys: ti.PrimaryKeys,
+				DestTable:              destTable,
+				Schema:                 writeSchema,
+				PrimaryKeys:            ti.PrimaryKeys,
+				CDCMode:                isCDC,
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: expectedIncarnation,
 			}
 			mu.Unlock()
 		}(tableInfo)
@@ -206,13 +392,14 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
 	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
-			Parallelism:         parallelism,
-			PageSize:            job.Config.PageSize,
-			Limit:               job.Config.SQLLimit,
-			CDCSlotSuffix:       job.Config.CDCSlotSuffix,
-			CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
-			CDCSnapshotReplace:  anyTableHasCDC && supportsCDCSnapshotReplace(job.Destination),
-			FullRefresh:         job.Config.FullRefresh,
+			Parallelism:          parallelism,
+			PageSize:             job.Config.PageSize,
+			Limit:                job.Config.SQLLimit,
+			CDCSlotSuffix:        job.Config.CDCSlotSuffix,
+			CDCLegacySlotSuffix:  job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace:   anyTableHasCDC && supportsCDCSnapshotReplace(job.Destination),
+			CDCStableDataBatches: anyTableHasCDC && job.CDCStateManager != nil,
+			FullRefresh:          job.Config.FullRefresh,
 		},
 		CDCResumeLSNs:               job.CDCResumeLSNs,
 		CDCResumeIncarnations:       resumeIncarnations,
@@ -225,17 +412,90 @@ func (s *AppendStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableI
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	records = applyMultiTableSnapshotInvalidations(readCtx, job, records)
 
-	if err := multitable.Write(ctx, job.Destination, records, destination.MultiTableWriteOptions{
-		TableConfigs:     tableConfigs,
-		Parallelism:      parallelism,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		CancelSource:     cancelRead,
-	}); err != nil {
+	writeOptions := destination.MultiTableWriteOptions{
+		TableConfigs:       tableConfigs,
+		Parallelism:        parallelism,
+		StagingBucket:      job.Config.StagingBucket,
+		LoaderFileSize:     job.Config.LoaderFileSize,
+		LoaderFileFormat:   job.Config.LoaderFileFormat,
+		CancelSource:       cancelRead,
+		CancelDrainTimeout: canceledSourceDrainTimeout,
+	}
+	if job.CDCStateManager != nil {
+		writeOptions.TableWriter = func(
+			writeCtx context.Context,
+			sourceTable string,
+			tableRecords <-chan source.RecordBatchResult,
+			opts destination.WriteOptions,
+		) (bool, error) {
+			if !tableConfigs[sourceTable].CDCMode {
+				return false, job.Destination.WriteParallel(writeCtx, tableRecords, opts)
+			}
+			return writeDurableCDCAppendRecords(writeCtx, job.Destination, tableRecords, opts, sourceTable)
+		}
+	}
+	if err := multitable.Write(ctx, job.Destination, records, writeOptions); err != nil {
 		return fmt.Errorf("failed to write multi-table data: %w", err)
 	}
 
 	return nil
+}
+
+func writeDurableCDCAppendRecords(
+	ctx context.Context,
+	dest destination.Destination,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+	sourceTable string,
+) (bool, error) {
+	truncated := false
+	for {
+		var result source.RecordBatchResult
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return truncated, ctx.Err()
+		case result, ok = <-records:
+			if !ok {
+				return truncated, nil
+			}
+		}
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return truncated, result.Err
+		}
+		if result.SnapshotInvalidation != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return truncated, fmt.Errorf("unexpected snapshot invalidation for %s after CDC append routing", sourceTable)
+		}
+		if result.Truncate {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			if !result.CDCWALTruncate {
+				return truncated, fmt.Errorf("managed CDC append replacement snapshots for table %s require atomic snapshot publication", opts.Table)
+			}
+			if err := destination.ApplyCDCTruncateIfIncarnation(ctx, dest, opts.Table, opts.CDCExpectedIncarnation); err != nil {
+				return truncated, err
+			}
+			truncated = true
+			continue
+		}
+		if result.TableName == "" {
+			result.TableName = sourceTable
+		}
+		batch := make(chan source.RecordBatchResult, 1)
+		batch <- result
+		close(batch)
+		if err := writeDurableKeylessCDCRecords(ctx, dest, batch, opts); err != nil {
+			drainAndRelease(batch)
+			return truncated, err
+		}
+	}
 }

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,15 +14,259 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 	"github.com/stretchr/testify/require"
 )
 
+type contractCaptureReplaceDestination struct {
+	*fakeDestination
+	muCapture sync.Mutex
+	types     []arrow.DataType
+	nulls     []int
+	rows      []int64
+	schemas   []*schema.TableSchema
+	fields    [][]string
+}
+
+type directContractCaptureReplaceDestination struct {
+	*contractCaptureReplaceDestination
+}
+
+func (d *directContractCaptureReplaceDestination) SupportsAtomicSwap() bool { return false }
+
+func (d *contractCaptureReplaceDestination) WriteParallel(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	for result := range records {
+		if result.Batch != nil {
+			d.muCapture.Lock()
+			if result.Batch.NumCols() > 1 {
+				d.types = append(d.types, result.Batch.Column(1).DataType())
+				d.nulls = append(d.nulls, result.Batch.Column(1).NullN())
+			}
+			d.rows = append(d.rows, result.Batch.NumRows())
+			d.schemas = append(d.schemas, opts.Schema)
+			fields := make([]string, result.Batch.NumCols())
+			for i, field := range result.Batch.Schema().Fields() {
+				fields[i] = field.Name
+			}
+			d.fields = append(d.fields, fields)
+			d.muCapture.Unlock()
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
 func singleBatchRecords(t *testing.T, rows ...int64) <-chan source.RecordBatchResult {
 	t.Helper()
 	batch := int64RecordBatch(t, "id", rows, nil)
 	return mustClosedRecords(source.RecordBatchResult{Batch: batch})
+}
+
+func TestReplaceStrategyAppliesDiscardValueContractToRecreatedTable(t *testing.T) {
+	job, src, base := minimalJob()
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job.Destination = dest
+	job.Config.SchemaContract = "discard_value"
+	job.Schema = finalSchema
+	job.SourceSchema = sourceSchema
+	job.SchemaComparison = comparison
+	job.DestinationSchema = finalSchema
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	})
+
+	require.NoError(t, (&ReplaceStrategy{}).Execute(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Len(t, dest.types, 1)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.types[0]))
+	require.Equal(t, []int{1}, dest.nulls)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestReplaceStrategyAppliesDiscardRowContractToRecreatedTable(t *testing.T) {
+	job, src, base := minimalJob()
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job.Destination = dest
+	job.Config.SchemaContract = "discard_row"
+	job.Schema = finalSchema
+	job.SourceSchema = sourceSchema
+	job.SchemaComparison = comparison
+	job.DestinationSchema = finalSchema
+	job.SchemaAligner = transformer.NewSafeTypeCaster(finalSchema.ToArrowSchema())
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	})
+
+	require.NoError(t, (&ReplaceStrategy{}).Execute(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, []int64{0}, dest.rows)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestMultiTableReplaceUsesContractFinalSchemaAndTransformation(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	table := source.SourceTableInfo{Name: "public.events", Schema: sourceSchema}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	}
+	close(records)
+	dest := &contractCaptureReplaceDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace, SchemaContract: "discard_value"},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+		},
+	}
+
+	require.NoError(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Len(t, dest.types, 1)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.types[0]))
+	require.Equal(t, []int{1}, dest.nulls)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+	require.Equal(t, schema.TypeInt64, dest.prepareCalls[0].Schema.Columns[1].DataType)
+}
+
+func TestMultiTableReplaceDiscardRowFiltersViolations(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	table := source.SourceTableInfo{Name: "public.events", Schema: sourceSchema}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	}
+	close(records)
+	dest := &contractCaptureReplaceDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace, SchemaContract: "discard_row"},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+		},
+	}
+
+	require.NoError(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, []int64{0}, dest.rows)
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestReplaceNeverPublishesStagingOnlyCDCColumns(t *testing.T) {
+	for _, direct := range []bool{false, true} {
+		name := "staging"
+		if direct {
+			name = "direct"
+		}
+		t.Run(name, func(t *testing.T) {
+			job, src, base := minimalJob()
+			fullSchema := &schema.TableSchema{Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true},
+			}}
+			capture := &contractCaptureReplaceDestination{fakeDestination: base}
+			if direct {
+				job.Destination = &directContractCaptureReplaceDestination{contractCaptureReplaceDestination: capture}
+			} else {
+				job.Destination = capture
+			}
+			job.Schema = fullSchema
+			job.SourceSchema = fullSchema
+			src.readCh = mustClosedRecords(source.RecordBatchResult{
+				Batch: intStringRecordBatch(t, "id", []int64{1}, "_cdc_unchanged_cols", []string{"value"}),
+			})
+
+			require.NoError(t, (&ReplaceStrategy{}).Execute(context.Background(), job))
+			capture.muCapture.Lock()
+			defer capture.muCapture.Unlock()
+			require.Equal(t, [][]string{{"id"}}, capture.fields)
+			require.Equal(t, []string{"id"}, capture.schemas[0].ColumnNames())
+			require.Equal(t, []string{"id"}, base.prepareCalls[0].Schema.ColumnNames())
+			if !direct {
+				require.Len(t, base.swapOptions, 1)
+				require.Equal(t, []string{"id"}, base.swapOptions[0].Schema.ColumnNames())
+			}
+		})
+	}
+}
+
+func TestMultiTableReplaceNeverPublishesStagingOnlyCDCColumns(t *testing.T) {
+	fullSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true},
+	}}
+	table := source.SourceTableInfo{Name: "events", Schema: fullSchema}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "_cdc_unchanged_cols", []string{"value"}),
+	}
+	close(records)
+	base := &fakeDestination{}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+	}
+
+	require.NoError(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, [][]string{{"id"}}, dest.fields)
+	require.Equal(t, []string{"id"}, dest.schemas[0].ColumnNames())
+	require.Equal(t, []string{"id"}, base.prepareCalls[0].Schema.ColumnNames())
+	require.Equal(t, []string{"id"}, base.swapOptions[0].Schema.ColumnNames())
 }
 
 func TestIngestionJob_GetRecords_UsesBuffered(t *testing.T) {
@@ -337,6 +582,52 @@ func TestReplaceStrategy_Execute_HappyPath(t *testing.T) {
 	}
 }
 
+func TestReplaceStrategyManagedCDCDoesNotDelegateTargetCursor(t *testing.T) {
+	job, src, _ := minimalJob()
+	dest := &replaceCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "managed-replace", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.Destination = dest
+	job.Config.IncrementalStrategy = config.StrategyReplace
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords()
+	require.NoError(t, (&ReplaceStrategy{}).Execute(t.Context(), job))
+	require.Len(t, dest.writeCalls, 1)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+	require.Len(t, dest.mergeCalls, 1)
+	require.True(t, dest.mergeCalls[0].SkipCDCResume)
+	dest.stateMu.Lock()
+	dest.incarnations[job.Config.DestTable] = "externally-replaced"
+	dest.stateMu.Unlock()
+	err = manager.Persist(t.Context(), source.CDCStateCommitToken{
+		Position: "0/20", SnapshotPositions: map[string]string{job.Config.SourceTable: "0/10"},
+		SnapshotIncarnations: map[string]string{job.Config.SourceTable: "source-v1"},
+	})
+	require.ErrorContains(t, err, "was replaced during its snapshot")
+}
+
+func TestManagedReplaceFailsClosedWithoutConditionalSwap(t *testing.T) {
+	job, src, _ := minimalJob()
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "managed-replace-unsupported-swap", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.Destination = dest
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords()
+	prepareCalls := len(dest.prepareCalls)
+	writeCalls := len(dest.writeCalls)
+
+	err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "cannot atomically fence managed CDC table replacement")
+	require.Len(t, dest.prepareCalls, prepareCalls)
+	require.Len(t, dest.writeCalls, writeCalls)
+	require.Empty(t, dest.swapCalls)
+}
+
 func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing.T) {
 	job, src, dest := minimalJob()
 	src.primaryKeysUnique = true
@@ -359,6 +650,897 @@ func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing
 	if len(dest.swapCalls) != 1 || dest.swapCalls[0][0] != dest.prepareCalls[0].Table {
 		t.Fatalf("expected staging table to be swapped directly, got swaps=%v prepares=%v", dest.swapCalls, dest.prepareCalls)
 	}
+}
+
+func TestReplaceStrategy_Execute_SkipsDedupWhenWhitespaceTrimmingCannotChangeNumericPrimaryKey(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.WhitespaceTrimmer = transformer.NewWhitespaceTrimmer()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 1 {
+		t.Fatalf("expected unique numeric primary key to keep fast path, got %d PrepareTable calls", len(dest.prepareCalls))
+	}
+	if len(dest.mergeCalls) != 0 {
+		t.Fatalf("expected no MergeTable call for numeric primary key, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_DedupsWhenWhitespaceTrimmingCanCollapseStringPrimaryKeys(t *testing.T) {
+	job, src, dest := minimalJob()
+	stringPrimaryKeySchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeString, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	job.Schema = stringPrimaryKeySchema
+	job.SourceSchema = stringPrimaryKeySchema
+	job.WhitespaceTrimmer = transformer.NewWhitespaceTrimmer()
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 2 {
+		t.Fatalf("expected trim-sensitive primary key to use dedup path, got %d PrepareTable calls", len(dest.prepareCalls))
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("raw staging table should be PK-free after whitespace trimming, got %v", got)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("expected MergeTable call after whitespace trimming, got %d", len(dest.mergeCalls))
+	}
+}
+
+func TestReplaceStrategy_Execute_RequestsDirectAtomicDeduplication(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &directReplaceDestination{fakeDestination: dest}
+	job.Config.IncrementalKey = "id"
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.prepareCalls) != 1 || dest.prepareCalls[0].Table != job.Config.DestTable {
+		t.Fatalf("direct replace should prepare the target once, got %+v", dest.prepareCalls)
+	}
+	if got := dest.prepareCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("direct target should retain its primary key metadata, got %v", got)
+	}
+	if len(dest.writeCalls) != 1 {
+		t.Fatalf("expected one direct write, got %d", len(dest.writeCalls))
+	}
+	if !dest.writeCalls[0].DeduplicatePrimaryKeys {
+		t.Fatal("direct replace did not request primary-key deduplication")
+	}
+	if got := dest.writeCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("WriteOptions.PrimaryKeys = %v, want [id]", got)
+	}
+	if dest.writeCalls[0].IncrementalKey != "id" {
+		t.Fatalf("WriteOptions.IncrementalKey = %q, want id", dest.writeCalls[0].IncrementalKey)
+	}
+	if len(dest.mergeCalls) != 0 || len(dest.swapCalls) != 0 {
+		t.Fatalf("direct replace should not stage/merge/swap, merge=%v swap=%v", dest.mergeCalls, dest.swapCalls)
+	}
+}
+
+type directReplaceDestination struct {
+	*fakeDestination
+}
+
+func (d *directReplaceDestination) SupportsAtomicSwap() bool { return false }
+func (d *directReplaceDestination) SupportsDirectReplaceDeduplication() bool {
+	return true
+}
+
+type replaceCDCStateDestination struct{ *cdcStateDestination }
+
+func (*replaceCDCStateDestination) SupportsCDCConditionalSwap() bool { return true }
+
+func (d *replaceCDCStateDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.fakeDestination.WriteParallel(ctx, records, opts)
+}
+
+func (d *replaceCDCStateDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	targetIncarnation, _, _ := d.CDCTargetIncarnation(ctx, opts.TargetTable)
+	if opts.CDCExpectedIncarnation != targetIncarnation {
+		return errors.New("destination target incarnation changed before staged replacement publish")
+	}
+	stagingIncarnation, _, _ := d.CDCTargetIncarnation(ctx, opts.StagingTable)
+	if opts.CDCExpectedStagingIncarnation != stagingIncarnation {
+		return errors.New("destination staging incarnation changed before staged replacement publish")
+	}
+	if err := d.fakeDestination.SwapTable(ctx, opts); err != nil {
+		return err
+	}
+	d.stateMu.Lock()
+	d.incarnations[opts.TargetTable] = stagingIncarnation
+	d.stateMu.Unlock()
+	return nil
+}
+
+type managedDirectReplaceDestination struct{ *replaceCDCStateDestination }
+
+func (*managedDirectReplaceDestination) SupportsAtomicSwap() bool { return false }
+func (*managedDirectReplaceDestination) SupportsDirectReplaceDeduplication() bool {
+	return true
+}
+
+type recreatingDirectReplaceDestination struct {
+	*managedDirectReplaceDestination
+	recreateTable string
+}
+
+func (d *recreatingDirectReplaceDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.stateMu.Lock()
+	d.incarnations[d.recreateTable] = "external-v2"
+	d.stateMu.Unlock()
+	current, _, _ := d.CDCTargetIncarnation(ctx, d.recreateTable)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	if opts.CDCExpectedIncarnation != current {
+		return errors.New("destination incarnation changed before direct replacement write")
+	}
+	return nil
+}
+
+type recreatingStagedReplaceDestination struct {
+	*replaceCDCStateDestination
+	recreateTable string
+}
+
+type recreatingAfterStagedReplaceDestination struct {
+	*replaceCDCStateDestination
+}
+
+type recreatingStagingAtSwapDestination struct {
+	*replaceCDCStateDestination
+}
+
+func (d *recreatingStagingAtSwapDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	d.stateMu.Lock()
+	d.incarnations[opts.StagingTable] = "unrelated-staging-recreation"
+	d.stateMu.Unlock()
+	return d.replaceCDCStateDestination.SwapTable(ctx, opts)
+}
+
+func (d *recreatingAfterStagedReplaceDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if err := d.replaceCDCStateDestination.SwapTable(ctx, opts); err != nil {
+		return err
+	}
+	d.stateMu.Lock()
+	d.incarnations[opts.TargetTable] = "unrelated-recreation"
+	d.stateMu.Unlock()
+	return nil
+}
+
+func (d *recreatingStagedReplaceDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if err := d.fakeDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	d.stateMu.Lock()
+	d.incarnations[d.recreateTable] = "external-v2"
+	d.stateMu.Unlock()
+	return nil
+}
+
+func (d *recreatingStagedReplaceDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	current, _, _ := d.CDCTargetIncarnation(ctx, opts.TargetTable)
+	if opts.CDCExpectedIncarnation != current {
+		return errors.New("destination incarnation changed before staged replacement publish")
+	}
+	return d.replaceCDCStateDestination.SwapTable(ctx, opts)
+}
+
+func TestManagedReplaceRejectsTargetRecreationDuringExtraction(t *testing.T) {
+	for _, staged := range []bool{false, true} {
+		name := "direct"
+		if staged {
+			name = "staged"
+		}
+		t.Run(name, func(t *testing.T) {
+			job, src, _ := minimalJob()
+			stateDest := newCDCStateDestination()
+			stateDest.incarnations[job.Config.DestTable] = "target-v1"
+			base := &replaceCDCStateDestination{cdcStateDestination: stateDest}
+			if staged {
+				job.Destination = &recreatingStagedReplaceDestination{replaceCDCStateDestination: base, recreateTable: job.Config.DestTable}
+			} else {
+				job.Destination = &recreatingDirectReplaceDestination{
+					managedDirectReplaceDestination: &managedDirectReplaceDestination{replaceCDCStateDestination: base},
+					recreateTable:                   job.Config.DestTable,
+				}
+			}
+			manager, err := NewCDCStateManager(job.Destination, "replace-recreation-"+name, job.Config.DestTable, "")
+			require.NoError(t, err)
+			require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+			require.NoError(t, manager.BeginRun(t.Context(), true))
+			job.CDCStateManager = manager
+			src.readCh = singleBatchRecords(t, 1)
+
+			err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+			require.ErrorContains(t, err, "incarnation changed")
+		})
+	}
+}
+
+func TestManagedReplaceRejectsRecreationAfterFencedPublication(t *testing.T) {
+	job, src, _ := minimalJob()
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &recreatingAfterStagedReplaceDestination{replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest}}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "replace-post-publication-recreation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	src.readCh = singleBatchRecords(t, 1)
+
+	err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "changed after its fenced replacement")
+}
+
+func TestManagedReplaceRejectsStagingRecreationBeforeFencedPublication(t *testing.T) {
+	job, src, _ := minimalJob()
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &recreatingStagingAtSwapDestination{replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest}}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "replace-staging-recreation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	src.readCh = singleBatchRecords(t, 1)
+
+	err = (&ReplaceStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "staging incarnation changed")
+	current, exists, incarnationErr := dest.CDCTargetIncarnation(t.Context(), job.Config.DestTable)
+	require.NoError(t, incarnationErr)
+	require.True(t, exists)
+	require.Equal(t, "target-v1", current)
+}
+
+func TestManagedMultiTableReplaceRejectsTargetRecreationDuringExtraction(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := mustClosedRecords(source.RecordBatchResult{
+		TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	})
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["users"] = "target-v1"
+	dest := &recreatingDirectReplaceDestination{
+		managedDirectReplaceDestination: &managedDirectReplaceDestination{
+			replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest},
+		},
+		recreateTable: "users",
+	}
+	manager, err := NewCDCStateManager(dest, "multi-replace-recreation", "users", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "users", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "users"},
+		CDCStateManager: manager,
+	}
+
+	err = (&ReplaceStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed")
+}
+
+func TestManagedMultiTableReplaceBindFailureCleansOnlyUnpublishedStaging(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{TableName: tables[0].Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{TableName: tables[1].Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+	)
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["users"] = "users-v1"
+	stateDest.incarnations["orders"] = "orders-v1"
+	dest := &recreatingAfterStagedReplaceDestination{replaceCDCStateDestination: &replaceCDCStateDestination{cdcStateDestination: stateDest}}
+	manager, err := NewCDCStateManager(dest, "multi-replace-bind-failure", "users", "")
+	require.NoError(t, err)
+	for _, table := range tables {
+		require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, strings.TrimPrefix(table.Name, "public."), "source-v1"))
+	}
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{}, Source: &announcingMultiTableSource{tables: tables, records: records},
+		Destination: dest, Tables: tables,
+		TableDestNames:  map[string]string{"public.users": "users", "public.orders": "orders"},
+		CDCStateManager: manager,
+	}
+
+	err = (&ReplaceStrategy{}).ExecuteMultiTable(t.Context(), job)
+	require.ErrorContains(t, err, "changed after its fenced replacement")
+	var stagingTables []string
+	for _, call := range stateDest.prepareCalls {
+		if call.ExpiresAfter == destination.ManagedStagingTTL {
+			stagingTables = append(stagingTables, call.Table)
+		}
+	}
+	require.GreaterOrEqual(t, len(stagingTables), 2)
+	require.Len(t, stateDest.swapCalls, 1)
+	publishedStaging := stateDest.swapCalls[0][0]
+	var unpublishedStaging []string
+	for _, stagingTable := range stagingTables {
+		if stagingTable != publishedStaging {
+			unpublishedStaging = append(unpublishedStaging, stagingTable)
+		}
+	}
+	require.ElementsMatch(t, unpublishedStaging, stateDest.dropCalls)
+	require.NotContains(t, stateDest.dropCalls, publishedStaging)
+	require.NotContains(t, stateDest.dropCalls, "users")
+}
+
+type directReplaceWithoutDedupDestination struct {
+	*fakeDestination
+}
+
+func (d *directReplaceWithoutDedupDestination) SupportsAtomicSwap() bool { return false }
+
+func TestReplaceStrategy_Execute_DoesNotRequestDirectDeduplicationWithoutCapability(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &directReplaceWithoutDedupDestination{fakeDestination: dest}
+	src.readCh = mustClosedRecords()
+
+	strat := &ReplaceStrategy{}
+	if err := strat.Execute(context.Background(), job); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(dest.writeCalls) != 1 {
+		t.Fatalf("expected one direct write, got %d", len(dest.writeCalls))
+	}
+	if dest.writeCalls[0].DeduplicatePrimaryKeys {
+		t.Fatal("direct replace requested deduplication from a destination without the capability")
+	}
+	if got := dest.writeCalls[0].PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("WriteOptions.PrimaryKeys = %v, want [id]", got)
+	}
+}
+
+func TestReplaceStrategy_DirectFailureCleanupStopsAtWriteAttempt(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*fakeSourceTable, *fakeDestination)
+		wantDrop  bool
+	}{
+		{
+			name: "read start failure",
+			configure: func(src *fakeSourceTable, _ *fakeDestination) {
+				src.readErr = errors.New("source unavailable")
+			},
+			wantDrop: true,
+		},
+		{
+			name: "write failure",
+			configure: func(src *fakeSourceTable, dest *fakeDestination) {
+				src.readCh = mustClosedRecords()
+				dest.writeErr = errors.New("catalog rejected write")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job, src, dest := minimalJob()
+			job.Destination = &directReplaceDestination{fakeDestination: dest}
+			tc.configure(src, dest)
+
+			err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+			if err == nil {
+				t.Fatal("expected direct replace to fail")
+			}
+			if tc.wantDrop {
+				require.Equal(t, []string{job.Config.DestTable}, dest.dropCalls)
+			} else {
+				require.Empty(t, dest.dropCalls, "a write error may be a lost response after durable replacement")
+			}
+		})
+	}
+}
+
+func TestReplaceStrategy_DirectFailurePreservesPreexistingTarget(t *testing.T) {
+	job, src, dest := minimalJob()
+	dest.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: job.Schema}
+	job.Destination = &directReplaceDestination{fakeDestination: dest}
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("catalog rejected write")
+
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected direct replace to fail")
+	}
+	if len(dest.dropCalls) != 0 {
+		t.Fatalf("preexisting target must survive failed direct replace, got drops %v", dest.dropCalls)
+	}
+}
+
+func TestReplaceStrategy_ReadSetupFailureDropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.readErr = errors.New("source unavailable")
+
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected read setup failure")
+	}
+	staging := dest.prepareCalls[0].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
+	}
+}
+
+func TestReplaceStrategy_WriterFailureBoundsNonclosingSourceDrain(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailStagedMergeDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	if time.Since(started) > time.Second {
+		t.Fatal("replace waited indefinitely for a nonclosing source")
+	}
+	close(records)
+	if len(base.dropCalls) != 1 {
+		t.Fatalf("expected failed replace staging cleanup, got %v", base.dropCalls)
+	}
+}
+
+func TestReplaceStrategy_ExecuteMultiTable_PropagatesDirectDeduplicationConfiguration(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tableSchema.IncrementalKey = "id"
+	table := source.SourceTableInfo{
+		Name:        "public.users",
+		Schema:      tableSchema,
+		PrimaryKeys: []string{"id"},
+	}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	stateDest := newCDCStateDestination()
+	replaceDest := &replaceCDCStateDestination{cdcStateDestination: stateDest}
+	managedDest := &managedDirectReplaceDestination{replaceCDCStateDestination: replaceDest}
+	manager, err := NewCDCStateManager(managedDest, "managed-multi-replace", "users", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "users", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	dest := stateDest.fakeDestination
+	job := &MultiTableIngestionJob{
+		Config:          &config.IngestConfig{},
+		Source:          src,
+		Destination:     managedDest,
+		Tables:          src.tables,
+		TableDestNames:  map[string]string{"public.users": "users"},
+		CDCStateManager: manager,
+	}
+
+	if err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job); err != nil {
+		t.Fatalf("ExecuteMultiTable returned error: %v", err)
+	}
+
+	if len(dest.writeCalls) != 1 {
+		t.Fatalf("expected one table write, got %d", len(dest.writeCalls))
+	}
+	write := dest.writeCalls[0]
+	if !write.DeduplicatePrimaryKeys {
+		t.Fatal("multi-table direct replace did not request primary-key deduplication")
+	}
+	if got := write.PrimaryKeys; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("WriteOptions.PrimaryKeys = %v, want [id]", got)
+	}
+	if write.IncrementalKey != "id" {
+		t.Fatalf("WriteOptions.IncrementalKey = %q, want id", write.IncrementalKey)
+	}
+	if !write.SkipCDCResume {
+		t.Fatal("managed multi-table direct replace delegated the CDC cursor to the destination")
+	}
+	stateDest.stateMu.Lock()
+	stateDest.incarnations["users"] = "externally-replaced"
+	stateDest.stateMu.Unlock()
+	err = manager.Persist(t.Context(), source.CDCStateCommitToken{
+		Position: "0/20", SnapshotPositions: map[string]string{table.Name: "0/10"},
+		SnapshotIncarnations: map[string]string{table.Name: "source-v1"},
+	})
+	require.ErrorContains(t, err, "was replaced during its snapshot")
+}
+
+func TestReplaceStrategy_MultiTableDirectWriteFailurePreservesAttemptedTargets(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Err: errors.New("source stream failed")}
+	close(records)
+	src := &announcingMultiTableSource{tables: tables, records: records}
+	base := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{
+		"users": tableSchema,
+	}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
+		Source:      src,
+		Destination: &directReplaceDestination{fakeDestination: base},
+		Tables:      tables,
+		TableDestNames: map[string]string{
+			"public.users":  "users",
+			"public.orders": "orders",
+		},
+	}
+
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected multi-table direct replace to fail")
+	}
+	require.Empty(t, base.dropCalls, "multi-table write errors may follow durable writes")
+}
+
+func TestReplaceStrategy_MultiTableSwapFailureCleansActiveStages(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tableSchema.IncrementalKey = "id"
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	dest := &fakeDestination{swapErr: errors.New("swap failed")}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    dest,
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected swap failure")
+	}
+	if len(dest.dropCalls) < 2 {
+		t.Fatalf("expected raw and normalised stage cleanup, got %v", dest.dropCalls)
+	}
+	normalised := dest.prepareCalls[len(dest.prepareCalls)-1].Table
+	if dest.dropCalls[len(dest.dropCalls)-1] != normalised {
+		t.Fatalf("expected active normalised stage %q to be cleaned, got %v", normalised, dest.dropCalls)
+	}
+}
+
+func TestAppendStrategy_WriterFailureBoundsNonclosingSource(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailStagedMergeDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&AppendStrategy{}).Execute(context.Background(), job)
+	if err == nil || time.Since(started) > time.Second {
+		t.Fatalf("append did not return promptly after writer failure: %v", err)
+	}
+	close(records)
+}
+
+type cancelAwareMultiTableSource struct {
+	*announcingMultiTableSource
+	done chan struct{}
+}
+
+func (s *cancelAwareMultiTableSource) ReadAll(ctx context.Context, _ source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(s.done)
+		defer close(records)
+		for {
+			select {
+			case records <- source.RecordBatchResult{TableName: s.tables[0].Name}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return records, nil
+}
+
+type immediateFailMultiTableDestination struct {
+	*directReplaceDestination
+}
+
+type ownedDirectReplaceDestination struct {
+	*directReplaceDestination
+	preparedToken string
+	dropTokens    []string
+	ownerChanged  bool
+}
+
+type uncertainPrepareOwnedDestination struct {
+	*directReplaceDestination
+	preparedToken string
+	dropTokens    []string
+}
+
+func (d *uncertainPrepareOwnedDestination) PrepareTable(_ context.Context, opts destination.PrepareOptions) error {
+	d.preparedToken = opts.OwnershipToken
+	return errors.New("prepare response lost after target creation")
+}
+
+func (d *uncertainPrepareOwnedDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	return nil
+}
+
+type contextAwareDropDestination struct {
+	*fakeDestination
+	successfulDrops []string
+}
+
+type uncertainManagedStagingPrepareDestination struct {
+	*contextAwareDropDestination
+}
+
+func (d *uncertainManagedStagingPrepareDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := d.contextAwareDropDestination.PrepareTable(ctx, opts); err != nil {
+		return err
+	}
+	if opts.ExpiresAfter > 0 {
+		return errors.New("managed staging prepare response lost after create")
+	}
+	return nil
+}
+
+func (d *contextAwareDropDestination) DropTable(ctx context.Context, table string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d.successfulDrops = append(d.successfulDrops, table)
+	return d.fakeDestination.DropTable(ctx, table)
+}
+
+func (d *ownedDirectReplaceDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	d.preparedToken = opts.OwnershipToken
+	return d.directReplaceDestination.PrepareTable(ctx, opts)
+}
+
+func (d *ownedDirectReplaceDestination) WriteParallel(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	d.ownerChanged = true
+	return errors.New("write failed after replacement owner appeared")
+}
+
+func (d *ownedDirectReplaceDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	if d.ownerChanged {
+		return errors.New("ownership changed")
+	}
+	return nil
+}
+
+func TestDirectReplaceWriteFailurePreservesOwnedTarget(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	dest := &ownedDirectReplaceDestination{
+		directReplaceDestination: &directReplaceDestination{fakeDestination: base},
+	}
+	job.Destination = dest
+
+	err := (&ReplaceStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "ownership does not prove a failed write was uncommitted")
+	if len(base.dropCalls) != 0 {
+		t.Fatalf("unconditional cleanup deleted a replacement owner: %v", base.dropCalls)
+	}
+}
+
+func TestMultiTableDirectReplaceWriteFailurePreservesOwnedTarget(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &ownedDirectReplaceDestination{
+		directReplaceDestination: &directReplaceDestination{fakeDestination: base},
+	}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	require.Error(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "ownership does not prove a failed write was uncommitted")
+	require.Empty(t, base.dropCalls, "unconditional cleanup must not delete the replacement owner")
+}
+
+func TestDirectReplaceUncertainPrepareFailureCleansRegisteredOwnedTarget(t *testing.T) {
+	job, _, base := minimalJob()
+	dest := &uncertainPrepareOwnedDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).Execute(context.Background(), job), "prepare response lost")
+	require.NotEmpty(t, dest.preparedToken)
+	require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+	require.Empty(t, base.dropCalls)
+}
+
+func TestMultiTableDirectReplaceUncertainPrepareFailureCleansRegisteredOwnedTarget(t *testing.T) {
+	table := source.SourceTableInfo{Name: "users", Schema: streamTestSchema()}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &uncertainPrepareOwnedDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job), "prepare response lost")
+	require.NotEmpty(t, dest.preparedToken)
+	require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+	require.Empty(t, base.dropCalls)
+}
+
+func TestReplaceFailureUsesDetachedStagingCleanupContext(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	base.swapErr = errors.New("swap failed")
+	dest := &contextAwareDropDestination{fakeDestination: base}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := (&ReplaceStrategy{}).Execute(ctx, job)
+	if err == nil {
+		t.Fatal("expected replace failure")
+	}
+	if len(dest.successfulDrops) != 2 {
+		t.Fatalf("staging cleanup inherited canceled caller context: %v", dest.successfulDrops)
+	}
+}
+
+func TestMultiTableReplaceLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	table := source.SourceTableInfo{Name: "users", Schema: streamTestSchema()}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyReplace},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "users"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).ExecuteMultiTable(ctx, job), "prepare response lost")
+	require.Len(t, dest.successfulDrops, 1)
+	require.Equal(t, base.prepareCalls[0].Table, dest.successfulDrops[0])
+}
+
+func TestReplaceLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&ReplaceStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 1)
+	require.Equal(t, []string{base.prepareCalls[0].Table}, dest.successfulDrops)
+}
+
+func TestDeduplicateStagingLostNormalisedPrepareCleansBothStagesDetached(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	rawTable := "lake.events_raw"
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := deduplicateStaging(ctx, dest, rawTable, "lake.events", "", "", streamTestSchema(), []string{"id"}, "", nil, false)
+	require.ErrorContains(t, err, "prepare response lost")
+	require.Len(t, base.prepareCalls, 1)
+	require.ElementsMatch(t, []string{rawTable, base.prepareCalls[0].Table}, dest.successfulDrops)
+}
+
+func (d *immediateFailMultiTableDestination) WriteParallel(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	return errors.New("writer failed")
+}
+
+func TestReplaceStrategy_MultiTableWriterFailureCancelsSource(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema}
+	done := make(chan struct{})
+	src := &cancelAwareMultiTableSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		done:                       done,
+	}
+	base := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    &immediateFailMultiTableDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("source producer remained blocked after writer failure")
+	}
+}
+
+func TestReplaceStrategy_MultiTableWriterFailureBoundsNonclosingSourceDrain(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema}
+	records := make(chan source.RecordBatchResult)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	base := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    &immediateFailMultiTableDestination{directReplaceDestination: &directReplaceDestination{fakeDestination: base}},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	started := time.Now()
+	err := (&ReplaceStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	if time.Since(started) > time.Second {
+		t.Fatal("replace waited indefinitely for a nonclosing source")
+	}
+	close(records)
 }
 
 func TestReplaceStrategy_Execute_UsesDestinationReplaceStagingPolicy(t *testing.T) {

--- a/pkg/strategy/cdc_state.go
+++ b/pkg/strategy/cdc_state.go
@@ -116,6 +116,8 @@ type CDCStateManager struct {
 	knownSchemas        map[string]string
 	knownDestinations   map[string]string
 	boundDestinations   map[string]string
+	boundDestinationRaw map[string]string
+	batchSnapshots      map[string]string
 	lateTargetModes     map[string]lateTargetMode
 	lateTargetRaw       map[string]string
 	snapshotEpochs      map[string]uint64
@@ -135,6 +137,9 @@ func NewCDCStateManager(dest destination.Destination, connectorID, _ string, sta
 	manager, err := newCDCStateManager(dest, connectorID, managedCDCStateTableName(dest, cdcStateTableName, stagingDataset))
 	if err != nil {
 		return nil, err
+	}
+	if _, ok := dest.(destination.CDCConditionalTruncater); !ok {
+		return nil, fmt.Errorf("destination scheme %q cannot conditionally apply managed CDC truncates", dest.GetScheme())
 	}
 	claimer, ok := dest.(destination.CDCTargetClaimer)
 	if !ok {
@@ -187,6 +192,8 @@ func newCDCStateManager(dest destination.Destination, connectorID, stateTable st
 		knownSchemas:        make(map[string]string),
 		knownDestinations:   make(map[string]string),
 		boundDestinations:   make(map[string]string),
+		boundDestinationRaw: make(map[string]string),
+		batchSnapshots:      make(map[string]string),
 		lateTargetModes:     make(map[string]lateTargetMode),
 		lateTargetRaw:       make(map[string]string),
 		snapshotEpochs:      make(map[string]uint64),
@@ -225,13 +232,17 @@ func (m *CDCStateManager) RegisterTableState(ctx context.Context, sourceTable, d
 // this returns, an older completed epoch can no longer make the table
 // resumable, even if the process crashes during truncate or backfill.
 func (m *CDCStateManager) InvalidateSnapshot(ctx context.Context, sourceTable, destTable, incarnation string) error {
+	return m.InvalidateSnapshotState(ctx, sourceTable, destTable, incarnation, "")
+}
+
+func (m *CDCStateManager) InvalidateSnapshotState(ctx context.Context, sourceTable, destTable, incarnation, schemaFingerprint string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if err := m.claimTarget(ctx, sourceTable, destTable); err != nil {
 		return err
 	}
-	if err := m.registerTable(ctx, sourceTable, destTable, incarnation, ""); err != nil {
+	if err := m.registerTable(ctx, sourceTable, destTable, incarnation, schemaFingerprint); err != nil {
 		return err
 	}
 	if incarnation == "" {
@@ -251,6 +262,7 @@ func (m *CDCStateManager) InvalidateSnapshot(ctx context.Context, sourceTable, d
 	delete(m.knownSchemas, sourceTable)
 	delete(m.knownDestinations, sourceTable)
 	delete(m.boundDestinations, sourceTable)
+	delete(m.boundDestinationRaw, sourceTable)
 	return nil
 }
 
@@ -270,7 +282,7 @@ func (m *CDCStateManager) BindDestinationIncarnation(ctx context.Context, source
 			return fmt.Errorf("CDC destination table %q disappeared before snapshot write", destTable)
 		}
 	}
-	current, exists, err := m.currentDestinationIncarnation(ctx, sourceTable)
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
 	if err != nil {
 		return err
 	}
@@ -281,6 +293,110 @@ func (m *CDCStateManager) BindDestinationIncarnation(ctx context.Context, source
 		return fmt.Errorf("CDC destination table %q was replaced during its snapshot", destTable)
 	}
 	m.boundDestinations[sourceTable] = current
+	m.boundDestinationRaw[sourceTable] = raw
+	return nil
+}
+
+func (m *CDCStateManager) BoundDestinationIncarnation(sourceTable string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.boundDestinationRaw[sourceTable]
+}
+
+func (m *CDCStateManager) DestinationIncarnationForPublication(ctx context.Context, destTable string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	raw, _, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return "", err
+	}
+	if !exists || raw == "" {
+		return "", fmt.Errorf("CDC replacement table %q has no stable physical incarnation", destTable)
+	}
+	return raw, nil
+}
+
+// BindPublishedDestinationIncarnation accepts the physical incarnation created
+// by a destination-fenced replacement. The caller must provide the incarnation
+// that guarded publication so an unrelated or stale run cannot rebind state.
+func (m *CDCStateManager) BindPublishedDestinationIncarnation(
+	ctx context.Context,
+	sourceTable, destTable, expectedPrevious, expectedPublished string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if expectedPrevious == "" || expectedPublished == "" || m.boundDestinationRaw[sourceTable] != expectedPrevious {
+		return fmt.Errorf("CDC destination table %q replacement was not fenced by its bound incarnation", destTable)
+	}
+	if err := m.registerTable(ctx, sourceTable, destTable, "", ""); err != nil {
+		return err
+	}
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || raw != expectedPublished {
+		return fmt.Errorf("CDC destination table %q changed after its fenced replacement was published", destTable)
+	}
+	m.boundDestinations[sourceTable] = current
+	m.boundDestinationRaw[sourceTable] = raw
+	return nil
+}
+
+func (m *CDCStateManager) InvalidateSnapshotPreservingDestination(ctx context.Context, sourceTable, destTable, incarnation string) error {
+	return m.InvalidateSnapshotStatePreservingDestination(ctx, sourceTable, destTable, incarnation, "")
+}
+
+func (m *CDCStateManager) InvalidateSnapshotStatePreservingDestination(ctx context.Context, sourceTable, destTable, incarnation, schemaFingerprint string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.claimTarget(ctx, sourceTable, destTable); err != nil {
+		return err
+	}
+	if err := m.registerTable(ctx, sourceTable, destTable, incarnation, schemaFingerprint); err != nil {
+		return err
+	}
+	if incarnation == "" {
+		incarnation = m.currentIncarnations[sourceTable]
+	}
+	if !m.started || m.generation == 0 {
+		return fmt.Errorf("CDC state run has not started")
+	}
+	expected := m.boundDestinations[sourceTable]
+	if expected == "" {
+		expected = m.knownDestinations[sourceTable]
+	}
+	if expected == "" {
+		return fmt.Errorf("CDC destination table %q has no previously verified physical incarnation", destTable)
+	}
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expected {
+		return fmt.Errorf("CDC destination table %q was replaced after its prior snapshot boundary", destTable)
+	}
+	epoch := m.snapshotEpochs[sourceTable] + 1
+	position := encodeCDCStatePositionWithSchema(zeroCDCPosition, incarnation, m.currentSchemas[sourceTable], epoch)
+	if err := m.writeState(ctx, sourceTable, destTable, cdcStateKindSnapshot, m.generation, cdcStateStatusInProgress, position); err != nil {
+		return fmt.Errorf("failed to invalidate CDC snapshot for %s: %w", sourceTable, err)
+	}
+	_, afterWrite, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || afterWrite != expected {
+		return fmt.Errorf("CDC destination table %q changed while invalidating its prior snapshot boundary", destTable)
+	}
+	m.snapshotEpochs[sourceTable] = epoch
+	delete(m.knownComplete, sourceTable)
+	delete(m.knownIncarnations, sourceTable)
+	delete(m.knownSchemas, sourceTable)
+	delete(m.knownDestinations, sourceTable)
+	m.boundDestinations[sourceTable] = expected
+	m.boundDestinationRaw[sourceTable] = raw
 	return nil
 }
 
@@ -345,6 +461,7 @@ func (m *CDCStateManager) ClaimLateDiscoveredTarget(
 		m.lateTargetModes[sourceTable] = lateTargetCreatedEmpty
 		m.lateTargetRaw[sourceTable] = createdIncarnation
 		m.boundDestinations[sourceTable] = cdcDestinationIncarnationDigest(createdIncarnation)
+		m.boundDestinationRaw[sourceTable] = createdIncarnation
 		return nil
 	}
 	if !allowReplacement {
@@ -374,6 +491,7 @@ func (m *CDCStateManager) ClaimLateDiscoveredTarget(
 		m.lateTargetModes[sourceTable] = lateTargetConditionalReplace
 		m.lateTargetRaw[sourceTable] = rawDestinationIncarnation
 		m.boundDestinations[sourceTable] = destinationIncarnation
+		m.boundDestinationRaw[sourceTable] = rawDestinationIncarnation
 	}
 	return nil
 }
@@ -546,6 +664,7 @@ func (m *CDCStateManager) ApplyLateSnapshotBoundary(ctx context.Context, sourceT
 		}
 	}
 	m.boundDestinations[sourceTable] = expectedDigest
+	m.boundDestinationRaw[sourceTable] = expectedRaw
 	delete(m.lateTargetModes, sourceTable)
 	delete(m.lateTargetRaw, sourceTable)
 	return true, nil
@@ -751,6 +870,8 @@ func (m *CDCStateManager) BeginRun(ctx context.Context, fullRefresh bool) error 
 		m.knownDestinations = make(map[string]string)
 	}
 	m.boundDestinations = make(map[string]string)
+	m.boundDestinationRaw = make(map[string]string)
+	m.batchSnapshots = make(map[string]string)
 	m.snapshotEpochs = make(map[string]uint64)
 	m.generation++
 	runID, err := newCDCStateRunID()
@@ -801,6 +922,18 @@ func (m *CDCStateManager) Persist(ctx context.Context, token source.CDCStateComm
 
 	if !m.started || m.generation == 0 {
 		return fmt.Errorf("CDC state run has not started")
+	}
+	token.SnapshotPositions = cloneStringMap(token.SnapshotPositions)
+	token.SnapshotIncarnations = cloneStringMap(token.SnapshotIncarnations)
+	token.SnapshotSchemas = cloneStringMap(token.SnapshotSchemas)
+	for table, position := range m.batchSnapshots {
+		if position == "" {
+			position = token.Position
+		}
+		if position == "" {
+			return fmt.Errorf("completed batch snapshot for %s has no durable source position", table)
+		}
+		token.SnapshotPositions[table] = position
 	}
 	if token.Position != "" && !cdcStatePositionValid(token.Position) {
 		return fmt.Errorf("invalid CDC checkpoint position %q", token.Position)
@@ -942,15 +1075,133 @@ func (m *CDCStateManager) Persist(ctx context.Context, token source.CDCStateComm
 			return fmt.Errorf("CDC destination table %q changed while its state was being persisted", m.destTables[sourceTable])
 		}
 		m.knownDestinations[sourceTable] = expected
-		if _, freshSnapshot := token.SnapshotPositions[sourceTable]; freshSnapshot {
-			delete(m.boundDestinations, sourceTable)
-		}
 	}
 	m.pruneSuperseded(ctx)
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
+	m.batchSnapshots = make(map[string]string)
 	return nil
+}
+
+func (m *CDCStateManager) RecordBatchSnapshotCompletion(sourceTable, position string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.batchSnapshots == nil {
+		m.batchSnapshots = make(map[string]string)
+	}
+	m.batchSnapshots[sourceTable] = position
+}
+
+func applyMultiTableSnapshotInvalidations(
+	ctx context.Context,
+	job *MultiTableIngestionJob,
+	records <-chan source.RecordBatchResult,
+) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult)
+	drainTimeout := canceledSourceDrainTimeout
+	go func() {
+		defer close(out)
+		knownTables := make(map[string]struct{}, len(job.Tables))
+		for _, table := range job.Tables {
+			knownTables[table.Name] = struct{}{}
+		}
+		pending := make(map[string]source.CDCSnapshotInvalidation)
+		fail := func(result source.RecordBatchResult, err error) {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			select {
+			case out <- source.RecordBatchResult{Err: err}:
+			case <-ctx.Done():
+			}
+			<-startBoundedRecordDrain(records, drainTimeout)
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				<-startBoundedRecordDrain(records, drainTimeout)
+				return
+			case result, ok := <-records:
+				if !ok {
+					if len(pending) > 0 {
+						tables := make([]string, 0, len(pending))
+						for table := range pending {
+							tables = append(tables, table)
+						}
+						sort.Strings(tables)
+						fail(source.RecordBatchResult{}, fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", tables[0]))
+					}
+					return
+				}
+				if result.Err != nil {
+					fail(result, result.Err)
+					return
+				}
+				if result.SnapshotInvalidation != nil {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					invalidation := *result.SnapshotInvalidation
+					if _, known := knownTables[invalidation.TableName]; !known {
+						fail(source.RecordBatchResult{}, fmt.Errorf("source requested snapshot invalidation for unknown table %q", invalidation.TableName))
+						return
+					}
+					if _, exists := pending[invalidation.TableName]; exists {
+						fail(source.RecordBatchResult{}, fmt.Errorf("source repeated snapshot invalidation for %s before its replacement boundary", invalidation.TableName))
+						return
+					}
+					pending[invalidation.TableName] = invalidation
+					continue
+				}
+				if invalidation, waiting := pending[result.TableName]; waiting {
+					if !result.Truncate || result.CDCWALTruncate {
+						if result.Batch == nil && result.TableInfo != nil {
+							select {
+							case out <- result:
+							case <-ctx.Done():
+								<-startBoundedRecordDrain(records, drainTimeout)
+								return
+							}
+							continue
+						}
+						fail(result, fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", result.TableName))
+						return
+					}
+					if job.CDCStateManager == nil {
+						fail(result, fmt.Errorf("source requested snapshot invalidation without destination-managed CDC state"))
+						return
+					}
+					if err := job.CDCStateManager.InvalidateSnapshotStatePreservingDestination(
+						ctx, invalidation.TableName, job.GetDestTableName(invalidation.TableName),
+						invalidation.Incarnation, invalidation.SchemaFingerprint,
+					); err != nil {
+						fail(result, err)
+						return
+					}
+					delete(pending, result.TableName)
+				}
+				select {
+				case out <- result:
+				case <-ctx.Done():
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					<-startBoundedRecordDrain(records, drainTimeout)
+					return
+				}
+			}
+		}
+	}()
+	return out
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (m *CDCStateManager) prepareTable(ctx context.Context) error {

--- a/pkg/strategy/cdc_state_test.go
+++ b/pkg/strategy/cdc_state_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/pkg/destination"
@@ -45,6 +46,35 @@ type cdcStateDestination struct {
 
 type caseCanonicalCDCStateDestination struct {
 	*cdcStateDestination
+}
+
+type nonConditionalCDCStateDestination struct {
+	*fakeDestination
+}
+
+func (*nonConditionalCDCStateDestination) LoadCDCState(context.Context, string, string) ([]destination.CDCStateEntry, error) {
+	return nil, nil
+}
+
+func (*nonConditionalCDCStateDestination) LoadCDCStateFence(context.Context, string, string) (destination.CDCStateFence, error) {
+	return destination.CDCStateFence{}, nil
+}
+
+func (*nonConditionalCDCStateDestination) DeleteCDCStateEvents(context.Context, string, string, []string) error {
+	return nil
+}
+
+func (*nonConditionalCDCStateDestination) WriteCDCState(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	return nil
+}
+
+func (*nonConditionalCDCStateDestination) ClaimCDCTarget(context.Context, string, destination.CDCTargetClaim) error {
+	return nil
 }
 
 func (d *caseCanonicalCDCStateDestination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {
@@ -108,6 +138,12 @@ func newCDCStateDestination() *cdcStateDestination {
 		targets:         make(map[string]string),
 		incarnations:    make(map[string]string),
 	}
+}
+
+func TestNewCDCStateManagerRejectsDestinationWithoutConditionalTruncate(t *testing.T) {
+	dest := &nonConditionalCDCStateDestination{fakeDestination: &fakeDestination{}}
+	_, err := NewCDCStateManager(dest, "missing-conditional-truncate", "raw.orders", "")
+	require.ErrorContains(t, err, "cannot conditionally apply managed CDC truncates")
 }
 
 func (d *cdcStateDestination) ClaimCDCTarget(_ context.Context, _ string, claim destination.CDCTargetClaim) error {
@@ -291,6 +327,94 @@ func TestCDCStateWALTruncatePreservesRegisteredSourceIncarnation(t *testing.T) {
 	position, err := restarted.ResumePosition(ctx, "public.orders")
 	require.NoError(t, err)
 	require.Equal(t, "00000000/00000030", position)
+}
+
+func TestMultiTableSnapshotInvalidationIsDurableBeforeNonAtomicTruncate(t *testing.T) {
+	ctx := t.Context()
+	dest := &orderedCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.items"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-invalidation", "raw.items", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.items", "raw.items", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.items", "raw.items"))
+	dest.resetOrder()
+	job := &MultiTableIngestionJob{
+		Tables:          []source.SourceTableInfo{{Name: "public.items"}},
+		TableDestNames:  map[string]string{"public.items": "raw.items"},
+		CDCStateManager: manager,
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+		TableName: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+	}}
+	records <- source.RecordBatchResult{TableName: "public.items", Truncate: true}
+	close(records)
+
+	_, err = destination.WriteWithTruncateBoundaries(ctx, dest, applyMultiTableSnapshotInvalidations(ctx, job, records), destination.WriteOptions{
+		Table: "raw.items", CDCExpectedIncarnation: "target-v1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"state", "truncate"}, dest.recordedOrder())
+}
+
+func TestMultiTableSnapshotInvalidationWithoutBoundaryPreservesPriorState(t *testing.T) {
+	ctx := t.Context()
+	dest := &orderedCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.items"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-missing-boundary", "raw.items", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.items", "raw.items", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.items", "raw.items"))
+	dest.resetOrder()
+	job := &MultiTableIngestionJob{
+		Tables:          []source.SourceTableInfo{{Name: "public.items"}},
+		TableDestNames:  map[string]string{"public.items": "raw.items"},
+		CDCStateManager: manager,
+	}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+		TableName: "public.items", Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+	}}
+	close(records)
+
+	var gotErr error
+	for result := range applyMultiTableSnapshotInvalidations(ctx, job, records) {
+		gotErr = result.Err
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	require.ErrorContains(t, gotErr, "was not followed by a replacement boundary")
+	require.Empty(t, dest.recordedOrder())
+}
+
+func TestMultiTableSnapshotInvalidationCancellationDrainsUpstream(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	batch := &singleReleaseCountingRecordBatch{RecordBatch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records := make(chan source.RecordBatchResult)
+	out := applyMultiTableSnapshotInvalidations(ctx, &MultiTableIngestionJob{}, records)
+	producerDone := make(chan struct{})
+	go func() {
+		records <- source.RecordBatchResult{Batch: batch}
+		close(records)
+		close(producerDone)
+	}()
+
+	for result := range out {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	select {
+	case <-producerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("snapshot invalidation wrapper stranded its upstream producer after cancellation")
+	}
+	require.EqualValues(t, 1, batch.releases.Load())
 }
 
 func TestCDCStateRequiresMatchingDestinationTableIncarnation(t *testing.T) {
@@ -1425,6 +1549,26 @@ func TestCDCStateRequiresLatestGenerationCompletedSnapshot(t *testing.T) {
 	if manager.stateTable != "_bruin_staging.cdc_state" {
 		t.Fatalf("unexpected shared state table: %s", manager.stateTable)
 	}
+}
+
+func TestCDCStateBatchSnapshotCompletionUsesFinalCheckpoint(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	manager, err := NewCDCStateManager(dest, "batch-truncate-completion", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.orders", "raw.orders", "source-v1", "schema-v1"))
+	require.NoError(t, manager.ClaimTarget(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	manager.RecordBatchSnapshotCompletion("public.orders", "")
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "00000000/00000020"}))
+
+	restarted, err := NewCDCStateManager(dest, "batch-truncate-completion", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(ctx, "public.orders", "raw.orders", "source-v1", "schema-v1"))
+	position, err := restarted.ResumePosition(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", position)
 }
 
 func TestCDCStateConnectorsShareTableWithoutSharingRows(t *testing.T) {

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -56,6 +56,9 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	}); err != nil {
 		return fmt.Errorf("failed to prepare destination table: %w", err)
 	}
+	if !job.Config.KeepStaging {
+		defer dropManagedStagingDetached(ctx, job.Destination, stagingTable, "DELETE+INSERT")
+	}
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
 		Table:        stagingTable,
@@ -120,13 +123,12 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 	intervalStart := resolveIntervalBound(job.Config.IntervalStart, intervalTracker.Min)
 	intervalEnd := resolveIntervalBound(job.Config.IntervalEnd, intervalTracker.Max)
 
+	if err := job.ApplyEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	}
+
 	if intervalStart == nil || intervalEnd == nil {
 		config.Debug("[DELETE+INSERT] No interval detected (empty data?), skipping delete+insert")
-		if !job.Config.KeepStaging {
-			if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-				config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
-			}
-		}
 		return nil
 	}
 
@@ -140,10 +142,6 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		intervalEnd = toDateOnly(intervalEnd)
 	}
 
-	if err := job.ApplyEvolution(ctx); err != nil {
-		return fmt.Errorf("failed to apply schema evolution: %w", err)
-	}
-
 	if err := job.Destination.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
 		StagingTable:       stagingTable,
 		TargetTable:        job.Config.DestTable,
@@ -151,16 +149,10 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 		IncrementalKeyType: incrementalKeyType,
 		IntervalStart:      intervalStart,
 		IntervalEnd:        intervalEnd,
-		Columns:            job.Schema.ColumnNames(),
+		Columns:            destination.DestinationColumns(job.Schema.ColumnNames()),
 		PrimaryKeys:        job.Config.PrimaryKeys,
 	}); err != nil {
 		return fmt.Errorf("failed to delete+insert data: %w", err)
-	}
-
-	if !job.Config.KeepStaging {
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[DELETE+INSERT] Warning: failed to drop staging table: %v", err)
-		}
 	}
 
 	return nil

--- a/pkg/strategy/direct_merge_test.go
+++ b/pkg/strategy/direct_merge_test.go
@@ -1,0 +1,340 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type directMergeCall struct {
+	write destination.WriteOptions
+	merge destination.MergeOptions
+}
+
+type directMergeDestination struct {
+	*fakeDestination
+	directMu    sync.Mutex
+	directCalls []directMergeCall
+}
+
+type durableDirectMergeDestination struct {
+	*directMergeDestination
+	tokenMu    sync.Mutex
+	tokenCalls []durableTokenCall
+}
+
+type failAfterOneDirectMergeDestination struct {
+	*fakeDestination
+	err error
+}
+
+func (d *failAfterOneDirectMergeDestination) MergeRecords(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions, _ destination.MergeOptions) error {
+	result, ok := <-records
+	if ok && result.Batch != nil {
+		result.Batch.Release()
+	}
+	return d.err
+}
+
+func (d *durableDirectMergeDestination) CommitWriteToken(_ context.Context, table string, token any, cdcResumeLSN string) error {
+	d.tokenMu.Lock()
+	defer d.tokenMu.Unlock()
+	d.tokenCalls = append(d.tokenCalls, durableTokenCall{table: table, token: token, cdcResumeLSN: cdcResumeLSN})
+	return nil
+}
+
+func (d *directMergeDestination) MergeRecords(ctx context.Context, records <-chan source.RecordBatchResult, write destination.WriteOptions, merge destination.MergeOptions) error {
+	d.directMu.Lock()
+	d.directCalls = append(d.directCalls, directMergeCall{write: write, merge: merge})
+	d.directMu.Unlock()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case result, ok := <-records:
+			if !ok {
+				return nil
+			}
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			if result.Err != nil {
+				return result.Err
+			}
+		}
+	}
+}
+
+func (d *directMergeDestination) callsSnapshot() []directMergeCall {
+	d.directMu.Lock()
+	defer d.directMu.Unlock()
+	return append([]directMergeCall(nil), d.directCalls...)
+}
+
+func TestMergeStrategyUsesDirectMergeWithoutStaging(t *testing.T) {
+	job, src, base := minimalJob()
+	dest := &directMergeDestination{fakeDestination: base}
+	job.Destination = dest
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1, 2}, nil)})
+
+	require.NoError(t, (&MergeStrategy{}).Execute(context.Background(), job))
+	require.Len(t, base.prepareCalls, 1)
+	require.Equal(t, job.Config.DestTable, base.prepareCalls[0].Table)
+	require.Empty(t, base.writeCalls)
+	require.Empty(t, base.mergeCalls)
+	require.Empty(t, base.dropCalls)
+
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 1)
+	require.Equal(t, job.Config.DestTable, calls[0].merge.TargetTable)
+	require.Equal(t, []string{"id"}, calls[0].merge.PrimaryKeys)
+	require.Equal(t, job.Config.ExtractParallelism, calls[0].write.Parallelism)
+}
+
+func TestStreamingDirectMergeFlushesTargetAndTokenWithoutStaging(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &directMergeDestination{fakeDestination: base}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+	state := &streamTableState{
+		destTable:      "ds.events",
+		schema:         streamTestSchema(),
+		primaryKeys:    []string{"id"},
+		incrementalKey: "id",
+	}
+	cfg := &config.IngestConfig{ExtractParallelism: 3}
+	require.NoError(t, executor.prepareTable(context.Background(), dest, cfg, state))
+	require.True(t, state.directMerge)
+	require.Empty(t, state.stagingTable)
+	require.Len(t, base.prepareCalls, 1)
+
+	committer := &fakeCommitter{}
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		Strategy: config.StrategyMerge, Committer: committer, FlushInterval: time.Hour,
+	}, map[string]*streamTableState{"": state})
+	loop.buffer(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{7}, nil), CommitToken: "0/70",
+		DurableCommitID: "0/70", DurableCommitPosition: "0/70",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 1)
+	require.Equal(t, "ds.events", calls[0].merge.TargetTable)
+	require.Equal(t, "0/70", calls[0].merge.CommitToken)
+	require.Empty(t, base.writeCalls)
+	require.Empty(t, base.mergeCalls)
+	require.Equal(t, []any{"0/70"}, committer.committed())
+}
+
+func TestWriteDirectMultiTableMergeRoutesEachTable(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &directMergeDestination{fakeDestination: base}
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	configs := map[string]destination.TableWriteConfig{
+		"public.users":  {DestTable: "lake.users", Schema: tableSchema, PrimaryKeys: []string{"id"}, SkipCDCResume: true, CDCExpectedIncarnation: "users-v1"},
+		"public.orders": {DestTable: "lake.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		source.RecordBatchResult{TableName: "public.orders", Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+	)
+	require.NoError(t, writeDirectMultiTableMerge(context.Background(), func() {}, dest, dest, records, tables, configs, 2))
+
+	calls := dest.callsSnapshot()
+	require.Len(t, calls, 2)
+	seen := map[string]bool{}
+	for _, call := range calls {
+		seen[call.merge.TargetTable] = true
+		if call.merge.TargetTable == "lake.users" {
+			require.True(t, call.write.SkipCDCResume)
+			require.True(t, call.merge.SkipCDCResume)
+			require.Equal(t, "users-v1", call.write.CDCExpectedIncarnation)
+		}
+	}
+	require.Equal(t, map[string]bool{"lake.users": true, "lake.orders": true}, seen)
+}
+
+func TestWriteDirectMultiTableMergeCommitsKeylessCDCByDurableTransaction(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &directMergeDestination{fakeDestination: base}
+	tableSchema := keylessCDCSchema()
+	tables := []source.SourceTableInfo{{Name: "public.events", Schema: tableSchema}}
+	configs := map[string]destination.TableWriteConfig{
+		"public.events": {DestTable: "lake.events", Schema: tableSchema},
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "wal:public.events:0/10", DurableCommitPosition: "0/10",
+		},
+		source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+			DurableCommitID: "wal:public.events:0/20", DurableCommitPosition: "0/20",
+		},
+	)
+
+	require.NoError(t, writeDirectMultiTableMerge(context.Background(), func() {}, dest, dest, records, tables, configs, 2))
+	require.Empty(t, dest.callsSnapshot(), "keyless CDC must append rather than merge")
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	require.Len(t, base.writeCalls, 2, "each stable WAL transaction must be its own Iceberg commit")
+	require.Equal(t, "wal:public.events:0/10", base.writeCalls[0].CommitToken)
+	require.Equal(t, "0/10", base.writeCalls[0].CDCResumeLSN)
+	require.False(t, base.writeCalls[0].SkipCDCResume)
+	require.Equal(t, "wal:public.events:0/20", base.writeCalls[1].CommitToken)
+	require.Equal(t, "0/20", base.writeCalls[1].CDCResumeLSN)
+}
+
+func TestWriteDirectMultiTableMergeDrainsBlockingProducerAfterCancellation(t *testing.T) {
+	mergeErr := errors.New("merge failed")
+	dest := &failAfterOneDirectMergeDestination{fakeDestination: &fakeDestination{}, err: mergeErr}
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}}
+	configs := map[string]destination.TableWriteConfig{
+		"public.users": {DestTable: "lake.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+
+	records := make(chan source.RecordBatchResult, 1)
+	trigger := source.RecordBatchResult{
+		TableName: "public.users",
+		Batch:     int64RecordBatch(t, "id", []int64{0}, nil),
+	}
+	pending := []source.RecordBatchResult{
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{2}, nil)},
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{3}, nil)},
+		{TableName: "public.users", Batch: int64RecordBatch(t, "id", []int64{4}, nil)},
+	}
+	canceled := make(chan struct{})
+	firstPendingSent := make(chan struct{})
+	resumeProducer := make(chan struct{})
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		records <- trigger
+		<-canceled
+		records <- pending[0]
+		close(firstPendingSent)
+		<-resumeProducer
+		for _, result := range pending[1:] {
+			records <- result
+		}
+		close(records)
+	}()
+	go func() {
+		<-firstPendingSent
+		time.Sleep(25 * time.Millisecond)
+		close(resumeProducer)
+	}()
+
+	var cancelOnce sync.Once
+	err := writeDirectMultiTableMerge(context.Background(), func() {
+		cancelOnce.Do(func() { close(canceled) })
+	}, dest, dest, records, tables, configs, 1)
+	require.ErrorIs(t, err, mergeErr)
+
+	select {
+	case <-producerDone:
+	case <-time.After(time.Second):
+		go drainAndRelease(records)
+		<-producerDone
+		t.Fatal("source producer remained blocked after cancellation")
+	}
+}
+
+func TestStartBoundedRecordDrainStopsForNonclosingSource(t *testing.T) {
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+
+	done := startBoundedRecordDrain(records, 20*time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("bounded source drain did not stop at its deadline")
+	}
+	close(records)
+}
+
+func TestWriteDurableKeylessCDCRecordsPersistsEmptySnapshotCheckpoint(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &durableDirectMergeDestination{
+		directMergeDestination: &directMergeDestination{fakeDestination: base},
+	}
+	records := mustClosedRecords(source.RecordBatchResult{
+		DurableCommitID: "snapshot:0/30:empty", DurableCommitPosition: "0/30",
+	})
+
+	require.NoError(t, writeDurableKeylessCDCRecords(context.Background(), dest, records, destination.WriteOptions{
+		Table: "lake.empty_events", Schema: keylessCDCSchema(),
+	}))
+	require.Empty(t, base.writeCalls)
+	dest.tokenMu.Lock()
+	defer dest.tokenMu.Unlock()
+	require.Equal(t, []durableTokenCall{{
+		table: "lake.empty_events", token: "snapshot:0/30:empty", cdcResumeLSN: "0/30",
+	}}, dest.tokenCalls)
+}
+
+func TestWriteDurableKeylessCDCRecordsManagedWriteSkipsTargetCursor(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &durableDirectMergeDestination{directMergeDestination: &directMergeDestination{fakeDestination: base}}
+	records := mustClosedRecords(
+		source.RecordBatchResult{
+			Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "wal:0/20", DurableCommitPosition: "0/20",
+		},
+		source.RecordBatchResult{DurableCommitID: "wal:0/21", DurableCommitPosition: "0/21"},
+	)
+
+	require.NoError(t, writeDurableKeylessCDCRecords(t.Context(), dest, records, destination.WriteOptions{
+		Table: "lake.events", Schema: keylessCDCSchema(), SkipCDCResume: true,
+	}))
+	require.Len(t, base.writeCalls, 1)
+	require.True(t, base.writeCalls[0].SkipCDCResume)
+	require.Empty(t, base.writeCalls[0].CDCResumeLSN)
+	dest.tokenMu.Lock()
+	require.Empty(t, dest.tokenCalls)
+	dest.tokenMu.Unlock()
+}
+
+func TestWriteDurableKeylessCDCRecordsUsesManagedBatchIdentity(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &durableDirectMergeDestination{directMergeDestination: &directMergeDestination{fakeDestination: base}}
+	records := mustClosedRecords(source.RecordBatchResult{
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+		TableName: "public.events",
+		CommitToken: source.CDCStateCommitToken{
+			Position: "0/20", DataBatchID: "public.events:0/20/1:0/20/1",
+		},
+	})
+
+	require.NoError(t, writeDurableKeylessCDCRecords(t.Context(), dest, records, destination.WriteOptions{
+		Table: "lake.events", Schema: keylessCDCSchema(), SkipCDCResume: true,
+	}))
+	require.Len(t, base.writeCalls, 1)
+	require.Equal(t, managedCDCDataWriteToken{
+		SourceTable: "public.events",
+		DataBatchID: "public.events:0/20/1:0/20/1",
+	}, base.writeCalls[0].CommitToken)
+	require.True(t, base.writeCalls[0].SkipCDCResume)
+	require.Empty(t, base.writeCalls[0].CDCResumeLSN)
+}
+
+var (
+	_ destination.DirectMergeWriter        = (*directMergeDestination)(nil)
+	_ destination.DirectMergeWriter        = (*failAfterOneDirectMergeDestination)(nil)
+	_ destination.DurableCommitTokenWriter = (*durableDirectMergeDestination)(nil)
+)

--- a/pkg/strategy/keyless_cdc_test.go
+++ b/pkg/strategy/keyless_cdc_test.go
@@ -2,6 +2,8 @@ package strategy
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,6 +38,120 @@ func schemaHasColumn(s *schema.TableSchema, name string) bool {
 		}
 	}
 	return false
+}
+
+type idempotentCommitTokenDestination struct{ *fakeDestination }
+
+func (*idempotentCommitTokenDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+type managedKeylessDestination struct {
+	*cdcStateDestination
+	dataMu             sync.Mutex
+	dataWrites         []destination.WriteOptions
+	committedData      map[managedCDCDataWriteToken]struct{}
+	visibleRows        int64
+	failStateAfterData bool
+}
+
+type emptyIncarnationManagedKeylessDestination struct {
+	*managedKeylessDestination
+}
+
+func (*emptyIncarnationManagedKeylessDestination) CDCTargetIncarnation(context.Context, string) (string, bool, error) {
+	return "", true, nil
+}
+
+type replacingManagedKeylessDestination struct {
+	*managedKeylessDestination
+	writes int
+}
+
+type recreateDuringInvalidationManagedKeylessDestination struct {
+	*managedKeylessDestination
+	recreateMu sync.Mutex
+	armed      bool
+}
+
+func (d *recreateDuringInvalidationManagedKeylessDestination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	if err := d.managedKeylessDestination.WriteCDCState(ctx, records, opts); err != nil {
+		return err
+	}
+	d.recreateMu.Lock()
+	armed := d.armed
+	d.armed = false
+	d.recreateMu.Unlock()
+	if armed {
+		d.stateMu.Lock()
+		d.incarnations["raw.events"] = "replacement-incarnation"
+		d.stateMu.Unlock()
+	}
+	return nil
+}
+
+func (d *replacingManagedKeylessDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	current, exists, err := d.CDCTargetIncarnation(ctx, opts.Table)
+	if err != nil {
+		drainAndRelease(records)
+		return err
+	}
+	if !exists || opts.CDCExpectedIncarnation == "" || opts.CDCExpectedIncarnation != current {
+		drainAndRelease(records)
+		return errors.New("destination was replaced before managed keyless write")
+	}
+	if err := d.managedKeylessDestination.WriteParallel(ctx, records, opts); err != nil {
+		return err
+	}
+	d.writes++
+	if d.writes == 1 {
+		d.stateMu.Lock()
+		d.incarnations[opts.Table] = "replacement-incarnation"
+		d.stateMu.Unlock()
+	}
+	return nil
+}
+
+func (*managedKeylessDestination) SupportsIdempotentCommitTokenWrites() bool { return true }
+
+func (d *managedKeylessDestination) WriteParallel(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	var rows int64
+	for result := range records {
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.dataMu.Lock()
+	d.dataWrites = append(d.dataWrites, opts)
+	if token, ok := opts.CommitToken.(managedCDCDataWriteToken); ok {
+		if d.committedData == nil {
+			d.committedData = make(map[managedCDCDataWriteToken]struct{})
+		}
+		if _, exists := d.committedData[token]; !exists {
+			d.committedData[token] = struct{}{}
+			d.visibleRows += rows
+		}
+	} else {
+		d.visibleRows += rows
+	}
+	d.dataMu.Unlock()
+	return nil
+}
+
+func (d *managedKeylessDestination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	d.dataMu.Lock()
+	fail := d.failStateAfterData && len(d.dataWrites) > 0
+	if fail {
+		d.failStateAfterData = false
+	}
+	d.dataMu.Unlock()
+	if fail {
+		drainAndRelease(records)
+		return errors.New("injected state persistence failure")
+	}
+	return d.cdcStateDestination.WriteCDCState(ctx, records, opts)
 }
 
 func TestMergeStrategy_MultiTableKeylessCDCLandsAppendOnly(t *testing.T) {
@@ -105,7 +221,7 @@ func TestMergeStrategy_MultiTableMixedKeyedAndKeyless(t *testing.T) {
 }
 
 func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
-	dest := &fakeDestination{}
+	dest := &idempotentCommitTokenDestination{fakeDestination: &fakeDestination{}}
 	exec := NewStreamingExecutor(StreamingOptions{
 		FlushInterval: time.Hour,
 		FlushRecords:  1,
@@ -149,4 +265,587 @@ func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
 	assert.Equal(t, "events", dest.writeCalls[0].Table)
 	assert.False(t, dest.writeCalls[0].StagingTable)
 	assert.Empty(t, dest.mergeCalls)
+}
+
+func TestManagedCDCDataWriteTokenIsStableAndTableScoped(t *testing.T) {
+	token := func(table, batchID string) managedCDCDataWriteToken {
+		return managedCDCDataWriteToken{SourceTable: table, DataBatchID: batchID}
+	}
+	require.Equal(t, token("public.events", "tx-1"), token("public.events", "tx-1"))
+	require.NotEqual(t, token("public.events", "tx-1"), token("public.audit", "tx-1"))
+	require.NotEqual(t, token("public.events", "tx-1"), token("public.events", "tx-2"))
+}
+
+func TestStreamingManagedKeylessCDCReplayUsesDataTokenWithoutResumeAuthority(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	require.Equal(t, "incarnation:raw.events", manager.BoundDestinationIncarnation("public.events"))
+
+	newLoop := func(flushRecords int64) *flushLoop {
+		st := &streamTableState{
+			destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+			incarnation: "100", schemaFingerprint: "schema-v1",
+		}
+		cfg := config.DefaultConfig()
+		cfg.NoLoadTimestamp = true
+		return newFlushLoop(dest, cfg, StreamingOptions{
+			FlushInterval: time.Hour,
+			FlushRecords:  flushRecords,
+			Strategy:      config.StrategyMerge,
+			StateManager:  manager,
+		}, map[string]*streamTableState{"public.events": st})
+	}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position:    position,
+				DataBatchID: "public.events:1:0/110/2:0/110/2",
+			},
+		}
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position:    position,
+				DataBatchID: "public.events:1:0/120/2:0/120/2",
+			},
+		}
+		close(records)
+		return records
+	}
+
+	err = newLoop(100).run(ctx, newRecords("0/100"))
+	require.ErrorContains(t, err, "injected state persistence failure")
+	require.NoError(t, newLoop(1).run(ctx, newRecords("0/105")))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	first, second := dest.dataWrites[0], dest.dataWrites[1]
+	replayFirst, replaySecond := dest.dataWrites[2], dest.dataWrites[3]
+	dest.dataMu.Unlock()
+	firstToken, ok := first.CommitToken.(managedCDCDataWriteToken)
+	require.True(t, ok)
+	secondToken, ok := second.CommitToken.(managedCDCDataWriteToken)
+	require.True(t, ok)
+	require.Equal(t, "public.events", firstToken.SourceTable)
+	require.Equal(t, "public.events:1:0/110/2:0/110/2", firstToken.DataBatchID)
+	require.Equal(t, "public.events", secondToken.SourceTable)
+	require.Equal(t, "public.events:1:0/120/2:0/120/2", secondToken.DataBatchID)
+	require.NotEqual(t, firstToken, secondToken, "duplicate-content batches at the same globally safe position must not collide")
+	require.Equal(t, first.CommitToken, replayFirst.CommitToken, "global safe position changes must not perturb a source batch's data-write identity")
+	require.Equal(t, second.CommitToken, replaySecond.CommitToken, "global safe position changes must not perturb a source batch's data-write identity")
+	require.Equal(t, "incarnation:raw.events", first.CDCExpectedIncarnation)
+	require.Equal(t, first.CDCExpectedIncarnation, second.CDCExpectedIncarnation)
+	require.Equal(t, first.CDCExpectedIncarnation, replayFirst.CDCExpectedIncarnation)
+	require.Equal(t, first.CDCExpectedIncarnation, replaySecond.CDCExpectedIncarnation)
+	require.True(t, first.SkipCDCResume)
+	require.True(t, second.SkipCDCResume)
+	require.True(t, replayFirst.SkipCDCResume)
+	require.True(t, replaySecond.SkipCDCResume)
+	require.Empty(t, first.CDCResumeLSN)
+	require.Empty(t, second.CDCResumeLSN)
+	require.Empty(t, replayFirst.CDCResumeLSN)
+	require.Empty(t, replaySecond.CDCResumeLSN)
+}
+
+func TestStreamingManagedKeyedAppendReplayUsesDataTokenWithoutResumeAuthority(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	manager, err := NewCDCStateManager(dest, "managed-keyed-append-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+
+	tableSchema := keylessCDCSchema()
+	tableSchema.PrimaryKeys = []string{"id"}
+	newLoop := func() *flushLoop {
+		st := &streamTableState{
+			destTable: "raw.events", schema: tableSchema, primaryKeys: []string{"id"}, isCDC: true,
+			incarnation: "100", schemaFingerprint: "schema-v1",
+		}
+		cfg := config.DefaultConfig()
+		cfg.NoLoadTimestamp = true
+		return newFlushLoop(dest, cfg, StreamingOptions{
+			FlushInterval: time.Hour,
+			FlushRecords:  100,
+			Strategy:      config.StrategyAppend,
+			StateManager:  manager,
+		}, map[string]*streamTableState{"public.events": st})
+	}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				TableName: "public.events",
+				Batch:     int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: batchID,
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+
+	require.ErrorContains(t, newLoop().run(ctx, newRecords("0/100")), "injected state persistence failure")
+	require.NoError(t, newLoop().run(ctx, newRecords("0/105")))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	for _, writeOpts := range dest.dataWrites {
+		require.True(t, writeOpts.SkipCDCResume)
+		require.Empty(t, writeOpts.CDCResumeLSN)
+		require.Equal(t, "incarnation:raw.events", writeOpts.CDCExpectedIncarnation)
+	}
+	dest.dataMu.Unlock()
+}
+
+func TestBatchAppendManagedCDCReplayUsesStableDataToken(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "batch-append-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyAppend
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Config.CDCResumeLSN = "0/10"
+	job.Schema = keylessCDCSchema()
+	job.Schema.PrimaryKeys = []string{"id"}
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: batchID,
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+
+	src.readCh = newRecords("0/20")
+	require.NoError(t, (&AppendStrategy{}).Execute(ctx, job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	require.ErrorContains(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/20"}), "injected state persistence failure")
+	src.readCh = newRecords("0/25")
+	require.NoError(t, (&AppendStrategy{}).Execute(ctx, job))
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/25"}))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	dest.dataMu.Unlock()
+}
+
+func TestMultiTableBatchAppendManagedCDCReplayUsesStableDataToken(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{
+		cdcStateDestination: newCDCStateDestination(),
+		failStateAfterData:  true,
+	}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "multi-batch-append-replay", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	table.Schema.PrimaryKeys = []string{"id"}
+	table.PrimaryKeys = []string{"id"}
+	newRecords := func(position string) <-chan source.RecordBatchResult {
+		records := make(chan source.RecordBatchResult, 2)
+		for i, batchID := range []string{"public.events:tx-1", "public.events:tx-2"} {
+			records <- source.RecordBatchResult{
+				TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{
+					Position: position, DataBatchID: batchID,
+				},
+			}
+		}
+		close(records)
+		return records
+	}
+	newJob := func(position string) *MultiTableIngestionJob {
+		return &MultiTableIngestionJob{
+			Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+			Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: newRecords(position)},
+			Destination: dest, Tables: []source.SourceTableInfo{table},
+			TableDestNames:  map[string]string{table.Name: "raw.events"},
+			CDCResumeLSNs:   map[string]string{table.Name: "0/10"},
+			CDCStateManager: manager,
+		}
+	}
+
+	firstJob := newJob("0/20")
+	require.NoError(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, firstJob))
+	require.True(t, firstJob.Source.(*announcingMultiTableSource).readOpts.CDCStableDataBatches)
+	require.ErrorContains(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/20"}), "injected state persistence failure")
+	require.NoError(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, newJob("0/25")))
+	require.NoError(t, manager.Persist(ctx, source.CDCStateCommitToken{Position: "0/25"}))
+
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 4)
+	require.EqualValues(t, 2, dest.visibleRows)
+	require.Equal(t, dest.dataWrites[0].CommitToken, dest.dataWrites[2].CommitToken)
+	require.Equal(t, dest.dataWrites[1].CommitToken, dest.dataWrites[3].CommitToken)
+	dest.dataMu.Unlock()
+}
+
+func TestBatchAppendManagedCDCRejectsNonAtomicSnapshotBeforeTruncate(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	opts := destination.WriteOptions{
+		Table: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "target-v1",
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+
+	truncated, err := writeDurableCDCAppendRecords(ctx, dest, records, opts, "public.events")
+	require.False(t, truncated)
+	require.ErrorContains(t, err, "require atomic snapshot publication")
+	drainAndRelease(records)
+
+	dest.dataMu.Lock()
+	require.Empty(t, dest.dataWrites)
+	require.Zero(t, dest.visibleRows)
+	dest.dataMu.Unlock()
+}
+
+func TestAppendStrategyManagedCDCRejectsNonAtomicSnapshot(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-append", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyAppend
+	job.Config.SourceTable = "public.events"
+	job.Config.DestTable = "raw.events"
+	job.Schema = keylessCDCSchema()
+	job.Schema.PrimaryKeys = []string{"id"}
+	job.SourceSchema = job.Schema
+	job.Destination = dest
+	job.CDCStateManager = manager
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	src.readCh = records
+
+	require.ErrorContains(t, (&AppendStrategy{}).Execute(ctx, job), "require atomic snapshot publication")
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	dest.dataMu.Lock()
+	require.Empty(t, dest.dataWrites)
+	dest.dataMu.Unlock()
+}
+
+func TestMultiTableAppendStrategyManagedCDCRejectsNonAtomicSnapshot(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "non-atomic-multi-append", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(ctx, "public.events", "raw.events", "source-v1", "schema-v1"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	table := source.SourceTableInfo{
+		Name: "public.events", Schema: keylessCDCSchema(), PrimaryKeys: []string{"id"},
+		Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	table.Schema.PrimaryKeys = []string{"id"}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+	src := &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "raw.events"}, CDCStateManager: manager,
+	}
+
+	require.ErrorContains(t, (&AppendStrategy{}).ExecuteMultiTable(ctx, job), "require atomic snapshot publication")
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	dest.dataMu.Lock()
+	require.Empty(t, dest.dataWrites)
+	dest.dataMu.Unlock()
+}
+
+func TestBatchAppendManagedCDCWALTruncateStillRequiresDataIdentity(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest.incarnations["raw.events"] = "target-v1"
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true, CDCWALTruncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	}
+	close(records)
+
+	truncated, err := writeDurableCDCAppendRecords(ctx, dest, records, destination.WriteOptions{
+		Table: "raw.events", SkipCDCResume: true, CDCExpectedIncarnation: "target-v1",
+	}, "public.events")
+	require.True(t, truncated)
+	require.ErrorContains(t, err, "has no durable transaction identifier")
+}
+
+func TestStreamingManagedKeylessCDCRejectsEmptyDestinationIncarnation(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &emptyIncarnationManagedKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-empty-incarnation", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	st := &streamTableState{
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+		incarnation: "100", schemaFingerprint: "schema-v1",
+	}
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, StateManager: manager,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events",
+		Batch:     int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: source.CDCStateCommitToken{
+			Position: "0/100", DataBatchID: "public.events:1:0/110/2:0/110/2",
+		},
+	}
+	close(records)
+
+	require.ErrorContains(t, loop.run(ctx, records), "has no previously verified physical incarnation")
+	base.dataMu.Lock()
+	require.Empty(t, base.dataWrites)
+	base.dataMu.Unlock()
+}
+
+func TestStreamingManagedKeylessCDCRejectsTargetRecreatedBetweenBoundaries(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &replacingManagedKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-recreated", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	st := &streamTableState{
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+		incarnation: "100", schemaFingerprint: "schema-v1",
+	}
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, StateManager: manager,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 2)
+	for i, batchID := range []string{"public.events:1:0/110/2:0/110/2", "public.events:1:0/120/2:0/120/2"} {
+		records <- source.RecordBatchResult{
+			TableName: "public.events",
+			Batch:     int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+			CommitToken: source.CDCStateCommitToken{
+				Position: "0/100", DataBatchID: batchID,
+			},
+		}
+	}
+	close(records)
+
+	require.ErrorContains(t, loop.run(ctx, records), "destination was replaced before managed keyless write")
+	base.dataMu.Lock()
+	require.Len(t, base.dataWrites, 1)
+	require.Equal(t, "incarnation:raw.events", base.dataWrites[0].CDCExpectedIncarnation)
+	require.EqualValues(t, 1, base.visibleRows)
+	base.dataMu.Unlock()
+}
+
+func TestStreamingManagedKeylessCDCRejectsTargetRecreatedBetweenFlushes(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-between-flushes", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	newLoop := func() *flushLoop {
+		cfg := config.DefaultConfig()
+		cfg.NoLoadTimestamp = true
+		return newFlushLoop(dest, cfg, StreamingOptions{
+			FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge, StateManager: manager,
+		}, map[string]*streamTableState{"public.events": {
+			destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+			incarnation: "100", schemaFingerprint: "schema-v1",
+		}})
+	}
+	records := func(batchID string, value int64) <-chan source.RecordBatchResult {
+		ch := make(chan source.RecordBatchResult, 1)
+		ch <- source.RecordBatchResult{
+			TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{value}, nil),
+			CommitToken: source.CDCStateCommitToken{Position: "0/100", DataBatchID: batchID},
+		}
+		close(ch)
+		return ch
+	}
+	require.NoError(t, newLoop().run(ctx, records("public.events:0/110", 1)))
+	dest.stateMu.Lock()
+	dest.incarnations["raw.events"] = "replacement-incarnation"
+	dest.stateMu.Unlock()
+
+	require.ErrorContains(t, newLoop().run(ctx, records("public.events:0/120", 2)), "was replaced after its prior snapshot boundary")
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 1)
+	require.EqualValues(t, 1, dest.visibleRows)
+	dest.dataMu.Unlock()
+}
+
+func TestStreamingManagedKeylessCDCInvalidationRaceReleasesAllMovedBatchesOnce(t *testing.T) {
+	ctx := t.Context()
+	base := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	dest := &recreateDuringInvalidationManagedKeylessDestination{managedKeylessDestination: base}
+	manager, err := NewCDCStateManager(dest, "managed-keyless-invalidation-race", "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, "public.events", "raw.events", "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.events", "raw.events"))
+	dest.recreateMu.Lock()
+	dest.armed = true
+	dest.recreateMu.Unlock()
+	cfg := config.DefaultConfig()
+	cfg.NoLoadTimestamp = true
+	loop := newFlushLoop(dest, cfg, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge, StateManager: manager,
+	}, map[string]*streamTableState{"public.events": {
+		destTable: "raw.events", schema: keylessCDCSchema(), isCDC: true,
+		incarnation: "100", schemaFingerprint: "schema-v1",
+	}})
+	batch := &singleReleaseCountingRecordBatch{RecordBatch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: batch,
+		CommitToken: source.CDCStateCommitToken{Position: "0/100", DataBatchID: "public.events:0/110"},
+	}
+	close(records)
+
+	require.ErrorContains(t, loop.run(ctx, records), "changed while invalidating its prior snapshot boundary")
+	require.EqualValues(t, 1, batch.releases.Load())
+	base.dataMu.Lock()
+	require.Empty(t, base.dataWrites)
+	base.dataMu.Unlock()
+}
+
+func TestBatchManagedCDCStagingSkipsDestinationResumeAuthority(t *testing.T) {
+	ctx := t.Context()
+	dest := &managedKeylessDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "managed-staging", "raw.events", "")
+	require.NoError(t, err)
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.CDCResumeLSN = "0/100"
+	job.CDCStateManager = manager
+	require.NoError(t, manager.RegisterTableIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable, "100"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+	})
+
+	require.NoError(t, (&MergeStrategy{}).Execute(ctx, job))
+	dest.dataMu.Lock()
+	require.Len(t, dest.dataWrites, 1)
+	require.True(t, dest.dataWrites[0].SkipCDCResume)
+	dest.dataMu.Unlock()
+	dest.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.True(t, dest.mergeCalls[0].SkipCDCResume)
+	dest.mu.Unlock()
+}
+
+func TestStreaming_PrepareTableRejectsUnsafeKeylessCDCDestination(t *testing.T) {
+	dest := &fakeDestination{}
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+	st := &streamTableState{
+		destTable: "events",
+		schema:    keylessCDCSchema(),
+		isCDC:     true,
+	}
+
+	err := exec.prepareTable(context.Background(), dest, &config.IngestConfig{}, st)
+	require.ErrorContains(t, err, "requires destination support for idempotent commit-token writes")
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Empty(t, dest.prepareCalls, "unsafe destination must fail before creating a table")
+}
+
+func TestStreamingSchemaRefreshRejectsPrimaryKeyModeChangeWithoutSnapshot(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &idempotentCommitTokenDestination{fakeDestination: base}
+	st := &streamTableState{
+		destTable: "events", stagingTable: "events_staging", schema: keylessCDCSchema(),
+		primaryKeys: []string{"id"}, isCDC: true,
+	}
+	st.schema.PrimaryKeys = []string{"id"}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	refreshed := *st.schema
+	refreshed.PrimaryKeys = nil
+
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &refreshed, PrimaryKeys: nil,
+	}, st)
+	require.ErrorContains(t, err, "requires a new snapshot")
+	require.Equal(t, []string{"id"}, st.primaryKeys)
+	require.Equal(t, "events_staging", st.stagingTable)
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	require.Empty(t, base.dropCalls)
+	require.Empty(t, base.prepareCalls)
 }

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -2,30 +2,38 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/databuffer"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/destination/multitable"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 )
 
 type MergeStrategy struct{}
 
+var canceledSourceDrainTimeout = time.Second
+
 // mergeTableParams describes one dest/staging table pair for a merge.
 type mergeTableParams struct {
-	DestTable    string
-	StagingTable string
-	Schema       *schema.TableSchema
-	PrimaryKeys  []string
-	PartitionBy  string
-	ClusterBy    []string
-	IsCDC        bool
+	DestTable      string
+	StagingTable   string
+	Schema         *schema.TableSchema
+	PrimaryKeys    []string
+	PartitionBy    string
+	ClusterBy      []string
+	IsCDC          bool
+	OwnershipToken string
 }
 
 // prepareMergeTables ensures the destination table exists (without dropping it)
@@ -34,23 +42,13 @@ func prepareMergeTables(ctx context.Context, dest destination.Destination, p mer
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       p.DestTable,
-		Schema:      destination.DestinationTableSchema(p.Schema),
-		DropFirst:   false,
-		PrimaryKeys: p.PrimaryKeys,
-		PartitionBy: p.PartitionBy,
-		ClusterBy:   p.ClusterBy,
-	}); err != nil {
-		return fmt.Errorf("failed to prepare destination table %s: %w", p.DestTable, err)
+	if err := prepareMergeTarget(ctx, dest, p); err != nil {
+		return err
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	if err := source.ConnectorLeaseLoss(ctx); err != nil {
-		return err
-	}
 	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
 		Table:        p.StagingTable,
 		Schema:       p.Schema,
@@ -70,17 +68,40 @@ func prepareMergeTables(ctx context.Context, dest destination.Destination, p mer
 	return nil
 }
 
+func prepareMergeTarget(ctx context.Context, dest destination.Destination, p mergeTableParams) error {
+	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:          p.DestTable,
+		Schema:         destination.DestinationTableSchema(p.Schema),
+		DropFirst:      false,
+		PrimaryKeys:    p.PrimaryKeys,
+		PartitionBy:    p.PartitionBy,
+		ClusterBy:      p.ClusterBy,
+		OwnershipToken: p.OwnershipToken,
+	}); err != nil {
+		return fmt.Errorf("failed to prepare destination table %s: %w", p.DestTable, err)
+	}
+	return nil
+}
+
 // mergeStagingInto merges the staging table into the target table by primary
 // key. A non-empty incrementalKey makes the per-PK dedup keep the row with the
 // highest value of that key (latest wins) instead of an arbitrary one.
 func mergeStagingInto(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey string) error {
+	return mergeStagingIntoWithCommit(ctx, dest, stagingTable, targetTable, primaryKeys, tableSchema, incrementalKey, nil, "", false, "")
+}
+
+func mergeStagingIntoWithCommit(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey string, commitToken any, cdcResumeLSN string, skipCDCResume bool, expectedIncarnation string) error {
 	return dest.MergeTable(ctx, destination.MergeOptions{
-		StagingTable:   stagingTable,
-		TargetTable:    targetTable,
-		PrimaryKeys:    primaryKeys,
-		Columns:        destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
-		IncrementalKey: mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
-		Schema:         tableSchema,
+		StagingTable:           stagingTable,
+		TargetTable:            targetTable,
+		PrimaryKeys:            primaryKeys,
+		Columns:                destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
+		IncrementalKey:         mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
+		Schema:                 tableSchema,
+		CommitToken:            commitToken,
+		CDCResumeLSN:           cdcResumeLSN,
+		SkipCDCResume:          skipCDCResume,
+		CDCExpectedIncarnation: expectedIncarnation,
 	})
 }
 
@@ -117,11 +138,16 @@ func isAppendOnlyCDCTable(ti source.SourceTableInfo) bool {
 // change batches carry it, and CDCMode relaxes NOT NULL since rows are change
 // events rather than complete entities.
 func prepareAppendOnlyCDCTable(ctx context.Context, dest destination.Destination, table string, tableSchema *schema.TableSchema) error {
+	return prepareAppendOnlyCDCTableOwned(ctx, dest, table, tableSchema, "")
+}
+
+func prepareAppendOnlyCDCTableOwned(ctx context.Context, dest destination.Destination, table string, tableSchema *schema.TableSchema, ownershipToken string) error {
 	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
-		Table:     table,
-		Schema:    tableSchema,
-		DropFirst: false,
-		CDCMode:   true,
+		Table:          table,
+		Schema:         tableSchema,
+		DropFirst:      false,
+		CDCMode:        true,
+		OwnershipToken: ownershipToken,
 	}); err != nil {
 		return fmt.Errorf("failed to prepare append-only change-log table %s: %w", table, err)
 	}
@@ -137,6 +163,9 @@ func warnIfCDCMergeUnsupported(dest destination.Destination) {
 }
 
 func supportsCDCSnapshotReplace(dest destination.Destination) bool {
+	if _, ok := dest.(destination.AtomicSnapshotPublisher); ok {
+		return true
+	}
 	_, ok := dest.(destination.TruncateCapable)
 	return ok
 }
@@ -163,13 +192,17 @@ func (s *MergeStrategy) RequiresIncrementalKey() bool {
 func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	// Generate staging table name
 	stagingTable := managedStagingTableName(job.Destination, job.Config.DestTable, "merge", job.Config.StagingDataset)
-	output.Statusf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
 	isCDC := hasCDCColumns(job.Schema)
 	if isCDC {
 		warnIfCDCMergeUnsupported(job.Destination)
 	}
+	if isCDC && !job.Config.Stream && (job.Config.FullRefresh || strings.TrimSpace(job.Config.CDCResumeLSN) == "") {
+		if publisher, ok := job.Destination.(destination.AtomicSnapshotPublisher); ok && supportsCDCSnapshotReplace(job.Destination) {
+			return s.executeAtomicBatchSnapshot(ctx, job, publisher)
+		}
+	}
 
-	if err := prepareMergeTables(ctx, job.Destination, mergeTableParams{
+	params := mergeTableParams{
 		DestTable:    job.Config.DestTable,
 		StagingTable: stagingTable,
 		Schema:       job.Schema,
@@ -177,12 +210,35 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		PartitionBy:  job.Config.PartitionBy,
 		ClusterBy:    job.Config.ClusterBy,
 		IsCDC:        isCDC,
-	}); err != nil {
-		return err
 	}
+	direct, directMerge := job.Destination.(destination.DirectMergeWriter)
+	directMerge = directMerge && !isCDC
+	if !directMerge && !job.Config.KeepStaging {
+		defer dropMergeStagingDetached(ctx, job.Destination, stagingTable)
+	}
+	var prepareErr error
+	if directMerge {
+		prepareErr = prepareMergeTarget(ctx, job.Destination, params)
+	} else {
+		output.Statusf("[MERGE] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+		prepareErr = prepareMergeTables(ctx, job.Destination, params)
+	}
+	if prepareErr != nil {
+		return prepareErr
+	}
+	if directMerge {
+		if err := job.ApplyEvolution(ctx); err != nil {
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
+	}
+	expectedIncarnation := ""
 	if job.CDCStateManager != nil {
 		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
 			return fmt.Errorf("failed to bind CDC destination before merge: %w", err)
+		}
+		expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if expectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", job.Config.DestTable)
 		}
 	}
 
@@ -214,7 +270,9 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
 		return fmt.Errorf("failed to get records: %w", err)
 	}
@@ -223,10 +281,33 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	if directMerge {
+		if err := direct.MergeRecords(readCtx, records, destination.WriteOptions{
+			Table:                  job.Config.DestTable,
+			Schema:                 job.Schema,
+			Parallelism:            parallelism,
+			StagingBucket:          job.Config.StagingBucket,
+			LoaderFileSize:         job.Config.LoaderFileSize,
+			LoaderFileFormat:       job.Config.LoaderFileFormat,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}, destination.MergeOptions{
+			TargetTable:            job.Config.DestTable,
+			PrimaryKeys:            job.Config.PrimaryKeys,
+			Columns:                destination.MergeColumnsFor(job.Destination, job.Schema.ColumnNames()),
+			IncrementalKey:         mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+			Schema:                 job.Schema,
+			Parallelism:            parallelism,
+			SkipCDCResume:          job.CDCStateManager != nil,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}); err != nil {
+			cancelRead()
+			<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+			return fmt.Errorf("failed to merge records directly: %w", err)
+		}
+		return nil
+	}
 
-	// Write to staging table using parallel writes. Source TRUNCATE controls
-	// split the input into ordered segments and clear earlier staged changes.
-	sourceTruncated, err := destination.WriteWithTruncateBoundaries(ctx, job.Destination, records, destination.WriteOptions{
+	writeOpts := destination.WriteOptions{
 		Table:            stagingTable,
 		Schema:           job.Schema,
 		Parallelism:      parallelism,
@@ -235,17 +316,25 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
-	})
+		SkipCDCResume:    job.CDCStateManager != nil,
+	}
+	var sourceTruncated bool
+	if isCDC {
+		// Source TRUNCATE controls split CDC into ordered segments and clear
+		// earlier staged changes.
+		sourceTruncated, err = destination.WriteWithTruncateBoundariesAfterCancel(readCtx, job.Destination, records, writeOpts, cancelRead)
+	} else {
+		err = job.Destination.WriteParallel(readCtx, records, writeOpts)
+	}
 	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	if err := source.ConnectorLeaseLoss(ctx); err != nil {
-		return err
-	}
 	if err := job.ApplyEvolution(ctx); err != nil {
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
@@ -261,8 +350,19 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
 		}
-		if err := destination.ApplyCDCTruncate(ctx, job.Destination, job.Config.DestTable); err != nil {
-			return err
+		var truncateErr error
+		if job.CDCStateManager != nil {
+			truncateErr = destination.ApplyCDCTruncateIfIncarnation(
+				ctx,
+				job.Destination,
+				job.Config.DestTable,
+				job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable),
+			)
+		} else {
+			truncateErr = destination.ApplyCDCTruncate(ctx, job.Destination, job.Config.DestTable)
+		}
+		if truncateErr != nil {
+			return truncateErr
 		}
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
@@ -271,27 +371,188 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := mergeStagingInto(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, job.Config.IncrementalKey); err != nil {
+	if err := mergeStagingIntoWithCommit(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, job.Config.IncrementalKey,
+		nil, "", job.CDCStateManager != nil, expectedIncarnation); err != nil {
 		return fmt.Errorf("failed to merge data: %w", err)
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	// Drop staging table (skip when KeepStaging is set for test inspection).
-	if !job.Config.KeepStaging {
-		if err := source.ConnectorLeaseLoss(ctx); err != nil {
-			return err
+	// The deferred cleanup uses a detached, lease-fenced context so cancellation
+	// cannot strand a managed staging table.
+	return nil
+}
+
+func (s *MergeStrategy) executeAtomicBatchSnapshot(
+	ctx context.Context,
+	job *IngestionJob,
+	publisher destination.AtomicSnapshotPublisher,
+) error {
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	existingSchema, err := job.Destination.GetTableSchema(ctx, job.Config.DestTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before atomic batch snapshot: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+	cleanupNewTarget := !targetExisted && ownershipToken != ""
+	defer func() {
+		if cleanupNewTarget {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, job.Config.DestTable, true, ownershipToken)
 		}
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[MERGE] Warning: failed to drop staging table: %v", err)
+	}()
+	if err := prepareMergeTarget(ctx, job.Destination, mergeTableParams{
+		DestTable: job.Config.DestTable, Schema: job.Schema, PrimaryKeys: job.Config.PrimaryKeys,
+		PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy, IsCDC: hasCDCColumns(job.Schema),
+		OwnershipToken: ownershipToken,
+	}); err != nil {
+		return err
+	}
+	expectedIncarnation := ""
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
+			return fmt.Errorf("failed to bind CDC destination before atomic snapshot: %w", err)
 		}
-		if err := source.ConnectorLeaseLoss(ctx); err != nil {
-			return err
+		expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if expectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", job.Config.DestTable)
 		}
 	}
 
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, source.ReadOptions{
+		IncrementalKey: job.Config.IncrementalKey, IntervalStart: job.Config.IntervalStart, IntervalEnd: job.Config.IntervalEnd,
+		PageSize: job.Config.PageSize, Limit: job.Config.SQLLimit, ExcludeColumns: job.Config.SQLExcludeColumns,
+		Parallelism: parallelism, Schema: job.SourceSchema, CDCResumeLSN: job.Config.CDCResumeLSN,
+		CDCResumeIncarnation: job.Config.CDCResumeIncarnation, CDCResumeSchemaFingerprint: job.Config.CDCResumeSchemaFingerprint,
+		CDCSlotSuffix: job.Config.CDCSlotSuffix, CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
+		CDCSnapshotReplace: true, FullRefresh: job.Config.FullRefresh,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get atomic snapshot records: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+	if err := consumeAtomicSnapshotBoundary(readCtx, job, records); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return err
+	}
+	boundary := &atomicBatchSnapshotBoundary{}
+
+	attemptID := uuid.NewString()
+	targetSchema := destination.DestinationTableSchema(job.Schema)
+	if job.EvolutionPlan != nil && job.EvolutionPlan.FinalSchema != nil {
+		targetSchema = job.EvolutionPlan.FinalSchema
+	}
+	opts := destination.AtomicSnapshotOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, TargetSchema: targetSchema,
+		PrimaryKeys: job.Config.PrimaryKeys, PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy,
+		Parallelism: parallelism, AttemptID: attemptID, SkipCDCResume: job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}
+	if err := publisher.BeginAtomicSnapshot(ctx, opts); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		if aborter, ok := job.Destination.(destination.AtomicSnapshotAborter); ok {
+			abortBase, detachCancel := source.WithoutCancelWithConnectorLease(ctx)
+			defer detachCancel()
+			abortCtx, cancel := context.WithTimeout(abortBase, 30*time.Second)
+			defer cancel()
+			_ = aborter.AbortAtomicSnapshot(abortCtx, opts)
+		}
+		return fmt.Errorf("failed to begin atomic batch snapshot: %w", err)
+	}
+	records = observeAtomicBatchSnapshot(readCtx, records, boundary)
+	publishAttempted := false
+	defer func() {
+		if publishAttempted {
+			return
+		}
+		if aborter, ok := job.Destination.(destination.AtomicSnapshotAborter); ok {
+			abortBase, detachCancel := source.WithoutCancelWithConnectorLease(ctx)
+			defer detachCancel()
+			abortCtx, cancel := context.WithTimeout(abortBase, 30*time.Second)
+			defer cancel()
+			_ = aborter.AbortAtomicSnapshot(abortCtx, opts)
+		}
+	}()
+	if err := publisher.WriteAtomicSnapshot(readCtx, records, destination.WriteOptions{
+		Table: job.Config.DestTable, Schema: job.Schema, PrimaryKeys: job.Config.PrimaryKeys,
+		Parallelism: parallelism, AtomicSnapshotAttemptID: attemptID, SkipCDCResume: job.CDCStateManager != nil,
+	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to stage atomic batch snapshot: %w", err)
+	}
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	publishAttempted = true
+	cleanupNewTarget = false
+	opts.CommitToken, opts.CDCResumeLSN = boundary.values()
+	if err := publisher.PublishAtomicSnapshot(ctx, opts); err != nil {
+		return fmt.Errorf("failed to publish atomic batch snapshot: %w", err)
+	}
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
+			return fmt.Errorf("failed to bind published CDC destination: %w", err)
+		}
+	}
 	return nil
+}
+
+func consumeAtomicSnapshotBoundary(ctx context.Context, job *IngestionJob, records <-chan source.RecordBatchResult) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case result, ok := <-records:
+			if !ok {
+				return fmt.Errorf("CDC snapshot ended before its replacement boundary")
+			}
+			if result.Err != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return result.Err
+			}
+			if result.SnapshotInvalidation != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				if job.CDCStateManager == nil {
+					return fmt.Errorf("source requested snapshot invalidation without destination-managed CDC state")
+				}
+				if err := job.CDCStateManager.InvalidateSnapshotState(
+					ctx, job.Config.SourceTable, job.Config.DestTable,
+					result.SnapshotInvalidation.Incarnation, result.SnapshotInvalidation.SchemaFingerprint,
+				); err != nil {
+					return err
+				}
+				continue
+			}
+			if result.Truncate && !result.CDCWALTruncate {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return nil
+			}
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return fmt.Errorf("CDC snapshot did not begin with a replacement boundary")
+		}
+	}
 }
 
 // ExecuteMultiTable implements multi-table merge strategy for CDC sources.
@@ -312,9 +573,18 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	if anyTableHasCDC {
 		warnIfCDCMergeUnsupported(job.Destination)
 	}
+	if anyTableHasCDC && !job.Config.Stream {
+		publisher, canPublish := job.Destination.(destination.AtomicSnapshotPublisher)
+		direct, canMergeDirectly := job.Destination.(destination.DirectMergeWriter)
+		if canPublish && canMergeDirectly {
+			return s.executeAtomicMultiTableBatch(ctx, job, publisher, direct)
+		}
+	}
 
 	stagingTables := make(map[string]string)
 	tableConfigs := make(map[string]destination.TableWriteConfig)
+	direct, directMerge := job.Destination.(destination.DirectMergeWriter)
+	directMerge = directMerge && !anyTableHasCDC
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
@@ -326,6 +596,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			defer wg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
 
 			if err := source.ConnectorLeaseLoss(ctx); err != nil {
 				errChan <- err
@@ -345,7 +616,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					errChan <- err
 					return
 				}
-				if err := prepareAppendOnlyCDCTable(ctx, job.Destination, destTable, ti.Schema); err != nil {
+				if err := prepareAppendOnlyCDCTable(ctx, job.Destination, destTable, writeSchema); err != nil {
 					errChan <- err
 					return
 				}
@@ -359,23 +630,58 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					errChan <- err
 					return
 				}
+				expectedIncarnation := ""
+				if job.CDCStateManager != nil {
+					expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(ti.Name)
+					if expectedIncarnation == "" {
+						errChan <- fmt.Errorf("managed CDC destination table %s has no bound physical incarnation", ti.Name)
+						return
+					}
+				}
 				mu.Lock()
 				tableConfigs[ti.Name] = destination.TableWriteConfig{
-					DestTable: destTable,
-					Schema:    ti.Schema,
+					DestTable:              destTable,
+					Schema:                 writeSchema,
+					CDCMode:                true,
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: expectedIncarnation,
+				}
+				mu.Unlock()
+				return
+			}
+			if directMerge {
+				if err := prepareMergeTarget(ctx, job.Destination, mergeTableParams{
+					DestTable:   destTable,
+					Schema:      writeSchema,
+					PrimaryKeys: ti.PrimaryKeys,
+					IsCDC:       hasCDCColumns(writeSchema),
+				}); err != nil {
+					errChan <- err
+					return
+				}
+				mu.Lock()
+				tableConfigs[ti.Name] = destination.TableWriteConfig{
+					DestTable:     destTable,
+					Schema:        writeSchema,
+					PrimaryKeys:   ti.PrimaryKeys,
+					CDCMode:       hasCDCColumns(writeSchema),
+					SkipCDCResume: job.CDCStateManager != nil,
 				}
 				mu.Unlock()
 				return
 			}
 
 			stagingTable := managedStagingTableName(job.Destination, destTable, "merge", job.Config.StagingDataset)
+			mu.Lock()
+			stagingTables[ti.Name] = stagingTable
+			mu.Unlock()
 
 			if err := prepareMergeTables(ctx, job.Destination, mergeTableParams{
 				DestTable:    destTable,
 				StagingTable: stagingTable,
-				Schema:       ti.Schema,
+				Schema:       writeSchema,
 				PrimaryKeys:  ti.PrimaryKeys,
-				IsCDC:        hasCDCColumns(ti.Schema), // Make non-PK columns nullable for CDC staging tables
+				IsCDC:        hasCDCColumns(writeSchema), // Make non-PK columns nullable for CDC staging tables
 			}); err != nil {
 				errChan <- err
 				return
@@ -388,11 +694,12 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			}
 
 			mu.Lock()
-			stagingTables[ti.Name] = stagingTable
 			tableConfigs[ti.Name] = destination.TableWriteConfig{
-				DestTable:   stagingTable,
-				Schema:      ti.Schema,
-				PrimaryKeys: nil,
+				DestTable:     stagingTable,
+				Schema:        writeSchema,
+				PrimaryKeys:   nil,
+				CDCMode:       hasCDCColumns(writeSchema),
+				SkipCDCResume: job.CDCStateManager != nil,
 			}
 			mu.Unlock()
 		}(tableInfo)
@@ -401,7 +708,10 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	wg.Wait()
 	close(errChan)
 
-	for err := range errChan {
+	if err := <-errChan; err != nil {
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
+		}
 		return err
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -431,13 +741,8 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 		CDCResumeSchemaFingerprints: resumeSchemas,
 	})
 	if err != nil {
-		if source.ConnectorLeaseLoss(ctx) == nil {
-			for _, stagingTable := range stagingTables {
-				if source.ConnectorLeaseLoss(ctx) != nil {
-					break
-				}
-				_ = job.Destination.DropTable(ctx, stagingTable)
-			}
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 		}
 		return fmt.Errorf("failed to read from multi-table source: %w", err)
 	}
@@ -445,24 +750,26 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	records = applyMultiTableSnapshotInvalidations(readCtx, job, records)
+	if directMerge {
+		return writeDirectMultiTableMerge(readCtx, cancelRead, direct, job.Destination, records, job.Tables, tableConfigs, parallelism)
+	}
 
-	writeResult, err := multitable.WriteWithResult(ctx, job.Destination, records, destination.MultiTableWriteOptions{
-		TableConfigs:     tableConfigs,
-		Parallelism:      parallelism,
-		StagingTable:     true,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		CancelSource:     cancelRead,
+	writeResult, err := multitable.WriteWithResult(readCtx, job.Destination, records, destination.MultiTableWriteOptions{
+		TableConfigs:       tableConfigs,
+		Parallelism:        parallelism,
+		StagingTable:       true,
+		StagingBucket:      job.Config.StagingBucket,
+		LoaderFileSize:     job.Config.LoaderFileSize,
+		LoaderFileFormat:   job.Config.LoaderFileFormat,
+		CancelSource:       cancelRead,
+		CancelDrainTimeout: canceledSourceDrainTimeout,
 	})
 	if err != nil {
-		if source.ConnectorLeaseLoss(ctx) == nil {
-			for _, stagingTable := range stagingTables {
-				if source.ConnectorLeaseLoss(ctx) != nil {
-					break
-				}
-				_ = job.Destination.DropTable(ctx, stagingTable)
-			}
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 		}
 		return fmt.Errorf("failed to write multi-table data: %w", err)
 	}
@@ -479,6 +786,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			defer mergeWg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
 			stagingTable, ok := stagingTables[ti.Name]
 			if !ok {
 				// Append-only change-log table: rows were written directly.
@@ -493,8 +801,19 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					mergeErrChan <- err
 					return
 				}
-				if err := destination.ApplyCDCTruncate(ctx, job.Destination, destTable); err != nil {
-					mergeErrChan <- fmt.Errorf("failed to reset CDC target %s: %w", ti.Name, err)
+				var truncateErr error
+				if job.CDCStateManager != nil {
+					truncateErr = destination.ApplyCDCTruncateIfIncarnation(
+						ctx,
+						job.Destination,
+						destTable,
+						job.CDCStateManager.BoundDestinationIncarnation(ti.Name),
+					)
+				} else {
+					truncateErr = destination.ApplyCDCTruncate(ctx, job.Destination, destTable)
+				}
+				if truncateErr != nil {
+					mergeErrChan <- fmt.Errorf("failed to reset CDC target %s: %w", ti.Name, truncateErr)
 					return
 				}
 				if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -507,7 +826,12 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 				mergeErrChan <- err
 				return
 			}
-			if err := mergeStagingInto(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, ti.Schema, ""); err != nil {
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(ti.Name)
+			}
+			if err := mergeStagingIntoWithCommit(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, writeSchema, "",
+				nil, "", job.CDCStateManager != nil, expectedIncarnation); err != nil {
 				mergeErrChan <- fmt.Errorf("failed to merge table %s: %w", ti.Name, err)
 				return
 			}
@@ -517,16 +841,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 			}
 
 			if !job.Config.KeepStaging {
-				if err := source.ConnectorLeaseLoss(ctx); err != nil {
-					mergeErrChan <- err
-					return
-				}
-				if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-					config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, err)
-				}
-				if err := source.ConnectorLeaseLoss(ctx); err != nil {
-					mergeErrChan <- err
-				}
+				dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 			}
 		}(tableInfo)
 	}
@@ -542,20 +857,838 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	}
 
 	if mergeErr != nil {
-		if source.ConnectorLeaseLoss(ctx) == nil {
-			for _, stagingTable := range stagingTables {
-				if source.ConnectorLeaseLoss(ctx) != nil {
-					break
-				}
-				if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-					config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, err)
-				}
-			}
+		for _, stagingTable := range stagingTables {
+			dropMergeStagingDetached(ctx, job.Destination, stagingTable)
 		}
 		return mergeErr
 	}
 
 	return nil
+}
+
+type atomicMultiTableBatchState struct {
+	info                 source.SourceTableInfo
+	destTable            string
+	writeSchema          *schema.TableSchema
+	targetSchema         *schema.TableSchema
+	expectedIncarnation  string
+	targetExisted        bool
+	ownershipToken       string
+	targetPrepared       bool
+	records              chan source.RecordBatchResult
+	snapshot             bool
+	walTruncate          bool
+	attempt              destination.AtomicSnapshotOptions
+	boundary             atomicBatchSnapshotBoundary
+	publishAttempted     bool
+	directWriteAttempted bool
+}
+
+type atomicBatchSnapshotBoundary struct {
+	mu       sync.Mutex
+	token    any
+	position string
+}
+
+func (b *atomicBatchSnapshotBoundary) observe(result source.RecordBatchResult) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if result.DurableCommitID != nil {
+		b.token = result.DurableCommitID
+		b.position = result.DurableCommitPosition
+		return
+	}
+	if token, ok := result.CommitToken.(source.CDCStateCommitToken); ok {
+		position := token.Position
+		if len(token.SnapshotPositions) == 1 {
+			for _, snapshotPosition := range token.SnapshotPositions {
+				position = snapshotPosition
+			}
+		}
+		if position != "" {
+			b.token = position
+			b.position = position
+		}
+	}
+}
+
+func (b *atomicBatchSnapshotBoundary) values() (any, string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.token, b.position
+}
+
+func observeAtomicBatchSnapshot(ctx context.Context, records <-chan source.RecordBatchResult, boundary *atomicBatchSnapshotBoundary) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult, cap(records))
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case result, ok := <-records:
+				if !ok {
+					return
+				}
+				boundary.observe(result)
+				select {
+				case out <- result:
+				case <-ctx.Done():
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+					return
+				}
+			case <-ctx.Done():
+				startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+				return
+			}
+		}
+	}()
+	return out
+}
+
+type multiTableSpoolEntry struct {
+	result   source.RecordBatchResult
+	hasBatch bool
+}
+
+type multiTableRecordSpool struct {
+	entries       []multiTableSpoolEntry
+	buffers       map[string]*databuffer.FileBuffer
+	invalidations []source.CDCSnapshotInvalidation
+}
+
+type atomicBatchSnapshotReset struct {
+	marker      source.RecordBatchResult
+	walTruncate bool
+}
+
+func spoolMultiTableRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	states map[string]*atomicMultiTableBatchState,
+) (*multiTableRecordSpool, map[string]atomicBatchSnapshotReset, error) {
+	spool := &multiTableRecordSpool{buffers: make(map[string]*databuffer.FileBuffer)}
+	resetTables := make(map[string]atomicBatchSnapshotReset)
+	for {
+		select {
+		case <-ctx.Done():
+			_ = spool.Close()
+			return nil, nil, context.Cause(ctx)
+		case result, ok := <-records:
+			if !ok {
+				return spool, resetTables, nil
+			}
+			if result.Err != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				_ = spool.Close()
+				return nil, nil, result.Err
+			}
+			if result.SnapshotInvalidation != nil {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				invalidation := *result.SnapshotInvalidation
+				if _, known := states[invalidation.TableName]; !known {
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("source requested snapshot invalidation for unknown table %q", invalidation.TableName)
+				}
+				spool.invalidations = append(spool.invalidations, invalidation)
+				continue
+			}
+			if result.Truncate {
+				if _, known := states[result.TableName]; !known {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					continue
+				}
+				resetTables[result.TableName] = atomicBatchSnapshotReset{marker: result, walTruncate: result.CDCWALTruncate}
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				if buffer := spool.buffers[result.TableName]; buffer != nil {
+					if err := buffer.Close(); err != nil {
+						_ = spool.Close()
+						return nil, nil, fmt.Errorf("failed to reset multi-table CDC spool for %s: %w", result.TableName, err)
+					}
+					delete(spool.buffers, result.TableName)
+				}
+				entries := spool.entries[:0]
+				for _, entry := range spool.entries {
+					if entry.result.TableName != result.TableName {
+						entries = append(entries, entry)
+					}
+				}
+				spool.entries = entries
+				continue
+			}
+			entry := multiTableSpoolEntry{result: result, hasBatch: result.Batch != nil}
+			entry.result.Batch = nil
+			if result.Batch != nil {
+				if _, known := states[result.TableName]; !known {
+					result.Batch.Release()
+					continue
+				}
+				buffer := spool.buffers[result.TableName]
+				if buffer == nil {
+					var err error
+					buffer, err = databuffer.NewFileBuffer()
+					if err != nil {
+						result.Batch.Release()
+						_ = spool.Close()
+						return nil, nil, fmt.Errorf("failed to create multi-table CDC spool for %s: %w", result.TableName, err)
+					}
+					spool.buffers[result.TableName] = buffer
+				}
+				if err := buffer.Append(ctx, result.Batch); err != nil {
+					result.Batch.Release()
+					_ = spool.Close()
+					return nil, nil, fmt.Errorf("failed to spool multi-table CDC batch for %s: %w", result.TableName, err)
+				}
+				result.Batch.Release()
+			}
+			spool.entries = append(spool.entries, entry)
+		}
+	}
+}
+
+func (s *multiTableRecordSpool) Replay(ctx context.Context, states map[string]*atomicMultiTableBatchState) (<-chan source.RecordBatchResult, error) {
+	readers := make(map[string]<-chan source.RecordBatchResult, len(s.buffers))
+	for table, buffer := range s.buffers {
+		reader, err := buffer.Reader(ctx, states[table].writeSchema.ToArrowSchema())
+		if err != nil {
+			return nil, fmt.Errorf("failed to replay multi-table CDC spool for %s: %w", table, err)
+		}
+		readers[table] = reader
+	}
+	out := make(chan source.RecordBatchResult, 16)
+	go func() {
+		defer close(out)
+		defer func() {
+			for _, reader := range readers {
+				drainAndRelease(reader)
+			}
+		}()
+		for _, entry := range s.entries {
+			result := entry.result
+			if entry.hasBatch {
+				batchResult, ok := <-readers[result.TableName]
+				if !ok {
+					result.Err = fmt.Errorf("multi-table CDC spool ended early for %s", result.TableName)
+				} else if batchResult.Err != nil {
+					result.Err = batchResult.Err
+				} else {
+					result.Batch = batchResult.Batch
+				}
+			}
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (s *multiTableRecordSpool) Close() error {
+	var err error
+	for _, buffer := range s.buffers {
+		err = errors.Join(err, buffer.Close())
+	}
+	return err
+}
+
+func (s *MergeStrategy) executeAtomicMultiTableBatch(
+	ctx context.Context,
+	job *MultiTableIngestionJob,
+	publisher destination.AtomicSnapshotPublisher,
+	direct destination.DirectMergeWriter,
+) error {
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	states := make(map[string]*atomicMultiTableBatchState, len(job.Tables))
+	for _, info := range job.Tables {
+		destTable := job.GetDestTableName(info.Name)
+		writeSchema := job.WriteSchemaFor(info.Name, info.Schema)
+		targetSchema := destination.DestinationTableSchema(writeSchema)
+		if job.Config.IncrementalStrategy == config.StrategyAppend && hasCDCColumns(writeSchema) {
+			targetSchema = writeSchema
+		} else if plan := job.EvolutionPlans[info.Name]; plan != nil && plan.FinalSchema != nil {
+			targetSchema = plan.FinalSchema
+		}
+		states[info.Name] = &atomicMultiTableBatchState{info: info, destTable: destTable, writeSchema: writeSchema, targetSchema: targetSchema}
+	}
+	plannedSnapshotTables := make(map[string]struct{})
+	for _, info := range job.Tables {
+		if !hasCDCColumns(info.Schema) {
+			continue
+		}
+		if job.Config.FullRefresh || strings.TrimSpace(job.CDCResumeLSNs[info.Name]) == "" {
+			plannedSnapshotTables[info.Name] = struct{}{}
+		}
+	}
+	jobSucceeded := false
+	defer func() {
+		if jobSucceeded {
+			return
+		}
+		aborter, canAbort := job.Destination.(destination.AtomicSnapshotAborter)
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cleanupCancel()
+		for _, st := range states {
+			if st.snapshot && !st.publishAttempted && canAbort && st.attempt.AttemptID != "" {
+				_ = aborter.AbortAtomicSnapshot(cleanupCtx, st.attempt)
+			}
+			neverMutatedTarget := st.snapshot && !st.publishAttempted || !st.snapshot && !st.directWriteAttempted
+			if st.targetPrepared && neverMutatedTarget && st.ownershipToken != "" {
+				cleanupFailedOwnedDirectReplace(cleanupCtx, job.Destination, st.destTable, !st.targetExisted, st.ownershipToken)
+			}
+		}
+	}()
+
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
+	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
+		ReadOptions: source.ReadOptions{
+			Parallelism: parallelism, PageSize: job.Config.PageSize, Limit: job.Config.SQLLimit,
+			CDCSlotSuffix: job.Config.CDCSlotSuffix, CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace: true, FullRefresh: job.Config.FullRefresh,
+			CDCStableDataBatches: job.Config.IncrementalStrategy == config.StrategyAppend && job.CDCStateManager != nil,
+		},
+		CDCResumeLSNs:               job.CDCResumeLSNs,
+		CDCResumeIncarnations:       resumeIncarnations,
+		CDCResumeSchemaFingerprints: resumeSchemas,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to read from multi-table source: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+
+	spool, resetTables, err := spoolMultiTableRecords(readCtx, records, states)
+	if err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to preflight multi-table CDC records: %w", err)
+	}
+	defer func() { _ = spool.Close() }()
+	if err := source.ConnectorLeaseLoss(ctx); err != nil {
+		return err
+	}
+	for _, invalidation := range spool.invalidations {
+		reset, ok := resetTables[invalidation.TableName]
+		if !ok || reset.walTruncate {
+			return fmt.Errorf("source snapshot invalidation for %s was not followed by a replacement boundary", invalidation.TableName)
+		}
+	}
+	for _, invalidation := range spool.invalidations {
+		if job.CDCStateManager == nil {
+			return fmt.Errorf("source requested snapshot invalidation without destination-managed CDC state")
+		}
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		st := states[invalidation.TableName]
+		if err := job.CDCStateManager.InvalidateSnapshotState(
+			ctx, invalidation.TableName, st.destTable, invalidation.Incarnation, invalidation.SchemaFingerprint,
+		); err != nil {
+			return err
+		}
+	}
+	for tableName, reset := range resetTables {
+		plannedSnapshotTables[tableName] = struct{}{}
+		if st, ok := states[tableName]; ok {
+			st.walTruncate = reset.walTruncate
+			st.boundary.observe(reset.marker)
+		}
+	}
+	for _, info := range job.Tables {
+		st := states[info.Name]
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		existingSchema, err := job.Destination.GetTableSchema(ctx, st.destTable)
+		if err != nil {
+			return fmt.Errorf("failed to inspect destination table %s before multi-table CDC: %w", st.destTable, err)
+		}
+		st.targetExisted = existingSchema != nil
+		st.ownershipToken = newTargetOwnershipToken(job.Destination, st.targetExisted)
+		st.targetPrepared = !st.targetExisted && st.ownershipToken != ""
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		if isAppendOnlyCDCTable(info) {
+			if !st.targetExisted {
+				if st.ownershipToken == "" {
+					return fmt.Errorf("destination %s cannot safely clean up a failed atomic append target", job.Destination.GetScheme())
+				}
+				if err := prepareAppendOnlyCDCTableOwned(ctx, job.Destination, st.destTable, st.writeSchema, st.ownershipToken); err != nil {
+					return err
+				}
+				st.targetPrepared = true
+			}
+		} else if err := prepareMergeTarget(ctx, job.Destination, mergeTableParams{
+			DestTable: st.destTable, Schema: st.writeSchema, PrimaryKeys: info.PrimaryKeys, IsCDC: hasCDCColumns(st.writeSchema),
+			OwnershipToken: st.ownershipToken,
+		}); err != nil {
+			return err
+		} else {
+			st.targetPrepared = true
+		}
+		if job.CDCStateManager != nil && job.CDCStateManager.dest != nil {
+			if err := job.CDCStateManager.BindDestinationIncarnation(ctx, info.Name, st.destTable); err != nil {
+				return fmt.Errorf("failed to bind CDC destination table %s before source replay: %w", info.Name, err)
+			}
+			st.expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(info.Name)
+			if st.expectedIncarnation == "" {
+				return fmt.Errorf("managed CDC destination table %s has no bound physical incarnation", info.Name)
+			}
+		}
+	}
+	records, err = spool.Replay(readCtx, states)
+	if err != nil {
+		return err
+	}
+	for tableName := range plannedSnapshotTables {
+		if st, ok := states[tableName]; ok {
+			st.snapshot = true
+			st.attempt = destination.AtomicSnapshotOptions{
+				Table: st.destTable, Schema: st.writeSchema, TargetSchema: st.targetSchema,
+				PrimaryKeys: st.info.PrimaryKeys, Parallelism: parallelism, AttemptID: uuid.NewString(),
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: st.expectedIncarnation,
+			}
+		}
+	}
+	snapshotTables := make([]string, 0, len(plannedSnapshotTables))
+	for tableName := range plannedSnapshotTables {
+		snapshotTables = append(snapshotTables, tableName)
+	}
+	sort.Strings(snapshotTables)
+	for _, tableName := range snapshotTables {
+		st := states[tableName]
+		if !st.snapshot {
+			continue
+		}
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		if err := publisher.BeginAtomicSnapshot(ctx, st.attempt); err != nil {
+			return fmt.Errorf("failed to begin snapshot table %s: %w", tableName, err)
+		}
+	}
+
+	g, gctx := errgroup.WithContext(readCtx)
+	startWorker := func(st *atomicMultiTableBatchState) error {
+		if !st.snapshot {
+			if err := source.ConnectorLeaseLoss(ctx); err != nil {
+				return err
+			}
+			if err := job.ApplyEvolutionFor(ctx, st.info.Name); err != nil {
+				return fmt.Errorf("failed to evolve destination table %s: %w", st.info.Name, err)
+			}
+		}
+		st.records = make(chan source.RecordBatchResult, 8)
+		g.Go(func() error {
+			if st.snapshot {
+				observed := observeAtomicBatchSnapshot(gctx, st.records, &st.boundary)
+				if err := publisher.WriteAtomicSnapshot(gctx, observed, destination.WriteOptions{
+					Table: st.destTable, Schema: st.writeSchema, PrimaryKeys: st.info.PrimaryKeys,
+					Parallelism: parallelism, AtomicSnapshotAttemptID: st.attempt.AttemptID,
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: st.expectedIncarnation,
+				}); err != nil {
+					drainAndRelease(observed)
+					return fmt.Errorf("failed to stage snapshot table %s: %w", st.info.Name, err)
+				}
+				return nil
+			}
+			st.directWriteAttempted = true
+			if isAppendOnlyCDCTable(st.info) {
+				return writeDurableKeylessCDCRecords(gctx, job.Destination, st.records, destination.WriteOptions{
+					Table: st.destTable, Schema: st.writeSchema, Parallelism: parallelism,
+					SkipCDCResume:          job.CDCStateManager != nil,
+					CDCExpectedIncarnation: st.expectedIncarnation,
+				})
+			}
+			return direct.MergeRecords(gctx, st.records, destination.WriteOptions{
+				Table: st.destTable, Schema: st.writeSchema, Parallelism: parallelism,
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: st.expectedIncarnation,
+			}, destination.MergeOptions{
+				TargetTable: st.destTable, PrimaryKeys: st.info.PrimaryKeys,
+				Columns:        destination.MergeColumnsFor(job.Destination, st.writeSchema.ColumnNames()),
+				IncrementalKey: mergeIncrementalKeyForSchema(st.writeSchema, st.writeSchema.IncrementalKey),
+				Schema:         st.writeSchema, Parallelism: parallelism,
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: st.expectedIncarnation,
+			})
+		})
+		return nil
+	}
+
+	var dispatchErr error
+dispatch:
+	for {
+		select {
+		case <-gctx.Done():
+			dispatchErr = context.Cause(gctx)
+			break dispatch
+		case result, ok := <-records:
+			if !ok {
+				break dispatch
+			}
+			if result.Err != nil && result.TableName == "" {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				dispatchErr = result.Err
+				break dispatch
+			}
+			st, known := states[result.TableName]
+			if !known {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				continue
+			}
+			if result.Truncate {
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				dispatchErr = fmt.Errorf("unexpected snapshot reset for table %s after multi-table CDC preflight", result.TableName)
+				break dispatch
+			}
+			if st.records == nil {
+				if err := startWorker(st); err != nil {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
+					dispatchErr = err
+					break dispatch
+				}
+			}
+			select {
+			case st.records <- result:
+			case <-gctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				dispatchErr = context.Cause(gctx)
+				break dispatch
+			}
+		}
+	}
+	if dispatchErr != nil {
+		for _, st := range states {
+			if st.records == nil {
+				continue
+			}
+			select {
+			case st.records <- source.RecordBatchResult{Err: dispatchErr}:
+			case <-gctx.Done():
+			}
+		}
+	}
+	for _, st := range states {
+		if st.records != nil {
+			close(st.records)
+		}
+	}
+	groupErr := g.Wait()
+	for _, st := range states {
+		if st.records != nil {
+			drainAndRelease(st.records)
+		}
+	}
+	if dispatchErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return dispatchErr
+	}
+	if groupErr != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return groupErr
+	}
+
+	for _, tableName := range snapshotTables {
+		st := states[tableName]
+		if !st.snapshot {
+			continue
+		}
+		st.attempt.CommitToken, st.attempt.CDCResumeLSN = st.boundary.values()
+		st.publishAttempted = true
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		if err := publisher.PublishAtomicSnapshot(ctx, st.attempt); err != nil {
+			return fmt.Errorf("failed to publish snapshot table %s: %w", tableName, err)
+		}
+		if job.CDCStateManager != nil && job.CDCStateManager.dest != nil {
+			if err := job.CDCStateManager.BindDestinationIncarnation(ctx, tableName, st.destTable); err != nil {
+				return fmt.Errorf("failed to revalidate published CDC destination table %s: %w", tableName, err)
+			}
+		}
+	}
+	if job.CDCStateManager != nil {
+		for _, tableName := range snapshotTables {
+			st := states[tableName]
+			if !st.walTruncate {
+				continue
+			}
+			_, position := st.boundary.values()
+			job.CDCStateManager.RecordBatchSnapshotCompletion(tableName, position)
+		}
+	}
+	jobSucceeded = true
+	return nil
+}
+
+func dropMergeStagingDetached(ctx context.Context, dest destination.Destination, table string) {
+	if source.ConnectorLeaseLoss(ctx) != nil {
+		return
+	}
+	cleanupBase, detachCancel := source.WithoutCancelWithConnectorLease(ctx)
+	defer detachCancel()
+	cleanupCtx, cancel := context.WithTimeout(cleanupBase, 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", table, err)
+	}
+}
+
+func writeDirectMultiTableMerge(
+	ctx context.Context,
+	cancelSource context.CancelFunc,
+	direct destination.DirectMergeWriter,
+	dest destination.Destination,
+	records <-chan source.RecordBatchResult,
+	tables []source.SourceTableInfo,
+	configs map[string]destination.TableWriteConfig,
+	parallelism int,
+) error {
+	channels := make(map[string]chan source.RecordBatchResult, len(configs))
+	g, gctx := errgroup.WithContext(ctx)
+	for _, ti := range tables {
+		cfg, ok := configs[ti.Name]
+		if !ok {
+			continue
+		}
+		ch := make(chan source.RecordBatchResult, 2)
+		channels[ti.Name] = ch
+		if isAppendOnlyCDCTable(ti) {
+			g.Go(func() error {
+				return writeDurableKeylessCDCRecords(gctx, dest, ch, destination.WriteOptions{
+					Table: cfg.DestTable, Schema: cfg.Schema, Parallelism: parallelism,
+					SkipCDCResume: cfg.SkipCDCResume, CDCExpectedIncarnation: cfg.CDCExpectedIncarnation,
+				})
+			})
+			continue
+		}
+		g.Go(func() error {
+			return direct.MergeRecords(gctx, ch, destination.WriteOptions{
+				Table: cfg.DestTable, Schema: cfg.Schema, Parallelism: parallelism,
+				SkipCDCResume: cfg.SkipCDCResume, CDCExpectedIncarnation: cfg.CDCExpectedIncarnation,
+			}, destination.MergeOptions{
+				TargetTable:            cfg.DestTable,
+				PrimaryKeys:            ti.PrimaryKeys,
+				Columns:                destination.MergeColumnsFor(dest, cfg.Schema.ColumnNames()),
+				Schema:                 cfg.Schema,
+				Parallelism:            parallelism,
+				SkipCDCResume:          cfg.SkipCDCResume,
+				CDCExpectedIncarnation: cfg.CDCExpectedIncarnation,
+			})
+		})
+	}
+
+	var dispatchErr error
+	var sourceFailed bool
+dispatch:
+	for {
+		var result source.RecordBatchResult
+		var ok bool
+		select {
+		case result, ok = <-records:
+			if !ok {
+				break dispatch
+			}
+		case <-gctx.Done():
+			dispatchErr = context.Cause(gctx)
+			cancelSource()
+			break dispatch
+		}
+		if result.Err != nil && result.TableName == "" {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			dispatchErr = result.Err
+			sourceFailed = true
+			break
+		}
+		ch, ok := channels[result.TableName]
+		if !ok {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			continue
+		}
+		select {
+		case ch <- result:
+		case <-gctx.Done():
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			dispatchErr = context.Cause(gctx)
+			break dispatch
+		}
+	}
+	for _, ch := range channels {
+		close(ch)
+	}
+	var sourceDrainDone <-chan struct{}
+	if dispatchErr != nil {
+		cancelSource()
+		sourceDrainDone = startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+	}
+	groupErr := g.Wait()
+	for _, ch := range channels {
+		drainAndRelease(ch)
+	}
+	if sourceDrainDone != nil {
+		<-sourceDrainDone
+	}
+	// A source failure cancels the merge goroutines, so their context-canceled
+	// group error must not mask the actual failure.
+	if sourceFailed {
+		return dispatchErr
+	}
+	if groupErr != nil {
+		return fmt.Errorf("failed to merge multi-table data directly: %w", groupErr)
+	}
+	return dispatchErr
+}
+
+// writeDurableKeylessCDCRecords commits each source transaction independently.
+// A keyless change log cannot deduplicate by row identity, so retry safety comes
+// from the stable per-transaction DurableCommitID emitted by the CDC source.
+func writeDurableKeylessCDCRecords(
+	ctx context.Context,
+	dest destination.Destination,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	for {
+		var result source.RecordBatchResult
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case result, ok = <-records:
+			if !ok {
+				return nil
+			}
+		}
+
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return result.Err
+		}
+		commitID := result.DurableCommitID
+		commitPosition := result.DurableCommitPosition
+		if opts.SkipCDCResume {
+			if token, ok := result.CommitToken.(source.CDCStateCommitToken); ok && token.DataBatchID != "" {
+				commitID = managedCDCDataWriteToken{
+					SourceTable: result.TableName,
+					DataBatchID: token.DataBatchID,
+				}
+				commitPosition = token.Position
+			}
+		}
+		if commitID == nil {
+			if result.Batch == nil {
+				continue
+			}
+			result.Batch.Release()
+			return fmt.Errorf("keyless CDC batch for table %s has no durable transaction identifier", opts.Table)
+		}
+
+		if result.Batch == nil {
+			if opts.SkipCDCResume {
+				continue
+			}
+			writer, ok := dest.(destination.DurableCommitTokenWriter)
+			if !ok {
+				return fmt.Errorf("destination %s cannot persist an empty keyless CDC checkpoint", dest.GetScheme())
+			}
+			if err := writer.CommitWriteToken(ctx, opts.Table, commitID, commitPosition); err != nil {
+				return fmt.Errorf("failed to persist keyless CDC checkpoint for table %s: %w", opts.Table, err)
+			}
+			continue
+		}
+
+		writeOpts := opts
+		writeOpts.CommitToken = commitID
+		writeOpts.CDCResumeLSN = commitPosition
+		if opts.SkipCDCResume {
+			writeOpts.CDCResumeLSN = ""
+		}
+		writeOpts.SkipCDCResume = opts.SkipCDCResume || commitPosition == ""
+		batch := make(chan source.RecordBatchResult, 1)
+		batch <- source.RecordBatchResult{Batch: result.Batch}
+		close(batch)
+		if err := dest.WriteParallel(ctx, batch, writeOpts); err != nil {
+			drainAndRelease(batch)
+			return fmt.Errorf("failed to write durable keyless CDC batch to table %s: %w", opts.Table, err)
+		}
+	}
+}
+
+// startBoundedRecordDrain lets a canceled source finish sends that were
+// already in flight. Some source producers use blocking sends, so consuming
+// only the records immediately available can strand them between sends. The
+// deadline also prevents an uncooperative source from blocking shutdown.
+func startBoundedRecordDrain(records <-chan source.RecordBatchResult, timeout time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				return
+			default:
+			}
+
+			select {
+			case result, ok := <-records:
+				if !ok {
+					return
+				}
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+			case <-timer.C:
+				return
+			}
+		}
+	}()
+	return done
 }
 
 // hasCDCColumns checks if a schema has CDC columns (specifically _cdc_deleted).

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -12,9 +13,12 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeStrategy_Validate(t *testing.T) {
@@ -29,6 +33,100 @@ func TestMergeStrategy_Validate(t *testing.T) {
 	if err := strat.Validate(cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestMultiTableMergeReadFailureUsesDetachedStagingCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func() (context.Context, context.CancelFunc)
+	}{
+		{name: "canceled", ctx: func() (context.Context, context.CancelFunc) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			return ctx, func() {}
+		}},
+		{name: "deadline", ctx: func() (context.Context, context.CancelFunc) {
+			return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			table := source.SourceTableInfo{Name: "events", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+			src := &readAllSetupErrorSource{
+				announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+				err:                        errors.New("read setup failed"),
+			}
+			base := &fakeDestination{}
+			dest := &contextAwareDropDestination{fakeDestination: base}
+			job := &MultiTableIngestionJob{
+				Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest,
+				Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+			}
+			ctx, cancel := tc.ctx()
+			defer cancel()
+
+			if err := (&MergeStrategy{}).ExecuteMultiTable(ctx, job); err == nil {
+				t.Fatal("expected read setup failure")
+			}
+			if len(dest.successfulDrops) != 1 {
+				t.Fatalf("managed staging cleanup inherited %s context: %v", tc.name, dest.successfulDrops)
+			}
+			if !strings.Contains(dest.successfulDrops[0], "_merge_") {
+				t.Fatalf("unexpected staging cleanup table: %v", dest.successfulDrops)
+			}
+		})
+	}
+}
+
+func TestMultiTableMergeLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	table := source.SourceTableInfo{Name: "events", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(ctx, job)
+	if err == nil || !strings.Contains(err.Error(), "prepare response lost") {
+		t.Fatalf("expected lost staging prepare response, got %v", err)
+	}
+	if len(dest.successfulDrops) != 1 {
+		t.Fatalf("lost staging prepare was not detached-cleaned: %v", dest.successfulDrops)
+	}
+	if dest.successfulDrops[0] != base.prepareCalls[1].Table {
+		t.Fatalf("cleaned %q, want prepared staging %q", dest.successfulDrops[0], base.prepareCalls[1].Table)
+	}
+}
+
+func TestMergeLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.PrimaryKeys = []string{"id"}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func TestDeleteInsertLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.IncrementalKey = "id"
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&DeleteInsertStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
 }
 
 func TestMergeStrategy_Execute_HappyPath(t *testing.T) {
@@ -177,7 +275,7 @@ func TestMergeStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema(t *testi
 	}
 }
 
-func TestMergeStrategy_Execute_GetRecordsFails_LeavesStagingForDebugging(t *testing.T) {
+func TestMergeStrategy_Execute_GetRecordsFails_DropsManagedStaging(t *testing.T) {
 	job, src, dest := minimalJob()
 	src.readErr = errors.New("read failed")
 
@@ -193,9 +291,122 @@ func TestMergeStrategy_Execute_GetRecordsFails_LeavesStagingForDebugging(t *test
 	if len(dest.prepareCalls) != 2 {
 		t.Fatalf("expected 2 PrepareTable calls, got %d", len(dest.prepareCalls))
 	}
-	if len(dest.dropCalls) != 0 {
-		t.Fatalf("expected staging table to be left for debugging, got %d DropTable calls", len(dest.dropCalls))
+	staging := dest.prepareCalls[1].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
 	}
+}
+
+func TestMergeStrategy_Execute_WriteFails_DropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("write failed")
+
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	staging := dest.prepareCalls[1].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
+	}
+}
+
+func TestMergeStrategy_WriterFailureBoundsNonclosingSource(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailStagedMergeDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	if err == nil || time.Since(started) > time.Second {
+		t.Fatalf("merge did not return promptly after writer failure: %v", err)
+	}
+	close(records)
+}
+
+type immediateFailStagedMergeDestination struct {
+	*fakeDestination
+}
+
+func (d *immediateFailStagedMergeDestination) WriteParallel(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	return errors.New("writer failed")
+}
+
+func TestMergeStrategy_MultiTableWriterFailureCancelsAndDrainsSource(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	done := make(chan struct{})
+	src := &cancelAwareMultiTableSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		done:                       done,
+	}
+	base := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    &immediateFailStagedMergeDestination{fakeDestination: base},
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected writer failure")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("source producer remained blocked after staged writer failure")
+	}
+	if len(base.dropCalls) != 1 {
+		t.Fatalf("expected failed staged merge cleanup, got %v", base.dropCalls)
+	}
+}
+
+func TestMergeStrategy_PartialMultiTableSetupCleansCreatedStages(t *testing.T) {
+	tableSchema := streamTestSchema()
+	tables := []source.SourceTableInfo{
+		{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.orders", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	base := &fakeDestination{}
+	base.prepareHook = func(opts destination.PrepareOptions) error {
+		if strings.Contains(opts.Table, "users_merge_") {
+			return errors.New("prepare failed")
+		}
+		return nil
+	}
+	src := &announcingMultiTableSource{tables: tables, records: mustClosedRecords()}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
+		Source:      src,
+		Destination: base,
+		Tables:      tables,
+		TableDestNames: map[string]string{
+			"public.users": "users", "public.orders": "orders",
+		},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job)
+	if err == nil {
+		t.Fatalf("expected partial setup failure, prepare calls: %+v", base.prepareCalls)
+	}
+	require.Len(t, base.dropCalls, 2)
+	require.Condition(t, func() bool {
+		return slices.ContainsFunc(base.dropCalls, func(table string) bool { return strings.Contains(table, "orders_merge_") })
+	}, "expected orders staging cleanup, got %v", base.dropCalls)
+	require.Condition(t, func() bool {
+		return slices.ContainsFunc(base.dropCalls, func(table string) bool { return strings.Contains(table, "users_merge_") })
+	}, "expected uncertain users staging cleanup, got %v", base.dropCalls)
 }
 
 func TestDeleteInsertStrategy_Validate(t *testing.T) {
@@ -243,10 +454,33 @@ func TestDeleteInsertStrategy_Execute_RejectsUnsupportedDestinationBeforeStaging
 	}
 }
 
+func TestDeleteInsertStrategy_FailureDropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
+	job.Config.IncrementalKey = "id"
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("write failed")
+
+	err := (&DeleteInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	staging := dest.prepareCalls[1].Table
+	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
+		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
+	}
+}
+
 func TestDeleteInsertStrategy_Execute_SkipsWhenNoIntervalDetected(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
 	job.Config.IncrementalKey = "id"
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable,
+		Comparison: &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeAddColumn, ColumnName: "new_column", NewColumn: schema.Column{Name: "new_column", DataType: schema.TypeInt64},
+		}}},
+	}
 
 	rec := int64RecordBatch(t, "other", []int64{1, 2, 3}, nil)
 	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: rec})
@@ -267,6 +501,9 @@ func TestDeleteInsertStrategy_Execute_SkipsWhenNoIntervalDetected(t *testing.T) 
 	if len(dest.diCalls) != 0 {
 		t.Fatalf("expected DeleteInsertTable not to be called, got %+v", dest.diCalls)
 	}
+	if len(dest.execCalls) != 1 {
+		t.Fatalf("empty delete+insert must still apply schema evolution, got %d calls", len(dest.execCalls))
+	}
 
 	if len(dest.dropCalls) != 1 || dest.dropCalls[0] != staging {
 		t.Fatalf("expected DropTable(%q), got %v", staging, dest.dropCalls)
@@ -278,6 +515,7 @@ func TestDeleteInsertStrategy_Execute_UsesAutoDetectedInterval(t *testing.T) {
 	job.Config.IncrementalStrategy = config.StrategyDeleteInsert
 	job.Config.IncrementalKey = "id"
 	job.Config.LoaderFileSize = 111
+	job.Schema.Columns = append(job.Schema.Columns, schema.Column{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true})
 
 	rec := int64RecordBatch(t, "id", []int64{5, 10, 7}, map[int]bool{1: false})
 	src.readCh = mustClosedRecords(source.RecordBatchResult{Batch: rec})
@@ -306,6 +544,11 @@ func TestDeleteInsertStrategy_Execute_UsesAutoDetectedInterval(t *testing.T) {
 	}
 	if di.IncrementalKey != "id" {
 		t.Fatalf("DeleteInsertOptions.IncrementalKey = %q", di.IncrementalKey)
+	}
+	for _, column := range di.Columns {
+		if column == "_cdc_unchanged_cols" {
+			t.Fatalf("staging-only CDC column leaked into delete+insert target columns: %v", di.Columns)
+		}
 	}
 	if di.IntervalStart != int64(5) || di.IntervalEnd != int64(10) {
 		t.Fatalf("DeleteInsertOptions interval = %v..%v, want 5..10", di.IntervalStart, di.IntervalEnd)

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -15,6 +15,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/google/uuid"
 )
 
 // replaceShouldDedup reports whether deduplicated replace applies for the
@@ -24,6 +26,11 @@ func replaceShouldDedup(dest destination.Destination, primaryKeys []string) bool
 	return len(primaryKeys) > 0 &&
 		dest.SupportsMergeStrategy() &&
 		dest.GetScheme() != "clickhouse"
+}
+
+func directReplaceShouldDedup(dest destination.Destination, primaryKeys []string) bool {
+	provider, ok := dest.(destination.DirectReplaceDeduplicator)
+	return ok && provider.SupportsDirectReplaceDeduplication() && replaceShouldDedup(dest, primaryKeys)
 }
 
 func sourcePrimaryKeysSafeForReplaceFastPath(job *IngestionJob) bool {
@@ -99,10 +106,30 @@ func primaryKeyValuesMayChange(job *IngestionJob) bool {
 	if job.ColumnMasker != nil && intersects(job.Config.PrimaryKeys, job.ColumnMasker.MaskedColumns()) {
 		return true
 	}
+	if whitespaceTrimmerMayChangePrimaryKeys(job) {
+		return true
+	}
 
 	mode, err := schemaevolution.ParseContractMode(job.Config.SchemaContract)
 	if err == nil && mode == schemaevolution.ContractDiscardValue && schemaChangesTouchPrimaryKeys(job.SchemaComparison, job.Config.PrimaryKeys) {
 		return true
+	}
+	return false
+}
+
+func whitespaceTrimmerMayChangePrimaryKeys(job *IngestionJob) bool {
+	if job.WhitespaceTrimmer == nil || job.Schema == nil {
+		return false
+	}
+
+	primaryKeys := make(map[string]bool, len(job.Config.PrimaryKeys))
+	for _, key := range job.Config.PrimaryKeys {
+		primaryKeys[key] = true
+	}
+	for _, column := range job.Schema.Columns {
+		if primaryKeys[column.Name] && (column.DataType == schema.TypeString || column.DataType == schema.TypeUUID) {
+			return true
+		}
 	}
 	return false
 }
@@ -146,7 +173,7 @@ func intersects(left, right []string) bool {
 // nil primary keys, since it already carries the PK and lives in the target's
 // schema (so the swap is a same-schema atomic rename rather than a second
 // recreate+copy). Staging tables are cleaned up on error.
-func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTable, targetTable, stagingDataset, incrementalKey string, tableSchema *schema.TableSchema, primaryKeys []string, partitionBy string, clusterBy []string) (string, error) {
+func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTable, targetTable, stagingDataset, incrementalKey string, tableSchema *schema.TableSchema, primaryKeys []string, partitionBy string, clusterBy []string, skipCDCResume bool) (string, error) {
 	normalised := GenerateNormalisedStagingTableName(targetTable, stagingDataset)
 	if err := dest.PrepareTable(ctx, destination.PrepareOptions{
 		Table:        normalised,
@@ -157,8 +184,8 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 		ClusterBy:    clusterBy,
 		ExpiresAfter: destination.ManagedStagingTTL,
 	}); err != nil {
-		if dropErr := dest.DropTable(ctx, rawTable); dropErr != nil {
-			config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
+		for _, table := range []string{rawTable, normalised} {
+			dropReplaceStagingDetached(ctx, dest, table)
 		}
 		return "", fmt.Errorf("failed to prepare normalised staging table: %w", err)
 	}
@@ -169,21 +196,23 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 		Columns:        tableSchema.ColumnNames(),
 		IncrementalKey: incrementalKey,
 		Schema:         tableSchema,
+		SkipCDCResume:  skipCDCResume,
 	}); err != nil {
 		for _, t := range []string{rawTable, normalised} {
-			if dropErr := dest.DropTable(ctx, t); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-			}
+			dropReplaceStagingDetached(ctx, dest, t)
 		}
 		return "", fmt.Errorf("failed to deduplicate staging table: %w", err)
 	}
-	if dropErr := dest.DropTable(ctx, rawTable); dropErr != nil {
-		config.Debug("[REPLACE] Warning: failed to drop raw staging table: %v", dropErr)
-	}
+	dropReplaceStagingDetached(ctx, dest, rawTable)
 	return normalised, nil
 }
 
 type ReplaceStrategy struct{}
+
+type ownedPreparedTarget struct {
+	table          string
+	ownershipToken string
+}
 
 func replaceStagingTableName(dest destination.Destination, targetTable, stagingDataset string) string {
 	policy := defaultReplaceStagingPolicy()
@@ -213,39 +242,92 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	// Check if destination supports atomic swap (staging pattern)
 	// File-based destinations like CSV, Parquet, and Blobstore write directly to target
 	useStaging := job.Destination.SupportsAtomicSwap()
+	if useStaging && job.CDCStateManager != nil {
+		capability, ok := job.Destination.(destination.CDCConditionalSwapCapable)
+		if !ok || !capability.SupportsCDCConditionalSwap() {
+			return fmt.Errorf("destination scheme %q cannot atomically fence managed CDC table replacement", job.Destination.GetScheme())
+		}
+	}
 
 	targetTable := job.Config.DestTable
+	replaceSchema := destination.DestinationTableSchema(job.Schema)
 	writeTable := targetTable
+	targetExisted := true
 	if useStaging {
 		writeTable = replaceStagingTableName(job.Destination, targetTable, job.Config.StagingDataset)
 		output.Statusf("[STRATEGY] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), writeTable)
 	} else {
 		config.Debug("[STRATEGY] Direct write to target (no staging): %s", writeTable)
+		existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+		if err != nil {
+			return fmt.Errorf("failed to inspect destination table before replace: %w", err)
+		}
+		targetExisted = existingSchema != nil
 	}
 
 	// Deduplicated replace: Load a PK-free staging table so duplicate keys can land.
-	dedup := useStaging &&
-		!sourcePrimaryKeysSafeForReplaceFastPath(job) &&
-		replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+	dedup := false
+	if !sourcePrimaryKeysSafeForReplaceFastPath(job) {
+		if useStaging {
+			dedup = replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+		} else {
+			dedup = directReplaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
+		}
+	}
 	stagingPrimaryKeys := job.Config.PrimaryKeys
-	if dedup {
+	if useStaging && dedup {
 		stagingPrimaryKeys = nil
+	}
+	ownershipToken := ""
+	if !useStaging && !targetExisted {
+		if _, ok := job.Destination.(destination.OwnedTableDropper); ok {
+			ownershipToken = uuid.NewString()
+		}
 	}
 
 	prepareOpts := destination.PrepareOptions{
-		Table:       writeTable,
-		Schema:      job.Schema,
-		DropFirst:   true,
-		PrimaryKeys: stagingPrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:          writeTable,
+		Schema:         replaceSchema,
+		DropFirst:      true,
+		PrimaryKeys:    stagingPrimaryKeys,
+		PartitionBy:    job.Config.PartitionBy,
+		ClusterBy:      job.Config.ClusterBy,
+		OwnershipToken: ownershipToken,
 	}
 	if useStaging {
 		prepareOpts.ExpiresAfter = destination.ManagedStagingTTL
 	}
+	cleanupStaging := useStaging && !job.Config.KeepStaging
+	cleanupTable := writeTable
+	defer func() {
+		if cleanupStaging {
+			dropReplaceStagingDetached(ctx, job.Destination, cleanupTable)
+		}
+	}()
 
 	if err := job.Destination.PrepareTable(ctx, prepareOpts); err != nil {
+		if !useStaging && ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		}
 		return fmt.Errorf("failed to prepare table: %w", err)
+	}
+	if useStaging && job.CDCStateManager != nil {
+		if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+			Table: targetTable, Schema: replaceSchema, DropFirst: false,
+			PrimaryKeys: job.Config.PrimaryKeys, PartitionBy: job.Config.PartitionBy, ClusterBy: job.Config.ClusterBy,
+		}); err != nil {
+			return fmt.Errorf("failed to prepare managed replacement target: %w", err)
+		}
+	}
+	expectedIncarnation := ""
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+			return fmt.Errorf("failed to bind replacement destination before extraction: %w", err)
+		}
+		expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if expectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", targetTable)
+		}
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -275,6 +357,9 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	defer cancelRead()
 	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
+		if !useStaging {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		}
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
@@ -282,16 +367,24 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	records = transformer.Wrap(records, transformer.NewSafeTypeCaster(replaceSchema.ToArrowSchema()))
 
 	writeOpts := destination.WriteOptions{
-		Table:            writeTable,
-		Schema:           job.Schema,
-		Parallelism:      parallelism,
-		StagingTable:     useStaging,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		PreStaged:        job.PreStaged,
+		Table:                  writeTable,
+		Schema:                 replaceSchema,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		Parallelism:            parallelism,
+		StagingTable:           useStaging,
+		StagingBucket:          job.Config.StagingBucket,
+		LoaderFileSize:         job.Config.LoaderFileSize,
+		LoaderFileFormat:       job.Config.LoaderFileFormat,
+		PreStaged:              job.PreStaged,
+		DeduplicatePrimaryKeys: dedup && !useStaging,
+		IncrementalKey:         job.Config.IncrementalKey,
+		SkipCDCResume:          job.CDCStateManager != nil,
+	}
+	if !useStaging {
+		writeOpts.CDCExpectedIncarnation = expectedIncarnation
 	}
 	if useStaging {
 		if atomicWriter, ok := job.Destination.(destination.AtomicCommitWriter); ok && atomicWriter.SupportsAtomicCommitWrites() {
@@ -301,18 +394,18 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 
 	var countedRows atomic.Int64
 	if !writeOpts.AtomicCommit && writeOpts.PreStaged == nil {
-		records = wrapWithRowCount(records, &countedRows)
+		records = wrapWithRowCount(readCtx, records, &countedRows)
 	}
 
-	if err := job.Destination.WriteParallel(ctx, records, writeOpts); err != nil {
+	if err := job.Destination.WriteParallel(readCtx, records, writeOpts); err != nil {
 		cancelRead()
-		drainAndReleaseUntil(records, streamAbortDrainTimeout)
-		if useStaging {
-			if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-			}
-		}
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write data: %w", err)
+	}
+	if !useStaging && job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+			return fmt.Errorf("failed to bind replaced destination table: %w", err)
+		}
 	}
 
 	// Only swap tables if using staging pattern
@@ -325,9 +418,6 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 				}
 				if expectedRows > 0 {
 					if err := verifier.WaitForExactRowCount(ctx, writeTable, expectedRows); err != nil {
-						if dropErr := job.Destination.DropTable(ctx, writeTable); dropErr != nil {
-							config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-						}
 						return fmt.Errorf("failed to verify staging table row count: %w", err)
 					}
 				}
@@ -336,42 +426,127 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		swapTable := writeTable
 		swapPrimaryKeys := job.Config.PrimaryKeys
 		if dedup {
+			cleanupStaging = false
 			normalised, err := deduplicateStaging(ctx, job.Destination, writeTable, targetTable,
-				job.Config.StagingDataset, job.Config.IncrementalKey, job.Schema,
-				job.Config.PrimaryKeys, job.Config.PartitionBy, job.Config.ClusterBy)
+				job.Config.StagingDataset, job.Config.IncrementalKey, replaceSchema,
+				job.Config.PrimaryKeys, job.Config.PartitionBy, job.Config.ClusterBy, job.CDCStateManager != nil)
 			if err != nil {
 				return err
 			}
 			swapTable = normalised
 			swapPrimaryKeys = nil
+			cleanupTable = normalised
+			cleanupStaging = !job.Config.KeepStaging
+		}
+		publishedIncarnation := ""
+		if job.CDCStateManager != nil {
+			publishedIncarnation, err = job.CDCStateManager.DestinationIncarnationForPublication(ctx, swapTable)
+			if err != nil {
+				return fmt.Errorf("failed to identify replacement table before publication: %w", err)
+			}
 		}
 
 		if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-			StagingTable:   swapTable,
-			TargetTable:    targetTable,
-			PrimaryKeys:    swapPrimaryKeys,
-			IncrementalKey: job.Config.IncrementalKey,
-			Schema:         job.Schema,
+			StagingTable:                  swapTable,
+			TargetTable:                   targetTable,
+			PrimaryKeys:                   swapPrimaryKeys,
+			IncrementalKey:                job.Config.IncrementalKey,
+			Schema:                        replaceSchema,
+			CDCExpectedIncarnation:        expectedIncarnation,
+			CDCExpectedStagingIncarnation: publishedIncarnation,
 		}); err != nil {
-			if dropErr := job.Destination.DropTable(ctx, swapTable); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
-			}
 			return fmt.Errorf("failed to swap tables: %w", err)
 		}
+		if job.CDCStateManager != nil {
+			if err := job.CDCStateManager.BindPublishedDestinationIncarnation(ctx, job.Config.SourceTable, targetTable, expectedIncarnation, publishedIncarnation); err != nil {
+				return fmt.Errorf("failed to bind replaced destination table: %w", err)
+			}
+		}
+		cleanupStaging = false
 	}
 
 	return nil
 }
 
-func wrapWithRowCount(records <-chan source.RecordBatchResult, totalRows *atomic.Int64) <-chan source.RecordBatchResult {
+func dropReplaceStagingDetached(ctx context.Context, dest destination.Destination, table string) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[REPLACE] Warning: failed to drop staging table %s: %v", table, err)
+	}
+}
+
+func cleanupFailedDirectReplace(ctx context.Context, dest destination.Destination, table string, createdByRun bool) {
+	if !createdByRun {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[REPLACE] Warning: failed to remove target created by unsuccessful replace: %v", err)
+	}
+}
+
+func newTargetOwnershipToken(dest destination.Destination, targetExisted bool) string {
+	if targetExisted {
+		return ""
+	}
+	if _, ok := dest.(destination.OwnedTableDropper); ok {
+		return uuid.NewString()
+	}
+	return ""
+}
+
+func cleanupFailedOwnedDirectReplace(
+	ctx context.Context,
+	dest destination.Destination,
+	table string,
+	createdByRun bool,
+	ownershipToken string,
+) {
+	if !createdByRun {
+		return
+	}
+	if dropper, ok := dest.(destination.OwnedTableDropper); ok && ownershipToken != "" {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := dropper.DropTableIfOwned(cleanupCtx, table, ownershipToken); err != nil {
+			config.Debug("[REPLACE] Warning: refused or failed owned target cleanup: %v", err)
+		}
+		return
+	}
+	cleanupFailedDirectReplace(ctx, dest, table, true)
+}
+
+func wrapWithRowCount(ctx context.Context, records <-chan source.RecordBatchResult, totalRows *atomic.Int64) <-chan source.RecordBatchResult {
 	out := make(chan source.RecordBatchResult, cap(records))
+	drainTimeout := canceledSourceDrainTimeout
 	go func() {
 		defer close(out)
-		for result := range records {
+		for {
+			var result source.RecordBatchResult
+			var ok bool
+			select {
+			case result, ok = <-records:
+				if !ok {
+					return
+				}
+			case <-ctx.Done():
+				<-startBoundedRecordDrain(records, drainTimeout)
+				return
+			}
 			if result.Err == nil && result.Batch != nil {
 				totalRows.Add(result.Batch.NumRows())
 			}
-			out <- result
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				<-startBoundedRecordDrain(records, drainTimeout)
+				return
+			}
 		}
 	}()
 	return out
@@ -384,10 +559,18 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 	}
 
 	useStaging := job.Destination.SupportsAtomicSwap()
+	if useStaging && job.CDCStateManager != nil {
+		capability, ok := job.Destination.(destination.CDCConditionalSwapCapable)
+		if !ok || !capability.SupportsCDCConditionalSwap() {
+			return fmt.Errorf("destination scheme %q cannot atomically fence managed CDC table replacement", job.Destination.GetScheme())
+		}
+	}
 	config.Debug("[STRATEGY] Multi-table replace with %d tables, staging=%v", len(job.Tables), useStaging)
 
 	stagingTables := make(map[string]string)
 	tableConfigs := make(map[string]destination.TableWriteConfig)
+	expectedIncarnations := make(map[string]string)
+	createdDirectTargets := make(map[string]ownedPreparedTarget)
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
@@ -399,31 +582,89 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 			defer wg.Done()
 
 			destTable := job.GetDestTableName(ti.Name)
+			writeSchema := job.WriteSchemaFor(ti.Name, ti.Schema)
 			writeTable := destTable
 			if useStaging {
 				writeTable = replaceStagingTableName(job.Destination, destTable, job.Config.StagingDataset)
 			}
+			targetExisted := true
+			if !useStaging {
+				existingSchema, err := job.Destination.GetTableSchema(ctx, destTable)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to inspect destination table %s before replace: %w", ti.Name, err)
+					return
+				}
+				targetExisted = existingSchema != nil
+			}
+			ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+
+			dedup := replaceShouldDedup(job.Destination, ti.PrimaryKeys)
+			if !useStaging {
+				dedup = directReplaceShouldDedup(job.Destination, ti.PrimaryKeys)
+			}
 
 			prepareOpts := destination.PrepareOptions{
-				Table:     writeTable,
-				Schema:    ti.Schema,
-				DropFirst: true,
+				Table:          writeTable,
+				Schema:         writeSchema,
+				DropFirst:      true,
+				PrimaryKeys:    ti.PrimaryKeys,
+				OwnershipToken: ownershipToken,
+			}
+			if useStaging && dedup {
+				prepareOpts.PrimaryKeys = nil
 			}
 			if useStaging {
 				prepareOpts.ExpiresAfter = destination.ManagedStagingTTL
+				mu.Lock()
+				stagingTables[ti.Name] = writeTable
+				mu.Unlock()
+			}
+			if !useStaging && !targetExisted && ownershipToken != "" {
+				mu.Lock()
+				createdDirectTargets[ti.Name] = ownedPreparedTarget{table: writeTable, ownershipToken: ownershipToken}
+				mu.Unlock()
 			}
 
 			if err := job.Destination.PrepareTable(ctx, prepareOpts); err != nil {
 				errChan <- fmt.Errorf("failed to prepare table %s: %w", ti.Name, err)
 				return
 			}
+			if useStaging && job.CDCStateManager != nil {
+				if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+					Table: destTable, Schema: writeSchema, DropFirst: false, PrimaryKeys: ti.PrimaryKeys,
+				}); err != nil {
+					errChan <- fmt.Errorf("failed to prepare managed replacement target %s: %w", ti.Name, err)
+					return
+				}
+			}
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				if err := job.CDCStateManager.BindDestinationIncarnation(ctx, ti.Name, destTable); err != nil {
+					errChan <- fmt.Errorf("failed to bind replacement destination table %s before extraction: %w", ti.Name, err)
+					return
+				}
+				expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(ti.Name)
+				if expectedIncarnation == "" {
+					errChan <- fmt.Errorf("managed CDC destination table %s has no bound physical incarnation", ti.Name)
+					return
+				}
+			}
 
 			mu.Lock()
-			stagingTables[ti.Name] = writeTable
-			tableConfigs[ti.Name] = destination.TableWriteConfig{
-				DestTable: writeTable,
-				Schema:    ti.Schema,
+			if !useStaging && !targetExisted && ownershipToken == "" {
+				createdDirectTargets[ti.Name] = ownedPreparedTarget{table: writeTable}
 			}
+			tableConfigs[ti.Name] = destination.TableWriteConfig{
+				DestTable:              writeTable,
+				Schema:                 writeSchema,
+				PrimaryKeys:            ti.PrimaryKeys,
+				DeduplicatePrimaryKeys: !useStaging && dedup,
+				IncrementalKey:         writeSchema.IncrementalKey,
+				CDCMode:                hasCDCColumns(writeSchema),
+				SkipCDCResume:          job.CDCStateManager != nil,
+				CDCExpectedIncarnation: expectedIncarnation,
+			}
+			expectedIncarnations[ti.Name] = expectedIncarnation
 			mu.Unlock()
 		}(tableInfo)
 	}
@@ -432,6 +673,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 	close(errChan)
 
 	for err := range errChan {
+		cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 		return err
 	}
 
@@ -454,56 +696,108 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 		CDCResumeLSNs: job.CDCResumeLSNs,
 	})
 	if err != nil {
+		cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 		return fmt.Errorf("failed to read from multi-table source: %w", err)
 	}
 
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
+	if !useStaging {
+		// Once writers are launched, any error can be a lost response after a
+		// durable direct replacement. Ownership alone cannot distinguish that
+		// from a pre-commit failure, so preserve all attempted targets.
+		createdDirectTargets = nil
+	}
 
-	if err := multitable.Write(ctx, job.Destination, records, destination.MultiTableWriteOptions{
-		TableConfigs:     tableConfigs,
-		Parallelism:      parallelism,
-		StagingTable:     useStaging,
-		StagingBucket:    job.Config.StagingBucket,
-		LoaderFileSize:   job.Config.LoaderFileSize,
-		LoaderFileFormat: job.Config.LoaderFileFormat,
-		CancelSource:     cancelRead,
+	if err := multitable.Write(readCtx, job.Destination, records, destination.MultiTableWriteOptions{
+		TableConfigs:       tableConfigs,
+		Parallelism:        parallelism,
+		StagingTable:       useStaging,
+		StagingBucket:      job.Config.StagingBucket,
+		LoaderFileSize:     job.Config.LoaderFileSize,
+		LoaderFileFormat:   job.Config.LoaderFileFormat,
+		CancelSource:       cancelRead,
+		CancelDrainTimeout: canceledSourceDrainTimeout,
 	}); err != nil {
-		for _, stagingTable := range stagingTables {
-			if dropErr := job.Destination.DropTable(ctx, stagingTable); dropErr != nil {
-				config.Debug("[REPLACE] Warning: failed to drop staging table %s: %v", stagingTable, dropErr)
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
+		return fmt.Errorf("failed to write multi-table data: %w", err)
+	}
+	if !useStaging && job.CDCStateManager != nil {
+		for _, tableInfo := range job.Tables {
+			if err := job.CDCStateManager.BindDestinationIncarnation(ctx, tableInfo.Name, job.GetDestTableName(tableInfo.Name)); err != nil {
+				return fmt.Errorf("failed to bind replaced destination table %s: %w", tableInfo.Name, err)
 			}
 		}
-		return fmt.Errorf("failed to write multi-table data: %w", err)
 	}
 
 	if useStaging {
 		for _, tableInfo := range job.Tables {
+			writeSchema := job.WriteSchemaFor(tableInfo.Name, tableInfo.Schema)
 			destTable := job.GetDestTableName(tableInfo.Name)
 			stagingTable := stagingTables[tableInfo.Name]
 			swapTable := stagingTable
 			swapPrimaryKeys := tableInfo.PrimaryKeys
 			if replaceShouldDedup(job.Destination, tableInfo.PrimaryKeys) {
 				normalised, err := deduplicateStaging(ctx, job.Destination, stagingTable, destTable,
-					job.Config.StagingDataset, tableInfo.Schema.IncrementalKey, tableInfo.Schema, tableInfo.PrimaryKeys, "", nil)
+					job.Config.StagingDataset, writeSchema.IncrementalKey, writeSchema, tableInfo.PrimaryKeys, "", nil, job.CDCStateManager != nil)
 				if err != nil {
+					cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 					return fmt.Errorf("failed to deduplicate table %s: %w", tableInfo.Name, err)
 				}
 				swapTable = normalised
 				swapPrimaryKeys = nil
+				stagingTables[tableInfo.Name] = normalised
+			}
+			publishedIncarnation := ""
+			if job.CDCStateManager != nil {
+				publishedIncarnation, err = job.CDCStateManager.DestinationIncarnationForPublication(ctx, swapTable)
+				if err != nil {
+					cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
+					return fmt.Errorf("failed to identify replacement table %s before publication: %w", tableInfo.Name, err)
+				}
 			}
 
 			if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-				StagingTable: swapTable,
-				TargetTable:  destTable,
-				PrimaryKeys:  swapPrimaryKeys,
-				Schema:       tableInfo.Schema,
+				StagingTable:                  swapTable,
+				TargetTable:                   destTable,
+				PrimaryKeys:                   swapPrimaryKeys,
+				Schema:                        writeSchema,
+				CDCExpectedIncarnation:        expectedIncarnations[tableInfo.Name],
+				CDCExpectedStagingIncarnation: publishedIncarnation,
 			}); err != nil {
+				cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
 				return fmt.Errorf("failed to swap table %s: %w", tableInfo.Name, err)
+			}
+			delete(stagingTables, tableInfo.Name)
+			if job.CDCStateManager != nil {
+				if err := job.CDCStateManager.BindPublishedDestinationIncarnation(ctx, tableInfo.Name, destTable, expectedIncarnations[tableInfo.Name], publishedIncarnation); err != nil {
+					cleanupFailedMultiTableReplace(ctx, job.Destination, useStaging, stagingTables, createdDirectTargets)
+					return fmt.Errorf("failed to bind replaced destination table %s: %w", tableInfo.Name, err)
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+func cleanupFailedMultiTableReplace(
+	ctx context.Context,
+	dest destination.Destination,
+	useStaging bool,
+	stagingTables map[string]string,
+	createdDirectTargets map[string]ownedPreparedTarget,
+) {
+	if useStaging {
+		for _, table := range stagingTables {
+			cleanupFailedDirectReplace(ctx, dest, table, true)
+		}
+		return
+	}
+	for _, target := range createdDirectTargets {
+		cleanupFailedOwnedDirectReplace(ctx, dest, target.table, true, target.ownershipToken)
+	}
 }

--- a/pkg/strategy/scd2.go
+++ b/pkg/strategy/scd2.go
@@ -65,6 +65,9 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 	}); err != nil {
 		return fmt.Errorf("failed to prepare destination table: %w", err)
 	}
+	if !job.Config.KeepStaging {
+		defer dropManagedStagingDetached(ctx, job.Destination, stagingTable, "SCD2")
+	}
 
 	// Create staging table with same extended schema
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
@@ -152,19 +155,12 @@ func (s *SCD2Strategy) Execute(ctx context.Context, job *IngestionJob) error {
 		StagingTable:   stagingTable,
 		TargetTable:    job.Config.DestTable,
 		PrimaryKeys:    job.Config.PrimaryKeys,
-		Columns:        job.Schema.ColumnNames(),
+		Columns:        destination.DestinationColumns(job.Schema.ColumnNames()),
 		IncrementalKey: job.Config.IncrementalKey,
 		Timestamp:      processTimestamp,
 		Schema:         job.Schema,
 	}); err != nil {
 		return fmt.Errorf("failed to perform SCD2 merge: %w", err)
-	}
-
-	// Drop staging table (skip when KeepStaging is set for test inspection).
-	if !job.Config.KeepStaging {
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[SCD2] Warning: failed to drop staging table: %v", err)
-		}
 	}
 
 	return nil

--- a/pkg/strategy/scd2_test.go
+++ b/pkg/strategy/scd2_test.go
@@ -55,6 +55,7 @@ func TestSCD2Strategy_Execute_BasicFlow(t *testing.T) {
 		Columns: []schema.Column{
 			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
 			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true},
 		},
 		PrimaryKeys: []string{"id"},
 	}
@@ -98,6 +99,8 @@ func TestSCD2Strategy_Execute_BasicFlow(t *testing.T) {
 
 	// Should have called SCD2Table
 	assert.Contains(t, dest.calls, "SCD2Table")
+	require.Len(t, dest.scdCalls, 1)
+	assert.NotContains(t, dest.scdCalls[0].Columns, "_cdc_unchanged_cols")
 
 	// Should have called DropTable for staging cleanup
 	assert.Contains(t, dest.calls, "DropTable")
@@ -113,6 +116,19 @@ func TestSCD2Strategy_RejectsCDCBeforeDestinationOrSourceWork(t *testing.T) {
 	require.Empty(t, dest.prepareCalls)
 	require.Empty(t, dest.writeCalls)
 	require.False(t, src.readCalled)
+}
+
+func TestSCD2LostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.PrimaryKeys = []string{"id"}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&SCD2Strategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
 }
 
 func TestSCD2Strategy_ExtendSchemaWithSCDColumns(t *testing.T) {

--- a/pkg/strategy/snapshot_reset_test.go
+++ b/pkg/strategy/snapshot_reset_test.go
@@ -1,0 +1,2071 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type atomicSnapshotDestination struct {
+	*fakeDestination
+	atomicMu                sync.Mutex
+	begins                  []destination.AtomicSnapshotOptions
+	writes                  []destination.WriteOptions
+	publishes               []destination.AtomicSnapshotOptions
+	evolves                 []destination.AtomicSnapshotOptions
+	aborts                  []destination.AtomicSnapshotOptions
+	beginErr                error
+	writeErr                error
+	preparedOwnershipTokens []string
+	ownedDropTokens         []string
+	ownedDropErr            error
+	mergeErr                error
+	mergeRows               []int64
+	mergeNulls              []int
+	writeTypes              []arrow.DataType
+	writeNulls              []int
+	writeRows               []int64
+}
+
+type unownedAtomicSnapshotDestination struct {
+	*fakeDestination
+	beginErr error
+}
+
+type immediateFailAtomicMultiDestination struct{ *atomicSnapshotDestination }
+
+type failNthPublishAtomicDestination struct {
+	*atomicSnapshotDestination
+	failAt int
+	calls  int
+}
+
+type lateDiscoveryFilteringSource struct {
+	*announcingMultiTableSource
+	late         source.SourceTableInfo
+	includedLate bool
+}
+
+func (s *lateDiscoveryFilteringSource) ReadAll(_ context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	s.readOpts = opts
+	known := make(map[string]struct{}, len(opts.KnownTables))
+	for _, table := range opts.KnownTables {
+		known[table] = struct{}{}
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	for _, table := range s.tables {
+		records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	}
+	if _, frozen := known[s.late.Name]; !frozen && len(opts.KnownTables) == 0 {
+		s.includedLate = true
+		records <- source.RecordBatchResult{TableName: s.late.Name, Truncate: true}
+	}
+	close(records)
+	return records, nil
+}
+
+func (d *failNthPublishAtomicDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.calls++
+	if d.calls == d.failAt {
+		return errors.New("injected multi-table publish failure")
+	}
+	return d.atomicSnapshotDestination.PublishAtomicSnapshot(context.Background(), opts)
+}
+
+func (*immediateFailAtomicMultiDestination) MergeRecords(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+	destination.MergeOptions,
+) error {
+	return errors.New("direct worker failed before draining")
+}
+
+func (d *unownedAtomicSnapshotDestination) BeginAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return d.beginErr
+}
+
+func (*unownedAtomicSnapshotDestination) EvolveAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return nil
+}
+
+func (*unownedAtomicSnapshotDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions) error {
+	drainAndRelease(records)
+	return nil
+}
+
+func (*unownedAtomicSnapshotDestination) PublishAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return nil
+}
+
+func (*unownedAtomicSnapshotDestination) MergeRecords(_ context.Context, records <-chan source.RecordBatchResult, _ destination.WriteOptions, _ destination.MergeOptions) error {
+	drainAndRelease(records)
+	return nil
+}
+
+type snapshotReplacementTrackingDestination struct {
+	*atomicSnapshotDestination
+	rowsMu  sync.Mutex
+	visible map[int64]struct{}
+	staged  map[string][]int64
+}
+
+func (d *snapshotReplacementTrackingDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	var rows []int64
+	for result := range records {
+		if result.Batch != nil {
+			values := result.Batch.Column(0).(*array.Int64)
+			for i := 0; i < values.Len(); i++ {
+				if !values.IsNull(i) {
+					rows = append(rows, values.Value(i))
+				}
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.rowsMu.Lock()
+	d.staged[opts.AtomicSnapshotAttemptID] = rows
+	d.rowsMu.Unlock()
+	return nil
+}
+
+func (d *snapshotReplacementTrackingDestination) PublishAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) error {
+	if err := d.atomicSnapshotDestination.PublishAtomicSnapshot(ctx, opts); err != nil {
+		return err
+	}
+	d.rowsMu.Lock()
+	d.visible = make(map[int64]struct{}, len(d.staged[opts.AttemptID]))
+	for _, id := range d.staged[opts.AttemptID] {
+		d.visible[id] = struct{}{}
+	}
+	d.rowsMu.Unlock()
+	return nil
+}
+
+type incarnationTrackingAtomicSnapshotDestination struct {
+	*cdcStateDestination
+	publishedIncarnation string
+	incarnationMu        sync.Mutex
+	incarnationReads     int
+	begunOpts            []destination.AtomicSnapshotOptions
+	publishedOpts        []destination.AtomicSnapshotOptions
+}
+
+func (*incarnationTrackingAtomicSnapshotDestination) MergeRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	_ destination.WriteOptions,
+	_ destination.MergeOptions,
+) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) BeginAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.incarnationMu.Lock()
+	d.begunOpts = append(d.begunOpts, opts)
+	d.incarnationMu.Unlock()
+	return nil
+}
+
+func (*incarnationTrackingAtomicSnapshotDestination) EvolveAtomicSnapshot(context.Context, destination.AtomicSnapshotOptions) error {
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	incarnation, exists, err := d.cdcStateDestination.CDCTargetIncarnation(ctx, table)
+	d.incarnationMu.Lock()
+	d.incarnationReads++
+	d.incarnationMu.Unlock()
+	return incarnation, exists, err
+}
+
+func (*incarnationTrackingAtomicSnapshotDestination) WriteAtomicSnapshot(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	_ destination.WriteOptions,
+) error {
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+func (d *incarnationTrackingAtomicSnapshotDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.incarnationMu.Lock()
+	d.publishedOpts = append(d.publishedOpts, opts)
+	d.incarnationMu.Unlock()
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	d.incarnations[opts.Table] = d.publishedIncarnation
+	return nil
+}
+
+func (d *atomicSnapshotDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	d.atomicMu.Lock()
+	d.preparedOwnershipTokens = append(d.preparedOwnershipTokens, opts.OwnershipToken)
+	d.atomicMu.Unlock()
+	return d.fakeDestination.PrepareTable(ctx, opts)
+}
+
+func (d *atomicSnapshotDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.ownedDropTokens = append(d.ownedDropTokens, token)
+	return d.ownedDropErr
+}
+
+func (*atomicSnapshotDestination) CDCTargetIncarnation(context.Context, string) (string, bool, error) {
+	return "target-v1", true, nil
+}
+
+func (d *atomicSnapshotDestination) AbortAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.aborts = append(d.aborts, opts)
+	return nil
+}
+
+func (d *atomicSnapshotDestination) MergeRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	_ destination.WriteOptions,
+	opts destination.MergeOptions,
+) error {
+	var rows int64
+	var nulls int
+	for result := range records {
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			if result.Batch.NumCols() > 1 {
+				nulls += result.Batch.Column(1).NullN()
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.mu.Lock()
+	d.mergeCalls = append(d.mergeCalls, opts)
+	d.mu.Unlock()
+	d.atomicMu.Lock()
+	d.mergeRows = append(d.mergeRows, rows)
+	d.mergeNulls = append(d.mergeNulls, nulls)
+	d.atomicMu.Unlock()
+	return d.mergeErr
+}
+
+type snapshotResetSourceTable struct{ *fakeSourceTable }
+
+func (*snapshotResetSourceTable) EmitsSnapshotResets() bool { return true }
+
+type snapshotResetMultiSource struct{ *announcingMultiTableSource }
+
+func (*snapshotResetMultiSource) EmitsSnapshotResets() bool { return true }
+
+type truncateCapableFakeDestination struct{ *fakeDestination }
+
+func (d *truncateCapableFakeDestination) TruncateTable(_ context.Context, table string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.truncateCalls = append(d.truncateCalls, table)
+	return d.truncateErr
+}
+
+func snapshotStateToken(table, position string) source.CDCStateCommitToken {
+	return source.CDCStateCommitToken{SnapshotPositions: map[string]string{table: position}}
+}
+
+func testCDCSchema(base *schema.TableSchema) *schema.TableSchema {
+	result := *base
+	result.Columns = append([]schema.Column(nil), base.Columns...)
+	result.PrimaryKeys = append([]string(nil), base.PrimaryKeys...)
+	result.Columns = append(
+		result.Columns,
+		schema.Column{Name: destination.CDCLSNColumn, DataType: schema.TypeString},
+		schema.Column{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean},
+		schema.Column{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ},
+		schema.Column{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString},
+	)
+	return &result
+}
+
+func (l *flushLoop) handleSnapshotReset(ctx context.Context, table string) error {
+	return l.handleResult(ctx, source.RecordBatchResult{TableName: table, Truncate: true})
+}
+
+func (d *atomicSnapshotDestination) BeginAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.begins = append(d.begins, opts)
+	return d.beginErr
+}
+
+func TestStreamingAtomicSnapshotBeginFailureAbortsOwnedAttempt(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}, beginErr: errors.New("begin failed after stage creation")}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+
+	err := loop.handleSnapshotReset(context.Background(), "public.events")
+	require.Error(t, err)
+	loop.cleanup(context.Background())
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.aborts, 1)
+	require.Equal(t, dest.begins[0].AttemptID, dest.aborts[0].AttemptID)
+}
+
+func TestStreamingAppendAtomicPreparationDoesNotMutateExistingTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": tableSchema},
+	}}
+	st := &streamTableState{destTable: "lake.events", schema: tableSchema, isCDC: true}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyAppend})
+
+	require.NoError(t, executor.prepareTable(t.Context(), dest, &config.IngestConfig{}, st))
+	require.Empty(t, dest.prepareCalls)
+	require.False(t, st.targetCreatedByRun)
+}
+
+func TestStreamingAppendAtomicPreparationCleansOwnedNewTargetOnFailure(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := &streamTableState{destTable: "lake.events", schema: tableSchema, isCDC: true}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyAppend})
+
+	require.NoError(t, executor.prepareTable(t.Context(), dest, &config.IngestConfig{}, st))
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyAppend}, map[string]*streamTableState{"public.events": st})
+	loop.cleanup(t.Context())
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+}
+
+func TestStreamingRepeatedSnapshotResetAbortsPreviousAttempt(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	firstAttempt := st.snapshotAttemptID
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	require.NotEqual(t, firstAttempt, st.snapshotAttemptID)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.aborts, 1)
+	require.Equal(t, firstAttempt, dest.aborts[0].AttemptID)
+	require.Len(t, dest.begins, 2)
+}
+
+func TestStreamingAtomicRefreshRebuildsDiscardValueTransformer(t *testing.T) {
+	current := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": current},
+	}}
+	st := &streamTableState{destTable: "lake.events", schema: current, primaryKeys: []string{"id"}, isCDC: true}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.cfg.SchemaContract = "discard_value"
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	refreshed := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	require.NoError(t, loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: refreshed, PrimaryKeys: []string{"id"},
+	}, st))
+	require.NotNil(t, st.schemaAligner)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, st.schemaAligner.OutputSchema(nil).Field(1).Type))
+	id := array.NewInt64Builder(memory.DefaultAllocator)
+	value := array.NewStringBuilder(memory.DefaultAllocator)
+	id.Append(1)
+	value.Append("not-an-integer")
+	idArray, valueArray := id.NewArray(), value.NewArray()
+	id.Release()
+	value.Release()
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "value", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: batch,
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.writeTypes, 1)
+	require.Truef(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.writeTypes[0]), "got type %s", dest.writeTypes[0])
+	require.Equal(t, []int{1}, dest.writeNulls)
+	require.Equal(t, schema.TypeInt64, dest.writes[0].Schema.Columns[1].DataType)
+}
+
+func TestBatchSnapshotMergePreservesTargetOnSourceFailure(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	snapshotSource := &snapshotResetSourceTable{fakeSourceTable: src}
+	job.Table = snapshotSource
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{Err: errors.New("snapshot extraction failed")}
+	close(records)
+	src.readCh = records
+
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	require.Empty(t, dest.truncateCalls)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.publishes)
+	require.Len(t, dest.aborts, 1)
+}
+
+func TestBatchSnapshotFailureConditionallyRemovesOnlyOwnedNewTarget(t *testing.T) {
+	dest := &atomicSnapshotDestination{
+		fakeDestination: &fakeDestination{},
+		writeErr:        errors.New("snapshot staging failed after replacement owner appeared"),
+		ownedDropErr:    errors.New("ownership changed"),
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+	)
+
+	err := (&MergeStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.dropCalls, "unconditional cleanup must not delete a replacement owner")
+	require.Empty(t, dest.publishes)
+	require.Len(t, dest.aborts, 1)
+}
+
+func TestBatchSnapshotLostPrepareResponseCleansOwnedTarget(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareHook: func(destination.PrepareOptions) error { return errors.New("prepare response lost after create") },
+	}}
+	job, _, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: job.Table.(*fakeSourceTable)}
+
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(context.Background(), job), "prepare response lost")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+}
+
+func TestBatchEmptySnapshotPublishesBatchlessDurablePosition(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Truncate: true}
+	records <- source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/900"}
+	close(records)
+	src.readCh = records
+
+	require.NoError(t, (&MergeStrategy{}).Execute(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "snapshot:empty", dest.publishes[0].CommitToken)
+	require.Equal(t, "0/900", dest.publishes[0].CDCResumeLSN)
+}
+
+func TestAtomicSnapshotBeginFailureDrainsUnreadArrowBatches(t *testing.T) {
+	for _, strategyName := range []string{"merge", "append"} {
+		t.Run(strategyName, func(t *testing.T) {
+			pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+			previousAllocator := memory.DefaultAllocator
+			memory.DefaultAllocator = pool
+			t.Cleanup(func() {
+				memory.DefaultAllocator = previousAllocator
+				pool.AssertSize(t, 0)
+			})
+
+			dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}, beginErr: errors.New("begin failed")}
+			job, src, _ := minimalJob()
+			job.Destination = dest
+			job.Schema = testCDCSchema(job.Schema)
+			job.SourceSchema = job.Schema
+			job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+			src.readCh = mustClosedRecords(
+				source.RecordBatchResult{Truncate: true},
+				source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil)},
+			)
+
+			var err error
+			if strategyName == "merge" {
+				err = (&MergeStrategy{}).Execute(t.Context(), job)
+			} else {
+				job.CDCStateManager = &CDCStateManager{
+					dest: dest, incarnation: dest,
+					destTables:          map[string]string{job.Config.SourceTable: job.Config.DestTable},
+					currentIncarnations: map[string]string{}, currentSchemas: map[string]string{},
+					boundDestinations: map[string]string{}, boundDestinationRaw: map[string]string{},
+				}
+				err = (&AppendStrategy{}).executeAtomicSnapshot(t.Context(), job, dest, destination.DestinationTableSchema(job.Schema))
+			}
+			require.ErrorContains(t, err, "failed to begin")
+			if strategyName == "append" {
+				dest.atomicMu.Lock()
+				require.Len(t, dest.preparedOwnershipTokens, 1)
+				require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+				require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+				dest.atomicMu.Unlock()
+			}
+		})
+	}
+}
+
+func TestBatchAtomicSnapshotBindsPublishedDestinationIncarnation(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "destination-before-publication",
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	stateDest.incarnations[job.Config.DestTable] = "destination-before-publication"
+	manager, err := NewCDCStateManager(dest, "batch-published-incarnation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-incarnation"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job.CDCStateManager = manager
+	dest.incarnationMu.Lock()
+	readsBeforeExecute := dest.incarnationReads
+	dest.incarnationMu.Unlock()
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{DurableCommitID: "snapshot:empty", DurableCommitPosition: "0/900"},
+	)
+
+	require.NoError(t, (&MergeStrategy{}).Execute(t.Context(), job))
+	require.Equal(
+		t,
+		cdcDestinationIncarnationDigest(dest.publishedIncarnation),
+		manager.boundDestinations[job.Config.SourceTable],
+	)
+	dest.incarnationMu.Lock()
+	readsAfterExecute := dest.incarnationReads
+	require.Len(t, dest.publishedOpts, 1)
+	require.True(t, dest.publishedOpts[0].SkipCDCResume)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, readsBeforeExecute+2, readsAfterExecute, "atomic batch snapshot must fence before publication and rebind after it")
+}
+
+func TestManagedAppendSnapshotPublishesAtomically(t *testing.T) {
+	stateDest := newCDCStateDestination()
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "target-v1",
+	}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.SourceSchema = job.Schema
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	manager, err := NewCDCStateManager(dest, "managed-append-atomic", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job.CDCStateManager = manager
+	src.readCh = mustClosedRecords(
+		source.RecordBatchResult{Truncate: true},
+		source.RecordBatchResult{
+			Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "snapshot:append", DurableCommitPosition: "0/900",
+		},
+	)
+
+	require.NoError(t, (&AppendStrategy{}).Execute(t.Context(), job))
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	for _, prepare := range stateDest.prepareCalls {
+		require.NotEqual(t, job.Config.DestTable, prepare.Table, "existing atomic append target must not be prepared before publication")
+	}
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, "snapshot:append", dest.publishedOpts[0].CommitToken)
+	require.Equal(t, "0/900", dest.publishedOpts[0].CDCResumeLSN)
+	require.True(t, dest.publishedOpts[0].SkipCDCResume)
+	require.Equal(t, "target-v1", dest.publishedOpts[0].CDCExpectedIncarnation)
+	dest.incarnationMu.Unlock()
+}
+
+func TestManagedMultiTableAppendSnapshotPublishesAtomically(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "snapshot:multi-append", DurableCommitPosition: "0/901",
+		}),
+	}}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{cdcStateDestination: stateDest, publishedIncarnation: "target-v1"}
+	manager, err := NewCDCStateManager(dest, "managed-multi-append-atomic", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "lake.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyAppend, NoLoadTimestamp: true},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"}, CDCStateManager: manager,
+	}
+
+	require.NoError(t, (&AppendStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.True(t, src.readOpts.CDCStableDataBatches)
+	stateDest.mu.Lock()
+	for _, prepare := range stateDest.prepareCalls {
+		require.NotEqual(t, "lake.events", prepare.Table, "existing atomic multi-table append target must not be prepared before publication")
+	}
+	stateDest.mu.Unlock()
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.begunOpts, 1)
+	require.Contains(t, dest.begunOpts[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, "snapshot:multi-append", dest.publishedOpts[0].CommitToken)
+	require.Empty(t, dest.publishedOpts[0].PrimaryKeys, "append snapshots must not acquire merge semantics")
+	require.Equal(t, "target-v1", dest.publishedOpts[0].CDCExpectedIncarnation)
+	require.Contains(t, dest.publishedOpts[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+	dest.incarnationMu.Unlock()
+}
+
+func TestBatchCDCResumeWithoutResetUsesDirectMerge(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.CDCResumeLSN = "0/900"
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch:           int64RecordBatch(t, "id", []int64{4}, nil),
+		DurableCommitID: "wal:resume", DurableCommitPosition: "0/901",
+	})
+
+	require.NoError(t, (&MergeStrategy{}).Execute(context.Background(), job))
+	dest.atomicMu.Lock()
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.publishes)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+}
+
+func TestBatchCDCResumeLostMergeResponsePreservesOwnedTarget(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{mergeErr: errors.New("merge response lost after commit")}}
+	job, src, _ := minimalJob()
+	job.Destination = dest
+	job.Schema = testCDCSchema(job.Schema)
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.CDCResumeLSN = "0/900"
+	job.Table = &snapshotResetSourceTable{fakeSourceTable: src}
+	src.readCh = mustClosedRecords(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{4}, nil), DurableCommitID: "wal:resume", DurableCommitPosition: "0/901",
+	})
+
+	require.ErrorContains(t, (&MergeStrategy{}).Execute(context.Background(), job), "merge response lost")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Empty(t, dest.ownedDropTokens, "a merge error may be a lost response after a durable commit")
+}
+
+func TestAtomicMultiTableInitialCDCSnapshotWithoutBoundaryReplacesStaleRows(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	dest := &snapshotReplacementTrackingDestination{
+		atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+			tableSchemas: map[string]*schema.TableSchema{"lake.events": destination.DestinationTableSchema(tableSchema)},
+		}},
+		visible: map[int64]struct{}{99: {}},
+		staged:  make(map[string][]int64),
+	}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{
+			table.Name: "lake.events",
+		},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	dest.rowsMu.Lock()
+	require.Equal(t, map[int64]struct{}{1: {}}, dest.visible)
+	dest.rowsMu.Unlock()
+	dest.atomicMu.Lock()
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.publishes, 1)
+	require.Empty(t, dest.mergeRows)
+	dest.atomicMu.Unlock()
+}
+
+func TestAtomicMultiTableManagedSnapshotAndReplaySkipDestinationCursor(t *testing.T) {
+	t.Run("snapshot", func(t *testing.T) {
+		tableSchema := testCDCSchema(streamTestSchema())
+		table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+		records := mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		})
+		dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+		job := &MultiTableIngestionJob{
+			Config: &config.IngestConfig{NoLoadTimestamp: true}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+			Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "lake.events"},
+			CDCStateManager: &CDCStateManager{},
+		}
+
+		require.NoError(t, (&MergeStrategy{}).executeAtomicMultiTableBatch(t.Context(), job, dest, dest))
+		dest.atomicMu.Lock()
+		require.Len(t, dest.writes, 1)
+		require.True(t, dest.writes[0].SkipCDCResume)
+		require.Len(t, dest.publishes, 1)
+		require.True(t, dest.publishes[0].SkipCDCResume)
+		dest.atomicMu.Unlock()
+	})
+
+	t.Run("incremental_replay", func(t *testing.T) {
+		tableSchema := testCDCSchema(streamTestSchema())
+		table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+		records := mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		})
+		dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+		job := &MultiTableIngestionJob{
+			Config: &config.IngestConfig{NoLoadTimestamp: true}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+			Destination: dest, Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "lake.events"},
+			CDCResumeLSNs: map[string]string{table.Name: "0/100"}, CDCStateManager: &CDCStateManager{},
+		}
+
+		require.NoError(t, (&MergeStrategy{}).executeAtomicMultiTableBatch(t.Context(), job, dest, dest))
+		dest.mu.Lock()
+		require.Len(t, dest.mergeCalls, 1)
+		require.True(t, dest.mergeCalls[0].SkipCDCResume)
+		dest.mu.Unlock()
+	})
+}
+
+func TestManagedMultiTableInitialSnapshotUsesAtomicPublicationAndLegacySlot(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &announcingMultiTableSource{
+		tables: []source.SourceTableInfo{table},
+		records: mustClosedRecords(source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		}),
+	}
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.events"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination:  stateDest,
+		publishedIncarnation: "target-v1",
+	}
+	manager, err := NewCDCStateManager(dest, "managed-multi-atomic", "lake.events", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), table.Name, "lake.events", "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{
+			IncrementalStrategy: config.StrategyMerge,
+			NoLoadTimestamp:     true,
+			CDCSlotSuffix:       "current-slot",
+			CDCLegacySlotSuffix: "legacy-slot",
+		},
+		Source: src, Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{table.Name: "lake.events"},
+		CDCStateManager: manager,
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.Equal(t, "current-slot", src.readOpts.CDCSlotSuffix)
+	require.Equal(t, "legacy-slot", src.readOpts.CDCLegacySlotSuffix)
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.publishedOpts, 1)
+	require.True(t, dest.publishedOpts[0].SkipCDCResume)
+	require.Equal(t, "target-v1", dest.publishedOpts[0].CDCExpectedIncarnation)
+	dest.incarnationMu.Unlock()
+	require.Equal(t, "target-v1", manager.BoundDestinationIncarnation(table.Name))
+}
+
+func TestAtomicCapableMultiTableResumeAppliesSchemaContract(t *testing.T) {
+	for _, tc := range []struct {
+		mode      string
+		wantRows  int64
+		wantNulls int
+	}{
+		{mode: "discard_value", wantRows: 1, wantNulls: 1},
+		{mode: "discard_row", wantRows: 0, wantNulls: 0},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "value", DataType: schema.TypeString, Nullable: true},
+			}, PrimaryKeys: []string{"id"}}
+			finalSchema := &schema.TableSchema{Columns: []schema.Column{
+				{Name: "id", DataType: schema.TypeInt64},
+				{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+			}, PrimaryKeys: []string{"id"}}
+			comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+				Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+			}}}
+			ids := array.NewInt64Builder(memory.DefaultAllocator)
+			values := array.NewStringBuilder(memory.DefaultAllocator)
+			ids.Append(1)
+			values.Append("invalid")
+			idArray, valueArray := ids.NewArray(), values.NewArray()
+			ids.Release()
+			values.Release()
+			batch := array.NewRecordBatch(sourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+			idArray.Release()
+			valueArray.Release()
+			table := source.SourceTableInfo{Name: "public.events", Schema: sourceSchema, PrimaryKeys: []string{"id"}}
+			records := make(chan source.RecordBatchResult, 1)
+			records <- source.RecordBatchResult{TableName: table.Name, Batch: batch}
+			close(records)
+			dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+			job := &MultiTableIngestionJob{
+				Config:      &config.IngestConfig{SchemaContract: tc.mode, NoLoadTimestamp: true},
+				Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records},
+				Destination: dest, Tables: []source.SourceTableInfo{table},
+				TableDestNames: map[string]string{table.Name: "lake.events"},
+				CDCResumeLSNs:  map[string]string{table.Name: "0/10"},
+				EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+					table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+				},
+			}
+
+			executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 100})
+			require.NoError(t, executor.ExecuteMultiTable(context.Background(), job))
+			dest.atomicMu.Lock()
+			defer dest.atomicMu.Unlock()
+			if tc.wantRows == 0 {
+				require.Empty(t, dest.mergeRows)
+				require.Empty(t, dest.mergeNulls)
+			} else {
+				require.Equal(t, []int64{tc.wantRows}, dest.mergeRows)
+				require.Equal(t, []int{tc.wantNulls}, dest.mergeNulls)
+			}
+			require.Empty(t, dest.publishes)
+		})
+	}
+}
+
+func TestAtomicCapableMultiTableSnapshotAppliesDiscardRowContract(t *testing.T) {
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	ids := array.NewInt64Builder(memory.DefaultAllocator)
+	values := array.NewStringBuilder(memory.DefaultAllocator)
+	ids.Append(1)
+	values.Append("invalid")
+	idArray, valueArray := ids.NewArray(), values.NewArray()
+	ids.Release()
+	values.Release()
+	batch := array.NewRecordBatch(sourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	table := source.SourceTableInfo{Name: "public.events", Schema: testCDCSchema(sourceSchema), PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: table.Name,
+		Batch:     batch,
+		CommitToken: source.CDCStateCommitToken{SnapshotPositions: map[string]string{
+			table.Name: "0/20",
+		}},
+	}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{SchemaContract: "discard_row", NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			table.Name: {TransformComparison: comparison, FinalSchema: finalSchema},
+		},
+	}
+
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 100})
+	require.NoError(t, executor.ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.writeRows)
+	require.Len(t, dest.publishes, 1)
+}
+
+func TestMultiTableBatchPublishesMultipleResetSnapshotsAfterAllStagesSucceed(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	tables := []source.SourceTableInfo{
+		{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "first-v1", SchemaFingerprint: "first-schema-v1"},
+		{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "second-v1", SchemaFingerprint: "second-schema-v1"},
+	}
+	records := make(chan source.RecordBatchResult, 2)
+	for _, table := range tables {
+		records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	}
+	close(records)
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{tables: tables, records: records}}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest, Tables: tables,
+		TableDestNames: map[string]string{"public.first": "lake.first", "public.second": "lake.second"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	require.ElementsMatch(t, []string{"public.first", "public.second"}, src.readOpts.KnownTables)
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+	require.Equal(t, "first-v1", src.readOpts.CDCResumeIncarnations["public.first"])
+	require.Equal(t, "second-schema-v1", src.readOpts.CDCResumeSchemaFingerprints["public.second"])
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.publishes, 2)
+	require.Equal(t, "lake.first", dest.publishes[0].Table)
+	require.Equal(t, "lake.second", dest.publishes[1].Table)
+	require.Len(t, dest.begins, 2)
+	require.Empty(t, dest.aborts)
+	require.Empty(t, dest.truncateCalls)
+}
+
+func TestAtomicMultiTableReadFreezesTablesDiscoveredBeforeSourceRead(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	known := source.SourceTableInfo{Name: "public.known", Schema: tableSchema, PrimaryKeys: []string{"id"}, Incarnation: "known-v1", SchemaFingerprint: "known-schema-v1"}
+	late := source.SourceTableInfo{Name: "public.late", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &lateDiscoveryFilteringSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{known}},
+		late:                       late,
+	}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source:         src,
+		Destination:    dest,
+		Tables:         []source.SourceTableInfo{known},
+		TableDestNames: map[string]string{known.Name: "lake.known"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.Equal(t, []string{known.Name}, src.readOpts.KnownTables)
+	require.False(t, src.includedLate, "a table discovered after the pipeline froze its target set must wait for the next run")
+	require.Equal(t, "known-v1", src.readOpts.CDCResumeIncarnations[known.Name])
+	require.Equal(t, "known-schema-v1", src.readOpts.CDCResumeSchemaFingerprints[known.Name])
+	require.True(t, src.readOpts.CDCSnapshotReplace)
+}
+
+func TestMultiTableBatchPartialPublicationIsReplayableWithoutCheckpoint(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	tables := []source.SourceTableInfo{
+		{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+		{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}},
+	}
+	dest := &failNthPublishAtomicDestination{
+		atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{}},
+		failAt:                    2,
+	}
+	newJob := func() *MultiTableIngestionJob {
+		records := make(chan source.RecordBatchResult, 4)
+		for i, table := range tables {
+			records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+			records <- source.RecordBatchResult{
+				TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{int64(i + 1)}, nil),
+				CommitToken: source.CDCStateCommitToken{SnapshotPositions: map[string]string{table.Name: "0/20"}},
+			}
+		}
+		close(records)
+		return &MultiTableIngestionJob{
+			Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+			Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+				tables: tables, records: records,
+			}},
+			Destination: dest,
+			Tables:      tables,
+			TableDestNames: map[string]string{
+				tables[0].Name: "lake.first", tables[1].Name: "lake.second",
+			},
+		}
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), newJob()), "injected multi-table publish failure")
+	dest.atomicMu.Lock()
+	require.Len(t, dest.begins, 2, "every replacement must be staged before publication begins")
+	require.Len(t, dest.publishes, 1, "the first per-table commit may be visible, but no source state is acknowledged")
+	dest.atomicMu.Unlock()
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), newJob()))
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 3, "replay must republish the complete target set after an incomplete generation")
+	require.Equal(t, "lake.first", dest.publishes[1].Table)
+	require.Equal(t, "lake.second", dest.publishes[2].Table)
+	dest.atomicMu.Unlock()
+}
+
+func TestMultiTableBatchSpoolKeepsOnlyRowsAfterEachReset(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	first := source.SourceTableInfo{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	second := source.SourceTableInfo{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 8)
+	records <- source.RecordBatchResult{TableName: first.Name, Batch: int64RecordBatch(t, "id", []int64{91}, nil)}
+	records <- source.RecordBatchResult{TableName: second.Name, Batch: int64RecordBatch(t, "id", []int64{92}, nil)}
+	records <- source.RecordBatchResult{TableName: first.Name, Truncate: true}
+	records <- source.RecordBatchResult{TableName: first.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records <- source.RecordBatchResult{TableName: second.Name, Truncate: true}
+	records <- source.RecordBatchResult{TableName: second.Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil)}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{first, second}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{first, second},
+		TableDestNames: map[string]string{
+			first.Name: "lake.first", second.Name: "lake.second",
+		},
+		CDCResumeLSNs: map[string]string{first.Name: "0/10", second.Name: "0/10"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 2)
+	require.Len(t, dest.publishes, 2)
+	require.ElementsMatch(t, []int64{1, 1}, dest.writeRows)
+}
+
+func TestMultiTableBatchWALTruncateUsesFencedAtomicReplacement(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	truncated := source.SourceTableInfo{Name: "public.truncated", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	unchanged := source.SourceTableInfo{Name: "public.unchanged", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 5)
+	records <- source.RecordBatchResult{TableName: truncated.Name, Batch: int64RecordBatch(t, "id", []int64{98}, nil)}
+	records <- source.RecordBatchResult{TableName: truncated.Name, Truncate: true, CDCWALTruncate: true}
+	records <- source.RecordBatchResult{
+		TableName: truncated.Name, Batch: int64RecordBatch(t, "id", []int64{7}, nil),
+		CommitToken: source.CDCStateCommitToken{Position: "0/20"},
+	}
+	records <- source.RecordBatchResult{TableName: unchanged.Name, Batch: int64RecordBatch(t, "id", []int64{8}, nil)}
+	close(records)
+	dest := &snapshotReplacementTrackingDestination{
+		atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+			tableSchemas: map[string]*schema.TableSchema{
+				"lake.truncated": destination.DestinationTableSchema(tableSchema),
+				"lake.unchanged": destination.DestinationTableSchema(tableSchema),
+			},
+		}},
+		visible: map[int64]struct{}{99: {}},
+		staged:  make(map[string][]int64),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{truncated, unchanged}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{truncated, unchanged},
+		TableDestNames: map[string]string{
+			truncated.Name: "lake.truncated", unchanged.Name: "lake.unchanged",
+		},
+		CDCResumeLSNs: map[string]string{truncated.Name: "0/10", unchanged.Name: "0/10"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	dest.rowsMu.Lock()
+	require.Equal(t, map[int64]struct{}{7: {}}, dest.visible)
+	dest.rowsMu.Unlock()
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "lake.truncated", dest.publishes[0].Table)
+	require.Equal(t, "0/20", dest.publishes[0].CDCResumeLSN)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.unchanged", dest.mergeCalls[0].TargetTable)
+	dest.mu.Unlock()
+}
+
+func TestMultiTableBatchFailureConditionallyRemovesOwnedUnpublishedSnapshotTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}, records: records}}
+	dest := &atomicSnapshotDestination{
+		fakeDestination: &fakeDestination{}, writeErr: errors.New("snapshot staging failed"), ownedDropErr: errors.New("ownership changed"),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest,
+		Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.Error(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Len(t, dest.aborts, 1)
+	require.Empty(t, dest.publishes)
+	require.Empty(t, dest.dropCalls, "unconditional cleanup must not delete a replacement owner")
+}
+
+func TestAtomicMultiTableBatchLeaseLossDuringSpoolPreventsDestinationMutation(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	lease := &streamingTestLease{done: make(chan struct{}), err: errors.New("lease lost during atomic preflight spool")}
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+		close(lease.done)
+		close(records)
+	}()
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	err := (&MergeStrategy{}).ExecuteMultiTable(guardedStreamingContext(lease), job)
+	require.ErrorContains(t, err, "lease lost during atomic preflight spool")
+	require.Empty(t, dest.prepareCalls)
+	dest.atomicMu.Lock()
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.publishes)
+	dest.atomicMu.Unlock()
+}
+
+func TestAtomicMultiTableFailureNeverDropsUnownedPreparedTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	dest := &unownedAtomicSnapshotDestination{
+		fakeDestination: &fakeDestination{},
+		beginErr:        errors.New("atomic begin failed after external replacement"),
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: mustClosedRecords(),
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job), "atomic begin failed")
+	require.Empty(t, dest.dropCalls, "without destination-enforced ownership, cleanup must preserve a possible external replacement")
+}
+
+func TestAtomicMultiTableDirectWorkerFailureReleasesDispatchedReplayBatches(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	previousAllocator := memory.DefaultAllocator
+	memory.DefaultAllocator = pool
+	t.Cleanup(func() {
+		memory.DefaultAllocator = previousAllocator
+		pool.AssertSize(t, 0)
+	})
+
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.resume", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 16)
+	for i := int64(0); i < 16; i++ {
+		records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{i}, nil)}
+	}
+	close(records)
+	dest := &immediateFailAtomicMultiDestination{atomicSnapshotDestination: &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.resume": destination.DestinationTableSchema(tableSchema)},
+	}}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.resume"},
+		CDCResumeLSNs:  map[string]string{table.Name: "0/10"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job), "direct worker failed")
+}
+
+func TestAtomicMultiTablePreflightFailureDrainsUnreadArrowBatches(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	previousAllocator := memory.DefaultAllocator
+	memory.DefaultAllocator = pool
+	t.Cleanup(func() {
+		memory.DefaultAllocator = previousAllocator
+		pool.AssertSize(t, 0)
+	})
+
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 18)
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	records <- source.RecordBatchResult{
+		TableName: table.Name,
+		Batch:     int64RecordBatch(t, "id", []int64{2}, nil),
+		Err:       errors.New("source failed during atomic preflight"),
+	}
+	for i := int64(3); i < 19; i++ {
+		records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{i}, nil)}
+	}
+	close(records)
+
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job), "source failed during atomic preflight")
+}
+
+func TestAtomicMultiTablePreflightAppliesSnapshotInvalidationBeforePublication(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{
+		Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"},
+		Incarnation: "source-v1", SchemaFingerprint: "schema-v1",
+	}
+	records := mustClosedRecords(
+		source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
+			TableName: table.Name, Incarnation: "source-v2", SchemaFingerprint: "schema-v2",
+		}},
+		source.RecordBatchResult{TableName: table.Name, Truncate: true},
+		source.RecordBatchResult{
+			TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+			DurableCommitID: "snapshot:metadata-v2", DurableCommitPosition: "0/20",
+		},
+	)
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations["lake.snapshot"] = "target-v1"
+	dest := &incarnationTrackingAtomicSnapshotDestination{
+		cdcStateDestination: stateDest, publishedIncarnation: "target-v1",
+	}
+	manager, err := NewCDCStateManager(dest, "metadata-change-atomic", "lake.snapshot", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableState(t.Context(), table.Name, "lake.snapshot", table.Incarnation, table.SchemaFingerprint))
+	require.NoError(t, manager.BeginRun(t.Context(), false))
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge, NoLoadTimestamp: true},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames:  map[string]string{table.Name: "lake.snapshot"},
+		CDCResumeLSNs:   map[string]string{table.Name: "0/10"},
+		CDCStateManager: manager,
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.NoError(t, manager.Persist(t.Context(), source.CDCStateCommitToken{
+		Position:             "0/20",
+		SnapshotPositions:    map[string]string{table.Name: "0/20"},
+		SnapshotIncarnations: map[string]string{table.Name: "source-v2"},
+		SnapshotSchemas:      map[string]string{table.Name: "schema-v2"},
+	}))
+	restarted, err := NewCDCStateManager(dest, "metadata-change-atomic", "lake.snapshot", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableState(t.Context(), table.Name, "lake.snapshot", "source-v2", "schema-v2"))
+	position, err := restarted.ResumePosition(t.Context(), table.Name)
+	require.NoError(t, err)
+	require.Equal(t, "0/20", position)
+	dest.incarnationMu.Lock()
+	require.Len(t, dest.publishedOpts, 1)
+	require.Equal(t, "snapshot:metadata-v2", dest.publishedOpts[0].CommitToken)
+	dest.incarnationMu.Unlock()
+}
+
+func TestMultiTableBatchLaterPrepareFailureCleansEarlierOwnedSnapshotTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	snapshotTable := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	resumeTable := source.SourceTableInfo{Name: "public.resume", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: snapshotTable.Name, Truncate: true}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareErrByTable: map[string]error{"lake.resume": errors.New("prepare failed")},
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{snapshotTable, resumeTable}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{snapshotTable, resumeTable},
+		TableDestNames: map[string]string{
+			snapshotTable.Name: "lake.snapshot", resumeTable.Name: "lake.resume",
+		},
+		CDCResumeLSNs: map[string]string{resumeTable.Name: "0/19"},
+	}
+
+	require.Error(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 2)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.ElementsMatch(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.publishes)
+}
+
+func TestMultiTableBatchLostPrepareResponseCleansItsOwnedTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: table.Name, Truncate: true}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareErrByTable: map[string]error{"lake.snapshot": errors.New("prepare response lost after create")},
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.snapshot"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job), "prepare response lost")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 1)
+	require.NotEmpty(t, dest.preparedOwnershipTokens[0])
+	require.Equal(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+}
+
+func TestMultiTableBatchLaterPrepareFailureCleansNeverWrittenResumedTarget(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	first := source.SourceTableInfo{Name: "public.first", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	second := source.SourceTableInfo{Name: "public.second", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: first.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		prepareErrByTable: map[string]error{"lake.second": errors.New("prepare failed")},
+	}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{first, second}, records: records,
+		}},
+		Destination: dest,
+		Tables:      []source.SourceTableInfo{first, second},
+		TableDestNames: map[string]string{
+			first.Name: "lake.first", second.Name: "lake.second",
+		},
+		CDCResumeLSNs: map[string]string{first.Name: "0/10", second.Name: "0/10"},
+	}
+
+	require.Error(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.preparedOwnershipTokens, 2)
+	require.ElementsMatch(t, dest.preparedOwnershipTokens, dest.ownedDropTokens)
+	require.Empty(t, dest.mergeRows)
+}
+
+func TestMultiTableBatchPreservesResumedTargetAfterDirectWriteError(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	table := source.SourceTableInfo{Name: "public.events", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: table.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil)}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}, mergeErr: errors.New("lost direct-write response")}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge},
+		Source: &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{
+			tables: []source.SourceTableInfo{table}, records: records,
+		}},
+		Destination: dest, Tables: []source.SourceTableInfo{table},
+		TableDestNames: map[string]string{table.Name: "lake.events"},
+		CDCResumeLSNs:  map[string]string{table.Name: "0/10"},
+	}
+
+	require.ErrorContains(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job), "lost direct-write response")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.mergeRows, 1)
+	require.Empty(t, dest.ownedDropTokens, "a direct-write error may be a lost success response")
+}
+
+func TestMultiTableBatchRoutesResetToPublishAndResumeToMerge(t *testing.T) {
+	tableSchema := testCDCSchema(streamTestSchema())
+	resetTable := source.SourceTableInfo{Name: "public.snapshot", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	resumeTable := source.SourceTableInfo{Name: "public.resume", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	tables := []source.SourceTableInfo{resetTable, resumeTable}
+	records := make(chan source.RecordBatchResult, 4)
+	records <- source.RecordBatchResult{TableName: resetTable.Name, Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: resetTable.Name, Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "snapshot:final", DurableCommitPosition: "0/20",
+	}
+	records <- source.RecordBatchResult{
+		TableName: resumeTable.Name, Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		DurableCommitID: "wal:resume", DurableCommitPosition: "0/21",
+	}
+	close(records)
+	src := &snapshotResetMultiSource{announcingMultiTableSource: &announcingMultiTableSource{tables: tables, records: records}}
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{IncrementalStrategy: config.StrategyMerge}, Source: src, Destination: dest, Tables: tables,
+		TableDestNames: map[string]string{resetTable.Name: "lake.snapshot", resumeTable.Name: "lake.resume"},
+		CDCResumeLSNs:  map[string]string{resumeTable.Name: "0/19"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(context.Background(), job))
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "lake.snapshot", dest.publishes[0].Table)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.resume", dest.mergeCalls[0].TargetTable)
+}
+
+func (d *atomicSnapshotDestination) EvolveAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.evolves = append(d.evolves, opts)
+	return nil
+}
+
+func (d *atomicSnapshotDestination) WriteAtomicSnapshot(_ context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	var types []arrow.DataType
+	var nulls []int
+	var rows int64
+	for result := range records {
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			if result.Batch.NumCols() > 1 {
+				types = append(types, result.Batch.Column(1).DataType())
+				nulls = append(nulls, result.Batch.Column(1).NullN())
+			}
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.writes = append(d.writes, opts)
+	d.writeTypes = append(d.writeTypes, types...)
+	d.writeNulls = append(d.writeNulls, nulls...)
+	d.writeRows = append(d.writeRows, rows)
+	return d.writeErr
+}
+
+func (d *atomicSnapshotDestination) PublishAtomicSnapshot(_ context.Context, opts destination.AtomicSnapshotOptions) error {
+	d.atomicMu.Lock()
+	defer d.atomicMu.Unlock()
+	d.publishes = append(d.publishes, opts)
+	return nil
+}
+
+func TestStreamingGetRecordsLeavesSnapshotResetForFlushLoop(t *testing.T) {
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	close(records)
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	job := &IngestionJob{
+		Config:      &config.IngestConfig{Stream: true, DestTable: "lake.events"},
+		Table:       &snapshotResetSourceTable{fakeSourceTable: &fakeSourceTable{readCh: records}},
+		Destination: dest,
+		Schema:      streamTestSchema(),
+	}
+
+	out, err := job.GetRecords(context.Background(), source.ReadOptions{Streaming: true})
+	require.NoError(t, err)
+	result, ok := <-out
+	require.True(t, ok)
+	require.True(t, result.Truncate)
+	require.Empty(t, dest.begins)
+	require.Empty(t, dest.prepareCalls)
+}
+
+func TestStreamingHandlesDynamicSnapshotResetBeforeRows(t *testing.T) {
+	dest := &truncateCapableFakeDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName:                 "public.events",
+		Batch:                     int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID:           "snapshot:final",
+		DurableCommitPosition:     "0/100",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.events",
+	}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Contains(t, dest.truncateCalls, "lake.events")
+	require.Len(t, dest.writeCalls, 1)
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "0/100", dest.mergeCalls[0].CDCResumeLSN)
+}
+
+func TestStreamingUnknownTableBatchIsNotAcknowledged(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{
+		"public.known": mergeTableState("lake.known"),
+	})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName:       "public.missing",
+		Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken:     "must-not-commit",
+		DurableCommitID: "must-not-commit",
+	}
+	close(records)
+	err := loop.run(context.Background(), records)
+	require.ErrorContains(t, err, `unknown table "public.missing"`)
+	require.Empty(t, committer.committed())
+	require.Empty(t, dest.writeCalls)
+}
+
+func TestStreamingShutdownProcessesSnapshotResetBeforeFinalRows(t *testing.T) {
+	dest := &truncateCapableFakeDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName:             "public.events",
+		Batch:                 int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID:       "snapshot:page-1",
+		DurableCommitPosition: "",
+	}
+	close(records)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, loop.shutdown(ctx, records))
+
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Contains(t, dest.truncateCalls, "lake.events")
+	require.Len(t, dest.writeCalls, 1)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+}
+
+func TestStreamingShutdownAbandonsActiveAtomicSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	records := make(chan source.RecordBatchResult, 1)
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		defer close(records)
+		for i := 0; i < 32; i++ {
+			records <- source.RecordBatchResult{
+				TableName:       "public.events",
+				Batch:           int64RecordBatch(t, "id", []int64{int64(i)}, nil),
+				DurableCommitID: "snapshot:unpublished-page",
+			}
+		}
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	require.ErrorIs(t, loop.shutdown(ctx, records), context.Canceled)
+	loop.cleanup(ctx)
+	require.Less(t, time.Since(started), time.Second)
+	require.Eventually(t, func() bool {
+		select {
+		case <-producerDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Empty(t, dest.writes)
+	require.Empty(t, dest.publishes)
+	require.Len(t, dest.aborts, 1)
+	require.Equal(t, dest.begins[0].AttemptID, dest.aborts[0].AttemptID)
+}
+
+func TestStreamingCleanupDoesNotAbortAfterPublicationAttempt(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.atomicSnapshot = true
+	st.snapshotAttemptID = "unknown-publication"
+	st.atomicPublishAttempted = true
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+
+	loop.cleanup(context.Background())
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.aborts)
+}
+
+func TestStreamingCanceledClosedChannelDoesNotPublishActiveAtomicSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName:   "public.events",
+		Batch:       int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("public.events", "0/123"),
+	})
+
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, loop.run(ctx, records), context.Canceled)
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Empty(t, dest.writes)
+	require.Empty(t, dest.publishes)
+}
+
+func TestStreamingAtomicSnapshotStagesPagesUntilFinalBoundary(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "snapshot:page-1",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.writes, 1)
+	require.Empty(t, dest.publishes)
+	dest.atomicMu.Unlock()
+	require.Empty(t, dest.prepareCalls, "atomic reset must not truncate or recreate the visible target")
+
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.writes, 2)
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "0/100", dest.publishes[0].CommitToken)
+	require.Equal(t, "0/100", dest.publishes[0].CDCResumeLSN)
+	require.False(t, st.atomicSnapshot)
+}
+
+func TestStreamingAtomicSnapshotPublishesEmptySnapshotImmediately(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.empty_events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", CommitToken: snapshotStateToken("public.events", "0/200"),
+	}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Empty(t, dest.writes)
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "0/200", dest.publishes[0].CommitToken)
+}
+
+func TestStreamingAtomicSnapshotPublishesSmallFinalBatchBeforeFollowingWAL(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult)
+	done := make(chan error, 1)
+	go func() { done <- loop.run(context.Background(), records) }()
+	records <- source.RecordBatchResult{TableName: "public.events", Truncate: true}
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("public.events", "0/100"),
+	}
+	require.Eventually(t, func() bool {
+		dest.atomicMu.Lock()
+		defer dest.atomicMu.Unlock()
+		return len(dest.publishes) == 1
+	}, time.Second, time.Millisecond, "final snapshot rows must publish before waiting for another result")
+
+	records <- source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken: source.CDCStateCommitToken{Position: "0/101"},
+	}
+	close(records)
+	require.NoError(t, <-done)
+
+	dest.atomicMu.Lock()
+	require.Len(t, dest.writes, 1, "only the snapshot batch is written through hidden atomic staging")
+	require.Equal(t, "0/100", dest.publishes[0].CommitToken)
+	require.Equal(t, "0/100", dest.publishes[0].CDCResumeLSN)
+	dest.atomicMu.Unlock()
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 1, "following WAL batch uses the normal merge staging path")
+	require.Nil(t, dest.writeCalls[0].CommitToken)
+	dest.mu.Unlock()
+}
+
+func TestStreamingAtomicSnapshotsPublishIndependentlyPerTable(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	first := mergeTableState("lake.first")
+	first.isCDC = true
+	second := mergeTableState("lake.second")
+	second.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.first": first, "public.second": second})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.first"))
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.second"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.first", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("public.first", "0/300"),
+	})
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.second", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		DurableCommitID: "second:page-1",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.atomicMu.Lock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "lake.first", dest.publishes[0].Table)
+	dest.atomicMu.Unlock()
+	require.False(t, first.atomicSnapshot)
+	require.True(t, second.atomicSnapshot)
+}
+
+func TestStreamingAtomicSnapshotSchemaRefreshRestartsHiddenSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	evolveCalls := 0
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error {
+		evolveCalls++
+		return nil
+	}
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	loop.buffer(source.RecordBatchResult{
+		TableName: "public.events", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		DurableCommitID: "old-shape-page",
+	})
+	newSchema := *st.schema
+	newSchema.Columns = append(append([]schema.Column{}, st.schema.Columns...), schema.Column{
+		Name: "added", DataType: schema.TypeString, Nullable: true,
+	})
+	require.NoError(t, loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &newSchema, PrimaryKeys: []string{"id"},
+	}, st))
+
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.writes, 1, "old-shape pages are durably consumed before restarting")
+	require.Len(t, dest.begins, 1)
+	require.Len(t, dest.evolves, 1, "schema refresh must evolve hidden staging without changing the target")
+	require.Empty(t, dest.publishes)
+	require.Equal(t, "added", dest.evolves[0].Schema.Columns[len(dest.evolves[0].Schema.Columns)-1].Name)
+	require.Zero(t, evolveCalls, "visible target schema must change with final snapshot publication")
+	require.True(t, st.atomicSnapshot)
+}
+
+func TestStreamingAtomicSnapshotSchemaRefreshHonorsFreezeContract(t *testing.T) {
+	current := streamTestSchema()
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": current},
+	}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.cfg.SchemaContract = "freeze"
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	newSchema := *current
+	newSchema.Columns = append(append([]schema.Column{}, current.Columns...), schema.Column{
+		Name: "forbidden", DataType: schema.TypeString, Nullable: true,
+	})
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &newSchema, PrimaryKeys: []string{"id"},
+	}, st)
+	require.ErrorContains(t, err, "schema contract violation")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.evolves)
+	require.NotContains(t, st.schema.ColumnNames(), "forbidden")
+}
+
+func TestStreamingAtomicSnapshotRejectsDiscardRowSchemaRefresh(t *testing.T) {
+	current := streamTestSchema()
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{
+		tableSchemas: map[string]*schema.TableSchema{"lake.events": current},
+	}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.events": st})
+	loop.cfg.NoLoadTimestamp = true
+	loop.cfg.SchemaContract = "discard_row"
+	loop.evolveTable = func(context.Context, string, *schema.TableSchema) error { return nil }
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+
+	newSchema := *current
+	newSchema.Columns = append(append([]schema.Column{}, current.Columns...), schema.Column{
+		Name: "violating", DataType: schema.TypeString, Nullable: true,
+	})
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.events", Schema: &newSchema, PrimaryKeys: []string{"id"},
+	}, st)
+	require.ErrorContains(t, err, "unsupported with discard_row")
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Empty(t, dest.evolves)
+	require.NotContains(t, st.schema.ColumnNames(), "violating")
+}
+
+func TestStreamingAtomicAppendSnapshotKeepsCDCChangelogColumns(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := &streamTableState{destTable: "lake.events", schema: keylessCDCSchema(), isCDC: true}
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyAppend,
+	}, map[string]*streamTableState{"public.events": st})
+
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "public.events"))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.begins, 1)
+	require.Contains(t, dest.begins[0].TargetSchema.ColumnNames(), destination.CDCUnchangedColsColumn)
+}
+
+func TestStreamingAtomicSnapshotDefersSharedSourceAckUntilAllTablesPublish(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	first := mergeTableState("lake.first")
+	second := mergeTableState("lake.second")
+	first.isCDC, second.isCDC = true, true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge, Committer: committer,
+	}, map[string]*streamTableState{"first": first, "second": second})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "first"))
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "second"))
+
+	loop.buffer(source.RecordBatchResult{
+		TableName: "first", Batch: int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken: snapshotStateToken("first", "0/500"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+	require.Empty(t, committer.committed(), "shared source cursor cannot advance while another snapshot table is hidden")
+
+	loop.buffer(source.RecordBatchResult{
+		TableName: "second", Batch: int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken: snapshotStateToken("second", "0/500"),
+	})
+	require.NoError(t, loop.flush(context.Background()))
+	require.Equal(t, []any{snapshotStateToken("second", "0/500")}, committer.committed())
+}
+
+func TestStreamingFinalFlushPublishesPendingEmptyAtomicSnapshot(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.empty")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge}, map[string]*streamTableState{"events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "events"))
+	require.NoError(t, loop.bufferResult(source.RecordBatchResult{
+		TableName: "events", CommitToken: snapshotStateToken("events", "0/600"),
+	}))
+	require.NoError(t, loop.finalFlush(context.Background()))
+	dest.atomicMu.Lock()
+	defer dest.atomicMu.Unlock()
+	require.Len(t, dest.publishes, 1)
+	require.Equal(t, "0/600", dest.publishes[0].CommitToken)
+}
+
+func TestStreamingAtomicSnapshotDefersEvolutionUntilPublication(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	evolutions := 0
+	st.deferredEvolution = func(context.Context) error { evolutions++; return nil }
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge}, map[string]*streamTableState{"events": st})
+	require.NoError(t, loop.handleSnapshotReset(context.Background(), "events"))
+	batch := int64RecordBatch(t, "id", []int64{1}, nil)
+	defer batch.Release()
+	require.NoError(t, loop.applyDeferredEvolution(context.Background(), source.RecordBatchResult{
+		TableName: "events", Batch: batch,
+	}))
+	require.Zero(t, evolutions)
+}
+
+func TestStreamingWithoutSnapshotAppliesDeferredEvolutionBeforeData(t *testing.T) {
+	dest := &atomicSnapshotDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	evolutions := 0
+	st.deferredEvolution = func(context.Context) error { evolutions++; return nil }
+	loop := newTestLoop(dest, StreamingOptions{FlushInterval: time.Hour, FlushRecords: 1, Strategy: config.StrategyMerge}, map[string]*streamTableState{"events": st})
+	batch := int64RecordBatch(t, "id", []int64{1}, nil)
+	defer batch.Release()
+	require.NoError(t, loop.applyDeferredEvolution(context.Background(), source.RecordBatchResult{TableName: "events", Batch: batch}))
+	require.Equal(t, 1, evolutions)
+}

--- a/pkg/strategy/staging.go
+++ b/pkg/strategy/staging.go
@@ -18,7 +18,10 @@ const DefaultStagingSchema = "_bruin_staging"
 // identifiers don't collide via silent truncation and don't fail on MySQL.
 const maxStagingTableNameLen = 60
 
-const encodedStagingIdentifierPrefix = "_ingestr_hex_"
+const (
+	encodedStagingIdentifierPrefix       = "ingestr_hex_"
+	legacyEncodedStagingIdentifierPrefix = "_ingestr_hex_"
+)
 
 func GenerateStagingTableName(targetTable, suffix, stagingDataset string) string {
 	catalog, originSchema, tableName := splitCatalogSchemaTable(targetTable)
@@ -183,7 +186,7 @@ func syntheticStagingIdentifier(parts ...string) string {
 }
 
 func isUnambiguousLegacyStagingIdentifier(candidate string, parts []string) bool {
-	if strings.HasPrefix(candidate, encodedStagingIdentifierPrefix) {
+	if strings.HasPrefix(candidate, encodedStagingIdentifierPrefix) || strings.HasPrefix(candidate, legacyEncodedStagingIdentifierPrefix) {
 		return false
 	}
 	for _, part := range parts {

--- a/pkg/strategy/staging_test.go
+++ b/pkg/strategy/staging_test.go
@@ -54,6 +54,7 @@ func TestSyntheticStagingIdentifierEncodesQualificationAndAmbiguity(t *testing.T
 		{"sales.schema", "order.events"},
 		{"analytics__users"},
 		{"_ingestr_hex_616263"},
+		{"ingestr_hex_616263"},
 		{"Case Schema", "orders"},
 	}
 	seen := map[string]bool{"analytics__users": true}
@@ -69,6 +70,28 @@ func TestSyntheticStagingIdentifierEncodesQualificationAndAmbiguity(t *testing.T
 			t.Fatalf("synthetic staging identifier collision for %q: %q", parts, got)
 		}
 		seen[got] = true
+	}
+}
+
+func TestManagedStagingNameIsValidForS3Tables(t *testing.T) {
+	policy := destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingManagedSchema,
+		DefaultManagedSchema: "bruin_staging",
+	}
+	for _, target := range []string{"analytics.orders", "analytics.foo__bar"} {
+		parts := tablename.Split(GenerateReplaceStagingTableName(target, "merge", "", policy))
+		if len(parts) != 2 || parts[0] != "bruin_staging" {
+			t.Fatalf("managed staging table for %q = %q, want bruin_staging.table", target, parts)
+		}
+		if strings.HasPrefix(parts[1], "_") {
+			t.Fatalf("S3 Tables staging identifier starts with an underscore: %q", parts[1])
+		}
+		for _, r := range parts[1] {
+			if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' {
+				continue
+			}
+			t.Fatalf("S3 Tables staging identifier contains invalid character %q: %q", r, parts[1])
+		}
 	}
 }
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -4,16 +4,27 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/progress"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 )
+
+func dropManagedStagingDetached(ctx context.Context, dest destination.Destination, table, strategy string) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := dest.DropTable(cleanupCtx, table); err != nil {
+		config.Debug("[%s] Warning: failed to drop staging table %s: %v", strategy, table, err)
+	}
+}
 
 type IngestionJob struct {
 	Config       *config.IngestConfig
@@ -138,51 +149,96 @@ func (j *MultiTableIngestionJob) ApplyEvolutionFor(ctx context.Context, sourceTa
 	return applyEvolutionPlan(ctx, j.Destination, j.EvolutionPlans[sourceTable])
 }
 
+func (j *MultiTableIngestionJob) WriteSchemaFor(sourceTable string, sourceSchema *schema.TableSchema) *schema.TableSchema {
+	plan := j.EvolutionPlans[sourceTable]
+	writeSchema := sourceSchema
+	if plan != nil && plan.FinalSchema != nil {
+		writeSchema = destination.StagingIngestSchema(sourceSchema, plan.FinalSchema)
+		writeSchema = destination.PreserveSourceCDCColumnTypes(writeSchema, sourceSchema)
+	}
+	if j.Config != nil && j.Config.IncrementalStrategy == config.StrategyReplace {
+		return destination.DestinationTableSchema(writeSchema)
+	}
+	return writeSchema
+}
+
 // evolveDestinationTable builds and applies a fresh schema evolution plan for
 // one table against the destination's current shape, honoring the configured
 // schema contract. It is the mid-stream counterpart of the pipeline's startup
 // evolution, used when a CDC source re-announces a table whose source schema
 // changed while streaming.
 func evolveDestinationTable(ctx context.Context, dest destination.Destination, destTable string, sourceSchema *schema.TableSchema, cfg *config.IngestConfig) error {
+	_, err := evolveDestinationTablePlan(ctx, dest, destTable, sourceSchema, cfg)
+	return err
+}
+
+func evolveDestinationTablePlan(ctx context.Context, dest destination.Destination, destTable string, sourceSchema *schema.TableSchema, cfg *config.IngestConfig) (*schemaevolution.EvolutionPlan, error) {
+	plan, err := planDestinationSchemaEvolution(ctx, dest, destTable, sourceSchema, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyEvolutionPlan(ctx, dest, plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func planDestinationSchemaEvolution(ctx context.Context, dest destination.Destination, destTable string, sourceSchema *schema.TableSchema, cfg *config.IngestConfig) (*schemaevolution.EvolutionPlan, error) {
+	if err := schemainfer.ValidateSchema(sourceSchema); err != nil {
+		return nil, fmt.Errorf("invalid source schema for destination table %s: %w", destTable, err)
+	}
 	destSchema, err := dest.GetTableSchema(ctx, destTable)
 	if err != nil {
-		return fmt.Errorf("failed to get destination schema: %w", err)
+		return nil, fmt.Errorf("failed to get destination schema: %w", err)
 	}
 	if destSchema == nil {
-		return nil
+		return &schemaevolution.EvolutionPlan{Table: destTable, FinalSchema: destination.DestinationTableSchema(sourceSchema)}, nil
 	}
 	destSchema = destination.PreserveSourceCDCColumnTypes(destSchema, sourceSchema)
 
 	contractMode, err := schemaevolution.ParseContractMode(cfg.SchemaContract)
 	if err != nil {
-		return fmt.Errorf("failed to parse schema contract: %w", err)
+		return nil, fmt.Errorf("failed to parse schema contract: %w", err)
 	}
 	overrides, err := schemaevolution.ParseColumnOverrides(cfg.Columns)
 	if err != nil {
-		return fmt.Errorf("failed to parse column overrides: %w", err)
+		return nil, fmt.Errorf("failed to parse column overrides: %w", err)
 	}
 
-	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), destSchema, &schemaevolution.CompareOptions{Overrides: overrides})
+	comparison, err := schemaevolution.Compare(destination.DestinationTableSchema(sourceSchema), destSchema, &schemaevolution.CompareOptions{
+		Overrides: overrides, PrimaryKeys: sourceSchema.PrimaryKeys,
+	})
 	if err != nil {
-		return fmt.Errorf("failed to compare schemas: %w", err)
+		return nil, fmt.Errorf("failed to compare schemas: %w", err)
 	}
 	if !comparison.HasChanges {
-		return nil
+		return &schemaevolution.EvolutionPlan{Table: destTable, Comparison: comparison, TransformComparison: comparison, FinalSchema: destSchema}, nil
 	}
 
 	contractResult := schemaevolution.ApplyContract(schemaevolution.SchemaContract{Mode: contractMode}, comparison)
 	if contractMode == schemaevolution.ContractFreeze && contractResult.HasViolations() {
-		return contractResult.ViolationError()
+		return nil, contractResult.ViolationError()
 	}
 	filtered := &schemaevolution.SchemaComparison{
 		Changes:    contractResult.Allowed,
 		HasChanges: len(contractResult.Allowed) > 0,
 	}
-	return applyEvolutionPlan(ctx, dest, &schemaevolution.EvolutionPlan{
-		Table:       destTable,
-		Comparison:  filtered,
-		FinalSchema: schemaevolution.BuildFinalSchema(destSchema, filtered),
-	})
+	evolver, ok := dest.(schemaevolution.SchemaEvolver)
+	if !ok {
+		return &schemaevolution.EvolutionPlan{
+			Table:               destTable,
+			Comparison:          &schemaevolution.SchemaComparison{},
+			TransformComparison: comparison,
+			FinalSchema:         schemaevolution.BuildFinalSchema(destSchema, nil),
+		}, nil
+	}
+	applicable := schemaevolution.ApplicableComparison(filtered, evolver.SupportsColumnTypeChanges())
+	return &schemaevolution.EvolutionPlan{
+		Table:               destTable,
+		Comparison:          applicable,
+		TransformComparison: comparison,
+		FinalSchema:         schemaevolution.BuildFinalSchema(destSchema, applicable),
+	}, nil
 }
 
 // applyEvolutionPlan asks the destination to apply an abstract evolution plan.
@@ -230,17 +286,55 @@ func (j *MultiTableIngestionJob) ReadAll(ctx context.Context, opts source.MultiT
 	if err != nil {
 		return nil, err
 	}
-	return j.ApplyBatchTransformation(ctx, records), nil
+	return j.ApplyBatchTransformation(ctx, records)
 }
 
-func (j *MultiTableIngestionJob) ApplyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult) <-chan source.RecordBatchResult {
+func (j *MultiTableIngestionJob) ApplyBatchTransformation(ctx context.Context, records <-chan source.RecordBatchResult) (<-chan source.RecordBatchResult, error) {
 	if len(j.ColumnRenamers) > 0 || j.NormalizeTableInfo != nil {
 		records = j.applyColumnRenaming(ctx, records)
 	}
 	if j.WhitespaceTrimmer != nil {
 		records = transformer.Wrap(records, j.WhitespaceTrimmer)
 	}
-	return j.ApplyLoadTimestamp(records)
+
+	contract := ""
+	if j.Config != nil {
+		contract = j.Config.SchemaContract
+	}
+	mode, err := schemaevolution.ParseContractMode(contract)
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema contract mode: %w", err)
+	}
+	contractTransformers := make(map[string]schemaevolution.BatchTransformer)
+	aligners := make(map[string]*transformer.TypeCaster)
+	for _, table := range j.Tables {
+		plan := j.EvolutionPlans[table.Name]
+		writeSchema := j.WriteSchemaFor(table.Name, table.Schema)
+		if writeSchema != nil {
+			aligners[table.Name] = transformer.NewSafeTypeCaster(writeSchema.ToArrowSchema())
+		}
+		if plan == nil || plan.FinalSchema == nil {
+			continue
+		}
+		comparison := plan.TransformComparison
+		if comparison == nil {
+			comparison = plan.Comparison
+		}
+		switch mode {
+		case schemaevolution.ContractDiscardValue:
+			contractTransformers[table.Name] = schemaevolution.NewDiscardValueTransformer(comparison, table.Schema, plan.FinalSchema)
+		case schemaevolution.ContractDiscardRow:
+			contractTransformers[table.Name] = schemaevolution.NewDiscardRowTransformer(table.Schema, plan.FinalSchema, comparison)
+		}
+	}
+	if len(contractTransformers) > 0 {
+		records = transformMultiTableContractBatches(ctx, records, contractTransformers)
+	}
+	records = j.ApplyLoadTimestamp(records)
+	if len(aligners) > 0 {
+		records = transformMultiTableAlignedBatches(ctx, records, aligners)
+	}
+	return records, nil
 }
 
 func (j *MultiTableIngestionJob) ApplyLoadTimestamp(records <-chan source.RecordBatchResult) <-chan source.RecordBatchResult {
@@ -289,6 +383,7 @@ func (j *MultiTableIngestionJob) applyColumnRenaming(ctx context.Context, record
 				if result.Batch != nil {
 					result.Batch.Release()
 				}
+				drainAndRelease(records)
 				return
 			}
 		}
@@ -313,6 +408,55 @@ func (j *MultiTableIngestionJob) setColumnRenamer(table string, renamer *transfo
 		j.ColumnRenamers = make(map[string]*transformer.ColumnRenamer)
 	}
 	j.ColumnRenamers[table] = renamer
+}
+
+func transformMultiTableContractBatches(ctx context.Context, records <-chan source.RecordBatchResult, transforms map[string]schemaevolution.BatchTransformer) <-chan source.RecordBatchResult {
+	return transformMultiTableBatches(ctx, records, func(table string, batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+		if transform := transforms[table]; transform != nil {
+			return transform.Transform(ctx, batch)
+		}
+		batch.Retain()
+		return batch, nil
+	})
+}
+
+func transformMultiTableAlignedBatches(ctx context.Context, records <-chan source.RecordBatchResult, aligners map[string]*transformer.TypeCaster) <-chan source.RecordBatchResult {
+	return transformMultiTableBatches(ctx, records, func(table string, batch arrow.RecordBatch) (arrow.RecordBatch, error) {
+		if aligner := aligners[table]; aligner != nil {
+			return aligner.Transform(batch)
+		}
+		batch.Retain()
+		return batch, nil
+	})
+}
+
+func transformMultiTableBatches(ctx context.Context, records <-chan source.RecordBatchResult, transform func(string, arrow.RecordBatch) (arrow.RecordBatch, error)) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(out)
+		for result := range records {
+			if result.Err == nil && result.Batch != nil {
+				transformed, err := transform(result.TableName, result.Batch)
+				result.Batch.Release()
+				if err != nil {
+					result.Batch = nil
+					result.Err = err
+				} else {
+					result.Batch = transformed
+				}
+			}
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				if result.Batch != nil {
+					result.Batch.Release()
+				}
+				drainAndRelease(records)
+				return
+			}
+		}
+	}()
+	return out
 }
 
 // MultiTableStrategy extends WriteStrategy for multi-table sources.

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -46,6 +46,7 @@ type fakeSourceTable struct {
 func TestMultiTableColumnRenamingRewritesCDCMarkers(t *testing.T) {
 	ctx := context.Background()
 	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{},
 		ColumnRenamers: map[string]*transformer.ColumnRenamer{
 			"public.items": transformer.NewColumnRenamer(map[string]string{"configData": "config_data"}),
 		},
@@ -54,7 +55,9 @@ func TestMultiTableColumnRenamingRewritesCDCMarkers(t *testing.T) {
 	records <- source.RecordBatchResult{TableName: "public.items", Batch: cdcRenameRecordBatch(t, "configData", nil, `["configData"]`)}
 	close(records)
 
-	result := <-job.ApplyBatchTransformation(ctx, records)
+	out, err := job.ApplyBatchTransformation(ctx, records)
+	require.NoError(t, err)
+	result := <-out
 	require.NoError(t, result.Err)
 	require.NotNil(t, result.Batch)
 	defer result.Batch.Release()
@@ -65,6 +68,7 @@ func TestMultiTableColumnRenamingRewritesCDCMarkers(t *testing.T) {
 func TestMultiTableDynamicAnnouncementInstallsColumnRenamer(t *testing.T) {
 	ctx := context.Background()
 	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{},
 		Destination: &fakeDestination{},
 		NormalizeTableInfo: func(_ context.Context, table source.SourceTableInfo, _ string) (source.SourceTableInfo, *transformer.ColumnRenamer, error) {
 			table.Schema = &schema.TableSchema{Columns: []schema.Column{
@@ -83,7 +87,8 @@ func TestMultiTableDynamicAnnouncementInstallsColumnRenamer(t *testing.T) {
 	records <- source.RecordBatchResult{TableName: rawInfo.Name, Batch: cdcRenameRecordBatch(t, "configData", nil, `["configData"]`)}
 	close(records)
 
-	out := job.ApplyBatchTransformation(ctx, records)
+	out, err := job.ApplyBatchTransformation(ctx, records)
+	require.NoError(t, err)
 	announcement := <-out
 	require.NoError(t, announcement.Err)
 	require.Equal(t, "config_data", announcement.TableInfo.Schema.Columns[0].Name)
@@ -166,8 +171,10 @@ type fakeDestination struct {
 	prepareCalls  []destination.PrepareOptions
 	writeCalls    []destination.WriteOptions
 	swapCalls     [][2]string
+	swapOptions   []destination.SwapOptions
 	mergeCalls    []destination.MergeOptions
 	diCalls       []destination.DeleteInsertOptions
+	scdCalls      []destination.SCD2Options
 	dropCalls     []string
 	execCalls     []execCall
 	truncateCalls []string
@@ -177,6 +184,7 @@ type fakeDestination struct {
 	}
 
 	prepareErrByTable map[string]error
+	prepareHook       func(destination.PrepareOptions) error
 	writeErr          error
 	swapErr           error
 	mergeErr          error
@@ -250,6 +258,9 @@ func (d *fakeDestination) PrepareTable(ctx context.Context, opts destination.Pre
 	if d.prepareErrByTable != nil {
 		err = d.prepareErrByTable[opts.Table]
 	}
+	if err == nil && d.prepareHook != nil {
+		err = d.prepareHook(opts)
+	}
 	d.mu.Unlock()
 	return err
 }
@@ -276,6 +287,7 @@ func (d *fakeDestination) SwapTable(ctx context.Context, opts destination.SwapOp
 	d.mu.Lock()
 	d.calls = append(d.calls, "SwapTable")
 	d.swapCalls = append(d.swapCalls, [2]string{opts.StagingTable, opts.TargetTable})
+	d.swapOptions = append(d.swapOptions, opts)
 	swapErr := d.swapErr
 	d.mu.Unlock()
 	return swapErr
@@ -302,6 +314,7 @@ func (d *fakeDestination) DeleteInsertTable(ctx context.Context, opts destinatio
 func (d *fakeDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
 	d.mu.Lock()
 	d.calls = append(d.calls, "SCD2Table")
+	d.scdCalls = append(d.scdCalls, opts)
 	d.mu.Unlock()
 	return nil
 }
@@ -321,6 +334,21 @@ func (d *fakeDestination) DropTable(ctx context.Context, table string) error {
 type truncateCapableDestination struct {
 	*fakeDestination
 }
+
+type nonEvolvingPlanDestination struct {
+	destination.Destination
+	tableSchema *schema.TableSchema
+}
+
+func (d *nonEvolvingPlanDestination) GetTableSchema(context.Context, string) (*schema.TableSchema, error) {
+	return d.tableSchema, nil
+}
+
+func (d *nonEvolvingPlanDestination) GetScheme() string { return "non-evolving" }
+
+type noTypeEvolutionDestination struct{ *fakeDestination }
+
+func (d *noTypeEvolutionDestination) SupportsColumnTypeChanges() bool { return false }
 
 func (d *truncateCapableDestination) TruncateTable(ctx context.Context, table string) error {
 	d.mu.Lock()
@@ -576,6 +604,108 @@ func TestApplyEvolution_NoMigrationDoesNothing(t *testing.T) {
 	job.EvolutionPlan = &schemaevolution.EvolutionPlan{Comparison: &schemaevolution.SchemaComparison{}}
 	require.NoError(t, job.ApplyEvolution(context.Background()))
 	assert.Empty(t, dest.execCalls)
+}
+
+func TestMidStreamEvolutionPlanRespectsDestinationCapabilities(t *testing.T) {
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: true}}}
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt64, Nullable: true}}}
+	cfg := &config.IngestConfig{}
+
+	t.Run("capable", func(t *testing.T) {
+		dest := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{"events": destinationSchema}}
+		plan, err := planDestinationSchemaEvolution(context.Background(), dest, "events", sourceSchema, cfg)
+		require.NoError(t, err)
+		require.Len(t, plan.Comparison.Changes, 1)
+		require.Equal(t, schema.TypeInt64, plan.FinalSchema.Columns[0].DataType)
+	})
+
+	t.Run("unsupported type change", func(t *testing.T) {
+		dest := &noTypeEvolutionDestination{fakeDestination: &fakeDestination{
+			tableSchemas: map[string]*schema.TableSchema{"events": destinationSchema},
+		}}
+		plan, err := planDestinationSchemaEvolution(context.Background(), dest, "events", sourceSchema, cfg)
+		require.NoError(t, err)
+		require.Empty(t, plan.Comparison.Changes)
+		require.Equal(t, schema.TypeInt32, plan.FinalSchema.Columns[0].DataType)
+		st := &streamTableState{}
+		configureStreamingContractState(cfg, sourceSchema, plan, st)
+		require.Equal(t, schema.TypeInt32, st.schema.Columns[0].DataType)
+		require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int32, st.schemaAligner.OutputSchema(nil).Field(0).Type))
+	})
+
+	t.Run("non evolver", func(t *testing.T) {
+		dest := &nonEvolvingPlanDestination{tableSchema: destinationSchema}
+		plan, err := planDestinationSchemaEvolution(context.Background(), dest, "events", sourceSchema, cfg)
+		require.NoError(t, err)
+		require.Empty(t, plan.Comparison.Changes)
+		require.Equal(t, schema.TypeInt32, plan.FinalSchema.Columns[0].DataType)
+		st := &streamTableState{}
+		configureStreamingContractState(cfg, sourceSchema, plan, st)
+		require.Equal(t, schema.TypeInt32, st.schema.Columns[0].DataType)
+		require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int32, st.schemaAligner.OutputSchema(nil).Field(0).Type))
+	})
+}
+
+func TestMultiTableBatchTransformationUsesPerTableContractAndFinalSchema(t *testing.T) {
+	sourceChanged := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	sourceStable := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	finalChanged := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+		OldColumn: &schema.Column{Name: "value", DataType: schema.TypeInt64},
+		NewColumn: schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{SchemaContract: "discard_value"},
+		Tables: []source.SourceTableInfo{
+			{Name: "changed", Schema: sourceChanged},
+			{Name: "stable", Schema: sourceStable},
+		},
+		EvolutionPlans: map[string]*schemaevolution.EvolutionPlan{
+			"changed": {TransformComparison: comparison, FinalSchema: finalChanged},
+		},
+	}
+
+	makeBatch := func(value string) arrow.RecordBatch {
+		ids := array.NewInt64Builder(memory.DefaultAllocator)
+		values := array.NewStringBuilder(memory.DefaultAllocator)
+		ids.Append(1)
+		values.Append(value)
+		idArray, valueArray := ids.NewArray(), values.NewArray()
+		ids.Release()
+		values.Release()
+		batch := array.NewRecordBatch(sourceChanged.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+		idArray.Release()
+		valueArray.Release()
+		return batch
+	}
+	in := make(chan source.RecordBatchResult, 2)
+	in <- source.RecordBatchResult{TableName: "changed", Batch: makeBatch("invalid")}
+	in <- source.RecordBatchResult{TableName: "stable", Batch: makeBatch("preserved")}
+	close(in)
+
+	out, err := job.ApplyBatchTransformation(context.Background(), in)
+	require.NoError(t, err)
+	changed := <-out
+	require.NoError(t, changed.Err)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, changed.Batch.Column(1).DataType()))
+	require.True(t, changed.Batch.Column(1).IsNull(0))
+	changed.Batch.Release()
+	stable := <-out
+	require.NoError(t, stable.Err)
+	require.True(t, arrow.TypeEqual(arrow.BinaryTypes.String, stable.Batch.Column(1).DataType()))
+	require.Equal(t, "preserved", stable.Batch.Column(1).(*array.String).Value(0))
+	stable.Batch.Release()
+	require.Equal(t, finalChanged.ColumnNames(), job.WriteSchemaFor("changed", sourceChanged).ColumnNames())
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/pkg/strategy/stream_schema_change_test.go
+++ b/pkg/strategy/stream_schema_change_test.go
@@ -5,9 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +51,7 @@ func TestFlushLoopRefreshEvolvesDestinationOnNewColumn(t *testing.T) {
 		{Name: "status", DataType: schema.TypeString},
 		{Name: "priority", DataType: schema.TypeInt64},
 	}}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema, PrimaryKeys: []string{"id"}})
 	require.NoError(t, err)
 
 	require.Len(t, dest.execCalls, 1)
@@ -63,6 +67,78 @@ func TestFlushLoopRefreshEvolvesDestinationOnNewColumn(t *testing.T) {
 	assert.Equal(t, "priority", st.schema.Columns[2].Name)
 }
 
+func TestStreamingRefreshRetainsContractFinalSchemaAndAlignsNewBatches(t *testing.T) {
+	finalSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	newSourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeWidenType, ColumnName: "value", ColumnPath: []string{"value"},
+	}}}
+	dest := &fakeDestination{}
+	st := &streamTableState{destTable: "dest_items", stagingTable: "stg_items", schema: finalSchema, primaryKeys: []string{"id"}}
+	loop := newFlushLoop(dest, &config.IngestConfig{NoLoadTimestamp: true, SchemaContract: "discard_value"}, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.items": st})
+	loop.evolveTablePlan = func(context.Context, string, *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		return &schemaevolution.EvolutionPlan{TransformComparison: comparison, FinalSchema: finalSchema}, nil
+	}
+
+	require.NoError(t, loop.refreshTableSchema(context.Background(), source.SourceTableInfo{
+		Name: "public.items", Schema: newSourceSchema, PrimaryKeys: []string{"id"},
+	}, st))
+	require.Equal(t, schema.TypeInt64, st.schema.Columns[1].DataType)
+	require.NotNil(t, st.batchTransformer)
+	require.NotNil(t, st.schemaAligner)
+	require.Equal(t, schema.TypeInt64, dest.prepareCalls[0].Schema.Columns[1].DataType)
+
+	ids := array.NewInt64Builder(memory.DefaultAllocator)
+	values := array.NewStringBuilder(memory.DefaultAllocator)
+	ids.Append(1)
+	values.Append("invalid")
+	idArray, valueArray := ids.NewArray(), values.NewArray()
+	ids.Release()
+	values.Release()
+	batch := array.NewRecordBatch(newSourceSchema.ToArrowSchema(), []arrow.Array{idArray, valueArray}, 1)
+	idArray.Release()
+	valueArray.Release()
+	defer batch.Release()
+	contracted, err := st.batchTransformer.Transform(context.Background(), batch)
+	require.NoError(t, err)
+	defer contracted.Release()
+	aligned, err := st.schemaAligner.Transform(contracted)
+	require.NoError(t, err)
+	defer aligned.Release()
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, aligned.Column(1).DataType()))
+	require.True(t, aligned.Column(1).IsNull(0))
+}
+
+func TestStreamingRefreshRejectsUnsupportedDecimalBeforeMutation(t *testing.T) {
+	current := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 2,
+	}}}
+	dest := &fakeDestination{}
+	st := &streamTableState{destTable: "dest_items", stagingTable: "stg_items", schema: current}
+	loop := newFlushLoop(dest, &config.IngestConfig{NoLoadTimestamp: true}, StreamingOptions{Strategy: config.StrategyMerge}, map[string]*streamTableState{"public.items": st})
+	plannerCalled := false
+	loop.evolveTablePlan = func(context.Context, string, *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		plannerCalled = true
+		return nil, nil
+	}
+	invalid := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2,
+	}}}
+
+	err := loop.refreshTableSchema(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: invalid}, st)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "public.items")
+	require.False(t, plannerCalled)
+	require.Empty(t, dest.prepareCalls)
+	require.Equal(t, 38, st.schema.Columns[0].Precision)
+}
+
 // A re-announcement with an unchanged schema (e.g. after a new-table rebuild)
 // must stay a no-op.
 func TestFlushLoopRefreshIgnoresUnchangedSchema(t *testing.T) {
@@ -72,7 +148,7 @@ func TestFlushLoopRefreshIgnoresUnchangedSchema(t *testing.T) {
 	}})
 
 	sameSchema := &schema.TableSchema{Columns: append([]schema.Column{}, st.schema.Columns...)}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: sameSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: sameSchema, PrimaryKeys: []string{"id"}})
 	require.NoError(t, err)
 
 	assert.Empty(t, dest.execCalls)
@@ -92,7 +168,7 @@ func TestFlushLoopRefreshHandlesTypeChange(t *testing.T) {
 		{Name: "id", DataType: schema.TypeInt64},
 		{Name: "status", DataType: schema.TypeString},
 	}}
-	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema})
+	err := loop.ensureTable(context.Background(), source.SourceTableInfo{Name: "public.items", Schema: newSchema, PrimaryKeys: []string{"id"}})
 	require.NoError(t, err)
 
 	require.Len(t, dest.execCalls, 1)

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -13,8 +13,11 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -55,8 +58,11 @@ func NewStreamingExecutor(opts StreamingOptions) *StreamingExecutor {
 }
 
 func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) error {
-	if err := job.ApplyEvolution(ctx); err != nil {
-		return fmt.Errorf("failed to apply schema evolution: %w", err)
+	_, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher)
+	if !atomicSnapshots {
+		if err := job.ApplyEvolution(ctx); err != nil {
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
 	}
 
 	st := &streamTableState{
@@ -68,6 +74,24 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		partitionBy:    job.Config.PartitionBy,
 		clusterBy:      job.Config.ClusterBy,
 	}
+	if atomicSnapshots {
+		st.deferredEvolution = job.ApplyEvolution
+		if job.EvolutionPlan != nil && job.EvolutionPlan.FinalSchema != nil {
+			st.atomicTargetSchema = job.EvolutionPlan.FinalSchema
+		} else if job.DestinationSchema != nil {
+			st.atomicTargetSchema = job.DestinationSchema
+		}
+		if mode, _ := schemaevolution.ParseContractMode(job.Config.SchemaContract); mode == schemaevolution.ContractDiscardValue && st.atomicTargetSchema != nil {
+			comparison := job.SchemaComparison
+			if job.EvolutionPlan != nil && job.EvolutionPlan.TransformComparison != nil {
+				comparison = job.EvolutionPlan.TransformComparison
+			}
+			st.atomicWriteSchema = st.atomicTargetSchema
+			st.atomicBatchTransformer = schemaevolution.NewDiscardValueTransformer(comparison, st.schema, st.atomicWriteSchema)
+		}
+	}
+	loop := newFlushLoop(job.Destination, job.Config, e.opts, map[string]*streamTableState{"": st})
+	defer loop.cleanup(ctx)
 	if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
 		return err
 	}
@@ -91,6 +115,7 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		CDCSlotSuffix:              job.Config.CDCSlotSuffix,
 		CDCLegacySlotSuffix:        job.Config.CDCLegacySlotSuffix,
 		CDCSnapshotReplace:         st.isCDC && supportsCDCSnapshotReplace(job.Destination),
+		CDCStableDataBatches:       st.isCDC && e.opts.StateManager != nil && e.opts.Strategy == config.StrategyAppend,
 		Streaming:                  true,
 		FlushInterval:              job.Config.FlushInterval,
 		FlushRecords:               job.Config.FlushRecords,
@@ -103,7 +128,6 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 		records = job.Tracker.Wrap(records)
 	}
 
-	loop := newFlushLoop(job.Destination, job.Config, e.opts, map[string]*streamTableState{"": st})
 	// CDC sources re-announce their table (with its refreshed schema) after
 	// rebuilding their stream around mid-stream DDL; evolve the destination
 	// before the new-shape batches arrive. Sources that never announce
@@ -111,7 +135,9 @@ func (e *StreamingExecutor) Execute(ctx context.Context, job *IngestionJob) erro
 	loop.evolveTable = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error {
 		return evolveDestinationTable(ctx, job.Destination, destTable, newSchema, job.Config)
 	}
-	defer loop.cleanup(ctx)
+	loop.evolveTablePlan = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		return evolveDestinationTablePlan(ctx, job.Destination, destTable, newSchema, job.Config)
+	}
 	err = loop.run(ctx, records)
 	if err != nil {
 		cancelRead()
@@ -134,7 +160,10 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	}
 
 	tables := make(map[string]*streamTableState, len(job.Tables))
+	loop := newFlushLoop(job.Destination, job.Config, e.opts, tables)
+	defer loop.cleanup(ctx)
 	for _, ti := range job.Tables {
+		sourceSchema := ti.Schema
 		st := &streamTableState{
 			destTable:         job.GetDestTableName(ti.Name),
 			schema:            ti.Schema,
@@ -144,16 +173,21 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 			incarnation:       ti.Incarnation,
 			schemaFingerprint: ti.SchemaFingerprint,
 		}
-
-		if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
-			return fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+		configureStreamingContractState(job.Config, sourceSchema, job.EvolutionPlans[ti.Name], st)
+		if _, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher); atomicSnapshots {
+			sourceTable := ti.Name
+			st.deferredEvolution = func(ctx context.Context) error { return job.ApplyEvolutionFor(ctx, sourceTable) }
+			configureAtomicStreamingContractState(job.Config, sourceSchema, job.EvolutionPlans[sourceTable], st)
+		} else {
+			if err := job.ApplyEvolutionFor(ctx, ti.Name); err != nil {
+				return fmt.Errorf("failed to evolve destination table %s: %w", ti.Name, err)
+			}
 		}
+		tables[ti.Name] = st
 		if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
 			return err
 		}
-		tables[ti.Name] = st
 	}
-
 	parallelism := job.Config.ExtractParallelism
 	if parallelism <= 0 {
 		parallelism = 4
@@ -168,14 +202,15 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	resumeIncarnations, resumeSchemas := cdcResumeMetadata(job.Tables)
 	records, err := job.ReadAll(readCtx, source.MultiTableReadOptions{
 		ReadOptions: source.ReadOptions{
-			Parallelism:         parallelism,
-			PageSize:            job.Config.PageSize,
-			CDCSlotSuffix:       job.Config.CDCSlotSuffix,
-			CDCLegacySlotSuffix: job.Config.CDCLegacySlotSuffix,
-			CDCSnapshotReplace:  (anyTableHasCDC || e.opts.StateManager != nil) && supportsCDCSnapshotReplace(job.Destination),
-			Streaming:           true,
-			FlushInterval:       job.Config.FlushInterval,
-			FlushRecords:        job.Config.FlushRecords,
+			Parallelism:          parallelism,
+			PageSize:             job.Config.PageSize,
+			CDCSlotSuffix:        job.Config.CDCSlotSuffix,
+			CDCLegacySlotSuffix:  job.Config.CDCLegacySlotSuffix,
+			CDCSnapshotReplace:   (anyTableHasCDC || e.opts.StateManager != nil) && supportsCDCSnapshotReplace(job.Destination),
+			CDCStableDataBatches: anyTableHasCDC && e.opts.StateManager != nil && e.opts.Strategy == config.StrategyAppend,
+			Streaming:            true,
+			FlushInterval:        job.Config.FlushInterval,
+			FlushRecords:         job.Config.FlushRecords,
 		},
 		KnownTables:                 knownTables,
 		CDCResumeLSNs:               job.CDCResumeLSNs,
@@ -185,12 +220,10 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	if err != nil {
 		return fmt.Errorf("failed to read from multi-table source: %w", err)
 	}
-
 	if job.Tracker != nil {
 		records = job.Tracker.Wrap(records)
 	}
 
-	loop := newFlushLoop(job.Destination, job.Config, e.opts, tables)
 	// CDC sources announce tables created mid-stream before emitting their
 	// batches. Normal runs stop at that boundary so a restart can include the
 	// table in the startup set; explicit full refresh retains dynamic handling.
@@ -213,6 +246,17 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 			incarnation:       ti.Incarnation,
 			schemaFingerprint: ti.SchemaFingerprint,
 		}
+		plan, err := planDestinationSchemaEvolution(ctx, job.Destination, st.destTable, ti.Schema, job.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate schema contract for newly discovered table %s: %w", ti.Name, err)
+		}
+		configureStreamingContractState(job.Config, ti.Schema, plan, st)
+		if _, atomicSnapshots := job.Destination.(destination.AtomicSnapshotPublisher); atomicSnapshots {
+			st.deferredEvolution = func(ctx context.Context) error { return applyEvolutionPlan(ctx, job.Destination, plan) }
+			configureAtomicStreamingContractState(job.Config, ti.Schema, plan, st)
+		} else if err := applyEvolutionPlan(ctx, job.Destination, plan); err != nil {
+			return nil, fmt.Errorf("failed to evolve newly discovered table %s: %w", ti.Name, err)
+		}
 		for sourceTable, destTable := range job.TableDestNames {
 			if sourceTable != ti.Name && destTable == st.destTable {
 				return nil, fmt.Errorf("multi-table destination collision: source tables %q and %q both map to destination table %q", sourceTable, ti.Name, st.destTable)
@@ -234,9 +278,11 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		pendingSafeBoundary := e.opts.StateManager != nil && e.opts.StateManager.HasPendingLateSnapshotBoundary(ti.Name)
 		if pendingSafeBoundary {
 			if err := e.prepareLateStagingTable(ctx, job.Destination, job.Config, st); err != nil {
+				cleanupUnregisteredStreamTable(ctx, job.Destination, st)
 				return nil, err
 			}
 		} else if err := e.prepareTable(ctx, job.Destination, job.Config, st); err != nil {
+			cleanupUnregisteredStreamTable(ctx, job.Destination, st)
 			return nil, err
 		}
 		if job.TableDestNames == nil {
@@ -245,9 +291,14 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 		job.TableDestNames[ti.Name] = st.destTable
 		if e.opts.StateManager != nil {
 			if err := e.opts.StateManager.RegisterTableState(ctx, ti.Name, st.destTable, ti.Incarnation, ti.SchemaFingerprint); err != nil {
+				cleanupUnregisteredStreamTable(ctx, job.Destination, st)
 				return nil, err
 			}
 		}
+		if job.EvolutionPlans == nil {
+			job.EvolutionPlans = make(map[string]*schemaevolution.EvolutionPlan)
+		}
+		job.EvolutionPlans[ti.Name] = plan
 		return st, nil
 	}
 	// CDC sources also re-announce a table (with its refreshed schema) after
@@ -257,13 +308,36 @@ func (e *StreamingExecutor) ExecuteMultiTable(ctx context.Context, job *MultiTab
 	loop.evolveTable = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error {
 		return evolveDestinationTable(ctx, job.Destination, destTable, newSchema, job.Config)
 	}
-	defer loop.cleanup(ctx)
+	loop.evolveTablePlan = func(ctx context.Context, destTable string, newSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error) {
+		return evolveDestinationTablePlan(ctx, job.Destination, destTable, newSchema, job.Config)
+	}
 	err = loop.run(ctx, records)
 	if err != nil {
 		cancelRead()
 		drainAndReleaseUntil(records, streamAbortDrainTimeout)
 	}
 	return err
+}
+
+func cleanupUnregisteredStreamTable(ctx context.Context, dest destination.Destination, st *streamTableState) {
+	if st == nil || connectorLeaseLoss(ctx) != nil {
+		return
+	}
+	if st.targetCreatedByRun && !st.atomicPublishAttempted {
+		cleanupFailedOwnedDirectReplace(ctx, dest, st.destTable, true, st.targetOwnershipToken)
+		st.targetCreatedByRun = false
+	}
+	if st.stagingTable == "" {
+		return
+	}
+	cleanupCtx, cancel := detachedLeaseContext(ctx, streamFinalFlushTimeout)
+	defer cancel()
+	if connectorLeaseLoss(cleanupCtx) != nil {
+		return
+	}
+	if err := dest.DropTable(cleanupCtx, st.stagingTable); err != nil {
+		config.Debug("[STREAM] Warning: failed to drop unregistered staging table %s: %v", st.stagingTable, err)
+	}
 }
 
 func (e *StreamingExecutor) lateTargetPrepareOptions(st *streamTableState) destination.PrepareOptions {
@@ -308,6 +382,52 @@ func (e *StreamingExecutor) prepareLateStagingTable(ctx context.Context, dest de
 	return connectorLeaseLoss(ctx)
 }
 
+func configureStreamingContractState(cfg *config.IngestConfig, sourceSchema *schema.TableSchema, plan *schemaevolution.EvolutionPlan, st *streamTableState) {
+	if plan == nil || plan.FinalSchema == nil {
+		st.schema = sourceSchema
+		st.batchTransformer = nil
+		st.schemaAligner = nil
+		return
+	}
+	st.schema = destination.StagingIngestSchema(sourceSchema, plan.FinalSchema)
+	st.schema = destination.PreserveSourceCDCColumnTypes(st.schema, sourceSchema)
+	comparison := plan.TransformComparison
+	if comparison == nil {
+		comparison = plan.Comparison
+	}
+	mode, _ := schemaevolution.ParseContractMode(cfg.SchemaContract)
+	switch mode {
+	case schemaevolution.ContractDiscardValue:
+		st.batchTransformer = schemaevolution.NewDiscardValueTransformer(comparison, sourceSchema, plan.FinalSchema)
+	case schemaevolution.ContractDiscardRow:
+		st.batchTransformer = schemaevolution.NewDiscardRowTransformer(sourceSchema, plan.FinalSchema, comparison)
+	default:
+		st.batchTransformer = nil
+	}
+	st.schemaAligner = transformer.NewSafeTypeCaster(st.schema.ToArrowSchema())
+}
+
+func configureAtomicStreamingContractState(cfg *config.IngestConfig, sourceSchema *schema.TableSchema, plan *schemaevolution.EvolutionPlan, st *streamTableState) {
+	if plan == nil || plan.FinalSchema == nil {
+		return
+	}
+	st.atomicTargetSchema = plan.FinalSchema
+	mode, _ := schemaevolution.ParseContractMode(cfg.SchemaContract)
+	if mode != schemaevolution.ContractDiscardValue && mode != schemaevolution.ContractDiscardRow {
+		return
+	}
+	comparison := plan.TransformComparison
+	if comparison == nil {
+		comparison = plan.Comparison
+	}
+	st.atomicWriteSchema = st.schema
+	if mode == schemaevolution.ContractDiscardValue {
+		st.atomicBatchTransformer = schemaevolution.NewDiscardValueTransformer(comparison, sourceSchema, plan.FinalSchema)
+	} else {
+		st.atomicBatchTransformer = schemaevolution.NewDiscardRowTransformer(sourceSchema, plan.FinalSchema, comparison)
+	}
+}
+
 // multiTableDestName computes the destination table name for a source table
 // discovered mid-stream, matching the pipeline's upfront naming.
 func multiTableDestName(dest destination.Destination, ti source.SourceTableInfo) string {
@@ -343,10 +463,28 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 	switch e.opts.Strategy {
 	case config.StrategyMerge:
 		if st.isCDC && len(st.primaryKeys) == 0 {
+			idempotent, ok := dest.(destination.IdempotentCommitTokenWriter)
+			if !ok || !idempotent.SupportsIdempotentCommitTokenWrites() {
+				return fmt.Errorf(
+					"streaming merge for keyless CDC table %s requires destination support for idempotent commit-token writes",
+					st.destTable,
+				)
+			}
 			// Keyless CDC table: no key to merge on, so its change log lands
 			// directly in the destination table and flush skips the merge
 			// (stagingTable stays empty). See isAppendOnlyCDCTable in merge.go.
 			return prepareAppendOnlyCDCTable(ctx, dest, st.destTable, st.schema)
+		}
+		if _, ok := dest.(destination.DirectMergeWriter); ok {
+			st.directMerge = true
+			return prepareMergeTarget(ctx, dest, mergeTableParams{
+				DestTable:   st.destTable,
+				Schema:      st.schema,
+				PrimaryKeys: st.primaryKeys,
+				PartitionBy: st.partitionBy,
+				ClusterBy:   st.clusterBy,
+				IsCDC:       st.isCDC,
+			})
 		}
 		st.stagingTable = managedStagingTableName(dest, st.destTable, "stream", cfg.StagingDataset)
 		output.Statusf("[STREAM] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), st.stagingTable)
@@ -373,14 +511,33 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 		if st.isCDC {
 			prepSchema = st.schema
 		}
+		if _, atomicSnapshots := dest.(destination.AtomicSnapshotPublisher); atomicSnapshots && st.isCDC {
+			existingSchema, err := dest.GetTableSchema(ctx, st.destTable)
+			if err != nil {
+				return fmt.Errorf("failed to inspect destination table %s before atomic append streaming: %w", st.destTable, err)
+			}
+			if existingSchema != nil {
+				return nil
+			}
+			st.targetOwnershipToken = newTargetOwnershipToken(dest, false)
+			if st.targetOwnershipToken == "" {
+				return fmt.Errorf("destination %s cannot safely clean up a failed atomic append target", dest.GetScheme())
+			}
+			st.targetCreatedByRun = true
+			prepSchema = st.schema
+			if st.atomicTargetSchema != nil {
+				prepSchema = st.atomicTargetSchema
+			}
+		}
 		if err := dest.PrepareTable(ctx, destination.PrepareOptions{
-			Table:       st.destTable,
-			Schema:      prepSchema,
-			DropFirst:   false,
-			PrimaryKeys: nil,
-			PartitionBy: st.partitionBy,
-			ClusterBy:   st.clusterBy,
-			CDCMode:     st.isCDC,
+			Table:          st.destTable,
+			Schema:         prepSchema,
+			DropFirst:      false,
+			PrimaryKeys:    nil,
+			PartitionBy:    st.partitionBy,
+			ClusterBy:      st.clusterBy,
+			CDCMode:        st.isCDC,
+			OwnershipToken: st.targetOwnershipToken,
 		}); err != nil {
 			return fmt.Errorf("failed to prepare destination table %s: %w", st.destTable, err)
 		}
@@ -393,19 +550,40 @@ func (e *StreamingExecutor) prepareTable(ctx context.Context, dest destination.D
 // streamTableState tracks one destination table's buffered batches across
 // flush cycles. stagingTable is empty in append mode.
 type streamTableState struct {
-	destTable         string
-	stagingTable      string
-	schema            *schema.TableSchema
-	primaryKeys       []string
-	incrementalKey    string
-	isCDC             bool
-	partitionBy       string
-	clusterBy         []string
-	incarnation       string
-	schemaFingerprint string
+	sourceTable            string
+	destTable              string
+	stagingTable           string
+	schema                 *schema.TableSchema
+	primaryKeys            []string
+	incrementalKey         string
+	isCDC                  bool
+	partitionBy            string
+	clusterBy              []string
+	incarnation            string
+	schemaFingerprint      string
+	directMerge            bool
+	atomicSnapshot         bool
+	atomicTargetSchema     *schema.TableSchema
+	atomicWriteSchema      *schema.TableSchema
+	atomicBatchTransformer schemaevolution.BatchTransformer
+	batchTransformer       schemaevolution.BatchTransformer
+	schemaAligner          *transformer.TypeCaster
+	snapshotAttemptID      string
+	atomicPublishAttempted bool
+	targetCreatedByRun     bool
+	targetOwnershipToken   string
+	snapshotStarted        bool
+	deferredEvolution      func(context.Context) error
+	evolutionApplied       bool
 
-	pending     []arrow.RecordBatch
-	pendingRows int64
+	pending          []arrow.RecordBatch
+	pendingPositions []managedCDCDataWriteBoundary
+	pendingRows      int64
+
+	durableCommitID       any
+	durableCommitPosition string
+	checkpointID          any
+	checkpointPosition    string
 }
 
 type flushLoop struct {
@@ -423,7 +601,8 @@ type flushLoop struct {
 	// source schema changed mid-stream (the source re-announces it with the
 	// refreshed schema after rebuilding its stream). Nil means mid-stream
 	// schema changes are unsupported and re-announcements are ignored.
-	evolveTable func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error
+	evolveTable     func(ctx context.Context, destTable string, newSchema *schema.TableSchema) error
+	evolveTablePlan func(ctx context.Context, destTable string, newSchema *schema.TableSchema) (*schemaevolution.EvolutionPlan, error)
 
 	buffered int64 // rows buffered across all tables
 
@@ -433,6 +612,9 @@ type flushLoop struct {
 	lastToken    any
 	tokenDirty   bool
 	pendingState source.CDCStateCommitToken
+
+	lastDurableCommitID       any
+	lastDurableCommitPosition string
 	// pendingTruncates contains source tables whose previous snapshot marker was
 	// invalidated before applying a replicated WAL TRUNCATE. The next durable
 	// source position completes the new empty-table snapshot boundary.
@@ -440,6 +622,16 @@ type flushLoop struct {
 	legacyFinalized  bool
 
 	cycles int64
+}
+
+type managedCDCDataWriteToken struct {
+	SourceTable string
+	DataBatchID string
+}
+
+type managedCDCDataWriteBoundary struct {
+	Token    managedCDCDataWriteToken
+	Position string
 }
 
 func newFlushLoop(dest destination.Destination, cfg *config.IngestConfig, opts StreamingOptions, tables map[string]*streamTableState) *flushLoop {
@@ -467,6 +659,9 @@ func (l *flushLoop) run(ctx context.Context, records <-chan source.RecordBatchRe
 			if !ok {
 				// Source ended on its own (e.g. its context was cancelled and
 				// it closed the channel before we observed ctx.Done).
+				if ctx.Err() != nil && l.hasActiveAtomicSnapshot() {
+					return ctx.Err()
+				}
 				return l.finalFlush(ctx)
 			}
 			if res.Err != nil {
@@ -540,6 +735,12 @@ func (l *flushLoop) processResult(ctx context.Context, res source.RecordBatchRes
 			return err
 		}
 	}
+	if err := l.applyDeferredEvolution(ctx, res); err != nil {
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+		return err
+	}
 	if err := l.handleResult(ctx, res); err != nil {
 		return err
 	}
@@ -565,7 +766,17 @@ func (l *flushLoop) invalidateSnapshot(ctx context.Context, invalidation source.
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := l.opts.StateManager.InvalidateSnapshot(ctx, invalidation.TableName, st.destTable, invalidation.Incarnation); err != nil {
+	if st.atomicSnapshot {
+		if st.atomicPublishAttempted {
+			return fmt.Errorf("cannot invalidate snapshot for table %s while atomic publication outcome is unknown", st.destTable)
+		}
+		if err := l.abortUnpublishedAtomicSnapshot(ctx, st); err != nil {
+			return fmt.Errorf("failed to abort stale atomic snapshot for table %s: %w", st.destTable, err)
+		}
+	}
+	if err := l.opts.StateManager.InvalidateSnapshotStatePreservingDestination(
+		ctx, invalidation.TableName, st.destTable, invalidation.Incarnation, invalidation.SchemaFingerprint,
+	); err != nil {
 		return err
 	}
 	st.incarnation = invalidation.Incarnation
@@ -584,8 +795,7 @@ func (l *flushLoop) tableState(sourceTable string) (*streamTableState, bool) {
 
 func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResult) error {
 	if !res.Truncate {
-		l.buffer(res)
-		return nil
+		return l.bufferResult(res)
 	}
 
 	if l.buffered > 0 || l.tokenDirty {
@@ -607,7 +817,7 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 			return fmt.Errorf("cannot resolve source table for CDC truncate")
 		}
 		if res.CDCWALTruncate {
-			if err := l.opts.StateManager.InvalidateSnapshot(ctx, stateTable, st.destTable, st.incarnation); err != nil {
+			if err := l.opts.StateManager.InvalidateSnapshotPreservingDestination(ctx, stateTable, st.destTable, st.incarnation); err != nil {
 				return fmt.Errorf("failed to invalidate CDC state before source truncate for %s: %w", stateTable, err)
 			}
 		}
@@ -617,20 +827,61 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 				return err
 			}
 			if handled {
-				l.buffer(res)
-				return nil
+				return l.bufferResult(res)
 			}
 		}
-		if err := l.opts.StateManager.BindDestinationIncarnation(ctx, stateTable, st.destTable); err != nil {
-			return fmt.Errorf("failed to bind CDC destination before source truncate for %s: %w", stateTable, err)
+		if !res.CDCWALTruncate {
+			if err := l.opts.StateManager.BindDestinationIncarnation(ctx, stateTable, st.destTable); err != nil {
+				return fmt.Errorf("failed to bind CDC destination before source truncate for %s: %w", stateTable, err)
+			}
 		}
 	}
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
+	if !res.CDCWALTruncate {
+		if publisher, ok := l.dest.(destination.AtomicSnapshotPublisher); ok {
+			if st.snapshotStarted && st.snapshotAttemptID != "" {
+				if st.atomicPublishAttempted {
+					return fmt.Errorf("cannot restart atomic snapshot for table %s while publication outcome is unknown", st.destTable)
+				}
+				if err := l.abortUnpublishedAtomicSnapshot(ctx, st); err != nil {
+					return fmt.Errorf("failed to abort previous atomic snapshot for table %s: %w", st.destTable, err)
+				}
+			}
+			st.snapshotStarted = true
+			st.snapshotAttemptID = uuid.NewString()
+			st.atomicPublishAttempted = false
+			expectedIncarnation := ""
+			if l.opts.StateManager != nil && l.opts.StateManager.dest != nil {
+				expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(stateTable)
+				if expectedIncarnation == "" {
+					return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+				}
+			}
+			if err := publisher.BeginAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+				Table: st.destTable, Schema: l.atomicSnapshotWriteSchema(st), TargetSchema: l.atomicSnapshotTargetSchema(st), PrimaryKeys: st.primaryKeys,
+				PartitionBy: st.partitionBy, ClusterBy: st.clusterBy, Parallelism: l.parallelism(), AttemptID: st.snapshotAttemptID,
+				CDCExpectedIncarnation: expectedIncarnation,
+			}); err != nil {
+				return fmt.Errorf("failed to begin atomic snapshot for table %s: %w", st.destTable, err)
+			}
+			st.atomicSnapshot = true
+			return l.bufferResult(res)
+		}
+	}
 	var truncateErr error
 	if res.CDCWALTruncate {
-		truncateErr = destination.ApplyCDCTruncate(ctx, l.dest, st.destTable)
+		if l.opts.StateManager != nil {
+			truncateErr = destination.ApplyCDCTruncateIfIncarnation(
+				ctx,
+				l.dest,
+				st.destTable,
+				l.opts.StateManager.BoundDestinationIncarnation(stateTable),
+			)
+		} else {
+			truncateErr = destination.ApplyCDCTruncate(ctx, l.dest, st.destTable)
+		}
 	} else {
 		truncateErr = destination.ApplyTruncate(ctx, l.dest, st.destTable)
 	}
@@ -643,8 +894,7 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 	if stateTable != "" && res.CDCWALTruncate {
 		l.pendingTruncates[stateTable] = st.incarnation
 	}
-	l.buffer(res)
-	return nil
+	return l.bufferResult(res)
 }
 
 func (l *flushLoop) stateSourceTable(recordTable string) string {
@@ -655,11 +905,47 @@ func (l *flushLoop) stateSourceTable(recordTable string) string {
 		return l.cfg.SourceTable
 	}
 	if len(l.tables) == 1 {
-		for table := range l.tables {
+		for table, st := range l.tables {
+			if table == "" && st.sourceTable != "" {
+				return st.sourceTable
+			}
 			return table
 		}
 	}
 	return ""
+}
+
+func (l *flushLoop) abortUnpublishedAtomicSnapshot(ctx context.Context, st *streamTableState) error {
+	aborter, ok := l.dest.(destination.AtomicSnapshotAborter)
+	if !ok {
+		return fmt.Errorf("destination %s cannot abort owned atomic snapshot attempts", l.dest.GetScheme())
+	}
+	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), streamFinalFlushTimeout)
+	defer cancel()
+	if err := aborter.AbortAtomicSnapshot(abortCtx, destination.AtomicSnapshotOptions{
+		Table: st.destTable, AttemptID: st.snapshotAttemptID,
+	}); err != nil {
+		return err
+	}
+	st.atomicSnapshot = false
+	st.snapshotStarted = false
+	st.snapshotAttemptID = ""
+	return nil
+}
+
+func (l *flushLoop) applyDeferredEvolution(ctx context.Context, res source.RecordBatchResult) error {
+	if res.Batch == nil {
+		return nil
+	}
+	st, ok := l.tableState(res.TableName)
+	if !ok || st.deferredEvolution == nil || st.evolutionApplied || st.snapshotStarted {
+		return nil
+	}
+	if err := st.deferredEvolution(ctx); err != nil {
+		return fmt.Errorf("failed to apply deferred schema evolution for table %s: %w", st.destTable, err)
+	}
+	st.evolutionApplied = true
+	return nil
 }
 
 // ensureTable provisions per-table state for a table announced mid-stream.
@@ -702,14 +988,27 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	}
 	st.incarnation = ti.Incarnation
 	st.schemaFingerprint = ti.SchemaFingerprint
-	if l.evolveTable == nil || ti.Schema == nil {
+	if ti.Schema == nil {
+		return nil
+	}
+	if err := schemainfer.ValidateSchema(ti.Schema); err != nil {
+		return fmt.Errorf("invalid refreshed schema for source table %s: %w", ti.Name, err)
+	}
+	if l.evolveTable == nil && l.evolveTablePlan == nil {
 		return nil
 	}
 	newSchema := ti.Schema
 	if !l.cfg.NoLoadTimestamp {
 		newSchema = withLoadTimestampColumn(newSchema)
 	}
-	if st.schema.SameColumnShape(newSchema) {
+	keysChanged := !equalFoldedStrings(st.primaryKeys, ti.PrimaryKeys)
+	if keysChanged {
+		return fmt.Errorf(
+			"streaming primary-key change for table %s from %v to %v requires a new snapshot; stop the stream and run a full refresh",
+			st.destTable, st.primaryKeys, ti.PrimaryKeys,
+		)
+	}
+	if st.schema.SameColumnShape(newSchema) && !keysChanged {
 		return nil
 	}
 
@@ -719,18 +1018,60 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := l.evolveTable(ctx, st.destTable, newSchema); err != nil {
+	if publisher, ok := l.dest.(destination.AtomicSnapshotPublisher); ok && st.atomicSnapshot {
+		contractMode, err := schemaevolution.ParseContractMode(l.cfg.SchemaContract)
+		if err != nil {
+			return fmt.Errorf("failed to parse schema contract for atomic snapshot refresh: %w", err)
+		}
+		if contractMode == schemaevolution.ContractDiscardRow {
+			return fmt.Errorf("atomic snapshot schema refresh for table %s is unsupported with discard_row because refreshed rows cannot be published without contract filtering", st.destTable)
+		}
+		plan, err := planDestinationSchemaEvolution(ctx, l.dest, st.destTable, newSchema, l.cfg)
+		if err != nil {
+			return fmt.Errorf("failed to validate atomic snapshot schema change for table %s: %w", st.destTable, err)
+		}
+		configureStreamingContractState(l.cfg, newSchema, plan, st)
+		st.atomicTargetSchema = plan.FinalSchema
+		st.atomicWriteSchema = nil
+		st.atomicBatchTransformer = nil
+		if contractMode == schemaevolution.ContractDiscardValue {
+			st.atomicWriteSchema = st.schema
+			st.atomicBatchTransformer = schemaevolution.NewDiscardValueTransformer(plan.TransformComparison, newSchema, plan.FinalSchema)
+		}
+		st.schemaAligner = transformer.NewSafeTypeCaster(l.atomicSnapshotWriteSchema(st).ToArrowSchema())
+		st.isCDC = hasCDCColumns(newSchema)
+		st.primaryKeys = append([]string(nil), ti.PrimaryKeys...)
+		_, supportsDirectMerge := l.dest.(destination.DirectMergeWriter)
+		st.directMerge = len(st.primaryKeys) > 0 && supportsDirectMerge
+		if err := publisher.EvolveAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+			Table: st.destTable, Schema: l.atomicSnapshotWriteSchema(st), TargetSchema: l.atomicSnapshotTargetSchema(st), PrimaryKeys: st.primaryKeys,
+			PartitionBy: st.partitionBy, ClusterBy: st.clusterBy, Parallelism: l.parallelism(), AttemptID: st.snapshotAttemptID,
+		}); err != nil {
+			return fmt.Errorf("failed to evolve atomic snapshot staging for table %s after schema change: %w", st.destTable, err)
+		}
+		if err := connectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		output.Statusf("[STREAM] %s | Snapshot schema change staged for %s (dest: %s)\n", time.Now().Format("15:04:05"), ti.Name, st.destTable)
+		return nil
+	}
+	var plan *schemaevolution.EvolutionPlan
+	if l.evolveTablePlan != nil {
+		var err error
+		plan, err = l.evolveTablePlan(ctx, st.destTable, newSchema)
+		if err != nil {
+			return fmt.Errorf("failed to evolve destination table %s: %w", st.destTable, err)
+		}
+	} else if err := l.evolveTable(ctx, st.destTable, newSchema); err != nil {
 		return fmt.Errorf("failed to evolve destination table %s: %w", st.destTable, err)
 	}
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 
-	st.schema = newSchema
+	configureStreamingContractState(l.cfg, newSchema, plan, st)
 	st.isCDC = hasCDCColumns(newSchema)
-	if len(ti.PrimaryKeys) > 0 {
-		st.primaryKeys = ti.PrimaryKeys
-	}
+	st.primaryKeys = append([]string(nil), ti.PrimaryKeys...)
 	if st.stagingTable != "" {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
@@ -755,7 +1096,38 @@ func (l *flushLoop) refreshTableSchema(ctx context.Context, ti source.SourceTabl
 	return nil
 }
 
+func equalFoldedStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !strings.EqualFold(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (l *flushLoop) buffer(res source.RecordBatchResult) {
+	if err := l.bufferResult(res); err != nil {
+		panic(err)
+	}
+}
+
+func (l *flushLoop) bufferResult(res source.RecordBatchResult) error {
+	var st *streamTableState
+	if res.Batch != nil && res.Batch.NumRows() > 0 {
+		var ok bool
+		st, ok = l.tableState(res.TableName)
+		if !ok {
+			rows := res.Batch.NumRows()
+			res.Batch.Release()
+			return fmt.Errorf("streaming received %d row(s) for unknown table %q", rows, res.TableName)
+		}
+		if res.TableName != "" {
+			st.sourceTable = res.TableName
+		}
+	}
 	if res.CommitToken != nil {
 		l.lastToken = res.CommitToken
 		l.tokenDirty = true
@@ -802,22 +1174,55 @@ func (l *flushLoop) buffer(res source.RecordBatchResult) {
 			}
 		}
 	}
+	if l.opts.StateManager == nil && res.DurableCheckpointID != nil {
+		if res.DurableCheckpointTable == "" {
+			l.lastDurableCommitID = res.DurableCheckpointID
+			l.lastDurableCommitPosition = res.DurableCheckpointPosition
+		} else if checkpointState, ok := l.tableState(res.DurableCheckpointTable); ok {
+			checkpointState.checkpointID = res.DurableCheckpointID
+			checkpointState.checkpointPosition = res.DurableCheckpointPosition
+		} else {
+			config.Debug("[STREAM] Ignoring checkpoint for unknown table %q", res.DurableCheckpointTable)
+		}
+	}
+	if res.Batch != nil && res.Batch.NumRows() == 0 {
+		res.Batch.Release()
+		res.Batch = nil
+	}
 	if res.Batch == nil {
-		return
+		if l.opts.StateManager == nil && res.DurableCheckpointID == nil && res.DurableCommitID != nil {
+			if checkpointState, ok := l.tableState(res.TableName); ok && res.TableName != "" {
+				checkpointState.checkpointID = res.DurableCommitID
+				checkpointState.checkpointPosition = res.DurableCommitPosition
+			} else {
+				l.lastDurableCommitID = res.DurableCommitID
+				l.lastDurableCommitPosition = res.DurableCommitPosition
+			}
+		}
+		return nil
 	}
-	if res.Batch.NumRows() == 0 {
-		res.Batch.Release()
-		return
+	if l.opts.StateManager == nil && res.DurableCommitID != nil {
+		st.durableCommitID = res.DurableCommitID
+		st.durableCommitPosition = res.DurableCommitPosition
 	}
-	st, ok := l.tableState(res.TableName)
-	if !ok {
-		config.Debug("[STREAM] Dropping batch for unknown table %q (%d rows)", res.TableName, res.Batch.NumRows())
-		res.Batch.Release()
-		return
+	if l.managedCDCNeedsDataWriteIdentity(st) {
+		token, ok := res.CommitToken.(source.CDCStateCommitToken)
+		if !ok || token.Position == "" || token.DataBatchID == "" {
+			res.Batch.Release()
+			return fmt.Errorf("managed CDC data batch for table %s has no typed source position and stable data batch identity", res.TableName)
+		}
+		st.pendingPositions = append(st.pendingPositions, managedCDCDataWriteBoundary{
+			Token: managedCDCDataWriteToken{
+				SourceTable: l.stateSourceTable(res.TableName),
+				DataBatchID: token.DataBatchID,
+			},
+			Position: token.Position,
+		})
 	}
 	st.pending = append(st.pending, res.Batch)
 	st.pendingRows += res.Batch.NumRows()
 	l.buffered += res.Batch.NumRows()
+	return nil
 }
 
 // flush writes all buffered batches to the destination (one write+merge cycle
@@ -842,18 +1247,21 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			if !ok {
 				return fmt.Errorf("CDC snapshot state references unknown table %q", sourceTable)
 			}
+			if st.atomicSnapshot {
+				continue
+			}
 			if err := l.opts.StateManager.BindDestinationIncarnation(ctx, sourceTable, st.destTable); err != nil {
 				return fmt.Errorf("streaming flush: failed to bind CDC destination for %s: %w", sourceTable, err)
 			}
 		}
 	}
-
 	type flushWork struct {
 		name string
 		st   *streamTableState
 
-		batches []arrow.RecordBatch
-		rows    int64
+		batches   []arrow.RecordBatch
+		positions []managedCDCDataWriteBoundary
+		rows      int64
 	}
 
 	var work []flushWork
@@ -861,10 +1269,18 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if st.pendingRows == 0 {
 			continue
 		}
-		work = append(work, flushWork{name: name, st: st, batches: st.pending, rows: st.pendingRows})
+		work = append(work, flushWork{name: name, st: st, batches: st.pending, positions: st.pendingPositions, rows: st.pendingRows})
 		l.buffered -= st.pendingRows
 		st.pending = nil
+		st.pendingPositions = nil
 		st.pendingRows = 0
+	}
+	releaseWork := func() {
+		for _, pending := range work {
+			for _, batch := range pending.batches {
+				batch.Release()
+			}
+		}
 	}
 	keylessSnapshots := make(map[string]*streamTableState)
 	if l.opts.StateManager != nil && l.pendingState.Position != "" {
@@ -876,7 +1292,8 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			if _, freshSnapshot := l.pendingState.SnapshotPositions[sourceTable]; freshSnapshot {
 				continue
 			}
-			if err := l.opts.StateManager.InvalidateSnapshot(ctx, sourceTable, w.st.destTable, w.st.incarnation); err != nil {
+			if err := l.opts.StateManager.InvalidateSnapshotPreservingDestination(ctx, sourceTable, w.st.destTable, w.st.incarnation); err != nil {
+				releaseWork()
 				return fmt.Errorf("streaming flush: failed to invalidate keyless CDC state for %s: %w", sourceTable, err)
 			}
 			keylessSnapshots[sourceTable] = w.st
@@ -889,6 +1306,76 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if displayName == "" {
 			displayName = st.destTable
 		}
+		if l.managedCDCNeedsDataWriteIdentity(st) {
+			if len(w.positions) != len(w.batches) {
+				for _, batch := range w.batches {
+					batch.Release()
+				}
+				return fmt.Errorf("streaming flush: managed CDC table %s lost source write boundaries", displayName)
+			}
+			sourceTable := l.stateSourceTable(w.name)
+			if sourceTable == "" {
+				for _, batch := range w.batches {
+					batch.Release()
+				}
+				return fmt.Errorf("streaming flush: managed CDC table %s has no source table identity", displayName)
+			}
+			expectedIncarnation := l.opts.StateManager.BoundDestinationIncarnation(sourceTable)
+			if expectedIncarnation == "" {
+				for _, batch := range w.batches {
+					batch.Release()
+				}
+				return fmt.Errorf("streaming flush: managed CDC table %s has no bound destination incarnation", displayName)
+			}
+			for i, batch := range w.batches {
+				boundary := w.positions[i]
+				writeToken := boundary.Token
+				if writeToken.SourceTable != sourceTable {
+					for _, unstarted := range w.batches[i:] {
+						unstarted.Release()
+					}
+					return fmt.Errorf("streaming flush: managed CDC table %s has inconsistent source write identity", displayName)
+				}
+				writeOpts := destination.WriteOptions{
+					Table: st.destTable, Schema: st.schema, Parallelism: l.parallelism(), CDCExpectedIncarnation: expectedIncarnation,
+					StagingBucket: l.cfg.StagingBucket, LoaderFileSize: l.cfg.LoaderFileSize, LoaderFileFormat: l.cfg.LoaderFileFormat,
+					CommitToken: writeToken, SkipCDCResume: true,
+				}
+				records := (<-chan source.RecordBatchResult)(prefilledBatchChannel([]arrow.RecordBatch{batch}))
+				if col, ok := loadTimestampColumn(st.schema); ok {
+					records = transformer.Wrap(records, transformer.NewLoadTimestamp(col, loadTimestamp))
+				}
+				if st.batchTransformer != nil {
+					records = schemaevolution.TransformBatchStream(ctx, records, st.batchTransformer)
+				}
+				if st.schemaAligner != nil {
+					records = transformer.Wrap(records, st.schemaAligner)
+				}
+				if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
+					drainAndRelease(records)
+					for _, unstarted := range w.batches[i+1:] {
+						unstarted.Release()
+					}
+					return fmt.Errorf("streaming flush: failed to write managed CDC boundary for table %s at %s: %w", displayName, boundary.Position, err)
+				}
+				if err := connectorLeaseLoss(ctx); err != nil {
+					for _, unstarted := range w.batches[i+1:] {
+						unstarted.Release()
+					}
+					return err
+				}
+			}
+			return nil
+		}
+
+		managedCDC := l.opts.StateManager != nil
+		commitToken := st.durableCommitID
+		cdcResumeLSN := st.durableCommitPosition
+		skipCDCResume := st.durableCommitID != nil && st.durableCommitPosition == ""
+		if managedCDC {
+			cdcResumeLSN = ""
+			skipCDCResume = true
+		}
 
 		writeOpts := destination.WriteOptions{
 			Table:            st.destTable,
@@ -897,10 +1384,28 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			StagingBucket:    l.cfg.StagingBucket,
 			LoaderFileSize:   l.cfg.LoaderFileSize,
 			LoaderFileFormat: l.cfg.LoaderFileFormat,
+			CommitToken:      commitToken,
+			CDCResumeLSN:     cdcResumeLSN,
+			SkipCDCResume:    skipCDCResume,
 		}
-		if st.stagingTable != "" {
+		expectedIncarnation := ""
+		if managedCDC && l.opts.StateManager.dest != nil {
+			expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(l.stateSourceTable(w.name))
+			if expectedIncarnation == "" {
+				for _, batch := range w.batches {
+					batch.Release()
+				}
+				return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+			}
+		}
+		if st.atomicSnapshot {
+			writeOpts.Schema = l.atomicSnapshotWriteSchema(st)
+		}
+		if st.stagingTable != "" && !st.atomicSnapshot {
 			writeOpts.Table = st.stagingTable
 			writeOpts.StagingTable = true
+		} else if !st.atomicSnapshot {
+			writeOpts.CDCExpectedIncarnation = expectedIncarnation
 		}
 
 		if err := connectorLeaseLoss(ctx); err != nil {
@@ -913,7 +1418,43 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if col, ok := loadTimestampColumn(st.schema); ok {
 			records = transformer.Wrap(records, transformer.NewLoadTimestamp(col, loadTimestamp))
 		}
-		if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
+		if !st.atomicSnapshot && st.batchTransformer != nil {
+			records = schemaevolution.TransformBatchStream(ctx, records, st.batchTransformer)
+		}
+		if !st.atomicSnapshot && st.schemaAligner != nil {
+			records = transformer.Wrap(records, st.schemaAligner)
+		}
+		if st.atomicSnapshot && st.atomicBatchTransformer != nil {
+			records = schemaevolution.TransformBatchStream(ctx, records, st.atomicBatchTransformer)
+		}
+		if st.atomicSnapshot && st.schemaAligner != nil {
+			records = transformer.Wrap(records, st.schemaAligner)
+		}
+		if st.atomicSnapshot {
+			publisher := l.dest.(destination.AtomicSnapshotPublisher)
+			writeOpts.AtomicSnapshotAttemptID = st.snapshotAttemptID
+			if err := publisher.WriteAtomicSnapshot(ctx, records, writeOpts); err != nil {
+				drainAndRelease(records)
+				return fmt.Errorf("streaming flush: failed to stage %d snapshot rows for table %s: %w", w.rows, displayName, err)
+			}
+		} else if st.directMerge {
+			direct := l.dest.(destination.DirectMergeWriter)
+			if err := direct.MergeRecords(ctx, records, writeOpts, destination.MergeOptions{
+				TargetTable:            st.destTable,
+				PrimaryKeys:            st.primaryKeys,
+				Columns:                destination.MergeColumnsFor(l.dest, st.schema.ColumnNames()),
+				IncrementalKey:         mergeIncrementalKeyForSchema(st.schema, st.incrementalKey),
+				Schema:                 st.schema,
+				Parallelism:            writeOpts.Parallelism,
+				CommitToken:            commitToken,
+				CDCResumeLSN:           cdcResumeLSN,
+				SkipCDCResume:          skipCDCResume,
+				CDCExpectedIncarnation: expectedIncarnation,
+			}); err != nil {
+				drainAndRelease(records)
+				return fmt.Errorf("streaming flush: failed to merge %d rows directly for table %s: %w", w.rows, displayName, err)
+			}
+		} else if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
 			drainAndRelease(records)
 			return fmt.Errorf("streaming flush: failed to write %d rows for table %s: %w", w.rows, displayName, err)
 		}
@@ -921,11 +1462,12 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			return err
 		}
 
-		if st.stagingTable != "" {
+		if st.stagingTable != "" && !st.atomicSnapshot {
 			if err := connectorLeaseLoss(ctx); err != nil {
 				return err
 			}
-			if err := mergeStagingInto(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey); err != nil {
+			if err := mergeStagingIntoWithCommit(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey,
+				commitToken, cdcResumeLSN, skipCDCResume, expectedIncarnation); err != nil {
 				return fmt.Errorf("streaming flush: failed to merge table %s: %w", displayName, err)
 			}
 			if err := connectorLeaseLoss(ctx); err != nil {
@@ -952,12 +1494,12 @@ func (l *flushLoop) flush(ctx context.Context) error {
 	} else {
 		for i, w := range work {
 			if err := flushOne(ctx, w); err != nil {
-				for _, unstarted := range work[i+1:] {
-					for _, batch := range unstarted.batches {
+				flushErr = err
+				for _, pending := range work[i+1:] {
+					for _, batch := range pending.batches {
 						batch.Release()
 					}
 				}
-				flushErr = err
 				break
 			}
 		}
@@ -983,12 +1525,84 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		return err
 	}
 
+	for tableName, st := range l.tables {
+		if !st.atomicSnapshot {
+			continue
+		}
+		sourceTable := l.stateSourceTable(tableName)
+		position, complete := l.pendingState.SnapshotPositions[sourceTable]
+		if !complete {
+			continue
+		}
+		publisher := l.dest.(destination.AtomicSnapshotPublisher)
+		st.atomicPublishAttempted = true
+		expectedIncarnation := ""
+		if l.opts.StateManager != nil && l.opts.StateManager.dest != nil {
+			expectedIncarnation = l.opts.StateManager.BoundDestinationIncarnation(sourceTable)
+			if expectedIncarnation == "" {
+				return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", st.destTable)
+			}
+		}
+		if err := publisher.PublishAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+			Table: st.destTable, Schema: st.schema, TargetSchema: l.atomicSnapshotTargetSchema(st), PrimaryKeys: st.primaryKeys,
+			PartitionBy: st.partitionBy, ClusterBy: st.clusterBy, Parallelism: l.parallelism(),
+			CommitToken: position, CDCResumeLSN: position, SkipCDCResume: l.opts.StateManager != nil, AttemptID: st.snapshotAttemptID,
+			CDCExpectedIncarnation: expectedIncarnation,
+		}); err != nil {
+			return fmt.Errorf("streaming flush: failed to publish snapshot for table %s: %w", st.destTable, err)
+		}
+		st.atomicSnapshot = false
+		st.snapshotStarted = false
+		st.snapshotAttemptID = ""
+		st.atomicPublishAttempted = false
+		st.targetCreatedByRun = false
+		if l.opts.StateManager != nil {
+			if err := l.opts.StateManager.BindDestinationIncarnation(ctx, sourceTable, st.destTable); err != nil {
+				return fmt.Errorf("streaming flush: failed to bind published CDC destination for %s: %w", sourceTable, err)
+			}
+		}
+	}
+
+	ackBlocked := l.hasActiveAtomicSnapshot()
+	if l.opts.StateManager == nil && !ackBlocked {
+		if tokenWriter, ok := l.dest.(destination.DurableCommitTokenWriter); ok {
+			workedTables := make(map[*streamTableState]struct{}, len(work))
+			for _, w := range work {
+				workedTables[w.st] = struct{}{}
+			}
+			for _, st := range l.tables {
+				if st.atomicSnapshot {
+					continue
+				}
+				if _, wroteRows := workedTables[st]; wroteRows {
+					continue
+				}
+				checkpointID := st.checkpointID
+				checkpointPosition := st.checkpointPosition
+				if checkpointID == nil {
+					checkpointID = l.lastDurableCommitID
+					checkpointPosition = l.lastDurableCommitPosition
+				}
+				if checkpointID == nil {
+					continue
+				}
+				cdcResumeLSN := ""
+				if st.isCDC {
+					cdcResumeLSN = checkpointPosition
+				}
+				if err := tokenWriter.CommitWriteToken(ctx, st.destTable, checkpointID, cdcResumeLSN); err != nil {
+					return fmt.Errorf("streaming flush: failed to persist source position for table %s: %w", st.destTable, err)
+				}
+			}
+		}
+	}
+
 	var flushedRows int64
 	for _, w := range work {
 		flushedRows += w.rows
 	}
 
-	if l.opts.StateManager != nil && l.tokenDirty {
+	if l.opts.StateManager != nil && l.tokenDirty && !ackBlocked {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -999,7 +1613,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			return err
 		}
 	}
-	if l.opts.Committer != nil && l.tokenDirty {
+	if l.opts.Committer != nil && l.tokenDirty && !ackBlocked {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -1010,7 +1624,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			return err
 		}
 	}
-	if l.opts.StateManager != nil && l.opts.LegacyFinalizer != nil && l.tokenDirty && !l.legacyFinalized {
+	if l.opts.StateManager != nil && l.opts.LegacyFinalizer != nil && l.tokenDirty && !ackBlocked && !l.legacyFinalized {
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -1022,8 +1636,18 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		}
 		l.legacyFinalized = true
 	}
-	l.tokenDirty = false
-	l.pendingState = source.CDCStateCommitToken{}
+	if !ackBlocked {
+		l.tokenDirty = false
+		l.pendingState = source.CDCStateCommitToken{}
+		l.lastDurableCommitID = nil
+		l.lastDurableCommitPosition = ""
+		for _, st := range l.tables {
+			st.durableCommitID = nil
+			st.durableCommitPosition = ""
+			st.checkpointID = nil
+			st.checkpointPosition = ""
+		}
+	}
 
 	// Only after the commit: the counters mean "durable in the destination and
 	// acknowledged to the source", not merely "written".
@@ -1042,6 +1666,39 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		output.Statusf("[STREAM] %s | cycle %d: flushed %d rows in %s\n", time.Now().Format("15:04:05"), l.cycles, flushedRows, time.Since(start).Round(time.Millisecond))
 	}
 	return nil
+}
+
+func (l *flushLoop) managedCDCNeedsDataWriteIdentity(st *streamTableState) bool {
+	if l.opts.StateManager == nil || st == nil || !st.isCDC || st.atomicSnapshot {
+		return false
+	}
+	return l.opts.Strategy == config.StrategyAppend || len(st.primaryKeys) == 0
+}
+
+func (l *flushLoop) atomicSnapshotTargetSchema(st *streamTableState) *schema.TableSchema {
+	if st.atomicTargetSchema != nil {
+		return st.atomicTargetSchema
+	}
+	if l.opts.Strategy == config.StrategyAppend && st.isCDC {
+		return st.schema
+	}
+	return destination.DestinationTableSchema(st.schema)
+}
+
+func (l *flushLoop) atomicSnapshotWriteSchema(st *streamTableState) *schema.TableSchema {
+	if st.atomicWriteSchema != nil {
+		return st.atomicWriteSchema
+	}
+	return st.schema
+}
+
+func (l *flushLoop) hasActiveAtomicSnapshot() bool {
+	for _, st := range l.tables {
+		if st.atomicSnapshot {
+			return true
+		}
+	}
+	return false
 }
 
 // flushConcurrency returns how many tables may flush at once: destinations
@@ -1081,6 +1738,13 @@ func (l *flushLoop) resetStaging(ctx context.Context, st *streamTableState) erro
 func (l *flushLoop) shutdown(ctx context.Context, records <-chan source.RecordBatchResult) error {
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return l.abortLeaseLoss(records, err)
+	}
+	// A partially staged atomic snapshot must never be flushed during shutdown.
+	// Its hidden attempt is safe to reclaim on restart; returning promptly also
+	// prevents a canceled source snapshot from being drained into durable pages.
+	if l.hasActiveAtomicSnapshot() {
+		startBoundedRecordDrain(records, streamDrainTimeout)
+		return ctx.Err()
 	}
 	deadline := time.NewTimer(streamDrainTimeout)
 	defer deadline.Stop()
@@ -1124,7 +1788,6 @@ drain:
 			break drain
 		}
 	}
-
 	return l.finalFlush(ctx)
 }
 
@@ -1138,12 +1801,36 @@ func (l *flushLoop) finalFlush(ctx context.Context) error {
 	}
 	flushCtx, cancel := detachedLeaseContext(ctx, streamFinalFlushTimeout)
 	defer cancel()
+	for _, st := range l.tables {
+		if st.deferredEvolution == nil || st.evolutionApplied || st.snapshotStarted {
+			continue
+		}
+		if err := st.deferredEvolution(flushCtx); err != nil {
+			return fmt.Errorf("failed to apply deferred schema evolution for table %s: %w", st.destTable, err)
+		}
+		st.evolutionApplied = true
+	}
 
-	if l.buffered == 0 && !l.tokenDirty {
+	if l.buffered == 0 && !l.tokenDirty && !l.hasPendingDurableCheckpoint() {
 		return nil
 	}
 	config.Debug("[STREAM] Final flush: %d buffered rows", l.buffered)
 	return l.flush(flushCtx)
+}
+
+func (l *flushLoop) hasPendingDurableCheckpoint() bool {
+	if l.opts.StateManager != nil {
+		return false
+	}
+	if l.lastDurableCommitID != nil {
+		return true
+	}
+	for _, st := range l.tables {
+		if st.checkpointID != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanup drops staging tables (best-effort) regardless of how the loop ended.
@@ -1159,6 +1846,19 @@ func (l *flushLoop) cleanup(ctx context.Context) {
 	for _, st := range l.tables {
 		if connectorLeaseLoss(dropCtx) != nil {
 			return
+		}
+		if st.snapshotStarted && !st.atomicPublishAttempted && st.snapshotAttemptID != "" {
+			if aborter, ok := l.dest.(destination.AtomicSnapshotAborter); ok {
+				if err := aborter.AbortAtomicSnapshot(dropCtx, destination.AtomicSnapshotOptions{
+					Table: st.destTable, AttemptID: st.snapshotAttemptID,
+				}); err != nil {
+					config.Debug("[STREAM] Warning: failed to abort atomic snapshot stage for %s: %v", st.destTable, err)
+				}
+			}
+		}
+		if st.targetCreatedByRun && !st.atomicPublishAttempted {
+			cleanupFailedOwnedDirectReplace(dropCtx, l.dest, st.destTable, true, st.targetOwnershipToken)
+			st.targetCreatedByRun = false
 		}
 		if st.stagingTable == "" {
 			continue
@@ -1179,6 +1879,7 @@ func (l *flushLoop) releasePending() {
 		}
 		l.buffered -= st.pendingRows
 		st.pending = nil
+		st.pendingPositions = nil
 		st.pendingRows = 0
 	}
 }

--- a/pkg/strategy/streaming_commit_token_test.go
+++ b/pkg/strategy/streaming_commit_token_test.go
@@ -1,0 +1,351 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+type durableTokenCall struct {
+	table        string
+	token        any
+	cdcResumeLSN string
+}
+
+type durableTokenDestination struct {
+	*fakeDestination
+
+	mu    sync.Mutex
+	calls []durableTokenCall
+	err   error
+}
+
+func (d *durableTokenDestination) CommitWriteToken(_ context.Context, table string, token any, cdcResumeLSN string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls = append(d.calls, durableTokenCall{table: table, token: token, cdcResumeLSN: cdcResumeLSN})
+	return d.err
+}
+
+func TestStreamingFlushPassesCommitMetadataToWriteAndMerge(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), CommitToken: stringerToken("00000000/00000020"),
+		DurableCommitID: stringerToken("00000000/00000020"), DurableCommitPosition: "00000000/00000020",
+	}
+	close(records)
+	require.NoError(t, loop.run(context.Background(), records))
+
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 1)
+	require.Equal(t, stringerToken("00000000/00000020"), dest.writeCalls[0].CommitToken)
+	require.Equal(t, "00000000/00000020", dest.writeCalls[0].CDCResumeLSN)
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, stringerToken("00000000/00000020"), dest.mergeCalls[0].CommitToken)
+	require.Equal(t, "00000000/00000020", dest.mergeCalls[0].CDCResumeLSN)
+	dest.mu.Unlock()
+	require.Equal(t, []any{stringerToken("00000000/00000020")}, committer.committed())
+}
+
+func TestStreamingSnapshotChunksDoNotAdvanceCDCResumeBeforeFinalChunk(t *testing.T) {
+	dest := &fakeDestination{}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:           int64RecordBatch(t, "id", []int64{1}, nil),
+		CommitToken:     "snapshot-page-1",
+		DurableCommitID: "snapshot-page-1",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:                 int64RecordBatch(t, "id", []int64{2}, nil),
+		CommitToken:           "snapshot-page-final",
+		DurableCommitID:       "snapshot-page-final",
+		DurableCommitPosition: "0/100",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Len(t, dest.writeCalls, 2)
+	require.True(t, dest.writeCalls[0].SkipCDCResume)
+	require.Empty(t, dest.writeCalls[0].CDCResumeLSN)
+	require.False(t, dest.writeCalls[1].SkipCDCResume)
+	require.Equal(t, "0/100", dest.writeCalls[1].CDCResumeLSN)
+	require.Len(t, dest.mergeCalls, 2)
+	require.True(t, dest.mergeCalls[0].SkipCDCResume)
+	require.Empty(t, dest.mergeCalls[0].CDCResumeLSN)
+	require.False(t, dest.mergeCalls[1].SkipCDCResume)
+	require.Equal(t, "0/100", dest.mergeCalls[1].CDCResumeLSN)
+	dest.mu.Unlock()
+	require.Equal(t, []any{"snapshot-page-1", "snapshot-page-final"}, committer.committed())
+}
+
+func TestStreamingFlushPersistsTokenOnlyCDCPositionBeforeAcknowledgingSource(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		CommitToken: "00000000/00000030", DurableCheckpointID: "00000000/00000030", DurableCheckpointPosition: "00000000/00000030",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.events",
+		token:        "00000000/00000030",
+		cdcResumeLSN: "00000000/00000030",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	require.Equal(t, []any{"00000000/00000030"}, committer.committed())
+	require.False(t, loop.tokenDirty)
+}
+
+func TestStreamingFlushPersistsZeroRowBatchPositionBeforeAcknowledgingSource(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{}, nil), CommitToken: "00000000/00000031",
+		DurableCommitID: "00000000/00000031", DurableCommitPosition: "00000000/00000031",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.events",
+		token:        "00000000/00000031",
+		cdcResumeLSN: "00000000/00000031",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	dest.fakeDestination.mu.Lock()
+	require.Empty(t, dest.writeCalls)
+	dest.fakeDestination.mu.Unlock()
+	require.Equal(t, []any{"00000000/00000031"}, committer.committed())
+}
+
+func TestStreamingFlushPersistsGlobalPositionForIdleTables(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	active := mergeTableState("lake.active")
+	active.isCDC = true
+	idle := mergeTableState("lake.idle")
+	idle.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{
+		"public.active": active,
+		"public.idle":   idle,
+	})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.active", CommitToken: "00000000/00000040",
+		DurableCommitID: "00000000/00000040", DurableCommitPosition: "00000000/00000040",
+		DurableCheckpointID: "00000000/00000040", DurableCheckpointPosition: "00000000/00000040",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.fakeDestination.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.active", dest.mergeCalls[0].TargetTable)
+	require.Equal(t, "00000000/00000040", dest.mergeCalls[0].CDCResumeLSN)
+	dest.fakeDestination.mu.Unlock()
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.idle",
+		token:        "00000000/00000040",
+		cdcResumeLSN: "00000000/00000040",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	require.Equal(t, []any{"00000000/00000040"}, committer.committed())
+}
+
+func TestStreamingSnapshotCheckpointDoesNotAdvanceOtherTables(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	committer := &fakeCommitter{}
+	first := mergeTableState("lake.first")
+	first.isCDC = true
+	second := mergeTableState("lake.second")
+	second.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{
+		"public.first":  first,
+		"public.second": second,
+	})
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:                     int64RecordBatch(t, "id", []int64{1}, nil),
+		TableName:                 "public.first",
+		CommitToken:               "0/100",
+		DurableCommitID:           "snapshot:first:final",
+		DurableCommitPosition:     "0/100",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.first",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.fakeDestination.mu.Lock()
+	require.Len(t, dest.mergeCalls, 1)
+	require.Equal(t, "lake.first", dest.mergeCalls[0].TargetTable)
+	require.Equal(t, "0/100", dest.mergeCalls[0].CDCResumeLSN)
+	dest.fakeDestination.mu.Unlock()
+	dest.mu.Lock()
+	require.Empty(t, dest.calls, "an unfinished table must not receive another table's snapshot cursor")
+	dest.mu.Unlock()
+
+	loop.buffer(source.RecordBatchResult{
+		Batch:                     int64RecordBatch(t, "id", []int64{2}, nil),
+		TableName:                 "public.second",
+		CommitToken:               "0/100",
+		DurableCommitID:           "snapshot:second:final",
+		DurableCommitPosition:     "0/100",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.second",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.fakeDestination.mu.Lock()
+	require.Len(t, dest.mergeCalls, 2)
+	require.Equal(t, "lake.second", dest.mergeCalls[1].TargetTable)
+	require.Equal(t, "0/100", dest.mergeCalls[1].CDCResumeLSN)
+	dest.fakeDestination.mu.Unlock()
+	dest.mu.Lock()
+	require.Empty(t, dest.calls)
+	dest.mu.Unlock()
+}
+
+func TestStreamingEmptySnapshotCheckpointOnlyAdvancesItsTable(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	first := mergeTableState("lake.first")
+	first.isCDC = true
+	second := mergeTableState("lake.second")
+	second.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  100,
+		Strategy:      config.StrategyMerge,
+	}, map[string]*streamTableState{
+		"public.first":  first,
+		"public.second": second,
+	})
+
+	loop.buffer(source.RecordBatchResult{
+		TableName:                 "public.first",
+		DurableCheckpointID:       "checkpoint:0/100",
+		DurableCheckpointPosition: "0/100",
+		DurableCheckpointTable:    "public.first",
+	})
+	require.NoError(t, loop.flush(context.Background()))
+
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table:        "lake.first",
+		token:        "checkpoint:0/100",
+		cdcResumeLSN: "0/100",
+	}}, dest.calls)
+	dest.mu.Unlock()
+}
+
+func TestStreamingFinalFlushPersistsTokenlessTableCheckpoint(t *testing.T) {
+	dest := &durableTokenDestination{fakeDestination: &fakeDestination{}}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour, FlushRecords: 100, Strategy: config.StrategyMerge,
+	}, map[string]*streamTableState{"public.events": st})
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.events", DurableCommitID: "empty-snapshot", DurableCommitPosition: "0/200",
+	}
+	close(records)
+
+	require.NoError(t, loop.run(context.Background(), records))
+	dest.mu.Lock()
+	require.Equal(t, []durableTokenCall{{
+		table: "lake.events", token: "empty-snapshot", cdcResumeLSN: "0/200",
+	}}, dest.calls)
+	dest.mu.Unlock()
+	require.False(t, loop.hasPendingDurableCheckpoint())
+}
+
+func TestStreamingCheckpointFailureDoesNotAcknowledgeSource(t *testing.T) {
+	checkpointErr := errors.New("checkpoint commit failed")
+	dest := &durableTokenDestination{
+		fakeDestination: &fakeDestination{},
+		err:             checkpointErr,
+	}
+	committer := &fakeCommitter{}
+	st := mergeTableState("lake.events")
+	st.isCDC = true
+	loop := newTestLoop(dest, StreamingOptions{
+		FlushInterval: time.Hour,
+		FlushRecords:  1,
+		Strategy:      config.StrategyMerge,
+		Committer:     committer,
+	}, map[string]*streamTableState{"": st})
+
+	loop.buffer(source.RecordBatchResult{
+		CommitToken: "00000000/00000050", DurableCheckpointID: "00000000/00000050", DurableCheckpointPosition: "00000000/00000050",
+	})
+	err := loop.flush(context.Background())
+	require.ErrorIs(t, err, checkpointErr)
+	require.Empty(t, committer.committed())
+	require.True(t, loop.tokenDirty)
+}
+
+type stringerToken string
+
+func (t stringerToken) String() string { return string(t) }
+
+var _ destination.DurableCommitTokenWriter = (*durableTokenDestination)(nil)

--- a/pkg/strategy/streaming_newtable_test.go
+++ b/pkg/strategy/streaming_newtable_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
@@ -227,7 +228,7 @@ func TestStreaming_AnnouncementForKnownTableIgnored(t *testing.T) {
 	assert.Equal(t, 1, writeCallCount(dest))
 }
 
-func TestStreaming_AnnouncementWithoutPreparerDropsBatches(t *testing.T) {
+func TestStreaming_AnnouncementWithoutPreparerFailsClosed(t *testing.T) {
 	dest := &fakeDestination{}
 	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
@@ -242,7 +243,7 @@ func TestStreaming_AnnouncementWithoutPreparerDropsBatches(t *testing.T) {
 	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.products"}
 	close(records)
 
-	require.NoError(t, loop.run(context.Background(), records))
+	require.EqualError(t, loop.run(context.Background(), records), `streaming received 1 row(s) for unknown table "public.products"`)
 	assert.Equal(t, 0, writeCallCount(dest))
 }
 
@@ -674,6 +675,95 @@ func seedLateCompletedState(t *testing.T, dest *lateTableCDCStateDestination, co
 		SnapshotIncarnations: map[string]string{sourceName: "100"},
 		SnapshotSchemas:      map[string]string{sourceName: "schema-a"},
 	}))
+}
+
+func TestStreamingDynamicTableFreezeRejectsBeforePrepare(t *testing.T) {
+	initial := newTableInfo("users")
+	dynamicSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	dynamic := source.SourceTableInfo{Name: "products", Schema: dynamicSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	close(records)
+	dest := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{
+		"users": initial.Schema, "products": destinationSchema,
+	}}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{SchemaContract: "freeze", NoLoadTimestamp: true, FullRefresh: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{"users": "users"},
+	}
+
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1})
+	err := exec.ExecuteMultiTable(context.Background(), job)
+	require.ErrorContains(t, err, "schema contract violation")
+	for _, call := range dest.prepareCalls {
+		require.NotEqual(t, "products", call.Table)
+		require.NotContains(t, call.Table, "products")
+	}
+}
+
+func TestStreamingDynamicTableDiscardValueUsesFinalSchemaAndTransforms(t *testing.T) {
+	initial := newTableInfo("users")
+	dynamicSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64}, {Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	dynamic := source.SourceTableInfo{Name: "products", Schema: dynamicSchema, PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	records <- source.RecordBatchResult{
+		TableName: dynamic.Name, Batch: intStringRecordBatch(t, "id", []int64{1}, "value", []string{"invalid"}),
+	}
+	close(records)
+	base := &fakeDestination{tableSchemas: map[string]*schema.TableSchema{
+		"users": initial.Schema, "products": destinationSchema,
+	}}
+	dest := &contractCaptureReplaceDestination{fakeDestination: base}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{SchemaContract: "discard_value", NoLoadTimestamp: true, FullRefresh: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{"users": "users"},
+	}
+
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1})
+	require.NoError(t, exec.ExecuteMultiTable(context.Background(), job))
+	dest.muCapture.Lock()
+	defer dest.muCapture.Unlock()
+	require.Equal(t, []int64{1}, dest.rows)
+	require.Equal(t, []int{1}, dest.nulls)
+	require.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int64, dest.types[0]))
+	require.Equal(t, schema.TypeInt64, dest.schemas[0].Columns[1].DataType)
+}
+
+func TestStreamingDynamicTableRejectsUnsupportedDecimalBeforePrepare(t *testing.T) {
+	initial := newTableInfo("users")
+	dynamic := source.SourceTableInfo{Name: "products", Schema: &schema.TableSchema{Columns: []schema.Column{{
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 50, Scale: 2,
+	}}}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	close(records)
+	dest := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:      &config.IngestConfig{NoLoadTimestamp: true, FullRefresh: true},
+		Source:      &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records},
+		Destination: dest, Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{"users": "users"},
+	}
+
+	exec := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1})
+	err := exec.ExecuteMultiTable(context.Background(), job)
+	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "products")
+	for _, call := range dest.prepareCalls {
+		require.NotContains(t, call.Table, "products")
+	}
 }
 
 func TestWithLoadTimestampColumn(t *testing.T) {

--- a/pkg/strategy/streaming_snapshot_invalidation_test.go
+++ b/pkg/strategy/streaming_snapshot_invalidation_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,16 +16,30 @@ import (
 
 type orderedCDCStateDestination struct {
 	*cdcStateDestination
-	orderMu           sync.Mutex
-	order             []string
-	replaceAfterWrite bool
+	orderMu                          sync.Mutex
+	order                            []string
+	replaceAfterWrite                bool
+	replaceDuringStateInvalidation   bool
+	replaceBeforeConditionalTruncate bool
 }
 
 func (d *orderedCDCStateDestination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	d.orderMu.Lock()
 	d.order = append(d.order, "state")
 	d.orderMu.Unlock()
-	return d.cdcStateDestination.WriteCDCState(ctx, records, opts)
+	if err := d.cdcStateDestination.WriteCDCState(ctx, records, opts); err != nil {
+		return err
+	}
+	d.orderMu.Lock()
+	replace := d.replaceDuringStateInvalidation
+	d.replaceDuringStateInvalidation = false
+	d.orderMu.Unlock()
+	if replace {
+		d.stateMu.Lock()
+		d.incarnations["raw.items"] = "externally-replaced"
+		d.stateMu.Unlock()
+	}
+	return nil
 }
 
 func (d *orderedCDCStateDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
@@ -47,6 +62,21 @@ func (d *orderedCDCStateDestination) TruncateTable(_ context.Context, table stri
 	d.truncateCalls = append(d.truncateCalls, table)
 	d.mu.Unlock()
 	return nil
+}
+
+func (d *orderedCDCStateDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expected string) error {
+	d.orderMu.Lock()
+	d.order = append(d.order, "truncate")
+	d.orderMu.Unlock()
+	d.mu.Lock()
+	d.truncateCalls = append(d.truncateCalls, table)
+	d.mu.Unlock()
+	if d.replaceBeforeConditionalTruncate {
+		d.stateMu.Lock()
+		d.incarnations[table] = "externally-replaced"
+		d.stateMu.Unlock()
+	}
+	return d.cdcStateDestination.TruncateCDCTableIfIncarnation(ctx, table, expected)
 }
 
 func (d *orderedCDCStateDestination) resetOrder() {
@@ -80,6 +110,9 @@ func replacementSnapshotLoop(t *testing.T) (*flushLoop, *orderedCDCStateDestinat
 		SnapshotPositions:    map[string]string{"public.items": "00000000/00000010"},
 		SnapshotIncarnations: map[string]string{"public.items": "100"},
 	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.BindDestinationIncarnation(ctx, "public.items", "raw.items"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,6 +179,19 @@ func TestStreamingSnapshotInvalidationFailurePreventsTruncate(t *testing.T) {
 	}
 }
 
+func TestStreamingSnapshotInvalidationRejectsTargetRecreatedDuringStateWrite(t *testing.T) {
+	loop, dest, _, _ := replacementSnapshotLoop(t)
+	dest.replaceDuringStateInvalidation = true
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{TableName: "public.items", Incarnation: "101"}}
+	close(records)
+
+	err := loop.run(t.Context(), records)
+	require.ErrorContains(t, err, "changed while invalidating its prior snapshot boundary")
+	require.Equal(t, []string{"state"}, dest.recordedOrder())
+	require.Empty(t, dest.truncateCalls)
+}
+
 func TestStreamingWALTruncateCompletesStableDestinationIncarnation(t *testing.T) {
 	loop, dest, _, _ := replacementSnapshotLoop(t)
 	token := source.CDCStateCommitToken{Position: "00000000/00000030"}
@@ -175,6 +221,43 @@ func TestStreamingWALTruncateCompletesStableDestinationIncarnation(t *testing.T)
 	if got, err := restarted.ResumePosition(t.Context(), "public.items"); err != nil || got != token.Position {
 		t.Fatalf("resume after completed WAL truncate = %q, %v; want %s", got, err, token.Position)
 	}
+}
+
+func TestStreamingWALTruncateRefusesTargetRecreatedAfterBinding(t *testing.T) {
+	loop, dest, _, _ := replacementSnapshotLoop(t)
+	dest.replaceBeforeConditionalTruncate = true
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName:      "public.items",
+		Truncate:       true,
+		CDCWALTruncate: true,
+		CommitToken:    source.CDCStateCommitToken{Position: "00000000/00000030"},
+	}
+	close(records)
+
+	err := loop.run(t.Context(), records)
+	if err == nil || !strings.Contains(err.Error(), "physical incarnation changed") {
+		t.Fatalf("streaming WAL truncate error = %v, want incarnation change", err)
+	}
+	if got := dest.recordedOrder(); len(got) != 2 || got[0] != "state" || got[1] != "truncate" {
+		t.Fatalf("WAL truncate replacement ordering = %v, want [state truncate]", got)
+	}
+}
+
+func TestStreamingWALTruncateRejectsTargetRecreatedDuringInvalidation(t *testing.T) {
+	loop, dest, _, _ := replacementSnapshotLoop(t)
+	dest.replaceDuringStateInvalidation = true
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{
+		TableName: "public.items", Truncate: true, CDCWALTruncate: true,
+		CommitToken: source.CDCStateCommitToken{Position: "00000000/00000030"},
+	}
+	close(records)
+
+	err := loop.run(t.Context(), records)
+	require.ErrorContains(t, err, "changed while invalidating its prior snapshot boundary")
+	require.Equal(t, []string{"state"}, dest.recordedOrder())
+	require.Empty(t, dest.truncateCalls)
 }
 
 func TestStreamingFreshSnapshotRejectsDestinationReplacementAfterWrite(t *testing.T) {
@@ -221,7 +304,8 @@ func TestStreamingKeylessAppendCrashBeforeStateForcesReplacement(t *testing.T) {
 		TableName: "public.items",
 		Batch:     int64RecordBatch(t, "id", []int64{7}, nil),
 		CommitToken: source.CDCStateCommitToken{
-			Position: "00000000/00000030",
+			Position:    "00000000/00000030",
+			DataBatchID: "public.items:1:00000000/00000030/0000000000000001:00000000/00000030/0000000000000001",
 		},
 	})
 	require.Error(t, loop.flush(t.Context()))

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -24,6 +24,131 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type readAllSetupErrorSource struct {
+	*announcingMultiTableSource
+	err error
+}
+
+type cancelOnNthManagedStagingPrepareDestination struct {
+	*contextAwareDropDestination
+	cancel  context.CancelFunc
+	failAt  int
+	managed int
+}
+
+func (d *cancelOnNthManagedStagingPrepareDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := d.contextAwareDropDestination.PrepareTable(ctx, opts); err != nil {
+		return err
+	}
+	if opts.ExpiresAfter > 0 {
+		d.managed++
+		if d.managed == d.failAt {
+			d.cancel()
+			return errors.New("managed staging prepare response lost after create")
+		}
+	}
+	return nil
+}
+
+func TestStreamingLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge}).Execute(ctx, job)
+	require.ErrorContains(t, err, "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func TestStreamingMultiTableLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	table := source.SourceTableInfo{Name: "events", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	base := &fakeDestination{}
+	dest := &uncertainManagedStagingPrepareDestination{contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{}, Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}}, Destination: dest,
+		Tables: []source.SourceTableInfo{table}, TableDestNames: map[string]string{table.Name: "events"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge}).ExecuteMultiTable(ctx, job)
+	require.ErrorContains(t, err, "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func TestStreamingDynamicTableLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	initial := source.SourceTableInfo{Name: "users", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	dynamic := source.SourceTableInfo{Name: "products", Schema: streamTestSchema(), PrimaryKeys: []string{"id"}}
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{TableName: dynamic.Name, TableInfo: &dynamic}
+	close(records)
+	base := &fakeDestination{}
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := &cancelOnNthManagedStagingPrepareDestination{
+		contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base}, cancel: cancel, failAt: 2,
+	}
+	job := &MultiTableIngestionJob{
+		Config: &config.IngestConfig{NoLoadTimestamp: true, FullRefresh: true},
+		Source: &announcingMultiTableSource{tables: []source.SourceTableInfo{initial}, records: records}, Destination: dest,
+		Tables: []source.SourceTableInfo{initial}, TableDestNames: map[string]string{initial.Name: initial.Name},
+	}
+
+	err := NewStreamingExecutor(StreamingOptions{
+		Strategy: config.StrategyMerge, FlushInterval: time.Hour, FlushRecords: 1,
+	}).ExecuteMultiTable(ctx, job)
+	require.ErrorContains(t, err, "prepare response lost")
+	var managedStages []string
+	for _, call := range base.prepareCalls {
+		if call.ExpiresAfter > 0 {
+			managedStages = append(managedStages, call.Table)
+		}
+	}
+	require.Len(t, managedStages, 2)
+	require.ElementsMatch(t, managedStages, dest.successfulDrops)
+}
+
+func (s *readAllSetupErrorSource) ReadAll(context.Context, source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	return nil, s.err
+}
+
+func TestStreamingReadSetupFailureDropsManagedStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	src.readErr = errors.New("stream read setup failed")
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+
+	err := executor.Execute(context.Background(), job)
+	require.Error(t, err)
+	require.Len(t, dest.dropCalls, 1)
+	require.Contains(t, dest.dropCalls[0], "_stream_")
+}
+
+func TestStreamingMultiTableReadSetupFailureDropsManagedStaging(t *testing.T) {
+	tableSchema := streamTestSchema()
+	table := source.SourceTableInfo{Name: "public.users", Schema: tableSchema, PrimaryKeys: []string{"id"}}
+	src := &readAllSetupErrorSource{
+		announcingMultiTableSource: &announcingMultiTableSource{tables: []source.SourceTableInfo{table}},
+		err:                        errors.New("stream read-all setup failed"),
+	}
+	dest := &fakeDestination{}
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         src,
+		Destination:    dest,
+		Tables:         src.tables,
+		TableDestNames: map[string]string{table.Name: "users"},
+	}
+	executor := NewStreamingExecutor(StreamingOptions{Strategy: config.StrategyMerge})
+
+	err := executor.ExecuteMultiTable(context.Background(), job)
+	require.Error(t, err)
+	require.Len(t, dest.dropCalls, 1)
+	require.Contains(t, dest.dropCalls[0], "_stream_")
+}
+
 type fakeCommitter struct {
 	mu     sync.Mutex
 	tokens []any
@@ -48,6 +173,17 @@ type cancelAwareSourceTable struct {
 	*fakeSourceTable
 	batches []arrow.RecordBatch
 	done    chan struct{}
+}
+
+type singleReleaseCountingRecordBatch struct {
+	arrow.RecordBatch
+	releases atomic.Int64
+}
+
+func (b *singleReleaseCountingRecordBatch) Release() {
+	if b.releases.Add(1) == 1 {
+		b.RecordBatch.Release()
+	}
 }
 
 func (t *cancelAwareSourceTable) Read(ctx context.Context, _ source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -81,6 +217,28 @@ func (c *fakeCommitter) committed() []any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]any(nil), c.tokens...)
+}
+
+func TestStreamingSequentialFlushFailureReleasesEveryBatchOnce(t *testing.T) {
+	dest := &fakeDestination{writeErr: errors.New("injected write failure")}
+	tables := map[string]*streamTableState{
+		"public.first":  {destTable: "first", schema: streamTestSchema()},
+		"public.second": {destTable: "second", schema: streamTestSchema()},
+		"public.third":  {destTable: "third", schema: streamTestSchema()},
+	}
+	loop := newTestLoop(dest, StreamingOptions{Strategy: config.StrategyAppend}, tables)
+
+	batches := make([]*singleReleaseCountingRecordBatch, 0, len(tables))
+	for table := range tables {
+		batch := &singleReleaseCountingRecordBatch{RecordBatch: int64RecordBatch(t, "id", []int64{1}, nil)}
+		batches = append(batches, batch)
+		loop.buffer(source.RecordBatchResult{TableName: table, Batch: batch})
+	}
+
+	require.ErrorContains(t, loop.flush(t.Context()), "injected write failure")
+	for _, batch := range batches {
+		require.EqualValues(t, 1, batch.releases.Load(), "every started or unstarted batch must have exactly one owner release it")
+	}
 }
 
 // ctxRecordingDest records the context error observed at each WriteParallel
@@ -763,6 +921,7 @@ func TestStreaming_LeaseLossDuringStatePersistSkipsSourceCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, manager.RegisterTable(context.Background(), "public.items", "raw.items"))
 	require.NoError(t, manager.BeginRun(context.Background(), false))
+	require.NoError(t, manager.BindDestinationIncarnation(context.Background(), "public.items", "raw.items"))
 	stateDest.block = true
 
 	committer := &fakeCommitter{}
@@ -773,6 +932,7 @@ func TestStreaming_LeaseLossDuringStatePersistSkipsSourceCommit(t *testing.T) {
 		Committer:     committer,
 		StateManager:  manager,
 	}, map[string]*streamTableState{"": mergeTableState("raw.items")})
+	loop.cfg.SourceTable = "public.items"
 	loop.buffer(source.RecordBatchResult{
 		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
 		CommitToken: source.CDCStateCommitToken{
@@ -798,6 +958,7 @@ func TestStreamingFinalizesLegacySlotAfterDurableStateAndSourceCommit(t *testing
 	require.NoError(t, err)
 	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), "public.items", "raw.items", "100"))
 	require.NoError(t, manager.BeginRun(t.Context(), false))
+	require.NoError(t, manager.BindDestinationIncarnation(t.Context(), "public.items", "raw.items"))
 
 	committer := &fakeCommitter{}
 	finalizer := &fakeLegacySlotFinalizer{committer: committer}
@@ -809,6 +970,7 @@ func TestStreamingFinalizesLegacySlotAfterDurableStateAndSourceCommit(t *testing
 		StateManager:    manager,
 		LegacyFinalizer: finalizer,
 	}, map[string]*streamTableState{"": mergeTableState("raw.items")})
+	loop.cfg.SourceTable = "public.items"
 	loop.buffer(source.RecordBatchResult{
 		Batch: int64RecordBatch(t, "id", []int64{1}, nil),
 		CommitToken: source.CDCStateCommitToken{
@@ -939,7 +1101,7 @@ func TestStreaming_MultiTableRouting(t *testing.T) {
 	assert.ElementsMatch(t, []string{"ds.users", "ds.orders"}, mergedTables)
 }
 
-func TestStreaming_UnknownTableBatchDropped(t *testing.T) {
+func TestStreaming_UnknownTableBatchFailsClosed(t *testing.T) {
 	dest := &fakeDestination{}
 	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
@@ -952,7 +1114,7 @@ func TestStreaming_UnknownTableBatchDropped(t *testing.T) {
 	records <- source.RecordBatchResult{Batch: int64RecordBatch(t, "id", []int64{1}, nil), TableName: "public.unknown"}
 	close(records)
 
-	require.NoError(t, loop.run(context.Background(), records))
+	require.EqualError(t, loop.run(context.Background(), records), `streaming received 1 row(s) for unknown table "public.unknown"`)
 	assert.Equal(t, 0, writeCallCount(dest))
 }
 

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -22,12 +22,14 @@ import (
 // once (e.g., page-based pagination over a live table). Without PKs, dedup is
 // not possible and rows are written directly into the truncated target.
 //
-// Tradeoffs the user has already accepted by opting in:
-//   - Non-atomic: the target is empty between TRUNCATE and the final insert,
-//     so concurrent readers may see an empty result set.
-//   - No rollback: if the insert fails after truncate, the target is left empty.
-//   - Schema drift: the existing table's schema is preserved as-is; this
-//     strategy does not drop and recreate to pick up schema changes.
+// Destinations implementing AtomicTruncateInsertWriter replace schema and rows
+// together. Other destinations retain the traditional truncate-then-write
+// behavior, where readers may observe an empty table and failures cannot roll
+// back the truncate.
+//
+// Additional tradeoffs:
+//   - Schema evolution is applied in place before rows are replaced, preserving
+//     dependent objects while allowing supported column additions and widening.
 //   - ClickHouse caveat: ClickHouse's merge implementation relies on
 //     ReplacingMergeTree semantics for dedup rather than pre-filtering, so
 //     duplicate PKs in staging will only be collapsed if the target table is
@@ -51,6 +53,9 @@ func (s *TruncateInsertStrategy) RequiresIncrementalKey() bool {
 }
 
 func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob) error {
+	if atomicWriter, ok := job.Destination.(destination.AtomicTruncateInsertWriter); ok {
+		return s.executeAtomic(ctx, job, atomicWriter)
+	}
 	truncator, ok := job.Destination.(destination.TruncateCapable)
 	if !ok {
 		return fmt.Errorf("destination does not support truncate+insert strategy; use replace instead")
@@ -62,27 +67,135 @@ func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob)
 	return s.executeDirect(ctx, job, truncator)
 }
 
+func (s *TruncateInsertStrategy) executeAtomic(ctx context.Context, job *IngestionJob, writer destination.AtomicTruncateInsertWriter) error {
+	targetTable := job.Config.DestTable
+	existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before truncate+insert: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
+
+	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
+		Table:                  targetTable,
+		Schema:                 destination.DestinationTableSchema(job.Schema),
+		DropFirst:              false,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		PartitionBy:            job.Config.PartitionBy,
+		ClusterBy:              job.Config.ClusterBy,
+		PreserveExistingLayout: true,
+		OwnershipToken:         ownershipToken,
+	}); err != nil {
+		if ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, true, ownershipToken)
+		}
+		return fmt.Errorf("failed to prepare table: %w", err)
+	}
+
+	atomicEvolution, ok := job.Destination.(destination.AtomicTruncateInsertSchemaEvolver)
+	if !ok || !atomicEvolution.EvolvesTruncateInsertSchemaAtomically() {
+		if err := job.ApplyEvolution(ctx); err != nil {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+			return fmt.Errorf("failed to apply schema evolution: %w", err)
+		}
+	}
+	expectedIncarnation := ""
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+			return fmt.Errorf("failed to bind CDC destination before truncate+insert extraction: %w", err)
+		}
+		expectedIncarnation = job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if expectedIncarnation == "" {
+			return fmt.Errorf("managed CDC destination %s has no bound physical incarnation", targetTable)
+		}
+	}
+
+	parallelism := job.Config.ExtractParallelism
+	if parallelism <= 0 {
+		parallelism = 4
+	}
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, source.ReadOptions{
+		IncrementalKey:                  job.Config.IncrementalKey,
+		IntervalStart:                   job.Config.IntervalStart,
+		IntervalEnd:                     job.Config.IntervalEnd,
+		ExtractPartitionBy:              job.Config.ExtractPartitionBy,
+		ExtractPartitionInterval:        job.Config.ExtractPartitionInterval,
+		ExtractPartitionNumericInterval: job.Config.ExtractPartitionNumericInterval,
+		ExtractPartitionAuto:            job.Config.ExtractPartitionAuto,
+		PageSize:                        job.Config.PageSize,
+		Limit:                           job.Config.SQLLimit,
+		ExcludeColumns:                  job.Config.SQLExcludeColumns,
+		Parallelism:                     parallelism,
+		Schema:                          job.SourceSchema,
+		CDCSlotSuffix:                   job.Config.CDCSlotSuffix,
+		CDCLegacySlotSuffix:             job.Config.CDCLegacySlotSuffix,
+		FullRefresh:                     job.Config.FullRefresh,
+	})
+	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
+		return fmt.Errorf("failed to get records: %w", err)
+	}
+	if job.Tracker != nil {
+		records = job.Tracker.Wrap(records)
+	}
+
+	if err := writer.TruncateInsertRecords(readCtx, records, destination.WriteOptions{
+		Table:                  targetTable,
+		Schema:                 job.Schema,
+		PrimaryKeys:            job.Config.PrimaryKeys,
+		Parallelism:            parallelism,
+		StagingBucket:          job.Config.StagingBucket,
+		LoaderFileSize:         job.Config.LoaderFileSize,
+		LoaderFileFormat:       job.Config.LoaderFileFormat,
+		PreStaged:              job.PreStaged,
+		DeduplicatePrimaryKeys: len(job.Config.PrimaryKeys) > 0,
+		IncrementalKey:         mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+		SkipCDCResume:          job.CDCStateManager != nil,
+		CDCExpectedIncarnation: expectedIncarnation,
+	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to atomically truncate and insert data: %w", err)
+	}
+	if job.CDCStateManager != nil {
+		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, targetTable); err != nil {
+			return fmt.Errorf("failed to revalidate CDC destination after truncate+insert: %w", err)
+		}
+	}
+	return nil
+}
+
 func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *IngestionJob, truncator destination.TruncateCapable) error {
 	targetTable := job.Config.DestTable
 	config.Debug("[TRUNCATE+INSERT] Target table: %s (direct path, no PKs)", targetTable)
+	existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before truncate+insert: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       targetTable,
-		Schema:      destination.DestinationTableSchema(job.Schema),
-		DropFirst:   false,
-		PrimaryKeys: job.Config.PrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:          targetTable,
+		Schema:         destination.DestinationTableSchema(job.Schema),
+		DropFirst:      false,
+		PrimaryKeys:    job.Config.PrimaryKeys,
+		PartitionBy:    job.Config.PartitionBy,
+		ClusterBy:      job.Config.ClusterBy,
+		OwnershipToken: ownershipToken,
 	}); err != nil {
+		if ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, true, ownershipToken)
+		}
 		return fmt.Errorf("failed to prepare table: %w", err)
 	}
 
 	if err := job.ApplyEvolution(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
-	}
-
-	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
-		return fmt.Errorf("failed to truncate table: %w", err)
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -108,8 +221,11 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
@@ -117,7 +233,13 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 		records = job.Tracker.Wrap(records)
 	}
 
-	if err := job.Destination.WriteParallel(ctx, records, destination.WriteOptions{
+	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		return fmt.Errorf("failed to truncate table: %w", err)
+	}
+
+	if err := job.Destination.WriteParallel(readCtx, records, destination.WriteOptions{
 		Table:            targetTable,
 		Schema:           job.Schema,
 		Parallelism:      parallelism,
@@ -126,6 +248,8 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
 	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
 		return fmt.Errorf("failed to write data: %w", err)
 	}
 
@@ -140,16 +264,29 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 	targetTable := job.Config.DestTable
 	stagingTable := managedStagingTableName(job.Destination, targetTable, "ti", job.Config.StagingDataset)
 	output.Statusf("[TRUNCATE+INSERT] %s | Using staging table: %s\n", time.Now().Format("15:04:05"), stagingTable)
+	existingSchema, err := job.Destination.GetTableSchema(ctx, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect destination table before truncate+insert: %w", err)
+	}
+	targetExisted := existingSchema != nil
+	ownershipToken := newTargetOwnershipToken(job.Destination, targetExisted)
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       targetTable,
-		Schema:      destination.DestinationTableSchema(job.Schema),
-		DropFirst:   false,
-		PrimaryKeys: job.Config.PrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:          targetTable,
+		Schema:         destination.DestinationTableSchema(job.Schema),
+		DropFirst:      false,
+		PrimaryKeys:    job.Config.PrimaryKeys,
+		PartitionBy:    job.Config.PartitionBy,
+		ClusterBy:      job.Config.ClusterBy,
+		OwnershipToken: ownershipToken,
 	}); err != nil {
+		if ownershipToken != "" {
+			cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, true, ownershipToken)
+		}
 		return fmt.Errorf("failed to prepare destination table: %w", err)
+	}
+	if !job.Config.KeepStaging {
+		defer dropManagedStagingDetached(ctx, job.Destination, stagingTable, "TRUNCATE+INSERT")
 	}
 
 	if err := job.Destination.PrepareTable(ctx, destination.PrepareOptions{
@@ -161,6 +298,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		ClusterBy:    job.Config.ClusterBy,
 		ExpiresAfter: destination.ManagedStagingTTL,
 	}); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to prepare staging table: %w", err)
 	}
 
@@ -187,8 +325,11 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to get records: %w", err)
 	}
 
@@ -196,7 +337,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		records = job.Tracker.Wrap(records)
 	}
 
-	if err := job.Destination.WriteParallel(ctx, records, destination.WriteOptions{
+	if err := job.Destination.WriteParallel(readCtx, records, destination.WriteOptions{
 		Table:            stagingTable,
 		Schema:           job.Schema,
 		Parallelism:      parallelism,
@@ -206,10 +347,14 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
 	}); err != nil {
+		cancelRead()
+		<-startBoundedRecordDrain(records, canceledSourceDrainTimeout)
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}
 
 	if err := job.ApplyEvolution(ctx); err != nil {
+		cleanupFailedOwnedDirectReplace(ctx, job.Destination, targetTable, !targetExisted, ownershipToken)
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
 
@@ -222,17 +367,11 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		StagingTable:   stagingTable,
 		TargetTable:    targetTable,
 		PrimaryKeys:    job.Config.PrimaryKeys,
-		Columns:        job.Schema.ColumnNames(),
+		Columns:        destination.DestinationColumns(job.Schema.ColumnNames()),
 		IncrementalKey: mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
 		Schema:         job.Schema,
 	}); err != nil {
 		return fmt.Errorf("failed to insert from staging: %w", err)
-	}
-
-	if !job.Config.KeepStaging {
-		if err := job.Destination.DropTable(ctx, stagingTable); err != nil {
-			config.Debug("[TRUNCATE+INSERT] Warning: failed to drop staging table: %v", err)
-		}
 	}
 
 	return nil

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -5,10 +5,392 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 )
+
+type atomicTruncateInsertDestination struct {
+	*fakeDestination
+	calls []destination.WriteOptions
+	err   error
+}
+
+type atomicSchemaEvolvingTruncateDestination struct {
+	*atomicTruncateInsertDestination
+}
+
+type immediateFailAtomicTruncateDestination struct {
+	*fakeDestination
+}
+
+type ownedAtomicTruncateDestination struct {
+	*atomicTruncateInsertDestination
+	preparedToken string
+	dropTokens    []string
+}
+
+type recreatingAtomicTruncateDestination struct {
+	*cdcStateDestination
+	calls []destination.WriteOptions
+}
+
+func (d *recreatingAtomicTruncateDestination) TruncateInsertRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.calls = append(d.calls, opts)
+	d.stateMu.Lock()
+	d.incarnations[opts.Table] = "external-v2"
+	d.stateMu.Unlock()
+	current, _, _ := d.CDCTargetIncarnation(ctx, opts.Table)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	if opts.CDCExpectedIncarnation != current {
+		return errors.New("destination incarnation changed before atomic truncate+insert")
+	}
+	return nil
+}
+
+func TestManagedAtomicTruncateInsertRejectsTargetRecreationDuringExtraction(t *testing.T) {
+	job, src, _ := minimalJob()
+	stateDest := newCDCStateDestination()
+	stateDest.incarnations[job.Config.DestTable] = "target-v1"
+	dest := &recreatingAtomicTruncateDestination{cdcStateDestination: stateDest}
+	job.Destination = dest
+	manager, err := NewCDCStateManager(dest, "truncate-insert-recreation", job.Config.DestTable, "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTableIncarnation(t.Context(), job.Config.SourceTable, job.Config.DestTable, "source-v1"))
+	require.NoError(t, manager.BeginRun(t.Context(), true))
+	job.CDCStateManager = manager
+	src.readCh = singleBatchRecords(t, 1)
+
+	err = (&TruncateInsertStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "incarnation changed")
+	require.Len(t, dest.calls, 1)
+	require.Equal(t, "target-v1", dest.calls[0].CDCExpectedIncarnation)
+	require.True(t, dest.calls[0].SkipCDCResume)
+}
+
+func (d *ownedAtomicTruncateDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if opts.Table != "" && opts.OwnershipToken != "" {
+		d.preparedToken = opts.OwnershipToken
+	}
+	return d.atomicTruncateInsertDestination.PrepareTable(ctx, opts)
+}
+
+func (d *ownedAtomicTruncateDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	return errors.New("ownership changed")
+}
+
+type ownedTruncateDestination struct {
+	*truncateCapableDestination
+	preparedToken string
+	dropTokens    []string
+}
+
+type uncertainStagingTruncateDestination struct {
+	*uncertainManagedStagingPrepareDestination
+}
+
+func (d *uncertainStagingTruncateDestination) TruncateTable(context.Context, string) error {
+	return nil
+}
+
+func (d *ownedTruncateDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if opts.OwnershipToken != "" {
+		d.preparedToken = opts.OwnershipToken
+	}
+	return d.truncateCapableDestination.PrepareTable(ctx, opts)
+}
+
+func TestTruncateInsertLostStagingPrepareUsesDetachedCleanup(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.PrimaryKeys = []string{"id"}
+	dest := &uncertainStagingTruncateDestination{uncertainManagedStagingPrepareDestination: &uncertainManagedStagingPrepareDestination{
+		contextAwareDropDestination: &contextAwareDropDestination{fakeDestination: base},
+	}}
+	job.Destination = dest
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorContains(t, (&TruncateInsertStrategy{}).Execute(ctx, job), "prepare response lost")
+	require.Len(t, base.prepareCalls, 2)
+	require.ElementsMatch(t, []string{base.prepareCalls[0].Table, base.prepareCalls[1].Table}, dest.successfulDrops)
+}
+
+func (d *ownedTruncateDestination) DropTableIfOwned(_ context.Context, _ string, token string) error {
+	d.dropTokens = append(d.dropTokens, token)
+	return errors.New("ownership changed")
+}
+
+func (d *immediateFailAtomicTruncateDestination) TruncateInsertRecords(
+	context.Context,
+	<-chan source.RecordBatchResult,
+	destination.WriteOptions,
+) error {
+	return errors.New("atomic writer failed")
+}
+
+func (d *atomicSchemaEvolvingTruncateDestination) EvolvesTruncateInsertSchemaAtomically() bool {
+	return true
+}
+
+func (d *atomicTruncateInsertDestination) TruncateInsertRecords(
+	_ context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	d.calls = append(d.calls, opts)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return d.err
+}
+
+func TestTruncateInsertStrategy_PrefersAtomicWriter(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.readCh = singleBatchRecords(t, 1, 1, 2)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	if len(atomic.calls) != 1 {
+		t.Fatalf("expected one atomic write, got %d", len(atomic.calls))
+	}
+	if !atomic.calls[0].DeduplicatePrimaryKeys {
+		t.Fatal("atomic truncate+insert did not request primary-key deduplication")
+	}
+	require.Len(t, base.prepareCalls, 1)
+	require.True(t, base.prepareCalls[0].PreserveExistingLayout)
+	if len(base.truncateCalls) != 0 || len(base.mergeCalls) != 0 {
+		t.Fatalf("atomic path must not truncate or merge separately: truncate=%v merge=%v", base.truncateCalls, base.mergeCalls)
+	}
+}
+
+func TestTruncateInsertStrategy_AtomicWriterForwardsCDCSlotSuffixes(t *testing.T) {
+	job, src, base := minimalJob()
+	job.Destination = &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.CDCSlotSuffix = "current-destination-slot"
+	job.Config.CDCLegacySlotSuffix = "legacy-destination-slot"
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.Equal(t, job.Config.CDCSlotSuffix, src.readOpts.CDCSlotSuffix)
+	require.Equal(t, job.Config.CDCLegacySlotSuffix, src.readOpts.CDCLegacySlotSuffix)
+}
+
+// Atomic writers without AtomicTruncateInsertSchemaEvolver still rely on the
+// strategy to apply the pending evolution plan before writing.
+func TestTruncateInsertStrategy_AtomicWriterAppliesEvolution(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	base.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: job.Schema}
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable,
+		Comparison: &schemaevolution.SchemaComparison{
+			HasChanges: true,
+			Changes: []schemaevolution.SchemaChange{{
+				Type:       schemaevolution.ChangeAddColumn,
+				ColumnName: "new_column",
+			}},
+		},
+	}
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Len(t, base.execCalls, 1)
+	require.Contains(t, base.execCalls[0].sql, "ADD COLUMN new_column")
+	require.Nil(t, job.EvolutionPlan.Comparison, "the evolution plan must be applied before the atomic write")
+}
+
+func TestTruncateInsertStrategy_AtomicSchemaEvolverOwnsEvolution(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicSchemaEvolvingTruncateDestination{
+		atomicTruncateInsertDestination: &atomicTruncateInsertDestination{fakeDestination: base},
+	}
+	job.Destination = atomic
+	base.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: job.Schema}
+	comparison := &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeAddColumn, ColumnName: "new_column",
+		}},
+	}
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{Table: job.Config.DestTable, Comparison: comparison}
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Empty(t, base.execCalls)
+	require.Same(t, comparison, job.EvolutionPlan.Comparison)
+	require.Len(t, atomic.calls, 1)
+}
+
+func TestTruncateInsertStrategy_AtomicSchemaEvolverSoftensRemovedRequiredColumn(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicSchemaEvolvingTruncateDestination{
+		atomicTruncateInsertDestination: &atomicTruncateInsertDestination{fakeDestination: base},
+	}
+	job.Destination = atomic
+	destinationSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "legacy", DataType: schema.TypeString, Nullable: false},
+	}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRemoveColumn, ColumnName: "legacy",
+		OldColumn: &destinationSchema.Columns[1],
+	}}}
+	job.Schema = schemaevolution.BuildFinalSchema(destinationSchema, comparison)
+	job.SourceSchema = &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	job.EvolutionPlan = &schemaevolution.EvolutionPlan{
+		Table: job.Config.DestTable, Comparison: comparison, FinalSchema: job.Schema,
+	}
+	base.tableSchemas = map[string]*schema.TableSchema{job.Config.DestTable: destinationSchema}
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Len(t, atomic.calls, 1)
+	require.Len(t, atomic.calls[0].Schema.Columns, 2)
+	require.Equal(t, "legacy", atomic.calls[0].Schema.Columns[1].Name)
+	require.True(t, atomic.calls[0].Schema.Columns[1].Nullable)
+}
+
+func TestTruncateInsertStrategy_AtomicWriterSkipsMissingOrderingKey(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{fakeDestination: base}
+	job.Destination = atomic
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.IncrementalKey = "missing_ordering_column"
+	src.readCh = singleBatchRecords(t, 1, 1, 2)
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.Len(t, atomic.calls, 1)
+	require.Empty(t, atomic.calls[0].IncrementalKey)
+}
+
+func TestTruncateInsertStrategy_AtomicFailurePreservesNewTargetForOutcomeReconciliation(t *testing.T) {
+	job, src, base := minimalJob()
+	atomic := &atomicTruncateInsertDestination{
+		fakeDestination: base,
+		err:             errors.New("atomic commit failed"),
+	}
+	job.Destination = atomic
+	src.readCh = mustClosedRecords()
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected atomic truncate+insert to fail")
+	}
+	require.Empty(t, base.dropCalls, "atomic write errors may be lost success responses and must preserve the target")
+}
+
+func TestTruncateInsertStrategy_AtomicFailureDoesNotAttemptCleanupAfterPossibleCommit(t *testing.T) {
+	job, src, base := minimalJob()
+	dest := &ownedAtomicTruncateDestination{atomicTruncateInsertDestination: &atomicTruncateInsertDestination{
+		fakeDestination: base,
+		err:             errors.New("atomic commit failed after replacement"),
+	}}
+	job.Destination = dest
+	src.readCh = mustClosedRecords()
+
+	require.Error(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "conditional ownership is insufficient after a possibly successful commit")
+	require.Empty(t, base.dropCalls, "unconditional cleanup must not delete a replacement owner")
+}
+
+func TestTruncateInsertStrategy_LostPrepareResponseCleansOwnedTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		make   func(*fakeDestination) destination.Destination
+		assert func(*testing.T, destination.Destination)
+	}{
+		{
+			name: "atomic",
+			make: func(base *fakeDestination) destination.Destination {
+				return &ownedAtomicTruncateDestination{atomicTruncateInsertDestination: &atomicTruncateInsertDestination{fakeDestination: base}}
+			},
+			assert: func(t *testing.T, raw destination.Destination) {
+				dest := raw.(*ownedAtomicTruncateDestination)
+				require.NotEmpty(t, dest.preparedToken)
+				require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			},
+		},
+		{
+			name: "direct",
+			make: func(base *fakeDestination) destination.Destination {
+				return &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+			},
+			assert: func(t *testing.T, raw destination.Destination) {
+				dest := raw.(*ownedTruncateDestination)
+				require.NotEmpty(t, dest.preparedToken)
+				require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			},
+		},
+		{
+			name: "staged",
+			make: func(base *fakeDestination) destination.Destination {
+				return &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+			},
+			assert: func(t *testing.T, raw destination.Destination) {
+				dest := raw.(*ownedTruncateDestination)
+				require.NotEmpty(t, dest.preparedToken)
+				require.Equal(t, []string{dest.preparedToken}, dest.dropTokens)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job, src, base := minimalJob()
+			base.prepareHook = func(destination.PrepareOptions) error { return errors.New("prepare response lost after create") }
+			if tc.name == "direct" {
+				job.Config.PrimaryKeys = nil
+				job.Schema.PrimaryKeys = nil
+				src.primaryKeys = nil
+			}
+			raw := tc.make(base)
+			job.Destination = raw
+
+			require.ErrorContains(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job), "prepare response lost")
+			tc.assert(t, raw)
+			require.Empty(t, base.dropCalls)
+		})
+	}
+}
+
+func TestTruncateInsertStrategy_AtomicWriterFailureBoundsNonclosingSource(t *testing.T) {
+	previousTimeout := canceledSourceDrainTimeout
+	canceledSourceDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { canceledSourceDrainTimeout = previousTimeout })
+	job, src, base := minimalJob()
+	records := make(chan source.RecordBatchResult)
+	src.readCh = records
+	job.Destination = &immediateFailAtomicTruncateDestination{fakeDestination: base}
+
+	started := time.Now()
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil || time.Since(started) > time.Second {
+		t.Fatalf("truncate+insert did not return promptly after writer failure: %v", err)
+	}
+	close(records)
+}
 
 func TestTruncateInsertStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
 	job, src, dest := minimalJob()
@@ -64,6 +446,7 @@ func TestTruncateInsertStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema
 	job.Destination = &truncateCapableDestination{fakeDestination: dest}
 	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
 	job.Config.IncrementalKey = "updated_at"
+	job.Schema.Columns = append(job.Schema.Columns, schema.Column{Name: "_cdc_unchanged_cols", DataType: schema.TypeString, Nullable: true})
 	src.readCh = mustClosedRecords()
 
 	strat := &TruncateInsertStrategy{}
@@ -77,6 +460,7 @@ func TestTruncateInsertStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema
 	if dest.mergeCalls[0].IncrementalKey != "" {
 		t.Fatalf("MergeOptions.IncrementalKey = %q, want empty for missing staging column", dest.mergeCalls[0].IncrementalKey)
 	}
+	require.NotContains(t, dest.mergeCalls[0].Columns, "_cdc_unchanged_cols")
 }
 
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {
@@ -100,4 +484,109 @@ func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t
 	if len(dest.writeCalls) != 0 {
 		t.Fatalf("expected no write when source read setup fails, got %d", len(dest.writeCalls))
 	}
+	require.ElementsMatch(t, []string{job.Config.DestTable, dest.prepareCalls[1].Table}, dest.dropCalls)
+}
+
+func TestTruncateInsertStrategy_DirectReadSetupFailsBeforeTruncate(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readErr = errors.New("read setup failed")
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected read setup failure")
+	}
+	if len(dest.truncateCalls) != 0 {
+		t.Fatalf("target was truncated before source setup succeeded: %v", dest.truncateCalls)
+	}
+	require.Equal(t, []string{job.Config.DestTable}, dest.dropCalls)
+}
+
+func TestTruncateInsertStrategy_StagingFailureDropsManagedTable(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.readCh = mustClosedRecords()
+	dest.writeErr = errors.New("write failed")
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	staging := dest.prepareCalls[1].Table
+	require.ElementsMatch(t, []string{job.Config.DestTable, staging}, dest.dropCalls)
+}
+
+func TestTruncateInsertStrategy_DirectTruncateFailurePreservesNewTarget(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+	dest.truncateErr = errors.New("truncate failed")
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	require.Empty(t, dest.dropCalls, "truncate errors may be lost responses after a durable truncate")
+}
+
+func TestTruncateInsertStrategy_DirectFailurePreservesReplacementOwner(t *testing.T) {
+	job, src, base := minimalJob()
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+	base.writeErr = errors.New("write failed after replacement")
+	dest := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.Error(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "write errors may follow durable truncate/insert work")
+	require.Empty(t, base.dropCalls, "unconditional cleanup must not delete a replacement owner")
+}
+
+func TestTruncateInsertStrategy_StagedMergeFailurePreservesTargetAndDropsStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	src.readCh = mustClosedRecords()
+	dest.mergeErr = errors.New("merge failed")
+
+	err := (&TruncateInsertStrategy{}).Execute(context.Background(), job)
+	require.Error(t, err)
+	require.NotContains(t, dest.dropCalls, job.Config.DestTable)
+	require.Equal(t, []string{dest.prepareCalls[1].Table}, dest.dropCalls)
+}
+
+func TestTruncateInsertStrategy_StagedTruncateLostResponsePreservesTargetAndDropsStaging(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	base.truncateErr = errors.New("truncate response lost after commit")
+	dest := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.ErrorContains(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job), "truncate response lost")
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens)
+	require.NotContains(t, base.dropCalls, job.Config.DestTable)
+	require.Equal(t, []string{base.prepareCalls[1].Table}, base.dropCalls)
+}
+
+func TestTruncateInsertStrategy_StagedFailurePreservesReplacementOwner(t *testing.T) {
+	job, src, base := minimalJob()
+	src.readCh = mustClosedRecords()
+	base.mergeErr = errors.New("merge failed after replacement")
+	dest := &ownedTruncateDestination{truncateCapableDestination: &truncateCapableDestination{fakeDestination: base}}
+	job.Destination = dest
+
+	require.Error(t, (&TruncateInsertStrategy{}).Execute(context.Background(), job))
+	require.NotEmpty(t, dest.preparedToken)
+	require.Empty(t, dest.dropTokens, "merge errors may follow a durable target mutation")
+	require.NotContains(t, base.dropCalls, job.Config.DestTable)
+	require.Contains(t, base.dropCalls, base.prepareCalls[1].Table, "owned staging table should still be reclaimed")
 }


### PR DESCRIPTION
## Summary

Routes evolution plans and source capabilities through the pipeline with validation and regression coverage.

## Stack

Part 6 of 11. Review and merge bottom-up. This PR is based on `stack/iceberg-05-strategy-safety`; GitHub therefore shows only this layer's delta.

Previous: https://github.com/bruin-data/ingestr/pull/963 · Next: https://github.com/bruin-data/ingestr/pull/965

## Validation

- `make format`
- `make lint`
- `make test`
- Layer-specific package tests

The complete stack is byte-for-byte equivalent to the previously reviewed full implementation.