### PR TITLE
Iceberg stack 7/11: PostgreSQL CDC snapshot safety

### DIFF
--- a/pkg/source/postgres_cdc/array_literal.go
+++ b/pkg/source/postgres_cdc/array_literal.go
@@ -20,6 +20,13 @@ type arrayElement struct {
 // recover the elements. Quoted elements are unescaped (\" -> ", \\ -> \), so a
 // jsonb[] element is returned as standalone JSON ready for per-element typing.
 func parsePostgresArrayLiteral(s string) ([]arrayElement, bool) {
+	return parsePostgresArrayLiteralWithDelimiter(s, ',')
+}
+
+func parsePostgresArrayLiteralWithDelimiter(s string, delimiter byte) ([]arrayElement, bool) {
+	if delimiter == 0 {
+		delimiter = ','
+	}
 	s = strings.TrimSpace(s)
 	if len(s) < 2 || s[0] != '{' || s[len(s)-1] != '}' {
 		return nil, false
@@ -58,7 +65,7 @@ func parsePostgresArrayLiteral(s string) ([]arrayElement, bool) {
 				i++
 			}
 			elems = append(elems, arrayElement{value: b.String()})
-			for i < n && inner[i] != ',' {
+			for i < n && inner[i] != delimiter {
 				i++
 			}
 			if i < n {
@@ -74,7 +81,7 @@ func parsePostgresArrayLiteral(s string) ([]arrayElement, bool) {
 		if inner[i] == '{' {
 			return nil, false
 		}
-		for i < n && inner[i] != ',' {
+		for i < n && inner[i] != delimiter {
 			i++
 		}
 		raw := strings.TrimSpace(inner[start:i])

--- a/pkg/source/postgres_cdc/array_literal_test.go
+++ b/pkg/source/postgres_cdc/array_literal_test.go
@@ -3,6 +3,9 @@ package postgres_cdc
 import (
 	"reflect"
 	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePostgresArrayLiteral(t *testing.T) {
@@ -58,4 +61,38 @@ func TestParsePostgresArrayLiteral(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertTextValueRejectsUnsupportedArrayShapes(t *testing.T) {
+	col := schema.Column{Name: "items", DataType: schema.TypeArray, ArrayType: schema.TypeString}
+	for _, literal := range []string{"[2:3]={a,b}", "{{a,b},{c,d}}"} {
+		t.Run(literal, func(t *testing.T) {
+			value, err := convertTextValue(literal, col)
+			require.Nil(t, value)
+			require.ErrorContains(t, err, "only one-dimensional arrays with default bounds are supported")
+		})
+	}
+}
+
+func TestConvertTextValueUsesArrayElementMetadata(t *testing.T) {
+	col := schema.Column{
+		Name:      "items",
+		DataType:  schema.TypeArray,
+		ArrayType: schema.TypeString,
+		Element:   &schema.Column{DataType: schema.TypeInt32},
+	}
+
+	value, err := convertTextValue("{1,2}", col)
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{int32(1), int32(2)}, value)
+}
+
+func TestConvertTextValueUsesPostgresArrayDelimiter(t *testing.T) {
+	col := schema.Column{
+		Name: "boxes", DataType: schema.TypeArray, ArrayType: schema.TypeString, ArrayDelimiter: ";",
+	}
+
+	value, err := convertTextValue("{(1,1),(0,0);(2,2),(1,1)}", col)
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{"(1,1),(0,0)", "(2,2),(1,1)"}, value)
 }

--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 	"unsafe"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -13,6 +14,15 @@ import (
 )
 
 const accumulatorTableOverhead = int64(1024)
+
+// These limits are part of the pgcdc-keyless-v1 durable ID contract. The
+// namespace predates keyed append support and is retained for replay
+// compatibility. They must not track decoder tuning constants; changing either
+// requires a new identity version.
+const (
+	keylessDataBatchWindowChanges uint64 = 1024
+	keylessDataBatchWindowBytes   int64  = 8 << 20
+)
 
 var (
 	changeStructBytes = int64(unsafe.Sizeof(Change{}))
@@ -36,16 +46,22 @@ type batchAccumulator struct {
 	totalBytes int64
 	threshold  int
 	byteLimit  int64
+	// blockedKeyless contains tables whose newest transaction sequence window
+	// has not closed yet. Its historical name is retained because the identity
+	// contract originated with keyless CDC.
+	blockedKeyless map[string]bool
+	stableAll      bool
 }
 
 func newBatchAccumulator(threshold int, schemas map[string]*schema.TableSchema) *batchAccumulator {
 	return &batchAccumulator{
-		schemas:   schemas,
-		changes:   make(map[string][]Change),
-		minLSN:    make(map[string]pglogrepl.LSN),
-		bytes:     make(map[string]int64),
-		threshold: threshold,
-		byteLimit: defaultDecoderMemoryBytes,
+		schemas:        schemas,
+		changes:        make(map[string][]Change),
+		minLSN:         make(map[string]pglogrepl.LSN),
+		bytes:          make(map[string]int64),
+		threshold:      threshold,
+		byteLimit:      defaultDecoderMemoryBytes,
+		blockedKeyless: make(map[string]bool),
 	}
 }
 
@@ -153,12 +169,102 @@ func (a *batchAccumulator) discard() {
 	a.minLSN = make(map[string]pglogrepl.LSN)
 	a.bytes = make(map[string]int64)
 	a.totalBytes = 0
+	a.blockedKeyless = make(map[string]bool)
 }
 
 // tokenFunc computes the CommitToken to attach to a flushed batch. It is
 // evaluated after the flushed table's changes have been removed from the
 // accumulator, so it reflects only data that remains un-emitted.
 type tokenFunc func() any
+
+type keylessBatchWindowState struct {
+	window  uint64
+	changes uint64
+	bytes   int64
+}
+
+func (s *keylessBatchWindowState) assign(change *Change) {
+	size := stableChangeBytes(*change)
+	if s.changes > 0 && (s.changes >= keylessDataBatchWindowChanges || s.bytes+size > keylessDataBatchWindowBytes) {
+		s.window++
+		s.changes = 0
+		s.bytes = 0
+	}
+	change.DataBatchWindow = s.window
+	s.changes++
+	s.bytes += size
+}
+
+func stableChangeBytes(change Change) int64 {
+	size := int64(32 + len(change.Operation))
+	for _, values := range [][]interface{}{change.Values, change.OldValues} {
+		size += 8
+		for _, value := range values {
+			size += stableValueBytes(reflect.ValueOf(value))
+		}
+	}
+	return size
+}
+
+func stableValueBytes(value reflect.Value) int64 {
+	if !value.IsValid() {
+		return 1
+	}
+	if value.Type() == reflect.TypeOf(time.Time{}) {
+		return 16
+	}
+	if value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return 1
+		}
+		return 1 + stableValueBytes(value.Elem())
+	}
+	switch value.Kind() {
+	case reflect.Bool:
+		return 1
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+		return int64(value.Type().Bits() / 8)
+	case reflect.String:
+		return 8 + int64(value.Len())
+	case reflect.Slice, reflect.Array:
+		size := int64(8)
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			return size + int64(value.Len())
+		}
+		for i := 0; i < value.Len(); i++ {
+			size += stableValueBytes(value.Index(i))
+		}
+		return size
+	case reflect.Map:
+		size := int64(8)
+		iter := value.MapRange()
+		for iter.Next() {
+			size += stableValueBytes(iter.Key()) + stableValueBytes(iter.Value())
+		}
+		return size
+	case reflect.Struct:
+		size := int64(8)
+		for i := 0; i < value.NumField(); i++ {
+			size += stableValueBytes(value.Field(i))
+		}
+		return size
+	default:
+		return 8
+	}
+}
+
+func transactionDataBatchID(tableName string, changes []Change) string {
+	first := changes[0]
+	return fmt.Sprintf(
+		"pgcdc-keyless-v1:%d:%s:%s:%d",
+		len(tableName),
+		tableName,
+		FormatLSN(first.LSN),
+		first.DataBatchWindow,
+	)
+}
 
 // flushReady sends merged batches for tables that have accumulated enough rows.
 func (a *batchAccumulator) flushReady(results chan<- source.RecordBatchResult, token tokenFunc) error {
@@ -167,6 +273,9 @@ func (a *batchAccumulator) flushReady(results chan<- source.RecordBatchResult, t
 
 func (a *batchAccumulator) flushReadyContext(ctx context.Context, results chan<- source.RecordBatchResult, token tokenFunc) error {
 	for tableName, changes := range a.changes {
+		if a.blockedKeyless[tableName] {
+			continue
+		}
 		if len(changes) >= a.threshold || lastTruncateIndex(changes) >= 0 {
 			if err := a.flushTableContext(ctx, tableName, results, token); err != nil {
 				return err
@@ -190,6 +299,9 @@ func (a *batchAccumulator) largestTable() (string, bool) {
 	var largestBytes int64
 	found := false
 	for tableName, size := range a.bytes {
+		if a.blockedKeyless[tableName] {
+			continue
+		}
 		if !found || size > largestBytes {
 			largest = tableName
 			largestBytes = size
@@ -206,6 +318,9 @@ func (a *batchAccumulator) flushAll(results chan<- source.RecordBatchResult, tok
 
 func (a *batchAccumulator) flushAllContext(ctx context.Context, results chan<- source.RecordBatchResult, token tokenFunc) error {
 	for tableName := range a.changes {
+		if a.blockedKeyless[tableName] {
+			continue
+		}
 		if err := a.flushTableContext(ctx, tableName, results, token); err != nil {
 			return err
 		}
@@ -213,15 +328,69 @@ func (a *batchAccumulator) flushAllContext(ctx context.Context, results chan<- s
 	return nil
 }
 
+// flushStableKeylessContext emits CDC data in fixed transaction-local sequence
+// windows. pendingLow is the decoder's oldest transaction that has not been
+// fully handed to this accumulator. A window is safe to emit when a later
+// window for the same table has arrived, or when its transaction is no longer
+// pending in the decoder. The historical name is retained because this replay
+// contract originated with keyless CDC.
+func (a *batchAccumulator) flushStableKeylessContext(
+	ctx context.Context,
+	results chan<- source.RecordBatchResult,
+	token tokenFunc,
+	pendingLow pglogrepl.LSN,
+	pending bool,
+) error {
+	for tableName := range a.changes {
+		tableSchema := a.schemas[tableName]
+		if tableSchema == nil || (!a.stableAll && len(tableSchema.PrimaryKeys) > 0) {
+			continue
+		}
+		for {
+			changes := a.changes[tableName]
+			if len(changes) == 0 {
+				delete(a.blockedKeyless, tableName)
+				break
+			}
+			lsn := changes[0].LSN
+			window := changes[0].DataBatchWindow
+			end := 1
+			for end < len(changes) && changes[end].LSN == lsn && changes[end].DataBatchWindow == window {
+				end++
+			}
+			transactionComplete := !pending || lsn < pendingLow
+			windowClosed := end < len(changes)
+			if !transactionComplete && !windowClosed {
+				a.blockedKeyless[tableName] = true
+				break
+			}
+			delete(a.blockedKeyless, tableName)
+			if err := a.flushTablePrefixContext(ctx, tableName, end, results, token); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName string, results chan<- source.RecordBatchResult, token tokenFunc) error {
+	return a.flushTablePrefixContext(ctx, tableName, len(a.changes[tableName]), results, token)
+}
+
+func (a *batchAccumulator) flushTablePrefixContext(ctx context.Context, tableName string, count int, results chan<- source.RecordBatchResult, token tokenFunc) error {
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		a.discard()
 		return err
 	}
-	changes := a.changes[tableName]
-	if len(changes) == 0 {
+	bufferedChanges := a.changes[tableName]
+	if len(bufferedChanges) == 0 || count <= 0 {
 		return nil
 	}
+	if count > len(bufferedChanges) {
+		count = len(bufferedChanges)
+	}
+	changes := bufferedChanges[:count:count]
+	remainder := bufferedChanges[count:]
 
 	delete(a.changes, tableName)
 	delete(a.minLSN, tableName)
@@ -230,12 +399,14 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 		a.totalBytes = 0
 	}
 	delete(a.bytes, tableName)
+	if len(remainder) > 0 {
+		a.add(tableName, remainder, remainder[0].LSN)
+	}
 
 	truncateIndex := lastTruncateIndex(changes)
 	if truncateIndex >= 0 {
 		changes = changes[truncateIndex+1:]
 	}
-
 	tableSchema := a.schemas[tableName]
 	if tableSchema == nil {
 		return fmt.Errorf("no schema registered for table %q", tableName)
@@ -279,6 +450,37 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	if len(changes) == 0 {
 		return nil
 	}
+	if len(tableSchema.PrimaryKeys) == 0 {
+		for start := 0; start < len(changes); {
+			end := start + 1
+			for end < len(changes) && changes[end].LSN == changes[start].LSN {
+				end++
+			}
+			transactionToken := commitToken
+			if stateToken, ok := transactionToken.(source.CDCStateCommitToken); ok {
+				stateToken.DataBatchID = transactionDataBatchID(tableName, changes[start:end])
+				transactionToken = stateToken
+			}
+			batch, err := changesToBatch(changes[start:end], tableSchema)
+			if err != nil {
+				return fmt.Errorf("failed to materialize transaction batch for table %s: %w", tableName, err)
+			}
+			if err := source.ConnectorLeaseLoss(ctx); err != nil {
+				batch.Release()
+				a.discard()
+				return err
+			}
+			if err := sendResult(ctx, results, source.RecordBatchResult{
+				Batch: batch, TableName: tableName, CommitToken: transactionToken,
+			}); err != nil {
+				a.discard()
+				return err
+			}
+			start = end
+		}
+		config.Debug("[CDC] Flushed %d buffered changes as transaction batches for keyless table %s", buffered, tableName)
+		return nil
+	}
 
 	batch, err := changesToBatch(changes, tableSchema)
 	if err != nil {
@@ -291,11 +493,16 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	}
 
 	config.Debug("[CDC] Flushed %d buffered changes (%d rows after compaction) for table %s", buffered, len(changes), tableName)
+	batchToken := commitToken
+	if stateToken, ok := batchToken.(source.CDCStateCommitToken); ok {
+		stateToken.DataBatchID = transactionDataBatchID(tableName, changes)
+		batchToken = stateToken
+	}
 
 	if err := sendResult(ctx, results, source.RecordBatchResult{
 		Batch:       batch,
 		TableName:   tableName,
-		CommitToken: commitToken,
+		CommitToken: batchToken,
 	}); err != nil {
 		a.discard()
 		return err

--- a/pkg/source/postgres_cdc/cdc_fill_test.go
+++ b/pkg/source/postgres_cdc/cdc_fill_test.go
@@ -332,13 +332,19 @@ func TestFlushWindowCompaction(t *testing.T) {
 		results := make(chan source.RecordBatchResult, 4)
 		require.NoError(t, accum.flushAll(results, nil))
 		close(results)
-		res := <-results
-		require.NotNil(t, res.Batch)
-		defer res.Batch.Release()
-		assert.EqualValues(t, 3, res.Batch.NumRows())
-		assert.False(t, deletedValueAt(t, res.Batch, 0))
-		assert.True(t, deletedValueAt(t, res.Batch, 1))
-		assert.False(t, deletedValueAt(t, res.Batch, 2))
+		var batches []arrow.RecordBatch
+		for res := range results {
+			require.NotNil(t, res.Batch)
+			batches = append(batches, res.Batch)
+		}
+		require.Len(t, batches, 2, "keyless CDC emits one durable write unit per source transaction")
+		defer batches[0].Release()
+		defer batches[1].Release()
+		assert.EqualValues(t, 1, batches[0].NumRows())
+		assert.False(t, deletedValueAt(t, batches[0], 0))
+		assert.EqualValues(t, 2, batches[1].NumRows())
+		assert.True(t, deletedValueAt(t, batches[1], 0))
+		assert.False(t, deletedValueAt(t, batches[1], 1))
 	})
 
 	t.Run("pk-changing update keeps old-key history and new-key row", func(t *testing.T) {

--- a/pkg/source/postgres_cdc/correctness_regression_test.go
+++ b/pkg/source/postgres_cdc/correctness_regression_test.go
@@ -3,6 +3,7 @@ package postgres_cdc
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,220 @@ func TestBatchAccumulatorFlushesOnByteLimitBelowRowThreshold(t *testing.T) {
 	result.Batch.Release()
 	assert.Empty(t, a.changes)
 	assert.Zero(t, a.totalBytes)
+}
+
+func TestBatchAccumulatorEmitsStableUniqueDataBatchIdentity(t *testing.T) {
+	for schemaName, tableSchema := range map[string]*schema.TableSchema{
+		"keyless": keylessTestSchema(),
+		"keyed":   keyedTestSchema(),
+	} {
+		for _, tableName := range []string{"", "public.events"} {
+			t.Run(schemaName+"/"+tableName, func(t *testing.T) {
+				flushWindows := func(windows [][]Change) []source.CDCStateCommitToken {
+					a := newBatchAccumulator(100, map[string]*schema.TableSchema{tableName: tableSchema})
+					a.stableAll = true
+					results := make(chan source.RecordBatchResult, 16)
+					for _, window := range windows {
+						a.add(tableName, window, window[0].LSN)
+						require.NoError(t, a.flushStableKeylessContext(t.Context(), results, func() any {
+							return source.CDCStateCommitToken{Position: "00000000/00000100"}
+						}, 0, false))
+						require.NoError(t, a.flushAllContext(t.Context(), results, func() any {
+							return source.CDCStateCommitToken{Position: "00000000/00000100"}
+						}))
+					}
+					close(results)
+					var tokens []source.CDCStateCommitToken
+					for result := range results {
+						require.NotNil(t, result.Batch)
+						result.Batch.Release()
+						token, ok := result.CommitToken.(source.CDCStateCommitToken)
+						require.True(t, ok)
+						tokens = append(tokens, token)
+					}
+					return tokens
+				}
+
+				c1 := Change{Operation: "INSERT", LSN: 0x110, Sequence: 2, Values: []interface{}{int32(1), "same"}}
+				c2 := Change{Operation: "INSERT", LSN: 0x120, Sequence: 2, Values: []interface{}{int32(1), "same"}}
+				c3 := Change{Operation: "INSERT", LSN: 0x130, Sequence: 2, Values: []interface{}{int32(1), "same"}}
+				firstGrouping := flushWindows([][]Change{{c1, c2}, {c3}})
+				retryGrouping := flushWindows([][]Change{{c1, c2, c3}})
+
+				require.Len(t, firstGrouping, 3)
+				require.Equal(t, firstGrouping, retryGrouping, "accumulator window regrouping must not change transaction write identities")
+				require.NotEqual(t, firstGrouping[0].DataBatchID, firstGrouping[1].DataBatchID, "duplicate payloads from distinct transactions need distinct identities")
+				require.NotEqual(t, firstGrouping[1].DataBatchID, firstGrouping[2].DataBatchID)
+			})
+		}
+	}
+}
+
+func TestDataBatchIdentityIsTableScoped(t *testing.T) {
+	changes := []Change{{LSN: 0x110, Sequence: 2}}
+	require.NotEqual(t, transactionDataBatchID("public.events", changes), transactionDataBatchID("public.audit", changes))
+	require.True(t, strings.HasPrefix(transactionDataBatchID("public.events", changes), "pgcdc-keyless-v1:"))
+}
+
+func TestIncompleteKeylessSequenceWindowIsNotFlushedOnErrorPath(t *testing.T) {
+	tableSchema := keylessTestSchema()
+	accum := newBatchAccumulator(1, map[string]*schema.TableSchema{"public.events": tableSchema})
+	accum.add("public.events", []Change{{
+		Operation: "INSERT", LSN: 0x900, Sequence: 2, Values: []interface{}{int32(1), "same"},
+	}}, 0x900)
+	results := make(chan source.RecordBatchResult, 1)
+	token := func() any { return source.CDCStateCommitToken{Position: "00000000/000008FF"} }
+
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, token, 0x900, true))
+	require.NoError(t, accum.flushReadyContext(t.Context(), results, token))
+	require.NoError(t, accum.flushAllContext(t.Context(), results, token))
+	require.Empty(t, results, "a partial deterministic window must be replayed, not emitted with a drain-dependent identity")
+
+	require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, token, 0, false))
+	result := <-results
+	require.NotNil(t, result.Batch)
+	result.Batch.Release()
+}
+
+func TestKeylessDataBatchWindowIsByteBoundedAndCapacityIndependent(t *testing.T) {
+	compactValues := []interface{}{strings.Repeat("x", 128)}
+	spareValues := make([]interface{}, 1, 64)
+	spareValues[0] = compactValues[0]
+	compact := Change{Operation: "INSERT", Values: compactValues}
+	spare := Change{Operation: "INSERT", Values: spareValues}
+	require.Equal(t, stableChangeBytes(compact), stableChangeBytes(spare))
+
+	large := Change{Operation: "INSERT", Values: []interface{}{strings.Repeat("x", int(keylessDataBatchWindowBytes/2)+1)}}
+	state := keylessBatchWindowState{}
+	state.assign(&large)
+	require.Equal(t, uint64(0), large.DataBatchWindow)
+	second := large
+	state.assign(&second)
+	require.Equal(t, uint64(1), second.DataBatchWindow)
+}
+
+func TestLargeKeylessTransactionFragmentsHaveStableUniqueIdentities(t *testing.T) {
+	const changeCount = defaultCommittedDrainChanges*2 + 2
+	run := func(drainLimit int) ([]string, int64) {
+		tableSchema := keylessTestSchema()
+		decoder := NewDecoder(tableSchema, "public", "events")
+		decoder.currentTxLSN = 0x900
+		for i := 0; i < changeCount; i++ {
+			require.NoError(t, decoder.appendChange(Change{
+				Operation: "INSERT", LSN: decoder.currentTxLSN, Values: []interface{}{int32(i), "same"},
+			}))
+		}
+		require.NoError(t, decoder.pendingChanges.Seal())
+		decoder.committed = decoder.pendingChanges
+		decoder.pendingChanges = newChangeSpoolWithBudget[Change](defaultTransactionMemoryBytes, decoder.memoryBudget, nil)
+		accum := newBatchAccumulator(changeCount+1, map[string]*schema.TableSchema{"": tableSchema})
+		results := make(chan source.RecordBatchResult, 8)
+		flush := func(changes []Change) {
+			accum.add("", changes, decoder.currentTxLSN)
+			pendingLow, pending := decoder.CommittedLowWater()
+			require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, func() any {
+				return source.CDCStateCommitToken{Position: "00000000/00000800"}
+			}, pendingLow, pending))
+		}
+		for decoder.HasCommitted() {
+			fragment, err := decoder.DrainCommitted(drainLimit)
+			require.NoError(t, err)
+			flush(fragment)
+		}
+		require.NoError(t, decoder.Close())
+		close(results)
+		var ids []string
+		var rows int64
+		for result := range results {
+			token := result.CommitToken.(source.CDCStateCommitToken)
+			ids = append(ids, token.DataBatchID)
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		return ids, rows
+	}
+
+	firstIDs, firstRows := run(257)
+	replayIDs, replayRows := run(defaultCommittedDrainChanges + 333)
+	require.EqualValues(t, changeCount, firstRows)
+	require.Equal(t, firstRows, replayRows)
+	require.Len(t, firstIDs, 3)
+	require.Equal(t, firstIDs, replayIDs)
+	require.Len(t, map[string]struct{}{firstIDs[0]: {}, firstIDs[1]: {}, firstIDs[2]: {}}, 3)
+}
+
+func TestLargeMultiTableKeylessTransactionFragmentsHaveStableUniqueIdentities(t *testing.T) {
+	const changesPerTable = defaultCommittedDrainChanges*2 + 2
+	run := func(drainLimit int, blockedInterleaving bool) ([]string, int64) {
+		tableSchema := keylessTestSchema()
+		tables := []source.SourceTableInfo{{Name: "public.events", Schema: tableSchema}, {Name: "public.audit", Schema: tableSchema}}
+		decoder := NewMultiTableDecoder(tables)
+		decoder.currentTxLSN = 0x900
+		appendTableChange := func(table string, value int) {
+			require.NoError(t, decoder.appendChange(TableChange{TableName: table, Change: Change{
+				Operation: "INSERT", Values: []interface{}{int32(value), "same"},
+			}}))
+		}
+		if blockedInterleaving {
+			for _, table := range tables {
+				for i := 0; i < changesPerTable; i++ {
+					appendTableChange(table.Name, i)
+				}
+			}
+		} else {
+			for i := 0; i < changesPerTable; i++ {
+				for _, table := range tables {
+					appendTableChange(table.Name, i)
+				}
+			}
+		}
+		require.NoError(t, decoder.pendingChanges.Seal())
+		decoder.committed = decoder.pendingChanges
+		decoder.committedLSN = decoder.currentTxLSN
+		decoder.committedTableSequences = make(map[string]uint64)
+		decoder.pendingChanges = newChangeSpoolWithBudget[streamedChange](defaultTransactionMemoryBytes, decoder.memoryBudget, streamedChangeXID)
+		schemas := map[string]*schema.TableSchema{tables[0].Name: tableSchema, tables[1].Name: tableSchema}
+		accum := newBatchAccumulator(changesPerTable*len(tables)+1, schemas)
+		results := make(chan source.RecordBatchResult, 16)
+		flush := func(groups []DecodedChanges) {
+			for _, group := range groups {
+				accum.add(group.TableName, group.Changes, group.LSN)
+			}
+			pendingLow, pending := decoder.CommittedLowWater()
+			require.NoError(t, accum.flushStableKeylessContext(t.Context(), results, func() any {
+				return source.CDCStateCommitToken{Position: "00000000/00000800"}
+			}, pendingLow, pending))
+		}
+		for decoder.HasCommitted() {
+			groups, err := decoder.DrainCommitted(drainLimit)
+			require.NoError(t, err)
+			flush(groups)
+		}
+		require.NoError(t, decoder.Close())
+		close(results)
+		var ids []string
+		var rows int64
+		for result := range results {
+			token := result.CommitToken.(source.CDCStateCommitToken)
+			ids = append(ids, token.DataBatchID)
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		sort.Strings(ids)
+		return ids, rows
+	}
+
+	firstIDs, firstRows := run(317, false)
+	replayIDs, replayRows := run(defaultCommittedDrainChanges+471, true)
+	require.EqualValues(t, changesPerTable*2, firstRows)
+	require.Equal(t, firstRows, replayRows)
+	require.Len(t, firstIDs, 6)
+	require.Equal(t, firstIDs, replayIDs)
+	unique := make(map[string]struct{}, len(firstIDs))
+	for _, id := range firstIDs {
+		unique[id] = struct{}{}
+	}
+	require.Len(t, unique, len(firstIDs))
 }
 
 func TestBatchAccumulatorByteLimitIsGlobalAcrossTables(t *testing.T) {

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -43,26 +43,28 @@ const (
 )
 
 type Change struct {
-	Operation string // "INSERT", "UPDATE", "DELETE", "TRUNCATE"
-	LSN       pglogrepl.LSN
-	Sequence  uint64 // 1-based order within the committing transaction
-	Values    []interface{}
-	OldValues []interface{} // For UPDATE/DELETE with replica identity
+	Operation       string // "INSERT", "UPDATE", "DELETE", "TRUNCATE"
+	LSN             pglogrepl.LSN
+	Sequence        uint64 // 1-based order within the committing transaction
+	DataBatchWindow uint64
+	Values          []interface{}
+	OldValues       []interface{} // For UPDATE/DELETE with replica identity
 }
 
 type Decoder struct {
-	tableSchema    *schema.TableSchema
-	targetSchema   string
-	targetTable    string
-	relations      map[uint32]*RelationInfo
-	targetRelID    uint32
-	expectedRelID  uint32
-	pendingChanges *changeSpool[Change]
-	committed      *changeSpool[Change]
-	currentTxLSN   pglogrepl.LSN
-	typeMap        *pgtype.Map
-	allowedUnknown map[string]struct{}
-	memoryBudget   *byteBudget
+	tableSchema          *schema.TableSchema
+	targetSchema         string
+	targetTable          string
+	relations            map[uint32]*RelationInfo
+	targetRelID          uint32
+	expectedRelID        uint32
+	pendingChanges       *changeSpool[Change]
+	committed            *changeSpool[Change]
+	committedBatchWindow keylessBatchWindowState
+	currentTxLSN         pglogrepl.LSN
+	typeMap              *pgtype.Map
+	allowedUnknown       map[string]struct{}
+	memoryBudget         *byteBudget
 }
 
 func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *Decoder {
@@ -257,6 +259,7 @@ func (d *Decoder) handleCommit() ([]Change, error) {
 		return nil, err
 	}
 	d.committed = d.pendingChanges
+	d.committedBatchWindow = keylessBatchWindowState{}
 	d.pendingChanges = newChangeSpoolWithBudget[Change](defaultTransactionMemoryBytes, d.memoryBudget, nil)
 	return d.DrainCommitted(defaultCommittedDrainChanges)
 }
@@ -276,6 +279,9 @@ func (d *Decoder) DrainCommitted(limit int) ([]Change, error) {
 	changes, err := d.committed.Drain(limit)
 	if err != nil {
 		return nil, err
+	}
+	for i := range changes {
+		d.committedBatchWindow.assign(&changes[i])
 	}
 	if d.committed.Len() == 0 {
 		err = d.committed.Close()
@@ -567,11 +573,24 @@ func convertTextValueWithMap(text string, col schema.Column, typeMap *pgtype.Map
 		// element by the element type. Returning a []interface{} lets the list
 		// builder populate the array; the snapshot path produces the same shape
 		// via pgx, keeping streaming and snapshot consistent.
-		elems, ok := parsePostgresArrayLiteral(text)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL array literal %q", text)
+		var delimiter byte
+		if col.ArrayDelimiter != "" {
+			if len(col.ArrayDelimiter) != 1 {
+				return nil, fmt.Errorf("unsupported PostgreSQL array delimiter %q", col.ArrayDelimiter)
+			}
+			delimiter = col.ArrayDelimiter[0]
 		}
-		elemCol := schema.Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale}
+		elems, ok := parsePostgresArrayLiteralWithDelimiter(text, delimiter)
+		if !ok {
+			return nil, fmt.Errorf("unsupported PostgreSQL array literal %q: only one-dimensional arrays with default bounds are supported", text)
+		}
+		elemCol := schema.Column{
+			DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale,
+			MaxLength: col.MaxLength, FixedLength: col.FixedLength,
+		}
+		if col.Element != nil {
+			elemCol = *col.Element
+		}
 		out := make([]interface{}, len(elems))
 		for i, e := range elems {
 			if e.isNull {

--- a/pkg/source/postgres_cdc/decoder_test.go
+++ b/pkg/source/postgres_cdc/decoder_test.go
@@ -11,6 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDecoderIgnoresTruncateOfNonTargetTables(t *testing.T) {
+	decoder := NewDecoder(&schema.TableSchema{}, "public", "events")
+	decoder.targetRelID = 42
+	changes, err := decoder.Decode(truncateMessage(7), 100)
+	require.NoError(t, err)
+	require.Nil(t, changes)
+}
+
+func truncateMessage(relIDs ...uint32) []byte {
+	msg := []byte{msgTypeTruncate}
+	msg = binary.BigEndian.AppendUint32(msg, uint32(len(relIDs)))
+	msg = append(msg, 0)
+	for _, id := range relIDs {
+		msg = binary.BigEndian.AppendUint32(msg, id)
+	}
+	return msg
+}
+
 func TestConvertTextValue(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -35,18 +35,20 @@ func streamedChangeXID(change streamedChange) uint32 { return change.XID }
 // (Stream Start/Stop/Commit/Abort) and, when the stream runs with the
 // `binary 'true'` option, binary-format tuple data.
 type MultiTableDecoder struct {
-	tableSchemas   map[string]*schema.TableSchema // schema name.table name -> schema
-	expectedRelIDs map[string]uint32              // full table name -> connect-time relation ID
-	relations      map[uint32]*RelationInfo
-	targetRelIDs   map[uint32]string // relation ID -> full table name
-	pendingChanges *changeSpool[streamedChange]
-	committed      *changeSpool[streamedChange]
-	committedLSN   pglogrepl.LSN
-	currentTxLSN   pglogrepl.LSN
-	typeMap        *pgtype.Map
-	allowedUnknown map[string]map[string]struct{}
-	historicalIDs  map[string]map[uint32]struct{}
-	memoryBudget   *byteBudget
+	tableSchemas            map[string]*schema.TableSchema // schema name.table name -> schema
+	expectedRelIDs          map[string]uint32              // full table name -> connect-time relation ID
+	relations               map[uint32]*RelationInfo
+	targetRelIDs            map[uint32]string // relation ID -> full table name
+	pendingChanges          *changeSpool[streamedChange]
+	committed               *changeSpool[streamedChange]
+	committedLSN            pglogrepl.LSN
+	committedTableSequences map[string]uint64
+	committedBatchWindows   map[string]*keylessBatchWindowState
+	currentTxLSN            pglogrepl.LSN
+	typeMap                 *pgtype.Map
+	allowedUnknown          map[string]map[string]struct{}
+	historicalIDs           map[string]map[uint32]struct{}
+	memoryBudget            *byteBudget
 
 	// Protocol v2 streaming state. Between Stream Start and Stream Stop,
 	// change messages carry a subtransaction xid and are buffered per
@@ -216,6 +218,8 @@ func (d *MultiTableDecoder) handleStreamCommit(data []byte) ([]DecodedChanges, e
 	}
 	d.committed = buffered
 	d.committedLSN = commitLSN
+	d.committedTableSequences = make(map[string]uint64)
+	d.committedBatchWindows = make(map[string]*keylessBatchWindowState)
 	return d.DrainCommitted(defaultCommittedDrainChanges)
 }
 
@@ -302,7 +306,9 @@ func (d *MultiTableDecoder) handleRelation(data []byte) error {
 	tableName := fmt.Sprintf("%s.%s", rel.Namespace, rel.Name)
 	if _, ok := d.tableSchemas[tableName]; !ok {
 		tableName = ""
-		// Also try without schema prefix for public schema
+		// Keep accepting legacy callers that constructed public table metadata
+		// with a bare name. GetTables always supplies the canonical qualified
+		// form, so managed CDC state never takes this compatibility path.
 		if rel.Namespace == "public" {
 			if _, ok := d.tableSchemas[rel.Name]; ok {
 				tableName = rel.Name
@@ -396,6 +402,8 @@ func (d *MultiTableDecoder) handleCommit() ([]DecodedChanges, error) {
 	}
 	d.committed = d.pendingChanges
 	d.committedLSN = d.currentTxLSN
+	d.committedTableSequences = make(map[string]uint64)
+	d.committedBatchWindows = make(map[string]*keylessBatchWindowState)
 	d.pendingChanges = newChangeSpoolWithBudget[streamedChange](defaultTransactionMemoryBytes, d.memoryBudget, streamedChangeXID)
 	return d.DrainCommitted(defaultCommittedDrainChanges)
 }
@@ -412,6 +420,12 @@ func (d *MultiTableDecoder) DrainCommitted(limit int) ([]DecodedChanges, error) 
 	if !d.HasCommitted() {
 		return nil, nil
 	}
+	if d.committedTableSequences == nil {
+		d.committedTableSequences = make(map[string]uint64)
+	}
+	if d.committedBatchWindows == nil {
+		d.committedBatchWindows = make(map[string]*keylessBatchWindowState)
+	}
 	buffered, err := d.committed.Drain(limit)
 	if err != nil {
 		return nil, err
@@ -424,6 +438,14 @@ func (d *MultiTableDecoder) DrainCommitted(limit int) ([]DecodedChanges, error) 
 			continue
 		}
 		tc.Change.LSN = d.committedLSN
+		d.committedTableSequences[tc.TableName]++
+		tc.Change.Sequence = d.committedTableSequences[tc.TableName] * 2
+		window := d.committedBatchWindows[tc.TableName]
+		if window == nil {
+			window = &keylessBatchWindowState{}
+			d.committedBatchWindows[tc.TableName] = window
+		}
+		window.assign(&tc.Change)
 		idx, ok := groupIdx[tc.TableName]
 		if !ok {
 			idx = len(groups)

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -285,7 +285,7 @@ func (r *MultiTableCDCReader) backfillTables(ctx context.Context, slotName strin
 			if opts.Streaming {
 				if _, replacement := replacements[table.Name]; replacement {
 					if err := sendResult(gctx, results, source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
-						TableName: table.Name, Incarnation: table.Incarnation,
+						TableName: table.Name, Incarnation: table.Incarnation, SchemaFingerprint: table.SchemaFingerprint,
 					}}); err != nil {
 						return err
 					}
@@ -383,19 +383,19 @@ func (r *MultiTableCDCReader) rebuildStream(ctx context.Context, slotName string
 	}
 	reconcileTableKeys(tables)
 
-	prevSchemas := make(map[string]*schema.TableSchema, len(r.tables))
+	previousTables := make(map[string]source.SourceTableInfo, len(r.tables))
 	prevIncarnations := make(map[string]string, len(r.tables))
 	for _, t := range r.tables {
-		prevSchemas[t.Name] = t.Schema
+		previousTables[t.Name] = t
 		prevIncarnations[t.Name] = t.Incarnation
 	}
 	var added []source.SourceTableInfo
 	for _, t := range tables {
-		if _, ok := prevSchemas[t.Name]; !ok {
+		if _, ok := previousTables[t.Name]; !ok {
 			added = append(added, t)
 		}
 	}
-	changedIndexes := shapeChangedTables(prevSchemas, tables)
+	changedIndexes := shapeChangedTables(previousTables, tables)
 	changedSet := make(map[string]struct{}, len(changedIndexes)+len(signal.changedTables)+len(signal.reincarnatedTables))
 	for _, idx := range changedIndexes {
 		changedSet[tables[idx].Name] = struct{}{}
@@ -495,18 +495,30 @@ func (r *MultiTableCDCReader) rebuildStream(ctx context.Context, slotName string
 // shapeChangedTables returns the indices of refreshed tables whose column
 // shape differs from the schema previously tracked for them. Tables not in
 // prev (newly added) are excluded — the backfill path announces those.
-func shapeChangedTables(prev map[string]*schema.TableSchema, refreshed []source.SourceTableInfo) []int {
+func shapeChangedTables(prev map[string]source.SourceTableInfo, refreshed []source.SourceTableInfo) []int {
 	var out []int
 	for i := range refreshed {
 		old, ok := prev[refreshed[i].Name]
 		if !ok {
 			continue
 		}
-		if !old.SameColumnShape(refreshed[i].Schema) {
+		if !old.Schema.SameColumnShape(refreshed[i].Schema) || !equalColumnNames(old.PrimaryKeys, refreshed[i].PrimaryKeys) {
 			out = append(out, i)
 		}
 	}
 	return out
+}
+
+func equalColumnNames(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !strings.EqualFold(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // detectNewTables lists the tables the stream should currently cover and
@@ -817,14 +829,13 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		schemas[t.Name] = t.Schema
 	}
 	accum := newBatchAccumulator(batchSize, schemas)
+	accum.stableAll = opts.CDCStableDataBatches
 
-	// In streaming mode, batches carry a CommitToken (safe LSN) so the pipeline
-	// confirms the slot only after the data is durable. barrierNonce is empty in
-	// streaming mode, so the barrier exit below never triggers.
-	var token tokenFunc
-	if opts.Streaming {
-		token = func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
-	}
+	// Every batch carries its safe source position. Streaming confirms the slot
+	// from it; managed batch ingestion uses it to identify keyless fragments.
+	// barrierNonce is empty in streaming mode, so the barrier exit below never
+	// triggers.
+	token := func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
 
 	// lastIdleToken is the highest LSN already handed to the pipeline via a bare
 	// idle commit token, so we only emit one when the caught-up position has
@@ -918,6 +929,10 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		}
 		for _, g := range groups {
 			accum.add(g.TableName, g.Changes, g.LSN)
+		}
+		pendingLow, pending := repl.PendingLowWater()
+		if err := accum.flushStableKeylessContext(ctx, results, token, pendingLow, pending); err != nil {
+			return nil, err
 		}
 
 		// Flush tables that have accumulated enough rows

--- a/pkg/source/postgres_cdc/new_table_test.go
+++ b/pkg/source/postgres_cdc/new_table_test.go
@@ -79,7 +79,7 @@ func TestBackfillSlotName(t *testing.T) {
 }
 
 func TestPublicationTableFullName(t *testing.T) {
-	assert.Equal(t, "users", publicationTableFullName("public", "users"))
+	assert.Equal(t, "public.users", publicationTableFullName("public", "users"))
 	assert.Equal(t, "app.orders", publicationTableFullName("app", "orders"))
 }
 

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -14,13 +14,14 @@ import (
 )
 
 type CDCReader struct {
-	source            *PostgresCDCSource
-	tableName         string
-	tableSchema       *schema.TableSchema
-	cdcConfig         CDCConfig
-	allowedUnknown    map[string]struct{}
-	incarnation       string
-	schemaFingerprint string
+	source                *PostgresCDCSource
+	tableName             string
+	tableSchema           *schema.TableSchema
+	configuredPrimaryKeys []string
+	cdcConfig             CDCConfig
+	allowedUnknown        map[string]struct{}
+	incarnation           string
+	schemaFingerprint     string
 }
 
 func NewCDCReader(src *PostgresCDCSource, tableName string, tableSchema *schema.TableSchema, cdcConfig CDCConfig) *CDCReader {
@@ -66,9 +67,7 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 				return
 			}
 			tableSchema = addCDCColumns(tableSchema)
-			if len(r.tableSchema.PrimaryKeys) > 0 {
-				tableSchema.PrimaryKeys = r.tableSchema.PrimaryKeys
-			}
+			r.applyConfiguredPrimaryKeys(tableSchema)
 			r.tableSchema = tableSchema
 		}
 
@@ -121,7 +120,7 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 		// Full mode: Phase 1: Snapshot
 		if replacementSnapshot && opts.Streaming {
 			if err := sendResult(ctx, results, source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
-				TableName: r.tableName, Incarnation: incarnation,
+				TableName: r.tableName, Incarnation: incarnation, SchemaFingerprint: fingerprint,
 			}}); err != nil {
 				return
 			}
@@ -255,6 +254,7 @@ func (r *CDCReader) runStream(ctx context.Context, startLSN pglogrepl.LSN, slotN
 	}
 
 	accum := newBatchAccumulator(batchSize, map[string]*schema.TableSchema{"": r.tableSchema})
+	accum.stableAll = opts.CDCStableDataBatches
 
 	err = streamLoop(ctx, repl, mode, batchSize, accum, results, opts.Streaming)
 	if err == nil && mode == ModeBatch {
@@ -287,12 +287,7 @@ func (r *CDCReader) rebuildForTableChange(ctx context.Context, slotName string, 
 		return 0, fmt.Errorf("failed to refresh schema for table %s: %w", r.tableName, err)
 	}
 	tableSchema = addCDCColumns(tableSchema)
-	// Keep the merge keys the run started with: they may carry user-provided
-	// keys that re-detection would drop, and the decoder, compaction, and
-	// unchanged-TOAST fill must keep keying off the same columns.
-	if len(r.tableSchema.PrimaryKeys) > 0 {
-		tableSchema.PrimaryKeys = r.tableSchema.PrimaryKeys
-	}
+	r.applyConfiguredPrimaryKeys(tableSchema)
 	r.tableSchema = tableSchema
 	if schemaErr != nil {
 		if r.allowedUnknown == nil {
@@ -346,7 +341,7 @@ func (r *CDCReader) resnapshotTable(ctx context.Context, slotName string, table 
 		return 0, fmt.Errorf("failed to parse schema backfill LSN: %w", err)
 	}
 	if err := sendResult(ctx, results, source.RecordBatchResult{SnapshotInvalidation: &source.CDCSnapshotInvalidation{
-		TableName: table.Name, Incarnation: table.Incarnation,
+		TableName: table.Name, Incarnation: table.Incarnation, SchemaFingerprint: table.SchemaFingerprint,
 	}}); err != nil {
 		return 0, err
 	}
@@ -378,6 +373,12 @@ func (r *CDCReader) resnapshotTable(ctx context.Context, slotName string, table 
 		return 0, err
 	}
 	return snapshotLSN, nil
+}
+
+func (r *CDCReader) applyConfiguredPrimaryKeys(tableSchema *schema.TableSchema) {
+	if tableSchema != nil && len(r.configuredPrimaryKeys) > 0 {
+		tableSchema.PrimaryKeys = append([]string(nil), r.configuredPrimaryKeys...)
+	}
 }
 
 func parseStoredPostgresLSN(raw string) (pglogrepl.LSN, error) {
@@ -425,13 +426,11 @@ type singleTableChangeFilter interface {
 // transaction and defeat accumulation entirely (see hadActivity in
 // Replicator.NextChanges).
 //
-// When streaming, each flushed batch carries a CommitToken (a safe LSN) so the
-// pipeline can confirm the replication slot only after the data is durable.
+// Each flushed batch carries its safe source position. Streaming uses it to
+// confirm the replication slot; managed batch ingestion uses it to identify
+// keyless transaction fragments durably.
 func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, batchSize int, accum *batchAccumulator, results chan<- source.RecordBatchResult, streaming bool) error {
-	var token tokenFunc
-	if streaming {
-		token = func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
-	}
+	token := func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
 
 	// lastIdleToken is the highest LSN already handed to the pipeline via a bare
 	// idle commit token, so we only emit one when the caught-up position has
@@ -472,6 +471,10 @@ func streamLoop(ctx context.Context, repl batchReplicator, mode CDCMode, batchSi
 			changes = nil
 		}
 		accum.add("", changes, lsn)
+		pendingLow, pending := repl.PendingLowWater()
+		if err := accum.flushStableKeylessContext(ctx, results, token, pendingLow, pending); err != nil {
+			return err
+		}
 
 		if err := accum.flushReadyContext(ctx, results, token); err != nil {
 			return err

--- a/pkg/source/postgres_cdc/schema_change_test.go
+++ b/pkg/source/postgres_cdc/schema_change_test.go
@@ -536,10 +536,10 @@ func TestMultiTableDecoderReportsEveryHistoricalSchemaMismatch(t *testing.T) {
 // rebuild. A missed announcement would leave the consumer writing new-shape
 // batches into old-shape staging.
 func TestShapeChangedTables(t *testing.T) {
-	prev := map[string]*schema.TableSchema{
-		"a": {Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}}},
-		"b": {Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}}},
-		"c": {Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}}},
+	prev := map[string]source.SourceTableInfo{
+		"a": {Name: "a", Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}}}},
+		"b": {Name: "b", Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}}}},
+		"c": {Name: "c", Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}}}, PrimaryKeys: []string{"id"}},
 	}
 	refreshed := []source.SourceTableInfo{
 		{Name: "a", Schema: &schema.TableSchema{Columns: []schema.Column{
@@ -551,12 +551,23 @@ func TestShapeChangedTables(t *testing.T) {
 		}}},
 		{Name: "c", Schema: &schema.TableSchema{Columns: []schema.Column{
 			{Name: "id", DataType: schema.TypeInt32},
-		}}},
+		}}, PrimaryKeys: nil},
 		{Name: "new_table", Schema: &schema.TableSchema{Columns: []schema.Column{
 			{Name: "id", DataType: schema.TypeInt32},
 		}}},
 	}
 
 	changed := shapeChangedTables(prev, refreshed)
-	require.Equal(t, []int{0, 1}, changed) // a: column added, b: type changed; c unchanged, new_table excluded
+	require.Equal(t, []int{0, 1, 2}, changed) // a: column added, b: type changed, c: primary key dropped
+}
+
+func TestSingleTableSchemaRefreshKeepsFreshAutoDetectedPrimaryKeys(t *testing.T) {
+	reader := &CDCReader{tableSchema: &schema.TableSchema{PrimaryKeys: []string{"old_id"}}}
+	refreshed := &schema.TableSchema{PrimaryKeys: []string{"new_id"}}
+	reader.applyConfiguredPrimaryKeys(refreshed)
+	require.Equal(t, []string{"new_id"}, refreshed.PrimaryKeys)
+
+	reader.configuredPrimaryKeys = []string{"configured_id"}
+	reader.applyConfiguredPrimaryKeys(refreshed)
+	require.Equal(t, []string{"configured_id"}, refreshed.PrimaryKeys)
 }

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -1259,12 +1259,9 @@ func (s *PostgresCDCSource) warnKeylessTable(name string) {
 	fmt.Printf("Warning: table %s has no primary key or replica identity index; ingesting it as an append-only change log (_cdc_deleted marks deletes, updates arrive as delete+insert pairs)\n", name)
 }
 
-// publicationTableFullName renders a table name the way GetTables and the WAL
-// decoder key tables: bare name for public, schema-qualified otherwise.
+// publicationTableFullName renders the canonical schema-qualified table name
+// used by GetTables and the WAL decoder.
 func publicationTableFullName(schemaName, tableName string) string {
-	if schemaName == "public" {
-		return tableName
-	}
 	return schemaName + "." + tableName
 }
 
@@ -1419,7 +1416,9 @@ func (s *PostgresCDCSource) ReadAll(ctx context.Context, opts source.MultiTableR
 		}
 		if resumeMetadataChanged(opts.CDCResumeIncarnations[table.Name], opts.CDCResumeSchemaFingerprints[table.Name], table.Incarnation, table.SchemaFingerprint) {
 			delete(resumeLSNs, table.Name)
-			invalidations = append(invalidations, source.CDCSnapshotInvalidation{TableName: table.Name, Incarnation: table.Incarnation})
+			invalidations = append(invalidations, source.CDCSnapshotInvalidation{
+				TableName: table.Name, Incarnation: table.Incarnation, SchemaFingerprint: table.SchemaFingerprint,
+			})
 		}
 	}
 	reader := NewMultiTableCDCReader(s, tables, s.cdcConfig, resumeLSNs, opts.CDCSlotSuffix)

--- a/pkg/source/postgres_cdc/stream_loop_test.go
+++ b/pkg/source/postgres_cdc/stream_loop_test.go
@@ -183,6 +183,48 @@ func TestStreamLoopAccumulatesSingleRowTransactions(t *testing.T) {
 	assert.Less(t, batchCount, numTxns, "batch count must not equal row count")
 }
 
+func TestBatchStreamLoopEmitsStableKeylessBatchIdentity(t *testing.T) {
+	steps, _ := buildSingleRowTxnStream(1)
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, len(steps)+1)
+	tableSchema := testStreamSchema()
+	tableSchema.PrimaryKeys = nil
+	accum := newBatchAccumulator(10000, map[string]*schema.TableSchema{"": tableSchema})
+
+	require.NoError(t, streamLoop(t.Context(), repl, ModeBatch, 10000, accum, results, false))
+	close(results)
+	result := <-results
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+	token, ok := result.CommitToken.(source.CDCStateCommitToken)
+	require.True(t, ok)
+	require.NotEmpty(t, token.Position)
+	require.NotEmpty(t, token.DataBatchID)
+}
+
+func TestBatchStreamLoopEmitsStableKeyedBatchIdentity(t *testing.T) {
+	steps, _ := buildSingleRowTxnStream(2)
+	repl := &fakeReplicator{steps: steps}
+	results := make(chan source.RecordBatchResult, len(steps)+1)
+	accum := newBatchAccumulator(10000, map[string]*schema.TableSchema{"": testStreamSchema()})
+	accum.stableAll = true
+
+	require.NoError(t, streamLoop(t.Context(), repl, ModeBatch, 10000, accum, results, false))
+	close(results)
+	var ids []string
+	for result := range results {
+		require.NotNil(t, result.Batch)
+		token, ok := result.CommitToken.(source.CDCStateCommitToken)
+		require.True(t, ok)
+		require.NotEmpty(t, token.Position)
+		require.NotEmpty(t, token.DataBatchID)
+		ids = append(ids, token.DataBatchID)
+		result.Batch.Release()
+	}
+	require.Len(t, ids, 2)
+	require.NotEqual(t, ids[0], ids[1])
+}
+
 func TestStreamLoopLeaseLossDiscardsAccumulatorWithoutMaterializing(t *testing.T) {
 	lease := &readerTestLease{done: make(chan struct{}), err: errors.New("lease backend terminated")}
 	ctx := source.WithConnectorLeaseGuard(context.Background(), source.NewConnectorLeaseGuard(lease))

--- a/pkg/source/postgres_cdc/table.go
+++ b/pkg/source/postgres_cdc/table.go
@@ -36,8 +36,11 @@ type CDCTable struct {
 	source      *PostgresCDCSource
 	tableName   string
 	primaryKeys []string
-	strategy    config.IncrementalStrategy
-	tableSchema *schema.TableSchema
+	// userProvidedPrimaryKeys distinguishes configured merge keys from keys
+	// auto-detected from PostgreSQL, which must be refreshed after DDL.
+	userProvidedPrimaryKeys bool
+	strategy                config.IncrementalStrategy
+	tableSchema             *schema.TableSchema
 }
 
 func NewCDCTable(src *PostgresCDCSource, req source.TableRequest) (*CDCTable, error) {
@@ -73,11 +76,12 @@ func NewCDCTable(src *PostgresCDCSource, req source.TableRequest) (*CDCTable, er
 	}
 
 	return &CDCTable{
-		source:      src,
-		tableName:   req.Name,
-		primaryKeys: pks,
-		strategy:    strategy,
-		tableSchema: tableSchema,
+		source:                  src,
+		tableName:               req.Name,
+		primaryKeys:             pks,
+		userProvidedPrimaryKeys: len(req.PrimaryKeys) > 0,
+		strategy:                strategy,
+		tableSchema:             tableSchema,
 	}, nil
 }
 
@@ -116,6 +120,9 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 
 		// Create the CDC reader
 		reader := NewCDCReader(t.source, t.tableName, t.tableSchema, t.source.cdcConfig)
+		if t.userProvidedPrimaryKeys {
+			reader.configuredPrimaryKeys = append([]string(nil), t.primaryKeys...)
+		}
 
 		// Start reading
 		batches, err := reader.Read(ctx, opts)
@@ -173,9 +180,13 @@ func getTableSchema(ctx context.Context, pool *pgxpool.Pool, table string) (*sch
 			numeric_precision,
 			numeric_scale,
 			character_maximum_length,
-			udt_name
-		FROM information_schema.columns
-		WHERE table_schema = $1 AND table_name = $2
+			c.udt_name,
+			COALESCE(elem.typdelim::text, '')
+		FROM information_schema.columns c
+		LEFT JOIN pg_namespace udtns ON udtns.nspname = c.udt_schema
+		LEFT JOIN pg_type array_type ON array_type.typnamespace = udtns.oid AND array_type.typname = c.udt_name
+		LEFT JOIN pg_type elem ON elem.oid = array_type.typelem
+		WHERE c.table_schema = $1 AND c.table_name = $2
 		ORDER BY ordinal_position
 	`
 
@@ -187,10 +198,10 @@ func getTableSchema(ctx context.Context, pool *pgxpool.Pool, table string) (*sch
 
 	var columns []schema.Column
 	for rows.Next() {
-		var columnName, dataType, isNullable, udtName string
+		var columnName, dataType, isNullable, udtName, arrayDelimiter string
 		var numericPrecision, numericScale, charMaxLen *int
 
-		if err := rows.Scan(&columnName, &dataType, &isNullable, &numericPrecision, &numericScale, &charMaxLen, &udtName); err != nil {
+		if err := rows.Scan(&columnName, &dataType, &isNullable, &numericPrecision, &numericScale, &charMaxLen, &udtName, &arrayDelimiter); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 
@@ -205,10 +216,11 @@ func getTableSchema(ctx context.Context, pool *pgxpool.Pool, table string) (*sch
 		dt, precision, scale, arrayType := postgres.MapPostgresToDataType(pgType)
 
 		col := schema.Column{
-			Name:      columnName,
-			DataType:  dt,
-			Nullable:  isNullable == "YES",
-			ArrayType: arrayType,
+			Name:           columnName,
+			DataType:       dt,
+			Nullable:       isNullable == "YES",
+			ArrayType:      arrayType,
+			ArrayDelimiter: arrayDelimiter,
 		}
 
 		if numericPrecision != nil {


### PR DESCRIPTION
## Summary

Hardens PostgreSQL CDC decoding, snapshot reset behavior, durable positions, and keyless batching.

## Stack

Part 7 of 11. Review and merge bottom-up. This PR is based on `stack/iceberg-06-pipeline-evolution`; GitHub therefore shows only this layer's delta.

Previous: https://github.com/bruin-data/ingestr/pull/964 · Next: https://github.com/bruin-data/ingestr/pull/966

## Validation

- `make format`
- `make lint`
- `make test`
- Layer-specific package tests

The complete stack is byte-for-byte equivalent to the previously reviewed full implementation.