### PR TITLE
Iceberg stack 8/11: catalogs, atomic commits, and lifecycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/xuri/excelize/v2 v2.10.1
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.mongodb.org/mongo-driver v1.17.7
+	gocloud.dev v0.45.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa
 	golang.org/x/net v0.55.0
@@ -409,7 +410,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	gocloud.dev v0.45.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -265,11 +265,6 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
-    - module: github.com/DataDog/zstd
-      version: v1.5.6
-      licenses:
-        - BSD-3-Clause
-      status: allowed
     - module: github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp
       version: v1.6.0
       licenses:
@@ -754,11 +749,6 @@ dependencies:
         - EPL-2.0
       status: manual-review
       note: EPL-2.0 reviewed for the MQTT source dependency.
-    - module: github.com/ebitengine/purego
-      version: v0.10.0
-      licenses:
-        - Apache-2.0
-      status: allowed
     - module: github.com/elastic/elastic-transport-go/v8
       version: v8.8.0
       licenses:

--- a/pkg/destination/iceberg/atomic_snapshot.go
+++ b/pkg/destination/iceberg/atomic_snapshot.go
@@ -1,0 +1,434 @@
+package iceberg
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	atomicSnapshotAttemptProperty = "ingestr.snapshot-attempt"
+	atomicSnapshotTargetProperty  = "ingestr.snapshot-target"
+	atomicSnapshotTargetUUID      = "ingestr.snapshot-target-uuid"
+)
+
+func atomicSnapshotStageIdent(target icebergtable.Identifier, attemptID string) icebergtable.Identifier {
+	sum := sha256.Sum256([]byte(strings.Join(target, "\x00") + "\x00" + attemptID))
+	stage := append(icebergtable.Identifier(nil), target...)
+	stage[len(stage)-1] = "ingestr_snapshot_" + hex.EncodeToString(sum[:8])
+	return stage
+}
+
+func (d *Destination) BeginAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	target, err := parseIdentifier(opts.Table)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.AttemptID) == "" {
+		return errors.New("iceberg: atomic snapshot requires an attempt identifier")
+	}
+	targetTable, err := d.catalog.LoadTable(ctx, target)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load atomic snapshot target %s: %w", strings.Join(target, "."), err)
+	}
+	if err := d.validateExpectedIncarnation(ctx, targetTable, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	targetUUID := targetTable.Metadata().TableUUID().String()
+	stage := atomicSnapshotStageIdent(target, opts.AttemptID)
+	if tbl, loadErr := d.catalog.LoadTable(ctx, stage); loadErr == nil {
+		if err := validateAtomicSnapshotStageGeneration(tbl, targetTable, opts.AttemptID); err == nil {
+			return nil
+		} else if !isRecoverablePreOwnershipAtomicSnapshotStage(tbl) {
+			return err
+		}
+		if err := d.dropAtomicSnapshotStage(ctx, tbl, target, opts.AttemptID, true); err != nil {
+			return fmt.Errorf("iceberg: failed to recover pre-ownership atomic snapshot staging table %s: %w", strings.Join(stage, "."), err)
+		}
+	} else if !isMissingTableOrNamespace(loadErr) {
+		return fmt.Errorf("iceberg: failed to inspect atomic snapshot staging table %s: %w", strings.Join(stage, "."), loadErr)
+	}
+
+	if err := d.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        strings.Join(stage, "."),
+		Schema:       opts.Schema,
+		CDCMode:      true,
+		ExpiresAfter: destination.ManagedStagingTTL,
+		TableProperties: map[string]string{
+			atomicSnapshotAttemptProperty: opts.AttemptID,
+			atomicSnapshotTargetProperty:  strings.Join(target, "."),
+			atomicSnapshotTargetUUID:      targetUUID,
+		},
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Destination) WriteAtomicSnapshot(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	target, err := parseIdentifier(opts.Table)
+	if err != nil {
+		return err
+	}
+	stageIdent := atomicSnapshotStageIdent(target, opts.AtomicSnapshotAttemptID)
+	stage, err := d.catalog.LoadTable(ctx, stageIdent)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load atomic snapshot staging table: %w", err)
+	}
+	if err := validateAtomicSnapshotStage(stage, target, opts.AtomicSnapshotAttemptID); err != nil {
+		return err
+	}
+	opts.Table = strings.Join(stageIdent, ".")
+	if _, err := d.renewManagedTableLease(ctx, stageIdent, time.Now()); err != nil {
+		return fmt.Errorf("iceberg: failed to refresh atomic snapshot staging lease for %s: %w", opts.Table, err)
+	}
+	opts.StagingTable = true
+	opts.CDCResumeLSN = ""
+	opts.SkipCDCResume = true
+	opts.CDCExpectedIncarnation = ""
+	return d.WriteParallel(ctx, records, opts)
+}
+
+func (d *Destination) EvolveAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) error {
+	target, err := parseIdentifier(opts.Table)
+	if err != nil {
+		return err
+	}
+	stageIdent := atomicSnapshotStageIdent(target, opts.AttemptID)
+	stage, err := d.catalog.LoadTable(ctx, stageIdent)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load atomic snapshot staging table %s for evolution: %w", strings.Join(stageIdent, "."), err)
+	}
+	if err := validateAtomicSnapshotStage(stage, target, opts.AttemptID); err != nil {
+		return err
+	}
+	txn := stage.NewTransaction()
+	changed, err := d.stageTableSchemaUpdate(txn, stage, opts.Schema, false, false)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to evolve atomic snapshot staging table %s: %w", strings.Join(stageIdent, "."), err)
+	}
+	return nil
+}
+
+func (d *Destination) AbortAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	target, err := parseIdentifier(opts.Table)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.AttemptID) == "" {
+		return errors.New("iceberg: atomic snapshot abort requires an attempt identifier")
+	}
+	if opts.CommitToken != nil {
+		tbl, loadErr := d.catalog.LoadTable(ctx, target)
+		if loadErr != nil {
+			return fmt.Errorf("iceberg: cannot verify atomic snapshot publication before abort: %w", loadErr)
+		}
+		if tableHasCommitToken(tbl, commitTokenID(opts.CommitToken)) {
+			return fmt.Errorf("iceberg: refusing to abort published atomic snapshot attempt %s", opts.AttemptID)
+		}
+	}
+	stageIdent := atomicSnapshotStageIdent(target, opts.AttemptID)
+	stage, err := d.catalog.LoadTable(ctx, stageIdent)
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to inspect atomic snapshot stage before abort: %w", err)
+	}
+	if err := validateAtomicSnapshotStage(stage, target, opts.AttemptID); err != nil {
+		return err
+	}
+	return d.dropAtomicSnapshotStage(ctx, stage, target, opts.AttemptID, false)
+}
+
+func (d *Destination) PublishAtomicSnapshot(ctx context.Context, opts destination.AtomicSnapshotOptions) error {
+	if strings.TrimSpace(opts.AttemptID) == "" {
+		return errors.New("iceberg: atomic snapshot publish requires an attempt identifier")
+	}
+	if commitTokenID(opts.CommitToken) == "" {
+		opts.CommitToken = "atomic-snapshot:" + opts.AttemptID
+	}
+	target, err := d.loadIcebergTable(ctx, opts.Table)
+	if err != nil {
+		return err
+	}
+	if err := d.validateExpectedIncarnation(ctx, target, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	metadata := newCommitMetadata(opts.CommitToken, opts.CDCResumeLSN).withExpectedIncarnation(opts.CDCExpectedIncarnation)
+	if opts.SkipCDCResume {
+		metadata.cdcResumeLSN = ""
+		metadata.resetCDCResume = true
+	}
+	stageIdent := atomicSnapshotStageIdent(target.Identifier(), opts.AttemptID)
+	stage, loadErr := d.catalog.LoadTable(ctx, stageIdent)
+	if isMissingTableOrNamespace(loadErr) {
+		if tableHasCommitToken(target, metadata.token) {
+			return d.completeAtomicSnapshotPublication(ctx, target, nil, opts, metadata.token)
+		}
+		return fmt.Errorf("iceberg: atomic snapshot staging table %s is missing", strings.Join(stageIdent, "."))
+	}
+	if loadErr != nil {
+		return fmt.Errorf("iceberg: failed to load atomic snapshot staging table %s: %w", strings.Join(stageIdent, "."), loadErr)
+	}
+	if err := validateAtomicSnapshotStageGeneration(stage, target, opts.AttemptID); err != nil {
+		return err
+	}
+	targetUUID := target.Metadata().TableUUID().String()
+	if err := d.validateExpectedIncarnation(ctx, target, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	if tableHasCommitToken(target, metadata.token) {
+		return d.completeAtomicSnapshotPublication(ctx, target, stage, opts, metadata.token)
+	}
+	if err := validateCDCResumeAdvance(target, metadata); err != nil {
+		return err
+	}
+	stageUUID := stage.Metadata().TableUUID().String()
+	publishCtx, cancelPublish := context.WithCancel(ctx)
+	defer cancelPublish()
+	stageHeartbeat, err := d.startManagedTableLeaseHeartbeatWithCancel(publishCtx, stage, cancelPublish)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to start atomic snapshot staging lease heartbeat: %w", err)
+	}
+	if stageHeartbeat == nil {
+		return errors.New("iceberg: atomic snapshot staging table is not managed")
+	}
+	defer stageHeartbeat.stop()
+	ctx = publishCtx
+
+	desired := opts.TargetSchema
+	if desired == nil {
+		desired = destination.DestinationTableSchema(opts.Schema)
+	}
+	if desired == nil {
+		return errors.New("iceberg: atomic snapshot publication requires schema")
+	}
+	if err := validateIcebergTableSchema(desired); err != nil {
+		return err
+	}
+	writeSchema := icebergArrowSchema(desired)
+	sourceFields := stage.Schema().Fields()
+	sourceColumns := make([]string, len(sourceFields))
+	for i, field := range sourceFields {
+		sourceColumns[i] = field.Name
+	}
+	openStageReader := func() *chanRecordReader {
+		projection := newRowProjection(writeSchema, sourceColumns)
+		return streamingReader(writeSchema, func(sink func(batch arrow.RecordBatch) error) error {
+			emitter := newBatchEmitter(projection, sink)
+			defer emitter.release()
+			if err := forEachScannedRow(ctx, stage, iceberggo.AlwaysTrue{}, emitter.add); err != nil {
+				return err
+			}
+			return emitter.flushBatch()
+		})
+	}
+	stageReader := openStageReader()
+	openReplay, cleanupReplay, err := spoolReplayableRecordReader(stageReader)
+	stageReader.Release()
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to spool atomic snapshot stage: %w", err)
+	}
+	defer cleanupReplay()
+
+	props := snapshotProps("snapshot", metadata)
+	prepared := preparedTable{
+		replace:          true,
+		preserveMetadata: true,
+		evolveSchema:     true,
+		schema:           desired,
+		partitionBy:      opts.PartitionBy,
+		clusterBy:        opts.ClusterBy,
+	}
+	current := target
+	var committed *icebergtable.Table
+	var publishErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if err := d.validateExpectedIncarnation(ctx, current, opts.CDCExpectedIncarnation); err != nil {
+			return err
+		}
+		if err := validateAtomicSnapshotTargetGeneration(current, targetUUID); err != nil {
+			return err
+		}
+		if tableHasCommitToken(current, metadata.token) {
+			committed = current
+			publishErr = nil
+			break
+		}
+		if err := validateCDCResumeAdvance(current, metadata); err != nil {
+			return err
+		}
+		currentStage, leaseErr := d.renewManagedTableLease(ctx, stageIdent, time.Now())
+		if leaseErr != nil {
+			return fmt.Errorf("iceberg: failed to renew atomic snapshot stage before publish attempt: %w", leaseErr)
+		}
+		if currentStage.Metadata().TableUUID().String() != stageUUID {
+			return fmt.Errorf("iceberg: atomic snapshot staging UUID changed before target commit")
+		}
+		if err := validateAtomicSnapshotStage(currentStage, target.Identifier(), opts.AttemptID); err != nil {
+			return err
+		}
+		reader, release, replayErr := openReplay()
+		if replayErr != nil {
+			return replayErr
+		}
+		committed, publishErr = d.overwritePrepared(ctx, current, reader, props, prepared, opts.Parallelism, nil, true, opts.CDCExpectedIncarnation)
+		release()
+		if publishErr == nil {
+			break
+		}
+		if !errors.Is(publishErr, icebergtable.ErrCommitFailed) {
+			if reconciled := d.reconcileCommit(ctx, opts.Table, metadata.token, opts.CDCExpectedIncarnation, publishErr); reconciled != nil {
+				return fmt.Errorf("iceberg: failed to publish atomic snapshot for table %s: %w", opts.Table, reconciled)
+			}
+			committed, err = d.loadIcebergTable(ctx, opts.Table)
+			if err != nil {
+				return fmt.Errorf("iceberg: atomic snapshot for table %s committed but could not be reloaded: %w", opts.Table, err)
+			}
+			if err := validateAtomicSnapshotTargetGeneration(committed, targetUUID); err != nil {
+				return err
+			}
+			publishErr = nil
+			break
+		}
+		current, err = d.loadIcebergTable(ctx, opts.Table)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to reload atomic snapshot target %s after commit conflict: %w", opts.Table, err)
+		}
+		if err := validateAtomicSnapshotTargetGeneration(current, targetUUID); err != nil {
+			return err
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	if committed == nil && publishErr != nil {
+		return fmt.Errorf("iceberg: failed to publish atomic snapshot for table %s after retries: %w", opts.Table, publishErr)
+	}
+	finalStage, err := stageHeartbeat.stopAndRefresh(ctx)
+	if err != nil {
+		return fmt.Errorf("iceberg: atomic snapshot target committed but staging lease finalization failed: %w", err)
+	}
+	if finalStage.Metadata().TableUUID().String() != stageUUID {
+		return fmt.Errorf("iceberg: atomic snapshot target committed but staging UUID changed")
+	}
+	if err := validateAtomicSnapshotStage(finalStage, target.Identifier(), opts.AttemptID); err != nil {
+		return err
+	}
+	return d.completeAtomicSnapshotPublication(ctx, committed, stage, opts, metadata.token)
+}
+
+func (d *Destination) completeAtomicSnapshotPublication(
+	ctx context.Context,
+	committed, stage *icebergtable.Table,
+	opts destination.AtomicSnapshotOptions,
+	commitToken string,
+) error {
+	if opts.SkipCDCResume {
+		if err := d.ensureManagedCDCResumeResetExpected(ctx, committed, commitToken, opts.CDCExpectedIncarnation); err != nil {
+			return err
+		}
+	}
+	if _, err := d.ensureSortOrderExpected(ctx, committed, opts.ClusterBy, opts.CDCExpectedIncarnation); err != nil {
+		return fmt.Errorf("iceberg: atomic snapshot for table %s committed but its sort order is not: %w", opts.Table, err)
+	}
+	d.afterSuccessfulCommitExpected(ctx, opts.Table, opts.CDCExpectedIncarnation)
+	if stage == nil {
+		return nil
+	}
+	if err := d.dropAtomicSnapshotStage(ctx, stage, committed.Identifier(), opts.AttemptID, false); err != nil {
+		return fmt.Errorf("iceberg: snapshot for table %s published but staging cleanup failed: %w", opts.Table, err)
+	}
+	return nil
+}
+
+func (d *Destination) dropAtomicSnapshotStage(
+	ctx context.Context,
+	stage *icebergtable.Table,
+	target icebergtable.Identifier,
+	attemptID string,
+	preOwnership bool,
+) error {
+	return d.dropTableWithLifecycleExpected(
+		ctx,
+		stage.Identifier(),
+		stage.Metadata().TableUUID().String(),
+		func(current *icebergtable.Table) error {
+			if preOwnership {
+				if !isRecoverablePreOwnershipAtomicSnapshotStage(current) {
+					return fmt.Errorf("iceberg: atomic snapshot staging ownership changed for %s", strings.Join(stage.Identifier(), "."))
+				}
+				return nil
+			}
+			return validateAtomicSnapshotStage(current, target, attemptID)
+		},
+	)
+}
+
+var (
+	_ destination.AtomicSnapshotPublisher = (*Destination)(nil)
+	_ destination.AtomicSnapshotAborter   = (*Destination)(nil)
+)
+
+func validateAtomicSnapshotStage(tbl *icebergtable.Table, target icebergtable.Identifier, attemptID string) error {
+	_, managed, err := managedTableExpiration(tbl.Properties())
+	if err != nil {
+		return fmt.Errorf("iceberg: invalid atomic snapshot staging table %s: %w", strings.Join(tbl.Identifier(), "."), err)
+	}
+	wantTarget := strings.Join(target, ".")
+	if !managed || tbl.Properties()[atomicSnapshotAttemptProperty] != attemptID || tbl.Properties()[atomicSnapshotTargetProperty] != wantTarget {
+		return fmt.Errorf("iceberg: atomic snapshot staging ownership mismatch for %s", strings.Join(tbl.Identifier(), "."))
+	}
+	return nil
+}
+
+func validateAtomicSnapshotStageGeneration(stage, target *icebergtable.Table, attemptID string) error {
+	if err := validateAtomicSnapshotStage(stage, target.Identifier(), attemptID); err != nil {
+		return err
+	}
+	expected := stage.Properties()[atomicSnapshotTargetUUID]
+	if expected == "" {
+		return fmt.Errorf("iceberg: atomic snapshot staging table %s has no target generation", strings.Join(stage.Identifier(), "."))
+	}
+	return validateAtomicSnapshotTargetGeneration(target, expected)
+}
+
+func validateAtomicSnapshotTargetGeneration(target *icebergtable.Table, expected string) error {
+	actual := target.Metadata().TableUUID().String()
+	if actual != expected {
+		return fmt.Errorf("iceberg: atomic snapshot target generation changed for %s: expected UUID %s, got %s", strings.Join(target.Identifier(), "."), expected, actual)
+	}
+	return nil
+}
+
+func isRecoverablePreOwnershipAtomicSnapshotStage(tbl *icebergtable.Table) bool {
+	_, managed, err := managedTableExpiration(tbl.Properties())
+	return err == nil && managed && tbl.Properties()[atomicSnapshotAttemptProperty] == "" && tbl.Properties()[atomicSnapshotTargetProperty] == "" && tbl.Properties()[atomicSnapshotTargetUUID] == ""
+}

--- a/pkg/destination/iceberg/catalog.go
+++ b/pkg/destination/iceberg/catalog.go
@@ -1,0 +1,183 @@
+package iceberg
+
+import (
+	"context"
+	"crypto/tls"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergrest "github.com/apache/iceberg-go/catalog/rest"
+	icebergsql "github.com/apache/iceberg-go/catalog/sql"
+	icebergtable "github.com/apache/iceberg-go/table"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+const s3TablesIdentifierMaxLength = 255
+
+type ownedSQLCatalog struct {
+	icebergcatalog.Catalog
+	db        *sql.DB
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (c *ownedSQLCatalog) Close() error {
+	c.closeOnce.Do(func() {
+		c.closeErr = c.db.Close()
+	})
+	return c.closeErr
+}
+
+func (c *ownedSQLCatalog) PurgeTable(ctx context.Context, identifier icebergtable.Identifier) error {
+	purger, ok := c.Catalog.(icebergcatalog.PurgeableTable)
+	if !ok {
+		return errors.New("iceberg: SQL catalog does not support physical table purge")
+	}
+	return purger.PurgeTable(ctx, identifier)
+}
+
+func loadIcebergCatalog(ctx context.Context, cfg icebergConfig) (icebergcatalog.Catalog, error) {
+	if cfg.Properties.Get("type", "") == "sql" {
+		return loadOwnedSQLCatalog(cfg)
+	}
+	if cfg.Properties.Get("rest.signing-name", "") != "s3tables" {
+		cat, err := icebergcatalog.Load(ctx, cfg.CatalogName, cfg.Properties)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.Properties.Get("type", "") == "hive" {
+			return &hiveFileCatalog{Catalog: cat}, nil
+		}
+		return cat, nil
+	}
+
+	region := cfg.Properties.Get("rest.signing-region", "")
+	loadOptions := []func(*awsconfig.LoadOptions) error{awsconfig.WithRegion(region)}
+	accessKey := cfg.Properties.Get("s3.access-key-id", "")
+	secretKey := cfg.Properties.Get("s3.secret-access-key", "")
+	if (accessKey == "") != (secretKey == "") {
+		return nil, fmt.Errorf("iceberg: access_key_id and secret_access_key must be provided together")
+	}
+	if accessKey != "" {
+		loadOptions = append(loadOptions, awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			accessKey,
+			secretKey,
+			cfg.Properties.Get("s3.session-token", ""),
+		)))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to load AWS configuration for S3 Tables: %w", err)
+	}
+
+	additional := iceberggo.Properties{}
+	for key, value := range cfg.Properties {
+		switch key {
+		case "type", "uri", "warehouse", "rest.sigv4-enabled", "rest.signing-region", "rest.signing-name", "rest.tls.skip-verify":
+			continue
+		default:
+			additional[key] = value
+		}
+	}
+	opts := []icebergrest.Option{
+		icebergrest.WithWarehouseLocation(cfg.Properties.Get("warehouse", "")),
+		icebergrest.WithSigV4RegionSvc(region, "s3tables"),
+		icebergrest.WithAwsConfig(awsCfg),
+		icebergrest.WithAdditionalProps(additional),
+	}
+	if strings.EqualFold(cfg.Properties.Get("rest.tls.skip-verify", ""), "true") {
+		//nolint:gosec // Explicit user opt-in for private/local REST endpoints.
+		opts = append(opts, icebergrest.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}))
+	}
+	return icebergrest.NewCatalog(ctx, cfg.CatalogName, cfg.Properties.Get("uri", ""), opts...)
+}
+
+func loadOwnedSQLCatalog(cfg icebergConfig) (icebergcatalog.Catalog, error) {
+	driver := strings.TrimSpace(cfg.Properties[icebergsql.DriverKey])
+	if driver == "" {
+		return nil, errors.New("must provide driver to pass to sql.Open")
+	}
+	dialect := strings.ToLower(strings.TrimSpace(cfg.Properties[icebergsql.DialectKey]))
+	if dialect == "" {
+		return nil, errors.New("must provide sql dialect to use")
+	}
+	supportedDialect := icebergsql.SupportedDialect(dialect)
+	switch supportedDialect {
+	case icebergsql.Postgres, icebergsql.MySQL, icebergsql.SQLite, icebergsql.MSSQL, icebergsql.Oracle:
+	default:
+		return nil, fmt.Errorf("unsupported SQL catalog dialect %q", dialect)
+	}
+
+	dsn := strings.TrimPrefix(cfg.Properties.Get("uri", ""), "sql://")
+	db, err := sql.Open(driver, dsn)
+	if err != nil {
+		return nil, err
+	}
+	catalogName := "sql"
+	if cfg.CatalogNameExplicit {
+		catalogName = cfg.CatalogName
+	}
+	cat, err := icebergsql.NewCatalog(
+		catalogName,
+		db,
+		supportedDialect,
+		cfg.Properties,
+	)
+	if err != nil {
+		return nil, errors.Join(err, db.Close())
+	}
+	return &ownedSQLCatalog{Catalog: cat, db: db}, nil
+}
+
+func validateS3TablesIdentifier(cfg icebergConfig, ident icebergtable.Identifier, tableSchema *schema.TableSchema) error {
+	if cfg.Properties.Get("rest.signing-name", "") != "s3tables" {
+		return nil
+	}
+	if len(ident) != 2 {
+		return fmt.Errorf("iceberg: S3 Tables requires a single-level namespace and table identifier")
+	}
+	for i, part := range ident {
+		kind := "table"
+		if i == 0 {
+			kind = "namespace"
+		}
+		if err := validateS3TablesName(kind, part); err != nil {
+			return err
+		}
+	}
+	if strings.HasPrefix(ident[0], "aws") {
+		return fmt.Errorf("iceberg: S3 Tables namespace name must not start with reserved prefix %q: %q", "aws", ident[0])
+	}
+	for _, col := range tableSchema.Columns {
+		if col.Name != strings.ToLower(col.Name) {
+			return fmt.Errorf("iceberg: S3 Tables column names must be lowercase: %q", col.Name)
+		}
+	}
+	return nil
+}
+
+func validateS3TablesName(kind, name string) error {
+	if len(name) < 1 || len(name) > s3TablesIdentifierMaxLength {
+		return fmt.Errorf("iceberg: S3 Tables %s name must be between 1 and %d characters: %q", kind, s3TablesIdentifierMaxLength, name)
+	}
+	if name != strings.ToLower(name) {
+		return fmt.Errorf("iceberg: S3 Tables namespace and table names must be lowercase: %q", name)
+	}
+	for i, r := range name {
+		valid := r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_'
+		if !valid {
+			return fmt.Errorf("iceberg: S3 Tables %s name may contain only lowercase letters, numbers, and underscores: %q", kind, name)
+		}
+		if i == 0 && r == '_' {
+			return fmt.Errorf("iceberg: S3 Tables %s name must begin with a letter or number: %q", kind, name)
+		}
+	}
+	return nil
+}

--- a/pkg/destination/iceberg/cdc_state.go
+++ b/pkg/destination/iceberg/cdc_state.go
@@ -1,0 +1,1047 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
+)
+
+const (
+	cdcTargetClaimPropertyPrefix = "ingestr.cdc-target-claim."
+	cdcTargetClaimLockPrefix     = "ingestr_cdc_claim_"
+	cdcTargetClaimLockTargetKey  = "ingestr.cdc-target-claim.target"
+	cdcTargetClaimLockOwnerKey   = "ingestr.cdc-target-claim.owner"
+	icebergCDCStatePruneBatch    = 500
+)
+
+var (
+	_ destination.CDCStateReader               = (*Destination)(nil)
+	_ destination.CDCStateFenceReader          = (*Destination)(nil)
+	_ destination.CDCStateWriter               = (*Destination)(nil)
+	_ destination.CDCStatePruner               = (*Destination)(nil)
+	_ destination.CDCStatePruneBatchSizer      = (*Destination)(nil)
+	_ destination.CDCTargetClaimer             = (*Destination)(nil)
+	_ destination.CDCTargetIdentityProvider    = (*Destination)(nil)
+	_ destination.CDCTargetIncarnationProvider = (*Destination)(nil)
+	_ destination.ManagedCDCStateValidator     = (*Destination)(nil)
+	_ destination.ManagedCDCTargetValidator    = (*Destination)(nil)
+	_ destination.CDCTruncateCapable           = (*Destination)(nil)
+	_ destination.CDCConditionalTruncater      = (*Destination)(nil)
+)
+
+func (d *Destination) ValidateManagedCDCState() error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	if !supportsAtomicCDCTargetClaims(d.catalog.CatalogType()) {
+		return fmt.Errorf(
+			"iceberg: managed CDC requires a catalog with atomic table creation; catalog type %q cannot provide permanent cross-process target claims",
+			d.catalog.CatalogType(),
+		)
+	}
+	if err := validateIsolatedTableFilePaths(d.cfg.TableProperties); err != nil {
+		return fmt.Errorf("iceberg: managed CDC state requires isolated table file paths: %w", err)
+	}
+	return nil
+}
+
+func (d *Destination) ValidateManagedCDCTarget(ctx context.Context, table string) error {
+	if err := d.ValidateManagedCDCState(); err != nil {
+		return err
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return err
+	}
+	exists, err := d.tableExists(ctx, ident)
+	if err != nil || !exists {
+		return err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to validate managed CDC target %s: %w", table, err)
+	}
+	if tbl.Metadata().TableUUID() == uuid.Nil {
+		return fmt.Errorf("iceberg: managed CDC target %s has no stable table UUID", table)
+	}
+	if err := validateIsolatedTableFilePaths(tbl.Properties()); err != nil {
+		return fmt.Errorf("iceberg: managed CDC target %s: %w", table, err)
+	}
+	return nil
+}
+
+func (d *Destination) CanonicalCDCTarget(_ context.Context, table string) (string, error) {
+	if d.catalog == nil {
+		return "", errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return "", err
+	}
+	catalogURI, err := icebergCatalogIdentityURI(d.cfg.Properties.Get("uri", ""))
+	if err != nil {
+		return "", fmt.Errorf("iceberg: catalog URI cannot be safely canonicalized for managed CDC: %w", err)
+	}
+	warehouse, err := icebergCatalogIdentityURI(d.cfg.Properties.Get("warehouse", ""))
+	if err != nil {
+		return "", fmt.Errorf("iceberg: warehouse cannot be safely canonicalized for managed CDC: %w", err)
+	}
+	glueID, glueRegion, glueEndpoint, err := icebergGlueCatalogIdentity(d.catalog.CatalogType(), d.cfg)
+	if err != nil {
+		return "", err
+	}
+	components := []string{
+		strings.ToLower(strings.TrimSpace(string(d.catalog.CatalogType()))),
+		icebergCatalogIdentityName(d.catalog.CatalogType(), d.cfg),
+		icebergRESTCatalogIdentityPrefix(d.catalog.CatalogType(), d.cfg.Properties.Get("prefix", "")),
+		catalogURI,
+		warehouse,
+		glueID,
+		glueRegion,
+		glueEndpoint,
+	}
+	components = append(components, ident...)
+	return destination.CDCTargetKeyDigest(components...), nil
+}
+
+func icebergCatalogIdentityURI(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", errors.New("unsupported or malformed catalog location")
+	}
+	if isInMemoryFileCatalogURI(parsed) {
+		return "", errors.New("in-memory file catalog location is unsupported for managed CDC")
+	}
+	if parsed.Opaque != "" {
+		if !strings.EqualFold(parsed.Scheme, "file") {
+			return "", errors.New("opaque catalog DSN is unsupported; use a URL or keyword-value DSN")
+		}
+		absolute, err := filepath.Abs(filepath.FromSlash(parsed.Opaque))
+		if err != nil {
+			return "", errors.New("relative file catalog location cannot be resolved")
+		}
+		parsed.Opaque = ""
+		parsed.Path = filepath.ToSlash(filepath.Clean(absolute))
+		parsed.RawPath = ""
+	}
+	if looksLikeKeywordCatalogDSN(raw) {
+		return canonicalKeywordCatalogDSN(raw)
+	}
+	if parsed.Scheme == "postgres" || parsed.Scheme == "postgresql" {
+		for key := range parsed.Query() {
+			switch normalizedCatalogIdentityQueryKey(key) {
+			case "service", "servicefile":
+				return "", errors.New("service-based catalog DSN is unsupported for managed CDC")
+			}
+		}
+	}
+	if parsed.Scheme == "" && parsed.Host == "" {
+		if strings.HasPrefix(parsed.Path, "/") {
+			return canonicalLocalFileIdentity(parsed.Path), nil
+		}
+		if strings.HasPrefix(parsed.Path, "./") || strings.HasPrefix(parsed.Path, "../") {
+			absolute, err := filepath.Abs(filepath.FromSlash(parsed.Path))
+			if err != nil {
+				return "", errors.New("relative catalog location cannot be resolved")
+			}
+			return canonicalLocalFileIdentity(absolute), nil
+		}
+		return "", errors.New("ambiguous catalog location")
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.User = nil
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	if parsed.Host != "" {
+		hostname := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+		port := parsed.Port()
+		if parsed.Scheme == "file" && hostname == "localhost" && port == "" {
+			parsed.Host = ""
+		} else {
+			if port == defaultCatalogIdentityPort(parsed.Scheme) {
+				port = ""
+			}
+			if strings.Contains(hostname, ":") {
+				hostname = "[" + strings.Trim(hostname, "[]") + "]"
+			}
+			parsed.Host = hostname
+			if port != "" {
+				parsed.Host = net.JoinHostPort(strings.Trim(hostname, "[]"), port)
+			}
+		}
+	}
+	if parsed.Opaque == "" {
+		cleanPath := path.Clean(parsed.Path)
+		switch cleanPath {
+		case ".":
+			cleanPath = ""
+		case "/":
+			if parsed.Scheme != "file" {
+				cleanPath = ""
+			}
+		}
+		parsed.Path = cleanPath
+		parsed.RawPath = ""
+		if parsed.Scheme == "file" && parsed.Host == "" {
+			parsed.OmitHost = false
+		}
+	}
+	query := make(url.Values)
+	for key, values := range parsed.Query() {
+		if isCatalogIdentityLocationQueryKey(key) {
+			normalized := normalizedCatalogIdentityQueryKey(key)
+			query[normalized] = append(query[normalized], values...)
+		}
+	}
+	for key, values := range query {
+		sort.Strings(values)
+		query[key] = slices.Compact(values)
+	}
+	parsed.RawQuery = query.Encode()
+	parsed.ForceQuery = false
+	return parsed.String(), nil
+}
+
+func isInMemoryFileCatalogURI(parsed *url.URL) bool {
+	if parsed == nil || !strings.EqualFold(parsed.Scheme, "file") {
+		return false
+	}
+	if strings.HasPrefix(parsed.Opaque, ":") {
+		return true
+	}
+	for key, values := range parsed.Query() {
+		if !strings.EqualFold(key, "mode") {
+			continue
+		}
+		for _, value := range values {
+			if strings.EqualFold(strings.TrimSpace(value), "memory") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func canonicalLocalFileIdentity(rawPath string) string {
+	return (&url.URL{
+		Scheme:   "file",
+		Path:     filepath.ToSlash(filepath.Clean(filepath.FromSlash(rawPath))),
+		OmitHost: false,
+	}).String()
+}
+
+func looksLikeKeywordCatalogDSN(raw string) bool {
+	if strings.Contains(raw, "://") || strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "./") || strings.HasPrefix(raw, "../") || strings.HasPrefix(strings.ToLower(raw), "file:") {
+		return false
+	}
+	return strings.Contains(raw, "=")
+}
+
+func canonicalKeywordCatalogDSN(raw string) (string, error) {
+	fields, err := parseKeywordCatalogDSN(raw)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(fields["service"]) != "" || strings.TrimSpace(fields["servicefile"]) != "" {
+		return "", errors.New("service-based keyword-value catalog DSN is unsupported for managed CDC")
+	}
+	locationFields := make(map[string]string)
+	for key, value := range fields {
+		if isCatalogIdentityLocationDSNKey(key) {
+			normalized := normalizedCatalogIdentityQueryKey(key)
+			if existing, ok := locationFields[normalized]; ok && existing != value {
+				return "", errors.New("keyword-value catalog DSN has conflicting location fields")
+			}
+			locationFields[normalized] = value
+		}
+	}
+	fields = locationFields
+	if len(fields) == 0 {
+		return "", errors.New("keyword-value catalog DSN has no supported location fields")
+	}
+	if host, ok := fields["host"]; ok {
+		hosts := strings.Split(host, ",")
+		for i := range hosts {
+			hosts[i] = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(hosts[i])), ".")
+		}
+		fields["host"] = strings.Join(hosts, ",")
+	}
+	if fields["port"] == "5432" {
+		delete(fields, "port")
+	}
+	values := make(url.Values, len(fields))
+	for key, value := range fields {
+		values.Set(key, value)
+	}
+	return "keyword-dsn:?" + values.Encode(), nil
+}
+
+func parseKeywordCatalogDSN(raw string) (map[string]string, error) {
+	fields := make(map[string]string)
+	for offset := 0; ; {
+		for offset < len(raw) && isCatalogDSNSpace(raw[offset]) {
+			offset++
+		}
+		if offset == len(raw) {
+			break
+		}
+		keyStart := offset
+		for offset < len(raw) && !isCatalogDSNSpace(raw[offset]) && raw[offset] != '=' {
+			offset++
+		}
+		key := strings.ToLower(strings.TrimSpace(raw[keyStart:offset]))
+		for offset < len(raw) && isCatalogDSNSpace(raw[offset]) {
+			offset++
+		}
+		if key == "" || offset >= len(raw) || raw[offset] != '=' {
+			return nil, errors.New("malformed keyword-value catalog DSN")
+		}
+		offset++
+		for offset < len(raw) && isCatalogDSNSpace(raw[offset]) {
+			offset++
+		}
+		value, next, err := parseKeywordCatalogDSNValue(raw, offset)
+		if err != nil {
+			return nil, err
+		}
+		fields[key] = value
+		offset = next
+	}
+	if len(fields) == 0 {
+		return nil, errors.New("empty keyword-value catalog DSN")
+	}
+	return fields, nil
+}
+
+func parseKeywordCatalogDSNValue(raw string, offset int) (string, int, error) {
+	var value strings.Builder
+	quoted := offset < len(raw) && raw[offset] == '\''
+	if quoted {
+		offset++
+	}
+	for offset < len(raw) {
+		character := raw[offset]
+		if character == '\\' {
+			offset++
+			if offset >= len(raw) {
+				return "", 0, errors.New("malformed keyword-value catalog DSN escape")
+			}
+			value.WriteByte(raw[offset])
+			offset++
+			continue
+		}
+		if quoted {
+			if character == '\'' {
+				offset++
+				if offset < len(raw) && !isCatalogDSNSpace(raw[offset]) {
+					return "", 0, errors.New("malformed quoted keyword-value catalog DSN")
+				}
+				return value.String(), offset, nil
+			}
+		} else if isCatalogDSNSpace(character) {
+			return value.String(), offset, nil
+		}
+		value.WriteByte(character)
+		offset++
+	}
+	if quoted {
+		return "", 0, errors.New("unterminated quoted keyword-value catalog DSN")
+	}
+	return value.String(), offset, nil
+}
+
+func isCatalogDSNSpace(character byte) bool {
+	return character == ' ' || character == '\t' || character == '\r' || character == '\n'
+}
+
+func defaultCatalogIdentityPort(scheme string) string {
+	switch scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	case "postgres", "postgresql":
+		return "5432"
+	case "mysql":
+		return "3306"
+	default:
+		return ""
+	}
+}
+
+func normalizedCatalogIdentityQueryKey(key string) string {
+	return strings.NewReplacer("_", "", "-", "", ".", "").Replace(strings.ToLower(key))
+}
+
+func isCatalogIdentityLocationQueryKey(key string) bool {
+	normalized := normalizedCatalogIdentityQueryKey(key)
+	switch normalized {
+	case "tenant", "region", "regionname",
+		"database", "dbname", "schema", "namespace", "catalog", "warehouse", "prefix", "branch", "ref",
+		"project", "projectid", "account", "accountid", "cluster", "instance", "endpoint",
+		"host", "hostaddr", "port":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCatalogIdentityLocationDSNKey(key string) bool {
+	normalized := normalizedCatalogIdentityQueryKey(key)
+	if isCatalogIdentityLocationQueryKey(normalized) {
+		return true
+	}
+	switch normalized {
+	case "service", "targetsessionattrs", "searchpath", "unixsocket", "socket", "protocol":
+		return true
+	default:
+		return false
+	}
+}
+
+func icebergCatalogIdentityName(catalogType icebergcatalog.Type, cfg icebergConfig) string {
+	if catalogType != icebergcatalog.SQL && catalogType != icebergcatalog.DynamoDB {
+		return ""
+	}
+	if !cfg.CatalogNameExplicit {
+		if catalogType == icebergcatalog.SQL {
+			return "sql"
+		}
+		return cfg.CatalogName
+	}
+	return cfg.CatalogName
+}
+
+func icebergGlueCatalogIdentity(catalogType icebergcatalog.Type, cfg icebergConfig) (string, string, string, error) {
+	if catalogType != icebergcatalog.Glue {
+		return "", "", "", nil
+	}
+	glueID := strings.TrimSpace(cfg.Properties.Get("glue.id", ""))
+	if glueID == "" {
+		return "", "", "", errors.New("iceberg: managed CDC with Glue requires explicit glue.id; ambient AWS account identity is unsupported")
+	}
+	glueRegion := strings.ToLower(strings.TrimSpace(cfg.Properties.Get("glue.region", "")))
+	if glueRegion == "" {
+		return "", "", "", errors.New("iceberg: managed CDC with Glue requires explicit glue.region; ambient AWS region is unsupported")
+	}
+	rawEndpoint := strings.TrimSpace(cfg.Properties.Get("glue.endpoint", ""))
+	if rawEndpoint == "" {
+		return "", "", "", errors.New("iceberg: managed CDC with Glue requires explicit glue.endpoint; ambient AWS endpoint resolution is unsupported")
+	}
+	glueEndpoint, err := icebergCatalogIdentityURI(rawEndpoint)
+	if err != nil {
+		return "", "", "", fmt.Errorf("iceberg: Glue endpoint cannot be safely canonicalized for managed CDC: %w", err)
+	}
+	return glueID, glueRegion, glueEndpoint, nil
+}
+
+func icebergRESTCatalogIdentityPrefix(catalogType icebergcatalog.Type, raw string) string {
+	if catalogType != icebergcatalog.REST {
+		return ""
+	}
+	clean := path.Clean("/" + strings.TrimSpace(raw))
+	if clean == "/" || clean == "." {
+		return ""
+	}
+	return strings.TrimPrefix(clean, "/")
+}
+
+func (d *Destination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	if d.catalog == nil {
+		return "", false, errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return "", false, err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if isMissingTableOrNamespace(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("iceberg: failed to load CDC target %s: %w", table, err)
+	}
+	incarnation := tbl.Metadata().TableUUID()
+	if incarnation == uuid.Nil {
+		return "", false, fmt.Errorf("iceberg: CDC target %s has no stable table UUID", table)
+	}
+	return incarnation.String(), true, nil
+}
+
+func (d *Destination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {
+	ownerID, err := claim.OwnerID()
+	if err != nil {
+		return err
+	}
+	canonicalTarget, err := d.CanonicalCDCTarget(ctx, claim.DestinationTable)
+	if err != nil {
+		return err
+	}
+	ident, err := parseIdentifier(claimTable)
+	if err != nil {
+		return err
+	}
+	claimTableState, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load CDC target claim table %s: %w", claimTable, err)
+	}
+	property := cdcTargetClaimPropertyPrefix + destination.CDCTargetKeyDigest(canonicalTarget)
+	existing := claimTableState.Properties()[property]
+	if existing == "" {
+		existing, err = icebergCDCClaimOwner(ctx, claimTableState, canonicalTarget)
+		if err != nil {
+			return err
+		}
+	}
+	if err := d.ensureCDCTargetClaimLock(ctx, ident, canonicalTarget, ownerID, existing); err != nil {
+		return err
+	}
+
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to load CDC target claim table %s: %w", claimTable, err)
+		}
+		existing := tbl.Properties()[property]
+		if existing == "" {
+			existing, err = icebergCDCClaimOwner(ctx, tbl, canonicalTarget)
+			if err != nil {
+				return err
+			}
+		}
+		if existing != "" && existing != ownerID {
+			return fmt.Errorf(
+				"iceberg: CDC target registry mirror for %q conflicts with its permanent claim lock",
+				claim.DestinationTable,
+			)
+		}
+		if tbl.Properties()[property] == ownerID {
+			return d.writeCDCClaimRow(ctx, claimTable, canonicalTarget, ownerID)
+		}
+
+		txn := tbl.NewTransaction()
+		if err := txn.SetProperties(iceberggo.Properties{property: ownerID}); err != nil {
+			return fmt.Errorf("iceberg: failed to stage CDC target claim: %w", err)
+		}
+		if _, err := txn.Commit(ctx); err == nil {
+			return d.writeCDCClaimRow(ctx, claimTable, canonicalTarget, ownerID)
+		} else if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			latest, loadErr := d.catalog.LoadTable(ctx, ident)
+			if loadErr == nil && latest.Properties()[property] == ownerID {
+				return d.writeCDCClaimRow(ctx, claimTable, canonicalTarget, ownerID)
+			}
+			return fmt.Errorf("iceberg: failed to commit CDC target claim: %w", errors.Join(err, loadErr))
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("iceberg: failed to claim CDC destination target %q after retries", claim.DestinationTable)
+}
+
+func (d *Destination) ensureCDCTargetClaimLock(
+	ctx context.Context,
+	claimTable icebergtable.Identifier,
+	canonicalTarget, ownerID, legacyOwnerID string,
+) error {
+	if !supportsAtomicCDCTargetClaims(d.catalog.CatalogType()) {
+		return fmt.Errorf("iceberg: catalog type %q cannot atomically claim CDC targets across processes", d.catalog.CatalogType())
+	}
+	lockIdent := icebergCDCTargetClaimLockIdentifier(claimTable, canonicalTarget)
+	lockSchema := iceberggo.NewSchema(0, iceberggo.NestedField{
+		ID: 1, Name: "claimed", Type: iceberggo.PrimitiveTypes.Bool, Required: true,
+	})
+	for attempt := range 5 {
+		lock, err := d.catalog.LoadTable(ctx, lockIdent)
+		if isMissingTableOrNamespace(err) {
+			if legacyOwnerID != "" && legacyOwnerID != ownerID {
+				return errors.New("iceberg: CDC destination target is already claimed by another connector")
+			}
+			_, err = d.catalog.CreateTable(ctx, lockIdent, lockSchema, icebergcatalog.WithProperties(iceberggo.Properties{
+				cdcTargetClaimLockTargetKey: canonicalTarget,
+				cdcTargetClaimLockOwnerKey:  ownerID,
+			}))
+			if err == nil {
+				return nil
+			}
+			if errors.Is(err, icebergcatalog.ErrTableAlreadyExists) ||
+				strings.Contains(strings.ToLower(err.Error()), "already exists") ||
+				strings.Contains(strings.ToLower(err.Error()), "unique constraint") {
+				continue
+			}
+			if isRetryableCDCClaimCatalogError(err) {
+				if err := waitForCommitRetry(ctx, attempt); err != nil {
+					return err
+				}
+				continue
+			}
+			return fmt.Errorf("iceberg: failed to create durable CDC target claim: %w", err)
+		}
+		if err != nil {
+			if isRetryableCDCClaimCatalogError(err) {
+				if err := waitForCommitRetry(ctx, attempt); err != nil {
+					return err
+				}
+				continue
+			}
+			return fmt.Errorf("iceberg: failed to inspect durable CDC target claim: %w", err)
+		}
+		if lock.Properties()[cdcTargetClaimLockTargetKey] != canonicalTarget {
+			return fmt.Errorf("iceberg: durable CDC target claim %s has invalid target metadata", strings.Join(lockIdent, "."))
+		}
+		if lock.Properties()[cdcTargetClaimLockOwnerKey] != ownerID {
+			return fmt.Errorf("iceberg: CDC destination target is already claimed by another connector")
+		}
+		return nil
+	}
+	return fmt.Errorf("iceberg: failed to resolve concurrent CDC target claim for %s", canonicalTarget)
+}
+
+func isRetryableCDCClaimCatalogError(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "database is locked") ||
+		strings.Contains(message, "serialization failure") ||
+		strings.Contains(message, "deadlock")
+}
+
+func supportsAtomicCDCTargetClaims(catalogType icebergcatalog.Type) bool {
+	switch catalogType {
+	case icebergcatalog.REST, icebergcatalog.Hive, icebergcatalog.Glue, icebergcatalog.DynamoDB, icebergcatalog.SQL:
+		return true
+	default:
+		return false
+	}
+}
+
+func icebergCDCTargetClaimLockIdentifier(claimTable icebergtable.Identifier, canonicalTarget string) icebergtable.Identifier {
+	ident := append(icebergtable.Identifier(nil), icebergcatalog.NamespaceFromIdent(claimTable)...)
+	return append(ident, cdcTargetClaimLockPrefix+destination.CDCTargetKeyDigest(canonicalTarget)[:24])
+}
+
+func icebergCDCClaimOwner(ctx context.Context, tbl *icebergtable.Table, canonicalTarget string) (string, error) {
+	rows, err := scanTableRows(ctx, tbl, iceberggo.EqualTo(iceberggo.Reference("destination_table"), canonicalTarget))
+	if err != nil {
+		return "", fmt.Errorf("iceberg: failed to inspect existing CDC target claims: %w", err)
+	}
+	if err := requireColumns(rows, []string{"destination_table", "connector_id"}, strings.Join(tbl.Identifier(), ".")); err != nil {
+		return "", err
+	}
+	var owner string
+	for _, row := range rows.Rows {
+		candidate, ok := rows.Value(row, "connector_id").(string)
+		if !ok || candidate == "" {
+			return "", errors.New("iceberg: existing CDC target claim has an invalid connector identifier")
+		}
+		if owner != "" && candidate != owner {
+			return "", errors.New("iceberg: CDC target claim table contains conflicting owners")
+		}
+		owner = candidate
+	}
+	return owner, nil
+}
+
+func (d *Destination) writeCDCClaimRow(ctx context.Context, table, canonicalTarget, ownerID string) error {
+	tbl, err := d.loadIcebergTable(ctx, table)
+	if err != nil {
+		return err
+	}
+	visibleOwner, err := icebergCDCClaimOwner(ctx, tbl, canonicalTarget)
+	if err != nil {
+		return err
+	}
+	if visibleOwner != "" {
+		if visibleOwner != ownerID {
+			return errors.New("iceberg: CDC target claim table contains a row owned by another connector")
+		}
+		return nil
+	}
+	tableSchema, err := d.GetTableSchema(ctx, table)
+	if err != nil {
+		return err
+	}
+	if tableSchema == nil {
+		return fmt.Errorf("iceberg: CDC target claim table %s does not exist", table)
+	}
+	arrowSchema := icebergArrowSchema(tableSchema)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer builder.Release()
+	values := map[string]any{
+		"destination_table": canonicalTarget,
+		"connector_id":      ownerID,
+		"claimed_at":        time.Now().UTC().UnixMicro(),
+	}
+	for index, field := range arrowSchema.Fields() {
+		value, ok := values[strings.ToLower(field.Name)]
+		if !ok {
+			return fmt.Errorf("iceberg: unexpected column %q in CDC target claim table", field.Name)
+		}
+		if err := appendValueAtPath(builder.Field(index), value, field.Name, field.Nullable); err != nil {
+			return err
+		}
+	}
+	record := builder.NewRecordBatch()
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: record}
+	close(records)
+	return d.WriteParallel(ctx, records, destination.WriteOptions{
+		Table:         table,
+		Schema:        tableSchema,
+		Parallelism:   1,
+		StagingTable:  true,
+		CommitToken:   "cdc-target-claim:" + destination.CDCTargetKeyDigest(canonicalTarget, ownerID),
+		SkipCDCResume: true,
+	})
+}
+
+func (d *Destination) WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	batches := make([]arrow.RecordBatch, 0, 1)
+	eventIDs := make([]string, 0)
+	var inputErr error
+	for result := range records {
+		if result.Err != nil && inputErr == nil {
+			inputErr = result.Err
+		}
+		if result.Batch == nil {
+			continue
+		}
+		if inputErr != nil {
+			result.Batch.Release()
+			continue
+		}
+		ids, err := cdcStateEventIDs(result.Batch)
+		if err != nil {
+			inputErr = err
+			result.Batch.Release()
+			continue
+		}
+		batches = append(batches, result.Batch)
+		eventIDs = append(eventIDs, ids...)
+	}
+	if inputErr != nil {
+		for _, batch := range batches {
+			batch.Release()
+		}
+		return inputErr
+	}
+	if len(eventIDs) == 0 {
+		for _, batch := range batches {
+			batch.Release()
+		}
+		return nil
+	}
+	sort.Strings(eventIDs)
+	opts.CommitToken = struct {
+		Kind     string
+		EventIDs []string
+	}{Kind: "iceberg-managed-cdc-state-v1", EventIDs: eventIDs}
+	opts.SkipCDCResume = true
+	opts.StagingTable = true
+	opts.CDCExpectedIncarnation = ""
+	forwarded := make(chan source.RecordBatchResult, len(batches))
+	for _, batch := range batches {
+		forwarded <- source.RecordBatchResult{Batch: batch}
+	}
+	close(forwarded)
+	return d.WriteParallel(ctx, forwarded, opts)
+}
+
+func cdcStateEventIDs(batch arrow.RecordBatch) ([]string, error) {
+	index := -1
+	for i, field := range batch.Schema().Fields() {
+		if strings.EqualFold(field.Name, "event_id") {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return nil, errors.New("iceberg: CDC state batch has no event_id column")
+	}
+	values, ok := batch.Column(index).(*array.String)
+	if !ok {
+		return nil, fmt.Errorf("iceberg: CDC state event_id column has type %s, want string", batch.Column(index).DataType())
+	}
+	ids := make([]string, 0, values.Len())
+	for row := 0; row < values.Len(); row++ {
+		if values.IsNull(row) || values.Value(row) == "" {
+			return nil, errors.New("iceberg: CDC state event_id must be non-empty")
+		}
+		ids = append(ids, values.Value(row))
+	}
+	return ids, nil
+}
+
+func (d *Destination) LoadCDCState(ctx context.Context, table, connectorID string) ([]destination.CDCStateEntry, error) {
+	tbl, err := d.loadOptionalCDCTable(ctx, table)
+	if err != nil || tbl == nil {
+		return nil, err
+	}
+	rows, err := scanTableRows(ctx, tbl, iceberggo.EqualTo(iceberggo.Reference("connector_id"), connectorID))
+	if err != nil {
+		return nil, err
+	}
+	required := []string{"event_id", "source_table", "destination_table", "state_kind", "state_generation", "state_status", "_cdc_lsn", "recorded_at"}
+	if err := requireColumns(rows, required, table); err != nil {
+		return nil, err
+	}
+	entries := make([]destination.CDCStateEntry, 0, len(rows.Rows))
+	for _, row := range rows.Rows {
+		entry, err := icebergCDCStateEntry(rows, row)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: invalid CDC state row: %w", err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func icebergCDCStateEntry(rows *scannedTable, row []any) (destination.CDCStateEntry, error) {
+	stringValue := func(column string) (string, error) {
+		value, ok := rows.Value(row, column).(string)
+		if !ok {
+			return "", fmt.Errorf("column %s has type %T, want string", column, rows.Value(row, column))
+		}
+		return value, nil
+	}
+	eventID, err := stringValue("event_id")
+	if err != nil {
+		return destination.CDCStateEntry{}, err
+	}
+	sourceTable, err := stringValue("source_table")
+	if err != nil {
+		return destination.CDCStateEntry{}, err
+	}
+	destinationTable, err := stringValue("destination_table")
+	if err != nil {
+		return destination.CDCStateEntry{}, err
+	}
+	stateKind, err := stringValue("state_kind")
+	if err != nil {
+		return destination.CDCStateEntry{}, err
+	}
+	status, err := stringValue("state_status")
+	if err != nil {
+		return destination.CDCStateEntry{}, err
+	}
+	position, err := stringValue("_cdc_lsn")
+	if err != nil {
+		return destination.CDCStateEntry{}, err
+	}
+	generation, ok := rows.Value(row, "state_generation").(int64)
+	if !ok {
+		return destination.CDCStateEntry{}, fmt.Errorf("column state_generation has type %T, want int64", rows.Value(row, "state_generation"))
+	}
+	entry := destination.CDCStateEntry{
+		EventID:          eventID,
+		SourceTable:      sourceTable,
+		DestinationTable: destinationTable,
+		StateKind:        stateKind,
+		Generation:       generation,
+		Status:           status,
+		Position:         position,
+	}
+	recordedAt, ok := rows.Value(row, "recorded_at").(int64)
+	if !ok {
+		return destination.CDCStateEntry{}, fmt.Errorf("column recorded_at has type %T, want timestamp", rows.Value(row, "recorded_at"))
+	}
+	entry.RecordedAt = time.UnixMicro(recordedAt).UTC()
+	return entry, nil
+}
+
+func (d *Destination) LoadCDCStateFence(ctx context.Context, table, connectorID string) (destination.CDCStateFence, error) {
+	tbl, err := d.loadOptionalCDCTable(ctx, table)
+	if err != nil || tbl == nil {
+		return destination.CDCStateFence{}, err
+	}
+	filter := iceberggo.NewAnd(
+		iceberggo.EqualTo(iceberggo.Reference("connector_id"), connectorID),
+		iceberggo.EqualTo(iceberggo.Reference("state_kind"), "run"),
+	)
+	rows, err := scanTableRows(ctx, tbl, filter)
+	if err != nil {
+		return destination.CDCStateFence{}, err
+	}
+	if err := requireColumns(rows, []string{"event_id", "state_generation"}, table); err != nil {
+		return destination.CDCStateFence{}, err
+	}
+	var fence destination.CDCStateFence
+	ids := make(map[string]struct{})
+	for _, row := range rows.Rows {
+		generation, ok := rows.Value(row, "state_generation").(int64)
+		if !ok {
+			return destination.CDCStateFence{}, errors.New("iceberg: CDC state fence generation is not int64")
+		}
+		eventID, ok := rows.Value(row, "event_id").(string)
+		if !ok {
+			return destination.CDCStateFence{}, errors.New("iceberg: CDC state fence event ID is not string")
+		}
+		if generation > fence.Generation {
+			fence.Generation = generation
+			clear(ids)
+		}
+		if generation == fence.Generation {
+			ids[eventID] = struct{}{}
+		}
+	}
+	for eventID := range ids {
+		fence.RunEventIDs = append(fence.RunEventIDs, eventID)
+	}
+	sort.Strings(fence.RunEventIDs)
+	return fence, nil
+}
+
+func (d *Destination) DeleteCDCStateEvents(ctx context.Context, table, connectorID string, eventIDs []string) error {
+	for start := 0; start < len(eventIDs); start += icebergCDCStatePruneBatch {
+		end := min(start+icebergCDCStatePruneBatch, len(eventIDs))
+		if err := d.deleteCDCStateEventBatch(ctx, table, connectorID, slices.Clone(eventIDs[start:end])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Destination) deleteCDCStateEventBatch(ctx context.Context, table, connectorID string, eventIDs []string) error {
+	if len(eventIDs) == 0 {
+		return nil
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return err
+	}
+	eventFilter := iceberggo.BooleanExpression(nil)
+	for _, eventID := range eventIDs {
+		predicate := iceberggo.EqualTo(iceberggo.Reference("event_id"), eventID)
+		if eventFilter == nil {
+			eventFilter = predicate
+		} else {
+			eventFilter = iceberggo.NewOr(eventFilter, predicate)
+		}
+	}
+	filter := iceberggo.NewAnd(iceberggo.EqualTo(iceberggo.Reference("connector_id"), connectorID), eventFilter)
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			if isMissingTableOrNamespace(err) {
+				return nil
+			}
+			return err
+		}
+		if tbl.CurrentSnapshot() == nil {
+			return nil
+		}
+		txn := tbl.NewTransaction()
+		if err := txn.Delete(ctx, filter, snapshotProps("cdc-state-prune")); err != nil {
+			return fmt.Errorf("iceberg: failed to stage CDC state pruning: %w", err)
+		}
+		if _, err := txn.Commit(ctx); err == nil {
+			d.afterSuccessfulCommit(ctx, table)
+			return nil
+		} else if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			return fmt.Errorf("iceberg: failed to commit CDC state pruning: %w", err)
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("iceberg: failed to prune CDC state from %s after retries", table)
+}
+
+func (*Destination) CDCStatePruneBatchSize() int { return icebergCDCStatePruneBatch }
+
+func (d *Destination) TruncateCDCTable(ctx context.Context, table string) error {
+	return d.truncateCDCTable(ctx, table, "")
+}
+
+func (d *Destination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
+	if strings.TrimSpace(expectedIncarnation) == "" {
+		return errors.New("iceberg: conditional CDC truncate requires an expected incarnation")
+	}
+	return d.truncateCDCTable(ctx, table, expectedIncarnation)
+}
+
+func (d *Destination) truncateCDCTable(ctx context.Context, table, expectedIncarnation string) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return err
+	}
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to load CDC target %s: %w", table, err)
+		}
+		actual := tbl.Metadata().TableUUID().String()
+		if expectedIncarnation != "" && actual != expectedIncarnation {
+			return fmt.Errorf("iceberg: refused to truncate CDC target %s because its incarnation changed", table)
+		}
+		txn := tbl.NewTransaction()
+		if err := stageResetCommitTokenLedger(txn, ""); err != nil {
+			return err
+		}
+		props := snapshotProps("cdc-truncate")
+		props[snapshotCDCResetKey] = "true"
+		if err := stageCDCResumeState(txn, props); err != nil {
+			return err
+		}
+		if tbl.CurrentSnapshot() != nil {
+			if err := txn.Delete(ctx, iceberggo.AlwaysTrue{}, props); err != nil {
+				return fmt.Errorf("iceberg: failed to stage CDC truncate of %s: %w", table, err)
+			}
+		}
+		if _, err := txn.Commit(ctx); err == nil {
+			d.afterSuccessfulCommitExpected(ctx, table, expectedIncarnation)
+			return nil
+		} else if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			return fmt.Errorf("iceberg: failed to commit CDC truncate of %s: %w", table, err)
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("iceberg: failed to truncate CDC target %s after retries", table)
+}
+
+func (d *Destination) loadOptionalCDCTable(ctx context.Context, table string) (*icebergtable.Table, error) {
+	if d.catalog == nil {
+		return nil, errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return nil, err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if errors.Is(err, icebergcatalog.ErrNoSuchTable) || errors.Is(err, icebergcatalog.ErrNoSuchNamespace) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("iceberg: failed to load CDC state table %s: %w", table, err)
+	}
+	return tbl, nil
+}

--- a/pkg/destination/iceberg/cluster.go
+++ b/pkg/destination/iceberg/cluster.go
@@ -1,0 +1,311 @@
+package iceberg
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+)
+
+type clusterValueEncoder func(*bytes.Buffer, any) error
+
+func newClusterSorter(sc *arrow.Schema, columns []string) (*spillSorter, error) {
+	sorter, err := newSpillSorter(sc, columns)
+	if err != nil {
+		return nil, err
+	}
+
+	encoders := make([]clusterValueEncoder, len(sorter.keyIdx))
+	for i, idx := range sorter.keyIdx {
+		encoder, err := clusterEncoder(sc.Field(idx).Type)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: cluster column %q: %w", sc.Field(idx).Name, err)
+		}
+		encoders[i] = encoder
+	}
+	sorter.allowNil = true
+	sorter.encode = func(values []any) (string, error) {
+		var out bytes.Buffer
+		for i, value := range values {
+			if value == nil {
+				out.WriteByte(0)
+				continue
+			}
+			out.WriteByte(1)
+			if err := encoders[i](&out, value); err != nil {
+				return "", err
+			}
+		}
+		return out.String(), nil
+	}
+	return sorter, nil
+}
+
+func clusterEncoder(dataType arrow.DataType) (clusterValueEncoder, error) {
+	switch t := dataType.(type) {
+	case *arrow.BooleanType:
+		return func(out *bytes.Buffer, value any) error {
+			v, ok := value.(bool)
+			if !ok {
+				return clusterTypeError(dataType, value)
+			}
+			if v {
+				out.WriteByte(1)
+			} else {
+				out.WriteByte(0)
+			}
+			return nil
+		}, nil
+	case *arrow.Int8Type, *arrow.Int16Type, *arrow.Int32Type, *arrow.Int64Type,
+		*arrow.Uint8Type, *arrow.Uint16Type, *arrow.Uint32Type, *arrow.Uint64Type,
+		*arrow.Date32Type, *arrow.Date64Type, *arrow.Time32Type, *arrow.Time64Type, *arrow.TimestampType:
+		return func(out *bytes.Buffer, value any) error {
+			v, ok := value.(int64)
+			if !ok {
+				return clusterTypeError(dataType, value)
+			}
+			var encoded [8]byte
+			binary.BigEndian.PutUint64(encoded[:], uint64(v)^(uint64(1)<<63))
+			out.Write(encoded[:])
+			return nil
+		}, nil
+	case *arrow.Float32Type, *arrow.Float64Type:
+		return func(out *bytes.Buffer, value any) error {
+			v, ok := value.(float64)
+			if !ok {
+				return clusterTypeError(dataType, value)
+			}
+			var sortable uint64
+			if math.IsNaN(v) {
+				sortable = math.MaxUint64
+			} else {
+				sortable = math.Float64bits(v)
+				if sortable&(uint64(1)<<63) != 0 {
+					sortable = ^sortable
+				} else {
+					sortable ^= uint64(1) << 63
+				}
+			}
+			var encoded [8]byte
+			binary.BigEndian.PutUint64(encoded[:], sortable)
+			out.Write(encoded[:])
+			return nil
+		}, nil
+	case *arrow.StringType, *arrow.LargeStringType:
+		return func(out *bytes.Buffer, value any) error {
+			v, ok := value.(string)
+			if !ok {
+				return clusterTypeError(dataType, value)
+			}
+			writeEscapedClusterBytes(out, []byte(v))
+			return nil
+		}, nil
+	case *arrow.BinaryType, *arrow.LargeBinaryType, *arrow.FixedSizeBinaryType:
+		return func(out *bytes.Buffer, value any) error {
+			v, ok := value.([]byte)
+			if !ok {
+				return clusterTypeError(dataType, value)
+			}
+			writeEscapedClusterBytes(out, v)
+			return nil
+		}, nil
+	case *extensions.UUIDType:
+		return func(out *bytes.Buffer, value any) error {
+			v, ok := value.(uuidVal)
+			if !ok {
+				return clusterTypeError(dataType, value)
+			}
+			writeEscapedClusterBytes(out, []byte(v))
+			return nil
+		}, nil
+	case *arrow.Decimal128Type:
+		return decimalClusterEncoder(dataType, t.Precision, t.Scale), nil
+	case *arrow.Decimal256Type:
+		return decimalClusterEncoder(dataType, t.Precision, t.Scale), nil
+	default:
+		return nil, fmt.Errorf("type %s is not orderable for clustering", dataType)
+	}
+}
+
+func decimalClusterEncoder(dataType arrow.DataType, precision, scale int32) clusterValueEncoder {
+	offset := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+	maximum := new(big.Int).Mul(new(big.Int).Set(offset), big.NewInt(2))
+	width := (maximum.BitLen() + 7) / 8
+	scaleFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+	return func(out *bytes.Buffer, value any) error {
+		v, ok := value.(decimalVal)
+		if !ok {
+			return clusterTypeError(dataType, value)
+		}
+		rational, ok := new(big.Rat).SetString(string(v))
+		if !ok {
+			return fmt.Errorf("invalid decimal cluster value %q", v)
+		}
+		rational.Mul(rational, new(big.Rat).SetInt(scaleFactor))
+		if !rational.IsInt() {
+			return fmt.Errorf("decimal cluster value %q exceeds scale %d", v, scale)
+		}
+		shifted := new(big.Int).Add(rational.Num(), offset)
+		if shifted.Sign() < 0 || shifted.Cmp(maximum) >= 0 {
+			return fmt.Errorf("decimal cluster value %q exceeds precision %d", v, precision)
+		}
+		encoded := make([]byte, width)
+		shifted.FillBytes(encoded)
+		out.Write(encoded)
+		return nil
+	}
+}
+
+func writeEscapedClusterBytes(out *bytes.Buffer, value []byte) {
+	for _, b := range value {
+		if b == 0 {
+			out.Write([]byte{0, 255})
+			continue
+		}
+		out.WriteByte(b)
+	}
+	out.Write([]byte{0, 0})
+}
+
+func clusterTypeError(dataType arrow.DataType, value any) error {
+	return fmt.Errorf("cannot order value of type %T as %s", value, dataType)
+}
+
+func clusterRecordReader(ctx context.Context, input array.RecordReader, columns []string) (array.RecordReader, func(), error) {
+	if len(columns) == 0 {
+		return input, func() {}, nil
+	}
+	sorter, err := newClusterSorter(input.Schema(), columns)
+	if err != nil {
+		return nil, nil, err
+	}
+	for input.Next() {
+		if err := ctx.Err(); err != nil {
+			sorter.Close()
+			return nil, nil, err
+		}
+		batch := input.RecordBatch()
+		for row := 0; row < int(batch.NumRows()); row++ {
+			if err := ctx.Err(); err != nil {
+				sorter.Close()
+				return nil, nil, err
+			}
+			values := make([]any, int(batch.NumCols()))
+			for column := range values {
+				value, err := rowValue(batch.Column(column), row)
+				if err != nil {
+					sorter.Close()
+					return nil, nil, err
+				}
+				values[column] = value
+			}
+			if err := sorter.AddContext(ctx, values); err != nil {
+				sorter.Close()
+				return nil, nil, err
+			}
+		}
+	}
+	if err := input.Err(); err != nil {
+		sorter.Close()
+		return nil, nil, err
+	}
+	sc := input.Schema()
+	reader := streamingReaderContext(ctx, sc, func(sink func(arrow.RecordBatch) error) error {
+		it, err := sorter.IterContext(ctx)
+		if err != nil {
+			return err
+		}
+		defer it.Close()
+		emitter := newBatchEmitter(newRowProjection(sc, arrowSchemaColumnNames(sc)), sink)
+		defer emitter.release()
+		for it.NextGroup() {
+			for it.NextRow() {
+				if err := emitter.add(it.Row()); err != nil {
+					return err
+				}
+			}
+		}
+		if err := it.Err(); err != nil {
+			return err
+		}
+		return emitter.flushBatch()
+	})
+	cleanup := func() {
+		reader.Release()
+		sorter.Close()
+	}
+	return reader, cleanup, nil
+}
+
+func deduplicateRecordReader(input array.RecordReader, primaryKeys []string, incrementalKey string) (array.RecordReader, func(), error) {
+	sorter, err := newSpillSorter(input.Schema(), primaryKeys)
+	if err != nil {
+		return nil, nil, err
+	}
+	incrementalIdx := -1
+	if incrementalKey != "" {
+		indices := input.Schema().FieldIndices(incrementalKey)
+		if len(indices) == 0 {
+			sorter.Close()
+			return nil, nil, fmt.Errorf("incremental key column %q not found", incrementalKey)
+		}
+		incrementalIdx = indices[0]
+		if _, err := clusterEncoder(input.Schema().Field(incrementalIdx).Type); err != nil {
+			sorter.Close()
+			return nil, nil, fmt.Errorf("incremental key column %q is not orderable: %w", incrementalKey, err)
+		}
+	}
+	for input.Next() {
+		batch := input.RecordBatch()
+		for row := 0; row < int(batch.NumRows()); row++ {
+			values := make([]any, int(batch.NumCols()))
+			for column := range values {
+				value, err := rowValue(batch.Column(column), row)
+				if err != nil {
+					sorter.Close()
+					return nil, nil, err
+				}
+				values[column] = value
+			}
+			if err := sorter.Add(values); err != nil {
+				sorter.Close()
+				return nil, nil, err
+			}
+		}
+	}
+	if err := input.Err(); err != nil {
+		sorter.Close()
+		return nil, nil, err
+	}
+
+	sc := input.Schema()
+	reader := streamingReader(sc, func(sink func(arrow.RecordBatch) error) error {
+		it, err := sorter.Iter()
+		if err != nil {
+			return err
+		}
+		defer it.Close()
+		emitter := newBatchEmitter(newRowProjection(sc, arrowSchemaColumnNames(sc)), sink)
+		defer emitter.release()
+		for it.NextGroup() {
+			if err := emitter.add(selectGroupWinner(it, incrementalIdx)); err != nil {
+				return err
+			}
+		}
+		if err := it.Err(); err != nil {
+			return err
+		}
+		return emitter.flushBatch()
+	})
+	cleanup := func() {
+		reader.Release()
+		sorter.Close()
+	}
+	return reader, cleanup, nil
+}

--- a/pkg/destination/iceberg/commit_metadata.go
+++ b/pkg/destination/iceberg/commit_metadata.go
@@ -1,0 +1,505 @@
+package iceberg
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+)
+
+const (
+	snapshotCommitTokenKey    = "ingestr.commit-token"
+	snapshotCDCResumeLSNKey   = "ingestr.cdc-resume-lsn"
+	snapshotCDCResetKey       = "ingestr.cdc-resume-reset"
+	tableCommitTokenLedgerKey = "ingestr.commit-token-ledger"
+	tableCDCResumeStateKey    = "ingestr.cdc-resume-state"
+	commitReconcileTimeout    = 2 * time.Second
+	commitTokenLedgerLimit    = 1024
+)
+
+type commitMetadata struct {
+	token               string
+	cdcResumeLSN        string
+	resetCDCResume      bool
+	expectedIncarnation string
+}
+
+type durableCDCResumeState struct {
+	Position string `json:"position,omitempty"`
+	Reset    bool   `json:"reset,omitempty"`
+}
+
+func newCommitMetadata(token any, cdcResumeLSN string) commitMetadata {
+	metadata := commitMetadata{
+		token:        commitTokenID(token),
+		cdcResumeLSN: strings.TrimSpace(cdcResumeLSN),
+	}
+	return metadata
+}
+
+func mergeCommitMetadata(opts destination.MergeOptions) commitMetadata {
+	metadata := newCommitMetadata(opts.CommitToken, opts.CDCResumeLSN)
+	metadata.expectedIncarnation = opts.CDCExpectedIncarnation
+	if opts.SkipCDCResume {
+		metadata.cdcResumeLSN = ""
+		metadata.resetCDCResume = true
+	}
+	return metadata
+}
+
+func (m commitMetadata) withExpectedIncarnation(expected string) commitMetadata {
+	m.expectedIncarnation = expected
+	return m
+}
+
+func (m commitMetadata) withCDCResumeLSN(lsn string) commitMetadata {
+	if m.cdcResumeLSN != "" {
+		return m
+	}
+	lsn = strings.TrimSpace(lsn)
+	if lsn == "" {
+		return m
+	}
+	m.cdcResumeLSN = lsn
+	return m
+}
+
+func (m commitMetadata) empty() bool {
+	return m.token == "" && m.cdcResumeLSN == "" && !m.resetCDCResume
+}
+
+func commitTokenID(token any) string {
+	if token == nil {
+		return ""
+	}
+
+	encoded, err := json.Marshal(token)
+	if err != nil || string(encoded) == "{}" {
+		encoded = []byte(fmt.Sprintf("%#v", token))
+	}
+	payload := append([]byte(fmt.Sprintf("%T:", token)), encoded...)
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func snapshotProps(operation string, metadata ...commitMetadata) iceberggo.Properties {
+	props := iceberggo.Properties{
+		"ingestr.destination": "iceberg",
+		"ingestr.operation":   operation,
+	}
+	if operation == "replace" || operation == "truncate" || operation == "truncate+insert" || operation == "snapshot" {
+		props[snapshotCDCResetKey] = "true"
+	}
+	if len(metadata) == 0 {
+		return props
+	}
+	if metadata[0].token != "" {
+		props[snapshotCommitTokenKey] = metadata[0].token
+	}
+	if metadata[0].cdcResumeLSN != "" {
+		props[snapshotCDCResumeLSNKey] = metadata[0].cdcResumeLSN
+	}
+	if metadata[0].resetCDCResume {
+		props[snapshotCDCResetKey] = "true"
+	}
+	return props
+}
+
+func observeCDCResumeLSN(props iceberggo.Properties, batch arrow.RecordBatch, preserveToken bool) {
+	lsn := maxCDCResumeLSNInBatch(batch)
+	if lsn == "" || compareCDCResumeLSN(lsn, props[snapshotCDCResumeLSNKey]) <= 0 {
+		return
+	}
+	props[snapshotCDCResumeLSNKey] = lsn
+	if !preserveToken {
+		delete(props, snapshotCommitTokenKey)
+	}
+}
+
+func maxCDCResumeLSNInBatch(batch arrow.RecordBatch) string {
+	idx := -1
+	for i, field := range batch.Schema().Fields() {
+		if strings.EqualFold(field.Name, destination.CDCLSNColumn) {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return ""
+	}
+
+	values, ok := batch.Column(idx).(interface {
+		arrow.Array
+		Value(int) string
+	})
+	if !ok {
+		return ""
+	}
+	var maxLSN string
+	for i := 0; i < values.Len(); i++ {
+		if values.IsNull(i) {
+			continue
+		}
+		if value := values.Value(i); compareCDCResumeLSN(value, maxLSN) > 0 {
+			maxLSN = value
+		}
+	}
+	return maxLSN
+}
+
+func compareCDCResumeLSN(left, right string) int {
+	return destination.CompareCDCPositions(left, right)
+}
+
+func validateCDCResumeAdvance(tbl *icebergtable.Table, metadata commitMetadata) error {
+	if metadata.cdcResumeLSN == "" || tableHasCommitToken(tbl, metadata.token) {
+		return nil
+	}
+	current := latestCDCResumeLSN(tbl)
+	// A PostgreSQL transaction's commit LSN can equal the replication slot's
+	// snapshot consistent point. The cursor is therefore a monotonic boundary,
+	// not the identity of the write: equal positions may carry distinct rows,
+	// while the stable commit token provides exactly-once behavior.
+	if current != "" && compareCDCResumeLSN(metadata.cdcResumeLSN, current) < 0 {
+		return fmt.Errorf(
+			"iceberg: stale CDC resume position %q is older than durable position %q",
+			metadata.cdcResumeLSN,
+			current,
+		)
+	}
+	return nil
+}
+
+func snapshotInCurrentLineage(tbl *icebergtable.Table, visit func(*icebergtable.Snapshot) bool) bool {
+	snapshot := tbl.CurrentSnapshot()
+	seen := make(map[int64]struct{})
+	for snapshot != nil {
+		if _, ok := seen[snapshot.SnapshotID]; ok {
+			return false
+		}
+		seen[snapshot.SnapshotID] = struct{}{}
+		if visit(snapshot) {
+			return true
+		}
+		if snapshot.ParentSnapshotID == nil {
+			return false
+		}
+		snapshot = tbl.SnapshotByID(*snapshot.ParentSnapshotID)
+	}
+	return false
+}
+
+func tableHasCommitToken(tbl *icebergtable.Table, token string) bool {
+	if token == "" {
+		return false
+	}
+	var ledger []string
+	if err := json.Unmarshal([]byte(tbl.Properties()[tableCommitTokenLedgerKey]), &ledger); err == nil {
+		for _, existing := range ledger {
+			if existing == token {
+				return true
+			}
+		}
+	}
+	snapshot := tbl.CurrentSnapshot()
+	seen := make(map[int64]struct{})
+	for snapshot != nil {
+		if _, ok := seen[snapshot.SnapshotID]; ok {
+			return false
+		}
+		seen[snapshot.SnapshotID] = struct{}{}
+		if snapshot.Summary != nil {
+			if snapshot.Summary.Properties[snapshotCommitTokenKey] == token {
+				return true
+			}
+			if snapshot.Summary.Properties[snapshotCDCResetKey] == "true" {
+				return false
+			}
+		}
+		if snapshot.ParentSnapshotID == nil {
+			return false
+		}
+		snapshot = tbl.SnapshotByID(*snapshot.ParentSnapshotID)
+	}
+	return false
+}
+
+func currentSnapshotHasCommitToken(tbl *icebergtable.Table, token string) bool {
+	if token == "" || tbl == nil || tbl.CurrentSnapshot() == nil || tbl.CurrentSnapshot().Summary == nil {
+		return false
+	}
+	return tbl.CurrentSnapshot().Summary.Properties[snapshotCommitTokenKey] == token
+}
+
+func lineageHasCommitTokenAfterSnapshot(tbl *icebergtable.Table, token string, baseSnapshotID int64) bool {
+	if token == "" || tbl == nil {
+		return false
+	}
+	snapshot := tbl.CurrentSnapshot()
+	seen := make(map[int64]struct{})
+	for snapshot != nil && snapshot.SnapshotID != baseSnapshotID {
+		if _, ok := seen[snapshot.SnapshotID]; ok {
+			return false
+		}
+		seen[snapshot.SnapshotID] = struct{}{}
+		if snapshot.Summary != nil && snapshot.Summary.Properties[snapshotCommitTokenKey] == token {
+			return true
+		}
+		if snapshot.ParentSnapshotID == nil {
+			return false
+		}
+		snapshot = tbl.SnapshotByID(*snapshot.ParentSnapshotID)
+	}
+	return false
+}
+
+func stageCommitTokenLedger(txn *icebergtable.Transaction, tbl *icebergtable.Table, token string) error {
+	if token == "" {
+		return nil
+	}
+	var ledger []string
+	_ = json.Unmarshal([]byte(tbl.Properties()[tableCommitTokenLedgerKey]), &ledger)
+	for _, existing := range ledger {
+		if existing == token {
+			return nil
+		}
+	}
+	ledger = append(ledger, token)
+	if len(ledger) > commitTokenLedgerLimit {
+		ledger = append([]string(nil), ledger[len(ledger)-commitTokenLedgerLimit:]...)
+	}
+	encoded, err := json.Marshal(ledger)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to encode commit-token ledger: %w", err)
+	}
+	if err := txn.SetProperties(iceberggo.Properties{tableCommitTokenLedgerKey: string(encoded)}); err != nil {
+		return fmt.Errorf("iceberg: failed to stage commit-token ledger: %w", err)
+	}
+	return nil
+}
+
+func stageResetCommitTokenLedger(txn *icebergtable.Transaction, token string) error {
+	ledger := []string{}
+	if token != "" {
+		ledger = append(ledger, token)
+	}
+	encoded, err := json.Marshal(ledger)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to encode reset commit-token ledger: %w", err)
+	}
+	if err := txn.SetProperties(iceberggo.Properties{tableCommitTokenLedgerKey: string(encoded)}); err != nil {
+		return fmt.Errorf("iceberg: failed to reset commit-token ledger: %w", err)
+	}
+	return nil
+}
+
+func stageCDCResumeState(txn *icebergtable.Transaction, props iceberggo.Properties) error {
+	state := durableCDCResumeState{Position: props[snapshotCDCResumeLSNKey]}
+	if state.Position == "" {
+		state.Reset = props[snapshotCDCResetKey] == "true"
+		if !state.Reset {
+			return nil
+		}
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to encode durable CDC resume state: %w", err)
+	}
+	if err := txn.SetProperties(iceberggo.Properties{tableCDCResumeStateKey: string(encoded)}); err != nil {
+		return fmt.Errorf("iceberg: failed to stage durable CDC resume state: %w", err)
+	}
+	return nil
+}
+
+func latestCDCResumeLSN(tbl *icebergtable.Table) string {
+	if raw, ok := tbl.Properties()[tableCDCResumeStateKey]; ok {
+		var state durableCDCResumeState
+		if json.Unmarshal([]byte(raw), &state) == nil {
+			return strings.TrimSpace(state.Position)
+		}
+	}
+	var result string
+	snapshotInCurrentLineage(tbl, func(snapshot *icebergtable.Snapshot) bool {
+		if snapshot.Summary == nil {
+			return false
+		}
+		result = snapshot.Summary.Properties[snapshotCDCResumeLSNKey]
+		if result != "" {
+			return true
+		}
+		operation := snapshot.Summary.Properties["ingestr.operation"]
+		return snapshot.Summary.Properties[snapshotCDCResetKey] == "true" ||
+			operation == "replace" || operation == "truncate" || operation == "truncate+insert"
+	})
+	return result
+}
+
+func (d *Destination) reconcileCommit(
+	ctx context.Context,
+	table string,
+	token string,
+	expectedIncarnation string,
+	commitErr error,
+) error {
+	return d.reconcileCommitMatching(ctx, table, token, expectedIncarnation, commitErr, tableHasCommitToken)
+}
+
+func (d *Destination) reconcileCommitAfterSnapshot(
+	ctx context.Context,
+	table string,
+	token string,
+	baseSnapshotID int64,
+	expectedIncarnation string,
+	commitErr error,
+) error {
+	return d.reconcileCommitMatching(ctx, table, token, expectedIncarnation, commitErr, func(tbl *icebergtable.Table, token string) bool {
+		return lineageHasCommitTokenAfterSnapshot(tbl, token, baseSnapshotID)
+	})
+}
+
+func (d *Destination) reconcileCommitMatching(
+	ctx context.Context,
+	table string,
+	token string,
+	expectedIncarnation string,
+	commitErr error,
+	committed func(*icebergtable.Table, string) bool,
+) error {
+	if commitErr == nil || token == "" {
+		return commitErr
+	}
+
+	reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), commitReconcileTimeout)
+	defer cancel()
+	var reconcileErr error
+	for attempt := 0; ; attempt++ {
+		tbl, err := d.loadIcebergTable(reconcileCtx, table)
+		if err == nil {
+			if err := d.validateExpectedIncarnation(reconcileCtx, tbl, expectedIncarnation); err != nil {
+				return err
+			}
+			if committed(tbl, token) {
+				return nil
+			}
+		}
+		if err != nil {
+			reconcileErr = fmt.Errorf("iceberg: failed to reconcile commit token for table %s: %w", table, err)
+		}
+		wait := min(25*time.Millisecond<<min(attempt, 5), 500*time.Millisecond)
+		timer := time.NewTimer(wait)
+		select {
+		case <-reconcileCtx.Done():
+			timer.Stop()
+			if reconcileErr != nil {
+				return errors.Join(commitErr, reconcileErr)
+			}
+			return commitErr
+		case <-timer.C:
+		}
+	}
+}
+
+func (d *Destination) commitMetadataOnly(ctx context.Context, tbl *icebergtable.Table, operation string, metadata commitMetadata) error {
+	if err := d.validateExpectedIncarnation(ctx, tbl, metadata.expectedIncarnation); err != nil {
+		return err
+	}
+	if metadata.empty() || tableHasCommitToken(tbl, metadata.token) {
+		return nil
+	}
+	if metadata.cdcResumeLSN != "" && compareCDCResumeLSN(metadata.cdcResumeLSN, latestCDCResumeLSN(tbl)) == 0 {
+		return nil
+	}
+	if err := validateCDCResumeAdvance(tbl, metadata); err != nil {
+		return err
+	}
+
+	writeSchema, err := tableWriteSchema(tbl)
+	if err != nil {
+		return err
+	}
+	reader, err := array.NewRecordReader(writeSchema, nil)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to create checkpoint reader: %w", err)
+	}
+	defer reader.Release()
+
+	props := snapshotProps(operation, metadata)
+	_, commitErr := d.commitTokenizedAppend(ctx, tbl, props, metadata.expectedIncarnation, func(txn *icebergtable.Transaction) error {
+		return txn.Append(ctx, reader, props)
+	})
+	table := strings.Join(tbl.Identifier(), ".")
+	if err := d.reconcileCommit(ctx, table, metadata.token, metadata.expectedIncarnation, commitErr); err != nil {
+		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, table, err)
+	}
+	d.afterSuccessfulCommitExpected(ctx, table, metadata.expectedIncarnation)
+	return nil
+}
+
+func (d *Destination) ensureManagedCDCResumeResetExpected(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	dataToken string,
+	expectedIncarnation string,
+) error {
+	if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+		return err
+	}
+	cursor := latestCDCResumeLSN(tbl)
+	if cursor == "" {
+		return nil
+	}
+	metadata := newCommitMetadata(struct {
+		Kind      string
+		DataToken string
+		Cursor    string
+	}{Kind: "managed-cdc-resume-reset", DataToken: dataToken, Cursor: cursor}, "")
+	metadata.resetCDCResume = true
+	metadata.expectedIncarnation = expectedIncarnation
+	return d.commitMetadataOnly(ctx, tbl, "managed-cdc-reset", metadata)
+}
+
+// CommitWriteToken records an otherwise row-less streaming checkpoint in an
+// empty Iceberg append snapshot. The snapshot changes metadata only and keeps
+// the table's data files unchanged.
+func (d *Destination) CommitWriteToken(ctx context.Context, table string, commitToken any, cdcResumeLSN string) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	tbl, err := d.loadIcebergTable(ctx, table)
+	if err != nil {
+		return err
+	}
+	return d.commitMetadataOnly(ctx, tbl, "checkpoint", newCommitMetadata(commitToken, cdcResumeLSN))
+}
+
+// GetMaxCDCLSN reads the newest durable CDC checkpoint from snapshot metadata.
+// Walking only the current snapshot lineage avoids returning a cursor from an
+// abandoned branch or a superseded full refresh.
+func (d *Destination) GetMaxCDCLSN(ctx context.Context, table string) (string, error) {
+	if d.catalog == nil {
+		return "", errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return "", err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if errors.Is(err, icebergcatalog.ErrNoSuchTable) || errors.Is(err, icebergcatalog.ErrNoSuchNamespace) {
+			return "", nil
+		}
+		return "", fmt.Errorf("iceberg: failed to load table %s: %w", table, err)
+	}
+	return latestCDCResumeLSN(tbl), nil
+}

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -10,11 +10,15 @@ import (
 )
 
 type icebergConfig struct {
-	CatalogName     string
-	Properties      iceberggo.Properties
-	TableProperties iceberggo.Properties
-	TableLocation   string
-	CreateNamespace bool
+	CatalogName         string
+	CatalogNameExplicit bool
+	Properties          iceberggo.Properties
+	TableProperties     iceberggo.Properties
+	TableLocation       string
+	PurgeJournalRoot    string
+	PartitionSpec       string
+	CheckNamespace      string
+	CreateNamespace     bool
 }
 
 func parseIcebergConfig(rawURI string) (icebergConfig, error) {
@@ -35,6 +39,9 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 	}
 
 	query := parsed.Query()
+	if err := validateCatalogTypeOverride(parsed.Scheme, query); err != nil {
+		return icebergConfig{}, err
+	}
 	for key, values := range query {
 		if len(values) == 0 {
 			continue
@@ -46,9 +53,21 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 		case "type":
 			cfg.Properties["type"] = normalizeCatalogType(value)
 		case "catalog_name":
+			if strings.TrimSpace(value) == "" {
+				return icebergConfig{}, fmt.Errorf("iceberg uri: catalog_name must not be empty")
+			}
 			cfg.CatalogName = value
+			cfg.CatalogNameExplicit = true
 		case "table_location", "table-location":
 			cfg.TableLocation = value
+		case "partition_spec", "partition-spec":
+			cfg.PartitionSpec = value
+		case "check_namespace", "check-namespace":
+			namespace, err := normalizeCheckNamespace(value)
+			if err != nil {
+				return icebergConfig{}, err
+			}
+			cfg.CheckNamespace = namespace
 		case "table_path", "table-path":
 			continue
 		case "create_namespace", "create-namespace":
@@ -59,21 +78,72 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 			cfg.CreateNamespace = enabled
 		default:
 			if tableKey, ok := strings.CutPrefix(key, "table."); ok {
+				switch tableKey {
+				case managedTableProperty, managedTableKindProperty, managedTableExpiresAt, managedTableExpiresAfterMS, managedTablePurgeClaim, atomicSnapshotAttemptProperty, atomicSnapshotTargetProperty, atomicSnapshotTargetUUID, tableCommitTokenLedgerKey, tableCDCResumeStateKey, prepareOwnershipProperty:
+					return icebergConfig{}, fmt.Errorf("iceberg uri: table property %q is managed internally", tableKey)
+				}
 				cfg.TableProperties[tableKey] = value
 				continue
 			}
-			if isFriendlyStorageParam(key) || isCatalogShorthandParam(key) {
+			if isFriendlyStorageParam(key) || isCatalogShorthandParam(key) ||
+				(parsed.Scheme == "iceberg+nessie" && (key == "branch" || key == "ref")) {
 				continue
 			}
 			cfg.Properties[key] = value
 		}
 	}
 
-	if err := applyStorageShorthand(query, &cfg); err != nil {
+	if err := applyStorageShorthand(parsed.Scheme, query, &cfg); err != nil {
+		return icebergConfig{}, err
+	}
+	if err := applyCatalogPropertyShorthand(parsed.Scheme, query, &cfg); err != nil {
 		return icebergConfig{}, err
 	}
 	applyPropertyAliases(cfg.Properties)
+	if token := strings.TrimSpace(cfg.Properties["token"]); token != "" {
+		if _, exists := cfg.Properties["header.Authorization"]; !exists {
+			cfg.Properties["header.Authorization"] = "Bearer " + token
+		}
+		delete(cfg.Properties, "token")
+	}
+	if err := validateCatalogShorthand(parsed.Scheme, cfg); err != nil {
+		return icebergConfig{}, err
+	}
 	return cfg, nil
+}
+
+func validateCatalogTypeOverride(scheme string, query url.Values) error {
+	if scheme == "iceberg" {
+		return nil
+	}
+	expected := normalizeCatalogType(catalogTypeFromScheme(scheme))
+	if expected == "" {
+		return nil
+	}
+	for _, key := range []string{"catalog", "type"} {
+		values, exists := query[key]
+		if !exists || len(values) == 0 {
+			continue
+		}
+		actual := normalizeCatalogType(values[0])
+		if actual != expected {
+			return fmt.Errorf("iceberg uri: %s requires catalog type %q; %s=%q conflicts with the URI scheme", scheme, expected, key, values[0])
+		}
+	}
+	return nil
+}
+
+func normalizeCheckNamespace(value string) (string, error) {
+	ident, err := parseIdentifier(value)
+	if err != nil {
+		return "", fmt.Errorf("iceberg uri: invalid check_namespace %q: %w", value, err)
+	}
+	for _, part := range ident {
+		if part != strings.TrimSpace(part) {
+			return "", fmt.Errorf("iceberg uri: invalid check_namespace %q: identifier components must not have surrounding whitespace", value)
+		}
+	}
+	return strings.Join(ident, "."), nil
 }
 
 func catalogTypeFromScheme(scheme string) string {
@@ -85,11 +155,14 @@ func catalogTypeFromScheme(scheme string) string {
 }
 
 func normalizeCatalogType(value string) string {
-	switch value {
+	normalized := strings.ToLower(value)
+	switch normalized {
 	case "sqlite", "postgres":
 		return "sql"
+	case "nessie", "polaris", "s3tables":
+		return "rest"
 	default:
-		return value
+		return normalized
 	}
 }
 
@@ -114,7 +187,59 @@ func applyCatalogShorthand(parsed *url.URL, cfg *icebergConfig) error {
 	case "iceberg+rest":
 		cfg.Properties["type"] = "rest"
 		if parsed.Host != "" {
-			cfg.Properties["uri"] = catalogHTTPURL(parsed, "rest")
+			uri, err := catalogHTTPURL(parsed, "rest", false)
+			if err != nil {
+				return err
+			}
+			cfg.Properties["uri"] = uri
+		}
+	case "iceberg+nessie":
+		cfg.Properties["type"] = "rest"
+		if parsed.Host != "" {
+			withDefaultPath := *parsed
+			if withDefaultPath.Path == "" || withDefaultPath.Path == "/" {
+				withDefaultPath.Path = "/iceberg"
+			}
+			uri, err := catalogHTTPURL(&withDefaultPath, "nessie", false)
+			if err != nil {
+				return err
+			}
+			cfg.Properties["uri"] = uri
+		}
+	case "iceberg+polaris":
+		cfg.Properties["type"] = "rest"
+		if parsed.Host != "" {
+			withDefaultPath := *parsed
+			if withDefaultPath.Path == "" || withDefaultPath.Path == "/" {
+				withDefaultPath.Path = "/api/catalog"
+			}
+			uri, err := catalogHTTPURL(&withDefaultPath, "polaris", true)
+			if err != nil {
+				return err
+			}
+			cfg.Properties["uri"] = uri
+		}
+	case "iceberg+s3tables":
+		cfg.Properties["type"] = "rest"
+		cfg.Properties["rest.sigv4-enabled"] = "true"
+		cfg.Properties["rest.signing-name"] = "s3tables"
+		region := firstQueryValue(parsed.Query(), "rest.signing-region", "region", "region_name")
+		if region != "" {
+			cfg.Properties["rest.signing-region"] = region
+			cfg.Properties["client.region"] = region
+		}
+		if parsed.Host != "" {
+			withDefaultPath := *parsed
+			if withDefaultPath.Path == "" || withDefaultPath.Path == "/" {
+				withDefaultPath.Path = "/iceberg"
+			}
+			uri, err := catalogHTTPURL(&withDefaultPath, "s3tables", true)
+			if err != nil {
+				return err
+			}
+			cfg.Properties["uri"] = uri
+		} else if region != "" {
+			cfg.Properties["uri"] = "https://s3tables." + region + ".amazonaws.com/iceberg"
 		}
 	case "iceberg+hive":
 		cfg.Properties["type"] = "hive"
@@ -194,74 +319,344 @@ func isPostgresDSNParam(key string) bool {
 	}
 }
 
-func catalogHTTPURL(parsed *url.URL, catalog string) string {
+func catalogHTTPURL(parsed *url.URL, catalog string, defaultTLS bool) (string, error) {
 	scheme := "http"
+	if defaultTLS {
+		scheme = "https"
+	}
 	query := parsed.Query()
 	for _, key := range []string{catalog + "_use_ssl", catalog + "-use-ssl", "catalog_use_ssl", "catalog-use-ssl"} {
 		if value := query.Get(key); value != "" {
-			if enabled, err := strconv.ParseBool(value); err == nil && enabled {
+			enabled, err := strconv.ParseBool(value)
+			if err != nil {
+				return "", fmt.Errorf("iceberg uri: invalid %s value %q: %w", key, value, err)
+			}
+			if enabled {
 				scheme = "https"
+			} else {
+				scheme = "http"
 			}
 			break
 		}
 	}
-	return catalogURL(parsed, scheme)
+	return catalogURL(parsed, scheme), nil
 }
 
 func isCatalogShorthandParam(key string) bool {
 	switch key {
-	case "catalog_use_ssl", "catalog-use-ssl", "rest_use_ssl", "rest-use-ssl":
+	case "catalog_use_ssl", "catalog-use-ssl", "rest_use_ssl", "rest-use-ssl",
+		"nessie_use_ssl", "nessie-use-ssl", "polaris_use_ssl", "polaris-use-ssl",
+		"s3tables_use_ssl", "s3tables-use-ssl", "catalog_prefix", "catalog-prefix",
+		"oauth_client_id", "oauth-client-id", "oauth_client_secret", "oauth-client-secret", "oauth_token", "oauth-token",
+		"nessie_branch", "nessie-branch", "nessie_warehouse", "nessie-warehouse",
+		"polaris_realm", "polaris-realm":
 		return true
 	default:
 		return false
 	}
+}
+
+func applyCatalogPropertyShorthand(scheme string, query url.Values, cfg *icebergConfig) error {
+	setIfMissing(cfg.Properties, "prefix", firstQueryValue(query, "catalog_prefix", "catalog-prefix"))
+	setIfMissing(cfg.Properties, "token", firstQueryValue(query, "oauth_token", "oauth-token"))
+
+	clientID := firstQueryValue(query, "oauth_client_id", "oauth-client-id")
+	clientSecret := firstQueryValue(query, "oauth_client_secret", "oauth-client-secret")
+	if (clientID == "") != (clientSecret == "") {
+		return fmt.Errorf("iceberg uri: oauth_client_id and oauth_client_secret must be provided together")
+	}
+	if clientID != "" {
+		setIfMissing(cfg.Properties, "credential", clientID+":"+clientSecret)
+	}
+	setIfMissing(cfg.Properties, "header.Polaris-Realm", firstQueryValue(query, "polaris_realm", "polaris-realm"))
+
+	if scheme == "iceberg+nessie" {
+		if err := applyNessieReferenceShorthand(query, cfg.Properties); err != nil {
+			return err
+		}
+	}
+
+	if credType := cfg.Properties.Get("gcs.credtype", ""); credType != "" {
+		if err := validateGCSCredentialType(credType); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCatalogShorthand(scheme string, cfg icebergConfig) error {
+	switch scheme {
+	case "iceberg+nessie", "iceberg+polaris":
+		if cfg.Properties.Get("type", "") != "rest" {
+			return fmt.Errorf("iceberg uri: %s requires the REST catalog type", scheme)
+		}
+		if err := validateRESTCatalogURI(cfg.Properties.Get("uri", "")); err != nil {
+			return err
+		}
+	}
+	if scheme == "iceberg+nessie" && cfg.Properties.Get("prefix", "") != "" {
+		return fmt.Errorf("iceberg uri: Nessie branches are selected with nessie_branch, not catalog_prefix")
+	}
+	if scheme == "iceberg+nessie" && cfg.Properties.Get("warehouse", "") != "" {
+		return fmt.Errorf("iceberg uri: Nessie warehouses are selected with nessie_warehouse, not warehouse")
+	}
+	if scheme == "iceberg+polaris" && cfg.Properties.Get("warehouse", "") == "" {
+		return fmt.Errorf("iceberg uri: iceberg+polaris requires warehouse (the Polaris catalog name)")
+	}
+
+	if scheme != "iceberg+s3tables" {
+		return nil
+	}
+	if cfg.Properties.Get("type", "") != "rest" {
+		return fmt.Errorf("iceberg uri: %s requires the REST catalog type", scheme)
+	}
+	region := cfg.Properties.Get("rest.signing-region", "")
+	if region == "" {
+		return fmt.Errorf("iceberg uri: iceberg+s3tables requires region or rest.signing-region")
+	}
+	if err := validateRESTCatalogURI(cfg.Properties.Get("uri", "")); err != nil {
+		return err
+	}
+	if cfg.Properties.Get("rest.sigv4-enabled", "") != "true" {
+		return fmt.Errorf("iceberg uri: iceberg+s3tables requires rest.sigv4-enabled=true")
+	}
+	if cfg.Properties.Get("rest.signing-name", "") != "s3tables" {
+		return fmt.Errorf("iceberg uri: iceberg+s3tables requires rest.signing-name=s3tables")
+	}
+	warehouse := cfg.Properties.Get("warehouse", "")
+	if err := validateS3TablesWarehouse(warehouse, region); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateS3TablesWarehouse(warehouse, region string) error {
+	parts := strings.SplitN(warehouse, ":", 6)
+	bucketName := ""
+	if len(parts) == 6 {
+		bucketName = strings.TrimPrefix(parts[5], "bucket/")
+	}
+	if len(parts) != 6 || parts[0] != "arn" || parts[1] == "" || parts[2] != "s3tables" ||
+		parts[3] == "" || len(parts[4]) != 12 || !allASCIIDigits(parts[4]) ||
+		!strings.HasPrefix(parts[5], "bucket/") || !validS3TablesBucketName(bucketName) {
+		return fmt.Errorf("iceberg uri: iceberg+s3tables requires an S3 Tables bucket ARN in warehouse")
+	}
+	if parts[3] != region {
+		return fmt.Errorf("iceberg uri: S3 Tables warehouse region %q does not match signing region %q", parts[3], region)
+	}
+	return nil
+}
+
+func validS3TablesBucketName(value string) bool {
+	if len(value) < 3 || len(value) > 63 {
+		return false
+	}
+	if value[0] == '-' || value[len(value)-1] == '-' {
+		return false
+	}
+	for _, prefix := range []string{"xn--", "sthree-", "amzn-s3-demo-", "aws"} {
+		if strings.HasPrefix(value, prefix) {
+			return false
+		}
+	}
+	for _, suffix := range []string{"-s3alias", "--ol-s3", "--x-s3", "--table-s3"} {
+		if strings.HasSuffix(value, suffix) {
+			return false
+		}
+	}
+	for _, char := range value {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func allASCIIDigits(value string) bool {
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func applyNessieReferenceShorthand(query url.Values, props iceberggo.Properties) error {
+	branch := strings.TrimSpace(firstQueryValue(query, "nessie_branch", "nessie-branch", "branch", "ref"))
+	warehouse := strings.TrimSpace(firstQueryValue(query, "nessie_warehouse", "nessie-warehouse"))
+	if branch == "" && warehouse == "" {
+		return nil
+	}
+	if strings.Contains(branch, "|") {
+		return fmt.Errorf("iceberg uri: invalid Nessie branch %q", branch)
+	}
+	if branch != "" && strings.Trim(branch, "/") == "" {
+		return fmt.Errorf("iceberg uri: invalid Nessie branch %q", branch)
+	}
+	if strings.ContainsAny(warehouse, "/|") {
+		return fmt.Errorf("iceberg uri: invalid Nessie warehouse %q", warehouse)
+	}
+
+	rawURI := props.Get("uri", "")
+	parsed, err := url.Parse(rawURI)
+	if err != nil || parsed.Host == "" {
+		return fmt.Errorf("iceberg uri: invalid Nessie REST endpoint %q", rawURI)
+	}
+	path := strings.TrimRight(parsed.Path, "/") + "/"
+	rawPath := strings.TrimRight(parsed.EscapedPath(), "/") + "/"
+	if branch != "" {
+		branch = strings.Trim(branch, "/")
+		path += branch
+		rawPath += url.PathEscape(branch)
+	}
+	if warehouse != "" {
+		path += "|" + warehouse
+		rawPath += "%7C" + url.PathEscape(warehouse)
+	}
+	parsed.Path = path
+	parsed.RawPath = rawPath
+	props["uri"] = parsed.String()
+	return nil
+}
+
+func validateRESTCatalogURI(rawURI string) error {
+	if rawURI == "" {
+		return fmt.Errorf("iceberg uri: REST catalog endpoint is required")
+	}
+	parsed, err := url.Parse(rawURI)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("iceberg uri: invalid REST catalog endpoint %q", rawURI)
+	}
+	return nil
 }
 
 func isFriendlyStorageParam(key string) bool {
 	switch key {
 	case "storage", "bucket", "warehouse_bucket", "warehouse-bucket", "warehouse_path", "warehouse-path",
-		"prefix", "endpoint", "storage_endpoint", "storage-endpoint", "use_ssl", "use-ssl":
+		"prefix", "storage_prefix", "storage-prefix", "endpoint", "storage_endpoint", "storage-endpoint", "use_ssl", "use-ssl",
+		"gcs_json_key", "gcs-json-key", "gcs_key_path", "gcs-key-path", "gcs_credential_type", "gcs-credential-type",
+		"gcs_use_json_api", "gcs-use-json-api", "container", "account_name", "account-name", "account_key", "account-key",
+		"sas_token", "sas-token", "connection_string", "connection-string", "managed_identity", "managed-identity",
+		"client_id", "client-id", "azure_host", "azure-host", "adls_scheme", "adls-scheme":
 		return true
 	default:
 		return false
 	}
 }
 
-func applyStorageShorthand(query url.Values, cfg *icebergConfig) error {
+func applyStorageShorthand(catalogScheme string, query url.Values, cfg *icebergConfig) error {
 	storage := strings.ToLower(query.Get("storage"))
-	bucket := firstQueryValue(query, "bucket", "warehouse_bucket", "warehouse-bucket")
-	prefix := query.Get("prefix")
-
-	if storage != "" && storage != "s3" {
+	if storage == "azure" {
+		storage = "adls"
+	}
+	if storage == "" {
+		storage = "s3"
+	}
+	if storage != "s3" && storage != "gcs" && storage != "adls" {
 		return fmt.Errorf("iceberg uri: unsupported storage %q", storage)
 	}
 
-	if _, ok := cfg.Properties["warehouse"]; !ok {
-		switch {
-		case firstQueryValue(query, "warehouse_path", "warehouse-path") != "":
-			cfg.Properties["warehouse"] = firstQueryValue(query, "warehouse_path", "warehouse-path")
-		case bucket != "":
-			cfg.Properties["warehouse"] = s3Location(bucket, prefix, true)
-		}
+	bucket := firstQueryValue(query, "bucket", "warehouse_bucket", "warehouse-bucket")
+	if storage == "adls" {
+		bucket = firstQueryValue(query, "container", "bucket", "warehouse_bucket", "warehouse-bucket")
+	}
+	prefix := firstQueryValue(query, "storage_prefix", "storage-prefix", "prefix")
+	warehousePath := firstQueryValue(query, "warehouse_path", "warehouse-path")
+	if catalogScheme == "iceberg+nessie" && warehousePath != "" {
+		return fmt.Errorf("iceberg uri: Nessie warehouses are selected with nessie_warehouse, not warehouse_path")
 	}
 
-	if endpoint := firstQueryValue(query, "endpoint", "storage_endpoint", "storage-endpoint"); endpoint != "" {
-		normalized, err := normalizeStorageEndpoint(endpoint, firstQueryValue(query, "use_ssl", "use-ssl"))
+	var generatedWarehouse string
+	if bucket != "" {
+		var err error
+		generatedWarehouse, err = storageLocation(storage, bucket, prefix, true, query)
 		if err != nil {
 			return err
 		}
-		if _, ok := cfg.Properties["s3.endpoint"]; !ok {
-			cfg.Properties["s3.endpoint"] = normalized
+	}
+	if warehousePath != "" {
+		cfg.PurgeJournalRoot = warehousePath
+	} else if generatedWarehouse != "" {
+		cfg.PurgeJournalRoot = generatedWarehouse
+	}
+
+	catalogUsesNamedWarehouse := catalogScheme == "iceberg+nessie" || catalogScheme == "iceberg+polaris"
+	if _, ok := cfg.Properties["warehouse"]; !ok && !catalogUsesNamedWarehouse {
+		switch {
+		case warehousePath != "":
+			cfg.Properties["warehouse"] = warehousePath
+		case generatedWarehouse != "":
+			cfg.Properties["warehouse"] = generatedWarehouse
 		}
+	}
+	if query.Get("storage") != "" && bucket == "" && cfg.Properties.Get("warehouse", "") == "" && cfg.TableLocation == "" {
+		return fmt.Errorf("iceberg uri: %s storage shorthand requires bucket/container or an explicit warehouse", storage)
+	}
+
+	if err := applyStorageProperties(storage, query, cfg.Properties); err != nil {
+		return err
 	}
 
 	tablePath := firstQueryValue(query, "table_path", "table-path")
 	if tablePath != "" && cfg.TableLocation == "" {
-		if bucket != "" {
-			cfg.TableLocation = s3Location(bucket, joinPathParts(prefix, tablePath), false)
-		} else if warehouse := cfg.Properties.Get("warehouse", ""); strings.HasPrefix(warehouse, "s3://") {
-			cfg.TableLocation = joinPathParts(warehouse, tablePath)
+		if generatedWarehouse != "" {
+			cfg.TableLocation = appendLocationPath(generatedWarehouse, tablePath, false)
+		} else if warehouse := cfg.Properties.Get("warehouse", ""); isObjectStorageLocation(warehouse) {
+			cfg.TableLocation = appendLocationPath(warehouse, tablePath, false)
 		}
+	}
+
+	return nil
+}
+
+func applyStorageProperties(storage string, query url.Values, props iceberggo.Properties) error {
+	endpoint := firstQueryValue(query, "endpoint", "storage_endpoint", "storage-endpoint")
+	useSSL := firstQueryValue(query, "use_ssl", "use-ssl")
+
+	switch storage {
+	case "s3":
+		if endpoint == "" {
+			return validateOptionalBool("use_ssl", useSSL)
+		}
+		normalized, err := normalizeStorageEndpoint(endpoint, useSSL)
+		if err != nil {
+			return err
+		}
+		setIfMissing(props, "s3.endpoint", normalized)
+	case "gcs":
+		if endpoint != "" {
+			normalized, err := normalizeStorageEndpoint(endpoint, useSSL)
+			if err != nil {
+				return err
+			}
+			setIfMissing(props, "gcs.endpoint", normalized)
+		} else if err := validateOptionalBool("use_ssl", useSSL); err != nil {
+			return err
+		}
+		jsonKey := firstQueryValue(query, "gcs_json_key", "gcs-json-key")
+		keyPath := firstQueryValue(query, "gcs_key_path", "gcs-key-path")
+		if jsonKey != "" && keyPath != "" {
+			return fmt.Errorf("iceberg uri: gcs_json_key and gcs_key_path are mutually exclusive")
+		}
+		setIfMissing(props, "gcs.jsonkey", jsonKey)
+		setIfMissing(props, "gcs.keypath", keyPath)
+		credType := firstQueryValue(query, "gcs_credential_type", "gcs-credential-type")
+		if err := validateGCSCredentialType(credType); err != nil {
+			return err
+		}
+		setIfMissing(props, "gcs.credtype", credType)
+		useJSONAPI := firstQueryValue(query, "gcs_use_json_api", "gcs-use-json-api")
+		if useJSONAPI != "" {
+			enabled, err := strconv.ParseBool(useJSONAPI)
+			if err != nil {
+				return fmt.Errorf("iceberg uri: invalid gcs_use_json_api value %q: %w", useJSONAPI, err)
+			}
+			if enabled {
+				setIfMissing(props, "gcs.usejsonapi", "true")
+			}
+		}
+	case "adls":
+		return applyADLSProperties(query, props, endpoint, useSSL)
 	}
 
 	return nil
@@ -276,8 +671,240 @@ func firstQueryValue(query url.Values, keys ...string) string {
 	return ""
 }
 
+func storageLocation(storage, bucket, path string, trailingSlash bool, query url.Values) (string, error) {
+	switch storage {
+	case "s3":
+		return objectStorageLocation("s3", bucket, path, trailingSlash), nil
+	case "gcs":
+		return objectStorageLocation("gs", bucket, path, trailingSlash), nil
+	case "adls":
+		account := firstQueryValue(query, "account_name", "account-name")
+		if account == "" {
+			return "", fmt.Errorf("iceberg uri: account_name is required for Azure storage shorthand")
+		}
+		if strings.ContainsAny(account, "/@") {
+			return "", fmt.Errorf("iceberg uri: invalid Azure account_name %q", account)
+		}
+		if strings.ContainsAny(bucket, "/@") {
+			return "", fmt.Errorf("iceberg uri: invalid Azure container %q", bucket)
+		}
+		scheme := strings.ToLower(firstQueryValue(query, "adls_scheme", "adls-scheme"))
+		if scheme == "" {
+			scheme = "abfss"
+		}
+		switch scheme {
+		case "abfs", "abfss", "wasb", "wasbs":
+		default:
+			return "", fmt.Errorf("iceberg uri: invalid adls_scheme %q", scheme)
+		}
+		host := firstQueryValue(query, "azure_host", "azure-host")
+		if host == "" {
+			if strings.HasPrefix(scheme, "wasb") {
+				host = account + ".blob.core.windows.net"
+			} else {
+				host = account + ".dfs.core.windows.net"
+			}
+		}
+		if strings.Contains(host, "://") || strings.ContainsAny(host, "/@") {
+			return "", fmt.Errorf("iceberg uri: invalid azure_host %q", host)
+		}
+		location := (&url.URL{Scheme: scheme, User: url.User(bucket), Host: host}).String()
+		return appendLocationPath(location, path, trailingSlash), nil
+	default:
+		return "", fmt.Errorf("iceberg uri: unsupported storage %q", storage)
+	}
+}
+
+func objectStorageLocation(scheme, bucket, path string, trailingSlash bool) string {
+	bucket = strings.TrimPrefix(bucket, scheme+"://")
+	if scheme == "gs" {
+		bucket = strings.TrimPrefix(bucket, "gcs://")
+	}
+	bucket = strings.Trim(bucket, "/")
+	return appendLocationPath(scheme+"://"+bucket, path, trailingSlash)
+}
+
+func appendLocationPath(location, path string, trailingSlash bool) string {
+	out := strings.TrimRight(location, "/")
+	if path != "" {
+		out += "/" + strings.Trim(path, "/")
+	}
+	if trailingSlash && !strings.HasSuffix(out, "/") {
+		out += "/"
+	}
+	return out
+}
+
+func isObjectStorageLocation(location string) bool {
+	for _, prefix := range []string{"s3://", "s3a://", "s3n://", "gs://", "abfs://", "abfss://", "wasb://", "wasbs://"} {
+		if strings.HasPrefix(strings.ToLower(location), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func applyADLSProperties(query url.Values, props iceberggo.Properties, endpoint, useSSL string) error {
+	account := firstQueryValue(query, "account_name", "account-name")
+	accountKey := firstQueryValue(query, "account_key", "account-key")
+	sasToken := firstQueryValue(query, "sas_token", "sas-token")
+	connectionString := firstQueryValue(query, "connection_string", "connection-string")
+	managedIdentity := firstQueryValue(query, "managed_identity", "managed-identity")
+	clientID := firstQueryValue(query, "client_id", "client-id")
+	managedIdentityEnabled := false
+	if managedIdentity != "" {
+		var err error
+		managedIdentityEnabled, err = strconv.ParseBool(managedIdentity)
+		if err != nil {
+			return fmt.Errorf("iceberg uri: invalid managed_identity value %q: %w", managedIdentity, err)
+		}
+	}
+
+	authMethods := 0
+	for _, configured := range []bool{accountKey != "", sasToken != "", connectionString != "", managedIdentityEnabled} {
+		if configured {
+			authMethods++
+		}
+	}
+	if authMethods > 1 {
+		return fmt.Errorf("iceberg uri: Azure account_key, sas_token, connection_string, and managed_identity are mutually exclusive")
+	}
+	if accountKey != "" {
+		if account == "" {
+			return fmt.Errorf("iceberg uri: account_name is required with account_key")
+		}
+		setIfMissing(props, "adls.auth.shared-key.account.name", account)
+		setIfMissing(props, "adls.auth.shared-key.account.key", accountKey)
+	}
+	if sasToken != "" {
+		if account == "" {
+			return fmt.Errorf("iceberg uri: account_name is required with sas_token")
+		}
+		host := firstQueryValue(query, "azure_host", "azure-host")
+		if host == "" {
+			scheme := strings.ToLower(firstQueryValue(query, "adls_scheme", "adls-scheme"))
+			if strings.HasPrefix(scheme, "wasb") {
+				host = account + ".blob.core.windows.net"
+			} else {
+				host = account + ".dfs.core.windows.net"
+			}
+		}
+		setIfMissing(props, "adls.sas-token."+host, strings.TrimPrefix(sasToken, "?"))
+	}
+	if connectionString != "" {
+		if account == "" {
+			return fmt.Errorf("iceberg uri: account_name is required with connection_string")
+		}
+		setIfMissing(props, "adls.connection-string."+account, connectionString)
+	}
+	if managedIdentity != "" {
+		setIfMissing(props, "adls.auth.managed-identity.enabled", strconv.FormatBool(managedIdentityEnabled))
+		if clientID != "" && !managedIdentityEnabled {
+			return fmt.Errorf("iceberg uri: client_id requires managed_identity=true")
+		}
+	} else if clientID != "" {
+		return fmt.Errorf("iceberg uri: client_id requires managed_identity=true")
+	}
+	setIfMissing(props, "adls.client-id", clientID)
+
+	if endpoint != "" {
+		domain, protocol, err := normalizeADLSEndpoint(endpoint, useSSL)
+		if err != nil {
+			return err
+		}
+		setIfMissing(props, "adls.endpoint", domain)
+		setIfMissing(props, "adls.protocol", protocol)
+	} else if useSSL != "" {
+		enabled, err := strconv.ParseBool(useSSL)
+		if err != nil {
+			return fmt.Errorf("iceberg uri: invalid use_ssl value %q: %w", useSSL, err)
+		}
+		protocol := "http"
+		if enabled {
+			protocol = "https"
+		}
+		setIfMissing(props, "adls.protocol", protocol)
+	}
+	return nil
+}
+
+func normalizeADLSEndpoint(endpoint, useSSL string) (string, string, error) {
+	protocol := "https"
+	domain := endpoint
+	if strings.Contains(endpoint, "://") {
+		parsed, err := url.Parse(endpoint)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return "", "", fmt.Errorf("iceberg uri: invalid Azure endpoint %q", endpoint)
+		}
+		if parsed.Path != "" && parsed.Path != "/" {
+			return "", "", fmt.Errorf("iceberg uri: Azure endpoint must not contain a path: %q", endpoint)
+		}
+		protocol = parsed.Scheme
+		domain = parsed.Host
+	}
+	if useSSL != "" {
+		enabled, err := strconv.ParseBool(useSSL)
+		if err != nil {
+			return "", "", fmt.Errorf("iceberg uri: invalid use_ssl value %q: %w", useSSL, err)
+		}
+		requested := "http"
+		if enabled {
+			requested = "https"
+		}
+		if strings.Contains(endpoint, "://") && requested != protocol {
+			return "", "", fmt.Errorf("iceberg uri: endpoint scheme %q conflicts with use_ssl=%s", protocol, useSSL)
+		}
+		protocol = requested
+	}
+	return domain, protocol, nil
+}
+
+func validateGCSCredentialType(value string) error {
+	if value == "" {
+		return nil
+	}
+	switch value {
+	case "service_account", "authorized_user", "impersonated_service_account", "external_account":
+		return nil
+	default:
+		return fmt.Errorf("iceberg uri: invalid gcs_credential_type %q", value)
+	}
+}
+
+func validateOptionalBool(name, value string) error {
+	if value == "" {
+		return nil
+	}
+	if _, err := strconv.ParseBool(value); err != nil {
+		return fmt.Errorf("iceberg uri: invalid %s value %q: %w", name, value, err)
+	}
+	return nil
+}
+
+func setIfMissing(props iceberggo.Properties, key, value string) {
+	if value == "" {
+		return
+	}
+	if _, ok := props[key]; !ok {
+		props[key] = value
+	}
+}
+
 func normalizeStorageEndpoint(endpoint, useSSL string) (string, error) {
 	if strings.Contains(endpoint, "://") {
+		parsed, err := url.Parse(endpoint)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return "", fmt.Errorf("iceberg uri: invalid storage endpoint %q", endpoint)
+		}
+		if useSSL != "" {
+			enabled, err := strconv.ParseBool(useSSL)
+			if err != nil {
+				return "", fmt.Errorf("iceberg uri: invalid use_ssl value %q: %w", useSSL, err)
+			}
+			if enabled != (parsed.Scheme == "https") {
+				return "", fmt.Errorf("iceberg uri: endpoint scheme %q conflicts with use_ssl=%s", parsed.Scheme, useSSL)
+			}
+		}
 		return endpoint, nil
 	}
 
@@ -292,30 +919,6 @@ func normalizeStorageEndpoint(endpoint, useSSL string) (string, error) {
 		}
 	}
 	return scheme + "://" + endpoint, nil
-}
-
-func s3Location(bucket, path string, trailingSlash bool) string {
-	bucket = strings.TrimPrefix(bucket, "s3://")
-	bucket = strings.Trim(bucket, "/")
-	out := "s3://" + bucket
-	if path != "" {
-		out += "/" + strings.Trim(path, "/")
-	}
-	if trailingSlash && !strings.HasSuffix(out, "/") {
-		out += "/"
-	}
-	return out
-}
-
-func joinPathParts(parts ...string) string {
-	clean := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.Trim(part, "/")
-		if part != "" {
-			clean = append(clean, part)
-		}
-	}
-	return strings.Join(clean, "/")
 }
 
 func applyPropertyAliases(props iceberggo.Properties) {

--- a/pkg/destination/iceberg/copy_on_write.go
+++ b/pkg/destination/iceberg/copy_on_write.go
@@ -1,0 +1,566 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/google/uuid"
+)
+
+func tableRowsMetadata(sc *arrow.Schema) *scannedTable {
+	rows := &scannedTable{ColIdx: make(map[string]int, len(sc.Fields()))}
+	for i, field := range sc.Fields() {
+		rows.Columns = append(rows.Columns, field.Name)
+		rows.ColIdx[field.Name] = i
+	}
+	return rows
+}
+
+func (d *Destination) mergeCopyOnWriteSorted(
+	ctx context.Context,
+	target *icebergtable.Table,
+	stagingRows *scannedTable,
+	stagingSorter *spillSorter,
+	opts destination.MergeOptions,
+	metadata commitMetadata,
+) error {
+	const maxAttempts = 5
+	current := target
+	var commitErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		commitErr = d.mergeCopyOnWriteSortedAttempt(ctx, current, stagingRows, stagingSorter, opts, metadata)
+		if !errors.Is(commitErr, icebergtable.ErrCommitFailed) {
+			return commitErr
+		}
+		var err error
+		current, err = d.catalog.LoadTable(ctx, target.Identifier())
+		if err != nil {
+			return errors.Join(commitErr, err)
+		}
+		if err := d.validateExpectedIncarnation(ctx, current, metadata.expectedIncarnation); err != nil {
+			return err
+		}
+		if tableHasCommitToken(current, metadata.token) {
+			return nil
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return commitErr
+}
+
+func (d *Destination) mergeCopyOnWriteSortedAttempt(
+	ctx context.Context,
+	target *icebergtable.Table,
+	stagingRows *scannedTable,
+	stagingSorter *spillSorter,
+	opts destination.MergeOptions,
+	metadata commitMetadata,
+) error {
+	if err := d.validateExpectedIncarnation(ctx, target, metadata.expectedIncarnation); err != nil {
+		return err
+	}
+	if tableHasCommitToken(target, metadata.token) {
+		return nil
+	}
+	if err := validateCDCResumeAdvance(target, metadata); err != nil {
+		return err
+	}
+	if err := requireColumns(stagingRows, opts.PrimaryKeys, opts.StagingTable); err != nil {
+		return err
+	}
+	if stagingSorter.Len() == 0 {
+		return d.commitMetadataOnly(ctx, target, "merge", metadata)
+	}
+
+	incrementalIdx := -1
+	isCDC := stagingRows.HasColumnFold(destination.CDCDeletedColumn)
+	if !isCDC && opts.IncrementalKey != "" {
+		idx, err := incrementalKeyIndex(stagingRows.Columns, opts.IncrementalKey, opts.StagingTable)
+		if err != nil {
+			return err
+		}
+		incrementalIdx = idx
+	}
+
+	preserveLineage := target.Metadata().Version() >= 3
+	targetSchema, err := copyOnWriteTargetSchema(target, preserveLineage)
+	if err != nil {
+		return err
+	}
+	targetRows := tableRowsMetadata(targetSchema)
+	targetSorter, err := newSpillSorter(targetSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer targetSorter.Close()
+	if err := forEachCopyOnWriteTargetRow(ctx, target, preserveLineage, func(row []any) error {
+		return targetSorter.AddContext(ctx, row)
+	}); err != nil {
+		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
+	}
+	if err := validateUniqueTargetKeys(ctx, targetSorter, opts.TargetTable); err != nil {
+		return err
+	}
+
+	produce := func(sink func(arrow.RecordBatch) error) error {
+		emitter := newBatchEmitter(newRowProjection(targetSchema, targetRows.Columns), sink)
+		defer emitter.release()
+		if err := mergeSortedCopyOnWriteRows(
+			ctx,
+			stagingSorter,
+			targetSorter,
+			stagingRows,
+			targetRows,
+			incrementalIdx,
+			isCDC,
+			preserveLineage,
+			emitter.add,
+		); err != nil {
+			return err
+		}
+		return emitter.flushBatch()
+	}
+
+	reader := streamingReaderContext(ctx, targetSchema, produce)
+	defer reader.Release()
+	clusterBy, sortable := identitySortColumns(target)
+	if !sortable {
+		clusterBy = nil
+	}
+	clustered, cleanup, err := clusterRecordReader(ctx, reader, clusterBy)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to cluster merge rows for table %s: %w", opts.TargetTable, err)
+	}
+	defer cleanup()
+
+	config.Debug(
+		"[ICEBERG MERGE] Copy-on-write sort/merge of %d staged and %d target row(s) into %s",
+		stagingSorter.Len(), targetSorter.Len(), opts.TargetTable,
+	)
+	return d.replaceAllMergeRecords(ctx, target, clustered, clusterBy, opts, metadata)
+}
+
+func mergeSortedCopyOnWriteRows(
+	ctx context.Context,
+	stagingSorter, targetSorter *spillSorter,
+	stagingRows, targetRows *scannedTable,
+	incrementalIdx int,
+	isCDC bool,
+	preserveLineage bool,
+	emit func([]any) error,
+) error {
+	staging, err := stagingSorter.IterContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer staging.Close()
+	target, err := targetSorter.IterContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer target.Close()
+
+	hasStaging := staging.NextGroup()
+	hasTarget := target.NextGroup()
+	for hasStaging || hasTarget {
+		switch {
+		case !hasStaging || hasTarget && strings.Compare(target.Key(), staging.Key()) < 0:
+			for target.NextRow() {
+				if err := emit(target.Row()); err != nil {
+					return err
+				}
+			}
+			hasTarget = target.NextGroup()
+		case !hasTarget || strings.Compare(staging.Key(), target.Key()) < 0:
+			entry, err := mergeEntryFromGroup(staging, stagingRows, incrementalIdx, isCDC)
+			if err != nil {
+				return err
+			}
+			row, err := composeCopyOnWriteRow(targetRows.Columns, stagingRows, entry, nil, isCDC, preserveLineage)
+			if err != nil {
+				return err
+			}
+			if err := emit(row); err != nil {
+				return err
+			}
+			hasStaging = staging.NextGroup()
+		default:
+			var existing []any
+			for target.NextRow() {
+				existing = target.Row()
+			}
+			entry, err := mergeEntryFromGroup(staging, stagingRows, incrementalIdx, isCDC)
+			if err != nil {
+				return err
+			}
+			row, err := composeCopyOnWriteRow(targetRows.Columns, stagingRows, entry, existing, isCDC, preserveLineage)
+			if err != nil {
+				return err
+			}
+			if err := emit(row); err != nil {
+				return err
+			}
+			hasStaging = staging.NextGroup()
+			hasTarget = target.NextGroup()
+		}
+	}
+	if err := staging.Err(); err != nil {
+		return err
+	}
+	return target.Err()
+}
+
+func validateUniqueTargetKeys(ctx context.Context, sorter *spillSorter, table string) error {
+	it, err := sorter.IterContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+	for it.NextGroup() {
+		count := 0
+		for it.NextRow() {
+			count++
+			if count > 1 {
+				return fmt.Errorf("iceberg: target table %s contains duplicate primary key %x; copy-on-write merge requires unique target keys", table, it.Key())
+			}
+		}
+	}
+	return it.Err()
+}
+
+func validateCDCEventPosition(tbl *icebergtable.Table, position string) error {
+	position = strings.TrimSpace(position)
+	current := latestCDCResumeLSN(tbl)
+	if position == "" || current == "" || compareCDCResumeLSN(position, current) >= 0 {
+		return nil
+	}
+	return fmt.Errorf("iceberg: stale CDC resume position in event %q is older than durable position %q", position, current)
+}
+
+func copyOnWriteContentIdentity(
+	ctx context.Context,
+	sorter *spillSorter,
+	rows *scannedTable,
+	opts destination.MergeOptions,
+) (string, error) {
+	incrementalIdx := -1
+	isCDC := rows.HasColumnFold(destination.CDCDeletedColumn)
+	if !isCDC && opts.IncrementalKey != "" {
+		idx, err := incrementalKeyIndex(rows.Columns, opts.IncrementalKey, opts.StagingTable)
+		if err != nil {
+			return "", err
+		}
+		incrementalIdx = idx
+	}
+	it, err := sorter.IterContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer it.Close()
+	hasher := newOrderedRowContentHasher(sorter.schema)
+	for it.NextGroup() {
+		entry, err := mergeEntryFromGroup(it, rows, incrementalIdx, isCDC)
+		if err != nil {
+			return "", err
+		}
+		if isCDC && entry.latestNonDeleted != nil {
+			hasher.Add(entry.latestNonDeleted)
+		}
+		hasher.Add(entry.latest)
+	}
+	if err := it.Err(); err != nil {
+		return "", err
+	}
+	return hasher.Identity(), nil
+}
+
+func mergeEntryFromGroup(it *spillIter, rows *scannedTable, incrementalIdx int, isCDC bool) (*mergeEntry, error) {
+	entry := &mergeEntry{}
+	for it.NextRow() {
+		row := it.Row()
+		switch {
+		case isCDC:
+			lsn, _ := asString(rows.ValueFold(row, destination.CDCLSNColumn))
+			deleted, _ := rows.ValueFold(row, destination.CDCDeletedColumn).(bool)
+			if entry.latest == nil || destination.CDCSupersedes(lsn, deleted, entry.latestLSN, entry.latestDeleted) {
+				entry.latest = row
+				entry.latestLSN = lsn
+				entry.latestDeleted = deleted
+			}
+			if !deleted && (entry.latestNonDeleted == nil || destination.CompareCDCPositions(lsn, entry.latestNonDeletedLSN) >= 0) {
+				entry.latestNonDeleted = row
+				entry.latestNonDeletedLSN = lsn
+			}
+		case incrementalIdx >= 0:
+			if entry.latest == nil {
+				entry.latest = row
+				entry.incrementalVal = row[incrementalIdx]
+				continue
+			}
+			cmp, comparable := compareOrdered(row[incrementalIdx], entry.incrementalVal)
+			if !comparable || cmp >= 0 {
+				entry.latest = row
+				entry.incrementalVal = row[incrementalIdx]
+			}
+		default:
+			entry.latest = row
+		}
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+	if entry.latest == nil {
+		return nil, fmt.Errorf("iceberg: encountered an empty staging key group")
+	}
+	return entry, nil
+}
+
+func composeCopyOnWriteRow(targetColumns []string, stagingRows *scannedTable, entry *mergeEntry, existing []any, isCDC, preserveLineage bool) ([]any, error) {
+	var row []any
+	var err error
+	if isCDC {
+		row, err = composeCDCMergeRow(targetColumns, stagingRows, entry, existing)
+	} else {
+		row = projectRow(targetColumns, stagingRows, entry.latest, existing)
+	}
+	if err != nil || row == nil || !preserveLineage {
+		return row, err
+	}
+	setColumn(targetColumns, row, iceberggo.LastUpdatedSequenceNumberColumnName, nil)
+	if existing == nil {
+		setColumn(targetColumns, row, iceberggo.RowIDColumnName, nil)
+	}
+	return row, nil
+}
+
+func copyOnWriteTargetSchema(tbl *icebergtable.Table, preserveLineage bool) (*arrow.Schema, error) {
+	if !preserveLineage {
+		return tableWriteSchema(tbl)
+	}
+	sc, err := icebergtable.SchemaToArrowSchema(iceberggo.SchemaWithRowLineage(tbl.Schema()), nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to build row-lineage merge schema: %w", err)
+	}
+	return sc, nil
+}
+
+func forEachCopyOnWriteTargetRow(ctx context.Context, tbl *icebergtable.Table, preserveLineage bool, fn func([]any) error) error {
+	if !preserveLineage {
+		return forEachScannedRow(ctx, tbl, iceberggo.AlwaysTrue{}, fn)
+	}
+	sc, records, err := tbl.Scan(icebergtable.WithRowLineage()).ToArrowRecords(ctx)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to scan target row lineage: %w", err)
+	}
+	for batch, readErr := range records {
+		if readErr != nil {
+			return readErr
+		}
+		for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
+			row := make([]any, len(sc.Fields()))
+			for colIdx := range sc.Fields() {
+				row[colIdx], err = rowValue(batch.Column(colIdx), rowIdx)
+				if err != nil {
+					batch.Release()
+					return err
+				}
+			}
+			if err := fn(row); err != nil {
+				batch.Release()
+				return err
+			}
+		}
+		batch.Release()
+	}
+	return nil
+}
+
+func (d *Destination) replaceAllMergeRecords(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	reader array.RecordReader,
+	clusterBy []string,
+	opts destination.MergeOptions,
+	metadata commitMetadata,
+) (retErr error) {
+	dataFilesToDelete, deleteFilesToRemove, err := liveFilesForReplace(ctx, tbl)
+	if err != nil {
+		return err
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return fmt.Errorf("iceberg: merge failed to load table file IO: %w", err)
+	}
+	generatedPaths := make([]string, 0)
+	writeID := uuid.New()
+	committed := false
+	cleanupSafe := true
+	defer func() {
+		if committed || !cleanupSafe {
+			return
+		}
+		if err := removeGeneratedMergeFiles(tableFS, tbl.Location(), writeID.String(), generatedPaths); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+
+	writeOptions := make([]icebergtable.WriteRecordOption, 0, 2)
+	writeOptions = append(writeOptions, icebergtable.WithMaxWriteWorkers(1))
+	writeOptions = append(writeOptions, icebergtable.WithWriteUUID(writeID))
+	if tbl.Metadata().Version() >= 3 {
+		writeOptions = append(writeOptions, icebergtable.WithPreserveRowLineage(iceberggo.SchemaWithRowLineage(tbl.Schema())))
+	}
+	sortOrderID := icebergtable.UnsortedSortOrderID
+	if len(clusterBy) > 0 {
+		sortOrderID = tbl.SortOrder().OrderID()
+	}
+	dataFiles := make([]iceberggo.DataFile, 0)
+	// WriteRecords can return before canceled worker goroutines finish. Keep its
+	// internal context alive so it joins every writer before cleanup; caller
+	// cancellation still reaches the record reader and is returned below.
+	writeCtx, cancelWrite := context.WithCancel(context.WithoutCancel(ctx))
+	defer cancelWrite()
+	for dataFile, writeErr := range icebergtable.WriteRecords(writeCtx, tbl, reader.Schema(), retainedRecordIterator(reader), writeOptions...) {
+		if writeErr != nil {
+			return fmt.Errorf("iceberg: merge failed to write replacement data: %w", writeErr)
+		}
+		generatedPaths = append(generatedPaths, dataFile.FilePath())
+		dataFile, err = withDataFileSortOrderID(dataFile, tbl, sortOrderID)
+		if err != nil {
+			return err
+		}
+		dataFiles = append(dataFiles, dataFile)
+	}
+	if err := reader.Err(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	props := snapshotProps("merge", metadata)
+	txn := tbl.NewTransaction()
+	if err := stageCommitTokenLedger(txn, tbl, metadata.token); err != nil {
+		return err
+	}
+	if err := stageCDCResumeState(txn, props); err != nil {
+		return err
+	}
+	if len(dataFilesToDelete) == 0 {
+		if tbl.Metadata().Version() >= 3 {
+			nextRowID := tbl.Metadata().NextRowID()
+			for i, file := range dataFiles {
+				dataFiles[i], err = withDataFileFirstRowID(file, tbl, nextRowID)
+				if err != nil {
+					return err
+				}
+				nextRowID += file.Count()
+			}
+		}
+		if err := txn.AddDataFiles(ctx, dataFiles, props); err != nil {
+			return fmt.Errorf("iceberg: merge failed to stage initial files: %w", err)
+		}
+	} else {
+		rewrite := txn.NewRewrite(props)
+		rewrite.Apply(dataFilesToDelete, dataFiles, deleteFilesToRemove)
+		if err := rewrite.Commit(ctx); err != nil {
+			return fmt.Errorf("iceberg: merge failed to stage replacement: %w", err)
+		}
+	}
+	table := strings.Join(tbl.Identifier(), ".")
+	if err := d.validateExpectedIncarnation(ctx, tbl, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		if reconciled := d.reconcileCommit(ctx, table, metadata.token, opts.CDCExpectedIncarnation, err); reconciled != nil {
+			cleanupSafe = errors.Is(err, icebergtable.ErrCommitFailed)
+			return fmt.Errorf("iceberg: failed to commit merge on table %s: %w", tbl.Identifier(), reconciled)
+		}
+	}
+	committed = true
+	d.afterSuccessfulCommitExpected(ctx, table, opts.CDCExpectedIncarnation)
+	return nil
+}
+
+func removeGeneratedMergeFiles(tableFS icebergio.IO, location, writeID string, yielded []string) error {
+	const cleanupTimeout = 2 * time.Second
+	deadline := time.Now().Add(cleanupTimeout)
+	emptyScans := 0
+	firstScan := true
+	for {
+		paths := make([]string, 0, len(yielded))
+		if firstScan {
+			paths = append(paths, yielded...)
+			firstScan = false
+		}
+		var walkErr error
+		if writeID != "" {
+			walkErr = walkGeneratedMergeFiles(tableFS, location, writeID, func(path string) {
+				paths = append(paths, path)
+			})
+		}
+		if walkErr != nil {
+			return fmt.Errorf("iceberg: failed to discover uncommitted merge files: %w", walkErr)
+		}
+		seen := make(map[string]struct{}, len(paths))
+		var cleanupErr error
+		for _, path := range paths {
+			if _, exists := seen[path]; exists {
+				continue
+			}
+			seen[path] = struct{}{}
+			if err := tableFS.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("iceberg: failed to remove uncommitted merge file %s: %w", path, err))
+			}
+		}
+		if cleanupErr != nil {
+			return cleanupErr
+		}
+		if len(seen) == 0 {
+			emptyScans++
+			if emptyScans >= 10 {
+				return nil
+			}
+		} else {
+			emptyScans = 0
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("iceberg: timed out cleaning uncommitted merge files for write %s", writeID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func walkGeneratedMergeFiles(tableFS icebergio.IO, location, writeID string, add func(string)) error {
+	visit := func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() && strings.Contains(entry.Name(), writeID) {
+			add(path)
+		}
+		return nil
+	}
+	if listable, ok := tableFS.(icebergio.ListableIO); ok {
+		return listable.WalkDir(location, visit)
+	}
+	local := strings.TrimPrefix(location, "file://")
+	if strings.Contains(local, "://") {
+		return fmt.Errorf("table file IO does not support listing %s", location)
+	}
+	return filepath.WalkDir(local, visit)
+}

--- a/pkg/destination/iceberg/direct_merge.go
+++ b/pkg/destination/iceberg/direct_merge.go
@@ -1,0 +1,182 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// MergeRecords merges incoming batches directly into the target snapshot,
+// avoiding a remote Iceberg staging-table write and scan.
+func (d *Destination) MergeRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	writeOpts destination.WriteOptions,
+	mergeOpts destination.MergeOptions,
+) error {
+	input := newRecordBatchInput(records)
+	defer input.Close()
+
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	if writeOpts.Schema == nil {
+		return errors.New("iceberg: direct merge requires schema")
+	}
+	if len(mergeOpts.PrimaryKeys) == 0 {
+		return errors.New("iceberg: direct merge requires at least one primary key")
+	}
+	target, err := d.loadIcebergTable(ctx, mergeOpts.TargetTable)
+	if err != nil {
+		return err
+	}
+	if mergeOpts.CDCExpectedIncarnation == "" {
+		mergeOpts.CDCExpectedIncarnation = writeOpts.CDCExpectedIncarnation
+	} else if writeOpts.CDCExpectedIncarnation != "" && mergeOpts.CDCExpectedIncarnation != writeOpts.CDCExpectedIncarnation {
+		return errors.New("iceberg: direct merge received conflicting expected target incarnations")
+	}
+	if err := d.validateExpectedIncarnation(ctx, target, mergeOpts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	metadata := mergeCommitMetadata(mergeOpts)
+	if mergeOpts.Parallelism <= 0 {
+		mergeOpts.Parallelism = writeOpts.Parallelism
+	}
+	if tableHasCommitToken(target, metadata.token) {
+		if err := input.Drain(ctx); err != nil {
+			return err
+		}
+		if mergeOpts.SkipCDCResume {
+			return d.ensureManagedCDCResumeResetExpected(ctx, target, metadata.token, mergeOpts.CDCExpectedIncarnation)
+		}
+		return nil
+	}
+	if !mergeOpts.SkipCDCResume {
+		if err := validateCDCResumeAdvance(target, metadata); err != nil {
+			return err
+		}
+	}
+
+	stagingSchema := icebergArrowSchema(writeOpts.Schema)
+	stagingIceSchema, err := icebergSchemaFromTableSchema(writeOpts.Schema)
+	if err != nil {
+		return err
+	}
+	isCDC := icebergSchemaHasFieldFold(stagingIceSchema, destination.CDCDeletedColumn)
+	rowDelta := false
+	if !isCDC && stagingCoversTarget(target.Schema(), stagingIceSchema) {
+		rowDelta, err = useRowDeltaMerge(ctx, target, mergeOpts.PrimaryKeys)
+		if err != nil {
+			return err
+		}
+	}
+	if target.Metadata().Version() >= 3 {
+		rowDelta = false
+	}
+	if rowDelta {
+		sorter, err := newSpillSorter(stagingSchema, mergeOpts.PrimaryKeys)
+		if err != nil {
+			return err
+		}
+		defer sorter.Close()
+		if _, err := consumeMergeRecords(ctx, input, stagingSchema, func(row []any) error { return sorter.AddContext(ctx, row) }); err != nil {
+			return err
+		}
+		return d.mergeRowDeltaFromSorter(ctx, target, stagingSchema, sorter, mergeOpts, metadata)
+	}
+
+	rows := tableRowsMetadata(stagingSchema)
+	sorter, err := newSpillSorter(stagingSchema, mergeOpts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer sorter.Close()
+	var staleEventErr error
+	maxLSN, err := consumeMergeRecords(ctx, input, stagingSchema, func(row []any) error {
+		lsn, _ := asString(rows.ValueFold(row, destination.CDCLSNColumn))
+		if !mergeOpts.SkipCDCResume {
+			if err := validateCDCEventPosition(target, lsn); err != nil && staleEventErr == nil {
+				staleEventErr = err
+			}
+		}
+		return sorter.AddContext(ctx, row)
+	})
+	if err != nil {
+		return err
+	}
+	if !mergeOpts.SkipCDCResume {
+		metadata = metadata.withCDCResumeLSN(maxLSN)
+	}
+	if metadata.token == "" && sorter.Len() > 0 {
+		contentID, err := copyOnWriteContentIdentity(ctx, sorter, rows, mergeOpts)
+		if err != nil {
+			return err
+		}
+		metadata.token = commitTokenID("merge-content:" + contentID)
+	}
+	if err := d.validateExpectedIncarnation(ctx, target, mergeOpts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	if tableHasCommitToken(target, metadata.token) {
+		if mergeOpts.SkipCDCResume {
+			return d.ensureManagedCDCResumeResetExpected(ctx, target, metadata.token, mergeOpts.CDCExpectedIncarnation)
+		}
+		return nil
+	}
+	if staleEventErr != nil {
+		return staleEventErr
+	}
+	// The resume position can be derived from the records rather than supplied
+	// by the caller, so validate it again after consumption. Equal positions are
+	// valid at a snapshot/WAL boundary; true regressions still fail.
+	if !mergeOpts.SkipCDCResume {
+		if err := validateCDCResumeAdvance(target, metadata); err != nil {
+			return err
+		}
+	}
+	return d.mergeCopyOnWriteSorted(ctx, target, rows, sorter, mergeOpts, metadata)
+}
+
+func consumeMergeRecords(
+	ctx context.Context,
+	input *recordBatchInput,
+	sc *arrow.Schema,
+	consume func([]any) error,
+) (string, error) {
+	reader := input.RecordReader(ctx, sc)
+	defer input.ReleaseReader()
+
+	var maxLSN string
+	for reader.Next() {
+		batch := reader.RecordBatch()
+		if lsn := maxCDCResumeLSNInBatch(batch); compareCDCResumeLSN(lsn, maxLSN) > 0 {
+			maxLSN = lsn
+		}
+		for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
+			row := make([]any, int(batch.NumCols()))
+			for columnIdx := range row {
+				value, err := rowValue(batch.Column(columnIdx), rowIdx)
+				if err != nil {
+					return "", fmt.Errorf("iceberg: direct merge column %q: %w", sc.Field(columnIdx).Name, err)
+				}
+				row[columnIdx] = value
+			}
+			if err := consume(row); err != nil {
+				return "", err
+			}
+		}
+	}
+	if err := reader.Err(); err != nil {
+		return "", fmt.Errorf("iceberg: failed to read direct merge records: %w", err)
+	}
+	if compareCDCResumeLSN(reader.DurableCommitPosition(), maxLSN) > 0 {
+		maxLSN = reader.DurableCommitPosition()
+	}
+	return maxLSN, nil
+}
+
+var _ destination.DirectMergeWriter = (*Destination)(nil)

--- a/pkg/destination/iceberg/evolve.go
+++ b/pkg/destination/iceberg/evolve.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
+	"time"
 
 	iceberggo "github.com/apache/iceberg-go"
 	icebergtable "github.com/apache/iceberg-go/table"
@@ -12,9 +15,6 @@ import (
 )
 
 func (d *Destination) ApplySchemaEvolution(ctx context.Context, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
-	if comparison == nil || !comparison.HasChanges {
-		return nil, nil
-	}
 	if d.catalog == nil {
 		return nil, errors.New("iceberg destination not connected")
 	}
@@ -31,18 +31,116 @@ func (d *Destination) ApplySchemaEvolution(ctx context.Context, table string, co
 		return nil, fmt.Errorf("iceberg: failed to load table %s: %w", table, err)
 	}
 
-	txn := tbl.NewTransaction()
-	changed, err := d.stageSchemaComparisonUpdate(txn, tbl, comparison)
-	if err != nil {
-		return nil, err
+	if comparison != nil && comparison.HasChanges {
+		txn := tbl.NewTransaction()
+		changed, err := d.stageSchemaComparisonUpdate(txn, tbl, comparison)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			tbl, err = txn.Commit(ctx)
+			if err != nil {
+				tbl, err = d.reconcileSchemaEvolutionCommit(ctx, ident, comparison, err)
+				if err != nil {
+					return nil, fmt.Errorf("iceberg: failed to commit schema update: %w", err)
+				}
+			}
+		}
 	}
-	if !changed {
-		return nil, nil
+
+	prepared := d.lookupPrepared(table)
+	if !prepared.replace && prepared.partitionBy != "" && layoutColumnsExist(tbl.Schema(), prepared.partitionBy, nil) {
+		if err := d.updateExistingPartitionSpec(ctx, tbl, prepared.partitionBy); err != nil {
+			return nil, err
+		}
+		tbl, err = d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: failed to reload table %s after partition evolution: %w", table, err)
+		}
 	}
-	if _, err := txn.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("iceberg: failed to commit schema update: %w", err)
+	if !prepared.replace && len(prepared.clusterBy) > 0 && layoutColumnsExist(tbl.Schema(), "", prepared.clusterBy) {
+		if _, err := d.ensureSortOrder(ctx, tbl, prepared.clusterBy); err != nil {
+			return nil, err
+		}
 	}
 	return nil, nil
+}
+
+func (d *Destination) reconcileSchemaEvolutionCommit(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	comparison *schemaevolution.SchemaComparison,
+	commitErr error,
+) (*icebergtable.Table, error) {
+	reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), commitReconcileTimeout)
+	defer cancel()
+
+	var reconcileErr error
+	for attempt := 0; ; attempt++ {
+		tbl, err := d.catalog.LoadTable(reconcileCtx, ident)
+		if err == nil {
+			landed, verifyErr := schemaEvolutionLanded(tbl.Schema(), comparison)
+			if verifyErr != nil {
+				return nil, errors.Join(commitErr, verifyErr)
+			}
+			if landed {
+				return tbl, nil
+			}
+		} else {
+			reconcileErr = fmt.Errorf("iceberg: failed to reload table %s while reconciling schema commit: %w", strings.Join(ident, "."), err)
+		}
+
+		wait := min(25*time.Millisecond<<min(attempt, 5), 500*time.Millisecond)
+		timer := time.NewTimer(wait)
+		select {
+		case <-reconcileCtx.Done():
+			timer.Stop()
+			if reconcileErr != nil {
+				return nil, errors.Join(commitErr, reconcileErr)
+			}
+			return nil, commitErr
+		case <-timer.C:
+		}
+	}
+}
+
+func schemaEvolutionLanded(tableSchema *iceberggo.Schema, comparison *schemaevolution.SchemaComparison) (bool, error) {
+	if tableSchema == nil || comparison == nil {
+		return false, nil
+	}
+	for _, change := range comparison.Changes {
+		fieldName := strings.Join(schemaChangePath(change), ".")
+		field, exists := tableSchema.FindFieldByName(fieldName)
+		switch change.Type {
+		case schemaevolution.ChangeAddColumn, schemaevolution.ChangeWidenType, schemaevolution.ChangeOverrideType:
+			if !exists {
+				return false, nil
+			}
+			targetType, err := icebergTypeForColumn(change.NewColumn)
+			if err != nil {
+				return false, fmt.Errorf("iceberg: failed to verify reconciled column %q type: %w", fieldName, err)
+			}
+			expectedRequired := !change.NewColumn.Nullable || slices.Contains(tableSchema.IdentifierFieldIDs, field.ID)
+			if !icebergTypesEquivalent(field.Type, targetType) || field.Required != expectedRequired {
+				return false, nil
+			}
+		case schemaevolution.ChangeRemoveColumn:
+			if exists && field.Required {
+				return false, nil
+			}
+		case schemaevolution.ChangeRelaxNullability:
+			if !exists {
+				return false, nil
+			}
+			identifier := slices.Contains(tableSchema.IdentifierFieldIDs, field.ID)
+			if field.Required != identifier {
+				return false, nil
+			}
+		default:
+			return false, fmt.Errorf("iceberg: cannot reconcile unsupported schema change %d for column %q", change.Type, fieldName)
+		}
+	}
+	return true, nil
 }
 
 func (d *Destination) SupportsColumnTypeChanges() bool {
@@ -51,26 +149,10 @@ func (d *Destination) SupportsColumnTypeChanges() bool {
 
 func (d *Destination) stageSchemaComparisonUpdate(txn *icebergtable.Transaction, tbl *icebergtable.Table, comparison *schemaevolution.SchemaComparison) (bool, error) {
 	update := txn.UpdateSchema(true, false, icebergtable.WithNameMapping(tbl.NameMapping()))
-	changed := false
-
-	for _, change := range comparison.Changes {
-		switch change.Type {
-		case schemaevolution.ChangeAddColumn:
-			applied, err := stageIcebergAddColumn(update, change.NewColumn)
-			if err != nil {
-				return false, err
-			}
-			changed = changed || applied
-
-		case schemaevolution.ChangeWidenType, schemaevolution.ChangeOverrideType:
-			applied, err := stageIcebergUpdateColumn(update, tbl, change.ColumnName, change.NewColumn)
-			if err != nil {
-				return false, err
-			}
-			changed = changed || applied
-		}
+	changed, err := stageSchemaComparisonChanges(update, tbl, comparison, false)
+	if err != nil {
+		return false, err
 	}
-
 	if !changed {
 		return false, nil
 	}
@@ -80,41 +162,131 @@ func (d *Destination) stageSchemaComparisonUpdate(txn *icebergtable.Transaction,
 	return true, nil
 }
 
-func stageIcebergAddColumn(update *icebergtable.UpdateSchema, col schema.Column) (bool, error) {
+func stageSchemaComparisonChanges(
+	update *icebergtable.UpdateSchema,
+	tbl *icebergtable.Table,
+	comparison *schemaevolution.SchemaComparison,
+	allowRequiredAdds bool,
+) (bool, error) {
+	changed := false
+
+	for _, change := range comparison.Changes {
+		switch change.Type {
+		case schemaevolution.ChangeAddColumn:
+			path := schemaChangePath(change)
+			applied, err := stageIcebergAddColumnAtPathRequired(update, path, change.NewColumn, allowRequiredAdds)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || applied
+
+		case schemaevolution.ChangeWidenType, schemaevolution.ChangeOverrideType:
+			applied, err := stageIcebergUpdateColumnAtPath(update, tbl, schemaChangePath(change), change.NewColumn)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || applied
+
+		case schemaevolution.ChangeRemoveColumn:
+			applied, err := stageIcebergSoftRemoveColumnAtPath(update, tbl, schemaChangePath(change))
+			if err != nil {
+				return false, err
+			}
+			changed = changed || applied
+
+		case schemaevolution.ChangeRelaxNullability:
+			path := schemaChangePath(change)
+			field, ok := tbl.Schema().FindFieldByName(strings.Join(path, "."))
+			if !ok {
+				return false, fmt.Errorf("iceberg: nested field %q not found for nullability relaxation", strings.Join(path, "."))
+			}
+			if field.Required && !slices.Contains(tbl.Schema().IdentifierFieldIDs, field.ID) {
+				update.UpdateColumn(path, icebergtable.ColumnUpdate{
+					Required: iceberggo.Optional[bool]{Valid: true, Val: false},
+				})
+				changed = true
+			}
+		}
+	}
+
+	return changed, nil
+}
+
+func stageIcebergAddColumnAtPath(update *icebergtable.UpdateSchema, path []string, col schema.Column) (bool, error) {
+	return stageIcebergAddColumnAtPathRequired(update, path, col, false)
+}
+
+func stageIcebergAddColumnAtPathRequired(update *icebergtable.UpdateSchema, path []string, col schema.Column, allowRequired bool) (bool, error) {
+	if err := validateIcebergColumnName(col.Name); err != nil {
+		return false, err
+	}
+	if !col.Nullable && !allowRequired {
+		return false, fmt.Errorf("iceberg: cannot add required column %q to an existing table without an initial default; make it nullable or use replace", col.Name)
+	}
 	targetType, err := icebergTypeForColumn(col)
 	if err != nil {
 		return false, fmt.Errorf("iceberg: failed to map column %q type: %w", col.Name, err)
 	}
-	update.AddColumn([]string{col.Name}, targetType, "", !col.Nullable, nil)
+	update.AddColumn(path, targetType, "", allowRequired && !col.Nullable, nil)
 	return true, nil
 }
 
-func stageIcebergUpdateColumn(update *icebergtable.UpdateSchema, tbl *icebergtable.Table, colName string, col schema.Column) (bool, error) {
+func stageIcebergUpdateColumnAtPath(update *icebergtable.UpdateSchema, tbl *icebergtable.Table, path []string, col schema.Column) (bool, error) {
+	colName := strings.Join(path, ".")
+	if err := validateIcebergColumnName(colName); err != nil {
+		return false, err
+	}
 	targetType, err := icebergTypeForColumn(col)
 	if err != nil {
 		return false, fmt.Errorf("iceberg: failed to map column %q type: %w", colName, err)
 	}
 	field, ok := tbl.Schema().FindFieldByName(colName)
 	if !ok {
-		update.AddColumn([]string{colName}, targetType, "", !col.Nullable, nil)
-		return true, nil
+		return stageIcebergAddColumnAtPath(update, path, col)
 	}
 
 	changed := false
-	if !field.Type.Equals(targetType) {
+	if !icebergTypesEquivalent(field.Type, targetType) {
 		if _, err := iceberggo.PromoteType(field.Type, targetType); err != nil {
 			return false, fmt.Errorf("iceberg: column %q type change from %s to %s is not supported: %w", colName, field.Type, targetType, err)
 		}
-		update.UpdateColumn([]string{colName}, icebergtable.ColumnUpdate{
+		if _, nested := field.Type.(*iceberggo.StructType); nested {
+			return false, fmt.Errorf("iceberg: replacing nested parent field %q is unsupported; evolve child fields instead", colName)
+		}
+		update.UpdateColumn(path, icebergtable.ColumnUpdate{
 			FieldType: iceberggo.Optional[iceberggo.Type]{Valid: true, Val: targetType},
 		})
 		changed = true
 	}
-	if field.Required && col.Nullable {
-		update.UpdateColumn([]string{colName}, icebergtable.ColumnUpdate{
+	if field.Required && col.Nullable && !slices.Contains(tbl.Schema().IdentifierFieldIDs, field.ID) {
+		update.UpdateColumn(path, icebergtable.ColumnUpdate{
 			Required: iceberggo.Optional[bool]{Valid: true, Val: false},
 		})
 		changed = true
 	}
 	return changed, nil
+}
+
+func schemaChangePath(change schemaevolution.SchemaChange) []string {
+	if len(change.ColumnPath) > 0 {
+		return append([]string(nil), change.ColumnPath...)
+	}
+	return []string{change.ColumnName}
+}
+
+func stageIcebergSoftRemoveColumnAtPath(update *icebergtable.UpdateSchema, tbl *icebergtable.Table, path []string) (bool, error) {
+	colName := strings.Join(path, ".")
+	field, ok := tbl.Schema().FindFieldByName(colName)
+	if !ok || !field.Required {
+		return false, nil
+	}
+	for _, identifierID := range tbl.Schema().IdentifierFieldIDs {
+		if identifierID == field.ID {
+			return false, fmt.Errorf("iceberg: cannot soft-remove identifier column %q; update the primary key or use replace", colName)
+		}
+	}
+	update.UpdateColumn(path, icebergtable.ColumnUpdate{
+		Required: iceberggo.Optional[bool]{Valid: true, Val: false},
+	})
+	return true, nil
 }

--- a/pkg/destination/iceberg/hive_file_io.go
+++ b/pkg/destination/iceberg/hive_file_io.go
@@ -1,0 +1,134 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"net/url"
+	"strings"
+
+	iceberg "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+)
+
+func init() {
+	// Hive Metastore canonicalizes local URIs as file:/absolute/path. The
+	// upstream LocalFS only strips file://, which turns that URI into a relative
+	// workspace path. Install a compatible file-scheme factory before catalogs
+	// are used; plain paths still use iceberg-go's empty-scheme LocalFS.
+	icebergio.Unregister("file")
+	icebergio.Register("file", func(context.Context, *url.URL, map[string]string) (icebergio.IO, error) {
+		return hiveLocalIO{}, nil
+	})
+}
+
+type hiveFileCatalog struct {
+	icebergcatalog.Catalog
+}
+
+func (c *hiveFileCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	return c.wrapTable(tbl), err
+}
+
+func (c *hiveFileCatalog) CreateTable(ctx context.Context, ident icebergtable.Identifier, tableSchema *iceberg.Schema, opts ...icebergcatalog.CreateTableOpt) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.CreateTable(ctx, ident, tableSchema, opts...)
+	return c.wrapTable(tbl), err
+}
+
+func (c *hiveFileCatalog) RenameTable(ctx context.Context, from, to icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.RenameTable(ctx, from, to)
+	return c.wrapTable(tbl), err
+}
+
+func (c *hiveFileCatalog) wrapTable(tbl *icebergtable.Table) *icebergtable.Table {
+	if tbl == nil || !strings.HasPrefix(tbl.MetadataLocation(), "file:/") {
+		return tbl
+	}
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), func(context.Context) (icebergio.IO, error) {
+		return hiveLocalIO{}, nil
+	}, c)
+}
+
+func (c *hiveFileCatalog) Close() error {
+	if closer, ok := c.Catalog.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+type hiveLocalIO struct{ icebergio.LocalFS }
+
+func normalizeHiveFilePath(path string) string {
+	if strings.HasPrefix(path, "file://") {
+		return strings.TrimPrefix(path, "file://")
+	}
+	return strings.TrimPrefix(path, "file:")
+}
+
+func (hiveLocalIO) Open(path string) (icebergio.File, error) {
+	return icebergio.LocalFS{}.Open(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) ReadFile(path string) ([]byte, error) {
+	return icebergio.LocalFS{}.ReadFile(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) Create(path string) (icebergio.FileWriter, error) {
+	return icebergio.LocalFS{}.Create(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) WriteFile(path string, content []byte) error {
+	return icebergio.LocalFS{}.WriteFile(normalizeHiveFilePath(path), content)
+}
+
+func (hiveLocalIO) Remove(path string) error {
+	return icebergio.LocalFS{}.Remove(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return icebergio.LocalFS{}.WalkDir(normalizeHiveFilePath(root), fn)
+}
+
+func (hiveLocalIO) RemoveAll(path string) error {
+	return icebergio.LocalFS{}.RemoveAll(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) ReadDir(path string) ([]fs.DirEntry, error) {
+	return icebergio.LocalFS{}.ReadDir(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) MkdirAll(path string) error {
+	return icebergio.LocalFS{}.MkdirAll(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) Mkdir(path string) error {
+	return icebergio.LocalFS{}.Mkdir(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) Stat(path string) (fs.FileInfo, error) {
+	return icebergio.LocalFS{}.Stat(normalizeHiveFilePath(path))
+}
+
+func (hiveLocalIO) Rename(oldPath, newPath string) error {
+	return icebergio.LocalFS{}.Rename(normalizeHiveFilePath(oldPath), normalizeHiveFilePath(newPath))
+}
+
+func (hiveLocalIO) DeleteFiles(ctx context.Context, paths []string) ([]string, error) {
+	deleted := make([]string, 0, len(paths))
+	var deleteErr error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return deleted, errors.Join(deleteErr, err)
+		}
+		if err := (hiveLocalIO{}).Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			deleteErr = errors.Join(deleteErr, err)
+			continue
+		}
+		deleted = append(deleted, path)
+	}
+	return deleted, deleteErr
+}

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -6,41 +6,66 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	iceberggo "github.com/apache/iceberg-go"
 	icebergcatalog "github.com/apache/iceberg-go/catalog"
 	_ "github.com/apache/iceberg-go/catalog/glue"
 	_ "github.com/apache/iceberg-go/catalog/hadoop"
 	_ "github.com/apache/iceberg-go/catalog/hive"
-	_ "github.com/apache/iceberg-go/catalog/rest"
 	_ "github.com/apache/iceberg-go/catalog/sql"
 	_ "github.com/apache/iceberg-go/io/gocloud"
 	icebergtable "github.com/apache/iceberg-go/table"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "modernc.org/sqlite"
 )
 
+const prepareOwnershipProperty = "ingestr.prepare-owner"
+
+const (
+	defaultManagedStagingNamespace  = "_bruin_staging"
+	s3TablesManagedStagingNamespace = "bruin_staging"
+)
+
 type preparedTable struct {
-	schema      *schema.TableSchema
-	replace     bool
-	partitionBy string
+	schema           *schema.TableSchema
+	replace          bool
+	preserveMetadata bool
+	evolveSchema     bool
+	partitionBy      string
+	clusterBy        []string
 }
 
 type Destination struct {
-	cfg     icebergConfig
-	catalog icebergcatalog.Catalog
+	cfg                          icebergConfig
+	catalog                      icebergcatalog.Catalog
+	leaseHeartbeatInterval       time.Duration
+	catalogLockHeartbeatInterval time.Duration
 
 	mu       sync.Mutex
 	prepared map[string]preparedTable
+	// expirationScans throttles best-effort catalog scans that reclaim
+	// abandoned managed staging tables. It is guarded by mu.
+	expirationScans map[string]int64
+}
+
+func (*Destination) SupportsIdempotentCommitTokenWrites() bool {
+	return true
 }
 
 func NewDestination() *Destination {
@@ -48,7 +73,18 @@ func NewDestination() *Destination {
 }
 
 func (d *Destination) Schemes() []string {
-	return []string{"iceberg", "iceberg+rest", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"}
+	return []string{"iceberg", "iceberg+rest", "iceberg+nessie", "iceberg+polaris", "iceberg+s3tables", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"}
+}
+
+func (d *Destination) ManagedStagingPolicy() destination.ReplaceStagingPolicy {
+	namespace := defaultManagedStagingNamespace
+	if d.cfg.Properties.Get("rest.signing-name", "") == "s3tables" {
+		namespace = s3TablesManagedStagingNamespace
+	}
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingManagedSchema,
+		DefaultManagedSchema: namespace,
+	}
 }
 
 func (d *Destination) Connect(ctx context.Context, rawURI string) error {
@@ -56,15 +92,37 @@ func (d *Destination) Connect(ctx context.Context, rawURI string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateMaintenanceConfiguration(cfg.TableProperties); err != nil {
+		return err
+	}
+	if err := validateMaintenanceTableLocation(cfg); err != nil {
+		return err
+	}
 
-	cat, err := icebergcatalog.Load(ctx, cfg.CatalogName, cfg.Properties)
+	cat, err := loadIcebergCatalog(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("iceberg: failed to load catalog: %w", err)
+	}
+	if err := validateIsolatedTableFilePaths(cfg.TableProperties); err != nil {
+		_ = closeIcebergCatalog(cat)
+		return fmt.Errorf("iceberg uri: %w", err)
+	}
+	if d.catalog != nil {
+		if err := closeIcebergCatalog(d.catalog); err != nil {
+			_ = closeIcebergCatalog(cat)
+			return fmt.Errorf("iceberg: failed to close previous catalog: %w", err)
+		}
 	}
 
 	d.cfg = cfg
 	d.catalog = cat
 	d.prepared = make(map[string]preparedTable)
+	d.expirationScans = make(map[string]int64)
+	if err := d.sweepPurgeJournals(ctx, nil); err != nil {
+		d.catalog = nil
+		_ = closeIcebergCatalog(cat)
+		return fmt.Errorf("iceberg: failed to resume durable purge journals: %w", err)
+	}
 	config.Debug("[ICEBERG] Connected catalog type=%s name=%s", cat.CatalogType(), cfg.CatalogName)
 	return nil
 }
@@ -73,10 +131,16 @@ func (d *Destination) Close(ctx context.Context) error {
 	cat := d.catalog
 	d.catalog = nil
 	d.prepared = nil
+	d.expirationScans = nil
+	if err := closeIcebergCatalog(cat); err != nil {
+		return fmt.Errorf("iceberg: failed to close catalog: %w", err)
+	}
+	return nil
+}
+
+func closeIcebergCatalog(cat icebergcatalog.Catalog) error {
 	if closer, ok := cat.(io.Closer); ok {
-		if err := closer.Close(); err != nil {
-			return fmt.Errorf("iceberg: failed to close catalog: %w", err)
-		}
+		return closer.Close()
 	}
 	return nil
 }
@@ -89,9 +153,20 @@ func (d *Destination) PrepareTable(ctx context.Context, opts destination.Prepare
 		return errors.New("iceberg destination requires schema")
 	}
 	tableSchema := tableSchemaWithPrimaryKeys(opts.Schema, opts.PrimaryKeys)
+	if err := validateIcebergTableSchema(tableSchema); err != nil {
+		return err
+	}
+	partitionBy := opts.PartitionBy
+	if d.cfg.PartitionSpec != "" {
+		partitionBy = d.cfg.PartitionSpec
+	}
+	clusterBy := append([]string(nil), opts.ClusterBy...)
 
 	ident, err := parseIdentifier(opts.Table)
 	if err != nil {
+		return err
+	}
+	if err := validateS3TablesIdentifier(d.cfg, ident, tableSchema); err != nil {
 		return err
 	}
 	namespace := icebergcatalog.NamespaceFromIdent(ident)
@@ -103,17 +178,79 @@ func (d *Destination) PrepareTable(ctx context.Context, opts destination.Prepare
 	if err != nil {
 		return err
 	}
+	if !exists {
+		var recoveryErr error
+		if d.usesServerManagedPurge() {
+			recoveryErr = d.ensureNoServerManagedPurgeLock(ctx, ident)
+		} else {
+			recoveryErr = d.resumePurgeJournal(ctx, ident)
+		}
+		if recoveryErr != nil {
+			return fmt.Errorf("iceberg: cannot prepare table %s while durable purge recovery is incomplete: %w", opts.Table, recoveryErr)
+		}
+		exists, err = d.tableExists(ctx, ident)
+		if err != nil {
+			return err
+		}
+	}
 	if exists {
+		expired, err := d.prepareExistingTableLifecycleNow(ctx, ident, opts.ExpiresAfter)
+		if err != nil {
+			return err
+		}
+		exists = !expired
+	}
+	if exists {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to load table %s: %w", opts.Table, err)
+		}
+		if opts.OwnershipToken != "" && tbl.Properties()[prepareOwnershipProperty] != opts.OwnershipToken {
+			return fmt.Errorf("iceberg: table %s was created by another owner", opts.Table)
+		}
 		if opts.DropFirst {
-			tbl, err := d.catalog.LoadTable(ctx, ident)
-			if err != nil {
-				return fmt.Errorf("iceberg: failed to load table %s: %w", opts.Table, err)
-			}
 			if err := validateIdentifierFieldsForEvolution(tbl.Schema(), tableSchema, true); err != nil {
 				return err
 			}
 		}
+		if opts.PreserveExistingLayout {
+			partitionBy = ""
+			clusterBy = nil
+		} else if !opts.DropFirst && len(clusterBy) == 0 && tbl.SortOrder().Len() > 0 {
+			inherited, ok := identitySortColumns(tbl)
+			if ok && preparedLayoutColumnsExist(tableSchema, "", inherited) {
+				clusterBy = inherited
+			} else if _, err := d.ensureSortOrder(ctx, tbl, nil); err != nil {
+				return err
+			}
+		}
+		// A replace stages schema, partition, properties, and rows in the same
+		// Iceberg transaction. Applying layout metadata here would leave the old
+		// rows behind with new metadata if extraction or file writing later fails.
+		if !opts.DropFirst && !opts.PreserveExistingLayout {
+			tbl, err = d.applyConfiguredTableProperties(ctx, tbl)
+			if err != nil {
+				return err
+			}
+			if partitionBy != "" && layoutColumnsExist(tbl.Schema(), partitionBy, nil) {
+				if err := d.updateExistingPartitionSpec(ctx, tbl, partitionBy); err != nil {
+					return err
+				}
+				tbl, err = d.catalog.LoadTable(ctx, ident)
+				if err != nil {
+					return fmt.Errorf("iceberg: failed to reload table %s after partition evolution: %w", opts.Table, err)
+				}
+			}
+			if len(clusterBy) > 0 && layoutColumnsExist(tbl.Schema(), "", clusterBy) {
+				if _, err := d.ensureSortOrder(ctx, tbl, clusterBy); err != nil {
+					return err
+				}
+			}
+		}
 	} else {
+		if err := validatePreparedLayoutColumns(tableSchema, partitionBy, clusterBy); err != nil {
+			return err
+		}
 		createOpts := opts
 		createOpts.Schema = tableSchema
 		if err := d.createTable(ctx, ident, createOpts); err != nil {
@@ -122,7 +259,12 @@ func (d *Destination) PrepareTable(ctx context.Context, opts destination.Prepare
 	}
 
 	d.mu.Lock()
-	d.prepared[opts.Table] = preparedTable{schema: tableSchema, replace: opts.DropFirst, partitionBy: opts.PartitionBy}
+	d.prepared[opts.Table] = preparedTable{
+		schema:      tableSchema,
+		replace:     opts.DropFirst,
+		partitionBy: partitionBy,
+		clusterBy:   clusterBy,
+	}
 	d.mu.Unlock()
 	return nil
 }
@@ -132,6 +274,9 @@ func (d *Destination) Write(ctx context.Context, records <-chan source.RecordBat
 }
 
 func (d *Destination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	input := newRecordBatchInput(records)
+	defer input.Close()
+
 	if d.catalog == nil {
 		return errors.New("iceberg destination not connected")
 	}
@@ -143,8 +288,41 @@ func (d *Destination) WriteParallel(ctx context.Context, records <-chan source.R
 	if err != nil {
 		return fmt.Errorf("iceberg: failed to load table %s: %w", opts.Table, err)
 	}
-
+	if err := validateIsolatedTableFilePaths(tbl.Properties()); err != nil {
+		return fmt.Errorf("iceberg: table %s: %w", opts.Table, err)
+	}
+	if err := d.validateExpectedIncarnation(ctx, tbl, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
 	prepared := d.lookupPrepared(opts.Table)
+	metadata := newCommitMetadata(opts.CommitToken, opts.CDCResumeLSN).withExpectedIncarnation(opts.CDCExpectedIncarnation)
+	if opts.SkipCDCResume {
+		metadata.cdcResumeLSN = ""
+		metadata.resetCDCResume = !opts.StagingTable
+	}
+	if prepared.replace && metadata.token == "" {
+		metadata = newCommitMetadata("replace-run:"+uuid.NewString(), "")
+	}
+	if tableHasCommitToken(tbl, metadata.token) {
+		if err := input.Drain(ctx); err != nil {
+			return fmt.Errorf("iceberg: failed to drain already-committed write for table %s: %w", opts.Table, err)
+		}
+		if opts.SkipCDCResume && !opts.StagingTable {
+			if err := d.ensureManagedCDCResumeResetExpected(ctx, tbl, metadata.token, opts.CDCExpectedIncarnation); err != nil {
+				return fmt.Errorf("iceberg: failed to clear legacy CDC resume state for table %s: %w", opts.Table, err)
+			}
+		}
+		if prepared.replace {
+			if _, err := d.ensureSortOrderExpected(ctx, tbl, prepared.clusterBy, opts.CDCExpectedIncarnation); err != nil {
+				return fmt.Errorf("iceberg: data replacement for table %s is committed but its sort order is not: %w", opts.Table, err)
+			}
+		}
+		return nil
+	}
+	if err := validateCDCResumeAdvance(tbl, metadata); err != nil {
+		return err
+	}
+
 	writeSchema := opts.Schema
 	if writeSchema == nil {
 		writeSchema = prepared.schema
@@ -152,26 +330,149 @@ func (d *Destination) WriteParallel(ctx context.Context, records <-chan source.R
 	if writeSchema == nil {
 		return errors.New("iceberg destination requires schema for write")
 	}
+	if err := validateIcebergTableSchema(writeSchema); err != nil {
+		return err
+	}
+	leaseHeartbeat, err := d.startManagedTableLeaseHeartbeat(ctx, tbl)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to start managed-table lease heartbeat for %s: %w", opts.Table, err)
+	}
+	if leaseHeartbeat != nil {
+		defer leaseHeartbeat.stop()
+	}
 
-	reader := newRecordBatchReader(ctx, records, icebergArrowSchema(writeSchema))
-	defer reader.Release()
+	operation := "append"
+	if prepared.replace {
+		operation = "replace"
+	}
+	props := snapshotProps(operation, metadata)
+	var observe func(arrow.RecordBatch)
+	if metadata.cdcResumeLSN == "" && !opts.SkipCDCResume {
+		observe = func(batch arrow.RecordBatch) { observeCDCResumeLSN(props, batch, metadata.token != "") }
+	}
 
-	props := iceberggo.Properties{
-		"ingestr.destination": "iceberg",
+	arrowSchema := icebergWriteArrowSchema(writeSchema, tbl.Schema())
+	if prepared.replace && prepared.schema != nil {
+		preparedIcebergSchema, schemaErr := icebergSchemaFromTableSchema(prepared.schema)
+		if schemaErr != nil {
+			return schemaErr
+		}
+		arrowSchema = icebergWriteArrowSchema(writeSchema, preparedIcebergSchema)
+	}
+	batchReader := input.RecordReader(ctx, arrowSchema)
+	batchReader.observe = observe
+	var reader array.RecordReader = batchReader
+	var transformedReaders []func()
+	defer func() {
+		for i := len(transformedReaders) - 1; i >= 0; i-- {
+			transformedReaders[i]()
+		}
+	}()
+	if prepared.replace && opts.DeduplicatePrimaryKeys && len(prepared.schema.PrimaryKeys) > 0 {
+		var cleanup func()
+		reader, cleanup, err = deduplicateRecordReader(reader, prepared.schema.PrimaryKeys, opts.IncrementalKey)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to deduplicate replace for table %s: %w", opts.Table, err)
+		}
+		transformedReaders = append(transformedReaders, cleanup)
+	}
+	if len(prepared.clusterBy) > 0 {
+		var cleanup func()
+		reader, cleanup, err = clusterRecordReader(ctx, reader, prepared.clusterBy)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to cluster write for table %s: %w", opts.Table, err)
+		}
+		transformedReaders = append(transformedReaders, cleanup)
 	}
 	if prepared.replace {
-		props["ingestr.operation"] = "replace"
-		_, err = d.overwritePrepared(ctx, tbl, reader, props, prepared)
+		openReplay, cleanupReplay, err := spoolReplayableRecordReader(reader)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to spool replacement for table %s: %w", opts.Table, err)
+		}
+		defer cleanupReplay()
+		var committed *icebergtable.Table
+		current := tbl
+		var writeErr error
+		const maxAttempts = 5
+		for attempt := 0; attempt < maxAttempts; attempt++ {
+			replay, release, replayErr := openReplay()
+			if replayErr != nil {
+				return replayErr
+			}
+			committed, writeErr = d.overwritePrepared(ctx, current, replay, props, prepared, opts.Parallelism, leaseHeartbeat, false, opts.CDCExpectedIncarnation)
+			release()
+			if writeErr == nil {
+				break
+			}
+			if !errors.Is(writeErr, icebergtable.ErrCommitFailed) {
+				if reconciled := d.reconcileCommit(ctx, opts.Table, props[snapshotCommitTokenKey], opts.CDCExpectedIncarnation, writeErr); reconciled != nil {
+					return fmt.Errorf("iceberg: failed to write table %s: %w", opts.Table, reconciled)
+				}
+				committed, err = d.loadIcebergTable(ctx, opts.Table)
+				if err != nil {
+					return fmt.Errorf("iceberg: replacement for table %s committed but could not be reloaded: %w", opts.Table, err)
+				}
+				if err := d.validateExpectedIncarnation(ctx, committed, opts.CDCExpectedIncarnation); err != nil {
+					return err
+				}
+				break
+			}
+			current, err = d.loadIcebergTable(ctx, opts.Table)
+			if err != nil {
+				return err
+			}
+			if err := d.validateExpectedIncarnation(ctx, current, opts.CDCExpectedIncarnation); err != nil {
+				return err
+			}
+			if err := waitForCommitRetry(ctx, attempt); err != nil {
+				return err
+			}
+		}
+		if committed == nil {
+			return fmt.Errorf("iceberg: replacement for table %s failed after retries: %w", opts.Table, writeErr)
+		}
+		if _, err := d.ensureSortOrderExpected(ctx, committed, prepared.clusterBy, opts.CDCExpectedIncarnation); err != nil {
+			return fmt.Errorf("iceberg: data replacement for table %s is committed but its sort order is not: %w", opts.Table, err)
+		}
 	} else {
-		props["ingestr.operation"] = "append"
-		_, err = tbl.Append(ctx, reader, props)
-		if err == nil {
-			err = reader.Err()
+		if leaseHeartbeat != nil {
+			spooled, cleanup, spoolErr := spoolRecordReader(reader)
+			if spoolErr != nil {
+				return fmt.Errorf("iceberg: failed to spool managed append for table %s: %w", opts.Table, spoolErr)
+			}
+			defer cleanup()
+			reader = spooled
+			tbl, err = leaseHeartbeat.stopAndRefresh(ctx)
+			if err != nil {
+				return fmt.Errorf("iceberg: failed to finalize managed-table lease before append: %w", err)
+			}
+			expiresAt, ttl, _, leaseErr := managedTableLease(tbl.Properties())
+			if leaseErr != nil {
+				return leaseErr
+			}
+			fileWriteDeadline := expiresAt.Add(-ttl / 4)
+			if !time.Now().Before(fileWriteDeadline) {
+				return errors.New("iceberg: managed-table lease has insufficient time remaining for append")
+			}
+			var cancelLeaseDeadline context.CancelFunc
+			ctx, cancelLeaseDeadline = context.WithDeadline(ctx, fileWriteDeadline)
+			defer cancelLeaseDeadline()
+		}
+		parallelism := opts.Parallelism
+		if len(prepared.clusterBy) > 0 {
+			parallelism = 1
+		}
+		err = d.appendRecordBatches(ctx, tbl, reader, props, parallelism, opts.CDCExpectedIncarnation)
+	}
+	if !prepared.replace && err != nil {
+		if incarnationErr := d.validateExpectedIncarnation(ctx, tbl, opts.CDCExpectedIncarnation); incarnationErr != nil {
+			return incarnationErr
+		}
+		if reconciled := d.reconcileCommit(ctx, opts.Table, props[snapshotCommitTokenKey], opts.CDCExpectedIncarnation, err); reconciled != nil {
+			return fmt.Errorf("iceberg: failed to write table %s: %w", opts.Table, reconciled)
 		}
 	}
-	if err != nil {
-		return fmt.Errorf("iceberg: failed to write table %s: %w", opts.Table, err)
-	}
+	d.afterSuccessfulCommitExpected(ctx, opts.Table, opts.CDCExpectedIncarnation)
 	return nil
 }
 
@@ -187,8 +488,140 @@ func (d *Destination) DropTable(ctx context.Context, table string) error {
 	if err != nil {
 		return err
 	}
-	if err := d.catalog.DropTable(ctx, ident); err != nil && !isMissingTableOrNamespace(err) {
-		return fmt.Errorf("iceberg: failed to drop table %s: %w", table, err)
+	return d.dropTableWithLifecycle(ctx, ident)
+}
+
+func (d *Destination) DropTableIfOwned(ctx context.Context, table, ownershipToken string) error {
+	if strings.TrimSpace(ownershipToken) == "" {
+		return errors.New("iceberg: conditional table drop requires an ownership token")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	expectedUUID := tbl.Metadata().TableUUID().String()
+	return d.dropTableWithLifecycleExpected(ctx, ident, expectedUUID, func(current *icebergtable.Table) error {
+		if current.Properties()[prepareOwnershipProperty] != ownershipToken {
+			return fmt.Errorf("iceberg: refused to drop table %s because preparation ownership changed", table)
+		}
+		return nil
+	})
+}
+
+var _ destination.OwnedTableDropper = (*Destination)(nil)
+
+// DropNamespace removes an empty Iceberg namespace using the destination's
+// configured catalog client, including URI-scoped authentication.
+func (d *Destination) DropNamespace(ctx context.Context, namespace string) error {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(namespace + ".placeholder")
+	if err != nil {
+		return err
+	}
+	namespaceIdent := icebergcatalog.NamespaceFromIdent(ident)
+	err = d.catalog.DropNamespace(ctx, namespaceIdent)
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err == nil {
+		return nil
+	}
+	originalErr := err
+	cleaned, cleanupErr := d.dropIdleLifecycleLocks(ctx, namespaceIdent)
+	if cleanupErr != nil {
+		return errors.Join(originalErr, cleanupErr)
+	}
+	if !cleaned {
+		return originalErr
+	}
+	err = d.catalog.DropNamespace(ctx, namespaceIdent)
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	return err
+}
+
+func (d *Destination) dropIdleLifecycleLocks(ctx context.Context, namespace icebergtable.Identifier) (bool, error) {
+	cleaned := false
+	for ident, listErr := range d.catalog.ListTables(ctx, namespace) {
+		if isMissingTableOrNamespace(listErr) {
+			return cleaned, nil
+		}
+		if listErr != nil {
+			return cleaned, fmt.Errorf("iceberg: failed to list namespace lifecycle locks: %w", listErr)
+		}
+		if len(ident) == 0 || !strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+			continue
+		}
+		lock, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return cleaned, fmt.Errorf("iceberg: failed to inspect namespace lifecycle lock %s: %w", strings.Join(ident, "."), err)
+		}
+		mode := lock.Properties()[purgeLockModeKey]
+		if mode != purgeLockModeIdle && mode != purgeLockModeCleanup {
+			return cleaned, fmt.Errorf("iceberg: namespace lifecycle lock %s is still active", strings.Join(ident, "."))
+		}
+		if mode == purgeLockModeCleanup {
+			expiresAt, parseErr := time.Parse(time.RFC3339Nano, lock.Properties()[purgeLockExpiresAtKey])
+			if parseErr != nil {
+				return cleaned, fmt.Errorf("iceberg: namespace lifecycle lock %s has an invalid cleanup expiry: %w", strings.Join(ident, "."), parseErr)
+			}
+			if time.Now().UTC().Before(expiresAt) {
+				return cleaned, fmt.Errorf("iceberg: namespace lifecycle lock %s cleanup is still active", strings.Join(ident, "."))
+			}
+		}
+		token := uuid.NewString()
+		txn := lock.NewTransaction()
+		if err := txn.SetProperties(iceberggo.Properties{
+			purgeLockModeKey: purgeLockModeCleanup, purgeLockTokenKey: token,
+			purgeLockExpiresAtKey: time.Now().UTC().Add(createGuardTTL).Format(time.RFC3339Nano),
+		}); err != nil {
+			return cleaned, err
+		}
+		if _, err := txn.Commit(ctx); err != nil {
+			return cleaned, fmt.Errorf("iceberg: failed to fence namespace lifecycle lock %s for cleanup: %w", strings.Join(ident, "."), err)
+		}
+		current, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return cleaned, err
+		}
+		if current.Properties()[purgeLockModeKey] != purgeLockModeCleanup || current.Properties()[purgeLockTokenKey] != token {
+			return cleaned, fmt.Errorf("iceberg: namespace lifecycle lock %s cleanup ownership changed", strings.Join(ident, "."))
+		}
+		if err := d.catalog.DropTable(ctx, ident); err != nil && !isMissingTableOrNamespace(err) {
+			rollbackErr := d.rollbackCleanupLock(context.WithoutCancel(ctx), ident, token)
+			return cleaned, errors.Join(
+				fmt.Errorf("iceberg: failed to remove idle namespace lifecycle lock %s: %w", strings.Join(ident, "."), err),
+				rollbackErr,
+			)
+		}
+		cleaned = true
+	}
+	return cleaned, nil
+}
+
+func (d *Destination) rollbackCleanupLock(ctx context.Context, ident icebergtable.Identifier, token string) error {
+	lock, err := d.catalog.LoadTable(ctx, ident)
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to inspect cleanup lock rollback for %s: %w", strings.Join(ident, "."), err)
+	}
+	if lock.Properties()[purgeLockModeKey] != purgeLockModeCleanup || lock.Properties()[purgeLockTokenKey] != token {
+		return fmt.Errorf("iceberg: refused cleanup lock rollback for %s because ownership changed", strings.Join(ident, "."))
+	}
+	if err := commitLockIdle(ctx, lock); err != nil {
+		return fmt.Errorf("iceberg: failed to roll cleanup lock %s back to idle: %w", strings.Join(ident, "."), err)
 	}
 	return nil
 }
@@ -231,36 +664,75 @@ func (d *Destination) GetScheme() string {
 	return "iceberg"
 }
 
-func (d *Destination) SupportsReplaceStrategy() bool      { return true }
-func (d *Destination) SupportsAppendStrategy() bool       { return true }
-func (d *Destination) SupportsMergeStrategy() bool        { return true }
-func (d *Destination) SupportsDeleteInsertStrategy() bool { return true }
-func (d *Destination) SupportsSCD2Strategy() bool         { return true }
-func (d *Destination) SupportsAtomicSwap() bool           { return false }
-func (d *Destination) SupportsCDCMerge() bool             { return true }
-func (d *Destination) SupportsCDCUnchangedCols() bool     { return true }
+func (d *Destination) SupportsReplaceStrategy() bool            { return true }
+func (d *Destination) SupportsAppendStrategy() bool             { return true }
+func (d *Destination) SupportsMergeStrategy() bool              { return true }
+func (d *Destination) SupportsDeleteInsertStrategy() bool       { return true }
+func (d *Destination) SupportsSCD2Strategy() bool               { return true }
+func (d *Destination) SupportsAtomicSwap() bool                 { return false }
+func (d *Destination) SupportsDirectReplaceDeduplication() bool { return true }
+func (d *Destination) SupportsCDCMerge() bool                   { return true }
+func (d *Destination) SupportsCDCUnchangedCols() bool           { return true }
+
+func (d *Destination) MaxConcurrentFlushes() int { return 4 }
 
 func (d *Destination) createTable(ctx context.Context, ident icebergtable.Identifier, opts destination.PrepareOptions) error {
+	if (d.catalog.CatalogType() == icebergcatalog.REST && !d.usesServerManagedPurge()) ||
+		d.catalog.CatalogType() == icebergcatalog.Hadoop {
+		return d.createTableGuarded(ctx, ident, opts)
+	}
+	token, err := d.acquireCreateGuard(ctx, ident)
+	if err != nil {
+		return err
+	}
+	createCtx, cancelCreate := context.WithCancel(ctx)
+	heartbeat := d.startCatalogLockHeartbeat(createCtx, ident, purgeLockModeCreate, "", token, createGuardTTL, cancelCreate)
+	createErr := d.createTableGuarded(createCtx, ident, opts)
+	heartbeatErr := heartbeat.stop()
+	cancelCreate()
+	releaseErr := d.releaseCreateGuard(context.WithoutCancel(ctx), ident, token)
+	return errors.Join(createErr, heartbeatErr, releaseErr)
+}
+
+func (d *Destination) createTableGuarded(ctx context.Context, ident icebergtable.Identifier, opts destination.PrepareOptions) error {
 	iceSchema, err := icebergSchemaFromTableSchema(opts.Schema)
 	if err != nil {
 		return err
 	}
 
 	createOpts := []icebergcatalog.CreateTableOpt{}
-	if len(d.cfg.TableProperties) > 0 {
-		createOpts = append(createOpts, icebergcatalog.WithProperties(d.cfg.TableProperties))
+	requestedProperties := maps.Clone(d.cfg.TableProperties)
+	maps.Copy(requestedProperties, opts.TableProperties)
+	if opts.OwnershipToken != "" {
+		requestedProperties[prepareOwnershipProperty] = opts.OwnershipToken
+	}
+	tableProperties, err := lifecyclePropertiesForCreate(requestedProperties, opts.ExpiresAfter)
+	if err != nil {
+		return err
+	}
+	if len(tableProperties) > 0 {
+		createOpts = append(createOpts, icebergcatalog.WithProperties(tableProperties))
 	}
 	if d.cfg.TableLocation != "" {
 		createOpts = append(createOpts, icebergcatalog.WithLocation(renderTableLocation(d.cfg.TableLocation, ident)))
 	}
-	if opts.PartitionBy != "" {
-		spec, err := iceberggo.NewPartitionSpecOpts(
-			iceberggo.AddPartitionFieldByName(opts.PartitionBy, opts.PartitionBy, iceberggo.IdentityTransform{}, iceSchema, nil),
-		)
+	partitionBy := opts.PartitionBy
+	if d.cfg.PartitionSpec != "" {
+		partitionBy = d.cfg.PartitionSpec
+	}
+	if partitionBy != "" {
+		spec, err := buildPartitionSpec(iceSchema, partitionBy)
 		if err != nil {
-			return fmt.Errorf("iceberg: invalid partition column %q: %w", opts.PartitionBy, err)
+			return err
 		}
 		createOpts = append(createOpts, icebergcatalog.WithPartitionSpec(&spec))
+	}
+	if len(opts.ClusterBy) > 0 {
+		order, err := sortOrderForColumns(iceSchema, opts.ClusterBy, icebergtable.InitialSortOrderID)
+		if err != nil {
+			return err
+		}
+		createOpts = append(createOpts, icebergcatalog.WithSortOrder(order))
 	}
 
 	if err := d.ensureLocalTableDirs(ident); err != nil {
@@ -268,18 +740,24 @@ func (d *Destination) createTable(ctx context.Context, ident icebergtable.Identi
 	}
 	if _, err := d.catalog.CreateTable(ctx, ident, iceSchema, createOpts...); err != nil {
 		if errors.Is(err, icebergcatalog.ErrTableAlreadyExists) {
-			return nil
+			return fmt.Errorf("iceberg: refused concurrent external creation of table %s: %w", strings.Join(ident, "."), err)
 		}
 		return fmt.Errorf("iceberg: failed to create table %s: %w", strings.Join(ident, "."), err)
 	}
 	return nil
 }
 
-func (d *Destination) stageTableSchemaUpdate(txn *icebergtable.Transaction, tbl *icebergtable.Table, desired *schema.TableSchema, reset bool) (bool, error) {
+func (d *Destination) stageTableSchemaUpdate(
+	txn *icebergtable.Transaction,
+	tbl *icebergtable.Table,
+	desired *schema.TableSchema,
+	reset bool,
+	allowIncompatible bool,
+) (bool, error) {
 	if err := validateIdentifierFieldsForEvolution(tbl.Schema(), desired, reset); err != nil {
 		return false, err
 	}
-	update := txn.UpdateSchema(true, reset, icebergtable.WithNameMapping(tbl.NameMapping()))
+	update := txn.UpdateSchema(true, allowIncompatible, icebergtable.WithNameMapping(tbl.NameMapping()))
 	changed := false
 
 	desiredColumns := make(map[string]struct{}, len(desired.Columns))
@@ -295,6 +773,20 @@ func (d *Destination) stageTableSchemaUpdate(txn *icebergtable.Transaction, tbl 
 			changed = true
 		}
 	}
+	if !reset {
+		for _, field := range tbl.Schema().Fields() {
+			if _, ok := desiredColumns[field.Name]; ok || !field.Required {
+				continue
+			}
+			if slices.Contains(tbl.Schema().IdentifierFieldIDs, field.ID) {
+				return false, fmt.Errorf("iceberg: cannot omit required identifier column %q", field.Name)
+			}
+			update.UpdateColumn([]string{field.Name}, icebergtable.ColumnUpdate{
+				Required: iceberggo.Optional[bool]{Valid: true, Val: false},
+			})
+			changed = true
+		}
+	}
 
 	for _, col := range desired.Columns {
 		targetType, err := icebergTypeForColumn(col)
@@ -303,12 +795,35 @@ func (d *Destination) stageTableSchemaUpdate(txn *icebergtable.Transaction, tbl 
 		}
 		field, ok := tbl.Schema().FindFieldByName(col.Name)
 		if !ok {
-			update.AddColumn([]string{col.Name}, targetType, "", reset && !col.Nullable, nil)
+			update.AddColumn([]string{col.Name}, targetType, "", allowIncompatible && !col.Nullable, nil)
 			changed = true
 			continue
 		}
 
-		if !field.Type.Equals(targetType) {
+		if !icebergTypesEquivalent(field.Type, targetType) {
+			if nestedColumn, nestedCurrent := nestedIcebergType(targetType), nestedIcebergType(field.Type); nestedColumn && nestedCurrent {
+				current, err := columnFromIcebergField(field)
+				if err != nil {
+					return false, fmt.Errorf("iceberg: failed to inspect nested column %q: %w", col.Name, err)
+				}
+				comparison, err := schemaevolution.Compare(
+					&schema.TableSchema{Columns: []schema.Column{col}},
+					&schema.TableSchema{Columns: []schema.Column{current}},
+					nil,
+				)
+				if err != nil {
+					return false, err
+				}
+				if allowIncompatible {
+					comparison = restoreDesiredNestedRequiredness(comparison, desired)
+				}
+				nestedChanged, err := stageSchemaComparisonChanges(update, tbl, comparison, allowIncompatible)
+				if err != nil {
+					return false, err
+				}
+				changed = changed || nestedChanged
+				continue
+			}
 			if !reset {
 				if _, err := iceberggo.PromoteType(field.Type, targetType); err != nil {
 					return false, fmt.Errorf("iceberg: column %q type change from %s to %s is not supported: %w", col.Name, field.Type, targetType, err)
@@ -325,7 +840,7 @@ func (d *Destination) stageTableSchemaUpdate(txn *icebergtable.Transaction, tbl 
 			})
 			changed = true
 		}
-		if reset && !field.Required && !col.Nullable {
+		if allowIncompatible && !field.Required && !col.Nullable {
 			update.UpdateColumn([]string{col.Name}, icebergtable.ColumnUpdate{
 				Required: iceberggo.Optional[bool]{Valid: true, Val: true},
 			})
@@ -350,17 +865,77 @@ func (d *Destination) stageTableSchemaUpdate(txn *icebergtable.Transaction, tbl 
 	return true, nil
 }
 
+func nestedIcebergType(t iceberggo.Type) bool {
+	switch t.(type) {
+	case *iceberggo.StructType, *iceberggo.ListType, *iceberggo.MapType:
+		return true
+	default:
+		return false
+	}
+}
+
+func restoreDesiredNestedRequiredness(comparison *schemaevolution.SchemaComparison, desired *schema.TableSchema) *schemaevolution.SchemaComparison {
+	if comparison == nil {
+		return nil
+	}
+	result := *comparison
+	result.Changes = append([]schemaevolution.SchemaChange(nil), comparison.Changes...)
+	for i := range result.Changes {
+		change := &result.Changes[i]
+		if change.Type != schemaevolution.ChangeAddColumn || len(change.ColumnPath) == 0 {
+			continue
+		}
+		if col, ok := nestedSchemaColumnAtPath(desired.Columns, change.ColumnPath); ok {
+			change.NewColumn.Nullable = col.Nullable
+		}
+	}
+	return &result
+}
+
+func nestedSchemaColumnAtPath(columns []schema.Column, path []string) (schema.Column, bool) {
+	if len(path) == 0 {
+		return schema.Column{}, false
+	}
+	for _, col := range columns {
+		if !strings.EqualFold(col.Name, path[0]) {
+			continue
+		}
+		if len(path) == 1 {
+			return col, true
+		}
+		switch col.DataType {
+		case schema.TypeStruct:
+			if col.StructFields != nil {
+				return nestedSchemaColumnAtPath(col.StructFields.Columns, path[1:])
+			}
+		case schema.TypeArray:
+			if path[1] == "element" && col.Element != nil {
+				return nestedSchemaColumnAtPath([]schema.Column{*col.Element}, append([]string{col.Element.Name}, path[2:]...))
+			}
+		case schema.TypeMap:
+			if path[1] == "value" && col.MapValue != nil {
+				return nestedSchemaColumnAtPath([]schema.Column{*col.MapValue}, append([]string{col.MapValue.Name}, path[2:]...))
+			}
+		}
+	}
+	return schema.Column{}, false
+}
+
 func (d *Destination) stagePartitionSpecUpdate(txn *icebergtable.Transaction, tbl *icebergtable.Table, partitionBy string) (bool, error) {
-	if partitionSpecMatches(tbl, partitionBy) {
+	if partitionExpressionMatches(tbl, partitionBy) {
 		return false, nil
+	}
+	terms, err := parsePartitionExpression(partitionBy)
+	if err != nil {
+		return false, err
 	}
 	update := txn.UpdateSpec(true)
 	spec := tbl.Metadata().PartitionSpec()
 	for _, field := range spec.Fields() {
 		update.RemoveField(field.Name)
 	}
-	if partitionBy != "" {
-		update.AddIdentity(partitionBy)
+	for _, term := range terms {
+		update.AddField(term.source, term.transform, term.name)
 	}
 	if err := update.Commit(); err != nil {
 		return false, fmt.Errorf("iceberg: failed to update partition spec: %w", err)
@@ -368,27 +943,218 @@ func (d *Destination) stagePartitionSpecUpdate(txn *icebergtable.Transaction, tb
 	return true, nil
 }
 
-func (d *Destination) overwritePrepared(ctx context.Context, tbl *icebergtable.Table, reader *recordBatchReader, props iceberggo.Properties, prepared preparedTable) (*icebergtable.Table, error) {
+func (d *Destination) overwritePrepared(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	reader array.RecordReader,
+	props iceberggo.Properties,
+	prepared preparedTable,
+	parallelism int,
+	leaseHeartbeat *managedLeaseHeartbeat,
+	readerAlreadySpooled bool,
+	expectedIncarnation string,
+) (committedTable *icebergtable.Table, retErr error) {
+	var err error
+	if !readerAlreadySpooled {
+		spooled, cleanup, err := spoolRecordReader(reader)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanup()
+		reader = spooled
+	}
+	if leaseHeartbeat != nil {
+		tbl, err = leaseHeartbeat.stopAndRefresh(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: failed to finalize managed-table lease before overwrite: %w", err)
+		}
+		expiresAt, ttl, _, err := managedTableLease(tbl.Properties())
+		if err != nil {
+			return nil, err
+		}
+		fileWriteDeadline := expiresAt.Add(-ttl / 4)
+		if !time.Now().Before(fileWriteDeadline) {
+			return nil, fmt.Errorf("iceberg: managed-table lease has insufficient time remaining for overwrite")
+		}
+		var cancelLeaseDeadline context.CancelFunc
+		ctx, cancelLeaseDeadline = context.WithDeadline(ctx, fileWriteDeadline)
+		defer cancelLeaseDeadline()
+	}
+	dataFilesToDelete, deleteFilesToRemove, err := liveFilesForReplace(ctx, tbl)
+	if err != nil {
+		return nil, err
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	writeID := uuid.New()
+	generatedPaths := make([]string, 0)
+	committed, cleanupSafe := false, true
+	defer func() {
+		if committed || !cleanupSafe {
+			return
+		}
+		if err := removeGeneratedMergeFiles(tableFS, tbl.Location(), writeID.String(), generatedPaths); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
 	txn := tbl.NewTransaction()
-	if prepared.schema != nil {
-		if _, err := d.stageTableSchemaUpdate(txn, tbl, prepared.schema, true); err != nil {
+	if err := stageResetCommitTokenLedger(txn, props[snapshotCommitTokenKey]); err != nil {
+		return nil, err
+	}
+	if err := stageCDCResumeState(txn, props); err != nil {
+		return nil, err
+	}
+	if prepared.evolveSchema && prepared.schema != nil {
+		if _, err := d.stageTableSchemaUpdate(txn, tbl, prepared.schema, false, true); err != nil {
 			return nil, err
 		}
 	}
-	if _, err := d.stagePartitionSpecUpdate(txn, tbl, prepared.partitionBy); err != nil {
-		return nil, err
+	if !prepared.preserveMetadata {
+		mutableProperties := maps.Clone(d.cfg.TableProperties)
+		delete(mutableProperties, icebergtable.PropertyFormatVersion)
+		if err := txn.SetProperties(mutableProperties); err != nil {
+			return nil, fmt.Errorf("iceberg: failed to stage configured table properties: %w", err)
+		}
+		if prepared.schema != nil && !prepared.evolveSchema {
+			if _, err := d.stageTableSchemaUpdate(txn, tbl, prepared.schema, true, true); err != nil {
+				return nil, err
+			}
+		}
+		if _, err := d.stagePartitionSpecUpdate(txn, tbl, prepared.partitionBy); err != nil {
+			return nil, err
+		}
 	}
-	if err := txn.Overwrite(ctx, reader, props); err != nil {
-		return nil, err
+	staged, err := txn.StagedTable()
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to construct staged overwrite table: %w", err)
+	}
+	stagedSortOrderMatches := sortOrderMatchesColumns(staged.Table, prepared.clusterBy)
+	writeOptions := make([]icebergtable.WriteRecordOption, 0, 1)
+	writeOptions = append(writeOptions, icebergtable.WithWriteUUID(writeID))
+	if parallelism > 0 {
+		if len(prepared.clusterBy) > 0 {
+			parallelism = 1
+		}
+		writeOptions = append(writeOptions, icebergtable.WithMaxWriteWorkers(parallelism))
+	}
+	var dataFiles []iceberggo.DataFile
+	for dataFile, writeErr := range icebergtable.WriteRecords(ctx, staged.Table, reader.Schema(), retainedRecordIterator(reader), writeOptions...) {
+		if writeErr != nil {
+			return nil, writeErr
+		}
+		if !stagedSortOrderMatches {
+			dataFile, err = withDataFileSortOrderID(dataFile, staged.Table, icebergtable.UnsortedSortOrderID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		dataFiles = append(dataFiles, dataFile)
+		generatedPaths = append(generatedPaths, dataFile.FilePath())
 	}
 	if err := reader.Err(); err != nil {
 		return nil, err
 	}
-	return txn.Commit(ctx)
+	if staged.Table.Metadata().Version() >= 3 {
+		nextRowID := staged.Table.Metadata().NextRowID()
+		for i, file := range dataFiles {
+			dataFiles[i], err = withDataFileFirstRowID(file, staged.Table, nextRowID)
+			if err != nil {
+				return nil, err
+			}
+			nextRowID += file.Count()
+		}
+	}
+	if len(dataFilesToDelete) == 0 && len(deleteFilesToRemove) == 0 && len(dataFiles) == 0 {
+		empty, emptyErr := array.NewRecordReader(reader.Schema(), nil)
+		if emptyErr != nil {
+			return nil, fmt.Errorf("iceberg: failed to create empty replace reader: %w", emptyErr)
+		}
+		defer empty.Release()
+		if err := txn.Append(ctx, empty, props); err != nil {
+			return nil, err
+		}
+	} else if err := txn.ReplaceFiles(
+		ctx,
+		dataFilesToDelete,
+		dataFiles,
+		deleteFilesToRemove,
+		props,
+		icebergtable.WithoutDuplicateCheck(),
+	); err != nil {
+		return nil, err
+	}
+	if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+		return nil, err
+	}
+	committedTable, err = txn.Commit(ctx)
+	if err != nil {
+		cleanupSafe = errors.Is(err, icebergtable.ErrCommitFailed)
+		return nil, err
+	}
+	committed = true
+	return committedTable, nil
+}
+
+func liveFilesForReplace(ctx context.Context, tbl *icebergtable.Table) ([]iceberggo.DataFile, []iceberggo.DataFile, error) {
+	snapshot := tbl.CurrentSnapshot()
+	if snapshot == nil {
+		return nil, nil, nil
+	}
+	fs, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("iceberg: failed to load table file IO for replace: %w", err)
+	}
+	manifests, err := snapshot.Manifests(fs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("iceberg: failed to load current manifests for replace: %w", err)
+	}
+	dataFiles := make([]iceberggo.DataFile, 0)
+	deleteFiles := make([]iceberggo.DataFile, 0)
+	seen := make(map[string]struct{})
+	for _, manifest := range manifests {
+		for entry, entryErr := range manifest.Entries(fs, true) {
+			if entryErr != nil {
+				return nil, nil, fmt.Errorf("iceberg: failed to read current manifest for replace: %w", entryErr)
+			}
+			file := entry.DataFile()
+			if _, ok := seen[file.FilePath()]; ok {
+				continue
+			}
+			seen[file.FilePath()] = struct{}{}
+			if file.ContentType() == iceberggo.EntryContentData {
+				dataFiles = append(dataFiles, file)
+			} else {
+				deleteFiles = append(deleteFiles, file)
+			}
+		}
+	}
+	return dataFiles, deleteFiles, nil
+}
+
+func (d *Destination) updateExistingPartitionSpec(ctx context.Context, tbl *icebergtable.Table, partitionBy string) error {
+	if partitionExpressionMatches(tbl, partitionBy) {
+		return nil
+	}
+	txn := tbl.NewTransaction()
+	if _, err := d.stagePartitionSpecUpdate(txn, tbl, partitionBy); err != nil {
+		return err
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return fmt.Errorf("iceberg: failed to commit partition spec update: %w", err)
+	}
+	return nil
 }
 
 func (d *Destination) ensureNamespace(ctx context.Context, namespace icebergtable.Identifier) error {
-	if len(namespace) == 0 || !d.cfg.CreateNamespace {
+	if len(namespace) == 0 {
+		return nil
+	}
+	if d.cfg.Properties.Get("type", "") == "hive" && len(namespace) != 1 {
+		return fmt.Errorf("iceberg: Hive catalog requires a single-level namespace, got %s", strings.Join(namespace, "."))
+	}
+	if !d.cfg.CreateNamespace {
 		return nil
 	}
 	for i := 1; i <= len(namespace); i++ {
@@ -400,7 +1166,13 @@ func (d *Destination) ensureNamespace(ctx context.Context, namespace icebergtabl
 		if exists {
 			continue
 		}
-		if err := d.catalog.CreateNamespace(ctx, current, iceberggo.Properties{}); err != nil && !errors.Is(err, icebergcatalog.ErrNamespaceAlreadyExists) {
+		properties := iceberggo.Properties{}
+		if d.cfg.Properties.Get("type", "") == "hive" {
+			if warehouse := d.cfg.Properties.Get("warehouse", ""); warehouse != "" {
+				properties["location"] = appendLocationPath(warehouse, strings.Join(current, "/"), false)
+			}
+		}
+		if err := d.catalog.CreateNamespace(ctx, current, properties); err != nil && !errors.Is(err, icebergcatalog.ErrNamespaceAlreadyExists) {
 			return fmt.Errorf("iceberg: failed to create namespace %s: %w", strings.Join(current, "."), err)
 		}
 	}
@@ -497,6 +1269,13 @@ func localFilesystemPath(location string) (string, bool) {
 	if location == "" {
 		return "", false
 	}
+	if strings.HasPrefix(strings.ToLower(location), "file:") {
+		parsed, err := url.Parse(location)
+		if err != nil || parsed.Scheme != "file" || parsed.Path == "" {
+			return "", false
+		}
+		return parsed.Path, true
+	}
 	if !strings.Contains(location, "://") {
 		return location, true
 	}
@@ -562,24 +1341,4 @@ func identifierFieldsEqual(iceSchema *iceberggo.Schema, primaryKeys []string, al
 		}
 	}
 	return true
-}
-
-func partitionSpecMatches(tbl *icebergtable.Table, partitionBy string) bool {
-	spec := tbl.Metadata().PartitionSpec()
-	fields := make([]iceberggo.PartitionField, 0)
-	for _, field := range spec.Fields() {
-		fields = append(fields, field)
-	}
-	if partitionBy == "" {
-		return len(fields) == 0
-	}
-	if len(fields) != 1 {
-		return false
-	}
-	sourceField, ok := tbl.Schema().FindFieldByName(partitionBy)
-	if !ok {
-		return false
-	}
-	field := fields[0]
-	return field.SourceID() == sourceField.ID && field.Transform.Equals(iceberggo.IdentityTransform{})
 }

--- a/pkg/destination/iceberg/incarnation.go
+++ b/pkg/destination/iceberg/incarnation.go
@@ -1,0 +1,37 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	icebergtable "github.com/apache/iceberg-go/table"
+)
+
+func (d *Destination) validateExpectedIncarnation(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	expected string,
+) error {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return nil
+	}
+	if actual := tbl.Metadata().TableUUID().String(); actual != expected {
+		return fmt.Errorf(
+			"iceberg: target incarnation changed for %s: expected UUID %s, got %s",
+			strings.Join(tbl.Identifier(), "."), expected, actual,
+		)
+	}
+	current, err := d.catalog.LoadTable(ctx, tbl.Identifier())
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to validate target incarnation for %s: %w", strings.Join(tbl.Identifier(), "."), err)
+	}
+	if actual := current.Metadata().TableUUID().String(); actual != expected {
+		return fmt.Errorf(
+			"iceberg: target incarnation changed for %s: expected UUID %s, got %s",
+			strings.Join(tbl.Identifier(), "."), expected, actual,
+		)
+	}
+	return nil
+}

--- a/pkg/destination/iceberg/lifecycle.go
+++ b/pkg/destination/iceberg/lifecycle.go
@@ -1,0 +1,1007 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+)
+
+const (
+	managedTableProperty       = "ingestr.managed"
+	managedTableKindProperty   = "ingestr.managed-kind"
+	managedTableKindStaging    = "staging"
+	managedTableExpiresAt      = "ingestr.expires-at"
+	managedTableExpiresAfterMS = "ingestr.expires-after-ms"
+	managedTablePurgeClaim     = "ingestr.purge-claim"
+	gcEnabledProperty          = "gc.enabled"
+	deletionFenceTablePrefix   = "ingestr_deleting_"
+
+	clientSidePurgeTimeout     = 30 * time.Minute
+	clientSidePurgeMaxAttempts = 6
+)
+
+// ExpiredTableCleanupResult reports catalog entries that were physically
+// purged by CleanupExpiredManagedTables. A table is eligible only when it was
+// explicitly marked as managed by ingestr and its persisted deadline passed.
+type ExpiredTableCleanupResult struct {
+	Purged []string
+}
+
+func lifecycleProperties(base iceberggo.Properties, expiresAfter time.Duration, now time.Time) (iceberggo.Properties, error) {
+	props := maps.Clone(base)
+	if props == nil {
+		props = iceberggo.Properties{}
+	}
+	if expiresAfter < 0 {
+		return nil, fmt.Errorf("iceberg: table expiration must not be negative: %s", expiresAfter)
+	}
+	if expiresAfter == 0 {
+		return props, nil
+	}
+
+	props[managedTableProperty] = "true"
+	props[managedTableKindProperty] = managedTableKindStaging
+	props[managedTableExpiresAt] = now.UTC().Add(expiresAfter).Format(time.RFC3339Nano)
+	props[managedTableExpiresAfterMS] = strconv.FormatInt(expiresAfter.Milliseconds(), 10)
+	delete(props, managedTablePurgeClaim)
+	// ExpiresAfter means the caller explicitly handed lifecycle ownership to
+	// ingestr. Force GC on so dropping the managed table cannot silently leave
+	// its data and metadata behind because of a generic URI table property.
+	props[gcEnabledProperty] = "true"
+	return props, nil
+}
+
+func lifecyclePropertiesForCreate(base iceberggo.Properties, expiresAfter time.Duration) (iceberggo.Properties, error) {
+	return lifecycleProperties(base, expiresAfter, time.Now())
+}
+
+func managedTableExpiration(props iceberggo.Properties) (time.Time, bool, error) {
+	managed, err := strconv.ParseBool(props.Get(managedTableProperty, "false"))
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("invalid %s property %q: %w", managedTableProperty, props[managedTableProperty], err)
+	}
+	if !managed {
+		return time.Time{}, false, nil
+	}
+
+	raw := strings.TrimSpace(props[managedTableExpiresAt])
+	if raw == "" {
+		return time.Time{}, false, fmt.Errorf("managed table is missing %s", managedTableExpiresAt)
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("invalid %s property %q: %w", managedTableExpiresAt, raw, err)
+	}
+	return expiresAt, true, nil
+}
+
+// prepareExistingTableLifecycle purges a stale managed table before it can be
+// reused and refreshes the persisted lease on a live managed table. It returns
+// true when an expired table was removed and must be recreated.
+func (d *Destination) prepareExistingTableLifecycle(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	expiresAfter time.Duration,
+	now time.Time,
+) (bool, error) {
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if isMissingTableOrNamespace(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("iceberg: failed to load table %s for lifecycle check: %w", strings.Join(ident, "."), err)
+	}
+	if err := validateIsolatedTableFilePaths(tbl.Properties()); err != nil {
+		return false, fmt.Errorf("iceberg: table %s: %w", strings.Join(ident, "."), err)
+	}
+
+	expiresAt, managed, err := managedTableExpiration(tbl.Properties())
+	if err != nil {
+		return false, fmt.Errorf("iceberg: table %s: %w", strings.Join(ident, "."), err)
+	}
+	if managed && !now.Before(expiresAt) {
+		purged, err := d.purgeExpiredManagedTable(ctx, ident, now)
+		if err != nil {
+			return false, err
+		}
+		return purged, nil
+	}
+	if expiresAfter == 0 {
+		return false, nil
+	}
+	if !managed {
+		return false, fmt.Errorf(
+			"iceberg: refusing to claim existing unmanaged table %s as managed staging data",
+			strings.Join(ident, "."),
+		)
+	}
+
+	desired, err := lifecycleProperties(nil, expiresAfter, now)
+	if err != nil {
+		return false, err
+	}
+	updates := iceberggo.Properties{}
+	for key, value := range desired {
+		if tbl.Properties()[key] != value {
+			updates[key] = value
+		}
+	}
+	if len(updates) == 0 {
+		return false, nil
+	}
+	txn := tbl.NewTransaction()
+	if err := txn.SetProperties(updates); err != nil {
+		return false, fmt.Errorf("iceberg: failed to stage lifecycle properties for table %s: %w", strings.Join(ident, "."), err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return false, fmt.Errorf("iceberg: failed to persist lifecycle properties for table %s: %w", strings.Join(ident, "."), err)
+	}
+	return false, nil
+}
+
+func (d *Destination) prepareExistingTableLifecycleNow(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	expiresAfter time.Duration,
+) (bool, error) {
+	return d.prepareExistingTableLifecycle(ctx, ident, expiresAfter, time.Now())
+}
+
+func (d *Destination) refreshManagedTableLease(ctx context.Context, tbl *icebergtable.Table, now time.Time) error {
+	expiresAt, ttl, managed, err := managedTableLease(tbl.Properties())
+	if err != nil || !managed {
+		return err
+	}
+	if claim := strings.TrimSpace(tbl.Properties()[managedTablePurgeClaim]); claim != "" {
+		return fmt.Errorf("managed table %s has been claimed for purge at %s", strings.Join(tbl.Identifier(), "."), claim)
+	}
+	if now.Add(ttl / 2).Before(expiresAt) {
+		return nil
+	}
+	_, err = commitManagedTableLease(ctx, tbl, now, ttl)
+	return err
+}
+
+func managedTableLease(props iceberggo.Properties) (time.Time, time.Duration, bool, error) {
+	expiresAt, managed, err := managedTableExpiration(props)
+	if err != nil || !managed {
+		return expiresAt, 0, managed, err
+	}
+	rawTTL := strings.TrimSpace(props[managedTableExpiresAfterMS])
+	ttlMS, err := strconv.ParseInt(rawTTL, 10, 64)
+	if err != nil {
+		return time.Time{}, 0, false, fmt.Errorf("invalid %s property %q: %w", managedTableExpiresAfterMS, rawTTL, err)
+	}
+	if ttlMS <= 0 {
+		return time.Time{}, 0, false, fmt.Errorf("invalid %s property %q: must be positive", managedTableExpiresAfterMS, rawTTL)
+	}
+	const maxDurationMilliseconds = int64(1<<63-1) / int64(time.Millisecond)
+	if ttlMS > maxDurationMilliseconds {
+		return time.Time{}, 0, false, fmt.Errorf("invalid %s property %q: duration overflows", managedTableExpiresAfterMS, rawTTL)
+	}
+	return expiresAt, time.Duration(ttlMS) * time.Millisecond, true, nil
+}
+
+func commitManagedTableLease(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	now time.Time,
+	ttl time.Duration,
+) (*icebergtable.Table, error) {
+	txn := tbl.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		managedTableExpiresAt: now.UTC().Add(ttl).Format(time.RFC3339Nano),
+	}); err != nil {
+		return nil, err
+	}
+	return txn.Commit(ctx)
+}
+
+func (d *Destination) renewManagedTableLease(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	now time.Time,
+) (*icebergtable.Table, error) {
+	const maxAttempts = 5
+	var commitErr error
+	for range maxAttempts {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return nil, err
+		}
+		_, ttl, managed, err := managedTableLease(tbl.Properties())
+		if err != nil {
+			return nil, err
+		}
+		if !managed {
+			return tbl, nil
+		}
+		if claim := strings.TrimSpace(tbl.Properties()[managedTablePurgeClaim]); claim != "" {
+			return nil, fmt.Errorf("managed table %s has been claimed for purge at %s", strings.Join(ident, "."), claim)
+		}
+		committed, err := commitManagedTableLease(ctx, tbl, now, ttl)
+		if err == nil {
+			return committed, nil
+		}
+		commitErr = err
+		if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("failed to refresh managed table %s lease after concurrent commits: %w", strings.Join(ident, "."), commitErr)
+}
+
+type managedLeaseHeartbeat struct {
+	destination *Destination
+	ident       icebergtable.Identifier
+	cancel      context.CancelFunc
+	done        chan struct{}
+	stopOnce    sync.Once
+	errMu       sync.Mutex
+	err         error
+}
+
+func (d *Destination) startManagedTableLeaseHeartbeat(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+) (*managedLeaseHeartbeat, error) {
+	return d.startManagedTableLeaseHeartbeatWithCancel(ctx, tbl, nil)
+}
+
+func (d *Destination) startManagedTableLeaseHeartbeatWithCancel(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	cancelOwner context.CancelFunc,
+) (*managedLeaseHeartbeat, error) {
+	_, _, managed, err := managedTableLease(tbl.Properties())
+	if err != nil || !managed {
+		return nil, err
+	}
+	tbl, err = d.renewManagedTableLease(ctx, tbl.Identifier(), time.Now())
+	if err != nil {
+		return nil, err
+	}
+	_, ttl, _, err := managedTableLease(tbl.Properties())
+	if err != nil {
+		return nil, err
+	}
+	interval := ttl / 4
+	if d.leaseHeartbeatInterval > 0 {
+		interval = d.leaseHeartbeatInterval
+	}
+	if interval < time.Millisecond {
+		interval = time.Millisecond
+	}
+
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	heartbeat := &managedLeaseHeartbeat{
+		destination: d,
+		ident:       slices.Clone(tbl.Identifier()),
+		cancel:      cancel,
+		done:        make(chan struct{}),
+	}
+	go func() {
+		defer close(heartbeat.done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case now := <-ticker.C:
+				if _, err := d.renewManagedTableLease(heartbeatCtx, heartbeat.ident, now); err != nil && heartbeatCtx.Err() == nil {
+					heartbeat.errMu.Lock()
+					heartbeat.err = err
+					heartbeat.errMu.Unlock()
+					if cancelOwner != nil {
+						cancelOwner()
+					}
+					return
+				}
+			}
+		}
+	}()
+	return heartbeat, nil
+}
+
+func (h *managedLeaseHeartbeat) stop() {
+	if h == nil {
+		return
+	}
+	h.stopOnce.Do(func() {
+		h.cancel()
+		<-h.done
+	})
+}
+
+func (h *managedLeaseHeartbeat) stopAndRefresh(ctx context.Context) (*icebergtable.Table, error) {
+	h.stop()
+	h.errMu.Lock()
+	err := h.err
+	h.errMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return h.destination.renewManagedTableLease(ctx, h.ident, time.Now())
+}
+
+func (d *Destination) dropTableWithLifecycle(ctx context.Context, ident icebergtable.Identifier) (retErr error) {
+	return d.dropTableWithLifecycleExpected(ctx, ident, "", nil)
+}
+
+func (d *Destination) dropTableWithLifecycleExpected(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	expectedUUID string,
+	validate func(*icebergtable.Table) error,
+) (retErr error) {
+	defer func() {
+		if retErr == nil {
+			d.forgetPreparedTable(ident)
+		}
+	}()
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if isMissingTableOrNamespace(err) {
+			if d.usesServerManagedPurge() {
+				return d.reconcileMissingServerManagedPurge(ctx, ident)
+			}
+			return d.resumePurgeJournal(ctx, ident)
+		}
+		return fmt.Errorf("iceberg: failed to load table %s before drop: %w", strings.Join(ident, "."), err)
+	}
+	if expectedUUID != "" && tbl.Metadata().TableUUID().String() != expectedUUID {
+		return fmt.Errorf("iceberg: refused to drop replaced table %s: UUID changed from %s to %s", strings.Join(ident, "."), expectedUUID, tbl.Metadata().TableUUID())
+	}
+	if validate != nil {
+		if err := validate(tbl); err != nil {
+			return err
+		}
+	}
+
+	_, managed, err := managedTableExpiration(tbl.Properties())
+	if err != nil {
+		return fmt.Errorf("iceberg: table %s: %w", strings.Join(ident, "."), err)
+	}
+	if !managed {
+		if d.catalog.CatalogType() == icebergcatalog.Hadoop {
+			return fmt.Errorf("iceberg: cannot drop unmanaged Hadoop table %s without deleting its physical table root", strings.Join(ident, "."))
+		}
+		claimed, err := d.claimTableForDeletion(ctx, tbl, expectedUUID, validate)
+		if err != nil {
+			return err
+		}
+		if err := d.catalog.DropTable(ctx, claimed.Identifier()); err != nil && !isMissingTableOrNamespace(err) {
+			restoreErr := d.restoreDeletionClaim(context.WithoutCancel(ctx), claimed, ident)
+			return errors.Join(fmt.Errorf("iceberg: failed to drop unmanaged table %s: %w", strings.Join(ident, "."), err), restoreErr)
+		}
+		return nil
+	}
+	if !strings.EqualFold(tbl.Properties().Get(gcEnabledProperty, "true"), "true") {
+		txn := tbl.NewTransaction()
+		if err := txn.SetProperties(iceberggo.Properties{gcEnabledProperty: "true"}); err != nil {
+			return fmt.Errorf("iceberg: failed to enable physical purge for table %s: %w", strings.Join(ident, "."), err)
+		}
+		if _, err := txn.Commit(ctx); err != nil {
+			return fmt.Errorf("iceberg: failed to commit physical purge setting for table %s: %w", strings.Join(ident, "."), err)
+		}
+	}
+	if err := d.validateOrphanCleanupIsolation(ctx, tbl); err != nil {
+		return fmt.Errorf("iceberg: refused to purge managed table %s: %w", strings.Join(ident, "."), err)
+	}
+	if expectedUUID == "" {
+		expectedUUID = tbl.Metadata().TableUUID().String()
+	}
+	return d.purgeLoadedTableExpected(ctx, tbl, expectedUUID, validate)
+}
+
+func (d *Destination) forgetPreparedTable(ident icebergtable.Identifier) {
+	d.mu.Lock()
+	delete(d.prepared, strings.Join(ident, "."))
+	d.mu.Unlock()
+}
+
+func deletionFenceIdentifier(ident icebergtable.Identifier) icebergtable.Identifier {
+	fenced := append(icebergtable.Identifier(nil), ident...)
+	fenced[len(fenced)-1] = deletionFenceTablePrefix + strings.ReplaceAll(uuid.NewString(), "-", "")
+	return fenced
+}
+
+func (d *Destination) claimTableForDeletion(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	expectedUUID string,
+	validate func(*icebergtable.Table) error,
+) (*icebergtable.Table, error) {
+	return d.claimTableForDeletionAt(ctx, tbl, expectedUUID, validate, deletionFenceIdentifier(tbl.Identifier()))
+}
+
+func (d *Destination) claimTableForDeletionAt(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	expectedUUID string,
+	validate func(*icebergtable.Table) error,
+	fencedIdent icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	ident := tbl.Identifier()
+	if expectedUUID == "" {
+		expectedUUID = tbl.Metadata().TableUUID().String()
+	}
+	if d.cfg.Properties.Get("type", "") == "hadoop" {
+		return d.claimHadoopTableForDeletion(ctx, tbl, fencedIdent, expectedUUID, validate)
+	}
+	switch d.catalog.CatalogType() {
+	case icebergcatalog.SQL, icebergcatalog.REST, icebergcatalog.Hive, icebergcatalog.Hadoop:
+	default:
+		return nil, fmt.Errorf("iceberg: catalog type %s cannot provide an atomic deletion fence for %s; refusing deletion", d.catalog.CatalogType(), strings.Join(ident, "."))
+	}
+	_, renameErr := d.catalog.RenameTable(ctx, ident, fencedIdent)
+	var claimed *icebergtable.Table
+	if renameErr != nil {
+		// A remote rename can commit despite a lost response. Only accept that
+		// outcome when the isolated identifier resolves to the expected UUID.
+		var loadErr error
+		claimed, loadErr = d.catalog.LoadTable(context.WithoutCancel(ctx), fencedIdent)
+		if loadErr != nil || claimed.Metadata().TableUUID().String() != expectedUUID {
+			return nil, errors.Join(
+				fmt.Errorf("iceberg: catalog cannot provide a server-enforced deletion fence for %s: %w", strings.Join(ident, "."), renameErr),
+				loadErr,
+			)
+		}
+	} else {
+		// Reload through the active catalog wrapper so filesystem/authentication
+		// behavior remains identical to a normal table load.
+		claimed, renameErr = d.catalog.LoadTable(ctx, fencedIdent)
+		if renameErr != nil {
+			return nil, fmt.Errorf("iceberg: failed to load fenced table %s after catalog rename: %w", strings.Join(fencedIdent, "."), renameErr)
+		}
+	}
+	if claimed == nil || claimed.Metadata().TableUUID().String() != expectedUUID {
+		actual := "<unknown>"
+		if claimed != nil {
+			actual = claimed.Metadata().TableUUID().String()
+		}
+		restoreErr := d.restoreDeletionClaim(context.WithoutCancel(ctx), claimed, ident)
+		return nil, errors.Join(
+			fmt.Errorf("iceberg: refused to delete replaced table %s: UUID changed from %s to %s", strings.Join(ident, "."), expectedUUID, actual),
+			restoreErr,
+		)
+	}
+	if validate != nil {
+		if err := validate(claimed); err != nil {
+			return nil, errors.Join(err, d.restoreDeletionClaim(context.WithoutCancel(ctx), claimed, ident))
+		}
+	}
+	return claimed, nil
+}
+
+func (d *Destination) claimHadoopTableForDeletion(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	fencedIdent icebergtable.Identifier,
+	expectedUUID string,
+	validate func(*icebergtable.Table) error,
+) (*icebergtable.Table, error) {
+	originalPath, ok := localFilesystemPath(tbl.Location())
+	if !ok {
+		return nil, fmt.Errorf("iceberg: Hadoop catalog cannot provide a server-enforced deletion fence for non-local table %s", strings.Join(tbl.Identifier(), "."))
+	}
+	fencedPath := filepath.Join(filepath.Dir(originalPath), fencedIdent[len(fencedIdent)-1])
+	if err := os.Rename(originalPath, fencedPath); err != nil {
+		return nil, fmt.Errorf("iceberg: failed to atomically fence Hadoop table %s for deletion: %w", strings.Join(tbl.Identifier(), "."), err)
+	}
+	claimed, err := d.catalog.LoadTable(ctx, fencedIdent)
+	if err == nil && claimed.Metadata().TableUUID().String() == expectedUUID {
+		if validate == nil {
+			return claimed, nil
+		}
+		if validationErr := validate(claimed); validationErr == nil {
+			return claimed, nil
+		} else {
+			err = validationErr
+		}
+	} else if err == nil {
+		err = fmt.Errorf("UUID changed from %s to %s", expectedUUID, claimed.Metadata().TableUUID())
+	}
+	restoreErr := os.Rename(fencedPath, originalPath)
+	return nil, errors.Join(fmt.Errorf("iceberg: refused fenced Hadoop deletion for %s: %w", strings.Join(tbl.Identifier(), "."), err), restoreErr)
+}
+
+func (d *Destination) restoreDeletionClaim(
+	ctx context.Context,
+	claimed *icebergtable.Table,
+	original icebergtable.Identifier,
+) error {
+	if claimed == nil {
+		return nil
+	}
+	if d.cfg.Properties.Get("type", "") == "hadoop" {
+		originalPath, ok := localFilesystemPath(claimed.Location())
+		if !ok {
+			return fmt.Errorf("iceberg: cannot restore non-local Hadoop deletion fence for %s", strings.Join(original, "."))
+		}
+		fencedPath := filepath.Join(filepath.Dir(originalPath), claimed.Identifier()[len(claimed.Identifier())-1])
+		if err := os.Rename(fencedPath, originalPath); err != nil {
+			return fmt.Errorf("iceberg: failed to restore Hadoop deletion fence for %s: %w", strings.Join(original, "."), err)
+		}
+		return nil
+	}
+	current, err := d.catalog.LoadTable(ctx, claimed.Identifier())
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to inspect fenced table before restoring %s: %w", strings.Join(original, "."), err)
+	}
+	if current.Metadata().TableUUID() != claimed.Metadata().TableUUID() {
+		return fmt.Errorf("iceberg: refused to restore deletion fence for %s because fenced UUID changed", strings.Join(original, "."))
+	}
+	if _, err := d.catalog.RenameTable(ctx, claimed.Identifier(), original); err != nil {
+		return fmt.Errorf("iceberg: failed to restore deletion fence for %s: %w", strings.Join(original, "."), err)
+	}
+	return nil
+}
+
+func (d *Destination) applyConfiguredTableProperties(ctx context.Context, tbl *icebergtable.Table) (*icebergtable.Table, error) {
+	updates := iceberggo.Properties{}
+	for key, value := range d.cfg.TableProperties {
+		if key == icebergtable.PropertyFormatVersion {
+			continue
+		}
+		if tbl.Properties()[key] != value {
+			updates[key] = value
+		}
+	}
+	if len(updates) == 0 {
+		return tbl, nil
+	}
+	txn := tbl.NewTransaction()
+	if err := txn.SetProperties(updates); err != nil {
+		return nil, fmt.Errorf("iceberg: failed to stage table properties for %s: %w", strings.Join(tbl.Identifier(), "."), err)
+	}
+	updated, err := txn.Commit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to commit table properties for %s: %w", strings.Join(tbl.Identifier(), "."), err)
+	}
+	return updated, nil
+}
+
+func (d *Destination) purgeExpiredManagedTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	now time.Time,
+) (bool, error) {
+	tableName := strings.Join(ident, ".")
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if isMissingTableOrNamespace(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("iceberg: failed to load managed table %s for expiration check: %w", tableName, err)
+	}
+	expiresAt, managed, err := managedTableExpiration(tbl.Properties())
+	if err != nil {
+		return false, fmt.Errorf("iceberg: table %s: %w", tableName, err)
+	}
+	if !managed || now.Before(expiresAt) {
+		return false, nil
+	}
+	if err := d.validateOrphanCleanupIsolation(ctx, tbl); err != nil {
+		return false, fmt.Errorf("iceberg: refused to purge managed table %s: %w", tableName, err)
+	}
+
+	claimed, eligible, err := d.claimExpiredManagedTable(ctx, ident, now)
+	if err != nil || !eligible {
+		return false, err
+	}
+	if err := d.purgeLoadedTable(ctx, claimed); err != nil {
+		return false, err
+	}
+	d.forgetPreparedTable(ident)
+	return true, nil
+}
+
+func (d *Destination) claimExpiredManagedTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	now time.Time,
+) (*icebergtable.Table, bool, error) {
+	const maxAttempts = 5
+	var commitErr error
+	for range maxAttempts {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			if isMissingTableOrNamespace(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		expiresAt, managed, err := managedTableExpiration(tbl.Properties())
+		if err != nil {
+			return nil, false, err
+		}
+		if !managed || now.Before(expiresAt) {
+			return nil, false, nil
+		}
+		if rawClaim := strings.TrimSpace(tbl.Properties()[managedTablePurgeClaim]); rawClaim != "" {
+			claimedAt, parseErr := time.Parse(time.RFC3339Nano, rawClaim)
+			if parseErr != nil || now.Before(claimedAt.Add(purgeResumeClaimTTL)) {
+				return tbl, false, nil
+			}
+		}
+
+		txn := tbl.NewTransaction()
+		if err := txn.SetProperties(iceberggo.Properties{
+			managedTablePurgeClaim: now.UTC().Format(time.RFC3339Nano),
+		}); err != nil {
+			return nil, false, err
+		}
+		claimed, err := txn.Commit(ctx)
+		if err == nil {
+			return claimed, true, nil
+		}
+		commitErr = err
+		if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			return nil, false, err
+		}
+	}
+	return nil, false, fmt.Errorf("failed to claim managed table %s for purge after concurrent commits: %w", strings.Join(ident, "."), commitErr)
+}
+
+func (d *Destination) purgeLoadedTable(ctx context.Context, tbl *icebergtable.Table) error {
+	return d.purgeLoadedTableExpected(ctx, tbl, tbl.Metadata().TableUUID().String(), nil)
+}
+
+func (d *Destination) purgeLoadedTableExpected(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	expectedUUID string,
+	validate func(*icebergtable.Table) error,
+) error {
+	ident := tbl.Identifier()
+	tableName := strings.Join(ident, ".")
+	if d.usesServerManagedPurge() {
+		return d.purgeServerManagedTable(ctx, tbl, expectedUUID, validate)
+	}
+	if err := d.resumePurgeJournal(ctx, ident); err != nil {
+		return fmt.Errorf("iceberg: cannot begin purge for table %s while prior purge recovery is active: %w", tableName, err)
+	}
+	journal, tableFS, journalFS, journalPath, lockToken, err := d.createPurgeJournal(ctx, tbl)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to prepare durable physical purge for table %s: %w", tableName, err)
+	}
+	claimed, err := d.claimTableForDeletionAt(ctx, tbl, expectedUUID, validate, journal.DeletionIdentifiers[0])
+	if err != nil {
+		cleanupErr := d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, journal.TableUUID, lockToken)
+		if cleanupErr == nil {
+			cleanupErr = removePurgeJournal(journalFS, journalPath)
+		}
+		return errors.Join(
+			fmt.Errorf("iceberg: failed to claim table %s for fenced catalog deletion", tableName),
+			err,
+			cleanupErr,
+		)
+	}
+	deleteIdent := claimed.Identifier()
+
+	if d.catalog.CatalogType() == icebergcatalog.REST {
+		purger, ok := d.catalog.(icebergcatalog.PurgeableTable)
+		if !ok {
+			return fmt.Errorf("iceberg: REST catalog cannot safely purge managed table %s", tableName)
+		}
+		if err := purger.PurgeTable(ctx, deleteIdent); err != nil && !isMissingTableOrNamespace(err) {
+			// Do not retry with DropTable here. A remote purge may have committed
+			// despite a lost response.
+			return d.reconcileFailedCatalogPurge(ctx, tbl, claimed, journalFS, journalPath, lockToken,
+				fmt.Errorf("iceberg: failed to purge managed table %s: %w", tableName, err))
+		}
+	} else if d.catalog.CatalogType() == icebergcatalog.Hadoop {
+		if err := d.catalog.DropTable(ctx, deleteIdent); err != nil && !isMissingTableOrNamespace(err) {
+			return d.reconcileFailedCatalogPurge(ctx, tbl, claimed, journalFS, journalPath, lockToken,
+				fmt.Errorf("iceberg: failed to drop managed table %s before physical purge: %w", tableName, err))
+		}
+	} else if err := d.catalog.DropTable(ctx, deleteIdent); err != nil {
+		if !isMissingTableOrNamespace(err) {
+			// The catalog mutation may have an unknown outcome. Deleting files in
+			// that state can corrupt a table whose catalog entry still exists.
+			return d.reconcileFailedCatalogPurge(ctx, tbl, claimed, journalFS, journalPath, lockToken,
+				fmt.Errorf("iceberg: failed to drop managed table %s before physical purge: %w", tableName, err))
+		}
+	}
+
+	if err := executePurgeJournal(ctx, d, tableFS, journalFS, journalPath, journal, lockToken); err != nil {
+		if claimErr := d.relinquishPurgeClaim(context.WithoutCancel(ctx), ident, journal.TableUUID, lockToken); claimErr != nil {
+			return errors.Join(
+				fmt.Errorf("iceberg: dropped managed table %s but failed to purge physical files: %w", tableName, err),
+				fmt.Errorf("iceberg: failed to relinquish purge recovery claim: %w", claimErr),
+			)
+		}
+		return fmt.Errorf("iceberg: dropped managed table %s but failed to purge physical files: %w", tableName, err)
+	}
+	return nil
+}
+
+func (d *Destination) purgeServerManagedTable(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	expectedUUID string,
+	validate func(*icebergtable.Table) error,
+) error {
+	ident := tbl.Identifier()
+	tableName := strings.Join(ident, ".")
+	tableUUID := tbl.Metadata().TableUUID().String()
+	lockToken, err := d.acquirePurgeLock(ctx, ident, tableUUID)
+	if err != nil {
+		lock, loadErr := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+		if loadErr != nil {
+			return fmt.Errorf("iceberg: failed to inspect prior server-managed purge for table %s: %w", tableName, err)
+		}
+		lockedUUID := lock.Properties()[purgeLockTableUUIDKey]
+		if validationErr := validatePurgeLock(lock, ident, lockedUUID); validationErr != nil {
+			return validationErr
+		}
+		lockToken, loadErr = d.claimPurgeResume(ctx, ident, lockedUUID)
+		if loadErr != nil {
+			return fmt.Errorf("iceberg: failed to claim prior server-managed purge for table %s: %w", tableName, loadErr)
+		}
+		if lockedUUID != tableUUID {
+			if releaseErr := d.releasePurgeLockOwned(ctx, ident, lockedUUID, lockToken); releaseErr != nil {
+				return fmt.Errorf("iceberg: refused stale purge for recreated table %s and failed to release its old ownership lock: %w", tableName, releaseErr)
+			}
+			return fmt.Errorf("iceberg: refused stale purge for recreated table %s: table UUID changed from %s to %s", tableName, lockedUUID, tableUUID)
+		}
+	}
+	purger, ok := d.catalog.(icebergcatalog.PurgeableTable)
+	if !ok {
+		_ = d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, tableUUID, lockToken)
+		return fmt.Errorf("iceberg: managed REST catalog cannot safely purge table %s", tableName)
+	}
+	if err := d.renewPurgeLock(ctx, ident, tableUUID, lockToken); err != nil {
+		return fmt.Errorf("iceberg: failed to renew server-managed purge fence for table %s: %w", tableName, err)
+	}
+	liveBeforePurge, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		if isMissingTableOrNamespace(err) {
+			if releaseErr := d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, tableUUID, lockToken); releaseErr != nil {
+				return releaseErr
+			}
+			return nil
+		}
+		return fmt.Errorf("iceberg: failed to revalidate table %s immediately before purge: %w", tableName, err)
+	}
+	if liveBeforePurge.Metadata().TableUUID().String() != tableUUID {
+		if releaseErr := d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, tableUUID, lockToken); releaseErr != nil {
+			return errors.Join(fmt.Errorf("iceberg: refused server-managed purge for recreated table %s", tableName), releaseErr)
+		}
+		return fmt.Errorf("iceberg: refused server-managed purge for recreated table %s: table UUID changed from %s to %s", tableName, tableUUID, liveBeforePurge.Metadata().TableUUID())
+	}
+	claimed, err := d.claimTableForDeletion(ctx, liveBeforePurge, expectedUUID, validate)
+	if err != nil {
+		if releaseErr := d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, tableUUID, lockToken); releaseErr != nil {
+			return errors.Join(err, releaseErr)
+		}
+		return err
+	}
+	purgeCtx, cancelPurge := context.WithCancel(ctx)
+	heartbeat := d.startCatalogLockHeartbeat(purgeCtx, ident, purgeLockModePurge, tableUUID, lockToken, purgeResumeClaimTTL, cancelPurge)
+	purgeErr := purger.PurgeTable(purgeCtx, claimed.Identifier())
+	heartbeatErr := heartbeat.stop()
+	cancelPurge()
+	if heartbeatErr != nil {
+		var restoreErr error
+		if live, loadErr := d.catalog.LoadTable(context.WithoutCancel(ctx), claimed.Identifier()); loadErr == nil &&
+			live.Metadata().TableUUID().String() == tableUUID {
+			restoreErr = d.restoreDeletionClaim(context.WithoutCancel(ctx), live, ident)
+		}
+		return errors.Join(fmt.Errorf("iceberg: server-managed purge lock heartbeat failed for table %s", tableName), heartbeatErr, purgeErr, restoreErr)
+	}
+	if purgeErr == nil || isMissingTableOrNamespace(purgeErr) {
+		if err := d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, tableUUID, lockToken); err != nil {
+			return fmt.Errorf("iceberg: server-managed purge completed for table %s but its ownership lock could not be released: %w", tableName, err)
+		}
+		return nil
+	}
+	live, loadErr := d.catalog.LoadTable(ctx, claimed.Identifier())
+	if loadErr == nil && live.Metadata().TableUUID().String() == tableUUID {
+		if restoreErr := d.restoreDeletionClaim(context.WithoutCancel(ctx), live, ident); restoreErr != nil {
+			return errors.Join(purgeErr, fmt.Errorf("failed to restore table after failed server-managed purge: %w", restoreErr))
+		}
+		if err := d.releasePurgeLockOwned(context.WithoutCancel(ctx), ident, tableUUID, lockToken); err != nil {
+			return errors.Join(purgeErr, fmt.Errorf("failed to release failed server-managed purge lock: %w", err))
+		}
+	} else if err := d.relinquishPurgeClaim(context.WithoutCancel(ctx), ident, tableUUID, lockToken); err != nil {
+		return errors.Join(purgeErr, fmt.Errorf("failed to relinquish uncertain server-managed purge claim: %w", err))
+	}
+	return fmt.Errorf("iceberg: failed to purge managed table %s: %w", tableName, purgeErr)
+}
+
+func (d *Destination) reconcileMissingServerManagedPurge(ctx context.Context, ident icebergtable.Identifier) error {
+	lock, err := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to inspect server-managed purge ownership for %s: %w", strings.Join(ident, "."), err)
+	}
+	if lock.Properties()[purgeLockModeKey] == purgeLockModeIdle {
+		return nil
+	}
+	tableUUID := lock.Properties()[purgeLockTableUUIDKey]
+	if err := validatePurgeLock(lock, ident, tableUUID); err != nil {
+		return err
+	}
+	token, err := d.claimPurgeResume(ctx, ident, tableUUID)
+	if err != nil {
+		return err
+	}
+	if lock.Properties()[purgeLockModeKey] == purgeLockModeIdle {
+		return nil
+	}
+	if err := d.releasePurgeLockOwned(ctx, ident, tableUUID, token); err != nil {
+		return fmt.Errorf("iceberg: failed to release completed server-managed purge ownership for %s: %w", strings.Join(ident, "."), err)
+	}
+	return nil
+}
+
+func (d *Destination) ensureNoServerManagedPurgeLock(ctx context.Context, ident icebergtable.Identifier) error {
+	lock, err := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if lock.Properties()[purgeLockModeKey] == purgeLockModeIdle {
+		return nil
+	}
+	return fmt.Errorf(
+		"iceberg: server-managed purge for %s with original table UUID %s must be reconciled before recreation",
+		strings.Join(ident, "."), lock.Properties()[purgeLockTableUUIDKey],
+	)
+}
+
+func (d *Destination) reconcileFailedCatalogPurge(
+	ctx context.Context,
+	original *icebergtable.Table,
+	claimed *icebergtable.Table,
+	journalFS icebergio.IO,
+	journalPath string,
+	lockToken string,
+	purgeErr error,
+) error {
+	live, err := d.catalog.LoadTable(ctx, claimed.Identifier())
+	if err != nil || live.Metadata().TableUUID() != original.Metadata().TableUUID() {
+		if claimErr := d.relinquishPurgeClaim(context.WithoutCancel(ctx), original.Identifier(), original.Metadata().TableUUID().String(), lockToken); claimErr != nil {
+			return errors.Join(purgeErr, fmt.Errorf("failed to relinquish purge recovery claim: %w", claimErr))
+		}
+		return purgeErr
+	}
+	if err := d.restoreDeletionClaim(context.WithoutCancel(ctx), live, original.Identifier()); err != nil {
+		return errors.Join(purgeErr, fmt.Errorf("failed to restore table after failed fenced deletion: %w", err))
+	}
+	if err := d.releasePurgeLockOwned(context.WithoutCancel(ctx), original.Identifier(), original.Metadata().TableUUID().String(), lockToken); err != nil {
+		return errors.Join(purgeErr, fmt.Errorf("failed to release abandoned purge lock: %w", err))
+	}
+	if err := removePurgeJournal(journalFS, journalPath); err != nil {
+		return errors.Join(purgeErr, fmt.Errorf("failed to remove abandoned purge journal: %w", err))
+	}
+	return purgeErr
+}
+
+func (d *Destination) usesServerManagedPurge() bool {
+	return d.catalog != nil && d.catalog.CatalogType() == icebergcatalog.REST &&
+		strings.EqualFold(d.cfg.Properties.Get("rest.signing-name", ""), "s3tables")
+}
+
+func filesUnderTableLocation(ctx context.Context, tableFS icebergio.ListableIO, location string) ([]string, error) {
+	var files []string
+	err := tableFS.WalkDir(location, func(path string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			if isObjectNotFound(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if !entry.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if isObjectNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list table location %s: %w", location, err)
+	}
+	return files, nil
+}
+
+func removeTableFiles(ctx context.Context, tableFS icebergio.IO, files []string) error {
+	if bulk, ok := tableFS.(icebergio.BulkRemovableIO); ok {
+		_, err := bulk.DeleteFiles(ctx, files)
+		return err
+	}
+
+	var removeErr error
+	for _, path := range files {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(removeErr, err)
+		}
+		if err := tableFS.Remove(path); err != nil && !isObjectNotFound(err) {
+			removeErr = errors.Join(removeErr, fmt.Errorf("failed to remove %s: %w", path, err))
+		}
+	}
+	return removeErr
+}
+
+// CleanupExpiredManagedTables enforces persisted ExpiresAfter deadlines for
+// one namespace. It never touches an unmarked table and never falls back to a
+// catalog-only drop when physical purge is unavailable or has unknown status.
+func (d *Destination) CleanupExpiredManagedTables(ctx context.Context, namespace string) (ExpiredTableCleanupResult, error) {
+	if d.catalog == nil {
+		return ExpiredTableCleanupResult{}, errors.New("iceberg destination not connected")
+	}
+
+	var ident icebergtable.Identifier
+	if strings.TrimSpace(namespace) != "" {
+		var err error
+		ident, err = parseIdentifier(namespace + ".placeholder")
+		if err != nil {
+			return ExpiredTableCleanupResult{}, err
+		}
+		ident = icebergcatalog.NamespaceFromIdent(ident)
+	}
+	if err := d.sweepPurgeJournals(ctx, ident); err != nil {
+		return ExpiredTableCleanupResult{}, err
+	}
+	return d.cleanupExpiredManagedTables(ctx, ident, time.Now())
+}
+
+func (d *Destination) cleanupExpiredManagedTables(
+	ctx context.Context,
+	namespace icebergtable.Identifier,
+	now time.Time,
+) (ExpiredTableCleanupResult, error) {
+	return d.cleanupExpiredManagedTablesExcept(ctx, namespace, nil, now)
+}
+
+func (d *Destination) cleanupExpiredManagedTablesExcept(
+	ctx context.Context,
+	namespace icebergtable.Identifier,
+	exclude icebergtable.Identifier,
+	now time.Time,
+) (ExpiredTableCleanupResult, error) {
+	result := ExpiredTableCleanupResult{}
+	for ident, listErr := range d.catalog.ListTables(ctx, namespace) {
+		if listErr != nil {
+			return result, fmt.Errorf("iceberg: failed to list tables in namespace %s: %w", strings.Join(namespace, "."), listErr)
+		}
+		if slices.Equal(ident, exclude) {
+			continue
+		}
+		purged, err := d.purgeExpiredManagedTable(ctx, ident, now)
+		if err != nil {
+			return result, err
+		}
+		if purged {
+			result.Purged = append(result.Purged, strings.Join(ident, "."))
+		}
+	}
+	slices.Sort(result.Purged)
+	return result, nil
+}

--- a/pkg/destination/iceberg/maintenance.go
+++ b/pkg/destination/iceberg/maintenance.go
@@ -1,0 +1,1097 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	icebergcompaction "github.com/apache/iceberg-go/table/compaction"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/google/uuid"
+)
+
+const (
+	maintenanceEnabledProperty            = "ingestr.maintenance.enabled"
+	maintenanceIntervalMSProperty         = "ingestr.maintenance.interval-ms"
+	maintenanceLastRunAtProperty          = "ingestr.maintenance.last-run-at"
+	maintenanceExpireSnapshotsProperty    = "ingestr.maintenance.expire-snapshots"
+	maintenanceSnapshotMaxAgeMSProperty   = "ingestr.maintenance.snapshot-max-age-ms"
+	maintenanceMinSnapshotsProperty       = "ingestr.maintenance.min-snapshots-to-keep"
+	maintenanceDeleteOrphansProperty      = "ingestr.maintenance.delete-orphans"
+	maintenanceOrphanAgeMSProperty        = "ingestr.maintenance.orphan-file-age-ms"
+	maintenanceCompactDataProperty        = "ingestr.maintenance.compact-data-files"
+	maintenanceTargetFileSizeProperty     = "ingestr.maintenance.target-file-size-bytes"
+	maintenanceMinInputFilesProperty      = "ingestr.maintenance.min-input-files"
+	maintenanceDeleteFileThreshold        = "ingestr.maintenance.delete-file-threshold"
+	maintenanceManifestMergeProperty      = "ingestr.maintenance.manifest-merge"
+	maintenanceManifestMinCountProperty   = "ingestr.maintenance.manifest-min-count"
+	maintenanceManifestTargetSizeProperty = "ingestr.maintenance.manifest-target-size-bytes"
+	maintenancePreviousMetadataProperty   = "ingestr.maintenance.previous-metadata-versions"
+
+	defaultMaintenanceInterval      = time.Hour
+	managedExpirationScanInterval   = time.Hour
+	managedExpirationCleanupTimeout = 30 * time.Minute
+	maintenanceRunTimeout           = 30 * time.Minute
+	defaultSnapshotMaxAge           = 7 * 24 * time.Hour
+	defaultMinSnapshotsToKeep       = 3
+	defaultOrphanFileAge            = 72 * time.Hour
+	minimumSafeOrphanFileAge        = 24 * time.Hour
+	defaultPreviousMetadataVersion  = 100
+)
+
+// MaintenanceOptions controls an explicit maintenance run. Every operation is
+// opt-in. Configured post-commit maintenance uses these same options after the
+// table property ingestr.maintenance.enabled has explicitly enabled it.
+type MaintenanceOptions struct {
+	ExpireSnapshots        bool
+	SnapshotMaxAge         time.Duration
+	MinSnapshotsToKeep     int
+	DeleteOrphanFiles      bool
+	OrphanFileAge          time.Duration
+	CompactDataFiles       bool
+	TargetFileSizeBytes    int64
+	MinInputFiles          uint
+	DeleteFileThreshold    int
+	EnableManifestMerge    bool
+	ManifestMinCount       int
+	ManifestTargetSize     int64
+	PreviousMetadataFiles  int
+	configureManifestMerge bool
+}
+
+// MaintenanceResult contains the observable effects of a maintenance run.
+// Data/delete files removed from snapshots remain on storage until they also
+// pass the orphan-file grace period.
+type MaintenanceResult struct {
+	SnapshotsBefore              int
+	SnapshotsAfter               int
+	CompactionGroups             int
+	AddedDataFiles               int
+	RemovedDataFiles             int
+	RemovedPositionDeleteFiles   int
+	RemovedEqualityDeleteFiles   int
+	DeletedOrphanFiles           int
+	DeletedOrphanFileLocations   []string
+	ManifestMergeEnabled         bool
+	PreviousMetadataVersionsKept int
+}
+
+// MaintainTable safely performs the selected maintenance operations. Snapshot
+// file deletion is deferred to orphan cleanup so a lost commit response never
+// causes the process to delete files that may still be referenced.
+func (d *Destination) MaintainTable(ctx context.Context, table string, opts MaintenanceOptions) (MaintenanceResult, error) {
+	if d.catalog == nil {
+		return MaintenanceResult{}, errors.New("iceberg destination not connected")
+	}
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		return MaintenanceResult{}, err
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return MaintenanceResult{}, fmt.Errorf("iceberg: failed to load table %s for maintenance: %w", table, err)
+	}
+	return d.maintainLoadedTable(ctx, tbl, opts)
+}
+
+func (d *Destination) maintainLoadedTable(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	opts MaintenanceOptions,
+) (result MaintenanceResult, retErr error) {
+	opts, err := normalizeMaintenanceOptions(opts)
+	if err != nil {
+		return MaintenanceResult{}, err
+	}
+	if opts.DeleteOrphanFiles {
+		if err := d.validateOrphanCleanupIsolation(ctx, tbl); err != nil {
+			return MaintenanceResult{}, err
+		}
+	}
+	result = MaintenanceResult{
+		SnapshotsBefore: len(tbl.Metadata().Snapshots()),
+		SnapshotsAfter:  len(tbl.Metadata().Snapshots()),
+	}
+	generatedCompactionPaths := make([]string, 0)
+	compactionCommitted, cleanupSafe := false, true
+	defer func() {
+		if compactionCommitted || !cleanupSafe || len(generatedCompactionPaths) == 0 {
+			return
+		}
+		fs, err := tbl.FS(context.WithoutCancel(ctx))
+		if err == nil {
+			err = removeGeneratedMergeFiles(fs, tbl.Location(), "", generatedCompactionPaths)
+		}
+		if err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+
+	txn := tbl.NewTransaction()
+	properties := maintenanceTablePropertyUpdates(tbl, opts)
+	if len(properties) > 0 {
+		if err := txn.SetProperties(properties); err != nil {
+			return result, fmt.Errorf("iceberg: failed to stage maintenance properties: %w", err)
+		}
+	}
+
+	if opts.CompactDataFiles && tbl.CurrentSnapshot() != nil {
+		rewriteResult, err := compactTable(ctx, txn, tbl, opts, &generatedCompactionPaths)
+		if err != nil {
+			return result, fmt.Errorf("iceberg: failed to compact table %s: %w", strings.Join(tbl.Identifier(), "."), err)
+		}
+		result.CompactionGroups = rewriteResult.RewrittenGroups
+		result.AddedDataFiles = rewriteResult.AddedDataFiles
+		result.RemovedDataFiles = rewriteResult.RemovedDataFiles
+		result.RemovedPositionDeleteFiles = rewriteResult.RemovedPositionDeleteFiles
+		result.RemovedEqualityDeleteFiles = rewriteResult.RemovedEqualityDeleteFiles
+	}
+
+	if opts.ExpireSnapshots {
+		if result.CompactionGroups == 0 {
+			if err := stageMaintenanceLineageSnapshot(ctx, txn, tbl); err != nil {
+				return result, fmt.Errorf("iceberg: failed to preserve commit lineage before snapshot expiration: %w", err)
+			}
+		}
+		// Never delete files from ExpireSnapshots.PostCommit. If Commit returns
+		// an unknown state, no physical deletion has happened. A later orphan
+		// pass reloads confirmed metadata and observes a mandatory grace period.
+		if err := txn.ExpireSnapshots(
+			icebergtable.WithOlderThan(opts.SnapshotMaxAge),
+			icebergtable.WithRetainLast(opts.MinSnapshotsToKeep),
+			icebergtable.WithPostCommit(false),
+		); err != nil {
+			return result, fmt.Errorf("iceberg: failed to stage snapshot expiration: %w", err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+
+	committed, err := txn.Commit(ctx)
+	if err != nil {
+		// This may be an unknown commit outcome. Do not reload-and-delete here:
+		// the generated compaction files and all pre-commit files are retained
+		// for a future, grace-delayed orphan cleanup to reconcile safely.
+		cleanupSafe = errors.Is(err, icebergtable.ErrCommitFailed)
+		return result, fmt.Errorf("iceberg: failed to commit maintenance for table %s: %w", strings.Join(tbl.Identifier(), "."), err)
+	}
+	compactionCommitted = true
+	result.SnapshotsAfter = len(committed.Metadata().Snapshots())
+	result.ManifestMergeEnabled = committed.Properties().GetBool(icebergtable.ManifestMergeEnabledKey, false)
+	result.PreviousMetadataVersionsKept = committed.Properties().GetInt(
+		icebergtable.MetadataPreviousVersionsMaxKey,
+		icebergtable.MetadataPreviousVersionsMaxDefault,
+	)
+
+	if opts.DeleteOrphanFiles {
+		confirmed, err := d.catalog.LoadTable(ctx, committed.Identifier())
+		if err != nil {
+			return result, fmt.Errorf("iceberg: failed to reload confirmed metadata before orphan cleanup for table %s: %w", strings.Join(tbl.Identifier(), "."), err)
+		}
+		orphans, err := confirmed.DeleteOrphanFiles(
+			ctx,
+			icebergtable.WithFilesOlderThan(opts.OrphanFileAge),
+			icebergtable.WithPrefixMismatchMode(icebergtable.PrefixMismatchError),
+		)
+		if err != nil {
+			return result, fmt.Errorf("iceberg: failed to delete orphan files for table %s: %w", strings.Join(tbl.Identifier(), "."), err)
+		}
+		result.DeletedOrphanFiles = len(orphans.DeletedFiles)
+		result.DeletedOrphanFileLocations = append([]string(nil), orphans.DeletedFiles...)
+	}
+	return result, nil
+}
+
+func stageMaintenanceLineageSnapshot(
+	ctx context.Context,
+	txn *icebergtable.Transaction,
+	tbl *icebergtable.Table,
+) error {
+	props := maintenanceSnapshotProperties(tbl)
+	if (props[snapshotCommitTokenKey] == "" && props[snapshotCDCResumeLSNKey] == "" && props[snapshotCDCResetKey] == "") ||
+		currentSnapshotHasProperties(tbl, props) {
+		// With no durable lineage values there is nothing that expiration needs
+		// to carry.
+		return nil
+	}
+	writeSchema, err := tableWriteSchema(tbl)
+	if err != nil {
+		return err
+	}
+	reader, err := array.NewRecordReader(writeSchema, nil)
+	if err != nil {
+		return err
+	}
+	defer reader.Release()
+	return txn.Append(ctx, reader, props)
+}
+
+func currentSnapshotHasProperties(tbl *icebergtable.Table, props iceberggo.Properties) bool {
+	snapshot := tbl.CurrentSnapshot()
+	if snapshot == nil || snapshot.Summary == nil {
+		return false
+	}
+	for _, key := range []string{snapshotCommitTokenKey, snapshotCDCResumeLSNKey, snapshotCDCResetKey} {
+		if value := props[key]; value != "" && snapshot.Summary.Properties[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeMaintenanceOptions(opts MaintenanceOptions) (MaintenanceOptions, error) {
+	if opts.ExpireSnapshots {
+		if opts.SnapshotMaxAge == 0 {
+			opts.SnapshotMaxAge = defaultSnapshotMaxAge
+		}
+		if opts.SnapshotMaxAge < 0 {
+			return opts, fmt.Errorf("iceberg: snapshot max age must not be negative: %s", opts.SnapshotMaxAge)
+		}
+		if opts.MinSnapshotsToKeep == 0 {
+			opts.MinSnapshotsToKeep = defaultMinSnapshotsToKeep
+		}
+		if opts.MinSnapshotsToKeep < 1 {
+			return opts, fmt.Errorf("iceberg: min snapshots to keep must be at least 1, got %d", opts.MinSnapshotsToKeep)
+		}
+	}
+	if opts.DeleteOrphanFiles {
+		if opts.OrphanFileAge == 0 {
+			opts.OrphanFileAge = defaultOrphanFileAge
+		}
+		if opts.OrphanFileAge < minimumSafeOrphanFileAge {
+			return opts, fmt.Errorf("iceberg: orphan file age %s is unsafe; minimum is %s", opts.OrphanFileAge, minimumSafeOrphanFileAge)
+		}
+	}
+	if opts.TargetFileSizeBytes < 0 {
+		return opts, fmt.Errorf("iceberg: compaction target file size must not be negative, got %d", opts.TargetFileSizeBytes)
+	}
+	const maxCompactionTargetFileSize = int64(1<<63-1) / 9 * 5
+	if opts.TargetFileSizeBytes > maxCompactionTargetFileSize {
+		return opts, fmt.Errorf("iceberg: compaction target file size is too large: %d", opts.TargetFileSizeBytes)
+	}
+	if opts.DeleteFileThreshold < 0 {
+		return opts, fmt.Errorf("iceberg: delete file threshold must not be negative, got %d", opts.DeleteFileThreshold)
+	}
+	if opts.PreviousMetadataFiles < 0 {
+		return opts, fmt.Errorf("iceberg: previous metadata versions must not be negative, got %d", opts.PreviousMetadataFiles)
+	}
+	if opts.ManifestMinCount < 0 {
+		return opts, fmt.Errorf("iceberg: manifest minimum count must not be negative, got %d", opts.ManifestMinCount)
+	}
+	if opts.ManifestTargetSize < 0 {
+		return opts, fmt.Errorf("iceberg: manifest target size must not be negative, got %d", opts.ManifestTargetSize)
+	}
+	return opts, nil
+}
+
+func maintenanceTablePropertyUpdates(tbl *icebergtable.Table, opts MaintenanceOptions) iceberggo.Properties {
+	desired := iceberggo.Properties{}
+	if opts.EnableManifestMerge || opts.configureManifestMerge {
+		desired[icebergtable.ManifestMergeEnabledKey] = strconv.FormatBool(opts.EnableManifestMerge)
+	}
+	if opts.EnableManifestMerge {
+		if opts.ManifestMinCount > 0 {
+			desired[icebergtable.ManifestMinMergeCountKey] = strconv.Itoa(opts.ManifestMinCount)
+		}
+		if opts.ManifestTargetSize > 0 {
+			desired[icebergtable.ManifestTargetSizeBytesKey] = strconv.FormatInt(opts.ManifestTargetSize, 10)
+		}
+	}
+	if opts.PreviousMetadataFiles > 0 {
+		desired[icebergtable.MetadataPreviousVersionsMaxKey] = strconv.Itoa(opts.PreviousMetadataFiles)
+	}
+
+	updates := iceberggo.Properties{}
+	for key, value := range desired {
+		if tbl.Properties()[key] != value {
+			updates[key] = value
+		}
+	}
+	return updates
+}
+
+func compactTable(
+	ctx context.Context,
+	txn *icebergtable.Transaction,
+	tbl *icebergtable.Table,
+	opts MaintenanceOptions,
+	generatedPaths *[]string,
+) (*icebergtable.RewriteResult, error) {
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("plan table files: %w", err)
+	}
+
+	cfg := icebergcompaction.DefaultConfig()
+	targetSize := opts.TargetFileSizeBytes
+	if targetSize == 0 {
+		targetSize = int64(tbl.Properties().GetInt(
+			icebergtable.WriteTargetFileSizeBytesKey,
+			icebergtable.WriteTargetFileSizeBytesDefault,
+		))
+	}
+	if targetSize > 0 {
+		cfg.TargetFileSizeBytes = targetSize
+		cfg.MinFileSizeBytes = targetSize * 3 / 4
+		cfg.MaxFileSizeBytes = targetSize * 9 / 5
+	}
+	if opts.MinInputFiles > 0 {
+		cfg.MinInputFiles = opts.MinInputFiles
+	}
+	if opts.DeleteFileThreshold > 0 {
+		cfg.DeleteFileThreshold = opts.DeleteFileThreshold
+	}
+	plan, err := cfg.PlanCompaction(tasks)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.Groups) == 0 {
+		return &icebergtable.RewriteResult{}, nil
+	}
+
+	groups := make([]icebergtable.CompactionTaskGroup, 0, len(plan.Groups))
+	rewrittenPaths := make(map[string]struct{})
+	for _, group := range plan.Groups {
+		groups = append(groups, icebergtable.CompactionTaskGroup{
+			PartitionKey:   group.PartitionKey,
+			Tasks:          group.Tasks,
+			TotalSizeBytes: group.TotalSizeBytes,
+		})
+		for _, task := range group.Tasks {
+			rewrittenPaths[task.File.FilePath()] = struct{}{}
+		}
+	}
+
+	fs, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load table file IO: %w", err)
+	}
+	deadEqualityDeletes, err := icebergcompaction.CollectDeadEqualityDeletes(
+		ctx,
+		fs,
+		tbl.CurrentSnapshot(),
+		rewrittenPaths,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("identify dead equality deletes: %w", err)
+	}
+
+	if tbl.SortOrder().Len() > 0 {
+		return rewriteSortedDataFiles(ctx, txn, tbl, tasks, groups, deadEqualityDeletes, targetSize, generatedPaths)
+	}
+	return txn.RewriteDataFiles(ctx, groups, icebergtable.RewriteDataFilesOptions{
+		SnapshotProps:            maintenanceSnapshotProperties(tbl),
+		ExtraDeleteFilesToRemove: deadEqualityDeletes,
+		GroupOptions: []icebergtable.CompactionGroupOption{
+			icebergtable.WithCompactionTargetFileSize(targetSize),
+		},
+	})
+}
+
+func rewriteSortedDataFiles(
+	ctx context.Context,
+	txn *icebergtable.Transaction,
+	tbl *icebergtable.Table,
+	allTasks []icebergtable.FileScanTask,
+	groups []icebergtable.CompactionTaskGroup,
+	deadEqualityDeletes []iceberggo.DataFile,
+	targetSize int64,
+	transferredPaths *[]string,
+) (retResult *icebergtable.RewriteResult, retErr error) {
+	clusterBy, ok := identitySortColumns(tbl)
+	if !ok {
+		return nil, fmt.Errorf("table sort order uses transforms, direction, or null ordering that the compactor cannot preserve")
+	}
+	result := &icebergtable.RewriteResult{}
+	retResult = result
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return result, err
+	}
+	generatedPaths := make([]string, 0)
+	committed, cleanupSafe := false, true
+	defer func() {
+		if committed || !cleanupSafe {
+			return
+		}
+		if cleanupErr := removeGeneratedMergeFiles(tableFS, tbl.Location(), "", generatedPaths); cleanupErr != nil {
+			retErr = errors.Join(retErr, cleanupErr)
+		}
+	}()
+	rewrite := txn.NewRewrite(maintenanceSnapshotProperties(tbl))
+	for _, group := range groups {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		groupResult, err := executeSortedCompactionGroup(ctx, tbl, group, clusterBy, targetSize)
+		if err != nil {
+			return result, err
+		}
+		if len(groupResult.OldDataFiles) == 0 && len(groupResult.NewDataFiles) == 0 {
+			continue
+		}
+		rewrite.ApplyResult(groupResult)
+		for _, file := range groupResult.NewDataFiles {
+			generatedPaths = append(generatedPaths, file.FilePath())
+		}
+		result.RewrittenGroups++
+		result.AddedDataFiles += len(groupResult.NewDataFiles)
+		result.RemovedDataFiles += len(groupResult.OldDataFiles)
+		result.RemovedPositionDeleteFiles += len(groupResult.SafePosDeletes)
+		result.BytesBefore += groupResult.BytesBefore
+		result.BytesAfter += groupResult.BytesAfter
+	}
+	if result.RewrittenGroups == 0 {
+		return result, nil
+	}
+	for _, file := range deadEqualityDeletes {
+		rewrite.DeleteFile(file)
+		result.RemovedEqualityDeleteFiles++
+	}
+	for _, file := range safePositionDeletesForRewrite(allTasks, groups) {
+		rewrite.DeleteFile(file)
+		result.RemovedPositionDeleteFiles++
+	}
+	if err := rewrite.Commit(ctx); err != nil {
+		cleanupSafe = errors.Is(err, icebergtable.ErrCommitFailed)
+		return result, fmt.Errorf("commit sorted compaction: %w", err)
+	}
+	*transferredPaths = append(*transferredPaths, generatedPaths...)
+	committed = true
+	return result, nil
+}
+
+func safePositionDeletesForRewrite(
+	allTasks []icebergtable.FileScanTask,
+	groups []icebergtable.CompactionTaskGroup,
+) []iceberggo.DataFile {
+	rewritten := make(map[string]struct{})
+	candidates := make(map[string]iceberggo.DataFile)
+	for _, group := range groups {
+		for _, task := range group.Tasks {
+			rewritten[task.File.FilePath()] = struct{}{}
+			for _, file := range task.DeleteFiles {
+				if file.ContentType() == iceberggo.EntryContentPosDeletes {
+					candidates[file.FilePath()] = file
+				}
+			}
+		}
+	}
+	unsafe := make(map[string]struct{})
+	for _, task := range allTasks {
+		if _, ok := rewritten[task.File.FilePath()]; ok {
+			continue
+		}
+		for _, file := range task.DeleteFiles {
+			if _, ok := candidates[file.FilePath()]; ok {
+				unsafe[file.FilePath()] = struct{}{}
+			}
+		}
+	}
+	paths := make([]string, 0, len(candidates))
+	for path := range candidates {
+		if _, ok := unsafe[path]; !ok {
+			paths = append(paths, path)
+		}
+	}
+	slices.Sort(paths)
+	result := make([]iceberggo.DataFile, 0, len(paths))
+	for _, path := range paths {
+		result = append(result, candidates[path])
+	}
+	return result
+}
+
+func executeSortedCompactionGroup(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	group icebergtable.CompactionTaskGroup,
+	clusterBy []string,
+	targetSize int64,
+) (retResult icebergtable.CompactionGroupResult, retErr error) {
+	if len(group.Tasks) == 0 {
+		return icebergtable.CompactionGroupResult{PartitionKey: group.PartitionKey}, nil
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return retResult, err
+	}
+	writeID := uuid.New()
+	generatedPaths := make([]string, 0)
+	transferred := false
+	defer func() {
+		if transferred {
+			return
+		}
+		if err := removeGeneratedMergeFiles(tableFS, tbl.Location(), writeID.String(), generatedPaths); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+	scan := tbl.Scan()
+	preserveLineage := tbl.Metadata().Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
+	if preserveLineage {
+		scan = tbl.Scan(icebergtable.WithRowLineage())
+	}
+	arrowSchema, records, err := scan.ReadTasks(ctx, group.Tasks)
+	if err != nil {
+		return icebergtable.CompactionGroupResult{}, fmt.Errorf("read sorted compaction group %q: %w", group.PartitionKey, err)
+	}
+	if preserveLineage {
+		arrowSchema, err = icebergtable.SchemaToArrowSchema(iceberggo.SchemaWithRowLineage(tbl.Schema()), nil, true, false)
+		if err != nil {
+			return icebergtable.CompactionGroupResult{}, fmt.Errorf("build row-lineage schema for sorted compaction group %q: %w", group.PartitionKey, err)
+		}
+	}
+	reader := streamingReader(arrowSchema, func(sink func(arrow.RecordBatch) error) error {
+		for batch, readErr := range records {
+			if readErr != nil {
+				return readErr
+			}
+			if err := sink(batch); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	defer reader.Release()
+	clustered, cleanup, err := clusterRecordReader(ctx, reader, clusterBy)
+	if err != nil {
+		return icebergtable.CompactionGroupResult{}, fmt.Errorf("sort compaction group %q: %w", group.PartitionKey, err)
+	}
+	defer cleanup()
+
+	writeOpts := []icebergtable.WriteRecordOption{icebergtable.WithClusteredWrite(), icebergtable.WithWriteUUID(writeID)}
+	if targetSize > 0 {
+		writeOpts = append(writeOpts, icebergtable.WithTargetFileSize(targetSize))
+	}
+	if preserveLineage {
+		writeOpts = append(writeOpts, icebergtable.WithPreserveRowLineage(iceberggo.SchemaWithRowLineage(tbl.Schema())))
+	}
+	newFiles := make([]iceberggo.DataFile, 0)
+	var bytesAfter int64
+	for dataFile, writeErr := range icebergtable.WriteRecords(ctx, tbl, arrowSchema, retainedRecordIterator(clustered), writeOpts...) {
+		if writeErr != nil {
+			return icebergtable.CompactionGroupResult{}, fmt.Errorf("write sorted compaction group %q: %w", group.PartitionKey, writeErr)
+		}
+		dataFile, err = withDataFileSortOrderID(dataFile, tbl, tbl.SortOrder().OrderID())
+		if err != nil {
+			return icebergtable.CompactionGroupResult{}, err
+		}
+		newFiles = append(newFiles, dataFile)
+		generatedPaths = append(generatedPaths, dataFile.FilePath())
+		bytesAfter += dataFile.FileSizeBytes()
+	}
+	if err := clustered.Err(); err != nil {
+		return icebergtable.CompactionGroupResult{}, err
+	}
+	oldFiles := make([]iceberggo.DataFile, 0, len(group.Tasks))
+	for _, task := range group.Tasks {
+		oldFiles = append(oldFiles, task.File)
+	}
+	retResult = icebergtable.CompactionGroupResult{
+		PartitionKey:   group.PartitionKey,
+		OldDataFiles:   oldFiles,
+		NewDataFiles:   newFiles,
+		SafePosDeletes: nil,
+		BytesBefore:    group.TotalSizeBytes,
+		BytesAfter:     bytesAfter,
+	}
+	transferred = true
+	return retResult, nil
+}
+
+func allTasksHaveRowLineage(tasks []icebergtable.FileScanTask) bool {
+	if len(tasks) == 0 {
+		return false
+	}
+	for _, task := range tasks {
+		if task.FirstRowID == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func maintenanceSnapshotProperties(tbl *icebergtable.Table) iceberggo.Properties {
+	props := snapshotProps("maintenance")
+	var newestToken string
+	snapshotInCurrentLineage(tbl, func(snapshot *icebergtable.Snapshot) bool {
+		if snapshot.Summary == nil {
+			return false
+		}
+		token := snapshot.Summary.Properties[snapshotCommitTokenKey]
+		if newestToken == "" {
+			newestToken = token
+		}
+		if cursor := snapshot.Summary.Properties[snapshotCDCResumeLSNKey]; cursor != "" {
+			props[snapshotCDCResumeLSNKey] = cursor
+			if token != "" {
+				props[snapshotCommitTokenKey] = token
+			}
+			return true
+		}
+		operation := snapshot.Summary.Properties["ingestr.operation"]
+		cdcBarrier := snapshot.Summary.Properties[snapshotCDCResetKey] == "true" ||
+			operation == "replace" || operation == "truncate" || operation == "truncate+insert"
+		if cdcBarrier {
+			props[snapshotCDCResetKey] = "true"
+		}
+		return cdcBarrier
+	})
+	if props[snapshotCommitTokenKey] == "" && props[snapshotCDCResumeLSNKey] == "" {
+		props[snapshotCommitTokenKey] = newestToken
+	}
+	if props[snapshotCommitTokenKey] == "" {
+		delete(props, snapshotCommitTokenKey)
+	}
+	if props[snapshotCDCResumeLSNKey] == "" {
+		delete(props, snapshotCDCResumeLSNKey)
+	}
+	return props
+}
+
+// runConfiguredMaintenance is the post-commit hook used by WriteParallel. It
+// deliberately has no error result: a confirmed data commit remains successful
+// even when optional maintenance fails. Configure it through table URI
+// properties such as table.ingestr.maintenance.enabled=true.
+func (d *Destination) runConfiguredMaintenance(ctx context.Context, table string) {
+	d.runConfiguredMaintenanceExpected(ctx, table, "")
+}
+
+func (d *Destination) runConfiguredMaintenanceExpected(ctx context.Context, table, expectedIncarnation string) {
+	ident, err := parseIdentifier(table)
+	if err != nil {
+		config.Debug("[ICEBERG] Skipping configured maintenance for %s: %v", table, err)
+		return
+	}
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		config.Debug("[ICEBERG] Failed to load %s for configured maintenance: %v", table, err)
+		return
+	}
+	if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+		config.Debug("[ICEBERG] Skipping configured maintenance for %s: %v", table, err)
+		return
+	}
+	managed, err := boolProperty(tbl.Properties(), managedTableProperty, false)
+	if err != nil {
+		config.Debug("[ICEBERG] Invalid managed-table marker for %s: %v", table, err)
+		return
+	}
+	if managed {
+		// Staging tables are short-lived and physically purged. Compacting them
+		// after extraction only delays the merge and creates redundant files.
+		if err := d.refreshManagedTableLease(ctx, tbl, time.Now()); err != nil {
+			config.Debug("[ICEBERG] Failed to refresh managed-table lease for %s: %v", table, err)
+		}
+	}
+	cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), managedExpirationCleanupTimeout)
+	d.runExpiredManagedTableCleanup(cleanupCtx, table, time.Now())
+	cancelCleanup()
+	if managed {
+		return
+	}
+	effectiveProperties := maps.Clone(tbl.Properties())
+	if effectiveProperties == nil {
+		effectiveProperties = iceberggo.Properties{}
+	}
+	for key, value := range d.cfg.TableProperties {
+		if strings.HasPrefix(key, "ingestr.maintenance.") {
+			effectiveProperties[key] = value
+		}
+	}
+	opts, due, err := configuredMaintenanceOptions(effectiveProperties, time.Now())
+	if err != nil {
+		config.Debug("[ICEBERG] Invalid maintenance configuration for %s: %v", table, err)
+		return
+	}
+	if !due {
+		return
+	}
+	// The caller's context only budgets the cheap post-commit inspection;
+	// whether maintenance runs is decided by the table's effective properties,
+	// so the actual run gets its own budget here.
+	maintainCtx, cancelMaintain := context.WithTimeout(context.WithoutCancel(ctx), maintenanceRunTimeout)
+	defer cancelMaintain()
+	if _, err := d.maintainLoadedTable(maintainCtx, tbl, opts); err != nil {
+		config.Debug("[ICEBERG] Maintenance failed for %s after successful write: %v", table, err)
+		return
+	}
+	if err := d.recordMaintenanceRunExpected(maintainCtx, ident, time.Now(), expectedIncarnation); err != nil {
+		config.Debug("[ICEBERG] Failed to record maintenance run for %s: %v", table, err)
+	}
+}
+
+func (d *Destination) runExpiredManagedTableCleanup(ctx context.Context, activeTable string, now time.Time) {
+	if ctx.Err() != nil {
+		return
+	}
+	active, err := parseIdentifier(activeTable)
+	if err != nil {
+		config.Debug("[ICEBERG] Skipping managed-table expiration cleanup for %s: %v", activeTable, err)
+		return
+	}
+	namespace := icebergcatalog.NamespaceFromIdent(active)
+	key := strings.Join(namespace, ".")
+	claim := now.UnixNano()
+
+	d.mu.Lock()
+	if d.expirationScans == nil {
+		d.expirationScans = make(map[string]int64)
+	}
+	lastClaim, claimed := d.expirationScans[key]
+	if claimed && now.Sub(time.Unix(0, lastClaim)) < managedExpirationScanInterval {
+		d.mu.Unlock()
+		return
+	}
+	d.expirationScans[key] = claim
+	d.mu.Unlock()
+
+	result, err := d.cleanupExpiredManagedTablesExcept(ctx, namespace, active, now)
+	if err != nil {
+		// Keep the claim after a failure as well. Catalog outages or malformed
+		// metadata must not turn every successful write into another full scan.
+		config.Debug("[ICEBERG] Managed-table expiration cleanup failed in namespace %s: %v", key, err)
+		return
+	}
+	if len(result.Purged) > 0 {
+		config.Debug("[ICEBERG] Purged %d expired managed table(s) in namespace %s", len(result.Purged), key)
+	}
+}
+
+func configuredMaintenanceOptions(props iceberggo.Properties, now time.Time) (MaintenanceOptions, bool, error) {
+	enabled, err := boolProperty(props, maintenanceEnabledProperty, false)
+	if err != nil || !enabled {
+		return MaintenanceOptions{}, false, err
+	}
+	interval, err := durationMSProperty(props, maintenanceIntervalMSProperty, defaultMaintenanceInterval)
+	if err != nil {
+		return MaintenanceOptions{}, false, err
+	}
+	if interval < 0 {
+		return MaintenanceOptions{}, false, fmt.Errorf("%s must not be negative", maintenanceIntervalMSProperty)
+	}
+	if raw := strings.TrimSpace(props[maintenanceLastRunAtProperty]); raw != "" {
+		lastRun, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return MaintenanceOptions{}, false, fmt.Errorf("invalid %s value %q: %w", maintenanceLastRunAtProperty, raw, err)
+		}
+		if now.Before(lastRun.Add(interval)) {
+			return MaintenanceOptions{}, false, nil
+		}
+	}
+
+	opts := MaintenanceOptions{}
+	if opts.ExpireSnapshots, err = boolProperty(props, maintenanceExpireSnapshotsProperty, true); err != nil {
+		return opts, false, err
+	}
+	if opts.SnapshotMaxAge, err = durationMSProperty(props, maintenanceSnapshotMaxAgeMSProperty, defaultSnapshotMaxAge); err != nil {
+		return opts, false, err
+	}
+	if opts.MinSnapshotsToKeep, err = intProperty(props, maintenanceMinSnapshotsProperty, defaultMinSnapshotsToKeep); err != nil {
+		return opts, false, err
+	}
+	if opts.DeleteOrphanFiles, err = boolProperty(props, maintenanceDeleteOrphansProperty, true); err != nil {
+		return opts, false, err
+	}
+	if opts.OrphanFileAge, err = durationMSProperty(props, maintenanceOrphanAgeMSProperty, defaultOrphanFileAge); err != nil {
+		return opts, false, err
+	}
+	if opts.CompactDataFiles, err = boolProperty(props, maintenanceCompactDataProperty, true); err != nil {
+		return opts, false, err
+	}
+	if opts.TargetFileSizeBytes, err = int64Property(props, maintenanceTargetFileSizeProperty, 0); err != nil {
+		return opts, false, err
+	}
+	minInput, err := intProperty(props, maintenanceMinInputFilesProperty, int(icebergcompaction.DefaultMinInputFiles))
+	if err != nil || minInput < 1 {
+		return opts, false, propertyRangeError(maintenanceMinInputFilesProperty, minInput, err)
+	}
+	opts.MinInputFiles = uint(minInput)
+	if opts.DeleteFileThreshold, err = intProperty(props, maintenanceDeleteFileThreshold, 5); err != nil {
+		return opts, false, err
+	}
+	if opts.DeleteFileThreshold < 1 {
+		return opts, false, fmt.Errorf("invalid %s value %d: must be at least 1", maintenanceDeleteFileThreshold, opts.DeleteFileThreshold)
+	}
+	if opts.EnableManifestMerge, err = boolProperty(props, maintenanceManifestMergeProperty, true); err != nil {
+		return opts, false, err
+	}
+	opts.configureManifestMerge = true
+	if opts.ManifestMinCount, err = intProperty(props, maintenanceManifestMinCountProperty, icebergtable.ManifestMinMergeCountDefault); err != nil {
+		return opts, false, err
+	}
+	if opts.ManifestTargetSize, err = int64Property(props, maintenanceManifestTargetSizeProperty, icebergtable.ManifestTargetSizeBytesDefault); err != nil {
+		return opts, false, err
+	}
+	if opts.EnableManifestMerge && (opts.ManifestMinCount < 1 || opts.ManifestTargetSize < 1) {
+		return opts, false, errors.New("manifest minimum count and target size must be positive when manifest merging is enabled")
+	}
+	if opts.PreviousMetadataFiles, err = intProperty(props, maintenancePreviousMetadataProperty, defaultPreviousMetadataVersion); err != nil {
+		return opts, false, err
+	}
+	if opts.PreviousMetadataFiles < 1 {
+		return opts, false, fmt.Errorf("invalid %s value %d: must be at least 1", maintenancePreviousMetadataProperty, opts.PreviousMetadataFiles)
+	}
+
+	opts, err = normalizeMaintenanceOptions(opts)
+	return opts, err == nil, err
+}
+
+func validateMaintenanceConfiguration(props iceberggo.Properties) error {
+	_, _, err := configuredMaintenanceOptions(props, time.Now())
+	if err != nil {
+		return fmt.Errorf("iceberg uri: invalid maintenance configuration: %w", err)
+	}
+	return nil
+}
+
+func validateMaintenanceTableLocation(cfg icebergConfig) error {
+	return validateOrphanCleanupTemplate(cfg.TableLocation)
+}
+
+func validateOrphanCleanupTemplate(template string) error {
+	if template == "" {
+		return nil
+	}
+	if strings.Contains(template, "{identifier}") || strings.Contains(template, "{identifier_dot}") {
+		return nil
+	}
+	hasNamespace := strings.Contains(template, "{namespace}") || strings.Contains(template, "{namespace_dot}")
+	if hasNamespace && strings.Contains(template, "{table}") {
+		return nil
+	}
+	return errors.New("iceberg uri: table_location/table_path must include {identifier}, {identifier_dot}, or both a namespace and {table} so every table has an isolated physical root")
+}
+
+func (d *Destination) validateOrphanCleanupIsolation(ctx context.Context, target *icebergtable.Table) error {
+	if err := validateOrphanCleanupTemplate(d.cfg.TableLocation); err != nil {
+		return err
+	}
+	if err := validateIsolatedTableFilePaths(target.Properties()); err != nil {
+		return fmt.Errorf("iceberg: table %s: %w", strings.Join(target.Identifier(), "."), err)
+	}
+	return d.validateOrphanCleanupLocation(ctx, target.Identifier(), target.Location())
+}
+
+func (d *Destination) validateOrphanCleanupLocation(ctx context.Context, targetIdent icebergtable.Identifier, location string) error {
+	targetLocation, err := canonicalTableRoot(location)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to resolve table %s location: %w", strings.Join(targetIdent, "."), err)
+	}
+	if targetLocation == "" {
+		return fmt.Errorf("iceberg: cannot delete orphan files for table %s with an empty table location", strings.Join(targetIdent, "."))
+	}
+	isolated, err := d.configuredTableLocationProvesIsolation(targetIdent, location, targetLocation)
+	if err != nil {
+		return err
+	}
+	if isolated {
+		return nil
+	}
+
+	queue := []icebergtable.Identifier{nil}
+	seenNamespaces := make(map[string]struct{})
+	seenTables := make(map[string]struct{})
+	flatNamespaces := d.cfg.Properties.Get("type", "") == "hive"
+	for len(queue) > 0 {
+		namespace := queue[0]
+		queue = queue[1:]
+		if !flatNamespaces || len(namespace) == 0 {
+			children, err := d.catalog.ListNamespaces(ctx, namespace)
+			if err != nil {
+				return fmt.Errorf("iceberg: failed to verify orphan-cleanup namespace isolation: %w", err)
+			}
+			for _, child := range children {
+				if len(child) > 0 && child[0] == ".ingestr" {
+					continue
+				}
+				key := strings.Join(child, "\x00")
+				if _, ok := seenNamespaces[key]; ok {
+					continue
+				}
+				seenNamespaces[key] = struct{}{}
+				queue = append(queue, child)
+			}
+		}
+
+		if len(namespace) == 0 {
+			continue
+		}
+		for ident, err := range d.catalog.ListTables(ctx, namespace) {
+			if err != nil {
+				return fmt.Errorf("iceberg: failed to verify orphan-cleanup table isolation: %w", err)
+			}
+			key := strings.Join(ident, "\x00")
+			if _, ok := seenTables[key]; ok {
+				continue
+			}
+			seenTables[key] = struct{}{}
+			if slices.Equal(ident, targetIdent) {
+				continue
+			}
+			other, err := d.catalog.LoadTable(ctx, ident)
+			if err != nil {
+				return fmt.Errorf("iceberg: failed to load table %s while verifying orphan-cleanup isolation: %w", strings.Join(ident, "."), err)
+			}
+			if err := validateIsolatedTableFilePaths(other.Properties()); err != nil {
+				return fmt.Errorf("iceberg: cannot verify orphan-cleanup isolation against table %s: %w", strings.Join(ident, "."), err)
+			}
+			otherLocation, err := canonicalTableRoot(other.Location())
+			if err != nil {
+				return fmt.Errorf("iceberg: failed to resolve table %s location: %w", strings.Join(ident, "."), err)
+			}
+			if otherLocation == targetLocation ||
+				strings.HasPrefix(otherLocation, targetLocation+"/") ||
+				strings.HasPrefix(targetLocation, otherLocation+"/") {
+				return fmt.Errorf(
+					"iceberg: cannot delete orphan files for table %s because table %s has overlapping location %q",
+					strings.Join(targetIdent, "."), strings.Join(ident, "."), other.Location(),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func (d *Destination) configuredTableLocationProvesIsolation(
+	targetIdent icebergtable.Identifier,
+	location string,
+	targetLocation string,
+) (bool, error) {
+	if d.cfg.TableLocation == "" {
+		return false, nil
+	}
+	if err := validateOrphanCleanupTemplate(d.cfg.TableLocation); err != nil {
+		return false, err
+	}
+	expectedLocation, err := canonicalTableRoot(renderTableLocation(d.cfg.TableLocation, targetIdent))
+	if err != nil {
+		return false, fmt.Errorf("iceberg: failed to resolve configured location for table %s: %w", strings.Join(targetIdent, "."), err)
+	}
+	if targetLocation != expectedLocation && !strings.HasPrefix(targetLocation, expectedLocation+"/") {
+		return false, fmt.Errorf(
+			"iceberg: table %s location %q is not within configured isolated location %q",
+			strings.Join(targetIdent, "."), location, renderTableLocation(d.cfg.TableLocation, targetIdent),
+		)
+	}
+
+	warehouse := strings.TrimSuffix(strings.TrimSpace(d.cfg.Properties.Get("warehouse", "")), "/")
+	if warehouse == "" {
+		return false, nil
+	}
+	if !locationContains(warehouse, location) {
+		return false, fmt.Errorf("iceberg: table location %q must be a strict descendant of configured warehouse %q", location, warehouse)
+	}
+	if err := validateCanonicalLocalContainment(warehouse, location); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func canonicalTableRoot(location string) (string, error) {
+	if local, ok := localFilesystemPath(location); ok {
+		resolved, err := resolveExistingPath(local)
+		if err != nil {
+			return "", err
+		}
+		return normalizeTableRoot(filepath.ToSlash(resolved)), nil
+	}
+	return normalizeTableRoot(location), nil
+}
+
+func normalizeTableRoot(location string) string {
+	return strings.TrimRight(strings.TrimSpace(location), "/")
+}
+
+func (d *Destination) recordMaintenanceRunExpected(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	now time.Time,
+	expectedIncarnation string,
+) error {
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return err
+	}
+	if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+		return err
+	}
+	txn := tbl.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		maintenanceLastRunAtProperty: now.UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		return err
+	}
+	_, err = txn.Commit(ctx)
+	return err
+}
+
+func boolProperty(props iceberggo.Properties, key string, fallback bool) (bool, error) {
+	raw, ok := props[key]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("invalid %s value %q: %w", key, raw, err)
+	}
+	return value, nil
+}
+
+func durationMSProperty(props iceberggo.Properties, key string, fallback time.Duration) (time.Duration, error) {
+	value, err := int64Property(props, key, fallback.Milliseconds())
+	if err != nil {
+		return 0, err
+	}
+	const (
+		maxDurationMilliseconds = int64(1<<63-1) / int64(time.Millisecond)
+		minDurationMilliseconds = int64(-1<<63) / int64(time.Millisecond)
+	)
+	if value > maxDurationMilliseconds || value < minDurationMilliseconds {
+		return 0, fmt.Errorf("invalid %s value %d: duration overflows", key, value)
+	}
+	return time.Duration(value) * time.Millisecond, nil
+}
+
+func intProperty(props iceberggo.Properties, key string, fallback int) (int, error) {
+	value, err := int64Property(props, key, int64(fallback))
+	if err != nil {
+		return 0, err
+	}
+	if int64(int(value)) != value {
+		return 0, fmt.Errorf("invalid %s value %d: outside integer range", key, value)
+	}
+	return int(value), nil
+}
+
+func int64Property(props iceberggo.Properties, key string, fallback int64) (int64, error) {
+	raw, ok := props[key]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value %q: %w", key, raw, err)
+	}
+	return value, nil
+}
+
+func propertyRangeError(key string, value int, err error) error {
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("invalid %s value %d: must be at least 1", key, value)
+}

--- a/pkg/destination/iceberg/mapper.go
+++ b/pkg/destination/iceberg/mapper.go
@@ -14,6 +14,9 @@ func icebergSchemaFromTableSchema(s *schema.TableSchema) (*iceberggo.Schema, err
 	if s == nil {
 		return nil, fmt.Errorf("schema is required")
 	}
+	if err := validateIcebergTableSchema(s); err != nil {
+		return nil, err
+	}
 	arrowSchema := icebergArrowSchema(s)
 	iceSchema, err := icebergtable.ArrowSchemaToIcebergWithFreshIDs(arrowSchema, false)
 	if err != nil {
@@ -83,19 +86,102 @@ func icebergArrowSchema(s *schema.TableSchema) *arrow.Schema {
 	return arrow.NewSchema(fields, nil)
 }
 
+func icebergWriteArrowSchema(s *schema.TableSchema, tableSchema *iceberggo.Schema) *arrow.Schema {
+	arrowSchema := icebergArrowSchema(s)
+	if tableSchema == nil {
+		return arrowSchema
+	}
+	fields := arrowSchema.Fields()
+	for i := range fields {
+		if field, ok := tableSchema.FindFieldByName(fields[i].Name); ok {
+			fields[i].Nullable = !field.Required
+			fields[i].Type = overlayIcebergRequiredness(fields[i].Type, field.Type)
+		}
+	}
+	metadata := arrowSchema.Metadata()
+	return arrow.NewSchema(fields, &metadata)
+}
+
+func overlayIcebergRequiredness(dataType arrow.DataType, iceType iceberggo.Type) arrow.DataType {
+	switch typed := dataType.(type) {
+	case *arrow.StructType:
+		iceStruct, ok := iceType.(*iceberggo.StructType)
+		if !ok {
+			return dataType
+		}
+		fields := typed.Fields()
+		for i := range fields {
+			for _, iceField := range iceStruct.FieldList {
+				if iceField.Name == fields[i].Name {
+					fields[i].Nullable = !iceField.Required
+					fields[i].Type = overlayIcebergRequiredness(fields[i].Type, iceField.Type)
+					break
+				}
+			}
+		}
+		return arrow.StructOf(fields...)
+	case *arrow.ListType:
+		iceList, ok := iceType.(*iceberggo.ListType)
+		if !ok {
+			return dataType
+		}
+		elem := typed.ElemField()
+		elem.Nullable = !iceList.ElementRequired
+		elem.Type = overlayIcebergRequiredness(elem.Type, iceList.Element)
+		return arrow.ListOfField(elem)
+	case *arrow.MapType:
+		iceMap, ok := iceType.(*iceberggo.MapType)
+		if !ok {
+			return dataType
+		}
+		key := typed.KeyField()
+		key.Nullable = false
+		key.Type = overlayIcebergRequiredness(key.Type, iceMap.KeyType)
+		value := typed.ItemField()
+		value.Nullable = !iceMap.ValueRequired
+		value.Type = overlayIcebergRequiredness(value.Type, iceMap.ValueType)
+		return arrow.MapOfFields(key, value)
+	default:
+		return dataType
+	}
+}
+
 func icebergArrowType(col schema.Column) arrow.DataType {
 	switch col.DataType {
 	case schema.TypeJSON, schema.TypeUnknown:
 		return arrow.BinaryTypes.String
+	case schema.TypeBinary:
+		return arrow.BinaryTypes.Binary
 	case schema.TypeUUID:
 		return extensions.NewUUIDType()
 	case schema.TypeArray:
-		elem := icebergArrowType(schema.Column{
-			DataType:  col.ArrayType,
-			Precision: col.Precision,
-			Scale:     col.Scale,
-		})
-		return arrow.ListOf(elem)
+		elem := col.Element
+		if elem == nil {
+			elem = &schema.Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale, MaxLength: col.MaxLength, FixedLength: col.FixedLength, Nullable: true}
+		}
+		return arrow.ListOfField(arrow.Field{Name: "element", Type: icebergArrowType(*elem), Nullable: elem.Nullable})
+	case schema.TypeStruct:
+		if col.StructFields == nil {
+			return arrow.StructOf()
+		}
+		fields := make([]arrow.Field, len(col.StructFields.Columns))
+		for i, field := range col.StructFields.Columns {
+			fields[i] = arrow.Field{Name: field.Name, Type: icebergArrowType(field), Nullable: field.Nullable}
+		}
+		return arrow.StructOf(fields...)
+	case schema.TypeMap:
+		key := schema.Column{DataType: schema.TypeString, Nullable: false}
+		if col.MapKey != nil {
+			key = *col.MapKey
+		}
+		value := schema.Column{DataType: schema.TypeUnknown, Nullable: true}
+		if col.MapValue != nil {
+			value = *col.MapValue
+		}
+		return arrow.MapOfFields(
+			arrow.Field{Name: "key", Type: icebergArrowType(key), Nullable: false},
+			arrow.Field{Name: "value", Type: icebergArrowType(value), Nullable: value.Nullable},
+		)
 	default:
 		dt := schema.DataTypeToArrowType(col)
 		if ext, ok := dt.(arrow.ExtensionType); ok {
@@ -106,7 +192,42 @@ func icebergArrowType(col schema.Column) arrow.DataType {
 }
 
 func icebergTypeForColumn(col schema.Column) (iceberggo.Type, error) {
-	return icebergtable.ArrowTypeToIceberg(icebergArrowType(col), false)
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: col.Name, Type: icebergArrowType(col), Nullable: col.Nullable}}, nil)
+	iceSchema, err := icebergtable.ArrowSchemaToIcebergWithFreshIDs(arrowSchema, false)
+	if err != nil {
+		return nil, err
+	}
+	field, ok := iceSchema.FindFieldByName(col.Name)
+	if !ok {
+		return nil, fmt.Errorf("converted Iceberg field %q not found", col.Name)
+	}
+	return field.Type, nil
+}
+
+func icebergTypesEquivalent(left, right iceberggo.Type) bool {
+	switch l := left.(type) {
+	case *iceberggo.ListType:
+		r, ok := right.(*iceberggo.ListType)
+		return ok && l.ElementRequired == r.ElementRequired && icebergTypesEquivalent(l.Element, r.Element)
+	case *iceberggo.MapType:
+		r, ok := right.(*iceberggo.MapType)
+		return ok && l.ValueRequired == r.ValueRequired &&
+			icebergTypesEquivalent(l.KeyType, r.KeyType) && icebergTypesEquivalent(l.ValueType, r.ValueType)
+	case *iceberggo.StructType:
+		r, ok := right.(*iceberggo.StructType)
+		if !ok || len(l.FieldList) != len(r.FieldList) {
+			return false
+		}
+		for i := range l.FieldList {
+			lf, rf := l.FieldList[i], r.FieldList[i]
+			if lf.Name != rf.Name || lf.Required != rf.Required || !icebergTypesEquivalent(lf.Type, rf.Type) {
+				return false
+			}
+		}
+		return true
+	default:
+		return left.Equals(right)
+	}
 }
 
 func tableSchemaFromIceberg(name string, iceSchema *iceberggo.Schema) (*schema.TableSchema, error) {
@@ -142,11 +263,13 @@ func columnFromIcebergField(field iceberggo.NestedField) (schema.Column, error) 
 		Name:     field.Name,
 		Nullable: !field.Required,
 	}
-	applyIcebergType(&col, field.Type)
+	if err := applyIcebergType(&col, field.Type); err != nil {
+		return schema.Column{}, fmt.Errorf("iceberg: column %q uses an unsupported type: %w", field.Name, err)
+	}
 	return col, nil
 }
 
-func applyIcebergType(col *schema.Column, typ iceberggo.Type) {
+func applyIcebergType(col *schema.Column, typ iceberggo.Type) error {
 	switch t := typ.(type) {
 	case iceberggo.BooleanType:
 		col.DataType = schema.TypeBoolean
@@ -169,32 +292,59 @@ func applyIcebergType(col *schema.Column, typ iceberggo.Type) {
 	case iceberggo.BinaryType:
 		col.DataType = schema.TypeBinary
 	case iceberggo.FixedType:
-		col.DataType = schema.TypeBinary
-		col.MaxLength = t.Len()
+		col.DataType = schema.TypeFixedBinary
+		col.FixedLength = t.Len()
 	case iceberggo.DateType:
 		col.DataType = schema.TypeDate
 	case iceberggo.TimeType:
 		col.DataType = schema.TypeTime
-	case iceberggo.TimestampType, iceberggo.TimestampNsType:
+	case iceberggo.TimestampType:
 		col.DataType = schema.TypeTimestamp
-	case iceberggo.TimestampTzType, iceberggo.TimestampTzNsType:
+	case iceberggo.TimestampTzType:
 		col.DataType = schema.TypeTimestampTZ
+	case iceberggo.TimestampNsType, iceberggo.TimestampTzNsType:
+		return fmt.Errorf("nanosecond timestamps cannot be represented without precision loss; ingestr uses microseconds")
 	case iceberggo.UnknownType:
 		col.DataType = schema.TypeUnknown
-	case iceberggo.VariantType, *iceberggo.StructType, *iceberggo.MapType:
-		col.DataType = schema.TypeJSON
+	case iceberggo.VariantType:
+		return fmt.Errorf("native Iceberg %s values cannot be represented by ingestr's flat schema; serialize or flatten the column at the source", typ.Type())
+	case *iceberggo.StructType:
+		fields := make([]schema.Column, 0, len(t.FieldList))
+		for _, field := range t.FieldList {
+			nested, err := columnFromIcebergField(field)
+			if err != nil {
+				return err
+			}
+			fields = append(fields, nested)
+		}
+		col.DataType = schema.TypeStruct
+		col.StructFields = &schema.TableSchema{Columns: fields}
+	case *iceberggo.MapType:
+		key := schema.Column{Name: "key", Nullable: false}
+		if err := applyIcebergType(&key, t.KeyType); err != nil {
+			return fmt.Errorf("map key: %w", err)
+		}
+		value := schema.Column{Name: "value", Nullable: !t.ValueRequired}
+		if err := applyIcebergType(&value, t.ValueType); err != nil {
+			return fmt.Errorf("map value: %w", err)
+		}
+		col.DataType = schema.TypeMap
+		col.MapKey = &key
+		col.MapValue = &value
 	case *iceberggo.ListType:
-		elem := schema.Column{}
-		applyIcebergType(&elem, t.Element)
-		if elem.DataType == schema.TypeJSON || elem.DataType == schema.TypeArray || elem.DataType == schema.TypeUnknown {
-			col.DataType = schema.TypeJSON
-			return
+		elem := schema.Column{Name: "element", Nullable: !t.ElementRequired}
+		if err := applyIcebergType(&elem, t.Element); err != nil {
+			return fmt.Errorf("list element: %w", err)
 		}
 		col.DataType = schema.TypeArray
 		col.ArrayType = elem.DataType
+		col.Element = &elem
 		col.Precision = elem.Precision
 		col.Scale = elem.Scale
+		col.MaxLength = elem.MaxLength
+		col.FixedLength = elem.FixedLength
 	default:
-		col.DataType = schema.TypeString
+		return fmt.Errorf("iceberg type %s cannot be represented by ingestr", typ.Type())
 	}
+	return nil
 }

--- a/pkg/destination/iceberg/observability.go
+++ b/pkg/destination/iceberg/observability.go
@@ -1,0 +1,113 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+)
+
+// CommitInfo describes the current Iceberg snapshot and its ingestion metrics.
+type CommitInfo struct {
+	SnapshotID       int64
+	SequenceNumber   int64
+	CommittedAt      time.Time
+	Operation        string
+	AddedRows        int64
+	DeletedRows      int64
+	TotalRows        int64
+	PhysicalRows     int64
+	AddedDataFiles   int64
+	DeletedDataFiles int64
+	CommitToken      string
+	CDCResumeLSN     string
+}
+
+// GetCommitInfo returns the current committed snapshot metrics for a table.
+func (d *Destination) GetCommitInfo(ctx context.Context, table string) (CommitInfo, error) {
+	return d.getCommitInfo(ctx, table, true)
+}
+
+func (d *Destination) getCommitInfo(ctx context.Context, table string, logicalCount bool) (CommitInfo, error) {
+	tbl, err := d.loadIcebergTable(ctx, table)
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	snapshot := tbl.CurrentSnapshot()
+	if snapshot == nil {
+		return CommitInfo{}, nil
+	}
+	info := CommitInfo{
+		SnapshotID:     snapshot.SnapshotID,
+		SequenceNumber: snapshot.SequenceNumber,
+		CommittedAt:    time.UnixMilli(snapshot.TimestampMs).UTC(),
+		CDCResumeLSN:   latestCDCResumeLSN(tbl),
+	}
+	if snapshot.Summary == nil {
+		return info, nil
+	}
+	info.Operation = snapshot.Summary.Properties["ingestr.operation"]
+	if info.Operation == "" {
+		info.Operation = string(snapshot.Summary.Operation)
+	}
+	info.AddedRows = snapshotMetric(snapshot.Summary.Properties, "added-records")
+	info.DeletedRows = snapshotMetric(snapshot.Summary.Properties, "deleted-records")
+	info.PhysicalRows = snapshotMetric(snapshot.Summary.Properties, "total-records")
+	info.TotalRows = info.PhysicalRows
+	info.AddedDataFiles = snapshotMetric(snapshot.Summary.Properties, "added-data-files")
+	info.DeletedDataFiles = snapshotMetric(snapshot.Summary.Properties, "deleted-data-files")
+	info.CommitToken = snapshot.Summary.Properties[snapshotCommitTokenKey]
+	if logicalCount {
+		rows, err := tbl.Scan().ToArrowTable(ctx)
+		if err != nil {
+			return CommitInfo{}, fmt.Errorf("iceberg: failed to count logical rows for table %s: %w", table, err)
+		}
+		info.TotalRows = rows.NumRows()
+		rows.Release()
+	}
+	return info, nil
+}
+
+func snapshotMetric(properties map[string]string, key string) int64 {
+	value, _ := strconv.ParseInt(properties[key], 10, 64)
+	return value
+}
+
+func (d *Destination) afterSuccessfulCommit(ctx context.Context, table string) {
+	d.afterSuccessfulCommitExpected(ctx, table, "")
+}
+
+func (d *Destination) afterSuccessfulCommitExpected(ctx context.Context, table, expectedIncarnation string) {
+	inspectCtx, cancelInspect := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+	info, err := d.getCommitInfo(inspectCtx, table, false)
+	cancelInspect()
+	if err != nil {
+		config.Debug("[ICEBERG] Failed to inspect committed snapshot for %s: %v", table, err)
+	} else {
+		config.Debug(
+			"[ICEBERG] Committed table=%s snapshot=%d sequence=%d operation=%s added_rows=%d deleted_rows=%d total_rows=%d added_files=%d deleted_files=%d cdc_resume_lsn=%s",
+			table,
+			info.SnapshotID,
+			info.SequenceNumber,
+			info.Operation,
+			info.AddedRows,
+			info.DeletedRows,
+			info.TotalRows,
+			info.AddedDataFiles,
+			info.DeletedDataFiles,
+			info.CDCResumeLSN,
+		)
+	}
+	// Budgets only the load/lease/cleanup phases; runConfiguredMaintenance
+	// gives an actual maintenance run its own budget once the table's
+	// effective properties say it is due.
+	maintenanceCtx, cancelMaintenance := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	d.runConfiguredMaintenanceExpected(maintenanceCtx, table, expectedIncarnation)
+	cancelMaintenance()
+}
+
+func (i CommitInfo) String() string {
+	return fmt.Sprintf("snapshot=%d operation=%s added_rows=%d deleted_rows=%d total_rows=%d", i.SnapshotID, i.Operation, i.AddedRows, i.DeletedRows, i.TotalRows)
+}

--- a/pkg/destination/iceberg/partition.go
+++ b/pkg/destination/iceberg/partition.go
@@ -1,0 +1,149 @@
+package iceberg
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+var partitionNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+
+type partitionTerm struct {
+	source    string
+	name      string
+	transform iceberggo.Transform
+}
+
+func validatePreparedLayoutColumns(tableSchema *schema.TableSchema, partitionBy string, clusterBy []string) error {
+	available := make(map[string]struct{}, len(tableSchema.Columns))
+	for _, col := range tableSchema.Columns {
+		available[col.Name] = struct{}{}
+	}
+	terms, err := parsePartitionExpression(partitionBy)
+	if err != nil {
+		return err
+	}
+	for _, term := range terms {
+		if _, ok := available[term.source]; !ok {
+			return fmt.Errorf("iceberg: partition column %q not found", term.source)
+		}
+	}
+	for _, column := range clusterBy {
+		if _, ok := available[column]; !ok {
+			return fmt.Errorf("iceberg: cluster column %q not found", column)
+		}
+	}
+	return nil
+}
+
+func preparedLayoutColumnsExist(tableSchema *schema.TableSchema, partitionBy string, clusterBy []string) bool {
+	return validatePreparedLayoutColumns(tableSchema, partitionBy, clusterBy) == nil
+}
+
+func layoutColumnsExist(iceSchema *iceberggo.Schema, partitionBy string, clusterBy []string) bool {
+	terms, err := parsePartitionExpression(partitionBy)
+	if err != nil {
+		return false
+	}
+	for _, term := range terms {
+		if _, ok := iceSchema.FindFieldByName(term.source); !ok {
+			return false
+		}
+	}
+	for _, column := range clusterBy {
+		if _, ok := iceSchema.FindFieldByName(column); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func parsePartitionExpression(expression string) ([]partitionTerm, error) {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(expression, ",")
+	terms := make([]partitionTerm, 0, len(parts))
+	seenNames := make(map[string]struct{}, len(parts))
+	for _, raw := range parts {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return nil, fmt.Errorf("iceberg: invalid partition specification %q: empty field", expression)
+		}
+
+		transformName := "identity"
+		source := raw
+		if open := strings.IndexByte(raw, '('); open >= 0 {
+			if !strings.HasSuffix(raw, ")") || open == 0 {
+				return nil, fmt.Errorf("iceberg: invalid partition field %q", raw)
+			}
+			transformName = strings.TrimSpace(raw[:open])
+			source = strings.TrimSpace(raw[open+1 : len(raw)-1])
+			if strings.Contains(source, "(") || strings.Contains(source, ")") {
+				return nil, fmt.Errorf("iceberg: invalid partition field %q", raw)
+			}
+		}
+		if source == "" {
+			return nil, fmt.Errorf("iceberg: invalid partition field %q: source column is empty", raw)
+		}
+
+		transform, err := iceberggo.ParseTransform(strings.ToLower(transformName))
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: invalid partition transform in %q: %w", raw, err)
+		}
+		name := source
+		if _, identity := transform.(iceberggo.IdentityTransform); !identity {
+			suffix := partitionNameSanitizer.ReplaceAllString(strings.ToLower(transform.String()), "_")
+			suffix = strings.Trim(suffix, "_")
+			name = source + "_" + suffix
+		}
+		if _, duplicate := seenNames[name]; duplicate {
+			return nil, fmt.Errorf("iceberg: partition field name %q is duplicated", name)
+		}
+		seenNames[name] = struct{}{}
+		terms = append(terms, partitionTerm{source: source, name: name, transform: transform})
+	}
+	return terms, nil
+}
+
+func buildPartitionSpec(iceSchema *iceberggo.Schema, expression string) (iceberggo.PartitionSpec, error) {
+	terms, err := parsePartitionExpression(expression)
+	if err != nil {
+		return iceberggo.PartitionSpec{}, err
+	}
+	opts := make([]iceberggo.PartitionOption, 0, len(terms))
+	for _, term := range terms {
+		opts = append(opts, iceberggo.AddPartitionFieldByName(term.source, term.name, term.transform, iceSchema, nil))
+	}
+	spec, err := iceberggo.NewPartitionSpecOpts(opts...)
+	if err != nil {
+		return iceberggo.PartitionSpec{}, fmt.Errorf("iceberg: invalid partition specification %q: %w", expression, err)
+	}
+	return spec, nil
+}
+
+func partitionExpressionMatches(tbl *icebergtable.Table, expression string) bool {
+	terms, err := parsePartitionExpression(expression)
+	if err != nil {
+		return false
+	}
+	spec := tbl.Metadata().PartitionSpec()
+	i := 0
+	for _, field := range spec.Fields() {
+		if i >= len(terms) {
+			return false
+		}
+		source, ok := tbl.Schema().FindColumnName(field.SourceID())
+		if !ok || source != terms[i].source || field.Name != terms[i].name || !field.Transform.Equals(terms[i].transform) {
+			return false
+		}
+		i++
+	}
+	return i == len(terms)
+}

--- a/pkg/destination/iceberg/purge_journal.go
+++ b/pkg/destination/iceberg/purge_journal.go
@@ -1,0 +1,701 @@
+package iceberg
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"gocloud.dev/gcerrors"
+)
+
+var errPurgeJournalRootUnavailable = errors.New("client-side purge requires a filesystem warehouse for durable cleanup journals")
+
+const purgeJournalVersion = 1
+
+type purgeJournal struct {
+	Version             int        `json:"version"`
+	Identifier          []string   `json:"identifier"`
+	DeletionIdentifiers [][]string `json:"deletion_identifiers,omitempty"`
+	TableUUID           string     `json:"table_uuid"`
+	TableLocation       string     `json:"table_location"`
+	Files               []string   `json:"files"`
+	CreatedAt           string     `json:"created_at"`
+}
+
+func (d *Destination) createPurgeJournal(ctx context.Context, tbl *icebergtable.Table) (*purgeJournal, icebergio.IO, icebergio.IO, string, string, error) {
+	lockToken, err := d.acquirePurgeLock(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String())
+	if err != nil {
+		return nil, nil, nil, "", "", err
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", fmt.Errorf("failed to load filesystem for purge journal: %w", err)
+	}
+	listable, ok := tableFS.(icebergio.ListableIO)
+	if !ok {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", fmt.Errorf("table filesystem cannot list files for a durable purge journal")
+	}
+	files, err := filesUnderTableLocation(ctx, listable, tbl.Location())
+	if err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", err
+	}
+	slices.Sort(files)
+
+	journal := &purgeJournal{
+		Version:             purgeJournalVersion,
+		Identifier:          slices.Clone(tbl.Identifier()),
+		DeletionIdentifiers: [][]string{deletionFenceIdentifier(tbl.Identifier())},
+		TableUUID:           tbl.Metadata().TableUUID().String(),
+		TableLocation:       tbl.Location(),
+		Files:               files,
+		CreatedAt:           time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := validatePurgeJournal(journal, tbl.Identifier()); err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", err
+	}
+	if err := d.validatePurgeJournalLocation(journal); err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", err
+	}
+	journalPath, err := d.purgeJournalPath(tbl.Identifier())
+	if err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", err
+	}
+	journalFS, err := icebergio.LoadFS(ctx, d.cfg.Properties, journalPath)
+	if err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", fmt.Errorf("failed to load purge journal filesystem: %w", err)
+	}
+	if err := writePurgeJournal(journalFS, journalPath, journal); err != nil {
+		_ = d.releasePurgeLockOwned(ctx, tbl.Identifier(), tbl.Metadata().TableUUID().String(), lockToken)
+		return nil, nil, nil, "", "", err
+	}
+	return journal, tableFS, journalFS, journalPath, lockToken, nil
+}
+
+func (d *Destination) resumePurgeJournal(ctx context.Context, ident icebergtable.Identifier) (retErr error) {
+	journalPath, err := d.purgeJournalPath(ident)
+	if err != nil {
+		return err
+	}
+	journalFS, err := icebergio.LoadFS(ctx, d.cfg.Properties, journalPath)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load purge journal filesystem: %w", err)
+	}
+	_, loadErr := d.catalog.LoadTable(ctx, ident)
+	journal, readErr := readPurgeJournal(journalFS, journalPath, ident)
+	if isObjectNotFound(readErr) {
+		return nil
+	}
+	if loadErr == nil {
+		if readErr != nil {
+			return fmt.Errorf("iceberg: table %s exists; refusing corrupt journaled physical purge: %w", strings.Join(ident, "."), readErr)
+		}
+		claimToken, err := d.claimPurgeResume(ctx, ident, journal.TableUUID)
+		if err != nil {
+			return fmt.Errorf("iceberg: table %s still exists and its purge recovery cannot be claimed: %w", strings.Join(ident, "."), err)
+		}
+		if err := d.releasePurgeLockOwned(ctx, ident, journal.TableUUID, claimToken); err != nil {
+			return fmt.Errorf("iceberg: table %s still exists; failed to release abandoned purge lock: %w", strings.Join(ident, "."), err)
+		}
+		if err := removePurgeJournal(journalFS, journalPath); err != nil {
+			return fmt.Errorf("iceberg: table %s still exists; failed to discard abandoned purge journal: %w", strings.Join(ident, "."), err)
+		}
+		return nil
+	}
+	if !isMissingTableOrNamespace(loadErr) {
+		return fmt.Errorf("iceberg: could not confirm table %s is absent before journaled physical purge: %w", strings.Join(ident, "."), loadErr)
+	}
+	if readErr != nil {
+		return fmt.Errorf("iceberg: catalog confirms table %s is absent but its purge journal is corrupt and was retained: %w", strings.Join(ident, "."), readErr)
+	}
+	if err := d.validatePurgeJournalLocation(journal); err != nil {
+		return fmt.Errorf("iceberg: unsafe purge journal for table %s: %w", strings.Join(ident, "."), err)
+	}
+	claimToken, err := d.claimPurgeResume(ctx, ident, journal.TableUUID)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to claim purge recovery for table %s: %w", strings.Join(ident, "."), err)
+	}
+	claimActive := true
+	defer func() {
+		if !claimActive {
+			return
+		}
+		if err := d.relinquishPurgeClaim(context.WithoutCancel(ctx), ident, journal.TableUUID, claimToken); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("iceberg: failed to relinquish purge recovery claim for %s: %w", strings.Join(ident, "."), err))
+		}
+	}()
+	if err := d.recoverJournalDeletionFence(ctx, journalFS, journalPath, journal); err != nil {
+		return fmt.Errorf("iceberg: failed to recover fenced catalog deletion for table %s: %w", strings.Join(ident, "."), err)
+	}
+	if err := d.validateOrphanCleanupLocation(ctx, ident, journal.TableLocation); err != nil {
+		return fmt.Errorf("iceberg: journaled purge isolation check failed for table %s: %w", strings.Join(ident, "."), err)
+	}
+	tableFS, err := icebergio.LoadFS(ctx, d.cfg.Properties, journal.TableLocation)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load table filesystem for journaled purge: %w", err)
+	}
+	if _, ok := tableFS.(icebergio.ListableIO); !ok {
+		return fmt.Errorf("iceberg: table filesystem cannot list residue for journaled purge")
+	}
+
+	if err := executePurgeJournal(ctx, d, tableFS, journalFS, journalPath, journal, claimToken); err != nil {
+		return fmt.Errorf("iceberg: failed to resume physical purge for table %s: %w", strings.Join(ident, "."), err)
+	}
+	claimActive = false
+	return nil
+}
+
+func (d *Destination) recoverJournalDeletionFence(
+	ctx context.Context,
+	journalFS icebergio.IO,
+	journalPath string,
+	journal *purgeJournal,
+) error {
+	var live *icebergtable.Table
+	for _, deletionIdent := range journal.DeletionIdentifiers {
+		tbl, err := d.catalog.LoadTable(ctx, deletionIdent)
+		if isMissingTableOrNamespace(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to inspect deletion fence %s: %w", strings.Join(deletionIdent, "."), err)
+		}
+		if tbl.Metadata().TableUUID().String() != journal.TableUUID {
+			return fmt.Errorf("deletion fence %s was reused by another table generation", strings.Join(deletionIdent, "."))
+		}
+		if live != nil {
+			return fmt.Errorf("multiple live deletion fences exist for table %s", strings.Join(journal.Identifier, "."))
+		}
+		live = tbl
+	}
+	if live == nil {
+		return nil
+	}
+	if d.cfg.Properties.Get("type", "") == "hadoop" {
+		if err := d.catalog.DropTable(ctx, live.Identifier()); err != nil && !isMissingTableOrNamespace(err) {
+			return fmt.Errorf("failed to remove verified Hadoop deletion fence %s: %w", strings.Join(live.Identifier(), "."), err)
+		}
+		return nil
+	}
+
+	next := deletionFenceIdentifier(journal.Identifier)
+	journal.DeletionIdentifiers = append(journal.DeletionIdentifiers, slices.Clone(next))
+	if err := writePurgeJournal(journalFS, journalPath, journal); err != nil {
+		return fmt.Errorf("failed to persist next deletion fence before recovery: %w", err)
+	}
+	claimed, err := d.claimTableForDeletionAt(ctx, live, journal.TableUUID, nil, next)
+	if err != nil {
+		return err
+	}
+	if err := d.catalog.DropTable(ctx, claimed.Identifier()); err != nil && !isMissingTableOrNamespace(err) {
+		remaining, loadErr := d.catalog.LoadTable(context.WithoutCancel(ctx), claimed.Identifier())
+		if isMissingTableOrNamespace(loadErr) {
+			return nil
+		}
+		if loadErr == nil && remaining.Metadata().TableUUID().String() != journal.TableUUID {
+			return fmt.Errorf("recovery deletion fence was replaced after claiming it")
+		}
+		return errors.Join(fmt.Errorf("failed to remove recovered deletion fence: %w", err), loadErr)
+	}
+	return nil
+}
+
+func executePurgeJournal(
+	ctx context.Context,
+	destination *Destination,
+	tableFS icebergio.IO,
+	journalFS icebergio.IO,
+	journalPath string,
+	journal *purgeJournal,
+	lockToken string,
+) error {
+	catalog := destination.catalog
+	purgeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), clientSidePurgeTimeout)
+	defer cancel()
+
+	var purgeErr error
+	for attempt := range clientSidePurgeMaxAttempts {
+		live, err := catalog.LoadTable(purgeCtx, journal.Identifier)
+		if err == nil {
+			if live.Metadata().TableUUID().String() != journal.TableUUID {
+				if err := destination.releasePurgeLockOwned(purgeCtx, journal.Identifier, journal.TableUUID, lockToken); err != nil {
+					return fmt.Errorf("table identifier was reused; failed to release purge lock: %w", err)
+				}
+				if removeErr := removePurgeJournal(journalFS, journalPath); removeErr != nil {
+					return fmt.Errorf("table identifier was reused; failed to discard stale purge journal: %w", removeErr)
+				}
+				return nil
+			}
+			return fmt.Errorf("table still exists; refusing physical purge")
+		}
+		if !isMissingTableOrNamespace(err) {
+			return fmt.Errorf("could not confirm catalog absence: %w", err)
+		}
+
+		purgeErr = removeTableFiles(purgeCtx, tableFS, journal.Files)
+		for purgeErr == nil {
+			listable, ok := tableFS.(icebergio.ListableIO)
+			if !ok {
+				return fmt.Errorf("table filesystem cannot list residue after purge")
+			}
+			residue, listErr := filesUnderTableLocation(purgeCtx, listable, journal.TableLocation)
+			if listErr != nil {
+				purgeErr = listErr
+			} else {
+				for _, file := range residue {
+					if !locationContains(journal.TableLocation, file) {
+						return fmt.Errorf("listed residue %q escapes table location %q", file, journal.TableLocation)
+					}
+				}
+				if len(residue) == 0 {
+					break
+				}
+				live, loadErr := catalog.LoadTable(purgeCtx, journal.Identifier)
+				if loadErr == nil {
+					if live.Metadata().TableUUID().String() != journal.TableUUID {
+						if err := destination.releasePurgeLockOwned(purgeCtx, journal.Identifier, journal.TableUUID, lockToken); err != nil {
+							return fmt.Errorf("table identifier was reused; failed to release purge lock: %w", err)
+						}
+						if removeErr := removePurgeJournal(journalFS, journalPath); removeErr != nil {
+							return fmt.Errorf("table identifier was reused; failed to discard stale purge journal: %w", removeErr)
+						}
+						return nil
+					}
+					return fmt.Errorf("table reappeared while purging residue; refusing further deletion")
+				}
+				if !isMissingTableOrNamespace(loadErr) {
+					return fmt.Errorf("could not reconfirm catalog absence before deleting residue: %w", loadErr)
+				}
+				purgeErr = removeTableFiles(purgeCtx, tableFS, residue)
+			}
+		}
+		if purgeErr == nil {
+			if err := destination.releasePurgeLockOwned(purgeCtx, journal.Identifier, journal.TableUUID, lockToken); err != nil {
+				return fmt.Errorf("physical files were removed but purge lock could not be released: %w", err)
+			}
+			if err := removePurgeJournal(journalFS, journalPath); err != nil {
+				return fmt.Errorf("physical files were removed but purge journal could not be removed: %w", err)
+			}
+			return nil
+		}
+		if attempt == clientSidePurgeMaxAttempts-1 {
+			break
+		}
+		wait := min(100*time.Millisecond<<attempt, 2*time.Second)
+		timer := time.NewTimer(wait)
+		select {
+		case <-purgeCtx.Done():
+			timer.Stop()
+			return errors.Join(purgeErr, purgeCtx.Err())
+		case <-timer.C:
+		}
+	}
+	return purgeErr
+}
+
+func (d *Destination) purgeJournalPath(ident icebergtable.Identifier) (string, error) {
+	base, err := d.purgeJournalRoot(ident)
+	if err != nil {
+		return "", err
+	}
+	name := identifierHash(d.cfg.CatalogName, ident) + ".json"
+	return appendLocationPath(base, name, false), nil
+}
+
+func (d *Destination) purgeJournalExists(ctx context.Context, ident icebergtable.Identifier) (bool, error) {
+	journalPath, err := d.purgeJournalPath(ident)
+	if err != nil {
+		return false, err
+	}
+	journalFS, err := icebergio.LoadFS(ctx, d.cfg.Properties, journalPath)
+	if err != nil {
+		return false, err
+	}
+	file, err := journalFS.Open(journalPath)
+	if isObjectNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := file.Close(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func identifierHash(catalogName string, ident icebergtable.Identifier) string {
+	hashInput := catalogName + "\x00" + strings.Join(ident, "\x00")
+	sum := sha256.Sum256([]byte(hashInput))
+	return hex.EncodeToString(sum[:])
+}
+
+func (d *Destination) purgeJournalRoot(ident icebergtable.Identifier) (string, error) {
+	base := d.configuredPurgeWarehouse()
+	if base == "" || strings.HasPrefix(strings.ToLower(base), "arn:") {
+		return "", fmt.Errorf("iceberg: %w", errPurgeJournalRootUnavailable)
+	}
+	if localBase, ok := localFilesystemPath(base); ok && !filepath.IsAbs(localBase) {
+		return "", fmt.Errorf("iceberg: client-side purge requires an absolute filesystem warehouse for durable cleanup journals")
+	}
+	return appendLocationPath(base, ".ingestr/purge-journals", false), nil
+}
+
+func (d *Destination) configuredPurgeWarehouse() string {
+	base := d.cfg.PurgeJournalRoot
+	if strings.TrimSpace(base) == "" {
+		base = d.cfg.Properties.Get("warehouse", "")
+	}
+	return strings.TrimSuffix(strings.TrimSpace(base), "/")
+}
+
+func writePurgeJournal(tableFS icebergio.IO, journalPath string, journal *purgeJournal) error {
+	writer, ok := tableFS.(icebergio.WriteFileIO)
+	if !ok {
+		return fmt.Errorf("filesystem cannot persist durable purge journals")
+	}
+	payload, err := json.Marshal(journal)
+	if err != nil {
+		return fmt.Errorf("failed to encode purge journal: %w", err)
+	}
+	if localPath, ok := localFilesystemPath(journalPath); ok {
+		if !filepath.IsAbs(localPath) {
+			return fmt.Errorf("purge journal path must be absolute: %s", journalPath)
+		}
+		return writeLocalPurgeJournal(localPath, payload)
+	}
+	if err := writer.WriteFile(journalPath, payload); err != nil {
+		return fmt.Errorf("failed to persist purge journal %s: %w", journalPath, err)
+	}
+	written, err := readBoundedIOFile(tableFS, journalPath, 64<<20)
+	if err != nil {
+		return fmt.Errorf("failed to verify persisted purge journal %s: %w", journalPath, err)
+	}
+	if !slices.Equal(written, payload) {
+		return fmt.Errorf("persisted purge journal %s failed verification", journalPath)
+	}
+	return nil
+}
+
+func ensureJournalDirectory(journalPath string) error {
+	if err := os.MkdirAll(filepath.Dir(journalPath), 0o700); err != nil {
+		return fmt.Errorf("failed to create purge journal directory: %w", err)
+	}
+	return nil
+}
+
+func writeLocalPurgeJournal(journalPath string, payload []byte) error {
+	if err := ensureJournalDirectory(journalPath); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(journalPath), ".purge-journal-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create purge journal temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(payload); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("failed to write purge journal temporary file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("failed to sync purge journal temporary file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, journalPath); err != nil {
+		return fmt.Errorf("failed to atomically publish purge journal: %w", err)
+	}
+	dir, err := os.Open(filepath.Dir(journalPath))
+	if err != nil {
+		return fmt.Errorf("failed to open purge journal directory for sync: %w", err)
+	}
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		return fmt.Errorf("failed to sync purge journal directory: %w", err)
+	}
+	if err := dir.Close(); err != nil {
+		return fmt.Errorf("failed to close purge journal directory: %w", err)
+	}
+	return nil
+}
+
+func readPurgeJournal(tableFS icebergio.IO, journalPath string, ident icebergtable.Identifier) (*purgeJournal, error) {
+	payload, err := readBoundedIOFile(tableFS, journalPath, 64<<20)
+	if err != nil {
+		return nil, err
+	}
+	var journal purgeJournal
+	if err := json.Unmarshal(payload, &journal); err != nil {
+		return nil, fmt.Errorf("invalid purge journal JSON: %w", err)
+	}
+	if err := validatePurgeJournal(&journal, ident); err != nil {
+		return nil, err
+	}
+	return &journal, nil
+}
+
+func validatePurgeJournal(journal *purgeJournal, ident icebergtable.Identifier) error {
+	if journal == nil || journal.Version != purgeJournalVersion {
+		return fmt.Errorf("unsupported purge journal version")
+	}
+	if !slices.Equal(journal.Identifier, ident) {
+		return fmt.Errorf("purge journal identifier mismatch")
+	}
+	parsedUUID, err := uuid.Parse(journal.TableUUID)
+	if err != nil || parsedUUID == uuid.Nil {
+		return fmt.Errorf("purge journal has invalid table UUID %q", journal.TableUUID)
+	}
+	if strings.TrimSpace(journal.TableLocation) == "" {
+		return fmt.Errorf("purge journal table location is empty")
+	}
+	for _, deletionIdent := range journal.DeletionIdentifiers {
+		if len(deletionIdent) != len(ident) ||
+			!slices.Equal(icebergcatalog.NamespaceFromIdent(deletionIdent), icebergcatalog.NamespaceFromIdent(ident)) ||
+			!strings.HasPrefix(deletionIdent[len(deletionIdent)-1], deletionFenceTablePrefix) {
+			return fmt.Errorf("purge journal has invalid deletion fence identifier %q", strings.Join(deletionIdent, "."))
+		}
+	}
+	for _, file := range journal.Files {
+		if !locationContains(journal.TableLocation, file) {
+			return fmt.Errorf("purge journal file %q is outside table location %q", file, journal.TableLocation)
+		}
+	}
+	return nil
+}
+
+func (d *Destination) validatePurgeJournalLocation(journal *purgeJournal) error {
+	warehouse := d.configuredPurgeWarehouse()
+	if warehouse == "" {
+		return fmt.Errorf("configured filesystem warehouse is required to validate table location %q", journal.TableLocation)
+	}
+	if d.cfg.TableLocation != "" {
+		expected := strings.TrimSuffix(renderTableLocation(d.cfg.TableLocation, journal.Identifier), "/")
+		actual := strings.TrimSuffix(journal.TableLocation, "/")
+		if actual != expected && !locationContains(expected, actual) {
+			return fmt.Errorf("table location %q does not match configured location %q", journal.TableLocation, expected)
+		}
+		if warehouse != "" && !locationContains(warehouse, journal.TableLocation) {
+			return fmt.Errorf("table location %q must be a strict descendant of configured warehouse %q", journal.TableLocation, warehouse)
+		}
+		if err := validateCanonicalLocalContainment(warehouse, journal.TableLocation); err != nil {
+			return err
+		}
+		return nil
+	}
+	if warehouse == "" || !locationContains(warehouse, journal.TableLocation) {
+		return fmt.Errorf("table location %q is outside configured warehouse %q", journal.TableLocation, warehouse)
+	}
+	if err := validateCanonicalLocalContainment(warehouse, journal.TableLocation); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateCanonicalLocalContainment(warehouse, tableLocation string) error {
+	warehousePath, warehouseLocal := localFilesystemPath(warehouse)
+	tablePath, tableLocal := localFilesystemPath(tableLocation)
+	if !warehouseLocal || !tableLocal {
+		return nil
+	}
+	canonicalWarehouse, err := resolveExistingPath(warehousePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve warehouse path %q: %w", warehousePath, err)
+	}
+	canonicalTable, err := resolveExistingPath(tablePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve table path %q: %w", tablePath, err)
+	}
+	rel, err := filepath.Rel(canonicalWarehouse, canonicalTable)
+	if err != nil || rel == "." || rel == "" || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("resolved table location %q escapes warehouse %q", canonicalTable, canonicalWarehouse)
+	}
+	return nil
+}
+
+func resolveExistingPath(filePath string) (string, error) {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", err
+	}
+	current := filepath.Clean(abs)
+	var missing []string
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return current, nil
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+}
+
+func locationContains(root, child string) bool {
+	if rootPath, rootLocal := localFilesystemPath(root); rootLocal {
+		if childPath, childLocal := localFilesystemPath(child); childLocal {
+			rel, err := filepath.Rel(filepath.Clean(rootPath), filepath.Clean(childPath))
+			return err == nil && rel != "." && rel != "" && rel != ".." &&
+				!strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+		}
+	}
+	rootURL, rootErr := url.Parse(root)
+	childURL, childErr := url.Parse(child)
+	if rootErr == nil && childErr == nil && (rootURL.Scheme != "" || childURL.Scheme != "") {
+		if !strings.EqualFold(rootURL.Scheme, childURL.Scheme) || !strings.EqualFold(rootURL.Host, childURL.Host) {
+			return false
+		}
+		rootPath := path.Clean("/" + strings.TrimPrefix(rootURL.Path, "/"))
+		childPath := path.Clean("/" + strings.TrimPrefix(childURL.Path, "/"))
+		return childPath != rootPath && strings.HasPrefix(childPath, strings.TrimSuffix(rootPath, "/")+"/")
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(child))
+	return err == nil && rel != "." && rel != "" && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func removePurgeJournal(tableFS icebergio.IO, journalPath string) error {
+	if err := tableFS.Remove(journalPath); err != nil && !isObjectNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func isObjectNotFound(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || gcerrors.Code(err) == gcerrors.NotFound
+}
+
+func (d *Destination) sweepPurgeJournals(ctx context.Context, namespace icebergtable.Identifier) error {
+	if d.catalog == nil {
+		return nil
+	}
+	root, err := d.purgeJournalRoot(namespace)
+	if err != nil {
+		if errors.Is(err, errPurgeJournalRootUnavailable) {
+			return nil
+		}
+		return err
+	}
+	journalFS, err := icebergio.LoadFS(ctx, d.cfg.Properties, root)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to load purge journal filesystem: %w", err)
+	}
+	listable, ok := journalFS.(icebergio.ListableIO)
+	if !ok {
+		return fmt.Errorf("iceberg: purge journal filesystem is not listable")
+	}
+	var journalPaths []string
+	err = listable.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if isObjectNotFound(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if !entry.IsDir() && strings.HasSuffix(filePath, ".json") {
+			journalPaths = append(journalPaths, filePath)
+		}
+		return nil
+	})
+	if isObjectNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to list purge journals: %w", err)
+	}
+	slices.Sort(journalPaths)
+	for _, journalPath := range journalPaths {
+		ident, err := readPurgeJournalIdentifier(journalFS, journalPath)
+		if err != nil {
+			return fmt.Errorf("iceberg: corrupt purge journal %s was retained: %w", journalPath, err)
+		}
+		expectedPath, err := d.purgeJournalPath(ident)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSuffix(journalPath, "/") != strings.TrimSuffix(expectedPath, "/") {
+			return fmt.Errorf(
+				"iceberg: purge journal filename/hash mismatch for embedded identifier %s: got %s, expected %s; journal was retained",
+				strings.Join(ident, "."), journalPath, expectedPath,
+			)
+		}
+		if len(namespace) > 0 && !slices.Equal(icebergcatalog.NamespaceFromIdent(ident), namespace) {
+			continue
+		}
+		if err := d.resumePurgeJournal(ctx, ident); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readPurgeJournalIdentifier(journalFS icebergio.IO, journalPath string) (icebergtable.Identifier, error) {
+	payload, err := readBoundedIOFile(journalFS, journalPath, 64<<20)
+	if err != nil {
+		return nil, err
+	}
+	var header struct {
+		Identifier []string `json:"identifier"`
+	}
+	if err := json.Unmarshal(payload, &header); err != nil {
+		return nil, err
+	}
+	if len(header.Identifier) == 0 {
+		return nil, fmt.Errorf("purge journal identifier is empty")
+	}
+	return header.Identifier, nil
+}
+
+func readBoundedIOFile(tableFS icebergio.IO, filePath string, limit int64) (payload []byte, err error) {
+	file, err := tableFS.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+	payload, err = io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(payload)) > limit {
+		return nil, fmt.Errorf("purge journal exceeds %d-byte size limit", limit)
+	}
+	return payload, nil
+}

--- a/pkg/destination/iceberg/purge_lock.go
+++ b/pkg/destination/iceberg/purge_lock.go
@@ -1,0 +1,385 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+)
+
+const (
+	purgeLockTablePrefix  = "ingestr_purge_lock_"
+	purgeLockTargetKey    = "ingestr.purge-lock-target"
+	purgeLockTableUUIDKey = "ingestr.purge-lock-table-uuid"
+	purgeLockModeKey      = "ingestr.purge-lock-mode"
+	purgeLockTokenKey     = "ingestr.purge-lock-token"
+	purgeLockExpiresAtKey = "ingestr.purge-lock-expires-at"
+	purgeLockModePurge    = "purge"
+	purgeLockModeCreate   = "create"
+	purgeLockModeIdle     = "idle"
+	purgeLockModeCleanup  = "cleanup"
+)
+
+const (
+	purgeResumeClaimTTL = 45 * time.Minute
+	createGuardTTL      = 5 * time.Minute
+)
+
+func (d *Destination) acquirePurgeLock(ctx context.Context, ident icebergtable.Identifier, tableUUID string) (string, error) {
+	lockIdent := purgeLockIdentifier(ident)
+	lockSchema := iceberggo.NewSchema(0, iceberggo.NestedField{
+		ID: 1, Name: "locked", Type: iceberggo.PrimitiveTypes.Bool, Required: true,
+	})
+	for range 5 {
+		token := uuid.NewString()
+		now := time.Now().UTC()
+		existing, err := d.catalog.LoadTable(ctx, lockIdent)
+		if isMissingTableOrNamespace(err) {
+			_, err = d.catalog.CreateTable(ctx, lockIdent, lockSchema, icebergcatalog.WithProperties(iceberggo.Properties{
+				purgeLockTargetKey: strings.Join(ident, "."), purgeLockTableUUIDKey: tableUUID,
+				purgeLockModeKey: purgeLockModePurge, purgeLockTokenKey: token,
+				purgeLockExpiresAtKey: now.Add(purgeResumeClaimTTL).Format(time.RFC3339Nano),
+			}))
+			if err == nil {
+				return token, nil
+			}
+			if errors.Is(err, icebergcatalog.ErrTableAlreadyExists) || strings.Contains(strings.ToLower(errString(err)), "already exists") || strings.Contains(strings.ToLower(errString(err)), "unique constraint") {
+				continue
+			}
+			return "", err
+		}
+		if err != nil {
+			return "", err
+		}
+		if existing.Properties()[purgeLockModeKey] != purgeLockModeIdle {
+			if validationErr := validatePurgeLock(existing, ident, tableUUID); validationErr != nil {
+				return "", validationErr
+			}
+			expiresAt, parseErr := time.Parse(time.RFC3339Nano, existing.Properties()[purgeLockExpiresAtKey])
+			if parseErr != nil || now.Before(expiresAt) {
+				return "", fmt.Errorf("iceberg: purge lock for %s is already held", strings.Join(ident, "."))
+			}
+			if !d.usesServerManagedPurge() {
+				journalExists, journalErr := d.purgeJournalExists(ctx, ident)
+				if journalErr != nil {
+					return "", fmt.Errorf("iceberg: failed to inspect journal for expired purge lock %s: %w", strings.Join(ident, "."), journalErr)
+				}
+				if journalExists {
+					return "", fmt.Errorf("iceberg: expired purge lock for %s still has a recovery journal", strings.Join(ident, "."))
+				}
+			}
+			live, liveErr := d.catalog.LoadTable(ctx, ident)
+			if liveErr != nil {
+				return "", fmt.Errorf("iceberg: cannot reclaim expired purge lock for %s without a live UUID check: %w", strings.Join(ident, "."), liveErr)
+			}
+			if live.Metadata().TableUUID().String() != tableUUID {
+				return "", fmt.Errorf("iceberg: cannot reclaim expired purge lock for %s: live table UUID changed", strings.Join(ident, "."))
+			}
+		}
+		txn := existing.NewTransaction()
+		if err := txn.SetProperties(iceberggo.Properties{
+			purgeLockTargetKey: strings.Join(ident, "."), purgeLockTableUUIDKey: tableUUID,
+			purgeLockModeKey: purgeLockModePurge, purgeLockTokenKey: token,
+			purgeLockExpiresAtKey: now.Add(purgeResumeClaimTTL).Format(time.RFC3339Nano),
+		}); err != nil {
+			return "", err
+		}
+		if _, err := txn.Commit(ctx); err == nil {
+			return token, nil
+		} else if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("iceberg: failed to acquire purge lock for %s after concurrent updates", strings.Join(ident, "."))
+}
+
+func (d *Destination) acquireCreateGuard(ctx context.Context, ident icebergtable.Identifier) (string, error) {
+	lockIdent := purgeLockIdentifier(ident)
+	lockSchema := iceberggo.NewSchema(0, iceberggo.NestedField{
+		ID: 1, Name: "locked", Type: iceberggo.PrimitiveTypes.Bool, Required: true,
+	})
+	for range 5 {
+		now := time.Now().UTC()
+		token := uuid.NewString()
+		existing, err := d.catalog.LoadTable(ctx, lockIdent)
+		if isMissingTableOrNamespace(err) {
+			_, err = d.catalog.CreateTable(
+				ctx, lockIdent, lockSchema,
+				icebergcatalog.WithProperties(iceberggo.Properties{
+					purgeLockTargetKey:    strings.Join(ident, "."),
+					purgeLockModeKey:      purgeLockModeCreate,
+					purgeLockTokenKey:     token,
+					purgeLockExpiresAtKey: now.Add(createGuardTTL).Format(time.RFC3339Nano),
+				}),
+			)
+			if err == nil {
+				return token, nil
+			}
+			if errors.Is(err, icebergcatalog.ErrTableAlreadyExists) ||
+				strings.Contains(strings.ToLower(errString(err)), "unique constraint") ||
+				strings.Contains(strings.ToLower(errString(err)), "already exists") {
+				continue
+			}
+			return "", fmt.Errorf("iceberg: failed to acquire create guard for %s: %w", strings.Join(ident, "."), err)
+		}
+		if err != nil {
+			return "", fmt.Errorf("iceberg: failed to inspect create guard for %s: %w", strings.Join(ident, "."), err)
+		}
+		mode := existing.Properties()[purgeLockModeKey]
+		if mode != purgeLockModeCreate && mode != purgeLockModeIdle && mode != purgeLockModeCleanup ||
+			existing.Properties()[purgeLockTargetKey] != strings.Join(ident, ".") {
+			return "", fmt.Errorf("iceberg: cannot create table %s while a durable purge lock exists", strings.Join(ident, "."))
+		}
+		if mode == purgeLockModeCreate || mode == purgeLockModeCleanup {
+			expiresAt, parseErr := time.Parse(time.RFC3339Nano, existing.Properties()[purgeLockExpiresAtKey])
+			if parseErr != nil || now.Before(expiresAt) {
+				return "", fmt.Errorf("iceberg: cannot create table %s while a durable %s guard exists", strings.Join(ident, "."), mode)
+			}
+		}
+		if !d.usesServerManagedPurge() {
+			journalExists, err := d.purgeJournalExists(ctx, ident)
+			if err != nil {
+				return "", fmt.Errorf("iceberg: cannot reclaim expired create guard for %s without checking its purge journal: %w", strings.Join(ident, "."), err)
+			}
+			if journalExists {
+				return "", fmt.Errorf("iceberg: cannot reclaim expired create guard for %s while a durable purge journal exists", strings.Join(ident, "."))
+			}
+		}
+		txn := existing.NewTransaction()
+		if err := txn.SetProperties(iceberggo.Properties{
+			purgeLockModeKey:      purgeLockModeCreate,
+			purgeLockTargetKey:    strings.Join(ident, "."),
+			purgeLockTableUUIDKey: "",
+			purgeLockTokenKey:     token,
+			purgeLockExpiresAtKey: now.Add(createGuardTTL).Format(time.RFC3339Nano),
+		}); err != nil {
+			return "", err
+		}
+		if _, err := txn.Commit(ctx); err == nil {
+			return token, nil
+		} else if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			return "", fmt.Errorf("iceberg: failed to reclaim expired create guard for %s: %w", strings.Join(ident, "."), err)
+		}
+	}
+	return "", fmt.Errorf("iceberg: failed to acquire create guard for %s after concurrent updates", strings.Join(ident, "."))
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func (d *Destination) releaseCreateGuard(ctx context.Context, ident icebergtable.Identifier, token string) error {
+	lockIdent := purgeLockIdentifier(ident)
+	lock, err := d.catalog.LoadTable(ctx, lockIdent)
+	if err != nil {
+		return err
+	}
+	if lock.Properties()[purgeLockModeKey] != purgeLockModeCreate || lock.Properties()[purgeLockTokenKey] != token {
+		return fmt.Errorf("iceberg: create guard ownership changed for %s", strings.Join(ident, "."))
+	}
+	return commitLockIdle(ctx, lock)
+}
+
+func (d *Destination) releasePurgeLockOwned(ctx context.Context, ident icebergtable.Identifier, tableUUID, token string) error {
+	lockIdent := purgeLockIdentifier(ident)
+	lock, err := d.catalog.LoadTable(ctx, lockIdent)
+	if isMissingTableOrNamespace(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := validatePurgeLock(lock, ident, tableUUID); err != nil {
+		return err
+	}
+	if lock.Properties()[purgeLockTokenKey] != token {
+		return fmt.Errorf("iceberg: purge lock ownership changed for %s", strings.Join(ident, "."))
+	}
+	return commitLockIdle(ctx, lock)
+}
+
+func commitLockIdle(ctx context.Context, lock *icebergtable.Table) error {
+	txn := lock.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		purgeLockModeKey: purgeLockModeIdle, purgeLockTokenKey: "", purgeLockExpiresAtKey: "", purgeLockTableUUIDKey: "",
+	}); err != nil {
+		return err
+	}
+	_, err := txn.Commit(ctx)
+	return err
+}
+
+type catalogLockHeartbeat struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	mu     sync.Mutex
+	err    error
+}
+
+func (d *Destination) startCatalogLockHeartbeat(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	mode, tableUUID, token string,
+	ttl time.Duration,
+	cancelOwner context.CancelFunc,
+) *catalogLockHeartbeat {
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	heartbeat := &catalogLockHeartbeat{cancel: cancel, done: make(chan struct{})}
+	go func() {
+		defer close(heartbeat.done)
+		interval := ttl / 4
+		if d.catalogLockHeartbeatInterval > 0 {
+			interval = d.catalogLockHeartbeatInterval
+		}
+		if interval < time.Millisecond {
+			interval = time.Millisecond
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				if err := d.renewCatalogLock(heartbeatCtx, ident, mode, tableUUID, token, ttl); err != nil {
+					// stop cancels heartbeatCtx before joining this goroutine. A
+					// renewal already in flight can therefore return ctx.Err(); that
+					// is a clean shutdown, not a lost ownership lease.
+					if heartbeatCtx.Err() != nil {
+						return
+					}
+					heartbeat.mu.Lock()
+					heartbeat.err = err
+					heartbeat.mu.Unlock()
+					if cancelOwner != nil {
+						cancelOwner()
+					}
+					return
+				}
+			}
+		}
+	}()
+	return heartbeat
+}
+
+func (h *catalogLockHeartbeat) stop() error {
+	h.cancel()
+	<-h.done
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.err
+}
+
+func (d *Destination) renewCatalogLock(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	mode, tableUUID, token string,
+	ttl time.Duration,
+) error {
+	lock, err := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	if err != nil {
+		return err
+	}
+	if lock.Properties()[purgeLockModeKey] != mode || lock.Properties()[purgeLockTargetKey] != strings.Join(ident, ".") ||
+		lock.Properties()[purgeLockTableUUIDKey] != tableUUID || lock.Properties()[purgeLockTokenKey] != token {
+		return fmt.Errorf("iceberg: catalog lock ownership changed for %s", strings.Join(ident, "."))
+	}
+	txn := lock.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(ttl).Format(time.RFC3339Nano),
+	}); err != nil {
+		return err
+	}
+	_, err = txn.Commit(ctx)
+	return err
+}
+
+func (d *Destination) claimPurgeResume(ctx context.Context, ident icebergtable.Identifier, tableUUID string) (string, error) {
+	lock, err := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	if err != nil {
+		return "", fmt.Errorf("iceberg: failed to load durable purge lock for %s: %w", strings.Join(ident, "."), err)
+	}
+	if err := validatePurgeLock(lock, ident, tableUUID); err != nil {
+		return "", err
+	}
+	properties := lock.Properties()
+	if existing := properties[purgeLockTokenKey]; existing != "" {
+		expiresAt, parseErr := time.Parse(time.RFC3339Nano, properties[purgeLockExpiresAtKey])
+		if parseErr != nil || time.Now().UTC().Before(expiresAt) {
+			return "", fmt.Errorf("iceberg: purge recovery for %s is already claimed", strings.Join(ident, "."))
+		}
+	}
+	token := uuid.NewString()
+	txn := lock.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		purgeLockTokenKey:     token,
+		purgeLockExpiresAtKey: time.Now().UTC().Add(purgeResumeClaimTTL).Format(time.RFC3339Nano),
+	}); err != nil {
+		return "", fmt.Errorf("iceberg: failed to stage purge recovery claim for %s: %w", strings.Join(ident, "."), err)
+	}
+	if _, err := txn.Commit(ctx); err != nil {
+		return "", fmt.Errorf("iceberg: failed to claim purge recovery for %s: %w", strings.Join(ident, "."), err)
+	}
+	claimed, err := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	if err != nil {
+		return "", fmt.Errorf("iceberg: failed to verify purge recovery claim for %s: %w", strings.Join(ident, "."), err)
+	}
+	if claimed.Properties()[purgeLockTokenKey] != token {
+		return "", fmt.Errorf("iceberg: purge recovery claim for %s was lost concurrently", strings.Join(ident, "."))
+	}
+	return token, nil
+}
+
+func (d *Destination) relinquishPurgeClaim(ctx context.Context, ident icebergtable.Identifier, tableUUID, token string) error {
+	lock, err := d.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	if err != nil {
+		return err
+	}
+	if err := validatePurgeLock(lock, ident, tableUUID); err != nil {
+		return err
+	}
+	if lock.Properties()[purgeLockTokenKey] != token {
+		return fmt.Errorf("iceberg: purge lock ownership changed for %s", strings.Join(ident, "."))
+	}
+	txn := lock.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		purgeLockTokenKey:     "",
+		purgeLockExpiresAtKey: "",
+	}); err != nil {
+		return err
+	}
+	_, err = txn.Commit(ctx)
+	return err
+}
+
+func (d *Destination) renewPurgeLock(ctx context.Context, ident icebergtable.Identifier, tableUUID, token string) error {
+	return d.renewCatalogLock(ctx, ident, purgeLockModePurge, tableUUID, token, purgeResumeClaimTTL)
+}
+
+func validatePurgeLock(lock *icebergtable.Table, ident icebergtable.Identifier, tableUUID string) error {
+	wantTarget := strings.Join(ident, ".")
+	if lock.Properties()[purgeLockModeKey] != purgeLockModePurge ||
+		lock.Properties()[purgeLockTargetKey] != wantTarget || lock.Properties()[purgeLockTableUUIDKey] != tableUUID {
+		return fmt.Errorf(
+			"iceberg: conflicting purge lock %s targets %q with table UUID %q; expected %q and %q",
+			strings.Join(lock.Identifier(), "."), lock.Properties()[purgeLockTargetKey],
+			lock.Properties()[purgeLockTableUUIDKey], wantTarget, tableUUID,
+		)
+	}
+	return nil
+}
+
+func purgeLockIdentifier(ident icebergtable.Identifier) icebergtable.Identifier {
+	lockIdent := append(icebergtable.Identifier(nil), icebergcatalog.NamespaceFromIdent(ident)...)
+	return append(lockIdent, purgeLockTablePrefix+identifierHash("", ident)[:24])
+}

--- a/pkg/destination/iceberg/reader.go
+++ b/pkg/destination/iceberg/reader.go
@@ -2,8 +2,11 @@ package iceberg
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -12,14 +15,160 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 )
 
+const (
+	writeInputDrainTimeout   = 30 * time.Second
+	immediateWriteDrainLimit = 64
+)
+
+// recordBatchInput owns the source channel and the reader consuming it. Close
+// releases the reader's current batch before taking over the channel, then
+// drains any trailing batches without making a failed write wait on a slow or
+// broken producer forever.
+type recordBatchInput struct {
+	records      <-chan source.RecordBatchResult
+	drainTimeout time.Duration
+	done         chan struct{}
+
+	mu            sync.Mutex
+	reader        *recordBatchReader
+	readerCreated bool
+	closed        bool
+	closeOnce     sync.Once
+}
+
+func newRecordBatchInput(records <-chan source.RecordBatchResult) *recordBatchInput {
+	return newRecordBatchInputWithDrainTimeout(records, writeInputDrainTimeout)
+}
+
+func newRecordBatchInputWithDrainTimeout(
+	records <-chan source.RecordBatchResult,
+	drainTimeout time.Duration,
+) *recordBatchInput {
+	return &recordBatchInput{
+		records:      records,
+		drainTimeout: drainTimeout,
+		done:         make(chan struct{}),
+	}
+}
+
+func (i *recordBatchInput) RecordReader(ctx context.Context, schema *arrow.Schema) *recordBatchReader {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.closed || i.readerCreated {
+		panic("iceberg: record batch input reader requested more than once")
+	}
+	i.readerCreated = true
+	i.reader = newRecordBatchReader(ctx, i.records, schema)
+	return i.reader
+}
+
+func (i *recordBatchInput) ReleaseReader() {
+	i.mu.Lock()
+	reader := i.reader
+	i.reader = nil
+	i.mu.Unlock()
+	if reader != nil {
+		reader.Release()
+	}
+}
+
+func (i *recordBatchInput) Drain(ctx context.Context) error {
+	if i.records == nil {
+		return nil
+	}
+	timer := time.NewTimer(i.drainTimeout)
+	defer timer.Stop()
+	var sourceErr error
+	for {
+		select {
+		case result, ok := <-i.records:
+			if !ok {
+				return sourceErr
+			}
+			releaseWriteResult(result)
+			if sourceErr == nil && result.Err != nil {
+				sourceErr = result.Err
+			}
+		case <-ctx.Done():
+			return errors.Join(sourceErr, ctx.Err())
+		case <-timer.C:
+			return errors.Join(sourceErr, fmt.Errorf("iceberg: timed out draining write input after %s", i.drainTimeout))
+		}
+	}
+}
+
+func (i *recordBatchInput) Close() {
+	i.closeOnce.Do(func() {
+		i.mu.Lock()
+		i.closed = true
+		i.mu.Unlock()
+		i.ReleaseReader()
+
+		if i.records == nil {
+			close(i.done)
+			return
+		}
+		if drainAvailableWriteRecords(i.records, immediateWriteDrainLimit) {
+			close(i.done)
+			return
+		}
+		go func() {
+			defer close(i.done)
+			drainTrailingWriteRecords(i.records, i.drainTimeout)
+		}()
+	})
+}
+
+func drainAvailableWriteRecords(records <-chan source.RecordBatchResult, limit int) bool {
+	for range limit {
+		select {
+		case result, ok := <-records:
+			if !ok {
+				return true
+			}
+			releaseWriteResult(result)
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func drainTrailingWriteRecords(records <-chan source.RecordBatchResult, timeout time.Duration) {
+	if timeout <= 0 {
+		return
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case result, ok := <-records:
+			if !ok {
+				return
+			}
+			releaseWriteResult(result)
+		case <-timer.C:
+			return
+		}
+	}
+}
+
+func releaseWriteResult(result source.RecordBatchResult) {
+	if result.Batch != nil {
+		result.Batch.Release()
+	}
+}
+
 type recordBatchReader struct {
 	ctx     context.Context
 	records <-chan source.RecordBatchResult
 	schema  *arrow.Schema
 
-	current  arrow.RecordBatch
-	err      error
-	refCount atomic.Int64
+	current               arrow.RecordBatch
+	err                   error
+	observe               func(arrow.RecordBatch)
+	durableCommitPosition string
+	refCount              atomic.Int64
 }
 
 func newRecordBatchReader(ctx context.Context, records <-chan source.RecordBatchResult, schema *arrow.Schema) *recordBatchReader {
@@ -57,6 +206,12 @@ func (r *recordBatchReader) Next() bool {
 	}
 
 	for {
+		// A canceled context must win over a ready batch: the select alone
+		// picks randomly, letting a canceled write occasionally commit.
+		if err := r.ctx.Err(); err != nil {
+			r.err = err
+			return false
+		}
 		select {
 		case <-r.ctx.Done():
 			r.err = r.ctx.Err()
@@ -66,8 +221,12 @@ func (r *recordBatchReader) Next() bool {
 				return false
 			}
 			if result.Err != nil {
+				releaseWriteResult(result)
 				r.err = result.Err
 				return false
+			}
+			if compareCDCResumeLSN(result.DurableCommitPosition, r.durableCommitPosition) > 0 {
+				r.durableCommitPosition = result.DurableCommitPosition
 			}
 			if result.Batch == nil {
 				continue
@@ -80,10 +239,15 @@ func (r *recordBatchReader) Next() bool {
 				return false
 			}
 			r.current = batch
+			if r.observe != nil {
+				r.observe(batch)
+			}
 			return true
 		}
 	}
 }
+
+func (r *recordBatchReader) DurableCommitPosition() string { return r.durableCommitPosition }
 
 func (r *recordBatchReader) RecordBatch() arrow.RecordBatch {
 	return r.current
@@ -99,6 +263,9 @@ func (r *recordBatchReader) Err() error {
 
 func normalizeRecordBatch(batch arrow.RecordBatch, target *arrow.Schema) (arrow.RecordBatch, error) {
 	if batch.Schema().Equal(target) {
+		if err := validateRequiredNestedBatch(batch, target); err != nil {
+			return nil, err
+		}
 		return batch, nil
 	}
 	if int(batch.NumCols()) != len(target.Fields()) {
@@ -134,6 +301,10 @@ func normalizeRecordBatch(batch arrow.RecordBatch, target *arrow.Schema) (arrow.
 	}
 
 	normalized := array.NewRecordBatch(target, cols, batch.NumRows())
+	if err := validateRequiredNestedBatch(normalized, target); err != nil {
+		normalized.Release()
+		return nil, err
+	}
 	batch.Release()
 	return normalized, nil
 }
@@ -146,7 +317,109 @@ func normalizeColumn(col arrow.Array, target arrow.DataType) (arrow.Array, bool,
 		converted, err := uuidStringArray(col)
 		return converted, true, err
 	}
+	if fixed, ok := target.(*arrow.FixedSizeBinaryType); ok {
+		converted, err := fixedSizeBinaryArray(col, fixed)
+		return converted, true, err
+	}
+	if listType, ok := target.(*arrow.ListType); ok {
+		converted, err := normalizedListArray(col, listType)
+		return converted, true, err
+	}
+	if _, ok := target.(*arrow.StructType); ok {
+		converted, err := normalizedNestedArray(col, target)
+		return converted, true, err
+	}
+	if _, ok := target.(*arrow.MapType); ok {
+		converted, err := normalizedNestedArray(col, target)
+		return converted, true, err
+	}
 	return nil, false, fmt.Errorf("got %s, want %s", col.DataType(), target)
+}
+
+func normalizedNestedArray(col arrow.Array, target arrow.DataType) (arrow.Array, error) {
+	builder := array.NewBuilder(memory.DefaultAllocator, target)
+	defer builder.Release()
+	for i := 0; i < col.Len(); i++ {
+		value, err := rowValue(col, i)
+		if err != nil {
+			return nil, err
+		}
+		if err := appendValueAtPath(builder, value, fmt.Sprintf("value[%d]", i), true); err != nil {
+			return nil, err
+		}
+	}
+	return builder.NewArray(), nil
+}
+
+func validateRequiredNestedBatch(batch arrow.RecordBatch, target *arrow.Schema) error {
+	for col := 0; col < int(batch.NumCols()); col++ {
+		field := target.Field(col)
+		if err := validateRequiredArray(batch.Column(col), field, field.Name, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRequiredArray(values arrow.Array, field arrow.Field, valuePath string, active []bool) error {
+	if !field.Nullable {
+		for i := 0; i < values.Len(); i++ {
+			if (active == nil || active[i]) && values.IsNull(i) {
+				return fmt.Errorf("required nested value %s[%d] is null", valuePath, i)
+			}
+		}
+	}
+	switch typed := values.(type) {
+	case *array.Struct:
+		structType := field.Type.(*arrow.StructType)
+		childActive := make([]bool, typed.Len())
+		for row := range childActive {
+			childActive[row] = (active == nil || active[row]) && !typed.IsNull(row)
+		}
+		for i := 0; i < typed.NumField(); i++ {
+			child := structType.Field(i)
+			if err := validateRequiredArray(typed.Field(i), child, valuePath+"."+child.Name, childActive); err != nil {
+				return err
+			}
+		}
+	case *array.Map:
+		mapType := field.Type.(*arrow.MapType)
+		entryActive := listChildActivity(typed, active)
+		if err := validateRequiredArray(typed.Keys(), mapType.KeyField(), valuePath+".key", entryActive); err != nil {
+			return err
+		}
+		if err := validateRequiredArray(typed.Items(), mapType.ItemField(), valuePath+".value", entryActive); err != nil {
+			return err
+		}
+	case array.ListLike:
+		var elem arrow.Field
+		switch listType := field.Type.(type) {
+		case *arrow.ListType:
+			elem = listType.ElemField()
+		case *arrow.LargeListType:
+			elem = listType.ElemField()
+		default:
+			return nil
+		}
+		if err := validateRequiredArray(typed.ListValues(), elem, valuePath+".element", listChildActivity(typed, active)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listChildActivity(list array.ListLike, active []bool) []bool {
+	child := make([]bool, list.ListValues().Len())
+	for row := 0; row < list.Len(); row++ {
+		if (active != nil && !active[row]) || list.IsNull(row) {
+			continue
+		}
+		start, end := list.ValueOffsets(row)
+		for index := start; index < end; index++ {
+			child[index] = true
+		}
+	}
+	return child
 }
 
 func uuidStringArray(col arrow.Array) (arrow.Array, error) {
@@ -167,4 +440,133 @@ func uuidStringArray(col arrow.Array) (arrow.Array, error) {
 		}
 	}
 	return builder.NewArray(), nil
+}
+
+func fixedSizeBinaryArray(col arrow.Array, target *arrow.FixedSizeBinaryType) (arrow.Array, error) {
+	col = extensionStorage(col)
+	builder := array.NewFixedSizeBinaryBuilder(memory.DefaultAllocator, target)
+	defer builder.Release()
+
+	for i := 0; i < col.Len(); i++ {
+		if col.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+		value, ok := binaryValue(col, i)
+		if !ok {
+			return nil, fmt.Errorf("got %s, want %s", col.DataType(), target)
+		}
+		if len(value) != target.ByteWidth {
+			return nil, fmt.Errorf("fixed binary value %d has length %d, want %d", i, len(value), target.ByteWidth)
+		}
+		builder.Append(value)
+	}
+	return builder.NewArray(), nil
+}
+
+func normalizedListArray(col arrow.Array, target *arrow.ListType) (arrow.Array, error) {
+	list, ok := col.(array.ListLike)
+	if !ok {
+		return nil, fmt.Errorf("got %s, want %s", col.DataType(), target)
+	}
+	builder := array.NewListBuilderWithField(memory.DefaultAllocator, target.ElemField())
+	defer builder.Release()
+	values := list.ListValues()
+
+	for row := 0; row < list.Len(); row++ {
+		if list.IsNull(row) {
+			builder.AppendNull()
+			continue
+		}
+		builder.Append(true)
+		start, end := list.ValueOffsets(row)
+		for idx := start; idx < end; idx++ {
+			if err := appendNormalizedListValue(builder.ValueBuilder(), values, int(idx), target.Elem()); err != nil {
+				return nil, fmt.Errorf("list row %d element %d: %w", row, idx-start, err)
+			}
+		}
+	}
+	return builder.NewArray(), nil
+}
+
+func appendNormalizedListValue(builder array.Builder, values arrow.Array, idx int, target arrow.DataType) error {
+	if values.IsNull(idx) {
+		builder.AppendNull()
+		return nil
+	}
+
+	switch targetType := target.(type) {
+	case *arrow.StringType:
+		stringBuilder, ok := builder.(*array.StringBuilder)
+		if !ok {
+			return fmt.Errorf("unexpected string builder %T", builder)
+		}
+		storage := extensionStorage(values)
+		if strings, ok := storage.(array.StringLike); ok {
+			stringBuilder.Append(strings.Value(idx))
+			return nil
+		}
+		return fmt.Errorf("got %s, want %s", values.DataType(), targetType)
+
+	case *extensions.UUIDType:
+		var uuidBuilder *extensions.UUIDBuilder
+		switch typedBuilder := builder.(type) {
+		case *extensions.UUIDBuilder:
+			uuidBuilder = typedBuilder
+		case *array.ExtensionBuilder:
+			uuidBuilder = &extensions.UUIDBuilder{ExtensionBuilder: typedBuilder}
+		default:
+			return fmt.Errorf("unexpected UUID builder %T", builder)
+		}
+		if strings, ok := values.(array.StringLike); ok {
+			return uuidBuilder.AppendValueFromString(strings.Value(idx))
+		}
+		value, ok := binaryValue(extensionStorage(values), idx)
+		if !ok || len(value) != 16 {
+			return fmt.Errorf("got %s, want %s", values.DataType(), targetType)
+		}
+		var uuidBytes [16]byte
+		copy(uuidBytes[:], value)
+		uuidBuilder.AppendBytes(uuidBytes)
+		return nil
+
+	case *arrow.FixedSizeBinaryType:
+		fixedBuilder, ok := builder.(*array.FixedSizeBinaryBuilder)
+		if !ok {
+			return fmt.Errorf("unexpected fixed binary builder %T", builder)
+		}
+		value, ok := binaryValue(extensionStorage(values), idx)
+		if !ok {
+			return fmt.Errorf("got %s, want %s", values.DataType(), targetType)
+		}
+		if len(value) != targetType.ByteWidth {
+			return fmt.Errorf("fixed binary value has length %d, want %d", len(value), targetType.ByteWidth)
+		}
+		fixedBuilder.Append(value)
+		return nil
+
+	default:
+		value, err := rowValue(values, idx)
+		if err != nil {
+			return err
+		}
+		return appendValueAtPath(builder, value, "element", true)
+	}
+}
+
+func extensionStorage(col arrow.Array) arrow.Array {
+	if ext, ok := col.(array.ExtensionArray); ok {
+		return ext.Storage()
+	}
+	return col
+}
+
+func binaryValue(col arrow.Array, idx int) ([]byte, bool) {
+	if values, ok := col.(interface{ Value(int) []byte }); ok {
+		return values.Value(idx), true
+	}
+	if values, ok := col.(array.StringLike); ok {
+		return []byte(values.Value(idx)), true
+	}
+	return nil, false
 }

--- a/pkg/destination/iceberg/register.go
+++ b/pkg/destination/iceberg/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterDestination(
-		[]string{"iceberg", "iceberg+rest", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"},
+		[]string{"iceberg", "iceberg+rest", "iceberg+nessie", "iceberg+polaris", "iceberg+s3tables", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"},
 		func() interface{} { return NewDestination() },
 	)
 }

--- a/pkg/destination/iceberg/row_delta.go
+++ b/pkg/destination/iceberg/row_delta.go
@@ -2,6 +2,7 @@ package iceberg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	icebergtable "github.com/apache/iceberg-go/table"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/google/uuid"
 )
 
 const (
@@ -26,12 +28,12 @@ const (
 // partition value, so every partition source column must be part of the
 // delete key — otherwise a row whose partition value changed would not be
 // deleted from its old partition.
-func useRowDeltaMerge(tbl *icebergtable.Table, deleteKeyColumns []string) bool {
+func useRowDeltaMerge(ctx context.Context, tbl *icebergtable.Table, deleteKeyColumns []string) (bool, error) {
 	if strings.EqualFold(tbl.Metadata().Properties().Get(writeMergeModeProperty, ""), mergeModeCopyOnWrite) {
-		return false
+		return false, nil
 	}
 	if tbl.Metadata().Version() < 2 {
-		return false
+		return false, nil
 	}
 	allowed := make(map[string]bool, len(deleteKeyColumns))
 	for _, col := range deleteKeyColumns {
@@ -41,10 +43,22 @@ func useRowDeltaMerge(tbl *icebergtable.Table, deleteKeyColumns []string) bool {
 	for _, field := range spec.Fields() {
 		name, ok := tbl.Schema().FindColumnName(field.SourceID())
 		if !ok || !allowed[name] {
-			return false
+			return false, nil
 		}
 	}
-	return true
+	if tbl.CurrentSnapshot() != nil {
+		tasks, err := tbl.Scan().PlanFiles(ctx)
+		if err != nil {
+			return false, fmt.Errorf("iceberg: failed to inspect live partition specs before merge: %w", err)
+		}
+		currentSpecID := int32(spec.ID())
+		for _, task := range tasks {
+			if task.File.SpecID() != currentSpecID {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
 }
 
 // stagingCoversTarget reports whether every target column also exists in
@@ -61,6 +75,15 @@ func stagingCoversTarget(target, staging *iceberggo.Schema) bool {
 		}
 	}
 	return true
+}
+
+func icebergSchemaHasFieldFold(sc *iceberggo.Schema, name string) bool {
+	for _, field := range sc.Fields() {
+		if strings.EqualFold(field.Name, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func fieldIDsByName(iceSchema *iceberggo.Schema, names []string) ([]int, error) {
@@ -103,7 +126,7 @@ type rowEmit func(proj *rowProjection, row []any) error
 // with bounded buffering. When consumerReleases is false the batches are
 // released after the consumer's yield returns (WriteEqualityDeletes borrows
 // batches); WriteRecords releases consumed batches itself.
-func batchStream(writeSchema *arrow.Schema, consumerReleases bool, produce func(emit rowEmit) error) iter.Seq2[arrow.RecordBatch, error] {
+func batchStream(ctx context.Context, writeSchema *arrow.Schema, consumerReleases bool, produce func(emit rowEmit) error) iter.Seq2[arrow.RecordBatch, error] {
 	return func(yield func(arrow.RecordBatch, error) bool) {
 		builder := array.NewRecordBuilder(memory.DefaultAllocator, writeSchema)
 		defer builder.Release()
@@ -128,6 +151,9 @@ func batchStream(writeSchema *arrow.Schema, consumerReleases bool, produce func(
 		}
 
 		err := produce(func(proj *rowProjection, row []any) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if err := proj.appendRow(builder, row); err != nil {
 				return err
 			}
@@ -150,27 +176,75 @@ var errStreamStopped = fmt.Errorf("iceberg: batch stream consumer stopped")
 
 // commitRowDelta writes the data and delete files produced by the two
 // streaming passes and commits them as one atomic snapshot.
-func commitRowDelta(
+func (d *Destination) commitRowDelta(
 	ctx context.Context,
 	tbl *icebergtable.Table,
 	operation string,
+	metadata commitMetadata,
 	writeSchema *arrow.Schema,
 	produceData func(emit rowEmit) error,
 	deleteKeyColumns []string,
 	produceDeletes func(emit rowEmit) error,
-) error {
-	txn := tbl.NewTransaction()
+	parallelism int,
+) (retErr error) {
+	if err := d.validateExpectedIncarnation(ctx, tbl, metadata.expectedIncarnation); err != nil {
+		return err
+	}
+	if tableHasCommitToken(tbl, metadata.token) {
+		return nil
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return err
+	}
+	writeID := uuid.New()
+	generatedPaths := make([]string, 0)
+	committed, cleanupSafe := false, true
+	defer func() {
+		if committed || !cleanupSafe {
+			return
+		}
+		if err := removeGeneratedMergeFiles(tableFS, tbl.Location(), writeID.String(), generatedPaths); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+	writeCtx, cancelWrite := context.WithCancel(context.WithoutCancel(ctx))
+	defer cancelWrite()
 
+	var writeOptions []icebergtable.WriteRecordOption
+	writeOptions = append(writeOptions, icebergtable.WithWriteUUID(writeID))
+	if parallelism > 0 {
+		writeOptions = append(writeOptions, icebergtable.WithMaxWriteWorkers(parallelism))
+	}
+	preserveLineage := tbl.Metadata().Version() >= 3 && len(writeSchema.FieldIndices(iceberggo.RowIDColumnName)) > 0
+	if preserveLineage {
+		writeOptions = append(writeOptions, icebergtable.WithPreserveRowLineage(iceberggo.SchemaWithRowLineage(tbl.Schema())))
+	}
 	var dataFiles []iceberggo.DataFile
-	for df, err := range icebergtable.WriteRecords(ctx, tbl, writeSchema, batchStream(writeSchema, true, produceData)) {
+	for df, err := range icebergtable.WriteRecords(writeCtx, tbl, writeSchema, batchStream(ctx, writeSchema, true, produceData), writeOptions...) {
 		if err != nil {
 			return fmt.Errorf("iceberg: %s failed to write data files: %w", operation, err)
 		}
 		dataFiles = append(dataFiles, df)
+		generatedPaths = append(generatedPaths, df.FilePath())
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if preserveLineage {
+		nextRowID := tbl.Metadata().NextRowID()
+		for i, file := range dataFiles {
+			dataFiles[i], err = withDataFileFirstRowID(file, tbl, nextRowID)
+			if err != nil {
+				return err
+			}
+			nextRowID += file.Count()
+		}
 	}
 
 	var deleteFiles []iceberggo.DataFile
 	if produceDeletes != nil && tbl.CurrentSnapshot() != nil {
+		writeTxn := tbl.NewTransaction()
 		deleteFieldIDs, err := fieldIDsByName(tbl.Schema(), deleteKeyColumns)
 		if err != nil {
 			return err
@@ -179,24 +253,74 @@ func commitRowDelta(
 		if err != nil {
 			return err
 		}
-		deleteFiles, err = txn.WriteEqualityDeletes(ctx, deleteFieldIDs, batchStream(deleteSchema, false, produceDeletes))
+		deleteFiles, err = writeTxn.WriteEqualityDeletes(writeCtx, deleteFieldIDs, batchStream(ctx, deleteSchema, false, produceDeletes))
 		if err != nil {
 			return fmt.Errorf("iceberg: %s failed to write delete files: %w", operation, err)
 		}
+		for _, file := range deleteFiles {
+			generatedPaths = append(generatedPaths, file.FilePath())
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	if len(dataFiles) == 0 && len(deleteFiles) == 0 {
-		return nil
+		err := d.commitMetadataOnly(ctx, tbl, operation, metadata)
+		committed = err == nil
+		return err
 	}
 
-	rowDelta := txn.NewRowDelta(snapshotProps(operation)).AddRows(dataFiles...).AddDeletes(deleteFiles...)
-	if err := rowDelta.Commit(ctx); err != nil {
-		return fmt.Errorf("iceberg: %s failed to stage row delta: %w", operation, err)
+	table := strings.Join(tbl.Identifier(), ".")
+	const maxAttempts = 5
+	current := tbl
+	var commitErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := d.validateExpectedIncarnation(ctx, current, metadata.expectedIncarnation); err != nil {
+			return err
+		}
+		if tableHasCommitToken(current, metadata.token) {
+			committed = true
+			return nil
+		}
+		txn := current.NewTransaction()
+		if err := stageCommitTokenLedger(txn, current, metadata.token); err != nil {
+			return err
+		}
+		props := snapshotProps(operation, metadata)
+		if err := stageCDCResumeState(txn, props); err != nil {
+			return err
+		}
+		rowDelta := txn.NewRowDelta(props).AddRows(dataFiles...).AddDeletes(deleteFiles...)
+		if err := rowDelta.Commit(ctx); err != nil {
+			return fmt.Errorf("iceberg: %s failed to stage row delta: %w", operation, err)
+		}
+		if err := d.validateExpectedIncarnation(ctx, current, metadata.expectedIncarnation); err != nil {
+			return err
+		}
+		if _, commitErr = txn.Commit(ctx); commitErr == nil {
+			committed = true
+			d.afterSuccessfulCommitExpected(ctx, table, metadata.expectedIncarnation)
+			return nil
+		}
+		if !errors.Is(commitErr, icebergtable.ErrCommitFailed) {
+			if reconciled := d.reconcileCommit(ctx, table, metadata.token, metadata.expectedIncarnation, commitErr); reconciled == nil {
+				committed = true
+				return nil
+			} else {
+				cleanupSafe = false
+				return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), reconciled)
+			}
+		}
+		current, err = d.catalog.LoadTable(ctx, tbl.Identifier())
+		if err != nil {
+			return errors.Join(commitErr, err)
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
 	}
-	if _, err := txn.Commit(ctx); err != nil {
-		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
-	}
-	return nil
+	return fmt.Errorf("iceberg: failed to commit %s on table %s after %d attempts: %w", operation, tbl.Identifier(), maxAttempts, commitErr)
 }
 
 // mergeRowDelta merges the staging table using merge-on-read: an equality
@@ -207,7 +331,6 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 	if err != nil {
 		return err
 	}
-	stagingCols := arrowSchemaColumnNames(stagingSchema)
 
 	sorter, err := newSpillSorter(stagingSchema, opts.PrimaryKeys)
 	if err != nil {
@@ -215,11 +338,23 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 	}
 	defer sorter.Close()
 
-	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, sorter.Add); err != nil {
+	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, func(row []any) error { return sorter.AddContext(ctx, row) }); err != nil {
 		return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
 	}
+	return d.mergeRowDeltaFromSorter(ctx, target, stagingSchema, sorter, opts, mergeCommitMetadata(opts))
+}
+
+func (d *Destination) mergeRowDeltaFromSorter(
+	ctx context.Context,
+	target *icebergtable.Table,
+	stagingSchema *arrow.Schema,
+	sorter *spillSorter,
+	opts destination.MergeOptions,
+	metadata commitMetadata,
+) error {
+	stagingCols := arrowSchemaColumnNames(stagingSchema)
 	if sorter.Len() == 0 {
-		return nil
+		return d.commitMetadataOnly(ctx, target, "merge", metadata)
 	}
 
 	incrementalIdx := -1
@@ -231,7 +366,8 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 		incrementalIdx = idx
 	}
 
-	writeSchema, err := tableWriteSchema(target)
+	preserveLineage := target.Metadata().Version() >= 3
+	writeSchema, err := copyOnWriteTargetSchema(target, preserveLineage)
 	if err != nil {
 		return err
 	}
@@ -239,7 +375,7 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 
 	emitWinners := func(proj *rowProjection) func(emit rowEmit) error {
 		return func(emit rowEmit) error {
-			it, err := sorter.Iter()
+			it, err := sorter.IterContext(ctx)
 			if err != nil {
 				return err
 			}
@@ -259,13 +395,56 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 		return err
 	}
 	deleteProjection := newRowProjection(deleteSchema, stagingCols)
+	dataProducer := emitWinners(dataProjection)
+	prepared := d.lookupPrepared(opts.TargetTable)
+	var clusterSorter *spillSorter
+	if len(prepared.clusterBy) > 0 {
+		clusterSorter, err = newClusterSorter(writeSchema, prepared.clusterBy)
+		if err != nil {
+			return err
+		}
+		defer clusterSorter.Close()
+		winners, err := sorter.IterContext(ctx)
+		if err != nil {
+			return err
+		}
+		for winners.NextGroup() {
+			if err := clusterSorter.AddContext(ctx, dataProjection.projectRow(selectGroupWinner(winners, incrementalIdx))); err != nil {
+				winners.Close()
+				return err
+			}
+		}
+		if err := winners.Err(); err != nil {
+			winners.Close()
+			return err
+		}
+		winners.Close()
+		identity := newRowProjection(writeSchema, arrowSchemaColumnNames(writeSchema))
+		dataProducer = func(emit rowEmit) error {
+			it, err := clusterSorter.IterContext(ctx)
+			if err != nil {
+				return err
+			}
+			defer it.Close()
+			for it.NextGroup() {
+				for it.NextRow() {
+					if err := emit(identity, it.Row()); err != nil {
+						return err
+					}
+				}
+			}
+			return it.Err()
+		}
+		opts.Parallelism = 1
+	}
 
 	config.Debug("[ICEBERG MERGE] Row-delta merge of %d staged row(s) into %s", sorter.Len(), opts.TargetTable)
-	return commitRowDelta(
-		ctx, target, "merge", writeSchema,
-		emitWinners(dataProjection),
+	return d.commitRowDelta(
+		ctx, target, "merge", metadata, writeSchema,
+		dataProducer,
 		opts.PrimaryKeys,
 		emitWinners(deleteProjection),
+		opts.Parallelism,
 	)
 }
 
@@ -281,7 +460,8 @@ func (d *Destination) scd2RowDelta(ctx context.Context, target, staging *iceberg
 		return err
 	}
 	stagingCols := arrowSchemaColumnNames(stagingSchema)
-	writeSchema, err := tableWriteSchema(target)
+	preserveLineage := target.Metadata().Version() >= 3
+	writeSchema, err := copyOnWriteTargetSchema(target, preserveLineage)
 	if err != nil {
 		return err
 	}
@@ -292,7 +472,7 @@ func (d *Destination) scd2RowDelta(ctx context.Context, target, staging *iceberg
 		return err
 	}
 	defer stagingSorter.Close()
-	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, stagingSorter.Add); err != nil {
+	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, func(row []any) error { return stagingSorter.AddContext(ctx, row) }); err != nil {
 		return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
 	}
 
@@ -306,7 +486,7 @@ func (d *Destination) scd2RowDelta(ctx context.Context, target, staging *iceberg
 		return err
 	}
 	defer currentSorter.Close()
-	if err := forEachScannedRow(ctx, target, currentFilter, currentSorter.Add); err != nil {
+	if err := forEachSCD2CurrentRow(ctx, target, currentFilter, preserveLineage, func(row []any) error { return currentSorter.AddContext(ctx, row) }); err != nil {
 		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
 	}
 
@@ -323,31 +503,74 @@ func (d *Destination) scd2RowDelta(ctx context.Context, target, staging *iceberg
 	stagingProjection := newRowProjection(writeSchema, stagingCols)
 	targetProjection := newRowProjection(writeSchema, targetCols)
 	deleteProjection := newRowProjection(deleteSchema, deleteKeyColumns)
+	dataProducer := func(emit rowEmit) error {
+		return join.run(ctx, stagingSorter, currentSorter, scd2Emitters{
+			newRow:    func(row []any) error { return emit(stagingProjection, row) },
+			closedRow: func(row []any) error { return emit(targetProjection, row) },
+		})
+	}
+	prepared := d.lookupPrepared(opts.TargetTable)
+	var clusterSorter *spillSorter
+	parallelism := 0
+	if len(prepared.clusterBy) > 0 {
+		parallelism = 1
+		clusterSorter, err = newClusterSorter(writeSchema, prepared.clusterBy)
+		if err != nil {
+			return err
+		}
+		defer clusterSorter.Close()
+		if err := join.run(ctx, stagingSorter, currentSorter, scd2Emitters{
+			newRow:    func(row []any) error { return clusterSorter.AddContext(ctx, stagingProjection.projectRow(row)) },
+			closedRow: func(row []any) error { return clusterSorter.AddContext(ctx, targetProjection.projectRow(row)) },
+		}); err != nil {
+			return err
+		}
+		identity := newRowProjection(writeSchema, arrowSchemaColumnNames(writeSchema))
+		dataProducer = func(emit rowEmit) error {
+			it, err := clusterSorter.IterContext(ctx)
+			if err != nil {
+				return err
+			}
+			defer it.Close()
+			for it.NextGroup() {
+				for it.NextRow() {
+					if err := emit(identity, it.Row()); err != nil {
+						return err
+					}
+				}
+			}
+			return it.Err()
+		}
+	}
 
 	config.Debug("[ICEBERG SCD2] Row-delta SCD2 of %d staged row(s) into %s", stagingSorter.Len(), opts.TargetTable)
-	return commitRowDelta(
-		ctx, target, "scd2", writeSchema,
-		func(emit rowEmit) error {
-			return join.run(stagingSorter, currentSorter, scd2Emitters{
-				newRow:    func(row []any) error { return emit(stagingProjection, row) },
-				closedRow: func(row []any) error { return emit(targetProjection, row) },
-			})
-		},
+	return d.commitRowDelta(
+		ctx, target, "scd2", commitMetadata{}, writeSchema,
+		dataProducer,
 		deleteKeyColumns,
 		func(emit rowEmit) error {
-			return join.run(stagingSorter, currentSorter, scd2Emitters{
+			return join.run(ctx, stagingSorter, currentSorter, scd2Emitters{
 				deleteKey: func(keyVals []any) error { return emit(deleteProjection, append(keyVals, true)) },
 			})
 		},
+		parallelism,
 	)
 }
 
 // scd2Emitters receives the join outputs; nil callbacks are skipped so the
 // two streaming passes (data files, delete files) can share one join.
 type scd2Emitters struct {
-	newRow    func(row []any) error
-	closedRow func(row []any) error
-	deleteKey func(keyVals []any) error
+	newRow       func(row []any) error
+	closedRow    func(row []any) error
+	unchangedRow func(row []any) error
+	deleteKey    func(keyVals []any) error
+}
+
+func (e scd2Emitters) emitUnchanged(row []any) error {
+	if e.unchangedRow == nil {
+		return nil
+	}
+	return e.unchangedRow(row)
 }
 
 func (e scd2Emitters) emitNew(row []any) error {
@@ -377,6 +600,7 @@ type scd2Join struct {
 	validFromIdx   int
 	validToIdx     int
 	isCurrentIdx   int
+	lastUpdatedIdx int
 	incrementalIdx int
 	changePairs    [][2]int // staging column index, target column index
 }
@@ -391,7 +615,7 @@ func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string)
 		targetIdx[col] = i
 	}
 
-	j := &scd2Join{opts: opts, validFromIdx: -1, validToIdx: -1, isCurrentIdx: -1, incrementalIdx: -1}
+	j := &scd2Join{opts: opts, validFromIdx: -1, validToIdx: -1, isCurrentIdx: -1, lastUpdatedIdx: -1, incrementalIdx: -1}
 	if idx, ok := stagingIdx[destination.SCD2ValidFromColumn]; ok {
 		j.validFromIdx = idx
 	} else {
@@ -413,6 +637,9 @@ func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string)
 		j.isCurrentIdx = idx
 	} else {
 		return nil, fmt.Errorf("iceberg: column %q not found in target table", destination.SCD2IsCurrentColumn)
+	}
+	if idx, ok := targetIdx[iceberggo.LastUpdatedSequenceNumberColumnName]; ok {
+		j.lastUpdatedIdx = idx
 	}
 
 	for _, pk := range opts.PrimaryKeys {
@@ -442,13 +669,13 @@ func newSCD2Join(opts destination.SCD2Options, stagingCols, targetCols []string)
 
 // run merge-joins the key-sorted staging winners against the key-sorted
 // current target rows and emits the SCD2 outcome per key.
-func (j *scd2Join) run(stagingSorter, currentSorter *spillSorter, emitters scd2Emitters) error {
-	stagingIt, err := stagingSorter.Iter()
+func (j *scd2Join) run(ctx context.Context, stagingSorter, currentSorter *spillSorter, emitters scd2Emitters) error {
+	stagingIt, err := stagingSorter.IterContext(ctx)
 	if err != nil {
 		return err
 	}
 	defer stagingIt.Close()
-	currentIt, err := currentSorter.Iter()
+	currentIt, err := currentSorter.IterContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -488,52 +715,50 @@ func (j *scd2Join) run(stagingSorter, currentSorter *spillSorter, emitters scd2E
 
 func (j *scd2Join) softDelete(currentIt *spillIter, emitters scd2Emitters) error {
 	if j.opts.IncrementalKey != "" {
-		return nil
-	}
-	softDeleteAt := j.opts.Timestamp.UTC().UnixMicro()
-	first := true
-	for currentIt.NextRow() {
-		row := currentIt.Row()
-		if first {
-			if err := emitters.emitDelete(j.targetKeyValues(row)); err != nil {
-				return err
-			}
-			first = false
-		}
-		if err := emitters.emitClosed(j.closeRow(row, softDeleteAt)); err != nil {
+		row, err := onlyCurrentRow(currentIt)
+		if err != nil || row == nil {
 			return err
 		}
+		return emitters.emitUnchanged(row)
 	}
-	return nil
+	softDeleteAt := j.opts.Timestamp.UTC().UnixMicro()
+	row, err := onlyCurrentRow(currentIt)
+	if err != nil || row == nil {
+		return err
+	}
+	if err := emitters.emitDelete(j.targetKeyValues(row)); err != nil {
+		return err
+	}
+	return emitters.emitClosed(j.closeRow(row, softDeleteAt))
 }
 
 func (j *scd2Join) matchKey(stagingIt, currentIt *spillIter, emitters scd2Emitters) error {
 	stagingRow := selectGroupWinner(stagingIt, j.incrementalIdx)
-	currentRows := collectGroupRows(currentIt)
-	if len(currentRows) == 0 {
+	currentRow, err := onlyCurrentRow(currentIt)
+	if err != nil {
+		return err
+	}
+	if currentRow == nil {
 		return emitters.emitNew(stagingRow)
 	}
 
 	changed := false
-	latestCurrent := currentRows[len(currentRows)-1]
 	for _, pair := range j.changePairs {
-		if !valuesEqual(stagingRow[pair[0]], latestCurrent[pair[1]]) {
+		if !valuesEqual(stagingRow[pair[0]], currentRow[pair[1]]) {
 			changed = true
 			break
 		}
 	}
 	if !changed {
-		return nil
+		return emitters.emitUnchanged(currentRow)
 	}
 
-	if err := emitters.emitDelete(j.targetKeyValues(latestCurrent)); err != nil {
+	if err := emitters.emitDelete(j.targetKeyValues(currentRow)); err != nil {
 		return err
 	}
 	validFrom := stagingRow[j.validFromIdx]
-	for _, row := range currentRows {
-		if err := emitters.emitClosed(j.closeRow(row, validFrom)); err != nil {
-			return err
-		}
+	if err := emitters.emitClosed(j.closeRow(currentRow, validFrom)); err != nil {
+		return err
 	}
 	return emitters.emitNew(stagingRow)
 }
@@ -550,15 +775,52 @@ func (j *scd2Join) closeRow(row []any, validTo any) []any {
 	closed := append([]any(nil), row...)
 	closed[j.validToIdx] = validTo
 	closed[j.isCurrentIdx] = false
+	if j.lastUpdatedIdx >= 0 {
+		closed[j.lastUpdatedIdx] = nil
+	}
 	return closed
 }
 
-func collectGroupRows(it *spillIter) [][]any {
-	var rows [][]any
-	for it.NextRow() {
-		rows = append(rows, it.Row())
+func forEachSCD2CurrentRow(ctx context.Context, tbl *icebergtable.Table, filter iceberggo.BooleanExpression, lineage bool, fn func([]any) error) error {
+	if !lineage {
+		return forEachScannedRow(ctx, tbl, filter, fn)
 	}
-	return rows
+	sc, records, err := tbl.Scan(icebergtable.WithRowLineage(), icebergtable.WithRowFilter(filter)).ToArrowRecords(ctx)
+	if err != nil {
+		return err
+	}
+	for batch, readErr := range records {
+		if readErr != nil {
+			return readErr
+		}
+		for r := 0; r < int(batch.NumRows()); r++ {
+			row := make([]any, len(sc.Fields()))
+			for c := range sc.Fields() {
+				row[c], err = rowValue(batch.Column(c), r)
+				if err != nil {
+					batch.Release()
+					return err
+				}
+			}
+			if err := fn(row); err != nil {
+				batch.Release()
+				return err
+			}
+		}
+		batch.Release()
+	}
+	return nil
+}
+
+func onlyCurrentRow(it *spillIter) ([]any, error) {
+	var row []any
+	for it.NextRow() {
+		if row != nil {
+			return nil, fmt.Errorf("iceberg: SCD2 target contains duplicate current rows for primary key %x", it.Key())
+		}
+		row = it.Row()
+	}
+	return row, it.Err()
 }
 
 // selectGroupWinner consumes the current group and returns the winning row:

--- a/pkg/destination/iceberg/rows.go
+++ b/pkg/destination/iceberg/rows.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -26,7 +27,14 @@ import (
 type (
 	decimalVal string
 	uuidVal    string
+	structVal  []any
+	mapVal     []mapEntryVal
 )
+
+type mapEntryVal struct {
+	key   any
+	value any
+}
 
 // scannedTable holds a fully materialized read of an Iceberg table. Rows are
 // normalized Go values aligned to Columns order.
@@ -41,8 +49,30 @@ func (s *scannedTable) HasColumn(name string) bool {
 	return ok
 }
 
+func (s *scannedTable) foldedColumnIndex(name string) (int, bool) {
+	for column, idx := range s.ColIdx {
+		if strings.EqualFold(column, name) {
+			return idx, true
+		}
+	}
+	return 0, false
+}
+
+func (s *scannedTable) HasColumnFold(name string) bool {
+	_, ok := s.foldedColumnIndex(name)
+	return ok
+}
+
 func (s *scannedTable) Value(row []any, column string) any {
 	idx, ok := s.ColIdx[column]
+	if !ok {
+		return nil
+	}
+	return row[idx]
+}
+
+func (s *scannedTable) ValueFold(row []any, column string) any {
+	idx, ok := s.foldedColumnIndex(column)
 	if !ok {
 		return nil
 	}
@@ -162,6 +192,31 @@ func rowValue(arr arrow.Array, i int) (any, error) {
 		return listValues(a.ListValues(), int(a.Offsets()[i]), int(a.Offsets()[i+1]))
 	case *array.LargeList:
 		return listValues(a.ListValues(), int(a.Offsets()[i]), int(a.Offsets()[i+1]))
+	case *array.Struct:
+		values := make(structVal, a.NumField())
+		for field := range values {
+			value, err := rowValue(a.Field(field), i)
+			if err != nil {
+				return nil, err
+			}
+			values[field] = value
+		}
+		return values, nil
+	case *array.Map:
+		start, end := int(a.Offsets()[i]), int(a.Offsets()[i+1])
+		entries := make(mapVal, 0, end-start)
+		for entry := start; entry < end; entry++ {
+			key, err := rowValue(a.Keys(), entry)
+			if err != nil {
+				return nil, err
+			}
+			value, err := rowValue(a.Items(), entry)
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, mapEntryVal{key: key, value: value})
+		}
+		return entries, nil
 	case array.ExtensionArray:
 		return rowValue(a.Storage(), i)
 	case *array.Null:
@@ -231,7 +286,14 @@ func normalizeDecimalString(s string) string {
 
 // appendValue writes a normalized value into a builder for the write schema.
 func appendValue(b array.Builder, v any) error {
+	return appendValueAtPath(b, v, "value", true)
+}
+
+func appendValueAtPath(b array.Builder, v any, valuePath string, nullable bool) error {
 	if v == nil {
+		if !nullable {
+			return fmt.Errorf("required nested value %s is null", valuePath)
+		}
 		b.AppendNull()
 		return nil
 	}
@@ -361,8 +423,37 @@ func appendValue(b array.Builder, v any) error {
 			return typeMismatch(b, v)
 		}
 		bldr.Append(true)
-		for _, elem := range vals {
-			if err := appendValue(bldr.ValueBuilder(), elem); err != nil {
+		elemField := bldr.Type().(*arrow.ListType).ElemField()
+		for index, elem := range vals {
+			if err := appendValueAtPath(bldr.ValueBuilder(), elem, fmt.Sprintf("%s.element[%d]", valuePath, index), elemField.Nullable); err != nil {
+				return err
+			}
+		}
+	case *array.StructBuilder:
+		vals, ok := v.(structVal)
+		if !ok || len(vals) != bldr.NumField() {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(true)
+		structType := bldr.Type().(*arrow.StructType)
+		for field, value := range vals {
+			fieldMeta := structType.Field(field)
+			if err := appendValueAtPath(bldr.FieldBuilder(field), value, valuePath+"."+fieldMeta.Name, fieldMeta.Nullable); err != nil {
+				return err
+			}
+		}
+	case *array.MapBuilder:
+		entries, ok := v.(mapVal)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		bldr.Append(true)
+		mapType := bldr.Type().(*arrow.MapType)
+		for index, entry := range entries {
+			if err := appendValueAtPath(bldr.KeyBuilder(), entry.key, fmt.Sprintf("%s.key[%d]", valuePath, index), false); err != nil {
+				return err
+			}
+			if err := appendValueAtPath(bldr.ItemBuilder(), entry.value, fmt.Sprintf("%s.value[%d]", valuePath, index), mapType.ItemField().Nullable); err != nil {
 				return err
 			}
 		}
@@ -418,7 +509,8 @@ func buildRecordBatches(writeSchema *arrow.Schema, rows [][]any) ([]arrow.Record
 		builder := array.NewRecordBuilder(memory.DefaultAllocator, writeSchema)
 		for _, row := range rows[start:end] {
 			for c := range writeSchema.Fields() {
-				if err := appendValue(builder.Field(c), row[c]); err != nil {
+				field := writeSchema.Field(c)
+				if err := appendValueAtPath(builder.Field(c), row[c], field.Name, true); err != nil {
 					builder.Release()
 					release()
 					return nil, fmt.Errorf("iceberg: column %q: %w", writeSchema.Field(c).Name, err)
@@ -429,12 +521,6 @@ func buildRecordBatches(writeSchema *arrow.Schema, rows [][]any) ([]arrow.Record
 		builder.Release()
 	}
 	return batches, nil
-}
-
-func releaseBatches(batches []arrow.RecordBatch) {
-	for _, b := range batches {
-		b.Release()
-	}
 }
 
 // valuesEqual compares two normalized values null-safely (both-nil is equal,
@@ -454,6 +540,28 @@ func valuesEqual(a, b any) bool {
 		}
 		for i := range av {
 			if !valuesEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case structVal:
+		bv, ok := b.(structVal)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !valuesEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case mapVal:
+		bv, ok := b.(mapVal)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !valuesEqual(av[i].key, bv[i].key) || !valuesEqual(av[i].value, bv[i].value) {
 				return false
 			}
 		}
@@ -531,7 +639,15 @@ func cmpInt(a, b int64) int {
 }
 
 func cmpFloat(a, b float64) int {
+	aNaN := math.IsNaN(a)
+	bNaN := math.IsNaN(b)
 	switch {
+	case aNaN && bNaN:
+		return 0
+	case aNaN:
+		return 1
+	case bNaN:
+		return -1
 	case a < b:
 		return -1
 	case a > b:
@@ -798,149 +914,4 @@ func decimalLiteral(field iceberggo.NestedField, v any) (iceberggo.Decimal, erro
 		return iceberggo.Decimal{}, fmt.Errorf("iceberg: invalid decimal value %q for column %q: %w", str, field.Name, err)
 	}
 	return iceberggo.Decimal{Val: num, Scale: dt.Scale()}, nil
-}
-
-// keyMatchFilter builds an expression matching rows whose primary key values
-// appear in keys. Single-column keys use an IN set; composite keys expand into
-// OR-of-AND equality chains.
-func keyMatchFilter(iceSchema *iceberggo.Schema, primaryKeys []string, keys [][]any) (iceberggo.BooleanExpression, error) {
-	if len(keys) == 0 {
-		return iceberggo.AlwaysFalse{}, nil
-	}
-	fields := make([]iceberggo.NestedField, len(primaryKeys))
-	for i, pk := range primaryKeys {
-		field, ok := iceSchema.FindFieldByName(pk)
-		if !ok {
-			return nil, fmt.Errorf("iceberg: primary key column %q not found in table schema", pk)
-		}
-		fields[i] = field
-	}
-
-	if len(primaryKeys) == 1 {
-		return singleKeyInFilter(fields[0], keys)
-	}
-
-	keyExprs := make([]iceberggo.BooleanExpression, 0, len(keys))
-	for _, key := range keys {
-		preds := make([]iceberggo.BooleanExpression, 0, len(fields))
-		for i, field := range fields {
-			pred, err := equalityPredicate(field, key[i])
-			if err != nil {
-				return nil, err
-			}
-			preds = append(preds, pred)
-		}
-		keyExprs = append(keyExprs, andAll(preds))
-	}
-	return orAll(keyExprs), nil
-}
-
-// orAll and andAll build balanced expression trees so large key sets don't
-// produce recursion-deep left-leaning chains in binding and evaluation.
-func orAll(exprs []iceberggo.BooleanExpression) iceberggo.BooleanExpression {
-	switch len(exprs) {
-	case 0:
-		return iceberggo.AlwaysFalse{}
-	case 1:
-		return exprs[0]
-	default:
-		mid := len(exprs) / 2
-		return iceberggo.NewOr(orAll(exprs[:mid]), orAll(exprs[mid:]))
-	}
-}
-
-func andAll(exprs []iceberggo.BooleanExpression) iceberggo.BooleanExpression {
-	switch len(exprs) {
-	case 0:
-		return iceberggo.AlwaysTrue{}
-	case 1:
-		return exprs[0]
-	default:
-		mid := len(exprs) / 2
-		return iceberggo.NewAnd(andAll(exprs[:mid]), andAll(exprs[mid:]))
-	}
-}
-
-func singleKeyInFilter(field iceberggo.NestedField, keys [][]any) (iceberggo.BooleanExpression, error) {
-	ref := iceberggo.Reference(field.Name)
-	switch field.Type.(type) {
-	case iceberggo.Int32Type:
-		vals, err := collectKeyValues(field, keys, func(v any) (int32, bool) {
-			i, ok := v.(int64)
-			return int32(i), ok
-		})
-		if err != nil {
-			return nil, err
-		}
-		return iceberggo.IsIn(ref, vals...), nil
-	case iceberggo.Int64Type:
-		vals, err := collectKeyValues(field, keys, func(v any) (int64, bool) {
-			i, ok := v.(int64)
-			return i, ok
-		})
-		if err != nil {
-			return nil, err
-		}
-		return iceberggo.IsIn(ref, vals...), nil
-	case iceberggo.StringType:
-		vals, err := collectKeyValues(field, keys, asString)
-		if err != nil {
-			return nil, err
-		}
-		return iceberggo.IsIn(ref, vals...), nil
-	case iceberggo.DateType:
-		vals, err := collectKeyValues(field, keys, func(v any) (iceberggo.Date, bool) {
-			i, ok := v.(int64)
-			return iceberggo.Date(i), ok
-		})
-		if err != nil {
-			return nil, err
-		}
-		return iceberggo.IsIn(ref, vals...), nil
-	case iceberggo.TimestampType, iceberggo.TimestampTzType:
-		vals, err := collectKeyValues(field, keys, func(v any) (iceberggo.Timestamp, bool) {
-			i, ok := v.(int64)
-			return iceberggo.Timestamp(i), ok
-		})
-		if err != nil {
-			return nil, err
-		}
-		return iceberggo.IsIn(ref, vals...), nil
-	case iceberggo.UUIDType:
-		vals, err := collectKeyValues(field, keys, func(v any) (uuid.UUID, bool) {
-			s, ok := asString(v)
-			if !ok {
-				return uuid.UUID{}, false
-			}
-			parsed, err := uuid.Parse(s)
-			return parsed, err == nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		return iceberggo.IsIn(ref, vals...), nil
-	default:
-		// Fall back to OR-of-equality for less common key types.
-		preds := make([]iceberggo.BooleanExpression, 0, len(keys))
-		for _, key := range keys {
-			pred, err := equalityPredicate(field, key[0])
-			if err != nil {
-				return nil, err
-			}
-			preds = append(preds, pred)
-		}
-		return orAll(preds), nil
-	}
-}
-
-func collectKeyValues[T any](field iceberggo.NestedField, keys [][]any, convert func(any) (T, bool)) ([]T, error) {
-	vals := make([]T, 0, len(keys))
-	for _, key := range keys {
-		v, ok := convert(key[0])
-		if !ok {
-			return nil, predicateTypeErr(field, key[0])
-		}
-		vals = append(vals, v)
-	}
-	return vals, nil
 }

--- a/pkg/destination/iceberg/sort_order.go
+++ b/pkg/destination/iceberg/sort_order.go
@@ -1,0 +1,271 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+)
+
+func sortOrderForColumns(sc *iceberggo.Schema, columns []string, orderID int) (icebergtable.SortOrder, error) {
+	fields := make([]icebergtable.SortField, len(columns))
+	for i, column := range columns {
+		field, ok := sc.FindFieldByName(column)
+		if !ok {
+			return icebergtable.SortOrder{}, fmt.Errorf("iceberg: cluster column %q not found", column)
+		}
+		fields[i] = icebergtable.SortField{
+			SourceIDs: []int{field.ID},
+			Transform: iceberggo.IdentityTransform{},
+			Direction: icebergtable.SortASC,
+			NullOrder: icebergtable.NullsFirst,
+		}
+	}
+	order, err := icebergtable.NewSortOrder(orderID, fields)
+	if err != nil {
+		return icebergtable.SortOrder{}, fmt.Errorf("iceberg: invalid cluster columns: %w", err)
+	}
+	if err := order.CheckCompatibility(sc); err != nil {
+		return icebergtable.SortOrder{}, fmt.Errorf("iceberg: invalid cluster columns: %w", err)
+	}
+	return order, nil
+}
+
+func (d *Destination) ensureSortOrder(ctx context.Context, tbl *icebergtable.Table, columns []string) (*icebergtable.Table, error) {
+	return d.ensureSortOrderExpected(ctx, tbl, columns, "")
+}
+
+func (d *Destination) ensureSortOrderExpected(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	columns []string,
+	expectedIncarnation string,
+) (*icebergtable.Table, error) {
+	if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+		return nil, err
+	}
+	if len(columns) == 0 {
+		if tbl.SortOrder().OrderID() == icebergtable.UnsortedSortOrder.OrderID() {
+			return tbl, nil
+		}
+		// A table created with a sort order carries only that order in its
+		// metadata; the unsorted order must be added before it can become the
+		// default.
+		updates := make([]icebergtable.Update, 0, 2)
+		hasUnsorted := false
+		for _, existing := range tbl.Metadata().SortOrders() {
+			if existing.OrderID() == icebergtable.UnsortedSortOrder.OrderID() {
+				hasUnsorted = true
+				break
+			}
+		}
+		if !hasUnsorted {
+			updates = append(updates, icebergtable.NewAddSortOrderUpdate(&icebergtable.UnsortedSortOrder))
+		}
+		updates = append(updates, icebergtable.NewSetDefaultSortOrderUpdate(icebergtable.UnsortedSortOrder.OrderID()))
+		if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+			return nil, err
+		}
+		_, _, err := d.catalog.CommitTable(ctx, tbl.Identifier(), []icebergtable.Requirement{
+			icebergtable.AssertTableUUID(tbl.Metadata().TableUUID()),
+			icebergtable.AssertDefaultSortOrderID(tbl.SortOrder().OrderID()),
+		}, updates)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: failed to clear sort order: %w", err)
+		}
+		refreshed, err := d.catalog.LoadTable(ctx, tbl.Identifier())
+		if err != nil {
+			return nil, fmt.Errorf("iceberg: failed to reload table after clearing sort order: %w", err)
+		}
+		if err := d.validateExpectedIncarnation(ctx, refreshed, expectedIncarnation); err != nil {
+			return nil, err
+		}
+		return refreshed, nil
+	}
+	desired, err := sortOrderForColumns(tbl.Schema(), columns, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	matchingID := -1
+	maxID := 0
+	for _, existing := range tbl.Metadata().SortOrders() {
+		if existing.OrderID() > maxID {
+			maxID = existing.OrderID()
+		}
+		if sortFieldsEqual(existing, desired) {
+			matchingID = existing.OrderID()
+		}
+	}
+	if matchingID == tbl.SortOrder().OrderID() {
+		return tbl, nil
+	}
+
+	updates := make([]icebergtable.Update, 0, 2)
+	if matchingID < 0 {
+		desired, err = sortOrderForColumns(tbl.Schema(), columns, maxID+1)
+		if err != nil {
+			return nil, err
+		}
+		matchingID = desired.OrderID()
+		updates = append(updates, icebergtable.NewAddSortOrderUpdate(&desired))
+	}
+	updates = append(updates, icebergtable.NewSetDefaultSortOrderUpdate(matchingID))
+	if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+		return nil, err
+	}
+	_, _, err = d.catalog.CommitTable(ctx, tbl.Identifier(), []icebergtable.Requirement{
+		icebergtable.AssertTableUUID(tbl.Metadata().TableUUID()),
+		icebergtable.AssertDefaultSortOrderID(tbl.SortOrder().OrderID()),
+	}, updates)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to update sort order: %w", err)
+	}
+	refreshed, err := d.catalog.LoadTable(ctx, tbl.Identifier())
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to reload table after sort order update: %w", err)
+	}
+	if err := d.validateExpectedIncarnation(ctx, refreshed, expectedIncarnation); err != nil {
+		return nil, err
+	}
+	return refreshed, nil
+}
+
+func identitySortColumns(tbl *icebergtable.Table) ([]string, bool) {
+	columns := make([]string, 0, tbl.SortOrder().Len())
+	for _, field := range tbl.SortOrder().Fields() {
+		if len(field.SourceIDs) != 1 {
+			return nil, false
+		}
+		if _, ok := field.Transform.(iceberggo.IdentityTransform); !ok || field.Direction != icebergtable.SortASC || field.NullOrder != icebergtable.NullsFirst {
+			return nil, false
+		}
+		name, ok := tbl.Schema().FindColumnName(field.SourceIDs[0])
+		if !ok {
+			return nil, false
+		}
+		columns = append(columns, name)
+	}
+	return columns, true
+}
+
+func sortFieldsEqual(left, right icebergtable.SortOrder) bool {
+	if left.Len() != right.Len() {
+		return false
+	}
+	rightFields := make([]icebergtable.SortField, 0, right.Len())
+	for _, field := range right.Fields() {
+		rightFields = append(rightFields, field)
+	}
+	i := 0
+	for _, field := range left.Fields() {
+		if !field.Equals(rightFields[i]) {
+			return false
+		}
+		i++
+	}
+	return true
+}
+
+func sortOrderMatchesColumns(tbl *icebergtable.Table, columns []string) bool {
+	if len(columns) == 0 {
+		return tbl.SortOrder().IsUnsorted()
+	}
+	desired, err := sortOrderForColumns(tbl.Schema(), columns, icebergtable.InitialSortOrderID)
+	return err == nil && sortFieldsEqual(tbl.SortOrder(), desired)
+}
+
+func withDataFileSortOrderID(dataFile iceberggo.DataFile, tbl *icebergtable.Table, sortOrderID int) (iceberggo.DataFile, error) {
+	if current := dataFile.SortOrderID(); current != nil && *current == sortOrderID {
+		return dataFile, nil
+	}
+	return copyDataFileMetadata(dataFile, tbl, &sortOrderID, nil)
+}
+
+func withDataFileFirstRowID(dataFile iceberggo.DataFile, tbl *icebergtable.Table, firstRowID int64) (iceberggo.DataFile, error) {
+	if current := dataFile.FirstRowID(); current != nil && *current == firstRowID {
+		return dataFile, nil
+	}
+	return copyDataFileMetadata(dataFile, tbl, nil, &firstRowID)
+}
+
+func copyDataFileMetadata(
+	dataFile iceberggo.DataFile,
+	tbl *icebergtable.Table,
+	sortOrderID *int,
+	firstRowID *int64,
+) (iceberggo.DataFile, error) {
+	logicalTypes := make(map[int]string)
+	fixedSizes := make(map[int]int)
+	spec := tbl.Spec()
+	for _, partitionField := range spec.Fields() {
+		sourceField, ok := tbl.Schema().FindFieldByID(partitionField.SourceID())
+		if !ok {
+			return nil, fmt.Errorf("iceberg: partition source field %d not found", partitionField.SourceID())
+		}
+		switch resultType := partitionField.Transform.ResultType(sourceField.Type).(type) {
+		case iceberggo.DateType:
+			logicalTypes[partitionField.FieldID] = "date"
+		case iceberggo.TimeType:
+			logicalTypes[partitionField.FieldID] = "time-micros"
+		case iceberggo.TimestampType, iceberggo.TimestampTzType:
+			logicalTypes[partitionField.FieldID] = "timestamp-micros"
+		case iceberggo.DecimalType:
+			logicalTypes[partitionField.FieldID] = "decimal"
+			fixedSizes[partitionField.FieldID] = resultType.Scale()
+		case iceberggo.UUIDType:
+			logicalTypes[partitionField.FieldID] = "uuid"
+		}
+	}
+
+	builder, err := iceberggo.NewDataFileBuilder(
+		spec,
+		dataFile.ContentType(),
+		dataFile.FilePath(),
+		dataFile.FileFormat(),
+		dataFile.Partition(),
+		logicalTypes,
+		fixedSizes,
+		dataFile.Count(),
+		dataFile.FileSizeBytes(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("iceberg: failed to copy data file metadata: %w", err)
+	}
+	builder.ColumnSizes(dataFile.ColumnSizes()).
+		ValueCounts(dataFile.ValueCounts()).
+		NullValueCounts(dataFile.NullValueCounts()).
+		NaNValueCounts(dataFile.NaNValueCounts()).
+		LowerBoundValues(dataFile.LowerBoundValues()).
+		UpperBoundValues(dataFile.UpperBoundValues())
+	if sortOrderID != nil {
+		builder.SortOrderID(*sortOrderID)
+	} else if current := dataFile.SortOrderID(); current != nil {
+		builder.SortOrderID(*current)
+	}
+	if key := dataFile.KeyMetadata(); key != nil {
+		builder.KeyMetadata(key)
+	}
+	if offsets := dataFile.SplitOffsets(); offsets != nil {
+		builder.SplitOffsets(offsets)
+	}
+	if fieldIDs := dataFile.EqualityFieldIDs(); fieldIDs != nil {
+		builder.EqualityFieldIDs(fieldIDs)
+	}
+	if firstRowID != nil {
+		builder.FirstRowID(*firstRowID)
+	} else if current := dataFile.FirstRowID(); current != nil {
+		builder.FirstRowID(*current)
+	}
+	if referencedDataFile := dataFile.ReferencedDataFile(); referencedDataFile != nil {
+		builder.ReferencedDataFile(*referencedDataFile)
+	}
+	if offset := dataFile.ContentOffset(); offset != nil {
+		builder.ContentOffset(*offset)
+	}
+	if size := dataFile.ContentSizeInBytes(); size != nil {
+		builder.ContentSizeInBytes(*size)
+	}
+	return builder.Build(), nil
+}

--- a/pkg/destination/iceberg/spill.go
+++ b/pkg/destination/iceberg/spill.go
@@ -2,6 +2,7 @@ package iceberg
 
 import (
 	"container/heap"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -40,6 +41,8 @@ type spillSorter struct {
 	schema   *arrow.Schema
 	runFile  *arrow.Schema
 	keyIdx   []int
+	encode   func([]any) (string, error)
+	allowNil bool
 	tmpDir   string
 	runs     []string
 	buf      []spillRow
@@ -75,21 +78,33 @@ func newSpillSorter(schema *arrow.Schema, keyColumns []string) (*spillSorter, er
 		schema:  schema,
 		runFile: arrow.NewSchema(fields, nil),
 		keyIdx:  keyIdx,
+		encode:  encodeRowKey,
 	}, nil
 }
 
 func (s *spillSorter) Add(vals []any) error {
+	return s.addContext(context.Background(), vals)
+}
+
+func (s *spillSorter) AddContext(ctx context.Context, vals []any) error {
+	return s.addContext(ctx, vals)
+}
+
+func (s *spillSorter) addContext(ctx context.Context, vals []any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if s.finished {
 		return errors.New("iceberg: spill sorter already finalized")
 	}
 	keyVals := make([]any, len(s.keyIdx))
 	for i, idx := range s.keyIdx {
-		if vals[idx] == nil {
+		if vals[idx] == nil && !s.allowNil {
 			return fmt.Errorf("primary key column %q contains NULL", s.schema.Field(idx).Name)
 		}
 		keyVals[i] = vals[idx]
 	}
-	key, err := encodeRowKey(keyVals)
+	key, err := s.encode(keyVals)
 	if err != nil {
 		return err
 	}
@@ -97,7 +112,7 @@ func (s *spillSorter) Add(vals []any) error {
 	s.buf = append(s.buf, spillRow{key: key, seq: s.seq, vals: vals})
 	s.seq++
 	if len(s.buf) >= spillRunRows {
-		return s.flushRun()
+		return s.flushRunContext(ctx)
 	}
 	return nil
 }
@@ -113,11 +128,17 @@ func sortSpillRows(rows []spillRow) {
 	})
 }
 
-func (s *spillSorter) flushRun() error {
+func (s *spillSorter) flushRunContext(ctx context.Context) error {
 	if len(s.buf) == 0 {
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	sortSpillRows(s.buf)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if s.tmpDir == "" {
 		dir, err := os.MkdirTemp("", "ingestr-iceberg-spill-")
@@ -135,8 +156,13 @@ func (s *spillSorter) flushRun() error {
 
 	writer := ipc.NewWriter(f, ipc.WithSchema(s.runFile))
 	numFields := len(s.schema.Fields())
-	for start := 0; start < len(s.buf); start += batchBuildRows {
-		end := min(start+batchBuildRows, len(s.buf))
+	batchRows := spillCursorBatchRows()
+	for start := 0; start < len(s.buf); start += batchRows {
+		if err := ctx.Err(); err != nil {
+			_ = writer.Close()
+			return err
+		}
+		end := min(start+batchRows, len(s.buf))
 		builder := array.NewRecordBuilder(memory.DefaultAllocator, s.runFile)
 		for _, row := range s.buf[start:end] {
 			for c := range numFields {
@@ -167,27 +193,31 @@ func (s *spillSorter) flushRun() error {
 	return nil
 }
 
-// finalize seals the sorter for iteration. When runs were spilled, the
+// finalizeContext seals the sorter for iteration. When runs were spilled, the
 // remaining buffer becomes a final run and runs beyond the merge fan-in are
 // compacted into larger sorted runs; otherwise the buffer is sorted in place
 // and iterated from memory.
-func (s *spillSorter) finalize() error {
+func (s *spillSorter) finalizeContext(ctx context.Context) error {
 	if s.finished {
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if len(s.runs) > 0 {
-		if err := s.flushRun(); err != nil {
+		if err := s.flushRunContext(ctx); err != nil {
 			return err
 		}
-		for len(s.runs) > spillMergeFanIn {
-			merged, err := s.mergeRuns(s.runs[:spillMergeFanIn])
+		fanIn := effectiveSpillMergeFanIn()
+		for len(s.runs) > fanIn {
+			merged, err := s.mergeRuns(ctx, s.runs[:fanIn])
 			if err != nil {
 				return err
 			}
-			for _, run := range s.runs[:spillMergeFanIn] {
+			for _, run := range s.runs[:fanIn] {
 				_ = os.Remove(run)
 			}
-			s.runs = append(s.runs[spillMergeFanIn:], merged)
+			s.runs = append(s.runs[fanIn:], merged)
 		}
 	} else {
 		sortSpillRows(s.buf)
@@ -197,7 +227,7 @@ func (s *spillSorter) finalize() error {
 }
 
 // mergeRuns k-way merges the given sorted runs into one larger sorted run.
-func (s *spillSorter) mergeRuns(runs []string) (path string, err error) {
+func (s *spillSorter) mergeRuns(ctx context.Context, runs []string) (path string, err error) {
 	numFields := len(s.schema.Fields())
 
 	var cursors runHeap
@@ -207,6 +237,9 @@ func (s *spillSorter) mergeRuns(runs []string) (path string, err error) {
 		}
 	}()
 	for _, run := range runs {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		cursor, cErr := newRunCursor(run, numFields)
 		if cErr != nil {
 			return "", cErr
@@ -246,6 +279,10 @@ func (s *spillSorter) mergeRuns(runs []string) (path string, err error) {
 	}
 
 	for len(cursors) > 0 {
+		if err := ctx.Err(); err != nil {
+			_ = writer.Close()
+			return "", err
+		}
 		cursor := cursors[0]
 		for c := range numFields {
 			if err := appendValue(builder.Field(c), cursor.vals[c]); err != nil {
@@ -256,7 +293,7 @@ func (s *spillSorter) mergeRuns(runs []string) (path string, err error) {
 		builder.Field(numFields).(*array.StringBuilder).Append(cursor.key)
 		builder.Field(numFields + 1).(*array.Int64Builder).Append(cursor.seq)
 		rows++
-		if rows >= batchBuildRows {
+		if rows >= spillCursorBatchRows() {
 			if err := flush(); err != nil {
 				_ = writer.Close()
 				return "", fmt.Errorf("iceberg: failed to write spill run: %w", err)
@@ -285,6 +322,16 @@ func (s *spillSorter) mergeRuns(runs []string) (path string, err error) {
 	return f.Name(), nil
 }
 
+func effectiveSpillMergeFanIn() int {
+	configured := max(spillMergeFanIn, 2)
+	memoryBound := max(spillRunRows/batchBuildRows, 2)
+	return min(configured, memoryBound)
+}
+
+func spillCursorBatchRows() int {
+	return max(1, min(batchBuildRows, spillRunRows/effectiveSpillMergeFanIn()))
+}
+
 func (s *spillSorter) Close() {
 	s.buf = nil
 	if s.tmpDir != "" {
@@ -297,16 +344,27 @@ func (s *spillSorter) Close() {
 // Iter returns a fresh cursor over all rows grouped by key. It may be called
 // multiple times; each call re-merges the spilled runs.
 func (s *spillSorter) Iter() (*spillIter, error) {
-	if err := s.finalize(); err != nil {
+	return s.IterContext(context.Background())
+}
+
+func (s *spillSorter) IterContext(ctx context.Context) (*spillIter, error) {
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	it := &spillIter{}
+	if err := s.finalizeContext(ctx); err != nil {
+		return nil, err
+	}
+	it := &spillIter{ctx: ctx}
 	if len(s.runs) == 0 {
 		it.mem = s.buf
 		return it, nil
 	}
 
 	for _, run := range s.runs {
+		if err := ctx.Err(); err != nil {
+			it.Close()
+			return nil, err
+		}
 		cursor, err := newRunCursor(run, len(s.schema.Fields()))
 		if err != nil {
 			it.Close()
@@ -337,6 +395,7 @@ func (s *spillSorter) Iter() (*spillIter, error) {
 //	}
 //	if err := it.Err(); err != nil { ... }
 type spillIter struct {
+	ctx context.Context
 	// in-memory mode
 	mem []spillRow
 	pos int
@@ -367,6 +426,10 @@ func (it *spillIter) Row() []any { return it.current }
 // NextGroup advances to the next key group, skipping any unconsumed rows of
 // the current group.
 func (it *spillIter) NextGroup() bool {
+	if err := it.ctx.Err(); err != nil {
+		it.err = err
+		return false
+	}
 	if it.err != nil {
 		return false
 	}
@@ -388,6 +451,10 @@ func (it *spillIter) NextGroup() bool {
 
 // NextRow advances within the current group.
 func (it *spillIter) NextRow() bool {
+	if err := it.ctx.Err(); err != nil {
+		it.err = err
+		return false
+	}
 	if it.err != nil {
 		return false
 	}

--- a/pkg/destination/iceberg/spool_reader.go
+++ b/pkg/destination/iceberg/spool_reader.go
@@ -1,0 +1,284 @@
+package iceberg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/bruin-data/ingestr/pkg/naming"
+)
+
+type orderedRowContentHasher struct {
+	schema *arrow.Schema
+	hash   hash.Hash
+}
+
+func newOrderedRowContentHasher(sc *arrow.Schema) *orderedRowContentHasher {
+	h := sha256.New()
+	_, _ = h.Write([]byte(sc.String()))
+	return &orderedRowContentHasher{schema: sc, hash: h}
+}
+
+func (h *orderedRowContentHasher) Add(row []any) {
+	var encoded bytes.Buffer
+	for i, value := range row {
+		if strings.EqualFold(h.schema.Field(i).Name, naming.IngestrLoadedAtColumn) {
+			continue
+		}
+		encodeContentValue(&encoded, value)
+	}
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(encoded.Len()))
+	_, _ = h.hash.Write(size[:])
+	_, _ = h.hash.Write(encoded.Bytes())
+}
+
+func (h *orderedRowContentHasher) Identity() string {
+	return hex.EncodeToString(h.hash.Sum(nil))
+}
+
+func spoolRecordReader(reader array.RecordReader) (array.RecordReader, func(), error) {
+	file, err := os.CreateTemp("", "ingestr-iceberg-overwrite-*.arrow")
+	if err != nil {
+		return nil, nil, fmt.Errorf("iceberg: failed to create overwrite spool: %w", err)
+	}
+	cleanupFile := func() {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+	}
+
+	writer := ipc.NewWriter(file, ipc.WithSchema(reader.Schema()))
+	for reader.Next() {
+		if err := writer.Write(reader.RecordBatch()); err != nil {
+			_ = writer.Close()
+			cleanupFile()
+			return nil, nil, fmt.Errorf("iceberg: failed to spool overwrite batch: %w", err)
+		}
+	}
+	if err := reader.Err(); err != nil {
+		_ = writer.Close()
+		cleanupFile()
+		return nil, nil, err
+	}
+	if err := writer.Close(); err != nil {
+		cleanupFile()
+		return nil, nil, fmt.Errorf("iceberg: failed to finish overwrite spool: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		cleanupFile()
+		return nil, nil, fmt.Errorf("iceberg: failed to rewind overwrite spool: %w", err)
+	}
+	spooled, err := ipc.NewReader(file)
+	if err != nil {
+		cleanupFile()
+		return nil, nil, fmt.Errorf("iceberg: failed to open overwrite spool: %w", err)
+	}
+	cleanup := func() {
+		spooled.Release()
+		cleanupFile()
+	}
+	return spooled, cleanup, nil
+}
+
+func spoolReplayableRecordReader(reader array.RecordReader) (func() (array.RecordReader, func(), error), func(), error) {
+	file, err := os.CreateTemp("", "ingestr-iceberg-replay-*.arrow")
+	if err != nil {
+		return nil, nil, fmt.Errorf("iceberg: failed to create replay spool: %w", err)
+	}
+	path := file.Name()
+	cleanup := func() {
+		_ = file.Close()
+		_ = os.Remove(path)
+	}
+	writer := ipc.NewWriter(file, ipc.WithSchema(reader.Schema()))
+	for reader.Next() {
+		if err := writer.Write(reader.RecordBatch()); err != nil {
+			_ = writer.Close()
+			cleanup()
+			return nil, nil, fmt.Errorf("iceberg: failed to write replay spool: %w", err)
+		}
+	}
+	if err := reader.Err(); err != nil {
+		_ = writer.Close()
+		cleanup()
+		return nil, nil, err
+	}
+	if err := writer.Close(); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("iceberg: failed to finish replay spool: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("iceberg: failed to close replay spool: %w", err)
+	}
+
+	open := func() (array.RecordReader, func(), error) {
+		input, err := os.Open(path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("iceberg: failed to open replay spool: %w", err)
+		}
+		replayed, err := ipc.NewReader(input)
+		if err != nil {
+			_ = input.Close()
+			return nil, nil, fmt.Errorf("iceberg: failed to read replay spool: %w", err)
+		}
+		release := func() {
+			replayed.Release()
+			_ = input.Close()
+		}
+		return replayed, release, nil
+	}
+	return open, cleanup, nil
+}
+
+func spoolAppendRecordReader(reader array.RecordReader) (array.RecordReader, func(), string, error) {
+	file, err := os.CreateTemp("", "ingestr-iceberg-append-*.arrow")
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("iceberg: failed to create append spool: %w", err)
+	}
+	cleanupFile := func() {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+	}
+
+	writer := ipc.NewWriter(file, ipc.WithSchema(reader.Schema()))
+	var aggregate [sha256.Size]byte
+	var rowCount uint64
+	for reader.Next() {
+		batch := reader.RecordBatch()
+		if err := writer.Write(batch); err != nil {
+			_ = writer.Close()
+			cleanupFile()
+			return nil, nil, "", fmt.Errorf("iceberg: failed to spool append batch: %w", err)
+		}
+		for row := 0; row < int(batch.NumRows()); row++ {
+			var encoded bytes.Buffer
+			for column := 0; column < int(batch.NumCols()); column++ {
+				if strings.EqualFold(batch.Schema().Field(column).Name, naming.IngestrLoadedAtColumn) {
+					continue
+				}
+				value, err := rowValue(batch.Column(column), row)
+				if err != nil {
+					_ = writer.Close()
+					cleanupFile()
+					return nil, nil, "", err
+				}
+				encodeContentValue(&encoded, value)
+			}
+			rowHash := sha256.Sum256(encoded.Bytes())
+			addDigest(&aggregate, rowHash)
+			rowCount++
+		}
+	}
+	if err := reader.Err(); err != nil {
+		_ = writer.Close()
+		cleanupFile()
+		return nil, nil, "", err
+	}
+	if err := writer.Close(); err != nil {
+		cleanupFile()
+		return nil, nil, "", fmt.Errorf("iceberg: failed to finish append spool: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		cleanupFile()
+		return nil, nil, "", fmt.Errorf("iceberg: failed to rewind append spool: %w", err)
+	}
+	spooled, err := ipc.NewReader(file)
+	if err != nil {
+		cleanupFile()
+		return nil, nil, "", fmt.Errorf("iceberg: failed to open append spool: %w", err)
+	}
+	identity := sha256.New()
+	_, _ = identity.Write([]byte(reader.Schema().String()))
+	_, _ = identity.Write(aggregate[:])
+	var count [8]byte
+	binary.BigEndian.PutUint64(count[:], rowCount)
+	_, _ = identity.Write(count[:])
+	cleanup := func() {
+		spooled.Release()
+		cleanupFile()
+	}
+	return spooled, cleanup, hex.EncodeToString(identity.Sum(nil)), nil
+}
+
+func addDigest(total *[sha256.Size]byte, value [sha256.Size]byte) {
+	carry := uint16(0)
+	for i := sha256.Size - 1; i >= 0; i-- {
+		sum := uint16(total[i]) + uint16(value[i]) + carry
+		total[i] = byte(sum)
+		carry = sum >> 8
+	}
+}
+
+func encodeContentValue(out *bytes.Buffer, value any) {
+	switch value := value.(type) {
+	case nil:
+		out.WriteByte(0)
+	case bool:
+		out.WriteByte(1)
+		if value {
+			out.WriteByte(1)
+		} else {
+			out.WriteByte(0)
+		}
+	case int64:
+		out.WriteByte(2)
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], uint64(value))
+		out.Write(encoded[:])
+	case float64:
+		out.WriteByte(3)
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], math.Float64bits(value))
+		out.Write(encoded[:])
+	case string:
+		writeContentBytes(out, 4, []byte(value))
+	case []byte:
+		writeContentBytes(out, 5, value)
+	case decimalVal:
+		writeContentBytes(out, 6, []byte(value))
+	case uuidVal:
+		writeContentBytes(out, 7, []byte(value))
+	case []any:
+		out.WriteByte(8)
+		_, _ = out.WriteString(strconv.Itoa(len(value)))
+		out.WriteByte(':')
+		for _, element := range value {
+			encodeContentValue(out, element)
+		}
+	case structVal:
+		out.WriteByte(9)
+		_, _ = out.WriteString(strconv.Itoa(len(value)))
+		out.WriteByte(':')
+		for _, field := range value {
+			encodeContentValue(out, field)
+		}
+	case mapVal:
+		out.WriteByte(10)
+		_, _ = out.WriteString(strconv.Itoa(len(value)))
+		out.WriteByte(':')
+		for _, entry := range value {
+			encodeContentValue(out, entry.key)
+			encodeContentValue(out, entry.value)
+		}
+	default:
+		writeContentBytes(out, 11, []byte(fmt.Sprintf("%T:%v", value, value)))
+	}
+}
+
+func writeContentBytes(out *bytes.Buffer, tag byte, value []byte) {
+	out.WriteByte(tag)
+	_, _ = out.WriteString(strconv.Itoa(len(value)))
+	out.WriteByte(':')
+	out.Write(value)
+}

--- a/pkg/destination/iceberg/strategies.go
+++ b/pkg/destination/iceberg/strategies.go
@@ -26,8 +26,6 @@ import (
 
 // mergeEntry tracks the winning staging row(s) per primary key.
 type mergeEntry struct {
-	keyValues []any
-
 	// latest is the winning row overall: for CDC ordered by LSN (deletes win
 	// ties), otherwise by incremental key (arrival order breaks ties).
 	latest         []any
@@ -39,12 +37,6 @@ type mergeEntry struct {
 	// existing rows use it so a trailing delete doesn't clobber column values.
 	latestNonDeleted    []any
 	latestNonDeletedLSN string
-}
-
-type dedupedStaging struct {
-	keys    []string
-	entries map[string]*mergeEntry
-	isCDC   bool
 }
 
 func (d *Destination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
@@ -59,6 +51,21 @@ func (d *Destination) MergeTable(ctx context.Context, opts destination.MergeOpti
 	if err != nil {
 		return err
 	}
+	if err := d.validateExpectedIncarnation(ctx, target, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	metadata := mergeCommitMetadata(opts)
+	if tableHasCommitToken(target, metadata.token) {
+		if opts.SkipCDCResume {
+			return d.ensureManagedCDCResumeResetExpected(ctx, target, metadata.token, opts.CDCExpectedIncarnation)
+		}
+		return nil
+	}
+	if !opts.SkipCDCResume {
+		if err := validateCDCResumeAdvance(target, metadata); err != nil {
+			return err
+		}
+	}
 	staging, err := d.loadIcebergTable(ctx, opts.StagingTable)
 	if err != nil {
 		return err
@@ -69,66 +76,70 @@ func (d *Destination) MergeTable(ctx context.Context, opts destination.MergeOpti
 	// must be read (CDC delete handling, destination-only columns) or when
 	// equality deletes cannot apply (v1 tables, partition keys outside the
 	// primary key, explicit write.merge.mode=copy-on-write).
-	_, isCDC := staging.Schema().FindFieldByName(destination.CDCDeletedColumn)
-	if !isCDC && stagingCoversTarget(target.Schema(), staging.Schema()) && useRowDeltaMerge(target, opts.PrimaryKeys) {
-		return d.mergeRowDelta(ctx, target, staging, opts)
+	isCDC := icebergSchemaHasFieldFold(staging.Schema(), destination.CDCDeletedColumn)
+	if !isCDC && stagingCoversTarget(target.Schema(), staging.Schema()) {
+		rowDelta, err := useRowDeltaMerge(ctx, target, opts.PrimaryKeys)
+		if err != nil {
+			return err
+		}
+		if rowDelta && target.Metadata().Version() < 3 {
+			return d.mergeRowDelta(ctx, target, staging, opts)
+		}
 	}
 	return d.mergeCopyOnWrite(ctx, target, staging, opts)
 }
 
 func (d *Destination) mergeCopyOnWrite(ctx context.Context, target, staging *icebergtable.Table, opts destination.MergeOptions) error {
-	stagingRows, err := scanTableRows(ctx, staging, iceberggo.AlwaysTrue{})
+	stagingSchema, err := tableWriteSchema(staging)
 	if err != nil {
 		return err
 	}
-	if err := requireColumns(stagingRows, opts.PrimaryKeys, opts.StagingTable); err != nil {
+	stagingRows := tableRowsMetadata(stagingSchema)
+	sorter, err := newSpillSorter(stagingSchema, opts.PrimaryKeys)
+	if err != nil {
 		return err
 	}
-	if len(stagingRows.Rows) == 0 {
+	defer sorter.Close()
+	var maxLSN string
+	var staleEventErr error
+	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, func(row []any) error {
+		lsn, _ := asString(stagingRows.ValueFold(row, destination.CDCLSNColumn))
+		if !opts.SkipCDCResume {
+			if err := validateCDCEventPosition(target, lsn); err != nil && staleEventErr == nil {
+				staleEventErr = err
+			}
+		}
+		if compareCDCResumeLSN(lsn, maxLSN) > 0 {
+			maxLSN = lsn
+		}
+		return sorter.AddContext(ctx, row)
+	}); err != nil {
+		return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
+	}
+	metadata := mergeCommitMetadata(opts)
+	if !opts.SkipCDCResume {
+		metadata = metadata.withCDCResumeLSN(maxLSN)
+	}
+	if metadata.token == "" && sorter.Len() > 0 {
+		contentID, err := copyOnWriteContentIdentity(ctx, sorter, stagingRows, opts)
+		if err != nil {
+			return err
+		}
+		metadata.token = commitTokenID("merge-content:" + contentID)
+	}
+	if err := d.validateExpectedIncarnation(ctx, target, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	if tableHasCommitToken(target, metadata.token) {
+		if opts.SkipCDCResume {
+			return d.ensureManagedCDCResumeResetExpected(ctx, target, metadata.token, opts.CDCExpectedIncarnation)
+		}
 		return nil
 	}
-
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable, true)
-	if err != nil {
-		return err
+	if staleEventErr != nil {
+		return staleEventErr
 	}
-
-	keyValues := make([][]any, 0, len(deduped.keys))
-	for _, key := range deduped.keys {
-		keyValues = append(keyValues, deduped.entries[key].keyValues)
-	}
-	filter, err := keyMatchFilter(target.Schema(), opts.PrimaryKeys, keyValues)
-	if err != nil {
-		return err
-	}
-
-	targetRows, err := scanTableRows(ctx, target, filter)
-	if err != nil {
-		return err
-	}
-	existingByKey, err := indexRowsByKey(targetRows, opts.PrimaryKeys)
-	if err != nil {
-		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
-	}
-
-	outRows := make([][]any, 0, len(deduped.keys))
-	for _, key := range deduped.keys {
-		entry := deduped.entries[key]
-		existing := lastRow(existingByKey[key])
-		var row []any
-		if deduped.isCDC {
-			row, err = composeCDCMergeRow(targetRows.Columns, stagingRows, entry, existing)
-			if err != nil {
-				return err
-			}
-		} else {
-			row = projectRow(targetRows.Columns, stagingRows, entry.latest, existing)
-		}
-		outRows = append(outRows, row)
-	}
-
-	config.Debug("[ICEBERG MERGE] Overwriting %d key(s) in %s", len(deduped.keys), opts.TargetTable)
-	return d.overwriteRows(ctx, target, outRows, filter, "merge")
+	return d.mergeCopyOnWriteSorted(ctx, target, stagingRows, sorter, opts, metadata)
 }
 
 func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
@@ -147,7 +158,32 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 	if err != nil {
 		return err
 	}
+	current := target
+	var writeErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		writeErr = d.deleteInsertTableOnce(ctx, current, staging, opts)
+		if writeErr == nil {
+			return nil
+		}
+		if !errors.Is(writeErr, icebergtable.ErrCommitFailed) {
+			return writeErr
+		}
+		current, err = d.loadIcebergTable(ctx, opts.TargetTable)
+		if err != nil {
+			return errors.Join(writeErr, err)
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("iceberg: delete+insert failed on table %s after retries: %w", opts.TargetTable, writeErr)
+}
 
+func (d *Destination) deleteInsertTableOnce(
+	ctx context.Context,
+	target, staging *icebergtable.Table,
+	opts destination.DeleteInsertOptions,
+) error {
 	field, ok := target.Schema().FindFieldByName(opts.IncrementalKey)
 	if !ok {
 		return fmt.Errorf("iceberg: incremental key column %q not found in table %s", opts.IncrementalKey, opts.TargetTable)
@@ -170,7 +206,8 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 	}
 	filter := iceberggo.NewAnd(lower, upper)
 
-	writeSchema, err := tableWriteSchema(target)
+	preserveLineage := target.Metadata().Version() >= 3
+	writeSchema, err := copyOnWriteTargetSchema(target, preserveLineage)
 	if err != nil {
 		return err
 	}
@@ -192,7 +229,7 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 			return err
 		}
 		defer sorter.Close()
-		if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, sorter.Add); err != nil {
+		if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, func(row []any) error { return sorter.AddContext(ctx, row) }); err != nil {
 			return fmt.Errorf("iceberg: staging table %s: %w", opts.StagingTable, err)
 		}
 
@@ -202,7 +239,7 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 		}
 
 		produce = func(sink func(arrow.RecordBatch) error) error {
-			it, err := sorter.Iter()
+			it, err := sorter.IterContext(ctx)
 			if err != nil {
 				return err
 			}
@@ -232,19 +269,37 @@ func (d *Destination) DeleteInsertTable(ctx context.Context, opts destination.De
 
 	config.Debug("[ICEBERG DELETE+INSERT] Replacing interval [%v, %v] on %q from %s", opts.IntervalStart, opts.IntervalEnd, opts.IncrementalKey, opts.StagingTable)
 
-	reader := streamingReader(writeSchema, produce)
+	var reader array.RecordReader = streamingReader(writeSchema, produce)
 	defer reader.Release()
-
-	txn := target.NewTransaction()
-	if err := txn.Overwrite(ctx, reader, snapshotProps("delete+insert"), icebergtable.WithOverwriteFilter(filter)); err != nil {
+	combined := streamingReaderContext(ctx, writeSchema, func(sink func(arrow.RecordBatch) error) error {
+		emitter := newBatchEmitter(newRowProjection(writeSchema, arrowSchemaColumnNames(writeSchema)), sink)
+		defer emitter.release()
+		if err := forEachSCD2CurrentRow(ctx, target, iceberggo.NewNot(filter), preserveLineage, emitter.add); err != nil {
+			return err
+		}
+		if err := emitter.flushBatch(); err != nil {
+			return err
+		}
+		for reader.Next() {
+			batch := reader.RecordBatch()
+			batch.Retain()
+			if err := sink(batch); err != nil {
+				return err
+			}
+		}
+		return reader.Err()
+	})
+	defer combined.Release()
+	prepared := d.lookupPrepared(opts.TargetTable)
+	clustered, cleanupCluster, err := clusterRecordReader(ctx, combined, prepared.clusterBy)
+	if err != nil {
+		return fmt.Errorf("iceberg: failed to cluster delete+insert rows: %w", err)
+	}
+	defer cleanupCluster()
+	if err := d.replaceAllMergeRecords(ctx, target, clustered, prepared.clusterBy, destination.MergeOptions{TargetTable: opts.TargetTable, PrimaryKeys: opts.PrimaryKeys}, commitMetadata{}); err != nil {
 		return fmt.Errorf("iceberg: delete+insert failed on table %s: %w", opts.TargetTable, err)
 	}
-	if err := reader.Err(); err != nil {
-		return fmt.Errorf("iceberg: delete+insert failed on table %s: %w", opts.TargetTable, err)
-	}
-	if _, err := txn.Commit(ctx); err != nil {
-		return fmt.Errorf("iceberg: failed to commit delete+insert on table %s: %w", opts.TargetTable, err)
-	}
+	d.afterSuccessfulCommit(ctx, opts.TargetTable)
 	return nil
 }
 
@@ -282,116 +337,131 @@ func (d *Destination) SCD2Table(ctx context.Context, opts destination.SCD2Option
 	// key is (primary keys, _scd_is_current): historical rows keep their
 	// older sequence numbers untouched.
 	deleteKeyColumns := append(append([]string{}, opts.PrimaryKeys...), destination.SCD2IsCurrentColumn)
-	if useRowDeltaMerge(target, deleteKeyColumns) {
+	rowDelta, err := useRowDeltaMerge(ctx, target, deleteKeyColumns)
+	if err != nil {
+		return err
+	}
+	if rowDelta && target.Metadata().Version() < 3 {
 		return d.scd2RowDelta(ctx, target, staging, opts, deleteKeyColumns)
 	}
 	return d.scd2CopyOnWrite(ctx, target, staging, opts)
 }
 
 func (d *Destination) scd2CopyOnWrite(ctx context.Context, target, staging *icebergtable.Table, opts destination.SCD2Options) error {
-	stagingRows, err := scanTableRows(ctx, staging, iceberggo.AlwaysTrue{})
+	current := target
+	var writeErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		writeErr = d.scd2CopyOnWriteOnce(ctx, current, staging, opts)
+		if writeErr == nil {
+			return nil
+		}
+		if !errors.Is(writeErr, icebergtable.ErrCommitFailed) {
+			return writeErr
+		}
+		next, err := d.loadIcebergTable(ctx, opts.TargetTable)
+		if err != nil {
+			return errors.Join(writeErr, err)
+		}
+		current = next
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("iceberg: scd2 failed on table %s after retries: %w", opts.TargetTable, writeErr)
+}
+
+func (d *Destination) scd2CopyOnWriteOnce(ctx context.Context, target, staging *icebergtable.Table, opts destination.SCD2Options) error {
+	stagingSchema, err := tableWriteSchema(staging)
 	if err != nil {
 		return err
 	}
-	required := append([]string{}, opts.PrimaryKeys...)
-	required = append(required, destination.SCD2ValidFromColumn)
-	if err := requireColumns(stagingRows, required, opts.StagingTable); err != nil {
+	stagingCols := arrowSchemaColumnNames(stagingSchema)
+	preserveLineage := target.Metadata().Version() >= 3
+	writeSchema, err := copyOnWriteTargetSchema(target, preserveLineage)
+	if err != nil {
 		return err
 	}
-
-	isCurrentField, ok := target.Schema().FindFieldByName(destination.SCD2IsCurrentColumn)
-	if !ok {
+	targetCols := arrowSchemaColumnNames(writeSchema)
+	stagingSorter, err := newSpillSorter(stagingSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer stagingSorter.Close()
+	if err := forEachScannedRow(ctx, staging, iceberggo.AlwaysTrue{}, func(row []any) error { return stagingSorter.AddContext(ctx, row) }); err != nil {
+		return err
+	}
+	currentSorter, err := newSpillSorter(writeSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer currentSorter.Close()
+	outputSorter, err := newSpillSorter(writeSchema, opts.PrimaryKeys)
+	if err != nil {
+		return err
+	}
+	defer outputSorter.Close()
+	isCurrentIdx := -1
+	for i, name := range targetCols {
+		if name == destination.SCD2IsCurrentColumn {
+			isCurrentIdx = i
+		}
+	}
+	if isCurrentIdx < 0 {
 		return fmt.Errorf("iceberg: column %q not found in table %s", destination.SCD2IsCurrentColumn, opts.TargetTable)
 	}
-	currentFilter, err := equalityPredicate(isCurrentField, true)
+	if err := forEachSCD2CurrentRow(ctx, target, iceberggo.AlwaysTrue{}, preserveLineage, func(row []any) error {
+		if current, _ := row[isCurrentIdx].(bool); current {
+			return currentSorter.AddContext(ctx, row)
+		}
+		return outputSorter.AddContext(ctx, row)
+	}); err != nil {
+		return err
+	}
+	join, err := newSCD2Join(opts, stagingCols, targetCols)
 	if err != nil {
 		return err
 	}
-	targetRows, err := scanTableRows(ctx, target, currentFilter)
+	stagingProjection := newRowProjection(writeSchema, stagingCols)
+	targetProjection := newRowProjection(writeSchema, targetCols)
+	if err := join.run(ctx, stagingSorter, currentSorter, scd2Emitters{
+		newRow:       func(row []any) error { return outputSorter.AddContext(ctx, stagingProjection.projectRow(row)) },
+		closedRow:    func(row []any) error { return outputSorter.AddContext(ctx, targetProjection.projectRow(row)) },
+		unchangedRow: func(row []any) error { return outputSorter.AddContext(ctx, targetProjection.projectRow(row)) },
+	}); err != nil {
+		return err
+	}
+	identity := newRowProjection(writeSchema, targetCols)
+	reader := streamingReaderContext(ctx, writeSchema, func(sink func(arrow.RecordBatch) error) error {
+		emitter := newBatchEmitter(identity, sink)
+		defer emitter.release()
+		it, err := outputSorter.IterContext(ctx)
+		if err != nil {
+			return err
+		}
+		defer it.Close()
+		for it.NextGroup() {
+			for it.NextRow() {
+				if err := emitter.add(it.Row()); err != nil {
+					return err
+				}
+			}
+		}
+		if err := it.Err(); err != nil {
+			return err
+		}
+		return emitter.flushBatch()
+	})
+	defer reader.Release()
+	clusterBy, sortable := identitySortColumns(target)
+	if !sortable {
+		clusterBy = nil
+	}
+	clustered, cleanup, err := clusterRecordReader(ctx, reader, clusterBy)
 	if err != nil {
 		return err
 	}
-	currentByKey, err := indexRowsByKey(targetRows, opts.PrimaryKeys)
-	if err != nil {
-		return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
-	}
-
-	deduped, err := dedupeStagingRows(stagingRows, opts.PrimaryKeys, opts.IncrementalKey, opts.StagingTable, true)
-	if err != nil {
-		return err
-	}
-
-	changeCols := scd2ChangeColumns(opts, stagingRows, targetRows)
-	validToIdx, hasValidTo := targetRows.ColIdx[destination.SCD2ValidToColumn]
-	isCurrentIdx := targetRows.ColIdx[destination.SCD2IsCurrentColumn]
-	if !hasValidTo {
-		return fmt.Errorf("iceberg: column %q not found in table %s", destination.SCD2ValidToColumn, opts.TargetTable)
-	}
-
-	var outRows [][]any
-	var affectedKeys [][]any
-	for _, key := range deduped.keys {
-		entry := deduped.entries[key]
-		current := currentByKey[key]
-		if len(current) == 0 {
-			outRows = append(outRows, projectRow(targetRows.Columns, stagingRows, entry.latest, nil))
-			continue
-		}
-
-		if !scd2RowChanged(changeCols, stagingRows, entry.latest, targetRows, current[len(current)-1]) {
-			continue
-		}
-
-		affectedKeys = append(affectedKeys, entry.keyValues)
-		validFrom := stagingRows.Value(entry.latest, destination.SCD2ValidFromColumn)
-		for _, cur := range current {
-			closed := append([]any(nil), cur...)
-			closed[validToIdx] = validFrom
-			closed[isCurrentIdx] = false
-			outRows = append(outRows, closed)
-		}
-		outRows = append(outRows, projectRow(targetRows.Columns, stagingRows, entry.latest, nil))
-	}
-
-	if opts.IncrementalKey == "" {
-		softDeleteAt := opts.Timestamp.UTC().UnixMicro()
-		for _, key := range targetRows.keyOrder(opts.PrimaryKeys) {
-			if _, inStaging := deduped.entries[key]; inStaging {
-				continue
-			}
-			current := currentByKey[key]
-			if len(current) == 0 {
-				continue
-			}
-			keyVals, err := rowKeyValues(targetRows, current[0], opts.PrimaryKeys)
-			if err != nil {
-				return fmt.Errorf("iceberg: target table %s: %w", opts.TargetTable, err)
-			}
-			affectedKeys = append(affectedKeys, keyVals)
-			for _, cur := range current {
-				closed := append([]any(nil), cur...)
-				closed[validToIdx] = softDeleteAt
-				closed[isCurrentIdx] = false
-				outRows = append(outRows, closed)
-			}
-		}
-	}
-
-	if len(outRows) == 0 {
-		return nil
-	}
-
-	config.Debug("[ICEBERG SCD2] Closing %d key(s), writing %d row(s) to %s", len(affectedKeys), len(outRows), opts.TargetTable)
-	if len(affectedKeys) == 0 {
-		return d.appendRows(ctx, target, outRows, "scd2")
-	}
-
-	keyFilter, err := keyMatchFilter(target.Schema(), opts.PrimaryKeys, affectedKeys)
-	if err != nil {
-		return err
-	}
-	filter := iceberggo.NewAnd(currentFilter, keyFilter)
-	return d.overwriteRows(ctx, target, outRows, filter, "scd2")
+	defer cleanup()
+	return d.replaceAllMergeRecords(ctx, target, clustered, clusterBy, destination.MergeOptions{TargetTable: opts.TargetTable, PrimaryKeys: opts.PrimaryKeys}, commitMetadata{})
 }
 
 // TruncateTable empties the table in place, keeping schema, partition spec and
@@ -404,16 +474,22 @@ func (d *Destination) TruncateTable(ctx context.Context, table string) error {
 	if err != nil {
 		return err
 	}
-	if tbl.CurrentSnapshot() == nil {
-		return nil
-	}
 	txn := tbl.NewTransaction()
-	if err := txn.Delete(ctx, iceberggo.AlwaysTrue{}, snapshotProps("truncate")); err != nil {
-		return fmt.Errorf("iceberg: failed to truncate table %s: %w", table, err)
+	if err := stageResetCommitTokenLedger(txn, ""); err != nil {
+		return err
+	}
+	if err := stageCDCResumeState(txn, snapshotProps("truncate")); err != nil {
+		return err
+	}
+	if tbl.CurrentSnapshot() != nil {
+		if err := txn.Delete(ctx, iceberggo.AlwaysTrue{}, snapshotProps("truncate")); err != nil {
+			return fmt.Errorf("iceberg: failed to truncate table %s: %w", table, err)
+		}
 	}
 	if _, err := txn.Commit(ctx); err != nil {
 		return fmt.Errorf("iceberg: failed to commit truncate of table %s: %w", table, err)
 	}
+	d.afterSuccessfulCommit(ctx, table)
 	return nil
 }
 
@@ -426,70 +502,10 @@ func (d *Destination) loadIcebergTable(ctx context.Context, table string) (*iceb
 	if err != nil {
 		return nil, fmt.Errorf("iceberg: failed to load table %s: %w", table, err)
 	}
+	if err := validateIsolatedTableFilePaths(tbl.Properties()); err != nil {
+		return nil, fmt.Errorf("iceberg: table %s: %w", table, err)
+	}
 	return tbl, nil
-}
-
-func snapshotProps(operation string) iceberggo.Properties {
-	return iceberggo.Properties{
-		"ingestr.destination": "iceberg",
-		"ingestr.operation":   operation,
-	}
-}
-
-// overwriteRows atomically deletes the rows matching filter and appends rows
-// in a single snapshot commit.
-func (d *Destination) overwriteRows(ctx context.Context, tbl *icebergtable.Table, rows [][]any, filter iceberggo.BooleanExpression, operation string) error {
-	writeSchema, err := tableWriteSchema(tbl)
-	if err != nil {
-		return err
-	}
-	batches, err := buildRecordBatches(writeSchema, rows)
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(batches)
-
-	rdr, err := array.NewRecordReader(writeSchema, batches)
-	if err != nil {
-		return fmt.Errorf("iceberg: failed to create record reader: %w", err)
-	}
-	defer rdr.Release()
-
-	txn := tbl.NewTransaction()
-	if err := txn.Overwrite(ctx, rdr, snapshotProps(operation), icebergtable.WithOverwriteFilter(filter)); err != nil {
-		return fmt.Errorf("iceberg: %s failed on table %s: %w", operation, tbl.Identifier(), err)
-	}
-	if _, err := txn.Commit(ctx); err != nil {
-		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
-	}
-	return nil
-}
-
-func (d *Destination) appendRows(ctx context.Context, tbl *icebergtable.Table, rows [][]any, operation string) error {
-	writeSchema, err := tableWriteSchema(tbl)
-	if err != nil {
-		return err
-	}
-	batches, err := buildRecordBatches(writeSchema, rows)
-	if err != nil {
-		return err
-	}
-	defer releaseBatches(batches)
-
-	rdr, err := array.NewRecordReader(writeSchema, batches)
-	if err != nil {
-		return fmt.Errorf("iceberg: failed to create record reader: %w", err)
-	}
-	defer rdr.Release()
-
-	txn := tbl.NewTransaction()
-	if err := txn.Append(ctx, rdr, snapshotProps(operation)); err != nil {
-		return fmt.Errorf("iceberg: %s failed on table %s: %w", operation, tbl.Identifier(), err)
-	}
-	if _, err := txn.Commit(ctx); err != nil {
-		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
-	}
-	return nil
 }
 
 func tableWriteSchema(tbl *icebergtable.Table) (*arrow.Schema, error) {
@@ -521,136 +537,6 @@ func incrementalKeyIndex(columns []string, incrementalKey, stagingTable string) 
 	return -1, fmt.Errorf("iceberg: incremental key column %q not found in staging table %s", incrementalKey, stagingTable)
 }
 
-// dedupeStagingRows keeps a single winning row per primary key. For CDC data
-// the latest change by LSN wins (with the latest non-delete tracked
-// separately); otherwise the highest incremental key value wins, with arrival
-// order breaking ties.
-func dedupeStagingRows(staging *scannedTable, primaryKeys []string, incrementalKey, stagingTable string, requireIncrementalKey bool) (*dedupedStaging, error) {
-	out := &dedupedStaging{
-		entries: make(map[string]*mergeEntry),
-		isCDC:   staging.HasColumn(destination.CDCDeletedColumn),
-	}
-
-	incrementalIdx := -1
-	if !out.isCDC && incrementalKey != "" {
-		idx, err := incrementalKeyIndex(staging.Columns, incrementalKey, stagingTable)
-		if err != nil {
-			if requireIncrementalKey {
-				return nil, err
-			}
-		} else {
-			incrementalIdx = idx
-		}
-	}
-
-	for _, row := range staging.Rows {
-		keyValues, err := rowKeyValues(staging, row, primaryKeys)
-		if err != nil {
-			return nil, fmt.Errorf("iceberg: staging data: %w", err)
-		}
-		key, err := encodeRowKey(keyValues)
-		if err != nil {
-			return nil, fmt.Errorf("iceberg: staging data: %w", err)
-		}
-
-		entry, ok := out.entries[key]
-		if !ok {
-			entry = &mergeEntry{keyValues: keyValues}
-			out.entries[key] = entry
-			out.keys = append(out.keys, key)
-		}
-
-		switch {
-		case out.isCDC:
-			lsn, _ := asString(staging.Value(row, destination.CDCLSNColumn))
-			deleted, _ := staging.Value(row, destination.CDCDeletedColumn).(bool)
-			if entry.latest == nil || destination.CDCSupersedes(lsn, deleted, entry.latestLSN, entry.latestDeleted) {
-				entry.latest = row
-				entry.latestLSN = lsn
-				entry.latestDeleted = deleted
-			}
-			if !deleted && (entry.latestNonDeleted == nil || lsn >= entry.latestNonDeletedLSN) {
-				entry.latestNonDeleted = row
-				entry.latestNonDeletedLSN = lsn
-			}
-		case incrementalIdx >= 0:
-			if entry.latest == nil {
-				entry.latest = row
-				entry.incrementalVal = row[incrementalIdx]
-				continue
-			}
-			cmp, comparable := compareOrdered(row[incrementalIdx], entry.incrementalVal)
-			if !comparable || cmp >= 0 {
-				entry.latest = row
-				entry.incrementalVal = row[incrementalIdx]
-			}
-		default:
-			entry.latest = row
-		}
-	}
-	return out, nil
-}
-
-func rowKeyValues(rows *scannedTable, row []any, primaryKeys []string) ([]any, error) {
-	values := make([]any, len(primaryKeys))
-	for i, pk := range primaryKeys {
-		idx, ok := rows.ColIdx[pk]
-		if !ok {
-			return nil, fmt.Errorf("primary key column %q not found", pk)
-		}
-		if row[idx] == nil {
-			return nil, fmt.Errorf("primary key column %q contains NULL", pk)
-		}
-		values[i] = row[idx]
-	}
-	return values, nil
-}
-
-func indexRowsByKey(rows *scannedTable, primaryKeys []string) (map[string][][]any, error) {
-	out := make(map[string][][]any, len(rows.Rows))
-	for _, row := range rows.Rows {
-		values, err := rowKeyValues(rows, row, primaryKeys)
-		if err != nil {
-			return nil, err
-		}
-		key, err := encodeRowKey(values)
-		if err != nil {
-			return nil, err
-		}
-		out[key] = append(out[key], row)
-	}
-	return out, nil
-}
-
-// keyOrder returns encoded keys in first-encounter row order.
-func (s *scannedTable) keyOrder(primaryKeys []string) []string {
-	seen := make(map[string]struct{}, len(s.Rows))
-	keys := make([]string, 0, len(s.Rows))
-	for _, row := range s.Rows {
-		values, err := rowKeyValues(s, row, primaryKeys)
-		if err != nil {
-			continue
-		}
-		key, err := encodeRowKey(values)
-		if err != nil {
-			continue
-		}
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		keys = append(keys, key)
-	}
-	return keys
-}
-
-func lastRow(rows [][]any) []any {
-	if len(rows) == 0 {
-		return nil
-	}
-	return rows[len(rows)-1]
-}
-
 // projectRow maps a staging row onto the target column layout. Columns missing
 // from staging keep the existing row's value (or NULL for new rows), mirroring
 // the SQL merge behavior where destination-only columns are left untouched.
@@ -671,6 +557,19 @@ func projectRow(targetCols []string, staging *scannedTable, stagingRow []any, ex
 // materialize the latest change overall (including tombstones), and keys whose
 // latest change is a delete keep their data with _cdc_deleted marked true.
 func composeCDCMergeRow(targetCols []string, staging *scannedTable, entry *mergeEntry, existing []any) ([]any, error) {
+	if existing != nil {
+		var existingLSN string
+		for i, col := range targetCols {
+			if strings.EqualFold(col, destination.CDCLSNColumn) {
+				existingLSN, _ = asString(existing[i])
+				break
+			}
+		}
+		if destination.CompareCDCPositions(entry.latestLSN, existingLSN) < 0 {
+			return append([]any(nil), existing...), nil
+		}
+	}
+
 	src := entry.latestNonDeleted
 	if existing == nil && src == nil {
 		src = entry.latest
@@ -684,6 +583,9 @@ func composeCDCMergeRow(targetCols []string, staging *scannedTable, entry *merge
 	out := make([]any, len(targetCols))
 	for i, col := range targetCols {
 		stagingIdx, inStaging := staging.ColIdx[col]
+		if !inStaging && destination.IsCDCMetaColumn(col) {
+			stagingIdx, inStaging = staging.foldedColumnIndex(col)
+		}
 		switch {
 		case !inStaging:
 			if existing != nil {
@@ -692,7 +594,7 @@ func composeCDCMergeRow(targetCols []string, staging *scannedTable, entry *merge
 		case src == nil:
 			// Existing row whose only new changes are deletes: keep the data.
 			out[i] = existing[i]
-		case existing != nil && unchanged[col] && !destination.IsCDCMetaColumn(col):
+		case existing != nil && unchanged[strings.ToLower(col)] && !destination.IsCDCMetaColumn(col):
 			out[i] = existing[i]
 		default:
 			out[i] = src[stagingIdx]
@@ -701,17 +603,17 @@ func composeCDCMergeRow(targetCols []string, staging *scannedTable, entry *merge
 
 	if entry.latestDeleted {
 		setColumn(targetCols, out, destination.CDCDeletedColumn, true)
-		setColumn(targetCols, out, destination.CDCLSNColumn, staging.Value(entry.latest, destination.CDCLSNColumn))
-		setColumn(targetCols, out, destination.CDCSyncedAtColumn, staging.Value(entry.latest, destination.CDCSyncedAtColumn))
+		setColumn(targetCols, out, destination.CDCLSNColumn, staging.ValueFold(entry.latest, destination.CDCLSNColumn))
+		setColumn(targetCols, out, destination.CDCSyncedAtColumn, staging.ValueFold(entry.latest, destination.CDCSyncedAtColumn))
 	}
 	return out, nil
 }
 
 func cdcUnchangedColumns(staging *scannedTable, src []any, hasExisting bool) (map[string]bool, error) {
-	if src == nil || !hasExisting || !staging.HasColumn(destination.CDCUnchangedColsColumn) {
+	if src == nil || !hasExisting {
 		return nil, nil
 	}
-	raw, ok := asString(staging.Value(src, destination.CDCUnchangedColsColumn))
+	raw, ok := asString(staging.ValueFold(src, destination.CDCUnchangedColsColumn))
 	if !ok || raw == "" {
 		return nil, nil
 	}
@@ -721,43 +623,16 @@ func cdcUnchangedColumns(staging *scannedTable, src []any, hasExisting bool) (ma
 	}
 	out := make(map[string]bool, len(cols))
 	for _, col := range cols {
-		out[col] = true
+		out[strings.ToLower(col)] = true
 	}
 	return out, nil
 }
 
 func setColumn(cols []string, row []any, name string, value any) {
 	for i, col := range cols {
-		if col == name {
+		if strings.EqualFold(col, name) {
 			row[i] = value
 			return
 		}
 	}
-}
-
-func scd2ChangeColumns(opts destination.SCD2Options, staging, target *scannedTable) []string {
-	excluded := make(map[string]bool)
-	for _, col := range destination.SCD2NonDataColumns(opts.PrimaryKeys) {
-		excluded[strings.ToLower(col)] = true
-	}
-	out := make([]string, 0, len(opts.Columns))
-	for _, col := range opts.Columns {
-		if excluded[strings.ToLower(col)] {
-			continue
-		}
-		if !staging.HasColumn(col) || !target.HasColumn(col) {
-			continue
-		}
-		out = append(out, col)
-	}
-	return out
-}
-
-func scd2RowChanged(changeCols []string, staging *scannedTable, stagingRow []any, target *scannedTable, targetRow []any) bool {
-	for _, col := range changeCols {
-		if !valuesEqual(staging.Value(stagingRow, col), target.Value(targetRow, col)) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/destination/iceberg/stream.go
+++ b/pkg/destination/iceberg/stream.go
@@ -105,6 +105,45 @@ func (p *rowProjection) appendRow(builder *array.RecordBuilder, row []any) error
 	return nil
 }
 
+func (p *rowProjection) projectRow(row []any) []any {
+	projected := make([]any, len(p.sourceIdx))
+	for i, sourceIdx := range p.sourceIdx {
+		if sourceIdx >= 0 {
+			projected[i] = row[sourceIdx]
+		}
+	}
+	return projected
+}
+
+func projectRecordReader(input array.RecordReader, target *arrow.Schema) (array.RecordReader, func()) {
+	projection := newRowProjection(target, arrowSchemaColumnNames(input.Schema()))
+	reader := streamingReader(target, func(sink func(arrow.RecordBatch) error) error {
+		emitter := newBatchEmitter(projection, sink)
+		defer emitter.release()
+		for input.Next() {
+			batch := input.RecordBatch()
+			for row := 0; row < int(batch.NumRows()); row++ {
+				values := make([]any, int(batch.NumCols()))
+				for column := range values {
+					value, err := rowValue(batch.Column(column), row)
+					if err != nil {
+						return err
+					}
+					values[column] = value
+				}
+				if err := emitter.add(values); err != nil {
+					return err
+				}
+			}
+		}
+		if err := input.Err(); err != nil {
+			return err
+		}
+		return emitter.flushBatch()
+	})
+	return reader, reader.Release
+}
+
 // batchEmitter accumulates projected rows and emits record batches of bounded
 // size through the sink. Callers must call flush at the end.
 type batchEmitter struct {
@@ -214,6 +253,10 @@ func (r *chanRecordReader) Err() error {
 // returned RecordReader. produce must send batches to the sink it is given
 // and return; the reader's Err() reflects the producer error once drained.
 func streamingReader(schema *arrow.Schema, produce func(sink func(arrow.RecordBatch) error) error) *chanRecordReader {
+	return streamingReaderContext(context.Background(), schema, produce)
+}
+
+func streamingReaderContext(ctx context.Context, schema *arrow.Schema, produce func(sink func(arrow.RecordBatch) error) error) *chanRecordReader {
 	batches := make(chan arrow.RecordBatch, 2)
 	var produceErr error
 	reader := newChanRecordReader(schema, batches, &produceErr)
@@ -221,8 +264,13 @@ func streamingReader(schema *arrow.Schema, produce func(sink func(arrow.RecordBa
 	go func() {
 		defer close(batches)
 		produceErr = produce(func(batch arrow.RecordBatch) error {
-			batches <- batch
-			return nil
+			select {
+			case batches <- batch:
+				return nil
+			case <-ctx.Done():
+				batch.Release()
+				return ctx.Err()
+			}
 		})
 	}()
 	return reader

--- a/pkg/destination/iceberg/truncate_insert.go
+++ b/pkg/destination/iceberg/truncate_insert.go
@@ -1,0 +1,214 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func (d *Destination) TruncateInsertRecords(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	input := newRecordBatchInput(records)
+	defer input.Close()
+
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+	tbl, err := d.loadIcebergTable(ctx, opts.Table)
+	if err != nil {
+		return err
+	}
+	if err := d.validateExpectedIncarnation(ctx, tbl, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	var baseSnapshotID int64
+	if snapshot := tbl.CurrentSnapshot(); snapshot != nil {
+		baseSnapshotID = snapshot.SnapshotID
+	}
+	metadata := newCommitMetadata(opts.CommitToken, opts.CDCResumeLSN).withExpectedIncarnation(opts.CDCExpectedIncarnation)
+	if opts.SkipCDCResume {
+		metadata.cdcResumeLSN = ""
+		metadata.resetCDCResume = true
+	}
+	callerToken := metadata.token != ""
+	if metadata.token != "" {
+		if tableHasCommitToken(tbl, metadata.token) {
+			if err := input.Drain(ctx); err != nil {
+				return fmt.Errorf("iceberg: failed to drain already-committed truncate+insert for table %s: %w", opts.Table, err)
+			}
+			if opts.SkipCDCResume {
+				return d.ensureManagedCDCResumeResetExpected(ctx, tbl, metadata.token, opts.CDCExpectedIncarnation)
+			}
+			return nil
+		}
+		if err := validateCDCResumeAdvance(tbl, metadata); err != nil {
+			return err
+		}
+	}
+	if opts.Schema == nil {
+		return errors.New("iceberg destination requires schema for truncate+insert")
+	}
+	if err := validateIcebergTableSchema(opts.Schema); err != nil {
+		return err
+	}
+	desiredSchema := destination.DestinationTableSchema(opts.Schema)
+	if err := validateIcebergTableSchema(desiredSchema); err != nil {
+		return err
+	}
+	if opts.DeduplicatePrimaryKeys && len(opts.PrimaryKeys) == 0 {
+		return errors.New("iceberg: truncate+insert primary-key deduplication requires at least one primary key")
+	}
+
+	clusterBy, physicallySortable := identitySortColumns(tbl)
+	if !physicallySortable {
+		clusterBy = nil
+	}
+	inputIcebergSchema, err := icebergSchemaFromTableSchema(opts.Schema)
+	if err != nil {
+		return err
+	}
+	arrowSchema := icebergWriteArrowSchema(opts.Schema, inputIcebergSchema)
+	batchReader := input.RecordReader(ctx, arrowSchema)
+	var reader array.RecordReader = batchReader
+	var cleanupTransforms []func()
+	defer func() {
+		for i := len(cleanupTransforms) - 1; i >= 0; i-- {
+			cleanupTransforms[i]()
+		}
+	}()
+	if opts.DeduplicatePrimaryKeys && len(opts.PrimaryKeys) > 0 {
+		reader, cleanupTransforms, err = addAtomicTruncateDedup(reader, cleanupTransforms, opts)
+		if err != nil {
+			return fmt.Errorf(
+				"iceberg: failed to deduplicate truncate+insert for table %s: %w",
+				opts.Table,
+				err,
+			)
+		}
+	}
+	desiredIcebergSchema, err := icebergSchemaFromTableSchema(desiredSchema)
+	if err != nil {
+		return err
+	}
+	targetArrowSchema := icebergWriteArrowSchema(desiredSchema, desiredIcebergSchema)
+	if !reader.Schema().Equal(targetArrowSchema) {
+		projected, cleanup := projectRecordReader(reader, targetArrowSchema)
+		reader = projected
+		cleanupTransforms = append(cleanupTransforms, cleanup)
+	}
+	if len(clusterBy) > 0 {
+		clustered, cleanup, clusterErr := clusterRecordReader(ctx, reader, clusterBy)
+		if clusterErr != nil {
+			return fmt.Errorf(
+				"iceberg: failed to cluster truncate+insert for table %s: %w",
+				opts.Table,
+				clusterErr,
+			)
+		}
+		reader = clustered
+		cleanupTransforms = append(cleanupTransforms, cleanup)
+	}
+
+	if metadata.token == "" {
+		spooled, cleanup, contentID, spoolErr := spoolAppendRecordReader(reader)
+		if spoolErr != nil {
+			return fmt.Errorf(
+				"iceberg: failed to prepare idempotent truncate+insert for table %s: %w",
+				opts.Table,
+				spoolErr,
+			)
+		}
+		reader = spooled
+		cleanupTransforms = append(cleanupTransforms, cleanup)
+		metadata = newCommitMetadata("truncate+insert-content:"+contentID, "")
+	}
+	if err := d.validateExpectedIncarnation(ctx, tbl, opts.CDCExpectedIncarnation); err != nil {
+		return err
+	}
+	if (callerToken && tableHasCommitToken(tbl, metadata.token)) ||
+		(!callerToken && currentSnapshotHasCommitToken(tbl, metadata.token)) {
+		if opts.SkipCDCResume {
+			return d.ensureManagedCDCResumeResetExpected(ctx, tbl, metadata.token, opts.CDCExpectedIncarnation)
+		}
+		return nil
+	}
+	if err := validateCDCResumeAdvance(tbl, metadata); err != nil {
+		return err
+	}
+
+	props := snapshotProps("truncate+insert", metadata)
+	prepared := preparedTable{
+		replace:          true,
+		preserveMetadata: true,
+		evolveSchema:     true,
+		schema:           desiredSchema,
+		clusterBy:        clusterBy,
+	}
+	openReplay, cleanupReplay, err := spoolReplayableRecordReader(reader)
+	if err != nil {
+		return err
+	}
+	defer cleanupReplay()
+	current := tbl
+	var committed *icebergtable.Table
+	var writeErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		replay, release, replayErr := openReplay()
+		if replayErr != nil {
+			return replayErr
+		}
+		committed, writeErr = d.overwritePrepared(ctx, current, replay, props, prepared, opts.Parallelism, nil, true, opts.CDCExpectedIncarnation)
+		release()
+		if writeErr == nil {
+			break
+		}
+		if !errors.Is(writeErr, icebergtable.ErrCommitFailed) {
+			if reconciled := d.reconcileCommitAfterSnapshot(ctx, opts.Table, metadata.token, baseSnapshotID, opts.CDCExpectedIncarnation, writeErr); reconciled != nil {
+				return fmt.Errorf("iceberg: failed to atomically truncate and insert table %s: %w", opts.Table, reconciled)
+			}
+			writeErr = nil
+			break
+		}
+		current, err = d.loadIcebergTable(ctx, opts.Table)
+		if err != nil {
+			return err
+		}
+		if err := d.validateExpectedIncarnation(ctx, current, opts.CDCExpectedIncarnation); err != nil {
+			return err
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	if committed == nil && writeErr != nil {
+		return fmt.Errorf("iceberg: failed to atomically truncate and insert table %s after retries: %w", opts.Table, writeErr)
+	}
+	d.afterSuccessfulCommitExpected(ctx, opts.Table, opts.CDCExpectedIncarnation)
+	return nil
+}
+
+func addAtomicTruncateDedup(
+	reader array.RecordReader,
+	cleanups []func(),
+	opts destination.WriteOptions,
+) (array.RecordReader, []func(), error) {
+	deduped, cleanup, err := deduplicateRecordReader(reader, opts.PrimaryKeys, opts.IncrementalKey)
+	if err != nil {
+		return reader, cleanups, err
+	}
+	return deduped, append(cleanups, cleanup), nil
+}
+
+var _ destination.AtomicTruncateInsertWriter = (*Destination)(nil)
+
+func (d *Destination) EvolvesTruncateInsertSchemaAtomically() bool { return true }
+
+var _ destination.AtomicTruncateInsertSchemaEvolver = (*Destination)(nil)

--- a/pkg/destination/iceberg/validation.go
+++ b/pkg/destination/iceberg/validation.go
@@ -1,0 +1,108 @@
+package iceberg
+
+import (
+	"fmt"
+	"strings"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+var reservedIcebergMetadataColumns = map[string]struct{}{
+	"_file":                         {},
+	"_pos":                          {},
+	"_deleted":                      {},
+	"_spec_id":                      {},
+	"_partition":                    {},
+	"_row_id":                       {},
+	"_last_updated_sequence_number": {},
+}
+
+func validateIsolatedTableFilePaths(props iceberggo.Properties) error {
+	for _, key := range []string{icebergtable.WriteDataPathKey, icebergtable.WriteMetadataPathKey} {
+		if _, configured := props[key]; configured {
+			return fmt.Errorf("table property %q is unsafe because files outside the table root cannot be isolated for orphan cleanup or purged reliably", key)
+		}
+	}
+	return nil
+}
+
+func validateIcebergTableSchema(tableSchema *schema.TableSchema) error {
+	if tableSchema == nil {
+		return fmt.Errorf("iceberg: schema is required")
+	}
+
+	seen := make(map[string]string, len(tableSchema.Columns))
+	for _, col := range tableSchema.Columns {
+		if err := validateIcebergColumnName(col.Name); err != nil {
+			return err
+		}
+		normalized := strings.ToLower(col.Name)
+		if previous, ok := seen[normalized]; ok {
+			return fmt.Errorf("iceberg: columns %q and %q differ only by case; use unique names for cross-engine compatibility", previous, col.Name)
+		}
+		seen[normalized] = col.Name
+		if err := validateIcebergNestedColumn(col, col.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateIcebergNestedColumn(col schema.Column, path string) error {
+	switch col.DataType {
+	case schema.TypeFixedBinary:
+		if col.FixedLength <= 0 {
+			return fmt.Errorf("iceberg: fixed binary column %q requires a positive length", path)
+		}
+	case schema.TypeArray:
+		if col.ArrayLength > 0 {
+			return fmt.Errorf("iceberg: fixed-size list column %q with length %d is unsupported because Iceberg list types do not preserve cardinality", path, col.ArrayLength)
+		}
+		if col.Element != nil {
+			return validateIcebergNestedColumn(*col.Element, path+".element")
+		}
+	case schema.TypeStruct:
+		if col.StructFields == nil || len(col.StructFields.Columns) == 0 {
+			return fmt.Errorf("iceberg: struct column %q requires at least one field", path)
+		}
+		seen := make(map[string]struct{}, len(col.StructFields.Columns))
+		for _, field := range col.StructFields.Columns {
+			if err := validateIcebergColumnName(field.Name); err != nil {
+				return err
+			}
+			name := strings.ToLower(field.Name)
+			if _, ok := seen[name]; ok {
+				return fmt.Errorf("iceberg: duplicate nested field %q", path+"."+field.Name)
+			}
+			seen[name] = struct{}{}
+			if err := validateIcebergNestedColumn(field, path+"."+field.Name); err != nil {
+				return err
+			}
+		}
+	case schema.TypeMap:
+		if col.MapKey == nil || col.MapValue == nil {
+			return fmt.Errorf("iceberg: map column %q requires key and value types", path)
+		}
+		if col.MapKey.Nullable {
+			return fmt.Errorf("iceberg: map key %q cannot be nullable", path)
+		}
+		if err := validateIcebergNestedColumn(*col.MapKey, path+".key"); err != nil {
+			return err
+		}
+		return validateIcebergNestedColumn(*col.MapValue, path+".value")
+	}
+	return nil
+}
+
+func validateIcebergColumnName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("iceberg: column name is required")
+	}
+	normalized := strings.ToLower(name)
+	if _, reserved := reservedIcebergMetadataColumns[normalized]; reserved {
+		return fmt.Errorf("iceberg: column %q conflicts with reserved metadata column %q; rename it at the source because automatic remapping would not be reversible", name, normalized)
+	}
+	return nil
+}

--- a/pkg/destination/iceberg/writer.go
+++ b/pkg/destination/iceberg/writer.go
@@ -1,0 +1,260 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+)
+
+func (d *Destination) appendRecordBatches(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	reader array.RecordReader,
+	props iceberggo.Properties,
+	parallelism int,
+	expectedIncarnation string,
+) (retErr error) {
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return err
+	}
+	writeID := uuid.New()
+	generatedPaths := make([]string, 0)
+	committed, cleanupSafe := false, true
+	defer func() {
+		if committed || !cleanupSafe {
+			return
+		}
+		if err := removeGeneratedMergeFiles(tableFS, tbl.Location(), writeID.String(), generatedPaths); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+
+	writeOpts := make([]icebergtable.WriteRecordOption, 0, 2)
+	writeOpts = append(writeOpts, icebergtable.WithWriteUUID(writeID))
+	if parallelism > 0 {
+		writeOpts = append(writeOpts, icebergtable.WithMaxWriteWorkers(parallelism))
+	}
+
+	files := make([]iceberggo.DataFile, 0)
+	for dataFile, err := range icebergtable.WriteRecords(ctx, tbl, reader.Schema(), retainedRecordIterator(reader), writeOpts...) {
+		if err != nil {
+			return err
+		}
+		files = append(files, dataFile)
+		generatedPaths = append(generatedPaths, dataFile.FilePath())
+	}
+	if err := reader.Err(); err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		empty, err := array.NewRecordReader(reader.Schema(), nil)
+		if err != nil {
+			return err
+		}
+		defer empty.Release()
+		if props[snapshotCommitTokenKey] == "" {
+			if err := d.validateExpectedIncarnation(ctx, tbl, expectedIncarnation); err != nil {
+				return err
+			}
+			_, err = tbl.Append(ctx, empty, props)
+			return err
+		}
+		_, err = d.commitTokenizedAppend(ctx, tbl, props, expectedIncarnation, func(txn *icebergtable.Transaction) error {
+			return txn.Append(ctx, empty, props)
+		})
+		return err
+	}
+
+	cleanupSafe, err = d.commitAppendDataFiles(ctx, tbl, files, props, expectedIncarnation)
+	committed = err == nil && !cleanupSafe
+	return err
+}
+
+func (d *Destination) commitAppendDataFiles(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	files []iceberggo.DataFile,
+	props iceberggo.Properties,
+	expectedIncarnation string,
+) (cleanupSafe bool, retErr error) {
+	const maxAttempts = 5
+	token := props[snapshotCommitTokenKey]
+	current := tbl
+	var commitErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if token != "" && tableHasCommitToken(current, token) {
+			if err := d.validateExpectedIncarnation(ctx, current, expectedIncarnation); err != nil {
+				return true, err
+			}
+			return true, nil
+		}
+		if err := validateCDCResumeAdvance(current, commitMetadata{
+			token: token, cdcResumeLSN: props[snapshotCDCResumeLSNKey],
+		}); err != nil {
+			return true, err
+		}
+
+		attemptFiles := files
+		if current.Metadata().Version() >= 3 {
+			attemptFiles = make([]iceberggo.DataFile, len(files))
+			nextRowID := current.Metadata().NextRowID()
+			for i, file := range files {
+				var err error
+				attemptFiles[i], err = withDataFileFirstRowID(file, current, nextRowID)
+				if err != nil {
+					return true, err
+				}
+				nextRowID += file.Count()
+			}
+		}
+
+		txn := current.NewTransaction()
+		if token != "" {
+			if err := stageCommitTokenLedger(txn, current, token); err != nil {
+				return true, err
+			}
+		}
+		if err := stageCDCResumeState(txn, props); err != nil {
+			return true, err
+		}
+		if err := txn.AddDataFiles(ctx, attemptFiles, props, icebergtable.WithoutDuplicateCheck()); err != nil {
+			return true, err
+		}
+		commit, err := txn.TableCommit()
+		if err != nil {
+			return true, err
+		}
+		if err := d.validateExpectedIncarnation(ctx, current, expectedIncarnation); err != nil {
+			return true, err
+		}
+		_, _, commitErr = d.catalog.CommitTable(ctx, commit.Identifier, commit.Requirements, commit.Updates)
+		if commitErr == nil {
+			txn.MarkCommitted()
+			return false, nil
+		}
+		if !errors.Is(commitErr, icebergtable.ErrCommitFailed) {
+			return false, commitErr
+		}
+
+		current, err = d.catalog.LoadTable(ctx, tbl.Identifier())
+		if err != nil {
+			return false, errors.Join(commitErr, err)
+		}
+		if token != "" && tableHasCommitToken(current, token) {
+			if err := d.validateExpectedIncarnation(ctx, current, expectedIncarnation); err != nil {
+				return true, err
+			}
+			return true, nil
+		}
+		if err := waitForCommitRetry(ctx, attempt); err != nil {
+			return true, err
+		}
+	}
+	return true, commitErr
+}
+
+func (d *Destination) commitTokenizedAppend(
+	ctx context.Context,
+	tbl *icebergtable.Table,
+	props iceberggo.Properties,
+	expectedIncarnation string,
+	stage func(*icebergtable.Transaction) error,
+) (cleanupSafe bool, retErr error) {
+	const maxAttempts = 5
+	token := props[snapshotCommitTokenKey]
+	current := tbl
+	var commitErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if tableHasCommitToken(current, token) {
+			if err := d.validateExpectedIncarnation(ctx, current, expectedIncarnation); err != nil {
+				return true, err
+			}
+			return true, nil
+		}
+		if err := validateCDCResumeAdvance(current, commitMetadata{
+			token: token, cdcResumeLSN: props[snapshotCDCResumeLSNKey],
+		}); err != nil {
+			return true, err
+		}
+		txn := current.NewTransaction()
+		if err := stageCommitTokenLedger(txn, current, token); err != nil {
+			return true, err
+		}
+		if err := stageCDCResumeState(txn, props); err != nil {
+			return true, err
+		}
+		if err := stage(txn); err != nil {
+			return true, err
+		}
+		commit, err := txn.TableCommit()
+		if err != nil {
+			return true, err
+		}
+		if err := d.validateExpectedIncarnation(ctx, current, expectedIncarnation); err != nil {
+			return true, err
+		}
+		_, _, commitErr = d.catalog.CommitTable(ctx, commit.Identifier, commit.Requirements, commit.Updates)
+		if commitErr == nil {
+			txn.MarkCommitted()
+			return false, nil
+		}
+		if !errors.Is(commitErr, icebergtable.ErrCommitFailed) {
+			return false, commitErr
+		}
+
+		current, err = d.catalog.LoadTable(ctx, tbl.Identifier())
+		if err != nil {
+			return false, errors.Join(commitErr, err)
+		}
+		if tableHasCommitToken(current, token) {
+			if err := d.validateExpectedIncarnation(ctx, current, expectedIncarnation); err != nil {
+				return true, err
+			}
+			return true, nil
+		}
+		wait := min(10*time.Millisecond<<attempt, 250*time.Millisecond)
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return true, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return true, commitErr
+}
+
+func retainedRecordIterator(reader array.RecordReader) iter.Seq2[arrow.RecordBatch, error] {
+	return func(yield func(arrow.RecordBatch, error) bool) {
+		for reader.Next() {
+			batch := reader.RecordBatch()
+			batch.Retain()
+			if !yield(batch, nil) {
+				return
+			}
+		}
+		if err := reader.Err(); err != nil {
+			yield(nil, err)
+		}
+	}
+}
+
+func waitForCommitRetry(ctx context.Context, attempt int) error {
+	wait := min(10*time.Millisecond<<attempt, 250*time.Millisecond)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

Implements the coupled Iceberg runtime: platform catalogs, durable atomic writes, direct strategies, partitioning, sorting, lifecycle, purge, and maintenance.

## Stack

Part 8 of 11. Review and merge bottom-up. This PR is based on `stack/iceberg-07-postgres-cdc`; GitHub therefore shows only this layer's delta.

Previous: https://github.com/bruin-data/ingestr/pull/965 · Next: https://github.com/bruin-data/ingestr/pull/967

## Validation

- `make format`
- `make lint`
- `make test`
- Layer-specific package tests

The complete stack is byte-for-byte equivalent to the previously reviewed full implementation.