### PR TITLE
Iceberg stack 9/11: correctness and failure-recovery coverage

### DIFF
--- a/pkg/destination/iceberg/append_idempotency_test.go
+++ b/pkg/destination/iceberg/append_idempotency_test.go
@@ -1,0 +1,418 @@
+package iceberg
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/naming"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestV3AppendRetriesWithOwnedFilesAndPreservesLineage(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{"table.format-version": []string{"3"}})
+	table := "lake.correctness.v3_append_retry"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	before := allTableParquetFiles(t, dest, table)
+	dest.catalog = &failNthCommitCatalog{Catalog: dest.catalog, failAt: 1, err: icebergtable.ErrCommitFailed}
+
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}))
+	require.Len(t, allTableParquetFiles(t, dest, table), len(before)+1)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.True(t, allTasksHaveRowLineage(tasks))
+}
+
+func TestTokenizedAppendRetryRejectsRecreatedTargetWithMatchingToken(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		metadataOnly bool
+	}{
+		{name: "data files"},
+		{name: "metadata only", metadataOnly: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dest := newHadoopDestination(t)
+			table := "lake.correctness.recreated_token_" + strings.ReplaceAll(tt.name, " ", "_")
+			tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+			writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+			original, err := dest.loadIcebergTable(ctx, table)
+			require.NoError(t, err)
+			const token = "recreated-target-token"
+			dest.catalog = &recreateWithCommitTokenOnConflictCatalog{
+				Catalog: dest.catalog,
+				schema:  tableSchema,
+				token:   token,
+			}
+
+			if tt.metadataOnly {
+				_, err = dest.commitTokenizedAppend(ctx, original, iceberggo.Properties{
+					snapshotCommitTokenKey: token,
+				}, original.Metadata().TableUUID().String(), func(*icebergtable.Transaction) error {
+					return nil
+				})
+			} else {
+				err = dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+					Table: table, Schema: tableSchema, CommitToken: token,
+					CDCExpectedIncarnation: original.Metadata().TableUUID().String(),
+				})
+			}
+			require.ErrorContains(t, err, "incarnation changed")
+			recreated, loadErr := dest.loadIcebergTable(ctx, table)
+			require.NoError(t, loadErr)
+			require.NotEqual(t, original.Metadata().TableUUID(), recreated.Metadata().TableUUID())
+		})
+	}
+}
+
+func TestCommitReconciliationRejectsRecreatedTargetWithMatchingToken(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		metadataOnly       bool
+		recreateAfterLoads int
+	}{
+		{name: "data files", recreateAfterLoads: 2},
+		{name: "metadata only", metadataOnly: true, recreateAfterLoads: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dest := newHadoopDestination(t)
+			table := "lake.correctness.reconcile_recreated_token_" + strings.ReplaceAll(tt.name, " ", "_")
+			tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+			writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+			original, err := dest.loadIcebergTable(ctx, table)
+			require.NoError(t, err)
+			const token = "reconcile-recreated-target-token"
+			dest.catalog = &recreateDuringCommitReconciliationCatalog{
+				Catalog:            dest.catalog,
+				schema:             tableSchema,
+				token:              token,
+				recreateAfterLoads: tt.recreateAfterLoads,
+			}
+
+			if tt.metadataOnly {
+				current, loadErr := dest.loadIcebergTable(ctx, table)
+				require.NoError(t, loadErr)
+				err = dest.commitMetadataOnly(ctx, current, "checkpoint",
+					newCommitMetadata(token, "").withExpectedIncarnation(original.Metadata().TableUUID().String()))
+			} else {
+				err = dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+					Table: table, Schema: tableSchema, CommitToken: token,
+					CDCExpectedIncarnation: original.Metadata().TableUUID().String(),
+				})
+			}
+			require.ErrorContains(t, err, "incarnation changed")
+			recreated, loadErr := dest.loadIcebergTable(ctx, table)
+			require.NoError(t, loadErr)
+			require.NotEqual(t, original.Metadata().TableUUID(), recreated.Metadata().TableUUID())
+		})
+	}
+}
+
+func TestCommitReconciliationRejectsRecreatedTargetWithoutMatchingToken(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.correctness.reconcile_recreated_without_token"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	original, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.NoError(t, recreateTableWithCommitToken(ctx, dest.catalog, original.Identifier(), tableSchema, "other-token"))
+
+	commitErr := errors.New("commit outcome is unknown")
+	err = dest.reconcileCommit(ctx, table, "missing-token", original.Metadata().TableUUID().String(), commitErr)
+	require.ErrorContains(t, err, "incarnation changed")
+	require.NotErrorIs(t, err, commitErr)
+}
+
+func TestV3AppendExhaustedConflictsCleanOwnedFiles(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{"table.format-version": []string{"3"}})
+	table := "lake.correctness.v3_append_cleanup"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	before := allTableParquetFiles(t, dest, table)
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+	}}
+
+	err := dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "v3-append-cleanup",
+	})
+	require.ErrorIs(t, err, icebergtable.ErrCommitFailed)
+	require.Equal(t, before, allTableParquetFiles(t, dest, table))
+}
+
+func TestTokenizedAppendCommitFailureCleansGeneratedFiles(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.correctness.append_cleanup"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	before := allTableParquetFiles(t, dest, table)
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+	}}
+
+	err := dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "append-cleanup",
+	})
+	require.True(t, errors.Is(err, icebergtable.ErrCommitFailed))
+	require.Equal(t, before, allTableParquetFiles(t, dest, table))
+}
+
+func TestAppendReaderFailureCleansPartiallyGeneratedFiles(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.correctness.append_reader_cleanup"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	readErr := errors.New("source failed after batch")
+	err := dest.WriteParallel(ctx, recordBatchesThenError(readErr, int64Batch(t, 1, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	})
+	require.ErrorIs(t, err, readErr)
+	require.Empty(t, allTableParquetFiles(t, dest, table))
+}
+
+func TestWriteParallelTokenlessAppendKeepsIdenticalRunsWithDifferentLoadTimestamps(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.correctness.content_idempotent_loaded_at"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: naming.IngestrLoadedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+	}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	write := func(loadedAt int64) {
+		t.Helper()
+		batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(1), loadedAt}})
+		require.NoError(t, err)
+		require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: table, Schema: tableSchema,
+		}))
+	}
+
+	write(micros(time.Date(2026, 7, 11, 1, 0, 0, 0, time.UTC)))
+	snapshots := icebergSnapshotCount(t, dest, table)
+	write(micros(time.Date(2026, 7, 11, 2, 0, 0, 0, time.UTC)))
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, snapshots+1, icebergSnapshotCount(t, dest, table))
+}
+
+func TestWriteParallelTokenlessAppendDoesNotDeduplicateIdenticalContent(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.correctness.content_idempotent_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, Parallelism: 2}
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(
+		int64Batch(t, 1, 2),
+		int64Batch(t, 3, 4),
+	), opts))
+	firstSnapshotCount := icebergSnapshotCount(t, dest, table)
+
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(
+		int64Batch(t, 4),
+		int64Batch(t, 2, 1, 3),
+	), opts))
+	require.EqualValues(t, 8, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, firstSnapshotCount+1, icebergSnapshotCount(t, dest, table))
+	require.Empty(t, latestSnapshotSummary(t, dest, table)[snapshotCommitTokenKey])
+
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(
+		int64Batch(t, 8),
+		int64Batch(t, 6, 5, 7),
+	), opts))
+	require.EqualValues(t, 12, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, firstSnapshotCount+2, icebergSnapshotCount(t, dest, table))
+}
+
+func TestCommitTokenLedgerSurvivesSnapshotExpiration(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.correctness.expired_snapshot_token_ledger"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	write := func(token string, id int64) {
+		t.Helper()
+		require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, id)), destination.WriteOptions{
+			Table: table, Schema: tableSchema, CommitToken: token,
+		}))
+	}
+
+	write("T1", 1)
+	before, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	t1SnapshotID := before.CurrentSnapshot().SnapshotID
+	time.Sleep(2 * time.Millisecond)
+	write("T2", 2)
+
+	result, err := dest.MaintainTable(ctx, table, MaintenanceOptions{
+		ExpireSnapshots:    true,
+		SnapshotMaxAge:     time.Millisecond,
+		MinSnapshotsToKeep: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.SnapshotsAfter)
+
+	afterExpiration, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Nil(t, afterExpiration.SnapshotByID(t1SnapshotID))
+	require.True(t, tableHasCommitToken(afterExpiration, commitTokenID("T1")))
+
+	write("T1", 1)
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, 1, icebergSnapshotCount(t, dest, table))
+}
+
+type recreateWithCommitTokenOnConflictCatalog struct {
+	icebergcatalog.Catalog
+	schema    *schema.TableSchema
+	token     string
+	recreated bool
+}
+
+type recreateDuringCommitReconciliationCatalog struct {
+	icebergcatalog.Catalog
+	schema             *schema.TableSchema
+	token              string
+	recreateAfterLoads int
+	postFailureLoads   int
+	commitFailed       bool
+}
+
+type recreateOnNthLoadCatalog struct {
+	icebergcatalog.Catalog
+	schema     *schema.TableSchema
+	token      string
+	recreateAt int
+	loads      int
+}
+
+func (c *recreateOnNthLoadCatalog) LoadTable(
+	ctx context.Context,
+	identifier icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	c.loads++
+	if c.loads == c.recreateAt {
+		if err := recreateTableWithCommitToken(ctx, c.Catalog, identifier, c.schema, c.token); err != nil {
+			return nil, err
+		}
+	}
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *recreateDuringCommitReconciliationCatalog) LoadTable(
+	ctx context.Context,
+	identifier icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	if c.commitFailed {
+		c.postFailureLoads++
+		if c.postFailureLoads == c.recreateAfterLoads {
+			if err := recreateTableWithCommitToken(ctx, c.Catalog, identifier, c.schema, c.token); err != nil {
+				return nil, err
+			}
+		}
+	}
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *recreateDuringCommitReconciliationCatalog) CommitTable(
+	ctx context.Context,
+	identifier icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	if c.commitFailed {
+		return c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+	}
+	c.commitFailed = true
+	return nil, "", errors.New("commit outcome is unknown")
+}
+
+func (c *recreateWithCommitTokenOnConflictCatalog) LoadTable(
+	ctx context.Context,
+	identifier icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *recreateWithCommitTokenOnConflictCatalog) CommitTable(
+	ctx context.Context,
+	identifier icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	if c.recreated {
+		return c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+	}
+	c.recreated = true
+	if err := recreateTableWithCommitToken(ctx, c.Catalog, identifier, c.schema, c.token); err != nil {
+		return nil, "", err
+	}
+	return nil, "", icebergtable.ErrCommitFailed
+}
+
+func recreateTableWithCommitToken(
+	ctx context.Context,
+	catalog icebergcatalog.Catalog,
+	identifier icebergtable.Identifier,
+	tableSchema *schema.TableSchema,
+	token string,
+) error {
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	if err != nil {
+		return err
+	}
+	ledger, err := json.Marshal([]string{commitTokenID(token)})
+	if err != nil {
+		return err
+	}
+	if err := catalog.DropTable(ctx, identifier); err != nil {
+		return err
+	}
+	_, err = catalog.CreateTable(ctx, identifier, iceSchema, icebergcatalog.WithProperties(iceberggo.Properties{
+		tableCommitTokenLedgerKey: string(ledger),
+	}))
+	return err
+}

--- a/pkg/destination/iceberg/atomic_snapshot_test.go
+++ b/pkg/destination/iceberg/atomic_snapshot_test.go
@@ -1,0 +1,839 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicSnapshotKeepsTargetUnchangedUntilPublication(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.visibility"
+	snapshotSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(snapshotSchema)
+	writeTableRows(t, dest, table, targetSchema, false, [][]any{
+		{int64(99), "old", "old-payload", "0/1", false, int64(1)},
+	})
+
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: snapshotSchema, PrimaryKeys: []string{"id"}, AttemptID: "visibility-attempt",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(snapshotSchema), [][]any{
+		{int64(1), "new", "new-payload", "0/100", false, int64(10), nil},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: snapshotSchema, CommitToken: "snapshot:page-1", AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(99))
+
+	opts.CommitToken = "snapshot:final"
+	opts.CDCResumeLSN = "0/100"
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	rows = singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(1))
+	require.NotContains(t, rows, int64(99))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/100", resume)
+	snapshotCount := icebergSnapshotCount(t, dest, table)
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts), "retry after target commit and staging cleanup must reconcile")
+	require.Equal(t, snapshotCount, icebergSnapshotCount(t, dest, table))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestAbortAtomicSnapshotRequiresMatchingOwnership(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.abort_owned"
+	tableSchema := destination.DestinationTableSchema(cdcSchema(true))
+	writeTableRows(t, dest, table, tableSchema, false, nil)
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: cdcSchema(true), AttemptID: "owned-attempt"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+
+	wrong := opts
+	wrong.AttemptID = "wrong-attempt"
+	require.NoError(t, dest.AbortAtomicSnapshot(ctx, wrong), "a missing unrelated stage is a no-op")
+	require.NoError(t, dest.AbortAtomicSnapshot(ctx, opts))
+	target, err := parseIdentifier(table)
+	require.NoError(t, err)
+	_, err = dest.catalog.LoadTable(ctx, atomicSnapshotStageIdent(target, opts.AttemptID))
+	require.True(t, isMissingTableOrNamespace(err))
+}
+
+func TestAbortAtomicSnapshotRefusesPublishedAttempt(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.abort_published"
+	snapshotSchema := cdcSchema(true)
+	writeTableRows(t, dest, table, destination.DestinationTableSchema(snapshotSchema), false, nil)
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: snapshotSchema, AttemptID: "published-attempt",
+		CommitToken: "snapshot:published", CDCResumeLSN: "0/100",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	require.ErrorContains(t, dest.AbortAtomicSnapshot(ctx, opts), "refusing to abort published")
+}
+
+func TestAtomicSnapshotStageNameIsValidForS3Tables(t *testing.T) {
+	stage := atomicSnapshotStageIdent(icebergcatalog.ToIdentifier("analytics.orders"), "attempt")
+	require.NoError(t, validateS3TablesName("table", stage[len(stage)-1]))
+	require.True(t, stage[len(stage)-1][0] >= 'a' && stage[len(stage)-1][0] <= 'z')
+}
+
+func TestAtomicSnapshotPreOwnershipRecoveryRefusesReplacedStage(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	target := icebergcatalog.ToIdentifier("atomic_snapshot.preownership_fence")
+	stageIdent := atomicSnapshotStageIdent(target, "fenced-attempt")
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, strings.Join(target, "."), tableSchema, false, nil)
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	require.NoError(t, err)
+	preOwnership, err := lifecyclePropertiesForCreate(nil, destination.ManagedStagingTTL)
+	require.NoError(t, err)
+	_, err = dest.catalog.CreateTable(ctx, stageIdent, iceSchema, icebergcatalog.WithProperties(preOwnership))
+	require.NoError(t, err)
+	owned := maps.Clone(preOwnership)
+	owned[atomicSnapshotAttemptProperty] = "fenced-attempt"
+	owned[atomicSnapshotTargetProperty] = strings.Join(target, ".")
+	targetTable, err := dest.catalog.LoadTable(ctx, target)
+	require.NoError(t, err)
+	owned[atomicSnapshotTargetUUID] = targetTable.Metadata().TableUUID().String()
+	wrapper := &replaceAtomicStageCatalog{
+		Catalog: dest.catalog, stage: stageIdent, schema: iceSchema, replacementProperties: owned,
+	}
+	dest.catalog = wrapper
+
+	err = dest.BeginAtomicSnapshot(ctx, destination.AtomicSnapshotOptions{
+		Table: strings.Join(target, "."), Schema: tableSchema, AttemptID: "fenced-attempt",
+	})
+	require.ErrorContains(t, err, "refused to delete replaced table")
+	live, err := dest.catalog.LoadTable(ctx, stageIdent)
+	require.NoError(t, err)
+	require.Equal(t, wrapper.replacementUUID, live.Metadata().TableUUID())
+	require.NoError(t, validateAtomicSnapshotStage(live, target, "fenced-attempt"))
+}
+
+func TestAtomicSnapshotPublishesEmptyTable(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.empty"
+	snapshotSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(snapshotSchema)
+	writeTableRows(t, dest, table, targetSchema, false, [][]any{
+		{int64(1), "old", "old-payload", "0/1", false, int64(1)},
+	})
+
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: snapshotSchema, PrimaryKeys: []string{"id"},
+		CommitToken: "snapshot:empty", CDCResumeLSN: "0/200", AttemptID: "empty-attempt",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	targetIdent, err := parseIdentifier(table)
+	require.NoError(t, err)
+	stageName := strings.Join(atomicSnapshotStageIdent(targetIdent, opts.AttemptID), ".")
+	dest.mu.Lock()
+	require.Contains(t, dest.prepared, stageName)
+	dest.mu.Unlock()
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	dest.mu.Lock()
+	require.NotContains(t, dest.prepared, stageName)
+	dest.mu.Unlock()
+	require.Zero(t, icebergRowCount(ctx, t, dest, table))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/200", resume)
+}
+
+func TestExpiredAtomicSnapshotStageForgetsPreparedSchema(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	opts := destination.AtomicSnapshotOptions{
+		Table: "atomic_snapshot.expired_stage", Schema: cdcSchema(true), AttemptID: "expired-attempt",
+	}
+	writeTableRows(t, dest, opts.Table, destination.DestinationTableSchema(opts.Schema), false, nil)
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	targetIdent, err := parseIdentifier(opts.Table)
+	require.NoError(t, err)
+	stageIdent := atomicSnapshotStageIdent(targetIdent, opts.AttemptID)
+	stageName := strings.Join(stageIdent, ".")
+	setManagedExpiration(t, dest, stageName, time.Now().Add(-time.Hour))
+
+	purged, err := dest.purgeExpiredManagedTable(ctx, stageIdent, time.Now())
+	require.NoError(t, err)
+	require.True(t, purged)
+	dest.mu.Lock()
+	require.NotContains(t, dest.prepared, stageName)
+	dest.mu.Unlock()
+}
+
+func TestAtomicSnapshotRestartDiscardsInterruptedAttempt(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.restart"
+	snapshotSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(snapshotSchema)
+	writeTableRows(t, dest, table, targetSchema, false, [][]any{
+		{int64(99), "old", "old-payload", "0/1", false, int64(1)},
+	})
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: snapshotSchema, PrimaryKeys: []string{"id"}, AttemptID: "interrupted-attempt"}
+
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	interrupted, err := buildRecordBatches(icebergArrowSchema(snapshotSchema), [][]any{
+		{int64(1), "interrupted", "payload", "0/100", false, int64(10), nil},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(interrupted...), destination.WriteOptions{
+		Table: table, Schema: snapshotSchema, CommitToken: "snapshot:old-page", AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+
+	opts.AttemptID = "restarted-attempt"
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	restarted, err := buildRecordBatches(icebergArrowSchema(snapshotSchema), [][]any{
+		{int64(2), "restarted", "payload", "0/200", false, int64(20), nil},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(restarted...), destination.WriteOptions{
+		Table: table, Schema: snapshotSchema, CommitToken: "snapshot:new-final", AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+	opts.CommitToken = "snapshot:new-final"
+	opts.CDCResumeLSN = "0/200"
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(2))
+	require.NotContains(t, rows, int64(1))
+	require.NotContains(t, rows, int64(99))
+}
+
+func TestAtomicSnapshotRepeatedBeginDoesNotEraseOwnedPages(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.repeated_begin"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, nil)
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, AttemptID: "same-run"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	page, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "first", "payload", "0/10", false, int64(10)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(page...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "page-1", AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	targetIdent, err := parseIdentifier(table)
+	require.NoError(t, err)
+	stage := strings.Join(atomicSnapshotStageIdent(targetIdent, opts.AttemptID), ".")
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, stage))
+}
+
+func TestAtomicSnapshotRecoversLegacyPreOwnershipStage(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.pre_ownership"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, nil)
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, AttemptID: "recoverable-run"}
+	writeTableRows(t, dest, table, tableSchema, false, nil)
+	targetIdent, err := parseIdentifier(table)
+	require.NoError(t, err)
+	stageIdent := atomicSnapshotStageIdent(targetIdent, opts.AttemptID)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: strings.Join(stageIdent, "."), Schema: tableSchema, ExpiresAfter: destination.ManagedStagingTTL,
+	}))
+
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	stage, err := dest.catalog.LoadTable(ctx, stageIdent)
+	require.NoError(t, err)
+	require.NoError(t, validateAtomicSnapshotStage(stage, targetIdent, opts.AttemptID))
+}
+
+func TestAtomicSnapshotBeginRetryRejectsRecreatedTarget(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.begin_generation_fence"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, nil)
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, AttemptID: "generation-attempt"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+
+	targetIdent, err := parseIdentifier(table)
+	require.NoError(t, err)
+	stageIdent := atomicSnapshotStageIdent(targetIdent, opts.AttemptID)
+	stageBefore, err := dest.catalog.LoadTable(ctx, stageIdent)
+	require.NoError(t, err)
+	stageUUID := stageBefore.Metadata().TableUUID()
+	replaceCatalogTable(t, ctx, dest.catalog, targetIdent, tableSchema)
+
+	err = dest.BeginAtomicSnapshot(ctx, opts)
+	require.ErrorContains(t, err, "target generation changed")
+	stageAfter, loadErr := dest.catalog.LoadTable(ctx, stageIdent)
+	require.NoError(t, loadErr, "generation mismatch must retain the stage")
+	require.Equal(t, stageUUID, stageAfter.Metadata().TableUUID())
+}
+
+func TestAtomicSnapshotPublishRetriesRejectRecreatedTarget(t *testing.T) {
+	for recreateOnAttempt := 1; recreateOnAttempt <= 5; recreateOnAttempt++ {
+		t.Run(fmt.Sprintf("attempt_%d", recreateOnAttempt), func(t *testing.T) {
+			dest := newHadoopDestination(t)
+			ctx := context.Background()
+			table := fmt.Sprintf("atomic_snapshot.publish_generation_fence_%d", recreateOnAttempt)
+			tableSchema := cdcSchema(false)
+			writeTableRows(t, dest, table, tableSchema, false, [][]any{
+				{int64(99), "old", "payload", "0/1", false, int64(1)},
+			})
+			opts := destination.AtomicSnapshotOptions{
+				Table: table, Schema: tableSchema, TargetSchema: tableSchema, AttemptID: "generation-attempt",
+				CommitToken: "snapshot:generation-final", CDCResumeLSN: "0/1000",
+			}
+			require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+			batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+				{int64(1), "never-published", "payload", "0/1000", false, int64(10)},
+			})
+			require.NoError(t, err)
+			require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+				Table: table, Schema: tableSchema, CommitToken: opts.CommitToken, AtomicSnapshotAttemptID: opts.AttemptID,
+			}))
+
+			targetIdent, err := parseIdentifier(table)
+			require.NoError(t, err)
+			stageIdent := atomicSnapshotStageIdent(targetIdent, opts.AttemptID)
+			stageBefore, err := dest.catalog.LoadTable(ctx, stageIdent)
+			require.NoError(t, err)
+			stageUUID := stageBefore.Metadata().TableUUID()
+			wrapper := &recreateTargetOnConflictCatalog{
+				Catalog: dest.catalog, target: targetIdent, schema: tableSchema, recreateOnCall: recreateOnAttempt,
+			}
+			dest.catalog = wrapper
+
+			err = dest.PublishAtomicSnapshot(ctx, opts)
+			require.ErrorContains(t, err, "target generation changed")
+			require.Equal(t, recreateOnAttempt, wrapper.commitCount())
+			stageAfter, loadErr := dest.catalog.LoadTable(ctx, stageIdent)
+			require.NoError(t, loadErr, "generation mismatch must retain the stage")
+			require.Equal(t, stageUUID, stageAfter.Metadata().TableUUID())
+			rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+			require.Empty(t, rows, "the recreated target must not receive staged rows")
+		})
+	}
+}
+
+func TestAtomicSnapshotPublishesSchemaAndRowsTogether(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.schema_evolution"
+	oldSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, oldSchema, false, [][]any{
+		{int64(1), "old", "payload", "0/1", false, int64(1)},
+	})
+	newSchema := *oldSchema
+	newSchema.Columns = append(append([]schema.Column{}, oldSchema.Columns...), schema.Column{
+		Name: "added", DataType: schema.TypeString, Nullable: true,
+	})
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: &newSchema, PrimaryKeys: []string{"id"}, AttemptID: "schema-attempt"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(&newSchema), [][]any{
+		{int64(2), "new", "payload", "0/400", false, int64(2), "visible-at-publish"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: &newSchema, CommitToken: "snapshot:schema-final", AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+
+	before, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.NotContains(t, before.ColumnNames(), "added")
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+
+	opts.CommitToken = "snapshot:schema-final"
+	opts.CDCResumeLSN = "0/400"
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	after, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Contains(t, after.ColumnNames(), "added")
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Equal(t, "visible-at-publish", rows[int64(2)][6])
+}
+
+func TestManagedAtomicSnapshotDoesNotValidateOrStoreTargetCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.managed_cursor"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{
+		{int64(99), "old", "payload", "0/400", false, int64(400)},
+	})
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "old-target-cursor", "0/400"))
+
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"}, AttemptID: "managed-cursor-attempt",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "replayed", "payload", "0/200", false, int64(200)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, AtomicSnapshotAttemptID: opts.AttemptID, SkipCDCResume: true,
+	}))
+
+	opts.CommitToken = "managed-snapshot-0-200"
+	opts.CDCResumeLSN = "0/200"
+	opts.SkipCDCResume = true
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(1))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+}
+
+func TestManagedAtomicSnapshotAlreadyCommittedTokenClearsLegacyCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.managed_same_token"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1), "committed", "payload", "0/200", false, int64(200)}})
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "managed-atomic-same-token", "0/400"))
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"}, AttemptID: "managed-same-token-attempt"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(1), "replay", "payload", "0/200", false, int64(200)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: tableSchema, AtomicSnapshotAttemptID: opts.AttemptID, SkipCDCResume: true}))
+	opts.CommitToken, opts.SkipCDCResume = "managed-atomic-same-token", true
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestAtomicSnapshotAttemptsCannotDeleteOrMixConcurrentStages(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.concurrent_attempts"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{
+		{int64(99), "old", "payload", "0/1", false, int64(1)},
+	})
+	first := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, AttemptID: "owner-a"}
+	second := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, AttemptID: "owner-b"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, first))
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, second))
+	targetIdent, err := parseIdentifier(table)
+	require.NoError(t, err)
+	_, err = dest.catalog.LoadTable(ctx, atomicSnapshotStageIdent(targetIdent, first.AttemptID))
+	require.NoError(t, err)
+	_, err = dest.catalog.LoadTable(ctx, atomicSnapshotStageIdent(targetIdent, second.AttemptID))
+	require.NoError(t, err)
+
+	firstRows, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "first", "payload", "0/10", false, int64(10)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(firstRows...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "first-final", AtomicSnapshotAttemptID: first.AttemptID,
+	}))
+	secondRows, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(2), "second", "payload", "0/20", false, int64(20)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(secondRows...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "second-final", AtomicSnapshotAttemptID: second.AttemptID,
+	}))
+	first.CommitToken, first.CDCResumeLSN = "first-final", "0/10"
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, first))
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Contains(t, rows, int64(1))
+	require.NotContains(t, rows, int64(2))
+	_, err = dest.catalog.LoadTable(ctx, atomicSnapshotStageIdent(targetIdent, second.AttemptID))
+	require.NoError(t, err, "publishing one owner must not remove another owner's stage")
+}
+
+func TestAtomicSnapshotRejectsStagingOwnershipMismatch(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.owner_mismatch"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, nil)
+	opts := destination.AtomicSnapshotOptions{Table: table, Schema: tableSchema, AttemptID: "expected-owner"}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	targetIdent, err := parseIdentifier(table)
+	require.NoError(t, err)
+	stage, err := dest.catalog.LoadTable(ctx, atomicSnapshotStageIdent(targetIdent, opts.AttemptID))
+	require.NoError(t, err)
+	txn := stage.NewTransaction()
+	require.NoError(t, txn.SetProperties(map[string]string{atomicSnapshotAttemptProperty: "forged-owner"}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	err = dest.WriteAtomicSnapshot(ctx, recordBatches(), destination.WriteOptions{
+		Table: table, Schema: tableSchema, AtomicSnapshotAttemptID: opts.AttemptID,
+	})
+	require.ErrorContains(t, err, "ownership mismatch")
+}
+
+func TestAtomicSnapshotReconcilesUnknownOutcomeAfterInterveningTargetCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.unknown_intervening_commit"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{
+		{int64(99), "old", "payload", "0/1", false, int64(1)},
+	})
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: tableSchema, TargetSchema: tableSchema, AttemptID: "unknown-attempt",
+		CommitToken: "snapshot:unknown-final", CDCResumeLSN: "0/700",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "published", "payload", "0/700", false, int64(7)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: opts.CommitToken, AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+
+	base := dest.catalog
+	ident, err := parseIdentifier(table)
+	require.NoError(t, err)
+	var hookErr error
+	dest.catalog = &commitOutcomeCatalog{
+		Catalog:          base,
+		injectIdentifier: ident,
+		afterCommitErrs:  []error{errors.New("simulated lost publish response")},
+		afterCommitHook: func() {
+			tbl, loadErr := base.LoadTable(ctx, ident)
+			if loadErr != nil {
+				hookErr = loadErr
+				return
+			}
+			empty, readerErr := array.NewRecordReader(icebergArrowSchema(tableSchema), nil)
+			if readerErr != nil {
+				hookErr = readerErr
+				return
+			}
+			defer empty.Release()
+			txn := tbl.NewTransaction()
+			if appendErr := txn.Append(ctx, empty, snapshotProps("intervening-target-commit")); appendErr != nil {
+				hookErr = appendErr
+				return
+			}
+			_, hookErr = txn.Commit(ctx)
+		},
+	}
+
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	require.NoError(t, hookErr)
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(1))
+	committed, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.True(t, tableHasCommitToken(committed, commitTokenID(opts.CommitToken)))
+}
+
+func TestAtomicSnapshotRetriesOptimisticCommitConflict(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.retry_conflict"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{
+		{int64(99), "old", "payload", "0/1", false, int64(1)},
+	})
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: tableSchema, TargetSchema: tableSchema, AttemptID: "retry-attempt",
+		CommitToken: "snapshot:retry-final", CDCResumeLSN: "0/800",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "published", "payload", "0/800", false, int64(8)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: opts.CommitToken, AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+	dest.catalog = &commitOutcomeCatalog{
+		Catalog: dest.catalog, injectIdentifier: icebergcatalog.ToIdentifier(table), beforeCommitErrs: []error{icebergtable.ErrCommitFailed},
+	}
+
+	require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(1))
+}
+
+func TestAtomicSnapshotRetryReconcilesSortOrderAfterDataCommit(t *testing.T) {
+	for _, stageMissing := range []bool{false, true} {
+		name := "stage_present"
+		if stageMissing {
+			name = "stage_missing"
+		}
+		t.Run(name, func(t *testing.T) {
+			dest := newHadoopDestination(t)
+			ctx := context.Background()
+			table := "atomic_snapshot.sort_retry_" + name
+			tableSchema := cdcSchema(false)
+			writeTableRows(t, dest, table, tableSchema, false, [][]any{
+				{int64(99), "old", "payload", "0/1", false, int64(1)},
+			})
+			targetIdent, err := parseIdentifier(table)
+			require.NoError(t, err)
+			target, err := dest.catalog.LoadTable(ctx, targetIdent)
+			require.NoError(t, err)
+			opts := destination.AtomicSnapshotOptions{
+				Table: table, Schema: tableSchema, TargetSchema: tableSchema, AttemptID: "sort-retry-attempt",
+				CommitToken: "snapshot:sort-retry-final", CDCResumeLSN: "0/850", ClusterBy: []string{"id"},
+				CDCExpectedIncarnation: target.Metadata().TableUUID().String(),
+			}
+			require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+			batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+				{int64(1), "published", "payload", "0/850", false, int64(8)},
+			})
+			require.NoError(t, err)
+			require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+				Table: table, Schema: tableSchema, CommitToken: opts.CommitToken, AtomicSnapshotAttemptID: opts.AttemptID,
+			}))
+
+			injected := errors.New("simulated sort-order commit failure")
+			dest.catalog = &failNthTargetCommitCatalog{
+				Catalog: dest.catalog, target: targetIdent, failOn: 2, failure: injected,
+			}
+			err = dest.PublishAtomicSnapshot(ctx, opts)
+			require.ErrorIs(t, err, injected)
+			require.ErrorContains(t, err, "sort order is not")
+
+			committed, err := dest.catalog.LoadTable(ctx, targetIdent)
+			require.NoError(t, err)
+			require.True(t, tableHasCommitToken(committed, commitTokenID(opts.CommitToken)))
+			require.False(t, sortOrderMatchesColumns(committed, opts.ClusterBy))
+			stageIdent := atomicSnapshotStageIdent(targetIdent, opts.AttemptID)
+			_, err = dest.catalog.LoadTable(ctx, stageIdent)
+			require.NoError(t, err, "failed sort-order reconciliation must retain the stage")
+			if stageMissing {
+				require.NoError(t, dest.catalog.DropTable(ctx, stageIdent))
+			}
+
+			require.NoError(t, dest.PublishAtomicSnapshot(ctx, opts))
+			committed, err = dest.catalog.LoadTable(ctx, targetIdent)
+			require.NoError(t, err)
+			require.True(t, sortOrderMatchesColumns(committed, opts.ClusterBy))
+			require.Equal(t, opts.CDCExpectedIncarnation, committed.Metadata().TableUUID().String())
+			rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+			require.Len(t, rows, 1)
+			require.Contains(t, rows, int64(1))
+			_, err = dest.catalog.LoadTable(ctx, stageIdent)
+			require.True(t, isMissingTableOrNamespace(err))
+		})
+	}
+}
+
+func TestAtomicSnapshotBoundsOptimisticCommitRetries(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "atomic_snapshot.exhaust_conflicts"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{
+		{int64(99), "old", "payload", "0/1", false, int64(1)},
+	})
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: tableSchema, TargetSchema: tableSchema, AttemptID: "exhaust-attempt",
+		CommitToken: "snapshot:exhaust-final", CDCResumeLSN: "0/900",
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "never-visible", "payload", "0/900", false, int64(9)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: opts.CommitToken, AtomicSnapshotAttemptID: opts.AttemptID,
+	}))
+	targetIdent, parseErr := parseIdentifier(table)
+	require.NoError(t, parseErr)
+	stageIdent := atomicSnapshotStageIdent(targetIdent, opts.AttemptID)
+	stageBefore, err := dest.catalog.LoadTable(ctx, stageIdent)
+	require.NoError(t, err)
+	expiresBefore, _, err := managedTableExpiration(stageBefore.Properties())
+	require.NoError(t, err)
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, injectIdentifier: icebergcatalog.ToIdentifier(table), beforeCommitErrs: []error{
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+	}}
+
+	err = dest.PublishAtomicSnapshot(ctx, opts)
+	require.ErrorIs(t, err, icebergtable.ErrCommitFailed)
+	require.ErrorContains(t, err, "after retries")
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 1)
+	require.Contains(t, rows, int64(99))
+	stageAfter, err := dest.catalog.LoadTable(ctx, stageIdent)
+	require.NoError(t, err, "retry exhaustion must retain the replayable stage")
+	expiresAfter, _, err := managedTableExpiration(stageAfter.Properties())
+	require.NoError(t, err)
+	require.True(t, expiresAfter.After(expiresBefore), "publication must renew the managed stage throughout retries")
+}
+
+type replaceAtomicStageCatalog struct {
+	icebergcatalog.Catalog
+	stage                 icebergtable.Identifier
+	schema                *iceberggo.Schema
+	replacementProperties iceberggo.Properties
+	loads                 int
+	replacementUUID       uuid.UUID
+}
+
+type recreateTargetOnConflictCatalog struct {
+	icebergcatalog.Catalog
+	target         icebergtable.Identifier
+	schema         *schema.TableSchema
+	recreateOnCall int
+
+	mu      sync.Mutex
+	commits int
+}
+
+type failNthTargetCommitCatalog struct {
+	icebergcatalog.Catalog
+	target  icebergtable.Identifier
+	failOn  int
+	failure error
+
+	mu      sync.Mutex
+	commits int
+}
+
+func (c *failNthTargetCommitCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *failNthTargetCommitCatalog) CommitTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	if slices.Equal(ident, c.target) {
+		c.mu.Lock()
+		c.commits++
+		fail := c.commits == c.failOn
+		c.mu.Unlock()
+		if fail {
+			return nil, "", c.failure
+		}
+	}
+	return c.Catalog.CommitTable(ctx, ident, requirements, updates)
+}
+
+func (c *recreateTargetOnConflictCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *recreateTargetOnConflictCatalog) CommitTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	if !slices.Equal(ident, c.target) {
+		return c.Catalog.CommitTable(ctx, ident, requirements, updates)
+	}
+	c.mu.Lock()
+	c.commits++
+	call := c.commits
+	c.mu.Unlock()
+	if call < c.recreateOnCall {
+		return nil, "", icebergtable.ErrCommitFailed
+	}
+	if call == c.recreateOnCall {
+		iceSchema, err := icebergSchemaFromTableSchema(c.schema)
+		if err != nil {
+			return nil, "", err
+		}
+		if err := c.DropTable(ctx, ident); err != nil {
+			return nil, "", err
+		}
+		if _, err := c.CreateTable(ctx, ident, iceSchema); err != nil {
+			return nil, "", err
+		}
+		return nil, "", icebergtable.ErrCommitFailed
+	}
+	return c.Catalog.CommitTable(ctx, ident, requirements, updates)
+}
+
+func (c *recreateTargetOnConflictCatalog) commitCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.commits
+}
+
+func replaceCatalogTable(
+	t *testing.T,
+	ctx context.Context,
+	catalog icebergcatalog.Catalog,
+	ident icebergtable.Identifier,
+	tableSchema *schema.TableSchema,
+) {
+	t.Helper()
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	require.NoError(t, err)
+	require.NoError(t, catalog.DropTable(ctx, ident))
+	_, err = catalog.CreateTable(ctx, ident, iceSchema)
+	require.NoError(t, err)
+}
+
+func (c *replaceAtomicStageCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	if slices.Equal(ident, c.stage) {
+		c.loads++
+		if c.loads == 3 {
+			if err := c.DropTable(ctx, ident); err != nil {
+				return nil, err
+			}
+			replacement, err := c.CreateTable(ctx, ident, c.schema, icebergcatalog.WithProperties(c.replacementProperties))
+			if err != nil {
+				return nil, err
+			}
+			c.replacementUUID = replacement.Metadata().TableUUID()
+			return replacement, nil
+		}
+	}
+	return c.Catalog.LoadTable(ctx, ident)
+}

--- a/pkg/destination/iceberg/catalog_close_test.go
+++ b/pkg/destination/iceberg/catalog_close_test.go
@@ -1,0 +1,114 @@
+package iceberg
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLCatalogDatabaseClosedWithDestination(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, sqliteCatalogTestURI(t, "first")))
+
+	owned, ok := dest.catalog.(*ownedSQLCatalog)
+	require.True(t, ok)
+	require.NoError(t, owned.db.PingContext(ctx))
+	require.NoError(t, dest.Close(ctx))
+	require.Error(t, owned.db.PingContext(ctx))
+	require.NoError(t, dest.Close(ctx))
+}
+
+func TestReconnectClosesPreviousSQLCatalogDatabase(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, sqliteCatalogTestURI(t, "first")))
+	first := dest.catalog.(*ownedSQLCatalog)
+
+	require.NoError(t, dest.Connect(ctx, sqliteCatalogTestURI(t, "second")))
+	second := dest.catalog.(*ownedSQLCatalog)
+	require.NotSame(t, first, second)
+	require.Error(t, first.db.PingContext(ctx))
+	require.NoError(t, second.db.PingContext(ctx))
+	require.NoError(t, dest.Close(ctx))
+}
+
+func TestFailedReconnectKeepsExistingSQLCatalogOpen(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, sqliteCatalogTestURI(t, "first")))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+	first := dest.catalog.(*ownedSQLCatalog)
+
+	err := dest.Connect(ctx, "iceberg+sql://?sql.driver=missing-ingestr-test-driver&sql.dialect=sqlite")
+	require.Error(t, err)
+	require.Same(t, first, dest.catalog)
+	require.NoError(t, first.db.PingContext(ctx))
+}
+
+func TestOwnedSQLCatalogPreservesPurgeCapability(t *testing.T) {
+	cfg, err := parseIcebergConfig(sqliteCatalogTestURI(t, "purge"))
+	require.NoError(t, err)
+	cat, err := loadIcebergCatalog(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closeIcebergCatalog(cat)) })
+	_, ok := cat.(icebergcatalog.PurgeableTable)
+	require.True(t, ok)
+}
+
+func TestSQLCatalogNameIsolationAndLegacyDefault(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	baseURI := "iceberg+sqlite://" + filepath.Join(root, "catalog.db") +
+		"?warehouse_path=" + url.QueryEscape(filepath.Join(root, "warehouse"))
+
+	connect := func(catalogName string) *Destination {
+		t.Helper()
+		dest := NewDestination()
+		uri := baseURI
+		if catalogName != "" {
+			uri += "&catalog_name=" + url.QueryEscape(catalogName)
+		}
+		require.NoError(t, dest.Connect(ctx, uri))
+		t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+		return dest
+	}
+
+	alpha := connect("alpha")
+	beta := connect("beta")
+	legacyDefault := connect("")
+	explicitLegacy := connect("sql")
+
+	require.NoError(t, alpha.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("alpha_only"), iceberggo.Properties{}))
+	require.NoError(t, beta.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("beta_only"), iceberggo.Properties{}))
+	require.NoError(t, legacyDefault.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("legacy_default"), iceberggo.Properties{}))
+
+	require.Equal(t, []string{"alpha_only"}, topLevelNamespaceNames(t, ctx, alpha.catalog))
+	require.Equal(t, []string{"beta_only"}, topLevelNamespaceNames(t, ctx, beta.catalog))
+	require.Equal(t, []string{"legacy_default"}, topLevelNamespaceNames(t, ctx, legacyDefault.catalog))
+	require.Equal(t, []string{"legacy_default"}, topLevelNamespaceNames(t, ctx, explicitLegacy.catalog))
+}
+
+func topLevelNamespaceNames(t *testing.T, ctx context.Context, cat icebergcatalog.Catalog) []string {
+	t.Helper()
+	namespaces, err := cat.ListNamespaces(ctx, nil)
+	require.NoError(t, err)
+	names := make([]string, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		require.Len(t, namespace, 1)
+		names = append(names, namespace[0])
+	}
+	return names
+}
+
+func sqliteCatalogTestURI(t *testing.T, name string) string {
+	t.Helper()
+	root := t.TempDir()
+	return "iceberg+sqlite://" + filepath.Join(root, name+".db") +
+		"?warehouse_path=" + url.QueryEscape(filepath.Join(root, "warehouse"))
+}

--- a/pkg/destination/iceberg/catalog_platform_test.go
+++ b/pkg/destination/iceberg/catalog_platform_test.go
@@ -1,0 +1,212 @@
+package iceberg
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadIcebergCatalogS3TablesSignsConfigWithURIStaticCredentials(t *testing.T) {
+	authHeader := make(chan string, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		authHeader <- r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"defaults":{},"overrides":{}}`))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	query := url.Values{}
+	query.Set("uri", server.URL)
+	query.Set("region", "us-east-1")
+	query.Set("warehouse", "arn:aws:s3tables:us-east-1:123456789012:bucket/analytics")
+	query.Set("access_key_id", "uri-access-key")
+	query.Set("secret_access_key", "uri-secret-key")
+	cfg, err := parseIcebergConfig("iceberg+s3tables://?" + query.Encode())
+	require.NoError(t, err)
+
+	_, err = loadIcebergCatalog(context.Background(), cfg)
+	require.NoError(t, err)
+
+	authorization := <-authHeader
+	require.Contains(t, authorization, "AWS4-HMAC-SHA256 Credential=uri-access-key/")
+	require.Contains(t, authorization, "/us-east-1/s3tables/aws4_request")
+	require.NotContains(t, authorization, "uri-secret-key")
+}
+
+func TestS3TablesDropNamespaceUsesURIStaticCredentialsWithoutAmbientAWS(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/missing-credentials")
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/missing-config")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	authHeader := make(chan string, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"defaults":{},"overrides":{}}`))
+	})
+	mux.HandleFunc("/v1/namespaces/analytics", func(w http.ResponseWriter, r *http.Request) {
+		authHeader <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	query := url.Values{}
+	query.Set("uri", server.URL)
+	query.Set("region", "us-east-1")
+	query.Set("warehouse", "arn:aws:s3tables:us-east-1:123456789012:bucket/analytics")
+	query.Set("access_key_id", "uri-cleanup-key")
+	query.Set("secret_access_key", "uri-cleanup-secret")
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(context.Background(), "iceberg+s3tables://?"+query.Encode()))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	require.NoError(t, dest.DropNamespace(context.Background(), "analytics"))
+
+	authorization := <-authHeader
+	require.Contains(t, authorization, "AWS4-HMAC-SHA256 Credential=uri-cleanup-key/")
+	require.Contains(t, authorization, "/us-east-1/s3tables/aws4_request")
+	require.NotContains(t, authorization, "uri-cleanup-secret")
+}
+
+func TestLoadIcebergCatalogRESTSendsOAuthTokenAsBearerOnConfig(t *testing.T) {
+	authHeader := make(chan string, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		authHeader <- r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"defaults":{},"overrides":{}}`))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	query := url.Values{}
+	query.Set("uri", server.URL)
+	query.Set("warehouse", "s3://catalog-warehouse")
+	query.Set("oauth_token", "uri-oauth-token")
+	cfg, err := parseIcebergConfig("iceberg+rest://?" + query.Encode())
+	require.NoError(t, err)
+
+	_, err = loadIcebergCatalog(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer uri-oauth-token", <-authHeader)
+}
+
+func TestParseIcebergConfigRejectsInvalidS3TablesBucketNames(t *testing.T) {
+	for _, bucket := range []string{
+		"data_lake", "-data-lake", "data-lake-", "xn--data", "sthree-data", "amzn-s3-demo-data", "aws-data",
+		"data-s3alias", "data--ol-s3", "data--x-s3", "data--table-s3",
+	} {
+		t.Run(bucket, func(t *testing.T) {
+			query := url.Values{}
+			query.Set("region", "us-east-1")
+			query.Set("warehouse", "arn:aws:s3tables:us-east-1:123456789012:bucket/"+bucket)
+
+			_, err := parseIcebergConfig("iceberg+s3tables://?" + query.Encode())
+			require.ErrorContains(t, err, "requires an S3 Tables bucket ARN")
+		})
+	}
+}
+
+func TestPrepareTableRejectsInvalidS3TablesIdentifiersBeforeCatalogMutation(t *testing.T) {
+	dest := newHadoopDestination(t)
+	dest.cfg.Properties["rest.signing-name"] = "s3tables"
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		table   string
+		column  string
+		wantErr string
+	}{
+		{name: "nested namespace", table: "company.analytics.events", column: "event_id", wantErr: "requires a single-level namespace"},
+		{name: "uppercase namespace", table: "Analytics.events", column: "event_id", wantErr: "namespace and table names must be lowercase"},
+		{name: "uppercase table", table: "analytics.Events", column: "event_id", wantErr: "namespace and table names must be lowercase"},
+		{name: "namespace starts underscore", table: "_analytics.events", column: "event_id", wantErr: "must begin with a letter or number"},
+		{name: "table starts underscore", table: "analytics._events", column: "event_id", wantErr: "must begin with a letter or number"},
+		{name: "hyphen", table: "analytics.foo-bar", column: "event_id", wantErr: "may contain only lowercase letters, numbers, and underscores"},
+		{name: "reserved namespace", table: "aws_analytics.events", column: "event_id", wantErr: "must not start with reserved prefix"},
+		{name: "too long table", table: "analytics." + strings.Repeat("a", 256), column: "event_id", wantErr: "between 1 and 255 characters"},
+		{name: "uppercase column", table: "analytics.events", column: "Event_ID", wantErr: "column names must be lowercase"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := dest.PrepareTable(ctx, destination.PrepareOptions{
+				Table: tt.table,
+				Schema: &schema.TableSchema{Columns: []schema.Column{{
+					Name: tt.column, DataType: schema.TypeInt64, Nullable: false,
+				}}},
+			})
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+
+	namespaces, err := dest.catalog.ListNamespaces(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, namespaces, "identifier validation must run before namespace creation")
+}
+
+func TestS3TablesManagedStagingPolicyUsesValidNamespace(t *testing.T) {
+	dest := newHadoopDestination(t)
+	dest.cfg.Properties["rest.signing-name"] = "s3tables"
+
+	policy := dest.ManagedStagingPolicy()
+	require.Equal(t, destination.ReplaceStagingManagedSchema, policy.DefaultPlacement)
+	require.Equal(t, s3TablesManagedStagingNamespace, policy.DefaultManagedSchema)
+	require.NoError(t, validateS3TablesName("namespace", policy.DefaultManagedSchema))
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: policy.DefaultManagedSchema + ".cdc_state",
+		Schema: &schema.TableSchema{Columns: []schema.Column{{
+			Name: "event_id", DataType: schema.TypeString, Nullable: false,
+		}}},
+	}))
+}
+
+func TestIcebergManagedStagingPolicyKeepsDefaultNamespace(t *testing.T) {
+	policy := NewDestination().ManagedStagingPolicy()
+	require.Equal(t, destination.ReplaceStagingManagedSchema, policy.DefaultPlacement)
+	require.Equal(t, defaultManagedStagingNamespace, policy.DefaultManagedSchema)
+}
+
+func TestPrepareTableRejectsNestedHiveNamespaceBeforeCatalogMutation(t *testing.T) {
+	dest := newHadoopDestination(t)
+	dest.cfg.Properties["type"] = "hive"
+	ctx := context.Background()
+
+	err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: "company.analytics.events",
+		Schema: &schema.TableSchema{Columns: []schema.Column{{
+			Name: "event_id", DataType: schema.TypeInt64, Nullable: false,
+		}}},
+	})
+	require.ErrorContains(t, err, "Hive catalog requires a single-level namespace")
+	namespaces, listErr := dest.catalog.ListNamespaces(ctx, nil)
+	require.NoError(t, listErr)
+	require.Empty(t, namespaces, "Hive namespace validation must precede every catalog mutation")
+}
+
+func TestValidateS3TablesIdentifierAcceptsDocumentedBoundaries(t *testing.T) {
+	cfg := icebergConfig{Properties: map[string]string{"rest.signing-name": "s3tables"}}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "event_id", DataType: schema.TypeInt64}}}
+
+	for _, ident := range []icebergtable.Identifier{
+		{"a", "0"},
+		{strings.Repeat("n", 255), strings.Repeat("t", 255)},
+		{"analytics", "aws_events"},
+	} {
+		require.NoError(t, validateS3TablesIdentifier(cfg, ident, tableSchema), ident)
+	}
+}

--- a/pkg/destination/iceberg/cdc_lineage_regression_test.go
+++ b/pkg/destination/iceberg/cdc_lineage_regression_test.go
@@ -1,0 +1,469 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagedCDCDataWritesRejectRecreatedTarget(t *testing.T) {
+	ctx := context.Background()
+	tableSchema := lifecycleTestSchema()
+
+	t.Run("append", func(t *testing.T) {
+		dest := newSQLiteManagedCDCDestination(t)
+		table := "cdc_regression.fenced_append"
+		writeTableRows(t, dest, table, tableSchema, false, nil)
+		expected, exists, err := dest.CDCTargetIncarnation(ctx, table)
+		require.NoError(t, err)
+		require.True(t, exists)
+		recreateIcebergTarget(t, ctx, dest, table, tableSchema)
+
+		err = dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+			Table: table, Schema: tableSchema, CDCExpectedIncarnation: expected,
+		})
+		require.ErrorContains(t, err, "incarnation changed")
+		require.Zero(t, icebergRowCount(ctx, t, dest, table))
+	})
+
+	t.Run("direct_merge", func(t *testing.T) {
+		dest := newSQLiteManagedCDCDestination(t)
+		table := "cdc_regression.fenced_direct_merge"
+		writeTableRows(t, dest, table, tableSchema, false, nil)
+		expected, exists, err := dest.CDCTargetIncarnation(ctx, table)
+		require.NoError(t, err)
+		require.True(t, exists)
+		recreateIcebergTarget(t, ctx, dest, table, tableSchema)
+
+		err = dest.MergeRecords(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+			Table: table, Schema: tableSchema, CDCExpectedIncarnation: expected,
+		}, destination.MergeOptions{TargetTable: table, PrimaryKeys: []string{"id"}})
+		require.ErrorContains(t, err, "incarnation changed")
+		require.Zero(t, icebergRowCount(ctx, t, dest, table))
+	})
+
+	t.Run("staged_merge", func(t *testing.T) {
+		dest := newSQLiteManagedCDCDestination(t)
+		target := "cdc_regression.fenced_staged_merge"
+		staging := "cdc_regression.fenced_staged_merge_input"
+		writeTableRows(t, dest, target, tableSchema, false, nil)
+		writeTableRows(t, dest, staging, tableSchema, true, [][]any{{int64(1)}})
+		expected, exists, err := dest.CDCTargetIncarnation(ctx, target)
+		require.NoError(t, err)
+		require.True(t, exists)
+		recreateIcebergTarget(t, ctx, dest, target, tableSchema)
+
+		err = dest.MergeTable(ctx, destination.MergeOptions{
+			StagingTable: staging, TargetTable: target, PrimaryKeys: []string{"id"},
+			CDCExpectedIncarnation: expected,
+		})
+		require.ErrorContains(t, err, "incarnation changed")
+		require.Zero(t, icebergRowCount(ctx, t, dest, target))
+	})
+
+	t.Run("truncate_insert", func(t *testing.T) {
+		dest := newSQLiteManagedCDCDestination(t)
+		table := "cdc_regression.fenced_truncate_insert"
+		writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(7)}})
+		expected, exists, err := dest.CDCTargetIncarnation(ctx, table)
+		require.NoError(t, err)
+		require.True(t, exists)
+		recreateIcebergTarget(t, ctx, dest, table, tableSchema)
+
+		err = dest.TruncateInsertRecords(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+			Table: table, Schema: tableSchema, CDCExpectedIncarnation: expected,
+		})
+		require.ErrorContains(t, err, "incarnation changed")
+		require.Zero(t, icebergRowCount(ctx, t, dest, table))
+	})
+}
+
+func TestManagedCDCAtomicSnapshotRejectsTargetRecreatedAfterBinding(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.fenced_atomic_snapshot"
+	snapshotSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(snapshotSchema)
+	writeTableRows(t, dest, table, targetSchema, false, nil)
+	expected, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	opts := destination.AtomicSnapshotOptions{
+		Table: table, Schema: snapshotSchema, TargetSchema: targetSchema, PrimaryKeys: []string{"id"},
+		AttemptID: "fenced-atomic-attempt", CDCExpectedIncarnation: expected,
+	}
+	require.NoError(t, dest.BeginAtomicSnapshot(ctx, opts))
+	batches, err := buildRecordBatches(icebergArrowSchema(snapshotSchema), [][]any{
+		{int64(1), "new", "payload", "0/100", false, int64(10), nil},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteAtomicSnapshot(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: snapshotSchema, AtomicSnapshotAttemptID: opts.AttemptID,
+		CDCExpectedIncarnation: expected,
+	}))
+	recreateIcebergTarget(t, ctx, dest, table, targetSchema)
+	opts.CommitToken = "snapshot:final"
+	opts.CDCResumeLSN = "0/100"
+	err = dest.PublishAtomicSnapshot(ctx, opts)
+	require.ErrorContains(t, err, "incarnation changed")
+	require.Zero(t, icebergRowCount(ctx, t, dest, table))
+}
+
+func recreateIcebergTarget(t *testing.T, ctx context.Context, dest *Destination, table string, tableSchema *schema.TableSchema) {
+	t.Helper()
+	require.NoError(t, dest.catalog.DropTable(ctx, icebergcatalog.ToIdentifier(table)))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+}
+
+func TestDurableCDCStateSurvivesExternalSnapshotExpiration(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.external_expiration"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "cursor-0-100", "0/100"))
+
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	writeSchema, err := tableWriteSchema(tbl)
+	require.NoError(t, err)
+	empty, err := array.NewRecordReader(writeSchema, nil)
+	require.NoError(t, err)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.Append(ctx, empty, snapshotProps("external-rewrite")))
+	empty.Release()
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	tbl, err = dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	txn = tbl.NewTransaction()
+	require.NoError(t, txn.ExpireSnapshots(
+		icebergtable.WithOlderThan(0),
+		icebergtable.WithRetainLast(1),
+		icebergtable.WithPostCommit(false),
+	))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/100", resume)
+}
+
+func TestMergeTableCDCEqualLSNPrefersDeletes(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "cdc_regression.equal_lsn_target"
+	staging := "cdc_regression.equal_lsn_staging"
+	targetSchema := cdcSchema(false)
+	stagingSchema := cdcSchema(true)
+	syncedAt := micros(time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:  target,
+		Schema: targetSchema,
+	}))
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), nil, nil, "0/100", true, syncedAt, nil},
+		{int64(1), "delete-then-insert", "resurrected", "0/100", false, syncedAt + 1, nil},
+		{int64(2), "insert-then-delete", "preserved", "0/100", false, syncedAt + 2, nil},
+		{int64(2), nil, nil, "0/100", true, syncedAt + 3, nil},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      stagingSchema.ColumnNames(),
+	}))
+
+	got := readTableRows(t, dest, target)
+	rows := singleRowByKey(t, got, "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "delete-then-insert", got.Value(rows[int64(1)], "name"))
+	require.Equal(t, "resurrected", got.Value(rows[int64(1)], "payload"))
+	require.Equal(t, true, got.Value(rows[int64(1)], destination.CDCDeletedColumn))
+	require.Equal(t, syncedAt, got.Value(rows[int64(1)], destination.CDCSyncedAtColumn))
+	require.Equal(t, "insert-then-delete", got.Value(rows[int64(2)], "name"))
+	require.Equal(t, "preserved", got.Value(rows[int64(2)], "payload"))
+	require.Equal(t, true, got.Value(rows[int64(2)], destination.CDCDeletedColumn))
+	require.Equal(t, syncedAt+3, got.Value(rows[int64(2)], destination.CDCSyncedAtColumn))
+}
+
+func TestMergeTableManagedCDCReplaysByKeyWithoutOwningGlobalCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "cdc_regression.managed_replay_target"
+	staging := "cdc_regression.managed_replay_staging"
+	targetSchema := cdcSchema(false)
+	stagingSchema := cdcSchema(true)
+	syncedAt := micros(time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
+
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{
+		{int64(1), "newer", "newer-payload", "0/300", false, syncedAt},
+	})
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "legacy-cursor", "0/300"))
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), "stale", "stale-payload", "0/200", false, syncedAt - 2, nil},
+		{int64(2), "replayed-new-key", "payload", "0/200", false, syncedAt - 1, nil},
+	})
+
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable:  staging,
+		TargetTable:   target,
+		PrimaryKeys:   []string{"id"},
+		Columns:       stagingSchema.ColumnNames(),
+		CDCResumeLSN:  "0/200",
+		SkipCDCResume: true,
+	}))
+
+	got := readTableRows(t, dest, target)
+	rows := singleRowByKey(t, got, "id")
+	require.Equal(t, "newer", got.Value(rows[int64(1)], "name"))
+	require.Equal(t, "0/300", got.Value(rows[int64(1)], destination.CDCLSNColumn))
+	require.Equal(t, "replayed-new-key", got.Value(rows[int64(2)], "name"))
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+}
+
+func TestCommitWriteTokenHandlesNonAdvancingDurableCDCCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.stale_cursor"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "durable-0-100", "0/100"))
+
+	snapshotCount := icebergSnapshotCount(t, dest, table)
+	err := dest.CommitWriteToken(ctx, table, "stale-0-ff", "0/FF")
+	require.ErrorContains(t, err, "stale CDC resume position")
+	require.ErrorContains(t, err, "0/FF")
+	require.ErrorContains(t, err, "0/100")
+	require.Equal(t, snapshotCount, icebergSnapshotCount(t, dest, table))
+
+	// A streaming snapshot can attach its final WAL position to the last data
+	// commit and then emit a metadata-only completion marker at the same
+	// position with a different token. The rows and cursor are already durable,
+	// so this is an idempotent no-op rather than a stale write.
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "snapshot-complete-0-100", "0/100"))
+	require.Equal(t, snapshotCount, icebergSnapshotCount(t, dest, table))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/100", resume)
+
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "durable-0-101", "0/101"))
+	resume, err = dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/101", resume)
+}
+
+func TestManagedAppendDoesNotValidateOrStoreExplicitTargetCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.managed_append_cursor"
+	tableSchema := cdcSchema(false)
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{
+		{int64(1), "already-committed", "payload", "0/200", false, int64(200)},
+	})
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "managed-append-0-200", "0/400"))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "replayed", "payload", "0/200", false, int64(200)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "managed-append-0-200",
+		CDCResumeLSN: "0/200", SkipCDCResume: true,
+	}))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+}
+
+func TestManagedStagedMergeAlreadyCommittedTokenClearsLegacyCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target, staging := "cdc_regression.managed_same_token", "cdc_regression.managed_same_token_staging"
+	targetSchema, stagingSchema := cdcSchema(false), cdcSchema(true)
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{{int64(1), "committed", "payload", "0/200", false, int64(200)}})
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{{int64(1), "replay", "payload", "0/200", false, int64(200), nil}})
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "managed-staged-same-token", "0/400"))
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging, TargetTable: target, PrimaryKeys: []string{"id"}, Columns: stagingSchema.ColumnNames(),
+		CommitToken: "managed-staged-same-token", SkipCDCResume: true,
+	}))
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, target))
+}
+
+func TestFullReplaceResetsCDCResumeLineage(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.full_replace_reset"
+	tableSchema := lifecycleTestSchema()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "pre-replace-cursor", "0/100"))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:     table,
+		Schema:    tableSchema,
+		DropFirst: true,
+	}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table:  table,
+		Schema: tableSchema,
+	}))
+
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "true", tbl.CurrentSnapshot().Summary.Properties[snapshotCDCResetKey])
+	var foundPreReplaceCursor bool
+	for _, snapshot := range tbl.Metadata().Snapshots() {
+		if snapshot.Summary != nil && snapshot.Summary.Properties[snapshotCDCResumeLSNKey] == "0/100" {
+			foundPreReplaceCursor = true
+		}
+	}
+	require.True(t, foundPreReplaceCursor, "the reset must hide, not physically erase, the older cursor")
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "post-replace-cursor", "0/1"))
+	resume, err = dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/1", resume)
+}
+
+func TestMaintenancePreservesCDCResetBarrier(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.maintenance_reset"
+	tableSchema := lifecycleTestSchema()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "pre-maintenance-cursor", "0/100"))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:     table,
+		Schema:    tableSchema,
+		DropFirst: true,
+	}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table:  table,
+		Schema: tableSchema,
+	}))
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "post-reset-broker-token", ""))
+
+	before, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	props := maintenanceSnapshotProperties(before)
+	require.Equal(t, commitTokenID("post-reset-broker-token"), props[snapshotCommitTokenKey])
+	require.Empty(t, props[snapshotCDCResumeLSNKey])
+	require.Equal(t, "true", props[snapshotCDCResetKey])
+
+	result, err := dest.MaintainTable(ctx, table, MaintenanceOptions{
+		ExpireSnapshots:    true,
+		SnapshotMaxAge:     time.Nanosecond,
+		MinSnapshotsToKeep: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.SnapshotsAfter)
+
+	after, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "maintenance", after.CurrentSnapshot().Summary.Properties["ingestr.operation"])
+	require.Equal(t, "true", after.CurrentSnapshot().Summary.Properties[snapshotCDCResetKey])
+	require.Empty(t, after.CurrentSnapshot().Summary.Properties[snapshotCDCResumeLSNKey])
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "post-maintenance-cursor", "0/1"))
+	resume, err = dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/1", resume)
+}
+
+func TestAppendSnapshotChunksPublishCursorOnlyOnFinalChunk(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.append_snapshot_chunks"
+	tableSchema := cdcSchema(false)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema,
+	}))
+
+	writeChunk := func(row []any, token, resume string, skip bool) {
+		t.Helper()
+		batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{row})
+		require.NoError(t, err)
+		require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: table, Schema: tableSchema, CommitToken: token, CDCResumeLSN: resume, SkipCDCResume: skip,
+		}))
+	}
+
+	writeChunk([]any{int64(1), "one", "payload-1", "0/100", false, int64(10)}, "snapshot-page-1", "", true)
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+
+	writeChunk([]any{int64(2), "two", "payload-2", "0/100", false, int64(11)}, "snapshot-page-final", "0/100", false)
+	resume, err = dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "0/100", resume)
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestKeylessAppendCommitsRowAtSnapshotBoundaryExactlyOnce(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "cdc_regression.keyless_snapshot_wal_boundary"
+	tableSchema := cdcSchema(false)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, CDCMode: true,
+	}))
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "snapshot-final", "0/100"))
+
+	appendRow := func(row []any, token, resume string) error {
+		t.Helper()
+		batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{row})
+		require.NoError(t, err)
+		return dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: table, Schema: tableSchema, CommitToken: token, CDCResumeLSN: resume,
+		})
+	}
+
+	boundaryToken := "wal:public.audit_log:0/100"
+	boundaryRow := []any{int64(1), "boundary", "payload", "0/100", false, int64(100)}
+	require.NoError(t, appendRow(boundaryRow, boundaryToken, "0/100"))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+	boundarySnapshotCount := icebergSnapshotCount(t, dest, table)
+
+	require.NoError(t, appendRow(boundaryRow, boundaryToken, "0/100"))
+	require.Equal(t, boundarySnapshotCount, icebergSnapshotCount(t, dest, table))
+
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "checkpoint-0-101", "0/101"))
+	advancedSnapshotCount := icebergSnapshotCount(t, dest, table)
+	require.NoError(t, appendRow(boundaryRow, boundaryToken, "0/100"))
+	require.Equal(t, advancedSnapshotCount, icebergSnapshotCount(t, dest, table))
+
+	err := appendRow(
+		[]any{int64(2), "stale", "payload", "0/FF", false, int64(99)},
+		"wal:public.audit_log:0/FF",
+		"0/FF",
+	)
+	require.ErrorContains(t, err, "stale CDC resume position")
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, advancedSnapshotCount, icebergSnapshotCount(t, dest, table))
+}

--- a/pkg/destination/iceberg/cdc_state_test.go
+++ b/pkg/destination/iceberg/cdc_state_test.go
@@ -1,0 +1,692 @@
+package iceberg
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagedCDCStateWriteLoadFencePruneAndRetry(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	ctx := context.Background()
+	table := "managed_cdc.state"
+	stateSchema := icebergCDCStateTestSchema()
+	recordedAt := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC).UnixMicro()
+	records := [][]any{
+		{"run-old", "2", "connector-a", "public.orders", "lake.orders", "run", int64(1), "complete", "0/10", recordedAt},
+		{"run-new", "2", "connector-a", "public.orders", "lake.orders", "run", int64(2), "complete", "0/20", recordedAt + 1},
+		{"checkpoint-new", "2", "connector-a", "public.orders", "lake.orders", "checkpoint", int64(2), "complete", "0/20", recordedAt + 2},
+		{"checkpoint-new", "2", "connector-b", "public.orders", "lake.orders_b", "checkpoint", int64(2), "complete", "0/30", recordedAt + 3},
+	}
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: stateSchema, PrimaryKeys: []string{"connector_id", "event_id"},
+	}))
+	writeState := func() {
+		batches, err := buildRecordBatches(icebergArrowSchema(stateSchema), records)
+		require.NoError(t, err)
+		require.NoError(t, dest.WriteCDCState(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: table, Schema: stateSchema, CDCExpectedIncarnation: "target-incarnation-must-not-fence-state-writes",
+		}))
+	}
+	writeState()
+	firstSnapshots := icebergSnapshotCount(t, dest, table)
+	writeState()
+	require.Equal(t, firstSnapshots, icebergSnapshotCount(t, dest, table))
+
+	entries, err := dest.LoadCDCState(ctx, table, "connector-a")
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	positions := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		positions[entry.EventID] = entry.Position
+		require.False(t, entry.RecordedAt.IsZero())
+	}
+	require.Equal(t, "0/20", positions["checkpoint-new"])
+
+	fence, err := dest.LoadCDCStateFence(ctx, table, "connector-a")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, fence.Generation)
+	require.Equal(t, []string{"run-new"}, fence.RunEventIDs)
+
+	require.NoError(t, dest.DeleteCDCStateEvents(ctx, table, "connector-a", []string{"checkpoint-new", "run-old"}))
+	entries, err = dest.LoadCDCState(ctx, table, "connector-a")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "run-new", entries[0].EventID)
+	otherEntries, err := dest.LoadCDCState(ctx, table, "connector-b")
+	require.NoError(t, err)
+	require.Len(t, otherEntries, 1)
+
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, tbl.Properties()[tableCDCResumeStateKey])
+	require.Empty(t, tbl.CurrentSnapshot().Summary.Properties[snapshotCDCResumeLSNKey])
+	require.Empty(t, tbl.CurrentSnapshot().Summary.Properties[snapshotCDCResetKey])
+	require.Equal(t, icebergCDCStatePruneBatch, dest.CDCStatePruneBatchSize())
+}
+
+func TestManagedCDCTargetClaimIsPermanentIdempotentAndVisible(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	ctx := context.Background()
+	table := "managed_cdc.targets"
+	claimSchema := icebergCDCClaimTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: claimSchema, PrimaryKeys: []string{"destination_table"},
+	}))
+
+	claim := destination.CDCTargetClaim{
+		DestinationTable: "lake.orders",
+		ConnectorID:      "connector-a",
+		SourceTable:      "public.orders",
+	}
+	require.NoError(t, dest.ClaimCDCTarget(ctx, table, claim))
+	canonical, err := dest.CanonicalCDCTarget(ctx, claim.DestinationTable)
+	require.NoError(t, err)
+	claimLock, err := dest.catalog.LoadTable(ctx, icebergCDCTargetClaimLockIdentifier(icebergcatalog.ToIdentifier(table), canonical))
+	require.NoError(t, err)
+	require.Equal(t, canonical, claimLock.Properties()[cdcTargetClaimLockTargetKey])
+	require.Len(t, canonical, 64)
+	require.Empty(t, claimLock.Properties()[managedTableProperty])
+	require.Empty(t, claimLock.Properties()[managedTableExpiresAt])
+	require.Empty(t, claimLock.Properties()[managedTableExpiresAfterMS])
+	firstSnapshots := icebergSnapshotCount(t, dest, table)
+	claimTable, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, claimTable.CurrentSnapshot().Summary.Properties[snapshotCDCResetKey])
+	require.NoError(t, dest.ClaimCDCTarget(ctx, table, claim))
+	require.Equal(t, firstSnapshots, icebergSnapshotCount(t, dest, table))
+	claimRows := readTableRows(t, dest, table)
+	require.Len(t, claimRows.Rows, 1)
+	require.Equal(t, canonical, claimRows.Value(claimRows.Rows[0], "destination_table"))
+	require.Len(t, claimRows.Value(claimRows.Rows[0], "destination_table"), 64)
+
+	claim.ConnectorID = "connector-b"
+	err = dest.ClaimCDCTarget(ctx, table, claim)
+	require.ErrorContains(t, err, "already claimed")
+	require.Len(t, readTableRows(t, dest, table).Rows, 1)
+
+	claim.DestinationTable = "lake.customers"
+	claim.SourceTable = "public.customers"
+	require.NoError(t, dest.ClaimCDCTarget(ctx, table, claim))
+	require.Len(t, readTableRows(t, dest, table).Rows, 2)
+}
+
+func TestManagedCDCTargetConcurrentClaimHasOnePermanentOwner(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	ctx := context.Background()
+	table := "managed_cdc.concurrent_targets"
+	claimSchema := icebergCDCClaimTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: claimSchema, PrimaryKeys: []string{"destination_table"},
+	}))
+	barrier := &cdcClaimCreateBarrierCatalog{
+		Catalog: dest.catalog,
+		ready:   make(chan struct{}, 8),
+		release: make(chan struct{}),
+	}
+	dest.catalog = barrier
+
+	errs := make(chan error, 2)
+	for _, connectorID := range []string{"connector-a", "connector-b"} {
+		go func() {
+			errs <- dest.ClaimCDCTarget(ctx, table, destination.CDCTargetClaim{
+				DestinationTable: "lake.orders",
+				ConnectorID:      connectorID,
+				SourceTable:      "public.orders",
+			})
+		}()
+	}
+	<-barrier.ready
+	<-barrier.ready
+	close(barrier.release)
+	first, second := <-errs, <-errs
+	require.True(t, first == nil || second == nil)
+	require.False(t, first == nil && second == nil)
+	if first != nil {
+		require.ErrorContains(t, first, "already claimed")
+	}
+	if second != nil {
+		require.ErrorContains(t, second, "already claimed")
+	}
+	require.Len(t, readTableRows(t, dest, table).Rows, 1)
+}
+
+func TestManagedCDCTargetClaimRetryRepairsMissingVisibleRow(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	ctx := context.Background()
+	table := "managed_cdc.retry_targets"
+	claimSchema := icebergCDCClaimTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: claimSchema, PrimaryKeys: []string{"destination_table"},
+	}))
+	claim := destination.CDCTargetClaim{
+		DestinationTable: "lake.orders",
+		ConnectorID:      "connector-a",
+		SourceTable:      "public.orders",
+	}
+	ownerID, err := claim.OwnerID()
+	require.NoError(t, err)
+	canonical, err := dest.CanonicalCDCTarget(ctx, claim.DestinationTable)
+	require.NoError(t, err)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.NoError(t, dest.ensureCDCTargetClaimLock(ctx, tbl.Identifier(), canonical, ownerID, ""))
+	tbl, err = dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, tbl.Properties()[cdcTargetClaimPropertyPrefix+destination.CDCTargetKeyDigest(canonical)])
+	require.Empty(t, readTableRows(t, dest, table).Rows)
+
+	require.NoError(t, dest.ClaimCDCTarget(ctx, table, claim))
+	require.Len(t, readTableRows(t, dest, table).Rows, 1)
+	tbl, err = dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, ownerID, tbl.Properties()[cdcTargetClaimPropertyPrefix+destination.CDCTargetKeyDigest(canonical)])
+	claim.ConnectorID = "connector-b"
+	require.ErrorContains(t, dest.ClaimCDCTarget(ctx, table, claim), "already claimed")
+}
+
+func TestManagedCDCTargetIncarnationAndConditionalTruncate(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	ctx := context.Background()
+	table := "managed_cdc.orders"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}, {int64(2)}})
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "legacy-checkpoint", "0/900"))
+
+	incarnation, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NotEmpty(t, incarnation)
+	require.NoError(t, dest.ValidateManagedCDCTarget(ctx, table))
+
+	err = dest.TruncateCDCTableIfIncarnation(ctx, table, "replaced-table")
+	require.ErrorContains(t, err, "incarnation changed")
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+
+	require.NoError(t, dest.TruncateCDCTableIfIncarnation(ctx, table, incarnation))
+	require.Zero(t, icebergRowCount(ctx, t, dest, table))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+	stable, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, incarnation, stable)
+
+	require.NoError(t, dest.catalog.DropTable(ctx, icebergcatalog.ToIdentifier(table)))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	recreated, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NotEqual(t, incarnation, recreated)
+	err = dest.TruncateCDCTableIfIncarnation(ctx, table, incarnation)
+	require.ErrorContains(t, err, "incarnation changed")
+}
+
+func TestIcebergCatalogIdentityIgnoresRotatedCredentials(t *testing.T) {
+	left := mustIcebergCatalogIdentity(t, "postgres://old-user:old@catalog/db?password=old&SSLPASSWORD=ssl-old&Api_Token=token-old&sslmode=require")
+	right := mustIcebergCatalogIdentity(t, "postgres://new-user:new@catalog/db?password=new&sslpassword=ssl-new&api_token=token-new&sslmode=require")
+	require.Equal(t, left, right)
+	require.NotContains(t, left, "old")
+	require.NotContains(t, left, "user")
+	require.NotContains(t, strings.ToLower(left), "password")
+	require.NotContains(t, strings.ToLower(left), "token")
+}
+
+func TestIcebergCatalogIdentityCanonicalizesEquivalentLocations(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		left  string
+		right string
+	}{
+		{
+			name:  "rest endpoint case default port path and query order",
+			left:  "HTTPS://CATALOG.EXAMPLE.COM.:443/api/../iceberg/?region=us-east-1&tenant=prod",
+			right: "https://catalog.example.com/iceberg?tenant=prod&region=us-east-1",
+		},
+		{
+			name:  "postgres default port and credentials",
+			left:  "postgres://first:old@CATALOG.EXAMPLE.COM:5432/catalog/?sslmode=require&password=old",
+			right: "postgres://second:new@catalog.example.com/catalog?password=new&sslmode=require",
+		},
+		{
+			name:  "object warehouse case and trailing path",
+			left:  "s3://WAREHOUSE/prod/./",
+			right: "s3://warehouse/prod",
+		},
+		{
+			name:  "file URI and local path spelling",
+			left:  "file:/var/lib/iceberg/warehouse/",
+			right: "/var/lib/iceberg/warehouse",
+		},
+		{
+			name:  "localhost file authority",
+			left:  "file://LOCALHOST./var/lib/iceberg/warehouse",
+			right: "file:///var/lib/iceberg/warehouse",
+		},
+		{
+			name:  "local warehouse path",
+			left:  "/var/lib/iceberg/warehouse/./",
+			right: "/var/lib/iceberg/warehouse",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, mustIcebergCatalogIdentity(t, tt.left), mustIcebergCatalogIdentity(t, tt.right))
+		})
+	}
+}
+
+func TestIcebergCatalogIdentityCanonicalizesKeywordDSN(t *testing.T) {
+	left := mustIcebergCatalogIdentity(t, "host=CATALOG.EXAMPLE.COM. port=5432 dbname='iceberg catalog' user=old password='old secret' sslpassword=ssl-old jwt=old-jwt bearer=old-bearer cookie=old-cookie session=old-session sslmode=REQUIRE connect_timeout=5")
+	right := mustIcebergCatalogIdentity(t, "connect_timeout=30 sslmode=verify-full session=new-session cookie=new-cookie bearer=new-bearer jwt=new-jwt password=new user=new dbname='iceberg catalog' host=catalog.example.com")
+
+	require.Equal(t, left, right)
+	require.Equal(t, "keyword-dsn:?dbname=iceberg+catalog&host=catalog.example.com", left)
+	for _, secret := range []string{"old", "secret", "password", "user", "sslpassword", "jwt", "bearer", "cookie", "session"} {
+		require.NotContains(t, strings.ToLower(left), secret)
+	}
+}
+
+func TestIcebergCatalogIdentityCanonicalizesRelativeFileLocations(t *testing.T) {
+	absolute, err := filepath.Abs("catalog.db")
+	require.NoError(t, err)
+	want := "file://" + filepath.ToSlash(absolute)
+
+	require.Equal(t, want, mustIcebergCatalogIdentity(t, "file:catalog.db"))
+	require.Equal(t, want, mustIcebergCatalogIdentity(t, "file:./catalog.db"))
+	require.Equal(t, want, mustIcebergCatalogIdentity(t, "./catalog.db"))
+	require.Equal(t, want, mustIcebergCatalogIdentity(t, want))
+}
+
+func TestIcebergCatalogIdentityRejectsNonDurableFileLocations(t *testing.T) {
+	for _, raw := range []string{
+		"file::memory:",
+		"file:catalog.db?mode=memory",
+		"file:///tmp/catalog.db?mode=memory",
+		"file:///tmp/catalog.db?MODE=MEMORY",
+	} {
+		_, err := icebergCatalogIdentityURI(raw)
+		require.ErrorContains(t, err, "in-memory")
+		require.NotContains(t, err.Error(), raw)
+	}
+}
+
+func TestIcebergCatalogIdentityIgnoresTransportOnlySSLMode(t *testing.T) {
+	left := mustIcebergCatalogIdentity(t, "postgres://catalog.example.com/iceberg?sslmode=require")
+	right := mustIcebergCatalogIdentity(t, "postgres://catalog.example.com/iceberg?sslmode=verify-full")
+	require.Equal(t, left, right)
+}
+
+func TestIcebergCatalogIdentityRejectsAmbientServiceDSN(t *testing.T) {
+	for _, raw := range []string{
+		"service=warehouse",
+		"service=warehouse host=catalog.example.com dbname=iceberg",
+		"servicefile=/etc/postgresql/service.conf host=catalog.example.com dbname=iceberg",
+		"postgres://catalog.example.com/iceberg?service=warehouse",
+		"postgres://catalog.example.com/iceberg?servicefile=%2Fetc%2Fpostgresql%2Fservice.conf",
+	} {
+		_, err := icebergCatalogIdentityURI(raw)
+		require.ErrorContains(t, err, "service-based")
+		require.NotContains(t, err.Error(), raw)
+	}
+}
+
+func TestIcebergCatalogIdentityDistinguishesKeywordDSNLocation(t *testing.T) {
+	base := mustIcebergCatalogIdentity(t, "host=catalog.example.com dbname=iceberg user=old password=secret")
+	differentHost := mustIcebergCatalogIdentity(t, "host=other.example.com dbname=iceberg user=new password=rotated")
+	differentDatabase := mustIcebergCatalogIdentity(t, "host=catalog.example.com dbname=other user=new password=rotated")
+
+	require.NotEqual(t, base, differentHost)
+	require.NotEqual(t, base, differentDatabase)
+}
+
+func TestIcebergCatalogIdentityRejectsUnsafeDSNsWithoutLeakingThem(t *testing.T) {
+	for _, raw := range []string{
+		"host=catalog.example.com password='unterminated-secret",
+		"user:opaque-secret@tcp(catalog.example.com:3306)/iceberg",
+		"postgres:host=catalog.example.com password=opaque-secret",
+		"catalog.example.com/ambiguous-secret",
+	} {
+		_, err := icebergCatalogIdentityURI(raw)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+		require.NotContains(t, err.Error(), raw)
+	}
+}
+
+func TestIcebergCatalogIdentityIgnoresSignedAndAuthQueryParameters(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		left  string
+		right string
+	}{
+		{
+			name: "AWS SigV4",
+			left: "https://catalog.example.com/iceberg?tenant=prod" +
+				"&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=old%2F20260714%2Fus-east-1%2Fexecute-api%2Faws4_request" +
+				"&X-Amz-Date=20260714T000000Z&X-Amz-Expires=60&X-Amz-Security-Token=old-token" +
+				"&X-Amz-SignedHeaders=host&X-Amz-Signature=old-signature",
+			right: "https://catalog.example.com/iceberg?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+				"&X-Amz-Credential=new%2F20260715%2Fus-east-1%2Fexecute-api%2Faws4_request" +
+				"&X-Amz-Date=20260715T000000Z&X-Amz-Expires=120&X-Amz-Security-Token=new-token" +
+				"&X-Amz-SignedHeaders=host&X-Amz-Signature=new-signature&tenant=prod",
+		},
+		{
+			name:  "legacy AWS signature",
+			left:  "https://catalog.example.com/iceberg?tenant=prod&AWSAccessKeyId=old&Expires=1&Signature=old",
+			right: "https://catalog.example.com/iceberg?Signature=new&Expires=2&AWSAccessKeyId=new&tenant=prod",
+		},
+		{
+			name:  "Azure SAS",
+			left:  "https://account.blob.core.windows.net/warehouse?tenant=prod&sv=2024-11-04&sp=rl&se=2026-07-14&sr=c&sig=old",
+			right: "https://account.blob.core.windows.net/warehouse?sig=new&sr=c&se=2026-07-15&sp=rl&sv=2025-01-05&tenant=prod",
+		},
+		{
+			name:  "Google signed URL",
+			left:  "https://storage.googleapis.com/warehouse?tenant=prod&X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=old&X-Goog-Date=20260714T000000Z&X-Goog-Signature=old",
+			right: "https://storage.googleapis.com/warehouse?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=new&X-Goog-Date=20260715T000000Z&X-Goog-Signature=new&tenant=prod",
+		},
+		{
+			name:  "OAuth and generic auth",
+			left:  "https://catalog.example.com/iceberg?tenant=prod&oauth_client_id=old&client_secret=old&Authorization=Bearer+old",
+			right: "https://catalog.example.com/iceberg?Authorization=Bearer+new&client_secret=new&oauth_client_id=new&tenant=prod",
+		},
+		{
+			name:  "session and bearer credentials",
+			left:  "https://catalog.example.com/iceberg?tenant=prod&jwt=old-jwt&bearer=old-bearer&cookie=old-cookie&session=old-session",
+			right: "https://catalog.example.com/iceberg?session=new-session&cookie=new-cookie&bearer=new-bearer&jwt=new-jwt&tenant=prod",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			left := mustIcebergCatalogIdentity(t, tt.left)
+			right := mustIcebergCatalogIdentity(t, tt.right)
+			require.Equal(t, left, right)
+			require.Equal(t, "https://"+strings.TrimPrefix(strings.Split(left, "?")[0], "https://")+"?tenant=prod", left)
+		})
+	}
+}
+
+func TestIcebergCatalogIdentityPreservesLocationQueryParameters(t *testing.T) {
+	base := mustIcebergCatalogIdentity(t, "https://catalog.example.com/iceberg?tenant=prod&region=us-east-1")
+	differentTenant := mustIcebergCatalogIdentity(t, "https://catalog.example.com/iceberg?tenant=staging&region=us-east-1")
+	differentRegion := mustIcebergCatalogIdentity(t, "https://catalog.example.com/iceberg?tenant=prod&region=eu-west-1")
+
+	require.NotEqual(t, base, differentTenant)
+	require.NotEqual(t, base, differentRegion)
+}
+
+func TestManagedCDCCatalogCapabilityValidation(t *testing.T) {
+	for _, supported := range []icebergcatalog.Type{
+		icebergcatalog.REST,
+		icebergcatalog.Hive,
+		icebergcatalog.Glue,
+		icebergcatalog.DynamoDB,
+		icebergcatalog.SQL,
+	} {
+		require.True(t, supportsAtomicCDCTargetClaims(supported), supported)
+	}
+	for _, unsupported := range []icebergcatalog.Type{icebergcatalog.Hadoop, "custom"} {
+		require.False(t, supportsAtomicCDCTargetClaims(unsupported), unsupported)
+	}
+
+	sqlDestination := newSQLiteManagedCDCDestination(t)
+	require.NoError(t, sqlDestination.ValidateManagedCDCState())
+	hadoopDestination := newHadoopDestination(t)
+	err := hadoopDestination.ValidateManagedCDCState()
+	require.ErrorContains(t, err, "atomic table creation")
+	require.ErrorContains(t, err, "hadoop")
+}
+
+func TestCanonicalCDCTargetUsesEncodedCatalogNamespace(t *testing.T) {
+	dest := newHadoopDestination(t)
+	canonical, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.Equal(t, destination.CDCTargetKeyDigest(
+		strings.ToLower(strings.TrimSpace(string(dest.catalog.CatalogType()))),
+		icebergCatalogIdentityName(dest.catalog.CatalogType(), dest.cfg),
+		icebergRESTCatalogIdentityPrefix(dest.catalog.CatalogType(), dest.cfg.Properties.Get("prefix", "")),
+		mustIcebergCatalogIdentity(t, dest.cfg.Properties.Get("uri", "")),
+		mustIcebergCatalogIdentity(t, dest.cfg.Properties.Get("warehouse", "")),
+		strings.TrimSpace(dest.cfg.Properties.Get("glue.id", "")),
+		strings.ToLower(strings.TrimSpace(dest.cfg.Properties.Get("glue.region", ""))),
+		"",
+		"lake",
+		"orders",
+	), canonical)
+	require.Len(t, canonical, 64)
+	differentTable, err := dest.CanonicalCDCTarget(context.Background(), "lake.customers")
+	require.NoError(t, err)
+	require.NotEqual(t, canonical, differentTable)
+
+	dest.cfg.Properties["uri"] = "postgres://first:secret@catalog/db?SSLPASSWORD=first"
+	firstCredentials, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	dest.cfg.Properties["uri"] = "postgres://second:rotated@catalog/db?sslpassword=second"
+	rotatedCredentials, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.Equal(t, firstCredentials, rotatedCredentials)
+	dest.cfg.Properties["uri"] = "postgres://second:rotated@different-catalog/db?sslpassword=second"
+	differentCatalog, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.NotEqual(t, rotatedCredentials, differentCatalog)
+}
+
+func TestCanonicalCDCTargetIncludesRESTPrefix(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	dest.catalog = catalogTypeOverride{Catalog: dest.catalog, catalogType: icebergcatalog.REST}
+	dest.cfg.Properties["prefix"] = "/tenant/./prod/"
+	first, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+
+	dest.cfg.Properties["prefix"] = "tenant/prod"
+	equivalent, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.Equal(t, first, equivalent)
+
+	dest.cfg.Properties["prefix"] = "tenant/staging"
+	different, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.NotEqual(t, first, different)
+}
+
+func TestCanonicalCDCTargetIgnoresNonRoutingCatalogName(t *testing.T) {
+	for _, catalogType := range []icebergcatalog.Type{icebergcatalog.REST, icebergcatalog.Hive, icebergcatalog.Glue} {
+		t.Run(string(catalogType), func(t *testing.T) {
+			dest := newSQLiteManagedCDCDestination(t)
+			dest.catalog = catalogTypeOverride{Catalog: dest.catalog, catalogType: catalogType}
+			if catalogType == icebergcatalog.Glue {
+				dest.cfg.Properties["glue.id"] = "123456789012"
+				dest.cfg.Properties["glue.region"] = "us-east-1"
+				dest.cfg.Properties["glue.endpoint"] = "https://glue.us-east-1.amazonaws.com"
+			}
+			dest.cfg.CatalogNameExplicit = true
+			dest.cfg.CatalogName = "alpha"
+			alpha, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+			require.NoError(t, err)
+			dest.cfg.CatalogName = "beta"
+			beta, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+			require.NoError(t, err)
+			require.Equal(t, alpha, beta)
+		})
+	}
+}
+
+func TestCanonicalCDCTargetRequiresExplicitGlueRoutingIdentity(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	dest.catalog = catalogTypeOverride{Catalog: dest.catalog, catalogType: icebergcatalog.Glue}
+
+	_, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.ErrorContains(t, err, "glue.id")
+	dest.cfg.Properties["glue.id"] = "123456789012"
+	_, err = dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.ErrorContains(t, err, "glue.region")
+	dest.cfg.Properties["glue.region"] = "US-EAST-1"
+	_, err = dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.ErrorContains(t, err, "glue.endpoint")
+	dest.cfg.Properties["glue.endpoint"] = "https://glue.us-east-1.amazonaws.com"
+	_, err = dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.NoError(t, err)
+}
+
+func TestCanonicalCDCTargetIncludesExplicitGlueEndpointAndRejectsAmbientEndpoint(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	dest.catalog = catalogTypeOverride{Catalog: dest.catalog, catalogType: icebergcatalog.Glue}
+	dest.cfg.Properties["glue.id"] = "123456789012"
+	dest.cfg.Properties["glue.region"] = "us-east-1"
+
+	t.Setenv("AWS_ENDPOINT_URL_GLUE", "https://ambient-secret.example")
+	_, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.ErrorContains(t, err, "explicit glue.endpoint")
+	require.NotContains(t, err.Error(), "ambient-secret")
+
+	dest.cfg.Properties["glue.endpoint"] = "HTTPS://GLUE.EXAMPLE.COM.:443/api/../catalog/"
+	first, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.NoError(t, err)
+	dest.cfg.Properties["glue.endpoint"] = "https://glue.example.com/catalog"
+	equivalent, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.NoError(t, err)
+	require.Equal(t, first, equivalent)
+	dest.cfg.Properties["glue.endpoint"] = "https://other.example.com/catalog"
+	different, err := dest.CanonicalCDCTarget(t.Context(), "lake.orders")
+	require.NoError(t, err)
+	require.NotEqual(t, first, different)
+}
+
+func TestCanonicalCDCTargetUsesEffectiveSQLCatalogName(t *testing.T) {
+	dest := newSQLiteManagedCDCDestination(t)
+	dest.cfg.CatalogName = "ingestr"
+	dest.cfg.CatalogNameExplicit = false
+	legacyDefault, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+
+	dest.cfg.CatalogName = "sql"
+	dest.cfg.CatalogNameExplicit = true
+	explicitDefault, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.Equal(t, legacyDefault, explicitDefault)
+
+	dest.cfg.CatalogName = "alpha"
+	alpha, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	dest.cfg.CatalogName = "beta"
+	beta, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.NotEqual(t, alpha, beta)
+}
+
+func mustIcebergCatalogIdentity(t *testing.T, raw string) string {
+	t.Helper()
+	identity, err := icebergCatalogIdentityURI(raw)
+	require.NoError(t, err)
+	return identity
+}
+
+func TestCanonicalCDCTargetNormalizesCatalogEndpointAndWarehouse(t *testing.T) {
+	dest := newHadoopDestination(t)
+	dest.cfg.Properties["uri"] = "HTTPS://CATALOG.EXAMPLE.COM.:443/api/../iceberg/?tenant=prod&X-Amz-Signature=old&X-Amz-Date=20260714T000000Z"
+	dest.cfg.Properties["warehouse"] = "s3://WAREHOUSE/prod/./?X-Amz-Signature=old&X-Amz-Date=20260714T000000Z"
+	first, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+
+	dest.cfg.Properties["uri"] = "https://catalog.example.com/iceberg?X-Amz-Date=20260715T000000Z&X-Amz-Signature=new&tenant=prod"
+	dest.cfg.Properties["warehouse"] = "s3://warehouse/prod?X-Amz-Date=20260715T000000Z&X-Amz-Signature=new"
+	equivalent, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.Equal(t, first, equivalent)
+
+	dest.cfg.Properties["warehouse"] = "s3://warehouse/other"
+	differentWarehouse, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.NotEqual(t, first, differentWarehouse)
+
+	dest.cfg.Properties["warehouse"] = "s3://warehouse/prod"
+	dest.cfg.Properties["uri"] = "https://other-catalog.example.com/iceberg?tenant=prod"
+	differentCatalog, err := dest.CanonicalCDCTarget(context.Background(), "lake.orders")
+	require.NoError(t, err)
+	require.NotEqual(t, first, differentCatalog)
+}
+
+func newSQLiteManagedCDCDestination(t *testing.T) *Destination {
+	t.Helper()
+	root := t.TempDir()
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(
+		context.Background(),
+		"iceberg+sqlite://"+filepath.Join(root, "catalog.db")+"?warehouse_path="+url.QueryEscape(filepath.Join(root, "warehouse")),
+	))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	return dest
+}
+
+func icebergCDCStateTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{Columns: []schema.Column{
+		{Name: "event_id", DataType: schema.TypeString, Nullable: false},
+		{Name: "state_version", DataType: schema.TypeString, Nullable: false},
+		{Name: "connector_id", DataType: schema.TypeString, Nullable: false},
+		{Name: "source_table", DataType: schema.TypeString, Nullable: false},
+		{Name: "destination_table", DataType: schema.TypeString, Nullable: false},
+		{Name: "state_kind", DataType: schema.TypeString, Nullable: false},
+		{Name: "state_generation", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "state_status", DataType: schema.TypeString, Nullable: false},
+		{Name: "_cdc_lsn", DataType: schema.TypeString, Nullable: false},
+		{Name: "recorded_at", DataType: schema.TypeTimestampTZ, Nullable: false},
+	}}
+}
+
+func icebergCDCClaimTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{Columns: []schema.Column{
+		{Name: "destination_table", DataType: schema.TypeString, Nullable: false},
+		{Name: "connector_id", DataType: schema.TypeString, Nullable: false},
+		{Name: "claimed_at", DataType: schema.TypeTimestampTZ, Nullable: false},
+	}}
+}
+
+type cdcClaimCreateBarrierCatalog struct {
+	icebergcatalog.Catalog
+	ready   chan struct{}
+	release chan struct{}
+}
+
+type catalogTypeOverride struct {
+	icebergcatalog.Catalog
+	catalogType icebergcatalog.Type
+}
+
+func (c catalogTypeOverride) CatalogType() icebergcatalog.Type {
+	return c.catalogType
+}
+
+func (c catalogTypeOverride) Close() error {
+	if closer, ok := c.Catalog.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func (c *cdcClaimCreateBarrierCatalog) CreateTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	tableSchema *iceberggo.Schema,
+	opts ...icebergcatalog.CreateTableOpt,
+) (*icebergtable.Table, error) {
+	if len(ident) > 0 && strings.HasPrefix(ident[len(ident)-1], cdcTargetClaimLockPrefix) {
+		c.ready <- struct{}{}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.release:
+		}
+	}
+	return c.Catalog.CreateTable(ctx, ident, tableSchema, opts...)
+}

--- a/pkg/destination/iceberg/check.go
+++ b/pkg/destination/iceberg/check.go
@@ -1,0 +1,292 @@
+package iceberg
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func (d *Destination) CheckConnection(ctx context.Context) (err error) {
+	if d.catalog == nil {
+		return errors.New("iceberg destination not connected")
+	}
+
+	suffix, err := connectionCheckSuffix()
+	if err != nil {
+		return err
+	}
+	namespace, dropNamespace, err := d.connectionCheckNamespace(ctx, suffix)
+	if err != nil {
+		return err
+	}
+	ident := append(append(icebergtable.Identifier(nil), namespace...), "write_read_"+suffix)
+	tableName := strings.Join(ident, ".")
+	tableSchema := &schema.TableSchema{
+		Name: tableName,
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false, IsPrimaryKey: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	defer func() {
+		d.mu.Lock()
+		delete(d.prepared, tableName)
+		d.mu.Unlock()
+	}()
+
+	var tableFS icebergio.IO
+	var tableLocation string
+	var writtenPaths []string
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		cleanupErr := d.cleanupConnectionCheck(cleanupCtx, ident, namespace, dropNamespace, tableFS, tableLocation, writtenPaths)
+		if cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+	}()
+	if err := validateS3TablesIdentifier(d.cfg, ident, tableSchema); err != nil {
+		return fmt.Errorf("validate test table identifier: %w", err)
+	}
+
+	if err := d.createConnectionCheckTable(ctx, ident, tableSchema); err != nil {
+		return fmt.Errorf("create test table: %w", err)
+	}
+
+	d.mu.Lock()
+	d.prepared[tableName] = preparedTable{schema: tableSchema}
+	d.mu.Unlock()
+
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(1)
+	values := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(tableSchema.ToArrowSchema(), []arrow.Array{values}, 1)
+	values.Release()
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: batch}
+	close(records)
+	if err := d.WriteParallel(ctx, records, destination.WriteOptions{
+		Table:        tableName,
+		Schema:       tableSchema,
+		PrimaryKeys:  tableSchema.PrimaryKeys,
+		Parallelism:  1,
+		AtomicCommit: true,
+	}); err != nil {
+		return fmt.Errorf("write test row: %w", err)
+	}
+
+	tbl, err := d.catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return fmt.Errorf("reload test table: %w", err)
+	}
+	tableFS, err = tbl.FS(ctx)
+	if err != nil {
+		return fmt.Errorf("load test table file IO: %w", err)
+	}
+	tableLocation = tbl.Location()
+	writtenPaths = append(writtenPaths, tbl.MetadataLocation())
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	if err != nil {
+		return fmt.Errorf("plan test table read: %w", err)
+	}
+	for _, task := range tasks {
+		writtenPaths = append(writtenPaths, task.File.FilePath())
+	}
+
+	read, err := tbl.Scan().ToArrowTable(ctx)
+	if err != nil {
+		return fmt.Errorf("read test table: %w", err)
+	}
+	defer read.Release()
+	if read.NumRows() != 1 || read.NumCols() != 1 {
+		return fmt.Errorf("read test table: got %d rows and %d columns, want 1 row and 1 column", read.NumRows(), read.NumCols())
+	}
+	chunks := read.Column(0).Data().Chunks()
+	if len(chunks) != 1 {
+		return fmt.Errorf("read test table: got %d id chunks, want 1", len(chunks))
+	}
+	ids, ok := chunks[0].(*array.Int64)
+	if !ok || ids.Len() != 1 || ids.IsNull(0) || ids.Value(0) != 1 {
+		return errors.New("read test table: row value did not round-trip as id=1")
+	}
+	return nil
+}
+
+func (d *Destination) connectionCheckNamespace(ctx context.Context, suffix string) (icebergtable.Identifier, bool, error) {
+	if d.cfg.CreateNamespace {
+		namespace := icebergcatalog.ToIdentifier("ingestr_connection_check_" + suffix)
+		if err := d.catalog.CreateNamespace(ctx, namespace, iceberggo.Properties{}); err != nil {
+			return nil, false, fmt.Errorf("create test namespace: %w", err)
+		}
+		return namespace, true, nil
+	}
+
+	if d.cfg.CheckNamespace == "" {
+		return nil, false, errors.New("connection check requires check_namespace when create_namespace=false")
+	}
+	namespace, err := parseIdentifier(d.cfg.CheckNamespace)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid configured check_namespace: %w", err)
+	}
+	if d.cfg.Properties.Get("type", "") == "hive" && len(namespace) != 1 {
+		return nil, false, fmt.Errorf("iceberg: Hive catalog requires a single-level namespace, got %s", strings.Join(namespace, "."))
+	}
+	exists, err := d.catalog.CheckNamespaceExists(ctx, namespace)
+	if err != nil && !errors.Is(err, icebergcatalog.ErrNoSuchNamespace) {
+		return nil, false, fmt.Errorf("check configured namespace %s: %w", d.cfg.CheckNamespace, err)
+	}
+	if !exists {
+		return nil, false, fmt.Errorf("configured check_namespace %q does not exist", d.cfg.CheckNamespace)
+	}
+	return namespace, false, nil
+}
+
+func (d *Destination) createConnectionCheckTable(ctx context.Context, ident icebergtable.Identifier, tableSchema *schema.TableSchema) error {
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	if err != nil {
+		return err
+	}
+	props, err := lifecyclePropertiesForCreate(d.cfg.TableProperties, destination.ManagedStagingTTL)
+	if err != nil {
+		return err
+	}
+	opts := []icebergcatalog.CreateTableOpt{icebergcatalog.WithProperties(props)}
+	if d.cfg.TableLocation != "" {
+		base := strings.TrimSuffix(renderTableLocation(d.cfg.TableLocation, ident), "/")
+		opts = append(opts, icebergcatalog.WithLocation(base+"/_ingestr_connection_check_"+ident[len(ident)-1]))
+	}
+	if err := d.ensureLocalTableDirs(ident); err != nil {
+		return err
+	}
+	_, err = d.catalog.CreateTable(ctx, ident, iceSchema, opts...)
+	return err
+}
+
+func (d *Destination) cleanupConnectionCheck(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	namespace icebergtable.Identifier,
+	dropNamespace bool,
+	tableFS icebergio.IO,
+	tableLocation string,
+	writtenPaths []string,
+) error {
+	var cleanupErr error
+	if err := d.DropTable(ctx, strings.Join(ident, ".")); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("purge test table: %w", err))
+	}
+	if exists, err := d.catalog.CheckTableExists(ctx, ident); err != nil && !isMissingTableOrNamespace(err) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("verify test table purge: %w", err))
+	} else if exists {
+		cleanupErr = errors.Join(cleanupErr, errors.New("verify test table purge: catalog entry still exists"))
+	}
+	if tableFS != nil {
+		if listable, ok := tableFS.(icebergio.ListableIO); ok && tableLocation != "" {
+			remaining := false
+			walkErr := listable.WalkDir(tableLocation, func(_ string, entry fs.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if !entry.IsDir() {
+					remaining = true
+				}
+				return nil
+			})
+			if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("verify test table files were purged: %w", walkErr))
+			} else if remaining {
+				cleanupErr = errors.Join(cleanupErr, errors.New("verify test table files were purged: files remain under table location"))
+			}
+		} else {
+			for _, path := range writtenPaths {
+				file, openErr := tableFS.Open(path)
+				if openErr == nil {
+					_ = file.Close()
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("verify test table files were purged: %s still exists", path))
+				} else if !errors.Is(openErr, fs.ErrNotExist) {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("verify test table file %s: %w", path, openErr))
+				}
+			}
+		}
+	}
+	if localPath, ok := localFilesystemPath(tableLocation); ok {
+		if removeErr := removeEmptyDirectoryTree(localPath); removeErr != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove empty test table directory: %w", removeErr))
+		}
+	}
+	lockIdent := purgeLockIdentifier(ident)
+	if lock, err := d.catalog.LoadTable(ctx, lockIdent); err == nil {
+		if lock.Properties()[purgeLockModeKey] != purgeLockModeIdle {
+			cleanupErr = errors.Join(cleanupErr, errors.New("remove test table lifecycle lock: lock is still active"))
+		} else if err := d.catalog.DropTable(ctx, lockIdent); err != nil && !isMissingTableOrNamespace(err) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove test table lifecycle lock: %w", err))
+		}
+	} else if !isMissingTableOrNamespace(err) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("inspect test table lifecycle lock: %w", err))
+	}
+	if dropNamespace {
+		if err := d.catalog.DropNamespace(ctx, namespace); err != nil && !isMissingTableOrNamespace(err) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("drop test namespace: %w", err))
+		}
+	}
+	return cleanupErr
+}
+
+func removeEmptyDirectoryTree(root string) error {
+	var directories []string
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			directories = append(directories, path)
+		} else {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(files) > 0 {
+		return fmt.Errorf("files remain after purge: %s", strings.Join(files, ", "))
+	}
+	for i := len(directories) - 1; i >= 0; i-- {
+		if err := os.Remove(directories[i]); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func connectionCheckSuffix() (string, error) {
+	var value [8]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate connection check identifier: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}

--- a/pkg/destination/iceberg/check_test.go
+++ b/pkg/destination/iceberg/check_test.go
@@ -1,0 +1,234 @@
+package iceberg
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIcebergConfigValidatesCheckNamespace(t *testing.T) {
+	cfg, err := parseIcebergConfig("iceberg+hadoop:///tmp/warehouse?check_namespace=lake.analytics")
+	require.NoError(t, err)
+	require.Equal(t, "lake.analytics", cfg.CheckNamespace)
+	require.NotContains(t, cfg.Properties, "check_namespace")
+
+	for _, namespace := range []string{"", "lake..analytics", "lake. analytics"} {
+		t.Run(namespace, func(t *testing.T) {
+			_, err := parseIcebergConfig("iceberg+hadoop:///tmp/warehouse?check_namespace=" + url.QueryEscape(namespace))
+			require.ErrorContains(t, err, "invalid check_namespace")
+		})
+	}
+}
+
+func TestConnectionCheckRejectsNestedHiveNamespaceBeforeCatalogAccess(t *testing.T) {
+	dest := newHadoopDestination(t)
+	dest.cfg.Properties["type"] = "hive"
+	dest.cfg.CreateNamespace = false
+	dest.cfg.CheckNamespace = "company.analytics"
+
+	_, _, err := dest.connectionCheckNamespace(context.Background(), "unused")
+	require.ErrorContains(t, err, "Hive catalog requires a single-level namespace")
+	namespaces, listErr := dest.catalog.ListNamespaces(context.Background(), nil)
+	require.NoError(t, listErr)
+	require.Empty(t, namespaces)
+}
+
+func TestCheckConnectionUsesConfiguredNamespace(t *testing.T) {
+	ctx := context.Background()
+	dest := newCheckDestination(t, "create_namespace=false&check_namespace=selected")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("aaa_unrelated"), iceberggo.Properties{}))
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("selected"), iceberggo.Properties{}))
+
+	base := dest.catalog
+	purger, ok := base.(icebergcatalog.PurgeableTable)
+	require.True(t, ok)
+	recording := &recordingCheckCatalog{Catalog: base, purger: purger}
+	dest.catalog = recording
+
+	require.NoError(t, dest.CheckConnection(ctx))
+	created := recording.createdIdentifiers()
+	require.Len(t, created, 1)
+	require.Len(t, created[0], 2)
+	require.Equal(t, "selected", created[0][0])
+	require.Contains(t, created[0][1], "write_read_")
+
+	for _, namespace := range []string{"aaa_unrelated", "selected"} {
+		exists, err := dest.catalog.CheckNamespaceExists(ctx, icebergcatalog.ToIdentifier(namespace))
+		require.NoError(t, err)
+		require.True(t, exists)
+	}
+	requirePreparedTablesEmpty(t, dest)
+}
+
+func TestCheckConnectionRequiresConfiguredNamespaceWhenCreationDisabled(t *testing.T) {
+	ctx := context.Background()
+	dest := newCheckDestination(t, "create_namespace=false")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("unrelated"), iceberggo.Properties{}))
+
+	err := dest.CheckConnection(ctx)
+	require.ErrorContains(t, err, "requires check_namespace when create_namespace=false")
+	requirePreparedTablesEmpty(t, dest)
+}
+
+func TestCheckConnectionRejectsMissingConfiguredNamespace(t *testing.T) {
+	dest := newCheckDestination(t, "create_namespace=false&check_namespace=missing")
+	err := dest.CheckConnection(context.Background())
+	require.ErrorContains(t, err, `configured check_namespace "missing" does not exist`)
+	requirePreparedTablesEmpty(t, dest)
+}
+
+func TestCheckConnectionIgnoresConfiguredPartitionSpec(t *testing.T) {
+	dest := newCheckDestination(t, "partition_spec=missing_check_column")
+	require.Equal(t, "missing_check_column", dest.cfg.PartitionSpec)
+	base := dest.catalog
+	purger, ok := base.(icebergcatalog.PurgeableTable)
+	require.True(t, ok)
+	recording := &recordingCheckCatalog{Catalog: base, purger: purger}
+	dest.catalog = recording
+
+	require.NoError(t, dest.CheckConnection(context.Background()))
+	require.Equal(t, []int{0}, recording.createdPartitionFieldCounts())
+	requirePreparedTablesEmpty(t, dest)
+}
+
+func TestCheckConnectionPreservesUnrelatedConfiguredLocationContents(t *testing.T) {
+	warehouse := t.TempDir()
+	shared := filepath.Join(warehouse, "shared-table-location")
+	sentinelDir := filepath.Join(shared, "unrelated-empty-directory")
+	require.NoError(t, os.MkdirAll(sentinelDir, 0o755))
+	sentinelFile := filepath.Join(shared, "unrelated-sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinelFile, []byte("keep me"), 0o600))
+
+	catalogPath := filepath.Join(t.TempDir(), "catalog.db")
+	rawURI := "iceberg+sqlite://" + catalogPath +
+		"?warehouse_path=" + url.QueryEscape(warehouse) +
+		"&table_location=" + url.QueryEscape(filepath.Join(shared, "{identifier}"))
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(context.Background(), rawURI))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	require.NoError(t, dest.CheckConnection(context.Background()))
+
+	contents, err := os.ReadFile(sentinelFile)
+	require.NoError(t, err)
+	require.Equal(t, "keep me", string(contents))
+	info, err := os.Stat(sentinelDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	requirePreparedTablesEmpty(t, dest)
+}
+
+func TestCheckConnectionClearsPreparedEntryAfterFailure(t *testing.T) {
+	dest := newCheckDestination(t, "")
+	base := dest.catalog
+	purger, ok := base.(icebergcatalog.PurgeableTable)
+	require.True(t, ok)
+	dest.catalog = &failOnceLoadCheckCatalog{Catalog: base, purger: purger}
+
+	err := dest.CheckConnection(context.Background())
+	require.ErrorContains(t, err, "write test row")
+	requirePreparedTablesEmpty(t, dest)
+}
+
+func newCheckDestination(t *testing.T, query string) *Destination {
+	t.Helper()
+	return newCheckDestinationWithWarehouse(t, t.TempDir(), query)
+}
+
+func newCheckDestinationWithWarehouse(t *testing.T, warehouse, query string) *Destination {
+	t.Helper()
+	rawURI := "iceberg+hadoop://?warehouse=" + url.QueryEscape(warehouse)
+	if query != "" {
+		rawURI += "&" + query
+	}
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(context.Background(), rawURI))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	return dest
+}
+
+func requirePreparedTablesEmpty(t *testing.T, dest *Destination) {
+	t.Helper()
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	require.Empty(t, dest.prepared)
+}
+
+type recordingCheckCatalog struct {
+	icebergcatalog.Catalog
+	purger icebergcatalog.PurgeableTable
+	mu     sync.Mutex
+	idents []icebergtable.Identifier
+	parts  []int
+}
+
+func (c *recordingCheckCatalog) CreateTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	tableSchema *iceberggo.Schema,
+	opts ...icebergcatalog.CreateTableOpt,
+) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.CreateTable(ctx, ident, tableSchema, opts...)
+	if err != nil {
+		return nil, err
+	}
+	partitionSpec := tbl.Metadata().PartitionSpec()
+	if strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+		return tbl, nil
+	}
+	c.mu.Lock()
+	c.idents = append(c.idents, append(icebergtable.Identifier(nil), ident...))
+	c.parts = append(c.parts, partitionSpec.NumFields())
+	c.mu.Unlock()
+	return tbl, nil
+}
+
+func (c *recordingCheckCatalog) PurgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	return c.purger.PurgeTable(ctx, ident)
+}
+
+func (c *recordingCheckCatalog) createdIdentifiers() []icebergtable.Identifier {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]icebergtable.Identifier, len(c.idents))
+	for i, ident := range c.idents {
+		result[i] = append(icebergtable.Identifier(nil), ident...)
+	}
+	return result
+}
+
+func (c *recordingCheckCatalog) createdPartitionFieldCounts() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.parts...)
+}
+
+type failOnceLoadCheckCatalog struct {
+	icebergcatalog.Catalog
+	purger icebergcatalog.PurgeableTable
+	mu     sync.Mutex
+	failed bool
+}
+
+func (c *failOnceLoadCheckCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	c.mu.Lock()
+	if !c.failed {
+		c.failed = true
+		c.mu.Unlock()
+		return nil, icebergcatalog.ErrNoSuchTable
+	}
+	c.mu.Unlock()
+	return c.Catalog.LoadTable(ctx, ident)
+}
+
+func (c *failOnceLoadCheckCatalog) PurgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	return c.purger.PurgeTable(ctx, ident)
+}

--- a/pkg/destination/iceberg/cluster_test.go
+++ b/pkg/destination/iceberg/cluster_test.go
@@ -1,0 +1,79 @@
+package iceberg
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterSorterUsesTypedOrderAndNullsFirst(t *testing.T) {
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "key", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "value", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	sorter, err := newClusterSorter(sc, []string{"key"})
+	require.NoError(t, err)
+	t.Cleanup(sorter.Close)
+
+	for _, row := range [][]any{
+		{int64(10), "ten"},
+		{int64(2), "two"},
+		{nil, "null"},
+		{int64(-1), "negative"},
+	} {
+		require.NoError(t, sorter.Add(row))
+	}
+
+	rows := clusteredRows(t, sorter)
+	require.Equal(t, []any{nil, int64(-1), int64(2), int64(10)}, []any{rows[0][0], rows[1][0], rows[2][0], rows[3][0]})
+}
+
+func TestClusterSorterOrdersVariableWidthAndDecimalValues(t *testing.T) {
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "name", Type: arrow.BinaryTypes.String},
+		{Name: "amount", Type: &arrow.Decimal128Type{Precision: 10, Scale: 2}},
+	}, nil)
+	sorter, err := newClusterSorter(sc, []string{"name", "amount"})
+	require.NoError(t, err)
+	t.Cleanup(sorter.Close)
+
+	for _, row := range [][]any{
+		{"aa", decimalVal("-10.25")},
+		{"a\x00", decimalVal("1.00")},
+		{"a", decimalVal("10.00")},
+		{"a", decimalVal("2.00")},
+	} {
+		require.NoError(t, sorter.Add(row))
+	}
+
+	rows := clusteredRows(t, sorter)
+	require.Equal(t, [][]any{
+		{"a", decimalVal("2.00")},
+		{"a", decimalVal("10.00")},
+		{"a\x00", decimalVal("1.00")},
+		{"aa", decimalVal("-10.25")},
+	}, rows)
+}
+
+func TestClusterSorterRejectsUnorderableColumns(t *testing.T) {
+	sc := arrow.NewSchema([]arrow.Field{{Name: "values", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)}}, nil)
+	_, err := newClusterSorter(sc, []string{"values"})
+	require.ErrorContains(t, err, "is not orderable for clustering")
+}
+
+func clusteredRows(t *testing.T, sorter *spillSorter) [][]any {
+	t.Helper()
+	it, err := sorter.Iter()
+	require.NoError(t, err)
+	defer it.Close()
+
+	var rows [][]any
+	for it.NextGroup() {
+		for it.NextRow() {
+			rows = append(rows, append([]any(nil), it.Row()...))
+		}
+	}
+	require.NoError(t, it.Err())
+	return rows
+}

--- a/pkg/destination/iceberg/commit_metadata_test.go
+++ b/pkg/destination/iceberg/commit_metadata_test.go
@@ -1,0 +1,574 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"sync"
+	"testing"
+
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateResetsCommitTokenScope(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "commit_metadata.truncate_token_scope"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "snapshot-page-1"}
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), opts))
+	before, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.True(t, tableHasCommitToken(before, commitTokenID(opts.CommitToken)))
+
+	require.NoError(t, dest.TruncateTable(ctx, table))
+	truncated, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.False(t, tableHasCommitToken(truncated, commitTokenID(opts.CommitToken)))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), opts))
+	require.Equal(t, [][]any{{int64(2)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestCommitTokenIDIsStableAndTypeAware(t *testing.T) {
+	left := map[string]any{"partition": 7, "offset": 42}
+	right := map[string]any{"offset": 42, "partition": 7}
+
+	require.Equal(t, commitTokenID(left), commitTokenID(right))
+	require.NotEqual(t, commitTokenID(int64(42)), commitTokenID("42"))
+	require.NotEqual(t, commitTokenID("first"), commitTokenID("second"))
+	require.Empty(t, commitTokenID(nil))
+}
+
+func TestWriteParallelCommitTokenMakesAppendIdempotent(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.idempotent_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: map[string]int{"offset": 10}}
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), opts))
+	firstSnapshotCount := icebergSnapshotCount(t, dest, table)
+
+	// A retry can carry the same token but a fresh copy of the records. It must
+	// consume/release that channel without appending the rows again.
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), opts))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, firstSnapshotCount, icebergSnapshotCount(t, dest, table))
+	require.Equal(t, commitTokenID(opts.CommitToken), latestSnapshotSummary(t, dest, table)[snapshotCommitTokenKey])
+
+	opts.CommitToken = map[string]int{"offset": 11}
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), opts))
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestWriteParallelConcurrentSameTokenCommitsRowsOnce(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.concurrent_idempotent_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	barrier := &commitBarrierCatalog{
+		Catalog: dest.catalog,
+		ready:   make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	dest.catalog = barrier
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "shared-flush-token", Parallelism: 2}
+
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errs <- dest.WriteParallel(ctx, recordBatches(int64Batch(t, 42)), opts)
+		}()
+	}
+	<-barrier.ready
+	<-barrier.ready
+	close(barrier.release)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, commitTokenID(opts.CommitToken), latestSnapshotSummary(t, dest, table)[snapshotCommitTokenKey])
+}
+
+func TestWriteParallelV3ConcurrentDifferentTokensReplayRowsAfterConflict(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table.format-version": []string{"3"},
+	})
+	ctx := context.Background()
+	table := "lake.correctness.concurrent_v3_replay"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	conflict := &conflictFirstOfTwoCatalog{
+		Catalog: dest.catalog, firstReady: make(chan struct{}), secondCommitted: make(chan struct{}),
+	}
+	dest.catalog = conflict
+	inputs := []<-chan source.RecordBatchResult{
+		recordBatches(int64Batch(t, 1)),
+		recordBatches(int64Batch(t, 2)),
+	}
+	errs := make(chan error, 2)
+	for i := range 2 {
+		go func(index int) {
+			errs <- dest.WriteParallel(ctx, inputs[index], destination.WriteOptions{
+				Table: table, Schema: tableSchema, CommitToken: fmt.Sprintf("v3-token-%d", index),
+			})
+		}(i)
+	}
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestWriteParallelReconcilesCommitWhoseOutcomeWasUnknown(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.unknown_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	unknown := errors.New("simulated response loss after catalog commit")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, afterCommitErrs: []error{unknown}}
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "flush-17"}
+
+	// The catalog applied the commit and then returned an error. Reloading the
+	// snapshot lineage finds the token, so the destination reports success.
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 17)), opts))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+
+	// A process-level retry is also a no-op.
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 17)), opts))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestLineageCommitReconciliationIgnoresAnOlderLedgerToken(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.lineage_reconcile"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "reused-token",
+	}))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "interleaved-append",
+	}))
+
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	baseSnapshotID := tbl.CurrentSnapshot().SnapshotID
+	require.True(t, tableHasCommitToken(tbl, commitTokenID("reused-token")))
+	require.False(t, lineageHasCommitTokenAfterSnapshot(tbl, commitTokenID("reused-token"), baseSnapshotID))
+	require.False(t, lineageHasCommitTokenAfterSnapshot(tbl, commitTokenID("interleaved-append"), baseSnapshotID))
+}
+
+func TestWriteParallelReconcilesUnknownCommitAfterCallerContextCancellation(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	table := "lake.correctness.cancelled_unknown_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	unknown := errors.New("simulated timeout after catalog commit")
+	dest.catalog = &commitOutcomeCatalog{
+		Catalog:         dest.catalog,
+		afterCommitErrs: []error{unknown},
+		afterCommitHook: cancel,
+	}
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "flush-cancelled-1"}
+
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 19)), opts))
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.EqualValues(t, 1, icebergRowCount(context.Background(), t, dest, table))
+}
+
+func TestWriteParallelPollsUntilUnknownCommitBecomesVisible(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.eventually_visible_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	eventual := &eventuallyVisibleCommitCatalog{
+		Catalog:          dest.catalog,
+		unknown:          errors.New("simulated response loss before catalog replicas converged"),
+		invisibleLoads:   3,
+		invisibleLoadErr: errors.New("simulated stale catalog replica"),
+	}
+	dest.catalog = eventual
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 23)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "eventual-flush-23",
+	}))
+	require.GreaterOrEqual(t, eventual.failedLoadCount(), 3)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestTokenlessReplaceReconcilesUnknownCommitOutcome(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.unknown_tokenless_replace"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true,
+	}))
+
+	unknown := errors.New("simulated response loss after tokenless replace")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, afterCommitErrs: []error{unknown}}
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}))
+
+	rows := readTableRows(t, dest, table)
+	require.Equal(t, [][]any{{int64(2)}}, rows.Rows)
+	require.NotEmpty(t, latestSnapshotSummary(t, dest, table)[snapshotCommitTokenKey])
+}
+
+func TestWriteParallelDoesNotReconcileDefinitelyFailedCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.failed_append"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	failed := errors.New("simulated catalog rejection")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{failed}}
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "flush-18"}
+
+	err := dest.WriteParallel(ctx, recordBatches(int64Batch(t, 18)), opts)
+	require.ErrorIs(t, err, failed)
+	require.EqualValues(t, 0, icebergRowCount(ctx, t, dest, table))
+
+	// The token was not committed, so a retry performs the append.
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 18)), opts))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+}
+
+func TestRowDeltaMergeReconcilesUnknownCommitAndRetry(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.correctness.unknown_merge_target"
+	staging := "lake.correctness.unknown_merge_staging"
+	tableSchema := mergeTestSchema()
+
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), "before", 1.0, int64(1)},
+	})
+	writeTableRows(t, dest, staging, tableSchema, true, [][]any{
+		{int64(1), "after", 2.0, int64(2)},
+		{int64(2), "new", 3.0, int64(2)},
+	})
+
+	unknown := errors.New("simulated response loss after row-delta commit")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, afterCommitErrs: []error{unknown}}
+	opts := destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      tableSchema.ColumnNames(),
+		CommitToken:  "merge-flush-1",
+	}
+	require.NoError(t, dest.MergeTable(ctx, opts))
+	firstSnapshotCount := icebergSnapshotCount(t, dest, target)
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "after", rows[int64(1)][1])
+
+	require.NoError(t, dest.MergeTable(ctx, opts))
+	require.Equal(t, firstSnapshotCount, icebergSnapshotCount(t, dest, target))
+	rows = singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 2)
+}
+
+func TestCommitWriteTokenReconcilesUnknownCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.unknown_checkpoint"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	unknown := errors.New("simulated response loss after checkpoint commit")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, afterCommitErrs: []error{unknown}}
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "idle-flush-1", "00000000/00000060"))
+	firstSnapshotCount := icebergSnapshotCount(t, dest, table)
+
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "idle-flush-1", "00000000/00000060"))
+	require.Equal(t, firstSnapshotCount, icebergSnapshotCount(t, dest, table))
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000060", resume)
+}
+
+func TestGetMaxCDCLSNUsesSnapshotLineage(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.cdc_append"
+	tableSchema := cdcSchema(false)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	first, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "one", "payload", "00000000/00000010", false, int64(10)},
+	})
+	require.NoError(t, err)
+	second, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(2), "two", "payload", "00000000/00000020", false, int64(20)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(first[0], second[0]), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}))
+
+	resume, err := dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", resume)
+
+	// A later non-CDC metadata checkpoint must not hide the last CDC cursor.
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "broker-checkpoint", ""))
+	resume, err = dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", resume)
+
+	// A source checkpoint can advance beyond the last data row.
+	require.NoError(t, dest.CommitWriteToken(ctx, table, "cdc-keepalive", "00000000/00000030"))
+	resume, err = dest.GetMaxCDCLSN(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000030", resume)
+
+	missing, err := dest.GetMaxCDCLSN(ctx, "lake.correctness.missing")
+	require.NoError(t, err)
+	require.Empty(t, missing)
+}
+
+func TestCDCMergePersistsCursorAndDeduplicatesDerivedToken(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.correctness.cdc_target"
+	staging := "lake.correctness.cdc_staging"
+	targetSchema := cdcSchema(false)
+	stagingSchema := cdcSchema(true)
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: target, Schema: targetSchema}))
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), "one", "payload", "00000000/00000040", false, int64(40), nil},
+		{int64(2), "two", "payload", "00000000/00000050", false, int64(50), nil},
+	})
+	opts := destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      stagingSchema.ColumnNames(),
+	}
+	require.NoError(t, dest.MergeTable(ctx, opts))
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, target))
+	firstSnapshotCount := icebergSnapshotCount(t, dest, target)
+
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000050", resume)
+
+	// Batch CDC does not provide a streaming CommitToken. The destination
+	// derives one from the max durable LSN, making a retried merge a no-op.
+	require.NoError(t, dest.MergeTable(ctx, opts))
+	require.Equal(t, firstSnapshotCount, icebergSnapshotCount(t, dest, target))
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, target))
+}
+
+func icebergSnapshotCount(t *testing.T, dest *Destination, table string) int {
+	t.Helper()
+	tbl, err := dest.loadIcebergTable(context.Background(), table)
+	require.NoError(t, err)
+	return len(tbl.Metadata().Snapshots())
+}
+
+// commitOutcomeCatalog injects failures immediately before or after the real
+// catalog commit. LoadTable rebinds returned tables to this wrapper so their
+// transactions exercise the injected CommitTable behavior too.
+type commitOutcomeCatalog struct {
+	icebergcatalog.Catalog
+
+	mu               sync.Mutex
+	beforeCommitErrs []error
+	afterCommitErrs  []error
+	afterCommitHook  func()
+	injectIdentifier icebergtable.Identifier
+}
+
+type commitBarrierCatalog struct {
+	icebergcatalog.Catalog
+	ready   chan struct{}
+	release chan struct{}
+}
+
+type conflictFirstOfTwoCatalog struct {
+	icebergcatalog.Catalog
+	mu              sync.Mutex
+	calls           int
+	firstReady      chan struct{}
+	secondCommitted chan struct{}
+}
+
+type eventuallyVisibleCommitCatalog struct {
+	icebergcatalog.Catalog
+
+	mu               sync.Mutex
+	unknown          error
+	invisibleLoads   int
+	invisibleLoadErr error
+	remainingLoads   int
+	failedLoads      int
+}
+
+func (c *eventuallyVisibleCommitCatalog) LoadTable(ctx context.Context, identifier icebergtable.Identifier) (*icebergtable.Table, error) {
+	c.mu.Lock()
+	if c.remainingLoads > 0 {
+		c.remainingLoads--
+		c.failedLoads++
+		err := c.invisibleLoadErr
+		c.mu.Unlock()
+		return nil, err
+	}
+	c.mu.Unlock()
+
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *eventuallyVisibleCommitCatalog) CommitTable(ctx context.Context, identifier icebergtable.Identifier, requirements []icebergtable.Requirement, updates []icebergtable.Update) (icebergtable.Metadata, string, error) {
+	metadata, location, err := c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+	if err != nil {
+		return metadata, location, err
+	}
+	c.mu.Lock()
+	c.remainingLoads = c.invisibleLoads
+	c.mu.Unlock()
+	return nil, "", c.unknown
+}
+
+func (c *eventuallyVisibleCommitCatalog) failedLoadCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.failedLoads
+}
+
+func (c *commitBarrierCatalog) LoadTable(ctx context.Context, identifier icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *commitBarrierCatalog) CommitTable(ctx context.Context, identifier icebergtable.Identifier, requirements []icebergtable.Requirement, updates []icebergtable.Update) (icebergtable.Metadata, string, error) {
+	c.ready <- struct{}{}
+	select {
+	case <-ctx.Done():
+		return nil, "", ctx.Err()
+	case <-c.release:
+		return c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+	}
+}
+
+func (c *conflictFirstOfTwoCatalog) LoadTable(ctx context.Context, identifier icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *conflictFirstOfTwoCatalog) CommitTable(
+	ctx context.Context,
+	identifier icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	c.mu.Lock()
+	c.calls++
+	call := c.calls
+	c.mu.Unlock()
+	switch call {
+	case 1:
+		close(c.firstReady)
+		select {
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		case <-c.secondCommitted:
+			return nil, "", icebergtable.ErrCommitFailed
+		}
+	case 2:
+		select {
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		case <-c.firstReady:
+		}
+		metadata, location, err := c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+		close(c.secondCommitted)
+		return metadata, location, err
+	default:
+		return c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+	}
+}
+
+func (c *commitOutcomeCatalog) LoadTable(ctx context.Context, identifier icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *commitOutcomeCatalog) CommitTable(ctx context.Context, identifier icebergtable.Identifier, requirements []icebergtable.Requirement, updates []icebergtable.Update) (icebergtable.Metadata, string, error) {
+	c.mu.Lock()
+	if len(c.beforeCommitErrs) > 0 && (len(c.injectIdentifier) == 0 || slices.Equal(c.injectIdentifier, identifier)) {
+		err := c.beforeCommitErrs[0]
+		c.beforeCommitErrs = c.beforeCommitErrs[1:]
+		c.mu.Unlock()
+		return nil, "", err
+	}
+	c.mu.Unlock()
+
+	metadata, location, err := c.Catalog.CommitTable(ctx, identifier, requirements, updates)
+	if err != nil {
+		return metadata, location, err
+	}
+	if c.afterCommitHook != nil && (len(c.injectIdentifier) == 0 || slices.Equal(c.injectIdentifier, identifier)) {
+		c.afterCommitHook()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.afterCommitErrs) > 0 && (len(c.injectIdentifier) == 0 || slices.Equal(c.injectIdentifier, identifier)) {
+		err := c.afterCommitErrs[0]
+		c.afterCommitErrs = c.afterCommitErrs[1:]
+		return nil, "", err
+	}
+	return metadata, location, nil
+}
+
+var (
+	_ icebergcatalog.Catalog               = (*commitOutcomeCatalog)(nil)
+	_ icebergcatalog.Catalog               = (*commitBarrierCatalog)(nil)
+	_ icebergcatalog.Catalog               = (*eventuallyVisibleCommitCatalog)(nil)
+	_ destination.CDCResumeProvider        = (*Destination)(nil)
+	_ destination.DurableCommitTokenWriter = (*Destination)(nil)
+)

--- a/pkg/destination/iceberg/config_platform_test.go
+++ b/pkg/destination/iceberg/config_platform_test.go
@@ -1,0 +1,317 @@
+package iceberg
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIcebergConfigCloudStorageShorthand(t *testing.T) {
+	tests := []struct {
+		name          string
+		uri           string
+		wantWarehouse string
+		wantLocation  string
+		wantProps     map[string]string
+	}{
+		{
+			name: "gcs",
+			uri: "iceberg+rest://catalog.internal:8181?catalog_use_ssl=true&storage=gcs&bucket=company-lake&prefix=prod" +
+				"&endpoint=localhost:4443&use_ssl=false&gcs_key_path=/var/run/gcp.json&gcs_credential_type=service_account" +
+				"&gcs_use_json_api=true&table_path={namespace}/{table}",
+			wantWarehouse: "gs://company-lake/prod/",
+			wantLocation:  "gs://company-lake/prod/{namespace}/{table}",
+			wantProps: map[string]string{
+				"type":           "rest",
+				"uri":            "https://catalog.internal:8181",
+				"gcs.endpoint":   "http://localhost:4443",
+				"gcs.keypath":    "/var/run/gcp.json",
+				"gcs.credtype":   "service_account",
+				"gcs.usejsonapi": "true",
+			},
+		},
+		{
+			name: "azure shared key",
+			uri: "iceberg+sqlite:///tmp/catalog.db?storage=azure&container=warehouse&account_name=devstoreaccount1" +
+				"&account_key=secret&prefix=prod&endpoint=127.0.0.1:10000&use_ssl=false&table_path={namespace}/{table}",
+			wantWarehouse: "abfss://warehouse@devstoreaccount1.dfs.core.windows.net/prod/",
+			wantLocation:  "abfss://warehouse@devstoreaccount1.dfs.core.windows.net/prod/{namespace}/{table}",
+			wantProps: map[string]string{
+				"type":                              "sql",
+				"adls.auth.shared-key.account.name": "devstoreaccount1",
+				"adls.auth.shared-key.account.key":  "secret",
+				"adls.endpoint":                     "127.0.0.1:10000",
+				"adls.protocol":                     "http",
+			},
+		},
+		{
+			name:          "gcs inline external account",
+			uri:           "iceberg+sqlite:///:memory:?storage=gcs&bucket=company-lake&gcs_json_key=%7B%22type%22%3A%22external_account%22%7D&gcs_credential_type=external_account",
+			wantWarehouse: "gs://company-lake/",
+			wantProps: map[string]string{
+				"gcs.jsonkey":  `{"type":"external_account"}`,
+				"gcs.credtype": "external_account",
+			},
+		},
+		{
+			name:          "azure sas with wasbs",
+			uri:           "iceberg+sqlite:///:memory:?storage=adls&bucket=warehouse&account_name=companylake&adls_scheme=wasbs&sas_token=sig%3Dsecret",
+			wantWarehouse: "wasbs://warehouse@companylake.blob.core.windows.net/",
+			wantProps: map[string]string{
+				"adls.sas-token.companylake.blob.core.windows.net": "sig=secret",
+			},
+		},
+		{
+			name:          "azure user assigned managed identity",
+			uri:           "iceberg+sqlite:///:memory:?storage=azure&container=warehouse&account_name=companylake&managed_identity=true&client_id=client-id",
+			wantWarehouse: "abfss://warehouse@companylake.dfs.core.windows.net/",
+			wantProps: map[string]string{
+				"adls.auth.managed-identity.enabled": "true",
+				"adls.client-id":                     "client-id",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseIcebergConfig(tt.uri)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantWarehouse, cfg.Properties["warehouse"])
+			require.Equal(t, tt.wantLocation, cfg.TableLocation)
+			for key, value := range tt.wantProps {
+				require.Equal(t, value, cfg.Properties[key], key)
+			}
+		})
+	}
+}
+
+func TestParseIcebergConfigRESTCatalogPresets(t *testing.T) {
+	tests := []struct {
+		name      string
+		uri       string
+		wantProps map[string]string
+		absent    []string
+	}{
+		{
+			name: "nessie",
+			uri:  "iceberg+nessie://nessie.internal:19120?nessie_branch=experiments&nessie_warehouse=sales",
+			wantProps: map[string]string{
+				"type": "rest",
+				"uri":  "http://nessie.internal:19120/iceberg/experiments%7Csales",
+			},
+		},
+		{
+			name: "nessie branch containing slash",
+			uri:  "iceberg+nessie://nessie.internal:19120?nessie_branch=feature%2Forders&storage=s3&bucket=client-io&region=us-east-1",
+			wantProps: map[string]string{
+				"type":      "rest",
+				"uri":       "http://nessie.internal:19120/iceberg/feature%2Forders",
+				"s3.region": "us-east-1",
+			},
+			absent: []string{"warehouse"},
+		},
+		{
+			name: "polaris",
+			uri: "iceberg+polaris://catalog.example.com?warehouse=production&oauth_client_id=client" +
+				"&oauth_client_secret=secret&scope=PRINCIPAL_ROLE:ALL&polaris_realm=POLARIS",
+			wantProps: map[string]string{
+				"type":                 "rest",
+				"uri":                  "https://catalog.example.com/api/catalog",
+				"warehouse":            "production",
+				"credential":           "client:secret",
+				"scope":                "PRINCIPAL_ROLE:ALL",
+				"header.Polaris-Realm": "POLARIS",
+			},
+		},
+		{
+			name: "s3 tables",
+			uri: "iceberg+s3tables://?region=us-east-1&warehouse=" +
+				url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"),
+			wantProps: map[string]string{
+				"type":                "rest",
+				"uri":                 "https://s3tables.us-east-1.amazonaws.com/iceberg",
+				"rest.sigv4-enabled":  "true",
+				"rest.signing-region": "us-east-1",
+				"rest.signing-name":   "s3tables",
+				"client.region":       "us-east-1",
+				"s3.region":           "us-east-1",
+				"glue.region":         "us-east-1",
+				"warehouse":           "arn:aws:s3tables:us-east-1:123456789012:bucket/analytics",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseIcebergConfig(tt.uri)
+			require.NoError(t, err)
+			for key, value := range tt.wantProps {
+				require.Equal(t, value, cfg.Properties[key], key)
+			}
+			for _, key := range tt.absent {
+				require.NotContains(t, cfg.Properties, key)
+			}
+		})
+	}
+}
+
+func TestNamedRESTCatalogRetainsStorageRootForPurgeJournals(t *testing.T) {
+	cfg, err := parseIcebergConfig("iceberg+nessie://nessie.internal:19120?storage=s3&bucket=client-io&prefix=warehouse")
+	require.NoError(t, err)
+	require.Empty(t, cfg.Properties["warehouse"], "named REST warehouse must not be replaced by a storage URI")
+	require.Equal(t, "s3://client-io/warehouse/", cfg.PurgeJournalRoot)
+}
+
+func TestParseIcebergConfigSpecializedSchemeCatalogTypeCannotBeOverridden(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		matching string
+		conflict string
+	}{
+		{name: "sqlite", uri: "iceberg+sqlite:///:memory:?warehouse_path=/tmp/warehouse", matching: "sqlite", conflict: "rest"},
+		{name: "postgres", uri: "iceberg+postgres://user@catalog.internal/db?warehouse_path=/tmp/warehouse", matching: "postgres", conflict: "rest"},
+		{name: "rest", uri: "iceberg+rest://catalog.internal:8181?warehouse_path=/tmp/warehouse", matching: "rest", conflict: "hadoop"},
+		{name: "nessie", uri: "iceberg+nessie://nessie.internal:19120?nessie_branch=main", matching: "nessie", conflict: "hadoop"},
+		{name: "polaris", uri: "iceberg+polaris://catalog.example.com?warehouse=production", matching: "polaris", conflict: "hadoop"},
+		{
+			name: "s3 tables",
+			uri: "iceberg+s3tables://?region=us-east-1&warehouse=" +
+				url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"),
+			matching: "s3tables",
+			conflict: "hadoop",
+		},
+		{name: "glue", uri: "iceberg+glue://?region=us-east-1&warehouse_path=/tmp/warehouse", matching: "glue", conflict: "hadoop"},
+		{name: "hive", uri: "iceberg+hive://catalog.internal:9083?warehouse_path=/tmp/warehouse", matching: "hive", conflict: "hadoop"},
+		{name: "hadoop", uri: "iceberg+hadoop:///tmp/warehouse?warehouse=/tmp/warehouse", matching: "hadoop", conflict: "rest"},
+		{name: "sql", uri: "iceberg+sql://?uri=file:/tmp/catalog.db&sql.driver=sqlite&sql.dialect=sqlite&warehouse_path=/tmp/warehouse", matching: "sql", conflict: "rest"},
+	}
+
+	for _, tt := range tests {
+		for _, key := range []string{"catalog", "type"} {
+			t.Run(tt.name+" matching "+key, func(t *testing.T) {
+				cfg, err := parseIcebergConfig(tt.uri + "&" + key + "=" + tt.matching)
+				require.NoError(t, err)
+				require.Equal(t, normalizeCatalogType(tt.matching), cfg.Properties["type"])
+			})
+
+			t.Run(tt.name+" conflicting "+key, func(t *testing.T) {
+				_, err := parseIcebergConfig(tt.uri + "&" + key + "=" + tt.conflict)
+				require.ErrorContains(t, err, "conflicts with the URI scheme")
+				require.ErrorContains(t, err, key+"=")
+			})
+		}
+	}
+}
+
+func TestParseIcebergConfigGenericSchemeAcceptsCatalogTypeSelection(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{name: "catalog alias", uri: "iceberg://?catalog=sqlite", want: "sql"},
+		{name: "type", uri: "iceberg://?type=hadoop", want: "hadoop"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseIcebergConfig(tt.uri)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, cfg.Properties["type"])
+		})
+	}
+}
+
+func TestParseIcebergConfigRejectsInvalidPlatformShorthand(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{
+			name:    "gcs credential type",
+			uri:     "iceberg+sqlite:///:memory:?storage=gcs&bucket=lake&gcs_credential_type=magic",
+			wantErr: `invalid gcs_credential_type "magic"`,
+		},
+		{
+			name:    "gcs credentials conflict",
+			uri:     "iceberg+sqlite:///:memory:?storage=gcs&bucket=lake&gcs_json_key={}&gcs_key_path=/key.json",
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "missing object location",
+			uri:     "iceberg+rest://catalog?storage=gcs",
+			wantErr: "requires bucket/container or an explicit warehouse",
+		},
+		{
+			name:    "azure account",
+			uri:     "iceberg+sqlite:///:memory:?storage=azure&container=lake",
+			wantErr: "account_name is required",
+		},
+		{
+			name:    "azure authentication conflict",
+			uri:     "iceberg+sqlite:///:memory:?storage=azure&container=lake&account_name=account&account_key=key&managed_identity=true",
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "endpoint TLS conflict",
+			uri:     "iceberg+sqlite:///:memory:?storage=gcs&bucket=lake&endpoint=https://localhost:4443&use_ssl=false",
+			wantErr: "conflicts with use_ssl=false",
+		},
+		{
+			name:    "oauth pair",
+			uri:     "iceberg+polaris://catalog.example.com?warehouse=prod&oauth_client_id=client",
+			wantErr: "must be provided together",
+		},
+		{
+			name:    "nessie prefix",
+			uri:     "iceberg+nessie://nessie.internal:19120?catalog_prefix=main",
+			wantErr: "selected with nessie_branch",
+		},
+		{
+			name:    "nessie warehouse property",
+			uri:     "iceberg+nessie://nessie.internal:19120?warehouse=s3://lake/path",
+			wantErr: "selected with nessie_warehouse",
+		},
+		{
+			name:    "polaris warehouse",
+			uri:     "iceberg+polaris://catalog.example.com",
+			wantErr: "requires warehouse",
+		},
+		{
+			name:    "polaris storage bucket is not catalog name",
+			uri:     "iceberg+polaris://catalog.example.com?storage=s3&bucket=data-lake",
+			wantErr: "requires warehouse",
+		},
+		{
+			name:    "s3 tables region",
+			uri:     "iceberg+s3tables://?warehouse=arn:aws:s3tables:us-east-1:123:bucket/lake",
+			wantErr: "requires region",
+		},
+		{
+			name:    "s3 tables warehouse",
+			uri:     "iceberg+s3tables://?region=us-east-1&warehouse=s3://lake",
+			wantErr: "requires an S3 Tables bucket ARN",
+		},
+		{
+			name:    "s3 tables region mismatch",
+			uri:     "iceberg+s3tables://?region=us-east-1&warehouse=arn:aws:s3tables:eu-west-1:123456789012:bucket/analytics",
+			wantErr: `warehouse region "eu-west-1" does not match signing region "us-east-1"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseIcebergConfig(tt.uri)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestParseIcebergConfigPartitionSpec(t *testing.T) {
+	cfg, err := parseIcebergConfig("iceberg+sqlite:///:memory:?partition_spec=id,day(created_at),bucket%5B16%5D(customer_id)")
+	require.NoError(t, err)
+	require.Equal(t, "id,day(created_at),bucket[16](customer_id)", cfg.PartitionSpec)
+	require.NotContains(t, cfg.Properties, "partition_spec")
+	require.NotContains(t, cfg.Properties, "partition-spec")
+}

--- a/pkg/destination/iceberg/copy_on_write_test.go
+++ b/pkg/destination/iceberg/copy_on_write_test.go
@@ -1,0 +1,584 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectCopyOnWriteMergeSpillsAndPreservesClustering(t *testing.T) {
+	forceCopyOnWriteSpills(t)
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.merge.mode=copy-on-write"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+
+	ctx := context.Background()
+	target := "lake.cow_spill.direct"
+	tableSchema := sortAuditSchema()
+	initial := make([][]any, 0, 24)
+	for id := int64(0); id < 24; id++ {
+		initial = append(initial, []any{id, 100 - id, id})
+	}
+	prepareClusteredTable(t, dest, target, tableSchema, []string{"cluster_key"}, false, initial)
+
+	updates := make([][]any, 0, 30)
+	for id := int64(12); id < 36; id++ {
+		updates = append(updates, []any{id, 200 - id, id})
+		if id%3 == 0 {
+			updates = append(updates, []any{id, 300 - id, id + 100})
+		}
+	}
+	merge := func() {
+		batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), updates)
+		require.NoError(t, err)
+		require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: target, Schema: tableSchema, Parallelism: 4,
+		}, destination.MergeOptions{
+			TargetTable: target, PrimaryKeys: []string{"id"}, IncrementalKey: "updated_at",
+			Columns: tableSchema.ColumnNames(), CommitToken: "forced-cow-spill",
+		}))
+	}
+
+	merge()
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 36)
+	require.Equal(t, int64(288), rows[int64(12)][1])
+	require.Equal(t, int64(112), rows[int64(12)][2])
+	firstSnapshots := icebergSnapshotCount(t, dest, target)
+	merge()
+	require.Equal(t, firstSnapshots, icebergSnapshotCount(t, dest, target))
+	assertPhysicalSortOrder(t, dest, target)
+	assertNoCopyOnWriteSpills(t)
+}
+
+func TestCopyOnWriteRetryRejectsRecreatedTargetWithMatchingToken(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table.write.merge.mode": []string{"copy-on-write"},
+	})
+	ctx := context.Background()
+	target := "lake.cow_retry_recreated.target"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	original, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	const token = "cow-recreated-target-token"
+	dest.catalog = &recreateWithCommitTokenOnConflictCatalog{
+		Catalog: dest.catalog,
+		schema:  tableSchema,
+		token:   token,
+	}
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "after", 2.0, int64(2)},
+	})
+	require.NoError(t, err)
+
+	err = dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: tableSchema,
+		CDCExpectedIncarnation: original.Metadata().TableUUID().String(),
+	}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, IncrementalKey: "updated_at",
+		Columns: tableSchema.ColumnNames(), CommitToken: token,
+	})
+	require.ErrorContains(t, err, "incarnation changed")
+	recreated, loadErr := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, loadErr)
+	require.NotEqual(t, original.Metadata().TableUUID(), recreated.Metadata().TableUUID())
+}
+
+func TestCopyOnWriteDerivedTokenFastPathRejectsRecreatedTarget(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table.write.merge.mode": []string{"copy-on-write"},
+	})
+	ctx := context.Background()
+	target := "lake.cow_derived_token_recreated.target"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	merge := func(expectedIncarnation string) error {
+		batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+			{int64(1), "after", 2.0, int64(2)},
+		})
+		require.NoError(t, err)
+		return dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: target, Schema: tableSchema, CDCExpectedIncarnation: expectedIncarnation,
+		}, destination.MergeOptions{
+			TargetTable: target, PrimaryKeys: []string{"id"}, IncrementalKey: "updated_at",
+			Columns: tableSchema.ColumnNames(), CDCExpectedIncarnation: expectedIncarnation,
+		})
+	}
+	require.NoError(t, merge(""))
+	original, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	dest.catalog = &recreateOnNthLoadCatalog{
+		Catalog: dest.catalog, schema: tableSchema, recreateAt: 3,
+	}
+
+	err = merge(original.Metadata().TableUUID().String())
+	require.ErrorContains(t, err, "incarnation changed")
+	recreated, loadErr := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, loadErr)
+	require.NotEqual(t, original.Metadata().TableUUID(), recreated.Metadata().TableUUID())
+}
+
+func TestCopyOnWriteMergePreservesV3Lineage(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table.format-version":   []string{"3"},
+		"table.write.merge.mode": []string{"copy-on-write"},
+	})
+	ctx := context.Background()
+	target := "lake.cow_lineage.target"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), "before", 1.0, int64(1)},
+		{int64(2), "untouched", 2.0, int64(1)},
+	})
+	before, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	lineageBefore := readV3LineageByID(t, before)
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "after", 10.0, int64(2)},
+		{int64(3), "inserted", 3.0, int64(2)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: target, Schema: tableSchema}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, IncrementalKey: "updated_at", Columns: tableSchema.ColumnNames(),
+	}))
+	after, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	lineageAfter := readV3LineageByID(t, after)
+	require.Equal(t, lineageBefore[int64(2)], lineageAfter[int64(2)], "untouched rows preserve complete lineage")
+	require.Equal(t, lineageBefore[int64(1)][0], lineageAfter[int64(1)][0], "updated rows preserve row identity")
+	require.Greater(t, lineageAfter[int64(1)][1], lineageBefore[int64(1)][1], "updated rows receive a new sequence")
+	require.NotEqual(t, lineageAfter[int64(1)][0], lineageAfter[int64(3)][0], "inserted rows receive a new identity")
+}
+
+func TestMergeRetriesConcurrentNonOverlappingCommitConflict(t *testing.T) {
+	for _, copyOnWrite := range []bool{false, true} {
+		t.Run(fmt.Sprintf("copy_on_write_%t", copyOnWrite), func(t *testing.T) {
+			uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir())
+			if copyOnWrite {
+				uri += "&table.write.merge.mode=copy-on-write"
+			}
+			dest := NewDestination()
+			require.NoError(t, dest.Connect(context.Background(), uri))
+			t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+			ctx := context.Background()
+			target := fmt.Sprintf("lake.concurrent_retry.mode_%t", copyOnWrite)
+			tableSchema := mergeTestSchema()
+			writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "initial", 1.0, int64(1)}})
+			dest.catalog = &conflictFirstOfTwoCatalog{
+				Catalog: dest.catalog, firstReady: make(chan struct{}), secondCommitted: make(chan struct{}),
+			}
+			errs := make(chan error, 2)
+			for _, id := range []int64{2, 3} {
+				id := id
+				go func() {
+					batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{id, fmt.Sprintf("row-%d", id), float64(id), id}})
+					if err == nil {
+						err = dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: target, Schema: tableSchema}, destination.MergeOptions{
+							TargetTable: target, PrimaryKeys: []string{"id"}, Columns: tableSchema.ColumnNames(), CommitToken: fmt.Sprintf("retry-%d", id),
+						})
+					}
+					errs <- err
+				}()
+			}
+			require.NoError(t, <-errs)
+			require.NoError(t, <-errs)
+			require.Len(t, readTableRows(t, dest, target).Rows, 3)
+		})
+	}
+}
+
+func TestCopyOnWriteMergeRejectsDuplicateTargetKeysBeforeCommit(t *testing.T) {
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.merge.mode=copy-on-write"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	ctx := context.Background()
+	target, staging := "lake.cow_duplicates.target", "lake.cow_duplicates.staging"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), "first", 1.0, int64(1)},
+		{int64(1), "duplicate", 2.0, int64(2)},
+	})
+	writeTableRows(t, dest, staging, tableSchema, true, [][]any{{int64(1), "update", 3.0, int64(3)}})
+	before := icebergSnapshotCount(t, dest, target)
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		TargetTable: target, StagingTable: staging, PrimaryKeys: []string{"id"},
+		IncrementalKey: "updated_at", Columns: tableSchema.ColumnNames(),
+	})
+	require.ErrorContains(t, err, "contains duplicate primary key")
+	require.Equal(t, before, icebergSnapshotCount(t, dest, target))
+	require.Len(t, readTableRows(t, dest, target).Rows, 2)
+}
+
+func TestDirectCDCEqualCursorUsesContentIdentity(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow_content.equal_cursor"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+
+	merge := func(id int64, name string) {
+		t.Helper()
+		batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{
+			{id, name, "payload", "0/100", false, int64(100), nil},
+		})
+		require.NoError(t, err)
+		require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: target, Schema: inputSchema,
+		}, destination.MergeOptions{
+			TargetTable: target, PrimaryKeys: []string{"id"}, Columns: inputSchema.ColumnNames(),
+		}))
+	}
+
+	merge(1, "first")
+	merge(2, "second")
+	require.Len(t, readTableRows(t, dest, target).Rows, 2)
+	afterDistinct := icebergSnapshotCount(t, dest, target)
+	merge(2, "second")
+	require.Equal(t, afterDistinct, icebergSnapshotCount(t, dest, target))
+}
+
+func TestDirectCDCContentIdentityIgnoresIndependentKeyOrder(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow_content.key_order"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+	merge := func(rows [][]any) {
+		batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), rows)
+		require.NoError(t, err)
+		require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: target, Schema: inputSchema,
+		}, destination.MergeOptions{
+			TargetTable: target, PrimaryKeys: []string{"id"}, Columns: inputSchema.ColumnNames(),
+		}))
+	}
+	first := []any{int64(1), "first", "one", "0/100", false, int64(100), nil}
+	second := []any{int64(2), "second", "two", "0/100", false, int64(100), nil}
+	merge([][]any{first, second})
+	beforeRetry := icebergSnapshotCount(t, dest, target)
+	merge([][]any{second, first})
+	require.Equal(t, beforeRetry, icebergSnapshotCount(t, dest, target))
+}
+
+func TestCDCDeleteWinsEqualLSNTieInBothOrdersWithSpill(t *testing.T) {
+	forceCopyOnWriteSpills(t)
+	for _, deleteFirst := range []bool{true, false} {
+		t.Run(fmt.Sprintf("delete_first_%t", deleteFirst), func(t *testing.T) {
+			dest := newHadoopDestination(t)
+			ctx := context.Background()
+			target := fmt.Sprintf("lake.cow_tie.order_%t", deleteFirst)
+			inputSchema := cdcSchema(true)
+			targetSchema := destination.DestinationTableSchema(inputSchema)
+			require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+				Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+			}))
+			update := []any{int64(1), "updated", "payload", "0/100", false, int64(100), nil}
+			deleted := []any{int64(1), nil, nil, "0/100", true, int64(101), nil}
+			rows := [][]any{update, deleted}
+			if deleteFirst {
+				rows = [][]any{deleted, update}
+			}
+			batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), rows)
+			require.NoError(t, err)
+			require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+				Table: target, Schema: inputSchema,
+			}, destination.MergeOptions{
+				TargetTable: target, PrimaryKeys: []string{"id"}, Columns: inputSchema.ColumnNames(),
+			}))
+			got := readTableRows(t, dest, target)
+			require.Len(t, got.Rows, 1)
+			require.Equal(t, true, got.Value(got.Rows[0], destination.CDCDeletedColumn))
+			require.Equal(t, "updated", got.Value(got.Rows[0], "name"))
+		})
+	}
+}
+
+func TestDirectCDCRejectsAnyStaleEventBeforeCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow_content.stale_event"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "checkpoint", "0/100"))
+	before := icebergSnapshotCount(t, dest, target)
+
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{
+		{int64(1), "stale", "payload", "0/090", false, int64(90), nil},
+		{int64(2), "newer", "payload", "0/110", false, int64(110), nil},
+	})
+	require.NoError(t, err)
+	err = dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: inputSchema,
+	}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: inputSchema.ColumnNames(),
+	})
+	require.ErrorContains(t, err, "stale CDC resume position in event")
+	require.Equal(t, before, icebergSnapshotCount(t, dest, target))
+	require.Empty(t, readTableRows(t, dest, target).Rows)
+}
+
+func TestCDCUnchangedColumnsMatchCaseInsensitively(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target, staging := "lake.cow_case.target", "lake.cow_case.staging"
+	targetSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "Payload", DataType: schema.TypeString, Nullable: true},
+		{Name: destination.CDCLSNColumn, DataType: schema.TypeString, Nullable: true},
+		{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: true},
+		{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+	}}
+	stagingSchema := &schema.TableSchema{Columns: append([]schema.Column(nil), targetSchema.Columns...)}
+	for i := range stagingSchema.Columns {
+		if destination.IsCDCMetaColumn(stagingSchema.Columns[i].Name) {
+			stagingSchema.Columns[i].Name = strings.ToUpper(stagingSchema.Columns[i].Name)
+		}
+	}
+	stagingSchema.Columns = append(stagingSchema.Columns, schema.Column{
+		Name: strings.ToUpper(destination.CDCUnchangedColsColumn), DataType: schema.TypeString, Nullable: true,
+	})
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{
+		{int64(1), "keep", "0/100", false, int64(100)},
+	})
+	writeTableRows(t, dest, staging, stagingSchema, true, [][]any{
+		{int64(1), nil, "0/110", false, int64(110), `["payload"]`},
+	})
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		TargetTable: target, StagingTable: staging, PrimaryKeys: []string{"id"}, Columns: stagingSchema.ColumnNames(),
+	}))
+	rows := readTableRows(t, dest, target)
+	require.Equal(t, "keep", rows.Value(rows.Rows[0], "Payload"))
+}
+
+func TestDirectCDCMixedCaseMetadataUsesCDCValidation(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow_case.direct_metadata"
+	targetSchema := cdcSchema(false)
+	inputSchema := cdcSchema(true)
+	for i := range inputSchema.Columns {
+		if destination.IsCDCMetaColumn(inputSchema.Columns[i].Name) || destination.IsCDCStagingOnlyColumn(inputSchema.Columns[i].Name) {
+			inputSchema.Columns[i].Name = strings.ToUpper(inputSchema.Columns[i].Name)
+		}
+	}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "mixed-case-checkpoint", "0/100"))
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{
+		{int64(1), "stale", "payload", "0/090", false, int64(90), nil},
+		{int64(2), "newer", "payload", "0/110", false, int64(110), nil},
+	})
+	require.NoError(t, err)
+	err = dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: inputSchema,
+	}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: inputSchema.ColumnNames(),
+	})
+	require.ErrorContains(t, err, "stale CDC resume position in event")
+	require.Empty(t, readTableRows(t, dest, target).Rows)
+}
+
+func TestCopyOnWriteRetriesDefiniteCommitFailureAndRemovesFirstAttemptFiles(t *testing.T) {
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.merge.mode=copy-on-write"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	ctx := context.Background()
+	target, staging := "lake.cow_cleanup.target", "lake.cow_cleanup.staging"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	writeTableRows(t, dest, staging, tableSchema, true, [][]any{{int64(1), "after", 2.0, int64(2)}})
+	before := allTableParquetFiles(t, dest, target)
+	base := dest.catalog
+	dest.catalog = &failNthCommitCatalog{Catalog: base, failAt: 1, err: icebergtable.ErrCommitFailed}
+
+	err := dest.MergeTable(ctx, destination.MergeOptions{
+		TargetTable: target, StagingTable: staging, PrimaryKeys: []string{"id"},
+		IncrementalKey: "updated_at", Columns: tableSchema.ColumnNames(),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, before, allTableParquetFiles(t, dest, target))
+	require.Len(t, allTableParquetFiles(t, dest, target), len(before)+1)
+}
+
+func TestCopyOnWriteCancellationRemovesGeneratedFiles(t *testing.T) {
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir()) + "&table.write.target-file-size-bytes=1"
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	target := "lake.cow_cleanup.canceled"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	before := allTableParquetFiles(t, dest, target)
+	tbl, err := dest.loadIcebergTable(context.Background(), target)
+	require.NoError(t, err)
+	first, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(1), "after", 2.0, int64(2)}})
+	require.NoError(t, err)
+	second, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(2), "new", 3.0, int64(3)}})
+	require.NoError(t, err)
+	batches := append(first, second...)
+	inner, err := array.NewRecordReader(icebergArrowSchema(tableSchema), batches)
+	require.NoError(t, err)
+	defer inner.Release()
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := &cancelAfterRecordReader{RecordReader: inner, cancel: cancel, cancelAt: 2}
+	err = dest.replaceAllMergeRecords(ctx, tbl, reader, nil, destination.MergeOptions{TargetTable: target}, newCommitMetadata("cancel-cleanup", ""))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, before, allTableParquetFiles(t, dest, target))
+}
+
+func allTableParquetFiles(t *testing.T, dest *Destination, table string) []string {
+	t.Helper()
+	tbl, err := dest.loadIcebergTable(context.Background(), table)
+	require.NoError(t, err)
+	root := strings.TrimPrefix(tbl.Location(), "file://")
+	var files []string
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err == nil && !entry.IsDir() && strings.HasSuffix(path, ".parquet") {
+			files = append(files, path)
+		}
+		return err
+	}))
+	slices.Sort(files)
+	return files
+}
+
+func TestClusterRecordReaderCancellationCleansSpills(t *testing.T) {
+	forceCopyOnWriteSpills(t)
+	sc := icebergArrowSchema(sortAuditSchema())
+	rows := make([][]any, 0, 20)
+	for i := int64(0); i < 20; i++ {
+		rows = append(rows, []any{i, 20 - i, i})
+	}
+	batches, err := buildRecordBatches(sc, rows)
+	require.NoError(t, err)
+	inner, err := array.NewRecordReader(sc, batches)
+	require.NoError(t, err)
+	defer inner.Release()
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := &cancelAfterRecordReader{RecordReader: inner, cancel: cancel}
+
+	_, _, err = clusterRecordReader(ctx, reader, []string{"cluster_key"})
+	require.ErrorIs(t, err, context.Canceled)
+	assertNoCopyOnWriteSpills(t)
+}
+
+type cancelAfterRecordReader struct {
+	array.RecordReader
+	cancel   context.CancelFunc
+	cancelAt int
+	seen     int
+}
+
+func (r *cancelAfterRecordReader) Next() bool {
+	next := r.RecordReader.Next()
+	if next {
+		r.seen++
+	}
+	if next && (r.cancelAt == 0 || r.seen == r.cancelAt) {
+		r.cancel()
+	}
+	return next
+}
+
+func TestSpillIterationStopsAfterCancellation(t *testing.T) {
+	forceCopyOnWriteSpills(t)
+	sorter, err := newSpillSorter(icebergArrowSchema(sortAuditSchema()), []string{"id"})
+	require.NoError(t, err)
+	defer sorter.Close()
+	for i := int64(0); i < 20; i++ {
+		require.NoError(t, sorter.Add([]any{i, i, i}))
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	it, err := sorter.IterContext(ctx)
+	require.NoError(t, err)
+	cancel()
+	require.False(t, it.NextGroup())
+	require.ErrorIs(t, it.Err(), context.Canceled)
+	it.Close()
+	sorter.Close()
+	require.Eventually(t, func() bool {
+		spills, _ := filepath.Glob(filepath.Join(os.TempDir(), "ingestr-iceberg-spill-*"))
+		return len(spills) == 0
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, errors.Is(ctx.Err(), context.Canceled))
+}
+
+func TestDirectCopyOnWriteMergeFailureCleansSpillsAndDoesNotCommit(t *testing.T) {
+	forceCopyOnWriteSpills(t)
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow_spill.failure"
+	inputSchema := cdcSchema(true)
+	targetSchema := cdcSchema(false)
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{
+		{int64(1), "one", "payload-1", "0/1", false, int64(1)},
+		{int64(2), "two", "payload-2", "0/1", false, int64(1)},
+		{int64(3), "three", "payload-3", "0/1", false, int64(1)},
+	})
+	beforeSnapshots := icebergSnapshotCount(t, dest, target)
+
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{
+		{int64(1), "updated", nil, "0/10", false, int64(10), `not-json`},
+		{int64(2), "updated", nil, "0/11", false, int64(11), `not-json`},
+		{int64(4), "new", "payload-4", "0/12", false, int64(12), nil},
+	})
+	require.NoError(t, err)
+	err = dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: inputSchema,
+	}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: inputSchema.ColumnNames(),
+		CommitToken: "forced-cow-failure",
+	})
+	require.ErrorContains(t, err, "invalid character")
+	require.Equal(t, beforeSnapshots, icebergSnapshotCount(t, dest, target))
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "one", rows[int64(1)][1])
+	assertNoCopyOnWriteSpills(t)
+}
+
+func forceCopyOnWriteSpills(t *testing.T) {
+	t.Helper()
+	oldRows, oldFanIn := spillRunRows, spillMergeFanIn
+	spillRunRows, spillMergeFanIn = 2, 2
+	t.Cleanup(func() {
+		spillRunRows, spillMergeFanIn = oldRows, oldFanIn
+	})
+	t.Setenv("TMPDIR", t.TempDir())
+}
+
+func assertNoCopyOnWriteSpills(t *testing.T) {
+	t.Helper()
+	spills, err := filepath.Glob(filepath.Join(os.TempDir(), "ingestr-iceberg-spill-*"))
+	require.NoError(t, err)
+	require.Empty(t, spills)
+}

--- a/pkg/destination/iceberg/direct_merge_test.go
+++ b/pkg/destination/iceberg/direct_merge_test.go
@@ -1,0 +1,265 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeRecordsDirectRowDeltaAvoidsStagingTable(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.target"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), "before", 1.0, int64(1)},
+	})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "after", 2.0, int64(2)},
+		{int64(2), "new", 3.0, int64(2)},
+	})
+	require.NoError(t, err)
+	opts := destination.MergeOptions{
+		TargetTable:    target,
+		PrimaryKeys:    []string{"id"},
+		Columns:        tableSchema.ColumnNames(),
+		IncrementalKey: "updated_at",
+		Schema:         tableSchema,
+		CommitToken:    "t1",
+	}
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: tableSchema, Parallelism: 3,
+	}, opts))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, "after", rows[int64(1)][1])
+	require.Equal(t, "new", rows[int64(2)][1])
+	require.Equal(t, commitTokenID(opts.CommitToken), latestSnapshotSummary(t, dest, target)[snapshotCommitTokenKey])
+	firstSnapshotCount := icebergSnapshotCount(t, dest, target)
+
+	retry, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "after", 2.0, int64(2)},
+		{int64(2), "new", 3.0, int64(2)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(retry...), destination.WriteOptions{
+		Table: target, Schema: tableSchema,
+	}, opts))
+	require.Len(t, readTableRows(t, dest, target).Rows, 2)
+	require.Equal(t, firstSnapshotCount, icebergSnapshotCount(t, dest, target))
+}
+
+func TestDirectMergePersistsBatchlessDurablePosition(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.empty_checkpoint"
+	tableSchema := cdcSchema(true)
+	writeTableRows(t, dest, target, destination.DestinationTableSchema(tableSchema), false, nil)
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{DurableCommitPosition: "0/ABC"}
+	close(records)
+
+	require.NoError(t, dest.MergeRecords(ctx, records, destination.WriteOptions{
+		Table: target, Schema: tableSchema,
+	}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: tableSchema.ColumnNames(), Schema: tableSchema,
+	}))
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, "0/ABC", resume)
+}
+
+func TestMergeRecordsDirectCDCPersistsResumeCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.cdc_target"
+	stagingSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(stagingSchema)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+
+	batches, err := buildRecordBatches(icebergArrowSchema(stagingSchema), [][]any{
+		{int64(1), "one", "payload", "0/10", false, int64(10), nil},
+		{int64(2), "two", "payload", "0/20", false, int64(20), nil},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: stagingSchema, Parallelism: 2,
+	}, destination.MergeOptions{
+		TargetTable: target,
+		PrimaryKeys: []string{"id"},
+		Columns:     destination.MergeColumnsFor(dest, stagingSchema.ColumnNames()),
+		Schema:      stagingSchema,
+		CommitToken: "t1",
+	}))
+
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, "0/20", resume)
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, target))
+}
+
+func TestMergeRecordsManagedCDCReplayDoesNotRegressRowsOrGlobalCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.managed_replay"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	syncedAt := micros(time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{
+		{int64(1), "newer", "newer-payload", "0/400", false, syncedAt},
+	})
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "legacy-cursor", "0/400"))
+
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{
+		{int64(1), "stale", "stale-payload", "0/350", false, syncedAt - 2, nil},
+		{int64(2), "replayed-new-key", "payload", "0/350", false, syncedAt - 1, nil},
+	})
+	require.NoError(t, err)
+	opts := destination.MergeOptions{
+		TargetTable:   target,
+		PrimaryKeys:   []string{"id"},
+		Columns:       destination.MergeColumnsFor(dest, inputSchema.ColumnNames()),
+		Schema:        inputSchema,
+		CDCResumeLSN:  "0/350",
+		SkipCDCResume: true,
+	}
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: inputSchema, SkipCDCResume: true,
+	}, opts))
+
+	got := readTableRows(t, dest, target)
+	rows := singleRowByKey(t, got, "id")
+	require.Equal(t, "newer", got.Value(rows[int64(1)], "name"))
+	require.Equal(t, "0/400", got.Value(rows[int64(1)], destination.CDCLSNColumn))
+	require.Equal(t, "replayed-new-key", got.Value(rows[int64(2)], "name"))
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+}
+
+func TestMergeRecordsManagedCDCAlreadyCommittedTokenClearsLegacyCursor(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.managed_same_token"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	writeTableRows(t, dest, target, targetSchema, false, [][]any{{int64(1), "committed", "payload", "0/200", false, int64(200)}})
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "managed-direct-same-token", "0/400"))
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{{int64(1), "replay", "payload", "0/200", false, int64(200), nil}})
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: target, Schema: inputSchema, SkipCDCResume: true}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: destination.MergeColumnsFor(dest, inputSchema.ColumnNames()),
+		Schema: inputSchema, CommitToken: "managed-direct-same-token", SkipCDCResume: true,
+	}))
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, target))
+}
+
+func TestMergeRecordsDirectSnapshotChunksPublishCursorOnlyOnFinalChunk(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.cdc_snapshot_chunks"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+
+	writeChunk := func(row []any, token, resume string, skip bool) {
+		t.Helper()
+		batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{row})
+		require.NoError(t, err)
+		require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: target, Schema: inputSchema, CommitToken: token, CDCResumeLSN: resume, SkipCDCResume: skip,
+		}, destination.MergeOptions{
+			TargetTable:   target,
+			PrimaryKeys:   []string{"id"},
+			Columns:       destination.MergeColumnsFor(dest, inputSchema.ColumnNames()),
+			Schema:        inputSchema,
+			CommitToken:   token,
+			CDCResumeLSN:  resume,
+			SkipCDCResume: skip,
+		}))
+	}
+
+	writeChunk([]any{int64(1), "one", "payload-1", "0/100", false, int64(10), nil}, "snapshot-page-1", "", true)
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, resume)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, target))
+
+	writeChunk([]any{int64(2), "two", "payload-2", "0/100", false, int64(11), nil}, "snapshot-page-final", "0/100", false)
+	resume, err = dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, "0/100", resume)
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, target))
+}
+
+func TestMergeRecordsDirectCommitsRowAtSnapshotBoundaryExactlyOnce(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.direct_merge.snapshot_wal_boundary"
+	inputSchema := cdcSchema(true)
+	targetSchema := destination.DestinationTableSchema(inputSchema)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: targetSchema, PrimaryKeys: []string{"id"},
+	}))
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "snapshot-final", "0/100"))
+
+	mergeRow := func(row []any, token, resume string) error {
+		t.Helper()
+		batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{row})
+		require.NoError(t, err)
+		return dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+			Table: target, Schema: inputSchema, CommitToken: token, CDCResumeLSN: resume,
+		}, destination.MergeOptions{
+			TargetTable:  target,
+			PrimaryKeys:  []string{"id"},
+			Columns:      destination.MergeColumnsFor(dest, inputSchema.ColumnNames()),
+			Schema:       inputSchema,
+			CommitToken:  token,
+			CDCResumeLSN: resume,
+		})
+	}
+
+	boundaryToken := "wal:public.events:0/100"
+	boundaryRow := []any{int64(1), "boundary", "payload", "0/100", false, int64(100), nil}
+	require.NoError(t, mergeRow(boundaryRow, boundaryToken, "0/100"))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, target))
+	boundarySnapshotCount := icebergSnapshotCount(t, dest, target)
+
+	// The transaction token, rather than its cursor, identifies a retry.
+	require.NoError(t, mergeRow(boundaryRow, boundaryToken, "0/100"))
+	require.Equal(t, boundarySnapshotCount, icebergSnapshotCount(t, dest, target))
+
+	// A retry remains a no-op even after a later checkpoint has advanced the
+	// cursor beyond the transaction's position.
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "checkpoint-0-101", "0/101"))
+	advancedSnapshotCount := icebergSnapshotCount(t, dest, target)
+	require.NoError(t, mergeRow(boundaryRow, boundaryToken, "0/100"))
+	require.Equal(t, advancedSnapshotCount, icebergSnapshotCount(t, dest, target))
+
+	// A different transaction whose position is genuinely older is rejected,
+	// including when the destination derives its cursor from the row data.
+	err := mergeRow(
+		[]any{int64(2), "stale", "payload", "0/FF", false, int64(99), nil},
+		"wal:public.events:0/FF",
+		"",
+	)
+	require.ErrorContains(t, err, "stale CDC resume position")
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, target))
+	require.Equal(t, advancedSnapshotCount, icebergSnapshotCount(t, dest, target))
+}

--- a/pkg/destination/iceberg/evolve_reconcile_test.go
+++ b/pkg/destination/iceberg/evolve_reconcile_test.go
@@ -1,0 +1,135 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplySchemaEvolutionReconcilesUnknownCommitOutcome(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "evolution.unknown_commit"
+	initial := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "widened", DataType: schema.TypeInt32, Nullable: false},
+		{Name: "removed", DataType: schema.TypeString, Nullable: false},
+		{Name: "relaxed", DataType: schema.TypeString, Nullable: false},
+	}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: initial}))
+
+	unknown := errors.New("schema commit response lost")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, afterCommitErrs: []error{unknown}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
+		{
+			Type: schemaevolution.ChangeWidenType, ColumnName: "widened", OldColumn: &initial.Columns[0],
+			NewColumn: schema.Column{Name: "widened", DataType: schema.TypeInt64, Nullable: true},
+		},
+		{Type: schemaevolution.ChangeRemoveColumn, ColumnName: "removed", OldColumn: &initial.Columns[1]},
+		{
+			Type: schemaevolution.ChangeRelaxNullability, ColumnName: "relaxed", OldColumn: &initial.Columns[2],
+			NewColumn: schema.Column{Name: "relaxed", DataType: schema.TypeString, Nullable: true},
+		},
+		{
+			Type: schemaevolution.ChangeAddColumn, ColumnName: "added",
+			NewColumn: schema.Column{Name: "added", DataType: schema.TypeInt64, Nullable: true},
+		},
+	}}
+
+	_, err := dest.ApplySchemaEvolution(ctx, table, comparison)
+	require.NoError(t, err)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	widened, ok := tbl.Schema().FindFieldByName("widened")
+	require.True(t, ok)
+	require.False(t, widened.Required)
+	targetType, err := icebergTypeForColumn(comparison.Changes[0].NewColumn)
+	require.NoError(t, err)
+	require.True(t, icebergTypesEquivalent(widened.Type, targetType))
+	removed, ok := tbl.Schema().FindFieldByName("removed")
+	require.True(t, ok)
+	require.False(t, removed.Required)
+	relaxed, ok := tbl.Schema().FindFieldByName("relaxed")
+	require.True(t, ok)
+	require.False(t, relaxed.Required)
+	added, ok := tbl.Schema().FindFieldByName("added")
+	require.True(t, ok)
+	require.False(t, added.Required)
+}
+
+func TestApplySchemaEvolutionReturnsPreCommitFailureWhenChangesDidNotLand(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "evolution.pre_commit_failure"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: initial}))
+
+	preCommit := errors.New("schema commit rejected before mutation")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{preCommit}}
+	comparison := addColumnComparison(schema.Column{Name: "age", DataType: schema.TypeInt64, Nullable: true})
+	_, err := dest.ApplySchemaEvolution(ctx, table, comparison)
+	require.ErrorIs(t, err, preCommit)
+	tbl, loadErr := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, loadErr)
+	_, exists := tbl.Schema().FindFieldByName("age")
+	require.False(t, exists)
+}
+
+func TestApplySchemaEvolutionKeepsIdentifierRequiredDuringWidening(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "evolution.identifier_widening"
+	initialColumn := schema.Column{Name: "id", DataType: schema.TypeInt32, Nullable: false}
+	initial := &schema.TableSchema{Columns: []schema.Column{initialColumn}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: initial, PrimaryKeys: []string{"id"},
+	}))
+
+	unknown := errors.New("identifier widening response lost")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, afterCommitErrs: []error{unknown}}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeWidenType,
+		ColumnName: "id",
+		OldColumn:  &initialColumn,
+		NewColumn:  schema.Column{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+	}}}
+	_, err := dest.ApplySchemaEvolution(ctx, table, comparison)
+	require.NoError(t, err)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	id, ok := tbl.Schema().FindFieldByName("id")
+	require.True(t, ok)
+	require.True(t, id.Required)
+	targetType, err := icebergTypeForColumn(comparison.Changes[0].NewColumn)
+	require.NoError(t, err)
+	require.True(t, icebergTypesEquivalent(id.Type, targetType))
+}
+
+func TestApplySchemaEvolutionIgnoresIdentifierNullabilityRelaxation(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "evolution.identifier_nullability"
+	initialColumn := schema.Column{Name: "id", DataType: schema.TypeInt64, Nullable: false}
+	initial := &schema.TableSchema{Columns: []schema.Column{initialColumn}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: initial, PrimaryKeys: []string{"id"},
+	}))
+
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeRelaxNullability,
+		ColumnName: "id",
+		OldColumn:  &initialColumn,
+		NewColumn:  schema.Column{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+	}}}
+	_, err := dest.ApplySchemaEvolution(ctx, table, comparison)
+	require.NoError(t, err)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	id, ok := tbl.Schema().FindFieldByName("id")
+	require.True(t, ok)
+	require.True(t, id.Required)
+}

--- a/pkg/destination/iceberg/hive_file_io_test.go
+++ b/pkg/destination/iceberg/hive_file_io_test.go
@@ -1,0 +1,35 @@
+package iceberg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	icebergio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHiveLocalIONormalizesSingleSlashFileURI(t *testing.T) {
+	working := t.TempDir()
+	t.Chdir(working)
+	target := filepath.Join(t.TempDir(), "warehouse", "metadata", "v1.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+
+	fileIO, err := icebergio.LoadFS(context.Background(), nil, "file:"+target)
+	require.NoError(t, err)
+	writeIO, ok := fileIO.(icebergio.WriteFileIO)
+	require.True(t, ok)
+	require.NoError(t, writeIO.WriteFile("file:"+target, []byte("metadata")))
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, []byte("metadata"), content)
+	require.NoDirExists(t, filepath.Join(working, "file:"), "file:/ must never be treated as a relative workspace path")
+}
+
+func TestFileURIContainsPlainAbsoluteChild(t *testing.T) {
+	root := t.TempDir()
+	require.True(t, locationContains("file:"+root, filepath.Join(root, "data", "file.parquet")))
+	require.True(t, locationContains("file://"+root, filepath.Join(root, "metadata", "v1.json")))
+	require.False(t, locationContains("file:"+root, filepath.Join(filepath.Dir(root), "outside.parquet")))
+}

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -31,6 +31,21 @@ func TestParseIcebergConfig(t *testing.T) {
 	require.False(t, cfg.CreateNamespace)
 }
 
+func TestParseIcebergConfigRejectsEmptyCatalogName(t *testing.T) {
+	for _, value := range []string{"", " \t "} {
+		_, err := parseIcebergConfig("iceberg+sqlite:///:memory:?catalog_name=" + url.QueryEscape(value))
+		require.ErrorContains(t, err, "catalog_name must not be empty")
+	}
+}
+
+func TestParseIcebergConfigRejectsInternallyManagedProperties(t *testing.T) {
+	for _, key := range []string{tableCDCResumeStateKey, managedTablePurgeClaim, atomicSnapshotAttemptProperty, atomicSnapshotTargetProperty} {
+		_, err := parseIcebergConfig("iceberg+hadoop:///tmp/warehouse?table." + key + "=forged")
+		require.ErrorContains(t, err, "managed internally")
+		require.ErrorContains(t, err, key)
+	}
+}
+
 func TestParseIcebergConfigFriendlyURIs(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -135,6 +150,42 @@ func TestDestinationConnectSQLiteCatalog(t *testing.T) {
 
 	require.NoError(t, dest.Connect(ctx, "iceberg+sqlite://"+catalogDB+"?warehouse_path="+url.QueryEscape(warehouse)))
 	require.NoError(t, dest.Close(ctx))
+}
+
+func TestDestinationRejectsExternalWritePaths(t *testing.T) {
+	for _, catalogType := range []string{"hadoop", "sqlite"} {
+		for _, key := range []string{"write.data.path", "write.metadata.path"} {
+			for _, value := range []string{t.TempDir(), ""} {
+				dest := NewDestination()
+				var uri string
+				if catalogType == "hadoop" {
+					uri = "iceberg+hadoop://?warehouse=" + url.QueryEscape(t.TempDir())
+				} else {
+					uri = "iceberg+sqlite://" + filepath.Join(t.TempDir(), "catalog.db") + "?warehouse_path=" + url.QueryEscape(t.TempDir())
+				}
+				err := dest.Connect(context.Background(), uri+"&table."+key+"="+url.QueryEscape(value))
+				require.ErrorContains(t, err, "cannot be isolated for orphan cleanup or purged reliably")
+				require.ErrorContains(t, err, key)
+			}
+		}
+	}
+}
+
+func TestDestinationCheckConnectionSQLiteCatalog(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	catalogDB := filepath.Join(t.TempDir(), "catalog.db")
+	warehouse := t.TempDir()
+
+	require.NoError(t, dest.Connect(ctx, "iceberg+sqlite://"+catalogDB+"?warehouse_path="+url.QueryEscape(warehouse)))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+
+	require.NoError(t, dest.CheckConnection(ctx))
+	namespaces, err := dest.catalog.ListNamespaces(ctx, nil)
+	require.NoError(t, err)
+	for _, namespace := range namespaces {
+		require.NotContains(t, namespace[0], "ingestr_connection_check_", "connection check must clean up its namespace")
+	}
 }
 
 func TestIcebergSchemaFromTableSchemaNormalizesJSON(t *testing.T) {

--- a/pkg/destination/iceberg/input_drain_test.go
+++ b/pkg/destination/iceberg/input_drain_test.go
@@ -1,0 +1,272 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordBatchInputReleasesCurrentErrorAndTrailingBatches(t *testing.T) {
+	mem := checkedDrainAllocator(t)
+	sc := drainTestArrowSchema("id")
+	records := make(chan source.RecordBatchResult, 3)
+	records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, sc, 1)}
+	sourceErr := errors.New("source failed")
+	records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, sc, 2), Err: sourceErr}
+	records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, sc, 3)}
+	close(records)
+
+	input := newRecordBatchInputWithDrainTimeout(records, time.Second)
+	reader := input.RecordReader(context.Background(), sc)
+	require.True(t, reader.Next())
+	require.False(t, reader.Next())
+	require.ErrorIs(t, reader.Err(), sourceErr)
+	input.Close()
+	waitForDrain(t, input.done)
+	require.Zero(t, mem.CurrentAlloc())
+}
+
+func TestRecordBatchInputCloseUnblocksBlockedAndDelayedProducers(t *testing.T) {
+	for _, delay := range []time.Duration{0, 25 * time.Millisecond} {
+		t.Run(delay.String(), func(t *testing.T) {
+			mem := checkedDrainAllocator(t)
+			sc := drainTestArrowSchema("id")
+			records := make(chan source.RecordBatchResult)
+			producerDone := make(chan struct{})
+			go func() {
+				defer close(producerDone)
+				if delay > 0 {
+					time.Sleep(delay)
+				}
+				records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, sc, 1)}
+				close(records)
+			}()
+
+			input := newRecordBatchInputWithDrainTimeout(records, time.Second)
+			input.Close()
+			waitForDrain(t, producerDone)
+			waitForDrain(t, input.done)
+			require.Zero(t, mem.CurrentAlloc())
+		})
+	}
+}
+
+func TestRecordBatchInputDrainIsBounded(t *testing.T) {
+	records := make(chan source.RecordBatchResult)
+	input := newRecordBatchInputWithDrainTimeout(records, 20*time.Millisecond)
+	started := time.Now()
+	input.Close()
+	waitForDrain(t, input.done)
+	require.Less(t, time.Since(started), time.Second)
+
+	nilInput := newRecordBatchInputWithDrainTimeout(nil, time.Hour)
+	nilInput.Close()
+	select {
+	case <-nilInput.done:
+	default:
+		require.Fail(t, "nil input did not close synchronously")
+	}
+}
+
+func TestIcebergWriteEntrypointPreflightFailuresDrainBlockedProducers(t *testing.T) {
+	calls := map[string]func(*Destination, <-chan source.RecordBatchResult) error{
+		"append_replace": func(dest *Destination, records <-chan source.RecordBatchResult) error {
+			return dest.WriteParallel(context.Background(), records, destination.WriteOptions{})
+		},
+		"direct_merge": func(dest *Destination, records <-chan source.RecordBatchResult) error {
+			return dest.MergeRecords(context.Background(), records, destination.WriteOptions{}, destination.MergeOptions{})
+		},
+		"truncate_insert": func(dest *Destination, records <-chan source.RecordBatchResult) error {
+			return dest.TruncateInsertRecords(context.Background(), records, destination.WriteOptions{})
+		},
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			mem := checkedDrainAllocator(t)
+			sc := drainTestArrowSchema("id")
+			records := make(chan source.RecordBatchResult)
+			producerDone := make(chan struct{})
+			go func() {
+				defer close(producerDone)
+				records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, sc, 1)}
+				close(records)
+			}()
+
+			require.Error(t, call(NewDestination(), records))
+			waitForDrain(t, producerDone)
+			requireDrainAllocatorZero(t, mem)
+		})
+	}
+}
+
+func TestWriteParallelTransformFailureDrainsDelayedProducer(t *testing.T) {
+	dest := newHadoopDestination(t)
+	tableSchema := &schema.TableSchema{
+		Columns:     []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}},
+		PrimaryKeys: []string{"id"},
+	}
+	table := "lake.correctness.transform_drain"
+	require.NoError(t, dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"}, DropFirst: true,
+	}))
+
+	mem := checkedDrainAllocator(t)
+	records := make(chan source.RecordBatchResult)
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		time.Sleep(20 * time.Millisecond)
+		records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, icebergArrowSchema(tableSchema), 1)}
+		close(records)
+	}()
+	err := dest.WriteParallel(context.Background(), records, destination.WriteOptions{
+		Table: table, Schema: tableSchema, DeduplicatePrimaryKeys: true, IncrementalKey: "missing",
+	})
+	require.ErrorContains(t, err, `incremental key column "missing" not found`)
+	waitForDrain(t, producerDone)
+	requireDrainAllocatorZero(t, mem)
+}
+
+func TestMergeRecordsReaderFailureReleasesErrorAndTrailingBatches(t *testing.T) {
+	dest := newHadoopDestination(t)
+	tableSchema := &schema.TableSchema{
+		Columns:     []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}},
+		PrimaryKeys: []string{"id"},
+	}
+	table := "lake.correctness.merge_reader_drain"
+	require.NoError(t, dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"},
+	}))
+
+	mem := checkedDrainAllocator(t)
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, drainTestArrowSchema("wrong_id"), 1)}
+	records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, icebergArrowSchema(tableSchema), 2)}
+	close(records)
+	err := dest.MergeRecords(context.Background(), records, destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}, destination.MergeOptions{
+		TargetTable: table, PrimaryKeys: []string{"id"}, Columns: []string{"id"}, Schema: tableSchema,
+	})
+	require.ErrorContains(t, err, "name mismatch")
+	require.Zero(t, mem.CurrentAlloc())
+}
+
+func TestAlreadyCommittedWriteDrainReportsSourceErrorAndReleasesTrailingBatch(t *testing.T) {
+	dest := newHadoopDestination(t)
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}},
+	}
+	table := "lake.correctness.retry_drain"
+	require.NoError(t, dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema,
+	}))
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "committed-token"}
+	require.NoError(t, dest.WriteParallel(
+		context.Background(),
+		recordBatches(int64Batch(t, 1)),
+		opts,
+	))
+
+	mem := checkedDrainAllocator(t)
+	sourceErr := errors.New("retry source failed")
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{
+		Batch: checkedDrainBatch(mem, icebergArrowSchema(tableSchema), 2),
+		Err:   sourceErr,
+	}
+	records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, icebergArrowSchema(tableSchema), 3)}
+	close(records)
+	err := dest.WriteParallel(context.Background(), records, opts)
+	require.ErrorIs(t, err, sourceErr)
+	require.Empty(t, records)
+	require.Zero(t, mem.CurrentAlloc())
+}
+
+func TestWriteParallelCancellationDuringFileWriteDrainsProducer(t *testing.T) {
+	dest := newHadoopDestination(t)
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}},
+	}
+	table := "lake.correctness.file_write_cancel_drain"
+	require.NoError(t, dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema,
+	}))
+	dest.catalog = loadIgnoringContextCatalog{Catalog: dest.catalog}
+
+	mem := checkedDrainAllocator(t)
+	records := make(chan source.RecordBatchResult)
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		records <- source.RecordBatchResult{Batch: checkedDrainBatch(mem, icebergArrowSchema(tableSchema), 1)}
+		close(records)
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := dest.WriteParallel(ctx, records, destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "canceled-write",
+	})
+	require.Error(t, err)
+	waitForDrain(t, producerDone)
+	require.Zero(t, mem.CurrentAlloc())
+}
+
+type loadIgnoringContextCatalog struct {
+	icebergcatalog.Catalog
+}
+
+func (c loadIgnoringContextCatalog) LoadTable(
+	_ context.Context,
+	ident icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	return c.Catalog.LoadTable(context.Background(), ident)
+}
+
+func checkedDrainAllocator(t *testing.T) *memory.CheckedAllocator {
+	t.Helper()
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+	return mem
+}
+
+func drainTestArrowSchema(name string) *arrow.Schema {
+	return arrow.NewSchema([]arrow.Field{{Name: name, Type: arrow.PrimitiveTypes.Int64, Nullable: false}}, nil)
+}
+
+func checkedDrainBatch(mem memory.Allocator, sc *arrow.Schema, value int64) arrow.RecordBatch {
+	builder := array.NewInt64Builder(mem)
+	builder.Append(value)
+	values := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(sc, []arrow.Array{values}, 1)
+	values.Release()
+	return batch
+}
+
+func waitForDrain(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timed out waiting for record-batch drain")
+	}
+}
+
+func requireDrainAllocatorZero(t *testing.T, mem *memory.CheckedAllocator) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return mem.CurrentAlloc() == 0
+	}, 2*time.Second, time.Millisecond)
+}

--- a/pkg/destination/iceberg/lifecycle_test.go
+++ b/pkg/destination/iceberg/lifecycle_test.go
@@ -1,0 +1,1269 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagedTableDropPurgesPhysicalFiles(t *testing.T) {
+	for _, catalogType := range []string{"hadoop", "sqlite"} {
+		t.Run(catalogType, func(t *testing.T) {
+			ctx := context.Background()
+			warehouse := t.TempDir()
+			dest := NewDestination()
+			var uri string
+			if catalogType == "hadoop" {
+				uri = "iceberg+hadoop://?warehouse=" + url.QueryEscape(warehouse)
+			} else {
+				uri = "iceberg+sqlite://" + filepath.Join(t.TempDir(), "catalog.db") +
+					"?warehouse_path=" + url.QueryEscape(warehouse)
+			}
+			require.NoError(t, dest.Connect(ctx, uri))
+			t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+
+			tableName := "lifecycle.purge_staging"
+			tableSchema := lifecycleTestSchema()
+			require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+				Table:        tableName,
+				Schema:       tableSchema,
+				DropFirst:    true,
+				ExpiresAfter: time.Hour,
+			}))
+			require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+				Table:  tableName,
+				Schema: tableSchema,
+			}))
+
+			tbl, err := dest.loadIcebergTable(ctx, tableName)
+			require.NoError(t, err)
+			require.Equal(t, "true", tbl.Properties()[managedTableProperty])
+			require.Equal(t, managedTableKindStaging, tbl.Properties()[managedTableKindProperty])
+			require.Equal(t, "true", tbl.Properties()[gcEnabledProperty])
+			_, err = time.Parse(time.RFC3339Nano, tbl.Properties()[managedTableExpiresAt])
+			require.NoError(t, err)
+
+			location, ok := localFilesystemPath(tbl.Location())
+			require.True(t, ok)
+			require.NotEmpty(t, regularFilesUnder(t, location))
+
+			require.NoError(t, dest.DropTable(ctx, tableName))
+			exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier(tableName))
+			require.NoError(t, err)
+			require.False(t, exists)
+			require.Empty(t, regularFilesUnder(t, location))
+		})
+	}
+}
+
+func TestCleanupExpiredManagedTablesOnlyPurgesExpiredOwnedTables(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableSchema := lifecycleTestSchema()
+
+	writeLifecycleTable(t, dest, "lifecycle.expired", tableSchema, time.Hour)
+	writeLifecycleTable(t, dest, "lifecycle.live", tableSchema, 48*time.Hour)
+	writeLifecycleTable(t, dest, "lifecycle.user_table", tableSchema, 0)
+
+	expired, err := dest.loadIcebergTable(ctx, "lifecycle.expired")
+	require.NoError(t, err)
+	expiredLocation, ok := localFilesystemPath(expired.Location())
+	require.True(t, ok)
+
+	result, err := dest.cleanupExpiredManagedTables(
+		ctx,
+		icebergcatalog.ToIdentifier("lifecycle"),
+		time.Now().Add(2*time.Hour),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"lifecycle.expired"}, result.Purged)
+	require.Empty(t, regularFilesUnder(t, expiredLocation))
+
+	for _, tableName := range []string{"lifecycle.live", "lifecycle.user_table"} {
+		exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier(tableName))
+		require.NoError(t, err)
+		require.True(t, exists, tableName)
+	}
+}
+
+func TestPrepareTableRecreatesExpiredManagedTable(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, "lifecycle.reused", tableSchema, time.Hour)
+
+	tbl, err := dest.loadIcebergTable(ctx, "lifecycle.reused")
+	require.NoError(t, err)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(map[string]string{
+		managedTableExpiresAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        "lifecycle.reused",
+		Schema:       tableSchema,
+		DropFirst:    true,
+		ExpiresAfter: time.Hour,
+	}))
+	recreated, err := dest.loadIcebergTable(ctx, "lifecycle.reused")
+	require.NoError(t, err)
+	require.Nil(t, recreated.CurrentSnapshot())
+	expiresAt, managed, err := managedTableExpiration(recreated.Properties())
+	require.NoError(t, err)
+	require.True(t, managed)
+	require.True(t, expiresAt.After(time.Now()))
+}
+
+func TestManagedWriteHeartbeatsLeaseWhileSourceIsBlocked(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	dest.leaseHeartbeatInterval = 5 * time.Millisecond
+	tableName := "lifecycle.heartbeat"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        tableName,
+		Schema:       tableSchema,
+		DropFirst:    true,
+		ExpiresAfter: time.Minute,
+	}))
+
+	before, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	initialExpiration, managed, err := managedTableExpiration(before.Properties())
+	require.NoError(t, err)
+	require.True(t, managed)
+
+	records := make(chan source.RecordBatchResult)
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- dest.WriteParallel(ctx, records, destination.WriteOptions{
+			Table:  tableName,
+			Schema: tableSchema,
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		current, loadErr := dest.loadIcebergTable(ctx, tableName)
+		if loadErr != nil {
+			return false
+		}
+		expiresAt, _, expirationErr := managedTableExpiration(current.Properties())
+		return expirationErr == nil && expiresAt.After(initialExpiration)
+	}, 2*time.Second, 5*time.Millisecond)
+
+	close(records)
+	require.NoError(t, <-writeDone)
+}
+
+func TestManagedAppendHeartbeatsLeaseWhileSourceIsBlocked(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	dest.leaseHeartbeatInterval = 5 * time.Millisecond
+	tableName := "lifecycle.append_heartbeat"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: tableSchema, ExpiresAfter: time.Minute,
+	}))
+
+	before, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	initialExpiration, managed, err := managedTableExpiration(before.Properties())
+	require.NoError(t, err)
+	require.True(t, managed)
+
+	records := make(chan source.RecordBatchResult)
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- dest.WriteParallel(ctx, records, destination.WriteOptions{Table: tableName, Schema: tableSchema})
+	}()
+	require.Eventually(t, func() bool {
+		current, loadErr := dest.loadIcebergTable(ctx, tableName)
+		if loadErr != nil {
+			return false
+		}
+		expiresAt, _, expirationErr := managedTableExpiration(current.Properties())
+		return expirationErr == nil && expiresAt.After(initialExpiration)
+	}, 2*time.Second, 5*time.Millisecond)
+	close(records)
+	require.NoError(t, <-writeDone)
+}
+
+func TestManagedAppendAbortsWhenFinalLeaseRefreshFails(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	dest.leaseHeartbeatInterval = time.Hour
+	tableName := "lifecycle.append_final_refresh"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: tableSchema, ExpiresAfter: time.Minute,
+	}))
+
+	leaseErr := errors.New("injected final lease refresh failure")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{leaseErr}}
+	err := dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table: tableName, Schema: tableSchema,
+	})
+	require.ErrorIs(t, err, leaseErr)
+	require.EqualValues(t, 0, icebergRowCount(ctx, t, dest, tableName))
+}
+
+func TestManagedWriteSynchronouslyRenewsLeaseBeforeReadingSource(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	dest.leaseHeartbeatInterval = time.Hour
+	tableName := "lifecycle.synchronous_lease_refresh"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: tableSchema, ExpiresAfter: time.Minute,
+	}))
+	setManagedExpiration(t, dest, tableName, time.Now().Add(-time.Minute))
+
+	records := make(chan source.RecordBatchResult)
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- dest.WriteParallel(ctx, records, destination.WriteOptions{Table: tableName, Schema: tableSchema})
+	}()
+	require.Eventually(t, func() bool {
+		current, err := dest.loadIcebergTable(ctx, tableName)
+		if err != nil {
+			return false
+		}
+		expiresAt, _, err := managedTableExpiration(current.Properties())
+		return err == nil && expiresAt.After(time.Now())
+	}, time.Second, 5*time.Millisecond)
+	close(records)
+	require.NoError(t, <-writeDone)
+}
+
+func TestManagedWriteRejectsPurgeClaimBeforeReadingSource(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "lifecycle.claim_before_read"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: tableSchema, ExpiresAfter: time.Minute,
+	}))
+	setLifecycleTableProperty(t, dest, tableName, managedTablePurgeClaim, time.Now().UTC().Format(time.RFC3339Nano))
+	records := make(chan source.RecordBatchResult)
+	err := dest.WriteParallel(ctx, records, destination.WriteOptions{Table: tableName, Schema: tableSchema})
+	require.ErrorContains(t, err, "claimed for purge")
+}
+
+func TestS3TablesManagedPurgeDoesNotRequireFilesystemJournal(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.s3tables_server_purge"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	wrapped := &missingRecoveryCatalog{Catalog: dest.catalog, catalogType: icebergcatalog.REST, target: ident, failed: true}
+	dest.catalog = wrapped
+	documented, err := parseIcebergConfig("iceberg+s3tables://?region=us-east-1&warehouse=" +
+		url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"))
+	require.NoError(t, err)
+	dest.cfg = documented
+	require.True(t, dest.usesServerManagedPurge())
+
+	require.NoError(t, dest.DropTable(ctx, tableName))
+	require.True(t, wrapped.failed, "server-managed PurgeTable path must be invoked")
+	_, err = dest.purgeJournalPath(ident)
+	require.ErrorContains(t, err, "requires a filesystem warehouse")
+	require.NoError(t, dest.DropTable(ctx, tableName), "missing-table retry must reconcile server-managed purge")
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: lifecycleTestSchema()}),
+		"idle server-managed ownership must allow later recreation")
+}
+
+func TestS3TablesLostPurgeResponseCannotDeleteRecreatedUUID(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.s3tables_recreated_uuid"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	base := dest.catalog
+	wrapped := &missingRecoveryCatalog{Catalog: base, catalogType: icebergcatalog.REST, target: ident}
+	dest.catalog = wrapped
+	documented, err := parseIcebergConfig("iceberg+s3tables://?region=us-east-1&warehouse=" +
+		url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"))
+	require.NoError(t, err)
+	dest.cfg = documented
+
+	err = dest.DropTable(ctx, tableName)
+	require.ErrorIs(t, err, errInjectedMissingRecoveryOutcome)
+	err = dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: lifecycleTestSchema()})
+	require.ErrorContains(t, err, "must be reconciled before recreation")
+
+	iceSchema, err := icebergSchemaFromTableSchema(lifecycleTestSchema())
+	require.NoError(t, err)
+	properties, err := lifecyclePropertiesForCreate(nil, time.Hour)
+	require.NoError(t, err)
+	recreated, err := base.CreateTable(ctx, ident, iceSchema, icebergcatalog.WithProperties(properties))
+	require.NoError(t, err, "simulate recreation by an external catalog client that bypasses ingestr's guard")
+	recreatedUUID := recreated.Metadata().TableUUID()
+
+	err = dest.DropTable(ctx, tableName)
+	require.ErrorContains(t, err, "refused stale purge for recreated table")
+	live, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	require.Equal(t, recreatedUUID, live.Metadata().TableUUID())
+
+	require.NoError(t, dest.DropTable(ctx, tableName), "a new explicit drop may delete the reconciled replacement")
+}
+
+func TestS3TablesCreationUsesCatalogGuard(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	dest.catalog = &missingRecoveryCatalog{Catalog: dest.catalog, catalogType: icebergcatalog.REST}
+	documented, err := parseIcebergConfig("iceberg+s3tables://?region=us-east-1&warehouse=" +
+		url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"))
+	require.NoError(t, err)
+	dest.cfg = documented
+	tableName := "s3guard.created"
+	lockIdent := purgeLockIdentifier(icebergcatalog.ToIdentifier(tableName))
+	require.NoError(t, validateS3TablesName("table", lockIdent[len(lockIdent)-1]))
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("s3guard"), iceberggo.Properties{}))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: lifecycleTestSchema()}))
+	idleLock, err := dest.catalog.LoadTable(ctx, lockIdent)
+	require.NoError(t, err)
+	require.Equal(t, purgeLockModeIdle, idleLock.Properties()[purgeLockModeKey])
+}
+
+func TestPrepareTableRejectsExternalCreateRace(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.external_create_race"
+	ident := icebergcatalog.ToIdentifier(tableName)
+	wrapper := &externalCreateRaceCatalog{Catalog: dest.catalog, target: ident}
+	dest.catalog = wrapper
+
+	err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: lifecycleTestSchema(), DropFirst: true,
+	})
+	require.ErrorContains(t, err, "refused concurrent external creation")
+	live, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	require.Equal(t, wrapper.externalUUID, live.Metadata().TableUUID())
+	dest.mu.Lock()
+	_, prepared := dest.prepared[tableName]
+	dest.mu.Unlock()
+	require.False(t, prepared)
+}
+
+func TestS3TablesRevalidatesUUIDImmediatelyBeforePurge(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.s3tables_pre_purge_fence"
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, tableName, tableSchema, time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	require.NoError(t, err)
+	properties, err := lifecyclePropertiesForCreate(nil, time.Hour)
+	require.NoError(t, err)
+	wrapper := &replaceBeforePurgeCatalog{
+		Catalog: dest.catalog, target: ident, schema: iceSchema, properties: properties,
+	}
+	dest.catalog = wrapper
+	documented, err := parseIcebergConfig("iceberg+s3tables://?region=us-east-1&warehouse=" +
+		url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"))
+	require.NoError(t, err)
+	dest.cfg = documented
+
+	err = dest.DropTable(ctx, tableName)
+	require.ErrorContains(t, err, "refused server-managed purge for recreated table")
+	require.Zero(t, wrapper.purgeCalls)
+	live, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	require.Equal(t, wrapper.recreatedUUID, live.Metadata().TableUUID())
+}
+
+func TestDeletionFenceDoesNotDropReplacementCreatedAtRename(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.rename_fenced_replacement"
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, tableName, tableSchema, time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	require.NoError(t, err)
+	properties, err := lifecyclePropertiesForCreate(nil, time.Hour)
+	require.NoError(t, err)
+	wrapper := &replaceDuringDeletionFenceCatalog{
+		Catalog: dest.catalog,
+		target:  ident,
+		schema:  iceSchema,
+		props:   properties,
+	}
+	dest.catalog = wrapper
+
+	err = dest.DropTable(ctx, tableName)
+	require.ErrorContains(t, err, "UUID changed")
+	live, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	require.Equal(t, wrapper.replacementUUID, live.Metadata().TableUUID())
+	exists, err := dest.catalog.CheckTableExists(ctx, wrapper.fencedIdent)
+	require.NoError(t, err)
+	require.False(t, exists, "mismatched replacement must be restored, never deleted")
+}
+
+func TestDeletionFenceFailsClosedBeforeGlueRename(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.glue_non_atomic_rename"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	wrapper := &nonAtomicRenameCatalog{Catalog: dest.catalog}
+	dest.catalog = wrapper
+
+	err := dest.DropTable(ctx, tableName)
+	require.ErrorContains(t, err, "cannot provide an atomic deletion fence")
+	require.Zero(t, wrapper.renameCalls)
+	_, err = dest.catalog.LoadTable(ctx, icebergcatalog.ToIdentifier(tableName))
+	require.NoError(t, err)
+}
+
+func TestS3TablesHeartbeatFailureCancelsBlockingPurgeBeforeTakeover(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "lifecycle.s3tables_cancel_failed_heartbeat"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	dest.catalogLockHeartbeatInterval = 5 * time.Millisecond
+	ident := icebergcatalog.ToIdentifier(tableName)
+	wrapper := &blockingPurgeHeartbeatFailureCatalog{
+		Catalog: dest.catalog, target: ident, purgeStarted: make(chan struct{}), purgeCanceled: make(chan struct{}), failHeartbeat: true,
+	}
+	dest.catalog = wrapper
+	documented, err := parseIcebergConfig("iceberg+s3tables://?region=us-east-1&warehouse=" +
+		url.QueryEscape("arn:aws:s3tables:us-east-1:123456789012:bucket/analytics"))
+	require.NoError(t, err)
+	dest.cfg = documented
+
+	err = dest.DropTable(ctx, tableName)
+	require.ErrorIs(t, err, errInjectedPurgeHeartbeatFailure)
+	select {
+	case <-wrapper.purgeCanceled:
+	default:
+		t.Fatal("blocking PurgeTable must terminate from cancellation before DropTable returns")
+	}
+	wrapper.failHeartbeat = false
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	_, err = dest.claimPurgeResume(ctx, ident, lock.Properties()[purgeLockTableUUIDKey])
+	require.NoError(t, err, "takeover is safe only after the original purge request has terminated")
+}
+
+func TestCreateGuardStopDoesNotReportCanceledInFlightHeartbeat(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	ident := icebergcatalog.ToIdentifier("lifecycle.create_guard_stop_heartbeat")
+	require.NoError(t, dest.ensureNamespace(ctx, icebergcatalog.NamespaceFromIdent(ident)))
+	wrapper := &cancelOnHeartbeatStopCatalog{
+		Catalog:       dest.catalog,
+		target:        ident,
+		lock:          purgeLockIdentifier(ident),
+		renewStarted:  make(chan struct{}),
+		renewCanceled: make(chan struct{}),
+	}
+	wrapper.blockRenew.Store(true)
+	dest.catalog = wrapper
+	dest.catalogLockHeartbeatInterval = time.Millisecond
+
+	require.NoError(t, dest.createTable(ctx, ident, destination.PrepareOptions{
+		Table:        strings.Join(ident, "."),
+		Schema:       lifecycleTestSchema(),
+		ExpiresAfter: time.Hour,
+	}))
+	require.NoError(t, ctx.Err())
+	select {
+	case <-wrapper.renewCanceled:
+	default:
+		t.Fatal("create guard must join the canceled in-flight heartbeat before returning")
+	}
+	exists, err := dest.catalog.CheckTableExists(ctx, ident)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestDropUnmanagedTableDoesNotEnableGCOrPurgeDataFiles(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	dest := NewDestination()
+	uri := "iceberg+sqlite://" + filepath.Join(root, "catalog.db") +
+		"?warehouse_path=" + url.QueryEscape(filepath.Join(root, "warehouse"))
+	require.NoError(t, dest.Connect(ctx, uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+	table := "lifecycle.unmanaged_drop"
+	writeTableRows(t, dest, table, lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	filesBefore := regularFilesUnder(t, location)
+	require.NotEmpty(t, filesBefore)
+
+	require.NoError(t, dest.DropTable(ctx, table))
+	exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier(table))
+	require.NoError(t, err)
+	require.False(t, exists)
+	for _, file := range filesBefore {
+		require.FileExists(t, file)
+	}
+}
+
+func TestDropUnmanagedHadoopTableRefusesPhysicalDeletion(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lifecycle.unmanaged_hadoop_drop"
+	writeTableRows(t, dest, table, lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	filesBefore := regularFilesUnder(t, location)
+	require.NotEmpty(t, filesBefore)
+
+	err = dest.DropTable(ctx, table)
+	require.ErrorContains(t, err, "cannot drop unmanaged Hadoop table")
+	exists, existsErr := dest.tableExists(ctx, icebergcatalog.ToIdentifier(table))
+	require.NoError(t, existsErr)
+	require.True(t, exists)
+	for _, file := range filesBefore {
+		require.FileExists(t, file)
+	}
+}
+
+func TestExpiredCleanupAbortsWhenLeaseRefreshWinsClaim(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "lifecycle.refresh_race"
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, tableName, tableSchema, time.Hour)
+
+	ident := icebergcatalog.ToIdentifier(tableName)
+	now := time.Now().UTC()
+	tbl, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(map[string]string{
+		managedTableExpiresAt: now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	base := dest.catalog
+	dest.catalog = &refreshBeforePurgeClaimCatalog{
+		Catalog: base,
+		target:  ident,
+		now:     now,
+	}
+	t.Cleanup(func() { dest.catalog = base })
+
+	result, err := dest.cleanupExpiredManagedTables(ctx, icebergcatalog.ToIdentifier("lifecycle"), now)
+	require.NoError(t, err)
+	require.Empty(t, result.Purged)
+	current, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	expiresAt, _, err := managedTableExpiration(current.Properties())
+	require.NoError(t, err)
+	require.True(t, expiresAt.After(now))
+	require.Empty(t, current.Properties()[managedTablePurgeClaim])
+}
+
+func TestPurgeClaimPreventsSubsequentLeaseRefresh(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "lifecycle.claimed"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	now := time.Now().UTC().Add(2 * time.Hour)
+
+	claimed, eligible, err := dest.claimExpiredManagedTable(ctx, ident, now)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	require.NotEmpty(t, claimed.Properties()[managedTablePurgeClaim])
+	_, eligible, err = dest.claimExpiredManagedTable(ctx, ident, now)
+	require.NoError(t, err)
+	require.False(t, eligible)
+	_, err = dest.renewManagedTableLease(ctx, ident, now.Add(time.Second))
+	require.ErrorContains(t, err, "claimed for purge")
+	reclaimed, eligible, err := dest.claimExpiredManagedTable(ctx, ident, now.Add(purgeResumeClaimTTL+time.Second))
+	require.NoError(t, err)
+	require.True(t, eligible, "a crashed purge claimant must be reclaimable after its lease")
+	require.NotEqual(t, claimed.Properties()[managedTablePurgeClaim], reclaimed.Properties()[managedTablePurgeClaim])
+}
+
+func TestPrepareTableRejectsLegacyExternalFilePathProperty(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "lifecycle.legacy_external_path"
+	tableSchema := lifecycleTestSchema()
+	writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{int64(1)}})
+	setLifecycleTableProperty(t, dest, tableName, icebergtable.WriteDataPathKey, t.TempDir())
+
+	err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:  tableName,
+		Schema: tableSchema,
+	})
+	require.ErrorContains(t, err, icebergtable.WriteDataPathKey)
+	require.ErrorContains(t, err, "cannot be isolated")
+}
+
+func TestPurgeRejectsAnotherTableWithLegacyExternalFilePath(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableSchema := lifecycleTestSchema()
+	target := "lifecycle.safe_drop_target"
+	other := "lifecycle.legacy_external_neighbor"
+	writeLifecycleTable(t, dest, target, tableSchema, time.Hour)
+	writeTableRows(t, dest, other, tableSchema, false, [][]any{{int64(2)}})
+	targetTable, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	setLifecycleTableProperty(t, dest, other, icebergtable.WriteDataPathKey, targetTable.Location()+"/foreign-data")
+
+	err = dest.DropTable(ctx, target)
+	require.ErrorContains(t, err, "cannot verify orphan-cleanup isolation")
+	for _, tableName := range []string{target, other} {
+		exists, existsErr := dest.tableExists(ctx, icebergcatalog.ToIdentifier(tableName))
+		require.NoError(t, existsErr)
+		require.True(t, exists, tableName)
+	}
+}
+
+func TestConfiguredMaintenanceDetachesExpirationCleanupFromCallerCancellation(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableSchema := lifecycleTestSchema()
+	activeTable := "lifecycle.cleanup_trigger"
+	expiredTable := "lifecycle.cleanup_detached"
+	writeLifecycleTable(t, dest, activeTable, tableSchema, 0)
+	writeLifecycleTable(t, dest, expiredTable, tableSchema, time.Hour)
+
+	expired, err := dest.loadIcebergTable(ctx, expiredTable)
+	require.NoError(t, err)
+	txn := expired.NewTransaction()
+	require.NoError(t, txn.SetProperties(map[string]string{
+		managedTableExpiresAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	base := dest.catalog
+	dest.catalog = &cancelAfterTableLoadCatalog{
+		Catalog: base,
+		target:  icebergcatalog.ToIdentifier(activeTable),
+		cancel:  cancel,
+	}
+	dest.expirationScans = make(map[string]int64)
+	t.Cleanup(func() { dest.catalog = base })
+
+	dest.runConfiguredMaintenance(canceledCtx, activeTable)
+	require.ErrorIs(t, canceledCtx.Err(), context.Canceled)
+	exists, err := dest.tableExists(context.Background(), icebergcatalog.ToIdentifier(expiredTable))
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestPrepareTableRejectsNegativeExpiration(t *testing.T) {
+	dest := newHadoopDestination(t)
+	err := dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table:        "lifecycle.bad_ttl",
+		Schema:       lifecycleTestSchema(),
+		ExpiresAfter: -time.Second,
+	})
+	require.ErrorContains(t, err, "table expiration must not be negative")
+}
+
+func TestPrepareTableRefusesToClaimUnmanagedTableAsStaging(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lifecycle.unmanaged_collision"
+	tableSchema := lifecycleTestSchema()
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(7)}})
+
+	err := dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        table,
+		Schema:       tableSchema,
+		DropFirst:    true,
+		ExpiresAfter: time.Hour,
+	})
+	require.ErrorContains(t, err, "refusing to claim existing unmanaged table")
+
+	tbl, loadErr := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, loadErr)
+	require.Empty(t, tbl.Properties()[managedTableProperty])
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, table))
+	require.Equal(t, int64(7), readTableRows(t, dest, table).Rows[0][0])
+}
+
+func TestManagedDropDoesNotFallbackAfterUnknownPurge(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeLifecycleTable(t, dest, "lifecycle.unknown_purge", lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	failing := &unknownPurgeCatalog{Catalog: base}
+	dest.catalog = failing
+	err := dest.DropTable(ctx, "lifecycle.unknown_purge")
+	require.ErrorContains(t, err, "unknown purge status")
+	require.Zero(t, failing.dropCalls)
+
+	dest.catalog = base
+	exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier("lifecycle.unknown_purge"))
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestClientSidePurgePropagatesPhysicalFailureAfterConfirmedDrop(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeLifecycleTable(t, dest, "lifecycle.failed_physical_purge", lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	injected := errors.New("injected physical purge failure")
+	catalog := &clientSidePurgeCatalog{Catalog: base, purgeErr: injected}
+	dest.catalog = catalog
+	t.Cleanup(func() { dest.catalog = base })
+
+	err := dest.DropTable(ctx, "lifecycle.failed_physical_purge")
+	require.ErrorContains(t, err, "dropped managed table lifecycle.failed_physical_purge")
+	require.ErrorIs(t, err, injected)
+	require.True(t, catalog.dropConfirmed)
+	require.Equal(t, 1, catalog.dropCalls)
+	require.Positive(t, catalog.removeCalls)
+	require.False(t, catalog.removeBeforeDrop)
+}
+
+func TestClientSidePurgeFinishesAfterCallerContextIsCanceledPostDrop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := newHadoopDestination(t)
+	writeLifecycleTable(t, dest, "lifecycle.detached_physical_purge", lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	catalog := &clientSidePurgeCatalog{Catalog: base, afterDrop: cancel}
+	dest.catalog = catalog
+	t.Cleanup(func() { dest.catalog = base })
+
+	require.NoError(t, dest.DropTable(ctx, "lifecycle.detached_physical_purge"))
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.True(t, catalog.dropConfirmed)
+	require.Positive(t, catalog.removeCalls)
+	require.False(t, catalog.removeBeforeDrop)
+}
+
+func TestClientSidePurgeResumesAfterPartialPhysicalDeletion(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lifecycle.partial_physical_purge"
+	writeLifecycleTable(t, dest, table, lifecycleTestSchema(), time.Hour)
+
+	loaded, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(loaded.Location())
+	require.True(t, ok)
+	require.NotEmpty(t, regularFilesUnder(t, location))
+
+	base := dest.catalog
+	catalog := &partialDeleteCatalog{Catalog: base}
+	dest.catalog = catalog
+	t.Cleanup(func() { dest.catalog = base })
+
+	require.NoError(t, dest.DropTable(ctx, table))
+	require.True(t, catalog.fs.failed)
+	require.Greater(t, catalog.fs.removeCalls, 1)
+	require.Empty(t, regularFilesUnder(t, location))
+}
+
+func TestClientSidePurgeDoesNotDeleteFilesAfterUnknownDrop(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeLifecycleTable(t, dest, "lifecycle.unknown_drop", lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	unknown := errors.New("unknown catalog drop outcome")
+	catalog := &clientSidePurgeCatalog{
+		Catalog:  base,
+		dropErr:  unknown,
+		purgeErr: errors.New("must not be reached"),
+	}
+	dest.catalog = catalog
+	t.Cleanup(func() { dest.catalog = base })
+
+	err := dest.DropTable(ctx, "lifecycle.unknown_drop")
+	require.ErrorContains(t, err, "before physical purge")
+	require.ErrorIs(t, err, unknown)
+	require.False(t, catalog.dropConfirmed)
+	require.Equal(t, 1, catalog.dropCalls)
+	require.Zero(t, catalog.removeCalls)
+
+	dest.catalog = base
+	exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier("lifecycle.unknown_drop"))
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+type unknownPurgeCatalog struct {
+	icebergcatalog.Catalog
+	dropCalls int
+}
+
+type refreshBeforePurgeClaimCatalog struct {
+	icebergcatalog.Catalog
+	target      icebergtable.Identifier
+	now         time.Time
+	targetLoads int
+}
+
+type cancelAfterTableLoadCatalog struct {
+	icebergcatalog.Catalog
+	target   icebergtable.Identifier
+	cancel   context.CancelFunc
+	canceled bool
+}
+
+func (c *cancelAfterTableLoadCatalog) LoadTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err == nil && !c.canceled && slices.Equal(ident, c.target) {
+		c.canceled = true
+		c.cancel()
+	}
+	return tbl, err
+}
+
+func (c *refreshBeforePurgeClaimCatalog) LoadTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil || !slices.Equal(ident, c.target) {
+		return tbl, err
+	}
+	c.targetLoads++
+	if c.targetLoads != 2 {
+		return tbl, nil
+	}
+	_, ttl, _, err := managedTableLease(tbl.Properties())
+	if err != nil {
+		return nil, err
+	}
+	return commitManagedTableLease(ctx, tbl, c.now, ttl)
+}
+
+func (c *unknownPurgeCatalog) CatalogType() icebergcatalog.Type {
+	return icebergcatalog.REST
+}
+
+func (c *unknownPurgeCatalog) PurgeTable(context.Context, icebergtable.Identifier) error {
+	return errors.New("unknown purge status")
+}
+
+func (c *unknownPurgeCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if !strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+		c.dropCalls++
+	}
+	return c.Catalog.DropTable(ctx, ident)
+}
+
+type clientSidePurgeCatalog struct {
+	icebergcatalog.Catalog
+	purgeErr         error
+	dropErr          error
+	dropCalls        int
+	removeCalls      int
+	dropConfirmed    bool
+	removeBeforeDrop bool
+	afterDrop        func()
+}
+
+type replaceBeforePurgeCatalog struct {
+	icebergcatalog.Catalog
+	target        icebergtable.Identifier
+	schema        *iceberggo.Schema
+	properties    iceberggo.Properties
+	targetLoads   int
+	purgeCalls    int
+	recreatedUUID uuid.UUID
+}
+
+type replaceDuringDeletionFenceCatalog struct {
+	icebergcatalog.Catalog
+	target          icebergtable.Identifier
+	schema          *iceberggo.Schema
+	props           iceberggo.Properties
+	replaced        bool
+	replacementUUID uuid.UUID
+	fencedIdent     icebergtable.Identifier
+}
+
+type nonAtomicRenameCatalog struct {
+	icebergcatalog.Catalog
+	renameCalls int
+}
+
+func (c *nonAtomicRenameCatalog) CatalogType() icebergcatalog.Type { return icebergcatalog.Glue }
+
+func (c *nonAtomicRenameCatalog) RenameTable(
+	ctx context.Context,
+	from, to icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	c.renameCalls++
+	return c.Catalog.RenameTable(ctx, from, to)
+}
+
+func (c *replaceDuringDeletionFenceCatalog) RenameTable(
+	ctx context.Context,
+	from, to icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	if slices.Equal(from, c.target) && !c.replaced {
+		c.replaced = true
+		if err := c.DropTable(ctx, from); err != nil {
+			return nil, err
+		}
+		replacement, err := c.CreateTable(ctx, from, c.schema, icebergcatalog.WithProperties(c.props))
+		if err != nil {
+			return nil, err
+		}
+		c.replacementUUID = replacement.Metadata().TableUUID()
+		c.fencedIdent = append(icebergtable.Identifier(nil), to...)
+	}
+	return c.Catalog.RenameTable(ctx, from, to)
+}
+
+type externalCreateRaceCatalog struct {
+	icebergcatalog.Catalog
+	target       icebergtable.Identifier
+	externalUUID uuid.UUID
+	created      bool
+}
+
+func (c *externalCreateRaceCatalog) CheckTableExists(ctx context.Context, ident icebergtable.Identifier) (bool, error) {
+	if slices.Equal(ident, c.target) && !c.created {
+		return false, nil
+	}
+	return c.Catalog.CheckTableExists(ctx, ident)
+}
+
+func (c *externalCreateRaceCatalog) CreateTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	tableSchema *iceberggo.Schema,
+	opts ...icebergcatalog.CreateTableOpt,
+) (*icebergtable.Table, error) {
+	if slices.Equal(ident, c.target) && !c.created {
+		c.created = true
+		external, err := c.Catalog.CreateTable(ctx, ident, tableSchema, opts...)
+		if err != nil {
+			return nil, err
+		}
+		c.externalUUID = external.Metadata().TableUUID()
+		return nil, icebergcatalog.ErrTableAlreadyExists
+	}
+	return c.Catalog.CreateTable(ctx, ident, tableSchema, opts...)
+}
+
+var errInjectedPurgeHeartbeatFailure = errors.New("injected purge lock heartbeat failure")
+
+type blockingPurgeHeartbeatFailureCatalog struct {
+	icebergcatalog.Catalog
+	target        icebergtable.Identifier
+	purgeStarted  chan struct{}
+	purgeCanceled chan struct{}
+	failHeartbeat bool
+}
+
+type cancelOnHeartbeatStopCatalog struct {
+	icebergcatalog.Catalog
+	target        icebergtable.Identifier
+	lock          icebergtable.Identifier
+	guardCreated  atomic.Bool
+	blockRenew    atomic.Bool
+	renewStarted  chan struct{}
+	renewCanceled chan struct{}
+}
+
+func (c *cancelOnHeartbeatStopCatalog) LoadTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+) (*icebergtable.Table, error) {
+	if slices.Equal(ident, c.lock) && c.guardCreated.Load() && c.blockRenew.CompareAndSwap(true, false) {
+		close(c.renewStarted)
+		<-ctx.Done()
+		close(c.renewCanceled)
+		return nil, ctx.Err()
+	}
+	return c.Catalog.LoadTable(ctx, ident)
+}
+
+func (c *cancelOnHeartbeatStopCatalog) CreateTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	tableSchema *iceberggo.Schema,
+	opts ...icebergcatalog.CreateTableOpt,
+) (*icebergtable.Table, error) {
+	if slices.Equal(ident, c.target) {
+		<-c.renewStarted
+	}
+	tbl, err := c.Catalog.CreateTable(ctx, ident, tableSchema, opts...)
+	if err == nil && slices.Equal(ident, c.lock) {
+		c.guardCreated.Store(true)
+	}
+	return tbl, err
+}
+
+func (c *blockingPurgeHeartbeatFailureCatalog) CatalogType() icebergcatalog.Type {
+	return icebergcatalog.REST
+}
+
+func (c *blockingPurgeHeartbeatFailureCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *blockingPurgeHeartbeatFailureCatalog) CommitTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	select {
+	case <-c.purgeStarted:
+		if c.failHeartbeat && strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+			return nil, "", errInjectedPurgeHeartbeatFailure
+		}
+	default:
+	}
+	return c.Catalog.CommitTable(ctx, ident, requirements, updates)
+}
+
+func (c *blockingPurgeHeartbeatFailureCatalog) PurgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if !slices.Equal(ident, c.target) && !isDeletionFenceForTestTarget(ident, c.target) {
+		return c.DropTable(ctx, ident)
+	}
+	close(c.purgeStarted)
+	<-ctx.Done()
+	close(c.purgeCanceled)
+	return ctx.Err()
+}
+
+func (c *replaceBeforePurgeCatalog) CatalogType() icebergcatalog.Type { return icebergcatalog.REST }
+
+func (c *replaceBeforePurgeCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	if slices.Equal(ident, c.target) {
+		c.targetLoads++
+		if c.targetLoads == 2 {
+			if err := c.DropTable(ctx, ident); err != nil {
+				return nil, err
+			}
+			recreated, err := c.CreateTable(ctx, ident, c.schema, icebergcatalog.WithProperties(c.properties))
+			if err != nil {
+				return nil, err
+			}
+			c.recreatedUUID = recreated.Metadata().TableUUID()
+			return recreated, nil
+		}
+	}
+	return c.Catalog.LoadTable(ctx, ident)
+}
+
+func (c *replaceBeforePurgeCatalog) PurgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	c.purgeCalls++
+	return c.DropTable(ctx, ident)
+}
+
+type partialDeleteCatalog struct {
+	icebergcatalog.Catalog
+	fs      *partialDeleteIO
+	dropped bool
+}
+
+func (c *partialDeleteCatalog) CatalogType() icebergcatalog.Type {
+	return icebergcatalog.SQL
+}
+
+func (c *partialDeleteCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	if c.dropped {
+		return nil, icebergcatalog.ErrNoSuchTable
+	}
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listable, ok := tableFS.(icebergio.ListableIO)
+	if !ok {
+		return nil, errors.New("test table filesystem is not listable")
+	}
+	if c.fs == nil {
+		c.fs = &partialDeleteIO{ListableIO: listable}
+	}
+	fsFactory := func(context.Context) (icebergio.IO, error) { return c.fs, nil }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *partialDeleteCatalog) DropTable(context.Context, icebergtable.Identifier) error {
+	c.dropped = true
+	return nil
+}
+
+type partialDeleteIO struct {
+	icebergio.ListableIO
+	failed      bool
+	removeCalls int
+}
+
+func (f *partialDeleteIO) Remove(path string) error {
+	f.removeCalls++
+	err := f.ListableIO.Remove(path)
+	if !f.failed {
+		f.failed = true
+		return errors.Join(err, errors.New("injected failure after deleting one file"))
+	}
+	return err
+}
+
+func (c *clientSidePurgeCatalog) CatalogType() icebergcatalog.Type {
+	return icebergcatalog.SQL
+}
+
+func (c *clientSidePurgeCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	if c.dropConfirmed {
+		return nil, icebergcatalog.ErrNoSuchTable
+	}
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	fs, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listable, ok := fs.(icebergio.ListableIO)
+	if !ok {
+		return nil, errors.New("test table filesystem is not listable")
+	}
+	fsFactory := func(context.Context) (icebergio.IO, error) {
+		return &failingPurgeIO{ListableIO: listable, catalog: c}, nil
+	}
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *clientSidePurgeCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+		return c.Catalog.DropTable(ctx, ident)
+	}
+	c.dropCalls++
+	if c.dropErr != nil {
+		return c.dropErr
+	}
+	c.dropConfirmed = true
+	if c.afterDrop != nil {
+		c.afterDrop()
+	}
+	return nil
+}
+
+type failingPurgeIO struct {
+	icebergio.ListableIO
+	catalog *clientSidePurgeCatalog
+}
+
+func (f *failingPurgeIO) Remove(path string) error {
+	f.catalog.removeCalls++
+	if !f.catalog.dropConfirmed {
+		f.catalog.removeBeforeDrop = true
+	}
+	if f.catalog.purgeErr != nil {
+		return f.catalog.purgeErr
+	}
+	return f.ListableIO.Remove(path)
+}
+
+func lifecycleTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+}
+
+func writeLifecycleTable(
+	t *testing.T,
+	dest *Destination,
+	tableName string,
+	tableSchema *schema.TableSchema,
+	ttl time.Duration,
+) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:        tableName,
+		Schema:       tableSchema,
+		DropFirst:    true,
+		ExpiresAfter: ttl,
+	}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table:  tableName,
+		Schema: tableSchema,
+	}))
+}
+
+func setLifecycleTableProperty(t *testing.T, dest *Destination, tableName, key, value string) {
+	t.Helper()
+	tbl, err := dest.catalog.LoadTable(context.Background(), icebergcatalog.ToIdentifier(tableName))
+	require.NoError(t, err)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(map[string]string{key: value}))
+	_, err = txn.Commit(context.Background())
+	require.NoError(t, err)
+}
+
+func regularFilesUnder(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if errors.Is(err, os.ErrNotExist) {
+			return fs.SkipDir
+		}
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	require.NoError(t, err)
+	return files
+}

--- a/pkg/destination/iceberg/maintenance_test.go
+++ b/pkg/destination/iceberg/maintenance_test.go
@@ -1,0 +1,927 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaintainTableCompactsFilesAndPreservesCommitLineage(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.compaction"
+	tableSchema := lifecycleTestSchema()
+
+	for value := int64(1); value <= 5; value++ {
+		writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{value}})
+	}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema}))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(6)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table:        tableName,
+		Schema:       tableSchema,
+		CommitToken:  "maintenance-token",
+		CDCResumeLSN: "0/16B6C50",
+	}))
+
+	before, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	beforeTasks, err := before.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, beforeTasks, 6)
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles:      true,
+		TargetFileSizeBytes:   1024 * 1024,
+		MinInputFiles:         2,
+		DeleteFileThreshold:   1,
+		EnableManifestMerge:   true,
+		ManifestMinCount:      2,
+		ManifestTargetSize:    1024 * 1024,
+		PreviousMetadataFiles: 2,
+	})
+	require.NoError(t, err)
+	require.Positive(t, result.CompactionGroups)
+	require.Equal(t, 6, result.RemovedDataFiles)
+	require.Less(t, result.AddedDataFiles, result.RemovedDataFiles)
+	require.True(t, result.ManifestMergeEnabled)
+	require.Equal(t, 2, result.PreviousMetadataVersionsKept)
+
+	after, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	afterTasks, err := after.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Less(t, len(afterTasks), len(beforeTasks))
+	require.EqualValues(t, 6, icebergRowCount(ctx, t, dest, tableName))
+	require.True(t, tableHasCommitToken(after, commitTokenID("maintenance-token")))
+	require.Equal(t, "0/16B6C50", latestCDCResumeLSN(after))
+	require.Equal(t, "maintenance", after.CurrentSnapshot().Summary.Properties["ingestr.operation"])
+}
+
+func TestMaintainTableCompactsFilesWithSQLiteCatalog(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	uri := "iceberg+sqlite://" + filepath.Join(t.TempDir(), "catalog.db") +
+		"?warehouse_path=" + url.QueryEscape(t.TempDir())
+	require.NoError(t, dest.Connect(ctx, uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+	tableName := "maintenance.sqlite_compaction"
+	tableSchema := lifecycleTestSchema()
+	for value := int64(1); value <= 4; value++ {
+		writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{value}})
+	}
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles:    true,
+		TargetFileSizeBytes: 1024 * 1024,
+		MinInputFiles:       2,
+	})
+	require.NoError(t, err)
+	require.Positive(t, result.CompactionGroups)
+	require.Equal(t, 4, result.RemovedDataFiles)
+	require.EqualValues(t, 4, icebergRowCount(ctx, t, dest, tableName))
+}
+
+func TestMaintainTableCompactsEachPartitionIndependently(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.partitioned_compaction"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       tableName,
+		Schema:      tableSchema,
+		PartitionBy: "id",
+	}))
+	for iteration := range 3 {
+		for _, value := range []int64{1, 2} {
+			require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema}))
+			require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, value)), destination.WriteOptions{
+				Table:       tableName,
+				Schema:      tableSchema,
+				CommitToken: fmt.Sprintf("partition-%d-%d", iteration, value),
+			}))
+		}
+	}
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles:    true,
+		TargetFileSizeBytes: 1024 * 1024,
+		MinInputFiles:       2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.CompactionGroups)
+	require.Equal(t, 6, result.RemovedDataFiles)
+	require.EqualValues(t, 6, icebergRowCount(ctx, t, dest, tableName))
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+}
+
+func TestMaintainTableSortsEachPartitionAndRecordsCurrentSortOrder(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.partitioned_sorted_compaction"
+	tableSchema := sortAuditSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       tableName,
+		Schema:      tableSchema,
+		PartitionBy: "id",
+		ClusterBy:   []string{"cluster_key"},
+	}))
+	for iteration, clusterKey := range []int64{30, 10, 20} {
+		for _, id := range []int64{1, 2} {
+			require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema}))
+			batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{id, clusterKey, int64(iteration)}})
+			require.NoError(t, err)
+			require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+				Table: tableName, Schema: tableSchema,
+				CommitToken: fmt.Sprintf("partition-sort-%d-%d", iteration, id),
+			}))
+		}
+	}
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles: true, TargetFileSizeBytes: 1024 * 1024, MinInputFiles: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.CompactionGroups)
+	require.Equal(t, 6, result.RemovedDataFiles)
+
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	for _, task := range tasks {
+		require.NotNil(t, task.File.SortOrderID())
+		require.Equal(t, tbl.SortOrder().OrderID(), *task.File.SortOrderID())
+	}
+	assertPhysicalSortOrder(t, dest, tableName)
+}
+
+func TestSafePositionDeletesRequireEveryReferencedDataFileToBeRewritten(t *testing.T) {
+	dataA := testMaintenanceDataFile(t, iceberggo.EntryContentData, "file:///data/a.parquet")
+	dataB := testMaintenanceDataFile(t, iceberggo.EntryContentData, "file:///data/b.parquet")
+	sharedDelete := testMaintenanceDataFile(t, iceberggo.EntryContentPosDeletes, "file:///delete/shared.parquet")
+	aOnlyDelete := testMaintenanceDataFile(t, iceberggo.EntryContentPosDeletes, "file:///delete/a-only.parquet")
+	tasks := []icebergtable.FileScanTask{
+		{File: dataA, DeleteFiles: []iceberggo.DataFile{sharedDelete, aOnlyDelete}},
+		{File: dataB, DeleteFiles: []iceberggo.DataFile{sharedDelete}},
+	}
+
+	oneGroup := []icebergtable.CompactionTaskGroup{{Tasks: tasks[:1]}}
+	require.Equal(t, []string{aOnlyDelete.FilePath()}, dataFilePaths(safePositionDeletesForRewrite(tasks, oneGroup)))
+
+	allGroups := []icebergtable.CompactionTaskGroup{{Tasks: tasks[:1]}, {Tasks: tasks[1:]}}
+	require.Equal(
+		t,
+		[]string{aOnlyDelete.FilePath(), sharedDelete.FilePath()},
+		dataFilePaths(safePositionDeletesForRewrite(tasks, allGroups)),
+	)
+}
+
+func TestSortedCompactionPreservesV3RowLineage(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table.format-version": []string{"3"},
+	})
+	tableName := "maintenance.v3_sorted_lineage"
+	tableSchema := sortAuditSchema()
+	for i, clusterKey := range []int64{30, 10, 20} {
+		prepareSortAuditTable(t, dest, tableName, tableSchema, false, [][]any{{int64(i + 1), clusterKey, int64(i)}})
+	}
+
+	before, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	require.Equal(t, 3, before.Metadata().Version())
+	beforeTasks, err := before.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.True(t, allTasksHaveRowLineage(beforeTasks))
+	lineageBefore := readV3LineageByID(t, before)
+
+	_, err = dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles: true, TargetFileSizeBytes: 1024 * 1024, MinInputFiles: 2,
+	})
+	require.NoError(t, err)
+	after, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	afterTasks, err := after.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.True(t, allTasksHaveRowLineage(afterTasks))
+	require.Equal(t, lineageBefore, readV3LineageByID(t, after))
+}
+
+func TestAllTasksHaveRowLineageRejectsMixedLegacyFiles(t *testing.T) {
+	firstRowID := int64(10)
+	lineage := icebergtable.FileScanTask{FirstRowID: &firstRowID}
+	legacy := icebergtable.FileScanTask{}
+	require.True(t, allTasksHaveRowLineage([]icebergtable.FileScanTask{lineage}))
+	require.False(t, allTasksHaveRowLineage([]icebergtable.FileScanTask{lineage, legacy}))
+	require.False(t, allTasksHaveRowLineage(nil))
+}
+
+func TestCanceledSortedCompactionDoesNotCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.canceled_sorted_compaction"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, tableName, tableSchema, false, [][]any{{int64(1), int64(20), int64(1)}})
+	prepareSortAuditTable(t, dest, tableName, tableSchema, false, [][]any{{int64(2), int64(10), int64(2)}})
+	before, err := dest.loadIcebergTable(context.Background(), tableName)
+	require.NoError(t, err)
+	beforeSnapshotID := before.CurrentSnapshot().SnapshotID
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles: true, TargetFileSizeBytes: 1024 * 1024, MinInputFiles: 2,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	after, loadErr := dest.loadIcebergTable(context.Background(), tableName)
+	require.NoError(t, loadErr)
+	require.Equal(t, beforeSnapshotID, after.CurrentSnapshot().SnapshotID)
+}
+
+func TestSortedCompactionCommitFailureCleansReplacementFiles(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	tableName := "maintenance.sorted_cleanup"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, tableName, tableSchema, false, [][]any{{int64(1), int64(20), int64(1)}})
+	prepareSortAuditTable(t, dest, tableName, tableSchema, false, [][]any{{int64(2), int64(10), int64(2)}})
+	before := allTableParquetFiles(t, dest, tableName)
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{icebergtable.ErrCommitFailed}}
+
+	_, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		CompactDataFiles: true, TargetFileSizeBytes: 1024 * 1024, MinInputFiles: 2,
+	})
+	require.ErrorIs(t, err, icebergtable.ErrCommitFailed)
+	require.Equal(t, before, allTableParquetFiles(t, dest, tableName))
+}
+
+func readV3LineageByID(t *testing.T, tbl *icebergtable.Table) map[int64][2]int64 {
+	t.Helper()
+	arrowSchema, records, err := tbl.Scan(icebergtable.WithRowLineage()).ToArrowRecords(context.Background())
+	require.NoError(t, err)
+	idColumns := make(map[string]int, 3)
+	for i, field := range arrowSchema.Fields() {
+		idColumns[field.Name] = i
+	}
+	require.Contains(t, idColumns, "id")
+	require.Contains(t, idColumns, "_row_id")
+	require.Contains(t, idColumns, "_last_updated_sequence_number")
+
+	result := make(map[int64][2]int64)
+	for batch, readErr := range records {
+		require.NoError(t, readErr)
+		for row := 0; row < int(batch.NumRows()); row++ {
+			idValue, valueErr := rowValue(batch.Column(idColumns["id"]), row)
+			require.NoError(t, valueErr)
+			rowID, valueErr := rowValue(batch.Column(idColumns["_row_id"]), row)
+			require.NoError(t, valueErr)
+			sequence, valueErr := rowValue(batch.Column(idColumns["_last_updated_sequence_number"]), row)
+			require.NoError(t, valueErr)
+			require.NotNil(t, rowID)
+			require.NotNil(t, sequence)
+			result[idValue.(int64)] = [2]int64{rowID.(int64), sequence.(int64)}
+		}
+		batch.Release()
+	}
+	return result
+}
+
+func testMaintenanceDataFile(t *testing.T, content iceberggo.ManifestEntryContent, path string) iceberggo.DataFile {
+	t.Helper()
+	builder, err := iceberggo.NewDataFileBuilder(
+		*iceberggo.UnpartitionedSpec, content, path, iceberggo.ParquetFile,
+		nil, nil, nil, 1, 1,
+	)
+	require.NoError(t, err)
+	return builder.Build()
+}
+
+func dataFilePaths(files []iceberggo.DataFile) []string {
+	paths := make([]string, len(files))
+	for i, file := range files {
+		paths[i] = file.FilePath()
+	}
+	return paths
+}
+
+func TestMaintainTableCompactsEqualityDeletesWithoutChangingRows(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	target := "maintenance.delete_compaction"
+	staging := "maintenance.delete_compaction_staging"
+	tableSchema := mergeTestSchema()
+	tableSchema.PrimaryKeys = []string{"id"}
+	base := micros(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), "v0", 0.0, base},
+		{int64(2), "unchanged", 2.0, base},
+	})
+	for version := 1; version <= 5; version++ {
+		writeTableRows(t, dest, staging, tableSchema, true, [][]any{
+			{int64(1), fmt.Sprintf("v%d", version), float64(version), base + int64(version)},
+		})
+		require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+			StagingTable:   staging,
+			TargetTable:    target,
+			PrimaryKeys:    []string{"id"},
+			Columns:        tableSchema.ColumnNames(),
+			IncrementalKey: "updated_at",
+		}))
+	}
+
+	before, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	beforeTasks, err := before.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	var equalityDeletesBefore int
+	for _, task := range beforeTasks {
+		equalityDeletesBefore += len(task.EqualityDeleteFiles)
+	}
+	require.Positive(t, equalityDeletesBefore)
+
+	result, err := dest.MaintainTable(ctx, target, MaintenanceOptions{
+		CompactDataFiles:    true,
+		TargetFileSizeBytes: 1024 * 1024,
+		MinInputFiles:       1,
+		DeleteFileThreshold: 1,
+	})
+	require.NoError(t, err)
+	require.Positive(t, result.RemovedEqualityDeleteFiles)
+
+	after, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	afterTasks, err := after.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	for _, task := range afterTasks {
+		require.Empty(t, task.EqualityDeleteFiles)
+	}
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Equal(t, "v5", rows[int64(1)][1])
+	require.Equal(t, "unchanged", rows[int64(2)][1])
+}
+
+func TestMaintainTableExpiresSnapshotsThenDeletesOnlyGraceAgedOrphans(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.expiration"
+	tableSchema := lifecycleTestSchema()
+
+	for value := int64(1); value <= 5; value++ {
+		writeTableRows(t, dest, tableName, tableSchema, true, [][]any{{value}})
+		time.Sleep(2 * time.Millisecond)
+	}
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	require.Len(t, tbl.Metadata().Snapshots(), 5)
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	orphan := filepath.Join(location, "data", "abandoned-write.parquet")
+	require.NoError(t, os.WriteFile(orphan, []byte("not parquet"), 0o600))
+	ageFiles(t, location, 25*time.Hour)
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		ExpireSnapshots:    true,
+		SnapshotMaxAge:     time.Millisecond,
+		MinSnapshotsToKeep: 2,
+		DeleteOrphanFiles:  true,
+		OrphanFileAge:      24 * time.Hour,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 5, result.SnapshotsBefore)
+	require.Equal(t, 2, result.SnapshotsAfter)
+	require.Positive(t, result.DeletedOrphanFiles)
+	require.NoFileExists(t, orphan)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, tableName))
+	rows := readTableRows(t, dest, tableName)
+	require.Equal(t, int64(5), rows.Rows[0][0])
+}
+
+func TestMaintainTableExpirationCarriesCommitTokenAndCDCCursorForward(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.lineage_expiration"
+	tableSchema := lifecycleTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema}))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(1)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table:        tableName,
+		Schema:       tableSchema,
+		CommitToken:  "cursor-snapshot-token",
+		CDCResumeLSN: "0/ABCDEF",
+	}))
+	for value := int64(2); value <= 5; value++ {
+		writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{value}})
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		ExpireSnapshots:    true,
+		SnapshotMaxAge:     time.Millisecond,
+		MinSnapshotsToKeep: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.SnapshotsAfter)
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	require.Equal(t, "0/ABCDEF", latestCDCResumeLSN(tbl))
+	require.True(t, tableHasCommitToken(tbl, commitTokenID("cursor-snapshot-token")))
+	require.Equal(t, "0/ABCDEF", tbl.CurrentSnapshot().Summary.Properties[snapshotCDCResumeLSNKey])
+	require.Equal(t, commitTokenID("cursor-snapshot-token"), tbl.CurrentSnapshot().Summary.Properties[snapshotCommitTokenKey])
+	require.EqualValues(t, 5, icebergRowCount(ctx, t, dest, tableName))
+}
+
+func TestMaintainTableTrimsAndDeletesOldMetadata(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.metadata_cleanup"
+	tableSchema := lifecycleTestSchema()
+
+	for value := int64(1); value <= 6; value++ {
+		writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{value}})
+	}
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	metadataDir := filepath.Join(location, "metadata")
+	metadataBefore := metadataJSONFiles(t, metadataDir)
+	require.Greater(t, len(metadataBefore), 3)
+	ageFiles(t, location, 25*time.Hour)
+
+	result, err := dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		DeleteOrphanFiles:     true,
+		OrphanFileAge:         24 * time.Hour,
+		PreviousMetadataFiles: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.PreviousMetadataVersionsKept)
+	require.Positive(t, result.DeletedOrphanFiles)
+	metadataAfter := metadataJSONFiles(t, metadataDir)
+	require.Less(t, len(metadataAfter), len(metadataBefore))
+	// Current metadata plus at most two retained previous versions.
+	require.LessOrEqual(t, len(metadataAfter), 3)
+	require.EqualValues(t, 6, icebergRowCount(ctx, t, dest, tableName))
+}
+
+func TestMaintainTableRejectsUnsafeOrphanDeletionWindow(t *testing.T) {
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "maintenance.unsafe_orphans", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+
+	_, err := dest.MaintainTable(context.Background(), "maintenance.unsafe_orphans", MaintenanceOptions{
+		DeleteOrphanFiles: true,
+		OrphanFileAge:     time.Hour,
+	})
+	require.ErrorContains(t, err, "minimum is 24h0m0s")
+}
+
+func TestConnectRejectsNamespaceCollidingLocationTemplate(t *testing.T) {
+	ctx := context.Background()
+	warehouse := t.TempDir()
+	dest := NewDestination()
+	uri := "iceberg+sqlite://" + filepath.Join(t.TempDir(), "catalog.db") + "?warehouse_path=" + url.QueryEscape(warehouse) +
+		"&table_location=" + url.QueryEscape(filepath.Join(warehouse, "{table}"))
+	err := dest.Connect(ctx, uri)
+	require.ErrorContains(t, err, "both a namespace and {table}")
+}
+
+func TestOrphanCleanupTemplateRequiresNamespaceAndTable(t *testing.T) {
+	for _, tt := range []struct {
+		template string
+		wantErr  bool
+	}{
+		{template: "s3://bucket/{table}", wantErr: true},
+		{template: "s3://bucket/fixed", wantErr: true},
+		{template: "s3://bucket/{namespace}", wantErr: true},
+		{template: "s3://bucket/{namespace}/{table}"},
+		{template: "s3://bucket/{namespace_dot}/{table}"},
+		{template: "s3://bucket/{identifier}"},
+		{template: "s3://bucket/{identifier_dot}"},
+	} {
+		err := validateOrphanCleanupTemplate(tt.template)
+		if tt.wantErr {
+			require.Error(t, err, tt.template)
+		} else {
+			require.NoError(t, err, tt.template)
+		}
+	}
+}
+
+func TestOrphanCleanupIsolationUsesVerifiedConfiguredTableLocation(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "maintenance.target", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	target, err := dest.loadIcebergTable(ctx, "maintenance.target")
+	require.NoError(t, err)
+	warehouse := dest.cfg.Properties.Get("warehouse", "")
+	dest.cfg.TableLocation = filepath.Join(warehouse, "{namespace}", "{table}")
+
+	wrapped := &namespaceListingFailureCatalog{Catalog: dest.catalog, err: errors.New("nested namespace pagination failed")}
+	dest.catalog = wrapped
+	require.NoError(t, dest.validateOrphanCleanupLocation(ctx, target.Identifier(), target.Location()))
+	require.Zero(t, wrapped.calls, "an exact injective table-location template must not require a catalog-wide scan")
+}
+
+func TestOrphanCleanupIsolationAllowsDescendantOfVerifiedConfiguredLocation(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "maintenance.target", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	target, err := dest.loadIcebergTable(ctx, "maintenance.target")
+	require.NoError(t, err)
+	warehouse := dest.cfg.Properties.Get("warehouse", "")
+	dest.cfg.TableLocation = filepath.Join(warehouse, "{namespace}", "{table}")
+	descendant := filepath.Join(target.Location(), "_ingestr_connection_check_unique")
+	require.NoError(t, os.MkdirAll(descendant, 0o755))
+	descendantRoot, err := canonicalTableRoot(descendant)
+	require.NoError(t, err)
+
+	isolated, err := dest.configuredTableLocationProvesIsolation(target.Identifier(), descendant, descendantRoot)
+	require.NoError(t, err)
+	require.True(t, isolated)
+}
+
+func TestOrphanCleanupIsolationRejectsConfiguredLocationMismatchWithoutBypass(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "maintenance.target", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	target, err := dest.loadIcebergTable(ctx, "maintenance.target")
+	require.NoError(t, err)
+	warehouse := dest.cfg.Properties.Get("warehouse", "")
+	dest.cfg.TableLocation = filepath.Join(warehouse, "different", "{namespace}", "{table}")
+
+	wrapped := &namespaceListingFailureCatalog{Catalog: dest.catalog, err: errors.New("must not be reached")}
+	dest.catalog = wrapped
+	err = dest.validateOrphanCleanupLocation(ctx, target.Identifier(), target.Location())
+	require.ErrorContains(t, err, "is not within configured isolated location")
+	require.Zero(t, wrapped.calls)
+}
+
+func TestOrphanCleanupIsolationStillScansCatalogAssignedLocations(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "maintenance.target", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	target, err := dest.loadIcebergTable(ctx, "maintenance.target")
+	require.NoError(t, err)
+
+	scanErr := errors.New("catalog namespace scan failed")
+	wrapped := &namespaceListingFailureCatalog{Catalog: dest.catalog, err: scanErr}
+	dest.catalog = wrapped
+	err = dest.validateOrphanCleanupLocation(ctx, target.Identifier(), target.Location())
+	require.ErrorIs(t, err, scanErr)
+	require.Equal(t, 1, wrapped.calls)
+}
+
+func TestOrphanCleanupIsolationSupportsFlatHiveNamespaces(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "maintenance.target", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	writeTableRows(t, dest, "maintenance.sibling", lifecycleTestSchema(), false, [][]any{{int64(2)}})
+	target, err := dest.loadIcebergTable(ctx, "maintenance.target")
+	require.NoError(t, err)
+
+	dest.catalog = &flatNamespaceOnlyCatalog{Catalog: dest.catalog}
+	dest.cfg.Properties["type"] = "hive"
+	require.NoError(t, dest.validateOrphanCleanupLocation(ctx, target.Identifier(), target.Location()))
+}
+
+func TestMaintainTableUnknownCommitNeverDeletesFiles(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableName := "maintenance.unknown_commit"
+	tableSchema := lifecycleTestSchema()
+	for value := int64(1); value <= 3; value++ {
+		writeTableRows(t, dest, tableName, tableSchema, true, [][]any{{value}})
+		time.Sleep(2 * time.Millisecond)
+	}
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	orphan := filepath.Join(location, "data", "unknown-status-orphan.parquet")
+	require.NoError(t, os.WriteFile(orphan, []byte("keep until reconciled"), 0o600))
+	ageFiles(t, location, 25*time.Hour)
+
+	base := dest.catalog
+	dest.catalog = &unknownAfterCommitCatalog{Catalog: base}
+	_, err = dest.MaintainTable(ctx, tableName, MaintenanceOptions{
+		ExpireSnapshots:    true,
+		SnapshotMaxAge:     time.Millisecond,
+		MinSnapshotsToKeep: 1,
+		DeleteOrphanFiles:  true,
+		OrphanFileAge:      24 * time.Hour,
+	})
+	require.ErrorContains(t, err, "unknown commit status")
+	require.FileExists(t, orphan)
+	dest.catalog = base
+}
+
+func TestConfiguredMaintenanceOptionsAreOffByDefaultAndRateLimited(t *testing.T) {
+	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	opts, due, err := configuredMaintenanceOptions(iceberggo.Properties{}, now)
+	require.NoError(t, err)
+	require.False(t, due)
+	require.Equal(t, MaintenanceOptions{}, opts)
+
+	props := iceberggo.Properties{
+		maintenanceEnabledProperty:          "true",
+		maintenanceIntervalMSProperty:       strconvDuration(time.Hour),
+		maintenanceLastRunAtProperty:        now.Add(-30 * time.Minute).Format(time.RFC3339Nano),
+		maintenanceCompactDataProperty:      "false",
+		maintenanceDeleteOrphansProperty:    "false",
+		maintenanceExpireSnapshotsProperty:  "true",
+		maintenanceMinSnapshotsProperty:     "7",
+		maintenanceSnapshotMaxAgeMSProperty: strconvDuration(48 * time.Hour),
+	}
+	_, due, err = configuredMaintenanceOptions(props, now)
+	require.NoError(t, err)
+	require.False(t, due)
+
+	props[maintenanceLastRunAtProperty] = now.Add(-2 * time.Hour).Format(time.RFC3339Nano)
+	opts, due, err = configuredMaintenanceOptions(props, now)
+	require.NoError(t, err)
+	require.True(t, due)
+	require.True(t, opts.ExpireSnapshots)
+	require.Equal(t, 48*time.Hour, opts.SnapshotMaxAge)
+	require.Equal(t, 7, opts.MinSnapshotsToKeep)
+	require.False(t, opts.CompactDataFiles)
+	require.False(t, opts.DeleteOrphanFiles)
+	require.True(t, opts.EnableManifestMerge)
+
+	props[maintenanceManifestMergeProperty] = "false"
+	opts, due, err = configuredMaintenanceOptions(props, now)
+	require.NoError(t, err)
+	require.True(t, due)
+	require.False(t, opts.EnableManifestMerge)
+	require.True(t, opts.configureManifestMerge)
+}
+
+func TestConnectRejectsUnsafeOrInvalidMaintenanceConfiguration(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			name:    "unsafe orphan window",
+			query:   "&table." + maintenanceEnabledProperty + "=true&table." + maintenanceOrphanAgeMSProperty + "=3600000",
+			wantErr: "orphan file age 1h0m0s is unsafe",
+		},
+		{
+			name:    "invalid boolean",
+			query:   "&table." + maintenanceEnabledProperty + "=true&table." + maintenanceCompactDataProperty + "=sometimes",
+			wantErr: "invalid ingestr.maintenance.compact-data-files value",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := NewDestination()
+			err := dest.Connect(context.Background(), "iceberg+hadoop://?warehouse="+url.QueryEscape(t.TempDir())+tt.query)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestRunConfiguredMaintenanceRecordsSuccessfulRun(t *testing.T) {
+	ctx := context.Background()
+	warehouse := t.TempDir()
+	dest := NewDestination()
+	uri := "iceberg+hadoop://?warehouse=" + url.QueryEscape(warehouse) +
+		"&table." + maintenanceEnabledProperty + "=true" +
+		"&table." + maintenanceCompactDataProperty + "=false" +
+		"&table." + maintenanceExpireSnapshotsProperty + "=false" +
+		"&table." + maintenanceDeleteOrphansProperty + "=false"
+	require.NoError(t, dest.Connect(ctx, uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+	writeTableRows(t, dest, "maintenance.configured", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+
+	dest.runConfiguredMaintenance(ctx, "maintenance.configured")
+	tbl, err := dest.loadIcebergTable(ctx, "maintenance.configured")
+	require.NoError(t, err)
+	_, err = time.Parse(time.RFC3339Nano, tbl.Properties()[maintenanceLastRunAtProperty])
+	require.NoError(t, err)
+	require.Equal(t, "true", tbl.Properties()[icebergtable.ManifestMergeEnabledKey])
+}
+
+func TestRunConfiguredMaintenanceSkipsRecreatedExpectedTarget(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "maintenance.recreated_expected_target"
+	tableSchema := lifecycleTestSchema()
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	original, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.NoError(t, recreateTableWithCommitToken(ctx, dest.catalog, original.Identifier(), tableSchema, "recreated"))
+	dest.cfg.TableProperties[maintenanceEnabledProperty] = "true"
+	dest.cfg.TableProperties[maintenanceCompactDataProperty] = "false"
+	dest.cfg.TableProperties[maintenanceExpireSnapshotsProperty] = "false"
+	dest.cfg.TableProperties[maintenanceDeleteOrphansProperty] = "false"
+
+	dest.runConfiguredMaintenanceExpected(ctx, table, original.Metadata().TableUUID().String())
+	recreated, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.NotEqual(t, original.Metadata().TableUUID(), recreated.Metadata().TableUUID())
+	require.Empty(t, recreated.Properties()[maintenanceLastRunAtProperty])
+}
+
+func TestConfiguredMaintenanceAppliesToAnExistingTable(t *testing.T) {
+	ctx := context.Background()
+	warehouse := t.TempDir()
+	baseURI := "iceberg+hadoop://?warehouse=" + url.QueryEscape(warehouse)
+	first := NewDestination()
+	require.NoError(t, first.Connect(ctx, baseURI))
+	writeTableRows(t, first, "maintenance.existing", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	require.NoError(t, first.Close(ctx))
+
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, baseURI+
+		"&table."+maintenanceEnabledProperty+"=true"+
+		"&table."+maintenanceCompactDataProperty+"=false"+
+		"&table."+maintenanceExpireSnapshotsProperty+"=false"+
+		"&table."+maintenanceDeleteOrphansProperty+"=false"))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+	writeTableRows(t, dest, "maintenance.existing", lifecycleTestSchema(), false, [][]any{{int64(2)}})
+
+	tbl, err := dest.loadIcebergTable(ctx, "maintenance.existing")
+	require.NoError(t, err)
+	_, err = time.Parse(time.RFC3339Nano, tbl.Properties()[maintenanceLastRunAtProperty])
+	require.NoError(t, err)
+	require.Equal(t, "true", tbl.Properties()[icebergtable.ManifestMergeEnabledKey])
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, "maintenance.existing"))
+}
+
+func TestPostCommitHookCleansExpiredManagedTablesHourlyAndExcludesActiveTable(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, "maintenance.active_staging", tableSchema, time.Hour)
+	writeLifecycleTable(t, dest, "maintenance.abandoned_staging", tableSchema, time.Hour)
+	setManagedExpiration(t, dest, "maintenance.active_staging", time.Now().Add(-time.Hour))
+	setManagedExpiration(t, dest, "maintenance.abandoned_staging", time.Now().Add(-time.Hour))
+	// The setup writes legitimately claimed the namespace scan. Release it so
+	// this call represents the next hourly opportunity.
+	dest.mu.Lock()
+	delete(dest.expirationScans, "maintenance")
+	dest.mu.Unlock()
+
+	dest.runConfiguredMaintenance(ctx, "maintenance.active_staging")
+	for tableName, wantExists := range map[string]bool{
+		"maintenance.active_staging":    true,
+		"maintenance.abandoned_staging": false,
+	} {
+		exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier(tableName))
+		require.NoError(t, err)
+		require.Equal(t, wantExists, exists, tableName)
+	}
+	active, err := dest.loadIcebergTable(ctx, "maintenance.active_staging")
+	require.NoError(t, err)
+	activeExpiration, managed, err := managedTableExpiration(active.Properties())
+	require.NoError(t, err)
+	require.True(t, managed)
+	require.True(t, activeExpiration.After(time.Now().Add(30*time.Minute)), "active lease must be refreshed")
+
+	writeLifecycleTable(t, dest, "maintenance.second_abandoned", tableSchema, time.Hour)
+	setManagedExpiration(t, dest, "maintenance.second_abandoned", time.Now().Add(-time.Hour))
+	dest.runConfiguredMaintenance(ctx, "maintenance.active_staging")
+	exists, err := dest.tableExists(ctx, icebergcatalog.ToIdentifier("maintenance.second_abandoned"))
+	require.NoError(t, err)
+	require.True(t, exists, "second scan must be throttled")
+
+	dest.mu.Lock()
+	dest.expirationScans["maintenance"] = time.Now().Add(-2 * time.Hour).UnixNano()
+	dest.mu.Unlock()
+	dest.runConfiguredMaintenance(ctx, "maintenance.active_staging")
+	exists, err = dest.tableExists(ctx, icebergcatalog.ToIdentifier("maintenance.second_abandoned"))
+	require.NoError(t, err)
+	require.False(t, exists)
+	exists, err = dest.tableExists(ctx, icebergcatalog.ToIdentifier("maintenance.active_staging"))
+	require.NoError(t, err)
+	require.True(t, exists, "active table must always be excluded")
+}
+
+type flatNamespaceOnlyCatalog struct {
+	icebergcatalog.Catalog
+}
+
+type namespaceListingFailureCatalog struct {
+	icebergcatalog.Catalog
+	err   error
+	calls int
+}
+
+func (c *namespaceListingFailureCatalog) ListNamespaces(context.Context, icebergtable.Identifier) ([]icebergtable.Identifier, error) {
+	c.calls++
+	return nil, c.err
+}
+
+func (c *flatNamespaceOnlyCatalog) ListNamespaces(ctx context.Context, parent icebergtable.Identifier) ([]icebergtable.Identifier, error) {
+	if len(parent) > 0 {
+		return nil, errors.New("hierarchical namespace is not supported")
+	}
+	return c.Catalog.ListNamespaces(ctx, parent)
+}
+
+type unknownAfterCommitCatalog struct {
+	icebergcatalog.Catalog
+}
+
+func (c *unknownAfterCommitCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	return icebergtable.New(
+		tbl.Identifier(),
+		tbl.Metadata(),
+		tbl.MetadataLocation(),
+		func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) },
+		c,
+	), nil
+}
+
+func (c *unknownAfterCommitCatalog) CommitTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	metadata, location, err := c.Catalog.CommitTable(ctx, ident, requirements, updates)
+	if err != nil {
+		return metadata, location, err
+	}
+	return metadata, location, errors.New("unknown commit status")
+}
+
+func ageFiles(t *testing.T, root string, age time.Duration) {
+	t.Helper()
+	then := time.Now().Add(-age)
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		return os.Chtimes(path, then, then)
+	}))
+}
+
+func metadataJSONFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && filepath.Ext(path) == ".json" {
+			files = append(files, path)
+		}
+		return nil
+	}))
+	return files
+}
+
+func strconvDuration(value time.Duration) string {
+	return fmt.Sprintf("%d", value.Milliseconds())
+}
+
+func setManagedExpiration(t *testing.T, dest *Destination, tableName string, expiration time.Time) {
+	t.Helper()
+	tbl, err := dest.loadIcebergTable(context.Background(), tableName)
+	require.NoError(t, err)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		managedTableExpiresAt: expiration.UTC().Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(context.Background())
+	require.NoError(t, err)
+}
+
+func TestOrphanCleanupRejectsTargetNestedInsideAnotherTable(t *testing.T) {
+	dest := newHadoopDestination(t)
+	writeTableRows(t, dest, "ns.b", lifecycleTestSchema(), false, [][]any{{int64(1)}})
+	writeTableRows(t, dest, "ns.b.data", lifecycleTestSchema(), false, [][]any{{int64(2)}})
+
+	_, err := dest.MaintainTable(context.Background(), "ns.b.data", MaintenanceOptions{
+		DeleteOrphanFiles: true,
+		OrphanFileAge:     24 * time.Hour,
+	})
+	require.ErrorContains(t, err, "overlapping location")
+}

--- a/pkg/destination/iceberg/nested_types_test.go
+++ b/pkg/destination/iceberg/nested_types_test.go
@@ -1,0 +1,350 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIcebergArrowTypeRecursivelyPreservesUUIDAndStringifiesJSON(t *testing.T) {
+	uuidCol := schema.Column{Name: "id", DataType: schema.TypeUUID, Nullable: false}
+	jsonCol := schema.Column{Name: "payload", DataType: schema.TypeJSON, Nullable: true}
+	unknownCol := schema.Column{Name: "unknown", DataType: schema.TypeUnknown, Nullable: true}
+	col := schema.Column{
+		Name: "nested", DataType: schema.TypeStruct,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{
+			uuidCol,
+			{Name: "items", DataType: schema.TypeArray, Element: &schema.Column{
+				Name: "element", DataType: schema.TypeStruct, Nullable: true,
+				StructFields: &schema.TableSchema{Columns: []schema.Column{uuidCol, jsonCol}},
+			}},
+			{Name: "lookup", DataType: schema.TypeMap, MapKey: &uuidCol, MapValue: &unknownCol},
+		}},
+	}
+	structType := icebergArrowType(col).(*arrow.StructType)
+	require.IsType(t, &extensions.UUIDType{}, structType.Field(0).Type)
+	listStruct := structType.Field(1).Type.(*arrow.ListType).Elem().(*arrow.StructType)
+	require.IsType(t, &extensions.UUIDType{}, listStruct.Field(0).Type)
+	require.Equal(t, arrow.STRING, listStruct.Field(1).Type.ID())
+	mapType := structType.Field(2).Type.(*arrow.MapType)
+	require.IsType(t, &extensions.UUIDType{}, mapType.KeyType())
+	require.Equal(t, arrow.STRING, mapType.ItemType().ID())
+}
+
+func TestLegacyFixedBinaryArrayPreservesWidth(t *testing.T) {
+	col := schema.Column{Name: "digests", DataType: schema.TypeArray, ArrayType: schema.TypeFixedBinary, FixedLength: 8}
+	list := icebergArrowType(col).(*arrow.ListType)
+	require.Equal(t, 8, list.Elem().(*arrow.FixedSizeBinaryType).ByteWidth)
+	generic := schema.DataTypeToArrowType(col).(*arrow.ListType)
+	require.Equal(t, 8, generic.Elem().(*arrow.FixedSizeBinaryType).ByteWidth)
+	iceType, err := icebergTypeForColumn(col)
+	require.NoError(t, err)
+	roundTripped := schema.Column{Name: col.Name}
+	require.NoError(t, applyIcebergType(&roundTripped, iceType))
+	require.Equal(t, schema.TypeFixedBinary, roundTripped.ArrayType)
+	require.Equal(t, 8, roundTripped.FixedLength)
+	require.NotNil(t, roundTripped.Element)
+	require.Equal(t, 8, roundTripped.Element.FixedLength)
+}
+
+func TestIcebergRejectsFixedSizeListsWithoutLosingCardinality(t *testing.T) {
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "coordinates", DataType: schema.TypeArray, ArrayLength: 3,
+		Element: &schema.Column{Name: "element", DataType: schema.TypeFloat64, Nullable: false},
+	}}}
+	_, err := icebergSchemaFromTableSchema(tableSchema)
+	require.ErrorContains(t, err, "fixed-size list column")
+	require.ErrorContains(t, err, "do not preserve cardinality")
+}
+
+func TestNativeNestedTypesRoundTrip(t *testing.T) {
+	dest := newHadoopDestination(t)
+	table := "lake.types.native_nested"
+	intElement := &schema.Column{Name: "element", DataType: schema.TypeInt64, Nullable: false}
+	stringElement := &schema.Column{Name: "element", DataType: schema.TypeString, Nullable: true}
+	innerList := &schema.Column{
+		Name: "element", DataType: schema.TypeArray, Nullable: true,
+		ArrayType: schema.TypeString, Element: stringElement,
+	}
+	mapKey := &schema.Column{Name: "key", DataType: schema.TypeString, Nullable: false}
+	mapValue := &schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "digest", DataType: schema.TypeFixedBinary, FixedLength: 4, Nullable: false},
+		{Name: "required_items", DataType: schema.TypeArray, ArrayType: schema.TypeInt64, Element: intElement, Nullable: true},
+		{Name: "nested_items", DataType: schema.TypeArray, ArrayType: schema.TypeArray, Element: innerList, Nullable: true},
+		{
+			Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+			StructFields: &schema.TableSchema{Columns: []schema.Column{
+				{Name: "code", DataType: schema.TypeInt32, Nullable: false},
+				{Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString, Element: stringElement, Nullable: true},
+			}},
+		},
+		{Name: "attributes", DataType: schema.TypeMap, MapKey: mapKey, MapValue: mapValue, Nullable: true},
+	}}
+	rows := [][]any{{
+		int64(1),
+		[]byte{1, 2, 3, 4},
+		[]any{int64(10), int64(20)},
+		[]any{[]any{"a", "b"}, nil, []any{"c"}},
+		structVal{int64(7), []any{"blue", nil}},
+		mapVal{{key: "one", value: "first"}, {key: "two", value: nil}},
+	}}
+
+	require.NoError(t, dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true,
+	}))
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), rows)
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(context.Background(), recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}))
+
+	loadedSchema, err := dest.GetTableSchema(context.Background(), table)
+	require.NoError(t, err)
+	require.True(t, tableSchema.SameColumnShape(loadedSchema))
+	loaded := readTableRows(t, dest, table)
+	require.Len(t, loaded.Rows, 1)
+	for i := range rows[0] {
+		require.Truef(t, valuesEqual(rows[0][i], loaded.Rows[0][i]), "column %d: want %#v, got %#v", i, rows[0][i], loaded.Rows[0][i])
+	}
+}
+
+func TestSharedArrowConversionWritesNestedValuesToIceberg(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.types.shared_arrow_conversion"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "profile", DataType: schema.TypeStruct, Nullable: true, StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeInt64, Nullable: true},
+		}}},
+		{
+			Name: "attributes", DataType: schema.TypeMap, Nullable: true,
+			MapKey: &schema.Column{Name: "key", DataType: schema.TypeString}, MapValue: &schema.Column{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+		},
+		{Name: "digest", DataType: schema.TypeFixedBinary, FixedLength: 4, Nullable: true},
+	}}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema([]map[string]interface{}{{
+		"id": int64(1), "profile": map[string]interface{}{"name": "alice", "score": int64(9)},
+		"attributes": map[string]int64{"b": 2, "a": 1}, "digest": []byte{1, 2, 3, 4},
+	}}, tableSchema.Columns, nil)
+	require.NoError(t, err)
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(record), destination.WriteOptions{Table: table, Schema: tableSchema}))
+
+	rows := readTableRows(t, dest, table).Rows
+	require.Len(t, rows, 1)
+	require.True(t, valuesEqual(structVal{"alice", int64(9)}, rows[0][1]))
+	require.True(t, valuesEqual(mapVal{{key: "a", value: int64(1)}, {key: "b", value: int64(2)}}, rows[0][2]))
+	require.Equal(t, []byte{1, 2, 3, 4}, rows[0][3])
+}
+
+func TestNativeNestedSchemaValidation(t *testing.T) {
+	require.ErrorContains(t, validateIcebergTableSchema(&schema.TableSchema{Columns: []schema.Column{{
+		Name: "bad_fixed", DataType: schema.TypeFixedBinary,
+	}}}), "positive length")
+	require.ErrorContains(t, validateIcebergTableSchema(&schema.TableSchema{Columns: []schema.Column{{
+		Name: "bad_map", DataType: schema.TypeMap,
+		MapKey:   &schema.Column{DataType: schema.TypeString, Nullable: true},
+		MapValue: &schema.Column{DataType: schema.TypeString, Nullable: true},
+	}}}), "cannot be nullable")
+}
+
+func TestNestedRowRebuildRejectsRequiredNullsWithPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		col  schema.Column
+		row  any
+		path string
+	}{
+		{
+			name: "list element",
+			col: schema.Column{
+				Name: "items", DataType: schema.TypeArray, Nullable: true,
+				Element: &schema.Column{Name: "element", DataType: schema.TypeString, Nullable: false},
+			},
+			row: []any{nil}, path: "items.element[0]",
+		},
+		{
+			name: "struct member",
+			col: schema.Column{
+				Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+				StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: false}}},
+			},
+			row: structVal{nil}, path: "profile.name",
+		},
+		{
+			name: "map key",
+			col: schema.Column{
+				Name: "attributes", DataType: schema.TypeMap, Nullable: true,
+				MapKey:   &schema.Column{Name: "key", DataType: schema.TypeString, Nullable: false},
+				MapValue: &schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true},
+			},
+			row: mapVal{{key: nil, value: "x"}}, path: "attributes.key[0]",
+		},
+		{
+			name: "map value",
+			col: schema.Column{
+				Name: "attributes", DataType: schema.TypeMap, Nullable: true,
+				MapKey:   &schema.Column{Name: "key", DataType: schema.TypeString, Nullable: false},
+				MapValue: &schema.Column{Name: "value", DataType: schema.TypeString, Nullable: false},
+			},
+			row: mapVal{{key: "x", value: nil}}, path: "attributes.value[0]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildRecordBatches(icebergArrowSchema(&schema.TableSchema{Columns: []schema.Column{tt.col}}), [][]any{{tt.row}})
+			require.ErrorContains(t, err, tt.path)
+			require.ErrorContains(t, err, "required nested value")
+		})
+	}
+}
+
+func TestAtomicTruncateInsertAddsNestedColumnWithRows(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.types.atomic_nested_evolution"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	profile := schema.Column{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: false},
+			{
+				Name: "scores", DataType: schema.TypeArray, ArrayType: schema.TypeInt64, Nullable: true,
+				Element: &schema.Column{Name: "element", DataType: schema.TypeInt64, Nullable: false},
+			},
+		}},
+	}
+	evolved := &schema.TableSchema{Columns: []schema.Column{initial.Columns[0], profile}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(evolved), [][]any{{int64(2), structVal{"new", []any{int64(8), int64(9)}}}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: evolved,
+	}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.True(t, evolved.SameColumnShape(loaded))
+	require.True(t, valuesEqual(structVal{"new", []any{int64(8), int64(9)}}, readTableRows(t, dest, table).Rows[0][1]))
+}
+
+func TestAtomicTruncateInsertEvolvesExistingNestedChildren(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.types.atomic_nested_child_evolution"
+	initial := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{
+			Name: "name", DataType: schema.TypeString, Nullable: false,
+		}}},
+	}}}
+	evolved := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "timezone", DataType: schema.TypeString, Nullable: false},
+		}},
+	}}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{structVal{"old"}}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(evolved), [][]any{{structVal{"new", "UTC"}}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: evolved,
+	}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.True(t, evolved.SameColumnShape(loaded))
+	require.Len(t, loaded.Columns[0].StructFields.Columns, 2)
+	require.Equal(t, "timezone", loaded.Columns[0].StructFields.Columns[1].Name)
+	require.False(t, loaded.Columns[0].StructFields.Columns[1].Nullable)
+	require.True(t, valuesEqual(structVal{"new", "UTC"}, readTableRows(t, dest, table).Rows[0][0]))
+}
+
+func TestReplaceEvolvesExistingNestedChildren(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.types.replace_nested_child_evolution"
+	initial := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{
+			Name: "name", DataType: schema.TypeString, Nullable: false,
+		}}},
+	}}}
+	evolved := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "timezone", DataType: schema.TypeString, Nullable: false},
+		}},
+	}}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{structVal{"old"}}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: evolved, DropFirst: true,
+	}))
+	batches, err := buildRecordBatches(icebergArrowSchema(evolved), [][]any{{structVal{"new", "UTC"}}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: evolved,
+	}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.True(t, evolved.SameColumnShape(loaded))
+	require.True(t, valuesEqual(structVal{"new", "UTC"}, readTableRows(t, dest, table).Rows[0][0]))
+}
+
+func TestNestedSchemaEvolutionPreservesIDsAndRelaxesChildren(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.types.nested_child_evolution"
+	initial := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "name", DataType: schema.TypeString, Nullable: false}}},
+	}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: initial}))
+	before, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	profileBefore, ok := before.Schema().FindFieldByName("profile")
+	require.True(t, ok)
+	nameBefore, ok := before.Schema().FindFieldByName("profile.name")
+	require.True(t, ok)
+
+	evolved := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "timezone", DataType: schema.TypeString, Nullable: true},
+		}},
+	}}}
+	comparison, err := schemaevolution.Compare(evolved, initial, nil)
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(ctx, table, comparison)
+	require.NoError(t, err)
+	after, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	profileAfter, ok := after.Schema().FindFieldByName("profile")
+	require.True(t, ok)
+	nameAfter, ok := after.Schema().FindFieldByName("profile.name")
+	require.True(t, ok)
+	timezone, ok := after.Schema().FindFieldByName("profile.timezone")
+	require.True(t, ok)
+	require.Equal(t, profileBefore.ID, profileAfter.ID)
+	require.Equal(t, nameBefore.ID, nameAfter.ID)
+	require.False(t, nameAfter.Required)
+	require.NotEqual(t, profileAfter.ID, timezone.ID)
+	require.NotEqual(t, nameAfter.ID, timezone.ID)
+}

--- a/pkg/destination/iceberg/observability_test.go
+++ b/pkg/destination/iceberg/observability_test.go
@@ -1,0 +1,37 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCommitInfoReportsSnapshotMetrics(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.observability.commits"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema}))
+
+	token := "observable-flush"
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1, 2)), destination.WriteOptions{
+		Table:       table,
+		Schema:      tableSchema,
+		CommitToken: token,
+		Parallelism: 2,
+	}))
+
+	info, err := dest.GetCommitInfo(ctx, table)
+	require.NoError(t, err)
+	require.NotZero(t, info.SnapshotID)
+	require.NotZero(t, info.CommittedAt)
+	require.Equal(t, "append", info.Operation)
+	require.EqualValues(t, 2, info.AddedRows)
+	require.EqualValues(t, 2, info.TotalRows)
+	require.Positive(t, info.AddedDataFiles)
+	require.Equal(t, commitTokenID(token), info.CommitToken)
+	require.Contains(t, info.String(), "added_rows=2")
+}

--- a/pkg/destination/iceberg/partition_test.go
+++ b/pkg/destination/iceberg/partition_test.go
@@ -1,0 +1,69 @@
+package iceberg
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePartitionExpression(t *testing.T) {
+	terms, err := parsePartitionExpression("day(created_at), bucket[16](id), truncate[4](category), region")
+	require.NoError(t, err)
+	require.Len(t, terms, 4)
+	require.Equal(t, "created_at", terms[0].source)
+	require.Equal(t, "created_at_day", terms[0].name)
+	require.Equal(t, "day", terms[0].transform.String())
+	require.Equal(t, "id_bucket_16", terms[1].name)
+	require.Equal(t, "bucket[16]", terms[1].transform.String())
+	require.Equal(t, "category_truncate_4", terms[2].name)
+	require.Equal(t, "truncate[4]", terms[2].transform.String())
+	require.Equal(t, "region", terms[3].name)
+	require.Equal(t, "identity", terms[3].transform.String())
+}
+
+func TestParsePartitionExpressionRejectsInvalidFields(t *testing.T) {
+	for _, expression := range []string{
+		"day()",
+		"unknown(created_at)",
+		"bucket[0](id)",
+		"id,,region",
+		"day(created_at",
+		"day(created_at),created_at_day",
+	} {
+		t.Run(expression, func(t *testing.T) {
+			_, err := parsePartitionExpression(expression)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestBuildPartitionSpecWithMultipleTransforms(t *testing.T) {
+	iceSchema, err := icebergSchemaFromTableSchema(&schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "created_at", DataType: schema.TypeTimestamp, Nullable: false},
+		{Name: "category", DataType: schema.TypeString, Nullable: true},
+		{Name: "region", DataType: schema.TypeString, Nullable: true},
+	}})
+	require.NoError(t, err)
+
+	spec, err := buildPartitionSpec(iceSchema, "day(created_at),bucket[16](id),truncate[4](category),region")
+	require.NoError(t, err)
+	fields := make([]struct {
+		name      string
+		transform string
+	}, 0, 4)
+	for _, field := range spec.Fields() {
+		fields = append(fields, struct {
+			name      string
+			transform string
+		}{name: field.Name, transform: field.Transform.String()})
+	}
+	require.Len(t, fields, 4)
+	require.Equal(t, "created_at_day", fields[0].name)
+	require.Equal(t, "day", fields[0].transform)
+	require.Equal(t, "id_bucket_16", fields[1].name)
+	require.Equal(t, "bucket[16]", fields[1].transform)
+	require.Equal(t, "category_truncate_4", fields[2].name)
+	require.Equal(t, "region", fields[3].name)
+}

--- a/pkg/destination/iceberg/performance_test.go
+++ b/pkg/destination/iceberg/performance_test.go
@@ -1,0 +1,91 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareTableCreatesPartitionTransformsAndSortOrder(t *testing.T) {
+	dest := newHadoopDestination(t)
+	dest.cfg.PartitionSpec = "day(created_at),bucket[16](id),truncate[4](category)"
+	ctx := context.Background()
+	table := "lake.performance.partitioned"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "created_at", DataType: schema.TypeTimestamp, Nullable: false},
+		{Name: "category", DataType: schema.TypeString, Nullable: true},
+	}}
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, ClusterBy: []string{"category", "id"},
+	}))
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+
+	var partitionFields []string
+	spec := tbl.Metadata().PartitionSpec()
+	for _, field := range spec.Fields() {
+		partitionFields = append(partitionFields, field.Name+":"+field.Transform.String())
+	}
+	require.Equal(t, []string{
+		"created_at_day:day",
+		"id_bucket_16:bucket[16]",
+		"category_truncate_4:truncate[4]",
+	}, partitionFields)
+
+	var sortSources []string
+	for _, field := range tbl.SortOrder().Fields() {
+		name, ok := tbl.Schema().FindColumnName(field.SourceID())
+		require.True(t, ok)
+		sortSources = append(sortSources, name)
+	}
+	require.Equal(t, []string{"category", "id"}, sortSources)
+}
+
+func TestWriteParallelPhysicallyClustersUnpartitionedRows(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.performance.clustered"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: true}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, ClusterBy: []string{"id"},
+	}))
+
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 10, 2, -1)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, Parallelism: 4,
+	}))
+	rows := readTableRows(t, dest, table)
+	require.Len(t, rows.Rows, 3)
+	require.Equal(t, []any{int64(-1), int64(2), int64(10)}, []any{rows.Rows[0][0], rows.Rows[1][0], rows.Rows[2][0]})
+}
+
+func TestPrepareTableUpdatesExistingSortOrder(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.performance.sort_evolution"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "score", DataType: schema.TypeInt64},
+	}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, ClusterBy: []string{"id"},
+	}))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, ClusterBy: []string{"score", "id"},
+	}))
+
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	var columns []string
+	for _, field := range tbl.SortOrder().Fields() {
+		name, ok := tbl.Schema().FindColumnName(field.SourceID())
+		require.True(t, ok)
+		columns = append(columns, name)
+	}
+	require.Equal(t, []string{"score", "id"}, columns)
+	require.GreaterOrEqual(t, len(tbl.Metadata().SortOrders()), 2)
+}

--- a/pkg/destination/iceberg/purge_journal_test.go
+++ b/pkg/destination/iceberg/purge_journal_test.go
@@ -1,0 +1,1036 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/memblob"
+)
+
+func TestPurgeJournalObjectStorePersistenceAndNotExist(t *testing.T) {
+	ctx := context.Background()
+	objectFS, err := icebergio.LoadFS(ctx, map[string]string{}, "mem://purge-journal-tests/warehouse")
+	require.NoError(t, err)
+	require.Implements(t, (*icebergio.WriteFileIO)(nil), objectFS)
+	require.Implements(t, (*icebergio.ListableIO)(nil), objectFS)
+
+	ident := icebergcatalog.ToIdentifier("journal.object_store")
+	journal := &purgeJournal{
+		Version: purgeJournalVersion, Identifier: ident,
+		TableUUID:     "9ed4d13f-a67f-485f-b65d-9dfc260ee765",
+		TableLocation: "mem://purge-journal-tests/warehouse/journal/object_store",
+		Files:         []string{"mem://purge-journal-tests/warehouse/journal/object_store/data/a.parquet"},
+	}
+	journalPath := "mem://purge-journal-tests/warehouse/.ingestr/purge-journals/object.json"
+	require.NoError(t, writePurgeJournal(objectFS, journalPath, journal))
+	read, err := readPurgeJournal(objectFS, journalPath, ident)
+	require.NoError(t, err)
+	require.Equal(t, journal, read)
+	require.NoError(t, removePurgeJournal(objectFS, journalPath))
+	require.NoError(t, removePurgeJournal(objectFS, journalPath), "object-store NotExist must be idempotent")
+}
+
+func TestRemovePurgeJournalNormalizesGoCloudProviderNotFound(t *testing.T) {
+	ctx := context.Background()
+	base, err := icebergio.LoadFS(ctx, map[string]string{}, "mem://purge-gocloud-adapter/base")
+	require.NoError(t, err)
+	bucket := memblob.OpenBucket(nil)
+	t.Cleanup(func() { require.NoError(t, bucket.Close()) })
+	adapter := &goCloudNotFoundIO{IO: base, bucket: bucket}
+	require.NoError(t, removePurgeJournal(adapter, "gs://provider-bucket/missing-journal.json"))
+	_, err = readPurgeJournal(adapter, "gs://provider-bucket/missing-journal.json", icebergcatalog.ToIdentifier("missing.table"))
+	require.True(t, isObjectNotFound(err))
+}
+
+func TestClientSidePurgeJournalResumesAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.resume_after_restart"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	failing := &durableFailureCatalog{Catalog: base}
+	dest.catalog = failing
+	err := dest.DropTable(ctx, tableName)
+	require.ErrorContains(t, err, "failed to purge physical files")
+	require.True(t, failing.dropped)
+
+	ident := icebergcatalog.ToIdentifier(tableName)
+	journalPath, err := dest.purgeJournalPath(ident)
+	require.NoError(t, err)
+	localJournal, ok := localFilesystemPath(journalPath)
+	require.True(t, ok)
+	require.FileExists(t, localJournal)
+
+	dest.catalog = base
+	require.NoError(t, dest.DropTable(ctx, tableName), "a retry after restart must resume the durable journal")
+	require.NoFileExists(t, localJournal)
+	location, ok := dest.localTableLocation(ident)
+	require.True(t, ok)
+	require.Empty(t, regularFilesUnder(t, location))
+}
+
+func TestMissingManagedTableResumesDurablePurgeForRESTAndHadoopCatalogs(t *testing.T) {
+	for _, catalogType := range []icebergcatalog.Type{icebergcatalog.REST, icebergcatalog.Hadoop} {
+		t.Run(string(catalogType), func(t *testing.T) {
+			ctx := context.Background()
+			dest := newJournalTestDestination(t)
+			tableName := "journal.missing_recovery_" + strings.ToLower(string(catalogType))
+			writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+			ident := icebergcatalog.ToIdentifier(tableName)
+			tbl, err := dest.loadIcebergTable(ctx, tableName)
+			require.NoError(t, err)
+			location, ok := localFilesystemPath(tbl.Location())
+			require.True(t, ok)
+			require.NotEmpty(t, regularFilesUnder(t, location))
+
+			base := dest.catalog
+			wrapped := &missingRecoveryCatalog{Catalog: base, catalogType: catalogType, target: ident}
+			dest.catalog = wrapped
+			err = dest.DropTable(ctx, tableName)
+			require.ErrorIs(t, err, errInjectedMissingRecoveryOutcome)
+			exists, existsErr := dest.tableExists(ctx, ident)
+			require.NoError(t, existsErr)
+			require.False(t, exists)
+			journalPath, pathErr := dest.purgeJournalPath(ident)
+			require.NoError(t, pathErr)
+			localJournal, ok := localFilesystemPath(journalPath)
+			require.True(t, ok)
+			require.FileExists(t, localJournal)
+
+			require.NoError(t, dest.DropTable(ctx, tableName))
+			require.NoFileExists(t, localJournal)
+			require.Empty(t, regularFilesUnder(t, location))
+		})
+	}
+}
+
+func TestRESTAndHadoopStartupSweepResumeDurablePurge(t *testing.T) {
+	for _, catalogType := range []icebergcatalog.Type{icebergcatalog.REST, icebergcatalog.Hadoop} {
+		t.Run(string(catalogType), func(t *testing.T) {
+			ctx := context.Background()
+			dest := newJournalTestDestination(t)
+			tableName := "journal.startup_sweep_" + strings.ToLower(string(catalogType))
+			writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+			ident := icebergcatalog.ToIdentifier(tableName)
+			tbl, err := dest.loadIcebergTable(ctx, tableName)
+			require.NoError(t, err)
+			location, ok := localFilesystemPath(tbl.Location())
+			require.True(t, ok)
+
+			wrapped := &missingRecoveryCatalog{Catalog: dest.catalog, catalogType: catalogType, target: ident}
+			dest.catalog = wrapped
+			err = dest.DropTable(ctx, tableName)
+			require.ErrorIs(t, err, errInjectedMissingRecoveryOutcome)
+			require.NoError(t, dest.sweepPurgeJournals(ctx, nil))
+			require.Empty(t, regularFilesUnder(t, location))
+			journalPath, pathErr := dest.purgeJournalPath(ident)
+			require.NoError(t, pathErr)
+			localJournal, ok := localFilesystemPath(journalPath)
+			require.True(t, ok)
+			require.NoFileExists(t, localJournal)
+		})
+	}
+}
+
+func TestFailedRESTAndHadoopDeletionReleasesJournalAndLockForRetry(t *testing.T) {
+	for _, catalogType := range []icebergcatalog.Type{icebergcatalog.REST, icebergcatalog.Hadoop} {
+		t.Run(string(catalogType), func(t *testing.T) {
+			ctx := context.Background()
+			dest := newJournalTestDestination(t)
+			tableName := "journal.live_delete_failure_" + strings.ToLower(string(catalogType))
+			writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+			ident := icebergcatalog.ToIdentifier(tableName)
+			wrapped := &liveDeleteFailureCatalog{
+				Catalog: dest.catalog, catalogType: catalogType, target: ident, fail: true,
+			}
+			dest.catalog = wrapped
+
+			err := dest.DropTable(ctx, tableName)
+			require.ErrorIs(t, err, errInjectedLiveDeleteFailure)
+			_, err = dest.catalog.LoadTable(ctx, ident)
+			require.NoError(t, err, "same table UUID must remain live after the injected failure")
+			idleLock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+			require.NoError(t, err)
+			require.Equal(t, purgeLockModeIdle, idleLock.Properties()[purgeLockModeKey])
+			journalPath, pathErr := dest.purgeJournalPath(ident)
+			require.NoError(t, pathErr)
+			localJournal, ok := localFilesystemPath(journalPath)
+			require.True(t, ok)
+			require.NoFileExists(t, localJournal)
+
+			wrapped.fail = false
+			require.NoError(t, dest.DropTable(ctx, tableName), "retry must not be wedged by the failed deletion")
+			_, err = dest.catalog.LoadTable(ctx, ident)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestInitialPurgeOwnerBlocksRecoveryUntilClaimExpiry(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.initial_owner_exclusive"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	_, _, _, _, ownerToken, err := dest.createPurgeJournal(ctx, tbl)
+	require.NoError(t, err)
+	require.NotEmpty(t, ownerToken)
+	require.NoError(t, dest.catalog.DropTable(ctx, ident))
+
+	err = dest.resumePurgeJournal(ctx, ident)
+	require.ErrorContains(t, err, "already claimed")
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	require.NoError(t, dest.resumePurgeJournal(ctx, ident))
+}
+
+func TestExpiredJournalLessPurgeLockIsReclaimedAfterLiveUUIDCheck(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.expired_without_journal"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	_, err = dest.acquirePurgeLock(ctx, ident, tbl.Metadata().TableUUID().String())
+	require.NoError(t, err)
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, dest.DropTable(ctx, tableName))
+	_, err = dest.catalog.LoadTable(ctx, ident)
+	require.Error(t, err)
+}
+
+func TestDropNamespaceRemovesFencedIdleLifecycleLocks(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "namespace_idle_lock.events"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	require.NoError(t, dest.DropTable(ctx, tableName))
+	lockIdent := purgeLockIdentifier(icebergcatalog.ToIdentifier(tableName))
+	lock, err := dest.catalog.LoadTable(ctx, lockIdent)
+	require.NoError(t, err)
+	require.Equal(t, purgeLockModeIdle, lock.Properties()[purgeLockModeKey])
+
+	require.NoError(t, dest.DropNamespace(ctx, "namespace_idle_lock"))
+	_, err = dest.catalog.LoadNamespaceProperties(ctx, icebergcatalog.ToIdentifier("namespace_idle_lock"))
+	require.Error(t, err)
+}
+
+func TestDropNamespaceCleansIdleLocksWithoutDependingOnCatalogErrorText(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "namespace_opaque_error.events"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	require.NoError(t, dest.DropTable(ctx, tableName))
+	dest.catalog = &opaqueNamespaceNotEmptyCatalog{Catalog: dest.catalog}
+
+	require.NoError(t, dest.DropNamespace(ctx, "namespace_opaque_error"))
+}
+
+func TestDropNamespaceReclaimsExpiredCleanupLock(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	namespace := icebergcatalog.ToIdentifier("namespace_expired_cleanup")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, namespace, iceberggo.Properties{}))
+	target := append(append(icebergtable.Identifier(nil), namespace...), "target")
+	token, err := dest.acquireCreateGuard(ctx, target)
+	require.NoError(t, err)
+	require.NoError(t, dest.releaseCreateGuard(ctx, target, token))
+	lockIdent := purgeLockIdentifier(target)
+	lock, err := dest.catalog.LoadTable(ctx, lockIdent)
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockModeKey:      purgeLockModeCleanup,
+		purgeLockTokenKey:     "crashed-owner",
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, dest.DropNamespace(ctx, strings.Join(namespace, ".")))
+	exists, err := dest.catalog.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDropNamespaceRollsFailedCleanupFenceBackToIdle(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	namespace := icebergcatalog.ToIdentifier("namespace_cleanup_rollback")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, namespace, iceberggo.Properties{}))
+	target := append(append(icebergtable.Identifier(nil), namespace...), "target")
+	token, err := dest.acquireCreateGuard(ctx, target)
+	require.NoError(t, err)
+	require.NoError(t, dest.releaseCreateGuard(ctx, target, token))
+	lockIdent := purgeLockIdentifier(target)
+	dest.catalog = &failLifecycleLockDropOnceCatalog{Catalog: dest.catalog, target: lockIdent}
+
+	err = dest.DropNamespace(ctx, strings.Join(namespace, "."))
+	require.ErrorContains(t, err, "injected lifecycle lock drop failure")
+	lock, loadErr := dest.catalog.LoadTable(ctx, lockIdent)
+	require.NoError(t, loadErr)
+	require.Equal(t, purgeLockModeIdle, lock.Properties()[purgeLockModeKey])
+	require.Empty(t, lock.Properties()[purgeLockTokenKey])
+	require.Empty(t, lock.Properties()[purgeLockExpiresAtKey])
+	require.NoError(t, dest.DropNamespace(ctx, strings.Join(namespace, ".")))
+}
+
+func TestCreateGuardReclaimsExpiredCleanupLockButNotLiveCleanup(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	namespace := icebergcatalog.ToIdentifier("namespace_create_cleanup")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, namespace, iceberggo.Properties{}))
+	target := append(append(icebergtable.Identifier(nil), namespace...), "target")
+	token, err := dest.acquireCreateGuard(ctx, target)
+	require.NoError(t, err)
+	require.NoError(t, dest.releaseCreateGuard(ctx, target, token))
+	lockIdent := purgeLockIdentifier(target)
+	lock, err := dest.catalog.LoadTable(ctx, lockIdent)
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockModeKey:      purgeLockModeCleanup,
+		purgeLockTokenKey:     "live-cleaner",
+		purgeLockExpiresAtKey: time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	_, err = dest.acquireCreateGuard(ctx, target)
+	require.ErrorContains(t, err, "durable cleanup guard exists")
+
+	lock, err = dest.catalog.LoadTable(ctx, lockIdent)
+	require.NoError(t, err)
+	txn = lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	newToken, err := dest.acquireCreateGuard(ctx, target)
+	require.NoError(t, err)
+	require.NotEqual(t, "live-cleaner", newToken)
+	require.NoError(t, dest.releaseCreateGuard(ctx, target, newToken))
+}
+
+func TestExpiredInitialPurgeOwnerWithLiveTableIsAbandonedForRetry(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.expired_live_initial_owner"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	_, _, _, journalPath, ownerToken, err := dest.createPurgeJournal(ctx, tbl)
+	require.NoError(t, err)
+	require.NotEmpty(t, ownerToken)
+
+	err = dest.resumePurgeJournal(ctx, ident)
+	require.ErrorContains(t, err, "already claimed")
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	require.NoError(t, dest.resumePurgeJournal(ctx, ident))
+	_, err = dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err, "abandoning the crashed pre-deletion attempt must retain the live table")
+	idleLock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	require.Equal(t, purgeLockModeIdle, idleLock.Properties()[purgeLockModeKey])
+	localJournal, ok := localFilesystemPath(journalPath)
+	require.True(t, ok)
+	require.NoFileExists(t, localJournal)
+	require.NoError(t, dest.DropTable(ctx, tableName))
+}
+
+func TestConnectSweepsDurablePurgeJournal(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	uri := journalTestURI(root)
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(ctx, uri))
+	tableName := "journal.connect_sweep"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	failing := &durableFailureCatalog{Catalog: base}
+	dest.catalog = failing
+	require.Error(t, dest.DropTable(ctx, tableName))
+	dest.catalog = base
+	require.NoError(t, dest.Close(ctx))
+
+	restarted := NewDestination()
+	require.NoError(t, restarted.Connect(ctx, uri), "Connect must sweep confirmed-absent purge journals")
+	t.Cleanup(func() { require.NoError(t, restarted.Close(context.Background())) })
+	location, ok := restarted.localTableLocation(icebergcatalog.ToIdentifier(tableName))
+	require.True(t, ok)
+	require.Empty(t, regularFilesUnder(t, location))
+	journalPath, err := restarted.purgeJournalPath(icebergcatalog.ToIdentifier(tableName))
+	require.NoError(t, err)
+	localJournal, ok := localFilesystemPath(journalPath)
+	require.True(t, ok)
+	require.NoFileExists(t, localJournal)
+}
+
+func TestClientSidePurgeJournalAbandonsCleanupWhenIdentifierIsReused(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.reused_identifier"
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, tableName, tableSchema, time.Hour)
+
+	base := dest.catalog
+	failing := &durableFailureCatalog{Catalog: base}
+	dest.catalog = failing
+	require.Error(t, dest.DropTable(ctx, tableName))
+
+	dest.catalog = base
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 99)), destination.WriteOptions{
+		Table: tableName, Schema: tableSchema,
+	}))
+	recreated, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	require.NotEqual(t, failing.tableUUID, recreated.Metadata().TableUUID().String())
+
+	require.NoError(t, dest.resumePurgeJournal(ctx, icebergcatalog.ToIdentifier(tableName)))
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, tableName))
+	require.Equal(t, int64(99), readTableRows(t, dest, tableName).Rows[0][0])
+	journalPath, err := dest.purgeJournalPath(icebergcatalog.ToIdentifier(tableName))
+	require.NoError(t, err)
+	localJournal, ok := localFilesystemPath(journalPath)
+	require.True(t, ok)
+	require.NoFileExists(t, localJournal)
+}
+
+func TestValidatePurgeJournalRejectsInvalidUUIDAndEscapingPaths(t *testing.T) {
+	ident := icebergcatalog.ToIdentifier("journal.validation")
+	journal := &purgeJournal{
+		Version:       purgeJournalVersion,
+		Identifier:    ident,
+		TableUUID:     "not-a-uuid",
+		TableLocation: "/warehouse/journal/validation",
+		Files:         []string{"/warehouse/journal/validation/data/file.parquet"},
+	}
+	require.ErrorContains(t, validatePurgeJournal(journal, ident), "invalid table UUID")
+
+	journal.TableUUID = "9ed4d13f-a67f-485f-b65d-9dfc260ee765"
+	journal.Files = []string{"/warehouse/journal/validation-neighbor/data/file.parquet"}
+	require.ErrorContains(t, validatePurgeJournal(journal, ident), "outside table location")
+
+	journal.TableLocation = "s3://bucket/warehouse/table"
+	journal.Files = []string{"s3://other-bucket/warehouse/table/data/file.parquet"}
+	require.ErrorContains(t, validatePurgeJournal(journal, ident), "outside table location")
+
+	journal.TableLocation = "file:/warehouse/journal/validation"
+	journal.Files = []string{"/warehouse/journal/validation/data/file.parquet"}
+	require.NoError(t, validatePurgeJournal(journal, ident))
+	journal.Files = []string{"/warehouse/journal/validation-neighbor/data/file.parquet"}
+	require.ErrorContains(t, validatePurgeJournal(journal, ident), "outside table location")
+}
+
+func TestResumePurgeJournalRefusesSameUUIDAndRetainsJournal(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.same_uuid"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	journal, _, journalFS, journalPath, _, err := dest.createPurgeJournal(ctx, tbl)
+	require.NoError(t, err)
+
+	err = dest.resumePurgeJournal(ctx, icebergcatalog.ToIdentifier(tableName))
+	require.ErrorContains(t, err, "still exists")
+	_, err = readPurgeJournal(journalFS, journalPath, journal.Identifier)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, tableName))
+}
+
+func TestResumePurgeJournalRetainsCorruptJournalWithoutDeletingLiveTable(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.corrupt_live"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	journalPath, err := dest.purgeJournalPath(ident)
+	require.NoError(t, err)
+	localPath, ok := localFilesystemPath(journalPath)
+	require.True(t, ok)
+	require.NoError(t, ensureJournalDirectory(localPath))
+	require.NoError(t, os.WriteFile(localPath, []byte("not json"), 0o600))
+
+	err = dest.resumePurgeJournal(ctx, ident)
+	require.ErrorContains(t, err, "exists; refusing corrupt")
+	require.FileExists(t, localPath)
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, tableName))
+}
+
+func TestPurgeJournalRetriesTransientDeleteAndRemovesLateResidue(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.transient_and_residue"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+
+	base := dest.catalog
+	wrapped := &transientResidueCatalog{Catalog: base}
+	dest.catalog = wrapped
+	require.NoError(t, dest.DropTable(ctx, tableName))
+	require.True(t, wrapped.failedOnce)
+	require.True(t, wrapped.wroteResidue)
+	location, ok := localFilesystemPath(wrapped.location)
+	require.True(t, ok)
+	require.Empty(t, regularFilesUnder(t, location))
+}
+
+func TestResumePurgeJournalRecoversCrashAfterDeletionFenceRename(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.crash_after_deletion_fence"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	journal, _, _, _, token, err := dest.createPurgeJournal(ctx, tbl)
+	require.NoError(t, err)
+	claimed, err := dest.claimTableForDeletionAt(ctx, tbl, journal.TableUUID, nil, journal.DeletionIdentifiers[0])
+	require.NoError(t, err)
+	require.NoError(t, dest.relinquishPurgeClaim(ctx, ident, journal.TableUUID, token))
+
+	require.NoError(t, dest.resumePurgeJournal(ctx, ident))
+	for _, deletionIdent := range journal.DeletionIdentifiers {
+		exists, checkErr := dest.catalog.CheckTableExists(ctx, deletionIdent)
+		require.NoError(t, checkErr)
+		require.False(t, exists)
+	}
+	exists, err := dest.catalog.CheckTableExists(ctx, claimed.Identifier())
+	require.NoError(t, err)
+	require.False(t, exists)
+	for listed, listErr := range dest.catalog.ListTables(ctx, icebergcatalog.NamespaceFromIdent(ident)) {
+		require.NoError(t, listErr)
+		require.NotContains(t, listed[len(listed)-1], deletionFenceTablePrefix)
+	}
+	journalPath, err := dest.purgeJournalPath(ident)
+	require.NoError(t, err)
+	localJournalPath, ok := localFilesystemPath(journalPath)
+	require.True(t, ok)
+	require.NoFileExists(t, localJournalPath)
+}
+
+func TestPurgeJournalMissingWarehouseIsReported(t *testing.T) {
+	dest := &Destination{cfg: icebergConfig{CatalogName: "test"}}
+	_, err := dest.purgeJournalPath(icebergcatalog.ToIdentifier("journal.missing_warehouse"))
+	require.ErrorContains(t, err, "requires a filesystem warehouse")
+}
+
+func TestCatalogPurgeLockBlocksRecreationUntilReleased(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.locked_recreation"
+	tableSchema := lifecycleTestSchema()
+	writeLifecycleTable(t, dest, tableName, tableSchema, time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	tableUUID := tbl.Metadata().TableUUID().String()
+	lockToken, err := dest.acquirePurgeLock(ctx, ident, tableUUID)
+	require.NoError(t, err)
+	_, err = dest.acquirePurgeLock(ctx, ident, tableUUID)
+	require.ErrorContains(t, err, "already held")
+	require.NoError(t, dest.catalog.DropTable(ctx, ident))
+
+	err = dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema})
+	require.ErrorContains(t, err, "durable purge lock")
+	require.NoError(t, dest.releasePurgeLockOwned(ctx, ident, tableUUID, lockToken))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: tableName, Schema: tableSchema}))
+}
+
+func TestPurgeRecoveryClaimIsExclusiveAndCanTakeOverAfterExpiry(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.exclusive_recovery_claim"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	tableUUID := tbl.Metadata().TableUUID().String()
+	firstToken, err := dest.acquirePurgeLock(ctx, ident, tableUUID)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstToken)
+	_, err = dest.claimPurgeResume(ctx, ident, tableUUID)
+	require.ErrorContains(t, err, "already claimed")
+
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	secondToken, err := dest.claimPurgeResume(ctx, ident, tableUUID)
+	require.NoError(t, err)
+	require.NotEqual(t, firstToken, secondToken)
+	require.ErrorContains(t, dest.releasePurgeLockOwned(ctx, ident, tableUUID, firstToken), "ownership changed")
+	require.NoError(t, dest.releasePurgeLockOwned(ctx, ident, tableUUID, secondToken))
+}
+
+func TestExpiredCreateGuardCanBeReclaimed(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	ident := icebergcatalog.ToIdentifier("journal.expired_create_guard")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("journal"), iceberggo.Properties{}))
+	firstToken, err := dest.acquireCreateGuard(ctx, ident)
+	require.NoError(t, err)
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	secondToken, err := dest.acquireCreateGuard(ctx, ident)
+	require.NoError(t, err)
+	require.NotEqual(t, firstToken, secondToken)
+	require.ErrorContains(t, dest.releaseCreateGuard(ctx, ident, firstToken), "ownership changed")
+	require.NoError(t, dest.releaseCreateGuard(ctx, ident, secondToken))
+}
+
+func TestCreateGuardOldOwnerCannotReleaseReclaimedGuard(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	ident := icebergcatalog.ToIdentifier("journal.create_guard_release_fence")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("journal"), iceberggo.Properties{}))
+	oldToken, err := dest.acquireCreateGuard(ctx, ident)
+	require.NoError(t, err)
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	wrapped := &conflictFirstOfTwoCatalog{
+		Catalog: dest.catalog, firstReady: make(chan struct{}), secondCommitted: make(chan struct{}),
+	}
+	dest.catalog = wrapped
+	oldRelease := make(chan error, 1)
+	go func() { oldRelease <- dest.releaseCreateGuard(ctx, ident, oldToken) }()
+	<-wrapped.firstReady
+	newToken, err := dest.acquireCreateGuard(ctx, ident)
+	require.NoError(t, err)
+	require.ErrorIs(t, <-oldRelease, icebergtable.ErrCommitFailed)
+	current, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	require.Equal(t, newToken, current.Properties()[purgeLockTokenKey])
+	require.NoError(t, dest.releaseCreateGuard(ctx, ident, newToken))
+}
+
+func TestPurgeLockOldOwnerCannotReleaseReclaimedLock(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.purge_release_fence"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	tbl, err := dest.catalog.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	tableUUID := tbl.Metadata().TableUUID().String()
+	oldToken, err := dest.acquirePurgeLock(ctx, ident, tableUUID)
+	require.NoError(t, err)
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	wrapped := &conflictFirstOfTwoCatalog{
+		Catalog: dest.catalog, firstReady: make(chan struct{}), secondCommitted: make(chan struct{}),
+	}
+	dest.catalog = wrapped
+	oldRelease := make(chan error, 1)
+	go func() { oldRelease <- dest.releasePurgeLockOwned(ctx, ident, tableUUID, oldToken) }()
+	<-wrapped.firstReady
+	newToken, err := dest.claimPurgeResume(ctx, ident, tableUUID)
+	require.NoError(t, err)
+	require.ErrorIs(t, <-oldRelease, icebergtable.ErrCommitFailed)
+	current, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	require.Equal(t, newToken, current.Properties()[purgeLockTokenKey])
+	require.NoError(t, dest.releasePurgeLockOwned(ctx, ident, tableUUID, newToken))
+}
+
+func TestExpiredCreateGuardIsNotReclaimedWhilePurgeJournalExists(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	ident := icebergcatalog.ToIdentifier("journal.guarded_by_purge_journal")
+	require.NoError(t, dest.catalog.CreateNamespace(ctx, icebergcatalog.ToIdentifier("journal"), iceberggo.Properties{}))
+	_, err := dest.acquireCreateGuard(ctx, ident)
+	require.NoError(t, err)
+	lock, err := dest.catalog.LoadTable(ctx, purgeLockIdentifier(ident))
+	require.NoError(t, err)
+	txn := lock.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberggo.Properties{
+		purgeLockExpiresAtKey: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+	journalPath, err := dest.purgeJournalPath(ident)
+	require.NoError(t, err)
+	journalFS, err := icebergio.LoadFS(ctx, dest.cfg.Properties, journalPath)
+	require.NoError(t, err)
+	require.NoError(t, writePurgeJournal(journalFS, journalPath, &purgeJournal{
+		Version: purgeJournalVersion, Identifier: ident, TableUUID: uuid.NewString(),
+		TableLocation: dest.configuredPurgeWarehouse() + "/journal/guarded_by_purge_journal",
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	}))
+
+	_, err = dest.acquireCreateGuard(ctx, ident)
+	require.ErrorContains(t, err, "durable purge journal exists")
+}
+
+func TestCatalogCreateGuardBlocksPurgeUntilReleased(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	tableName := "journal.create_guard_blocks_purge"
+	writeLifecycleTable(t, dest, tableName, lifecycleTestSchema(), time.Hour)
+	ident := icebergcatalog.ToIdentifier(tableName)
+	token, err := dest.acquireCreateGuard(ctx, ident)
+	require.NoError(t, err)
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	_, _, _, _, _, err = dest.createPurgeJournal(ctx, tbl)
+	require.ErrorContains(t, err, "conflicting purge lock")
+	require.EqualValues(t, 1, icebergRowCount(ctx, t, dest, tableName))
+	require.NoError(t, dest.releaseCreateGuard(ctx, ident, token))
+}
+
+func TestSweepRejectsJournalFilenameHashMismatch(t *testing.T) {
+	ctx := context.Background()
+	dest := newJournalTestDestination(t)
+	ident := icebergcatalog.ToIdentifier("journal.hash_mismatch")
+	root, err := dest.purgeJournalRoot(ident)
+	require.NoError(t, err)
+	wrongPath := appendLocationPath(root, "wrong.json", false)
+	journalFS, err := icebergio.LoadFS(ctx, dest.cfg.Properties, wrongPath)
+	require.NoError(t, err)
+	journal := &purgeJournal{
+		Version: purgeJournalVersion, Identifier: ident,
+		TableUUID:     "9ed4d13f-a67f-485f-b65d-9dfc260ee765",
+		TableLocation: filepath.Join(dest.cfg.Properties["warehouse"], "journal", "hash_mismatch"),
+	}
+	require.NoError(t, writePurgeJournal(journalFS, wrongPath, journal))
+	err = dest.sweepPurgeJournals(ctx, nil)
+	require.ErrorContains(t, err, "filename/hash mismatch")
+	localPath, ok := localFilesystemPath(wrongPath)
+	require.True(t, ok)
+	require.FileExists(t, localPath)
+}
+
+func TestValidatePurgeJournalRejectsLocationOutsideConfiguredWarehouse(t *testing.T) {
+	dest := &Destination{cfg: icebergConfig{Properties: map[string]string{"warehouse": "/safe/warehouse"}}}
+	journal := &purgeJournal{
+		Identifier:    icebergcatalog.ToIdentifier("journal.forged"),
+		TableLocation: "/attacker/root",
+	}
+	require.ErrorContains(t, dest.validatePurgeJournalLocation(journal), "outside configured warehouse")
+	journal.TableLocation = "/safe/warehouse"
+	require.ErrorContains(t, dest.validatePurgeJournalLocation(journal), "outside configured warehouse")
+}
+
+func TestValidatePurgeJournalRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	warehouse := filepath.Join(root, "warehouse")
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(warehouse, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(outside, "table"), 0o755))
+	require.NoError(t, os.Symlink(outside, filepath.Join(warehouse, "escape")))
+	dest := &Destination{cfg: icebergConfig{Properties: map[string]string{"warehouse": warehouse}}}
+	journal := &purgeJournal{TableLocation: filepath.Join(warehouse, "escape", "table")}
+	require.ErrorContains(t, dest.validatePurgeJournalLocation(journal), "escapes warehouse")
+}
+
+func TestReadBoundedIOFileRejectsOversizedJournal(t *testing.T) {
+	ctx := context.Background()
+	objectFS, err := icebergio.LoadFS(ctx, map[string]string{}, "mem://purge-bounds/root")
+	require.NoError(t, err)
+	writer := objectFS.(icebergio.WriteFileIO)
+	path := "mem://purge-bounds/root/oversized.json"
+	require.NoError(t, writer.WriteFile(path, []byte("01234567890")))
+	_, err = readBoundedIOFile(objectFS, path, 10)
+	require.ErrorContains(t, err, "size limit")
+}
+
+func newJournalTestDestination(t *testing.T) *Destination {
+	t.Helper()
+	root := t.TempDir()
+	dest := NewDestination()
+	uri := journalTestURI(root)
+	require.NoError(t, dest.Connect(context.Background(), uri))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	return dest
+}
+
+func journalTestURI(root string) string {
+	return "iceberg+sqlite://" + filepath.Join(root, "catalog.db") +
+		"?warehouse_path=" + url.QueryEscape(filepath.Join(root, "warehouse"))
+}
+
+type durableFailureCatalog struct {
+	icebergcatalog.Catalog
+	dropped   bool
+	tableUUID string
+}
+
+type opaqueNamespaceNotEmptyCatalog struct {
+	icebergcatalog.Catalog
+	failed bool
+}
+
+type failLifecycleLockDropOnceCatalog struct {
+	icebergcatalog.Catalog
+	target icebergtable.Identifier
+	failed bool
+}
+
+func (c *failLifecycleLockDropOnceCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if slices.Equal(ident, c.target) && !c.failed {
+		c.failed = true
+		return errors.New("injected lifecycle lock drop failure")
+	}
+	return c.Catalog.DropTable(ctx, ident)
+}
+
+func (c *opaqueNamespaceNotEmptyCatalog) DropNamespace(ctx context.Context, ident icebergtable.Identifier) error {
+	if !c.failed {
+		c.failed = true
+		return errors.New("opaque catalog failure")
+	}
+	return c.Catalog.DropNamespace(ctx, ident)
+}
+
+var errInjectedMissingRecoveryOutcome = errors.New("injected lost purge response after catalog removal")
+
+var errInjectedLiveDeleteFailure = errors.New("injected catalog deletion failure while table remains live")
+
+type missingRecoveryCatalog struct {
+	icebergcatalog.Catalog
+	catalogType icebergcatalog.Type
+	target      icebergtable.Identifier
+	failed      bool
+}
+
+type liveDeleteFailureCatalog struct {
+	icebergcatalog.Catalog
+	catalogType icebergcatalog.Type
+	target      icebergtable.Identifier
+	fail        bool
+}
+
+func (c *liveDeleteFailureCatalog) CatalogType() icebergcatalog.Type { return c.catalogType }
+
+func (c *liveDeleteFailureCatalog) PurgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if c.fail && (slices.Equal(ident, c.target) || isDeletionFenceForTestTarget(ident, c.target)) {
+		return errInjectedLiveDeleteFailure
+	}
+	return c.Catalog.DropTable(ctx, ident)
+}
+
+func (c *liveDeleteFailureCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if c.fail && (slices.Equal(ident, c.target) || isDeletionFenceForTestTarget(ident, c.target)) {
+		return errInjectedLiveDeleteFailure
+	}
+	return c.Catalog.DropTable(ctx, ident)
+}
+
+func (c *missingRecoveryCatalog) CatalogType() icebergcatalog.Type { return c.catalogType }
+
+func (c *missingRecoveryCatalog) PurgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	return c.dropTargetWithUnknownOutcome(ctx, ident)
+}
+
+func (c *missingRecoveryCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if c.catalogType == icebergcatalog.Hadoop && (slices.Equal(ident, c.target) || isDeletionFenceForTestTarget(ident, c.target)) {
+		return c.dropTargetWithUnknownOutcome(ctx, ident)
+	}
+	return c.Catalog.DropTable(ctx, ident)
+}
+
+func (c *missingRecoveryCatalog) dropTargetWithUnknownOutcome(ctx context.Context, ident icebergtable.Identifier) error {
+	if err := c.Catalog.DropTable(ctx, ident); err != nil {
+		return err
+	}
+	if !c.failed && (slices.Equal(ident, c.target) || isDeletionFenceForTestTarget(ident, c.target)) {
+		c.failed = true
+		return errInjectedMissingRecoveryOutcome
+	}
+	return nil
+}
+
+func isDeletionFenceForTestTarget(ident, target icebergtable.Identifier) bool {
+	return len(ident) == len(target) && slices.Equal(icebergcatalog.NamespaceFromIdent(ident), icebergcatalog.NamespaceFromIdent(target)) &&
+		strings.HasPrefix(ident[len(ident)-1], deletionFenceTablePrefix)
+}
+
+func (c *durableFailureCatalog) CatalogType() icebergcatalog.Type {
+	return icebergcatalog.SQL
+}
+
+func (c *durableFailureCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+		return tbl, nil
+	}
+	c.tableUUID = tbl.Metadata().TableUUID().String()
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listable, ok := tableFS.(icebergio.ListableIO)
+	if !ok {
+		return nil, errors.New("test filesystem is not listable")
+	}
+	failing := &alwaysFailRemoveIO{ListableIO: listable}
+	fsFactory := func(context.Context) (icebergio.IO, error) { return failing, nil }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *durableFailureCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if err := c.Catalog.DropTable(ctx, ident); err != nil {
+		return err
+	}
+	c.dropped = true
+	return nil
+}
+
+type alwaysFailRemoveIO struct {
+	icebergio.ListableIO
+}
+
+type goCloudNotFoundIO struct {
+	icebergio.IO
+	bucket *blob.Bucket
+}
+
+func (g *goCloudNotFoundIO) Remove(string) error {
+	return g.bucket.Delete(context.Background(), "missing")
+}
+
+func (g *goCloudNotFoundIO) Open(string) (icebergio.File, error) {
+	_, err := g.bucket.Attributes(context.Background(), "missing")
+	return nil, err
+}
+
+type transientResidueCatalog struct {
+	icebergcatalog.Catalog
+	fs           icebergio.ListableIO
+	location     string
+	failedOnce   bool
+	wroteResidue bool
+	target       icebergtable.Identifier
+}
+
+func (c *transientResidueCatalog) CatalogType() icebergcatalog.Type { return icebergcatalog.SQL }
+
+func (c *transientResidueCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(ident[len(ident)-1], purgeLockTablePrefix) {
+		return tbl, nil
+	}
+	tableFS, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listable, ok := tableFS.(icebergio.ListableIO)
+	if !ok {
+		return nil, errors.New("test filesystem is not listable")
+	}
+	c.fs = listable
+	c.location = tbl.Location()
+	if len(c.target) == 0 {
+		c.target = append(icebergtable.Identifier(nil), ident...)
+	}
+	wrapped := &transientRemoveIO{ListableIO: listable, catalog: c}
+	fsFactory := func(context.Context) (icebergio.IO, error) { return wrapped, nil }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *transientResidueCatalog) DropTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if err := c.Catalog.DropTable(ctx, ident); err != nil {
+		return err
+	}
+	if !slices.Equal(ident, c.target) && !isDeletionFenceForTestTarget(ident, c.target) {
+		return nil
+	}
+	writer, ok := c.fs.(icebergio.WriteFileIO)
+	if !ok {
+		return errors.New("test filesystem is not writable")
+	}
+	c.wroteResidue = true
+	return writer.WriteFile(appendLocationPath(c.location, "data/late.parquet", false), []byte("late"))
+}
+
+type transientRemoveIO struct {
+	icebergio.ListableIO
+	catalog *transientResidueCatalog
+}
+
+func (f *transientRemoveIO) Remove(filePath string) error {
+	if !f.catalog.failedOnce {
+		f.catalog.failedOnce = true
+		return errors.New("injected transient delete failure")
+	}
+	return f.ListableIO.Remove(filePath)
+}
+
+func (f *alwaysFailRemoveIO) Remove(path string) error {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return errors.New("injected durable cleanup interruption")
+}

--- a/pkg/destination/iceberg/reader_nested_test.go
+++ b/pkg/destination/iceberg/reader_nested_test.go
@@ -1,0 +1,156 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordBatchReaderNormalizesUUIDListElements(t *testing.T) {
+	listBuilder := array.NewListBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String)
+	values := listBuilder.ValueBuilder().(*array.StringBuilder)
+	listBuilder.Append(true)
+	values.Append("550e8400-e29b-41d4-a716-446655440000")
+	values.AppendNull()
+	listBuilder.AppendNull()
+	listBuilder.Append(true)
+	values.Append("7b9a2d1e-4d72-4f85-8b26-a63761f42d31")
+	input := listBuilder.NewArray()
+	listBuilder.Release()
+
+	inputSchema := arrow.NewSchema([]arrow.Field{{Name: "external_ids", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true}}, nil)
+	batch := array.NewRecordBatch(inputSchema, []arrow.Array{input}, 3)
+	input.Release()
+	targetSchema := arrow.NewSchema([]arrow.Field{{Name: "external_ids", Type: arrow.ListOf(extensions.NewUUIDType()), Nullable: true}}, nil)
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: batch}
+	close(records)
+
+	reader := newRecordBatchReader(context.Background(), records, targetSchema)
+	defer reader.Release()
+	hasRecord := reader.Next()
+	require.NoError(t, reader.Err())
+	require.True(t, hasRecord)
+	require.Equal(t, targetSchema, reader.RecordBatch().Schema())
+
+	got := reader.RecordBatch().Column(0).(*array.List)
+	gotValues := got.ListValues().(*extensions.UUIDArray)
+	require.Equal(t, "550e8400-e29b-41d4-a716-446655440000", gotValues.Value(0).String())
+	require.True(t, gotValues.IsNull(1))
+	require.Equal(t, "7b9a2d1e-4d72-4f85-8b26-a63761f42d31", gotValues.Value(2).String())
+	require.True(t, got.IsNull(1))
+	require.False(t, reader.Next())
+	require.NoError(t, reader.Err())
+}
+
+func TestNormalizeColumnValidatesFixedBinaryWidths(t *testing.T) {
+	builder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	builder.Append([]byte{1, 2, 3, 4})
+	builder.AppendNull()
+	input := builder.NewArray()
+	builder.Release()
+	defer input.Release()
+
+	converted, release, err := normalizeColumn(input, &arrow.FixedSizeBinaryType{ByteWidth: 4})
+	require.NoError(t, err)
+	require.True(t, release)
+	defer converted.Release()
+	require.Equal(t, []byte{1, 2, 3, 4}, converted.(*array.FixedSizeBinary).Value(0))
+	require.True(t, converted.IsNull(1))
+
+	badBuilder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	badBuilder.Append([]byte{1, 2, 3})
+	bad := badBuilder.NewArray()
+	badBuilder.Release()
+	defer bad.Release()
+	_, _, err = normalizeColumn(bad, &arrow.FixedSizeBinaryType{ByteWidth: 4})
+	require.ErrorContains(t, err, "has length 3, want 4")
+}
+
+func TestNormalizeColumnNormalizesFixedBinaryListElements(t *testing.T) {
+	listBuilder := array.NewListBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	values := listBuilder.ValueBuilder().(*array.BinaryBuilder)
+	listBuilder.Append(true)
+	values.Append([]byte{1, 2, 3, 4})
+	values.AppendNull()
+	input := listBuilder.NewArray()
+	listBuilder.Release()
+	defer input.Release()
+
+	converted, release, err := normalizeColumn(input, arrow.ListOf(&arrow.FixedSizeBinaryType{ByteWidth: 4}))
+	require.NoError(t, err)
+	require.True(t, release)
+	defer converted.Release()
+	got := converted.(*array.List).ListValues().(*array.FixedSizeBinary)
+	require.Equal(t, []byte{1, 2, 3, 4}, got.Value(0))
+	require.True(t, got.IsNull(1))
+}
+
+func TestNormalizeColumnRejectsInvalidNestedUUID(t *testing.T) {
+	listBuilder := array.NewListBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String)
+	values := listBuilder.ValueBuilder().(*array.StringBuilder)
+	listBuilder.Append(true)
+	values.Append("not-a-uuid")
+	input := listBuilder.NewArray()
+	listBuilder.Release()
+	defer input.Release()
+
+	_, _, err := normalizeColumn(input, arrow.ListOf(extensions.NewUUIDType()))
+	require.ErrorContains(t, err, "list row 0 element 0")
+}
+
+func TestNormalizeColumnNormalizesJSONListElementsToStrings(t *testing.T) {
+	listBuilder := array.NewListBuilder(memory.DefaultAllocator, schema.JSONArrowType)
+	values := &schema.JSONBuilder{ExtensionBuilder: listBuilder.ValueBuilder().(*array.ExtensionBuilder)}
+	listBuilder.Append(true)
+	values.Append(`{"ok":true}`)
+	values.AppendNull()
+	input := listBuilder.NewArray()
+	listBuilder.Release()
+	defer input.Release()
+
+	converted, release, err := normalizeColumn(input, arrow.ListOf(arrow.BinaryTypes.String))
+	require.NoError(t, err)
+	require.True(t, release)
+	defer converted.Release()
+	got := converted.(*array.List).ListValues().(*array.String)
+	require.Equal(t, `{"ok":true}`, got.Value(0))
+	require.True(t, got.IsNull(1))
+}
+
+func TestNormalizeRecordBatchRecursivelyNormalizesStructUUID(t *testing.T) {
+	logical := &schema.TableSchema{Columns: []schema.Column{{
+		Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+		StructFields: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeUUID, Nullable: false}}},
+	}}}
+	sourceSchema := logical.ToArrowSchema()
+	batches, err := buildRecordBatches(sourceSchema, [][]any{{structVal{"9ed4d13f-a67f-485f-b65d-9dfc260ee765"}}})
+	require.NoError(t, err)
+	normalized, err := normalizeRecordBatch(batches[0], icebergArrowSchema(logical))
+	require.NoError(t, err)
+	defer normalized.Release()
+	profile := normalized.Column(0).(*array.Struct)
+	require.IsType(t, &extensions.UUIDArray{}, profile.Field(0))
+}
+
+func TestNormalizeRecordBatchRejectsRequiredNullListElementOnEqualSchema(t *testing.T) {
+	listType := arrow.ListOfField(arrow.Field{Name: "element", Type: arrow.BinaryTypes.String, Nullable: false})
+	builder := array.NewListBuilderWithField(memory.DefaultAllocator, listType.ElemField())
+	builder.Append(true)
+	builder.ValueBuilder().AppendNull()
+	values := builder.NewArray()
+	builder.Release()
+	defer values.Release()
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "items", Type: listType, Nullable: true}}, nil)
+	record := array.NewRecordBatch(arrowSchema, []arrow.Array{values}, 1)
+	_, err := normalizeRecordBatch(record, arrowSchema)
+	require.ErrorContains(t, err, "required nested value items.element")
+	record.Release()
+}

--- a/pkg/destination/iceberg/replace_atomicity_test.go
+++ b/pkg/destination/iceberg/replace_atomicity_test.go
@@ -1,0 +1,188 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnedPrepareAndCleanupRejectReplacementOwner(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.replace.owned_cleanup"
+	tableSchema := mergeTestSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, OwnershipToken: "owner-a",
+	}))
+	require.ErrorContains(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, OwnershipToken: "owner-b",
+	}), "another owner")
+	require.ErrorContains(t, dest.DropTableIfOwned(ctx, table, "owner-b"), "ownership changed")
+	_, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+}
+
+func TestReplaceFailureLeavesRowsAndTableMetadataUnchanged(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_replace_metadata"
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+	}}
+	evolvedSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "cluster_key", DataType: schema.TypeInt64, Nullable: true},
+	}}
+
+	writeTableRows(t, dest, table, initialSchema, false, [][]any{{int64(1)}})
+	dest.cfg.TableProperties["owner"] = "replacement"
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: evolvedSchema, DropFirst: true,
+		PartitionBy: "bucket[8](id)", ClusterBy: []string{"cluster_key"},
+	}))
+
+	prepared, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	preparedSchema, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, preparedSchema.ColumnNames())
+	require.Empty(t, prepared.Properties()["owner"])
+	require.Empty(t, icebergPartitionFieldNames(ctx, t, dest, table))
+	require.Zero(t, prepared.SortOrder().Len())
+
+	failed := errors.New("simulated final replace rejection")
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{failed}}
+	err = dest.WriteParallel(ctx, recordBatches(int64PairBatch(t, "id", []int64{2}, "cluster_key", []int64{20})), destination.WriteOptions{
+		Table: table, Schema: evolvedSchema,
+	})
+	require.ErrorIs(t, err, failed)
+
+	afterFailure, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	afterFailureSchema, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, afterFailureSchema.ColumnNames())
+	require.Empty(t, afterFailure.Properties()["owner"])
+	require.Empty(t, icebergPartitionFieldNames(ctx, t, dest, table))
+	require.Zero(t, afterFailure.SortOrder().Len())
+	require.Equal(t, [][]any{{int64(1)}}, readTableRows(t, dest, table).Rows)
+
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64PairBatch(t, "id", []int64{2}, "cluster_key", []int64{20})), destination.WriteOptions{
+		Table: table, Schema: evolvedSchema,
+	}))
+	committed, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	committedSchema, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, []string{"id", "cluster_key"}, committedSchema.ColumnNames())
+	require.Equal(t, "replacement", committed.Properties()["owner"])
+	require.NotEmpty(t, icebergPartitionFieldNames(ctx, t, dest, table))
+	require.NotZero(t, committed.SortOrder().Len())
+	require.Equal(t, [][]any{{int64(2), int64(20)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestReplaceNormalizesNullableSourceIdentifierToRequiredTableField(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.replace_nullable_source_identifier"
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "value", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1), "old"}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"}, DropFirst: true,
+	}))
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	batches, err := buildRecordBatches(icebergArrowSchema(sourceSchema), [][]any{{int64(2), "new"}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: sourceSchema, PrimaryKeys: []string{"id"}, DeduplicatePrimaryKeys: true,
+	}))
+	require.Equal(t, [][]any{{int64(2), "new"}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestReplaceReportsSortMetadataFailureAndRetryRepairsIt(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.replace_sort_retry"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "cluster_key", DataType: schema.TypeInt64, Nullable: false},
+	}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1), int64(10)}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true, ClusterBy: []string{"cluster_key"},
+	}))
+
+	injected := errors.New("simulated sort metadata rejection")
+	base := dest.catalog
+	dest.catalog = &failNthCommitCatalog{Catalog: base, failAt: 2, err: injected}
+	t.Cleanup(func() { dest.catalog = base })
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "stable-replace"}
+
+	err := dest.WriteParallel(ctx, recordBatches(int64PairBatch(t, "id", []int64{2}, "cluster_key", []int64{20})), opts)
+	require.ErrorIs(t, err, injected)
+	require.ErrorContains(t, err, "data replacement")
+	require.Equal(t, [][]any{{int64(2), int64(20)}}, readTableRows(t, dest, table).Rows)
+	committed, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.True(t, committed.SortOrder().IsUnsorted())
+
+	// The data token is already durable, so the retry drains its input and
+	// completes only the missing sort-order metadata update.
+	retry := recordBatches(int64PairBatch(t, "id", []int64{999}, "cluster_key", []int64{999}))
+	require.NoError(t, dest.WriteParallel(ctx, retry, opts))
+	require.Empty(t, retry)
+	require.Equal(t, [][]any{{int64(2), int64(20)}}, readTableRows(t, dest, table).Rows)
+	repaired, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.False(t, repaired.SortOrder().IsUnsorted())
+}
+
+type failNthCommitCatalog struct {
+	icebergcatalog.Catalog
+	mu     sync.Mutex
+	calls  int
+	failAt int
+	err    error
+}
+
+func (c *failNthCommitCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	fsFactory := func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) }
+	return icebergtable.New(tbl.Identifier(), tbl.Metadata(), tbl.MetadataLocation(), fsFactory, c), nil
+}
+
+func (c *failNthCommitCatalog) CommitTable(
+	ctx context.Context,
+	ident icebergtable.Identifier,
+	requirements []icebergtable.Requirement,
+	updates []icebergtable.Update,
+) (icebergtable.Metadata, string, error) {
+	c.mu.Lock()
+	c.calls++
+	fail := c.calls == c.failAt
+	c.mu.Unlock()
+	if fail {
+		return nil, "", c.err
+	}
+	return c.Catalog.CommitTable(ctx, ident, requirements, updates)
+}

--- a/pkg/destination/iceberg/replace_dedup_test.go
+++ b/pkg/destination/iceberg/replace_dedup_test.go
@@ -1,0 +1,116 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceDeduplicatesPrimaryKeysAcrossSpillRuns(t *testing.T) {
+	withSpillRunRows(t, 2)
+
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.replace_dedup.incremental"
+	tableSchema := replaceDedupSchema()
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(99), "old target", int64(0)}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true,
+		PrimaryKeys: []string{"id"}, ClusterBy: []string{"score"},
+	}))
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(1), "v1-old", int64(1)},
+		{int64(2), "v2", int64(2)},
+		{int64(1), "v1-latest", int64(10)},
+		{int64(3), "v3-latest", int64(30)},
+		{int64(3), "v3-old", int64(3)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, Parallelism: 4,
+		DeduplicatePrimaryKeys: true, IncrementalKey: "score",
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "v1-latest", rows[int64(1)][1])
+	require.Equal(t, "v2", rows[int64(2)][1])
+	require.Equal(t, "v3-latest", rows[int64(3)][1])
+	assertPhysicalSortOrder(t, dest, table)
+}
+
+func TestReplaceDeduplicationFailureLeavesTargetUnchanged(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.replace_dedup.null_key"
+	tableSchema := replaceDedupSchema()
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(7), "preserved", int64(7)}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true, PrimaryKeys: []string{"id"},
+	}))
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{nil, "invalid", int64(8)}})
+	require.NoError(t, err)
+	records := recordBatches(batches...)
+	err = dest.WriteParallel(ctx, records, destination.WriteOptions{
+		Table: table, Schema: tableSchema, DeduplicatePrimaryKeys: true,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `id`)
+	require.ErrorContains(t, err, `null`)
+	require.Zero(t, len(records), "failed deduplication must drain remaining source batches")
+
+	rows := readTableRows(t, dest, table)
+	require.Equal(t, [][]any{{int64(7), "preserved", int64(7)}}, rows.Rows)
+}
+
+func TestReplaceDeduplicationRejectsUnorderedIncrementalKey(t *testing.T) {
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "versions", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)},
+	}, nil)
+	id := array.NewInt64Builder(memory.DefaultAllocator)
+	id.Append(1)
+	versions := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64)
+	versions.Append(true)
+	versions.ValueBuilder().(*array.Int64Builder).Append(1)
+	batch := array.NewRecordBatch(sc, []arrow.Array{id.NewArray(), versions.NewArray()}, 1)
+	id.Release()
+	versions.Release()
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: batch}
+	close(records)
+	reader := newRecordBatchReader(context.Background(), records, sc)
+	defer reader.Release()
+
+	_, cleanup, err := deduplicateRecordReader(reader, []string{"id"}, "versions")
+	if cleanup != nil {
+		cleanup()
+	}
+	require.ErrorContains(t, err, `incremental key column "versions" is not orderable`)
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+}
+
+func replaceDedupSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "score", DataType: schema.TypeInt64, Nullable: true},
+		},
+		PrimaryKeys:    []string{"id"},
+		IncrementalKey: "score",
+	}
+}

--- a/pkg/destination/iceberg/row_delta_test.go
+++ b/pkg/destination/iceberg/row_delta_test.go
@@ -2,15 +2,83 @@ package iceberg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"testing"
 	"time"
 
+	icebergtable "github.com/apache/iceberg-go/table"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRowDeltaRetriesCommitConflictWithoutLeavingAttemptFiles(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.row_delta.retry"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	before := allTableParquetFiles(t, dest, target)
+	base := dest.catalog
+	dest.catalog = &failNthCommitCatalog{Catalog: base, failAt: 1, err: icebergtable.ErrCommitFailed}
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(2), "new", 2.0, int64(2)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: target, Schema: tableSchema}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: tableSchema.ColumnNames(), CommitToken: "row-delta-retry",
+	}))
+	require.Len(t, allTableParquetFiles(t, dest, target), len(before)+2)
+}
+
+func TestRowDeltaExhaustedCommitConflictsCleanOutputs(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.row_delta.cleanup"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	before := allTableParquetFiles(t, dest, target)
+	dest.catalog = &commitOutcomeCatalog{Catalog: dest.catalog, beforeCommitErrs: []error{
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+		icebergtable.ErrCommitFailed, icebergtable.ErrCommitFailed,
+	}}
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(2), "new", 2.0, int64(2)}})
+	require.NoError(t, err)
+	err = dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: target, Schema: tableSchema}, destination.MergeOptions{
+		TargetTable: target, PrimaryKeys: []string{"id"}, Columns: tableSchema.ColumnNames(), CommitToken: "row-delta-fail",
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, icebergtable.ErrCommitFailed))
+	require.Equal(t, before, allTableParquetFiles(t, dest, target))
+}
+
+func TestRowDeltaCancellationAfterOutputCleansFiles(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.row_delta.canceled_output"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{{int64(1), "before", 1.0, int64(1)}})
+	before := allTableParquetFiles(t, dest, target)
+	tbl, err := dest.loadIcebergTable(context.Background(), target)
+	require.NoError(t, err)
+	writeSchema, err := tableWriteSchema(tbl)
+	require.NoError(t, err)
+	projection := newRowProjection(writeSchema, arrowSchemaColumnNames(writeSchema))
+	ctx, cancel := context.WithCancel(context.Background())
+	produce := func(emit rowEmit) error {
+		for i := 0; i <= batchBuildRows; i++ {
+			if i == batchBuildRows {
+				cancel()
+			}
+			if err := emit(projection, []any{int64(i + 10), "new", float64(i), int64(i)}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	err = dest.commitRowDelta(ctx, tbl, "merge", newCommitMetadata("canceled-row-delta", ""), writeSchema, produce, nil, nil, 1)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, before, allTableParquetFiles(t, dest, target))
+}
 
 // latestSnapshotSummary returns the summary properties of the table's current
 // snapshot, used to detect whether an operation committed equality delete
@@ -148,6 +216,84 @@ func TestMergeTablePartitionedOutsidePrimaryKeyFallsBack(t *testing.T) {
 	requireNoEqualityDeletes(t, dest, target)
 }
 
+func TestMergeTableWithLiveFilesFromOlderPartitionSpecFallsBack(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.cow.mixed_spec_target"
+	staging := "lake.cow.mixed_spec_staging"
+	tableSchema := mergeTestSchema()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       target,
+		Schema:      tableSchema,
+		PartitionBy: "id",
+	}))
+	writeTableRows(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), "old", 1.0, nil},
+		{int64(2), "unchanged", 2.0, nil},
+	})
+	old, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	oldSpec := old.Metadata().PartitionSpec()
+	oldSpecID := oldSpec.ID()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       target,
+		Schema:      tableSchema,
+		PartitionBy: "bucket[4](id)",
+	}))
+	evolved, err := dest.loadIcebergTable(ctx, target)
+	require.NoError(t, err)
+	evolvedSpec := evolved.Metadata().PartitionSpec()
+	require.NotEqual(t, oldSpecID, evolvedSpec.ID())
+
+	writeTableRows(t, dest, staging, tableSchema, true, [][]any{
+		{int64(1), "updated", 10.0, nil},
+		{int64(3), "inserted", 3.0, nil},
+	})
+	require.NoError(t, dest.MergeTable(ctx, destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      tableSchema.ColumnNames(),
+	}))
+
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Len(t, rows, 3)
+	require.Equal(t, "updated", rows[int64(1)][1])
+	require.Equal(t, "unchanged", rows[int64(2)][1])
+	require.Equal(t, "inserted", rows[int64(3)][1])
+	requireNoEqualityDeletes(t, dest, target)
+}
+
+func TestPrepareTableEmptyPartitionExpressionPreservesCurrentSpec(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.partition.preserve_current"
+	tableSchema := mergeTestSchema()
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       table,
+		Schema:      tableSchema,
+		PartitionBy: "bucket[8](id)",
+	}))
+	before, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	beforeSpec := before.Metadata().PartitionSpec()
+	specID := beforeSpec.ID()
+	require.True(t, partitionExpressionMatches(before, "bucket[8](id)"))
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:  table,
+		Schema: tableSchema,
+	}))
+	after, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	afterSpec := after.Metadata().PartitionSpec()
+	require.Equal(t, specID, afterSpec.ID())
+	require.True(t, partitionExpressionMatches(after, "bucket[8](id)"))
+}
+
 func TestMergeTableSpilledRuns(t *testing.T) {
 	withSpillRunRows(t, 8)
 
@@ -238,6 +384,43 @@ func TestSCD2TableUsesRowDeltaByDefault(t *testing.T) {
 	got := readTableRows(t, dest, target)
 	require.Len(t, got.Rows, 3, "changed key gains a closed version, unchanged key stays single")
 	requireEqualityDeletes(t, dest, target)
+}
+
+func TestSCD2RowDeltaPreservesV3Lineage(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{"table.format-version": []string{"3"}})
+	target, staging := "lake.mor.v3_scd2_target", "lake.mor.v3_scd2_staging"
+	t1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "active", 1.0, micros(t1)), scd2Row(2, "active", 2.0, micros(t1)),
+	})
+	runSCD2(t, dest, target, staging, t1, "")
+	before, err := dest.loadIcebergTable(context.Background(), target)
+	require.NoError(t, err)
+	lineageBefore := readV3LineageByID(t, before)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{
+		scd2Row(1, "inactive", 1.0, micros(t2)), scd2Row(2, "active", 2.0, micros(t2)),
+	})
+	runSCD2(t, dest, target, staging, t2, "")
+	after, err := dest.loadIcebergTable(context.Background(), target)
+	require.NoError(t, err)
+	require.Equal(t, lineageBefore[int64(2)], readV3LineageByID(t, after)[int64(2)])
+	tasks, err := after.Scan().PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.True(t, allTasksHaveRowLineage(tasks))
+}
+
+func TestV3SCD2RetriesCommitConflict(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{"table.format-version": []string{"3"}})
+	target, staging := "lake.mor.v3_scd2_retry_target", "lake.mor.v3_scd2_retry_staging"
+	t1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	writeTableRows(t, dest, target, scd2TestSchema(), false, nil)
+	writeTableRows(t, dest, staging, scd2TestSchema(), true, [][]any{scd2Row(1, "active", 1.0, micros(t1))})
+	dest.catalog = &failNthCommitCatalog{Catalog: dest.catalog, failAt: 1, err: icebergtable.ErrCommitFailed}
+
+	runSCD2(t, dest, target, staging, t1, "")
+	require.Len(t, readTableRows(t, dest, target).Rows, 1)
 }
 
 func TestSCD2TableRowDeltaDedupesByIncrementalKey(t *testing.T) {

--- a/pkg/destination/iceberg/schema_platform_test.go
+++ b/pkg/destination/iceberg/schema_platform_test.go
@@ -1,0 +1,205 @@
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	iceberggo "github.com/apache/iceberg-go"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIcebergSchemaRejectsReservedMetadataColumnNames(t *testing.T) {
+	for _, name := range []string{
+		"_file",
+		"_pos",
+		"_deleted",
+		"_spec_id",
+		"_partition",
+		"_row_id",
+		"_last_updated_sequence_number",
+		"_FILE",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := icebergSchemaFromTableSchema(&schema.TableSchema{Columns: []schema.Column{{
+				Name: name, DataType: schema.TypeString, Nullable: true,
+			}}})
+			require.ErrorContains(t, err, "conflicts with reserved metadata column")
+			require.ErrorContains(t, err, "automatic remapping would not be reversible")
+		})
+	}
+}
+
+func TestIcebergSchemaRejectsCaseInsensitiveNameCollisions(t *testing.T) {
+	_, err := icebergSchemaFromTableSchema(&schema.TableSchema{Columns: []schema.Column{
+		{Name: "customer_id", DataType: schema.TypeInt64},
+		{Name: "Customer_ID", DataType: schema.TypeInt64},
+	}})
+	require.ErrorContains(t, err, "differ only by case")
+}
+
+func TestDestinationPrepareTableValidatesNamesBeforeCatalogMutation(t *testing.T) {
+	dest := newHadoopDestination(t)
+	err := dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: "lake.validation.reserved",
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "_file", DataType: schema.TypeString},
+		}},
+	})
+	require.ErrorContains(t, err, "reserved metadata column")
+
+	exists, existsErr := dest.tableExists(context.Background(), []string{"lake", "validation", "reserved"})
+	require.NoError(t, existsErr)
+	require.False(t, exists)
+}
+
+func TestIcebergPrimitiveNestedTypesRoundTrip(t *testing.T) {
+	input := iceberggo.NewSchema(
+		1,
+		iceberggo.NestedField{ID: 1, Name: "amounts", Type: &iceberggo.ListType{
+			ElementID: 2, Element: iceberggo.DecimalTypeOf(18, 4), ElementRequired: false,
+		}},
+		iceberggo.NestedField{ID: 3, Name: "external_ids", Type: &iceberggo.ListType{
+			ElementID: 4, Element: iceberggo.PrimitiveTypes.UUID, ElementRequired: false,
+		}},
+	)
+
+	logical, err := tableSchemaFromIceberg("analytics.nested", input)
+	require.NoError(t, err)
+	require.Equal(t, schema.TypeArray, logical.Columns[0].DataType)
+	require.Equal(t, schema.TypeDecimal, logical.Columns[0].ArrayType)
+	require.Equal(t, 18, logical.Columns[0].Precision)
+	require.Equal(t, 4, logical.Columns[0].Scale)
+	require.Equal(t, schema.TypeArray, logical.Columns[1].DataType)
+	require.Equal(t, schema.TypeUUID, logical.Columns[1].ArrayType)
+
+	roundTripped, err := icebergSchemaFromTableSchema(logical)
+	require.NoError(t, err)
+	amounts, ok := roundTripped.FindFieldByName("amounts")
+	require.True(t, ok)
+	require.True(t, amounts.Type.Equals(&iceberggo.ListType{
+		ElementID: 2, Element: iceberggo.DecimalTypeOf(18, 4), ElementRequired: false,
+	}))
+	externalIDs, ok := roundTripped.FindFieldByName("external_ids")
+	require.True(t, ok)
+	require.True(t, externalIDs.Type.Equals(&iceberggo.ListType{
+		ElementID: 4, Element: iceberggo.PrimitiveTypes.UUID, ElementRequired: false,
+	}))
+}
+
+func TestTableSchemaFromIcebergRejectsNanosecondTimestamps(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  iceberggo.Type
+	}{
+		{
+			name: "nanosecond timestamp",
+			typ:  iceberggo.PrimitiveTypes.TimestampNs,
+		},
+		{
+			name: "nanosecond timestamp with timezone",
+			typ:  iceberggo.PrimitiveTypes.TimestampTzNs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tableSchemaFromIceberg("analytics.nested", iceberggo.NewSchema(
+				1,
+				iceberggo.NestedField{ID: 1, Name: "payload", Type: tt.typ},
+			))
+			require.ErrorContains(t, err, "precision loss")
+		})
+	}
+}
+
+func TestDestinationSchemaEvolutionSoftRemovesRequiredColumn(t *testing.T) {
+	dest := newHadoopDestination(t)
+	table := "lake.evolution.soft_remove"
+	initial := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "legacy", DataType: schema.TypeString, Nullable: false},
+	}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1), "preserved"}})
+
+	_, err := dest.ApplySchemaEvolution(context.Background(), table, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeRemoveColumn, ColumnName: "legacy", OldColumn: &initial.Columns[1],
+		}},
+	})
+	require.NoError(t, err)
+
+	evolved, err := dest.GetTableSchema(context.Background(), table)
+	require.NoError(t, err)
+	require.True(t, icebergColumn(t, evolved, "legacy").Nullable)
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(2), nil}})
+
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Equal(t, "preserved", rows[int64(1)][1])
+	require.Nil(t, rows[int64(2)][1])
+}
+
+func TestDestinationSchemaEvolutionRejectsSoftRemovingIdentifierColumn(t *testing.T) {
+	dest := newHadoopDestination(t)
+	table := "lake.evolution.identifier_remove"
+	initial := &schema.TableSchema{
+		Columns:     []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}},
+		PrimaryKeys: []string{"id"},
+	}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	_, err := dest.ApplySchemaEvolution(context.Background(), table, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeRemoveColumn, ColumnName: "id", OldColumn: &initial.Columns[0],
+		}},
+	})
+	require.ErrorContains(t, err, "cannot soft-remove identifier column")
+
+	got, schemaErr := dest.GetTableSchema(context.Background(), table)
+	require.NoError(t, schemaErr)
+	require.False(t, got.Columns[0].Nullable)
+}
+
+func TestDestinationSchemaEvolutionRejectsRequiredColumnWithoutDefault(t *testing.T) {
+	dest := newHadoopDestination(t)
+	table := "lake.evolution.required_add"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	required := schema.Column{Name: "required_value", DataType: schema.TypeString, Nullable: false}
+	_, err := dest.ApplySchemaEvolution(context.Background(), table, addColumnComparison(required))
+	require.ErrorContains(t, err, "cannot add required column")
+	require.ErrorContains(t, err, "without an initial default")
+
+	got, schemaErr := dest.GetTableSchema(context.Background(), table)
+	require.NoError(t, schemaErr)
+	require.Equal(t, []string{"id"}, got.ColumnNames())
+}
+
+func TestDestinationSchemaEvolutionRejectsReservedColumnBeforeCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	table := "lake.evolution.reserved_add"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	_, err := dest.ApplySchemaEvolution(context.Background(), table, addColumnComparison(schema.Column{
+		Name: "_deleted", DataType: schema.TypeBoolean, Nullable: true,
+	}))
+	require.ErrorContains(t, err, "reserved metadata column")
+
+	got, schemaErr := dest.GetTableSchema(context.Background(), table)
+	require.NoError(t, schemaErr)
+	require.Equal(t, []string{"id"}, got.ColumnNames())
+}
+
+func TestDestinationSchemesIncludeManagedRESTCatalogs(t *testing.T) {
+	require.ElementsMatch(t, []string{
+		"iceberg", "iceberg+rest", "iceberg+nessie", "iceberg+polaris", "iceberg+s3tables",
+		"iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres",
+	}, NewDestination().Schemes())
+}

--- a/pkg/destination/iceberg/sort_order_physical_test.go
+++ b/pkg/destination/iceberg/sort_order_physical_test.go
@@ -1,0 +1,423 @@
+package iceberg
+
+import (
+	"context"
+	"net/url"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPhysicalSortOrderClusteredAppend(t *testing.T) {
+	dest := newHadoopDestination(t)
+	table := "lake.sort_audit.append"
+	tableSchema := sortAuditSchema()
+
+	prepareSortAuditTable(t, dest, table, tableSchema, false, [][]any{
+		{int64(1), int64(30), int64(3)},
+		{int64(2), int64(10), int64(1)},
+		{int64(3), int64(20), int64(2)},
+	})
+
+	assertPhysicalSortOrder(t, dest, table)
+}
+
+func TestPhysicalSortOrderReplace(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.sort_audit.replace"
+	tableSchema := sortAuditSchema()
+
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(9), int64(90), int64(9)}})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"},
+		ClusterBy: []string{"cluster_key"}, DropFirst: true,
+	}))
+	writeSortAuditBatches(t, dest, table, tableSchema, [][]any{
+		{int64(1), int64(30), int64(3)},
+		{int64(2), int64(10), int64(1)},
+		{int64(3), int64(20), int64(2)},
+	})
+
+	assertPhysicalSortOrder(t, dest, table)
+}
+
+func TestReplaceSortOrderTransitionUsesConservativeFileMetadata(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.sort_audit.replace_transition"
+	tableSchema := sortAuditSchema()
+
+	prepareSortAuditTable(t, dest, table, tableSchema, false, [][]any{
+		{int64(1), int64(10), int64(30)},
+		{int64(2), int64(20), int64(10)},
+	})
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"},
+		ClusterBy: []string{"updated_at"}, DropFirst: true,
+	}))
+	writeSortAuditBatches(t, dest, table, tableSchema, [][]any{
+		{int64(3), int64(40), int64(30)},
+		{int64(4), int64(30), int64(10)},
+		{int64(5), int64(50), int64(20)},
+	})
+
+	assertPhysicalSortOrder(t, dest, table)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+	for _, task := range tasks {
+		require.NotNil(t, task.File.SortOrderID())
+		require.Equal(t, icebergtable.UnsortedSortOrderID, *task.File.SortOrderID())
+	}
+}
+
+func TestPhysicalSortOrderDirectMerge(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.sort_audit.direct_merge"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), int64(10), int64(1)},
+		{int64(2), int64(20), int64(2)},
+	})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{
+		{int64(3), int64(40), int64(3)},
+		{int64(4), int64(30), int64(4)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: target, Schema: tableSchema, Parallelism: 4,
+	}, destination.MergeOptions{
+		TargetTable: target, StagingTable: "direct-records", PrimaryKeys: []string{"id"},
+		IncrementalKey: "updated_at", Parallelism: 4,
+	}))
+
+	assertPhysicalSortOrder(t, dest, target)
+}
+
+func TestPhysicalSortOrderDeleteInsert(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	target := "lake.sort_audit.delete_insert_target"
+	staging := "lake.sort_audit.delete_insert_staging"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), int64(10), int64(10)},
+		{int64(2), int64(20), int64(20)},
+	})
+	prepareSortAuditTable(t, dest, staging, tableSchema, true, [][]any{
+		{int64(3), int64(40), int64(30)},
+		{int64(4), int64(30), int64(40)},
+	})
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		TargetTable: target, StagingTable: staging, PrimaryKeys: []string{"id"},
+		IncrementalKey: "updated_at", IntervalStart: int64(10), IntervalEnd: int64(40),
+		Columns: []string{"id", "cluster_key", "updated_at"},
+	}))
+
+	assertPhysicalSortOrder(t, dest, target)
+}
+
+func TestPhysicalSortOrderSCD2(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.sort_audit.scd2_target"
+	staging := "lake.sort_audit.scd2_staging"
+	tableSchema := scd2TestSchema()
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(24 * time.Hour)
+
+	prepareClusteredTable(t, dest, target, tableSchema, []string{"score"}, false, nil)
+	prepareClusteredTable(t, dest, staging, tableSchema, []string{"score"}, true, [][]any{
+		scd2Row(3, "first", 40, micros(t1)),
+		scd2Row(4, "stable", 30, micros(t1)),
+	})
+	runSCD2(t, dest, target, staging, t1, "")
+
+	prepareClusteredTable(t, dest, staging, tableSchema, []string{"score"}, true, [][]any{
+		scd2Row(3, "changed", 5, micros(t2)),
+		scd2Row(4, "stable", 30, micros(t2)),
+		scd2Row(5, "new", 25, micros(t2)),
+	})
+	runSCD2(t, dest, target, staging, t2, "")
+
+	assertPhysicalSortOrder(t, dest, target)
+}
+
+func TestPhysicalSortOrderMergeOnReadRowDelta(t *testing.T) {
+	dest := newHadoopDestination(t)
+	target := "lake.sort_audit.mor_target"
+	staging := "lake.sort_audit.mor_staging"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), int64(10), int64(1)},
+		{int64(2), int64(20), int64(2)},
+	})
+	prepareSortAuditTable(t, dest, staging, tableSchema, true, [][]any{
+		{int64(3), int64(40), int64(3)},
+		{int64(4), int64(30), int64(4)},
+	})
+
+	require.NoError(t, dest.MergeTable(context.Background(), destination.MergeOptions{
+		TargetTable: target, StagingTable: staging, PrimaryKeys: []string{"id"},
+		IncrementalKey: "updated_at", Columns: []string{"id", "cluster_key", "updated_at"},
+		Parallelism: 4,
+	}))
+
+	assertPhysicalSortOrder(t, dest, target)
+}
+
+func TestPhysicalSortOrderCopyOnWriteFallback(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table." + writeMergeModeProperty: []string{mergeModeCopyOnWrite},
+	})
+	target := "lake.sort_audit.cow_target"
+	staging := "lake.sort_audit.cow_staging"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, target, tableSchema, false, [][]any{
+		{int64(1), int64(10), int64(1)},
+		{int64(2), int64(20), int64(2)},
+	})
+	prepareSortAuditTable(t, dest, staging, tableSchema, true, [][]any{
+		{int64(3), int64(40), int64(3)},
+		{int64(4), int64(30), int64(4)},
+	})
+
+	require.NoError(t, dest.MergeTable(context.Background(), destination.MergeOptions{
+		TargetTable: target, StagingTable: staging, PrimaryKeys: []string{"id"},
+		IncrementalKey: "updated_at", Columns: []string{"id", "cluster_key", "updated_at"},
+	}))
+
+	assertPhysicalSortOrder(t, dest, target)
+}
+
+func TestPhysicalSortOrderCopyOnWriteSCD2NetNewRows(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{
+		"table." + writeMergeModeProperty: []string{mergeModeCopyOnWrite},
+	})
+	target := "lake.sort_audit.cow_scd2_target"
+	staging := "lake.sort_audit.cow_scd2_staging"
+	tableSchema := scd2TestSchema()
+	now := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+
+	prepareClusteredTable(t, dest, target, tableSchema, []string{"score"}, false, nil)
+	prepareClusteredTable(t, dest, staging, tableSchema, []string{"score"}, true, [][]any{
+		scd2Row(1, "highest", 50, micros(now)),
+		scd2Row(2, "lowest", 10, micros(now)),
+		scd2Row(3, "middle", 30, micros(now)),
+	})
+	runSCD2(t, dest, target, staging, now, "")
+
+	assertPhysicalSortOrder(t, dest, target)
+}
+
+func TestSortedTableCompactionPreservesPhysicalOrder(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.sort_audit.compaction_skip"
+	tableSchema := sortAuditSchema()
+	prepareSortAuditTable(t, dest, table, tableSchema, false, [][]any{
+		{int64(1), int64(20), int64(1)},
+		{int64(2), int64(10), int64(2)},
+	})
+	writeSortAuditBatches(t, dest, table, tableSchema, [][]any{
+		{int64(3), int64(40), int64(3)},
+		{int64(4), int64(30), int64(4)},
+	})
+
+	before := sortAuditDataFilePaths(t, dest, table)
+	require.Len(t, before, 2)
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	beforeSnapshotID := tbl.CurrentSnapshot().SnapshotID
+
+	result, err := dest.MaintainTable(ctx, table, MaintenanceOptions{
+		CompactDataFiles: true, MinInputFiles: 2, TargetFileSizeBytes: 1 << 30,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.CompactionGroups)
+	require.Equal(t, 1, result.AddedDataFiles)
+	require.Equal(t, 2, result.RemovedDataFiles)
+	require.NotEqual(t, before, sortAuditDataFilePaths(t, dest, table))
+	tbl, err = dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.NotEqual(t, beforeSnapshotID, tbl.CurrentSnapshot().SnapshotID)
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+	for _, task := range tasks {
+		require.NotNil(t, task.File.SortOrderID())
+		require.Equal(t, tbl.SortOrder().OrderID(), *task.File.SortOrderID())
+	}
+
+	assertPhysicalSortOrder(t, dest, table)
+	rows := readTableRows(t, dest, table).Rows
+	require.Len(t, rows, 4)
+	for i := 1; i < len(rows); i++ {
+		require.LessOrEqual(t, rows[i-1][1].(int64), rows[i][1].(int64))
+	}
+}
+
+func sortAuditSchema() *schema.TableSchema {
+	return &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "cluster_key", DataType: schema.TypeInt64, Nullable: true},
+		{Name: "updated_at", DataType: schema.TypeInt64, Nullable: false},
+	}}
+}
+
+func newHadoopDestinationWithTableProperties(t *testing.T, properties url.Values) *Destination {
+	t.Helper()
+	properties.Set("warehouse", t.TempDir())
+	dest := NewDestination()
+	require.NoError(t, dest.Connect(context.Background(), "iceberg+hadoop://?"+properties.Encode()))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	return dest
+}
+
+func prepareSortAuditTable(t *testing.T, dest *Destination, table string, tableSchema *schema.TableSchema, dropFirst bool, rows [][]any) {
+	t.Helper()
+	prepareClusteredTable(t, dest, table, tableSchema, []string{"cluster_key"}, dropFirst, rows)
+}
+
+func prepareClusteredTable(t *testing.T, dest *Destination, table string, tableSchema *schema.TableSchema, clusterBy []string, dropFirst bool, rows [][]any) {
+	t.Helper()
+	require.NoError(t, dest.PrepareTable(context.Background(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PrimaryKeys: []string{"id"},
+		ClusterBy: clusterBy, DropFirst: dropFirst,
+	}))
+	writeSortAuditBatches(t, dest, table, tableSchema, rows)
+}
+
+func writeSortAuditBatches(t *testing.T, dest *Destination, table string, tableSchema *schema.TableSchema, rows [][]any) {
+	t.Helper()
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), rows)
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(context.Background(), recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema, Parallelism: 4,
+	}))
+}
+
+func assertPhysicalSortOrder(t *testing.T, dest *Destination, table string) {
+	t.Helper()
+	ctx := context.Background()
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	order := tbl.SortOrder()
+	require.NotZero(t, order.Len(), "table %s has no declared sort order", table)
+
+	var sortColumns []string
+	for _, sortField := range order.Fields() {
+		require.Equal(t, icebergtable.SortASC, sortField.Direction)
+		require.Equal(t, icebergtable.NullsFirst, sortField.NullOrder)
+		require.Equal(t, "identity", sortField.Transform.String())
+		name, ok := tbl.Schema().FindColumnName(sortField.SourceID())
+		require.True(t, ok, "sort source field %d is missing", sortField.SourceID())
+		sortColumns = append(sortColumns, name)
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks, "table %s has no live data files", table)
+	fs, err := tbl.FS(ctx)
+	require.NoError(t, err)
+	for _, task := range tasks {
+		dataFile := task.File
+		require.Equal(t, iceberggo.EntryContentData, dataFile.ContentType())
+		require.NotNil(t, dataFile.SortOrderID(), "data file %s has no sort-order-id", dataFile.FilePath())
+		require.Contains(t, []int{icebergtable.UnsortedSortOrderID, order.OrderID()}, *dataFile.SortOrderID(),
+			"data file %s claims an unexpected sort-order-id", dataFile.FilePath())
+		require.Equal(t, iceberggo.ParquetFile, dataFile.FileFormat())
+
+		input, err := fs.Open(dataFile.FilePath())
+		require.NoError(t, err)
+		parquetReader, err := file.NewParquetReader(input)
+		if err != nil {
+			_ = input.Close()
+		}
+		require.NoError(t, err)
+		arrowReader, err := pqarrow.NewFileReader(parquetReader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+		require.NoError(t, err)
+		recordReader, err := arrowReader.GetRecordReader(ctx, nil, nil)
+		require.NoError(t, err)
+		sorter, err := newClusterSorter(recordReader.Schema(), sortColumns)
+		require.NoError(t, err)
+
+		var previous string
+		var previousValues []any
+		hasPrevious := false
+		var rowsRead int64
+		for recordReader.Next() {
+			batch := recordReader.RecordBatch()
+			for row := 0; row < int(batch.NumRows()); row++ {
+				rowsRead++
+				values := make([]any, len(sorter.keyIdx))
+				for i, column := range sorter.keyIdx {
+					values[i], err = rowValue(batch.Column(column), row)
+					require.NoError(t, err)
+				}
+				key, err := sorter.encode(values)
+				require.NoError(t, err)
+				if hasPrevious {
+					require.LessOrEqual(t, previous, key,
+						"data file %s is not sorted by %v: %v precedes %v",
+						dataFile.FilePath(), sortColumns, previousValues, values)
+				}
+				previous = key
+				previousValues = slices.Clone(values)
+				hasPrevious = true
+			}
+		}
+		require.NoError(t, recordReader.Err())
+		require.Equal(t, dataFile.Count(), rowsRead, "data file %s row-count audit", dataFile.FilePath())
+		sorter.Close()
+		recordReader.Release()
+		require.NoError(t, parquetReader.Close())
+	}
+}
+
+func sortAuditDataFilePaths(t *testing.T, dest *Destination, table string) []string {
+	t.Helper()
+	tbl, err := dest.loadIcebergTable(context.Background(), table)
+	require.NoError(t, err)
+	tasks, err := tbl.Scan().PlanFiles(context.Background())
+	require.NoError(t, err)
+	paths := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		paths = append(paths, task.File.FilePath())
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func TestEnsureSortOrderClearsOrderOnTableCreatedSorted(t *testing.T) {
+	ctx := context.Background()
+	dest := newHadoopDestination(t)
+	table := "lake.sort_audit.created_sorted"
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:     table,
+		Schema:    lifecycleTestSchema(),
+		ClusterBy: []string{"id"},
+	}))
+
+	tbl, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	require.NotEqual(t, icebergtable.UnsortedSortOrder.OrderID(), tbl.SortOrder().OrderID())
+
+	cleared, err := dest.ensureSortOrder(ctx, tbl, nil)
+	require.NoError(t, err)
+	require.Equal(t, icebergtable.UnsortedSortOrder.OrderID(), cleared.SortOrder().OrderID())
+}

--- a/pkg/destination/iceberg/spill_test.go
+++ b/pkg/destination/iceberg/spill_test.go
@@ -154,6 +154,31 @@ func TestSpillSorterMultiPassMerge(t *testing.T) {
 	}
 }
 
+func TestSpillMergeCursorMemoryTracksRunLimit(t *testing.T) {
+	withSpillRunRows(t, 7)
+	previousFanIn := spillMergeFanIn
+	spillMergeFanIn = 64
+	t.Cleanup(func() { spillMergeFanIn = previousFanIn })
+
+	for i := range 70 {
+		sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
+		require.NoError(t, err)
+		for row := range 70 {
+			require.NoError(t, sorter.Add([]any{int64(row % 5), fmt.Sprintf("%d-%d", i, row)}))
+		}
+		it, err := sorter.Iter()
+		require.NoError(t, err)
+		for it.NextGroup() {
+			for it.NextRow() {
+			}
+		}
+		require.NoError(t, it.Err())
+		it.Close()
+		sorter.Close()
+	}
+	require.LessOrEqual(t, effectiveSpillMergeFanIn()*spillCursorBatchRows(), spillRunRows)
+}
+
 func TestSpillSorterRejectsNullKeys(t *testing.T) {
 	sorter, err := newSpillSorter(spillTestSchema(), []string{"id"})
 	require.NoError(t, err)

--- a/pkg/destination/iceberg/strategies_test.go
+++ b/pkg/destination/iceberg/strategies_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	iceberggo "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/require"
@@ -405,6 +406,25 @@ func TestDeleteInsertTable(t *testing.T) {
 	require.Equal(t, "v2", rows[int64(7)][1])
 	require.NotContains(t, rows, int64(5))
 	require.NotContains(t, rows, int64(6))
+}
+
+func TestV3DeleteInsertRetriesCommitConflict(t *testing.T) {
+	dest := newHadoopDestinationWithTableProperties(t, url.Values{"table.format-version": []string{"3"}})
+	ctx := context.Background()
+	target, staging := "lake.di.v3_retry_target", "lake.di.v3_retry_staging"
+	writeTableRows(t, dest, target, mergeTestSchema(), false, [][]any{
+		{int64(1), "old", 1.0, nil}, {int64(2), "keep", 2.0, nil},
+	})
+	writeTableRows(t, dest, staging, mergeTestSchema(), true, [][]any{{int64(1), "new", 3.0, nil}})
+	dest.catalog = &failNthCommitCatalog{Catalog: dest.catalog, failAt: 1, err: icebergtable.ErrCommitFailed}
+
+	require.NoError(t, dest.DeleteInsertTable(ctx, destination.DeleteInsertOptions{
+		StagingTable: staging, TargetTable: target, IncrementalKey: "id",
+		IntervalStart: int64(1), IntervalEnd: int64(1), PrimaryKeys: []string{"id"},
+	}))
+	rows := singleRowByKey(t, readTableRows(t, dest, target), "id")
+	require.Equal(t, "new", rows[int64(1)][1])
+	require.Equal(t, "keep", rows[int64(2)][1])
 }
 
 func TestDeleteInsertTableTimestampInterval(t *testing.T) {

--- a/pkg/destination/iceberg/truncate_insert_test.go
+++ b/pkg/destination/iceberg/truncate_insert_test.go
@@ -1,0 +1,462 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicTruncateInsertPreservesTargetOnFailureAndDeduplicatesCommit(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_insert"
+	targetSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "version", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "legacy", DataType: schema.TypeString, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+	inputSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "version", DataType: schema.TypeInt64, Nullable: false},
+	}, PrimaryKeys: []string{"id"}}
+	writeTableRows(t, dest, table, targetSchema, false, [][]any{
+		{int64(1), int64(10), "one"},
+		{int64(2), int64(20), "two"},
+	})
+
+	beforeSnapshots := icebergSnapshotCount(t, dest, table)
+	failedBatch, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{{int64(9), int64(90)}})
+	require.NoError(t, err)
+	trailingBatch, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{{int64(10), int64(100)}})
+	require.NoError(t, err)
+	failedRecords := make(chan source.RecordBatchResult, 3)
+	failedRecords <- source.RecordBatchResult{Batch: failedBatch[0]}
+	failedRecords <- source.RecordBatchResult{Err: errors.New("source failed after data")}
+	failedRecords <- source.RecordBatchResult{Batch: trailingBatch[0]}
+	close(failedRecords)
+	err = dest.TruncateInsertRecords(ctx, failedRecords, destination.WriteOptions{
+		Table: table, Schema: inputSchema, PrimaryKeys: []string{"id"},
+		DeduplicatePrimaryKeys: true, IncrementalKey: "version",
+	})
+	require.ErrorContains(t, err, "source failed after data")
+	require.Empty(t, failedRecords, "a failed atomic reload must release all remaining source batches")
+	require.Equal(t, beforeSnapshots, icebergSnapshotCount(t, dest, table))
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+	require.Contains(t, readTableRows(t, dest, table).Columns, "legacy")
+
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{
+		{int64(2), int64(21)},
+		{int64(3), int64(30)},
+		{int64(2), int64(22)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: inputSchema, PrimaryKeys: []string{"id"},
+		DeduplicatePrimaryKeys: true, IncrementalKey: "version",
+	}))
+
+	require.Equal(t, beforeSnapshots+1, icebergSnapshotCount(t, dest, table))
+	rows := singleRowByKey(t, readTableRows(t, dest, table), "id")
+	require.Len(t, rows, 2)
+	require.Equal(t, int64(22), rows[int64(2)][1])
+	require.Nil(t, rows[int64(2)][2])
+	require.Equal(t, int64(30), rows[int64(3)][1])
+	require.Nil(t, rows[int64(3)][2])
+	require.Equal(t, "truncate+insert", latestSnapshotSummary(t, dest, table)["ingestr.operation"])
+}
+
+func TestAtomicTruncateInsertRetriesCommitConflictAndCleansFirstAttempt(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_retry"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	before := allTableParquetFiles(t, dest, table)
+	dest.catalog = &failNthCommitCatalog{Catalog: dest.catalog, failAt: 1, err: icebergtable.ErrCommitFailed}
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "truncate-retry",
+	}))
+	require.Equal(t, [][]any{{int64(2)}}, readTableRows(t, dest, table).Rows)
+	require.Len(t, allTableParquetFiles(t, dest, table), len(before)+1)
+}
+
+func TestAtomicTruncateInsertPreservesExternalPartitionFieldMetadata(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_external_partition"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	iceSchema, err := icebergSchemaFromTableSchema(tableSchema)
+	require.NoError(t, err)
+	spec, err := iceberggo.NewPartitionSpecOpts(iceberggo.AddPartitionFieldByName(
+		"id",
+		"external_bucket_name",
+		iceberggo.BucketTransform{NumBuckets: 8},
+		iceSchema,
+		nil,
+	))
+	require.NoError(t, err)
+	idField, ok := iceSchema.FindFieldByName("id")
+	require.True(t, ok)
+	sortOrder, err := icebergtable.NewSortOrder(1, []icebergtable.SortField{{
+		SourceIDs: []int{idField.ID},
+		Transform: iceberggo.IdentityTransform{},
+		Direction: icebergtable.SortDESC,
+		NullOrder: icebergtable.NullsLast,
+	}})
+	require.NoError(t, err)
+	ident, err := parseIdentifier(table)
+	require.NoError(t, err)
+	require.NoError(t, dest.ensureNamespace(ctx, icebergcatalog.NamespaceFromIdent(ident)))
+	require.NoError(t, dest.ensureLocalTableDirs(ident))
+	_, err = dest.catalog.CreateTable(
+		ctx, ident, iceSchema,
+		icebergcatalog.WithPartitionSpec(&spec),
+		icebergcatalog.WithSortOrder(sortOrder),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: table, Schema: tableSchema, PreserveExistingLayout: true,
+	}))
+	oldBatches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(1), "old"}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(oldBatches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}))
+	before, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	beforeSpec := before.Metadata().PartitionSpec()
+	beforeField := onlyPartitionField(t, beforeSpec)
+	beforeSortOrder := before.SortOrder()
+	dest.cfg.PartitionSpec = "id"
+	dest.cfg.TableProperties["external.should-not-be-applied"] = "configured"
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table:                  table,
+		Schema:                 tableSchema,
+		PartitionBy:            "id",
+		ClusterBy:              []string{"id"},
+		PreserveExistingLayout: true,
+	}))
+	prepared, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	preparedSpec := prepared.Metadata().PartitionSpec()
+	preparedField := onlyPartitionField(t, preparedSpec)
+	require.Equal(t, beforeSpec.ID(), preparedSpec.ID())
+	require.Equal(t, beforeField.Name, preparedField.Name)
+	require.Equal(t, beforeSortOrder.OrderID(), prepared.SortOrder().OrderID())
+	require.True(t, sortFieldsEqual(beforeSortOrder, prepared.SortOrder()))
+	require.NotContains(t, prepared.Properties(), "external.should-not-be-applied")
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(2), "new"}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: tableSchema,
+	}))
+
+	after, err := dest.loadIcebergTable(ctx, table)
+	require.NoError(t, err)
+	afterSpec := after.Metadata().PartitionSpec()
+	afterField := onlyPartitionField(t, afterSpec)
+	require.Equal(t, beforeSpec.ID(), afterSpec.ID())
+	require.Equal(t, beforeField.FieldID, afterField.FieldID)
+	require.Equal(t, beforeField.SourceIDs, afterField.SourceIDs)
+	require.Equal(t, beforeField.Name, afterField.Name)
+	require.True(t, beforeField.Transform.Equals(afterField.Transform))
+	require.Equal(t, "external_bucket_name", afterField.Name)
+	require.Equal(t, beforeSortOrder.OrderID(), after.SortOrder().OrderID())
+	require.True(t, sortFieldsEqual(beforeSortOrder, after.SortOrder()))
+	tasks, err := after.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+	for _, task := range tasks {
+		require.NotNil(t, task.File.SortOrderID())
+		require.Equal(t, icebergtable.UnsortedSortOrderID, *task.File.SortOrderID())
+	}
+	require.Equal(t, [][]any{{int64(2), "new"}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertAlreadyCommittedTokenDrainsRetry(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_retry"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+	}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(2)}})
+	require.NoError(t, err)
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "stable-reload"}
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), opts))
+	beforeSnapshots := icebergSnapshotCount(t, dest, table)
+
+	retryBatches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(999)}})
+	require.NoError(t, err)
+	retry := recordBatches(retryBatches...)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, retry, opts))
+	require.Empty(t, retry)
+	require.Equal(t, beforeSnapshots, icebergSnapshotCount(t, dest, table))
+	require.Equal(t, [][]any{{int64(2)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertExplicitTokenRetryPreservesInterleavedAppend(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_explicit_token_lineage"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+	opts := destination.WriteOptions{Table: table, Schema: tableSchema, CommitToken: "explicit-reload"}
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(int64Batch(t, 2)), opts))
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(3)}})
+	beforeSnapshots := icebergSnapshotCount(t, dest, table)
+
+	retry := recordBatches(int64Batch(t, 999))
+	require.NoError(t, dest.TruncateInsertRecords(ctx, retry, opts))
+	require.Empty(t, retry)
+	require.Equal(t, beforeSnapshots, icebergSnapshotCount(t, dest, table))
+	require.ElementsMatch(t, [][]any{{int64(2)}, {int64(3)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertReconcilesUnknownOutcomeAcrossInterleavedAppend(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_unknown_interleaved"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+
+	base := dest.catalog
+	unknown := errors.New("simulated lost truncate commit response")
+	var hookErr error
+	dest.catalog = &commitOutcomeCatalog{
+		Catalog:         base,
+		afterCommitErrs: []error{unknown},
+		afterCommitHook: func() {
+			tbl, err := base.LoadTable(ctx, icebergtable.Identifier{"lake", "correctness", "atomic_truncate_unknown_interleaved"})
+			if err != nil {
+				hookErr = err
+				return
+			}
+			batch := int64Batch(t, 3)
+			reader := newRecordBatchReader(ctx, recordBatches(batch), batch.Schema())
+			defer reader.Release()
+			_, hookErr = tbl.Append(ctx, reader, snapshotProps("append", newCommitMetadata("interleaved-after-truncate", "")))
+		},
+	}
+	t.Cleanup(func() { dest.catalog = base })
+
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(int64Batch(t, 2)), destination.WriteOptions{
+		Table: table, Schema: tableSchema, CommitToken: "truncate-unknown-token",
+	}))
+	require.NoError(t, hookErr)
+	require.ElementsMatch(t, [][]any{{int64(2)}, {int64(3)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertUsesEvolvedSchemaInSameReload(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_schema_evolution"
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+	}}
+	evolvedSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "value", DataType: schema.TypeString, Nullable: true},
+		{Name: "new_value", DataType: schema.TypeInt64, Nullable: true},
+	}}
+	writeTableRows(t, dest, table, initialSchema, false, [][]any{{int64(1), "old"}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(evolvedSchema), [][]any{{int64(2), "new", int64(42)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{
+		Table: table, Schema: evolvedSchema,
+	}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, evolvedSchema.Columns, loaded.Columns)
+	require.Equal(t, [][]any{{int64(2), "new", int64(42)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertRollsBackSchemaEvolutionWithFailedInput(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_schema_rollback"
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+	}}
+	evolvedSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "new_value", DataType: schema.TypeString, Nullable: true},
+	}}
+	writeTableRows(t, dest, table, initialSchema, false, [][]any{{int64(1)}})
+	beforeSnapshots := icebergSnapshotCount(t, dest, table)
+
+	batches, err := buildRecordBatches(icebergArrowSchema(evolvedSchema), [][]any{{int64(2), "uncommitted"}})
+	require.NoError(t, err)
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: batches[0]}
+	records <- source.RecordBatchResult{Err: errors.New("source failed")}
+	close(records)
+
+	err = dest.TruncateInsertRecords(ctx, records, destination.WriteOptions{Table: table, Schema: evolvedSchema})
+	require.ErrorContains(t, err, "source failed")
+	require.Equal(t, beforeSnapshots, icebergSnapshotCount(t, dest, table))
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, initialSchema.Columns, loaded.Columns)
+	require.Equal(t, [][]any{{int64(1)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertContentRetryDoesNotIgnoreLaterDataCommits(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_content_lineage"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, tableSchema, false, [][]any{{int64(1)}})
+
+	reload := func() {
+		batches, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(10)}})
+		require.NoError(t, err)
+		require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: tableSchema}))
+	}
+	reload()
+	appended, err := buildRecordBatches(icebergArrowSchema(tableSchema), [][]any{{int64(99)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(appended...), destination.WriteOptions{Table: table, Schema: tableSchema}))
+	require.EqualValues(t, 2, icebergRowCount(ctx, t, dest, table))
+
+	reload()
+	require.Equal(t, [][]any{{int64(10)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertSoftRemovesRequiredColumn(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_soft_remove"
+	initial := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "legacy", DataType: schema.TypeString, Nullable: false},
+	}}
+	desired := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1), "old"}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(desired), [][]any{{int64(2)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: desired}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Len(t, loaded.Columns, 2)
+	require.True(t, loaded.Columns[1].Nullable)
+	require.Equal(t, [][]any{{int64(2), nil}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertStripsStagingOnlyCDCColumns(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_cdc_projection"
+	targetSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	inputSchema := &schema.TableSchema{Columns: []schema.Column{
+		targetSchema.Columns[0],
+		{Name: destination.CDCUnchangedColsColumn, DataType: schema.TypeString, Nullable: true},
+	}}
+	writeTableRows(t, dest, table, targetSchema, false, [][]any{{int64(1)}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(inputSchema), [][]any{{int64(2), `["payload"]`}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: inputSchema}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, targetSchema.Columns, loaded.Columns)
+	require.Equal(t, [][]any{{int64(2)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertTypeEvolutionIsAtomic(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_type_evolution"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt32, Nullable: false}}}
+	widened := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeInt64, Nullable: false}}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(widened), [][]any{{int64(1 << 40)}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: widened}))
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Equal(t, schema.TypeInt64, loaded.Columns[0].DataType)
+	require.Equal(t, [][]any{{int64(1 << 40)}}, readTableRows(t, dest, table).Rows)
+
+	invalid := &schema.TableSchema{Columns: []schema.Column{{Name: "value", DataType: schema.TypeBoolean, Nullable: false}}}
+	invalidBatches, err := buildRecordBatches(icebergArrowSchema(invalid), [][]any{{true}})
+	require.NoError(t, err)
+	err = dest.TruncateInsertRecords(ctx, recordBatches(invalidBatches...), destination.WriteOptions{Table: table, Schema: invalid})
+	require.ErrorContains(t, err, "not supported")
+	require.Equal(t, [][]any{{int64(1 << 40)}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertAddsRequiredColumnDuringFullReplacement(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_required_add"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	desired := &schema.TableSchema{Columns: []schema.Column{
+		initial.Columns[0],
+		{Name: "required_value", DataType: schema.TypeString, Nullable: false},
+	}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(desired), [][]any{{int64(2), "present"}})
+	require.NoError(t, err)
+	require.NoError(t, dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: desired}))
+
+	loaded, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.Len(t, loaded.Columns, 2)
+	require.False(t, loaded.Columns[1].Nullable)
+	require.Equal(t, [][]any{{int64(2), "present"}}, readTableRows(t, dest, table).Rows)
+}
+
+func TestAtomicTruncateInsertRejectsNullRequiredAdditionAndRollsBack(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	table := "lake.correctness.atomic_truncate_null_required_add"
+	initial := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}}
+	desired := &schema.TableSchema{Columns: []schema.Column{
+		initial.Columns[0],
+		{Name: "required_value", DataType: schema.TypeString, Nullable: false},
+	}}
+	writeTableRows(t, dest, table, initial, false, [][]any{{int64(1)}})
+
+	batches, err := buildRecordBatches(icebergArrowSchema(desired), [][]any{{int64(2), nil}})
+	require.NoError(t, err)
+	err = dest.TruncateInsertRecords(ctx, recordBatches(batches...), destination.WriteOptions{Table: table, Schema: desired})
+	require.ErrorContains(t, err, "required nested value required_value[0] is null")
+	loaded, loadErr := dest.GetTableSchema(ctx, table)
+	require.NoError(t, loadErr)
+	require.Equal(t, initial.Columns, loaded.Columns)
+	require.Equal(t, [][]any{{int64(1)}}, readTableRows(t, dest, table).Rows)
+}
+
+func onlyPartitionField(t *testing.T, spec iceberggo.PartitionSpec) iceberggo.PartitionField {
+	t.Helper()
+	var fields []iceberggo.PartitionField
+	for _, field := range spec.Fields() {
+		fields = append(fields, field)
+	}
+	require.Len(t, fields, 1)
+	return fields[0]
+}


### PR DESCRIPTION
## Summary

Adds comprehensive Iceberg unit and regression coverage for correctness, concurrency, retries, failure recovery, and platform behavior.

## Stack

Part 9 of 11. Review and merge bottom-up. This PR is based on `stack/iceberg-08-core-runtime`; GitHub therefore shows only this layer's delta.

Previous: https://github.com/bruin-data/ingestr/pull/966 · Next: https://github.com/bruin-data/ingestr/pull/968

## Validation

- `make format`
- `make lint`
- `make test`
- Layer-specific package tests

The complete stack is byte-for-byte equivalent to the previously reviewed full implementation.