### PR TITLE
Iceberg stack 10/11: real-service integration coverage

### DIFF
--- a/pkg/source/postgres_cdc/array_delimiter_integration_test.go
+++ b/pkg/source/postgres_cdc/array_delimiter_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package postgres_cdc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresArrayDelimiterMetadataFromContainer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	container, connString := startConnectorLeasePostgres(t, ctx)
+	defer func() { _ = container.Terminate(context.Background()) }()
+
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE public.array_delimiters (id bigint PRIMARY KEY, boxes box[]);
+		INSERT INTO public.array_delimiters VALUES (1, ARRAY[box(point(1, 1), point(0, 0)), box(point(2, 2), point(1, 1))]);
+	`)
+	require.NoError(t, err)
+
+	tableSchema, err := getTableSchema(ctx, pool, "public.array_delimiters")
+	require.NoError(t, err)
+	var boxes schema.Column
+	for _, column := range tableSchema.Columns {
+		if column.Name == "boxes" {
+			boxes = column
+			break
+		}
+	}
+	require.Equal(t, schema.TypeArray, boxes.DataType)
+	require.Equal(t, ";", boxes.ArrayDelimiter)
+
+	var literal string
+	require.NoError(t, pool.QueryRow(ctx, `SELECT boxes::text FROM public.array_delimiters WHERE id = 1`).Scan(&literal))
+	value, err := convertTextValue(literal, boxes)
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{"(1,1),(0,0)", "(2,2),(1,1)"}, value)
+}

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -22,7 +22,10 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/uri"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/snowflake"
 	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // Register ADBC driver
 	"github.com/bruin-data/ingestr/pkg/strategy"
@@ -76,6 +79,70 @@ type destCase struct {
 	replaceDedupCapable  bool
 	validateNonSQL       func(t *testing.T, destURI, destTable string)
 	validateAppendNonSQL func(t *testing.T, destURI, destTable string)
+}
+
+func TestRequiredColumnDDLConformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	for _, tc := range destinationCases() {
+		if tc.name != "postgres" && tc.name != "mysql" && tc.name != "duckdb" {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			destURI, table, cleanup := tc.setup(t, ctx)
+			defer cleanup()
+			dest, err := uri.DefaultRegistry.GetDestination(destURI)
+			require.NoError(t, err)
+			require.NoError(t, dest.Connect(ctx, destURI))
+			require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+				Table: table,
+				Schema: &schema.TableSchema{Columns: []schema.Column{
+					{Name: "required_value", DataType: schema.TypeInt64, Nullable: false},
+					{Name: "optional_value", DataType: schema.TypeString, Nullable: true},
+				}},
+				DropFirst: true,
+			}))
+			if tc.name == "postgres" {
+				evolver := dest.(schemaevolution.SchemaEvolver)
+				_, err = evolver.ApplySchemaEvolution(ctx, table, &schemaevolution.SchemaComparison{
+					HasChanges: true,
+					Changes: []schemaevolution.SchemaChange{{
+						Type: schemaevolution.ChangeAddColumn, ColumnName: "added_required",
+						NewColumn: schema.Column{Name: "added_required", DataType: schema.TypeInt64, Nullable: false},
+					}},
+				})
+				require.NoError(t, err)
+			}
+			require.NoError(t, dest.Close(ctx))
+
+			db, err := tc.sqlBackend.openDB(destURI)
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			assertNullability := func(column, want string) {
+				t.Helper()
+				var got string
+				switch tc.name {
+				case "postgres":
+					schemaName, tableName := splitSchemaTable(table, "public")
+					err = db.QueryRowContext(ctx, `SELECT is_nullable FROM information_schema.columns WHERE table_schema=$1 AND table_name=$2 AND column_name=$3`, schemaName, tableName, column).Scan(&got)
+				case "mysql":
+					err = db.QueryRowContext(ctx, `SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME=? AND COLUMN_NAME=?`, table, column).Scan(&got)
+				case "duckdb":
+					schemaName, tableName := splitSchemaTable(table, "main")
+					err = db.QueryRowContext(ctx, `SELECT is_nullable FROM information_schema.columns WHERE table_schema=? AND table_name=? AND column_name=?`, schemaName, tableName, column).Scan(&got)
+				}
+				require.NoError(t, err)
+				assert.Equal(t, want, strings.ToUpper(got))
+			}
+			assertNullability("required_value", "NO")
+			assertNullability("optional_value", "YES")
+			if tc.name == "postgres" {
+				assertNullability("added_required", "NO")
+			}
+		})
+	}
 }
 
 func destinationCases() []destCase {

--- a/tests/integration/iceberg_destination_test.go
+++ b/tests/integration/iceberg_destination_test.go
@@ -3,9 +3,12 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -13,6 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	iceberggo "github.com/apache/iceberg-go"
 	icebergcatalog "github.com/apache/iceberg-go/catalog"
 	_ "github.com/apache/iceberg-go/catalog/rest"
@@ -22,7 +29,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	ingestconfig "github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	icebergdest "github.com/bruin-data/ingestr/pkg/destination/iceberg"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
 	dockercontainer "github.com/moby/moby/api/types/container"
 	dockermount "github.com/moby/moby/api/types/mount"
 	"github.com/stretchr/testify/assert"
@@ -32,11 +43,18 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+const (
+	icebergAzuriteAccountName = "devstoreaccount1"
+	icebergAzuriteAccountKey  = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==" //gitleaks:allow -- public Azurite emulator key
+)
+
 type icebergCatalogTestEnv struct {
-	destURI      string
-	client       *s3.Client
-	bucket       string
-	objectPrefix string
+	destURI                string
+	client                 *s3.Client
+	bucket                 string
+	objectPrefix           string
+	tableLocationHasSuffix bool
+	localWarehouse         string
 }
 
 func TestIcebergCatalogBackends(t *testing.T) {
@@ -68,6 +86,14 @@ func TestIcebergCatalogBackends(t *testing.T) {
 			name:  "rest catalog with minio",
 			setup: setupIcebergRESTMinioCatalog,
 		},
+		{
+			name:  "nessie catalog with minio",
+			setup: setupIcebergNessieMinioCatalog,
+		},
+		{
+			name:  "hive metastore catalog with local warehouse",
+			setup: setupIcebergHiveCatalog,
+		},
 	}
 
 	for _, tt := range tests {
@@ -78,14 +104,283 @@ func TestIcebergCatalogBackends(t *testing.T) {
 			tableName := namespace + "." + table
 
 			exerciseIcebergDestination(t, ctx, env.destURI, tableName)
+			if env.localWarehouse != "" {
+				assert.Greater(t, countRegularFiles(t, env.localWarehouse), 0, "catalog writes must land in the configured warehouse")
+				assert.NoDirExists(t, "file:", "file:/ URIs must not create a relative workspace directory")
+			}
 
 			if env.client != nil {
 				tablePrefix := joinIcebergObjectPrefix(env.objectPrefix, namespace, table)
-				assert.Greater(t, countMinioObjects(t, ctx, env.client, env.bucket, tablePrefix+"data/"), 0)
-				assert.Greater(t, countMinioObjects(t, ctx, env.client, env.bucket, tablePrefix+"metadata/"), 0)
+				if env.tableLocationHasSuffix {
+					assert.Greater(t, countMinioObjects(t, ctx, env.client, env.bucket, strings.Trim(env.objectPrefix, "/")+"/"), 0)
+				} else {
+					assert.Greater(t, countMinioObjects(t, ctx, env.client, env.bucket, tablePrefix+"data/"), 0)
+					assert.Greater(t, countMinioObjects(t, ctx, env.client, env.bucket, tablePrefix+"metadata/"), 0)
+				}
 			}
 		})
 	}
+}
+
+func TestIcebergManagedCatalogBackends(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping managed Iceberg catalog integration tests in short mode")
+	}
+
+	ctx := context.Background()
+	tests := []struct {
+		name   string
+		envVar string
+	}{
+		{name: "AWS Glue", envVar: "GONG_TEST_ICEBERG_GLUE_URI"},
+		{name: "Amazon S3 Tables", envVar: "GONG_TEST_ICEBERG_S3TABLES_URI"},
+		{name: "Polaris", envVar: "GONG_TEST_ICEBERG_POLARIS_URI"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destURI := strings.TrimSpace(os.Getenv(tt.envVar))
+			if destURI == "" {
+				t.Skipf("Set %s to run the %s Iceberg destination conformance matrix", tt.envVar, tt.name)
+			}
+			namespace := "it_" + uniqueSuffix()
+			tableName := namespace + ".events"
+			t.Cleanup(func() { cleanupManagedIcebergCatalog(t, ctx, destURI, namespace, tableName) })
+			exerciseIcebergDestination(t, ctx, destURI, tableName)
+		})
+	}
+}
+
+func TestIcebergHiveLocalWarehouseNormalizesFileURI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Hive Iceberg integration test in short mode")
+	}
+	ctx := context.Background()
+	env := setupIcebergHiveCatalog(t, ctx)
+	namespace := "it_" + uniqueSuffix()
+	tableName := namespace + ".events"
+	t.Cleanup(func() { cleanupManagedIcebergCatalog(t, ctx, env.destURI, namespace, tableName) })
+	initial := writeIcebergJSONL(t, "hive-file-uri.jsonl", `{"id":1,"name":"absolute"}`)
+	runIcebergPipeline(t, ctx, initial, env.destURI, tableName, ingestconfig.StrategyReplace)
+	require.Greater(t, countRegularFiles(t, env.localWarehouse), 0)
+	require.NoDirExists(t, "file:", "file:/ URIs must not create a relative workspace directory")
+}
+
+func cleanupManagedIcebergCatalog(t *testing.T, ctx context.Context, destURI, namespace, tableName string) {
+	t.Helper()
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+	defer cancel()
+
+	var cleanupErr error
+	dest := icebergdest.NewDestination()
+	if err := dest.Connect(cleanupCtx, destURI); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("connect for managed Iceberg cleanup: %w", err))
+	} else {
+		if err := dest.DropTable(cleanupCtx, tableName); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("purge managed Iceberg test table %s: %w", tableName, err))
+		}
+		if err := dest.DropNamespace(cleanupCtx, namespace); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("drop managed Iceberg test namespace %s: %w", namespace, err))
+		}
+		if err := dest.Close(cleanupCtx); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("close managed Iceberg cleanup destination: %w", err))
+		}
+	}
+	assert.NoError(t, cleanupErr)
+}
+
+func TestIcebergCloudObjectStores(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, ctx context.Context) string
+	}{
+		{name: "gcs json api", setup: setupIcebergGCSCatalog},
+		{name: "azure data lake shared key", setup: setupIcebergAzureCatalog},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destURI := tt.setup(t, ctx)
+			dest := icebergdest.NewDestination()
+			require.NoError(t, dest.Connect(ctx, destURI))
+			require.NoError(t, dest.CheckConnection(ctx))
+			require.NoError(t, dest.Close(ctx))
+
+			namespace := "it_" + uniqueSuffix()
+			exerciseIcebergDestination(t, ctx, destURI, namespace+".events")
+		})
+	}
+}
+
+func TestIcebergRESTMinioDurableTokensAndCDCResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	dest := icebergdest.NewDestination()
+	require.NoError(t, dest.Connect(ctx, env.destURI))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+
+	namespace := "it_" + uniqueSuffix()
+	target := namespace + ".cdc_target"
+	staging := namespace + ".cdc_staging"
+	tableSchema := icebergIntegrationCDCSchema()
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: target, Schema: tableSchema, PrimaryKeys: []string{"id"},
+	}))
+
+	appendOpts := destination.WriteOptions{
+		Table: target, Schema: tableSchema, PrimaryKeys: []string{"id"},
+		Parallelism: 3, CommitToken: "rest-minio-append-1", CDCResumeLSN: "0/10",
+	}
+	require.NoError(t, dest.WriteParallel(ctx, icebergCDCRecords(t, tableSchema, 1, "first", "0/10"), appendOpts))
+	require.NoError(t, dest.WriteParallel(ctx, icebergCDCRecords(t, tableSchema, 1, "first", "0/10"), appendOpts))
+	require.EqualValues(t, 1, loadIcebergTableSummary(t, ctx, env.destURI, target).rows)
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: staging, Schema: tableSchema}))
+	require.NoError(t, dest.WriteParallel(ctx, icebergCDCRecords(t, tableSchema, 2, "merged", "0/20"), destination.WriteOptions{
+		Table: staging, Schema: tableSchema, Parallelism: 2,
+	}))
+	mergeOpts := destination.MergeOptions{
+		StagingTable: staging,
+		TargetTable:  target,
+		PrimaryKeys:  []string{"id"},
+		Columns:      tableSchema.ColumnNames(),
+		CommitToken:  "rest-minio-merge-1",
+	}
+	require.NoError(t, dest.MergeTable(ctx, mergeOpts))
+	require.NoError(t, dest.MergeTable(ctx, mergeOpts))
+	require.EqualValues(t, 2, loadIcebergTableSummary(t, ctx, env.destURI, target).rows)
+
+	resume, err := dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, "0/20", resume)
+	require.NoError(t, dest.CommitWriteToken(ctx, target, "rest-minio-idle-1", "0/30"))
+	resume, err = dest.GetMaxCDCLSN(ctx, target)
+	require.NoError(t, err)
+	require.Equal(t, "0/30", resume)
+}
+
+func icebergIntegrationCDCSchema() *schema.TableSchema {
+	return &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+		{Name: destination.CDCLSNColumn, DataType: schema.TypeString, Nullable: true},
+		{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: true},
+		{Name: destination.CDCSyncedAtColumn, DataType: schema.TypeTimestampTZ, Nullable: true},
+	}, PrimaryKeys: []string{"id"}}
+}
+
+func icebergCDCRecords(t *testing.T, tableSchema *schema.TableSchema, id int64, name, lsn string) <-chan source.RecordBatchResult {
+	t.Helper()
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, tableSchema.ToArrowSchema())
+	builder.Field(0).(*array.Int64Builder).Append(id)
+	builder.Field(1).(*array.StringBuilder).Append(name)
+	builder.Field(2).(*array.StringBuilder).Append(lsn)
+	builder.Field(3).(*array.BooleanBuilder).Append(false)
+	builder.Field(4).(*array.TimestampBuilder).Append(arrow.Timestamp(time.Now().UTC().UnixMicro()))
+	batch := builder.NewRecordBatch()
+	builder.Release()
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: batch}
+	close(records)
+	return records
+}
+
+func setupIcebergGCSCatalog(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "fsouza/fake-gcs-server:1.52.3",
+		ExposedPorts: []string{"4443/tcp"},
+		Cmd:          []string{"-scheme", "http", "-port", "4443", "-backend", "memory"},
+		WaitingFor: wait.ForHTTP("/storage/v1/b?project=fake-project-id").
+			WithPort("4443/tcp").
+			WithStartupTimeout(60 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "4443")
+	require.NoError(t, err)
+	endpoint := fmt.Sprintf("http://%s:%s/storage/v1", host, port.Port())
+	bucket := "iceberg-" + uniqueSuffix()
+
+	body, err := json.Marshal(map[string]string{"name": bucket})
+	require.NoError(t, err)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/b?project=fake-project-id", bytes.NewReader(body))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, response.Body.Close()) }()
+	require.Contains(t, []int{http.StatusOK, http.StatusConflict}, response.StatusCode)
+
+	values := url.Values{}
+	values.Set("storage", "gcs")
+	values.Set("bucket", bucket)
+	values.Set("prefix", "warehouse")
+	values.Set("endpoint", endpoint+"/")
+	values.Set("use_ssl", "false")
+	values.Set("gcs_use_json_api", "true")
+	values.Set("table.write.format.default", "parquet")
+	return "iceberg+sqlite://" + filepath.Join(t.TempDir(), "catalog.db") + "?" + values.Encode()
+}
+
+func setupIcebergAzureCatalog(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "mcr.microsoft.com/azure-storage/azurite:3.35.0",
+		ExposedPorts: []string{"10000/tcp"},
+		Cmd:          []string{"azurite-blob", "--loose", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--skipApiVersionCheck"},
+		WaitingFor:   wait.ForListeningPort("10000/tcp").WithStartupTimeout(60 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "10000")
+	require.NoError(t, err)
+	endpoint := fmt.Sprintf("%s:%s", host, port.Port())
+	containerName := "warehouse"
+
+	credential, err := azblob.NewSharedKeyCredential(icebergAzuriteAccountName, icebergAzuriteAccountKey)
+	require.NoError(t, err)
+	client, err := azblob.NewClientWithSharedKeyCredential("http://"+endpoint+"/"+icebergAzuriteAccountName, credential, nil)
+	require.NoError(t, err)
+	_, err = client.CreateContainer(ctx, containerName, nil)
+	require.NoError(t, err)
+
+	values := url.Values{}
+	values.Set("storage", "azure")
+	values.Set("container", containerName)
+	values.Set("account_name", icebergAzuriteAccountName)
+	values.Set("account_key", icebergAzuriteAccountKey)
+	values.Set("prefix", "warehouse")
+	values.Set("endpoint", endpoint)
+	values.Set("use_ssl", "false")
+	values.Set("adls_scheme", "abfs")
+	values.Set("table.write.format.default", "parquet")
+	return "iceberg+sqlite://" + filepath.Join(t.TempDir(), "catalog.db") + "?" + values.Encode()
 }
 
 func setupIcebergSQLiteMinioCatalog(t *testing.T, ctx context.Context) icebergCatalogTestEnv {
@@ -167,6 +462,78 @@ func setupIcebergRESTMinioCatalog(t *testing.T, ctx context.Context) icebergCata
 		bucket:       bucket,
 		objectPrefix: "rest",
 	}
+}
+
+func setupIcebergNessieMinioCatalog(t *testing.T, ctx context.Context) icebergCatalogTestEnv {
+	t.Helper()
+
+	nw, err := tcnetwork.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nw.Remove(ctx) })
+
+	minioContainer, minioEndpoint := startIcebergMinioContainer(t, ctx, nw.Name)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(minioContainer) })
+	setIcebergMinioEnv(t, minioEndpoint)
+
+	client := createMinioClient(t, minioEndpoint)
+	bucket := "iceberg-" + uniqueSuffix()
+	createIcebergBucket(t, ctx, client, bucket)
+	nessieURI := startIcebergNessieContainer(t, ctx, nw.Name, minioEndpoint, bucket)
+
+	values := icebergMinioValues(minioEndpoint, bucket)
+	values.Del("table_path")
+	clearAmbientAWSCredentials(t)
+	return icebergCatalogTestEnv{
+		destURI:                nessieURI + "?" + values.Encode(),
+		client:                 client,
+		bucket:                 bucket,
+		objectPrefix:           "nessie",
+		tableLocationHasSuffix: true,
+	}
+}
+
+func clearAmbientAWSCredentials(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SECURITY_TOKEN",
+		"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_S3_ENDPOINT", "AWS_ENDPOINT_URL", "AWS_ENDPOINT_URL_S3",
+		"AWS_PROFILE", "AWS_DEFAULT_PROFILE", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN", "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+	} {
+		t.Setenv(key, "")
+	}
+	missingConfigDir := t.TempDir()
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(missingConfigDir, "missing-credentials"))
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(missingConfigDir, "missing-config"))
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+}
+
+func setupIcebergHiveCatalog(t *testing.T, ctx context.Context) icebergCatalogTestEnv {
+	t.Helper()
+
+	warehouse := dockerSharedTempDir(t, "hive")
+	hiveURI := startIcebergHiveMetastoreContainer(t, ctx, warehouse)
+	values := url.Values{}
+	values.Set("warehouse_path", warehouse)
+	values.Set("table.write.format.default", "parquet")
+	return icebergCatalogTestEnv{destURI: hiveURI + "?" + values.Encode(), localWarehouse: warehouse}
+}
+
+func countRegularFiles(t *testing.T, root string) int {
+	t.Helper()
+	count := 0
+	err := filepath.WalkDir(root, func(_ string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() {
+			count++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return count
 }
 
 func exerciseIcebergDestination(t *testing.T, ctx context.Context, destURI, tableName string) {
@@ -369,6 +736,7 @@ func startIcebergRESTContainer(t *testing.T, ctx context.Context, warehouse stri
 		ExposedPorts: []string{"8181/tcp"},
 		Env: map[string]string{
 			"CATALOG_WAREHOUSE": warehouse,
+			"CATALOG_URI":       "jdbc:sqlite:/tmp/iceberg-rest.db",
 		},
 		HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
 			hostConfig.Mounts = append(hostConfig.Mounts, dockermount.Mount{
@@ -415,6 +783,7 @@ func startIcebergRESTContainerWithS3(t *testing.T, ctx context.Context, networkN
 			"CATALOG_S3_ACCESS__KEY__ID":        minioAccessKey,
 			"CATALOG_S3_SECRET__ACCESS__KEY":    minioSecretKey,
 			"CATALOG_CLIENT_REGION":             "us-east-1",
+			"CATALOG_URI":                       "jdbc:sqlite:/tmp/iceberg-rest.db",
 			"CATALOG_S3_PRELOAD_CLIENT_ENABLED": "false",
 		},
 		Networks: []string{networkName},
@@ -440,6 +809,90 @@ func startIcebergRESTContainerWithS3(t *testing.T, ctx context.Context, networkN
 	require.NoError(t, err)
 
 	return fmt.Sprintf("iceberg+rest://%s:%s", host, port.Port())
+}
+
+func startIcebergNessieContainer(t *testing.T, ctx context.Context, networkName, externalMinioEndpoint, bucket string) string {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "ghcr.io/projectnessie/nessie:0.107.2",
+		ExposedPorts: []string{"19120/tcp", "9000/tcp"},
+		Env: map[string]string{
+			"nessie.version.store.type":                                   "IN_MEMORY",
+			"nessie.server.authentication.enabled":                        "false",
+			"nessie.catalog.default-warehouse":                            "warehouse",
+			"nessie.catalog.warehouses.warehouse.location":                "s3://" + bucket + "/nessie/",
+			"nessie.catalog.service.s3.default-options.region":            "us-east-1",
+			"nessie.catalog.service.s3.default-options.path-style-access": "true",
+			"nessie.catalog.service.s3.default-options.endpoint":          "http://minio:9000/",
+			"nessie.catalog.service.s3.default-options.external-endpoint": externalMinioEndpoint + "/",
+			"nessie.catalog.service.s3.default-options.access-key":        "urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key",
+			"nessie.catalog.secrets.access-key.name":                      minioAccessKey,
+			"nessie.catalog.secrets.access-key.secret":                    minioSecretKey,
+		},
+		Networks: []string{networkName},
+		NetworkAliases: map[string][]string{
+			networkName: {"nessie"},
+		},
+		WaitingFor: wait.ForHTTP("/q/health/ready").
+			WithPort("9000/tcp").
+			WithStartupTimeout(120 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "19120")
+	require.NoError(t, err)
+	return fmt.Sprintf("iceberg+nessie://%s:%s", host, port.Port())
+}
+
+func startIcebergHiveMetastoreContainer(t *testing.T, ctx context.Context, warehouse string) string {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "apache/hive:4.0.0",
+		User:         "root",
+		ExposedPorts: []string{"9083/tcp"},
+		Env: map[string]string{
+			"SERVICE_NAME": "metastore",
+			"DB_DRIVER":    "derby",
+		},
+		HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
+			hostConfig.Mounts = append(hostConfig.Mounts, dockermount.Mount{
+				Type: dockermount.TypeBind, Source: warehouse, Target: warehouse,
+			})
+		},
+		WaitingFor: wait.ForListeningPort("9083/tcp").
+			WithStartupTimeout(180 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "9083")
+	require.NoError(t, err)
+	hiveURI := fmt.Sprintf("iceberg+hive://%s:%s", host, port.Port())
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		probe := icebergdest.NewDestination()
+		if !assert.NoError(collect, probe.Connect(ctx, hiveURI+"?warehouse_path="+url.QueryEscape(warehouse))) {
+			return
+		}
+		defer func() { _ = probe.Close(ctx) }()
+		_, probeErr := probe.GetTableSchema(ctx, "default.__ingestr_readiness_probe")
+		assert.NoError(collect, probeErr)
+	}, 90*time.Second, 500*time.Millisecond, "Hive metastore did not become query-ready")
+	return hiveURI
 }
 
 func startIcebergMinioContainer(t *testing.T, ctx context.Context, networkName string) (testcontainers.Container, string) {
@@ -544,21 +997,110 @@ func parseIcebergTestURI(rawURI string) (iceberggo.Properties, error) {
 	case "iceberg+rest":
 		props["type"] = "rest"
 		props["uri"] = "http://" + parsed.Host
+	case "iceberg+nessie":
+		props["type"] = "rest"
+		path := strings.TrimRight(parsed.EscapedPath(), "/")
+		if path == "" {
+			path = "/iceberg"
+		}
+		branch := strings.Trim(firstIcebergTestQueryValue(query, "nessie_branch", "nessie-branch", "branch", "ref"), "/")
+		warehouse := firstIcebergTestQueryValue(query, "nessie_warehouse", "nessie-warehouse")
+		if branch != "" || warehouse != "" {
+			path += "/" + url.PathEscape(branch)
+			if warehouse != "" {
+				path += "%7C" + url.PathEscape(warehouse)
+			}
+		}
+		props["uri"] = "http://" + parsed.Host + path
+	case "iceberg+polaris":
+		props["type"] = "rest"
+		path := strings.TrimRight(parsed.EscapedPath(), "/")
+		if path == "" {
+			path = "/api/catalog"
+		}
+		protocol := "https"
+		if firstIcebergTestQueryValue(query, "polaris_use_ssl", "polaris-use-ssl", "catalog_use_ssl", "catalog-use-ssl") == "false" {
+			protocol = "http"
+		}
+		props["uri"] = protocol + "://" + parsed.Host + path
+		props["warehouse"] = query.Get("warehouse")
+	case "iceberg+s3tables":
+		props["type"] = "rest"
+		region := firstIcebergTestQueryValue(query, "region", "region_name", "rest.signing-region")
+		endpoint := "https://s3tables." + region + ".amazonaws.com/iceberg"
+		if parsed.Host != "" {
+			path := strings.TrimRight(parsed.EscapedPath(), "/")
+			if path == "" {
+				path = "/iceberg"
+			}
+			protocol := "https"
+			if firstIcebergTestQueryValue(query, "s3tables_use_ssl", "s3tables-use-ssl", "catalog_use_ssl", "catalog-use-ssl") == "false" {
+				protocol = "http"
+			}
+			endpoint = protocol + "://" + parsed.Host + path
+		}
+		props["uri"] = endpoint
+		props["warehouse"] = query.Get("warehouse")
+		props["rest.sigv4-enabled"] = "true"
+		props["rest.signing-name"] = "s3tables"
+		props["rest.signing-region"] = region
+	case "iceberg+hive":
+		props["type"] = "hive"
+		props["uri"] = "thrift://" + parsed.Host
 	default:
 		props["type"] = strings.TrimPrefix(parsed.Scheme, "iceberg+")
 	}
 
-	if bucket := query.Get("bucket"); bucket != "" {
-		warehouse := "s3://" + bucket + "/"
-		if prefix := query.Get("prefix"); prefix != "" {
-			warehouse = "s3://" + bucket + "/" + strings.Trim(prefix, "/") + "/"
+	storage := strings.ToLower(query.Get("storage"))
+	bucket := query.Get("bucket")
+	prefix := strings.Trim(query.Get("prefix"), "/")
+	switch storage {
+	case "gcs":
+		if bucket != "" {
+			props["warehouse"] = joinIcebergCloudWarehouse("gs://"+bucket, prefix)
 		}
-		props["warehouse"] = warehouse
+		if endpoint := query.Get("endpoint"); endpoint != "" {
+			if !strings.Contains(endpoint, "://") {
+				endpoint = "http://" + endpoint
+			}
+			props["gcs.endpoint"] = endpoint
+		}
+		if query.Has("gcs_use_json_api") {
+			props["gcs.usejsonapi"] = query.Get("gcs_use_json_api")
+		}
+	case "azure", "adls":
+		containerName := firstIcebergTestQueryValue(query, "container", "bucket")
+		accountName := query.Get("account_name")
+		scheme := query.Get("adls_scheme")
+		if scheme == "" {
+			scheme = "abfss"
+		}
+		if containerName != "" && accountName != "" {
+			props["warehouse"] = joinIcebergCloudWarehouse(fmt.Sprintf("%s://%s@%s.dfs.core.windows.net", scheme, containerName, accountName), prefix)
+		}
+		if accountName != "" {
+			props["adls.auth.shared-key.account.name"] = accountName
+		}
+		if accountKey := query.Get("account_key"); accountKey != "" {
+			props["adls.auth.shared-key.account.key"] = accountKey
+		}
+		if endpoint := query.Get("endpoint"); endpoint != "" {
+			props["adls.endpoint"] = strings.TrimPrefix(strings.TrimPrefix(endpoint, "http://"), "https://")
+		}
+		protocol := "https"
+		if query.Get("use_ssl") == "false" {
+			protocol = "http"
+		}
+		props["adls.protocol"] = protocol
+	default:
+		if bucket != "" && parsed.Scheme != "iceberg+nessie" && parsed.Scheme != "iceberg+polaris" && parsed.Scheme != "iceberg+s3tables" {
+			props["warehouse"] = joinIcebergCloudWarehouse("s3://"+bucket, prefix)
+		}
 	}
 	if warehouse := firstIcebergTestQueryValue(query, "warehouse", "warehouse_path", "warehouse-path"); warehouse != "" {
 		props["warehouse"] = warehouse
 	}
-	if endpoint := query.Get("endpoint"); endpoint != "" {
+	if endpoint := query.Get("endpoint"); endpoint != "" && storage != "gcs" && storage != "azure" && storage != "adls" {
 		if !strings.Contains(endpoint, "://") {
 			endpoint = "http://" + endpoint
 		}
@@ -573,11 +1115,35 @@ func parseIcebergTestURI(rawURI string) (iceberggo.Properties, error) {
 	if secretKey := query.Get("secret_access_key"); secretKey != "" {
 		props["s3.secret-access-key"] = secretKey
 	}
+	if token := firstIcebergTestQueryValue(query, "oauth_token", "oauth-token"); token != "" {
+		props["token"] = token
+	}
+	clientID := firstIcebergTestQueryValue(query, "oauth_client_id", "oauth-client-id")
+	clientSecret := firstIcebergTestQueryValue(query, "oauth_client_secret", "oauth-client-secret")
+	if clientID != "" && clientSecret != "" {
+		props["credential"] = clientID + ":" + clientSecret
+	}
+	if realm := firstIcebergTestQueryValue(query, "polaris_realm", "polaris-realm"); realm != "" {
+		props["header.Polaris-Realm"] = realm
+	}
+	if region := firstIcebergTestQueryValue(query, "region", "region_name"); region != "" {
+		props["glue.region"] = region
+	}
+	if accessKey := query.Get("access_key_id"); accessKey != "" {
+		props["glue.access-key-id"] = accessKey
+	}
+	if secretKey := query.Get("secret_access_key"); secretKey != "" {
+		props["glue.secret-access-key"] = secretKey
+	}
+	if sessionToken := query.Get("session_token"); sessionToken != "" {
+		props["glue.session-token"] = sessionToken
+		props["s3.session-token"] = sessionToken
+	}
 	for key, values := range parsed.Query() {
 		if strings.HasPrefix(key, "table.") || key == "table_location" {
 			continue
 		}
-		if key == "storage" || key == "bucket" || key == "prefix" || key == "endpoint" || key == "use_ssl" || key == "region" || key == "access_key_id" || key == "secret_access_key" || key == "table_path" || key == "warehouse_path" || key == "warehouse-path" || key == "uri" {
+		if key == "storage" || key == "bucket" || key == "container" || key == "prefix" || key == "endpoint" || key == "use_ssl" || key == "region" || key == "access_key_id" || key == "secret_access_key" || key == "table_path" || key == "warehouse_path" || key == "warehouse-path" || key == "uri" || key == "account_name" || key == "account_key" || key == "adls_scheme" || key == "gcs_use_json_api" {
 			continue
 		}
 		if len(values) > 0 {
@@ -585,6 +1151,14 @@ func parseIcebergTestURI(rawURI string) (iceberggo.Properties, error) {
 		}
 	}
 	return props, nil
+}
+
+func joinIcebergCloudWarehouse(base, prefix string) string {
+	base = strings.TrimRight(base, "/")
+	if prefix != "" {
+		base += "/" + strings.Trim(prefix, "/")
+	}
+	return base + "/"
 }
 
 func icebergTestCatalogName(rawURI string) string {

--- a/tests/integration/iceberg_nested_types_test.go
+++ b/tests/integration/iceberg_nested_types_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	"github.com/bruin-data/ingestr/internal/uri"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIcebergNestedTypesRESTMinIO(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	table := "it_" + uniqueSuffix() + ".nested_values"
+	tableSchema := integrationNestedSchema()
+
+	dest, err := uri.DefaultRegistry.GetDestination(env.destURI)
+	require.NoError(t, err)
+	require.NoError(t, dest.Connect(ctx, env.destURI))
+	t.Cleanup(func() { require.NoError(t, dest.Close(context.Background())) })
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{Table: table, Schema: tableSchema, DropFirst: true}))
+
+	record := integrationNestedRecord(t, tableSchema.ToArrowSchema())
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: record}
+	close(records)
+	require.NoError(t, dest.WriteParallel(ctx, records, destination.WriteOptions{Table: table, Schema: tableSchema}))
+
+	props, err := parseIcebergTestURI(env.destURI)
+	require.NoError(t, err)
+	cat, err := icebergcatalog.Load(ctx, icebergTestCatalogName(env.destURI), props)
+	require.NoError(t, err)
+	tbl, err := cat.LoadTable(ctx, icebergcatalog.ToIdentifier(strings.Split(table, ".")...))
+	require.NoError(t, err)
+	arrowTable, err := tbl.Scan().ToArrowTable(ctx)
+	require.NoError(t, err)
+	defer arrowTable.Release()
+	require.EqualValues(t, 1, arrowTable.NumRows())
+	require.IsType(t, &array.FixedSizeBinary{}, arrowTable.Column(1).Data().Chunk(0))
+	require.IsType(t, &array.List{}, arrowTable.Column(2).Data().Chunk(0))
+	require.IsType(t, &array.List{}, arrowTable.Column(3).Data().Chunk(0))
+	require.IsType(t, &array.Struct{}, arrowTable.Column(4).Data().Chunk(0))
+	require.IsType(t, &array.Map{}, arrowTable.Column(5).Data().Chunk(0))
+
+	digest := arrowTable.Column(1).Data().Chunk(0).(*array.FixedSizeBinary)
+	require.Equal(t, []byte{1, 2, 3, 4}, digest.Value(0))
+	items := arrowTable.Column(2).Data().Chunk(0).(*array.List)
+	require.False(t, items.DataType().(*arrow.ListType).ElemField().Nullable)
+	profile := arrowTable.Column(4).Data().Chunk(0).(*array.Struct)
+	require.Equal(t, int32(7), profile.Field(0).(*array.Int32).Value(0))
+	attributes := arrowTable.Column(5).Data().Chunk(0).(*array.Map)
+	require.Equal(t, "one", attributes.Keys().(*array.String).Value(0))
+	require.Equal(t, "first", attributes.Items().(*array.String).Value(0))
+}
+
+func integrationNestedSchema() *schema.TableSchema {
+	stringElement := &schema.Column{Name: "element", DataType: schema.TypeString, Nullable: true}
+	return &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "digest", DataType: schema.TypeFixedBinary, FixedLength: 4, Nullable: false},
+		{
+			Name: "required_items", DataType: schema.TypeArray, ArrayType: schema.TypeInt64, Nullable: true,
+			Element: &schema.Column{Name: "element", DataType: schema.TypeInt64, Nullable: false},
+		},
+		{
+			Name: "nested_items", DataType: schema.TypeArray, ArrayType: schema.TypeArray, Nullable: true,
+			Element: &schema.Column{Name: "element", DataType: schema.TypeArray, ArrayType: schema.TypeString, Nullable: true, Element: stringElement},
+		},
+		{
+			Name: "profile", DataType: schema.TypeStruct, Nullable: true,
+			StructFields: &schema.TableSchema{Columns: []schema.Column{
+				{Name: "code", DataType: schema.TypeInt32, Nullable: false},
+				{Name: "labels", DataType: schema.TypeArray, ArrayType: schema.TypeString, Nullable: true, Element: stringElement},
+			}},
+		},
+		{
+			Name: "attributes", DataType: schema.TypeMap, Nullable: true,
+			MapKey:   &schema.Column{Name: "key", DataType: schema.TypeString, Nullable: false},
+			MapValue: &schema.Column{Name: "value", DataType: schema.TypeString, Nullable: true},
+		},
+	}}
+}
+
+func integrationNestedRecord(t *testing.T, arrowSchema *arrow.Schema) arrow.RecordBatch {
+	t.Helper()
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	t.Cleanup(builder.Release)
+	builder.Field(0).(*array.Int64Builder).Append(1)
+	builder.Field(1).(*array.FixedSizeBinaryBuilder).Append([]byte{1, 2, 3, 4})
+
+	required := builder.Field(2).(*array.ListBuilder)
+	required.Append(true)
+	requiredValues := required.ValueBuilder().(*array.Int64Builder)
+	requiredValues.Append(10)
+	requiredValues.Append(20)
+
+	outer := builder.Field(3).(*array.ListBuilder)
+	outer.Append(true)
+	inner := outer.ValueBuilder().(*array.ListBuilder)
+	inner.Append(true)
+	innerValues := inner.ValueBuilder().(*array.StringBuilder)
+	innerValues.Append("a")
+	innerValues.Append("b")
+	inner.AppendNull()
+	inner.Append(true)
+	innerValues.Append("c")
+
+	profile := builder.Field(4).(*array.StructBuilder)
+	profile.Append(true)
+	profile.FieldBuilder(0).(*array.Int32Builder).Append(7)
+	labels := profile.FieldBuilder(1).(*array.ListBuilder)
+	labels.Append(true)
+	labelValues := labels.ValueBuilder().(*array.StringBuilder)
+	labelValues.Append("blue")
+	labelValues.AppendNull()
+
+	attributes := builder.Field(5).(*array.MapBuilder)
+	attributes.Append(true)
+	keys := attributes.KeyBuilder().(*array.StringBuilder)
+	values := attributes.ItemBuilder().(*array.StringBuilder)
+	keys.Append("one")
+	values.Append("first")
+	keys.Append("two")
+	values.AppendNull()
+	return builder.NewRecordBatch()
+}

--- a/tests/integration/iceberg_strategies_test.go
+++ b/tests/integration/iceberg_strategies_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	icebergcatalog "github.com/apache/iceberg-go/catalog"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	icebergdest "github.com/bruin-data/ingestr/pkg/destination/iceberg"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -246,6 +249,57 @@ func TestIcebergConformance_TruncateInsert(t *testing.T) {
 	rows := readIcebergRows(t, ctx, destURI, destTable)
 	assert.Len(t, rows, replaceFixtureRows, "old rows must be gone, not appended")
 	assert.Equal(t, "juliet", icebergNameByID(t, rows, 10))
+}
+
+func TestIcebergTruncateInsertPipelineSoftensRemovedRequiredColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	destURI := icebergConformanceDestURI(t)
+	destTable := icebergConformanceTable()
+	dest := icebergdest.NewDestination()
+	require.NoError(t, dest.Connect(ctx, destURI))
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: destTable,
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+			{Name: "legacy", DataType: schema.TypeString, Nullable: false},
+		}},
+	}))
+	require.NoError(t, dest.Close(ctx))
+
+	cfg := &config.IngestConfig{
+		SourceURI:           jsonlURI(t, "testdata/conformance_append_initial.jsonl"),
+		SourceTable:         "truncate_soft_remove",
+		DestURI:             destURI,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyTruncateInsert,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	rows := readIcebergRows(t, ctx, destURI, destTable)
+	require.NotEmpty(t, rows)
+	for _, row := range rows {
+		require.Contains(t, row, "legacy")
+		require.Nil(t, row["legacy"])
+	}
+	verify := icebergdest.NewDestination()
+	require.NoError(t, verify.Connect(ctx, destURI))
+	loaded, err := verify.GetTableSchema(ctx, destTable)
+	require.NoError(t, err)
+	require.NoError(t, verify.Close(ctx))
+	var legacyColumn *schema.Column
+	for i := range loaded.Columns {
+		if loaded.Columns[i].Name == "legacy" {
+			legacyColumn = &loaded.Columns[i]
+			break
+		}
+	}
+	require.NotNil(t, legacyColumn)
+	require.True(t, legacyColumn.Nullable)
 }
 
 func TestIcebergConformance_TruncateInsert_Dedup(t *testing.T) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
 	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // Register ADBC driver
+	_ "github.com/bruin-data/ingestr/pkg/source/jsonl"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"

--- a/tests/integration/postgres_cdc_iceberg_test.go
+++ b/tests/integration/postgres_cdc_iceberg_test.go
@@ -1,0 +1,619 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	internalregistry "github.com/bruin-data/ingestr/internal/registry"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	icebergdest "github.com/bruin-data/ingestr/pkg/destination/iceberg"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresCDCToIcebergRESTMinioStreamingSnapshotCrashRecovery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = sourceContainer.Terminate(ctx) })
+	setupCDCSource(t, ctx, sourceConnString)
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	t.Cleanup(sourcePool.Close)
+	_, err = sourcePool.Exec(ctx, `
+		INSERT INTO public.test_cdc (name, value)
+		SELECT 'snapshot-' || g, g FROM generate_series(4, 300) g
+	`)
+	require.NoError(t, err)
+	var removedBeforeRecoveryID int64
+	require.NoError(t, sourcePool.QueryRow(ctx, "SELECT min(id) FROM public.test_cdc").Scan(&removedBeforeRecoveryID))
+
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	target := "it_" + uniqueSuffix() + ".postgres_cdc_streaming_recovery"
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&publication=test_pub"
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = cdcSourceURI
+	cfg.SourceTable = "public.test_cdc"
+	cfg.DestURI = env.destURI
+	cfg.DestTable = target
+	cfg.PrimaryKeys = []string{"id"}
+	cfg.PageSize = 1
+	cfg.Stream = true
+	cfg.FlushInterval = time.Hour
+	cfg.FlushRecords = 1
+	cfg.Progress = config.ProgressLog
+	cfg.IncrementalStrategy = config.StrategyMerge
+	cfg.IncrementalStrategyExplicit = true
+
+	firstCtx, cancelFirst := context.WithCancel(ctx)
+	firstRun := make(chan error, 1)
+	go func() { firstRun <- pipeline.New(cfg).Run(firstCtx) }()
+
+	require.Eventually(t, func() bool {
+		var slots int
+		err := sourcePool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_replication_slots
+			WHERE slot_name LIKE 'ingestr_%'
+		`).Scan(&slots)
+		return err == nil && slots > 0
+	}, 30*time.Second, 50*time.Millisecond, "streaming snapshot should create its durable replication slot")
+	time.Sleep(time.Second)
+	cancelFirst()
+	waitForCanceledPipeline(t, firstRun)
+
+	partialRows := readIcebergRows(t, ctx, env.destURI, target)
+	require.Empty(t, partialRows, "an interrupted snapshot must not become visible")
+	connectorID, partialState := managedIcebergCDCStateForTarget(t, ctx, env.destURI, target)
+	require.False(t, hasCompleteManagedIcebergState(partialState, "snapshot", target),
+		"a partial snapshot must not publish resumable destination state")
+
+	var replacementID int64
+	_, err = sourcePool.Exec(ctx, "DELETE FROM public.test_cdc WHERE id = $1", removedBeforeRecoveryID)
+	require.NoError(t, err)
+	err = sourcePool.QueryRow(
+		ctx,
+		"INSERT INTO public.test_cdc (name, value) VALUES ('after-crash', 9999) RETURNING id",
+	).Scan(&replacementID)
+	require.NoError(t, err)
+
+	restartCfg := *cfg
+	restartCfg.PageSize = 25
+	restartCfg.FlushRecords = 25
+	restartCfg.CDCResumeLSN = ""
+	secondCtx, cancelSecond := context.WithCancel(ctx)
+	secondRun := make(chan error, 1)
+	go func() { secondRun <- pipeline.New(&restartCfg).Run(secondCtx) }()
+
+	stateDest := icebergdest.NewDestination()
+	require.NoError(t, stateDest.Connect(ctx, env.destURI))
+	t.Cleanup(func() { _ = stateDest.Close(ctx) })
+	require.Eventually(t, func() bool {
+		entries, stateErr := stateDest.LoadCDCState(ctx, managedIcebergCDCStateTable, connectorID)
+		return stateErr == nil && hasCompleteManagedIcebergState(entries, "snapshot", target)
+	}, 120*time.Second, 250*time.Millisecond,
+		"the restarted stream should reset the partial attempt and complete one fresh managed snapshot")
+	cancelSecond()
+	waitForCanceledPipeline(t, secondRun)
+
+	rows := readIcebergRows(t, ctx, env.destURI, target)
+	require.Len(t, rows, 300)
+	byID := icebergRowsByID(rows)
+	require.Empty(t, byID[removedBeforeRecoveryID], "a row deleted before the recovery snapshot must not survive from the interrupted attempt")
+	require.Len(t, byID[replacementID], 1)
+	for id, group := range byID {
+		require.Lenf(t, group, 1, "id=%d must occur exactly once after recovery", id)
+		require.Equal(t, false, group[0][destination.CDCDeletedColumn])
+	}
+}
+
+func waitForCanceledPipeline(t *testing.T, run <-chan error) {
+	t.Helper()
+	select {
+	case err := <-run:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("streaming pipeline did not exit within 30 seconds of cancellation")
+	}
+}
+
+func TestPostgresCDCToIcebergRESTMinioResumesDurably(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = sourceContainer.Terminate(ctx) })
+	setupCDCSource(t, ctx, sourceConnString)
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	t.Cleanup(sourcePool.Close)
+
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	target := "it_" + uniqueSuffix() + ".postgres_cdc_resume"
+	cdcSourceURI := "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+		"&publication=test_pub&mode=batch"
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = cdcSourceURI
+	cfg.SourceTable = "public.test_cdc"
+	cfg.DestURI = env.destURI
+	cfg.DestTable = target
+	cfg.PrimaryKeys = []string{"id"}
+	cfg.PageSize = 1
+	cfg.IncrementalStrategy = config.StrategyMerge
+	cfg.IncrementalStrategyExplicit = true
+
+	// The first process snapshots the source and records its resume authority in
+	// the shared destination-managed state table.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	initialRows := readIcebergRows(t, ctx, env.destURI, target)
+	require.Len(t, initialRows, 3)
+	initialByID := icebergRowsByID(initialRows)
+	for id := int64(1); id <= 3; id++ {
+		require.Lenf(t, initialByID[id], 1, "snapshot row id=%d", id)
+		require.Equal(t, false, initialByID[id][0][destination.CDCDeletedColumn])
+	}
+	connectorID, firstState := managedIcebergCDCStateForTarget(t, ctx, env.destURI, target)
+	firstCheckpoint := latestCompleteManagedIcebergCheckpoint(t, firstState)
+	require.NotEmpty(t, firstCheckpoint)
+	firstIncarnation := managedIcebergTargetIncarnation(t, ctx, env.destURI, target)
+	firstConfirmed, _ := cdcReplicationSlotState(t, ctx, sourcePool)
+	require.NotEmpty(t, firstConfirmed)
+
+	// These transactions land while no pipeline exists. id=4 changes twice so
+	// the resumed batch must collapse multiple WAL versions without duplicating
+	// the key; id=2 exercises a durable tombstone.
+	_, err = sourcePool.Exec(ctx, `
+		BEGIN;
+		UPDATE public.test_cdc SET name = 'item1-updated', value = 111 WHERE id = 1;
+		DELETE FROM public.test_cdc WHERE id = 2;
+		INSERT INTO public.test_cdc (name, value) VALUES ('item4', 400);
+		COMMIT;
+		UPDATE public.test_cdc SET name = 'item4-updated', value = 444 WHERE name = 'item4';
+	`)
+	require.NoError(t, err)
+
+	// A new Pipeline is the restart boundary. It must discover the checkpoint
+	// from managed state and consume only the WAL gap after the snapshot.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	secondState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	secondCheckpoint := latestCompleteManagedIcebergCheckpoint(t, secondState)
+	require.Truef(t, lsnGreater(t, ctx, sourcePool, secondCheckpoint, firstCheckpoint),
+		"managed checkpoint must advance after resume (%s -> %s)", firstCheckpoint, secondCheckpoint)
+	secondConfirmed, _ := cdcReplicationSlotState(t, ctx, sourcePool)
+	require.Truef(t, lsnGreater(t, ctx, sourcePool, secondConfirmed, firstConfirmed),
+		"PostgreSQL confirmed_flush_lsn must advance after the resumed data is durable (%s -> %s)", firstConfirmed, secondConfirmed)
+
+	assertPostgresCDCToIcebergState(t, readIcebergRows(t, ctx, env.destURI, target))
+
+	// A second clean restart with no source changes must not replay rows or move
+	// the durable checkpoint backwards.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	thirdState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	thirdCheckpoint := latestCompleteManagedIcebergCheckpoint(t, thirdState)
+	require.GreaterOrEqual(t, destination.CompareCDCPositions(thirdCheckpoint, secondCheckpoint), 0)
+	assertPostgresCDCToIcebergState(t, readIcebergRows(t, ctx, env.destURI, target))
+	require.Equal(t, firstIncarnation, managedIcebergTargetIncarnation(t, ctx, env.destURI, target))
+
+	// WAL TRUNCATE is a destination mutation and a state transition. The target
+	// is cleared in place, the following row is applied once, and only then may
+	// the managed checkpoint advance.
+	_, err = sourcePool.Exec(ctx, `
+		BEGIN;
+		TRUNCATE TABLE public.test_cdc;
+		INSERT INTO public.test_cdc (name, value) VALUES ('after-truncate', 900);
+		COMMIT;
+	`)
+	require.NoError(t, err)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	truncateRows := readIcebergRows(t, ctx, env.destURI, target)
+	require.Len(t, truncateRows, 1)
+	require.Equal(t, "after-truncate", truncateRows[0]["name"])
+	require.Equal(t, false, truncateRows[0][destination.CDCDeletedColumn])
+	truncateState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	truncateCheckpoint := latestCompleteManagedIcebergCheckpoint(t, truncateState)
+	require.Truef(t, lsnGreater(t, ctx, sourcePool, truncateCheckpoint, thirdCheckpoint),
+		"managed checkpoint must advance after WAL TRUNCATE (%s -> %s)", thirdCheckpoint, truncateCheckpoint)
+	require.True(t, hasCompleteManagedIcebergState(truncateState, "snapshot", target))
+	require.True(t, hasCompleteManagedIcebergState(truncateState, "destination", target))
+	require.Equal(t, firstIncarnation, managedIcebergTargetIncarnation(t, ctx, env.destURI, target),
+		"WAL TRUNCATE must preserve the physical Iceberg table incarnation")
+}
+
+func TestPostgresCDCMultiTableToIcebergRESTMinioSnapshotsAndWALTruncate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := t.Context()
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = sourceContainer.Terminate(ctx) })
+	setupCDCSource(t, ctx, sourceConnString)
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	t.Cleanup(sourcePool.Close)
+	_, err = sourcePool.Exec(ctx, `
+		CREATE TABLE public.test_cdc_aux (
+			id BIGSERIAL PRIMARY KEY,
+			name TEXT NOT NULL
+		);
+		INSERT INTO public.test_cdc_aux (name) VALUES ('aux-1'), ('aux-2');
+		ALTER PUBLICATION test_pub ADD TABLE public.test_cdc_aux;
+	`)
+	require.NoError(t, err)
+
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	namespace := "it_" + uniqueSuffix()
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+		"&publication=test_pub&mode=batch&dest_schema=" + namespace
+	cfg.SourceTable = ""
+	cfg.DestURI = env.destURI
+	cfg.DestTable = namespace + ".anchor"
+	cfg.NoLoadTimestamp = true
+	cfg.IncrementalStrategy = config.StrategyMerge
+	cfg.IncrementalStrategyExplicit = true
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	firstTarget := namespace + ".public_test_cdc"
+	secondTarget := namespace + ".public_test_cdc_aux"
+	require.Len(t, readIcebergRows(t, ctx, env.destURI, firstTarget), 3)
+	require.Len(t, readIcebergRows(t, ctx, env.destURI, secondTarget), 2)
+
+	_, err = sourcePool.Exec(ctx, `
+		BEGIN;
+		TRUNCATE TABLE public.test_cdc;
+		INSERT INTO public.test_cdc (name, value) VALUES ('after-multi-truncate', 901);
+		INSERT INTO public.test_cdc_aux (name) VALUES ('aux-3');
+		COMMIT;
+	`)
+	require.NoError(t, err)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	firstRows := readIcebergRows(t, ctx, env.destURI, firstTarget)
+	require.Len(t, firstRows, 1)
+	require.Equal(t, "after-multi-truncate", firstRows[0]["name"])
+	secondRows := readIcebergRows(t, ctx, env.destURI, secondTarget)
+	require.Len(t, secondRows, 3)
+}
+
+func TestPostgresCDCKeylessToIcebergRESTMinioIsIdempotentByTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = sourceContainer.Terminate(ctx) })
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	t.Cleanup(sourcePool.Close)
+	_, err = sourcePool.Exec(ctx, `
+		CREATE TABLE public.keyless_events (event_id BIGINT, payload TEXT);
+		ALTER TABLE public.keyless_events REPLICA IDENTITY FULL;
+		INSERT INTO public.keyless_events VALUES (1, 'one'), (2, 'two');
+		CREATE PUBLICATION keyless_pub FOR TABLE public.keyless_events;
+		ALTER USER testuser REPLICATION;
+	`)
+	require.NoError(t, err)
+
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	namespace := "it_" + uniqueSuffix()
+	target := namespace + ".public_keyless_events"
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+		"&publication=keyless_pub&mode=batch&dest_schema=" + namespace
+	cfg.DestURI = env.destURI
+	cfg.PageSize = 1
+	cfg.IncrementalStrategy = config.StrategyMerge
+	cfg.IncrementalStrategyExplicit = true
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	require.Len(t, readIcebergRows(t, ctx, env.destURI, target), 2)
+	connectorID, initialState := managedIcebergCDCStateForTarget(t, ctx, env.destURI, target)
+	initialCheckpoint := latestCompleteManagedIcebergCheckpoint(t, initialState)
+	initialIncarnation := managedIcebergTargetIncarnation(t, ctx, env.destURI, target)
+
+	_, err = sourcePool.Exec(ctx, `INSERT INTO public.keyless_events VALUES (3, 'three')`)
+	require.NoError(t, err)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	require.Len(t, readIcebergRows(t, ctx, env.destURI, target), 3)
+	insertState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	insertCheckpoint := latestCompleteManagedIcebergCheckpoint(t, insertState)
+	require.True(t, lsnGreater(t, ctx, sourcePool, insertCheckpoint, initialCheckpoint))
+
+	// UPDATE on a REPLICA IDENTITY FULL table is a retract pair: one deleted old
+	// image plus one live new image, committed under the transaction's stable LSN.
+	_, err = sourcePool.Exec(ctx, `UPDATE public.keyless_events SET payload = 'three-updated' WHERE event_id = 3`)
+	require.NoError(t, err)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	rows := readIcebergRows(t, ctx, env.destURI, target)
+	require.Len(t, rows, 5)
+
+	var oldDeletes, updatedInserts int
+	for _, row := range rows {
+		if row["event_id"] != int64(3) {
+			continue
+		}
+		if row["payload"] == "three" && row[destination.CDCDeletedColumn] == true {
+			oldDeletes++
+		}
+		if row["payload"] == "three-updated" && row[destination.CDCDeletedColumn] == false {
+			updatedInserts++
+		}
+	}
+	require.Equal(t, 1, oldDeletes)
+	require.Equal(t, 1, updatedInserts)
+	updateState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	updateCheckpoint := latestCompleteManagedIcebergCheckpoint(t, updateState)
+	require.True(t, lsnGreater(t, ctx, sourcePool, updateCheckpoint, insertCheckpoint))
+
+	// A clean finite rerun must not append the strict-resume boundary transaction
+	// again. Managed state is the resume authority; the target commit token makes
+	// a strict-boundary replay idempotent.
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	require.Len(t, readIcebergRows(t, ctx, env.destURI, target), 5)
+	restartState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	require.GreaterOrEqual(t,
+		destination.CompareCDCPositions(latestCompleteManagedIcebergCheckpoint(t, restartState), updateCheckpoint), 0)
+	require.True(t, hasCompleteManagedIcebergState(restartState, "snapshot", target))
+	require.True(t, hasCompleteManagedIcebergState(restartState, "destination", target))
+	require.Equal(t, initialIncarnation, managedIcebergTargetIncarnation(t, ctx, env.destURI, target))
+}
+
+func TestPostgresCDCToIcebergRESTMinioReplaysAfterDataBeforeStateFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	t.Cleanup(func() { _ = sourceContainer.Terminate(ctx) })
+	setupCDCSource(t, ctx, sourceConnString)
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	t.Cleanup(sourcePool.Close)
+
+	env := setupIcebergRESTMinioCatalog(t, ctx)
+	target := "it_" + uniqueSuffix() + ".postgres_cdc_state_failure"
+	controller := &managedIcebergStateFailureController{}
+	scheme := "iceberg-cdc-state-failure-" + uniqueSuffix()
+	internalregistry.Default.RegisterDestination([]string{scheme}, func() interface{} {
+		return &managedIcebergStateFailureDestination{
+			Destination: icebergdest.NewDestination(),
+			actualURI:   env.destURI,
+			controller:  controller,
+		}
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+		"&publication=test_pub&mode=batch&state_id=iceberg-data-before-state"
+	cfg.SourceTable = "public.test_cdc"
+	cfg.DestURI = scheme + "://catalog"
+	cfg.DestTable = target
+	cfg.PrimaryKeys = []string{"id"}
+	cfg.PageSize = 1
+	cfg.IncrementalStrategy = config.StrategyMerge
+	cfg.IncrementalStrategyExplicit = true
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	connectorID, initialState := managedIcebergCDCStateForTarget(t, ctx, env.destURI, target)
+	initialCheckpoint := latestCompleteManagedIcebergCheckpoint(t, initialState)
+	initialConfirmed, _ := cdcReplicationSlotState(t, ctx, sourcePool)
+	require.NotEmpty(t, initialConfirmed)
+
+	_, err = sourcePool.Exec(ctx, `
+		BEGIN;
+		UPDATE public.test_cdc SET name = 'item1-after-failure', value = 1111 WHERE id = 1;
+		INSERT INTO public.test_cdc (name, value) VALUES ('fault-replay', 4444);
+		COMMIT;
+	`)
+	require.NoError(t, err)
+	controller.arm()
+	err = pipeline.New(cfg).Run(ctx)
+	require.ErrorIs(t, err, errInjectedManagedIcebergStateFailure)
+
+	rowsAfterFailure := icebergRowsByID(readIcebergRows(t, ctx, env.destURI, target))
+	require.Len(t, rowsAfterFailure[1], 1)
+	require.Equal(t, "item1-after-failure", rowsAfterFailure[1][0]["name"],
+		"target data must commit before the injected managed-state failure")
+	require.Len(t, rowsAfterFailure[4], 1)
+	failedState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	require.Equal(t, initialCheckpoint, latestCompleteManagedIcebergCheckpoint(t, failedState),
+		"failed state persistence must not advance resume authority")
+	failedConfirmed, _ := cdcReplicationSlotState(t, ctx, sourcePool)
+	require.Equal(t, initialConfirmed, failedConfirmed,
+		"PostgreSQL confirmed_flush_lsn must not advance when managed state persistence fails")
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	replayedRows := icebergRowsByID(readIcebergRows(t, ctx, env.destURI, target))
+	require.Len(t, replayedRows, 4)
+	for id, rows := range replayedRows {
+		require.Lenf(t, rows, 1, "keyed WAL replay must remain idempotent for id=%d", id)
+	}
+	require.Equal(t, "item1-after-failure", replayedRows[1][0]["name"])
+	require.Equal(t, "fault-replay", replayedRows[4][0]["name"])
+	replayedState := loadManagedIcebergCDCState(t, ctx, env.destURI, connectorID)
+	replayedCheckpoint := latestCompleteManagedIcebergCheckpoint(t, replayedState)
+	require.Truef(t, lsnGreater(t, ctx, sourcePool, replayedCheckpoint, initialCheckpoint),
+		"managed checkpoint must advance only after replay succeeds (%s -> %s)", initialCheckpoint, replayedCheckpoint)
+	replayedConfirmed, _ := cdcReplicationSlotState(t, ctx, sourcePool)
+	require.Truef(t, lsnGreater(t, ctx, sourcePool, replayedConfirmed, failedConfirmed),
+		"PostgreSQL confirmed_flush_lsn must advance after durable replay (%s -> %s)", failedConfirmed, replayedConfirmed)
+}
+
+const managedIcebergCDCStateTable = "_bruin_staging.cdc_state"
+
+var errInjectedManagedIcebergStateFailure = errors.New("injected Iceberg managed CDC state failure")
+
+type managedIcebergStateFailureController struct {
+	mu     sync.Mutex
+	armed  bool
+	writes int
+}
+
+func (c *managedIcebergStateFailureController) arm() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.armed = true
+	c.writes = 0
+}
+
+func (c *managedIcebergStateFailureController) shouldFail() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.armed {
+		return false
+	}
+	c.writes++
+	// BeginRun durably writes its run fence and in-progress snapshot first. The
+	// third write is Persist, after the target data commit has succeeded.
+	if c.writes != 3 {
+		return false
+	}
+	c.armed = false
+	return true
+}
+
+type managedIcebergStateFailureDestination struct {
+	*icebergdest.Destination
+	actualURI  string
+	controller *managedIcebergStateFailureController
+}
+
+func (d *managedIcebergStateFailureDestination) Connect(ctx context.Context, _ string) error {
+	return d.Destination.Connect(ctx, d.actualURI)
+}
+
+func (d *managedIcebergStateFailureDestination) WriteCDCState(
+	ctx context.Context,
+	records <-chan source.RecordBatchResult,
+	opts destination.WriteOptions,
+) error {
+	if !d.controller.shouldFail() {
+		return d.Destination.WriteCDCState(ctx, records, opts)
+	}
+	for result := range records {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+	}
+	return errInjectedManagedIcebergStateFailure
+}
+
+func managedIcebergCDCStateForTarget(
+	t *testing.T,
+	ctx context.Context,
+	destURI, target string,
+) (string, []destination.CDCStateEntry) {
+	t.Helper()
+	rows := readIcebergRows(t, ctx, destURI, managedIcebergCDCStateTable)
+	connectors := make(map[string]struct{})
+	for _, row := range rows {
+		if row["destination_table"] == target {
+			connectorID, ok := row["connector_id"].(string)
+			require.True(t, ok)
+			connectors[connectorID] = struct{}{}
+		}
+	}
+	require.Len(t, connectors, 1, "managed state should have one connector for target %s", target)
+	var connectorID string
+	for connectorID = range connectors {
+	}
+	return connectorID, loadManagedIcebergCDCState(t, ctx, destURI, connectorID)
+}
+
+func loadManagedIcebergCDCState(
+	t *testing.T,
+	ctx context.Context,
+	destURI, connectorID string,
+) []destination.CDCStateEntry {
+	t.Helper()
+	dest := icebergdest.NewDestination()
+	require.NoError(t, dest.Connect(ctx, destURI))
+	entries, err := dest.LoadCDCState(ctx, managedIcebergCDCStateTable, connectorID)
+	require.NoError(t, err)
+	require.NoError(t, dest.Close(ctx))
+	return entries
+}
+
+func latestCompleteManagedIcebergCheckpoint(t *testing.T, entries []destination.CDCStateEntry) string {
+	t.Helper()
+	latest := ""
+	for _, entry := range entries {
+		if entry.StateKind != "checkpoint" || entry.Status != destination.CDCStateStatusComplete {
+			continue
+		}
+		if latest == "" || destination.CompareCDCPositions(entry.Position, latest) > 0 {
+			latest = entry.Position
+		}
+	}
+	require.NotEmpty(t, latest, "managed CDC state has no complete checkpoint")
+	return latest
+}
+
+func hasCompleteManagedIcebergState(entries []destination.CDCStateEntry, kind, target string) bool {
+	for _, entry := range entries {
+		if entry.StateKind == kind && entry.Status == destination.CDCStateStatusComplete && entry.DestinationTable == target {
+			return true
+		}
+	}
+	return false
+}
+
+func managedIcebergTargetIncarnation(t *testing.T, ctx context.Context, destURI, table string) string {
+	t.Helper()
+	dest := icebergdest.NewDestination()
+	require.NoError(t, dest.Connect(ctx, destURI))
+	incarnation, exists, err := dest.CDCTargetIncarnation(ctx, table)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NotEmpty(t, incarnation)
+	require.NoError(t, dest.Close(ctx))
+	return incarnation
+}
+
+func assertPostgresCDCToIcebergState(t *testing.T, rows []map[string]any) {
+	t.Helper()
+
+	require.Len(t, rows, 4, "the delete tombstone remains as one logical Iceberg row")
+	byID := icebergRowsByID(rows)
+	for id := int64(1); id <= 4; id++ {
+		require.Lenf(t, byID[id], 1, "id=%d must have exactly one logical row", id)
+	}
+	require.Equal(t, "item1-updated", byID[1][0]["name"])
+	require.Equal(t, int64(111), byID[1][0]["value"])
+	require.Equal(t, false, byID[1][0][destination.CDCDeletedColumn])
+	require.Equal(t, true, byID[2][0][destination.CDCDeletedColumn])
+	require.Equal(t, "item3", byID[3][0]["name"])
+	require.Equal(t, false, byID[3][0][destination.CDCDeletedColumn])
+	require.Equal(t, "item4-updated", byID[4][0]["name"])
+	require.Equal(t, int64(444), byID[4][0]["value"])
+	require.Equal(t, false, byID[4][0][destination.CDCDeletedColumn])
+
+	var live int
+	for _, row := range rows {
+		if row[destination.CDCDeletedColumn] == false {
+			live++
+		}
+	}
+	require.Equal(t, 3, live)
+}


### PR DESCRIPTION
## Summary

Adds real-container catalog, object-store, nested-type, strategy, conformance, and PostgreSQL CDC-to-Iceberg tests.

## Stack

Part 10 of 11. Review and merge bottom-up. This PR is based on `stack/iceberg-09-unit-regressions`; GitHub therefore shows only this layer's delta.

Previous: https://github.com/bruin-data/ingestr/pull/967 · Next: https://github.com/bruin-data/ingestr/pull/969

## Validation

- `make format`
- `make lint`
- `make test`
- Layer-specific package tests

The complete stack is byte-for-byte equivalent to the previously reviewed full implementation.