### PR TITLE
fix(duckdb): avoid DuckLake attach alias colliding with destination schema

### DIFF
--- a/pkg/source/duckdb/lakehouse.go
+++ b/pkg/source/duckdb/lakehouse.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 )
 
-const AttachAlias = "lake"
+const AttachAlias = "ducklake_catalog"
 
 type CatalogType string
 

--- a/pkg/source/duckdb/lakehouse_test.go
+++ b/pkg/source/duckdb/lakehouse_test.go
@@ -179,11 +179,11 @@ func TestGenerateAttachStatements_OrderAndShape(t *testing.T) {
 		"LOAD httpfs",
 		"INSTALL postgres",
 		"LOAD postgres",
-		"CREATE OR REPLACE SECRET ingestr_lake_storage",
-		"CREATE OR REPLACE SECRET ingestr_lake_catalog",
+		"CREATE OR REPLACE SECRET ingestr_ducklake_catalog_storage",
+		"CREATE OR REPLACE SECRET ingestr_ducklake_catalog_catalog",
 		"SELECT COUNT(*) FROM glob(", // storage probe — fails fast on missing bucket
 		"ATTACH 'ducklake:postgres:'",
-		"CREATE SCHEMA IF NOT EXISTS lake.main",
+		"CREATE SCHEMA IF NOT EXISTS ducklake_catalog.main",
 		"USE " + AttachAlias,
 	}
 	if len(stmts) != len(wantPrefixes) {
@@ -330,7 +330,7 @@ func TestGenerateS3Secret_MinIO(t *testing.T) {
 
 	got := NewLakehouseAttacher().generateS3Secret(defaultSecretName(AttachAlias, "storage"), cfg.Storage)
 	for _, want := range []string{
-		"CREATE OR REPLACE SECRET ingestr_lake_storage (",
+		"CREATE OR REPLACE SECRET ingestr_ducklake_catalog_storage (",
 		"TYPE s3",
 		"KEY_ID 'AKID'",
 		"SECRET 'SECRET'",
@@ -355,7 +355,7 @@ func TestGeneratePostgresSecret(t *testing.T) {
 
 	got := NewLakehouseAttacher().generatePostgresSecret(defaultSecretName(AttachAlias, "catalog"), cfg.Catalog)
 	for _, want := range []string{
-		"CREATE OR REPLACE SECRET ingestr_lake_catalog (",
+		"CREATE OR REPLACE SECRET ingestr_ducklake_catalog_catalog (",
 		"TYPE postgres",
 		"HOST 'meta.host'",
 		"PORT 5433",
@@ -380,17 +380,17 @@ func TestGenerateDuckLakeAttach(t *testing.T) {
 		{
 			"duckdb catalog",
 			"ducklake://?catalog_type=duckdb&catalog_path=/tmp/meta.duckdb&storage_type=s3&storage_path=s3://b/p&storage_access_key=a&storage_secret_key=b",
-			"ATTACH 'ducklake:/tmp/meta.duckdb' AS lake (DATA_PATH 's3://b/p', OVERRIDE_DATA_PATH true)",
+			"ATTACH 'ducklake:/tmp/meta.duckdb' AS ducklake_catalog (DATA_PATH 's3://b/p', OVERRIDE_DATA_PATH true)",
 		},
 		{
 			"sqlite catalog",
 			"ducklake://?catalog_type=sqlite&catalog_path=/tmp/meta.sqlite&storage_type=s3&storage_path=s3://b/p&storage_access_key=a&storage_secret_key=b",
-			"ATTACH 'ducklake:sqlite:/tmp/meta.sqlite' AS lake (DATA_PATH 's3://b/p', OVERRIDE_DATA_PATH true)",
+			"ATTACH 'ducklake:sqlite:/tmp/meta.sqlite' AS ducklake_catalog (DATA_PATH 's3://b/p', OVERRIDE_DATA_PATH true)",
 		},
 		{
 			"postgres catalog",
 			"ducklake://?catalog_type=postgres&catalog_host=h&catalog_database=d&catalog_username=u&catalog_password=p&storage_type=s3&storage_path=s3://b/p&storage_access_key=a&storage_secret_key=b",
-			"ATTACH 'ducklake:postgres:' AS lake (DATA_PATH 's3://b/p', META_SECRET 'ingestr_lake_catalog', OVERRIDE_DATA_PATH true)",
+			"ATTACH 'ducklake:postgres:' AS ducklake_catalog (DATA_PATH 's3://b/p', META_SECRET 'ingestr_ducklake_catalog_catalog', OVERRIDE_DATA_PATH true)",
 		},
 	}
 


### PR DESCRIPTION
Rename the attach alias from `lake` to **`ducklake_catalog`**, mirroring Bruin's own lakehouse alias convention. The `_catalog` suffix keeps the catalog name distinct from any realistic destination schema, so two-part `"<schema>"."<table>"` references resolve unambiguously for any schema name.
