### PR TITLE
fix(schemaevolution): match columns case-insensitively in BuildFinalSchema

### DIFF
--- a/pkg/schemaevolution/evolve_test.go
+++ b/pkg/schemaevolution/evolve_test.go
@@ -87,3 +87,34 @@ func TestBuildFinalSchema_AppliesApplicableChanges(t *testing.T) {
 		}
 	}
 }
+
+// The comparison's dest schema is read back from the destination (Snowflake
+// upper-cases identifiers) while change.ColumnName comes from the source schema
+// (lower case). BuildFinalSchema must match case-insensitively, otherwise the
+// type change is silently skipped and the staging schema built from the result
+// disagrees with the evolved destination.
+func TestBuildFinalSchema_CaseInsensitiveColumnMatch(t *testing.T) {
+	dest := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "DATE", DataType: schema.TypeTimestampTZ},
+		},
+	}
+	comparison := &SchemaComparison{
+		HasChanges: true,
+		Changes: []SchemaChange{
+			{
+				Type:       ChangeOverrideType,
+				ColumnName: "date", // lower case, as produced from the source schema
+				OldColumn:  &schema.Column{Name: "date", DataType: schema.TypeTimestampTZ},
+				NewColumn:  schema.Column{Name: "date", DataType: schema.TypeTimestamp},
+			},
+		},
+	}
+
+	final := BuildFinalSchema(dest, comparison)
+	require.Len(t, final.Columns, 1)
+	// Type change is applied despite the case difference...
+	assert.Equal(t, schema.TypeTimestamp, final.Columns[0].DataType)
+	// ...and the destination's identifier casing is preserved.
+	assert.Equal(t, "DATE", final.Columns[0].Name)
+}

--- a/pkg/schemaevolution/plan.go
+++ b/pkg/schemaevolution/plan.go
@@ -1,6 +1,8 @@
 package schemaevolution
 
 import (
+	"strings"
+
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
@@ -48,8 +50,10 @@ func BuildFinalSchema(destSchema *schema.TableSchema, comparison *SchemaComparis
 
 		case ChangeWidenType, ChangeOverrideType:
 			for i, col := range result.Columns {
-				if col.Name == change.ColumnName {
-					result.Columns[i] = change.NewColumn
+				if strings.EqualFold(col.Name, change.ColumnName) {
+					newCol := change.NewColumn
+					newCol.Name = col.Name
+					result.Columns[i] = newCol
 					break
 				}
 			}


### PR DESCRIPTION
`BuildFinalSchema` match columns case-sensitively with `strings.EqualFold` and preserve the destination's identifier casing (change the column's type, not its name). 
