### PR TITLE
Improve MySQL to PostgreSQL ingestion performance

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,10 +206,16 @@ func (c *IngestConfig) validateExtractPartitioning() error {
 	if c.ExtractPartitionInterval < 0 || c.ExtractPartitionNumericInterval < 0 {
 		return &ValidationError{Field: "extract-partition-interval", Message: "must be positive"}
 	}
-	if c.IntervalStart == nil {
+	if c.IntervalStart == nil && c.IntervalEnd != nil {
+		return &ValidationError{Field: "interval-start", Message: "is required when interval-end is set"}
+	}
+	if c.IntervalEnd == nil && c.IntervalStart != nil {
+		return &ValidationError{Field: "interval-end", Message: "is required when interval-start is set"}
+	}
+	if c.IncrementalKey != "" && c.IntervalStart == nil {
 		return &ValidationError{Field: "interval-start", Message: "is required when extract partitioning is enabled"}
 	}
-	if c.IntervalEnd == nil {
+	if c.IncrementalKey != "" && c.IntervalEnd == nil {
 		return &ValidationError{Field: "interval-end", Message: "is required when extract partitioning is enabled"}
 	}
 	if c.SQLLimit > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -230,6 +230,15 @@ func TestIngestConfigValidate_ExtractPartitioning(t *testing.T) {
 			},
 		},
 		{
+			name: "valid full numeric bounds discovery",
+			mutate: func(c *IngestConfig) {
+				c.IntervalStart = nil
+				c.IntervalEnd = nil
+				c.ExtractPartitionInterval = 0
+				c.ExtractPartitionAuto = true
+			},
+		},
+		{
 			name:    "mixed interval modes rejected",
 			mutate:  func(c *IngestConfig) { c.ExtractPartitionAuto = true },
 			wantErr: "extract-partition-interval",
@@ -246,12 +255,12 @@ func TestIngestConfigValidate_ExtractPartitioning(t *testing.T) {
 		},
 		{
 			name:    "missing interval start",
-			mutate:  func(c *IngestConfig) { c.IntervalStart = nil },
+			mutate:  func(c *IngestConfig) { c.IncrementalKey = "updated_at"; c.IntervalStart = nil },
 			wantErr: "interval-start",
 		},
 		{
 			name:    "missing interval end",
-			mutate:  func(c *IngestConfig) { c.IntervalEnd = nil },
+			mutate:  func(c *IngestConfig) { c.IncrementalKey = "updated_at"; c.IntervalEnd = nil },
 			wantErr: "interval-end",
 		},
 		{

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -740,6 +740,16 @@ var pow10 = [19]int64{
 // the target scale. Anything else (exponents, rounding, huge values) reports
 // false so the caller can use decimal128.FromString.
 func parseDecimal128Fast(s string, precision, scale int32) (decimal128.Num, bool) {
+	return parseDecimal128Text(s, precision, scale)
+}
+
+// ParseDecimal128BytesFast parses a plain decimal byte slice without converting
+// it to a string. It returns false for inputs that require the general parser.
+func ParseDecimal128BytesFast(s []byte, precision, scale int32) (decimal128.Num, bool) {
+	return parseDecimal128Text(s, precision, scale)
+}
+
+func parseDecimal128Text[T ~string | ~[]byte](s T, precision, scale int32) (decimal128.Num, bool) {
 	if scale < 0 || int(scale) >= len(pow10) {
 		return decimal128.Num{}, false
 	}

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -467,3 +467,17 @@ func TestParseDecimal128Fast_FallsBack(t *testing.T) {
 		}
 	}
 }
+
+func TestParseDecimal128BytesFast(t *testing.T) {
+	inputs := []string{"0", "-1", "+5", "15716.10", ".5", "5.", "00042.10"}
+	for _, input := range inputs {
+		fromBytes, ok := ParseDecimal128BytesFast([]byte(input), 15, 2)
+		if !ok {
+			t.Fatalf("ParseDecimal128BytesFast(%q) unexpectedly fell back", input)
+		}
+		fromString, ok := parseDecimal128Fast(input, 15, 2)
+		if !ok || fromBytes != fromString {
+			t.Fatalf("byte parse for %q = %v; string parse = %v, %v", input, fromBytes, fromString, ok)
+		}
+	}
+}

--- a/pkg/destination/postgres/arrow_copy_reader.go
+++ b/pkg/destination/postgres/arrow_copy_reader.go
@@ -1,0 +1,360 @@
+package postgres
+
+import (
+	"encoding/binary"
+	"io"
+	"math"
+	"math/bits"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+var postgresBinaryCopyHeader = []byte("PGCOPY\n\xff\r\n\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+
+type arrowCopyReader struct {
+	record  arrow.RecordBatch
+	columns []arrowCopyColumn
+	row     int
+	buffer  []byte
+	offset  int
+	started bool
+	done    bool
+	err     error
+}
+
+type arrowCopyColumn func(int, []byte) ([]byte, bool, error)
+
+func newArrowCopyReader(record arrow.RecordBatch, tableSchema *schema.TableSchema, typeMap *pgtype.Map, oids []uint32) (*arrowCopyReader, bool) {
+	if len(oids) != int(record.NumCols()) {
+		return nil, false
+	}
+
+	columns := make([]arrowCopyColumn, record.NumCols())
+	var columnTypes map[string]schema.DataType
+	for column := range columns {
+		if direct, ok := directArrowCopyColumn(record.Column(column), oids[column]); ok {
+			columns[column] = direct
+			continue
+		}
+		if columnTypes == nil {
+			columnTypes = postgresColumnTypesByName(tableSchema)
+		}
+		get := postgresValueGetterForType(record.Column(column), columnTypes[record.ColumnName(column)])
+
+		var plan pgtype.EncodePlan
+		for row := 0; row < int(record.NumRows()); row++ {
+			value := get(row)
+			if value == nil {
+				continue
+			}
+
+			plan = typeMap.PlanEncode(oids[column], pgx.BinaryFormatCode, value)
+			if plan == nil {
+				return nil, false
+			}
+			if _, err := plan.Encode(value, nil); err != nil {
+				return nil, false
+			}
+			break
+		}
+		columns[column] = func(row int, dst []byte) ([]byte, bool, error) {
+			value := get(row)
+			if value == nil {
+				return dst, true, nil
+			}
+			encoded, err := plan.Encode(value, dst)
+			return encoded, false, err
+		}
+	}
+
+	return &arrowCopyReader{
+		record:  record,
+		columns: columns,
+	}, true
+}
+
+func directArrowCopyColumn(column arrow.Array, oid uint32) (arrowCopyColumn, bool) {
+	switch values := column.(type) {
+	case *array.Boolean:
+		if oid != pgtype.BoolOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			if values.Value(row) {
+				return append(dst, 1)
+			}
+			return append(dst, 0)
+		}), true
+	case *array.Int8:
+		if oid != pgtype.Int2OID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint16(dst, uint16(int16(values.Value(row))))
+		}), true
+	case *array.Int16:
+		if oid != pgtype.Int2OID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint16(dst, uint16(values.Value(row)))
+		}), true
+	case *array.Int32:
+		if oid != pgtype.Int4OID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint32(dst, uint32(values.Value(row)))
+		}), true
+	case *array.Int64:
+		if oid != pgtype.Int8OID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint64(dst, uint64(values.Value(row)))
+		}), true
+	case *array.Float32:
+		if oid != pgtype.Float4OID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint32(dst, math.Float32bits(values.Value(row)))
+		}), true
+	case *array.Float64:
+		if oid != pgtype.Float8OID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint64(dst, math.Float64bits(values.Value(row)))
+		}), true
+	case *array.Decimal128:
+		decimalType := values.DataType().(*arrow.Decimal128Type)
+		if oid != pgtype.NumericOID || decimalType.Scale < 0 || decimalType.Scale%4 != 0 {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return appendPostgresNumeric(dst, values.Value(row), decimalType.Scale)
+		}), true
+	case *array.Date32:
+		if oid != pgtype.DateOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return binary.BigEndian.AppendUint32(dst, uint32(int32(values.Value(row))-postgresDateEpochDays))
+		}), true
+	case *array.Date64:
+		if oid != pgtype.DateOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			days := int64(values.Value(row)) / millisecondsPerDay
+			return binary.BigEndian.AppendUint32(dst, uint32(int32(days)-postgresDateEpochDays))
+		}), true
+	case *array.Time64:
+		if oid != pgtype.TimeOID {
+			return nil, false
+		}
+		timeType := values.DataType().(*arrow.Time64Type)
+		if timeType.Unit != arrow.Microsecond && timeType.Unit != arrow.Nanosecond {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			value := int64(values.Value(row))
+			if timeType.Unit == arrow.Nanosecond {
+				value /= 1_000
+			}
+			return binary.BigEndian.AppendUint64(dst, uint64(value))
+		}), true
+	case *array.Timestamp:
+		if oid != pgtype.TimestampOID && oid != pgtype.TimestamptzOID {
+			return nil, false
+		}
+		timestampType := values.DataType().(*arrow.TimestampType)
+		if timestampType.Unit != arrow.Microsecond {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			value := int64(values.Value(row)) - postgresTimestampEpochMicroseconds
+			return binary.BigEndian.AppendUint64(dst, uint64(value))
+		}), true
+	case *array.String:
+		if oid != pgtype.TextOID && oid != pgtype.VarcharOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return append(dst, values.Value(row)...)
+		}), true
+	case *array.LargeString:
+		if oid != pgtype.TextOID && oid != pgtype.VarcharOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return append(dst, values.Value(row)...)
+		}), true
+	case *array.Binary:
+		if oid != pgtype.ByteaOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return append(dst, values.Value(row)...)
+		}), true
+	case *array.LargeBinary:
+		if oid != pgtype.ByteaOID {
+			return nil, false
+		}
+		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
+			return append(dst, values.Value(row)...)
+		}), true
+	case array.ExtensionArray:
+		if oid == pgtype.JSONBOID {
+			storage, ok := values.Storage().(*array.String)
+			if !ok {
+				return nil, false
+			}
+			return fixedArrowCopyColumn(storage, func(row int, dst []byte) []byte {
+				dst = append(dst, 1)
+				return append(dst, storage.Value(row)...)
+			}), true
+		}
+	}
+	return nil, false
+}
+
+const (
+	postgresDateEpochDays              = 10_957
+	postgresTimestampEpochMicroseconds = 946_684_800_000_000
+	millisecondsPerDay                 = 86_400_000
+	postgresNumericNegative            = 0x4000
+)
+
+func appendPostgresNumeric(dst []byte, value decimal128.Num, scale int32) []byte {
+	negative := value.Sign() < 0
+	if negative {
+		value = value.Negate()
+	}
+
+	var digits [10]uint16
+	hi := uint64(value.HighBits())
+	lo := value.LowBits()
+	digitCount := 0
+	for hi != 0 || lo != 0 {
+		quotientHigh, remainder := bits.Div64(0, hi, 10_000)
+		quotientLow, remainder := bits.Div64(remainder, lo, 10_000)
+		digits[digitCount] = uint16(remainder)
+		digitCount++
+		hi = quotientHigh
+		lo = quotientLow
+	}
+
+	fractionalDigits := int(scale / 4)
+	for digitCount < fractionalDigits {
+		digitCount++
+	}
+
+	weight := int16(-1)
+	if wholeDigits := digitCount - fractionalDigits; wholeDigits > 0 {
+		weight = int16(wholeDigits - 1)
+	}
+	sign := uint16(0)
+	if negative {
+		sign = postgresNumericNegative
+	}
+
+	dst = binary.BigEndian.AppendUint16(dst, uint16(digitCount))
+	dst = binary.BigEndian.AppendUint16(dst, uint16(weight))
+	dst = binary.BigEndian.AppendUint16(dst, sign)
+	dst = binary.BigEndian.AppendUint16(dst, uint16(scale))
+	for i := digitCount - 1; i >= 0; i-- {
+		dst = binary.BigEndian.AppendUint16(dst, digits[i])
+	}
+	return dst
+}
+
+func fixedArrowCopyColumn(values arrow.Array, encode func(int, []byte) []byte) arrowCopyColumn {
+	if values.NullN() == 0 {
+		return func(row int, dst []byte) ([]byte, bool, error) {
+			return encode(row, dst), false, nil
+		}
+	}
+	return func(row int, dst []byte) ([]byte, bool, error) {
+		if values.IsNull(row) {
+			return dst, true, nil
+		}
+		return encode(row, dst), false, nil
+	}
+}
+
+func (r *arrowCopyReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	if r.offset == len(r.buffer) {
+		if r.done {
+			return 0, io.EOF
+		}
+		r.fill(p)
+		if r.err != nil {
+			return 0, r.err
+		}
+	}
+
+	n := copy(p, r.buffer[r.offset:])
+	r.offset += n
+	return n, nil
+}
+
+func (r *arrowCopyReader) fill(target []byte) {
+	fillLimit := 64 * 1024
+	if len(target) >= 32*1024 {
+		r.buffer = target[:0:len(target)]
+		fillLimit = len(target) - 1024
+	} else {
+		r.buffer = r.buffer[:0]
+	}
+	r.offset = 0
+	if !r.started {
+		r.buffer = append(r.buffer, postgresBinaryCopyHeader...)
+		r.started = true
+	}
+
+	for r.row < int(r.record.NumRows()) && len(r.buffer) < fillLimit {
+		r.appendRow(r.row)
+		if r.err != nil {
+			return
+		}
+		r.row++
+	}
+
+	if r.row == int(r.record.NumRows()) {
+		r.buffer = binary.BigEndian.AppendUint16(r.buffer, uint16(0xffff))
+		r.done = true
+	}
+}
+
+func (r *arrowCopyReader) appendRow(row int) {
+	r.buffer = binary.BigEndian.AppendUint16(r.buffer, uint16(len(r.columns)))
+	for _, column := range r.columns {
+		lengthOffset := len(r.buffer)
+		r.buffer = binary.BigEndian.AppendUint32(r.buffer, uint32(0xffffffff))
+
+		encoded, isNull, err := column(row, r.buffer)
+		if err != nil {
+			r.err = err
+			return
+		}
+		if isNull || encoded == nil {
+			continue
+		}
+		r.buffer = encoded
+		binary.BigEndian.PutUint32(r.buffer[lengthOffset:], uint32(len(r.buffer)-lengthOffset-4))
+	}
+}

--- a/pkg/destination/postgres/arrow_copy_reader.go
+++ b/pkg/destination/postgres/arrow_copy_reader.go
@@ -134,7 +134,7 @@ func directArrowCopyColumn(column arrow.Array, oid uint32) (arrowCopyColumn, boo
 		}), true
 	case *array.Decimal128:
 		decimalType := values.DataType().(*arrow.Decimal128Type)
-		if oid != pgtype.NumericOID || decimalType.Scale < 0 || decimalType.Scale%4 != 0 {
+		if oid != pgtype.NumericOID || decimalType.Scale < 0 {
 			return nil, false
 		}
 		return fixedArrowCopyColumn(values, func(row int, dst []byte) []byte {
@@ -238,7 +238,7 @@ func appendPostgresNumeric(dst []byte, value decimal128.Num, scale int32) []byte
 		value = value.Negate()
 	}
 
-	var digits [10]uint16
+	var digits [11]uint16
 	hi := uint64(value.HighBits())
 	lo := value.LowBits()
 	digitCount := 0
@@ -251,7 +251,24 @@ func appendPostgresNumeric(dst []byte, value decimal128.Num, scale int32) []byte
 		lo = quotientLow
 	}
 
-	fractionalDigits := int(scale / 4)
+	if remainder := scale % 4; remainder != 0 {
+		multiplier := uint32(10)
+		for i := remainder + 1; i < 4; i++ {
+			multiplier *= 10
+		}
+		var carry uint32
+		for i := 0; i < digitCount; i++ {
+			product := uint32(digits[i])*multiplier + carry
+			digits[i] = uint16(product % 10_000)
+			carry = product / 10_000
+		}
+		if carry != 0 {
+			digits[digitCount] = uint16(carry)
+			digitCount++
+		}
+	}
+
+	fractionalDigits := int((scale + 3) / 4)
 	for digitCount < fractionalDigits {
 		digitCount++
 	}

--- a/pkg/destination/postgres/arrow_copy_reader_test.go
+++ b/pkg/destination/postgres/arrow_copy_reader_test.go
@@ -1,0 +1,294 @@
+package postgres
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestArrowCopyReaderMatchesPGXBinaryEncoding(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	arrays := []arrow.Array{
+		buildBoolArray(mem),
+		buildInt16Array(mem),
+		buildInt32Array(mem),
+		buildInt64Array(mem),
+		buildFloat32Array(mem),
+		buildFloat64Array(mem),
+		buildStringArray(mem),
+		buildBinaryArray(mem),
+		buildDecimal128Array(mem),
+		buildDate32Array(mem),
+		buildTime64Array(mem),
+		buildTimestampArray(mem),
+		buildJSONExtensionArray(mem),
+	}
+	for _, arr := range arrays {
+		defer arr.Release()
+	}
+
+	fields := make([]arrow.Field, len(arrays))
+	for i, arr := range arrays {
+		fields[i] = arrow.Field{Name: "column_" + string(rune('a'+i)), Type: arr.DataType(), Nullable: true}
+	}
+	record := array.NewRecordBatch(arrow.NewSchema(fields, nil), arrays, 2)
+	defer record.Release()
+
+	oids := []uint32{
+		pgtype.BoolOID,
+		pgtype.Int2OID,
+		pgtype.Int4OID,
+		pgtype.Int8OID,
+		pgtype.Float4OID,
+		pgtype.Float8OID,
+		pgtype.TextOID,
+		pgtype.ByteaOID,
+		pgtype.NumericOID,
+		pgtype.DateOID,
+		pgtype.TimeOID,
+		pgtype.TimestampOID,
+		pgtype.JSONBOID,
+	}
+	typeMap := pgtype.NewMap()
+	reader, ok := newArrowCopyReader(record, nil, typeMap, oids)
+	if !ok {
+		t.Fatal("newArrowCopyReader rejected built-in PostgreSQL types")
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.HasPrefix(data, postgresBinaryCopyHeader) {
+		t.Fatal("binary COPY header is missing")
+	}
+	offset := len(postgresBinaryCopyHeader)
+	getters := postgresValueGetters(record, nil)
+	for row := 0; row < int(record.NumRows()); row++ {
+		columnCount := int(binary.BigEndian.Uint16(data[offset:]))
+		offset += 2
+		if columnCount != len(getters) {
+			t.Fatalf("row %d column count = %d, want %d", row, columnCount, len(getters))
+		}
+
+		for column, get := range getters {
+			length := int32(binary.BigEndian.Uint32(data[offset:]))
+			offset += 4
+			value := get(row)
+			if value == nil {
+				if length != -1 {
+					t.Fatalf("row %d column %d null length = %d", row, column, length)
+				}
+				continue
+			}
+
+			want, err := typeMap.Encode(oids[column], pgx.BinaryFormatCode, value, nil)
+			if err != nil {
+				t.Fatalf("encode expected row %d column %d: %v", row, column, err)
+			}
+			if length != int32(len(want)) {
+				t.Fatalf("row %d column %d length = %d, want %d", row, column, length, len(want))
+			}
+			if !bytes.Equal(data[offset:offset+int(length)], want) {
+				t.Fatalf("row %d column %d binary value differs from pgx", row, column)
+			}
+			offset += int(length)
+		}
+	}
+
+	if trailer := int16(binary.BigEndian.Uint16(data[offset:])); trailer != -1 {
+		t.Fatalf("binary COPY trailer = %d, want -1", trailer)
+	}
+	offset += 2
+	if offset != len(data) {
+		t.Fatalf("binary COPY stream has %d trailing bytes", len(data)-offset)
+	}
+}
+
+func TestDirectArrowCopyColumnsMatchPGXBinaryEncoding(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	tests := []struct {
+		name  string
+		array arrow.Array
+		oid   uint32
+	}{
+		{name: "numeric scale 4", array: buildDirectDecimalArray(t, mem, 4, []string{"0.0000", "0.0001", "-0.0001", "123456789012345678901234567890.1234", "-999999999999999999999999999999.9999"}), oid: pgtype.NumericOID},
+		{name: "numeric scale 8", array: buildDirectDecimalArray(t, mem, 8, []string{"0.00000000", "0.00000001", "-0.00010000", "123456789012345678901234567890.12345678"}), oid: pgtype.NumericOID},
+		{name: "date32", array: buildDirectDate32Array(mem), oid: pgtype.DateOID},
+		{name: "date64", array: buildDirectDate64Array(mem), oid: pgtype.DateOID},
+		{name: "time microseconds", array: buildDirectTime64Array(mem, arrow.Microsecond), oid: pgtype.TimeOID},
+		{name: "time nanoseconds", array: buildDirectTime64Array(mem, arrow.Nanosecond), oid: pgtype.TimeOID},
+		{name: "timestamp", array: buildDirectTimestampArray(mem), oid: pgtype.TimestampOID},
+		{name: "timestamp with time zone", array: buildDirectTimestampArray(mem), oid: pgtype.TimestamptzOID},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer test.array.Release()
+			column, ok := directArrowCopyColumn(test.array, test.oid)
+			if !ok {
+				t.Fatal("directArrowCopyColumn rejected supported type")
+			}
+
+			get := postgresValueGetter(test.array)
+			typeMap := pgtype.NewMap()
+			for row := 0; row < test.array.Len(); row++ {
+				got, isNull, err := column(row, nil)
+				if err != nil {
+					t.Fatalf("encode row %d: %v", row, err)
+				}
+				if test.array.IsNull(row) {
+					if !isNull {
+						t.Fatalf("row %d was not reported as null", row)
+					}
+					continue
+				}
+				if isNull {
+					t.Fatalf("row %d was unexpectedly reported as null", row)
+				}
+				want, err := typeMap.Encode(test.oid, pgx.BinaryFormatCode, get(row), nil)
+				if err != nil {
+					t.Fatalf("encode expected row %d: %v", row, err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("row %d binary value differs from pgx: got %x, want %x", row, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDirectArrowCopyColumnFallsBackForNonAlignedDecimalScale(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	values := buildDirectDecimalArray(t, mem, 2, []string{"123.45"})
+	defer values.Release()
+	if _, ok := directArrowCopyColumn(values, pgtype.NumericOID); ok {
+		t.Fatal("directArrowCopyColumn accepted a decimal scale requiring normalization")
+	}
+}
+
+func TestArrowCopyReaderHandlesRowsLargerThanReadBuffer(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	builder := array.NewStringBuilder(mem)
+	builder.Append(string(bytes.Repeat([]byte("x"), 100_000)))
+	values := builder.NewStringArray()
+	builder.Release()
+	defer values.Release()
+	record := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.BinaryTypes.String}}, nil),
+		[]arrow.Array{values},
+		1,
+	)
+	defer record.Release()
+
+	smallBufferReader, ok := newArrowCopyReader(record, nil, pgtype.NewMap(), []uint32{pgtype.TextOID})
+	if !ok {
+		t.Fatal("newArrowCopyReader rejected string record")
+	}
+	want := readAllWithBuffer(t, smallBufferReader, 4*1024)
+
+	directBufferReader, ok := newArrowCopyReader(record, nil, pgtype.NewMap(), []uint32{pgtype.TextOID})
+	if !ok {
+		t.Fatal("newArrowCopyReader rejected string record")
+	}
+	got := readAllWithBuffer(t, directBufferReader, 65_531)
+	if !bytes.Equal(got, want) {
+		t.Fatal("direct-buffer COPY stream differs for an oversized row")
+	}
+}
+
+func readAllWithBuffer(t *testing.T, reader io.Reader, size int) []byte {
+	t.Helper()
+	buffer := make([]byte, size)
+	var result []byte
+	for {
+		n, err := reader.Read(buffer)
+		result = append(result, buffer[:n]...)
+		if err == io.EOF {
+			return result
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func buildDirectDecimalArray(t *testing.T, mem memory.Allocator, scale int32, values []string) arrow.Array {
+	t.Helper()
+	dt := &arrow.Decimal128Type{Precision: 38, Scale: scale}
+	builder := array.NewDecimal128Builder(mem, dt)
+	defer builder.Release()
+	for _, value := range values {
+		number, err := decimal128.FromString(value, dt.Precision, dt.Scale)
+		if err != nil {
+			t.Fatalf("parse decimal %q: %v", value, err)
+		}
+		builder.Append(number)
+	}
+	builder.AppendNull()
+	return builder.NewArray()
+}
+
+func buildDirectDate32Array(mem memory.Allocator) arrow.Array {
+	builder := array.NewDate32Builder(mem)
+	defer builder.Release()
+	builder.AppendValues([]arrow.Date32{-20_000, -1, 0, 10_957, 20_000}, []bool{true, true, true, true, true})
+	builder.AppendNull()
+	return builder.NewArray()
+}
+
+func buildDirectDate64Array(mem memory.Allocator) arrow.Array {
+	builder := array.NewDate64Builder(mem)
+	defer builder.Release()
+	builder.AppendValues([]arrow.Date64{-millisecondsPerDay - 1, -1, 0, millisecondsPerDay, 20_000 * millisecondsPerDay}, []bool{true, true, true, true, true})
+	builder.AppendNull()
+	return builder.NewArray()
+}
+
+func buildDirectTime64Array(mem memory.Allocator, unit arrow.TimeUnit) arrow.Array {
+	builder := array.NewTime64Builder(mem, &arrow.Time64Type{Unit: unit})
+	defer builder.Release()
+	multiplier := int64(1)
+	if unit == arrow.Nanosecond {
+		multiplier = 1_000
+	}
+	builder.AppendValues([]arrow.Time64{0, arrow.Time64(1*multiplier + multiplier/2), arrow.Time64(43_210_987_654 * multiplier)}, []bool{true, true, true})
+	builder.AppendNull()
+	return builder.NewArray()
+}
+
+func buildDirectTimestampArray(mem memory.Allocator) arrow.Array {
+	dt := arrow.FixedWidthTypes.Timestamp_us.(*arrow.TimestampType)
+	builder := array.NewTimestampBuilder(mem, dt)
+	defer builder.Release()
+	for _, value := range []time.Time{
+		time.Date(1900, 1, 1, 0, 0, 0, 1_000, time.UTC),
+		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2100, 12, 31, 23, 59, 59, 999_999_000, time.UTC),
+	} {
+		timestamp, err := arrow.TimestampFromTime(value, arrow.Microsecond)
+		if err != nil {
+			panic(err)
+		}
+		builder.Append(timestamp)
+	}
+	builder.AppendNull()
+	return builder.NewArray()
+}

--- a/pkg/destination/postgres/arrow_copy_reader_test.go
+++ b/pkg/destination/postgres/arrow_copy_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,8 +126,15 @@ func TestDirectArrowCopyColumnsMatchPGXBinaryEncoding(t *testing.T) {
 		array arrow.Array
 		oid   uint32
 	}{
+		{name: "numeric scale 0", array: buildDirectDecimalArray(t, mem, 0, []string{"0", "1", "-1", strings.Repeat("9", 38)}), oid: pgtype.NumericOID},
+		{name: "numeric scale 1", array: buildDirectDecimalArray(t, mem, 1, []string{"0.0", "0.1", "-12.3", strings.Repeat("9", 37) + ".9"}), oid: pgtype.NumericOID},
+		{name: "numeric scale 2", array: buildDirectDecimalArray(t, mem, 2, []string{"0.00", "0.01", "-123.45", "123456789012345678901234567890123456.78"}), oid: pgtype.NumericOID},
+		{name: "numeric scale 3", array: buildDirectDecimalArray(t, mem, 3, []string{"0.000", "0.001", "-123.456", "99999999999999999999999999999999999.999"}), oid: pgtype.NumericOID},
 		{name: "numeric scale 4", array: buildDirectDecimalArray(t, mem, 4, []string{"0.0000", "0.0001", "-0.0001", "123456789012345678901234567890.1234", "-999999999999999999999999999999.9999"}), oid: pgtype.NumericOID},
+		{name: "numeric scale 6", array: buildDirectDecimalArray(t, mem, 6, []string{"0.000000", "0.000001", "-123.456789", "12345678901234567890123456789012.345678"}), oid: pgtype.NumericOID},
 		{name: "numeric scale 8", array: buildDirectDecimalArray(t, mem, 8, []string{"0.00000000", "0.00000001", "-0.00010000", "123456789012345678901234567890.12345678"}), oid: pgtype.NumericOID},
+		{name: "numeric scale 37", array: buildDirectDecimalArray(t, mem, 37, []string{"0." + strings.Repeat("0", 36) + "1", "-0." + strings.Repeat("9", 37)}), oid: pgtype.NumericOID},
+		{name: "numeric scale 38", array: buildDirectDecimalArray(t, mem, 38, []string{"0." + strings.Repeat("0", 37) + "1", "-0." + strings.Repeat("9", 38)}), oid: pgtype.NumericOID},
 		{name: "date32", array: buildDirectDate32Array(mem), oid: pgtype.DateOID},
 		{name: "date64", array: buildDirectDate64Array(mem), oid: pgtype.DateOID},
 		{name: "time microseconds", array: buildDirectTime64Array(mem, arrow.Microsecond), oid: pgtype.TimeOID},
@@ -167,17 +175,6 @@ func TestDirectArrowCopyColumnsMatchPGXBinaryEncoding(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestDirectArrowCopyColumnFallsBackForNonAlignedDecimalScale(t *testing.T) {
-	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	t.Cleanup(func() { mem.AssertSize(t, 0) })
-
-	values := buildDirectDecimalArray(t, mem, 2, []string{"123.45"})
-	defer values.Release()
-	if _, ok := directArrowCopyColumn(values, pgtype.NumericOID); ok {
-		t.Fatal("directArrowCopyColumn accepted a decimal scale requiring normalization")
 	}
 }
 

--- a/pkg/destination/postgres/copy_write_coalescing.go
+++ b/pkg/destination/postgres/copy_write_coalescing.go
@@ -1,0 +1,107 @@
+package postgres
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const postgresCopyWriteBufferSize = 1024 * 1024
+
+type copyDataWriteCoalescingConn struct {
+	net.Conn
+
+	mu          sync.Mutex
+	buffer      []byte
+	bufferLimit int
+	writeErr    error
+}
+
+func configureCopyDataWriteCoalescing(config *pgxpool.Config) {
+	afterNetConnect := config.ConnConfig.AfterNetConnect
+	config.ConnConfig.AfterNetConnect = func(ctx context.Context, connectConfig *pgconn.Config, conn net.Conn) (net.Conn, error) {
+		if afterNetConnect != nil {
+			var err error
+			conn, err = afterNetConnect(ctx, connectConfig, conn)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &copyDataWriteCoalescingConn{
+			Conn:        conn,
+			bufferLimit: postgresCopyWriteBufferSize,
+		}, nil
+	}
+}
+
+func (c *copyDataWriteCoalescingConn) Write(data []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	if !isPostgresCopyDataFrame(data) {
+		if err := c.flushLocked(); err != nil {
+			return 0, err
+		}
+		return c.Conn.Write(data)
+	}
+
+	if len(c.buffer) > 0 && len(c.buffer)+len(data) > c.bufferLimit {
+		if err := c.flushLocked(); err != nil {
+			return 0, err
+		}
+	}
+	if len(data) >= c.bufferLimit {
+		if err := c.writeAllLocked(data); err != nil {
+			return 0, err
+		}
+		return len(data), nil
+	}
+
+	if c.buffer == nil {
+		c.buffer = make([]byte, 0, c.bufferLimit)
+	}
+	c.buffer = append(c.buffer, data...)
+	if len(c.buffer) >= c.bufferLimit {
+		if err := c.flushLocked(); err != nil {
+			return 0, err
+		}
+	}
+	return len(data), nil
+}
+
+func (c *copyDataWriteCoalescingConn) flushLocked() error {
+	if len(c.buffer) == 0 {
+		return nil
+	}
+	err := c.writeAllLocked(c.buffer)
+	c.buffer = c.buffer[:0]
+	return err
+}
+
+func (c *copyDataWriteCoalescingConn) writeAllLocked(data []byte) error {
+	for len(data) > 0 {
+		n, err := c.Conn.Write(data)
+		data = data[n:]
+		if err != nil {
+			c.writeErr = err
+			return err
+		}
+		if n == 0 {
+			c.writeErr = io.ErrShortWrite
+			return c.writeErr
+		}
+	}
+	return nil
+}
+
+func isPostgresCopyDataFrame(data []byte) bool {
+	return len(data) >= 5 && data[0] == 'd' && int(binary.BigEndian.Uint32(data[1:5])) == len(data)-1
+}

--- a/pkg/destination/postgres/copy_write_coalescing_test.go
+++ b/pkg/destination/postgres/copy_write_coalescing_test.go
@@ -1,0 +1,100 @@
+package postgres
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyDataWriteCoalescingConnFlushesCopyFramesTogether(t *testing.T) {
+	underlying := &recordingConn{}
+	conn := &copyDataWriteCoalescingConn{Conn: underlying, bufferLimit: 1024}
+	first := copyDataFrame([]byte("first"))
+	second := copyDataFrame([]byte("second"))
+
+	n, err := conn.Write(first)
+	require.NoError(t, err)
+	require.Equal(t, len(first), n)
+	n, err = conn.Write(second)
+	require.NoError(t, err)
+	require.Equal(t, len(second), n)
+	require.Empty(t, underlying.writes)
+
+	query := []byte{'Q', 0, 0, 0, 4}
+	n, err = conn.Write(query)
+	require.NoError(t, err)
+	require.Equal(t, len(query), n)
+	require.Equal(t, [][]byte{append(append([]byte{}, first...), second...), query}, underlying.writes)
+}
+
+func TestCopyDataWriteCoalescingConnFlushesAtLimit(t *testing.T) {
+	underlying := &recordingConn{}
+	first := copyDataFrame([]byte("one"))
+	second := copyDataFrame([]byte("two"))
+	conn := &copyDataWriteCoalescingConn{Conn: underlying, bufferLimit: len(first) + len(second)}
+
+	_, err := conn.Write(first)
+	require.NoError(t, err)
+	require.Empty(t, underlying.writes)
+	_, err = conn.Write(second)
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{append(append([]byte{}, first...), second...)}, underlying.writes)
+}
+
+func TestCopyDataWriteCoalescingConnDoesNotBufferMalformedFrame(t *testing.T) {
+	underlying := &recordingConn{}
+	conn := &copyDataWriteCoalescingConn{Conn: underlying, bufferLimit: 1024}
+	frame := copyDataFrame([]byte("valid"))
+	malformed := []byte{'d', 0, 0, 0, 99, 1}
+
+	_, err := conn.Write(frame)
+	require.NoError(t, err)
+	_, err = conn.Write(malformed)
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{frame, malformed}, underlying.writes)
+}
+
+func TestCopyDataWriteCoalescingConnRetainsFlushError(t *testing.T) {
+	wantErr := errors.New("write failed")
+	underlying := &recordingConn{writeErr: wantErr}
+	frame := copyDataFrame([]byte("data"))
+	conn := &copyDataWriteCoalescingConn{Conn: underlying, bufferLimit: len(frame)}
+
+	_, err := conn.Write(frame)
+	require.ErrorIs(t, err, wantErr)
+	_, err = conn.Write(frame)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func copyDataFrame(payload []byte) []byte {
+	frame := make([]byte, 5, len(payload)+5)
+	frame[0] = 'd'
+	binary.BigEndian.PutUint32(frame[1:], uint32(len(payload)+4))
+	return append(frame, payload...)
+}
+
+type recordingConn struct {
+	writes   [][]byte
+	writeErr error
+}
+
+func (c *recordingConn) Read([]byte) (int, error)         { return 0, nil }
+func (c *recordingConn) Close() error                     { return nil }
+func (c *recordingConn) LocalAddr() net.Addr              { return nil }
+func (c *recordingConn) RemoteAddr() net.Addr             { return nil }
+func (c *recordingConn) SetDeadline(time.Time) error      { return nil }
+func (c *recordingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *recordingConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *recordingConn) Write(data []byte) (int, error) {
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	c.writes = append(c.writes, bytes.Clone(data))
+	return len(data), nil
+}

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -30,6 +30,10 @@ type PostgresDestination struct {
 	uri  string
 }
 
+type postgresStatementDescriber interface {
+	Prepare(context.Context, string, string, []uint32) (*pgconn.StatementDescription, error)
+}
+
 func NewPostgresDestination() *PostgresDestination {
 	return &PostgresDestination{}
 }
@@ -342,7 +346,7 @@ func (d *PostgresDestination) copyRecord(ctx context.Context, record arrow.Recor
 	tableIdent := parseTableIdentifier(opts.Table)
 
 	selectSQL := fmt.Sprintf("select %s from %s", strings.Join(quotedColumns, ", "), tableIdent.Sanitize())
-	description, err := pgxConn.Prepare(ctx, selectSQL, selectSQL)
+	description, err := describePostgresStatement(ctx, pgxConn.PgConn(), selectSQL)
 	if err != nil {
 		return 0, err
 	}
@@ -369,6 +373,10 @@ func (d *PostgresDestination) copyRecord(ctx context.Context, record arrow.Recor
 		return 0, err
 	}
 	return tag.RowsAffected(), nil
+}
+
+func describePostgresStatement(ctx context.Context, describer postgresStatementDescriber, sql string) (*pgconn.StatementDescription, error) {
+	return describer.Prepare(ctx, "", sql, nil)
 }
 
 func postgresValueGetters(record arrow.RecordBatch, tableSchema *schema.TableSchema) []func(int) any {

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -51,6 +51,7 @@ func (d *PostgresDestination) Connect(ctx context.Context, uri string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse connection string: %w", err)
 	}
+	configureCopyDataWriteCoalescing(config)
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
@@ -212,7 +213,6 @@ func (d *PostgresDestination) Write(ctx context.Context, records <-chan source.R
 		}
 
 		numRows := record.NumRows()
-		numCols := record.NumCols()
 
 		if numRows == 0 {
 			record.Release()
@@ -222,29 +222,7 @@ func (d *PostgresDestination) Write(ctx context.Context, records <-chan source.R
 		config.Debug("[DEST] Batch %d: received %d rows", batchNum, numRows)
 
 		startCopy := time.Now()
-
-		// Build column names
-		columns := make([]string, numCols)
-		for i := 0; i < int(numCols); i++ {
-			columns[i] = record.ColumnName(i)
-		}
-
-		// Use CopyFromSlice for streaming conversion without materializing all rows
-		// Pre-allocate row buffer and reuse it for each row to reduce allocations
-		tableIdent := parseTableIdentifier(opts.Table)
-		getters := postgresValueGetters(record, opts.Schema)
-		rowBuf := make([]any, numCols)
-		copyCount, err := d.pool.CopyFrom(
-			ctx,
-			tableIdent,
-			columns,
-			pgx.CopyFromSlice(int(numRows), func(i int) ([]any, error) {
-				for j := 0; j < int(numCols); j++ {
-					rowBuf[j] = getters[j](i)
-				}
-				return rowBuf, nil
-			}),
-		)
+		copyCount, err := d.copyRecord(ctx, record, opts)
 
 		record.Release()
 
@@ -278,7 +256,6 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 
 	results := make(chan writeResult, parallelism*2)
 	var wg sync.WaitGroup
-
 	batchNum := int64(0)
 
 	for i := 0; i < parallelism; i++ {
@@ -303,37 +280,13 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 				}
 
 				numRows := record.NumRows()
-				numCols := record.NumCols()
-
 				if numRows == 0 {
 					record.Release()
 					continue
 				}
 
 				startBatch := time.Now()
-
-				// Build column names
-				columns := make([]string, numCols)
-				for i := 0; i < int(numCols); i++ {
-					columns[i] = record.ColumnName(i)
-				}
-
-				// Use CopyFromSlice for streaming conversion
-				// Pre-allocate row buffer and reuse it for each row
-				tableIdent := parseTableIdentifier(opts.Table)
-				getters := postgresValueGetters(record, opts.Schema)
-				rowBuf := make([]any, numCols)
-				copyCount, err := d.pool.CopyFrom(
-					ctx,
-					tableIdent,
-					columns,
-					pgx.CopyFromSlice(int(numRows), func(i int) ([]any, error) {
-						for j := 0; j < int(numCols); j++ {
-							rowBuf[j] = getters[j](i)
-						}
-						return rowBuf, nil
-					}),
-				)
+				copyCount, err := d.copyRecord(ctx, record, opts)
 				record.Release()
 
 				results <- writeResult{
@@ -369,6 +322,53 @@ func (d *PostgresDestination) WriteParallel(ctx context.Context, records <-chan 
 
 	config.Debug("[DEST] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), float64(totalRows)/time.Since(startTotal).Seconds())
 	return nil
+}
+
+func (d *PostgresDestination) copyRecord(ctx context.Context, record arrow.RecordBatch, opts destination.WriteOptions) (int64, error) {
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Release()
+	pgxConn := conn.Conn()
+
+	columns := make([]string, record.NumCols())
+	quotedColumns := make([]string, record.NumCols())
+	for i := range columns {
+		columns[i] = record.ColumnName(i)
+		quotedColumns[i] = destination.QuoteIdentifier(columns[i])
+	}
+
+	tableIdent := parseTableIdentifier(opts.Table)
+
+	selectSQL := fmt.Sprintf("select %s from %s", strings.Join(quotedColumns, ", "), tableIdent.Sanitize())
+	description, err := pgxConn.Prepare(ctx, selectSQL, selectSQL)
+	if err != nil {
+		return 0, err
+	}
+	oids := make([]uint32, len(description.Fields))
+	for i := range description.Fields {
+		oids[i] = description.Fields[i].DataTypeOID
+	}
+
+	reader, ok := newArrowCopyReader(record, opts.Schema, pgxConn.TypeMap(), oids)
+	if !ok {
+		getters := postgresValueGetters(record, opts.Schema)
+		values := make([]any, record.NumCols())
+		return pgxConn.CopyFrom(ctx, tableIdent, columns, pgx.CopyFromSlice(int(record.NumRows()), func(row int) ([]any, error) {
+			for column := range values {
+				values[column] = getters[column](row)
+			}
+			return values, nil
+		}))
+	}
+
+	copySQL := fmt.Sprintf("copy %s (%s) from stdin binary", tableIdent.Sanitize(), strings.Join(quotedColumns, ", "))
+	tag, err := pgxConn.PgConn().CopyFrom(ctx, reader, copySQL)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
 }
 
 func postgresValueGetters(record arrow.RecordBatch, tableSchema *schema.TableSchema) []func(int) any {
@@ -485,7 +485,11 @@ func postgresValueGetterForType(col arrow.Array, dataType schema.DataType) func(
 			if a.IsNull(i) {
 				return nil
 			}
-			return a.Value(i).ToFloat64(dt.Scale)
+			return pgtype.Numeric{
+				Int:   a.Value(i).BigInt(),
+				Exp:   -dt.Scale,
+				Valid: true,
+			}
 		}
 	case *array.Date32:
 		return func(i int) any {

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -16,8 +16,22 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+type postgresStatementDescriberStub struct {
+	name      string
+	sql       string
+	paramOIDs []uint32
+}
+
+func (s *postgresStatementDescriberStub) Prepare(_ context.Context, name, sql string, paramOIDs []uint32) (*pgconn.StatementDescription, error) {
+	s.name = name
+	s.sql = sql
+	s.paramOIDs = paramOIDs
+	return &pgconn.StatementDescription{}, nil
+}
 
 type postgresResolverStub struct {
 	query  string
@@ -54,6 +68,24 @@ func TestResolveSchemaTableUsesSearchPathForUnqualifiedTarget(t *testing.T) {
 	}
 	if !strings.Contains(resolver.query, "to_regclass($1)") || !strings.Contains(resolver.query, "current_schema()") {
 		t.Fatalf("resolver query does not honor existing table resolution and search_path: %s", resolver.query)
+	}
+}
+
+func TestDescribePostgresStatementUsesAnonymousPreparedStatement(t *testing.T) {
+	describer := &postgresStatementDescriberStub{}
+	const sql = `select "id" from "public"."events"`
+
+	if _, err := describePostgresStatement(t.Context(), describer, sql); err != nil {
+		t.Fatal(err)
+	}
+	if describer.name != "" {
+		t.Fatalf("prepared statement name = %q, want anonymous statement", describer.name)
+	}
+	if describer.sql != sql {
+		t.Fatalf("prepared statement SQL = %q, want %q", describer.sql, sql)
+	}
+	if describer.paramOIDs != nil {
+		t.Fatalf("prepared statement parameter OIDs = %v, want nil", describer.paramOIDs)
 	}
 }
 

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -205,6 +205,35 @@ func TestPostgresValueGettersConvertsUUIDColumns(t *testing.T) {
 	}
 }
 
+func TestPostgresValueGetterPreservesDecimalPrecision(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	dt := &arrow.Decimal128Type{Precision: 38, Scale: 4}
+	b := array.NewDecimal128Builder(mem, dt)
+	defer b.Release()
+	want, err := decimal128.FromString("123456789012345678901234567890.1234", dt.Precision, dt.Scale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Append(want)
+	b.AppendNull()
+	arr := b.NewArray()
+	defer arr.Release()
+
+	get := postgresValueGetter(arr)
+	got, ok := get(0).(pgtype.Numeric)
+	if !ok {
+		t.Fatalf("decimal getter returned %T, want pgtype.Numeric", get(0))
+	}
+	if !got.Valid || got.Exp != -dt.Scale || got.Int.Cmp(want.BigInt()) != 0 {
+		t.Fatalf("decimal getter returned %#v, want unscaled %s with exponent %d", got, want.BigInt(), -dt.Scale)
+	}
+	if got := get(1); got != nil {
+		t.Fatalf("decimal getter null = %#v, want nil", got)
+	}
+}
+
 func postgresTestValuesEqual(left, right any) bool {
 	switch l := left.(type) {
 	case []byte:
@@ -213,6 +242,13 @@ func postgresTestValuesEqual(left, right any) bool {
 	case time.Time:
 		r, ok := right.(time.Time)
 		return ok && l.Equal(r)
+	case pgtype.Numeric:
+		r, ok := right.(float64)
+		if !ok {
+			return false
+		}
+		converted, err := l.Float64Value()
+		return err == nil && converted.Valid && converted.Float64 == r
 	default:
 		return reflect.DeepEqual(left, right)
 	}

--- a/pkg/source/extract_partition.go
+++ b/pkg/source/extract_partition.go
@@ -187,7 +187,8 @@ func ReadExtractPartitions(ctx context.Context, opts ReadOptions, tableSchema *s
 	opts.ExtractPartitionBy = partitionColumn.Name
 	opts.ExtractPartitionKind = kind
 	opts.ExtractPartitionDataType = partitionColumn.DataType
-	if opts.IntervalStart == nil || opts.IntervalEnd == nil {
+	fullNumericExtract := kind == ExtractPartitionKindNumeric && strings.TrimSpace(opts.IncrementalKey) == ""
+	if !fullNumericExtract && (opts.IntervalStart == nil || opts.IntervalEnd == nil) {
 		return nil, fmt.Errorf("extract partitioning requires interval start and end")
 	}
 	if opts.ExtractPartitionAuto {
@@ -205,10 +206,6 @@ func ReadExtractPartitions(ctx context.Context, opts ReadOptions, tableSchema *s
 			return nil, fmt.Errorf("extract partition interval must be a positive integer for numeric partition column %q", opts.ExtractPartitionBy)
 		}
 	}
-	if kind == ExtractPartitionKindNumeric && strings.TrimSpace(opts.IncrementalKey) == "" {
-		return nil, fmt.Errorf("numeric extract partitioning requires an incremental key to discover bounded partition ranges")
-	}
-
 	jobsToRun, err := extractPartitionJobs(ctx, opts, discover)
 	if err != nil {
 		return nil, err
@@ -226,7 +223,7 @@ func ReadExtractPartitions(ctx context.Context, opts ReadOptions, tableSchema *s
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	out := make(chan RecordBatchResult, parallelism)
+	out := make(chan RecordBatchResult, extractPartitionReadBufferSize)
 	jobs := make(chan extractPartitionJob)
 
 	var wg sync.WaitGroup
@@ -323,10 +320,12 @@ func ReadExtractPartitions(ctx context.Context, opts ReadOptions, tableSchema *s
 
 func extractPartitionJobs(ctx context.Context, opts ReadOptions, discover ExtractPartitionBoundsFunc) ([]extractPartitionJob, error) {
 	bounds := ExtractPartitionBounds{
-		Start:    *opts.IntervalStart,
-		End:      *opts.IntervalEnd,
-		Kind:     opts.ExtractPartitionKind,
-		HasRange: true,
+		Kind: opts.ExtractPartitionKind,
+	}
+	if opts.IntervalStart != nil && opts.IntervalEnd != nil {
+		bounds.Start = *opts.IntervalStart
+		bounds.End = *opts.IntervalEnd
+		bounds.HasRange = true
 	}
 	if opts.ExtractPartitionBoundsDiscoveryEnabled() {
 		if discover == nil {

--- a/pkg/source/extract_partition_test.go
+++ b/pkg/source/extract_partition_test.go
@@ -3,7 +3,6 @@ package source
 import (
 	"context"
 	"math/big"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -671,9 +670,7 @@ func TestReadExtractPartitionsDiscoversNumericBounds(t *testing.T) {
 	}
 }
 
-func TestReadExtractPartitionsRejectsNumericBoundsWithoutIncrementalKey(t *testing.T) {
-	intervalStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	intervalEnd := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+func TestReadExtractPartitionsDiscoversFullNumericBoundsWithoutIncrementalKey(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{
 			{Name: "id", DataType: schema.TypeInt64},
@@ -681,27 +678,33 @@ func TestReadExtractPartitionsRejectsNumericBoundsWithoutIncrementalKey(t *testi
 	}
 
 	discoverCalled := false
-	_, err := ReadExtractPartitions(context.Background(), ReadOptions{
-		IntervalStart:                   &intervalStart,
-		IntervalEnd:                     &intervalEnd,
+	records, err := ReadExtractPartitions(context.Background(), ReadOptions{
 		ExtractPartitionBy:              "id",
 		ExtractPartitionNumericInterval: 10,
 		Parallelism:                     1,
 	}, tableSchema, func(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error) {
-		t.Fatal("read should not be called")
-		return nil, nil
+		ch := make(chan RecordBatchResult)
+		close(ch)
+		return ch, nil
 	}, func(ctx context.Context, opts ReadOptions) (ExtractPartitionBounds, error) {
 		discoverCalled = true
-		return ExtractPartitionBounds{}, nil
+		return ExtractPartitionBounds{
+			NumericStart: 1,
+			NumericEnd:   20,
+			Kind:         ExtractPartitionKindNumeric,
+			HasRange:     true,
+		}, nil
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("ReadExtractPartitions() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "incremental key") {
-		t.Fatalf("error = %v, want incremental key message", err)
+	for result := range records {
+		if result.Err != nil {
+			t.Fatalf("unexpected read error: %v", result.Err)
+		}
 	}
-	if discoverCalled {
-		t.Fatal("bounds discovery should not be called")
+	if !discoverCalled {
+		t.Fatal("bounds discovery should be called")
 	}
 }
 

--- a/pkg/source/mysql/arrow_allocator_cgo.go
+++ b/pkg/source/mysql/arrow_allocator_cgo.go
@@ -1,0 +1,14 @@
+//go:build cgo
+
+package mysql
+
+import (
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/memory/mallocator"
+)
+
+const mysqlArrowBuffersOffHeap = true
+
+func newMySQLArrowAllocator() memory.Allocator {
+	return mallocator.NewMallocator()
+}

--- a/pkg/source/mysql/arrow_allocator_nocgo.go
+++ b/pkg/source/mysql/arrow_allocator_nocgo.go
@@ -1,0 +1,11 @@
+//go:build !cgo
+
+package mysql
+
+import "github.com/apache/arrow-go/v18/arrow/memory"
+
+const mysqlArrowBuffersOffHeap = false
+
+func newMySQLArrowAllocator() memory.Allocator {
+	return memory.NewGoAllocator()
+}

--- a/pkg/source/mysql/arrow_gc.go
+++ b/pkg/source/mysql/arrow_gc.go
@@ -1,0 +1,38 @@
+package mysql
+
+import (
+	"os"
+	"runtime/debug"
+	"sync"
+)
+
+var mysqlArrowGCState struct {
+	sync.Mutex
+	readers  int
+	previous int
+}
+
+func beginMySQLArrowGCOptimization() func() {
+	if !mysqlArrowBuffersOffHeap {
+		return func() {}
+	}
+	if _, configured := os.LookupEnv("GOGC"); configured {
+		return func() {}
+	}
+
+	mysqlArrowGCState.Lock()
+	if mysqlArrowGCState.readers == 0 {
+		mysqlArrowGCState.previous = debug.SetGCPercent(200)
+	}
+	mysqlArrowGCState.readers++
+	mysqlArrowGCState.Unlock()
+
+	return func() {
+		mysqlArrowGCState.Lock()
+		mysqlArrowGCState.readers--
+		if mysqlArrowGCState.readers == 0 {
+			debug.SetGCPercent(mysqlArrowGCState.previous)
+		}
+		mysqlArrowGCState.Unlock()
+	}
+}

--- a/pkg/source/mysql/arrow_value_test.go
+++ b/pkg/source/mysql/arrow_value_test.go
@@ -1,0 +1,226 @@
+package mysql
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+type testDriverRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+	closed  bool
+}
+
+func (r *testDriverRows) Columns() []string { return r.columns }
+
+func (r *testDriverRows) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (r *testDriverRows) Next(dest []driver.Value) error {
+	if r.next == len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}
+
+func TestDriverRowsToArrowRecordBatch(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "name", DataType: schema.TypeString},
+		{Name: "amount", DataType: schema.TypeDecimal, Precision: 18, Scale: 4},
+		{Name: "enabled", DataType: schema.TypeBoolean},
+		{Name: "created_date", DataType: schema.TypeDate},
+		{Name: "created_at", DataType: schema.TypeTimestamp},
+		{Name: "payload", DataType: schema.TypeJSON},
+	}
+	now := time.Date(2026, 7, 15, 12, 34, 56, 123456000, time.UTC)
+	rows := &testDriverRows{
+		columns: []string{"id", "name", "amount", "enabled", "created_date", "created_at", "payload"},
+		values: [][]driver.Value{
+			{int64(1), []byte("first"), []byte("123.4567"), int64(1), now, now, []byte(`{"id":1}`)},
+			{int64(2), []byte{}, []byte("-0.0001"), int64(0), now.AddDate(0, 0, 1), now.Add(time.Second), nil},
+		},
+	}
+	dataCapacities := make([]int, len(columns))
+	record, count, err := driverRowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 25_000, dataCapacities)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer record.Release()
+	if count != 2 || record.NumRows() != 2 {
+		t.Fatalf("row count = %d/%d, want 2", count, record.NumRows())
+	}
+	if got := record.Column(0).(*array.Int64).Value(1); got != 2 {
+		t.Fatalf("id = %d, want 2", got)
+	}
+	names := record.Column(1).(*array.String)
+	if names.Value(0) != "first" || names.IsNull(1) || names.Value(1) != "" {
+		t.Fatalf("names = %v, want first and non-null empty", names)
+	}
+	amounts := record.Column(2).(*array.Decimal128)
+	if got := amounts.Value(0).ToString(4); got != "123.4567" {
+		t.Fatalf("amount = %s, want 123.4567", got)
+	}
+	enabled := record.Column(3).(*array.Boolean)
+	if !enabled.Value(0) || enabled.Value(1) {
+		t.Fatalf("enabled = %v/%v, want true/false", enabled.Value(0), enabled.Value(1))
+	}
+	if got := record.Column(4).(*array.Date32).Value(0); got != arrow.Date32FromTime(now) {
+		t.Fatalf("date = %d, want %d", got, arrow.Date32FromTime(now))
+	}
+	if got := record.Column(5).(*array.Timestamp).Value(0); got != arrow.Timestamp(now.UnixMicro()) {
+		t.Fatalf("timestamp = %d, want %d", got, now.UnixMicro())
+	}
+	jsonStorage := record.Column(6).(array.ExtensionArray).Storage().(*array.String)
+	if jsonStorage.Value(0) != `{"id":1}` || !jsonStorage.IsNull(1) {
+		t.Fatalf("JSON values = %v, want value and null", jsonStorage)
+	}
+	if dataCapacities[1] == 0 || dataCapacities[6] == 0 {
+		t.Fatalf("variable-width capacities were not recorded: %v", dataCapacities)
+	}
+}
+
+func TestMySQLValueAppenderMatchesGenericConversion(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+	now := time.Date(2026, 7, 15, 12, 34, 56, 123456000, time.UTC)
+
+	tests := []struct {
+		name     string
+		dataType arrow.DataType
+		values   []driver.Value
+	}{
+		{name: "boolean", dataType: arrow.FixedWidthTypes.Boolean, values: []driver.Value{nil, int64(0), int64(1), true}},
+		{name: "int16", dataType: arrow.PrimitiveTypes.Int16, values: []driver.Value{nil, int64(-32768), int64(32767), int64(32768)}},
+		{name: "int32", dataType: arrow.PrimitiveTypes.Int32, values: []driver.Value{nil, int64(-42), int64(42)}},
+		{name: "int64", dataType: arrow.PrimitiveTypes.Int64, values: []driver.Value{nil, int64(-42), int64(42)}},
+		{name: "float64", dataType: arrow.PrimitiveTypes.Float64, values: []driver.Value{nil, float64(-1.25), int64(2)}},
+		{name: "string", dataType: arrow.BinaryTypes.String, values: []driver.Value{nil, []byte("bytes"), "string"}},
+		{name: "binary", dataType: arrow.BinaryTypes.Binary, values: []driver.Value{nil, []byte{0, 1, 2}, "string"}},
+		{name: "date", dataType: arrow.FixedWidthTypes.Date32, values: []driver.Value{nil, now, "2026-07-15"}},
+		{name: "timestamp", dataType: &arrow.TimestampType{Unit: arrow.Microsecond}, values: []driver.Value{nil, now, "2026-07-15T12:34:56Z"}},
+		{name: "time", dataType: &arrow.Time64Type{Unit: arrow.Microsecond}, values: []driver.Value{nil, []byte("12:34:56.123456")}},
+		{name: "decimal", dataType: &arrow.Decimal128Type{Precision: 18, Scale: 4}, values: []driver.Value{nil, []byte("123.4567"), []byte("  -0.0001  "), []byte("1e2"), []byte("invalid")}},
+		{name: "json", dataType: schema.JSONArrowType, values: []driver.Value{nil, []byte(`{"key":"value"}`), `{"other":1}`}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generic := array.NewBuilder(mem, test.dataType)
+			typed := array.NewBuilder(mem, test.dataType)
+			typed.Reserve(len(test.values))
+			appendTyped := mysqlValueAppender(typed, true)
+			for _, value := range test.values {
+				appendMySQLValue(generic, value)
+				appendTyped(value)
+			}
+			genericArray := generic.NewArray()
+			typedArray := typed.NewArray()
+			generic.Release()
+			typed.Release()
+			defer genericArray.Release()
+			defer typedArray.Release()
+			if !array.Equal(genericArray, typedArray) {
+				t.Fatalf("typed appender result differs: generic=%v typed=%v", genericArray, typedArray)
+			}
+		})
+	}
+}
+
+func TestAppendMySQLValueCopiesDriverBytesIntoArrow(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	stringBuilder := array.NewStringBuilder(mem)
+	input := []byte("mysql text")
+	appendMySQLValue(stringBuilder, input)
+	input[0] = 'X'
+	stringArray := stringBuilder.NewStringArray()
+	if got := stringArray.Value(0); got != "mysql text" {
+		t.Fatalf("string value = %q, want %q", got, "mysql text")
+	}
+	stringArray.Release()
+	stringBuilder.Release()
+
+	binaryBuilder := array.NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	input = []byte{1, 2, 3}
+	appendMySQLValue(binaryBuilder, input)
+	input[0] = 9
+	binaryArray := binaryBuilder.NewBinaryArray()
+	if got := binaryArray.Value(0); got[0] != 1 {
+		t.Fatalf("binary value = %v, want [1 2 3]", got)
+	}
+	binaryArray.Release()
+	binaryBuilder.Release()
+
+	jsonBuilder := array.NewExtensionBuilder(mem, schema.JSONArrowType)
+	input = []byte(`{"key":"value"}`)
+	appendMySQLValue(jsonBuilder, input)
+	input[2] = 'X'
+	storage := jsonBuilder.StorageBuilder().(*array.StringBuilder)
+	if got := storage.Value(0); got != `{"key":"value"}` {
+		t.Fatalf("JSON value = %q, want %q", got, `{"key":"value"}`)
+	}
+	jsonBuilder.Release()
+}
+
+func TestMySQLRawBytesScanPreservesNullAndEmpty(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	builder := array.NewStringBuilder(mem)
+	nullValue := sql.RawBytes(nil)
+	appendMySQLScannedValue(builder, &nullValue)
+	emptyValue := sql.RawBytes([]byte{})
+	appendMySQLScannedValue(builder, &emptyValue)
+	values := builder.NewStringArray()
+	defer values.Release()
+	builder.Release()
+
+	if !values.IsNull(0) {
+		t.Fatal("nil RawBytes should append a null")
+	}
+	if values.IsNull(1) || values.Value(1) != "" {
+		t.Fatal("non-nil empty RawBytes should append an empty value")
+	}
+}
+
+func TestMySQLScanDestinationUsesRawBytesOnlyForByteBackedTypes(t *testing.T) {
+	for _, dataType := range []schema.DataType{
+		schema.TypeDecimal,
+		schema.TypeString,
+		schema.TypeBinary,
+		schema.TypeTime,
+		schema.TypeJSON,
+		schema.TypeUUID,
+	} {
+		if _, ok := mysqlScanDestination(dataType).(*sql.RawBytes); !ok {
+			t.Fatalf("%s scan destination is not *sql.RawBytes", dataType)
+		}
+	}
+
+	for _, dataType := range []schema.DataType{
+		schema.TypeBoolean,
+		schema.TypeInt64,
+		schema.TypeFloat64,
+		schema.TypeDate,
+		schema.TypeTimestamp,
+	} {
+		if _, ok := mysqlScanDestination(dataType).(*interface{}); !ok {
+			t.Fatalf("%s scan destination is not *interface{}", dataType)
+		}
+	}
+}

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -1,9 +1,16 @@
 package mysql
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
+	"io"
+	"math"
+	"net"
 	"strings"
 	"time"
 
@@ -15,14 +22,26 @@ import (
 	"github.com/bruin-data/ingestr/pkg/mysqluri"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
-	_ "github.com/go-sql-driver/mysql"
+	mysqldriver "github.com/go-sql-driver/mysql"
 )
+
+const mysqlReadBufferSize = 1024 * 1024
+
+type bufferedReadConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *bufferedReadConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
 
 type MySQLSource struct {
 	db          *sql.DB
 	uri         string
 	database    string
 	sessionInit []string
+	restoreGC   func()
 	// vitessBackend is set by VitessSource. When false, Connect rejects servers
 	// that identify as Vitess so mysql:// URIs fail fast against Vitess/PlanetScale.
 	vitessBackend bool
@@ -42,10 +61,31 @@ func (s *MySQLSource) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to parse MySQL URI: %w", err)
 	}
 
-	db, err := sql.Open("mysql", dsn)
+	driverConfig, err := mysqldriver.ParseDSN(dsn)
 	if err != nil {
-		return fmt.Errorf("failed to open MySQL connection: %w", err)
+		return fmt.Errorf("failed to parse MySQL DSN: %w", err)
 	}
+	driverConfig.DialFunc = func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := (&net.Dialer{}).DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			if err := tcpConn.SetKeepAlive(true); err != nil {
+				_ = conn.Close()
+				return nil, err
+			}
+		}
+		return &bufferedReadConn{
+			Conn:   conn,
+			reader: bufio.NewReaderSize(conn, mysqlReadBufferSize),
+		}, nil
+	}
+	connector, err := mysqldriver.NewConnector(driverConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create MySQL connector: %w", err)
+	}
+	db := sql.OpenDB(connector)
 
 	// Configure connection pool
 	db.SetMaxOpenConns(10)
@@ -70,6 +110,7 @@ func (s *MySQLSource) Connect(ctx context.Context, uri string) error {
 	s.db = db
 	s.uri = uri
 	s.database = database
+	s.restoreGC = beginMySQLArrowGCOptimization()
 	return nil
 }
 
@@ -89,10 +130,15 @@ func isVitessServer(ctx context.Context, db *sql.DB) (bool, error) {
 }
 
 func (s *MySQLSource) Close(ctx context.Context) error {
+	var err error
 	if s.db != nil {
-		return s.db.Close()
+		err = s.db.Close()
 	}
-	return nil
+	if s.restoreGC != nil {
+		s.restoreGC()
+		s.restoreGC = nil
+	}
+	return err
 }
 
 func (s *MySQLSource) HandlesIncrementality() bool {
@@ -252,6 +298,7 @@ func getMySQLSchema(ctx context.Context, db *sql.DB, database string, table stri
 type rowQuerier interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
 }
 
 // querier returns something to run a query on plus a cleanup func. When the
@@ -313,6 +360,13 @@ func (s *MySQLSource) readQuery(ctx context.Context, table string, columns []sch
 		defer close(results)
 
 		query := buildSelectQuery(table, columns, opts)
+		usedDirect, err := s.readQueryDirect(ctx, query, columns, arrowSchema, batchSize, startTotal, results)
+		if usedDirect {
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+			}
+			return
+		}
 
 		q, cleanup, err := s.querier(ctx)
 		if err != nil {
@@ -322,11 +376,12 @@ func (s *MySQLSource) readQuery(ctx context.Context, table string, columns []sch
 		defer cleanup()
 
 		startQuery := time.Now()
-		rows, err := q.QueryContext(ctx, query)
+		rows, closeStmt, err := queryRows(ctx, q, query)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to query: %w", err)}
 			return
 		}
+		defer closeStmt()
 		defer func() { _ = rows.Close() }()
 		config.Debug("[SOURCE] Query started in %v", time.Since(startQuery))
 
@@ -358,21 +413,118 @@ func (s *MySQLSource) readQuery(ctx context.Context, table string, columns []sch
 	return results, nil
 }
 
-func (s *MySQLSource) discoverExtractPartitionBounds(ctx context.Context, table string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
-	query := source.SQLExtractPartitionBoundsQuery(table, opts.ExtractPartitionBy, opts.IncrementalKey, opts.IncrementalKeyDataType, opts.IntervalStart, opts.IntervalEnd, quoteColumn, quoteTable, source.NativeSQLTimeFormat)
+var errDirectDriverRowsUnsupported = errors.New("direct driver rows unsupported")
 
+func (s *MySQLSource) readQueryDirect(ctx context.Context, query string, columns []schema.Column, arrowSchema *arrow.Schema, batchSize int, startTotal time.Time, results chan<- source.RecordBatchResult) (bool, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return true, fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	for _, statement := range s.sessionInit {
+		if _, err := conn.ExecContext(ctx, statement); err != nil {
+			return true, fmt.Errorf("failed to apply session setting %q: %w", statement, err)
+		}
+	}
+
+	startQuery := time.Now()
+	err = conn.Raw(func(rawConn any) error {
+		preparer, ok := rawConn.(driver.ConnPrepareContext)
+		if !ok {
+			return errDirectDriverRowsUnsupported
+		}
+		statement, err := preparer.PrepareContext(ctx, query)
+		if err != nil {
+			return errDirectDriverRowsUnsupported
+		}
+		defer func() { _ = statement.Close() }()
+
+		queryer, ok := statement.(driver.StmtQueryContext)
+		if !ok {
+			return errDirectDriverRowsUnsupported
+		}
+		rows, err := queryer.QueryContext(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+		config.Debug("[SOURCE] Query started in %v", time.Since(startQuery))
+
+		batchNum := 0
+		totalRows := int64(0)
+		dataCapacities := make([]int, len(columns))
+		allocator := newMySQLArrowAllocator()
+		for {
+			startBatch := time.Now()
+			record, count, err := driverRowsToArrowRecordBatchWithAllocator(rows, arrowSchema, columns, batchSize, dataCapacities, allocator)
+			if err != nil {
+				return err
+			}
+			if count == 0 {
+				break
+			}
+
+			batchNum++
+			totalRows += count
+			config.Debug("[SOURCE] Batch %d: %d rows read in %v (total: %d)", batchNum, count, time.Since(startBatch), totalRows)
+			select {
+			case results <- source.RecordBatchResult{Batch: record}:
+			case <-ctx.Done():
+				record.Release()
+				return ctx.Err()
+			}
+		}
+		config.Debug("[SOURCE] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
+		return nil
+	})
+	if errors.Is(err, errDirectDriverRowsUnsupported) {
+		return false, nil
+	}
+	if err != nil {
+		return true, fmt.Errorf("failed to query: %w", err)
+	}
+	return true, nil
+}
+
+func (s *MySQLSource) discoverExtractPartitionBounds(ctx context.Context, table string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
 	q, cleanup, err := s.querier(ctx)
 	if err != nil {
 		return source.ExtractPartitionBounds{}, err
 	}
 	defer cleanup()
 
+	if opts.IncrementalKey == "" && mysqlColumnIsNonNullable(opts.Schema, opts.ExtractPartitionBy) {
+		query := fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s", quoteColumn(opts.ExtractPartitionBy), quoteColumn(opts.ExtractPartitionBy), quoteTable(table))
+		var minValue, maxValue any
+		if err := q.QueryRowContext(ctx, query).Scan(&minValue, &maxValue); err != nil {
+			return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover extract partition bounds: %w", err)
+		}
+		if minValue == nil || maxValue == nil {
+			return source.ExtractPartitionBounds{}, nil
+		}
+		return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, 1, 1)
+	}
+
+	query := source.SQLExtractPartitionBoundsQuery(table, opts.ExtractPartitionBy, opts.IncrementalKey, opts.IncrementalKeyDataType, opts.IntervalStart, opts.IntervalEnd, quoteColumn, quoteTable, source.NativeSQLTimeFormat)
 	var minValue, maxValue any
 	var totalCount, nonNullCount int64
 	if err := q.QueryRowContext(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
 		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover extract partition bounds: %w", err)
 	}
 	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
+}
+
+func mysqlColumnIsNonNullable(tableSchema *schema.TableSchema, columnName string) bool {
+	if tableSchema == nil {
+		return false
+	}
+	for _, column := range tableSchema.Columns {
+		if strings.EqualFold(column.Name, columnName) {
+			return !column.Nullable
+		}
+	}
+	return false
 }
 
 func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -394,11 +546,12 @@ func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 		}
 		defer cleanup()
 
-		rows, err := q.QueryContext(ctx, query)
+		rows, closeStmt, err := queryRows(ctx, q, query)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to execute custom query: %w", err)}
 			return
 		}
+		defer closeStmt()
 		defer func() { _ = rows.Close() }()
 
 		colTypes, err := rows.ColumnTypes()
@@ -436,6 +589,21 @@ func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 	}()
 
 	return results, nil
+}
+
+func queryRows(ctx context.Context, q rowQuerier, query string) (*sql.Rows, func(), error) {
+	stmt, err := q.PrepareContext(ctx, query)
+	if err != nil {
+		rows, queryErr := q.QueryContext(ctx, query)
+		return rows, func() {}, queryErr
+	}
+
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		_ = stmt.Close()
+		return nil, func() {}, err
+	}
+	return rows, func() { _ = stmt.Close() }, nil
 }
 
 func parseMySQLTableName(database string, table string) (string, string) {
@@ -521,12 +689,15 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 
 	for i, field := range arrowSchema.Fields() {
 		builders[i] = array.NewBuilder(mem, field.Type)
+		if batchSize > 0 {
+			builders[i].Reserve(batchSize)
+		}
 	}
 
 	// Prepare scan destinations
 	scanDest := make([]interface{}, len(columns))
-	for i := range columns {
-		scanDest[i] = new(interface{})
+	for i, column := range columns {
+		scanDest[i] = mysqlScanDestination(column.DataType)
 	}
 
 	var rowCount int64
@@ -539,8 +710,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		}
 
 		for i, dest := range scanDest {
-			val := *dest.(*interface{})
-			arrowconv.AppendValue(builders[i], convertValue(val))
+			appendMySQLScannedValue(builders[i], dest)
 		}
 		rowCount++
 
@@ -566,6 +736,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	arrays := make([]arrow.Array, len(builders))
 	for i, b := range builders {
 		arrays[i] = b.NewArray()
+		b.Release()
 	}
 
 	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
@@ -577,11 +748,464 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	return record, rowCount, nil
 }
 
-func convertValue(val interface{}) interface{} {
-	switch v := val.(type) {
-	case []byte:
-		return string(v)
+func driverRowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, dataCapacities []int) (arrow.RecordBatch, int64, error) {
+	return driverRowsToArrowRecordBatchWithAllocator(rows, arrowSchema, columns, batchSize, dataCapacities, newMySQLArrowAllocator())
+}
+
+func driverRowsToArrowRecordBatchWithAllocator(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, dataCapacities []int, mem memory.Allocator) (arrow.RecordBatch, int64, error) {
+	builders := make([]array.Builder, len(columns))
+	for i, field := range arrowSchema.Fields() {
+		builders[i] = array.NewBuilder(mem, field.Type)
+		if batchSize > 0 {
+			builders[i].Reserve(batchSize)
+		}
+		if i < len(dataCapacities) {
+			reserveMySQLBuilderData(builders[i], dataCapacities[i])
+		}
+	}
+	releaseBuilders := func() {
+		for _, builder := range builders {
+			builder.Release()
+		}
+	}
+	appenders := make([]func(driver.Value), len(builders))
+	for i, builder := range builders {
+		appenders[i] = mysqlValueAppender(builder, batchSize > 0)
+	}
+
+	values := make([]driver.Value, len(columns))
+	var rowCount int64
+	for batchSize <= 0 || rowCount < int64(batchSize) {
+		err := rows.Next(values)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			releaseBuilders()
+			return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+		}
+		for i, value := range values {
+			appenders[i](value)
+		}
+		rowCount++
+	}
+
+	if rowCount == 0 {
+		releaseBuilders()
+		return nil, 0, nil
+	}
+
+	arrays := make([]arrow.Array, len(builders))
+	for i, builder := range builders {
+		if i < len(dataCapacities) {
+			dataCapacities[i] = mysqlBuilderDataLen(builder)
+		}
+		arrays[i] = builder.NewArray()
+		builder.Release()
+	}
+	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
+	for _, values := range arrays {
+		values.Release()
+	}
+	return record, rowCount, nil
+}
+
+func mysqlValueAppender(builder array.Builder, preallocated bool) func(driver.Value) {
+	appendFallback := func(value driver.Value) {
+		appendMySQLValue(builder, value)
+	}
+	switch b := builder.(type) {
+	case *array.BooleanBuilder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if integer, ok := value.(int64); ok {
+				appendValue(integer != 0)
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.Int8Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if integer, ok := value.(int64); ok && integer >= math.MinInt8 && integer <= math.MaxInt8 {
+				appendValue(int8(integer))
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.Int16Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if integer, ok := value.(int64); ok && integer >= math.MinInt16 && integer <= math.MaxInt16 {
+				appendValue(int16(integer))
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.Int32Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if integer, ok := value.(int64); ok && integer >= math.MinInt32 && integer <= math.MaxInt32 {
+				appendValue(int32(integer))
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.Int64Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if integer, ok := value.(int64); ok {
+				appendValue(integer)
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.Float32Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			switch number := value.(type) {
+			case nil:
+				appendNull()
+			case float32:
+				appendValue(number)
+			case float64:
+				appendValue(float32(number))
+			default:
+				appendFallback(value)
+			}
+		}
+	case *array.Float64Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			switch number := value.(type) {
+			case nil:
+				appendNull()
+			case float32:
+				appendValue(float64(number))
+			case float64:
+				appendValue(number)
+			default:
+				appendFallback(value)
+			}
+		}
+	case *array.Decimal128Builder:
+		decimalType := b.Type().(*arrow.Decimal128Type)
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+				return
+			}
+			if raw, ok := value.([]byte); ok {
+				trimmed := bytes.TrimSpace(raw)
+				if len(trimmed) == 0 {
+					appendNull()
+					return
+				}
+				if number, ok := arrowconv.ParseDecimal128BytesFast(trimmed, decimalType.Precision, decimalType.Scale); ok {
+					appendValue(number)
+					return
+				}
+			}
+			appendFallback(value)
+		}
+	case *array.Date32Builder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if date, ok := value.(time.Time); ok {
+				appendValue(arrow.Date32FromTime(date))
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.TimestampBuilder:
+		appendValue := b.Append
+		appendNull := b.AppendNull
+		if preallocated {
+			appendValue = b.UnsafeAppend
+			appendNull = func() { b.UnsafeAppendBoolToBitmap(false) }
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				appendNull()
+			} else if timestamp, ok := value.(time.Time); ok {
+				appendValue(arrow.Timestamp(timestamp.UnixMicro()))
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.StringBuilder:
+		appendBytes := b.BinaryBuilder.Append
+		if preallocated {
+			appendBytes = func(value []byte) {
+				if b.DataLen()+len(value) <= b.DataCap() {
+					b.UnsafeAppend(value)
+					return
+				}
+				b.BinaryBuilder.Append(value)
+			}
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				b.AppendNull()
+			} else if bytes, ok := value.([]byte); ok {
+				appendBytes(bytes)
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.BinaryBuilder:
+		appendBytes := b.Append
+		if preallocated {
+			appendBytes = func(value []byte) {
+				if b.DataLen()+len(value) <= b.DataCap() {
+					b.UnsafeAppend(value)
+					return
+				}
+				b.Append(value)
+			}
+		}
+		return func(value driver.Value) {
+			if value == nil {
+				b.AppendNull()
+			} else if bytes, ok := value.([]byte); ok {
+				appendBytes(bytes)
+			} else {
+				appendFallback(value)
+			}
+		}
+	case *array.ExtensionBuilder:
+		if extType, ok := b.Type().(arrow.ExtensionType); ok && extType.ExtensionName() == schema.JSONExtensionName {
+			if storage, ok := b.StorageBuilder().(*array.StringBuilder); ok {
+				appendBytes := storage.BinaryBuilder.Append
+				if preallocated {
+					appendBytes = func(value []byte) {
+						if storage.DataLen()+len(value) <= storage.DataCap() {
+							storage.UnsafeAppend(value)
+							return
+						}
+						storage.BinaryBuilder.Append(value)
+					}
+				}
+				return func(value driver.Value) {
+					if value == nil {
+						b.AppendNull()
+					} else if bytes, ok := value.([]byte); ok {
+						appendBytes(bytes)
+					} else {
+						appendFallback(value)
+					}
+				}
+			}
+		}
+	}
+	return appendFallback
+}
+
+func reserveMySQLBuilderData(builder array.Builder, capacity int) {
+	if capacity <= 0 {
+		return
+	}
+	switch b := builder.(type) {
+	case *array.StringBuilder:
+		b.ReserveData(capacity)
+	case *array.BinaryBuilder:
+		b.ReserveData(capacity)
+	case *array.ExtensionBuilder:
+		if storage, ok := b.StorageBuilder().(*array.StringBuilder); ok {
+			storage.ReserveData(capacity)
+		}
+	}
+}
+
+func mysqlBuilderDataLen(builder array.Builder) int {
+	switch b := builder.(type) {
+	case *array.StringBuilder:
+		return b.DataLen()
+	case *array.BinaryBuilder:
+		return b.DataLen()
+	case *array.ExtensionBuilder:
+		if storage, ok := b.StorageBuilder().(*array.StringBuilder); ok {
+			return storage.DataLen()
+		}
+	}
+	return 0
+}
+
+func mysqlScanDestination(dataType schema.DataType) interface{} {
+	switch dataType {
+	case schema.TypeDecimal, schema.TypeString, schema.TypeBinary, schema.TypeTime, schema.TypeJSON, schema.TypeUUID:
+		return new(sql.RawBytes)
 	default:
-		return val
+		return new(interface{})
+	}
+}
+
+func appendMySQLScannedValue(builder array.Builder, dest interface{}) {
+	if raw, ok := dest.(*sql.RawBytes); ok {
+		if *raw == nil {
+			builder.AppendNull()
+			return
+		}
+		appendMySQLBytes(builder, *raw)
+		return
+	}
+	appendMySQLValue(builder, *dest.(*interface{}))
+}
+
+func appendMySQLValue(builder array.Builder, val interface{}) {
+	if val == nil {
+		builder.AppendNull()
+		return
+	}
+
+	switch b := builder.(type) {
+	case *array.BooleanBuilder:
+		if value, ok := val.(int64); ok {
+			b.Append(value != 0)
+			return
+		}
+	case *array.Int8Builder:
+		if value, ok := val.(int64); ok {
+			if value >= math.MinInt8 && value <= math.MaxInt8 {
+				b.Append(int8(value))
+			} else {
+				b.AppendNull()
+			}
+			return
+		}
+	case *array.Int16Builder:
+		if value, ok := val.(int64); ok {
+			if value >= math.MinInt16 && value <= math.MaxInt16 {
+				b.Append(int16(value))
+			} else {
+				b.AppendNull()
+			}
+			return
+		}
+	case *array.Int32Builder:
+		if value, ok := val.(int64); ok {
+			if value >= math.MinInt32 && value <= math.MaxInt32 {
+				b.Append(int32(value))
+			} else {
+				b.AppendNull()
+			}
+			return
+		}
+	case *array.Int64Builder:
+		if value, ok := val.(int64); ok {
+			b.Append(value)
+			return
+		}
+	case *array.Float32Builder:
+		switch value := val.(type) {
+		case float32:
+			b.Append(value)
+			return
+		case float64:
+			b.Append(float32(value))
+			return
+		}
+	case *array.Float64Builder:
+		switch value := val.(type) {
+		case float32:
+			b.Append(float64(value))
+			return
+		case float64:
+			b.Append(value)
+			return
+		}
+	case *array.Date32Builder:
+		if value, ok := val.(time.Time); ok {
+			b.Append(arrow.Date32FromTime(value))
+			return
+		}
+	case *array.TimestampBuilder:
+		if value, ok := val.(time.Time); ok {
+			b.Append(arrow.Timestamp(value.UnixMicro()))
+			return
+		}
+	}
+
+	if bytes, ok := val.([]byte); ok {
+		appendMySQLBytes(builder, bytes)
+		return
+	}
+	arrowconv.AppendValue(builder, val)
+}
+
+func appendMySQLBytes(builder array.Builder, bytes []byte) {
+	switch b := builder.(type) {
+	case *array.StringBuilder:
+		b.BinaryBuilder.Append(bytes)
+	case *array.BinaryBuilder:
+		b.Append(bytes)
+	case *array.ExtensionBuilder:
+		extType, ok := b.Type().(arrow.ExtensionType)
+		storage, storageOK := b.StorageBuilder().(*array.StringBuilder)
+		if ok && storageOK && extType.ExtensionName() == schema.JSONExtensionName {
+			storage.BinaryBuilder.Append(bytes)
+			return
+		}
+		arrowconv.AppendValue(builder, string(bytes))
+	default:
+		arrowconv.AppendValue(builder, string(bytes))
 	}
 }

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -110,7 +110,7 @@ func (s *MySQLSource) Connect(ctx context.Context, uri string) error {
 	s.db = db
 	s.uri = uri
 	s.database = database
-	s.restoreGC = beginMySQLArrowGCOptimization()
+	s.replaceGCRestore(beginMySQLArrowGCOptimization())
 	return nil
 }
 
@@ -134,11 +134,15 @@ func (s *MySQLSource) Close(ctx context.Context) error {
 	if s.db != nil {
 		err = s.db.Close()
 	}
+	s.replaceGCRestore(nil)
+	return err
+}
+
+func (s *MySQLSource) replaceGCRestore(next func()) {
 	if s.restoreGC != nil {
 		s.restoreGC()
-		s.restoreGC = nil
 	}
-	return err
+	s.restoreGC = next
 }
 
 func (s *MySQLSource) HandlesIncrementality() bool {

--- a/pkg/source/mysql/mysql_test.go
+++ b/pkg/source/mysql/mysql_test.go
@@ -1,7 +1,12 @@
 package mysql
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"errors"
+	"io"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +15,36 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
+
+func TestBufferedReadConnPreservesBytes(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	want := bytes.Repeat([]byte("mysql-row-packet"), 10_000)
+	go func() {
+		for offset := 0; offset < len(want); {
+			end := min(offset+997, len(want))
+			_, _ = server.Write(want[offset:end])
+			offset = end
+		}
+		_ = server.Close()
+	}()
+
+	conn := &bufferedReadConn{
+		Conn:   client,
+		reader: bufio.NewReaderSize(client, mysqlReadBufferSize),
+	}
+	got, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("buffered connection returned %d bytes, want %d", len(got), len(want))
+	}
+}
 
 func TestIsVitessServer(t *testing.T) {
 	cases := []struct {
@@ -87,5 +122,64 @@ func TestBuildSelectQueryAddsExtractPartitionPredicate(t *testing.T) {
 	want := "SELECT `id`, `created_at` FROM `shop`.`orders` WHERE `updated_at` >= '2026-01-01 00:00:00' AND `updated_at` <= '2026-01-31 00:00:00' AND `created_at` >= '2026-01-08 00:00:00' AND `created_at` < '2026-01-15 00:00:00'"
 	if query != want {
 		t.Fatalf("query = %q, want %q", query, want)
+	}
+}
+
+func TestQueryRowsUsesPreparedStatement(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPrepare("SELECT 1").
+		WillBeClosed().
+		ExpectQuery().
+		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+
+	rows, closeStmt, err := queryRows(t.Context(), db, "SELECT 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int
+	if !rows.Next() {
+		t.Fatal("prepared query returned no rows")
+	}
+	if err := rows.Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	closeStmt()
+	if got != 1 {
+		t.Fatalf("prepared query value = %d, want 1", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQueryRowsFallsBackWhenPrepareIsUnsupported(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPrepare("SELECT 1").WillReturnError(errors.New("prepare unsupported"))
+	mock.ExpectQuery("SELECT 1").WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+
+	rows, closeStmt, err := queryRows(t.Context(), db, "SELECT 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStmt()
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		t.Fatal("fallback query returned no rows")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/source/mysql/mysql_test.go
+++ b/pkg/source/mysql/mysql_test.go
@@ -46,6 +46,24 @@ func TestBufferedReadConnPreservesBytes(t *testing.T) {
 	}
 }
 
+func TestReplaceGCRestoreReleasesPreviousLease(t *testing.T) {
+	source := NewMySQLSource()
+	firstCalls := 0
+	secondCalls := 0
+
+	source.replaceGCRestore(func() { firstCalls++ })
+	source.replaceGCRestore(func() { secondCalls++ })
+	if firstCalls != 1 || secondCalls != 0 {
+		t.Fatalf("replacing restore called first %d times and second %d times", firstCalls, secondCalls)
+	}
+
+	source.replaceGCRestore(nil)
+	source.replaceGCRestore(nil)
+	if firstCalls != 1 || secondCalls != 1 {
+		t.Fatalf("clearing restore called first %d times and second %d times", firstCalls, secondCalls)
+	}
+}
+
 func TestIsVitessServer(t *testing.T) {
 	cases := []struct {
 		version string


### PR DESCRIPTION
## Summary
- bypass database/sql row scanning for MySQL when the native driver supports direct prepared binary rows, with a safe fallback
- build Arrow values with typed appenders, reusable variable-width capacity, libc-backed buffers in CGO builds, and exact byte-decimal parsing
- stream Arrow record batches directly as PostgreSQL binary COPY and coalesce COPY transport frames
- allow opt-in full-table numeric extract partitioning to discover bounds without requiring incremental interval bounds

## Why
Large MySQL-to-PostgreSQL transfers spent most CPU in generic row scanning and conversion, per-value pgx COPY encoding, and small network writes. These changes retain the existing conversion and pgx fallback paths for unsupported values and types while optimizing common native types.

## Behavior and safety
- preserves exact decimal precision and the microsecond timestamp convention
- retains null handling and generic fallbacks
- bounds Arrow buffering and restores GC settings on close
- keeps partitioned extraction opt-in; the default command does not enable it
- includes no benchmark results or experiment artifacts

## Validation
- `make format`
- `make lint`
- `make test`
- MySQL typed appenders compared against generic conversion
- PostgreSQL direct binary encoders compared byte-for-byte with pgx
- COPY coalescing tests cover framing, flushing, malformed frames, and sticky write errors