### PR TITLE
docs: CDC guide and per-source CDC→DuckDB tutorials

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -66,6 +66,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             text: "Incremental Loading",
             link: "/getting-started/incremental-loading.md",
           },
+          {
+            text: "Change Data Capture (CDC)",
+            link: "/getting-started/cdc.md",
+          },
           { text: "Data Masking", link: "/getting-started/data-masking.md" },
           { text: "Migration Guide", link: "/getting-started/migration-to-v1.md" },
           { text: "Telemetry", link: "/getting-started/telemetry.md" },
@@ -125,13 +129,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               {
                 text: "Microsoft SQL Server",
                 link: "/supported-sources/mssql.md",
+                collapsed: true,
+                items: [
+                  { text: "CDC to DuckDB Tutorial", link: "/tutorials/cdc-sqlserver-duckdb.md" },
+                ],
               },
-              { text: "MongoDB", link: "/supported-sources/mongodb.md" },
+              {
+                text: "MongoDB",
+                link: "/supported-sources/mongodb.md",
+                collapsed: true,
+                items: [
+                  { text: "CDC to DuckDB Tutorial", link: "/tutorials/cdc-mongodb-duckdb.md" },
+                ],
+              },
               { text: "MotherDuck", link: "/supported-sources/motherduck.md" },
-              { text: "MySQL", link: "/supported-sources/mysql.md" },
+              {
+                text: "MySQL",
+                link: "/supported-sources/mysql.md",
+                collapsed: true,
+                items: [
+                  { text: "CDC to DuckDB Tutorial", link: "/tutorials/cdc-mysql-duckdb.md" },
+                ],
+              },
               { text: "Oracle", link: "/supported-sources/oracle.md" },
               { text: "PlanetScale", link: "/supported-sources/planetscale.md" },
-              { text: "Postgres", link: "/supported-sources/postgres.md" },
+              {
+                text: "Postgres",
+                link: "/supported-sources/postgres.md",
+                collapsed: true,
+                items: [
+                  { text: "CDC to DuckDB Tutorial", link: "/tutorials/cdc-postgres-duckdb.md" },
+                ],
+              },
               { text: "RabbitMQ", link: "/supported-sources/rabbitmq.md" },
               { text: "SAP Hana", link: "/supported-sources/sap-hana.md" },
               { text: "Snowflake", link: "/supported-sources/snowflake.md" },

--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -48,7 +48,7 @@ On every run after the first, a CDC connector resumes from the last durable posi
 
 ### One-shot vs. streaming
 
-By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs. Pass the `--stream` CLI flag to run continuously instead: ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery, and the `merge` strategy makes replays idempotent. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
+By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs, and the way to run MySQL CDC. Continuous streaming is available for `postgres+cdc`, `mssql+cdc`, and `mongodb+cdc`: pass the `--stream` CLI flag and ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery, and the `merge` strategy makes replays idempotent. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
 
 ### Multi-table CDC
 

--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -1,0 +1,125 @@
+---
+outline: deep
+---
+
+# Change Data Capture (CDC)
+
+Change Data Capture (CDC) is a way of ingesting data that reads a database's own change log — every insert, update, and delete — instead of repeatedly querying the tables. ingestr can capture those changes from several databases and apply them to your destination, keeping it in sync with the source without full reloads or `updated_at`-style polling.
+
+## What is CDC?
+
+Most ingestion strategies read data by *querying*: they run a `SELECT`, often filtered by an incremental key such as `updated_at`, and copy the rows they get back. That works well in many cases, but it has structural limits:
+
+- **Deletes are invisible.** A query only returns rows that still exist, so a row deleted at the source silently lingers in the destination.
+- **You need a reliable change column.** Incremental loading depends on a monotonic `updated_at`/`id` column. Not every table has one, and application bugs can leave it stale.
+- **Intermediate states are lost.** If a row changes three times between two runs, a query-based load only ever sees the final value.
+- **Repeated full scans are expensive.** Without a good incremental key, keeping a large table fresh means re-reading it.
+
+CDC solves these by reading the database's **transaction log** (or an equivalent change feed) — the same internal mechanism the database uses for replication and crash recovery. Because the log records *every* row-level operation in commit order, CDC can reproduce inserts, updates, and deletes exactly as they happened at the source.
+
+## How CDC works in ingestr
+
+Every ingestr CDC connector follows the same two-phase shape:
+
+1. **Snapshot.** On the first run, ingestr takes a consistent snapshot of each selected table and loads it into the destination. This establishes a known baseline and records the log position that corresponds to it.
+2. **Stream.** From that position onward, ingestr reads the change log and applies each insert, update, and delete to the destination. Subsequent runs resume from where the previous one left off.
+
+The snapshot-to-stream handoff is designed to be safe: changes that overlap the boundary are applied idempotently, so no data is lost or double-counted.
+
+### The `merge` strategy and metadata columns
+
+CDC runs always use the [`merge` strategy](/getting-started/incremental-loading.md#merge) so that updates and deletes can be applied by primary key — even if you pass `--incremental-strategy=replace`. Every CDC row is annotated with three metadata columns in the destination:
+
+| Column | Meaning |
+| --- | --- |
+| `_cdc_lsn` | The source log position (LSN, GTID, resume token, or version) for the change. Used to order changes and to resume on the next run. |
+| `_cdc_deleted` | `true` when the source row was deleted. Deletes are **soft**: the row is kept in the destination and flagged rather than physically removed. |
+| `_cdc_synced_at` | When ingestr applied the change to the destination. |
+
+Because a primary key is required to merge changes, **tables without a primary key (or an equivalent replica identity) are skipped** with a warning.
+
+### Deletes
+
+Deletes are captured as soft deletes: the destination keeps the row and sets `_cdc_deleted = true`. For most databases the deleted row's other columns are preserved as they were, so you retain the last known values. Some sources (SQL Server Change Tracking, PlanetScale) only emit the primary key of a deleted row, so ingestr marks the row deleted without disturbing its other columns.
+
+### Resuming and full refresh
+
+On every run after the first, a CDC connector resumes from the last durable position rather than re-snapshotting. If that saved position is no longer available in the source's log (for example, the log was truncated or retention expired), the run **fails instead of silently taking a partial snapshot**. To rebuild the destination from a fresh snapshot, run with `--full-refresh`.
+
+### One-shot vs. streaming
+
+By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs. Pass the `--stream` CLI flag to run continuously instead: ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery, and the `merge` strategy makes replays idempotent. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
+
+### Multi-table CDC
+
+If you omit `--source-table`, most CDC connectors run in multi-table mode and replicate every eligible table in the source's capture set. Each table is snapshotted and streamed from its own position; a multi-table run is not a single global point-in-time snapshot across all tables, but each table is individually consistent. Use `--dest-schema` (or `dest_schema` in the URI) to control where multi-table output lands.
+
+## Supported CDC platforms
+
+ingestr selects the CDC path through a dedicated URI scheme (usually the database scheme with a `+cdc` suffix). Each platform reads changes through the mechanism native to that database:
+
+| Platform | URI scheme(s) | Change mechanism | Docs |
+| --- | --- | --- | --- |
+| **PostgreSQL** | `postgres+cdc://`, `postgresql+cdc://` | Logical replication (WAL) | [Postgres CDC](/supported-sources/postgres.md#change-data-capture-postgrescdc) |
+| **MySQL / MariaDB** | `mysql+cdc://`, `mysql+pymysql+cdc://`, `mariadb+cdc://` | Binary log (binlog) | [MySQL CDC](/supported-sources/mysql.md#change-data-capture) |
+| **SQL Server (Change Tracking)** | `mssql+ct://`, `sqlserver+ct://`, `azuresql+ct://`, `azure-sql+ct://` | Change Tracking | [SQL Server Change Tracking](/supported-sources/mssql.md#change-tracking) |
+| **SQL Server (log-based CDC)** | `mssql+cdc://`, `sqlserver+cdc://`, `azuresql+cdc://`, `azure-sql+cdc://` | SQL Server CDC capture tables | [SQL Server CDC](/supported-sources/mssql.md#change-data-capture) |
+| **MongoDB** | `mongodb+cdc://`, `mongodb+srv+cdc://` | Change streams (oplog) | [MongoDB CDC](/supported-sources/mongodb.md#change-data-capture) |
+| **Vitess** | `vitess+cdc://` | vtgate VStream API (gRPC) | [Vitess CDC](/supported-sources/vitess.md#change-data-capture) |
+| **PlanetScale** | `ps_mysql+cdc://` | Hosted `psdbconnect` API | [PlanetScale CDC](/supported-sources/planetscale.md#change-data-capture) |
+
+Each platform has requirements and knobs specific to its change mechanism — for example PostgreSQL needs `wal_level=logical` and a `REPLICATION`-privileged user, MySQL needs `binlog_format=ROW` with `binlog_row_image=FULL`, and SQL Server Change Tracking must be enabled per database and table. Follow the platform-specific link above for exact setup, URI parameters, and privileges.
+
+### Platform notes at a glance
+
+- **PostgreSQL** reads logical replication from a publication and slot. It can manage its own `ingestr_publication` or use one you supply, tracks progress in shared state tables in the destination (not the max `_cdc_lsn` of a user table), and automatically discovers tables added after setup. `TRUNCATE` is captured as a table replacement.
+- **MySQL / MariaDB** stream the binary log after a consistent snapshot, resuming from the destination's maximum `_cdc_lsn`. Pin a unique `server_id` for scheduled or overlapping runs.
+- **SQL Server** offers two paths: lightweight **Change Tracking** (net changes since the last version, primary key required) and **log-based CDC** (full row-level change history). Both resume from `_cdc_lsn`.
+- **MongoDB** tails change streams from a replica set / Atlas cluster. Being schema-less, it uses schema inference, so the destination schema is derived from sampled documents.
+- **Vitess** streams through vtgate's VStream API because a sharded cluster has no single binlog to tail; the position is a VGTID covering every shard, so it works for sharded and unsharded keyspaces alike.
+- **PlanetScale** is managed Vitess but does not expose VStream externally, so ingestr uses PlanetScale's hosted `psdbconnect` API over TLS, authenticating with the database credentials already in the URI.
+
+## CDC vs. regular incremental loading
+
+CDC is powerful, but it is not always the right tool. Prefer CDC when:
+
+- you need **deletes** reflected in the destination,
+- your tables lack a reliable incremental key,
+- you want near-real-time sync with `--stream`, or
+- repeated full/incremental scans of large tables are too expensive.
+
+Prefer [regular incremental loading](/getting-started/incremental-loading.md) when:
+
+- the source is an API/SaaS platform or a database without a usable change log,
+- you cannot enable logical replication / binlog / Change Tracking on the source,
+- an `updated_at` column already gives you everything you need, or
+- you only need periodic batch refreshes and simplicity matters more than delete-awareness.
+
+## Example
+
+A minimal PostgreSQL CDC run into DuckDB:
+
+```bash
+ingestr ingest \
+    --source-uri "postgres+cdc://user:pass@localhost:5432/mydb?publication=my_pub" \
+    --source-table "public.users" \
+    --dest-uri "duckdb:///warehouse.duckdb" \
+    --dest-table "public.users"
+```
+
+The first run snapshots `public.users` and records the WAL position; each later run applies the inserts, updates, and deletes that happened since. Add `--stream` to keep the process running and apply changes continuously.
+
+## Hands-on tutorials
+
+Step-by-step walkthroughs that set up a source, take the initial snapshot, and capture live inserts, updates, and deletes into DuckDB:
+
+- [Replicate PostgreSQL to DuckDB with CDC](/tutorials/cdc-postgres-duckdb.md)
+- [Replicate MySQL to DuckDB with CDC](/tutorials/cdc-mysql-duckdb.md)
+- [Replicate SQL Server to DuckDB with CDC](/tutorials/cdc-sqlserver-duckdb.md)
+- [Replicate MongoDB to DuckDB with CDC](/tutorials/cdc-mongodb-duckdb.md)
+
+## See also
+
+- [Incremental Loading](/getting-started/incremental-loading.md) — write strategies, including the `merge` strategy CDC builds on.
+- [`ingest` command](/commands/ingest.md) — full CLI reference, including `--stream` and streaming flags.
+- Platform CDC docs: [Postgres](/supported-sources/postgres.md#change-data-capture-postgrescdc), [MySQL](/supported-sources/mysql.md#change-data-capture), [SQL Server](/supported-sources/mssql.md#change-data-capture), [MongoDB](/supported-sources/mongodb.md#change-data-capture), [Vitess](/supported-sources/vitess.md#change-data-capture), [PlanetScale](/supported-sources/planetscale.md#change-data-capture).

--- a/docs/supported-sources/mongodb.md
+++ b/docs/supported-sources/mongodb.md
@@ -160,6 +160,26 @@ ingestr performs several validations on custom aggregation pipelines:
 - Consider using `$limit` to restrict the number of documents processed
 - For large datasets, MongoDB's `allowDiskUse: true` option is automatically enabled for aggregation pipelines
 
+## Change data capture
+
+ingestr can keep a destination in sync with a MongoDB collection through [change streams](https://www.mongodb.com/docs/manual/changeStreams/) using the `mongodb+cdc://` and `mongodb+srv+cdc://` URI schemes.
+
+```bash
+ingestr ingest \
+  --source-uri "mongodb+cdc://user:password@localhost:27017/" \
+  --source-table "shop.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers"
+```
+
+This path reads a consistent snapshot of the collection first, then follows the change stream for inserts, updates, and deletes. It produces the `_cdc_lsn` (a change-stream resume token), `_cdc_deleted`, and `_cdc_synced_at` metadata columns and resumes from the stored token on subsequent runs. Incremental runs use the `merge` strategy so changes are applied by `_id`; deletes are soft (`_cdc_deleted = true`, and because MongoDB delete events carry only the `_id`, the row's other values are left untouched). Run with `--full-refresh` to rebuild from a fresh snapshot, or `--stream` to ingest continuously instead of once per invocation.
+
+Requirements:
+- Change streams require a **replica set** (or sharded cluster); they aren't available on a standalone `mongod`. Atlas clusters already satisfy this.
+- As a schema-less source, MongoDB CDC infers the destination schema from the documents it reads (see [schema inference](/getting-started/core-concepts.md)); nested documents and arrays land as JSON.
+
+For a full walkthrough — initializing a replica set and replicating a collection into DuckDB — see [Replicate MongoDB to DuckDB with CDC](/tutorials/cdc-mongodb-duckdb.md).
+
 ## Using MongoDB Atlas as a source
 
 MongoDB Atlas can be used as a source to extract data using the SRV connection string format.

--- a/docs/supported-sources/mssql.md
+++ b/docs/supported-sources/mssql.md
@@ -57,6 +57,31 @@ WITH (TRACK_COLUMNS_UPDATED = OFF);
 
 Change Tracking returns net row changes since the last loaded version. For inserts and updates, ingestr joins the changed primary keys back to the source table and loads the current row. For deletes, SQL Server only returns the primary key, so ingestr marks the destination row as deleted with `_cdc_deleted = true` while preserving existing destination values for other columns. If a row is updated and then deleted between two ingestr runs, Change Tracking cannot reconstruct the intermediate updated values.
 
+## Change Data Capture
+
+For full row-level change history — not just which rows changed — ingestr can read SQL Server's log-based **Change Data Capture** with the `mssql+cdc://`, `sqlserver+cdc://`, `azuresql+cdc://`, and `azure-sql+cdc://` URI schemes.
+
+```sh
+ingestr ingest \
+    --source-uri "mssql+cdc://user:password@host:1433/shop?encrypt=disable" \
+    --source-table "dbo.customers" \
+    --dest-uri "duckdb:///warehouse.duckdb" \
+    --dest-table "dbo.customers"
+```
+
+This path reads a consistent snapshot first, then reads the CDC change tables SQL Server's capture job populates from the transaction log. It produces the `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at` metadata columns and resumes from the destination table's maximum `_cdc_lsn` on subsequent runs. Incremental runs use the `merge` strategy so updates and deletes are applied by primary key; deletes are soft (`_cdc_deleted = true`). Run with `--full-refresh` to rebuild from a fresh snapshot, or `--stream` to ingest continuously instead of once per invocation.
+
+Requirements:
+- The **SQL Server Agent** must be running — it drives the capture job that copies changes from the log into the CDC tables.
+- CDC must be enabled on the database (`sys.sp_cdc_enable_db`) and on each source table (`sys.sp_cdc_enable_table`), which creates a capture instance.
+- Source tables must have a primary key.
+- The connecting user needs `SELECT` on the table and its capture instance.
+
+CDC URI parameters:
+- `capture_instance`: optional capture-instance name; defaults to the single instance registered for the table.
+
+For a full walkthrough — enabling CDC and replicating a table into DuckDB — see [Replicate SQL Server to DuckDB with CDC](/tutorials/cdc-sqlserver-duckdb.md).
+
 ## Tips & Tricks
 
 If you're using Azure SQL Server, you can use `az cli` to generate access tokens to connect to SQL server. 

--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -74,3 +74,7 @@ CDC URI parameters:
 - `flavor`: `mysql` or `mariadb`; inferred from the URI scheme unless overridden.
 
 Multi-table CDC snapshots each selected table independently and then stream each table from its own snapshot position. Each table is consistent on its own, but a multi-table run is not a single global point-in-time snapshot across all tables.
+
+### Tutorial
+
+For a step-by-step walkthrough — from enabling the binary log to capturing live inserts, updates, and deletes into DuckDB — see [Replicate MySQL to DuckDB with CDC](/tutorials/cdc-mysql-duckdb.md).

--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -42,7 +42,7 @@ Pointing a `mysql://` URI at a Vitess or PlanetScale server fails fast with a me
 ## Change data capture
 CDC uses the `mysql+cdc://`, `mysql+pymysql+cdc://`, and `mariadb+cdc://` URI schemes for standard MySQL and MariaDB, which stream the binary log. It produces the `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at` metadata columns and resumes from the destination table's maximum `_cdc_lsn` on subsequent runs. (Vitess and PlanetScale have their own CDC schemes — see [Vitess](/supported-sources/vitess.md) and [PlanetScale](/supported-sources/planetscale.md).)
 
-This path reads a consistent snapshot first, then streams the binary log, resuming from the destination table's maximum `_cdc_lsn` on subsequent runs.
+This path reads a consistent snapshot first, then streams the binary log, resuming from the destination table's maximum `_cdc_lsn` on subsequent runs. MySQL CDC runs in batch mode only: each invocation catches up and exits, so re-run it (for example on a schedule) to keep the destination up to date. The continuous `--stream` mode is not supported for MySQL.
 
 If the saved `_cdc_lsn` is invalid or no longer available in MySQL binary logs, the run fails instead of taking a partial snapshot. Run with `--full-refresh` to rebuild the destination from a fresh snapshot.
 

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -52,3 +52,7 @@ Tables created on the source after CDC has been set up are picked up automatical
 With a user-managed publication (`publication=` supplied), ingestr never alters the publication: a new table is picked up after you run `ALTER PUBLICATION ... ADD TABLE` yourself (or immediately, if the publication was created `FOR ALL TABLES`).
 
 The backfill-plus-stream handoff is safe under the `merge` strategy: changes that fall in the overlap between the snapshot and the WAL stream are applied idempotently by primary key. Tables without a primary key (or replica identity) cannot be part of logical replication and are skipped with a warning.
+
+### Tutorial
+
+For a step-by-step walkthrough — from enabling logical replication to streaming live inserts, updates, and deletes into DuckDB — see [Replicate PostgreSQL to DuckDB with CDC](/tutorials/cdc-postgres-duckdb.md).

--- a/docs/tutorials/cdc-mongodb-duckdb.md
+++ b/docs/tutorials/cdc-mongodb-duckdb.md
@@ -1,0 +1,110 @@
+# Replicate MongoDB to DuckDB with CDC
+
+This walkthrough takes you from a running MongoDB deployment to a DuckDB file kept in sync through [Change Data Capture](/getting-started/cdc.md): an initial snapshot of a collection, then inserts, updates, and deletes picked up by re-running ingestr. It assumes you already have a MongoDB deployment you can connect to and [ingestr installed](/getting-started/quickstart.md#installation).
+
+## 1. Prepare the source
+
+MongoDB CDC reads [change streams](https://www.mongodb.com/docs/manual/changeStreams/), which are only available on a **replica set** (or a sharded cluster) — they don't work against a standalone `mongod`. MongoDB Atlas clusters are replica sets already. For a self-managed server, start it with `--replSet` and initialize the set once:
+
+```javascript
+// in mongosh, connected to the server
+rs.initiate();
+```
+
+MongoDB is schema-less, so ingestr infers the destination schema from the documents it reads. We'll replicate a `customers` collection in a `shop` database. Insert a few documents to follow along:
+
+```javascript
+use shop;
+db.customers.insertMany([
+  { _id: 1, name: "Alice", email: "alice@example.com" },
+  { _id: 2, name: "Bob",   email: "bob@example.com" },
+  { _id: 3, name: "Carol", email: "carol@example.com" }
+]);
+```
+
+## 2. Run the initial load
+
+Run ingestr with the `mongodb+cdc://` scheme. The source table is addressed as `database.collection`:
+
+```bash
+ingestr ingest \
+  --source-uri "mongodb+cdc://user:password@localhost:27017/" \
+  --source-table "shop.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers"
+```
+
+> Use `mongodb+srv+cdc://` instead for an Atlas / SRV connection string. If you connect to a single-node replica set through a mapped port (common in local Docker setups), add `?directConnection=true` so the driver talks to that node directly instead of trying to reach the set's advertised member address.
+
+The run snapshots the collection, records a change-stream resume position, and exits. Inspect the result:
+
+```bash
+duckdb warehouse.duckdb "SELECT _id, name, email, _cdc_deleted FROM shop.customers ORDER BY _id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  _id  │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@example.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ false        │
+│     3 │ Carol   │ carol@example.com │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+The document's `_id` becomes the primary key. Alongside your fields, ingestr adds the CDC metadata columns `_cdc_lsn` (a change-stream resume token), `_cdc_deleted`, and `_cdc_synced_at`.
+
+## 3. Capture ongoing changes
+
+Change the source:
+
+```javascript
+db.customers.insertOne({ _id: 4, name: "Dave", email: "dave@example.com" });
+db.customers.updateOne({ _id: 1 }, { $set: { email: "alice@newmail.com" } });
+db.customers.deleteOne({ _id: 2 });
+```
+
+Now run **exactly the same command again**. Instead of re-snapshotting, ingestr resumes the change stream from the token stored in the destination and applies only what changed:
+
+```bash
+ingestr ingest \
+  --source-uri "mongodb+cdc://user:password@localhost:27017/" \
+  --source-table "shop.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers"
+```
+
+```bash
+duckdb warehouse.duckdb "SELECT _id, name, email, _cdc_deleted FROM shop.customers ORDER BY _id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  _id  │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@newmail.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ true         │
+│     3 │ Carol   │ carol@example.com │ false        │
+│     4 │ Dave    │ dave@example.com  │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+The insert and update are applied, and the delete is a **soft delete**: `_id = 2` stays in DuckDB with `_cdc_deleted = true`. MongoDB delete events carry only the `_id`, so ingestr marks the row deleted while preserving the values it already has. Filter deleted rows out at query time with `WHERE _cdc_deleted = false`. Schedule this same command (for example with cron) to keep the destination up to date, or add `--stream` to run continuously instead of once per invocation.
+
+## 4. Start over if needed
+
+To discard the destination state and rebuild from a fresh snapshot, add `--full-refresh`:
+
+```bash
+ingestr ingest \
+  --source-uri "mongodb+cdc://user:password@localhost:27017/" \
+  --source-table "shop.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers" \
+  --full-refresh
+```
+
+## See also
+
+- [Change Data Capture](/getting-started/cdc.md) — how CDC works across ingestr, and the other supported platforms.
+- [MongoDB source reference](/supported-sources/mongodb.md) — connection formats, source-table syntax, and aggregations.

--- a/docs/tutorials/cdc-mysql-duckdb.md
+++ b/docs/tutorials/cdc-mysql-duckdb.md
@@ -1,0 +1,124 @@
+# Replicate MySQL to DuckDB with CDC
+
+This walkthrough takes you from a running MySQL database to a DuckDB file kept in sync through [Change Data Capture](/getting-started/cdc.md): an initial snapshot, then inserts, updates, and deletes picked up by re-running ingestr. It assumes you already have a MySQL server you can connect to and [ingestr installed](/getting-started/quickstart.md#installation).
+
+For the full reference on the connector's options, see [MySQL → Change data capture](/supported-sources/mysql.md#change-data-capture).
+
+## 1. Prepare the source
+
+MySQL CDC reads the binary log, so it must be enabled in `ROW` format with full row images. Check the current settings:
+
+```sql
+SELECT @@log_bin, @@binlog_format, @@binlog_row_image;
+```
+
+You want `@@log_bin = 1`, `@@binlog_format = ROW`, and `@@binlog_row_image = FULL`. On MySQL 8.0 these are the defaults; if not, set them in your server config (`log_bin`, `binlog_format=ROW`, `binlog_row_image=FULL`) and restart.
+
+The connecting user needs read access plus replication privileges. A dedicated user is straightforward:
+
+```sql
+CREATE USER 'ingestr_cdc'@'%' IDENTIFIED BY 'cdcpass';
+GRANT SELECT, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'ingestr_cdc'@'%';
+FLUSH PRIVILEGES;
+```
+
+`SELECT` and `RELOAD` cover the consistent initial snapshot; `REPLICATION SLAVE` and `REPLICATION CLIENT` cover streaming the binary log.
+
+We'll replicate a small `customers` table. Create one to follow along (or point the commands at a table of your own — it just needs a primary key):
+
+```sql
+CREATE TABLE customers (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(100) NOT NULL,
+    email VARCHAR(255)
+);
+INSERT INTO customers (id, name, email) VALUES
+    (1, 'Alice', 'alice@example.com'),
+    (2, 'Bob',   'bob@example.com'),
+    (3, 'Carol', 'carol@example.com');
+```
+
+## 2. Run the initial load
+
+Run ingestr with the `mysql+cdc://` scheme to take the initial snapshot into DuckDB. Pin a unique `server_id` so the connector has a stable replication identity:
+
+```bash
+ingestr ingest \
+  --source-uri "mysql+cdc://ingestr_cdc:cdcpass@localhost:3306/shop?server_id=1001" \
+  --source-table "customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers"
+```
+
+The run snapshots the table, records its binary-log position, and exits. Inspect the result:
+
+```bash
+duckdb warehouse.duckdb "SELECT id, name, email, _cdc_deleted FROM shop.customers ORDER BY id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  id   │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@example.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ false        │
+│     3 │ Carol   │ carol@example.com │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+Alongside your columns, ingestr adds the CDC metadata columns `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at`.
+
+## 3. Capture ongoing changes
+
+Change the source:
+
+```sql
+INSERT INTO customers (id, name, email) VALUES (4, 'Dave', 'dave@example.com');
+UPDATE customers SET email = 'alice@newmail.com' WHERE id = 1;
+DELETE FROM customers WHERE id = 2;
+```
+
+Now run **exactly the same command again**. Instead of re-snapshotting, ingestr resumes from the binary-log position stored in the destination's maximum `_cdc_lsn` and applies only what changed:
+
+```bash
+ingestr ingest \
+  --source-uri "mysql+cdc://ingestr_cdc:cdcpass@localhost:3306/shop?server_id=1001" \
+  --source-table "customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers"
+```
+
+```bash
+duckdb warehouse.duckdb "SELECT id, name, email, _cdc_deleted FROM shop.customers ORDER BY id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  id   │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@newmail.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ true         │
+│     3 │ Carol   │ carol@example.com │ false        │
+│     4 │ Dave    │ dave@example.com  │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+The insert and update are applied, and the delete is a **soft delete**: `id = 2` stays in DuckDB with `_cdc_deleted = true` and its last known values intact. Filter it out at query time with `WHERE _cdc_deleted = false`. Schedule this same command (for example with cron) to keep the destination continuously up to date; each run picks up where the previous one stopped.
+
+## 4. Start over if needed
+
+If the saved position is no longer available in MySQL's binary logs (for example the logs were purged), the run fails rather than taking a partial snapshot. To discard the destination state and rebuild from a fresh snapshot, add `--full-refresh`:
+
+```bash
+ingestr ingest \
+  --source-uri "mysql+cdc://ingestr_cdc:cdcpass@localhost:3306/shop?server_id=1001" \
+  --source-table "customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "shop.customers" \
+  --full-refresh
+```
+
+## See also
+
+- [Change Data Capture](/getting-started/cdc.md) — how CDC works across ingestr, and the other supported platforms.
+- [MySQL source reference](/supported-sources/mysql.md) — all URI parameters, requirements, and CDC internals.

--- a/docs/tutorials/cdc-postgres-duckdb.md
+++ b/docs/tutorials/cdc-postgres-duckdb.md
@@ -1,0 +1,145 @@
+# Replicate PostgreSQL to DuckDB with CDC
+
+This walkthrough takes you from a running PostgreSQL database to a DuckDB file that stays in sync through [Change Data Capture](/getting-started/cdc.md): an initial snapshot, then live inserts, updates, and deletes. It assumes you already have a PostgreSQL server you can connect to and [ingestr installed](/getting-started/quickstart.md#installation).
+
+For the full reference on the connector's options, see [Postgres → Change Data Capture](/supported-sources/postgres.md#change-data-capture-postgres-cdc).
+
+## 1. Prepare the source
+
+Logical replication must be enabled. Check the current setting:
+
+```sql
+SHOW wal_level;   -- must return "logical"
+```
+
+If it returns `replica` (the default), set `wal_level = logical` in `postgresql.conf` (along with enough `max_wal_senders` and `max_replication_slots`, e.g. `10` each) and **restart** the server — this parameter cannot be changed at runtime.
+
+The connecting user needs the `REPLICATION` attribute. Using an admin/superuser is the simplest option for a first run; ingestr will then create and manage its own publication automatically. For a least-privilege setup, see [Using a dedicated replication user](#using-a-dedicated-replication-user) below.
+
+We'll replicate a small `customers` table. Create one to follow along (or point the commands at a table of your own — it just needs a primary key):
+
+```sql
+CREATE TABLE public.customers (
+    id    INTEGER PRIMARY KEY,
+    name  TEXT NOT NULL,
+    email TEXT
+);
+INSERT INTO public.customers (id, name, email) VALUES
+    (1, 'Alice', 'alice@example.com'),
+    (2, 'Bob',   'bob@example.com'),
+    (3, 'Carol', 'carol@example.com');
+```
+
+## 2. Run the initial load
+
+Run ingestr once to take the initial snapshot into DuckDB. The `postgres+cdc://` scheme selects the CDC path:
+
+```bash
+ingestr ingest \
+  --source-uri "postgres+cdc://user:password@localhost:5432/shop?sslmode=disable" \
+  --source-table "public.customers" \
+  --dest-uri "duckdb:///shop.duckdb" \
+  --dest-table "public.customers"
+```
+
+By default the run snapshots the table, catches up to the current WAL position, and exits. Inspect the result:
+
+```bash
+duckdb shop.duckdb "SELECT id, name, email, _cdc_deleted FROM public.customers ORDER BY id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  id   │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@example.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ false        │
+│     3 │ Carol   │ carol@example.com │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+Alongside your columns, ingestr adds the CDC metadata columns `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at`.
+
+## 3. Capture ongoing changes
+
+To keep the destination in sync continuously, run the same command with `--stream`. The process snapshots first (if needed) and then tails the WAL, flushing changes on the `--flush-interval`, until you stop it with `Ctrl+C`:
+
+```bash
+ingestr ingest \
+  --source-uri "postgres+cdc://user:password@localhost:5432/shop?sslmode=disable" \
+  --source-table "public.customers" \
+  --dest-uri "duckdb:///shop.duckdb" \
+  --dest-table "public.customers" \
+  --stream --flush-interval 2s
+```
+
+Leave it running and, from another session, change the source:
+
+```sql
+INSERT INTO public.customers (id, name, email) VALUES (4, 'Dave', 'dave@example.com');
+UPDATE public.customers SET email = 'alice@newmail.com' WHERE id = 1;
+DELETE FROM public.customers WHERE id = 2;
+```
+
+Within a few seconds the stream reports a flush cycle. Stop it with `Ctrl+C` (`Streaming ingestion stopped.`) and re-inspect the destination:
+
+```bash
+duckdb shop.duckdb "SELECT id, name, email, _cdc_deleted FROM public.customers ORDER BY id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  id   │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@newmail.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ true         │
+│     3 │ Carol   │ carol@example.com │ false        │
+│     4 │ Dave    │ dave@example.com  │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+The insert and update are applied, and the delete is a **soft delete**: `id = 2` stays in DuckDB with `_cdc_deleted = true` and its last known values intact. Filter it out at query time with `WHERE _cdc_deleted = false`.
+
+> Prefer scheduled batch syncs over a long-running process? Run the command **without** `--stream` on a cron schedule — each run catches up to the current WAL position and exits.
+
+## 4. Start over if needed
+
+To discard the destination state and rebuild from a fresh snapshot, add `--full-refresh`:
+
+```bash
+ingestr ingest \
+  --source-uri "postgres+cdc://user:password@localhost:5432/shop?sslmode=disable" \
+  --source-table "public.customers" \
+  --dest-uri "duckdb:///shop.duckdb" \
+  --dest-table "public.customers" \
+  --full-refresh
+```
+
+## Using a dedicated replication user
+
+Instead of an admin user, you can run CDC as a least-privilege role. It needs `REPLICATION` and `SELECT` on the tables, plus a publication created ahead of time (a non-owner cannot create one). As an admin:
+
+```sql
+CREATE ROLE ingestr_cdc WITH LOGIN PASSWORD 'cdcpass' REPLICATION;
+GRANT USAGE ON SCHEMA public TO ingestr_cdc;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO ingestr_cdc;
+CREATE PUBLICATION ingestr_pub FOR TABLE public.customers;
+```
+
+Then point ingestr at that publication with the `publication` URI parameter:
+
+```bash
+ingestr ingest \
+  --source-uri "postgres+cdc://ingestr_cdc:cdcpass@localhost:5432/shop?sslmode=disable&publication=ingestr_pub" \
+  --source-table "public.customers" \
+  --dest-uri "duckdb:///shop.duckdb" \
+  --dest-table "public.customers"
+```
+
+To add more tables later, extend the publication yourself with `ALTER PUBLICATION ingestr_pub ADD TABLE ...`.
+
+## See also
+
+- [Change Data Capture](/getting-started/cdc.md) — how CDC works across ingestr, and the other supported platforms.
+- [Postgres source reference](/supported-sources/postgres.md) — all URI parameters and CDC internals.
+- [`ingest` command](/commands/ingest.md#streaming-ingestion) — streaming flags and monitoring.

--- a/docs/tutorials/cdc-postgres-duckdb.md
+++ b/docs/tutorials/cdc-postgres-duckdb.md
@@ -2,7 +2,7 @@
 
 This walkthrough takes you from a running PostgreSQL database to a DuckDB file that stays in sync through [Change Data Capture](/getting-started/cdc.md): an initial snapshot, then live inserts, updates, and deletes. It assumes you already have a PostgreSQL server you can connect to and [ingestr installed](/getting-started/quickstart.md#installation).
 
-For the full reference on the connector's options, see [Postgres → Change Data Capture](/supported-sources/postgres.md#change-data-capture-postgres-cdc).
+For the full reference on the connector's options, see [Postgres → Change Data Capture](/supported-sources/postgres.md#change-data-capture-postgrescdc).
 
 ## 1. Prepare the source
 

--- a/docs/tutorials/cdc-sqlserver-duckdb.md
+++ b/docs/tutorials/cdc-sqlserver-duckdb.md
@@ -1,0 +1,122 @@
+# Replicate SQL Server to DuckDB with CDC
+
+This walkthrough takes you from a running SQL Server database to a DuckDB file kept in sync through [Change Data Capture](/getting-started/cdc.md): an initial snapshot, then inserts, updates, and deletes picked up by re-running ingestr. It assumes you already have a SQL Server instance you can connect to and [ingestr installed](/getting-started/quickstart.md#installation).
+
+This tutorial uses SQL Server's **log-based CDC** (the `mssql+cdc://` scheme). SQL Server also offers a lighter-weight [Change Tracking](/supported-sources/mssql.md#change-tracking) path (`mssql+ct://`) if you only need to know which rows changed.
+
+## 1. Prepare the source
+
+Log-based CDC is driven by the SQL Server Agent, so the Agent must be running on your instance. Then enable CDC at the database level and on the table you want to replicate. Connect as an administrator (`sysadmin`) and run:
+
+```sql
+-- enable CDC for the database
+USE shop;
+EXEC sys.sp_cdc_enable_db;
+
+-- our demo table (any table with a primary key works)
+CREATE TABLE dbo.customers (
+    id    INT PRIMARY KEY,
+    name  NVARCHAR(100) NOT NULL,
+    email NVARCHAR(255)
+);
+
+-- enable CDC for the table; this creates the capture instance "dbo_customers"
+EXEC sys.sp_cdc_enable_table
+    @source_schema = 'dbo',
+    @source_name   = 'customers',
+    @role_name     = NULL;
+
+INSERT INTO dbo.customers (id, name, email) VALUES
+    (1, 'Alice', 'alice@example.com'),
+    (2, 'Bob',   'bob@example.com'),
+    (3, 'Carol', 'carol@example.com');
+```
+
+`sp_cdc_enable_table` starts the capture and cleanup jobs; you can confirm the capture instance with `SELECT capture_instance FROM cdc.change_tables;`. The user ingestr connects as needs `SELECT` on the table (and on the `cdc` schema, which `@role_name = NULL` leaves ungated).
+
+## 2. Run the initial load
+
+Run ingestr with the `mssql+cdc://` scheme to take the initial snapshot into DuckDB:
+
+```bash
+ingestr ingest \
+  --source-uri "mssql+cdc://user:password@localhost:1433/shop?encrypt=disable" \
+  --source-table "dbo.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "dbo.customers"
+```
+
+If your password contains URL-reserved characters (like `!` or `@`), percent-encode them in the URI (`!` → `%21`). The `encrypt=disable` parameter is fine for a local instance; drop it (or set the appropriate encryption options) when connecting to a server that requires TLS.
+
+The run snapshots the table, records its log position, and exits. Inspect the result:
+
+```bash
+duckdb warehouse.duckdb "SELECT id, name, email, _cdc_deleted FROM dbo.customers ORDER BY id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  id   │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@example.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ false        │
+│     3 │ Carol   │ carol@example.com │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+Alongside your columns, ingestr adds the CDC metadata columns `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at`.
+
+## 3. Capture ongoing changes
+
+Change the source:
+
+```sql
+INSERT INTO dbo.customers (id, name, email) VALUES (4, 'Dave', 'dave@example.com');
+UPDATE dbo.customers SET email = 'alice@newmail.com' WHERE id = 1;
+DELETE FROM dbo.customers WHERE id = 2;
+```
+
+SQL Server's capture job scans the transaction log on an interval (a few seconds by default), so give it a moment to record the changes into the CDC tables. Then run **exactly the same command again** — ingestr resumes from the log position stored in the destination's maximum `_cdc_lsn` and applies only what changed:
+
+```bash
+ingestr ingest \
+  --source-uri "mssql+cdc://user:password@localhost:1433/shop?encrypt=disable" \
+  --source-table "dbo.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "dbo.customers"
+```
+
+```bash
+duckdb warehouse.duckdb "SELECT id, name, email, _cdc_deleted FROM dbo.customers ORDER BY id;"
+```
+
+```plaintext
+┌───────┬─────────┬───────────────────┬──────────────┐
+│  id   │  name   │       email       │ _cdc_deleted │
+├───────┼─────────┼───────────────────┼──────────────┤
+│     1 │ Alice   │ alice@newmail.com │ false        │
+│     2 │ Bob     │ bob@example.com   │ true         │
+│     3 │ Carol   │ carol@example.com │ false        │
+│     4 │ Dave    │ dave@example.com  │ false        │
+└───────┴─────────┴───────────────────┴──────────────┘
+```
+
+The insert and update are applied, and the delete is a **soft delete**: `id = 2` stays in DuckDB with `_cdc_deleted = true` and its last known values intact. Filter it out at query time with `WHERE _cdc_deleted = false`. Schedule this same command (for example with cron) to keep the destination up to date, or add `--stream` to run continuously instead of once per invocation.
+
+## 4. Start over if needed
+
+To discard the destination state and rebuild from a fresh snapshot, add `--full-refresh`:
+
+```bash
+ingestr ingest \
+  --source-uri "mssql+cdc://user:password@localhost:1433/shop?encrypt=disable" \
+  --source-table "dbo.customers" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "dbo.customers" \
+  --full-refresh
+```
+
+## See also
+
+- [Change Data Capture](/getting-started/cdc.md) — how CDC works across ingestr, and the other supported platforms.
+- [SQL Server source reference](/supported-sources/mssql.md) — Change Tracking, log-based CDC, and connection options.


### PR DESCRIPTION
## What
Documents ingestr's Change Data Capture support: a concept page on how CDC works, plus hands-on tutorials for replicating PostgreSQL, MySQL, SQL Server, and MongoDB into DuckDB. It also fills gaps in the SQL Server and MongoDB source references, which had no log-based CDC / change-stream docs before.

## Changes
- `docs/getting-started/cdc.md`: new CDC concept page (what it is, how it works, supported platforms).
- `docs/tutorials/cdc-{postgres,mysql,sqlserver,mongodb}-duckdb.md`: four step-by-step CDC→DuckDB tutorials.
- `docs/supported-sources/{mssql,mongodb}.md`: document log-based CDC (`mssql+cdc`) and change streams (`mongodb+cdc`).
- `docs/supported-sources/{postgres,mysql}.md`: link the tutorials from their CDC sections.
- `docs/.vitepress/config.mjs`: sidebar entries for the CDC page and each tutorial nested under its source.

## How to test
1. `npm run docs:build` — builds clean with no dead links.
2. Every command in the tutorials was run end-to-end against local Postgres/MySQL/SQL Server/MongoDB containers into DuckDB.

## Risk & rollback
- **Risk:** low — docs only, no code changes.
- **Rollback:** Revert the merge commit.

## Checklist
- [ ] Unit tests added or updated (`make test`) — N/A, docs only
- [x] Format and lint pass (`npm run docs:build`)
- [ ] Integration tests pass if affected — N/A
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
