### PR TITLE
test(integration): filter which backends run to skip Docker setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ comma := ,
 #   make test-conformance-only BACKENDS=snowflake
 #   make test-conformance-only BACKENDS=snowflake,postgres
 test-conformance-only:
+	@if [ -z "$(BACKENDS)" ]; then echo "$(ERROR_COLOR)==> BACKENDS is required, e.g. make test-conformance-only BACKENDS=snowflake$(NO_COLOR)"; exit 1; fi
 	@echo "$(OK_COLOR)==> Running destination standards tests for: $(BACKENDS)$(NO_COLOR)"
 	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) \
 		INTEGRATION_BACKENDS=$(BACKENDS) go test -tags integration -v -timeout 15m ./tests/integration \

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,18 @@ test-conformance:
 	@echo "$(OK_COLOR)==> Running destination standards tests$(NO_COLOR)"
 	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -timeout 10m ./tests/integration -run TestDestinations_
 
+comma := ,
+# Run destination conformance for only the given backend(s), skipping the Docker
+# setup for every other backend. Backends with no container (snowflake, bigquery)
+# need no Docker at all. Comma-separate for multiple. Examples:
+#   make test-conformance-only BACKENDS=snowflake
+#   make test-conformance-only BACKENDS=snowflake,postgres
+test-conformance-only:
+	@echo "$(OK_COLOR)==> Running destination standards tests for: $(BACKENDS)$(NO_COLOR)"
+	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) \
+		INTEGRATION_BACKENDS=$(BACKENDS) go test -tags integration -v -timeout 15m ./tests/integration \
+		-run 'TestDestinations_.*/($(subst $(comma),|,$(BACKENDS)))'
+
 
 # Format code and run linters (for local development)
 format: generate

--- a/tests/integration/testenv_postgres_test.go
+++ b/tests/integration/testenv_postgres_test.go
@@ -6,12 +6,43 @@ import (
 	"context"
 	"flag"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/bruin-data/ingestr/internal/testutil"
 	"github.com/testcontainers/testcontainers-go"
 )
+
+var containerBackends = []string{
+	"postgres", "clickhouse", "mysql", "mssql", "oracle",
+	"cratedb", "maxcompute", "minio", "dynamodb", "cassandra", "rabbitmq", "mqtt",
+}
+
+// containerWanted reports whether the shared container for the given backend
+// should be started.
+func containerWanted(name string) bool {
+	v := strings.TrimSpace(os.Getenv("INTEGRATION_BACKENDS"))
+	if v == "" {
+		return true
+	}
+	for _, b := range strings.Split(v, ",") {
+		if strings.EqualFold(strings.TrimSpace(b), name) {
+			return true
+		}
+	}
+	return false
+}
+
+// anyContainerWanted reports whether any container-backed backend is requested.
+func anyContainerWanted() bool {
+	for _, name := range containerBackends {
+		if containerWanted(name) {
+			return true
+		}
+	}
+	return false
+}
 
 // Shared Postgres containers for integration tests.
 // Starting containers once avoids slow per-test startup.
@@ -79,7 +110,7 @@ func TestMain(m *testing.M) {
 
 	ctx := context.Background()
 
-	if !testutil.DockerProviderHealthy(ctx) {
+	if anyContainerWanted() && !testutil.DockerProviderHealthy(ctx) {
 		// Treat as a skip: these tests require Docker (testcontainers).
 		_, _ = os.Stderr.WriteString("skipping integration tests: Docker provider is not available/healthy\n")
 		os.Exit(0)
@@ -90,36 +121,54 @@ func TestMain(m *testing.M) {
 	wg.Add(11)
 	go func() {
 		defer wg.Done()
+		if !containerWanted("postgres") {
+			return
+		}
 		if c, uri, err := startPostgresContainerForMain(ctx, "shared-source"); err == nil {
 			pgSource = postgresEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("postgres") {
+			return
+		}
 		if c, uri, err := startPostgresContainerForMain(ctx, "shared-dest"); err == nil {
 			pgDest = postgresEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("clickhouse") {
+			return
+		}
 		if c, uri, err := startClickHouseContainerForMain(ctx, "shared-clickhouse"); err == nil {
 			chDest = clickhouseEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("mysql") {
+			return
+		}
 		if c, uri, err := startMySQLContainerForMain(ctx, "shared-mysql"); err == nil {
 			mysqlDest = mysqlEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("mssql") {
+			return
+		}
 		if c, uri, err := startMSSQLContainerForMain(ctx, "shared-mssql"); err == nil {
 			mssqlDest = mssqlEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("oracle") {
+			return
+		}
 		if uri := os.Getenv("GONG_TEST_ORACLE_URI"); uri != "" {
 			oracleDest = oracleEnv{uri: uri}
 			return
@@ -130,30 +179,45 @@ func TestMain(m *testing.M) {
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("cratedb") {
+			return
+		}
 		if c, uri, err := startCrateDBContainerForMain(ctx, "shared-cratedb"); err == nil {
 			cratedbDest = cratedbEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("maxcompute") {
+			return
+		}
 		if c, uri, dbPath, err := startMaxComputeContainerForMain(ctx, "shared-maxcompute"); err == nil {
 			maxcomputeDest = maxcomputeEnv{container: c, uri: uri, dbPath: dbPath}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("minio") {
+			return
+		}
 		if c, endpoint, uri, err := startMinioContainerForMain(ctx); err == nil {
 			minioShared = minioEnv{container: c, endpoint: endpoint, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("dynamodb") {
+			return
+		}
 		if c, uri, err := startDynamoDBContainerForMain(ctx); err == nil {
 			dynamoDBDest = dynamoDBEnv{container: c, uri: uri}
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		if !containerWanted("cassandra") {
+			return
+		}
 		if c, uri, host, port, err := startCassandraContainerForMain(ctx); err == nil {
 			cassandraShared = cassandraEnv{container: c, uri: uri, host: host, port: port}
 		}
@@ -161,14 +225,18 @@ func TestMain(m *testing.M) {
 	wg.Wait()
 
 	// Start RabbitMQ container
-	rmqC, rmqURI, rmqErr := startRabbitMQContainerForMain(ctx)
-	if rmqErr == nil {
-		rabbitmqShared = rabbitmqEnv{container: rmqC, uri: rmqURI}
+	if containerWanted("rabbitmq") {
+		rmqC, rmqURI, rmqErr := startRabbitMQContainerForMain(ctx)
+		if rmqErr == nil {
+			rabbitmqShared = rabbitmqEnv{container: rmqC, uri: rmqURI}
+		}
 	}
 
-	mqttC, mqttURI, mqttErr := startMQTTContainerForMain(ctx)
-	if mqttErr == nil {
-		mqttShared = mqttEnv{container: mqttC, uri: mqttURI}
+	if containerWanted("mqtt") {
+		mqttC, mqttURI, mqttErr := startMQTTContainerForMain(ctx)
+		if mqttErr == nil {
+			mqttShared = mqttEnv{container: mqttC, uri: mqttURI}
+		}
 	}
 
 	code := m.Run()


### PR DESCRIPTION
`TestMain` starts every shared testcontainer regardless of the `-run` filter, so a single-backend conformance run (e.g. `snowflake`, which needs no container) pays the full Docker startup cost and fails when Docker is down. This adds an `INTEGRATION_BACKENDS` env var (comma-separated) so only the listed backends' containers start, and skips the Docker health check entirely when none are container-backed. 