### PR TITLE
fix(kafka): make batch _kafka_msg_id unique per message

### DIFF
--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -530,7 +530,7 @@ func messageToItem(msg kafkago.Message) map[string]interface{} {
 		"data": string(msg.Value),
 	}
 
-	msgID := generateMsgID(msg.Topic, msg.Partition, msg.Offset, keyStr)
+	msgID := physicalMsgID(msg.Topic, msg.Partition, msg.Offset)
 
 	return map[string]interface{}{
 		"_kafka":        kafkaMeta,
@@ -577,17 +577,33 @@ func messageToEnvelope(msg kafkago.Message) map[string]interface{} {
 // redeliveries, so at-least-once dedup still works.
 func streamMsgID(msg kafkago.Message) string {
 	if len(msg.Key) > 0 {
-		return generateMsgID(msg.Topic, msg.Partition, msg.Offset, string(msg.Key))
+		return keyedMsgID(msg.Topic, msg.Partition, string(msg.Key))
 	}
-	return fmt.Sprintf("%s:%d:%d", msg.Topic, msg.Partition, msg.Offset)
+	// Same (topic, partition, offset) identity as physicalMsgID, but kept as the
+	// raw plaintext form — frozen for backward compatibility with already-persisted
+	// keyless msg_id primary keys, not an intentional design difference. Do not
+	// switch to shake128ID: that would rotate every persisted keyless id.
+	return msg.Topic + ":" + strconv.Itoa(msg.Partition) + ":" + strconv.FormatInt(msg.Offset, 10)
 }
 
-func generateMsgID(topic string, partition int, offset int64, key interface{}) string {
-	keyStr := "None"
-	if key != nil {
-		keyStr = fmt.Sprintf("%v", key)
-	}
-	input := fmt.Sprintf("%s%d%s", topic, partition, keyStr)
+// physicalMsgID identifies a single physical message by its unique coordinate
+// (topic, partition, offset). Used for the batch _kafka_msg_id, where every
+// message — keyed or keyless — must get a distinct id.
+func physicalMsgID(topic string, partition int, offset int64) string {
+	return shake128ID(topic + strconv.Itoa(partition) + strconv.FormatInt(offset, 10))
+}
+
+// keyedMsgID identifies a message by its key (topic, partition, key), offset
+// deliberately excluded so redeliveries and updates for a key share one id.
+// Used by the streaming envelope's keyed branch for last-value-per-key
+// (changelog/compaction) merge semantics.
+func keyedMsgID(topic string, partition int, key string) string {
+	return shake128ID(topic + strconv.Itoa(partition) + key)
+}
+
+// shake128ID returns a Python-compatible SHAKE-128 digest of input: 15 bytes
+// base64-encoded without padding (20 chars).
+func shake128ID(input string) string {
 	h := sha3.NewShake128()
 	h.Write([]byte(input))
 	digest := make([]byte, 15)

--- a/pkg/source/kafka/kafka.go
+++ b/pkg/source/kafka/kafka.go
@@ -579,18 +579,26 @@ func streamMsgID(msg kafkago.Message) string {
 	if len(msg.Key) > 0 {
 		return keyedMsgID(msg.Topic, msg.Partition, string(msg.Key))
 	}
-	// Same (topic, partition, offset) identity as physicalMsgID, but kept as the
-	// raw plaintext form — frozen for backward compatibility with already-persisted
+	// Same physicalCoordinate identity as physicalMsgID, but kept as the raw
+	// plaintext form — frozen for backward compatibility with already-persisted
 	// keyless msg_id primary keys, not an intentional design difference. Do not
 	// switch to shake128ID: that would rotate every persisted keyless id.
-	return msg.Topic + ":" + strconv.Itoa(msg.Partition) + ":" + strconv.FormatInt(msg.Offset, 10)
+	return physicalCoordinate(msg.Topic, msg.Partition, msg.Offset)
+}
+
+// physicalCoordinate is the unique location of a message within a topic. The
+// colon separators keep the encoding injective — Kafka topic names cannot
+// contain ':', so no (topic, partition, offset) tuple can alias another (e.g.
+// partition 1/offset 10 vs partition 11/offset 0 both resolving to "110").
+func physicalCoordinate(topic string, partition int, offset int64) string {
+	return topic + ":" + strconv.Itoa(partition) + ":" + strconv.FormatInt(offset, 10)
 }
 
 // physicalMsgID identifies a single physical message by its unique coordinate
 // (topic, partition, offset). Used for the batch _kafka_msg_id, where every
 // message — keyed or keyless — must get a distinct id.
 func physicalMsgID(topic string, partition int, offset int64) string {
-	return shake128ID(topic + strconv.Itoa(partition) + strconv.FormatInt(offset, 10))
+	return shake128ID(physicalCoordinate(topic, partition, offset))
 }
 
 // keyedMsgID identifies a message by its key (topic, partition, key), offset

--- a/pkg/source/kafka/kafka_test.go
+++ b/pkg/source/kafka/kafka_test.go
@@ -196,10 +196,9 @@ func TestPhysicalMsgID(t *testing.T) {
 		t.Errorf("physicalMsgID length = %d, want 20", len(id1))
 	}
 
-	// Verify it matches SHAKE-128 base64 of (topic + partition + offset) — the
-	// message's unique coordinate. This mirrors dlt's Kafka source, which keys
-	// on topic-partition-offset.
-	expected := shake128Base64(fmt.Sprintf("%s%d%d", "my-topic", 0, 100))
+	// Verify it matches SHAKE-128 base64 of the injective "topic:partition:offset"
+	// coordinate — the message's unique location within the topic.
+	expected := shake128Base64("my-topic:0:100")
 	if id1 != expected {
 		t.Errorf("physicalMsgID = %q, want %q", id1, expected)
 	}
@@ -209,6 +208,13 @@ func TestPhysicalMsgID(t *testing.T) {
 	idOff := physicalMsgID("my-topic", 0, 101)
 	if id1 == idOff {
 		t.Error("physicalMsgID collision for different offsets")
+	}
+
+	// The input encoding must be injective across the (partition, offset) split:
+	// partition 1/offset 10 and partition 11/offset 0 are different messages and
+	// must not produce the same id (a separator-less encoding would collide here).
+	if a, b := physicalMsgID("t", 1, 10), physicalMsgID("t", 11, 0); a == b {
+		t.Errorf("physicalMsgID collision across partition/offset boundary: %q", a)
 	}
 
 	if id3 := physicalMsgID("my-topic", 1, 100); id1 == id3 {

--- a/pkg/source/kafka/kafka_test.go
+++ b/pkg/source/kafka/kafka_test.go
@@ -184,56 +184,67 @@ func shake128Base64(input string) string {
 	return strings.TrimRight(base64.StdEncoding.EncodeToString(digest), "=")
 }
 
-func TestGenerateMsgID(t *testing.T) {
-	id1 := generateMsgID("my-topic", 0, 100, "key1")
-	id2 := generateMsgID("my-topic", 0, 100, "key1")
+func TestPhysicalMsgID(t *testing.T) {
+	id1 := physicalMsgID("my-topic", 0, 100)
+	id2 := physicalMsgID("my-topic", 0, 100)
 	if id1 != id2 {
-		t.Errorf("generateMsgID not deterministic: %q != %q", id1, id2)
+		t.Errorf("physicalMsgID not deterministic: %q != %q", id1, id2)
 	}
 
 	// SHAKE-128 → 15 bytes → base64 without padding = 20 chars
 	if len(id1) != 20 {
-		t.Errorf("generateMsgID length = %d, want 20", len(id1))
+		t.Errorf("physicalMsgID length = %d, want 20", len(id1))
 	}
 
-	// Verify it matches SHAKE-128 base64 of concatenated string (Python-compatible)
-	expected := shake128Base64(fmt.Sprintf("%s%d%s", "my-topic", 0, "key1"))
+	// Verify it matches SHAKE-128 base64 of (topic + partition + offset) — the
+	// message's unique coordinate. This mirrors dlt's Kafka source, which keys
+	// on topic-partition-offset.
+	expected := shake128Base64(fmt.Sprintf("%s%d%d", "my-topic", 0, 100))
 	if id1 != expected {
-		t.Errorf("generateMsgID = %q, want %q", id1, expected)
+		t.Errorf("physicalMsgID = %q, want %q", id1, expected)
 	}
 
-	// Different inputs produce different IDs
-	id3 := generateMsgID("my-topic", 1, 100, "key1")
-	if id1 == id3 {
-		t.Error("generateMsgID collision for different partitions")
+	// The regression this fix targets: ids differing only by offset must be
+	// distinct (a null-key stream on one partition previously collapsed to one id).
+	idOff := physicalMsgID("my-topic", 0, 101)
+	if id1 == idOff {
+		t.Error("physicalMsgID collision for different offsets")
 	}
 
-	id4 := generateMsgID("other-topic", 0, 100, "key1")
-	if id1 == id4 {
-		t.Error("generateMsgID collision for different topics")
+	if id3 := physicalMsgID("my-topic", 1, 100); id1 == id3 {
+		t.Error("physicalMsgID collision for different partitions")
 	}
-
-	id5 := generateMsgID("my-topic", 0, 100, "key2")
-	if id1 == id5 {
-		t.Error("generateMsgID collision for different keys")
+	if id4 := physicalMsgID("other-topic", 0, 100); id1 == id4 {
+		t.Error("physicalMsgID collision for different topics")
 	}
 }
 
-func TestGenerateMsgID_NilKey(t *testing.T) {
-	idNil := generateMsgID("my-topic", 0, 50, nil)
-	if len(idNil) != 20 {
-		t.Errorf("generateMsgID nil key length = %d, want 20", len(idNil))
+func TestKeyedMsgID(t *testing.T) {
+	id1 := keyedMsgID("my-topic", 0, "key1")
+	id2 := keyedMsgID("my-topic", 0, "key1")
+	if id1 != id2 {
+		t.Errorf("keyedMsgID not deterministic: %q != %q", id1, id2)
 	}
 
-	// nil key should use "None" (Python compatibility)
-	expected := shake128Base64(fmt.Sprintf("%s%d%s", "my-topic", 0, "None"))
-	if idNil != expected {
-		t.Errorf("generateMsgID nil key = %q, want %q", idNil, expected)
+	if len(id1) != 20 {
+		t.Errorf("keyedMsgID length = %d, want 20", len(id1))
 	}
 
-	idStr := generateMsgID("my-topic", 0, 50, "key1")
-	if idNil == idStr {
-		t.Error("generateMsgID collision for nil vs string key")
+	// Stable per key (topic + partition + key), offset excluded — this is the
+	// changelog/compaction identity used by the streaming envelope's keyed branch.
+	expected := shake128Base64(fmt.Sprintf("%s%d%s", "my-topic", 0, "key1"))
+	if id1 != expected {
+		t.Errorf("keyedMsgID = %q, want %q", id1, expected)
+	}
+
+	if id3 := keyedMsgID("my-topic", 1, "key1"); id1 == id3 {
+		t.Error("keyedMsgID collision for different partitions")
+	}
+	if id4 := keyedMsgID("other-topic", 0, "key1"); id1 == id4 {
+		t.Error("keyedMsgID collision for different topics")
+	}
+	if id5 := keyedMsgID("my-topic", 0, "key2"); id1 == id5 {
+		t.Error("keyedMsgID collision for different keys")
 	}
 }
 
@@ -334,6 +345,26 @@ func TestMessageToItem_NilKey(t *testing.T) {
 	tsMeta := meta["ts"].(map[string]interface{})
 	if tsMeta["type"] != 0 {
 		t.Errorf("ts.type = %v, want 0 for zero time", tsMeta["type"])
+	}
+}
+
+// Keyless messages on one partition differing only by offset must produce
+// distinct _kafka_msg_id values; previously they all collapsed to one id.
+func TestMessageToItem_KeylessDistinctPerOffset(t *testing.T) {
+	base := kafkago.Message{Topic: "test-topic", Partition: 0, Key: nil, Value: []byte("data")}
+
+	seen := make(map[string]int64)
+	for off := int64(0); off < 500; off++ {
+		msg := base
+		msg.Offset = off
+		id, ok := messageToItem(msg)["_kafka_msg_id"].(string)
+		if !ok {
+			t.Fatalf("offset %d: _kafka_msg_id is not a string", off)
+		}
+		if prev, dup := seen[id]; dup {
+			t.Fatalf("offset %d and %d collide on _kafka_msg_id %q", prev, off, id)
+		}
+		seen[id] = off
 	}
 }
 


### PR DESCRIPTION
## Summary

In batch mode the Kafka source derived `_kafka_msg_id` from `(topic, partition, key)` and **silently ignored the message offset**. Any messages sharing a topic/partition/key — including the very common **null-key** case — collapsed to a single `_kafka_msg_id`, degenerating the per-message identifier used for dedup and lineage (and usable as a primary key). The load "succeeds" with correct row counts, but the id column is degenerate:

```sql
SELECT COUNT(*) AS total, COUNT(DISTINCT _kafka_msg_id) AS distinct_msg_ids FROM <table>;
-- before:  total=500,  distinct_msg_ids=1
-- after:   total=500,  distinct_msg_ids=500
```

## Root cause

`generateMsgID(topic, partition, offset, key)` was **shared by two callers with opposite identity needs** and dropped its `offset` argument:

- **Batch** (`messageToItem`) needs **unique-per-physical-message** → `(topic, partition, offset)`.
- **Streaming keyed** (`streamMsgID`) intentionally needs **stable-per-key** → `(topic, partition, key)` for changelog/compaction merge semantics.

One function could not serve both — which is exactly why the offset silently went unused on the batch path.

## The fix

Split the overloaded function into two intent-named helpers over a shared hash body, so a field that doesn't belong to an identity can no longer be passed and dropped:

| helper | identity | used by |
|---|---|---|
| `physicalMsgID(topic, partition, offset)` | unique per physical message | batch `_kafka_msg_id` **(the fix)** |
| `keyedMsgID(topic, partition, key)` | stable per key | streaming keyed branch |
| `shake128ID(input)` | shared SHAKE-128 digest | both |

## Compatibility

- `keyedMsgID` is **byte-identical** to the old keyed hash → streaming keyed and keyless primary keys are **unchanged** (no persisted-PK migration).
- Only the **degenerate** batch id changes; the new value is unique per `(topic, partition, offset)`, matching dlt's Kafka source.
- Also swapped `fmt.Sprintf` → `strconv` concatenation in the per-message id builders (byte-identical, avoids reflection on the hot path), and documented that the keyless streaming branch stays plaintext for backward compatibility with already-persisted ids.

## Tests

- `TestPhysicalMsgID` — asserts ids differing **only by offset** are distinct (the regression), plus determinism / length / SHAKE-128 oracle.
- `TestMessageToItem_KeylessDistinctPerOffset` — 500 keyless messages on one partition produce 500 distinct ids (mirrors the repro).
- `TestKeyedMsgID` — keyed identity + sensitivity to topic/partition/key.
- `TestStreamMsgID` — unchanged, confirms keyed byte-compatibility.

Verified: regression tests fail against the pre-fix code and pass after; `make format`/`golangci-lint` clean (0 issues); `go test -race ./pkg/source/kafka/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)