### PR TITLE
sharepoint: make download timeout configurable (default 120s → 10m)

### DIFF
--- a/docs/supported-sources/sharepoint.md
+++ b/docs/supported-sources/sharepoint.md
@@ -22,6 +22,7 @@ URI parameters:
 - `library` (optional): document library (drive) name; defaults to the site's default **Documents** library. Set it to read from a secondary library on the same site.
 - `max_file_size` (optional): maximum bytes for any single downloaded file; the read fails if a file exceeds it. Defaults to `0` (unlimited).
 - `max_files` (optional): maximum number of files a glob may match before erroring, to guard against an over-broad recursive pattern. Defaults to `10000`; set `0` for unlimited.
+- `download_timeout` (optional): per-request HTTP timeout as a Go duration (e.g. `30m`, `600s`). Bounds each Graph call, most importantly the file download, which streams the whole workbook. Defaults to `10m`; raise it for very large files on slow links.
 
 Authentication uses the OAuth2 **client-credentials** flow. The app registration needs application permission to read the site's files (e.g. `Sites.Read.All` or `Files.Read.All`), granted with admin consent.
 

--- a/pkg/source/sharepoint/graph.go
+++ b/pkg/source/sharepoint/graph.go
@@ -29,6 +29,8 @@ var graphScopes = []string{"https://graph.microsoft.com/.default"}
 // Microsoft's expected format: ISV|CompanyName|AppName/Version.
 const userAgent = "ISV|Bruin|ingestr/1.0"
 
+const defaultDownloadTimeout = 10 * time.Minute
+
 // graphClient talks to the Microsoft Graph API for a single SharePoint site.
 // Authentication uses the OAuth2 client-credentials flow via azidentity, which
 // caches and refreshes the access token internally.
@@ -66,8 +68,13 @@ func newGraphClient(cfg connConfig) (*graphClient, error) {
 		return nil, fmt.Errorf("failed to create SharePoint client credential: %w", err)
 	}
 
+	timeout := cfg.httpTimeout
+	if timeout <= 0 {
+		timeout = defaultDownloadTimeout
+	}
+
 	client := httpclient.New(
-		httpclient.WithTimeout(120*time.Second),
+		httpclient.WithTimeout(timeout),
 		httpclient.WithRetry(5, 2*time.Second, 30*time.Second),
 		httpclient.WithUserAgent(userAgent),
 		httpclient.WithDebug(config.DebugMode),

--- a/pkg/source/sharepoint/sharepoint.go
+++ b/pkg/source/sharepoint/sharepoint.go
@@ -13,6 +13,7 @@ import (
 	gopath "path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -47,9 +48,10 @@ type connConfig struct {
 	clientSecret string
 	hostname     string
 	sitePath     string
-	library      string // optional document library name; empty => default ("Documents")
-	maxFileSize  int64  // optional max bytes per downloaded file; 0 => unlimited
-	maxFiles     int    // optional max files a glob may match; 0 => unlimited
+	library      string        // optional document library name; empty => default ("Documents")
+	maxFileSize  int64         // optional max bytes per downloaded file; 0 => unlimited
+	maxFiles     int           // optional max files a glob may match; 0 => unlimited
+	httpTimeout  time.Duration // per-request HTTP timeout; 0 => defaultDownloadTimeout
 }
 
 // tableSpec is the parsed form of a source-table string.
@@ -240,6 +242,13 @@ func parseURI(uri string) (connConfig, error) {
 			return connConfig{}, fmt.Errorf("invalid max_files %q: must be a non-negative integer (0 = unlimited)", v)
 		}
 		cfg.maxFiles = n
+	}
+	if v := strings.TrimSpace(q.Get("download_timeout")); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil || d < 0 {
+			return connConfig{}, fmt.Errorf("invalid download_timeout %q: must be a non-negative Go duration such as 30m, 10m, or 600s", v)
+		}
+		cfg.httpTimeout = d
 	}
 
 	missing := make([]string, 0, 5)

--- a/pkg/source/sharepoint/sharepoint_test.go
+++ b/pkg/source/sharepoint/sharepoint_test.go
@@ -339,6 +339,7 @@ func TestParseURI(t *testing.T) {
 	assert.Equal(t, "", cfg.library)          // optional, defaults to the Documents library
 	assert.EqualValues(t, 0, cfg.maxFileSize) // unlimited by default
 	assert.Equal(t, defaultMaxFiles, cfg.maxFiles)
+	assert.EqualValues(t, 0, cfg.httpTimeout)
 
 	cfg, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=example.sharepoint.com&library=Finance%20Docs")
 	require.NoError(t, err)
@@ -353,6 +354,16 @@ func TestParseURI(t *testing.T) {
 	_, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&max_file_size=-1")
 	require.Error(t, err)
 	_, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&max_files=abc")
+	require.Error(t, err)
+
+	// configurable download timeout (Go duration)
+	cfg, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&download_timeout=30m")
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, cfg.httpTimeout)
+
+	_, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&download_timeout=abc")
+	require.Error(t, err)
+	_, err = parseURI("sharepoint://?tenant_id=t&client_id=c&client_secret=s&site=sites/Example&hostname=h&download_timeout=-5m")
 	require.Error(t, err)
 
 	_, err = parseURI("sharepoint://?tenant_id=t")


### PR DESCRIPTION
The Graph HTTP client timeout was hardcoded to 120s, so downloads of large workbooks abort before finishing — a ~184 MB SharePoint workbook takes several minutes to stream and never completes.

This adds a `download_timeout` URI parameter (Go duration, e.g. `30m`) and raises the default to 10m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
