### PR TITLE
docs: PostgreSQL CDC schema changes and keyless-table behavior

### DIFF
--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -38,7 +38,7 @@ Every row a CDC merge writes carries three metadata columns in the destination:
 | `_cdc_deleted` | `true` when the source row was deleted. Deletes are **soft**: the row is kept in the destination and flagged rather than physically removed. |
 | `_cdc_synced_at` | When ingestr applied the change to the destination. |
 
-Merging needs a key: to keep a one-row-per-key mirror of a table, ingestr needs a primary key or an equivalent replica-identity index. What happens without one depends on the connector. In PostgreSQL, a keyless table with `REPLICA IDENTITY FULL` is still ingested — just as an append-only change log rather than a mirror: a delete is appended as a new row with `_cdc_deleted = true`, and an update shows up as a delete followed by an insert. Because nothing gets merged, a retry can replay events into these tables, and they keep the internal `_cdc_unchanged_cols` column. When ingestr manages the publication, it leaves out PostgreSQL tables that have no usable replica identity at all; if you manage the publication yourself, give such tables a usable replica identity before they start publishing updates or deletes.
+Merging needs a key: to keep a one-row-per-key mirror of a table, ingestr needs a primary key or an equivalent replica-identity index. What happens without one depends on the connector — most connectors simply **skip keyless tables with a warning**. PostgreSQL is the exception: a keyless table with `REPLICA IDENTITY FULL` is still ingested — just as an append-only change log rather than a mirror: a delete is appended as a new row with `_cdc_deleted = true`, and an update shows up as a delete followed by an insert. Because nothing gets merged, a retry can replay events into these tables, and they keep the internal `_cdc_unchanged_cols` column. When ingestr manages the publication, it leaves out PostgreSQL tables that have no usable replica identity at all; if you manage the publication yourself, give such tables a usable replica identity before they start publishing updates or deletes.
 
 ### Deletes
 
@@ -61,6 +61,8 @@ You can add, alter, or drop columns on a replicated PostgreSQL table without res
 3. Evolve the destination table so it can hold the new shape.
 4. Recreate the staging table.
 5. Resume logical replication, taking care not to skip past the transaction that revealed the change.
+
+Keep in mind that the replacement snapshot in step 2 is a full copy of the table, not a delta — on a large table every detected schema change costs a re-snapshot. If you're running a DDL-heavy migration, it can be cheaper to batch the changes together, or pause the stream and let the next run pick them up at once.
 
 New columns are added to the destination when it supports schema evolution, and compatible type or nullability changes are applied where the destination allows them. Dropped columns are never deleted from the destination — they stay behind as nullable columns — and a rename looks like a drop plus an add, so you end up with both the old column and the new one. If the destination can't replace the table safely, the run fails rather than pressing on with a wrong schema; a `freeze` schema contract rejects the change too, which is exactly what freezing is for.
 

--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -24,11 +24,13 @@ Every ingestr CDC connector follows the same two-phase shape:
 1. **Snapshot.** On the first run, ingestr takes a consistent snapshot of each selected table and loads it into the destination. This establishes a known baseline and records the log position that corresponds to it.
 2. **Stream.** From that position onward, ingestr reads the change log and applies each insert, update, and delete to the destination. Subsequent runs resume from where the previous one left off.
 
-The snapshot-to-stream handoff is designed to be safe: changes that overlap the boundary are applied idempotently, so no data is lost or double-counted.
+The snapshot-to-stream handoff is designed to be safe: as long as a table has a stable row key to merge on, changes that overlap the boundary are applied idempotently, so no data is lost or double-counted. Tables without such a key are captured as append-only change logs instead (more on those below), and there the guarantee is at-least-once — a retry can leave the same event in the log twice.
 
-### The `merge` strategy and metadata columns
+### The `merge` strategy, metadata columns, and keyless tables
 
-CDC runs always use the [`merge` strategy](/getting-started/incremental-loading.md#merge) so that updates and deletes can be applied by primary key — even if you pass `--incremental-strategy=replace`. Every CDC row is annotated with three metadata columns in the destination:
+CDC runs normally use the [`merge` strategy](/getting-started/incremental-loading.md#merge) so that updates and deletes can be applied by row key. You don't have to ask for it: if you pass no strategy, or pass `replace` without `--full-refresh`, ingestr upgrades the run to `merge` on its own. Asking for anything else explicitly either fails or draws a warning, depending on the connector — and `--full-refresh` still does what it says, rebuilding the table from a fresh snapshot.
+
+Every row a CDC merge writes carries three metadata columns in the destination:
 
 | Column | Meaning |
 | --- | --- |
@@ -36,11 +38,11 @@ CDC runs always use the [`merge` strategy](/getting-started/incremental-loading.
 | `_cdc_deleted` | `true` when the source row was deleted. Deletes are **soft**: the row is kept in the destination and flagged rather than physically removed. |
 | `_cdc_synced_at` | When ingestr applied the change to the destination. |
 
-Because a primary key is required to merge changes, **tables without a primary key (or an equivalent replica identity) are skipped** with a warning.
+Merging needs a key: to keep a one-row-per-key mirror of a table, ingestr needs a primary key or an equivalent replica-identity index. What happens without one depends on the connector. In PostgreSQL, a keyless table with `REPLICA IDENTITY FULL` is still ingested — just as an append-only change log rather than a mirror: a delete is appended as a new row with `_cdc_deleted = true`, and an update shows up as a delete followed by an insert. Because nothing gets merged, a retry can replay events into these tables, and they keep the internal `_cdc_unchanged_cols` column. When ingestr manages the publication, it leaves out PostgreSQL tables that have no usable replica identity at all; if you manage the publication yourself, give such tables a usable replica identity before they start publishing updates or deletes.
 
 ### Deletes
 
-Deletes are captured as soft deletes: the destination keeps the row and sets `_cdc_deleted = true`. For most databases the deleted row's other columns are preserved as they were, so you retain the last known values. Some sources (SQL Server Change Tracking, PlanetScale) only emit the primary key of a deleted row, so ingestr marks the row deleted without disturbing its other columns.
+For tables with a merge key, deletes are captured as soft deletes: the destination keeps the row and sets `_cdc_deleted = true`. For most databases the deleted row's other columns are preserved as they were, so you retain the last known values. Some sources (SQL Server Change Tracking, PlanetScale) only emit the primary key of a deleted row, so ingestr marks the row deleted without disturbing its other columns. In a keyless append-only table there is no single destination row to flag, so a delete simply lands as one more event in the log.
 
 ### Resuming and full refresh
 
@@ -48,11 +50,27 @@ On every run after the first, a CDC connector resumes from the last durable posi
 
 ### One-shot vs. streaming
 
-By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs, and the way to run MySQL CDC. Continuous streaming is available for `postgres+cdc`, `mssql+cdc`, and `mongodb+cdc`: pass the `--stream` CLI flag and ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery, and the `merge` strategy makes replays idempotent. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
+By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs, and the way to run MySQL CDC. Continuous streaming is available for `postgres+cdc`, `mssql+cdc`, and `mongodb+cdc`: pass the `--stream` CLI flag and ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery — for keyed tables the `merge` strategy makes replays harmless, though keyless append-only change logs can end up with duplicate events after a recovery. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
+
+### PostgreSQL schema changes while streaming
+
+You can add, alter, or drop columns on a replicated PostgreSQL table without restarting ingestr. When a stream notices that a table's shape has changed — either because logical replication delivers a changed relation, or because the periodic schema check catches it — it rebuilds itself in place:
+
+1. Flush any buffered batches that still use the old schema.
+2. Re-read the source schema and take a fresh, consistent snapshot of the affected table.
+3. Evolve the destination table so it can hold the new shape.
+4. Recreate the staging table.
+5. Resume logical replication, taking care not to skip past the transaction that revealed the change.
+
+New columns are added to the destination when it supports schema evolution, and compatible type or nullability changes are applied where the destination allows them. Dropped columns are never deleted from the destination — they stay behind as nullable columns — and a rename looks like a drop plus an add, so you end up with both the old column and the new one. If the destination can't replace the table safely, the run fails rather than pressing on with a wrong schema; a `freeze` schema contract rejects the change too, which is exactly what freezing is for.
+
+How quickly a change is noticed depends on the table. A busy table surfaces it right away, because PostgreSQL sends the changed relation along with the next row. An idle table relies on the periodic check, controlled by the `discover_interval` URI setting (default `30s`) — set it to `0` or `off` and idle tables are no longer proactively checked. One-shot runs simply pick up whatever schema exists when they start; if DDL lands while a one-shot run is mid-decode, the run exits and the next one refreshes and re-snapshots the table.
 
 ### Multi-table CDC
 
 If you omit `--source-table`, most CDC connectors run in multi-table mode and replicate every eligible table in the source's capture set. Each table is snapshotted and streamed from its own position; a multi-table run is not a single global point-in-time snapshot across all tables, but each table is individually consistent. Use `--dest-schema` (or `dest_schema` in the URI) to control where multi-table output lands.
+
+For PostgreSQL, a schema change to a table already in the stream is handled in process, as described above. A brand-new table showing up is a bigger event: a one-shot run simply picks it up on its next start, but a running stream can't snapshot it mid-flight — when the periodic check finds one, the stream stops cleanly before touching any destination data and expects whatever supervises it (systemd, Kubernetes, a scheduler) to start it again. The restarted process snapshots the new table and then continues from the WAL still held by the existing slot, so no changes are missed in between. If you manage the publication yourself, remember to add the new table to it — ingestr won't do it for you.
 
 ## Supported CDC platforms
 
@@ -72,7 +90,7 @@ Each platform has requirements and knobs specific to its change mechanism — fo
 
 ### Platform notes at a glance
 
-- **PostgreSQL** reads logical replication from a publication and slot. It can manage its own `ingestr_publication` or use one you supply, tracks progress in shared state tables in the destination (not the max `_cdc_lsn` of a user table), and automatically discovers tables added after setup. `TRUNCATE` is captured as a table replacement.
+- **PostgreSQL** reads logical replication from a publication and slot. It can manage its own `ingestr_publication` or use one you supply, and tracks progress in shared destination state tables rather than the maximum `_cdc_lsn` in a user table. A running stream absorbs column-level schema changes without restarting; picking up a newly added table takes a restart, since the stream exits and lets its supervisor bring it back up. `TRUNCATE` — or dropping and recreating a source table — is captured as a table replacement.
 - **MySQL / MariaDB** stream the binary log after a consistent snapshot, resuming from the destination's maximum `_cdc_lsn`. Pin a unique `server_id` for scheduled or overlapping runs.
 - **SQL Server** offers two paths: lightweight **Change Tracking** (net changes since the last version, primary key required) and **log-based CDC** (full row-level change history). Both resume from `_cdc_lsn`.
 - **MongoDB** tails change streams from a replica set / Atlas cluster. Being schema-less, it uses schema inference, so the destination schema is derived from sampled documents.


### PR DESCRIPTION
## What
Updates the CDC guide for the new PostgreSQL behavior: in-stream handling of column-level schema changes, and keyless tables being ingested as append-only change logs instead of skipped.

## Changes
- `docs/getting-started/cdc.md` — new "PostgreSQL schema changes while streaming" section, reworked merge/keyless-table and deletes sections, updated one-shot vs. streaming delivery guarantees, multi-table new-table restart behavior, and the PostgreSQL platform note.

## How to test
1. Read the rendered `docs/getting-started/cdc.md` and check it against the actual connector behavior.

## Risk & rollback
- **Risk:** low — docs only.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`) — n/a, docs only
- [x] Format and lint pass (`make format`, `make lint`) — n/a, docs only
- [x] Integration tests pass if affected (`make test-integration`) — n/a
- [x] No unrelated changes included
- [x] Tested locally — proofread

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
—