### PR TITLE
Add size-aware benchmark policy and opt-in Spark partitioning

### DIFF
--- a/benchmarks/scenarios.yaml
+++ b/benchmarks/scenarios.yaml
@@ -141,6 +141,8 @@ scenarios:
     destination: snowflake
 
 tools:
+  # Keep the standard five-run plus warmup sweep from spending hours on known
+  # slow combinations. The 1k and 100k sizes remain fully covered.
   gong:
     binary: bin/ingestr
 
@@ -156,9 +158,18 @@ tools:
     skip:
       - source_type: mongodb
         destination_type: mssql
+      - source_type: mongodb
+        sizes: ["10m"]
+      - destination_type: mssql
+        sizes: ["10m"]
 
   sling:
     requires: sling
+    skip:
+      - destination_type: mssql
+        sizes: ["1m", "10m"]
+      - source_type: mongodb
+        sizes: ["10m"]
 
   dlt:
     script: scripts/bench_dlt.py
@@ -171,6 +182,12 @@ tools:
       - source: local_mongodb
         destination_type: mssql
         backend: default
+    skip:
+      - destination_type: mssql
+        sizes: ["1m", "10m"]
+      - source_type: mongodb
+        destination_type: postgres
+        sizes: ["10m"]
 
   airbyte:
     script: scripts/bench_airbyte.py
@@ -181,6 +198,7 @@ tools:
       - destination_type: bigquery
       - destination_type: snowflake
       - destination_type: mssql
+      - sizes: ["10m"]
 
   spark:
     script: scripts/bench_spark.py
@@ -191,3 +209,5 @@ tools:
       - source_type: mongodb
       - destination_type: bigquery
       - destination_type: snowflake
+      - destination_type: duckdb
+        sizes: ["1m", "10m"]

--- a/benchmarks/scripts/bench_spark.py
+++ b/benchmarks/scripts/bench_spark.py
@@ -4,7 +4,12 @@
 #     "pyspark>=3.5,<3.6",
 # ]
 # ///
-"""Single-node Spark ingestion benchmark."""
+"""Single-node Spark ingestion benchmark.
+
+JDBC range partitioning is opt-in. Set BENCH_SPARK_PARTITIONED_READ=true to
+enable it, then optionally tune BENCH_SPARK_PARTITION_COLUMN,
+BENCH_SPARK_LOWER_BOUND, and BENCH_SPARK_NUM_PARTITIONS.
+"""
 
 import argparse
 import os
@@ -50,6 +55,17 @@ def int_env(name: str, default: int) -> int:
     if not value:
         return default
     return int(value)
+
+
+def bool_env(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    if value.lower() in ("1", "true", "yes", "on"):
+        return True
+    if value.lower() in ("0", "false", "no", "off"):
+        return False
+    raise ValueError(f"{name} must be a boolean value")
 
 
 def default_partitions() -> int:
@@ -211,8 +227,9 @@ def read_source(spark: SparkSession, args) -> object:
         options["customSchema"] = "json_val STRING"
 
     rows = args.rows or int(os.environ.get("BENCH_ROWS") or "0")
+    partitioned_read = bool_env("BENCH_SPARK_PARTITIONED_READ")
     partition_column = os.environ.get("BENCH_SPARK_PARTITION_COLUMN", "id")
-    if rows > 1 and partition_column:
+    if partitioned_read and rows > 1 and partition_column:
         options["partitionColumn"] = partition_column
         options["lowerBound"] = os.environ.get("BENCH_SPARK_LOWER_BOUND", "1")
         options["upperBound"] = str(rows)

--- a/benchmarks/scripts/runner.py
+++ b/benchmarks/scripts/runner.py
@@ -304,7 +304,14 @@ def check_tool_available(name: str, tool_cfg: dict) -> bool:
     return True
 
 
-def scenario_rule_matches(rule: dict, src_type: str, dst_type: str, src_name: str, dst_name: str) -> bool:
+def scenario_rule_matches(
+    rule: dict,
+    src_type: str,
+    dst_type: str,
+    src_name: str,
+    dst_name: str,
+    size: str | None = None,
+) -> bool:
     checks = []
     if "source_type" in rule:
         checks.append(rule["source_type"] == src_type)
@@ -314,12 +321,24 @@ def scenario_rule_matches(rule: dict, src_type: str, dst_type: str, src_name: st
         checks.append(rule["source"] == src_name)
     if "destination" in rule:
         checks.append(rule["destination"] == dst_name)
+    if "sizes" in rule:
+        sizes = rule["sizes"]
+        if isinstance(sizes, str):
+            sizes = [sizes]
+        checks.append(size in sizes)
     return bool(checks) and all(checks)
 
 
-def should_skip_tool(tool_cfg: dict, src_type: str, dst_type: str, src_name: str, dst_name: str) -> bool:
+def should_skip_tool(
+    tool_cfg: dict,
+    src_type: str,
+    dst_type: str,
+    src_name: str,
+    dst_name: str,
+    size: str,
+) -> bool:
     for rule in tool_cfg.get("skip", []):
-        if scenario_rule_matches(rule, src_type, dst_type, src_name, dst_name):
+        if scenario_rule_matches(rule, src_type, dst_type, src_name, dst_name, size):
             return True
     return False
 
@@ -656,8 +675,8 @@ def run_benchmarks(
         for tool_name in tools:
             tool_cfg = tool_configs[tool_name]
 
-            if should_skip_tool(tool_cfg, src["type"], dst["type"], src_name, dst_name):
-                console.print(f"  [dim]{tool_name}: skipped[/dim]")
+            if should_skip_tool(tool_cfg, src["type"], dst["type"], src_name, dst_name, size):
+                console.print(f"  [dim]{tool_name}: skipped for {size}[/dim]")
                 continue
 
             cmd = build_tool_command(
@@ -1013,7 +1032,7 @@ def run_validation(
         for tool_name in tools:
             tool_cfg = tool_configs[tool_name]
 
-            if should_skip_tool(tool_cfg, src["type"], dst["type"], src_name, dst_name):
+            if should_skip_tool(tool_cfg, src["type"], dst["type"], src_name, dst_name, size):
                 console.print(f"  [{tool_name}] [dim]SKIP (tool skip rule)[/dim]")
                 skipped += 1
                 continue


### PR DESCRIPTION
## Summary

- add size-aware matching to benchmark tool skip rules
- skip the known prohibitively slow 1m and 10m tool/scenario combinations
- preserve complete coverage for the 1k and 100k benchmark sizes
- make Spark JDBC range-partitioned extraction opt-in

## Why

The standard benchmark executes one warmup and five measured runs. Recent full-sweep results showed several combinations taking between roughly 30 minutes and multiple hours per combination, preventing the all-size benchmark from completing in a useful window.

At 1m rows, this skips Spark writes to DuckDB and Sling/dlt writes to SQL Server. At 10m rows, it additionally skips Airbyte, legacy ingestr reads from MongoDB or writes to SQL Server, Sling reads from MongoDB, and dlt MongoDB-to-PostgreSQL runs.

Spark previously enabled JDBC range partitioning by default using the `id` column and one partition per CPU. That silently compared a tuned parallel extraction mode against other tools' default extraction behavior. Spark now uses a single JDBC read by default. Set `BENCH_SPARK_PARTITIONED_READ=true` to benchmark the partitioned mode separately; the existing column, lower-bound, and partition-count environment variables remain available for tuning.

## Validation

- `make format`
- `make lint`
- `make test`
- focused 15-case size-aware skip-policy matrix
- focused Spark default, partitioned, and invalid-feature-flag checks
