### PR TITLE
Add Adapty source connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Adapty</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Airtable</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/supported-sources/adapty.md
+++ b/docs/supported-sources/adapty.md
@@ -13,7 +13,7 @@ adapty://?api_key=<secret-api-key>&lookback_days=30&timezone=UTC
 Parameters:
 
 - `api_key`: Required. The app-specific secret API key from **App Settings → General → API keys**.
-- `lookback_days`: Optional. Number of days to re-fetch before an incremental analytics interval. Defaults to `30`; use `0` to disable lookback.
+- `lookback_days`: Optional. Number of days loaded when no analytics interval is supplied. Defaults to `30`; use `0` to load only today.
 - `timezone`: Optional. IANA timezone used by Adapty to group analytics dates. Defaults to `UTC`.
 
 Use the secret API key, not a public SDK key. The connector sends it as `Authorization: Api-Key <secret-api-key>`.
@@ -31,7 +31,7 @@ Use the secret API key, not a public SDK key. The connector sends it as `Authori
 | `placements` | `placement_type` | `replace` | Exported paywall or onboarding placement configuration. |
 | `paywalls` | – | `merge` on `paywall_id`, incremental key `updated_at` | All paginated paywalls, including their state, deletion marker, and nested products. |
 
-The six analytics tables are requested one calendar day at a time and receive an ingestr-managed `date` column. When no interval is supplied, they load the last 30 days by default. `lookback_days` expands an incremental interval so mutable subscription and revenue aggregates are refreshed safely.
+The six analytics tables are requested one calendar day at a time and receive an ingestr-managed `date` column. When no interval is supplied, they load the last 30 days by default. Explicit incremental intervals are loaded exactly as supplied so their `delete+insert` boundaries remain aligned.
 
 The paywall API does not accept an `updated_at` filter. ingestr scans its paginated list and applies the incremental interval client-side. Adapty returns archived and deleted paywalls with `state` and `is_deleted`, allowing merge loads to retain lifecycle changes.
 

--- a/docs/supported-sources/adapty.md
+++ b/docs/supported-sources/adapty.md
@@ -1,0 +1,136 @@
+# Adapty
+
+[Adapty](https://adapty.io/) is a subscription monetization platform for mobile and web apps. ingestr supports its batch Analytics Export API and the paginated paywall list from the Server-side API.
+
+The connector does not use webhooks or realtime event tracking. Adapty does not expose a batch endpoint for listing raw purchase transactions, so purchase activity is available through its revenue, subscription, refund, cohort, conversion, LTV, funnel, and retention analytics.
+
+## URI format
+
+```plaintext
+adapty://?api_key=<secret-api-key>&lookback_days=30&timezone=UTC
+```
+
+Parameters:
+
+- `api_key`: Required. The app-specific secret API key from **App Settings → General → API keys**.
+- `lookback_days`: Optional. Number of days to re-fetch before an incremental analytics interval. Defaults to `30`; use `0` to disable lookback.
+- `timezone`: Optional. IANA timezone used by Adapty to group analytics dates. Defaults to `UTC`.
+
+Use the secret API key, not a public SDK key. The connector sends it as `Authorization: Api-Key <secret-api-key>`.
+
+## Tables
+
+| Table | Required parameters | Incremental behavior | Description |
+| --- | --- | --- | --- |
+| `analytics` | `chart_id` | `delete+insert` on `date` | Revenue, MRR, ARR, ARPU/ARPPU, subscriptions, trials, refunds, billing issues, installs, and related chart metrics. |
+| `cohorts` | – | `delete+insert` on `date` | Cohort revenue, subscriber, subscription, ARPU, ARPPU, and ARPAS analytics. |
+| `conversion` | `from_period`, `to_period` | `delete+insert` on `date` | Conversion between two subscription states. Use `from_period=null` when there is no starting state. |
+| `funnel` | – | `delete+insert` on `date` | Subscription funnel and churn analytics. |
+| `ltv` | – | `delete+insert` on `date` | Actual lifetime value for revenue, proceeds, and net revenue. |
+| `retention` | – | `delete+insert` on `date` | Subscriber retention analytics. |
+| `placements` | `placement_type` | `replace` | Exported paywall or onboarding placement configuration. |
+| `paywalls` | – | `merge` on `paywall_id`, incremental key `updated_at` | All paginated paywalls, including their state, deletion marker, and nested products. |
+
+The six analytics tables are requested one calendar day at a time and receive an ingestr-managed `date` column. When no interval is supplied, they load the last 30 days by default. `lookback_days` expands an incremental interval so mutable subscription and revenue aggregates are refreshed safely.
+
+The paywall API does not accept an `updated_at` filter. ingestr scans its paginated list and applies the incremental interval client-side. Adapty returns archived and deleted paywalls with `state` and `is_deleted`, allowing merge loads to retain lifecycle changes.
+
+Provider response objects and arrays, such as cohort values and paywall products, remain nested rather than being flattened.
+
+## Analytics table parameters
+
+Parameters are URL-style query parameters on the source table. All six analytics tables accept these optional filters:
+
+- `compare_date`: Exactly two `YYYY-MM-DD` dates.
+- `store`, `country`, `store_product_id`, `duration`
+- `attribution_source`, `attribution_status`, `attribution_channel`, `attribution_campaign`, `attribution_adgroup`, `attribution_adset`, `attribution_creative`
+- `offer_category`, `offer_type`, `offer_id`
+
+List values are comma-separated. Each table also accepts its endpoint-specific parameters:
+
+| Table | Optional parameters |
+| --- | --- |
+| `analytics` | `date_type`, `segmentation` |
+| `cohorts` | `period_type`, `value_type`, `value_field`, `accounting_type`, `renewal_days`, `prediction_months` |
+| `conversion` | `date_type`, `segmentation` |
+| `funnel` | `show_value_as`, `segmentation` |
+| `ltv` | `period_type`, `segmentation` |
+| `retention` | `segmentation`, `use_trial` |
+
+ingestr fixes `period_unit` to `day` and `format` to `json` so each batch has a stable daily incremental boundary.
+
+Valid `chart_id` values are:
+
+- `revenue`
+- `mrr`
+- `arr`
+- `arppu`
+- `subscriptions_active`
+- `subscriptions_new`
+- `subscriptions_renewal_cancelled`
+- `subscriptions_expired`
+- `trials_active`
+- `trials_new`
+- `trials_renewal_cancelled`
+- `trials_expired`
+- `grace_period`
+- `billing_issue`
+- `refund_events`
+- `refund_money`
+- `non_subscriptions`
+- `arpu`
+- `installs`
+
+## Examples
+
+Load daily purchase revenue into DuckDB:
+
+```sh
+ingestr ingest \
+  --source-uri 'adapty://?api_key=secret_live_...' \
+  --source-table 'analytics?chart_id=revenue' \
+  --dest-uri 'duckdb:///adapty.duckdb' \
+  --dest-table 'adapty.revenue'
+```
+
+Load refund totals for selected stores and countries:
+
+```sh
+ingestr ingest \
+  --source-uri 'adapty://?api_key=secret_live_...&lookback_days=60' \
+  --source-table 'analytics?chart_id=refund_money&store=app_store,play_store&country=us,gb' \
+  --dest-uri 'duckdb:///adapty.duckdb' \
+  --dest-table 'adapty.refunds'
+```
+
+Load cohort revenue by days:
+
+```sh
+ingestr ingest \
+  --source-uri 'adapty://?api_key=secret_live_...' \
+  --source-table 'cohorts?period_type=days&value_field=revenue&accounting_type=net_revenue&renewal_days=0,1,3,7,14,30' \
+  --dest-uri 'duckdb:///adapty.duckdb' \
+  --dest-table 'adapty.cohorts'
+```
+
+Load paywall placement configuration:
+
+```sh
+ingestr ingest \
+  --source-uri 'adapty://?api_key=secret_live_...' \
+  --source-table 'placements?placement_type=paywall' \
+  --dest-uri 'duckdb:///adapty.duckdb' \
+  --dest-table 'adapty.placements'
+```
+
+Load all paywall definitions:
+
+```sh
+ingestr ingest \
+  --source-uri 'adapty://?api_key=secret_live_...' \
+  --source-table 'paywalls' \
+  --dest-uri 'duckdb:///adapty.duckdb' \
+  --dest-table 'adapty.paywalls'
+```
+
+See Adapty's [Analytics Export API reference](https://adapty.io/docs/api-export-analytics) and [Server-side API reference](https://adapty.io/docs/api-adapty) for the upstream response fields and metric definitions.

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -24,6 +24,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 
 ## Analytics, feedback, and media
 
+- [Adapty](/supported-sources/adapty.md)
 - [G2](/supported-sources/g2.md)
 - [Google Analytics](/supported-sources/google_analytics.md)
 - [Mixpanel](/supported-sources/mixpanel.md)

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -278,6 +278,7 @@ func GetConnectors() []ConnectorType {
 	connectors = append(
 		connectors,
 		genericURIConnector("adjust", "Adjust", []string{"adjust"}, true, false),
+		genericURIConnector("adapty", "Adapty", []string{"adapty"}, true, false),
 		genericURIConnector("airtable", "Airtable", []string{"airtable"}, true, false),
 		genericURIConnector("allium", "Allium", []string{"allium"}, true, false),
 		genericURIConnector("amplitude", "Amplitude", []string{"amplitude"}, true, false),

--- a/pkg/source/adapty/adapty.go
+++ b/pkg/source/adapty/adapty.go
@@ -1,0 +1,849 @@
+package adapty
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
+)
+
+const (
+	analyticsBaseURL    = "https://api-admin.adapty.io"
+	serverBaseURL       = "https://api.adapty.io"
+	defaultLookbackDays = 30
+	// Adapty allows 2 analytics requests/second and 40,000 server-side
+	// requests/minute. Keep both independent limiters at 80% of those limits.
+	analyticsRateLimit   = 1.6
+	serverRateLimit      = 533.33
+	defaultResultBuffer  = 8
+	defaultPaywallPage   = 100
+	maximumPaywallPages  = 100000
+	adaptyDateLayout     = "2006-01-02"
+	analyticsContentType = "application/json"
+)
+
+var supportedTables = []string{
+	"analytics",
+	"cohorts",
+	"conversion",
+	"funnel",
+	"ltv",
+	"retention",
+	"placements",
+	"paywalls",
+}
+
+var metricTables = map[string]string{
+	"analytics":  "/api/v1/client-api/metrics/analytics/",
+	"cohorts":    "/api/v1/client-api/metrics/cohort/",
+	"conversion": "/api/v1/client-api/metrics/conversion/",
+	"funnel":     "/api/v1/client-api/metrics/funnel/",
+	"ltv":        "/api/v1/client-api/metrics/ltv/",
+	"retention":  "/api/v1/client-api/metrics/retention/",
+}
+
+var commonMetricParams = []string{
+	"compare_date",
+	"store",
+	"country",
+	"store_product_id",
+	"duration",
+	"attribution_source",
+	"attribution_status",
+	"attribution_channel",
+	"attribution_campaign",
+	"attribution_adgroup",
+	"attribution_adset",
+	"attribution_creative",
+	"offer_category",
+	"offer_type",
+	"offer_id",
+}
+
+type AdaptySource struct {
+	analyticsClient *ingestrhttp.Client
+	serverClient    *ingestrhttp.Client
+	lookbackDays    int
+	location        *time.Location
+}
+
+type adaptyCredentials struct {
+	apiKey       string
+	lookbackDays int
+	timezone     string
+	location     *time.Location
+}
+
+type tableParams struct {
+	CompareDate         []string `mapstructure:"compare_date"`
+	Store               []string `mapstructure:"store"`
+	Country             []string `mapstructure:"country"`
+	StoreProductID      []string `mapstructure:"store_product_id"`
+	Duration            []string `mapstructure:"duration"`
+	AttributionSource   []string `mapstructure:"attribution_source"`
+	AttributionStatus   []string `mapstructure:"attribution_status"`
+	AttributionChannel  []string `mapstructure:"attribution_channel"`
+	AttributionCampaign []string `mapstructure:"attribution_campaign"`
+	AttributionAdgroup  []string `mapstructure:"attribution_adgroup"`
+	AttributionAdset    []string `mapstructure:"attribution_adset"`
+	AttributionCreative []string `mapstructure:"attribution_creative"`
+	OfferCategory       []string `mapstructure:"offer_category"`
+	OfferType           []string `mapstructure:"offer_type"`
+	OfferID             []string `mapstructure:"offer_id"`
+	ChartID             string   `mapstructure:"chart_id"`
+	DateType            string   `mapstructure:"date_type"`
+	Segmentation        string   `mapstructure:"segmentation"`
+	PeriodType          string   `mapstructure:"period_type"`
+	ValueType           string   `mapstructure:"value_type"`
+	ValueField          string   `mapstructure:"value_field"`
+	AccountingType      string   `mapstructure:"accounting_type"`
+	RenewalDays         []string `mapstructure:"renewal_days"`
+	PredictionMonths    int      `mapstructure:"prediction_months"`
+	FromPeriod          string   `mapstructure:"from_period"`
+	ToPeriod            string   `mapstructure:"to_period"`
+	ShowValueAs         string   `mapstructure:"show_value_as"`
+	UseTrial            bool     `mapstructure:"use_trial"`
+	PlacementType       string   `mapstructure:"placement_type"`
+
+	fromPeriodSet    bool
+	renewalDayValues []int
+}
+
+func NewAdaptySource() *AdaptySource {
+	return &AdaptySource{}
+}
+
+func (s *AdaptySource) Schemes() []string {
+	return []string{"adapty"}
+}
+
+func (s *AdaptySource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *AdaptySource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseAdaptyURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.lookbackDays = creds.lookbackDays
+	s.location = creds.location
+	auth := ingestrhttp.NewAPIKeyAuth("Authorization", "Api-Key "+creds.apiKey, true)
+
+	s.analyticsClient = ingestrhttp.New(
+		ingestrhttp.WithBaseURL(analyticsBaseURL),
+		ingestrhttp.WithTimeout(2*time.Minute),
+		ingestrhttp.WithRateLimiter(analyticsRateLimit, 1),
+		ingestrhttp.WithAuth(auth),
+		ingestrhttp.WithAllowNonIdempotentRetry(),
+		ingestrhttp.WithDebug(config.DebugMode),
+		ingestrhttp.WithHeaders(map[string]string{
+			"Accept":       analyticsContentType,
+			"Content-Type": analyticsContentType,
+			"Adapty-Tz":    creds.timezone,
+		}),
+	)
+	s.serverClient = ingestrhttp.New(
+		ingestrhttp.WithBaseURL(serverBaseURL),
+		ingestrhttp.WithTimeout(2*time.Minute),
+		ingestrhttp.WithRateLimiter(serverRateLimit, 5),
+		ingestrhttp.WithAuth(auth),
+		ingestrhttp.WithDebug(config.DebugMode),
+	)
+
+	config.Debug("[ADAPTY] Connected successfully")
+	return nil
+}
+
+func parseAdaptyURI(uri string) (adaptyCredentials, error) {
+	if !strings.HasPrefix(uri, "adapty://") {
+		return adaptyCredentials{}, fmt.Errorf("invalid adapty URI: must start with adapty://")
+	}
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return adaptyCredentials{}, fmt.Errorf("failed to parse adapty URI: %w", err)
+	}
+	if parsed.Scheme != "adapty" {
+		return adaptyCredentials{}, fmt.Errorf("invalid adapty URI: must start with adapty://")
+	}
+	if parsed.Host != "" || parsed.Path != "" {
+		return adaptyCredentials{}, fmt.Errorf("invalid adapty URI: credentials must be query parameters (adapty://?api_key=...)")
+	}
+
+	values, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return adaptyCredentials{}, fmt.Errorf("failed to parse adapty URI query: %w", err)
+	}
+	for key := range values {
+		switch key {
+		case "api_key", "lookback_days", "timezone":
+		default:
+			return adaptyCredentials{}, fmt.Errorf("unknown adapty URI parameter: %s", key)
+		}
+	}
+
+	apiKey := values.Get("api_key")
+	if apiKey == "" {
+		return adaptyCredentials{}, fmt.Errorf("api_key is required in adapty URI (adapty://?api_key=...)")
+	}
+
+	lookbackDays := defaultLookbackDays
+	if raw := values.Get("lookback_days"); raw != "" {
+		lookbackDays, err = strconv.Atoi(raw)
+		if err != nil || lookbackDays < 0 {
+			return adaptyCredentials{}, fmt.Errorf("lookback_days must be a non-negative integer")
+		}
+	}
+
+	timezone := values.Get("timezone")
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return adaptyCredentials{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
+	}
+
+	return adaptyCredentials{
+		apiKey:       apiKey,
+		lookbackDays: lookbackDays,
+		timezone:     timezone,
+		location:     location,
+	}, nil
+}
+
+func (s *AdaptySource) Close(ctx context.Context) error {
+	var errs []error
+	if s.analyticsClient != nil {
+		errs = append(errs, s.analyticsClient.Close())
+	}
+	if s.serverClient != nil {
+		errs = append(errs, s.serverClient.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func (s *AdaptySource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName, params, err := parseTableSpec(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !isValidTable(tableName) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, strings.Join(supportedTables, ", "))
+	}
+
+	table := &source.DynamicSourceTable{
+		TableName:   tableName,
+		KnownSchema: false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("adapty source does not have a predefined schema; schema inference is required")
+		},
+	}
+
+	switch tableName {
+	case "paywalls":
+		table.TablePrimaryKeys = []string{"paywall_id"}
+		table.TableIncrementalKey = "updated_at"
+		table.TableStrategy = config.StrategyMerge
+		table.ReadFn = func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.readPaywalls(ctx, opts)
+		}
+	case "placements":
+		table.TablePrimaryKeys = req.PrimaryKeys
+		table.TableStrategy = config.StrategyReplace
+		table.ReadFn = func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.readPlacements(ctx, params, opts)
+		}
+	default:
+		table.TablePrimaryKeys = req.PrimaryKeys
+		table.TableIncrementalKey = "date"
+		table.TableStrategy = config.StrategyDeleteInsert
+		table.TablePartitionBy = "date"
+		table.ReadFn = func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.readMetricTable(ctx, tableName, params, opts)
+		}
+	}
+
+	return table, nil
+}
+
+func isValidTable(table string) bool {
+	for _, supported := range supportedTables {
+		if table == supported {
+			return true
+		}
+	}
+	return false
+}
+
+func parseTableSpec(raw string) (string, tableParams, error) {
+	path, values, hasParams, err := tablespec.Split(raw)
+	if err != nil {
+		return "", tableParams{}, err
+	}
+	if !isValidTable(path) {
+		return path, tableParams{}, nil
+	}
+
+	allowed := allowedParams(path)
+	if hasParams {
+		if len(allowed) == 0 {
+			return "", tableParams{}, fmt.Errorf("%s does not accept table parameters", path)
+		}
+		if err := tablespec.ValidateKeys(values, allowed...); err != nil {
+			return "", tableParams{}, err
+		}
+	}
+
+	var params tableParams
+	if _, _, err := tablespec.Parse(raw, &params, tablespec.WithListSeparator(",")); err != nil {
+		return "", tableParams{}, err
+	}
+	params.fromPeriodSet = values.Has("from_period")
+	if err := validateTableParams(path, &params); err != nil {
+		return "", tableParams{}, err
+	}
+	return path, params, nil
+}
+
+func allowedParams(table string) []string {
+	var specific []string
+	switch table {
+	case "analytics":
+		specific = []string{"chart_id", "date_type", "segmentation"}
+	case "cohorts":
+		specific = []string{"period_type", "value_type", "value_field", "accounting_type", "renewal_days", "prediction_months"}
+	case "conversion":
+		specific = []string{"from_period", "to_period", "date_type", "segmentation"}
+	case "funnel":
+		specific = []string{"show_value_as", "segmentation"}
+	case "ltv":
+		specific = []string{"period_type", "segmentation"}
+	case "retention":
+		specific = []string{"segmentation", "use_trial"}
+	case "placements":
+		return []string{"placement_type"}
+	case "paywalls":
+		return nil
+	}
+	return append(append([]string{}, commonMetricParams...), specific...)
+}
+
+func validateTableParams(table string, params *tableParams) error {
+	if len(params.CompareDate) > 0 {
+		if len(params.CompareDate) != 2 {
+			return fmt.Errorf("compare_date must contain exactly two dates")
+		}
+		for _, value := range params.CompareDate {
+			if _, err := time.Parse(adaptyDateLayout, value); err != nil {
+				return fmt.Errorf("compare_date contains invalid date %q; expected YYYY-MM-DD", value)
+			}
+		}
+	}
+
+	if err := validateEnum("date_type", params.DateType, "purchase_date", "profile_install_date"); err != nil {
+		return err
+	}
+	if err := validateEnum("period_type", params.PeriodType, "renewals", "days"); err != nil {
+		return err
+	}
+
+	switch table {
+	case "analytics":
+		if params.ChartID == "" {
+			return fmt.Errorf("analytics requires chart_id")
+		}
+		if err := validateEnum("chart_id", params.ChartID,
+			"revenue", "mrr", "arr", "arppu", "subscriptions_active", "subscriptions_new",
+			"subscriptions_renewal_cancelled", "subscriptions_expired", "trials_active", "trials_new",
+			"trials_renewal_cancelled", "trials_expired", "grace_period", "billing_issue", "refund_events",
+			"refund_money", "non_subscriptions", "arpu", "installs"); err != nil {
+			return err
+		}
+	case "cohorts":
+		if err := validateEnum("value_type", params.ValueType, "absolute", "relative"); err != nil {
+			return err
+		}
+		if err := validateEnum("value_field", params.ValueField, "revenue", "arppu", "arpu", "arpas", "subscribers", "subscriptions"); err != nil {
+			return err
+		}
+		if err := validateEnum("accounting_type", params.AccountingType, "revenue", "proceeds", "net_revenue"); err != nil {
+			return err
+		}
+		if params.PredictionMonths != 0 && !containsInt([]int{3, 6, 9, 12, 18, 24}, params.PredictionMonths) {
+			return fmt.Errorf("invalid prediction_months %d (supported: 3, 6, 9, 12, 18, 24)", params.PredictionMonths)
+		}
+		for _, raw := range params.RenewalDays {
+			day, err := strconv.Atoi(raw)
+			if err != nil || day < 0 {
+				return fmt.Errorf("renewal_days must contain non-negative integers")
+			}
+			params.renewalDayValues = append(params.renewalDayValues, day)
+		}
+	case "conversion":
+		if !params.fromPeriodSet {
+			return fmt.Errorf("conversion requires from_period (use from_period=null for no starting state)")
+		}
+		if params.ToPeriod == "" {
+			return fmt.Errorf("conversion requires to_period")
+		}
+	case "funnel":
+		if err := validateEnum("show_value_as", params.ShowValueAs, "absolute", "relative", "both"); err != nil {
+			return err
+		}
+	case "placements":
+		if params.PlacementType == "" {
+			return fmt.Errorf("placements requires placement_type")
+		}
+		if err := validateEnum("placement_type", params.PlacementType, "paywall", "onboarding"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEnum(name, value string, allowed ...string) error {
+	if value == "" {
+		return nil
+	}
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid %s %q (supported: %s)", name, value, strings.Join(allowed, ", "))
+}
+
+func containsInt(values []int, target int) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *AdaptySource) readMetricTable(ctx context.Context, table string, params tableParams, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, source.RecordBatchBufferSize(opts, defaultResultBuffer))
+	start, end, err := s.resolveDateRange(&opts)
+	if err != nil {
+		close(results)
+		return nil, err
+	}
+
+	go func() {
+		defer close(results)
+
+		for date := start; !date.After(end); date = date.AddDate(0, 0, 1) {
+			if err := ctx.Err(); err != nil {
+				emitError(ctx, results, err)
+				return
+			}
+
+			dateString := date.Format(adaptyDateLayout)
+			body := buildMetricRequest(table, params, dateString)
+			response, err := s.analyticsClient.R(ctx).SetBody(body).Post(metricTables[table])
+			if err != nil {
+				emitError(ctx, results, fmt.Errorf("failed to fetch %s for %s: %w", table, dateString, err))
+				return
+			}
+			if !response.IsSuccess() {
+				emitError(ctx, results, fmt.Errorf("failed to fetch %s for %s: status %d: %s", table, dateString, response.StatusCode(), response.String()))
+				return
+			}
+
+			var payload map[string]any
+			if err := decodeJSONUseNumber(response.Body(), &payload); err != nil {
+				emitError(ctx, results, fmt.Errorf("failed to parse %s response for %s: %w", table, dateString, err))
+				return
+			}
+			rows, err := metricRows(table, params, dateString, payload)
+			if err != nil {
+				emitError(ctx, results, err)
+				return
+			}
+			if len(rows) > 0 {
+				if err := emitRows(ctx, results, rows, metricColumns(table), opts.ExcludeColumns); err != nil {
+					emitError(ctx, results, fmt.Errorf("failed to emit %s rows for %s: %w", table, dateString, err))
+					return
+				}
+			}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *AdaptySource) resolveDateRange(opts *source.ReadOptions) (time.Time, time.Time, error) {
+	location := s.location
+	if location == nil {
+		location = time.UTC
+	}
+	now := dayInLocation(time.Now(), location)
+	start := now.AddDate(0, 0, -s.lookbackDays)
+	end := now
+
+	if opts.IntervalStart != nil {
+		start = dayInLocation(*opts.IntervalStart, location).AddDate(0, 0, -s.lookbackDays)
+		*opts.IntervalStart = start
+	}
+	if opts.IntervalEnd != nil {
+		end = dayInLocation(*opts.IntervalEnd, location)
+	}
+	if start.After(end) {
+		return time.Time{}, time.Time{}, fmt.Errorf("adapty interval start (%s) must not be after interval end (%s)", start.Format(adaptyDateLayout), end.Format(adaptyDateLayout))
+	}
+	return start, end, nil
+}
+
+func dayInLocation(value time.Time, location *time.Location) time.Time {
+	value = value.In(location)
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, location)
+}
+
+func buildMetricRequest(table string, params tableParams, date string) map[string]any {
+	body := map[string]any{
+		"filters":     buildMetricFilters(params, date),
+		"period_unit": "day",
+		"format":      "json",
+	}
+
+	switch table {
+	case "analytics":
+		body["chart_id"] = params.ChartID
+		setString(body, "date_type", params.DateType)
+		setString(body, "segmentation", params.Segmentation)
+	case "cohorts":
+		setString(body, "period_type", params.PeriodType)
+		setString(body, "value_type", params.ValueType)
+		setString(body, "value_field", params.ValueField)
+		setString(body, "accounting_type", params.AccountingType)
+		if len(params.renewalDayValues) > 0 {
+			body["renewal_days"] = params.renewalDayValues
+		}
+		if params.PredictionMonths > 0 {
+			body["prediction_months"] = params.PredictionMonths
+		}
+	case "conversion":
+		if params.FromPeriod == "" || params.FromPeriod == "null" {
+			body["from_period"] = nil
+		} else {
+			body["from_period"] = params.FromPeriod
+		}
+		body["to_period"] = params.ToPeriod
+		setString(body, "date_type", params.DateType)
+		setString(body, "segmentation", params.Segmentation)
+	case "funnel":
+		setString(body, "show_value_as", params.ShowValueAs)
+		setString(body, "segmentation", params.Segmentation)
+	case "ltv":
+		setString(body, "period_type", params.PeriodType)
+		setString(body, "segmentation", params.Segmentation)
+	case "retention":
+		setString(body, "segmentation", params.Segmentation)
+		if params.UseTrial {
+			body["use_trial"] = true
+		}
+	}
+	return body
+}
+
+func buildMetricFilters(params tableParams, date string) map[string]any {
+	filters := map[string]any{"date": []string{date, date}}
+	setStrings(filters, "compare_date", params.CompareDate)
+	setStrings(filters, "store", params.Store)
+	setStrings(filters, "country", params.Country)
+	setStrings(filters, "store_product_id", params.StoreProductID)
+	setStrings(filters, "duration", params.Duration)
+	setStrings(filters, "attribution_source", params.AttributionSource)
+	setStrings(filters, "attribution_status", params.AttributionStatus)
+	setStrings(filters, "attribution_channel", params.AttributionChannel)
+	setStrings(filters, "attribution_campaign", params.AttributionCampaign)
+	setStrings(filters, "attribution_adgroup", params.AttributionAdgroup)
+	setStrings(filters, "attribution_adset", params.AttributionAdset)
+	setStrings(filters, "attribution_creative", params.AttributionCreative)
+	setStrings(filters, "offer_category", params.OfferCategory)
+	setStrings(filters, "offer_type", params.OfferType)
+	setStrings(filters, "offer_id", params.OfferID)
+	return filters
+}
+
+func setString(target map[string]any, key, value string) {
+	if value != "" {
+		target[key] = value
+	}
+}
+
+func setStrings(target map[string]any, key string, values []string) {
+	if len(values) > 0 {
+		target[key] = values
+	}
+}
+
+func metricRows(table string, params tableParams, date string, payload map[string]any) ([]map[string]any, error) {
+	switch table {
+	case "analytics":
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected analytics response: data is not an object")
+		}
+		keys := make([]string, 0, len(data))
+		for key := range data {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		rows := make([]map[string]any, 0, len(keys))
+		for _, key := range keys {
+			item, ok := data[key].(map[string]any)
+			if !ok {
+				continue
+			}
+			row := cloneMap(item)
+			row["date"] = date
+			row["metric"] = key
+			row["chart_id"] = params.ChartID
+			rows = append(rows, row)
+		}
+		return rows, nil
+	case "cohorts", "funnel":
+		data, ok := payload["data"].([]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected %s response: data is not an array", table)
+		}
+		rows := make([]map[string]any, 0, len(data))
+		for _, value := range data {
+			item, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			row := cloneMap(item)
+			row["date"] = date
+			rows = append(rows, row)
+		}
+		return rows, nil
+	case "conversion", "retention":
+		row := cloneMap(payload)
+		row["date"] = date
+		return []map[string]any{row}, nil
+	case "ltv":
+		rows := make([]map[string]any, 0, 3)
+		for _, accountingType := range []string{"revenue", "proceeds", "net_revenue"} {
+			item, ok := payload[accountingType].(map[string]any)
+			if !ok {
+				continue
+			}
+			row := cloneMap(item)
+			row["date"] = date
+			row["accounting_type"] = accountingType
+			rows = append(rows, row)
+		}
+		return rows, nil
+	default:
+		return nil, fmt.Errorf("unsupported metric table: %s", table)
+	}
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	output := make(map[string]any, len(input)+2)
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func metricColumns(table string) []schema.Column {
+	columns := []schema.Column{{Name: "date", DataType: schema.TypeDate, Nullable: false}}
+	if table == "analytics" {
+		columns = append(
+			columns,
+			schema.Column{Name: "metric", DataType: schema.TypeString, Nullable: false},
+			schema.Column{Name: "chart_id", DataType: schema.TypeString, Nullable: false},
+		)
+	}
+	if table == "ltv" {
+		columns = append(columns, schema.Column{Name: "accounting_type", DataType: schema.TypeString, Nullable: false})
+	}
+	return columns
+}
+
+func (s *AdaptySource) readPlacements(ctx context.Context, params tableParams, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, source.RecordBatchBufferSize(opts, 1))
+	go func() {
+		defer close(results)
+
+		body := map[string]any{"filters": map[string]any{"placement_type": params.PlacementType}}
+		response, err := s.analyticsClient.R(ctx).SetBody(body).Post("/api/v1/client-api/exports/placements/")
+		if err != nil {
+			emitError(ctx, results, fmt.Errorf("failed to fetch placements: %w", err))
+			return
+		}
+		if !response.IsSuccess() {
+			emitError(ctx, results, fmt.Errorf("failed to fetch placements: status %d: %s", response.StatusCode(), response.String()))
+			return
+		}
+
+		var payload struct {
+			Data []map[string]any `json:"data"`
+		}
+		if err := decodeJSONUseNumber(response.Body(), &payload); err != nil {
+			emitError(ctx, results, fmt.Errorf("failed to parse placements response: %w", err))
+			return
+		}
+		if len(payload.Data) == 0 {
+			return
+		}
+		if err := emitRows(ctx, results, payload.Data, nil, opts.ExcludeColumns); err != nil {
+			emitError(ctx, results, fmt.Errorf("failed to emit placements: %w", err))
+		}
+	}()
+	return results, nil
+}
+
+func (s *AdaptySource) readPaywalls(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, source.RecordBatchBufferSize(opts, defaultResultBuffer))
+	go func() {
+		defer close(results)
+
+		pageSize := opts.PageSize
+		if pageSize <= 0 || pageSize > defaultPaywallPage {
+			pageSize = defaultPaywallPage
+		}
+		for page := 1; page <= maximumPaywallPages; page++ {
+			if err := ctx.Err(); err != nil {
+				emitError(ctx, results, err)
+				return
+			}
+
+			response, err := s.serverClient.R(ctx).
+				SetQueryParam("page[number]", strconv.Itoa(page)).
+				SetQueryParam("page[size]", strconv.Itoa(pageSize)).
+				Get("/api/v2/server-side-api/paywalls/")
+			if err != nil {
+				emitError(ctx, results, fmt.Errorf("failed to fetch paywalls page %d: %w", page, err))
+				return
+			}
+			if !response.IsSuccess() {
+				emitError(ctx, results, fmt.Errorf("failed to fetch paywalls page %d: status %d: %s", page, response.StatusCode(), response.String()))
+				return
+			}
+
+			var payload struct {
+				Data []map[string]any `json:"data"`
+				Meta struct {
+					Pagination struct {
+						Page  int `json:"page"`
+						Pages int `json:"pages"`
+					} `json:"pagination"`
+				} `json:"meta"`
+			}
+			if err := decodeJSONUseNumber(response.Body(), &payload); err != nil {
+				emitError(ctx, results, fmt.Errorf("failed to parse paywalls page %d: %w", page, err))
+				return
+			}
+			if len(payload.Data) == 0 {
+				return
+			}
+
+			rows, err := filterPaywallsByUpdatedAt(payload.Data, opts.IntervalStart, opts.IntervalEnd)
+			if err != nil {
+				emitError(ctx, results, err)
+				return
+			}
+			if len(rows) > 0 {
+				if err := emitRows(ctx, results, rows, paywallColumns(), opts.ExcludeColumns); err != nil {
+					emitError(ctx, results, fmt.Errorf("failed to emit paywalls page %d: %w", page, err))
+					return
+				}
+			}
+			if payload.Meta.Pagination.Pages <= page || len(payload.Data) < pageSize {
+				return
+			}
+		}
+
+		emitError(ctx, results, fmt.Errorf("paywalls pagination exceeded %d pages", maximumPaywallPages))
+	}()
+	return results, nil
+}
+
+func filterPaywallsByUpdatedAt(rows []map[string]any, start, end *time.Time) ([]map[string]any, error) {
+	if start == nil && end == nil {
+		return rows, nil
+	}
+
+	filtered := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		raw, ok := row["updated_at"].(string)
+		if !ok || raw == "" {
+			return nil, fmt.Errorf("paywall response is missing updated_at")
+		}
+		updatedAt, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid paywall updated_at %q: %w", raw, err)
+		}
+		if start != nil && updatedAt.Before(*start) {
+			continue
+		}
+		if end != nil && updatedAt.After(*end) {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	return filtered, nil
+}
+
+func paywallColumns() []schema.Column {
+	return []schema.Column{
+		{Name: "paywall_id", DataType: schema.TypeString, Nullable: false},
+		{Name: "created_at", DataType: schema.TypeTimestampTZ, Nullable: false},
+		{Name: "updated_at", DataType: schema.TypeTimestampTZ, Nullable: false},
+	}
+}
+
+func decodeJSONUseNumber(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("response contains multiple JSON values")
+	}
+	return nil
+}
+
+func emitRows(ctx context.Context, results chan<- source.RecordBatchResult, rows []map[string]any, columns []schema.Column, excludeColumns []string) error {
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(rows, columns, excludeColumns)
+	if err != nil {
+		return err
+	}
+	select {
+	case results <- source.RecordBatchResult{Batch: record}:
+		return nil
+	case <-ctx.Done():
+		record.Release()
+		return ctx.Err()
+	}
+}
+
+func emitError(ctx context.Context, results chan<- source.RecordBatchResult, err error) {
+	select {
+	case results <- source.RecordBatchResult{Err: err}:
+	case <-ctx.Done():
+	}
+}

--- a/pkg/source/adapty/adapty.go
+++ b/pkg/source/adapty/adapty.go
@@ -499,8 +499,7 @@ func (s *AdaptySource) resolveDateRange(opts *source.ReadOptions) (time.Time, ti
 	end := now
 
 	if opts.IntervalStart != nil {
-		start = dayInLocation(*opts.IntervalStart, location).AddDate(0, 0, -s.lookbackDays)
-		*opts.IntervalStart = start
+		start = dayInLocation(*opts.IntervalStart, location)
 	}
 	if opts.IntervalEnd != nil {
 		end = dayInLocation(*opts.IntervalEnd, location)
@@ -598,7 +597,11 @@ func setStrings(target map[string]any, key string, values []string) {
 func metricRows(table string, params tableParams, date string, payload map[string]any) ([]map[string]any, error) {
 	switch table {
 	case "analytics":
-		data, ok := payload["data"].(map[string]any)
+		rawData, exists := payload["data"]
+		if !exists || rawData == nil {
+			return nil, nil
+		}
+		data, ok := rawData.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("unexpected analytics response: data is not an object")
 		}
@@ -621,7 +624,11 @@ func metricRows(table string, params tableParams, date string, payload map[strin
 		}
 		return rows, nil
 	case "cohorts", "funnel":
-		data, ok := payload["data"].([]any)
+		rawData, exists := payload["data"]
+		if !exists || rawData == nil {
+			return nil, nil
+		}
+		data, ok := rawData.([]any)
 		if !ok {
 			return nil, fmt.Errorf("unexpected %s response: data is not an array", table)
 		}
@@ -770,7 +777,7 @@ func (s *AdaptySource) readPaywalls(ctx context.Context, opts source.ReadOptions
 					return
 				}
 			}
-			if payload.Meta.Pagination.Pages <= page || len(payload.Data) < pageSize {
+			if len(payload.Data) < pageSize || (payload.Meta.Pagination.Pages > 0 && payload.Meta.Pagination.Pages <= page) {
 				return
 			}
 		}

--- a/pkg/source/adapty/adapty_test.go
+++ b/pkg/source/adapty/adapty_test.go
@@ -1,0 +1,360 @@
+package adapty
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAdaptyURI(t *testing.T) {
+	tests := []struct {
+		name          string
+		uri           string
+		wantKey       string
+		wantLookback  int
+		wantTimezone  string
+		wantErrSubstr string
+	}{
+		{
+			name:         "defaults",
+			uri:          "adapty://?api_key=secret_live_test",
+			wantKey:      "secret_live_test",
+			wantLookback: 30,
+			wantTimezone: "UTC",
+		},
+		{
+			name:         "custom lookback and timezone",
+			uri:          "adapty://?api_key=secret&lookback_days=0&timezone=Europe%2FIstanbul",
+			wantKey:      "secret",
+			wantLookback: 0,
+			wantTimezone: "Europe/Istanbul",
+		},
+		{name: "wrong scheme", uri: "https://example.com", wantErrSubstr: "must start with adapty://"},
+		{name: "missing slashes", uri: "adapty:?api_key=secret", wantErrSubstr: "must start with adapty://"},
+		{name: "host is rejected", uri: "adapty://secret", wantErrSubstr: "credentials must be query parameters"},
+		{name: "missing key", uri: "adapty://?lookback_days=5", wantErrSubstr: "api_key is required"},
+		{name: "negative lookback", uri: "adapty://?api_key=x&lookback_days=-1", wantErrSubstr: "non-negative integer"},
+		{name: "invalid lookback", uri: "adapty://?api_key=x&lookback_days=many", wantErrSubstr: "non-negative integer"},
+		{name: "invalid timezone", uri: "adapty://?api_key=x&timezone=Moon%2FSea", wantErrSubstr: "invalid timezone"},
+		{name: "unknown parameter", uri: "adapty://?api_key=x&foo=bar", wantErrSubstr: "unknown adapty URI parameter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := parseAdaptyURI(tt.uri)
+			if tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKey, creds.apiKey)
+			assert.Equal(t, tt.wantLookback, creds.lookbackDays)
+			assert.Equal(t, tt.wantTimezone, creds.timezone)
+			assert.Equal(t, tt.wantTimezone, creds.location.String())
+		})
+	}
+}
+
+func TestSupportedTables(t *testing.T) {
+	for _, table := range supportedTables {
+		assert.True(t, isValidTable(table), table)
+	}
+	for _, table := range []string{"", "cohort", "transactions", "profiles", "webhooks"} {
+		assert.False(t, isValidTable(table), table)
+	}
+}
+
+func TestParseTableSpec(t *testing.T) {
+	tests := []struct {
+		name          string
+		table         string
+		wantName      string
+		assertParams  func(*testing.T, tableParams)
+		wantErrSubstr string
+	}{
+		{
+			name:     "analytics with filters",
+			table:    "analytics?chart_id=revenue&store=app_store,play_store&country=us&segmentation=country",
+			wantName: "analytics",
+			assertParams: func(t *testing.T, params tableParams) {
+				assert.Equal(t, "revenue", params.ChartID)
+				assert.Equal(t, []string{"app_store", "play_store"}, params.Store)
+				assert.Equal(t, []string{"us"}, params.Country)
+				assert.Equal(t, "country", params.Segmentation)
+			},
+		},
+		{
+			name:     "cohort numeric parameters",
+			table:    "cohorts?period_type=days&renewal_days=0,3,7&prediction_months=12",
+			wantName: "cohorts",
+			assertParams: func(t *testing.T, params tableParams) {
+				assert.Equal(t, []int{0, 3, 7}, params.renewalDayValues)
+				assert.Equal(t, 12, params.PredictionMonths)
+			},
+		},
+		{
+			name:     "conversion null starting state",
+			table:    "conversion?from_period=null&to_period=paid",
+			wantName: "conversion",
+			assertParams: func(t *testing.T, params tableParams) {
+				assert.True(t, params.fromPeriodSet)
+				assert.Equal(t, "null", params.FromPeriod)
+			},
+		},
+		{
+			name:     "placement type",
+			table:    "placements?placement_type=paywall",
+			wantName: "placements",
+			assertParams: func(t *testing.T, params tableParams) {
+				assert.Equal(t, "paywall", params.PlacementType)
+			},
+		},
+		{name: "paywalls", table: "paywalls", wantName: "paywalls"},
+		{name: "analytics requires chart", table: "analytics", wantErrSubstr: "requires chart_id"},
+		{name: "invalid chart", table: "analytics?chart_id=purchases", wantErrSubstr: "invalid chart_id"},
+		{name: "conversion requires from", table: "conversion?to_period=paid", wantErrSubstr: "requires from_period"},
+		{name: "conversion requires to", table: "conversion?from_period=trial", wantErrSubstr: "requires to_period"},
+		{name: "placements requires type", table: "placements", wantErrSubstr: "requires placement_type"},
+		{name: "invalid placement type", table: "placements?placement_type=flow", wantErrSubstr: "invalid placement_type"},
+		{name: "unknown parameter", table: "retention?unknown=value", wantErrSubstr: "unknown table parameter"},
+		{name: "parameter on paywalls", table: "paywalls?state=live", wantErrSubstr: "does not accept table parameters"},
+		{name: "invalid comparison", table: "ltv?compare_date=2024-01-01", wantErrSubstr: "exactly two dates"},
+		{name: "invalid renewal day", table: "cohorts?renewal_days=one", wantErrSubstr: "non-negative integers"},
+		{name: "invalid prediction", table: "cohorts?prediction_months=5", wantErrSubstr: "invalid prediction_months"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, params, err := parseTableSpec(tt.table)
+			if tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, name)
+			if tt.assertParams != nil {
+				tt.assertParams(t, params)
+			}
+		})
+	}
+}
+
+func TestGetTableConfiguration(t *testing.T) {
+	src := &AdaptySource{}
+	tests := []struct {
+		name           string
+		request        string
+		strategy       config.IncrementalStrategy
+		primaryKeys    []string
+		incrementalKey string
+		partitionBy    string
+	}{
+		{name: "analytics", request: "analytics?chart_id=revenue", strategy: config.StrategyDeleteInsert, incrementalKey: "date", partitionBy: "date"},
+		{name: "cohorts", request: "cohorts", strategy: config.StrategyDeleteInsert, incrementalKey: "date", partitionBy: "date"},
+		{name: "placements", request: "placements?placement_type=paywall", strategy: config.StrategyReplace},
+		{name: "paywalls", request: "paywalls", strategy: config.StrategyMerge, primaryKeys: []string{"paywall_id"}, incrementalKey: "updated_at"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table, err := src.GetTable(context.Background(), source.TableRequest{Name: tt.request})
+			require.NoError(t, err)
+			assert.Equal(t, tt.strategy, table.Strategy())
+			assert.Equal(t, tt.primaryKeys, table.PrimaryKeys())
+			assert.Equal(t, tt.incrementalKey, table.IncrementalKey())
+			assert.False(t, table.HasKnownSchema())
+			if partitioned, ok := table.(source.PartitionedTable); ok {
+				assert.Equal(t, tt.partitionBy, partitioned.PartitionBy())
+			}
+		})
+	}
+}
+
+func TestBuildMetricRequest(t *testing.T) {
+	params := tableParams{
+		ChartID:             "refund_money",
+		DateType:            "purchase_date",
+		Segmentation:        "country",
+		Store:               []string{"app_store"},
+		Country:             []string{"us", "gb"},
+		AttributionCampaign: []string{"summer"},
+	}
+	body := buildMetricRequest("analytics", params, "2025-06-01")
+
+	assert.Equal(t, "refund_money", body["chart_id"])
+	assert.Equal(t, "day", body["period_unit"])
+	assert.Equal(t, "json", body["format"])
+	assert.Equal(t, "purchase_date", body["date_type"])
+	filters := body["filters"].(map[string]any)
+	assert.Equal(t, []string{"2025-06-01", "2025-06-01"}, filters["date"])
+	assert.Equal(t, []string{"app_store"}, filters["store"])
+	assert.Equal(t, []string{"us", "gb"}, filters["country"])
+	assert.Equal(t, []string{"summer"}, filters["attribution_campaign"])
+}
+
+func TestMetricRowsPreserveNestedData(t *testing.T) {
+	payload := map[string]any{
+		"data": map[string]any{
+			"revenue": map[string]any{
+				"value": json.Number("12.34"),
+				"data":  []any{map[string]any{"value": json.Number("12.34")}},
+			},
+		},
+	}
+	rows, err := metricRows("analytics", tableParams{ChartID: "revenue"}, "2025-01-02", payload)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "2025-01-02", rows[0]["date"])
+	assert.Equal(t, "revenue", rows[0]["metric"])
+	assert.Equal(t, "revenue", rows[0]["chart_id"])
+	assert.IsType(t, []any{}, rows[0]["data"])
+	assert.IsType(t, json.Number(""), rows[0]["value"])
+
+	ltvRows, err := metricRows("ltv", tableParams{}, "2025-01-02", map[string]any{
+		"revenue":     map[string]any{"data": []any{}},
+		"proceeds":    map[string]any{"data": []any{}},
+		"net_revenue": map[string]any{"data": []any{}},
+	})
+	require.NoError(t, err)
+	assert.Len(t, ltvRows, 3)
+	assert.Equal(t, "net_revenue", ltvRows[2]["accounting_type"])
+}
+
+func TestDecodeJSONUseNumber(t *testing.T) {
+	var payload map[string]any
+	require.NoError(t, decodeJSONUseNumber([]byte(`{"integer":9007199254740993,"decimal":12.34}`), &payload))
+	assert.Equal(t, json.Number("9007199254740993"), payload["integer"])
+	assert.Equal(t, json.Number("12.34"), payload["decimal"])
+	assert.Error(t, decodeJSONUseNumber([]byte(`{} {}`), &payload))
+}
+
+func TestResolveDateRangeAppliesLookback(t *testing.T) {
+	start := time.Date(2025, 1, 10, 16, 30, 0, 0, time.FixedZone("offset", 2*60*60))
+	end := time.Date(2025, 1, 12, 23, 0, 0, 0, time.UTC)
+	src := &AdaptySource{lookbackDays: 3, location: time.UTC}
+	opts := source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}
+
+	gotStart, gotEnd, err := src.resolveDateRange(&opts)
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-07", gotStart.Format(adaptyDateLayout))
+	assert.Equal(t, "2025-01-12", gotEnd.Format(adaptyDateLayout))
+	assert.Equal(t, gotStart, *opts.IntervalStart)
+}
+
+func TestReadAnalyticsHTTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "/api/v1/client-api/metrics/analytics/", request.URL.Path)
+		assert.Equal(t, "Api-Key test-secret", request.Header.Get("Authorization"))
+		assert.Equal(t, "UTC", request.Header.Get("Adapty-Tz"))
+
+		var body map[string]any
+		decoder := json.NewDecoder(request.Body)
+		decoder.UseNumber()
+		assert.NoError(t, decoder.Decode(&body))
+		assert.Equal(t, "revenue", body["chart_id"])
+		filters := body["filters"].(map[string]any)
+		assert.Equal(t, []any{"2025-03-04", "2025-03-04"}, filters["date"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"revenue":{"value":12.5,"data":[{"value":12.5}]},"proceeds":{"value":8.0,"data":[]}}}`))
+	}))
+	defer server.Close()
+
+	client := testAdaptyClient(server.URL)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	src := &AdaptySource{analyticsClient: client, lookbackDays: 0, location: time.UTC}
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "analytics?chart_id=revenue"})
+	require.NoError(t, err)
+	date := time.Date(2025, 3, 4, 0, 0, 0, 0, time.UTC)
+	results, err := table.Read(context.Background(), source.ReadOptions{IntervalStart: &date, IntervalEnd: &date, Limit: 1})
+	require.NoError(t, err)
+
+	batches := collectBatches(t, results)
+	require.Len(t, batches, 1)
+	defer batches[0].Release()
+	require.EqualValues(t, 2, batches[0].NumRows())
+	assert.Equal(t, arrow.FixedWidthTypes.Date32, batches[0].Schema().Field(0).Type)
+	dateColumn := batches[0].Column(batches[0].Schema().FieldIndices("date")[0]).(*array.Date32)
+	assert.Equal(t, arrow.Date32FromTime(date), dateColumn.Value(0))
+	metricColumn := batches[0].Column(batches[0].Schema().FieldIndices("metric")[0]).(*array.String)
+	assert.Equal(t, "proceeds", metricColumn.Value(0))
+	assert.Equal(t, "revenue", metricColumn.Value(1))
+}
+
+func TestReadPaywallsPaginatesAndFiltersUpdatedAt(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, http.MethodGet, request.Method)
+		assert.Equal(t, "/api/v2/server-side-api/paywalls/", request.URL.Path)
+		assert.Equal(t, "2", request.URL.Query().Get("page[size]"))
+		assert.Equal(t, "Api-Key test-secret", request.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+
+		switch request.URL.Query().Get("page[number]") {
+		case "1":
+			_, _ = w.Write([]byte(`{"data":[{"paywall_id":"old","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","products":[]},{"paywall_id":"included","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-03T00:00:00Z","products":[]}],"meta":{"pagination":{"count":3,"page":1,"pages":2}}}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"data":[{"paywall_id":"new","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-05T00:00:00Z","products":[]}],"meta":{"pagination":{"count":3,"page":2,"pages":2}}}`))
+		default:
+			http.Error(w, "unexpected page", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client := testAdaptyClient(server.URL)
+	t.Cleanup(func() { assert.NoError(t, client.Close()) })
+	src := &AdaptySource{serverClient: client}
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "paywalls"})
+	require.NoError(t, err)
+	start := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)
+	results, err := table.Read(context.Background(), source.ReadOptions{IntervalStart: &start, IntervalEnd: &end, PageSize: 2})
+	require.NoError(t, err)
+
+	batches := collectBatches(t, results)
+	require.Len(t, batches, 1)
+	defer batches[0].Release()
+	require.EqualValues(t, 1, batches[0].NumRows())
+	idColumn := batches[0].Column(batches[0].Schema().FieldIndices("paywall_id")[0]).(*array.String)
+	assert.Equal(t, "included", idColumn.Value(0))
+	assert.EqualValues(t, 2, requests.Load())
+	assert.Equal(t, schema.DataTypeToArrowType(schema.Column{DataType: schema.TypeTimestampTZ}), batches[0].Schema().Field(batches[0].Schema().FieldIndices("updated_at")[0]).Type)
+}
+
+func testAdaptyClient(baseURL string) *ingestrhttp.Client {
+	return ingestrhttp.New(
+		ingestrhttp.WithBaseURL(baseURL),
+		ingestrhttp.WithDisableRetry(),
+		ingestrhttp.WithAuth(ingestrhttp.NewAPIKeyAuth("Authorization", "Api-Key test-secret", true)),
+		ingestrhttp.WithHeaders(map[string]string{"Content-Type": "application/json", "Adapty-Tz": "UTC"}),
+	)
+}
+
+func collectBatches(t *testing.T, results <-chan source.RecordBatchResult) []arrow.RecordBatch {
+	t.Helper()
+	var batches []arrow.RecordBatch
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch != nil {
+			batches = append(batches, result.Batch)
+		}
+	}
+	return batches
+}

--- a/pkg/source/adapty/adapty_test.go
+++ b/pkg/source/adapty/adapty_test.go
@@ -233,6 +233,22 @@ func TestMetricRowsPreserveNestedData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, ltvRows, 3)
 	assert.Equal(t, "net_revenue", ltvRows[2]["accounting_type"])
+
+	for _, tt := range []struct {
+		table   string
+		payload map[string]any
+	}{
+		{table: "analytics", payload: map[string]any{"data": nil}},
+		{table: "cohorts", payload: map[string]any{}},
+		{table: "funnel", payload: map[string]any{"data": nil}},
+	} {
+		rows, err := metricRows(tt.table, tableParams{}, "2025-01-02", tt.payload)
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	}
+
+	_, err = metricRows("analytics", tableParams{}, "2025-01-02", map[string]any{"data": "invalid"})
+	assert.ErrorContains(t, err, "data is not an object")
 }
 
 func TestDecodeJSONUseNumber(t *testing.T) {
@@ -243,17 +259,18 @@ func TestDecodeJSONUseNumber(t *testing.T) {
 	assert.Error(t, decodeJSONUseNumber([]byte(`{} {}`), &payload))
 }
 
-func TestResolveDateRangeAppliesLookback(t *testing.T) {
+func TestResolveDateRangePreservesExplicitInterval(t *testing.T) {
 	start := time.Date(2025, 1, 10, 16, 30, 0, 0, time.FixedZone("offset", 2*60*60))
 	end := time.Date(2025, 1, 12, 23, 0, 0, 0, time.UTC)
+	originalStart := start
 	src := &AdaptySource{lookbackDays: 3, location: time.UTC}
 	opts := source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}
 
 	gotStart, gotEnd, err := src.resolveDateRange(&opts)
 	require.NoError(t, err)
-	assert.Equal(t, "2025-01-07", gotStart.Format(adaptyDateLayout))
+	assert.Equal(t, "2025-01-10", gotStart.Format(adaptyDateLayout))
 	assert.Equal(t, "2025-01-12", gotEnd.Format(adaptyDateLayout))
-	assert.Equal(t, gotStart, *opts.IntervalStart)
+	assert.Equal(t, originalStart, *opts.IntervalStart)
 }
 
 func TestReadAnalyticsHTTP(t *testing.T) {
@@ -309,7 +326,7 @@ func TestReadPaywallsPaginatesAndFiltersUpdatedAt(t *testing.T) {
 
 		switch request.URL.Query().Get("page[number]") {
 		case "1":
-			_, _ = w.Write([]byte(`{"data":[{"paywall_id":"old","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","products":[]},{"paywall_id":"included","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-03T00:00:00Z","products":[]}],"meta":{"pagination":{"count":3,"page":1,"pages":2}}}`))
+			_, _ = w.Write([]byte(`{"data":[{"paywall_id":"old","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","products":[]},{"paywall_id":"included","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-03T00:00:00Z","products":[]}]}`))
 		case "2":
 			_, _ = w.Write([]byte(`{"data":[{"paywall_id":"new","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-05T00:00:00Z","products":[]}],"meta":{"pagination":{"count":3,"page":2,"pages":2}}}`))
 		default:

--- a/pkg/source/adapty/register.go
+++ b/pkg/source/adapty/register.go
@@ -1,0 +1,10 @@
+package adapty
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"adapty"},
+		func() interface{} { return NewAdaptySource() },
+	)
+}


### PR DESCRIPTION
## What
Add a batch Adapty source connector with incremental analytics and paywall loading.

## Changes
- Support analytics, cohorts, conversion, funnel, LTV, retention, placements, and paywalls.
- Add URI/table validation, rate limiting, tests, catalog registration, and documentation.

## How to test
1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback
- **Risk:** Low; this adds an isolated source connector.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.
