### PR TITLE
Add size-aware benchmark policy and opt-in Spark partitioning

### DIFF
--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -12,7 +12,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
-	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/jackc/pgx/v5"
@@ -485,20 +484,34 @@ func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []
 
 	for i, field := range arrowSchema.Fields() {
 		builders[i] = array.NewBuilder(mem, field.Type)
+		if batchSize > 0 {
+			builders[i].Reserve(batchSize)
+		}
+	}
+
+	fields := rows.FieldDescriptions()
+	if len(fields) != len(builders) {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, fmt.Errorf("postgres returned %d columns, expected %d", len(fields), len(builders))
+	}
+	typeMap := pgtype.NewMap()
+	if conn := rows.Conn(); conn != nil {
+		typeMap = conn.TypeMap()
+	}
+	appenders := make([]postgresRawAppender, len(builders))
+	for i := range builders {
+		appenders[i] = newPostgresRawAppender(builders[i], fields[i], columns[i], typeMap)
 	}
 
 	var rowCount int64
 	for rows.Next() {
-		values, err := rows.Values()
-		if err != nil {
+		if err := appendPostgresRawRow(appenders, builders, rows.RawValues()); err != nil {
 			for _, b := range builders {
 				b.Release()
 			}
-			return nil, 0, fmt.Errorf("failed to get values: %w", err)
-		}
-
-		for i, val := range values {
-			arrowconv.AppendValue(builders[i], convertValue(val, columns[i]))
+			return nil, 0, err
 		}
 		rowCount++
 
@@ -524,6 +537,7 @@ func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []
 	arrays := make([]arrow.Array, len(builders))
 	for i, b := range builders {
 		arrays[i] = b.NewArray()
+		b.Release()
 	}
 
 	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)

--- a/pkg/source/postgres/postgres_benchmark_test.go
+++ b/pkg/source/postgres/postgres_benchmark_test.go
@@ -1,0 +1,300 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const benchmarkPostgresBatchSize = 25_000
+
+var benchmarkArrowRows int64
+
+type syntheticBenchmarkRows struct {
+	fields  []pgconn.FieldDescription
+	values  [][]byte
+	typeMap *pgtype.Map
+	rows    int
+	index   int
+}
+
+func (r *syntheticBenchmarkRows) Close() {}
+
+func (r *syntheticBenchmarkRows) Err() error { return nil }
+
+func (r *syntheticBenchmarkRows) CommandTag() pgconn.CommandTag { return pgconn.CommandTag{} }
+
+func (r *syntheticBenchmarkRows) FieldDescriptions() []pgconn.FieldDescription { return r.fields }
+
+func (r *syntheticBenchmarkRows) Next() bool {
+	if r.index == r.rows {
+		return false
+	}
+	r.index++
+	return true
+}
+
+func (r *syntheticBenchmarkRows) Scan(...any) error { return errors.New("not implemented") }
+
+func (r *syntheticBenchmarkRows) Values() ([]any, error) {
+	values := make([]any, 0, len(r.values))
+	for i, raw := range r.values {
+		field := r.fields[i]
+		dataType, ok := r.typeMap.TypeForOID(field.DataTypeOID)
+		if !ok {
+			return nil, fmt.Errorf("OID %d is not registered", field.DataTypeOID)
+		}
+		value, err := dataType.Codec.DecodeValue(r.typeMap, field.DataTypeOID, field.Format, raw)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func (r *syntheticBenchmarkRows) RawValues() [][]byte { return r.values }
+
+func (r *syntheticBenchmarkRows) Conn() *pgx.Conn { return nil }
+
+func BenchmarkPostgresJSONBToArrow(b *testing.B) {
+	payload := []byte(`{"key": "val_99", "num": 9999999}`)
+	typeMap := pgtype.NewMap()
+	codec := typeMap.TypeForOID
+
+	b.Run("legacy_decode_reencode", func(b *testing.B) {
+		jsonbType, ok := codec(pgtype.JSONBOID)
+		if !ok {
+			b.Fatal("JSONB codec not registered")
+		}
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload) * benchmarkPostgresBatchSize))
+		for b.Loop() {
+			builder := array.NewBuilder(memory.DefaultAllocator, schema.JSONArrowType)
+			for range benchmarkPostgresBatchSize {
+				value, err := jsonbType.Codec.DecodeValue(typeMap, pgtype.JSONBOID, pgx.TextFormatCode, payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+				arrowconv.AppendValue(builder, value)
+			}
+			result := builder.NewArray()
+			benchmarkArrowRows = int64(result.Len())
+			result.Release()
+			builder.Release()
+		}
+	})
+
+	b.Run("optimized_raw_append", func(b *testing.B) {
+		field := pgconn.FieldDescription{DataTypeOID: pgtype.JSONBOID, Format: pgx.TextFormatCode}
+		column := schema.Column{DataType: schema.TypeJSON}
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload) * benchmarkPostgresBatchSize))
+		for b.Loop() {
+			builder := array.NewBuilder(memory.DefaultAllocator, schema.JSONArrowType)
+			builder.Reserve(benchmarkPostgresBatchSize)
+			appendRaw := newPostgresRawAppender(builder, field, column, typeMap)
+			for range benchmarkPostgresBatchSize {
+				if err := appendRaw(payload); err != nil {
+					b.Fatal(err)
+				}
+			}
+			result := builder.NewArray()
+			benchmarkArrowRows = int64(result.Len())
+			result.Release()
+			builder.Release()
+		}
+	})
+}
+
+func BenchmarkPostgresRowBatchToArrow(b *testing.B) {
+	columns, fields, values := benchmarkPostgresRow()
+	arrowSchema := buildArrowSchema(columns)
+	rowBytes := 0
+	for _, value := range values {
+		rowBytes += len(value)
+	}
+
+	b.Run("legacy_values_generic_append", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(rowBytes * benchmarkPostgresBatchSize))
+		for b.Loop() {
+			rows := &syntheticBenchmarkRows{
+				fields: fields, values: values, typeMap: pgtype.NewMap(), rows: benchmarkPostgresBatchSize,
+			}
+			record, count, err := rowsToArrowRecordBatchLegacy(rows, arrowSchema, columns, benchmarkPostgresBatchSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkArrowRows = count
+			record.Release()
+		}
+	})
+
+	b.Run("optimized_raw_typed_append", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(rowBytes * benchmarkPostgresBatchSize))
+		for b.Loop() {
+			rows := &syntheticBenchmarkRows{
+				fields: fields, values: values, typeMap: pgtype.NewMap(), rows: benchmarkPostgresBatchSize,
+			}
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, benchmarkPostgresBatchSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkArrowRows = count
+			record.Release()
+		}
+	})
+}
+
+func benchmarkPostgresRow() ([]schema.Column, []pgconn.FieldDescription, [][]byte) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt32},
+		{Name: "small_str", DataType: schema.TypeString, MaxLength: 20},
+		{Name: "medium_str", DataType: schema.TypeString, MaxLength: 100},
+		{Name: "large_str", DataType: schema.TypeString, MaxLength: 500},
+		{Name: "tiny_int", DataType: schema.TypeInt16},
+		{Name: "regular_int", DataType: schema.TypeInt32},
+		{Name: "big_int", DataType: schema.TypeInt64},
+		{Name: "float_val", DataType: schema.TypeFloat64},
+		{Name: "decimal_val", DataType: schema.TypeDecimal, Precision: 18, Scale: 4},
+		{Name: "bool_val", DataType: schema.TypeBoolean},
+		{Name: "date_val", DataType: schema.TypeDate},
+		{Name: "ts_val", DataType: schema.TypeTimestamp},
+		{Name: "ts_tz_val", DataType: schema.TypeTimestampTZ},
+		{Name: "json_val", DataType: schema.TypeJSON},
+		{Name: "extra_text", DataType: schema.TypeString},
+	}
+	fields := []pgconn.FieldDescription{
+		{Name: "id", DataTypeOID: pgtype.Int4OID, Format: pgx.BinaryFormatCode},
+		{Name: "small_str", DataTypeOID: pgtype.VarcharOID, Format: pgx.TextFormatCode},
+		{Name: "medium_str", DataTypeOID: pgtype.VarcharOID, Format: pgx.TextFormatCode},
+		{Name: "large_str", DataTypeOID: pgtype.VarcharOID, Format: pgx.TextFormatCode},
+		{Name: "tiny_int", DataTypeOID: pgtype.Int2OID, Format: pgx.BinaryFormatCode},
+		{Name: "regular_int", DataTypeOID: pgtype.Int4OID, Format: pgx.BinaryFormatCode},
+		{Name: "big_int", DataTypeOID: pgtype.Int8OID, Format: pgx.BinaryFormatCode},
+		{Name: "float_val", DataTypeOID: pgtype.Float8OID, Format: pgx.BinaryFormatCode},
+		{Name: "decimal_val", DataTypeOID: pgtype.NumericOID, Format: pgx.BinaryFormatCode},
+		{Name: "bool_val", DataTypeOID: pgtype.BoolOID, Format: pgx.BinaryFormatCode},
+		{Name: "date_val", DataTypeOID: pgtype.DateOID, Format: pgx.BinaryFormatCode},
+		{Name: "ts_val", DataTypeOID: pgtype.TimestampOID, Format: pgx.BinaryFormatCode},
+		{Name: "ts_tz_val", DataTypeOID: pgtype.TimestamptzOID, Format: pgx.BinaryFormatCode},
+		{Name: "json_val", DataTypeOID: pgtype.JSONBOID, Format: pgx.TextFormatCode},
+		{Name: "extra_text", DataTypeOID: pgtype.TextOID, Format: pgx.TextFormatCode},
+	}
+	values := [][]byte{
+		binaryUint32(9_999_999),
+		[]byte("name_9999"),
+		[]byte("user_9999999@example-499.com"),
+		[]byte(strings.Repeat("A", 150)),
+		binaryUint16(123),
+		binaryUint32(9_999_999),
+		binaryUint64(9_999_999_000_000),
+		binaryUint64(math.Float64bits(1_429_570.285714)),
+		binaryNumeric(0, 0, 4, 999, 9900),
+		{1},
+		binaryUint32(postgresDateEpochDays),
+		binaryUint64(9_999_999_000_000),
+		binaryUint64(9_999_999_000_000),
+		[]byte(`{"key":"val_99","num":9999999}`),
+		[]byte(strings.Repeat("x", 122)),
+	}
+	return columns, fields, values
+}
+
+func rowsToArrowRecordBatchLegacy(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+	builders := make([]array.Builder, len(columns))
+	for i, field := range arrowSchema.Fields() {
+		builders[i] = array.NewBuilder(memory.NewGoAllocator(), field.Type)
+	}
+
+	var rowCount int64
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, 0, err
+		}
+		for i, value := range values {
+			arrowconv.AppendValue(builders[i], convertValue(value, columns[i]))
+		}
+		rowCount++
+		if rowCount >= int64(batchSize) {
+			break
+		}
+	}
+
+	arrays := make([]arrow.Array, len(builders))
+	for i, builder := range builders {
+		arrays[i] = builder.NewArray()
+	}
+	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
+	for _, column := range arrays {
+		column.Release()
+	}
+	return record, rowCount, nil
+}
+
+func binaryUint16(value uint16) []byte {
+	result := make([]byte, 2)
+	result[0] = byte(value >> 8)
+	result[1] = byte(value)
+	return result
+}
+
+func binaryUint32(value uint32) []byte {
+	result := make([]byte, 4)
+	result[0] = byte(value >> 24)
+	result[1] = byte(value >> 16)
+	result[2] = byte(value >> 8)
+	result[3] = byte(value)
+	return result
+}
+
+func binaryUint64(value uint64) []byte {
+	result := make([]byte, 8)
+	for i := 7; i >= 0; i-- {
+		result[i] = byte(value)
+		value >>= 8
+	}
+	return result
+}
+
+var _ pgx.Rows = (*syntheticBenchmarkRows)(nil)
+
+func TestPostgresRawBatchMatchesLegacyForBenchmarkTypes(t *testing.T) {
+	columns, fields, values := benchmarkPostgresRow()
+	arrowSchema := buildArrowSchema(columns)
+	legacyRows := &syntheticBenchmarkRows{
+		fields: fields, values: values, typeMap: pgtype.NewMap(), rows: 1,
+	}
+	rawRows := &syntheticBenchmarkRows{
+		fields: fields, values: values, typeMap: pgtype.NewMap(), rows: 1,
+	}
+	legacy, _, err := rowsToArrowRecordBatchLegacy(legacyRows, arrowSchema, columns, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer legacy.Release()
+	optimized, _, err := rowsToArrowRecordBatch(rawRows, arrowSchema, columns, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer optimized.Release()
+	if !array.RecordEqual(legacy, optimized) {
+		t.Fatal("optimized PostgreSQL decoder produced a different Arrow record")
+	}
+}

--- a/pkg/source/postgres/raw_decoder.go
+++ b/pkg/source/postgres/raw_decoder.go
@@ -1,0 +1,311 @@
+package postgres
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	postgresDateEpochDays              = 10_957
+	postgresTimestampEpochMicroseconds = 946_684_800_000_000
+	postgresNumericNegative            = 0x4000
+)
+
+type postgresRawAppender func([]byte) error
+
+func newPostgresRawAppender(builder array.Builder, field pgconn.FieldDescription, column schema.Column, typeMap *pgtype.Map) postgresRawAppender {
+	fallback := func(src []byte) error {
+		value, err := decodePostgresValue(typeMap, field, src)
+		if err != nil {
+			return err
+		}
+		arrowconv.AppendValue(builder, convertValue(value, column))
+		return nil
+	}
+
+	switch b := builder.(type) {
+	case *array.BooleanBuilder:
+		if field.DataTypeOID == pgtype.BoolOID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 1 {
+					b.Append(src[0] != 0)
+					return nil
+				}
+				if field.Format == pgx.TextFormatCode && len(src) == 1 && (src[0] == 't' || src[0] == 'f') {
+					b.Append(src[0] == 't')
+					return nil
+				}
+				return fallback(src)
+			}
+		}
+	case *array.Int16Builder:
+		if field.DataTypeOID == pgtype.Int2OID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 2 {
+					b.Append(int16(binary.BigEndian.Uint16(src)))
+					return nil
+				}
+				return appendPostgresTextInt(src, field.Format, 16, func(value int64) { b.Append(int16(value)) }, fallback)
+			}
+		}
+	case *array.Int32Builder:
+		if field.DataTypeOID == pgtype.Int4OID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 4 {
+					b.Append(int32(binary.BigEndian.Uint32(src)))
+					return nil
+				}
+				return appendPostgresTextInt(src, field.Format, 32, func(value int64) { b.Append(int32(value)) }, fallback)
+			}
+		}
+	case *array.Int64Builder:
+		if field.DataTypeOID == pgtype.Int8OID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 8 {
+					b.Append(int64(binary.BigEndian.Uint64(src)))
+					return nil
+				}
+				return appendPostgresTextInt(src, field.Format, 64, b.Append, fallback)
+			}
+		}
+	case *array.Float32Builder:
+		if field.DataTypeOID == pgtype.Float4OID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 4 {
+					b.Append(math.Float32frombits(binary.BigEndian.Uint32(src)))
+					return nil
+				}
+				if field.Format == pgx.TextFormatCode {
+					value, err := strconv.ParseFloat(string(src), 32)
+					if err == nil {
+						b.Append(float32(value))
+						return nil
+					}
+				}
+				return fallback(src)
+			}
+		}
+	case *array.Float64Builder:
+		if field.DataTypeOID == pgtype.Float8OID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 8 {
+					b.Append(math.Float64frombits(binary.BigEndian.Uint64(src)))
+					return nil
+				}
+				if field.Format == pgx.TextFormatCode {
+					value, err := strconv.ParseFloat(string(src), 64)
+					if err == nil {
+						b.Append(value)
+						return nil
+					}
+				}
+				return fallback(src)
+			}
+		}
+	case *array.StringBuilder:
+		if isPostgresTextOID(field.DataTypeOID) && (field.Format == pgx.TextFormatCode || field.Format == pgx.BinaryFormatCode) {
+			return func(src []byte) error {
+				b.BinaryBuilder.Append(src)
+				return nil
+			}
+		}
+	case *array.BinaryBuilder:
+		if field.DataTypeOID == pgtype.ByteaOID && field.Format == pgx.BinaryFormatCode {
+			return func(src []byte) error {
+				b.Append(src)
+				return nil
+			}
+		}
+	case *array.Date32Builder:
+		if field.DataTypeOID == pgtype.DateOID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 4 {
+					days := int32(binary.BigEndian.Uint32(src))
+					if days != math.MinInt32 && days <= math.MaxInt32-postgresDateEpochDays {
+						b.Append(arrow.Date32(days + postgresDateEpochDays))
+						return nil
+					}
+				}
+				return fallback(src)
+			}
+		}
+	case *array.Time64Builder:
+		if field.DataTypeOID == pgtype.TimeOID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 8 {
+					b.Append(arrow.Time64(int64(binary.BigEndian.Uint64(src))))
+					return nil
+				}
+				return fallback(src)
+			}
+		}
+	case *array.TimestampBuilder:
+		if field.DataTypeOID == pgtype.TimestampOID || field.DataTypeOID == pgtype.TimestamptzOID {
+			return func(src []byte) error {
+				if field.Format == pgx.BinaryFormatCode && len(src) == 8 {
+					microseconds := int64(binary.BigEndian.Uint64(src))
+					if microseconds <= math.MaxInt64-postgresTimestampEpochMicroseconds && microseconds != math.MinInt64 {
+						b.Append(arrow.Timestamp(microseconds + postgresTimestampEpochMicroseconds))
+						return nil
+					}
+				}
+				return fallback(src)
+			}
+		}
+	case *array.Decimal128Builder:
+		if field.DataTypeOID == pgtype.NumericOID && column.Precision > 0 && column.Precision <= 18 {
+			return func(src []byte) error {
+				var value decimal128.Num
+				var ok bool
+				switch field.Format {
+				case pgx.BinaryFormatCode:
+					value, ok = parsePostgresBinaryDecimal128(src, int32(column.Precision), int32(column.Scale))
+				case pgx.TextFormatCode:
+					value, ok = arrowconv.ParseDecimal128BytesFast(src, int32(column.Precision), int32(column.Scale))
+				}
+				if ok {
+					b.Append(value)
+					return nil
+				}
+				return fallback(src)
+			}
+		}
+	case *array.ExtensionBuilder:
+		if arrowconv.IsJSONType(b.Type()) && (field.DataTypeOID == pgtype.JSONOID || field.DataTypeOID == pgtype.JSONBOID) {
+			storage, ok := b.StorageBuilder().(*array.StringBuilder)
+			if ok {
+				return func(src []byte) error {
+					if field.DataTypeOID == pgtype.JSONBOID && field.Format == pgx.BinaryFormatCode {
+						if len(src) == 0 || src[0] != 1 {
+							return fallback(src)
+						}
+						src = src[1:]
+					}
+					storage.BinaryBuilder.Append(src)
+					return nil
+				}
+			}
+		}
+	}
+
+	return fallback
+}
+
+func appendPostgresTextInt(src []byte, format int16, bitSize int, appendValue func(int64), fallback postgresRawAppender) error {
+	if format == pgx.TextFormatCode {
+		value, err := strconv.ParseInt(string(src), 10, bitSize)
+		if err == nil {
+			appendValue(value)
+			return nil
+		}
+	}
+	return fallback(src)
+}
+
+func decodePostgresValue(typeMap *pgtype.Map, field pgconn.FieldDescription, src []byte) (any, error) {
+	if dataType, ok := typeMap.TypeForOID(field.DataTypeOID); ok {
+		return dataType.Codec.DecodeValue(typeMap, field.DataTypeOID, field.Format, src)
+	}
+	if field.Format == pgx.TextFormatCode {
+		return string(src), nil
+	}
+	value := make([]byte, len(src))
+	copy(value, src)
+	return value, nil
+}
+
+func isPostgresTextOID(oid uint32) bool {
+	switch oid {
+	case pgtype.TextOID, pgtype.VarcharOID, pgtype.BPCharOID, pgtype.NameOID:
+		return true
+	default:
+		return false
+	}
+}
+
+func parsePostgresBinaryDecimal128(src []byte, precision, scale int32) (decimal128.Num, bool) {
+	if len(src) < 8 || precision <= 0 || precision > 18 {
+		return decimal128.Num{}, false
+	}
+	ndigits := int(binary.BigEndian.Uint16(src))
+	weight := int(int16(binary.BigEndian.Uint16(src[2:])))
+	sign := binary.BigEndian.Uint16(src[4:])
+	if (sign != 0 && sign != postgresNumericNegative) || len(src) != 8+ndigits*2 {
+		return decimal128.Num{}, false
+	}
+
+	var unscaled uint64
+	for i := range ndigits {
+		digit := uint64(binary.BigEndian.Uint16(src[8+i*2:]))
+		if digit >= 10_000 || unscaled > (math.MaxUint64-digit)/10_000 {
+			return decimal128.Num{}, false
+		}
+		unscaled = unscaled*10_000 + digit
+	}
+
+	exponent := int(scale) + 4*(weight-ndigits+1)
+	if exponent > 0 {
+		multiplier, ok := uint64PowerOfTen(exponent)
+		if !ok || unscaled > math.MaxUint64/multiplier {
+			return decimal128.Num{}, false
+		}
+		unscaled *= multiplier
+	} else if exponent < 0 {
+		divisor, ok := uint64PowerOfTen(-exponent)
+		if !ok || unscaled%divisor != 0 {
+			return decimal128.Num{}, false
+		}
+		unscaled /= divisor
+	}
+
+	if unscaled > math.MaxInt64 {
+		return decimal128.Num{}, false
+	}
+	value := int64(unscaled)
+	if sign == postgresNumericNegative {
+		value = -value
+	}
+	result := decimal128.FromI64(value)
+	if !result.FitsInPrecision(precision) {
+		return decimal128.Num{}, false
+	}
+	return result, true
+}
+
+func uint64PowerOfTen(exponent int) (uint64, bool) {
+	if exponent < 0 || exponent > 18 {
+		return 0, false
+	}
+	result := uint64(1)
+	for range exponent {
+		result *= 10
+	}
+	return result, true
+}
+
+func appendPostgresRawRow(appenders []postgresRawAppender, builders []array.Builder, values [][]byte) error {
+	if len(values) != len(appenders) {
+		return fmt.Errorf("postgres row has %d values, expected %d", len(values), len(appenders))
+	}
+	for i, value := range values {
+		if value == nil {
+			builders[i].AppendNull()
+			continue
+		}
+		if err := appenders[i](value); err != nil {
+			return fmt.Errorf("failed to decode PostgreSQL column %d: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/pkg/source/postgres/raw_decoder_test.go
+++ b/pkg/source/postgres/raw_decoder_test.go
@@ -1,0 +1,216 @@
+package postgres
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type rawTestRows struct {
+	fields       []pgconn.FieldDescription
+	rows         [][][]byte
+	index        int
+	valuesCalled bool
+}
+
+func (r *rawTestRows) Close() {}
+
+func (r *rawTestRows) Err() error { return nil }
+
+func (r *rawTestRows) CommandTag() pgconn.CommandTag { return pgconn.CommandTag{} }
+
+func (r *rawTestRows) FieldDescriptions() []pgconn.FieldDescription { return r.fields }
+
+func (r *rawTestRows) Next() bool {
+	if r.index >= len(r.rows) {
+		return false
+	}
+	r.index++
+	return true
+}
+
+func (r *rawTestRows) Scan(...any) error { return errors.New("not implemented") }
+
+func (r *rawTestRows) Values() ([]any, error) {
+	r.valuesCalled = true
+	return nil, errors.New("Values must not be called by the raw decoder")
+}
+
+func (r *rawTestRows) RawValues() [][]byte { return r.rows[r.index-1] }
+
+func (r *rawTestRows) Conn() *pgx.Conn { return nil }
+
+func TestRowsToArrowRecordBatchUsesRawPostgresValues(t *testing.T) {
+	createdAt := time.Date(2026, 7, 17, 12, 34, 56, 123456000, time.UTC)
+	postgresMicros := createdAt.UnixMicro() - postgresTimestampEpochMicroseconds
+	payload := []byte(`{"key": "value", "num": 123}`)
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt32},
+		{Name: "name", DataType: schema.TypeString},
+		{Name: "amount", DataType: schema.TypeDecimal, Precision: 18, Scale: 4},
+		{Name: "created_at", DataType: schema.TypeTimestamp},
+		{Name: "payload", DataType: schema.TypeJSON},
+		{Name: "nullable", DataType: schema.TypeInt64, Nullable: true},
+	}
+	rows := &rawTestRows{
+		fields: []pgconn.FieldDescription{
+			{Name: "id", DataTypeOID: pgtype.Int4OID, Format: pgx.BinaryFormatCode},
+			{Name: "name", DataTypeOID: pgtype.TextOID, Format: pgx.TextFormatCode},
+			{Name: "amount", DataTypeOID: pgtype.NumericOID, Format: pgx.BinaryFormatCode},
+			{Name: "created_at", DataTypeOID: pgtype.TimestampOID, Format: pgx.BinaryFormatCode},
+			{Name: "payload", DataTypeOID: pgtype.JSONBOID, Format: pgx.TextFormatCode},
+			{Name: "nullable", DataTypeOID: pgtype.Int8OID, Format: pgx.BinaryFormatCode},
+		},
+		rows: [][][]byte{
+			{
+				binaryInt32(42),
+				[]byte("alice"),
+				binaryNumeric(0, 0, 4, 123, 4500),
+				binaryInt64(postgresMicros),
+				payload,
+				binaryInt64(99),
+			},
+			{nil, nil, nil, nil, nil, nil},
+		},
+	}
+
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 25_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer record.Release()
+	if rows.valuesCalled {
+		t.Fatal("rows.Values was called")
+	}
+	if count != 2 {
+		t.Fatalf("row count = %d, want 2", count)
+	}
+	if got := record.Column(0).(*array.Int32).Value(0); got != 42 {
+		t.Fatalf("id = %d, want 42", got)
+	}
+	if got := record.Column(1).(*array.String).Value(0); got != "alice" {
+		t.Fatalf("name = %q, want alice", got)
+	}
+	if got := record.Column(2).(*array.Decimal128).Value(0).ToString(4); got != "123.4500" {
+		t.Fatalf("amount = %s, want 123.4500", got)
+	}
+	if got := record.Column(3).(*array.Timestamp).Value(0).ToTime(arrow.Microsecond); !got.Equal(createdAt) {
+		t.Fatalf("created_at = %s, want %s", got, createdAt)
+	}
+	jsonColumn := record.Column(4).(array.ExtensionArray).Storage().(*array.String)
+	if got := jsonColumn.Value(0); got != string(payload) {
+		t.Fatalf("payload = %q, want exact raw value %q", got, payload)
+	}
+	for column := 0; column < int(record.NumCols()); column++ {
+		if !record.Column(column).IsNull(1) {
+			t.Fatalf("column %d row 1 should be null", column)
+		}
+	}
+}
+
+func TestRowsToArrowRecordBatchHandlesBinaryPostgresValues(t *testing.T) {
+	uuid := []byte{0x0f, 0x36, 0x41, 0x30, 0xda, 0x0b, 0x49, 0x09, 0xb8, 0x24, 0x54, 0x13, 0xd7, 0x95, 0xaa, 0x93}
+	payload := []byte(`{"binary":true}`)
+	columns := []schema.Column{
+		{Name: "time_value", DataType: schema.TypeTime},
+		{Name: "binary_value", DataType: schema.TypeBinary},
+		{Name: "uuid_value", DataType: schema.TypeUUID},
+		{Name: "json_value", DataType: schema.TypeJSON},
+	}
+	rows := &rawTestRows{
+		fields: []pgconn.FieldDescription{
+			{Name: "time_value", DataTypeOID: pgtype.TimeOID, Format: pgx.BinaryFormatCode},
+			{Name: "binary_value", DataTypeOID: pgtype.ByteaOID, Format: pgx.BinaryFormatCode},
+			{Name: "uuid_value", DataTypeOID: pgtype.UUIDOID, Format: pgx.BinaryFormatCode},
+			{Name: "json_value", DataTypeOID: pgtype.JSONBOID, Format: pgx.BinaryFormatCode},
+		},
+		rows: [][][]byte{{
+			binaryInt64(45_296_123_456),
+			{0x00, 0x01, 0xfe, 0xff},
+			uuid,
+			append([]byte{1}, payload...),
+		}},
+	}
+
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer record.Release()
+	if count != 1 {
+		t.Fatalf("row count = %d, want 1", count)
+	}
+	if got := record.Column(0).(*array.Time64).Value(0); got != 45_296_123_456 {
+		t.Fatalf("time_value = %d, want 45296123456", got)
+	}
+	if got := record.Column(1).(*array.Binary).Value(0); string(got) != string([]byte{0x00, 0x01, 0xfe, 0xff}) {
+		t.Fatalf("binary_value = %v", got)
+	}
+	if got := record.Column(2).(*array.String).Value(0); got != "0f364130-da0b-4909-b824-5413d795aa93" {
+		t.Fatalf("uuid_value = %q", got)
+	}
+	jsonColumn := record.Column(3).(array.ExtensionArray).Storage().(*array.String)
+	if got := jsonColumn.Value(0); got != string(payload) {
+		t.Fatalf("json_value = %q, want %q", got, payload)
+	}
+}
+
+func TestParsePostgresBinaryDecimal128(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     []byte
+		precision int32
+		scale     int32
+		want      string
+	}{
+		{name: "scale four", value: binaryNumeric(0, 0, 4, 123, 4500), precision: 18, scale: 4, want: "123.4500"},
+		{name: "remove base ten thousand padding", value: binaryNumeric(0, 0, 2, 123, 4500), precision: 18, scale: 2, want: "123.45"},
+		{name: "negative", value: binaryNumeric(0, postgresNumericNegative, 2, 12, 3400), precision: 18, scale: 2, want: "-12.34"},
+		{name: "zero", value: binaryNumeric(0, 0, 4), precision: 18, scale: 4, want: "0.0000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parsePostgresBinaryDecimal128(tt.value, tt.precision, tt.scale)
+			if !ok {
+				t.Fatal("parse failed")
+			}
+			if value := got.ToString(tt.scale); value != tt.want {
+				t.Fatalf("value = %s, want %s", value, tt.want)
+			}
+		})
+	}
+}
+
+func binaryInt32(value int32) []byte {
+	result := make([]byte, 4)
+	binary.BigEndian.PutUint32(result, uint32(value))
+	return result
+}
+
+func binaryInt64(value int64) []byte {
+	result := make([]byte, 8)
+	binary.BigEndian.PutUint64(result, uint64(value))
+	return result
+}
+
+func binaryNumeric(weight int16, sign uint16, scale int16, digits ...uint16) []byte {
+	result := make([]byte, 8+len(digits)*2)
+	binary.BigEndian.PutUint16(result, uint16(len(digits)))
+	binary.BigEndian.PutUint16(result[2:], uint16(weight))
+	binary.BigEndian.PutUint16(result[4:], sign)
+	binary.BigEndian.PutUint16(result[6:], uint16(scale))
+	for i, digit := range digits {
+		binary.BigEndian.PutUint16(result[8+i*2:], digit)
+	}
+	return result
+}
+
+var _ pgx.Rows = (*rawTestRows)(nil)


### PR DESCRIPTION
## Summary

- decode common PostgreSQL binary and text values directly from `pgx.Rows.RawValues()` into Arrow builders
- keep generic pgx decoding as a fallback for unsupported types
- avoid JSON/JSONB decode-and-reencode work and reserve/release Arrow builders correctly
- add reproducible legacy-vs-optimized allocation benchmarks and type-equivalence tests

## Results

For 25k-row local batches:

- JSONB: 22.65 MB / 450,071 allocs to 2.30 MB / 36 allocs
- 15-column row batch: 72.77 MB / 1,275,506 allocs to 24.68 MB / 283 allocs
- remote 10m PostgreSQL to PostgreSQL mean: 95.41s to 52.55s (44.9% faster)

## Validation

- `make format`
- `make lint`
- `make test`
- PostgreSQL to PostgreSQL integration test
- five-run remote 10m PostgreSQL to PostgreSQL benchmark
