### PR TITLE
Skip PostgreSQL replace dedup for unique keys

### DIFF
--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -74,16 +74,19 @@ type Transaction interface {
 
 // MergeOptions contains parameters for merge operations.
 type MergeOptions struct {
-	StagingTable         string
-	TargetTable          string
-	PrimaryKeys          []string
-	Columns              []string
-	IncrementalKey       string
-	IncrementalPredicate string
-	Schema               *schema.TableSchema
-	CommitToken          source.DurableID
-	CDCResumeLSN         string
-	SkipCDCResume        bool
+	StagingTable string
+	TargetTable  string
+	PrimaryKeys  []string
+	// StagingPrimaryKeysUnique allows destinations to skip per-key staging
+	// deduplication when the caller guarantees the effective keys are unique.
+	StagingPrimaryKeysUnique bool
+	Columns                  []string
+	IncrementalKey           string
+	IncrementalPredicate     string
+	Schema                   *schema.TableSchema
+	CommitToken              source.DurableID
+	CDCResumeLSN             string
+	SkipCDCResume            bool
 	// CDCExpectedIncarnation fences a managed CDC merge to the physical target
 	// that was bound before the source read began.
 	CDCExpectedIncarnation string

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -913,15 +913,17 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 		}
 	} else {
 		// Non-CDC mode: efficient upsert using INSERT ... ON CONFLICT.
-		// DISTINCT ON dedupes staging by PK so the same target row isn't
-		// affected twice in one statement, which Postgres rejects with
-		// SQLSTATE 21000. When an incremental key is set the latest row per PK
-		// wins; otherwise the winner is arbitrary.
+		// Unless the caller guarantees staging PK uniqueness, DISTINCT ON
+		// prevents the same target row from being affected twice in one
+		// statement, which Postgres rejects with SQLSTATE 21000. When an
+		// incremental key is set the latest row per PK wins; otherwise the
+		// winner is arbitrary.
 		pkList := strings.Join(quotedPKs, ", ")
 		orderBy := pkList
 		if opts.IncrementalKey != "" {
 			orderBy = fmt.Sprintf("%s, %s DESC", pkList, destination.QuoteIdentifier(opts.IncrementalKey))
 		}
+		stagingSelect := buildMergeStagingSelect(quotedStagingTable, pkList, destQuoted, orderBy, opts.StagingPrimaryKeysUnique)
 
 		var upsertSQL string
 		if strings.TrimSpace(opts.IncrementalPredicate) != "" {
@@ -933,16 +935,14 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 				nonPKColumns,
 				orderBy,
 				opts.IncrementalPredicate,
+				opts.StagingPrimaryKeysUnique,
 			)
 		} else {
 			upsertSQL = fmt.Sprintf(
-				`INSERT INTO %s (%s) SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s ON CONFLICT (%s) DO UPDATE SET %s`,
+				`INSERT INTO %s (%s) %s ON CONFLICT (%s) DO UPDATE SET %s`,
 				quotedTargetTable,
 				strings.Join(destQuoted, ", "),
-				pkList,
-				strings.Join(destQuoted, ", "),
-				quotedStagingTable,
-				orderBy,
+				stagingSelect,
 				pkList,
 				buildConflictUpdateSet(nonPKColumns),
 			)
@@ -1614,7 +1614,15 @@ func buildConflictUpdateSet(columns []string) string {
 	return strings.Join(sets, ", ")
 }
 
-func buildPredicateMergeSQL(quotedTargetTable, quotedStagingTable string, primaryKeys, destQuoted, nonPKColumns []string, orderBy, incrementalPredicate string) string {
+func buildMergeStagingSelect(quotedStagingTable, pkList string, destQuoted []string, orderBy string, primaryKeysUnique bool) string {
+	columns := strings.Join(destQuoted, ", ")
+	if primaryKeysUnique {
+		return fmt.Sprintf("SELECT %s FROM %s", columns, quotedStagingTable)
+	}
+	return fmt.Sprintf("SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s", pkList, columns, quotedStagingTable, orderBy)
+}
+
+func buildPredicateMergeSQL(quotedTargetTable, quotedStagingTable string, primaryKeys, destQuoted, nonPKColumns []string, orderBy, incrementalPredicate string, primaryKeysUnique bool) string {
 	pkList := strings.Join(quoteColumns(primaryKeys), ", ")
 	matchCondition := destination.MergeJoinCondition(
 		buildJoinCondition(primaryKeys, "target", "source"),
@@ -1624,20 +1632,18 @@ func buildPredicateMergeSQL(quotedTargetTable, quotedStagingTable string, primar
 	for i, col := range destQuoted {
 		sourceColumns[i] = "source." + col
 	}
+	stagingSelect := buildMergeStagingSelect(quotedStagingTable, pkList, destQuoted, orderBy, primaryKeysUnique)
 
 	return fmt.Sprintf(
 		`WITH source AS (
-			SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s
+			%s
 		), updated AS (
 			UPDATE %s AS target SET %s FROM source WHERE %s RETURNING 1
 		)
 		INSERT INTO %s (%s)
 		SELECT %s FROM source
 		WHERE NOT EXISTS (SELECT 1 FROM %s AS target WHERE %s)`,
-		pkList,
-		strings.Join(destQuoted, ", "),
-		quotedStagingTable,
-		orderBy,
+		stagingSelect,
 		quotedTargetTable,
 		buildCDCConflictUpdateSet(nonPKColumns, "target", "source", ""),
 		matchCondition,

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -923,8 +923,6 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 		if opts.IncrementalKey != "" {
 			orderBy = fmt.Sprintf("%s, %s DESC", pkList, destination.QuoteIdentifier(opts.IncrementalKey))
 		}
-		stagingSelect := buildMergeStagingSelect(quotedStagingTable, pkList, destQuoted, orderBy, opts.StagingPrimaryKeysUnique)
-
 		var upsertSQL string
 		if strings.TrimSpace(opts.IncrementalPredicate) != "" {
 			upsertSQL = buildPredicateMergeSQL(
@@ -938,6 +936,7 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 				opts.StagingPrimaryKeysUnique,
 			)
 		} else {
+			stagingSelect := buildMergeStagingSelect(quotedStagingTable, pkList, destQuoted, orderBy, opts.StagingPrimaryKeysUnique)
 			upsertSQL = fmt.Sprintf(
 				`INSERT INTO %s (%s) %s ON CONFLICT (%s) DO UPDATE SET %s`,
 				quotedTargetTable,

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -87,6 +87,7 @@ func TestBuildPredicateMergeSQLUsesPredicateForUpdateAndInsertMatch(t *testing.T
 		[]string{"event_date", "value"},
 		`"id"`,
 		predicate,
+		false,
 	)
 
 	matchCondition := `target."id" = source."id" AND (` + predicate + `)`
@@ -101,6 +102,19 @@ func TestBuildPredicateMergeSQLUsesPredicateForUpdateAndInsertMatch(t *testing.T
 	}
 	if strings.Contains(sql, "ON CONFLICT") {
 		t.Fatalf("predicate merge SQL must not use ON CONFLICT:\n%s", sql)
+	}
+}
+
+func TestBuildMergeStagingSelectSkipsDedupForUniquePrimaryKeys(t *testing.T) {
+	columns := quoteColumns([]string{"id", "value"})
+	unique := buildMergeStagingSelect(`"staging"."events"`, `"id"`, columns, `"id"`, true)
+	if strings.Contains(unique, "DISTINCT ON") {
+		t.Fatalf("unique staging select unexpectedly deduplicates: %s", unique)
+	}
+
+	uncertain := buildMergeStagingSelect(`"staging"."events"`, `"id"`, columns, `"id"`, false)
+	if !strings.Contains(uncertain, `DISTINCT ON ("id")`) {
+		t.Fatalf("uncertain staging select does not deduplicate: %s", uncertain)
 	}
 }
 

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -26,7 +26,7 @@ func replaceShouldDedup(dest destination.Destination, primaryKeys []string) bool
 		dest.GetScheme() != "clickhouse"
 }
 
-func sourcePrimaryKeysSafeForReplaceFastPath(job *IngestionJob) bool {
+func effectivePrimaryKeysGuaranteedUnique(job *IngestionJob) bool {
 	return sourcePrimaryKeysGuaranteedUnique(job) &&
 		!primaryKeyValuesMayChange(job)
 }
@@ -225,7 +225,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 
 	// Deduplicated replace: Load a PK-free staging table so duplicate keys can land.
 	dedup := useStaging &&
-		!sourcePrimaryKeysSafeForReplaceFastPath(job) &&
+		!effectivePrimaryKeysGuaranteedUnique(job) &&
 		replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
 	stagingPrimaryKeys := job.Config.PrimaryKeys
 	if dedup {

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -17,10 +17,10 @@ import (
 // (views, grants, foreign keys).
 //
 // When primary keys are configured, rows are first written to a staging table
-// and then deduplicated by PK into the truncated target via the destination's
-// existing merge SQL. This tolerates sources that emit the same PK more than
-// once (e.g., page-based pagination over a live table). Without PKs, dedup is
-// not possible and rows are written directly into the truncated target.
+// and then inserted into the truncated target via the destination's existing
+// merge SQL. Staging is deduplicated unless the source guarantees that its
+// effective primary keys are unique. Without PKs, rows are written directly
+// into the truncated target.
 //
 // Tradeoffs the user has already accepted by opting in:
 //   - Non-atomic: the target is empty between TRUNCATE and the final insert,
@@ -217,14 +217,20 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		return fmt.Errorf("failed to truncate target: %w", err)
 	}
 
-	config.Debug("[TRUNCATE+INSERT] Executing deduplicated insert via merge from staging")
+	stagingPrimaryKeysUnique := effectivePrimaryKeysGuaranteedUnique(job)
+	if stagingPrimaryKeysUnique {
+		config.Debug("[TRUNCATE+INSERT] Executing unique-key insert via merge from staging")
+	} else {
+		config.Debug("[TRUNCATE+INSERT] Executing deduplicated insert via merge from staging")
+	}
 	if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
-		StagingTable:   stagingTable,
-		TargetTable:    targetTable,
-		PrimaryKeys:    job.Config.PrimaryKeys,
-		Columns:        job.Schema.ColumnNames(),
-		IncrementalKey: mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
-		Schema:         job.Schema,
+		StagingTable:             stagingTable,
+		TargetTable:              targetTable,
+		PrimaryKeys:              job.Config.PrimaryKeys,
+		StagingPrimaryKeysUnique: stagingPrimaryKeysUnique,
+		Columns:                  job.Schema.ColumnNames(),
+		IncrementalKey:           mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
+		Schema:                   job.Schema,
 	}); err != nil {
 		return fmt.Errorf("failed to insert from staging: %w", err)
 	}

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -79,6 +79,29 @@ func TestTruncateInsertStrategy_Execute_SkipsOrderingKeyMissingFromStagingSchema
 	}
 }
 
+func TestTruncateInsertStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.Len(t, dest.mergeCalls, 1)
+	require.True(t, dest.mergeCalls[0].StagingPrimaryKeysUnique)
+}
+
+func TestTruncateInsertStrategy_Execute_DedupsUncertainSourcePrimaryKeys(t *testing.T) {
+	job, src, dest := minimalJob()
+	job.Destination = &truncateCapableDestination{fakeDestination: dest}
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.Len(t, dest.mergeCalls, 1)
+	require.False(t, dest.mergeCalls[0].StagingPrimaryKeysUnique)
+}
+
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Destination = &truncateCapableDestination{fakeDestination: dest}


### PR DESCRIPTION
## What
Skip PostgreSQL staging deduplication when effective primary keys are guaranteed unique.

## Changes
- Reuse the replace uniqueness proof in truncate+insert and omit `DISTINCT ON` on the safe path.
- Keep deduplication for uncertain or transformed keys and cover both paths with tests.

## How to test
1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback
- **Risk:** Low; uncertain keys retain the existing deduplication path.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
