### PR TITLE
Harden NATS source and add integration coverage

### DIFF
--- a/docs/supported-sources/nats.md
+++ b/docs/supported-sources/nats.md
@@ -1,0 +1,70 @@
+# NATS JetStream
+
+[NATS](https://nats.io/) is a messaging system with a persistent streaming layer called JetStream. ingestr reads messages from JetStream streams in finite batch runs or continuously with streaming ingestion.
+
+JetStream must be enabled on the NATS server. Core NATS subjects without a backing JetStream stream are not supported because they cannot replay messages or acknowledge them after a destination write.
+
+## URI format
+
+```text
+nats://username:password@host:4222?subject=events.>&durable=ingestr_events
+```
+
+The required `source-table` is the JetStream stream name. Embedded callers that allow an empty table request can instead supply it with the `stream` URI parameter.
+
+URI parameters:
+
+- `stream`: JetStream stream-name fallback for embedded callers. The CLI still requires `source-table`.
+- `subject`: Subject or wildcard filter within the stream. Defaults to `>`.
+- `durable`: Durable consumer name used by streaming ingestion. If omitted, ingestr derives one from the stream name.
+- `consumer` or `consumer_name`: Bind to an existing durable pull consumer.
+- `bind` or `bind_consumer`: Bind to the consumer named by `durable` instead of creating or updating it.
+- `token`: NATS authentication token.
+- `credentials`, `creds`, or `credentials_file`: Path to a NATS credentials file.
+- `batch_size`: Maximum messages fetched at once. Defaults to `3000`.
+- `batch_timeout`: Maximum fetch wait in seconds. Defaults to `5` and accepts fractional seconds.
+
+Username/password authentication can be supplied in the URI authority. For example:
+
+```text
+nats://ingestr:secret@nats.example.com:4222?subject=orders.*
+```
+
+## Output format
+
+For finite batch ingestion, each message produces these columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `nats_msg_id` | VARCHAR | Stable ID derived from the JetStream stream name and stream sequence. |
+| `data` | JSON | Decoded JSON payload, or a string when the payload is not JSON. |
+| `nats` | JSON | Stream, consumer, subject, sequence, timestamp, delivery count, and headers. |
+
+A finite run captures the stream's last sequence when the read starts and exits after reaching that cutoff. Messages published later are left for a subsequent run.
+
+## Sample command
+
+```sh
+ingestr ingest \
+    --source-uri 'nats://localhost:4222?subject=events.>' \
+    --source-table EVENTS \
+    --dest-uri duckdb:///nats.duckdb \
+    --dest-table dest.events
+```
+
+## Streaming ingestion
+
+Add `--stream` to consume continuously. Streaming mode uses a fixed envelope with a stable `msg_id`, a JSON `data` column containing the payload and NATS metadata, and an `_ingestr_order` sequence column. The default merge strategy de-duplicates redeliveries by `msg_id`.
+
+Messages use explicit JetStream acknowledgements. ingestr acknowledges them only after the destination flush succeeds, so a failed or interrupted flush can be safely replayed.
+
+```sh
+ingestr ingest \
+    --source-uri 'nats://localhost:4222?subject=events.>&durable=ingestr_events' \
+    --source-table EVENTS \
+    --dest-uri duckdb:///nats.duckdb \
+    --dest-table dest.events \
+    --stream
+```
+
+When binding an existing consumer, it must be a pull consumer with explicit acknowledgements. Its acknowledgement wait must also be long enough for the configured destination flush interval.

--- a/pkg/source/nats/nats.go
+++ b/pkg/source/nats/nats.go
@@ -41,7 +41,7 @@ type natsConfig struct {
 }
 
 type natsCommitToken struct {
-	MaxSeq uint64
+	MaxPendingSeq uint64
 }
 
 type NATSSource struct {
@@ -49,8 +49,9 @@ type NATSSource struct {
 	nc  *natsgo.Conn
 	js  natsgo.JetStreamContext
 
-	mu      sync.Mutex
-	pending map[uint64]*natsgo.Msg
+	mu             sync.Mutex
+	nextPendingSeq uint64
+	pending        map[uint64]*natsgo.Msg
 }
 
 func NewNATSSource() *NATSSource {
@@ -85,7 +86,7 @@ func (s *NATSSource) Connect(_ context.Context, raw string) error {
 	s.cfg = cfg
 	s.nc = nc
 	s.js = js
-	config.Debug("[NATS] Connected to %s", cfg.URL)
+	config.Debug("[NATS] Connected to %s", sanitizeNATSURL(cfg.URL))
 	return nil
 }
 
@@ -177,14 +178,20 @@ func parseNATSURI(raw string) (natsConfig, error) {
 	if err != nil {
 		return natsConfig{}, fmt.Errorf("invalid NATS URI: %w", err)
 	}
-	switch u.Scheme {
+	switch strings.ToLower(u.Scheme) {
 	case "nats":
 	default:
 		return natsConfig{}, fmt.Errorf("invalid NATS URI: unsupported scheme %q", u.Scheme)
 	}
+	if u.Hostname() == "" {
+		return natsConfig{}, fmt.Errorf("nats URI: host is required")
+	}
 	q := u.Query()
 	durable := q.Get("durable")
-	bindConsumer := parseBool(firstQuery(q, "bind", "bind_consumer"))
+	bindConsumer, err := parseNATSBool(firstQuery(q, "bind", "bind_consumer"))
+	if err != nil {
+		return natsConfig{}, err
+	}
 	if durable == "" {
 		if consumer := firstQuery(q, "consumer", "consumer_name"); consumer != "" {
 			durable = consumer
@@ -236,9 +243,15 @@ func firstQuery(values url.Values, keys ...string) string {
 	return ""
 }
 
-func parseBool(value string) bool {
-	value = strings.TrimSpace(strings.ToLower(value))
-	return value == "1" || value == "true" || value == "yes"
+func parseNATSBool(value string) (bool, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "0", "false", "no":
+		return false, nil
+	case "1", "true", "yes":
+		return true, nil
+	default:
+		return false, fmt.Errorf("nats URI: bind must be a boolean")
+	}
 }
 
 func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -303,6 +316,7 @@ func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOp
 
 	if opts.Streaming {
 		s.mu.Lock()
+		s.nextPendingSeq = 0
 		s.pending = make(map[uint64]*natsgo.Msg)
 		s.mu.Unlock()
 	}
@@ -318,12 +332,15 @@ func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOp
 			if ctx.Err() != nil {
 				return
 			}
-			msgs, err := sub.Fetch(batchSize, natsgo.MaxWait(s.cfg.BatchTimeout))
+			fetchCtx, cancel := context.WithTimeout(ctx, s.cfg.BatchTimeout)
+			msgs, err := sub.Fetch(batchSize, natsgo.Context(fetchCtx))
+			timedOut := errors.Is(fetchCtx.Err(), context.DeadlineExceeded)
+			cancel()
 			if err != nil {
 				if ctx.Err() != nil {
 					return
 				}
-				if errors.Is(err, natsgo.ErrTimeout) {
+				if timedOut || errors.Is(err, natsgo.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
 					if !opts.Streaming {
 						return
 					}
@@ -341,6 +358,7 @@ func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOp
 
 			items := make([]map[string]any, 0, len(msgs))
 			var maxSeq uint64
+			var maxPendingSeq uint64
 			var ackNow []*natsgo.Msg
 			reachedCutoff := false
 			for _, msg := range msgs {
@@ -356,7 +374,7 @@ func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOp
 				}
 				if opts.Streaming {
 					items = append(items, messageToEnvelope(msg, meta))
-					s.trackPending(seq, msg)
+					maxPendingSeq = s.trackPending(msg)
 				} else {
 					items = append(items, messageToItem(msg, meta))
 					ackNow = append(ackNow, msg)
@@ -382,7 +400,7 @@ func (s *NATSSource) read(ctx context.Context, stream string, opts source.ReadOp
 			}
 			res := source.RecordBatchResult{Batch: record}
 			if opts.Streaming {
-				res.CommitToken = natsCommitToken{MaxSeq: maxSeq}
+				res.CommitToken = natsCommitToken{MaxPendingSeq: maxPendingSeq}
 			}
 			results <- res
 			for _, msg := range ackNow {
@@ -426,10 +444,13 @@ func (s *NATSSource) resolveBoundConsumerSubject(stream, durable string, opts so
 	}
 }
 
-func (s *NATSSource) trackPending(seq uint64, msg *natsgo.Msg) {
+func (s *NATSSource) trackPending(msg *natsgo.Msg) uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.nextPendingSeq++
+	seq := s.nextPendingSeq
 	s.pending[seq] = msg
+	return seq
 }
 
 func (s *NATSSource) CommitStream(_ context.Context, token any) error {
@@ -438,17 +459,13 @@ func (s *NATSSource) CommitStream(_ context.Context, token any) error {
 		return fmt.Errorf("nats: unexpected commit token type %T", token)
 	}
 	s.mu.Lock()
-	msgs := make([]*natsgo.Msg, 0)
+	defer s.mu.Unlock()
 	for seq, msg := range s.pending {
-		if seq <= tok.MaxSeq {
-			msgs = append(msgs, msg)
+		if seq <= tok.MaxPendingSeq {
+			if err := msg.Ack(); err != nil {
+				return fmt.Errorf("failed to ack NATS message: %w", err)
+			}
 			delete(s.pending, seq)
-		}
-	}
-	s.mu.Unlock()
-	for _, msg := range msgs {
-		if err := msg.Ack(); err != nil {
-			return fmt.Errorf("failed to ack NATS message: %w", err)
 		}
 	}
 	return nil
@@ -529,6 +546,15 @@ func digest128(value string) string {
 func safeName(value string) string {
 	replacer := strings.NewReplacer(".", "_", "-", "_", "/", "_", ">", "_", "*", "_")
 	return replacer.Replace(value)
+}
+
+func sanitizeNATSURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = url.User("***")
+	return u.String()
 }
 
 var (

--- a/pkg/source/nats/nats.go
+++ b/pkg/source/nats/nats.go
@@ -459,13 +459,17 @@ func (s *NATSSource) CommitStream(_ context.Context, token any) error {
 		return fmt.Errorf("nats: unexpected commit token type %T", token)
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	msgs := make([]*natsgo.Msg, 0)
 	for seq, msg := range s.pending {
 		if seq <= tok.MaxPendingSeq {
-			if err := msg.Ack(); err != nil {
-				return fmt.Errorf("failed to ack NATS message: %w", err)
-			}
+			msgs = append(msgs, msg)
 			delete(s.pending, seq)
+		}
+	}
+	s.mu.Unlock()
+	for _, msg := range msgs {
+		if err := msg.Ack(); err != nil {
+			return fmt.Errorf("failed to ack NATS message: %w", err)
 		}
 	}
 	return nil

--- a/pkg/source/nats/nats_test.go
+++ b/pkg/source/nats/nats_test.go
@@ -1,8 +1,12 @@
 package nats
 
 import (
+	"encoding/json"
+	"net/url"
 	"testing"
 	"time"
+
+	natsgo "github.com/nats-io/nats.go"
 )
 
 func TestParseNATSURI(t *testing.T) {
@@ -69,6 +73,25 @@ func TestParseNATSURIDefaultSubject(t *testing.T) {
 	}
 }
 
+func TestParseNATSURIValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{name: "missing host", uri: "nats://?stream=EVENTS"},
+		{name: "invalid bind", uri: "nats://localhost:4222?bind=sometimes"},
+		{name: "invalid batch size", uri: "nats://localhost:4222?batch_size=0"},
+		{name: "invalid batch timeout", uri: "nats://localhost:4222?batch_timeout=soon"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseNATSURI(tt.uri); err == nil {
+				t.Fatalf("parseNATSURI(%q) returned no error", tt.uri)
+			}
+		})
+	}
+}
+
 func TestNATSAckWaitUsesFlushInterval(t *testing.T) {
 	if got := natsAckWait(5*time.Second, 30*time.Second); got < 90*time.Second {
 		t.Errorf("natsAckWait = %v, want at least 90s", got)
@@ -81,5 +104,45 @@ func TestNATSAckWaitUsesFlushInterval(t *testing.T) {
 func TestSafeName(t *testing.T) {
 	if got := safeName("ORDERS.events.>"); got != "ORDERS_events__" {
 		t.Errorf("safeName returned %q", got)
+	}
+}
+
+func TestTrackPendingUsesDeliveryOrder(t *testing.T) {
+	src := NewNATSSource()
+	first := &natsgo.Msg{Data: []byte("first")}
+	second := &natsgo.Msg{Data: []byte("second")}
+
+	if seq := src.trackPending(first); seq != 1 {
+		t.Fatalf("first pending sequence = %d, want 1", seq)
+	}
+	if seq := src.trackPending(second); seq != 2 {
+		t.Fatalf("second pending sequence = %d, want 2", seq)
+	}
+	if src.pending[1] != first || src.pending[2] != second {
+		t.Fatal("pending messages were not tracked in delivery order")
+	}
+}
+
+func TestDecodeMaybeJSONPreservesLargeNumbers(t *testing.T) {
+	decoded, ok := decodeMaybeJSON([]byte(`{"id":9007199254740993}`)).(map[string]any)
+	if !ok {
+		t.Fatalf("decodeMaybeJSON returned %T, want map[string]any", decoded)
+	}
+	if got, ok := decoded["id"].(json.Number); !ok || got.String() != "9007199254740993" {
+		t.Fatalf("decoded id = %#v, want json.Number with exact value", decoded["id"])
+	}
+}
+
+func TestSanitizeNATSURL(t *testing.T) {
+	sanitized := sanitizeNATSURL("nats://user:password@localhost:4222")
+	u, err := url.Parse(sanitized)
+	if err != nil {
+		t.Fatalf("failed to parse sanitized URL: %v", err)
+	}
+	if got := u.User.Username(); got != "***" {
+		t.Fatalf("sanitized username = %q, want ***", got)
+	}
+	if _, ok := u.User.Password(); ok {
+		t.Fatal("sanitized URL still contains a password")
 	}
 }

--- a/tests/integration/nats_test.go
+++ b/tests/integration/nats_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/source"
+	natssource "github.com/bruin-data/ingestr/pkg/source/nats"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNATS_ToSQLite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	natsURI := startNATSContainer(t, ctx)
+	nc, js := newNATSClient(t, natsURI)
+	defer nc.Close()
+
+	stream := fmt.Sprintf("SQLITE_%d", time.Now().UnixNano())
+	subject := fmt.Sprintf("events.sqlite.%d", time.Now().UnixNano())
+	createNATSStream(t, js, stream, subject)
+	publishNATSMessages(t, js, subject, 1, 25)
+
+	tmpFile, err := os.CreateTemp("", "nats_test_*.db")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	t.Cleanup(func() { _ = os.Remove(tmpFile.Name()) })
+
+	cfg := &config.IngestConfig{
+		SourceURI: fmt.Sprintf(
+			"%s?subject=%s&batch_size=10&batch_timeout=0.2",
+			natsURI,
+			url.QueryEscape(subject),
+		),
+		SourceTable:         stream,
+		DestURI:             fmt.Sprintf("sqlite:///%s", tmpFile.Name()),
+		DestTable:           "messages",
+		IncrementalStrategy: config.StrategyReplace,
+		Progress:            config.ProgressLog,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	db, err := sql.Open("sqlite3", tmpFile.Name())
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var count, distinctIDs, metadataRows int
+	var minSeq, maxSeq int
+	require.NoError(t, db.QueryRow(`
+		SELECT
+			COUNT(*),
+			COUNT(DISTINCT nats_msg_id),
+			MIN(CAST(json_extract(data, '$.seq') AS INTEGER)),
+			MAX(CAST(json_extract(data, '$.seq') AS INTEGER)),
+			COUNT(CASE
+				WHEN json_extract(nats, '$.stream') = ?
+				 AND json_extract(nats, '$.subject') = ? THEN 1
+			END)
+		FROM messages`, stream, subject).Scan(&count, &distinctIDs, &minSeq, &maxSeq, &metadataRows))
+
+	assert.Equal(t, 25, count)
+	assert.Equal(t, count, distinctIDs)
+	assert.Equal(t, 1, minSeq)
+	assert.Equal(t, 25, maxSeq)
+	assert.Equal(t, count, metadataRows)
+}
+
+func TestNATS_CancellationInterruptsFetch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	natsURI := startNATSContainer(t, ctx)
+	nc, js := newNATSClient(t, natsURI)
+	defer nc.Close()
+
+	stream := fmt.Sprintf("CANCEL_%d", time.Now().UnixNano())
+	subject := fmt.Sprintf("events.cancel.%d", time.Now().UnixNano())
+	createNATSStream(t, js, stream, subject)
+
+	src := natssource.NewNATSSource()
+	require.NoError(t, src.Connect(ctx, fmt.Sprintf("%s?subject=%s&batch_timeout=30", natsURI, url.QueryEscape(subject))))
+	defer func() { _ = src.Close(ctx) }()
+
+	table, err := src.GetTable(ctx, source.TableRequest{Name: stream, Streaming: true})
+	require.NoError(t, err)
+	readCtx, cancel := context.WithCancel(ctx)
+	records, err := table.Read(readCtx, source.ReadOptions{Streaming: true})
+	require.NoError(t, err)
+
+	started := time.Now()
+	cancel()
+	select {
+	case _, ok := <-records:
+		assert.False(t, ok, "results channel should close without an error result")
+		assert.Less(t, time.Since(started), 2*time.Second)
+	case <-time.After(2 * time.Second):
+		t.Fatal("NATS fetch did not stop promptly after context cancellation")
+	}
+}

--- a/tests/integration/streaming_platform_sources_test.go
+++ b/tests/integration/streaming_platform_sources_test.go
@@ -136,7 +136,8 @@ func TestNATS_Streaming(t *testing.T) {
 	publishNATSMessages(t, js, subject, 1, 20)
 
 	destURI, destSchema, destPool := streamingPostgresDest(t, ctx, "nats")
-	sourceURI := natsURI + "?subject=" + url.QueryEscape(subject) + "&durable=ingestr_" + stream + "&batch_timeout=1"
+	durable := "ingestr_" + stream
+	sourceURI := natsURI + "?subject=" + url.QueryEscape(subject) + "&durable=" + durable + "&batch_timeout=1"
 	cfg := &config.IngestConfig{
 		SourceURI:     sourceURI,
 		SourceTable:   stream,
@@ -160,6 +161,10 @@ func TestNATS_Streaming(t *testing.T) {
 		assertStreamStillRunning(t, runErr)
 		return rowCount() == 30
 	}, 60*time.Second, 500*time.Millisecond)
+	require.Eventually(t, func() bool {
+		info, err := js.ConsumerInfo(stream, durable)
+		return err == nil && info.NumAckPending == 0 && info.AckFloor.Stream == 30
+	}, 30*time.Second, 500*time.Millisecond, "destination flush should acknowledge all durable consumer messages")
 
 	cancel()
 	assertStreamStopped(t, runErr)


### PR DESCRIPTION
## What
Harden NATS JetStream ingestion and add end-to-end container coverage for batch and streaming behavior.

## Changes
- Validate and sanitize NATS connection settings, make fetch cancellation immediate, and acknowledge messages in delivery order after durable flushes.
- Add unit tests, NATS-to-SQLite and streaming integration assertions, plus source documentation.

## How to test
1. Run `make format`, `make lint`, and `GOFLAGS=-p=4 make test`.
2. Run `INTEGRATION_BACKENDS=postgres go test -tags integration -run '^TestNATS_' -count=1 -v ./tests/integration`.

## Risk & rollback
- **Risk:** Low; changes are isolated to the NATS source and its tests/docs.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
