### PR TITLE
Make PostgreSQL truncate inserts atomic

### DIFF
--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -93,6 +93,17 @@ type MergeOptions struct {
 	Parallelism            int
 }
 
+// TruncateInsertFromStagingOptions configures an atomic replacement from a
+// populated staging table into an existing target table.
+type TruncateInsertFromStagingOptions struct {
+	StagingTable             string
+	TargetTable              string
+	PrimaryKeys              []string
+	StagingPrimaryKeysUnique bool
+	Columns                  []string
+	IncrementalKey           string
+}
+
 // DeleteInsertOptions contains parameters for delete+insert operations.
 type DeleteInsertOptions struct {
 	StagingTable       string
@@ -502,6 +513,12 @@ type CDCTruncateCapable interface {
 // readers never observe an empty or partially reloaded target.
 type AtomicTruncateInsertWriter interface {
 	TruncateInsertRecords(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
+}
+
+// AtomicTruncateInsertStagingWriter replaces all target rows from a populated
+// staging table in one destination transaction.
+type AtomicTruncateInsertStagingWriter interface {
+	TruncateInsertFromStaging(ctx context.Context, opts TruncateInsertFromStagingOptions) error
 }
 
 // AtomicTruncateInsertSchemaEvolver marks an atomic truncate+insert writer that

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -962,6 +962,35 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 	return nil
 }
 
+func (d *PostgresDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	start := time.Now()
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate target: %w", err)
+	}
+	if _, err := tx.Exec(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	config.Debug("[TRUNCATE+INSERT] Atomic staging finalization completed in %v", time.Since(start))
+	return nil
+}
+
 // DeleteInsertTable performs a DELETE + INSERT operation using a transaction.
 func (d *PostgresDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
 	startOp := time.Now()
@@ -1619,6 +1648,34 @@ func buildMergeStagingSelect(quotedStagingTable, pkList string, destQuoted []str
 		return fmt.Sprintf("SELECT %s FROM %s", columns, quotedStagingTable)
 	}
 	return fmt.Sprintf("SELECT DISTINCT ON (%s) %s FROM %s ORDER BY %s", pkList, columns, quotedStagingTable, orderBy)
+}
+
+func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
+	if len(opts.PrimaryKeys) == 0 {
+		return "", "", fmt.Errorf("truncate+insert from staging requires primary keys")
+	}
+
+	destQuoted := quoteColumns(destination.DestinationColumns(opts.Columns))
+	pkList := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
+	orderBy := pkList
+	if opts.IncrementalKey != "" {
+		orderBy = fmt.Sprintf("%s, %s DESC", pkList, destination.QuoteIdentifier(opts.IncrementalKey))
+	}
+	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
+	stagingSelect := buildMergeStagingSelect(
+		destination.QuoteTableName(opts.StagingTable),
+		pkList,
+		destQuoted,
+		orderBy,
+		opts.StagingPrimaryKeysUnique,
+	)
+
+	return fmt.Sprintf("TRUNCATE TABLE %s", quotedTargetTable), fmt.Sprintf(
+		"INSERT INTO %s (%s) %s",
+		quotedTargetTable,
+		strings.Join(destQuoted, ", "),
+		stagingSelect,
+	), nil
 }
 
 func buildPredicateMergeSQL(quotedTargetTable, quotedStagingTable string, primaryKeys, destQuoted, nonPKColumns []string, orderBy, incrementalPredicate string, primaryKeysUnique bool) string {

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -118,6 +118,65 @@ func TestBuildMergeStagingSelectSkipsDedupForUniquePrimaryKeys(t *testing.T) {
 	}
 }
 
+func TestBuildTruncateInsertFromStagingSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     destination.TruncateInsertFromStagingOptions
+		contains string
+		excludes string
+	}{
+		{
+			name: "unique keys",
+			opts: destination.TruncateInsertFromStagingOptions{
+				StagingTable:             "_bruin_staging.events",
+				TargetTable:              "public.events",
+				PrimaryKeys:              []string{"id"},
+				StagingPrimaryKeysUnique: true,
+				Columns:                  []string{"id", "value"},
+			},
+			contains: `SELECT "id", "value" FROM "_bruin_staging"."events"`,
+			excludes: "DISTINCT ON",
+		},
+		{
+			name: "uncertain keys",
+			opts: destination.TruncateInsertFromStagingOptions{
+				StagingTable:   "_bruin_staging.events",
+				TargetTable:    "public.events",
+				PrimaryKeys:    []string{"id"},
+				Columns:        []string{"id", "updated_at", "value"},
+				IncrementalKey: "updated_at",
+			},
+			contains: `SELECT DISTINCT ON ("id") "id", "updated_at", "value" FROM "_bruin_staging"."events" ORDER BY "id", "updated_at" DESC`,
+			excludes: "ON CONFLICT",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(tt.opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if truncateSQL != `TRUNCATE TABLE "public"."events"` {
+				t.Fatalf("truncate SQL = %q", truncateSQL)
+			}
+			if !strings.Contains(insertSQL, tt.contains) {
+				t.Fatalf("insert SQL does not contain %q:\n%s", tt.contains, insertSQL)
+			}
+			if strings.Contains(insertSQL, tt.excludes) {
+				t.Fatalf("insert SQL unexpectedly contains %q:\n%s", tt.excludes, insertSQL)
+			}
+		})
+	}
+}
+
+func TestBuildTruncateInsertFromStagingSQLRequiresPrimaryKeys(t *testing.T) {
+	_, _, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{})
+	if err == nil {
+		t.Fatal("expected missing primary key error")
+	}
+}
+
 func TestDescribePostgresStatementUsesAnonymousPreparedStatement(t *testing.T) {
 	describer := &postgresStatementDescriberStub{}
 	const sql = `select "id" from "public"."events"`

--- a/pkg/destination/postgres/truncate_insert_integration_test.go
+++ b/pkg/destination/postgres/truncate_insert_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestTruncateInsertFromStagingIsAtomic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image: "postgres:16-alpine",
+			Env: map[string]string{
+				"POSTGRES_USER": "testuser", "POSTGRES_PASSWORD": "testpass", "POSTGRES_DB": "testdb",
+			},
+			ExposedPorts: []string{"5432/tcp"},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = container.Terminate(context.Background()) }()
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+
+	dest := NewPostgresDestination()
+	uri := fmt.Sprintf("postgres://testuser:testpass@%s:%s/testdb?sslmode=disable", host, port.Port())
+	require.NoError(t, dest.Connect(ctx, uri))
+	defer func() { _ = dest.Close(context.Background()) }()
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE SCHEMA _bruin_staging;
+		CREATE TABLE public.events (id bigint PRIMARY KEY, value text NOT NULL);
+		INSERT INTO public.events VALUES (1, 'old');
+		CREATE VIEW public.current_events AS SELECT id, value FROM public.events;
+		CREATE TABLE _bruin_staging.events (id bigint, value text);
+		INSERT INTO _bruin_staging.events VALUES (2, NULL);
+	`))
+
+	opts := destination.TruncateInsertFromStagingOptions{
+		StagingTable:             "_bruin_staging.events",
+		TargetTable:              "public.events",
+		PrimaryKeys:              []string{"id"},
+		StagingPrimaryKeysUnique: true,
+		Columns:                  []string{"id", "value"},
+	}
+	require.Error(t, dest.TruncateInsertFromStaging(ctx, opts))
+
+	var id int64
+	var value string
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id, value FROM public.current_events`).Scan(&id, &value))
+	require.Equal(t, int64(1), id)
+	require.Equal(t, "old", value)
+
+	require.NoError(t, dest.Exec(ctx, `TRUNCATE _bruin_staging.events; INSERT INTO _bruin_staging.events VALUES (2, 'new')`))
+	require.NoError(t, dest.TruncateInsertFromStaging(ctx, opts))
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id, value FROM public.current_events`).Scan(&id, &value))
+	require.Equal(t, int64(2), id)
+	require.Equal(t, "new", value)
+}

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -23,10 +23,12 @@ import (
 // primary keys are unique. Without PKs, rows are written directly into the
 // truncated target.
 //
-// Tradeoffs the user has already accepted by opting in:
+// Destinations without atomic truncate+insert support retain these tradeoffs:
 //   - Non-atomic: the target is empty between TRUNCATE and the final insert,
 //     so concurrent readers may see an empty result set.
 //   - No rollback: if the insert fails after truncate, the target is left empty.
+//
+// All truncate+insert paths retain these tradeoffs:
 //   - Schema drift: the existing table's schema is preserved as-is; this
 //     strategy does not drop and recreate to pick up schema changes.
 //   - ClickHouse caveat: ClickHouse's merge implementation relies on
@@ -134,7 +136,8 @@ func (s *TruncateInsertStrategy) executeDirect(ctx context.Context, job *Ingesti
 }
 
 func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *IngestionJob, truncator destination.TruncateCapable) error {
-	if !job.Destination.SupportsMergeStrategy() {
+	atomicWriter, supportsAtomicFinalize := job.Destination.(destination.AtomicTruncateInsertStagingWriter)
+	if !supportsAtomicFinalize && !job.Destination.SupportsMergeStrategy() {
 		return fmt.Errorf("destination does not support deduplicated truncate+insert (merge not supported); use replace instead")
 	}
 
@@ -216,7 +219,7 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 
 	stagingPrimaryKeysUnique := effectivePrimaryKeysGuaranteedUnique(job)
 	incrementalKey := mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey)
-	if atomicWriter, ok := job.Destination.(destination.AtomicTruncateInsertStagingWriter); ok {
+	if supportsAtomicFinalize {
 		config.Debug("[TRUNCATE+INSERT] Executing atomic insert from staging")
 		if err := atomicWriter.TruncateInsertFromStaging(ctx, destination.TruncateInsertFromStagingOptions{
 			StagingTable:             stagingTable,

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -17,10 +17,11 @@ import (
 // (views, grants, foreign keys).
 //
 // When primary keys are configured, rows are first written to a staging table
-// and then inserted into the truncated target via the destination's existing
-// merge SQL. Staging is deduplicated unless the source guarantees that its
-// effective primary keys are unique. Without PKs, rows are written directly
-// into the truncated target.
+// and then inserted into the truncated target. Destinations can finalize the
+// replacement atomically; otherwise the strategy uses the destination's merge
+// SQL. Staging is deduplicated unless the source guarantees that its effective
+// primary keys are unique. Without PKs, rows are written directly into the
+// truncated target.
 //
 // Tradeoffs the user has already accepted by opting in:
 //   - Non-atomic: the target is empty between TRUNCATE and the final insert,
@@ -213,26 +214,35 @@ func (s *TruncateInsertStrategy) executeWithStaging(ctx context.Context, job *In
 		return fmt.Errorf("failed to apply schema evolution: %w", err)
 	}
 
-	if err := truncator.TruncateTable(ctx, targetTable); err != nil {
-		return fmt.Errorf("failed to truncate target: %w", err)
-	}
-
 	stagingPrimaryKeysUnique := effectivePrimaryKeysGuaranteedUnique(job)
-	if stagingPrimaryKeysUnique {
-		config.Debug("[TRUNCATE+INSERT] Executing unique-key insert via merge from staging")
+	incrementalKey := mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey)
+	if atomicWriter, ok := job.Destination.(destination.AtomicTruncateInsertStagingWriter); ok {
+		config.Debug("[TRUNCATE+INSERT] Executing atomic insert from staging")
+		if err := atomicWriter.TruncateInsertFromStaging(ctx, destination.TruncateInsertFromStagingOptions{
+			StagingTable:             stagingTable,
+			TargetTable:              targetTable,
+			PrimaryKeys:              job.Config.PrimaryKeys,
+			StagingPrimaryKeysUnique: stagingPrimaryKeysUnique,
+			Columns:                  job.Schema.ColumnNames(),
+			IncrementalKey:           incrementalKey,
+		}); err != nil {
+			return fmt.Errorf("failed to atomically insert from staging: %w", err)
+		}
 	} else {
-		config.Debug("[TRUNCATE+INSERT] Executing deduplicated insert via merge from staging")
-	}
-	if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
-		StagingTable:             stagingTable,
-		TargetTable:              targetTable,
-		PrimaryKeys:              job.Config.PrimaryKeys,
-		StagingPrimaryKeysUnique: stagingPrimaryKeysUnique,
-		Columns:                  job.Schema.ColumnNames(),
-		IncrementalKey:           mergeIncrementalKeyForSchema(job.Schema, job.Config.IncrementalKey),
-		Schema:                   job.Schema,
-	}); err != nil {
-		return fmt.Errorf("failed to insert from staging: %w", err)
+		if err := truncator.TruncateTable(ctx, targetTable); err != nil {
+			return fmt.Errorf("failed to truncate target: %w", err)
+		}
+		if err := job.Destination.MergeTable(ctx, destination.MergeOptions{
+			StagingTable:             stagingTable,
+			TargetTable:              targetTable,
+			PrimaryKeys:              job.Config.PrimaryKeys,
+			StagingPrimaryKeysUnique: stagingPrimaryKeysUnique,
+			Columns:                  job.Schema.ColumnNames(),
+			IncrementalKey:           incrementalKey,
+			Schema:                   job.Schema,
+		}); err != nil {
+			return fmt.Errorf("failed to insert from staging: %w", err)
+		}
 	}
 
 	if !job.Config.KeepStaging {

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -23,6 +23,10 @@ func (d *atomicTruncateInsertDestination) TruncateInsertFromStaging(_ context.Co
 	return d.finalizeErr
 }
 
+func (d *atomicTruncateInsertDestination) SupportsMergeStrategy() bool {
+	return false
+}
+
 func TestTruncateInsertStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
 	job, src, dest := minimalJob()
 	job.Destination = &truncateCapableDestination{fakeDestination: dest}

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -3,12 +3,25 @@ package strategy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/stretchr/testify/require"
 )
+
+type atomicTruncateInsertDestination struct {
+	*truncateCapableDestination
+	finalizeCalls []destination.TruncateInsertFromStagingOptions
+	finalizeErr   error
+}
+
+func (d *atomicTruncateInsertDestination) TruncateInsertFromStaging(_ context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	d.finalizeCalls = append(d.finalizeCalls, opts)
+	return d.finalizeErr
+}
 
 func TestTruncateInsertStrategy_Execute_PassesFullRefreshToRead(t *testing.T) {
 	job, src, dest := minimalJob()
@@ -100,6 +113,26 @@ func TestTruncateInsertStrategy_Execute_DedupsUncertainSourcePrimaryKeys(t *test
 	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
 	require.Len(t, dest.mergeCalls, 1)
 	require.False(t, dest.mergeCalls[0].StagingPrimaryKeysUnique)
+}
+
+func TestTruncateInsertStrategy_Execute_PrefersAtomicStagingFinalizer(t *testing.T) {
+	for _, primaryKeysUnique := range []bool{false, true} {
+		t.Run(fmt.Sprintf("unique=%t", primaryKeysUnique), func(t *testing.T) {
+			job, src, dest := minimalJob()
+			truncateDest := &truncateCapableDestination{fakeDestination: dest}
+			atomicDest := &atomicTruncateInsertDestination{truncateCapableDestination: truncateDest}
+			job.Destination = atomicDest
+			job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+			src.primaryKeysUnique = primaryKeysUnique
+			src.readCh = mustClosedRecords()
+
+			require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+			require.Len(t, atomicDest.finalizeCalls, 1)
+			require.Equal(t, primaryKeysUnique, atomicDest.finalizeCalls[0].StagingPrimaryKeysUnique)
+			require.Empty(t, dest.truncateCalls)
+			require.Empty(t, dest.mergeCalls)
+		})
+	}
 }
 
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {


### PR DESCRIPTION
## Summary

- finalize PostgreSQL truncate+insert from staging in one transaction
- use a plain insert after truncation instead of redundant conflict handling
- keep deduplication for sources whose primary-key uniqueness is uncertain

This prevents readers from seeing a committed empty target and restores the old rows if finalization fails, while preserving the target table and its dependencies.

## Benchmark

10m PostgreSQL to PostgreSQL mean: 47.86s to 35.46s (25.9% faster).

## Validation

- `make format`
- `make lint`
- `make test`
- PostgreSQL integration test covering rollback and dependent-view preservation
