### PR TITLE
Harden MySQL CDC correctness and recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,13 +107,14 @@ cdc-postgres-stress-test: generate
 	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestPostgresCDC_StressComplexWorkload$$' ./tests/integration/
 
 # High-volume MySQL CDC accuracy and performance test (~6 minutes with the
-# default profile). Drives repeated batch catch-up runs (resume under load)
-# against a non-UTC source, with unsigned/decimal/JSON/temporal/binary type
-# coverage, PK updates, deletes, late tables, and a schema-drift
-# fail-then-full-refresh phase. Gated behind the `stress` build tag.
+# default profile), plus focused correctness regressions for protocol modes and
+# failure recovery. Gated behind the `stress` build tag.
 cdc-mysql-stress-test: generate
-	@echo "$(OK_COLOR)==> Running MySQL CDC complex-workload stress test (default profile: ~6m)$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestMySQLCDC_StressComplexWorkload$$' ./tests/integration/
+	@echo "$(OK_COLOR)==> Running MySQL CDC stress and correctness regression tests (default profile: ~6m)$(NO_COLOR)"
+	@if [ -f test.env ]; then . ./test.env; fi; \
+	resolved_docker_host="$${DOCKER_HOST:-$$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)}"; \
+	if [ -n "$$resolved_docker_host" ]; then export DOCKER_HOST="$$resolved_docker_host"; fi; \
+	$(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestMySQLCDC_Stress' ./pkg/source/mysql ./tests/integration/
 
 test-db2-integration: generate
 	@echo "$(OK_COLOR)==> Running Db2 integration tests$(NO_COLOR)"

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -3329,6 +3329,58 @@ func (d *BigQueryDestination) LoadCDCState(ctx context.Context, table, connector
 	return entries, nil
 }
 
+// EnsureCDCStatePositionColumn widens a `_cdc_lsn STRING(64)` column left by
+// older releases to unbounded STRING. PrepareTable's schema reconciliation
+// rejects a bounded column against the now-unbounded state schema, so this
+// runs before retrying the preparation.
+func (d *BigQueryDestination) EnsureCDCStatePositionColumn(ctx context.Context, table string) error {
+	project, dataset, tableName, err := d.parseTable(table)
+	if err != nil {
+		return err
+	}
+	if dataset == "" {
+		dataset = d.datasetID
+	}
+	if dataset == "" {
+		return errors.New("dataset must be specified in state table name or URI path")
+	}
+	meta, err := d.client.DatasetInProject(project, dataset).Table(tableName).Metadata(ctx)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+	bounded := false
+	for _, field := range meta.Schema {
+		if field.Name == destination.CDCLSNColumn {
+			bounded = field.MaxLength > 0
+			break
+		}
+	}
+	if !bounded {
+		return nil
+	}
+	quotedTable := fmt.Sprintf("%s.%s.%s", quoteIdentifier(project), quoteIdentifier(dataset), quoteIdentifier(tableName))
+	sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN `_cdc_lsn` SET DATA TYPE STRING", quotedTable)
+	query := d.client.Query(sql)
+	if d.location != "" {
+		query.Location = d.location
+	}
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to widen BigQuery CDC state position column: %w", err)
+	}
+	status, err := waitForBigQueryJob(ctx, job)
+	if err != nil {
+		return fmt.Errorf("failed to widen BigQuery CDC state position column: %w", err)
+	}
+	if err := status.Err(); err != nil {
+		return fmt.Errorf("failed to widen BigQuery CDC state position column: %w", err)
+	}
+	return nil
+}
+
 func (d *BigQueryDestination) LoadCDCStateFence(ctx context.Context, table, connectorID string) (destination.CDCStateFence, error) {
 	project, dataset, tableName, err := d.parseTable(table)
 	if err != nil {

--- a/pkg/destination/cdc_truncate.go
+++ b/pkg/destination/cdc_truncate.go
@@ -227,6 +227,11 @@ func ApplyCDCTruncate(ctx context.Context, dest Destination, table string) error
 	return ApplyTruncate(ctx, dest, table)
 }
 
+func SupportsCDCConditionalTruncate(dest Destination) bool {
+	_, ok := dest.(CDCConditionalTruncater)
+	return ok
+}
+
 func ApplyCDCTruncateIfIncarnation(ctx context.Context, dest Destination, table, expectedIncarnation string) error {
 	if expectedIncarnation == "" {
 		return fmt.Errorf("cannot conditionally truncate %s without a bound destination incarnation", table)

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -124,6 +124,7 @@ type SwapOptions struct {
 	Schema                        *schema.TableSchema
 	CDCExpectedIncarnation        string
 	CDCExpectedStagingIncarnation string
+	CDCExpectedResultIncarnation  string
 }
 
 // SCD2Options contains parameters for SCD2 (Slowly Changing Dimensions Type 2) operations.
@@ -267,6 +268,12 @@ type CDCStateWriter interface {
 	WriteCDCState(ctx context.Context, records <-chan source.RecordBatchResult, opts WriteOptions) error
 }
 
+// CDCStatePositionMigrator widens state tables created by older releases whose
+// position column was bounded too narrowly for every supported CDC cursor.
+type CDCStatePositionMigrator interface {
+	EnsureCDCStatePositionColumn(ctx context.Context, table string) error
+}
+
 type CDCTargetClaim struct {
 	DestinationTable string
 	ConnectorID      string
@@ -324,11 +331,30 @@ type CDCConditionalTruncater interface {
 	TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error
 }
 
+// CDCConditionalMergeCapable advertises that MergeTable enforces
+// MergeOptions.CDCExpectedIncarnation in the same transaction as target DML.
+type CDCConditionalMergeCapable interface {
+	SupportsCDCConditionalMerge() bool
+}
+
+// ManagedCDCRunLeaser serializes all target mutations for one managed CDC
+// connector and reports loss through the standard connector lease guard.
+type ManagedCDCRunLeaser interface {
+	AcquireManagedCDCRunLease(ctx context.Context, connectorID string) (source.ConnectorLease, error)
+}
+
 // CDCConditionalSwapCapable advertises that SwapTable enforces both expected
 // target and staging incarnations in the same atomic operation that replaces
 // the target.
 type CDCConditionalSwapCapable interface {
 	SupportsCDCConditionalSwap() bool
+}
+
+// CDCConditionalSwapPlanner derives the physical staging incarnation checked
+// by SwapTable and the incarnation that same physical table will have under
+// the target name after the atomic rename.
+type CDCConditionalSwapPlanner interface {
+	CDCConditionalSwapIncarnations(ctx context.Context, targetTable, stagingTable string) (stagingIncarnation, resultIncarnation string, err error)
 }
 
 // CDCTargetIncarnationInitializer establishes destination-specific physical

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/vitess"
 )
 
-// Destinations eligible for destination-managed PostgreSQL CDC state must
+// Destinations eligible for destination-managed CDC state must
 // support one connector-scoped read from the shared state table.
 var (
 	_ destination.CDCStateReader = (*bigquery.BigQueryDestination)(nil)
@@ -57,6 +57,17 @@ var (
 
 var (
 	_ destination.CDCStateWriter                 = (*bigquery.BigQueryDestination)(nil)
+	_ destination.CDCStatePositionMigrator       = (*bigquery.BigQueryDestination)(nil)
+	_ destination.CDCStatePositionMigrator       = (*mssql.MSSQLDestination)(nil)
+	_ destination.CDCStatePositionMigrator       = (*mysql.MySQLDestination)(nil)
+	_ destination.CDCStatePositionMigrator       = (*oracle.OracleDestination)(nil)
+	_ destination.CDCStatePositionMigrator       = (*postgres.PostgresDestination)(nil)
+	_ destination.CDCConditionalMergeCapable     = (*mysql.MySQLDestination)(nil)
+	_ destination.CDCConditionalSwapCapable      = (*mysql.MySQLDestination)(nil)
+	_ destination.CDCConditionalSwapPlanner      = (*mysql.MySQLDestination)(nil)
+	_ destination.CDCConditionalTruncater        = (*mysql.MySQLDestination)(nil)
+	_ destination.CDCLateTargetClaimPreparer     = (*mysql.MySQLDestination)(nil)
+	_ destination.ManagedCDCRunLeaser            = (*mysql.MySQLDestination)(nil)
 	_ destination.ManagedCDCStateValidator       = (*mysql.MySQLDestination)(nil)
 	_ destination.ManagedCDCStateValidator       = (*planetscale.Destination)(nil)
 	_ destination.ManagedCDCStateValidator       = (*redshift.RedshiftDestination)(nil)

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -1241,7 +1241,7 @@ func (d *MSSQLDestination) ValidateManagedCDCTarget(ctx context.Context, table s
 
 func validateMSSQLCompatibilityLevel(database string, compatibilityLevel int) error {
 	if compatibilityLevel < 130 {
-		return fmt.Errorf("SQL Server database %q has compatibility level %d; managed PostgreSQL CDC requires level 130 or newer for OPENJSON", database, compatibilityLevel)
+		return fmt.Errorf("SQL Server database %q has compatibility level %d; managed CDC requires level 130 or newer for OPENJSON", database, compatibilityLevel)
 	}
 	return nil
 }
@@ -1283,6 +1283,27 @@ func (d *MSSQLDestination) LoadCDCState(ctx context.Context, table, connectorID 
 		entries = append(entries, entry)
 	}
 	return entries, rows.Err()
+}
+
+func (d *MSSQLDestination) EnsureCDCStatePositionColumn(ctx context.Context, table string) error {
+	var maxLength int64
+	err := d.db.QueryRowContext(ctx,
+		`SELECT c.max_length FROM sys.columns AS c WHERE c.object_id = OBJECT_ID(@p1) AND c.name = '_cdc_lsn'`,
+		table).Scan(&maxLength)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect SQL Server CDC state position column: %w", err)
+	}
+	if maxLength == -1 {
+		return nil
+	}
+	query := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN [_cdc_lsn] NVARCHAR(MAX) NOT NULL", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, query); err != nil {
+		return fmt.Errorf("failed to widen SQL Server CDC state position column: %w", err)
+	}
+	return nil
 }
 
 func (d *MSSQLDestination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,11 +44,113 @@ const (
 
 var mysqlLoadDataReaderID uint64
 
+type mysqlManagedCDCRunLease struct {
+	conn        *sql.Conn
+	name        string
+	done        chan struct{}
+	stop        chan struct{}
+	stopped     chan struct{}
+	doneOnce    sync.Once
+	releaseOnce sync.Once
+	mu          sync.Mutex
+	err         error
+	releaseErr  error
+}
+
 func NewMySQLDestination() *MySQLDestination {
 	return &MySQLDestination{
 		useLoadData: true,
 		scheme:      "mysql",
 	}
+}
+
+func (d *MySQLDestination) AcquireManagedCDCRunLease(ctx context.Context, connectorID string) (source.ConnectorLease, error) {
+	if d.isVitess {
+		return nil, errors.New("vitess and planetscale do not support MySQL advisory locks for managed CDC")
+	}
+	if connectorID == "" {
+		return nil, errors.New("managed CDC connector ID is empty")
+	}
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reserve MySQL CDC lease connection: %w", err)
+	}
+	name := "ingestr_cdc_" + connectorID
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", name).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to acquire MySQL CDC run lease: %w", err)
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		_ = conn.Close()
+		return nil, fmt.Errorf("another MySQL CDC run already owns connector %s", connectorID)
+	}
+	lease := &mysqlManagedCDCRunLease{
+		conn:    conn,
+		name:    name,
+		done:    make(chan struct{}),
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	go lease.monitor()
+	return lease, nil
+}
+
+func (l *mysqlManagedCDCRunLease) monitor() {
+	defer close(l.stopped)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.stop:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			var held sql.NullInt64
+			err := l.conn.QueryRowContext(ctx, "SELECT IS_USED_LOCK(?) = CONNECTION_ID()", l.name).Scan(&held)
+			cancel()
+			if err == nil && held.Valid && held.Int64 == 1 {
+				continue
+			}
+			if err == nil {
+				err = errors.New("advisory lock is no longer owned by this connection")
+			}
+			l.mu.Lock()
+			l.err = errors.Join(source.ErrConnectorLeaseLost, fmt.Errorf("MySQL CDC run lease lost: %w", err))
+			l.mu.Unlock()
+			l.doneOnce.Do(func() { close(l.done) })
+			return
+		}
+	}
+}
+
+func (l *mysqlManagedCDCRunLease) Done() <-chan struct{} {
+	return l.done
+}
+
+func (l *mysqlManagedCDCRunLease) Err() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.err
+}
+
+func (l *mysqlManagedCDCRunLease) Release() error {
+	l.releaseOnce.Do(func() {
+		close(l.stop)
+		<-l.stopped
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		var released sql.NullInt64
+		if err := l.conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", l.name).Scan(&released); err != nil {
+			l.releaseErr = fmt.Errorf("failed to release MySQL CDC run lease: %w", err)
+		} else if !released.Valid || released.Int64 != 1 {
+			l.releaseErr = errors.New("MySQL CDC run lease was not owned during release")
+		}
+		if err := l.conn.Close(); err != nil {
+			l.releaseErr = errors.Join(l.releaseErr, err)
+		}
+	})
+	return l.releaseErr
 }
 
 func NewVitessCompatibleDestination(defaultScheme string) *MySQLDestination {
@@ -619,6 +722,9 @@ func isLoadDataLocalDisabledError(err error) bool {
 }
 
 func (d *MySQLDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if opts.CDCExpectedIncarnation != "" || opts.CDCExpectedStagingIncarnation != "" || opts.CDCExpectedResultIncarnation != "" {
+		return d.swapTableConditionally(ctx, opts)
+	}
 	startSwap := time.Now()
 	if err := tablename.TwoLevel("mysql").CheckName(opts.StagingTable); err != nil {
 		return err
@@ -700,6 +806,203 @@ func (d *MySQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 	return nil
 }
 
+func (d *MySQLDestination) SupportsCDCConditionalSwap() bool {
+	return !d.isVitess
+}
+
+func (d *MySQLDestination) CDCConditionalSwapIncarnations(ctx context.Context, targetTable, stagingTable string) (string, string, error) {
+	stagingIncarnation, exists, err := d.CDCTargetIncarnation(ctx, stagingTable)
+	if err != nil {
+		return "", "", err
+	}
+	if !exists || stagingIncarnation == "" {
+		return "", "", fmt.Errorf("MySQL CDC staging table %q has no durable physical incarnation", stagingTable)
+	}
+	stagingDatabase, stagingName := splitDatabaseTable(stagingTable)
+	if stagingDatabase == "" {
+		stagingDatabase = d.database
+	}
+	_, _, tableID, exists, err := d.mysqlInnoDBTableID(ctx, d.db, stagingDatabase, stagingName)
+	if err != nil {
+		return "", "", err
+	}
+	if !exists {
+		return "", "", fmt.Errorf("MySQL CDC staging table %q disappeared before swap", stagingTable)
+	}
+	targetDatabase, targetName := splitDatabaseTable(targetTable)
+	if targetDatabase == "" {
+		targetDatabase = d.database
+	}
+	if d.lowerCaseTableNames != 0 {
+		targetDatabase = strings.ToLower(targetDatabase)
+		targetName = strings.ToLower(targetName)
+	}
+	return stagingIncarnation, mysqlTableIncarnation(targetDatabase, targetName, tableID), nil
+}
+
+func (d *MySQLDestination) swapTableConditionally(ctx context.Context, opts destination.SwapOptions) error {
+	if !d.SupportsCDCConditionalSwap() {
+		return errors.New("MySQL CDC conditional swaps are unavailable for Vitess and PlanetScale")
+	}
+	if opts.CDCExpectedIncarnation == "" || opts.CDCExpectedStagingIncarnation == "" || opts.CDCExpectedResultIncarnation == "" {
+		return errors.New("MySQL CDC conditional swap requires target, staging, and result incarnations")
+	}
+	if err := tablename.TwoLevel("mysql").CheckName(opts.StagingTable); err != nil {
+		return err
+	}
+	if err := tablename.TwoLevel("mysql").CheckName(opts.TargetTable); err != nil {
+		return err
+	}
+	targetDatabase, targetName := splitDatabaseTable(opts.TargetTable)
+	if targetDatabase == "" {
+		targetDatabase = d.database
+	}
+	stagingDatabase, stagingName := splitDatabaseTable(opts.StagingTable)
+	if stagingDatabase == "" {
+		stagingDatabase = d.database
+	}
+	targetRef := quoteMySQLTable(targetDatabase, targetName)
+	stagingRef := quoteMySQLTable(stagingDatabase, stagingName)
+	backupCandidate := fmt.Sprintf("%s_old_%d", targetName, time.Now().UnixNano())
+	backupName := destination.ShortenIdentifier(backupCandidate, backupCandidate, destination.MaxIdentifierLength("mysql"))
+	backupRef := quoteMySQLTable(targetDatabase, backupName)
+
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to reserve MySQL CDC conditional swap connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	lockSQL := fmt.Sprintf("LOCK TABLES %s WRITE, %s WRITE", targetRef, stagingRef)
+	if _, err := conn.ExecContext(ctx, lockSQL); err != nil {
+		return fmt.Errorf("failed to lock MySQL CDC swap tables: %w", err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, _ = conn.ExecContext(unlockCtx, "UNLOCK TABLES")
+		}
+	}()
+
+	currentTarget, exists, err := d.mysqlCDCTargetIncarnation(ctx, conn, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	if !exists || currentTarget != opts.CDCExpectedIncarnation {
+		return fmt.Errorf("MySQL CDC target %s was replaced before conditional swap", opts.TargetTable)
+	}
+	currentStaging, exists, err := d.mysqlCDCTargetIncarnation(ctx, conn, opts.StagingTable)
+	if err != nil {
+		return err
+	}
+	if !exists || currentStaging != opts.CDCExpectedStagingIncarnation {
+		return fmt.Errorf("MySQL CDC staging table %s was replaced before conditional swap", opts.StagingTable)
+	}
+	// MariaDB and MySQL before 8.0.13 reject RENAME TABLE while the session
+	// holds LOCK TABLES. There the locks are released first and the swap is
+	// re-verified afterwards: if the demoted backup is not the table that was
+	// validated under the lock, the rename clobbered a concurrent replacement
+	// and is atomically undone.
+	renameUnderLock, err := d.supportsRenameTableUnderLock(ctx, conn)
+	if err != nil {
+		return err
+	}
+	var demotedTableID uint64
+	if !renameUnderLock {
+		_, _, tableID, exists, err := d.mysqlInnoDBTableID(ctx, conn, targetDatabase, targetName)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("MySQL CDC target %s was replaced before conditional swap", opts.TargetTable)
+		}
+		demotedTableID = tableID
+		if _, err := conn.ExecContext(ctx, "UNLOCK TABLES"); err != nil {
+			return fmt.Errorf("failed to unlock MySQL CDC swap tables: %w", err)
+		}
+		locked = false
+	}
+	renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s, %s TO %s", targetRef, backupRef, stagingRef, targetRef)
+	if _, err := conn.ExecContext(ctx, renameSQL); err != nil {
+		return fmt.Errorf("failed to conditionally swap MySQL CDC target: %w", err)
+	}
+	if locked {
+		if _, err := conn.ExecContext(ctx, "UNLOCK TABLES"); err != nil {
+			return fmt.Errorf("failed to unlock MySQL CDC swap tables: %w", err)
+		}
+		locked = false
+	}
+	if !renameUnderLock {
+		_, _, backupID, exists, err := d.mysqlInnoDBTableID(ctx, conn, targetDatabase, backupName)
+		if err != nil {
+			return err
+		}
+		if !exists || backupID != demotedTableID {
+			restoreSQL := fmt.Sprintf("RENAME TABLE %s TO %s, %s TO %s", targetRef, stagingRef, backupRef, targetRef)
+			if _, restoreErr := conn.ExecContext(ctx, restoreSQL); restoreErr != nil {
+				return fmt.Errorf("MySQL CDC target %s was replaced during conditional swap and could not be restored from %s: %w", opts.TargetTable, backupName, restoreErr)
+			}
+			return fmt.Errorf("MySQL CDC target %s was replaced during conditional swap", opts.TargetTable)
+		}
+	}
+	resultIncarnation, exists, err := d.CDCTargetIncarnation(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	if !exists || resultIncarnation != opts.CDCExpectedResultIncarnation {
+		if !renameUnderLock {
+			restoreSQL := fmt.Sprintf("RENAME TABLE %s TO %s, %s TO %s", targetRef, stagingRef, backupRef, targetRef)
+			if _, restoreErr := conn.ExecContext(ctx, restoreSQL); restoreErr != nil {
+				return fmt.Errorf("MySQL CDC target %s was replaced during conditional swap and could not be restored from %s: %w", opts.TargetTable, backupName, restoreErr)
+			}
+		}
+		return fmt.Errorf("MySQL CDC target %s was replaced during conditional swap", opts.TargetTable)
+	}
+	if _, err := d.db.ExecContext(ctx, "DROP TABLE IF EXISTS "+backupRef); err != nil {
+		return fmt.Errorf("failed to drop prior MySQL CDC target after conditional swap: %w", err)
+	}
+	return nil
+}
+
+func (d *MySQLDestination) supportsRenameTableUnderLock(ctx context.Context, q mysqlCDCQueryRower) (bool, error) {
+	var version string
+	if err := q.QueryRowContext(ctx, "SELECT @@version").Scan(&version); err != nil {
+		return false, fmt.Errorf("failed to read MySQL server version: %w", err)
+	}
+	return mysqlVersionAllowsRenameUnderLock(version), nil
+}
+
+// mysqlVersionAllowsRenameUnderLock reports whether the server permits RENAME
+// TABLE while the session holds LOCK TABLES ... WRITE: MySQL 8.0.13 and newer;
+// MariaDB has not adopted the relaxation.
+func mysqlVersionAllowsRenameUnderLock(version string) bool {
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return false
+	}
+	parts := strings.SplitN(version, "-", 2)
+	numbers := strings.Split(parts[0], ".")
+	if len(numbers) < 3 {
+		return false
+	}
+	major, err := strconv.Atoi(numbers[0])
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(numbers[1])
+	if err != nil {
+		return false
+	}
+	patch, err := strconv.Atoi(numbers[2])
+	if err != nil {
+		return false
+	}
+	if major != 8 {
+		return major > 8
+	}
+	return minor > 0 || patch >= 13
+}
+
 func quoteMySQLTable(database, table string) string {
 	quotedTable := fmt.Sprintf("`%s`", strings.ReplaceAll(table, "`", "``"))
 	if database == "" {
@@ -722,6 +1025,11 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if opts.CDCExpectedIncarnation != "" {
+		if err := d.lockAndValidateCDCIncarnation(ctx, tx, opts.TargetTable, opts.CDCExpectedIncarnation); err != nil {
+			return err
+		}
+	}
 
 	// Build dedup subquery to handle duplicate PKs in staging. For CDC data the
 	// latest change per PK wins (LSN strings are fixed-width and sort
@@ -1131,9 +1439,14 @@ func (d *MySQLDestination) LoadCDCState(ctx context.Context, table, connectorID 
 }
 
 func (d *MySQLDestination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {
+	_, err := d.claimCDCTarget(ctx, claimTable, claim)
+	return err
+}
+
+func (d *MySQLDestination) claimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) (bool, error) {
 	ownerID, err := claim.OwnerID()
 	if err != nil {
-		return err
+		return false, err
 	}
 	database, tableName := splitDatabaseTable(claim.DestinationTable)
 	if database == "" {
@@ -1142,25 +1455,158 @@ func (d *MySQLDestination) ClaimCDCTarget(ctx context.Context, claimTable string
 	canonicalTarget := canonicalMySQLTarget(database, tableName, d.lowerCaseTableNames)
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = tx.Rollback() }()
-	insert := fmt.Sprintf("INSERT INTO %s (`destination_table`, `connector_id`, `claimed_at`) VALUES (?, ?, CURRENT_TIMESTAMP(6)) ON DUPLICATE KEY UPDATE `destination_table` = VALUES(`destination_table`)", quoteTable(claimTable))
-	if _, err := tx.ExecContext(ctx, insert, canonicalTarget, ownerID); err != nil {
-		return err
+	insert := fmt.Sprintf("INSERT IGNORE INTO %s (`destination_table`, `connector_id`, `claimed_at`) VALUES (?, ?, CURRENT_TIMESTAMP(6))", quoteTable(claimTable))
+	result, err := tx.ExecContext(ctx, insert, canonicalTarget, ownerID)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
 	}
 	var owner string
 	query := fmt.Sprintf("SELECT `connector_id` FROM %s WHERE `destination_table` = ?", quoteTable(claimTable))
 	if err := tx.QueryRowContext(ctx, query, canonicalTarget).Scan(&owner); err != nil {
-		return err
+		return false, err
 	}
 	if owner != ownerID {
-		return fmt.Errorf("destination table %q is already claimed by CDC connector %q", canonicalTarget, owner)
+		return false, fmt.Errorf("destination table %q is already claimed by CDC connector %q", canonicalTarget, owner)
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return rowsAffected == 1, nil
+}
+
+func (d *MySQLDestination) ClaimAndPrepareEmptyCDCTarget(
+	ctx context.Context,
+	claimTable string,
+	claim destination.CDCTargetClaim,
+	opts destination.PrepareOptions,
+) (string, error) {
+	if opts.Schema == nil {
+		return "", errors.New("cannot create an empty managed CDC target without a schema")
+	}
+	targetDatabase, targetTable := splitDatabaseTable(opts.Table)
+	if targetDatabase == "" {
+		targetDatabase = d.database
+	}
+	claimDatabase, claimTableName := splitDatabaseTable(claim.DestinationTable)
+	if claimDatabase == "" {
+		claimDatabase = d.database
+	}
+	canonicalTarget := canonicalMySQLTarget(targetDatabase, targetTable, d.lowerCaseTableNames)
+	if canonicalMySQLTarget(claimDatabase, claimTableName, d.lowerCaseTableNames) != canonicalTarget {
+		return "", fmt.Errorf("CDC target claim %q does not match prepared table %q", claim.DestinationTable, opts.Table)
+	}
+	if _, exists, err := d.CDCTargetIncarnation(ctx, opts.Table); err != nil {
+		return "", err
+	} else if exists {
+		return "", fmt.Errorf("destination table %q already exists", opts.Table)
+	}
+	claimInserted, err := d.claimCDCTarget(ctx, claimTable, claim)
+	if err != nil {
+		return "", err
+	}
+	ownerID, err := claim.OwnerID()
+	if err != nil {
+		return "", err
+	}
+	cleanupClaim := func() error {
+		if !claimInserted {
+			return nil
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		query := fmt.Sprintf("DELETE FROM %s WHERE `destination_table` = ? AND `connector_id` = ?", quoteTable(claimTable))
+		_, cleanupErr := d.db.ExecContext(cleanupCtx, query, canonicalTarget, ownerID)
+		return cleanupErr
+	}
+	if targetDatabase != "" {
+		if err := d.ensureDatabaseExists(ctx, targetDatabase); err != nil {
+			return "", errors.Join(err, cleanupClaim())
+		}
+	}
+	tempCandidate := fmt.Sprintf("%s_ingestr_claim_%d", targetTable, time.Now().UnixNano())
+	tempTable := destination.ShortenIdentifier(tempCandidate, tempCandidate, destination.MaxIdentifierLength("mysql"))
+	tempRef := quoteMySQLTable(targetDatabase, tempTable)
+	targetRef := quoteMySQLTable(targetDatabase, targetTable)
+	createSQL := buildCreateTableSQLForReference(tempRef, opts.Schema.Columns, opts.PrimaryKeys)
+	createSQL = strings.Replace(createSQL, "CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1) + " ENGINE=InnoDB"
+	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+		return "", errors.Join(fmt.Errorf("failed to create temporary MySQL CDC target for %q: %w", opts.Table, err), cleanupClaim())
+	}
+	cleanupTemp := func() error {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, cleanupErr := d.db.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS "+tempRef)
+		return cleanupErr
+	}
+	normalizedDB, _, tableID, exists, err := d.mysqlInnoDBTableID(ctx, d.db, targetDatabase, tempTable)
+	if err != nil || !exists {
+		if err == nil {
+			err = fmt.Errorf("temporary MySQL CDC target %q has no durable physical incarnation", tempTable)
+		}
+		return "", errors.Join(err, cleanupTemp(), cleanupClaim())
+	}
+	normalizedTarget := targetTable
+	if d.lowerCaseTableNames != 0 {
+		normalizedTarget = strings.ToLower(normalizedTarget)
+	}
+	expectedIncarnation := mysqlTableIncarnation(normalizedDB, normalizedTarget, tableID)
+	renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s", tempRef, targetRef)
+	if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
+		return "", errors.Join(fmt.Errorf("failed to atomically bind claimed MySQL CDC target %q: %w", opts.Table, err), cleanupTemp(), cleanupClaim())
+	}
+	incarnation, exists, err := d.CDCTargetIncarnation(ctx, opts.Table)
+	if err != nil {
+		return "", err
+	}
+	if !exists || incarnation != expectedIncarnation {
+		return "", errors.Join(fmt.Errorf("claimed MySQL CDC target %q was replaced while it was being bound", opts.Table), cleanupClaim())
+	}
+	return incarnation, nil
+}
+
+func (d *MySQLDestination) EnsureCDCStatePositionColumn(ctx context.Context, table string) error {
+	database, tableName := splitDatabaseTable(table)
+	if database == "" {
+		database = d.database
+	}
+	var dataType string
+	err := d.db.QueryRowContext(ctx,
+		`SELECT DATA_TYPE FROM information_schema.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?`,
+		database, tableName, destination.CDCLSNColumn).Scan(&dataType)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect MySQL CDC state position column: %w", err)
+	}
+	switch strings.ToLower(dataType) {
+	case "varchar", "char":
+	default:
+		return nil
+	}
+	query := fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN `_cdc_lsn` TEXT NOT NULL", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, query); err != nil {
+		return fmt.Errorf("failed to widen MySQL CDC state position column: %w", err)
+	}
+	return nil
+}
+
+type mysqlCDCQueryRower interface {
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
 func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table string) (string, bool, error) {
+	return d.mysqlCDCTargetIncarnation(ctx, d.db, table)
+}
+
+func (d *MySQLDestination) mysqlCDCTargetIncarnation(ctx context.Context, q mysqlCDCQueryRower, table string) (string, bool, error) {
 	if d.isVitess {
 		return "", false, errors.New("vitess and planetscale do not expose a durable physical table incarnation")
 	}
@@ -1169,7 +1615,7 @@ func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 		database = d.database
 	}
 	var engine string
-	err := d.db.QueryRowContext(ctx, `SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?`, database, tableName).Scan(&engine)
+	err := q.QueryRowContext(ctx, `SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?`, database, tableName).Scan(&engine)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", false, nil
 	}
@@ -1180,23 +1626,71 @@ func (d *MySQLDestination) CDCTargetIncarnation(ctx context.Context, table strin
 		return "", false, fmt.Errorf("MySQL CDC target %s uses %s, which has no supported durable table incarnation", table, engine)
 	}
 
-	if d.lowerCaseTableNames != 0 {
-		database = strings.ToLower(database)
-		tableName = strings.ToLower(tableName)
-	}
-	internalName := database + "/" + tableName
-	var tableID uint64
-	err = d.db.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
-	if err != nil {
-		err = d.db.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_SYS_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
-	}
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", false, nil
-	}
+	database, tableName, tableID, exists, err := d.mysqlInnoDBTableID(ctx, q, database, tableName)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to read durable InnoDB table identity for %s: %w", table, err)
 	}
+	if !exists {
+		return "", false, nil
+	}
 	return mysqlTableIncarnation(database, tableName, tableID), true, nil
+}
+
+func (d *MySQLDestination) mysqlInnoDBTableID(ctx context.Context, q mysqlCDCQueryRower, database, table string) (string, string, uint64, bool, error) {
+	if d.lowerCaseTableNames != 0 {
+		database = strings.ToLower(database)
+		table = strings.ToLower(table)
+	}
+	internalName := database + "/" + table
+	var tableID uint64
+	err := q.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
+	if err != nil {
+		err = q.QueryRowContext(ctx, `SELECT TABLE_ID FROM information_schema.INNODB_SYS_TABLES WHERE NAME = ?`, internalName).Scan(&tableID)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return database, table, 0, false, nil
+	}
+	if err != nil {
+		return database, table, 0, false, err
+	}
+	return database, table, tableID, true, nil
+}
+
+func (d *MySQLDestination) SupportsCDCConditionalMerge() bool {
+	return !d.isVitess
+}
+
+func (d *MySQLDestination) lockAndValidateCDCIncarnation(ctx context.Context, tx *sql.Tx, table, expected string) error {
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT 1 FROM %s LIMIT 1 FOR UPDATE", quoteTable(table)))
+	if err != nil {
+		return fmt.Errorf("failed to lock MySQL CDC target %s: %w", table, err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to release MySQL CDC target lock query for %s: %w", table, err)
+	}
+	current, exists, err := d.mysqlCDCTargetIncarnation(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expected {
+		return fmt.Errorf("MySQL CDC target %s was replaced before mutation", table)
+	}
+	return nil
+}
+
+func (d *MySQLDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := d.lockAndValidateCDCIncarnation(ctx, tx, table, expectedIncarnation); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", quoteTable(table))); err != nil {
+		return fmt.Errorf("failed to conditionally clear MySQL CDC target %s: %w", table, err)
+	}
+	return tx.Commit()
 }
 
 func mysqlTableIncarnation(database, table string, tableID uint64) string {
@@ -1267,12 +1761,13 @@ func (d *MySQLDestination) DeleteCDCStateEvents(ctx context.Context, table, conn
 }
 
 // isMySQLMissingTableError reports whether err means the queried table does not
-// exist. Plain MySQL raises errno 1146 ("... doesn't exist"); vtgate raises
-// errno 1146 or 1051 with "table ... does not exist" (VT05004/VT05005).
+// exist. Plain MySQL raises errno 1146 for a missing table and 1049 for its
+// missing database; vtgate raises errno 1146 or 1051 with "table ... does not
+// exist" (VT05004/VT05005).
 func isMySQLMissingTableError(err error) bool {
 	var myErr *mysqldriver.MySQLError
 	if errors.As(err, &myErr) {
-		return myErr.Number == 1146 || myErr.Number == 1051
+		return myErr.Number == 1146 || myErr.Number == 1051 || myErr.Number == 1049
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "does not exist")
@@ -1512,6 +2007,10 @@ func extractTableName(table string) string {
 }
 
 func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
+	return buildCreateTableSQLForReference(quoteTable(table), columns, primaryKeys)
+}
+
+func buildCreateTableSQLForReference(tableReference string, columns []schema.Column, primaryKeys []string) string {
 	var colDefs []string
 	binaryClaimKey := isCDCTargetClaimTable(columns, primaryKeys)
 	for _, col := range columns {
@@ -1522,7 +2021,7 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
 	}
 
-	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))
+	sql := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s", tableReference, strings.Join(colDefs, ",\n  "))
 
 	if len(primaryKeys) > 0 {
 		quotedKeys := make([]string, len(primaryKeys))

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"database/sql"
 	"errors"
 	"regexp"
 	"strings"
@@ -11,7 +12,116 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestManagedCDCRunLeaseAcquiresAndReleasesAdvisoryLock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dest := &MySQLDestination{db: db}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, 0)")).
+		WithArgs("ingestr_cdc_connector").
+		WillReturnRows(sqlmock.NewRows([]string{"acquired"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs("ingestr_cdc_connector").
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	lease, err := dest.AcquireManagedCDCRunLease(t.Context(), "connector")
+	require.NoError(t, err)
+	require.NoError(t, lease.Release())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestManagedCDCRunLeaseRejectsConcurrentOwner(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dest := &MySQLDestination{db: db}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, 0)")).
+		WithArgs("ingestr_cdc_connector").
+		WillReturnRows(sqlmock.NewRows([]string{"acquired"}).AddRow(sql.NullInt64{Int64: 0, Valid: true}))
+
+	_, err = dest.AcquireManagedCDCRunLease(t.Context(), "connector")
+	require.ErrorContains(t, err, "already owns connector")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestClaimAndPrepareEmptyCDCTargetUsesAtomicRename(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}))
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO `_bruin_staging`.`cdc_targets` (`destination_table`, `connector_id`, `claimed_at`) VALUES (?, ?, CURRENT_TIMESTAMP(6))")).
+		WithArgs(destination.CDCTargetKey("app", "events"), destination.CDCTargetOwnerID("connector", "source.events")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT `connector_id` FROM `_bruin_staging`.`cdc_targets` WHERE `destination_table` = ?")).
+		WithArgs(destination.CDCTargetKey("app", "events")).
+		WillReturnRows(sqlmock.NewRows([]string{"connector_id"}).AddRow(destination.CDCTargetOwnerID("connector", "source.events")))
+	mock.ExpectCommit()
+	mock.ExpectExec("CREATE TABLE `app`\\.`events_ingestr_claim_[0-9]+`").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(42)))
+	mock.ExpectExec("RENAME TABLE `app`\\.`events_ingestr_claim_[0-9]+` TO `app`\\.`events`").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(42)))
+
+	incarnation, err := dest.ClaimAndPrepareEmptyCDCTarget(t.Context(), "_bruin_staging.cdc_targets", destination.CDCTargetClaim{
+		DestinationTable: "events",
+		ConnectorID:      "connector",
+		SourceTable:      "source.events",
+	}, destination.PrepareOptions{
+		Table:       "events",
+		Schema:      &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}, PrimaryKeys: []string{"id"}},
+		PrimaryKeys: []string{"id"},
+		CDCMode:     true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, mysqlTableIncarnation("app", "events", 42), incarnation)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestConditionalCDCSwapRejectsReplacedTargetBeforeRename(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+
+	mock.ExpectExec(regexp.QuoteMeta("LOCK TABLES `app`.`events` WRITE, `app`.`events_staging` WRITE")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(43)))
+	mock.ExpectExec(regexp.QuoteMeta("UNLOCK TABLES")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = dest.SwapTable(t.Context(), destination.SwapOptions{
+		TargetTable:                   "events",
+		StagingTable:                  "events_staging",
+		CDCExpectedIncarnation:        mysqlTableIncarnation("app", "events", 42),
+		CDCExpectedStagingIncarnation: mysqlTableIncarnation("app", "events_staging", 44),
+		CDCExpectedResultIncarnation:  mysqlTableIncarnation("app", "events", 44),
+	})
+	require.ErrorContains(t, err, "replaced before conditional swap")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
 
 func TestCanonicalMySQLTargetHonorsLowerCaseTableNames(t *testing.T) {
 	if got := canonicalMySQLTarget("Sales", "Orders", 0); got != destination.CDCTargetKey("Sales", "Orders") {
@@ -113,6 +223,51 @@ func TestCDCTruncatePreservesInnoDBPhysicalIdentityWithoutChangingBatchTruncate(
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestConditionalCDCTruncateRejectsReplacedTarget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM `app`.`events` LIMIT 1 FOR UPDATE")).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(43)))
+	mock.ExpectRollback()
+
+	err = dest.TruncateCDCTableIfIncarnation(t.Context(), "app.events", mysqlTableIncarnation("app", "events", 42))
+	require.ErrorContains(t, err, "was replaced before mutation")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestConditionalCDCTruncateMutatesBoundTarget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dest := &MySQLDestination{db: db, database: "app"}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM `app`.`events` LIMIT 1 FOR UPDATE")).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT ENGINE FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"ENGINE"}).AddRow("InnoDB"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT TABLE_ID FROM information_schema.INNODB_TABLES WHERE NAME = ?")).
+		WithArgs("app/events").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_ID"}).AddRow(uint64(42)))
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `app`.`events`")).
+		WillReturnResult(sqlmock.NewResult(0, 3))
+	mock.ExpectCommit()
+
+	require.NoError(t, dest.TruncateCDCTableIfIncarnation(t.Context(), "app.events", mysqlTableIncarnation("app", "events", 42)))
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestVitessManagedCDCStateFailsWithoutDurableIncarnation(t *testing.T) {
@@ -565,6 +720,7 @@ func TestIsMySQLMissingTableError(t *testing.T) {
 		want bool
 	}{
 		{"mysql errno 1146", &mysqldriver.MySQLError{Number: 1146, Message: "Table 'db.t' doesn't exist"}, true},
+		{"mysql errno 1049", &mysqldriver.MySQLError{Number: 1049, Message: "Unknown database 'db'"}, true},
 		{"vtgate errno 1051", &mysqldriver.MySQLError{Number: 1051, Message: "VT05004: table 't' does not exist"}, true},
 		{"vtgate text without errno", errors.New("target: db.0.primary: vttablet: table 't' does not exist in keyspace 'db'"), true},
 		{"plain mysql text without errno", errors.New("Error 1146: Table 'db.t' doesn't exist"), true},
@@ -718,4 +874,17 @@ func TestDeleteInsertLockName(t *testing.T) {
 	assert.NotEqual(t, first, other)
 	assert.LessOrEqual(t, len(first), 64)
 	assert.Contains(t, first, "ingestr_di_")
+}
+
+func TestMySQLVersionAllowsRenameUnderLock(t *testing.T) {
+	assert.True(t, mysqlVersionAllowsRenameUnderLock("8.0.13"))
+	assert.True(t, mysqlVersionAllowsRenameUnderLock("8.0.34-log"))
+	assert.True(t, mysqlVersionAllowsRenameUnderLock("8.4.0"))
+	assert.True(t, mysqlVersionAllowsRenameUnderLock("9.1.0"))
+
+	assert.False(t, mysqlVersionAllowsRenameUnderLock("8.0.12"))
+	assert.False(t, mysqlVersionAllowsRenameUnderLock("5.7.44-log"))
+	assert.False(t, mysqlVersionAllowsRenameUnderLock("10.11.6-MariaDB-1:10.11.6+maria~ubu2204"))
+	assert.False(t, mysqlVersionAllowsRenameUnderLock("11.4.2-MariaDB"))
+	assert.False(t, mysqlVersionAllowsRenameUnderLock("garbage"))
 }

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -809,6 +809,32 @@ func (d *OracleDestination) LoadCDCState(ctx context.Context, table, connectorID
 	return entries, rows.Err()
 }
 
+func (d *OracleDestination) EnsureCDCStatePositionColumn(ctx context.Context, table string) error {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+	var dataType string
+	var charLength sql.NullInt64
+	err := d.db.QueryRowContext(ctx,
+		"SELECT DATA_TYPE, CHAR_LENGTH FROM ALL_TAB_COLUMNS WHERE OWNER = :1 AND TABLE_NAME = :2 AND COLUMN_NAME = :3",
+		schemaName, tableName, destination.CDCLSNColumn).Scan(&dataType, &charLength)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect Oracle CDC state position column: %w", err)
+	}
+	if !strings.EqualFold(dataType, "VARCHAR2") || (charLength.Valid && charLength.Int64 >= 4000) {
+		return nil
+	}
+	// NOT NULL is deliberately not re-specified: Oracle raises ORA-01442 when a
+	// MODIFY names NOT NULL on a column that already carries the constraint, and
+	// the column is created NOT NULL. Omitting it leaves nullability unchanged.
+	query := fmt.Sprintf("ALTER TABLE %s MODIFY (%s VARCHAR2(4000 CHAR))", quoteTable(table), quoteColumn(destination.CDCLSNColumn))
+	if _, err := d.db.ExecContext(ctx, query); err != nil {
+		return fmt.Errorf("failed to widen Oracle CDC state position column: %w", err)
+	}
+	return nil
+}
+
 func (d *OracleDestination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {
 	ownerID, err := claim.OwnerID()
 	if err != nil {

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -1243,6 +1243,31 @@ func (d *PostgresDestination) LoadCDCState(ctx context.Context, table, connector
 	return entries, rows.Err()
 }
 
+func (d *PostgresDestination) EnsureCDCStatePositionColumn(ctx context.Context, table string) error {
+	schemaName, tableName, err := d.resolveSchemaTable(ctx, d.pool, table)
+	if err != nil {
+		return err
+	}
+	var dataType string
+	err = d.pool.QueryRow(ctx,
+		`SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = '_cdc_lsn'`,
+		schemaName, tableName).Scan(&dataType)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect PostgreSQL CDC state position column: %w", err)
+	}
+	if strings.EqualFold(dataType, "text") {
+		return nil
+	}
+	query := fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "_cdc_lsn" TYPE TEXT`, destination.QuoteTableName(table))
+	if _, err := d.pool.Exec(ctx, query); err != nil {
+		return fmt.Errorf("failed to widen PostgreSQL CDC state position column: %w", err)
+	}
+	return nil
+}
+
 func (d *PostgresDestination) CanonicalCDCTarget(ctx context.Context, table string) (string, error) {
 	schemaName, tableName, err := d.resolveSchemaTable(ctx, d.pool, table)
 	if err != nil {

--- a/pkg/destination/redshift/redshift.go
+++ b/pkg/destination/redshift/redshift.go
@@ -35,7 +35,7 @@ func (d *RedshiftDestination) Connect(ctx context.Context, uri string) error {
 }
 
 func (d *RedshiftDestination) ValidateManagedCDCState() error {
-	return errors.New("redshift does not support destination-managed PostgreSQL CDC state")
+	return errors.New("redshift does not support destination-managed CDC state")
 }
 
 func (d *RedshiftDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {

--- a/pkg/destination/redshift/redshift_test.go
+++ b/pkg/destination/redshift/redshift_test.go
@@ -13,7 +13,7 @@ import (
 func TestValidateManagedCDCStateFailsClosed(t *testing.T) {
 	dest := NewRedshiftDestination()
 
-	require.ErrorContains(t, dest.ValidateManagedCDCState(), "does not support destination-managed PostgreSQL CDC state")
+	require.ErrorContains(t, dest.ValidateManagedCDCState(), "does not support destination-managed CDC state")
 }
 
 func TestBuildPredicateMergeStatements(t *testing.T) {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -142,8 +142,11 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		}
 	}()
 
+	managedPostgresCDC := isPostgresCDCSource(p.config.SourceURI)
+	managedMySQLCDC := isMySQLCDCSource(p.config.SourceURI)
+	managedDestinationCDC := managedPostgresCDC || managedMySQLCDC
 	destinationTarget := ""
-	if isPostgresCDCSource(p.config.SourceURI) {
+	if managedPostgresCDC {
 		destinationTarget = managedCDCDestinationTarget(p.config, dest)
 		destinationIdentity, err := managedCDCDestinationIdentity(ctx, dest, destinationTarget)
 		if err != nil {
@@ -151,6 +154,9 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		}
 		p.cdcConnectorID = resolvedCDCStateConnectorID(p.config, postgresCDCIdentity, destinationIdentity)
 	} else if isCDCSource(p.config.SourceURI) {
+		if managedMySQLCDC {
+			destinationTarget = managedCDCDestinationTarget(p.config, dest)
+		}
 		p.cdcConnectorID = genericCDCConnectorID(p.config)
 	}
 
@@ -163,16 +169,43 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		config.Debug("[PIPELINE] CDC slot suffix: %s", p.config.CDCSlotSuffix)
 	}
 
-	managedPostgresCDC := isPostgresCDCSource(p.config.SourceURI)
-	if managedPostgresCDC {
+	if managedDestinationCDC {
 		if err := validateDestinationManagedCDCState(dest); err != nil {
 			return err
+		}
+		if managedMySQLCDC {
+			if err := validateMySQLCDCMutationFencing(dest); err != nil {
+				return err
+			}
 		}
 		if validator, ok := dest.(destination.ManagedCDCTargetValidator); ok {
 			if err := validator.ValidateManagedCDCTarget(ctx, destinationTarget); err != nil {
 				return fmt.Errorf("destination scheme %q cannot safely use managed CDC target %q: %w", dest.GetScheme(), destinationTarget, err)
 			}
 		}
+	}
+	if managedMySQLCDC {
+		leaser, ok := dest.(destination.ManagedCDCRunLeaser)
+		if !ok {
+			return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC without a connector run lease", dest.GetScheme())
+		}
+		lease, err := leaser.AcquireManagedCDCRunLease(ctx, p.cdcConnectorID)
+		if err != nil {
+			return err
+		}
+		leaseCtx, stopLeaseWatch := connectorLeaseContext(ctx, lease)
+		ctx = leaseCtx
+		defer func() {
+			stopLeaseWatch()
+			if err := lease.Release(); err != nil {
+				retErr = errors.Join(retErr, err)
+			}
+			if leaseErr := lease.Err(); leaseErr != nil {
+				retErr = errors.Join(retErr, leaseErr)
+			}
+		}()
+	}
+	if managedPostgresCDC {
 		leaser, ok := src.(source.ConnectorLeaser)
 		if !ok {
 			return fmt.Errorf("postgres CDC source does not support connector leases")
@@ -209,7 +242,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	}
 	sourceIncarnation := ""
 	sourceSchemaFingerprint := ""
-	if managedPostgresCDC {
+	if managedDestinationCDC {
 		cdcStateManager, err = strategy.NewCDCStateManager(
 			dest,
 			p.cdcConnectorID,
@@ -290,10 +323,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		} else {
 			maxLSN, err := resumeProvider.GetMaxCDCLSN(ctx, p.config.DestTable)
 			if err != nil {
-				if isChangeTrackingSource(p.config.SourceURI) {
-					return fmt.Errorf("failed to get SQL Server Change Tracking cursor from destination: %w", err)
-				}
-				config.Debug("[PIPELINE] Failed to get max change cursor from destination: %v", err)
+				return fmt.Errorf("failed to get CDC resume cursor from destination: %w", err)
 			} else if maxLSN != "" {
 				config.Debug("[PIPELINE] Found existing change data, will resume from cursor: %s", maxLSN)
 				p.config.CDCResumeLSN = maxLSN
@@ -692,7 +722,18 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		job.TypeCaster = p.buildTypeCaster(tableSchema, destSchema)
 	}
 	if cdcStateManager != nil {
-		if err := cdcStateManager.ClaimTarget(ctx, p.config.SourceTable, p.config.DestTable); err != nil {
+		var err error
+		if managedMySQLCDC {
+			err = cdcStateManager.ClaimAndPrepareTarget(ctx, p.config.SourceTable, p.config.DestTable, destination.PrepareOptions{
+				Table:       p.config.DestTable,
+				Schema:      ingestSchema,
+				PrimaryKeys: resolvedConfig.PrimaryKeys,
+				CDCMode:     true,
+			})
+		} else {
+			err = cdcStateManager.ClaimTarget(ctx, p.config.SourceTable, p.config.DestTable)
+		}
+		if err != nil {
 			return err
 		}
 		if err := cdcStateManager.BeginRun(ctx, p.config.FullRefresh); err != nil {
@@ -726,7 +767,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	if cdcStateManager != nil {
 		stateProvider, ok := src.(source.CDCStateProvider)
 		if !ok {
-			return fmt.Errorf("postgres CDC source does not expose completed batch state")
+			return fmt.Errorf("managed CDC source does not expose completed batch state")
 		}
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
@@ -1338,7 +1379,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 	var cdcStateManager *strategy.CDCStateManager
 	anchorTable := ""
-	if isPostgresCDCSource(p.config.SourceURI) {
+	if isPostgresCDCSource(p.config.SourceURI) || isMySQLCDCSource(p.config.SourceURI) {
 		for _, destTable := range tableDestNames {
 			if anchorTable == "" || destTable < anchorTable {
 				anchorTable = destTable
@@ -1392,8 +1433,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 				destTable := tableDestNames[table.Name]
 				maxLSN, err := resumeProvider.GetMaxCDCLSN(ctx, destTable)
 				if err != nil {
-					config.Debug("[PIPELINE] Failed to get max CDC LSN for table %s: %v", destTable, err)
-					continue
+					return fmt.Errorf("failed to get CDC resume cursor from destination table %s: %w", destTable, err)
 				}
 				if maxLSN != "" {
 					cdcResumeLSNs[table.Name] = maxLSN
@@ -1404,7 +1444,18 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 	if cdcStateManager != nil {
 		for _, table := range tables {
-			if err := cdcStateManager.ClaimTarget(ctx, table.Name, tableDestNames[table.Name]); err != nil {
+			var err error
+			if isMySQLCDCSource(p.config.SourceURI) {
+				err = cdcStateManager.ClaimAndPrepareTarget(ctx, table.Name, tableDestNames[table.Name], destination.PrepareOptions{
+					Table:       tableDestNames[table.Name],
+					Schema:      table.Schema,
+					PrimaryKeys: table.PrimaryKeys,
+					CDCMode:     true,
+				})
+			} else {
+				err = cdcStateManager.ClaimTarget(ctx, table.Name, tableDestNames[table.Name])
+			}
+			if err != nil {
 				return err
 			}
 		}
@@ -1486,7 +1537,7 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	if cdcStateManager != nil {
 		stateProvider, ok := src.(source.CDCStateProvider)
 		if !ok {
-			return fmt.Errorf("postgres CDC source does not expose completed batch state")
+			return fmt.Errorf("managed CDC source does not expose completed batch state")
 		}
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
@@ -2369,6 +2420,19 @@ func isPostgresCDCSource(rawURI string) bool {
 	return scheme == "postgres+cdc" || scheme == "postgresql+cdc"
 }
 
+func isMySQLCDCSource(rawURI string) bool {
+	schemeEnd := strings.Index(rawURI, "://")
+	if schemeEnd == -1 {
+		return false
+	}
+	switch strings.ToLower(rawURI[:schemeEnd]) {
+	case "mysql+cdc", "mysql+pymysql+cdc", "mariadb+cdc":
+		return true
+	default:
+		return false
+	}
+}
+
 func resolvedCDCStateConnectorID(cfg *config.IngestConfig, identity source.ConnectorIdentity, destinationIdentity string) string {
 	if parsed, err := url.Parse(cfg.SourceURI); err == nil {
 		if stateID := parsed.Query().Get("state_id"); stateID != "" {
@@ -2442,6 +2506,7 @@ func canonicalCDCStateURI(rawURI string) string {
 	for _, key := range []string{
 		"state_id", "mode", "binary", "discover_interval",
 		"database", "dbname",
+		"server_id", "xa_buffer_limit", "xa_buffer_bytes_limit", "xa_pending_limit",
 		"password", "pass", "token", "secret", "api_key", "private_key",
 	} {
 		query.Del(key)
@@ -2521,6 +2586,16 @@ func validateManagedChangeConfig(cfg *config.IngestConfig) error {
 			}
 		}
 	}
+	if isMySQLCDCSource(cfg.SourceURI) && !cfg.FullRefresh {
+		switch cfg.IncrementalStrategy {
+		case "", config.StrategyMerge, config.StrategyReplace:
+		default:
+			return &config.ValidationError{
+				Field:   "incremental-strategy",
+				Message: fmt.Sprintf("%q is not supported for MySQL CDC; use merge or replace", cfg.IncrementalStrategy),
+			}
+		}
+	}
 	if isChangeTrackingSource(cfg.SourceURI) && cfg.SQLLimit > 0 {
 		return &config.ValidationError{Field: "sql-limit", Message: "is not supported for SQL Server Change Tracking sources because partial snapshots cannot safely advance the resume cursor"}
 	}
@@ -2563,21 +2638,21 @@ func supportsDestinationManagedCDCState(dest destination.Destination) bool {
 
 func validateDestinationManagedCDCState(dest destination.Destination) error {
 	if !supportsDestinationManagedCDCState(dest) {
-		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: destination-managed state with fencing, pruning, and truncation is not supported", dest.GetScheme())
+		return fmt.Errorf("destination scheme %q cannot safely run managed CDC: destination-managed state with fencing, pruning, and truncation is not supported", dest.GetScheme())
 	}
 	if _, ok := dest.(destination.CDCTargetClaimer); !ok {
-		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: atomic destination-table claims are not supported", dest.GetScheme())
+		return fmt.Errorf("destination scheme %q cannot safely run managed CDC: atomic destination-table claims are not supported", dest.GetScheme())
 	}
 	if _, ok := dest.(destination.CDCTargetIncarnationProvider); !ok {
-		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: destination-table incarnation checks are not supported", dest.GetScheme())
+		return fmt.Errorf("destination scheme %q cannot safely run managed CDC: destination-table incarnation checks are not supported", dest.GetScheme())
 	}
 	cdcMerge, ok := dest.(destination.CDCMergeAware)
 	if !ok || !cdcMerge.SupportsCDCMerge() {
-		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: CDC-aware merge is not supported", dest.GetScheme())
+		return fmt.Errorf("destination scheme %q cannot safely run managed CDC: CDC-aware merge is not supported", dest.GetScheme())
 	}
 	unchangedCols, ok := dest.(destination.CDCUnchangedColsAware)
 	if !ok || !unchangedCols.SupportsCDCUnchangedCols() {
-		return fmt.Errorf("destination scheme %q cannot safely run PostgreSQL CDC: preserving unchanged TOAST columns is not supported", dest.GetScheme())
+		return fmt.Errorf("destination scheme %q cannot safely run managed CDC: preserving unchanged TOAST columns is not supported", dest.GetScheme())
 	}
 	validator, ok := dest.(destination.ManagedCDCStateValidator)
 	if !ok {
@@ -2585,6 +2660,30 @@ func validateDestinationManagedCDCState(dest destination.Destination) error {
 	}
 	if err := validator.ValidateManagedCDCState(); err != nil {
 		return fmt.Errorf("destination scheme %q cannot safely use managed CDC state: %w", dest.GetScheme(), err)
+	}
+	return nil
+}
+
+func validateMySQLCDCMutationFencing(dest destination.Destination) error {
+	mergeFencer, ok := dest.(destination.CDCConditionalMergeCapable)
+	if !ok || !mergeFencer.SupportsCDCConditionalMerge() {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic target-incarnation fencing for merge is not supported", dest.GetScheme())
+	}
+	if _, ok := dest.(destination.CDCConditionalTruncater); !ok {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic target-incarnation fencing for source TRUNCATE is not supported", dest.GetScheme())
+	}
+	if _, ok := dest.(destination.ManagedCDCRunLeaser); !ok {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: connector run leases are not supported", dest.GetScheme())
+	}
+	if _, ok := dest.(destination.CDCLateTargetClaimPreparer); !ok {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic target claim and creation are not supported", dest.GetScheme())
+	}
+	swapFencer, ok := dest.(destination.CDCConditionalSwapCapable)
+	if !ok || !swapFencer.SupportsCDCConditionalSwap() {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic target-incarnation fencing for full-refresh swaps is not supported", dest.GetScheme())
+	}
+	if _, ok := dest.(destination.CDCConditionalSwapPlanner); !ok {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: full-refresh swap incarnation planning is not supported", dest.GetScheme())
 	}
 	return nil
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -323,6 +323,30 @@ func TestPostgresCDCManagedStrategyDefaultsRemainValid(t *testing.T) {
 	}
 }
 
+func TestMySQLCDCRejectsNonMergeIncrementalStrategies(t *testing.T) {
+	for _, strategy := range []config.IncrementalStrategy{
+		config.StrategyAppend,
+		config.StrategyDeleteInsert,
+		config.StrategySCD2,
+		config.StrategyTruncateInsert,
+	} {
+		t.Run(string(strategy), func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.SourceURI = "mysql+cdc://source/app"
+			cfg.IncrementalStrategy = strategy
+			err := validateManagedChangeConfig(cfg)
+			require.ErrorContains(t, err, "not supported for MySQL CDC")
+		})
+	}
+
+	for _, strategy := range []config.IncrementalStrategy{"", config.StrategyMerge, config.StrategyReplace} {
+		cfg := config.DefaultConfig()
+		cfg.SourceURI = "mysql+cdc://source/app"
+		cfg.IncrementalStrategy = strategy
+		require.NoError(t, validateManagedChangeConfig(cfg))
+	}
+}
+
 func TestPostgresCDCFailsClosedBeforeConnectorPreparationForUnsafeDestination(t *testing.T) {
 	oldSource, err := internalregistry.Default.GetSourceConstructor("postgres+cdc")
 	require.NoError(t, err)
@@ -340,7 +364,7 @@ func TestPostgresCDCFailsClosedBeforeConnectorPreparationForUnsafeDestination(t 
 	cfg.DestTable = "raw.items"
 
 	err = New(cfg).Run(context.Background())
-	require.ErrorContains(t, err, "cannot safely run PostgreSQL CDC")
+	require.ErrorContains(t, err, "cannot safely run managed CDC")
 	require.ErrorContains(t, err, "destination-managed state")
 	require.True(t, src.connected)
 	require.True(t, src.closed)
@@ -846,6 +870,34 @@ type mockValidatedManagedCDCStateDestination struct {
 	validationErr error
 }
 
+type mockMySQLCDCFencedDestination struct {
+	mockManagedCDCStateDestination
+}
+
+func (m *mockMySQLCDCFencedDestination) SupportsCDCConditionalMerge() bool {
+	return true
+}
+
+func (m *mockMySQLCDCFencedDestination) TruncateCDCTableIfIncarnation(context.Context, string, string) error {
+	return nil
+}
+
+func (m *mockMySQLCDCFencedDestination) AcquireManagedCDCRunLease(context.Context, string) (source.ConnectorLease, error) {
+	return &mockConnectorLease{done: make(chan struct{})}, nil
+}
+
+func (m *mockMySQLCDCFencedDestination) ClaimAndPrepareEmptyCDCTarget(context.Context, string, destination.CDCTargetClaim, destination.PrepareOptions) (string, error) {
+	return "incarnation", nil
+}
+
+func (m *mockMySQLCDCFencedDestination) SupportsCDCConditionalSwap() bool {
+	return true
+}
+
+func (m *mockMySQLCDCFencedDestination) CDCConditionalSwapIncarnations(context.Context, string, string) (string, string, error) {
+	return "staging-incarnation", "result-incarnation", nil
+}
+
 func (m *mockValidatedManagedCDCStateDestination) ValidateManagedCDCState() error {
 	return m.validationErr
 }
@@ -1030,7 +1082,7 @@ func TestValidateDestinationManagedCDCState(t *testing.T) {
 		t.Fatalf("destination without managed state validation error = %v", err)
 	}
 	legacyOnly := &mockCDCResumeDestination{mockDestination: mockDestination{scheme: "legacy-only"}}
-	if err := validateDestinationManagedCDCState(legacyOnly); err == nil || !strings.Contains(err.Error(), "cannot safely run PostgreSQL CDC") {
+	if err := validateDestinationManagedCDCState(legacyOnly); err == nil || !strings.Contains(err.Error(), "cannot safely run managed CDC") {
 		t.Fatalf("legacy resume-only destination validation error = %v", err)
 	}
 	unclaimable := &mockUnclaimableCDCStateDestination{}
@@ -1053,6 +1105,12 @@ func TestValidateDestinationManagedCDCState(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "consistency ONE is unsafe") {
 		t.Fatalf("validation error = %v, want consistency rejection", err)
 	}
+}
+
+func TestValidateMySQLCDCMutationFencing(t *testing.T) {
+	unsupported := &mockManagedCDCStateDestination{}
+	require.ErrorContains(t, validateMySQLCDCMutationFencing(unsupported), "atomic target-incarnation fencing for merge")
+	require.NoError(t, validateMySQLCDCMutationFencing(&mockMySQLCDCFencedDestination{}))
 }
 
 func TestValidateChangeTrackingDestinationRequiresResumeProvider(t *testing.T) {
@@ -2451,6 +2509,19 @@ func TestMultiTableCDCConnectorIDIncludesNormalizedDestinationNamespace(t *testi
 		cdcSlotSuffix(canonicalCDCStateURI(base.DestURI)+"\x00"+idA),
 		cdcSlotSuffix(canonicalCDCStateURI(other.DestURI)+"\x00"+idB),
 		"different dest_schema mappings must not share automatic PostgreSQL slots")
+}
+
+func TestMySQLCDCConnectorIDIgnoresOperationalXALimits(t *testing.T) {
+	base := &config.IngestConfig{
+		SourceURI:   "mysql+cdc://reader@source/app?server_id=11&xa_buffer_limit=100&xa_buffer_bytes_limit=10000&xa_pending_limit=2",
+		SourceTable: "orders",
+		DestURI:     "mysql://loader@warehouse/analytics",
+		DestTable:   "orders",
+	}
+	changed := *base
+	changed.SourceURI = "mysql+cdc://reader@source/app?server_id=22&xa_buffer_limit=1000&xa_buffer_bytes_limit=20000&xa_pending_limit=20"
+
+	require.Equal(t, genericCDCConnectorID(base), genericCDCConnectorID(&changed))
 }
 
 func TestDroppedColumnsPKFiltering(t *testing.T) {

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -6,13 +6,17 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -27,11 +31,25 @@ import (
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/shopspring/decimal"
+	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 const (
 	defaultMySQLCDCHeartbeat       = 1 * time.Second
 	defaultMySQLCDCStreamBatchSize = 10000
+	defaultMySQLCDCXABufferLimit   = 1000000
+	defaultMySQLCDCXABufferBytes   = 256 * 1024 * 1024
+	defaultMySQLCDCPendingXALimit  = 10000
+	// MySQL DECIMAL is limited to 65 digits. This bound covers the boxed
+	// decimal, big.Int header, limb capacity, and allocator rounding without
+	// allocating a coefficient copy during accounting.
+	maxMySQLCDCDecodedDecimalSize = 256
+	// These bounds cover the pending-XA map entry/buckets and per-table map
+	// entry/buckets, including temporary map growth. Row batches themselves are
+	// retained as immutable chunks whose actual capacities are charged exactly.
+	mysqlCDCXATransactionOverhead = 1024
+	mysqlCDCXATableOverhead       = 512
 	// mysqlCDCStreamStallTimeout bounds how long the catch-up loop waits without
 	// receiving any event. Heartbeats arrive every defaultMySQLCDCHeartbeat on a
 	// healthy connection, so a stall this long means the connection is broken
@@ -46,9 +64,12 @@ var mysqlCDCColumns = []schema.Column{
 }
 
 type MySQLCDCConfig struct {
-	DestSchema string
-	ServerID   uint32
-	Flavor     string
+	DestSchema     string
+	ServerID       uint32
+	Flavor         string
+	XABufferLimit  uint64
+	XABufferBytes  uint64
+	PendingXALimit uint64
 }
 
 type mysqlCDCConnInfo struct {
@@ -63,11 +84,15 @@ type mysqlCDCConnInfo struct {
 }
 
 type MySQLCDCSource struct {
-	db        *sql.DB
-	uri       string
-	database  string
-	cdcConfig MySQLCDCConfig
-	connInfo  mysqlCDCConnInfo
+	db                *sql.DB
+	uri               string
+	database          string
+	cdcConfig         MySQLCDCConfig
+	connInfo          mysqlCDCConnInfo
+	stateMu           sync.Mutex
+	state             source.CDCStateCommitToken
+	schemaMu          sync.Mutex
+	discoveredSchemas map[string]*schema.TableSchema
 }
 
 type mysqlCDCTableMetadata struct {
@@ -86,6 +111,8 @@ type MySQLCDCTable struct {
 	strategy    config.IncrementalStrategy
 }
 
+var _ source.CDCStateProvider = (*MySQLCDCSource)(nil)
+
 type mysqlCDCChange struct {
 	values  []interface{}
 	lsn     string
@@ -96,6 +123,115 @@ type mysqlCDCChangeBuffer struct {
 	tableSchema *schema.TableSchema
 	tableName   string
 	changes     []mysqlCDCChange
+}
+
+type mysqlCDCXAChanges struct {
+	byTable map[string]*mysqlCDCXATableChanges
+	start   gomysql.Position
+	count   uint64
+	bytes   uint64
+}
+
+type mysqlCDCXATableChanges struct {
+	head *mysqlCDCXAChangeChunk
+	tail *mysqlCDCXAChangeChunk
+}
+
+type mysqlCDCXAChangeChunk struct {
+	changes []mysqlCDCChange
+	next    *mysqlCDCXAChangeChunk
+}
+
+type mysqlCDCXAAction int
+
+const (
+	mysqlCDCXAActionNone mysqlCDCXAAction = iota
+	mysqlCDCXAActionStart
+	mysqlCDCXAActionEnd
+	mysqlCDCXAActionCommit
+	mysqlCDCXAActionRollback
+)
+
+func mysqlCDCChangesSize(changes []mysqlCDCChange) uint64 {
+	total := saturatingMySQLCDCSizeMul(uint64(len(changes)), 64)
+	for _, change := range changes {
+		total = saturatingMySQLCDCSizeAdd(total, uint64(len(change.lsn)))
+		total = saturatingMySQLCDCSizeAdd(total, saturatingMySQLCDCSizeMul(uint64(len(change.values)), 16))
+		for _, value := range change.values {
+			total = saturatingMySQLCDCSizeAdd(total, mysqlCDCValueSize(value))
+		}
+	}
+	return total
+}
+
+func mysqlCDCXATransactionSize(xaID string) uint64 {
+	return saturatingMySQLCDCSizeAdd(mysqlCDCXATransactionOverhead, uint64(len(xaID)))
+}
+
+func mysqlCDCXATableSize(table string) uint64 {
+	return saturatingMySQLCDCSizeAdd(mysqlCDCXATableOverhead, uint64(len(table)))
+}
+
+func mysqlCDCXAChunkSize(changes []mysqlCDCChange) uint64 {
+	backingBytes := saturatingMySQLCDCSizeMul(
+		uint64(cap(changes)),
+		uint64(reflect.TypeOf(mysqlCDCChange{}).Size()),
+	)
+	return saturatingMySQLCDCSizeAdd(uint64(reflect.TypeOf(mysqlCDCXAChangeChunk{}).Size()), backingBytes)
+}
+
+func mysqlCDCValueSize(value interface{}) uint64 {
+	if value == nil {
+		return 0
+	}
+	switch value := value.(type) {
+	case string:
+		return saturatingMySQLCDCSizeAdd(uint64(reflect.TypeOf(value).Size()), uint64(len(value)))
+	case []byte:
+		return saturatingMySQLCDCSizeAdd(uint64(reflect.TypeOf(value).Size()), uint64(len(value)))
+	case decimal.Decimal:
+		return mysqlCDCDecimalSize(value)
+	case *decimal.Decimal:
+		if value == nil {
+			return 0
+		}
+		return mysqlCDCDecimalSize(*value)
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.String:
+		return saturatingMySQLCDCSizeAdd(uint64(rv.Type().Size()), uint64(rv.Len()))
+	case reflect.Array:
+		return uint64(rv.Type().Size())
+	case reflect.Slice:
+		length := uint64(rv.Len())
+		elementSize := uint64(rv.Type().Elem().Size())
+		return saturatingMySQLCDCSizeAdd(uint64(rv.Type().Size()), saturatingMySQLCDCSizeMul(length, elementSize))
+	default:
+		return uint64(rv.Type().Size())
+	}
+}
+
+func mysqlCDCDecimalSize(decimal.Decimal) uint64 {
+	return maxMySQLCDCDecodedDecimalSize
+}
+
+func saturatingMySQLCDCSizeAdd(left, right uint64) uint64 {
+	if left > ^uint64(0)-right {
+		return ^uint64(0)
+	}
+	return left + right
+}
+
+func saturatingMySQLCDCSizeMul(left, right uint64) uint64 {
+	if left != 0 && right > ^uint64(0)/left {
+		return ^uint64(0)
+	}
+	return left * right
+}
+
+type mysqlCDCBinlogStreamer interface {
+	GetEvent(context.Context) (*replication.BinlogEvent, error)
 }
 
 func NewMySQLCDCSource() *MySQLCDCSource {
@@ -159,6 +295,48 @@ func (s *MySQLCDCSource) Close(ctx context.Context) error {
 	return nil
 }
 
+func (s *MySQLCDCSource) resetCDCState() {
+	s.stateMu.Lock()
+	s.state = source.CDCStateCommitToken{
+		SnapshotPositions: make(map[string]string),
+	}
+	s.stateMu.Unlock()
+}
+
+func (s *MySQLCDCSource) recordMySQLCDCSnapshot(table string, position gomysql.Position) {
+	if table == "" || position.Name == "" {
+		return
+	}
+	s.stateMu.Lock()
+	if s.state.SnapshotPositions == nil {
+		s.state.SnapshotPositions = make(map[string]string)
+	}
+	s.state.SnapshotPositions[table] = formatStoredMySQLPosition(position, 0)
+	s.stateMu.Unlock()
+}
+
+func (s *MySQLCDCSource) recordMySQLCDCCheckpoint(position gomysql.Position) {
+	if position.Name == "" {
+		return
+	}
+	s.stateMu.Lock()
+	s.state.Position = formatStoredMySQLPosition(position, 0)
+	s.stateMu.Unlock()
+}
+
+func (s *MySQLCDCSource) CDCState() source.CDCStateCommitToken {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	snapshots := make(map[string]string, len(s.state.SnapshotPositions))
+	for table, position := range s.state.SnapshotPositions {
+		snapshots[table] = position
+	}
+	return source.CDCStateCommitToken{
+		Position:          s.state.Position,
+		SnapshotPositions: snapshots,
+	}
+}
+
 func (s *MySQLCDCSource) HandlesIncrementality() bool {
 	return true
 }
@@ -186,9 +364,8 @@ func (s *MySQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) 
 	}
 	tableSchema.PrimaryKeys = pks
 
-	strategy := config.StrategyMerge
-	if req.Strategy != "" && req.Strategy != config.StrategyReplace {
-		strategy = req.Strategy
+	if req.Strategy != "" && req.Strategy != config.StrategyMerge && req.Strategy != config.StrategyReplace {
+		return nil, fmt.Errorf("MySQL CDC only supports the merge strategy (replace is accepted as a request for the initial snapshot)")
 	}
 
 	return &MySQLCDCTable{
@@ -197,7 +374,7 @@ func (s *MySQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) 
 		metadata:    newMySQLCDCMetadata(req.Name, fullSchema, s.database),
 		tableSchema: tableSchema,
 		primaryKeys: pks,
-		strategy:    strategy,
+		strategy:    config.StrategyMerge,
 	}, nil
 }
 
@@ -210,11 +387,36 @@ func (s *MySQLCDCSource) IsMultiTable() bool {
 }
 
 func (s *MySQLCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
-	return s.getTables(ctx, true)
+	tables, err := s.getTables(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	s.schemaMu.Lock()
+	s.discoveredSchemas = make(map[string]*schema.TableSchema, len(tables))
+	for _, table := range tables {
+		s.discoveredSchemas[table.Name] = cloneMySQLCDCTableSchema(table.Schema)
+	}
+	s.schemaMu.Unlock()
+	return tables, nil
 }
 
 func (s *MySQLCDCSource) getTables(ctx context.Context, validateSupported bool) ([]source.SourceTableInfo, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	tableNames, err := s.getMySQLCDCTableNames(ctx, s.db)
+	if err != nil {
+		return nil, err
+	}
+	tables, err := s.loadMySQLCDCTables(ctx, tableNames, validateSupported)
+	if err != nil {
+		return nil, err
+	}
+	if len(tables) == 0 {
+		return nil, fmt.Errorf("no MySQL tables found in database %s", s.database)
+	}
+	return tables, nil
+}
+
+func (s *MySQLCDCSource) getMySQLCDCTableNames(ctx context.Context, q mysqlCDCPositionQueryer) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `
 		SELECT TABLE_NAME
 		FROM INFORMATION_SCHEMA.TABLES
 		WHERE TABLE_SCHEMA = ?
@@ -226,13 +428,23 @@ func (s *MySQLCDCSource) getTables(ctx context.Context, validateSupported bool) 
 	}
 	defer func() { _ = rows.Close() }()
 
-	var tables []source.SourceTableInfo
+	var tableNames []string
 	for rows.Next() {
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan MySQL table: %w", err)
 		}
+		tableNames = append(tableNames, tableName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tableNames, nil
+}
 
+func (s *MySQLCDCSource) loadMySQLCDCTables(ctx context.Context, tableNames []string, validateSupported bool) ([]source.SourceTableInfo, error) {
+	tables := make([]source.SourceTableInfo, 0, len(tableNames))
+	for _, tableName := range tableNames {
 		fullSchema, err := s.getSchema(ctx, tableName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get schema for %s: %w", tableName, err)
@@ -254,19 +466,16 @@ func (s *MySQLCDCSource) getTables(ctx context.Context, validateSupported bool) 
 			DestSchema:  s.cdcConfig.DestSchema,
 		})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	if len(tables) == 0 {
-		return nil, fmt.Errorf("no MySQL tables found in database %s", s.database)
-	}
 	return tables, nil
 }
 
 func (s *MySQLCDCSource) getSelectedTables(ctx context.Context, opts source.MultiTableReadOptions) ([]source.SourceTableInfo, error) {
-	allTables, err := s.getTables(ctx, false)
+	tableNames, err := s.getMySQLCDCTableNames(ctx, s.db)
 	if err != nil {
 		return nil, err
+	}
+	if len(tableNames) == 0 && len(opts.Tables) == 0 {
+		return nil, fmt.Errorf("no MySQL tables found in database %s", s.database)
 	}
 
 	filter := map[string]bool{}
@@ -274,15 +483,21 @@ func (s *MySQLCDCSource) getSelectedTables(ctx context.Context, opts source.Mult
 		filter[strings.ToLower(table)] = true
 	}
 
-	selected := make([]source.SourceTableInfo, 0, len(allTables))
-	for _, table := range allTables {
-		if len(filter) > 0 && !filter[strings.ToLower(table.Name)] {
+	selectedNames := make([]string, 0, len(tableNames))
+	for _, tableName := range tableNames {
+		if len(filter) > 0 && !filter[strings.ToLower(tableName)] {
 			continue
 		}
+		selectedNames = append(selectedNames, tableName)
+	}
+	selected, err := s.loadMySQLCDCTables(ctx, selectedNames, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, table := range selected {
 		if err := validateMySQLCDCTableSupported(ctx, s.db, s.database, table.Name); err != nil {
 			return nil, err
 		}
-		selected = append(selected, table)
 	}
 	return selected, nil
 }
@@ -292,10 +507,14 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 	if err != nil {
 		return nil, err
 	}
+	if err := s.validateMySQLCDCDiscoveredSchemas(selected, opts.Tables); err != nil {
+		return nil, err
+	}
 
 	results := make(chan source.RecordBatchResult, 16)
 	go func() {
 		defer close(results)
+		s.resetCDCState()
 
 		startByTable := make(map[string]gomysql.Position, len(selected))
 		metaByTable := make(map[string]mysqlCDCTableMetadata, len(selected))
@@ -325,12 +544,16 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 				return
 			}
 
-			snapshotPos, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name)
+			inventoryValidator := func(validationCtx context.Context, q mysqlCDCPositionQueryer) error {
+				return s.validateMySQLCDCInventory(validationCtx, q, opts.Tables)
+			}
+			snapshotPos, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name, inventoryValidator)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed for %s: %w", table.Name, err)}
 				return
 			}
 			startByTable[table.Name] = snapshotPos
+			s.recordMySQLCDCSnapshot(table.Name, snapshotPos)
 		}
 
 		if err := s.streamTables(ctx, selected, metaByTable, startByTable, opts.ReadOptions, results, true); err != nil {
@@ -341,10 +564,102 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 	return results, nil
 }
 
+func cloneMySQLCDCTableSchema(tableSchema *schema.TableSchema) *schema.TableSchema {
+	if tableSchema == nil {
+		return nil
+	}
+	cloned := *tableSchema
+	cloned.Columns = append([]schema.Column(nil), tableSchema.Columns...)
+	cloned.PrimaryKeys = append([]string(nil), tableSchema.PrimaryKeys...)
+	return &cloned
+}
+
+func (s *MySQLCDCSource) validateMySQLCDCDiscoveredSchemas(selected []source.SourceTableInfo, requested []string) error {
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.discoveredSchemas == nil {
+		s.discoveredSchemas = make(map[string]*schema.TableSchema, len(selected))
+		for _, table := range selected {
+			s.discoveredSchemas[table.Name] = cloneMySQLCDCTableSchema(table.Schema)
+		}
+	}
+	current := make(map[string]*schema.TableSchema, len(selected))
+	currentFolded := make(map[string]struct{}, len(selected))
+	for _, table := range selected {
+		current[table.Name] = table.Schema
+		currentFolded[strings.ToLower(table.Name)] = struct{}{}
+		expected, exists := s.discoveredSchemas[table.Name]
+		if !exists {
+			return fmt.Errorf("MySQL table %s appeared after CDC table discovery and before snapshots began; retry so it can be prepared safely", table.Name)
+		}
+		if !reflect.DeepEqual(expected, table.Schema) {
+			return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before its snapshot; run with --full-refresh to restart with the current schema", table.Name)
+		}
+	}
+	if len(requested) == 0 {
+		for table := range s.discoveredSchemas {
+			if _, exists := current[table]; !exists {
+				return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before its snapshot; run with --full-refresh to restart with the current schema", table)
+			}
+		}
+		return nil
+	}
+	for _, table := range requested {
+		if _, exists := currentFolded[strings.ToLower(table)]; !exists {
+			return fmt.Errorf("selected MySQL table %s is no longer available after CDC table discovery; run with --full-refresh to restart with the current schema", table)
+		}
+	}
+	return nil
+}
+
+func (s *MySQLCDCSource) validateMySQLCDCInventory(ctx context.Context, q mysqlCDCPositionQueryer, requested []string) error {
+	tableNames, err := s.getMySQLCDCTableNames(ctx, q)
+	if err != nil {
+		return err
+	}
+	current := make(map[string]struct{}, len(tableNames))
+	for _, table := range tableNames {
+		current[strings.ToLower(table)] = struct{}{}
+	}
+
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	expected := make(map[string]string, len(s.discoveredSchemas))
+	for table := range s.discoveredSchemas {
+		expected[strings.ToLower(table)] = table
+	}
+	if len(requested) == 0 {
+		for table, original := range expected {
+			if _, exists := current[table]; !exists {
+				return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before snapshots began; run with --full-refresh to restart with the current schema", original)
+			}
+		}
+		for table := range current {
+			if _, exists := expected[table]; !exists {
+				return fmt.Errorf("MySQL table %s appeared after CDC table discovery and before snapshots began; retry so it can be prepared safely", table)
+			}
+		}
+		return nil
+	}
+	for _, table := range requested {
+		folded := strings.ToLower(table)
+		if _, discovered := expected[folded]; !discovered {
+			return fmt.Errorf("selected MySQL table %s appeared after CDC table discovery; retry so it can be prepared safely", table)
+		}
+		if _, exists := current[folded]; !exists {
+			return fmt.Errorf("selected MySQL table %s is no longer available after CDC table discovery; run with --full-refresh to restart with the current schema", table)
+		}
+	}
+	return nil
+}
+
 func parseMySQLCDCURI(rawURI string) (MySQLCDCConfig, string, mysqlCDCConnInfo, error) {
 	cfg := MySQLCDCConfig{
-		ServerID: randomMySQLServerID(),
-		Flavor:   gomysql.MySQLFlavor,
+		ServerID:       randomMySQLServerID(),
+		Flavor:         gomysql.MySQLFlavor,
+		XABufferLimit:  defaultMySQLCDCXABufferLimit,
+		XABufferBytes:  defaultMySQLCDCXABufferBytes,
+		PendingXALimit: defaultMySQLCDCPendingXALimit,
 	}
 
 	parsed, err := mysqluri.ParseURL(rawURI)
@@ -381,11 +696,35 @@ func parseMySQLCDCURI(rawURI string) (MySQLCDCConfig, string, mysqlCDCConnInfo, 
 		}
 		cfg.ServerID = uint32(serverID)
 	}
+	if rawLimit := strings.TrimSpace(query.Get("xa_buffer_limit")); rawLimit != "" {
+		limit, err := strconv.ParseUint(rawLimit, 10, 64)
+		if err != nil || limit == 0 {
+			return cfg, "", mysqlCDCConnInfo{}, fmt.Errorf("xa_buffer_limit must be a positive integer")
+		}
+		cfg.XABufferLimit = limit
+	}
+	if rawLimit := strings.TrimSpace(query.Get("xa_buffer_bytes_limit")); rawLimit != "" {
+		limit, err := strconv.ParseUint(rawLimit, 10, 64)
+		if err != nil || limit == 0 {
+			return cfg, "", mysqlCDCConnInfo{}, fmt.Errorf("xa_buffer_bytes_limit must be a positive integer")
+		}
+		cfg.XABufferBytes = limit
+	}
+	if rawLimit := strings.TrimSpace(query.Get("xa_pending_limit")); rawLimit != "" {
+		limit, err := strconv.ParseUint(rawLimit, 10, 64)
+		if err != nil || limit == 0 {
+			return cfg, "", mysqlCDCConnInfo{}, fmt.Errorf("xa_pending_limit must be a positive integer")
+		}
+		cfg.PendingXALimit = limit
+	}
 
 	query.Del("dest_schema")
 	query.Del("flavor")
 	query.Del("mode")
 	query.Del("server_id")
+	query.Del("xa_buffer_limit")
+	query.Del("xa_buffer_bytes_limit")
+	query.Del("xa_pending_limit")
 
 	// Vitess-only parameters: irrelevant to (and rejected by) the MySQL DSN. The
 	// tls parameter is deliberately kept — it secures the MySQL-protocol probe and
@@ -576,6 +915,7 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 
 	go func() {
 		defer close(results)
+		t.source.resetCDCState()
 
 		storedLSN := strings.TrimSpace(opts.CDCResumeLSN)
 		if resume, ok := parseStoredMySQLPosition(storedLSN); ok {
@@ -605,11 +945,12 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 			return
 		}
 
-		snapshotPos, err := t.source.snapshotTable(ctx, t.metadata, outputSchema, opts, results, "")
+		snapshotPos, err := t.source.snapshotTable(ctx, t.metadata, outputSchema, opts, results, "", nil)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)}
 			return
 		}
+		t.source.recordMySQLCDCSnapshot(t.tableName, snapshotPos)
 
 		internalName := t.metadata.Name
 		startByTable := map[string]gomysql.Position{internalName: snapshotPos}
@@ -660,7 +1001,7 @@ func (s *MySQLCDCSource) canResume(ctx context.Context, pos gomysql.Position) (b
 	return false, nil
 }
 
-func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMetadata, outputSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) (gomysql.Position, error) {
+func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMetadata, outputSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string, validateInventory func(context.Context, mysqlCDCPositionQueryer) error) (gomysql.Position, error) {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return gomysql.Position{}, fmt.Errorf("failed to acquire MySQL connection: %w", err)
@@ -674,8 +1015,15 @@ func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMe
 		}
 	}()
 
-	snapshotPos, err := beginMySQLConsistentSnapshot(ctx, conn)
+	snapshotPos, err := beginMySQLConsistentSnapshotWithValidation(ctx, conn, validateInventory)
 	if err != nil {
+		return gomysql.Position{}, err
+	}
+	freshSchema, err := getMySQLSchema(ctx, conn, s.database, meta.Name)
+	if err != nil {
+		return gomysql.Position{}, fmt.Errorf("failed to validate snapshot schema for %s: %w", meta.Name, err)
+	}
+	if err := validateMySQLCDCSnapshotSchema(removeMySQLCDCColumns(meta.FullSchema), freshSchema, meta.Name); err != nil {
 		return gomysql.Position{}, err
 	}
 
@@ -684,6 +1032,9 @@ func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMe
 	rows, err := conn.QueryContext(ctx, query)
 	if err != nil {
 		return gomysql.Position{}, fmt.Errorf("failed to query snapshot for %s: %w", meta.Name, err)
+	}
+	if opts.CDCSnapshotReplace {
+		results <- source.RecordBatchResult{TableName: resultTable, Truncate: true}
 	}
 
 	if err := rowsToMySQLCDCSnapshotBatches(rows, outputSchema, opts, snapshotPos, results, resultTable); err != nil {
@@ -702,7 +1053,18 @@ func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMe
 	return snapshotPos, nil
 }
 
+func validateMySQLCDCSnapshotSchema(expected, current *schema.TableSchema, table string) error {
+	if reflect.DeepEqual(expected, current) {
+		return nil
+	}
+	return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before its snapshot; run with --full-refresh to restart with the current schema", table)
+}
+
 func beginMySQLConsistentSnapshot(ctx context.Context, conn mysqlCDCSnapshotConn) (gomysql.Position, error) {
+	return beginMySQLConsistentSnapshotWithValidation(ctx, conn, nil)
+}
+
+func beginMySQLConsistentSnapshotWithValidation(ctx context.Context, conn mysqlCDCSnapshotConn, validate func(context.Context, mysqlCDCPositionQueryer) error) (gomysql.Position, error) {
 	// The binlog stream decodes TIMESTAMP columns as UTC epoch instants. Pin the
 	// snapshot session to UTC so the driver (loc=UTC) reads the same instants;
 	// otherwise snapshot rows shift by the server's time zone offset.
@@ -732,6 +1094,14 @@ func beginMySQLConsistentSnapshot(ctx context.Context, conn mysqlCDCSnapshotConn
 	if err != nil {
 		return gomysql.Position{}, err
 	}
+	if err := ensureNoPreparedMySQLXA(ctx, conn); err != nil {
+		return gomysql.Position{}, err
+	}
+	if validate != nil {
+		if err := validate(ctx, conn); err != nil {
+			return gomysql.Position{}, err
+		}
+	}
 
 	if _, err := conn.ExecContext(ctx, "UNLOCK TABLES"); err != nil {
 		return gomysql.Position{}, fmt.Errorf("failed to unlock MySQL tables after snapshot: %w", err)
@@ -739,6 +1109,21 @@ func beginMySQLConsistentSnapshot(ctx context.Context, conn mysqlCDCSnapshotConn
 	locked = false
 
 	return snapshotPos, nil
+}
+
+func ensureNoPreparedMySQLXA(ctx context.Context, conn mysqlCDCPositionQueryer) error {
+	rows, err := conn.QueryContext(ctx, "XA RECOVER")
+	if err != nil {
+		return fmt.Errorf("failed to inspect prepared MySQL XA transactions before the CDC snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if rows.Next() {
+		return fmt.Errorf("cannot start a safe MySQL CDC snapshot while prepared XA transactions exist; commit or roll back the prepared transactions and retry")
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to inspect prepared MySQL XA transactions before the CDC snapshot: %w", err)
+	}
+	return nil
 }
 
 func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.SourceTableInfo, metas map[string]mysqlCDCTableMetadata, startByTable map[string]gomysql.Position, opts source.ReadOptions, results chan<- source.RecordBatchResult, tagResults bool) error {
@@ -755,6 +1140,7 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		return nil
 	}
 	if start.Compare(target) >= 0 {
+		s.recordMySQLCDCCheckpoint(target)
 		return nil
 	}
 
@@ -785,6 +1171,86 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 	current := start
 	batchSize := mysqlCDCStreamBatchSize(opts)
 	buffers := make(map[string]*mysqlCDCChangeBuffer, len(tables))
+	pendingXA := make(map[string]*mysqlCDCXAChanges)
+	activeXA := ""
+	pendingXAChanges := uint64(0)
+	pendingXABytes := uint64(0)
+	xaBufferLimit := s.cdcConfig.XABufferLimit
+	if xaBufferLimit == 0 {
+		xaBufferLimit = defaultMySQLCDCXABufferLimit
+	}
+	xaBufferBytes := s.cdcConfig.XABufferBytes
+	if xaBufferBytes == 0 {
+		xaBufferBytes = defaultMySQLCDCXABufferBytes
+	}
+	pendingXALimit := s.cdcConfig.PendingXALimit
+	if pendingXALimit == 0 {
+		pendingXALimit = defaultMySQLCDCPendingXALimit
+	}
+	safeCheckpoint := func(position gomysql.Position) gomysql.Position {
+		for _, pending := range pendingXA {
+			if pending.start.Name == "" {
+				continue
+			}
+			if position.Name == "" || pending.start.Compare(position) < 0 {
+				position = pending.start
+			}
+		}
+		return position
+	}
+	finish := func(position gomysql.Position) error {
+		if err := flushMySQLCDCChangeBuffers(buffers, results); err != nil {
+			return err
+		}
+		s.recordMySQLCDCCheckpoint(safeCheckpoint(position))
+		return nil
+	}
+	appendChanges := func(table string, changes []mysqlCDCChange) error {
+		if len(changes) == 0 {
+			return nil
+		}
+		meta := metas[table]
+		outputSchema := schemaByTable[table]
+		if outputSchema == nil {
+			return fmt.Errorf("missing output schema for MySQL CDC table %s", table)
+		}
+		resultTable := mysqlCDCResultTableName(meta.Name, len(tables), tagResults)
+		return appendMySQLCDCBufferedChanges(buffers, meta.Name, outputSchema, resultTable, changes, batchSize, results)
+	}
+	releaseXA := func(xaID string, commit bool) error {
+		pending := pendingXA[xaID]
+		if pending == nil {
+			// An outcome for an XA transaction prepared before the resume
+			// position: finish() rolls the checkpoint back before the START of
+			// any still-pending XA, and snapshots reject outstanding prepared
+			// XA (ensureNoPreparedMySQLXA), so a transaction unseen since the
+			// resume position was fully released — rows emitted and
+			// checkpointed — by the run that recorded it. Replaying its
+			// terminal event alone is benign.
+			return nil
+		}
+		if commit {
+			tableNames := make([]string, 0, len(pending.byTable))
+			for table := range pending.byTable {
+				tableNames = append(tableNames, table)
+			}
+			sort.Strings(tableNames)
+			for _, table := range tableNames {
+				for chunk := pending.byTable[table].head; chunk != nil; chunk = chunk.next {
+					if err := appendChanges(table, chunk.changes); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		pendingXAChanges -= pending.count
+		pendingXABytes -= pending.bytes
+		delete(pendingXA, xaID)
+		if activeXA == xaID {
+			activeXA = ""
+		}
+		return nil
+	}
 	lastDelivery := time.Now()
 	for {
 		select {
@@ -794,14 +1260,15 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		}
 
 		if current.Compare(target) >= 0 {
-			return flushMySQLCDCChangeBuffers(buffers, results)
+			return finish(current)
 		}
 
-		eventCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		event, err := streamer.GetEvent(eventCtx)
-		cancel()
+		event, err, eventCtxErr := readMySQLCDCEvent(ctx, streamer)
 		if err != nil {
-			if eventCtx.Err() != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if isMySQLCDCReadPollTimeout(ctx, err, eventCtxErr) {
 				if time.Since(lastDelivery) >= mysqlCDCStreamStallTimeout {
 					return fmt.Errorf("MySQL binlog stream stalled at %s while catching up to %s: no events or heartbeats received for %s; check connectivity to the server", current, target, mysqlCDCStreamStallTimeout)
 				}
@@ -825,48 +1292,698 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 				// The last emitted _cdc_lsn may then sit slightly before
 				// target, so the next run re-streams a short suffix of
 				// events; merge-by-LSN dedup makes that harmless.
-				return flushMySQLCDCChangeBuffers(buffers, results)
+				return finish(current)
 			}
 		}
 
+		previousPosition := current
 		eventPos := mysqlEventPosition(event, current)
 		current = eventPos
 		if eventPos.Compare(target) > 0 {
-			return flushMySQLCDCChangeBuffers(buffers, results)
+			return finish(previousPosition)
 		}
-
-		rowsEvent, ok := event.Event.(*replication.RowsEvent)
-		if !ok {
-			continue
-		}
-		tableKey := mysqlCDCEventTableName(string(rowsEvent.Table.Schema), string(rowsEvent.Table.Table), s.database)
-		meta, ok := metaByAlias[strings.ToLower(tableKey)]
-		if !ok {
-			continue
-		}
-
-		startForTable := startByTable[meta.Name]
-		if eventPos.Compare(startForTable) <= 0 {
-			continue
-		}
-
-		outputSchema := schemaByTable[meta.Name]
-		if outputSchema == nil {
-			continue
-		}
-		changes, err := mysqlRowsEventToChanges(rowsEvent.Type(), rowsEvent.Rows, meta.FullSchema, outputSchema, eventPos)
+		logicalEvents, err := mysqlBinlogEvents(event)
 		if err != nil {
-			return fmt.Errorf("failed to decode MySQL CDC rows for %s: %w", meta.Name, err)
-		}
-		if len(changes) == 0 {
-			continue
-		}
-
-		resultTable := mysqlCDCResultTableName(meta.Name, len(tables), tagResults)
-		if err := appendMySQLCDCBufferedChanges(buffers, meta.Name, outputSchema, resultTable, changes, batchSize, results); err != nil {
 			return err
 		}
+		rowSeq := 0
+		for _, logicalEvent := range logicalEvents {
+			if queryEvent, ok := logicalEvent.Event.(*replication.QueryEvent); ok {
+				xaAction, xaID, xaFlag, err := mysqlCDCXAQuery(string(queryEvent.Query))
+				if err != nil {
+					return err
+				}
+				switch xaAction {
+				case mysqlCDCXAActionStart:
+					if activeXA != "" {
+						return fmt.Errorf("MySQL CDC encountered XA START for %s while XA transaction %s is active", xaID, activeXA)
+					}
+					if _, exists := pendingXA[xaID]; exists {
+						if !xaFlag {
+							return fmt.Errorf("MySQL CDC encountered duplicate XA transaction %s", xaID)
+						}
+					} else {
+						if xaFlag {
+							return fmt.Errorf("MySQL CDC encountered XA continuation for unknown transaction %s", xaID)
+						}
+						if uint64(len(pendingXA)) >= pendingXALimit {
+							return fmt.Errorf("MySQL CDC pending XA transactions exceed xa_pending_limit=%d; resolve prepared XA transactions or increase xa_pending_limit and retry", pendingXALimit)
+						}
+						transactionBytes := mysqlCDCXATransactionSize(xaID)
+						if transactionBytes > xaBufferBytes || pendingXABytes > xaBufferBytes-transactionBytes {
+							return fmt.Errorf("MySQL CDC buffered XA payloads exceed xa_buffer_bytes_limit=%d; increase xa_buffer_bytes_limit and retry", xaBufferBytes)
+						}
+						pendingXA[xaID] = &mysqlCDCXAChanges{
+							byTable: make(map[string]*mysqlCDCXATableChanges),
+							start:   previousPosition,
+							bytes:   transactionBytes,
+						}
+						pendingXABytes += transactionBytes
+					}
+					activeXA = xaID
+				case mysqlCDCXAActionEnd:
+					if activeXA == "" || activeXA != xaID {
+						return fmt.Errorf("MySQL CDC encountered XA END for %s while XA transaction %s is active", xaID, activeXA)
+					}
+					activeXA = ""
+				case mysqlCDCXAActionCommit:
+					if err := releaseXA(xaID, true); err != nil {
+						return err
+					}
+				case mysqlCDCXAActionRollback:
+					if err := releaseXA(xaID, false); err != nil {
+						return err
+					}
+				}
+				if xaAction != mysqlCDCXAActionNone {
+					continue
+				}
+				truncated, err := mysqlCDCQueryTruncatesAfter(queryEvent, s.database, metaByAlias, eventPos, startByTable)
+				if err != nil {
+					return err
+				}
+				if len(truncated) > 0 {
+					if err := flushMySQLCDCChangeBuffers(buffers, results); err != nil {
+						return err
+					}
+					for _, meta := range truncated {
+						results <- source.RecordBatchResult{
+							TableName:      mysqlCDCResultTableName(meta.Name, len(tables), tagResults),
+							Truncate:       true,
+							CDCWALTruncate: true,
+						}
+					}
+				}
+				continue
+			}
+			if logicalEvent.Header != nil && logicalEvent.Header.EventType == replication.XA_PREPARE_LOG_EVENT {
+				xaID, onePhase, err := mysqlCDCXAPrepare(logicalEvent)
+				if err != nil {
+					return err
+				}
+				if activeXA != "" && activeXA != xaID {
+					return fmt.Errorf("MySQL CDC encountered XA PREPARE for %s while XA transaction %s is active", xaID, activeXA)
+				}
+				if pendingXA[xaID] == nil {
+					return fmt.Errorf("MySQL CDC encountered XA PREPARE for unknown transaction %s", xaID)
+				}
+				activeXA = ""
+				if onePhase {
+					if err := releaseXA(xaID, true); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			rowsEvent, ok := logicalEvent.Event.(*replication.RowsEvent)
+			if !ok {
+				continue
+			}
+			tableKey := mysqlCDCEventTableName(string(rowsEvent.Table.Schema), string(rowsEvent.Table.Table), s.database)
+			meta, ok := metaByAlias[strings.ToLower(tableKey)]
+			if !ok {
+				continue
+			}
+
+			startForTable := startByTable[meta.Name]
+			if eventPos.Compare(startForTable) <= 0 {
+				continue
+			}
+
+			outputSchema := schemaByTable[meta.Name]
+			if outputSchema == nil {
+				continue
+			}
+			if err := validateMySQLCDCFullRowImage(rowsEvent, len(sourceColumnsWithoutMySQLCDC(meta.FullSchema))); err != nil {
+				return fmt.Errorf("failed to decode MySQL CDC rows for %s: %w", meta.Name, err)
+			}
+			changes, nextRowSeq, err := mysqlRowsEventToChangesFromSequence(rowsEvent.Type(), rowsEvent.Rows, meta.FullSchema, outputSchema, eventPos, rowSeq)
+			if err != nil {
+				return fmt.Errorf("failed to decode MySQL CDC rows for %s: %w", meta.Name, err)
+			}
+			rowSeq = nextRowSeq
+			if len(changes) == 0 {
+				continue
+			}
+			if activeXA != "" {
+				pending := pendingXA[activeXA]
+				if pending == nil {
+					return fmt.Errorf("MySQL CDC lost pending state for XA transaction %s", activeXA)
+				}
+				changeCount := uint64(len(changes))
+				if changeCount > xaBufferLimit || pendingXAChanges > xaBufferLimit-changeCount {
+					return fmt.Errorf("MySQL CDC buffered XA changes exceed xa_buffer_limit=%d; increase xa_buffer_limit and retry", xaBufferLimit)
+				}
+				changeBytes := saturatingMySQLCDCSizeAdd(mysqlCDCChangesSize(changes), mysqlCDCXAChunkSize(changes))
+				tableChanges := pending.byTable[meta.Name]
+				if tableChanges == nil {
+					changeBytes = saturatingMySQLCDCSizeAdd(changeBytes, mysqlCDCXATableSize(meta.Name))
+				}
+				if changeBytes > xaBufferBytes || pendingXABytes > xaBufferBytes-changeBytes {
+					return fmt.Errorf("MySQL CDC buffered XA payloads exceed xa_buffer_bytes_limit=%d; increase xa_buffer_bytes_limit and retry", xaBufferBytes)
+				}
+				if tableChanges == nil {
+					tableChanges = &mysqlCDCXATableChanges{}
+					pending.byTable[meta.Name] = tableChanges
+				}
+				chunk := &mysqlCDCXAChangeChunk{changes: changes}
+				if tableChanges.tail == nil {
+					tableChanges.head = chunk
+				} else {
+					tableChanges.tail.next = chunk
+				}
+				tableChanges.tail = chunk
+				pending.count += changeCount
+				pending.bytes += changeBytes
+				pendingXAChanges += changeCount
+				pendingXABytes += changeBytes
+				continue
+			}
+			if err := appendChanges(meta.Name, changes); err != nil {
+				return err
+			}
+		}
 	}
+}
+
+func mysqlBinlogEvents(event *replication.BinlogEvent) ([]*replication.BinlogEvent, error) {
+	if event == nil {
+		return nil, nil
+	}
+	if event.Header != nil && event.Header.EventType == replication.PARTIAL_UPDATE_ROWS_EVENT {
+		return nil, fmt.Errorf("MySQL CDC does not support PARTIAL_UPDATE_ROWS_EVENT; disable binlog_row_value_options=PARTIAL_JSON")
+	}
+	payload, ok := event.Event.(*replication.TransactionPayloadEvent)
+	if !ok {
+		return []*replication.BinlogEvent{event}, nil
+	}
+	var events []*replication.BinlogEvent
+	for _, nested := range payload.Events {
+		nestedEvents, err := mysqlBinlogEvents(nested)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, nestedEvents...)
+	}
+	return events, nil
+}
+
+func validateMySQLCDCFullRowImage(rowsEvent *replication.RowsEvent, expectedColumns int) error {
+	if rowsEvent.ColumnCount != 0 && rowsEvent.ColumnCount != uint64(expectedColumns) {
+		return fmt.Errorf("binlog row image declares %d columns but the table schema has %d; the table structure changed since the sync started; run with --full-refresh to rebuild the destination safely", rowsEvent.ColumnCount, expectedColumns)
+	}
+	if len(rowsEvent.SkippedColumns) != 0 && len(rowsEvent.SkippedColumns) != len(rowsEvent.Rows) {
+		return fmt.Errorf("binlog row image metadata has %d images for %d rows", len(rowsEvent.SkippedColumns), len(rowsEvent.Rows))
+	}
+	for image, skipped := range rowsEvent.SkippedColumns {
+		if len(skipped) == 0 {
+			continue
+		}
+		return fmt.Errorf("binlog row image %d omits columns %v; producer sessions must use binlog_row_image=FULL", image, skipped)
+	}
+	return nil
+}
+
+func mysqlCDCQueryTruncates(queryEvent *replication.QueryEvent, defaultDatabase string, metaByAlias map[string]mysqlCDCTableMetadata) ([]mysqlCDCTableMetadata, error) {
+	return mysqlCDCQueryTruncatesAfter(queryEvent, defaultDatabase, metaByAlias, gomysql.Position{}, nil)
+}
+
+func mysqlCDCQueryTruncatesAfter(queryEvent *replication.QueryEvent, defaultDatabase string, metaByAlias map[string]mysqlCDCTableMetadata, eventPosition gomysql.Position, startByTable map[string]gomysql.Position) ([]mysqlCDCTableMetadata, error) {
+	query := normalizeMySQLCDCQuery(string(queryEvent.Query))
+	if !mysqlCDCIsDDL(query) {
+		return nil, nil
+	}
+	if mysqlCDCIsKnownNonTableDDL(query) {
+		return nil, nil
+	}
+	statement, err := sqlparser.NewTestParser().ParseStrictDDL(query)
+	if err != nil {
+		if !mysqlCDCUnparseableDDLMentionsCaptured(query, defaultDatabase, metaByAlias) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to parse MySQL DDL event %q: %w", query, err)
+	}
+	ddl, ok := statement.(sqlparser.DDLStatement)
+	if !ok {
+		if databaseDDL, databaseOK := statement.(sqlparser.DBDDLStatement); databaseOK {
+			if !strings.EqualFold(databaseDDL.GetDatabaseName(), defaultDatabase) {
+				return nil, nil
+			}
+			if _, dropsDatabase := statement.(*sqlparser.DropDatabase); dropsDatabase {
+				return nil, fmt.Errorf("MySQL CDC cannot safely apply DDL event %q for the captured database; run with --full-refresh to rebuild the destination", query)
+			}
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	eventDatabase := string(queryEvent.Schema)
+	if eventDatabase == "" {
+		eventDatabase = defaultDatabase
+	}
+	affected := make(map[string]mysqlCDCTableMetadata)
+	affectedTables := ddl.AffectedTables()
+	if alter, alterOK := statement.(*sqlparser.AlterTable); alterOK && alter.PartitionSpec != nil && alter.PartitionSpec.Action == sqlparser.ExchangeAction {
+		affectedTables = append(affectedTables, alter.PartitionSpec.TableName)
+	}
+	for _, table := range affectedTables {
+		database := table.Qualifier.String()
+		if database == "" {
+			database = eventDatabase
+		}
+		tableKey := mysqlCDCEventTableName(database, table.Name.String(), defaultDatabase)
+		if meta, exists := metaByAlias[strings.ToLower(tableKey)]; exists {
+			if start, bounded := startByTable[meta.Name]; bounded && eventPosition.Compare(start) <= 0 {
+				continue
+			}
+			affected[meta.Name] = meta
+		}
+	}
+	if len(affected) == 0 {
+		return nil, nil
+	}
+	if _, ok := statement.(*sqlparser.TruncateTable); !ok {
+		return nil, fmt.Errorf("MySQL CDC cannot safely apply DDL event %q for a captured table; run with --full-refresh to rebuild the destination", query)
+	}
+
+	tables := make([]string, 0, len(affected))
+	for table := range affected {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	truncated := make([]mysqlCDCTableMetadata, 0, len(tables))
+	for _, table := range tables {
+		truncated = append(truncated, affected[table])
+	}
+	return truncated, nil
+}
+
+// mysqlCDCUnparseableDDLMentionsCaptured reports whether a DDL statement the
+// parser rejected could refer to a captured table or database. The binlog
+// carries DDL from every database on the server, and table-affecting DDL must
+// name its object, so a statement that mentions no captured identifier cannot
+// touch a captured table and is safe to skip; anything that does mention one
+// fails closed at the caller.
+func mysqlCDCUnparseableDDLMentionsCaptured(query, defaultDatabase string, metaByAlias map[string]mysqlCDCTableMetadata) bool {
+	names := make(map[string]struct{}, 2*len(metaByAlias)+1)
+	if defaultDatabase != "" {
+		names[strings.ToLower(defaultDatabase)] = struct{}{}
+	}
+	for _, meta := range metaByAlias {
+		if meta.SourceSchema != "" {
+			names[strings.ToLower(meta.SourceSchema)] = struct{}{}
+		}
+		if meta.SourceName != "" {
+			names[strings.ToLower(meta.SourceName)] = struct{}{}
+		}
+	}
+	lowerQuery := strings.ToLower(query)
+	tokens := mysqlCDCIdentifierTokens(lowerQuery)
+	for name := range names {
+		if mysqlCDCIsIdentifierWord(name) {
+			if _, ok := tokens[name]; ok {
+				return true
+			}
+			continue
+		}
+		if strings.Contains(lowerQuery, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func mysqlCDCIdentifierTokens(lowerQuery string) map[string]struct{} {
+	tokens := make(map[string]struct{})
+	start := -1
+	for i := 0; i <= len(lowerQuery); i++ {
+		if i < len(lowerQuery) && mysqlCDCIsIdentifierByte(lowerQuery[i]) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			tokens[lowerQuery[start:i]] = struct{}{}
+			start = -1
+		}
+	}
+	return tokens
+}
+
+func mysqlCDCIsIdentifierByte(b byte) bool {
+	return b == '_' || b == '$' || b >= 0x80 ||
+		(b >= '0' && b <= '9') || (b >= 'a' && b <= 'z')
+}
+
+func mysqlCDCIsIdentifierWord(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !mysqlCDCIsIdentifierByte(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func mysqlCDCIsDDL(query string) bool {
+	fields := strings.Fields(normalizeMySQLCDCQuery(query))
+	if len(fields) == 0 {
+		return false
+	}
+	switch strings.ToUpper(fields[0]) {
+	case "ALTER", "CREATE", "DROP", "RENAME", "TRUNCATE":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeMySQLCDCQuery(query string) string {
+	return strings.TrimSpace(stripMySQLCDCComments(query))
+}
+
+func stripMySQLCDCComments(query string) string {
+	var result strings.Builder
+	result.Grow(len(query))
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'', '"', '`':
+			quote := query[i]
+			start := i
+			i++
+			for i < len(query) {
+				if query[i] == '\\' && quote != '`' && i+1 < len(query) {
+					i += 2
+					continue
+				}
+				if query[i] == quote {
+					if i+1 < len(query) && query[i+1] == quote {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+			result.WriteString(query[start:i])
+		case '/':
+			if i+1 >= len(query) || query[i+1] != '*' {
+				result.WriteByte(query[i])
+				i++
+				continue
+			}
+			end := strings.Index(query[i+2:], "*/")
+			if end < 0 {
+				result.WriteString(query[i:])
+				return result.String()
+			}
+			end += i + 2
+			executableBody := -1
+			if i+2 < len(query) && query[i+2] == '!' {
+				executableBody = i + 3
+			} else if i+3 < len(query) && (query[i+2] == 'M' || query[i+2] == 'm') && query[i+3] == '!' {
+				executableBody = i + 4
+			}
+			if executableBody >= 0 {
+				body := strings.TrimSpace(query[executableBody:end])
+				versionEnd := 0
+				for versionEnd < len(body) && body[versionEnd] >= '0' && body[versionEnd] <= '9' {
+					versionEnd++
+				}
+				if versionEnd >= 5 {
+					body = strings.TrimSpace(body[versionEnd:])
+				}
+				result.WriteByte(' ')
+				result.WriteString(stripMySQLCDCComments(body))
+				result.WriteByte(' ')
+			} else {
+				result.WriteByte(' ')
+			}
+			i = end + 2
+		case '#':
+			for i < len(query) && query[i] != '\n' {
+				i++
+			}
+			result.WriteByte(' ')
+		case '-':
+			if i+2 >= len(query) || query[i+1] != '-' || query[i+2] > ' ' {
+				result.WriteByte(query[i])
+				i++
+				continue
+			}
+			for i < len(query) && query[i] != '\n' {
+				i++
+			}
+			result.WriteByte(' ')
+		default:
+			result.WriteByte(query[i])
+			i++
+		}
+	}
+	return result.String()
+}
+
+func mysqlCDCIsKnownNonTableDDL(query string) bool {
+	fields := strings.Fields(strings.ToUpper(query))
+	if len(fields) < 2 {
+		return false
+	}
+	for i := 1; i < len(fields); i++ {
+		field := strings.Trim(fields[i], "(),;")
+		switch field {
+		case "TABLE", "DATABASE", "SCHEMA", "INDEX":
+			return false
+		case "EVENT", "FUNCTION", "INSTANCE", "PROCEDURE", "ROLE", "SERVER", "TABLESPACE", "TRIGGER", "USER", "VIEW":
+			return true
+		case "LOGFILE":
+			return i+1 < len(fields) && strings.Trim(fields[i+1], "(),;") == "GROUP"
+		case "RESOURCE":
+			return i+1 < len(fields) && strings.Trim(fields[i+1], "(),;") == "GROUP"
+		case "SPATIAL":
+			return i+2 < len(fields) && strings.Trim(fields[i+1], "(),;") == "REFERENCE" && strings.Trim(fields[i+2], "(),;") == "SYSTEM"
+		}
+	}
+	return false
+}
+
+func mysqlCDCXAQuery(query string) (mysqlCDCXAAction, string, bool, error) {
+	normalized := normalizeMySQLCDCQuery(query)
+	normalized = strings.TrimSuffix(normalized, ";")
+	tokenizer := sqlparser.NewTestParser().NewStringTokenizer(normalized)
+	_, first := mysqlCDCNextNonCommentToken(tokenizer)
+	if !strings.EqualFold(first, "XA") {
+		return mysqlCDCXAActionNone, "", false, nil
+	}
+	_, command := mysqlCDCNextNonCommentToken(tokenizer)
+	var action mysqlCDCXAAction
+	switch strings.ToUpper(command) {
+	case "START", "BEGIN":
+		action = mysqlCDCXAActionStart
+	case "END":
+		action = mysqlCDCXAActionEnd
+	case "COMMIT":
+		action = mysqlCDCXAActionCommit
+	case "ROLLBACK":
+		action = mysqlCDCXAActionRollback
+	default:
+		return mysqlCDCXAActionNone, "", false, nil
+	}
+	remainder := strings.TrimSpace(sqlparser.StripLeadingComments(normalized[tokenizer.Pos:]))
+	xaID, modifier, err := mysqlCDCCanonicalXID(remainder)
+	if err != nil {
+		return mysqlCDCXAActionNone, "", false, fmt.Errorf("failed to parse MySQL XA event %q: %w", normalized, err)
+	}
+	modifier = strings.Join(strings.Fields(strings.ToUpper(modifier)), " ")
+	onePhase := false
+	switch action {
+	case mysqlCDCXAActionStart:
+		if modifier != "" && modifier != "JOIN" && modifier != "RESUME" {
+			return mysqlCDCXAActionNone, "", false, fmt.Errorf("unsupported MySQL XA START modifier %q", modifier)
+		}
+		onePhase = modifier != ""
+	case mysqlCDCXAActionEnd:
+		if modifier != "" && modifier != "SUSPEND" && modifier != "SUSPEND FOR MIGRATE" {
+			return mysqlCDCXAActionNone, "", false, fmt.Errorf("unsupported MySQL XA END modifier %q", modifier)
+		}
+	case mysqlCDCXAActionCommit:
+		if modifier != "" && modifier != "ONE PHASE" {
+			return mysqlCDCXAActionNone, "", false, fmt.Errorf("unsupported MySQL XA COMMIT modifier %q", modifier)
+		}
+		onePhase = modifier == "ONE PHASE"
+	case mysqlCDCXAActionRollback:
+		if modifier != "" {
+			return mysqlCDCXAActionNone, "", false, fmt.Errorf("unsupported MySQL XA ROLLBACK modifier %q", modifier)
+		}
+	}
+	return action, xaID, onePhase, nil
+}
+
+func mysqlCDCNextNonCommentToken(tokenizer *sqlparser.Tokenizer) (int, string) {
+	for {
+		token, value := tokenizer.Scan()
+		if token != sqlparser.COMMENT {
+			return token, value
+		}
+	}
+}
+
+func mysqlCDCCanonicalXID(input string) (string, string, error) {
+	parts, modifier, err := splitMySQLXID(input)
+	if err != nil {
+		return "", "", err
+	}
+	if len(parts) == 0 || len(parts) > 3 {
+		return "", "", fmt.Errorf("an XID must contain one to three components")
+	}
+	gtrid, err := mysqlCDCXIDBytes(parts[0])
+	if err != nil {
+		return "", "", fmt.Errorf("invalid XID gtrid: %w", err)
+	}
+	var bqual []byte
+	if len(parts) >= 2 {
+		bqual, err = mysqlCDCXIDBytes(parts[1])
+		if err != nil {
+			return "", "", fmt.Errorf("invalid XID bqual: %w", err)
+		}
+	}
+	formatID := uint64(1)
+	if len(parts) == 3 {
+		formatID, err = strconv.ParseUint(strings.TrimSpace(parts[2]), 10, 32)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid XID format ID: %w", err)
+		}
+	}
+	if len(gtrid) == 0 || len(gtrid) > 64 || len(bqual) > 64 || len(gtrid)+len(bqual) > 128 {
+		return "", "", fmt.Errorf("XID component lengths are out of range")
+	}
+	return fmt.Sprintf("%d:%s:%s", formatID, hex.EncodeToString(gtrid), hex.EncodeToString(bqual)), modifier, nil
+}
+
+func splitMySQLXID(input string) ([]string, string, error) {
+	input = strings.TrimSpace(input)
+	var parts []string
+	start := 0
+	quote := byte(0)
+	for i := 0; i < len(input); i++ {
+		c := input[i]
+		if quote != 0 {
+			if c == '\\' && i+1 < len(input) {
+				i++
+				continue
+			}
+			if c == quote {
+				if i+1 < len(input) && input[i+1] == quote {
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+			continue
+		}
+		if c == ',' {
+			parts = append(parts, strings.TrimSpace(input[start:i]))
+			start = i + 1
+		}
+	}
+	if quote != 0 {
+		return nil, "", fmt.Errorf("unterminated quoted XID component")
+	}
+	parts = append(parts, strings.TrimSpace(input[start:]))
+	last := parts[len(parts)-1]
+	if split := mysqlXIDModifierOffset(last); split >= 0 {
+		parts[len(parts)-1] = strings.TrimSpace(last[:split])
+		return parts, strings.TrimSpace(last[split:]), nil
+	}
+	return parts, "", nil
+}
+
+func mysqlXIDModifierOffset(input string) int {
+	quote := byte(0)
+	for i := 0; i < len(input); i++ {
+		c := input[i]
+		if quote != 0 {
+			if c == '\\' && i+1 < len(input) {
+				i++
+				continue
+			}
+			if c == quote {
+				if i+1 < len(input) && input[i+1] == quote {
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+			continue
+		}
+		if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+func mysqlCDCXIDBytes(input string) ([]byte, error) {
+	expr, err := sqlparser.NewTestParser().ParseExpr(strings.TrimSpace(input))
+	if err != nil {
+		return nil, err
+	}
+	literal, ok := expr.(*sqlparser.Literal)
+	if !ok {
+		return nil, fmt.Errorf("XID component must be a string, hex, or bit literal")
+	}
+	switch literal.Type {
+	case sqlparser.StrVal, sqlparser.HexVal, sqlparser.HexNum, sqlparser.BitNum:
+	default:
+		return nil, fmt.Errorf("XID component must be a string, hex, or bit literal")
+	}
+	value, err := sqlparser.LiteralToValue(literal)
+	if err != nil {
+		return nil, err
+	}
+	return value.Raw(), nil
+}
+
+func mysqlCDCXAPrepare(event *replication.BinlogEvent) (string, bool, error) {
+	generic, ok := event.Event.(*replication.GenericEvent)
+	if !ok || len(generic.Data) < 13 {
+		return "", false, fmt.Errorf("MySQL CDC encountered a malformed XA PREPARE event")
+	}
+	data := generic.Data
+	formatID := binary.LittleEndian.Uint32(data[1:5])
+	gtridLength := int(binary.LittleEndian.Uint32(data[5:9]))
+	bqualLength := int(binary.LittleEndian.Uint32(data[9:13]))
+	if gtridLength <= 0 || gtridLength > 64 || bqualLength < 0 || bqualLength > 64 || gtridLength+bqualLength > 128 || len(data) != 13+gtridLength+bqualLength {
+		return "", false, fmt.Errorf("MySQL CDC encountered invalid XID lengths in an XA PREPARE event")
+	}
+	gtrid := data[13 : 13+gtridLength]
+	bqual := data[13+gtridLength:]
+	xaID := fmt.Sprintf("%d:%s:%s", formatID, hex.EncodeToString(gtrid), hex.EncodeToString(bqual))
+	return xaID, data[0] != 0, nil
+}
+
+func readMySQLCDCEvent(ctx context.Context, streamer mysqlCDCBinlogStreamer) (*replication.BinlogEvent, error, error) {
+	eventCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	event, err := streamer.GetEvent(eventCtx)
+	eventCtxErr := eventCtx.Err()
+	cancel()
+	return event, err, eventCtxErr
+}
+
+func isMySQLCDCReadPollTimeout(ctx context.Context, eventErr, eventCtxErr error) bool {
+	return ctx.Err() == nil && errors.Is(eventErr, context.DeadlineExceeded) && errors.Is(eventCtxErr, context.DeadlineExceeded)
 }
 
 func (s *MySQLCDCSource) newBinlogSyncer() *replication.BinlogSyncer {
@@ -894,23 +2011,27 @@ func (s *MySQLCDCSource) binlogSyncerConfig() replication.BinlogSyncerConfig {
 }
 
 func mysqlRowsEventToChanges(eventType replication.EnumRowsEventType, rows [][]interface{}, fullSchema *schema.TableSchema, outputSchema *schema.TableSchema, pos gomysql.Position) ([]mysqlCDCChange, error) {
+	changes, _, err := mysqlRowsEventToChangesFromSequence(eventType, rows, fullSchema, outputSchema, pos, 0)
+	return changes, err
+}
+
+func mysqlRowsEventToChangesFromSequence(eventType replication.EnumRowsEventType, rows [][]interface{}, fullSchema *schema.TableSchema, outputSchema *schema.TableSchema, pos gomysql.Position, rowSeq int) ([]mysqlCDCChange, int, error) {
 	fullSourceColumns := sourceColumnsWithoutMySQLCDC(fullSchema)
 	outputSourceColumns := sourceColumnsWithoutMySQLCDC(outputSchema)
 	indexes, err := sourceIndexes(fullSourceColumns, outputSourceColumns)
 	if err != nil {
-		return nil, err
+		return nil, rowSeq, err
 	}
 
 	pkIndexes := primaryKeyIndexes(fullSourceColumns, outputSchema.PrimaryKeys)
 	changes := make([]mysqlCDCChange, 0, len(rows))
-	rowSeq := 0
 
 	switch eventType {
 	case replication.EnumRowsEventTypeInsert:
 		for _, row := range rows {
 			values, err := projectMySQLCDCRow(row, fullSourceColumns, outputSourceColumns, indexes)
 			if err != nil {
-				return nil, err
+				return nil, rowSeq, err
 			}
 			changes = append(changes, mysqlCDCChange{values: values, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: false})
 			rowSeq++
@@ -919,14 +2040,14 @@ func mysqlRowsEventToChanges(eventType replication.EnumRowsEventType, rows [][]i
 		for _, row := range rows {
 			values, err := projectMySQLCDCRow(row, fullSourceColumns, outputSourceColumns, indexes)
 			if err != nil {
-				return nil, err
+				return nil, rowSeq, err
 			}
 			changes = append(changes, mysqlCDCChange{values: values, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: true})
 			rowSeq++
 		}
 	case replication.EnumRowsEventTypeUpdate:
 		if len(rows)%2 != 0 {
-			return nil, fmt.Errorf("update rows event has odd row count")
+			return nil, rowSeq, fmt.Errorf("update rows event has odd row count")
 		}
 		for i := 0; i < len(rows); i += 2 {
 			before := rows[i]
@@ -934,23 +2055,23 @@ func mysqlRowsEventToChanges(eventType replication.EnumRowsEventType, rows [][]i
 			if primaryKeyChanged(before, after, pkIndexes) {
 				beforeValues, err := projectMySQLCDCRow(before, fullSourceColumns, outputSourceColumns, indexes)
 				if err != nil {
-					return nil, err
+					return nil, rowSeq, err
 				}
 				changes = append(changes, mysqlCDCChange{values: beforeValues, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: true})
 				rowSeq++
 			}
 			afterValues, err := projectMySQLCDCRow(after, fullSourceColumns, outputSourceColumns, indexes)
 			if err != nil {
-				return nil, err
+				return nil, rowSeq, err
 			}
 			changes = append(changes, mysqlCDCChange{values: afterValues, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: false})
 			rowSeq++
 		}
 	default:
-		return nil, fmt.Errorf("unsupported MySQL rows event type: %s", eventType)
+		return nil, rowSeq, fmt.Errorf("unsupported MySQL rows event type: %s", eventType)
 	}
 
-	return changes, nil
+	return changes, rowSeq, nil
 }
 
 func projectMySQLCDCRow(row []interface{}, fullSourceColumns []schema.Column, outputSourceColumns []schema.Column, indexes []int) ([]interface{}, error) {
@@ -967,6 +2088,9 @@ func projectMySQLCDCRow(row []interface{}, fullSourceColumns []schema.Column, ou
 		if sourceIdx < 0 || sourceIdx >= len(row) {
 			values[i] = nil
 			continue
+		}
+		if _, partialJSON := row[sourceIdx].(*replication.JsonDiff); partialJSON {
+			return nil, fmt.Errorf("binlog row image contains a partial JSON value; producer sessions must leave binlog_row_value_options empty")
 		}
 		values[i] = convertMySQLCDCBinlogValue(row[sourceIdx], outputSourceColumns[i])
 	}
@@ -1005,6 +2129,8 @@ func convertMySQLCDCValue(value interface{}, col schema.Column) interface{} {
 		return nil
 	}
 	switch v := value.(type) {
+	case string:
+		return strings.Clone(v)
 	case []byte:
 		if col.DataType == schema.TypeBinary {
 			copied := make([]byte, len(v))

--- a/pkg/source/mysql/cdc_regression_stress_test.go
+++ b/pkg/source/mysql/cdc_regression_stress_test.go
@@ -1,0 +1,28 @@
+//go:build stress
+
+package mysql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/stretchr/testify/require"
+)
+
+type mysqlCDCFailingStreamer struct {
+	err error
+}
+
+func (s mysqlCDCFailingStreamer) GetEvent(context.Context) (*replication.BinlogEvent, error) {
+	return nil, s.err
+}
+
+func TestMySQLCDC_StressReaderErrorIsNotTimeout(t *testing.T) {
+	readerErr := errors.New("replication stream closed")
+	_, err, eventCtxErr := readMySQLCDCEvent(context.Background(), mysqlCDCFailingStreamer{err: readerErr})
+
+	require.ErrorIs(t, err, readerErr)
+	require.NoError(t, eventCtxErr, "an immediate binlog-reader failure must not be classified as a timeout")
+}

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -3,29 +3,38 @@ package mysql
 import (
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseMySQLCDCURI(t *testing.T) {
-	cfg, normalized, connInfo, err := parseMySQLCDCURI("mysql+cdc://user:pass@example:3307/app?charset=utf8mb4&mode=batch&dest_schema=raw&server_id=123&flavor=mysql")
+	cfg, normalized, connInfo, err := parseMySQLCDCURI("mysql+cdc://user:pass@example:3307/app?charset=utf8mb4&mode=batch&dest_schema=raw&server_id=123&flavor=mysql&xa_buffer_limit=456&xa_buffer_bytes_limit=789&xa_pending_limit=7")
 	require.NoError(t, err)
 
 	assert.Equal(t, "raw", cfg.DestSchema)
 	assert.Equal(t, uint32(123), cfg.ServerID)
 	assert.Equal(t, gomysql.MySQLFlavor, cfg.Flavor)
+	assert.Equal(t, uint64(456), cfg.XABufferLimit)
+	assert.Equal(t, uint64(7), cfg.PendingXALimit)
+	assert.Equal(t, uint64(789), cfg.XABufferBytes)
 	assert.Equal(t, "example", connInfo.Host)
 	assert.Equal(t, uint16(3307), connInfo.Port)
 	assert.Equal(t, "user", connInfo.User)
@@ -40,6 +49,9 @@ func TestParseMySQLCDCURI(t *testing.T) {
 	assert.Empty(t, u.Query().Get("dest_schema"))
 	assert.Empty(t, u.Query().Get("server_id"))
 	assert.Empty(t, u.Query().Get("flavor"))
+	assert.Empty(t, u.Query().Get("xa_buffer_limit"))
+	assert.Empty(t, u.Query().Get("xa_buffer_bytes_limit"))
+	assert.Empty(t, u.Query().Get("xa_pending_limit"))
 }
 
 func TestParseMySQLCDCURICarriesReplicationConnectionOptions(t *testing.T) {
@@ -150,7 +162,6 @@ func TestMySQLCDCReadAllValidatesOnlySelectedTables(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).
 			AddRow("bad").
 			AddRow("good"))
-	expectMySQLCDCTableSchema(mock, "app", "bad")
 	expectMySQLCDCTableSchema(mock, "app", "good")
 	mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
 		WithArgs("app", "good").
@@ -161,6 +172,303 @@ func TestMySQLCDCReadAllValidatesOnlySelectedTables(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, selected, 1)
 	assert.Equal(t, "good", selected[0].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCReadAllInitializesFilteredDiscoveryWithoutGetTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("bad").AddRow("good"))
+	expectMySQLCDCTableSchema(mock, "app", "good")
+	mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
+		WithArgs("app", "good").
+		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
+
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("bad").AddRow("good"))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectMySQLCDCTableSchema(mock, "app", "good")
+	mock.ExpectQuery("SELECT .* FROM .*good").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(int64(1), "one"))
+	mock.ExpectExec("COMMIT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{Tables: []string{"good"}})
+	require.NoError(t, err)
+	var batches int
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch != nil {
+			batches++
+			assert.Equal(t, "good", result.TableName)
+			result.Batch.Release()
+		}
+	}
+	require.Equal(t, 1, batches)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCReadAllInitializesUnfilteredDiscoveryWithoutGetTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("good"))
+	expectMySQLCDCTableSchema(mock, "app", "good")
+	mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
+		WithArgs("app", "good").
+		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
+
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("good"))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectMySQLCDCTableSchema(mock, "app", "good")
+	mock.ExpectQuery("SELECT .* FROM .*good").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(int64(1), "one"))
+	mock.ExpectExec("COMMIT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{})
+	require.NoError(t, err)
+	var batches int
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch != nil {
+			batches++
+			assert.Equal(t, "good", result.TableName)
+			result.Batch.Release()
+		}
+	}
+	require.Equal(t, 1, batches)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCReadAllRejectsMissingOrEmptyInventoryWithoutGetTables(t *testing.T) {
+	t.Run("missing selected table", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+			WithArgs("app").
+			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("other"))
+		src := &MySQLCDCSource{db: db, database: "app"}
+		_, err = src.ReadAll(t.Context(), source.MultiTableReadOptions{Tables: []string{"missing"}})
+		require.ErrorContains(t, err, "no longer available")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("empty unfiltered inventory", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+			WithArgs("app").
+			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}))
+		src := &MySQLCDCSource{db: db, database: "app"}
+		_, err = src.ReadAll(t.Context(), source.MultiTableReadOptions{})
+		require.ErrorContains(t, err, "no MySQL tables found")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestMySQLCDCReadAllValidatesInventoryAtEverySnapshotBoundary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("second"))
+	for _, table := range []string{"first", "second"} {
+		expectMySQLCDCTableSchema(mock, "app", table)
+	}
+	for _, table := range []string{"first", "second"} {
+		mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
+			WithArgs("app", table).
+			WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
+	}
+
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("second"))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectMySQLCDCTableSchema(mock, "app", "first")
+	mock.ExpectQuery("SELECT .* FROM .*first").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(int64(1), "one"))
+	mock.ExpectExec("COMMIT").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "400"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("late").AddRow("second"))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("ROLLBACK").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{})
+	require.NoError(t, err)
+	var readErr error
+	for result := range results {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			readErr = result.Err
+		}
+	}
+	require.ErrorContains(t, readErr, "appeared after")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCReadAllValidatesInventoryAfterResumedTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("second"))
+	for _, table := range []string{"first", "second"} {
+		expectMySQLCDCTableSchema(mock, "app", table)
+	}
+	for _, table := range []string{"first", "second"} {
+		mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
+			WithArgs("app", table).
+			WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
+	}
+	mock.ExpectQuery("SHOW BINARY LOGS").
+		WillReturnRows(sqlmock.NewRows([]string{"Log_name", "File_size"}).AddRow("mysql-bin.000012", "1000"))
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "400"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("late").AddRow("second"))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("ROLLBACK").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	resume := formatStoredMySQLPosition(gomysql.Position{Name: "mysql-bin.000012", Pos: 300}, 0)
+	src := &MySQLCDCSource{db: db, database: "app"}
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{
+		CDCResumeLSNs: map[string]string{"first": resume},
+	})
+	require.NoError(t, err)
+	var readErr error
+	for result := range results {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		if result.Err != nil {
+			readErr = result.Err
+		}
+	}
+	require.ErrorContains(t, readErr, "appeared after")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCReadAllIgnoresUnrequestedInventoryChangesAtSnapshotBoundaries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("ignored").AddRow("second"))
+	for _, table := range []string{"first", "second"} {
+		expectMySQLCDCTableSchema(mock, "app", table)
+	}
+	for _, table := range []string{"first", "second"} {
+		mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
+			WithArgs("app", table).
+			WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
+	}
+
+	for i, table := range []string{"first", "second"} {
+		mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery("SHOW BINARY LOG STATUS").
+			WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+		mock.ExpectQuery("XA RECOVER").
+			WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+		inventory := sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("first").AddRow("ignored")
+		if i == 1 {
+			inventory.AddRow("late")
+		}
+		inventory.AddRow("second")
+		mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").WithArgs("app").WillReturnRows(inventory)
+		mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+		expectMySQLCDCTableSchema(mock, "app", table)
+		mock.ExpectQuery("SELECT .* FROM .*" + table).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(int64(i+1), table))
+		mock.ExpectExec("COMMIT").WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{Tables: []string{"first", "second"}})
+	require.NoError(t, err)
+	var batches int
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch != nil {
+			batches++
+			result.Batch.Release()
+		}
+	}
+	require.Equal(t, 2, batches)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -180,6 +488,27 @@ func expectMySQLCDCTableSchema(mock sqlmock.Sqlmock, database, table string) {
 	mock.ExpectQuery("INFORMATION_SCHEMA\\.KEY_COLUMN_USAGE").
 		WithArgs(database, table).
 		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME"}).AddRow("id"))
+}
+
+func TestMySQLCDCRejectsNonMergeStrategies(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectMySQLCDCTableSchema(mock, "app", "items")
+	mock.ExpectQuery("(?s)SELECT\\s+COLUMN_NAME,\\s+DATA_TYPE.*INFORMATION_SCHEMA\\.COLUMNS").
+		WithArgs("app", "items").
+		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	_, err = src.GetTable(t.Context(), source.TableRequest{Name: "items", Strategy: config.StrategyAppend})
+	require.ErrorContains(t, err, "only supports the merge strategy")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCDoesNotAdvertiseStreaming(t *testing.T) {
+	_, ok := any(NewMySQLCDCSource()).(source.StreamingSource)
+	require.False(t, ok)
 }
 
 func TestStoredMySQLPositionHelpers(t *testing.T) {
@@ -456,6 +785,37 @@ func TestMySQLCDCResultTableName(t *testing.T) {
 	assert.Equal(t, "items", mysqlCDCResultTableName("items", 2, false), "multiple-table stream batches must be tagged")
 }
 
+func TestValidateMySQLCDCSnapshotSchemaRejectsDiscoveryRace(t *testing.T) {
+	expected := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	current := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "added", DataType: schema.TypeString},
+	}}
+	require.NoError(t, validateMySQLCDCSnapshotSchema(expected, expected, "items"))
+	require.ErrorContains(t, validateMySQLCDCSnapshotSchema(expected, current, "items"), "--full-refresh")
+}
+
+func TestValidateMySQLCDCDiscoveredSchemasRejectsMultiTableRace(t *testing.T) {
+	expected := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	src := &MySQLCDCSource{discoveredSchemas: map[string]*schema.TableSchema{"items": expected}}
+	require.NoError(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{{Name: "items", Schema: cloneMySQLCDCTableSchema(expected)}}, nil))
+
+	changed := cloneMySQLCDCTableSchema(expected)
+	changed.Columns = append(changed.Columns, schema.Column{Name: "added", DataType: schema.TypeString})
+	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{{Name: "items", Schema: changed}}, nil), "--full-refresh")
+	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{
+		{Name: "items", Schema: expected},
+		{Name: "late", Schema: expected},
+	}, nil), "appeared after")
+
+	src.discoveredSchemas["ignored"] = cloneMySQLCDCTableSchema(expected)
+	require.NoError(t, src.validateMySQLCDCDiscoveredSchemas(
+		[]source.SourceTableInfo{{Name: "items", Schema: cloneMySQLCDCTableSchema(expected)}},
+		[]string{"items"},
+	))
+	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas(nil, []string{"items"}), "no longer available")
+}
+
 func TestBeginMySQLConsistentSnapshotLocksAroundPosition(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -471,6 +831,8 @@ func TestBeginMySQLConsistentSnapshotLocksAroundPosition(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery("SHOW BINARY LOG STATUS").
 		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
 	mock.ExpectExec("UNLOCK TABLES").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -483,6 +845,40 @@ func TestBeginMySQLConsistentSnapshotLocksAroundPosition(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, gomysql.Position{Name: "mysql-bin.000012", Pos: 345}, pos)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBeginMySQLConsistentSnapshotValidatesInventoryBeforeUnlock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}))
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("items").AddRow("late"))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	src := &MySQLCDCSource{
+		database:          "app",
+		discoveredSchemas: map[string]*schema.TableSchema{"items": {}},
+	}
+
+	_, err = beginMySQLConsistentSnapshotWithValidation(ctx, conn, func(validationCtx context.Context, q mysqlCDCPositionQueryer) error {
+		return src.validateMySQLCDCInventory(validationCtx, q, nil)
+	})
+	require.ErrorContains(t, err, "appeared after")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -514,6 +910,295 @@ func TestBeginMySQLConsistentSnapshotUnlocksOnPositionError(t *testing.T) {
 	_, err = beginMySQLConsistentSnapshot(ctx, conn)
 	require.Error(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBeginMySQLConsistentSnapshotRejectsPreparedXA(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("SET time_zone = '\\+00:00'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("START TRANSACTION WITH CONSISTENT SNAPSHOT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").
+		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
+	mock.ExpectQuery("XA RECOVER").
+		WillReturnRows(sqlmock.NewRows([]string{"formatID", "gtrid_length", "bqual_length", "data"}).AddRow(1, 3, 0, []byte("xid")))
+	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	_, err = beginMySQLConsistentSnapshot(ctx, conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prepared XA")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+type mysqlCDCTestStreamer func(context.Context) (*replication.BinlogEvent, error)
+
+func (f mysqlCDCTestStreamer) GetEvent(ctx context.Context) (*replication.BinlogEvent, error) {
+	return f(ctx)
+}
+
+func TestReadMySQLCDCEventClassifiesOnlyActualPollDeadlines(t *testing.T) {
+	readerErr := errors.New("replication stream closed")
+	_, err, eventCtxErr := readMySQLCDCEvent(context.Background(), mysqlCDCTestStreamer(func(context.Context) (*replication.BinlogEvent, error) {
+		return nil, readerErr
+	}))
+	require.ErrorIs(t, err, readerErr)
+	require.NoError(t, eventCtxErr)
+	assert.False(t, isMySQLCDCReadPollTimeout(context.Background(), err, eventCtxErr))
+
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err, eventCtxErr = readMySQLCDCEvent(parent, mysqlCDCTestStreamer(func(ctx context.Context) (*replication.BinlogEvent, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, isMySQLCDCReadPollTimeout(parent, err, eventCtxErr))
+
+	_, err, eventCtxErr = readMySQLCDCEvent(context.Background(), mysqlCDCTestStreamer(func(ctx context.Context) (*replication.BinlogEvent, error) {
+		<-ctx.Done()
+		return nil, readerErr
+	}))
+	require.ErrorIs(t, err, readerErr)
+	require.ErrorIs(t, eventCtxErr, context.DeadlineExceeded)
+	assert.False(t, isMySQLCDCReadPollTimeout(context.Background(), err, eventCtxErr))
+
+	assert.True(t, isMySQLCDCReadPollTimeout(context.Background(), context.DeadlineExceeded, context.DeadlineExceeded))
+}
+
+func TestMySQLBinlogEventsPreservesCompressedTransactionOrder(t *testing.T) {
+	start := &replication.BinlogEvent{Event: &replication.QueryEvent{Query: []byte("XA START X'41',X'',1")}}
+	rows := &replication.BinlogEvent{Event: &replication.RowsEvent{Rows: [][]interface{}{{int64(1)}}}}
+	prepare := mysqlCDCTestXAPrepareEvent(t, "A", "", 1, true)
+	payload := &replication.BinlogEvent{Event: &replication.TransactionPayloadEvent{Events: []*replication.BinlogEvent{start, rows, prepare}}}
+
+	events, err := mysqlBinlogEvents(payload)
+	require.NoError(t, err)
+	require.Equal(t, []*replication.BinlogEvent{start, rows, prepare}, events)
+}
+
+func TestValidateMySQLCDCFullRowImageDistinguishesNullFromOmitted(t *testing.T) {
+	full := &replication.RowsEvent{
+		ColumnCount:    3,
+		Rows:           [][]interface{}{{int64(1), nil, "value"}},
+		SkippedColumns: [][]int{{}},
+	}
+	require.NoError(t, validateMySQLCDCFullRowImage(full, 3), "an explicit SQL NULL in a full image is valid")
+
+	omitted := &replication.RowsEvent{
+		ColumnCount:    3,
+		Rows:           [][]interface{}{{int64(1), nil, "value"}},
+		SkippedColumns: [][]int{{1}},
+	}
+	err := validateMySQLCDCFullRowImage(omitted, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "binlog_row_image=FULL")
+}
+
+func TestMySQLCDCXIDCanonicalizationAndPrepare(t *testing.T) {
+	action, quotedID, continuation, err := mysqlCDCXAQuery("XA START 'CaseSensitive', X'6272616E6368', 17 RESUME")
+	require.NoError(t, err)
+	assert.Equal(t, mysqlCDCXAActionStart, action)
+	assert.True(t, continuation)
+
+	action, hexID, onePhase, err := mysqlCDCXAQuery("XA COMMIT X'4361736553656e736974697665',X'6272616e6368',17 ONE PHASE")
+	require.NoError(t, err)
+	assert.Equal(t, mysqlCDCXAActionCommit, action)
+	assert.True(t, onePhase)
+	assert.Equal(t, quotedID, hexID)
+
+	prepare := mysqlCDCTestXAPrepareEvent(t, "CaseSensitive", "branch", 17, true)
+	prepareID, prepareOnePhase, err := mysqlCDCXAPrepare(prepare)
+	require.NoError(t, err)
+	assert.True(t, prepareOnePhase)
+	assert.Equal(t, quotedID, prepareID)
+
+	_, lowerID, _, err := mysqlCDCXAQuery("XA START 'casesensitive','branch',17")
+	require.NoError(t, err)
+	assert.NotEqual(t, quotedID, lowerID)
+
+	for _, formatID := range []uint32{1 << 31, 1<<32 - 1} {
+		query := fmt.Sprintf("XA START 'boundary','',%d", formatID)
+		_, queryID, _, err := mysqlCDCXAQuery(query)
+		require.NoError(t, err)
+		prepareID, _, err := mysqlCDCXAPrepare(mysqlCDCTestXAPrepareEvent(t, "boundary", "", formatID, false))
+		require.NoError(t, err)
+		assert.Equal(t, queryID, prepareID)
+	}
+}
+
+func TestMySQLCDCXAQueryAcceptsWhitespaceAndComments(t *testing.T) {
+	action, xaID, _, err := mysqlCDCXAQuery("/* leading */ XA\t/* inter-token */ START\n/* before XID */ 'spaced-xid'")
+	require.NoError(t, err)
+	require.Equal(t, mysqlCDCXAActionStart, action)
+	require.NotEmpty(t, xaID)
+
+	action, committedID, onePhase, err := mysqlCDCXAQuery("XA  COMMIT /* before XID */ 'spaced-xid'   ONE PHASE;")
+	require.NoError(t, err)
+	require.Equal(t, mysqlCDCXAActionCommit, action)
+	require.Equal(t, xaID, committedID)
+	require.True(t, onePhase)
+
+	action, committedID, onePhase, err = mysqlCDCXAQuery("XA COMMIT 'spaced-xid' /* after XID */ ONE /* between modifier */ PHASE /* trailing */;")
+	require.NoError(t, err)
+	require.Equal(t, mysqlCDCXAActionCommit, action)
+	require.Equal(t, xaID, committedID)
+	require.True(t, onePhase)
+}
+
+func TestMySQLCDCChangesSizeAccountsForLargePayloads(t *testing.T) {
+	require.Greater(t, mysqlCDCValueSize("x"), uint64(1))
+	require.Greater(t, mysqlCDCValueSize([]byte{1}), uint64(1))
+	require.Equal(t, ^uint64(0), saturatingMySQLCDCSizeMul(^uint64(0), 2))
+
+	small := mysqlCDCChangesSize([]mysqlCDCChange{{values: []interface{}{int64(1), "small"}, lsn: "lsn"}})
+	large := mysqlCDCChangesSize([]mysqlCDCChange{{values: []interface{}{int64(1), strings.Repeat("x", 1024*1024)}, lsn: "lsn"}})
+	require.Greater(t, large, small+uint64(1024*1024-16))
+
+	smallDecimal := decimal.RequireFromString("12345.67")
+	largeDecimal := decimal.RequireFromString(strings.Repeat("9", 65))
+	small = mysqlCDCChangesSize([]mysqlCDCChange{{values: []interface{}{smallDecimal}, lsn: "lsn"}})
+	large = mysqlCDCChangesSize([]mysqlCDCChange{{values: []interface{}{largeDecimal}, lsn: "lsn"}})
+	require.Equal(t, small, large)
+	require.Equal(t, uint64(maxMySQLCDCDecodedDecimalSize), mysqlCDCValueSize(smallDecimal))
+
+	spareCapacity := make([]mysqlCDCChange, 1, 1024)
+	require.Greater(
+		t,
+		mysqlCDCXAChunkSize(spareCapacity),
+		uint64(cap(spareCapacity))*uint64(unsafe.Sizeof(mysqlCDCChange{})),
+	)
+	require.Greater(t, mysqlCDCXATransactionSize("xid"), uint64(len("xid")))
+	require.Greater(t, mysqlCDCXATableSize("table"), uint64(len("table")))
+}
+
+func TestConvertMySQLCDCValueDetachesDecodedStrings(t *testing.T) {
+	backing := strings.Repeat("x", 1024*1024)
+	decoded := backing[:5]
+	converted := convertMySQLCDCValue(decoded, schema.Column{DataType: schema.TypeString}).(string)
+	require.Equal(t, decoded, converted)
+	require.NotEqual(t, uintptr(unsafe.Pointer(unsafe.StringData(decoded))), uintptr(unsafe.Pointer(unsafe.StringData(converted))))
+}
+
+func TestProjectMySQLCDCRowRejectsPartialJSON(t *testing.T) {
+	columns := []schema.Column{{Name: "payload", DataType: schema.TypeJSON}}
+	_, err := projectMySQLCDCRow(
+		[]interface{}{&replication.JsonDiff{Path: "$.large", Value: strings.Repeat("x", 1024)}},
+		columns,
+		columns,
+		[]int{0},
+	)
+	require.ErrorContains(t, err, "partial JSON")
+}
+
+func mysqlCDCTestXAPrepareEvent(t *testing.T, gtrid, bqual string, formatID uint32, onePhase bool) *replication.BinlogEvent {
+	t.Helper()
+	data := make([]byte, 13+len(gtrid)+len(bqual))
+	if onePhase {
+		data[0] = 1
+	}
+	binary.LittleEndian.PutUint32(data[1:5], uint32(formatID))
+	binary.LittleEndian.PutUint32(data[5:9], uint32(len(gtrid)))
+	binary.LittleEndian.PutUint32(data[9:13], uint32(len(bqual)))
+	copy(data[13:], gtrid)
+	copy(data[13+len(gtrid):], bqual)
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.XA_PREPARE_LOG_EVENT},
+		Event:  &replication.GenericEvent{Data: data},
+	}
+}
+
+func TestMySQLCDCQueryDDLScoping(t *testing.T) {
+	meta := mysqlCDCTableMetadata{Name: "items", SourceSchema: "app", SourceName: "items"}
+	exchange := mysqlCDCTableMetadata{Name: "exchange_items", SourceSchema: "app", SourceName: "exchange_items"}
+	aliases := map[string]mysqlCDCTableMetadata{
+		"items":              meta,
+		"app.items":          meta,
+		"exchange_items":     exchange,
+		"app.exchange_items": exchange,
+	}
+
+	truncated, err := mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("/* audit */ TRUNCATE TABLE `app`.`items`")}, "app", aliases)
+	require.NoError(t, err)
+	require.Len(t, truncated, 1)
+	assert.Equal(t, "items", truncated[0].Name)
+
+	truncated, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("/* audit */ /*!80000 TRUNCATE TABLE `app`.`items` */")}, "app", aliases)
+	require.NoError(t, err)
+	require.Len(t, truncated, 1)
+	assert.Equal(t, "items", truncated[0].Name)
+
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("ALTER TABLE other EXCHANGE PARTITION p0 WITH TABLE exchange_items")}, "app", aliases)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "full-refresh")
+
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Query: []byte("CREATE DATABASE unrelated")}, "app", aliases)
+	require.NoError(t, err)
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Query: []byte("CREATE EVENT unrelated.cleanup ON SCHEDULE EVERY 1 DAY DO DELETE FROM unrelated.logs")}, "app", aliases)
+	require.NoError(t, err)
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("CREATE DEFINER = 'svc'@'%' TRIGGER items BEFORE INSERT ON items FOR EACH ROW SET NEW.id = NEW.id")}, "app", aliases)
+	require.NoError(t, err, "routine DDL must not be mistaken for captured table DDL when its object name collides")
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("CREATE OR REPLACE DEFINER='svc'@'%' VIEW items AS SELECT 1 AS id")}, "app", aliases)
+	require.NoError(t, err)
+	require.False(t, mysqlCDCIsKnownNonTableDDL("CREATE SPATIAL INDEX idx ON items (id)"))
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("ALTER /* VIEW */ TABLE items ADD COLUMN added INT")}, "app", aliases)
+	require.ErrorContains(t, err, "full-refresh", "comments must not disguise captured table DDL")
+	require.True(t, mysqlCDCIsKnownNonTableDDL(normalizeMySQLCDCQuery("CREATE /*!80000 OR REPLACE */ /* object */ VIEW items AS SELECT 1")))
+	truncated, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("/*M!100100 TRUNCATE TABLE items */")}, "app", aliases)
+	require.NoError(t, err)
+	require.Len(t, truncated, 1)
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("CREATE TABLE newly_discovered (id BIGINT NOT NULL PRIMARY KEY)")}, "app", aliases)
+	require.NoError(t, err)
+	newMeta := mysqlCDCTableMetadata{Name: "newly_discovered", SourceSchema: "app", SourceName: "newly_discovered"}
+	aliases["newly_discovered"] = newMeta
+	aliases["app.newly_discovered"] = newMeta
+	createEvent := &replication.QueryEvent{Schema: []byte("app"), Query: []byte("CREATE TABLE newly_discovered (id BIGINT NOT NULL PRIMARY KEY)")}
+	_, err = mysqlCDCQueryTruncatesAfter(
+		createEvent, "app", aliases,
+		gomysql.Position{Name: "mysql-bin.000001", Pos: 100},
+		map[string]gomysql.Position{"newly_discovered": {Name: "mysql-bin.000001", Pos: 200}},
+	)
+	require.NoError(t, err, "DDL covered by the table's initial snapshot must be ignored")
+	_, err = mysqlCDCQueryTruncatesAfter(
+		createEvent, "app", aliases,
+		gomysql.Position{Name: "mysql-bin.000001", Pos: 300},
+		map[string]gomysql.Position{"newly_discovered": {Name: "mysql-bin.000001", Pos: 200}},
+	)
+	require.ErrorContains(t, err, "full-refresh", "DDL after the snapshot boundary must fail closed")
+
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Query: []byte("DROP DATABASE app")}, "app", aliases)
+	require.Error(t, err)
+}
+
+func TestMySQLCDCQueryUnparseableDDLScoping(t *testing.T) {
+	meta := mysqlCDCTableMetadata{Name: "items", SourceSchema: "app", SourceName: "items"}
+	aliases := map[string]mysqlCDCTableMetadata{
+		"items":     meta,
+		"app.items": meta,
+	}
+
+	// Valid server DDL the vendored parser rejects must be skipped when it
+	// cannot involve captured tables, instead of wedging the stream.
+	_, err := mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("report"), Query: []byte("CREATE TABLE tmp (id SERIAL PRIMARY KEY)")}, "app", aliases)
+	require.NoError(t, err)
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("CREATE SEQUENCE seq_orders START WITH 1")}, "app", aliases)
+	require.NoError(t, err)
+
+	// Unparseable DDL naming a captured table or the captured database still
+	// fails closed.
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("ALTER TABLE items SECONDARY_LOAD")}, "app", aliases)
+	require.ErrorContains(t, err, "failed to parse MySQL DDL event")
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("report"), Query: []byte("CREATE TABLE app.tmp (id SERIAL PRIMARY KEY)")}, "app", aliases)
+	require.ErrorContains(t, err, "failed to parse MySQL DDL event")
+	_, err = mysqlCDCQueryTruncates(&replication.QueryEvent{Schema: []byte("app"), Query: []byte("CREATE TABLE `items_archive` (id SERIAL)")}, "app", aliases)
+	require.NoError(t, err, "identifiers merely containing a captured name must not fail closed")
 }
 
 func TestMySQLCDCTableReadErrorsWhenResumePositionExpired(t *testing.T) {

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -127,7 +127,7 @@ func uriToDSN(uri string) (string, string, error) {
 // implicit `json_valid(column)` check constraint, so INFORMATION_SCHEMA
 // reports them as longtext; without this detection they would be ingested as
 // plain strings and double-encoded by JSON-aware destinations.
-func mariadbJSONColumns(ctx context.Context, db *sql.DB, schemaName, tableName string) (map[string]bool, error) {
+func mariadbJSONColumns(ctx context.Context, db rowQuerier, schemaName, tableName string) (map[string]bool, error) {
 	var version string
 	if err := db.QueryRowContext(ctx, "SELECT @@version").Scan(&version); err != nil {
 		return nil, err
@@ -240,7 +240,7 @@ func (s *MySQLSource) getSchema(ctx context.Context, table string) (*schema.Tabl
 	return getMySQLSchema(ctx, s.db, s.database, table)
 }
 
-func getMySQLSchema(ctx context.Context, db *sql.DB, database string, table string) (*schema.TableSchema, error) {
+func getMySQLSchema(ctx context.Context, db rowQuerier, database string, table string) (*schema.TableSchema, error) {
 	schemaName, tableName := parseMySQLTableName(database, table)
 
 	query := `

--- a/pkg/strategy/cdc_state.go
+++ b/pkg/strategy/cdc_state.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -51,7 +52,7 @@ var cdcStateSchema = &schema.TableSchema{Columns: []schema.Column{
 	{Name: "state_kind", DataType: schema.TypeString, MaxLength: 32, Nullable: false},
 	{Name: "state_generation", DataType: schema.TypeInt64, Nullable: false},
 	{Name: "state_status", DataType: schema.TypeString, MaxLength: 32, Nullable: false},
-	{Name: "_cdc_lsn", DataType: schema.TypeString, MaxLength: 64, Nullable: false},
+	{Name: "_cdc_lsn", DataType: schema.TypeString, Nullable: false},
 	{Name: "recorded_at", DataType: schema.TypeTimestampTZ, Nullable: false},
 }}
 
@@ -98,29 +99,30 @@ type CDCStateManager struct {
 	stateTable     string
 	targetTable    string
 
-	mu                  sync.Mutex
-	prepared            bool
-	targetPrepared      bool
-	loaded              bool
-	started             bool
-	generation          int64
-	runID               string
-	runEventID          string
-	runs                map[string]struct{}
-	states              map[cdcStateKey]reducedCDCState
-	destTables          map[string]string
-	knownComplete       map[string]string
-	currentIncarnations map[string]string
-	currentSchemas      map[string]string
-	knownIncarnations   map[string]string
-	knownSchemas        map[string]string
-	knownDestinations   map[string]string
-	boundDestinations   map[string]string
-	lateTargetModes     map[string]lateTargetMode
-	lateTargetRaw       map[string]string
-	snapshotEpochs      map[string]uint64
-	entries             []destination.CDCStateEntry
-	cleanupDue          bool
+	mu                   sync.Mutex
+	prepared             bool
+	targetPrepared       bool
+	loaded               bool
+	started              bool
+	generation           int64
+	runID                string
+	runEventID           string
+	runs                 map[string]struct{}
+	states               map[cdcStateKey]reducedCDCState
+	destTables           map[string]string
+	knownComplete        map[string]string
+	currentIncarnations  map[string]string
+	currentSchemas       map[string]string
+	knownIncarnations    map[string]string
+	knownSchemas         map[string]string
+	knownDestinations    map[string]string
+	boundDestinations    map[string]string
+	boundRawDestinations map[string]string
+	lateTargetModes      map[string]lateTargetMode
+	lateTargetRaw        map[string]string
+	snapshotEpochs       map[string]uint64
+	entries              []destination.CDCStateEntry
+	cleanupDue           bool
 }
 
 type lateTargetMode uint8
@@ -168,28 +170,29 @@ func newCDCStateManager(dest destination.Destination, connectorID, stateTable st
 		}
 	}
 	return &CDCStateManager{
-		dest:                dest,
-		reader:              reader,
-		fenceReader:         fenceReader,
-		pruner:              pruner,
-		incarnation:         destinationIncarnationProvider(dest),
-		initializer:         destinationIncarnationInitializer(dest),
-		pruneBatchSize:      pruneBatchSize,
-		connectorID:         connectorID,
-		stateTable:          stateTable,
-		runs:                make(map[string]struct{}),
-		states:              make(map[cdcStateKey]reducedCDCState),
-		destTables:          make(map[string]string),
-		knownComplete:       make(map[string]string),
-		currentIncarnations: make(map[string]string),
-		currentSchemas:      make(map[string]string),
-		knownIncarnations:   make(map[string]string),
-		knownSchemas:        make(map[string]string),
-		knownDestinations:   make(map[string]string),
-		boundDestinations:   make(map[string]string),
-		lateTargetModes:     make(map[string]lateTargetMode),
-		lateTargetRaw:       make(map[string]string),
-		snapshotEpochs:      make(map[string]uint64),
+		dest:                 dest,
+		reader:               reader,
+		fenceReader:          fenceReader,
+		pruner:               pruner,
+		incarnation:          destinationIncarnationProvider(dest),
+		initializer:          destinationIncarnationInitializer(dest),
+		pruneBatchSize:       pruneBatchSize,
+		connectorID:          connectorID,
+		stateTable:           stateTable,
+		runs:                 make(map[string]struct{}),
+		states:               make(map[cdcStateKey]reducedCDCState),
+		destTables:           make(map[string]string),
+		knownComplete:        make(map[string]string),
+		currentIncarnations:  make(map[string]string),
+		currentSchemas:       make(map[string]string),
+		knownIncarnations:    make(map[string]string),
+		knownSchemas:         make(map[string]string),
+		knownDestinations:    make(map[string]string),
+		boundDestinations:    make(map[string]string),
+		boundRawDestinations: make(map[string]string),
+		lateTargetModes:      make(map[string]lateTargetMode),
+		lateTargetRaw:        make(map[string]string),
+		snapshotEpochs:       make(map[string]uint64),
 	}, nil
 }
 
@@ -251,6 +254,7 @@ func (m *CDCStateManager) InvalidateSnapshot(ctx context.Context, sourceTable, d
 	delete(m.knownSchemas, sourceTable)
 	delete(m.knownDestinations, sourceTable)
 	delete(m.boundDestinations, sourceTable)
+	delete(m.boundRawDestinations, sourceTable)
 	return nil
 }
 
@@ -270,18 +274,72 @@ func (m *CDCStateManager) BindDestinationIncarnation(ctx context.Context, source
 			return fmt.Errorf("CDC destination table %q disappeared before snapshot write", destTable)
 		}
 	}
-	current, exists, err := m.currentDestinationIncarnation(ctx, sourceTable)
+	raw, current, exists, err := m.destinationIncarnationForTable(ctx, destTable)
 	if err != nil {
 		return err
 	}
 	if !exists {
 		return fmt.Errorf("CDC destination table %q disappeared before snapshot write", destTable)
 	}
+	if known := m.knownDestinations[sourceTable]; known != "" && current != known {
+		return fmt.Errorf("CDC destination table %q was replaced after its completed snapshot", destTable)
+	}
 	if bound := m.boundDestinations[sourceTable]; bound != "" && current != bound {
 		return fmt.Errorf("CDC destination table %q was replaced during its snapshot", destTable)
 	}
 	m.boundDestinations[sourceTable] = current
+	m.boundRawDestinations[sourceTable] = raw
 	return nil
+}
+
+func (m *CDCStateManager) BoundDestinationIncarnation(sourceTable string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	incarnation := m.boundRawDestinations[sourceTable]
+	if incarnation == "" {
+		return "", fmt.Errorf("CDC destination for source table %q has not been bound", sourceTable)
+	}
+	return incarnation, nil
+}
+
+func (m *CDCStateManager) CompleteConditionalSwap(ctx context.Context, sourceTable, destTable, previousIncarnation, resultIncarnation string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if previousIncarnation == "" || resultIncarnation == "" {
+		return fmt.Errorf("CDC conditional swap for %q has an empty physical incarnation", destTable)
+	}
+	if bound := m.boundRawDestinations[sourceTable]; bound != previousIncarnation {
+		return fmt.Errorf("CDC destination table %q changed before its conditional swap", destTable)
+	}
+	raw, digest, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || raw != resultIncarnation {
+		return fmt.Errorf("CDC destination table %q was replaced during its conditional swap", destTable)
+	}
+	m.boundRawDestinations[sourceTable] = raw
+	m.boundDestinations[sourceTable] = digest
+	return nil
+}
+
+func (m *CDCStateManager) SourceTableForDestination(destTable string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sourceTable := ""
+	for candidate, destinationTable := range m.destTables {
+		if destinationTable != destTable {
+			continue
+		}
+		if sourceTable != "" && sourceTable != candidate {
+			return "", fmt.Errorf("multiple managed CDC source tables map to destination %q", destTable)
+		}
+		sourceTable = candidate
+	}
+	if sourceTable == "" {
+		return "", fmt.Errorf("cannot resolve managed CDC source table for destination %q", destTable)
+	}
+	return sourceTable, nil
 }
 
 // ClaimTarget reserves a destination table for one logical source table before
@@ -290,6 +348,58 @@ func (m *CDCStateManager) ClaimTarget(ctx context.Context, sourceTable, destTabl
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.claimTarget(ctx, sourceTable, destTable)
+}
+
+func (m *CDCStateManager) ClaimAndPrepareTarget(ctx context.Context, sourceTable, destTable string, opts destination.PrepareOptions) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.validateTarget(ctx, destTable); err != nil {
+		return err
+	}
+	if err := m.prepareTargetTable(ctx); err != nil {
+		return err
+	}
+	rawIncarnation, incarnation, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if rawIncarnation == "" {
+			return fmt.Errorf("CDC destination table %q has no provable physical incarnation", destTable)
+		}
+		if err := m.claimTarget(ctx, sourceTable, destTable); err != nil {
+			return err
+		}
+		m.boundRawDestinations[sourceTable] = rawIncarnation
+		m.boundDestinations[sourceTable] = incarnation
+		return nil
+	}
+	preparer, ok := m.dest.(destination.CDCLateTargetClaimPreparer)
+	if !ok {
+		return fmt.Errorf("destination scheme %q cannot atomically claim and create an empty managed CDC target", m.dest.GetScheme())
+	}
+	opts.Table = destTable
+	created, err := preparer.ClaimAndPrepareEmptyCDCTarget(ctx, m.targetTable, destination.CDCTargetClaim{
+		DestinationTable: destTable,
+		ConnectorID:      m.connectorID,
+		SourceTable:      sourceTable,
+	}, opts)
+	if err != nil {
+		return fmt.Errorf("failed to atomically claim and create CDC destination table %q: %w", destTable, err)
+	}
+	if created == "" {
+		return fmt.Errorf("destination scheme %q created CDC destination table %q without a provable physical incarnation", m.dest.GetScheme(), destTable)
+	}
+	currentRaw, currentDigest, exists, err := m.destinationIncarnationForTable(ctx, destTable)
+	if err != nil {
+		return err
+	}
+	if !exists || currentRaw != created {
+		return fmt.Errorf("CDC destination table %q was replaced while it was being claimed", destTable)
+	}
+	m.boundRawDestinations[sourceTable] = currentRaw
+	m.boundDestinations[sourceTable] = currentDigest
+	return nil
 }
 
 // ClaimLateDiscoveredTarget validates a target that was not part of the
@@ -345,6 +455,7 @@ func (m *CDCStateManager) ClaimLateDiscoveredTarget(
 		m.lateTargetModes[sourceTable] = lateTargetCreatedEmpty
 		m.lateTargetRaw[sourceTable] = createdIncarnation
 		m.boundDestinations[sourceTable] = cdcDestinationIncarnationDigest(createdIncarnation)
+		m.boundRawDestinations[sourceTable] = createdIncarnation
 		return nil
 	}
 	if !allowReplacement {
@@ -374,6 +485,7 @@ func (m *CDCStateManager) ClaimLateDiscoveredTarget(
 		m.lateTargetModes[sourceTable] = lateTargetConditionalReplace
 		m.lateTargetRaw[sourceTable] = rawDestinationIncarnation
 		m.boundDestinations[sourceTable] = destinationIncarnation
+		m.boundRawDestinations[sourceTable] = rawDestinationIncarnation
 	}
 	return nil
 }
@@ -546,6 +658,7 @@ func (m *CDCStateManager) ApplyLateSnapshotBoundary(ctx context.Context, sourceT
 		}
 	}
 	m.boundDestinations[sourceTable] = expectedDigest
+	m.boundRawDestinations[sourceTable] = expectedRaw
 	delete(m.lateTargetModes, sourceTable)
 	delete(m.lateTargetRaw, sourceTable)
 	return true, nil
@@ -750,7 +863,6 @@ func (m *CDCStateManager) BeginRun(ctx context.Context, fullRefresh bool) error 
 		m.knownIncarnations = make(map[string]string)
 		m.knownDestinations = make(map[string]string)
 	}
-	m.boundDestinations = make(map[string]string)
 	m.snapshotEpochs = make(map[string]uint64)
 	m.generation++
 	runID, err := newCDCStateRunID()
@@ -944,6 +1056,7 @@ func (m *CDCStateManager) Persist(ctx context.Context, token source.CDCStateComm
 		m.knownDestinations[sourceTable] = expected
 		if _, freshSnapshot := token.SnapshotPositions[sourceTable]; freshSnapshot {
 			delete(m.boundDestinations, sourceTable)
+			delete(m.boundRawDestinations, sourceTable)
 		}
 	}
 	m.pruneSuperseded(ctx)
@@ -960,10 +1073,30 @@ func (m *CDCStateManager) prepareTable(ctx context.Context) error {
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := m.dest.PrepareTable(ctx, destination.PrepareOptions{
-		Table: m.stateTable, Schema: cdcStateSchema, DropFirst: false, PrimaryKeys: []string{"connector_id", "event_id"},
-	}); err != nil {
-		return fmt.Errorf("failed to prepare shared CDC state table %s: %w", m.stateTable, err)
+	prepare := func() error {
+		return m.dest.PrepareTable(ctx, destination.PrepareOptions{
+			Table: m.stateTable, Schema: cdcStateSchema, DropFirst: false, PrimaryKeys: []string{"connector_id", "event_id"},
+		})
+	}
+	migrator, hasMigrator := m.dest.(destination.CDCStatePositionMigrator)
+	if err := prepare(); err != nil {
+		// A state table created by an older release carries a bounded position
+		// column that some destinations (BigQuery) refuse to reconcile against
+		// the now-unbounded schema; widen it and retry once.
+		if !hasMigrator {
+			return fmt.Errorf("failed to prepare shared CDC state table %s: %w", m.stateTable, err)
+		}
+		if migrateErr := migrator.EnsureCDCStatePositionColumn(ctx, m.stateTable); migrateErr != nil {
+			return fmt.Errorf("failed to prepare shared CDC state table %s: %w", m.stateTable,
+				errors.Join(err, fmt.Errorf("automatic position-column migration failed: %w", migrateErr)))
+		}
+		if err := prepare(); err != nil {
+			return fmt.Errorf("failed to prepare shared CDC state table %s: %w", m.stateTable, err)
+		}
+	} else if hasMigrator {
+		if err := migrator.EnsureCDCStatePositionColumn(ctx, m.stateTable); err != nil {
+			return fmt.Errorf("failed to widen shared CDC state position column in %s: %w", m.stateTable, err)
+		}
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
@@ -1359,8 +1492,10 @@ func preferCDCStateEntry(candidate, current destination.CDCStateEntry) bool {
 
 func cdcStatePositionValid(position string) bool {
 	position, _, _ = decodeCDCStatePosition(position)
-	_, err := pglogrepl.ParseLSN(position)
-	return err == nil
+	if _, err := pglogrepl.ParseLSN(position); err == nil {
+		return true
+	}
+	return mysqlCDCStatePositionRE.MatchString(position)
 }
 
 func cdcStateEntryPositionValid(entry destination.CDCStateEntry) bool {
@@ -1383,6 +1518,9 @@ func compareCDCPositions(left, right string) int {
 	leftLSN, leftErr := pglogrepl.ParseLSN(left)
 	rightLSN, rightErr := pglogrepl.ParseLSN(right)
 	if leftErr != nil || rightErr != nil {
+		if mysqlCDCStatePositionRE.MatchString(left) && mysqlCDCStatePositionRE.MatchString(right) {
+			return strings.Compare(left, right)
+		}
 		return 0
 	}
 	switch {
@@ -1394,6 +1532,8 @@ func compareCDCPositions(left, right string) int {
 		return 0
 	}
 }
+
+var mysqlCDCStatePositionRE = regexp.MustCompile(`^\d{20}:[^:]+:\d{20}:\d{20}$`)
 
 const (
 	cdcStateIncarnationSeparator   = ";incarnation="
@@ -1497,7 +1637,7 @@ func decodeCDCDestinationState(encoded string) (position, incarnation string, sn
 	if _, err := hex.DecodeString(parts[1]); err != nil {
 		return "", "", 0, false
 	}
-	if _, err := pglogrepl.ParseLSN(parts[2]); err != nil {
+	if !cdcStatePositionValid(parts[2]) {
 		return "", "", 0, false
 	}
 	return parts[2], parts[1], epoch, true

--- a/pkg/strategy/cdc_state_bigquery_live_test.go
+++ b/pkg/strategy/cdc_state_bigquery_live_test.go
@@ -1,0 +1,74 @@
+//go:build bigquerylive
+
+package strategy
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	bqdest "github.com/bruin-data/ingestr/pkg/destination/bigquery"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// Live regression test for the _cdc_lsn widening upgrade path against a real
+// BigQuery project. Run with:
+//
+//	BIGQUERY_LIVE_URI=bigquery://<project>/<dataset> go test -tags bigquerylive -run TestBigQueryCDCStatePositionMigrationLive ./pkg/strategy/
+func TestBigQueryCDCStatePositionMigrationLive(t *testing.T) {
+	uri := os.Getenv("BIGQUERY_LIVE_URI")
+	if uri == "" {
+		t.Skip("BIGQUERY_LIVE_URI not set")
+	}
+	ctx := context.Background()
+	dest := bqdest.NewBigQueryDestination()
+	require.NoError(t, dest.Connect(ctx, uri))
+	defer func() { _ = dest.Close(ctx) }()
+
+	manager, err := NewCDCStateManager(dest, "livetest-connector", "ignored", "")
+	require.NoError(t, err)
+	stateTable := manager.stateTable
+	t.Logf("state table: %s", stateTable)
+
+	_ = dest.DropTable(ctx, stateTable)
+	_ = dest.DropTable(ctx, manager.targetTable)
+	defer func() {
+		_ = dest.DropTable(ctx, stateTable)
+		_ = dest.DropTable(ctx, manager.targetTable)
+	}()
+
+	// Create the state table exactly as a pre-widening release did: bounded
+	// _cdc_lsn STRING(64).
+	legacy := &schema.TableSchema{Columns: make([]schema.Column, len(cdcStateSchema.Columns))}
+	copy(legacy.Columns, cdcStateSchema.Columns)
+	for i := range legacy.Columns {
+		if legacy.Columns[i].Name == destination.CDCLSNColumn {
+			legacy.Columns[i].MaxLength = 64
+		}
+	}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: stateTable, Schema: legacy, PrimaryKeys: []string{"connector_id", "event_id"},
+	}))
+
+	// Sanity: without migration, the new unbounded schema must fail reconcile.
+	err = dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: stateTable, Schema: cdcStateSchema, PrimaryKeys: []string{"connector_id", "event_id"},
+	})
+	require.ErrorContains(t, err, "bounded")
+	t.Logf("un-migrated reconcile correctly rejected: %v", err)
+
+	// The manager's prepare must widen through the migrator and succeed.
+	require.NoError(t, manager.prepareTable(ctx))
+
+	// The column is now unbounded: strict reconcile passes.
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: stateTable, Schema: cdcStateSchema, PrimaryKeys: []string{"connector_id", "event_id"},
+	}))
+
+	// No-op path: a fresh manager prepares without needing DDL.
+	manager2, err := NewCDCStateManager(dest, "livetest-connector", "ignored", "")
+	require.NoError(t, err)
+	require.NoError(t, manager2.prepareTable(ctx))
+}

--- a/pkg/strategy/cdc_state_test.go
+++ b/pkg/strategy/cdc_state_test.go
@@ -106,6 +106,7 @@ func newCDCStateDestination() *cdcStateDestination {
 		fakeDestination: &fakeDestination{},
 		states:          make(map[string][]storedCDCState),
 		targets:         make(map[string]string),
+		missing:         make(map[string]bool),
 		incarnations:    make(map[string]string),
 	}
 }
@@ -328,6 +329,48 @@ func TestCDCStateRequiresMatchingDestinationTableIncarnation(t *testing.T) {
 	}
 }
 
+func TestCDCStateExposesBoundRawDestinationIncarnation(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	dest.incarnations["raw.orders"] = "physical-target-42"
+	manager, err := NewCDCStateManager(dest, "bound-incarnation", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.NoError(t, manager.BindDestinationIncarnation(ctx, "public.orders", "raw.orders"))
+
+	incarnation, err := manager.BoundDestinationIncarnation("public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "physical-target-42", incarnation)
+}
+
+func TestCDCStateRejectsTargetReplacementAfterResumeBeforeBind(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	dest.incarnations["raw.orders"] = "destination-100"
+	first, err := NewCDCStateManager(dest, "bind-race", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTableIncarnation(ctx, "public.orders", "raw.orders", "source-100"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:             "00000000/00000020",
+		SnapshotPositions:    map[string]string{"public.orders": "00000000/00000010"},
+		SnapshotIncarnations: map[string]string{"public.orders": "source-100"},
+	}))
+
+	restarted, err := NewCDCStateManager(dest, "bind-race", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTableIncarnation(ctx, "public.orders", "raw.orders", "source-100"))
+	position, err := restarted.ResumePosition(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", position)
+	require.NoError(t, restarted.BeginRun(ctx, false))
+
+	dest.incarnations["raw.orders"] = "destination-101"
+	err = restarted.BindDestinationIncarnation(ctx, "public.orders", "raw.orders")
+	require.ErrorContains(t, err, "replaced after its completed snapshot")
+}
+
 func TestCDCStateRejectsDestinationReplacementBeforeCheckpoint(t *testing.T) {
 	ctx := t.Context()
 	dest := newCDCStateDestination()
@@ -538,6 +581,50 @@ func TestCDCTargetClaimsAreAtomic(t *testing.T) {
 	if successes != 1 {
 		t.Fatalf("concurrent claims had %d winners, want exactly one", successes)
 	}
+}
+
+func TestCDCStateClaimsCreatesAndBindsMissingTargetBeforeRun(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	dest.missing["raw.orders"] = true
+	manager, err := NewCDCStateManager(dest, "connector-a", "raw.orders", "")
+	require.NoError(t, err)
+
+	err = manager.ClaimAndPrepareTarget(ctx, "public.orders", "raw.orders", destination.PrepareOptions{
+		Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}},
+	})
+	require.NoError(t, err)
+	require.False(t, dest.missing["raw.orders"])
+	require.Equal(t, destination.CDCTargetOwnerID("connector-a", "public.orders"), dest.targets["raw.orders"])
+
+	incarnation, err := manager.BoundDestinationIncarnation("public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "incarnation:raw.orders", incarnation)
+	require.NoError(t, manager.BeginRun(ctx, false))
+	incarnation, err = manager.BoundDestinationIncarnation("public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "incarnation:raw.orders", incarnation)
+}
+
+func TestCDCStatePreservesTargetFenceAcrossFullRefreshAndRebindsConditionalSwap(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	dest.incarnations["raw.orders"] = "old-incarnation"
+	manager, err := NewCDCStateManager(dest, "connector-a", "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, manager.ClaimAndPrepareTarget(ctx, "public.orders", "raw.orders", destination.PrepareOptions{
+		Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}},
+	}))
+	require.NoError(t, manager.BeginRun(ctx, true))
+	incarnation, err := manager.BoundDestinationIncarnation("public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "old-incarnation", incarnation)
+
+	dest.incarnations["raw.orders"] = "swap-result-incarnation"
+	require.NoError(t, manager.CompleteConditionalSwap(ctx, "public.orders", "raw.orders", "old-incarnation", "swap-result-incarnation"))
+	incarnation, err = manager.BoundDestinationIncarnation("public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "swap-result-incarnation", incarnation)
 }
 
 func TestCDCStateValidationFailureDoesNotClaimTarget(t *testing.T) {
@@ -2069,6 +2156,31 @@ func TestCDCStatePruningPreservesUnparseablePositions(t *testing.T) {
 	}
 }
 
+func TestCDCDestinationStateAcceptsMySQLPosition(t *testing.T) {
+	position := "00000000000000000012:mysql-bin.000012:00000000000000000345:00000000000000000000"
+	encoded := encodeCDCDestinationState(position, "0123456789abcdefabcd", 7)
+
+	decoded, incarnation, epoch, valid := decodeCDCDestinationState(encoded)
+	if !valid {
+		t.Fatal("MySQL destination state was rejected")
+	}
+	if decoded != position || incarnation != "0123456789abcdefabcd" || epoch != 7 {
+		t.Fatalf("decoded destination state = (%q, %q, %d), want (%q, %q, 7)", decoded, incarnation, epoch, position, "0123456789abcdefabcd")
+	}
+}
+
+func TestCDCStatePositionColumnIsUnbounded(t *testing.T) {
+	for _, column := range cdcStateSchema.Columns {
+		if column.Name == "_cdc_lsn" {
+			if column.MaxLength != 0 {
+				t.Fatalf("CDC state position MaxLength = %d, want unbounded", column.MaxLength)
+			}
+			return
+		}
+	}
+	t.Fatal("CDC state schema is missing _cdc_lsn")
+}
+
 func connectorStateCount(dest *cdcStateDestination, table, connectorID string) int {
 	dest.stateMu.Lock()
 	defer dest.stateMu.Unlock()
@@ -2104,4 +2216,29 @@ func assertCDCStatePruneBatchesBounded(t *testing.T, dest *cdcStateDestination) 
 			t.Fatalf("prune batch size = %d, want at most %d", size, cdcStatePruneBatchSize)
 		}
 	}
+}
+
+type migratingCDCStateDestination struct {
+	*cdcStateDestination
+	migrations int
+}
+
+func (d *migratingCDCStateDestination) EnsureCDCStatePositionColumn(_ context.Context, table string) error {
+	d.migrations++
+	delete(d.prepareErrByTable, table)
+	return nil
+}
+
+func TestCDCStatePrepareRetriesThroughPositionMigration(t *testing.T) {
+	ctx := context.Background()
+	dest := &migratingCDCStateDestination{cdcStateDestination: newCDCStateDestination()}
+	manager, err := NewCDCStateManager(dest, "widen-connector", "raw.orders", "")
+	require.NoError(t, err)
+
+	dest.prepareErrByTable = map[string]error{
+		manager.stateTable: errors.New(`bigquery table has incompatible column "_cdc_lsn": existing max length 64 is bounded, want unbounded`),
+	}
+	require.NoError(t, manager.RegisterTableState(ctx, "public.orders", "raw.orders", "", ""))
+	require.NoError(t, manager.BeginRun(ctx, false))
+	require.Equal(t, 1, dest.migrations, "prepare failure must be retried through the position migration exactly once")
 }

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -73,15 +73,16 @@ func prepareMergeTables(ctx context.Context, dest destination.Destination, p mer
 // mergeStagingInto merges the staging table into the target table by primary
 // key. A non-empty incrementalKey makes the per-PK dedup keep the row with the
 // highest value of that key (latest wins) instead of an arbitrary one.
-func mergeStagingInto(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey, incrementalPredicate string) error {
+func mergeStagingInto(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey, incrementalPredicate, expectedIncarnation string) error {
 	return dest.MergeTable(ctx, destination.MergeOptions{
-		StagingTable:         stagingTable,
-		TargetTable:          targetTable,
-		PrimaryKeys:          primaryKeys,
-		Columns:              destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
-		IncrementalKey:       mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
-		IncrementalPredicate: incrementalPredicate,
-		Schema:               tableSchema,
+		StagingTable:           stagingTable,
+		TargetTable:            targetTable,
+		PrimaryKeys:            primaryKeys,
+		Columns:                destination.MergeColumnsFor(dest, tableSchema.ColumnNames()),
+		IncrementalKey:         mergeIncrementalKeyForSchema(tableSchema, incrementalKey),
+		IncrementalPredicate:   incrementalPredicate,
+		Schema:                 tableSchema,
+		CDCExpectedIncarnation: expectedIncarnation,
 	})
 }
 
@@ -181,10 +182,16 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	}); err != nil {
 		return err
 	}
+	expectedIncarnation := ""
 	if job.CDCStateManager != nil {
 		if err := job.CDCStateManager.BindDestinationIncarnation(ctx, job.Config.SourceTable, job.Config.DestTable); err != nil {
 			return fmt.Errorf("failed to bind CDC destination before merge: %w", err)
 		}
+		boundIncarnation, err := job.CDCStateManager.BoundDestinationIncarnation(job.Config.SourceTable)
+		if err != nil {
+			return err
+		}
+		expectedIncarnation = boundIncarnation
 	}
 
 	// Read from source
@@ -262,8 +269,14 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
 		}
-		if err := destination.ApplyCDCTruncate(ctx, job.Destination, job.Config.DestTable); err != nil {
-			return err
+		var truncateErr error
+		if expectedIncarnation != "" && destination.SupportsCDCConditionalTruncate(job.Destination) {
+			truncateErr = destination.ApplyCDCTruncateIfIncarnation(ctx, job.Destination, job.Config.DestTable, expectedIncarnation)
+		} else {
+			truncateErr = destination.ApplyCDCTruncate(ctx, job.Destination, job.Config.DestTable)
+		}
+		if truncateErr != nil {
+			return truncateErr
 		}
 		if err := source.ConnectorLeaseLoss(ctx); err != nil {
 			return err
@@ -272,7 +285,7 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if err := mergeStagingInto(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, job.Config.IncrementalKey, job.Config.IncrementalPredicate); err != nil {
+	if err := mergeStagingInto(ctx, job.Destination, stagingTable, job.Config.DestTable, job.Config.PrimaryKeys, job.Schema, job.Config.IncrementalKey, job.Config.IncrementalPredicate, expectedIncarnation); err != nil {
 		return fmt.Errorf("failed to merge data: %w", err)
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -485,6 +498,15 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 				// Append-only change-log table: rows were written directly.
 				return
 			}
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				var err error
+				expectedIncarnation, err = job.CDCStateManager.BoundDestinationIncarnation(ti.Name)
+				if err != nil {
+					mergeErrChan <- err
+					return
+				}
+			}
 			if err := source.ConnectorLeaseLoss(ctx); err != nil {
 				mergeErrChan <- err
 				return
@@ -494,8 +516,14 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 					mergeErrChan <- err
 					return
 				}
-				if err := destination.ApplyCDCTruncate(ctx, job.Destination, destTable); err != nil {
-					mergeErrChan <- fmt.Errorf("failed to reset CDC target %s: %w", ti.Name, err)
+				var truncateErr error
+				if expectedIncarnation != "" && destination.SupportsCDCConditionalTruncate(job.Destination) {
+					truncateErr = destination.ApplyCDCTruncateIfIncarnation(ctx, job.Destination, destTable, expectedIncarnation)
+				} else {
+					truncateErr = destination.ApplyCDCTruncate(ctx, job.Destination, destTable)
+				}
+				if truncateErr != nil {
+					mergeErrChan <- fmt.Errorf("failed to reset CDC target %s: %w", ti.Name, truncateErr)
 					return
 				}
 				if err := source.ConnectorLeaseLoss(ctx); err != nil {
@@ -507,7 +535,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 				mergeErrChan <- err
 				return
 			}
-			if err := mergeStagingInto(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, ti.Schema, "", ""); err != nil {
+			if err := mergeStagingInto(ctx, job.Destination, stagingTable, destTable, ti.PrimaryKeys, ti.Schema, "", "", expectedIncarnation); err != nil {
 				mergeErrChan <- fmt.Errorf("failed to merge table %s: %w", ti.Name, err)
 				return
 			}

--- a/pkg/strategy/merge_delete_insert_test.go
+++ b/pkg/strategy/merge_delete_insert_test.go
@@ -95,6 +95,37 @@ func TestMergeStrategy_Execute_HappyPath(t *testing.T) {
 	}
 }
 
+func TestMergeStrategyPropagatesBoundDestinationIncarnation(t *testing.T) {
+	job, src, _ := minimalJob()
+	job.Config.IncrementalStrategy = config.StrategyMerge
+	job.Config.PrimaryKeys = []string{"id"}
+	src.readCh = mustClosedRecords()
+	dest := newCDCStateDestination()
+	dest.incarnations[job.Config.DestTable] = "physical-target-42"
+	manager, err := NewCDCStateManager(dest, "merge-incarnation", job.Config.DestTable, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.RegisterTable(context.Background(), job.Config.SourceTable, job.Config.DestTable); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.BeginRun(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	job.Destination = dest
+	job.CDCStateManager = manager
+
+	if err := (&MergeStrategy{}).Execute(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	if len(dest.mergeCalls) != 1 {
+		t.Fatalf("merge calls = %d, want 1", len(dest.mergeCalls))
+	}
+	if got := dest.mergeCalls[0].CDCExpectedIncarnation; got != "physical-target-42" {
+		t.Fatalf("CDCExpectedIncarnation = %q, want physical-target-42", got)
+	}
+}
+
 func TestMergeStrategy_LeaseLossAfterStagingWriteSkipsLaterMutations(t *testing.T) {
 	job, src, base := minimalJob()
 	job.Config.IncrementalStrategy = config.StrategyMerge

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -185,6 +185,56 @@ func deduplicateStaging(ctx context.Context, dest destination.Destination, rawTa
 
 type ReplaceStrategy struct{}
 
+func bindCDCReplaceTarget(ctx context.Context, manager *CDCStateManager, dest destination.Destination, sourceTable, destTable string) (string, error) {
+	if manager == nil {
+		return "", nil
+	}
+	capable, ok := dest.(destination.CDCConditionalSwapCapable)
+	if !ok || !capable.SupportsCDCConditionalSwap() {
+		if dest.GetScheme() == "mysql" {
+			return "", fmt.Errorf("MySQL CDC full refresh requires atomic target-incarnation fencing for swaps")
+		}
+		return "", nil
+	}
+	if _, ok := dest.(destination.CDCConditionalSwapPlanner); !ok {
+		return "", fmt.Errorf("destination scheme %q cannot plan a conditionally fenced CDC swap", dest.GetScheme())
+	}
+	if provider, ok := dest.(destination.CDCTargetIncarnationProvider); ok {
+		_, exists, err := provider.CDCTargetIncarnation(ctx, destTable)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			// Nothing to fence: the target does not exist yet (only the
+			// MySQL-CDC pipeline pre-creates targets) and the swap creates it.
+			return "", nil
+		}
+	}
+	if err := manager.BindDestinationIncarnation(ctx, sourceTable, destTable); err != nil {
+		return "", err
+	}
+	return manager.BoundDestinationIncarnation(sourceTable)
+}
+
+func prepareCDCConditionalSwap(ctx context.Context, dest destination.Destination, targetTable, stagingTable, expectedTarget string) (destination.SwapOptions, error) {
+	opts := destination.SwapOptions{StagingTable: stagingTable, TargetTable: targetTable}
+	if expectedTarget == "" {
+		return opts, nil
+	}
+	planner, ok := dest.(destination.CDCConditionalSwapPlanner)
+	if !ok {
+		return destination.SwapOptions{}, fmt.Errorf("destination scheme %q cannot plan a conditionally fenced CDC swap", dest.GetScheme())
+	}
+	stagingIncarnation, resultIncarnation, err := planner.CDCConditionalSwapIncarnations(ctx, targetTable, stagingTable)
+	if err != nil {
+		return destination.SwapOptions{}, err
+	}
+	opts.CDCExpectedIncarnation = expectedTarget
+	opts.CDCExpectedStagingIncarnation = stagingIncarnation
+	opts.CDCExpectedResultIncarnation = resultIncarnation
+	return opts, nil
+}
+
 func replaceStagingTableName(dest destination.Destination, targetTable, stagingDataset string) string {
 	policy := defaultReplaceStagingPolicy()
 	if provider, ok := dest.(destination.ReplaceStagingPolicyProvider); ok {
@@ -246,6 +296,10 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 
 	if err := job.Destination.PrepareTable(ctx, prepareOpts); err != nil {
 		return fmt.Errorf("failed to prepare table: %w", err)
+	}
+	expectedTargetIncarnation, err := bindCDCReplaceTarget(ctx, job.CDCStateManager, job.Destination, job.Config.SourceTable, targetTable)
+	if err != nil {
+		return fmt.Errorf("failed to bind CDC destination before replace: %w", err)
 	}
 
 	parallelism := job.Config.ExtractParallelism
@@ -346,17 +400,23 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 			swapPrimaryKeys = nil
 		}
 
-		if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-			StagingTable:   swapTable,
-			TargetTable:    targetTable,
-			PrimaryKeys:    swapPrimaryKeys,
-			IncrementalKey: job.Config.IncrementalKey,
-			Schema:         job.Schema,
-		}); err != nil {
+		swapOpts, err := prepareCDCConditionalSwap(ctx, job.Destination, targetTable, swapTable, expectedTargetIncarnation)
+		if err != nil {
+			return err
+		}
+		swapOpts.PrimaryKeys = swapPrimaryKeys
+		swapOpts.IncrementalKey = job.Config.IncrementalKey
+		swapOpts.Schema = job.Schema
+		if err := job.Destination.SwapTable(ctx, swapOpts); err != nil {
 			if dropErr := job.Destination.DropTable(ctx, swapTable); dropErr != nil {
 				config.Debug("[REPLACE] Warning: failed to drop staging table: %v", dropErr)
 			}
 			return fmt.Errorf("failed to swap tables: %w", err)
+		}
+		if expectedTargetIncarnation != "" {
+			if err := job.CDCStateManager.CompleteConditionalSwap(ctx, job.Config.SourceTable, targetTable, expectedTargetIncarnation, swapOpts.CDCExpectedResultIncarnation); err != nil {
+				return fmt.Errorf("failed to bind CDC destination after replace: %w", err)
+			}
 		}
 	}
 
@@ -388,6 +448,7 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 
 	stagingTables := make(map[string]string)
 	tableConfigs := make(map[string]destination.TableWriteConfig)
+	expectedTargetIncarnations := make(map[string]string)
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
@@ -417,9 +478,15 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 				errChan <- fmt.Errorf("failed to prepare table %s: %w", ti.Name, err)
 				return
 			}
+			expectedTarget, err := bindCDCReplaceTarget(ctx, job.CDCStateManager, job.Destination, ti.Name, destTable)
+			if err != nil {
+				errChan <- fmt.Errorf("failed to bind CDC destination table %s before replace: %w", ti.Name, err)
+				return
+			}
 
 			mu.Lock()
 			stagingTables[ti.Name] = writeTable
+			expectedTargetIncarnations[ti.Name] = expectedTarget
 			tableConfigs[ti.Name] = destination.TableWriteConfig{
 				DestTable: writeTable,
 				Schema:    ti.Schema,
@@ -494,13 +561,20 @@ func (s *ReplaceStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTable
 				swapPrimaryKeys = nil
 			}
 
-			if err := job.Destination.SwapTable(ctx, destination.SwapOptions{
-				StagingTable: swapTable,
-				TargetTable:  destTable,
-				PrimaryKeys:  swapPrimaryKeys,
-				Schema:       tableInfo.Schema,
-			}); err != nil {
+			expectedTarget := expectedTargetIncarnations[tableInfo.Name]
+			swapOpts, err := prepareCDCConditionalSwap(ctx, job.Destination, destTable, swapTable, expectedTarget)
+			if err != nil {
+				return fmt.Errorf("failed to plan conditional swap for table %s: %w", tableInfo.Name, err)
+			}
+			swapOpts.PrimaryKeys = swapPrimaryKeys
+			swapOpts.Schema = tableInfo.Schema
+			if err := job.Destination.SwapTable(ctx, swapOpts); err != nil {
 				return fmt.Errorf("failed to swap table %s: %w", tableInfo.Name, err)
+			}
+			if expectedTarget != "" {
+				if err := job.CDCStateManager.CompleteConditionalSwap(ctx, tableInfo.Name, destTable, expectedTarget, swapOpts.CDCExpectedResultIncarnation); err != nil {
+					return fmt.Errorf("failed to bind CDC destination table %s after replace: %w", tableInfo.Name, err)
+				}
 			}
 		}
 	}

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -603,6 +603,7 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 		return fmt.Errorf("source requested truncate for unknown table %q", res.TableName)
 	}
 	stateTable := ""
+	expectedIncarnation := ""
 	if l.opts.StateManager != nil {
 		stateTable = l.stateSourceTable(res.TableName)
 		if stateTable == "" {
@@ -626,12 +627,19 @@ func (l *flushLoop) handleResult(ctx context.Context, res source.RecordBatchResu
 		if err := l.opts.StateManager.BindDestinationIncarnation(ctx, stateTable, st.destTable); err != nil {
 			return fmt.Errorf("failed to bind CDC destination before source truncate for %s: %w", stateTable, err)
 		}
+		boundIncarnation, err := l.opts.StateManager.BoundDestinationIncarnation(stateTable)
+		if err != nil {
+			return err
+		}
+		expectedIncarnation = boundIncarnation
 	}
 	if err := connectorLeaseLoss(ctx); err != nil {
 		return err
 	}
 	var truncateErr error
-	if res.CDCWALTruncate {
+	if expectedIncarnation != "" && destination.SupportsCDCConditionalTruncate(l.dest) {
+		truncateErr = destination.ApplyCDCTruncateIfIncarnation(ctx, l.dest, st.destTable, expectedIncarnation)
+	} else if res.CDCWALTruncate {
 		truncateErr = destination.ApplyCDCTruncate(ctx, l.dest, st.destTable)
 	} else {
 		truncateErr = destination.ApplyTruncate(ctx, l.dest, st.destTable)
@@ -850,15 +858,21 @@ func (l *flushLoop) flush(ctx context.Context) error {
 	}
 	start := time.Now()
 	loadTimestamp := start.UTC().Truncate(time.Microsecond)
+	boundSourceTables := make(map[string]string)
 	if l.opts.StateManager != nil {
-		for sourceTable := range l.pendingState.SnapshotPositions {
-			st, ok := l.tableState(sourceTable)
-			if !ok {
-				return fmt.Errorf("CDC snapshot state references unknown table %q", sourceTable)
+		for recordTable, st := range l.tables {
+			sourceTable := l.stateSourceTable(recordTable)
+			if sourceTable == "" {
+				var err error
+				sourceTable, err = l.opts.StateManager.SourceTableForDestination(st.destTable)
+				if err != nil {
+					return err
+				}
 			}
 			if err := l.opts.StateManager.BindDestinationIncarnation(ctx, sourceTable, st.destTable); err != nil {
 				return fmt.Errorf("streaming flush: failed to bind CDC destination for %s: %w", sourceTable, err)
 			}
+			boundSourceTables[recordTable] = sourceTable
 		}
 	}
 
@@ -939,7 +953,15 @@ func (l *flushLoop) flush(ctx context.Context) error {
 			if err := connectorLeaseLoss(ctx); err != nil {
 				return err
 			}
-			if err := mergeStagingInto(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey, st.incrementalPredicate); err != nil {
+			expectedIncarnation := ""
+			if l.opts.StateManager != nil {
+				var err error
+				expectedIncarnation, err = l.opts.StateManager.BoundDestinationIncarnation(boundSourceTables[w.name])
+				if err != nil {
+					return err
+				}
+			}
+			if err := mergeStagingInto(ctx, l.dest, st.stagingTable, st.destTable, st.primaryKeys, st.schema, st.incrementalKey, st.incrementalPredicate, expectedIncarnation); err != nil {
 				return fmt.Errorf("streaming flush: failed to merge table %s: %w", displayName, err)
 			}
 			if err := connectorLeaseLoss(ctx); err != nil {

--- a/pkg/strategy/streaming_snapshot_invalidation_test.go
+++ b/pkg/strategy/streaming_snapshot_invalidation_test.go
@@ -49,6 +49,13 @@ func (d *orderedCDCStateDestination) TruncateTable(_ context.Context, table stri
 	return nil
 }
 
+func (d *orderedCDCStateDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expected string) error {
+	if err := d.cdcStateDestination.TruncateCDCTableIfIncarnation(ctx, table, expected); err != nil {
+		return err
+	}
+	return d.TruncateTable(ctx, table)
+}
+
 func (d *orderedCDCStateDestination) resetOrder() {
 	d.orderMu.Lock()
 	d.order = nil

--- a/tests/integration/mysql_cdc_regression_stress_test.go
+++ b/tests/integration/mysql_cdc_regression_stress_test.go
@@ -1,0 +1,604 @@
+//go:build stress
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/testutil"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/require"
+)
+
+const mysqlCDCRegressionTable = "cdc_regression_items"
+
+type mysqlCDCRegressionHarness struct {
+	sourceURI string
+	destURI   string
+	sourceDB  *sql.DB
+	destDB    *sql.DB
+}
+
+func newMySQLCDCRegressionHarness(t *testing.T, ctx context.Context, sourceOptions ...string) *mysqlCDCRegressionHarness {
+	t.Helper()
+
+	sourceCommand := []string{
+		"--server-id=21777",
+		"--log-bin=mysql-bin",
+		"--binlog-format=ROW",
+		"--binlog-row-image=FULL",
+		"--max-connections=100",
+	}
+	sourceCommand = append(sourceCommand, sourceOptions...)
+	_, sourceURI, sourceDSN := mysqlStressContainer(t, ctx, sourceCommand)
+	_, destURI, destDSN := mysqlStressContainer(t, ctx, []string{"--max-connections=100"})
+
+	return &mysqlCDCRegressionHarness{
+		sourceURI: mysqlCDCRegressionSourceURI(t, sourceURI),
+		destURI:   destURI,
+		sourceDB:  mysqlStressOpenDB(t, sourceDSN, 12),
+		destDB:    mysqlStressOpenDB(t, destDSN, 12),
+	}
+}
+
+func mysqlCDCRegressionSourceURI(t *testing.T, rawURI string) string {
+	t.Helper()
+	u, err := url.Parse(rawURI)
+	require.NoError(t, err)
+	u.Scheme = "mysql+cdc"
+	query := u.Query()
+	query.Set("server_id", "21999")
+	u.RawQuery = query.Encode()
+	return u.String()
+}
+
+func mysqlCDCRegressionURIParam(t *testing.T, rawURI, key, value string) string {
+	t.Helper()
+	u, err := url.Parse(rawURI)
+	require.NoError(t, err)
+	query := u.Query()
+	query.Set(key, value)
+	u.RawQuery = query.Encode()
+	return u.String()
+}
+
+func (h *mysqlCDCRegressionHarness) run(ctx context.Context) error {
+	return pipeline.New(&config.IngestConfig{
+		SourceURI:           h.sourceURI,
+		SourceTable:         mysqlCDCRegressionTable,
+		DestURI:             h.destURI,
+		DestTable:           mysqlCDCRegressionTable,
+		IncrementalStrategy: config.StrategyMerge,
+	}).Run(ctx)
+}
+
+func (h *mysqlCDCRegressionHarness) runFullRefresh(ctx context.Context) error {
+	return pipeline.New(&config.IngestConfig{
+		SourceURI:           h.sourceURI,
+		SourceTable:         mysqlCDCRegressionTable,
+		DestURI:             h.destURI,
+		DestTable:           mysqlCDCRegressionTable,
+		IncrementalStrategy: config.StrategyMerge,
+		FullRefresh:         true,
+	}).Run(ctx)
+}
+
+func (h *mysqlCDCRegressionHarness) activeCount(ctx context.Context) (int, error) {
+	var count int
+	err := h.destDB.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s WHERE `_cdc_deleted` = FALSE",
+		mysqlCDCRegressionTable,
+	)).Scan(&count)
+	return count, err
+}
+
+func TestMySQLCDC_StressCorrectnessRegressions(t *testing.T) {
+	ctx := context.Background()
+	if !testutil.DockerProviderHealthy(ctx) {
+		t.Skip("skipping stress test: Docker provider is not available/healthy")
+	}
+
+	t.Run("compressed transaction payload", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx, "--binlog-transaction-compression=ON")
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload MEDIUMTEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (0, 'seed')"))
+		require.NoError(t, h.run(ctx))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, "TRUNCATE TABLE performance_schema.binary_log_transaction_compression_stats"))
+
+		conn, err := h.sourceDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "SET SESSION binlog_transaction_compression = ON"))
+		tx, err := conn.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback() }()
+
+		for firstID := 1; firstID <= 200; firstID += 50 {
+			var query strings.Builder
+			query.WriteString("INSERT INTO cdc_regression_items (id, payload) VALUES ")
+			args := make([]interface{}, 0, 100)
+			for id := firstID; id < firstID+50; id++ {
+				if id > firstID {
+					query.WriteString(",")
+				}
+				query.WriteString("(?, ?)")
+				args = append(args, id, strings.Repeat(fmt.Sprintf("payload-%03d-", id), 100))
+			}
+			_, err = tx.ExecContext(ctx, query.String(), args...)
+			require.NoError(t, err)
+		}
+		require.NoError(t, tx.Commit())
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "SET SESSION binlog_transaction_compression = OFF"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn,
+			"INSERT INTO cdc_regression_items VALUES (1000, 'later-normal-event')"))
+
+		var compressedTransactions int64
+		require.NoError(t, h.sourceDB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(TRANSACTION_COUNTER), 0)
+			FROM performance_schema.binary_log_transaction_compression_stats
+			WHERE COMPRESSION_TYPE = 'ZSTD'
+		`).Scan(&compressedTransactions))
+		require.Positive(t, compressedTransactions, "test precondition: MySQL must write a compressed transaction payload")
+
+		require.NoError(t, h.run(ctx))
+		count, err := h.activeCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 202, count, "rows nested inside Transaction_payload_event must not be skipped by a later event")
+
+		rows, err := h.destDB.QueryContext(ctx, `
+			SELECT _cdc_lsn
+			FROM cdc_regression_items
+			WHERE id IN (1, 51, 101, 151) AND _cdc_deleted = FALSE
+			ORDER BY id
+		`)
+		require.NoError(t, err)
+		defer func() { _ = rows.Close() }()
+		var lsns []string
+		for rows.Next() {
+			var lsn string
+			require.NoError(t, rows.Scan(&lsn))
+			lsns = append(lsns, lsn)
+		}
+		require.NoError(t, rows.Err())
+		require.Len(t, lsns, 4)
+		for i := 1; i < len(lsns); i++ {
+			require.Less(t, lsns[i-1], lsns[i], "row sequence must advance across nested row events")
+		}
+	})
+
+	t.Run("truncate table", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'one'), (2, 'two'), (3, 'three')"))
+		require.NoError(t, h.run(ctx))
+
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, "TRUNCATE TABLE cdc_regression_items"))
+		require.NoError(t, h.run(ctx))
+		count, err := h.activeCount(ctx)
+		require.NoError(t, err)
+		require.Zero(t, count, "source TRUNCATE must empty the materialized destination")
+	})
+
+	t.Run("xa rollback", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (0, 'seed')"))
+		require.NoError(t, h.run(ctx))
+
+		conn, err := h.sourceDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "SET SESSION binlog_transaction_compression = ON"))
+		xid := "ingestr-xa-regression"
+		rolledBack := false
+		defer func() {
+			if !rolledBack {
+				_, _ = conn.ExecContext(context.Background(), "XA ROLLBACK '"+xid+"'")
+			}
+		}()
+
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA START '"+xid+"'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn,
+			"INSERT INTO cdc_regression_items VALUES (1, 'must-roll-back')"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA END '"+xid+"'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA PREPARE '"+xid+"'"))
+		require.NoError(t, h.run(ctx), "prepared XA rows should not make the CDC run fail")
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA ROLLBACK '"+xid+"'"))
+		rolledBack = true
+		require.NoError(t, h.run(ctx))
+
+		count, err := h.activeCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, count, "rows from a rolled-back XA transaction must not remain active")
+		var rolledBackRows int
+		require.NoError(t, h.destDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM cdc_regression_items WHERE id = 1 AND `_cdc_deleted` = FALSE").Scan(&rolledBackRows))
+		require.Zero(t, rolledBackRows, "the rolled-back XA row must not remain active")
+
+		onePhaseXID := "CaseSensitive-OnePhase"
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA START '"+onePhaseXID+"','branch',17"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn,
+			"INSERT INTO cdc_regression_items VALUES (2, 'one-phase-commit')"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA END '"+onePhaseXID+"','branch',17"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA COMMIT '"+onePhaseXID+"','branch',17 ONE PHASE"))
+		require.NoError(t, h.run(ctx))
+
+		var committedRows int
+		require.NoError(t, h.destDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM cdc_regression_items WHERE id = 2 AND `_cdc_deleted` = FALSE").Scan(&committedRows))
+		require.Equal(t, 1, committedRows, "a compressed one-phase XA commit must be applied")
+	})
+
+	t.Run("producer session uses noblob row image", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL,
+			counter INT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'keep-me', 1)"))
+		require.NoError(t, h.run(ctx))
+
+		conn, err := h.sourceDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "SET SESSION binlog_row_image = 'NOBLOB'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn,
+			"UPDATE cdc_regression_items SET counter = 2 WHERE id = 1"))
+
+		runErr := h.run(ctx)
+		require.Error(t, runErr, "unsafe producer-session row images must fail closed")
+		require.Contains(t, strings.ToLower(runErr.Error()), "row image")
+	})
+
+	t.Run("unresolved empty xa transactions are bounded", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		h.sourceURI = mysqlCDCRegressionURIParam(t, h.sourceURI, "xa_pending_limit", "2")
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE uncaptured_items (
+			id BIGINT NOT NULL PRIMARY KEY
+		)`))
+		require.NoError(t, h.run(ctx))
+		conn, err := h.sourceDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		xids := []string{"uncaptured-xa-1", "uncaptured-xa-2", "uncaptured-xa-3"}
+		defer func() {
+			for _, xid := range xids {
+				_, _ = h.sourceDB.ExecContext(context.Background(), "XA ROLLBACK '"+xid+"'")
+			}
+		}()
+		for i, xid := range xids {
+			require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA START '"+xid+"'"))
+			require.NoError(t, execMySQLCDCRegression(ctx, conn,
+				fmt.Sprintf("INSERT INTO uncaptured_items VALUES (%d)", i+1)))
+			require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA END '"+xid+"'"))
+			require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA PREPARE '"+xid+"'"))
+		}
+
+		err = h.run(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "xa_pending_limit")
+	})
+
+	t.Run("xa payload bytes are bounded", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		h.sourceURI = mysqlCDCRegressionURIParam(t, h.sourceURI, "xa_buffer_bytes_limit", "4096")
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload MEDIUMBLOB NULL
+		)`))
+		require.NoError(t, h.run(ctx))
+		conn, err := h.sourceDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		const smallXID = "small-xa-payload"
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA START '"+smallXID+"'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn,
+			"INSERT INTO cdc_regression_items VALUES (1, REPEAT('x', 128))"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA END '"+smallXID+"'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA COMMIT '"+smallXID+"' ONE PHASE"))
+		require.NoError(t, h.run(ctx), "fixed XA container overhead must fit below the payload budget")
+
+		const xid = "large-xa-payload"
+		rolledBack := false
+		defer func() {
+			if !rolledBack {
+				_, _ = h.sourceDB.ExecContext(context.Background(), "XA ROLLBACK '"+xid+"'")
+			}
+		}()
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA START '"+xid+"'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn,
+			"INSERT INTO cdc_regression_items VALUES (2, REPEAT('x', 4096))"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA END '"+xid+"'"))
+		require.NoError(t, execMySQLCDCRegression(ctx, conn, "XA PREPARE '"+xid+"'"))
+
+		runErr := h.run(ctx)
+		require.ErrorContains(t, runErr, "xa_buffer_bytes_limit")
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, "XA ROLLBACK '"+xid+"'"))
+		rolledBack = true
+	})
+
+	t.Run("resume lookup failure", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		h.destURI = mysqlCDCRegressionURIParam(t, h.destURI, "lock_wait_timeout", "1")
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'one'), (2, 'two')"))
+		require.NoError(t, h.run(ctx))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"DELETE FROM cdc_regression_items WHERE id = 2"))
+
+		lockConn, err := h.destDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = lockConn.Close() }()
+		require.NoError(t, execMySQLCDCRegression(ctx, lockConn, "LOCK TABLES `_bruin_staging`.`cdc_state` WRITE"))
+
+		runDone := make(chan error, 1)
+		go func() { runDone <- h.run(ctx) }()
+		waitForMySQLCDCStateQuery(t, ctx, h.destDB, runDone)
+		time.Sleep(1010 * time.Millisecond)
+		require.NoError(t, execMySQLCDCRegression(context.Background(), lockConn, "UNLOCK TABLES"))
+		runErr := <-runDone
+		require.Error(t, runErr, "a failed resume lookup must abort instead of falling back to a snapshot")
+		require.Regexp(t, `(?i)(resume|cursor|lsn|state)`, runErr.Error(), "the run should fail specifically at resume lookup")
+	})
+
+	t.Run("recovery snapshot replaces stale target", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'one'), (2, 'two')"))
+		require.NoError(t, h.run(ctx))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, "DELETE FROM cdc_regression_items"))
+
+		var connectorID string
+		var generation int64
+		require.NoError(t, h.destDB.QueryRowContext(ctx, `
+			SELECT connector_id, MAX(state_generation)
+			FROM _bruin_staging.cdc_state
+			GROUP BY connector_id
+		`).Scan(&connectorID, &generation))
+		runID := strings.Repeat("a", 32)
+		eventID := connectorID + "-" + runID + "-" + strings.Repeat("b", 64)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.destDB, `
+			INSERT INTO _bruin_staging.cdc_state
+				(event_id, state_version, connector_id, source_table, destination_table,
+				 state_kind, state_generation, state_status, _cdc_lsn, recorded_at)
+			VALUES (?, '2', ?, '', '', 'run', ?, 'in_progress', '00000000/00000000', CURRENT_TIMESTAMP(6))
+		`, eventID, connectorID, generation+1))
+
+		require.NoError(t, h.run(ctx))
+		count, err := h.activeCount(ctx)
+		require.NoError(t, err)
+		require.Zero(t, count, "a recovery snapshot must remove rows absent from an empty source snapshot")
+	})
+
+	t.Run("concurrent connector run is rejected", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, h.run(ctx))
+
+		var connectorID string
+		require.NoError(t, h.destDB.QueryRowContext(ctx, `
+			SELECT connector_id
+			FROM _bruin_staging.cdc_state
+			LIMIT 1
+		`).Scan(&connectorID))
+		lockConn, err := h.destDB.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { _ = lockConn.Close() }()
+		lockName := "ingestr_cdc_" + connectorID
+		var acquired int
+		require.NoError(t, lockConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&acquired))
+		require.Equal(t, 1, acquired)
+		defer func() {
+			var released sql.NullInt64
+			_ = lockConn.QueryRowContext(context.Background(), "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
+		}()
+
+		runErr := h.run(ctx)
+		require.ErrorContains(t, runErr, "already owns connector")
+	})
+
+	t.Run("full refresh uses a fenced atomic swap", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'one'), (2, 'two')"))
+		require.NoError(t, h.run(ctx))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"ALTER TABLE cdc_regression_items ADD COLUMN added INT NOT NULL DEFAULT 7"))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"DELETE FROM cdc_regression_items WHERE id = 2"))
+
+		require.NoError(t, h.runFullRefresh(ctx))
+		count, err := h.activeCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		var added int
+		require.NoError(t, h.destDB.QueryRowContext(ctx,
+			"SELECT added FROM cdc_regression_items WHERE id = 1 AND `_cdc_deleted` = FALSE").Scan(&added))
+		require.Equal(t, 7, added)
+	})
+
+	t.Run("partial target row skips earlier rows in one event", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, h.run(ctx))
+
+		binlogFile, beforePos := currentMySQLCDCRegressionPosition(t, ctx, h.sourceDB)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'one'), (2, 'two'), (3, 'three')"))
+		rowsEventEnd := mysqlCDCRegressionRowsEventEnd(t, ctx, h.sourceDB, binlogFile, beforePos)
+		lsn := formatMySQLCDCRegressionLSN(t, binlogFile, rowsEventEnd, 2)
+
+		require.NoError(t, execMySQLCDCRegression(ctx, h.destDB, `
+			INSERT INTO cdc_regression_items
+				(id, payload, _cdc_lsn, _cdc_deleted, _cdc_synced_at)
+			VALUES (?, 'three', ?, FALSE, CURRENT_TIMESTAMP(6))
+		`, 3, lsn))
+		require.NoError(t, h.run(ctx))
+
+		count, err := h.activeCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 3, count, "resuming from one durable row must not skip earlier rows from the same binlog event")
+	})
+
+	t.Run("legacy state position column is widened", func(t *testing.T) {
+		h := newMySQLCDCRegressionHarness(t, ctx)
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB, `CREATE TABLE cdc_regression_items (
+			id BIGINT NOT NULL PRIMARY KEY,
+			payload TEXT NULL
+		)`))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.sourceDB,
+			"INSERT INTO cdc_regression_items VALUES (1, 'one')"))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.destDB, "CREATE DATABASE `_bruin_staging`"))
+		require.NoError(t, execMySQLCDCRegression(ctx, h.destDB, `CREATE TABLE _bruin_staging.cdc_state (
+			event_id VARCHAR(128) NOT NULL,
+			state_version VARCHAR(16) NOT NULL,
+			connector_id VARCHAR(64) NOT NULL,
+			source_table VARCHAR(1000) NOT NULL,
+			destination_table VARCHAR(1000) NOT NULL,
+			state_kind VARCHAR(32) NOT NULL,
+			state_generation BIGINT NOT NULL,
+			state_status VARCHAR(32) NOT NULL,
+			_cdc_lsn VARCHAR(64) NOT NULL,
+			recorded_at TIMESTAMP(6) NOT NULL,
+			PRIMARY KEY (connector_id, event_id)
+		)`))
+
+		require.NoError(t, h.run(ctx))
+		var dataType string
+		require.NoError(t, h.destDB.QueryRowContext(ctx, `
+			SELECT DATA_TYPE
+			FROM information_schema.columns
+			WHERE table_schema = '_bruin_staging'
+			  AND table_name = 'cdc_state'
+			  AND column_name = '_cdc_lsn'
+		`).Scan(&dataType))
+		require.Equal(t, "text", strings.ToLower(dataType))
+	})
+}
+
+type mysqlCDCRegressionExecer interface {
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+}
+
+func execMySQLCDCRegression(ctx context.Context, execer mysqlCDCRegressionExecer, query string, args ...interface{}) error {
+	_, err := execer.ExecContext(ctx, query, args...)
+	return err
+}
+
+func waitForMySQLCDCStateQuery(t *testing.T, ctx context.Context, db *sql.DB, runDone <-chan error) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var count int
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM information_schema.PROCESSLIST
+			WHERE ID <> CONNECTION_ID()
+			  AND INFO LIKE '%cdc_state%'
+			  AND INFO LIKE '%connector_id%'
+		`).Scan(&count)
+		require.NoError(t, err)
+		if count > 0 {
+			return
+		}
+		select {
+		case err := <-runDone:
+			require.NoError(t, err, "pipeline exited before its resume query was blocked")
+			t.Fatal("pipeline exited before its resume query was observed")
+		case <-time.After(10 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for blocked CDC resume query")
+		}
+	}
+}
+
+func currentMySQLCDCRegressionPosition(t *testing.T, ctx context.Context, db *sql.DB) (string, uint64) {
+	t.Helper()
+	var file string
+	var pos uint64
+	var doDB, ignoreDB, gtid sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx, "SHOW MASTER STATUS").Scan(&file, &pos, &doDB, &ignoreDB, &gtid))
+	return file, pos
+}
+
+func mysqlCDCRegressionRowsEventEnd(t *testing.T, ctx context.Context, db *sql.DB, file string, from uint64) uint64 {
+	t.Helper()
+	query := fmt.Sprintf(
+		"SHOW BINLOG EVENTS IN '%s' FROM %d",
+		strings.ReplaceAll(file, "'", "''"),
+		from,
+	)
+	rows, err := db.QueryContext(ctx, query)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var rowsEventEnd uint64
+	for rows.Next() {
+		var logName, eventType string
+		var eventPos, endPos uint64
+		var serverID uint32
+		var info sql.NullString
+		require.NoError(t, rows.Scan(&logName, &eventPos, &eventType, &serverID, &endPos, &info))
+		if strings.Contains(strings.ToLower(eventType), "write_rows") {
+			rowsEventEnd = endPos
+		}
+	}
+	require.NoError(t, rows.Err())
+	require.NotZero(t, rowsEventEnd, "test precondition: multi-row INSERT must produce a rows event")
+	return rowsEventEnd
+}
+
+func formatMySQLCDCRegressionLSN(t *testing.T, file string, pos uint64, rowSeq int) string {
+	t.Helper()
+	dot := strings.LastIndex(file, ".")
+	require.NotEqual(t, -1, dot)
+	sequence, err := strconv.ParseUint(file[dot+1:], 10, 64)
+	require.NoError(t, err)
+	return fmt.Sprintf("%020d:%s:%020d:%020d", sequence, file, pos, rowSeq)
+}

--- a/tests/integration/mysql_cdc_test.go
+++ b/tests/integration/mysql_cdc_test.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -93,7 +92,7 @@ func insertMySQLCDCItems(t *testing.T, ctx context.Context, db *sql.DB, startID 
 	}
 }
 
-func TestMySQLCDC_SnapshotAndIncremental_SQLite(t *testing.T) {
+func TestMySQLCDC_SnapshotAndIncremental_MySQL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -124,33 +123,24 @@ func TestMySQLCDC_SnapshotAndIncremental_SQLite(t *testing.T) {
 	_, err = sourceDB.ExecContext(ctx, `UPDATE items SET big_unsigned = 18446744073709551615, updated_at = '2026-01-02 03:04:05' WHERE id = 5`)
 	require.NoError(t, err)
 
-	tmpDir, err := os.MkdirTemp("", "mysql_cdc_sqlite_*")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
-	sqlitePath := tmpDir + "/test.db"
-
 	cfg := &config.IngestConfig{
 		SourceURI:   mysqlCDCURI(t, sourceURI, map[string]string{"mode": "batch", "server_id": "18888"}),
 		SourceTable: "items",
-		DestURI:     "sqlite:///" + sqlitePath,
+		DestURI:     sourceURI,
 		DestTable:   "items_dest",
 	}
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 
-	dest, err := sql.Open("sqlite3", sqlitePath)
-	require.NoError(t, err)
-	defer func() { _ = dest.Close() }()
-
 	queryCount := func(query string) int {
 		t.Helper()
 		var n int
-		require.NoError(t, dest.QueryRow(query).Scan(&n))
+		require.NoError(t, sourceDB.QueryRow(query).Scan(&n))
 		return n
 	}
 
 	assert.Equal(t, initialRows, queryCount(`SELECT COUNT(*) FROM items_dest`))
-	assert.Equal(t, 0, queryCount(`SELECT COUNT(*) FROM items_dest WHERE "_cdc_deleted" = true`))
-	firstDistinctLSNs := queryCount(`SELECT COUNT(DISTINCT "_cdc_lsn") FROM items_dest`)
+	assert.Equal(t, 0, queryCount("SELECT COUNT(*) FROM items_dest WHERE `_cdc_deleted` = true"))
+	firstDistinctLSNs := queryCount("SELECT COUNT(DISTINCT `_cdc_lsn`) FROM items_dest")
 	assert.Equal(t, 1, firstDistinctLSNs)
 
 	_, err = sourceDB.ExecContext(ctx, `INSERT INTO items (id, name, value) VALUES (?, ?, ?)`, newID, fmt.Sprintf("item%d", newID), 400)
@@ -171,17 +161,14 @@ func TestMySQLCDC_SnapshotAndIncremental_SQLite(t *testing.T) {
 	require.NoError(t, pipeline.New(cfg).Run(ctxWithTimeout))
 
 	assert.Equal(t, initialRows+2, queryCount(`SELECT COUNT(*) FROM items_dest`))
-	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM items_dest WHERE id = 1 AND value = 150 AND "_cdc_deleted" = false`), "plain update should be applied")
-	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM items_dest WHERE id = 2 AND value = 200 AND "_cdc_deleted" = true`), "delete should be soft-applied")
-	assert.Equal(t, 1, queryCount(`SELECT COUNT(*) FROM items_dest WHERE id = 3 AND name = 'item3_final' AND value = 999 AND "_cdc_deleted" = true`), "update then delete should keep last values")
-	assert.Equal(t, 1, queryCount(fmt.Sprintf(`SELECT COUNT(*) FROM items_dest WHERE id = %d AND name = 'item%d' AND value = 400 AND "_cdc_deleted" = false`, newID, newID)), "insert should be applied")
-	assert.Greater(t, queryCount(`SELECT COUNT(DISTINCT "_cdc_lsn") FROM items_dest`), firstDistinctLSNs)
+	assert.Equal(t, 1, queryCount("SELECT COUNT(*) FROM items_dest WHERE id = 1 AND value = 150 AND `_cdc_deleted` = false"), "plain update should be applied")
+	assert.Equal(t, 1, queryCount("SELECT COUNT(*) FROM items_dest WHERE id = 2 AND value = 200 AND `_cdc_deleted` = true"), "delete should be soft-applied")
+	assert.Equal(t, 1, queryCount("SELECT COUNT(*) FROM items_dest WHERE id = 3 AND name = 'item3_final' AND value = 999 AND `_cdc_deleted` = true"), "update then delete should keep last values")
+	assert.Equal(t, 1, queryCount(fmt.Sprintf("SELECT COUNT(*) FROM items_dest WHERE id = %d AND name = 'item%d' AND value = 400 AND `_cdc_deleted` = false", newID, newID)), "insert should be applied")
+	assert.Greater(t, queryCount("SELECT COUNT(DISTINCT `_cdc_lsn`) FROM items_dest"), firstDistinctLSNs)
 
 	agreementIDs := fmt.Sprintf("(5, %d)", pathAgreementID)
-	// datetime() normalizes the destination's text representations (the merge
-	// path stores a trailing Z, the create path does not); the instants must
-	// still agree.
-	assert.Equal(t, 1, queryCount(`SELECT COUNT(DISTINCT datetime(updated_at)) FROM items_dest WHERE id IN `+agreementIDs), "snapshot and binlog rows must agree on TIMESTAMP instants despite the non-UTC server time zone")
+	assert.Equal(t, 1, queryCount(`SELECT COUNT(DISTINCT updated_at) FROM items_dest WHERE id IN `+agreementIDs), "snapshot and binlog rows must agree on TIMESTAMP instants despite the non-UTC server time zone")
 	assert.Equal(t, 1, queryCount(`SELECT COUNT(DISTINCT big_unsigned) FROM items_dest WHERE id IN `+agreementIDs), "snapshot and binlog rows must agree on BIGINT UNSIGNED values")
 	assert.Equal(t, 2, queryCount(`SELECT COUNT(*) FROM items_dest WHERE id IN `+agreementIDs+` AND big_unsigned > 9.3e18`), "BIGINT UNSIGNED must keep its unsigned range instead of clamping to MaxInt64 or wrapping negative")
 }


### PR DESCRIPTION
## What
Hardens MySQL CDC against concurrent runs, table replacement, mixed protocol rows, schema drift, and interrupted snapshots.

## Changes
- Adds durable run leases, atomic target claims, incarnation-checked mutations, safer checkpoints, and cross-destination CDC state column widening
- Strengthens binlog decoding and lifecycle handling, with unit, stress, integration, and BigQuery live coverage

## How to test
1. `make format`
2. `make lint`
3. `make test`
4. `make cdc-mysql-stress-test`

## Risk & rollback
- **Risk:** Medium — CDC coordination, decoding, and state persistence paths change
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (`make cdc-mysql-stress-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None
