### PR TITLE
Fix flaky NATS integration test container connect

### DIFF
--- a/tests/integration/streaming_platform_sources_test.go
+++ b/tests/integration/streaming_platform_sources_test.go
@@ -310,7 +310,7 @@ func startNATSContainer(t *testing.T, ctx context.Context) string {
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("4222/tcp"),
 			wait.ForLog("Server is ready"),
-		).WithStartupTimeout(60 * time.Second),
+		).WithDeadline(60 * time.Second),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/tests/integration/streaming_platform_sources_test.go
+++ b/tests/integration/streaming_platform_sources_test.go
@@ -307,7 +307,10 @@ func startNATSContainer(t *testing.T, ctx context.Context) string {
 		Image:        "nats:2.10-alpine",
 		ExposedPorts: []string{"4222/tcp"},
 		Cmd:          []string{"-js"},
-		WaitingFor:   wait.ForListeningPort("4222/tcp").WithStartupTimeout(60 * time.Second),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort("4222/tcp"),
+			wait.ForLog("Server is ready"),
+		).WithStartupTimeout(60 * time.Second),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -325,8 +328,15 @@ func startNATSContainer(t *testing.T, ctx context.Context) string {
 
 func newNATSClient(t *testing.T, natsURI string) (*natsgo.Conn, natsgo.JetStreamContext) {
 	t.Helper()
-	nc, err := natsgo.Connect(natsURI)
-	require.NoError(t, err)
+	var nc *natsgo.Conn
+	require.Eventually(t, func() bool {
+		conn, err := natsgo.Connect(natsURI)
+		if err != nil {
+			return false
+		}
+		nc = conn
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "connect to NATS test container")
 	js, err := nc.JetStream()
 	require.NoError(t, err)
 	return nc, js


### PR DESCRIPTION
## Problem

The NATS integration tests (`TestNATS_Streaming`, `TestNATS_BatchCutoff`) intermittently failed in CI with `EOF` on the first client connect:

```
Error: Received unexpected error: EOF
    streaming_platform_sources_test.go:329 (newNATSClient)
```

`wait.ForListeningPort("4222/tcp")` declares the container ready the instant the TCP port opens, but the NATS server (and the Docker/OrbStack port-forward proxy) can accept a connection and then reset it mid-handshake during startup — surfacing as `EOF`. Waiting longer doesn't help; the first connect needs to ride out that startup window.
