### PR TITLE
pipeline: fail fast when multi-table CDC lacks a destination namespace

### DIFF
--- a/pkg/destination/namespace.go
+++ b/pkg/destination/namespace.go
@@ -1,0 +1,18 @@
+package destination
+
+import "github.com/bruin-data/ingestr/pkg/tablename"
+
+// namespaceRequiringSchemes lists destinations that reject bare, unqualified
+// table names. Multi-table CDC synthesizes names for these destinations from
+// dest_schema, so a run against one of them cannot proceed without a namespace.
+var namespaceRequiringSchemes = map[string]tablename.Capability{
+	"bigquery":   tablename.BigQuery,
+	"databricks": tablename.Databricks,
+}
+
+// RequiresNamespace reports whether scheme rejects unqualified table names,
+// returning the capability describing its accepted name format.
+func RequiresNamespace(scheme string) (tablename.Capability, bool) {
+	c, ok := namespaceRequiringSchemes[scheme]
+	return c, ok
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2425,7 +2425,8 @@ func validateMultiTableNamespace(cfg *config.IngestConfig, dest destination.Dest
 	namespace := capability.Labels[1]
 	return fmt.Errorf(
 		"multi-table CDC to %s requires a %s: add ?dest_schema=<%s> to the source URI, or a default %s to the destination URI",
-		dest.GetScheme(), namespace, namespace, namespace)
+		dest.GetScheme(), namespace, namespace, namespace,
+	)
 }
 
 func managedCDCDestinationTarget(cfg *config.IngestConfig, dest destination.Destination) string {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -145,6 +145,9 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	destinationTarget := ""
 	if isPostgresCDCSource(p.config.SourceURI) {
 		destinationTarget = managedCDCDestinationTarget(p.config, dest)
+		if err := validateMultiTableNamespace(p.config, dest, destinationTarget); err != nil {
+			return err
+		}
 		destinationIdentity, err := managedCDCDestinationIdentity(ctx, dest, destinationTarget)
 		if err != nil {
 			return fmt.Errorf("failed to resolve PostgreSQL CDC destination identity: %w", err)
@@ -2402,6 +2405,27 @@ func managedCDCDestinationIdentity(ctx context.Context, dest destination.Destina
 		return target, nil
 	}
 	return provider.CanonicalCDCTarget(ctx, target)
+}
+
+// validateMultiTableNamespace rejects a multi-table CDC run whose destination
+// requires a namespace that neither dest_schema nor the destination URI
+// supplies. Left to the destination, the failure names an internal synthesized
+// table instead of the setting the user has to change.
+func validateMultiTableNamespace(cfg *config.IngestConfig, dest destination.Destination, target string) error {
+	if cfg.SourceTable != "" {
+		return nil
+	}
+	if cfg.DestTable != "" {
+		output.Warnf("Warning: --dest-table=%s is ignored in multi-table CDC mode; use ?dest_schema= on the source URI\n", cfg.DestTable)
+	}
+	capability, ok := destination.RequiresNamespace(dest.GetScheme())
+	if !ok || capability.CheckName(target) == nil {
+		return nil
+	}
+	namespace := capability.Labels[1]
+	return fmt.Errorf(
+		"multi-table CDC to %s requires a %s: add ?dest_schema=<%s> to the source URI, or a default %s to the destination URI",
+		dest.GetScheme(), namespace, namespace, namespace)
 }
 
 func managedCDCDestinationTarget(cfg *config.IngestConfig, dest destination.Destination) string {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3198,3 +3198,55 @@ func TestApplyPartitionNaming(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMultiTableNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		scheme      string
+		sourceTable string
+		target      string
+		wantErr     string
+	}{
+		{
+			name:    "bigquery without dataset is rejected",
+			scheme:  "bigquery",
+			target:  "__ingestr_cdc_namespace__",
+			wantErr: "multi-table CDC to bigquery requires a dataset",
+		},
+		{
+			name:   "bigquery with dest_schema is accepted",
+			scheme: "bigquery",
+			target: "raw.__ingestr_cdc_namespace__",
+		},
+		{
+			name:    "databricks without schema is rejected",
+			scheme:  "databricks",
+			target:  "__ingestr_cdc_namespace__",
+			wantErr: "multi-table CDC to databricks requires a schema",
+		},
+		{
+			name:   "postgres allows unqualified names",
+			scheme: "postgres",
+			target: "__ingestr_cdc_namespace__",
+		},
+		{
+			name:        "single-table mode is not checked",
+			scheme:      "bigquery",
+			sourceTable: "public.users",
+			target:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := &mockDestination{scheme: tt.scheme}
+			cfg := &config.IngestConfig{SourceTable: tt.sourceTable}
+			err := validateMultiTableNamespace(cfg, dest, tt.target)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Multi-table CDC derives destination table names from the `dest_schema` query parameter on the source URI. When neither `dest_schema` nor the destination URI supplies a namespace, destinations that require one (BigQuery, Databricks) receive a bare, unqualified name and reject it deep in the destination layer:

```
failed to resolve PostgreSQL CDC destination identity: BigQuery table name
must include dataset (format: [project.]dataset.table), got: __ingestr_cdc_namespace__
```

The message names an internal synthesized table the user never wrote, and says nothing about `dest_schema`.

This is the default configuration rather than an edge case. The documented BigQuery URI (`bigquery://<project>?credentials_path=...`) carries no dataset, because single-table runs take it from `--dest-table`. In multi-table mode `--dest-table` is ignored, so both sources of a namespace are absent at once.

## Change

Validate the resolved CDC target immediately after it is computed and before the destination identity is resolved, reporting the parameter to set:

```
multi-table CDC to bigquery requires a dataset: add ?dest_schema=<dataset>
to the source URI, or a default dataset to the destination URI
```

`RequiresNamespace` in `pkg/destination` maps a scheme to its `tablename.Capability`, so the check generalizes beyond BigQuery and the message adapts per destination ("dataset" for BigQuery, "schema" for Databricks). Destinations that accept unqualified names, such as Postgres, are unaffected.

A separate warning covers `--dest-table` passed in multi-table mode, where it silently has no effect.

## Notes

- No behavioral change to runs that already work; this only replaces a failure with a clearer one.
- The original failure occurred before slot creation, publication reconcile, and any writes, so no leaked replication slots or partial data were involved. This is an error-reporting fix, not a correctness fix.
- The `--dest-table` warning currently only fires on the Postgres CDC path, since that is where the validation hook sits. Extending it to all CDC sources would need a separate check earlier in `Run`.