### PR TITLE
cdc: warn when dest_schema is ignored in single-table mode

### DIFF
--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -70,7 +70,11 @@ How quickly a change is noticed depends on the table. A busy table surfaces it r
 
 ### Multi-table CDC
 
-If you omit `--source-table`, most CDC connectors run in multi-table mode and replicate every eligible table in the source's capture set. Each table is snapshotted and streamed from its own position; a multi-table run is not a single global point-in-time snapshot across all tables, but each table is individually consistent. Use `--dest-schema` (or `dest_schema` in the URI) to control where multi-table output lands.
+If you omit `--source-table`, most CDC connectors run in multi-table mode and replicate every eligible table in the source's capture set. Each table is snapshotted and streamed from its own position; a multi-table run is not a single global point-in-time snapshot across all tables, but each table is individually consistent. Use the `dest_schema` URI parameter to control where multi-table output lands. It applies to multi-table runs only: once `--source-table` is set, the destination comes from `--dest-table` and `dest_schema` is ignored.
+
+```plaintext
+postgres+cdc://user:pass@host:5432/mydb?dest_schema=analytics
+```
 
 For PostgreSQL, a schema change to a table already in the stream is handled in process, as described above. A brand-new table showing up is a bigger event: a one-shot run simply picks it up on its next start, but a running stream can't snapshot it mid-flight — when the periodic check finds one, the stream stops cleanly before touching any destination data and expects whatever supervises it (systemd, Kubernetes, a scheduler) to start it again. The restarted process snapshots the new table and then continues from the WAL still held by the existing slot, so no changes are missed in between. If you manage the publication yourself, remember to add the new table to it — ingestr won't do it for you.
 

--- a/docs/supported-sources/mongodb.md
+++ b/docs/supported-sources/mongodb.md
@@ -174,6 +174,9 @@ ingestr ingest \
 
 This path reads a consistent snapshot of the collection first, then follows the change stream for inserts, updates, and deletes. It produces the `_cdc_lsn` (a change-stream resume token), `_cdc_deleted`, and `_cdc_synced_at` metadata columns and resumes from the stored token on subsequent runs. Incremental runs use the `merge` strategy so changes are applied by `_id`; deletes are soft (`_cdc_deleted = true`, and because MongoDB delete events carry only the `_id`, the row's other values are left untouched). Run with `--full-refresh` to rebuild from a fresh snapshot, or `--stream` to ingest continuously instead of once per invocation.
 
+CDC URI parameters:
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
+
 Requirements:
 - Change streams require a **replica set** (or sharded cluster); they aren't available on a standalone `mongod`. Atlas clusters already satisfy this.
 - As a schema-less source, MongoDB CDC infers the destination schema from the documents it reads (see [schema inference](/getting-started/core-concepts.md)); nested documents and arrays land as JSON.

--- a/docs/supported-sources/mssql.md
+++ b/docs/supported-sources/mssql.md
@@ -79,6 +79,7 @@ Requirements:
 
 CDC URI parameters:
 - `capture_instance`: optional capture-instance name; defaults to the single instance registered for the table.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
 
 For a full walkthrough — enabling CDC and replicating a table into DuckDB — see [Replicate SQL Server to DuckDB with CDC](/tutorials/cdc-sqlserver-duckdb.md).
 

--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -70,7 +70,7 @@ Requirements:
 CDC URI parameters:
 - `mode`: `batch`; defaults to `batch`.
 - `server_id`: optional positive uint32 replication server id; generated automatically when omitted. Pin a unique value for scheduled or overlapping CDC runs.
-- `dest_schema`: optional destination schema for multi-table CDC runs.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
 - `flavor`: `mysql` or `mariadb`; inferred from the URI scheme unless overridden.
 
 Multi-table CDC snapshots each selected table independently and then stream each table from its own snapshot position. Each table is consistent on its own, but a multi-table run is not a single global point-in-time snapshot across all tables.

--- a/docs/supported-sources/planetscale.md
+++ b/docs/supported-sources/planetscale.md
@@ -70,7 +70,7 @@ psdbconnect performs a per-shard snapshot first (resumable by primary key) and t
 
 CDC URI parameters:
 - `tls`: auto-enabled for the `ps_mysql://` scheme; set it explicitly only to choose a different mode (see [TLS](#tls)).
-- `dest_schema`: optional destination schema for multi-table CDC runs.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
 
 Requirements:
 - PlanetScale database credentials (`user:password`) with read access to the branch/keyspace.

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -35,7 +35,7 @@ CDC-specific URI parameters (all optional):
 - `slot`: the replication slot name. When omitted, ingestr derives a stable name from the publication.
 - `state_id`: an optional stable identity for this logical connector. Ingestr otherwise derives one from the source, destination, slot/publication, and table configuration. Set it when multiple otherwise-identical CDC connectors write to the same destination and must keep independent state.
 - `mode`: **deprecated and ignored.** Continuous ingestion is controlled by `--stream`. `mode=batch` is accepted as a no-op; `mode=stream` is rejected unless `--stream` is also passed.
-- `dest_schema`: a schema/dataset prefix for destination table names.
+- `dest_schema`: optional destination schema/dataset for multi-table CDC runs. It is ignored when `--source-table` is set; in that case the destination is `--dest-table` (defaulting to the source table name), which must carry its own schema/dataset qualifier.
 - `discover_interval`: how often a running stream re-checks the source for new tables (default `30s`, e.g. `1m`, `10s`). Set to `0` or `off` to disable mid-stream discovery.
 
 Without `--source-table`, CDC runs in multi-table mode and replicates every table in the publication. Deletes are soft: rows are kept in the destination with `_cdc_deleted = true`.

--- a/docs/supported-sources/vitess.md
+++ b/docs/supported-sources/vitess.md
@@ -50,7 +50,7 @@ Vitess CDC URI parameters:
 - `grpc_host`: optional vtgate gRPC host; defaults to the host in the URI.
 - `grpc_tls`: optional override for the gRPC connection's TLS, independent of `tls`. `true` verifies the server certificate, `skip-verify` skips verification, `false` forces plaintext. When omitted, the gRPC connection inherits `tls` (`true`/`skip-verify` enable it; `preferred` and custom CA names do not).
 - `mode`: `batch`; defaults to `batch`.
-- `dest_schema`: optional destination schema for multi-table CDC runs.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
 
 Requirements:
 - The vtgate gRPC endpoint must be reachable (`grpc_port`, plus `grpc_host` if it differs from the MySQL host).

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -207,6 +207,9 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 			return p.runMultiTable(ctx, mtSource)
 		}
 	}
+	if hasIgnoredDestSchema(p.config) {
+		output.Warnf("Warning: dest_schema is ignored when --source-table is set; the destination is %q. Omit --source-table for multi-table mode, or qualify --dest-table instead\n", p.config.DestTable)
+	}
 	sourceIncarnation := ""
 	sourceSchemaFingerprint := ""
 	if managedPostgresCDC {
@@ -2246,6 +2249,21 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 	}
 
 	return nil
+}
+
+// hasIgnoredDestSchema reports whether the source URI carries a dest_schema
+// that will not be honoured. dest_schema only names destination tables in
+// multi-table mode; with an explicit --source-table the destination is
+// --dest-table (or the source table name) and dest_schema is silently dropped.
+func hasIgnoredDestSchema(cfg *config.IngestConfig) bool {
+	if cfg.SourceTable == "" {
+		return false
+	}
+	parsed, err := url.Parse(cfg.SourceURI)
+	if err != nil {
+		return false
+	}
+	return parsed.Query().Get("dest_schema") != ""
 }
 
 // shouldWarnCDCStrategy returns true if the user should be warned about using

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3251,7 +3251,6 @@ func TestHasIgnoredDestSchema(t *testing.T) {
 	}
 }
 
-
 func TestValidateMultiTableNamespace(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3198,3 +3198,55 @@ func TestApplyPartitionNaming(t *testing.T) {
 		})
 	}
 }
+
+func TestHasIgnoredDestSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		sourceURI   string
+		sourceTable string
+		want        bool
+	}{
+		{
+			name:        "single table with dest_schema is ignored",
+			sourceURI:   "postgres+cdc://user:pass@host:5432/db?dest_schema=analytics",
+			sourceTable: "public.users",
+			want:        true,
+		},
+		{
+			name:      "multi table honours dest_schema",
+			sourceURI: "postgres+cdc://user:pass@host:5432/db?dest_schema=analytics",
+			want:      false,
+		},
+		{
+			name:        "single table without dest_schema",
+			sourceURI:   "postgres+cdc://user:pass@host:5432/db",
+			sourceTable: "public.users",
+			want:        false,
+		},
+		{
+			name:        "empty dest_schema value",
+			sourceURI:   "postgres+cdc://user:pass@host:5432/db?dest_schema=",
+			sourceTable: "public.users",
+			want:        false,
+		},
+		{
+			name:        "unparseable uri",
+			sourceURI:   "://not a uri",
+			sourceTable: "public.users",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasIgnoredDestSchema(&config.IngestConfig{
+				SourceURI:   tt.sourceURI,
+				SourceTable: tt.sourceTable,
+			})
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`dest_schema` only influences destination table names in multi-table CDC mode, where `multiTableDestinationNames()` passes it to `ResolveMultiTableName()`. When `--source-table` is set, the pipeline takes the single-table path and the destination is `cfg.DestTable` verbatim — `dest_schema` is parsed, stored on the CDC config, and then silently dropped.

This is easy to trip over on Postgres. With `--source-table=public.users` and no `--dest-table`, `DestTable` defaults to `public.users`, and BigQuery's `ParseTableName()` reads that as dataset `public`, table `users`. Both the dataset from the destination URI and `dest_schema` are discarded, so rows land in a dataset named after the Postgres schema.

The docs made this worse rather than better:

- `docs/supported-sources/postgres.md` described `dest_schema` as a general "schema/dataset prefix for destination table names", with no multi-table qualifier — unlike the mysql, planetscale, and vitess pages, which all scope it explicitly.
- `docs/getting-started/cdc.md` told users to "use `--dest-schema`", a CLI flag that does not exist. Only the URI parameter does.
- `mssql` and `mongodb` parse `dest_schema` but never documented it.

## Changes

- Warn when a source URI carries `dest_schema` alongside `--source-table`, naming the destination that will actually be used. The check lives in the pipeline so it covers all four connectors that parse the parameter (postgres, mysql, mongodb, mssql) instead of being repeated per source.
- Scope the `dest_schema` description consistently across all six docs pages, replace the `--dest-schema` reference with the URI parameter and an example, and add the missing bullets for mssql and mongodb.

Behavior is otherwise unchanged: existing pipelines that set `dest_schema` with `--source-table` keep writing where they write today, now with the discrepancy surfaced rather than silent.