### PR TITLE
Document CDC connector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,112 +121,134 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <th></th>
         <th>Source</th>
         <th>Destination</th>
+        <th>CDC</th>
     </tr>
     <tr>
-        <td colspan="3" style='text-align:center;'><strong>Databases</strong></td>
+        <td colspan="4" style='text-align:center;'><strong>Databases</strong></td>
     </tr>
     <tr>
         <td>AWS Athena</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Apache Iceberg</td>
         <td>-</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>AWS Redshift</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Cassandra</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>ClickHouse</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Couchbase</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>CrateDB</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Databricks</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>DuckDB</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>DynamoDB</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Elasticsearch</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Google BigQuery</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>GCP Spanner</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>IBM Db2</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>InfluxDB</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Kafka</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Local CSV file</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>MaxCompute</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Microsoft Fabric</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Microsoft OneLake</td>
         <td>-</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Microsoft SQL Server</td>
+        <td>✅</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
@@ -234,14 +256,17 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>MongoDB</td>
         <td>✅</td>
         <td>✅</td>
+        <td>✅</td>
     </tr>
     <tr>
         <td>MotherDuck</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>MySQL</td>
+        <td>✅</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
@@ -249,9 +274,11 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>Oracle</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>PlanetScale</td>
+        <td>✅</td>
         <td>✅</td>
         <td>✅</td>
     </tr>
@@ -259,463 +286,561 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>Postgres</td>
         <td>✅</td>
         <td>✅</td>
+        <td>✅</td>
     </tr>
     <tr>
         <td>RabbitMQ</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>SAP Hana</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Snowflake</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Socrata</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>SQLite</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>StarRocks</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Synapse</td>
         <td>-</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Trino</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
-        <td colspan="3" style='text-align:center;'><strong>Platforms</strong></td>
+        <td>Vitess</td>
+        <td>✅</td>
+        <td>✅</td>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <td colspan="4" style='text-align:center;'><strong>Platforms</strong></td>
     </tr>
     <tr>
         <td>Adjust</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Adapty</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Airtable</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Allium</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Amazon Kinesis</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Anthropic</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>API-Football</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>AppsFlyer</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Apple Ads</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Apple App Store</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Applovin</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Applovin Max</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Asana</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Attio</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Azure Data Lake Storage Gen2</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>BallDontLie FIFA</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Braze</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Bruin</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Chess.com</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>ClickUp</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Cursor</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Docebo</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Dune</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Facebook Ads</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Fireflies</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Fluxx</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>football-data.org</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Frankfurter</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Freshdesk</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>FundraiseUp</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>G2</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>GitHub</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>GitLab</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Google Ads</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Google Analytics</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Google Cloud Storage (GCS)</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Google Sheets</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Gorgias</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Granola</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Hostaway</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>HubSpot</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Indeed</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Intercom</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Internet Society Pulse</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Jira</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>JobTread</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Klaviyo</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Linear</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>LinkedIn Ads</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Mailchimp</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Mixpanel</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Monday</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Notion</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Paddle</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Personio</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>PhantomBuster</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Pinterest</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Pipedrive</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Plus Vibe AI</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>PostHog</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Primer</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>QuickBooks</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Reddit Ads</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>RevenueCat</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>S3</td>
         <td>✅</td>
         <td>✅</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Salesforce</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>SFTP</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>SendGrid</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Shopify</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Slack</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Smartsheet</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Snapchat Ads</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Solidgate</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Square</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Stripe</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>SurveyMonkey</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>TikTok Ads</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Trello</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Trustpilot</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Twilio</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
     <tr>
         <td>Wise</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Zendesk</td>
         <td>✅</td>
         <td>-</td>
+        <td>-</td>
     </tr>
     <tr>
         <td>Zoom</td>
         <td>✅</td>
+        <td>-</td>
         <td>-</td>
     </tr>
 </table>


### PR DESCRIPTION
## Summary
- add a CDC support column to the README connector matrix
- mark PostgreSQL, MySQL, SQL Server, MongoDB, PlanetScale, and Vitess as CDC-capable
- add the missing Vitess source and destination row

## Validation
- `make format` passed
- `make lint` passed
- `make test` failed only in existing-looking `internal/server` job-manager timeout tests:
  - `TestJobManagerRedactsCommandOutputURIs`
  - `TestJobManagerPersistsLogsToFileAndRepository`
  - `TestStartJobReportsLogFileCreateFailure`