### PR TITLE
fix(snowflake): handle NOT NULL columns during schema evolution

### DIFF
--- a/pkg/destination/snowflake/dialect.go
+++ b/pkg/destination/snowflake/dialect.go
@@ -43,6 +43,12 @@ func (d *Dialect) SupportsAlterType() bool {
 	return true
 }
 
+func (d *Dialect) RelaxColumnNullabilitySQL(table, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL",
+		table,
+		d.QuoteIdentifier(colName))
+}
+
 func (d *Dialect) TypeName(col schema.Column) string {
 	switch col.DataType {
 	case schema.TypeBoolean:

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -206,6 +206,14 @@ func TestQuoteIdentifier(t *testing.T) {
 	}
 }
 
+func TestRelaxColumnNullabilitySQL(t *testing.T) {
+	var _ destination.NullabilityRelaxer = (*Dialect)(nil)
+
+	d := &Dialect{}
+	got := d.RelaxColumnNullabilitySQL("bruin_facebook.insights", "spend")
+	assert.Equal(t, `ALTER TABLE bruin_facebook.insights ALTER COLUMN "SPEND" DROP NOT NULL`, got)
+}
+
 func TestImplicitTableStageName(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/schemaevolution/compare.go
+++ b/pkg/schemaevolution/compare.go
@@ -64,7 +64,7 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 				newCol.Name = destColumn.Name
 				comparisonCol.Name = destCol.Name
 				_, isPrimaryKey := primaryKeys[lowerName]
-				relaxNullability := sourceColumn.Nullable && !destColumn.Nullable && !isPrimaryKey
+				relaxNullability := sourceColumn.Nullable && !destColumn.Nullable && !isPrimaryKey && !naming.IsIngestrColumn(sourceColumn.Name)
 				newCol.Nullable = destColumn.Nullable || relaxNullability
 				if relaxNullability {
 					old := destColumn
@@ -135,7 +135,7 @@ func Compare(source, dest *schema.TableSchema, opts *CompareOptions) (*SchemaCom
 			continue
 		}
 		_, isPrimaryKey := primaryKeys[lowerName]
-		if sourceColumn.Nullable && !destColumn.Nullable && !isPrimaryKey {
+		if sourceColumn.Nullable && !destColumn.Nullable && !isPrimaryKey && !naming.IsIngestrColumn(sourceColumn.Name) {
 			old := destColumn
 			newCol := sourceColumn
 			newCol.Name = destColumn.Name

--- a/pkg/schemaevolution/compare_test.go
+++ b/pkg/schemaevolution/compare_test.go
@@ -448,6 +448,31 @@ func TestCompare_IgnoresInferredNullabilityForConfiguredPrimaryKeys(t *testing.T
 	assert.Equal(t, "value", result.Changes[0].ColumnName)
 }
 
+func TestCompare_DoesNotRelaxNullabilityForIngestrMetadataColumns(t *testing.T) {
+	source := &schema.TableSchema{
+		Name: "insights",
+		Columns: []schema.Column{
+			{Name: "impressions", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "_dlt_load_id", DataType: schema.TypeString, Nullable: true},
+			{Name: "_dlt_id", DataType: schema.TypeString, Nullable: true},
+		},
+	}
+	dest := &schema.TableSchema{
+		Name: "insights",
+		Columns: []schema.Column{
+			{Name: "impressions", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "_DLT_LOAD_ID", DataType: schema.TypeString, Nullable: false},
+			{Name: "_DLT_ID", DataType: schema.TypeString, Nullable: false},
+		},
+	}
+
+	result, err := Compare(source, dest, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, ChangeRelaxNullability, result.Changes[0].Type)
+	assert.Equal(t, "impressions", result.Changes[0].ColumnName)
+}
+
 func TestMakeNullable(t *testing.T) {
 	col := schema.Column{
 		Name:     "test",


### PR DESCRIPTION
## What
Schema evolution failed on Snowflake whenever a source column was nullable but the destination column was NOT NULL (e.g. legacy `_DLT_LOAD_ID` columns re-added by the backward-compat filler). Since #960 this emits a nullability-relaxation change that the Snowflake dialect couldn't apply, so ingestion errored out.

## Changes
- `pkg/schemaevolution/compare.go` — skip nullability relaxation for ingestr metadata columns (always populated), matching the removal loop's existing `IsIngestrColumn` guard.
- `pkg/destination/snowflake/dialect.go` — implement `RelaxColumnNullabilitySQL` so real data columns are relaxed via `ALTER COLUMN … DROP NOT NULL` instead of failing.
- Tests for both.

## How to test
1. Create a Snowflake table with a `NOT NULL` column.
2. Ingest with `--incremental-strategy merge` from a source where that column is nullable — it now succeeds instead of erroring on nullability relaxation.

## Risk & rollback
- **Risk:** low — metadata columns are skipped; real columns get a non-destructive `DROP NOT NULL`.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)