### PR TITLE
Speed up SQL Server replace bulk loads

### DIFF
--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -20,6 +20,7 @@ type PrepareOptions struct {
 	Schema                 *schema.TableSchema
 	DropFirst              bool
 	PrimaryKeys            []string
+	DeferredPrimaryKeys    []string // PK columns whose constraint is created after loading.
 	PartitionBy            string   // Column to partition by (BigQuery)
 	ClusterBy              []string // Columns to cluster by (BigQuery)
 	CDCMode                bool     // If true, make non-PK columns nullable for staging tables (CDC delete handling)
@@ -593,6 +594,13 @@ type ReplaceStagingPolicy struct {
 // staging tables should live while keeping strategy orchestration generic.
 type ReplaceStagingPolicyProvider interface {
 	ReplaceStagingPolicy() ReplaceStagingPolicy
+}
+
+// ReplaceStagingPrimaryKeyDeferrer lets a destination bulk-load a known-unique
+// replace staging table before creating its primary key during the swap.
+type ReplaceStagingPrimaryKeyDeferrer interface {
+	DeferReplaceStagingPrimaryKey() bool
+	DeferredReplaceStagingParallelism() int
 }
 
 // ManagedStagingPolicyProvider lets a destination declare where strategy-owned

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -31,6 +31,8 @@ type MSSQLDestination struct {
 	compatibilityLevel int
 }
 
+const defaultMSSQLPacketSize = "32767"
+
 var errDirectInsertRequiresRetry = errors.New("direct insert transaction cannot be reused")
 
 func NewMSSQLDestination() *MSSQLDestination {
@@ -117,6 +119,9 @@ func uriToConnString(uri string) (string, string, error) {
 
 	query := u.Query()
 	query.Del("driver")
+	if !query.Has("packet size") {
+		query.Set("packet size", defaultMSSQLPacketSize)
+	}
 	if database != "" {
 		query.Set("database", database)
 	}
@@ -155,7 +160,12 @@ func (d *MSSQLDestination) PrepareTable(ctx context.Context, opts destination.Pr
 
 	if opts.Schema != nil {
 		startCreate := time.Now()
-		createSQL := buildCreateTableSQL(resolvedTable, opts.Schema.Columns, opts.PrimaryKeys)
+		createSQL := buildCreateTableSQLWithDeferredPrimaryKeys(
+			resolvedTable,
+			opts.Schema.Columns,
+			opts.PrimaryKeys,
+			opts.DeferredPrimaryKeys,
+		)
 		if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
 			if isObjectAlreadyExistsError(err) {
 				return nil
@@ -522,6 +532,10 @@ func (d *MSSQLDestination) SwapTable(ctx context.Context, opts destination.SwapO
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := addPrimaryKeyIfMissing(ctx, tx, staging.qualifiedTable(d.server), opts.PrimaryKeys); err != nil {
+		return err
+	}
+
 	if !sameSchema {
 		transferSQL, err := d.databaseScopedSQL(target, fmt.Sprintf(
 			"ALTER SCHEMA %s TRANSFER %s",
@@ -849,6 +863,30 @@ func addPrimaryKey(ctx context.Context, tx *sql.Tx, table, constraintName string
 		config.LogFailedQuery(addSQL, err)
 		return fmt.Errorf("failed to recreate primary key after deduplicated insert: %w", err)
 	}
+	return nil
+}
+
+func addPrimaryKeyIfMissing(ctx context.Context, tx *sql.Tx, table string, primaryKeys []string) error {
+	if len(primaryKeys) == 0 {
+		return nil
+	}
+
+	query := `SELECT kc.name
+FROM sys.key_constraints AS kc
+WHERE kc.parent_object_id = OBJECT_ID(@p1) AND kc.[type] = 'PK'`
+	var constraintName string
+	if err := tx.QueryRowContext(ctx, query, table).Scan(&constraintName); err == nil {
+		return nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		config.LogFailedQuery(query, err)
+		return fmt.Errorf("failed to inspect staging primary key: %w", err)
+	}
+
+	start := time.Now()
+	if err := addPrimaryKey(ctx, tx, table, "", primaryKeys); err != nil {
+		return err
+	}
+	config.Debug("[MSSQL] Deferred primary key created in %v", time.Since(start))
 	return nil
 }
 
@@ -1204,15 +1242,17 @@ func (t *mssqlTransaction) Rollback(ctx context.Context) error {
 	return t.tx.Rollback()
 }
 
-func (d *MSSQLDestination) SupportsReplaceStrategy() bool      { return true }
-func (d *MSSQLDestination) SupportsAppendStrategy() bool       { return true }
-func (d *MSSQLDestination) SupportsMergeStrategy() bool        { return true }
-func (d *MSSQLDestination) SupportsIncrementalPredicate() bool { return true }
-func (d *MSSQLDestination) SupportsDeleteInsertStrategy() bool { return true }
-func (d *MSSQLDestination) SupportsSCD2Strategy() bool         { return true }
-func (d *MSSQLDestination) SupportsAtomicSwap() bool           { return true }
-func (d *MSSQLDestination) SupportsCDCMerge() bool             { return true }
-func (d *MSSQLDestination) SupportsCDCUnchangedCols() bool     { return true }
+func (d *MSSQLDestination) SupportsReplaceStrategy() bool          { return true }
+func (d *MSSQLDestination) SupportsAppendStrategy() bool           { return true }
+func (d *MSSQLDestination) SupportsMergeStrategy() bool            { return true }
+func (d *MSSQLDestination) SupportsIncrementalPredicate() bool     { return true }
+func (d *MSSQLDestination) SupportsDeleteInsertStrategy() bool     { return true }
+func (d *MSSQLDestination) SupportsSCD2Strategy() bool             { return true }
+func (d *MSSQLDestination) SupportsAtomicSwap() bool               { return true }
+func (d *MSSQLDestination) DeferReplaceStagingPrimaryKey() bool    { return true }
+func (d *MSSQLDestination) DeferredReplaceStagingParallelism() int { return 12 }
+func (d *MSSQLDestination) SupportsCDCMerge() bool                 { return true }
+func (d *MSSQLDestination) SupportsCDCUnchangedCols() bool         { return true }
 
 func (d *MSSQLDestination) ValidateManagedCDCState() error {
 	return validateMSSQLCompatibilityLevel(d.database, d.compatibilityLevel)
@@ -1723,15 +1763,24 @@ func escapeTableNameForRename(table string) string {
 }
 
 func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
+	return buildCreateTableSQLWithDeferredPrimaryKeys(table, columns, primaryKeys, nil)
+}
+
+func buildCreateTableSQLWithDeferredPrimaryKeys(table string, columns []schema.Column, primaryKeys, deferredPrimaryKeys []string) string {
 	columnNames := make([]string, len(columns))
 	for i := range columns {
 		columnNames[i] = columns[i].Name
 	}
 	primaryKeySet := matchedMSSQLIdentifiers(columnNames, primaryKeys)
+	deferredPrimaryKeySet := matchedMSSQLIdentifiers(columnNames, deferredPrimaryKeys)
 
 	var colDefs []string
 	for _, col := range columns {
-		colType := mapColumnTypeForCreate(col, primaryKeySet[col.Name])
+		isDeferredPrimaryKey := deferredPrimaryKeySet[col.Name]
+		colType := mapColumnTypeForCreate(col, primaryKeySet[col.Name] || isDeferredPrimaryKey)
+		if isDeferredPrimaryKey {
+			colType += " NOT NULL"
+		}
 		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
 	}
 

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -27,6 +27,27 @@ type releaseCountingBatch struct {
 	releases int
 }
 
+func TestURIToConnStringDefaultsLargePacketSize(t *testing.T) {
+	connString, database, err := uriToConnString("mssql://sa:secret@localhost:1433/warehouse?encrypt=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if database != "warehouse" {
+		t.Fatalf("database = %q, want warehouse", database)
+	}
+	if !strings.Contains(connString, "packet+size=32767") {
+		t.Fatalf("connection string = %q, want default packet size", connString)
+	}
+
+	explicit, _, err := uriToConnString("mssql://sa:secret@localhost:1433/warehouse?packet+size=8192")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(explicit, "packet+size=8192") || strings.Contains(explicit, "32767") {
+		t.Fatalf("explicit packet size was not preserved: %q", explicit)
+	}
+}
+
 func TestResolveMSSQLTargetIdentityIncludesServerAndDatabase(t *testing.T) {
 	tests := map[string]mssqlTargetIdentity{
 		"orders":                        {server: "srv", database: "db", schema: "sales", table: "orders"},
@@ -228,6 +249,41 @@ func TestSwapTableTransfersCaseDistinctSchemasUnderCaseSensitiveCollation(t *tes
 	err = dest.SwapTable(t.Context(), destination.SwapOptions{
 		TargetTable:  "Sales.orders",
 		StagingTable: "sales.orders_staging",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSwapTableCreatesDeferredPrimaryKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	dest := &MSSQLDestination{db: db, server: "server-a", database: "AppDB"}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT kc.name
+FROM sys.key_constraints AS kc
+WHERE kc.parent_object_id = OBJECT_ID(@p1) AND kc.[type] = 'PK'`)).
+		WithArgs("AppDB.dbo.orders_staging").
+		WillReturnRows(sqlmock.NewRows([]string{"name"}))
+	mock.ExpectExec(regexp.QuoteMeta("ALTER TABLE [AppDB].[dbo].[orders_staging] ADD PRIMARY KEY ([id]) WITH (SORT_IN_TEMPDB = ON)")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(`OBJECT_ID\('\[AppDB\]\.\[dbo\]\.\[orders\]', 'U'\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta("EXEC sys.sp_rename 'dbo.orders_staging', 'orders'")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err = dest.SwapTable(t.Context(), destination.SwapOptions{
+		TargetTable:  "dbo.orders",
+		StagingTable: "dbo.orders_staging",
+		PrimaryKeys:  []string{"id"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -442,6 +498,19 @@ func TestBuildCreateTableSQL_StringPrimaryKeyUsesIndexableType(t *testing.T) {
 	assertContains(t, sql, "[_id] NVARCHAR(450)")
 	assertContains(t, sql, "[payload] NVARCHAR(MAX)")
 	assertContains(t, sql, "PRIMARY KEY ([_id])")
+}
+
+func TestBuildCreateTableSQL_DeferredPrimaryKeyIsIndexableAndNotNull(t *testing.T) {
+	sql := buildCreateTableSQLWithDeferredPrimaryKeys("dbo.events", []schema.Column{
+		{Name: "_id", DataType: schema.TypeString},
+		{Name: "payload", DataType: schema.TypeJSON},
+	}, nil, []string{"_id"})
+
+	assertContains(t, sql, "[_id] NVARCHAR(450) NOT NULL")
+	assertContains(t, sql, "[payload] NVARCHAR(MAX)")
+	if strings.Contains(sql, "PRIMARY KEY") {
+		t.Fatalf("deferred primary key constraint was created eagerly:\n%s", sql)
+	}
 }
 
 func TestBuildCreateTableSQL_CapsLongStringPrimaryKeyLength(t *testing.T) {

--- a/pkg/strategy/append_replace_test.go
+++ b/pkg/strategy/append_replace_test.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -386,6 +387,48 @@ func TestReplaceStrategy_Execute_SkipsDedupForUniqueSourcePrimaryKeys(t *testing
 	}
 	if len(dest.swapCalls) != 1 || dest.swapCalls[0][0] != dest.prepareCalls[0].Table {
 		t.Fatalf("expected staging table to be swapped directly, got swaps=%v prepares=%v", dest.swapCalls, dest.prepareCalls)
+	}
+}
+
+func TestReplaceStrategy_Execute_DefersPrimaryKeyForBulkLoadDestination(t *testing.T) {
+	job, src, base := minimalJob()
+	job.Config.ExtractParallelism = config.DefaultExtractParallelism
+	src.primaryKeysUnique = true
+	src.readCh = mustClosedRecords()
+	job.Destination = &fakeReplaceStagingPrimaryKeyDeferrer{fakeDestination: base}
+
+	if err := (&ReplaceStrategy{}).Execute(t.Context(), job); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(base.prepareCalls) != 1 {
+		t.Fatalf("expected 1 PrepareTable call, got %d", len(base.prepareCalls))
+	}
+	if got := base.prepareCalls[0].PrimaryKeys; len(got) != 0 {
+		t.Fatalf("staging table should defer primary keys, got %v", got)
+	}
+	if got := base.prepareCalls[0].DeferredPrimaryKeys; !slices.Equal(got, job.Config.PrimaryKeys) {
+		t.Fatalf("staging table should preserve deferred primary key columns, got %v", got)
+	}
+	if len(base.mergeCalls) != 0 {
+		t.Fatalf("expected no MergeTable calls on unique-PK fast path, got %d", len(base.mergeCalls))
+	}
+	if got := base.writeCalls[0].Parallelism; got != 12 {
+		t.Fatalf("deferred staging write parallelism = %d, want 12", got)
+	}
+	if len(base.swapOptions) != 1 || !slices.Equal(base.swapOptions[0].PrimaryKeys, job.Config.PrimaryKeys) {
+		t.Fatalf("swap should create primary keys, got %+v", base.swapOptions)
+	}
+}
+
+func TestReplaceWriteParallelism_PreservesExplicitValue(t *testing.T) {
+	job, _, base := minimalJob()
+	job.Config.ExtractParallelism = config.DefaultExtractParallelism
+	job.Config.DestinationParallelism = 7
+	job.Destination = &fakeReplaceStagingPrimaryKeyDeferrer{fakeDestination: base}
+
+	if got := replaceWriteParallelism(job, true); got != 7 {
+		t.Fatalf("replace write parallelism = %d, want explicit value 7", got)
 	}
 }
 

--- a/pkg/strategy/replace.go
+++ b/pkg/strategy/replace.go
@@ -31,6 +31,27 @@ func supportsDirectReplaceDeduplication(dest destination.Destination) bool {
 	return ok && deduplicator.SupportsDirectReplaceDeduplication()
 }
 
+func replaceShouldDeferStagingPrimaryKey(job *IngestionJob) bool {
+	provider, ok := job.Destination.(destination.ReplaceStagingPrimaryKeyDeferrer)
+	return ok && provider.DeferReplaceStagingPrimaryKey() && effectivePrimaryKeysGuaranteedUnique(job)
+}
+
+func replaceWriteParallelism(job *IngestionJob, deferredPrimaryKey bool) int {
+	parallelism := job.Config.EffectiveDestinationParallelism()
+	if !deferredPrimaryKey || job.Config.DestinationParallelism > 0 || job.Config.ExtractParallelism != config.DefaultExtractParallelism {
+		return parallelism
+	}
+
+	provider, ok := job.Destination.(destination.ReplaceStagingPrimaryKeyDeferrer)
+	if !ok {
+		return parallelism
+	}
+	if preferred := provider.DeferredReplaceStagingParallelism(); preferred > 0 {
+		return preferred
+	}
+	return parallelism
+}
+
 func effectivePrimaryKeysGuaranteedUnique(job *IngestionJob) bool {
 	return sourcePrimaryKeysGuaranteedUnique(job) &&
 		!primaryKeyValuesMayChange(job)
@@ -282,20 +303,26 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 		replaceShouldDedup(job.Destination, job.Config.PrimaryKeys)
 	stagedDedup := useStaging && shouldDedup
 	directDedup := !useStaging && shouldDedup && supportsDirectReplaceDeduplication(job.Destination)
+	deferStagingPrimaryKey := useStaging && replaceShouldDeferStagingPrimaryKey(job)
 
 	// Staged dedup loads into a PK-free table so duplicate keys can land.
 	stagingPrimaryKeys := job.Config.PrimaryKeys
-	if stagedDedup {
+	deferredPrimaryKeys := []string(nil)
+	if deferStagingPrimaryKey {
+		deferredPrimaryKeys = job.Config.PrimaryKeys
+		stagingPrimaryKeys = nil
+	} else if stagedDedup {
 		stagingPrimaryKeys = nil
 	}
 
 	prepareOpts := destination.PrepareOptions{
-		Table:       writeTable,
-		Schema:      job.Schema,
-		DropFirst:   true,
-		PrimaryKeys: stagingPrimaryKeys,
-		PartitionBy: job.Config.PartitionBy,
-		ClusterBy:   job.Config.ClusterBy,
+		Table:               writeTable,
+		Schema:              job.Schema,
+		DropFirst:           true,
+		PrimaryKeys:         stagingPrimaryKeys,
+		DeferredPrimaryKeys: deferredPrimaryKeys,
+		PartitionBy:         job.Config.PartitionBy,
+		ClusterBy:           job.Config.ClusterBy,
 	}
 	if useStaging {
 		prepareOpts.ExpiresAfter = destination.ManagedStagingTTL
@@ -347,7 +374,7 @@ func (s *ReplaceStrategy) Execute(ctx context.Context, job *IngestionJob) error 
 	writeOpts := destination.WriteOptions{
 		Table:            writeTable,
 		Schema:           job.Schema,
-		Parallelism:      job.Config.EffectiveDestinationParallelism(),
+		Parallelism:      replaceWriteParallelism(job, deferStagingPrimaryKey),
 		StagingTable:     useStaging,
 		StagingBucket:    job.Config.StagingBucket,
 		LoaderFileSize:   job.Config.LoaderFileSize,

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -166,6 +166,7 @@ type fakeDestination struct {
 	prepareCalls  []destination.PrepareOptions
 	writeCalls    []destination.WriteOptions
 	swapCalls     [][2]string
+	swapOptions   []destination.SwapOptions
 	mergeCalls    []destination.MergeOptions
 	diCalls       []destination.DeleteInsertOptions
 	dropCalls     []string
@@ -276,6 +277,7 @@ func (d *fakeDestination) SwapTable(ctx context.Context, opts destination.SwapOp
 	d.mu.Lock()
 	d.calls = append(d.calls, "SwapTable")
 	d.swapCalls = append(d.swapCalls, [2]string{opts.StagingTable, opts.TargetTable})
+	d.swapOptions = append(d.swapOptions, opts)
 	swapErr := d.swapErr
 	d.mu.Unlock()
 	return swapErr
@@ -346,6 +348,18 @@ type fakeReplaceStagingPolicyProvider struct {
 	*fakeDestination
 
 	policy destination.ReplaceStagingPolicy
+}
+
+type fakeReplaceStagingPrimaryKeyDeferrer struct {
+	*fakeDestination
+}
+
+func (d *fakeReplaceStagingPrimaryKeyDeferrer) DeferReplaceStagingPrimaryKey() bool {
+	return true
+}
+
+func (d *fakeReplaceStagingPrimaryKeyDeferrer) DeferredReplaceStagingParallelism() int {
+	return 12
 }
 
 func (d *fakeReplaceStagingPolicyProvider) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {


### PR DESCRIPTION
## Summary

- bulk-load known-unique SQL Server replacement data into an unindexed staging heap, then create its primary key atomically during the swap
- use 12 staging writers for that fast path while preserving explicit concurrency settings
- default SQL Server connections to 32 KB TDS packets while preserving user overrides

## Benchmark

PostgreSQL → SQL Server, 1M rows, one warmup and five measured runs:

- before: 22.565s ± 1.075s
- after: 4.384s ± 0.113s
- 5.15× faster (44k → 228k rows/s)

## Validation

- `make format`
- `make lint`
- `make test`
- remote five-run 1M benchmark
