### PR TITLE
Fix Iceberg staging file leaks

### DIFF
--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	iceberggo "github.com/apache/iceberg-go"
@@ -40,9 +44,16 @@ type Destination struct {
 	cfg     icebergConfig
 	catalog icebergcatalog.Catalog
 
-	mu       sync.Mutex
-	prepared map[string]preparedTable
+	mu                       sync.Mutex
+	prepared                 map[string]preparedTable
+	orphanCleanupLastAttempt map[string]time.Time
 }
+
+const (
+	managedExpiresAtProperty = "ingestr.managed-staging.expires-at-ms"
+	orphanCleanupRetention   = 72 * time.Hour
+	orphanCleanupInterval    = 24 * time.Hour
+)
 
 func NewDestination() *Destination {
 	return &Destination{}
@@ -66,6 +77,7 @@ func (d *Destination) Connect(ctx context.Context, rawURI string) error {
 	d.cfg = cfg
 	d.catalog = cat
 	d.prepared = make(map[string]preparedTable)
+	d.orphanCleanupLastAttempt = make(map[string]time.Time)
 	config.Debug("[ICEBERG] Connected catalog type=%s name=%s", cat.CatalogType(), cfg.CatalogName)
 	return nil
 }
@@ -74,6 +86,7 @@ func (d *Destination) Close(ctx context.Context) error {
 	cat := d.catalog
 	d.catalog = nil
 	d.prepared = nil
+	d.orphanCleanupLastAttempt = nil
 	if closer, ok := cat.(io.Closer); ok {
 		if err := closer.Close(); err != nil {
 			return fmt.Errorf("iceberg: failed to close catalog: %w", err)
@@ -99,19 +112,28 @@ func (d *Destination) PrepareTable(ctx context.Context, opts destination.Prepare
 	if err := d.ensureNamespace(ctx, namespace); err != nil {
 		return err
 	}
+	if opts.ExpiresAfter > 0 {
+		d.purgeExpiredManagedTables(ctx, namespace, ident, time.Now())
+	}
 
 	exists, err := d.tableExists(ctx, ident)
 	if err != nil {
 		return err
 	}
 	if exists {
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			return fmt.Errorf("iceberg: failed to load table %s: %w", opts.Table, err)
+		}
+		d.cleanupOldOrphans(ctx, tbl)
 		if opts.DropFirst {
-			tbl, err := d.catalog.LoadTable(ctx, ident)
-			if err != nil {
-				return fmt.Errorf("iceberg: failed to load table %s: %w", opts.Table, err)
-			}
 			if err := validateIdentifierFieldsForEvolution(tbl.Schema(), tableSchema, true); err != nil {
 				return err
+			}
+		}
+		if opts.ExpiresAfter > 0 {
+			if err := setManagedExpiration(ctx, tbl, time.Now().Add(opts.ExpiresAfter)); err != nil {
+				return fmt.Errorf("iceberg: failed to refresh managed table expiration for %s: %w", opts.Table, err)
 			}
 		}
 	} else {
@@ -223,9 +245,13 @@ func (d *Destination) DropTable(ctx context.Context, table string) error {
 	if err != nil {
 		return err
 	}
-	if err := d.catalog.DropTable(ctx, ident); err != nil && !isMissingTableOrNamespace(err) {
+	if err := d.purgeTable(ctx, ident); err != nil && !isMissingTableOrNamespace(err) {
 		return fmt.Errorf("iceberg: failed to drop table %s: %w", table, err)
 	}
+	d.mu.Lock()
+	delete(d.prepared, table)
+	delete(d.orphanCleanupLastAttempt, table)
+	d.mu.Unlock()
 	return nil
 }
 
@@ -283,9 +309,17 @@ func (d *Destination) createTable(ctx context.Context, ident icebergtable.Identi
 		return err
 	}
 
+	properties := maps.Clone(d.cfg.TableProperties)
+	if properties == nil {
+		properties = iceberggo.Properties{}
+	}
+	if opts.ExpiresAfter > 0 {
+		properties[managedExpiresAtProperty] = strconv.FormatInt(time.Now().Add(opts.ExpiresAfter).UnixMilli(), 10)
+	}
+
 	createOpts := []icebergcatalog.CreateTableOpt{}
-	if len(d.cfg.TableProperties) > 0 {
-		createOpts = append(createOpts, icebergcatalog.WithProperties(d.cfg.TableProperties))
+	if len(properties) > 0 {
+		createOpts = append(createOpts, icebergcatalog.WithProperties(properties))
 	}
 	if d.cfg.TableLocation != "" {
 		createOpts = append(createOpts, icebergcatalog.WithLocation(renderTableLocation(d.cfg.TableLocation, ident)))
@@ -310,6 +344,78 @@ func (d *Destination) createTable(ctx context.Context, ident icebergtable.Identi
 		return fmt.Errorf("iceberg: failed to create table %s: %w", strings.Join(ident, "."), err)
 	}
 	return nil
+}
+
+func setManagedExpiration(ctx context.Context, tbl *icebergtable.Table, expiresAt time.Time) error {
+	txn := tbl.NewTransaction()
+	if err := txn.SetProperties(iceberggo.Properties{
+		managedExpiresAtProperty: strconv.FormatInt(expiresAt.UnixMilli(), 10),
+	}); err != nil {
+		return err
+	}
+	_, err := txn.Commit(ctx)
+	return err
+}
+
+func (d *Destination) purgeTable(ctx context.Context, ident icebergtable.Identifier) error {
+	if purger, ok := d.catalog.(icebergcatalog.PurgeableTable); ok {
+		return purger.PurgeTable(ctx, ident)
+	}
+	return d.catalog.DropTable(ctx, ident)
+}
+
+func (d *Destination) purgeExpiredManagedTables(ctx context.Context, namespace, exclude icebergtable.Identifier, now time.Time) {
+	var expired []icebergtable.Identifier
+	for ident, err := range d.catalog.ListTables(ctx, namespace) {
+		if err != nil {
+			config.Debug("[ICEBERG] Warning: failed to list managed tables for expiry cleanup: %v", err)
+			return
+		}
+		if slices.Equal(ident, exclude) {
+			continue
+		}
+		tbl, err := d.catalog.LoadTable(ctx, ident)
+		if err != nil {
+			if !isMissingTableOrNamespace(err) {
+				config.Debug("[ICEBERG] Warning: failed to load managed table %s for expiry cleanup: %v", strings.Join(ident, "."), err)
+			}
+			continue
+		}
+		expiresAtMillis, err := strconv.ParseInt(tbl.Properties().Get(managedExpiresAtProperty, ""), 10, 64)
+		if err != nil || now.Before(time.UnixMilli(expiresAtMillis)) {
+			continue
+		}
+		expired = append(expired, ident)
+	}
+	for _, ident := range expired {
+		if err := d.purgeTable(ctx, ident); err != nil && !isMissingTableOrNamespace(err) {
+			config.Debug("[ICEBERG] Warning: failed to purge expired managed table %s: %v", strings.Join(ident, "."), err)
+		}
+	}
+}
+
+func (d *Destination) cleanupOldOrphans(ctx context.Context, tbl *icebergtable.Table) {
+	if !tbl.Properties().GetBool("gc.enabled", true) {
+		return
+	}
+	tableName := strings.Join(tbl.Identifier(), ".")
+	now := time.Now()
+	d.mu.Lock()
+	if lastAttempt := d.orphanCleanupLastAttempt[tableName]; now.Sub(lastAttempt) < orphanCleanupInterval {
+		d.mu.Unlock()
+		return
+	}
+	d.orphanCleanupLastAttempt[tableName] = now
+	d.mu.Unlock()
+
+	result, err := tbl.DeleteOrphanFiles(ctx, icebergtable.WithFilesOlderThan(orphanCleanupRetention))
+	if err != nil {
+		config.Debug("[ICEBERG] Warning: failed to clean old orphan files for table %s: %v", tableName, err)
+		return
+	}
+	if len(result.DeletedFiles) > 0 {
+		config.Debug("[ICEBERG] Removed %d old orphan file(s) for table %s", len(result.DeletedFiles), tableName)
+	}
 }
 
 func (d *Destination) stageTableSchemaUpdate(txn *icebergtable.Transaction, tbl *icebergtable.Table, desired *schema.TableSchema, reset bool) (bool, error) {

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -3,9 +3,13 @@ package iceberg
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"net/url"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -135,6 +139,106 @@ func TestDestinationConnectSQLiteCatalog(t *testing.T) {
 
 	require.NoError(t, dest.Connect(ctx, "iceberg+sqlite://"+catalogDB+"?warehouse_path="+url.QueryEscape(warehouse)))
 	require.NoError(t, dest.Close(ctx))
+}
+
+func TestDestinationDropTablePurgesSQLCatalogFiles(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	root := t.TempDir()
+	catalogDB := filepath.Join(root, "catalog.db")
+	warehouse := filepath.Join(root, "warehouse")
+	require.NoError(t, dest.Connect(ctx, "iceberg+sqlite://"+catalogDB+"?warehouse_path="+url.QueryEscape(warehouse)))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+
+	tableName := "lake.cleanup.managed_staging"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: tableName, Schema: tableSchema, ExpiresAfter: time.Hour,
+	}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table: tableName, Schema: tableSchema,
+	}))
+
+	tbl, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	require.NotEmpty(t, regularFiles(t, location))
+
+	require.NoError(t, dest.DropTable(ctx, tableName))
+	exists, err := dest.catalog.CheckTableExists(ctx, icebergCatalogIdentifier(t, tableName))
+	require.NoError(t, err)
+	require.False(t, exists, "purge must remove the catalog entry")
+	require.Empty(t, regularFiles(t, location), "purge must remove the table's data and metadata objects")
+}
+
+func TestDestinationPurgesExpiredManagedTables(t *testing.T) {
+	ctx := context.Background()
+	dest := NewDestination()
+	root := t.TempDir()
+	catalogDB := filepath.Join(root, "catalog.db")
+	warehouse := filepath.Join(root, "warehouse")
+	require.NoError(t, dest.Connect(ctx, "iceberg+sqlite://"+catalogDB+"?warehouse_path="+url.QueryEscape(warehouse)))
+	t.Cleanup(func() { require.NoError(t, dest.Close(ctx)) })
+
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	expiredTable := "lake.cleanup.expired_staging"
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: expiredTable, Schema: tableSchema, ExpiresAfter: time.Hour,
+	}))
+	require.NoError(t, dest.WriteParallel(ctx, recordBatches(int64Batch(t, 1)), destination.WriteOptions{
+		Table: expiredTable, Schema: tableSchema,
+	}))
+
+	tbl, err := dest.loadIcebergTable(ctx, expiredTable)
+	require.NoError(t, err)
+	expiresAtMillis, err := strconv.ParseInt(tbl.Properties().Get(managedExpiresAtProperty, ""), 10, 64)
+	require.NoError(t, err)
+	require.True(t, time.UnixMilli(expiresAtMillis).After(time.Now()))
+	location, ok := localFilesystemPath(tbl.Location())
+	require.True(t, ok)
+	require.NotEmpty(t, regularFiles(t, location))
+
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(map[string]string{managedExpiresAtProperty: "0"}))
+	_, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, dest.PrepareTable(ctx, destination.PrepareOptions{
+		Table: "lake.cleanup.current_staging", Schema: tableSchema, ExpiresAfter: time.Hour,
+	}))
+	exists, err := dest.catalog.CheckTableExists(ctx, icebergCatalogIdentifier(t, expiredTable))
+	require.NoError(t, err)
+	require.False(t, exists, "preparing managed staging should remove expired catalog entries in its namespace")
+	require.Empty(t, regularFiles(t, location), "expiry cleanup must purge underlying objects")
+}
+
+func icebergCatalogIdentifier(t *testing.T, table string) []string {
+	t.Helper()
+	ident, err := parseIdentifier(table)
+	require.NoError(t, err)
+	return ident
+}
+
+func regularFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if errors.Is(err, os.ErrNotExist) {
+			return fs.SkipDir
+		}
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if !errors.Is(err, os.ErrNotExist) {
+		require.NoError(t, err)
+	}
+	return files
 }
 
 func TestIcebergSchemaFromTableSchemaNormalizesJSON(t *testing.T) {

--- a/pkg/destination/iceberg/row_delta.go
+++ b/pkg/destination/iceberg/row_delta.go
@@ -2,9 +2,12 @@ package iceberg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -150,7 +153,7 @@ var errStreamStopped = fmt.Errorf("iceberg: batch stream consumer stopped")
 
 // commitRowDelta writes the data and delete files produced by the two
 // streaming passes and commits them as one atomic snapshot.
-func commitRowDelta(
+func (d *Destination) commitRowDelta(
 	ctx context.Context,
 	tbl *icebergtable.Table,
 	operation string,
@@ -162,6 +165,14 @@ func commitRowDelta(
 	txn := tbl.NewTransaction()
 
 	var dataFiles []iceberggo.DataFile
+	var deleteFiles []iceberggo.DataFile
+	cleanupFiles := true
+	defer func() {
+		if cleanupFiles {
+			removeUncommittedFiles(ctx, tbl, dataFiles, deleteFiles)
+		}
+	}()
+
 	for df, err := range icebergtable.WriteRecords(ctx, tbl, writeSchema, batchStream(writeSchema, true, produceData)) {
 		if err != nil {
 			return fmt.Errorf("iceberg: %s failed to write data files: %w", operation, err)
@@ -169,7 +180,6 @@ func commitRowDelta(
 		dataFiles = append(dataFiles, df)
 	}
 
-	var deleteFiles []iceberggo.DataFile
 	if produceDeletes != nil && tbl.CurrentSnapshot() != nil {
 		deleteFieldIDs, err := fieldIDsByName(tbl.Schema(), deleteKeyColumns)
 		if err != nil {
@@ -193,10 +203,47 @@ func commitRowDelta(
 	if err := rowDelta.Commit(ctx); err != nil {
 		return fmt.Errorf("iceberg: %s failed to stage row delta: %w", operation, err)
 	}
-	if _, err := txn.Commit(ctx); err != nil {
+	committed, err := txn.Commit(ctx)
+	if err != nil {
+		if !errors.Is(err, icebergtable.ErrCommitFailed) {
+			cleanupFiles = false
+		}
 		return fmt.Errorf("iceberg: failed to commit %s on table %s: %w", operation, tbl.Identifier(), err)
 	}
+	cleanupFiles = false
+	d.cleanupOldOrphans(ctx, committed)
 	return nil
+}
+
+func removeUncommittedFiles(ctx context.Context, tbl *icebergtable.Table, fileGroups ...[]iceberggo.DataFile) {
+	fileCount := 0
+	for _, files := range fileGroups {
+		fileCount += len(files)
+	}
+	if fileCount == 0 {
+		return
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	fs, err := tbl.FS(cleanupCtx)
+	if err != nil {
+		log.Printf("Warning: failed to load Iceberg filesystem for uncommitted-file cleanup on %s: %v", tbl.Identifier(), err)
+		return
+	}
+	seen := make(map[string]struct{})
+	for _, files := range fileGroups {
+		for _, file := range files {
+			path := file.FilePath()
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			if err := fs.Remove(path); err != nil {
+				log.Printf("Warning: failed to delete uncommitted Iceberg file %s: %v", path, err)
+			}
+		}
+	}
 }
 
 // mergeRowDelta merges the staging table using merge-on-read: an equality
@@ -261,7 +308,7 @@ func (d *Destination) mergeRowDelta(ctx context.Context, target, staging *iceber
 	deleteProjection := newRowProjection(deleteSchema, stagingCols)
 
 	config.Debug("[ICEBERG MERGE] Row-delta merge of %d staged row(s) into %s", sorter.Len(), opts.TargetTable)
-	return commitRowDelta(
+	return d.commitRowDelta(
 		ctx, target, "merge", writeSchema,
 		emitWinners(dataProjection),
 		opts.PrimaryKeys,
@@ -325,7 +372,7 @@ func (d *Destination) scd2RowDelta(ctx context.Context, target, staging *iceberg
 	deleteProjection := newRowProjection(deleteSchema, deleteKeyColumns)
 
 	config.Debug("[ICEBERG SCD2] Row-delta SCD2 of %d staged row(s) into %s", stagingSorter.Len(), opts.TargetTable)
-	return commitRowDelta(
+	return d.commitRowDelta(
 		ctx, target, "scd2", writeSchema,
 		func(emit rowEmit) error {
 			return join.run(stagingSorter, currentSorter, scd2Emitters{

--- a/pkg/destination/iceberg/row_delta_test.go
+++ b/pkg/destination/iceberg/row_delta_test.go
@@ -2,15 +2,45 @@ package iceberg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
+	icebergtable "github.com/apache/iceberg-go/table"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/require"
 )
+
+type failingCommitCatalog struct {
+	icebergcatalog.Catalog
+	err error
+}
+
+func (c *failingCommitCatalog) LoadTable(ctx context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	tbl, err := c.Catalog.LoadTable(ctx, ident)
+	if err != nil {
+		return nil, err
+	}
+	return icebergtable.New(
+		tbl.Identifier(),
+		tbl.Metadata(),
+		tbl.MetadataLocation(),
+		func(ctx context.Context) (icebergio.IO, error) { return tbl.FS(ctx) },
+		c,
+	), nil
+}
+
+func (c *failingCommitCatalog) CommitTable(context.Context, icebergtable.Identifier, []icebergtable.Requirement, []icebergtable.Update) (icebergtable.Metadata, string, error) {
+	return nil, "", c.err
+}
 
 // latestSnapshotSummary returns the summary properties of the table's current
 // snapshot, used to detect whether an operation committed equality delete
@@ -71,6 +101,113 @@ func TestMergeTableUsesRowDeltaByDefault(t *testing.T) {
 	runBasicMerge(t, dest, target, "lake.mor.merge_staging")
 	requireEqualityDeletes(t, dest, target)
 }
+
+func TestRowDeltaRemovesFilesAfterUnambiguousCommitFailure(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	tableName := "lake.cleanup.uncommitted"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{int64(1), "seed", 1.0, nil}})
+
+	baseCatalog := dest.catalog
+	dest.catalog = &failingCommitCatalog{Catalog: baseCatalog, err: icebergtable.ErrCommitFailed}
+	target, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(target.Location())
+	require.True(t, ok)
+	dataDir := filepath.Join(location, "data")
+	before := regularFiles(t, dataDir)
+	require.NotEmpty(t, before)
+	deleteSchema, err := equalityDeleteArrowSchema(target.Schema(), []string{"id"})
+	require.NoError(t, err)
+
+	err = dest.commitRowDelta(
+		ctx, target, "merge", icebergArrowSchema(tableSchema),
+		rowProducer(icebergArrowSchema(tableSchema), tableSchema.ColumnNames(), []any{int64(1), "updated", 2.0, nil}),
+		[]string{"id"},
+		rowProducer(deleteSchema, []string{"id"}, []any{int64(1)}),
+	)
+	require.ErrorIs(t, err, icebergtable.ErrCommitFailed)
+	require.ElementsMatch(t, before, regularFiles(t, dataDir), "data and equality-delete files from a definitely rejected commit must be deleted immediately")
+	dest.catalog = baseCatalog
+}
+
+func TestRowDeltaRemovesDataFilesAfterPrecommitFailure(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	tableName := "lake.cleanup.precommit"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, tableName, tableSchema, false, [][]any{{int64(1), "seed", 1.0, nil}})
+
+	target, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(target.Location())
+	require.True(t, ok)
+	dataDir := filepath.Join(location, "data")
+	before := regularFiles(t, dataDir)
+	require.NotEmpty(t, before)
+
+	err = dest.commitRowDelta(
+		ctx, target, "merge", icebergArrowSchema(tableSchema),
+		rowProducer(icebergArrowSchema(tableSchema), tableSchema.ColumnNames(), []any{int64(2), "new", 2.0, nil}),
+		[]string{"missing_key"},
+		func(rowEmit) error { return nil },
+	)
+	require.ErrorContains(t, err, `column "missing_key" not found`)
+	require.ElementsMatch(t, before, regularFiles(t, dataDir), "precommit failures must remove newly written data files")
+}
+
+func TestRowDeltaRetainsAmbiguousFilesUntilSafeOrphanCleanup(t *testing.T) {
+	dest := newHadoopDestination(t)
+	ctx := context.Background()
+	tableName := "lake.cleanup.ambiguous"
+	tableSchema := mergeTestSchema()
+	writeTableRows(t, dest, tableName, tableSchema, false, nil)
+
+	baseCatalog := dest.catalog
+	unknownCommitErr := errors.New("commit state unknown")
+	dest.catalog = &failingCommitCatalog{Catalog: baseCatalog, err: unknownCommitErr}
+	target, err := dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	location, ok := localFilesystemPath(target.Location())
+	require.True(t, ok)
+
+	err = dest.commitRowDelta(
+		ctx, target, "merge", icebergArrowSchema(tableSchema),
+		rowProducer(icebergArrowSchema(tableSchema), tableSchema.ColumnNames(), []any{int64(1), "ambiguous", 1.0, nil}),
+		nil, nil,
+	)
+	require.ErrorIs(t, err, unknownCommitErr)
+	orphans := regularFiles(t, filepath.Join(location, "data"))
+	require.Len(t, orphans, 1, "ambiguous commit files must not be deleted immediately")
+	old := time.Now().Add(-orphanCleanupRetention - time.Hour)
+	require.NoError(t, os.Chtimes(orphans[0], old, old))
+
+	dest.catalog = baseCatalog
+	target, err = dest.loadIcebergTable(ctx, tableName)
+	require.NoError(t, err)
+	require.NoError(t, dest.commitRowDelta(
+		ctx, target, "merge", icebergArrowSchema(tableSchema),
+		rowProducer(icebergArrowSchema(tableSchema), tableSchema.ColumnNames(), []any{int64(2), "committed", 2.0, nil}),
+		nil, nil,
+	))
+	_, err = os.Stat(orphans[0])
+	require.ErrorIs(t, err, os.ErrNotExist, "a later successful operation should reclaim old ambiguous orphans")
+}
+
+func rowProducer(writeSchema *arrow.Schema, columns []string, rows ...[]any) func(rowEmit) error {
+	projection := newRowProjection(writeSchema, columns)
+	return func(emit rowEmit) error {
+		for _, row := range rows {
+			if err := emit(projection, row); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+var _ icebergcatalog.Catalog = (*failingCommitCatalog)(nil)
 
 func TestMergeTableHonorsCopyOnWriteProperty(t *testing.T) {
 	dest := NewDestination()


### PR DESCRIPTION
## What
Fixes leaked Iceberg staging and uncommitted row-delta files.

## Changes
- Purge managed staging tables and honor their expiry.
- Clean definitely uncommitted files immediately and ambiguous orphans after retention.
- Add catalog, object-deletion, expiry, and commit-failure regression tests.

## How to test
1. `make format && make lint && make test`

## Risk & rollback
- **Risk:** Medium — changes physical cleanup behavior for Iceberg-managed files.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.
