### PR TITLE
docs(salesforce): note field-level security controls which fields are ingested

### DIFF
--- a/docs/supported-sources/salesforce.md
+++ b/docs/supported-sources/salesforce.md
@@ -168,3 +168,15 @@ ingestr ingest \
 
 > [!WARNING]
 > Salesforce API limits may affect the frequency and volume of data ingestion. Incremental loading is supported for objects with the `SystemModstamp` field, but some objects may require full-refresh loads. This is indicated by `mode` in the tables above. Tables with mode `replace` don't support incremental loads, while the ones with `merge` do.
+
+## Field-level security
+
+ingestr ingests only the fields the authenticating user is allowed to read. It builds its query from Salesforce's `describe` response, and Salesforce omits any field the user lacks **Read** field-level security (FLS) on — with no error. Such fields simply arrive empty (NULL) in the destination, even though they hold data in Salesforce.
+
+If a field you expect is unexpectedly empty, check that the user (or its permission set / profile) has Read access to it. You can confirm what the user can see by describing the object as that user, for example:
+
+```plaintext
+GET https://<your-domain>.my.salesforce.com/services/data/v59.0/sobjects/<object>/describe
+```
+
+Only the fields listed in the response are ingested. Grant Read FLS on the missing fields and re-run.

--- a/docs/supported-sources/salesforce.md
+++ b/docs/supported-sources/salesforce.md
@@ -171,12 +171,12 @@ ingestr ingest \
 
 ## Field-level security
 
-ingestr ingests only the fields the authenticating user is allowed to read. It builds its query from Salesforce's `describe` response, and Salesforce omits any field the user lacks **Read** field-level security (FLS) on — with no error. Such fields simply arrive empty (NULL) in the destination, even though they hold data in Salesforce.
+ingestr ingests only the fields the authenticating user is permitted to read — its query is built from what Salesforce returns for that user, so a field the user cannot read isn't fetched and stays empty (NULL) in the destination.
 
-If a field you expect is unexpectedly empty, check that the user (or its permission set / profile) has Read access to it. You can confirm what the user can see by describing the object as that user, for example:
+If a field you expect is coming through empty, make sure the user (or its permission set / profile) has **Read** access to it — for example, check its field-level security (FLS). You can see which fields the user can read by describing the object as that user:
 
 ```plaintext
 GET https://<your-domain>.my.salesforce.com/services/data/v59.0/sobjects/<object>/describe
 ```
 
-Only the fields listed in the response are ingested. Grant Read FLS on the missing fields and re-run.
+Only the fields listed in the response are ingested. Grant Read access to the missing fields and re-run.

--- a/docs/supported-sources/salesforce.md
+++ b/docs/supported-sources/salesforce.md
@@ -171,12 +171,12 @@ ingestr ingest \
 
 ## Field-level security
 
-ingestr ingests only the fields the authenticating user is permitted to read — its query is built from what Salesforce returns for that user, so a field the user cannot read isn't fetched and stays empty (NULL) in the destination.
+ingestr ingests only the fields the authenticating user is permitted to read. Its query is built from what Salesforce returns for that user, so a field the user cannot read is not fetched.
 
-If a field you expect is coming through empty, make sure the user (or its permission set / profile) has **Read** access to it — for example, check its field-level security (FLS). You can see which fields the user can read by describing the object as that user:
+If you want a field to be ingested, make sure the user (or its permission set or profile) has **Read** access to it, for example through its field-level security (FLS) settings. You can see which fields the user can read by describing the object as that user:
 
 ```plaintext
 GET https://<your-domain>.my.salesforce.com/services/data/v59.0/sobjects/<object>/describe
 ```
 
-Only the fields listed in the response are ingested. Grant Read access to the missing fields and re-run.
+Only the fields listed in the response are ingested. Grant Read access to the fields you want and run the ingestion again.


### PR DESCRIPTION
## What

Adds a short **Field-level security** section to the Salesforce source docs.

## Why

We hit a support case where a Salesforce custom-object load returned several columns fully empty (NULL) with no error, even though the fields held data. Root cause: the integration user lacked **Read** field-level security (FLS) on those fields, so Salesforce omitted them from the `describe` response. ingestr builds its `SELECT` from `describe`, so those fields were never queried — they only appeared as empty columns because they were declared via `--columns`.

This is Salesforce-side behavior, not an ingestr bug, but it's completely silent and easy to misread as a data-fetch bug. The docs now explain it and show how to confirm (describe as the connecting user) and fix (grant Read FLS).

## Notes

Docs-only change. A companion PR adds the same note to the bruin Salesforce docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)