### PR TITLE
Add OpenAI usage source

### DIFF
--- a/docs/supported-sources/openai.md
+++ b/docs/supported-sources/openai.md
@@ -1,0 +1,90 @@
+# OpenAI
+
+[OpenAI](https://openai.com/) provides organization-level usage reporting for API traffic. The OpenAI source loads daily completion usage totals, including input, cached-input, cache-write, and output tokens where available.
+
+## URI format
+
+```plaintext
+openai://?api_key=<admin-api-key>&codex_api_key=<codex-analytics-api-key>
+```
+
+The credentials are independent and either can be omitted when its API family is not used:
+
+- `api_key` is an OpenAI organization Admin API key used by Platform organization usage tables.
+- `codex_api_key` is the Platform organization API key associated with the ChatGPT workspace used by Codex Analytics tables.
+
+Both values should be stored as secrets. If the same key has access to both API families, pass it explicitly in both parameters.
+
+The currently available `api_usage` table uses only `api_key`. Codex Analytics tables will use only `codex_api_key` once their authenticated API contract is available.
+
+## Examples
+
+### Daily usage by user
+
+Load the last 30 days of API usage into DuckDB. `api_usage` groups by `user_id` by default:
+
+```sh
+ingestr ingest \
+  --source-uri 'openai://?api_key=<admin-api-key>' \
+  --source-table 'api_usage' \
+  --dest-uri 'duckdb:///openai.duckdb' \
+  --dest-table 'openai.api_usage'
+```
+
+### Daily usage by user and API key
+
+Use Monday-style table parameters to add grouping dimensions:
+
+```sh
+ingestr ingest \
+  --source-uri 'openai://?api_key=<admin-api-key>' \
+  --source-table 'api_usage?group_by=user_id,api_key_id' \
+  --dest-uri 'duckdb:///openai.duckdb' \
+  --dest-table 'openai.api_usage_by_key'
+```
+
+The equivalent repeated-parameter form is also supported:
+
+```sh
+--source-table 'api_usage?group_by=user_id&group_by=api_key_id'
+```
+
+### Daily usage by user, API key, and model
+
+```sh
+ingestr ingest \
+  --source-uri 'openai://?api_key=<admin-api-key>' \
+  --source-table 'api_usage?group_by=user_id,api_key_id,model' \
+  --dest-uri 'duckdb:///openai.duckdb' \
+  --dest-table 'openai.api_usage_by_key_model'
+```
+
+### A specific time range
+
+```sh
+ingestr ingest \
+  --source-uri 'openai://?api_key=<admin-api-key>' \
+  --source-table 'api_usage?group_by=project_id,model' \
+  --dest-uri 'duckdb:///openai.duckdb' \
+  --dest-table 'openai.api_usage_by_project' \
+  --interval-start '2026-07-01T00:00:00Z' \
+  --interval-end '2026-08-01T00:00:00Z'
+```
+
+### Separate credentials for both API families
+
+When the Platform Usage and Codex Analytics APIs require different keys, include both in the same source URI:
+
+```plaintext
+openai://?api_key=<admin-api-key>&codex_api_key=<codex-analytics-api-key>
+```
+
+## Tables
+
+| Table | Incremental key | Strategy | Description |
+| --- | --- | --- | --- |
+| `api_usage` | `bucket_start` | delete-insert | Daily API completion usage grouped by OpenAI organization user. |
+
+`api_usage` supports `group_by` with one or more of: `project_id`, `user_id`, `api_key_id`, `model`, `batch`, and `service_tier`. Values may be comma-separated or supplied by repeating `group_by`. Unknown options and grouping fields return an error.
+
+`user_id` identifies the OpenAI organization user associated with API usage. It does not necessarily identify an end user of your application. If multiple customers share a service account or API key, maintain customer attribution in your own application data.

--- a/internal/registry/imports/openai.go
+++ b/internal/registry/imports/openai.go
@@ -1,0 +1,3 @@
+package imports
+
+import _ "github.com/bruin-data/ingestr/pkg/source/openai"

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -361,6 +361,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("mqtt", "MQTT", []string{"mqtt", "mqtts"}, true, false),
 		genericURIConnector("nats", "NATS JetStream", []string{"nats"}, true, false),
 		genericURIConnector("notion", "Notion", []string{"notion"}, true, false),
+		genericURIConnector("openai", "OpenAI", []string{"openai"}, true, false),
 		genericURIConnector("onelake", "OneLake", []string{"onelake"}, false, true),
 		genericURIConnector("oracle", "Oracle", []string{"oracle", "oracle+cx_oracle"}, true, true),
 		genericURIConnector("paddle", "Paddle", []string{"paddle"}, true, false),

--- a/pkg/source/openai/openai.go
+++ b/pkg/source/openai/openai.go
@@ -1,0 +1,387 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
+)
+
+const (
+	defaultBaseURL      = "https://api.openai.com"
+	usageEndpoint       = "/v1/organization/usage/completions"
+	defaultLookbackDays = 30
+	maxPageSize         = 31
+	maxPages            = 100000
+	defaultResultBuffer = 8
+
+	// OpenAI does not publish a fixed Admin Usage API quota; keep requests conservative.
+	rateLimit      = 1.0
+	rateLimitBurst = 1
+)
+
+var supportedTables = []string{"api_usage"}
+
+var supportedGroupBy = []string{
+	"project_id",
+	"user_id",
+	"api_key_id",
+	"model",
+	"batch",
+	"service_tier",
+}
+
+type OpenAISource struct {
+	baseURL        string
+	platformClient *httpclient.Client
+	codexClient    *httpclient.Client
+}
+
+type openAICredentials struct {
+	apiKey      string
+	codexAPIKey string
+}
+
+type apiUsageParams struct {
+	GroupBy []string `mapstructure:"group_by"`
+}
+
+type usagePage struct {
+	Data     []usageBucket `json:"data"`
+	HasMore  bool          `json:"has_more"`
+	NextPage string        `json:"next_page"`
+}
+
+type usageBucket struct {
+	StartTime json.Number              `json:"start_time"`
+	EndTime   json.Number              `json:"end_time"`
+	Results   []map[string]interface{} `json:"results"`
+}
+
+func NewOpenAISource() *OpenAISource {
+	return newOpenAISource(defaultBaseURL)
+}
+
+func newOpenAISource(baseURL string) *OpenAISource {
+	return &OpenAISource{baseURL: strings.TrimRight(baseURL, "/")}
+}
+
+func (s *OpenAISource) Schemes() []string {
+	return []string{"openai"}
+}
+
+func (s *OpenAISource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *OpenAISource) Connect(ctx context.Context, uri string) error {
+	credentials, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	if credentials.apiKey != "" {
+		s.platformClient = s.newClient(credentials.apiKey)
+	}
+	if credentials.codexAPIKey != "" {
+		s.codexClient = s.newClient(credentials.codexAPIKey)
+	}
+
+	config.Debug("[OPENAI] Connected successfully")
+	return nil
+}
+
+func (s *OpenAISource) newClient(apiKey string) *httpclient.Client {
+	return httpclient.New(
+		httpclient.WithBaseURL(s.baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithAuth(httpclient.NewBearerAuth(apiKey)),
+		httpclient.WithDebug(config.DebugMode),
+	)
+}
+
+func parseURI(raw string) (openAICredentials, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return openAICredentials{}, fmt.Errorf("failed to parse openai URI: %w", err)
+	}
+	if parsed.Scheme != "openai" {
+		return openAICredentials{}, fmt.Errorf("invalid openai URI: must start with openai://")
+	}
+	if parsed.Host != "" || parsed.Path != "" || parsed.User != nil || parsed.Fragment != "" {
+		return openAICredentials{}, fmt.Errorf("invalid openai URI: credentials must be query parameters (openai://?api_key=...&codex_api_key=...)")
+	}
+
+	values, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return openAICredentials{}, fmt.Errorf("failed to parse openai URI query: %w", err)
+	}
+	for key := range values {
+		if key != "api_key" && key != "codex_api_key" {
+			return openAICredentials{}, fmt.Errorf("unknown openai URI parameter: %s", key)
+		}
+	}
+
+	apiKey := values.Get("api_key")
+	codexAPIKey := values.Get("codex_api_key")
+	if apiKey == "" && codexAPIKey == "" {
+		return openAICredentials{}, fmt.Errorf("at least one of api_key or codex_api_key is required in openai URI")
+	}
+
+	return openAICredentials{apiKey: apiKey, codexAPIKey: codexAPIKey}, nil
+}
+
+func (s *OpenAISource) Close(ctx context.Context) error {
+	var errs []error
+	if s.platformClient != nil {
+		errs = append(errs, s.platformClient.Close())
+	}
+	if s.codexClient != nil {
+		errs = append(errs, s.codexClient.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func (s *OpenAISource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName, params, err := parseTableSpec(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !isValidTable(tableName) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, strings.Join(supportedTables, ", "))
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TableIncrementalKey: "bucket_start",
+		TableStrategy:       config.StrategyDeleteInsert,
+		TablePartitionBy:    "bucket_start",
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("openai source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.readAPIUsage(ctx, params, opts)
+		},
+	}, nil
+}
+
+func isValidTable(table string) bool {
+	return slices.Contains(supportedTables, table)
+}
+
+func parseTableSpec(raw string) (string, apiUsageParams, error) {
+	var params apiUsageParams
+	path, _, err := tablespec.Parse(raw, &params, tablespec.WithListSeparator(","))
+	if err != nil {
+		return "", apiUsageParams{}, err
+	}
+	if !isValidTable(path) {
+		return path, apiUsageParams{}, nil
+	}
+
+	if len(params.GroupBy) == 0 {
+		params.GroupBy = []string{"user_id"}
+	}
+
+	seen := make(map[string]struct{}, len(params.GroupBy))
+	for _, field := range params.GroupBy {
+		if !slices.Contains(supportedGroupBy, field) {
+			return "", apiUsageParams{}, fmt.Errorf("invalid group_by field %q (supported: %s)", field, strings.Join(supportedGroupBy, ", "))
+		}
+		if _, ok := seen[field]; ok {
+			return "", apiUsageParams{}, fmt.Errorf("duplicate group_by field %q", field)
+		}
+		seen[field] = struct{}{}
+	}
+
+	return path, params, nil
+}
+
+func (s *OpenAISource) readAPIUsage(ctx context.Context, params apiUsageParams, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	if s.platformClient == nil {
+		return nil, fmt.Errorf("api_key is required for table api_usage")
+	}
+
+	results := make(chan source.RecordBatchResult, source.RecordBatchBufferSize(opts, defaultResultBuffer))
+
+	go func() {
+		defer close(results)
+		if err := s.paginateAPIUsage(ctx, s.platformClient, params, opts, results); err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *OpenAISource) paginateAPIUsage(ctx context.Context, client *httpclient.Client, tableParams apiUsageParams, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	start, end, err := usageInterval(opts)
+	if err != nil {
+		return err
+	}
+	config.Debug("[OPENAI] Reading api_usage from %s to %s", start.Format(time.RFC3339), end.Format(time.RFC3339))
+
+	params := url.Values{
+		"start_time":   {strconv.FormatInt(start.Unix(), 10)},
+		"end_time":     {strconv.FormatInt(end.Unix(), 10)},
+		"bucket_width": {"1d"},
+		"limit":        {strconv.Itoa(maxPageSize)},
+		"group_by":     tableParams.GroupBy,
+	}
+
+	var pageCursor string
+	for page := 0; page < maxPages; page++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if pageCursor != "" {
+			params.Set("page", pageCursor)
+		}
+
+		resp, err := client.R(ctx).SetQueryParamValues(params).Get(usageEndpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch api_usage: %w", err)
+		}
+		if err := checkResponse(resp); err != nil {
+			return err
+		}
+
+		payload, err := decodeUsagePage(resp.Body())
+		if err != nil {
+			return fmt.Errorf("failed to decode api_usage response: %w", err)
+		}
+		items, err := flattenUsagePage(payload)
+		if err != nil {
+			return fmt.Errorf("failed to normalize api_usage response: %w", err)
+		}
+		if err := sendBatch(ctx, items, opts, results); err != nil {
+			return err
+		}
+
+		if !payload.HasMore {
+			return nil
+		}
+		if payload.NextPage == "" {
+			return fmt.Errorf("api_usage response has_more=true but next_page is empty")
+		}
+		pageCursor = payload.NextPage
+	}
+
+	config.Debug("[OPENAI] Stopped api_usage pagination after %d pages", maxPages)
+	return fmt.Errorf("api_usage pagination exceeded the %d-page safety limit", maxPages)
+}
+
+func usageInterval(opts source.ReadOptions) (time.Time, time.Time, error) {
+	now := time.Now().UTC()
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -defaultLookbackDays)
+	end := now
+	if opts.IntervalStart != nil {
+		start = opts.IntervalStart.UTC()
+	}
+	if opts.IntervalEnd != nil {
+		end = opts.IntervalEnd.UTC()
+	}
+	if !end.After(start) {
+		return time.Time{}, time.Time{}, fmt.Errorf("api_usage interval end must be after interval start")
+	}
+	return start, end, nil
+}
+
+func decodeUsagePage(body []byte) (usagePage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var page usagePage
+	if err := decoder.Decode(&page); err != nil {
+		return usagePage{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return usagePage{}, fmt.Errorf("response contains multiple JSON values")
+		}
+		return usagePage{}, err
+	}
+	return page, nil
+}
+
+func flattenUsagePage(page usagePage) ([]map[string]interface{}, error) {
+	items := make([]map[string]interface{}, 0)
+	for _, bucket := range page.Data {
+		start, err := unixTime(bucket.StartTime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bucket start_time %q: %w", bucket.StartTime, err)
+		}
+		end, err := unixTime(bucket.EndTime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bucket end_time %q: %w", bucket.EndTime, err)
+		}
+		for _, result := range bucket.Results {
+			item := make(map[string]interface{}, len(result)+2)
+			for key, value := range result {
+				item[key] = value
+			}
+			item["bucket_start"] = start
+			item["bucket_end"] = end
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+func unixTime(value json.Number) (time.Time, error) {
+	seconds, err := value.Int64()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(seconds, 0).UTC(), nil
+}
+
+func sendBatch(ctx context.Context, items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert api_usage data to Arrow: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		record.Release()
+		return ctx.Err()
+	case results <- source.RecordBatchResult{Batch: record}:
+		return nil
+	}
+}
+
+func checkResponse(resp *httpclient.Response) error {
+	if resp.IsSuccess() {
+		return nil
+	}
+	switch resp.StatusCode() {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("OpenAI API authentication or organization access failed for api_usage (status %d): %s", resp.StatusCode(), resp.String())
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("OpenAI API rate limit exceeded for api_usage (status 429): %s", resp.String())
+	default:
+		return fmt.Errorf("OpenAI API error for api_usage (status %d): %s", resp.StatusCode(), resp.String())
+	}
+}

--- a/pkg/source/openai/openai.go
+++ b/pkg/source/openai/openai.go
@@ -46,6 +46,11 @@ var supportedGroupBy = []string{
 	"service_tier",
 }
 
+var apiUsageColumns = []schema.Column{
+	{Name: "bucket_start", DataType: schema.TypeTimestampTZ},
+	{Name: "bucket_end", DataType: schema.TypeTimestampTZ},
+}
+
 type OpenAISource struct {
 	baseURL        string
 	platformClient *httpclient.Client
@@ -358,7 +363,11 @@ func sendBatch(ctx context.Context, items []map[string]interface{}, opts source.
 	if len(items) == 0 {
 		return nil
 	}
-	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	columns := apiUsageColumns
+	if opts.Schema != nil {
+		columns = opts.Schema.Columns
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, columns, opts.ExcludeColumns)
 	if err != nil {
 		return fmt.Errorf("failed to convert api_usage data to Arrow: %w", err)
 	}

--- a/pkg/source/openai/openai_test.go
+++ b/pkg/source/openai/openai_test.go
@@ -1,0 +1,181 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/registry"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantAPIKey   string
+		wantCodexKey string
+		wantErr      string
+	}{
+		{name: "platform key", uri: "openai://?api_key=sk-admin-test", wantAPIKey: "sk-admin-test"},
+		{name: "codex key", uri: "openai://?codex_api_key=sk-codex-test", wantCodexKey: "sk-codex-test"},
+		{name: "both keys", uri: "openai://?api_key=sk-admin-test&codex_api_key=sk-codex-test", wantAPIKey: "sk-admin-test", wantCodexKey: "sk-codex-test"},
+		{name: "encoded", uri: "openai://?api_key=key%2Bvalue&codex_api_key=codex%2Bvalue", wantAPIKey: "key+value", wantCodexKey: "codex+value"},
+		{name: "wrong scheme", uri: "https://?api_key=test", wantErr: "must start with openai://"},
+		{name: "missing keys", uri: "openai://", wantErr: "at least one of api_key or codex_api_key is required"},
+		{name: "empty keys", uri: "openai://?api_key=&codex_api_key=", wantErr: "at least one of api_key or codex_api_key is required"},
+		{name: "host is rejected", uri: "openai://host?api_key=test", wantErr: "credentials must be query parameters"},
+		{name: "unknown parameter", uri: "openai://?api_key=test&workspace_id=ws", wantErr: "unknown openai URI parameter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credentials, err := parseURI(tt.uri)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAPIKey, credentials.apiKey)
+			require.Equal(t, tt.wantCodexKey, credentials.codexAPIKey)
+		})
+	}
+}
+
+func TestParseTableSpec(t *testing.T) {
+	tests := []struct {
+		name      string
+		table     string
+		wantPath  string
+		wantGroup []string
+		wantErr   string
+	}{
+		{name: "default grouping", table: "api_usage", wantPath: "api_usage", wantGroup: []string{"user_id"}},
+		{name: "custom grouping", table: "api_usage?group_by=user_id,model", wantPath: "api_usage", wantGroup: []string{"user_id", "model"}},
+		{name: "unknown table", table: "codex_usage", wantPath: "codex_usage"},
+		{name: "unknown parameter", table: "api_usage?bucket_width=1h", wantErr: "unknown table parameter"},
+		{name: "invalid grouping", table: "api_usage?group_by=organization_id", wantErr: "invalid group_by field"},
+		{name: "duplicate grouping", table: "api_usage?group_by=user_id,user_id", wantErr: "duplicate group_by field"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, params, err := parseTableSpec(tt.table)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPath, path)
+			require.Equal(t, tt.wantGroup, params.GroupBy)
+		})
+	}
+}
+
+func TestGetTable(t *testing.T) {
+	src := NewOpenAISource()
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "api_usage?group_by=user_id,model"})
+	require.NoError(t, err)
+	require.Equal(t, "api_usage", table.Name())
+	require.Equal(t, "bucket_start", table.IncrementalKey())
+	require.Equal(t, "bucket_start", table.(source.PartitionedTable).PartitionBy())
+	require.Equal(t, config.StrategyDeleteInsert, table.Strategy())
+	require.False(t, table.HasKnownSchema())
+}
+
+func TestReadAPIUsagePaginatesAndPreservesLargeIntegers(t *testing.T) {
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	var requests int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		require.Equal(t, usageEndpoint, r.URL.Path)
+		require.Equal(t, "Bearer sk-admin-test", r.Header.Get("Authorization"))
+		require.Equal(t, fmt.Sprint(start.Unix()), r.URL.Query().Get("start_time"))
+		require.Equal(t, fmt.Sprint(end.Unix()), r.URL.Query().Get("end_time"))
+		require.Equal(t, "1d", r.URL.Query().Get("bucket_width"))
+		require.Equal(t, "31", r.URL.Query().Get("limit"))
+		require.Equal(t, []string{"user_id", "model"}, r.URL.Query()["group_by"])
+
+		switch r.URL.Query().Get("page") {
+		case "":
+			_, _ = fmt.Fprintf(w, `{"object":"page","data":[{"object":"bucket","start_time":%d,"end_time":%d,"results":[{"object":"organization.usage.completions.result","input_tokens":9007199254740993,"output_tokens":2,"user_id":"user-1","model":"gpt-test"}]}],"has_more":true,"next_page":"page-2"}`, start.Unix(), start.AddDate(0, 0, 1).Unix())
+		case "page-2":
+			_, _ = fmt.Fprintf(w, `{"object":"page","data":[{"object":"bucket","start_time":%d,"end_time":%d,"results":[{"object":"organization.usage.completions.result","input_tokens":3,"output_tokens":4,"user_id":"user-2","model":"gpt-test"}]}],"has_more":false}`, start.AddDate(0, 0, 1).Unix(), end.Unix())
+		default:
+			t.Fatalf("unexpected page cursor %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	src := newOpenAISource(server.URL)
+	require.NoError(t, src.Connect(context.Background(), "openai://?api_key=sk-admin-test&codex_api_key=sk-codex-test"))
+	t.Cleanup(func() { require.NoError(t, src.Close(context.Background())) })
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "api_usage?group_by=user_id,model"})
+	require.NoError(t, err)
+	results, err := table.Read(context.Background(), source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	require.NoError(t, err)
+
+	var records []arrow.RecordBatch
+	for result := range results {
+		require.NoError(t, result.Err)
+		records = append(records, result.Batch)
+	}
+	require.Equal(t, 2, requests)
+	require.Len(t, records, 2)
+	require.EqualValues(t, 1, records[0].NumRows())
+	require.EqualValues(t, 1, records[1].NumRows())
+	for _, record := range records {
+		record.Release()
+	}
+}
+
+func TestAPIUsageRequiresPlatformKey(t *testing.T) {
+	src := NewOpenAISource()
+	require.NoError(t, src.Connect(context.Background(), "openai://?codex_api_key=sk-codex-test"))
+	t.Cleanup(func() { require.NoError(t, src.Close(context.Background())) })
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "api_usage"})
+	require.NoError(t, err)
+	_, err = table.Read(context.Background(), source.ReadOptions{})
+	require.ErrorContains(t, err, "api_key is required for table api_usage")
+}
+
+func TestDecodeUsagePageUsesJSONNumber(t *testing.T) {
+	page, err := decodeUsagePage([]byte(`{"data":[{"start_time":1,"end_time":2,"results":[{"input_tokens":9007199254740993}]}],"has_more":false}`))
+	require.NoError(t, err)
+
+	value, ok := page.Data[0].Results[0]["input_tokens"].(json.Number)
+	require.True(t, ok)
+	require.Equal(t, json.Number("9007199254740993"), value)
+}
+
+func TestUsageIntervalRejectsInvalidRange(t *testing.T) {
+	start := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	end := start
+	_, _, err := usageInterval(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	require.ErrorContains(t, err, "end must be after interval start")
+}
+
+func TestUnsupportedTable(t *testing.T) {
+	src := NewOpenAISource()
+	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "codex_usage"})
+	require.ErrorContains(t, err, "unsupported table")
+}
+
+func TestRegistryLookup(t *testing.T) {
+	constructor, err := registry.Default.GetSourceConstructor("openai")
+	require.NoError(t, err)
+	src, ok := constructor().(source.Source)
+	require.True(t, ok)
+	require.Contains(t, src.Schemes(), "openai")
+}

--- a/pkg/source/openai/openai_test.go
+++ b/pkg/source/openai/openai_test.go
@@ -134,6 +134,10 @@ func TestReadAPIUsagePaginatesAndPreservesLargeIntegers(t *testing.T) {
 	require.Len(t, records, 2)
 	require.EqualValues(t, 1, records[0].NumRows())
 	require.EqualValues(t, 1, records[1].NumRows())
+	require.Equal(t, "bucket_start", records[0].Schema().Field(0).Name)
+	require.Equal(t, arrow.TIMESTAMP, records[0].Schema().Field(0).Type.ID())
+	require.Equal(t, "bucket_end", records[0].Schema().Field(1).Name)
+	require.Equal(t, arrow.TIMESTAMP, records[0].Schema().Field(1).Type.ID())
 	for _, record := range records {
 		record.Release()
 	}

--- a/pkg/source/openai/register.go
+++ b/pkg/source/openai/register.go
@@ -1,0 +1,10 @@
+package openai
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"openai"},
+		func() interface{} { return NewOpenAISource() },
+	)
+}


### PR DESCRIPTION
## What
Adds an OpenAI source for daily organization API usage.

## Changes
- Adds the OpenAI usage connector, tests, documentation, and UI registration.

## How to test
1. Run `make format && make lint && make test`.

## Risk & rollback
- **Risk:** Low; this adds an opt-in source.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
- None