### PR TITLE
perf(mongodb): reduce BSON extraction allocations

### DIFF
--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -692,6 +692,7 @@ func (s *MongoDBSource) readAggregate(ctx context.Context, collection *mongo.Col
 func (s *MongoDBSource) consumeCursor(ctx context.Context, cursor *mongo.Cursor, batchSize int, opts source.ReadOptions, results chan<- source.RecordBatchResult, startTotal time.Time) {
 	batchNum := 0
 	totalRows := int64(0)
+	mem := newRecyclingAllocator(memory.NewGoAllocator(), mongoArrowBufferCacheSize)
 
 	for {
 		select {
@@ -702,9 +703,9 @@ func (s *MongoDBSource) consumeCursor(ctx context.Context, cursor *mongo.Cursor,
 		}
 
 		startBatch := time.Now()
-		var builder mongoRecordBatchBuilder = newMongoRawBatchBuilderWithCapacity(opts.ExcludeColumns, batchSize)
+		var builder mongoRecordBatchBuilder = newMongoRawBatchBuilderWithAllocator(mem, opts.ExcludeColumns, batchSize)
 		if opts.Schema != nil {
-			builder = newMongoSchemaBatchBuilderWithCapacity(opts.Schema.Columns, opts.ExcludeColumns, batchSize)
+			builder = newMongoSchemaBatchBuilderWithAllocator(mem, opts.Schema.Columns, opts.ExcludeColumns, batchSize)
 		}
 		batchRows := 0
 
@@ -1035,13 +1036,17 @@ func newMongoRawBatchBuilder(excludeColumns []string) *mongoRawBatchBuilder {
 }
 
 func newMongoRawBatchBuilderWithCapacity(excludeColumns []string, rowCapacity int) *mongoRawBatchBuilder {
+	return newMongoRawBatchBuilderWithAllocator(memory.NewGoAllocator(), excludeColumns, rowCapacity)
+}
+
+func newMongoRawBatchBuilderWithAllocator(mem memory.Allocator, excludeColumns []string, rowCapacity int) *mongoRawBatchBuilder {
 	excludeMap := make(map[string]bool, len(excludeColumns))
 	for _, col := range excludeColumns {
 		excludeMap[strings.ToLower(col)] = true
 	}
 
 	return &mongoRawBatchBuilder{
-		mem:         memory.NewGoAllocator(),
+		mem:         mem,
 		excludeMap:  excludeMap,
 		hasExcludes: len(excludeMap) > 0,
 		fieldOrder:  make([]string, 0),
@@ -1068,6 +1073,7 @@ func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 	var stackFields [64]rawDocumentField
 	fields := stackFields[:0]
 	generation := b.nextGeneration()
+	nextFieldIndex := 0
 
 	for length > 1 {
 		elem, next, ok := bsoncore.ReadElement(rem)
@@ -1090,8 +1096,12 @@ func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 		}
 
 		key := transientString(keyBytes)
-		index, ok := b.columnIndex[key]
-		if !ok {
+		index := nextFieldIndex
+		exists := index < len(b.fieldOrder) && b.fieldOrder[index] == key
+		if !exists {
+			index, exists = b.columnIndex[key]
+		}
+		if !exists {
 			key = string(keyBytes)
 			index = len(b.columns)
 			b.columnIndex[key] = index
@@ -1100,6 +1110,7 @@ func (b *mongoRawBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 			b.seenAt = append(b.seenAt, 0)
 			b.fieldAt = append(b.fieldAt, 0)
 		}
+		nextFieldIndex = index + 1
 
 		value := rawValueFromCore(val)
 		if b.seenAt[index] == generation {
@@ -1216,6 +1227,10 @@ func newMongoSchemaBatchBuilder(columns []schema.Column, excludeColumns []string
 }
 
 func newMongoSchemaBatchBuilderWithCapacity(columns []schema.Column, excludeColumns []string, rowCapacity int) *mongoSchemaBatchBuilder {
+	return newMongoSchemaBatchBuilderWithAllocator(memory.NewGoAllocator(), columns, excludeColumns, rowCapacity)
+}
+
+func newMongoSchemaBatchBuilderWithAllocator(mem memory.Allocator, columns []schema.Column, excludeColumns []string, rowCapacity int) *mongoSchemaBatchBuilder {
 	excludeMap := make(map[string]bool, len(excludeColumns))
 	for _, col := range excludeColumns {
 		excludeMap[strings.ToLower(col)] = true
@@ -1229,7 +1244,6 @@ func newMongoSchemaBatchBuilderWithCapacity(columns []schema.Column, excludeColu
 		filtered = append(filtered, col)
 	}
 
-	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(filtered))
 	columnIndex := make(map[string]int, len(filtered))
 	for i, col := range filtered {
@@ -1280,6 +1294,7 @@ func (b *mongoSchemaBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 	var stackFields [64]rawDocumentField
 	fields := stackFields[:0]
 	generation := b.nextGeneration()
+	nextFieldIndex := 0
 	for length > 1 {
 		elem, next, ok := bsoncore.ReadElement(rem)
 		if !ok {
@@ -1292,10 +1307,16 @@ func (b *mongoSchemaBatchBuilder) AppendRawDocument(doc bson.Raw) error {
 		if err != nil {
 			return err
 		}
-		index, exists := b.columnIndex[transientString(key)]
+		keyString := transientString(key)
+		index := nextFieldIndex
+		exists := index < len(b.columns) && b.columns[index].Name == keyString
+		if !exists {
+			index, exists = b.columnIndex[keyString]
+		}
 		if !exists {
 			continue
 		}
+		nextFieldIndex = index + 1
 		value, err := elem.ValueErr()
 		if err != nil {
 			return err

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/arrowutil"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -1161,6 +1162,55 @@ func TestMongoRawBatchBuilder_DuplicateKeysMatchDecodedPath(t *testing.T) {
 	}
 }
 
+func TestMongoRawBatchBuilder_FieldOrderFallbacks(t *testing.T) {
+	documents := []bson.Raw{
+		bson.Raw(bsoncore.NewDocumentBuilder().
+			AppendInt32("a", 1).
+			AppendString("b", "one").
+			AppendBoolean("c", true).
+			Build()),
+		bson.Raw(bsoncore.NewDocumentBuilder().
+			AppendBoolean("c", false).
+			AppendInt32("a", 2).
+			Build()),
+		bson.Raw(bsoncore.NewDocumentBuilder().
+			AppendString("d", "new").
+			AppendString("b", "three").
+			AppendInt32("a", 3).
+			Build()),
+	}
+
+	builder := newMongoRawBatchBuilder(nil)
+	for _, document := range documents {
+		if err := builder.AppendRawDocument(document); err != nil {
+			t.Fatalf("AppendRawDocument error = %v", err)
+		}
+	}
+	record, err := builder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("NewRecordBatch error = %v", err)
+	}
+	defer record.Release()
+
+	want := map[string][]any{
+		"a": {int64(1), int64(2), int64(3)},
+		"b": {"one", nil, "three"},
+		"c": {true, false, nil},
+		"d": {nil, nil, "new"},
+	}
+	if got := int(record.NumCols()); got != len(want) {
+		t.Fatalf("NumCols = %d, want %d", got, len(want))
+	}
+	for columnIndex := 0; columnIndex < int(record.NumCols()); columnIndex++ {
+		name := record.Schema().Field(columnIndex).Name
+		for row, expected := range want[name] {
+			if got := arrowutil.Value(record.Column(columnIndex), row); got != expected {
+				t.Fatalf("%s row %d = %#v, want %#v", name, row, got, expected)
+			}
+		}
+	}
+}
+
 func TestMongoRawBatchBuilder_NestedTemporalValuesMatchDecodedPath(t *testing.T) {
 	nested := bsoncore.NewDocumentBuilder().
 		AppendDateTime("dt", 1_782_003_600_123).
@@ -1365,6 +1415,54 @@ func TestMongoSchemaBatchBuilder_UsesProvidedSchema(t *testing.T) {
 	}
 }
 
+func TestMongoSchemaBatchBuilder_FieldOrderFallbacks(t *testing.T) {
+	builder := newMongoSchemaBatchBuilder([]schema.Column{
+		{Name: "a", DataType: schema.TypeInt64},
+		{Name: "b", DataType: schema.TypeString},
+		{Name: "c", DataType: schema.TypeBoolean},
+	}, nil)
+	documents := []bson.Raw{
+		bson.Raw(bsoncore.NewDocumentBuilder().
+			AppendInt32("a", 1).
+			AppendString("b", "one").
+			AppendBoolean("c", true).
+			Build()),
+		bson.Raw(bsoncore.NewDocumentBuilder().
+			AppendString("extra", "ignored").
+			AppendBoolean("c", false).
+			AppendInt32("a", 2).
+			Build()),
+		bson.Raw(bsoncore.NewDocumentBuilder().
+			AppendString("b", "three").
+			AppendInt32("a", 3).
+			Build()),
+	}
+	for _, document := range documents {
+		if err := builder.AppendRawDocument(document); err != nil {
+			t.Fatalf("AppendRawDocument error = %v", err)
+		}
+	}
+
+	record, err := builder.NewRecordBatch()
+	if err != nil {
+		t.Fatalf("NewRecordBatch error = %v", err)
+	}
+	defer record.Release()
+
+	want := [][]any{
+		{int64(1), int64(2), int64(3)},
+		{"one", nil, "three"},
+		{true, false, nil},
+	}
+	for columnIndex, values := range want {
+		for row, expected := range values {
+			if got := arrowutil.Value(record.Column(columnIndex), row); got != expected {
+				t.Fatalf("column %d row %d = %#v, want %#v", columnIndex, row, got, expected)
+			}
+		}
+	}
+}
+
 func BenchmarkMongoRawBatchBuilder(b *testing.B) {
 	benchmarkMongoRawBatchBuilder(b, 25_000)
 }
@@ -1373,13 +1471,29 @@ func BenchmarkMongoRawBatchBuilderNoReserve(b *testing.B) {
 	benchmarkMongoRawBatchBuilder(b, 0)
 }
 
+func BenchmarkMongoRawBatchBuilderRecyclingAllocator(b *testing.B) {
+	for _, cacheSize := range []int{8 << 20, 16 << 20, 32 << 20, 64 << 20} {
+		b.Run(fmt.Sprintf("Cache%dMiB", cacheSize>>20), func(b *testing.B) {
+			benchmarkMongoRawBatchBuilderWithAllocator(
+				b,
+				25_000,
+				newRecyclingAllocator(memory.NewGoAllocator(), cacheSize),
+			)
+		})
+	}
+}
+
 func benchmarkMongoRawBatchBuilder(b *testing.B, rowCapacity int) {
+	benchmarkMongoRawBatchBuilderWithAllocator(b, rowCapacity, memory.NewGoAllocator())
+}
+
+func benchmarkMongoRawBatchBuilderWithAllocator(b *testing.B, rowCapacity int, mem memory.Allocator) {
 	raw := benchmarkMongoRawDocument(b)
 	b.SetBytes(int64(len(raw)))
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	builder := newMongoRawBatchBuilderWithCapacity(nil, rowCapacity)
+	builder := newMongoRawBatchBuilderWithAllocator(mem, nil, rowCapacity)
 	for i := 0; i < b.N; i++ {
 		if err := builder.AppendRawDocument(raw); err != nil {
 			b.Fatal(err)
@@ -1427,14 +1541,26 @@ func BenchmarkMongoSchemaRawBatchBuilderNoReserve(b *testing.B) {
 	benchmarkMongoSchemaRawBatchBuilder(b, 0)
 }
 
+func BenchmarkMongoSchemaRawBatchBuilderRecyclingAllocator(b *testing.B) {
+	benchmarkMongoSchemaRawBatchBuilderWithAllocator(
+		b,
+		25_000,
+		newRecyclingAllocator(memory.NewGoAllocator(), mongoArrowBufferCacheSize),
+	)
+}
+
 func benchmarkMongoSchemaRawBatchBuilder(b *testing.B, rowCapacity int) {
+	benchmarkMongoSchemaRawBatchBuilderWithAllocator(b, rowCapacity, memory.NewGoAllocator())
+}
+
+func benchmarkMongoSchemaRawBatchBuilderWithAllocator(b *testing.B, rowCapacity int, mem memory.Allocator) {
 	raw := benchmarkMongoRawDocument(b)
 	columns := benchmarkMongoSchema()
 	b.SetBytes(int64(len(raw)))
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	builder := newMongoSchemaBatchBuilderWithCapacity(columns, nil, rowCapacity)
+	builder := newMongoSchemaBatchBuilderWithAllocator(mem, columns, nil, rowCapacity)
 	for i := 0; i < b.N; i++ {
 		if err := builder.AppendRawDocument(raw); err != nil {
 			b.Fatal(err)
@@ -1445,7 +1571,7 @@ func benchmarkMongoSchemaRawBatchBuilder(b *testing.B, rowCapacity int) {
 				b.Fatal(err)
 			}
 			record.Release()
-			builder = newMongoSchemaBatchBuilderWithCapacity(columns, nil, rowCapacity)
+			builder = newMongoSchemaBatchBuilderWithAllocator(mem, columns, nil, rowCapacity)
 		}
 	}
 

--- a/pkg/source/mongodb/recycling_allocator.go
+++ b/pkg/source/mongodb/recycling_allocator.go
@@ -1,0 +1,77 @@
+package mongodb
+
+import (
+	"sync"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+const mongoArrowBufferCacheSize = 32 << 20
+
+type recyclingAllocator struct {
+	upstream       memory.Allocator
+	maxCachedBytes int
+
+	mu          sync.Mutex
+	free        map[int][][]byte
+	cachedBytes int
+}
+
+func newRecyclingAllocator(upstream memory.Allocator, maxCachedBytes int) *recyclingAllocator {
+	return &recyclingAllocator{
+		upstream:       upstream,
+		maxCachedBytes: maxCachedBytes,
+		free:           make(map[int][][]byte),
+	}
+}
+
+func (a *recyclingAllocator) Allocate(size int) []byte {
+	a.mu.Lock()
+	buffers := a.free[size]
+	if len(buffers) > 0 {
+		buffer := buffers[len(buffers)-1]
+		if len(buffers) == 1 {
+			delete(a.free, size)
+		} else {
+			a.free[size] = buffers[:len(buffers)-1]
+		}
+		a.cachedBytes -= cap(buffer)
+		a.mu.Unlock()
+		clear(buffer)
+		return buffer
+	}
+	a.mu.Unlock()
+
+	return a.upstream.Allocate(size)
+}
+
+func (a *recyclingAllocator) Reallocate(size int, buffer []byte) []byte {
+	if cap(buffer) >= size {
+		if size > len(buffer) {
+			clear(buffer[len(buffer):size])
+		}
+		return buffer[:size]
+	}
+
+	resized := a.Allocate(size)
+	copy(resized, buffer)
+	a.Free(buffer)
+	return resized
+}
+
+func (a *recyclingAllocator) Free(buffer []byte) {
+	if len(buffer) == 0 || cap(buffer) > a.maxCachedBytes {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cachedBytes+cap(buffer) > a.maxCachedBytes {
+		return
+	}
+
+	a.free[len(buffer)] = append(a.free[len(buffer)], buffer)
+	a.cachedBytes += cap(buffer)
+}
+
+var _ memory.Allocator = (*recyclingAllocator)(nil)

--- a/pkg/source/mongodb/recycling_allocator_test.go
+++ b/pkg/source/mongodb/recycling_allocator_test.go
@@ -1,0 +1,72 @@
+package mongodb
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+type countingAllocator struct {
+	memory.Allocator
+	allocations int
+}
+
+func (a *countingAllocator) Allocate(size int) []byte {
+	a.allocations++
+	return a.Allocator.Allocate(size)
+}
+
+func TestRecyclingAllocatorReusesAndClearsBuffers(t *testing.T) {
+	upstream := &countingAllocator{Allocator: memory.NewGoAllocator()}
+	allocator := newRecyclingAllocator(upstream, 1024)
+
+	buffer := allocator.Allocate(128)
+	for i := range buffer {
+		buffer[i] = 0xff
+	}
+	allocator.Free(buffer)
+
+	reused := allocator.Allocate(128)
+	if upstream.allocations != 1 {
+		t.Fatalf("upstream allocations = %d, want 1", upstream.allocations)
+	}
+	for i, value := range reused {
+		if value != 0 {
+			t.Fatalf("reused buffer byte %d = %d, want 0", i, value)
+		}
+	}
+}
+
+func TestRecyclingAllocatorHonorsCacheLimit(t *testing.T) {
+	upstream := &countingAllocator{Allocator: memory.NewGoAllocator()}
+	allocator := newRecyclingAllocator(upstream, 128)
+
+	allocator.Free(allocator.Allocate(128))
+	allocator.Free(allocator.Allocate(64))
+	allocator.Allocate(64)
+
+	if upstream.allocations != 3 {
+		t.Fatalf("upstream allocations = %d, want 3", upstream.allocations)
+	}
+}
+
+func TestRecyclingAllocatorReallocatePreservesContents(t *testing.T) {
+	upstream := &countingAllocator{Allocator: memory.NewGoAllocator()}
+	allocator := newRecyclingAllocator(upstream, 1024)
+
+	buffer := allocator.Allocate(64)
+	copy(buffer, []byte("mongodb"))
+	resized := allocator.Reallocate(128, buffer)
+
+	if got := string(resized[:7]); got != "mongodb" {
+		t.Fatalf("reallocated contents = %q, want %q", got, "mongodb")
+	}
+	if upstream.allocations != 2 {
+		t.Fatalf("upstream allocations = %d, want 2", upstream.allocations)
+	}
+
+	allocator.Allocate(64)
+	if upstream.allocations != 2 {
+		t.Fatalf("upstream allocations after reuse = %d, want 2", upstream.allocations)
+	}
+}


### PR DESCRIPTION
## What

Reduce MongoDB BSON extraction allocations and CPU by recycling released Arrow buffers and using document field order as a fast path.

## Changes

- Add a cursor-scoped, thread-safe 32 MiB Arrow buffer cache.
- Avoid repeated field-map lookups when BSON order matches the learned schema, with fallbacks for reordered, missing, duplicate, and new fields.
- Add allocator and field-order correctness tests plus allocation benchmarks.

The 1M BSON-to-DuckDB benchmark improved from 14.87s to 14.08s end to end and from 7.21s to 6.27s in extraction.

## How to test

1. `make format`
2. `make lint`
3. `make test`

## Risk & rollback

- **Risk:** Low; reuse is bounded and field-order mismatches retain the existing map lookup path.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

N/A
