### PR TITLE
Support partitioned extraction for custom queries

### DIFF
--- a/docs/supported-sources/custom_queries.md
+++ b/docs/supported-sources/custom_queries.md
@@ -48,3 +48,35 @@ ingestr ingest \
 
 In this example, the query is filtering the data to only include rows where the `updated_at` column is greater than the `interval_start` variable.
 
+### Parallel extract partitioning
+
+Custom queries on PostgreSQL, MySQL, Microsoft SQL Server, SQLite, DuckDB, Snowflake, and BigQuery can split the query result into parallel extract windows. The partition column must be returned by the query and must have a unique output name.
+
+```bash
+ingestr ingest \
+    --source-uri "$POSTGRES_URI" \
+    --source-table "query:select oi.*, o.created_at as partition_ts, o.updated_at from order_items oi join orders o on oi.order_id = o.id where o.updated_at >= :interval_start and o.updated_at <= :interval_end" \
+    --dest-uri "$DEST_URI" \
+    --dest-table public.order_items \
+    --incremental-key updated_at \
+    --incremental-strategy merge \
+    --primary-key id \
+    --interval-start 2026-01-01 \
+    --interval-end 2026-02-01 \
+    --extract-partition-by partition_ts \
+    --extract-partition-interval 1d \
+    --extract-parallelism 4
+```
+
+ingestr applies each partition predicate to the result of the custom query, equivalent to:
+
+```sql
+SELECT *
+FROM (<custom query>) AS __ingestr_query
+WHERE __ingestr_query.partition_ts >= <window start>
+  AND __ingestr_query.partition_ts < <window end>
+```
+
+The final window includes its end boundary. Numeric partition columns and `--extract-partition-interval auto` use a bounds query over the same custom-query result.
+
+Because the query is used as a derived table, it must be a single query that is valid inside a `FROM (...)` clause. Some dialect-specific constructs, such as an unbounded `ORDER BY` in Microsoft SQL Server, cannot be used in a derived table.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,12 +271,6 @@ func (c *IngestConfig) validateExtractPartitioning() error {
 	case StrategyReplace, StrategyTruncateInsert:
 		return &ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("%q cannot be combined with extract partitioning because it rewrites the whole destination table from a bounded source read", c.IncrementalStrategy)}
 	}
-	if rawQuery, ok := strings.CutPrefix(c.SourceTable, "query:"); ok {
-		if strings.TrimSpace(rawQuery) == "" {
-			return nil
-		}
-		return &ValidationError{Field: "source-table", Message: "custom queries do not support extract partitioning"}
-	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -372,9 +372,8 @@ func TestIngestConfigValidate_ExtractPartitioning(t *testing.T) {
 			wantErr: "source-uri",
 		},
 		{
-			name:    "custom query rejected",
-			mutate:  func(c *IngestConfig) { c.SourceTable = "query:select * from orders" },
-			wantErr: "source-table",
+			name:   "custom query accepted",
+			mutate: func(c *IngestConfig) { c.SourceTable = "query:select * from orders" },
 		},
 		{
 			name:    "full refresh rejected",

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -414,6 +414,31 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	var preStageRpt *preStageReport
 	var preStageKeyTransform func(string) string
 	var preStagedForJob destination.PreStagedData
+	var extractReadSchema *schema.TableSchema
+
+	if p.config.ExtractPartitionBy != "" && !table.HasKnownSchema() {
+		provider, ok := table.(source.ReadSchemaProvider)
+		if ok && provider.SupportsReadSchema() {
+			extractReadSchema, err = provider.GetReadSchema(ctx, source.ReadOptions{
+				IncrementalKey:     table.IncrementalKey(),
+				IntervalStart:      p.config.IntervalStart,
+				IntervalEnd:        p.config.IntervalEnd,
+				ExtractPartitionBy: p.config.ExtractPartitionBy,
+				Columns:            p.config.Columns,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get custom query schema for extract partitioning: %w", err)
+			}
+			if err := applyExtractReadSchemaOverrides(extractReadSchema, p.config.Columns, p.config.SchemaNaming); err != nil {
+				return fmt.Errorf("failed to apply column overrides to custom query schema: %w", err)
+			}
+			partitionColumn, err := source.ValidateExtractPartitionColumn(extractReadSchema, p.config.ExtractPartitionBy)
+			if err != nil {
+				return err
+			}
+			p.config.ExtractPartitionBy = partitionColumn
+		}
+	}
 
 	if table.HasKnownSchema() {
 		tableSchema, err = table.GetSchema(ctx)
@@ -431,7 +456,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		config.Debug("[PIPELINE] Source has unknown schema, inferring from data...")
 		var preStage destination.PreStageWriter
 		preStage, preStageKeyTransform = p.maybeStartPreStage(ctx, preFetchStrategy, preFetchConfig.PrimaryKeys, loadTimestamp)
-		tableSchema, inferBuffer, preStagedData, preStageRpt, err = p.inferSchemaFromData(ctx, table, tracker, preStage)
+		tableSchema, inferBuffer, preStagedData, preStageRpt, err = p.inferSchemaFromData(ctx, table, tracker, preStage, extractReadSchema)
 		defer func() {
 			if preStagedData != nil {
 				preStagedData.Close()
@@ -449,7 +474,10 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 			config.Debug("[PIPELINE] Inferred schema with %d columns", len(tableSchema.Columns))
 		} else {
 			config.Debug("[PIPELINE] Inferred schema is nil")
-			if fallback, err := table.GetSchema(ctx); err == nil && fallback != nil && len(fallback.Columns) > 0 {
+			if extractReadSchema != nil && len(extractReadSchema.Columns) > 0 {
+				tableSchema = extractReadSchema
+				config.Debug("[PIPELINE] Using custom query metadata schema (%d columns) for empty extract", len(extractReadSchema.Columns))
+			} else if fallback, err := table.GetSchema(ctx); err == nil && fallback != nil && len(fallback.Columns) > 0 {
 				tableSchema = fallback
 				config.Debug("[PIPELINE] Using source-provided schema (%d columns) for empty extract", len(fallback.Columns))
 			} else if synthetic, err := schemainfer.TableSchemaFromColumnOverrides(p.config.Columns, table.Name(), p.config.SchemaNaming); err != nil {
@@ -480,7 +508,11 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	}
 
 	if p.config.ExtractPartitionBy != "" {
-		partitionColumn, err := source.ValidateExtractPartitionColumn(tableSchema, p.config.ExtractPartitionBy)
+		partitionSchema := tableSchema
+		if extractReadSchema != nil {
+			partitionSchema = extractReadSchema
+		}
+		partitionColumn, err := source.ValidateExtractPartitionColumn(partitionSchema, p.config.ExtractPartitionBy)
 		if err != nil {
 			return err
 		}
@@ -701,24 +733,25 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	}
 
 	job := &strategy.IngestionJob{
-		Config:              &resolvedConfig,
-		Table:               table,
-		Destination:         dest,
-		Schema:              ingestSchema,
-		SourceSchema:        originalSourceSchema,
-		Tracker:             jobTracker,
-		BufferedRecords:     bufferedRecords,
-		PreStaged:           preStagedForJob,
-		SchemaComparison:    p.schemaComparison,
-		DestinationSchema:   p.destinationSchema,
-		ColumnRenamer:       p.columnRenamer,
-		IngestrColumnFiller: p.ingestrColumnFiller,
-		ColumnMasker:        columnMasker,
-		WhitespaceTrimmer:   whitespaceTrimmer,
-		LoadTimestamp:       loadTimestampTransformer,
-		SchemaAligner:       transformer.NewSafeTypeCaster(ingestSchema.ToArrowSchema()).EnableRetarget(),
-		EvolutionPlan:       evolutionPlan,
-		CDCStateManager:     cdcStateManager,
+		Config:                 &resolvedConfig,
+		Table:                  table,
+		Destination:            dest,
+		Schema:                 ingestSchema,
+		SourceSchema:           originalSourceSchema,
+		ExtractPartitionSchema: extractReadSchema,
+		Tracker:                jobTracker,
+		BufferedRecords:        bufferedRecords,
+		PreStaged:              preStagedForJob,
+		SchemaComparison:       p.schemaComparison,
+		DestinationSchema:      p.destinationSchema,
+		ColumnRenamer:          p.columnRenamer,
+		IngestrColumnFiller:    p.ingestrColumnFiller,
+		ColumnMasker:           columnMasker,
+		WhitespaceTrimmer:      whitespaceTrimmer,
+		LoadTimestamp:          loadTimestampTransformer,
+		SchemaAligner:          transformer.NewSafeTypeCaster(ingestSchema.ToArrowSchema()).EnableRetarget(),
+		EvolutionPlan:          evolutionPlan,
+		CDCStateManager:        cdcStateManager,
 	}
 
 	// For --no-inference, enforce the user-provided source schema even when
@@ -893,6 +926,24 @@ func (p *Pipeline) schemaFromColumnOverrides(table source.SourceTable) (*schema.
 	return tableSchema, nil
 }
 
+func applyExtractReadSchemaOverrides(tableSchema *schema.TableSchema, columnsSpec, schemaNaming string) error {
+	if tableSchema == nil {
+		return nil
+	}
+	overrides, err := schemaevolution.ParseColumnOverrides(columnsSpec)
+	if err != nil {
+		return err
+	}
+	for i, column := range tableSchema.Columns {
+		override, ok := overrides.GetForColumn(column.Name, schemaNaming)
+		if !ok || override.DataType == schema.TypeUnknown {
+			continue
+		}
+		tableSchema.Columns[i] = override.ApplyToColumn(column)
+	}
+	return nil
+}
+
 func (p *Pipeline) buildSourceSchemaCaster(sourceSchema *schema.TableSchema) *transformer.TypeCaster {
 	if sourceSchema == nil {
 		return nil
@@ -983,6 +1034,7 @@ func (p *Pipeline) inferSchemaFromData(
 	table source.SourceTable,
 	tracker progress.Tracker,
 	preStage destination.PreStageWriter,
+	readSchema *schema.TableSchema,
 ) (*schema.TableSchema, *databuffer.FileBuffer, destination.PreStagedData, *preStageReport, error) {
 	// Create schema inferrer and file-backed data buffer
 	inferrer := schemainfer.NewSchemaInferrer()
@@ -1014,6 +1066,8 @@ func (p *Pipeline) inferSchemaFromData(
 		Parallelism:                     parallelism,
 		FullRefresh:                     p.config.FullRefresh,
 		Columns:                         p.config.Columns,
+		Schema:                          readSchema,
+		ExtractPartitionSchema:          readSchema,
 	}
 
 	records, err := table.Read(ctx, readOpts)
@@ -2386,12 +2440,9 @@ func validateExtractPartitionSupport(cfg *config.IngestConfig, table source.Sour
 	if cfg.ExtractPartitionBy == "" {
 		return nil
 	}
-	if table.Name() == source.CustomQueryTableName {
-		return fmt.Errorf("custom queries do not support extract partitioning")
-	}
 	provider, ok := table.(source.ExtractPartitioningProvider)
 	if !ok || !provider.SupportsExtractPartitioning() {
-		return fmt.Errorf("source table %q does not support extract partitioning; v1 supports normal SQL table scans for postgres, mysql, mssql, sqlite, and ADBC-backed sources", table.Name())
+		return fmt.Errorf("source table %q does not support extract partitioning; supported sources are postgres, mysql, mssql, sqlite, and ADBC-backed SQL sources", table.Name())
 	}
 	return nil
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1300,6 +1300,41 @@ func TestValidateExtractPartitionSupportAllowsMatchingIncrementalKey(t *testing.
 	}
 }
 
+func TestValidateExtractPartitionSupportUsesCustomQueryCapability(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ExtractPartitionBy = "created_at"
+
+	supported := &source.DynamicSourceTable{
+		TableName:                        source.CustomQueryTableName,
+		TableSupportsExtractPartitioning: true,
+	}
+	if err := validateExtractPartitionSupport(cfg, supported); err != nil {
+		t.Fatalf("expected partition-aware custom query to pass validation, got %v", err)
+	}
+
+	unsupported := &source.DynamicSourceTable{TableName: source.CustomQueryTableName}
+	if err := validateExtractPartitionSupport(cfg, unsupported); err == nil {
+		t.Fatal("expected custom query without partition capability to be rejected")
+	}
+}
+
+func TestApplyExtractReadSchemaOverridesKeepsMetadataColumnName(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{{Name: "PARTITION_ID", DataType: schema.TypeString}},
+	}
+
+	err := applyExtractReadSchemaOverrides(tableSchema, "partition_id:bigint", "snake_case")
+	if err != nil {
+		t.Fatalf("applyExtractReadSchemaOverrides() error = %v", err)
+	}
+	if got := tableSchema.Columns[0].Name; got != "PARTITION_ID" {
+		t.Fatalf("column name = %q, want PARTITION_ID", got)
+	}
+	if got := tableSchema.Columns[0].DataType; got != schema.TypeInt64 {
+		t.Fatalf("column type = %s, want %s", got, schema.TypeInt64)
+	}
+}
+
 func TestValidateChangeTrackingDestinationRunsForFullRefreshRequirement(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.SourceURI = "mssql+ct://example:1433/app"

--- a/pkg/source/adbc/dialect.go
+++ b/pkg/source/adbc/dialect.go
@@ -61,6 +61,12 @@ type Dialect interface {
 	ParsePrimaryKeyResult(rawValue interface{}) []string
 }
 
+// CustomQueryIdentifierQuoter preserves identifiers returned by custom-query
+// metadata when a dialect's normal identifier rules canonicalize names.
+type CustomQueryIdentifierQuoter interface {
+	QuoteCustomQueryIdentifier(name string) string
+}
+
 // DatasetAwareDialect is implemented by databases like BigQuery where the
 // dataset (schema) must be embedded in INFORMATION_SCHEMA query paths rather
 // than passed as parameters.

--- a/pkg/source/adbc/source.go
+++ b/pkg/source/adbc/source.go
@@ -99,7 +99,16 @@ func (s *ADBCSource) GetTable(ctx context.Context, req source.TableRequest) (sou
 				return nil, fmt.Errorf("failed to set dataset for custom query: %w", err)
 			}
 		}
-		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+		quoteIdentifier := s.dialect.QuoteIdentifier
+		if quoter, ok := s.dialect.(CustomQueryIdentifierQuoter); ok {
+			quoteIdentifier = quoter.QuoteCustomQueryIdentifier
+		}
+		return source.PartitionedCustomQueryTable(req, s.ExecuteCustomQuery, source.PartitionedCustomQueryOptions{
+			QuoteIdentifier: quoteIdentifier,
+			FormatTime:      source.DefaultSQLTimeFormat,
+			GetSchema:       s.getCustomQuerySchema,
+			DiscoverBounds:  s.discoverCustomQueryExtractPartitionBounds,
+		})
 	}
 
 	tableSchema, err := s.getSchema(ctx, req.Name)
@@ -396,19 +405,7 @@ func (s *ADBCSource) ExecuteCustomQuery(ctx context.Context, query string, opts 
 			return
 		}
 
-		columns := make([]schema.Column, len(colTypes))
-		for i, ct := range colTypes {
-			dt, precision, scale, arrayType := s.dialect.MapDataType(ct.DatabaseTypeName())
-			nullable, _ := ct.Nullable()
-			columns[i] = schema.Column{
-				Name:      ct.Name(),
-				DataType:  dt,
-				Nullable:  nullable,
-				Precision: precision,
-				Scale:     scale,
-				ArrayType: arrayType,
-			}
-		}
+		columns := s.customQueryColumns(colTypes)
 		arrowSchema := BuildArrowSchema(columns)
 
 		for {
@@ -425,6 +422,48 @@ func (s *ADBCSource) ExecuteCustomQuery(ctx context.Context, query string, opts 
 	}()
 
 	return results, nil
+}
+
+func (s *ADBCSource) getCustomQuerySchema(ctx context.Context, query string) (*schema.TableSchema, error) {
+	query = annotation.Prepend(annotation.WithStep(ctx, annotation.StepExtract), query)
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect custom query schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get custom query column types: %w", err)
+	}
+	return &schema.TableSchema{Name: source.CustomQueryTableName, Columns: s.customQueryColumns(colTypes)}, nil
+}
+
+func (s *ADBCSource) discoverCustomQueryExtractPartitionBounds(ctx context.Context, query string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
+	query = annotation.Prepend(annotation.WithStep(ctx, annotation.StepExtract), query)
+	var minValue, maxValue any
+	var totalCount, nonNullCount int64
+	if err := s.db.QueryRowContext(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
+		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover custom query extract partition bounds: %w", err)
+	}
+	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
+}
+
+func (s *ADBCSource) customQueryColumns(colTypes []*sql.ColumnType) []schema.Column {
+	columns := make([]schema.Column, len(colTypes))
+	for i, ct := range colTypes {
+		dt, precision, scale, arrayType := s.dialect.MapDataType(ct.DatabaseTypeName())
+		nullable, _ := ct.Nullable()
+		columns[i] = schema.Column{
+			Name:      ct.Name(),
+			DataType:  dt,
+			Nullable:  nullable,
+			Precision: precision,
+			Scale:     scale,
+			ArrayType: arrayType,
+		}
+	}
+	return columns
 }
 
 func (s *ADBCSource) read(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {

--- a/pkg/source/extract_partition.go
+++ b/pkg/source/extract_partition.go
@@ -53,6 +53,7 @@ const (
 	extractAutoPartitionsPerWorker = 4
 	maxExtractPartitionWindows     = 100000
 	extractPartitionReadBufferSize = 1
+	customQueryAlias               = "__ingestr_query"
 )
 
 type (
@@ -553,6 +554,45 @@ func SQLExtractPartitionConditions(opts ReadOptions, quote func(string) string, 
 		return SQLNumericRangeConditions(opts.ExtractPartitionBy, opts.ExtractPartitionNumericStart, opts.ExtractPartitionNumericEnd, opts.ExtractPartitionEndOperator(), quote)
 	}
 	return SQLTemporalRangeConditions(opts.ExtractPartitionBy, opts.ExtractPartitionDataType, opts.ExtractPartitionStart, opts.ExtractPartitionEnd, opts.ExtractPartitionEndOperator(), quote, format)
+}
+
+func SQLCustomQuerySchemaQuery(query string, quote func(string) string) string {
+	return fmt.Sprintf("SELECT * FROM (%s) AS %s WHERE 1 = 0", normalizeCustomQuery(query), quote(customQueryAlias))
+}
+
+func SQLCustomQuerySelectQuery(query string, opts ReadOptions, quote func(string) string, format func(time.Time) string) string {
+	alias := quote(customQueryAlias)
+	qualifiedQuote := func(column string) string {
+		return alias + "." + quote(column)
+	}
+	conditions := SQLExtractPartitionConditions(opts, qualifiedQuote, format)
+
+	result := fmt.Sprintf("SELECT * FROM (%s) AS %s", normalizeCustomQuery(query), alias)
+	if len(conditions) > 0 {
+		result += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	return result
+}
+
+func SQLCustomQueryBoundsQuery(query, partitionColumn string, quote func(string) string) string {
+	alias := quote(customQueryAlias)
+	partition := alias + "." + quote(partitionColumn)
+	return fmt.Sprintf(
+		"SELECT MIN(%s), MAX(%s), COUNT(*), COUNT(%s) FROM (%s) AS %s",
+		partition,
+		partition,
+		partition,
+		normalizeCustomQuery(query),
+		alias,
+	)
+}
+
+func normalizeCustomQuery(query string) string {
+	query = strings.TrimSpace(query)
+	for strings.HasSuffix(query, ";") {
+		query = strings.TrimSpace(strings.TrimSuffix(query, ";"))
+	}
+	return query
 }
 
 func SQLExtractPartitionBoundsQuery(table, partitionColumn, incrementalKey string, incrementalKeyDataType schema.DataType, intervalStart, intervalEnd *time.Time, quoteIdentifier, quoteTable func(string) string, format func(time.Time) string) string {

--- a/pkg/source/extract_partition_test.go
+++ b/pkg/source/extract_partition_test.go
@@ -958,3 +958,42 @@ func TestSQLIntValueRejectsNonIntegerFloat(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestSQLCustomQueryBuilders(t *testing.T) {
+	quote := func(name string) string { return `"` + name + `"` }
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+
+	schemaQuery := SQLCustomQuerySchemaQuery(" SELECT id, created_at FROM orders; ", quote)
+	wantSchema := `SELECT * FROM (SELECT id, created_at FROM orders) AS "__ingestr_query" WHERE 1 = 0`
+	if schemaQuery != wantSchema {
+		t.Fatalf("schema query = %q, want %q", schemaQuery, wantSchema)
+	}
+
+	windowQuery := SQLCustomQuerySelectQuery("SELECT id, created_at FROM orders;", ReadOptions{
+		ExtractPartitionBy:           "created_at",
+		ExtractPartitionStart:        &start,
+		ExtractPartitionEnd:          &end,
+		ExtractPartitionEndInclusive: true,
+		ExtractPartitionDataType:     schema.TypeTimestamp,
+	}, quote, DefaultSQLTimeFormat)
+	wantWindow := `SELECT * FROM (SELECT id, created_at FROM orders) AS "__ingestr_query" WHERE "__ingestr_query"."created_at" >= '2026-01-01 00:00:00' AND "__ingestr_query"."created_at" <= '2026-01-02 00:00:00'`
+	if windowQuery != wantWindow {
+		t.Fatalf("window query = %q, want %q", windowQuery, wantWindow)
+	}
+
+	nullQuery := SQLCustomQuerySelectQuery("SELECT id FROM orders", ReadOptions{
+		ExtractPartitionBy:     "id",
+		ExtractPartitionIsNull: true,
+	}, quote, DefaultSQLTimeFormat)
+	wantNull := `SELECT * FROM (SELECT id FROM orders) AS "__ingestr_query" WHERE "__ingestr_query"."id" IS NULL`
+	if nullQuery != wantNull {
+		t.Fatalf("null query = %q, want %q", nullQuery, wantNull)
+	}
+
+	boundsQuery := SQLCustomQueryBoundsQuery("SELECT id FROM orders;", "id", quote)
+	wantBounds := `SELECT MIN("__ingestr_query"."id"), MAX("__ingestr_query"."id"), COUNT(*), COUNT("__ingestr_query"."id") FROM (SELECT id FROM orders) AS "__ingestr_query"`
+	if boundsQuery != wantBounds {
+		t.Fatalf("bounds query = %q, want %q", boundsQuery, wantBounds)
+	}
+}

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -244,7 +244,12 @@ func (s *MSSQLSource) HandlesIncrementality() bool {
 
 func (s *MSSQLSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
 	if _, ok := source.IsCustomQuery(req.Name); ok {
-		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+		return source.PartitionedCustomQueryTable(req, s.ExecuteCustomQuery, source.PartitionedCustomQueryOptions{
+			QuoteIdentifier: quoteColumn,
+			FormatTime:      source.NativeSQLTimeFormat,
+			GetSchema:       s.getCustomQuerySchema,
+			DiscoverBounds:  s.discoverCustomQueryExtractPartitionBounds,
+		})
 	}
 
 	tableSchema, err := s.getSchema(ctx, req.Name)
@@ -482,6 +487,29 @@ func (s *MSSQLSource) discoverExtractPartitionBounds(ctx context.Context, table 
 	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
 }
 
+func (s *MSSQLSource) getCustomQuerySchema(ctx context.Context, query string) (*schema.TableSchema, error) {
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect custom query schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get custom query column types: %w", err)
+	}
+	return &schema.TableSchema{Name: source.CustomQueryTableName, Columns: mssqlCustomQueryColumns(colTypes)}, nil
+}
+
+func (s *MSSQLSource) discoverCustomQueryExtractPartitionBounds(ctx context.Context, query string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
+	var minValue, maxValue any
+	var totalCount, nonNullCount int64
+	if err := s.db.QueryRowContext(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
+		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover custom query extract partition bounds: %w", err)
+	}
+	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
+}
+
 func (s *MSSQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	batchSize := opts.PageSize
 	if batchSize <= 0 {
@@ -507,24 +535,7 @@ func (s *MSSQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 			return
 		}
 
-		columns := make([]schema.Column, len(colTypes))
-		for i, ct := range colTypes {
-			dt, precision, scale, arrayType := MapMSSQLToDataType(ct.DatabaseTypeName())
-			if dt == schema.TypeDecimal {
-				if p, s, ok := ct.DecimalSize(); ok {
-					precision, scale = int(p), int(s)
-				}
-			}
-			nullable, _ := ct.Nullable()
-			columns[i] = schema.Column{
-				Name:      ct.Name(),
-				DataType:  dt,
-				Nullable:  nullable,
-				Precision: precision,
-				Scale:     scale,
-				ArrayType: arrayType,
-			}
-		}
+		columns := mssqlCustomQueryColumns(colTypes)
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
@@ -541,6 +552,28 @@ func (s *MSSQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 	}()
 
 	return results, nil
+}
+
+func mssqlCustomQueryColumns(colTypes []*sql.ColumnType) []schema.Column {
+	columns := make([]schema.Column, len(colTypes))
+	for i, ct := range colTypes {
+		dt, precision, scale, arrayType := MapMSSQLToDataType(ct.DatabaseTypeName())
+		if dt == schema.TypeDecimal {
+			if p, s, ok := ct.DecimalSize(); ok {
+				precision, scale = int(p), int(s)
+			}
+		}
+		nullable, _ := ct.Nullable()
+		columns[i] = schema.Column{
+			Name:      ct.Name(),
+			DataType:  dt,
+			Nullable:  nullable,
+			Precision: precision,
+			Scale:     scale,
+			ArrayType: arrayType,
+		}
+	}
+	return columns
 }
 
 type mssqlTableRef struct {

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -199,7 +199,12 @@ func (s *MySQLSource) HandlesIncrementality() bool {
 
 func (s *MySQLSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
 	if _, ok := source.IsCustomQuery(req.Name); ok {
-		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+		return source.PartitionedCustomQueryTable(req, s.ExecuteCustomQuery, source.PartitionedCustomQueryOptions{
+			QuoteIdentifier: quoteColumn,
+			FormatTime:      source.NativeSQLTimeFormat,
+			GetSchema:       s.getCustomQuerySchema,
+			DiscoverBounds:  s.discoverCustomQueryExtractPartitionBounds,
+		})
 	}
 
 	tableSchema, err := s.getSchema(ctx, req.Name)
@@ -585,6 +590,42 @@ func (s *MySQLSource) discoverExtractPartitionBounds(ctx context.Context, table 
 	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
 }
 
+func (s *MySQLSource) getCustomQuerySchema(ctx context.Context, query string) (*schema.TableSchema, error) {
+	q, cleanup, err := s.querier(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	rows, closeStmt, err := queryRows(ctx, q, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect custom query schema: %w", err)
+	}
+	defer closeStmt()
+	defer func() { _ = rows.Close() }()
+
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get custom query column types: %w", err)
+	}
+	return &schema.TableSchema{Name: source.CustomQueryTableName, Columns: mysqlCustomQueryColumns(colTypes)}, nil
+}
+
+func (s *MySQLSource) discoverCustomQueryExtractPartitionBounds(ctx context.Context, query string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
+	q, cleanup, err := s.querier(ctx)
+	if err != nil {
+		return source.ExtractPartitionBounds{}, err
+	}
+	defer cleanup()
+
+	var minValue, maxValue any
+	var totalCount, nonNullCount int64
+	if err := q.QueryRowContext(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
+		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover custom query extract partition bounds: %w", err)
+	}
+	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
+}
+
 func mysqlColumnIsNonNullable(tableSchema *schema.TableSchema, columnName string) bool {
 	if tableSchema == nil {
 		return false
@@ -630,19 +671,7 @@ func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 			return
 		}
 
-		columns := make([]schema.Column, len(colTypes))
-		for i, ct := range colTypes {
-			dt, precision, scale, arrayType := MapMySQLToDataType(ct.DatabaseTypeName())
-			nullable, _ := ct.Nullable()
-			columns[i] = schema.Column{
-				Name:      ct.Name(),
-				DataType:  dt,
-				Nullable:  nullable,
-				Precision: precision,
-				Scale:     scale,
-				ArrayType: arrayType,
-			}
-		}
+		columns := mysqlCustomQueryColumns(colTypes)
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
@@ -659,6 +688,23 @@ func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 	}()
 
 	return results, nil
+}
+
+func mysqlCustomQueryColumns(colTypes []*sql.ColumnType) []schema.Column {
+	columns := make([]schema.Column, len(colTypes))
+	for i, ct := range colTypes {
+		dt, precision, scale, arrayType := MapMySQLToDataType(ct.DatabaseTypeName())
+		nullable, _ := ct.Nullable()
+		columns[i] = schema.Column{
+			Name:      ct.Name(),
+			DataType:  dt,
+			Nullable:  nullable,
+			Precision: precision,
+			Scale:     scale,
+			ArrayType: arrayType,
+		}
+	}
+	return columns
 }
 
 func queryRows(ctx context.Context, q rowQuerier, query string) (*sql.Rows, func(), error) {

--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -78,7 +78,12 @@ func (s *PostgresSource) GetTable(ctx context.Context, req source.TableRequest) 
 	}
 
 	if _, ok := source.IsCustomQuery(req.Name); ok {
-		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+		return source.PartitionedCustomQueryTable(req, s.ExecuteCustomQuery, source.PartitionedCustomQueryOptions{
+			QuoteIdentifier: quoteIdentifier,
+			FormatTime:      source.DefaultSQLTimeFormat,
+			GetSchema:       s.getCustomQuerySchema,
+			DiscoverBounds:  s.discoverCustomQueryExtractPartitionBounds,
+		})
 	}
 
 	// Fetch schema from database
@@ -334,6 +339,56 @@ func (s *PostgresSource) discoverExtractPartitionBounds(ctx context.Context, tab
 	var totalCount, nonNullCount int64
 	if err := conn.QueryRow(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
 		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover extract partition bounds: %w", err)
+	}
+	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
+}
+
+func (s *PostgresSource) getCustomQuerySchema(ctx context.Context, query string) (*schema.TableSchema, error) {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect custom query schema: %w", err)
+	}
+	defer rows.Close()
+
+	fields := rows.FieldDescriptions()
+	typeMap := conn.Conn().TypeMap()
+	columns := make([]schema.Column, len(fields))
+	for i, fd := range fields {
+		pgTypeName := "text"
+		if t, ok := typeMap.TypeForOID(fd.DataTypeOID); ok {
+			pgTypeName = t.Name
+		}
+		dt, precision, scale, arrayType := MapPostgresToDataType(pgTypeName)
+		columns[i] = schema.Column{
+			Name:      string(fd.Name),
+			DataType:  dt,
+			Nullable:  true,
+			Precision: precision,
+			Scale:     scale,
+			ArrayType: arrayType,
+		}
+	}
+
+	return &schema.TableSchema{Name: source.CustomQueryTableName, Columns: columns}, nil
+}
+
+func (s *PostgresSource) discoverCustomQueryExtractPartitionBounds(ctx context.Context, query string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer conn.Release()
+
+	var minValue, maxValue any
+	var totalCount, nonNullCount int64
+	if err := conn.QueryRow(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
+		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover custom query extract partition bounds: %w", err)
 	}
 	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
 }

--- a/pkg/source/snowflake/dialect.go
+++ b/pkg/source/snowflake/dialect.go
@@ -168,6 +168,10 @@ func (d *Dialect) QuoteIdentifier(name string) string {
 	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(strings.ToUpper(name), `"`, `""`))
 }
 
+func (d *Dialect) QuoteCustomQueryIdentifier(name string) string {
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
+}
+
 func (d *Dialect) ParsePrimaryKeyResult(rawValue interface{}) []string {
 	if rawValue == nil {
 		return nil

--- a/pkg/source/snowflake/dialect_test.go
+++ b/pkg/source/snowflake/dialect_test.go
@@ -1,0 +1,22 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/source/adbc"
+)
+
+func TestDialectCustomQueryIdentifierQuotingPreservesCase(t *testing.T) {
+	dialect := NewDialect()
+	quoter, ok := any(dialect).(adbc.CustomQueryIdentifierQuoter)
+	if !ok {
+		t.Fatal("snowflake dialect does not implement custom query identifier quoting")
+	}
+
+	if got, want := dialect.QuoteIdentifier("partition_ts"), `"PARTITION_TS"`; got != want {
+		t.Fatalf("QuoteIdentifier() = %q, want %q", got, want)
+	}
+	if got, want := quoter.QuoteCustomQueryIdentifier("partition_ts"), `"partition_ts"`; got != want {
+		t.Fatalf("QuoteCustomQueryIdentifier() = %q, want %q", got, want)
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -114,6 +114,7 @@ type ReadOptions struct {
 	ExcludeColumns                  []string
 	Parallelism                     int
 	Schema                          *schema.TableSchema // Optional: if provided, Read will skip GetSchema call
+	ExtractPartitionSchema          *schema.TableSchema // Optional: source metadata used to plan extract partitions
 	CDCResumeLSN                    string              // Optional: for CDC sources, resume from this LSN (skip snapshot)
 	CDCResumeIncarnation            string              // Source table incarnation that authorized CDCResumeLSN
 	CDCResumeSchemaFingerprint      string              // Source schema fingerprint that authorized CDCResumeLSN
@@ -319,6 +320,13 @@ type SourceTable interface {
 	HasKnownSchema() bool
 	GetSchema(ctx context.Context) (*schema.TableSchema, error)
 	Read(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error)
+}
+
+// ReadSchemaProvider resolves the source schema for a specific read. It is
+// used by sources whose query schema depends on read-time parameters.
+type ReadSchemaProvider interface {
+	SupportsReadSchema() bool
+	GetReadSchema(ctx context.Context, opts ReadOptions) (*schema.TableSchema, error)
 }
 
 type PrimaryKeyUniquenessProvider interface {

--- a/pkg/source/sqlite/sqlite.go
+++ b/pkg/source/sqlite/sqlite.go
@@ -70,7 +70,12 @@ func (s *SQLiteSource) GetTable(ctx context.Context, req source.TableRequest) (s
 	}
 
 	if _, ok := source.IsCustomQuery(req.Name); ok {
-		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+		return source.PartitionedCustomQueryTable(req, s.ExecuteCustomQuery, source.PartitionedCustomQueryOptions{
+			QuoteIdentifier: quoteIdentifier,
+			FormatTime:      source.NativeSQLTimeFormat,
+			GetSchema:       s.getCustomQuerySchema,
+			DiscoverBounds:  s.discoverCustomQueryExtractPartitionBounds,
+		})
 	}
 
 	tableSchema, err := s.getSchema(ctx, req.Name)
@@ -244,6 +249,29 @@ func (s *SQLiteSource) discoverExtractPartitionBounds(ctx context.Context, table
 	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
 }
 
+func (s *SQLiteSource) getCustomQuerySchema(ctx context.Context, query string) (*schema.TableSchema, error) {
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect custom query schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get custom query column types: %w", err)
+	}
+	return &schema.TableSchema{Name: source.CustomQueryTableName, Columns: sqliteCustomQueryColumns(colTypes)}, nil
+}
+
+func (s *SQLiteSource) discoverCustomQueryExtractPartitionBounds(ctx context.Context, query string, opts source.ReadOptions) (source.ExtractPartitionBounds, error) {
+	var minValue, maxValue any
+	var totalCount, nonNullCount int64
+	if err := s.db.QueryRowContext(ctx, query).Scan(&minValue, &maxValue, &totalCount, &nonNullCount); err != nil {
+		return source.ExtractPartitionBounds{}, fmt.Errorf("failed to discover custom query extract partition bounds: %w", err)
+	}
+	return source.ExtractPartitionBoundsFromValues(opts.ExtractPartitionKind, minValue, maxValue, totalCount, nonNullCount)
+}
+
 func (s *SQLiteSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	batchSize := opts.PageSize
 	if batchSize <= 0 {
@@ -269,18 +297,7 @@ func (s *SQLiteSource) ExecuteCustomQuery(ctx context.Context, query string, opt
 			return
 		}
 
-		columns := make([]schema.Column, len(colTypes))
-		for i, ct := range colTypes {
-			dt, precision, scale := MapSQLiteToDataType(ct.DatabaseTypeName())
-			nullable, _ := ct.Nullable()
-			columns[i] = schema.Column{
-				Name:      ct.Name(),
-				DataType:  dt,
-				Nullable:  nullable,
-				Precision: precision,
-				Scale:     scale,
-			}
-		}
+		columns := sqliteCustomQueryColumns(colTypes)
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
@@ -297,6 +314,22 @@ func (s *SQLiteSource) ExecuteCustomQuery(ctx context.Context, query string, opt
 	}()
 
 	return results, nil
+}
+
+func sqliteCustomQueryColumns(colTypes []*sql.ColumnType) []schema.Column {
+	columns := make([]schema.Column, len(colTypes))
+	for i, ct := range colTypes {
+		dt, precision, scale := MapSQLiteToDataType(ct.DatabaseTypeName())
+		nullable, _ := ct.Nullable()
+		columns[i] = schema.Column{
+			Name:      ct.Name(),
+			DataType:  dt,
+			Nullable:  nullable,
+			Precision: precision,
+			Scale:     scale,
+		}
+	}
+	return columns
 }
 
 func filterColumns(columns []schema.Column, exclude []string) []schema.Column {

--- a/pkg/source/sqlite/sqlite_test.go
+++ b/pkg/source/sqlite/sqlite_test.go
@@ -1,6 +1,8 @@
 package sqlite
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -147,6 +149,57 @@ func TestBuildSelectQueryAddsExtractPartitionPredicate(t *testing.T) {
 	if query != want {
 		t.Fatalf("query = %q, want %q", query, want)
 	}
+}
+
+func TestCustomQueryExtractPartitioning(t *testing.T) {
+	ctx := context.Background()
+	src := NewSQLiteSource()
+	uri := "sqlite:///" + filepath.Join(t.TempDir(), "source.db")
+	require.NoError(t, src.Connect(ctx, uri))
+	t.Cleanup(func() { require.NoError(t, src.Close(ctx)) })
+
+	_, err := src.db.ExecContext(ctx, `
+		CREATE TABLE events (id INTEGER, created_at TIMESTAMP);
+		INSERT INTO events VALUES
+			(1, '2026-01-01 00:00:00'),
+			(2, '2026-01-01 12:00:00'),
+			(3, '2026-01-02 00:00:00'),
+			(4, '2026-01-03 00:00:00');
+	`)
+	require.NoError(t, err)
+
+	table, err := src.GetTable(ctx, source.TableRequest{
+		Name:           "query:SELECT id, created_at AS partition_ts FROM events;",
+		IncrementalKey: "partition_ts",
+	})
+	require.NoError(t, err)
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+	opts := source.ReadOptions{
+		IncrementalKey:           "partition_ts",
+		IntervalStart:            &start,
+		IntervalEnd:              &end,
+		ExtractPartitionBy:       "partition_ts",
+		ExtractPartitionInterval: 24 * time.Hour,
+		Parallelism:              2,
+	}
+	provider, ok := table.(source.ReadSchemaProvider)
+	require.True(t, ok)
+	opts.Schema, err = provider.GetReadSchema(ctx, opts)
+	require.NoError(t, err)
+	_, err = source.ValidateExtractPartitionColumn(opts.Schema, opts.ExtractPartitionBy)
+	require.NoError(t, err)
+
+	records, err := table.Read(ctx, opts)
+	require.NoError(t, err)
+	rowCount := int64(0)
+	for result := range records {
+		require.NoError(t, result.Err)
+		rowCount += result.Batch.NumRows()
+		result.Batch.Release()
+	}
+	assert.Equal(t, int64(4), rowCount)
 }
 
 func TestExtractTableName(t *testing.T) {

--- a/pkg/source/sqltable.go
+++ b/pkg/source/sqltable.go
@@ -22,6 +22,7 @@ type DynamicSourceTable struct {
 	TableSupportsExtractPartitioning bool
 	KnownSchema                      bool
 	SchemaFn                         func(ctx context.Context) (*schema.TableSchema, error)
+	ReadSchemaFn                     func(ctx context.Context, opts ReadOptions) (*schema.TableSchema, error)
 	ReadFn                           func(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error)
 }
 
@@ -61,11 +62,25 @@ func (t *DynamicSourceTable) GetSchema(ctx context.Context) (*schema.TableSchema
 	return t.SchemaFn(ctx)
 }
 
+func (t *DynamicSourceTable) GetReadSchema(ctx context.Context, opts ReadOptions) (*schema.TableSchema, error) {
+	if t.ReadSchemaFn != nil {
+		return t.ReadSchemaFn(ctx, opts)
+	}
+	return t.GetSchema(ctx)
+}
+
+func (t *DynamicSourceTable) SupportsReadSchema() bool {
+	return t.ReadSchemaFn != nil
+}
+
 func (t *DynamicSourceTable) Read(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error) {
 	return t.ReadFn(ctx, opts)
 }
 
-var _ SourceTable = (*DynamicSourceTable)(nil)
+var (
+	_ SourceTable        = (*DynamicSourceTable)(nil)
+	_ ReadSchemaProvider = (*DynamicSourceTable)(nil)
+)
 
 // IsCustomQuery checks if a table name has the "query:" prefix indicating a custom SQL query.
 func IsCustomQuery(tableName string) (string, bool) {
@@ -103,6 +118,82 @@ func CustomQueryTable(
 				return nil, fmt.Errorf("custom query contains unresolved interval placeholders; provide --interval-start and --interval-end")
 			}
 			return executeFn(ctx, query, opts)
+		},
+	}, nil
+}
+
+type PartitionedCustomQueryOptions struct {
+	QuoteIdentifier func(string) string
+	FormatTime      func(time.Time) string
+	GetSchema       func(ctx context.Context, query string) (*schema.TableSchema, error)
+	DiscoverBounds  func(ctx context.Context, query string, opts ReadOptions) (ExtractPartitionBounds, error)
+}
+
+// PartitionedCustomQueryTable builds a custom query table whose result set can
+// be split into extract partition windows.
+func PartitionedCustomQueryTable(
+	req TableRequest,
+	executeFn func(ctx context.Context, query string, opts ReadOptions) (<-chan RecordBatchResult, error),
+	partitioning PartitionedCustomQueryOptions,
+) (*DynamicSourceTable, error) {
+	rawQuery, ok := IsCustomQuery(req.Name)
+	if !ok {
+		return nil, fmt.Errorf("not a custom query: %s", req.Name)
+	}
+	if strings.TrimSpace(rawQuery) == "" {
+		return nil, fmt.Errorf("custom query cannot be empty (nothing after \"query:\")")
+	}
+	if partitioning.QuoteIdentifier == nil || partitioning.FormatTime == nil || partitioning.GetSchema == nil || partitioning.DiscoverBounds == nil {
+		return nil, fmt.Errorf("partitioned custom query requires quoting, time formatting, schema, and bounds callbacks")
+	}
+
+	resolveQuery := func(opts ReadOptions) (string, error) {
+		query := SubstituteIntervalParams(rawQuery, opts.IntervalStart, opts.IntervalEnd)
+		if strings.Contains(query, ":interval_start") || strings.Contains(query, ":interval_end") {
+			return "", fmt.Errorf("custom query contains unresolved interval placeholders; provide --interval-start and --interval-end")
+		}
+		return query, nil
+	}
+
+	return &DynamicSourceTable{
+		TableName:                        CustomQueryTableName,
+		TablePrimaryKeys:                 req.PrimaryKeys,
+		TableIncrementalKey:              req.IncrementalKey,
+		TableStrategy:                    req.Strategy,
+		TableSupportsExtractPartitioning: true,
+		KnownSchema:                      false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("schema is not available for custom queries without read options; use schema inference")
+		},
+		ReadSchemaFn: func(ctx context.Context, opts ReadOptions) (*schema.TableSchema, error) {
+			query, err := resolveQuery(opts)
+			if err != nil {
+				return nil, err
+			}
+			return partitioning.GetSchema(ctx, SQLCustomQuerySchemaQuery(query, partitioning.QuoteIdentifier))
+		},
+		ReadFn: func(ctx context.Context, opts ReadOptions) (<-chan RecordBatchResult, error) {
+			query, err := resolveQuery(opts)
+			if err != nil {
+				return nil, err
+			}
+			if !opts.ExtractPartitioningEnabled() {
+				return executeFn(ctx, query, opts)
+			}
+
+			read := func(ctx context.Context, readOpts ReadOptions) (<-chan RecordBatchResult, error) {
+				windowQuery := SQLCustomQuerySelectQuery(query, readOpts, partitioning.QuoteIdentifier, partitioning.FormatTime)
+				return executeFn(ctx, windowQuery, readOpts)
+			}
+			discover := func(ctx context.Context, readOpts ReadOptions) (ExtractPartitionBounds, error) {
+				boundsQuery := SQLCustomQueryBoundsQuery(query, readOpts.ExtractPartitionBy, partitioning.QuoteIdentifier)
+				return partitioning.DiscoverBounds(ctx, boundsQuery, readOpts)
+			}
+			partitionSchema := opts.ExtractPartitionSchema
+			if partitionSchema == nil {
+				partitionSchema = opts.Schema
+			}
+			return ReadExtractPartitions(ctx, opts, partitionSchema, read, discover)
 		},
 	}, nil
 }

--- a/pkg/source/sqltable_test.go
+++ b/pkg/source/sqltable_test.go
@@ -2,10 +2,12 @@ package source
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
 func TestIsCustomQuery(t *testing.T) {
@@ -146,6 +148,138 @@ func TestCustomQueryTable(t *testing.T) {
 			t.Fatal("expected error for non-custom-query name")
 		}
 	})
+}
+
+func TestPartitionedCustomQueryTable(t *testing.T) {
+	var schemaQuery string
+	var executedQueries []string
+	quote := func(name string) string { return `"` + name + `"` }
+	tableSchema := &schema.TableSchema{
+		Name: CustomQueryTableName,
+		Columns: []schema.Column{
+			{Name: "created_at", DataType: schema.TypeTimestamp},
+			{Name: "id", DataType: schema.TypeInt64},
+		},
+	}
+
+	executeFn := func(ctx context.Context, query string, opts ReadOptions) (<-chan RecordBatchResult, error) {
+		executedQueries = append(executedQueries, query)
+		ch := make(chan RecordBatchResult)
+		close(ch)
+		return ch, nil
+	}
+	table, err := PartitionedCustomQueryTable(TableRequest{
+		Name:           "query:SELECT id, created_at FROM orders WHERE updated_at >= :interval_start;",
+		IncrementalKey: "created_at",
+	}, executeFn, PartitionedCustomQueryOptions{
+		QuoteIdentifier: quote,
+		FormatTime:      DefaultSQLTimeFormat,
+		GetSchema: func(ctx context.Context, query string) (*schema.TableSchema, error) {
+			schemaQuery = query
+			return tableSchema, nil
+		},
+		DiscoverBounds: func(ctx context.Context, query string, opts ReadOptions) (ExtractPartitionBounds, error) {
+			t.Fatal("bounds discovery should not run when the time partition column matches the incremental key")
+			return ExtractPartitionBounds{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("PartitionedCustomQueryTable() error = %v", err)
+	}
+	if !table.SupportsExtractPartitioning() {
+		t.Fatal("expected custom query table to support extract partitioning")
+	}
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(48 * time.Hour)
+	readOpts := ReadOptions{
+		IncrementalKey:           "created_at",
+		IntervalStart:            &start,
+		IntervalEnd:              &end,
+		ExtractPartitionBy:       "created_at",
+		ExtractPartitionInterval: 24 * time.Hour,
+		Parallelism:              1,
+	}
+	resolvedSchema, err := table.GetReadSchema(context.Background(), readOpts)
+	if err != nil {
+		t.Fatalf("GetReadSchema() error = %v", err)
+	}
+	if resolvedSchema != tableSchema {
+		t.Fatal("GetReadSchema() returned an unexpected schema")
+	}
+	if strings.Contains(schemaQuery, ":interval_start") || strings.Contains(schemaQuery, ";)") {
+		t.Fatalf("schema query was not normalized: %s", schemaQuery)
+	}
+	if !strings.Contains(schemaQuery, "updated_at >= '2026-01-01 00:00:00+00:00'") {
+		t.Fatalf("schema query did not substitute the interval: %s", schemaQuery)
+	}
+
+	readOpts.Schema = resolvedSchema
+	records, err := table.Read(context.Background(), readOpts)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	for result := range records {
+		if result.Err != nil {
+			t.Fatalf("Read() result error = %v", result.Err)
+		}
+	}
+
+	if len(executedQueries) != 2 {
+		t.Fatalf("executed query count = %d, want 2: %v", len(executedQueries), executedQueries)
+	}
+	if !strings.Contains(executedQueries[0], `"__ingestr_query"."created_at" >= '2026-01-01 00:00:00'`) ||
+		!strings.Contains(executedQueries[0], `"__ingestr_query"."created_at" < '2026-01-02 00:00:00'`) {
+		t.Fatalf("first window query = %s", executedQueries[0])
+	}
+	if !strings.Contains(executedQueries[1], `"__ingestr_query"."created_at" <= '2026-01-03 00:00:00'`) {
+		t.Fatalf("final window query does not use an inclusive end: %s", executedQueries[1])
+	}
+}
+
+func TestPartitionedCustomQueryTableUsesExtractPartitionSchemaNames(t *testing.T) {
+	var executedQuery string
+	table, err := PartitionedCustomQueryTable(
+		TableRequest{Name: "query:SELECT created_at AS partition_ts FROM events", IncrementalKey: "partition_ts"},
+		func(ctx context.Context, query string, opts ReadOptions) (<-chan RecordBatchResult, error) {
+			executedQuery = query
+			return closedRecordBatchResults(), nil
+		},
+		PartitionedCustomQueryOptions{
+			QuoteIdentifier: func(name string) string { return `"` + name + `"` },
+			FormatTime:      DefaultSQLTimeFormat,
+			GetSchema: func(ctx context.Context, query string) (*schema.TableSchema, error) {
+				return nil, nil
+			},
+			DiscoverBounds: func(ctx context.Context, query string, opts ReadOptions) (ExtractPartitionBounds, error) {
+				return ExtractPartitionBounds{}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("PartitionedCustomQueryTable() error = %v", err)
+	}
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	records, err := table.Read(context.Background(), ReadOptions{
+		IncrementalKey:           "partition_ts",
+		IntervalStart:            &start,
+		IntervalEnd:              &end,
+		ExtractPartitionBy:       "PARTITION_TS",
+		ExtractPartitionInterval: time.Hour,
+		Schema:                   &schema.TableSchema{Columns: []schema.Column{{Name: "partition_ts", DataType: schema.TypeTimestamp}}},
+		ExtractPartitionSchema:   &schema.TableSchema{Columns: []schema.Column{{Name: "PARTITION_TS", DataType: schema.TypeTimestamp}}},
+	})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	for range records {
+	}
+
+	if !strings.Contains(executedQuery, `"__ingestr_query"."PARTITION_TS"`) {
+		t.Fatalf("partition query did not preserve metadata casing: %s", executedQuery)
+	}
 }
 
 func TestSubstituteIntervalParams(t *testing.T) {

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -16,12 +16,13 @@ import (
 )
 
 type IngestionJob struct {
-	Config       *config.IngestConfig
-	Table        source.SourceTable
-	Destination  destination.Destination
-	Schema       *schema.TableSchema
-	SourceSchema *schema.TableSchema // Original source schema without extra ingestr metadata columns
-	Tracker      progress.Tracker    // Progress tracker for monitoring ingestion
+	Config                 *config.IngestConfig
+	Table                  source.SourceTable
+	Destination            destination.Destination
+	Schema                 *schema.TableSchema
+	SourceSchema           *schema.TableSchema // Original source schema without extra ingestr metadata columns
+	ExtractPartitionSchema *schema.TableSchema
+	Tracker                progress.Tracker // Progress tracker for monitoring ingestion
 
 	// BufferedRecords contains pre-read data for schema-unknown sources.
 	// If non-nil, GetRecords() transforms this stream instead of reading from Table.
@@ -76,6 +77,9 @@ func (j *IngestionJob) GetRecords(ctx context.Context, opts source.ReadOptions) 
 		records = j.BufferedRecords
 	} else {
 		var err error
+		if opts.ExtractPartitionSchema == nil {
+			opts.ExtractPartitionSchema = j.ExtractPartitionSchema
+		}
 		records, err = j.Table.Read(ctx, opts)
 		if err != nil {
 			return nil, err

--- a/tests/integration/custom_query_test.go
+++ b/tests/integration/custom_query_test.go
@@ -206,6 +206,70 @@ func TestCustomQuery_PostgresToPostgres(t *testing.T) {
 	assert.Greater(t, minAmount, 500.0, "all amounts should be > 500")
 }
 
+func TestCustomQuery_PostgresPartitionedExtraction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceURI := sharedPostgresURI(t, "source")
+	destURI := sharedPostgresURI(t, "dest")
+	sourceSchema := uniqueSchemaName(t, "cq_partition_src")
+	destSchema := uniqueSchemaName(t, "cq_partition_dst")
+	ensurePostgresSchema(t, ctx, sourceURI, sourceSchema)
+	ensurePostgresSchema(t, ctx, destURI, destSchema)
+	t.Cleanup(func() {
+		dropPostgresSchema(t, ctx, sourceURI, sourceSchema)
+		dropPostgresSchema(t, ctx, destURI, destSchema)
+	})
+	setupCustomQuerySourceData(t, ctx, sourceURI, sourceSchema)
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(99 * time.Minute)
+	query := fmt.Sprintf(`
+		SELECT
+			o.id,
+			o.amount,
+			o.status,
+			o.created_at AS partition_ts,
+			o.created_at AS updated_at
+		FROM %s AS o
+		JOIN (VALUES ('active'), ('inactive')) AS allowed(status)
+			ON allowed.status = o.status
+		WHERE o.created_at >= :interval_start
+			AND o.created_at <= :interval_end
+	`, pqTable(sourceSchema, "orders"))
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = sourceURI
+	cfg.SourceTable = "query:" + query
+	cfg.DestURI = destURI
+	cfg.DestTable = destSchema + ".partitioned_orders"
+	cfg.IncrementalStrategy = config.StrategyAppend
+	cfg.IncrementalKey = "updated_at"
+	cfg.IntervalStart = &start
+	cfg.IntervalEnd = &end
+	cfg.ExtractPartitionBy = "partition_ts"
+	cfg.ExtractPartitionInterval = 20 * time.Minute
+	cfg.ExtractParallelism = 3
+
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	db, err := sql.Open("pgx", destURI)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var count, distinctCount, boundaryCount int
+	err = db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT COUNT(*), COUNT(DISTINCT id), COUNT(*) FILTER (WHERE id IN (1, 100))
+		FROM %s
+	`, pqTable(destSchema, "partitioned_orders"))).Scan(&count, &distinctCount, &boundaryCount)
+	require.NoError(t, err)
+	assert.Equal(t, 100, count)
+	assert.Equal(t, 100, distinctCount)
+	assert.Equal(t, 2, boundaryCount)
+}
+
 func TestCustomQuery_WithIntervalParams(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
## What
Add parallel extract partitioning for SQL custom queries.

## Changes
- Build schema, bounds, and window queries around custom-query results across supported SQL sources.
- Preserve exact result identifiers and apply read-time schema overrides for partition planning.
- Add unit, SQLite, Snowflake, and PostgreSQL integration coverage.

## How to test
1. Run make format, make lint, and make test.

## Risk & rollback
- **Risk:** Medium — wrapper SQL behavior varies by database dialect.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (make test)
- [x] Format and lint pass (make format, make lint)
- [ ] Integration tests pass if affected (make test-integration)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.