### PR TITLE
Support Fabric column type changes

### DIFF
--- a/pkg/destination/dialect_conformance_test.go
+++ b/pkg/destination/dialect_conformance_test.go
@@ -449,8 +449,8 @@ func TestAllDialects_AlterColumnTypeSQL(t *testing.T) {
 }
 
 func TestDialect_SupportsAlterType(t *testing.T) {
-	dialectsWithAlter := []string{"postgres", "duckdb", "snowflake", "bigquery", "clickhouse", "mysql", "mssql", "redshift", "synapse"}
-	dialectsWithoutAlter := []string{"sqlite", "trino", "cassandra", "athena", "cratedb", "fabric", "maxcompute", "oracle"}
+	dialectsWithAlter := []string{"postgres", "duckdb", "snowflake", "bigquery", "clickhouse", "mysql", "mssql", "redshift", "synapse", "fabric"}
+	dialectsWithoutAlter := []string{"sqlite", "trino", "cassandra", "athena", "cratedb", "maxcompute", "oracle"}
 
 	for _, scheme := range dialectsWithAlter {
 		t.Run(scheme+"_supports", func(t *testing.T) {

--- a/pkg/destination/fabric/dialect.go
+++ b/pkg/destination/fabric/dialect.go
@@ -34,10 +34,10 @@ func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Colum
 		nullable)
 }
 
-// SupportsAlterType is false for v1: ALTER COLUMN type changes are a preview
-// feature in Fabric Warehouse.
+// SupportsAlterType is true because Fabric Warehouse supports compatible,
+// metadata-only ALTER COLUMN changes. Fabric validates the specific conversion.
 func (d *Dialect) SupportsAlterType() bool {
-	return false
+	return true
 }
 
 func (d *Dialect) TypeName(col schema.Column) string {

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -1,11 +1,15 @@
 package fabric
 
 import (
+	"context"
+	"errors"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -424,5 +428,59 @@ func TestSchemaEvolutionNoPhantomTimestampTZChange(t *testing.T) {
 	}
 	if !without.HasChanges {
 		t.Fatal("expected a phantom change without the normalizer")
+	}
+}
+
+func TestSchemaEvolutionAttemptsTypeChange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create mock database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	d := &FabricDestination{db: db}
+	oldColumn := schema.Column{Name: "clause_names", DataType: schema.TypeString, MaxLength: -1, Nullable: true}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeWidenType,
+		ColumnName: "clause_names",
+		OldColumn:  &oldColumn,
+		NewColumn:  schema.Column{Name: "clause_names", DataType: schema.TypeArray, ArrayType: schema.TypeString, Nullable: true},
+	}}}
+	query := "ALTER TABLE dbo.events ALTER COLUMN [clause_names] VARCHAR(MAX) NULL"
+	mock.ExpectExec(regexp.QuoteMeta(query)).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	_, err = d.ApplySchemaEvolution(context.Background(), "dbo.events", comparison)
+	if err != nil {
+		t.Fatalf("apply schema evolution: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSchemaEvolutionTypeChangeFailureIncludesQuery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create mock database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	d := &FabricDestination{db: db}
+	oldColumn := schema.Column{Name: "value", DataType: schema.TypeInt32, Nullable: true}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeWidenType,
+		ColumnName: "value",
+		OldColumn:  &oldColumn,
+		NewColumn:  schema.Column{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}}
+	query := "ALTER TABLE dbo.events ALTER COLUMN [value] BIGINT NULL"
+	mock.ExpectExec(regexp.QuoteMeta(query)).WillReturnError(errors.New("Fabric rejected conversion"))
+
+	_, err = d.ApplySchemaEvolution(context.Background(), "dbo.events", comparison)
+	if err == nil || !strings.Contains(err.Error(), query) || !strings.Contains(err.Error(), "Fabric rejected conversion") {
+		t.Fatalf("expected query and Fabric error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -431,7 +431,7 @@ func TestSchemaEvolutionNoPhantomTimestampTZChange(t *testing.T) {
 	}
 }
 
-func TestSchemaEvolutionAttemptsTypeChange(t *testing.T) {
+func TestSchemaEvolutionSkipsUnchangedFabricType(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("create mock database: %v", err)
@@ -446,7 +446,32 @@ func TestSchemaEvolutionAttemptsTypeChange(t *testing.T) {
 		OldColumn:  &oldColumn,
 		NewColumn:  schema.Column{Name: "clause_names", DataType: schema.TypeArray, ArrayType: schema.TypeString, Nullable: true},
 	}}}
-	query := "ALTER TABLE dbo.events ALTER COLUMN [clause_names] VARCHAR(MAX) NULL"
+
+	_, err = d.ApplySchemaEvolution(context.Background(), "dbo.events", comparison)
+	if err != nil {
+		t.Fatalf("apply schema evolution: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSchemaEvolutionAttemptsTypeChange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create mock database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	d := &FabricDestination{db: db}
+	oldColumn := schema.Column{Name: "value", DataType: schema.TypeInt32, Nullable: true}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeWidenType,
+		ColumnName: "value",
+		OldColumn:  &oldColumn,
+		NewColumn:  schema.Column{Name: "value", DataType: schema.TypeInt64, Nullable: true},
+	}}}
+	query := "ALTER TABLE dbo.events ALTER COLUMN [value] BIGINT NULL"
 	mock.ExpectExec(regexp.QuoteMeta(query)).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	_, err = d.ApplySchemaEvolution(context.Background(), "dbo.events", comparison)

--- a/pkg/destination/schema_evolution.go
+++ b/pkg/destination/schema_evolution.go
@@ -137,11 +137,9 @@ func ApplyEvolution(ctx context.Context, dest Destination, dialect Dialect, tabl
 	if comparison != nil {
 		for _, change := range comparison.Changes {
 			if change.Type == schemaevolution.ChangeWidenType || change.Type == schemaevolution.ChangeOverrideType {
-				if !dialect.SupportsAlterType() || dialect.AlterColumnTypeSQL(table, change.ColumnName, change.NewColumn) == "" {
-					return nil, fmt.Errorf(
-						"apply schema evolution: column %q requires a type change, which generic %s DDL does not support",
-						change.ColumnName, dialect.Name(),
-					)
+				stmt := dialect.AlterColumnTypeSQL(table, change.ColumnName, change.NewColumn)
+				if !dialect.SupportsAlterType() || stmt == "" {
+					return nil, unsupportedTypeChangeError(dialect, table, change, stmt)
 				}
 			}
 			needsRelaxation := change.Type == schemaevolution.ChangeRelaxNullability ||
@@ -164,4 +162,30 @@ func ApplyEvolution(ctx context.Context, dest Destination, dialect Dialect, tabl
 		}
 	}
 	return warnings, nil
+}
+
+func unsupportedTypeChangeError(dialect Dialect, table string, change schemaevolution.SchemaChange, stmt string) error {
+	oldLogicalType := "unknown"
+	oldDestinationType := "unknown"
+	if change.OldColumn != nil {
+		oldLogicalType = change.OldColumn.DataType.String()
+		oldDestinationType = dialect.TypeName(*change.OldColumn)
+	}
+
+	detail := fmt.Sprintf(
+		"apply schema evolution: column %q on table %q requires a type change from %s (%s type %s) to %s (%s type %s), which generic %s DDL does not support",
+		change.ColumnName,
+		table,
+		oldLogicalType,
+		dialect.Name(),
+		oldDestinationType,
+		change.NewColumn.DataType,
+		dialect.Name(),
+		dialect.TypeName(change.NewColumn),
+		dialect.Name(),
+	)
+	if stmt == "" {
+		return fmt.Errorf("%s; no ALTER COLUMN query was generated or executed", detail)
+	}
+	return fmt.Errorf("%s; query was not executed: %s", detail, stmt)
 }

--- a/pkg/destination/schema_evolution.go
+++ b/pkg/destination/schema_evolution.go
@@ -73,6 +73,9 @@ func BuildMigration(dialect Dialect, table string, comparison *schemaevolution.S
 			}
 
 		case schemaevolution.ChangeWidenType, schemaevolution.ChangeOverrideType:
+			if sameDestinationType(dialect, change) {
+				continue
+			}
 			if !dialect.SupportsAlterType() {
 				warnings = append(warnings, fmt.Sprintf(
 					"column %q type change skipped: %s does not support ALTER COLUMN TYPE",
@@ -137,6 +140,9 @@ func ApplyEvolution(ctx context.Context, dest Destination, dialect Dialect, tabl
 	if comparison != nil {
 		for _, change := range comparison.Changes {
 			if change.Type == schemaevolution.ChangeWidenType || change.Type == schemaevolution.ChangeOverrideType {
+				if sameDestinationType(dialect, change) {
+					continue
+				}
 				stmt := dialect.AlterColumnTypeSQL(table, change.ColumnName, change.NewColumn)
 				if !dialect.SupportsAlterType() || stmt == "" {
 					return nil, unsupportedTypeChangeError(dialect, table, change, stmt)
@@ -162,6 +168,10 @@ func ApplyEvolution(ctx context.Context, dest Destination, dialect Dialect, tabl
 		}
 	}
 	return warnings, nil
+}
+
+func sameDestinationType(dialect Dialect, change schemaevolution.SchemaChange) bool {
+	return change.OldColumn != nil && dialect.TypeName(*change.OldColumn) == dialect.TypeName(change.NewColumn)
 }
 
 func unsupportedTypeChangeError(dialect Dialect, table string, change schemaevolution.SchemaChange, stmt string) error {

--- a/pkg/destination/schema_evolution_test.go
+++ b/pkg/destination/schema_evolution_test.go
@@ -35,9 +35,6 @@ func (d *fakeDialect) AddColumnSQL(table string, col schema.Column) string {
 }
 
 func (d *fakeDialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {
-	if !d.supportsAlter {
-		return ""
-	}
 	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s", table, d.QuoteIdentifier(colName), d.TypeName(newType))
 }
 
@@ -145,13 +142,17 @@ func TestApplyEvolutionExecutesSupportedNullabilityRelaxation(t *testing.T) {
 }
 
 func TestApplyEvolutionRejectsUnsupportedTypeChangeBeforeExecutingDDL(t *testing.T) {
+	oldColumn := schema.Column{Name: "value", DataType: schema.TypeInt32}
 	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{
 		{Type: schemaevolution.ChangeAddColumn, ColumnName: "new_col", NewColumn: schema.Column{Name: "new_col", DataType: schema.TypeString}},
-		{Type: schemaevolution.ChangeWidenType, ColumnName: "value", NewColumn: schema.Column{Name: "value", DataType: schema.TypeInt64}},
+		{Type: schemaevolution.ChangeWidenType, ColumnName: "value", OldColumn: &oldColumn, NewColumn: schema.Column{Name: "value", DataType: schema.TypeInt64}},
 	}}
 	dest := &fakeExecDestination{}
 	_, err := destination.ApplyEvolution(context.Background(), dest, &fakeDialect{supportsAlter: false}, "events", comparison)
 	require.ErrorContains(t, err, "requires a type change")
+	require.ErrorContains(t, err, `column "value" on table "events"`)
+	require.ErrorContains(t, err, "from int32 (fake type T_int32) to int64 (fake type T_int64)")
+	require.ErrorContains(t, err, `query was not executed: ALTER TABLE events ALTER COLUMN "value" TYPE T_int64`)
 	require.Empty(t, dest.statements, "validation must reject the complete migration before ADD COLUMN executes")
 }
 
@@ -166,6 +167,7 @@ func TestApplyEvolutionRejectsEmptyTypeAlterationBeforeExecutingDDL(t *testing.T
 	dest := &fakeExecDestination{}
 	_, err := destination.ApplyEvolution(context.Background(), dest, &emptyAlterDialect{fakeDialect{supportsAlter: true}}, "events", comparison)
 	require.ErrorContains(t, err, "requires a type change")
+	require.ErrorContains(t, err, "no ALTER COLUMN query was generated or executed")
 	require.Empty(t, dest.statements)
 }
 

--- a/pkg/destination/schema_evolution_test.go
+++ b/pkg/destination/schema_evolution_test.go
@@ -171,6 +171,25 @@ func TestApplyEvolutionRejectsEmptyTypeAlterationBeforeExecutingDDL(t *testing.T
 	require.Empty(t, dest.statements)
 }
 
+type sameTypeDialect struct{ fakeDialect }
+
+func (*sameTypeDialect) TypeName(schema.Column) string { return "SAME_TYPE" }
+
+func TestApplyEvolutionSkipsUnchangedDestinationType(t *testing.T) {
+	oldColumn := schema.Column{Name: "value", DataType: schema.TypeInt32}
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeWidenType,
+		ColumnName: "value",
+		OldColumn:  &oldColumn,
+		NewColumn:  schema.Column{Name: "value", DataType: schema.TypeInt64},
+	}}}
+	dest := &fakeExecDestination{}
+
+	_, err := destination.ApplyEvolution(context.Background(), dest, &sameTypeDialect{fakeDialect{supportsAlter: true}}, "events", comparison)
+	require.NoError(t, err)
+	require.Empty(t, dest.statements)
+}
+
 func TestBuildMigration_NoChanges(t *testing.T) {
 	stmts, warnings := destination.BuildMigration(&fakeDialect{supportsAlter: true}, "t", &schemaevolution.SchemaComparison{})
 	assert.Empty(t, stmts)


### PR DESCRIPTION
## What
Let Fabric execute compatible `ALTER COLUMN` changes and surface exact SQL when schema evolution cannot proceed.

## Changes
- Enable Fabric column type evolution, improve unsupported-change diagnostics, and cover success and failure paths.

## How to test
1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback
- **Risk:** Medium — Fabric now attempts destination type changes and relies on Fabric to validate each conversion.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
