### PR TITLE
Support partitioned replace ingestion

### DIFF
--- a/docs/getting-started/incremental-loading.md
+++ b/docs/getting-started/incremental-loading.md
@@ -34,6 +34,10 @@ Here's how the replace strategy works:
 - The source table is downloaded.
 - The source table is uploaded to the destination, replacing the destination table.
 
+Replace can use `--extract-partition-by` to read a bounded incremental-key interval through parallel source queries. All extract windows are loaded before the destination replacement is finalized. On destinations with a staging-based replace or transactional truncate+insert implementation, a failed extract or load leaves the existing destination data unchanged.
+
+The interval still defines the complete replacement data set: destination rows outside `--interval-start` and `--interval-end` are not retained. Use `merge` or `delete+insert` instead when the destination should keep rows outside the extracted interval.
+
 
 > [!CAUTION]
 > This strategy will delete the entire destination table and replace it with the source table, use with caution.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -267,9 +267,8 @@ func (c *IngestConfig) validateExtractPartitioning() error {
 	if c.FullRefresh {
 		return &ValidationError{Field: "full-refresh", Message: "cannot be combined with extract partitioning"}
 	}
-	switch c.IncrementalStrategy {
-	case StrategyReplace, StrategyTruncateInsert:
-		return &ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("%q cannot be combined with extract partitioning because it rewrites the whole destination table from a bounded source read", c.IncrementalStrategy)}
+	if c.IncrementalStrategy == StrategyTruncateInsert {
+		return &ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("%q cannot be combined with extract partitioning; use replace so the complete extract is staged before the destination is finalized", c.IncrementalStrategy)}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -381,9 +381,8 @@ func TestIngestConfigValidate_ExtractPartitioning(t *testing.T) {
 			wantErr: "full-refresh",
 		},
 		{
-			name:    "replace rejected",
-			mutate:  func(c *IngestConfig) { c.IncrementalStrategy = StrategyReplace },
-			wantErr: "incremental-strategy",
+			name:   "replace accepted",
+			mutate: func(c *IngestConfig) { c.IncrementalStrategy = StrategyReplace },
 		},
 		{
 			name:    "truncate insert rejected",

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -1751,24 +1751,24 @@ func buildMergeStagingSelect(quotedStagingTable, pkList string, destQuoted []str
 }
 
 func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
-	if len(opts.PrimaryKeys) == 0 {
-		return "", "", fmt.Errorf("truncate+insert from staging requires primary keys")
-	}
-
 	destQuoted := quoteColumns(destination.DestinationColumns(opts.Columns))
-	pkList := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
-	orderBy := pkList
-	if opts.IncrementalKey != "" {
-		orderBy = fmt.Sprintf("%s, %s DESC", pkList, destination.QuoteIdentifier(opts.IncrementalKey))
-	}
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
-	stagingSelect := buildMergeStagingSelect(
-		destination.QuoteTableName(opts.StagingTable),
-		pkList,
-		destQuoted,
-		orderBy,
-		opts.StagingPrimaryKeysUnique,
-	)
+	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
+	stagingSelect := fmt.Sprintf("SELECT %s FROM %s", strings.Join(destQuoted, ", "), quotedStagingTable)
+	if len(opts.PrimaryKeys) > 0 {
+		pkList := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
+		orderBy := pkList
+		if opts.IncrementalKey != "" {
+			orderBy = fmt.Sprintf("%s, %s DESC", pkList, destination.QuoteIdentifier(opts.IncrementalKey))
+		}
+		stagingSelect = buildMergeStagingSelect(
+			quotedStagingTable,
+			pkList,
+			destQuoted,
+			orderBy,
+			opts.StagingPrimaryKeysUnique,
+		)
+	}
 
 	return fmt.Sprintf("TRUNCATE TABLE %s", quotedTargetTable), fmt.Sprintf(
 		"INSERT INTO %s (%s) %s",

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -197,6 +197,16 @@ func TestBuildTruncateInsertFromStagingSQL(t *testing.T) {
 		excludes string
 	}{
 		{
+			name: "without keys",
+			opts: destination.TruncateInsertFromStagingOptions{
+				StagingTable: "_bruin_staging.events",
+				TargetTable:  "public.events",
+				Columns:      []string{"id", "value"},
+			},
+			contains: `SELECT "id", "value" FROM "_bruin_staging"."events"`,
+			excludes: "DISTINCT ON",
+		},
+		{
 			name: "unique keys",
 			opts: destination.TruncateInsertFromStagingOptions{
 				StagingTable:             "_bruin_staging.events",
@@ -238,13 +248,6 @@ func TestBuildTruncateInsertFromStagingSQL(t *testing.T) {
 				t.Fatalf("insert SQL unexpectedly contains %q:\n%s", tt.excludes, insertSQL)
 			}
 		})
-	}
-}
-
-func TestBuildTruncateInsertFromStagingSQLRequiresPrimaryKeys(t *testing.T) {
-	_, _, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{})
-	if err == nil {
-		t.Fatal("expected missing primary key error")
 	}
 }
 

--- a/pkg/destination/postgres/truncate_insert_integration_test.go
+++ b/pkg/destination/postgres/truncate_insert_integration_test.go
@@ -73,4 +73,28 @@ func TestTruncateInsertFromStagingIsAtomic(t *testing.T) {
 	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id, value FROM public.current_events`).Scan(&id, &value))
 	require.Equal(t, int64(2), id)
 	require.Equal(t, "new", value)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE public.keyless_events (id bigint, value text NOT NULL);
+		INSERT INTO public.keyless_events VALUES (10, 'old-keyless');
+		CREATE VIEW public.current_keyless_events AS SELECT id, value FROM public.keyless_events;
+		CREATE TABLE _bruin_staging.keyless_events (id bigint, value text);
+		INSERT INTO _bruin_staging.keyless_events VALUES (20, NULL);
+	`))
+
+	keylessOpts := destination.TruncateInsertFromStagingOptions{
+		StagingTable: "_bruin_staging.keyless_events",
+		TargetTable:  "public.keyless_events",
+		Columns:      []string{"id", "value"},
+	}
+	require.Error(t, dest.TruncateInsertFromStaging(ctx, keylessOpts))
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id, value FROM public.current_keyless_events`).Scan(&id, &value))
+	require.Equal(t, int64(10), id)
+	require.Equal(t, "old-keyless", value)
+
+	require.NoError(t, dest.Exec(ctx, `TRUNCATE _bruin_staging.keyless_events; INSERT INTO _bruin_staging.keyless_events VALUES (20, 'new-keyless')`))
+	require.NoError(t, dest.TruncateInsertFromStaging(ctx, keylessOpts))
+	require.NoError(t, dest.pool.QueryRow(ctx, `SELECT id, value FROM public.current_keyless_events`).Scan(&id, &value))
+	require.Equal(t, int64(20), id)
+	require.Equal(t, "new-keyless", value)
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -379,7 +379,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	preFetchConfig.IncrementalKey = resolveIncrementalKey(p.config, src, table)
 	preFetchConfig.PrimaryKeys = resolvePrimaryKeys(p.config, table)
 	preFetchConfig.PartitionBy = resolvePartitionBy(p.config, table)
-	if err := validateExtractPartitionStrategy(&preFetchConfig, preFetchStrategy); err != nil {
+	if err := validateExtractPartitionStrategy(p.config); err != nil {
 		return err
 	}
 	if err := validateIncrementalPredicate(p.config, dest, preFetchStrategy); err != nil {
@@ -2447,15 +2447,13 @@ func validateExtractPartitionSupport(cfg *config.IngestConfig, table source.Sour
 	return nil
 }
 
-func validateExtractPartitionStrategy(cfg *config.IngestConfig, resolvedStrategy config.IncrementalStrategy) error {
-	if cfg.ExtractPartitionBy == "" {
+func validateExtractPartitionStrategy(cfg *config.IngestConfig) error {
+	if cfg.ExtractPartitionBy == "" || cfg.IncrementalStrategy != config.StrategyTruncateInsert {
 		return nil
 	}
-	switch resolvedStrategy {
-	case config.StrategyReplace, config.StrategyTruncateInsert:
-		return &config.ValidationError{Field: "incremental-strategy", Message: fmt.Sprintf("%q cannot be combined with extract partitioning because it rewrites the whole destination table from a bounded source read", resolvedStrategy)}
-	default:
-		return nil
+	return &config.ValidationError{
+		Field:   "incremental-strategy",
+		Message: fmt.Sprintf("%q cannot be combined with extract partitioning; use replace so the complete extract is staged before the destination is finalized", cfg.IncrementalStrategy),
 	}
 }
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -379,7 +379,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	preFetchConfig.IncrementalKey = resolveIncrementalKey(p.config, src, table)
 	preFetchConfig.PrimaryKeys = resolvePrimaryKeys(p.config, table)
 	preFetchConfig.PartitionBy = resolvePartitionBy(p.config, table)
-	if err := validateExtractPartitionStrategy(p.config); err != nil {
+	if err := validateExtractPartitionStrategy(p.config, preFetchStrategy, dest); err != nil {
 		return err
 	}
 	if err := validateIncrementalPredicate(p.config, dest, preFetchStrategy); err != nil {
@@ -2447,8 +2447,20 @@ func validateExtractPartitionSupport(cfg *config.IngestConfig, table source.Sour
 	return nil
 }
 
-func validateExtractPartitionStrategy(cfg *config.IngestConfig) error {
-	if cfg.ExtractPartitionBy == "" || cfg.IncrementalStrategy != config.StrategyTruncateInsert {
+func validateExtractPartitionStrategy(cfg *config.IngestConfig, resolvedStrategy config.IncrementalStrategy, dest destination.Destination) error {
+	if cfg.ExtractPartitionBy == "" {
+		return nil
+	}
+	if cfg.IncrementalStrategy != config.StrategyTruncateInsert && resolvedStrategy == config.StrategyTruncateInsert {
+		if _, ok := dest.(destination.AtomicTruncateInsertStagingWriter); ok {
+			return nil
+		}
+		return &config.ValidationError{
+			Field:   "incremental-strategy",
+			Message: fmt.Sprintf("%q resolves to %q, but the destination cannot stage the complete extract before finalization", cfg.IncrementalStrategy, resolvedStrategy),
+		}
+	}
+	if cfg.IncrementalStrategy != config.StrategyTruncateInsert {
 		return nil
 	}
 	return &config.ValidationError{

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1318,6 +1318,27 @@ func TestValidateExtractPartitionSupportUsesCustomQueryCapability(t *testing.T) 
 	}
 }
 
+func TestValidateExtractPartitionStrategyAllowsReplace(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ExtractPartitionBy = "created_at"
+	cfg.IncrementalStrategy = config.StrategyReplace
+
+	if err := validateExtractPartitionStrategy(cfg); err != nil {
+		t.Fatalf("expected replace to support extract partitioning, got %v", err)
+	}
+}
+
+func TestValidateExtractPartitionStrategyRejectsExplicitTruncateInsert(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ExtractPartitionBy = "created_at"
+	cfg.IncrementalStrategy = config.StrategyTruncateInsert
+
+	err := validateExtractPartitionStrategy(cfg)
+	if err == nil || !strings.Contains(err.Error(), "use replace") {
+		t.Fatalf("expected truncate+insert validation error, got %v", err)
+	}
+}
+
 func TestApplyExtractReadSchemaOverridesKeepsMetadataColumnName(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Columns: []schema.Column{{Name: "PARTITION_ID", DataType: schema.TypeString}},

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -31,6 +31,14 @@ type mockDestination struct {
 	scheme      string
 }
 
+type atomicTruncateInsertMockDestination struct {
+	mockDestination
+}
+
+func (*atomicTruncateInsertMockDestination) TruncateInsertFromStaging(context.Context, destination.TruncateInsertFromStagingOptions) error {
+	return nil
+}
+
 type mockConnectorLease struct {
 	done chan struct{}
 	err  error
@@ -1323,8 +1331,29 @@ func TestValidateExtractPartitionStrategyAllowsReplace(t *testing.T) {
 	cfg.ExtractPartitionBy = "created_at"
 	cfg.IncrementalStrategy = config.StrategyReplace
 
-	if err := validateExtractPartitionStrategy(cfg); err != nil {
+	if err := validateExtractPartitionStrategy(cfg, config.StrategyReplace, &mockDestination{}); err != nil {
 		t.Fatalf("expected replace to support extract partitioning, got %v", err)
+	}
+}
+
+func TestValidateExtractPartitionStrategyAllowsAtomicResolvedTruncateInsert(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ExtractPartitionBy = "created_at"
+	cfg.IncrementalStrategy = config.StrategyReplace
+
+	if err := validateExtractPartitionStrategy(cfg, config.StrategyTruncateInsert, &atomicTruncateInsertMockDestination{}); err != nil {
+		t.Fatalf("expected atomic resolved truncate+insert to support extract partitioning, got %v", err)
+	}
+}
+
+func TestValidateExtractPartitionStrategyRejectsNonAtomicResolvedTruncateInsert(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ExtractPartitionBy = "created_at"
+	cfg.IncrementalStrategy = config.StrategyReplace
+
+	err := validateExtractPartitionStrategy(cfg, config.StrategyTruncateInsert, &mockDestination{})
+	if err == nil || !strings.Contains(err.Error(), "cannot stage the complete extract") {
+		t.Fatalf("expected non-atomic resolved truncate+insert validation error, got %v", err)
 	}
 }
 
@@ -1333,7 +1362,7 @@ func TestValidateExtractPartitionStrategyRejectsExplicitTruncateInsert(t *testin
 	cfg.ExtractPartitionBy = "created_at"
 	cfg.IncrementalStrategy = config.StrategyTruncateInsert
 
-	err := validateExtractPartitionStrategy(cfg)
+	err := validateExtractPartitionStrategy(cfg, config.StrategyTruncateInsert, &atomicTruncateInsertMockDestination{})
 	if err == nil || !strings.Contains(err.Error(), "use replace") {
 		t.Fatalf("expected truncate+insert validation error, got %v", err)
 	}

--- a/pkg/strategy/truncate_insert.go
+++ b/pkg/strategy/truncate_insert.go
@@ -59,7 +59,8 @@ func (s *TruncateInsertStrategy) Execute(ctx context.Context, job *IngestionJob)
 		return fmt.Errorf("destination does not support truncate+insert strategy; use replace instead")
 	}
 
-	if len(job.Config.PrimaryKeys) > 0 {
+	_, supportsAtomicStaging := job.Destination.(destination.AtomicTruncateInsertStagingWriter)
+	if len(job.Config.PrimaryKeys) > 0 || (job.Config.ExtractPartitionBy != "" && supportsAtomicStaging) {
 		return s.executeWithStaging(ctx, job, truncator)
 	}
 	return s.executeDirect(ctx, job, truncator)

--- a/pkg/strategy/truncate_insert_test.go
+++ b/pkg/strategy/truncate_insert_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
@@ -137,6 +138,54 @@ func TestTruncateInsertStrategy_Execute_PrefersAtomicStagingFinalizer(t *testing
 			require.Empty(t, dest.mergeCalls)
 		})
 	}
+}
+
+func TestTruncateInsertStrategy_Execute_PartitionedExtractWithoutKeysUsesAtomicStaging(t *testing.T) {
+	job, src, dest := minimalJob()
+	truncateDest := &truncateCapableDestination{fakeDestination: dest}
+	atomicDest := &atomicTruncateInsertDestination{truncateCapableDestination: truncateDest}
+	job.Destination = atomicDest
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	job.SourceSchema.PrimaryKeys = nil
+	job.Config.ExtractPartitionBy = "created_at"
+	job.Config.ExtractPartitionInterval = 24 * time.Hour
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+
+	require.NoError(t, (&TruncateInsertStrategy{}).Execute(t.Context(), job))
+	require.Len(t, dest.prepareCalls, 2)
+	require.Equal(t, job.Config.DestTable, dest.prepareCalls[0].Table)
+	require.True(t, dest.prepareCalls[1].DropFirst)
+	require.True(t, dest.writeCalls[0].StagingTable)
+	require.Len(t, atomicDest.finalizeCalls, 1)
+	require.Empty(t, atomicDest.finalizeCalls[0].PrimaryKeys)
+	require.Empty(t, dest.truncateCalls)
+	require.Equal(t, job.Config.ExtractPartitionBy, src.readOpts.ExtractPartitionBy)
+	require.Equal(t, job.Config.ExtractPartitionInterval, src.readOpts.ExtractPartitionInterval)
+}
+
+func TestTruncateInsertStrategy_Execute_PartitionedExtractFinalizeFailureDoesNotTruncateDirectly(t *testing.T) {
+	job, src, dest := minimalJob()
+	truncateDest := &truncateCapableDestination{fakeDestination: dest}
+	atomicDest := &atomicTruncateInsertDestination{
+		truncateCapableDestination: truncateDest,
+		finalizeErr:                errors.New("finalize failed"),
+	}
+	job.Destination = atomicDest
+	job.Config.IncrementalStrategy = config.StrategyTruncateInsert
+	job.Config.PrimaryKeys = nil
+	job.Schema.PrimaryKeys = nil
+	job.SourceSchema.PrimaryKeys = nil
+	job.Config.ExtractPartitionBy = "created_at"
+	job.Config.ExtractPartitionInterval = 24 * time.Hour
+	src.primaryKeys = nil
+	src.readCh = mustClosedRecords()
+
+	err := (&TruncateInsertStrategy{}).Execute(t.Context(), job)
+	require.ErrorContains(t, err, "failed to atomically insert from staging")
+	require.Empty(t, dest.truncateCalls)
 }
 
 func TestTruncateInsertStrategy_Execute_ReadFailsBeforeTruncateWithPrimaryKeys(t *testing.T) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -110,6 +110,8 @@ func TestPostgresPartitionedExtraction(t *testing.T) {
 			(9, '2026-01-10 00:00:00', '2026-02-01 00:00:00', 90)
 	`, sourceSchema))
 	require.NoError(t, err)
+	_, err = sourceDB.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %s.orders_without_pk AS TABLE %s.orders`, sourceSchema, sourceSchema))
+	require.NoError(t, err)
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 1, 22, 0, 0, 0, 0, time.UTC)
@@ -194,6 +196,49 @@ func TestPostgresPartitionedExtraction(t *testing.T) {
 	assert.Equal(t, 8, distinctCount)
 	assert.Equal(t, 1, endRows)
 	assert.Equal(t, 1, oldCreatedRows)
+	assert.Equal(t, 0, excludedRows)
+
+	_, err = destDB.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.orders_replace (
+			id INTEGER,
+			created_at TIMESTAMP,
+			updated_at TIMESTAMP,
+			amount INTEGER
+		);
+		INSERT INTO %s.orders_replace VALUES (100, '2020-01-01', '2020-01-01', -1);
+		CREATE VIEW %s.orders_replace_view AS SELECT id, amount FROM %s.orders_replace;
+	`, destSchema, destSchema, destSchema, destSchema))
+	require.NoError(t, err)
+
+	var targetOIDBefore uint32
+	require.NoError(t, destDB.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT '%s.orders_replace'::regclass::oid`, destSchema,
+	)).Scan(&targetOIDBefore))
+
+	replaceCfg := *cfg
+	replaceCfg.SourceTable = sourceSchema + ".orders_without_pk"
+	replaceCfg.DestTable = destSchema + ".orders_replace"
+	replaceCfg.IncrementalStrategy = config.StrategyReplace
+	replaceCfg.DestinationParallelism = 8
+	replaceCfg.NoLoadTimestamp = true
+	require.NoError(t, pipeline.New(&replaceCfg).Run(ctx))
+
+	var targetOIDAfter uint32
+	require.NoError(t, destDB.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT '%s.orders_replace'::regclass::oid`, destSchema,
+	)).Scan(&targetOIDAfter))
+	assert.Equal(t, targetOIDBefore, targetOIDAfter, "partitioned replace should preserve the PostgreSQL target table")
+
+	err = destDB.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT
+			COUNT(*),
+			COUNT(DISTINCT id),
+			COUNT(*) FILTER (WHERE id = 100)
+		FROM %s.orders_replace_view
+	`, destSchema)).Scan(&count, &distinctCount, &excludedRows)
+	require.NoError(t, err)
+	assert.Equal(t, 8, count)
+	assert.Equal(t, 8, distinctCount)
 	assert.Equal(t, 0, excludedRows)
 }
 


### PR DESCRIPTION
## What
Allow partitioned extracts with the replace strategy while keeping PostgreSQL replacement atomic.

## Changes
- Stage keyless PostgreSQL loads before transactional truncate+insert finalization.
- Update validation, docs, and unit/integration coverage.

## How to test
1. Run `make format`, `make lint`, and `make test`.
2. With Docker available, run the PostgreSQL integration tests.

## Risk & rollback
- **Risk:** Medium; this changes the PostgreSQL replace path for partitioned extracts.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`) — Docker was unavailable locally
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
