### PR TITLE
fix(duckdb): make DuckLake destination writes work via SQL staging

### DIFF
--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -3,8 +3,11 @@ package duckdb
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
 	srcduckdb "github.com/bruin-data/ingestr/pkg/source/duckdb"
 )
 
@@ -18,6 +21,79 @@ func NewDuckLakeDestination() *DuckLakeDestination {
 
 func (d *DuckLakeDestination) Schemes() []string { return []string{"ducklake"} }
 func (d *DuckLakeDestination) GetScheme() string { return "ducklake" }
+
+// Write and WriteParallel stage the Arrow stream in a regular in-memory DuckDB
+// table, then copy it into the DuckLake table with a SQL INSERT ... SELECT.
+//
+// The embedded DuckDBDestination writes via ADBC bulk-append (the DuckDB
+// appender), which cannot target tables in a DuckLake catalog. SQL writes
+// into DuckLake tables work,so we ADBC-load into a plain in-memory table
+// and then hand the rows to DuckLake via SQL.
+func (d *DuckLakeDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.writeViaMemoryStage(ctx, records, opts)
+}
+
+func (d *DuckLakeDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.writeViaMemoryStage(ctx, records, opts)
+}
+
+func (d *DuckLakeDestination) writeViaMemoryStage(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	target := opts.Table
+	memName := duckLakeMemStageName(target)
+	memQualified := "memory.main." + memName
+
+	// Mirror the DuckLake table's schema into a plain in-memory table.
+	if err := d.exec(ctx, fmt.Sprintf(
+		"CREATE OR REPLACE TABLE %s AS SELECT * FROM %s WHERE 1=0",
+		memQualified, destination.QuoteTableName(target),
+	)); err != nil {
+		return fmt.Errorf("ducklake: create in-memory stage: %w", err)
+	}
+	defer func() { _ = d.exec(ctx, "DROP TABLE IF EXISTS "+memQualified) }()
+
+	// ADBC bulk-append cannot target a DuckLake table, and DuckDB rejects the
+	// ADBC target_catalog option — so switch the default catalog to `memory`,
+	// load the rows there via the embedded ADBC path, then switch back.
+	if err := d.exec(ctx, "USE memory"); err != nil {
+		return fmt.Errorf("ducklake: switch to memory catalog: %w", err)
+	}
+	restore := func() error { return d.exec(ctx, "USE "+srcduckdb.AttachAlias) }
+
+	memOpts := opts
+	memOpts.Table = "main." + memName // schema-qualified only: no ADBC catalog option
+	if err := d.DuckDBDestination.Write(ctx, records, memOpts); err != nil {
+		_ = restore()
+		return fmt.Errorf("ducklake: load in-memory stage: %w", err)
+	}
+	if err := restore(); err != nil {
+		return fmt.Errorf("ducklake: restore catalog: %w", err)
+	}
+
+	if err := d.exec(ctx, fmt.Sprintf(
+		"INSERT INTO %s SELECT * FROM %s",
+		destination.QuoteTableName(target), memQualified,
+	)); err != nil {
+		return fmt.Errorf("ducklake: copy stage into ducklake table: %w", err)
+	}
+	return nil
+}
+
+// duckLakeMemStageName derives a collision-safe in-memory staging table name
+// from the (already unique) target table name.
+func duckLakeMemStageName(target string) string {
+	name := duckTable(target).Table + "__ducklake_memstage"
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
 
 func (d *DuckLakeDestination) Connect(ctx context.Context, uri string) error {
 	cfg, err := srcduckdb.ParseLakehouseURI(uri)

--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
@@ -13,6 +15,14 @@ import (
 
 type DuckLakeDestination struct {
 	*DuckDBDestination
+
+	// writeMu serializes the whole create/load/copy/drop staging sequence. The
+	// sequence toggles the shared connection's default catalog (USE memory /
+	// USE ducklake_catalog), so two DuckLake writes must never interleave.
+	writeMu sync.Mutex
+	// stageSeq makes each staging table name unique, even for the same target
+	// or targets whose names sanitize identically.
+	stageSeq atomic.Uint64
 }
 
 func NewDuckLakeDestination() *DuckLakeDestination {
@@ -38,9 +48,19 @@ func (d *DuckLakeDestination) WriteParallel(ctx context.Context, records <-chan 
 }
 
 func (d *DuckLakeDestination) writeViaMemoryStage(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	// The sequence below toggles the shared connection's default catalog, so it
+	// must run start-to-finish without another DuckLake write interleaving.
+	d.writeMu.Lock()
+	defer d.writeMu.Unlock()
+
 	target := opts.Table
-	memName := duckLakeMemStageName(target)
+	memName := fmt.Sprintf("%s_%d", duckLakeMemStageName(target), d.stageSeq.Add(1))
 	memQualified := "memory.main." + memName
+
+	// Restore and cleanup must run even if ctx is cancelled mid-write, otherwise
+	// the connection can stay pointed at `memory` and the stage table leaks for
+	// the connection's lifetime.
+	cleanupCtx := context.WithoutCancel(ctx)
 
 	// Mirror the DuckLake table's schema into a plain in-memory table.
 	if err := d.exec(ctx, fmt.Sprintf(
@@ -49,7 +69,7 @@ func (d *DuckLakeDestination) writeViaMemoryStage(ctx context.Context, records <
 	)); err != nil {
 		return fmt.Errorf("ducklake: create in-memory stage: %w", err)
 	}
-	defer func() { _ = d.exec(ctx, "DROP TABLE IF EXISTS "+memQualified) }()
+	defer func() { _ = d.exec(cleanupCtx, "DROP TABLE IF EXISTS "+memQualified) }()
 
 	// ADBC bulk-append cannot target a DuckLake table, and DuckDB rejects the
 	// ADBC target_catalog option — so switch the default catalog to `memory`,
@@ -57,7 +77,7 @@ func (d *DuckLakeDestination) writeViaMemoryStage(ctx context.Context, records <
 	if err := d.exec(ctx, "USE memory"); err != nil {
 		return fmt.Errorf("ducklake: switch to memory catalog: %w", err)
 	}
-	restore := func() error { return d.exec(ctx, "USE "+srcduckdb.AttachAlias) }
+	restore := func() error { return d.exec(cleanupCtx, "USE "+srcduckdb.AttachAlias) }
 
 	memOpts := opts
 	memOpts.Table = "main." + memName // schema-qualified only: no ADBC catalog option

--- a/pkg/destination/duckdb/lakehouse_test.go
+++ b/pkg/destination/duckdb/lakehouse_test.go
@@ -1,0 +1,47 @@
+package duckdb
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDuckLakeMemStageName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "schema-qualified staging table",
+			target: "main.orders_staging_1784713433980251000",
+			want:   "orders_staging_1784713433980251000__ducklake_memstage",
+		},
+		{
+			name:   "catalog-qualified target uses only the table component",
+			target: "ducklake_catalog.main.orders",
+			want:   "orders__ducklake_memstage",
+		},
+		{
+			name:   "unsafe characters are sanitized",
+			target: `weird-name.with space`,
+			want:   "with_space__ducklake_memstage",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := duckLakeMemStageName(tt.target)
+			if got != tt.want {
+				t.Errorf("duckLakeMemStageName(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+			// The staged name must be a valid single SQL identifier body.
+			if strings.ContainsAny(got, ". -") {
+				t.Errorf("staged name %q contains characters that need quoting", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The DuckLake destination inherited DuckDBDestination.Write, which bulk-loads rows with adbc.IngestStream (the DuckDB ADBC appender). The appender cannot target tables in a DuckLake catalog, so every ingestion failed on the first batch with an opaque "[drivermgr] nil error".

Override Write/WriteParallel for DuckLake: ADBC-load the Arrow stream into a plain in-memory DuckDB table, then INSERT ... SELECT into the DuckLake table via SQL, which DuckLake supports. Fix is storage-agnostic (s3 / gcs / azure) and catalog-agnostic (duckdb / sqlite / postgres).