### PR TITLE
metrics: exclude expvar built-ins from /debug/vars

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,9 +6,10 @@ package metrics
 
 import (
 	"expvar"
-	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -160,18 +161,23 @@ func Serve(addr string) (boundAddr string, stop func(), err error) {
 // particular calls runtime.ReadMemStats on each scrape, which is needless work
 // and a stop-the-world pause for data no ingestr consumer asked for.
 func handler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, "{\n")
+	var buf strings.Builder
+	buf.WriteString("{\n")
 	first := true
 	expvar.Do(func(kv expvar.KeyValue) {
 		if !strings.HasPrefix(kv.Key, varPrefix) {
 			return
 		}
 		if !first {
-			fmt.Fprintf(w, ",\n")
+			buf.WriteString(",\n")
 		}
 		first = false
-		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+		buf.WriteString(strconv.Quote(kv.Key))
+		buf.WriteString(": ")
+		buf.WriteString(kv.Value.String())
 	})
-	fmt.Fprintf(w, "\n}\n")
+	buf.WriteString("\n}\n")
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_, _ = io.WriteString(w, buf.String())
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,14 +6,22 @@ package metrics
 
 import (
 	"expvar"
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/bruin-data/ingestr/pkg/source"
 )
+
+// varPrefix namespaces every variable ingestr publishes. The handler filters on
+// it so the endpoint exposes only ingestr's own vars, never expvar's built-in
+// cmdline/memstats, which the standard library injects into the shared registry
+// at package-import time.
+const varPrefix = "ingestr_"
 
 // reporter holds the active source's lag reporter. It is a package global
 // because expvar's registry is process-global and ingestr runs one stream per
@@ -138,10 +146,32 @@ func Serve(addr string) (boundAddr string, stop func(), err error) {
 	// A dedicated mux, never http.DefaultServeMux: importing expvar registers
 	// /debug/vars there, and that must not leak into the web UI server.
 	mux := http.NewServeMux()
-	mux.Handle("/debug/vars", expvar.Handler())
+	mux.HandleFunc("/debug/vars", handler)
 
 	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	go func() { _ = srv.Serve(ln) }()
 
 	return ln.Addr().String(), func() { _ = srv.Close() }, nil
+}
+
+// handler serves ingestr's own vars as a JSON object, mirroring the format of
+// expvar.Handler but skipping every var outside the ingestr_ namespace. This
+// keeps expvar's cmdline/memstats built-ins out of the response; memstats in
+// particular calls runtime.ReadMemStats on each scrape, which is needless work
+// and a stop-the-world pause for data no ingestr consumer asked for.
+func handler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, "{\n")
+	first := true
+	expvar.Do(func(kv expvar.KeyValue) {
+		if !strings.HasPrefix(kv.Key, varPrefix) {
+			return
+		}
+		if !first {
+			fmt.Fprintf(w, ",\n")
+		}
+		first = false
+		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+	})
+	fmt.Fprintf(w, "\n}\n")
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -225,6 +225,15 @@ func TestServeExposesDebugVars(t *testing.T) {
 	if _, ok := out["ingestr_stream_rows_synced"]; !ok {
 		t.Fatalf("expected ingestr_stream_rows_synced in /debug/vars, got keys %v", out)
 	}
+
+	// expvar injects cmdline and memstats into the shared registry; the handler
+	// must filter them out so scrapes never trigger runtime.ReadMemStats or leak
+	// the process arguments.
+	for _, builtin := range []string{"memstats", "cmdline"} {
+		if _, ok := out[builtin]; ok {
+			t.Fatalf("expected %q to be excluded from /debug/vars, got keys %v", builtin, out)
+		}
+	}
 }
 
 func TestServeStopDoesNotHang(t *testing.T) {


### PR DESCRIPTION
## What

The streaming metrics endpoint (`--metrics-addr`) mounted `expvar.Handler()`, which serves the entire process-global expvar registry. That registry includes the Go standard library's own `cmdline` and `memstats` variables, which `expvar` publishes at package-import time. As a result, scrapes of `/debug/vars` returned the process arguments and a full `runtime.MemStats` dump alongside ingestr's own metrics.

This replaces `expvar.Handler()` with a custom handler that serves only variables in the `ingestr_` namespace, mirroring `expvar.Handler`'s JSON output format. All of ingestr's published vars already use that prefix, so the response is unchanged for real consumers.

## Why

- The `memstats`/`cmdline` variables are noise that no ingestr consumer requested.
- `memstats` is registered as an `expvar.Func` that calls `runtime.ReadMemStats` on every scrape — a stop-the-world pause. Since we no longer serialize it, scrapes now do strictly less work.
- `cmdline` leaks the full process argument list over the endpoint.

## Notes

- Output format is byte-compatible with `expvar.Handler` for the vars we keep, so existing scrapers are unaffected.
- ingestr's vars remain registered in the global expvar registry as before; only the HTTP response is filtered.
- Extends `TestServeExposesDebugVars` to assert `memstats` and `cmdline` are excluded.