### PR TITLE
cmd: add delete command for CDC replication slots

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/source/postgres_cdc"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v3"
+)
+
+func DeleteCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a resource from the source (e.g. a CDC replication slot)",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "uri",
+				Usage:    "The URI of the source",
+				Required: true,
+				Sources:  cli.EnvVars("SOURCE_URI", "INGESTR_SOURCE_URI"),
+			},
+			&cli.StringFlag{
+				Name:    "replication-slot",
+				Usage:   "Name of the PostgreSQL CDC replication slot to drop",
+				Sources: cli.EnvVars("INGESTR_CDC_SLOT"),
+			},
+		},
+		Action: runDelete,
+	}
+}
+
+func runDelete(ctx context.Context, c *cli.Command) (err error) {
+	trackCommandTriggered(ctx, "delete")
+	defer func() {
+		trackCommandFinished(ctx, "delete", err, nil)
+	}()
+
+	sourceURI := c.String("uri")
+
+	switch {
+	case c.IsSet("replication-slot"):
+		return dropReplicationSlot(ctx, sourceURI, c.String("replication-slot"))
+	default:
+		return fmt.Errorf("no delete target specified; provide one of: --replication-slot")
+	}
+}
+
+func dropReplicationSlot(ctx context.Context, sourceURI, slotName string) error {
+	existed, err := postgres_cdc.DropReplicationSlot(ctx, sourceURI, slotName)
+	if err != nil {
+		return err
+	}
+
+	if !output.IsJSON() {
+		if existed {
+			color.Green("Dropped replication slot %q", slotName)
+		} else {
+			color.Yellow("Replication slot %q does not exist; nothing to do", slotName)
+		}
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ func NewApp() *cli.Command {
 		Commands: []*cli.Command{
 			IngestCommand(),
 			ServerCommand(),
+			DeleteCommand(),
 		},
 	}
 }

--- a/pkg/source/postgres_cdc/slot_admin.go
+++ b/pkg/source/postgres_cdc/slot_admin.go
@@ -1,0 +1,46 @@
+package postgres_cdc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// DropReplicationSlot connects to the Postgres server described by uri (a
+// postgres+cdc://, postgresql+cdc://, postgres:// or postgresql:// URI) and
+// drops the named logical replication slot.
+//
+// It returns existed=false with a nil error when the slot is already gone, so
+// the operation is idempotent. Real failures (unreachable server, or a slot
+// that is still active for a running walsender) are returned as errors.
+func DropReplicationSlot(ctx context.Context, uri, slotName string) (existed bool, err error) {
+	if slotName == "" {
+		return false, fmt.Errorf("slot name is required")
+	}
+
+	_, normalizedURI, err := parseURIConfig(uri)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse CDC config: %w", err)
+	}
+
+	pgConfig, err := pgxpool.ParseConfig(normalizedURI)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, pgConfig)
+	if err != nil {
+		return false, fmt.Errorf("failed to connect to postgres: %w", err)
+	}
+	defer pool.Close()
+
+	if _, err := pool.Exec(ctx, "SELECT pg_drop_replication_slot($1)", slotName); err != nil {
+		if isMissingReplicationSlotError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to drop replication slot %q: %w", slotName, err)
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
## What

Adds a top-level `delete` command for removing resources from a source. The first supported target is a PostgreSQL logical replication slot:

```
ingestr delete --uri 'postgres+cdc://user:pass@host:5432/db' --replication-slot 'ingestr_mt_ingestr_publication_ab12cd34ef'
```

## Why

The PostgreSQL CDC source deliberately keeps its logical replication slot across runs so the next run resumes from `confirmed_flush_lsn`. When a pipeline is abandoned, that persistent slot lingers on the server and can pin WAL indefinitely. There was no supported way to remove it without dropping into `psql`.

## How

- New `delete` command (`cmd/delete.go`) takes `--uri` plus a target flag and dispatches on which target is set, erroring clearly when none is given. The dispatch is structured so future targets (e.g. `--table`) drop into the same switch.
- Slot removal is handled by a new exported `postgres_cdc.DropReplicationSlot` helper, which reuses the source's URI normalization and query-pool connection path and runs `pg_drop_replication_slot`. A missing slot is treated as an idempotent no-op; a still-active slot surfaces as an error.

Postgres is the only CDC source that holds a persistent server-side slot, so the target is intentionally postgres-specific for now.