### PR TITLE
Harden MySQL CDC safety guarantees

### DIFF
--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -96,6 +96,15 @@ type MergeOptions struct {
 	Parallelism            int
 }
 
+type CDCAtomicTableMerge struct {
+	Options  MergeOptions
+	Truncate bool
+}
+
+type CDCMultiTableAtomicMerger interface {
+	MergeCDCTablesAtomically(ctx context.Context, merges []CDCAtomicTableMerge) error
+}
+
 // TruncateInsertFromStagingOptions configures an atomic replacement from a
 // populated staging table into an existing target table.
 type TruncateInsertFromStagingOptions struct {

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -31,6 +31,8 @@ type MySQLDestination struct {
 	db                  *sql.DB
 	uri                 string
 	database            string
+	serverIdentity      string
+	serverFlavor        string
 	isVitess            bool
 	vitessBackend       bool
 	useLoadData         bool
@@ -224,11 +226,58 @@ func (d *MySQLDestination) Connect(ctx context.Context, uri string) error {
 	d.isVitess = d.vitessBackend
 	d.useLoadData = !d.vitessBackend
 	d.lowerCaseTableNames = lowerCaseTableNames
+	if !d.vitessBackend {
+		// Detect the flavor from the server itself, not the URI scheme: the
+		// mysql:// and mariadb:// schemes are interchangeable for this
+		// destination, and the identity string must match the one the CDC
+		// source computes from the server flavor for feedback-loop detection.
+		d.serverFlavor = detectMySQLFlavor(ctx, db)
+		identityVariable := "@@GLOBAL.server_uuid"
+		identityPrefix := "mysql:"
+		if d.serverFlavor == "mariadb" {
+			identityVariable = "@@GLOBAL.server_uid"
+			identityPrefix = "mariadb:"
+		}
+		if d.serverFlavor != "" {
+			var identity string
+			if err := db.QueryRowContext(ctx, "SELECT "+identityVariable).Scan(&identity); err != nil {
+				config.Debug("[MYSQL] server identity probe (%s) failed: %v", identityVariable, err)
+			} else if strings.TrimSpace(identity) != "" {
+				d.serverIdentity = identityPrefix + identity
+			}
+		}
+	}
 	if scheme != "" {
 		d.scheme = scheme
 	}
 	config.Debug("[MYSQL] Connected to database: %s", database)
 	return nil
+}
+
+func (d *MySQLDestination) MySQLServerIdentity() string {
+	return d.serverIdentity
+}
+
+func (d *MySQLDestination) MySQLServerFlavor() string {
+	return d.serverFlavor
+}
+
+func (d *MySQLDestination) MySQLDatabaseName() string {
+	return d.database
+}
+
+// detectMySQLFlavor returns "mariadb" or "mysql" based on the server's own
+// version string, or "" when the probe fails and the flavor is unknown.
+func detectMySQLFlavor(ctx context.Context, db *sql.DB) string {
+	var version string
+	if err := db.QueryRowContext(ctx, "SELECT @@version").Scan(&version); err != nil {
+		config.Debug("[MYSQL] server flavor detection failed: %v", err)
+		return ""
+	}
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return "mariadb"
+	}
+	return "mysql"
 }
 
 // detectVitess reports whether the server identifies as Vitess (this also covers
@@ -1095,18 +1144,28 @@ func quoteMySQLTable(database, table string) string {
 
 func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
 	startMerge := time.Now()
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := d.mergeTableInTx(ctx, tx, opts); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
 
+func (d *MySQLDestination) mergeTableInTx(ctx context.Context, tx *sql.Tx, opts destination.MergeOptions) error {
 	columns := opts.Columns
 	quotedColumns := quoteColumns(columns)
 	targetColumns := destination.DestinationColumns(columns)
 	quotedTargetColumns := quoteColumns(targetColumns)
 	nonPKColumns := filterColumns(targetColumns, opts.PrimaryKeys)
 
-	tx, err := d.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
 	if opts.CDCExpectedIncarnation != "" {
 		if err := d.lockAndValidateCDCIncarnation(ctx, tx, opts.TargetTable, opts.CDCExpectedIncarnation); err != nil {
 			return err
@@ -1280,11 +1339,34 @@ func (d *MySQLDestination) MergeTable(ctx context.Context, opts destination.Merg
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
+	return nil
+}
 
-	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
+func (d *MySQLDestination) MergeCDCTablesAtomically(ctx context.Context, merges []destination.CDCAtomicTableMerge) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin multi-table CDC transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, merge := range merges {
+		if merge.Truncate {
+			if merge.Options.CDCExpectedIncarnation != "" {
+				if err := d.lockAndValidateCDCIncarnation(ctx, tx, merge.Options.TargetTable, merge.Options.CDCExpectedIncarnation); err != nil {
+					return err
+				}
+			}
+			if _, err := tx.ExecContext(ctx, "DELETE FROM "+quoteTable(merge.Options.TargetTable)); err != nil {
+				return fmt.Errorf("failed to reset CDC target %s: %w", merge.Options.TargetTable, err)
+			}
+		}
+		if err := d.mergeTableInTx(ctx, tx, merge.Options); err != nil {
+			return fmt.Errorf("failed to merge CDC target %s: %w", merge.Options.TargetTable, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit multi-table CDC transaction: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/destination/mysql/mysql_test.go
+++ b/pkg/destination/mysql/mysql_test.go
@@ -812,6 +812,30 @@ func TestCDCMergeWithIncrementalPredicateInsertsBeforeUpdate(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestMultiTableCDCMergeUsesSingleTransaction(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dest := &MySQLDestination{db: db}
+	mock.ExpectBegin()
+	for _, table := range []string{"orders", "users"} {
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE `" + table + "` AS target")).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `" + table + "`")).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE `" + table + "` AS target")).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `" + table + "`")).WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+	mock.ExpectCommit()
+
+	columns := []string{"id", "payload", destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn}
+	err = dest.MergeCDCTablesAtomically(t.Context(), []destination.CDCAtomicTableMerge{
+		{Options: destination.MergeOptions{TargetTable: "orders", StagingTable: "orders_staging", PrimaryKeys: []string{"id"}, Columns: columns}},
+		{Options: destination.MergeOptions{TargetTable: "users", StagingTable: "users_staging", PrimaryKeys: []string{"id"}, Columns: columns}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBuildMultiRowInsertSQL(t *testing.T) {
 	got := buildMultiRowInsertSQL("analytics.users", []string{"`id`", "`name`"}, 3)
 	want := "INSERT INTO `analytics`.`users` (`id`, `name`) VALUES (?, ?), (?, ?), (?, ?)"

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/strategy"
+	"github.com/bruin-data/ingestr/pkg/tablename"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 	"golang.org/x/term"
 )
@@ -145,6 +146,11 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	managedPostgresCDC := isPostgresCDCSource(p.config.SourceURI)
 	managedMySQLCDC := isMySQLCDCSource(p.config.SourceURI)
 	managedDestinationCDC := managedPostgresCDC || managedMySQLCDC
+	if managedMySQLCDC {
+		if err := validateMySQLCDCSourceDestination(p.config, src, dest); err != nil {
+			return err
+		}
+	}
 	if err := validateCDCRunSerialization(p.config, dest); err != nil {
 		return err
 	}
@@ -180,7 +186,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 			return err
 		}
 		if managedMySQLCDC {
-			if err := validateMySQLCDCMutationFencing(dest); err != nil {
+			if err := validateMySQLCDCMutationFencing(dest, p.config.SourceTable == ""); err != nil {
 				return err
 			}
 		}
@@ -2186,6 +2192,17 @@ func (p *Pipeline) applyNamingConvention(sourceSchema *schema.TableSchema, namin
 		config.Debug("[NAMING] No column renames needed")
 		return nil
 	}
+	if isCDCSource(p.config.SourceURI) {
+		for sourceName, destinationName := range columnMapping {
+			if destination.IsCDCMetaColumn(sourceName) {
+				delete(columnMapping, sourceName)
+				continue
+			}
+			if destination.IsCDCMetaColumn(destinationName) {
+				return fmt.Errorf("source column %q normalizes to reserved CDC metadata column %q", sourceName, destinationName)
+			}
+		}
+	}
 
 	// Log the column mappings
 	for src, dest := range columnMapping {
@@ -2518,6 +2535,71 @@ func isMySQLCDCSource(rawURI string) bool {
 	}
 }
 
+type mysqlServerIdentityProvider interface {
+	MySQLServerIdentity() string
+	MySQLDatabaseName() string
+}
+
+type mysqlServerFlavorProvider interface {
+	MySQLServerFlavor() string
+}
+
+func validateMySQLCDCSourceDestination(cfg *config.IngestConfig, src source.Source, dest destination.Destination) error {
+	sourceIdentity, ok := src.(mysqlServerIdentityProvider)
+	if !ok || sourceIdentity.MySQLServerIdentity() == "" {
+		return fmt.Errorf("MySQL CDC source does not expose a verifiable server identity")
+	}
+	destinationIdentity, ok := dest.(mysqlServerIdentityProvider)
+	if !ok || destinationIdentity.MySQLServerIdentity() == "" {
+		// A missing identity (e.g. a MariaDB destination predating
+		// @@GLOBAL.server_uid) is still safe when the destination flavor
+		// provably differs from the source's: identities are prefixed by
+		// flavor, so they can never refer to the same physical server.
+		if flavorProvider, ok := dest.(mysqlServerFlavorProvider); ok {
+			destinationFlavor := flavorProvider.MySQLServerFlavor()
+			sourceFlavor, _, _ := strings.Cut(sourceIdentity.MySQLServerIdentity(), ":")
+			if destinationFlavor != "" && destinationFlavor != sourceFlavor {
+				return nil
+			}
+		}
+		return fmt.Errorf("destination scheme %q does not expose a verifiable MySQL server identity required to prevent CDC feedback loops", dest.GetScheme())
+	}
+	if sourceIdentity.MySQLServerIdentity() != destinationIdentity.MySQLServerIdentity() {
+		return nil
+	}
+
+	sourceDatabase := sourceIdentity.MySQLDatabaseName()
+	destinationDatabase := destinationIdentity.MySQLDatabaseName()
+	if cfg.SourceTable == "" {
+		if parsed, err := url.Parse(cfg.SourceURI); err == nil {
+			if mappedDatabase := strings.TrimSpace(parsed.Query().Get("dest_schema")); mappedDatabase != "" {
+				destinationDatabase = mappedDatabase
+			}
+		}
+		if strings.EqualFold(sourceDatabase, destinationDatabase) {
+			return fmt.Errorf("MySQL CDC source and multi-table destination resolve to the same server and database %q; choose a different destination database to prevent the connector from consuming its own writes", sourceDatabase)
+		}
+		return nil
+	}
+
+	sourceParts := tablename.Split(cfg.SourceTable)
+	destinationTable := cfg.DestTable
+	if strings.TrimSpace(destinationTable) == "" {
+		destinationTable = cfg.SourceTable
+	}
+	destinationParts := tablename.Split(destinationTable)
+	if len(sourceParts) == 0 || len(destinationParts) == 0 {
+		return fmt.Errorf("failed to resolve MySQL CDC source and destination table names for feedback-loop validation")
+	}
+	if len(destinationParts) > 1 {
+		destinationDatabase = destinationParts[len(destinationParts)-2]
+	}
+	if strings.EqualFold(sourceDatabase, destinationDatabase) && strings.EqualFold(sourceParts[len(sourceParts)-1], destinationParts[len(destinationParts)-1]) {
+		return fmt.Errorf("MySQL CDC source and destination resolve to the same physical table %s.%s; choose a different destination to prevent the connector from consuming its own writes", sourceDatabase, sourceParts[len(sourceParts)-1])
+	}
+	return nil
+}
+
 func resolvedCDCStateConnectorID(cfg *config.IngestConfig, identity source.ConnectorIdentity, destinationIdentity string) string {
 	if parsed, err := url.Parse(cfg.SourceURI); err == nil {
 		if stateID := parsed.Query().Get("state_id"); stateID != "" {
@@ -2693,13 +2775,46 @@ func validateManagedChangeConfig(cfg *config.IngestConfig) error {
 			}
 		}
 	}
-	if isMySQLCDCSource(cfg.SourceURI) && !cfg.FullRefresh {
-		switch cfg.IncrementalStrategy {
-		case "", config.StrategyMerge, config.StrategyReplace:
-		default:
-			return &config.ValidationError{
-				Field:   "incremental-strategy",
-				Message: fmt.Sprintf("%q is not supported for MySQL CDC; use merge or replace", cfg.IncrementalStrategy),
+	if isMySQLCDCSource(cfg.SourceURI) {
+		if !cfg.FullRefresh {
+			switch cfg.IncrementalStrategy {
+			case "", config.StrategyMerge, config.StrategyReplace:
+			default:
+				return &config.ValidationError{
+					Field:   "incremental-strategy",
+					Message: fmt.Sprintf("%q is not supported for MySQL CDC; use merge or replace", cfg.IncrementalStrategy),
+				}
+			}
+		}
+		if cfg.SourceTable == "" {
+			switch {
+			case len(cfg.SQLExcludeColumns) > 0:
+				return &config.ValidationError{Field: "sql-exclude-columns", Message: "is not supported in multi-table MySQL CDC because exclusions are not applied consistently; select one table or remove the option"}
+			case len(cfg.Mask) > 0:
+				return &config.ValidationError{Field: "mask", Message: "is not supported in multi-table MySQL CDC because masks are not applied consistently; select one table or remove the option"}
+			case strings.TrimSpace(cfg.Columns) != "":
+				return &config.ValidationError{Field: "columns", Message: "is not supported in multi-table MySQL CDC because overrides are not applied consistently; select one table or remove the option"}
+			}
+		}
+		for _, column := range cfg.SQLExcludeColumns {
+			if destination.IsCDCMetaColumn(column) {
+				return &config.ValidationError{Field: "sql-exclude-columns", Message: fmt.Sprintf("cannot exclude reserved CDC metadata column %q", column)}
+			}
+		}
+		masker, err := transformer.NewColumnMasker(cfg.Mask)
+		if err == nil {
+			for _, column := range masker.MaskedColumns() {
+				if destination.IsCDCMetaColumn(column) {
+					return &config.ValidationError{Field: "mask", Message: fmt.Sprintf("cannot mask reserved CDC metadata column %q", column)}
+				}
+			}
+		}
+		overrides, err := schemaevolution.ParseColumnOverrides(cfg.Columns)
+		if err == nil {
+			for _, override := range overrides {
+				if destination.IsCDCMetaColumn(override.Name) || destination.IsCDCMetaColumn(override.RenameTo) {
+					return &config.ValidationError{Field: "columns", Message: "cannot rename or override reserved CDC metadata columns"}
+				}
 			}
 		}
 	}
@@ -2794,7 +2909,7 @@ func validateDestinationManagedCDCState(dest destination.Destination) error {
 	return nil
 }
 
-func validateMySQLCDCMutationFencing(dest destination.Destination) error {
+func validateMySQLCDCMutationFencing(dest destination.Destination, multiTable bool) error {
 	mergeFencer, ok := dest.(destination.CDCConditionalMergeCapable)
 	if !ok || !mergeFencer.SupportsCDCConditionalMerge() {
 		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic target-incarnation fencing for merge is not supported", dest.GetScheme())
@@ -2804,6 +2919,9 @@ func validateMySQLCDCMutationFencing(dest destination.Destination) error {
 	}
 	if _, ok := dest.(destination.ManagedCDCRunLeaser); !ok {
 		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: connector run leases are not supported", dest.GetScheme())
+	}
+	if _, ok := dest.(destination.CDCMultiTableAtomicMerger); multiTable && !ok {
+		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic multi-table merge is not supported", dest.GetScheme())
 	}
 	if _, ok := dest.(destination.CDCLateTargetClaimPreparer); !ok {
 		return fmt.Errorf("destination scheme %q cannot safely run MySQL CDC: atomic target claim and creation are not supported", dest.GetScheme())

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -355,6 +355,96 @@ func TestMySQLCDCRejectsNonMergeIncrementalStrategies(t *testing.T) {
 	}
 }
 
+func TestMySQLCDCRejectsUnsafeMetadataTransforms(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*config.IngestConfig)
+		field string
+	}{
+		{name: "exclude metadata", apply: func(cfg *config.IngestConfig) { cfg.SQLExcludeColumns = []string{"_cdc_lsn"} }, field: "sql-exclude-columns"},
+		{name: "mask metadata", apply: func(cfg *config.IngestConfig) { cfg.Mask = []string{"_cdc_deleted:redact"} }, field: "mask"},
+		{name: "override metadata", apply: func(cfg *config.IngestConfig) { cfg.Columns = "_cdc_lsn:string" }, field: "columns"},
+		{name: "rename to metadata", apply: func(cfg *config.IngestConfig) { cfg.Columns = "_cdc_lsn::source_lsn" }, field: "columns"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.SourceURI = "mysql+cdc://source/app"
+			cfg.SourceTable = "items"
+			tt.apply(cfg)
+			err := validateManagedChangeConfig(cfg)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.field)
+		})
+	}
+}
+
+func TestMySQLCDCMultiTableRejectsBypassedTransforms(t *testing.T) {
+	for _, apply := range []func(*config.IngestConfig){
+		func(cfg *config.IngestConfig) { cfg.SQLExcludeColumns = []string{"secret"} },
+		func(cfg *config.IngestConfig) { cfg.Mask = []string{"secret:redact"} },
+		func(cfg *config.IngestConfig) { cfg.Columns = "secret:string" },
+	} {
+		cfg := config.DefaultConfig()
+		cfg.SourceURI = "mysql+cdc://source/app"
+		apply(cfg)
+		require.ErrorContains(t, validateManagedChangeConfig(cfg), "multi-table MySQL CDC")
+	}
+}
+
+type mysqlIdentitySource struct {
+	source.Source
+	identity string
+	database string
+}
+
+func (s *mysqlIdentitySource) MySQLServerIdentity() string { return s.identity }
+func (s *mysqlIdentitySource) MySQLDatabaseName() string   { return s.database }
+
+type mysqlIdentityDestination struct {
+	mockDestination
+	identity string
+	database string
+	flavor   string
+}
+
+func (d *mysqlIdentityDestination) MySQLServerIdentity() string { return d.identity }
+func (d *mysqlIdentityDestination) MySQLDatabaseName() string   { return d.database }
+func (d *mysqlIdentityDestination) MySQLServerFlavor() string   { return d.flavor }
+
+func TestMySQLCDCRejectsSourceToSameTable(t *testing.T) {
+	src := &mysqlIdentitySource{identity: "mysql:server-a", database: "app"}
+	dest := &mysqlIdentityDestination{mockDestination: mockDestination{scheme: "mysql"}, identity: "mysql:server-a", database: "app"}
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mysql+cdc://source/app"
+	cfg.SourceTable = "items"
+	cfg.DestTable = "items"
+	require.ErrorContains(t, validateMySQLCDCSourceDestination(cfg, src, dest), "same physical table")
+
+	cfg.DestTable = "archive.items"
+	require.NoError(t, validateMySQLCDCSourceDestination(cfg, src, dest))
+
+	cfg.SourceTable = ""
+	cfg.SourceURI = "mysql+cdc://source/app?dest_schema=app"
+	require.ErrorContains(t, validateMySQLCDCSourceDestination(cfg, src, dest), "same server and database")
+}
+
+func TestMySQLCDCDestinationWithoutIdentity(t *testing.T) {
+	src := &mysqlIdentitySource{identity: "mysql:server-a", database: "app"}
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mysql+cdc://source/app"
+	cfg.SourceTable = "items"
+
+	differentFlavor := &mysqlIdentityDestination{mockDestination: mockDestination{scheme: "mariadb"}, database: "app", flavor: "mariadb"}
+	require.NoError(t, validateMySQLCDCSourceDestination(cfg, src, differentFlavor))
+
+	sameFlavor := &mysqlIdentityDestination{mockDestination: mockDestination{scheme: "mysql"}, database: "app", flavor: "mysql"}
+	require.ErrorContains(t, validateMySQLCDCSourceDestination(cfg, src, sameFlavor), "verifiable MySQL server identity")
+
+	unknownFlavor := &mysqlIdentityDestination{mockDestination: mockDestination{scheme: "mysql"}, database: "app"}
+	require.ErrorContains(t, validateMySQLCDCSourceDestination(cfg, src, unknownFlavor), "verifiable MySQL server identity")
+}
+
 func TestValidateCDCRunSerialization(t *testing.T) {
 	required := &serializedCDCRunsDestination{mockDestination: mockDestination{scheme: "unenforced-key-dest"}}
 	leased := &leasedSerializedCDCRunsDestination{
@@ -1248,8 +1338,8 @@ func TestValidateDestinationManagedCDCState(t *testing.T) {
 
 func TestValidateMySQLCDCMutationFencing(t *testing.T) {
 	unsupported := &mockManagedCDCStateDestination{}
-	require.ErrorContains(t, validateMySQLCDCMutationFencing(unsupported), "atomic target-incarnation fencing for merge")
-	require.NoError(t, validateMySQLCDCMutationFencing(&mockMySQLCDCFencedDestination{}))
+	require.ErrorContains(t, validateMySQLCDCMutationFencing(unsupported, false), "atomic target-incarnation fencing for merge")
+	require.NoError(t, validateMySQLCDCMutationFencing(&mockMySQLCDCFencedDestination{}, false))
 }
 
 func TestValidateChangeTrackingDestinationRequiresResumeProvider(t *testing.T) {

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"database/sql"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -87,12 +88,19 @@ type MySQLCDCSource struct {
 	db                *sql.DB
 	uri               string
 	database          string
+	lineageIdentity   string
 	cdcConfig         MySQLCDCConfig
 	connInfo          mysqlCDCConnInfo
 	stateMu           sync.Mutex
 	state             source.CDCStateCommitToken
 	schemaMu          sync.Mutex
 	discoveredSchemas map[string]*schema.TableSchema
+}
+
+type mysqlCDCCheckpoint struct {
+	Position gomysql.Position
+	Identity string
+	GTIDSet  string
 }
 
 type mysqlCDCTableMetadata struct {
@@ -279,10 +287,16 @@ func (s *MySQLCDCSource) Connect(ctx context.Context, rawURI string) error {
 		_ = db.Close()
 		return err
 	}
+	lineageIdentity, err := loadMySQLCDCLineageIdentity(ctx, db, cdcConfig.Flavor)
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
 
 	s.db = db
 	s.uri = rawURI
 	s.database = database
+	s.lineageIdentity = lineageIdentity
 	s.cdcConfig = cdcConfig
 	s.connInfo = connInfo
 	return nil
@@ -295,6 +309,14 @@ func (s *MySQLCDCSource) Close(ctx context.Context) error {
 	return nil
 }
 
+func (s *MySQLCDCSource) MySQLServerIdentity() string {
+	return s.lineageIdentity
+}
+
+func (s *MySQLCDCSource) MySQLDatabaseName() string {
+	return s.database
+}
+
 func (s *MySQLCDCSource) resetCDCState() {
 	s.stateMu.Lock()
 	s.state = source.CDCStateCommitToken{
@@ -303,24 +325,24 @@ func (s *MySQLCDCSource) resetCDCState() {
 	s.stateMu.Unlock()
 }
 
-func (s *MySQLCDCSource) recordMySQLCDCSnapshot(table string, position gomysql.Position) {
-	if table == "" || position.Name == "" {
+func (s *MySQLCDCSource) recordMySQLCDCSnapshot(table string, checkpoint mysqlCDCCheckpoint) {
+	if table == "" || checkpoint.Position.Name == "" {
 		return
 	}
 	s.stateMu.Lock()
 	if s.state.SnapshotPositions == nil {
 		s.state.SnapshotPositions = make(map[string]string)
 	}
-	s.state.SnapshotPositions[table] = formatStoredMySQLPosition(position, 0)
+	s.state.SnapshotPositions[table] = formatStoredMySQLCheckpoint(checkpoint)
 	s.stateMu.Unlock()
 }
 
-func (s *MySQLCDCSource) recordMySQLCDCCheckpoint(position gomysql.Position) {
-	if position.Name == "" {
+func (s *MySQLCDCSource) recordMySQLCDCCheckpoint(checkpoint mysqlCDCCheckpoint) {
+	if checkpoint.Position.Name == "" {
 		return
 	}
 	s.stateMu.Lock()
-	s.state.Position = formatStoredMySQLPosition(position, 0)
+	s.state.Position = formatStoredMySQLCheckpoint(checkpoint)
 	s.stateMu.Unlock()
 }
 
@@ -348,6 +370,9 @@ func (s *MySQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) 
 
 	fullSchema, err := s.getSchema(ctx, req.Name)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateMySQLCDCSourceColumns(fullSchema, req.Name); err != nil {
 		return nil, err
 	}
 	if err := validateMySQLCDCTableSupported(ctx, s.db, s.database, req.Name); err != nil {
@@ -449,6 +474,9 @@ func (s *MySQLCDCSource) loadMySQLCDCTables(ctx context.Context, tableNames []st
 		if err != nil {
 			return nil, fmt.Errorf("failed to get schema for %s: %w", tableName, err)
 		}
+		if err := validateMySQLCDCSourceColumns(fullSchema, tableName); err != nil {
+			return nil, err
+		}
 		if validateSupported {
 			if err := validateMySQLCDCTableSupported(ctx, s.db, s.database, tableName); err != nil {
 				return nil, err
@@ -527,17 +555,17 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 			metaByTable[table.Name] = meta
 
 			storedLSN := strings.TrimSpace(opts.CDCResumeLSNs[table.Name])
-			if resume, ok := parseStoredMySQLPosition(storedLSN); ok {
+			if resume, ok := parseStoredMySQLCheckpoint(storedLSN); ok {
 				canResume, err := s.canResume(ctx, resume)
 				if err != nil {
 					results <- source.RecordBatchResult{Err: err}
 					return
 				}
 				if canResume {
-					startByTable[table.Name] = resume
+					startByTable[table.Name] = resume.Position
 					continue
 				}
-				results <- source.RecordBatchResult{Err: mysqlCDCResumeExpiredError(table.Name, resume)}
+				results <- source.RecordBatchResult{Err: mysqlCDCResumeExpiredError(table.Name, resume.Position)}
 				return
 			} else if storedLSN != "" {
 				results <- source.RecordBatchResult{Err: mysqlCDCResumeInvalidError(table.Name, storedLSN)}
@@ -547,13 +575,13 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 			inventoryValidator := func(validationCtx context.Context, q mysqlCDCPositionQueryer) error {
 				return s.validateMySQLCDCInventory(validationCtx, q, opts.Tables)
 			}
-			snapshotPos, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name, inventoryValidator)
+			snapshotCheckpoint, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name, inventoryValidator)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed for %s: %w", table.Name, err)}
 				return
 			}
-			startByTable[table.Name] = snapshotPos
-			s.recordMySQLCDCSnapshot(table.Name, snapshotPos)
+			startByTable[table.Name] = snapshotCheckpoint.Position
+			s.recordMySQLCDCSnapshot(table.Name, snapshotCheckpoint)
 		}
 
 		if err := s.streamTables(ctx, selected, metaByTable, startByTable, opts.ReadOptions, results, true); err != nil {
@@ -918,7 +946,7 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 		t.source.resetCDCState()
 
 		storedLSN := strings.TrimSpace(opts.CDCResumeLSN)
-		if resume, ok := parseStoredMySQLPosition(storedLSN); ok {
+		if resume, ok := parseStoredMySQLCheckpoint(storedLSN); ok {
 			canResume, err := t.source.canResume(ctx, resume)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
@@ -926,7 +954,7 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 			}
 			if canResume {
 				internalName := t.metadata.Name
-				startByTable := map[string]gomysql.Position{internalName: resume}
+				startByTable := map[string]gomysql.Position{internalName: resume.Position}
 				metaByTable := map[string]mysqlCDCTableMetadata{internalName: t.metadata}
 				tableInfo := source.SourceTableInfo{
 					Name:        internalName,
@@ -938,22 +966,22 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 				}
 				return
 			}
-			results <- source.RecordBatchResult{Err: mysqlCDCResumeExpiredError(t.tableName, resume)}
+			results <- source.RecordBatchResult{Err: mysqlCDCResumeExpiredError(t.tableName, resume.Position)}
 			return
 		} else if storedLSN != "" {
 			results <- source.RecordBatchResult{Err: mysqlCDCResumeInvalidError(t.tableName, storedLSN)}
 			return
 		}
 
-		snapshotPos, err := t.source.snapshotTable(ctx, t.metadata, outputSchema, opts, results, "", nil)
+		snapshotCheckpoint, err := t.source.snapshotTable(ctx, t.metadata, outputSchema, opts, results, "", nil)
 		if err != nil {
 			results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)}
 			return
 		}
-		t.source.recordMySQLCDCSnapshot(t.tableName, snapshotPos)
+		t.source.recordMySQLCDCSnapshot(t.tableName, snapshotCheckpoint)
 
 		internalName := t.metadata.Name
-		startByTable := map[string]gomysql.Position{internalName: snapshotPos}
+		startByTable := map[string]gomysql.Position{internalName: snapshotCheckpoint.Position}
 		metaByTable := map[string]mysqlCDCTableMetadata{internalName: t.metadata}
 		tableInfo := source.SourceTableInfo{
 			Name:        internalName,
@@ -968,7 +996,27 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 	return results, nil
 }
 
-func (s *MySQLCDCSource) canResume(ctx context.Context, pos gomysql.Position) (bool, error) {
+func (s *MySQLCDCSource) canResume(ctx context.Context, checkpoint mysqlCDCCheckpoint) (bool, error) {
+	pos := checkpoint.Position
+	if s.lineageIdentity != "" {
+		if checkpoint.Identity == "" {
+			return false, fmt.Errorf("MySQL CDC resume checkpoint has no source lineage identity; run with --full-refresh to establish a lineage-aware checkpoint")
+		}
+		if checkpoint.Identity != s.lineageIdentity {
+			return false, fmt.Errorf("MySQL CDC resume checkpoint belongs to source server %q, but the connected server is %q; run with --full-refresh instead of reusing file positions across servers", checkpoint.Identity, s.lineageIdentity)
+		}
+		currentGTIDSet, err := s.currentMySQLCDCLineageGTIDSet(ctx)
+		if err != nil {
+			return false, err
+		}
+		contains, err := mysqlCDCGTIDSetContains(s.cdcConfig.Flavor, currentGTIDSet, checkpoint.GTIDSet)
+		if err != nil {
+			return false, err
+		}
+		if !contains {
+			return false, fmt.Errorf("MySQL CDC resume checkpoint GTID history is not contained in the connected server history; the server may have been reset or replaced, so run with --full-refresh")
+		}
+	}
 	rows, err := s.db.QueryContext(ctx, "SHOW BINARY LOGS")
 	if err != nil {
 		rows, err = s.db.QueryContext(ctx, "SHOW MASTER LOGS")
@@ -1001,10 +1049,10 @@ func (s *MySQLCDCSource) canResume(ctx context.Context, pos gomysql.Position) (b
 	return false, nil
 }
 
-func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMetadata, outputSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string, validateInventory func(context.Context, mysqlCDCPositionQueryer) error) (gomysql.Position, error) {
+func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMetadata, outputSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string, validateInventory func(context.Context, mysqlCDCPositionQueryer) error) (mysqlCDCCheckpoint, error) {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return gomysql.Position{}, fmt.Errorf("failed to acquire MySQL connection: %w", err)
+		return mysqlCDCCheckpoint{}, fmt.Errorf("failed to acquire MySQL connection: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
 
@@ -1017,21 +1065,25 @@ func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMe
 
 	snapshotPos, err := beginMySQLConsistentSnapshotWithValidation(ctx, conn, validateInventory)
 	if err != nil {
-		return gomysql.Position{}, err
+		return mysqlCDCCheckpoint{}, err
+	}
+	snapshotCheckpoint, err := s.checkpointForPosition(ctx, conn, snapshotPos)
+	if err != nil {
+		return mysqlCDCCheckpoint{}, err
 	}
 	freshSchema, err := getMySQLSchema(ctx, conn, s.database, meta.Name)
 	if err != nil {
-		return gomysql.Position{}, fmt.Errorf("failed to validate snapshot schema for %s: %w", meta.Name, err)
+		return mysqlCDCCheckpoint{}, fmt.Errorf("failed to validate snapshot schema for %s: %w", meta.Name, err)
 	}
 	if err := validateMySQLCDCSnapshotSchema(removeMySQLCDCColumns(meta.FullSchema), freshSchema, meta.Name); err != nil {
-		return gomysql.Position{}, err
+		return mysqlCDCCheckpoint{}, err
 	}
 
 	sourceColumns := sourceColumnsWithoutMySQLCDC(outputSchema)
 	query := buildMySQLCDCSnapshotQuery(meta, sourceColumns)
 	rows, err := conn.QueryContext(ctx, query)
 	if err != nil {
-		return gomysql.Position{}, fmt.Errorf("failed to query snapshot for %s: %w", meta.Name, err)
+		return mysqlCDCCheckpoint{}, fmt.Errorf("failed to query snapshot for %s: %w", meta.Name, err)
 	}
 	if opts.CDCSnapshotReplace {
 		results <- source.RecordBatchResult{TableName: resultTable, Truncate: true}
@@ -1039,18 +1091,18 @@ func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMe
 
 	if err := rowsToMySQLCDCSnapshotBatches(rows, outputSchema, opts, snapshotPos, results, resultTable); err != nil {
 		_ = rows.Close()
-		return gomysql.Position{}, err
+		return mysqlCDCCheckpoint{}, err
 	}
 	if err := rows.Close(); err != nil {
-		return gomysql.Position{}, err
+		return mysqlCDCCheckpoint{}, err
 	}
 
 	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
-		return gomysql.Position{}, fmt.Errorf("failed to commit MySQL snapshot transaction: %w", err)
+		return mysqlCDCCheckpoint{}, fmt.Errorf("failed to commit MySQL snapshot transaction: %w", err)
 	}
 	committed = true
 
-	return snapshotPos, nil
+	return snapshotCheckpoint, nil
 }
 
 func validateMySQLCDCSnapshotSchema(expected, current *schema.TableSchema, table string) error {
@@ -1135,12 +1187,16 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 	if err != nil {
 		return err
 	}
+	targetCheckpoint, err := s.checkpointForPosition(ctx, s.db, target)
+	if err != nil {
+		return err
+	}
 	start := minMySQLPosition(startByTable)
 	if start.Name == "" {
 		return nil
 	}
 	if start.Compare(target) >= 0 {
-		s.recordMySQLCDCCheckpoint(target)
+		s.recordMySQLCDCCheckpoint(targetCheckpoint)
 		return nil
 	}
 
@@ -1202,7 +1258,9 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		if err := flushMySQLCDCChangeBuffers(buffers, results); err != nil {
 			return err
 		}
-		s.recordMySQLCDCCheckpoint(safeCheckpoint(position))
+		checkpoint := targetCheckpoint
+		checkpoint.Position = safeCheckpoint(position)
+		s.recordMySQLCDCCheckpoint(checkpoint)
 		return nil
 	}
 	appendChanges := func(table string, changes []mysqlCDCChange) error {
@@ -2372,6 +2430,80 @@ type mysqlCDCSnapshotConn interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 }
 
+type mysqlCDCLineageQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+func loadMySQLCDCLineageIdentity(ctx context.Context, q mysqlCDCLineageQueryer, flavor string) (string, error) {
+	if flavor == gomysql.MariaDBFlavor {
+		var identity string
+		if err := q.QueryRowContext(ctx, "SELECT @@GLOBAL.server_uid").Scan(&identity); err != nil {
+			return "", fmt.Errorf("MariaDB CDC requires a server version exposing immutable @@GLOBAL.server_uid for checkpoint lineage validation: %w", err)
+		}
+		if strings.TrimSpace(identity) == "" {
+			return "", fmt.Errorf("MariaDB CDC server_uid is empty; checkpoint lineage cannot be validated safely")
+		}
+		return "mariadb:" + identity, nil
+	}
+
+	var identity, gtidMode string
+	if err := q.QueryRowContext(ctx, "SELECT @@GLOBAL.server_uuid, @@GLOBAL.gtid_mode").Scan(&identity, &gtidMode); err != nil {
+		return "", fmt.Errorf("failed to read MySQL server identity and GTID mode: %w", err)
+	}
+	if strings.TrimSpace(identity) == "" {
+		return "", fmt.Errorf("MySQL server_uuid is empty; checkpoint lineage cannot be validated safely")
+	}
+	if !strings.EqualFold(strings.TrimSpace(gtidMode), "ON") {
+		return "", fmt.Errorf("MySQL CDC requires gtid_mode=ON for lineage-safe checkpoints; current mode is %q", gtidMode)
+	}
+	return "mysql:" + identity, nil
+}
+
+func (s *MySQLCDCSource) currentMySQLCDCLineageGTIDSet(ctx context.Context) (string, error) {
+	return currentMySQLCDCLineageGTIDSet(ctx, s.db, s.cdcConfig.Flavor)
+}
+
+func currentMySQLCDCLineageGTIDSet(ctx context.Context, q mysqlCDCLineageQueryer, flavor string) (string, error) {
+	variable := "@@GLOBAL.gtid_executed"
+	if flavor == gomysql.MariaDBFlavor {
+		// gtid_binlog_state is the full per-(domain, server_id) history;
+		// gtid_binlog_pos only holds the latest GTID per domain, so a
+		// primary switch or server_id change would make containment fail
+		// even though the binlog history is intact.
+		variable = "@@GLOBAL.gtid_binlog_state"
+	}
+	var value sql.NullString
+	if err := q.QueryRowContext(ctx, "SELECT "+variable).Scan(&value); err != nil {
+		return "", fmt.Errorf("failed to read MySQL CDC GTID history: %w", err)
+	}
+	return value.String, nil
+}
+
+func (s *MySQLCDCSource) checkpointForPosition(ctx context.Context, q mysqlCDCLineageQueryer, position gomysql.Position) (mysqlCDCCheckpoint, error) {
+	checkpoint := mysqlCDCCheckpoint{Position: position, Identity: s.lineageIdentity}
+	if s.lineageIdentity == "" {
+		return checkpoint, nil
+	}
+	gtidSet, err := currentMySQLCDCLineageGTIDSet(ctx, q, s.cdcConfig.Flavor)
+	if err != nil {
+		return mysqlCDCCheckpoint{}, err
+	}
+	checkpoint.GTIDSet = gtidSet
+	return checkpoint, nil
+}
+
+func mysqlCDCGTIDSetContains(flavor, current, checkpoint string) (bool, error) {
+	currentSet, err := gomysql.ParseGTIDSet(flavor, strings.TrimSpace(current))
+	if err != nil {
+		return false, fmt.Errorf("failed to parse current MySQL CDC GTID history: %w", err)
+	}
+	checkpointSet, err := gomysql.ParseGTIDSet(flavor, strings.TrimSpace(checkpoint))
+	if err != nil {
+		return false, fmt.Errorf("failed to parse checkpoint MySQL CDC GTID history: %w", err)
+	}
+	return currentSet.Contain(checkpointSet), nil
+}
+
 func currentMySQLBinlogPosition(ctx context.Context, q mysqlCDCPositionQueryer) (gomysql.Position, error) {
 	pos, ok, err := currentMySQLBinlogPositionFromStatement(ctx, q, "SHOW BINARY LOG STATUS")
 	if err == nil && ok {
@@ -2488,6 +2620,18 @@ func addMySQLCDCColumns(tableSchema *schema.TableSchema) *schema.TableSchema {
 	return &copied
 }
 
+func validateMySQLCDCSourceColumns(tableSchema *schema.TableSchema, table string) error {
+	if tableSchema == nil {
+		return nil
+	}
+	for _, column := range tableSchema.Columns {
+		if destination.IsCDCMetaColumn(column.Name) {
+			return fmt.Errorf("MySQL CDC source table %s contains reserved metadata column %q; rename the source column before enabling CDC", table, column.Name)
+		}
+	}
+	return nil
+}
+
 func removeMySQLCDCColumns(tableSchema *schema.TableSchema) *schema.TableSchema {
 	if tableSchema == nil {
 		return nil
@@ -2539,7 +2683,7 @@ func mysqlEventPosition(event *replication.BinlogEvent, current gomysql.Position
 }
 
 var (
-	storedMySQLPositionRegex    = regexp.MustCompile(`^(\d{20}):([^:]+):(\d{20})(?::\d{6,})?$`)
+	storedMySQLPositionRegex    = regexp.MustCompile(`^(\d{20}):([^:]+):(\d{20})(?::\d{6,})?(?::l1:([^:]+):([^:]*))?$`)
 	legacyStoredMySQLPositionRE = regexp.MustCompile(`^([^:]+):(\d{20})(?::\d{6,})?$`)
 )
 
@@ -2547,26 +2691,53 @@ func formatStoredMySQLPosition(pos gomysql.Position, rowSeq int) string {
 	return fmt.Sprintf("%020d:%s:%020d:%020d", mysqlBinlogSequence(pos.Name), pos.Name, pos.Pos, rowSeq)
 }
 
-func parseStoredMySQLPosition(stored string) (gomysql.Position, bool) {
+func formatStoredMySQLCheckpoint(checkpoint mysqlCDCCheckpoint) string {
+	position := formatStoredMySQLPosition(checkpoint.Position, 0)
+	if checkpoint.Identity == "" {
+		return position
+	}
+	encode := base64.RawURLEncoding.EncodeToString
+	return position + ":l1:" + encode([]byte(checkpoint.Identity)) + ":" + encode([]byte(checkpoint.GTIDSet))
+}
+
+func parseStoredMySQLCheckpoint(stored string) (mysqlCDCCheckpoint, bool) {
 	stored = strings.TrimSpace(stored)
 	if stored == "" {
-		return gomysql.Position{}, false
+		return mysqlCDCCheckpoint{}, false
 	}
-	if matches := storedMySQLPositionRegex.FindStringSubmatch(stored); len(matches) == 4 {
+	if matches := storedMySQLPositionRegex.FindStringSubmatch(stored); len(matches) == 6 {
 		pos, err := strconv.ParseUint(matches[3], 10, 32)
 		if err != nil {
-			return gomysql.Position{}, false
+			return mysqlCDCCheckpoint{}, false
 		}
-		return gomysql.Position{Name: matches[2], Pos: uint32(pos)}, true
+		checkpoint := mysqlCDCCheckpoint{Position: gomysql.Position{Name: matches[2], Pos: uint32(pos)}}
+		if matches[4] != "" {
+			identity, err := base64.RawURLEncoding.DecodeString(matches[4])
+			if err != nil {
+				return mysqlCDCCheckpoint{}, false
+			}
+			gtidSet, err := base64.RawURLEncoding.DecodeString(matches[5])
+			if err != nil {
+				return mysqlCDCCheckpoint{}, false
+			}
+			checkpoint.Identity = string(identity)
+			checkpoint.GTIDSet = string(gtidSet)
+		}
+		return checkpoint, true
 	}
 	if matches := legacyStoredMySQLPositionRE.FindStringSubmatch(stored); len(matches) == 3 {
 		pos, err := strconv.ParseUint(matches[2], 10, 32)
 		if err != nil {
-			return gomysql.Position{}, false
+			return mysqlCDCCheckpoint{}, false
 		}
-		return gomysql.Position{Name: matches[1], Pos: uint32(pos)}, true
+		return mysqlCDCCheckpoint{Position: gomysql.Position{Name: matches[1], Pos: uint32(pos)}}, true
 	}
-	return gomysql.Position{}, false
+	return mysqlCDCCheckpoint{}, false
+}
+
+func parseStoredMySQLPosition(stored string) (gomysql.Position, bool) {
+	checkpoint, ok := parseStoredMySQLCheckpoint(stored)
+	return checkpoint.Position, ok
 }
 
 func mysqlBinlogSequence(name string) uint64 {

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -539,6 +539,48 @@ func TestStoredMySQLPositionHelpers(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestStoredMySQLCheckpointCarriesLineage(t *testing.T) {
+	checkpoint := mysqlCDCCheckpoint{
+		Position: gomysql.Position{Name: "mysql-bin.000012", Pos: 345},
+		Identity: "mysql:550e8400-e29b-41d4-a716-446655440000",
+		GTIDSet:  "550e8400-e29b-41d4-a716-446655440000:1-42",
+	}
+	stored := formatStoredMySQLCheckpoint(checkpoint)
+	parsed, ok := parseStoredMySQLCheckpoint(stored)
+	require.True(t, ok)
+	assert.Equal(t, checkpoint, parsed)
+	assert.True(t, strings.HasPrefix(stored, formatStoredMySQLPosition(checkpoint.Position, 0)+":l1:"))
+}
+
+func TestMySQLCDCResumeRejectsMissingAndMismatchedLineage(t *testing.T) {
+	src := &MySQLCDCSource{lineageIdentity: "mysql:current"}
+
+	_, err := src.canResume(t.Context(), mysqlCDCCheckpoint{Position: gomysql.Position{Name: "mysql-bin.000001", Pos: 4}})
+	require.ErrorContains(t, err, "no source lineage identity")
+
+	_, err = src.canResume(t.Context(), mysqlCDCCheckpoint{
+		Position: gomysql.Position{Name: "mysql-bin.000001", Pos: 4},
+		Identity: "mysql:other",
+	})
+	require.ErrorContains(t, err, "connected server is")
+}
+
+func TestMySQLCDCGTIDContainment(t *testing.T) {
+	const uuid = "550e8400-e29b-41d4-a716-446655440000"
+	contains, err := mysqlCDCGTIDSetContains(gomysql.MySQLFlavor, uuid+":1-10", uuid+":1-5")
+	require.NoError(t, err)
+	assert.True(t, contains)
+
+	contains, err = mysqlCDCGTIDSetContains(gomysql.MySQLFlavor, uuid+":1-4", uuid+":1-5")
+	require.NoError(t, err)
+	assert.False(t, contains)
+}
+
+func TestMySQLCDCRejectsReservedSourceColumns(t *testing.T) {
+	err := validateMySQLCDCSourceColumns(&schema.TableSchema{Columns: []schema.Column{{Name: "_CDC_LSN"}}}, "items")
+	require.ErrorContains(t, err, "reserved metadata column")
+}
+
 func TestAddMySQLCDCColumns(t *testing.T) {
 	original := &schema.TableSchema{
 		Name: "users",

--- a/pkg/strategy/cdc_state.go
+++ b/pkg/strategy/cdc_state.go
@@ -1541,7 +1541,7 @@ func compareCDCPositions(left, right string) int {
 	}
 }
 
-var mysqlCDCStatePositionRE = regexp.MustCompile(`^\d{20}:[^:]+:\d{20}:\d{20}$`)
+var mysqlCDCStatePositionRE = regexp.MustCompile(`^\d{20}:[^:]+:\d{20}:\d{20}(?::l1:[A-Za-z0-9_-]+:[A-Za-z0-9_-]*)?$`)
 
 const (
 	cdcStateIncarnationSeparator   = ";incarnation="

--- a/pkg/strategy/keyless_cdc_test.go
+++ b/pkg/strategy/keyless_cdc_test.go
@@ -142,6 +142,31 @@ func TestMergeStrategy_MultiTableCDCUsesOneAtomicDestinationMerge(t *testing.T) 
 	assert.Empty(t, base.mergeCalls)
 }
 
+func TestMergeStrategy_MixedKeyedAndKeylessCDCDoesNotClaimAtomicMerge(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &atomicBatchDestination{fakeDestination: base}
+	keyed := keylessCDCSchema()
+	keyed.PrimaryKeys = []string{"id"}
+	tables := []source.SourceTableInfo{
+		{Name: "users", Schema: keyed, PrimaryKeys: []string{"id"}},
+		{Name: "events", Schema: keylessCDCSchema()},
+	}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         &announcingMultiTableSource{tables: tables, records: records},
+		Destination:    dest,
+		Tables:         tables,
+		TableDestNames: map[string]string{"users": "users", "events": "events"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	assert.Empty(t, dest.atomicCalls)
+	require.Len(t, base.mergeCalls, 1)
+	assert.Equal(t, "users", base.mergeCalls[0].TargetTable)
+}
+
 func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
 	dest := &fakeDestination{}
 	exec := NewStreamingExecutor(StreamingOptions{

--- a/pkg/strategy/keyless_cdc_test.go
+++ b/pkg/strategy/keyless_cdc_test.go
@@ -104,6 +104,44 @@ func TestMergeStrategy_MultiTableMixedKeyedAndKeyless(t *testing.T) {
 	assert.Equal(t, "users", dest.mergeCalls[0].TargetTable)
 }
 
+type atomicBatchDestination struct {
+	*fakeDestination
+	atomicCalls [][]destination.CDCAtomicTableMerge
+}
+
+func (d *atomicBatchDestination) MergeCDCTablesAtomically(_ context.Context, merges []destination.CDCAtomicTableMerge) error {
+	d.atomicCalls = append(d.atomicCalls, append([]destination.CDCAtomicTableMerge(nil), merges...))
+	return nil
+}
+
+func TestMergeStrategy_MultiTableCDCUsesOneAtomicDestinationMerge(t *testing.T) {
+	base := &fakeDestination{}
+	dest := &atomicBatchDestination{fakeDestination: base}
+	keyedCDCSchema := func() *schema.TableSchema {
+		result := keylessCDCSchema()
+		result.PrimaryKeys = []string{"id"}
+		return result
+	}
+	tables := []source.SourceTableInfo{
+		{Name: "users", Schema: keyedCDCSchema(), PrimaryKeys: []string{"id"}},
+		{Name: "orders", Schema: keyedCDCSchema(), PrimaryKeys: []string{"id"}},
+	}
+	records := make(chan source.RecordBatchResult)
+	close(records)
+	job := &MultiTableIngestionJob{
+		Config:         &config.IngestConfig{},
+		Source:         &announcingMultiTableSource{tables: tables, records: records},
+		Destination:    dest,
+		Tables:         tables,
+		TableDestNames: map[string]string{"users": "users", "orders": "orders"},
+	}
+
+	require.NoError(t, (&MergeStrategy{}).ExecuteMultiTable(t.Context(), job))
+	require.Len(t, dest.atomicCalls, 1)
+	require.Len(t, dest.atomicCalls[0], 2)
+	assert.Empty(t, base.mergeCalls)
+}
+
 func TestStreaming_PrepareTableKeylessCDCSkipsStaging(t *testing.T) {
 	dest := &fakeDestination{}
 	exec := NewStreamingExecutor(StreamingOptions{

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -84,7 +84,11 @@ func prepareMergeTables(ctx context.Context, dest destination.Destination, p mer
 // key. A non-empty incrementalKey makes the per-PK dedup keep the row with the
 // highest value of that key (latest wins) instead of an arbitrary one.
 func mergeStagingInto(ctx context.Context, dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey, incrementalPredicate, expectedIncarnation string) error {
-	return dest.MergeTable(ctx, destination.MergeOptions{
+	return dest.MergeTable(ctx, mergeStagingOptions(dest, stagingTable, targetTable, primaryKeys, tableSchema, incrementalKey, incrementalPredicate, expectedIncarnation))
+}
+
+func mergeStagingOptions(dest destination.Destination, stagingTable, targetTable string, primaryKeys []string, tableSchema *schema.TableSchema, incrementalKey, incrementalPredicate, expectedIncarnation string) destination.MergeOptions {
+	return destination.MergeOptions{
 		StagingTable:           stagingTable,
 		TargetTable:            targetTable,
 		PrimaryKeys:            primaryKeys,
@@ -93,7 +97,7 @@ func mergeStagingInto(ctx context.Context, dest destination.Destination, staging
 		IncrementalPredicate:   incrementalPredicate,
 		Schema:                 tableSchema,
 		CDCExpectedIncarnation: expectedIncarnation,
-	})
+	}
 }
 
 func mergeIncrementalKeyForSchema(tableSchema *schema.TableSchema, incrementalKey string) string {
@@ -492,6 +496,51 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	}
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
+	}
+	if atomicMerger, ok := job.Destination.(destination.CDCMultiTableAtomicMerger); ok && anyTableHasCDC {
+		dropStagingTables := func() {
+			if source.ConnectorLeaseLoss(ctx) != nil {
+				return
+			}
+			for _, stagingTable := range stagingTables {
+				if source.ConnectorLeaseLoss(ctx) != nil {
+					break
+				}
+				if dropErr := job.Destination.DropTable(ctx, stagingTable); dropErr != nil {
+					config.Debug("[MERGE] Warning: failed to drop staging table %s: %v", stagingTable, dropErr)
+				}
+			}
+		}
+		merges := make([]destination.CDCAtomicTableMerge, 0, len(stagingTables))
+		for _, tableInfo := range job.Tables {
+			stagingTable, staged := stagingTables[tableInfo.Name]
+			if !staged {
+				continue
+			}
+			expectedIncarnation := ""
+			if job.CDCStateManager != nil {
+				expectedIncarnation, err = job.CDCStateManager.BoundDestinationIncarnation(tableInfo.Name)
+				if err != nil {
+					dropStagingTables()
+					return err
+				}
+			}
+			merges = append(merges, destination.CDCAtomicTableMerge{
+				Options:  mergeStagingOptions(job.Destination, stagingTable, job.GetDestTableName(tableInfo.Name), tableInfo.PrimaryKeys, tableInfo.Schema, "", "", expectedIncarnation),
+				Truncate: writeResult.TruncatedTables[tableInfo.Name],
+			})
+		}
+		if err := source.ConnectorLeaseLoss(ctx); err != nil {
+			return err
+		}
+		if err := atomicMerger.MergeCDCTablesAtomically(ctx, merges); err != nil {
+			dropStagingTables()
+			return fmt.Errorf("failed to atomically merge multi-table CDC batch: %w", err)
+		}
+		if !job.Config.KeepStaging {
+			dropStagingTables()
+		}
+		return source.ConnectorLeaseLoss(ctx)
 	}
 
 	mergeErrChan := make(chan error, len(job.Tables))

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -497,7 +497,7 @@ func (s *MergeStrategy) ExecuteMultiTable(ctx context.Context, job *MultiTableIn
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		return err
 	}
-	if atomicMerger, ok := job.Destination.(destination.CDCMultiTableAtomicMerger); ok && anyTableHasCDC {
+	if atomicMerger, ok := job.Destination.(destination.CDCMultiTableAtomicMerger); ok && anyTableHasCDC && len(stagingTables) == len(job.Tables) {
 		dropStagingTables := func() {
 			if source.ConnectorLeaseLoss(ctx) != nil {
 				return

--- a/tests/integration/mysql_cdc_regression_stress_test.go
+++ b/tests/integration/mysql_cdc_regression_stress_test.go
@@ -33,6 +33,8 @@ func newMySQLCDCRegressionHarness(t *testing.T, ctx context.Context, sourceOptio
 	sourceCommand := []string{
 		"--server-id=21777",
 		"--log-bin=mysql-bin",
+		"--gtid-mode=ON",
+		"--enforce-gtid-consistency=ON",
 		"--binlog-format=ROW",
 		"--binlog-row-image=FULL",
 		"--max-connections=100",

--- a/tests/integration/mysql_cdc_stress_test.go
+++ b/tests/integration/mysql_cdc_stress_test.go
@@ -539,6 +539,8 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 	sourceContainer, sourceURI, sourceDSN := mysqlStressContainer(t, ctx, []string{
 		"--server-id=21777",
 		"--log-bin=mysql-bin",
+		"--gtid-mode=ON",
+		"--enforce-gtid-consistency=ON",
 		"--binlog-format=ROW",
 		"--binlog-row-image=FULL",
 		// Non-UTC source: snapshot and binlog paths must agree on instants.

--- a/tests/integration/mysql_cdc_test.go
+++ b/tests/integration/mysql_cdc_test.go
@@ -32,6 +32,8 @@ func setupMySQLCDCContainer(t *testing.T, ctx context.Context) (testcontainers.C
 			req.Cmd = []string{
 				"--server-id=17777",
 				"--log-bin=mysql-bin",
+				"--gtid-mode=ON",
+				"--enforce-gtid-consistency=ON",
 				"--binlog-format=ROW",
 				"--binlog-row-image=FULL",
 				// Non-UTC server time zone: snapshot and binlog rows must still


### PR DESCRIPTION
## What
Harden MySQL CDC checkpoints and writes against lineage changes, feedback loops, metadata corruption, and partial multi-table commits.

## Changes
- Add server identity and GTID history to checkpoints, reject unsafe legacy resumes, and require lineage-capable MySQL/MariaDB servers.
- Reject source-to-self targets and unsafe CDC metadata transformations.
- Merge multi-table CDC staging tables in one destination transaction.

## How to test
1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback
- **Risk:** Medium — legacy checkpoints require one full refresh and MySQL CDC now requires GTID mode.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
