### PR TITLE
Make truncate insert finalization transactional

### DIFF
--- a/docs/getting-started/incremental-loading.md
+++ b/docs/getting-started/incremental-loading.md
@@ -45,7 +45,7 @@ The interval still defines the complete replacement data set: destination rows o
 ## Truncate+Insert
 Truncate+Insert empties the existing destination table in place and then inserts the rows read from the source. Unlike `replace`, it keeps the same destination table object, which can help preserve dependent views, grants, and foreign keys on destinations that support truncation.
 
-This strategy is only available for destinations that support truncating a table in place. It is not atomic on every destination: readers may see an empty table between the truncate and the insert, and a failed insert can leave the table empty.
+This strategy is only available for destinations that support truncating a table in place. PostgreSQL, DuckDB, SQLite, SQL Server, Fabric Warehouse, Synapse dedicated SQL pool, and Databricks finalize the staged load atomically, so an insert failure rolls the target back to its previous rows. Databricks uses an atomic `DELETE` plus `INSERT` block because its multi-statement transactions support DML but not `TRUNCATE` DDL. On other destinations, readers may see an empty table between the truncate and insert, and a failed insert can leave the table empty.
 
 ## Append
 Append writes every row returned by the source to the destination table. By default, it appends all rows read from the source. `incremental_key` is only used for source-side filtering when the source supports it, usually together with `--interval-start` and `--interval-end`; append does not look at the destination table to find the latest value.

--- a/docs/supported-sources/databricks.md
+++ b/docs/supported-sources/databricks.md
@@ -47,4 +47,4 @@ The same URI structure can be used both for sources and destinations. You can re
 
 When using Databricks as a destination, ingestr supports `replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`.
 
-`delete+insert` is executed as a Databricks `BEGIN ATOMIC ... END` compound statement so the delete and insert run together. `scd2` is not supported for Databricks destinations. ingestr does not expose a separate destination transaction API for Databricks; transaction requests fail instead of returning a no-op transaction wrapper.
+`delete+insert` and the final target update for `truncate+insert` are executed as Databricks `BEGIN ATOMIC ... END` compound statements so the delete and insert run together. These transactional loads require transaction-enabled Unity Catalog managed tables and supported Databricks compute. `scd2` is not supported for Databricks destinations. ingestr does not expose a separate destination transaction API for Databricks; transaction requests fail instead of returning a no-op transaction wrapper.

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -561,11 +561,13 @@ func (d *DatabricksDestination) buildTruncateInsertFromStagingSQL(opts destinati
 		if opts.IncrementalKey != "" {
 			orderBy = quoteIdentifier(opts.IncrementalKey)
 		}
-		selectClause = destination.DedupStagingSelect(
+		rowNumberAlias := quoteIdentifier(destination.UniqueInternalColumnName(opts.Columns, "__bruin_dedup_rn"))
+		selectClause = destination.DedupStagingSelectWithRowNumberAlias(
 			columnList,
 			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
 			stagingTable,
 			orderBy,
+			rowNumberAlias,
 		)
 	}
 

--- a/pkg/destination/databricks/databricks.go
+++ b/pkg/destination/databricks/databricks.go
@@ -530,6 +530,51 @@ func (d *DatabricksDestination) InsertFromStaging(ctx context.Context, opts dest
 	return nil
 }
 
+func (d *DatabricksDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	deleteSQL, insertSQL, atomicSQL, err := d.buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+	config.Debug("[DATABRICKS] Executing transactional target clear: %s", deleteSQL)
+	config.Debug("[DATABRICKS] Executing transactional insert: %s", insertSQL)
+	if err := d.executeStatement(ctx, atomicSQL); err != nil {
+		config.LogFailedQuery(atomicSQL, err)
+		return fmt.Errorf("failed to execute atomic truncate+insert load: %w", err)
+	}
+	return nil
+}
+
+func (d *DatabricksDestination) buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, string, error) {
+	_, stagingName := d.parseTableName(opts.StagingTable)
+	targetSchema, targetName := d.parseTableName(opts.TargetTable)
+	columns := quoteColumns(destination.DestinationColumns(opts.Columns))
+	if len(columns) == 0 {
+		return "", "", "", errors.New("truncate+insert from staging requires at least one column")
+	}
+
+	targetTable := d.quoteFullTable(targetSchema, targetName)
+	stagingTable := d.quoteFullTable(stagingSchema, stagingName)
+	columnList := strings.Join(columns, ", ")
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", columnList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 && !opts.StagingPrimaryKeysUnique {
+		orderBy := ""
+		if opts.IncrementalKey != "" {
+			orderBy = quoteIdentifier(opts.IncrementalKey)
+		}
+		selectClause = destination.DedupStagingSelect(
+			columnList,
+			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+			stagingTable,
+			orderBy,
+		)
+	}
+
+	deleteSQL := fmt.Sprintf("DELETE FROM %s", targetTable)
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetTable, columnList, selectClause)
+	atomicSQL := fmt.Sprintf("BEGIN ATOMIC\n  %s;\n  %s;\nEND;", deleteSQL, insertSQL)
+	return deleteSQL, insertSQL, atomicSQL, nil
+}
+
 func (d *DatabricksDestination) Exec(ctx context.Context, sql string, args ...interface{}) error {
 	if len(args) > 0 {
 		for i, arg := range args {

--- a/pkg/destination/databricks/databricks_test.go
+++ b/pkg/destination/databricks/databricks_test.go
@@ -65,6 +65,36 @@ func TestBuildDeleteInsertSQLUsesAtomicBlock(t *testing.T) {
 	}
 }
 
+func TestBuildTruncateInsertFromStagingSQLUsesAtomicDMLBlock(t *testing.T) {
+	t.Parallel()
+	dest := &DatabricksDestination{catalog: "main"}
+	deleteSQL, insertSQL, atomicSQL, err := dest.buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{
+		StagingTable:   "scratch.orders_ti",
+		TargetTable:    "analytics.orders",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "name", "updated_at"},
+		IncrementalKey: "updated_at",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleteSQL != "DELETE FROM `main`.`analytics`.`orders`" {
+		t.Fatalf("deleteSQL = %q", deleteSQL)
+	}
+	for _, want := range []string{
+		"INSERT INTO `main`.`analytics`.`orders` (`id`, `name`, `updated_at`)",
+		"ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `updated_at` DESC)",
+		"FROM `main`.`ingestr_staging`.`orders_ti`",
+	} {
+		if !strings.Contains(insertSQL, want) {
+			t.Fatalf("insertSQL missing %q:\n%s", want, insertSQL)
+		}
+	}
+	if want := "BEGIN ATOMIC\n  " + deleteSQL + ";\n  " + insertSQL + ";\nEND;"; atomicSQL != want {
+		t.Fatalf("atomicSQL = %q, want %q", atomicSQL, want)
+	}
+}
+
 func TestBeginTransactionUnsupported(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/destination/dedup.go
+++ b/pkg/destination/dedup.go
@@ -1,6 +1,9 @@
 package destination
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // DedupStagingSelect builds a SELECT over the staging table that keeps a single
 // row per primary key. When quotedOrderByCol is non-empty, ROW_NUMBER orders by
@@ -10,6 +13,18 @@ import "fmt"
 // comma-joined lists, and stagingExpr is the quoted staging table reference.
 // When there are no primary keys it returns a plain SELECT (no dedup).
 func DedupStagingSelect(quotedColumns, quotedPrimaryKeys, stagingExpr, quotedOrderByCol string) string {
+	return DedupStagingSelectWithRowNumberAlias(
+		quotedColumns,
+		quotedPrimaryKeys,
+		stagingExpr,
+		quotedOrderByCol,
+		"__bruin_dedup_rn",
+	)
+}
+
+// DedupStagingSelectWithRowNumberAlias is DedupStagingSelect with a
+// caller-selected, already-quoted ROW_NUMBER alias.
+func DedupStagingSelectWithRowNumberAlias(quotedColumns, quotedPrimaryKeys, stagingExpr, quotedOrderByCol, quotedRowNumberAlias string) string {
 	if quotedPrimaryKeys == "" {
 		return fmt.Sprintf("SELECT %s FROM %s", quotedColumns, stagingExpr)
 	}
@@ -20,7 +35,25 @@ func DedupStagingSelect(quotedColumns, quotedPrimaryKeys, stagingExpr, quotedOrd
 	}
 
 	return fmt.Sprintf(
-		"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS __bruin_dedup_rn FROM %s) AS _numbered WHERE __bruin_dedup_rn = 1",
-		quotedColumns, quotedColumns, quotedPrimaryKeys, orderBy, stagingExpr,
+		"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS %s FROM %s) AS _numbered WHERE %s = 1",
+		quotedColumns, quotedColumns, quotedPrimaryKeys, orderBy, quotedRowNumberAlias, stagingExpr, quotedRowNumberAlias,
 	)
+}
+
+// UniqueInternalColumnName returns a case-insensitively unique helper column
+// name for a staging query.
+func UniqueInternalColumnName(columns []string, base string) string {
+	used := make(map[string]struct{}, len(columns)+1)
+	for _, column := range columns {
+		used[strings.ToLower(column)] = struct{}{}
+	}
+	for suffix := 1; ; suffix++ {
+		candidate := base
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s_%d", base, suffix)
+		}
+		if _, exists := used[strings.ToLower(candidate)]; !exists {
+			return candidate
+		}
+	}
 }

--- a/pkg/destination/dedup_test.go
+++ b/pkg/destination/dedup_test.go
@@ -1,6 +1,9 @@
 package destination
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestDedupStagingSelect(t *testing.T) {
 	cols := `"id", "name", "ts"`
@@ -36,4 +39,16 @@ func TestDedupStagingSelect(t *testing.T) {
 			t.Fatalf("got %q, want %q", got, want)
 		}
 	})
+}
+
+func TestDedupStagingSelectWithCollisionSafeAlias(t *testing.T) {
+	alias := UniqueInternalColumnName([]string{"id", "__BRUIN_DEDUP_RN", "__bruin_dedup_rn_2"}, "__bruin_dedup_rn")
+	if alias != "__bruin_dedup_rn_3" {
+		t.Fatalf("alias = %q, want __bruin_dedup_rn_3", alias)
+	}
+	quotedAlias := `"` + alias + `"`
+	got := DedupStagingSelectWithRowNumberAlias(`"id", "__BRUIN_DEDUP_RN"`, `"id"`, `"staging"`, "", quotedAlias)
+	if !strings.Contains(got, `AS "__bruin_dedup_rn_3"`) || !strings.Contains(got, `WHERE "__bruin_dedup_rn_3" = 1`) {
+		t.Fatalf("dedup SQL does not use collision-safe alias: %s", got)
+	}
 }

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -1457,6 +1457,67 @@ func (d *DuckDBDestination) InsertFromStaging(ctx context.Context, opts destinat
 	return nil
 }
 
+func (d *DuckDBDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.exec(ctx, "BEGIN"); err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = d.exec(ctx, "ROLLBACK")
+		}
+	}()
+
+	if err := d.exec(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate target: %w", err)
+	}
+	if err := d.exec(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+	if err := d.exec(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
+	columns := quoteColumns(destination.DestinationColumns(opts.Columns))
+	if len(columns) == 0 {
+		return "", "", errors.New("truncate+insert from staging requires at least one column")
+	}
+
+	columnList := strings.Join(columns, ", ")
+	stagingTable := destination.QuoteTableName(opts.StagingTable)
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", columnList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 && !opts.StagingPrimaryKeysUnique {
+		orderBy := ""
+		if opts.IncrementalKey != "" {
+			orderBy = quoteIdentifier(opts.IncrementalKey)
+		}
+		selectClause = destination.DedupStagingSelect(
+			columnList,
+			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+			stagingTable,
+			orderBy,
+		)
+	}
+
+	targetTable := destination.QuoteTableName(opts.TargetTable)
+	return fmt.Sprintf("TRUNCATE TABLE %s", targetTable),
+		fmt.Sprintf("INSERT INTO %s (%s) %s", targetTable, columnList, selectClause),
+		nil
+}
+
 func (d *DuckDBDestination) TruncateCDCTableIfIncarnation(ctx context.Context, table, expectedIncarnation string) error {
 	if expectedIncarnation == "" {
 		return fmt.Errorf("cannot conditionally truncate %s without a destination incarnation", table)

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -1471,7 +1471,9 @@ func (d *DuckDBDestination) TruncateInsertFromStaging(ctx context.Context, opts 
 	committed := false
 	defer func() {
 		if !committed {
-			_ = d.exec(ctx, "ROLLBACK")
+			rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cancel()
+			_ = d.exec(rollbackCtx, "ROLLBACK")
 		}
 	}()
 
@@ -1504,11 +1506,13 @@ func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagin
 		if opts.IncrementalKey != "" {
 			orderBy = quoteIdentifier(opts.IncrementalKey)
 		}
-		selectClause = destination.DedupStagingSelect(
+		rowNumberAlias := quoteIdentifier(destination.UniqueInternalColumnName(opts.Columns, "__bruin_dedup_rn"))
+		selectClause = destination.DedupStagingSelectWithRowNumberAlias(
 			columnList,
 			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
 			stagingTable,
 			orderBy,
+			rowNumberAlias,
 		)
 	}
 

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -68,6 +68,54 @@ func TestSchemes(t *testing.T) {
 	}
 }
 
+func TestTruncateInsertFromStagingIsAtomic(t *testing.T) {
+	ctx := t.Context()
+	dest, path := connectTestDuckDB(t, ctx)
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE target_events (id BIGINT PRIMARY KEY, value VARCHAR NOT NULL)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO target_events VALUES (1, 'old')`))
+	require.NoError(t, dest.Exec(ctx, `CREATE TABLE staging_events (id BIGINT, value VARCHAR)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO staging_events VALUES (2, NULL)`))
+
+	opts := destination.TruncateInsertFromStagingOptions{
+		StagingTable:             "staging_events",
+		TargetTable:              "target_events",
+		PrimaryKeys:              []string{"id"},
+		StagingPrimaryKeysUnique: true,
+		Columns:                  []string{"id", "value"},
+	}
+	require.Error(t, dest.TruncateInsertFromStaging(ctx, opts))
+
+	db := openDuckDB(t, ctx, path)
+	var id int64
+	var value string
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT id, value FROM target_events`).Scan(&id, &value))
+	require.Equal(t, int64(1), id)
+	require.Equal(t, "old", value)
+
+	require.NoError(t, dest.Exec(ctx, `DELETE FROM staging_events`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO staging_events VALUES (2, 'new')`))
+	require.NoError(t, dest.TruncateInsertFromStaging(ctx, opts))
+	require.NoError(t, db.Close())
+	require.NoError(t, dest.Close(ctx))
+	db = openDuckDB(t, ctx, path)
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT id, value FROM target_events`).Scan(&id, &value))
+	require.Equal(t, int64(2), id)
+	require.Equal(t, "new", value)
+}
+
+func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T) {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{
+		StagingTable:   "stage.events",
+		TargetTable:    "main.events",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "updated_at", "value"},
+		IncrementalKey: "updated_at",
+	})
+	require.NoError(t, err)
+	require.Equal(t, `TRUNCATE TABLE "main"."events"`, truncateSQL)
+	require.Contains(t, insertSQL, `ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "updated_at" DESC)`)
+}
+
 func TestWriteCancellationReleasesQueuedRecords(t *testing.T) {
 	t.Setenv("INGESTR_DUCKDB_CHECKPOINT_ROWS", "-1")
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -264,6 +264,60 @@ func (d *FabricDestination) InsertFromStaging(ctx context.Context, opts destinat
 	return nil
 }
 
+func (d *FabricDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate target: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
+	columns := quoteColumns(destination.DestinationColumns(opts.Columns))
+	if len(columns) == 0 {
+		return "", "", errors.New("truncate+insert from staging requires at least one column")
+	}
+
+	columnList := strings.Join(columns, ", ")
+	stagingTable := quoteTable(opts.StagingTable)
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", columnList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 && !opts.StagingPrimaryKeysUnique {
+		orderBy := ""
+		if opts.IncrementalKey != "" {
+			orderBy = quoteColumn(opts.IncrementalKey)
+		}
+		selectClause = destination.DedupStagingSelect(
+			columnList,
+			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+			stagingTable,
+			orderBy,
+		)
+	}
+
+	targetTable := quoteTable(opts.TargetTable)
+	return fmt.Sprintf("TRUNCATE TABLE %s", targetTable),
+		fmt.Sprintf("INSERT INTO %s (%s) %s", targetTable, columnList, selectClause),
+		nil
+}
+
 func (d *FabricDestination) DropTable(ctx context.Context, table string) error {
 	dropSQL := fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s",
 		escapeTableName(table), quoteTable(table))

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -276,6 +276,8 @@ func (d *FabricDestination) TruncateInsertFromStaging(ctx context.Context, opts 
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	// Fabric Warehouse explicitly supports TRUNCATE TABLE in ACID transactions.
+	// https://learn.microsoft.com/fabric/data-warehouse/transactions
 	if _, err := tx.ExecContext(ctx, truncateSQL); err != nil {
 		config.LogFailedQuery(truncateSQL, err)
 		return fmt.Errorf("failed to truncate target: %w", err)
@@ -304,11 +306,13 @@ func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagin
 		if opts.IncrementalKey != "" {
 			orderBy = quoteColumn(opts.IncrementalKey)
 		}
-		selectClause = destination.DedupStagingSelect(
+		rowNumberAlias := quoteColumn(destination.UniqueInternalColumnName(opts.Columns, "__bruin_dedup_rn"))
+		selectClause = destination.DedupStagingSelectWithRowNumberAlias(
 			columnList,
 			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
 			stagingTable,
 			orderBy,
+			rowNumberAlias,
 		)
 	}
 

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -73,7 +73,7 @@ func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T
 		StagingTable:   "stage.events",
 		TargetTable:    "dbo.events",
 		PrimaryKeys:    []string{"id"},
-		Columns:        []string{"id", "updated_at", "value"},
+		Columns:        []string{"id", "updated_at", "value", "__BRUIN_DEDUP_RN"},
 		IncrementalKey: "updated_at",
 	})
 	if err != nil {
@@ -84,6 +84,9 @@ func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T
 	}
 	if !strings.Contains(insertSQL, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY [updated_at] DESC)") {
 		t.Fatalf("insertSQL does not deduplicate staging rows:\n%s", insertSQL)
+	}
+	if !strings.Contains(insertSQL, "AS [__bruin_dedup_rn_2]") || !strings.Contains(insertSQL, "WHERE [__bruin_dedup_rn_2] = 1") {
+		t.Fatalf("insertSQL does not avoid the user column alias:\n%s", insertSQL)
 	}
 }
 

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -31,6 +32,58 @@ func TestBuildMergeSQLWithIncrementalPredicate(t *testing.T) {
 
 	if !strings.Contains(sql, "ON target.[id] = source.[id] AND (target.[event_date] >= DATEADD(day, -7, CAST(GETDATE() AS date)))") {
 		t.Fatalf("merge SQL missing incremental predicate: %s", sql)
+	}
+}
+
+func TestTruncateInsertFromStagingRollsBackInsertFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	dest := &FabricDestination{db: db}
+	opts := destination.TruncateInsertFromStagingOptions{
+		StagingTable:             "stage.events",
+		TargetTable:              "dbo.events",
+		PrimaryKeys:              []string{"id"},
+		StagingPrimaryKeysUnique: true,
+		Columns:                  []string{"id", "value"},
+	}
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(truncateSQL)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(insertSQL)).WillReturnError(errors.New("insert failed"))
+	mock.ExpectRollback()
+
+	err = dest.TruncateInsertFromStaging(t.Context(), opts)
+	if err == nil || !strings.Contains(err.Error(), "failed to insert from staging") {
+		t.Fatalf("TruncateInsertFromStaging() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T) {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{
+		StagingTable:   "stage.events",
+		TargetTable:    "dbo.events",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "updated_at", "value"},
+		IncrementalKey: "updated_at",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncateSQL != "TRUNCATE TABLE [dbo].[events]" {
+		t.Fatalf("truncateSQL = %q", truncateSQL)
+	}
+	if !strings.Contains(insertSQL, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY [updated_at] DESC)") {
+		t.Fatalf("insertSQL does not deduplicate staging rows:\n%s", insertSQL)
 	}
 }
 

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -168,6 +168,16 @@ var (
 )
 
 var (
+	_ destination.AtomicTruncateInsertStagingWriter = (*databricks.DatabricksDestination)(nil)
+	_ destination.AtomicTruncateInsertStagingWriter = (*duckdb.DuckDBDestination)(nil)
+	_ destination.AtomicTruncateInsertStagingWriter = (*fabric.FabricDestination)(nil)
+	_ destination.AtomicTruncateInsertStagingWriter = (*mssql.MSSQLDestination)(nil)
+	_ destination.AtomicTruncateInsertStagingWriter = (*postgres.PostgresDestination)(nil)
+	_ destination.AtomicTruncateInsertStagingWriter = (*sqlite.SQLiteDestination)(nil)
+	_ destination.AtomicTruncateInsertStagingWriter = (*synapse.SynapseDestination)(nil)
+)
+
+var (
 	_ destination.Destination = (*athena.AthenaDestination)(nil)
 	_ destination.Destination = (*bigquery.BigQueryDestination)(nil)
 	_ destination.Destination = (*cassandra.CassandraDestination)(nil)

--- a/pkg/destination/mssql/mssql.go
+++ b/pkg/destination/mssql/mssql.go
@@ -364,6 +364,47 @@ func (d *MSSQLDestination) InsertFromStaging(ctx context.Context, opts destinati
 	return nil
 }
 
+func (d *MSSQLDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate target: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
+	columns := destination.DestinationColumns(opts.Columns)
+	if len(columns) == 0 {
+		return "", "", errors.New("truncate+insert from staging requires at least one column")
+	}
+
+	var insertSQL string
+	if len(opts.PrimaryKeys) > 0 && !opts.StagingPrimaryKeysUnique {
+		insertSQL = buildInsertDedupSQL(opts.TargetTable, opts.StagingTable, opts.PrimaryKeys, columns, opts.IncrementalKey)
+	} else {
+		insertSQL = buildInsertDirectSQL(opts.TargetTable, opts.StagingTable, columns)
+	}
+	return fmt.Sprintf("TRUNCATE TABLE %s", quoteTable(opts.TargetTable)), insertSQL, nil
+}
+
 func (d *MSSQLDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
 	return d.WriteParallel(ctx, records, opts)
 }

--- a/pkg/destination/mssql/mssql_test.go
+++ b/pkg/destination/mssql/mssql_test.go
@@ -95,6 +95,58 @@ func TestValidateManagedCDCTargetChecksCrossDatabaseCompatibility(t *testing.T) 
 	}
 }
 
+func TestTruncateInsertFromStagingRollsBackInsertFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	dest := &MSSQLDestination{db: db}
+	opts := destination.TruncateInsertFromStagingOptions{
+		StagingTable:             "stage.events",
+		TargetTable:              "dbo.events",
+		PrimaryKeys:              []string{"id"},
+		StagingPrimaryKeysUnique: true,
+		Columns:                  []string{"id", "value"},
+	}
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(truncateSQL)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(insertSQL)).WillReturnError(errors.New("insert failed"))
+	mock.ExpectRollback()
+
+	err = dest.TruncateInsertFromStaging(t.Context(), opts)
+	if err == nil || !strings.Contains(err.Error(), "failed to insert from staging") {
+		t.Fatalf("TruncateInsertFromStaging() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T) {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{
+		StagingTable:   "stage.events",
+		TargetTable:    "dbo.events",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "updated_at", "value"},
+		IncrementalKey: "updated_at",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncateSQL != "TRUNCATE TABLE [dbo].[events]" {
+		t.Fatalf("truncateSQL = %q", truncateSQL)
+	}
+	if !strings.Contains(insertSQL, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY [updated_at] DESC)") {
+		t.Fatalf("insertSQL does not deduplicate staging rows:\n%s", insertSQL)
+	}
+}
+
 func TestCanonicalCDCTargetUsesConnectedDefaultSchema(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -921,11 +921,13 @@ func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagin
 		if opts.IncrementalKey != "" {
 			orderBy = destination.QuoteIdentifier(opts.IncrementalKey)
 		}
-		selectClause = destination.DedupStagingSelect(
+		rowNumberAlias := destination.QuoteIdentifier(destination.UniqueInternalColumnName(opts.Columns, "__bruin_dedup_rn"))
+		selectClause = destination.DedupStagingSelectWithRowNumberAlias(
 			columnList,
 			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
 			stagingTable,
 			orderBy,
+			rowNumberAlias,
 		)
 	}
 

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -881,6 +881,60 @@ func (d *SQLiteDestination) InsertFromStaging(ctx context.Context, opts destinat
 	return nil
 }
 
+func (d *SQLiteDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	deleteSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, deleteSQL); err != nil {
+		config.LogFailedQuery(deleteSQL, err)
+		return fmt.Errorf("failed to clear target: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
+	columns := quoteColumns(destination.DestinationColumns(opts.Columns))
+	if len(columns) == 0 {
+		return "", "", errors.New("truncate+insert from staging requires at least one column")
+	}
+
+	columnList := strings.Join(columns, ", ")
+	stagingTable := destination.QuoteTableName(opts.StagingTable)
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", columnList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 && !opts.StagingPrimaryKeysUnique {
+		orderBy := ""
+		if opts.IncrementalKey != "" {
+			orderBy = destination.QuoteIdentifier(opts.IncrementalKey)
+		}
+		selectClause = destination.DedupStagingSelect(
+			columnList,
+			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+			stagingTable,
+			orderBy,
+		)
+	}
+
+	targetTable := destination.QuoteTableName(opts.TargetTable)
+	return fmt.Sprintf("DELETE FROM %s", targetTable),
+		fmt.Sprintf("INSERT INTO %s (%s) %s", targetTable, columnList, selectClause),
+		nil
+}
+
 // SupportsReplaceStrategy returns true as SQLite supports the replace strategy.
 func (d *SQLiteDestination) SupportsReplaceStrategy() bool { return true }
 

--- a/pkg/destination/sqlite/sqlite_test.go
+++ b/pkg/destination/sqlite/sqlite_test.go
@@ -16,7 +16,54 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/bruin-data/ingestr/pkg/transformer"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTruncateInsertFromStagingIsAtomic(t *testing.T) {
+	d := NewSQLiteDestination()
+	path := filepath.Join(t.TempDir(), "truncate-insert.db")
+	require.NoError(t, d.Connect(t.Context(), "sqlite://"+path))
+	t.Cleanup(func() { _ = d.Close(t.Context()) })
+	require.NoError(t, d.Exec(t.Context(), `CREATE TABLE target_events (id INTEGER PRIMARY KEY, value TEXT NOT NULL)`))
+	require.NoError(t, d.Exec(t.Context(), `INSERT INTO target_events VALUES (1, 'old')`))
+	require.NoError(t, d.Exec(t.Context(), `CREATE TABLE staging_events (id INTEGER, value TEXT)`))
+	require.NoError(t, d.Exec(t.Context(), `INSERT INTO staging_events VALUES (2, NULL)`))
+
+	opts := destination.TruncateInsertFromStagingOptions{
+		StagingTable:             "staging_events",
+		TargetTable:              "target_events",
+		PrimaryKeys:              []string{"id"},
+		StagingPrimaryKeysUnique: true,
+		Columns:                  []string{"id", "value"},
+	}
+	require.Error(t, d.TruncateInsertFromStaging(t.Context(), opts))
+
+	var id int64
+	var value string
+	require.NoError(t, d.db.QueryRowContext(t.Context(), `SELECT id, value FROM target_events`).Scan(&id, &value))
+	require.Equal(t, int64(1), id)
+	require.Equal(t, "old", value)
+
+	require.NoError(t, d.Exec(t.Context(), `DELETE FROM staging_events`))
+	require.NoError(t, d.Exec(t.Context(), `INSERT INTO staging_events VALUES (2, 'new')`))
+	require.NoError(t, d.TruncateInsertFromStaging(t.Context(), opts))
+	require.NoError(t, d.db.QueryRowContext(t.Context(), `SELECT id, value FROM target_events`).Scan(&id, &value))
+	require.Equal(t, int64(2), id)
+	require.Equal(t, "new", value)
+}
+
+func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T) {
+	deleteSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{
+		StagingTable:   "stage.events",
+		TargetTable:    "main.events",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "updated_at", "value"},
+		IncrementalKey: "updated_at",
+	})
+	require.NoError(t, err)
+	require.Equal(t, `DELETE FROM "main"."events"`, deleteSQL)
+	require.Contains(t, insertSQL, `ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "updated_at" DESC)`)
+}
 
 func TestPrepareTableRequiresMatchingCDCMergePrimaryKey(t *testing.T) {
 	d := NewSQLiteDestination()

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -213,6 +213,9 @@ func (d *SynapseDestination) TruncateInsertFromStaging(ctx context.Context, opts
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	// Dedicated SQL pools allow minimally logged TRUNCATE TABLE operations to
+	// participate in explicit transactions.
+	// https://learn.microsoft.com/azure/synapse-analytics/sql/develop-transaction-best-practices
 	if _, err := tx.ExecContext(ctx, truncateSQL); err != nil {
 		config.LogFailedQuery(truncateSQL, err)
 		return fmt.Errorf("failed to truncate target: %w", err)
@@ -241,11 +244,13 @@ func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagin
 		if opts.IncrementalKey != "" {
 			orderBy = quoteColumn(opts.IncrementalKey)
 		}
-		selectClause = destination.DedupStagingSelect(
+		rowNumberAlias := quoteColumn(destination.UniqueInternalColumnName(opts.Columns, "__bruin_dedup_rn"))
+		selectClause = destination.DedupStagingSelectWithRowNumberAlias(
 			columnList,
 			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
 			stagingTable,
 			orderBy,
+			rowNumberAlias,
 		)
 	}
 

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -201,6 +201,60 @@ func (d *SynapseDestination) InsertFromStaging(ctx context.Context, opts destina
 	return nil
 }
 
+func (d *SynapseDestination) TruncateInsertFromStaging(ctx context.Context, opts destination.TruncateInsertFromStagingOptions) error {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate target: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert from staging: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+func buildTruncateInsertFromStagingSQL(opts destination.TruncateInsertFromStagingOptions) (string, string, error) {
+	columns := quoteColumns(destination.DestinationColumns(opts.Columns))
+	if len(columns) == 0 {
+		return "", "", errors.New("truncate+insert from staging requires at least one column")
+	}
+
+	columnList := strings.Join(columns, ", ")
+	stagingTable := quoteTable(opts.StagingTable)
+	selectClause := fmt.Sprintf("SELECT %s FROM %s", columnList, stagingTable)
+	if len(opts.PrimaryKeys) > 0 && !opts.StagingPrimaryKeysUnique {
+		orderBy := ""
+		if opts.IncrementalKey != "" {
+			orderBy = quoteColumn(opts.IncrementalKey)
+		}
+		selectClause = destination.DedupStagingSelect(
+			columnList,
+			strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+			stagingTable,
+			orderBy,
+		)
+	}
+
+	targetTable := quoteTable(opts.TargetTable)
+	return fmt.Sprintf("TRUNCATE TABLE %s", targetTable),
+		fmt.Sprintf("INSERT INTO %s (%s) %s", targetTable, columnList, selectClause),
+		nil
+}
+
 func (d *SynapseDestination) DropTable(ctx context.Context, table string) error {
 	dropSQL := fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s",
 		escapeTableName(table), quoteTable(table))

--- a/pkg/destination/synapse/synapse_test.go
+++ b/pkg/destination/synapse/synapse_test.go
@@ -1,9 +1,66 @@
 package synapse
 
 import (
+	"errors"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bruin-data/ingestr/pkg/destination"
 )
+
+func TestTruncateInsertFromStagingRollsBackInsertFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	dest := &SynapseDestination{db: db}
+	opts := destination.TruncateInsertFromStagingOptions{
+		StagingTable:             "stage.events",
+		TargetTable:              "dbo.events",
+		PrimaryKeys:              []string{"id"},
+		StagingPrimaryKeysUnique: true,
+		Columns:                  []string{"id", "value"},
+	}
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(truncateSQL)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(insertSQL)).WillReturnError(errors.New("insert failed"))
+	mock.ExpectRollback()
+
+	err = dest.TruncateInsertFromStaging(t.Context(), opts)
+	if err == nil || !strings.Contains(err.Error(), "failed to insert from staging") {
+		t.Fatalf("TruncateInsertFromStaging() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildTruncateInsertFromStagingSQLDeduplicatesUncertainKeys(t *testing.T) {
+	truncateSQL, insertSQL, err := buildTruncateInsertFromStagingSQL(destination.TruncateInsertFromStagingOptions{
+		StagingTable:   "stage.events",
+		TargetTable:    "dbo.events",
+		PrimaryKeys:    []string{"id"},
+		Columns:        []string{"id", "updated_at", "value"},
+		IncrementalKey: "updated_at",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncateSQL != "TRUNCATE TABLE [dbo].[events]" {
+		t.Fatalf("truncateSQL = %q", truncateSQL)
+	}
+	if !strings.Contains(insertSQL, "ROW_NUMBER() OVER (PARTITION BY [id] ORDER BY [updated_at] DESC)") {
+		t.Fatalf("insertSQL does not deduplicate staging rows:\n%s", insertSQL)
+	}
+}
 
 func TestBuildDeleteInsertDeleteSQLUsesTableLock(t *testing.T) {
 	sql := buildDeleteInsertDeleteSQL("dbo.events", "updated_at")


### PR DESCRIPTION
## What

Make staged `truncate+insert` finalization transactional wherever the destination supports it.

## Changes

- Add atomic finalizers for DuckDB, SQLite, SQL Server, Fabric, Synapse, and Databricks; PostgreSQL was already transactional.
- Preserve staging deduplication and document the atomic support boundary.
- Add rollback and SQL-generation coverage.

## How to test

1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback

- **Risk:** Medium; final target mutation now runs in destination transactions or atomic scripts.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

None.
