### PR TITLE
metrics: expose streaming metrics in Prometheus format

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -236,7 +236,7 @@ func IngestCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "metrics-addr",
-				Usage:   "Serve streaming metrics (expvar at /debug/vars) on this address, e.g. 127.0.0.1:6060. Only valid together with --stream",
+				Usage:   "Serve streaming metrics (Prometheus at /metrics) on this address, e.g. 127.0.0.1:6060. Only valid together with --stream",
 				Sources: cli.EnvVars("INGESTR_METRICS_ADDR"),
 			},
 			&cli.StringFlag{
@@ -368,7 +368,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 		}
 		defer stop()
 		if !output.IsJSON() {
-			color.Green("Serving metrics on http://%s/debug/vars", boundAddr)
+			color.Green("Serving metrics on http://%s/metrics", boundAddr)
 		}
 	}
 

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -85,7 +85,7 @@ ingestr ingest \
 
 ### Monitoring a stream
 
-Passing `--metrics-addr` starts a small HTTP server for the lifetime of the stream that exposes Go [expvar](https://pkg.go.dev/expvar) metrics at `/debug/vars`. It is off unless the flag is set, and the address is bound before ingestion starts, so a port conflict fails immediately rather than half-way through a run.
+Passing `--metrics-addr` starts a small HTTP server for the lifetime of the stream that exposes [Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/) metrics at `/metrics`. It is off unless the flag is set, and the address is bound before ingestion starts, so a port conflict fails immediately rather than half-way through a run. Only ingestr's own metrics are served — the Go runtime and process collectors are deliberately excluded.
 
 ```bash
 ingestr ingest \
@@ -94,28 +94,28 @@ ingestr ingest \
    --stream \
    --metrics-addr 127.0.0.1:6060
 
-curl -s localhost:6060/debug/vars | jq '.ingestr_replication, .ingestr_stream_tables'
+curl -s localhost:6060/metrics | grep -E '^ingestr_replication|^ingestr_stream_table'
 ```
 
-Alongside Go's standard `cmdline` and `memstats`, ingestr publishes:
+ingestr publishes:
 
-| Key | Meaning |
+| Metric | Meaning |
 |---|---|
-| `ingestr_replication` | Replication lag for the current source (see below). `{"streaming": false}` when the source cannot report lag. |
-| `ingestr_stream_rows_synced` | Cumulative rows written **and** confirmed durable since the process started. |
-| `ingestr_stream_flush_cycles` | Number of completed flush cycles. |
-| `ingestr_stream_last_synced_unix` | Unix time of the last successful commit. |
-| `ingestr_stream_tables` | The same row counts and timestamp, broken out per destination table. |
+| `ingestr_replication_*{source}` | Replication lag for the current source (see below). Absent when the source cannot report lag. |
+| `ingestr_stream_rows_synced_total` | Cumulative rows written **and** confirmed durable since the process started. |
+| `ingestr_stream_flush_cycles_total` | Number of completed flush cycles. |
+| `ingestr_stream_last_synced_timestamp_seconds` | Unix time of the last successful commit. |
+| `ingestr_stream_table_*{table}` | The same row counts and timestamp, broken out per destination table. |
 
-The row counters advance only after a flush's destination write **and** its source-position commit have both succeeded, so they count durable rows rather than merely written ones. `ingestr_stream_last_synced_unix` also advances on cycles that commit a position without writing rows, which is what makes it usable as a staleness alarm: if it stops moving, the stream is stuck.
+The row counters advance only after a flush's destination write **and** its source-position commit have both succeeded, so they count durable rows rather than merely written ones. `ingestr_stream_last_synced_timestamp_seconds` also advances on cycles that commit a position without writing rows, which is what makes it usable as a staleness alarm: if it stops moving, the stream is stuck.
 
-What `ingestr_replication` contains depends on the engine, because "lag" is not the same quantity everywhere:
+The `ingestr_replication_*` series carry a `source` label and depend on the engine, because "lag" is not the same quantity everywhere:
 
-- **Postgres** (`postgres+cdc`) reports `bytes_behind`: the distance between the server's WAL head and the position ingestr has confirmed durable. This is the same number as `pg_current_wal_lsn() - confirmed_flush_lsn` for the replication slot, so it is what predicts unbounded WAL growth on the source. It is the value to alert on.
-- **MongoDB** (`mongodb+cdc`) reports `seconds_behind`: the gap between the server's `operationTime` and the cluster time of the last processed change event. Both clocks are server-side, so an idle collection converges to zero instead of drifting upward.
-- **SQL Server** (`mssql+cdc`) reports `seconds_behind`: the change time between the processed LSN and the capture watermark, via `sys.fn_cdc_map_lsn_to_time`. SQL Server's `binary(10)` LSNs are ordered but their difference is not a log distance, so no `bytes_behind` is published.
+- **Postgres** (`postgres+cdc`) reports `ingestr_replication_bytes_behind`: the distance between the server's WAL head and the position ingestr has confirmed durable. This is the same number as `pg_current_wal_lsn() - confirmed_flush_lsn` for the replication slot, so it is what predicts unbounded WAL growth on the source. It is the value to alert on.
+- **MongoDB** (`mongodb+cdc`) reports `ingestr_replication_seconds_behind`: the gap between the server's `operationTime` and the cluster time of the last processed change event. Both clocks are server-side, so an idle collection converges to zero instead of drifting upward.
+- **SQL Server** (`mssql+cdc`) reports `ingestr_replication_seconds_behind`: the change time between the processed LSN and the capture watermark, via `sys.fn_cdc_map_lsn_to_time`. SQL Server's `binary(10)` LSNs are ordered but their difference is not a log distance, so no `bytes_behind` is published.
 
-Fields that an engine cannot express are omitted rather than reported as a misleading zero. Postgres, for instance, has no per-LSN timestamp, so it publishes no `seconds_behind`. Message-broker sources report no lag block at all.
+Fields that an engine cannot express are omitted rather than reported as a misleading zero. Postgres, for instance, has no per-LSN timestamp, so it publishes no `ingestr_replication_seconds_behind`. Message-broker sources report no replication series at all.
 
 ## General flags
 

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,8 @@ require (
 	github.com/nats-io/nats.go v1.52.0
 	github.com/olekukonko/tablewriter v1.1.2
 	github.com/pkg/sftp v1.13.10
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/schollz/progressbar/v3 v3.18.0
@@ -340,8 +342,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/pterm/pterm v0.12.83 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -71,23 +71,28 @@ var (
 	descReplStreaming = prometheus.NewDesc(
 		"ingestr_replication_streaming",
 		"1 when the source is actively streaming replication.",
-		[]string{"source"}, nil)
+		[]string{"source"}, nil,
+	)
 	descReplCaughtUp = prometheus.NewDesc(
 		"ingestr_replication_caught_up",
 		"1 when the durable position has caught up to the server position, 0 otherwise.",
-		[]string{"source"}, nil)
+		[]string{"source"}, nil,
+	)
 	descReplBytesBehind = prometheus.NewDesc(
 		"ingestr_replication_bytes_behind",
 		"Bytes the durable position lags behind the server write position.",
-		[]string{"source"}, nil)
+		[]string{"source"}, nil,
+	)
 	descReplSecondsBehind = prometheus.NewDesc(
 		"ingestr_replication_seconds_behind",
 		"Seconds the durable position lags behind the server.",
-		[]string{"source"}, nil)
+		[]string{"source"}, nil,
+	)
 	descReplUpdatedAt = prometheus.NewDesc(
 		"ingestr_replication_updated_at_timestamp_seconds",
 		"Unix timestamp when the lag snapshot was taken.",
-		[]string{"source"}, nil)
+		[]string{"source"}, nil,
+	)
 )
 
 // replicationCollector reads the active lag reporter on every scrape. Using a

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,102 +1,142 @@
-// Package metrics exposes streaming ingestion metrics over HTTP via expvar.
+// Package metrics exposes streaming ingestion metrics over HTTP in the
+// Prometheus text exposition format.
 //
-// It is opt-in: nothing is served unless the caller invokes Serve. The exported
-// vars are published once at init because expvar panics on duplicate publish.
+// It is opt-in: nothing is served unless the caller invokes Serve. Metrics are
+// registered on a dedicated registry (never the default) so scrapes expose only
+// ingestr's own metrics, never the Go runtime or process collectors the default
+// registry ships with; those would add needless work (a stop-the-world
+// runtime.ReadMemStats) and noise no ingestr consumer asked for.
 package metrics
 
 import (
-	"expvar"
-	"io"
 	"net"
 	"net/http"
-	"strconv"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// varPrefix namespaces every variable ingestr publishes. The handler filters on
-// it so the endpoint exposes only ingestr's own vars, never expvar's built-in
-// cmdline/memstats, which the standard library injects into the shared registry
-// at package-import time.
-const varPrefix = "ingestr_"
+// registry backs every metric ingestr publishes. It is process-global because
+// ingestr runs one stream per process; a hypothetical concurrent pipeline would
+// share it.
+var registry = prometheus.NewRegistry()
 
-// reporter holds the active source's lag reporter. It is a package global
-// because expvar's registry is process-global and ingestr runs one stream per
-// process; a hypothetical concurrent pipeline would overwrite it.
+// reporter holds the active source's lag reporter. The replication collector
+// reads it fresh on each scrape, so lag reflects the moment of the scrape.
 var reporter atomic.Pointer[source.LagReporter]
 
 var (
-	rowsSynced   = expvar.NewInt("ingestr_stream_rows_synced")
-	flushCycles  = expvar.NewInt("ingestr_stream_flush_cycles")
-	lastSyncedTS = expvar.NewInt("ingestr_stream_last_synced_unix")
+	rowsSynced = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ingestr_stream_rows_synced_total",
+		Help: "Total rows durably synced to the destination and acknowledged to the source.",
+	})
+	flushCycles = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ingestr_stream_flush_cycles_total",
+		Help: "Total committed flush cycles.",
+	})
+	lastSyncedTS = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ingestr_stream_last_synced_timestamp_seconds",
+		Help: "Unix timestamp of the last committed flush cycle.",
+	})
+	tableRowsSynced = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingestr_stream_table_rows_synced_total",
+		Help: "Total rows durably synced, per table.",
+	}, []string{"table"})
+	tableLastFlushRows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ingestr_stream_table_last_flush_rows",
+		Help: "Rows written for a table in its most recent flush cycle.",
+	}, []string{"table"})
+	tableLastSyncedTS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ingestr_stream_table_last_synced_timestamp_seconds",
+		Help: "Unix timestamp of the most recent flush cycle that included a table.",
+	}, []string{"table"})
 )
-
-var (
-	tablesMu sync.Mutex
-	tables   = map[string]*tableStat{}
-)
-
-type tableStat struct {
-	RowsSynced     int64 `json:"rows_synced"`
-	LastFlushRows  int64 `json:"last_flush_rows"`
-	LastSyncedUnix int64 `json:"last_synced_unix"`
-}
-
-type lagVars struct {
-	Streaming       bool     `json:"streaming"`
-	Source          string   `json:"source,omitempty"`
-	BytesBehind     *uint64  `json:"bytes_behind,omitempty"`
-	SecondsBehind   *float64 `json:"seconds_behind,omitempty"`
-	ServerPosition  string   `json:"server_position,omitempty"`
-	DurablePosition string   `json:"durable_position,omitempty"`
-	CaughtUp        bool     `json:"caught_up"`
-	UpdatedAtUnix   int64    `json:"updated_at_unix,omitempty"`
-}
 
 func init() {
-	expvar.Publish("ingestr_replication", expvar.Func(replicationVars))
-	expvar.Publish("ingestr_stream_tables", expvar.Func(tableVars))
+	registry.MustRegister(
+		rowsSynced,
+		flushCycles,
+		lastSyncedTS,
+		tableRowsSynced,
+		tableLastFlushRows,
+		tableLastSyncedTS,
+		replicationCollector{},
+	)
 }
 
-func replicationVars() any {
+var (
+	descReplStreaming = prometheus.NewDesc(
+		"ingestr_replication_streaming",
+		"1 when the source is actively streaming replication.",
+		[]string{"source"}, nil)
+	descReplCaughtUp = prometheus.NewDesc(
+		"ingestr_replication_caught_up",
+		"1 when the durable position has caught up to the server position, 0 otherwise.",
+		[]string{"source"}, nil)
+	descReplBytesBehind = prometheus.NewDesc(
+		"ingestr_replication_bytes_behind",
+		"Bytes the durable position lags behind the server write position.",
+		[]string{"source"}, nil)
+	descReplSecondsBehind = prometheus.NewDesc(
+		"ingestr_replication_seconds_behind",
+		"Seconds the durable position lags behind the server.",
+		[]string{"source"}, nil)
+	descReplUpdatedAt = prometheus.NewDesc(
+		"ingestr_replication_updated_at_timestamp_seconds",
+		"Unix timestamp when the lag snapshot was taken.",
+		[]string{"source"}, nil)
+)
+
+// replicationCollector reads the active lag reporter on every scrape. Using a
+// collector rather than gauges lets it omit dimensions the engine cannot
+// express: Postgres has no per-LSN timestamp (no seconds_behind), and
+// MongoDB/SQL Server logs have no byte offset (no bytes_behind). Sources that do
+// not report lag (e.g. MySQL/Vitess CDC) emit nothing at all.
+type replicationCollector struct{}
+
+func (replicationCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descReplStreaming
+	ch <- descReplCaughtUp
+	ch <- descReplBytesBehind
+	ch <- descReplSecondsBehind
+	ch <- descReplUpdatedAt
+}
+
+func (replicationCollector) Collect(ch chan<- prometheus.Metric) {
 	rp := reporter.Load()
 	if rp == nil {
-		return lagVars{}
+		return
 	}
 	s, ok := (*rp).ReplicationLag()
 	if !ok {
-		return lagVars{}
+		return
 	}
-	v := lagVars{
-		Streaming:       true,
-		Source:          s.Source,
-		BytesBehind:     s.BytesBehind,
-		SecondsBehind:   s.SecondsBehind,
-		ServerPosition:  s.ServerPosition,
-		DurablePosition: s.DurablePosition,
-		CaughtUp:        s.CaughtUp,
+	ch <- prometheus.MustNewConstMetric(descReplStreaming, prometheus.GaugeValue, 1, s.Source)
+	ch <- prometheus.MustNewConstMetric(descReplCaughtUp, prometheus.GaugeValue, boolToFloat(s.CaughtUp), s.Source)
+	if s.BytesBehind != nil {
+		ch <- prometheus.MustNewConstMetric(descReplBytesBehind, prometheus.GaugeValue, float64(*s.BytesBehind), s.Source)
+	}
+	if s.SecondsBehind != nil {
+		ch <- prometheus.MustNewConstMetric(descReplSecondsBehind, prometheus.GaugeValue, *s.SecondsBehind, s.Source)
 	}
 	if !s.UpdatedAt.IsZero() {
-		v.UpdatedAtUnix = s.UpdatedAt.Unix()
+		ch <- prometheus.MustNewConstMetric(descReplUpdatedAt, prometheus.GaugeValue, float64(s.UpdatedAt.Unix()), s.Source)
 	}
-	return v
 }
 
-// tableVars returns a copy: expvar encodes the returned value after this
-// function has released the lock.
-func tableVars() any {
-	tablesMu.Lock()
-	defer tablesMu.Unlock()
-	out := make(map[string]tableStat, len(tables))
-	for name, st := range tables {
-		out[name] = *st
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
 	}
-	return out
+	return 0
 }
+
+// Gatherer returns the registry backing the streaming metrics so embedders and
+// tests can gather ingestr's own metrics without going through HTTP.
+func Gatherer() prometheus.Gatherer { return registry }
 
 // SetLagReporter installs the source whose lag is published. Pass nil to clear.
 func SetLagReporter(r source.LagReporter) {
@@ -111,29 +151,22 @@ func SetLagReporter(r source.LagReporter) {
 // invoke it only after the source position is committed, so the counters mean
 // "durable in the destination" rather than merely "written".
 func RecordSync(perTable map[string]int64, at time.Time) {
-	unix := at.Unix()
+	unix := float64(at.Unix())
 	var total int64
 
-	tablesMu.Lock()
 	for name, rows := range perTable {
-		st, ok := tables[name]
-		if !ok {
-			st = &tableStat{}
-			tables[name] = st
-		}
-		st.RowsSynced += rows
-		st.LastFlushRows = rows
-		st.LastSyncedUnix = unix
+		tableRowsSynced.WithLabelValues(name).Add(float64(rows))
+		tableLastFlushRows.WithLabelValues(name).Set(float64(rows))
+		tableLastSyncedTS.WithLabelValues(name).Set(unix)
 		total += rows
 	}
-	tablesMu.Unlock()
 
-	rowsSynced.Add(total)
-	flushCycles.Add(1)
+	rowsSynced.Add(float64(total))
+	flushCycles.Inc()
 	lastSyncedTS.Set(unix)
 }
 
-// Serve starts an HTTP server exposing expvar at /debug/vars. The listener is
+// Serve starts an HTTP server exposing the metrics at /metrics. The listener is
 // bound synchronously so an unusable address fails fast, and the resolved
 // address is returned so a port of 0 can be used. The returned stop closes the
 // server immediately rather than draining: this is a read-only endpoint, and an
@@ -144,40 +177,13 @@ func Serve(addr string) (boundAddr string, stop func(), err error) {
 		return "", nil, err
 	}
 
-	// A dedicated mux, never http.DefaultServeMux: importing expvar registers
-	// /debug/vars there, and that must not leak into the web UI server.
+	// A dedicated mux, never http.DefaultServeMux: a transitively-imported expvar
+	// would register /debug/vars there, and that must not leak into this server.
 	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/vars", handler)
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 
 	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	go func() { _ = srv.Serve(ln) }()
 
 	return ln.Addr().String(), func() { _ = srv.Close() }, nil
-}
-
-// handler serves ingestr's own vars as a JSON object, mirroring the format of
-// expvar.Handler but skipping every var outside the ingestr_ namespace. This
-// keeps expvar's cmdline/memstats built-ins out of the response; memstats in
-// particular calls runtime.ReadMemStats on each scrape, which is needless work
-// and a stop-the-world pause for data no ingestr consumer asked for.
-func handler(w http.ResponseWriter, _ *http.Request) {
-	var buf strings.Builder
-	buf.WriteString("{\n")
-	first := true
-	expvar.Do(func(kv expvar.KeyValue) {
-		if !strings.HasPrefix(kv.Key, varPrefix) {
-			return
-		}
-		if !first {
-			buf.WriteString(",\n")
-		}
-		first = false
-		buf.WriteString(strconv.Quote(kv.Key))
-		buf.WriteString(": ")
-		buf.WriteString(kv.Value.String())
-	})
-	buf.WriteString("\n}\n")
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	_, _ = io.WriteString(w, buf.String())
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,16 +1,17 @@
 package metrics
 
 import (
-	"encoding/json"
-	"expvar"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
 
 type fakeReporter struct {
@@ -20,60 +21,70 @@ type fakeReporter struct {
 
 func (f fakeReporter) ReplicationLag() (source.LagSnapshot, bool) { return f.snap, f.ok }
 
-func scrapeReplication(t *testing.T) map[string]any {
+// replicationValue gathers the current value of a source-labeled replication
+// metric. found is false when the series is absent, which is how the collector
+// signals a dimension the engine cannot express.
+func replicationValue(t *testing.T, name string) (value float64, found bool) {
 	t.Helper()
-	var out map[string]any
-	if err := json.Unmarshal([]byte(expvar.Get("ingestr_replication").String()), &out); err != nil {
-		t.Fatalf("failed to decode ingestr_replication: %v", err)
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather failed: %v", err)
 	}
-	return out
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		m := mf.GetMetric()
+		if len(m) == 0 {
+			return 0, false
+		}
+		return metricValue(m[0]), true
+	}
+	return 0, false
 }
 
-func scrapeTables(t *testing.T) map[string]map[string]any {
-	t.Helper()
-	var out map[string]map[string]any
-	if err := json.Unmarshal([]byte(expvar.Get("ingestr_stream_tables").String()), &out); err != nil {
-		t.Fatalf("failed to decode ingestr_stream_tables: %v", err)
+func metricValue(m *dto.Metric) float64 {
+	switch {
+	case m.Gauge != nil:
+		return m.Gauge.GetValue()
+	case m.Counter != nil:
+		return m.Counter.GetValue()
+	default:
+		return 0
 	}
-	return out
 }
 
-// resetState clears the package globals so each test starts clean. expvar has
-// no deregister, so the vars themselves are reused across tests.
+// resetState clears the per-table series and the reporter so each test starts
+// clean. The plain counters (rowsSynced, flushCycles) cannot be reset, so tests
+// that assert their totals measure a before/after delta instead.
 func resetState(t *testing.T) {
 	t.Helper()
 	SetLagReporter(nil)
-	tablesMu.Lock()
-	tables = map[string]*tableStat{}
-	tablesMu.Unlock()
-	rowsSynced.Set(0)
-	flushCycles.Set(0)
+	tableRowsSynced.Reset()
+	tableLastFlushRows.Reset()
+	tableLastSyncedTS.Reset()
 	lastSyncedTS.Set(0)
 	t.Cleanup(func() { SetLagReporter(nil) })
 }
 
-func TestReplicationVarsWithoutReporter(t *testing.T) {
+func TestReplicationWithoutReporter(t *testing.T) {
 	resetState(t)
 
-	got := scrapeReplication(t)
-	if got["streaming"] != false {
-		t.Fatalf("expected streaming=false with no reporter, got %v", got)
-	}
-	if _, ok := got["bytes_behind"]; ok {
-		t.Fatalf("expected no bytes_behind with no reporter, got %v", got)
+	if _, found := replicationValue(t, "ingestr_replication_streaming"); found {
+		t.Fatal("expected no replication series without a reporter")
 	}
 }
 
-func TestReplicationVarsReporterNotReady(t *testing.T) {
+func TestReplicationReporterNotReady(t *testing.T) {
 	resetState(t)
 	SetLagReporter(fakeReporter{ok: false})
 
-	if got := scrapeReplication(t); got["streaming"] != false {
-		t.Fatalf("expected streaming=false when reporter is not ready, got %v", got)
+	if _, found := replicationValue(t, "ingestr_replication_streaming"); found {
+		t.Fatal("expected no replication series when the reporter is not ready")
 	}
 }
 
-func TestReplicationVarsBytesBehind(t *testing.T) {
+func TestReplicationBytesBehind(t *testing.T) {
 	resetState(t)
 	behind := uint64(4096)
 	SetLagReporter(fakeReporter{
@@ -87,27 +98,26 @@ func TestReplicationVarsBytesBehind(t *testing.T) {
 		},
 	})
 
-	got := scrapeReplication(t)
-	if got["streaming"] != true {
-		t.Fatalf("expected streaming=true, got %v", got)
+	if v, found := replicationValue(t, "ingestr_replication_streaming"); !found || v != 1 {
+		t.Fatalf("expected streaming=1, got %v (found=%v)", v, found)
 	}
-	if got["bytes_behind"] != float64(4096) {
-		t.Fatalf("expected bytes_behind=4096, got %v", got["bytes_behind"])
+	if v, found := replicationValue(t, "ingestr_replication_bytes_behind"); !found || v != 4096 {
+		t.Fatalf("expected bytes_behind=4096, got %v (found=%v)", v, found)
 	}
-	if got["caught_up"] != false {
-		t.Fatalf("expected caught_up=false, got %v", got["caught_up"])
+	if v, found := replicationValue(t, "ingestr_replication_caught_up"); !found || v != 0 {
+		t.Fatalf("expected caught_up=0, got %v (found=%v)", v, found)
 	}
-	if got["server_position"] != "0/1A2B3C0" {
-		t.Fatalf("unexpected server_position: %v", got["server_position"])
+	if v, found := replicationValue(t, "ingestr_replication_updated_at_timestamp_seconds"); !found || v != 1700000000 {
+		t.Fatalf("expected updated_at=1700000000, got %v (found=%v)", v, found)
 	}
 	// seconds_behind is not applicable to Postgres and must be omitted rather
 	// than reported as a misleading zero.
-	if _, ok := got["seconds_behind"]; ok {
-		t.Fatalf("expected seconds_behind to be omitted, got %v", got)
+	if _, found := replicationValue(t, "ingestr_replication_seconds_behind"); found {
+		t.Fatal("expected seconds_behind to be omitted for postgres")
 	}
 }
 
-func TestReplicationVarsSecondsBehindOnly(t *testing.T) {
+func TestReplicationSecondsBehindOnly(t *testing.T) {
 	resetState(t)
 	secs := 12.0
 	SetLagReporter(fakeReporter{
@@ -115,52 +125,52 @@ func TestReplicationVarsSecondsBehindOnly(t *testing.T) {
 		snap: source.LagSnapshot{Source: "mongodb", SecondsBehind: &secs},
 	})
 
-	got := scrapeReplication(t)
-	if got["seconds_behind"] != float64(12) {
-		t.Fatalf("expected seconds_behind=12, got %v", got["seconds_behind"])
+	if v, found := replicationValue(t, "ingestr_replication_seconds_behind"); !found || v != 12 {
+		t.Fatalf("expected seconds_behind=12, got %v (found=%v)", v, found)
 	}
-	if _, ok := got["bytes_behind"]; ok {
-		t.Fatalf("expected bytes_behind to be omitted for mongodb, got %v", got)
+	if _, found := replicationValue(t, "ingestr_replication_bytes_behind"); found {
+		t.Fatal("expected bytes_behind to be omitted for mongodb")
 	}
 }
 
 func TestRecordSyncAccumulates(t *testing.T) {
 	resetState(t)
 
+	beforeRows := testutil.ToFloat64(rowsSynced)
+	beforeCycles := testutil.ToFloat64(flushCycles)
+
 	RecordSync(map[string]int64{"public.users": 100, "public.orders": 50}, time.Unix(1000, 0))
 	RecordSync(map[string]int64{"public.users": 25, "public.items": 7}, time.Unix(2000, 0))
 
-	if got := rowsSynced.Value(); got != 182 {
-		t.Fatalf("expected 182 rows synced in total, got %d", got)
+	if got := testutil.ToFloat64(rowsSynced) - beforeRows; got != 182 {
+		t.Fatalf("expected 182 rows synced in total, got %v", got)
 	}
-	if got := flushCycles.Value(); got != 2 {
-		t.Fatalf("expected 2 flush cycles, got %d", got)
+	if got := testutil.ToFloat64(flushCycles) - beforeCycles; got != 2 {
+		t.Fatalf("expected 2 flush cycles, got %v", got)
 	}
-	if got := lastSyncedTS.Value(); got != 2000 {
-		t.Fatalf("expected last synced 2000, got %d", got)
+	if got := testutil.ToFloat64(lastSyncedTS); got != 2000 {
+		t.Fatalf("expected last synced 2000, got %v", got)
 	}
-
-	tbl := scrapeTables(t)
 
 	// rows_synced accumulates across cycles; last_flush_rows is replaced.
-	if tbl["public.users"]["rows_synced"] != float64(125) {
-		t.Fatalf("expected users rows_synced=125, got %v", tbl["public.users"]["rows_synced"])
+	if got := testutil.ToFloat64(tableRowsSynced.WithLabelValues("public.users")); got != 125 {
+		t.Fatalf("expected users rows_synced=125, got %v", got)
 	}
-	if tbl["public.users"]["last_flush_rows"] != float64(25) {
-		t.Fatalf("expected users last_flush_rows=25, got %v", tbl["public.users"]["last_flush_rows"])
+	if got := testutil.ToFloat64(tableLastFlushRows.WithLabelValues("public.users")); got != 25 {
+		t.Fatalf("expected users last_flush_rows=25, got %v", got)
 	}
 
 	// A table absent from cycle 2 keeps its totals and its older timestamp.
-	if tbl["public.orders"]["rows_synced"] != float64(50) {
-		t.Fatalf("expected orders rows_synced=50, got %v", tbl["public.orders"]["rows_synced"])
+	if got := testutil.ToFloat64(tableRowsSynced.WithLabelValues("public.orders")); got != 50 {
+		t.Fatalf("expected orders rows_synced=50, got %v", got)
 	}
-	if tbl["public.orders"]["last_synced_unix"] != float64(1000) {
-		t.Fatalf("expected orders to keep last_synced_unix=1000, got %v", tbl["public.orders"]["last_synced_unix"])
+	if got := testutil.ToFloat64(tableLastSyncedTS.WithLabelValues("public.orders")); got != 1000 {
+		t.Fatalf("expected orders to keep last_synced=1000, got %v", got)
 	}
 
 	// A table first seen in cycle 2 appears.
-	if tbl["public.items"]["rows_synced"] != float64(7) {
-		t.Fatalf("expected items rows_synced=7, got %v", tbl["public.items"]["rows_synced"])
+	if got := testutil.ToFloat64(tableRowsSynced.WithLabelValues("public.items")); got != 7 {
+		t.Fatalf("expected items rows_synced=7, got %v", got)
 	}
 }
 
@@ -169,18 +179,21 @@ func TestRecordSyncAccumulates(t *testing.T) {
 func TestRecordSyncIdleCycleAdvancesTimestamp(t *testing.T) {
 	resetState(t)
 
+	beforeRows := testutil.ToFloat64(rowsSynced)
 	RecordSync(map[string]int64{}, time.Unix(500, 0))
 
-	if got := rowsSynced.Value(); got != 0 {
-		t.Fatalf("expected no rows synced, got %d", got)
+	if got := testutil.ToFloat64(rowsSynced) - beforeRows; got != 0 {
+		t.Fatalf("expected no rows synced, got %v", got)
 	}
-	if got := lastSyncedTS.Value(); got != 500 {
-		t.Fatalf("expected last synced 500, got %d", got)
+	if got := testutil.ToFloat64(lastSyncedTS); got != 500 {
+		t.Fatalf("expected last synced 500, got %v", got)
 	}
 }
 
 func TestRecordSyncConcurrentWithScrape(t *testing.T) {
 	resetState(t)
+
+	beforeRows := testutil.ToFloat64(rowsSynced)
 
 	var wg sync.WaitGroup
 	for i := range 8 {
@@ -188,17 +201,17 @@ func TestRecordSyncConcurrentWithScrape(t *testing.T) {
 			RecordSync(map[string]int64{fmt.Sprintf("t%d", i%3): 1}, time.Unix(int64(i), 0))
 		})
 		wg.Go(func() {
-			_ = expvar.Get("ingestr_stream_tables").String()
+			_, _ = registry.Gather()
 		})
 	}
 	wg.Wait()
 
-	if got := rowsSynced.Value(); got != 8 {
-		t.Fatalf("expected 8 rows synced, got %d", got)
+	if got := testutil.ToFloat64(rowsSynced) - beforeRows; got != 8 {
+		t.Fatalf("expected 8 rows synced, got %v", got)
 	}
 }
 
-func TestServeExposesDebugVars(t *testing.T) {
+func TestServeExposesMetrics(t *testing.T) {
 	resetState(t)
 	RecordSync(map[string]int64{"public.users": 3}, time.Unix(1234, 0))
 
@@ -208,7 +221,7 @@ func TestServeExposesDebugVars(t *testing.T) {
 	}
 	t.Cleanup(stop)
 
-	resp, err := http.Get("http://" + addr + "/debug/vars")
+	resp, err := http.Get("http://" + addr + "/metrics")
 	if err != nil {
 		t.Fatalf("could not reach metrics server: %v", err)
 	}
@@ -218,20 +231,20 @@ func TestServeExposesDebugVars(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read body: %v", err)
 	}
-	var out map[string]any
-	if err := json.Unmarshal(body, &out); err != nil {
-		t.Fatalf("expvar output is not valid JSON: %v", err)
+	text := string(body)
+
+	if !strings.Contains(text, "ingestr_stream_rows_synced_total") {
+		t.Fatalf("expected ingestr_stream_rows_synced_total in /metrics, got:\n%s", text)
 	}
-	if _, ok := out["ingestr_stream_rows_synced"]; !ok {
-		t.Fatalf("expected ingestr_stream_rows_synced in /debug/vars, got keys %v", out)
+	if !strings.Contains(text, `ingestr_stream_table_rows_synced_total{table="public.users"}`) {
+		t.Fatalf("expected per-table series in /metrics, got:\n%s", text)
 	}
 
-	// expvar injects cmdline and memstats into the shared registry; the handler
-	// must filter them out so scrapes never trigger runtime.ReadMemStats or leak
-	// the process arguments.
-	for _, builtin := range []string{"memstats", "cmdline"} {
-		if _, ok := out[builtin]; ok {
-			t.Fatalf("expected %q to be excluded from /debug/vars, got keys %v", builtin, out)
+	// The dedicated registry must not carry the default registry's Go runtime or
+	// process collectors, so scrapes never trigger runtime.ReadMemStats.
+	for _, builtin := range []string{"go_goroutines", "go_memstats_", "process_"} {
+		if strings.Contains(text, builtin) {
+			t.Fatalf("expected %q to be absent from /metrics", builtin)
 		}
 	}
 }

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -1399,6 +1399,7 @@ dependencies:
       version: v1.23.2
       licenses:
         - Apache-2.0
+        - BSD-3-Clause
       status: allowed
     - module: github.com/prometheus/client_model
       version: v0.6.2

--- a/pkg/strategy/streaming_metrics_test.go
+++ b/pkg/strategy/streaming_metrics_test.go
@@ -2,36 +2,77 @@ package strategy
 
 import (
 	"context"
-	"encoding/json"
-	"expvar"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/metrics"
 	"github.com/bruin-data/ingestr/pkg/source"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func rowsSyncedValue(t *testing.T) int64 {
+// gatherValue reads the current value of a metric series from the metrics
+// registry, matching every label in labels. It returns 0 when the series is
+// absent, which is sufficient for the delta-based assertions below.
+func gatherValue(t *testing.T, name string, labels map[string]string) float64 {
 	t.Helper()
-	v, ok := expvar.Get("ingestr_stream_rows_synced").(*expvar.Int)
-	require.True(t, ok, "ingestr_stream_rows_synced is not an expvar.Int")
-	return v.Value()
+	mfs, err := metrics.Gatherer().Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if labelsMatch(m, labels) {
+				return metricScalar(m)
+			}
+		}
+	}
+	return 0
 }
 
-func lastSyncedValue(t *testing.T) int64 {
+func labelsMatch(m *dto.Metric, want map[string]string) bool {
+	for k, v := range want {
+		found := false
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == k && lp.GetValue() == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func metricScalar(m *dto.Metric) float64 {
+	switch {
+	case m.Counter != nil:
+		return m.Counter.GetValue()
+	case m.Gauge != nil:
+		return m.Gauge.GetValue()
+	default:
+		return 0
+	}
+}
+
+func rowsSyncedValue(t *testing.T) float64 {
 	t.Helper()
-	v, ok := expvar.Get("ingestr_stream_last_synced_unix").(*expvar.Int)
-	require.True(t, ok, "ingestr_stream_last_synced_unix is not an expvar.Int")
-	return v.Value()
+	return gatherValue(t, "ingestr_stream_rows_synced_total", nil)
+}
+
+func lastSyncedValue(t *testing.T) float64 {
+	t.Helper()
+	return gatherValue(t, "ingestr_stream_last_synced_timestamp_seconds", nil)
 }
 
 func tableRowsSynced(t *testing.T, table string) float64 {
 	t.Helper()
-	var out map[string]map[string]float64
-	require.NoError(t, json.Unmarshal([]byte(expvar.Get("ingestr_stream_tables").String()), &out))
-	return out[table]["rows_synced"]
+	return gatherValue(t, "ingestr_stream_table_rows_synced_total", map[string]string{"table": table})
 }
 
 func TestStreaming_FlushRecordsRowsSynced(t *testing.T) {
@@ -52,7 +93,7 @@ func TestStreaming_FlushRecordsRowsSynced(t *testing.T) {
 	})
 	require.NoError(t, loop.flush(context.Background()))
 
-	assert.Equal(t, int64(4), rowsSyncedValue(t)-before)
+	assert.Equal(t, float64(4), rowsSyncedValue(t)-before)
 	// Single-table loops key l.tables on "", so the metric must fall back to
 	// the destination table name rather than publishing an empty key.
 	assert.Positive(t, tableRowsSynced(t, "ds.tbl"))


### PR DESCRIPTION
## What

Replace the streaming/CDC metrics endpoint's ad-hoc expvar JSON (`/debug/vars`) with the Prometheus text exposition format served at `/metrics`.

The public API of `internal/metrics` (`RecordSync`, `SetLagReporter`, `Serve`) is unchanged, so the call sites in `pkg/strategy/streaming.go` and `pkg/pipeline/pipeline.go` are untouched.

### Metric mapping

| old (expvar) | new (Prometheus) |
|---|---|
| `ingestr_stream_rows_synced` | `ingestr_stream_rows_synced_total` (counter) |
| `ingestr_stream_flush_cycles` | `ingestr_stream_flush_cycles_total` (counter) |
| `ingestr_stream_last_synced_unix` | `ingestr_stream_last_synced_timestamp_seconds` (gauge) |
| `ingestr_stream_tables` (JSON map) | `ingestr_stream_table_*{table}` labeled vecs |
| `ingestr_replication` (JSON) | `ingestr_replication_*{source}` |

## Why

expvar's JSON is a non-standard exposition format that no monitoring tool scrapes by default, and it forced the package to work around expvar's process-global registry (duplicate-publish panics, plus manual filtering of `cmdline`/`memstats` to avoid a stop-the-world scrape). Prometheus is the de-facto scrape standard, its text format is trivially parseable, and `prometheus/client_golang` was already in the module graph.

## Notes

- Metrics are registered on a dedicated registry (never the default), so scrapes carry only ingestr's own metrics — never the Go runtime or process collectors.
- Replication lag uses a custom `prometheus.Collector`, so it is evaluated at scrape time (matching the old `expvar.Func` behaviour) and omits dimensions an engine cannot express (no `seconds_behind` on Postgres, no `bytes_behind` on Mongo/SQL Server).
- The LSN position strings (`server_position`/`durable_position`) are dropped: Prometheus values must be numeric, and carrying LSNs as labels would churn a new time series on every commit. Lag is fully conveyed by the numeric fields.
- `prometheus/client_golang` and `client_model` are promoted from indirect to direct requirements (already in the graph; `go.sum` unchanged).

## Breaking change

The endpoint path moves `/debug/vars` → `/metrics` and metric names change to Prometheus conventions. This endpoint is opt-in behind `--metrics-addr`; anyone scraping the old expvar JSON must update their scrape config.