### PR TITLE
Add Typeform source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -274,6 +274,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "TikTok Ads", link: "/supported-sources/tiktok-ads.md" },
               { text: "Trello", link: "/supported-sources/trello.md" },
               { text: "Twilio", link: "/supported-sources/twilio.md" },
+              { text: "Typeform", link: "/supported-sources/typeform.md" },
               { text: "Wise", link: "/supported-sources/wise.md" },
               { text: "Wistia", link: "/supported-sources/wistia.md" },
               { text: "Zendesk", link: "/supported-sources/zendesk.md" },

--- a/docs/supported-sources/typeform.md
+++ b/docs/supported-sources/typeform.md
@@ -1,0 +1,54 @@
+# Typeform
+
+[Typeform](https://www.typeform.com/) is an online form and survey platform for building interactive forms and collecting responses.
+
+ingestr supports Typeform as a source.
+
+## URI format
+
+```
+typeform://?token=<personal_access_token>
+```
+
+URI parameters:
+
+- `token`: The personal access token used to authenticate with the Typeform API.
+- `region` (optional): The account region. Must be `us` (default) or `eu`.
+
+For EU accounts, specify the region:
+
+```
+typeform://?token=<personal_access_token>&region=eu
+```
+
+## Setting up a Typeform Integration
+
+Typeform requires a personal access token to connect to its API. To create one:
+
+1. Log in to your Typeform account.
+2. Go to your [personal tokens settings](https://admin.typeform.com/user/tokens).
+3. Click **Generate a new token**, give it a name, and grant at least read access to forms, responses, workspaces, and themes.
+4. Copy the generated token.
+
+Once you have the token, here's a sample command that will copy form data into a DuckDB database:
+
+```sh
+ingestr ingest \
+  --source-uri "typeform://?token=your_token_here" \
+  --source-table "forms" \
+  --dest-uri duckdb:///typeform.duckdb \
+  --dest-table "public.forms"
+```
+
+## Tables
+
+Typeform source allows ingesting the following resources into separate tables:
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| ----- | -- | ------- | ------------ | ------- |
+| [forms](https://www.typeform.com/developers/create/reference/retrieve-forms/) | id | last_updated_at | merge | All forms in the account with metadata (title, settings, theme, timestamps) |
+| [responses](https://www.typeform.com/developers/responses/reference/retrieve-responses/) | response_id | submitted_at | merge | Submitted responses with answers and metadata, collected per form |
+| [workspaces](https://www.typeform.com/developers/create/reference/retrieve-workspaces/) | id | - | replace | Workspaces in the account |
+| [themes](https://www.typeform.com/developers/create/reference/retrieve-themes/) | id | - | replace | Themes available in the account |
+
+Use these as the `--source-table` parameter in the `ingestr ingest` command.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -404,6 +404,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("trino", "Trino", []string{"trino"}, true, true),
 		genericURIConnector("trustpilot", "Trustpilot", []string{"trustpilot"}, true, false),
 		genericURIConnector("twilio", "Twilio", []string{"twilio"}, true, false),
+		genericURIConnector("typeform", "Typeform", []string{"typeform"}, true, false),
 		genericURIConnector("wise", "Wise", []string{"wise"}, true, false),
 		genericURIConnector("wistia", "Wistia", []string{"wistia"}, true, false),
 		genericURIConnector("zendesk", "Zendesk", []string{"zendesk"}, true, false),

--- a/pkg/source/typeform/register.go
+++ b/pkg/source/typeform/register.go
@@ -1,0 +1,10 @@
+package typeform
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"typeform"},
+		func() interface{} { return NewTypeformSource() },
+	)
+}

--- a/pkg/source/typeform/typeform.go
+++ b/pkg/source/typeform/typeform.go
@@ -1,0 +1,554 @@
+package typeform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	baseURL   = "https://api.typeform.com"
+	baseURLEU = "https://api.eu.typeform.com"
+
+	// Typeform allows 2 requests/second per account for the Create and Responses APIs.
+	rateLimit      = 2.0 * 0.8 // 1.6 req/s
+	rateLimitBurst = 5
+
+	maxPageSize         = 200  // forms/workspaces/themes cap at 200 results per page
+	maxResponsePageSize = 1000 // the responses endpoint caps at 1000 per page
+	maxPages            = 1000
+	workerCount         = 5
+)
+
+var supportedTables = []string{
+	"forms",
+	"responses",
+	"workspaces",
+	"themes",
+}
+
+type TypeformSource struct {
+	token  string
+	client *httpclient.Client
+}
+
+func NewTypeformSource() *TypeformSource {
+	return &TypeformSource{}
+}
+
+func (s *TypeformSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *TypeformSource) Schemes() []string {
+	return []string{"typeform"}
+}
+
+func (s *TypeformSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+	s.token = creds.token
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(creds.apiURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(httpclient.NewBearerAuth(s.token)),
+	)
+	config.Debug("[TYPEFORM] Connected successfully")
+	return nil
+}
+
+func (s *TypeformSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+type typeformCredentials struct {
+	token  string
+	apiURL string
+}
+
+func parseURI(uri string) (*typeformCredentials, error) {
+	if !strings.HasPrefix(uri, "typeform://") {
+		return nil, fmt.Errorf("invalid typeform URI: must start with typeform://")
+	}
+
+	rest := strings.TrimPrefix(uri, "typeform://")
+	if rest == "" || rest == "?" {
+		return nil, fmt.Errorf("token is required in typeform URI")
+	}
+
+	rest = strings.TrimPrefix(rest, "?")
+
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse typeform URI query: %w", err)
+	}
+
+	token := values.Get("token")
+	if token == "" {
+		return nil, fmt.Errorf("token is required in typeform URI")
+	}
+
+	apiURL := baseURL
+	if region := values.Get("region"); region != "" {
+		switch region {
+		case "us":
+			apiURL = baseURL
+		case "eu":
+			apiURL = baseURLEU
+		default:
+			return nil, fmt.Errorf("invalid region %q: must be us or eu", region)
+		}
+	}
+
+	return &typeformCredentials{
+		token:  token,
+		apiURL: apiURL,
+	}, nil
+}
+
+func (s *TypeformSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName := req.Name
+
+	if !isValidTable(tableName) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", req.Name, strings.Join(supportedTables, ", "))
+	}
+
+	incrementalKey := ""
+	strategy := config.StrategyReplace
+	primaryKey := "id"
+
+	switch tableName {
+	case "forms":
+		incrementalKey = "last_updated_at"
+		strategy = config.StrategyMerge
+	case "responses":
+		incrementalKey = "submitted_at"
+		strategy = config.StrategyMerge
+		primaryKey = "response_id"
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    []string{primaryKey},
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("typeform source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, opts)
+		},
+	}, nil
+}
+
+func isValidTable(table string) bool {
+	for _, t := range supportedTables {
+		if t == table {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *TypeformSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "forms":
+			err = s.readForms(ctx, opts, results)
+		case "responses":
+			err = s.readResponses(ctx, opts, results)
+		case "workspaces":
+			err = s.readWorkspaces(ctx, opts, results)
+		case "themes":
+			err = s.readThemes(ctx, opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", table)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+// --- helpers ---
+
+func jsonUseNumber(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+func extractItems(body map[string]interface{}) []map[string]interface{} {
+	raw, ok := body["items"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	items := make([]map[string]interface{}, 0, len(raw))
+	for _, d := range raw {
+		if item, ok := d.(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func toInt(v interface{}) int {
+	switch n := v.(type) {
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	case float64:
+		return int(n)
+	}
+	return 0
+}
+
+func filterItemsByInterval(items []map[string]interface{}, incrementalKey string, start, end *time.Time) []map[string]interface{} {
+	if incrementalKey == "" || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		raw, ok := item[incrementalKey]
+		if !ok || raw == nil {
+			filtered = append(filtered, item)
+			continue
+		}
+
+		str, ok := raw.(string)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, str)
+		if err != nil {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && t.Before(*start) {
+			continue
+		}
+		if end != nil && t.After(*end) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+type pageConfig struct {
+	endpoint     string
+	label        string
+	pageSize     int
+	queryParams  map[string]string
+	intervalKey  string            // if set, client-side filter items by this field
+	injectFields map[string]string // fields injected into every item (e.g. parent id)
+}
+
+// paginatePages is the shared page-number pagination loop for the forms,
+// workspaces, and themes endpoints, which share the {items, page_count} envelope.
+func (s *TypeformSource) paginatePages(ctx context.Context, cfg pageConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	page := 1
+	totalSent := 0
+	pageSize := cfg.pageSize
+	if pageSize == 0 {
+		pageSize = maxPageSize
+	}
+
+	for page <= maxPages {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("page", strconv.Itoa(page)).
+			SetQueryParam("page_size", strconv.Itoa(pageSize))
+
+		for k, v := range cfg.queryParams {
+			req.SetQueryParam(k, v)
+		}
+
+		resp, err := req.Get(cfg.endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", cfg.label, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("typeform API %s returned status %d: %s", cfg.endpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]interface{}
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", cfg.label, err)
+		}
+
+		items := extractItems(body)
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			for k, v := range cfg.injectFields {
+				if _, exists := item[k]; !exists {
+					item[k] = v
+				}
+			}
+		}
+
+		if cfg.intervalKey != "" {
+			items = filterItemsByInterval(items, cfg.intervalKey, opts.IntervalStart, opts.IntervalEnd)
+		}
+
+		if len(items) > 0 {
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s to Arrow: %w", cfg.label, err)
+			}
+			results <- source.RecordBatchResult{Batch: record}
+			totalSent += len(items)
+			config.Debug("[TYPEFORM] %s page %d: sent %d records (total: %d)", cfg.label, page, len(items), totalSent)
+		}
+
+		pageCount := toInt(body["page_count"])
+		if pageCount > 0 && page >= pageCount {
+			break
+		}
+		if pageCount == 0 && len(extractItems(body)) < pageSize {
+			break
+		}
+		page++
+	}
+
+	if totalSent == 0 {
+		config.Debug("[TYPEFORM] No %s found", cfg.label)
+	}
+	return nil
+}
+
+// --- table readers ---
+
+func (s *TypeformSource) readForms(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[TYPEFORM] reading forms")
+	// The /forms endpoint has no server-side time filter, so filter client-side
+	// on last_updated_at after fetching each page.
+	return s.paginatePages(ctx, pageConfig{
+		endpoint:    "/forms",
+		label:       "forms",
+		pageSize:    maxPageSize,
+		intervalKey: "last_updated_at",
+	}, opts, results)
+}
+
+func (s *TypeformSource) readWorkspaces(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[TYPEFORM] reading workspaces")
+	return s.paginatePages(ctx, pageConfig{
+		endpoint: "/workspaces",
+		label:    "workspaces",
+		pageSize: maxPageSize,
+	}, opts, results)
+}
+
+func (s *TypeformSource) readThemes(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[TYPEFORM] reading themes")
+	return s.paginatePages(ctx, pageConfig{
+		endpoint: "/themes",
+		label:    "themes",
+		pageSize: maxPageSize,
+	}, opts, results)
+}
+
+func (s *TypeformSource) readResponses(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[TYPEFORM] reading responses")
+
+	formIDs, err := s.getAllFormIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	sem := make(chan struct{}, workerCount)
+	var mu sync.Mutex
+	var firstErr error
+
+	var wg sync.WaitGroup
+	for _, formID := range formIDs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(id string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if err := s.readFormResponses(ctx, id, opts, results); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(formID)
+	}
+
+	wg.Wait()
+	return firstErr
+}
+
+// readFormResponses walks a single form's responses using cursor pagination.
+// since/until filter server-side on submitted_at; before is the token cursor.
+func (s *TypeformSource) readFormResponses(ctx context.Context, formID string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	endpoint := fmt.Sprintf("/forms/%s/responses", formID)
+	before := ""
+	totalSent := 0
+
+	for page := 0; page < maxPages; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("page_size", strconv.Itoa(maxResponsePageSize))
+
+		if opts.IntervalStart != nil {
+			req.SetQueryParam("since", opts.IntervalStart.UTC().Format(time.RFC3339))
+		}
+		if opts.IntervalEnd != nil {
+			req.SetQueryParam("until", opts.IntervalEnd.UTC().Format(time.RFC3339))
+		}
+		if before != "" {
+			req.SetQueryParam("before", before)
+		}
+
+		resp, err := req.Get(endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch responses for form %s: %w", formID, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("typeform API %s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]interface{}
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse responses for form %s: %w", formID, err)
+		}
+
+		items := extractItems(body)
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			if _, exists := item["form_id"]; !exists {
+				item["form_id"] = formID
+			}
+		}
+
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert responses for form %s to Arrow: %w", formID, err)
+		}
+		results <- source.RecordBatchResult{Batch: record}
+		totalSent += len(items)
+		config.Debug("[TYPEFORM] form %s: sent %d responses (total: %d)", formID, len(items), totalSent)
+
+		if len(items) < maxResponsePageSize {
+			break
+		}
+
+		token, _ := items[len(items)-1]["token"].(string)
+		if token == "" || token == before {
+			break
+		}
+		before = token
+	}
+
+	return nil
+}
+
+func (s *TypeformSource) getAllFormIDs(ctx context.Context) ([]string, error) {
+	var formIDs []string
+	page := 1
+
+	for page <= maxPages {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		resp, err := s.client.R(ctx).
+			SetQueryParam("page", strconv.Itoa(page)).
+			SetQueryParam("page_size", strconv.Itoa(maxPageSize)).
+			Get("/forms")
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch forms for IDs: %w", err)
+		}
+		if !resp.IsSuccess() {
+			return nil, fmt.Errorf("typeform API /forms returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+
+		var body map[string]interface{}
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return nil, fmt.Errorf("failed to parse forms response: %w", err)
+		}
+
+		items := extractItems(body)
+		if len(items) == 0 {
+			break
+		}
+		for _, item := range items {
+			if id, ok := item["id"].(string); ok {
+				formIDs = append(formIDs, id)
+			}
+		}
+
+		pageCount := toInt(body["page_count"])
+		if pageCount > 0 && page >= pageCount {
+			break
+		}
+		if pageCount == 0 && len(items) < maxPageSize {
+			break
+		}
+		page++
+	}
+
+	config.Debug("[TYPEFORM] Found %d forms", len(formIDs))
+	return formIDs, nil
+}

--- a/pkg/source/typeform/typeform_test.go
+++ b/pkg/source/typeform/typeform_test.go
@@ -1,0 +1,174 @@
+package typeform
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		wantToken   string
+		wantAPIURL  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "valid URI",
+			uri:        "typeform://?token=my-token-123",
+			wantToken:  "my-token-123",
+			wantAPIURL: baseURL,
+		},
+		{
+			name:       "valid URI with eu region",
+			uri:        "typeform://?token=tok&region=eu",
+			wantToken:  "tok",
+			wantAPIURL: baseURLEU,
+		},
+		{
+			name:       "valid URI with us region",
+			uri:        "typeform://?token=tok&region=us",
+			wantToken:  "tok",
+			wantAPIURL: baseURL,
+		},
+		{
+			name:      "token with special characters",
+			uri:       "typeform://?token=aaa.bbb-ccc_ddd",
+			wantToken: "aaa.bbb-ccc_ddd",
+		},
+		{
+			name:        "wrong scheme",
+			uri:         "surveymonkey://?token=my-token",
+			wantErr:     true,
+			errContains: "must start with typeform://",
+		},
+		{
+			name:        "missing token",
+			uri:         "typeform://?other_param=value",
+			wantErr:     true,
+			errContains: "token is required",
+		},
+		{
+			name:        "empty URI after scheme",
+			uri:         "typeform://",
+			wantErr:     true,
+			errContains: "token is required",
+		},
+		{
+			name:        "only question mark",
+			uri:         "typeform://?",
+			wantErr:     true,
+			errContains: "token is required",
+		},
+		{
+			name:        "invalid region",
+			uri:         "typeform://?token=tok&region=au",
+			wantErr:     true,
+			errContains: "invalid region",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := parseURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errContains)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if creds.token != tt.wantToken {
+				t.Fatalf("expected token %q, got %q", tt.wantToken, creds.token)
+			}
+			if tt.wantAPIURL != "" && creds.apiURL != tt.wantAPIURL {
+				t.Fatalf("expected apiURL %q, got %q", tt.wantAPIURL, creds.apiURL)
+			}
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	validTables := []string{"forms", "responses", "workspaces", "themes"}
+	for _, table := range validTables {
+		if !isValidTable(table) {
+			t.Errorf("expected %q to be valid", table)
+		}
+	}
+
+	invalidTables := []string{"", "unknown", "FORMS", "Form", "users"}
+	for _, table := range invalidTables {
+		if isValidTable(table) {
+			t.Errorf("expected %q to be invalid", table)
+		}
+	}
+}
+
+func TestExtractItems(t *testing.T) {
+	t.Run("valid items array", func(t *testing.T) {
+		body := map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"id": "1"},
+				map[string]interface{}{"id": "2"},
+			},
+		}
+		items := extractItems(body)
+		if len(items) != 2 {
+			t.Fatalf("expected 2, got %d", len(items))
+		}
+	})
+
+	t.Run("missing items field", func(t *testing.T) {
+		body := map[string]interface{}{"other": "value"}
+		if items := extractItems(body); items != nil {
+			t.Fatalf("expected nil, got %v", items)
+		}
+	})
+
+	t.Run("empty items array", func(t *testing.T) {
+		body := map[string]interface{}{"items": []interface{}{}}
+		if items := extractItems(body); len(items) != 0 {
+			t.Fatalf("expected 0, got %d", len(items))
+		}
+	})
+}
+
+func TestToInt(t *testing.T) {
+	if got := toInt(json.Number("42")); got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+	if got := toInt(float64(7)); got != 7 {
+		t.Fatalf("expected 7, got %d", got)
+	}
+	if got := toInt("not a number"); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+	if got := toInt(nil); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}
+
+func TestJsonUseNumber(t *testing.T) {
+	var result map[string]interface{}
+	if err := jsonUseNumber([]byte(`{"id": 9007199254740993}`), &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	id, ok := result["id"].(json.Number)
+	if !ok {
+		t.Fatalf("expected json.Number, got %T", result["id"])
+	}
+	if id.String() != "9007199254740993" {
+		t.Fatalf("expected 9007199254740993, got %s", id.String())
+	}
+
+	if err := jsonUseNumber([]byte(`{"broken":`), &result); err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}


### PR DESCRIPTION
Adds a Typeform API source to ingestr.

## Tables

| Table | PK | Inc key | Strategy | Filtering |
|---|---|---|---|---|
| `forms` | `id` | `last_updated_at` | merge | client-side (`/forms` has no server-side time filter) |
| `responses` | `response_id` | `submitted_at` | merge | server-side `since`/`until`, cursor (`before`) pagination, fanned out per-form (5-worker pool) |
| `workspaces` | `id` | — | replace | full fetch |
| `themes` | `id` | — | replace | full fetch |

## URI

```
typeform://?token=<personal_access_token>       # optional &region=eu
```

## Notes

- Rate limiter: 1.6 req/s, burst 5 (Typeform's documented 2 req/s per account × 80%).
- Nested objects (settings, theme, answers, etc.) pass through as JSON via schema inference — nothing flattened.
- No time-window parallelism within a form (only per-form fan-out), since `before` is a cursor rather than a symmetric start/end filter, avoiding duplicate rows.

## Verification

Ran all four tables into DuckDB against a live account: `forms`, `responses`, `workspaces` (2), `themes` (41) all loaded with correct schemas — PKs (`id`, `response_id`) present and non-null, timestamps as `timestamptz`, nested fields as JSON.

## Incremental verification

Verified both incremental tables against a live account, table by table, using the three-scenario check (wide window / pre-data window / full load). Test account had 1 form and 5 responses.

| Table | Strategy | Inc key | Filtering | Wide window | Pre-data window (yr 2000) |
|-------|----------|---------|-----------|-------------|---------------------------|
| `forms` | merge | `last_updated_at` | client-side | 1 row | 0 rows |
| `responses` | merge | `submitted_at` | server-side (`since`/`until`) | 5 rows | 0 rows |

- **Covering window → full set**, **pre-data window → 0 rows** for both tables, confirming `--interval-start`/`--interval-end` are actually applied (notparsed-and-ignored).
- For `responses`, the 0-row pre-data window confirms the Typeform API honored the server-side `until=` filter; for `forms`, the client-side`last_updated_at` filter correctly excluded out-of-window records.
- `workspaces` and `themes` are `replace` (full refresh) — no incremental key, nothing to verify.