### PR TITLE
Add Lumify sports intelligence source

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,12 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Lumify</td>
+        <td>✅</td>
+        <td>-</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Mailchimp</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -239,6 +239,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Klaviyo", link: "/supported-sources/klaviyo.md" },
               { text: "Linear", link: "/supported-sources/linear.md" },
               { text: "LinkedIn Ads", link: "/supported-sources/linkedin_ads.md" },
+              { text: "Lumify", link: "/supported-sources/lumify.md" },
               { text: "Mailchimp", link: "/supported-sources/mailchimp.md" },
               { text: "Manifold", link: "/supported-sources/manifold.md" },
               { text: "Mixpanel", link: "/supported-sources/mixpanel.md" },

--- a/docs/supported-sources/lumify.md
+++ b/docs/supported-sources/lumify.md
@@ -1,0 +1,63 @@
+# Lumify
+
+[Lumify](https://lumify.ai) is an agent-ready sports intelligence API covering schedules, live scores, odds, betting splits, and explainable bet confidence across 8+ sports.
+
+`ingestr` supports Lumify as a keyed source for sports reference data and event windows.
+
+## URI format
+
+```plaintext
+lumify://?api_key=<api-key>&sport=nba
+```
+
+URI parameters:
+
+- `api_key`: Lumify API key (`lmfy-...`). Required. Get a free instant key (no signup) at [lumify.ai/docs/ai](https://lumify.ai/docs/ai), or create a persistent key at [lumify.ai/api-keys](https://lumify.ai/api-keys).
+- `sport`: Optional sport slug filter applied to `seasons`, `teams`, `players`, `events`, and `leagues` (for example `nba`, `nfl`, `mlb`, `nhl`, `soccer`, `tennis`, `golf`, `mma`).
+- `league`: Optional league slug filter applied to `teams` and `events`.
+- `base_url`: Overrides the API base URL. Defaults to `https://lumify.ai`.
+
+## Example
+
+Load NBA teams into DuckDB:
+
+```sh
+ingestr ingest \
+  --source-uri 'lumify://?api_key=<api-key>&sport=nba' \
+  --source-table 'teams' \
+  --dest-uri 'duckdb:///sports.duckdb' \
+  --dest-table 'lumify.teams'
+```
+
+Load events for a date window:
+
+```sh
+ingestr ingest \
+  --source-uri 'lumify://?api_key=<api-key>&sport=nba' \
+  --source-table 'events' \
+  --dest-uri 'duckdb:///sports.duckdb' \
+  --dest-table 'lumify.events' \
+  --interval-start '2026-07-01T00:00:00Z' \
+  --interval-end '2026-07-08T00:00:00Z'
+```
+
+## Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| --- | --- | --- | --- | --- |
+| `sports` | `id` | - | replace | Loads sports from `/v1/sports`. Nested `leagues` are kept as JSON. |
+| `leagues` | `id` | - | replace | Flattens nested leagues from `/v1/sports` and adds `sport_id`, `sport_slug`, and `sport_name`. |
+| `seasons` | `id` | - | replace | Loads seasons from `/v1/seasons`. Nested `sport` and `league` objects are kept as JSON. |
+| `teams` | `id` | - | replace | Loads paginated teams from `/v1/teams`. |
+| `players` | `id` | - | replace | Loads paginated players from `/v1/players`. |
+| `events` | `id` | - | merge | Loads events from `/v1/events` for an interval window, with `include_scores=true` so participants/scores are present. |
+
+Use these as the `--source-table` parameter in the `ingestr ingest` command.
+
+## Notes
+
+- The API key is sent as `Authorization: Bearer <api_key>`.
+- `teams`, `players`, and `events` handle Lumify `after_id` cursor pagination automatically.
+- `events` uses `--interval-start` / `--interval-end` when provided. If omitted, the source defaults to the last 7 days through now. Intervals longer than 90 days are chunked to match the Lumify API limit.
+- Each successful request consumes Lumify API credits. Prefer scoped `sport` / `league` filters and tight event intervals in production syncs.
+- Docs: [https://lumify.ai/docs](https://lumify.ai/docs) · OpenAPI: [https://lumify.ai/openapi.json](https://lumify.ai/openapi.json)

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -110,4 +110,5 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Frankfurter](/supported-sources/frankfurter.md)
 - [Internet Society Pulse](/supported-sources/isoc-pulse.md)
 - [Kalshi](/supported-sources/kalshi.md)
+- [Lumify](/supported-sources/lumify.md)
 - [Polymarket](/supported-sources/polymarket.md)

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -351,6 +351,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("klaviyo", "Klaviyo", []string{"klaviyo"}, true, false),
 		genericURIConnector("linear", "Linear", []string{"linear"}, true, false),
 		genericURIConnector("linkedinads", "LinkedIn Ads", []string{"linkedinads"}, true, false),
+		genericURIConnector("lumify", "Lumify", []string{"lumify"}, true, false),
 		genericURIConnector("mailchimp", "Mailchimp", []string{"mailchimp"}, true, false),
 		genericURIConnector("manifold", "Manifold", []string{"manifold"}, true, false),
 		genericURIConnector("maxcompute", "MaxCompute", []string{"maxcompute", "odps"}, true, true),

--- a/pkg/source/lumify/lumify.go
+++ b/pkg/source/lumify/lumify.go
@@ -1,0 +1,505 @@
+package lumify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	defaultBaseURL = "https://lumify.ai"
+	defaultPerPage = 100
+	// Free-tier keys allow ~20 req/min; stay under that with headroom.
+	rateLimit       = 0.25
+	rateLimitBurst  = 3
+	maxEventSpan    = 90 * 24 * time.Hour
+	defaultLookback = 7 * 24 * time.Hour
+)
+
+type tableKind string
+
+const (
+	kindSports  tableKind = "sports"
+	kindLeagues tableKind = "leagues"
+	kindSeasons tableKind = "seasons"
+	kindTeams   tableKind = "teams"
+	kindPlayers tableKind = "players"
+	kindEvents  tableKind = "events"
+)
+
+type tableConfig struct {
+	kind        tableKind
+	endpoint    string
+	listKey     string
+	primaryKeys []string
+	strategy    config.IncrementalStrategy
+	paginated   bool
+	dateWindow  bool
+}
+
+type LumifySource struct {
+	client  *httpclient.Client
+	apiKey  string
+	sport   string
+	league  string
+	baseURL string
+}
+
+func NewLumifySource() *LumifySource {
+	return &LumifySource{}
+}
+
+func (s *LumifySource) Schemes() []string {
+	return []string{"lumify"}
+}
+
+func (s *LumifySource) Connect(ctx context.Context, uri string) error {
+	apiKey, sport, league, baseURL, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.apiKey = apiKey
+	s.sport = sport
+	s.league = league
+	s.baseURL = baseURL
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithHeader("Authorization", "Bearer "+apiKey),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithDebug(config.DebugMode),
+	)
+	return nil
+}
+
+func parseURI(raw string) (apiKey, sport, league, baseURL string, err error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("failed to parse lumify URI: %w", err)
+	}
+	if parsed.Scheme != "lumify" {
+		return "", "", "", "", fmt.Errorf("invalid lumify URI: must start with lumify://")
+	}
+
+	values := parsed.Query()
+	apiKey = strings.TrimSpace(values.Get("api_key"))
+	if apiKey == "" {
+		return "", "", "", "", fmt.Errorf("invalid lumify URI: api_key query parameter is required")
+	}
+	// Accept either a bare key or a value that already includes the Bearer prefix.
+	apiKey = strings.TrimPrefix(apiKey, "Bearer ")
+	apiKey = strings.TrimPrefix(apiKey, "bearer ")
+
+	sport = strings.TrimSpace(values.Get("sport"))
+	league = strings.TrimSpace(values.Get("league"))
+
+	baseURL = strings.TrimRight(values.Get("base_url"), "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	return apiKey, sport, league, baseURL, nil
+}
+
+func (s *LumifySource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *LumifySource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *LumifySource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	cfg, ok := tables[req.Name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported table: %s, supported tables are: sports, leagues, seasons, teams, players, events", req.Name)
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:        req.Name,
+		TablePrimaryKeys: cfg.primaryKeys,
+		TableStrategy:    cfg.strategy,
+		KnownSchema:      false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("lumify source relies on schema inference")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, cfg, opts)
+		},
+	}, nil
+}
+
+func (s *LumifySource) read(ctx context.Context, cfg tableConfig, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 1)
+
+	go func() {
+		defer close(results)
+		var err error
+		switch cfg.kind {
+		case kindLeagues:
+			err = s.streamLeagues(ctx, opts, results)
+		default:
+			err = s.stream(ctx, cfg, opts, results)
+		}
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *LumifySource) stream(ctx context.Context, cfg tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if s.client == nil {
+		return fmt.Errorf("lumify source is not connected")
+	}
+	config.Debug("[LUMIFY] reading %s", cfg.endpoint)
+
+	perPage := defaultPerPage
+	if opts.PageSize > 0 && opts.PageSize < perPage {
+		perPage = opts.PageSize
+	}
+
+	windows := [][2]*time.Time{{nil, nil}}
+	if cfg.dateWindow {
+		var err error
+		windows, err = eventWindows(opts.IntervalStart, opts.IntervalEnd)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, window := range windows {
+		if err := s.streamWindow(ctx, cfg, opts, perPage, window[0], window[1], results); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *LumifySource) streamWindow(
+	ctx context.Context,
+	cfg tableConfig,
+	opts source.ReadOptions,
+	perPage int,
+	from, to *time.Time,
+	results chan<- source.RecordBatchResult,
+) error {
+	var afterID string
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var payload map[string]interface{}
+		req := s.client.R(ctx).SetResult(&payload)
+		if cfg.paginated {
+			req.SetQueryParam("limit", strconv.Itoa(perPage))
+			if afterID != "" {
+				req.SetQueryParam("after_id", afterID)
+			}
+		}
+		if s.sport != "" && (cfg.kind == kindSeasons || cfg.kind == kindTeams || cfg.kind == kindPlayers || cfg.kind == kindEvents) {
+			req.SetQueryParam("sport", s.sport)
+		}
+		if s.league != "" && (cfg.kind == kindTeams || cfg.kind == kindEvents) {
+			req.SetQueryParam("league", s.league)
+		}
+		if from != nil {
+			req.SetQueryParam("from", from.UTC().Format(time.RFC3339))
+		}
+		if to != nil {
+			req.SetQueryParam("to", to.UTC().Format(time.RFC3339))
+		}
+		if cfg.kind == kindEvents {
+			req.SetQueryParam("include_scores", "true")
+		}
+
+		resp, err := req.Get(cfg.endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch lumify endpoint %s: %w", cfg.endpoint, err)
+		}
+		if err := checkResponse(cfg.endpoint, resp); err != nil {
+			return err
+		}
+		if len(payload) == 0 {
+			if err := resp.JSON(&payload); err != nil {
+				return fmt.Errorf("malformed lumify response from %s: %w", cfg.endpoint, err)
+			}
+		}
+
+		pageItems, err := extractList(payload, cfg.listKey)
+		if err != nil {
+			return fmt.Errorf("malformed lumify response from %s: %w", cfg.endpoint, err)
+		}
+		if err := sendBatch(pageItems, opts, results); err != nil {
+			return err
+		}
+
+		if !cfg.paginated {
+			break
+		}
+		next := extractNextAfterID(payload)
+		if next == "" {
+			break
+		}
+		afterID = next
+	}
+	return nil
+}
+
+// streamLeagues reads /v1/sports and emits one row per nested league, promoting
+// parent sport identifiers onto each league row.
+func (s *LumifySource) streamLeagues(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if s.client == nil {
+		return fmt.Errorf("lumify source is not connected")
+	}
+	config.Debug("[LUMIFY] reading leagues from /v1/sports")
+
+	var payload map[string]interface{}
+	resp, err := s.client.R(ctx).SetResult(&payload).Get("/v1/sports")
+	if err != nil {
+		return fmt.Errorf("failed to fetch lumify endpoint /v1/sports: %w", err)
+	}
+	if err := checkResponse("/v1/sports", resp); err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		if err := resp.JSON(&payload); err != nil {
+			return fmt.Errorf("malformed lumify response from /v1/sports: %w", err)
+		}
+	}
+
+	sports, err := extractList(payload, "sports")
+	if err != nil {
+		return fmt.Errorf("malformed lumify response from /v1/sports: %w", err)
+	}
+
+	leagues := make([]map[string]interface{}, 0)
+	for _, sport := range sports {
+		sportID := sport["id"]
+		sportSlug, _ := sport["slug"].(string)
+		sportName, _ := sport["name"].(string)
+		rawLeagues, _ := sport["leagues"].([]interface{})
+		for i, raw := range rawLeagues {
+			league, ok := raw.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("sport leagues item %d is not an object", i)
+			}
+			row := normalizeMap(league)
+			row["sport_id"] = sportID
+			row["sport_slug"] = sportSlug
+			row["sport_name"] = sportName
+			if s.sport != "" && sportSlug != "" && !strings.EqualFold(sportSlug, s.sport) {
+				continue
+			}
+			leagues = append(leagues, row)
+		}
+	}
+	return sendBatch(leagues, opts, results)
+}
+
+func eventWindows(start, end *time.Time) ([][2]*time.Time, error) {
+	now := time.Now().UTC()
+	var from time.Time
+	var to time.Time
+	if start != nil {
+		from = start.UTC()
+	} else {
+		from = now.Add(-defaultLookback)
+	}
+	if end != nil {
+		to = end.UTC()
+	} else {
+		to = now
+	}
+	if to.Before(from) {
+		return nil, fmt.Errorf("invalid interval: end %s is before start %s", to.Format(time.RFC3339), from.Format(time.RFC3339))
+	}
+
+	windows := make([][2]*time.Time, 0)
+	cursor := from
+	for cursor.Before(to) || cursor.Equal(to) {
+		chunkEnd := cursor.Add(maxEventSpan)
+		if chunkEnd.After(to) {
+			chunkEnd = to
+		}
+		startCopy := cursor
+		endCopy := chunkEnd
+		windows = append(windows, [2]*time.Time{&startCopy, &endCopy})
+		if !chunkEnd.Before(to) {
+			break
+		}
+		// Advance just past the previous window end to avoid duplicate boundary rows.
+		cursor = chunkEnd.Add(time.Second)
+	}
+	if len(windows) == 0 {
+		windows = append(windows, [2]*time.Time{&from, &to})
+	}
+	return windows, nil
+}
+
+func sendBatch(items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert lumify data to Arrow: %w", err)
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}
+
+func checkResponse(endpoint string, resp *httpclient.Response) error {
+	if resp.IsSuccess() {
+		return nil
+	}
+	switch resp.StatusCode() {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("lumify API authentication failed for %s (status %d)", endpoint, resp.StatusCode())
+	case http.StatusPaymentRequired:
+		return fmt.Errorf("lumify API credits exhausted for %s (status 402)", endpoint)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("lumify API rate limit exceeded for %s (status 429)", endpoint)
+	default:
+		return fmt.Errorf("lumify API error for %s (status %d): %s", endpoint, resp.StatusCode(), resp.String())
+	}
+}
+
+func extractList(payload map[string]interface{}, key string) ([]map[string]interface{}, error) {
+	raw, ok := payload[key].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("missing %s array", key)
+	}
+	items := make([]map[string]interface{}, 0, len(raw))
+	for i, rawItem := range raw {
+		item, ok := rawItem.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s item %d is not an object", key, i)
+		}
+		items = append(items, normalizeMap(item))
+	}
+	return items, nil
+}
+
+func extractNextAfterID(payload map[string]interface{}) string {
+	next, ok := payload["next_after_id"]
+	if !ok || next == nil {
+		return ""
+	}
+	switch v := next.(type) {
+	case string:
+		return v
+	case float64:
+		if v == 0 {
+			return ""
+		}
+		return strconv.FormatInt(int64(v), 10)
+	case int:
+		if v == 0 {
+			return ""
+		}
+		return strconv.Itoa(v)
+	case int64:
+		if v == 0 {
+			return ""
+		}
+		return strconv.FormatInt(v, 10)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func normalizeMap(item map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(item))
+	for key, value := range item {
+		out[key] = normalizeValue(value)
+	}
+	return out
+}
+
+func normalizeValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case string:
+		if strings.EqualFold(strings.TrimSpace(v), "null") {
+			return nil
+		}
+		return v
+	case map[string]interface{}:
+		return normalizeMap(v)
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, item := range v {
+			out[i] = normalizeValue(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+var tables = map[string]tableConfig{
+	"sports": {
+		kind:        kindSports,
+		endpoint:    "/v1/sports",
+		listKey:     "sports",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+	},
+	"leagues": {
+		kind:        kindLeagues,
+		endpoint:    "/v1/sports",
+		listKey:     "sports",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+	},
+	"seasons": {
+		kind:        kindSeasons,
+		endpoint:    "/v1/seasons",
+		listKey:     "seasons",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+	},
+	"teams": {
+		kind:        kindTeams,
+		endpoint:    "/v1/teams",
+		listKey:     "data",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		paginated:   true,
+	},
+	"players": {
+		kind:        kindPlayers,
+		endpoint:    "/v1/players",
+		listKey:     "data",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyReplace,
+		paginated:   true,
+	},
+	"events": {
+		kind:        kindEvents,
+		endpoint:    "/v1/events",
+		listKey:     "events",
+		primaryKeys: []string{"id"},
+		strategy:    config.StrategyMerge,
+		paginated:   true,
+		dateWindow:  true,
+	},
+}
+
+var _ source.Source = (*LumifySource)(nil)

--- a/pkg/source/lumify/lumify.go
+++ b/pkg/source/lumify/lumify.go
@@ -24,6 +24,8 @@ const (
 	rateLimitBurst  = 3
 	maxEventSpan    = 90 * 24 * time.Hour
 	defaultLookback = 7 * 24 * time.Hour
+	// The events endpoint expects calendar dates, not RFC3339 timestamps.
+	dateFormat = "2006-01-02"
 )
 
 type tableKind string
@@ -220,10 +222,10 @@ func (s *LumifySource) streamWindow(
 			req.SetQueryParam("league", s.league)
 		}
 		if from != nil {
-			req.SetQueryParam("from", from.UTC().Format(time.RFC3339))
+			req.SetQueryParam("from", from.UTC().Format(dateFormat))
 		}
 		if to != nil {
-			req.SetQueryParam("to", to.UTC().Format(time.RFC3339))
+			req.SetQueryParam("to", to.UTC().Format(dateFormat))
 		}
 		if cfg.kind == kindEvents {
 			req.SetQueryParam("include_scores", "true")

--- a/pkg/source/lumify/lumify_test.go
+++ b/pkg/source/lumify/lumify_test.go
@@ -1,0 +1,240 @@
+package lumify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/registry"
+	"github.com/bruin-data/ingestr/pkg/schemainfer"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLumifyMissingAPIKey(t *testing.T) {
+	src := NewLumifySource()
+	err := src.Connect(context.Background(), "lumify://")
+	require.ErrorContains(t, err, "api_key")
+}
+
+func TestLumifyConnectStripsBearerPrefix(t *testing.T) {
+	src := NewLumifySource()
+	require.NoError(t, src.Connect(context.Background(), "lumify://?api_key=Bearer%20lmfy-test"))
+	require.Equal(t, "lmfy-test", src.apiKey)
+}
+
+func TestLumifyReadTeamsUsesAuthSportAndPagination(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/teams", r.URL.Path)
+		require.Equal(t, "Bearer lmfy-test", r.Header.Get("Authorization"))
+		require.Equal(t, "nba", r.URL.Query().Get("sport"))
+		requests = append(requests, r.URL.RawQuery)
+
+		switch r.URL.Query().Get("after_id") {
+		case "":
+			_, _ = fmt.Fprint(w, `{"data":[{"id":1,"slug":"lal","name":"Los Angeles Lakers","sport":"nba"}],"has_more":true,"next_after_id":1}`)
+		case "1":
+			_, _ = fmt.Fprint(w, `{"data":[{"id":2,"slug":"bos","name":"Boston Celtics","sport":"nba"}],"has_more":false,"next_after_id":null}`)
+		default:
+			t.Fatalf("unexpected after_id %q", r.URL.Query().Get("after_id"))
+		}
+	}))
+	defer server.Close()
+
+	src := NewLumifySource()
+	require.NoError(t, src.Connect(context.Background(), "lumify://?api_key=lmfy-test&sport=nba&base_url="+url.QueryEscape(server.URL)))
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, table.PrimaryKeys())
+	require.Equal(t, "replace", string(table.Strategy()))
+
+	records := readAll(t, table)
+	require.Len(t, requests, 2)
+	require.Len(t, records, 2)
+	require.EqualValues(t, 1, records[0].NumRows())
+	require.EqualValues(t, 1, records[1].NumRows())
+	require.Equal(t, "1", fmt.Sprint(decodeUnknown(t, records[0], "id", 0)))
+	require.Equal(t, "2", fmt.Sprint(decodeUnknown(t, records[1], "id", 0)))
+}
+
+func TestLumifyReadSportsPreservesNestedLeagues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/sports", r.URL.Path)
+		_, _ = fmt.Fprint(w, `{"sports":[{"id":1,"slug":"nba","name":"NBA","is_team_sport":true,"leagues":[{"id":10,"slug":"nba","name":"NBA","abbr":"NBA"}]}],"total":1}`)
+	}))
+	defer server.Close()
+
+	src := NewLumifySource()
+	require.NoError(t, src.Connect(context.Background(), "lumify://?api_key=lmfy-test&base_url="+url.QueryEscape(server.URL)))
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "sports"})
+	require.NoError(t, err)
+
+	record := readOnce(t, table)
+	require.EqualValues(t, 1, record.NumRows())
+	require.Subset(t, columnNames(record), []string{"id", "slug", "leagues"})
+	leagues := decodeUnknown(t, record, "leagues", 0).([]any)
+	require.Len(t, leagues, 1)
+	require.Equal(t, "NBA", leagues[0].(map[string]any)["name"])
+}
+
+func TestLumifyReadLeaguesFlattensNestedSport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/sports", r.URL.Path)
+		_, _ = fmt.Fprint(w, `{"sports":[{"id":1,"slug":"nba","name":"NBA","leagues":[{"id":10,"slug":"nba","name":"NBA"}]},{"id":2,"slug":"nfl","name":"NFL","leagues":[{"id":20,"slug":"nfl","name":"NFL"}]}],"total":2}`)
+	}))
+	defer server.Close()
+
+	src := NewLumifySource()
+	require.NoError(t, src.Connect(context.Background(), "lumify://?api_key=lmfy-test&sport=nba&base_url="+url.QueryEscape(server.URL)))
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "leagues"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, table.PrimaryKeys())
+
+	record := readOnce(t, table)
+	require.EqualValues(t, 1, record.NumRows())
+	require.Subset(t, columnNames(record), []string{"id", "slug", "sport_id", "sport_slug", "sport_name"})
+	require.Equal(t, "10", fmt.Sprint(decodeUnknown(t, record, "id", 0)))
+	require.Equal(t, "nba", fmt.Sprint(decodeUnknown(t, record, "sport_slug", 0)))
+}
+
+func TestLumifyReadEventsUsesDateWindowAndIncludeScores(t *testing.T) {
+	var gotFrom, gotTo, includeScores string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/events", r.URL.Path)
+		gotFrom = r.URL.Query().Get("from")
+		gotTo = r.URL.Query().Get("to")
+		includeScores = r.URL.Query().Get("include_scores")
+		_, _ = fmt.Fprint(w, `{"events":[{"id":99,"name":"Lakers vs Celtics","sport":"nba","starts_at":"2026-07-20T00:00:00Z","status":"scheduled","participants":[{"role":"home","name":"Lakers"}]}],"total":1,"next_after_id":null}`)
+	}))
+	defer server.Close()
+
+	src := NewLumifySource()
+	require.NoError(t, src.Connect(context.Background(), "lumify://?api_key=lmfy-test&base_url="+url.QueryEscape(server.URL)))
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "events"})
+	require.NoError(t, err)
+	require.Equal(t, "merge", string(table.Strategy()))
+
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	results, err := table.Read(context.Background(), source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	defer result.Batch.Release()
+
+	require.Equal(t, "2026-07-20T00:00:00Z", gotFrom)
+	require.Equal(t, "2026-07-21T00:00:00Z", gotTo)
+	require.Equal(t, "true", includeScores)
+	require.EqualValues(t, 1, result.Batch.NumRows())
+	require.Equal(t, "99", fmt.Sprint(decodeUnknown(t, result.Batch, "id", 0)))
+	participants := decodeUnknown(t, result.Batch, "participants", 0).([]any)
+	require.Equal(t, "Lakers", participants[0].(map[string]any)["name"])
+}
+
+func TestLumifyReadReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	src := NewLumifySource()
+	require.NoError(t, src.Connect(context.Background(), "lumify://?api_key=lmfy-test&base_url="+url.QueryEscape(server.URL)))
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "teams"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.ErrorContains(t, result.Err, "authentication failed")
+}
+
+func TestLumifyRegistryLookup(t *testing.T) {
+	constructor, err := registry.Default.GetSourceConstructor("lumify")
+	require.NoError(t, err)
+	src, ok := constructor().(source.Source)
+	require.True(t, ok)
+	require.NotNil(t, src)
+	require.Contains(t, src.Schemes(), "lumify")
+}
+
+func TestLumifyUnsupportedTable(t *testing.T) {
+	src := NewLumifySource()
+	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "odds"})
+	require.ErrorContains(t, err, "unsupported table")
+}
+
+func TestEventWindowsChunksLongIntervals(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	windows, err := eventWindows(&start, &end)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(windows), 2)
+	require.True(t, windows[0][0].Equal(start))
+	require.True(t, windows[len(windows)-1][1].Equal(end))
+}
+
+func readAll(t *testing.T, table source.SourceTable) []arrow.RecordBatch {
+	t.Helper()
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	var records []arrow.RecordBatch
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch != nil {
+			records = append(records, result.Batch)
+		}
+	}
+	t.Cleanup(func() {
+		for _, r := range records {
+			r.Release()
+		}
+	})
+	return records
+}
+
+func readOnce(t *testing.T, table source.SourceTable) arrow.RecordBatch {
+	t.Helper()
+	records := readAll(t, table)
+	require.Len(t, records, 1)
+	return records[0]
+}
+
+func columnNames(record arrow.RecordBatch) []string {
+	names := make([]string, 0, record.Schema().NumFields())
+	for _, f := range record.Schema().Fields() {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func decodeUnknown(t *testing.T, record arrow.RecordBatch, col string, row int) any {
+	t.Helper()
+	idx := -1
+	for i, f := range record.Schema().Fields() {
+		if f.Name == col {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqualf(t, idx, 0, "column %q not found", col)
+
+	ext, ok := record.Column(idx).(array.ExtensionArray)
+	require.Truef(t, ok, "column %q is not an extension array", col)
+	raw, ok := schemainfer.StringValueAt(ext.Storage(), row)
+	require.Truef(t, ok, "column %q storage is not string-backed", col)
+	value, err := schemainfer.DecodeUnknownValue(raw)
+	require.NoError(t, err)
+	return value
+}

--- a/pkg/source/lumify/lumify_test.go
+++ b/pkg/source/lumify/lumify_test.go
@@ -133,8 +133,8 @@ func TestLumifyReadEventsUsesDateWindowAndIncludeScores(t *testing.T) {
 	require.NoError(t, result.Err)
 	defer result.Batch.Release()
 
-	require.Equal(t, "2026-07-20T00:00:00Z", gotFrom)
-	require.Equal(t, "2026-07-21T00:00:00Z", gotTo)
+	require.Equal(t, "2026-07-20", gotFrom)
+	require.Equal(t, "2026-07-21", gotTo)
 	require.Equal(t, "true", includeScores)
 	require.EqualValues(t, 1, result.Batch.NumRows())
 	require.Equal(t, "99", fmt.Sprint(decodeUnknown(t, result.Batch, "id", 0)))

--- a/pkg/source/lumify/register.go
+++ b/pkg/source/lumify/register.go
@@ -1,0 +1,10 @@
+package lumify
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"lumify"},
+		func() interface{} { return NewLumifySource() },
+	)
+}


### PR DESCRIPTION
## Summary
- Adds a keyed `lumify://` source for [Lumify](https://lumify.ai), an agent-ready sports intelligence API (schedules, scores, odds context across 8+ sports).
- Tables: `sports`, `leagues`, `seasons`, `teams`, `players`, `events` (date-windowed with `after_id` pagination).
- Docs wired into README, VitePress sidebar, and the Sports platforms index.

## URI

```text
lumify://?api_key=<lmfy-...>&sport=nba
```

Free instant keys (no signup): https://lumify.ai/docs/ai

## Test plan
- [x] `go test ./pkg/source/lumify/ -count=1`
- [ ] Reviewer: optional live smoke with a free key:
  ```sh
  ingestr ingest \
    --source-uri 'lumify://?api_key=<key>&sport=nba' \
    --source-table 'teams' \
    --dest-uri 'duckdb:///tmp/lumify.duckdb' \
    --dest-table 'main.teams'
  ```


Made with [Cursor](https://cursor.com)