### PR TITLE
Harden SQL Server CDC and add destination-managed state

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2522,6 +2522,18 @@ func isPostgresCDCSource(rawURI string) bool {
 	return scheme == "postgres+cdc" || scheme == "postgresql+cdc"
 }
 
+func isMSSQLCDCSource(rawURI string) bool {
+	schemeEnd := strings.Index(rawURI, "://")
+	if schemeEnd == -1 {
+		return false
+	}
+	switch strings.ToLower(rawURI[:schemeEnd]) {
+	case "mssql+cdc", "sqlserver+cdc", "azuresql+cdc", "azure-sql+cdc":
+		return true
+	}
+	return false
+}
+
 func isMySQLCDCSource(rawURI string) bool {
 	schemeEnd := strings.Index(rawURI, "://")
 	if schemeEnd == -1 {
@@ -2775,6 +2787,16 @@ func validateManagedChangeConfig(cfg *config.IngestConfig) error {
 			}
 		}
 	}
+	if isMSSQLCDCSource(cfg.SourceURI) && !cfg.FullRefresh {
+		switch cfg.IncrementalStrategy {
+		case "", config.StrategyMerge, config.StrategyReplace:
+		default:
+			return &config.ValidationError{
+				Field:   "incremental-strategy",
+				Message: fmt.Sprintf("%q is not supported for SQL Server CDC; use merge or replace", cfg.IncrementalStrategy),
+			}
+		}
+	}
 	if isMySQLCDCSource(cfg.SourceURI) {
 		if !cfg.FullRefresh {
 			switch cfg.IncrementalStrategy {
@@ -2820,6 +2842,9 @@ func validateManagedChangeConfig(cfg *config.IngestConfig) error {
 	}
 	if isChangeTrackingSource(cfg.SourceURI) && cfg.SQLLimit > 0 {
 		return &config.ValidationError{Field: "sql-limit", Message: "is not supported for SQL Server Change Tracking sources because partial snapshots cannot safely advance the resume cursor"}
+	}
+	if isMSSQLCDCSource(cfg.SourceURI) && cfg.SQLLimit > 0 {
+		return &config.ValidationError{Field: "sql-limit", Message: "is not supported for SQL Server CDC sources; the snapshot and change stream must be read completely to keep the resume cursor safe"}
 	}
 	return nil
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -145,7 +145,15 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 
 	managedPostgresCDC := isPostgresCDCSource(p.config.SourceURI)
 	managedMySQLCDC := isMySQLCDCSource(p.config.SourceURI)
-	managedDestinationCDC := managedPostgresCDC || managedMySQLCDC
+	// SQL Server CDC joins destination-managed state only when the
+	// destination supports it; unlike the peers it keeps a legacy fallback
+	// (resume from MAX(_cdc_lsn) with completeness-encoded snapshot stamps)
+	// so destinations without state support keep working.
+	managedMSSQLCDC := isMSSQLCDCSource(p.config.SourceURI) && validateDestinationManagedCDCState(dest) == nil
+	if isMSSQLCDCSource(p.config.SourceURI) && !managedMSSQLCDC {
+		config.Debug("[PIPELINE] Destination %q does not support managed CDC state; SQL Server CDC uses destination-data resume", dest.GetScheme())
+	}
+	managedDestinationCDC := managedPostgresCDC || managedMySQLCDC || managedMSSQLCDC
 	if managedMySQLCDC {
 		if err := validateMySQLCDCSourceDestination(p.config, src, dest); err != nil {
 			return err
@@ -166,7 +174,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		}
 		p.cdcConnectorID = resolvedCDCStateConnectorID(p.config, postgresCDCIdentity, destinationIdentity)
 	} else if isCDCSource(p.config.SourceURI) {
-		if managedMySQLCDC {
+		if managedMySQLCDC || managedMSSQLCDC {
 			destinationTarget = managedCDCDestinationTarget(p.config, dest)
 		}
 		p.cdcConnectorID = genericCDCConnectorID(p.config)
@@ -904,7 +912,7 @@ func rejectUnprovenLegacyCDCTarget(ctx context.Context, dest destination.Destina
 	if position == "" {
 		return nil
 	}
-	return fmt.Errorf("destination table %q contains PostgreSQL CDC data at LSN %s, but no matching completed CDC state exists for source table %q; rerun with --full-refresh or restore the completed v1 CDC state before upgrading", destTable, position, sourceTable)
+	return fmt.Errorf("destination table %q contains CDC data at position %s, but no matching completed CDC state exists for source table %q; rerun with --full-refresh to let this connector adopt the target", destTable, position, sourceTable)
 }
 
 func (p *Pipeline) schemaFromColumnOverrides(table source.SourceTable) (*schema.TableSchema, error) {
@@ -1448,7 +1456,8 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 
 	var cdcStateManager *strategy.CDCStateManager
 	anchorTable := ""
-	if isPostgresCDCSource(p.config.SourceURI) || isMySQLCDCSource(p.config.SourceURI) {
+	managedMSSQLCDC := isMSSQLCDCSource(p.config.SourceURI) && validateDestinationManagedCDCState(p.dest) == nil
+	if isPostgresCDCSource(p.config.SourceURI) || isMySQLCDCSource(p.config.SourceURI) || managedMSSQLCDC {
 		for _, destTable := range tableDestNames {
 			if anchorTable == "" || destTable < anchorTable {
 				anchorTable = destTable

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -355,6 +355,48 @@ func TestMySQLCDCRejectsNonMergeIncrementalStrategies(t *testing.T) {
 	}
 }
 
+func TestMSSQLCDCRejectsNonMergeIncrementalStrategies(t *testing.T) {
+	for _, strategy := range []config.IncrementalStrategy{
+		config.StrategyAppend,
+		config.StrategyDeleteInsert,
+		config.StrategySCD2,
+		config.StrategyTruncateInsert,
+	} {
+		t.Run(string(strategy), func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.SourceURI = "mssql+cdc://source/app"
+			cfg.IncrementalStrategy = strategy
+			err := validateManagedChangeConfig(cfg)
+			require.ErrorContains(t, err, "not supported for SQL Server CDC")
+		})
+	}
+
+	for _, strategy := range []config.IncrementalStrategy{"", config.StrategyMerge, config.StrategyReplace} {
+		cfg := config.DefaultConfig()
+		cfg.SourceURI = "mssql+cdc://source/app"
+		cfg.IncrementalStrategy = strategy
+		require.NoError(t, validateManagedChangeConfig(cfg))
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "sqlserver+cdc://source/app"
+	cfg.IncrementalStrategy = config.StrategySCD2
+	cfg.FullRefresh = true
+	require.NoError(t, validateManagedChangeConfig(cfg), "full refresh bypasses CDC strategy limits like the peers")
+}
+
+func TestMSSQLCDCRejectsSQLLimit(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mssql+cdc://source/app"
+	cfg.SQLLimit = 10
+	err := validateManagedChangeConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sql-limit")
+
+	cfg.SQLLimit = 0
+	require.NoError(t, validateManagedChangeConfig(cfg))
+}
+
 func TestMySQLCDCRejectsUnsafeMetadataTransforms(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -792,6 +792,21 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	return record, rowCount, nil
 }
 
+// NormalizeUUIDValue converts the driver's raw uniqueidentifier
+// representation into its canonical string form, honoring the connection's
+// "guid conversion" byte-order setting. Shared with the CDC source, which
+// scans the same driver values.
+func NormalizeUUIDValue(val interface{}, guidConversion bool) (interface{}, error) {
+	return normalizeUUIDValue(val, guidConversion)
+}
+
+// GUIDConversionEnabled reports whether the connection string enables the
+// go-mssqldb "guid conversion" setting, which changes uniqueidentifier byte
+// order on the wire.
+func GUIDConversionEnabled(connStr string) bool {
+	return guidConversionEnabled(connStr)
+}
+
 func normalizeUUIDValue(val interface{}, guidConversion bool) (interface{}, error) {
 	switch v := val.(type) {
 	case nil:

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -92,6 +92,9 @@ type MSSQLCDCSource struct {
 	lag            *mssqlLagState
 	health         captureHealth
 	guidConversion bool
+
+	stateMu sync.Mutex
+	state   source.CDCStateCommitToken
 }
 
 // captureHealth throttles capture-job error probes and deduplicates the
@@ -211,12 +214,15 @@ type tableMetadata struct {
 }
 
 type CDCTable struct {
-	source      *MSSQLCDCSource
-	tableName   string
-	metadata    tableMetadata
-	tableSchema *schema.TableSchema
-	primaryKeys []string
-	strategy    config.IncrementalStrategy
+	source    *MSSQLCDCSource
+	tableName string
+	// requestedName is the table name the pipeline asked for, which is the
+	// key it registers CDC state under; state recording must use it verbatim.
+	requestedName string
+	metadata      tableMetadata
+	tableSchema   *schema.TableSchema
+	primaryKeys   []string
+	strategy      config.IncrementalStrategy
 }
 
 func NewMSSQLCDCSource() *MSSQLCDCSource {
@@ -419,12 +425,13 @@ func (s *MSSQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) 
 	}
 
 	return &CDCTable{
-		source:      s,
-		tableName:   tableName(meta),
-		metadata:    meta,
-		tableSchema: tableSchema,
-		primaryKeys: pks,
-		strategy:    strategy,
+		source:        s,
+		tableName:     tableName(meta),
+		requestedName: req.Name,
+		metadata:      meta,
+		tableSchema:   tableSchema,
+		primaryKeys:   pks,
+		strategy:      strategy,
 	}, nil
 }
 
@@ -521,11 +528,22 @@ func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInf
 			continue
 		}
 
+		incarnation, err := s.TableIncarnation(ctx, tableName(meta))
+		if err != nil {
+			return nil, nil, err
+		}
+		fingerprint, err := s.TableSchemaFingerprint(ctx, tableName(meta))
+		if err != nil {
+			return nil, nil, err
+		}
+
 		tables = append(tables, source.SourceTableInfo{
-			Name:        tableName(meta),
-			Schema:      tableSchema,
-			PrimaryKeys: tableSchema.PrimaryKeys,
-			DestSchema:  s.cdcConfig.DestSchema,
+			Name:              tableName(meta),
+			Schema:            tableSchema,
+			PrimaryKeys:       tableSchema.PrimaryKeys,
+			DestSchema:        s.cdcConfig.DestSchema,
+			Incarnation:       incarnation,
+			SchemaFingerprint: fingerprint,
 		})
 	}
 
@@ -545,6 +563,7 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 		return nil, err
 	}
 
+	s.resetCDCState()
 	results := make(chan source.RecordBatchResult, 16)
 	go func() {
 		defer close(results)
@@ -586,6 +605,10 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 				return
 			}
 			startByTable[table.Name] = snapshotLSN
+			s.recordSnapshotState(table.Name, snapshotCompleteLSN(snapshotLSN))
+			if err := s.emitStateToken(ctx, opts.ReadOptions, results, table.Name); err != nil {
+				return
+			}
 		}
 
 		if err := s.streamTables(ctx, selected, metaByTable, startByTable, reReadByTable, opts.ReadOptions, results); err != nil {
@@ -922,6 +945,7 @@ func (t *CDCTable) GetSchema(ctx context.Context) (*schema.TableSchema, error) {
 }
 
 func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	t.source.resetCDCState()
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -951,6 +975,10 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 		snapshotLSN, err := t.source.snapshotTable(ctx, t.metadata, t.tableSchema, opts, results, "")
 		if err != nil {
 			_ = emitResult(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)})
+			return
+		}
+		t.source.recordSnapshotState(t.requestedName, snapshotCompleteLSN(snapshotLSN))
+		if err := t.source.emitStateToken(ctx, opts, results, ""); err != nil {
 			return
 		}
 
@@ -1195,6 +1223,7 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		inclusiveByTable[table.Name] = true
 	}
 	transientFailures := make(map[string]int, len(tables))
+	lastCheckpointLSN := ""
 	for {
 		if opts.Streaming {
 			s.checkCaptureHealth(ctx)
@@ -1250,6 +1279,16 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 				return err
 			}
 			continue
+		}
+
+		// Every table has been read through targetLSN, so it is the globally
+		// safe position for this stream.
+		if targetLSN != lastCheckpointLSN {
+			s.recordCheckpointState(watermarkStoredLSN(targetLSN))
+			if err := s.emitStateToken(ctx, opts, results, ""); err != nil {
+				return err
+			}
+			lastCheckpointLSN = targetLSN
 		}
 
 		if !opts.Streaming {
@@ -1330,6 +1369,10 @@ func (s *MSSQLCDCSource) streamTable(ctx context.Context, meta tableMetadata, ta
 			inclusive = false
 			reReadBoundary = false
 			current = targetLSN
+			s.recordCheckpointState(watermarkStoredLSN(current))
+			if err := s.emitStateToken(ctx, opts, results, resultTable); err != nil {
+				return err
+			}
 		}
 
 		if !opts.Streaming {

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -532,7 +532,9 @@ func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInf
 		if err != nil {
 			return nil, nil, err
 		}
-		fingerprint, err := s.TableSchemaFingerprint(ctx, tableName(meta))
+		// Fingerprint the metadata this listing selected: multi-table reads
+		// ignore the configured capture_instance, so the fingerprint must too.
+		fingerprint, err := s.fingerprintCaptureInstance(ctx, meta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1216,11 +1218,12 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 	if opts.Streaming {
 		s.health.reset(time.Now())
 	}
-	// Each table's initial position (a resume cursor or a snapshot stamp) may
-	// sit mid-transaction, so the first read includes it; see streamTable.
+	// Only change-row resume cursors may sit mid-transaction and need an
+	// inclusive first read; snapshot stamps already cover their LSN. See
+	// streamTable.
 	inclusiveByTable := make(map[string]bool, len(tables))
 	for _, table := range tables {
-		inclusiveByTable[table.Name] = true
+		inclusiveByTable[table.Name] = reReadByTable[table.Name]
 	}
 	transientFailures := make(map[string]int, len(tables))
 	lastCheckpointLSN := ""
@@ -1328,14 +1331,13 @@ func (s *MSSQLCDCSource) streamTable(ctx context.Context, meta tableMetadata, ta
 		s.health.reset(time.Now())
 	}
 	current := startLSN
-	// The initial position may sit mid-transaction: a resume cursor names the
-	// destination's last durable change row, whose transaction can continue
-	// past it, and a snapshot stamp must re-deliver changes at the boundary
-	// LSN. The first read therefore includes the position; merge is idempotent
-	// for the rows this re-delivers. Once the stream has advanced to a harvest
-	// watermark, everything at that LSN has been delivered, so later polls
-	// start strictly after it.
-	inclusive := true
+	// Only a change-row resume cursor may sit mid-transaction: its transaction
+	// can continue past the stored row, so the first read includes the
+	// position and merge absorbs the re-delivered rows. A snapshot stamp or a
+	// delivered watermark already covers everything at its LSN, so the first
+	// read starts strictly after it — an inclusive read there would re-deliver
+	// whole transactions as change rows for no benefit.
+	inclusive := reReadBoundary
 	transientFailures := 0
 	for {
 		if opts.Streaming {

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -41,6 +41,12 @@ const (
 	// change reads are retried per table before the failure is treated as
 	// permanent.
 	maxTransientReadFailures = 20
+
+	// captureHealthInterval throttles the best-effort sys.dm_cdc_errors
+	// probe that surfaces capture-job failures during streaming. Without it
+	// a dead capture job freezes the harvest watermark and the stream reads
+	// as caught up while the source backlog grows.
+	captureHealthInterval = 5 * time.Minute
 )
 
 func sleepPoll(ctx context.Context, interval time.Duration) error {
@@ -69,7 +75,63 @@ type MSSQLCDCSource struct {
 	uri            string
 	cdcConfig      CDCConfig
 	lag            *mssqlLagState
+	health         captureHealth
 	guidConversion bool
+}
+
+// captureHealth throttles capture-job error probes and deduplicates the
+// warnings they produce. Only errors recorded after the stream started are
+// reported, each once.
+type captureHealth struct {
+	mu            sync.Mutex
+	nextCheck     time.Time
+	warnedThrough time.Time
+}
+
+func (h *captureHealth) reset(now time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.nextCheck = now.Add(captureHealthInterval)
+	h.warnedThrough = now
+}
+
+func (h *captureHealth) shouldCheck(now time.Time) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if now.Before(h.nextCheck) {
+		return false
+	}
+	h.nextCheck = now.Add(captureHealthInterval)
+	return true
+}
+
+func (h *captureHealth) claimWarn(entry time.Time) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !entry.After(h.warnedThrough) {
+		return false
+	}
+	h.warnedThrough = entry
+	return true
+}
+
+// checkCaptureHealth surfaces capture-job failures recorded in
+// sys.dm_cdc_errors. Best-effort: a missing VIEW DATABASE STATE permission or
+// an empty view stays silent.
+func (s *MSSQLCDCSource) checkCaptureHealth(ctx context.Context) {
+	if !s.health.shouldCheck(time.Now()) {
+		return
+	}
+	var entryTime sql.NullTime
+	var message sql.NullString
+	err := s.db.QueryRowContext(ctx, "SELECT TOP (1) entry_time, error_message FROM sys.dm_cdc_errors ORDER BY entry_time DESC").Scan(&entryTime, &message)
+	if err != nil || !entryTime.Valid {
+		return
+	}
+	if !s.health.claimWarn(entryTime.Time) {
+		return
+	}
+	output.Warnf("Warning: SQL Server CDC capture job error at %s: %s\n", entryTime.Time.Format(time.RFC3339), strings.TrimSpace(message.String))
 }
 
 // mssqlLagState holds the last observed capture watermark and how far behind the
@@ -262,6 +324,14 @@ func (s *MSSQLCDCSource) Connect(ctx context.Context, uri string) error {
 	if !cdcEnabled {
 		_ = db.Close()
 		return fmt.Errorf("SQL Server CDC is not enabled for the current database; run sys.sp_cdc_enable_db first")
+	}
+
+	// A NULL harvest watermark means the capture job has never processed the
+	// log — the most common cause is SQL Server Agent not running, which
+	// otherwise reads as an eternally idle, "caught up" stream.
+	var watermark sql.NullString
+	if err := db.QueryRowContext(ctx, "SELECT CONVERT(varchar(20), sys.fn_cdc_get_max_lsn(), 2)").Scan(&watermark); err == nil && !watermark.Valid {
+		output.Warnf("Warning: SQL Server CDC has not harvested any changes yet; ensure the CDC capture job is running (SQL Server Agent on self-hosted instances)\n")
 	}
 
 	s.db = db
@@ -1049,6 +1119,9 @@ func lowestLSN(byTable map[string]string) string {
 
 func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.SourceTableInfo, metas map[string]tableMetadata, startByTable map[string]string, reReadByTable map[string]bool, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	s.lag.streaming.Store(opts.Streaming)
+	if opts.Streaming {
+		s.health.reset(time.Now())
+	}
 	// Each table's initial position (a resume cursor or a snapshot stamp) may
 	// sit mid-transaction, so the first read includes it; see streamTable.
 	inclusiveByTable := make(map[string]bool, len(tables))
@@ -1057,6 +1130,9 @@ func (s *MSSQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 	}
 	transientFailures := make(map[string]int, len(tables))
 	for {
+		if opts.Streaming {
+			s.checkCaptureHealth(ctx)
+		}
 		targetLSN, err := s.maxLSN(ctx)
 		if err != nil {
 			return err
@@ -1143,6 +1219,9 @@ func planChangeWindow(start, target string, reReadBoundary bool) (string, bool) 
 
 func (s *MSSQLCDCSource) streamTable(ctx context.Context, meta tableMetadata, tableSchema *schema.TableSchema, startLSN string, reReadBoundary bool, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) error {
 	s.lag.streaming.Store(opts.Streaming)
+	if opts.Streaming {
+		s.health.reset(time.Now())
+	}
 	current := startLSN
 	// The initial position may sit mid-transaction: a resume cursor names the
 	// destination's last durable change row, whose transaction can continue
@@ -1154,6 +1233,9 @@ func (s *MSSQLCDCSource) streamTable(ctx context.Context, meta tableMetadata, ta
 	inclusive := true
 	transientFailures := 0
 	for {
+		if opts.Streaming {
+			s.checkCaptureHealth(ctx)
+		}
 		targetLSN, err := s.maxLSN(ctx)
 		if err != nil {
 			return err

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -63,10 +63,11 @@ type CDCConfig struct {
 }
 
 type MSSQLCDCSource struct {
-	db        *sql.DB
-	uri       string
-	cdcConfig CDCConfig
-	lag       *mssqlLagState
+	db             *sql.DB
+	uri            string
+	cdcConfig      CDCConfig
+	lag            *mssqlLagState
+	guidConversion bool
 }
 
 // mssqlLagState holds the last observed capture watermark and how far behind the
@@ -235,6 +236,7 @@ func (s *MSSQLCDCSource) Connect(ctx context.Context, uri string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL Server URI: %w", err)
 	}
+	s.guidConversion = mssql.GUIDConversionEnabled(connStr)
 
 	db, err := sql.Open(driverName, connStr)
 	if err != nil {
@@ -1120,7 +1122,7 @@ func (s *MSSQLCDCSource) rowsToSnapshotBatches(rows *sql.Rows, tableSchema *sche
 	syncedAt := time.Now().UTC()
 
 	for {
-		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, func(builders []array.Builder) {
+		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, s.guidConversion, func(builders []array.Builder) {
 			appendCDCValues(builders, len(sourceColumns), cdcLSN, false, syncedAt)
 		})
 		if err != nil {
@@ -1147,7 +1149,7 @@ func (s *MSSQLCDCSource) rowsToChangeBatches(rows *sql.Rows, tableSchema *schema
 	}
 
 	for {
-		record, count, err := buildChangeBatch(rows, tableSchema, sourceColumns, batchSize, syncedAt, pairer)
+		record, count, err := buildChangeBatch(rows, tableSchema, sourceColumns, batchSize, s.guidConversion, syncedAt, pairer)
 		if err != nil {
 			return err
 		}
@@ -1278,7 +1280,21 @@ func cdcValueEqual(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
+// normalizeSourceValue converts driver-specific representations into the
+// values the Arrow builders expect. uniqueidentifier arrives as raw bytes
+// whose order depends on the connection's "guid conversion" setting.
+func normalizeSourceValue(col schema.Column, val any, guidConversion bool) (any, error) {
+	if col.DataType != schema.TypeUUID {
+		return val, nil
+	}
+	normalized, err := mssql.NormalizeUUIDValue(val, guidConversion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert uniqueidentifier column %q: %w", col.Name, err)
+	}
+	return normalized, nil
+}
+
+func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, guidConversion bool, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	arrowSchema := buildArrowSchema(tableSchema.Columns)
 
@@ -1300,7 +1316,12 @@ func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns [
 		}
 
 		for i, dest := range scanDest {
-			arrowconv.AppendValue(builders[i], *dest.(*any))
+			val, err := normalizeSourceValue(sourceColumns[i], *dest.(*any), guidConversion)
+			if err != nil {
+				releaseBuilders(builders)
+				return nil, 0, err
+			}
+			arrowconv.AppendValue(builders[i], val)
 		}
 		appendCDC(builders)
 
@@ -1313,7 +1334,7 @@ func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns [
 	return finishBatch(rows, arrowSchema, builders, rowCount)
 }
 
-func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, syncedAt time.Time, pairer *updatePairer) (arrow.RecordBatch, int64, error) {
+func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, guidConversion bool, syncedAt time.Time, pairer *updatePairer) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	arrowSchema := buildArrowSchema(tableSchema.Columns)
 
@@ -1337,7 +1358,12 @@ func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceCol
 
 		values := make([]any, len(sourceColumns))
 		for i := range values {
-			values[i] = *scanDest[i].(*any)
+			val, err := normalizeSourceValue(sourceColumns[i], *scanDest[i].(*any), guidConversion)
+			if err != nil {
+				releaseBuilders(builders)
+				return nil, 0, err
+			}
+			values[i] = val
 		}
 		lsn := fmt.Sprintf("%v", *scanDest[len(sourceColumns)].(*any))
 		op, err := operationValue(*scanDest[len(sourceColumns)+1].(*any))

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -882,8 +882,22 @@ func (s *MSSQLCDCSource) snapshotTable(ctx context.Context, meta tableMetadata, 
 	if err == nil {
 		return snapshotLSN, nil
 	}
-	config.Debug("[MSSQL CDC] SNAPSHOT isolation snapshot failed for %s: %v; retrying with table lock", tableName(meta), err)
+	// Only fall back when the database rejects SNAPSHOT isolation outright.
+	// Retrying every failure (a mid-scan network error, a cancelled context)
+	// would rescan the whole table under HOLDLOCK, holding shared locks on a
+	// live table for no benefit.
+	if !isSnapshotIsolationUnavailableError(err) {
+		return "", err
+	}
+	config.Debug("[MSSQL CDC] SNAPSHOT isolation is not allowed for this database (%v); retrying snapshot of %s with a table lock", err, tableName(meta))
 	return s.snapshotTableWithIsolation(ctx, meta, tableSchema, opts, results, resultTable, sql.LevelSerializable)
+}
+
+// isSnapshotIsolationUnavailableError matches error 3952: the database does
+// not allow SNAPSHOT isolation (ALLOW_SNAPSHOT_ISOLATION is OFF).
+func isSnapshotIsolationUnavailableError(err error) bool {
+	var sqlErr mssqldb.Error
+	return errors.As(err, &sqlErr) && sqlErr.Number == 3952
 }
 
 func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta tableMetadata, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string, isolation sql.IsolationLevel) (string, error) {
@@ -952,6 +966,16 @@ func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta ta
 	}
 
 	return snapshotLSN, nil
+}
+
+// isInvalidLSNRangeError matches error 313, which fn_cdc_get_all_changes
+// raises with a famously misleading message ("an insufficient number of
+// arguments were supplied") when the requested window falls outside the
+// capture instance's valid LSN range — in practice, when cleanup advanced the
+// low watermark past the cursor mid-stream.
+func isInvalidLSNRangeError(err error) bool {
+	var sqlErr mssqldb.Error
+	return errors.As(err, &sqlErr) && sqlErr.Number == 313
 }
 
 // isTransientMSSQLError reports errors SQL Server tells the client to retry:
@@ -1184,6 +1208,9 @@ func (s *MSSQLCDCSource) readChanges(ctx context.Context, meta tableMetadata, ta
 	query := buildChangesQuery(meta, sourceColumns, inclusive)
 	rows, err := s.db.QueryContext(ctx, query, fromLSN, toLSN)
 	if err != nil {
+		if isInvalidLSNRangeError(err) {
+			return fmt.Errorf("CDC changes for %s from LSN %s are no longer available: change-table cleanup advanced past the cursor (retention exceeded); the next run will take a fresh snapshot: %w", tableName(meta), fromLSN, err)
+		}
 		return fmt.Errorf("failed to query CDC changes for %s: %w", tableName(meta), err)
 	}
 	defer func() { _ = rows.Close() }()

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -323,9 +323,14 @@ func (s *MSSQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) 
 	}
 	tableSchema.PrimaryKeys = pks
 
+	// Replace resolves to merge outside full-refresh runs, matching the
+	// pipeline's managed-change resolution. Anything else cannot represent
+	// CDC deletes and boundary re-deliveries correctly.
 	strategy := config.StrategyMerge
-	if req.Strategy != "" && req.Strategy != config.StrategyReplace {
-		strategy = req.Strategy
+	switch req.Strategy {
+	case "", config.StrategyMerge, config.StrategyReplace:
+	default:
+		return nil, fmt.Errorf("incremental strategy %q is not supported for SQL Server CDC; use merge or replace", req.Strategy)
 	}
 
 	return &CDCTable{

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -341,23 +343,92 @@ func (s *MSSQLCDCSource) IsMultiTable() bool {
 }
 
 func (s *MSSQLCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
-	metas, err := s.getAllTableMetadata(ctx)
+	if s.cdcConfig.CaptureInstance != "" {
+		output.Warnf("Warning: capture_instance is ignored in multi-table SQL Server CDC mode; the newest capture instance of each table is used\n")
+	}
+	tables, skipped, err := s.getTables(ctx)
 	if err != nil {
 		return nil, err
 	}
+	for _, st := range skipped {
+		output.Warnf("Warning: skipping SQL Server CDC table %s: %s\n", st.name, st.reason)
+	}
+	return tables, nil
+}
+
+type skippedTable struct {
+	name   string
+	reason string
+}
+
+// selectTables applies the requested-table filter. A filter entry that
+// matches nothing is a hard error: silently ingesting nothing (and, in
+// streaming mode, polling forever) would hide a typo or an unqualified
+// table name.
+func selectTables(allTables []source.SourceTableInfo, skipped []skippedTable, requested []string) ([]source.SourceTableInfo, error) {
+	filter := map[string]string{}
+	for _, table := range requested {
+		table = strings.TrimSpace(table)
+		if table == "" {
+			continue
+		}
+		filter[strings.ToLower(table)] = table
+	}
+	filtered := len(filter) > 0
+
+	selected := make([]source.SourceTableInfo, 0, len(allTables))
+	for _, table := range allTables {
+		key := strings.ToLower(table.Name)
+		if filtered && filter[key] == "" {
+			continue
+		}
+		delete(filter, key)
+		selected = append(selected, table)
+	}
+
+	for _, st := range skipped {
+		if requestedName, ok := filter[strings.ToLower(st.name)]; ok {
+			return nil, fmt.Errorf("SQL Server CDC table %s cannot be ingested: %s", requestedName, st.reason)
+		}
+	}
+	if len(filter) > 0 {
+		missing := make([]string, 0, len(filter))
+		for _, requestedName := range filter {
+			missing = append(missing, requestedName)
+		}
+		sort.Strings(missing)
+		return nil, fmt.Errorf("tables not found among SQL Server CDC-enabled tables: %s; use schema-qualified names (e.g. dbo.users)", strings.Join(missing, ", "))
+	}
+	return selected, nil
+}
+
+// getTables lists ingestible CDC-enabled tables. Tables that cannot join a
+// multi-table run (no primary key, so merge has nothing to apply changes by)
+// are returned separately instead of failing the run: one such table anywhere
+// in the database must not block ingesting the others.
+func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInfo, []skippedTable, error) {
+	metas, err := s.getAllTableMetadata(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(metas) == 0 {
-		return nil, fmt.Errorf("no SQL Server CDC-enabled tables found")
+		return nil, nil, fmt.Errorf("no SQL Server CDC-enabled tables found")
 	}
 
 	tables := make([]source.SourceTableInfo, 0, len(metas))
+	var skipped []skippedTable
 	for _, meta := range metas {
 		tableSchema, err := s.getCapturedSchema(ctx, meta)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get schema for %s: %w", tableName(meta), err)
+			return nil, nil, fmt.Errorf("failed to get schema for %s: %w", tableName(meta), err)
 		}
 		tableSchema = addCDCColumns(tableSchema)
 		if len(tableSchema.PrimaryKeys) == 0 {
-			return nil, fmt.Errorf("SQL Server CDC table %s has no primary key; multi-table CDC requires source primary keys", tableName(meta))
+			skipped = append(skipped, skippedTable{
+				name:   tableName(meta),
+				reason: "it has no primary key; add one, or ingest it alone with --source-table and --primary-key",
+			})
+			continue
 		}
 
 		tables = append(tables, source.SourceTableInfo{
@@ -368,26 +439,20 @@ func (s *MSSQLCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInf
 		})
 	}
 
-	return tables, nil
+	if len(tables) == 0 {
+		return nil, skipped, fmt.Errorf("no SQL Server CDC-enabled tables with a primary key found")
+	}
+	return tables, skipped, nil
 }
 
 func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
-	allTables, err := s.GetTables(ctx)
+	allTables, skipped, err := s.getTables(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	filter := map[string]bool{}
-	for _, table := range opts.Tables {
-		filter[strings.ToLower(table)] = true
-	}
-
-	selected := make([]source.SourceTableInfo, 0, len(allTables))
-	for _, table := range allTables {
-		if len(filter) > 0 && !filter[strings.ToLower(table.Name)] {
-			continue
-		}
-		selected = append(selected, table)
+	selected, err := selectTables(allTables, skipped, opts.Tables)
+	if err != nil {
+		return nil, err
 	}
 
 	results := make(chan source.RecordBatchResult, 16)

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -973,19 +973,41 @@ func (s *MSSQLCDCSource) canResume(ctx context.Context, meta tableMetadata, star
 }
 
 func (s *MSSQLCDCSource) snapshotTable(ctx context.Context, meta tableMetadata, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) (string, error) {
-	snapshotLSN, err := s.snapshotTableWithIsolation(ctx, meta, tableSchema, opts, results, resultTable, sql.LevelSnapshot)
-	if err == nil {
-		return snapshotLSN, nil
-	}
-	// Only fall back when the database rejects SNAPSHOT isolation outright.
-	// Retrying every failure (a mid-scan network error, a cancelled context)
-	// would rescan the whole table under HOLDLOCK, holding shared locks on a
-	// live table for no benefit.
-	if !isSnapshotIsolationUnavailableError(err) {
+	// Probe instead of try-and-fall-back: a failed SNAPSHOT attempt leaves
+	// the session isolation level set on the pooled connection (SQL Server
+	// scopes SET TRANSACTION ISOLATION LEVEL to the session, not the
+	// transaction), poisoning later queries with error 3952.
+	useSnapshot, err := s.snapshotIsolationAllowed(ctx)
+	if err != nil {
 		return "", err
 	}
-	config.Debug("[MSSQL CDC] SNAPSHOT isolation is not allowed for this database (%v); retrying snapshot of %s with a table lock", err, tableName(meta))
+	if useSnapshot {
+		snapshotLSN, err := s.snapshotTableWithIsolation(ctx, meta, tableSchema, opts, results, resultTable, sql.LevelSnapshot)
+		if err == nil {
+			return snapshotLSN, nil
+		}
+		// Only fall back when the database rejected SNAPSHOT isolation after
+		// all (the setting can flip between probe and scan). Retrying every
+		// failure would rescan the whole table under HOLDLOCK, holding shared
+		// locks on a live table for no benefit.
+		if !isSnapshotIsolationUnavailableError(err) {
+			return "", err
+		}
+		config.Debug("[MSSQL CDC] SNAPSHOT isolation became unavailable (%v); retrying snapshot of %s with a table lock", err, tableName(meta))
+	} else {
+		config.Debug("[MSSQL CDC] Snapshot isolation is not allowed for this database; snapshotting %s with a table lock", tableName(meta))
+	}
 	return s.snapshotTableWithIsolation(ctx, meta, tableSchema, opts, results, resultTable, sql.LevelSerializable)
+}
+
+// snapshotIsolationAllowed reports whether the database permits SNAPSHOT
+// isolation (sys.databases.snapshot_isolation_state = 1).
+func (s *MSSQLCDCSource) snapshotIsolationAllowed(ctx context.Context) (bool, error) {
+	var state int
+	if err := s.db.QueryRowContext(ctx, "SELECT CONVERT(int, snapshot_isolation_state) FROM sys.databases WHERE database_id = DB_ID()").Scan(&state); err != nil {
+		return false, fmt.Errorf("failed to check snapshot isolation state: %w", err)
+	}
+	return state == 1, nil
 }
 
 // isSnapshotIsolationUnavailableError matches error 3952: the database does
@@ -1028,9 +1050,18 @@ func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta ta
 	if err != nil {
 		return "", fmt.Errorf("failed to acquire connection: %w", err)
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() {
+		// BeginTx's isolation level sticks to the session, so restore the
+		// default before the connection re-enters the pool.
+		_, _ = conn.ExecContext(ctx, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+		_ = conn.Close()
+	}()
 
-	tx, err := conn.BeginTx(ctx, &sql.TxOptions{Isolation: isolation, ReadOnly: isolation == sql.LevelSnapshot})
+	// go-mssqldb rejects ReadOnly transactions outright ("read-only
+	// transactions are not supported"), so requesting one here used to fail
+	// every SNAPSHOT-isolation attempt and silently push all snapshots onto
+	// the SERIALIZABLE+HOLDLOCK fallback, which blocks writers.
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if err != nil {
 		return "", fmt.Errorf("failed to begin snapshot transaction: %w", err)
 	}

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -58,6 +58,20 @@ func sleepPoll(ctx context.Context, interval time.Duration) error {
 	}
 }
 
+// emitResult sends a result without wedging the producer goroutine when the
+// consumer has gone away: cancellation releases the batch and unblocks.
+func emitResult(ctx context.Context, results chan<- source.RecordBatchResult, res source.RecordBatchResult) error {
+	select {
+	case results <- res:
+		return nil
+	case <-ctx.Done():
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+		return ctx.Err()
+	}
+}
+
 var mssqlCDCColumns = []schema.Column{
 	{Name: destination.CDCLSNColumn, DataType: schema.TypeString, Nullable: false},
 	{Name: destination.CDCDeletedColumn, DataType: schema.TypeBoolean, Nullable: false},
@@ -541,7 +555,7 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 		for _, table := range selected {
 			meta, err := s.getTableMetadata(ctx, table.Name, "")
 			if err != nil {
-				results <- source.RecordBatchResult{Err: err}
+				_ = emitResult(ctx, results, source.RecordBatchResult{Err: err})
 				return
 			}
 			metaByTable[table.Name] = meta
@@ -555,7 +569,7 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 			if startHex != "" {
 				canResume, err := s.canResume(ctx, meta, startHex)
 				if err != nil {
-					results <- source.RecordBatchResult{Err: err}
+					_ = emitResult(ctx, results, source.RecordBatchResult{Err: err})
 					return
 				}
 				if canResume {
@@ -567,14 +581,14 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 
 			snapshotLSN, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name)
 			if err != nil {
-				results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed for %s: %w", table.Name, err)}
+				_ = emitResult(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("snapshot failed for %s: %w", table.Name, err)})
 				return
 			}
 			startByTable[table.Name] = snapshotLSN
 		}
 
 		if err := s.streamTables(ctx, selected, metaByTable, startByTable, reReadByTable, opts.ReadOptions, results); err != nil {
-			results <- source.RecordBatchResult{Err: err}
+			_ = emitResult(ctx, results, source.RecordBatchResult{Err: err})
 		}
 	}()
 
@@ -799,6 +813,17 @@ func (s *MSSQLCDCSource) getCapturedSchema(ctx context.Context, meta tableMetada
 		return nil, fmt.Errorf("CDC capture instance %s has no captured columns", meta.CaptureInstance)
 	}
 
+	// Captured columns the source table no longer has are snapshotted as
+	// NULL, so they must read as nullable regardless of the change table's
+	// original constraint.
+	if len(meta.CurrentColumns) > 0 {
+		for i := range columns {
+			if !meta.CurrentColumns[strings.ToLower(columns[i].Name)] {
+				columns[i].Nullable = true
+			}
+		}
+	}
+
 	primaryKeys, err := s.primaryKeys(ctx, meta)
 	if err != nil {
 		return nil, err
@@ -910,12 +935,12 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 		if startHex != "" {
 			canResume, err := t.source.canResume(ctx, t.metadata, startHex)
 			if err != nil {
-				results <- source.RecordBatchResult{Err: err}
+				_ = emitResult(ctx, results, source.RecordBatchResult{Err: err})
 				return
 			}
 			if canResume {
 				if err := t.source.streamTable(ctx, t.metadata, t.tableSchema, startHex, !isSnapshotStamp(resume), opts, results, ""); err != nil {
-					results <- source.RecordBatchResult{Err: err}
+					_ = emitResult(ctx, results, source.RecordBatchResult{Err: err})
 				}
 				return
 			}
@@ -924,12 +949,12 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 
 		snapshotLSN, err := t.source.snapshotTable(ctx, t.metadata, t.tableSchema, opts, results, "")
 		if err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)}
+			_ = emitResult(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("snapshot failed: %w", err)})
 			return
 		}
 
 		if err := t.source.streamTable(ctx, t.metadata, t.tableSchema, snapshotLSN, false, opts, results, ""); err != nil {
-			results <- source.RecordBatchResult{Err: err}
+			_ = emitResult(ctx, results, source.RecordBatchResult{Err: err})
 		}
 	}()
 
@@ -1024,10 +1049,12 @@ func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta ta
 		// discard target rows left by an interrupted earlier attempt or a lost
 		// resume position, so source deletes missed while the position was
 		// invalid cannot linger.
-		results <- source.RecordBatchResult{Truncate: true, TableName: resultTable}
+		if err := emitResult(ctx, results, source.RecordBatchResult{Truncate: true, TableName: resultTable}); err != nil {
+			return "", err
+		}
 	}
 
-	if err := s.rowsToSnapshotBatches(rows, tableSchema, opts, snapshotLSN, results, resultTable); err != nil {
+	if err := s.rowsToSnapshotBatches(ctx, rows, tableSchema, opts, snapshotLSN, results, resultTable); err != nil {
 		return "", err
 	}
 
@@ -1297,10 +1324,10 @@ func (s *MSSQLCDCSource) readChanges(ctx context.Context, meta tableMetadata, ta
 	}
 	defer func() { _ = rows.Close() }()
 
-	return s.rowsToChangeBatches(rows, tableSchema, opts, results, resultTable)
+	return s.rowsToChangeBatches(ctx, rows, tableSchema, opts, results, resultTable)
 }
 
-func (s *MSSQLCDCSource) rowsToSnapshotBatches(rows *sql.Rows, tableSchema *schema.TableSchema, opts source.ReadOptions, snapshotLSN string, results chan<- source.RecordBatchResult, resultTable string) error {
+func (s *MSSQLCDCSource) rowsToSnapshotBatches(ctx context.Context, rows *sql.Rows, tableSchema *schema.TableSchema, opts source.ReadOptions, snapshotLSN string, results chan<- source.RecordBatchResult, resultTable string) error {
 	sourceColumns := sourceColumnsWithoutCDC(tableSchema)
 	batchSize := opts.PageSize
 	if batchSize <= 0 {
@@ -1332,15 +1359,17 @@ func (s *MSSQLCDCSource) rowsToSnapshotBatches(rows *sql.Rows, tableSchema *sche
 			break
 		}
 		if pending != nil {
-			results <- source.RecordBatchResult{Batch: pending, TableName: resultTable}
+			if err := emitResult(ctx, results, source.RecordBatchResult{Batch: pending, TableName: resultTable}); err != nil {
+				record.Release()
+				return err
+			}
 		}
 		pending = record
 	}
 	if pending == nil {
 		return nil
 	}
-	results <- source.RecordBatchResult{Batch: restampSnapshotLSN(pending, len(sourceColumns), completeLSN), TableName: resultTable}
-	return nil
+	return emitResult(ctx, results, source.RecordBatchResult{Batch: restampSnapshotLSN(pending, len(sourceColumns), completeLSN), TableName: resultTable})
 }
 
 // restampSnapshotLSN rebuilds a snapshot batch's _cdc_lsn column with the
@@ -1366,7 +1395,7 @@ func restampSnapshotLSN(record arrow.RecordBatch, lsnCol int, lsn string) arrow.
 	return out
 }
 
-func (s *MSSQLCDCSource) rowsToChangeBatches(rows *sql.Rows, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) error {
+func (s *MSSQLCDCSource) rowsToChangeBatches(ctx context.Context, rows *sql.Rows, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) error {
 	sourceColumns := sourceColumnsWithoutCDC(tableSchema)
 	batchSize := opts.PageSize
 	if batchSize <= 0 {
@@ -1387,7 +1416,9 @@ func (s *MSSQLCDCSource) rowsToChangeBatches(rows *sql.Rows, tableSchema *schema
 		if count == 0 {
 			return nil
 		}
-		results <- source.RecordBatchResult{Batch: record, TableName: resultTable}
+		if err := emitResult(ctx, results, source.RecordBatchResult{Batch: record, TableName: resultTable}); err != nil {
+			return err
+		}
 	}
 }
 

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"net/url"
@@ -1052,8 +1053,15 @@ func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta ta
 	}
 	defer func() {
 		// BeginTx's isolation level sticks to the session, so restore the
-		// default before the connection re-enters the pool.
-		_, _ = conn.ExecContext(ctx, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+		// default before the connection re-enters the pool. The reset must
+		// survive request cancellation — otherwise the poisoned session leaks
+		// back into the pool — and a connection that cannot be reset is
+		// discarded rather than returned.
+		resetCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if _, err := conn.ExecContext(resetCtx, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED"); err != nil {
+			_ = conn.Raw(func(any) error { return driver.ErrBadConn })
+		}
 		_ = conn.Close()
 	}()
 
@@ -1349,13 +1357,25 @@ func (s *MSSQLCDCSource) readChanges(ctx context.Context, meta tableMetadata, ta
 	rows, err := s.db.QueryContext(ctx, query, fromLSN, toLSN)
 	if err != nil {
 		if isInvalidLSNRangeError(err) {
-			return fmt.Errorf("CDC changes for %s from LSN %s are no longer available: change-table cleanup advanced past the cursor (retention exceeded); the next run will take a fresh snapshot: %w", tableName(meta), fromLSN, err)
+			return cleanedUpLSNRangeError(meta, fromLSN, err)
 		}
 		return fmt.Errorf("failed to query CDC changes for %s: %w", tableName(meta), err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	return s.rowsToChangeBatches(ctx, rows, tableSchema, opts, results, resultTable)
+	// Error 313 can also surface during row iteration rather than on the
+	// initial query, so classify the read error too.
+	if err := s.rowsToChangeBatches(ctx, rows, tableSchema, opts, results, resultTable); err != nil {
+		if isInvalidLSNRangeError(err) {
+			return cleanedUpLSNRangeError(meta, fromLSN, err)
+		}
+		return err
+	}
+	return nil
+}
+
+func cleanedUpLSNRangeError(meta tableMetadata, fromLSN string, err error) error {
+	return fmt.Errorf("CDC changes for %s from LSN %s are no longer available: change-table cleanup advanced past the cursor (retention exceeded); the next run will take a fresh snapshot: %w", tableName(meta), fromLSN, err)
 }
 
 func (s *MSSQLCDCSource) rowsToSnapshotBatches(ctx context.Context, rows *sql.Rows, tableSchema *schema.TableSchema, opts source.ReadOptions, snapshotLSN string, results chan<- source.RecordBatchResult, resultTable string) error {

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -407,6 +407,10 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 			metaByTable[table.Name] = meta
 
 			resume := opts.CDCResumeLSNs[table.Name]
+			if isIncompleteSnapshotStamp(resume) {
+				config.Debug("[MSSQL CDC] Stored position %s marks an unfinished snapshot of %s; taking a fresh snapshot", strings.TrimSpace(resume), table.Name)
+				resume = ""
+			}
 			startHex := startLSNFromStored(resume)
 			if startHex != "" {
 				canResume, err := s.canResume(ctx, meta, startHex)
@@ -757,7 +761,12 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 	go func() {
 		defer close(results)
 
-		startHex := startLSNFromStored(opts.CDCResumeLSN)
+		resume := opts.CDCResumeLSN
+		if isIncompleteSnapshotStamp(resume) {
+			config.Debug("[MSSQL CDC] Stored position %s marks an unfinished snapshot of %s; taking a fresh snapshot", strings.TrimSpace(resume), t.tableName)
+			resume = ""
+		}
+		startHex := startLSNFromStored(resume)
 		if startHex != "" {
 			canResume, err := t.source.canResume(ctx, t.metadata, startHex)
 			if err != nil {
@@ -765,7 +774,7 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 				return
 			}
 			if canResume {
-				if err := t.source.streamTable(ctx, t.metadata, t.tableSchema, startHex, !isSnapshotStamp(opts.CDCResumeLSN), opts, results, ""); err != nil {
+				if err := t.source.streamTable(ctx, t.metadata, t.tableSchema, startHex, !isSnapshotStamp(resume), opts, results, ""); err != nil {
 					results <- source.RecordBatchResult{Err: err}
 				}
 				return
@@ -1118,21 +1127,64 @@ func (s *MSSQLCDCSource) rowsToSnapshotBatches(rows *sql.Rows, tableSchema *sche
 	if batchSize <= 0 {
 		batchSize = 100000
 	}
-	cdcLSN := formatStoredLSN(snapshotLSN, "", 0)
+	// Snapshot rows are stamped incomplete until the last batch. Resume
+	// trusts the destination's MAX(_cdc_lsn), and streaming destinations
+	// commit batches incrementally, so a crash mid-snapshot leaves partial
+	// rows whose stamp must not read as a resumable position. Batches are
+	// emitted one behind the read, and only the final batch carries the
+	// complete stamp, which sorts above the incomplete one: MAX names a
+	// complete stamp exactly when the whole snapshot became durable.
+	incompleteLSN := snapshotIncompleteLSN(snapshotLSN)
+	completeLSN := snapshotCompleteLSN(snapshotLSN)
 	syncedAt := time.Now().UTC()
 
+	var pending arrow.RecordBatch
 	for {
 		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, s.guidConversion, func(builders []array.Builder) {
-			appendCDCValues(builders, len(sourceColumns), cdcLSN, false, syncedAt)
+			appendCDCValues(builders, len(sourceColumns), incompleteLSN, false, syncedAt)
 		})
 		if err != nil {
+			if pending != nil {
+				pending.Release()
+			}
 			return err
 		}
 		if count == 0 {
-			return nil
+			break
 		}
-		results <- source.RecordBatchResult{Batch: record, TableName: resultTable}
+		if pending != nil {
+			results <- source.RecordBatchResult{Batch: pending, TableName: resultTable}
+		}
+		pending = record
 	}
+	if pending == nil {
+		return nil
+	}
+	results <- source.RecordBatchResult{Batch: restampSnapshotLSN(pending, len(sourceColumns), completeLSN), TableName: resultTable}
+	return nil
+}
+
+// restampSnapshotLSN rebuilds a snapshot batch's _cdc_lsn column with the
+// given stamp. Used to mark the final batch of a snapshot complete after the
+// scan proves no rows follow it.
+func restampSnapshotLSN(record arrow.RecordBatch, lsnCol int, lsn string) arrow.RecordBatch {
+	mem := memory.NewGoAllocator()
+	b := array.NewStringBuilder(mem)
+	defer b.Release()
+	for range int(record.NumRows()) {
+		b.Append(lsn)
+	}
+	arr := b.NewArray()
+	defer arr.Release()
+
+	cols := make([]arrow.Array, record.NumCols())
+	for i := range cols {
+		cols[i] = record.Column(i)
+	}
+	cols[lsnCol] = arr
+	out := array.NewRecordBatch(record.Schema(), cols, record.NumRows())
+	record.Release()
+	return out
 }
 
 func (s *MSSQLCDCSource) rowsToChangeBatches(rows *sql.Rows, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) error {
@@ -1567,11 +1619,35 @@ func formatStoredLSN(startHex, seqHex string, op int) string {
 	return fmt.Sprintf("%s:%s:%02d", startHex, seqHex, op)
 }
 
+// Snapshot stamps carry a zero seqval, which no delivered change row can
+// have, plus a final byte encoding completeness. The incomplete stamp sorts
+// below the complete one so the destination's MAX(_cdc_lsn) only names a
+// complete stamp once the snapshot's final batch became durable.
+//
+// Positions written by versions that predate the completeness byte used the
+// incomplete encoding for finished snapshots; they re-snapshot once after an
+// upgrade, which is the safe direction (they cannot prove completeness).
+func snapshotIncompleteLSN(startHex string) string {
+	return formatStoredLSN(startHex, "", 0)
+}
+
+func snapshotCompleteLSN(startHex string) string {
+	return formatStoredLSN(startHex, "", 1)
+}
+
 // isSnapshotStamp reports whether a stored position was written by a snapshot
-// (zero seqval and operation) rather than by a delivered change row. Only a
-// change-row position can sit mid-transaction, so only it earns a boundary
-// re-read; a snapshot stamp already covers everything at its LSN.
+// (zero seqval) rather than by a delivered change row. Only a change-row
+// position can sit mid-transaction, so only it earns a boundary re-read; a
+// snapshot stamp already covers everything at its LSN.
 func isSnapshotStamp(stored string) bool {
+	s := strings.ToUpper(strings.TrimSpace(stored))
+	return strings.HasSuffix(s, ":00000000000000000000:00") || strings.HasSuffix(s, ":00000000000000000000:01")
+}
+
+// isIncompleteSnapshotStamp reports whether a stored position marks a
+// snapshot that never finished: resuming from it would skip every row the
+// interrupted scan had not reached, so it forces a fresh snapshot instead.
+func isIncompleteSnapshotStamp(stored string) bool {
 	return strings.HasSuffix(strings.ToUpper(strings.TrimSpace(stored)), ":00000000000000000000:00")
 }
 

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -174,6 +175,60 @@ func TestRowsToSnapshotBatchesReturnsIteratorErrorForEmptyBatch(t *testing.T) {
 	require.ErrorIs(t, err, iterErr)
 	assert.Empty(t, results)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRowsToSnapshotBatchesNormalizesUUIDColumns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Wire-order bytes for FF19966F-868B-11D0-B42D-00C04FC964FF: the first
+	// three fields arrive little-endian from the driver.
+	wire := []byte{
+		0x6F, 0x96, 0x19, 0xFF,
+		0x8B, 0x86,
+		0xD0, 0x11,
+		0xB4, 0x2D, 0x00, 0xC0, 0x4F, 0xC9, 0x64, 0xFF,
+	}
+	mockRows := sqlmock.NewRows([]string{"id", "guid"}).AddRow(int64(1), wire)
+	mock.ExpectQuery("SELECT").WillReturnRows(mockRows)
+
+	rows, err := db.Query("SELECT")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	tableSchema := addCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "guid", DataType: schema.TypeUUID, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, 2)
+	s := &MSSQLCDCSource{}
+
+	err = s.rowsToSnapshotBatches(rows, tableSchema, source.ReadOptions{}, "00000000000000000001", results, "items")
+	require.NoError(t, err)
+
+	res := <-results
+	require.NoError(t, res.Err)
+	defer res.Batch.Release()
+
+	guidCol, ok := res.Batch.Column(1).(*array.String)
+	require.True(t, ok, "UUID column must be an Arrow string column")
+	assert.Equal(t, "FF19966F-868B-11D0-B42D-00C04FC964FF", guidCol.Value(0))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestNormalizeSourceValueLeavesNonUUIDColumnsAlone(t *testing.T) {
+	raw := []byte{0x01, 0x02}
+	got, err := normalizeSourceValue(schema.Column{Name: "blob", DataType: schema.TypeBinary}, raw, false)
+	require.NoError(t, err)
+	assert.Equal(t, raw, got)
+
+	_, err = normalizeSourceValue(schema.Column{Name: "guid", DataType: schema.TypeUUID}, raw, false)
+	assert.ErrorContains(t, err, `uniqueidentifier column "guid"`)
 }
 
 func TestValidateCapturedPrimaryKeys(t *testing.T) {

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -301,6 +301,30 @@ func TestNormalizeSourceValueLeavesNonUUIDColumnsAlone(t *testing.T) {
 	assert.ErrorContains(t, err, `uniqueidentifier column "guid"`)
 }
 
+func TestSelectTables(t *testing.T) {
+	all := []source.SourceTableInfo{
+		{Name: "dbo.users"},
+		{Name: "sales.orders"},
+	}
+	skipped := []skippedTable{{name: "dbo.audit_log", reason: "it has no primary key"}}
+
+	selected, err := selectTables(all, skipped, nil)
+	require.NoError(t, err)
+	assert.Len(t, selected, 2, "no filter selects every ingestible table")
+
+	selected, err = selectTables(all, skipped, []string{"DBO.Users"})
+	require.NoError(t, err)
+	require.Len(t, selected, 1)
+	assert.Equal(t, "dbo.users", selected[0].Name)
+
+	_, err = selectTables(all, skipped, []string{"dbo.users", "dbo.missing"})
+	assert.ErrorContains(t, err, "dbo.missing")
+	assert.ErrorContains(t, err, "schema-qualified")
+
+	_, err = selectTables(all, skipped, []string{"dbo.audit_log"})
+	assert.ErrorContains(t, err, "no primary key")
+}
+
 func TestValidateCapturedPrimaryKeys(t *testing.T) {
 	tableSchema := &schema.TableSchema{
 		Name:   "users",

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -145,6 +145,76 @@ func TestPlanChangeWindowNeverRegressesCursor(t *testing.T) {
 	assert.True(t, read)
 }
 
+func TestSnapshotStampLifecycle(t *testing.T) {
+	const start = "0000002F0000010D0002"
+	incomplete := snapshotIncompleteLSN(start)
+	complete := snapshotCompleteLSN(start)
+
+	assert.True(t, isIncompleteSnapshotStamp(incomplete))
+	assert.False(t, isIncompleteSnapshotStamp(complete))
+	assert.True(t, isSnapshotStamp(incomplete))
+	assert.True(t, isSnapshotStamp(complete))
+	assert.False(t, isSnapshotStamp(formatStoredLSN(start, "0000002F0000010D0003", 4)))
+	assert.False(t, isIncompleteSnapshotStamp(""))
+
+	// The destination resumes from MAX(_cdc_lsn) as a string, so the stamps
+	// and change rows must order: incomplete < complete < any change row.
+	changeRow := formatStoredLSN(start, "0000002F0000010D0003", 1)
+	assert.Less(t, incomplete, complete)
+	assert.Less(t, complete, changeRow)
+}
+
+func TestRowsToSnapshotBatchesMarksOnlyFinalBatchComplete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mockRows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(int64(1), "a").
+		AddRow(int64(2), "b").
+		AddRow(int64(3), "c")
+	mock.ExpectQuery("SELECT").WillReturnRows(mockRows)
+
+	rows, err := db.Query("SELECT")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	tableSchema := addCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, 4)
+	s := &MSSQLCDCSource{}
+
+	const snapshotLSN = "0000002F0000010D0002"
+	err = s.rowsToSnapshotBatches(rows, tableSchema, source.ReadOptions{PageSize: 1}, snapshotLSN, results, "items")
+	require.NoError(t, err)
+	close(results)
+
+	var stamps []string
+	var ids []int64
+	for res := range results {
+		require.NoError(t, res.Err)
+		lsnCol, ok := res.Batch.Column(2).(*array.String)
+		require.True(t, ok)
+		require.EqualValues(t, 1, res.Batch.NumRows())
+		stamps = append(stamps, lsnCol.Value(0))
+		ids = append(ids, res.Batch.Column(0).(*array.Int64).Value(0))
+		res.Batch.Release()
+	}
+
+	require.Len(t, stamps, 3)
+	assert.Equal(t, []int64{1, 2, 3}, ids, "restamping the final batch must preserve its data columns")
+	assert.Equal(t, snapshotIncompleteLSN(snapshotLSN), stamps[0])
+	assert.Equal(t, snapshotIncompleteLSN(snapshotLSN), stamps[1])
+	assert.Equal(t, snapshotCompleteLSN(snapshotLSN), stamps[2], "only the final batch may carry the complete stamp")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestRowsToSnapshotBatchesReturnsIteratorErrorForEmptyBatch(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -462,6 +462,17 @@ func TestNewUpdatePairerRequiresCapturedKeys(t *testing.T) {
 	assert.ErrorContains(t, err, `primary key column "ssn"`)
 }
 
+func TestErrorClassifiers(t *testing.T) {
+	assert.True(t, isInvalidLSNRangeError(mssqldb.Error{Number: 313}))
+	assert.True(t, isInvalidLSNRangeError(fmt.Errorf("query: %w", mssqldb.Error{Number: 313})))
+	assert.False(t, isInvalidLSNRangeError(mssqldb.Error{Number: 1205}))
+	assert.False(t, isInvalidLSNRangeError(errors.New("boom")))
+
+	assert.True(t, isSnapshotIsolationUnavailableError(mssqldb.Error{Number: 3952}))
+	assert.False(t, isSnapshotIsolationUnavailableError(mssqldb.Error{Number: 1205}))
+	assert.False(t, isSnapshotIsolationUnavailableError(nil))
+}
+
 func TestIsTransientMSSQLError(t *testing.T) {
 	deadlock := mssqldb.Error{Number: 1205, Message: "deadlock victim"}
 	assert.True(t, isTransientMSSQLError(deadlock))

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -462,6 +462,22 @@ func TestNewUpdatePairerRequiresCapturedKeys(t *testing.T) {
 	assert.ErrorContains(t, err, `primary key column "ssn"`)
 }
 
+func TestCaptureHealthThrottleAndDedup(t *testing.T) {
+	var h captureHealth
+	start := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	h.reset(start)
+
+	assert.False(t, h.shouldCheck(start.Add(time.Minute)), "probe must wait out the interval")
+	assert.True(t, h.shouldCheck(start.Add(captureHealthInterval)))
+	assert.False(t, h.shouldCheck(start.Add(captureHealthInterval+time.Second)), "claiming the slot must re-arm the throttle")
+
+	assert.False(t, h.claimWarn(start.Add(-time.Hour)), "errors predating the stream are not reported")
+	errAt := start.Add(10 * time.Minute)
+	assert.True(t, h.claimWarn(errAt))
+	assert.False(t, h.claimWarn(errAt), "the same error is reported once")
+	assert.True(t, h.claimWarn(errAt.Add(time.Minute)), "a newer error is reported again")
+}
+
 func TestErrorClassifiers(t *testing.T) {
 	assert.True(t, isInvalidLSNRangeError(mssqldb.Error{Number: 313}))
 	assert.True(t, isInvalidLSNRangeError(fmt.Errorf("query: %w", mssqldb.Error{Number: 313})))

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -191,7 +191,7 @@ func TestRowsToSnapshotBatchesMarksOnlyFinalBatchComplete(t *testing.T) {
 	s := &MSSQLCDCSource{}
 
 	const snapshotLSN = "0000002F0000010D0002"
-	err = s.rowsToSnapshotBatches(rows, tableSchema, source.ReadOptions{PageSize: 1}, snapshotLSN, results, "items")
+	err = s.rowsToSnapshotBatches(t.Context(), rows, tableSchema, source.ReadOptions{PageSize: 1}, snapshotLSN, results, "items")
 	require.NoError(t, err)
 	close(results)
 
@@ -241,7 +241,7 @@ func TestRowsToSnapshotBatchesReturnsIteratorErrorForEmptyBatch(t *testing.T) {
 	results := make(chan source.RecordBatchResult, 1)
 	s := &MSSQLCDCSource{}
 
-	err = s.rowsToSnapshotBatches(rows, tableSchema, source.ReadOptions{}, "00000000000000000001", results, "items")
+	err = s.rowsToSnapshotBatches(t.Context(), rows, tableSchema, source.ReadOptions{}, "00000000000000000001", results, "items")
 	require.ErrorIs(t, err, iterErr)
 	assert.Empty(t, results)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -278,7 +278,7 @@ func TestRowsToSnapshotBatchesNormalizesUUIDColumns(t *testing.T) {
 	results := make(chan source.RecordBatchResult, 2)
 	s := &MSSQLCDCSource{}
 
-	err = s.rowsToSnapshotBatches(rows, tableSchema, source.ReadOptions{}, "00000000000000000001", results, "items")
+	err = s.rowsToSnapshotBatches(t.Context(), rows, tableSchema, source.ReadOptions{}, "00000000000000000001", results, "items")
 	require.NoError(t, err)
 
 	res := <-results

--- a/pkg/source/mssql_cdc/state.go
+++ b/pkg/source/mssql_cdc/state.go
@@ -1,0 +1,188 @@
+package mssql_cdc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+var (
+	_ source.TableExistenceChecker          = (*MSSQLCDCSource)(nil)
+	_ source.TableIncarnationProvider       = (*MSSQLCDCSource)(nil)
+	_ source.TableSchemaFingerprintProvider = (*MSSQLCDCSource)(nil)
+	_ source.CDCStateProvider               = (*MSSQLCDCSource)(nil)
+)
+
+func (s *MSSQLCDCSource) resetCDCState() {
+	s.stateMu.Lock()
+	s.state = source.CDCStateCommitToken{SnapshotPositions: make(map[string]string)}
+	s.stateMu.Unlock()
+}
+
+// recordSnapshotState marks table's full snapshot as included in all results
+// emitted so far, at the given stored position.
+func (s *MSSQLCDCSource) recordSnapshotState(table, position string) {
+	if table == "" || position == "" {
+		return
+	}
+	s.stateMu.Lock()
+	if s.state.SnapshotPositions == nil {
+		s.state.SnapshotPositions = make(map[string]string)
+	}
+	s.state.SnapshotPositions[table] = position
+	s.stateMu.Unlock()
+}
+
+// recordCheckpointState advances the globally safe position: every change at
+// or below it has been emitted for every table in the read.
+func (s *MSSQLCDCSource) recordCheckpointState(position string) {
+	if position == "" {
+		return
+	}
+	s.stateMu.Lock()
+	s.state.Position = position
+	s.stateMu.Unlock()
+}
+
+// CDCState returns the state produced by the read so far. The pipeline
+// persists it after a batch write succeeds; streaming flushes consume the
+// same token incrementally via CommitToken markers.
+func (s *MSSQLCDCSource) CDCState() source.CDCStateCommitToken {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	snapshots := make(map[string]string, len(s.state.SnapshotPositions))
+	for table, position := range s.state.SnapshotPositions {
+		snapshots[table] = position
+	}
+	return source.CDCStateCommitToken{
+		Position:          s.state.Position,
+		SnapshotPositions: snapshots,
+	}
+}
+
+// emitStateToken sends a batchless result carrying the current cumulative
+// state token. Only the streaming executor consumes CommitToken markers, so
+// batch mode relies on CDCState() after the write instead.
+func (s *MSSQLCDCSource) emitStateToken(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) error {
+	if !opts.Streaming {
+		return nil
+	}
+	return emitResult(ctx, results, source.RecordBatchResult{CommitToken: s.CDCState(), TableName: resultTable})
+}
+
+// watermarkStoredLSN encodes a fully delivered harvest watermark. It shares
+// the complete-snapshot encoding: everything at the LSN is included, so a
+// resume reads strictly after it with no boundary re-read.
+func watermarkStoredLSN(lsn string) string {
+	return snapshotCompleteLSN(lsn)
+}
+
+func (s *MSSQLCDCSource) TableExists(ctx context.Context, table string) (bool, error) {
+	schemaName, tableName := parseTableName(table)
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT CAST(CASE WHEN EXISTS (
+			SELECT 1
+			FROM sys.tables AS t
+			JOIN sys.schemas AS sc ON sc.schema_id = t.schema_id
+			WHERE sc.name = @p1 AND t.name = @p2
+		) THEN 1 ELSE 0 END AS bit)`, schemaName, tableName).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check source table existence for %s: %w", table, err)
+	}
+	return exists, nil
+}
+
+// TableIncarnation identifies one life of a source table. object_id alone can
+// be reused after a drop, so the creation time is folded in: a dropped and
+// recreated table always yields a new incarnation, invalidating resume state
+// that was recorded against the old one.
+func (s *MSSQLCDCSource) TableIncarnation(ctx context.Context, table string) (string, error) {
+	schemaName, tableName := parseTableName(table)
+	var incarnation string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT CONVERT(varchar(20), t.object_id) + N':' + CONVERT(varchar(33), t.create_date, 126)
+		FROM sys.tables AS t
+		JOIN sys.schemas AS sc ON sc.schema_id = t.schema_id
+		WHERE sc.name = @p1 AND t.name = @p2`, schemaName, tableName).Scan(&incarnation)
+	if err != nil {
+		return "", fmt.Errorf("failed to read source table incarnation for %s: %w", table, err)
+	}
+	return incarnation, nil
+}
+
+// TableSchemaFingerprint hashes the schema this source actually delivers: the
+// newest capture instance's identity and captured columns, plus the source
+// table's primary key. A recreated capture instance or a changed merge key
+// therefore changes the fingerprint and invalidates recorded resume state.
+func (s *MSSQLCDCSource) TableSchemaFingerprint(ctx context.Context, table string) (string, error) {
+	meta, err := s.getTableMetadata(ctx, table, s.cdcConfig.CaptureInstance)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+	writeFingerprintValues(h, meta.CaptureInstance)
+
+	var startLSN string
+	err = s.db.QueryRowContext(
+		ctx,
+		"SELECT CONVERT(varchar(20), start_lsn, 2) FROM cdc.change_tables WHERE capture_instance = @p1 AND end_lsn IS NULL",
+		meta.CaptureInstance,
+	).Scan(&startLSN)
+	if err != nil {
+		return "", fmt.Errorf("failed to fingerprint capture instance %s: %w", meta.CaptureInstance, err)
+	}
+	writeFingerprintValues(h, startLSN)
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT c.name, t.name, CONVERT(int, c.is_nullable), CONVERT(int, c.precision), CONVERT(int, c.scale), CONVERT(int, c.max_length)
+		FROM sys.columns AS c
+		JOIN sys.types AS t ON c.user_type_id = t.user_type_id
+		WHERE c.object_id = OBJECT_ID(@p1)
+		  AND c.name NOT LIKE '__$%'
+		ORDER BY c.column_id`, meta.ChangeTable)
+	if err != nil {
+		return "", fmt.Errorf("failed to fingerprint captured columns for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	columnCount := 0
+	for rows.Next() {
+		var name, typeName string
+		var nullable, precision, scale, maxLength int
+		if err := rows.Scan(&name, &typeName, &nullable, &precision, &scale, &maxLength); err != nil {
+			return "", fmt.Errorf("failed to scan captured-column fingerprint for %s: %w", table, err)
+		}
+		writeFingerprintValues(h, name, typeName, fmt.Sprint(nullable), fmt.Sprint(precision), fmt.Sprint(scale), fmt.Sprint(maxLength))
+		columnCount++
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("failed to read captured-column fingerprint for %s: %w", table, err)
+	}
+	if columnCount == 0 {
+		return "", fmt.Errorf("capture instance %s has no captured columns", meta.CaptureInstance)
+	}
+
+	pks, err := s.primaryKeys(ctx, meta)
+	if err != nil {
+		return "", err
+	}
+	writeFingerprintValues(h, pks...)
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func writeFingerprintValues(h hash.Hash, values ...string) {
+	var length [8]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+		_, _ = h.Write(length[:])
+		_, _ = h.Write([]byte(value))
+	}
+}

--- a/pkg/source/mssql_cdc/state.go
+++ b/pkg/source/mssql_cdc/state.go
@@ -117,20 +117,27 @@ func (s *MSSQLCDCSource) TableIncarnation(ctx context.Context, table string) (st
 }
 
 // TableSchemaFingerprint hashes the schema this source actually delivers: the
-// newest capture instance's identity and captured columns, plus the source
-// table's primary key. A recreated capture instance or a changed merge key
-// therefore changes the fingerprint and invalidates recorded resume state.
+// capture instance's identity and captured columns, plus the source table's
+// primary key. A recreated capture instance or a changed merge key therefore
+// changes the fingerprint and invalidates recorded resume state.
+//
+// The configured capture_instance applies here because single-table reads
+// honor it; multi-table reads ignore it and fingerprint their own selected
+// metadata via fingerprintCaptureInstance.
 func (s *MSSQLCDCSource) TableSchemaFingerprint(ctx context.Context, table string) (string, error) {
 	meta, err := s.getTableMetadata(ctx, table, s.cdcConfig.CaptureInstance)
 	if err != nil {
 		return "", err
 	}
+	return s.fingerprintCaptureInstance(ctx, meta)
+}
 
+func (s *MSSQLCDCSource) fingerprintCaptureInstance(ctx context.Context, meta tableMetadata) (string, error) {
 	h := sha256.New()
 	writeFingerprintValues(h, meta.CaptureInstance)
 
 	var startLSN string
-	err = s.db.QueryRowContext(
+	err := s.db.QueryRowContext(
 		ctx,
 		"SELECT CONVERT(varchar(20), start_lsn, 2) FROM cdc.change_tables WHERE capture_instance = @p1 AND end_lsn IS NULL",
 		meta.CaptureInstance,
@@ -148,7 +155,7 @@ func (s *MSSQLCDCSource) TableSchemaFingerprint(ctx context.Context, table strin
 		  AND c.name NOT LIKE '__$%'
 		ORDER BY c.column_id`, meta.ChangeTable)
 	if err != nil {
-		return "", fmt.Errorf("failed to fingerprint captured columns for %s: %w", table, err)
+		return "", fmt.Errorf("failed to fingerprint captured columns for %s: %w", tableName(meta), err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -157,13 +164,13 @@ func (s *MSSQLCDCSource) TableSchemaFingerprint(ctx context.Context, table strin
 		var name, typeName string
 		var nullable, precision, scale, maxLength int
 		if err := rows.Scan(&name, &typeName, &nullable, &precision, &scale, &maxLength); err != nil {
-			return "", fmt.Errorf("failed to scan captured-column fingerprint for %s: %w", table, err)
+			return "", fmt.Errorf("failed to scan captured-column fingerprint for %s: %w", tableName(meta), err)
 		}
 		writeFingerprintValues(h, name, typeName, fmt.Sprint(nullable), fmt.Sprint(precision), fmt.Sprint(scale), fmt.Sprint(maxLength))
 		columnCount++
 	}
 	if err := rows.Err(); err != nil {
-		return "", fmt.Errorf("failed to read captured-column fingerprint for %s: %w", table, err)
+		return "", fmt.Errorf("failed to read captured-column fingerprint for %s: %w", tableName(meta), err)
 	}
 	if columnCount == 0 {
 		return "", fmt.Errorf("capture instance %s has no captured columns", meta.CaptureInstance)

--- a/pkg/strategy/cdc_state.go
+++ b/pkg/strategy/cdc_state.go
@@ -1503,7 +1503,7 @@ func cdcStatePositionValid(position string) bool {
 	if _, err := pglogrepl.ParseLSN(position); err == nil {
 		return true
 	}
-	return mysqlCDCStatePositionRE.MatchString(position)
+	return mysqlCDCStatePositionRE.MatchString(position) || mssqlCDCStatePositionRE.MatchString(position)
 }
 
 func cdcStateEntryPositionValid(entry destination.CDCStateEntry) bool {
@@ -1529,6 +1529,11 @@ func compareCDCPositions(left, right string) int {
 		if mysqlCDCStatePositionRE.MatchString(left) && mysqlCDCStatePositionRE.MatchString(right) {
 			return strings.Compare(left, right)
 		}
+		// SQL Server CDC positions are fixed-width uppercase hex, so their
+		// lexicographic order is their LSN order.
+		if mssqlCDCStatePositionRE.MatchString(left) && mssqlCDCStatePositionRE.MatchString(right) {
+			return strings.Compare(left, right)
+		}
 		return 0
 	}
 	switch {
@@ -1542,6 +1547,11 @@ func compareCDCPositions(left, right string) int {
 }
 
 var mysqlCDCStatePositionRE = regexp.MustCompile(`^\d{20}:[^:]+:\d{20}:\d{20}(?::l1:[A-Za-z0-9_-]+:[A-Za-z0-9_-]*)?$`)
+
+// mssqlCDCStatePositionRE matches SQL Server CDC stored positions:
+// start LSN and seqval as fixed-width uppercase hex plus a two-digit
+// operation/completeness byte (see pkg/source/mssql_cdc formatStoredLSN).
+var mssqlCDCStatePositionRE = regexp.MustCompile(`^[0-9A-F]{20}:[0-9A-F]{20}:\d{2}$`)
 
 const (
 	cdcStateIncarnationSeparator   = ";incarnation="

--- a/pkg/strategy/cdc_state_test.go
+++ b/pkg/strategy/cdc_state_test.go
@@ -2152,6 +2152,37 @@ func TestCDCStatePositionComparisonIsNumeric(t *testing.T) {
 	}
 }
 
+func TestCDCStatePositionSupportsMSSQLFormat(t *testing.T) {
+	const (
+		snapshotIncomplete = "0000002F0000010D0002:00000000000000000000:00"
+		snapshotComplete   = "0000002F0000010D0002:00000000000000000000:01"
+		changeRow          = "0000002F0000010D0002:0000002F0000010D0003:04"
+		laterChange        = "0000003A0000010D0001:0000003A0000010D0002:02"
+	)
+
+	for _, position := range []string{snapshotIncomplete, snapshotComplete, changeRow, laterChange} {
+		if !cdcStatePositionValid(position) {
+			t.Fatalf("cdcStatePositionValid(%q) = false, want true", position)
+		}
+	}
+	if cdcStatePositionValid("0000002f0000010d0002") {
+		t.Fatal("bare LSN without seqval/op must not validate as an mssql position")
+	}
+
+	if got := compareCDCPositions(snapshotIncomplete, snapshotComplete); got >= 0 {
+		t.Fatalf("incomplete stamp must order below complete stamp, got %d", got)
+	}
+	if got := compareCDCPositions(snapshotComplete, changeRow); got >= 0 {
+		t.Fatalf("snapshot stamp must order below a change row at the same LSN, got %d", got)
+	}
+	if got := compareCDCPositions(changeRow, laterChange); got >= 0 {
+		t.Fatalf("earlier change must order below a later change, got %d", got)
+	}
+	if got := compareCDCPositions(changeRow, "0/10"); got != 0 {
+		t.Fatalf("cross-format comparison must be incomparable (0), got %d", got)
+	}
+}
+
 func TestCDCStatePruningPreservesUnparseablePositions(t *testing.T) {
 	const (
 		connectorID = "0123456789abcdef"

--- a/tests/integration/mssql_cdc_correctness_test.go
+++ b/tests/integration/mssql_cdc_correctness_test.go
@@ -313,3 +313,57 @@ func TestMSSQLCDC_SnapshotConcurrentWriter_Postgres(t *testing.T) {
 	_ = dstRows.Close()
 	assert.Empty(t, srcIDs, "source rows missing from destination")
 }
+
+// TestMSSQLCDC_ManagedState_Postgres proves SQL Server CDC runs on
+// destination-managed state when the destination supports it: the run must
+// record a completed snapshot event, and a follow-up run must resume from
+// that state rather than re-snapshot (original rows keep their exact
+// _cdc_lsn stamps).
+func TestMSSQLCDC_ManagedState_Postgres(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, cfg, destSchema := setupMSSQLCDCPostgresRun(t, ctx, "mssqlstate")
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pg := openPostgresDest(t)
+
+	var stateSchema string
+	err := pg.QueryRowContext(ctx, `
+		SELECT table_schema FROM information_schema.tables
+		WHERE table_name = 'cdc_state'
+		ORDER BY table_schema LIMIT 1`).Scan(&stateSchema)
+	require.NoError(t, err, "managed CDC state table must exist after an mssql+cdc run")
+
+	completeSnapshots := queryPostgresCount(t, ctx, pg, fmt.Sprintf(
+		`SELECT COUNT(*) FROM %q.cdc_state WHERE state_kind = 'snapshot' AND state_status = 'complete' AND source_table = 'dbo.items'`,
+		stateSchema,
+	))
+	require.Positive(t, completeSnapshots, "a completed snapshot event must be recorded for dbo.items")
+
+	stampsBefore := map[int]string{}
+	rows, err := pg.QueryContext(ctx, fmt.Sprintf(`SELECT id, "_cdc_lsn" FROM %q.items_dest ORDER BY id`, destSchema))
+	require.NoError(t, err)
+	for rows.Next() {
+		var id int
+		var lsn string
+		require.NoError(t, rows.Scan(&id, &lsn))
+		stampsBefore[id] = lsn
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	require.Len(t, stampsBefore, 3)
+
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES (4, N'item4', 400)`)
+	require.NoError(t, err)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_items", 4)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.Equal(t, 4, queryPostgresCount(t, ctx, pg, fmt.Sprintf(`SELECT COUNT(*) FROM %q.items_dest`, destSchema)))
+	for id, before := range stampsBefore {
+		var after string
+		require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT "_cdc_lsn" FROM %q.items_dest WHERE id = $1`, destSchema), id).Scan(&after))
+		assert.Equal(t, before, after, "row %d must keep its stamp: a changed stamp means the second run re-snapshotted instead of resuming from managed state", id)
+	}
+}

--- a/tests/integration/mssql_cdc_correctness_test.go
+++ b/tests/integration/mssql_cdc_correctness_test.go
@@ -131,11 +131,12 @@ func TestMSSQLCDC_ResumeMidTransaction_Postgres(t *testing.T) {
 
 	// Simulate a crash where the second run's write was only partially
 	// durable and its state commit never happened: remove the row carrying
-	// the newest change AND the recorded checkpoints. Resume then falls back
-	// to the completed-snapshot position and must re-deliver the transaction.
-	// (Deleting destination rows while keeping the checkpoint would be
-	// out-of-band tampering: managed state persists only after the write, so
-	// state never runs ahead of data in a real crash.)
+	// the newest change AND every state event of the second run's generation,
+	// reverting the connector to the first run's completed-snapshot state.
+	// Resume must then re-deliver the transaction and restore the lost row.
+	// (Deleting destination rows while keeping the second run's state would
+	// be out-of-band tampering: managed state persists only after the write,
+	// so state never runs ahead of data in a real crash.)
 	var droppedID int64
 	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(
 		`DELETE FROM %q.items_dest WHERE "_cdc_lsn" = (SELECT MAX("_cdc_lsn") FROM %q.items_dest) RETURNING id`,
@@ -146,8 +147,20 @@ func TestMSSQLCDC_ResumeMidTransaction_Postgres(t *testing.T) {
 		SELECT table_schema FROM information_schema.tables
 		WHERE table_name = 'cdc_state'
 		ORDER BY table_schema LIMIT 1`).Scan(&stateSchema))
-	_, err = pg.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %q.cdc_state WHERE state_kind = 'checkpoint'`, stateSchema))
+	res, err := pg.ExecContext(ctx, fmt.Sprintf(`
+		DELETE FROM %q.cdc_state AS cs
+		USING (
+			SELECT connector_id, MAX(state_generation) AS max_gen
+			FROM %q.cdc_state
+			WHERE destination_table = $1
+			GROUP BY connector_id
+		) AS mine
+		WHERE cs.connector_id = mine.connector_id AND cs.state_generation = mine.max_gen`,
+		stateSchema, stateSchema), cfg.DestTable)
 	require.NoError(t, err)
+	deleted, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Positive(t, deleted, "the second run's state generation must exist to be rolled back")
 	assert.Contains(t, []int64{4, 5}, droppedID)
 	assert.Equal(t, 0, count(`SELECT COUNT(*) FROM %q.items_dest WHERE id = %d`, destSchema, droppedID))
 

--- a/tests/integration/mssql_cdc_correctness_test.go
+++ b/tests/integration/mssql_cdc_correctness_test.go
@@ -129,13 +129,25 @@ func TestMSSQLCDC_ResumeMidTransaction_Postgres(t *testing.T) {
 	}
 	assert.Equal(t, 5, count(`SELECT COUNT(*) FROM %q.items_dest`, destSchema), "both transaction rows delivered")
 
-	// Simulate a crash after only part of the transaction was flushed: remove
-	// the row carrying the newest change, leaving the cursor mid-transaction.
+	// Simulate a crash where the second run's write was only partially
+	// durable and its state commit never happened: remove the row carrying
+	// the newest change AND the recorded checkpoints. Resume then falls back
+	// to the completed-snapshot position and must re-deliver the transaction.
+	// (Deleting destination rows while keeping the checkpoint would be
+	// out-of-band tampering: managed state persists only after the write, so
+	// state never runs ahead of data in a real crash.)
 	var droppedID int64
 	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(
 		`DELETE FROM %q.items_dest WHERE "_cdc_lsn" = (SELECT MAX("_cdc_lsn") FROM %q.items_dest) RETURNING id`,
 		destSchema, destSchema,
 	)).Scan(&droppedID))
+	var stateSchema string
+	require.NoError(t, pg.QueryRowContext(ctx, `
+		SELECT table_schema FROM information_schema.tables
+		WHERE table_name = 'cdc_state'
+		ORDER BY table_schema LIMIT 1`).Scan(&stateSchema))
+	_, err = pg.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %q.cdc_state WHERE state_kind = 'checkpoint'`, stateSchema))
+	require.NoError(t, err)
 	assert.Contains(t, []int64{4, 5}, droppedID)
 	assert.Equal(t, 0, count(`SELECT COUNT(*) FROM %q.items_dest WHERE id = %d`, destSchema, droppedID))
 


### PR DESCRIPTION
## What
Harden SQL Server CDC correctness and enroll supported destinations in managed CDC state.

## Changes
- Fix snapshot isolation, cleanup races, schema mapping, multi-table selection, capture failures, and crash-safe resume boundaries.
- Add source/schema/destination incarnation checks, snapshot/checkpoint state, and streaming commit tokens.
- Keep stamp-based resume as a fallback for destinations without managed-state support.

## How to test
1. Run `make format`, `make lint`, `make test`, and the MSSQL/MySQL/Postgres CDC integration tests.

## Risk & rollback
- **Risk:** Medium — CDC snapshot and resume behavior changes.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.
