### PR TITLE
Standardize CDC stress tests and harden CDC transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 
-.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration cdc-postgres-stress-test cdc-mysql-stress-test cdc-mssql-stress-test
+.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration cdc-stress-test cdc-postgres-stress-test cdc-mysql-stress-test cdc-mssql-stress-test
 
 all: clean deps test build
 
@@ -98,15 +98,39 @@ test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
 	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags integration -v -p 64 -parallel 64 -timeout 20m ./tests/integration/...
 
-# High-volume PostgreSQL CDC accuracy and schema-churn test running parallel
-# ingestion processes into PostgreSQL and DuckDB (~6 minutes with the default
-# profile), followed by focused schema-evolution regressions. The high-volume
-# workload remains gated behind the `stress` build tag.
+# The CDC stress tests share one harness: a queue-based load generator that
+# tracks the target ops/sec (STRESS_OPS_PER_SEC, default 1000) as closely as
+# the source engine allows, parallel ingestion into two destinations at the
+# same time, and post-run verification that both destinations hold an exact
+# replica of the source (aggregates plus row-by-row canonical comparison).
+# PostgreSQL and MSSQL land into PostgreSQL + DuckDB; MySQL lands into
+# MySQL + DuckDB because only MySQL-family and DuckDB destinations implement
+# the CDC mutation-fencing interfaces MySQL CDC requires. Tune with
+# STRESS_OPS_PER_SEC, STRESS_LOAD_DURATION, STRESS_WORKERS, STRESS_SEED_ROWS:
+#   STRESS_OPS_PER_SEC=5000 STRESS_LOAD_DURATION=5m make cdc-postgres-stress-test
+
+# Resolve DOCKER_HOST from the active docker context so testcontainers finds
+# non-default daemons (OrbStack, Colima) in every stress target.
+define STRESS_ENV_SETUP
+if [ -f test.env ]; then . ./test.env; fi; \
+resolved_docker_host="$${DOCKER_HOST:-$$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)}"; \
+if [ -n "$$resolved_docker_host" ]; then export DOCKER_HOST="$$resolved_docker_host"; fi
+endef
+
+# Run every CDC stress test back to back (~20 minutes with default profiles).
+cdc-stress-test: cdc-postgres-stress-test cdc-mysql-stress-test cdc-mssql-stress-test
+
+# High-volume PostgreSQL CDC accuracy and schema-churn test streaming into
+# PostgreSQL and DuckDB in parallel (~6 minutes with the default profile),
+# followed by focused schema-evolution regressions. The high-volume workload
+# remains gated behind the `stress` build tag.
 cdc-postgres-stress-test: generate
 	@echo "$(OK_COLOR)==> Running PostgreSQL CDC complex-workload stress test (default profile: ~6m)$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestPostgresCDC_StressComplexWorkload$$' ./tests/integration/
+	@$(STRESS_ENV_SETUP); \
+	$(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestPostgresCDC_StressComplexWorkload$$' ./tests/integration/
 	@echo "$(OK_COLOR)==> Running PostgreSQL CDC schema-evolution regressions for DuckDB and MySQL$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && INTEGRATION_BACKENDS=postgres,mysql $(TELEMETRY_ENV) go test -tags integration -count=1 -v -timeout 5m -run '^TestPostgresCDC_StreamingSchemaEvolution_(DuckDB|MySQL)$$' ./tests/integration/
+	@$(STRESS_ENV_SETUP); \
+	INTEGRATION_BACKENDS=postgres,mysql $(TELEMETRY_ENV) go test -tags integration -count=1 -v -timeout 5m -run '^TestPostgresCDC_StreamingSchemaEvolution_(DuckDB|MySQL)$$' ./tests/integration/
 
 # High-volume MySQL CDC accuracy and performance test running parallel batch
 # ingestion processes into MySQL and DuckDB (~6 minutes with the default
@@ -114,19 +138,19 @@ cdc-postgres-stress-test: generate
 # recovery. Gated behind the `stress` build tag.
 cdc-mysql-stress-test: generate
 	@echo "$(OK_COLOR)==> Running MySQL CDC stress and correctness regression tests (default profile: ~6m)$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi; \
-	resolved_docker_host="$${DOCKER_HOST:-$$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)}"; \
-	if [ -n "$$resolved_docker_host" ]; then export DOCKER_HOST="$$resolved_docker_host"; fi; \
+	@$(STRESS_ENV_SETUP); \
 	$(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestMySQLCDC_Stress' ./pkg/source/mysql ./tests/integration/
 
 # High-volume SQL Server CDC accuracy and schema-churn test (~7 minutes with
-# the default profile). Streams multi-table CDC into Postgres under load with
-# late tables, capture-instance recreation for add/rename/widen DDL, a
-# transactional delete-all wipe, PK moves, deletes, and wide type coverage,
-# then verifies exact row-by-row parity. Gated behind the `stress` build tag.
+# the default profile). Streams multi-table CDC into PostgreSQL and DuckDB in
+# parallel under load with late tables, capture-instance recreation for
+# add/rename/widen DDL, a transactional delete-all wipe, PK moves, deletes,
+# and wide type coverage, then verifies exact row-by-row parity in both
+# destinations. Gated behind the `stress` build tag.
 cdc-mssql-stress-test: generate
 	@echo "$(OK_COLOR)==> Running SQL Server CDC complex-workload stress test (default profile: ~7m)$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && $(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestMSSQLCDC_StressComplexWorkload$$' ./tests/integration/
+	@$(STRESS_ENV_SETUP); \
+	$(TELEMETRY_ENV) go test -tags stress -count=1 -v -timeout 30m -run '^TestMSSQLCDC_StressComplexWorkload$$' ./tests/integration/
 
 test-db2-integration: generate
 	@echo "$(OK_COLOR)==> Running Db2 integration tests$(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -100,13 +100,11 @@ test-integration: generate
 
 # The CDC stress tests share one harness: a queue-based load generator that
 # tracks the target ops/sec (STRESS_OPS_PER_SEC, default 1000) as closely as
-# the source engine allows, parallel ingestion into two destinations at the
-# same time, and post-run verification that both destinations hold an exact
-# replica of the source (aggregates plus row-by-row canonical comparison).
-# PostgreSQL and MSSQL land into PostgreSQL + DuckDB; MySQL lands into
-# MySQL + DuckDB because only MySQL-family and DuckDB destinations implement
-# the CDC mutation-fencing interfaces MySQL CDC requires. Tune with
-# STRESS_OPS_PER_SEC, STRESS_LOAD_DURATION, STRESS_WORKERS, STRESS_SEED_ROWS:
+# the source engine allows, parallel ingestion into PostgreSQL and DuckDB
+# destinations at the same time, and post-run verification that both
+# destinations hold an exact replica of the source (aggregates plus row-by-row
+# canonical comparison). Tune with STRESS_OPS_PER_SEC, STRESS_LOAD_DURATION,
+# STRESS_WORKERS, STRESS_SEED_ROWS:
 #   STRESS_OPS_PER_SEC=5000 STRESS_LOAD_DURATION=5m make cdc-postgres-stress-test
 
 # Resolve DOCKER_HOST from the active docker context so testcontainers finds
@@ -133,7 +131,7 @@ cdc-postgres-stress-test: generate
 	INTEGRATION_BACKENDS=postgres,mysql $(TELEMETRY_ENV) go test -tags integration -count=1 -v -timeout 5m -run '^TestPostgresCDC_StreamingSchemaEvolution_(DuckDB|MySQL)$$' ./tests/integration/
 
 # High-volume MySQL CDC accuracy and performance test running parallel batch
-# ingestion processes into MySQL and DuckDB (~6 minutes with the default
+# ingestion processes into PostgreSQL and DuckDB (~6 minutes with the default
 # profile), plus focused correctness regressions for protocol modes and failure
 # recovery. Gated behind the `stress` build tag.
 cdc-mysql-stress-test: generate

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -870,14 +870,6 @@ func (d *DuckDBDestination) CDCConditionalSwapIncarnations(ctx context.Context, 
 }
 
 func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
-	startMerge := time.Now()
-
-	stagingColumns := opts.Columns
-	destColumns := destination.DestinationColumns(stagingColumns)
-	stagingQuoted := quoteColumns(stagingColumns)
-	destQuoted := quoteColumns(destColumns)
-	nonPKColumns := filterColumns(destColumns, opts.PrimaryKeys)
-
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -890,13 +882,79 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 			_ = d.exec(ctx, "ROLLBACK")
 		}
 	}()
-	if opts.CDCExpectedIncarnation != "" {
-		current, exists, err := d.cdcTargetIncarnationLocked(ctx, opts.TargetTable)
-		if err != nil {
-			return err
+	if err := d.mergeTableLocked(ctx, opts); err != nil {
+		return err
+	}
+	if err := d.exec(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	commit = true
+	return nil
+}
+
+// MergeCDCTablesAtomically applies one CDC batch's staged changes to every
+// target table inside a single transaction, so a crash cannot leave a torn
+// cross-table state.
+func (d *DuckDBDestination) MergeCDCTablesAtomically(ctx context.Context, merges []destination.CDCAtomicTableMerge) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.exec(ctx, "BEGIN"); err != nil {
+		return fmt.Errorf("failed to begin multi-table CDC transaction: %w", err)
+	}
+	commit := false
+	defer func() {
+		if !commit {
+			_ = d.exec(ctx, "ROLLBACK")
 		}
-		if !exists || current != opts.CDCExpectedIncarnation {
-			return fmt.Errorf("DuckDB CDC target %s was replaced before mutation", opts.TargetTable)
+	}()
+	for _, merge := range merges {
+		if merge.Truncate {
+			if merge.Options.CDCExpectedIncarnation != "" {
+				if err := d.validateCDCIncarnationLocked(ctx, merge.Options.TargetTable, merge.Options.CDCExpectedIncarnation); err != nil {
+					return err
+				}
+			}
+			if err := d.exec(ctx, "DELETE FROM "+destination.QuoteTableName(merge.Options.TargetTable)); err != nil {
+				return fmt.Errorf("failed to reset CDC target %s: %w", merge.Options.TargetTable, err)
+			}
+		}
+		if err := d.mergeTableLocked(ctx, merge.Options); err != nil {
+			return fmt.Errorf("failed to merge CDC target %s: %w", merge.Options.TargetTable, err)
+		}
+	}
+	if err := d.exec(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("failed to commit multi-table CDC transaction: %w", err)
+	}
+	commit = true
+	return nil
+}
+
+func (d *DuckDBDestination) validateCDCIncarnationLocked(ctx context.Context, table, expectedIncarnation string) error {
+	current, exists, err := d.cdcTargetIncarnationLocked(ctx, table)
+	if err != nil {
+		return err
+	}
+	if !exists || current != expectedIncarnation {
+		return fmt.Errorf("DuckDB CDC target %s was replaced before mutation", table)
+	}
+	return nil
+}
+
+// mergeTableLocked runs the merge inside the caller's open transaction;
+// d.mu must be held.
+func (d *DuckDBDestination) mergeTableLocked(ctx context.Context, opts destination.MergeOptions) error {
+	startMerge := time.Now()
+
+	stagingColumns := opts.Columns
+	destColumns := destination.DestinationColumns(stagingColumns)
+	stagingQuoted := quoteColumns(stagingColumns)
+	destQuoted := quoteColumns(destColumns)
+	nonPKColumns := filterColumns(destColumns, opts.PrimaryKeys)
+
+	if opts.CDCExpectedIncarnation != "" {
+		if err := d.validateCDCIncarnationLocked(ctx, opts.TargetTable, opts.CDCExpectedIncarnation); err != nil {
+			return err
 		}
 	}
 
@@ -1046,11 +1104,6 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 			return fmt.Errorf("failed to insert new records: %w", err)
 		}
 
-		if err := d.exec(ctx, "COMMIT"); err != nil {
-			return fmt.Errorf("failed to commit transaction: %w", err)
-		}
-		commit = true
-
 		config.Debug("[DUCKDB MERGE] Merge completed in %v", time.Since(startMerge))
 		return nil
 	}
@@ -1125,11 +1178,6 @@ func (d *DuckDBDestination) MergeTable(ctx context.Context, opts destination.Mer
 			return fmt.Errorf("failed to mark deleted records: %w", err)
 		}
 	}
-
-	if err := d.exec(ctx, "COMMIT"); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-	commit = true
 
 	config.Debug("[DUCKDB MERGE] Merge completed in %v", time.Since(startMerge))
 	return nil

--- a/pkg/destination/duckdb/duckdb_test.go
+++ b/pkg/destination/duckdb/duckdb_test.go
@@ -267,6 +267,121 @@ func TestConditionalMergeAndTruncateRejectRecreatedTarget(t *testing.T) {
 	require.ErrorContains(t, dest.TruncateCDCTableIfIncarnation(t.Context(), "target", expected), "physical incarnation changed")
 }
 
+func TestMergeCDCTablesAtomically(t *testing.T) {
+	ctx := t.Context()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	for _, name := range []string{"target_a", "target_b"} {
+		require.NoError(t, dest.Exec(ctx, fmt.Sprintf(`
+			CREATE TABLE %s (
+				id BIGINT PRIMARY KEY,
+				name VARCHAR,
+				"_cdc_lsn" VARCHAR,
+				"_cdc_deleted" BOOLEAN,
+				"_cdc_synced_at" TIMESTAMP
+			)`, name)))
+	}
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO target_a VALUES (1, 'old', '00000000000000000001', false, CURRENT_TIMESTAMP)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO target_b VALUES (1, 'stale', '00000000000000000001', false, CURRENT_TIMESTAMP), (2, 'stale', '00000000000000000001', false, CURRENT_TIMESTAMP)`))
+	incarnationA, exists, err := dest.EnsureCDCTargetIncarnation(ctx, "target_a")
+	require.NoError(t, err)
+	require.True(t, exists)
+	incarnationB, exists, err := dest.EnsureCDCTargetIncarnation(ctx, "target_b")
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	for _, name := range []string{"staging_a", "staging_b"} {
+		require.NoError(t, dest.Exec(ctx, fmt.Sprintf(`
+			CREATE TABLE %s (
+				id BIGINT,
+				name VARCHAR,
+				"_cdc_lsn" VARCHAR,
+				"_cdc_deleted" BOOLEAN,
+				"_cdc_synced_at" TIMESTAMP
+			)`, name)))
+	}
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO staging_a VALUES
+		(1, 'updated', '00000000000000000002', false, CURRENT_TIMESTAMP),
+		(2, 'inserted', '00000000000000000002', false, CURRENT_TIMESTAMP)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO staging_b VALUES (10, 'repopulated', '00000000000000000002', false, CURRENT_TIMESTAMP)`))
+
+	columns := []string{"id", "name", destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn}
+	require.NoError(t, dest.MergeCDCTablesAtomically(ctx, []destination.CDCAtomicTableMerge{
+		{Options: destination.MergeOptions{
+			StagingTable:           "staging_a",
+			TargetTable:            "target_a",
+			PrimaryKeys:            []string{"id"},
+			Columns:                columns,
+			CDCExpectedIncarnation: incarnationA,
+		}},
+		{Options: destination.MergeOptions{
+			StagingTable:           "staging_b",
+			TargetTable:            "target_b",
+			PrimaryKeys:            []string{"id"},
+			Columns:                columns,
+			CDCExpectedIncarnation: incarnationB,
+		}, Truncate: true},
+	}))
+
+	db := openDuckDB(t, ctx, path)
+	var name string
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name FROM target_a WHERE id = 1`).Scan(&name))
+	require.Equal(t, "updated", name)
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM target_a`).Scan(&count))
+	require.Equal(t, 2, count)
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM target_b`).Scan(&count))
+	require.Equal(t, 1, count)
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name FROM target_b WHERE id = 10`).Scan(&name))
+	require.Equal(t, "repopulated", name)
+}
+
+func TestMergeCDCTablesAtomicallyRollsBackAllTablesOnFailure(t *testing.T) {
+	ctx := t.Context()
+	dest, path := connectTestDuckDB(t, ctx)
+
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE target_a (
+			id BIGINT PRIMARY KEY,
+			name VARCHAR,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMP
+		)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO target_a VALUES (1, 'old', '00000000000000000001', false, CURRENT_TIMESTAMP)`))
+	require.NoError(t, dest.Exec(ctx, `
+		CREATE TABLE staging_a (
+			id BIGINT,
+			name VARCHAR,
+			"_cdc_lsn" VARCHAR,
+			"_cdc_deleted" BOOLEAN,
+			"_cdc_synced_at" TIMESTAMP
+		)`))
+	require.NoError(t, dest.Exec(ctx, `INSERT INTO staging_a VALUES (1, 'updated', '00000000000000000002', false, CURRENT_TIMESTAMP)`))
+
+	columns := []string{"id", "name", destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn}
+	err := dest.MergeCDCTablesAtomically(ctx, []destination.CDCAtomicTableMerge{
+		{Options: destination.MergeOptions{
+			StagingTable: "staging_a",
+			TargetTable:  "target_a",
+			PrimaryKeys:  []string{"id"},
+			Columns:      columns,
+		}},
+		{Options: destination.MergeOptions{
+			StagingTable: "staging_missing",
+			TargetTable:  "target_missing",
+			PrimaryKeys:  []string{"id"},
+			Columns:      columns,
+		}},
+	})
+	require.ErrorContains(t, err, "target_missing")
+
+	db := openDuckDB(t, ctx, path)
+	var name string
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name FROM target_a WHERE id = 1`).Scan(&name))
+	require.Equal(t, "old", name, "failed multi-table merge must roll back every table")
+}
+
 func TestConditionalSwapRebindsStagingIncarnationToTarget(t *testing.T) {
 	dest, path := connectTestDuckDB(t, t.Context())
 	require.NoError(t, dest.Exec(t.Context(), `CREATE TABLE target (id BIGINT, "_cdc_lsn" VARCHAR)`))

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"slices"
 	"strings"
 	"sync"
@@ -727,6 +728,24 @@ func (d *PostgresDestination) SwapTable(ctx context.Context, opts destination.Sw
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	if opts.CDCExpectedIncarnation != "" || opts.CDCExpectedStagingIncarnation != "" || opts.CDCExpectedResultIncarnation != "" {
+		if opts.CDCExpectedIncarnation == "" || opts.CDCExpectedStagingIncarnation == "" || opts.CDCExpectedResultIncarnation == "" {
+			return errors.New("PostgreSQL CDC conditional swap requires target, staging, and result incarnations")
+		}
+		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, targetSchema+"."+targetName, opts.CDCExpectedIncarnation, "ACCESS EXCLUSIVE"); err != nil {
+			return err
+		}
+		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, stagingSchema+"."+stagingName, opts.CDCExpectedStagingIncarnation, "ACCESS EXCLUSIVE"); err != nil {
+			return err
+		}
+		// A PostgreSQL rename (and SET SCHEMA) keeps the relation's OID, so
+		// the staging table's incarnation is what the target name will hold
+		// after the swap.
+		if opts.CDCExpectedResultIncarnation != opts.CDCExpectedStagingIncarnation {
+			return fmt.Errorf("PostgreSQL CDC swap result incarnation %q cannot match the staging relation %q", opts.CDCExpectedResultIncarnation, opts.CDCExpectedStagingIncarnation)
+		}
+	}
+
 	// Postgres' ALTER TABLE … RENAME TO … is same-schema only. If staging lives in a
 	// different schema (the new _bruin_staging design), move it into the target's
 	// schema first via ALTER TABLE … SET SCHEMA (metadata-only, no data copy), then
@@ -854,7 +873,89 @@ func (t *pgTransaction) Rollback(ctx context.Context) error {
 // MergeTable performs an efficient upsert using INSERT ... ON CONFLICT.
 // For CDC sources (detected by presence of _cdc_deleted column), it handles
 // deleted rows specially by only updating CDC columns (preserving original data).
+// lockAndValidateCDCIncarnation locks the table by name inside the caller's
+// transaction and verifies its physical incarnation, so no swap or rebuild
+// can replace the relation between validation and the transaction's
+// mutations: replacing it requires ACCESS EXCLUSIVE, which conflicts with
+// every lock mode used here.
+func (d *PostgresDestination) lockAndValidateCDCIncarnation(ctx context.Context, tx pgx.Tx, table, expectedIncarnation, lockMode string) (string, error) {
+	schemaName, tableName, err := d.resolveSchemaTable(ctx, tx, table)
+	if err != nil {
+		return "", err
+	}
+	resolved := schemaName + "." + tableName
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+destination.QuoteTableName(resolved)+" IN "+lockMode+" MODE"); err != nil {
+		return "", err
+	}
+	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolved)
+	if err != nil {
+		return "", err
+	}
+	if !exists || current != expectedIncarnation {
+		return "", fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed", table)
+	}
+	return resolved, nil
+}
+
 func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	// Begin transaction for atomic merge
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if opts.CDCExpectedIncarnation != "" {
+		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, opts.TargetTable, opts.CDCExpectedIncarnation, "ROW EXCLUSIVE"); err != nil {
+			return err
+		}
+	}
+	if err := d.mergeTableInTx(ctx, tx, opts); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+// MergeCDCTablesAtomically applies one CDC batch's staged changes to every
+// target table inside a single transaction, so a crash cannot leave a torn
+// cross-table state.
+func (d *PostgresDestination) MergeCDCTablesAtomically(ctx context.Context, merges []destination.CDCAtomicTableMerge) error {
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin multi-table CDC transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	for _, merge := range merges {
+		resolved := merge.Options.TargetTable
+		if merge.Options.CDCExpectedIncarnation != "" {
+			resolved, err = d.lockAndValidateCDCIncarnation(ctx, tx, merge.Options.TargetTable, merge.Options.CDCExpectedIncarnation, "ROW EXCLUSIVE")
+			if err != nil {
+				return err
+			}
+		}
+		if merge.Truncate {
+			if _, err := tx.Exec(ctx, "TRUNCATE TABLE "+destination.QuoteTableName(resolved)); err != nil {
+				return fmt.Errorf("failed to reset CDC target %s: %w", merge.Options.TargetTable, err)
+			}
+		}
+		if err := d.mergeTableInTx(ctx, tx, merge.Options); err != nil {
+			return fmt.Errorf("failed to merge CDC target %s: %w", merge.Options.TargetTable, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit multi-table CDC transaction: %w", err)
+	}
+	return nil
+}
+
+// mergeTableInTx runs the merge inside the caller's open transaction.
+func (d *PostgresDestination) mergeTableInTx(ctx context.Context, tx pgx.Tx, opts destination.MergeOptions) error {
 	startMerge := time.Now()
 
 	stagingColumns := opts.Columns
@@ -870,13 +971,6 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 	// unchanged (e.g. Postgres TOAST); other CDC sources materialize full rows
 	// and their staging tables have no such column to reference.
 	hasUnchangedCols := slices.Contains(stagingColumns, destination.CDCUnchangedColsColumn)
-
-	// Begin transaction for atomic merge
-	tx, err := d.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
 
 	quotedTargetTable := destination.QuoteTableName(opts.TargetTable)
 	quotedStagingTable := destination.QuoteTableName(opts.StagingTable)
@@ -1027,10 +1121,6 @@ func (d *PostgresDestination) MergeTable(ctx context.Context, opts destination.M
 			config.LogFailedQuery(upsertSQL, err)
 			return fmt.Errorf("failed to upsert records: %w", err)
 		}
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
@@ -1451,25 +1541,154 @@ func (d *PostgresDestination) TruncateCDCTableIfIncarnation(ctx context.Context,
 		return err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-	schemaName, tableName, err := d.resolveSchemaTable(ctx, tx, table)
+	resolved, err := d.lockAndValidateCDCIncarnation(ctx, tx, table, expectedIncarnation, "ACCESS EXCLUSIVE")
 	if err != nil {
 		return err
-	}
-	resolved := schemaName + "." + tableName
-	if _, err := tx.Exec(ctx, "LOCK TABLE "+destination.QuoteTableName(resolved)+" IN ACCESS EXCLUSIVE MODE"); err != nil {
-		return err
-	}
-	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolved)
-	if err != nil {
-		return err
-	}
-	if !exists || current != expectedIncarnation {
-		return fmt.Errorf("PostgreSQL CDC target %q physical incarnation changed", table)
 	}
 	if _, err := tx.Exec(ctx, "TRUNCATE TABLE "+destination.QuoteTableName(resolved)); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+// SupportsCDCConditionalMerge advertises that MergeTable enforces
+// MergeOptions.CDCExpectedIncarnation in the same transaction as target DML.
+func (d *PostgresDestination) SupportsCDCConditionalMerge() bool { return true }
+
+func (d *PostgresDestination) SupportsCDCConditionalSwap() bool { return true }
+
+func (d *PostgresDestination) CDCConditionalSwapIncarnations(ctx context.Context, targetTable, stagingTable string) (string, string, error) {
+	stagingIncarnation, exists, err := d.CDCTargetIncarnation(ctx, stagingTable)
+	if err != nil {
+		return "", "", err
+	}
+	if !exists || stagingIncarnation == "" {
+		return "", "", fmt.Errorf("PostgreSQL CDC staging table %q has no durable physical incarnation", stagingTable)
+	}
+	// The incarnation key is name-independent (database OID, relation OID,
+	// relkind) and a rename or SET SCHEMA keeps the relation's OID, so the
+	// staging incarnation carries over to the target name unchanged.
+	_ = targetTable
+	return stagingIncarnation, stagingIncarnation, nil
+}
+
+func (d *PostgresDestination) ValidateManagedCDCState() error { return nil }
+
+type postgresManagedCDCRunLease struct {
+	conn        *pgxpool.Conn
+	classID     uint32
+	objID       uint32
+	done        chan struct{}
+	stop        chan struct{}
+	stopped     chan struct{}
+	doneOnce    sync.Once
+	releaseOnce sync.Once
+	mu          sync.Mutex
+	err         error
+	releaseErr  error
+}
+
+// AcquireManagedCDCRunLease serializes all target mutations for one managed
+// CDC connector via a session advisory lock held on a dedicated connection.
+// If the session dies, the server releases the lock and the monitor reports
+// the loss through the standard connector lease guard.
+func (d *PostgresDestination) AcquireManagedCDCRunLease(ctx context.Context, connectorID string) (source.ConnectorLease, error) {
+	if connectorID == "" {
+		return nil, errors.New("managed CDC connector ID is empty")
+	}
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reserve PostgreSQL CDC lease connection: %w", err)
+	}
+	key := postgresAdvisoryLockKey("ingestr_cdc_" + connectorID)
+	var acquired bool
+	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", key).Scan(&acquired); err != nil {
+		conn.Release()
+		return nil, fmt.Errorf("failed to acquire PostgreSQL CDC run lease: %w", err)
+	}
+	if !acquired {
+		conn.Release()
+		return nil, fmt.Errorf("another PostgreSQL CDC run already owns connector %s", connectorID)
+	}
+	lease := &postgresManagedCDCRunLease{
+		conn:    conn,
+		classID: uint32(uint64(key) >> 32),
+		objID:   uint32(uint64(key) & 0xFFFFFFFF),
+		done:    make(chan struct{}),
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	go lease.monitor()
+	return lease, nil
+}
+
+func postgresAdvisoryLockKey(name string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	return int64(h.Sum64())
+}
+
+func (l *postgresManagedCDCRunLease) monitor() {
+	defer close(l.stopped)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.stop:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			var held bool
+			err := l.conn.QueryRow(ctx, `
+				SELECT EXISTS (
+					SELECT 1 FROM pg_locks
+					WHERE locktype = 'advisory' AND objsubid = 1
+					  AND classid = $1 AND objid = $2
+					  AND pid = pg_backend_pid() AND granted
+				)`, int64(l.classID), int64(l.objID)).Scan(&held)
+			cancel()
+			if err == nil && held {
+				continue
+			}
+			if err == nil {
+				err = errors.New("advisory lock is no longer held by this session")
+			}
+			l.mu.Lock()
+			l.err = errors.Join(source.ErrConnectorLeaseLost, fmt.Errorf("PostgreSQL CDC run lease lost: %w", err))
+			l.mu.Unlock()
+			l.doneOnce.Do(func() { close(l.done) })
+			return
+		}
+	}
+}
+
+func (l *postgresManagedCDCRunLease) Done() <-chan struct{} {
+	return l.done
+}
+
+func (l *postgresManagedCDCRunLease) Err() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.err
+}
+
+func (l *postgresManagedCDCRunLease) Release() error {
+	l.releaseOnce.Do(func() {
+		close(l.stop)
+		<-l.stopped
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		key := (int64(l.classID) << 32) | int64(l.objID)
+		var released bool
+		if err := l.conn.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", key).Scan(&released); err != nil {
+			l.releaseErr = fmt.Errorf("failed to release PostgreSQL CDC run lease: %w", err)
+		} else if !released {
+			l.releaseErr = errors.New("PostgreSQL CDC run lease was not held at release")
+		}
+		l.conn.Release()
+		l.doneOnce.Do(func() { close(l.done) })
+	})
+	return l.releaseErr
 }
 
 func (d *PostgresDestination) ClaimCDCTarget(ctx context.Context, claimTable string, claim destination.CDCTargetClaim) error {

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -732,10 +732,10 @@ func (d *PostgresDestination) SwapTable(ctx context.Context, opts destination.Sw
 		if opts.CDCExpectedIncarnation == "" || opts.CDCExpectedStagingIncarnation == "" || opts.CDCExpectedResultIncarnation == "" {
 			return errors.New("PostgreSQL CDC conditional swap requires target, staging, and result incarnations")
 		}
-		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, targetSchema+"."+targetName, opts.CDCExpectedIncarnation, "ACCESS EXCLUSIVE"); err != nil {
+		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, targetRef, opts.CDCExpectedIncarnation, "ACCESS EXCLUSIVE"); err != nil {
 			return err
 		}
-		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, stagingSchema+"."+stagingName, opts.CDCExpectedStagingIncarnation, "ACCESS EXCLUSIVE"); err != nil {
+		if _, err := d.lockAndValidateCDCIncarnation(ctx, tx, stagingRef, opts.CDCExpectedStagingIncarnation, "ACCESS EXCLUSIVE"); err != nil {
 			return err
 		}
 		// A PostgreSQL rename (and SET SCHEMA) keeps the relation's OID, so
@@ -883,8 +883,8 @@ func (d *PostgresDestination) lockAndValidateCDCIncarnation(ctx context.Context,
 	if err != nil {
 		return "", err
 	}
-	resolved := schemaName + "." + tableName
-	if _, err := tx.Exec(ctx, "LOCK TABLE "+destination.QuoteTableName(resolved)+" IN "+lockMode+" MODE"); err != nil {
+	resolved := quotePostgresTable(schemaName, tableName)
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+resolved+" IN "+lockMode+" MODE"); err != nil {
 		return "", err
 	}
 	current, exists, err := d.postgresTargetIncarnation(ctx, tx, resolved)
@@ -1454,7 +1454,7 @@ func (d *PostgresDestination) postgresTargetIncarnation(ctx context.Context, que
 	if err != nil {
 		return "", false, err
 	}
-	resolvedTable := destination.QuoteTableName(schemaName + "." + tableName)
+	resolvedTable := quotePostgresTable(schemaName, tableName)
 	var databaseOID, relationOID, relationKind string
 	err = queryer.QueryRow(ctx, `
 		SELECT d.oid::text, c.oid::text, c.relkind::text

--- a/pkg/destination/postgres/postgres_test.go
+++ b/pkg/destination/postgres/postgres_test.go
@@ -62,6 +62,31 @@ func (r postgresResolverRow) Scan(dest ...any) error {
 	return nil
 }
 
+type postgresIncarnationTxStub struct {
+	pgx.Tx
+	execSQL   string
+	queryArgs []any
+}
+
+func (s *postgresIncarnationTxStub) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	s.execSQL = sql
+	return pgconn.NewCommandTag("LOCK TABLE"), nil
+}
+
+func (s *postgresIncarnationTxStub) QueryRow(_ context.Context, _ string, args ...any) pgx.Row {
+	s.queryArgs = args
+	return postgresIncarnationRow{}
+}
+
+type postgresIncarnationRow struct{}
+
+func (postgresIncarnationRow) Scan(dest ...any) error {
+	*dest[0].(*string) = "database-oid"
+	*dest[1].(*string) = "relation-oid"
+	*dest[2].(*string) = "r"
+	return nil
+}
+
 type postgresPrimaryKeyResolverStub struct {
 	query string
 	args  []any
@@ -424,6 +449,32 @@ func TestQuotePostgresTablePreservesDottedIdentifierBoundary(t *testing.T) {
 	got := quotePostgresTable("tenant", "order.events_old_123")
 	if got != `"tenant"."order.events_old_123"` {
 		t.Fatalf("quotePostgresTable() = %q", got)
+	}
+}
+
+func TestLockAndValidateCDCIncarnationPreservesDottedIdentifierBoundary(t *testing.T) {
+	dest := NewPostgresDestination()
+	tx := &postgresIncarnationTxStub{}
+	expected := destination.CDCTargetKey("database-oid", "relation-oid", "r")
+
+	resolved, err := dest.lockAndValidateCDCIncarnation(
+		t.Context(),
+		tx,
+		`"public"."order.events"`,
+		expected,
+		"ACCESS EXCLUSIVE",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != `"public"."order.events"` {
+		t.Fatalf("resolved table = %q", resolved)
+	}
+	if tx.execSQL != `LOCK TABLE "public"."order.events" IN ACCESS EXCLUSIVE MODE` {
+		t.Fatalf("lock SQL = %q", tx.execSQL)
+	}
+	if len(tx.queryArgs) != 1 || tx.queryArgs[0] != `"public"."order.events"` {
+		t.Fatalf("incarnation query args = %v", tx.queryArgs)
 	}
 }
 

--- a/pkg/destination/postgres/swap_integration_test.go
+++ b/pkg/destination/postgres/swap_integration_test.go
@@ -53,9 +53,21 @@ func TestSwapTablePreservesQuotedDottedTargetBoundary(t *testing.T) {
 		INSERT INTO "public"."staging_for_order_events" VALUES (2);
 	`))
 
+	targetTable := `"public"."order.events"`
+	stagingTable := `"public"."staging_for_order_events"`
+	targetIncarnation, exists, err := dest.CDCTargetIncarnation(ctx, targetTable)
+	require.NoError(t, err)
+	require.True(t, exists)
+	stagingIncarnation, exists, err := dest.CDCTargetIncarnation(ctx, stagingTable)
+	require.NoError(t, err)
+	require.True(t, exists)
+
 	require.NoError(t, dest.SwapTable(ctx, destination.SwapOptions{
-		StagingTable: `"public"."staging_for_order_events"`,
-		TargetTable:  `"public"."order.events"`,
+		StagingTable:                  stagingTable,
+		TargetTable:                   targetTable,
+		CDCExpectedIncarnation:        targetIncarnation,
+		CDCExpectedStagingIncarnation: stagingIncarnation,
+		CDCExpectedResultIncarnation:  stagingIncarnation,
 	}))
 
 	var targetID, sentinelID, oldCount int64

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -1485,8 +1485,9 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		frac := (micros % 1000000)
 		return fmt.Sprintf("%02d:%02d:%02d.%06d", hours, mins, secs, frac)
 	case *array.Timestamp:
-		ts := a.Value(idx)
-		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.000000")
+		// Arrow's own rendering ("2026-03-30T13:15:43.123456Z") so create-run
+		// inserts and merge-run schema-aligner casts store identical text.
+		return a.ValueStr(idx)
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
 	case array.ExtensionArray:

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2535,6 +2535,12 @@ func isMySQLCDCSource(rawURI string) bool {
 	}
 }
 
+func isMySQLFamilyScheme(scheme string) bool {
+	normalized := strings.ToLower(scheme)
+	return normalized == "mysql" || normalized == "mariadb" ||
+		strings.HasPrefix(normalized, "mysql+") || strings.HasPrefix(normalized, "mariadb+")
+}
+
 type mysqlServerIdentityProvider interface {
 	MySQLServerIdentity() string
 	MySQLDatabaseName() string
@@ -2549,18 +2555,25 @@ func validateMySQLCDCSourceDestination(cfg *config.IngestConfig, src source.Sour
 	if !ok || sourceIdentity.MySQLServerIdentity() == "" {
 		return fmt.Errorf("MySQL CDC source does not expose a verifiable server identity")
 	}
-	destinationIdentity, ok := dest.(mysqlServerIdentityProvider)
-	if !ok || destinationIdentity.MySQLServerIdentity() == "" {
+	destinationIdentity, hasIdentity := dest.(mysqlServerIdentityProvider)
+	if !hasIdentity || destinationIdentity.MySQLServerIdentity() == "" {
 		// A missing identity (e.g. a MariaDB destination predating
 		// @@GLOBAL.server_uid) is still safe when the destination flavor
 		// provably differs from the source's: identities are prefixed by
 		// flavor, so they can never refer to the same physical server.
-		if flavorProvider, ok := dest.(mysqlServerFlavorProvider); ok {
+		flavorProvider, hasFlavor := dest.(mysqlServerFlavorProvider)
+		if hasFlavor {
 			destinationFlavor := flavorProvider.MySQLServerFlavor()
 			sourceFlavor, _, _ := strings.Cut(sourceIdentity.MySQLServerIdentity(), ":")
 			if destinationFlavor != "" && destinationFlavor != sourceFlavor {
 				return nil
 			}
+		}
+		// Destinations that are not MySQL-family servers at all (DuckDB,
+		// PostgreSQL, ...) can never be the CDC source server, so no feedback
+		// loop is possible and no identity is required.
+		if !hasIdentity && !hasFlavor && !isMySQLFamilyScheme(dest.GetScheme()) {
+			return nil
 		}
 		return fmt.Errorf("destination scheme %q does not expose a verifiable MySQL server identity required to prevent CDC feedback loops", dest.GetScheme())
 	}

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	internalregistry "github.com/bruin-data/ingestr/internal/registry"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	postgresdest "github.com/bruin-data/ingestr/pkg/destination/postgres"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -1350,6 +1351,8 @@ func TestValidateMySQLCDCMutationFencing(t *testing.T) {
 	unsupported := &mockManagedCDCStateDestination{}
 	require.ErrorContains(t, validateMySQLCDCMutationFencing(unsupported, false), "atomic target-incarnation fencing for merge")
 	require.NoError(t, validateMySQLCDCMutationFencing(&mockMySQLCDCFencedDestination{}, false))
+	require.NoError(t, validateMySQLCDCMutationFencing(postgresdest.NewPostgresDestination(), true),
+		"the PostgreSQL destination must satisfy every MySQL CDC fencing capability, including atomic multi-table merge")
 }
 
 func TestValidateChangeTrackingDestinationRequiresResumeProvider(t *testing.T) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -443,6 +443,16 @@ func TestMySQLCDCDestinationWithoutIdentity(t *testing.T) {
 
 	unknownFlavor := &mysqlIdentityDestination{mockDestination: mockDestination{scheme: "mysql"}, database: "app"}
 	require.ErrorContains(t, validateMySQLCDCSourceDestination(cfg, src, unknownFlavor), "verifiable MySQL server identity")
+
+	// Destinations that are not MySQL-family servers can never be the CDC
+	// source server, so they need no identity.
+	for _, scheme := range []string{"duckdb", "postgres", "bigquery"} {
+		require.NoError(t, validateMySQLCDCSourceDestination(cfg, src, &mockDestination{scheme: scheme}), scheme)
+	}
+	for _, scheme := range []string{"mysql", "mysql+pymysql", "mariadb"} {
+		require.ErrorContains(t, validateMySQLCDCSourceDestination(cfg, src, &mockDestination{scheme: scheme}),
+			"verifiable MySQL server identity", scheme)
+	}
 }
 
 func TestValidateCDCRunSerialization(t *testing.T) {

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -875,21 +875,29 @@ func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta ta
 
 // isTransientMSSQLError reports errors SQL Server tells the client to retry:
 // a deadlock victim (1205), most commonly the watermark or change-table reads
-// losing a lock race against the CDC capture job under write-heavy load.
+// losing a lock race against the CDC capture job under write-heavy load. CDC
+// procedures can also wrap the victim error inside their own error number,
+// where only the message text carries the 1205 cause.
 func isTransientMSSQLError(err error) bool {
 	var sqlErr mssqldb.Error
-	return errors.As(err, &sqlErr) && sqlErr.Number == 1205
+	if errors.As(err, &sqlErr) && sqlErr.Number == 1205 {
+		return true
+	}
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "deadlock")
 }
 
 func (s *MSSQLCDCSource) maxLSN(ctx context.Context) (string, error) {
 	var lsn sql.NullString
 	var err error
-	for attempt := 0; attempt < 4; attempt++ {
+	// Deadlock storms around capture-instance DDL or large transactions can
+	// outlast a short retry window, so back off progressively before treating
+	// the watermark read as fatal.
+	for attempt := 0; attempt < 8; attempt++ {
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
 				return "", ctx.Err()
-			case <-time.After(250 * time.Millisecond):
+			case <-time.After(time.Duration(attempt) * 250 * time.Millisecond):
 			}
 		}
 		err = s.db.QueryRowContext(ctx, "SELECT CONVERT(varchar(20), sys.fn_cdc_get_max_lsn(), 2)").Scan(&lsn)

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -417,6 +417,16 @@ func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 					reReadByTable[table.Name] = !isSnapshotStamp(resume)
 					continue
 				}
+				handoffStart, handed, err := s.handoffStartFromPreviousInstance(ctx, meta, table.Schema, startHex, opts.ReadOptions, results, table.Name)
+				if err != nil {
+					results <- source.RecordBatchResult{Err: err}
+					return
+				}
+				if handed {
+					startByTable[table.Name] = handoffStart
+					reReadByTable[table.Name] = true
+					continue
+				}
 			}
 
 			snapshotLSN, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name)
@@ -768,6 +778,17 @@ func (t *CDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-chan so
 				}
 				return
 			}
+			handoffStart, handed, err := t.source.handoffStartFromPreviousInstance(ctx, t.metadata, t.tableSchema, startHex, opts, results, "")
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+			if handed {
+				if err := t.source.streamTable(ctx, t.metadata, t.tableSchema, handoffStart, true, opts, results, ""); err != nil {
+					results <- source.RecordBatchResult{Err: err}
+				}
+				return
+			}
 			config.Debug("[MSSQL CDC] Resume LSN %s is no longer valid for %s; taking a fresh snapshot", startHex, t.tableName)
 		}
 
@@ -794,6 +815,125 @@ func (s *MSSQLCDCSource) canResume(ctx context.Context, meta tableMetadata, star
 		return false, nil
 	}
 	return compareLSNHex(startHex, minLSN) >= 0, nil
+}
+
+// previousTableMetadata returns the second-newest active capture instance for
+// the table, if one exists. SQL Server allows at most two instances per
+// table; during an instance recreation the older one still covers the LSN
+// range before the new instance's start.
+func (s *MSSQLCDCSource) previousTableMetadata(ctx context.Context, meta tableMetadata) (tableMetadata, bool, error) {
+	var previous tableMetadata
+	err := s.db.QueryRowContext(ctx, `
+		SELECT TOP (1)
+			ss.name,
+			st.name,
+			ct.capture_instance,
+			OBJECT_SCHEMA_NAME(ct.object_id) + N'.' + OBJECT_NAME(ct.object_id)
+		FROM cdc.change_tables AS ct
+		JOIN sys.tables AS st ON st.object_id = ct.source_object_id
+		JOIN sys.schemas AS ss ON ss.schema_id = st.schema_id
+		WHERE ss.name = @p1
+		  AND st.name = @p2
+		  AND ct.end_lsn IS NULL
+		  AND ct.capture_instance <> @p3
+		ORDER BY ct.start_lsn DESC
+	`, meta.SourceSchema, meta.SourceName, meta.CaptureInstance).
+		Scan(&previous.SourceSchema, &previous.SourceName, &previous.CaptureInstance, &previous.ChangeTable)
+	if err == sql.ErrNoRows {
+		return previous, false, nil
+	}
+	if err != nil {
+		return previous, false, fmt.Errorf("failed to query previous capture instance for %s: %w", tableName(meta), err)
+	}
+	previous.CurrentColumns = meta.CurrentColumns
+	return previous, true, nil
+}
+
+// captureInstanceColumnSignature renders an instance's captured column layout
+// (name, type, length, precision, scale in ordinal order, metadata columns
+// excluded) so two instances can be compared for an identical capture shape.
+func (s *MSSQLCDCSource) captureInstanceColumnSignature(ctx context.Context, meta tableMetadata) (string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT c.name, ty.name, c.max_length, c.precision, c.scale
+		FROM cdc.change_tables AS ct
+		JOIN sys.columns AS c ON c.object_id = ct.object_id
+		JOIN sys.types AS ty ON ty.user_type_id = c.user_type_id
+		WHERE ct.capture_instance = @p1
+		  AND c.name NOT LIKE N'[_][_]$%'
+		ORDER BY c.column_id
+	`, meta.CaptureInstance)
+	if err != nil {
+		return "", fmt.Errorf("failed to query captured columns for instance %s: %w", meta.CaptureInstance, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var signature strings.Builder
+	for rows.Next() {
+		var name, typeName string
+		var maxLength, precision, scale int
+		if err := rows.Scan(&name, &typeName, &maxLength, &precision, &scale); err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&signature, "%s:%s:%d:%d:%d;", strings.ToLower(name), strings.ToLower(typeName), maxLength, precision, scale)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return signature.String(), nil
+}
+
+// handoffStartFromPreviousInstance implements the documented capture-instance
+// recreation flow without a re-snapshot: when the resume cursor predates the
+// newest instance but a previous instance with an identical captured column
+// layout still covers it, the gap up to the new instance's start is drained
+// from the previous instance and the position moves onto the new one. A
+// changed column layout keeps the re-snapshot path — rows untouched since the
+// DDL would otherwise never receive the new columns' values in the
+// destination. Boundary rows can exist in both change tables; the caller
+// resumes the new instance with a re-read boundary and merge absorbs the
+// overlap.
+func (s *MSSQLCDCSource) handoffStartFromPreviousInstance(
+	ctx context.Context,
+	meta tableMetadata,
+	tableSchema *schema.TableSchema,
+	startHex string,
+	opts source.ReadOptions,
+	results chan<- source.RecordBatchResult,
+	resultTable string,
+) (string, bool, error) {
+	previous, ok, err := s.previousTableMetadata(ctx, meta)
+	if err != nil || !ok {
+		return "", false, err
+	}
+	coveredByPrevious, err := s.canResume(ctx, previous, startHex)
+	if err != nil || !coveredByPrevious {
+		return "", false, err
+	}
+	newStart, err := s.minLSN(ctx, meta)
+	if err != nil {
+		return "", false, err
+	}
+	if newStart == "" || isZeroLSN(newStart) {
+		return "", false, nil
+	}
+	currentSignature, err := s.captureInstanceColumnSignature(ctx, meta)
+	if err != nil {
+		return "", false, err
+	}
+	previousSignature, err := s.captureInstanceColumnSignature(ctx, previous)
+	if err != nil {
+		return "", false, err
+	}
+	if currentSignature == "" || currentSignature != previousSignature {
+		return "", false, nil
+	}
+
+	config.Debug("[MSSQL CDC] Handing off %s from capture instance %s to %s: draining %s..%s before switching",
+		tableName(meta), previous.CaptureInstance, meta.CaptureInstance, startHex, newStart)
+	if err := s.readChanges(ctx, previous, tableSchema, startHex, newStart, true, opts, results, resultTable); err != nil {
+		return "", false, fmt.Errorf("failed to drain previous capture instance %s for %s: %w", previous.CaptureInstance, tableName(meta), err)
+	}
+	return newStart, true, nil
 }
 
 func (s *MSSQLCDCSource) snapshotTable(ctx context.Context, meta tableMetadata, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string) (string, error) {

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"reflect"
 	"regexp"
@@ -95,6 +94,12 @@ type MySQLCDCSource struct {
 	state             source.CDCStateCommitToken
 	schemaMu          sync.Mutex
 	discoveredSchemas map[string]*schema.TableSchema
+	// keylessWarned dedupes the append-only notice per table: discovery runs
+	// repeatedly (initial run, catch-up runs, streaming rediscovery) and the
+	// warning should print once per table, not once per pass.
+	keylessWarnedMu sync.Mutex
+	keylessWarned   map[string]bool
+	reloadPrivOnce  sync.Once
 }
 
 type mysqlCDCCheckpoint struct {
@@ -392,6 +397,9 @@ func (s *MySQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) 
 	if req.Strategy != "" && req.Strategy != config.StrategyMerge && req.Strategy != config.StrategyReplace {
 		return nil, fmt.Errorf("MySQL CDC only supports the merge strategy (replace is accepted as a request for the initial snapshot)")
 	}
+	if req.Strategy == config.StrategyReplace {
+		fmt.Printf("Warning: MySQL CDC runs --incremental-strategy replace as merge; the initial snapshot rebuilds the table and later runs apply changes incrementally\n")
+	}
 
 	return &MySQLCDCTable{
 		source:      s,
@@ -484,7 +492,11 @@ func (s *MySQLCDCSource) loadMySQLCDCTables(ctx context.Context, tableNames []st
 		}
 		tableSchema := addMySQLCDCColumns(fullSchema)
 		if len(tableSchema.PrimaryKeys) == 0 {
-			return nil, fmt.Errorf("MySQL CDC table %s has no primary key; multi-table CDC requires source primary keys", tableName)
+			// Same policy as Postgres CDC: a table with no primary key has no
+			// row identity to merge on, so it lands as an append-only change
+			// log (updates arrive as delete+insert retract pairs) instead of
+			// blocking CDC for every other table in the database.
+			s.warnKeylessTable(tableName)
 		}
 
 		tables = append(tables, source.SourceTableInfo{
@@ -495,6 +507,21 @@ func (s *MySQLCDCSource) loadMySQLCDCTables(ctx context.Context, tableNames []st
 		})
 	}
 	return tables, nil
+}
+
+// warnKeylessTable tells the user (once per table) that a table with no
+// primary key is ingested as an append-only change log.
+func (s *MySQLCDCSource) warnKeylessTable(name string) {
+	s.keylessWarnedMu.Lock()
+	defer s.keylessWarnedMu.Unlock()
+	if s.keylessWarned == nil {
+		s.keylessWarned = make(map[string]bool)
+	}
+	if s.keylessWarned[name] {
+		return
+	}
+	s.keylessWarned[name] = true
+	fmt.Printf("Warning: table %s has no primary key; ingesting it as an append-only change log (_cdc_deleted marks deletes, updates arrive as delete+insert pairs)\n", name)
 }
 
 func (s *MySQLCDCSource) getSelectedTables(ctx context.Context, opts source.MultiTableReadOptions) ([]source.SourceTableInfo, error) {
@@ -877,7 +904,12 @@ func validateMySQLCDCTableSupported(ctx context.Context, db *sql.DB, database st
 		SELECT COLUMN_NAME, DATA_TYPE
 		FROM INFORMATION_SCHEMA.COLUMNS
 		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
-		  AND LOWER(DATA_TYPE) IN ('enum', 'set', 'bit')
+		  AND LOWER(DATA_TYPE) IN (
+			'enum', 'set', 'bit',
+			'geometry', 'point', 'linestring', 'polygon',
+			'multipoint', 'multilinestring', 'multipolygon',
+			'geomcollection', 'geometrycollection'
+		  )
 		ORDER BY ORDINAL_POSITION
 	`, schemaName, tableName)
 	if err != nil {
@@ -897,7 +929,7 @@ func validateMySQLCDCTableSupported(ctx context.Context, db *sql.DB, database st
 		return err
 	}
 	if len(unsupported) > 0 {
-		return fmt.Errorf("MySQL CDC does not support ENUM, SET, or BIT columns yet; unsupported columns in %s: %s", table, strings.Join(unsupported, ", "))
+		return fmt.Errorf("MySQL CDC does not support ENUM, SET, BIT, or spatial (GEOMETRY) columns yet; unsupported columns in %s: %s", table, strings.Join(unsupported, ", "))
 	}
 	return nil
 }
@@ -1049,7 +1081,38 @@ func (s *MySQLCDCSource) canResume(ctx context.Context, checkpoint mysqlCDCCheck
 	return false, nil
 }
 
+// warnMissingReloadPrivilege checks (once per source) whether the connected
+// user shows evidence of the RELOAD/FLUSH_TABLES privilege the snapshot's
+// FLUSH TABLES WITH READ LOCK needs, and warns before per-table work starts.
+// Grant parsing cannot see role-granted privileges reliably, so a miss only
+// warns; the FTWRL itself still fails loudly when the privilege is absent.
+func (s *MySQLCDCSource) warnMissingReloadPrivilege(ctx context.Context) {
+	s.reloadPrivOnce.Do(func() {
+		rows, err := s.db.QueryContext(ctx, "SHOW GRANTS FOR CURRENT_USER()")
+		if err != nil {
+			return
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var grant string
+			if err := rows.Scan(&grant); err != nil {
+				return
+			}
+			upper := strings.ToUpper(grant)
+			if strings.Contains(upper, "RELOAD") || strings.Contains(upper, "FLUSH_TABLES") ||
+				strings.Contains(upper, "ALL PRIVILEGES ON *.*") {
+				return
+			}
+		}
+		if rows.Err() != nil {
+			return
+		}
+		fmt.Printf("Warning: the MySQL user does not appear to have the RELOAD (or FLUSH_TABLES) privilege; the CDC snapshot's FLUSH TABLES WITH READ LOCK will fail without it (GRANT RELOAD ON *.* TO <user>)\n")
+	})
+}
+
 func (s *MySQLCDCSource) snapshotTable(ctx context.Context, meta mysqlCDCTableMetadata, outputSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string, validateInventory func(context.Context, mysqlCDCPositionQueryer) error) (mysqlCDCCheckpoint, error) {
+	s.warnMissingReloadPrivilege(ctx)
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return mysqlCDCCheckpoint{}, fmt.Errorf("failed to acquire MySQL connection: %w", err)
@@ -1125,7 +1188,7 @@ func beginMySQLConsistentSnapshotWithValidation(ctx context.Context, conn mysqlC
 	}
 
 	if _, err := conn.ExecContext(ctx, "FLUSH TABLES WITH READ LOCK"); err != nil {
-		return gomysql.Position{}, fmt.Errorf("failed to lock MySQL tables for snapshot: %w", err)
+		return gomysql.Position{}, fmt.Errorf("failed to lock MySQL tables for snapshot (FLUSH TABLES WITH READ LOCK requires the RELOAD privilege): %w", err)
 	}
 
 	locked := true
@@ -2048,8 +2111,18 @@ func (s *MySQLCDCSource) newBinlogSyncer() *replication.BinlogSyncer {
 	return replication.NewBinlogSyncer(s.binlogSyncerConfig())
 }
 
+// mysqlCDCSyncerLogWriter forwards go-mysql's internal logs (connection
+// losses, auto-reconnect attempts) to the debug log so a stalling stream is
+// diagnosable with --debug instead of silently retrying.
+type mysqlCDCSyncerLogWriter struct{}
+
+func (mysqlCDCSyncerLogWriter) Write(p []byte) (int, error) {
+	config.Debug("[MYSQL BINLOG] %s", strings.TrimRight(string(p), "\n"))
+	return len(p), nil
+}
+
 func (s *MySQLCDCSource) binlogSyncerConfig() replication.BinlogSyncerConfig {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.NewTextHandler(mysqlCDCSyncerLogWriter{}, nil))
 	return replication.BinlogSyncerConfig{
 		ServerID:        s.cdcConfig.ServerID,
 		Flavor:          s.cdcConfig.Flavor,
@@ -2150,6 +2223,9 @@ func projectMySQLCDCRow(row []interface{}, fullSourceColumns []schema.Column, ou
 		if _, partialJSON := row[sourceIdx].(*replication.JsonDiff); partialJSON {
 			return nil, fmt.Errorf("binlog row image contains a partial JSON value; producer sessions must leave binlog_row_value_options empty")
 		}
+		if err := validateMySQLCDCTimeValue(row[sourceIdx], outputSourceColumns[i]); err != nil {
+			return nil, err
+		}
 		values[i] = convertMySQLCDCBinlogValue(row[sourceIdx], outputSourceColumns[i])
 	}
 	return values, nil
@@ -2188,6 +2264,9 @@ func convertMySQLCDCValue(value interface{}, col schema.Column) interface{} {
 	}
 	switch v := value.(type) {
 	case string:
+		if isMySQLCDCZeroDate(v, col.DataType) {
+			return nil
+		}
 		return strings.Clone(v)
 	case []byte:
 		if col.DataType == schema.TypeBinary {
@@ -2195,13 +2274,70 @@ func convertMySQLCDCValue(value interface{}, col schema.Column) interface{} {
 			copy(copied, v)
 			return copied
 		}
-		return string(v)
+		s := string(v)
+		if isMySQLCDCZeroDate(s, col.DataType) {
+			return nil
+		}
+		return s
+	case time.Time:
+		// The driver delivers MySQL zero dates ('0000-00-00') as Go's zero
+		// time; the binlog path delivers them as strings that fail to parse.
+		// Normalize both to NULL so snapshot and change rows agree.
+		if v.IsZero() {
+			return nil
+		}
+		return v
 	default:
 		return v
 	}
 }
 
+func isMySQLCDCZeroDate(value string, dataType schema.DataType) bool {
+	switch dataType {
+	case schema.TypeDate, schema.TypeTimestamp, schema.TypeTimestampTZ:
+		return strings.HasPrefix(value, "0000-00-00")
+	default:
+		return false
+	}
+}
+
+// mysqlCDCTimeLiteral matches MySQL TIME literals: an optional sign and an
+// hour count up to MySQL's ±838 hour range, with optional fractional seconds.
+var mysqlCDCTimeLiteral = regexp.MustCompile(`^(-?)(\d{1,3}):([0-5]\d):([0-5]\d)(?:\.\d{1,6})?$`)
+
+// validateMySQLCDCTimeValue rejects TIME values that cannot be represented as
+// an Arrow time of day. MySQL TIME is a signed duration spanning ±838 hours;
+// values outside 00:00:00–23:59:59 previously became NULL silently.
+func validateMySQLCDCTimeValue(value interface{}, col schema.Column) error {
+	if col.DataType != schema.TypeTime {
+		return nil
+	}
+	var literal string
+	switch v := value.(type) {
+	case string:
+		literal = v
+	case []byte:
+		literal = string(v)
+	default:
+		return nil
+	}
+	match := mysqlCDCTimeLiteral.FindStringSubmatch(literal)
+	if match == nil {
+		return nil
+	}
+	hours, _ := strconv.Atoi(match[2])
+	if match[1] == "-" || hours > 23 {
+		return fmt.Errorf("MySQL TIME value %q in column %s is outside 00:00:00-23:59:59 and cannot be represented as a time of day (MySQL TIME spans ±838 hours); cast the column to seconds or a string on the source, or exclude it", literal, col.Name)
+	}
+	return nil
+}
+
 func primaryKeyChanged(before, after []interface{}, pkIndexes []int) bool {
+	// Keyless change-log tables have no identity to match an update on, so
+	// every update is emitted as a delete+insert retract pair.
+	if len(pkIndexes) == 0 {
+		return true
+	}
 	for _, idx := range pkIndexes {
 		if idx < 0 || idx >= len(before) || idx >= len(after) {
 			continue
@@ -2297,7 +2433,12 @@ func buildMySQLCDCSQLBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sour
 		}
 
 		for i, dest := range scanDest {
-			arrowconv.AppendValue(builders[i], convertMySQLCDCValue(*dest.(*interface{}), sourceColumns[i]))
+			value := *dest.(*interface{})
+			if err := validateMySQLCDCTimeValue(value, sourceColumns[i]); err != nil {
+				releaseMySQLCDCBuilders(builders)
+				return nil, 0, err
+			}
+			arrowconv.AppendValue(builders[i], convertMySQLCDCValue(value, sourceColumns[i]))
 		}
 		appendCDC(builders)
 
@@ -2648,11 +2789,35 @@ func removeMySQLCDCColumns(tableSchema *schema.TableSchema) *schema.TableSchema 
 	return &copied
 }
 
+// sourceColumnsWithoutMySQLCDC strips the CDC metadata columns from a table
+// schema. The metadata columns are normally appended at the end, so the fast
+// path verifies the suffix by name and returns a prefix slice; any other
+// layout falls back to name-based filtering instead of blindly chopping the
+// last columns.
 func sourceColumnsWithoutMySQLCDC(tableSchema *schema.TableSchema) []schema.Column {
-	if tableSchema == nil || len(tableSchema.Columns) < len(mysqlCDCColumns) {
+	if tableSchema == nil {
 		return nil
 	}
-	return tableSchema.Columns[:len(tableSchema.Columns)-len(mysqlCDCColumns)]
+	columns := tableSchema.Columns
+	if split := len(columns) - len(mysqlCDCColumns); split >= 0 {
+		suffixIsMeta := true
+		for _, col := range columns[split:] {
+			if !destination.IsCDCMetaColumn(col.Name) {
+				suffixIsMeta = false
+				break
+			}
+		}
+		if suffixIsMeta {
+			return columns[:split]
+		}
+	}
+	filtered := make([]schema.Column, 0, len(columns))
+	for _, col := range columns {
+		if !destination.IsCDCMetaColumn(col.Name) {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered
 }
 
 func minMySQLPosition(positions map[string]gomysql.Position) gomysql.Position {

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -142,13 +142,15 @@ func TestValidateMySQLCDCTableSupportedRejectsNativeBinlogTypes(t *testing.T) {
 		WithArgs("app", "items").
 		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}).
 			AddRow("status", "enum").
-			AddRow("flags", "bit"))
+			AddRow("flags", "bit").
+			AddRow("location", "point"))
 
 	err = validateMySQLCDCTableSupported(context.Background(), db, "app", "items")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ENUM, SET, or BIT")
+	assert.Contains(t, err.Error(), "ENUM, SET, BIT, or spatial (GEOMETRY)")
 	assert.Contains(t, err.Error(), "status ENUM")
 	assert.Contains(t, err.Error(), "flags BIT")
+	assert.Contains(t, err.Error(), "location POINT")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -735,6 +737,44 @@ func TestConvertMySQLCDCBinlogValueUnsigned(t *testing.T) {
 	}
 }
 
+func TestConvertMySQLCDCValueNormalizesZeroDates(t *testing.T) {
+	cases := []struct {
+		name  string
+		value interface{}
+		col   schema.Column
+		want  interface{}
+	}{
+		{"zero date string", "0000-00-00", schema.Column{Name: "d", DataType: schema.TypeDate}, nil},
+		{"zero datetime string", "0000-00-00 00:00:00", schema.Column{Name: "dt", DataType: schema.TypeTimestamp}, nil},
+		{"zero timestamp bytes", []byte("0000-00-00 00:00:00"), schema.Column{Name: "ts", DataType: schema.TypeTimestampTZ}, nil},
+		{"driver zero time", time.Time{}, schema.Column{Name: "dt", DataType: schema.TypeTimestamp}, nil},
+		{"valid date string", "2026-07-24", schema.Column{Name: "d", DataType: schema.TypeDate}, "2026-07-24"},
+		{"zero-date-looking text column untouched", "0000-00-00", schema.Column{Name: "note", DataType: schema.TypeString}, "0000-00-00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, convertMySQLCDCValue(tc.value, tc.col))
+		})
+	}
+	valid := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	assert.Equal(t, valid, convertMySQLCDCValue(valid, schema.Column{Name: "dt", DataType: schema.TypeTimestamp}))
+}
+
+func TestValidateMySQLCDCTimeValueRejectsOutOfRange(t *testing.T) {
+	timeCol := schema.Column{Name: "elapsed", DataType: schema.TypeTime}
+	require.NoError(t, validateMySQLCDCTimeValue("23:59:59", timeCol))
+	require.NoError(t, validateMySQLCDCTimeValue("00:00:00", timeCol))
+	require.NoError(t, validateMySQLCDCTimeValue([]byte("12:34:56.123456"), timeCol))
+	require.NoError(t, validateMySQLCDCTimeValue(nil, timeCol))
+	require.NoError(t, validateMySQLCDCTimeValue("838:59:59", schema.Column{Name: "note", DataType: schema.TypeString}))
+
+	err := validateMySQLCDCTimeValue("838:59:59", timeCol)
+	require.Error(t, err, "TIME above 24h must fail loudly instead of silently becoming NULL")
+	assert.Contains(t, err.Error(), "elapsed")
+	require.Error(t, validateMySQLCDCTimeValue("-12:34:56", timeCol))
+	require.Error(t, validateMySQLCDCTimeValue([]byte("24:00:00"), timeCol))
+}
+
 func mysqlCDCTestSchema() *schema.TableSchema {
 	return addMySQLCDCColumns(&schema.TableSchema{
 		Name: "items",
@@ -791,6 +831,29 @@ func TestMySQLRowsEventToChangesPKChangeEmitsDeleteAndInsert(t *testing.T) {
 	assert.Equal(t, []interface{}{int64(1), "a"}, changes[0].values)
 	assert.False(t, changes[1].deleted)
 	assert.Equal(t, []interface{}{int64(9), "a"}, changes[1].values)
+	assert.Less(t, changes[0].lsn, changes[1].lsn)
+}
+
+func TestMySQLRowsEventToChangesKeylessUpdateEmitsRetractPair(t *testing.T) {
+	tableSchema := addMySQLCDCColumns(&schema.TableSchema{
+		Name: "events",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: true},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+	})
+	pos := gomysql.Position{Name: "mysql-bin.000001", Pos: 500}
+
+	changes, err := mysqlRowsEventToChanges(replication.EnumRowsEventTypeUpdate, [][]interface{}{
+		{int64(1), "a"},
+		{int64(1), "a2"},
+	}, tableSchema, tableSchema, pos)
+	require.NoError(t, err)
+	require.Len(t, changes, 2, "keyless updates must land as delete+insert retract pairs")
+	assert.True(t, changes[0].deleted)
+	assert.Equal(t, []interface{}{int64(1), "a"}, changes[0].values)
+	assert.False(t, changes[1].deleted)
+	assert.Equal(t, []interface{}{int64(1), "a2"}, changes[1].values)
 	assert.Less(t, changes[0].lsn, changes[1].lsn)
 }
 

--- a/pkg/strategy/merge.go
+++ b/pkg/strategy/merge.go
@@ -236,7 +236,13 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		FullRefresh:                     job.Config.FullRefresh,
 	}
 
-	records, err := job.GetRecords(ctx, readOpts)
+	// The read context is cancelable so a staging-write failure stops the
+	// source goroutine instead of leaving it parked on a channel send after
+	// the drain window closes (the multi-table path does the same via
+	// CancelSource).
+	readCtx, cancelRead := context.WithCancel(ctx)
+	defer cancelRead()
+	records, err := job.GetRecords(readCtx, readOpts)
 	if err != nil {
 		return fmt.Errorf("failed to get records: %w", err)
 	}
@@ -248,7 +254,7 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 
 	// Write to staging table using parallel writes. Source TRUNCATE controls
 	// split the input into ordered segments and clear earlier staged changes.
-	sourceTruncated, err := destination.WriteWithTruncateBoundaries(ctx, job.Destination, records, destination.WriteOptions{
+	sourceTruncated, err := destination.WriteWithTruncateBoundariesAfterCancel(ctx, job.Destination, records, destination.WriteOptions{
 		Table:            stagingTable,
 		Schema:           job.Schema,
 		Parallelism:      job.Config.EffectiveDestinationParallelism(),
@@ -257,7 +263,7 @@ func (s *MergeStrategy) Execute(ctx context.Context, job *IngestionJob) error {
 		LoaderFileSize:   job.Config.LoaderFileSize,
 		LoaderFileFormat: job.Config.LoaderFileFormat,
 		PreStaged:        job.PreStaged,
-	})
+	}, cancelRead)
 	if err != nil {
 		return fmt.Errorf("failed to write to staging: %w", err)
 	}

--- a/tests/integration/cdc_stress_duckdb_test.go
+++ b/tests/integration/cdc_stress_duckdb_test.go
@@ -66,6 +66,20 @@ func withCDCStressDuckDB(path string, fn func(*sql.DB) error) error {
 	return fn(db)
 }
 
+// withCDCStressDuckDBReadOnly opens a read-only monitoring connection. Any
+// query that runs while a pipeline may still be writing the file must use
+// this: in-process DuckDB instances do not conflict on the file lock, and a
+// read-write open replays and truncates the writer's WAL, corrupting the
+// database under load.
+func withCDCStressDuckDBReadOnly(path string, fn func(*sql.DB) error) error {
+	db, err := sql.Open("adbc_generic", "driver=duckdb;path="+path+";access_mode=read_only")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return fn(db)
+}
+
 func canonicalizeCDCStressJSON(raw string) (string, error) {
 	decoder := json.NewDecoder(bytes.NewBufferString(raw))
 	decoder.UseNumber()
@@ -133,6 +147,8 @@ func normalizeCDCStressTime(value string) (string, bool) {
 	for _, layout := range []string{
 		"2006-01-02 15:04:05.999999999",
 		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
 	} {
 		if parsed, err := time.ParseInLocation(layout, value, time.UTC); err == nil {
 			return parsed.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), true

--- a/tests/integration/cdc_stress_load_test.go
+++ b/tests/integration/cdc_stress_load_test.go
@@ -1,0 +1,246 @@
+//go:build stress
+
+// Shared load generator for the CDC stress tests. A due-count scheduler emits
+// operation tokens into a bounded queue at the configured rate — catching up
+// after stalls instead of silently under-delivering like per-worker tickers —
+// and a fixed pool of workers drains the queue, so the achieved throughput
+// tracks the target as closely as the source engine allows. Every scheduled
+// operation is accounted for as enqueued or explicitly dropped, and statement
+// latency is bucketed so a slow source is visible in the logs.
+package integration
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stressPKMoveOffset is the shared offset used by every engine's primary-key
+// move operation: rows with id below the offset are moved above it, so moved
+// rows and their tombstones can be told apart during verification.
+const stressPKMoveOffset = int64(1_000_000_000)
+
+type cdcStressOpErrBox struct{ err error }
+
+// cdcStressOpFunc performs one mutation against the source and reports the
+// operation kind ("insert", "update", "delete", "pk-update"), the rows
+// affected, and any error.
+type cdcStressOpFunc func(rng *rand.Rand) (operation string, affected int64, err error)
+
+type cdcStressLoadGen struct {
+	t        *testing.T
+	workers  int
+	target   int
+	duration time.Duration
+
+	queueCapacity int
+	queue         chan struct{}
+	started       time.Time
+
+	scheduled, enqueued, dropped, attempted atomic.Int64
+	inserts, updates, deletes, pkUpdates    atomic.Int64
+	opErrors, statementErrors, zeroAffected atomic.Int64
+	inFlight, maxQueueDepth                 atomic.Int64
+	totalLatencyNanos, maxLatencyNanos      atomic.Int64
+	latencyBuckets                          [7]atomic.Int64
+	// Boxed so atomic.Value always stores one concrete type; storing raw error
+	// values panics as soon as two distinct error types are recorded.
+	firstOpErr atomic.Value
+}
+
+func newCDCStressLoadGen(t *testing.T, workers, targetOpsPerSec int, duration time.Duration) *cdcStressLoadGen {
+	queueCapacity := max(workers*8, targetOpsPerSec/4)
+	return &cdcStressLoadGen{
+		t:             t,
+		workers:       workers,
+		target:        targetOpsPerSec,
+		duration:      duration,
+		queueCapacity: queueCapacity,
+		queue:         make(chan struct{}, queueCapacity),
+	}
+}
+
+// recordOpErr is shared with the late-table and DDL goroutines so every load
+// failure funnels into the same counters the final verification checks.
+func (g *cdcStressLoadGen) recordOpErr(err error) {
+	g.opErrors.Add(1)
+	g.firstOpErr.CompareAndSwap(nil, cdcStressOpErrBox{err: err})
+	g.t.Logf("load op error: %v", err)
+}
+
+func (g *cdcStressLoadGen) recordLatency(elapsed time.Duration) {
+	nanos := elapsed.Nanoseconds()
+	g.totalLatencyNanos.Add(nanos)
+	for {
+		current := g.maxLatencyNanos.Load()
+		if nanos <= current || g.maxLatencyNanos.CompareAndSwap(current, nanos) {
+			break
+		}
+	}
+	bucket := 6
+	switch {
+	case elapsed < time.Millisecond:
+		bucket = 0
+	case elapsed < 5*time.Millisecond:
+		bucket = 1
+	case elapsed < 10*time.Millisecond:
+		bucket = 2
+	case elapsed < 50*time.Millisecond:
+		bucket = 3
+	case elapsed < 100*time.Millisecond:
+		bucket = 4
+	case elapsed < 500*time.Millisecond:
+		bucket = 5
+	}
+	g.latencyBuckets[bucket].Add(1)
+}
+
+// start launches the scheduler and worker pool on wg. The scheduler stops and
+// closes the queue when loadCtx is done; workers exit once the queue drains,
+// so wg.Wait() observes a fully settled source.
+func (g *cdcStressLoadGen) start(loadCtx context.Context, wg *sync.WaitGroup, doOp cdcStressOpFunc) {
+	g.started = time.Now()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(g.queue)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		var emitted int64
+		emitDue := func(elapsed time.Duration) {
+			if elapsed > g.duration {
+				elapsed = g.duration
+			}
+			due := int64(elapsed) * int64(g.target) / int64(time.Second)
+			for emitted < due {
+				emitted++
+				g.scheduled.Add(1)
+				select {
+				case g.queue <- struct{}{}:
+					g.enqueued.Add(1)
+					depth := int64(len(g.queue))
+					for {
+						current := g.maxQueueDepth.Load()
+						if depth <= current || g.maxQueueDepth.CompareAndSwap(current, depth) {
+							break
+						}
+					}
+				default:
+					g.dropped.Add(1)
+				}
+			}
+		}
+		for {
+			select {
+			case <-loadCtx.Done():
+				emitDue(g.duration)
+				return
+			case <-ticker.C:
+				emitDue(time.Since(g.started))
+			}
+		}
+	}()
+
+	for w := 0; w < g.workers; w++ {
+		wg.Add(1)
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			for range g.queue {
+				g.attempted.Add(1)
+				g.inFlight.Add(1)
+				operationStarted := time.Now()
+				operation, affected, err := doOp(rng)
+				if err != nil {
+					g.statementErrors.Add(1)
+					g.recordOpErr(err)
+				} else {
+					switch operation {
+					case "insert":
+						g.inserts.Add(affected)
+					case "update":
+						g.updates.Add(affected)
+					case "delete":
+						g.deletes.Add(affected)
+					case "pk-update":
+						g.pkUpdates.Add(affected)
+					}
+					if affected == 0 {
+						g.zeroAffected.Add(1)
+					}
+				}
+				g.recordLatency(time.Since(operationStarted))
+				g.inFlight.Add(-1)
+			}
+		}(int64(w + 1))
+	}
+}
+
+func (g *cdcStressLoadGen) effectiveOps() int64 {
+	return g.inserts.Load() + g.updates.Load() + g.deletes.Load() + g.pkUpdates.Load()
+}
+
+// status renders one progress line for the periodic status ticker.
+func (g *cdcStressLoadGen) status() string {
+	elapsed := time.Since(g.started)
+	elapsedSeconds := elapsed.Seconds()
+	effective := g.effectiveOps()
+	completed := g.attempted.Load() - g.inFlight.Load()
+	averageLatency := time.Duration(0)
+	if completed > 0 {
+		averageLatency = time.Duration(g.totalLatencyNanos.Load() / completed)
+	}
+	return fmt.Sprintf("scheduled=%d attempted=%d (%.0f/sec), effective=%d (%.0f/sec), dropped=%d, queue=%d/%d (max=%d), latency avg=%v max=%v; mutations=%d/%d/%d/%d, errors=%d",
+		g.scheduled.Load(), g.attempted.Load(), float64(g.attempted.Load())/elapsedSeconds,
+		effective, float64(effective)/elapsedSeconds, g.dropped.Load(), len(g.queue), g.queueCapacity, g.maxQueueDepth.Load(),
+		averageLatency.Round(time.Microsecond), time.Duration(g.maxLatencyNanos.Load()).Round(time.Microsecond),
+		g.inserts.Load(), g.updates.Load(), g.deletes.Load(), g.pkUpdates.Load(), g.opErrors.Load())
+}
+
+// verify asserts the scheduler accounting is airtight, that no operation
+// failed, and that the achieved rate approximates the target closely enough
+// for the run to be meaningful. Returns the achieved effective ops/sec.
+func (g *cdcStressLoadGen) verify() float64 {
+	t := g.t
+	t.Helper()
+	if n := g.opErrors.Load(); n > 0 {
+		first, _ := g.firstOpErr.Load().(cdcStressOpErrBox)
+		t.Fatalf("%d load operations failed, first error: %v", n, first.err)
+	}
+	require.Equal(t, g.scheduled.Load(), g.enqueued.Load()+g.dropped.Load(),
+		"every scheduled operation must be enqueued or explicitly dropped")
+	require.Equal(t, g.enqueued.Load(), g.attempted.Load(), "workers must drain every enqueued operation")
+
+	totalOps := g.effectiveOps()
+	achieved := float64(totalOps) / g.duration.Seconds()
+	attemptedRate := float64(g.attempted.Load()) / g.duration.Seconds()
+	dropPercent := float64(0)
+	if g.scheduled.Load() > 0 {
+		dropPercent = 100 * float64(g.dropped.Load()) / float64(g.scheduled.Load())
+	}
+	averageLatency := time.Duration(0)
+	if g.attempted.Load() > 0 {
+		averageLatency = time.Duration(g.totalLatencyNanos.Load() / g.attempted.Load())
+	}
+	t.Logf("load complete: scheduled=%d, enqueued/attempted=%d (%.0f/sec), dropped=%d (%.2f%%), no-op=%d, statement errors=%d, max queue=%d/%d",
+		g.scheduled.Load(), g.attempted.Load(), attemptedRate, g.dropped.Load(), dropPercent,
+		g.zeroAffected.Load(), g.statementErrors.Load(), g.maxQueueDepth.Load(), g.queueCapacity)
+	t.Logf("effective mutations: %d (%d inserts, %d updates, %d deletes, %d pk-updates), %.0f/sec; latency avg=%v max=%v",
+		totalOps, g.inserts.Load(), g.updates.Load(), g.deletes.Load(), g.pkUpdates.Load(), achieved,
+		averageLatency.Round(time.Microsecond), time.Duration(g.maxLatencyNanos.Load()).Round(time.Microsecond))
+	t.Logf("statement latency buckets: <1ms=%d, 1-5ms=%d, 5-10ms=%d, 10-50ms=%d, 50-100ms=%d, 100-500ms=%d, >=500ms=%d",
+		g.latencyBuckets[0].Load(), g.latencyBuckets[1].Load(), g.latencyBuckets[2].Load(), g.latencyBuckets[3].Load(),
+		g.latencyBuckets[4].Load(), g.latencyBuckets[5].Load(), g.latencyBuckets[6].Load())
+	require.GreaterOrEqual(t, achieved, float64(g.target)/2,
+		"load generator could not sustain enough pressure for the test to be meaningful")
+	require.Positive(t, g.pkUpdates.Load(), "workload should execute real primary-key updates")
+	require.Positive(t, g.deletes.Load(), "workload should execute real deletes")
+	return achieved
+}

--- a/tests/integration/custom_query_test.go
+++ b/tests/integration/custom_query_test.go
@@ -325,9 +325,9 @@ func TestCustomQuery_WithIntervalParams(t *testing.T) {
 	var minTSStr, maxTSStr string
 	err = db.QueryRow("SELECT MIN(created_at), MAX(created_at) FROM interval_orders").Scan(&minTSStr, &maxTSStr)
 	require.NoError(t, err)
-	minTS, err := time.Parse("2006-01-02 15:04:05.000000", minTSStr)
+	minTS, err := time.Parse(time.RFC3339Nano, minTSStr)
 	require.NoError(t, err)
-	maxTS, err := time.Parse("2006-01-02 15:04:05.000000", maxTSStr)
+	maxTS, err := time.Parse(time.RFC3339Nano, maxTSStr)
 	require.NoError(t, err)
 	assert.False(t, minTS.Before(start), "min timestamp should be >= interval_start")
 	assert.True(t, maxTS.Before(end), "max timestamp should be < interval_end")

--- a/tests/integration/mssql_cdc_stress_test.go
+++ b/tests/integration/mssql_cdc_stress_test.go
@@ -4,9 +4,10 @@
 // variants it is excluded from the regular integration suite (build tag
 // `stress`); run it with `make cdc-mssql-stress-test`.
 //
-// Scenario: a streaming multi-table CDC pipeline replicates from SQL Server
-// into Postgres while parallel workers apply ~1000 inserts/updates/deletes/
-// PK-updates per second. SQL Server CDC freezes captured columns per capture
+// Scenario: two streaming multi-table CDC pipelines replicate from SQL Server
+// into PostgreSQL and DuckDB while the shared queue-based load generator
+// applies inserts/updates/deletes/PK-updates at the configured target rate.
+// SQL Server CDC freezes captured columns per capture
 // instance and discovers tables only at stream start, so schema changes follow
 // the documented operational path — recreate the capture instance and restart
 // the stream, which must recover via resume-from-destination-LSN or the
@@ -24,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -51,7 +53,6 @@ const (
 	msqStressLateSeed    = 2000
 	msqStressEvolving    = "stress_evolving"
 	msqStressTypes       = "stress_types"
-	msqStressPKOffset    = int64(1_000_000_000)
 	msqStressSentinelOld = int64(9_000_000_000_000)
 	msqStressSentinelNew = int64(9_000_000_000_001)
 	msqStressGiB         = uint64(1 << 30)
@@ -59,7 +60,6 @@ const (
 
 var (
 	msqStressSeedRows       = envInt("STRESS_SEED_ROWS", 5000)
-	msqStressWorkers        = envInt("STRESS_WORKERS", 32)
 	msqStressDataInitialMB  = envInt("MSSQL_STRESS_DATA_INITIAL_MB", 4096)
 	msqStressDataMaxMB      = envInt("MSSQL_STRESS_DATA_MAX_MB", 8192)
 	msqStressLogInitialMB   = envInt("MSSQL_STRESS_LOG_INITIAL_MB", 4096)
@@ -178,7 +178,7 @@ func msqStressAgentJobBusy(err error) bool {
 // run against tables the workers are hammering.
 func msqStressExec(ctx context.Context, db *sql.DB, query string, args ...any) (int64, error) {
 	var lastErr error
-	for attempt := 0; attempt < 5; attempt++ {
+	for attempt := 0; attempt < 8; attempt++ {
 		result, err := db.ExecContext(ctx, query, args...)
 		if err == nil {
 			affected, _ := result.RowsAffected()
@@ -188,14 +188,20 @@ func msqStressExec(ctx context.Context, db *sql.DB, query string, args ...any) (
 		if !msqStressIsDeadlock(err) {
 			return 0, err
 		}
-		time.Sleep(time.Duration(50*(attempt+1)) * time.Millisecond)
+		time.Sleep(time.Duration(100*(attempt+1)) * time.Millisecond)
 	}
 	return 0, lastErr
 }
 
+// Deadlocks may surface directly (error 1205) or nested inside a CDC
+// procedure failure (e.g. sp_cdc_disable_table wrapping the victim error in
+// 22837/22933), where only the message text carries the 1205 cause.
 func msqStressIsDeadlock(err error) bool {
 	var sqlErr mssqldb.Error
-	return errors.As(err, &sqlErr) && sqlErr.Number == 1205
+	if errors.As(err, &sqlErr) && sqlErr.Number == 1205 {
+		return true
+	}
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "deadlock")
 }
 
 func msqStressEnableCDC(ctx context.Context, db *sql.DB, table, instance string) error {
@@ -286,18 +292,31 @@ func msqStressCreateTypes(ctx context.Context, db *sql.DB, seedRows int) error {
 	return err
 }
 
-// msqStreamCtrl runs the streaming pipeline and supports test-driven restarts:
-// SQL Server CDC discovers tables and capture instances only at stream start,
-// so topology changes are absorbed by restarting the run, which must resume
-// every unchanged table from the destination's max _cdc_lsn.
+// msqStreamCtrl runs one streaming pipeline per destination and supports
+// test-driven restarts: SQL Server CDC discovers tables and capture instances
+// only at stream start, so topology changes are absorbed by restarting every
+// run together, each of which must resume every unchanged table from its own
+// destination's max _cdc_lsn. Capture-instance swaps require all consumers
+// stopped, so the sinks always stop and start as a group.
+type msqStreamSink struct {
+	name   string
+	cfg    *config.IngestConfig
+	cancel context.CancelFunc
+	done   chan error
+}
+
+type msqStreamHandle struct {
+	name   string
+	cancel context.CancelFunc
+	done   chan error
+}
+
 type msqStreamCtrl struct {
-	cfg       *config.IngestConfig
+	sinks     []*msqStreamSink
 	mu        sync.Mutex
 	restartMu sync.Mutex
-	cancel    context.CancelFunc
-	done      chan error
 	restarts  int
-	// aborted unblocks every pending restart once the stream has failed for
+	// aborted unblocks every pending restart once a stream has failed for
 	// good; without it a stolen exit value leaves restarts waiting forever on
 	// an empty channel and deadlocks the whole test.
 	aborted   chan struct{}
@@ -306,13 +325,26 @@ type msqStreamCtrl struct {
 }
 
 func (c *msqStreamCtrl) start(ctx context.Context) {
-	runCtx, cancel := context.WithCancel(ctx)
-	done := make(chan error, 1)
 	c.mu.Lock()
-	c.cancel = cancel
-	c.done = done
-	c.mu.Unlock()
-	go func() { done <- pipeline.New(c.cfg).Run(runCtx) }()
+	defer c.mu.Unlock()
+	for _, sink := range c.sinks {
+		runCtx, cancel := context.WithCancel(ctx)
+		done := make(chan error, 1)
+		sink.cancel = cancel
+		sink.done = done
+		cfg := sink.cfg
+		go func() { done <- pipeline.New(cfg).Run(runCtx) }()
+	}
+}
+
+func (c *msqStreamCtrl) handles() []msqStreamHandle {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]msqStreamHandle, len(c.sinks))
+	for i, sink := range c.sinks {
+		out[i] = msqStreamHandle{name: sink.name, cancel: sink.cancel, done: sink.done}
+	}
+	return out
 }
 
 func msqStressIsCancel(err error) bool {
@@ -338,30 +370,34 @@ func (c *msqStreamCtrl) restart(ctx context.Context, t *testing.T, reason string
 	return c.withStreamStopped(ctx, t, reason, nil)
 }
 
-// withStreamStopped cancels the running stream, waits for it to wind down,
-// runs fn (nil-safe) while no consumer is querying the change tables, and
-// starts a fresh stream. Capture-instance swaps must run inside fn: dropping
-// an instance while the stream reads its change table fails with error 22837.
+// withStreamStopped cancels every running stream, waits for them to wind
+// down, runs fn (nil-safe) while no consumer is querying the change tables,
+// and starts fresh streams. Capture-instance swaps must run inside fn:
+// dropping an instance while any stream reads its change table fails with
+// error 22837.
 func (c *msqStreamCtrl) withStreamStopped(ctx context.Context, t *testing.T, reason string, fn func() error) error {
 	c.restartMu.Lock()
 	defer c.restartMu.Unlock()
-	c.mu.Lock()
-	cancel, done := c.cancel, c.done
-	c.mu.Unlock()
+	handles := c.handles()
 	waitStart := time.Now()
-	cancel()
-	select {
-	case err := <-done:
-		if !msqStressIsCancel(err) {
+	for _, handle := range handles {
+		handle.cancel()
+	}
+	deadline := time.After(3 * time.Minute)
+	for _, handle := range handles {
+		select {
+		case err := <-handle.done:
+			if !msqStressIsCancel(err) {
+				c.abort(err)
+				return fmt.Errorf("%s stream exited with unexpected error during restart (%s): %w", handle.name, reason, err)
+			}
+		case <-c.aborted:
+			return fmt.Errorf("restart (%s) aborted: stream already failed: %w", reason, c.fatal())
+		case <-deadline:
+			err := fmt.Errorf("%s stream did not exit within 3m of cancellation (%s)", handle.name, reason)
 			c.abort(err)
-			return fmt.Errorf("stream exited with unexpected error during restart (%s): %w", reason, err)
+			return err
 		}
-	case <-c.aborted:
-		return fmt.Errorf("restart (%s) aborted: stream already failed: %w", reason, c.fatal())
-	case <-time.After(3 * time.Minute):
-		err := fmt.Errorf("stream did not exit within 3m of cancellation (%s)", reason)
-		c.abort(err)
-		return err
 	}
 	windDown := time.Since(waitStart).Round(time.Millisecond)
 	var fnErr error
@@ -388,37 +424,41 @@ func (c *msqStreamCtrl) exitedUnexpectedly() (error, bool) {
 		return nil, false
 	}
 	defer c.restartMu.Unlock()
-	c.mu.Lock()
-	done := c.done
-	c.mu.Unlock()
-	select {
-	case err := <-done:
-		if err == nil {
-			err = errors.New("streaming pipeline returned nil while the load was still running")
+	for _, handle := range c.handles() {
+		select {
+		case err := <-handle.done:
+			if err == nil {
+				err = fmt.Errorf("%s streaming pipeline returned nil while the load was still running", handle.name)
+			} else {
+				err = fmt.Errorf("%s stream: %w", handle.name, err)
+			}
+			c.abort(err)
+			return err, true
+		default:
 		}
-		c.abort(err)
-		return err, true
-	default:
-		return nil, false
 	}
+	return nil, false
 }
 
 func (c *msqStreamCtrl) stop(t *testing.T) {
 	c.restartMu.Lock()
 	defer c.restartMu.Unlock()
-	c.mu.Lock()
-	cancel, done := c.cancel, c.done
-	c.mu.Unlock()
-	cancel()
-	select {
-	case err := <-done:
-		if !msqStressIsCancel(err) {
-			t.Fatalf("streaming pipeline exited with unexpected error on shutdown: %v", err)
+	handles := c.handles()
+	for _, handle := range handles {
+		handle.cancel()
+	}
+	deadline := time.After(60 * time.Second)
+	for _, handle := range handles {
+		select {
+		case err := <-handle.done:
+			if !msqStressIsCancel(err) {
+				t.Fatalf("%s streaming pipeline exited with unexpected error on shutdown: %v", handle.name, err)
+			}
+		case <-c.aborted:
+			t.Fatalf("streaming pipeline already failed: %v", c.fatal())
+		case <-deadline:
+			t.Fatal("streaming pipelines did not exit within 60s of cancellation")
 		}
-	case <-c.aborted:
-		t.Fatalf("streaming pipeline already failed: %v", c.fatal())
-	case <-time.After(60 * time.Second):
-		t.Fatal("streaming pipeline did not exit within 60s of cancellation")
 	}
 }
 
@@ -762,6 +802,178 @@ func msqStressDestTruth(ctx context.Context, pool *pgxpool.Pool, table string) (
 	return tr, err
 }
 
+func msqStressDuckDBTableRef(table string) string {
+	return quoteStressIdentifier(msqStressDestSchema) + "." + quoteStressIdentifier("dbo_"+table)
+}
+
+// msqStressDuckDBExpr mirrors msqStressDestExpr for DuckDB so both
+// destinations render each column to the value the SQL Server side produces.
+func msqStressDuckDBExpr(c msqStressColumn) string {
+	quoted := "t." + quoteStressIdentifier(strings.ToLower(c.name))
+	switch c.kind {
+	case msqKindNum, msqKindFloat:
+		return "CAST(" + quoted + " AS VARCHAR)"
+	case msqKindTimestamp, msqKindTimestampTZ:
+		return "epoch_us(" + quoted + ")"
+	case msqKindDate:
+		return "(" + quoted + " - DATE '1970-01-01')"
+	case msqKindBool:
+		return "CAST(" + quoted + " AS INTEGER)"
+	case msqKindHex:
+		return "UPPER(hex(" + quoted + "))"
+	default:
+		return quoted
+	}
+}
+
+func msqStressFetchDuckDBDestChunk(ctx context.Context, db *sql.DB, table string, columns []msqStressColumn, offset, limit int64) ([]msqStressRow, error) {
+	exprs := make([]string, len(columns))
+	for i, c := range columns {
+		exprs[i] = msqStressDuckDBExpr(c)
+	}
+	query := fmt.Sprintf(
+		`SELECT t.id AS row_pk, %s FROM %s AS t WHERE NOT t._cdc_deleted ORDER BY t.id LIMIT ? OFFSET ?`,
+		strings.Join(exprs, ", "), msqStressDuckDBTableRef(table),
+	)
+	rows, err := db.QueryContext(ctx, query, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	return msqStressScanRows(rows.Next, rows.Scan, rows.Err, columns)
+}
+
+func msqStressCompareDuckDBChunkRange(ctx context.Context, src, dst *sql.DB, table string, columns []msqStressColumn, offset, limit int64) error {
+	srcRows, err := msqStressFetchSourceChunk(ctx, src, table, columns, offset, limit)
+	if err != nil {
+		return fmt.Errorf("%s offset %d: source fetch: %w", table, offset, err)
+	}
+	dstRows, err := msqStressFetchDuckDBDestChunk(ctx, dst, table, columns, offset, limit)
+	if err != nil {
+		return fmt.Errorf("%s offset %d: DuckDB fetch: %w", table, offset, err)
+	}
+	if len(srcRows) != len(dstRows) {
+		return fmt.Errorf("%s offset %d: row count mismatch: source=%d DuckDB=%d", table, offset, len(srcRows), len(dstRows))
+	}
+	for i := range srcRows {
+		s, d := srcRows[i], dstRows[i]
+		if s.id != d.id || s.canonical != d.canonical {
+			return fmt.Errorf("%s: content mismatch at id=%d:\n  source: %s\n  DuckDB: {id:%d row:%s}",
+				table, s.id, s.canonical, d.id, d.canonical)
+		}
+	}
+	return nil
+}
+
+func msqStressCompareAllDuckDB(ctx context.Context, src, dst *sql.DB, tables []*msqStressTable) error {
+	type chunk struct {
+		table   string
+		columns []msqStressColumn
+		offset  int64
+	}
+	var chunks []chunk
+	for _, tbl := range tables {
+		columns, err := msqStressSourceColumns(ctx, src, tbl.name)
+		if err != nil {
+			return err
+		}
+		var count int64
+		if err := src.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT_BIG(*) FROM dbo.[%s]", tbl.name)).Scan(&count); err != nil {
+			return fmt.Errorf("count source table %s: %w", tbl.name, err)
+		}
+		for offset := int64(0); offset < count; offset += stressCompareChunk {
+			chunks = append(chunks, chunk{table: tbl.name, columns: columns, offset: offset})
+		}
+	}
+
+	sem := make(chan struct{}, stressCompareParallel)
+	errCh := make(chan error, len(chunks))
+	var wg sync.WaitGroup
+	for _, c := range chunks {
+		wg.Add(1)
+		go func(c chunk) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			if err := msqStressCompareDuckDBChunkRange(ctx, src, dst, c.table, c.columns, c.offset, stressCompareChunk); err != nil {
+				errCh <- err
+			}
+		}(c)
+	}
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func msqStressDuckDBDestTruth(ctx context.Context, db *sql.DB, table string) (msqStressTruth, error) {
+	var tr msqStressTruth
+	err := db.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT COUNT(*), CAST(COALESCE(SUM(val), 0) AS VARCHAR) FROM %s WHERE NOT _cdc_deleted`,
+		msqStressDuckDBTableRef(table),
+	)).Scan(&tr.count, &tr.sum)
+	tr.sum = msqStressNormalizeNumeric(tr.sum)
+	return tr, err
+}
+
+// msqStressDuckDBDestColumns lists a destination table's columns via a
+// zero-row SELECT so lookup uses the same name resolution as the comparison
+// queries instead of information_schema string matching.
+func msqStressDuckDBDestColumns(ctx context.Context, db *sql.DB, table string) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0", msqStressDuckDBTableRef(table)))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	names, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	columns := make(map[string]bool, len(names))
+	for _, name := range names {
+		columns[strings.ToLower(name)] = true
+	}
+	return columns, rows.Err()
+}
+
+func msqStressValidateDuckDBSchemas(ctx context.Context, src, dst *sql.DB, tables []*msqStressTable) error {
+	for _, tbl := range tables {
+		sourceColumns, err := msqStressSourceColumns(ctx, src, tbl.name)
+		if err != nil {
+			return fmt.Errorf("source schema %s: %w", tbl.name, err)
+		}
+		destColumns, err := msqStressDuckDBDestColumns(ctx, dst, tbl.name)
+		if err != nil {
+			return fmt.Errorf("DuckDB schema %s: %w", tbl.name, err)
+		}
+		for _, col := range sourceColumns {
+			if !destColumns[strings.ToLower(col.name)] {
+				return fmt.Errorf("DuckDB table %s is missing active source column %s", tbl.name, col.name)
+			}
+		}
+		for _, meta := range []string{"_cdc_lsn", "_cdc_deleted", "_cdc_synced_at"} {
+			if !destColumns[meta] {
+				return fmt.Errorf("DuckDB table %s is missing CDC metadata column %s", tbl.name, meta)
+			}
+		}
+		if tbl.name == msqStressEvolving {
+			for _, removed := range []string{"legacy", "segment"} {
+				if !destColumns[removed] {
+					return fmt.Errorf("soft-removed DuckDB column %s is missing on %s", removed, tbl.name)
+				}
+			}
+			if !destColumns["cohort"] {
+				return fmt.Errorf("renamed column cohort is missing on DuckDB table %s", tbl.name)
+			}
+		}
+	}
+	return nil
+}
+
 // msqStressDiffIDs reports which live source ids are missing from the
 // destination and whether they are absent entirely (delivery loss) or present
 // only as tombstones (spurious delete), plus live destination ids the source
@@ -973,7 +1185,7 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 	`, msqStressDB, msqStressDataInitialMB, msqStressDataMaxMB, msqStressLogInitialMB, msqStressLogMaxMB))
 	require.NoError(t, err)
 
-	loadDB := msqStressOpenDB(t, host, port, msqStressDB, max(32, msqStressWorkers+8))
+	loadDB := msqStressOpenDB(t, host, port, msqStressDB, max(32, stressWorkers+8))
 	var recoveryModel string
 	require.NoError(t, loadDB.QueryRowContext(
 		ctx,
@@ -1044,7 +1256,7 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 	}
 	require.NoError(t, err, "restart CDC capture job with tuned parameters")
 
-	cfg := &config.IngestConfig{
+	postgresConfig := &config.IngestConfig{
 		SourceURI: fmt.Sprintf("mssql+cdc://sa:%s@%s:%s/%s?encrypt=disable&dest_schema=%s&poll_interval=500ms",
 			msqStressPasswordEnc, host, port, msqStressDB, msqStressDestSchema),
 		DestURI:             destConnString,
@@ -1054,185 +1266,85 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 		FlushRecords:        25000,
 		Progress:            config.ProgressLog,
 	}
-	ctrl := &msqStreamCtrl{cfg: cfg, aborted: make(chan struct{})}
+	duckDBPath := filepath.Join(t.TempDir(), "mssql-cdc-stress.duckdb")
+	duckDBConfig := *postgresConfig
+	duckDBConfig.DestURI = "duckdb:///" + duckDBPath
+	ctrl := &msqStreamCtrl{sinks: []*msqStreamSink{
+		{name: "postgres", cfg: postgresConfig},
+		{name: "duckdb", cfg: &duckDBConfig},
+	}, aborted: make(chan struct{})}
 	ctrl.start(ctx)
 
 	ddlDelay := stressEventDelay(stressSchemaEvery, stressLoadDuration, 6)
 	lateTableDelay := stressEventDelay(stressNewTableEvery, stressLoadDuration, stressLateTables)
 	t.Logf("load phase: %v at %d scheduled ops/sec across %d workers, %d late tables every %v, 6 schema phases every %v",
-		stressLoadDuration, stressTargetOpsPerSec, msqStressWorkers, stressLateTables, lateTableDelay, ddlDelay)
+		stressLoadDuration, stressTargetOpsPerSec, stressWorkers, stressLateTables, lateTableDelay, ddlDelay)
 
 	loadCtx, stopLoad := context.WithTimeout(ctx, stressLoadDuration)
 	defer stopLoad()
 
-	var inserts, updates, deletes, pkUpdates, opErrors, completedDDL atomic.Int64
-	var scheduled, enqueued, dropped, attempted, statementErrors, zeroAffected atomic.Int64
-	var inFlight, maxQueueDepth, totalLatencyNanos, maxLatencyNanos atomic.Int64
-	var latencyBuckets [7]atomic.Int64
-	// Boxed so atomic.Value always stores one concrete type; storing raw error
-	// values panics as soon as two distinct error types are recorded.
-	type opErrBox struct{ err error }
-	var firstOpErr atomic.Value
-	recordOpErr := func(err error) {
-		opErrors.Add(1)
-		firstOpErr.CompareAndSwap(nil, opErrBox{err: err})
-		t.Logf("load op error: %v", err)
-	}
+	var completedDDL atomic.Int64
+	gen := newCDCStressLoadGen(t, stressWorkers, stressTargetOpsPerSec, stressLoadDuration)
+	recordOpErr := gen.recordOpErr
 
-	recordLatency := func(elapsed time.Duration) {
-		nanos := elapsed.Nanoseconds()
-		totalLatencyNanos.Add(nanos)
-		for {
-			current := maxLatencyNanos.Load()
-			if nanos <= current || maxLatencyNanos.CompareAndSwap(current, nanos) {
-				break
-			}
-		}
-		bucket := 6
-		switch {
-		case elapsed < time.Millisecond:
-			bucket = 0
-		case elapsed < 5*time.Millisecond:
-			bucket = 1
-		case elapsed < 10*time.Millisecond:
-			bucket = 2
-		case elapsed < 50*time.Millisecond:
-			bucket = 3
-		case elapsed < 100*time.Millisecond:
-			bucket = 4
-		case elapsed < 500*time.Millisecond:
-			bucket = 5
-		}
-		latencyBuckets[bucket].Add(1)
-	}
-
-	queueCapacity := max(msqStressWorkers*8, stressTargetOpsPerSec/4)
-	operationQueue := make(chan struct{}, queueCapacity)
 	loadStarted := time.Now()
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer close(operationQueue)
-		ticker := time.NewTicker(10 * time.Millisecond)
-		defer ticker.Stop()
-		var emitted int64
-		emitDue := func(elapsed time.Duration) {
-			if elapsed > stressLoadDuration {
-				elapsed = stressLoadDuration
+	gen.start(loadCtx, &wg, func(rng *rand.Rand) (string, int64, error) {
+		tbl := tables.pick(rng)
+		roll := rng.Intn(100)
+		var affected int64
+		var err error
+		var id int64
+		operation := "insert"
+		switch {
+		case roll < 40:
+			id = tbl.nextID.Add(1)
+			if tbl.types {
+				affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(`
+					INSERT INTO dbo.%s (id, val, ival, dec_amount, name, body, ts6, tzo, d, flag, bin, fval)
+					VALUES (@p1, @p1, @p1 %% 100000, CONVERT(decimal(18,4), @p1) / 7, CONCAT(N'name-', @p1),
+						CONCAT(N'body-', @p1, REPLICATE(N'x', @p1 %% 200)), SYSUTCDATETIME(), SYSDATETIMEOFFSET(),
+						CONVERT(date, SYSUTCDATETIME()), @p1 %% 2, CONVERT(varbinary(64), CONCAT('bin-', @p1)),
+						CONVERT(float, @p1) / 3.0)`, tbl.name), id)
+			} else {
+				affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(
+					"INSERT INTO dbo.%s (id, val, payload, updated_at) VALUES (@p1, @p2, @p3, SYSUTCDATETIME())", tbl.name,
+				),
+					id, id, fmt.Sprintf("ins-%d", id))
 			}
-			due := int64(elapsed) * int64(stressTargetOpsPerSec) / int64(time.Second)
-			for emitted < due {
-				emitted++
-				scheduled.Add(1)
-				select {
-				case operationQueue <- struct{}{}:
-					enqueued.Add(1)
-					depth := int64(len(operationQueue))
-					for {
-						current := maxQueueDepth.Load()
-						if depth <= current || maxQueueDepth.CompareAndSwap(current, depth) {
-							break
-						}
-					}
-				default:
-					dropped.Add(1)
-				}
+		case roll < 75:
+			operation = "update"
+			id = rng.Int63n(tbl.nextID.Load()) + 1
+			if tbl.types {
+				affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(`
+					UPDATE dbo.%s SET val = val + 1, dec_amount = dec_amount + CONVERT(decimal(18,4), 0.0001),
+						body = CONCAT(N'upd-', id, N'-', @p2), ts6 = SYSUTCDATETIME() WHERE id = @p1`, tbl.name),
+					id, rng.Int63n(1_000_000))
+			} else {
+				affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(
+					"UPDATE dbo.%s SET val = val + 1, payload = @p2, updated_at = SYSUTCDATETIME() WHERE id = @p1", tbl.name,
+				),
+					id, fmt.Sprintf("upd-%d", id))
 			}
+		case roll < 90 || tbl.types:
+			operation = "delete"
+			id = rng.Int63n(tbl.nextID.Load()) + 1
+			affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf("DELETE FROM dbo.%s WHERE id = @p1", tbl.name), id)
+		default:
+			// Primary-key move: exercises the update pairer's replay of the
+			// before-image as a delete of the old key.
+			operation = "pk-update"
+			id = rng.Int63n(tbl.nextID.Load()) + 1
+			affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(
+				"UPDATE dbo.%s SET id = id + @p1, updated_at = SYSUTCDATETIME() WHERE id = @p2 AND id < @p1", tbl.name,
+			),
+				stressPKMoveOffset, id)
 		}
-		for {
-			select {
-			case <-loadCtx.Done():
-				emitDue(stressLoadDuration)
-				return
-			case <-ticker.C:
-				emitDue(time.Since(loadStarted))
-			}
+		if err != nil {
+			return operation, 0, fmt.Errorf("%s %s id=%d: %w", operation, tbl.name, id, err)
 		}
-	}()
-
-	for w := 0; w < msqStressWorkers; w++ {
-		wg.Add(1)
-		go func(seed int64) {
-			defer wg.Done()
-			rng := rand.New(rand.NewSource(seed))
-			for range operationQueue {
-				attempted.Add(1)
-				inFlight.Add(1)
-				operationStarted := time.Now()
-				tbl := tables.pick(rng)
-				roll := rng.Intn(100)
-				var affected int64
-				var err error
-				var id int64
-				operation := "insert"
-				switch {
-				case roll < 40:
-					id = tbl.nextID.Add(1)
-					if tbl.types {
-						affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(`
-							INSERT INTO dbo.%s (id, val, ival, dec_amount, name, body, ts6, tzo, d, flag, bin, fval)
-							VALUES (@p1, @p1, @p1 %% 100000, CONVERT(decimal(18,4), @p1) / 7, CONCAT(N'name-', @p1),
-								CONCAT(N'body-', @p1, REPLICATE(N'x', @p1 %% 200)), SYSUTCDATETIME(), SYSDATETIMEOFFSET(),
-								CONVERT(date, SYSUTCDATETIME()), @p1 %% 2, CONVERT(varbinary(64), CONCAT('bin-', @p1)),
-								CONVERT(float, @p1) / 3.0)`, tbl.name), id)
-					} else {
-						affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(
-							"INSERT INTO dbo.%s (id, val, payload, updated_at) VALUES (@p1, @p2, @p3, SYSUTCDATETIME())", tbl.name,
-						),
-							id, id, fmt.Sprintf("ins-%d-%d", seed, id))
-					}
-				case roll < 75:
-					operation = "update"
-					id = rng.Int63n(tbl.nextID.Load()) + 1
-					if tbl.types {
-						affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(`
-							UPDATE dbo.%s SET val = val + 1, dec_amount = dec_amount + CONVERT(decimal(18,4), 0.0001),
-								body = CONCAT(N'upd-', id, N'-', @p2), ts6 = SYSUTCDATETIME() WHERE id = @p1`, tbl.name),
-							id, seed)
-					} else {
-						affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(
-							"UPDATE dbo.%s SET val = val + 1, payload = @p2, updated_at = SYSUTCDATETIME() WHERE id = @p1", tbl.name,
-						),
-							id, fmt.Sprintf("upd-%d-%d", seed, id))
-					}
-				case roll < 90 || tbl.types:
-					operation = "delete"
-					id = rng.Int63n(tbl.nextID.Load()) + 1
-					affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf("DELETE FROM dbo.%s WHERE id = @p1", tbl.name), id)
-				default:
-					// Primary-key move: exercises the update pairer's replay of the
-					// before-image as a delete of the old key.
-					operation = "pk-update"
-					id = rng.Int63n(tbl.nextID.Load()) + 1
-					affected, err = msqStressExec(ctx, loadDB, fmt.Sprintf(
-						"UPDATE dbo.%s SET id = id + @p1, updated_at = SYSUTCDATETIME() WHERE id = @p2 AND id < @p1", tbl.name,
-					),
-						msqStressPKOffset, id)
-				}
-				if err != nil {
-					statementErrors.Add(1)
-					recordOpErr(fmt.Errorf("%s %s id=%d: %w", operation, tbl.name, id, err))
-				} else {
-					switch operation {
-					case "insert":
-						inserts.Add(affected)
-					case "update":
-						updates.Add(affected)
-					case "delete":
-						deletes.Add(affected)
-					case "pk-update":
-						pkUpdates.Add(affected)
-					}
-					if affected == 0 {
-						zeroAffected.Add(1)
-					}
-				}
-				recordLatency(time.Since(operationStarted))
-				inFlight.Add(-1)
-			}
-		}(int64(w + 1))
-	}
+		return operation, affected, nil
+	})
 
 	wg.Add(1)
 	go func() {
@@ -1390,54 +1502,14 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 				<-loadDone
 				t.Fatalf("stream exited during load phase: %v", err)
 			}
-			elapsed := time.Since(loadStarted)
-			elapsedSeconds := elapsed.Seconds()
-			effective := inserts.Load() + updates.Load() + deletes.Load() + pkUpdates.Load()
-			completed := attempted.Load() - inFlight.Load()
-			averageLatency := time.Duration(0)
-			if completed > 0 {
-				averageLatency = time.Duration(totalLatencyNanos.Load() / completed)
-			}
-			t.Logf("t=%v: scheduled=%d attempted=%d (%.0f/sec), effective=%d (%.0f/sec), dropped=%d, queue=%d/%d (max=%d), latency avg=%v max=%v; mutations=%d/%d/%d/%d, DDL=%d/%d, restarts=%d, errors=%d",
-				elapsed.Round(time.Second), scheduled.Load(), attempted.Load(), float64(attempted.Load())/elapsedSeconds,
-				effective, float64(effective)/elapsedSeconds, dropped.Load(), len(operationQueue), queueCapacity, maxQueueDepth.Load(),
-				averageLatency.Round(time.Microsecond), time.Duration(maxLatencyNanos.Load()).Round(time.Microsecond),
-				inserts.Load(), updates.Load(), deletes.Load(), pkUpdates.Load(), completedDDL.Load(), len(ddlPhases),
-				ctrl.restartCount(), opErrors.Load())
+			t.Logf("t=%v: %s, DDL=%d/%d, restarts=%d",
+				time.Since(loadStarted).Round(time.Second), gen.status(),
+				completedDDL.Load(), len(ddlPhases), ctrl.restartCount())
 		}
 	}
 
-	if n := opErrors.Load(); n > 0 {
-		first, _ := firstOpErr.Load().(opErrBox)
-		t.Fatalf("%d load operations failed, first error: %v", n, first.err)
-	}
 	require.Equal(t, int64(len(ddlPhases)), completedDDL.Load(), "all schema phases must complete")
-	require.Equal(t, scheduled.Load(), enqueued.Load()+dropped.Load(), "every scheduled operation must be enqueued or explicitly dropped")
-	require.Equal(t, enqueued.Load(), attempted.Load(), "workers must drain every enqueued operation")
-	totalOps := inserts.Load() + updates.Load() + deletes.Load() + pkUpdates.Load()
-	achieved := float64(totalOps) / stressLoadDuration.Seconds()
-	attemptedRate := float64(attempted.Load()) / stressLoadDuration.Seconds()
-	dropPercent := float64(0)
-	if scheduled.Load() > 0 {
-		dropPercent = 100 * float64(dropped.Load()) / float64(scheduled.Load())
-	}
-	averageLatency := time.Duration(0)
-	if attempted.Load() > 0 {
-		averageLatency = time.Duration(totalLatencyNanos.Load() / attempted.Load())
-	}
-	t.Logf("load complete: scheduled=%d, enqueued/attempted=%d (%.0f/sec), dropped=%d (%.2f%%), no-op=%d, statement errors=%d, max queue=%d/%d",
-		scheduled.Load(), attempted.Load(), attemptedRate, dropped.Load(), dropPercent, zeroAffected.Load(), statementErrors.Load(),
-		maxQueueDepth.Load(), queueCapacity)
-	t.Logf("effective mutations: %d (%d inserts, %d updates, %d deletes, %d pk-updates), %.0f/sec; latency avg=%v max=%v; stream restarts=%d",
-		totalOps, inserts.Load(), updates.Load(), deletes.Load(), pkUpdates.Load(), achieved,
-		averageLatency.Round(time.Microsecond), time.Duration(maxLatencyNanos.Load()).Round(time.Microsecond), ctrl.restartCount())
-	t.Logf("statement latency buckets: <1ms=%d, 1-5ms=%d, 5-10ms=%d, 10-50ms=%d, 50-100ms=%d, 100-500ms=%d, >=500ms=%d",
-		latencyBuckets[0].Load(), latencyBuckets[1].Load(), latencyBuckets[2].Load(), latencyBuckets[3].Load(),
-		latencyBuckets[4].Load(), latencyBuckets[5].Load(), latencyBuckets[6].Load())
-	require.GreaterOrEqual(t, achieved, float64(stressTargetOpsPerSec)/2,
-		"load generator could not sustain enough pressure for the test to be meaningful")
-	require.Positive(t, pkUpdates.Load(), "workload should execute real primary-key updates")
-	require.Positive(t, deletes.Load(), "workload should execute real deletes")
+	achieved := gen.verify()
 	require.Positive(t, ctrl.restartCount(), "late tables and capture-instance recreation must exercise stream restarts")
 	finalTables := tables.snapshot()
 	require.Len(t, finalTables, stressInitialTables+2+stressLateTables, "all initial, evolving, types, and late tables should exist")
@@ -1451,21 +1523,97 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 		t.Logf("source truth %s: count=%d sum=%s", tbl.name, tr.count, tr.sum)
 	}
 
+	// DuckDB access goes through transient read-only opens while the streams
+	// are running (convergence polling; a read-write open would corrupt the
+	// writer's WAL) and switches to one held read-write connection once the
+	// streams are stopped for the deep verification phase.
+	var duckDB *sql.DB
+	withDuckDB := func(fn func(*sql.DB) error) error {
+		if duckDB != nil {
+			return fn(duckDB)
+		}
+		return withCDCStressDuckDBReadOnly(duckDBPath, fn)
+	}
+
+	// Sentinel predicates use literal int64 values so the same SQL fragment
+	// runs on both destinations without placeholder-style differences.
+	type msqStressDestination struct {
+		name       string
+		aggregate  func(table string) (msqStressTruth, error)
+		compareAll func() error
+		validate   func() error
+		countWhere func(table, predicate string) (int64, error)
+	}
+	destinations := []msqStressDestination{
+		{
+			name: "postgres",
+			aggregate: func(table string) (msqStressTruth, error) {
+				return msqStressDestTruth(ctx, destPool, table)
+			},
+			compareAll: func() error { return msqStressCompareAll(ctx, loadDB, destPool, finalTables) },
+			validate:   func() error { return msqStressValidateSchemas(ctx, loadDB, destPool, finalTables) },
+			countWhere: func(table, predicate string) (int64, error) {
+				var count int64
+				err := destPool.QueryRow(ctx, fmt.Sprintf(
+					`SELECT COUNT(*) FROM %s.%s WHERE %s`,
+					quoteStressIdentifier(msqStressDestSchema), quoteStressIdentifier("dbo_"+table), predicate,
+				)).Scan(&count)
+				return count, err
+			},
+		},
+		{
+			name: "duckdb",
+			aggregate: func(table string) (msqStressTruth, error) {
+				var truth msqStressTruth
+				err := withDuckDB(func(db *sql.DB) error {
+					var err error
+					truth, err = msqStressDuckDBDestTruth(ctx, db, table)
+					return err
+				})
+				return truth, err
+			},
+			compareAll: func() error {
+				return withDuckDB(func(db *sql.DB) error {
+					return msqStressCompareAllDuckDB(ctx, loadDB, db, finalTables)
+				})
+			},
+			validate: func() error {
+				return withDuckDB(func(db *sql.DB) error {
+					return msqStressValidateDuckDBSchemas(ctx, loadDB, db, finalTables)
+				})
+			},
+			countWhere: func(table, predicate string) (int64, error) {
+				var count int64
+				err := withDuckDB(func(db *sql.DB) error {
+					return db.QueryRowContext(ctx, fmt.Sprintf(
+						`SELECT COUNT(*) FROM %s WHERE %s`, msqStressDuckDBTableRef(table), predicate,
+					)).Scan(&count)
+				})
+				return count, err
+			},
+		},
+	}
+
 	dumpDiagnostics := func() {
 		msqStressDumpCDCState(t, ctx, loadDB, finalTables)
-		for _, tbl := range finalTables {
-			got, err := msqStressDestTruth(ctx, destPool, tbl.name)
-			t.Logf("  %s: want %+v, got %+v (err=%v)", tbl.name, truths[tbl.name], got, err)
-			msqStressDiffIDs(t, ctx, loadDB, destPool, tbl.name)
+		for _, destination := range destinations {
+			for _, tbl := range finalTables {
+				got, err := destination.aggregate(tbl.name)
+				t.Logf("  %s/%s: want %+v, got %+v (err=%v)", destination.name, tbl.name, truths[tbl.name], got, err)
+			}
+			if err := destination.compareAll(); err != nil {
+				t.Logf("  %s first content mismatch: %v", destination.name, err)
+			}
 		}
-		if err := msqStressCompareAll(ctx, loadDB, destPool, finalTables); err != nil {
-			t.Logf("  first content mismatch: %v", err)
+		for _, tbl := range finalTables {
+			msqStressDiffIDs(t, ctx, loadDB, destPool, tbl.name)
 		}
 		stressDumpContainerLogs(t, ctx, sourceContainer, 120)
 	}
 
-	// Convergence: the stream keeps polling; the capture job drains its backlog
-	// and every table's aggregates must match the quiescent source exactly.
+	// Convergence: the streams keep polling; the capture job drains its backlog
+	// and every table's aggregates must match the quiescent source exactly in
+	// both destinations.
 	deadline := time.Now().Add(stressConvergeTimeout)
 	lastProgressLog := time.Now()
 	for {
@@ -1474,10 +1622,15 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 			t.Fatalf("stream exited during convergence: %v", err)
 		}
 		pending := ""
-		for _, tbl := range finalTables {
-			got, err := msqStressDestTruth(ctx, destPool, tbl.name)
-			if err != nil || got != truths[tbl.name] {
-				pending = fmt.Sprintf("%s: want %+v, got %+v (err=%v)", tbl.name, truths[tbl.name], got, err)
+		for _, destination := range destinations {
+			for _, tbl := range finalTables {
+				got, err := destination.aggregate(tbl.name)
+				if err != nil || got != truths[tbl.name] {
+					pending = fmt.Sprintf("%s/%s: want %+v, got %+v (err=%v)", destination.name, tbl.name, truths[tbl.name], got, err)
+					break
+				}
+			}
+			if pending != "" {
 				break
 			}
 		}
@@ -1490,60 +1643,59 @@ func TestMSSQLCDC_StressComplexWorkload(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			dumpDiagnostics()
-			t.Fatalf("destination did not converge within %v; still pending: %s", stressConvergeTimeout, pending)
+			t.Fatalf("destinations did not converge within %v; still pending: %s", stressConvergeTimeout, pending)
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Log("destination converged on count/sum aggregates for all tables")
+	t.Log("PostgreSQL and DuckDB destinations converged on count/sum aggregates for all tables")
 
-	// Aggregates can match while a final merge is still landing payload
-	// updates, so retry the deep comparison briefly before declaring failure.
-	var compareErr error
-	for attempt := 1; attempt <= 6; attempt++ {
-		if compareErr = msqStressCompareAll(ctx, loadDB, destPool, finalTables); compareErr == nil {
-			break
-		}
-		t.Logf("deep comparison attempt %d: %v", attempt, compareErr)
-		time.Sleep(5 * time.Second)
-	}
-	require.NoError(t, compareErr, "row-by-row content comparison failed")
-	t.Log("row-by-row content comparison passed for all tables")
-
-	require.NoError(t, msqStressValidateSchemas(ctx, loadDB, destPool, finalTables))
-
-	var softDeleted int64
-	for _, tbl := range finalTables {
-		var deleted int64
-		require.NoError(t, destPool.QueryRow(ctx, fmt.Sprintf(
-			`SELECT COUNT(*) FROM %s.%s WHERE "_cdc_deleted"`,
-			quoteStressIdentifier(msqStressDestSchema), quoteStressIdentifier("dbo_"+tbl.name),
-		)).Scan(&deleted))
-		softDeleted += deleted
-	}
-	require.Positive(t, softDeleted, "destination should retain soft-deleted CDC rows")
-
-	var movedLive int64
-	require.NoError(t, destPool.QueryRow(ctx, fmt.Sprintf(
-		`SELECT COUNT(*) FROM %s.%s WHERE id >= $1 AND NOT "_cdc_deleted"`,
-		quoteStressIdentifier(msqStressDestSchema), quoteStressIdentifier("dbo_"+stressTableName(0)),
-	),
-		msqStressPKOffset).Scan(&movedLive))
-	require.Positive(t, movedLive, "primary-key moves must land live rows under the new keys")
-
-	var sentinelLive, sentinelOldLive int64
-	evolvingDest := quoteStressIdentifier(msqStressDestSchema) + "." + quoteStressIdentifier("dbo_"+msqStressEvolving)
-	require.NoError(t, destPool.QueryRow(ctx, fmt.Sprintf(
-		`SELECT COUNT(*) FROM %s WHERE id = $1 AND cohort = 'sentinel' AND NOT "_cdc_deleted"`, evolvingDest,
-	),
-		msqStressSentinelNew).Scan(&sentinelLive))
-	require.NoError(t, destPool.QueryRow(ctx, fmt.Sprintf(
-		`SELECT COUNT(*) FROM %s WHERE id = $1 AND NOT "_cdc_deleted"`, evolvingDest,
-	),
-		msqStressSentinelOld).Scan(&sentinelOldLive))
-	require.Equal(t, int64(1), sentinelLive, "sentinel row must live under its moved primary key")
-	require.Zero(t, sentinelOldLive, "sentinel row must not remain live under its old primary key")
-
+	// Deep verification runs against quiescent destinations: stop the streams
+	// and hold one DuckDB connection so every check sees a settled catalog.
 	ctrl.stop(t)
-	t.Logf("PERF SUMMARY: %.0f attempted ops/sec, %.0f effective mutations/sec over %v across %d tables; %.2f%% scheduler drops; %d stream restarts; %d soft-deleted rows retained",
-		attemptedRate, achieved, stressLoadDuration, len(finalTables), dropPercent, ctrl.restartCount(), softDeleted)
+	duckDB = openCDCStressDuckDB(t, duckDBPath)
+
+	// Aggregates can match while a final merge was still landing payload
+	// updates when the streams stopped, so retry the deep comparison briefly
+	// before declaring failure.
+	var softDeletedTotal int64
+	for _, destination := range destinations {
+		var compareErr error
+		for attempt := 1; attempt <= 6; attempt++ {
+			if compareErr = destination.compareAll(); compareErr == nil {
+				break
+			}
+			t.Logf("%s deep comparison attempt %d: %v", destination.name, attempt, compareErr)
+			time.Sleep(5 * time.Second)
+		}
+		require.NoError(t, compareErr, "%s row-by-row content comparison failed", destination.name)
+		t.Logf("%s row-by-row content comparison passed for all tables", destination.name)
+
+		require.NoError(t, destination.validate(), "%s destination schema validation failed", destination.name)
+
+		var softDeleted int64
+		for _, tbl := range finalTables {
+			deleted, err := destination.countWhere(tbl.name, "_cdc_deleted")
+			require.NoError(t, err)
+			softDeleted += deleted
+		}
+		require.Positive(t, softDeleted, "%s destination should retain soft-deleted CDC rows", destination.name)
+		softDeletedTotal += softDeleted
+
+		movedLive, err := destination.countWhere(stressTableName(0),
+			fmt.Sprintf("id >= %d AND NOT _cdc_deleted", stressPKMoveOffset))
+		require.NoError(t, err)
+		require.Positive(t, movedLive, "%s: primary-key moves must land live rows under the new keys", destination.name)
+
+		sentinelLive, err := destination.countWhere(msqStressEvolving,
+			fmt.Sprintf("id = %d AND cohort = 'sentinel' AND NOT _cdc_deleted", msqStressSentinelNew))
+		require.NoError(t, err)
+		sentinelOldLive, err := destination.countWhere(msqStressEvolving,
+			fmt.Sprintf("id = %d AND NOT _cdc_deleted", msqStressSentinelOld))
+		require.NoError(t, err)
+		require.Equal(t, int64(1), sentinelLive, "%s: sentinel row must live under its moved primary key", destination.name)
+		require.Zero(t, sentinelOldLive, "%s: sentinel row must not remain live under its old primary key", destination.name)
+	}
+
+	t.Logf("PERF SUMMARY: %.0f effective mutations/sec over %v across %d tables into PostgreSQL and DuckDB; %d stream restarts; %d soft-deleted rows retained across destinations",
+		achieved, stressLoadDuration, len(finalTables), ctrl.restartCount(), softDeletedTotal)
 }

--- a/tests/integration/mssql_cdc_test.go
+++ b/tests/integration/mssql_cdc_test.go
@@ -435,6 +435,105 @@ func TestMSSQLCDC_FreshCaptureInstanceResume_DuckDB(t *testing.T) {
 	assert.True(t, deleted, "delete after fresh snapshot must be applied")
 }
 
+// TestMSSQLCDC_CaptureInstanceHandoff_DuckDB verifies the two-phase capture
+// instance recreation flow: when a second instance with an identical captured
+// column layout is created, a run whose cursor predates the new instance
+// drains the gap from the old instance and switches to the new one WITHOUT
+// re-snapshotting. A canary row planted directly in the destination proves no
+// destination-cleaning re-snapshot happened.
+func TestMSSQLCDC_CaptureInstanceHandoff_DuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dbName, db := setupMSSQLCDCDatabase(t, ctx)
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE dbo.handoff (id INT NOT NULL PRIMARY KEY, v INT NOT NULL)`)
+	require.NoError(t, err)
+	enableMSSQLCDCOnTable(t, ctx, db, "handoff")
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.handoff (id, v) VALUES (1, 10), (2, 20), (3, 30)`)
+	require.NoError(t, err)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_handoff", 3)
+
+	tmpDir, err := os.MkdirTemp("", "mssql_cdc_handoff_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	duckdbPath := tmpDir + "/test.duckdb"
+
+	cfg := &config.IngestConfig{
+		SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+cdc", dbName, map[string]string{"mode": "batch"}),
+		SourceTable: "dbo.handoff",
+		DestURI:     "duckdb:///" + duckdbPath,
+		DestTable:   "handoff_dest",
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	// Gap change: only the original capture instance covers it.
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.handoff (id, v) VALUES (4, 40)`)
+	require.NoError(t, err)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_handoff", 4)
+
+	// Recreate the capture instance with an identical layout (documented
+	// operational flow: create the new instance first, drop the old one only
+	// after consumers moved past its start).
+	_, err = db.ExecContext(ctx, `EXEC sys.sp_cdc_enable_table
+		@source_schema = N'dbo', @source_name = N'handoff', @role_name = NULL,
+		@capture_instance = N'dbo_handoff_v2', @supports_net_changes = 0`)
+	require.NoError(t, err)
+
+	// Post-recreation change: captured by both instances.
+	_, err = db.ExecContext(ctx, `INSERT INTO dbo.handoff (id, v) VALUES (5, 50)`)
+	require.NoError(t, err)
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_handoff_v2", 1)
+
+	// Canary: a destination-only row with an LSN below every real stamp. It
+	// survives merges but not the destination-cleaning re-snapshot, so its
+	// survival proves the handoff path ran.
+	duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+	require.NoError(t, err)
+	_, err = duck.Exec(`INSERT INTO handoff_dest (id, v, "_cdc_lsn", "_cdc_deleted", "_cdc_synced_at")
+		VALUES (999, 0, '00000000000000000000:00000000000000000000:00', false, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+	require.NoError(t, duck.Close())
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	queryDuckCount := func(query string) int64 {
+		duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+		require.NoError(t, err)
+		defer func() { _ = duck.Close() }()
+		var v int64
+		require.NoError(t, duck.QueryRow(query).Scan(&v))
+		return v
+	}
+
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM handoff_dest WHERE id = 999`),
+		"canary must survive: an instance recreation with an identical layout must hand off instead of re-snapshotting")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM handoff_dest WHERE id = 4 AND v = 40 AND NOT "_cdc_deleted"`),
+		"the gap change covered only by the old instance must be drained during handoff")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM handoff_dest WHERE id = 5 AND v = 50 AND NOT "_cdc_deleted"`),
+		"the post-recreation change must arrive from the new instance")
+	assert.EqualValues(t, 6, queryDuckCount(`SELECT COUNT(*) FROM handoff_dest`))
+
+	// Final documented step: drop the old instance now that the cursor moved
+	// past its range; subsequent runs resume normally on the new instance.
+	_, err = db.ExecContext(ctx, `EXEC sys.sp_cdc_disable_table
+		@source_schema = N'dbo', @source_name = N'handoff', @capture_instance = N'dbo_handoff'`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE dbo.handoff SET v = 51 WHERE id = 5`)
+	require.NoError(t, err)
+	// v2 captures insert5 (1) plus the update's before+after images (2).
+	waitForMSSQLCDCRows(t, ctx, db, "dbo_handoff_v2", 3)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM handoff_dest WHERE id = 5 AND v = 51 AND NOT "_cdc_deleted"`),
+		"post-handoff runs must resume incrementally on the new instance")
+	assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM handoff_dest WHERE id = 999`),
+		"canary must still survive the post-handoff resume")
+}
+
 func TestMSSQLCDC_MultiTable_Postgres(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/tests/integration/mssql_confidence_test.go
+++ b/tests/integration/mssql_confidence_test.go
@@ -191,10 +191,14 @@ func TestMSSQLSource_TableToSQLite_CustomSchemaFiltersAndExcludeColumns(t *testi
 	cols = withoutLoadTimestampColumns(cols)
 	assert.Equal(t, []string{"id", "name", "updated_at"}, cols, "excluded MSSQL columns should be removed from the destination schema")
 
-	var minTS, maxTS string
-	require.NoError(t, destDB.QueryRow("SELECT MIN(updated_at), MAX(updated_at) FROM filtered_rows").Scan(&minTS, &maxTS))
-	assert.GreaterOrEqual(t, minTS, "2024-01-01 00:20:00", "interval start filter should be applied")
-	assert.LessOrEqual(t, maxTS, "2024-01-01 00:40:00", "interval end filter should be applied")
+	var minTSStr, maxTSStr string
+	require.NoError(t, destDB.QueryRow("SELECT MIN(updated_at), MAX(updated_at) FROM filtered_rows").Scan(&minTSStr, &maxTSStr))
+	minTS, err := time.Parse(time.RFC3339Nano, minTSStr)
+	require.NoError(t, err)
+	maxTS, err := time.Parse(time.RFC3339Nano, maxTSStr)
+	require.NoError(t, err)
+	assert.False(t, minTS.Before(time.Date(2024, 1, 1, 0, 20, 0, 0, time.UTC)), "interval start filter should be applied")
+	assert.False(t, maxTS.After(time.Date(2024, 1, 1, 0, 40, 0, 0, time.UTC)), "interval end filter should be applied")
 }
 
 func TestMSSQLSource_TableToSQLite_DatabaseQualifiedTable(t *testing.T) {

--- a/tests/integration/mysql_cdc_stress_test.go
+++ b/tests/integration/mysql_cdc_stress_test.go
@@ -7,7 +7,8 @@
 // MySQL CDC is batch catch-up (snapshot, then replay the binlog to the
 // position captured at stream start, then exit), so instead of one streaming
 // pipeline this test drives parallel MySQL- and DuckDB-destination runs while
-// workers apply ~1000 inserts/updates/deletes/PK-updates per second — every
+// the shared queue-based load generator applies inserts/updates/deletes/
+// PK-updates at the configured target rate — every
 // mid-load run exercises the resume-from-LSN path under active writes. The source
 // server runs in a non-UTC time zone and a wide-types table covers unsigned
 // integer extremes, DECIMAL, JSON, DATE/DATETIME/TIMESTAMP, and binary
@@ -40,7 +41,6 @@ import (
 const (
 	mysqlStressLateSeedRows = 2000
 	mysqlStressTypesTable   = "mstress_types"
-	mysqlStressPKOffset     = int64(1_000_000_000)
 	// Lenient floor: even constrained CI machines snapshot far faster; a miss
 	// indicates a real regression in the snapshot path.
 	mysqlStressMinSnapshotRowsPerSec = 1000.0
@@ -611,91 +611,68 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 	loadCtx, stopLoad := context.WithTimeout(ctx, stressLoadDuration)
 	defer stopLoad()
 
-	var inserts, updates, deletes, pkUpdates, opErrors atomic.Int64
-	var firstOpErr atomic.Value
-	recordOpErr := func(err error) {
-		opErrors.Add(1)
-		firstOpErr.CompareAndSwap(nil, err)
-	}
+	gen := newCDCStressLoadGen(t, stressWorkers, stressTargetOpsPerSec, stressLoadDuration)
+	recordOpErr := gen.recordOpErr
 
-	workerInterval := time.Duration(stressWorkers) * time.Second / time.Duration(stressTargetOpsPerSec)
 	var wg sync.WaitGroup
-	for w := 0; w < stressWorkers; w++ {
-		wg.Add(1)
-		go func(seed int64) {
-			defer wg.Done()
-			rng := rand.New(rand.NewSource(seed))
-			ticker := time.NewTicker(workerInterval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-loadCtx.Done():
-					return
-				case <-ticker.C:
-				}
-				tbl := tables.pick(rng)
-				roll := rng.Intn(100)
-				switch {
-				case roll < 40:
-					id := tbl.nextID.Add(1)
-					var err error
-					if tbl.types {
-						err = mysqlStressInsertTypes(ctx, loadDB, id)
-					} else {
-						_, err = loadDB.ExecContext(ctx,
-							fmt.Sprintf("INSERT INTO %s (id, val, payload, updated_at) VALUES (?, ?, ?, NOW(6))", tbl.name),
-							id, id, fmt.Sprintf("ins-%d-%d", seed, id))
-					}
-					if err != nil {
-						recordOpErr(fmt.Errorf("insert %s id=%d: %w", tbl.name, id, err))
-					} else {
-						inserts.Add(1)
-					}
-				case roll < 75:
-					id := rng.Int63n(tbl.nextID.Load()) + 1
-					var affected int64
-					var err error
-					if tbl.types {
-						affected, err = mysqlStressUpdateTypes(ctx, loadDB, id, seed)
-					} else {
-						var result sql.Result
-						result, err = loadDB.ExecContext(ctx,
-							fmt.Sprintf("UPDATE %s SET val = val + 1, payload = ?, updated_at = NOW(6) WHERE id = ?", tbl.name),
-							fmt.Sprintf("upd-%d-%d", seed, id), id)
-						if err == nil {
-							affected, _ = result.RowsAffected()
-						}
-					}
-					if err != nil {
-						recordOpErr(fmt.Errorf("update %s id=%d: %w", tbl.name, id, err))
-					} else {
-						updates.Add(affected)
-					}
-				case roll < 90 || tbl.types:
-					id := rng.Int63n(tbl.nextID.Load()) + 1
-					result, err := loadDB.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = ?", tbl.name), id)
-					if err != nil {
-						recordOpErr(fmt.Errorf("delete %s id=%d: %w", tbl.name, id, err))
-					} else {
-						affected, _ := result.RowsAffected()
-						deletes.Add(affected)
-					}
-				default:
-					// Primary-key update: exercises the delete+insert change pair.
-					id := rng.Int63n(tbl.nextID.Load()) + 1
-					result, err := loadDB.ExecContext(ctx,
-						fmt.Sprintf("UPDATE %s SET id = id + ?, updated_at = NOW(6) WHERE id = ? AND id < ?", tbl.name),
-						mysqlStressPKOffset, id, mysqlStressPKOffset)
-					if err != nil {
-						recordOpErr(fmt.Errorf("pk-update %s id=%d: %w", tbl.name, id, err))
-					} else {
-						affected, _ := result.RowsAffected()
-						pkUpdates.Add(affected)
-					}
+	gen.start(loadCtx, &wg, func(rng *rand.Rand) (string, int64, error) {
+		tbl := tables.pick(rng)
+		roll := rng.Intn(100)
+		switch {
+		case roll < 40:
+			id := tbl.nextID.Add(1)
+			var err error
+			if tbl.types {
+				err = mysqlStressInsertTypes(ctx, loadDB, id)
+			} else {
+				_, err = loadDB.ExecContext(ctx,
+					fmt.Sprintf("INSERT INTO %s (id, val, payload, updated_at) VALUES (?, ?, ?, NOW(6))", tbl.name),
+					id, id, fmt.Sprintf("ins-%d", id))
+			}
+			if err != nil {
+				return "insert", 0, fmt.Errorf("insert %s id=%d: %w", tbl.name, id, err)
+			}
+			return "insert", 1, nil
+		case roll < 75:
+			id := rng.Int63n(tbl.nextID.Load()) + 1
+			var affected int64
+			var err error
+			if tbl.types {
+				affected, err = mysqlStressUpdateTypes(ctx, loadDB, id, rng.Int63n(1_000_000))
+			} else {
+				var result sql.Result
+				result, err = loadDB.ExecContext(ctx,
+					fmt.Sprintf("UPDATE %s SET val = val + 1, payload = ?, updated_at = NOW(6) WHERE id = ?", tbl.name),
+					fmt.Sprintf("upd-%d", id), id)
+				if err == nil {
+					affected, _ = result.RowsAffected()
 				}
 			}
-		}(int64(w + 1))
-	}
+			if err != nil {
+				return "update", 0, fmt.Errorf("update %s id=%d: %w", tbl.name, id, err)
+			}
+			return "update", affected, nil
+		case roll < 90 || tbl.types:
+			id := rng.Int63n(tbl.nextID.Load()) + 1
+			result, err := loadDB.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = ?", tbl.name), id)
+			if err != nil {
+				return "delete", 0, fmt.Errorf("delete %s id=%d: %w", tbl.name, id, err)
+			}
+			affected, _ := result.RowsAffected()
+			return "delete", affected, nil
+		default:
+			// Primary-key update: exercises the delete+insert change pair.
+			id := rng.Int63n(tbl.nextID.Load()) + 1
+			result, err := loadDB.ExecContext(ctx,
+				fmt.Sprintf("UPDATE %s SET id = id + ?, updated_at = NOW(6) WHERE id = ? AND id < ?", tbl.name),
+				stressPKMoveOffset, id, stressPKMoveOffset)
+			if err != nil {
+				return "pk-update", 0, fmt.Errorf("pk-update %s id=%d: %w", tbl.name, id, err)
+			}
+			affected, _ := result.RowsAffected()
+			return "pk-update", affected, nil
+		}
+	})
 
 	wg.Add(1)
 	go func() {
@@ -760,9 +737,8 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 			<-loadDone
 			t.Fatalf("catch-up run failed during load phase: %v", err)
 		case <-status.C:
-			t.Logf("t=%v: %d inserts, %d updates, %d deletes, %d pk-updates, %d catch-up runs, %d op errors",
-				time.Since(started).Round(time.Second), inserts.Load(), updates.Load(), deletes.Load(),
-				pkUpdates.Load(), catchupRuns.Load(), opErrors.Load())
+			t.Logf("t=%v: %s, catch-up runs=%d",
+				time.Since(started).Round(time.Second), gen.status(), catchupRuns.Load())
 		}
 	}
 	select {
@@ -771,19 +747,10 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 	case <-runnerDone:
 	}
 
-	if n := opErrors.Load(); n > 0 {
-		t.Fatalf("%d load operations failed, first error: %v", n, firstOpErr.Load())
-	}
-	totalOps := inserts.Load() + updates.Load() + deletes.Load() + pkUpdates.Load()
-	achieved := float64(totalOps) / stressLoadDuration.Seconds()
-	t.Logf("load complete: %d effective ops (%d inserts, %d updates, %d deletes, %d pk-updates), %.0f ops/sec achieved, %d mid-load catch-up runs (avg %v)",
-		totalOps, inserts.Load(), updates.Load(), deletes.Load(), pkUpdates.Load(), achieved,
+	achieved := gen.verify()
+	t.Logf("%d mid-load catch-up runs (avg %v)",
 		catchupRuns.Load(), (time.Duration(catchupTotal.Load()) / time.Duration(max(1, catchupRuns.Load()))).Round(time.Millisecond))
-	require.GreaterOrEqual(t, achieved, float64(stressTargetOpsPerSec)/2,
-		"load generator could not sustain enough pressure for the test to be meaningful")
 	require.Positive(t, catchupRuns.Load(), "at least one mid-load catch-up run must complete to exercise resume under load")
-	require.Positive(t, pkUpdates.Load(), "workload should execute real primary-key updates")
-	require.Positive(t, deletes.Load(), "workload should execute real deletes")
 
 	finalTables := tables.snapshot()
 	require.Len(t, finalTables, mysqlStressInitialTables+1+stressLateTables, "all initial, types, and late tables should exist")
@@ -821,12 +788,12 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 				var live, tombstones int64
 				if err := dstVerify.QueryRowContext(ctx, fmt.Sprintf(
 					"SELECT COUNT(*) FROM %s WHERE id >= ? AND `_cdc_deleted` = FALSE", table,
-				), mysqlStressPKOffset).Scan(&live); err != nil {
+				), stressPKMoveOffset).Scan(&live); err != nil {
 					return 0, 0, err
 				}
 				err := dstVerify.QueryRowContext(ctx, fmt.Sprintf(
 					"SELECT COUNT(*) FROM %s WHERE id < ? AND `_cdc_deleted` = TRUE", table,
-				), mysqlStressPKOffset).Scan(&tombstones)
+				), stressPKMoveOffset).Scan(&tombstones)
 				return live, tombstones, err
 			},
 		},
@@ -861,12 +828,12 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 					quoted := `"` + strings.ReplaceAll(table, `"`, `""`) + `"`
 					if err := db.QueryRowContext(ctx, fmt.Sprintf(
 						"SELECT COUNT(*) FROM %s WHERE id >= ? AND _cdc_deleted = FALSE", quoted,
-					), mysqlStressPKOffset).Scan(&live); err != nil {
+					), stressPKMoveOffset).Scan(&live); err != nil {
 						return err
 					}
 					return db.QueryRowContext(ctx, fmt.Sprintf(
 						"SELECT COUNT(*) FROM %s WHERE id < ? AND _cdc_deleted = TRUE", quoted,
-					), mysqlStressPKOffset).Scan(&tombstones)
+					), stressPKMoveOffset).Scan(&tombstones)
 				})
 				return live, tombstones, err
 			},

--- a/tests/integration/mysql_cdc_stress_test.go
+++ b/tests/integration/mysql_cdc_stress_test.go
@@ -6,16 +6,16 @@
 //
 // MySQL CDC is batch catch-up (snapshot, then replay the binlog to the
 // position captured at stream start, then exit), so instead of one streaming
-// pipeline this test drives parallel MySQL- and DuckDB-destination runs while
-// the shared queue-based load generator applies inserts/updates/deletes/
+// pipeline this test drives parallel PostgreSQL- and DuckDB-destination runs
+// while the shared queue-based load generator applies inserts/updates/deletes/
 // PK-updates at the configured target rate — every
 // mid-load run exercises the resume-from-LSN path under active writes. The source
 // server runs in a non-UTC time zone and a wide-types table covers unsigned
 // integer extremes, DECIMAL, JSON, DATE/DATETIME/TIMESTAMP, and binary
-// columns. Afterwards the destination must converge to the exact source rows,
-// verified by aggregates and canonical row comparison. A final phase alters a
-// table mid-binlog and asserts the pipeline fails loudly and recovers via
-// --full-refresh.
+// columns. Afterwards both destinations must converge to the exact source
+// rows, verified by aggregates and canonical cross-engine row comparison. A
+// final phase alters a table mid-binlog and asserts the pipeline fails loudly
+// and recovers via --full-refresh.
 package integration
 
 import (
@@ -33,6 +33,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/testutil"
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcmysql "github.com/testcontainers/testcontainers-go/modules/mysql"
@@ -324,33 +325,91 @@ func mysqlStressFetchChunk(ctx context.Context, db *sql.DB, table, canonical, ex
 	return out, rows.Err()
 }
 
-func mysqlStressCompareChunkRange(ctx context.Context, src, dst *sql.DB, table, canonical string, offset, limit int64) error {
-	srcRows, err := mysqlStressFetchChunk(ctx, src, table, canonical, "", offset, limit)
+// mysqlStressPostgresCanonicalExpr mirrors mysqlStressCanonicalExpr for the
+// PostgreSQL destination: binary columns as uppercase hex, everything else
+// embedded in a jsonb array whose text rendering both sides normalize through
+// canonicalizeCDCStressJSON.
+func mysqlStressPostgresCanonicalExpr(columns []mysqlStressColumn) string {
+	parts := make([]string, len(columns))
+	for i, column := range columns {
+		quoted := quoteStressIdentifier(column.name)
+		switch strings.ToLower(column.dataType) {
+		case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit":
+			parts[i] = "UPPER(encode(" + quoted + ", 'hex'))"
+		default:
+			parts[i] = quoted
+		}
+	}
+	return "jsonb_build_array(" + strings.Join(parts, ", ") + ")::text"
+}
+
+func mysqlStressFetchPostgresChunk(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	table, canonical string,
+	offset, limit int64,
+) ([]mysqlStressRow, error) {
+	rows, err := pool.Query(ctx, fmt.Sprintf(
+		`SELECT id, %s FROM %s WHERE _cdc_deleted = false ORDER BY id LIMIT $1 OFFSET $2`,
+		canonical, quoteStressIdentifier(table),
+	), limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []mysqlStressRow
+	for rows.Next() {
+		var row mysqlStressRow
+		var raw string
+		if err := rows.Scan(&row.id, &raw); err != nil {
+			return nil, err
+		}
+		row.canonical, err = canonicalizeCDCStressJSON(raw)
+		if err != nil {
+			return nil, fmt.Errorf("canonicalize PostgreSQL row %s id=%d: %w", table, row.id, err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func mysqlStressComparePostgresChunkRange(
+	ctx context.Context,
+	src *sql.DB,
+	dst *pgxpool.Pool,
+	table string,
+	columns []mysqlStressColumn,
+	offset, limit int64,
+) error {
+	srcRows, err := mysqlStressFetchChunk(ctx, src, table, mysqlStressCanonicalExpr(columns), "", offset, limit)
 	if err != nil {
 		return fmt.Errorf("%s offset %d: source fetch: %w", table, offset, err)
 	}
-	dstRows, err := mysqlStressFetchChunk(ctx, dst, table, canonical, " AND `_cdc_deleted` = FALSE", offset, limit)
+	dstRows, err := mysqlStressFetchPostgresChunk(ctx, dst, table, mysqlStressPostgresCanonicalExpr(columns), offset, limit)
 	if err != nil {
-		return fmt.Errorf("%s offset %d: destination fetch: %w", table, offset, err)
+		return fmt.Errorf("%s offset %d: PostgreSQL fetch: %w", table, offset, err)
 	}
 	if len(srcRows) != len(dstRows) {
-		return fmt.Errorf("%s offset %d: row count mismatch: source=%d destination=%d", table, offset, len(srcRows), len(dstRows))
+		return fmt.Errorf("%s offset %d: row count mismatch: source=%d PostgreSQL=%d", table, offset, len(srcRows), len(dstRows))
 	}
 	for i := range srcRows {
-		s, d := srcRows[i], dstRows[i]
-		if s.id != d.id || s.canonical != d.canonical {
-			return fmt.Errorf("%s: content mismatch at id=%d:\n  source:      %s\n  destination: {id:%d row:%s}",
-				table, s.id, s.canonical, d.id, d.canonical)
+		sourceCanonical, err := canonicalizeCDCStressJSON(srcRows[i].canonical)
+		if err != nil {
+			return fmt.Errorf("canonicalize MySQL row %s id=%d: %w", table, srcRows[i].id, err)
+		}
+		if srcRows[i].id != dstRows[i].id || sourceCanonical != dstRows[i].canonical {
+			return fmt.Errorf("%s: content mismatch at id=%d:\n  source:     %s\n  PostgreSQL: {id:%d row:%s}",
+				table, srcRows[i].id, sourceCanonical, dstRows[i].id, dstRows[i].canonical)
 		}
 	}
 	return nil
 }
 
-func mysqlStressCompareAll(ctx context.Context, src, dst *sql.DB, tables []*mysqlStressTable) error {
+func mysqlStressCompareAllPostgres(ctx context.Context, src *sql.DB, dst *pgxpool.Pool, tables []*mysqlStressTable) error {
 	type chunk struct {
-		table     string
-		canonical string
-		offset    int64
+		table   string
+		columns []mysqlStressColumn
+		offset  int64
 	}
 	var chunks []chunk
 	for _, tbl := range tables {
@@ -358,13 +417,12 @@ func mysqlStressCompareAll(ctx context.Context, src, dst *sql.DB, tables []*mysq
 		if err != nil {
 			return err
 		}
-		canonical := mysqlStressCanonicalExpr(columns)
 		var count int64
 		if err := src.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tbl.name)).Scan(&count); err != nil {
 			return fmt.Errorf("count source table %s: %w", tbl.name, err)
 		}
 		for offset := int64(0); offset < count; offset += stressCompareChunk {
-			chunks = append(chunks, chunk{table: tbl.name, canonical: canonical, offset: offset})
+			chunks = append(chunks, chunk{table: tbl.name, columns: columns, offset: offset})
 		}
 	}
 
@@ -377,7 +435,7 @@ func mysqlStressCompareAll(ctx context.Context, src, dst *sql.DB, tables []*mysq
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			if err := mysqlStressCompareChunkRange(ctx, src, dst, c.table, c.canonical, c.offset, stressCompareChunk); err != nil {
+			if err := mysqlStressComparePostgresChunkRange(ctx, src, dst, c.table, c.columns, c.offset, stressCompareChunk); err != nil {
 				errCh <- err
 			}
 		}(c)
@@ -399,10 +457,12 @@ func mysqlStressSourceTruth(ctx context.Context, db *sql.DB, table string) (mysq
 	return tr, err
 }
 
-func mysqlStressDestTruth(ctx context.Context, db *sql.DB, table string) (mysqlStressTruth, error) {
+func mysqlStressPostgresTruth(ctx context.Context, pool *pgxpool.Pool, table string) (mysqlStressTruth, error) {
 	var tr mysqlStressTruth
-	err := db.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT COUNT(*), CAST(COALESCE(SUM(val), 0) AS CHAR) FROM %s WHERE `_cdc_deleted` = FALSE", table)).Scan(&tr.count, &tr.sum)
+	err := pool.QueryRow(ctx, fmt.Sprintf(
+		`SELECT count(*), COALESCE(sum(val), 0)::text FROM %s WHERE _cdc_deleted = false`,
+		quoteStressIdentifier(table),
+	)).Scan(&tr.count, &tr.sum)
 	return tr, err
 }
 
@@ -552,15 +612,12 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 		"--innodb-flush-log-at-trx-commit=0",
 		"--sync-binlog=0",
 	})
-	_, destURI, destDSN := mysqlStressContainer(t, ctx, []string{
-		"--max-connections=200",
-	})
+	destConnString, destPool := stressDestContainer(t, ctx)
 
 	loadDB := mysqlStressOpenDB(t, sourceDSN, stressWorkers+8)
-	// Verification sessions pin time_zone so TIMESTAMP columns render
-	// identically on both servers regardless of their server time zones.
+	// The source verification session pins time_zone to UTC so TIMESTAMP
+	// columns render the same instants the destinations store.
 	srcVerify := mysqlStressOpenDB(t, sourceDSN+"&time_zone=%27%2B00%3A00%27", stressCompareParallel+2)
-	dstVerify := mysqlStressOpenDB(t, destDSN+"&time_zone=%27%2B00%3A00%27", stressCompareParallel+2)
 	duckDBPath := filepath.Join(t.TempDir(), "mysql-cdc-stress.duckdb")
 
 	tables := &mysqlStressTableSet{}
@@ -578,16 +635,16 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 	seededRows := (mysqlStressInitialTables + 1) * mysqlStressSeedRows
 	t.Logf("seeded %d rows across %d tables in %v", seededRows, mysqlStressInitialTables+1, time.Since(seedStart).Round(time.Millisecond))
 
-	nativeConfig := &config.IngestConfig{
+	postgresConfig := &config.IngestConfig{
 		SourceURI:           sourceURI[:len("mysql")] + "+cdc" + sourceURI[len("mysql"):] + "?server_id=21999",
-		DestURI:             destURI,
+		DestURI:             destConnString,
 		IncrementalStrategy: config.StrategyMerge,
 	}
-	duckDBConfig := *nativeConfig
+	duckDBConfig := *postgresConfig
 	duckDBConfig.SourceURI = sourceURI[:len("mysql")] + "+cdc" + sourceURI[len("mysql"):] + "?server_id=22000"
 	duckDBConfig.DestURI = "duckdb:///" + duckDBPath
 	pipelines := []cdcStressPipeline{
-		{name: "mysql", config: nativeConfig},
+		{name: "postgres", config: postgresConfig},
 		{name: "duckdb", config: &duckDBConfig},
 	}
 
@@ -773,26 +830,27 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 	}
 	destinations := []mysqlStressDestination{
 		{
-			name: "mysql",
+			name: "postgres",
 			aggregate: func(table string) (mysqlStressTruth, error) {
-				return mysqlStressDestTruth(ctx, dstVerify, table)
+				return mysqlStressPostgresTruth(ctx, destPool, table)
 			},
-			compareAll: func() error { return mysqlStressCompareAll(ctx, srcVerify, dstVerify, finalTables) },
+			compareAll: func() error { return mysqlStressCompareAllPostgres(ctx, srcVerify, destPool, finalTables) },
 			softDeleted: func(table string) (int64, error) {
 				var count int64
-				err := dstVerify.QueryRowContext(ctx,
-					fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE `_cdc_deleted` = TRUE", table)).Scan(&count)
+				err := destPool.QueryRow(ctx, fmt.Sprintf(
+					`SELECT count(*) FROM %s WHERE _cdc_deleted = true`, quoteStressIdentifier(table),
+				)).Scan(&count)
 				return count, err
 			},
 			movedCounts: func(table string) (int64, int64, error) {
 				var live, tombstones int64
-				if err := dstVerify.QueryRowContext(ctx, fmt.Sprintf(
-					"SELECT COUNT(*) FROM %s WHERE id >= ? AND `_cdc_deleted` = FALSE", table,
+				if err := destPool.QueryRow(ctx, fmt.Sprintf(
+					`SELECT count(*) FROM %s WHERE id >= $1 AND _cdc_deleted = false`, quoteStressIdentifier(table),
 				), stressPKMoveOffset).Scan(&live); err != nil {
 					return 0, 0, err
 				}
-				err := dstVerify.QueryRowContext(ctx, fmt.Sprintf(
-					"SELECT COUNT(*) FROM %s WHERE id < ? AND `_cdc_deleted` = TRUE", table,
+				err := destPool.QueryRow(ctx, fmt.Sprintf(
+					`SELECT count(*) FROM %s WHERE id < $1 AND _cdc_deleted = true`, quoteStressIdentifier(table),
 				), stressPKMoveOffset).Scan(&tombstones)
 				return live, tombstones, err
 			},
@@ -889,7 +947,7 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 		time.Sleep(2 * time.Second)
 	}
 	convergeDuration := time.Since(convergeStart)
-	t.Logf("MySQL and DuckDB destinations converged on count/sum aggregates for all tables in %v after load stop", convergeDuration.Round(time.Millisecond))
+	t.Logf("PostgreSQL and DuckDB destinations converged on count/sum aggregates for all tables in %v after load stop", convergeDuration.Round(time.Millisecond))
 
 	for _, destination := range destinations {
 		compareStart := time.Now()
@@ -958,7 +1016,7 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 		for _, destination := range destinations {
 			require.NoError(t, destination.compareAll(), "phase %q: %s row-by-row comparison failed", phase, destination.name)
 		}
-		t.Logf("phase %q: aggregates and row-by-row content verified for %d tables in MySQL and DuckDB", phase, len(finalTables))
+		t.Logf("phase %q: aggregates and row-by-row content verified for %d tables in PostgreSQL and DuckDB", phase, len(finalTables))
 	}
 
 	execSQL := func(query string, args ...interface{}) error {
@@ -1011,9 +1069,9 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 		return execSQL(fmt.Sprintf("INSERT INTO %s (id, val, drift_note, payload, updated_at) VALUES (?, ?, 'post-drift', 'post-drift', NOW(6))", driftTable), churnBase+1, churnBase+1)
 	})
 	var driftNote string
-	require.NoError(t, dstVerify.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT drift_note FROM %s WHERE id = ?", driftTable), churnBase+1).Scan(&driftNote))
-	require.Equal(t, "post-drift", driftNote, "the post-ALTER column must land after recovery")
+	require.NoError(t, destPool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT drift_note FROM %s WHERE id = $1`, quoteStressIdentifier(driftTable)), churnBase+1).Scan(&driftNote))
+	require.Equal(t, "post-drift", driftNote, "the post-ALTER column must land in PostgreSQL after recovery")
 	require.NoError(t, withCDCStressDuckDB(duckDBPath, func(db *sql.DB) error {
 		return db.QueryRowContext(ctx, fmt.Sprintf(
 			`SELECT drift_note FROM "%s" WHERE id = ?`, strings.ReplaceAll(driftTable, `"`, `""`),
@@ -1073,8 +1131,8 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 		return execSQL(fmt.Sprintf("UPDATE %s SET val = val + 7, updated_at = NOW(6) WHERE id %% 5 = 0", tbl.name))
 	})
 
-	t.Logf("PERF SUMMARY: MySQL snapshot %.0f rows/sec in %v; DuckDB snapshot %.0f rows/sec in %v (%d rows each); load %.0f ops/sec sustained; %d parallel catch-up rounds; convergence %v after load stop; %d parallel full-refresh phases across 6 schema-churn phases",
-		snapshotRates["mysql"], snapshotResults[0].duration.Round(time.Millisecond),
+	t.Logf("PERF SUMMARY: PostgreSQL snapshot %.0f rows/sec in %v; DuckDB snapshot %.0f rows/sec in %v (%d rows each); load %.0f ops/sec sustained; %d parallel catch-up rounds; convergence %v after load stop; %d parallel full-refresh phases across 6 schema-churn phases",
+		snapshotRates["postgres"], snapshotResults[0].duration.Round(time.Millisecond),
 		snapshotRates["duckdb"], snapshotResults[1].duration.Round(time.Millisecond), seededRows,
 		achieved, catchupRuns.Load(), convergeDuration.Round(time.Millisecond), fullRefreshes)
 }

--- a/tests/integration/postgres_cdc_stress_test.go
+++ b/tests/integration/postgres_cdc_stress_test.go
@@ -5,8 +5,8 @@
 // never slows down CI; run it with `make cdc-postgres-stress-test`.
 //
 // Scenario: two streaming CDC pipelines replicate from one Postgres container
-// into PostgreSQL and DuckDB while parallel workers apply
-// ~1000 inserts/updates/deletes per second.
+// into PostgreSQL and DuckDB while the shared queue-based load generator
+// applies inserts/updates/deletes/PK-updates at the configured target rate.
 // During the load, tables with pre-existing rows are discovered and one table
 // goes through column add/drop/rename, a numeric type change, large JSONB
 // updates, primary-key updates, and TRUNCATE followed by inserts in the same
@@ -58,7 +58,7 @@ var (
 	stressNewTableEvery   = envDuration("STRESS_NEW_TABLE_EVERY", 1*time.Minute)
 	stressSchemaEvery     = envDuration("STRESS_SCHEMA_CHANGE_EVERY", 20*time.Second)
 	stressLateTables      = envInt("STRESS_LATE_TABLES", 2)
-	stressWorkers         = envInt("STRESS_WORKERS", 12)
+	stressWorkers         = envInt("STRESS_WORKERS", 32)
 )
 
 func envInt(name string, def int) int {
@@ -80,11 +80,12 @@ func envDuration(name string, def time.Duration) time.Duration {
 }
 
 type stressTable struct {
-	name      string
-	nextID    atomic.Int64
-	insertSQL string
-	updateSQL string
-	deleteSQL string
+	name        string
+	nextID      atomic.Int64
+	insertSQL   string
+	updateSQL   string
+	deleteSQL   string
+	pkUpdateSQL string
 }
 
 type stressTruth struct {
@@ -94,10 +95,11 @@ type stressTruth struct {
 
 func newStressTable(name string, seeded int64) *stressTable {
 	t := &stressTable{
-		name:      name,
-		insertSQL: fmt.Sprintf(`INSERT INTO public.%s (id, val, payload, updated_at) VALUES ($1, $2, $3, now())`, name),
-		updateSQL: fmt.Sprintf(`UPDATE public.%s SET val = val + 1, payload = $2, updated_at = now() WHERE id = $1`, name),
-		deleteSQL: fmt.Sprintf(`DELETE FROM public.%s WHERE id = $1`, name),
+		name:        name,
+		insertSQL:   fmt.Sprintf(`INSERT INTO public.%s (id, val, payload, updated_at) VALUES ($1, $2, $3, now())`, name),
+		updateSQL:   fmt.Sprintf(`UPDATE public.%s SET val = val + 1, payload = $2, updated_at = now() WHERE id = $1`, name),
+		deleteSQL:   fmt.Sprintf(`DELETE FROM public.%s WHERE id = $1`, name),
+		pkUpdateSQL: fmt.Sprintf(`UPDATE public.%s SET id = id + $1, updated_at = now() WHERE id = $2 AND id < $1`, name),
 	}
 	t.nextID.Store(seeded)
 	return t
@@ -407,62 +409,46 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 	loadCtx, stopLoad := context.WithTimeout(ctx, stressLoadDuration)
 	defer stopLoad()
 
-	var inserts, updates, deletes, opErrors, completedDDL atomic.Int64
-	var firstOpErr atomic.Value
-	recordOpErr := func(err error) {
-		opErrors.Add(1)
-		firstOpErr.CompareAndSwap(nil, err)
-	}
-
-	// Each worker paces itself at target/workers so the aggregate rate scales
-	// past what a single shared ticker channel can hand out.
-	workerInterval := time.Duration(stressWorkers) * time.Second / time.Duration(stressTargetOpsPerSec)
+	var completedDDL atomic.Int64
+	gen := newCDCStressLoadGen(t, stressWorkers, stressTargetOpsPerSec, stressLoadDuration)
+	recordOpErr := gen.recordOpErr
 
 	var wg sync.WaitGroup
-	for w := 0; w < stressWorkers; w++ {
-		wg.Add(1)
-		go func(seed int64) {
-			defer wg.Done()
-			rng := rand.New(rand.NewSource(seed))
-			ticker := time.NewTicker(workerInterval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-loadCtx.Done():
-					return
-				case <-ticker.C:
-				}
-				tbl := tables.pick(rng)
-				switch roll := rng.Intn(100); {
-				case roll < 45:
-					id := tbl.nextID.Add(1)
-					// ctx, not loadCtx: every issued op runs to completion so
-					// the post-load source state is settled when workers exit.
-					if _, err := srcPool.Exec(ctx, tbl.insertSQL, id, id, fmt.Sprintf("ins-%d-%d", seed, id)); err != nil {
-						recordOpErr(fmt.Errorf("insert %s id=%d: %w", tbl.name, id, err))
-					} else {
-						inserts.Add(1)
-					}
-				case roll < 85:
-					id := rng.Int63n(tbl.nextID.Load()) + 1
-					result, err := srcPool.Exec(ctx, tbl.updateSQL, id, fmt.Sprintf("upd-%d-%d", seed, id))
-					if err != nil {
-						recordOpErr(fmt.Errorf("update %s id=%d: %w", tbl.name, id, err))
-					} else {
-						updates.Add(result.RowsAffected())
-					}
-				default:
-					id := rng.Int63n(tbl.nextID.Load()) + 1
-					result, err := srcPool.Exec(ctx, tbl.deleteSQL, id)
-					if err != nil {
-						recordOpErr(fmt.Errorf("delete %s id=%d: %w", tbl.name, id, err))
-					} else {
-						deletes.Add(result.RowsAffected())
-					}
-				}
+	// ctx, not loadCtx, inside each op: every issued op runs to completion so
+	// the post-load source state is settled when workers exit.
+	gen.start(loadCtx, &wg, func(rng *rand.Rand) (string, int64, error) {
+		tbl := tables.pick(rng)
+		switch roll := rng.Intn(100); {
+		case roll < 40:
+			id := tbl.nextID.Add(1)
+			if _, err := srcPool.Exec(ctx, tbl.insertSQL, id, id, fmt.Sprintf("ins-%d", id)); err != nil {
+				return "insert", 0, fmt.Errorf("insert %s id=%d: %w", tbl.name, id, err)
 			}
-		}(int64(w + 1))
-	}
+			return "insert", 1, nil
+		case roll < 75:
+			id := rng.Int63n(tbl.nextID.Load()) + 1
+			result, err := srcPool.Exec(ctx, tbl.updateSQL, id, fmt.Sprintf("upd-%d", id))
+			if err != nil {
+				return "update", 0, fmt.Errorf("update %s id=%d: %w", tbl.name, id, err)
+			}
+			return "update", result.RowsAffected(), nil
+		case roll < 90:
+			id := rng.Int63n(tbl.nextID.Load()) + 1
+			result, err := srcPool.Exec(ctx, tbl.deleteSQL, id)
+			if err != nil {
+				return "delete", 0, fmt.Errorf("delete %s id=%d: %w", tbl.name, id, err)
+			}
+			return "delete", result.RowsAffected(), nil
+		default:
+			// Primary-key update: exercises the delete+insert change pair.
+			id := rng.Int63n(tbl.nextID.Load()) + 1
+			result, err := srcPool.Exec(ctx, tbl.pkUpdateSQL, stressPKMoveOffset, id)
+			if err != nil {
+				return "pk-update", 0, fmt.Errorf("pk-update %s id=%d: %w", tbl.name, id, err)
+			}
+			return "pk-update", result.RowsAffected(), nil
+		}
+	})
 
 	wg.Add(1)
 	go func() {
@@ -518,20 +504,13 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 			<-loadDone
 			t.Fatalf("%s stream exited during load phase: %v", exit.sink.name, exit.err)
 		case <-status.C:
-			t.Logf("t=%v: %d inserts, %d updates, %d deletes, %d/%d schema phases, %d op errors",
-				time.Since(started).Round(time.Second), inserts.Load(), updates.Load(), deletes.Load(), completedDDL.Load(), len(ddlPhases), opErrors.Load())
+			t.Logf("t=%v: %s, DDL=%d/%d",
+				time.Since(started).Round(time.Second), gen.status(), completedDDL.Load(), len(ddlPhases))
 		}
 	}
 
-	if n := opErrors.Load(); n > 0 {
-		t.Fatalf("%d load operations failed, first error: %v", n, firstOpErr.Load())
-	}
 	require.Equal(t, int64(len(ddlPhases)), completedDDL.Load(), "all schema phases must complete")
-	totalOps := inserts.Load() + updates.Load() + deletes.Load()
-	achieved := float64(totalOps) / stressLoadDuration.Seconds()
-	t.Logf("load complete: %d effective ops (%d inserts, %d updates, %d deletes), %.0f ops/sec achieved", totalOps, inserts.Load(), updates.Load(), deletes.Load(), achieved)
-	require.GreaterOrEqual(t, achieved, float64(stressTargetOpsPerSec)/2,
-		"load generator could not sustain enough pressure for the test to be meaningful")
+	gen.verify()
 	finalTables := tables.snapshot()
 	require.Len(t, finalTables, stressInitialTables+1+stressLateTables, "all initial, evolving, and late tables should exist")
 
@@ -544,12 +523,14 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 		truths[tbl.name] = tr
 		t.Logf("source truth %s: count=%d sum=%s", tbl.name, tr.count, tr.sum)
 	}
+	// While the streams are writing, monitoring must open the file read-only;
+	// after shutdown the held read-write connection takes over.
 	var duckDB *sql.DB
 	withDuckDB := func(fn func(*sql.DB) error) error {
 		if duckDB != nil {
 			return fn(duckDB)
 		}
-		return withCDCStressDuckDB(duckDBPath, fn)
+		return withCDCStressDuckDBReadOnly(duckDBPath, fn)
 	}
 
 	type stressDestination struct {
@@ -715,7 +696,6 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 		}
 		require.Positive(t, softDeleted, "%s destination should retain soft-deleted CDC rows outside truncated tables", destination.name)
 	}
-	require.Positive(t, deletes.Load(), "workload should execute real deletes")
 }
 
 func stressDumpReplicationState(t *testing.T, ctx context.Context, srcPool *pgxpool.Pool) {


### PR DESCRIPTION
## What
Standardizes CDC stress tests around a shared rate-controlled harness and hardens cross-table CDC application against partial or stale writes.

## Changes
- Share one high-throughput harness across PostgreSQL, MySQL, and MSSQL stress tests, with PostgreSQL and DuckDB verification
- Make CDC merge, truncate, incarnation validation, and checkpoint updates transactionally safe across affected backends
- Add focused regression coverage and consistent stress-test Make targets

## How to test
1. `make format`
2. `make lint`
3. `make test`

## Risk & rollback
- **Risk:** Medium — CDC transaction and checkpoint behavior changes across several backends.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.
