### PR TITLE
Fix MongoDB incremental interval end gap

### DIFF
--- a/docs/supported-sources/mongodb.md
+++ b/docs/supported-sources/mongodb.md
@@ -118,7 +118,7 @@ ingestr ingest \
     {"$match": {
       "created_at": {
         "$gte": ":interval_start",
-        "$lt": ":interval_end"
+        "$lte": ":interval_end"
       }
     }},
     {"$project": {

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -496,18 +496,8 @@ func (s *MongoDBSource) readFind(ctx context.Context, collection *mongo.Collecti
 
 		filters := make([]bson.D, 0, 2)
 		if opts.IncrementalKey != "" {
-			hasStart := opts.IntervalStart != nil
-			hasEnd := opts.IntervalEnd != nil
-
-			if hasStart || hasEnd {
-				rangeFilter := bson.D{}
-				if hasStart {
-					rangeFilter = append(rangeFilter, bson.E{Key: "$gte", Value: opts.IntervalStart})
-				}
-				if hasEnd {
-					rangeFilter = append(rangeFilter, bson.E{Key: "$lt", Value: opts.IntervalEnd})
-				}
-				filters = append(filters, bson.D{{Key: opts.IncrementalKey, Value: rangeFilter}})
+			if incrementalFilter := mongoIncrementalFilter(opts); len(incrementalFilter) > 0 {
+				filters = append(filters, incrementalFilter)
 			}
 
 			findOpts.SetSort(bson.D{{Key: opts.IncrementalKey, Value: 1}})
@@ -535,6 +525,21 @@ func (s *MongoDBSource) readFind(ctx context.Context, collection *mongo.Collecti
 	}()
 
 	return results, nil
+}
+
+func mongoIncrementalFilter(opts source.ReadOptions) bson.D {
+	if opts.IncrementalKey == "" || opts.IntervalStart == nil && opts.IntervalEnd == nil {
+		return nil
+	}
+
+	rangeFilter := bson.D{}
+	if opts.IntervalStart != nil {
+		rangeFilter = append(rangeFilter, bson.E{Key: "$gte", Value: opts.IntervalStart})
+	}
+	if opts.IntervalEnd != nil {
+		rangeFilter = append(rangeFilter, bson.E{Key: "$lte", Value: opts.IntervalEnd})
+	}
+	return bson.D{{Key: opts.IncrementalKey, Value: rangeFilter}}
 }
 
 func mongoExtractPartitionFilter(opts source.ReadOptions) bson.D {

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -174,6 +174,33 @@ func TestMongoExtractPartitionFilter(t *testing.T) {
 	}
 }
 
+func TestMongoIncrementalFilter(t *testing.T) {
+	start := time.Date(2026, 7, 24, 15, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 24, 15, 59, 59, 999_000_000, time.UTC)
+
+	got, err := bson.Marshal(mongoIncrementalFilter(source.ReadOptions{
+		IncrementalKey: "updated_at",
+		IntervalStart:  &start,
+		IntervalEnd:    &end,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := bson.Marshal(bson.D{{
+		Key: "updated_at",
+		Value: bson.D{
+			{Key: "$gte", Value: start},
+			{Key: "$lte", Value: end},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("filter BSON = %v, want %v", got, want)
+	}
+}
+
 func TestValidateIncrementalKeyProjection(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## What
The MongoDB incremental range filter used an exclusive `$lt` on the interval end, so records whose timestamp exactly matched the upper bound were skipped between runs, causing a recurring "last minute" gap. This changes it to inclusive `$lte` and extracts the filter builder into a helper with a unit test.

## Changes
- `pkg/source/mongodb/mongodb.go`: extract `mongoIncrementalFilter` helper; use `$lte` for `IntervalEnd`.
- `pkg/source/mongodb/mongodb_test.go`: add `TestMongoIncrementalFilter`.
- `docs/supported-sources/mongodb.md`: update example to use `:interval_end` with `$lte`.

## How to test
1. `go test ./pkg/source/mongodb/...`
2. Run an incremental MongoDB ingest with `--incremental-end` and confirm records at the boundary are included.

## Risk & rollback
- **Risk:** low — behavior change is scoped to the MongoDB incremental range filter.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [ ] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [ ] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
