### PR TITLE
Parallelize CDC stress tests and fix MSSQL handoff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,50 @@ jobs:
       - name: Run integration tests
         run: make test-integration
 
+  cdc-stress:
+    name: ${{ matrix.name }}
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: postgres-cdc-stress-test
+            target: cdc-postgres-stress-test
+            images: |
+              postgres:16-alpine
+          - name: mysql-cdc-stress-test
+            target: cdc-mysql-stress-test
+            images: |
+              mysql:8.0
+              postgres:16-alpine
+          - name: mssql-cdc-stress-test
+            target: cdc-mssql-stress-test
+            images: |
+              mcr.microsoft.com/mssql/server:2022-latest
+              postgres:16-alpine
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pre-pull testcontainer images (background)
+        env:
+          TEST_IMAGES: ${{ matrix.images }}
+        run: |
+          while IFS= read -r img; do
+            docker pull "$img" >/dev/null 2>&1 &
+          done <<< "$TEST_IMAGES"
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
+
+      - name: Run ${{ matrix.name }}
+        run: make ${{ matrix.target }}
+
   dockerBuild:
     runs-on: depot-ubuntu-latest
     name: Docker Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,7 @@ jobs:
               mcr.microsoft.com/mssql/server:2022-latest
               postgres:16-alpine
     env:
+      GOFLAGS: "-p=1"
       TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
       - uses: actions/checkout@v4

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -86,6 +86,54 @@ func TestSourceColumnsWithoutCDC(t *testing.T) {
 	assert.Equal(t, "name", got[1].Name)
 }
 
+func TestFingerprintCaptureInstanceIgnoresIdentityButTracksLayout(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectFingerprint := func(changeTable, valueType string) {
+		mock.ExpectQuery("SELECT c.name, t.name").
+			WithArgs(changeTable).
+			WillReturnRows(sqlmock.NewRows([]string{"name", "type", "nullable", "precision", "scale", "max_length"}).
+				AddRow("id", "int", 0, 10, 0, 4).
+				AddRow("value", valueType, 0, 10, 0, 4))
+		mock.ExpectQuery("SELECT c.name").
+			WithArgs("dbo.items").
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow("id"))
+	}
+
+	s := &MSSQLCDCSource{db: db}
+	expectFingerprint("cdc.dbo_items_CT", "int")
+	first, err := s.fingerprintCaptureInstance(t.Context(), tableMetadata{
+		SourceSchema:    "dbo",
+		SourceName:      "items",
+		CaptureInstance: "dbo_items",
+		ChangeTable:     "cdc.dbo_items_CT",
+	})
+	require.NoError(t, err)
+
+	expectFingerprint("cdc.dbo_items_v2_CT", "int")
+	replacement, err := s.fingerprintCaptureInstance(t.Context(), tableMetadata{
+		SourceSchema:    "dbo",
+		SourceName:      "items",
+		CaptureInstance: "dbo_items_v2",
+		ChangeTable:     "cdc.dbo_items_v2_CT",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, first, replacement)
+
+	expectFingerprint("cdc.dbo_items_v3_CT", "bigint")
+	changedLayout, err := s.fingerprintCaptureInstance(t.Context(), tableMetadata{
+		SourceSchema:    "dbo",
+		SourceName:      "items",
+		CaptureInstance: "dbo_items_v3",
+		ChangeTable:     "cdc.dbo_items_v3_CT",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, first, changedLayout)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBuildSnapshotQueryUsesNullForDroppedCapturedColumns(t *testing.T) {
 	meta := tableMetadata{
 		SourceSchema:   "dbo",

--- a/pkg/source/mssql_cdc/state.go
+++ b/pkg/source/mssql_cdc/state.go
@@ -117,9 +117,9 @@ func (s *MSSQLCDCSource) TableIncarnation(ctx context.Context, table string) (st
 }
 
 // TableSchemaFingerprint hashes the schema this source actually delivers: the
-// capture instance's identity and captured columns, plus the source table's
-// primary key. A recreated capture instance or a changed merge key therefore
-// changes the fingerprint and invalidates recorded resume state.
+// captured columns plus the source table's primary key. Capture-instance
+// identity is intentionally excluded so an identical-layout replacement can
+// retain its resume cursor and use the two-phase handoff path.
 //
 // The configured capture_instance applies here because single-table reads
 // honor it; multi-table reads ignore it and fingerprint their own selected
@@ -134,18 +134,6 @@ func (s *MSSQLCDCSource) TableSchemaFingerprint(ctx context.Context, table strin
 
 func (s *MSSQLCDCSource) fingerprintCaptureInstance(ctx context.Context, meta tableMetadata) (string, error) {
 	h := sha256.New()
-	writeFingerprintValues(h, meta.CaptureInstance)
-
-	var startLSN string
-	err := s.db.QueryRowContext(
-		ctx,
-		"SELECT CONVERT(varchar(20), start_lsn, 2) FROM cdc.change_tables WHERE capture_instance = @p1 AND end_lsn IS NULL",
-		meta.CaptureInstance,
-	).Scan(&startLSN)
-	if err != nil {
-		return "", fmt.Errorf("failed to fingerprint capture instance %s: %w", meta.CaptureInstance, err)
-	}
-	writeFingerprintValues(h, startLSN)
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT c.name, t.name, CONVERT(int, c.is_nullable), CONVERT(int, c.precision), CONVERT(int, c.scale), CONVERT(int, c.max_length)


### PR DESCRIPTION
## What
Run CDC stress suites in parallel and keep identical-layout SQL Server capture-instance handoffs incremental.

## Changes
- Add independent PostgreSQL, MySQL, and MSSQL CDC stress jobs.
- Preserve MSSQL resume state across compatible capture-instance replacements while still invalidating changed layouts.

## How to test
1. Run `make format`, `make lint`, and `make test`.
2. Run `TestMSSQLCDC_CaptureInstanceHandoff_DuckDB` with the `integration` tag.

## Risk & rollback
- **Risk:** Low; the fingerprint still includes captured columns and primary keys.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Affected integration test passes (`TestMSSQLCDC_CaptureInstanceHandoff_DuckDB`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
