### PR TITLE
Speed up local Go checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,14 @@ env:
 
 jobs:
   integration-tests:
+    env:
+      TEST_CONCURRENCY: "1"
     strategy:
       matrix:
         platform:
           - depot-ubuntu-latest
           - macos-15
-        suite: ["test", "test-integration"]
+        suite: ["test-full", "test-integration"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       # DuckDB's ADBC driver can crash when several package test binaries load it
       # at the same time under race builds.
-      GOFLAGS: "-p=1"
+      TEST_CONCURRENCY: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -53,7 +53,8 @@ jobs:
           cache-dependency-path: "go.sum"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - run: make test
+      - name: Run full test suite
+        run: make test-full
 
   end2end:
     runs-on: depot-ubuntu-24.04-4
@@ -172,8 +173,10 @@ jobs:
           cache-dependency-path: "go.sum"
       - name: Install linting tools
         run: make setup
-      - name: Check the formatting and linting
-        run: make lint-ci
+      - name: Check formatting
+        run: make format-ci
+      - name: Run full lint suite
+        run: make lint-full
 
   licenses:
     runs-on: depot-ubuntu-24.04-4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,1 @@
 version: "2"
-
-# Integration tests are behind the `integration` build tag. Without this,
-# golangci-lint would silently drop those files from analysis.
-run:
-  build-tags:
-    - integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@
 make build                    # Builds to bin/ingestr
 
 # Run unit tests
-make test                     # All unit tests with race detection
-go test -short ./...          # Unit tests only
+make test                     # Fast Go unit tests
+make test-full                # Race detection, coverage, and Python SDK tests
 
 # Run integration tests (gated by the `integration` build tag)
 make test-integration
@@ -30,8 +30,10 @@ make run ARGS="ingest --source-uri=postgres://... --dest-uri=sqlite://... --sour
 go run . ingest --source-uri=<uri> --dest-uri=<uri> --source-table=<table>
 
 # Format and lint
-make format                   # gci + gofumpt + go vet + golangci-lint
-make lint                     # Linters only
+make format                   # gci + gofumpt + fast lint
+make lint                     # fast linters on changed Go packages
+make lint-fast                # alias for make lint
+make lint-full                # all linters, all packages, integration-tagged files
 
 # After changing dependencies (go.mod/go.sum), refresh the license audit lock
 make licenses-audit-update    # CI runs `make licenses-audit` (--check) and fails if the lock is stale

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,28 @@ LICENSE_AUDIT_TARGETS ?= $(LICENSE_CHECK_TARGETS)
 LICENSE_AUDIT_INCLUDE_TESTS ?= $(LICENSE_CHECK_INCLUDE_TESTS)
 LICENSE_AUDIT_NEW_STATUS ?= needs-review
 LINT_MERGE_BASE ?= origin/main
-LINT_BUILD_TAGS ?= no_duckdb_arrow
-LINT_CHANGED_FLAGS := --new-from-merge-base=$(LINT_MERGE_BASE) --build-tags="$(LINT_BUILD_TAGS)"
+# Pinned, not @latest. v2.12.x made its cache checkout-independent, but cached
+# diagnostics still contain absolute paths from the checkout that produced
+# them. That makes shared-cache results unsafe across worktrees. Re-test before
+# bumping beyond the latest pre-change patch release.
+GOLANGCI_LINT_VERSION ?= v2.11.4
+# Built with the toolchain this module targets, not golangci-lint's own minimum.
+# `go install` never downgrades but does pick the module's minimum when the base
+# toolchain is older, which yields a binary that refuses to lint this repo:
+# "the Go language version (go1.25) ... is lower than the targeted Go version".
+GOLANGCI_LINT_INSTALL := GOTOOLCHAIN=go$(shell awk '/^go /{print $$2; exit}' go.mod) \
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+# golangci-lint takes a single global lock at $TMPDIR/golangci-lint.lock and
+# aborts after 5s if another instance holds it, so two checkouts linting at once
+# make one of them fail outright. Its cache is Go's own DiskCache, which is
+# built for concurrent multi-process use, so opting out of the lock is safe.
+LINT_PARALLEL_FLAGS ?= --allow-parallel-runners
+LINT_CONCURRENCY ?= 4
+LINT_TIMEOUT ?= 10m
+LINT_INTEGRATION_FLAGS ?= --build-tags=integration
+TEST_CONCURRENCY ?= 4
+REGISTRY_OUTPUT := internal/registry/imports/imports.gen.go
+REGISTRY_INPUTS := cmd/genregistry/main.go pkg/source pkg/destination $(wildcard pkg/source/* pkg/destination/*)
 export INGESTR_DISABLE_TELEMETRY := true
 export DISABLE_TELEMETRY := true
 TELEMETRY_ENV := INGESTR_DISABLE_TELEMETRY=true DISABLE_TELEMETRY=true
@@ -23,7 +43,7 @@ NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 
-.PHONY: all clean test test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint format lint-ci format-ci test-ci setup test-db2-integration cdc-stress-test cdc-postgres-stress-test cdc-mysql-stress-test cdc-mssql-stress-test
+.PHONY: all clean test test-full test-python build deps generate licenses licenses-check licenses-audit licenses-audit-update licenses-notices-check lint lint-fast lint-full format lint-ci format-ci test-ci setup test-db2-integration cdc-stress-test cdc-postgres-stress-test cdc-mysql-stress-test cdc-mssql-stress-test
 
 all: clean deps test build
 
@@ -35,16 +55,18 @@ setup:
 	@printf "$(OK_COLOR)==> Installing development tools$(NO_COLOR)\n"
 	@command -v gci >/dev/null 2>&1 || go install github.com/daixiang0/gci@latest
 	@command -v gofumpt >/dev/null 2>&1 || go install mvdan.cc/gofumpt@latest
-	@command -v golangci-lint >/dev/null 2>&1 || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@current_version="$$(golangci-lint version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($$i == "version") { print "v"$$(i+1); exit } }')"; \
+	if [ "$$current_version" != "$(GOLANGCI_LINT_VERSION)" ]; then $(GOLANGCI_LINT_INSTALL); fi
 
 tools-update:
 	@printf "$(OK_COLOR)==> Installing development tools$(NO_COLOR)\n"
 	go install github.com/daixiang0/gci@latest
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-	
+	$(GOLANGCI_LINT_INSTALL)
 
-generate:
+generate: $(REGISTRY_OUTPUT)
+
+$(REGISTRY_OUTPUT): $(REGISTRY_INPUTS)
 	@echo "$(OK_COLOR)==> Generating registry imports$(NO_COLOR)"
 	@go run ./cmd/genregistry
 
@@ -82,9 +104,15 @@ run: build
 
 
 test: generate
-	@echo "$(OK_COLOR)==> Running unit tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -short -race -cover -timeout 5m ./...
+	@echo "$(OK_COLOR)==> Running unit tests (fast)$(NO_COLOR)"
+	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -short -p "$(TEST_CONCURRENCY)" -timeout 5m ./...
+
+test-full: generate
+	@echo "$(OK_COLOR)==> Running unit tests (full)$(NO_COLOR)"
+	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -short -race -cover -p "$(TEST_CONCURRENCY)" -timeout 5m ./...
 	@$(MAKE) test-python
+
+test-ci: test-full
 
 test-python:
 	@echo "$(OK_COLOR)==> Running Python SDK tests$(NO_COLOR)"
@@ -173,24 +201,30 @@ test-conformance-only:
 		-run 'TestDestinations_.*/($(subst $(comma),|,$(BACKENDS)))'
 
 
-# Format code and run linters (for local development)
-format: generate
+# Format code and run the fast changed-package lint for local cleanup.
+format:
 	@echo "$(OK_COLOR)==> Formatting code$(NO_COLOR)"
 	@gci write cmd pkg internal tests main.go
 	@gofumpt -w cmd pkg internal tests main.go
 	@$(MAKE) lint
-	wait
 
-# Just run linters on changed lines without formatting
+# Fast edit-loop check on changed Go packages. `go vet` is deliberately absent
+# because govet is already enabled here.
 lint: generate
-	@echo "$(OK_COLOR)==> Running linters on changed lines since $(LINT_MERGE_BASE)$(NO_COLOR)"
-	@go vet ./...
-	@golangci-lint run --timeout 10m $(LINT_CHANGED_FLAGS) ./...
+	@echo "$(OK_COLOR)==> Running fast linters on packages changed since $(LINT_MERGE_BASE)$(NO_COLOR)"
+	@LINT_MERGE_BASE="$(LINT_MERGE_BASE)" LINT_CONCURRENCY="$(LINT_CONCURRENCY)" LINT_TIMEOUT="$(LINT_TIMEOUT)" LINT_PARALLEL_FLAGS="$(LINT_PARALLEL_FLAGS)" LINT_ENABLE_ONLY="errcheck,govet,ineffassign" ./hack/lint-changed.sh
+
+lint-fast: lint
+
+# Full local check, including files gated behind the integration build tag.
+lint-full: generate
+	@echo "$(OK_COLOR)==> Running all linters across the repository$(NO_COLOR)"
+	@golangci-lint run --timeout "$(LINT_TIMEOUT)" --concurrency "$(LINT_CONCURRENCY)" $(LINT_PARALLEL_FLAGS) $(LINT_INTEGRATION_FLAGS) ./...
 
 # CI: Check formatting without modifying files (fails if changes needed)
 format-ci: generate
 	@echo "$(OK_COLOR)==> Checking code formatting$(NO_COLOR)"
-	@DIFF=$$(gofumpt -d cmd pkg internal tests main.go 2>&1); \
+	@DIFF="$$(gci diff cmd pkg internal tests main.go 2>&1)$$(gofumpt -d cmd pkg internal tests main.go 2>&1)"; \
 	if [ -n "$$DIFF" ]; then \
 		echo "$(ERROR_COLOR)Files need formatting:$(NO_COLOR)"; \
 		echo "$$DIFF"; \
@@ -199,9 +233,6 @@ format-ci: generate
 	fi
 	@echo "$(OK_COLOR)All files are properly formatted$(NO_COLOR)"
 
-# CI: Full lint check (format check + linters)
-lint-ci: format-ci generate
-	@echo "$(OK_COLOR)==> Running linters (CI)$(NO_COLOR)"
-	@go vet ./...
-	@golangci-lint run --timeout 10m ./...
+# CI: Full formatting and lint checks.
+lint-ci: format-ci lint-full
 	@echo "$(OK_COLOR)All checks passed$(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ LICENSE_AUDIT_TARGETS ?= $(LICENSE_CHECK_TARGETS)
 LICENSE_AUDIT_INCLUDE_TESTS ?= $(LICENSE_CHECK_INCLUDE_TESTS)
 LICENSE_AUDIT_NEW_STATUS ?= needs-review
 LINT_MERGE_BASE ?= origin/main
+GCI_VERSION ?= v0.14.0
+GOFUMPT_VERSION ?= v0.11.0
 # Pinned, not @latest. v2.12.x made its cache checkout-independent, but cached
 # diagnostics still contain absolute paths from the checkout that produced
 # them. That makes shared-cache results unsafe across worktrees. Re-test before
@@ -53,15 +55,17 @@ deps:
 
 setup:
 	@printf "$(OK_COLOR)==> Installing development tools$(NO_COLOR)\n"
-	@command -v gci >/dev/null 2>&1 || go install github.com/daixiang0/gci@latest
-	@command -v gofumpt >/dev/null 2>&1 || go install mvdan.cc/gofumpt@latest
+	@current_version="$$(gci --version 2>/dev/null | awk '{ print "v"$$NF; exit }')"; \
+	if [ "$$current_version" != "$(GCI_VERSION)" ]; then go install github.com/daixiang0/gci@$(GCI_VERSION); fi
+	@current_version="$$(gofumpt -version 2>/dev/null | awk '{ print $$1; exit }')"; \
+	if [ "$$current_version" != "$(GOFUMPT_VERSION)" ]; then go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION); fi
 	@current_version="$$(golangci-lint version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($$i == "version") { print "v"$$(i+1); exit } }')"; \
 	if [ "$$current_version" != "$(GOLANGCI_LINT_VERSION)" ]; then $(GOLANGCI_LINT_INSTALL); fi
 
 tools-update:
 	@printf "$(OK_COLOR)==> Installing development tools$(NO_COLOR)\n"
-	go install github.com/daixiang0/gci@latest
-	go install mvdan.cc/gofumpt@latest
+	go install github.com/daixiang0/gci@$(GCI_VERSION)
+	go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 	$(GOLANGCI_LINT_INSTALL)
 
 generate: $(REGISTRY_OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ test-conformance-only:
 # Format code and run the fast changed-package lint for local cleanup.
 format:
 	@echo "$(OK_COLOR)==> Formatting code$(NO_COLOR)"
-	@gci write cmd pkg internal tests main.go
+	@for path in cmd pkg internal tests main.go; do gci write "$$path"; done
 	@gofumpt -w cmd pkg internal tests main.go
 	@$(MAKE) lint
 
@@ -228,7 +228,7 @@ lint-full: generate
 # CI: Check formatting without modifying files (fails if changes needed)
 format-ci: generate
 	@echo "$(OK_COLOR)==> Checking code formatting$(NO_COLOR)"
-	@DIFF="$$(gci diff cmd pkg internal tests main.go 2>&1)$$(gofumpt -d cmd pkg internal tests main.go 2>&1)"; \
+	@DIFF="$$(for path in cmd pkg internal tests main.go; do gci diff "$$path" 2>&1; done)$$(gofumpt -d cmd pkg internal tests main.go 2>&1)"; \
 	if [ -n "$$DIFF" ]; then \
 		echo "$(ERROR_COLOR)Files need formatting:$(NO_COLOR)"; \
 		echo "$$DIFF"; \

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ test-conformance-only:
 # Format code and run the fast changed-package lint for local cleanup.
 format:
 	@echo "$(OK_COLOR)==> Formatting code$(NO_COLOR)"
-	@for path in cmd pkg internal tests main.go; do gci write "$$path"; done
+	@gci write cmd pkg internal tests main.go
 	@gofumpt -w cmd pkg internal tests main.go
 	@$(MAKE) lint
 
@@ -228,7 +228,7 @@ lint-full: generate
 # CI: Check formatting without modifying files (fails if changes needed)
 format-ci: generate
 	@echo "$(OK_COLOR)==> Checking code formatting$(NO_COLOR)"
-	@DIFF="$$(for path in cmd pkg internal tests main.go; do gci diff "$$path" 2>&1; done)$$(gofumpt -d cmd pkg internal tests main.go 2>&1)"; \
+	@DIFF="$$(gci list cmd pkg internal tests main.go 2>&1)$$(gofumpt -d cmd pkg internal tests main.go 2>&1)"; \
 	if [ -n "$$DIFF" ]; then \
 		echo "$(ERROR_COLOR)Files need formatting:$(NO_COLOR)"; \
 		echo "$$DIFF"; \

--- a/hack/lint-changed.sh
+++ b/hack/lint-changed.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+merge_base_ref="${LINT_MERGE_BASE:-origin/main}"
+concurrency="${LINT_CONCURRENCY:-4}"
+timeout="${LINT_TIMEOUT:-10m}"
+parallel_flags="${LINT_PARALLEL_FLAGS:---allow-parallel-runners}"
+enable_only="${LINT_ENABLE_ONLY:-}"
+
+merge_base="$(git merge-base "$merge_base_ref" HEAD)"
+
+changed_files=()
+while IFS= read -r file; do
+  changed_files+=("$file")
+done < <(
+  {
+    git diff --name-only --diff-filter=ACMRD "$merge_base" --
+    git ls-files --others --exclude-standard
+  } | sed '/^$/d' | LC_ALL=C sort -u
+)
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  echo "No changes found."
+  exit 0
+fi
+
+lint_all=false
+packages=()
+
+for file in "${changed_files[@]}"; do
+  case "$file" in
+    go.mod|go.sum|.golangci.yml)
+      lint_all=true
+      ;;
+    *.go)
+      if [[ ! -e "$file" ]]; then
+        lint_all=true
+        continue
+      fi
+
+      directory="$(dirname "$file")"
+      if [[ "$directory" == "." ]]; then
+        packages+=("./")
+      else
+        packages+=("./$directory")
+      fi
+      ;;
+  esac
+done
+
+if [[ "$lint_all" == true ]]; then
+  packages=("./...")
+elif [[ ${#packages[@]} -eq 0 ]]; then
+  echo "No changed Go packages to lint."
+  exit 0
+else
+  unique_packages=()
+  while IFS= read -r package; do
+    unique_packages+=("$package")
+  done < <(printf '%s\n' "${packages[@]}" | LC_ALL=C sort -u)
+  packages=("${unique_packages[@]}")
+fi
+
+args=(run --timeout "$timeout" --concurrency "$concurrency")
+
+if [[ -n "$parallel_flags" ]]; then
+  read -r -a parsed_parallel_flags <<< "$parallel_flags"
+  args+=("${parsed_parallel_flags[@]}")
+fi
+
+if [[ -n "$enable_only" ]]; then
+  args+=(--enable-only "$enable_only")
+fi
+
+echo "Packages: ${packages[*]}"
+exec golangci-lint "${args[@]}" "${packages[@]}"


### PR DESCRIPTION
## What
Make local format, lint, and test loops faster and worktree-safe while keeping full checks in CI.

## Changes
- Add fast local targets, changed-package linting, bounded concurrency, incremental generation, and a Go 1.26-built golangci-lint v2.11.4 pin.
- Update CI workflows and contributor docs to use the full checks.

## How to test
1. Run `make format`, `make lint`, `make test`, `make format-ci`, `make lint-full`, and `make test-full`.

## Risk & rollback
- **Risk:** Low; this only changes developer tooling and CI commands.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.