### PR TITLE
ci: stop publishing macOS Intel wheel to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,6 @@ jobs:
 
           build_one artifacts/ingestr_Linux_x86_64.tar.gz   ingestr     manylinux2014_x86_64
           build_one artifacts/ingestr_Linux_arm64.tar.gz    ingestr     manylinux2014_aarch64
-          build_one artifacts/ingestr_Darwin_x86_64.tar.gz  ingestr     macosx_10_15_x86_64
           build_one artifacts/ingestr_Darwin_arm64.tar.gz   ingestr     macosx_11_0_arm64
           build_one artifacts/ingestr_Windows_x86_64.zip    ingestr.exe win_amd64
 


### PR DESCRIPTION
Drops the macOS Intel (`darwin/amd64`) wheel from the `release-pip` job so `pip install ingestr` no longer offers an Intel-Mac binary.

The Intel binary remains available on GitHub Releases — GoReleaser still builds and attaches `ingestr_Darwin_x86_64.tar.gz`, and `install.sh` keeps fetching it from there — so users who still need it can download it directly.

## Changes

- `release-pip`: remove the `ingestr_Darwin_x86_64.tar.gz` → `macosx_10_15_x86_64` `build_one` call. The Linux x86_64/arm64, Darwin arm64, and Windows wheels are unchanged.

Nothing else changes: `.goreleaser.yaml` still produces and ships the Intel tarball to the GitHub release, and the license audit still covers `darwin/amd64`.