### PR TITLE
Audit and tighten CLI telemetry events

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/source/postgres_cdc"
@@ -32,9 +33,9 @@ func DeleteCommand() *cli.Command {
 }
 
 func runDelete(ctx context.Context, c *cli.Command) (err error) {
-	trackCommandTriggered(ctx, "delete")
+	startedAt := time.Now()
 	defer func() {
-		trackCommandFinished(ctx, "delete", err, nil)
+		trackCommandFinished(ctx, "delete", startedAt, err, nil)
 	}()
 
 	sourceURI := c.String("uri")

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -12,9 +12,11 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/metrics"
 	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/internal/registry"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/strategy"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v3"
@@ -250,11 +252,11 @@ func IngestCommand() *cli.Command {
 }
 
 func runIngest(ctx context.Context, c *cli.Command) (err error) {
-	trackCommandTriggered(ctx, "ingest")
-	var finishedProperties map[string]any
+	startedAt := time.Now()
+	var cfg *config.IngestConfig
 	defer func() {
 		output.EnsureTerminal(err)
-		trackCommandFinished(ctx, "ingest", err, finishedProperties)
+		trackCommandFinished(ctx, "ingest", startedAt, err, ingestTelemetryProperties(cfg))
 	}()
 
 	config.DebugMode = c.Bool("debug")
@@ -263,7 +265,7 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 		outputMode = output.ModeJSON
 	}
 	output.Init(os.Stdout, os.Stderr, outputMode)
-	cfg := config.DefaultConfig()
+	cfg = config.DefaultConfig()
 
 	cfg.SourceURI = c.String("source-uri")
 	cfg.DestURI = c.String("dest-uri")
@@ -303,7 +305,6 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	cfg.Stream = c.Bool("stream")
 	cfg.FlushInterval = c.Duration("flush-interval")
 	cfg.FlushRecords = int(c.Int("flush-records"))
-	finishedProperties = ingestTelemetryProperties(cfg)
 
 	if !cfg.Stream && (c.IsSet("flush-interval") || c.IsSet("flush-records")) {
 		return fmt.Errorf("--flush-interval and --flush-records are only valid together with --stream")
@@ -397,21 +398,91 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 
 func ingestTelemetryProperties(cfg *config.IngestConfig) map[string]any {
 	properties := map[string]any{}
-	if sourceType := telemetryScheme(cfg.SourceURI); sourceType != "" {
+	if cfg == nil {
+		return properties
+	}
+	if sourceType := telemetrySourceScheme(cfg.SourceURI); sourceType != "" {
 		properties["source_platform"] = sourceType
 	}
-	if destinationType := telemetryScheme(cfg.DestURI); destinationType != "" {
+	if destinationType := telemetryDestinationScheme(cfg.DestURI); destinationType != "" {
 		properties["destination_platform"] = destinationType
+	}
+	properties["execution_mode"] = telemetryExecutionMode(cfg)
+	properties["full_refresh"] = cfg.FullRefresh
+	properties["multi_table"] = cfg.IsCDCSource() && cfg.SourceTable == ""
+	properties["schema_inference_disabled"] = cfg.NoInference
+	properties["masking_enabled"] = len(cfg.Mask) > 0
+	properties["partitioned_extract"] = cfg.ExtractPartitionBy != ""
+	properties["trim_whitespace"] = cfg.TrimWhitespace
+	properties["load_timestamp_enabled"] = !cfg.NoLoadTimestamp
+	properties["strategy_selection"] = "default"
+	if cfg.IncrementalStrategyExplicit {
+		properties["strategy_selection"] = "explicit"
+		properties["requested_strategy"] = telemetryStrategy(cfg.IncrementalStrategy)
+	}
+	if schemaContract := telemetrySchemaContract(cfg.SchemaContract); schemaContract != "" {
+		properties["schema_contract"] = schemaContract
 	}
 	return properties
 }
 
-func telemetryScheme(rawURI string) string {
+func telemetrySourceScheme(rawURI string) string {
 	parsed, err := uri.Parse(rawURI)
 	if err != nil {
 		return ""
 	}
-	return parsed.Scheme
+	scheme := uri.NormalizeScheme(parsed.Scheme)
+	if _, err := registry.Default.GetSourceConstructor(scheme); err != nil {
+		return ""
+	}
+	return scheme
+}
+
+func telemetryDestinationScheme(rawURI string) string {
+	parsed, err := uri.Parse(rawURI)
+	if err != nil {
+		return ""
+	}
+	scheme := uri.NormalizeScheme(parsed.Scheme)
+	if _, err := registry.Default.GetDestinationConstructor(scheme); err != nil {
+		return ""
+	}
+	return scheme
+}
+
+func telemetryExecutionMode(cfg *config.IngestConfig) string {
+	switch {
+	case cfg.Stream && cfg.IsCDCSource():
+		return "cdc_stream"
+	case cfg.Stream:
+		return "stream"
+	case cfg.IsCDCSource():
+		return "cdc_batch"
+	default:
+		return "batch"
+	}
+}
+
+func telemetryStrategy(strategy config.IncrementalStrategy) string {
+	switch strategy {
+	case config.StrategyReplace,
+		config.StrategyAppend,
+		config.StrategyDeleteInsert,
+		config.StrategyMerge,
+		config.StrategySCD2,
+		config.StrategyNone:
+		return string(strategy)
+	default:
+		return "invalid"
+	}
+}
+
+func telemetrySchemaContract(contract string) string {
+	mode, err := schemaevolution.ParseContractMode(contract)
+	if err != nil {
+		return ""
+	}
+	return string(mode)
 }
 
 func parseDateTime(s string) (time.Time, error) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/server"
 	"github.com/urfave/cli/v3"
@@ -47,9 +48,9 @@ func ServerCommand() *cli.Command {
 }
 
 func runServer(ctx context.Context, c *cli.Command) (err error) {
-	trackCommandTriggered(ctx, "server")
+	startedAt := time.Now()
 	defer func() {
-		trackCommandFinished(ctx, "server", err, nil)
+		trackCommandFinished(ctx, "server", startedAt, err, nil)
 	}()
 
 	port := int(c.Int("port"))

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -3,23 +3,22 @@ package cmd
 import (
 	"context"
 	"errors"
-	"sync"
+	"os"
+	"runtime"
+	"strings"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/telemetry"
+	"golang.org/x/term"
 )
 
-var telemetryWG sync.WaitGroup
-
-func trackCommandTriggered(ctx context.Context, command string) {
-	trackTelemetryAsync(ctx, "command_triggered", commandTelemetryProperties(command, nil))
-}
-
-func trackCommandFinished(ctx context.Context, command string, err error, additionalProperties map[string]any) {
+func trackCommandFinished(ctx context.Context, command string, startedAt time.Time, err error, additionalProperties map[string]any) {
 	finishedProperties := map[string]any{}
 	for key, value := range additionalProperties {
 		finishedProperties[key] = value
 	}
+	finishedProperties["duration_bucket"] = telemetryDurationBucket(time.Since(startedAt))
 	finishedProperties["status"] = "success"
 	if err != nil {
 		finishedProperties["status"] = "failed"
@@ -27,34 +26,137 @@ func trackCommandFinished(ctx context.Context, command string, err error, additi
 	}
 
 	properties := commandTelemetryProperties(command, finishedProperties)
-	telemetryWG.Wait()
 	telemetry.Track(context.WithoutCancel(ctx), "command_finished", properties, versionFlagValue())
 }
 
-func trackTelemetryAsync(ctx context.Context, event string, properties map[string]any) {
-	if telemetry.Disabled() {
-		return
-	}
-
-	ctx = context.WithoutCancel(ctx)
-	version := versionFlagValue()
-	telemetryWG.Add(1)
-	go func() {
-		defer telemetryWG.Done()
-		telemetry.Track(ctx, event, properties, version)
-	}()
-}
-
 func commandTelemetryProperties(command string, properties map[string]any) map[string]any {
-	eventProperties := map[string]any{
-		"command": command,
-		"version": versionFlagValue(),
-	}
+	eventProperties := make(map[string]any, len(properties)+6)
 	for key, value := range properties {
 		eventProperties[key] = value
 	}
+	eventProperties["command"] = command
 	eventProperties["version"] = versionFlagValue()
+	eventProperties["deployment_type"] = telemetryDeploymentType(os.Getenv, telemetryFileExists)
+	eventProperties["invocation_style"] = telemetryInvocationStyle(os.Getenv, telemetryTerminal)
+	eventProperties["invoker"] = telemetryInvoker(os.Getenv)
+	eventProperties["cpu_bucket"] = telemetryCPUBucket(runtime.GOMAXPROCS(0))
 	return eventProperties
+}
+
+func telemetryDeploymentType(getenv func(string) string, fileExists func(string) bool) string {
+	switch {
+	case getenv("KUBERNETES_SERVICE_HOST") != "":
+		return "kubernetes"
+	case getenv("ECS_CONTAINER_METADATA_URI_V4") != "" || getenv("ECS_CONTAINER_METADATA_URI") != "":
+		return "ecs"
+	case getenv("K_SERVICE") != "" && getenv("K_REVISION") != "" && getenv("K_CONFIGURATION") != "":
+		return "cloud_run"
+	case getenv("CLOUD_RUN_JOB") != "" && getenv("CLOUD_RUN_EXECUTION") != "":
+		return "cloud_run_job"
+	case getenv("AWS_LAMBDA_FUNCTION_NAME") != "":
+		return "lambda"
+	case getenv("WEBSITE_INSTANCE_ID") != "":
+		return "azure_app_service"
+	case fileExists("/.dockerenv") || fileExists("/run/.containerenv"):
+		return "container"
+	default:
+		return "host"
+	}
+}
+
+func telemetryInvocationStyle(getenv func(string) string, isTerminal func(int) bool) string {
+	if telemetryCIEnvironment(getenv) {
+		return "ci"
+	}
+	if isTerminal(int(os.Stdin.Fd())) || isTerminal(int(os.Stdout.Fd())) {
+		return "interactive"
+	}
+	return "non_interactive"
+}
+
+func telemetryCIEnvironment(getenv func(string) string) bool {
+	for _, key := range []string{
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"BUILDKITE",
+		"JENKINS_URL",
+		"TF_BUILD",
+		"CIRCLECI",
+	} {
+		if telemetryEnvEnabled(getenv(key)) {
+			return true
+		}
+	}
+	return false
+}
+
+func telemetryEnvEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+func telemetryInvoker(getenv func(string) string) string {
+	value := strings.ToLower(strings.TrimSpace(getenv("INGESTR_TELEMETRY_INVOKER")))
+	switch value {
+	case "":
+		return "direct"
+	case "bruin_cli", "bruin_cloud", "ingestr_server":
+		return value
+	default:
+		return "other"
+	}
+}
+
+func telemetryCPUBucket(cpus int) string {
+	switch {
+	case cpus <= 1:
+		return "1"
+	case cpus <= 3:
+		return "2-3"
+	case cpus <= 7:
+		return "4-7"
+	case cpus <= 15:
+		return "8-15"
+	case cpus <= 31:
+		return "16-31"
+	default:
+		return "32+"
+	}
+}
+
+func telemetryDurationBucket(duration time.Duration) string {
+	switch {
+	case duration < time.Second:
+		return "<1s"
+	case duration < 10*time.Second:
+		return "1s-10s"
+	case duration < time.Minute:
+		return "10s-1m"
+	case duration < 10*time.Minute:
+		return "1m-10m"
+	case duration < time.Hour:
+		return "10m-1h"
+	case duration < 24*time.Hour:
+		return "1h-1d"
+	case duration < 7*24*time.Hour:
+		return "1d-7d"
+	default:
+		return "7d+"
+	}
+}
+
+func telemetryFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func telemetryTerminal(fd int) bool {
+	return term.IsTerminal(fd)
 }
 
 func commandTelemetryError(err error) string {

--- a/cmd/telemetry_test.go
+++ b/cmd/telemetry_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/stretchr/testify/require"
@@ -23,13 +25,116 @@ func TestCommandTelemetryPropertiesIncludeVersionFlagValue(t *testing.T) {
 }
 
 func TestIngestTelemetryPropertiesIncludeConnectorSchemes(t *testing.T) {
-	properties := ingestTelemetryProperties(&config.IngestConfig{
-		SourceURI: "postgres://user:pass@localhost:5432/db",
-		DestURI:   "bigquery://project/dataset",
-	})
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "postgresql://user:pass@localhost:5432/db"
+	cfg.DestURI = "bigquery://project/dataset"
+
+	properties := ingestTelemetryProperties(cfg)
 
 	require.Equal(t, "postgres", properties["source_platform"])
 	require.Equal(t, "bigquery", properties["destination_platform"])
+	require.Equal(t, "batch", properties["execution_mode"])
+	require.Equal(t, "default", properties["strategy_selection"])
+	require.Equal(t, "evolve", properties["schema_contract"])
+}
+
+func TestIngestTelemetryPropertiesUseAllowlistedValues(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "customer-secret://source"
+	cfg.DestURI = "tenant-secret://destination"
+	cfg.IncrementalStrategy = "strategy-secret"
+	cfg.IncrementalStrategyExplicit = true
+	cfg.SchemaContract = "contract-secret"
+
+	properties := ingestTelemetryProperties(cfg)
+
+	require.NotContains(t, properties, "source_platform")
+	require.NotContains(t, properties, "destination_platform")
+	require.NotContains(t, properties, "schema_contract")
+	require.Equal(t, "invalid", properties["requested_strategy"])
+	require.NotContains(t, fmt.Sprint(properties), "customer-secret")
+	require.NotContains(t, fmt.Sprint(properties), "tenant-secret")
+	require.NotContains(t, fmt.Sprint(properties), "strategy-secret")
+	require.NotContains(t, fmt.Sprint(properties), "contract-secret")
+}
+
+func TestTelemetrySchemaContractMatchesParser(t *testing.T) {
+	require.Equal(t, "evolve", telemetrySchemaContract("evolve"))
+	require.Equal(t, "discard_row", telemetrySchemaContract("discard-row"))
+	require.Equal(t, "discard_value", telemetrySchemaContract("discard-value"))
+	require.Equal(t, "freeze", telemetrySchemaContract(" Freeze "))
+	require.Equal(t, "", telemetrySchemaContract("contract-secret"))
+}
+
+func TestTelemetryExecutionMode(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		sourceURI string
+		stream    bool
+		want      string
+	}{
+		{name: "batch", sourceURI: "postgres://host/db", want: "batch"},
+		{name: "stream", sourceURI: "kafka://host/topic", stream: true, want: "stream"},
+		{name: "cdc batch", sourceURI: "postgres+cdc://host/db", want: "cdc_batch"},
+		{name: "cdc stream", sourceURI: "postgres+cdc://host/db", stream: true, want: "cdc_stream"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.SourceURI = tt.sourceURI
+			cfg.Stream = tt.stream
+			require.Equal(t, tt.want, telemetryExecutionMode(cfg))
+		})
+	}
+}
+
+func TestTelemetryDeploymentTypeUsesOnlyKnownSignals(t *testing.T) {
+	getenv := func(key string) string {
+		values := map[string]string{
+			"KUBERNETES_SERVICE_HOST": "customer-cluster.internal",
+			"WEBSITE_INSTANCE_ID":     "customer-instance-id",
+		}
+		return values[key]
+	}
+
+	require.Equal(t, "kubernetes", telemetryDeploymentType(getenv, func(string) bool { return false }))
+	require.Equal(t, "cloud_run_job", telemetryDeploymentType(func(key string) string {
+		values := map[string]string{
+			"CLOUD_RUN_JOB":       "customer-job-name",
+			"CLOUD_RUN_EXECUTION": "customer-job-execution",
+		}
+		return values[key]
+	}, func(string) bool { return false }))
+	require.Equal(t, "container", telemetryDeploymentType(func(string) string { return "" }, func(path string) bool {
+		return path == "/.dockerenv"
+	}))
+	require.Equal(t, "host", telemetryDeploymentType(func(string) string { return "" }, func(string) bool { return false }))
+}
+
+func TestTelemetryInvocationStyle(t *testing.T) {
+	require.Equal(t, "ci", telemetryInvocationStyle(func(key string) string {
+		if key == "GITHUB_ACTIONS" {
+			return "true"
+		}
+		return ""
+	}, func(int) bool { return true }))
+	require.Equal(t, "interactive", telemetryInvocationStyle(func(string) string { return "" }, func(int) bool { return true }))
+	require.Equal(t, "non_interactive", telemetryInvocationStyle(func(string) string { return "" }, func(int) bool { return false }))
+}
+
+func TestTelemetryInvokerDoesNotForwardUnknownValues(t *testing.T) {
+	require.Equal(t, "direct", telemetryInvoker(func(string) string { return "" }))
+	require.Equal(t, "bruin_cli", telemetryInvoker(func(string) string { return "bruin_cli" }))
+	require.Equal(t, "other", telemetryInvoker(func(string) string { return "customer-name" }))
+}
+
+func TestTelemetryBuckets(t *testing.T) {
+	require.Equal(t, "1", telemetryCPUBucket(1))
+	require.Equal(t, "4-7", telemetryCPUBucket(4))
+	require.Equal(t, "32+", telemetryCPUBucket(64))
+
+	require.Equal(t, "<1s", telemetryDurationBucket(500*time.Millisecond))
+	require.Equal(t, "1m-10m", telemetryDurationBucket(5*time.Minute))
+	require.Equal(t, "1d-7d", telemetryDurationBucket(48*time.Hour))
 }
 
 func TestNewAppUsesVersionFlagValue(t *testing.T) {

--- a/docs/getting-started/telemetry.md
+++ b/docs/getting-started/telemetry.md
@@ -3,24 +3,33 @@ outline: deep
 ---
 
 # Telemetry
-ingestr uses a very basic form of **anonymous telemetry** to be able to keep track of the usage on a high-level.
-- It uses anonymous machine IDs that are hashed to keep track of the number of unique users.
+ingestr uses a basic form of usage telemetry to understand adoption at a high level.
+- It uses a protected, pseudonymous machine ID to keep track of the number of unique installations. On machines where that ID cannot be read, ingestr falls back to a hash derived from the OS name and the hostname.
 - It sends the following information:
   - ingestr version
   - machine ID
   - OS information: OS, architecture, Go version
   - command executed
   - success/failure
+  - source and destination connector types, such as `postgres` or `bigquery`
+  - execution mode, such as batch, stream, or CDC stream
+  - non-identifying feature flags, such as full refresh, multi-table, masking, and schema inference
+  - coarse duration and CPU-capacity buckets
+  - coarse deployment and invocation categories, such as Kubernetes, container, CI, or interactive
 
-The information collected here is used to understand the usage of ingestr and to improve the product. We use [Rudderstack](https://www.rudderstack.com/) to collect the events and we don't store any PII. 
+The information collected here is used to understand the usage of ingestr and to improve the product. We use [Rudderstack](https://www.rudderstack.com/) to collect the events. The telemetry payload is designed not to contain PII.
 
-The specific events that are sent are:
-- command triggered
-- command finished
+ingestr sends one `command_finished` event after a command exits. Long-running server and streaming commands do not send periodic telemetry.
+
+Telemetry properties are selected from fixed values. ingestr does not send connection URIs, credentials, hostnames, IP addresses, table or column names, queries, raw errors, arbitrary environment-variable values, or company identifiers.
+
+Tools that embed ingestr can set `INGESTR_TELEMETRY_INVOKER` to identify themselves. Only the known values `bruin_cli`, `bruin_cloud`, and `ingestr_server` are reported; anything else is recorded as `other`, and an unset variable is recorded as `direct`.
 
 The questions we answer by these simple events are:
-- How many unique users are using ingestr?
+- How many unique installations are using ingestr?
 - How many times is ingestr being used?
+- Which execution environments and features are commonly used?
+- Which broad classes of commands fail?
 
 ## Disabling telemetry
 If you'd like to turn off the telemetry, simply set the `INGESTR_DISABLE_TELEMETRY` environment variable to `true`.

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -42,7 +42,7 @@ func TestTrackSendsRudderStackPayload(t *testing.T) {
 		},
 	}
 
-	err := client.Track(context.Background(), "command_triggered", map[string]any{"command": "ingest"}, "v1.2.3")
+	err := client.Track(context.Background(), "command_finished", map[string]any{"command": "ingest"}, "v1.2.3")
 	require.NoError(t, err)
 
 	require.True(t, hasAuth)
@@ -50,7 +50,7 @@ func TestTrackSendsRudderStackPayload(t *testing.T) {
 	require.Empty(t, authPassword)
 
 	require.Equal(t, "machine-123", got["userId"])
-	require.Equal(t, "command_triggered", got["event"])
+	require.Equal(t, "command_finished", got["event"])
 	require.Equal(t, "2026-05-25T17:08:00Z", got["timestamp"])
 
 	properties := got["properties"].(map[string]any)
@@ -81,7 +81,7 @@ func TestTrackHonorsDisableTelemetryEnv(t *testing.T) {
 		},
 	}
 
-	err := client.Track(context.Background(), "command_triggered", nil, "dev")
+	err := client.Track(context.Background(), "command_finished", nil, "dev")
 	require.NoError(t, err)
 	require.False(t, called)
 }
@@ -114,7 +114,7 @@ func TestTrackFallsBackWhenMachineIDFails(t *testing.T) {
 		},
 	}
 
-	err := client.Track(context.Background(), "command_triggered", nil, "dev")
+	err := client.Track(context.Background(), "command_finished", nil, "dev")
 	require.NoError(t, err)
 	require.NotEmpty(t, got["userId"])
 }


### PR DESCRIPTION
## What
Audits what the ingestr CLI reports. Drops the `command_triggered` event and the async goroutine that sent it, so a command now emits a single `command_finished` event on exit, and adds allowlisted properties so we can answer basic questions about how ingestr is deployed and used.

## Changes
- `cmd/telemetry.go` — removed `trackCommandTriggered` and the WaitGroup/goroutine path; added `deployment_type`, `invocation_style`, `invoker`, `cpu_bucket`, and `duration_bucket`. Every value is a fixed enum or a coarse bucket.
- `cmd/ingest.go` — added `execution_mode`, `schema_contract`, `requested_strategy`, and boolean feature flags; source/destination platforms now resolve through the connector registry so unknown schemes are dropped rather than reported.
- `cmd/delete.go`, `cmd/server.go` — updated for the new `trackCommandFinished` signature.
- `docs/getting-started/telemetry.md` — documents the new properties, the single-event model, and the hostname-derived machine-ID fallback.
- `cmd/telemetry_test.go`, `internal/telemetry/client_test.go` — tests covering the allowlists and buckets.

## How to test
1. `make format && make lint && make test`
2. `INGESTR_DISABLE_TELEMETRY=true ingestr ingest ...` still sends nothing.
3. Point the telemetry endpoint at a local server and confirm one `command_finished` event with no URIs, hostnames, table names, or raw errors in the payload.

## Risk & rollback
- **Risk:** low — telemetry only, no ingestion behavior changes. Exit latency is slightly better since there is one blocking send instead of two.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`) — not affected
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered — properties are drawn from fixed allowlists; connection URIs, credentials, hostnames, table/column names, raw errors, and arbitrary env values are never sent.

## Related issues