### PR TITLE
Change RudderStack base URI

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultDataPlaneURL = "https://getbruinbumlky.dataplane.rudderstack.com"
+	defaultDataPlaneURL = "https://events-rs.getbruin.com"
 	defaultTimeout      = 2 * time.Second
 )
 


### PR DESCRIPTION
## What

Update ingestr telemetry to use the new RudderStack events endpoint.

## Changes

- Changed the default data plane URL to `https://events-rs.getbruin.com`.

## How to test

1. Run `make format`, `make lint`, and `make test`.
2. Send a telemetry event and confirm `/v1/track` returns 2xx.

## Risk & rollback

- **Risk:** Low; this only changes the telemetry host.
- **Rollback:** Revert the merge commit.

## Checklist

- [ ] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues

None.
