### PR TITLE
Skip replace dedup for enforced source primary keys

### DIFF
--- a/.claude/skills/bigquery-destination/SKILL.md
+++ b/.claude/skills/bigquery-destination/SKILL.md
@@ -49,6 +49,11 @@ Two places dedup by primary key, both using `QUALIFY ROW_NUMBER()`:
 
 So the swap reads either the normalised staging (dedup already done) or the raw staging (no dedup needed).
 
+The guaranteed-unique fast path is source-declared. Connectors only declare
+auto-detected, database-enforced primary keys unique; user-supplied keys,
+custom-query keys, and informational constraints remain untrusted and continue
+through deduplication.
+
 ## 5. Swap: Staging -> Destination (replace strategy, `SwapTable`)
 
 Two swap mechanisms:

--- a/pkg/source/adbc/dialect.go
+++ b/pkg/source/adbc/dialect.go
@@ -44,7 +44,7 @@ type Dialect interface {
 	SchemaQuery() string
 
 	// PrimaryKeyQuery returns the SQL query for fetching primary key columns.
-	// The query should accept parameters based on the database's needs.
+	// The query should accept two parameters: schemaName, tableName.
 	// Returns empty string if PK detection is not supported.
 	PrimaryKeyQuery() string
 
@@ -115,7 +115,7 @@ type CatalogSQLDialect interface {
 	SchemaQueryForCatalog() string
 
 	// PrimaryKeyQueryForCatalog returns a PK query whose parameters are
-	// (catalog, tableName). Returns "" if PK detection is unsupported.
+	// (catalog, schemaName, tableName). Returns "" if PK detection is unsupported.
 	PrimaryKeyQueryForCatalog() string
 }
 
@@ -126,6 +126,12 @@ type SchemaProvider interface {
 	// GetSchema retrieves the schema for a table using native APIs.
 	// Returns the table schema with columns and primary keys.
 	GetSchema(ctx context.Context, table string) (*schema.TableSchema, error)
+}
+
+// PrimaryKeyEnforcementProvider identifies dialects whose detected primary-key
+// constraints enforce uniqueness.
+type PrimaryKeyEnforcementProvider interface {
+	EnforcesPrimaryKeys() bool
 }
 
 // StorageReader is an optional interface for dialects that support native

--- a/pkg/source/adbc/source.go
+++ b/pkg/source/adbc/source.go
@@ -116,11 +116,11 @@ func (s *ADBCSource) GetTable(ctx context.Context, req source.TableRequest) (sou
 		return nil, err
 	}
 
-	// Use user-provided PKs if available, otherwise use auto-detected
-	pks := req.PrimaryKeys
-	if len(pks) == 0 {
-		pks = tableSchema.PrimaryKeys
+	detectedPKsUnique := false
+	if provider, ok := s.dialect.(PrimaryKeyEnforcementProvider); ok {
+		detectedPKsUnique = provider.EnforcesPrimaryKeys()
 	}
+	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, tableSchema.PrimaryKeys, detectedPKsUnique)
 
 	// Use user's strategy or default to replace
 	strategy := req.Strategy
@@ -132,6 +132,7 @@ func (s *ADBCSource) GetTable(ctx context.Context, req source.TableRequest) (sou
 	return &source.DynamicSourceTable{
 		TableName:                        tableName,
 		TablePrimaryKeys:                 pks,
+		TablePrimaryKeysUnique:           pksUnique,
 		TableIncrementalKey:              req.IncrementalKey,
 		TableStrategy:                    strategy,
 		TableSupportsExtractPartitioning: true,
@@ -319,10 +320,10 @@ func (s *ADBCSource) fetchPrimaryKeys(ctx context.Context, catalog, schemaName, 
 		args = []any{tableName}
 	case catalog != "" && isCatalogSQL(s.dialect):
 		pkSQL = s.dialect.(CatalogSQLDialect).PrimaryKeyQueryForCatalog()
-		args = []any{catalog, tableName}
+		args = []any{catalog, schemaName, tableName}
 	default:
 		pkSQL = s.dialect.PrimaryKeyQuery()
-		args = []any{tableName}
+		args = []any{schemaName, tableName}
 	}
 	if pkSQL == "" {
 		return nil

--- a/pkg/source/duckdb/dialect.go
+++ b/pkg/source/duckdb/dialect.go
@@ -32,13 +32,12 @@ const (
 		FROM (
 			SELECT unnest(constraint_column_names) as col
 			FROM duckdb_constraints()
-			WHERE database_name = current_database() AND table_name = ? AND constraint_type = 'PRIMARY KEY'
+			WHERE database_name = current_database() AND schema_name = ? AND table_name = ? AND constraint_type = 'PRIMARY KEY'
 		)
 	`
 
 	// Catalog-qualified variants, used when a catalog (attached database) is
-	// present in the table name. Parameters: (catalog, schema, table) and
-	// (catalog, table) respectively.
+	// present in the table name. Both queries accept (catalog, schema, table).
 	schemaQueryForCatalogSQL = `
 		SELECT
 			column_name,
@@ -54,7 +53,7 @@ const (
 		FROM (
 			SELECT unnest(constraint_column_names) as col
 			FROM duckdb_constraints()
-			WHERE database_name = ? AND table_name = ? AND constraint_type = 'PRIMARY KEY'
+			WHERE database_name = ? AND schema_name = ? AND table_name = ? AND constraint_type = 'PRIMARY KEY'
 		)
 	`
 )
@@ -219,6 +218,10 @@ func (d *Dialect) SchemaQuery() string {
 
 func (d *Dialect) PrimaryKeyQuery() string {
 	return primaryKeyQuerySQL
+}
+
+func (d *Dialect) EnforcesPrimaryKeys() bool {
+	return true
 }
 
 func (d *Dialect) SchemaQueryForCatalog() string {

--- a/pkg/source/duckdb/dialect_test.go
+++ b/pkg/source/duckdb/dialect_test.go
@@ -2,7 +2,16 @@ package duckdb
 
 import (
 	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/source/adbc"
 )
+
+func TestDialectEnforcesPrimaryKeys(t *testing.T) {
+	var provider adbc.PrimaryKeyEnforcementProvider = NewDialect()
+	if !provider.EnforcesPrimaryKeys() {
+		t.Fatal("DuckDB primary keys should be enforced")
+	}
+}
 
 func TestParseDBPath_MotherDuck(t *testing.T) {
 	tests := []struct {

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -96,14 +96,13 @@ func (s *MongoDBSource) GetTable(ctx context.Context, req source.TableRequest) (
 		strategy = config.StrategyReplace
 	}
 
-	pks := req.PrimaryKeys
-	if len(pks) == 0 {
-		pks = []string{"_id"}
-	}
+	_, _, pipeline, parseErr := s.parseTableSpec(tableName)
+	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, []string{"_id"}, parseErr == nil && pipeline == nil)
 
 	return &source.DynamicSourceTable{
 		TableName:                        tableName,
 		TablePrimaryKeys:                 pks,
+		TablePrimaryKeysUnique:           pksUnique,
 		TableIncrementalKey:              req.IncrementalKey,
 		TableStrategy:                    strategy,
 		TableSupportsExtractPartitioning: true,

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -32,9 +32,10 @@ import (
 const defaultBatchSize = 10000
 
 type MongoDBSource struct {
-	client   *mongo.Client
-	database string
-	uri      string
+	client                       *mongo.Client
+	database                     string
+	uri                          string
+	collectionPrimaryKeyUniqueFn func(context.Context, string, string) (bool, error)
 }
 
 func NewMongoDBSource() *MongoDBSource {
@@ -96,8 +97,17 @@ func (s *MongoDBSource) GetTable(ctx context.Context, req source.TableRequest) (
 		strategy = config.StrategyReplace
 	}
 
-	_, _, pipeline, parseErr := s.parseTableSpec(tableName)
-	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, []string{"_id"}, parseErr == nil && pipeline == nil)
+	detectedPKUnique := false
+	db, collection, pipeline, parseErr := s.parseTableSpec(tableName)
+	if len(req.PrimaryKeys) == 0 && parseErr == nil && pipeline == nil {
+		unique, err := s.collectionPrimaryKeyUnique(ctx, db, collection)
+		if err != nil {
+			config.Debug("[MONGODB] Failed to inspect collection type: %v", err)
+		} else {
+			detectedPKUnique = unique
+		}
+	}
+	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, []string{"_id"}, detectedPKUnique)
 
 	return &source.DynamicSourceTable{
 		TableName:                        tableName,
@@ -114,6 +124,24 @@ func (s *MongoDBSource) GetTable(ctx context.Context, req source.TableRequest) (
 			return s.read(ctx, tableName, opts)
 		},
 	}, nil
+}
+
+func (s *MongoDBSource) collectionPrimaryKeyUnique(ctx context.Context, database, collection string) (bool, error) {
+	if s.collectionPrimaryKeyUniqueFn != nil {
+		return s.collectionPrimaryKeyUniqueFn(ctx, database, collection)
+	}
+	if s.client == nil {
+		return false, nil
+	}
+
+	collections, err := s.client.Database(database).ListCollectionNames(ctx, bson.D{
+		{Key: "name", Value: collection},
+		{Key: "type", Value: "collection"},
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(collections) == 1, nil
 }
 
 // parseTableSpec parses the table string into database, collection, and optional custom query.

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -22,6 +22,48 @@ import (
 
 var benchmarkJSONString string
 
+func TestGetTablePrimaryKeyUniqueness(t *testing.T) {
+	tests := []struct {
+		name       string
+		table      string
+		primaryKey []string
+		wantUnique bool
+	}{
+		{
+			name:       "normal collection",
+			table:      "bench.events",
+			wantUnique: true,
+		},
+		{
+			name:       "aggregation pipeline",
+			table:      `bench.events:[{"$unwind":"$items"}]`,
+			wantUnique: false,
+		},
+		{
+			name:       "user-provided key",
+			table:      "bench.events",
+			primaryKey: []string{"external_id"},
+			wantUnique: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table, err := (&MongoDBSource{}).GetTable(t.Context(), source.TableRequest{
+				Name:        tt.table,
+				PrimaryKeys: tt.primaryKey,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := table.(source.PrimaryKeyUniquenessProvider).PrimaryKeysUnique()
+			if got != tt.wantUnique {
+				t.Fatalf("PrimaryKeysUnique() = %v, want %v", got, tt.wantUnique)
+			}
+		})
+	}
+}
+
 func TestParseTableSpec(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -24,32 +24,46 @@ var benchmarkJSONString string
 
 func TestGetTablePrimaryKeyUniqueness(t *testing.T) {
 	tests := []struct {
-		name       string
-		table      string
-		primaryKey []string
-		wantUnique bool
+		name             string
+		table            string
+		primaryKey       []string
+		collectionUnique bool
+		wantUnique       bool
 	}{
 		{
-			name:       "normal collection",
-			table:      "bench.events",
-			wantUnique: true,
+			name:             "normal collection",
+			table:            "bench.events",
+			collectionUnique: true,
+			wantUnique:       true,
 		},
 		{
-			name:       "aggregation pipeline",
-			table:      `bench.events:[{"$unwind":"$items"}]`,
+			name:       "view",
+			table:      "bench.events_view",
 			wantUnique: false,
 		},
 		{
-			name:       "user-provided key",
-			table:      "bench.events",
-			primaryKey: []string{"external_id"},
-			wantUnique: false,
+			name:             "aggregation pipeline",
+			table:            `bench.events:[{"$unwind":"$items"}]`,
+			collectionUnique: true,
+			wantUnique:       false,
+		},
+		{
+			name:             "user-provided key",
+			table:            "bench.events",
+			primaryKey:       []string{"external_id"},
+			collectionUnique: true,
+			wantUnique:       false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			table, err := (&MongoDBSource{}).GetTable(t.Context(), source.TableRequest{
+			mongoSource := &MongoDBSource{
+				collectionPrimaryKeyUniqueFn: func(context.Context, string, string) (bool, error) {
+					return tt.collectionUnique, nil
+				},
+			}
+			table, err := mongoSource.GetTable(t.Context(), source.TableRequest{
 				Name:        tt.table,
 				PrimaryKeys: tt.primaryKey,
 			})

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -257,11 +257,7 @@ func (s *MSSQLSource) GetTable(ctx context.Context, req source.TableRequest) (so
 		return nil, err
 	}
 
-	// Use user-provided PKs if available, otherwise use auto-detected
-	pks := req.PrimaryKeys
-	if len(pks) == 0 {
-		pks = tableSchema.PrimaryKeys
-	}
+	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, tableSchema.PrimaryKeys, true)
 
 	// Use user's strategy or default to replace
 	strategy := req.Strategy
@@ -273,6 +269,7 @@ func (s *MSSQLSource) GetTable(ctx context.Context, req source.TableRequest) (so
 	return &source.DynamicSourceTable{
 		TableName:                        tableName,
 		TablePrimaryKeys:                 pks,
+		TablePrimaryKeysUnique:           pksUnique,
 		TableIncrementalKey:              req.IncrementalKey,
 		TableStrategy:                    strategy,
 		TableSupportsExtractPartitioning: true,

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -1,15 +1,50 @@
 package mssql
 
 import (
+	"database/sql"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	mssqldb "github.com/microsoft/go-mssqldb"
 )
+
+func TestGetTableMarksDetectedPrimaryKeysUnique(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`(?s)FROM INFORMATION_SCHEMA\.COLUMNS`).
+		WithArgs("dbo", "events").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"COLUMN_NAME",
+			"DATA_TYPE",
+			"IS_NULLABLE",
+			"NUMERIC_PRECISION",
+			"NUMERIC_SCALE",
+			"CHARACTER_MAXIMUM_LENGTH",
+		}).AddRow("id", "int", "NO", sql.NullInt64{Int64: 10, Valid: true}, sql.NullInt64{}, sql.NullInt64{}))
+	mock.ExpectQuery(`(?s)FROM INFORMATION_SCHEMA\.TABLE_CONSTRAINTS`).
+		WithArgs("dbo", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME"}).AddRow("id"))
+
+	table, err := (&MSSQLSource{db: db}).GetTable(t.Context(), source.TableRequest{Name: "dbo.events"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !table.(source.PrimaryKeyUniquenessProvider).PrimaryKeysUnique() {
+		t.Fatal("auto-detected SQL Server primary key should be unique")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestURIToConnString(t *testing.T) {
 	tests := []struct {

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -212,11 +212,7 @@ func (s *MySQLSource) GetTable(ctx context.Context, req source.TableRequest) (so
 		return nil, err
 	}
 
-	// Use user-provided PKs if available, otherwise use auto-detected
-	pks := req.PrimaryKeys
-	if len(pks) == 0 {
-		pks = tableSchema.PrimaryKeys
-	}
+	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, tableSchema.PrimaryKeys, true)
 
 	// Use user's strategy or default to replace
 	strategy := req.Strategy
@@ -228,6 +224,7 @@ func (s *MySQLSource) GetTable(ctx context.Context, req source.TableRequest) (so
 	return &source.DynamicSourceTable{
 		TableName:                        tableName,
 		TablePrimaryKeys:                 pks,
+		TablePrimaryKeysUnique:           pksUnique,
 		TableIncrementalKey:              req.IncrementalKey,
 		TableStrategy:                    strategy,
 		TableSupportsExtractPartitioning: true,

--- a/pkg/source/mysql/mysql_test.go
+++ b/pkg/source/mysql/mysql_test.go
@@ -64,6 +64,39 @@ func TestReplaceGCRestoreReleasesPreviousLease(t *testing.T) {
 	}
 }
 
+func TestGetTableMarksDetectedPrimaryKeysUnique(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`(?s)FROM INFORMATION_SCHEMA\.COLUMNS`).
+		WithArgs("bench", "events").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"COLUMN_NAME",
+			"COLUMN_TYPE",
+			"IS_NULLABLE",
+			"NUMERIC_PRECISION",
+			"NUMERIC_SCALE",
+			"CHARACTER_MAXIMUM_LENGTH",
+		}).AddRow("id", "int", "NO", 10, 0, nil))
+	mock.ExpectQuery(`(?s)FROM INFORMATION_SCHEMA\.KEY_COLUMN_USAGE`).
+		WithArgs("bench", "events").
+		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME"}).AddRow("id"))
+
+	table, err := (&MySQLSource{db: db, database: "bench"}).GetTable(t.Context(), source.TableRequest{Name: "events"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !table.(source.PrimaryKeyUniquenessProvider).PrimaryKeysUnique() {
+		t.Fatal("auto-detected MySQL primary key should be unique")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestIsVitessServer(t *testing.T) {
 	cases := []struct {
 		version string

--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -92,12 +92,7 @@ func (s *PostgresSource) GetTable(ctx context.Context, req source.TableRequest) 
 		return nil, fmt.Errorf("failed to get schema: %w", err)
 	}
 
-	// Auto-detect primary keys from database if user didn't provide
-	pks := req.PrimaryKeys
-	if len(pks) == 0 {
-		pks = tableSchema.PrimaryKeys
-	}
-	pksUnique := len(req.PrimaryKeys) == 0 && len(tableSchema.PrimaryKeys) > 0
+	pks, pksUnique := source.ResolvePrimaryKeys(req.PrimaryKeys, tableSchema.PrimaryKeys, true)
 
 	// Use user's strategy or default to replace
 	strategy := req.Strategy

--- a/pkg/source/sqltable.go
+++ b/pkg/source/sqltable.go
@@ -82,6 +82,15 @@ var (
 	_ ReadSchemaProvider = (*DynamicSourceTable)(nil)
 )
 
+// ResolvePrimaryKeys prefers user-provided keys over detected keys. Detected
+// keys are unique only when the source confirms that the database enforces them.
+func ResolvePrimaryKeys(requested, detected []string, detectedUnique bool) ([]string, bool) {
+	if len(requested) > 0 {
+		return requested, false
+	}
+	return detected, detectedUnique && len(detected) > 0
+}
+
 // IsCustomQuery checks if a table name has the "query:" prefix indicating a custom SQL query.
 func IsCustomQuery(tableName string) (string, bool) {
 	query, ok := strings.CutPrefix(tableName, "query:")

--- a/pkg/source/sqltable_test.go
+++ b/pkg/source/sqltable_test.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,54 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
+
+func TestResolvePrimaryKeys(t *testing.T) {
+	tests := []struct {
+		name           string
+		requested      []string
+		detected       []string
+		detectedUnique bool
+		want           []string
+		wantUnique     bool
+	}{
+		{
+			name:           "enforced detected keys are unique",
+			detected:       []string{"tenant_id", "id"},
+			detectedUnique: true,
+			want:           []string{"tenant_id", "id"},
+			wantUnique:     true,
+		},
+		{
+			name:           "informational detected keys are not unique",
+			detected:       []string{"id"},
+			detectedUnique: false,
+			want:           []string{"id"},
+		},
+		{
+			name:           "user keys are never assumed unique",
+			requested:      []string{"external_id"},
+			detected:       []string{"id"},
+			detectedUnique: true,
+			want:           []string{"external_id"},
+		},
+		{
+			name:           "empty detected keys are not unique",
+			detectedUnique: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotUnique := ResolvePrimaryKeys(tt.requested, tt.detected, tt.detectedUnique)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("ResolvePrimaryKeys() keys = %v, want %v", got, tt.want)
+			}
+			if gotUnique != tt.wantUnique {
+				t.Fatalf("ResolvePrimaryKeys() unique = %v, want %v", gotUnique, tt.wantUnique)
+			}
+		})
+	}
+}
 
 func TestIsCustomQuery(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What
Skip replace deduplication when an auto-detected source primary key is database-enforced.

## Changes
- Mark enforced PKs unique for MySQL, SQL Server, PostgreSQL, DuckDB, and normal MongoDB collections.
- Keep user-provided keys, custom queries, aggregation pipelines, and informational constraints on the dedup path.
- Make DuckDB PK metadata schema-qualified and add source-level regression tests.

## How to test
1. Run `make format`.
2. Run `make lint`.
3. Run `make test`.
4. Benchmark MySQL to SQL Server with 1M rows; Gong averaged 4.366s versus Sling at 437.67s.

## Risk & rollback
- **Risk:** Medium; correctness depends on only trusted source metadata enabling the fast path.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.
