### PR TITLE
fix(bigquery): cap query-job start retries so a persistent rate limit fails fast

### DIFF
--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bruin-data/ingestr/internal/annotation"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -36,6 +37,10 @@ const (
 	exactRowCountPollInterval          = 1 * time.Second
 	queryJobMaxAttempts                = 4
 	deleteInsertTransactionMaxAttempts = 8
+	// queryJobStartMaxAttempts caps retries of the job-submission call so a
+	// persistently retryable error (e.g. a sustained rateLimitExceeded from too
+	// many DDL ops) fails cleanly instead of retrying the start forever.
+	queryJobStartMaxAttempts = 5
 )
 
 type bigQueryLoadMethod string
@@ -1736,7 +1741,11 @@ func (d *BigQueryDestination) startQueryJobWithRetry(ctx context.Context, sql st
 			_ = d.resolveCDCJob(context.Background(), jobID)
 			return nil, err
 		}
-		config.Debug("[%s] Retrying ambiguous start with stable job ID %s: %v", opLabel, jobID, err)
+		if attempt >= queryJobStartMaxAttempts {
+			_ = d.resolveCDCJob(context.Background(), jobID)
+			return nil, fmt.Errorf("failed to start %s query job %s after %d attempts: %w", opLabel, jobID, attempt, err)
+		}
+		output.Warnf("[%s] job %s start failed (attempt %d/%d): %v; retrying\n", opLabel, jobID, attempt, queryJobStartMaxAttempts, err)
 		if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(min(attempt, queryJobMaxAttempts), err)); sleepErr != nil {
 			return d.reconcileAmbiguousBigQueryJob(ctx, jobID)
 		}

--- a/pkg/destination/bigquery/bigquery.go
+++ b/pkg/destination/bigquery/bigquery.go
@@ -1742,8 +1742,15 @@ func (d *BigQueryDestination) startQueryJobWithRetry(ctx context.Context, sql st
 			return nil, err
 		}
 		if attempt >= queryJobStartMaxAttempts {
-			_ = d.resolveCDCJob(context.Background(), jobID)
-			return nil, fmt.Errorf("failed to start %s query job %s after %d attempts: %w", opLabel, jobID, attempt, err)
+			// The job may have been accepted under its stable ID despite the
+			// retryable error, so reconcile (cancel/confirm) rather than abandon it
+			// with its fence cleared. reconcile resolves the fence in every path; a
+			// (nil, nil) result means the job never landed, so surface a clear error.
+			job, recErr := d.reconcileAmbiguousBigQueryJob(ctx, jobID)
+			if job == nil && recErr == nil {
+				return nil, fmt.Errorf("failed to start %s query job %s after %d attempts: %w", opLabel, jobID, attempt, err)
+			}
+			return job, recErr
 		}
 		output.Warnf("[%s] job %s start failed (attempt %d/%d): %v; retrying\n", opLabel, jobID, attempt, queryJobStartMaxAttempts, err)
 		if sleepErr := sleepWithContextForLoadJob(ctx, retryDelayForQueryJob(min(attempt, queryJobMaxAttempts), err)); sleepErr != nil {


### PR DESCRIPTION
## Problem
`startQueryJobWithRetry` retried the BigQuery job-submission call (`query.Run`) in an **unbounded loop** on any retryable error. When the error was persistent — e.g. a sustained `rateLimitExceeded` from issuing more than the allowed DDL/metadata operations in a short window (>8 `ALTER COLUMN` in ~10s) — the loop spun **forever**:
- it never succeeded (submission kept getting rate-limited),
- it never failed (`rateLimitExceeded` is classified retryable, so `!retry` never triggered),
- it only logged at `config.Debug`, so with `--debug` off it looked like a **silent hang** with no feedback.

## Fix
- Cap the job-start retries at `queryJobStartMaxAttempts` (5). On exhaustion, return a clear error (`failed to start <op> query job <id> after N attempts: …`) while still resolving the CDC job fence, so a persistently retryable condition **fails cleanly** instead of looping forever.
- Surface each retry via `output.Warnf` instead of `config.Debug`, so the retrying is **visible** (no more silent hang).

Scope is limited to BigQuery's job-submission loop; no other destination has this pattern (they run queries synchronously via `ExecContext`). The backoff-delay computation (`min(attempt, queryJobMaxAttempts)`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)