### PR TITLE
databuffer: disable IPC read body-size cap for trusted buffer files

### DIFF
--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -167,7 +167,7 @@ func (b *FileBuffer) readAndCastBatch(path string, targetSchema *arrow.Schema) (
 	}
 	defer func() { _ = file.Close() }()
 
-	reader, err := ipc.NewFileReader(file, ipc.WithAllocator(memory.DefaultAllocator))
+	reader, err := ipc.NewFileReader(file, ipc.WithAllocator(memory.DefaultAllocator), ipc.WithBodySizeLimit(0))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create arrow reader: %w", err)
 	}


### PR DESCRIPTION
## Problem

`replace`/large ingestions buffer source batches to disk as Arrow IPC files (`pkg/databuffer`) and replay them into the staging table. A Fluxx `client_store` run failed on replay:

```
arrow/ipc: file block body length 463358608 exceeds limit 268435456
```

arrow-go's IPC `FileReader` rejects any single record batch whose body exceeds **256 MiB**. The fat-row `client_store` batch was ~442 MiB, so the reader refused a file **ingestr itself wrote seconds earlier**.

## Root cause

The 256 MiB cap is a **new default** introduced by arrow-go 18.7.0. The dep was bumped from 18.5.1 → 18.7.0 transitively in `863194ea` (the iceberg-go pin), silently turning "read any batch" into "reject batches > 256 MiB". At `v1` (arrow-go 18.5.1) this cap did not exist and the pipeline worked.