### PR TITLE
mysql: support cdc streaming

### DIFF
--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -33,7 +33,7 @@ ingestr ingest \
 - `--mask <column_name>:<algorithm>[:param]`: Applies data masking to specified columns. Can be used multiple times for different columns. See the [Data Masking](../getting-started/data-masking.md) documentation for available algorithms and usage examples. Defaults to `None`.
 - `--trim-whitespace`: Trims leading and trailing whitespace from all string column values before writing to the destination. This applies to regular batch ingestions and CDC ingestions, preserves nulls and column types, and leaves non-string columns unchanged. Defaults to `false`. Can also be set with `TRIM_WHITESPACE=true` or `INGESTR_TRIM_WHITESPACE=true`.
 - `--schema-naming` Specifies what naming convention to use for table and column names on the destination. Can be `default` or `direct`.default is snake_case. `direct is case sensitive and doesn't contract underscores.
-- `--stream`: Runs continuous (streaming) ingestion instead of a one-shot load. Supported by CDC sources (`postgres+cdc`, `mssql+cdc`) and message brokers (`kafka`, `amqp`). The process runs until interrupted (SIGINT/SIGTERM), flushing buffered records to the destination on an interval or record-count trigger. See [Streaming ingestion](#streaming-ingestion) below.
+- `--stream`: Runs continuous (streaming) ingestion instead of a one-shot load. Supported by CDC sources (`postgres+cdc`, `mysql+cdc`, `mariadb+cdc`, `mssql+cdc`, `mongodb+cdc`) and message brokers. The process runs until interrupted (SIGINT/SIGTERM), flushing buffered records to the destination on an interval or record-count trigger. See [Streaming ingestion](#streaming-ingestion) below.
 - `--flush-interval`: In streaming mode, flush buffered records to the destination at least this often. Defaults to `30s`. Only valid with `--stream`.
 - `--flush-records`: In streaming mode, flush when this many records have been buffered. Defaults to `50000`. Only valid with `--stream`.
 - `--metrics-addr`: In streaming mode, serve replication lag and throughput metrics over HTTP on this address (e.g. `127.0.0.1:6060`). Disabled unless set. Only valid with `--stream`. See [Monitoring a stream](#monitoring-a-stream) below.
@@ -54,7 +54,7 @@ The `interval-start` and `interval-end` options support various datetime formats
 
 The `--stream` flag turns `ingest` into a long-running process that continuously pulls changes from the source and flushes them to the destination, rather than running once and exiting. It is supported by:
 
-- **CDC sources** (`postgres+cdc`, `mssql+cdc`): captures every insert, update, and delete across all tables in the publication/capture set and applies them with the `merge` strategy.
+- **CDC sources** (`postgres+cdc`, `mysql+cdc`, `mariadb+cdc`, `mssql+cdc`, `mongodb+cdc`): captures every insert, update, and delete across all selected tables and applies them with the `merge` strategy.
 - **Message brokers** (`kafka`, `amqp`): consumes messages into a fixed envelope schema — a `msg_id` primary key, a JSON `data` column holding the decoded body and metadata, and an `_ingestr_order` column (source offset / delivery tag) — and applies them with `merge` keyed on `msg_id`, keeping the latest record per key within each flush window. Schema inference is skipped (a never-ending stream has no end to infer from).
 
 A flush happens whenever **either** `--flush-interval` (default 30s) **or** `--flush-records` (default 50000) is reached, whichever comes first. `--flush-records` is the memory bound: records are buffered until a flush.

--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -50,7 +50,7 @@ On every run after the first, a CDC connector resumes from the last durable posi
 
 ### One-shot vs. streaming
 
-By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs, and the way to run MySQL CDC. Continuous streaming is available for `postgres+cdc`, `mssql+cdc`, and `mongodb+cdc`: pass the `--stream` CLI flag and ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery — for keyed tables the `merge` strategy makes replays harmless, though keyless append-only change logs can end up with duplicate events after a recovery. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
+By default a CDC run catches up to the current log position and exits — ideal for scheduled, batch-style syncs. Continuous streaming is available for `postgres+cdc`, `mysql+cdc`, `mariadb+cdc`, `mssql+cdc`, and `mongodb+cdc`: pass the `--stream` CLI flag and ingestr stays up as a long-running process, flushing buffered changes to the destination on an interval or record-count trigger, until it is interrupted. Streaming gives at-least-once delivery — for keyed tables the `merge` strategy makes replays harmless, though keyless append-only change logs can end up with duplicate events after a recovery. See [Streaming ingestion](/commands/ingest.md#streaming-ingestion) and [Monitoring a stream](/commands/ingest.md#monitoring-a-stream) for flags (`--flush-interval`, `--flush-records`, `--metrics-addr`) and lag metrics.
 
 ### PostgreSQL schema changes while streaming
 
@@ -97,7 +97,7 @@ Each platform has requirements and knobs specific to its change mechanism — fo
 ### Platform notes at a glance
 
 - **PostgreSQL** reads logical replication from a publication and slot. It can manage its own `ingestr_publication` or use one you supply, and tracks progress in shared destination state tables rather than the maximum `_cdc_lsn` in a user table. A running stream absorbs column-level schema changes without restarting; picking up a newly added table takes a restart, since the stream exits and lets its supervisor bring it back up. `TRUNCATE` — or dropping and recreating a source table — is captured as a table replacement.
-- **MySQL / MariaDB** stream the binary log after a consistent snapshot, resuming from the destination's maximum `_cdc_lsn`. Pin a unique `server_id` for scheduled or overlapping runs.
+- **MySQL / MariaDB** stream the binary log after a consistent snapshot, resuming from durable CDC state recorded in the destination. Pin a unique `server_id` for scheduled or overlapping runs.
 - **SQL Server** offers two paths: lightweight **Change Tracking** (net changes since the last version, primary key required) and **log-based CDC** (full row-level change history). Both resume from `_cdc_lsn`.
 - **MongoDB** tails change streams from a replica set / Atlas cluster. Being schema-less, it uses schema inference, so the destination schema is derived from sampled documents.
 - **Vitess** streams through vtgate's VStream API because a sharded cluster has no single binlog to tail; the position is a VGTID covering every shard, so it works for sharded and unsharded keyspaces alike.

--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -40,9 +40,9 @@ Vitess and PlanetScale speak the MySQL wire protocol but are selected with their
 Pointing a `mysql://` URI at a Vitess or PlanetScale server fails fast with a message telling you to switch to the dedicated scheme.
 
 ## Change data capture
-CDC uses the `mysql+cdc://`, `mysql+pymysql+cdc://`, and `mariadb+cdc://` URI schemes for standard MySQL and MariaDB, which stream the binary log. It produces the `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at` metadata columns and resumes from the destination table's maximum `_cdc_lsn` on subsequent runs. (Vitess and PlanetScale have their own CDC schemes — see [Vitess](/supported-sources/vitess.md) and [PlanetScale](/supported-sources/planetscale.md).)
+CDC uses the `mysql+cdc://`, `mysql+pymysql+cdc://`, and `mariadb+cdc://` URI schemes for standard MySQL and MariaDB, which stream the binary log. It produces the `_cdc_lsn`, `_cdc_deleted`, and `_cdc_synced_at` metadata columns and records durable CDC state in the destination for subsequent resumes. (Vitess and PlanetScale have their own CDC schemes — see [Vitess](/supported-sources/vitess.md) and [PlanetScale](/supported-sources/planetscale.md).)
 
-This path reads a consistent snapshot first, then streams the binary log, resuming from the destination table's maximum `_cdc_lsn` on subsequent runs. MySQL CDC runs in batch mode only: each invocation catches up and exits, so re-run it (for example on a schedule) to keep the destination up to date. The continuous `--stream` mode is not supported for MySQL.
+This path reads a consistent snapshot first, then streams the binary log, resuming from the last durable destination CDC state on subsequent runs. By default each invocation catches up and exits, so re-run it (for example on a schedule) to keep the destination up to date. Add `--stream` to keep the binary log reader running continuously and flush buffered changes by interval or record count.
 
 If the saved `_cdc_lsn` is invalid or no longer available in MySQL binary logs, the run fails instead of taking a partial snapshot. Run with `--full-refresh` to rebuild the destination from a fresh snapshot.
 
@@ -68,7 +68,7 @@ Requirements:
 - The source user needs normal read access, permission to run `FLUSH TABLES WITH READ LOCK` for the initial snapshot, and replication privileges required to stream binary logs.
 
 CDC URI parameters:
-- `mode`: `batch`; defaults to `batch`.
+- `mode`: **deprecated and ignored.** Continuous ingestion is controlled by `--stream`. `mode=batch` is accepted as a no-op; `mode=stream` is rejected unless `--stream` is also passed.
 - `server_id`: optional positive uint32 replication server id; generated automatically when omitted. Pin a unique value for scheduled or overlapping CDC runs.
 - `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
 - `flavor`: `mysql` or `mariadb`; inferred from the URI scheme unless overridden.

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -118,7 +118,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	if p.config.Stream {
 		ss, ok := src.(source.StreamingSource)
 		if !ok || !ss.SupportsStreaming() {
-			return fmt.Errorf("--stream is not supported by this source; streaming requires a CDC source (postgres+cdc, mssql+cdc) or a message broker source (kafka, amqp, mqtt, sqs, pubsub, kinesis)")
+			return fmt.Errorf("--stream is not supported by this source; streaming requires a CDC source (postgres+cdc, mysql+cdc/mariadb+cdc, mssql+cdc, mongodb+cdc) or a message broker source")
 		}
 		if lr, ok := src.(source.LagReporter); ok {
 			metrics.SetLagReporter(lr)

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -1512,9 +1512,6 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 			// terminal event alone is benign.
 			return nil
 		}
-		pendingXAChanges -= pending.count
-		pendingXABytes -= pending.bytes
-		delete(pendingXA, xaID)
 		if activeXA == xaID {
 			activeXA = ""
 		}
@@ -1532,6 +1529,9 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 				}
 			}
 		}
+		pendingXAChanges -= pending.count
+		pendingXABytes -= pending.bytes
+		delete(pendingXA, xaID)
 		return nil
 	}
 	lastDelivery := time.Now()

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -54,7 +54,9 @@ const (
 	// receiving any event. Heartbeats arrive every defaultMySQLCDCHeartbeat on a
 	// healthy connection, so a stall this long means the connection is broken
 	// (the syncer reconnects silently and indefinitely by default).
-	mysqlCDCStreamStallTimeout = 60 * time.Second
+	mysqlCDCStreamStallTimeout     = 60 * time.Second
+	mysqlCDCStreamDrainTimeout     = 15 * time.Second
+	mysqlCDCStateTokenQueryTimeout = 5 * time.Second
 )
 
 var mysqlCDCColumns = []schema.Column{
@@ -127,9 +129,10 @@ type MySQLCDCTable struct {
 var _ source.CDCStateProvider = (*MySQLCDCSource)(nil)
 
 type mysqlCDCChange struct {
-	values  []interface{}
-	lsn     string
-	deleted bool
+	values     []interface{}
+	lsn        string
+	checkpoint gomysql.Position
+	deleted    bool
 }
 
 type mysqlCDCChangeBuffer struct {
@@ -137,6 +140,8 @@ type mysqlCDCChangeBuffer struct {
 	tableName   string
 	changes     []mysqlCDCChange
 }
+
+type mysqlCDCCommitTokenFunc func(lastLSN string) (any, error)
 
 type mysqlCDCXAChanges struct {
 	byTable map[string]*mysqlCDCXATableChanges
@@ -364,8 +369,77 @@ func (s *MySQLCDCSource) CDCState() source.CDCStateCommitToken {
 	}
 }
 
+func (s *MySQLCDCSource) snapshotCommitToken(table string, checkpoint mysqlCDCCheckpoint) source.CDCStateCommitToken {
+	position := formatStoredMySQLCheckpoint(checkpoint)
+	return source.CDCStateCommitToken{
+		SnapshotPositions: map[string]string{table: position},
+	}
+}
+
+func (s *MySQLCDCSource) checkpointCommitToken(ctx context.Context, position string, checkpointPosition gomysql.Position) (source.CDCStateCommitToken, error) {
+	if checkpointPosition.Name == "" {
+		return source.CDCStateCommitToken{}, nil
+	}
+	checkpointCtx, cancel := source.WithoutCancelWithConnectorLease(ctx)
+	defer cancel()
+	checkpointCtx, cancel = context.WithTimeout(checkpointCtx, mysqlCDCStateTokenQueryTimeout)
+	defer cancel()
+	checkpoint, err := s.checkpointForPosition(checkpointCtx, s.db, checkpointPosition)
+	if err != nil {
+		return source.CDCStateCommitToken{}, err
+	}
+	if position == "" {
+		position = formatStoredMySQLPosition(checkpoint.Position, 0)
+	}
+	return source.CDCStateCommitToken{
+		Position: formatStoredMySQLCheckpointAt(position, checkpoint),
+	}, nil
+}
+
+func emitMySQLCDCCommitToken(ctx context.Context, results chan<- source.RecordBatchResult, token source.CDCStateCommitToken) error {
+	if token.Position == "" && len(token.SnapshotPositions) == 0 {
+		return nil
+	}
+	return emitMySQLCDCResult(ctx, results, source.RecordBatchResult{CommitToken: token})
+}
+
+func emitMySQLCDCResult(ctx context.Context, results chan<- source.RecordBatchResult, result source.RecordBatchResult) error {
+	if err := ctx.Err(); err != nil {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		return err
+	}
+	select {
+	case results <- result:
+		return nil
+	case <-ctx.Done():
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		return ctx.Err()
+	}
+}
+
+func detachedMySQLCDCStreamDrainContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	drainCtx, stopGuard := source.WithoutCancelWithConnectorLease(ctx)
+	drainCtx, cancel := context.WithTimeout(drainCtx, mysqlCDCStreamDrainTimeout)
+	return drainCtx, func() {
+		cancel()
+		stopGuard()
+	}
+}
+
 func (s *MySQLCDCSource) HandlesIncrementality() bool {
 	return true
+}
+
+func (s *MySQLCDCSource) SupportsStreaming() bool {
+	return true
+}
+
+func (s *MySQLCDCSource) DefaultStreamingStrategy() config.IncrementalStrategy {
+	return config.StrategyMerge
 }
 
 func (s *MySQLCDCSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
@@ -609,10 +683,20 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 			}
 			startByTable[table.Name] = snapshotCheckpoint.Position
 			s.recordMySQLCDCSnapshot(table.Name, snapshotCheckpoint)
+			if opts.Streaming {
+				if err := emitMySQLCDCCommitToken(ctx, results, s.snapshotCommitToken(table.Name, snapshotCheckpoint)); err != nil {
+					_ = emitMySQLCDCResult(ctx, results, source.RecordBatchResult{Err: err})
+					return
+				}
+			}
 		}
 
 		if err := s.streamTables(ctx, selected, metaByTable, startByTable, opts.ReadOptions, results, true); err != nil {
-			results <- source.RecordBatchResult{Err: err}
+			if opts.Streaming {
+				_ = emitMySQLCDCResult(ctx, results, source.RecordBatchResult{Err: err})
+			} else {
+				results <- source.RecordBatchResult{Err: err}
+			}
 		}
 	}()
 
@@ -994,7 +1078,11 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 					PrimaryKeys: outputSchema.PrimaryKeys,
 				}
 				if err := t.source.streamTables(ctx, []source.SourceTableInfo{tableInfo}, metaByTable, startByTable, opts, results, false); err != nil {
-					results <- source.RecordBatchResult{Err: err}
+					if opts.Streaming {
+						_ = emitMySQLCDCResult(ctx, results, source.RecordBatchResult{Err: err})
+					} else {
+						results <- source.RecordBatchResult{Err: err}
+					}
 				}
 				return
 			}
@@ -1011,6 +1099,12 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 			return
 		}
 		t.source.recordMySQLCDCSnapshot(t.tableName, snapshotCheckpoint)
+		if opts.Streaming {
+			if err := emitMySQLCDCCommitToken(ctx, results, t.source.snapshotCommitToken(t.tableName, snapshotCheckpoint)); err != nil {
+				_ = emitMySQLCDCResult(ctx, results, source.RecordBatchResult{Err: err})
+				return
+			}
+		}
 
 		internalName := t.metadata.Name
 		startByTable := map[string]gomysql.Position{internalName: snapshotCheckpoint.Position}
@@ -1021,7 +1115,11 @@ func (t *MySQLCDCTable) Read(ctx context.Context, opts source.ReadOptions) (<-ch
 			PrimaryKeys: outputSchema.PrimaryKeys,
 		}
 		if err := t.source.streamTables(ctx, []source.SourceTableInfo{tableInfo}, metaByTable, startByTable, opts, results, false); err != nil {
-			results <- source.RecordBatchResult{Err: err}
+			if opts.Streaming {
+				_ = emitMySQLCDCResult(ctx, results, source.RecordBatchResult{Err: err})
+			} else {
+				results <- source.RecordBatchResult{Err: err}
+			}
 		}
 	}()
 
@@ -1246,19 +1344,24 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		return nil
 	}
 
-	target, err := currentMySQLBinlogPosition(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	targetCheckpoint, err := s.checkpointForPosition(ctx, s.db, target)
-	if err != nil {
-		return err
+	var target gomysql.Position
+	var targetCheckpoint mysqlCDCCheckpoint
+	if !opts.Streaming {
+		var err error
+		target, err = currentMySQLBinlogPosition(ctx, s.db)
+		if err != nil {
+			return err
+		}
+		targetCheckpoint, err = s.checkpointForPosition(ctx, s.db, target)
+		if err != nil {
+			return err
+		}
 	}
 	start := minMySQLPosition(startByTable)
 	if start.Name == "" {
 		return nil
 	}
-	if start.Compare(target) >= 0 {
+	if !opts.Streaming && start.Compare(target) >= 0 {
 		s.recordMySQLCDCCheckpoint(targetCheckpoint)
 		return nil
 	}
@@ -1307,18 +1410,77 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		pendingXALimit = defaultMySQLCDCPendingXALimit
 	}
 	safeCheckpoint := func(position gomysql.Position) gomysql.Position {
-		for _, pending := range pendingXA {
-			if pending.start.Name == "" {
-				continue
-			}
-			if position.Name == "" || pending.start.Compare(position) < 0 {
-				position = pending.start
+		return safeMySQLCDCCheckpoint(position, pendingXA, buffers)
+	}
+	lastTokenPosition := ""
+	streamingToken := func(position gomysql.Position, preferredLSN string) (source.CDCStateCommitToken, error) {
+		safe := safeCheckpoint(position)
+		if safe.Name == "" {
+			return source.CDCStateCommitToken{}, nil
+		}
+		commitPosition := ""
+		if preferredLSN != "" {
+			if parsed, ok := parseStoredMySQLPosition(preferredLSN); ok && parsed.Compare(safe) == 0 {
+				commitPosition = preferredLSN
 			}
 		}
-		return position
+		token, err := s.checkpointCommitToken(ctx, commitPosition, safe)
+		if err != nil {
+			return source.CDCStateCommitToken{}, err
+		}
+		if token.Position == "" || token.Position == lastTokenPosition {
+			return source.CDCStateCommitToken{}, nil
+		}
+		lastTokenPosition = token.Position
+		return token, nil
+	}
+	var tokenFn mysqlCDCCommitTokenFunc
+	if opts.Streaming {
+		tokenFn = func(lastLSN string) (any, error) {
+			position, ok := parseStoredMySQLPosition(lastLSN)
+			if !ok {
+				return nil, fmt.Errorf("invalid MySQL CDC change LSN %q", lastLSN)
+			}
+			token, err := streamingToken(position, lastLSN)
+			if err != nil {
+				return nil, err
+			}
+			if token.Position == "" {
+				return nil, nil
+			}
+			return token, nil
+		}
+	}
+	emitStreamingProgress := func(sendCtx context.Context, position gomysql.Position) error {
+		if !opts.Streaming {
+			return nil
+		}
+		token, err := streamingToken(position, "")
+		if err != nil {
+			return err
+		}
+		return emitMySQLCDCCommitToken(sendCtx, results, token)
+	}
+	flushBuffers := func(sendCtx context.Context) error {
+		return flushMySQLCDCChangeBuffersWithTokenContext(sendCtx, buffers, results, tokenFn)
+	}
+	flushBuffersAndProgress := func(sendCtx context.Context, position gomysql.Position) error {
+		if err := flushBuffers(sendCtx); err != nil {
+			return err
+		}
+		return emitStreamingProgress(sendCtx, position)
+	}
+	streamingFlushInterval := mysqlCDCStreamingFlushInterval(opts)
+	lastStreamingFlush := time.Now()
+	maybeFlushStreaming := func(position gomysql.Position) error {
+		if !opts.Streaming || time.Since(lastStreamingFlush) < streamingFlushInterval {
+			return nil
+		}
+		lastStreamingFlush = time.Now()
+		return flushBuffersAndProgress(ctx, position)
 	}
 	finish := func(position gomysql.Position) error {
-		if err := flushMySQLCDCChangeBuffers(buffers, results); err != nil {
+		if err := flushMySQLCDCChangeBuffersWithTokenContext(ctx, buffers, results, nil); err != nil {
 			return err
 		}
 		checkpoint := targetCheckpoint
@@ -1336,7 +1498,7 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 			return fmt.Errorf("missing output schema for MySQL CDC table %s", table)
 		}
 		resultTable := mysqlCDCResultTableName(meta.Name, len(tables), tagResults)
-		return appendMySQLCDCBufferedChanges(buffers, meta.Name, outputSchema, resultTable, changes, batchSize, results)
+		return appendMySQLCDCBufferedChangesWithTokenContext(ctx, buffers, meta.Name, outputSchema, resultTable, changes, batchSize, results, tokenFn)
 	}
 	releaseXA := func(xaID string, commit bool) error {
 		pending := pendingXA[xaID]
@@ -1349,6 +1511,12 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 			// checkpointed — by the run that recorded it. Replaying its
 			// terminal event alone is benign.
 			return nil
+		}
+		pendingXAChanges -= pending.count
+		pendingXABytes -= pending.bytes
+		delete(pendingXA, xaID)
+		if activeXA == xaID {
+			activeXA = ""
 		}
 		if commit {
 			tableNames := make([]string, 0, len(pending.byTable))
@@ -1364,34 +1532,50 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 				}
 			}
 		}
-		pendingXAChanges -= pending.count
-		pendingXABytes -= pending.bytes
-		delete(pendingXA, xaID)
-		if activeXA == xaID {
-			activeXA = ""
-		}
 		return nil
 	}
 	lastDelivery := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
+			if opts.Streaming {
+				drainCtx, cancel := detachedMySQLCDCStreamDrainContext(ctx)
+				err := flushBuffersAndProgress(drainCtx, current)
+				cancel()
+				if err != nil {
+					return err
+				}
+			}
 			return ctx.Err()
 		default:
 		}
 
-		if current.Compare(target) >= 0 {
+		if !opts.Streaming && current.Compare(target) >= 0 {
 			return finish(current)
 		}
 
 		event, err, eventCtxErr := readMySQLCDCEvent(ctx, streamer)
 		if err != nil {
 			if ctx.Err() != nil {
+				if opts.Streaming {
+					drainCtx, cancel := detachedMySQLCDCStreamDrainContext(ctx)
+					flushErr := flushBuffersAndProgress(drainCtx, current)
+					cancel()
+					if flushErr != nil {
+						return flushErr
+					}
+				}
 				return ctx.Err()
 			}
 			if isMySQLCDCReadPollTimeout(ctx, err, eventCtxErr) {
 				if time.Since(lastDelivery) >= mysqlCDCStreamStallTimeout {
+					if opts.Streaming {
+						return fmt.Errorf("MySQL binlog stream stalled at %s: no events or heartbeats received for %s; check connectivity to the server", current, mysqlCDCStreamStallTimeout)
+					}
 					return fmt.Errorf("MySQL binlog stream stalled at %s while catching up to %s: no events or heartbeats received for %s; check connectivity to the server", current, target, mysqlCDCStreamStallTimeout)
+				}
+				if err := maybeFlushStreaming(current); err != nil {
+					return err
 				}
 				continue
 			}
@@ -1407,6 +1591,13 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 				return fmt.Errorf("MySQL CDC does not support PARTIAL_UPDATE_ROWS_EVENT; disable binlog_row_value_options=PARTIAL_JSON")
 			}
 			if event.Header.EventType == replication.HEARTBEAT_EVENT || event.Header.EventType == replication.HEARTBEAT_LOG_EVENT_V2 {
+				if opts.Streaming {
+					lastStreamingFlush = time.Now()
+					if err := flushBuffersAndProgress(ctx, current); err != nil {
+						return err
+					}
+					continue
+				}
 				// current < target here is normal, not an anomaly: non-data
 				// events (FORMAT_DESCRIPTION, PREVIOUS_GTIDS, artificial
 				// MariaDB events) carry LogPos=0 and don't advance current.
@@ -1420,7 +1611,7 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 		previousPosition := current
 		eventPos := mysqlEventPosition(event, current)
 		current = eventPos
-		if eventPos.Compare(target) > 0 {
+		if !opts.Streaming && eventPos.Compare(target) > 0 {
 			return finish(previousPosition)
 		}
 		logicalEvents, err := mysqlBinlogEvents(event)
@@ -1484,15 +1675,20 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 					return err
 				}
 				if len(truncated) > 0 {
-					if err := flushMySQLCDCChangeBuffers(buffers, results); err != nil {
+					if err := flushBuffers(ctx); err != nil {
 						return err
 					}
 					for _, meta := range truncated {
-						results <- source.RecordBatchResult{
+						if err := emitMySQLCDCResult(ctx, results, source.RecordBatchResult{
 							TableName:      mysqlCDCResultTableName(meta.Name, len(tables), tagResults),
 							Truncate:       true,
 							CDCWALTruncate: true,
+						}); err != nil {
+							return err
 						}
+					}
+					if err := emitStreamingProgress(ctx, eventPos); err != nil {
+						return err
 					}
 				}
 				continue
@@ -1539,7 +1735,7 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 			if err := validateMySQLCDCFullRowImage(rowsEvent, len(sourceColumnsWithoutMySQLCDC(meta.FullSchema))); err != nil {
 				return fmt.Errorf("failed to decode MySQL CDC rows for %s: %w", meta.Name, err)
 			}
-			changes, nextRowSeq, err := mysqlRowsEventToChangesFromSequence(rowsEvent.Type(), rowsEvent.Rows, meta.FullSchema, outputSchema, eventPos, rowSeq)
+			changes, nextRowSeq, err := mysqlRowsEventToChangesFromSequence(rowsEvent.Type(), rowsEvent.Rows, meta.FullSchema, outputSchema, eventPos, rowSeq, previousPosition)
 			if err != nil {
 				return fmt.Errorf("failed to decode MySQL CDC rows for %s: %w", meta.Name, err)
 			}
@@ -1585,7 +1781,43 @@ func (s *MySQLCDCSource) streamTables(ctx context.Context, tables []source.Sourc
 				return err
 			}
 		}
+		if err := maybeFlushStreaming(current); err != nil {
+			return err
+		}
 	}
+}
+
+func safeMySQLCDCCheckpoint(position gomysql.Position, pendingXA map[string]*mysqlCDCXAChanges, buffers map[string]*mysqlCDCChangeBuffer) gomysql.Position {
+	for _, pending := range pendingXA {
+		if pending.start.Name == "" {
+			continue
+		}
+		if position.Name == "" || pending.start.Compare(position) < 0 {
+			position = pending.start
+		}
+	}
+	for _, buffer := range buffers {
+		checkpoint := firstMySQLCDCBufferedCheckpoint(buffer)
+		if checkpoint.Name == "" {
+			continue
+		}
+		if position.Name == "" || checkpoint.Compare(position) < 0 {
+			position = checkpoint
+		}
+	}
+	return position
+}
+
+func firstMySQLCDCBufferedCheckpoint(buffer *mysqlCDCChangeBuffer) gomysql.Position {
+	if buffer == nil || len(buffer.changes) == 0 {
+		return gomysql.Position{}
+	}
+	checkpoint := buffer.changes[0].checkpoint
+	if checkpoint.Name != "" {
+		return checkpoint
+	}
+	position, _ := parseStoredMySQLPosition(buffer.changes[0].lsn)
+	return position
 }
 
 func mysqlBinlogEvents(event *replication.BinlogEvent) ([]*replication.BinlogEvent, error) {
@@ -2142,11 +2374,11 @@ func (s *MySQLCDCSource) binlogSyncerConfig() replication.BinlogSyncerConfig {
 }
 
 func mysqlRowsEventToChanges(eventType replication.EnumRowsEventType, rows [][]interface{}, fullSchema *schema.TableSchema, outputSchema *schema.TableSchema, pos gomysql.Position) ([]mysqlCDCChange, error) {
-	changes, _, err := mysqlRowsEventToChangesFromSequence(eventType, rows, fullSchema, outputSchema, pos, 0)
+	changes, _, err := mysqlRowsEventToChangesFromSequence(eventType, rows, fullSchema, outputSchema, pos, 0, pos)
 	return changes, err
 }
 
-func mysqlRowsEventToChangesFromSequence(eventType replication.EnumRowsEventType, rows [][]interface{}, fullSchema *schema.TableSchema, outputSchema *schema.TableSchema, pos gomysql.Position, rowSeq int) ([]mysqlCDCChange, int, error) {
+func mysqlRowsEventToChangesFromSequence(eventType replication.EnumRowsEventType, rows [][]interface{}, fullSchema *schema.TableSchema, outputSchema *schema.TableSchema, pos gomysql.Position, rowSeq int, checkpoint gomysql.Position) ([]mysqlCDCChange, int, error) {
 	fullSourceColumns := sourceColumnsWithoutMySQLCDC(fullSchema)
 	outputSourceColumns := sourceColumnsWithoutMySQLCDC(outputSchema)
 	indexes, err := sourceIndexes(fullSourceColumns, outputSourceColumns)
@@ -2164,7 +2396,7 @@ func mysqlRowsEventToChangesFromSequence(eventType replication.EnumRowsEventType
 			if err != nil {
 				return nil, rowSeq, err
 			}
-			changes = append(changes, mysqlCDCChange{values: values, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: false})
+			changes = append(changes, mysqlCDCChange{values: values, lsn: formatStoredMySQLPosition(pos, rowSeq), checkpoint: checkpoint, deleted: false})
 			rowSeq++
 		}
 	case replication.EnumRowsEventTypeDelete:
@@ -2173,7 +2405,7 @@ func mysqlRowsEventToChangesFromSequence(eventType replication.EnumRowsEventType
 			if err != nil {
 				return nil, rowSeq, err
 			}
-			changes = append(changes, mysqlCDCChange{values: values, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: true})
+			changes = append(changes, mysqlCDCChange{values: values, lsn: formatStoredMySQLPosition(pos, rowSeq), checkpoint: checkpoint, deleted: true})
 			rowSeq++
 		}
 	case replication.EnumRowsEventTypeUpdate:
@@ -2188,14 +2420,14 @@ func mysqlRowsEventToChangesFromSequence(eventType replication.EnumRowsEventType
 				if err != nil {
 					return nil, rowSeq, err
 				}
-				changes = append(changes, mysqlCDCChange{values: beforeValues, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: true})
+				changes = append(changes, mysqlCDCChange{values: beforeValues, lsn: formatStoredMySQLPosition(pos, rowSeq), checkpoint: checkpoint, deleted: true})
 				rowSeq++
 			}
 			afterValues, err := projectMySQLCDCRow(after, fullSourceColumns, outputSourceColumns, indexes)
 			if err != nil {
 				return nil, rowSeq, err
 			}
-			changes = append(changes, mysqlCDCChange{values: afterValues, lsn: formatStoredMySQLPosition(pos, rowSeq), deleted: false})
+			changes = append(changes, mysqlCDCChange{values: afterValues, lsn: formatStoredMySQLPosition(pos, rowSeq), checkpoint: checkpoint, deleted: false})
 			rowSeq++
 		}
 	default:
@@ -2478,13 +2710,31 @@ func mysqlCDCChangesToBatch(changes []mysqlCDCChange, tableSchema *schema.TableS
 }
 
 func mysqlCDCStreamBatchSize(opts source.ReadOptions) int {
+	if opts.Streaming && opts.FlushRecords > 0 {
+		return opts.FlushRecords
+	}
 	if opts.PageSize > 0 {
 		return opts.PageSize
 	}
 	return defaultMySQLCDCStreamBatchSize
 }
 
+func mysqlCDCStreamingFlushInterval(opts source.ReadOptions) time.Duration {
+	if opts.Streaming && opts.FlushInterval > 0 {
+		return opts.FlushInterval
+	}
+	return defaultMySQLCDCHeartbeat
+}
+
 func appendMySQLCDCBufferedChanges(buffers map[string]*mysqlCDCChangeBuffer, key string, tableSchema *schema.TableSchema, tableName string, changes []mysqlCDCChange, batchSize int, results chan<- source.RecordBatchResult) error {
+	return appendMySQLCDCBufferedChangesWithToken(buffers, key, tableSchema, tableName, changes, batchSize, results, nil)
+}
+
+func appendMySQLCDCBufferedChangesWithToken(buffers map[string]*mysqlCDCChangeBuffer, key string, tableSchema *schema.TableSchema, tableName string, changes []mysqlCDCChange, batchSize int, results chan<- source.RecordBatchResult, tokenFn mysqlCDCCommitTokenFunc) error {
+	return appendMySQLCDCBufferedChangesWithTokenContext(context.Background(), buffers, key, tableSchema, tableName, changes, batchSize, results, tokenFn)
+}
+
+func appendMySQLCDCBufferedChangesWithTokenContext(ctx context.Context, buffers map[string]*mysqlCDCChangeBuffer, key string, tableSchema *schema.TableSchema, tableName string, changes []mysqlCDCChange, batchSize int, results chan<- source.RecordBatchResult, tokenFn mysqlCDCCommitTokenFunc) error {
 	if len(changes) == 0 {
 		return nil
 	}
@@ -2500,27 +2750,48 @@ func appendMySQLCDCBufferedChanges(buffers map[string]*mysqlCDCChangeBuffer, key
 	if len(buffer.changes) < batchSize {
 		return nil
 	}
-	return buffer.flush(results)
+	return buffer.flush(ctx, results, tokenFn)
 }
 
 func flushMySQLCDCChangeBuffers(buffers map[string]*mysqlCDCChangeBuffer, results chan<- source.RecordBatchResult) error {
+	return flushMySQLCDCChangeBuffersWithToken(buffers, results, nil)
+}
+
+func flushMySQLCDCChangeBuffersWithToken(buffers map[string]*mysqlCDCChangeBuffer, results chan<- source.RecordBatchResult, tokenFn mysqlCDCCommitTokenFunc) error {
+	return flushMySQLCDCChangeBuffersWithTokenContext(context.Background(), buffers, results, tokenFn)
+}
+
+func flushMySQLCDCChangeBuffersWithTokenContext(ctx context.Context, buffers map[string]*mysqlCDCChangeBuffer, results chan<- source.RecordBatchResult, tokenFn mysqlCDCCommitTokenFunc) error {
 	for _, buffer := range buffers {
-		if err := buffer.flush(results); err != nil {
+		if err := buffer.flush(ctx, results, tokenFn); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (b *mysqlCDCChangeBuffer) flush(results chan<- source.RecordBatchResult) error {
+func (b *mysqlCDCChangeBuffer) flush(ctx context.Context, results chan<- source.RecordBatchResult, tokenFn mysqlCDCCommitTokenFunc) error {
 	if b == nil || len(b.changes) == 0 {
 		return nil
 	}
-	record, err := mysqlCDCChangesToBatch(b.changes, b.tableSchema)
+	changes := b.changes
+	b.changes = b.changes[:0]
+	lastLSN := changes[len(changes)-1].lsn
+	record, err := mysqlCDCChangesToBatch(changes, b.tableSchema)
 	if err != nil {
 		return err
 	}
-	results <- source.RecordBatchResult{Batch: record, TableName: b.tableName}
+	var token any
+	if tokenFn != nil {
+		token, err = tokenFn(lastLSN)
+		if err != nil {
+			record.Release()
+			return err
+		}
+	}
+	if err := emitMySQLCDCResult(ctx, results, source.RecordBatchResult{Batch: record, TableName: b.tableName, CommitToken: token}); err != nil {
+		return err
+	}
 	b.changes = b.changes[:0]
 	return nil
 }
@@ -2858,6 +3129,10 @@ func formatStoredMySQLPosition(pos gomysql.Position, rowSeq int) string {
 
 func formatStoredMySQLCheckpoint(checkpoint mysqlCDCCheckpoint) string {
 	position := formatStoredMySQLPosition(checkpoint.Position, 0)
+	return formatStoredMySQLCheckpointAt(position, checkpoint)
+}
+
+func formatStoredMySQLCheckpointAt(position string, checkpoint mysqlCDCCheckpoint) string {
 	if checkpoint.Identity == "" {
 		return position
 	}
@@ -2920,5 +3195,6 @@ func mysqlBinlogSequence(name string) uint64 {
 var (
 	_ source.Source           = (*MySQLCDCSource)(nil)
 	_ source.MultiTableSource = (*MySQLCDCSource)(nil)
+	_ source.StreamingSource  = (*MySQLCDCSource)(nil)
 	_ source.SourceTable      = (*MySQLCDCTable)(nil)
 )

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -790,6 +790,52 @@ func TestAppendMySQLCDCBufferedChangesTokenExcludesFlushedBuffer(t *testing.T) {
 	assert.Equal(t, formatStoredMySQLPosition(current, 0), token.Position)
 }
 
+func TestAppendMySQLCDCBufferedChangesTokenIncludesPendingXA(t *testing.T) {
+	tableSchema := addMySQLCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, 1)
+	buffers := map[string]*mysqlCDCChangeBuffer{}
+	pendingStart := gomysql.Position{Name: "mysql-bin.000001", Pos: 80}
+	current := gomysql.Position{Name: "mysql-bin.000001", Pos: 200}
+	beforeEvent := gomysql.Position{Name: "mysql-bin.000001", Pos: 100}
+	lsn := formatStoredMySQLPosition(current, 0)
+	pendingXA := map[string]*mysqlCDCXAChanges{
+		"xa": &mysqlCDCXAChanges{start: pendingStart},
+	}
+
+	err := appendMySQLCDCBufferedChangesWithTokenContext(
+		context.Background(),
+		buffers,
+		"items",
+		tableSchema,
+		"items",
+		[]mysqlCDCChange{{values: []interface{}{int64(1), "item1"}, lsn: lsn, checkpoint: beforeEvent}},
+		1,
+		results,
+		func(lastLSN string) (any, error) {
+			position, ok := parseStoredMySQLPosition(lastLSN)
+			require.True(t, ok)
+			safe := safeMySQLCDCCheckpoint(position, pendingXA, buffers)
+			return source.CDCStateCommitToken{Position: formatStoredMySQLPosition(safe, 0)}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	result := <-results
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+	token, ok := result.CommitToken.(source.CDCStateCommitToken)
+	require.True(t, ok)
+	assert.Equal(t, formatStoredMySQLPosition(pendingStart, 0), token.Position)
+}
+
 func TestSafeMySQLCDCCheckpointIncludesUnflushedBuffers(t *testing.T) {
 	current := gomysql.Position{Name: "mysql-bin.000001", Pos: 300}
 	bufferCheckpoint := gomysql.Position{Name: "mysql-bin.000001", Pos: 200}

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -508,9 +508,11 @@ func TestMySQLCDCRejectsNonMergeStrategies(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestMySQLCDCDoesNotAdvertiseStreaming(t *testing.T) {
-	_, ok := any(NewMySQLCDCSource()).(source.StreamingSource)
-	require.False(t, ok)
+func TestMySQLCDCAdvertisesStreaming(t *testing.T) {
+	streaming, ok := any(NewMySQLCDCSource()).(source.StreamingSource)
+	require.True(t, ok)
+	require.True(t, streaming.SupportsStreaming())
+	assert.Equal(t, config.StrategyMerge, streaming.DefaultStreamingStrategy())
 }
 
 func TestStoredMySQLPositionHelpers(t *testing.T) {
@@ -552,6 +554,13 @@ func TestStoredMySQLCheckpointCarriesLineage(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, checkpoint, parsed)
 	assert.True(t, strings.HasPrefix(stored, formatStoredMySQLPosition(checkpoint.Position, 0)+":l1:"))
+
+	rowPosition := formatStoredMySQLPosition(checkpoint.Position, 42)
+	stored = formatStoredMySQLCheckpointAt(rowPosition, checkpoint)
+	parsed, ok = parseStoredMySQLCheckpoint(stored)
+	require.True(t, ok)
+	assert.Equal(t, checkpoint, parsed)
+	assert.True(t, strings.HasPrefix(stored, rowPosition+":l1:"))
 }
 
 func TestMySQLCDCResumeRejectsMissingAndMismatchedLineage(t *testing.T) {
@@ -699,6 +708,123 @@ func TestAppendMySQLCDCBufferedChangesFlushesAtBatchSize(t *testing.T) {
 	require.NotNil(t, result.Batch)
 	assert.EqualValues(t, 1, result.Batch.NumRows())
 	result.Batch.Release()
+}
+
+func TestAppendMySQLCDCBufferedChangesAttachesCommitToken(t *testing.T) {
+	tableSchema := addMySQLCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, 1)
+	buffers := map[string]*mysqlCDCChangeBuffer{}
+	lsn := formatStoredMySQLPosition(gomysql.Position{Name: "mysql-bin.000001", Pos: 100}, 0)
+
+	err := appendMySQLCDCBufferedChangesWithToken(
+		buffers,
+		"items",
+		tableSchema,
+		"items",
+		[]mysqlCDCChange{{values: []interface{}{int64(1), "item1"}, lsn: lsn}},
+		1,
+		results,
+		func(lastLSN string) (any, error) {
+			assert.Equal(t, lsn, lastLSN)
+			return source.CDCStateCommitToken{Position: lastLSN}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	result := <-results
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+	assert.Equal(t, "items", result.TableName)
+	token, ok := result.CommitToken.(source.CDCStateCommitToken)
+	require.True(t, ok)
+	assert.Equal(t, lsn, token.Position)
+}
+
+func TestAppendMySQLCDCBufferedChangesTokenExcludesFlushedBuffer(t *testing.T) {
+	tableSchema := addMySQLCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, 1)
+	buffers := map[string]*mysqlCDCChangeBuffer{}
+	current := gomysql.Position{Name: "mysql-bin.000001", Pos: 200}
+	beforeEvent := gomysql.Position{Name: "mysql-bin.000001", Pos: 100}
+	lsn := formatStoredMySQLPosition(current, 0)
+
+	err := appendMySQLCDCBufferedChangesWithTokenContext(
+		context.Background(),
+		buffers,
+		"items",
+		tableSchema,
+		"items",
+		[]mysqlCDCChange{{values: []interface{}{int64(1), "item1"}, lsn: lsn, checkpoint: beforeEvent}},
+		1,
+		results,
+		func(lastLSN string) (any, error) {
+			position, ok := parseStoredMySQLPosition(lastLSN)
+			require.True(t, ok)
+			safe := safeMySQLCDCCheckpoint(position, nil, buffers)
+			return source.CDCStateCommitToken{Position: formatStoredMySQLPosition(safe, 0)}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	result := <-results
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+	token, ok := result.CommitToken.(source.CDCStateCommitToken)
+	require.True(t, ok)
+	assert.Equal(t, formatStoredMySQLPosition(current, 0), token.Position)
+}
+
+func TestSafeMySQLCDCCheckpointIncludesUnflushedBuffers(t *testing.T) {
+	current := gomysql.Position{Name: "mysql-bin.000001", Pos: 300}
+	bufferCheckpoint := gomysql.Position{Name: "mysql-bin.000001", Pos: 200}
+	pendingCheckpoint := gomysql.Position{Name: "mysql-bin.000001", Pos: 120}
+
+	got := safeMySQLCDCCheckpoint(current, nil, map[string]*mysqlCDCChangeBuffer{
+		"orders": &mysqlCDCChangeBuffer{
+			changes: []mysqlCDCChange{{
+				lsn:        formatStoredMySQLPosition(gomysql.Position{Name: "mysql-bin.000001", Pos: 220}, 0),
+				checkpoint: bufferCheckpoint,
+			}},
+		},
+	})
+	assert.Equal(t, bufferCheckpoint, got)
+
+	got = safeMySQLCDCCheckpoint(current, map[string]*mysqlCDCXAChanges{
+		"xa": &mysqlCDCXAChanges{start: pendingCheckpoint},
+	}, map[string]*mysqlCDCChangeBuffer{
+		"orders": &mysqlCDCChangeBuffer{
+			changes: []mysqlCDCChange{{
+				lsn:        formatStoredMySQLPosition(gomysql.Position{Name: "mysql-bin.000001", Pos: 220}, 0),
+				checkpoint: bufferCheckpoint,
+			}},
+		},
+	})
+	assert.Equal(t, pendingCheckpoint, got)
+}
+
+func TestMySQLCDCStreamingBatchSizeUsesFlushRecords(t *testing.T) {
+	assert.Equal(t, 7, mysqlCDCStreamBatchSize(source.ReadOptions{
+		Streaming:    true,
+		FlushRecords: 7,
+		PageSize:     100,
+	}))
+	assert.Equal(t, 100, mysqlCDCStreamBatchSize(source.ReadOptions{PageSize: 100}))
 }
 
 func assertNoCDCResult(t *testing.T, results <-chan source.RecordBatchResult) {

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -806,7 +806,7 @@ func TestAppendMySQLCDCBufferedChangesTokenIncludesPendingXA(t *testing.T) {
 	beforeEvent := gomysql.Position{Name: "mysql-bin.000001", Pos: 100}
 	lsn := formatStoredMySQLPosition(current, 0)
 	pendingXA := map[string]*mysqlCDCXAChanges{
-		"xa": &mysqlCDCXAChanges{start: pendingStart},
+		"xa": {start: pendingStart},
 	}
 
 	err := appendMySQLCDCBufferedChangesWithTokenContext(
@@ -842,7 +842,7 @@ func TestSafeMySQLCDCCheckpointIncludesUnflushedBuffers(t *testing.T) {
 	pendingCheckpoint := gomysql.Position{Name: "mysql-bin.000001", Pos: 120}
 
 	got := safeMySQLCDCCheckpoint(current, nil, map[string]*mysqlCDCChangeBuffer{
-		"orders": &mysqlCDCChangeBuffer{
+		"orders": {
 			changes: []mysqlCDCChange{{
 				lsn:        formatStoredMySQLPosition(gomysql.Position{Name: "mysql-bin.000001", Pos: 220}, 0),
 				checkpoint: bufferCheckpoint,
@@ -852,9 +852,9 @@ func TestSafeMySQLCDCCheckpointIncludesUnflushedBuffers(t *testing.T) {
 	assert.Equal(t, bufferCheckpoint, got)
 
 	got = safeMySQLCDCCheckpoint(current, map[string]*mysqlCDCXAChanges{
-		"xa": &mysqlCDCXAChanges{start: pendingCheckpoint},
+		"xa": {start: pendingCheckpoint},
 	}, map[string]*mysqlCDCChangeBuffer{
-		"orders": &mysqlCDCChangeBuffer{
+		"orders": {
 			changes: []mysqlCDCChange{{
 				lsn:        formatStoredMySQLPosition(gomysql.Position{Name: "mysql-bin.000001", Pos: 220}, 0),
 				checkpoint: bufferCheckpoint,


### PR DESCRIPTION
## Summary
- Advertise MySQL/MariaDB CDC sources as `--stream` capable with merge as the default streaming strategy.
- Keep MySQL CDC reads alive after catch-up, emit durable CDC state commit tokens for flushed batches and idle progress, and preserve safe checkpoints across buffered table changes and XA transactions.
- Document MySQL/MariaDB CDC streaming support and update the unsupported streaming source message.

## Validation
- `git diff --check`
- `make format` could not run locally because `gci` is not installed in this environment.
- `make lint` and `make test` could not run locally because `go` is not installed in this environment.