### PR TITLE
Add schema evolution for OneLake destinations

### DIFF
--- a/docs/supported-sources/onelake.md
+++ b/docs/supported-sources/onelake.md
@@ -71,6 +71,13 @@ ingestr ingest \
     --incremental-strategy append
 ```
 
+With the default `--schema-contract evolve`, ingestr reads the current Delta
+metadata before an incremental load. New source columns are added to the table
+through a metadata-only Delta commit and are always declared nullable, because
+data files written before the commit do not contain them. Required columns
+removed from the source are retained and relaxed to nullable, matching
+ingestr's soft-removal behavior.
+
 ## Incremental strategies
 
 For **Tables** (Delta) mode, ingestr supports `replace`, `append`, `merge`, `delete+insert` and `scd2`:
@@ -103,6 +110,9 @@ ingestr ingest \
 
 - **Replace** is not atomic — there is a brief window where the table is empty.
 - **Copy-on-write** strategies load the entire target table into memory and rewrite it on every run.
-- **Partitioning**: Delta tables are written non-partitioned; `partition_by` is ignored in Tables mode for now.
+- **Partitioning**: Delta tables are written non-partitioned; `partition_by` is ignored in Tables mode for now. An existing partitioned table is rejected by the copy-on-write strategies, because its partition values live in the Delta log rather than in the Parquet files; `append` and `replace` do not check for this.
 - **Type mapping**: timestamps are stored as Delta `timestamp` (microseconds, UTC); JSON and UUID columns are stored as `string`; `TIME` columns are carried as microsecond `long` values (Delta has no time type).
+- **Schema evolution**: adding columns and relaxing nullability are supported for Tables mode. Changing an existing column's Delta type fails the load rather than being skipped with a warning — recreate the table or pin the column with `--columns`. Because Delta types are coarser than ingestr's, source type changes that collapse to the same Delta type (`timestamp` ↔ `timestamptz`, `string` ↔ `json`/`uuid`) are accepted and need no rewrite.
+- **Delta column mapping**: tables with `delta.columnMapping.mode` set to anything other than `none` are rejected by schema evolution and by the copy-on-write strategies (`merge`, `delete+insert`, `scd2`), because ingestr reads the Parquet files by their physical column names. `append` and `replace` do not check for this and will write files that Fabric reads back incorrectly.
+- **Delta protocol and table features**: schema evolution and the copy-on-write strategies check the table's `protocol` action and reject tables that require reader or writer capabilities ingestr does not have (for example row tracking or Iceberg compatibility). Rewrites are also rejected when a data file carries a deletion vector (rewriting it would restore the deleted rows), or when the table uses `delta.appendOnly`, `delta.enableChangeDataFeed`, CHECK constraints, column invariants, or generated/identity columns — guarantees a plain remove-and-add commit would not keep. Rewrites also reject tables whose transaction log no longer starts at commit 0 (checkpointed logs cleaned up by the engine), because ingestr does not read checkpoints and cannot reconstruct the full set of active data files. `append` and `replace` do not check for this.
 - **CDC-aware merge** (soft-deletes via `_cdc_deleted`) is not implemented; CDC delete markers are merged as regular rows.

--- a/internal/adlsutil/datalake.go
+++ b/internal/adlsutil/datalake.go
@@ -211,10 +211,29 @@ func (c *DataLakeClient) DeleteDir(ctx context.Context, fileSystem, dirPath stri
 	return nil
 }
 
+// DeltaLogEntry identifies a Delta JSON commit and its storage version.
+type DeltaLogEntry struct {
+	Version int64
+	ETag    string
+}
+
 // ListLogVersions returns the Delta commit versions found under logDir (the
 // numeric prefixes of the "<version>.json" files), sorted ascending. Returns an
 // empty slice if the directory does not exist.
 func (c *DataLakeClient) ListLogVersions(ctx context.Context, fileSystem, logDir string) ([]int64, error) {
+	entries, err := c.ListLogEntries(ctx, fileSystem, logDir)
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]int64, len(entries))
+	for i, entry := range entries {
+		versions[i] = entry.Version
+	}
+	return versions, nil
+}
+
+// ListLogEntries returns each Delta JSON commit's version and storage ETag.
+func (c *DataLakeClient) ListLogEntries(ctx context.Context, fileSystem, logDir string) ([]DeltaLogEntry, error) {
 	fsURL := FilesystemURLWithSuffix(c.accountName, c.dnsSuffix, fileSystem)
 	fsClient, err := c.newFilesystemClient(fsURL)
 	if err != nil {
@@ -226,7 +245,7 @@ func (c *DataLakeClient) ListLogVersions(ctx context.Context, fileSystem, logDir
 		Prefix: &prefix,
 	})
 
-	var versions []int64
+	var entries []DeltaLogEntry
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
@@ -250,12 +269,25 @@ func (c *DataLakeClient) ListLogVersions(ctx context.Context, fileSystem, logDir
 			if err != nil {
 				continue
 			}
-			versions = append(versions, v)
+			entry := DeltaLogEntry{Version: v}
+			if p.ETag != nil {
+				entry.ETag = *p.ETag
+			}
+			entries = append(entries, entry)
 		}
 	}
 
-	slices.Sort(versions)
-	return versions, nil
+	slices.SortFunc(entries, func(a, b DeltaLogEntry) int {
+		switch {
+		case a.Version < b.Version:
+			return -1
+		case a.Version > b.Version:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return entries, nil
 }
 
 func recreateFile(ctx context.Context, fileClient *datalakefile.Client, path string) error {

--- a/pkg/destination/onelake/delta.go
+++ b/pkg/destination/onelake/delta.go
@@ -27,6 +27,20 @@ type deltaStruct struct {
 	Fields []deltaField `json:"fields"`
 }
 
+// deltaMetadata keeps the metadata action as raw JSON fields so schema changes
+// can preserve table properties that ingestr does not interpret.
+type deltaMetadata map[string]json.RawMessage
+
+// deltaProtocol is the table's protocol action. It states the reader and writer
+// capabilities a client must have before touching the table, so it has to be
+// read and checked before any rewrite or metadata commit.
+type deltaProtocol struct {
+	MinReaderVersion int      `json:"minReaderVersion"`
+	MinWriterVersion int      `json:"minWriterVersion"`
+	ReaderFeatures   []string `json:"readerFeatures"`
+	WriterFeatures   []string `json:"writerFeatures"`
+}
+
 // deltaTypeFor maps an ingestr column type to a Delta Lake schema type. Scalar
 // types are returned as strings; arrays as nested type objects.
 func deltaTypeFor(col schema.Column) any {
@@ -63,9 +77,11 @@ func deltaTypeFor(col schema.Column) any {
 		// Delta has no TIME type; values are carried as microsecond longs.
 		return "long"
 	case schema.TypeArray:
+		// Array elements carry their precision/scale on the parent column, the
+		// same way schema.DataTypeToArrowType reads them.
 		return map[string]any{
 			"type":         "array",
-			"elementType":  deltaTypeFor(schema.Column{DataType: col.ArrayType}),
+			"elementType":  deltaTypeFor(schema.Column{DataType: col.ArrayType, Precision: col.Precision, Scale: col.Scale}),
 			"containsNull": true,
 		}
 	default:
@@ -90,6 +106,31 @@ func buildSchemaString(cols []schema.Column) (string, error) {
 		return "", fmt.Errorf("failed to encode delta schema: %w", err)
 	}
 	return string(b), nil
+}
+
+func newDeltaMetadata(cols []schema.Column, tableID string, createdTime int64) (deltaMetadata, error) {
+	schemaString, err := buildSchemaString(cols)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := map[string]any{
+		"id":               tableID,
+		"format":           map[string]any{"provider": "parquet", "options": map[string]string{}},
+		"schemaString":     schemaString,
+		"partitionColumns": []string{},
+		"configuration":    map[string]string{},
+		"createdTime":      createdTime,
+	}
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode delta metadata: %w", err)
+	}
+	var result deltaMetadata
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode delta metadata: %w", err)
+	}
+	return result, nil
 }
 
 func addActions(adds []deltaAddFile, nowMillis int64) []any {
@@ -123,14 +164,16 @@ func removeActions(paths []string, nowMillis int64) []any {
 }
 
 func commitInfo(mode string, nowMillis int64) any {
+	return operationCommitInfo("WRITE", map[string]string{"mode": mode}, nowMillis)
+}
+
+func operationCommitInfo(operation string, parameters map[string]string, nowMillis int64) any {
 	return map[string]any{
 		"commitInfo": map[string]any{
-			"timestamp": nowMillis,
-			"operation": "WRITE",
-			"operationParameters": map[string]string{
-				"mode": mode,
-			},
-			"clientVersion": "ingestr",
+			"timestamp":           nowMillis,
+			"operation":           operation,
+			"operationParameters": parameters,
+			"clientVersion":       "ingestr",
 		},
 	}
 }
@@ -151,7 +194,7 @@ func marshalActions(actions []any) ([]byte, error) {
 // buildInitialCommit produces the newline-delimited JSON for Delta commit
 // version 0: protocol, metaData, one add per data file, and a commitInfo.
 func buildInitialCommit(cols []schema.Column, adds []deltaAddFile, tableID string, nowMillis int64) ([]byte, error) {
-	schemaString, err := buildSchemaString(cols)
+	metadata, err := newDeltaMetadata(cols, tableID, nowMillis)
 	if err != nil {
 		return nil, err
 	}
@@ -163,20 +206,25 @@ func buildInitialCommit(cols []schema.Column, adds []deltaAddFile, tableID strin
 				"minWriterVersion": 2,
 			},
 		},
-		map[string]any{
-			"metaData": map[string]any{
-				"id":               tableID,
-				"format":           map[string]any{"provider": "parquet", "options": map[string]string{}},
-				"schemaString":     schemaString,
-				"partitionColumns": []string{},
-				"configuration":    map[string]string{},
-				"createdTime":      nowMillis,
-			},
-		},
+		map[string]any{"metaData": metadata},
 	}
 	actions = append(actions, addActions(adds, nowMillis)...)
 	actions = append(actions, commitInfo("Overwrite", nowMillis))
 
+	return marshalActions(actions)
+}
+
+// buildSchemaEvolutionCommit replaces the table metadata without changing its
+// active data files. Delta readers fill newly-added columns with NULL for old
+// files that do not contain them.
+func buildSchemaEvolutionCommit(metadata deltaMetadata, nowMillis int64) ([]byte, error) {
+	if len(metadata) == 0 {
+		return nil, fmt.Errorf("cannot build schema evolution commit without delta metadata")
+	}
+	actions := []any{
+		map[string]any{"metaData": metadata},
+		operationCommitInfo("ALTER TABLE", map[string]string{}, nowMillis),
+	}
 	return marshalActions(actions)
 }
 

--- a/pkg/destination/onelake/delta_io.go
+++ b/pkg/destination/onelake/delta_io.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -12,19 +13,27 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
-	"github.com/bruin-data/ingestr/internal/adlsutil"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/databuffer"
+	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
 // deltaSnapshot is the reconstructed state of a Delta table from its log.
 type deltaSnapshot struct {
-	exists      bool
-	version     int64    // latest commit version
-	activeFiles []string // data file paths relative to the table directory
+	exists              bool
+	version             int64    // latest commit version
+	firstVersion        int64    // oldest commit still in the log; not 0 when cleanup truncated it
+	activeFiles         []string // data file paths relative to the table directory
+	deletionVectorFiles []string // active files whose add action carries a deletion vector
+	metadata            deltaMetadata
+	metadataVersion     int64 // version of the commit metadata was read from
+	protocol            *deltaProtocol
+	protocolVersion     int64 // version of the commit protocol was read from
 }
 
 // readDeltaSnapshot replays the Delta transaction log under tableDir and returns
 // the set of currently-active data files.
-func readDeltaSnapshot(ctx context.Context, client *adlsutil.DataLakeClient, fileSystem, tableDir string) (*deltaSnapshot, error) {
+func readDeltaSnapshot(ctx context.Context, client dataLakeClient, fileSystem, tableDir string) (*deltaSnapshot, error) {
 	logDir := tableDir + "/_delta_log"
 	versions, err := client.ListLogVersions(ctx, fileSystem, logDir)
 	if err != nil {
@@ -34,50 +43,163 @@ func readDeltaSnapshot(ctx context.Context, client *adlsutil.DataLakeClient, fil
 		return &deltaSnapshot{exists: false}, nil
 	}
 
-	active := make(map[string]struct{})
+	active := make(map[string]bool)
 	order := make([]string, 0)
+	snapshot := &deltaSnapshot{exists: true, firstVersion: versions[0]}
 
 	for _, v := range versions {
 		data, err := client.Download(ctx, fileSystem, logDir+"/"+commitFileName(v))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read delta commit %d: %w", v, err)
 		}
-		for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
-			if strings.TrimSpace(line) == "" {
-				continue
-			}
-			var action struct {
-				Add    *struct{ Path string } `json:"add"`
-				Remove *struct{ Path string } `json:"remove"`
-			}
-			if err := json.Unmarshal([]byte(line), &action); err != nil {
-				return nil, fmt.Errorf("failed to parse delta commit %d: %w", v, err)
-			}
-			switch {
-			case action.Add != nil:
-				if _, ok := active[action.Add.Path]; !ok {
-					order = append(order, action.Add.Path)
-				}
-				active[action.Add.Path] = struct{}{}
-			case action.Remove != nil:
-				delete(active, action.Remove.Path)
-			}
+		if err := replayDeltaCommit(snapshot, active, &order, data); err != nil {
+			return nil, fmt.Errorf("failed to parse delta commit %d: %w", v, err)
 		}
 	}
 
 	files := make([]string, 0, len(active))
 	for _, p := range order {
-		if _, ok := active[p]; ok {
+		if deletionVector, ok := active[p]; ok {
 			files = append(files, p)
+			if deletionVector {
+				snapshot.deletionVectorFiles = append(snapshot.deletionVectorFiles, p)
+			}
 		}
 	}
 
-	return &deltaSnapshot{exists: true, version: versions[len(versions)-1], activeFiles: files}, nil
+	snapshot.version = versions[len(versions)-1]
+	snapshot.activeFiles = files
+	return snapshot, nil
+}
+
+// deltaMetadataCache is the result of an earlier metadata scan of a table's
+// log: the metaData and protocol actions that were in effect at version, and
+// the versions whose commits carried them. protocolVersion is -1 when the
+// scanned log carried no protocol action at all.
+type deltaMetadataCache struct {
+	version         int64
+	metadataVersion int64
+	protocolVersion int64
+	metadata        deltaMetadata
+}
+
+// readDeltaMetadata returns the table's latest version plus its metaData and
+// protocol actions without replaying the whole log. Both actions fully replace
+// their predecessor, so the newest commit that carries one wins and the scan
+// runs backwards. ingestr only emits them in the version-0 commit though, so on
+// an append-only table that scan still reaches version 0 — pass a cached result
+// to bound it to the commits appended since, which is what keeps the pipeline's
+// repeated schema lookups off the whole log.
+//
+// Skipping commits is only sound while the log is the same one the cache was
+// taken from, so the commits the cached actions came from are always re-read: a
+// table another writer dropped and recreated restarts its log, and its commit
+// at the cached metaData version carries different metadata, or none at all.
+func readDeltaMetadata(ctx context.Context, client dataLakeClient, fileSystem, tableDir string, cached *deltaMetadataCache) (*deltaSnapshot, error) {
+	logDir := tableDir + "/_delta_log"
+	versions, err := client.ListLogVersions(ctx, fileSystem, logDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(versions) == 0 {
+		return &deltaSnapshot{exists: false}, nil
+	}
+	latest := versions[len(versions)-1]
+	if cached != nil && (len(cached.metadata) == 0 || cached.version > latest) {
+		cached = nil
+	}
+
+	snapshot := &deltaSnapshot{exists: true, version: latest, firstVersion: versions[0]}
+	for i := len(versions) - 1; i >= 0; i-- {
+		version := versions[i]
+		if cached != nil && version <= cached.version && version != cached.metadataVersion && version != cached.protocolVersion {
+			// Delta commits are immutable, so this one held neither action when
+			// the cache entry was taken and still holds none.
+			continue
+		}
+		data, err := client.Download(ctx, fileSystem, logDir+"/"+commitFileName(version))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read delta commit %d: %w", version, err)
+		}
+		// The scan can continue past the newest metaData while it looks for the
+		// protocol action, so each commit replays into its own snapshot and the
+		// newest occurrence of each action wins.
+		var commit deltaSnapshot
+		if err := replayDeltaCommit(&commit, map[string]bool{}, &[]string{}, data); err != nil {
+			return nil, fmt.Errorf("failed to parse delta commit %d: %w", version, err)
+		}
+		if cached != nil && version == cached.metadataVersion && !sameDeltaMetadata(commit.metadata, cached.metadata) {
+			return readDeltaMetadata(ctx, client, fileSystem, tableDir, nil)
+		}
+		if len(snapshot.metadata) == 0 && len(commit.metadata) > 0 {
+			snapshot.metadata = commit.metadata
+			snapshot.metadataVersion = version
+		}
+		if snapshot.protocol == nil && commit.protocol != nil {
+			snapshot.protocol = commit.protocol
+			snapshot.protocolVersion = version
+		}
+		if len(snapshot.metadata) > 0 && snapshot.protocol != nil {
+			break
+		}
+	}
+	return snapshot, nil
+}
+
+func sameDeltaMetadata(left, right deltaMetadata) bool {
+	encodedLeft, err := json.Marshal(left)
+	if err != nil {
+		return false
+	}
+	encodedRight, err := json.Marshal(right)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(encodedLeft, encodedRight)
+}
+
+func replayDeltaCommit(snapshot *deltaSnapshot, active map[string]bool, order *[]string, data []byte) error {
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var action struct {
+			Add *struct {
+				Path           string          `json:"path"`
+				DeletionVector json.RawMessage `json:"deletionVector"`
+			} `json:"add"`
+			Remove   *struct{ Path string } `json:"remove"`
+			MetaData deltaMetadata          `json:"metaData"`
+			Protocol *deltaProtocol         `json:"protocol"`
+		}
+		if err := json.Unmarshal([]byte(line), &action); err != nil {
+			return err
+		}
+		switch {
+		case action.Add != nil:
+			if _, ok := active[action.Add.Path]; !ok {
+				*order = append(*order, action.Add.Path)
+			}
+			active[action.Add.Path] = jsonValuePresent(action.Add.DeletionVector)
+		case action.Remove != nil:
+			delete(active, action.Remove.Path)
+		case action.MetaData != nil:
+			snapshot.metadata = action.MetaData
+		case action.Protocol != nil:
+			snapshot.protocol = action.Protocol
+		}
+	}
+	return nil
+}
+
+func jsonValuePresent(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
 }
 
 // readDeltaData downloads and decodes all active data files of a Delta table into
 // Arrow record batches. The caller owns the returned batches and must Release them.
-func readDeltaData(ctx context.Context, client *adlsutil.DataLakeClient, fileSystem, tableDir string, files []string) ([]arrow.RecordBatch, error) {
+func readDeltaData(ctx context.Context, client dataLakeClient, fileSystem, tableDir string, files []string, tableSchema *deltaStruct) ([]arrow.RecordBatch, error) {
 	var batches []arrow.RecordBatch
 	for _, f := range files {
 		data, err := client.Download(ctx, fileSystem, tableDir+"/"+f)
@@ -92,7 +214,218 @@ func readDeltaData(ctx context.Context, client *adlsutil.DataLakeClient, fileSys
 		}
 		batches = append(batches, b...)
 	}
-	return batches, nil
+	aligned, err := alignDeltaBatches(batches, tableSchema)
+	if err != nil {
+		releaseBatches(batches)
+		return nil, err
+	}
+	releaseBatches(batches)
+	return aligned, nil
+}
+
+// alignDeltaBatches projects every Parquet file to the current Delta schema.
+// Older files can omit columns introduced by metadata-only evolution; those
+// values are materialized as NULL before copy-on-write strategies read them.
+func alignDeltaBatches(batches []arrow.RecordBatch, tableSchema *deltaStruct) ([]arrow.RecordBatch, error) {
+	if len(batches) == 0 {
+		return nil, nil
+	}
+	if tableSchema == nil {
+		return nil, fmt.Errorf("cannot align delta data without a table schema")
+	}
+
+	fields := make([]arrow.Field, 0, len(tableSchema.Fields))
+	for _, deltaField := range tableSchema.Fields {
+		column, columnErr := columnFromDeltaField(deltaField)
+		field, found := latestArrowField(batches, deltaField.Name)
+		switch {
+		case !found:
+			if columnErr != nil {
+				// A metadata-only ALTER TABLE can declare a column ingestr
+				// cannot map before any file carries it. There is nothing to
+				// materialize: the rewrite leaves the metaData action alone, so
+				// the column stays declared and readers keep NULL-filling it,
+				// the same way tableSchemaFromDelta keeps it out of the write
+				// schema.
+				config.Debug("[ONELAKE] Skipping delta column %q with no data that ingestr cannot map: %v", deltaField.Name, columnErr)
+				continue
+			}
+			// The fill is entirely NULL, so it has to be nullable no matter what
+			// the Delta schema declares.
+			field = arrow.Field{Type: schema.DataTypeToArrowType(column), Nullable: true}
+
+		case columnErr == nil && sameDeltaEncoding(field, deltaField.Type):
+			field.Type = schema.DataTypeToArrowType(column)
+			field.Nullable = field.Nullable || deltaField.Nullable
+
+		default:
+			field.Nullable = field.Nullable || deltaField.Nullable
+		}
+		field.Name = deltaField.Name
+		fields = append(fields, field)
+	}
+	target := arrow.NewSchema(fields, nil)
+
+	aligned := make([]arrow.RecordBatch, 0, len(batches))
+	for _, batch := range batches {
+		record, err := databuffer.CastRecordToSchema(batch, target, true)
+		if err != nil {
+			releaseBatches(aligned)
+			return nil, fmt.Errorf("failed to align delta data file to table schema: %w", err)
+		}
+		aligned = append(aligned, record)
+	}
+	return aligned, nil
+}
+
+// unifyRewriteBatches casts the target and staging batches to one Arrow schema.
+// A copy-on-write rewrite concatenates data written before and after a schema
+// evolution: on the target side an evolved column is a NULL fill typed from the
+// lossy Delta metadata and forced nullable, while on the staging side it still
+// carries the source's own Arrow type and nullability. declared is the target
+// table's Delta column list, or nil when the table does not exist yet. The
+// returned release function frees whatever this call allocated; the inputs stay
+// owned by the caller.
+func unifyRewriteBatches(target, staging []arrow.RecordBatch, declared []string) ([]arrow.RecordBatch, []arrow.RecordBatch, func(), error) {
+	noop := func() {}
+	if len(staging) == 0 {
+		return target, staging, noop, nil
+	}
+	// A rewrite commit carries no metaData action, so a staging column the table
+	// does not declare would be written into the data file and then ignored by
+	// every Delta reader. Fail instead of losing it silently — this is what a
+	// schema change that evolution could not apply looks like here.
+	if declared != nil {
+		if missing, ok := columnsNotIn(staging[0].Schema(), declared); !ok {
+			return nil, nil, noop, fmt.Errorf(
+				"cannot rewrite the table: column %q is not declared in its Delta schema (declared columns are %v)", missing, declared)
+		}
+	}
+	if len(target) == 0 {
+		return target, staging, noop, nil
+	}
+	unified, err := unifiedRewriteSchema(target, staging)
+	if err != nil {
+		return nil, nil, noop, err
+	}
+	if unified == nil {
+		return target, staging, noop, nil
+	}
+
+	castTarget, err := castBatchesToSchema(target, unified)
+	if err != nil {
+		return nil, nil, noop, err
+	}
+	castStaging, err := castBatchesToSchema(staging, unified)
+	if err != nil {
+		releaseBatches(castTarget)
+		return nil, nil, noop, err
+	}
+	return castTarget, castStaging, func() {
+		releaseBatches(castTarget)
+		releaseBatches(castStaging)
+	}, nil
+}
+
+// unifiedRewriteSchema returns the schema both sides should be cast to, nil when
+// they already agree, or an error when they genuinely conflict — a conflict must
+// fail the rewrite rather than be silently reconciled. Columns are matched by
+// name, not position: schema evolution appends a new column to the end of the
+// Delta schema while the ingest schema keeps its own ordering (SCD2, for
+// instance, always keeps the _scd_* columns last).
+func unifiedRewriteSchema(target, staging []arrow.RecordBatch) (*arrow.Schema, error) {
+	targetSchema := target[0].Schema()
+	stagingSchema := staging[0].Schema()
+	if missing, ok := columnsNotIn(stagingSchema, arrowFieldNames(targetSchema)); !ok {
+		return nil, fmt.Errorf("cannot rewrite the table: column %q is missing from its data files (columns are %v)",
+			missing, arrowFieldNames(targetSchema))
+	}
+
+	fields := make([]arrow.Field, targetSchema.NumFields())
+	for i := 0; i < targetSchema.NumFields(); i++ {
+		field := targetSchema.Field(i)
+		index, ok := fieldIndex(stagingSchema, field.Name)
+		if !ok {
+			// A column the source dropped is kept and relaxed to nullable, so
+			// the incoming rows get a NULL fill for it. If the table still
+			// declares it NOT NULL — evolution was skipped or the contract is
+			// not "evolve" — filling it would break that declaration.
+			if !field.Nullable {
+				return nil, fmt.Errorf(
+					"cannot rewrite the table: column %q is required but the incoming rows do not have it", field.Name)
+			}
+			fields[i] = field
+			continue
+		}
+		other := stagingSchema.Field(index)
+		if !arrow.TypeEqual(field.Type, other.Type) {
+			return nil, fmt.Errorf("cannot rewrite the table: column %q is %s in the table and %s in the incoming rows",
+				field.Name, field.Type, other.Type)
+		}
+		if other.Nullable {
+			field.Nullable = true
+		}
+		fields[i] = field
+	}
+
+	unified := arrow.NewSchema(fields, nil)
+	if schemaEqualIgnoringMetadata(unified, targetSchema) && schemaEqualIgnoringMetadata(unified, stagingSchema) {
+		return nil, nil
+	}
+	return unified, nil
+}
+
+// columnsNotIn returns the first column of s that names is missing, if any.
+func columnsNotIn(s *arrow.Schema, names []string) (string, bool) {
+	for i := 0; i < s.NumFields(); i++ {
+		name := s.Field(i).Name
+		if !slices.ContainsFunc(names, func(other string) bool { return strings.EqualFold(name, other) }) {
+			return name, false
+		}
+	}
+	return "", true
+}
+
+func castBatchesToSchema(batches []arrow.RecordBatch, target *arrow.Schema) ([]arrow.RecordBatch, error) {
+	out := make([]arrow.RecordBatch, 0, len(batches))
+	for _, batch := range batches {
+		record, err := databuffer.CastRecordToSchema(batch, target, true)
+		if err != nil {
+			releaseBatches(out)
+			return nil, fmt.Errorf("failed to reconcile target and staging schemas during rewrite: %w", err)
+		}
+		out = append(out, record)
+	}
+	return out, nil
+}
+
+// sameDeltaEncoding reports whether an Arrow field found in a data file encodes
+// the Delta type the table schema declares. Delta has no naive timestamp, TIME
+// or JSON type, so one Delta type covers several Arrow types and files written
+// by different generations of the same table disagree on which one they used.
+// Re-deriving the Arrow type from the Delta type puts them back in step.
+func sameDeltaEncoding(field arrow.Field, deltaType any) bool {
+	fileType, err := json.Marshal(deltaTypeFor(arrowFieldToColumn(field)))
+	if err != nil {
+		return false
+	}
+	declared, err := json.Marshal(deltaType)
+	if err != nil {
+		return false
+	}
+	return string(fileType) == string(declared)
+}
+
+func latestArrowField(batches []arrow.RecordBatch, name string) (arrow.Field, bool) {
+	for i := len(batches) - 1; i >= 0; i-- {
+		batchSchema := batches[i].Schema()
+		for j := 0; j < batchSchema.NumFields(); j++ {
+			if strings.EqualFold(batchSchema.Field(j).Name, name) {
+				return batchSchema.Field(j), true
+			}
+		}
+	}
+	return arrow.Field{}, false
 }
 
 // readParquetBytes decodes Parquet bytes into Arrow record batches.

--- a/pkg/destination/onelake/delta_io.go
+++ b/pkg/destination/onelake/delta_io.go
@@ -29,6 +29,7 @@ type deltaSnapshot struct {
 	metadataVersion     int64 // version of the commit metadata was read from
 	protocol            *deltaProtocol
 	protocolVersion     int64 // version of the commit protocol was read from
+	logETags            map[int64]string
 }
 
 // readDeltaSnapshot replays the Delta transaction log under tableDir and returns
@@ -81,6 +82,7 @@ type deltaMetadataCache struct {
 	metadataVersion int64
 	protocolVersion int64
 	metadata        deltaMetadata
+	logETags        map[int64]string
 }
 
 // readDeltaMetadata returns the table's latest version plus its metaData and
@@ -92,24 +94,30 @@ type deltaMetadataCache struct {
 // repeated schema lookups off the whole log.
 //
 // Skipping commits is only sound while the log is the same one the cache was
-// taken from, so the commits the cached actions came from are always re-read: a
-// table another writer dropped and recreated restarts its log, and its commit
-// at the cached metaData version carries different metadata, or none at all.
+// taken from. The listing ETags verify every previously-scanned commit, and the
+// commits carrying the cached actions are also re-read before their values are
+// used.
 func readDeltaMetadata(ctx context.Context, client dataLakeClient, fileSystem, tableDir string, cached *deltaMetadataCache) (*deltaSnapshot, error) {
 	logDir := tableDir + "/_delta_log"
-	versions, err := client.ListLogVersions(ctx, fileSystem, logDir)
+	entries, err := client.ListLogEntries(ctx, fileSystem, logDir)
 	if err != nil {
 		return nil, err
+	}
+	versions := make([]int64, len(entries))
+	logETags := make(map[int64]string, len(entries))
+	for i, entry := range entries {
+		versions[i] = entry.Version
+		logETags[entry.Version] = entry.ETag
 	}
 	if len(versions) == 0 {
 		return &deltaSnapshot{exists: false}, nil
 	}
 	latest := versions[len(versions)-1]
-	if cached != nil && (len(cached.metadata) == 0 || cached.version > latest) {
+	if cached != nil && (len(cached.metadata) == 0 || cached.version > latest || !sameCachedDeltaLog(cached, logETags)) {
 		cached = nil
 	}
 
-	snapshot := &deltaSnapshot{exists: true, version: latest, firstVersion: versions[0]}
+	snapshot := &deltaSnapshot{exists: true, version: latest, firstVersion: versions[0], logETags: logETags}
 	for i := len(versions) - 1; i >= 0; i-- {
 		version := versions[i]
 		if cached != nil && version <= cached.version && version != cached.metadataVersion && version != cached.protocolVersion {
@@ -144,6 +152,29 @@ func readDeltaMetadata(ctx context.Context, client dataLakeClient, fileSystem, t
 		}
 	}
 	return snapshot, nil
+}
+
+func sameCachedDeltaLog(cached *deltaMetadataCache, current map[int64]string) bool {
+	if len(cached.logETags) == 0 {
+		return false
+	}
+	for version, etag := range cached.logETags {
+		if version > cached.version {
+			continue
+		}
+		if etag == "" || current[version] != etag {
+			return false
+		}
+	}
+	for version, etag := range current {
+		if version > cached.version {
+			continue
+		}
+		if etag == "" || cached.logETags[version] != etag {
+			return false
+		}
+	}
+	return true
 }
 
 func sameDeltaMetadata(left, right deltaMetadata) bool {

--- a/pkg/destination/onelake/delta_io.go
+++ b/pkg/destination/onelake/delta_io.go
@@ -314,10 +314,10 @@ func alignDeltaBatches(batches []arrow.RecordBatch, tableSchema *deltaStruct) ([
 // evolution: on the target side an evolved column is a NULL fill typed from the
 // lossy Delta metadata and forced nullable, while on the staging side it still
 // carries the source's own Arrow type and nullability. declared is the target
-// table's Delta column list, or nil when the table does not exist yet. The
+// table's Delta schema, or nil when the table does not exist yet. The
 // returned release function frees whatever this call allocated; the inputs stay
 // owned by the caller.
-func unifyRewriteBatches(target, staging []arrow.RecordBatch, declared []string) ([]arrow.RecordBatch, []arrow.RecordBatch, func(), error) {
+func unifyRewriteBatches(target, staging []arrow.RecordBatch, declared *deltaStruct) ([]arrow.RecordBatch, []arrow.RecordBatch, func(), error) {
 	noop := func() {}
 	if len(staging) == 0 {
 		return target, staging, noop, nil
@@ -327,15 +327,26 @@ func unifyRewriteBatches(target, staging []arrow.RecordBatch, declared []string)
 	// every Delta reader. Fail instead of losing it silently — this is what a
 	// schema change that evolution could not apply looks like here.
 	if declared != nil {
-		if missing, ok := columnsNotIn(staging[0].Schema(), declared); !ok {
+		if missing, ok := columnsNotIn(staging[0].Schema(), deltaFieldNames(declared)); !ok {
 			return nil, nil, noop, fmt.Errorf(
-				"cannot rewrite the table: column %q is not declared in its Delta schema (declared columns are %v)", missing, declared)
+				"cannot rewrite the table: column %q is not declared in its Delta schema (declared columns are %v)", missing, deltaFieldNames(declared))
 		}
 	}
 	if len(target) == 0 {
-		return target, staging, noop, nil
+		unified, err := rewriteSchemaFromDelta(declared, staging[0].Schema())
+		if err != nil {
+			return nil, nil, noop, err
+		}
+		if unified == nil {
+			return target, staging, noop, nil
+		}
+		castStaging, err := castBatchesToSchema(staging, unified)
+		if err != nil {
+			return nil, nil, noop, err
+		}
+		return target, castStaging, func() { releaseBatches(castStaging) }, nil
 	}
-	unified, err := unifiedRewriteSchema(target, staging)
+	unified, err := unifiedRewriteSchema(target, staging, declared)
 	if err != nil {
 		return nil, nil, noop, err
 	}
@@ -364,7 +375,7 @@ func unifyRewriteBatches(target, staging []arrow.RecordBatch, declared []string)
 // name, not position: schema evolution appends a new column to the end of the
 // Delta schema while the ingest schema keeps its own ordering (SCD2, for
 // instance, always keeps the _scd_* columns last).
-func unifiedRewriteSchema(target, staging []arrow.RecordBatch) (*arrow.Schema, error) {
+func unifiedRewriteSchema(target, staging []arrow.RecordBatch, declared *deltaStruct) (*arrow.Schema, error) {
 	targetSchema := target[0].Schema()
 	stagingSchema := staging[0].Schema()
 	if missing, ok := columnsNotIn(stagingSchema, arrowFieldNames(targetSchema)); !ok {
@@ -390,8 +401,19 @@ func unifiedRewriteSchema(target, staging []arrow.RecordBatch) (*arrow.Schema, e
 		}
 		other := stagingSchema.Field(index)
 		if !arrow.TypeEqual(field.Type, other.Type) {
-			return nil, fmt.Errorf("cannot rewrite the table: column %q is %s in the table and %s in the incoming rows",
-				field.Name, field.Type, other.Type)
+			deltaIndex := -1
+			if declared != nil {
+				deltaIndex = deltaFieldIndex(declared.Fields, field.Name)
+			}
+			if deltaIndex < 0 || !sameDeltaEncoding(field, declared.Fields[deltaIndex].Type) || !sameDeltaEncoding(other, declared.Fields[deltaIndex].Type) {
+				return nil, fmt.Errorf("cannot rewrite the table: column %q is %s in the table and %s in the incoming rows",
+					field.Name, field.Type, other.Type)
+			}
+			column, err := columnFromDeltaField(declared.Fields[deltaIndex])
+			if err != nil {
+				return nil, fmt.Errorf("cannot reconcile column %q with its Delta type: %w", field.Name, err)
+			}
+			field.Type = schema.DataTypeToArrowType(column)
 		}
 		if other.Nullable {
 			field.Nullable = true
@@ -404,6 +426,56 @@ func unifiedRewriteSchema(target, staging []arrow.RecordBatch) (*arrow.Schema, e
 		return nil, nil
 	}
 	return unified, nil
+}
+
+func rewriteSchemaFromDelta(declared *deltaStruct, staging *arrow.Schema) (*arrow.Schema, error) {
+	if declared == nil {
+		return nil, nil
+	}
+	fields := make([]arrow.Field, 0, len(declared.Fields))
+	for _, deltaField := range declared.Fields {
+		index, found := fieldIndex(staging, deltaField.Name)
+		column, err := columnFromDeltaField(deltaField)
+		if err != nil {
+			if found {
+				return nil, fmt.Errorf("cannot rewrite the table: column %q has an unsupported declared Delta type: %w", deltaField.Name, err)
+			}
+			if !deltaField.Nullable {
+				return nil, fmt.Errorf("cannot rewrite the table: column %q is required but the incoming rows do not have it", deltaField.Name)
+			}
+			continue
+		}
+		field := arrow.Field{Name: deltaField.Name, Type: schema.DataTypeToArrowType(column), Nullable: deltaField.Nullable}
+		if !found {
+			if !deltaField.Nullable {
+				return nil, fmt.Errorf("cannot rewrite the table: column %q is required but the incoming rows do not have it", deltaField.Name)
+			}
+		} else {
+			incoming := staging.Field(index)
+			if !sameDeltaEncoding(incoming, deltaField.Type) {
+				return nil, fmt.Errorf("cannot rewrite the table: column %q is Delta %s in the table and %s in the incoming rows",
+					deltaField.Name, describeDeltaType(deltaField.Type), incoming.Type)
+			}
+			field.Nullable = field.Nullable || incoming.Nullable
+		}
+		fields = append(fields, field)
+	}
+	unified := arrow.NewSchema(fields, nil)
+	if schemaEqualIgnoringMetadata(unified, staging) {
+		return nil, nil
+	}
+	return unified, nil
+}
+
+func deltaFieldNames(deltaSchema *deltaStruct) []string {
+	if deltaSchema == nil {
+		return nil
+	}
+	names := make([]string, len(deltaSchema.Fields))
+	for i, field := range deltaSchema.Fields {
+		names[i] = field.Name
+	}
+	return names
 }
 
 // columnsNotIn returns the first column of s that names is missing, if any.

--- a/pkg/destination/onelake/evolve.go
+++ b/pkg/destination/onelake/evolve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"regexp"
 	"strconv"
 	"strings"
@@ -28,7 +29,16 @@ func deltaSchemaFromMetadata(metadata deltaMetadata) (*deltaStruct, error) {
 	}
 
 	var result deltaStruct
-	if err := json.Unmarshal([]byte(schemaString), &result); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(schemaString))
+	decoder.UseNumber()
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode delta table schema: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("failed to decode delta table schema: multiple JSON values")
+		}
 		return nil, fmt.Errorf("failed to decode delta table schema: %w", err)
 	}
 	if !strings.EqualFold(result.Type, "struct") {
@@ -504,6 +514,9 @@ func (d *OneLakeDestination) ApplySchemaEvolution(ctx context.Context, table str
 	if err != nil {
 		return nil, err
 	}
+	d.metaMu.Lock()
+	expectedMetadata := d.metaCache[tableDir].metadata
+	d.metaMu.Unlock()
 
 	var lastConflict error
 	for range maxDeltaCommitAttempts {
@@ -513,6 +526,11 @@ func (d *OneLakeDestination) ApplySchemaEvolution(ctx context.Context, table str
 		}
 		if !snapshot.exists || len(snapshot.metadata) == 0 {
 			return nil, nil
+		}
+		if len(expectedMetadata) == 0 {
+			expectedMetadata = snapshot.metadata
+		} else if !sameDeltaMetadata(snapshot.metadata, expectedMetadata) {
+			return nil, fmt.Errorf("OneLake table metadata changed after its schema evolution plan was built; retry the load against the current table schema")
 		}
 		if err := checkSupportedDeltaProtocol(snapshot.protocol, "schema evolution"); err != nil {
 			return nil, err

--- a/pkg/destination/onelake/evolve.go
+++ b/pkg/destination/onelake/evolve.go
@@ -1,0 +1,550 @@
+package onelake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+)
+
+var deltaDecimalTypePattern = regexp.MustCompile(`(?i)^decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
+
+func deltaSchemaFromMetadata(metadata deltaMetadata) (*deltaStruct, error) {
+	raw, ok := metadata["schemaString"]
+	if !ok {
+		return nil, errors.New("delta metadata is missing schemaString")
+	}
+	var schemaString string
+	if err := json.Unmarshal(raw, &schemaString); err != nil {
+		return nil, fmt.Errorf("failed to decode delta schemaString: %w", err)
+	}
+
+	var result deltaStruct
+	if err := json.Unmarshal([]byte(schemaString), &result); err != nil {
+		return nil, fmt.Errorf("failed to decode delta table schema: %w", err)
+	}
+	if !strings.EqualFold(result.Type, "struct") {
+		return nil, fmt.Errorf("unsupported delta root schema type %q", result.Type)
+	}
+	for i := range result.Fields {
+		// The Delta protocol requires every field to carry a metadata object.
+		// Writers are free to omit it, and re-encoding a nil map would commit
+		// the field back as "metadata":null, which readers reject.
+		if result.Fields[i].Metadata == nil {
+			result.Fields[i].Metadata = map[string]any{}
+		}
+	}
+	return &result, nil
+}
+
+func deltaMetadataWithSchema(metadata deltaMetadata, tableSchema *deltaStruct) (deltaMetadata, error) {
+	if len(metadata) == 0 {
+		return nil, errors.New("delta metadata is empty")
+	}
+	schemaBytes, err := json.Marshal(tableSchema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode delta table schema: %w", err)
+	}
+	schemaString, err := json.Marshal(string(schemaBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode delta schemaString: %w", err)
+	}
+
+	result := make(deltaMetadata, len(metadata))
+	for key, value := range metadata {
+		result[key] = append(json.RawMessage(nil), value...)
+	}
+	result["schemaString"] = schemaString
+	return result, nil
+}
+
+// deltaConfiguration returns the table's configuration map. It is optional in
+// the Delta metaData action, and an absent one unambiguously means no table
+// properties are set.
+func deltaConfiguration(metadata deltaMetadata) (map[string]string, error) {
+	raw, ok := metadata["configuration"]
+	if !ok {
+		return nil, nil
+	}
+	var configuration map[string]string
+	if err := json.Unmarshal(raw, &configuration); err != nil {
+		return nil, fmt.Errorf("failed to decode delta table configuration: %w", err)
+	}
+	return configuration, nil
+}
+
+// deltaColumnMappingMode reports the table's delta.columnMapping.mode.
+func deltaColumnMappingMode(metadata deltaMetadata) (string, error) {
+	configuration, err := deltaConfiguration(metadata)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(strings.TrimSpace(configuration["delta.columnMapping.mode"])), nil
+}
+
+// deltaPartitionColumns returns the table's partition columns. Their values are
+// stored in the log's partitionValues rather than in the Parquet files, so any
+// code that projects a data file onto the table schema has to know about them.
+func deltaPartitionColumns(metadata deltaMetadata) ([]string, error) {
+	raw, ok := metadata["partitionColumns"]
+	if !ok {
+		return nil, nil
+	}
+	var columns []string
+	if err := json.Unmarshal(raw, &columns); err != nil {
+		return nil, fmt.Errorf("failed to decode delta partition columns: %w", err)
+	}
+	return columns, nil
+}
+
+const (
+	maxSupportedDeltaReaderVersion = 3
+	maxSupportedDeltaWriterVersion = 7
+)
+
+// Table features (lowercased) whose presence in the protocol action is
+// compatible with how ingestr reads and rewrites a table. Features that only
+// matter when actually in use — deletion vectors on active files, a column
+// mapping mode other than none, constraints or generated columns declared in
+// the metadata — are allowed here and rejected by the in-use checks below.
+var (
+	supportedDeltaReaderFeatures = map[string]struct{}{
+		"columnmapping":       {},
+		"deletionvectors":     {},
+		"timestampntz":        {},
+		"v2checkpoint":        {},
+		"vacuumprotocolcheck": {},
+	}
+	supportedDeltaWriterFeatures = map[string]struct{}{
+		"appendonly":          {},
+		"changedatafeed":      {},
+		"checkconstraints":    {},
+		"clustering":          {},
+		"columnmapping":       {},
+		"deletionvectors":     {},
+		"domainmetadata":      {},
+		"generatedcolumns":    {},
+		"identitycolumns":     {},
+		"invariants":          {},
+		"timestampntz":        {},
+		"v2checkpoint":        {},
+		"vacuumprotocolcheck": {},
+	}
+)
+
+// checkSupportedDeltaProtocol rejects tables that require reader or writer
+// capabilities ingestr does not have. Ignoring the protocol action and writing
+// anyway is how deleted rows come back or table guarantees get broken, so an
+// unknown version or feature has to fail the operation.
+func checkSupportedDeltaProtocol(protocol *deltaProtocol, op string) error {
+	if protocol == nil {
+		return fmt.Errorf("the delta log carries no protocol action, so %s cannot verify the table features it requires; the log may have been truncated", op)
+	}
+	if protocol.MinReaderVersion > maxSupportedDeltaReaderVersion || protocol.MinWriterVersion > maxSupportedDeltaWriterVersion {
+		return fmt.Errorf("the table requires delta reader version %d and writer version %d, which OneLake does not support for %s",
+			protocol.MinReaderVersion, protocol.MinWriterVersion, op)
+	}
+	for _, feature := range protocol.ReaderFeatures {
+		if _, ok := supportedDeltaReaderFeatures[strings.ToLower(feature)]; !ok {
+			return fmt.Errorf("the table requires the delta reader feature %q, which OneLake does not support for %s", feature, op)
+		}
+	}
+	for _, feature := range protocol.WriterFeatures {
+		if _, ok := supportedDeltaWriterFeatures[strings.ToLower(feature)]; !ok {
+			return fmt.Errorf("the table requires the delta writer feature %q, which OneLake does not support for %s", feature, op)
+		}
+	}
+	return nil
+}
+
+// checkRewritableDeltaTable rejects tables a copy-on-write rewrite would
+// corrupt rather than fail on: files with deletion vectors would have their
+// deleted rows resurrected, column mapping renames the physical columns and
+// partition columns are not stored in the files at all (both of which would
+// replace real values with NULLs), and append-only, change-data-feed,
+// constraint, invariant, generated and identity columns all promise readers
+// guarantees a plain remove-and-add commit does not keep.
+func checkRewritableDeltaTable(snap *deltaSnapshot, tableSchema *deltaStruct, op string) error {
+	if err := checkSupportedDeltaProtocol(snap.protocol, op); err != nil {
+		return err
+	}
+	if snap.firstVersion != 0 {
+		// Log cleanup removes commits already covered by a checkpoint, which
+		// ingestr does not read, so the replayed set of active data files is
+		// incomplete and the rewrite would leave the checkpoint-era files live
+		// next to its own output.
+		return fmt.Errorf("%s rewrites the table from its transaction log, but the log has been truncated (its oldest commit is %d, not 0), so the active data files cannot be reconstructed", op, snap.firstVersion)
+	}
+	if len(snap.deletionVectorFiles) > 0 {
+		return fmt.Errorf("%s rewrites the table, which OneLake does not support while data file %q carries a deletion vector (rewriting it would restore its deleted rows)",
+			op, snap.deletionVectorFiles[0])
+	}
+
+	configuration, err := deltaConfiguration(snap.metadata)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s table configuration: %w", op, err)
+	}
+	if mode := strings.ToLower(strings.TrimSpace(configuration["delta.columnMapping.mode"])); mode != "" && mode != "none" {
+		return fmt.Errorf("%s rewrites the table, which OneLake does not support for Delta column mapping mode %q", op, mode)
+	}
+	partitionColumns, err := deltaPartitionColumns(snap.metadata)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s table configuration: %w", op, err)
+	}
+	if len(partitionColumns) > 0 {
+		return fmt.Errorf("%s rewrites the table, which OneLake does not support for the partitioned Delta table (partition columns %v)", op, partitionColumns)
+	}
+
+	if strings.EqualFold(configuration["delta.appendOnly"], "true") {
+		return fmt.Errorf("%s rewrites the table, which OneLake does not support for an append-only Delta table (delta.appendOnly is true)", op)
+	}
+	if strings.EqualFold(configuration["delta.enableChangeDataFeed"], "true") {
+		return fmt.Errorf("%s rewrites the table without writing the change data files delta.enableChangeDataFeed promises its readers, which OneLake does not support", op)
+	}
+	for key := range configuration {
+		if strings.HasPrefix(strings.ToLower(key), "delta.constraints.") {
+			return fmt.Errorf("%s writes rows without enforcing the table's CHECK constraint %q, which OneLake does not support", op, key)
+		}
+	}
+	for _, field := range tableSchema.Fields {
+		for key := range field.Metadata {
+			switch lowered := strings.ToLower(key); {
+			case lowered == "delta.invariants":
+				return fmt.Errorf("%s writes rows without enforcing the invariant on column %q, which OneLake does not support", op, field.Name)
+			case lowered == "delta.generationexpression":
+				return fmt.Errorf("%s writes rows without computing the generated column %q, which OneLake does not support", op, field.Name)
+			case strings.HasPrefix(lowered, "delta.identity."):
+				return fmt.Errorf("%s writes rows without maintaining the identity column %q, which OneLake does not support", op, field.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func tableSchemaFromDelta(table string, deltaSchema *deltaStruct) (*schema.TableSchema, error) {
+	if deltaSchema == nil {
+		return nil, errors.New("delta schema is nil")
+	}
+	columns := make([]schema.Column, 0, len(deltaSchema.Fields))
+	seen := make(map[string]struct{}, len(deltaSchema.Fields))
+	for _, field := range deltaSchema.Fields {
+		name := strings.ToLower(field.Name)
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("delta schema contains duplicate column %q", field.Name)
+		}
+		seen[name] = struct{}{}
+
+		column, err := columnFromDeltaField(field)
+		if err != nil {
+			// Tables authored by Fabric or Spark can contain Delta types ingestr
+			// has no equivalent for (structs, maps, nested arrays). Omitting them
+			// keeps the rest of the table evolvable without carrying the column
+			// into the write schema, where it would be materialized with the
+			// wrong physical type; appended files simply leave it out and Delta
+			// readers fill NULL. A source column colliding with an omitted one
+			// still fails loudly in evolveDeltaMetadata, which checks the raw
+			// Delta fields.
+			config.Debug("[ONELAKE] Skipping delta column %q ingestr cannot map: %v", field.Name, err)
+			continue
+		}
+		columns = append(columns, column)
+	}
+	return &schema.TableSchema{Name: table, Columns: columns}, nil
+}
+
+func columnFromDeltaField(field deltaField) (schema.Column, error) {
+	column := schema.Column{Name: field.Name, Nullable: field.Nullable}
+	if err := applyDeltaType(&column, field.Type, false); err != nil {
+		return schema.Column{}, err
+	}
+	return column, nil
+}
+
+func applyDeltaType(column *schema.Column, deltaType any, arrayElement bool) error {
+	if typeName, ok := deltaType.(string); ok {
+		dataType, precision, scale, err := primitiveDeltaType(typeName)
+		if err != nil {
+			return err
+		}
+		if arrayElement {
+			column.ArrayType = dataType
+		} else {
+			column.DataType = dataType
+		}
+		column.Precision = precision
+		column.Scale = scale
+		return nil
+	}
+
+	typeBytes, err := json.Marshal(deltaType)
+	if err != nil {
+		return fmt.Errorf("failed to inspect delta type: %w", err)
+	}
+	var complexType struct {
+		Type        string `json:"type"`
+		ElementType any    `json:"elementType"`
+	}
+	if err := json.Unmarshal(typeBytes, &complexType); err != nil {
+		return fmt.Errorf("failed to decode delta type: %w", err)
+	}
+	if !strings.EqualFold(complexType.Type, "array") || arrayElement {
+		return fmt.Errorf("unsupported delta type %s", string(typeBytes))
+	}
+	column.DataType = schema.TypeArray
+	if err := applyDeltaType(column, complexType.ElementType, true); err != nil {
+		return fmt.Errorf("unsupported delta array element: %w", err)
+	}
+	return nil
+}
+
+func primitiveDeltaType(typeName string) (schema.DataType, int, int, error) {
+	switch strings.ToLower(strings.TrimSpace(typeName)) {
+	case "boolean":
+		return schema.TypeBoolean, 0, 0, nil
+	case "byte":
+		return schema.TypeInt8, 0, 0, nil
+	case "short":
+		return schema.TypeInt16, 0, 0, nil
+	case "integer", "int":
+		return schema.TypeInt32, 0, 0, nil
+	case "long":
+		return schema.TypeInt64, 0, 0, nil
+	case "float":
+		return schema.TypeFloat32, 0, 0, nil
+	case "double":
+		return schema.TypeFloat64, 0, 0, nil
+	case "string":
+		return schema.TypeString, 0, 0, nil
+	case "binary":
+		return schema.TypeBinary, 0, 0, nil
+	case "date":
+		return schema.TypeDate, 0, 0, nil
+	case "timestamp":
+		return schema.TypeTimestampTZ, 0, 0, nil
+	case "timestamp_ntz":
+		return schema.TypeTimestamp, 0, 0, nil
+	}
+
+	matches := deltaDecimalTypePattern.FindStringSubmatch(typeName)
+	if len(matches) == 3 {
+		precision, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return schema.TypeUnknown, 0, 0, fmt.Errorf("invalid delta decimal precision %q", matches[1])
+		}
+		scale, err := strconv.Atoi(matches[2])
+		if err != nil {
+			return schema.TypeUnknown, 0, 0, fmt.Errorf("invalid delta decimal scale %q", matches[2])
+		}
+		return schema.TypeDecimal, precision, scale, nil
+	}
+	return schema.TypeUnknown, 0, 0, fmt.Errorf("unsupported delta type %q", typeName)
+}
+
+func (*OneLakeDestination) NormalizeSchemaEvolutionColumn(column schema.Column) schema.Column {
+	return normalizeSchemaEvolutionColumn(column)
+}
+
+func normalizeSchemaEvolutionColumn(column schema.Column) schema.Column {
+	column.MaxLength = 0
+	if column.DataType == schema.TypeArray {
+		column.ArrayType = normalizeOneLakeType(column.ArrayType)
+		return column
+	}
+	column.DataType = normalizeOneLakeType(column.DataType)
+	return column
+}
+
+func normalizeOneLakeType(dataType schema.DataType) schema.DataType {
+	switch dataType {
+	case schema.TypeUUID, schema.TypeJSON:
+		return schema.TypeString
+	case schema.TypeTime:
+		return schema.TypeInt64
+	case schema.TypeTimestamp:
+		return schema.TypeTimestampTZ
+	default:
+		return dataType
+	}
+}
+
+func evolveDeltaMetadata(metadata deltaMetadata, comparison *schemaevolution.SchemaComparison) (deltaMetadata, bool, error) {
+	if comparison == nil || !comparison.HasChanges {
+		return metadata, false, nil
+	}
+	mappingMode, err := deltaColumnMappingMode(metadata)
+	if err != nil {
+		return nil, false, err
+	}
+	if mappingMode != "" && mappingMode != "none" {
+		return nil, false, fmt.Errorf("OneLake schema evolution does not support Delta column mapping mode %q", mappingMode)
+	}
+
+	deltaSchema, err := deltaSchemaFromMetadata(metadata)
+	if err != nil {
+		return nil, false, err
+	}
+	changed := false
+	for _, change := range comparison.Changes {
+		switch change.Type {
+		case schemaevolution.ChangeAddColumn:
+			index := deltaFieldIndex(deltaSchema.Fields, change.ColumnName)
+			if index >= 0 {
+				existing, err := columnFromDeltaField(deltaSchema.Fields[index])
+				if err != nil {
+					return nil, false, fmt.Errorf("column %q: %w", change.ColumnName, err)
+				}
+				if !sameOneLakePhysicalType(existing, change.NewColumn) {
+					return nil, false, fmt.Errorf(
+						"cannot add column %q because the table already has it as Delta %s, not %s",
+						change.ColumnName, describeDeltaType(deltaSchema.Fields[index].Type), describeDeltaType(deltaTypeFor(change.NewColumn)),
+					)
+				}
+				continue
+			}
+			newColumn := change.NewColumn
+			newColumn.Nullable = true
+			deltaSchema.Fields = append(deltaSchema.Fields, deltaField{
+				Name: newColumn.Name, Type: deltaTypeFor(newColumn), Nullable: true, Metadata: map[string]any{},
+			})
+			changed = true
+
+		case schemaevolution.ChangeRelaxNullability, schemaevolution.ChangeRemoveColumn:
+			index := deltaFieldIndex(deltaSchema.Fields, change.ColumnName)
+			if index >= 0 && !deltaSchema.Fields[index].Nullable {
+				deltaSchema.Fields[index].Nullable = true
+				changed = true
+			}
+
+		case schemaevolution.ChangeWidenType, schemaevolution.ChangeOverrideType:
+			if change.OldColumn == nil || !sameOneLakePhysicalType(*change.OldColumn, change.NewColumn) {
+				// Report the type the table actually declares: deltaTypeFor
+				// renders columns ingestr could not map as "string", which would
+				// make the message read "from string to string".
+				oldType := "unknown"
+				if index := deltaFieldIndex(deltaSchema.Fields, change.ColumnName); index >= 0 {
+					oldType = describeDeltaType(deltaSchema.Fields[index].Type)
+				} else if change.OldColumn != nil {
+					oldType = describeDeltaType(deltaTypeFor(*change.OldColumn))
+				}
+				return nil, false, fmt.Errorf(
+					"column %q requires changing its Delta type from %s to %s, which OneLake does not support; recreate the table or pin the column type with --columns",
+					change.ColumnName, oldType, describeDeltaType(deltaTypeFor(change.NewColumn)),
+				)
+			}
+		}
+	}
+	if !changed {
+		return metadata, false, nil
+	}
+
+	updated, err := deltaMetadataWithSchema(metadata, deltaSchema)
+	if err != nil {
+		return nil, false, err
+	}
+	return updated, true, nil
+}
+
+// describeDeltaType renders a Delta type the way the table's schemaString
+// carries it. Complex types are decoded JSON objects, which %v would print as
+// Go map syntax.
+func describeDeltaType(deltaType any) string {
+	if name, ok := deltaType.(string); ok {
+		return name
+	}
+	encoded, err := json.Marshal(deltaType)
+	if err != nil {
+		return fmt.Sprintf("%v", deltaType)
+	}
+	return string(encoded)
+}
+
+func deltaFieldIndex(fields []deltaField, name string) int {
+	for i := range fields {
+		if strings.EqualFold(fields[i].Name, name) {
+			return i
+		}
+	}
+	return -1
+}
+
+func sameOneLakePhysicalType(left, right schema.Column) bool {
+	// deltaTypeFor falls back to "string" for anything it does not recognize,
+	// which would make an unknown column look compatible with every string
+	// column, so refuse to judge unknown columns here.
+	if left.DataType == schema.TypeUnknown || right.DataType == schema.TypeUnknown {
+		return false
+	}
+	leftType, err := json.Marshal(deltaTypeFor(left))
+	if err != nil {
+		return false
+	}
+	rightType, err := json.Marshal(deltaTypeFor(right))
+	if err != nil {
+		return false
+	}
+	return string(leftType) == string(rightType)
+}
+
+func (d *OneLakeDestination) ApplySchemaEvolution(ctx context.Context, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
+	if comparison == nil || !comparison.HasChanges {
+		return nil, nil
+	}
+	if d.client == nil {
+		return nil, errors.New("OneLake destination is not connected")
+	}
+	tableDir, err := d.tableDirForTables(table, "schema evolution")
+	if err != nil {
+		return nil, err
+	}
+
+	var lastConflict error
+	for range maxDeltaCommitAttempts {
+		snapshot, err := d.readTableMetadata(ctx, tableDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read OneLake table schema: %w", err)
+		}
+		if !snapshot.exists || len(snapshot.metadata) == 0 {
+			return nil, nil
+		}
+		if err := checkSupportedDeltaProtocol(snapshot.protocol, "schema evolution"); err != nil {
+			return nil, err
+		}
+
+		metadata, changed, err := evolveDeltaMetadata(snapshot.metadata, comparison)
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return nil, nil
+		}
+		commit, err := buildSchemaEvolutionCommit(metadata, time.Now().UnixMilli())
+		if err != nil {
+			return nil, err
+		}
+		version := snapshot.version + 1
+		if err := d.uploadDeltaCommit(ctx, tableDir+"/_delta_log", version, commit); err != nil {
+			if errors.Is(err, errDeltaCommitConflict) {
+				lastConflict = err
+				config.Debug("[ONELAKE] Delta commit conflict during schema evolution; retrying from latest snapshot")
+				continue
+			}
+			return nil, err
+		}
+		config.Debug("[ONELAKE] Evolved schema in delta version %d at %s", version, tableDir)
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("failed to commit OneLake schema evolution after %d attempts: %w", maxDeltaCommitAttempts, lastConflict)
+}
+
+func (d *OneLakeDestination) SupportsColumnTypeChanges() bool {
+	return false
+}

--- a/pkg/destination/onelake/local_store_test.go
+++ b/pkg/destination/onelake/local_store_test.go
@@ -2,6 +2,7 @@ package onelake
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/internal/adlsutil"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -64,6 +66,18 @@ func (c *localDataLakeClient) DeleteDir(ctx context.Context, _ string, path stri
 }
 
 func (c *localDataLakeClient) ListLogVersions(ctx context.Context, _ string, path string) ([]int64, error) {
+	entries, err := c.ListLogEntries(ctx, "", path)
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]int64, len(entries))
+	for i, entry := range entries {
+		versions[i] = entry.Version
+	}
+	return versions, nil
+}
+
+func (c *localDataLakeClient) ListLogEntries(ctx context.Context, _ string, path string) ([]adlsutil.DeltaLogEntry, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -78,19 +92,27 @@ func (c *localDataLakeClient) ListLogVersions(ctx context.Context, _ string, pat
 	if err != nil {
 		return nil, err
 	}
-	versions := make([]int64, 0, len(entries))
+	logEntries := make([]adlsutil.DeltaLogEntry, 0, len(entries))
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || len(name) != 25 || !strings.HasSuffix(name, ".json") {
 			continue
 		}
 		version, err := strconv.ParseInt(strings.TrimSuffix(name, ".json"), 10, 64)
-		if err == nil {
-			versions = append(versions, version)
+		if err != nil {
+			continue
 		}
+		data, err := os.ReadFile(filepath.Join(fullPath, name))
+		if err != nil {
+			return nil, err
+		}
+		logEntries = append(logEntries, adlsutil.DeltaLogEntry{
+			Version: version,
+			ETag:    fmt.Sprintf("%x", sha256.Sum256(data)),
+		})
 	}
-	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
-	return versions, nil
+	sort.Slice(logEntries, func(i, j int) bool { return logEntries[i].Version < logEntries[j].Version })
+	return logEntries, nil
 }
 
 func (c *localDataLakeClient) Download(ctx context.Context, _ string, path string) ([]byte, error) {
@@ -719,6 +741,56 @@ func TestLocalStoreGetTableSchemaDetectsRecreatedTable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ID", "BRAND_NEW"}, got.ColumnNames(),
 		"a recreated table must not be reported with the previous table's schema")
+}
+
+func TestLocalStoreSchemaEvolutionDetectsRecreatedTableWithChangedProtocol(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.protocol_recreated"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+
+	for i := range 2 {
+		require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+			Table: table, Schema: tableSchema, DropFirst: i == 0,
+		}))
+		writeOneLakeTestBatch(t, dest, table, tableSchema, makeBatch(t, []arrow.Field{
+			{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		}, [][]any{{int64(i)}}))
+	}
+
+	current, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	tableDir, err := dest.tableDirForTables(table, "test")
+	require.NoError(t, err)
+	logDir := tableDir + "/_delta_log"
+	versionZero, err := client.Download(t.Context(), dest.workspace, logDir+"/"+commitFileName(0))
+	require.NoError(t, err)
+	fullLogDir, err := client.path(logDir)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(fullLogDir))
+	require.NoError(t, client.UploadBufferSkippingPrefix(
+		t.Context(), dest.workspace, logDir+"/"+commitFileName(0), versionZero, 0,
+	))
+	unsupportedProtocol := []byte(`{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors","rowTracking"]}}` + "\n")
+	require.NoError(t, client.UploadBufferSkippingPrefix(
+		t.Context(), dest.workspace, logDir+"/"+commitFileName(1), unsupportedProtocol, 0,
+	))
+
+	desired := &schema.TableSchema{Columns: append(
+		append([]schema.Column(nil), current.Columns...),
+		schema.Column{Name: "EXTERNAL_REF_ID", DataType: schema.TypeString},
+	)}
+	comparison, err := schemaevolution.Compare(desired, current, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(t.Context(), table, comparison)
+	require.ErrorContains(t, err, `writer feature "rowTracking"`)
+
+	versions, err := client.ListLogVersions(t.Context(), dest.workspace, logDir)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{0, 1}, versions, "schema evolution must not commit against the recreated table")
 }
 
 // TestLocalStoreGetTableSchemaDetectsRecreatedTableAfterAlter covers the same

--- a/pkg/destination/onelake/local_store_test.go
+++ b/pkg/destination/onelake/local_store_test.go
@@ -1,0 +1,1062 @@
+package onelake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type localDataLakeClient struct {
+	root      string
+	downloads int
+}
+
+func (c *localDataLakeClient) UploadBufferSkippingPrefix(ctx context.Context, _ string, path string, data []byte, _ int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fullPath, err := c.path(path)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(fullPath, data, 0o644)
+}
+
+func (c *localDataLakeClient) EnsureDirectoriesSkippingPrefix(ctx context.Context, _ string, path string, _ int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fullPath, err := c.path(path)
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(fullPath, 0o755)
+}
+
+func (c *localDataLakeClient) DeleteDir(ctx context.Context, _ string, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fullPath, err := c.path(path)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(fullPath)
+}
+
+func (c *localDataLakeClient) ListLogVersions(ctx context.Context, _ string, path string) ([]int64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	fullPath, err := c.path(path)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(fullPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]int64, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || len(name) != 25 || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		version, err := strconv.ParseInt(strings.TrimSuffix(name, ".json"), 10, 64)
+		if err == nil {
+			versions = append(versions, version)
+		}
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	return versions, nil
+}
+
+func (c *localDataLakeClient) Download(ctx context.Context, _ string, path string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.downloads++
+	fullPath, err := c.path(path)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(fullPath)
+}
+
+func (c *localDataLakeClient) publishCommit(ctx context.Context, logDir string, version int64, commit []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	dir, err := c.path(logDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(dir, ".ingestr-commit-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if _, err := temp.Write(commit); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	target := filepath.Join(dir, commitFileName(version))
+	if err := os.Link(tempPath, target); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return errDeltaCommitConflict
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *localDataLakeClient) path(path string) (string, error) {
+	clean := filepath.Clean(filepath.FromSlash(path))
+	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid local OneLake path %q", path)
+	}
+	return filepath.Join(c.root, clean), nil
+}
+
+func newLocalOneLakeDestination(root string) (*OneLakeDestination, *localDataLakeClient) {
+	client := &localDataLakeClient{root: root}
+	destination := &OneLakeDestination{
+		workspace: "local",
+		lakehouse: "test",
+		client:    client,
+		layout:    defaultLayout,
+	}
+	destination.publishCommit = client.publishCommit
+	return destination, client
+}
+
+func writeOneLakeTestBatch(t *testing.T, dest *OneLakeDestination, table string, tableSchema *schema.TableSchema, batch arrow.RecordBatch) {
+	t.Helper()
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: batch}
+	close(records)
+	require.NoError(t, dest.WriteParallel(t.Context(), records, destination.WriteOptions{Table: table, Schema: tableSchema}))
+}
+
+// TestLocalStoreDeleteInsertAfterAdditiveSchemaEvolution drives a full
+// evolve-then-rewrite cycle against a local Delta table. The added column is
+// declared NOT NULL at the source, which is the case that forces the target's
+// NULL-filled column and the staging column to be reconciled before the
+// copy-on-write rewrite.
+func TestLocalStoreDeleteInsertAfterAdditiveSchemaEvolution(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	targetTable := "analytics.orders"
+	stagingTable := "analytics.orders_staging"
+	updatedAt := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ORDER_ID", DataType: schema.TypeInt64},
+		{Name: "LINE_ID", DataType: schema.TypeInt64},
+		{Name: "UPDATED_AT", DataType: schema.TypeTimestampTZ},
+	}}
+	evolvedSchema := &schema.TableSchema{Columns: append(
+		append([]schema.Column(nil), initialSchema.Columns...),
+		schema.Column{Name: "EXTERNAL_REF_ID", DataType: schema.TypeString},
+	)}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: targetTable, Schema: initialSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, targetTable, initialSchema, makeBatch(t, []arrow.Field{
+		{Name: "ORDER_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "LINE_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "UPDATED_AT", Type: tsTZType},
+	}, [][]any{
+		{int64(1), int64(10), updatedAt.Add(-time.Hour)},
+		{int64(2), int64(20), updatedAt},
+	}))
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: stagingTable, Schema: evolvedSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, stagingTable, evolvedSchema, makeBatch(t, []arrow.Field{
+		{Name: "ORDER_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "LINE_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "UPDATED_AT", Type: tsTZType},
+		{Name: "EXTERNAL_REF_ID", Type: arrow.BinaryTypes.String},
+	}, [][]any{
+		{int64(2), int64(20), updatedAt, "external-2"},
+		{int64(3), int64(30), updatedAt, "external-3"},
+	}))
+
+	currentSchema, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	comparison, err := schemaevolution.Compare(evolvedSchema, currentSchema, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(t.Context(), targetTable, comparison)
+	require.NoError(t, err)
+	require.NoError(t, dest.DeleteInsertTable(t.Context(), destination.DeleteInsertOptions{
+		TargetTable:        targetTable,
+		StagingTable:       stagingTable,
+		IncrementalKey:     "UPDATED_AT",
+		IncrementalKeyType: schema.TypeTimestampTZ,
+		IntervalStart:      updatedAt,
+		IntervalEnd:        updatedAt,
+		PrimaryKeys:        []string{"ORDER_ID", "LINE_ID"},
+	}))
+
+	finalSchema, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ORDER_ID", "LINE_ID", "UPDATED_AT", "EXTERNAL_REF_ID"}, finalSchema.ColumnNames())
+	_, snapshot, batches, err := dest.readTable(t.Context(), targetTable, "test")
+	require.NoError(t, err)
+	defer releaseBatches(batches)
+	require.True(t, snapshot.exists)
+	require.Len(t, snapshot.activeFiles, 1)
+
+	rows := collectRows(batches)
+	require.Len(t, rows, 3)
+	byOrderID := make(map[int64]map[string]any, len(rows))
+	for _, row := range rows {
+		byOrderID[row["ORDER_ID"].(int64)] = row
+	}
+	assert.Nil(t, byOrderID[1]["EXTERNAL_REF_ID"])
+	assert.Equal(t, "external-2", byOrderID[2]["EXTERNAL_REF_ID"])
+	assert.Equal(t, "external-3", byOrderID[3]["EXTERNAL_REF_ID"])
+
+	logDir := dest.itemPath() + "/Tables/analytics/orders/_delta_log"
+	versions, err := client.ListLogVersions(t.Context(), dest.workspace, logDir)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{0, 1, 2}, versions)
+	assert.FileExists(t, filepath.Join(root, filepath.FromSlash(logDir), commitFileName(2)))
+}
+
+// TestLocalStoreMergeAfterMidSchemaColumnAdd covers the ordering skew between
+// the two sides of a rewrite: schema evolution appends the new column to the
+// end of the Delta schema, while the ingest schema keeps it where the source
+// put it (SCD2 does the same by always keeping its _scd_* columns last).
+func TestLocalStoreMergeAfterMidSchemaColumnAdd(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, _ := newLocalOneLakeDestination(root)
+	targetTable := "analytics.people"
+	stagingTable := "analytics.people_staging"
+
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "TAIL", DataType: schema.TypeString},
+	}}
+	// EXTRA sits before TAIL at the source, but evolution can only append it
+	// after TAIL in the Delta schema.
+	evolvedSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "EXTRA", DataType: schema.TypeString},
+		{Name: "TAIL", DataType: schema.TypeString},
+	}}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: targetTable, Schema: initialSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, targetTable, initialSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "TAIL", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(1), "kept"}}))
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: stagingTable, Schema: evolvedSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, stagingTable, evolvedSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "EXTRA", Type: arrow.BinaryTypes.String},
+		{Name: "TAIL", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(2), "new-extra", "new-tail"}}))
+
+	current, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	comparison, err := schemaevolution.Compare(evolvedSchema, current, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(t.Context(), targetTable, comparison)
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable: targetTable, StagingTable: stagingTable, PrimaryKeys: []string{"ID"},
+	}))
+
+	_, _, batches, err := dest.readTable(t.Context(), targetTable, "test")
+	require.NoError(t, err)
+	defer releaseBatches(batches)
+	rows := collectRows(batches)
+	require.Len(t, rows, 2)
+	byID := make(map[int64]map[string]any, len(rows))
+	for _, row := range rows {
+		byID[row["ID"].(int64)] = row
+	}
+	assert.Equal(t, "kept", byID[1]["TAIL"], "the pre-evolution row must keep its own column values")
+	assert.Nil(t, byID[1]["EXTRA"])
+	assert.Equal(t, "new-extra", byID[2]["EXTRA"])
+	assert.Equal(t, "new-tail", byID[2]["TAIL"])
+}
+
+// TestLocalStoreMergeAfterSourceDropsColumn drives the soft-removal path end to
+// end: the dropped column stays in the table relaxed to nullable, so the
+// rewrite has to NULL-fill it for the rows the staging table no longer carries.
+func TestLocalStoreMergeAfterSourceDropsColumn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, _ := newLocalOneLakeDestination(root)
+	targetTable := "analytics.invoices"
+	stagingTable := "analytics.invoices_staging"
+
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "GONE", DataType: schema.TypeString},
+	}}
+	reducedSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+	}}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: targetTable, Schema: initialSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, targetTable, initialSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "GONE", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(1), "kept"}}))
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: stagingTable, Schema: reducedSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, stagingTable, reducedSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(2)}}))
+
+	current, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	comparison, err := schemaevolution.Compare(reducedSchema, current, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(t.Context(), targetTable, comparison)
+	require.NoError(t, err)
+	require.NoError(t, dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable: targetTable, StagingTable: stagingTable, PrimaryKeys: []string{"ID"},
+	}))
+
+	finalSchema, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ID", "GONE"}, finalSchema.ColumnNames(), "the dropped column must be retained")
+
+	_, _, batches, err := dest.readTable(t.Context(), targetTable, "test")
+	require.NoError(t, err)
+	defer releaseBatches(batches)
+	rows := collectRows(batches)
+	require.Len(t, rows, 2)
+	byID := make(map[int64]map[string]any, len(rows))
+	for _, row := range rows {
+		byID[row["ID"].(int64)] = row
+	}
+	assert.Equal(t, "kept", byID[1]["GONE"], "rows written before the drop must keep their value")
+	assert.Nil(t, byID[2]["GONE"])
+}
+
+// TestLocalStoreMergeRejectsUndeclaredStagingColumn covers a rewrite whose
+// staging table carries a column the target never declared, which is what a
+// skipped schema evolution looks like from here. A rewrite commit carries no
+// metaData action, so writing the column would hide it from every Delta reader
+// — including ingestr's own next run.
+func TestLocalStoreMergeRejectsUndeclaredStagingColumn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, _ := newLocalOneLakeDestination(root)
+	targetTable := "analytics.tickets"
+	stagingTable := "analytics.tickets_staging"
+
+	targetSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+	stagingSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "NEWCOL", DataType: schema.TypeString},
+	}}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: targetTable, Schema: targetSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, targetTable, targetSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(1)}}))
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: stagingTable, Schema: stagingSchema, DropFirst: true,
+	}))
+	// The staging row replaces every target row, so nothing from the target
+	// survives the merge to expose the skew further down the write path.
+	writeOneLakeTestBatch(t, dest, stagingTable, stagingSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "NEWCOL", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(1), "new"}}))
+
+	err := dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable: targetTable, StagingTable: stagingTable, PrimaryKeys: []string{"ID"},
+	})
+	require.ErrorContains(t, err, `column "NEWCOL" is not declared in its Delta schema`)
+
+	// The target's own data files are what the check falls back to, so empty the
+	// table out and confirm the Delta schema alone still rejects the column.
+	dir, snapshot, batches, err := dest.readTable(t.Context(), targetTable, "test")
+	require.NoError(t, err)
+	releaseBatches(batches)
+	require.NoError(t, dest.commitRewrite(t.Context(), dir, snapshot, &rewriteData{}, "DELETE"))
+
+	err = dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable: targetTable, StagingTable: stagingTable, PrimaryKeys: []string{"ID"},
+	})
+	require.ErrorContains(t, err, `column "NEWCOL" is not declared in its Delta schema`)
+}
+
+// TestLocalStoreSchemaEvolutionRetriesCommitConflict covers the case where
+// another writer takes the next Delta version while evolution is preparing its
+// commit: the retry has to re-read the table so it does not lose that writer's
+// changes or add the column twice.
+func TestLocalStoreSchemaEvolutionRetriesCommitConflict(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.contested"
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+	evolvedSchema := &schema.TableSchema{Columns: append(
+		append([]schema.Column(nil), initialSchema.Columns...),
+		schema.Column{Name: "LABEL", DataType: schema.TypeString},
+	)}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: table, Schema: initialSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, table, initialSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(1)}}))
+
+	// Steal version 1 the first time evolution tries to publish it.
+	stolen := false
+	dest.publishCommit = func(ctx context.Context, logDir string, version int64, commit []byte) error {
+		if !stolen {
+			stolen = true
+			require.NoError(t, client.publishCommit(ctx, logDir, version, appendOnlyCommit(t)))
+			return errDeltaCommitConflict
+		}
+		return client.publishCommit(ctx, logDir, version, commit)
+	}
+
+	current, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	comparison, err := schemaevolution.Compare(evolvedSchema, current, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(t.Context(), table, comparison)
+	require.NoError(t, err)
+	assert.True(t, stolen)
+
+	final, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ID", "LABEL"}, final.ColumnNames(), "the retry must add the column exactly once")
+
+	versions, err := client.ListLogVersions(t.Context(), dest.workspace, dest.itemPath()+"/Tables/analytics/contested/_delta_log")
+	require.NoError(t, err)
+	assert.Equal(t, []int64{0, 1, 2}, versions)
+}
+
+func appendOnlyCommit(t *testing.T) []byte {
+	t.Helper()
+	commit, err := buildAppendCommit([]deltaAddFile{{Path: "part-other.parquet", Size: 1}}, 1)
+	require.NoError(t, err)
+	return commit
+}
+
+// TestLocalStoreMergeAcrossLossyTypeGenerations covers the schema the pipeline
+// feeds back into the next run. Delta has no TIME type, so once GetTableSchema
+// reports the table the ingest schema carries the column as an int64 while the
+// data already written for it is a time64. Both encodings describe the same
+// Delta "long" column and must still merge.
+func TestLocalStoreMergeAcrossLossyTypeGenerations(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, _ := newLocalOneLakeDestination(root)
+	targetTable := "analytics.sessions"
+	stagingTable := "analytics.sessions_staging"
+
+	firstRunSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "DURATION", DataType: schema.TypeTime},
+	}}
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: targetTable, Schema: firstRunSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, targetTable, firstRunSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "DURATION", Type: arrow.FixedWidthTypes.Time64us},
+	}, [][]any{{int64(1), int64(3_600_000_000)}}))
+
+	// The second run's ingest schema comes from the destination, where the
+	// column reads back as a plain long.
+	secondRunSchema, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	require.Equal(t, schema.TypeInt64, secondRunSchema.Columns[1].DataType)
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: stagingTable, Schema: secondRunSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, stagingTable, secondRunSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "DURATION", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(2), int64(7_200_000_000)}}))
+
+	require.NoError(t, dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable: targetTable, StagingTable: stagingTable, PrimaryKeys: []string{"ID"},
+	}))
+
+	_, _, batches, err := dest.readTable(t.Context(), targetTable, "test")
+	require.NoError(t, err)
+	defer releaseBatches(batches)
+	rows := collectRows(batches)
+	require.Len(t, rows, 2)
+	byID := make(map[int64]map[string]any, len(rows))
+	for _, row := range rows {
+		byID[row["ID"].(int64)] = row
+	}
+	assert.Equal(t, int64(3_600_000_000), byID[1]["DURATION"])
+	assert.Equal(t, int64(7_200_000_000), byID[2]["DURATION"])
+}
+
+// TestLocalStoreRewriteRejectsPartitionedTable guards the copy-on-write read
+// path: a partitioned table keeps its partition values in the Delta log rather
+// than in the Parquet files, so rewriting one would blank those columns.
+func TestLocalStoreRewriteRejectsPartitionedTable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.partitioned"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "REGION", DataType: schema.TypeString},
+	}}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, table, tableSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "REGION", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(1), "eu"}}))
+
+	dir := rewriteDeltaMetadata(t, dest, client, table, func(metadata deltaMetadata) {
+		metadata["partitionColumns"] = json.RawMessage(`["REGION"]`)
+	})
+	assert.NotEmpty(t, dir)
+
+	_, _, _, err := dest.readTable(t.Context(), table, "merge")
+	require.ErrorContains(t, err, "partitioned Delta table")
+}
+
+// TestLocalStoreGetTableSchemaStopsAtTheNewestMetadata pins the backward scan:
+// the pipeline asks for the schema on every run, so the lookup must stop at the
+// most recent metaData action rather than replaying the whole commit history.
+func TestLocalStoreGetTableSchemaStopsAtTheNewestMetadata(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.events"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+
+	for i := range 4 {
+		require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+			Table: table, Schema: tableSchema, DropFirst: i == 0,
+		}))
+		writeOneLakeTestBatch(t, dest, table, tableSchema, makeBatch(t, []arrow.Field{
+			{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		}, [][]any{{int64(i)}}))
+	}
+	evolvedSchema := &schema.TableSchema{Columns: append(
+		append([]schema.Column(nil), tableSchema.Columns...),
+		schema.Column{Name: "LABEL", DataType: schema.TypeString},
+	)}
+	current, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	comparison, err := schemaevolution.Compare(evolvedSchema, current, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	_, err = dest.ApplySchemaEvolution(t.Context(), table, comparison)
+	require.NoError(t, err)
+
+	client.downloads = 0
+	got, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"ID", "LABEL"}, got.ColumnNames())
+	assert.Equal(t, 2, client.downloads,
+		"the backward scan may only read the newest metaData commit plus the version-0 commit the protocol anchors to")
+}
+
+// TestLocalStoreGetTableSchemaReusesMetadataAcrossAppends pins the cost of the
+// schema lookup on an append-only table, where ingestr's only metaData action
+// sits in the version-0 commit and the backward scan therefore reaches the
+// bottom of the log. The pipeline asks for the schema several times per run, so
+// only the first lookup may pay for the history.
+func TestLocalStoreGetTableSchemaReusesMetadataAcrossAppends(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.appends"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+
+	appendRow := func(i int, dropFirst bool) {
+		require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+			Table: table, Schema: tableSchema, DropFirst: dropFirst,
+		}))
+		writeOneLakeTestBatch(t, dest, table, tableSchema, makeBatch(t, []arrow.Field{
+			{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+		}, [][]any{{int64(i)}}))
+	}
+	for i := range 4 {
+		appendRow(i, i == 0)
+	}
+
+	client.downloads = 0
+	got, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 4, client.downloads, "the first lookup scans back to the version-0 metaData")
+
+	client.downloads = 0
+	_, err = dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.downloads, "an unchanged log must only re-read the commit the metaData came from")
+
+	appendRow(4, false)
+	client.downloads = 0
+	_, err = dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.downloads, "only the appended commit and the metaData commit may be read")
+
+	// Recreating the table restarts the log, so the cached metaData must go.
+	appendRow(5, true)
+	client.downloads = 0
+	recreated, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ID"}, recreated.ColumnNames())
+	assert.Equal(t, 1, client.downloads)
+}
+
+// TestLocalStoreGetTableSchemaDetectsRecreatedTable covers the one way the
+// metaData cache can go stale: another writer drops and recreates the table, so
+// its log restarts at version 0 and the versions the cache treats as already
+// scanned belong to a table that no longer exists.
+func TestLocalStoreGetTableSchemaDetectsRecreatedTable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, _ := newLocalOneLakeDestination(root)
+	other, _ := newLocalOneLakeDestination(root)
+	table := "analytics.recreated"
+
+	oldSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "OLD_ONLY", DataType: schema.TypeString},
+	}}
+	newSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "BRAND_NEW", DataType: schema.TypeString},
+	}}
+	writeRows := func(d *OneLakeDestination, tableSchema *schema.TableSchema, field arrow.Field, value any, dropFirst bool) {
+		require.NoError(t, d.PrepareTable(t.Context(), destination.PrepareOptions{
+			Table: table, Schema: tableSchema, DropFirst: dropFirst,
+		}))
+		writeOneLakeTestBatch(t, d, table, tableSchema, makeBatch(t, []arrow.Field{
+			{Name: "ID", Type: arrow.PrimitiveTypes.Int64}, field,
+		}, [][]any{{int64(1), value}}))
+	}
+
+	oldField := arrow.Field{Name: "OLD_ONLY", Type: arrow.BinaryTypes.String}
+	writeRows(dest, oldSchema, oldField, "old", true)
+	writeRows(dest, oldSchema, oldField, "old", false)
+	current, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ID", "OLD_ONLY"}, current.ColumnNames())
+
+	// The recreated log is rebuilt to the same length, so the cached versions
+	// all still exist — only their contents changed.
+	newField := arrow.Field{Name: "BRAND_NEW", Type: arrow.BinaryTypes.String}
+	writeRows(other, newSchema, newField, "new", true)
+	writeRows(other, newSchema, newField, "new", false)
+
+	got, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ID", "BRAND_NEW"}, got.ColumnNames(),
+		"a recreated table must not be reported with the previous table's schema")
+}
+
+// TestLocalStoreGetTableSchemaDetectsRecreatedTableAfterAlter covers the same
+// staleness with the cached metaData coming from a commit other than version 0,
+// which is what an ALTER TABLE by another engine leaves behind. The recreated
+// log carries no metaData at that version at all, so re-reading it is the only
+// thing that can tell the two tables apart.
+func TestLocalStoreGetTableSchemaDetectsRecreatedTableAfterAlter(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	other, _ := newLocalOneLakeDestination(root)
+	table := "analytics.altered"
+
+	oldSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "OLD_ONLY", DataType: schema.TypeString},
+	}}
+	newSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "BRAND_NEW", DataType: schema.TypeString},
+	}}
+	writeRows := func(d *OneLakeDestination, tableSchema *schema.TableSchema, field arrow.Field, value any, dropFirst bool) {
+		require.NoError(t, d.PrepareTable(t.Context(), destination.PrepareOptions{
+			Table: table, Schema: tableSchema, DropFirst: dropFirst,
+		}))
+		writeOneLakeTestBatch(t, d, table, tableSchema, makeBatch(t, []arrow.Field{
+			{Name: "ID", Type: arrow.PrimitiveTypes.Int64}, field,
+		}, [][]any{{int64(1), value}}))
+	}
+
+	oldField := arrow.Field{Name: "OLD_ONLY", Type: arrow.BinaryTypes.String}
+	writeRows(dest, oldSchema, oldField, "old", true)
+	writeRows(dest, oldSchema, oldField, "old", false)
+	// An ALTER TABLE-style commit at version 2, so the cached metaData no longer
+	// comes from version 0.
+	rewriteDeltaMetadata(t, dest, client, table, func(deltaMetadata) {})
+	current, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ID", "OLD_ONLY"}, current.ColumnNames())
+
+	newField := arrow.Field{Name: "BRAND_NEW", Type: arrow.BinaryTypes.String}
+	writeRows(other, newSchema, newField, "new", true)
+	writeRows(other, newSchema, newField, "new", false)
+	writeRows(other, newSchema, newField, "new", false)
+
+	got, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	require.NotNil(t, got, "the recreated table must not read back as schema-less")
+	assert.Equal(t, []string{"ID", "BRAND_NEW"}, got.ColumnNames())
+}
+
+// TestLocalStoreRewriteRejectsColumnMappedTable guards the copy-on-write read
+// path: Parquet files of a column-mapped table carry physical column names, so
+// projecting them onto the logical Delta schema would null out every value.
+func TestLocalStoreRewriteRejectsColumnMappedTable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.mapped"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, table, tableSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(7)}}))
+
+	rewriteDeltaMetadata(t, dest, client, table, func(metadata deltaMetadata) {
+		metadata["configuration"] = json.RawMessage(`{"delta.columnMapping.mode":"name"}`)
+	})
+
+	_, _, _, err := dest.readTable(t.Context(), table, "merge")
+	require.ErrorContains(t, err, "column mapping mode")
+}
+
+// TestLocalStoreMergeSkipsDeclaredUnmappableColumnWithoutData covers a
+// Fabric-style metadata-only ALTER TABLE ADD COLUMNS of a struct column: the
+// column is declared in the Delta schema but present in no data file. The
+// rewrite must skip it — the metaData action stays untouched, so readers keep
+// NULL-filling it — rather than fail trying to materialize a type ingestr
+// cannot map.
+func TestLocalStoreMergeSkipsDeclaredUnmappableColumnWithoutData(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	targetTable := "analytics.profiles"
+	stagingTable := "analytics.profiles_staging"
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: targetTable, Schema: tableSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, targetTable, tableSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(1)}}))
+
+	rewriteDeltaMetadata(t, dest, client, targetTable, func(metadata deltaMetadata) {
+		raw, err := json.Marshal(`{"type":"struct","fields":[` +
+			`{"name":"ID","type":"long","nullable":true,"metadata":{}},` +
+			`{"name":"PROFILE","type":{"type":"struct","fields":[]},"nullable":true,"metadata":{}}]}`)
+		require.NoError(t, err)
+		metadata["schemaString"] = raw
+	})
+
+	current, err := dest.GetTableSchema(t.Context(), targetTable)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ID"}, current.ColumnNames(), "the unmappable column must stay out of the write schema")
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: stagingTable, Schema: tableSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, stagingTable, tableSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(2)}}))
+	require.NoError(t, dest.MergeTable(t.Context(), destination.MergeOptions{
+		TargetTable: targetTable, StagingTable: stagingTable, PrimaryKeys: []string{"ID"},
+	}))
+
+	_, snapshot, batches, err := dest.readTable(t.Context(), targetTable, "test")
+	require.NoError(t, err)
+	defer releaseBatches(batches)
+	rows := collectRows(batches)
+	require.Len(t, rows, 2)
+	for _, row := range rows {
+		_, hasProfile := row["PROFILE"]
+		assert.False(t, hasProfile, "rewritten files must omit the column so readers NULL-fill it")
+	}
+
+	deltaSchema, err := deltaSchemaFromMetadata(snapshot.metadata)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, deltaFieldIndex(deltaSchema.Fields, "PROFILE"), 0,
+		"the rewrite must keep the column declared in the Delta metadata")
+}
+
+func newLocalOneLakeTableWithRow(t *testing.T, table string) (*OneLakeDestination, *localDataLakeClient) {
+	t.Helper()
+	dest, client := newLocalOneLakeDestination(t.TempDir())
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: table, Schema: tableSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, table, tableSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(1)}}))
+	return dest, client
+}
+
+// TestLocalStoreRewriteRejectsDeletionVectorFiles guards the copy-on-write read
+// path against tables whose engine deletes rows through deletion vectors: the
+// Parquet file still contains those rows, so rewriting it would commit them
+// back as live data.
+func TestLocalStoreRewriteRejectsDeletionVectorFiles(t *testing.T) {
+	t.Parallel()
+	table := "analytics.dv"
+	dest, client := newLocalOneLakeTableWithRow(t, table)
+
+	commit := `{"add":{"path":"part-dv.parquet","partitionValues":{},"size":10,"modificationTime":1,"dataChange":true,"deletionVector":{"storageType":"u","pathOrInlineDv":"x","offset":1,"sizeInBytes":36,"cardinality":1}}}
+{"commitInfo":{"operation":"DELETE"}}
+`
+	logDir := dest.itemPath() + "/Tables/analytics/dv/_delta_log"
+	require.NoError(t, client.UploadBufferSkippingPrefix(
+		t.Context(), dest.workspace, logDir+"/"+commitFileName(1), []byte(commit), 0,
+	))
+
+	_, _, _, err := dest.readTable(t.Context(), table, "merge")
+	require.ErrorContains(t, err, "deletion vector")
+	require.ErrorContains(t, err, "part-dv.parquet")
+}
+
+// TestLocalStoreRejectsUnsupportedProtocol covers tables whose protocol action
+// demands writer capabilities ingestr does not have. Both the copy-on-write
+// read path and the schema evolution commit have to refuse such tables instead
+// of writing to them.
+func TestLocalStoreRejectsUnsupportedProtocol(t *testing.T) {
+	t.Parallel()
+	table := "analytics.upgraded"
+	dest, client := newLocalOneLakeTableWithRow(t, table)
+
+	commit := `{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors","rowTracking"]}}
+{"commitInfo":{"operation":"UPGRADE PROTOCOL"}}
+`
+	logDir := dest.itemPath() + "/Tables/analytics/upgraded/_delta_log"
+	require.NoError(t, client.UploadBufferSkippingPrefix(
+		t.Context(), dest.workspace, logDir+"/"+commitFileName(1), []byte(commit), 0,
+	))
+
+	_, _, _, err := dest.readTable(t.Context(), table, "merge")
+	require.ErrorContains(t, err, `writer feature "rowTracking"`)
+
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeAddColumn,
+		ColumnName: "LABEL",
+		NewColumn:  schema.Column{Name: "LABEL", DataType: schema.TypeString},
+	}}}
+	_, err = dest.ApplySchemaEvolution(t.Context(), table, comparison)
+	require.ErrorContains(t, err, `writer feature "rowTracking"`)
+}
+
+// TestLocalStoreRewriteRejectsTruncatedLog covers a checkpointed table whose
+// old JSON commits were removed by log cleanup while a recent commit (a
+// SET TBLPROPERTIES-style one) still carries both a protocol and a metaData
+// action. Every per-action gate passes on such a table, but the JSON-only
+// replay cannot see the data files recorded in the checkpoint, so a rewrite
+// would leave them live next to its own output.
+func TestLocalStoreRewriteRejectsTruncatedLog(t *testing.T) {
+	t.Parallel()
+	table := "analytics.truncated"
+	dest, client := newLocalOneLakeTableWithRow(t, table)
+
+	_, snapshot, batches, err := dest.readTable(t.Context(), table, "test")
+	require.NoError(t, err)
+	releaseBatches(batches)
+	metadataRaw, err := json.Marshal(snapshot.metadata)
+	require.NoError(t, err)
+
+	commit := `{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}` + "\n" +
+		`{"metaData":` + string(metadataRaw) + "}\n" +
+		`{"commitInfo":{"operation":"SET TBLPROPERTIES"}}` + "\n"
+	logDir := dest.itemPath() + "/Tables/analytics/truncated/_delta_log"
+	require.NoError(t, client.UploadBufferSkippingPrefix(
+		t.Context(), dest.workspace, logDir+"/"+commitFileName(1), []byte(commit), 0,
+	))
+	fullPath, err := client.path(logDir + "/" + commitFileName(0))
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(fullPath))
+
+	_, _, _, err = dest.readTable(t.Context(), table, "merge")
+	require.ErrorContains(t, err, "truncated")
+	require.ErrorContains(t, err, "oldest commit is 1")
+}
+
+// TestLocalStoreRewriteRejectsTableFeaturesInUse covers the table properties a
+// plain remove-and-add rewrite commit would silently violate even though the
+// feature names themselves are tolerated in the protocol action.
+func TestLocalStoreRewriteRejectsTableFeaturesInUse(t *testing.T) {
+	t.Parallel()
+
+	setFieldMetadata := func(t *testing.T, metadata deltaMetadata, key string, value any) {
+		t.Helper()
+		deltaSchema, err := deltaSchemaFromMetadata(metadata)
+		require.NoError(t, err)
+		deltaSchema.Fields[0].Metadata[key] = value
+		updated, err := deltaMetadataWithSchema(metadata, deltaSchema)
+		require.NoError(t, err)
+		metadata["schemaString"] = updated["schemaString"]
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(t *testing.T, metadata deltaMetadata)
+		wantErr string
+	}{
+		{
+			"append only",
+			func(t *testing.T, metadata deltaMetadata) {
+				t.Helper()
+				metadata["configuration"] = json.RawMessage(`{"delta.appendOnly":"true"}`)
+			},
+			"append-only Delta table",
+		},
+		{
+			"change data feed",
+			func(t *testing.T, metadata deltaMetadata) {
+				t.Helper()
+				metadata["configuration"] = json.RawMessage(`{"delta.enableChangeDataFeed":"true"}`)
+			},
+			"change data files",
+		},
+		{
+			"check constraint",
+			func(t *testing.T, metadata deltaMetadata) {
+				t.Helper()
+				metadata["configuration"] = json.RawMessage(`{"delta.constraints.positive_id":"ID > 0"}`)
+			},
+			`CHECK constraint "delta.constraints.positive_id"`,
+		},
+		{
+			"invariant",
+			func(t *testing.T, metadata deltaMetadata) {
+				t.Helper()
+				setFieldMetadata(t, metadata, "delta.invariants", `{"expression":{"expression":"ID > 0"}}`)
+			},
+			`invariant on column "ID"`,
+		},
+		{
+			"generated column",
+			func(t *testing.T, metadata deltaMetadata) {
+				t.Helper()
+				setFieldMetadata(t, metadata, "delta.generationExpression", "ID + 1")
+			},
+			`generated column "ID"`,
+		},
+		{
+			"identity column",
+			func(t *testing.T, metadata deltaMetadata) {
+				t.Helper()
+				setFieldMetadata(t, metadata, "delta.identity.start", float64(1))
+			},
+			`identity column "ID"`,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			table := "analytics.features"
+			dest, client := newLocalOneLakeTableWithRow(t, table)
+			rewriteDeltaMetadata(t, dest, client, table, func(metadata deltaMetadata) {
+				tt.mutate(t, metadata)
+			})
+
+			_, _, _, err := dest.readTable(t.Context(), table, "merge")
+			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorContains(t, err, "merge")
+		})
+	}
+}
+
+// rewriteDeltaMetadata commits a new metaData action for an existing table so a
+// test can give it properties ingestr itself never writes. It returns the
+// table directory.
+func rewriteDeltaMetadata(t *testing.T, dest *OneLakeDestination, client *localDataLakeClient, table string, mutate func(deltaMetadata)) string {
+	t.Helper()
+	dir, snapshot, batches, err := dest.readTable(t.Context(), table, "test")
+	require.NoError(t, err)
+	releaseBatches(batches)
+
+	deltaSchema, err := deltaSchemaFromMetadata(snapshot.metadata)
+	require.NoError(t, err)
+	metadata, err := deltaMetadataWithSchema(snapshot.metadata, deltaSchema)
+	require.NoError(t, err)
+	mutate(metadata)
+	commit, err := buildSchemaEvolutionCommit(metadata, 5)
+	require.NoError(t, err)
+	logDir := dir + "/_delta_log"
+	require.NoError(t, client.UploadBufferSkippingPrefix(
+		t.Context(), dest.workspace, logDir+"/"+commitFileName(snapshot.version+1), commit, 0,
+	))
+	return dir
+}

--- a/pkg/destination/onelake/local_store_test.go
+++ b/pkg/destination/onelake/local_store_test.go
@@ -515,6 +515,59 @@ func TestLocalStoreSchemaEvolutionRetriesCommitConflict(t *testing.T) {
 	assert.Equal(t, []int64{0, 1, 2}, versions)
 }
 
+func TestLocalStoreSchemaEvolutionRejectsConcurrentMetadataChange(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest, client := newLocalOneLakeDestination(root)
+	table := "analytics.schema_conflict"
+	initialSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "ID", DataType: schema.TypeInt64}}}
+	desiredSchema := &schema.TableSchema{Columns: append(
+		append([]schema.Column(nil), initialSchema.Columns...),
+		schema.Column{Name: "LABEL", DataType: schema.TypeString},
+	)}
+
+	require.NoError(t, dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table: table, Schema: initialSchema, DropFirst: true,
+	}))
+	writeOneLakeTestBatch(t, dest, table, initialSchema, makeBatch(t, []arrow.Field{
+		{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(1)}}))
+	current, err := dest.GetTableSchema(t.Context(), table)
+	require.NoError(t, err)
+	comparison, err := schemaevolution.Compare(desiredSchema, current, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+
+	tableDir, err := dest.tableDirForTables(table, "test")
+	require.NoError(t, err)
+	snapshot, err := dest.readTableMetadata(t.Context(), tableDir)
+	require.NoError(t, err)
+	concurrentSchema, err := deltaSchemaFromMetadata(snapshot.metadata)
+	require.NoError(t, err)
+	concurrentSchema.Fields[0].Type = "string"
+	concurrentMetadata, err := deltaMetadataWithSchema(snapshot.metadata, concurrentSchema)
+	require.NoError(t, err)
+	concurrentCommit, err := buildSchemaEvolutionCommit(concurrentMetadata, 2)
+	require.NoError(t, err)
+
+	stolen := false
+	dest.publishCommit = func(ctx context.Context, logDir string, version int64, commit []byte) error {
+		if !stolen {
+			stolen = true
+			require.NoError(t, client.publishCommit(ctx, logDir, version, concurrentCommit))
+			return errDeltaCommitConflict
+		}
+		return client.publishCommit(ctx, logDir, version, commit)
+	}
+
+	_, err = dest.ApplySchemaEvolution(t.Context(), table, comparison)
+	require.ErrorContains(t, err, "metadata changed after its schema evolution plan was built")
+	versions, err := client.ListLogVersions(t.Context(), dest.workspace, tableDir+"/_delta_log")
+	require.NoError(t, err)
+	assert.Equal(t, []int64{0, 1}, versions, "stale evolution must not publish another metadata commit")
+}
+
 func appendOnlyCommit(t *testing.T) []byte {
 	t.Helper()
 	commit, err := buildAppendCommit([]deltaAddFile{{Path: "part-other.parquet", Size: 1}}, 1)

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -46,6 +46,7 @@ type dataLakeClient interface {
 	EnsureDirectoriesSkippingPrefix(context.Context, string, string, int) error
 	DeleteDir(context.Context, string, string) error
 	ListLogVersions(context.Context, string, string) ([]int64, error)
+	ListLogEntries(context.Context, string, string) ([]adlsutil.DeltaLogEntry, error)
 	Download(context.Context, string, string) ([]byte, error)
 }
 
@@ -553,6 +554,7 @@ func (d *OneLakeDestination) readTableMetadata(ctx context.Context, tableDir str
 		metadataVersion: snapshot.metadataVersion,
 		protocolVersion: snapshot.protocolVersion,
 		metadata:        snapshot.metadata,
+		logETags:        snapshot.logETags,
 	}
 	if snapshot.protocol == nil {
 		// A log with no protocol action stays that way — commits are immutable —

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -41,16 +41,29 @@ const (
 
 var errDeltaCommitConflict = errors.New("delta commit version already exists")
 
+type dataLakeClient interface {
+	UploadBufferSkippingPrefix(context.Context, string, string, []byte, int) error
+	EnsureDirectoriesSkippingPrefix(context.Context, string, string, int) error
+	DeleteDir(context.Context, string, string) error
+	ListLogVersions(context.Context, string, string) ([]int64, error)
+	Download(context.Context, string, string) ([]byte, error)
+}
+
 // OneLakeDestination writes data to a Microsoft Fabric OneLake lakehouse. It can
 // target the lakehouse "Tables" area (written as a Delta table so it is queryable
 // in Fabric) or the "Files" area (raw Parquet files).
 type OneLakeDestination struct {
 	workspace string
 	lakehouse string
-	client    *adlsutil.DataLakeClient
+	client    dataLakeClient
 	cred      azcore.TokenCredential
 	sasToken  string
 	layout    string
+
+	publishCommit func(context.Context, string, int64, []byte) error
+
+	metaMu    sync.Mutex
+	metaCache map[string]deltaMetadataCache
 
 	mu          sync.Mutex
 	schema      *schema.TableSchema
@@ -122,6 +135,8 @@ func (d *OneLakeDestination) Connect(ctx context.Context, uri string) error {
 	d.cred = nil
 	d.sasToken = parsed.sasToken
 	d.layout = parsed.layout
+	d.publishCommit = nil
+	d.metaCache = nil
 	if d.layout == "" {
 		d.layout = defaultLayout
 	}
@@ -224,6 +239,7 @@ func (d *OneLakeDestination) PrepareTable(ctx context.Context, opts destination.
 		if err := d.client.DeleteDir(ctx, d.workspace, dir); err != nil {
 			return fmt.Errorf("failed to clear target %s: %w", dir, err)
 		}
+		d.forgetTableMetadata(dir)
 		config.Debug("[ONELAKE] Cleared target directory %s", dir)
 	}
 
@@ -383,6 +399,9 @@ func (d *OneLakeDestination) writeTablesMode(ctx context.Context, data []byte) e
 }
 
 func (d *OneLakeDestination) uploadDeltaCommit(ctx context.Context, logDir string, version int64, commit []byte) error {
+	if d.publishCommit != nil {
+		return d.publishCommit(ctx, logDir, version, commit)
+	}
 	commitPath := logDir + "/" + commitFileName(version)
 	if err := d.ensureDirectories(ctx, logDir); err != nil {
 		return fmt.Errorf("failed to prepare delta log directory: %w", err)
@@ -505,8 +524,87 @@ func (d *OneLakeDestination) renderLayout(loadID string, fileID int) string {
 	return result
 }
 
+// readTableMetadata reads a table's metaData action, reusing the result of the
+// previous read when the log has only been appended to since. The pipeline asks
+// for the schema several times per run and ingestr writes a metaData action
+// only in the version-0 commit, so an uncached lookup downloads the table's
+// entire commit history every time.
+func (d *OneLakeDestination) readTableMetadata(ctx context.Context, tableDir string) (*deltaSnapshot, error) {
+	d.metaMu.Lock()
+	defer d.metaMu.Unlock()
+
+	var cached *deltaMetadataCache
+	if entry, ok := d.metaCache[tableDir]; ok {
+		cached = &entry
+	}
+	snapshot, err := readDeltaMetadata(ctx, d.client, d.workspace, tableDir, cached)
+	if err != nil {
+		return nil, err
+	}
+	if !snapshot.exists || len(snapshot.metadata) == 0 {
+		delete(d.metaCache, tableDir)
+		return snapshot, nil
+	}
+	if d.metaCache == nil {
+		d.metaCache = make(map[string]deltaMetadataCache, 1)
+	}
+	entry := deltaMetadataCache{
+		version:         snapshot.version,
+		metadataVersion: snapshot.metadataVersion,
+		protocolVersion: snapshot.protocolVersion,
+		metadata:        snapshot.metadata,
+	}
+	if snapshot.protocol == nil {
+		// A log with no protocol action stays that way — commits are immutable —
+		// so no version needs re-reading for it, and 0 would wrongly pin the
+		// version-0 commit.
+		entry.protocolVersion = -1
+	}
+	d.metaCache[tableDir] = entry
+	return snapshot, nil
+}
+
+// forgetTableMetadata drops a cached metaData action. Delta versions are
+// immutable, so the cache is only ever stale when the table directory itself is
+// removed and a new table restarts the log at version 0.
+func (d *OneLakeDestination) forgetTableMetadata(tableDir string) {
+	d.metaMu.Lock()
+	defer d.metaMu.Unlock()
+	delete(d.metaCache, tableDir)
+}
+
 func (d *OneLakeDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
-	return nil, nil
+	if d.client == nil {
+		return nil, fmt.Errorf("OneLake destination is not connected")
+	}
+	mode, relPath, err := parseTarget(table)
+	if err != nil {
+		return nil, err
+	}
+	if mode == modeFiles {
+		return nil, nil
+	}
+
+	tableDir := d.itemPath() + "/Tables/" + strings.Trim(relPath, "/")
+	snapshot, err := d.readTableMetadata(ctx, tableDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OneLake table schema: %w", err)
+	}
+	if !snapshot.exists {
+		return nil, nil
+	}
+	if len(snapshot.metadata) == 0 {
+		// A log whose early commits have been truncated no longer carries the
+		// metaData action. Report the table as unknown so evolution is skipped
+		// rather than aborting the load.
+		config.Debug("[ONELAKE] Delta log at %s has no metadata action; skipping schema evolution", tableDir)
+		return nil, nil
+	}
+	deltaSchema, err := deltaSchemaFromMetadata(snapshot.metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OneLake table schema: %w", err)
+	}
+	return tableSchemaFromDelta(table, deltaSchema)
 }
 
 // Strategy support: OneLake is a direct-write, file-based destination.
@@ -549,11 +647,39 @@ func (d *OneLakeDestination) readTable(ctx context.Context, table, op string) (s
 	if !snap.exists {
 		return dir, snap, nil, nil
 	}
-	batches, err := readDeltaData(ctx, d.client, d.workspace, dir, snap.activeFiles)
+	if len(snap.metadata) == 0 {
+		return "", nil, nil, fmt.Errorf("%s rewrites the table, but the delta log under %s carries no metaData action to rewrite it against", op, dir)
+	}
+	tableSchema, err := deltaSchemaFromMetadata(snap.metadata)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to parse %s table schema: %w", op, err)
+	}
+	if err := checkRewritableDeltaTable(snap, tableSchema, op); err != nil {
+		return "", nil, nil, err
+	}
+	batches, err := readDeltaData(ctx, d.client, d.workspace, dir, snap.activeFiles, tableSchema)
 	if err != nil {
 		return "", nil, nil, err
 	}
 	return dir, snap, batches, nil
+}
+
+// declaredDeltaColumns returns the column names the table's metaData action
+// declares, or nil when the table does not exist yet — in which case the
+// rewrite writes the first commit and declares whatever it produces.
+func declaredDeltaColumns(snap *deltaSnapshot) ([]string, error) {
+	if snap == nil || !snap.exists || len(snap.metadata) == 0 {
+		return nil, nil
+	}
+	deltaSchema, err := deltaSchemaFromMetadata(snap.metadata)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(deltaSchema.Fields))
+	for _, field := range deltaSchema.Fields {
+		names = append(names, field.Name)
+	}
+	return names, nil
 }
 
 func (d *OneLakeDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
@@ -588,7 +714,18 @@ func (d *OneLakeDestination) rewriteTableWithRetry(ctx context.Context, targetTa
 			return err
 		}
 
-		result, err := transform(tBatches, sBatches)
+		declared, err := declaredDeltaColumns(tSnap)
+		if err != nil {
+			releaseBatches(tBatches)
+			return err
+		}
+		unifiedTarget, unifiedStaging, releaseUnified, err := unifyRewriteBatches(tBatches, sBatches, declared)
+		if err != nil {
+			releaseBatches(tBatches)
+			return err
+		}
+		result, err := transform(unifiedTarget, unifiedStaging)
+		releaseUnified()
 		releaseBatches(tBatches)
 		if err != nil {
 			return err
@@ -716,7 +853,7 @@ func writeBatchesToParquet(batches []arrow.RecordBatch) ([]byte, *arrow.Schema, 
 		if !b.Schema().Equal(target) {
 			if !schemaEqualIgnoringMetadata(b.Schema(), target) {
 				_ = writer.Close()
-				return nil, nil, fmt.Errorf("incompatible batch schema during rewrite")
+				return nil, nil, fmt.Errorf("incompatible batch schema during rewrite: %s", describeSchemaSkew(target, b.Schema()))
 			}
 			normalized, err := normalizeRecordToSchema(b, target)
 			if err != nil {
@@ -754,7 +891,11 @@ func (d *OneLakeDestination) DropTable(ctx context.Context, table string) error 
 		area = "Files"
 	}
 	dir := d.itemPath() + "/" + area + "/" + strings.Trim(relPath, "/")
-	return d.client.DeleteDir(ctx, d.workspace, dir)
+	if err := d.client.DeleteDir(ctx, d.workspace, dir); err != nil {
+		return err
+	}
+	d.forgetTableMetadata(dir)
+	return nil
 }
 
 func (d *OneLakeDestination) Exec(ctx context.Context, sql string, args ...interface{}) error {
@@ -784,6 +925,37 @@ func stripSchemaMetadata(s *arrow.Schema) *arrow.Schema {
 		fields[i] = f
 	}
 	return arrow.NewSchema(fields, nil)
+}
+
+// describeSchemaSkew explains why two batch schemas cannot be written to the
+// same Parquet file. unifyRewriteBatches reconciles the target and staging
+// schemas (and rejects the pairs it cannot), so this is a last-resort invariant
+// check rather than the message users normally see for schema drift.
+func describeSchemaSkew(want, got *arrow.Schema) string {
+	if want.NumFields() != got.NumFields() {
+		return fmt.Sprintf("expected %d columns (%v), got %d (%v)",
+			want.NumFields(), arrowFieldNames(want), got.NumFields(), arrowFieldNames(got))
+	}
+	for i := 0; i < want.NumFields(); i++ {
+		wantField := want.Field(i)
+		index, ok := fieldIndex(got, wantField.Name)
+		if !ok {
+			return fmt.Sprintf("column %q is missing (columns are %v)", wantField.Name, arrowFieldNames(got))
+		}
+		if gotField := got.Field(index); !arrow.TypeEqual(wantField.Type, gotField.Type) {
+			return fmt.Sprintf("column %q is %s in one data file and %s in another",
+				wantField.Name, wantField.Type, gotField.Type)
+		}
+	}
+	return fmt.Sprintf("expected %s, got %s", want, got)
+}
+
+func arrowFieldNames(s *arrow.Schema) []string {
+	names := make([]string, s.NumFields())
+	for i := 0; i < s.NumFields(); i++ {
+		names[i] = s.Field(i).Name
+	}
+	return names
 }
 
 func schemaEqualIgnoringMetadata(a, b *arrow.Schema) bool {
@@ -838,6 +1010,8 @@ func arrowFieldToColumn(f arrow.Field) schema.Column {
 	switch dt := f.Type.(type) {
 	case *arrow.BooleanType:
 		col.DataType = schema.TypeBoolean
+	case *arrow.Int8Type:
+		col.DataType = schema.TypeInt8
 	case *arrow.Int16Type:
 		col.DataType = schema.TypeInt16
 	case *arrow.Int32Type:
@@ -865,8 +1039,13 @@ func arrowFieldToColumn(f arrow.Field) schema.Column {
 			col.DataType = schema.TypeTimestamp
 		}
 	case *arrow.ListType:
+		// Array elements keep their precision/scale on the parent column, the
+		// same way schema.DataTypeToArrowType reads them back.
+		element := arrowFieldToColumn(arrow.Field{Type: dt.Elem()})
 		col.DataType = schema.TypeArray
-		col.ArrayType = arrowFieldToColumn(arrow.Field{Type: dt.Elem()}).DataType
+		col.ArrayType = element.DataType
+		col.Precision = element.Precision
+		col.Scale = element.Scale
 	default:
 		col.DataType = schema.TypeString
 	}

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -666,22 +666,14 @@ func (d *OneLakeDestination) readTable(ctx context.Context, table, op string) (s
 	return dir, snap, batches, nil
 }
 
-// declaredDeltaColumns returns the column names the table's metaData action
-// declares, or nil when the table does not exist yet — in which case the
-// rewrite writes the first commit and declares whatever it produces.
-func declaredDeltaColumns(snap *deltaSnapshot) ([]string, error) {
+// declaredDeltaSchema returns the schema from the table's metaData action, or
+// nil when the table does not exist yet — in which case the rewrite writes the
+// first commit and declares whatever it produces.
+func declaredDeltaSchema(snap *deltaSnapshot) (*deltaStruct, error) {
 	if snap == nil || !snap.exists || len(snap.metadata) == 0 {
 		return nil, nil
 	}
-	deltaSchema, err := deltaSchemaFromMetadata(snap.metadata)
-	if err != nil {
-		return nil, err
-	}
-	names := make([]string, 0, len(deltaSchema.Fields))
-	for _, field := range deltaSchema.Fields {
-		names = append(names, field.Name)
-	}
-	return names, nil
+	return deltaSchemaFromMetadata(snap.metadata)
 }
 
 func (d *OneLakeDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
@@ -716,7 +708,7 @@ func (d *OneLakeDestination) rewriteTableWithRetry(ctx context.Context, targetTa
 			return err
 		}
 
-		declared, err := declaredDeltaColumns(tSnap)
+		declared, err := declaredDeltaSchema(tSnap)
 		if err != nil {
 			releaseBatches(tBatches)
 			return err

--- a/pkg/destination/onelake/onelake_test.go
+++ b/pkg/destination/onelake/onelake_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -310,4 +312,464 @@ func TestRenderLayout(t *testing.T) {
 
 	d2 := &OneLakeDestination{relPath: "exports/users", layout: "{table_name}.{ext}"}
 	assert.Equal(t, "users.parquet", d2.renderLayout("x", 0))
+}
+
+func TestDeltaMetadataEvolvesWhenSourceAddsColumn(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata([]schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+	}, "table-id", 1700000000000)
+	require.NoError(t, err)
+	metadata["description"] = json.RawMessage(`"raw landing table"`)
+
+	deltaSchema, err := deltaSchemaFromMetadata(metadata)
+	require.NoError(t, err)
+	destinationSchema, err := tableSchemaFromDelta("Tables/users", deltaSchema)
+	require.NoError(t, err)
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		{Name: "name", DataType: schema.TypeString, Nullable: true},
+		{Name: "email", DataType: schema.TypeString, Nullable: false},
+	}}
+	normalizer := (&OneLakeDestination{}).NormalizeSchemaEvolutionColumn
+	comparison, err := schemaevolution.Compare(sourceSchema, destinationSchema, &schemaevolution.CompareOptions{
+		NormalizeColumn: normalizer,
+	})
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	require.Equal(t, schemaevolution.ChangeAddColumn, comparison.Changes[0].Type)
+
+	updated, changed, err := evolveDeltaMetadata(metadata, comparison)
+	require.NoError(t, err)
+	require.True(t, changed)
+	assert.JSONEq(t, `"raw landing table"`, string(updated["description"]))
+
+	evolvedSchema, err := deltaSchemaFromMetadata(updated)
+	require.NoError(t, err)
+	require.Len(t, evolvedSchema.Fields, 3)
+	assert.Equal(t, "email", evolvedSchema.Fields[2].Name)
+	assert.Equal(t, "string", evolvedSchema.Fields[2].Type)
+	assert.True(t, evolvedSchema.Fields[2].Nullable, "new columns must be nullable for pre-evolution files")
+
+	originalSchema, err := deltaSchemaFromMetadata(metadata)
+	require.NoError(t, err)
+	require.Len(t, originalSchema.Fields, 2, "evolution must not mutate the snapshot used to build the plan")
+}
+
+func TestBuildSchemaEvolutionCommitContainsMetadataOnly(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata([]schema.Column{{Name: "id", DataType: schema.TypeInt64}}, "table-id", 1)
+	require.NoError(t, err)
+	commit, err := buildSchemaEvolutionCommit(metadata, 1700000000000)
+	require.NoError(t, err)
+
+	lines := parseCommitLines(t, commit)
+	require.Len(t, lines, 2)
+	_, hasMetadata := lines[0]["metaData"]
+	assert.True(t, hasMetadata)
+	_, hasAdd := lines[0]["add"]
+	assert.False(t, hasAdd)
+
+	var info struct {
+		Operation string `json:"operation"`
+	}
+	require.NoError(t, json.Unmarshal(lines[1]["commitInfo"], &info))
+	assert.Equal(t, "ALTER TABLE", info.Operation)
+}
+
+func TestReplayDeltaCommitsKeepsLatestSchemaAndActiveFiles(t *testing.T) {
+	t.Parallel()
+
+	initial, err := buildInitialCommit(
+		[]schema.Column{{Name: "id", DataType: schema.TypeInt64}},
+		[]deltaAddFile{{Path: "part-a.parquet", Size: 10}},
+		"table-id",
+		1,
+	)
+	require.NoError(t, err)
+	metadata, err := newDeltaMetadata([]schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "email", DataType: schema.TypeString, Nullable: true},
+	}, "table-id", 1)
+	require.NoError(t, err)
+	evolution, err := buildSchemaEvolutionCommit(metadata, 2)
+	require.NoError(t, err)
+	rewrite, err := buildRewriteCommit(
+		[]string{"part-a.parquet"},
+		[]deltaAddFile{{Path: "part-b.parquet", Size: 20}},
+		"MERGE",
+		3,
+	)
+	require.NoError(t, err)
+
+	snapshot := &deltaSnapshot{exists: true}
+	active := make(map[string]bool)
+	var order []string
+	for _, commit := range [][]byte{initial, evolution, rewrite} {
+		require.NoError(t, replayDeltaCommit(snapshot, active, &order, commit))
+	}
+
+	var activeFiles []string
+	for _, path := range order {
+		if _, ok := active[path]; ok {
+			activeFiles = append(activeFiles, path)
+		}
+	}
+	assert.Equal(t, []string{"part-b.parquet"}, activeFiles)
+	deltaSchema, err := deltaSchemaFromMetadata(snapshot.metadata)
+	require.NoError(t, err)
+	require.Len(t, deltaSchema.Fields, 2)
+	assert.Equal(t, "email", deltaSchema.Fields[1].Name)
+	require.NotNil(t, snapshot.protocol)
+	assert.Equal(t, 1, snapshot.protocol.MinReaderVersion)
+	assert.Equal(t, 2, snapshot.protocol.MinWriterVersion)
+}
+
+func TestReplayDeltaCommitTracksDeletionVectors(t *testing.T) {
+	t.Parallel()
+
+	commit := []byte(`{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors"]}}
+{"add":{"path":"part-plain.parquet","size":1,"dataChange":true}}
+{"add":{"path":"part-null-dv.parquet","size":1,"dataChange":true,"deletionVector":null}}
+{"add":{"path":"part-dv.parquet","size":1,"dataChange":true,"deletionVector":{"storageType":"u","pathOrInlineDv":"x","offset":1,"sizeInBytes":36,"cardinality":2}}}
+`)
+
+	snapshot := &deltaSnapshot{exists: true}
+	active := make(map[string]bool)
+	var order []string
+	require.NoError(t, replayDeltaCommit(snapshot, active, &order, commit))
+
+	assert.False(t, active["part-plain.parquet"])
+	assert.False(t, active["part-null-dv.parquet"])
+	assert.True(t, active["part-dv.parquet"])
+	require.NotNil(t, snapshot.protocol)
+	assert.Equal(t, []string{"deletionVectors"}, snapshot.protocol.ReaderFeatures)
+
+	// A later add of the same file without a deletion vector replaces the entry.
+	require.NoError(t, replayDeltaCommit(snapshot, active, &order,
+		[]byte(`{"add":{"path":"part-dv.parquet","size":1,"dataChange":true}}`)))
+	assert.False(t, active["part-dv.parquet"])
+}
+
+func TestCheckSupportedDeltaProtocol(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		protocol *deltaProtocol
+		wantErr  string
+	}{
+		{"missing", nil, "carries no protocol action"},
+		{"legacy", &deltaProtocol{MinReaderVersion: 1, MinWriterVersion: 2}, ""},
+		{
+			"table features within allowlist",
+			&deltaProtocol{
+				MinReaderVersion: 3, MinWriterVersion: 7,
+				ReaderFeatures: []string{"deletionVectors", "timestampNtz"},
+				WriterFeatures: []string{"deletionVectors", "appendOnly", "invariants"},
+			},
+			"",
+		},
+		{
+			"unknown reader feature",
+			&deltaProtocol{MinReaderVersion: 3, MinWriterVersion: 7, ReaderFeatures: []string{"typeWidening"}},
+			`reader feature "typeWidening"`,
+		},
+		{
+			"unknown writer feature",
+			&deltaProtocol{MinReaderVersion: 3, MinWriterVersion: 7, WriterFeatures: []string{"icebergCompatV2"}},
+			`writer feature "icebergCompatV2"`,
+		},
+		{
+			"future versions",
+			&deltaProtocol{MinReaderVersion: 4, MinWriterVersion: 8},
+			"reader version 4 and writer version 8",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkSupportedDeltaProtocol(tt.protocol, "merge")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestEvolveDeltaMetadataRelaxesColumnsAndRejectsTypeChanges(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata([]schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: false}}, "table-id", 1)
+	require.NoError(t, err)
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type: schemaevolution.ChangeRemoveColumn, ColumnName: "id",
+	}}}
+
+	updated, changed, err := evolveDeltaMetadata(metadata, comparison)
+	require.NoError(t, err)
+	require.True(t, changed)
+	deltaSchema, err := deltaSchemaFromMetadata(updated)
+	require.NoError(t, err)
+	assert.True(t, deltaSchema.Fields[0].Nullable)
+
+	oldColumn := schema.Column{Name: "id", DataType: schema.TypeInt64}
+	_, changed, err = evolveDeltaMetadata(metadata, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeWidenType, ColumnName: "id", OldColumn: &oldColumn,
+			NewColumn: schema.Column{Name: "id", DataType: schema.TypeString},
+		}},
+	})
+	require.ErrorContains(t, err, "requires changing its Delta type from long to string")
+	assert.False(t, changed)
+}
+
+func TestEvolveDeltaMetadataRejectsUnmappableExistingColumn(t *testing.T) {
+	t.Parallel()
+
+	// tableSchemaFromDelta omits the Fabric-authored struct column, so a source
+	// column with the same name arrives as an add; it must fail loudly instead
+	// of redeclaring the struct as a string.
+	metadata, err := newDeltaMetadata(nil, "table-id", 1)
+	require.NoError(t, err)
+	metadata["schemaString"], err = json.Marshal(`{"type":"struct","fields":[` +
+		`{"name":"profile","type":{"type":"struct","fields":[]},"nullable":true,"metadata":{}}]}`)
+	require.NoError(t, err)
+
+	_, _, err = evolveDeltaMetadata(metadata, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeAddColumn, ColumnName: "profile",
+			NewColumn: schema.Column{Name: "profile", DataType: schema.TypeString},
+		}},
+	})
+	require.ErrorContains(t, err, `column "profile"`)
+	require.ErrorContains(t, err, "unsupported delta type")
+
+	// An unknown column must not be mistaken for a string just because that is
+	// deltaTypeFor's fallback.
+	_, _, err = evolveDeltaMetadata(metadata, &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type: schemaevolution.ChangeWidenType, ColumnName: "profile",
+			OldColumn: &schema.Column{Name: "profile", DataType: schema.TypeUnknown, Nullable: true},
+			NewColumn: schema.Column{Name: "profile", DataType: schema.TypeString},
+		}},
+	})
+	require.ErrorContains(t, err, `requires changing its Delta type from {"fields":[],"type":"struct"} to string`)
+}
+
+func TestTableSchemaFromDeltaSkipsUnmappableColumns(t *testing.T) {
+	t.Parallel()
+
+	deltaSchema := &deltaStruct{Type: "struct", Fields: []deltaField{
+		{Name: "id", Type: "long"},
+		{Name: "profile", Type: map[string]any{"type": "struct", "fields": []any{}}, Nullable: true},
+	}}
+
+	tableSchema, err := tableSchemaFromDelta("Tables/users", deltaSchema)
+	require.NoError(t, err, "a Delta type ingestr cannot map must not fail the whole load")
+	require.Len(t, tableSchema.Columns, 1,
+		"unmappable columns must stay out of the write schema so appended files omit them")
+	assert.Equal(t, schema.TypeInt64, tableSchema.Columns[0].DataType)
+}
+
+// TestArrowFieldToColumnRoundTripsDeltaTypes pins the two directions of the
+// type map against each other. The first copy-on-write commit derives the Delta
+// metadata from the Arrow schema of the file it just wrote, and every later run
+// aligns that file to the declared metadata, so a column that does not round
+// trip breaks the table on its second run.
+func TestArrowFieldToColumnRoundTripsDeltaTypes(t *testing.T) {
+	t.Parallel()
+
+	columns := []schema.Column{
+		{Name: "bool", DataType: schema.TypeBoolean},
+		{Name: "i8", DataType: schema.TypeInt8},
+		{Name: "i16", DataType: schema.TypeInt16},
+		{Name: "i32", DataType: schema.TypeInt32},
+		{Name: "i64", DataType: schema.TypeInt64},
+		{Name: "f32", DataType: schema.TypeFloat32},
+		{Name: "f64", DataType: schema.TypeFloat64},
+		{Name: "dec", DataType: schema.TypeDecimal, Precision: 10, Scale: 2},
+		{Name: "dec_default", DataType: schema.TypeDecimal},
+		{Name: "str", DataType: schema.TypeString, MaxLength: 64},
+		{Name: "json", DataType: schema.TypeJSON},
+		{Name: "uuid", DataType: schema.TypeUUID},
+		{Name: "bin", DataType: schema.TypeBinary},
+		{Name: "date", DataType: schema.TypeDate},
+		{Name: "time", DataType: schema.TypeTime},
+		{Name: "ts", DataType: schema.TypeTimestamp},
+		{Name: "tstz", DataType: schema.TypeTimestampTZ},
+		{Name: "arr_str", DataType: schema.TypeArray, ArrayType: schema.TypeString},
+		{Name: "arr_i64", DataType: schema.TypeArray, ArrayType: schema.TypeInt64},
+		{Name: "arr_dec", DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 10, Scale: 2},
+		{Name: "arr_ts", DataType: schema.TypeArray, ArrayType: schema.TypeTimestampTZ},
+	}
+
+	for _, column := range columns {
+		t.Run(column.Name, func(t *testing.T) {
+			roundTripped := arrowFieldToColumn(arrow.Field{
+				Name: column.Name, Type: schema.DataTypeToArrowType(column),
+			})
+			assert.Equal(t, deltaTypeFor(column), deltaTypeFor(roundTripped))
+		})
+	}
+}
+
+func TestDeltaTypeForArrayKeepsElementPrecision(t *testing.T) {
+	t.Parallel()
+
+	deltaType := deltaTypeFor(schema.Column{
+		DataType: schema.TypeArray, ArrayType: schema.TypeDecimal, Precision: 10, Scale: 2,
+	})
+	encoded, err := json.Marshal(deltaType)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"array","elementType":"decimal(10,2)","containsNull":true}`, string(encoded))
+}
+
+func TestEvolveDeltaMetadataAllowsMissingConfiguration(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata([]schema.Column{{Name: "id", DataType: schema.TypeInt64}}, "table-id", 1)
+	require.NoError(t, err)
+	delete(metadata, "configuration")
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeAddColumn,
+		ColumnName: "email",
+		NewColumn:  schema.Column{Name: "email", DataType: schema.TypeString},
+	}}}
+
+	updated, changed, err := evolveDeltaMetadata(metadata, comparison)
+	require.NoError(t, err)
+	require.True(t, changed)
+	evolved, err := deltaSchemaFromMetadata(updated)
+	require.NoError(t, err)
+	require.Len(t, evolved.Fields, 2)
+}
+
+// TestEvolveDeltaMetadataKeepsFieldMetadataObject covers tables written by
+// other engines, which may omit the per-field metadata object the Delta
+// protocol requires. Committing it back as null makes the table unreadable.
+func TestEvolveDeltaMetadataKeepsFieldMetadataObject(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata([]schema.Column{{Name: "id", DataType: schema.TypeInt64}}, "table-id", 1)
+	require.NoError(t, err)
+	schemaString, err := json.Marshal(`{"type":"struct","fields":[{"name":"id","type":"long","nullable":true}]}`)
+	require.NoError(t, err)
+	metadata["schemaString"] = schemaString
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeAddColumn,
+		ColumnName: "email",
+		NewColumn:  schema.Column{Name: "email", DataType: schema.TypeString},
+	}}}
+
+	updated, changed, err := evolveDeltaMetadata(metadata, comparison)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var encoded string
+	require.NoError(t, json.Unmarshal(updated["schemaString"], &encoded))
+	assert.NotContains(t, encoded, `"metadata":null`)
+	assert.JSONEq(t, `{"type":"struct","fields":[`+
+		`{"name":"id","type":"long","nullable":true,"metadata":{}},`+
+		`{"name":"email","type":"string","nullable":true,"metadata":{}}]}`, encoded)
+}
+
+func TestNormalizeSchemaEvolutionColumn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   schema.Column
+		want schema.Column
+	}{
+		// Delta has no JSON, UUID, TIME or naive timestamp type, so these are
+		// the columns GetTableSchema reports back differently from what the
+		// source declared. Without the normalization the second run of a
+		// pipeline sees a type change and fails.
+		{"json", schema.Column{DataType: schema.TypeJSON}, schema.Column{DataType: schema.TypeString}},
+		{"uuid", schema.Column{DataType: schema.TypeUUID}, schema.Column{DataType: schema.TypeString}},
+		{"time", schema.Column{DataType: schema.TypeTime}, schema.Column{DataType: schema.TypeInt64}},
+		{"timestamp", schema.Column{DataType: schema.TypeTimestamp}, schema.Column{DataType: schema.TypeTimestampTZ}},
+		{"timestamptz", schema.Column{DataType: schema.TypeTimestampTZ}, schema.Column{DataType: schema.TypeTimestampTZ}},
+		{
+			"max length is not carried by delta",
+			schema.Column{DataType: schema.TypeString, MaxLength: 64},
+			schema.Column{DataType: schema.TypeString},
+		},
+		{
+			"decimal keeps precision and scale",
+			schema.Column{DataType: schema.TypeDecimal, Precision: 10, Scale: 2},
+			schema.Column{DataType: schema.TypeDecimal, Precision: 10, Scale: 2},
+		},
+		{
+			"array element",
+			schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeJSON},
+			schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeString},
+		},
+		{
+			"array of time",
+			schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeTime},
+			schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeInt64},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, normalizeSchemaEvolutionColumn(tt.in))
+		})
+	}
+}
+
+// TestNormalizedSchemaSurvivesTheNextRun ties the normalizer to what it exists
+// for: the schema GetTableSchema reports must compare equal to the source
+// schema that produced the table, or every run after the first fails.
+func TestNormalizedSchemaSurvivesTheNextRun(t *testing.T) {
+	t.Parallel()
+
+	sourceSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "ID", DataType: schema.TypeInt64},
+		{Name: "PAYLOAD", DataType: schema.TypeJSON},
+		{Name: "EXTERNAL_ID", DataType: schema.TypeUUID},
+		{Name: "DURATION", DataType: schema.TypeTime},
+		{Name: "SEEN_AT", DataType: schema.TypeTimestamp},
+		{Name: "NAME", DataType: schema.TypeString, MaxLength: 64},
+	}}
+	metadata, err := newDeltaMetadata(sourceSchema.Columns, "table-id", 1)
+	require.NoError(t, err)
+	deltaSchema, err := deltaSchemaFromMetadata(metadata)
+	require.NoError(t, err)
+	reported, err := tableSchemaFromDelta("analytics.events", deltaSchema)
+	require.NoError(t, err)
+
+	dest := &OneLakeDestination{}
+	comparison, err := schemaevolution.Compare(sourceSchema, reported, &schemaevolution.CompareOptions{
+		NormalizeColumn: dest.NormalizeSchemaEvolutionColumn,
+	})
+	require.NoError(t, err)
+	assert.False(t, comparison.HasChanges, "the lossy Delta types must not read back as schema changes: %+v", comparison.Changes)
+}
+
+func TestEvolveDeltaMetadataRejectsColumnMapping(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata([]schema.Column{{Name: "id", DataType: schema.TypeInt64}}, "table-id", 1)
+	require.NoError(t, err)
+	metadata["configuration"] = json.RawMessage(`{"delta.columnMapping.mode":"name"}`)
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeAddColumn,
+		ColumnName: "email",
+		NewColumn:  schema.Column{Name: "email", DataType: schema.TypeString},
+	}}}
+
+	_, changed, err := evolveDeltaMetadata(metadata, comparison)
+	require.ErrorContains(t, err, "column mapping mode")
+	assert.False(t, changed)
 }

--- a/pkg/destination/onelake/onelake_test.go
+++ b/pkg/destination/onelake/onelake_test.go
@@ -682,6 +682,34 @@ func TestEvolveDeltaMetadataKeepsFieldMetadataObject(t *testing.T) {
 		`{"name":"email","type":"string","nullable":true,"metadata":{}}]}`, encoded)
 }
 
+func TestEvolveDeltaMetadataPreservesIdentityLongs(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := newDeltaMetadata(nil, "table-id", 1)
+	require.NoError(t, err)
+	metadata["schemaString"], err = json.Marshal(`{"type":"struct","fields":[{` +
+		`"name":"id","type":"long","nullable":false,"metadata":{` +
+		`"delta.identity.start":9007199254740993,` +
+		`"delta.identity.step":1,` +
+		`"delta.identity.highWaterMark":9007199254740995,` +
+		`"delta.identity.allowExplicitInsert":false}}]}`)
+	require.NoError(t, err)
+	comparison := &schemaevolution.SchemaComparison{HasChanges: true, Changes: []schemaevolution.SchemaChange{{
+		Type:       schemaevolution.ChangeAddColumn,
+		ColumnName: "email",
+		NewColumn:  schema.Column{Name: "email", DataType: schema.TypeString},
+	}}}
+
+	updated, changed, err := evolveDeltaMetadata(metadata, comparison)
+	require.NoError(t, err)
+	require.True(t, changed)
+	evolved, err := deltaSchemaFromMetadata(updated)
+	require.NoError(t, err)
+	require.Len(t, evolved.Fields, 2)
+	assert.Equal(t, json.Number("9007199254740993"), evolved.Fields[0].Metadata["delta.identity.start"])
+	assert.Equal(t, json.Number("9007199254740995"), evolved.Fields[0].Metadata["delta.identity.highWaterMark"])
+}
+
 func TestNormalizeSchemaEvolutionColumn(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/destination/onelake/transform_test.go
+++ b/pkg/destination/onelake/transform_test.go
@@ -221,7 +221,7 @@ func TestUnifyRewriteBatchesReconcilesNullabilityAndOrder(t *testing.T) {
 	defer staging.Release()
 
 	unifiedTarget, unifiedStaging, release, err := unifyRewriteBatches(
-		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "tail", "extra"},
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, deltaSchemaForArrow(target.Schema()),
 	)
 	require.NoError(t, err)
 	defer release()
@@ -253,7 +253,7 @@ func TestUnifyRewriteBatchesFillsSoftRemovedColumn(t *testing.T) {
 	defer staging.Release()
 
 	unifiedTarget, unifiedStaging, release, err := unifyRewriteBatches(
-		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "gone"},
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, deltaSchemaForArrow(target.Schema()),
 	)
 	require.NoError(t, err)
 	defer release()
@@ -285,7 +285,7 @@ func TestUnifyRewriteBatchesKeepsRequiredColumnMissingFromStaging(t *testing.T) 
 	defer staging.Release()
 
 	_, _, release, err := unifyRewriteBatches(
-		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "gone"},
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, deltaSchemaForArrow(target.Schema()),
 	)
 	defer release()
 	require.ErrorContains(t, err, `column "gone" is required but the incoming rows do not have it`)
@@ -309,7 +309,7 @@ func TestUnifyRewriteBatchesKeepsUndeclaredStagingColumn(t *testing.T) {
 	defer staging.Release()
 
 	_, _, release, err := unifyRewriteBatches(
-		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "kept"},
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, deltaSchemaForArrow(target.Schema()),
 	)
 	defer release()
 	require.ErrorContains(t, err, `column "undeclared" is not declared in its Delta schema`)
@@ -330,10 +330,77 @@ func TestUnifyRewriteBatchesKeepsRealTypeConflicts(t *testing.T) {
 	defer staging.Release()
 
 	_, _, release, err := unifyRewriteBatches(
-		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "note"},
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, deltaSchemaForArrow(target.Schema()),
 	)
 	defer release()
 	require.ErrorContains(t, err, `column "note" is utf8 in the table and int64 in the incoming rows`)
+}
+
+func TestUnifyRewriteBatchesValidatesEmptyTargetAgainstDeltaSchema(t *testing.T) {
+	t.Parallel()
+
+	staging := makeBatch(t, []arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, [][]any{{int64(1)}})
+	defer staging.Release()
+	declared := &deltaStruct{Type: "struct", Fields: []deltaField{
+		{Name: "id", Type: "long", Metadata: map[string]any{}},
+		{Name: "note", Type: "string", Nullable: true, Metadata: map[string]any{}},
+	}}
+
+	_, unifiedStaging, release, err := unifyRewriteBatches(nil, []arrow.RecordBatch{staging}, declared)
+	require.NoError(t, err)
+	defer release()
+	require.Len(t, unifiedStaging, 1)
+	assert.Equal(t, []string{"id", "note"}, arrowFieldNames(unifiedStaging[0].Schema()))
+	assert.True(t, unifiedStaging[0].Column(1).IsNull(0))
+
+	declared.Fields[1].Nullable = false
+	_, _, releaseRequired, err := unifyRewriteBatches(nil, []arrow.RecordBatch{staging}, declared)
+	defer releaseRequired()
+	require.ErrorContains(t, err, `column "note" is required but the incoming rows do not have it`)
+
+	wrongType := &deltaStruct{Type: "struct", Fields: []deltaField{{Name: "id", Type: "string", Metadata: map[string]any{}}}}
+	_, _, releaseType, err := unifyRewriteBatches(nil, []arrow.RecordBatch{staging}, wrongType)
+	defer releaseType()
+	require.ErrorContains(t, err, `column "id" is Delta string in the table and int64 in the incoming rows`)
+}
+
+func TestUnifyRewriteBatchesAcceptsEquivalentLossyDeltaTypes(t *testing.T) {
+	t.Parallel()
+
+	target := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}, [][]any{{int64(1), nil}})
+	defer target.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "duration", Type: arrow.FixedWidthTypes.Time64us},
+	}, [][]any{{int64(2), int64(3_600_000_000)}})
+	defer staging.Release()
+	declared := &deltaStruct{Type: "struct", Fields: []deltaField{
+		{Name: "id", Type: "long", Metadata: map[string]any{}},
+		{Name: "duration", Type: "long", Nullable: true, Metadata: map[string]any{}},
+	}}
+
+	unifiedTarget, unifiedStaging, release, err := unifyRewriteBatches(
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, declared,
+	)
+	require.NoError(t, err)
+	defer release()
+	assert.True(t, unifiedTarget[0].Schema().Equal(unifiedStaging[0].Schema()))
+	assert.Equal(t, arrow.PrimitiveTypes.Int64, unifiedStaging[0].Schema().Field(1).Type)
+	assert.Equal(t, int64(3_600_000_000), unifiedStaging[0].Column(1).(*array.Int64).Value(0))
+}
+
+func deltaSchemaForArrow(arrowSchema *arrow.Schema) *deltaStruct {
+	fields := make([]deltaField, arrowSchema.NumFields())
+	for i := 0; i < arrowSchema.NumFields(); i++ {
+		field := arrowSchema.Field(i)
+		fields[i] = deltaField{
+			Name: field.Name, Type: deltaTypeFor(arrowFieldToColumn(field)), Nullable: field.Nullable, Metadata: map[string]any{},
+		}
+	}
+	return &deltaStruct{Type: "struct", Fields: fields}
 }
 
 func TestDeleteInsertBatches(t *testing.T) {

--- a/pkg/destination/onelake/transform_test.go
+++ b/pkg/destination/onelake/transform_test.go
@@ -55,6 +55,8 @@ func appendTestCell(t *testing.T, b array.Builder, v any) {
 		bb.Append(v.(bool))
 	case *array.TimestampBuilder:
 		bb.Append(arrow.Timestamp(v.(time.Time).UnixMicro()))
+	case *array.Time64Builder:
+		bb.Append(arrow.Time64(v.(int64)))
 	default:
 		t.Fatalf("unsupported builder type %T", b)
 	}
@@ -115,6 +117,223 @@ func TestMergeBatchesEmptyTarget(t *testing.T) {
 	rows := collectRows(out)
 	require.Len(t, rows, 1)
 	assert.Equal(t, int64(1), rows[0]["id"])
+}
+
+func TestAlignDeltaBatchesFillsEvolvedColumnsForOldFiles(t *testing.T) {
+	t.Parallel()
+
+	oldBatch := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, [][]any{{int64(1), "old"}})
+	defer oldBatch.Release()
+	newBatch := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "email", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, [][]any{{int64(2), "new", "new@example.com"}})
+	defer newBatch.Release()
+	tableSchema := &deltaStruct{Type: "struct", Fields: []deltaField{
+		{Name: "id", Type: "long", Metadata: map[string]any{}},
+		{Name: "name", Type: "string", Nullable: true, Metadata: map[string]any{}},
+		{Name: "email", Type: "string", Nullable: true, Metadata: map[string]any{}},
+	}}
+
+	aligned, err := alignDeltaBatches([]arrow.RecordBatch{oldBatch, newBatch}, tableSchema)
+	require.NoError(t, err)
+	defer releaseBatches(aligned)
+	require.Len(t, aligned, 2)
+	for _, batch := range aligned {
+		assert.Equal(t, "id", batch.Schema().Field(0).Name)
+		assert.Equal(t, "name", batch.Schema().Field(1).Name)
+		assert.Equal(t, "email", batch.Schema().Field(2).Name)
+	}
+	assert.True(t, aligned[0].Column(2).IsNull(0))
+	assert.Equal(t, "new@example.com", aligned[1].Column(2).(*array.String).Value(0))
+
+	merged, err := mergeBatches(t.Context(), []arrow.RecordBatch{aligned[0]}, []arrow.RecordBatch{aligned[1]}, []string{"id"})
+	require.NoError(t, err)
+	defer releaseBatches(merged)
+	_, _, err = writeBatchesToParquet(merged)
+	require.NoError(t, err, "copy-on-write strategies must accept files from before and after schema evolution")
+}
+
+func TestDeleteInsertRewriteAfterAdditiveSchemaEvolution(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	oldTarget := makeBatch(t, []arrow.Field{
+		{Name: "ORDER_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "LINE_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "UPDATED_AT", Type: tsTZType},
+	}, [][]any{{int64(1), int64(10), updatedAt.Add(-time.Hour)}})
+	defer oldTarget.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "ORDER_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "LINE_ID", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "UPDATED_AT", Type: tsTZType},
+		{Name: "EXTERNAL_REF_ID", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, [][]any{{int64(2), int64(20), updatedAt, "external-2"}})
+	defer staging.Release()
+	evolvedSchema := &deltaStruct{Type: "struct", Fields: []deltaField{
+		{Name: "ORDER_ID", Type: "long", Metadata: map[string]any{}},
+		{Name: "LINE_ID", Type: "long", Metadata: map[string]any{}},
+		{Name: "UPDATED_AT", Type: "timestamp", Metadata: map[string]any{}},
+		{Name: "EXTERNAL_REF_ID", Type: "string", Nullable: true, Metadata: map[string]any{}},
+	}}
+
+	targetBatches, err := alignDeltaBatches([]arrow.RecordBatch{oldTarget}, evolvedSchema)
+	require.NoError(t, err)
+	defer releaseBatches(targetBatches)
+	stagingBatches, err := alignDeltaBatches([]arrow.RecordBatch{staging}, evolvedSchema)
+	require.NoError(t, err)
+	defer releaseBatches(stagingBatches)
+	assert.True(t, targetBatches[0].Column(3).IsNull(0))
+
+	result, err := deleteInsertBatches(t.Context(), targetBatches, stagingBatches, destination.DeleteInsertOptions{
+		IncrementalKey:     "UPDATED_AT",
+		IncrementalKeyType: schema.TypeTimestampTZ,
+		IntervalStart:      updatedAt,
+		IntervalEnd:        updatedAt,
+	})
+	require.NoError(t, err)
+	defer releaseBatches(result)
+	_, _, err = writeBatchesToParquet(result)
+	require.NoError(t, err, "delete+insert rewrite must accept the evolved target and staging schemas")
+}
+
+func TestUnifyRewriteBatchesReconcilesNullabilityAndOrder(t *testing.T) {
+	t.Parallel()
+
+	// Evolution forces the target's added column nullable and appends it last;
+	// staging keeps the source's NOT NULL flag and its own column order.
+	target := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "tail", Type: arrow.BinaryTypes.String},
+		{Name: "extra", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, [][]any{{int64(1), "kept", nil}})
+	defer target.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "extra", Type: arrow.BinaryTypes.String},
+		{Name: "tail", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(2), "new-extra", "new-tail"}})
+	defer staging.Release()
+
+	unifiedTarget, unifiedStaging, release, err := unifyRewriteBatches(
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "tail", "extra"},
+	)
+	require.NoError(t, err)
+	defer release()
+	assert.True(t, unifiedTarget[0].Schema().Equal(unifiedStaging[0].Schema()))
+	assert.Equal(t, []string{"id", "tail", "extra"}, arrowFieldNames(unifiedStaging[0].Schema()))
+	assert.Equal(t, "new-tail", unifiedStaging[0].Column(1).(*array.String).Value(0), "values must follow names, not positions")
+	assert.Equal(t, "new-extra", unifiedStaging[0].Column(2).(*array.String).Value(0))
+
+	merged := append(retainAll(unifiedTarget), retainAll(unifiedStaging)...)
+	defer releaseBatches(merged)
+	_, _, err = writeBatchesToParquet(merged)
+	require.NoError(t, err)
+}
+
+// TestUnifyRewriteBatchesFillsSoftRemovedColumn covers the other direction of
+// evolution: the source dropped a column, so the table keeps it relaxed to
+// nullable and the incoming rows have to be NULL-filled for it.
+func TestUnifyRewriteBatchesFillsSoftRemovedColumn(t *testing.T) {
+	t.Parallel()
+
+	target := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "gone", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, [][]any{{int64(1), "kept"}})
+	defer target.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(2)}})
+	defer staging.Release()
+
+	unifiedTarget, unifiedStaging, release, err := unifyRewriteBatches(
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "gone"},
+	)
+	require.NoError(t, err)
+	defer release()
+	assert.Equal(t, []string{"id", "gone"}, arrowFieldNames(unifiedStaging[0].Schema()))
+	assert.True(t, unifiedStaging[0].Column(1).IsNull(0))
+	assert.Equal(t, "kept", unifiedTarget[0].Column(1).(*array.String).Value(0))
+
+	merged := append(retainAll(unifiedTarget), retainAll(unifiedStaging)...)
+	defer releaseBatches(merged)
+	_, _, err = writeBatchesToParquet(merged)
+	require.NoError(t, err)
+}
+
+// TestUnifyRewriteBatchesKeepsRequiredColumnMissingFromStaging guards the same
+// case when the column is still declared NOT NULL, which is what a table looks
+// like when evolution was skipped: filling it would contradict the declaration,
+// so the rewrite has to keep failing.
+func TestUnifyRewriteBatchesKeepsRequiredColumnMissingFromStaging(t *testing.T) {
+	t.Parallel()
+
+	target := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "gone", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(1), "kept"}})
+	defer target.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(2)}})
+	defer staging.Release()
+
+	_, _, release, err := unifyRewriteBatches(
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "gone"},
+	)
+	defer release()
+	require.ErrorContains(t, err, `column "gone" is required but the incoming rows do not have it`)
+}
+
+// TestUnifyRewriteBatchesKeepsUndeclaredStagingColumn guards against silently
+// dropping a staging column the target does not declare, which the NULL-filling
+// projection would otherwise do.
+func TestUnifyRewriteBatchesKeepsUndeclaredStagingColumn(t *testing.T) {
+	t.Parallel()
+
+	target := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "kept", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, [][]any{{int64(1), "old"}})
+	defer target.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "undeclared", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(2), "new"}})
+	defer staging.Release()
+
+	_, _, release, err := unifyRewriteBatches(
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "kept"},
+	)
+	defer release()
+	require.ErrorContains(t, err, `column "undeclared" is not declared in its Delta schema`)
+}
+
+func TestUnifyRewriteBatchesKeepsRealTypeConflicts(t *testing.T) {
+	t.Parallel()
+
+	target := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "note", Type: arrow.BinaryTypes.String},
+	}, [][]any{{int64(1), "kept"}})
+	defer target.Release()
+	staging := makeBatch(t, []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "note", Type: arrow.PrimitiveTypes.Int64},
+	}, [][]any{{int64(2), int64(3)}})
+	defer staging.Release()
+
+	_, _, release, err := unifyRewriteBatches(
+		[]arrow.RecordBatch{target}, []arrow.RecordBatch{staging}, []string{"id", "note"},
+	)
+	defer release()
+	require.ErrorContains(t, err, `column "note" is utf8 in the table and int64 in the incoming rows`)
 }
 
 func TestDeleteInsertBatches(t *testing.T) {


### PR DESCRIPTION
## What
Add schema evolution for OneLake Delta tables so incremental loads continue when sources add columns.

## Changes
- Preserve and evolve Delta metadata, and align older Parquet files to the current schema during copy-on-write rewrites.
- Reject unsupported Delta protocols and table features instead of risking corrupt rewrites.
- Add coverage for additive columns, metadata replay, schema alignment, and the reported `delete+insert` failure.

## How to test
1. `make test`

## Risk & rollback
- **Risk:** Medium — this changes Delta transaction-log reads and copy-on-write behavior.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
N/A
