### PR TITLE
Add SAP HANA destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Pull requests are welcome. However, please open an issue first to discuss what y
     <tr>
         <td>SAP Hana</td>
         <td>✅</td>
-        <td>-</td>
+        <td>✅</td>
         <td>-</td>
     </tr>
     <tr>

--- a/docs/supported-sources/sap-hana.md
+++ b/docs/supported-sources/sap-hana.md
@@ -1,7 +1,7 @@
 # SAP HANA
 SAP HANA is an in-memory, column-oriented, relational database management system.
 
-ingestr supports SAP HANA as both a source and destination. It uses the [SQLAlchemy connector for SAP HANA](https://github.com/SAP/sqlalchemy-hana/), so the connection options there would all be valid.
+ingestr supports SAP HANA as both a source and destination. It uses SAP's pure-Go [`go-hdb`](https://github.com/SAP/go-hdb) driver and does not require SAP client libraries or cgo.
 
 ## URI format
 The URI format for SAP HANA is as follows:
@@ -17,4 +17,6 @@ URI parameters:
 - `port`: the port number the database server is listening on, default is 30015
 - `dbname`: the name of the database to connect to
 
-The URI structure can be used both for sources and destinations. More details about SAP HANA’s JDBC and ODBC interfaces can be found [here](https://github.com/SAP/sqlalchemy-hana/).
+The same URI structure is used for both sources and destinations. HANA Cloud connections on port 443 enable TLS automatically, and `go-hdb` DSN parameters such as `databaseName` can be supplied as query parameters when needed.
+
+The destination supports `replace`, `append`, `merge`, `delete+insert`, and `scd2` strategies. Tables may be specified as either `table` or `schema.table`. SCD2 logical primary keys must use bounded, non-LOB types. Other LOB-backed string, JSON, array, and binary columns can be compared when current and staged values are at most 2000 bytes; larger LOB values require a different strategy.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.42.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0
-	github.com/SAP/go-hdb v1.16.2
+	github.com/SAP/go-hdb v1.17.2
 	github.com/alecthomas/chroma/v2 v2.23.1
 	github.com/aliyun/aliyun-odps-go-sdk v0.4.22
 	github.com/apache/arrow-adbc/go/adbc v0.0.0-20260729182025-74d5395a880c

--- a/go.sum
+++ b/go.sum
@@ -1009,8 +1009,8 @@ github.com/ProtonMail/gopenpgp/v3 v3.3.0/go.mod h1:J+iNPt0/5EO9wRt7Eit9dRUlzyu3h
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/RoaringBitmap/roaring/v2 v2.21.0 h1:RKVgkD+c9ouyCydF2PW/mztDyZTsb7ksas/IofnguDg=
 github.com/RoaringBitmap/roaring/v2 v2.21.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/SAP/go-hdb v1.16.2 h1:JEFwumHG/5qbBISYpTcR22e20nX4yYxZ5ZwhGNKskms=
-github.com/SAP/go-hdb v1.16.2/go.mod h1:LNpXz+MoCtka8RqefdbjwXXCXpqngFcsF3qpARsCR3U=
+github.com/SAP/go-hdb v1.17.2 h1:bxQfX6tw3twRIeCUf4HCcagORVPtLF5/vigFRQkh1UA=
+github.com/SAP/go-hdb v1.17.2/go.mod h1:UyvW+7VKLmwEYhV3KGEqrR63BWPP22LWWYG6WK0BHSc=
 github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06/go.mod h1:7erjKLwalezA0k99cWs5L11HWOAPNjdUZ6RxH1BXbbM=
 github.com/Shopify/sarama v1.38.1/go.mod h1:iwv9a67Ha8VNa+TifujYoWGxWnu2kNVAQdSdZ4X2o5g=
 github.com/Shopify/toxiproxy/v2 v2.12.0/go.mod h1:R9Z38Pw6k2cGZWXHe7tbxjGW9azmY1KbDQJ1kd+h7Tk=

--- a/internal/hanautil/uri.go
+++ b/internal/hanautil/uri.go
@@ -1,0 +1,48 @@
+package hanautil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	hdbdriver "github.com/SAP/go-hdb/driver"
+)
+
+func ParseURI(uri string) (string, string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", "", err
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "hana" && scheme != "saphana" {
+		return "", "", fmt.Errorf("unsupported scheme: %s", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return "", "", errors.New("host is required")
+	}
+
+	port := u.Port()
+	if port == "" {
+		port = "30015"
+	}
+
+	dsn := &url.URL{
+		Scheme: hdbdriver.DriverName,
+		Host:   net.JoinHostPort(u.Hostname(), port),
+		User:   u.User,
+	}
+	database := strings.TrimPrefix(u.Path, "/")
+	query := u.Query()
+	if database != "" {
+		query.Set(hdbdriver.DSNDefaultSchema, database)
+	}
+	if port == "443" && query.Get("TLSInsecureSkipVerify") == "" && query.Get("TLSServerName") == "" {
+		query.Set("TLSServerName", u.Hostname())
+	}
+	dsn.RawQuery = query.Encode()
+
+	return dsn.String(), database, nil
+}

--- a/internal/hanautil/uri_test.go
+++ b/internal/hanautil/uri_test.go
@@ -1,0 +1,66 @@
+package hanautil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantDSN      string
+		wantDatabase string
+		wantError    string
+	}{
+		{
+			name:         "original source format",
+			uri:          "hana://user:p%40ss@hana.example.com/landing",
+			wantDSN:      "hdb://user:p%40ss@hana.example.com:30015?defaultSchema=landing",
+			wantDatabase: "landing",
+		},
+		{
+			name:         "tenant query parameter",
+			uri:          "hana://user:pass@hana.example.com/landing?databaseName=TENANT",
+			wantDSN:      "hdb://user:pass@hana.example.com:30015?databaseName=TENANT&defaultSchema=landing",
+			wantDatabase: "landing",
+		},
+		{
+			name:         "cloud TLS defaults",
+			uri:          "saphana://user:pass@abc.hanacloud.ondemand.com:443/APP",
+			wantDSN:      "hdb://user:pass@abc.hanacloud.ondemand.com:443?TLSServerName=abc.hanacloud.ondemand.com&defaultSchema=APP",
+			wantDatabase: "APP",
+		},
+		{
+			name:         "ipv6 literal host keeps brackets",
+			uri:          "hana://user:pass@[2001:db8::1]:30015/APP",
+			wantDSN:      "hdb://user:pass@[2001:db8::1]:30015?defaultSchema=APP",
+			wantDatabase: "APP",
+		},
+		{
+			name:      "invalid scheme",
+			uri:       "postgres://user:pass@localhost/db",
+			wantError: "unsupported scheme",
+		},
+		{
+			name:      "missing host",
+			uri:       "hana:///APP",
+			wantError: "host is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn, database, err := ParseURI(tt.uri)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDSN, dsn)
+			assert.Equal(t, tt.wantDatabase, database)
+		})
+	}
+}

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -264,7 +264,7 @@ func GetConnectors() []ConnectorType {
 			Name:          "SAP HANA",
 			Schemes:       []string{"hana", "saphana"},
 			IsSource:      true,
-			IsDestination: false,
+			IsDestination: true,
 			Fields: []ConnectorField{
 				{Name: "host", Label: "Host", Type: "string", Required: true, Placeholder: "localhost"},
 				{Name: "port", Label: "Port", Type: "number", Required: false, Default: "30015", Placeholder: "30015"},

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -275,6 +275,11 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
+    - module: github.com/DataDog/zstd
+      version: v1.5.7
+      licenses:
+        - BSD-3-Clause
+      status: allowed
     - module: github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp
       version: v1.6.0
       licenses:
@@ -757,6 +762,11 @@ dependencies:
       version: v1.0.1
       licenses:
         - MIT
+      status: allowed
+    - module: github.com/ebitengine/purego
+      version: v0.10.0
+      licenses:
+        - Apache-2.0
       status: allowed
     - module: github.com/eclipse/paho.mqtt.golang
       version: v1.5.1

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -275,11 +275,6 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
-    - module: github.com/DataDog/zstd
-      version: v1.5.7
-      licenses:
-        - BSD-3-Clause
-      status: allowed
     - module: github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp
       version: v1.6.0
       licenses:
@@ -326,7 +321,7 @@ dependencies:
         - Apache-2.0
       status: allowed
     - module: github.com/SAP/go-hdb
-      version: v1.16.2
+      version: v1.17.2
       licenses:
         - Apache-2.0
       status: allowed
@@ -762,11 +757,6 @@ dependencies:
       version: v1.0.1
       licenses:
         - MIT
-      status: allowed
-    - module: github.com/ebitengine/purego
-      version: v0.10.0
-      licenses:
-        - Apache-2.0
       status: allowed
     - module: github.com/eclipse/paho.mqtt.golang
       version: v1.5.1

--- a/pkg/destination/dialect_conformance_test.go
+++ b/pkg/destination/dialect_conformance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/cratedb"
 	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
 	"github.com/bruin-data/ingestr/pkg/destination/fabric"
+	"github.com/bruin-data/ingestr/pkg/destination/hana"
 	"github.com/bruin-data/ingestr/pkg/destination/maxcompute"
 	"github.com/bruin-data/ingestr/pkg/destination/mssql"
 	"github.com/bruin-data/ingestr/pkg/destination/mysql"
@@ -43,6 +44,7 @@ func dialectsByScheme() map[string]destination.Dialect {
 		"clickhouse": &clickhouse.Dialect{},
 		"cratedb":    &cratedb.Dialect{},
 		"fabric":     &fabric.Dialect{},
+		"hana":       &hana.Dialect{},
 		"maxcompute": &maxcompute.Dialect{},
 		"mysql":      &mysql.Dialect{},
 		"mssql":      &mssql.Dialect{},
@@ -101,6 +103,7 @@ func TestAllDialects_QuoteIdentifier(t *testing.T) {
 		{"mysql", "column_name", "`column_name`"},
 		{"mssql", "column_name", "[column_name]"},
 		{"oracle", "column_name", `"COLUMN_NAME"`},
+		{"hana", "column_name", `"COLUMN_NAME"`},
 		{"redshift", "column_name", `"column_name"`},
 		{"synapse", "column_name", "[column_name]"},
 		{"trino", "column_name", `"column_name"`},
@@ -131,6 +134,7 @@ func TestAllDialects_TypeName_Boolean(t *testing.T) {
 		"mysql":      "TINYINT(1)",
 		"mssql":      "BIT",
 		"oracle":     "NUMBER(1,0)",
+		"hana":       "BOOLEAN",
 		"redshift":   "BOOLEAN",
 		"synapse":    "BIT",
 		"trino":      "BOOLEAN",
@@ -164,6 +168,7 @@ func TestAllDialects_TypeName_Integers(t *testing.T) {
 				"mysql":      "SMALLINT",
 				"mssql":      "SMALLINT",
 				"oracle":     "NUMBER(5,0)",
+				"hana":       "SMALLINT",
 				"redshift":   "SMALLINT",
 				"synapse":    "SMALLINT",
 				"trino":      "SMALLINT",
@@ -185,6 +190,7 @@ func TestAllDialects_TypeName_Integers(t *testing.T) {
 				"mysql":      "INT",
 				"mssql":      "INT",
 				"oracle":     "NUMBER(10,0)",
+				"hana":       "INTEGER",
 				"redshift":   "INTEGER",
 				"synapse":    "INT",
 				"trino":      "INTEGER",
@@ -206,6 +212,7 @@ func TestAllDialects_TypeName_Integers(t *testing.T) {
 				"mysql":      "BIGINT",
 				"mssql":      "BIGINT",
 				"oracle":     "NUMBER(19,0)",
+				"hana":       "BIGINT",
 				"redshift":   "BIGINT",
 				"synapse":    "BIGINT",
 				"trino":      "BIGINT",
@@ -246,6 +253,7 @@ func TestAllDialects_TypeName_Floats(t *testing.T) {
 				"mysql":      "FLOAT",
 				"mssql":      "REAL",
 				"oracle":     "BINARY_FLOAT",
+				"hana":       "REAL",
 				"redshift":   "REAL",
 				"synapse":    "REAL",
 				"trino":      "REAL",
@@ -267,6 +275,7 @@ func TestAllDialects_TypeName_Floats(t *testing.T) {
 				"mysql":      "DOUBLE",
 				"mssql":      "FLOAT",
 				"oracle":     "BINARY_DOUBLE",
+				"hana":       "DOUBLE",
 				"redshift":   "DOUBLE PRECISION",
 				"synapse":    "FLOAT",
 				"trino":      "DOUBLE",
@@ -359,6 +368,7 @@ func TestAllDialects_TypeName_SizedString(t *testing.T) {
 		"redshift":   "VARCHAR(50)",
 		"bigquery":   "STRING(50)",
 		"oracle":     "VARCHAR2(50 CHAR)",
+		"hana":       "NVARCHAR(50)",
 		"duckdb":     "VARCHAR(50)",
 		"trino":      "VARCHAR(50)",
 		"cratedb":    "VARCHAR(50)",
@@ -410,6 +420,7 @@ func TestAllDialects_AddColumnSQL(t *testing.T) {
 func TestAllDialects_AddColumnSQL_Nullable(t *testing.T) {
 	// Dialects that include NULL/NOT NULL in AddColumnSQL.
 	dialectsWithNullability := map[string]bool{
+		"hana":  true,
 		"mysql": true,
 		"mssql": true,
 	}
@@ -433,23 +444,32 @@ func TestAllDialects_AddColumnSQL_Nullable(t *testing.T) {
 }
 
 func TestAllDialects_AlterColumnTypeSQL(t *testing.T) {
+	// Dialects that fold unquoted identifiers to upper case.
+	dialectsUpperCasingIdentifiers := map[string]bool{
+		"hana": true,
+	}
+
 	for _, dt := range allDialects() {
 		t.Run(dt.Scheme, func(t *testing.T) {
 			if !dt.Dialect.SupportsAlterType() {
 				t.Skip("dialect does not support ALTER TYPE")
 			}
 
+			expectedTable := "test_table"
+			if dialectsUpperCasingIdentifiers[dt.Scheme] {
+				expectedTable = "TEST_TABLE"
+			}
 			newType := schema.Column{Name: "val", DataType: schema.TypeInt64, Nullable: true}
 			sql := dt.Dialect.AlterColumnTypeSQL("test_table", "val", newType)
 			assert.Contains(t, sql, "ALTER TABLE")
-			assert.Contains(t, sql, "test_table")
+			assert.Contains(t, sql, expectedTable, "SQL should contain table name")
 			assert.True(t, strings.Contains(strings.ToLower(sql), "val"), "SQL should contain column name")
 		})
 	}
 }
 
 func TestDialect_SupportsAlterType(t *testing.T) {
-	dialectsWithAlter := []string{"postgres", "duckdb", "snowflake", "bigquery", "clickhouse", "mysql", "mssql", "redshift", "synapse", "fabric"}
+	dialectsWithAlter := []string{"postgres", "duckdb", "snowflake", "bigquery", "clickhouse", "mysql", "mssql", "redshift", "synapse", "fabric", "hana"}
 	dialectsWithoutAlter := []string{"sqlite", "trino", "cassandra", "athena", "cratedb", "maxcompute", "oracle"}
 
 	for _, scheme := range dialectsWithAlter {

--- a/pkg/destination/error_batch_release_test.go
+++ b/pkg/destination/error_batch_release_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/destination/hana"
 	"github.com/bruin-data/ingestr/pkg/destination/mssql"
 	"github.com/bruin-data/ingestr/pkg/destination/mysql"
 	"github.com/bruin-data/ingestr/pkg/destination/oracle"
@@ -31,6 +32,7 @@ func TestDestinationWritersReleaseBatchAttachedToError(t *testing.T) {
 		{name: "mysql", dest: mysql.NewMySQLDestination(), write: writeParallel},
 		{name: "mssql serial", dest: mssql.NewMSSQLDestination(), write: writeParallel},
 		{name: "mssql parallel", dest: mssql.NewMSSQLDestination(), opts: destination.WriteOptions{StagingTable: true, Parallelism: 2}, write: writeParallel},
+		{name: "hana", dest: hana.NewHanaDestination(), write: writeParallel},
 		{name: "sqlite", dest: sqlite.NewSQLiteDestination(), write: writeParallel},
 		{name: "oracle", dest: oracle.NewOracleDestination(), write: writeParallel},
 		{name: "redshift", dest: redshift.NewRedshiftDestination(), write: writeParallel},

--- a/pkg/destination/hana/dialect.go
+++ b/pkg/destination/hana/dialect.go
@@ -1,0 +1,68 @@
+package hana
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+type Dialect struct{}
+
+func (d *Dialect) Name() string {
+	return "SAP HANA"
+}
+
+func (d *Dialect) AddColumnSQL(table string, col schema.Column) string {
+	nullable := ""
+	if !col.Nullable {
+		nullable = " NOT NULL"
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD (%s %s%s)", quoteTable(table), d.QuoteIdentifier(col.Name), d.TypeName(col), nullable)
+}
+
+func (d *Dialect) BatchAddColumnsSQL(table string, cols []schema.Column) string {
+	if len(cols) == 0 {
+		return ""
+	}
+	definitions := make([]string, len(cols))
+	for i, col := range cols {
+		nullable := ""
+		if !col.Nullable {
+			nullable = " NOT NULL"
+		}
+		definitions[i] = fmt.Sprintf("%s %s%s", d.QuoteIdentifier(col.Name), d.TypeName(col), nullable)
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD (%s)", quoteTable(table), strings.Join(definitions, ", "))
+}
+
+func (d *Dialect) AlterColumnTypeSQL(table, colName string, newType schema.Column) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER (%s %s)", quoteTable(table), d.QuoteIdentifier(colName), d.TypeName(newType))
+}
+
+func (d *Dialect) BatchAlterColumnTypesSQL(table string, cols []schema.Column) string {
+	if len(cols) == 0 {
+		return ""
+	}
+	definitions := make([]string, len(cols))
+	for i, col := range cols {
+		definitions[i] = fmt.Sprintf("%s %s", d.QuoteIdentifier(col.Name), d.TypeName(col))
+	}
+	return fmt.Sprintf("ALTER TABLE %s ALTER (%s)", quoteTable(table), strings.Join(definitions, ", "))
+}
+
+func (d *Dialect) RelaxColumnNullabilitySQL(table, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER (%s NULL)", quoteTable(table), d.QuoteIdentifier(colName))
+}
+
+func (d *Dialect) SupportsAlterType() bool {
+	return true
+}
+
+func (d *Dialect) TypeName(col schema.Column) string {
+	return mapDataTypeToHana(col, col.IsPrimaryKey)
+}
+
+func (d *Dialect) QuoteIdentifier(name string) string {
+	return quoteColumn(name)
+}

--- a/pkg/destination/hana/evolve.go
+++ b/pkg/destination/hana/evolve.go
@@ -1,0 +1,264 @@
+package hana
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+)
+
+func (d *HanaDestination) ApplySchemaEvolution(ctx context.Context, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
+	if comparison == nil || !comparison.HasChanges {
+		return nil, nil
+	}
+
+	dialect := &Dialect{}
+	var warnings []string
+	for _, change := range comparison.Changes {
+		if change.Type != schemaevolution.ChangeAddColumn || change.OldColumn != nil {
+			continue
+		}
+		recovered, err := d.recoverInterruptedColumnRewrite(ctx, table, change.ColumnName)
+		if err != nil {
+			return warnings, err
+		}
+		if recovered {
+			return warnings, fmt.Errorf("recovered interrupted HANA rewrite for column %q; retry ingestion so schema evolution can be replanned", change.ColumnName)
+		}
+	}
+
+	for _, change := range comparison.Changes {
+		if change.Type == schemaevolution.ChangeRemoveColumn && isRewriteArtifactColumn(change.ColumnName) {
+			if err := d.dropColumn(ctx, table, change.ColumnName); err != nil {
+				return warnings, fmt.Errorf("clean interrupted HANA rewrite artifact %q: %w", change.ColumnName, err)
+			}
+			continue
+		}
+		// HANA cannot store a primary key in a LOB column, so such columns are created as
+		// NVARCHAR(hanaMaxInlineLength). Carry the flag over so the rendered types match and
+		// the no-op widening back to NCLOB is suppressed instead of failing.
+		if change.OldColumn != nil && change.OldColumn.IsPrimaryKey {
+			change.NewColumn.IsPrimaryKey = true
+		}
+		singleChange := &schemaevolution.SchemaComparison{
+			Changes:    []schemaevolution.SchemaChange{change},
+			HasChanges: true,
+		}
+		statements, changeWarnings, err := destination.RenderEvolution(dialect, table, singleChange)
+		if err != nil {
+			return warnings, err
+		}
+		warnings = append(warnings, changeWarnings...)
+
+		for _, statement := range statements {
+			if err := d.Exec(ctx, statement); err != nil {
+				if isTypeChange(change) && supportsColumnRewrite(change.NewColumn) {
+					if rewriteErr := d.rewriteColumnType(ctx, table, change); rewriteErr == nil {
+						continue
+					} else {
+						return warnings, fmt.Errorf("apply schema evolution: %s: %w; HANA column rewrite also failed: %v", statement, err, rewriteErr)
+					}
+				}
+				return warnings, fmt.Errorf("apply schema evolution: %s: %w", statement, err)
+			}
+		}
+	}
+	return warnings, nil
+}
+
+func isRewriteArtifactColumn(column string) bool {
+	name := canonicalIdentifier(column)
+	return strings.HasPrefix(name, "__BRUIN_EVOLVE_NEW_") || strings.HasPrefix(name, "__BRUIN_EVOLVE_OLD_")
+}
+
+func (d *HanaDestination) SupportsColumnTypeChanges() bool {
+	return (&Dialect{}).SupportsAlterType()
+}
+
+func isTypeChange(change schemaevolution.SchemaChange) bool {
+	return change.Type == schemaevolution.ChangeWidenType || change.Type == schemaevolution.ChangeOverrideType
+}
+
+func supportsColumnRewrite(column schema.Column) bool {
+	switch column.DataType {
+	case schema.TypeString, schema.TypeJSON, schema.TypeArray:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *HanaDestination) rewriteColumnType(ctx context.Context, table string, change schemaevolution.SchemaChange) error {
+	if change.OldColumn == nil {
+		return fmt.Errorf("column %q has no existing type to rewrite", change.ColumnName)
+	}
+	if change.OldColumn.IsPrimaryKey {
+		return fmt.Errorf("cannot rewrite primary-key column %q", change.ColumnName)
+	}
+
+	temporaryName, backupName := rewriteArtifactColumnNames(table, change.ColumnName)
+	if recovered, err := d.recoverInterruptedColumnRewrite(ctx, table, change.ColumnName); err != nil {
+		return err
+	} else if recovered {
+		return fmt.Errorf("recovered an interrupted rewrite for column %q; retry schema evolution", change.ColumnName)
+	}
+	targetType := (&Dialect{}).TypeName(change.NewColumn)
+	addSQL := fmt.Sprintf("ALTER TABLE %s ADD (%s %s)", quoteTable(table), quoteColumn(temporaryName), targetType)
+	if err := d.Exec(ctx, addSQL); err != nil {
+		return fmt.Errorf("add conversion column: %w", err)
+	}
+
+	cleanupTemporary := true
+	defer func() {
+		if cleanupTemporary {
+			_ = d.Exec(ctx, fmt.Sprintf("ALTER TABLE %s DROP (%s)", quoteTable(table), quoteColumn(temporaryName)))
+		}
+	}()
+
+	conversion := fmt.Sprintf("CAST(%s AS %s)", quoteColumn(change.ColumnName), targetType)
+	if targetType == "NCLOB" {
+		conversion = fmt.Sprintf("TO_NCLOB(%s)", quoteColumn(change.ColumnName))
+	}
+	updateSQL := fmt.Sprintf(
+		"UPDATE %s SET %s = %s",
+		quoteTable(table), quoteColumn(temporaryName), conversion,
+	)
+	if err := d.Exec(ctx, updateSQL); err != nil {
+		return fmt.Errorf("convert column values: %w", err)
+	}
+
+	if !change.NewColumn.Nullable {
+		notNullSQL := fmt.Sprintf("ALTER TABLE %s ALTER (%s NOT NULL)", quoteTable(table), quoteColumn(temporaryName))
+		if err := d.Exec(ctx, notNullSQL); err != nil {
+			return fmt.Errorf("apply NOT NULL to converted column: %w", err)
+		}
+	}
+
+	if err := d.renameColumn(ctx, table, change.ColumnName, backupName); err != nil {
+		_, recoveryErr := d.recoverInterruptedColumnRewrite(ctx, table, change.ColumnName)
+		if recoveryErr != nil {
+			return fmt.Errorf("preserve original column %q as %q: %w; recovery failed: %v", change.ColumnName, backupName, err, recoveryErr)
+		}
+		return fmt.Errorf("preserve original column %q as %q: %w", change.ColumnName, backupName, err)
+	}
+	if err := d.renameColumn(ctx, table, temporaryName, change.ColumnName); err != nil {
+		exists, inspectErr := d.rewriteColumnExistence(ctx, table, change.ColumnName, temporaryName, backupName)
+		if inspectErr == nil && exists[canonicalIdentifier(change.ColumnName)] && !exists[canonicalIdentifier(temporaryName)] {
+			cleanupTemporary = false
+			if dropErr := d.dropColumn(ctx, table, backupName); dropErr != nil {
+				return fmt.Errorf("converted column %q was activated despite a connection error, but backup cleanup failed: %w", change.ColumnName, dropErr)
+			}
+			return nil
+		}
+		if restoreErr := d.renameColumn(ctx, table, backupName, change.ColumnName); restoreErr != nil {
+			return fmt.Errorf("activate converted column %q: %w; original remains at %q and restore failed: %v; state inspection failed: %v", change.ColumnName, err, backupName, restoreErr, inspectErr)
+		}
+		return fmt.Errorf("activate converted column %q: %w; original column restored", change.ColumnName, err)
+	}
+	cleanupTemporary = false
+
+	if err := d.dropColumn(ctx, table, backupName); err != nil {
+		return fmt.Errorf("drop rewrite backup column %q after activating %q: %w", backupName, change.ColumnName, err)
+	}
+	return nil
+}
+
+func rewriteArtifactColumnNames(table, column string) (string, string) {
+	seed := quoteTable(table) + "\x00" + canonicalIdentifier(column)
+	digest := sha256.Sum256([]byte(seed))
+	tag := canonicalIdentifier(hex.EncodeToString(digest[:4]))
+	name := func(kind string) string {
+		candidate := fmt.Sprintf("__BRUIN_EVOLVE_%s_%s_%s", kind, canonicalIdentifier(column), tag)
+		return destination.ShortenIdentifier(candidate, candidate, destination.MaxIdentifierLength("hana"))
+	}
+	return name("NEW"), name("OLD")
+}
+
+func (d *HanaDestination) recoverInterruptedColumnRewrite(ctx context.Context, table, column string) (bool, error) {
+	temporaryName, backupName := rewriteArtifactColumnNames(table, column)
+	exists, err := d.rewriteColumnExistence(ctx, table, column, temporaryName, backupName)
+	if err != nil {
+		return false, err
+	}
+	originalExists := exists[canonicalIdentifier(column)]
+	temporaryExists := exists[canonicalIdentifier(temporaryName)]
+	backupExists := exists[canonicalIdentifier(backupName)]
+
+	switch {
+	case originalExists && temporaryExists && backupExists:
+		return false, fmt.Errorf("ambiguous HANA rewrite state for column %q: both rewrite artifacts still exist", column)
+	case originalExists && backupExists:
+		if err := d.dropColumn(ctx, table, backupName); err != nil {
+			return false, fmt.Errorf("clean completed rewrite backup %q: %w", backupName, err)
+		}
+	case originalExists && temporaryExists:
+		if err := d.dropColumn(ctx, table, temporaryName); err != nil {
+			return false, fmt.Errorf("clean abandoned rewrite column %q: %w", temporaryName, err)
+		}
+	case !originalExists && backupExists:
+		if err := d.renameColumn(ctx, table, backupName, column); err != nil {
+			return false, fmt.Errorf("restore interrupted rewrite backup %q to %q: %w", backupName, column, err)
+		}
+		if temporaryExists {
+			if err := d.dropColumn(ctx, table, temporaryName); err != nil {
+				return false, fmt.Errorf("clean converted rewrite column %q after restoring %q: %w", temporaryName, column, err)
+			}
+		}
+		return true, nil
+	case !originalExists && temporaryExists:
+		if err := d.renameColumn(ctx, table, temporaryName, column); err != nil {
+			return false, fmt.Errorf("activate recovered rewrite column %q as %q: %w", temporaryName, column, err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (d *HanaDestination) rewriteColumnExistence(ctx context.Context, table string, columns ...string) (map[string]bool, error) {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+	query := `
+		SELECT COLUMN_NAME
+		FROM SYS.TABLE_COLUMNS
+		WHERE SCHEMA_NAME = ? AND TABLE_NAME = ? AND COLUMN_NAME IN (?, ?, ?)`
+	rows, err := d.db.QueryContext(
+		ctx,
+		query,
+		schemaName,
+		tableName,
+		canonicalIdentifier(columns[0]),
+		canonicalIdentifier(columns[1]),
+		canonicalIdentifier(columns[2]),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("inspect HANA rewrite state for column %q: %w", columns[0], err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	exists := make(map[string]bool, len(columns))
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan HANA rewrite state: %w", err)
+		}
+		exists[canonicalIdentifier(name)] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate HANA rewrite state: %w", err)
+	}
+	return exists, nil
+}
+
+func (d *HanaDestination) renameColumn(ctx context.Context, table, from, to string) error {
+	query := fmt.Sprintf("RENAME COLUMN %s.%s TO %s", quoteTable(table), quoteColumn(from), quoteColumn(to))
+	return d.Exec(ctx, query)
+}
+
+func (d *HanaDestination) dropColumn(ctx context.Context, table, column string) error {
+	query := fmt.Sprintf("ALTER TABLE %s DROP (%s)", quoteTable(table), quoteColumn(column))
+	return d.Exec(ctx, query)
+}

--- a/pkg/destination/hana/hana.go
+++ b/pkg/destination/hana/hana.go
@@ -22,6 +22,9 @@ import (
 const (
 	defaultHanaStagingSchema = "_bruin_staging"
 	hanaSCD2HashMaxLength    = 2000
+	hanaDDLAutocommitOff     = "SET TRANSACTION AUTOCOMMIT DDL OFF"
+	hanaDDLAutocommitOn      = "SET TRANSACTION AUTOCOMMIT DDL ON"
+	hanaRecoveryTimeout      = 30 * time.Second
 	// Matches go-hdb's default bulk package size, so each Exec maps to one wire package.
 	hanaInsertRowsPerStatement = 10000
 )
@@ -270,21 +273,20 @@ func (d *HanaDestination) SwapTable(ctx context.Context, opts destination.SwapOp
 	backupTable := ""
 	if targetExists {
 		backupTable = backupTableName(targetSchema, targetName)
-		if err := d.DropTable(ctx, backupTable); err != nil {
-			return err
-		}
-		if err := d.renameTable(ctx, opts.TargetTable, backupTable); err != nil {
-			return fmt.Errorf("failed to rename HANA target to backup: %w", err)
-		}
 	}
 
-	if err := d.renameTable(ctx, opts.StagingTable, opts.TargetTable); err != nil {
+	if err := d.withAtomicDDL(ctx, func(tx *sql.Tx) error {
 		if backupTable != "" {
-			if restoreErr := d.renameTable(ctx, backupTable, opts.TargetTable); restoreErr != nil {
-				return fmt.Errorf("failed to rename HANA staging table to target: %w; backup restore failed: %v", err, restoreErr)
+			if err := renameHanaTable(ctx, tx, opts.TargetTable, backupTable); err != nil {
+				return fmt.Errorf("failed to rename HANA target to backup: %w", err)
 			}
 		}
-		return fmt.Errorf("failed to rename HANA staging table to target: %w", err)
+		if err := renameHanaTable(ctx, tx, opts.StagingTable, opts.TargetTable); err != nil {
+			return fmt.Errorf("failed to rename HANA staging table to target: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if backupTable != "" {
@@ -308,12 +310,6 @@ func (d *HanaDestination) copySwapTable(ctx context.Context, opts destination.Sw
 	backupTable := ""
 	if targetExists {
 		backupTable = backupTableName(targetSchema, targetName)
-		if err := d.DropTable(ctx, backupTable); err != nil {
-			return err
-		}
-		if err := d.renameTable(ctx, opts.TargetTable, backupTable); err != nil {
-			return err
-		}
 	}
 
 	// The rename path carries the staging table's PRIMARY KEY over to the target, so the copy
@@ -322,27 +318,36 @@ func (d *HanaDestination) copySwapTable(ctx context.Context, opts destination.Sw
 	if len(primaryKeys) == 0 {
 		primaryKeys = opts.Schema.PrimaryKeys
 	}
-	if err := d.PrepareTable(ctx, destination.PrepareOptions{
-		Table: opts.TargetTable, Schema: opts.Schema, PrimaryKeys: primaryKeys,
-	}); err != nil {
-		if backupTable != "" {
-			_ = d.renameTable(ctx, backupTable, opts.TargetTable)
-		}
+	targetSchemaName, _ := d.effectiveSchemaTable(opts.TargetTable)
+	if err := d.ensureSchemaExists(ctx, targetSchemaName); err != nil {
 		return err
 	}
 
 	columns := strings.Join(quoteColumns(opts.Schema.ColumnNames()), ", ")
+	createSQL := buildCreateTableSQL(opts.TargetTable, destination.PrepareOptions{
+		Table: opts.TargetTable, Schema: opts.Schema, PrimaryKeys: primaryKeys,
+	})
 	copySQL := fmt.Sprintf(
 		"INSERT INTO %s (%s) SELECT %s FROM %s",
 		quoteTable(opts.TargetTable), columns, columns, quoteTable(opts.StagingTable),
 	)
-	if _, err := d.db.ExecContext(ctx, copySQL); err != nil {
-		config.LogFailedQuery(copySQL, err)
-		_ = d.DropTable(ctx, opts.TargetTable)
+	if err := d.withAtomicDDL(ctx, func(tx *sql.Tx) error {
 		if backupTable != "" {
-			_ = d.renameTable(ctx, backupTable, opts.TargetTable)
+			if err := renameHanaTable(ctx, tx, opts.TargetTable, backupTable); err != nil {
+				return fmt.Errorf("failed to rename HANA target to backup: %w", err)
+			}
 		}
-		return fmt.Errorf("failed to copy HANA staging table into target: %w", err)
+		if _, err := tx.ExecContext(ctx, createSQL); err != nil {
+			config.LogFailedQuery(createSQL, err)
+			return fmt.Errorf("failed to create HANA replacement table: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, copySQL); err != nil {
+			config.LogFailedQuery(copySQL, err)
+			return fmt.Errorf("failed to copy HANA staging table into target: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if err := d.DropTable(ctx, opts.StagingTable); err != nil {
@@ -356,11 +361,55 @@ func (d *HanaDestination) copySwapTable(ctx context.Context, opts destination.Sw
 	return nil
 }
 
-func (d *HanaDestination) renameTable(ctx context.Context, from, to string) error {
+type hanaExecer interface {
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+}
+
+func renameHanaTable(ctx context.Context, execer hanaExecer, from, to string) error {
 	renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s", quoteTable(from), quoteTable(to))
-	if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
+	if _, err := execer.ExecContext(ctx, renameSQL); err != nil {
 		config.LogFailedQuery(renameSQL, err)
 		return err
+	}
+	return nil
+}
+
+func (d *HanaDestination) withAtomicDDL(ctx context.Context, fn func(*sql.Tx) error) (err error) {
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire HANA swap connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	tx, err := conn.BeginTx(context.WithoutCancel(ctx), nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin HANA atomic DDL transaction: %w", err)
+	}
+	ddlAutocommitDisabled := false
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				err = errors.Join(err, fmt.Errorf("failed to roll back HANA atomic DDL transaction: %w", rollbackErr))
+			}
+		}
+		if ddlAutocommitDisabled {
+			recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hanaRecoveryTimeout)
+			defer cancel()
+			if _, resetErr := conn.ExecContext(recoveryCtx, hanaDDLAutocommitOn); resetErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to restore HANA DDL autocommit: %w", resetErr))
+			}
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, hanaDDLAutocommitOff); err != nil {
+		return fmt.Errorf("failed to disable HANA DDL autocommit: %w", err)
+	}
+	ddlAutocommitDisabled = true
+	if err = fn(tx); err != nil {
+		return err
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit HANA atomic DDL transaction: %w", err)
 	}
 	return nil
 }
@@ -1026,7 +1075,10 @@ func resolvedIdentifierReference(name string) string {
 }
 
 func isOrdinaryIdentifier(name string) bool {
-	if name == "" || !((name[0] >= 'A' && name[0] <= 'Z') || name[0] == '_') {
+	if name == "" {
+		return false
+	}
+	if name[0] != '_' && (name[0] < 'A' || name[0] > 'Z') {
 		return false
 	}
 	for i := 1; i < len(name); i++ {

--- a/pkg/destination/hana/hana.go
+++ b/pkg/destination/hana/hana.go
@@ -1,0 +1,1131 @@
+package hana
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	hdbdriver "github.com/SAP/go-hdb/driver"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/hanautil"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
+)
+
+const (
+	defaultHanaStagingSchema = "_bruin_staging"
+	hanaSCD2HashMaxLength    = 2000
+	// Matches go-hdb's default bulk package size, so each Exec maps to one wire package.
+	hanaInsertRowsPerStatement = 10000
+)
+
+type HanaDestination struct {
+	db            *sql.DB
+	uri           string
+	defaultSchema string
+}
+
+func NewHanaDestination() *HanaDestination {
+	return &HanaDestination{}
+}
+
+func (d *HanaDestination) Schemes() []string {
+	return []string{"hana", "saphana"}
+}
+
+func (d *HanaDestination) Connect(ctx context.Context, uri string) error {
+	dsn, _, err := hanautil.ParseURI(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse HANA URI: %w", err)
+	}
+
+	connector, err := hdbdriver.NewDSNConnector(dsn)
+	if err != nil {
+		return fmt.Errorf("failed to create HANA connector: %w", err)
+	}
+	connector.SetBufferSize(1 << 20)
+	db := sql.OpenDB(connector)
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping HANA: %w", err)
+	}
+
+	var currentSchema string
+	if err := db.QueryRowContext(ctx, "SELECT CURRENT_SCHEMA FROM DUMMY").Scan(&currentSchema); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to get current HANA schema: %w", err)
+	}
+
+	d.db = db
+	d.uri = uri
+	d.defaultSchema = currentSchema
+	config.Debug("[HANA] Connected with default schema: %s", currentSchema)
+	return nil
+}
+
+func (d *HanaDestination) Close(ctx context.Context) error {
+	if d.db == nil {
+		return nil
+	}
+	return d.db.Close()
+}
+
+func (d *HanaDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := tablename.TwoLevel("hana").CheckName(opts.Table); err != nil {
+		return err
+	}
+	if opts.DropFirst {
+		if err := d.DropTable(ctx, opts.Table); err != nil {
+			return err
+		}
+	}
+	if opts.Schema == nil {
+		return nil
+	}
+
+	exists, err := d.tableExists(ctx, opts.Table)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		schemaName, _ := d.effectiveSchemaTable(opts.Table)
+		if err := d.ensureSchemaExists(ctx, schemaName); err != nil {
+			return err
+		}
+		createSQL := buildCreateTableSQL(opts.Table, opts)
+		if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+			created, lookupErr := d.tableExists(ctx, opts.Table)
+			if lookupErr != nil || !created {
+				config.LogFailedQuery(createSQL, err)
+				return fmt.Errorf("failed to create HANA table: %w", err)
+			}
+		}
+	}
+
+	if opts.RequirePrimaryKeyMatch {
+		schemaName, tableName := d.effectiveSchemaTable(opts.Table)
+		actualKeys, err := d.getPrimaryKeys(ctx, schemaName, tableName)
+		if err != nil {
+			return fmt.Errorf("failed to inspect HANA target primary key: %w", err)
+		}
+		if !identifierSetsEqual(opts.PrimaryKeys, actualKeys) {
+			return fmt.Errorf("CDC merge target %s must have primary key %v; found %v", opts.Table, opts.PrimaryKeys, actualKeys)
+		}
+	}
+	return nil
+}
+
+func (d *HanaDestination) DropTable(ctx context.Context, table string) error {
+	if err := tablename.TwoLevel("hana").CheckName(table); err != nil {
+		return err
+	}
+	exists, err := d.tableExists(ctx, table)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	dropSQL := fmt.Sprintf("DROP TABLE %s", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+		config.LogFailedQuery(dropSQL, err)
+		return fmt.Errorf("failed to drop HANA table %s: %w", table, err)
+	}
+	return nil
+}
+
+func (d *HanaDestination) TruncateTable(ctx context.Context, table string) error {
+	truncateSQL := fmt.Sprintf("TRUNCATE TABLE %s", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, truncateSQL); err != nil {
+		config.LogFailedQuery(truncateSQL, err)
+		return fmt.Errorf("failed to truncate HANA table %s: %w", table, err)
+	}
+	return nil
+}
+
+func (d *HanaDestination) InsertFromStaging(ctx context.Context, opts destination.InsertFromStagingOptions) error {
+	columns := destination.DestinationColumns(opts.Columns)
+	if len(columns) == 0 {
+		return errors.New("insert from staging requires at least one column")
+	}
+	columnList := strings.Join(quoteColumns(columns), ", ")
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s",
+		quoteTable(opts.TargetTable), columnList, columnList, quoteTable(opts.StagingTable),
+	)
+	if _, err := d.db.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert into HANA table %s from staging: %w", opts.TargetTable, err)
+	}
+	return nil
+}
+
+func (d *HanaDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.WriteParallel(ctx, records, opts)
+}
+
+func (d *HanaDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	batchNumber := 0
+	for result := range records {
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return result.Err
+		}
+		if result.Batch == nil {
+			continue
+		}
+
+		batchNumber++
+		_, err := d.writeRecordBatch(ctx, result.Batch, opts.Table)
+		result.Batch.Release()
+		if err != nil {
+			return fmt.Errorf("failed to write HANA batch %d: %w", batchNumber, err)
+		}
+	}
+	return nil
+}
+
+func (d *HanaDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+	if record.NumRows() == 0 {
+		return 0, nil
+	}
+
+	numColumns := int(record.NumCols())
+	columnNames := make([]string, numColumns)
+	placeholders := make([]string, numColumns)
+	for i := 0; i < numColumns; i++ {
+		columnNames[i] = quoteColumn(record.Schema().Field(i).Name)
+		placeholders[i] = "?"
+	}
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		quoteTable(table), strings.Join(columnNames, ", "), strings.Join(placeholders, ", "),
+	)
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin HANA transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, insertSQL)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare HANA bulk insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	numRows := record.NumRows()
+	values := make([]interface{}, 0, min(numRows, hanaInsertRowsPerStatement)*int64(numColumns))
+	for start := int64(0); start < numRows; start += hanaInsertRowsPerStatement {
+		end := min(start+hanaInsertRowsPerStatement, numRows)
+		values = values[:0]
+		for row := start; row < end; row++ {
+			for col := 0; col < numColumns; col++ {
+				values = append(values, extractValue(record.Column(col), int(row)))
+			}
+		}
+		if _, err := stmt.ExecContext(ctx, values...); err != nil {
+			config.LogFailedQuery(insertSQL, err)
+			return 0, fmt.Errorf("failed to execute HANA bulk insert for rows %d-%d: %w", start, end-1, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit HANA bulk insert: %w", err)
+	}
+	return record.NumRows(), nil
+}
+
+func (d *HanaDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if err := tablename.TwoLevel("hana").CheckName(opts.StagingTable); err != nil {
+		return err
+	}
+	if err := tablename.TwoLevel("hana").CheckName(opts.TargetTable); err != nil {
+		return err
+	}
+
+	stagingSchema, _ := parseTableName(opts.StagingTable)
+	targetSchema, targetName := parseTableName(opts.TargetTable)
+	if !d.sameSchema(stagingSchema, targetSchema) {
+		return d.copySwapTable(ctx, opts)
+	}
+
+	targetExists, err := d.tableExists(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	backupTable := ""
+	if targetExists {
+		backupTable = backupTableName(targetSchema, targetName)
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			return err
+		}
+		if err := d.renameTable(ctx, opts.TargetTable, backupTable); err != nil {
+			return fmt.Errorf("failed to rename HANA target to backup: %w", err)
+		}
+	}
+
+	if err := d.renameTable(ctx, opts.StagingTable, opts.TargetTable); err != nil {
+		if backupTable != "" {
+			if restoreErr := d.renameTable(ctx, backupTable, opts.TargetTable); restoreErr != nil {
+				return fmt.Errorf("failed to rename HANA staging table to target: %w; backup restore failed: %v", err, restoreErr)
+			}
+		}
+		return fmt.Errorf("failed to rename HANA staging table to target: %w", err)
+	}
+
+	if backupTable != "" {
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			config.Debug("[HANA] Failed to drop swap backup %s: %v", backupTable, err)
+		}
+	}
+	return nil
+}
+
+func (d *HanaDestination) copySwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if opts.Schema == nil {
+		return fmt.Errorf("cannot swap %s to %s across HANA schemas without schema", opts.StagingTable, opts.TargetTable)
+	}
+
+	targetSchema, targetName := parseTableName(opts.TargetTable)
+	targetExists, err := d.tableExists(ctx, opts.TargetTable)
+	if err != nil {
+		return err
+	}
+	backupTable := ""
+	if targetExists {
+		backupTable = backupTableName(targetSchema, targetName)
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			return err
+		}
+		if err := d.renameTable(ctx, opts.TargetTable, backupTable); err != nil {
+			return err
+		}
+	}
+
+	// The rename path carries the staging table's PRIMARY KEY over to the target, so the copy
+	// path has to reconstruct it when the caller did not pass the keys explicitly.
+	primaryKeys := opts.PrimaryKeys
+	if len(primaryKeys) == 0 {
+		primaryKeys = opts.Schema.PrimaryKeys
+	}
+	if err := d.PrepareTable(ctx, destination.PrepareOptions{
+		Table: opts.TargetTable, Schema: opts.Schema, PrimaryKeys: primaryKeys,
+	}); err != nil {
+		if backupTable != "" {
+			_ = d.renameTable(ctx, backupTable, opts.TargetTable)
+		}
+		return err
+	}
+
+	columns := strings.Join(quoteColumns(opts.Schema.ColumnNames()), ", ")
+	copySQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s",
+		quoteTable(opts.TargetTable), columns, columns, quoteTable(opts.StagingTable),
+	)
+	if _, err := d.db.ExecContext(ctx, copySQL); err != nil {
+		config.LogFailedQuery(copySQL, err)
+		_ = d.DropTable(ctx, opts.TargetTable)
+		if backupTable != "" {
+			_ = d.renameTable(ctx, backupTable, opts.TargetTable)
+		}
+		return fmt.Errorf("failed to copy HANA staging table into target: %w", err)
+	}
+
+	if err := d.DropTable(ctx, opts.StagingTable); err != nil {
+		config.Debug("[HANA] Failed to drop copied staging table %s: %v", opts.StagingTable, err)
+	}
+	if backupTable != "" {
+		if err := d.DropTable(ctx, backupTable); err != nil {
+			config.Debug("[HANA] Failed to drop copied swap backup %s: %v", backupTable, err)
+		}
+	}
+	return nil
+}
+
+func (d *HanaDestination) renameTable(ctx context.Context, from, to string) error {
+	renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s", quoteTable(from), quoteTable(to))
+	if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
+		config.LogFailedQuery(renameSQL, err)
+		return err
+	}
+	return nil
+}
+
+func (d *HanaDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	if len(opts.PrimaryKeys) == 0 {
+		return errors.New("HANA merge requires at least one primary key")
+	}
+	mergeSQL := buildMergeSQL(opts.StagingTable, opts.TargetTable, opts.PrimaryKeys, opts.Columns, opts.IncrementalKey)
+	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to merge HANA records: %w", err)
+	}
+	return nil
+}
+
+func buildMergeSQL(stagingTable, targetTable string, primaryKeys, columns []string, incrementalKey string) string {
+	destinationColumns := destination.DestinationColumns(columns)
+	nonPrimaryColumns := filterColumns(destinationColumns, primaryKeys)
+	sourceExpr := dedupSource(stagingTable, columns, primaryKeys, incrementalKey)
+	targetRef := "target"
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "MERGE INTO %s AS target\nUSING %s AS source\nON %s\n", quoteTable(targetTable), sourceExpr, buildJoinCondition(primaryKeys, targetRef, "source"))
+	if len(nonPrimaryColumns) > 0 {
+		assignments := make([]string, len(nonPrimaryColumns))
+		for i, col := range nonPrimaryColumns {
+			assignments[i] = fmt.Sprintf("%s = source.%s", quoteColumn(col), quoteColumn(col))
+		}
+		fmt.Fprintf(&b, "WHEN MATCHED THEN UPDATE SET %s\n", strings.Join(assignments, ", "))
+	}
+	fmt.Fprintf(
+		&b,
+		"WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)",
+		strings.Join(quoteColumns(destinationColumns), ", "),
+		strings.Join(sourceColumnRefs(destinationColumns, "source"), ", "),
+	)
+	return b.String()
+}
+
+func (d *HanaDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin HANA delete+insert transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deleteSQL := fmt.Sprintf(
+		"DELETE FROM %s WHERE %s >= ? AND %s <= ?",
+		quoteTable(opts.TargetTable), quoteColumn(opts.IncrementalKey), quoteColumn(opts.IncrementalKey),
+	)
+	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
+		config.LogFailedQuery(deleteSQL, err)
+		return fmt.Errorf("failed to delete HANA interval: %w", err)
+	}
+
+	columnList := strings.Join(quoteColumns(opts.Columns), ", ")
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) %s",
+		quoteTable(opts.TargetTable), columnList, dedupSelect(opts.StagingTable, opts.Columns, opts.PrimaryKeys, opts.IncrementalKey),
+	)
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert HANA interval: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit HANA delete+insert transaction: %w", err)
+	}
+	return nil
+}
+
+func (d *HanaDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
+	if len(opts.PrimaryKeys) == 0 {
+		return errors.New("HANA SCD2 requires at least one primary key")
+	}
+
+	targetSchema, err := d.GetTableSchema(ctx, opts.TargetTable)
+	if err != nil {
+		return fmt.Errorf("failed to get HANA target schema for SCD2: %w", err)
+	}
+	if targetSchema == nil {
+		return fmt.Errorf("HANA SCD2 target table %q does not exist", opts.TargetTable)
+	}
+	stagingSchema, err := d.GetTableSchema(ctx, opts.StagingTable)
+	if err != nil {
+		return fmt.Errorf("failed to get HANA staging schema for SCD2: %w", err)
+	}
+	if stagingSchema == nil {
+		return fmt.Errorf("HANA SCD2 staging table %q does not exist", opts.StagingTable)
+	}
+	if err := d.validateSCD2LOBValues(ctx, opts, targetSchema, stagingSchema); err != nil {
+		return err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin HANA SCD2 transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	nonPrimaryColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
+	targetRef := "target"
+	onCondition := buildJoinCondition(opts.PrimaryKeys, targetRef, "source")
+	changeConditions := buildChangeConditions(nonPrimaryColumns, targetRef, "source", targetSchema, stagingSchema)
+	closeChangedSQL := fmt.Sprintf(
+		"MERGE INTO %s AS target\nUSING %s AS source\nON %s AND %s.%s = TRUE AND (%s)\nWHEN MATCHED THEN UPDATE SET %s = source.%s, %s = FALSE",
+		quoteTable(opts.TargetTable), quoteTable(opts.StagingTable), onCondition,
+		targetRef, quoteColumn(destination.SCD2IsCurrentColumn), changeConditions,
+		quoteColumn(destination.SCD2ValidToColumn), quoteColumn(destination.SCD2ValidFromColumn),
+		quoteColumn(destination.SCD2IsCurrentColumn),
+	)
+	if _, err := tx.ExecContext(ctx, closeChangedSQL); err != nil {
+		config.LogFailedQuery(closeChangedSQL, err)
+		return fmt.Errorf("failed to close changed HANA SCD2 records: %w", err)
+	}
+
+	if opts.IncrementalKey == "" {
+		softDeleteSQL := fmt.Sprintf(
+			"UPDATE %s AS target SET %s = ?, %s = FALSE WHERE target.%s = TRUE AND NOT EXISTS (SELECT 1 FROM %s AS source WHERE %s)",
+			quoteTable(opts.TargetTable), quoteColumn(destination.SCD2ValidToColumn), quoteColumn(destination.SCD2IsCurrentColumn),
+			quoteColumn(destination.SCD2IsCurrentColumn), quoteTable(opts.StagingTable), buildJoinCondition(opts.PrimaryKeys, "target", "source"),
+		)
+		if _, err := tx.ExecContext(ctx, softDeleteSQL, opts.Timestamp); err != nil {
+			config.LogFailedQuery(softDeleteSQL, err)
+			return fmt.Errorf("failed to soft-delete missing HANA SCD2 records: %w", err)
+		}
+	}
+
+	allColumns := destination.AppendSCD2Columns(opts.Columns)
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s AS source WHERE NOT EXISTS (SELECT 1 FROM %s AS target WHERE %s AND target.%s = TRUE)",
+		quoteTable(opts.TargetTable), strings.Join(quoteColumns(allColumns), ", "), strings.Join(sourceColumnRefs(allColumns, "source"), ", "),
+		quoteTable(opts.StagingTable), quoteTable(opts.TargetTable), buildJoinCondition(opts.PrimaryKeys, "target", "source"),
+		quoteColumn(destination.SCD2IsCurrentColumn),
+	)
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert HANA SCD2 records: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit HANA SCD2 transaction: %w", err)
+	}
+	return nil
+}
+
+func (d *HanaDestination) validateSCD2LOBValues(ctx context.Context, opts destination.SCD2Options, tableSchemas ...*schema.TableSchema) error {
+	for _, name := range opts.PrimaryKeys {
+		if columnUsesLOBInAnySchema(name, tableSchemas...) {
+			return fmt.Errorf("HANA SCD2 logical primary key %q is stored as a LOB and cannot be used in join predicates; convert it to a bounded NVARCHAR or VARBINARY column", name)
+		}
+	}
+
+	dataColumns := filterColumns(opts.Columns, destination.SCD2NonDataColumns(opts.PrimaryKeys))
+	lobColumns := make([]string, 0, len(dataColumns))
+	for _, name := range dataColumns {
+		if columnUsesLOBInAnySchema(name, tableSchemas...) {
+			lobColumns = append(lobColumns, name)
+		}
+	}
+	if len(lobColumns) == 0 {
+		return nil
+	}
+
+	tables := []struct {
+		name    string
+		schema  *schema.TableSchema
+		current bool
+	}{
+		{name: opts.TargetTable, schema: tableSchemas[0], current: true},
+		{name: opts.StagingTable, schema: tableSchemas[1]},
+	}
+	for _, table := range tables {
+		lengthChecks := make([]string, len(lobColumns))
+		for i, name := range lobColumns {
+			lengthChecks[i] = fmt.Sprintf("%s > %d", scd2ByteLengthExpression(name, table.schema), hanaSCD2HashMaxLength)
+		}
+		condition := "(" + strings.Join(lengthChecks, " OR ") + ")"
+		if table.current {
+			condition = quoteColumn(destination.SCD2IsCurrentColumn) + " = TRUE AND " + condition
+		}
+		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", quoteTable(table.name), condition)
+		var count int64
+		if err := d.db.QueryRowContext(ctx, query).Scan(&count); err != nil {
+			config.LogFailedQuery(query, err)
+			return fmt.Errorf("failed to validate HANA SCD2 LOB values in %s: %w", table.name, err)
+		}
+		if count > 0 {
+			return fmt.Errorf("HANA SCD2 cannot compare LOB columns %v when a current or staged value exceeds %d bytes", lobColumns, hanaSCD2HashMaxLength)
+		}
+	}
+	return nil
+}
+
+func scd2ByteLengthExpression(name string, tableSchema *schema.TableSchema) string {
+	column := quoteColumn(name)
+	col, exists := columnForIdentifier(tableSchema, name)
+	if exists && col.DataType == schema.TypeString && !columnUsesLOB(col) {
+		return fmt.Sprintf("LENGTH(TO_BLOB(TO_NCLOB(%s)))", column)
+	}
+	return fmt.Sprintf("LENGTH(%s)", column)
+}
+
+func (d *HanaDestination) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := d.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+	}
+	return err
+}
+
+func (d *HanaDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &hanaTransaction{tx: tx}, nil
+}
+
+type hanaTransaction struct {
+	tx *sql.Tx
+}
+
+func (t *hanaTransaction) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := t.tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+	}
+	return err
+}
+
+func (t *hanaTransaction) Commit(ctx context.Context) error {
+	return t.tx.Commit()
+}
+
+func (t *hanaTransaction) Rollback(ctx context.Context) error {
+	return t.tx.Rollback()
+}
+
+func (d *HanaDestination) SupportsReplaceStrategy() bool      { return true }
+func (d *HanaDestination) SupportsAppendStrategy() bool       { return true }
+func (d *HanaDestination) SupportsMergeStrategy() bool        { return true }
+func (d *HanaDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *HanaDestination) SupportsSCD2Strategy() bool         { return true }
+func (d *HanaDestination) SupportsAtomicSwap() bool           { return true }
+
+func (d *HanaDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingTargetSchema,
+		DefaultTargetSchema:  resolvedIdentifierReference(d.defaultSchema),
+		DefaultManagedSchema: defaultHanaStagingSchema,
+	}
+}
+
+func (d *HanaDestination) ManagedStagingPolicy() destination.ReplaceStagingPolicy {
+	return d.ReplaceStagingPolicy()
+}
+
+func (d *HanaDestination) GetScheme() string {
+	return "hana"
+}
+
+func (d *HanaDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	if err := tablename.TwoLevel("hana").CheckName(table); err != nil {
+		return nil, err
+	}
+	schemaName, tableName := d.effectiveSchemaTable(table)
+	query := `
+		SELECT COLUMN_NAME, DATA_TYPE_NAME, IS_NULLABLE, LENGTH, SCALE
+		FROM SYS.TABLE_COLUMNS
+		WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?
+		ORDER BY POSITION`
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query HANA table schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	for rows.Next() {
+		var name, dataType, nullable string
+		var length, scale sql.NullInt64
+		if err := rows.Scan(&name, &dataType, &nullable, &length, &scale); err != nil {
+			return nil, fmt.Errorf("failed to scan HANA column: %w", err)
+		}
+		col := mapHanaTypeToColumn(dataType, nullIntPtr(length), nullIntPtr(scale))
+		col.Name = resolvedIdentifierReference(name)
+		col.Nullable = nullable == "TRUE"
+		columns = append(columns, col)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate HANA columns: %w", err)
+	}
+	if len(columns) == 0 {
+		return nil, nil
+	}
+
+	primaryKeys, err := d.getPrimaryKeys(ctx, schemaName, tableName)
+	if err != nil {
+		return nil, err
+	}
+	primaryKeySet := matchedIdentifiers(columnNames(columns), primaryKeys)
+	for i := range columns {
+		columns[i].IsPrimaryKey = primaryKeySet[columns[i].Name]
+	}
+
+	return &schema.TableSchema{
+		Name: tableName, Schema: schemaName, Columns: columns, PrimaryKeys: primaryKeys,
+	}, nil
+}
+
+func (d *HanaDestination) getPrimaryKeys(ctx context.Context, schemaName, tableName string) ([]string, error) {
+	query := `
+		SELECT COLUMN_NAME
+		FROM SYS.CONSTRAINTS
+		WHERE SCHEMA_NAME = ? AND TABLE_NAME = ? AND IS_PRIMARY_KEY = 'TRUE'
+		ORDER BY POSITION`
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query HANA primary keys: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("failed to scan HANA primary key: %w", err)
+		}
+		keys = append(keys, resolvedIdentifierReference(key))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func (d *HanaDestination) ensureSchemaExists(ctx context.Context, schemaName string) error {
+	if schemaName == "" || schemaName == d.defaultSchema {
+		return nil
+	}
+	exists, err := d.schemaExists(ctx, schemaName)
+	if err != nil || exists {
+		return err
+	}
+
+	// schemaName is already canonical (unquoted), so quote it verbatim rather than re-folding it.
+	createSQL := fmt.Sprintf("CREATE SCHEMA %s", `"`+strings.ReplaceAll(schemaName, `"`, `""`)+`"`)
+	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+		created, lookupErr := d.schemaExists(ctx, schemaName)
+		if lookupErr != nil || !created {
+			config.LogFailedQuery(createSQL, err)
+			return fmt.Errorf("failed to create HANA schema %s: %w", schemaName, err)
+		}
+	}
+	return nil
+}
+
+func (d *HanaDestination) schemaExists(ctx context.Context, schemaName string) (bool, error) {
+	var count int
+	query := "SELECT COUNT(*) FROM SYS.SCHEMAS WHERE SCHEMA_NAME = ?"
+	if err := d.db.QueryRowContext(ctx, query, schemaName).Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to check HANA schema existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (d *HanaDestination) tableExists(ctx context.Context, table string) (bool, error) {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+	var count int
+	query := "SELECT COUNT(*) FROM SYS.TABLES WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?"
+	if err := d.db.QueryRowContext(ctx, query, schemaName, tableName).Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to check HANA table existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (d *HanaDestination) effectiveSchemaTable(table string) (string, string) {
+	schemaName, tableName := parseTableName(table)
+	if schemaName == "" {
+		schemaName = d.defaultSchema
+	} else {
+		schemaName = canonicalIdentifier(schemaName)
+	}
+	return schemaName, canonicalIdentifier(tableName)
+}
+
+func (d *HanaDestination) sameSchema(left, right string) bool {
+	if left == "" {
+		left = d.defaultSchema
+	} else {
+		left = canonicalIdentifier(left)
+	}
+	if right == "" {
+		right = d.defaultSchema
+	} else {
+		right = canonicalIdentifier(right)
+	}
+	return left == right
+}
+
+func buildCreateTableSQL(table string, opts destination.PrepareOptions) string {
+	columns := opts.Schema.Columns
+	columnNameList := columnNames(columns)
+	comparableNames := append([]string{}, opts.PrimaryKeys...)
+	comparableNames = append(comparableNames, opts.Schema.PrimaryKeys...)
+	if opts.Schema.IncrementalKey != "" {
+		comparableNames = append(comparableNames, opts.Schema.IncrementalKey)
+	}
+	comparable := matchedIdentifiers(columnNameList, comparableNames)
+	cdcKeys := matchedIdentifiers(columnNameList, opts.CDCKeys)
+	primaryKeys := matchedIdentifiers(columnNameList, opts.PrimaryKeys)
+
+	definitions := make([]string, 0, len(columns)+1)
+	for _, col := range columns {
+		required := !col.Nullable
+		if opts.CDCMode && !primaryKeys[col.Name] && !cdcKeys[col.Name] {
+			required = false
+		}
+		nullable := ""
+		if required {
+			nullable = " NOT NULL"
+		}
+		definitions = append(definitions, fmt.Sprintf(
+			"%s %s%s", quoteColumn(col.Name), mapDataTypeToHana(col, col.IsPrimaryKey || comparable[col.Name]), nullable,
+		))
+	}
+	if len(opts.PrimaryKeys) > 0 {
+		definitions = append(definitions, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(quoteColumns(opts.PrimaryKeys), ", ")))
+	}
+	return fmt.Sprintf("CREATE COLUMN TABLE %s (\n  %s\n)", quoteTable(table), strings.Join(definitions, ",\n  "))
+}
+
+func dedupSource(table string, columns, primaryKeys []string, incrementalKey string) string {
+	return "(" + dedupSelect(table, columns, primaryKeys, incrementalKey) + ")"
+}
+
+func dedupSelect(table string, columns, primaryKeys []string, incrementalKey string) string {
+	quotedColumns := strings.Join(quoteColumns(columns), ", ")
+	if len(primaryKeys) == 0 {
+		return fmt.Sprintf("SELECT %s FROM %s", quotedColumns, quoteTable(table))
+	}
+	orderBy := quoteColumn(primaryKeys[0])
+	if incrementalKey != "" {
+		orderBy = quoteColumn(incrementalKey) + " DESC"
+	}
+	rowNumber := quoteColumn(newInternalNameAllocator(columns)("__bruin_dedup_rn"))
+	return fmt.Sprintf(
+		"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS %s FROM %s) AS numbered WHERE %s = 1",
+		quotedColumns, quotedColumns, strings.Join(quoteColumns(primaryKeys), ", "), orderBy, rowNumber, quoteTable(table), rowNumber,
+	)
+}
+
+func buildJoinCondition(keys []string, targetRef, sourceRef string) string {
+	conditions := make([]string, len(keys))
+	for i, key := range keys {
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetRef, quoteColumn(key), sourceRef, quoteColumn(key))
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func buildChangeConditions(columns []string, targetRef, sourceRef string, tableSchemas ...*schema.TableSchema) string {
+	if len(columns) == 0 {
+		return "1 = 0"
+	}
+	conditions := make([]string, len(columns))
+	for i, name := range columns {
+		target := targetRef + "." + quoteColumn(name)
+		source := sourceRef + "." + quoteColumn(name)
+		comparison := fmt.Sprintf("%s <> %s", target, source)
+		if columnUsesLOBInAnySchema(name, tableSchemas...) {
+			comparison = fmt.Sprintf("HASH_SHA256(TO_BINARY(%s)) <> HASH_SHA256(TO_BINARY(%s))", target, source)
+		}
+		conditions[i] = fmt.Sprintf(
+			"(%s OR (%s IS NULL AND %s IS NOT NULL) OR (%s IS NOT NULL AND %s IS NULL))",
+			comparison, target, source, target, source,
+		)
+	}
+	return strings.Join(conditions, " OR ")
+}
+
+func columnUsesLOBInAnySchema(name string, tableSchemas ...*schema.TableSchema) bool {
+	for _, tableSchema := range tableSchemas {
+		col, exists := columnForIdentifier(tableSchema, name)
+		if exists && columnUsesLOB(col) {
+			return true
+		}
+	}
+	return false
+}
+
+func columnUsesLOB(col schema.Column) bool {
+	switch col.DataType {
+	case schema.TypeString:
+		return col.MaxLength <= 0 || col.MaxLength > hanaMaxInlineLength
+	case schema.TypeBinary:
+		return col.MaxLength <= 0 || col.MaxLength > hanaMaxInlineLength
+	case schema.TypeJSON, schema.TypeArray:
+		return true
+	default:
+		return false
+	}
+}
+
+func quoteTable(table string) string {
+	parts := splitIdentifiers(table)
+	quoted := make([]string, len(parts))
+	for i, part := range parts {
+		quoted[i] = quoteColumn(part)
+	}
+	return strings.Join(quoted, ".")
+}
+
+func quoteColumn(name string) string {
+	return `"` + strings.ReplaceAll(canonicalIdentifier(name), `"`, `""`) + `"`
+}
+
+func quoteColumns(columns []string) []string {
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = quoteColumn(col)
+	}
+	return quoted
+}
+
+func sourceColumnRefs(columns []string, alias string) []string {
+	refs := make([]string, len(columns))
+	for i, col := range columns {
+		refs[i] = alias + "." + quoteColumn(col)
+	}
+	return refs
+}
+
+func filterColumns(columns, excluded []string) []string {
+	matches := matchedIdentifiers(columns, excluded)
+	filtered := make([]string, 0, len(columns))
+	for _, col := range columns {
+		if !matches[col] {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered
+}
+
+func matchedIdentifiers(columns, selected []string) map[string]bool {
+	foldedCounts := make(map[string]int, len(columns))
+	for _, col := range columns {
+		foldedCounts[strings.ToLower(canonicalIdentifier(col))]++
+	}
+	exact := make(map[string]bool, len(selected))
+	folded := make(map[string]bool, len(selected))
+	for _, col := range selected {
+		canonical := canonicalIdentifier(col)
+		exact[canonical] = true
+		folded[strings.ToLower(canonical)] = true
+	}
+
+	matches := make(map[string]bool, len(selected))
+	for _, col := range columns {
+		canonical := canonicalIdentifier(col)
+		foldedName := strings.ToLower(canonical)
+		if exact[canonical] || (foldedCounts[foldedName] == 1 && folded[foldedName]) {
+			matches[col] = true
+		}
+	}
+	return matches
+}
+
+func identifierSetsEqual(expected, actual []string) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	remaining := make(map[string]int, len(expected))
+	for _, item := range expected {
+		remaining[canonicalIdentifier(item)]++
+	}
+	for _, item := range actual {
+		canonical := canonicalIdentifier(item)
+		if remaining[canonical] == 0 {
+			return false
+		}
+		remaining[canonical]--
+	}
+	return true
+}
+
+func columnForIdentifier(tableSchema *schema.TableSchema, selected string) (schema.Column, bool) {
+	if tableSchema == nil {
+		return schema.Column{}, false
+	}
+	canonical := canonicalIdentifier(selected)
+	for _, col := range tableSchema.Columns {
+		if canonicalIdentifier(col.Name) == canonical {
+			return col, true
+		}
+	}
+	return schema.Column{}, false
+}
+
+func columnNames(columns []schema.Column) []string {
+	names := make([]string, len(columns))
+	for i, col := range columns {
+		names[i] = col.Name
+	}
+	return names
+}
+
+func newInternalNameAllocator(columns []string) func(string) string {
+	used := make(map[string]struct{}, len(columns)+1)
+	for _, col := range columns {
+		used[strings.ToLower(canonicalIdentifier(col))] = struct{}{}
+	}
+	return func(base string) string {
+		candidate := base
+		for suffix := 2; ; suffix++ {
+			key := strings.ToLower(canonicalIdentifier(candidate))
+			if _, exists := used[key]; !exists {
+				used[key] = struct{}{}
+				return candidate
+			}
+			candidate = fmt.Sprintf("%s_%d", base, suffix)
+		}
+	}
+}
+
+func parseTableName(table string) (string, string) {
+	parts := splitIdentifiers(table)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", table
+}
+
+func backupTableName(schemaName, tableName string) string {
+	canonical := canonicalIdentifier(tableName)
+	candidate := fmt.Sprintf("%s_OLD_%d", canonical, time.Now().UnixNano())
+	backup := destination.ShortenIdentifier(candidate, candidate, destination.MaxIdentifierLength("hana"))
+	backupRef := resolvedIdentifierReference(backup)
+	if schemaName == "" {
+		return backupRef
+	}
+	return schemaName + "." + backupRef
+}
+
+func canonicalIdentifier(name string) string {
+	name = strings.TrimSpace(name)
+	if len(name) >= 2 && name[0] == '"' && name[len(name)-1] == '"' {
+		return strings.ReplaceAll(name[1:len(name)-1], `""`, `"`)
+	}
+	return strings.ToUpper(name)
+}
+
+func resolvedIdentifierReference(name string) string {
+	if name == "" {
+		return ""
+	}
+	if isOrdinaryIdentifier(name) && name == strings.ToUpper(name) {
+		return name
+	}
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func isOrdinaryIdentifier(name string) bool {
+	if name == "" || !((name[0] >= 'A' && name[0] <= 'Z') || name[0] == '_') {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		ch := name[i]
+		if (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '$' || ch == '#' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func splitIdentifiers(name string) []string {
+	return tablename.SplitRaw(name)
+}
+
+func nullIntPtr(value sql.NullInt64) *int {
+	if !value.Valid {
+		return nil
+	}
+	result := int(value.Int64)
+	return &result
+}
+
+func extractValue(arr arrow.Array, index int) interface{} {
+	if arr.IsNull(index) {
+		return nil
+	}
+	switch values := arr.(type) {
+	case *array.Boolean:
+		return values.Value(index)
+	case *array.Int8:
+		return values.Value(index)
+	case *array.Int16:
+		return values.Value(index)
+	case *array.Int32:
+		return values.Value(index)
+	case *array.Int64:
+		return values.Value(index)
+	case *array.Uint8:
+		return values.Value(index)
+	case *array.Uint16:
+		return values.Value(index)
+	case *array.Uint32:
+		return values.Value(index)
+	case *array.Uint64:
+		return values.Value(index)
+	case *array.Float16:
+		return values.Value(index).Float32()
+	case *array.Float32:
+		return values.Value(index)
+	case *array.Float64:
+		return values.Value(index)
+	case *array.String:
+		return values.Value(index)
+	case *array.LargeString:
+		return values.Value(index)
+	case *array.Binary:
+		return values.Value(index)
+	case *array.LargeBinary:
+		return values.Value(index)
+	case *array.FixedSizeBinary:
+		return values.Value(index)
+	case *array.Date32:
+		return values.Value(index).ToTime()
+	case *array.Date64:
+		return values.Value(index).ToTime()
+	case *array.Time32:
+		return arrowTimeToTime(int64(values.Value(index)), values.DataType().(*arrow.Time32Type).Unit)
+	case *array.Time64:
+		return arrowTimeToTime(int64(values.Value(index)), values.DataType().(*arrow.Time64Type).Unit)
+	case *array.Timestamp:
+		return values.Value(index).ToTime(values.DataType().(*arrow.TimestampType).Unit)
+	case *array.Decimal128:
+		return values.Value(index).ToString(int32(values.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return values.ValueStr(index)
+	case array.ListLike:
+		return values.ValueStr(index)
+	case *array.Struct:
+		return values.ValueStr(index)
+	case array.ExtensionArray:
+		return extractValue(values.Storage(), index)
+	default:
+		return arr.ValueStr(index)
+	}
+}
+
+func arrowTimeToTime(value int64, unit arrow.TimeUnit) time.Time {
+	var duration time.Duration
+	switch unit {
+	case arrow.Second:
+		duration = time.Duration(value) * time.Second
+	case arrow.Millisecond:
+		duration = time.Duration(value) * time.Millisecond
+	case arrow.Microsecond:
+		duration = time.Duration(value) * time.Microsecond
+	case arrow.Nanosecond:
+		duration = time.Duration(value)
+	}
+	return time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC).Add(duration)
+}

--- a/pkg/destination/hana/hana_test.go
+++ b/pkg/destination/hana/hana_test.go
@@ -1,0 +1,634 @@
+package hana
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/decimal256"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuoteTableUsesHanaIdentifierSemantics(t *testing.T) {
+	assert.Equal(t, `"ORDERS"`, quoteTable("orders"))
+	assert.Equal(t, `"SALES"."ORDERS"`, quoteTable("sales.orders"))
+	assert.Equal(t, `"sales.schema"."Orders"`, quoteTable(`"sales.schema"."Orders"`))
+	assert.Equal(t, `"SALES"."USER""EVENTS"`, quoteTable(`sales.user"events`))
+}
+
+func TestMapDataTypeToHana(t *testing.T) {
+	tests := []struct {
+		column schema.Column
+		want   string
+	}{
+		{schema.Column{DataType: schema.TypeBoolean}, "BOOLEAN"},
+		{schema.Column{DataType: schema.TypeInt8}, "SMALLINT"},
+		{schema.Column{DataType: schema.TypeInt32}, "INTEGER"},
+		{schema.Column{DataType: schema.TypeInt64}, "BIGINT"},
+		{schema.Column{DataType: schema.TypeFloat32}, "REAL"},
+		{schema.Column{DataType: schema.TypeFloat64}, "DOUBLE"},
+		{schema.Column{DataType: schema.TypeDecimal, Precision: 18, Scale: 4}, "DECIMAL(18,4)"},
+		{schema.Column{DataType: schema.TypeDecimal, Precision: 50, Scale: 45}, "DECIMAL(38,38)"},
+		{schema.Column{DataType: schema.TypeString, MaxLength: 128}, "NVARCHAR(128)"},
+		{schema.Column{DataType: schema.TypeString}, "NCLOB"},
+		{schema.Column{DataType: schema.TypeBinary, MaxLength: 64}, "VARBINARY(64)"},
+		{schema.Column{DataType: schema.TypeBinary}, "BLOB"},
+		{schema.Column{DataType: schema.TypeTimestampTZ}, "TIMESTAMP"},
+		{schema.Column{DataType: schema.TypeJSON}, "NCLOB"},
+		{schema.Column{DataType: schema.TypeUUID}, "NVARCHAR(36)"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, MapDataTypeToHana(tt.column))
+	}
+	assert.Equal(t, "NVARCHAR(5000)", mapDataTypeToHana(schema.Column{DataType: schema.TypeString}, true))
+}
+
+func TestNormalizeSchemaEvolutionColumn(t *testing.T) {
+	dest := NewHanaDestination()
+
+	assert.Equal(t, schema.TypeInt16, dest.NormalizeSchemaEvolutionColumn(schema.Column{DataType: schema.TypeInt8}).DataType)
+	assert.Equal(t, schema.TypeTimestamp, dest.NormalizeSchemaEvolutionColumn(schema.Column{DataType: schema.TypeTimestampTZ}).DataType)
+	assert.Equal(t, schema.Column{DataType: schema.TypeString, MaxLength: 36}, dest.NormalizeSchemaEvolutionColumn(schema.Column{DataType: schema.TypeUUID}))
+	assert.Equal(t, schema.Column{DataType: schema.TypeString}, dest.NormalizeSchemaEvolutionColumn(schema.Column{DataType: schema.TypeJSON}))
+}
+
+func TestApplySchemaEvolutionRewritesUnsupportedStringWidening(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+	temporaryName, backupName := rewriteArtifactColumnNames("app.events", "AGE")
+
+	mock.ExpectExec(`ALTER TABLE "APP"\."EVENTS" ALTER \("AGE" NCLOB\)`).
+		WillReturnError(assert.AnError)
+	mock.ExpectQuery(`FROM SYS\.TABLE_COLUMNS`).
+		WithArgs("APP", "EVENTS", "AGE", temporaryName, backupName).
+		WillReturnRows(sqlmock.NewRows([]string{"column"}).AddRow("AGE"))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`ALTER TABLE "APP"."EVENTS" ADD ("%s" NCLOB)`, temporaryName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`UPDATE "APP"."EVENTS" SET "%s" = TO_NCLOB("AGE")`, temporaryName))).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`ALTER TABLE "APP"."EVENTS" ALTER ("%s" NOT NULL)`, temporaryName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`RENAME COLUMN "APP"."EVENTS"."AGE" TO "%s"`, backupName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`RENAME COLUMN "APP"."EVENTS"."%s" TO "AGE"`, temporaryName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`ALTER TABLE "APP"."EVENTS" DROP ("%s")`, backupName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	oldColumn := schema.Column{Name: "AGE", DataType: schema.TypeInt64, Nullable: false}
+	warnings, err := dest.ApplySchemaEvolution(t.Context(), "app.events", &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type:       schemaevolution.ChangeWidenType,
+			ColumnName: "AGE",
+			OldColumn:  &oldColumn,
+			NewColumn:  schema.Column{Name: "AGE", DataType: schema.TypeString, Nullable: false},
+		}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, warnings, `column "AGE": type widened to string`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplySchemaEvolutionRecoversInterruptedColumnRewrite(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+	temporaryName, backupName := rewriteArtifactColumnNames("app.events", "AGE")
+
+	mock.ExpectQuery(`FROM SYS\.TABLE_COLUMNS`).
+		WithArgs("APP", "EVENTS", "AGE", temporaryName, backupName).
+		WillReturnRows(sqlmock.NewRows([]string{"column"}).AddRow(temporaryName).AddRow(backupName))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`RENAME COLUMN "APP"."EVENTS"."%s" TO "AGE"`, backupName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`ALTER TABLE "APP"."EVENTS" DROP ("%s")`, temporaryName))).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	_, err = dest.ApplySchemaEvolution(t.Context(), "app.events", &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type:       schemaevolution.ChangeAddColumn,
+			ColumnName: "AGE",
+			NewColumn:  schema.Column{Name: "AGE", DataType: schema.TypeString, Nullable: true},
+		}},
+	})
+	require.ErrorContains(t, err, "recovered interrupted HANA rewrite")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplySchemaEvolutionCleansRewriteArtifactsBeforeApplyingPlan(t *testing.T) {
+	temporaryName, backupName := rewriteArtifactColumnNames("app.events", "AGE")
+	for _, artifactName := range []string{temporaryName, backupName} {
+		t.Run(artifactName, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = db.Close() })
+			dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+			mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(`ALTER TABLE "APP"."EVENTS" DROP ("%s")`, artifactName))).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+
+			warnings, err := dest.ApplySchemaEvolution(t.Context(), "app.events", &schemaevolution.SchemaComparison{
+				HasChanges: true,
+				Changes: []schemaevolution.SchemaChange{{
+					Type:       schemaevolution.ChangeRemoveColumn,
+					ColumnName: artifactName,
+					OldColumn:  &schema.Column{Name: artifactName, DataType: schema.TypeString},
+				}},
+			})
+			require.NoError(t, err)
+			assert.Empty(t, warnings)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestPrepareTableCreatesMissingSchema(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	mock.ExpectQuery(`FROM SYS\.TABLES`).WithArgs("LANDING", "EVENTS").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`FROM SYS\.SCHEMAS`).WithArgs("LANDING").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta(`CREATE SCHEMA "LANDING"`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`CREATE COLUMN TABLE "LANDING"\."EVENTS"`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table:  "landing.events",
+		Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPrepareTableSkipsSchemaCreationForDefaultSchema(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	mock.ExpectQuery(`FROM SYS\.TABLES`).WithArgs("APP", "EVENTS").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(`CREATE COLUMN TABLE "APP"\."EVENTS"`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table:  "app.events",
+		Schema: &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplySchemaEvolutionSkipsLOBWideningOnPrimaryKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	// The target column was created as NVARCHAR(5000) because it is a primary key; the source
+	// reports it as an unbounded string. No ALTER may be issued, as HANA rejects LOB keys.
+	oldColumn := schema.Column{Name: "ID", DataType: schema.TypeString, MaxLength: 5000, IsPrimaryKey: true}
+	warnings, err := dest.ApplySchemaEvolution(t.Context(), "app.events", &schemaevolution.SchemaComparison{
+		HasChanges: true,
+		Changes: []schemaevolution.SchemaChange{{
+			Type:       schemaevolution.ChangeWidenType,
+			ColumnName: "ID",
+			OldColumn:  &oldColumn,
+			NewColumn:  schema.Column{Name: "ID", DataType: schema.TypeString},
+		}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBuildCreateTableSQL(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		IncrementalKey: "updated_at",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeString, Nullable: false},
+			{Name: "payload", DataType: schema.TypeJSON, Nullable: false},
+			{Name: "updated_at", DataType: schema.TypeTimestamp, Nullable: false},
+		},
+	}
+
+	got := buildCreateTableSQL("landing.events", destination.PrepareOptions{
+		Schema: tableSchema, PrimaryKeys: []string{"id"}, CDCMode: true, CDCKeys: []string{"id"},
+	})
+
+	assert.Equal(t, `CREATE COLUMN TABLE "LANDING"."EVENTS" (
+  "ID" NVARCHAR(5000) NOT NULL,
+  "PAYLOAD" NCLOB,
+  "UPDATED_AT" TIMESTAMP,
+  PRIMARY KEY ("ID")
+)`, got)
+}
+
+func TestBuildMergeSQLDeduplicatesStaging(t *testing.T) {
+	got := buildMergeSQL("landing.events_merge", "landing.events", []string{"id"}, []string{"id", "name", "updated_at"}, "updated_at")
+
+	assert.Contains(t, got, `MERGE INTO "LANDING"."EVENTS" AS target`)
+	assert.Contains(t, got, `ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "UPDATED_AT" DESC)`)
+	assert.Contains(t, got, `ON target."ID" = source."ID"`)
+	assert.Contains(t, got, `WHEN MATCHED THEN UPDATE SET "NAME" = source."NAME", "UPDATED_AT" = source."UPDATED_AT"`)
+	assert.Contains(t, got, `WHEN NOT MATCHED THEN INSERT ("ID", "NAME", "UPDATED_AT")`)
+}
+
+func TestGetTableSchema(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	mock.ExpectQuery(`FROM SYS\.TABLE_COLUMNS`).
+		WithArgs("APP", "EVENTS").
+		WillReturnRows(sqlmock.NewRows([]string{"column", "type", "nullable", "length", "scale"}).
+			AddRow("ID", "BIGINT", "FALSE", 19, 0).
+			AddRow("Name", "NVARCHAR", "TRUE", 255, nil).
+			AddRow("AMOUNT", "DECIMAL", "TRUE", 18, 4))
+	mock.ExpectQuery(`FROM SYS\.CONSTRAINTS`).
+		WithArgs("APP", "EVENTS").
+		WillReturnRows(sqlmock.NewRows([]string{"column"}).AddRow("ID"))
+
+	got, err := dest.GetTableSchema(t.Context(), "events")
+	require.NoError(t, err)
+	require.Len(t, got.Columns, 3)
+	assert.Equal(t, schema.Column{Name: "ID", DataType: schema.TypeInt64, Nullable: false, IsPrimaryKey: true}, got.Columns[0])
+	assert.Equal(t, schema.Column{Name: `"Name"`, DataType: schema.TypeString, Nullable: true, MaxLength: 255}, got.Columns[1])
+	assert.Equal(t, schema.Column{Name: "AMOUNT", DataType: schema.TypeDecimal, Nullable: true, Precision: 18, Scale: 4}, got.Columns[2])
+	assert.Equal(t, []string{"ID"}, got.PrimaryKeys)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWriteRecordBatchUsesHanaBulkInsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	allocator := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { allocator.AssertSize(t, 0) })
+	idBuilder := array.NewInt64Builder(allocator)
+	idBuilder.AppendValues([]int64{1, 2}, nil)
+	ids := idBuilder.NewArray()
+	idBuilder.Release()
+	nameBuilder := array.NewStringBuilder(allocator)
+	nameBuilder.AppendValues([]string{"one", "two"}, nil)
+	names := nameBuilder.NewArray()
+	nameBuilder.Release()
+	record := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}, {Name: "name", Type: arrow.BinaryTypes.String}}, nil),
+		[]arrow.Array{ids, names}, 2,
+	)
+	ids.Release()
+	names.Release()
+	t.Cleanup(record.Release)
+
+	query := regexp.QuoteMeta(`INSERT INTO "EVENTS" ("ID", "NAME") VALUES (?, ?)`)
+	mock.ExpectBegin()
+	prepared := mock.ExpectPrepare(query)
+	prepared.ExpectExec().WithArgs(int64(1), "one", int64(2), "two").WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	rows, err := dest.writeRecordBatch(t.Context(), record, "events")
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, rows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWriteRecordBatchChunksLargeBatches(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	allocator := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	t.Cleanup(func() { allocator.AssertSize(t, 0) })
+	numRows := hanaInsertRowsPerStatement + 5
+	idBuilder := array.NewInt64Builder(allocator)
+	for i := 0; i < numRows; i++ {
+		idBuilder.Append(int64(i))
+	}
+	ids := idBuilder.NewArray()
+	idBuilder.Release()
+	record := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil),
+		[]arrow.Array{ids}, int64(numRows),
+	)
+	ids.Release()
+	t.Cleanup(record.Release)
+
+	query := regexp.QuoteMeta(`INSERT INTO "EVENTS" ("ID") VALUES (?)`)
+	mock.ExpectBegin()
+	prepared := mock.ExpectPrepare(query)
+	prepared.ExpectExec().WillReturnResult(sqlmock.NewResult(0, hanaInsertRowsPerStatement))
+	prepared.ExpectExec().WithArgs(
+		int64(hanaInsertRowsPerStatement), int64(hanaInsertRowsPerStatement+1), int64(hanaInsertRowsPerStatement+2),
+		int64(hanaInsertRowsPerStatement+3), int64(hanaInsertRowsPerStatement+4),
+	).WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectCommit()
+
+	rows, err := dest.writeRecordBatch(t.Context(), record, "events")
+	require.NoError(t, err)
+	assert.EqualValues(t, numRows, rows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExtractValue(t *testing.T) {
+	allocator := memory.NewGoAllocator()
+
+	cases := []struct {
+		name  string
+		build func() arrow.Array
+		want  interface{}
+	}{
+		{
+			name: "null",
+			build: func() arrow.Array {
+				b := array.NewInt64Builder(allocator)
+				defer b.Release()
+				b.AppendNull()
+				return b.NewArray()
+			},
+			want: nil,
+		},
+		{
+			name: "uint64",
+			build: func() arrow.Array {
+				b := array.NewUint64Builder(allocator)
+				defer b.Release()
+				b.Append(42)
+				return b.NewArray()
+			},
+			want: uint64(42),
+		},
+		{
+			name: "date32",
+			build: func() arrow.Array {
+				b := array.NewDate32Builder(allocator)
+				defer b.Release()
+				b.Append(arrow.Date32FromTime(time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC)))
+				return b.NewArray()
+			},
+			want: time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "time32_seconds",
+			build: func() arrow.Array {
+				b := array.NewTime32Builder(allocator, &arrow.Time32Type{Unit: arrow.Second})
+				defer b.Release()
+				b.Append(arrow.Time32(13*3600 + 45*60 + 30))
+				return b.NewArray()
+			},
+			want: time.Date(1, time.January, 1, 13, 45, 30, 0, time.UTC),
+		},
+		{
+			name: "time64_microseconds",
+			build: func() arrow.Array {
+				b := array.NewTime64Builder(allocator, &arrow.Time64Type{Unit: arrow.Microsecond})
+				defer b.Release()
+				b.Append(arrow.Time64((13*3600+45*60+30)*1e6 + 123456))
+				return b.NewArray()
+			},
+			want: time.Date(1, time.January, 1, 13, 45, 30, 123456000, time.UTC),
+		},
+		{
+			name: "timestamp_microseconds",
+			build: func() arrow.Array {
+				b := array.NewTimestampBuilder(allocator, &arrow.TimestampType{Unit: arrow.Microsecond})
+				defer b.Release()
+				b.Append(arrow.Timestamp(time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC).UnixMicro()))
+				return b.NewArray()
+			},
+			want: time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC),
+		},
+		{
+			name: "decimal128_negative",
+			build: func() arrow.Array {
+				b := array.NewDecimal128Builder(allocator, &arrow.Decimal128Type{Precision: 10, Scale: 3})
+				defer b.Release()
+				b.Append(decimal128.FromI64(-1234))
+				return b.NewArray()
+			},
+			want: "-1.234",
+		},
+		{
+			name: "decimal256",
+			build: func() arrow.Array {
+				b := array.NewDecimal256Builder(allocator, &arrow.Decimal256Type{Precision: 40, Scale: 5})
+				defer b.Release()
+				b.Append(decimal256.FromI64(1234567))
+				return b.NewArray()
+			},
+			want: "12.34567",
+		},
+		{
+			name: "list_renders_json",
+			build: func() arrow.Array {
+				b := array.NewListBuilder(allocator, arrow.PrimitiveTypes.Int64)
+				defer b.Release()
+				b.Append(true)
+				b.ValueBuilder().(*array.Int64Builder).AppendValues([]int64{1, 2}, nil)
+				return b.NewArray()
+			},
+			want: "[1,2]",
+		},
+		{
+			name: "struct_renders_json",
+			build: func() arrow.Array {
+				structType := arrow.StructOf(arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int64})
+				b := array.NewStructBuilder(allocator, structType)
+				defer b.Release()
+				b.Append(true)
+				b.FieldBuilder(0).(*array.Int64Builder).Append(7)
+				return b.NewArray()
+			},
+			want: `{"a":7}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			arr := tt.build()
+			defer arr.Release()
+			assert.Equal(t, tt.want, extractValue(arr, 0))
+		})
+	}
+}
+
+func TestDeleteInsertTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+	intervalStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	intervalEnd := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "APP"."EVENTS" WHERE "UPDATED_AT" >= ? AND "UPDATED_AT" <= ?`)).
+		WithArgs(intervalStart, intervalEnd).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(`(?s)^INSERT INTO "APP"\."EVENTS".*ROW_NUMBER\(\) OVER \(PARTITION BY "ID" ORDER BY "UPDATED_AT" DESC\)`).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	err = dest.DeleteInsertTable(t.Context(), destination.DeleteInsertOptions{
+		StagingTable:   "app.events_staging",
+		TargetTable:    "app.events",
+		IncrementalKey: "updated_at",
+		IntervalStart:  intervalStart,
+		IntervalEnd:    intervalEnd,
+		Columns:        []string{"id", "updated_at"},
+		PrimaryKeys:    []string{"id"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func expectHanaTableSchema(mock sqlmock.Sqlmock, schemaName, tableName string, rows *sqlmock.Rows) {
+	mock.ExpectQuery(`FROM SYS\.TABLE_COLUMNS`).
+		WithArgs(schemaName, tableName).
+		WillReturnRows(rows)
+	mock.ExpectQuery(`FROM SYS\.CONSTRAINTS`).
+		WithArgs(schemaName, tableName).
+		WillReturnRows(sqlmock.NewRows([]string{"column"}))
+}
+
+func TestSCD2Table(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+	timestamp := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeString},
+		{Name: "payload", DataType: schema.TypeJSON},
+	}}
+
+	physicalColumns := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"column", "type", "nullable", "length", "scale"}).
+			AddRow("ID", "NVARCHAR", "FALSE", 5000, nil).
+			AddRow("PAYLOAD", "NCLOB", "TRUE", nil, nil)
+	}
+	expectHanaTableSchema(mock, "APP", "DIM_EVENTS", physicalColumns())
+	expectHanaTableSchema(mock, "APP", "DIM_EVENTS_STAGING", physicalColumns())
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM "APP"\."DIM_EVENTS" WHERE "_SCD_IS_CURRENT" = TRUE AND \(LENGTH\("PAYLOAD"\) > 2000\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM "APP"\."DIM_EVENTS_STAGING" WHERE \(LENGTH\("PAYLOAD"\) > 2000\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)^MERGE INTO "APP"\."DIM_EVENTS" AS target.*HASH_SHA256\(TO_BINARY\(target\."PAYLOAD"\)\).*WHEN MATCHED THEN UPDATE`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`(?s)^UPDATE "APP"\."DIM_EVENTS" AS target.*NOT EXISTS`).
+		WithArgs(timestamp).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`(?s)^INSERT INTO "APP"\."DIM_EVENTS".*NOT EXISTS`).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	err = dest.SCD2Table(t.Context(), destination.SCD2Options{
+		StagingTable: "app.dim_events_staging",
+		TargetTable:  "app.dim_events",
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "payload"},
+		Timestamp:    timestamp,
+		Schema:       tableSchema,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSCD2TableRejectsOversizedLOBValues(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "payload", DataType: schema.TypeString},
+	}}
+
+	physicalColumns := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"column", "type", "nullable", "length", "scale"}).
+			AddRow("ID", "BIGINT", "FALSE", 19, nil).
+			AddRow("PAYLOAD", "NCLOB", "TRUE", nil, nil)
+	}
+	expectHanaTableSchema(mock, "APP", "DIM_EVENTS", physicalColumns())
+	expectHanaTableSchema(mock, "APP", "DIM_EVENTS_STAGING", physicalColumns())
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM "APP"\."DIM_EVENTS" WHERE "_SCD_IS_CURRENT" = TRUE AND \(LENGTH\("PAYLOAD"\) > 2000\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	err = dest.SCD2Table(t.Context(), destination.SCD2Options{
+		StagingTable: "app.dim_events_staging",
+		TargetTable:  "app.dim_events",
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "payload"},
+		Schema:       tableSchema,
+	})
+	require.ErrorContains(t, err, "exceeds 2000 bytes")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSCD2ByteLengthExpressionUsesByteLengthForBoundedUnicode(t *testing.T) {
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "bounded_text", DataType: schema.TypeString, MaxLength: 5000},
+		{Name: "lob_text", DataType: schema.TypeString},
+		{Name: "binary_data", DataType: schema.TypeBinary, MaxLength: 5000},
+	}}
+
+	assert.Equal(t, `LENGTH(TO_BLOB(TO_NCLOB("BOUNDED_TEXT")))`, scd2ByteLengthExpression("bounded_text", tableSchema))
+	assert.Equal(t, `LENGTH("LOB_TEXT")`, scd2ByteLengthExpression("lob_text", tableSchema))
+	assert.Equal(t, `LENGTH("BINARY_DATA")`, scd2ByteLengthExpression("binary_data", tableSchema))
+}
+
+func TestSCD2TableRejectsLOBLogicalPrimaryKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeString, MaxLength: 100},
+		{Name: "payload", DataType: schema.TypeInt64},
+	}}
+
+	expectHanaTableSchema(mock, "APP", "DIM_EVENTS", sqlmock.NewRows([]string{"column", "type", "nullable", "length", "scale"}).
+		AddRow("ID", "NCLOB", "FALSE", nil, nil).
+		AddRow("PAYLOAD", "BIGINT", "TRUE", 19, nil))
+	expectHanaTableSchema(mock, "APP", "DIM_EVENTS_STAGING", sqlmock.NewRows([]string{"column", "type", "nullable", "length", "scale"}).
+		AddRow("ID", "NVARCHAR", "FALSE", 100, nil).
+		AddRow("PAYLOAD", "BIGINT", "TRUE", 19, nil))
+	err = dest.SCD2Table(t.Context(), destination.SCD2Options{
+		StagingTable: "app.dim_events_staging",
+		TargetTable:  "app.dim_events",
+		PrimaryKeys:  []string{"id"},
+		Columns:      []string{"id", "payload"},
+		Schema:       tableSchema,
+	})
+	require.ErrorContains(t, err, "logical primary key")
+	require.ErrorContains(t, err, "stored as a LOB")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReplaceStagingPolicyUsesCurrentSchema(t *testing.T) {
+	dest := &HanaDestination{defaultSchema: "appUser"}
+	policy := dest.ReplaceStagingPolicy()
+	assert.Equal(t, destination.ReplaceStagingTargetSchema, policy.DefaultPlacement)
+	assert.Equal(t, `"appUser"`, policy.DefaultTargetSchema)
+}

--- a/pkg/destination/hana/hana_test.go
+++ b/pkg/destination/hana/hana_test.go
@@ -1,6 +1,7 @@
 package hana
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -24,6 +25,64 @@ func TestQuoteTableUsesHanaIdentifierSemantics(t *testing.T) {
 	assert.Equal(t, `"SALES"."ORDERS"`, quoteTable("sales.orders"))
 	assert.Equal(t, `"sales.schema"."Orders"`, quoteTable(`"sales.schema"."Orders"`))
 	assert.Equal(t, `"SALES"."USER""EVENTS"`, quoteTable(`sales.user"events`))
+}
+
+func TestSwapTableUsesAtomicDDL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM SYS\.TABLES`).
+		WithArgs("APP", "EVENTS").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(hanaDDLAutocommitOff)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`RENAME TABLE "APP"\."EVENTS" TO "APP"\."EVENTS_OLD_[0-9]+"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`RENAME TABLE "APP"."STAGING" TO "APP"."EVENTS"`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+	mock.ExpectExec(regexp.QuoteMeta(hanaDDLAutocommitOn)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM SYS\.TABLES`).
+		WithArgs("APP", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectExec(`DROP TABLE "APP"\."EVENTS_OLD_[0-9]+"`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	require.NoError(t, dest.SwapTable(t.Context(), destination.SwapOptions{
+		StagingTable: "app.staging",
+		TargetTable:  "app.events",
+	}))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSwapTableRestoresDDLAutocommitAfterCancellation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dest := &HanaDestination{db: db, defaultSchema: "APP"}
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM SYS\.TABLES`).
+		WithArgs("APP", "EVENTS").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(hanaDDLAutocommitOff)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`RENAME TABLE "APP"\."EVENTS" TO "APP"\."EVENTS_OLD_[0-9]+"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`RENAME TABLE "APP"."STAGING" TO "APP"."EVENTS"`)).
+		WillDelayFor(50 * time.Millisecond).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+	mock.ExpectExec(regexp.QuoteMeta(hanaDDLAutocommitOn)).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	err = dest.SwapTable(ctx, destination.SwapOptions{
+		StagingTable: "app.staging",
+		TargetTable:  "app.events",
+	})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestMapDataTypeToHana(t *testing.T) {

--- a/pkg/destination/hana/mapper.go
+++ b/pkg/destination/hana/mapper.go
@@ -1,0 +1,148 @@
+package hana
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+const hanaMaxInlineLength = 5000
+
+func MapDataTypeToHana(col schema.Column) string {
+	return mapDataTypeToHana(col, false)
+}
+
+func mapDataTypeToHana(col schema.Column, comparable bool) string {
+	switch col.DataType {
+	case schema.TypeBoolean:
+		return "BOOLEAN"
+	case schema.TypeInt8, schema.TypeInt16:
+		return "SMALLINT"
+	case schema.TypeInt32:
+		return "INTEGER"
+	case schema.TypeInt64:
+		return "BIGINT"
+	case schema.TypeFloat32:
+		return "REAL"
+	case schema.TypeFloat64:
+		return "DOUBLE"
+	case schema.TypeDecimal:
+		precision := col.Precision
+		if precision <= 0 {
+			precision = 38
+		}
+		if precision > 38 {
+			precision = 38
+		}
+		scale := col.Scale
+		if scale < 0 {
+			scale = 0
+		}
+		if scale > precision {
+			scale = precision
+		}
+		return fmt.Sprintf("DECIMAL(%d,%d)", precision, scale)
+	case schema.TypeString:
+		if col.MaxLength > 0 && col.MaxLength <= hanaMaxInlineLength {
+			return fmt.Sprintf("NVARCHAR(%d)", col.MaxLength)
+		}
+		if comparable {
+			return fmt.Sprintf("NVARCHAR(%d)", hanaMaxInlineLength)
+		}
+		return "NCLOB"
+	case schema.TypeBinary:
+		if col.MaxLength > 0 && col.MaxLength <= hanaMaxInlineLength {
+			return fmt.Sprintf("VARBINARY(%d)", col.MaxLength)
+		}
+		if comparable {
+			return fmt.Sprintf("VARBINARY(%d)", hanaMaxInlineLength)
+		}
+		return "BLOB"
+	case schema.TypeDate:
+		return "DATE"
+	case schema.TypeTime:
+		return "TIME"
+	case schema.TypeTimestamp, schema.TypeTimestampTZ:
+		return "TIMESTAMP"
+	case schema.TypeUUID:
+		return "NVARCHAR(36)"
+	case schema.TypeInterval:
+		return "NVARCHAR(255)"
+	case schema.TypeJSON, schema.TypeArray:
+		return "NCLOB"
+	default:
+		return "NCLOB"
+	}
+}
+
+func mapHanaTypeToColumn(dataType string, length, scale *int) schema.Column {
+	typeName := strings.ToUpper(strings.TrimSpace(dataType))
+	col := schema.Column{DataType: schema.TypeString, Nullable: true}
+
+	switch typeName {
+	case "BOOLEAN":
+		col.DataType = schema.TypeBoolean
+	case "TINYINT", "SMALLINT":
+		col.DataType = schema.TypeInt16
+	case "INTEGER", "INT":
+		col.DataType = schema.TypeInt32
+	case "BIGINT":
+		col.DataType = schema.TypeInt64
+	case "REAL":
+		col.DataType = schema.TypeFloat32
+	case "DOUBLE", "FLOAT":
+		col.DataType = schema.TypeFloat64
+	case "DECIMAL", "SMALLDECIMAL":
+		col.DataType = schema.TypeDecimal
+		if length != nil {
+			col.Precision = *length
+		}
+		if scale != nil {
+			col.Scale = *scale
+		}
+	case "VARCHAR", "NVARCHAR", "ALPHANUM", "SHORTTEXT", "CHAR", "NCHAR":
+		col.DataType = schema.TypeString
+		if length != nil {
+			col.MaxLength = *length
+		}
+	case "CLOB", "NCLOB", "TEXT", "BINTEXT":
+		col.DataType = schema.TypeString
+	case "VARBINARY", "BINARY":
+		col.DataType = schema.TypeBinary
+		if length != nil {
+			col.MaxLength = *length
+		}
+	case "BLOB":
+		col.DataType = schema.TypeBinary
+	case "DATE":
+		col.DataType = schema.TypeDate
+	case "TIME":
+		col.DataType = schema.TypeTime
+	case "TIMESTAMP", "SECONDDATE":
+		col.DataType = schema.TypeTimestamp
+	case "ARRAY":
+		col.DataType = schema.TypeArray
+	}
+
+	return col
+}
+
+func (d *HanaDestination) NormalizeSchemaEvolutionColumn(col schema.Column) schema.Column {
+	switch col.DataType {
+	case schema.TypeInt8:
+		col.DataType = schema.TypeInt16
+	case schema.TypeTimestampTZ:
+		col.DataType = schema.TypeTimestamp
+	case schema.TypeUUID:
+		col.DataType = schema.TypeString
+		col.MaxLength = 36
+	case schema.TypeInterval:
+		col.DataType = schema.TypeString
+		col.MaxLength = 255
+	case schema.TypeJSON, schema.TypeArray:
+		col.DataType = schema.TypeString
+		col.MaxLength = 0
+	}
+	return col
+}

--- a/pkg/destination/hana/register.go
+++ b/pkg/destination/hana/register.go
@@ -1,0 +1,10 @@
+package hana
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"hana", "saphana"},
+		func() interface{} { return NewHanaDestination() },
+	)
+}

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/databricks"
 	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
 	"github.com/bruin-data/ingestr/pkg/destination/fabric"
+	"github.com/bruin-data/ingestr/pkg/destination/hana"
 	"github.com/bruin-data/ingestr/pkg/destination/iceberg"
 	"github.com/bruin-data/ingestr/pkg/destination/mssql"
 	"github.com/bruin-data/ingestr/pkg/destination/mysql"
@@ -176,6 +177,7 @@ var (
 	_ destination.Destination = (*databricks.DatabricksDestination)(nil)
 	_ destination.Destination = (*duckdb.DuckDBDestination)(nil)
 	_ destination.Destination = (*fabric.FabricDestination)(nil)
+	_ destination.Destination = (*hana.HanaDestination)(nil)
 	_ destination.Destination = (*iceberg.Destination)(nil)
 	_ destination.Destination = (*mssql.MSSQLDestination)(nil)
 	_ destination.Destination = (*mysql.MySQLDestination)(nil)

--- a/pkg/destination/schema_evolver_compliance_test.go
+++ b/pkg/destination/schema_evolver_compliance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/cratedb"
 	"github.com/bruin-data/ingestr/pkg/destination/duckdb"
 	"github.com/bruin-data/ingestr/pkg/destination/fabric"
+	"github.com/bruin-data/ingestr/pkg/destination/hana"
 	"github.com/bruin-data/ingestr/pkg/destination/iceberg"
 	"github.com/bruin-data/ingestr/pkg/destination/maxcompute"
 	"github.com/bruin-data/ingestr/pkg/destination/mssql"
@@ -35,6 +36,7 @@ var (
 	// DuckLake is duckdb-backed and intentionally inherits evolution via embedding.
 	_ schemaevolution.SchemaEvolver = (*duckdb.DuckLakeDestination)(nil)
 	_ schemaevolution.SchemaEvolver = (*fabric.FabricDestination)(nil)
+	_ schemaevolution.SchemaEvolver = (*hana.HanaDestination)(nil)
 	_ schemaevolution.SchemaEvolver = (*iceberg.Destination)(nil)
 	_ schemaevolution.SchemaEvolver = (*maxcompute.MaxComputeDestination)(nil)
 	_ schemaevolution.SchemaEvolver = (*mssql.MSSQLDestination)(nil)

--- a/pkg/destination/shorten.go
+++ b/pkg/destination/shorten.go
@@ -19,6 +19,8 @@ var maxIdentifierLengths = map[string]int{
 	"mariadb":             64,
 	"oracle":              128,
 	"oracle+cx_oracle":    128,
+	"hana":                127,
+	"saphana":             127,
 	"mssql":               128,
 	"sqlserver":           128,
 	"mssql+pyodbc":        128,

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -36,8 +36,23 @@ import (
 
 const (
 	oracleComparableStringLen = 4000
+	hanaComparableStringLen   = 5000
 	resourceCloseTimeout      = 30 * time.Second
 )
+
+type comparableColumnLimits struct {
+	stringLength int
+	binaryLength int
+}
+
+// Destinations that store unbounded values as LOB types, which cannot be used in range
+// comparisons or ORDER BY. Their incremental key is pinned to the widest comparable type.
+var comparableColumnLimitsByScheme = map[string]comparableColumnLimits{
+	"oracle":           {stringLength: oracleComparableStringLen},
+	"oracle+cx_oracle": {stringLength: oracleComparableStringLen},
+	"hana":             {stringLength: hanaComparableStringLen, binaryLength: hanaComparableStringLen},
+	"saphana":          {stringLength: hanaComparableStringLen, binaryLength: hanaComparableStringLen},
+}
 
 type Pipeline struct {
 	config                   *config.IngestConfig
@@ -647,6 +662,12 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		if evolutionPlan != nil && evolutionPlan.FinalSchema != nil {
 			destSchema = evolutionPlan.FinalSchema
 		}
+	}
+	// Evolution plans retain an existing unbounded destination type because narrowing is
+	// intentionally forbidden. Reapply the physical staging constraint to the final schema.
+	p.applyDestinationSchemaConstraints(destSchema)
+	if err := p.validateExistingDestinationSchemaConstraints(p.destinationSchema, destSchema.IncrementalKey, resolvedStrategy); err != nil {
+		return err
 	}
 	if p.config.NoLoadTimestamp {
 		destSchema = removeLoadTimestampColumn(destSchema)
@@ -1739,7 +1760,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 		config.Debug("[SCHEMA EVOLUTION] No schema changes detected")
 		return &schemaevolution.EvolutionPlan{
 			Table:       destTable,
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
+			FinalSchema: buildFinalSchema(comparisonDestSchema, sourceSchema, nil),
 		}, nil
 	}
 
@@ -1768,7 +1789,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 		p.filteredSchemaComparison = comparison
 		return &schemaevolution.EvolutionPlan{
 			Table:       destTable,
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
+			FinalSchema: buildFinalSchema(comparisonDestSchema, sourceSchema, p.filteredSchemaComparison),
 		}, nil
 
 	case schemaevolution.ContractDiscardRow:
@@ -1813,7 +1834,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 			}
 			return &schemaevolution.EvolutionPlan{
 				Table:       destTable,
-				FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, p.filteredSchemaComparison),
+				FinalSchema: buildFinalSchema(comparisonDestSchema, sourceSchema, p.filteredSchemaComparison),
 			}, nil
 		}
 		// For migration, only apply allowed changes (new columns) for discard_value mode
@@ -1836,7 +1857,7 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 		config.Debug("[SCHEMA EVOLUTION] Destination %s does not support schema evolution, skipping", p.dest.GetScheme())
 		return &schemaevolution.EvolutionPlan{
 			Table:       destTable,
-			FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, nil),
+			FinalSchema: buildFinalSchema(comparisonDestSchema, sourceSchema, nil),
 		}, nil
 	}
 
@@ -1848,10 +1869,18 @@ func (p *Pipeline) evolveSchemaIfNeeded(ctx context.Context, destTable string, s
 	plan := &schemaevolution.EvolutionPlan{
 		Table:       destTable,
 		Comparison:  p.filteredSchemaComparison,
-		FinalSchema: schemaevolution.BuildFinalSchema(comparisonDestSchema, applicable),
+		FinalSchema: buildFinalSchema(comparisonDestSchema, sourceSchema, applicable),
 	}
 	config.Debug("[SCHEMA EVOLUTION] Built plan with %d changes (deferred apply)", len(p.filteredSchemaComparison.Changes))
 	return plan, nil
+}
+
+func buildFinalSchema(destinationSchema, sourceSchema *schema.TableSchema, comparison *schemaevolution.SchemaComparison) *schema.TableSchema {
+	finalSchema := schemaevolution.BuildFinalSchema(destinationSchema, comparison)
+	if finalSchema != nil && sourceSchema != nil {
+		finalSchema.IncrementalKey = sourceSchema.IncrementalKey
+	}
+	return finalSchema
 }
 
 func (p *Pipeline) setupIngestrColumns(ctx context.Context, sourceSchema *schema.TableSchema) (*schema.TableSchema, error) {
@@ -1983,19 +2012,58 @@ func (p *Pipeline) applyDestinationSchemaConstraints(tableSchema *schema.TableSc
 	if tableSchema == nil || tableSchema.IncrementalKey == "" || p.dest == nil {
 		return
 	}
-	if p.dest.GetScheme() != "oracle" && p.dest.GetScheme() != "oracle+cx_oracle" {
+	limits, ok := comparableColumnLimitsByScheme[p.dest.GetScheme()]
+	if !ok {
 		return
 	}
 
 	for i := range tableSchema.Columns {
 		col := &tableSchema.Columns[i]
-		if col.DataType != schema.TypeString || !strings.EqualFold(col.Name, tableSchema.IncrementalKey) {
+		if !strings.EqualFold(col.Name, tableSchema.IncrementalKey) {
 			continue
 		}
-		if col.MaxLength <= 0 || col.MaxLength > oracleComparableStringLen {
-			col.MaxLength = oracleComparableStringLen
+		var comparableLength int
+		switch col.DataType {
+		case schema.TypeString:
+			comparableLength = limits.stringLength
+		case schema.TypeBinary:
+			comparableLength = limits.binaryLength
+		}
+		if comparableLength > 0 && (col.MaxLength <= 0 || col.MaxLength > comparableLength) {
+			col.MaxLength = comparableLength
 		}
 	}
+}
+
+func (p *Pipeline) validateExistingDestinationSchemaConstraints(tableSchema *schema.TableSchema, incrementalKey string, strategy config.IncrementalStrategy) error {
+	if tableSchema == nil || incrementalKey == "" || p.dest == nil || strategy != config.StrategyDeleteInsert {
+		return nil
+	}
+	limits, ok := comparableColumnLimitsByScheme[p.dest.GetScheme()]
+	if !ok || limits.binaryLength == 0 {
+		return nil
+	}
+
+	for _, col := range tableSchema.Columns {
+		if !strings.EqualFold(col.Name, incrementalKey) {
+			continue
+		}
+		limit := 0
+		typeName := ""
+		switch col.DataType {
+		case schema.TypeString:
+			limit = limits.stringLength
+			typeName = fmt.Sprintf("NVARCHAR(%d)", limit)
+		case schema.TypeBinary:
+			limit = limits.binaryLength
+			typeName = fmt.Sprintf("VARBINARY(%d)", limit)
+		}
+		if limit > 0 && (col.MaxLength <= 0 || col.MaxLength > limit) {
+			return fmt.Errorf("existing HANA incremental key %q is stored as a LOB and cannot be used by delete+insert; convert it to %s or recreate the destination table", col.Name, typeName)
+		}
+		return nil
+	}
+	return nil
 }
 
 func strategyUsesLogicalPrimaryKeys(strategy config.IncrementalStrategy) bool {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2026,6 +2026,55 @@ func TestApplyDestinationSchemaConstraints_OracleStringIncrementalKey(t *testing
 	}
 }
 
+func TestApplyDestinationSchemaConstraints_HanaStringIncrementalKey(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "cursor", DataType: schema.TypeString},
+			{Name: "payload", DataType: schema.TypeString},
+		},
+		IncrementalKey: "cursor",
+	}
+	p := &Pipeline{dest: &mockDestination{scheme: "hana"}}
+
+	p.applyDestinationSchemaConstraints(tableSchema)
+
+	if tableSchema.Columns[1].MaxLength != hanaComparableStringLen {
+		t.Fatalf("incremental key MaxLength = %d, want %d", tableSchema.Columns[1].MaxLength, hanaComparableStringLen)
+	}
+	if tableSchema.Columns[2].MaxLength != 0 {
+		t.Fatalf("non-incremental string MaxLength = %d, want 0", tableSchema.Columns[2].MaxLength)
+	}
+}
+
+func TestApplyDestinationSchemaConstraints_HanaBinaryIncrementalKey(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns:        []schema.Column{{Name: "cursor", DataType: schema.TypeBinary}},
+		IncrementalKey: "cursor",
+	}
+	p := &Pipeline{dest: &mockDestination{scheme: "hana"}}
+
+	p.applyDestinationSchemaConstraints(tableSchema)
+
+	if tableSchema.Columns[0].MaxLength != hanaComparableStringLen {
+		t.Fatalf("incremental key MaxLength = %d, want %d", tableSchema.Columns[0].MaxLength, hanaComparableStringLen)
+	}
+}
+
+func TestValidateExistingDestinationSchemaConstraints_HanaDeleteInsertLOBKey(t *testing.T) {
+	p := &Pipeline{dest: &mockDestination{scheme: "hana"}}
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "cursor", DataType: schema.TypeString}}}
+
+	err := p.validateExistingDestinationSchemaConstraints(tableSchema, "cursor", config.StrategyDeleteInsert)
+
+	if err == nil || !strings.Contains(err.Error(), "stored as a LOB") {
+		t.Fatalf("expected incompatible LOB error, got %v", err)
+	}
+	if err := p.validateExistingDestinationSchemaConstraints(tableSchema, "cursor", config.StrategyMerge); err != nil {
+		t.Fatalf("merge should use the constrained staging schema: %v", err)
+	}
+}
+
 func TestEvolveSchemaIfNeededBuildsAbstractPlanForSchemaEvolver(t *testing.T) {
 	destSchema := tschema(
 		"events",
@@ -2036,6 +2085,7 @@ func TestEvolveSchemaIfNeededBuildsAbstractPlanForSchemaEvolver(t *testing.T) {
 		tcol("id", schema.TypeInt64),
 		tcol("age", schema.TypeInt64),
 	)
+	sourceSchema.IncrementalKey = "age"
 	p := &Pipeline{
 		config: &config.IngestConfig{
 			DestTable: "events",
@@ -2057,6 +2107,9 @@ func TestEvolveSchemaIfNeededBuildsAbstractPlanForSchemaEvolver(t *testing.T) {
 	}
 	if plan.Table != "events" {
 		t.Fatalf("plan table = %q, want events", plan.Table)
+	}
+	if plan.FinalSchema.IncrementalKey != "age" {
+		t.Fatalf("final schema incremental key = %q, want age", plan.FinalSchema.IncrementalKey)
 	}
 	if !plan.HasChanges() {
 		t.Fatal("expected abstract comparison changes")

--- a/pkg/source/hana/hana.go
+++ b/pkg/source/hana/hana.go
@@ -44,6 +44,9 @@ func (s *HanaSource) Connect(ctx context.Context, uri string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create HANA connector: %w", err)
 	}
+	if dbName != "" {
+		connector.SetDefaultSchema(dbName)
+	}
 	connector.SetFetchSize(defaultFetchSize)
 	connector.SetBufferSize(1 << 20) // 1MB network read buffer
 

--- a/pkg/source/hana/hana.go
+++ b/pkg/source/hana/hana.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/hanautil"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
@@ -35,7 +35,7 @@ func (s *HanaSource) Schemes() []string {
 const defaultFetchSize = 100000
 
 func (s *HanaSource) Connect(ctx context.Context, uri string) error {
-	dsn, dbName, err := uriToDSN(uri)
+	dsn, dbName, err := hanautil.ParseURI(uri)
 	if err != nil {
 		return fmt.Errorf("failed to parse HANA URI: %w", err)
 	}
@@ -58,70 +58,10 @@ func (s *HanaSource) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("failed to ping HANA: %w", err)
 	}
 
-	if dbName != "" {
-		safeName := strings.ReplaceAll(dbName, "\"", "\"\"")
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET SCHEMA \"%s\"", safeName)); err != nil {
-			_ = db.Close()
-			return fmt.Errorf("failed to set schema %s: %w", dbName, err)
-		}
-	}
-
 	s.db = db
 	s.uri = uri
 	s.defaultSchema = dbName
 	return nil
-}
-
-func uriToDSN(uri string) (string, string, error) {
-	u, err := url.Parse(uri)
-	if err != nil {
-		return "", "", err
-	}
-
-	scheme := strings.ToLower(u.Scheme)
-	if scheme != "hana" && scheme != "saphana" {
-		return "", "", fmt.Errorf("unsupported scheme: %s", scheme)
-	}
-
-	host := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		port = "30015"
-	}
-
-	var user, password string
-	if u.User != nil {
-		user = u.User.Username()
-		password, _ = u.User.Password()
-	}
-
-	// go-hdb driver DSN format: hdb://user:password@host:port
-	dsn := &url.URL{
-		Scheme: "hdb",
-		Host:   fmt.Sprintf("%s:%s", host, port),
-	}
-
-	if user != "" {
-		if password != "" {
-			dsn.User = url.UserPassword(user, password)
-		} else {
-			dsn.User = url.User(user)
-		}
-	}
-
-	query := u.Query()
-
-	// HANA Cloud uses port 443 with TLS
-	if port == "443" && query.Get("TLSInsecureSkipVerify") == "" && query.Get("TLSServerName") == "" {
-		query.Set("TLSServerName", host)
-	}
-
-	if len(query) > 0 {
-		dsn.RawQuery = query.Encode()
-	}
-
-	database := strings.TrimPrefix(u.Path, "/")
-	return dsn.String(), database, nil
 }
 
 func (s *HanaSource) Close(ctx context.Context) error {

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -17,10 +17,12 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/ClickHouse/clickhouse-go/v2"
+	hdbdriver "github.com/SAP/go-hdb/driver"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/hanautil"
 	"github.com/bruin-data/ingestr/internal/uri"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
 	"github.com/bruin-data/ingestr/pkg/snowflake"
@@ -97,6 +99,31 @@ func destinationCases() []destCase {
 				return pgDest.uri, table, cleanup
 			},
 			sqlBackend:             postgresBackend(),
+			mergeCapable:           true,
+			deleteInsertCapable:    true,
+			scd2Capable:            true,
+			schemaEvolutionCapable: true,
+			replaceDedupCapable:    true,
+		},
+		{
+			name: "hana",
+			setup: func(t *testing.T, ctx context.Context) (string, string, func()) {
+				hanaURI := os.Getenv("GONG_TEST_HANA_URI")
+				if hanaURI == "" {
+					t.Skip("Set GONG_TEST_HANA_URI to run SAP HANA destination conformance tests")
+				}
+
+				table := fmt.Sprintf("SYSTEM.conformance_%s", uniqueSuffix())
+				cleanup := func() {
+					db, err := hanaBackend().openDB(hanaURI)
+					if err == nil {
+						_, _ = db.ExecContext(ctx, "DROP TABLE "+hanaQuoteTable(table))
+						_ = db.Close()
+					}
+				}
+				return hanaURI, table, cleanup
+			},
+			sqlBackend:             hanaBackend(),
 			mergeCapable:           true,
 			deleteInsertCapable:    true,
 			scd2Capable:            true,
@@ -1038,6 +1065,83 @@ func postgresBackend() *sqlBackend {
 			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE _scd_is_current = false AND _scd_valid_to IS NULL", table)
 		},
 	}
+}
+
+func hanaBackend() *sqlBackend {
+	return &sqlBackend{
+		openDB: func(uri string) (*sql.DB, error) {
+			dsn, _, err := hanautil.ParseURI(uri)
+			if err != nil {
+				return nil, err
+			}
+			connector, err := hdbdriver.NewDSNConnector(dsn)
+			if err != nil {
+				return nil, err
+			}
+			return sql.OpenDB(connector), nil
+		},
+		schemaTypes: func(db *sql.DB, table string) (map[string]string, error) {
+			schemaName, tableName := splitSchemaTable(table, "SYSTEM")
+			rows, err := db.Query(`
+				SELECT COLUMN_NAME, DATA_TYPE_NAME
+				FROM SYS.TABLE_COLUMNS
+				WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?
+				ORDER BY POSITION
+			`, strings.ToUpper(schemaName), strings.ToUpper(tableName))
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = rows.Close() }()
+			out := map[string]string{}
+			for rows.Next() {
+				var name, dataType string
+				if err := rows.Scan(&name, &dataType); err != nil {
+					return nil, err
+				}
+				out[strings.ToLower(name)] = normalizeTypeName(dataType)
+			}
+			return out, rows.Err()
+		},
+		expectedTypes: map[string]string{
+			"id":     "bigint",
+			"name":   "nclob",
+			"active": "boolean",
+			"score":  "double",
+		},
+		countQuery: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s", hanaQuoteTable(table))
+		},
+		nameByIDQuery: func(table string, id int) string {
+			return fmt.Sprintf("SELECT TO_NVARCHAR(%s) FROM %s WHERE %s = %d", hanaQuoteIdentifier("name"), hanaQuoteTable(table), hanaQuoteIdentifier("id"), id)
+		},
+		ageByIDQuery: func(table string, id int) string {
+			return fmt.Sprintf("SELECT TO_NVARCHAR(%s) FROM %s WHERE %s = %d", hanaQuoteIdentifier("age"), hanaQuoteTable(table), hanaQuoteIdentifier("id"), id)
+		},
+		scd2CountCurrent: func(table string) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = TRUE", hanaQuoteTable(table), hanaQuoteIdentifier("_scd_is_current"))
+		},
+		scd2CountByID: func(table string, id int) string {
+			return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = %d", hanaQuoteTable(table), hanaQuoteIdentifier("id"), id)
+		},
+		scd2HistNoValidTo: func(table string) string {
+			return fmt.Sprintf(
+				"SELECT COUNT(*) FROM %s WHERE %s = FALSE AND %s IS NULL",
+				hanaQuoteTable(table), hanaQuoteIdentifier("_scd_is_current"), hanaQuoteIdentifier("_scd_valid_to"),
+			)
+		},
+	}
+}
+
+func hanaQuoteTable(table string) string {
+	parts := strings.Split(table, ".")
+	for i := range parts {
+		parts[i] = hanaQuoteIdentifier(parts[i])
+	}
+	return strings.Join(parts, ".")
+}
+
+func hanaQuoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(strings.ToUpper(identifier), `"`, `""`) + `"`
 }
 
 func splitSchemaTable(table string, defaultSchema string) (string, string) {
@@ -2309,6 +2413,14 @@ func getSchemaEvolutionExpectedTypes(backend *sqlBackend) map[string]string {
 			"age":   "text",
 			"score": "bigint",
 		}
+	case backend.expectedTypes["id"] == "bigint" && backend.expectedTypes["name"] == "nclob":
+		// SAP HANA
+		return map[string]string{
+			"id":    "bigint",
+			"name":  "nclob",
+			"age":   "nclob",
+			"score": "bigint",
+		}
 	case backend.expectedTypes["id"] == "integer" && backend.expectedTypes["name"] == "text":
 		// SQLite - types are more flexible
 		return map[string]string{
@@ -2389,7 +2501,7 @@ func TestDestinations_SwapTableCleansUpOldTables(t *testing.T) {
 			continue
 		}
 		// Include backends that use SwapTable in replace strategy.
-		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "sqlite" || tc.name == "mssql" || tc.name == "oracle" {
+		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "hana" || tc.name == "sqlite" || tc.name == "mssql" || tc.name == "oracle" {
 			swapCapableCases = append(swapCapableCases, tc)
 		}
 	}
@@ -2476,6 +2588,14 @@ func countOldTables(t *testing.T, backend *sqlBackend, uri, table string) int {
 			SELECT COUNT(*) FROM information_schema.tables
 			WHERE table_schema = '%s' AND table_name LIKE '%s_old_%%'
 		`, schemaName, tableName)
+	case strings.Contains(uri, "hana"):
+		if schemaName == "" {
+			schemaName = "SYSTEM"
+		}
+		query = fmt.Sprintf(`
+			SELECT COUNT(*) FROM SYS.TABLES
+			WHERE SCHEMA_NAME = '%s' AND TABLE_NAME LIKE '%s_OLD_%%'
+		`, strings.ToUpper(schemaName), strings.ToUpper(tableName))
 	case strings.Contains(uri, "mssql") || strings.Contains(uri, "sqlserver"):
 		// MSSQL: query sys.tables and sys.schemas
 		if schemaName == "" {
@@ -2567,6 +2687,17 @@ func hasPrimaryKey(t *testing.T, backend *sqlBackend, uri, table, column string)
 			  AND tc.constraint_type = 'PRIMARY KEY'
 			  AND kcu.column_name = '%s'
 		`, schemaName, tableName, column)
+	case strings.Contains(uri, "hana"):
+		if schemaName == "" {
+			schemaName = "SYSTEM"
+		}
+		query = fmt.Sprintf(`
+			SELECT COUNT(*) FROM SYS.CONSTRAINTS
+			WHERE SCHEMA_NAME = '%s'
+			  AND TABLE_NAME = '%s'
+			  AND IS_PRIMARY_KEY = 'TRUE'
+			  AND COLUMN_NAME = '%s'
+		`, strings.ToUpper(schemaName), strings.ToUpper(tableName), strings.ToUpper(column))
 	case strings.Contains(uri, "mssql") || strings.Contains(uri, "sqlserver"):
 		if schemaName == "" {
 			schemaName = "dbo"
@@ -2641,7 +2772,7 @@ func TestDestinations_Replace_PreservesConstraints(t *testing.T) {
 		if tc.sqlBackend == nil {
 			continue
 		}
-		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "sqlite" || tc.name == "mssql" || tc.name == "oracle" {
+		if tc.name == "duckdb" || tc.name == "postgres" || tc.name == "hana" || tc.name == "sqlite" || tc.name == "mssql" || tc.name == "oracle" {
 			swapCapableCases = append(swapCapableCases, tc)
 		}
 	}


### PR DESCRIPTION
## What
Adds SAP HANA as a destination while keeping the existing source URI format.

## Changes
- Added HANA writes, strategies, schema evolution, type mapping, and connector registration.
- Shared URI parsing between source and destination and added HANA-specific pipeline safeguards.

## How to test
1. Run `make format && make lint && make test`.
2. Run `make licenses-audit`.
3. Run the HANA destination conformance suite with `GONG_TEST_HANA_URI` and `INTEGRATION_BACKENDS=hana`.

## Risk & rollback
- **Risk:** Medium; this adds database-specific DDL and narrowly scoped HANA pipeline constraints.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #1050
