### PR TITLE
fix(iceberg): apply the non-AWS S3 defaults only to non-AWS endpoints

### DIFF
--- a/docs/supported-sources/iceberg.md
+++ b/docs/supported-sources/iceberg.md
@@ -32,7 +32,7 @@ Common URI parameters:
 - `prefix` (optional): path prefix inside the bucket.
 - `endpoint` (optional): S3-compatible endpoint such as `localhost:9000`.
 - `use_ssl=false` (optional): use plain HTTP for S3-compatible local storage.
-- `access_key_id`, `secret_access_key`, `session_token`, `region`: S3 or Glue credentials and region aliases.
+- `access_key_id`, `secret_access_key`, `session_token`, `region`: S3 or Glue credentials and region aliases. `region` is required for AWS S3, where it routes the request. With `endpoint` set (MinIO, GCS interop, R2) it is unused but still has to be present for the AWS SDK to sign, so it defaults to `auto`.
 - `gcs.keypath` (optional, GCS): path to a Google Cloud service-account JSON key for a `gs://` warehouse. Without it, GCS uses Application Default Credentials.
 - `warehouse`: advanced override for the Iceberg warehouse location, such as `s3://bucket/warehouse`.
 - `warehouse_path`: local warehouse path alias for non-S3 catalog setups.

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -86,6 +86,12 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 		if _, ok := cfg.Properties["s3.compat-mode"]; !ok {
 			cfg.Properties["s3.compat-mode"] = "true"
 		}
+		// Those endpoints ignore the region, but the AWS SDK refuses to sign without
+		// one and fails on a name it cannot turn into a host. Only when an endpoint
+		// is set: on real AWS the region routes, and a default would hide a typo.
+		if cfg.Properties["s3.region"] == "" {
+			cfg.Properties["s3.region"] = "auto"
+		}
 	}
 	return cfg, nil
 }

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -81,17 +81,18 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 		return icebergConfig{}, fmt.Errorf("iceberg uri: sql catalog requires both sql.driver and sql.dialect (e.g. sql.driver=pgx&sql.dialect=postgres), or use the iceberg+postgres / iceberg+sqlite scheme which set them automatically")
 	}
 
-	// Non-AWS S3 endpoints (MinIO, GCS interop, R2) need iceberg-go's compat-mode;
-	// enable it by default unless set explicitly.
-	if cfg.Properties["s3.endpoint"] != "" {
+	// Non-AWS S3 endpoints (MinIO, GCS interop, R2) need settings the AWS SDK will
+	// not infer. An AWS endpoint (regional, VPC, FIPS, dualstack) is not one of
+	// them: compat-mode there would disable upload checksums for no reason, and
+	// the region routes the request rather than being ignored.
+	if cfg.Properties["s3.endpoint"] != "" && !isAWSEndpoint(cfg.Properties["s3.endpoint"]) {
 		if _, ok := cfg.Properties["s3.compat-mode"]; !ok {
 			cfg.Properties["s3.compat-mode"] = "true"
 		}
 		// Those endpoints ignore the region, but the AWS SDK refuses to sign without
-		// one and fails on a name it cannot turn into a host. Never for an AWS
-		// endpoint (regional, VPC, FIPS, dualstack): there the region routes, and
-		// without this property the SDK still resolves it from the environment.
-		if cfg.Properties["s3.region"] == "" && !isAWSEndpoint(cfg.Properties["s3.endpoint"]) {
+		// one and fails on a name it cannot turn into a host. On AWS it is resolved
+		// from AWS_REGION or the shared config when the property is absent.
+		if cfg.Properties["s3.region"] == "" {
 			cfg.Properties["s3.region"] = "auto"
 		}
 	}

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -2,6 +2,7 @@ package iceberg
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -87,13 +88,33 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 			cfg.Properties["s3.compat-mode"] = "true"
 		}
 		// Those endpoints ignore the region, but the AWS SDK refuses to sign without
-		// one and fails on a name it cannot turn into a host. Only when an endpoint
-		// is set: on real AWS the region routes, and a default would hide a typo.
-		if cfg.Properties["s3.region"] == "" {
+		// one and fails on a name it cannot turn into a host. Never for an AWS
+		// endpoint (regional, VPC, FIPS, dualstack): there the region routes, and
+		// without this property the SDK still resolves it from the environment.
+		if cfg.Properties["s3.region"] == "" && !isAWSEndpoint(cfg.Properties["s3.endpoint"]) {
 			cfg.Properties["s3.region"] = "auto"
 		}
 	}
 	return cfg, nil
+}
+
+// isAWSEndpoint reports whether an S3 endpoint is AWS itself rather than an
+// S3-compatible service. Regional, VPC, FIPS, dualstack and accelerate
+// endpoints all live under amazonaws.com.
+func isAWSEndpoint(endpoint string) bool {
+	if endpoint == "" {
+		return false
+	}
+	host := endpoint
+	if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
+		host = parsed.Host
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+
+	return host == "amazonaws.com" || strings.HasSuffix(host, ".amazonaws.com")
 }
 
 func catalogTypeFromScheme(scheme string) string {

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -81,17 +81,12 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 		return icebergConfig{}, fmt.Errorf("iceberg uri: sql catalog requires both sql.driver and sql.dialect (e.g. sql.driver=pgx&sql.dialect=postgres), or use the iceberg+postgres / iceberg+sqlite scheme which set them automatically")
 	}
 
-	// Non-AWS S3 endpoints (MinIO, GCS interop, R2) need settings the AWS SDK will
-	// not infer. An AWS endpoint (regional, VPC, FIPS, dualstack) is not one of
-	// them: compat-mode there would disable upload checksums for no reason, and
-	// the region routes the request rather than being ignored.
+	// MinIO, GCS interop and R2 need compat-mode, and ignore the region the AWS SDK
+	// still refuses to sign without. An AWS endpoint needs neither.
 	if cfg.Properties["s3.endpoint"] != "" && !isAWSEndpoint(cfg.Properties["s3.endpoint"]) {
 		if _, ok := cfg.Properties["s3.compat-mode"]; !ok {
 			cfg.Properties["s3.compat-mode"] = "true"
 		}
-		// Those endpoints ignore the region, but the AWS SDK refuses to sign without
-		// one and fails on a name it cannot turn into a host. On AWS it is resolved
-		// from AWS_REGION or the shared config when the property is absent.
 		if cfg.Properties["s3.region"] == "" {
 			cfg.Properties["s3.region"] = "auto"
 		}
@@ -100,8 +95,7 @@ func parseIcebergConfig(rawURI string) (icebergConfig, error) {
 }
 
 // isAWSEndpoint reports whether an S3 endpoint is AWS itself rather than an
-// S3-compatible service. Regional, VPC, FIPS, dualstack and accelerate
-// endpoints all live under amazonaws.com.
+// S3-compatible service; regional, VPC, FIPS and dualstack all count as AWS.
 func isAWSEndpoint(endpoint string) bool {
 	if endpoint == "" {
 		return false

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -208,7 +208,15 @@ func TestParseIcebergConfigEndpointRegionDefault(t *testing.T) {
 		cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=" + url.QueryEscape(endpoint))
 		require.NoError(t, err, endpoint)
 		require.Empty(t, cfg.Properties["s3.region"], endpoint)
+		// Nor compat-mode, which would switch off upload checksums on real AWS.
+		require.Empty(t, cfg.Properties["s3.compat-mode"], endpoint)
 	}
+
+	// Explicitly asked for, even on AWS: honoured.
+	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=s3.eu-north-1.amazonaws.com&s3.compat-mode=true&region=eu-north-1")
+	require.NoError(t, err)
+	require.Equal(t, "true", cfg.Properties["s3.compat-mode"])
+	require.Equal(t, "eu-north-1", cfg.Properties["s3.region"])
 }
 
 func TestParseIcebergConfigPreservesPlusInCredentials(t *testing.T) {

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -174,8 +174,7 @@ func TestParseIcebergConfigSQLCatalogRequiresDriverDialect(t *testing.T) {
 }
 
 func TestParseIcebergConfigEndpointRegionDefault(t *testing.T) {
-	// MinIO, GCS interop and R2 ignore the region, but the AWS SDK will not sign a
-	// request without one -- it fails resolving an endpoint from the empty string.
+	// The SDK will not sign without a region, even where the store ignores it.
 	cfg, err := parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=storage.googleapis.com")
 	require.NoError(t, err)
 	require.Equal(t, "auto", cfg.Properties["s3.region"])
@@ -185,20 +184,18 @@ func TestParseIcebergConfigEndpointRegionDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "us-east-1", cfg.Properties["s3.region"])
 
-	// No endpoint means real AWS, where the region routes: no default, so a missing
-	// one still surfaces instead of being silently wrong.
+	// Real AWS routes by region, so a missing one must surface, not be guessed.
 	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w")
 	require.NoError(t, err)
 	require.Empty(t, cfg.Properties["s3.region"])
 
-	// The catalog's own region is untouched -- glue is a real AWS service.
+	// Glue is a real AWS service and keeps needing a real region.
 	cfg, err = parseIcebergConfig("iceberg+glue://?storage=s3&warehouse=s3://b/w&endpoint=storage.googleapis.com")
 	require.NoError(t, err)
 	require.Empty(t, cfg.Properties["glue.region"])
 
-	// An AWS endpoint (regional, VPC, FIPS, dualstack) routes by region, and
-	// without the property the SDK resolves it from AWS_REGION or the shared
-	// config -- which "auto" would override with something unusable.
+	// An AWS endpoint still routes by region, which the SDK resolves from the
+	// environment when the property is absent.
 	for _, endpoint := range []string{
 		"https://s3.eu-north-1.amazonaws.com",
 		"bucket.vpce-123-abc.s3.eu-west-1.vpce.amazonaws.com",
@@ -208,11 +205,11 @@ func TestParseIcebergConfigEndpointRegionDefault(t *testing.T) {
 		cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=" + url.QueryEscape(endpoint))
 		require.NoError(t, err, endpoint)
 		require.Empty(t, cfg.Properties["s3.region"], endpoint)
-		// Nor compat-mode, which would switch off upload checksums on real AWS.
+		// Nor compat-mode, which switches off upload checksums.
 		require.Empty(t, cfg.Properties["s3.compat-mode"], endpoint)
 	}
 
-	// Explicitly asked for, even on AWS: honoured.
+	// Explicit values win everywhere.
 	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=s3.eu-north-1.amazonaws.com&s3.compat-mode=true&region=eu-north-1")
 	require.NoError(t, err)
 	require.Equal(t, "true", cfg.Properties["s3.compat-mode"])

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -173,6 +173,30 @@ func TestParseIcebergConfigSQLCatalogRequiresDriverDialect(t *testing.T) {
 	require.Equal(t, "sqlite", cfg.Properties["sql.dialect"])
 }
 
+func TestParseIcebergConfigEndpointRegionDefault(t *testing.T) {
+	// MinIO, GCS interop and R2 ignore the region, but the AWS SDK will not sign a
+	// request without one -- it fails resolving an endpoint from the empty string.
+	cfg, err := parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=storage.googleapis.com")
+	require.NoError(t, err)
+	require.Equal(t, "auto", cfg.Properties["s3.region"])
+
+	// An explicit region is left alone.
+	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=localhost:9000&region=us-east-1")
+	require.NoError(t, err)
+	require.Equal(t, "us-east-1", cfg.Properties["s3.region"])
+
+	// No endpoint means real AWS, where the region routes: no default, so a missing
+	// one still surfaces instead of being silently wrong.
+	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w")
+	require.NoError(t, err)
+	require.Empty(t, cfg.Properties["s3.region"])
+
+	// The catalog's own region is untouched -- glue is a real AWS service.
+	cfg, err = parseIcebergConfig("iceberg+glue://?storage=s3&warehouse=s3://b/w&endpoint=storage.googleapis.com")
+	require.NoError(t, err)
+	require.Empty(t, cfg.Properties["glue.region"])
+}
+
 func TestParseIcebergConfigPreservesPlusInCredentials(t *testing.T) {
 	// STS tokens/secrets commonly contain '+','/','='. Percent-encode them in the
 	// URI (a raw '+' would decode to a space); '%2B' decodes back to '+'.

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -195,6 +195,20 @@ func TestParseIcebergConfigEndpointRegionDefault(t *testing.T) {
 	cfg, err = parseIcebergConfig("iceberg+glue://?storage=s3&warehouse=s3://b/w&endpoint=storage.googleapis.com")
 	require.NoError(t, err)
 	require.Empty(t, cfg.Properties["glue.region"])
+
+	// An AWS endpoint (regional, VPC, FIPS, dualstack) routes by region, and
+	// without the property the SDK resolves it from AWS_REGION or the shared
+	// config -- which "auto" would override with something unusable.
+	for _, endpoint := range []string{
+		"https://s3.eu-north-1.amazonaws.com",
+		"bucket.vpce-123-abc.s3.eu-west-1.vpce.amazonaws.com",
+		"s3-fips.us-gov-west-1.amazonaws.com",
+		"s3.dualstack.us-east-1.amazonaws.com",
+	} {
+		cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db?storage=s3&warehouse=s3://b/w&endpoint=" + url.QueryEscape(endpoint))
+		require.NoError(t, err, endpoint)
+		require.Empty(t, cfg.Properties["s3.region"], endpoint)
+	}
 }
 
 func TestParseIcebergConfigPreservesPlusInCredentials(t *testing.T) {


### PR DESCRIPTION
Two defaults keyed off `s3.endpoint`, neither of which should apply when that endpoint is AWS.

### 1. The region has no default, and needs one

MinIO, GCS interop and R2 ignore the S3 region, but the AWS SDK will not sign a request without one. Leave it out and the write fails with:

```
Invalid region: region was not a valid DNS name
```

before the endpoint override is ever consulted — so the error describes building `bucket.s3..amazonaws.com`, a host with nothing to do with the store being written to. Every user of a non-AWS endpoint has to work out that an arbitrary non-empty string is required, then invent one. Now defaults to `auto`.

### 2. compat-mode should not apply to AWS

`s3.compat-mode` is already auto-enabled from `s3.endpoint`, but `endpoint` does not mean non-AWS: regional, VPC, FIPS, dualstack and accelerate endpoints are all AWS. Compat-mode sets `RequestChecksumCalculation` to `WhenRequired`, strips `ChecksumAlgorithm` off `PutObject` / `UploadPart` / `CreateMultipartUpload`, and removes `Amz-Sdk-*` and `Accept-Encoding` from the signed set. Against AWS none of that fails — it just disables upload checksums for a store that never needed the workaround.

Both now hang off one condition, `endpoint != "" && !isAWSEndpoint(endpoint)`, matching the distinction bruin already draws for the same reason.