### PR TITLE
fix(iceberg): tolerate a namespace created by a concurrent writer

### DIFF
--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -544,6 +544,13 @@ func (d *Destination) ensureNamespace(ctx context.Context, namespace icebergtabl
 			continue
 		}
 		if err := d.catalog.CreateNamespace(ctx, current, iceberggo.Properties{}); err != nil && !errors.Is(err, icebergcatalog.ErrNamespaceAlreadyExists) {
+			// Another writer may have created it since the check above. Only the
+			// catalogs that return ErrNamespaceAlreadyExists are covered by the
+			// guard -- the sql catalog surfaces its driver's duplicate-key error.
+			if exists, checkErr := d.catalog.CheckNamespaceExists(ctx, current); checkErr == nil && exists {
+				continue
+			}
+
 			return fmt.Errorf("iceberg: failed to create namespace %s: %w", strings.Join(current, "."), err)
 		}
 	}

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -544,9 +544,8 @@ func (d *Destination) ensureNamespace(ctx context.Context, namespace icebergtabl
 			continue
 		}
 		if err := d.catalog.CreateNamespace(ctx, current, iceberggo.Properties{}); err != nil && !errors.Is(err, icebergcatalog.ErrNamespaceAlreadyExists) {
-			// Another writer may have created it since the check above. Only the
-			// catalogs that return ErrNamespaceAlreadyExists are covered by the
-			// guard -- the sql catalog surfaces its driver's duplicate-key error.
+			// A concurrent writer may have created it; the sql catalog reports that
+			// as a driver error rather than ErrNamespaceAlreadyExists.
 			if exists, checkErr := d.catalog.CheckNamespaceExists(ctx, current); checkErr == nil && exists {
 				continue
 			}

--- a/pkg/destination/iceberg/namespace_test.go
+++ b/pkg/destination/iceberg/namespace_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// racingCatalog reports a namespace as missing, then fails to create it the way
-// the sql catalog does when another writer won: a driver error, not
-// ErrNamespaceAlreadyExists.
+// racingCatalog reports a namespace as missing, then fails creation the way the
+// sql catalog does when another writer won: a driver error, not the sentinel.
 type racingCatalog struct {
 	icebergcatalog.Catalog
 	created     bool
@@ -27,7 +26,7 @@ func (c *racingCatalog) CheckNamespaceExists(ctx context.Context, ns icebergtabl
 
 func (c *racingCatalog) CreateNamespace(ctx context.Context, ns icebergtable.Identifier, props iceberggo.Properties) error {
 	c.createCalls++
-	c.created = true // the winner's row is in place by the time we fail
+	c.created = true // the winner's row is already in place
 
 	return c.createErr
 }
@@ -46,7 +45,7 @@ func TestEnsureNamespaceToleratesConcurrentCreation(t *testing.T) {
 func TestEnsureNamespaceStillReportsRealFailures(t *testing.T) {
 	t.Parallel()
 
-	// Same driver error, but the namespace genuinely is not there afterwards.
+	// Creation fails and the namespace genuinely is not there.
 	cat := &neverCreatedCatalog{createErr: errors.New("permission denied")}
 	d := &Destination{catalog: cat, cfg: icebergConfig{CreateNamespace: true}}
 

--- a/pkg/destination/iceberg/namespace_test.go
+++ b/pkg/destination/iceberg/namespace_test.go
@@ -1,0 +1,69 @@
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	iceberggo "github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+// racingCatalog reports a namespace as missing, then fails to create it the way
+// the sql catalog does when another writer won: a driver error, not
+// ErrNamespaceAlreadyExists.
+type racingCatalog struct {
+	icebergcatalog.Catalog
+	created     bool
+	createCalls int
+	createErr   error
+}
+
+func (c *racingCatalog) CheckNamespaceExists(ctx context.Context, ns icebergtable.Identifier) (bool, error) {
+	return c.created, nil
+}
+
+func (c *racingCatalog) CreateNamespace(ctx context.Context, ns icebergtable.Identifier, props iceberggo.Properties) error {
+	c.createCalls++
+	c.created = true // the winner's row is in place by the time we fail
+
+	return c.createErr
+}
+
+func TestEnsureNamespaceToleratesConcurrentCreation(t *testing.T) {
+	t.Parallel()
+
+	driverErr := errors.New("UncheckedSQLException: Failed to execute: INSERT INTO iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) VALUES (?,?,?,?)")
+	cat := &racingCatalog{createErr: driverErr}
+	d := &Destination{catalog: cat, cfg: icebergConfig{CreateNamespace: true}}
+
+	require.NoError(t, d.ensureNamespace(context.Background(), icebergtable.Identifier{"raw"}))
+	require.Equal(t, 1, cat.createCalls)
+}
+
+func TestEnsureNamespaceStillReportsRealFailures(t *testing.T) {
+	t.Parallel()
+
+	// Same driver error, but the namespace genuinely is not there afterwards.
+	cat := &neverCreatedCatalog{createErr: errors.New("permission denied")}
+	d := &Destination{catalog: cat, cfg: icebergConfig{CreateNamespace: true}}
+
+	err := d.ensureNamespace(context.Background(), icebergtable.Identifier{"raw"})
+	require.ErrorContains(t, err, "failed to create namespace raw")
+	require.ErrorContains(t, err, "permission denied")
+}
+
+type neverCreatedCatalog struct {
+	icebergcatalog.Catalog
+	createErr error
+}
+
+func (c *neverCreatedCatalog) CheckNamespaceExists(ctx context.Context, ns icebergtable.Identifier) (bool, error) {
+	return false, nil
+}
+
+func (c *neverCreatedCatalog) CreateNamespace(ctx context.Context, ns icebergtable.Identifier, props iceberggo.Properties) error {
+	return c.createErr
+}


### PR DESCRIPTION
Two assets writing into the same Iceberg namespace can fail on the **first** run:

```
Error: ingestion failed: failed to prepare destination table raw.exchange_rates:
iceberg: failed to create namespace raw: UncheckedSQLException: Failed to execute:
INSERT INTO iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) VALUES (?,?,?,?)
```

`ensureNamespace` checks whether the namespace exists and creates it if not — a check-then-act that both writers pass when they start together. The loser's `CreateNamespace` then hits the row the winner inserted.

`ErrNamespaceAlreadyExists` is already tolerated, but only catalogs that return that sentinel are covered. The sql catalog does the same check-then-insert internally and returns its driver's duplicate-key error instead ([sql.go `CreateNamespace`](https://github.com/apache/iceberg-go/blob/main/catalog/sql/sql.go)), so the guard misses it.

Rather than pattern-match another error, re-check existence when the create fails and carry on if the namespace is there now. That covers every catalog, including ones whose duplicate error we have never seen, and a create that failed for a real reason still returns exactly as before.