### PR TITLE
fix(iceberg): give the sqlite catalog a busy timeout

### DIFF
--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -183,9 +183,24 @@ func sqliteCatalogURI(parsed *url.URL) string {
 		return ":memory:"
 	}
 	if strings.HasPrefix(path, "file:") {
-		return path
+		return withBusyTimeout(path)
 	}
-	return "file:" + path
+
+	return withBusyTimeout("file:" + path)
+}
+
+// withBusyTimeout makes a second writer wait for the lock instead of failing
+// immediately with SQLITE_BUSY. Left alone if the caller set their own.
+func withBusyTimeout(uri string) string {
+	if strings.Contains(uri, "busy_timeout") {
+		return uri
+	}
+	sep := "?"
+	if strings.Contains(uri, "?") {
+		sep = "&"
+	}
+
+	return uri + sep + "_pragma=" + url.QueryEscape("busy_timeout(10000)")
 }
 
 func catalogURL(parsed *url.URL, scheme string) string {

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -192,11 +192,14 @@ func sqliteCatalogURI(parsed *url.URL) string {
 // withBusyTimeout makes a second writer wait for the lock instead of failing
 // immediately with SQLITE_BUSY. Left alone if the caller set their own.
 func withBusyTimeout(uri string) string {
-	if strings.Contains(uri, "busy_timeout") {
+	// Only the query carries pragmas; a catalog path that happens to contain
+	// "busy_timeout" must not be mistaken for one already being set.
+	_, query, hasQuery := strings.Cut(uri, "?")
+	if strings.Contains(query, "busy_timeout") {
 		return uri
 	}
 	sep := "?"
-	if strings.Contains(uri, "?") {
+	if hasQuery {
 		sep = "&"
 	}
 

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -166,6 +166,11 @@ func TestSqliteCatalogURIBusyTimeout(t *testing.T) {
 	require.Contains(t, cfg.Properties["uri"], "busy_timeout(1)")
 	require.NotContains(t, cfg.Properties["uri"], "10000")
 
+	// "busy_timeout" in the path is not a pragma; the default still applies.
+	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/busy_timeout.db")
+	require.NoError(t, err)
+	require.Equal(t, "file:/tmp/busy_timeout.db?_pragma=busy_timeout%2810000%29", cfg.Properties["uri"])
+
 	// :memory: is per-connection, so there is nothing to contend with.
 	cfg, err = parseIcebergConfig("iceberg+sqlite:///:memory:")
 	require.NoError(t, err)

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -50,7 +50,7 @@ func TestParseIcebergConfigFriendlyURIs(t *testing.T) {
 			},
 			wantProp: map[string]string{
 				"type":                 "sql",
-				"uri":                  "file:/tmp/iceberg/catalog.db",
+				"uri":                  "file:/tmp/iceberg/catalog.db?_pragma=busy_timeout%2810000%29",
 				"sql.driver":           "sqlite",
 				"sql.dialect":          "sqlite",
 				"warehouse":            "s3://ingestr-iceberg/",
@@ -149,6 +149,27 @@ func TestParseIcebergConfigFriendlyURIs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSqliteCatalogURIBusyTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Two ingestr processes share one catalog file; without a timeout the second
+	// fails instantly with SQLITE_BUSY instead of waiting for the lock.
+	cfg, err := parseIcebergConfig("iceberg+sqlite:///tmp/cat.db")
+	require.NoError(t, err)
+	require.Equal(t, "file:/tmp/cat.db?_pragma=busy_timeout%2810000%29", cfg.Properties["uri"])
+
+	// An explicit one is respected.
+	cfg, err = parseIcebergConfig("iceberg+sqlite:///tmp/cat.db%3F_pragma=busy_timeout(1)")
+	require.NoError(t, err)
+	require.Contains(t, cfg.Properties["uri"], "busy_timeout(1)")
+	require.NotContains(t, cfg.Properties["uri"], "10000")
+
+	// :memory: is per-connection, so there is nothing to contend with.
+	cfg, err = parseIcebergConfig("iceberg+sqlite:///:memory:")
+	require.NoError(t, err)
+	require.Equal(t, ":memory:", cfg.Properties["uri"])
 }
 
 func TestParseIcebergConfigSQLCatalogRequiresDriverDialect(t *testing.T) {


### PR DESCRIPTION
Two ingestr processes sharing one sqlite catalog file fail immediately:

```
iceberg: failed to load catalog: database is locked (5) (SQLITE_BUSY)
```

SQLite serialises writers, and its normal answer to contention is to wait — but only if a busy timeout is set. The catalog DSN is built as bare `file:/path/catalog.db`, so there is none, and the second process gives up the instant it finds the lock held rather than waiting the moment it would take.

That makes a sqlite catalog unusable for any pipeline with more than one asset in it, which is how someone trying Iceberg locally for the first time will hit it.

Sets `busy_timeout(10000)` unless the caller specified their own. `:memory:` is untouched, being per-connection.

### Testing

Unit tests cover the default, an explicit `busy_timeout` being left alone, and `:memory:`.

End to end, two ingestr processes started together against one fresh sqlite catalog and local warehouse, loading two tables into the same namespace:

| | SQLITE_BUSY failures |
|---|---|
| `main` | 4 of 6 |
| this branch | 0 of 6 |

Found while writing Iceberg templates for the CLI (bruin-data/bruin#2495): the local template has to order its two assets with `depends` to work around this, and that workaround can come out once this ships.