### PR TITLE
test: parallelize Postgres CDC integration tests (2.8x faster family)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test-python:
 
 test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
-	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -tags integration -v -p 64 -parallel 64 -timeout 20m ./tests/integration/...
+	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -tags integration -v -p 64 -parallel 8 -timeout 20m ./tests/integration/...
 
 # The CDC stress tests share one harness: a queue-based load generator that
 # tracks the target ops/sec (STRESS_OPS_PER_SEC, default 1000) as closely as

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1152,9 +1153,11 @@ func splitSchemaTable(table string, defaultSchema string) (string, string) {
 	return defaultSchema, table
 }
 
+var uniqueCounter atomic.Uint64
+
 func uniqueSuffix() string {
-	// short, safe suffix for table names
-	return fmt.Sprintf("%d", time.Now().UnixNano())
+	// collision-safe even when parallel tests race on the same nanosecond
+	return fmt.Sprintf("%d_%d", time.Now().UnixNano(), uniqueCounter.Add(1))
 }
 
 func sqliteBackend() *sqlBackend {

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -1156,8 +1156,10 @@ func splitSchemaTable(table string, defaultSchema string) (string, string) {
 var uniqueCounter atomic.Uint64
 
 func uniqueSuffix() string {
-	// collision-safe even when parallel tests race on the same nanosecond
-	return fmt.Sprintf("%d_%d", time.Now().UnixNano(), uniqueCounter.Add(1))
+	// Collision-safe even when parallel tests race on the same nanosecond. Digits
+	// only (no separator): this feeds SQL identifiers and S3 bucket names, which
+	// forbid hyphens and underscores respectively.
+	return fmt.Sprintf("%d%d", time.Now().UnixNano(), uniqueCounter.Add(1))
 }
 
 func sqliteBackend() *sqlBackend {

--- a/tests/integration/postgres_cdc_binary_test.go
+++ b/tests/integration/postgres_cdc_binary_test.go
@@ -160,6 +160,7 @@ func runBinaryParityScenario(t *testing.T, ctx context.Context, uriExtra string)
 // text decode path and the pgoutput binary decode path (binary=true) and
 // requires byte-identical destination content across every supported type.
 func TestPostgresCDC_BinaryModeParity(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	textRows := runBinaryParityScenario(t, ctx, "&discover_interval=off")
@@ -182,6 +183,7 @@ func TestPostgresCDC_BinaryModeParity(t *testing.T) {
 // a large committed transaction lands exactly and a rolled-back one leaves no
 // trace, while the server reports that streaming actually happened.
 func TestPostgresCDC_LargeTransactionStreaming(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	req := testcontainers.ContainerRequest{

--- a/tests/integration/postgres_cdc_keepalive_test.go
+++ b/tests/integration/postgres_cdc_keepalive_test.go
@@ -145,6 +145,7 @@ func setupPostgresCDCContainerWithTimeout(t *testing.T, ctx context.Context, wal
 // is chosen well above keepaliveInterval (5s) so the keepalive's
 // send-then-tick cadence comfortably refreshes the walsender.
 func TestPostgresCDC_BatchRunAdvancesSlotWithSlowWrites(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/postgres_cdc_new_table_test.go
+++ b/tests/integration/postgres_cdc_new_table_test.go
@@ -48,6 +48,7 @@ func setupNewTableDest(t *testing.T, ctx context.Context) (string, *pgxpool.Pool
 // backfill of its pre-existing rows, while the original table keeps resuming
 // incrementally.
 func TestPostgresCDC_NewTableBetweenBatchRuns(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -125,6 +126,7 @@ func TestPostgresCDC_NewTableBetweenBatchRuns(t *testing.T) {
 }
 
 func TestPostgresCDC_StreamingRestartRecoversOfflineDDLAndTableRecreation(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -281,6 +283,7 @@ func TestPostgresCDC_StreamingRestartRecoversOfflineDDLAndTableRecreation(t *tes
 // discovery is a side-effect-free restart boundary. The restarted stream sees
 // the table in its startup set, backfills it, and then replicates live changes.
 func TestPostgresCDC_StreamingNewTableDetection(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -403,6 +406,7 @@ func TestPostgresCDC_StreamingNewTableDetection(t *testing.T) {
 }
 
 func TestPostgresCDC_StreamingColumnRenameAcrossHistoricalRelations(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -491,6 +495,7 @@ func TestPostgresCDC_StreamingColumnRenameAcrossHistoricalRelations(t *testing.T
 }
 
 func TestPostgresCDC_StreamingNumericTypeChangesRefreshCopyEncoding(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -563,6 +568,7 @@ func TestPostgresCDC_StreamingNumericTypeChangesRefreshCopyEncoding(t *testing.T
 }
 
 func TestPostgresCDC_SingleTableStreamingReplacesRecreatedTable(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -646,6 +652,7 @@ func TestPostgresCDC_SingleTableStreamingReplacesRecreatedTable(t *testing.T) {
 }
 
 func TestPostgresCDC_MultiTableStreamingRejectsReplacementRelationBeforeResnapshot(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -68,6 +68,7 @@ func setupPostgresCDCContainer(t *testing.T, ctx context.Context) (testcontainer
 }
 
 func TestPostgresCDCConnectorLeaseExclusiveAndReusable(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -244,6 +245,7 @@ func assertRelationAbsent(t *testing.T, ctx context.Context, db *sql.DB, schema,
 // skips unlogged tables and tables without a replica identity (no primary key),
 // warns about each, and reconciles the table set on every connection.
 func TestPostgresCDC_ManagedPublicationSelectsReplicatableTables(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -342,6 +344,7 @@ func TestPostgresCDC_ManagedPublicationSelectsReplicatableTables(t *testing.T) {
 // which Postgres rejects (failing Connect). Only the leaf partition, which
 // physically holds rows, is published.
 func TestPostgresCDC_ManagedPublicationHandlesPartitionedTables(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -389,6 +392,7 @@ func TestPostgresCDC_ManagedPublicationHandlesPartitionedTables(t *testing.T) {
 // end-to-end (snapshot then CDC insert/update), while an unlogged table and a
 // table without a primary key are excluded entirely.
 func TestPostgresCDC_ManagedPublicationEndToEnd(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -472,6 +476,7 @@ func TestPostgresCDC_ManagedPublicationEndToEnd(t *testing.T) {
 }
 
 func TestPostgresCDCMultiTableNamingPreservesPartialTOASTAndExplicitNull(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -536,6 +541,7 @@ func TestPostgresCDCMultiTableNamingPreservesPartialTOASTAndExplicitNull(t *test
 }
 
 func TestPostgresCDC_Snapshot(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -637,6 +643,7 @@ func TestPostgresCDC_Snapshot(t *testing.T) {
 }
 
 func TestPostgresCDC_URISchemes(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -660,6 +667,7 @@ func TestPostgresCDC_URISchemes(t *testing.T) {
 }
 
 func TestPostgresCDC_IncrementalResume(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -799,6 +807,7 @@ func TestPostgresCDC_IncrementalResume(t *testing.T) {
 }
 
 func TestPostgresCDC_DestinationStateTruncateAndSnapshotRecovery(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -923,6 +932,7 @@ func TestPostgresCDC_DestinationStateTruncateAndSnapshotRecovery(t *testing.T) {
 }
 
 func TestPostgresCDC_LegacyAutoSlotCutoverRequiresSuccessfulDurability(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -998,6 +1008,7 @@ func TestPostgresCDC_LegacyAutoSlotCutoverRequiresSuccessfulDurability(t *testin
 }
 
 func TestPostgresCDC_SharedStateMySQL(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1072,6 +1083,7 @@ func postgresCDCStateTables(t *testing.T, ctx context.Context, pool *pgxpool.Poo
 }
 
 func TestPostgresCDC_DuplicatePKWithinBatch(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1160,6 +1172,7 @@ func TestPostgresCDC_DuplicatePKWithinBatch(t *testing.T) {
 }
 
 func TestPostgresCDC_MergePreservesUnchangedJSONB(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1270,6 +1283,7 @@ func TestPostgresCDC_MergePreservesUnchangedJSONB(t *testing.T) {
 }
 
 func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1392,6 +1406,7 @@ func TestPostgresCDC_IntraBatchInsertUpdatePreservesUnchangedJSONB(t *testing.T)
 // the filled value must overwrite the stale target value rather than be dropped
 // via the _cdc_unchanged_cols target fallback.
 func TestPostgresCDC_IntraBatchChangedThenUnchangedOverwritesExistingRow(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1526,6 +1541,7 @@ func TestPostgresCDC_IntraBatchChangedThenUnchangedOverwritesExistingRow(t *test
 // to prevent regression of a bug where batch mode would wait forever if the source
 // database was continuously receiving writes.
 func TestPostgresCDC_BatchModeCompletesWithActiveWrites(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1664,6 +1680,7 @@ func TestPostgresCDC_BatchModeCompletesWithActiveWrites(t *testing.T) {
 }
 
 func TestPostgresCDC_IncrementalResume_DuckDB(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1774,6 +1791,7 @@ func TestPostgresCDC_IncrementalResume_DuckDB(t *testing.T) {
 // added at the source between multi-table CDC runs must be added to the
 // destination table via schema evolution before the merge.
 func TestPostgresCDC_MultiTable_SchemaEvolution(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1857,6 +1875,7 @@ func TestPostgresCDC_MultiTable_SchemaEvolution(t *testing.T) {
 }
 
 func TestPostgresCDC_StreamingSchemaEvolution_DuckDB(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -1951,6 +1970,7 @@ func TestPostgresCDC_StreamingSchemaEvolution_DuckDB(t *testing.T) {
 }
 
 func TestPostgresCDC_StreamingSchemaEvolution_MySQL(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -2099,6 +2119,7 @@ func waitForPostgresCDCSlotConfirmation(
 }
 
 func TestPostgresCDC_MultiTableTrimWhitespace(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -2197,6 +2218,7 @@ func TestPostgresCDC_MultiTableTrimWhitespace(t *testing.T) {
 // decoder to emit unchanged markers; without column filtering the SQLite
 // merge would reference a column the target table doesn't have.
 func TestPostgresCDC_UnawareDestination_SQLite(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -2344,6 +2366,7 @@ func assertBatchRunsAdvanceSlot(t *testing.T, ctx context.Context, sourceConnStr
 // (multi-table) path: repeated batch runs must keep advancing the replication
 // slot so lag returns toward zero across runs.
 func TestPostgresCDC_BatchRunAdvancesReplicationSlot(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -2374,6 +2397,7 @@ func TestPostgresCDC_BatchRunAdvancesReplicationSlot(t *testing.T) {
 // single-table path (--source-table) which streams via a different reader but
 // must confirm the slot the same way.
 func TestPostgresCDC_SingleTableBatchRunAdvancesReplicationSlot(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/streaming_cdc_idle_test.go
+++ b/tests/integration/streaming_cdc_idle_test.go
@@ -32,6 +32,7 @@ import (
 // stays frozen at the last evt change and the require.Eventually below times out
 // with lag still pinned at the noise-burst size.
 func TestPostgresCDC_StreamingIdleSlotAdvances(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/streaming_cdc_test.go
+++ b/tests/integration/streaming_cdc_test.go
@@ -25,6 +25,7 @@ import (
 // cancellation, and that the replication slot's confirmed_flush_lsn advances
 // only as data becomes durable (commit-after-flush).
 func TestPostgresCDC_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -153,6 +154,7 @@ func TestPostgresCDC_Streaming(t *testing.T) {
 // destination's max LSN without re-snapshotting and without losing changes
 // made while it was down.
 func TestPostgresCDC_StreamingResume(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}


### PR DESCRIPTION
## What

Add `t.Parallel()` to the 37 Postgres CDC integration tests, harden `uniqueSuffix()` for concurrency (digits-only), and set `-parallel 8`.

## Why it's safe (framed as workflows)

Each Postgres CDC **test function is a self-contained workflow**: it creates its **own container** and runs its own ordered a→b→c steps (snapshot → incremental → resume, etc.), then tears down.

`t.Parallel()` only adds concurrency **across** test functions — it never reorders steps **within** a test.

## Measurement

- Postgres CDC family, local, excl. the 171s `SlowWrites` outlier: **228s → 80s** at `-parallel 8` (**2.8×**), 0 failures.
- Full integration suite on CI: **~1060s → 924s** (~13%; the sequential MSSQL floor + the 171s long-pole cap the rest).