### PR TITLE
ci: pre-pull heavy testcontainer images + tighten StarRocks polls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           # Pull in parallel with go-test compilation; testcontainers will
           # find the image already cached and skip its own pull.
-          for img in mongo:7 postgres:16-alpine mysql:8.0 mcr.microsoft.com/mssql/server:2022-latest clickhouse/clickhouse-server:24.3 amazon/dynamodb-local:latest crate:latest minio/minio:latest rabbitmq:3-management-alpine; do
+          for img in mongo:7 postgres:16-alpine mysql:8.0 mcr.microsoft.com/mssql/server:2022-latest clickhouse/clickhouse-server:24.3 amazon/dynamodb-local:latest crate:latest minio/minio:latest rabbitmq:3-management-alpine starrocks/allin1-ubuntu:3.3-latest gvenzl/oracle-free:23-slim vitess/vttestserver:mysql80 redpandadata/redpanda:v24.2.7 localstack/localstack:3.8.1 cassandra:4.1 maxcompute/maxcompute-emulator:v0.0.7; do
             docker pull "$img" >/dev/null 2>&1 &
           done
 

--- a/tests/integration/starrocks_container_test.go
+++ b/tests/integration/starrocks_container_test.go
@@ -65,7 +65,7 @@ func waitForStarRocksBackend(t *testing.T, dsn string) {
 		if starRocksBackendAlive(db) {
 			return
 		}
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 	t.Fatal("StarRocks backend did not become alive within the deadline")
 }
@@ -118,7 +118,7 @@ func execEventually(t *testing.T, db *sql.DB, stmt string) {
 		} else {
 			lastErr = err
 		}
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 	t.Fatalf("statement did not succeed within deadline: %v\nstatement: %s", lastErr, stmt)
 }


### PR DESCRIPTION
## What

Two targeted, low-risk speedups for the slowest container-boot tests — **no sharding, no parallelism changes**.

### 1. Pre-pull the heavy images (`tests.yml`)
The `end2end` job pre-pulls images in the background so their pull overlaps `go build` + the rest of the suite. But the list **omitted the largest images**, so those were pulled *serially at test time*. Added:

`starrocks/allin1-ubuntu`, `gvenzl/oracle-free`, `vitess/vttestserver`, `redpandadata/redpanda`, `localstack/localstack`, `cassandra`, `maxcompute-emulator`

Now their (multi-hundred-MB to ~GB) pulls run in the background and are cached by the time those tests run, taking the pull cost off the test.

### 2. Tighten StarRocks readiness polls (`starrocks_container_test.go`)
`waitForStarRocksBackend` and `execEventually` polled every **3s**; dropped to **1s** so the test stops sleeping past the moment the backend is actually ready.

