### PR TITLE
test: parallelize streaming integration tests (155s → 40s locally)

### DIFF
--- a/tests/integration/streaming_kafka_test.go
+++ b/tests/integration/streaming_kafka_test.go
@@ -29,6 +29,7 @@ import (
 // msg_id+data envelope, offsets are committed only after a flush (a second run
 // in the same group reads nothing new), and the stream exits on cancellation.
 func TestKafka_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/streaming_platform_sources_test.go
+++ b/tests/integration/streaming_platform_sources_test.go
@@ -95,6 +95,7 @@ func TestRedis_Streaming(t *testing.T) {
 }
 
 func TestNATS_BatchCutoff(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -122,6 +123,7 @@ func TestNATS_BatchCutoff(t *testing.T) {
 }
 
 func TestNATS_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/streaming_rabbitmq_test.go
+++ b/tests/integration/streaming_rabbitmq_test.go
@@ -26,6 +26,7 @@ import (
 // acked only after a flush (queue drains, no redelivery on a second run), and
 // the stream exits cleanly on cancellation.
 func TestRabbitMQ_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -137,6 +138,7 @@ func TestRabbitMQ_Streaming(t *testing.T) {
 // the final flush (regression test: the consumer channel must outlive its
 // goroutine so CommitStream can ack at shutdown).
 func TestRabbitMQ_StreamingShutdownFlushesPending(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/streaming_tier1_test.go
+++ b/tests/integration/streaming_tier1_test.go
@@ -43,6 +43,7 @@ const (
 )
 
 func TestSQS_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -96,6 +97,7 @@ func TestSQS_Streaming(t *testing.T) {
 }
 
 func TestKinesis_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -146,6 +148,7 @@ func TestKinesis_Streaming(t *testing.T) {
 }
 
 func TestPubSub_Streaming(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}


### PR DESCRIPTION
## What
Add `t.Parallel()` to the 8 broker streaming tests (Kafka, SQS, Kinesis, PubSub, NATS ×2, RabbitMQ ×2).

## Why it's safe
Each test uses its **own source container** (redpanda/localstack/rabbitmq) and an **isolated destination** — own `postgres.Run` dest (Kafka/RabbitMQ) or a `uniqueSchemaName` schema on shared `pgDest` (SQS/Kinesis/PubSub/NATS). The two RabbitMQ tests share the broker but use distinct queue names. Same pattern as the merged Postgres CDC parallelization.

## Measurement (local, `-parallel 8`)
Sequential **154.9s** → parallel **39.7s** (3.9×), 0 failures. (RabbitMQ ×2 skipped locally — shared broker not started — isolation verified by inspection; CI exercises them.)