### PR TITLE
test: parallelize Vitess integration tests (241s → 60s locally)

### DIFF
--- a/tests/integration/vitess_cdc_batch_test.go
+++ b/tests/integration/vitess_cdc_batch_test.go
@@ -95,6 +95,7 @@ func duckQueryInt(t *testing.T, ctx context.Context, duckPath, query string) int
 // interval, which suppresses vtgate's idle heartbeats entirely. Before the stop
 // boundary existed, this run would never terminate.
 func TestVitessCDC_BusyKeyspaceBatchStops(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -172,6 +173,7 @@ func TestVitessCDC_BusyKeyspaceBatchStops(t *testing.T) {
 // first per-shard event used to truncate the snapshot to whichever shard
 // finished first.
 func TestVitessCDC_ShardedKeyspaceCopy(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -264,6 +266,7 @@ func TestVitessCDC_ShardedKeyspaceCopy(t *testing.T) {
 // tombstones rows deleted since the cursor, so the delete below would have been
 // lost. The fix resumes cursor-holding tables and copies only the new table.
 func TestVitessCDC_MixedResumeKeepsDeletes(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -319,6 +322,7 @@ func TestVitessCDC_MixedResumeKeepsDeletes(t *testing.T) {
 // against the stop boundary, so termination rides on the idle-heartbeat
 // fallback. A follow-up run picks up rows inserted later.
 func TestVitessCDC_EmptyTableBatchCompletes(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/vitess_cdc_test.go
+++ b/tests/integration/vitess_cdc_test.go
@@ -78,6 +78,7 @@ func startVitessCDCContainer(ctx context.Context) (testcontainers.Container, str
 // (VStream) performs a consistent copy-phase snapshot and then captures
 // INSERT/UPDATE/DELETE changes on a re-run, resuming from the stored VGTID.
 func TestVitessCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -157,6 +158,7 @@ func TestVitessCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
 }
 
 func TestVitessCDC_Streaming_Postgres(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/vitess_container_test.go
+++ b/tests/integration/vitess_container_test.go
@@ -72,6 +72,7 @@ func startVitessContainer(ctx context.Context) (testcontainers.Container, string
 // read is rejected by that cap, then verifies ingestr reads every row (only
 // possible because the Vitess source enables the OLAP workload).
 func TestVitessSourceReadsBeyondRowCap(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -117,6 +118,7 @@ func TestVitessSourceReadsBeyondRowCap(t *testing.T) {
 // pointing the user at the dedicated vitess:// scheme rather than silently
 // misbehaving (e.g. hitting the OLTP row cap).
 func TestMySQLSchemeRejectsVitess(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/vitess_destination_test.go
+++ b/tests/integration/vitess_destination_test.go
@@ -24,6 +24,7 @@ const shardedVitessKeyspace = "shardedks"
 // target keyspace, since _bruin_staging can't be auto-created on Vitess) + the RENAME
 // swap; the follow-up merge load exercises the UPDATE...JOIN + INSERT...NOT EXISTS path.
 func TestVitessDestination_ReplaceAndMerge(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -77,6 +78,7 @@ func TestVitessDestination_ReplaceAndMerge(t *testing.T) {
 // connect and rejected with a clear error, rather than surfacing a cryptic vtgate error
 // partway through a run.
 func TestVitessDestination_ShardedRejected(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}


### PR DESCRIPTION
## What
Add `t.Parallel()` to the 10 Vitess tests (CDC, batch, destination, container).

## Why it's safe (data)
Each test boots its **own `vttestserver`** and writes to an isolated dest (duckdb temp file or its own `postgres.Run` container). No shared mutable state — same isolation profile as the merged Postgres CDC / streaming parallelization. 0 failures locally.

## Measurement (local, `-parallel 8`)
| | wall (test time) |
|---|---|
| sequential | **241s** |
| parallel | **59.6s** (4×) |