### PR TITLE
fabric: add primary keys after creating tables

### DIFF
--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -899,13 +899,13 @@ func escapeTableName(table string) string {
 func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
 	primaryKeySet := make(map[string]struct{}, len(primaryKeys))
 	for _, key := range primaryKeys {
-		primaryKeySet[key] = struct{}{}
+		primaryKeySet[strings.ToLower(key)] = struct{}{}
 	}
 
 	var colDefs []string
 	for _, col := range columns {
 		colType := MapDataTypeToFabric(col)
-		if _, ok := primaryKeySet[col.Name]; ok {
+		if _, ok := primaryKeySet[strings.ToLower(col.Name)]; ok {
 			colType += " NOT NULL"
 		}
 		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
@@ -916,9 +916,11 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 
 	if len(primaryKeys) > 0 {
 		return fmt.Sprintf(
-			"IF OBJECT_ID('%s', 'U') IS NULL BEGIN\n  %s;\n  %s\nEND",
+			"IF OBJECT_ID('%s', 'U') IS NULL %s;\nIF OBJECT_ID('%s', 'U') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM sys.key_constraints WHERE parent_object_id = OBJECT_ID('%s') AND [type] = 'PK') %s",
 			escapeTableName(table),
 			createPart,
+			escapeTableName(table),
+			escapeTableName(table),
 			buildAddPrimaryKeySQL(table, primaryKeys),
 		)
 	}

--- a/pkg/destination/fabric/fabric.go
+++ b/pkg/destination/fabric/fabric.go
@@ -897,25 +897,53 @@ func escapeTableName(table string) string {
 }
 
 func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []string) string {
+	primaryKeySet := make(map[string]struct{}, len(primaryKeys))
+	for _, key := range primaryKeys {
+		primaryKeySet[key] = struct{}{}
+	}
+
 	var colDefs []string
 	for _, col := range columns {
-		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), MapDataTypeToFabric(col)))
+		colType := MapDataTypeToFabric(col)
+		if _, ok := primaryKeySet[col.Name]; ok {
+			colType += " NOT NULL"
+		}
+		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteColumn(col.Name), colType))
 	}
 
 	createPart := fmt.Sprintf("CREATE TABLE %s (\n  %s", quoteTable(table), strings.Join(colDefs, ",\n  "))
-
-	if len(primaryKeys) > 0 {
-		quotedKeys := make([]string, len(primaryKeys))
-		for i, k := range primaryKeys {
-			quotedKeys[i] = quoteColumn(k)
-		}
-		// Fabric only allows NONCLUSTERED, NOT ENFORCED primary keys.
-		createPart += fmt.Sprintf(",\n  PRIMARY KEY NONCLUSTERED (%s) NOT ENFORCED", strings.Join(quotedKeys, ", "))
-	}
-
 	createPart += "\n)"
 
+	if len(primaryKeys) > 0 {
+		return fmt.Sprintf(
+			"IF OBJECT_ID('%s', 'U') IS NULL BEGIN\n  %s;\n  %s\nEND",
+			escapeTableName(table),
+			createPart,
+			buildAddPrimaryKeySQL(table, primaryKeys),
+		)
+	}
+
 	return fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NULL %s", escapeTableName(table), createPart)
+}
+
+func buildAddPrimaryKeySQL(table string, primaryKeys []string) string {
+	constraintName := buildPrimaryKeyConstraintName(table)
+	quotedKeys := make([]string, len(primaryKeys))
+	for i, key := range primaryKeys {
+		quotedKeys[i] = quoteColumn(key)
+	}
+	return fmt.Sprintf(
+		"ALTER TABLE %s ADD CONSTRAINT %s PRIMARY KEY NONCLUSTERED (%s) NOT ENFORCED",
+		quoteTable(table),
+		quoteColumn(constraintName),
+		strings.Join(quotedKeys, ", "),
+	)
+}
+
+func buildPrimaryKeyConstraintName(table string) string {
+	_, tableName := parseTableName(table)
+	name := "PK_" + tableName
+	return destination.ShortenIdentifier(name, name, destination.MaxIdentifierLength("fabric"))
 }
 
 func extractValue(arr arrow.Array, idx int) interface{} {

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/naming"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -188,6 +189,71 @@ func TestURIToConnString(t *testing.T) {
 				t.Errorf("write_strategy should not appear in DSN query, got %q", q.Get("write_strategy"))
 			}
 		})
+	}
+}
+
+func TestBuildCreateTableSQLAddsPrimaryKeyWithAlterTable(t *testing.T) {
+	sql := buildCreateTableSQL("dbo.events", []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "payload", DataType: schema.TypeString},
+	}, []string{"id"})
+
+	createIdx := strings.Index(sql, "CREATE TABLE")
+	alterIdx := strings.Index(sql, "ALTER TABLE")
+	if createIdx == -1 || alterIdx == -1 || alterIdx < createIdx {
+		t.Fatalf("SQL should create the table before altering the primary key:\n%s", sql)
+	}
+
+	createSQL := sql[createIdx:alterIdx]
+	if strings.Contains(createSQL, "PRIMARY KEY") {
+		t.Fatalf("CREATE TABLE should not contain an inline primary key:\n%s", sql)
+	}
+	if !strings.Contains(createSQL, "[id] BIGINT NOT NULL") {
+		t.Fatalf("primary key column should be created NOT NULL:\n%s", sql)
+	}
+	wantAlter := "ALTER TABLE [dbo].[events] ADD CONSTRAINT [PK_events] PRIMARY KEY NONCLUSTERED ([id]) NOT ENFORCED"
+	if !strings.Contains(sql, wantAlter) {
+		t.Fatalf("SQL missing Fabric primary key ALTER TABLE statement %q:\n%s", wantAlter, sql)
+	}
+}
+
+func TestBuildCreateTableSQLShortensPrimaryKeyConstraintName(t *testing.T) {
+	longTable := strings.Repeat("orders_", 30)
+	constraintName := buildPrimaryKeyConstraintName("dbo." + longTable)
+
+	if len(constraintName) > destination.MaxIdentifierLength("fabric") {
+		t.Fatalf("constraint name length = %d, want <= %d", len(constraintName), destination.MaxIdentifierLength("fabric"))
+	}
+	if !strings.HasPrefix(constraintName, "PK_") {
+		t.Fatalf("constraint name = %q, want PK_ prefix", constraintName)
+	}
+}
+
+func TestPrepareTableUsesFabricPrimaryKeyAlterTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "payload", DataType: schema.TypeString},
+	}}
+	createSQL := buildCreateTableSQL("dbo.events", tableSchema.Columns, []string{"id"})
+	mock.ExpectExec(regexp.QuoteMeta(createSQL)).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	dest := &FabricDestination{db: db}
+	err = dest.PrepareTable(t.Context(), destination.PrepareOptions{
+		Table:       "dbo.events",
+		Schema:      tableSchema,
+		PrimaryKeys: []string{"id"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/destination/fabric/fabric_test.go
+++ b/pkg/destination/fabric/fabric_test.go
@@ -211,9 +211,25 @@ func TestBuildCreateTableSQLAddsPrimaryKeyWithAlterTable(t *testing.T) {
 	if !strings.Contains(createSQL, "[id] BIGINT NOT NULL") {
 		t.Fatalf("primary key column should be created NOT NULL:\n%s", sql)
 	}
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM sys.key_constraints WHERE parent_object_id = OBJECT_ID('dbo.events') AND [type] = 'PK')") {
+		t.Fatalf("SQL should retry missing primary key creation independently:\n%s", sql)
+	}
 	wantAlter := "ALTER TABLE [dbo].[events] ADD CONSTRAINT [PK_events] PRIMARY KEY NONCLUSTERED ([id]) NOT ENFORCED"
 	if !strings.Contains(sql, wantAlter) {
 		t.Fatalf("SQL missing Fabric primary key ALTER TABLE statement %q:\n%s", wantAlter, sql)
+	}
+}
+
+func TestBuildCreateTableSQLMatchesPrimaryKeysCaseInsensitively(t *testing.T) {
+	sql := buildCreateTableSQL("dbo.events", []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+	}, []string{"ID"})
+
+	if !strings.Contains(sql, "[id] BIGINT NOT NULL") {
+		t.Fatalf("primary key column should be created NOT NULL:\n%s", sql)
+	}
+	if !strings.Contains(sql, "PRIMARY KEY NONCLUSTERED ([ID]) NOT ENFORCED") {
+		t.Fatalf("SQL missing requested primary key spelling:\n%s", sql)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Create Fabric tables without inline primary key constraints.
- Add Fabric primary keys after table creation with ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY NONCLUSTERED ... NOT ENFORCED.
- Retry missing primary key constraint creation independently after partial DDL failures.
- Mark primary key columns NOT NULL and cover the generated DDL shape.