### PR TITLE
python: download github release binary from wrapper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,58 +172,24 @@ jobs:
     needs: [release-windows, release-unix]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - name: download binaries
-        id: fetch
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1
-        with:
-          tag: ${{ github.ref_name }}
-          fileName: ingestr_*
-          out-file-path: artifacts
-      
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Install build tooling
-        run: pip install --quiet build wheel twine
+        run: pip install --quiet build twine
 
-      - name: Build pip wheels
+      - name: Build pip wheel
         run: |
           set -euo pipefail
 
-          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          VERSION="${GITHUB_REF_NAME#v}"
           export SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION"
-          echo "building wheels for ingestr $VERSION"
+          echo "building Python wrapper for ingestr $VERSION"
 
-          mkdir -p dist
-          cp pyproject.toml pyproject.toml.orig
-
-          build_one() {
-            local archive=$1 bin_name=$2 platform_tag=$3
-            rm -rf bin build
-            mkdir -p bin
-            case "$archive" in
-              *.tar.gz) tar -xzf "$archive" -C bin "$bin_name" ;;
-              *.zip)    unzip -qoj "$archive" "$bin_name" -d bin ;;
-            esac
-            chmod +x "bin/$bin_name"
-
-            cp pyproject.toml.orig pyproject.toml
-            sed -i "s|\"bin/ingestr\" = \"ingestr\"|\"bin/$bin_name\" = \"$bin_name\"|" pyproject.toml
-
-            python -m build --wheel --outdir dist >/dev/null
-            local wheel
-            wheel=$(ls -t dist/ingestr-"$VERSION"-py*-none-any.whl | head -1)
-            python -m wheel tags --remove --platform-tag="$platform_tag" "$wheel" >/dev/null
-          }
-
-          build_one artifacts/ingestr_Linux_x86_64.tar.gz   ingestr     manylinux2014_x86_64
-          build_one artifacts/ingestr_Linux_arm64.tar.gz    ingestr     manylinux2014_aarch64
-          build_one artifacts/ingestr_Darwin_arm64.tar.gz   ingestr     macosx_11_0_arm64
-          build_one artifacts/ingestr_Windows_x86_64.zip    ingestr.exe win_amd64
-
-          mv pyproject.toml.orig pyproject.toml
+          python -m build --wheel --outdir dist
           ls -la dist/
 
       - name: Upload to pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,55 @@ jobs:
       - name: Install build tooling
         run: pip install --quiet build twine
 
+      - name: Embed release checksums
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          tag = os.environ["GITHUB_REF_NAME"]
+          token = os.environ["GITHUB_TOKEN"]
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/releases/tags/{tag}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {token}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+
+          with urllib.request.urlopen(request) as response:
+              release = json.load(response)
+
+          checksums = {}
+          for asset in release["assets"]:
+              name = asset["name"]
+              if not name.startswith("ingestr_") or not name.endswith((".tar.gz", ".zip")):
+                  continue
+
+              digest = asset.get("digest", "")
+              if not digest.startswith("sha256:"):
+                  raise RuntimeError(f"release asset {name} is missing a SHA256 digest")
+              checksums[name] = digest.removeprefix("sha256:")
+
+          if not checksums:
+              raise RuntimeError(f"no ingestr release archives found for {tag}")
+
+          Path("ingestr/_checksums.py").write_text(
+              "ARCHIVE_SHA256 = "
+              + json.dumps(checksums, indent=4, sort_keys=True)
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
       - name: Build pip wheel
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
 
           Path("ingestr/_checksums.py").write_text(
               "ARCHIVE_SHA256 = "
-              + json.dumps(checksums, indent=4, sort_keys=True)
+              + json.dumps({tag: checksums}, indent=4, sort_keys=True)
               + "\n",
               encoding="utf-8",
           )

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The pip package can also be used from Python. Install the SDK extra for Python d
 pip install 'ingestr[sdk]'
 ```
 
-Python rows, generators, and DataFrames are sent to the bundled `ingestr` binary as Arrow IPC streams by default:
+Python rows, generators, and DataFrames are sent to the `ingestr` CLI binary as Arrow IPC streams by default. The pip package downloads and caches the matching GitHub release binary on first use:
 
 ```python
 import ingestr

--- a/docs/getting-started/python-sdk.md
+++ b/docs/getting-started/python-sdk.md
@@ -6,7 +6,7 @@ outline: deep
 
 The `ingestr` pip package can be used as a Python library when your source data already lives in Python: API responses, yielded pages, dictionaries, pandas DataFrames, Polars DataFrames, or PyArrow tables.
 
-The SDK still runs the bundled `ingestr` binary for the actual ingestion work. Python data is passed to the process as Arrow IPC by default, so the Go pipeline can load it into any supported destination.
+The SDK still runs the `ingestr` CLI binary for the actual ingestion work. The pip package downloads and caches the matching GitHub release binary on first use. Python data is passed to the process as Arrow IPC by default, so the Go pipeline can load it into any supported destination.
 
 ## Installation
 
@@ -122,7 +122,7 @@ A bare `yield` inside the `with` block yields from your Python function; it does
 
 ## Transport options
 
-By default, Python data is streamed to the bundled binary over Arrow IPC:
+By default, Python data is streamed to the CLI binary over Arrow IPC:
 
 ```python
 ingestr.ingest(rows, dest_uri="duckdb:///tmp/warehouse.duckdb", dest_table="main.rows")

--- a/docs/getting-started/python-sdk.md
+++ b/docs/getting-started/python-sdk.md
@@ -8,6 +8,8 @@ The `ingestr` pip package can be used as a Python library when your source data 
 
 The SDK still runs the `ingestr` CLI binary for the actual ingestion work. The pip package downloads and caches the matching GitHub release binary on first use. Python data is passed to the process as Arrow IPC by default, so the Go pipeline can load it into any supported destination.
 
+Downloaded archives are verified against checksums embedded in the pip package. On Linux, the downloaded release binaries require glibc; musl-based distributions such as Alpine should build or provide a compatible binary with `INGESTR_BINARY_PATH`.
+
 ## Installation
 
 Install `ingestr` with the SDK extra:

--- a/ingestr/__init__.py
+++ b/ingestr/__init__.py
@@ -6,12 +6,12 @@ cli = run_cli
 try:
     from importlib.metadata import PackageNotFoundError, version
 except ModuleNotFoundError:
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+
+try:
+    __version__ = version("ingestr")
+except PackageNotFoundError:
     __version__ = "0+unknown"
-else:
-    try:
-        __version__ = version("ingestr")
-    except PackageNotFoundError:
-        __version__ = "0+unknown"
 
 __all__ = [
     "IngestrNotFoundError",

--- a/ingestr/_checksums.py
+++ b/ingestr/_checksums.py
@@ -1,0 +1,1 @@
+ARCHIVE_SHA256 = {}

--- a/ingestr/_runner.py
+++ b/ingestr/_runner.py
@@ -300,7 +300,7 @@ def _download_binary(target: Path) -> Path:
         archive_path = temp_dir / archive_name
         extracted_path = temp_dir / release.binary_name
         _download_file(url, archive_path)
-        _verify_archive_checksum(archive_path, archive_name)
+        _verify_archive_checksum(archive_path, tag, archive_name)
         _extract_binary(archive_path, release.binary_name, extracted_path)
         _ensure_executable(extracted_path)
         os.replace(str(extracted_path), str(target))
@@ -325,12 +325,12 @@ def _download_file(url: str, destination: Path) -> None:
             shutil.copyfileobj(response, output)
 
 
-def _verify_archive_checksum(archive_path: Path, archive_name: str) -> None:
-    expected = ARCHIVE_SHA256.get(archive_name)
+def _verify_archive_checksum(archive_path: Path, tag: str, archive_name: str) -> None:
+    expected = _archive_checksum(tag, archive_name)
     if not expected:
         raise IngestrNotFoundError(
-            "no embedded SHA256 checksum for %s; set %s to use a trusted local binary"
-            % (archive_name, _BINARY_PATH_ENV)
+            "no embedded SHA256 checksum for %s/%s; set %s to use a trusted local binary"
+            % (tag, archive_name, _BINARY_PATH_ENV)
         )
 
     actual = _sha256_file(archive_path)
@@ -339,6 +339,17 @@ def _verify_archive_checksum(archive_path: Path, archive_name: str) -> None:
             "downloaded archive checksum mismatch for %s: expected %s, got %s"
             % (archive_name, expected, actual)
         )
+
+
+def _archive_checksum(tag: str, archive_name: str) -> Optional[str]:
+    checksums = ARCHIVE_SHA256.get(tag)
+    if not isinstance(checksums, Mapping):
+        return None
+
+    expected = checksums.get(archive_name)
+    if not isinstance(expected, str):
+        return None
+    return expected
 
 
 def _sha256_file(path: Path) -> str:

--- a/ingestr/_runner.py
+++ b/ingestr/_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import platform
@@ -16,6 +17,8 @@ from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Union
+
+from ._checksums import ARCHIVE_SHA256
 
 try:
     from importlib.metadata import PackageNotFoundError, version
@@ -297,6 +300,7 @@ def _download_binary(target: Path) -> Path:
         archive_path = temp_dir / archive_name
         extracted_path = temp_dir / release.binary_name
         _download_file(url, archive_path)
+        _verify_archive_checksum(archive_path, archive_name)
         _extract_binary(archive_path, release.binary_name, extracted_path)
         _ensure_executable(extracted_path)
         os.replace(str(extracted_path), str(target))
@@ -319,6 +323,30 @@ def _download_file(url: str, destination: Path) -> None:
     with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
         with destination.open("wb") as output:
             shutil.copyfileobj(response, output)
+
+
+def _verify_archive_checksum(archive_path: Path, archive_name: str) -> None:
+    expected = ARCHIVE_SHA256.get(archive_name)
+    if not expected:
+        raise IngestrNotFoundError(
+            "no embedded SHA256 checksum for %s; set %s to use a trusted local binary"
+            % (archive_name, _BINARY_PATH_ENV)
+        )
+
+    actual = _sha256_file(archive_path)
+    if actual.lower() != expected.lower():
+        raise IngestrNotFoundError(
+            "downloaded archive checksum mismatch for %s: expected %s, got %s"
+            % (archive_name, expected, actual)
+        )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        for chunk in iter(lambda: input_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _extract_binary(archive_path: Path, binary_name: str, destination: Path) -> None:
@@ -398,6 +426,11 @@ def _release_platform() -> _ReleasePlatform:
     arch = arch_names.get(machine)
     if os_name is None or arch is None:
         raise IngestrNotFoundError("ingestr release binaries are not available for %s/%s" % (system, machine))
+    if os_name == "Linux" and _linux_uses_musl():
+        raise IngestrNotFoundError(
+            "ingestr release binaries require glibc on Linux; build a musl-compatible binary and set %s"
+            % _BINARY_PATH_ENV
+        )
     if os_name == "Windows" and arch != "x86_64":
         raise IngestrNotFoundError("ingestr release binaries are not available for %s/%s" % (system, machine))
 
@@ -407,6 +440,20 @@ def _release_platform() -> _ReleasePlatform:
         archive_suffix="zip" if os_name == "Windows" else "tar.gz",
         binary_name="ingestr.exe" if os_name == "Windows" else "ingestr",
     )
+
+
+def _linux_uses_musl() -> bool:
+    libc_name = platform.libc_ver()[0].lower()
+    if "musl" in libc_name:
+        return True
+
+    for directory in (Path("/lib"), Path("/usr/lib")):
+        try:
+            if any(directory.glob("ld-musl-*.so.1")):
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def _release_tag() -> str:

--- a/ingestr/_runner.py
+++ b/ingestr/_runner.py
@@ -2,41 +2,64 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
+import stat
 import subprocess
 import sys
-import sysconfig
+import tarfile
+import tempfile
+import urllib.parse
+import urllib.request
+import zipfile
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, NamedTuple, Optional, Union
+
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ModuleNotFoundError:
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
 
 PathLike = Union[str, os.PathLike]
+_GITHUB_RELEASE_BASE_URL = "https://github.com/bruin-data/ingestr/releases/download"
+_BINARY_PATH_ENV = "INGESTR_BINARY_PATH"
+_BINARY_CACHE_DIR_ENV = "INGESTR_BINARY_CACHE_DIR"
+_BINARY_TAG_ENV = "INGESTR_BINARY_TAG"
+_DOWNLOAD_TIMEOUT_SECONDS = 60
 
 
 class IngestrNotFoundError(FileNotFoundError):
-    """Raised when the bundled ingestr executable cannot be found."""
+    """Raised when the ingestr executable cannot be found or installed."""
 
     pass
 
 
+class _ReleasePlatform(NamedTuple):
+    os_name: str
+    arch: str
+    archive_suffix: str
+    binary_name: str
+
+
 def binary_path() -> str:
-    """Return the path to the installed ingestr executable."""
+    """Return the path to the ingestr executable, downloading it if needed."""
 
-    for candidate in _binary_candidates():
-        if candidate.is_file():
-            return str(candidate)
+    override = _binary_path_override()
+    if override is not None:
+        return str(override)
 
-    for name in _binary_names():
-        resolved = shutil.which(name)
-        if resolved:
-            return resolved
+    local = _local_binary_path()
+    if local is not None:
+        return str(local)
 
-    checked = ", ".join(str(path) for path in _binary_candidates())
-    raise IngestrNotFoundError(
-        "could not find the ingestr executable; reinstall with `pip install ingestr` "
-        "or build it locally with `make build`. Checked: " + checked
-    )
+    cached = _cached_binary_path()
+    if cached.is_file():
+        _ensure_executable(cached)
+        return str(cached)
+
+    return str(_download_binary(cached))
 
 
 def run(
@@ -229,31 +252,214 @@ def _binary_names() -> Sequence[str]:
     return ("ingestr", "ingestr.exe")
 
 
-def _binary_candidates() -> List[Path]:
-    dirs = _binary_dirs()
-    seen = set()
-    candidates: List[Path] = []
-    for directory in dirs:
+def _binary_path_override() -> Optional[Path]:
+    configured = os.environ.get(_BINARY_PATH_ENV)
+    if not configured:
+        return None
+
+    candidate = Path(os.path.expandvars(configured)).expanduser()
+    if candidate.is_file():
+        _ensure_executable(candidate)
+        return candidate
+
+    raise IngestrNotFoundError("%s points to a missing ingestr executable: %s" % (_BINARY_PATH_ENV, candidate))
+
+
+def _local_binary_path() -> Optional[Path]:
+    for directory in _local_binary_dirs():
         for name in _binary_names():
             candidate = directory / name
-            marker = str(candidate)
-            if marker not in seen:
-                seen.add(marker)
-                candidates.append(candidate)
-    return candidates
+            if candidate.is_file():
+                _ensure_executable(candidate)
+                return candidate
+    return None
 
 
-def _binary_dirs() -> List[Path]:
-    dirs: List[Path] = []
-    dirs.append(Path(__file__).resolve().parents[1] / "bin")
+def _local_binary_dirs() -> List[Path]:
+    return [Path(__file__).resolve().parents[1] / "bin"]
 
-    scripts_dir = sysconfig.get_path("scripts")
-    if scripts_dir:
-        dirs.append(Path(scripts_dir))
 
-    if sys.executable:
-        dirs.append(Path(sys.executable).resolve().parent)
-    return dirs
+def _cached_binary_path() -> Path:
+    release = _release_platform()
+    platform_dir = "%s_%s" % (release.os_name, release.arch)
+    return _cache_root() / "bin" / _release_tag() / platform_dir / release.binary_name
+
+
+def _download_binary(target: Path) -> Path:
+    release = _release_platform()
+    tag = _release_tag()
+    archive_name = _release_archive_name(release)
+    url = _release_asset_url(tag, archive_name)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="ingestr-download-", dir=str(target.parent)))
+    try:
+        archive_path = temp_dir / archive_name
+        extracted_path = temp_dir / release.binary_name
+        _download_file(url, archive_path)
+        _extract_binary(archive_path, release.binary_name, extracted_path)
+        _ensure_executable(extracted_path)
+        os.replace(str(extracted_path), str(target))
+        _ensure_executable(target)
+        return target
+    except Exception as exc:
+        raise IngestrNotFoundError(
+            "failed to download ingestr %s for %s/%s from %s: %s"
+            % (tag, release.os_name, release.arch, url, exc)
+        ) from exc
+    finally:
+        shutil.rmtree(str(temp_dir), ignore_errors=True)
+
+
+def _download_file(url: str, destination: Path) -> None:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "ingestr-python/%s" % _package_version()},
+    )
+    with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
+        with destination.open("wb") as output:
+            shutil.copyfileobj(response, output)
+
+
+def _extract_binary(archive_path: Path, binary_name: str, destination: Path) -> None:
+    if archive_path.suffix == ".zip":
+        _extract_binary_from_zip(archive_path, binary_name, destination)
+        return
+    _extract_binary_from_tar(archive_path, binary_name, destination)
+
+
+def _extract_binary_from_tar(archive_path: Path, binary_name: str, destination: Path) -> None:
+    with tarfile.open(str(archive_path), "r:*") as archive:
+        member = _find_tar_binary_member(archive, binary_name)
+        if member is None:
+            raise IngestrNotFoundError("%s was not found in %s" % (binary_name, archive_path.name))
+        source = archive.extractfile(member)
+        if source is None:
+            raise IngestrNotFoundError("%s could not be read from %s" % (binary_name, archive_path.name))
+        with source:
+            with destination.open("wb") as output:
+                shutil.copyfileobj(source, output)
+
+
+def _extract_binary_from_zip(archive_path: Path, binary_name: str, destination: Path) -> None:
+    with zipfile.ZipFile(str(archive_path)) as archive:
+        member = _find_zip_binary_member(archive, binary_name)
+        if member is None:
+            raise IngestrNotFoundError("%s was not found in %s" % (binary_name, archive_path.name))
+        with archive.open(member) as source:
+            with destination.open("wb") as output:
+                shutil.copyfileobj(source, output)
+
+
+def _find_tar_binary_member(archive: tarfile.TarFile, binary_name: str) -> Optional[tarfile.TarInfo]:
+    for member in archive.getmembers():
+        if member.isfile() and Path(member.name).name == binary_name:
+            return member
+    return None
+
+
+def _find_zip_binary_member(archive: zipfile.ZipFile, binary_name: str) -> Optional[str]:
+    for name in archive.namelist():
+        if not name.endswith("/") and Path(name).name == binary_name:
+            return name
+    return None
+
+
+def _release_asset_url(tag: str, archive_name: str) -> str:
+    return "%s/%s/%s" % (
+        _GITHUB_RELEASE_BASE_URL,
+        urllib.parse.quote(tag, safe=""),
+        urllib.parse.quote(archive_name, safe=""),
+    )
+
+
+def _release_archive_name(release: _ReleasePlatform) -> str:
+    return "ingestr_%s_%s.%s" % (release.os_name, release.arch, release.archive_suffix)
+
+
+def _release_platform() -> _ReleasePlatform:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    os_names = {
+        "darwin": "Darwin",
+        "linux": "Linux",
+        "windows": "Windows",
+    }
+    arch_names = {
+        "amd64": "x86_64",
+        "x86_64": "x86_64",
+        "x64": "x86_64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }
+
+    os_name = os_names.get(system)
+    arch = arch_names.get(machine)
+    if os_name is None or arch is None:
+        raise IngestrNotFoundError("ingestr release binaries are not available for %s/%s" % (system, machine))
+    if os_name == "Windows" and arch != "x86_64":
+        raise IngestrNotFoundError("ingestr release binaries are not available for %s/%s" % (system, machine))
+
+    return _ReleasePlatform(
+        os_name=os_name,
+        arch=arch,
+        archive_suffix="zip" if os_name == "Windows" else "tar.gz",
+        binary_name="ingestr.exe" if os_name == "Windows" else "ingestr",
+    )
+
+
+def _release_tag() -> str:
+    configured = os.environ.get(_BINARY_TAG_ENV)
+    if configured:
+        return configured
+
+    package_version = _package_version()
+    public_version = package_version.split("+", 1)[0]
+    if not public_version or "dev" in public_version or public_version == "0":
+        raise IngestrNotFoundError(
+            "cannot infer an ingestr GitHub release tag from package version %r; set %s or %s"
+            % (package_version, _BINARY_TAG_ENV, _BINARY_PATH_ENV)
+        )
+    if public_version.startswith("v"):
+        return public_version
+    return "v" + public_version
+
+
+def _package_version() -> str:
+    try:
+        return version("ingestr")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def _cache_root() -> Path:
+    configured = os.environ.get(_BINARY_CACHE_DIR_ENV)
+    if configured:
+        return Path(os.path.expandvars(configured)).expanduser()
+
+    if os.name == "nt":
+        root = os.environ.get("LOCALAPPDATA")
+        if root:
+            return Path(root) / "ingestr"
+        return Path.home() / "AppData" / "Local" / "ingestr"
+
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "ingestr"
+
+    root = os.environ.get("XDG_CACHE_HOME")
+    if root:
+        return Path(root) / "ingestr"
+    return Path.home() / ".cache" / "ingestr"
+
+
+def _ensure_executable(path: Path) -> None:
+    if os.name == "nt":
+        return
+    mode = stat.S_IMODE(path.stat().st_mode)
+    executable_mode = mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    if executable_mode != mode:
+        path.chmod(executable_mode)
 
 
 def _normalize_args(args: Optional[Sequence[object]]) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dynamic = ["version"]
 description = "ingestr is a command-line application that ingests data from various sources and stores them in any database."
 readme = "README.md"
 requires-python = ">=3.7"
+dependencies = [
+  "importlib-metadata>=4; python_version < '3.8'",
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -28,10 +31,11 @@ Issues = "https://github.com/bruin-data/ingestr/issues"
 [project.optional-dependencies]
 sdk = ["pyarrow>=10"]
 
+[project.scripts]
+ingestr = "ingestr._runner:main"
+
 [tool.hatch.build.targets.wheel]
 packages = ["ingestr"]
-shared-scripts = { "bin/ingestr" = "ingestr" }
-bypass-selection = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/tests/python/test_ingestr_package.py
+++ b/tests/python/test_ingestr_package.py
@@ -1,3 +1,4 @@
+import hashlib
 import io
 import os
 import subprocess
@@ -209,9 +210,12 @@ class IngestrPackageTest(unittest.TestCase):
                 with patch("ingestr._runner._local_binary_path", return_value=None):
                     with patch("ingestr._runner._package_version", return_value="1.2.3"):
                         with patch("ingestr._runner._release_platform", return_value=release):
-                            with patch("ingestr._runner._download_file", side_effect=fake_download):
-                                path = Path(ingestr.binary_path())
-                                second_path = Path(ingestr.binary_path())
+                            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+                            checksums = {"ingestr_Linux_x86_64.tar.gz": checksum}
+                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, checksums, clear=True):
+                                with patch("ingestr._runner._download_file", side_effect=fake_download):
+                                    path = Path(ingestr.binary_path())
+                                    second_path = Path(ingestr.binary_path())
 
             self.assertEqual(path, second_path)
             self.assertEqual(path.name, "ingestr")
@@ -221,6 +225,30 @@ class IngestrPackageTest(unittest.TestCase):
                 downloads,
                 ["https://github.com/bruin-data/ingestr/releases/download/v1.2.3/ingestr_Linux_x86_64.tar.gz"],
             )
+
+    def test_binary_path_rejects_checksum_mismatch(self):
+        binary = b"#!/bin/sh\necho ingestr\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive_path = root / "ingestr_Linux_x86_64.tar.gz"
+            _write_tar_binary(archive_path, "ingestr", binary)
+
+            def fake_download(url, destination):
+                destination.write_bytes(archive_path.read_bytes())
+
+            release = ingestr_runner._ReleasePlatform("Linux", "x86_64", "tar.gz", "ingestr")
+            with patch.dict(os.environ, {"INGESTR_BINARY_CACHE_DIR": str(root / "cache")}, clear=True):
+                with patch("ingestr._runner._local_binary_path", return_value=None):
+                    with patch("ingestr._runner._package_version", return_value="1.2.3"):
+                        with patch("ingestr._runner._release_platform", return_value=release):
+                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, {"ingestr_Linux_x86_64.tar.gz": "0" * 64}, clear=True):
+                                with patch("ingestr._runner._download_file", side_effect=fake_download):
+                                    with self.assertRaisesRegex(
+                                        ingestr.IngestrNotFoundError,
+                                        "checksum mismatch",
+                                    ):
+                                        ingestr.binary_path()
 
     def test_release_platform_uses_goreleaser_asset_names(self):
         with patch("platform.system", return_value="Linux"):
@@ -240,6 +268,13 @@ class IngestrPackageTest(unittest.TestCase):
             with patch("platform.machine", return_value="riscv64"):
                 with self.assertRaises(ingestr.IngestrNotFoundError):
                     ingestr_runner._release_platform()
+
+    def test_release_platform_rejects_musl_linux(self):
+        with patch("platform.system", return_value="Linux"):
+            with patch("platform.machine", return_value="x86_64"):
+                with patch("ingestr._runner._linux_uses_musl", return_value=True):
+                    with self.assertRaisesRegex(ingestr.IngestrNotFoundError, "glibc"):
+                        ingestr_runner._release_platform()
 
     @unittest.skipIf(pa is None, "pyarrow is required for SDK data ingestion tests")
     def test_ingest_streams_records_to_stdin(self):

--- a/tests/python/test_ingestr_package.py
+++ b/tests/python/test_ingestr_package.py
@@ -1,5 +1,7 @@
 import io
+import os
 import subprocess
+import tarfile
 import tempfile
 import unittest
 from dataclasses import dataclass
@@ -9,6 +11,7 @@ from unittest.mock import patch
 
 import ingestr
 import ingestr._data as ingestr_data
+import ingestr._runner as ingestr_runner
 
 try:
     import pyarrow as pa
@@ -112,7 +115,7 @@ class IngestrPackageTest(unittest.TestCase):
             ],
         )
 
-    def test_run_invokes_bundled_binary(self):
+    def test_run_invokes_resolved_binary(self):
         completed = subprocess.CompletedProcess(["/tmp/ingestr", "--version"], 0)
 
         with patch("ingestr._runner.binary_path", return_value="/tmp/ingestr"):
@@ -170,14 +173,73 @@ class IngestrPackageTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             ingestr.run("ingest --help")
 
-    def test_binary_path_finds_installed_script(self):
+    def test_binary_path_uses_explicit_override(self):
         with tempfile.TemporaryDirectory() as tmp:
             executable = Path(tmp) / "ingestr"
             executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
-            with patch("ingestr._runner._binary_dirs", return_value=[Path(tmp)]):
-                with patch("ingestr._runner.shutil.which", return_value=None):
+            with patch.dict(os.environ, {"INGESTR_BINARY_PATH": str(executable)}):
+                self.assertEqual(ingestr.binary_path(), str(executable))
+
+    def test_binary_path_uses_local_build(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            executable = Path(tmp) / "ingestr"
+            executable.write_text("#!/bin/sh\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("ingestr._runner._local_binary_dirs", return_value=[Path(tmp)]):
                     self.assertEqual(ingestr.binary_path(), str(executable))
+
+    def test_binary_path_downloads_release_binary(self):
+        binary = b"#!/bin/sh\necho ingestr\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive_path = root / "ingestr_Linux_x86_64.tar.gz"
+            _write_tar_binary(archive_path, "ingestr", binary)
+
+            downloads = []
+
+            def fake_download(url, destination):
+                downloads.append(url)
+                destination.write_bytes(archive_path.read_bytes())
+
+            release = ingestr_runner._ReleasePlatform("Linux", "x86_64", "tar.gz", "ingestr")
+            with patch.dict(os.environ, {"INGESTR_BINARY_CACHE_DIR": str(root / "cache")}, clear=True):
+                with patch("ingestr._runner._local_binary_path", return_value=None):
+                    with patch("ingestr._runner._package_version", return_value="1.2.3"):
+                        with patch("ingestr._runner._release_platform", return_value=release):
+                            with patch("ingestr._runner._download_file", side_effect=fake_download):
+                                path = Path(ingestr.binary_path())
+                                second_path = Path(ingestr.binary_path())
+
+            self.assertEqual(path, second_path)
+            self.assertEqual(path.name, "ingestr")
+            self.assertEqual(path.read_bytes(), binary)
+            self.assertTrue(os.access(path, os.X_OK))
+            self.assertEqual(
+                downloads,
+                ["https://github.com/bruin-data/ingestr/releases/download/v1.2.3/ingestr_Linux_x86_64.tar.gz"],
+            )
+
+    def test_release_platform_uses_goreleaser_asset_names(self):
+        with patch("platform.system", return_value="Linux"):
+            with patch("platform.machine", return_value="aarch64"):
+                release = ingestr_runner._release_platform()
+
+        self.assertEqual(ingestr_runner._release_archive_name(release), "ingestr_Linux_arm64.tar.gz")
+
+        with patch("platform.system", return_value="Windows"):
+            with patch("platform.machine", return_value="AMD64"):
+                release = ingestr_runner._release_platform()
+
+        self.assertEqual(ingestr_runner._release_archive_name(release), "ingestr_Windows_x86_64.zip")
+
+    def test_release_platform_rejects_unsupported_arch(self):
+        with patch("platform.system", return_value="Linux"):
+            with patch("platform.machine", return_value="riscv64"):
+                with self.assertRaises(ingestr.IngestrNotFoundError):
+                    ingestr_runner._release_platform()
 
     @unittest.skipIf(pa is None, "pyarrow is required for SDK data ingestion tests")
     def test_ingest_streams_records_to_stdin(self):
@@ -495,6 +557,14 @@ class IngestrPackageTest(unittest.TestCase):
                 dest_table="main.df",
                 text=True,
             )
+
+
+def _write_tar_binary(path, name, data):
+    with tarfile.open(path, "w:gz") as archive:
+        info = tarfile.TarInfo(name)
+        info.size = len(data)
+        info.mode = 0o755
+        archive.addfile(info, io.BytesIO(data))
 
 
 if __name__ == "__main__":

--- a/tests/python/test_ingestr_package.py
+++ b/tests/python/test_ingestr_package.py
@@ -211,7 +211,7 @@ class IngestrPackageTest(unittest.TestCase):
                     with patch("ingestr._runner._package_version", return_value="1.2.3"):
                         with patch("ingestr._runner._release_platform", return_value=release):
                             checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
-                            checksums = {"ingestr_Linux_x86_64.tar.gz": checksum}
+                            checksums = {"v1.2.3": {"ingestr_Linux_x86_64.tar.gz": checksum}}
                             with patch.dict(ingestr_runner.ARCHIVE_SHA256, checksums, clear=True):
                                 with patch("ingestr._runner._download_file", side_effect=fake_download):
                                     path = Path(ingestr.binary_path())
@@ -225,6 +225,74 @@ class IngestrPackageTest(unittest.TestCase):
                 downloads,
                 ["https://github.com/bruin-data/ingestr/releases/download/v1.2.3/ingestr_Linux_x86_64.tar.gz"],
             )
+
+    def test_binary_path_uses_tag_specific_checksum_for_tag_override(self):
+        binary = b"#!/bin/sh\necho ingestr\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive_path = root / "ingestr_Linux_x86_64.tar.gz"
+            _write_tar_binary(archive_path, "ingestr", binary)
+
+            downloads = []
+
+            def fake_download(url, destination):
+                downloads.append(url)
+                destination.write_bytes(archive_path.read_bytes())
+
+            release = ingestr_runner._ReleasePlatform("Linux", "x86_64", "tar.gz", "ingestr")
+            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            checksums = {
+                "v1.2.3": {"ingestr_Linux_x86_64.tar.gz": "0" * 64},
+                "v9.9.9": {"ingestr_Linux_x86_64.tar.gz": checksum},
+            }
+            env = {
+                "INGESTR_BINARY_CACHE_DIR": str(root / "cache"),
+                "INGESTR_BINARY_TAG": "v9.9.9",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                with patch("ingestr._runner._local_binary_path", return_value=None):
+                    with patch("ingestr._runner._package_version", return_value="1.2.3"):
+                        with patch("ingestr._runner._release_platform", return_value=release):
+                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, checksums, clear=True):
+                                with patch("ingestr._runner._download_file", side_effect=fake_download):
+                                    path = Path(ingestr.binary_path())
+
+            self.assertEqual(path.read_bytes(), binary)
+            self.assertEqual(
+                downloads,
+                ["https://github.com/bruin-data/ingestr/releases/download/v9.9.9/ingestr_Linux_x86_64.tar.gz"],
+            )
+
+    def test_binary_path_rejects_missing_tag_checksum(self):
+        binary = b"#!/bin/sh\necho ingestr\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive_path = root / "ingestr_Linux_x86_64.tar.gz"
+            _write_tar_binary(archive_path, "ingestr", binary)
+
+            def fake_download(url, destination):
+                destination.write_bytes(archive_path.read_bytes())
+
+            release = ingestr_runner._ReleasePlatform("Linux", "x86_64", "tar.gz", "ingestr")
+            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            env = {
+                "INGESTR_BINARY_CACHE_DIR": str(root / "cache"),
+                "INGESTR_BINARY_TAG": "v9.9.9",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                with patch("ingestr._runner._local_binary_path", return_value=None):
+                    with patch("ingestr._runner._package_version", return_value="1.2.3"):
+                        with patch("ingestr._runner._release_platform", return_value=release):
+                            checksums = {"v1.2.3": {"ingestr_Linux_x86_64.tar.gz": checksum}}
+                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, checksums, clear=True):
+                                with patch("ingestr._runner._download_file", side_effect=fake_download):
+                                    with self.assertRaisesRegex(
+                                        ingestr.IngestrNotFoundError,
+                                        "no embedded SHA256 checksum for v9.9.9/ingestr_Linux_x86_64.tar.gz",
+                                    ):
+                                        ingestr.binary_path()
 
     def test_binary_path_rejects_checksum_mismatch(self):
         binary = b"#!/bin/sh\necho ingestr\n"
@@ -242,7 +310,8 @@ class IngestrPackageTest(unittest.TestCase):
                 with patch("ingestr._runner._local_binary_path", return_value=None):
                     with patch("ingestr._runner._package_version", return_value="1.2.3"):
                         with patch("ingestr._runner._release_platform", return_value=release):
-                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, {"ingestr_Linux_x86_64.tar.gz": "0" * 64}, clear=True):
+                            checksums = {"v1.2.3": {"ingestr_Linux_x86_64.tar.gz": "0" * 64}}
+                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, checksums, clear=True):
                                 with patch("ingestr._runner._download_file", side_effect=fake_download):
                                     with self.assertRaisesRegex(
                                         ingestr.IngestrNotFoundError,

--- a/uv.lock
+++ b/uv.lock
@@ -9,8 +9,24 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "6.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.8'" },
+    { name = "zipp", marker = "python_full_version < '3.8'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/82/f6e29c8d5c098b6be61460371c2c5591f4a335923639edec43b3830650a4/importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4", size = 53569, upload-time = "2023-06-18T21:44:35.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/94/64287b38c7de4c90683630338cf28f129decbba0a44f0c6db35a873c73c4/importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5", size = 22934, upload-time = "2023-06-18T21:44:33.441Z" },
+]
+
+[[package]]
 name = "ingestr"
 source = { editable = "." }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.8'" },
+]
 
 [package.optional-dependencies]
 sdk = [
@@ -21,7 +37,10 @@ sdk = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyarrow", marker = "extra == 'sdk'", specifier = ">=10" }]
+requires-dist = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.8'", specifier = ">=4" },
+    { name = "pyarrow", marker = "extra == 'sdk'", specifier = ">=10" },
+]
 provides-extras = ["sdk"]
 
 [[package]]
@@ -301,4 +320,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876, upload-time = "2023-07-02T14:20:55.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232, upload-time = "2023-07-02T14:20:53.275Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b", size = 18454, upload-time = "2023-02-25T02:17:22.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556", size = 6758, upload-time = "2023-02-25T02:17:20.807Z" },
 ]


### PR DESCRIPTION
## Summary
- Publish the pip package as a small pure-Python console wrapper instead of platform wheels containing compiled binaries.
- Resolve the CLI binary from an explicit override, local dev build, or per-version cache, downloading the matching GitHub release asset on first use.
- Embed release archive SHA256 digests into the PyPI wheel and verify downloads before extraction.
- Reject musl-based Linux for downloaded release binaries and document `INGESTR_BINARY_PATH` for compatible local binaries.
- Update Python SDK docs, package tests, and the lockfile for the Python 3.7 metadata backport.

## Verification
- `uv run --extra sdk python tests/python/test_ingestr_package.py`
- `python -m build --wheel --outdir /tmp/ingestr-wheel-check`
- `make format`
- `make lint`
- `make test`