### PR TITLE
metrics: expose stream byte counters

### DIFF
--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -103,11 +103,18 @@ ingestr publishes:
 |---|---|
 | `ingestr_replication_*{source}` | Replication lag for the current source (see below). Absent when the source cannot report lag. |
 | `ingestr_stream_rows_synced_total` | Cumulative rows written **and** confirmed durable since the process started. |
+| `ingestr_stream_bytes_synced_total` | Cumulative logical Arrow payload bytes written **and** confirmed durable since the process started. |
 | `ingestr_stream_flush_cycles_total` | Number of completed flush cycles. |
 | `ingestr_stream_last_synced_timestamp_seconds` | Unix time of the last successful commit. |
-| `ingestr_stream_table_*{table}` | The same row counts and timestamp, broken out per destination table. |
+| `ingestr_stream_table_rows_synced_total{table}` | Cumulative rows written and confirmed durable, broken out per destination table. |
+| `ingestr_stream_table_bytes_synced_total{table}` | Cumulative logical Arrow payload bytes written and confirmed durable, broken out per destination table. |
+| `ingestr_stream_table_last_flush_rows{table}` | Rows written for a table in its most recent successful flush cycle. |
+| `ingestr_stream_table_last_flush_bytes{table}` | Logical Arrow payload bytes written for a table in its most recent successful flush cycle. |
+| `ingestr_stream_table_last_synced_timestamp_seconds{table}` | Unix time of the most recent successful flush cycle that included a table. |
 
 The row counters advance only after a flush's destination write **and** its source-position commit have both succeeded, so they count durable rows rather than merely written ones. `ingestr_stream_last_synced_timestamp_seconds` also advances on cycles that commit a position without writing rows, which is what makes it usable as a staleness alarm: if it stops moving, the stream is stuck.
+
+The byte counters use the Arrow record-batch buffers ingestr hands to the destination after stream transformations such as `_ingestr_loaded_at`. They are useful for stream throughput and workload monitoring, but they are not source log bytes, network bytes, compressed staging-file bytes, warehouse billing bytes, or destination table growth after merge/deduplication.
 
 The `ingestr_replication_*` series carry a `source` label and depend on the engine, because "lag" is not the same quantity everywhere:
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,6 +33,10 @@ var (
 		Name: "ingestr_stream_rows_synced_total",
 		Help: "Total rows durably synced to the destination and acknowledged to the source.",
 	})
+	bytesSynced = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ingestr_stream_bytes_synced_total",
+		Help: "Total logical Arrow payload bytes durably synced to the destination and acknowledged to the source.",
+	})
 	flushCycles = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "ingestr_stream_flush_cycles_total",
 		Help: "Total committed flush cycles.",
@@ -45,9 +49,17 @@ var (
 		Name: "ingestr_stream_table_rows_synced_total",
 		Help: "Total rows durably synced, per table.",
 	}, []string{"table"})
+	tableBytesSynced = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingestr_stream_table_bytes_synced_total",
+		Help: "Total logical Arrow payload bytes durably synced, per table.",
+	}, []string{"table"})
 	tableLastFlushRows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ingestr_stream_table_last_flush_rows",
 		Help: "Rows written for a table in its most recent flush cycle.",
+	}, []string{"table"})
+	tableLastFlushBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ingestr_stream_table_last_flush_bytes",
+		Help: "Logical Arrow payload bytes written for a table in its most recent flush cycle.",
 	}, []string{"table"})
 	tableLastSyncedTS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ingestr_stream_table_last_synced_timestamp_seconds",
@@ -58,10 +70,13 @@ var (
 func init() {
 	registry.MustRegister(
 		rowsSynced,
+		bytesSynced,
 		flushCycles,
 		lastSyncedTS,
 		tableRowsSynced,
+		tableBytesSynced,
 		tableLastFlushRows,
+		tableLastFlushBytes,
 		tableLastSyncedTS,
 		replicationCollector{},
 	)
@@ -152,21 +167,32 @@ func SetLagReporter(r source.LagReporter) {
 	reporter.Store(&r)
 }
 
+// SyncStats describes the logical payload committed for one table in a flush.
+type SyncStats struct {
+	Rows  int64
+	Bytes uint64
+}
+
 // RecordSync accounts one successfully committed flush cycle. Callers must
 // invoke it only after the source position is committed, so the counters mean
 // "durable in the destination" rather than merely "written".
-func RecordSync(perTable map[string]int64, at time.Time) {
+func RecordSync(perTable map[string]SyncStats, at time.Time) {
 	unix := float64(at.Unix())
 	var total int64
+	var totalBytes uint64
 
-	for name, rows := range perTable {
-		tableRowsSynced.WithLabelValues(name).Add(float64(rows))
-		tableLastFlushRows.WithLabelValues(name).Set(float64(rows))
+	for name, stats := range perTable {
+		tableRowsSynced.WithLabelValues(name).Add(float64(stats.Rows))
+		tableBytesSynced.WithLabelValues(name).Add(float64(stats.Bytes))
+		tableLastFlushRows.WithLabelValues(name).Set(float64(stats.Rows))
+		tableLastFlushBytes.WithLabelValues(name).Set(float64(stats.Bytes))
 		tableLastSyncedTS.WithLabelValues(name).Set(unix)
-		total += rows
+		total += stats.Rows
+		totalBytes += stats.Bytes
 	}
 
 	rowsSynced.Add(float64(total))
+	bytesSynced.Add(float64(totalBytes))
 	flushCycles.Inc()
 	lastSyncedTS.Set(unix)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -55,13 +55,15 @@ func metricValue(m *dto.Metric) float64 {
 }
 
 // resetState clears the per-table series and the reporter so each test starts
-// clean. The plain counters (rowsSynced, flushCycles) cannot be reset, so tests
-// that assert their totals measure a before/after delta instead.
+// clean. The plain counters cannot be reset, so tests that assert their totals
+// measure a before/after delta instead.
 func resetState(t *testing.T) {
 	t.Helper()
 	SetLagReporter(nil)
 	tableRowsSynced.Reset()
+	tableBytesSynced.Reset()
 	tableLastFlushRows.Reset()
+	tableLastFlushBytes.Reset()
 	tableLastSyncedTS.Reset()
 	lastSyncedTS.Set(0)
 	t.Cleanup(func() { SetLagReporter(nil) })
@@ -137,13 +139,23 @@ func TestRecordSyncAccumulates(t *testing.T) {
 	resetState(t)
 
 	beforeRows := testutil.ToFloat64(rowsSynced)
+	beforeBytes := testutil.ToFloat64(bytesSynced)
 	beforeCycles := testutil.ToFloat64(flushCycles)
 
-	RecordSync(map[string]int64{"public.users": 100, "public.orders": 50}, time.Unix(1000, 0))
-	RecordSync(map[string]int64{"public.users": 25, "public.items": 7}, time.Unix(2000, 0))
+	RecordSync(map[string]SyncStats{
+		"public.users":  {Rows: 100, Bytes: 1000},
+		"public.orders": {Rows: 50, Bytes: 500},
+	}, time.Unix(1000, 0))
+	RecordSync(map[string]SyncStats{
+		"public.users": {Rows: 25, Bytes: 250},
+		"public.items": {Rows: 7, Bytes: 70},
+	}, time.Unix(2000, 0))
 
 	if got := testutil.ToFloat64(rowsSynced) - beforeRows; got != 182 {
 		t.Fatalf("expected 182 rows synced in total, got %v", got)
+	}
+	if got := testutil.ToFloat64(bytesSynced) - beforeBytes; got != 1820 {
+		t.Fatalf("expected 1820 bytes synced in total, got %v", got)
 	}
 	if got := testutil.ToFloat64(flushCycles) - beforeCycles; got != 2 {
 		t.Fatalf("expected 2 flush cycles, got %v", got)
@@ -156,13 +168,22 @@ func TestRecordSyncAccumulates(t *testing.T) {
 	if got := testutil.ToFloat64(tableRowsSynced.WithLabelValues("public.users")); got != 125 {
 		t.Fatalf("expected users rows_synced=125, got %v", got)
 	}
+	if got := testutil.ToFloat64(tableBytesSynced.WithLabelValues("public.users")); got != 1250 {
+		t.Fatalf("expected users bytes_synced=1250, got %v", got)
+	}
 	if got := testutil.ToFloat64(tableLastFlushRows.WithLabelValues("public.users")); got != 25 {
 		t.Fatalf("expected users last_flush_rows=25, got %v", got)
+	}
+	if got := testutil.ToFloat64(tableLastFlushBytes.WithLabelValues("public.users")); got != 250 {
+		t.Fatalf("expected users last_flush_bytes=250, got %v", got)
 	}
 
 	// A table absent from cycle 2 keeps its totals and its older timestamp.
 	if got := testutil.ToFloat64(tableRowsSynced.WithLabelValues("public.orders")); got != 50 {
 		t.Fatalf("expected orders rows_synced=50, got %v", got)
+	}
+	if got := testutil.ToFloat64(tableBytesSynced.WithLabelValues("public.orders")); got != 500 {
+		t.Fatalf("expected orders bytes_synced=500, got %v", got)
 	}
 	if got := testutil.ToFloat64(tableLastSyncedTS.WithLabelValues("public.orders")); got != 1000 {
 		t.Fatalf("expected orders to keep last_synced=1000, got %v", got)
@@ -172,6 +193,9 @@ func TestRecordSyncAccumulates(t *testing.T) {
 	if got := testutil.ToFloat64(tableRowsSynced.WithLabelValues("public.items")); got != 7 {
 		t.Fatalf("expected items rows_synced=7, got %v", got)
 	}
+	if got := testutil.ToFloat64(tableBytesSynced.WithLabelValues("public.items")); got != 70 {
+		t.Fatalf("expected items bytes_synced=70, got %v", got)
+	}
 }
 
 // An idle commit cycle confirms the source position without writing rows; it
@@ -180,10 +204,14 @@ func TestRecordSyncIdleCycleAdvancesTimestamp(t *testing.T) {
 	resetState(t)
 
 	beforeRows := testutil.ToFloat64(rowsSynced)
-	RecordSync(map[string]int64{}, time.Unix(500, 0))
+	beforeBytes := testutil.ToFloat64(bytesSynced)
+	RecordSync(map[string]SyncStats{}, time.Unix(500, 0))
 
 	if got := testutil.ToFloat64(rowsSynced) - beforeRows; got != 0 {
 		t.Fatalf("expected no rows synced, got %v", got)
+	}
+	if got := testutil.ToFloat64(bytesSynced) - beforeBytes; got != 0 {
+		t.Fatalf("expected no bytes synced, got %v", got)
 	}
 	if got := testutil.ToFloat64(lastSyncedTS); got != 500 {
 		t.Fatalf("expected last synced 500, got %v", got)
@@ -198,7 +226,7 @@ func TestRecordSyncConcurrentWithScrape(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := range 8 {
 		wg.Go(func() {
-			RecordSync(map[string]int64{fmt.Sprintf("t%d", i%3): 1}, time.Unix(int64(i), 0))
+			RecordSync(map[string]SyncStats{fmt.Sprintf("t%d", i%3): {Rows: 1, Bytes: 2}}, time.Unix(int64(i), 0))
 		})
 		wg.Go(func() {
 			_, _ = registry.Gather()
@@ -213,7 +241,7 @@ func TestRecordSyncConcurrentWithScrape(t *testing.T) {
 
 func TestServeExposesMetrics(t *testing.T) {
 	resetState(t)
-	RecordSync(map[string]int64{"public.users": 3}, time.Unix(1234, 0))
+	RecordSync(map[string]SyncStats{"public.users": {Rows: 3, Bytes: 24}}, time.Unix(1234, 0))
 
 	addr, stop, err := Serve("127.0.0.1:0")
 	if err != nil {
@@ -236,8 +264,14 @@ func TestServeExposesMetrics(t *testing.T) {
 	if !strings.Contains(text, "ingestr_stream_rows_synced_total") {
 		t.Fatalf("expected ingestr_stream_rows_synced_total in /metrics, got:\n%s", text)
 	}
+	if !strings.Contains(text, "ingestr_stream_bytes_synced_total") {
+		t.Fatalf("expected ingestr_stream_bytes_synced_total in /metrics, got:\n%s", text)
+	}
 	if !strings.Contains(text, `ingestr_stream_table_rows_synced_total{table="public.users"}`) {
 		t.Fatalf("expected per-table series in /metrics, got:\n%s", text)
+	}
+	if !strings.Contains(text, `ingestr_stream_table_bytes_synced_total{table="public.users"}`) {
+		t.Fatalf("expected per-table byte series in /metrics, got:\n%s", text)
 	}
 
 	// The dedicated registry must not carry the default registry's Go runtime or

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -923,6 +923,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 
 		batches []arrow.RecordBatch
 		rows    int64
+		bytes   uint64
 	}
 
 	var work []flushWork
@@ -952,7 +953,7 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		}
 	}
 
-	flushOne := func(ctx context.Context, w flushWork) error {
+	flushOne := func(ctx context.Context, w *flushWork) error {
 		st := w.st
 		displayName := w.name
 		if displayName == "" {
@@ -982,10 +983,13 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		if col, ok := loadTimestampColumn(st.schema); ok {
 			records = transformer.Wrap(records, transformer.NewLoadTimestamp(col, loadTimestamp))
 		}
+		var bytes uint64
+		records = countRecordBatchBytes(records, &bytes)
 		if err := l.dest.WriteParallel(ctx, records, writeOpts); err != nil {
 			drainAndRelease(records)
 			return fmt.Errorf("streaming flush: failed to write %d rows for table %s: %w", w.rows, displayName, err)
 		}
+		w.bytes = bytes
 		if err := connectorLeaseLoss(ctx); err != nil {
 			return err
 		}
@@ -1022,13 +1026,14 @@ func (l *flushLoop) flush(ctx context.Context) error {
 	if limit := l.flushConcurrency(); limit > 1 && len(work) > 1 {
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(limit)
-		for _, w := range work {
+		for i := range work {
+			w := &work[i]
 			g.Go(func() error { return flushOne(gctx, w) })
 		}
 		flushErr = g.Wait()
 	} else {
-		for i, w := range work {
-			if err := flushOne(ctx, w); err != nil {
+		for i := range work {
+			if err := flushOne(ctx, &work[i]); err != nil {
 				for _, unstarted := range work[i+1:] {
 					for _, batch := range unstarted.batches {
 						batch.Release()
@@ -1104,13 +1109,13 @@ func (l *flushLoop) flush(ctx context.Context) error {
 
 	// Only after the commit: the counters mean "durable in the destination and
 	// acknowledged to the source", not merely "written".
-	perTable := make(map[string]int64, len(work))
+	perTable := make(map[string]metrics.SyncStats, len(work))
 	for _, w := range work {
 		name := w.name
 		if name == "" {
 			name = w.st.destTable // single-table streams key l.tables on ""
 		}
-		perTable[name] = w.rows
+		perTable[name] = metrics.SyncStats{Rows: w.rows, Bytes: w.bytes}
 	}
 	metrics.RecordSync(perTable, time.Now())
 
@@ -1119,6 +1124,35 @@ func (l *flushLoop) flush(ctx context.Context) error {
 		output.Statusf("[STREAM] %s | cycle %d: flushed %d rows in %s\n", time.Now().Format("15:04:05"), l.cycles, flushedRows, time.Since(start).Round(time.Millisecond))
 	}
 	return nil
+}
+
+func countRecordBatchBytes(records <-chan source.RecordBatchResult, total *uint64) <-chan source.RecordBatchResult {
+	out := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(out)
+		for result := range records {
+			if result.Err == nil && result.Batch != nil {
+				*total += recordBatchPayloadBytes(result.Batch)
+			}
+			out <- result
+		}
+	}()
+	return out
+}
+
+func recordBatchPayloadBytes(batch arrow.RecordBatch) uint64 {
+	if batch == nil {
+		return 0
+	}
+	var total uint64
+	for i := 0; i < int(batch.NumCols()); i++ {
+		col := batch.Column(i)
+		if col == nil || col.Data() == nil {
+			continue
+		}
+		total += col.Data().SizeInBytes()
+	}
+	return total
 }
 
 // flushConcurrency returns how many tables may flush at once: destinations

--- a/pkg/strategy/streaming_metrics_test.go
+++ b/pkg/strategy/streaming_metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/metrics"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/transformer"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,11 @@ func rowsSyncedValue(t *testing.T) float64 {
 	return gatherValue(t, "ingestr_stream_rows_synced_total", nil)
 }
 
+func bytesSyncedValue(t *testing.T) float64 {
+	t.Helper()
+	return gatherValue(t, "ingestr_stream_bytes_synced_total", nil)
+}
+
 func lastSyncedValue(t *testing.T) float64 {
 	t.Helper()
 	return gatherValue(t, "ingestr_stream_last_synced_timestamp_seconds", nil)
@@ -75,28 +81,52 @@ func tableRowsSynced(t *testing.T, table string) float64 {
 	return gatherValue(t, "ingestr_stream_table_rows_synced_total", map[string]string{"table": table})
 }
 
+func tableBytesSynced(t *testing.T, table string) float64 {
+	t.Helper()
+	return gatherValue(t, "ingestr_stream_table_bytes_synced_total", map[string]string{"table": table})
+}
+
+func tableLastFlushBytes(t *testing.T, table string) float64 {
+	t.Helper()
+	return gatherValue(t, "ingestr_stream_table_last_flush_bytes", map[string]string{"table": table})
+}
+
 func TestStreaming_FlushRecordsRowsSynced(t *testing.T) {
 	dest := &fakeDestination{}
 	committer := &fakeCommitter{}
+	tableSchema := streamTestSchemaWithLoadTimestamp()
 	loop := newTestLoop(dest, StreamingOptions{
 		FlushInterval: time.Hour,
 		FlushRecords:  100,
 		Strategy:      config.StrategyAppend,
 		Committer:     committer,
-	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchema()}})
+	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: tableSchema}})
 
 	before := rowsSyncedValue(t)
+	beforeBytes := bytesSyncedValue(t)
+	beforeTableBytes := tableBytesSynced(t, "ds.tbl")
+
+	batch := int64RecordBatch(t, "id", []int64{1, 2, 3, 4}, nil)
+	loadColumn, ok := loadTimestampColumn(tableSchema)
+	require.True(t, ok)
+	transformed, err := transformer.NewLoadTimestamp(loadColumn, time.Unix(1000, 0)).Transform(batch)
+	require.NoError(t, err)
+	expectedBytes := recordBatchPayloadBytes(transformed)
+	transformed.Release()
 
 	loop.buffer(source.RecordBatchResult{
-		Batch:       int64RecordBatch(t, "id", []int64{1, 2, 3, 4}, nil),
+		Batch:       batch,
 		CommitToken: 7,
 	})
 	require.NoError(t, loop.flush(context.Background()))
 
 	assert.Equal(t, float64(4), rowsSyncedValue(t)-before)
+	assert.Equal(t, float64(expectedBytes), bytesSyncedValue(t)-beforeBytes)
 	// Single-table loops key l.tables on "", so the metric must fall back to
 	// the destination table name rather than publishing an empty key.
 	assert.Positive(t, tableRowsSynced(t, "ds.tbl"))
+	assert.Equal(t, float64(expectedBytes), tableBytesSynced(t, "ds.tbl")-beforeTableBytes)
+	assert.Equal(t, float64(expectedBytes), tableLastFlushBytes(t, "ds.tbl"))
 	assert.NotZero(t, lastSyncedValue(t))
 }
 
@@ -113,6 +143,7 @@ func TestStreaming_FailedCommitDoesNotRecordRowsSynced(t *testing.T) {
 	}, map[string]*streamTableState{"": {destTable: "ds.tbl", schema: streamTestSchema()}})
 
 	before := rowsSyncedValue(t)
+	beforeBytes := bytesSyncedValue(t)
 	beforeTS := lastSyncedValue(t)
 
 	loop.buffer(source.RecordBatchResult{
@@ -122,5 +153,17 @@ func TestStreaming_FailedCommitDoesNotRecordRowsSynced(t *testing.T) {
 	require.Error(t, loop.flush(context.Background()))
 
 	assert.Equal(t, before, rowsSyncedValue(t), "rows must not be counted when the commit fails")
+	assert.Equal(t, beforeBytes, bytesSyncedValue(t), "bytes must not be counted when the commit fails")
 	assert.Equal(t, beforeTS, lastSyncedValue(t), "last synced must not advance when the commit fails")
+}
+
+func TestRecordBatchPayloadBytesIncludesNestedBuffers(t *testing.T) {
+	batch := intStringRecordBatch(t, "id", []int64{1, 2}, "name", []string{"alpha", "beta"})
+	defer batch.Release()
+
+	assert.Greater(t, recordBatchPayloadBytes(batch), uint64(2*8), "string offsets and values should contribute to payload bytes")
+}
+
+func TestRecordBatchPayloadBytesNilBatch(t *testing.T) {
+	assert.Zero(t, recordBatchPayloadBytes(nil))
 }


### PR DESCRIPTION
## Summary

Adds Prometheus counters for logical Arrow payload bytes processed by streaming ingestion, including total and per-table views plus the latest per-table flush size.

The byte accounting is captured from the transformed record batches handed to destinations and is recorded only after the destination write and source-position commit succeed, matching the durability boundary used by the existing row counters.

## Documentation

Updates the streaming monitoring docs to describe the new byte metrics and clarify that they represent logical Arrow payload bytes rather than source log bytes, network traffic, compressed staging size, warehouse billing bytes, or net table growth.