### PR TITLE
Add Oracle Exadata destination support

### DIFF
--- a/docs/supported-sources/oracle.md
+++ b/docs/supported-sources/oracle.md
@@ -3,6 +3,8 @@ Oracle is a powerful, fully integrated stack of cloud applications and platform 
 
 ingestr supports Oracle as a source and destination through the `oracle+cx_oracle`-compatible URI format. Under the hood, ingestr uses the Go Oracle driver in thin mode, which means **no Oracle Client libraries are required** to be installed on your system.
 
+Oracle Exadata is also supported as a destination. Exadata uses the same Oracle Database protocol and SQL dialect, so it shares Oracle's destination implementation and does not require a separate client library.
+
 ## URI format
 The URI format for Oracle is as follows:
 
@@ -18,6 +20,22 @@ URI parameters:
 - `dbname`: the name of the database
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's Oracle dialect [here](https://docs.sqlalchemy.org/en/20/core/engines.html#oracle).
+
+### Oracle Exadata destination
+
+Use `exadata` when you want to identify the destination explicitly as Exadata:
+
+```plaintext
+exadata://user:password@scan-host:1521/service_name
+```
+
+`oracle+exadata` and `oracle_exadata` are accepted as aliases. Existing `oracle` and `oracle+cx_oracle` destination URIs work with Exadata as well.
+
+Exadata RAC deployments can pass additional listeners with repeated `server` query parameters. TCPS deployments can pass the thin driver's `SSL`, `SSL VERIFY`, `WALLET`, and `WALLET PASSWORD` options. Query parameter names and values must be URL-encoded.
+
+```plaintext
+exadata://user:password@scan1.example.com:1521/analytics?server=scan2.example.com%3A1521&SSL=true&WALLET=%2Fsecure%2Foracle-wallet
+```
 
 ## Destination notes
 

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -317,6 +317,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("elasticsearch", "Elasticsearch", []string{"elasticsearch"}, true, true),
 		genericURIConnector("espn", "ESPN", []string{"espn"}, true, false),
 		genericURIConnector("eventhubs", "Azure Event Hubs", []string{"eventhubs", "eventhub", "azure-event-hubs", "azureeventhubs"}, true, false),
+		genericURIConnector("exadata", "Oracle Exadata", []string{"exadata", "oracle+exadata", "oracle_exadata"}, false, true),
 		genericURIConnector("fabric", "Microsoft Fabric", []string{"fabric"}, true, true),
 		genericURIConnector("facebookads", "Facebook Ads", []string{"facebookads"}, true, false),
 		genericURIConnector("fastspring", "FastSpring", []string{"fastspring"}, true, false),

--- a/internal/server/connectors_test.go
+++ b/internal/server/connectors_test.go
@@ -22,6 +22,23 @@ func TestAzureSQLConnectorMetadata(t *testing.T) {
 	}
 }
 
+func TestOracleExadataConnectorMetadata(t *testing.T) {
+	connector := GetConnectorByID("exadata")
+	if connector == nil {
+		t.Fatal("expected Oracle Exadata connector to be registered")
+	}
+	if connector.IsSource {
+		t.Fatal("Oracle Exadata connector should not be source-capable")
+	}
+	if !connector.IsDestination {
+		t.Fatal("Oracle Exadata connector should be destination-capable")
+	}
+	wantSchemes := []string{"exadata", "oracle+exadata", "oracle_exadata"}
+	if strings.Join(connector.Schemes, ",") != strings.Join(wantSchemes, ",") {
+		t.Fatalf("schemes = %v, want %v", connector.Schemes, wantSchemes)
+	}
+}
+
 func TestBuildAzureSQLURI(t *testing.T) {
 	uri := BuildURI("azuresql", map[string]string{
 		"host":      "myserver.database.windows.net",

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -41,7 +41,7 @@ func NewOracleDestination() *OracleDestination {
 }
 
 func (d *OracleDestination) Schemes() []string {
-	return []string{"oracle", "oracle+cx_oracle"}
+	return []string{"oracle", "oracle+cx_oracle", "exadata", "oracle+exadata", "oracle_exadata"}
 }
 
 func (d *OracleDestination) Connect(ctx context.Context, uri string) error {
@@ -84,8 +84,11 @@ func (d *OracleDestination) Connect(ctx context.Context, uri string) error {
 
 func buildConnStrings(uri string) ([]string, error) {
 	normalized := uri
-	if strings.HasPrefix(strings.ToLower(uri), "oracle+cx_oracle://") {
-		normalized = "oracle://" + uri[len("oracle+cx_oracle://"):]
+	if scheme, rest, ok := strings.Cut(uri, "://"); ok {
+		switch strings.ToLower(scheme) {
+		case "oracle+cx_oracle", "exadata", "oracle+exadata", "oracle_exadata":
+			normalized = "oracle://" + rest
+		}
 	}
 
 	u, err := url.Parse(normalized)

--- a/pkg/destination/oracle/oracle_test.go
+++ b/pkg/destination/oracle/oracle_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/registry"
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/strategy"
@@ -152,6 +153,24 @@ func TestBuildConnStrings(t *testing.T) {
 			},
 		},
 		{
+			name: "Exadata scheme",
+			uri:  "exadata://user:pass@scan.example.com:1521/EXAPDB",
+			want: []string{
+				"oracle://user:pass@scan.example.com:1521/?SID=EXAPDB",
+				"oracle://user:pass@scan.example.com:1521/EXAPDB",
+			},
+		},
+		{
+			name: "Oracle Exadata aliases",
+			uri:  "oracle_exadata://user:pass@scan.example.com:1521/?service_name=EXAPDB",
+			want: []string{"oracle://user:pass@scan.example.com:1521/EXAPDB"},
+		},
+		{
+			name: "Exadata RAC and wallet options",
+			uri:  "oracle+exadata://user:pass@scan1.example.com:1521/?service_name=EXAPDB&server=scan2.example.com%3A1521&SSL=true&WALLET=%2Fsecure%2Fwallet",
+			want: []string{"oracle://user:pass@scan1.example.com:1521/EXAPDB?SSL=true&WALLET=%2Fsecure%2Fwallet&server=scan2.example.com%3A1521"},
+		},
+		{
 			name: "explicit service name",
 			uri:  "oracle://user:pass@host:1521/?service_name=XEPDB1",
 			want: []string{"oracle://user:pass@host:1521/XEPDB1"},
@@ -186,6 +205,25 @@ func TestBuildConnStrings(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestOracleDestinationSchemes(t *testing.T) {
+	dest := NewOracleDestination()
+	assert.ElementsMatch(t, []string{
+		"oracle",
+		"oracle+cx_oracle",
+		"exadata",
+		"oracle+exadata",
+		"oracle_exadata",
+	}, dest.Schemes())
+}
+
+func TestExadataDestinationSchemesAreRegistered(t *testing.T) {
+	for _, scheme := range []string{"exadata", "oracle+exadata", "oracle_exadata"} {
+		constructor, err := registry.Default.GetDestinationConstructor(scheme)
+		require.NoError(t, err)
+		assert.IsType(t, &OracleDestination{}, constructor())
 	}
 }
 

--- a/pkg/destination/oracle/register.go
+++ b/pkg/destination/oracle/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterDestination(
-		[]string{"oracle", "oracle+cx_oracle"},
+		[]string{"oracle", "oracle+cx_oracle", "exadata", "oracle+exadata", "oracle_exadata"},
 		func() interface{} { return NewOracleDestination() },
 	)
 }

--- a/tests/integration/destination_conformance_test.go
+++ b/tests/integration/destination_conformance_test.go
@@ -505,6 +505,42 @@ func TestDestinations_Replace(t *testing.T) {
 	}
 }
 
+func TestDestinations_OracleExadataAlias(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	t.Run("oracle", func(t *testing.T) {
+		if oracleDest.uri == "" {
+			t.Skip("shared oracle destination container not available")
+		}
+
+		_, uriRest, ok := strings.Cut(oracleDest.uri, "://")
+		require.True(t, ok, "Oracle test URI must contain a scheme")
+		exadataURI := "exadata://" + uriRest
+		table := fmt.Sprintf("EXADATA_ALIAS_%s", uniqueSuffix())
+		ctx := t.Context()
+		t.Cleanup(func() {
+			db, err := sql.Open("oracle", oracleSQLConnString(exadataURI))
+			if err == nil {
+				_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE %s PURGE", quoteTableOracle(table)))
+				_ = db.Close()
+			}
+		})
+
+		cfg := &config.IngestConfig{
+			SourceURI:           jsonlURI(t, "testdata/conformance.jsonl"),
+			SourceTable:         "replace_source",
+			DestURI:             exadataURI,
+			DestTable:           table,
+			IncrementalStrategy: config.StrategyReplace,
+		}
+
+		require.NoError(t, pipeline.New(cfg).Run(ctx))
+		validateReplaceSQL(t, oracleBackend(), exadataURI, table)
+	})
+}
+
 func validateAthenaReplace(t *testing.T, destURI, destTable string) {
 	ctx := context.Background()
 	rows := countRowsViaAthenaRead(t, ctx, destURI, destTable)
@@ -1830,8 +1866,11 @@ func normalizeMySQLType(mysqlType string) string {
 
 func oracleSQLConnString(rawURI string) string {
 	normalized := rawURI
-	if strings.HasPrefix(strings.ToLower(normalized), "oracle+cx_oracle://") {
-		normalized = "oracle://" + normalized[len("oracle+cx_oracle://"):]
+	if scheme, rest, ok := strings.Cut(rawURI, "://"); ok {
+		switch strings.ToLower(scheme) {
+		case "oracle+cx_oracle", "exadata", "oracle+exadata", "oracle_exadata":
+			normalized = "oracle://" + rest
+		}
 	}
 
 	u, err := url.Parse(normalized)


### PR DESCRIPTION
## What
Adds Oracle Exadata as an explicit destination while reusing the existing Oracle implementation.

## Changes
- Register `exadata`, `oracle+exadata`, and `oracle_exadata` destination schemes.
- Preserve RAC, TCPS, and wallet connection options during URI normalization.
- Add connector metadata, documentation, unit tests, and Oracle-backed conformance coverage.

## How to test
1. Run `make test`.
2. Run `make lint-full`.
3. Run `make test-conformance-only BACKENDS=oracle`.

## Risk & rollback
- **Risk:** Low; the change adds aliases over the existing Oracle destination path.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (targeted Oracle conformance)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
