### PR TITLE
python: report first binary download

### DIFF
--- a/ingestr/_runner.py
+++ b/ingestr/_runner.py
@@ -294,6 +294,7 @@ def _download_binary(target: Path) -> Path:
     archive_name = _release_archive_name(release)
     url = _release_asset_url(tag, archive_name)
     target.parent.mkdir(parents=True, exist_ok=True)
+    _report_download_start(tag, release)
 
     temp_dir = Path(tempfile.mkdtemp(prefix="ingestr-download-", dir=str(target.parent)))
     try:
@@ -323,6 +324,24 @@ def _download_file(url: str, destination: Path) -> None:
     with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
         with destination.open("wb") as output:
             shutil.copyfileobj(response, output)
+
+
+def _report_download_start(tag: str, release: _ReleasePlatform) -> None:
+    stream = sys.stderr
+    if stream is None:
+        return
+
+    try:
+        message = (
+            "ingestr: downloading CLI binary %s for %s/%s from GitHub; "
+            "this happens once per version and may take a moment\n"
+        )
+        stream.write(
+            message % (tag, release.os_name, release.arch)
+        )
+        stream.flush()
+    except (OSError, ValueError):
+        pass
 
 
 def _verify_archive_checksum(archive_path: Path, tag: str, archive_name: str) -> None:

--- a/tests/python/test_ingestr_package.py
+++ b/tests/python/test_ingestr_package.py
@@ -226,6 +226,37 @@ class IngestrPackageTest(unittest.TestCase):
                 ["https://github.com/bruin-data/ingestr/releases/download/v1.2.3/ingestr_Linux_x86_64.tar.gz"],
             )
 
+    def test_binary_path_reports_first_download_to_stderr(self):
+        binary = b"#!/bin/sh\necho ingestr\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive_path = root / "ingestr_Linux_x86_64.tar.gz"
+            _write_tar_binary(archive_path, "ingestr", binary)
+
+            def fake_download(url, destination):
+                destination.write_bytes(archive_path.read_bytes())
+
+            release = ingestr_runner._ReleasePlatform("Linux", "x86_64", "tar.gz", "ingestr")
+            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            checksums = {"v1.2.3": {"ingestr_Linux_x86_64.tar.gz": checksum}}
+            stderr = io.StringIO()
+            with patch.dict(os.environ, {"INGESTR_BINARY_CACHE_DIR": str(root / "cache")}, clear=True):
+                with patch("ingestr._runner._local_binary_path", return_value=None):
+                    with patch("ingestr._runner._package_version", return_value="1.2.3"):
+                        with patch("ingestr._runner._release_platform", return_value=release):
+                            with patch.dict(ingestr_runner.ARCHIVE_SHA256, checksums, clear=True):
+                                with patch("ingestr._runner._download_file", side_effect=fake_download):
+                                    with patch("sys.stderr", stderr):
+                                        ingestr.binary_path()
+                                        ingestr.binary_path()
+
+            self.assertEqual(
+                stderr.getvalue(),
+                "ingestr: downloading CLI binary v1.2.3 for Linux/x86_64 from GitHub; "
+                "this happens once per version and may take a moment\n",
+            )
+
     def test_binary_path_uses_tag_specific_checksum_for_tag_override(self):
         binary = b"#!/bin/sh\necho ingestr\n"
 


### PR DESCRIPTION
## Summary

- Print a one-line stderr notice before the Python wrapper downloads the GitHub release binary on first use.
- Keep cached, local, and explicit binary paths quiet by only reporting from the download path.
- Add Python package coverage for the first-download-only message behavior.

## Why

The pip wrapper can spend noticeable time downloading the CLI binary during the first run. Reporting that state prevents the command from looking hung while preserving stdout for command output.
