### PR TITLE
fix(delete+insert): correct timezone/DATE handling of delete-window bounds

### DIFF
--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -932,6 +932,12 @@ func (d *ClickHouseDestination) buildDeleteInsertStatements(opts destination.Del
 }
 
 func formatClickHouseLiteral(value interface{}, dataType schema.DataType) string {
+	if p, ok := value.(*time.Time); ok {
+		if p == nil {
+			return "NULL"
+		}
+		value = *p
+	}
 	switch v := value.(type) {
 	case time.Time:
 		switch dataType {

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -193,6 +193,10 @@ func (d *DuckDBDestination) Connect(ctx context.Context, uri string) error {
 		_ = opt.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueEnabled)
 	}
 
+	// Pin the session to UTC so bound timestamps aren't reinterpreted in the
+	// process-local timezone against TIMESTAMPTZ columns (BRU-5581).
+	_ = d.exec(ctx, "SET TimeZone='UTC'")
+
 	if limit := os.Getenv("INGESTR_DUCKDB_MEMORY_LIMIT"); limit != "" {
 		if strings.ContainsAny(limit, "';\n") {
 			config.Debug("[DUCKDB] Ignoring invalid INGESTR_DUCKDB_MEMORY_LIMIT=%q", limit)

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -195,7 +195,9 @@ func (d *DuckDBDestination) Connect(ctx context.Context, uri string) error {
 
 	// Pin the session to UTC so bound timestamps aren't reinterpreted in the
 	// process-local timezone against TIMESTAMPTZ columns (BRU-5581).
-	_ = d.exec(ctx, "SET TimeZone='UTC'")
+	if err := d.exec(ctx, "SET TimeZone='UTC'"); err != nil {
+		return fmt.Errorf("failed to set DuckDB session timezone to UTC: %w", err)
+	}
 
 	if limit := os.Getenv("INGESTR_DUCKDB_MEMORY_LIMIT"); limit != "" {
 		if strings.ContainsAny(limit, "';\n") {

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -715,8 +715,8 @@ func (d *SnowflakeDestination) DeleteInsertTable(ctx context.Context, opts desti
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	startVal := formatSnowflakeValue(opts.IntervalStart)
-	endVal := formatSnowflakeValue(opts.IntervalEnd)
+	startVal := formatSnowflakeValue(opts.IntervalStart, opts.IncrementalKeyType)
+	endVal := formatSnowflakeValue(opts.IntervalEnd, opts.IncrementalKeyType)
 
 	deleteSQL := fmt.Sprintf(
 		"DELETE FROM %s WHERE %s >= %s AND %s <= %s",
@@ -1461,13 +1461,18 @@ func buildCreateTableSQL(table string, columns []schema.Column, primaryKeys []st
 	return sql
 }
 
-func formatSnowflakeValue(v interface{}) string {
+func formatSnowflakeValue(v interface{}, keyType schema.DataType) string {
+	if p, ok := v.(*time.Time); ok {
+		if p == nil {
+			return "NULL"
+		}
+		v = *p
+	}
 	switch val := v.(type) {
 	case time.Time:
-		return fmt.Sprintf("TO_TIMESTAMP('%s')", val.Format("2006-01-02 15:04:05.000000"))
-	case *time.Time:
-		if val == nil {
-			return "NULL"
+		// Anchor TZ-aware bounds to UTC so the session TIMEZONE can't shift the window (BRU-5586).
+		if keyType == schema.TypeTimestampTZ {
+			return fmt.Sprintf("TO_TIMESTAMP_TZ('%s +0000')", val.UTC().Format("2006-01-02 15:04:05.000000"))
 		}
 		return fmt.Sprintf("TO_TIMESTAMP('%s')", val.Format("2006-01-02 15:04:05.000000"))
 	case string:

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -76,10 +76,11 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 
 	sourceIncrementalKey := sourceIncrementalKeyForRead(job)
 	destinationIncrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
-	// Prefer the stable source type: the reconciled job.Schema can inherit the destination's
-	// storage type (e.g. SQLite stores DATE as TEXT), flipping the key type on re-runs.
-	if job.SourceSchema != nil {
-		if _, srcType := resolveSchemaColumn(job.SourceSchema, job.Config.IncrementalKey); srcType != schema.TypeUnknown {
+	// When the reconciled type came back degraded (e.g. SQLite stores DATE as TEXT, so the
+	// key type flips to string on re-runs), recover the real temporal type from the source
+	// schema so date-only bound conversion still fires.
+	if job.SourceSchema != nil && (incrementalKeyType == schema.TypeString || incrementalKeyType == schema.TypeUnknown) {
+		if _, srcType := resolveSchemaColumn(job.SourceSchema, job.Config.IncrementalKey); srcType == schema.TypeDate || srcType == schema.TypeTimestamp || srcType == schema.TypeTimestampTZ {
 			incrementalKeyType = srcType
 		}
 	}

--- a/pkg/strategy/delete_insert.go
+++ b/pkg/strategy/delete_insert.go
@@ -76,6 +76,13 @@ func (s *DeleteInsertStrategy) Execute(ctx context.Context, job *IngestionJob) e
 
 	sourceIncrementalKey := sourceIncrementalKeyForRead(job)
 	destinationIncrementalKey, incrementalKeyType := resolveSchemaColumn(job.Schema, job.Config.IncrementalKey)
+	// Prefer the stable source type: the reconciled job.Schema can inherit the destination's
+	// storage type (e.g. SQLite stores DATE as TEXT), flipping the key type on re-runs.
+	if job.SourceSchema != nil {
+		if _, srcType := resolveSchemaColumn(job.SourceSchema, job.Config.IncrementalKey); srcType != schema.TypeUnknown {
+			incrementalKeyType = srcType
+		}
+	}
 
 	readOpts := source.ReadOptions{
 		IncrementalKey:                  sourceIncrementalKey,


### PR DESCRIPTION
## Summary

`delete+insert` computes its delete window correctly in UTC, but several destinations reinterpreted the bounds and deleted the **wrong range** — so edge rows were never deleted and got re-inserted on every run (silent duplicates), or the delete failed outright. Fixes [BRU-5581](https://linear.app/bruin/issue/BRU-5581).

Each fix is scoped to the delete+insert bound handling (except the DuckDB one, which is a connection-level UTC pin).

## Changes

| Destination | Fix |
|---|---|
| **DuckDB** | Pin the session to UTC on connect (`SET TimeZone='UTC'`) so bound timestamps aren't reinterpreted in the process-local timezone against `TIMESTAMPTZ` columns. This was the original BRU-5581 bug. |
| **Snowflake** | Emit a UTC-anchored `TO_TIMESTAMP_TZ('… +0000')` for timezone-aware keys, so the **server** session `TIMEZONE` (default `America/Los_Angeles`) can't shift the window. Unlike DuckDB, this one affects **production**, not just local dev. Naive `TIMESTAMP`/`DATE` paths unchanged. |
| **ClickHouse** | Handle `*time.Time` bounds — previously fell through to an unquoted literal → SQL syntax error on any timestamp incremental key. |
| **strategy** (`delete_insert.go`) | Resolve the incremental-key **type** from the stable `SourceSchema`. The reconciled `job.Schema` can inherit the destination's storage type (e.g. SQLite stores `DATE` as `TEXT`), flipping the key type on re-runs and skipping date-only bound conversion → silent duplicates on `DATE` keys. Benefits every param-binding destination. |

## Verification

- **Destination conformance** (`TestDestinations_*`, incl. `DeleteInsert` + `DeleteInsert_DedupesStagingByPK`): PASS for duckdb, sqlite, postgres, mysql, mssql, oracle, **snowflake** (19/19), **bigquery**, **clickhouse**. No regressions.
- **Direct per-key-type matrices** under non-UTC `TZ` (`Europe/Istanbul`, `America/New_York`, `Asia/Kolkata`) across `TIMESTAMPTZ`/naive `TIMESTAMP`/`DATE` — idempotent + correct delete window (marker-row tests).
- Unit tests `./pkg/...` and `gofmt` clean.