### PR TITLE
Fix flaky mysql-cdc-stress-test on late-table race

### DIFF
--- a/tests/integration/mysql_cdc_stress_test.go
+++ b/tests/integration/mysql_cdc_stress_test.go
@@ -766,7 +766,8 @@ func TestMySQLCDC_StressComplexWorkload(t *testing.T) {
 			start := time.Now()
 			results := runCDCStressPipelines(ctx, pipelines)
 			for i, result := range results {
-				if result.err != nil {
+				// A late table racing in mid-run is an expected transient; the source asks us to retry.
+				if result.err != nil && !strings.Contains(result.err.Error(), "retry so it can be prepared safely") {
 					runnerErr <- fmt.Errorf("%s: %w", pipelines[i].name, result.err)
 					return
 				}


### PR DESCRIPTION
## Problem

`mysql-cdc-stress-test` intermittently fails on the **first** CI attempt and passes on re-run. Confirmed across multiple runs (31093539564, 31156771739, 30913364935), always the same error:

```
mysql_cdc_stress_test.go:795: catch-up run failed during load phase:
  MySQL table mstress_03 appeared after CDC table discovery and before snapshots began;
  retry so it can be prepared safely
--- FAIL: TestMySQLCDC_StressComplexWorkload
```

## Root cause

The stress load phase **deliberately** creates "late tables" concurrently while the back-to-back catch-up runner streams multi-table CDC. When a late table lands in the window between the source's CDC table discovery and snapshot start, `pkg/source/mysql/cdc.go` returns an **intentional, retryable** error ("retry so it can be prepared safely"). The catch-up runner treated any error as fatal (`t.Fatalf`), so a normal timing window flaked the job. On re-run the window usually doesn't line up, hence the pass-on-retry signature.

## Fix

Skip that specific transient in the catch-up runner; the loop retries on its next iteration. Test-only, one guard condition. `go vet -tags stress ./tests/integration/` passes.