### PR TITLE
feat(clevertap): add CleverTap source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -202,6 +202,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Bruin", link: "/supported-sources/bruin.md" },
               { text: "Chargebee", link: "/supported-sources/chargebee.md" },
               { text: "Chess.com", link: "/supported-sources/chess.md" },
+              { text: "CleverTap", link: "/supported-sources/clevertap.md" },
               { text: "ClickUp", link: "/supported-sources/clickup.md" },
               { text: "Cursor", link: "/supported-sources/cursor.md" },
               { text: "Docebo", link: "/supported-sources/docebo.md" },

--- a/docs/supported-sources/clevertap.md
+++ b/docs/supported-sources/clevertap.md
@@ -72,8 +72,10 @@ Leave the parameter out and you get everything:
 
 ```sh
 --source-table "events"     # every event, in one table
---source-table "profiles"   # your whole user base
+--source-table "profiles"   # everyone who has done anything
 ```
+
+CleverTap reaches profiles through their activity, so `profiles` covers users who have raised at least one exportable event. Anyone whose only recorded activity is a notification event, which CleverTap will not export, is not included.
 
 ## Joining events to profiles
 

--- a/docs/supported-sources/clevertap.md
+++ b/docs/supported-sources/clevertap.md
@@ -1,0 +1,127 @@
+# CleverTap
+[CleverTap](https://clevertap.com/) is a customer engagement and retention platform that combines analytics, segmentation, and cross-channel campaigns for mobile and web apps.
+
+ingestr supports CleverTap as a source.
+
+## URI format
+
+```
+clevertap://?account_id=<account_id>&passcode=<passcode>&region=<region>&timezone=<timezone>
+```
+
+URI parameters:
+- `account_id`: the CleverTap Account ID for your project.
+- `passcode`: the Account Passcode, or your user passcode if your admin has enabled user-level passcodes.
+- `region`: optional, the data centre your account lives in. One of `eu1`, `in1`, `us1`, `sg1`, `aps3`, `mec1`. Defaults to `eu1`. European projects appear as `global` in the dashboard, and that value works too.
+- `timezone`: optional, the timezone your CleverTap project is set to, as an IANA name such as `Asia/Kolkata`. Defaults to `UTC`. **Set this to match your project**, otherwise every event time is shifted by the difference.
+
+Find all four in the CleverTap dashboard under **Settings → Project**. Your region is also the subdomain of your dashboard URL, so `in1.dashboard.clevertap.com` means `region=in1`.
+
+Here's a sample command that copies your user profiles into a DuckDB database:
+
+```sh
+ingestr ingest \
+  --source-uri "clevertap://?account_id=TEST-ABC-123&passcode=pass_123&region=eu1" \
+  --source-table "profiles" \
+  --dest-uri duckdb:///clevertap.duckdb \
+  --dest-table "public.profiles"
+```
+
+## Tables
+
+CleverTap source allows ingesting the following resources into separate tables:
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| ----- | -- | ------- | ------------ | ------- |
+| [events](https://developer.clevertap.com/docs/get-events-api) | – | ts | delete+insert | Individual occurrences of an event, with who raised it and the event's properties |
+| [profiles](https://developer.clevertap.com/docs/get-user-profiles-api) | object_id | – | replace | Your users, with their custom properties, activity summaries, and devices |
+| [campaigns](https://developer.clevertap.com/docs/get-campaigns-api) | id | – | replace | Campaigns created **through the API**, with their name, schedule, and status |
+| [campaign_reports](https://developer.clevertap.com/docs/get-campaign-report-api) | id | – | replace | Delivery and engagement metrics for each completed campaign created **through the API** |
+| [content_blocks](https://developer.clevertap.com/docs/get-content-block-list-api) | id | updatedAt | merge | Reusable content blocks, with their type, content, and authorship |
+| [message_reports](https://developer.clevertap.com/docs/get-message-reports-api) | message_id | – | replace | Per-message delivery and engagement counts |
+| [event_schema](https://developer.clevertap.com/docs/get-schema) | name | – | replace | Every event defined in your project, with its properties |
+| [user_properties](https://developer.clevertap.com/docs/get-schema) | name | – | replace | Every custom profile property defined in your project |
+| [category_groups](https://developer.clevertap.com/docs/settings-api-endpoints) | key | – | replace | Messaging subscription groups, with the channels each one covers |
+
+Use these as the `--source-table` parameter in the `ingestr ingest` command.
+
+> [!WARNING]
+> `campaigns` and `campaign_reports` only ever contain campaigns **created through the CleverTap API**. Campaigns you build in the dashboard are not included.
+
+### Choosing which events to load
+
+`events` and `profiles` accept an `event_name` parameter, which narrows them to a single event:
+
+```sh
+ingestr ingest \
+  --source-uri "clevertap://?account_id=TEST-ABC-123&passcode=pass_123" \
+  --source-table "events?event_name=App Launched" \
+  --dest-uri duckdb:///clevertap.duckdb \
+  --dest-table "public.app_launched"
+```
+
+The name must match your CleverTap dashboard exactly, including spaces and capitalisation. It is also included as a column, so several events can share one destination table.
+
+Separate names with a comma to load more than one:
+
+```sh
+--source-table "events?event_name=Charged,App Launched"
+```
+
+Leave the parameter out and you get everything:
+
+```sh
+--source-table "events"     # every event, in one table
+--source-table "profiles"   # your whole user base
+```
+
+## Joining events to profiles
+
+`events` carries two keys:
+
+| Column | Identifies | Use it for |
+| ------ | ---------- | ---------- |
+| `identity` | the person | joining to `profiles` |
+| `object_id` | one device | per-device analysis |
+
+```sql
+SELECT e.ts, e.event_name, p.name, p.profile_data
+FROM events e
+JOIN profiles p ON e.identity = p.identity
+```
+
+**Join on `identity`.** Someone using your app on both a phone and a laptop has a different `object_id` for each, so joining on `object_id` silently drops the events they raised on their other devices. Every device is still listed in `profiles.platform_info`.
+
+`identity` is only set for users who have logged in, so events from anonymous visitors have no profile to join to.
+
+## Date ranges
+
+`events` and `content_blocks` respect `--interval-start` and `--interval-end`:
+
+```sh
+ingestr ingest \
+  --source-uri "clevertap://?account_id=TEST-ABC-123&passcode=pass_123" \
+  --source-table "events?event_name=Charged" \
+  --dest-uri duckdb:///clevertap.duckdb \
+  --dest-table "public.charged" \
+  --interval-start 2024-01-01 \
+  --interval-end 2024-04-01
+```
+
+The end bound is exclusive of that day's activity, so use the following day to capture a full day. With no interval at all, everything is loaded.
+
+The other tables always load in full and ignore the interval.
+
+## Limitations
+
+> [!WARNING]
+> As noted above, `campaigns` and `campaign_reports` cover only API-created campaigns. Dashboard campaigns never appear whatever their channel or schedule, because CleverTap offers no way to list them.
+
+> [!NOTE]
+> The `profile` column on `events` shows the user's details as they stand today, not as they were when the event happened. CleverTap keeps no history of past values, so point-in-time user attributes are not available from this source.
+
+> [!NOTE]
+> A campaign only has a report once it has completed and delivered. Campaigns that are still scheduled, running, paused, or were stopped before delivering are skipped, so `campaign_reports` usually holds fewer rows than `campaigns`.
+
+> [!NOTE]
+> Notification events such as push impressions and clicks cannot be exported from CleverTap and are skipped automatically.

--- a/docs/supported-sources/clevertap.md
+++ b/docs/supported-sources/clevertap.md
@@ -50,7 +50,7 @@ Use these as the `--source-table` parameter in the `ingestr ingest` command.
 
 ### Choosing which events to load
 
-`events` and `profiles` accept an `event_name` parameter, which narrows them to a single event:
+`events` and `profiles` accept an `event_name` parameter, which narrows them to the events you name:
 
 ```sh
 ingestr ingest \
@@ -60,7 +60,7 @@ ingestr ingest \
   --dest-table "public.app_launched"
 ```
 
-The name must match your CleverTap dashboard exactly, including spaces and capitalisation. It is also included as a column, so several events can share one destination table.
+Each name must match your CleverTap dashboard exactly, including spaces and capitalisation. The name is also included as a column, so several events can share one destination table.
 
 Separate names with a comma to load more than one:
 

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -301,6 +301,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("bruin", "Bruin", []string{"bruin"}, true, false),
 		genericURIConnector("chargebee", "Chargebee", []string{"chargebee"}, true, false),
 		genericURIConnector("chess", "Chess.com", []string{"chess"}, true, false),
+		genericURIConnector("clevertap", "CleverTap", []string{"clevertap"}, true, false),
 		genericURIConnector("clickhouse", "ClickHouse", []string{"clickhouse"}, true, true),
 		genericURIConnector("clickup", "ClickUp", []string{"clickup"}, true, false),
 		genericURIConnector("couchbase", "Couchbase", []string{"couchbase"}, true, false),

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -773,6 +773,11 @@ func (s *CleverTapSource) fanOutByEvent(ctx context.Context, names []string, fn 
 		select {
 		case nameCh <- name:
 		case <-ctx.Done():
+			// A worker failed; stop queueing instead of spinning through the rest.
+			close(nameCh)
+			wg.Wait()
+			close(errs)
+			return <-errs
 		}
 	}
 	close(nameCh)
@@ -1073,6 +1078,11 @@ func (s *CleverTapSource) readCampaignReports(ctx context.Context, opts source.R
 		select {
 		case idCh <- id:
 		case <-ctx.Done():
+			// A worker failed; stop queueing instead of spinning through the rest.
+			close(idCh)
+			wg.Wait()
+			close(errs)
+			return <-errs
 		}
 	}
 	close(idCh)

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -339,6 +339,15 @@ func dateRange(opts source.ReadOptions, loc *time.Location) (int, int) {
 	return yyyymmdd(from.In(loc)), yyyymmdd(to.In(loc))
 }
 
+// nowIn is today in the project's timezone, which is the day CleverTap's
+// date filters are measured against.
+func nowIn(loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	return time.Now().In(loc)
+}
+
 func yyyymmdd(t time.Time) int {
 	n, _ := strconv.Atoi(t.Format("20060102"))
 	return n
@@ -428,9 +437,10 @@ func (s *CleverTapSource) cursorExport(
 		default:
 		}
 
+		// Stopping here would truncate silently, and delete+insert would commit the
+		// short result over the full window.
 		if pages >= maxPages {
-			config.Debug("[CLEVERTAP] %s hit the %d page cap, stopping", endpoint, maxPages)
-			break
+			return fmt.Errorf("%s exceeded the %d page cap; narrow the interval", endpoint, maxPages)
 		}
 
 		var page struct {
@@ -799,7 +809,7 @@ func (s *CleverTapSource) readProfiles(ctx context.Context, eventName string, op
 
 	// Interval ignored: profiles are selected by event activity, not by when the
 	// profile changed, so only a full sweep is complete.
-	from, to := yyyymmdd(defaultStartDate), yyyymmdd(time.Now().UTC())
+	from, to := yyyymmdd(defaultStartDate), yyyymmdd(nowIn(s.timezone))
 	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
 	query := map[string]string{
 		"batch_size": strconv.Itoa(maxPageSize),
@@ -898,7 +908,7 @@ func (s *CleverTapSource) readContentBlocks(ctx context.Context, opts source.Rea
 			break
 		}
 		if page == maxPages {
-			config.Debug("[CLEVERTAP] content_blocks hit the %d page cap, stopping", maxPages)
+			return fmt.Errorf("content blocks exceeded the %d page cap; narrow the interval", maxPages)
 		}
 	}
 
@@ -910,7 +920,7 @@ func (s *CleverTapSource) readMessageReports(ctx context.Context, opts source.Re
 
 	// Interval ignored: from/to select on send date while counts keep rising after
 	// it. The optional filters are omitted so every channel and status is covered.
-	from, to := yyyymmdd(defaultStartDate), yyyymmdd(time.Now().UTC())
+	from, to := yyyymmdd(defaultStartDate), yyyymmdd(nowIn(s.timezone))
 	resp, err := s.client.R(ctx).
 		SetBody(map[string]interface{}{"from": from, "to": to}).
 		Post("/1/message/report.json")
@@ -970,7 +980,7 @@ func (s *CleverTapSource) fetchCampaigns(ctx context.Context, opts source.ReadOp
 	start := defaultStartDate
 	// Campaigns are selected by their scheduled date, which for a pending campaign
 	// is in the future, so the sweep has to run past today to see them at all.
-	end := time.Now().UTC().AddDate(0, campaignFutureMonths, 0)
+	end := nowIn(s.timezone).AddDate(0, campaignFutureMonths, 0)
 
 	for windowStart := start; !windowStart.After(end); windowStart = windowStart.AddDate(0, 0, campaignWindowDays) {
 		select {

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -548,32 +548,25 @@ func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts
 		}
 		if ts, ok := parseEventTimestamp(item["ts"], s.timezone); ok {
 			item["ts"] = ts
+		} else {
+			// Keep the record with a null ts rather than dropping it; a raw value
+			// would clash with the timestamp column.
+			item["ts"] = nil
 		}
 		return item
 	}
 
 	// The API filters by whole days but delete+insert removes an exact instant
 	// range, so trim the day padding or the edges duplicate on every run.
-	var undated int64
 	keep := func(item map[string]interface{}) bool {
-		// A record whose ts did not parse cannot be placed in the delete window, so
-		// keeping it would insert a duplicate on every run.
-		if _, ok := item["ts"].(time.Time); !ok {
-			undated++
-			return false
-		}
 		return withinInterval(item["ts"], opts.IntervalStart, opts.IntervalEnd)
 	}
 
-	err := s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
-	if undated > 0 {
-		output.Warnf("Warning: clevertap dropped %d %q record(s) with an unreadable timestamp\n", undated, eventName)
-	}
-	return err
+	return s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
 }
 
 // withinInterval reports whether a converted timestamp is inside the bounds. Both
-// ends are inclusive to match the delete predicate; unconverted values are kept.
+// ends are inclusive to match the delete predicate; a null ts is kept.
 func withinInterval(v interface{}, start, end *time.Time) bool {
 	ts, ok := v.(time.Time)
 	if !ok {

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -63,9 +63,8 @@ var supportedTables = []string{
 // events, which are only available through its S3/GCP exports).
 var errExportNotAllowed = errors.New("export not allowed for this event")
 
-// validRegions maps a region code to its API host prefix. Europe is served from
-// the unprefixed host, and the dashboard labels that project "global", so both
-// spellings are accepted for it.
+// validRegions maps a region code to its API host prefix. Europe uses the
+// unprefixed host and the dashboard labels it "global", so both are accepted.
 var validRegions = map[string]string{
 	"eu1":    "",
 	"global": "",
@@ -76,9 +75,8 @@ var validRegions = map[string]string{
 	"mec1":   "mec1",
 }
 
-// defaultStartDate bounds the export when no interval is supplied; the CleverTap
-// export endpoints require an explicit from/to range. CleverTap was founded in
-// 2013, so no project can hold data from before then and nothing is cut off.
+// defaultStartDate bounds the export when no interval is supplied. CleverTap was
+// founded in 2013, so nothing can predate it.
 var defaultStartDate = time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC)
 
 type CleverTapSource struct {
@@ -229,22 +227,17 @@ func (s *CleverTapSource) GetTable(ctx context.Context, req source.TableRequest)
 	switch table {
 	case "events":
 		// Event records carry no unique id, so merge is impossible; delete+insert
-		// rewrites the loaded window instead, which also refreshes the profile
-		// snapshot each record embeds.
+		// rewrites the loaded window instead.
 		incrementalKey = "ts"
 		strategy = config.StrategyDeleteInsert
 	case "profiles":
-		// CleverTap exposes no way to detect profile edits or deletions, so the
-		// table is rebuilt from a full sweep rather than accumulated; merging
-		// would leave deleted users and dormant edits behind forever.
+		// No way to detect profile edits or deletions, so each run rebuilds rather
+		// than accumulating stale rows.
 		primaryKeys = []string{"object_id"}
 		strategy = config.StrategyReplace
 	case "campaigns", "campaign_reports":
-		// The endpoint filters on a campaign's scheduled date, which says nothing
-		// about when it last changed: a campaign's status moves through running to
-		// completed long after that date, and its report only exists once it has
-		// finished. A narrow window would freeze both, so each run rebuilds from a
-		// full sweep.
+		// scheduled_on says nothing about when a campaign last changed, so a
+		// windowed load would freeze its status; each run rebuilds in full.
 		primaryKeys = []string{"id"}
 		strategy = config.StrategyReplace
 	case "content_blocks":
@@ -329,18 +322,21 @@ func jsonUseNumber(data []byte, v any) error {
 	return dec.Decode(v)
 }
 
-// dateRange converts the ingestion interval into the inclusive YYYYMMDD bounds the
-// CleverTap export endpoints require.
-func dateRange(opts source.ReadOptions) (int, int) {
+// dateRange converts the interval into inclusive YYYYMMDD bounds. Resolved in loc
+// because CleverTap's days are project-local; UTC dates would skip a boundary day.
+func dateRange(opts source.ReadOptions, loc *time.Location) (int, int) {
+	if loc == nil {
+		loc = time.UTC
+	}
 	from := defaultStartDate
-	to := time.Now().UTC()
+	to := time.Now()
 	if opts.IntervalStart != nil {
-		from = opts.IntervalStart.UTC()
+		from = *opts.IntervalStart
 	}
 	if opts.IntervalEnd != nil {
-		to = opts.IntervalEnd.UTC()
+		to = *opts.IntervalEnd
 	}
-	return yyyymmdd(from), yyyymmdd(to)
+	return yyyymmdd(from.In(loc)), yyyymmdd(to.In(loc))
 }
 
 func yyyymmdd(t time.Time) int {
@@ -525,11 +521,10 @@ func decodeCursor(cursor string) string {
 func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[CLEVERTAP] reading events for %q", eventName)
 
-	from, to := dateRange(opts)
+	from, to := dateRange(opts, s.timezone)
 	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
-	// The profile enrichments are all off: they would copy profile_data, the
-	// device list and the lifetime activity summary onto every event row, and the
-	// profiles table already holds those. objectId is returned either way.
+	// Enrichments off: they would copy onto every row what profiles already holds.
+	// objectId and identity are returned either way.
 	query := map[string]string{
 		"batch_size": strconv.Itoa(maxPageSize),
 		"app":        "false",
@@ -542,9 +537,8 @@ func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts
 		// events would be indistinguishable in one table.
 		item["event_name"] = eventName
 		if profile, ok := item["profile"].(map[string]interface{}); ok {
-			// object_id identifies the device, so it only joins to the one device
-			// profiles happens to key on. identity is the person and joins reliably;
-			// it is empty for users who never logged in.
+			// object_id is per-device so it under-joins; identity is per-person and
+			// is the reliable key, though empty for users who never logged in.
 			if id, ok := profile["objectId"].(string); ok {
 				item["object_id"] = id
 			}
@@ -558,9 +552,8 @@ func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts
 		return item
 	}
 
-	// CleverTap filters by whole days, but delete+insert removes exactly the
-	// requested instant range, so anything outside it would be re-inserted every
-	// run without ever being deleted. Trim the day padding to keep runs idempotent.
+	// The API filters by whole days but delete+insert removes an exact instant
+	// range, so trim the day padding or the edges duplicate on every run.
 	keep := func(item map[string]interface{}) bool {
 		return withinInterval(item["ts"], opts.IntervalStart, opts.IntervalEnd)
 	}
@@ -568,9 +561,8 @@ func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts
 	return s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
 }
 
-// withinInterval reports whether an already-converted event timestamp falls inside the
-// requested bounds. Both ends are inclusive to match the delete+insert delete predicate.
-// A value that is absent or was never converted is kept rather than silently dropped.
+// withinInterval reports whether a converted timestamp is inside the bounds. Both
+// ends are inclusive to match the delete predicate; unconverted values are kept.
 func withinInterval(v interface{}, start, end *time.Time) bool {
 	ts, ok := v.(time.Time)
 	if !ok {
@@ -585,9 +577,8 @@ func withinInterval(v interface{}, start, end *time.Time) bool {
 	return true
 }
 
-// parseEventTimestamp turns CleverTap's 14-digit yyyyMMddHHmmss event timestamp into
-// a real instant. It is reported in the project's timezone, so loc supplies the offset;
-// an unparseable value is left untouched rather than dropped.
+// parseEventTimestamp turns the 14-digit yyyyMMddHHmmss timestamp into an instant.
+// It is project-local, so loc supplies the offset.
 func parseEventTimestamp(v interface{}, loc *time.Location) (time.Time, bool) {
 	if loc == nil {
 		loc = time.UTC
@@ -701,9 +692,7 @@ func (s *CleverTapSource) readCategoryGroups(ctx context.Context, opts source.Re
 }
 
 // fetchEventNames lists every event name in the project. Nothing is filtered out:
-// eventCount only covers the current and previous month and reads zero for events
-// that hold data, and a Discarded event has merely stopped collecting new data
-// while keeping its history. The export call decides what is actually available.
+// eventCount is unreliable and Discarded events keep their history.
 func (s *CleverTapSource) fetchEventNames(ctx context.Context) ([]string, error) {
 	resp, err := s.client.R(ctx).SetQueryParam("type", "events").Get("/getSchema")
 	if err != nil {
@@ -736,9 +725,8 @@ func (s *CleverTapSource) fetchEventNames(ctx context.Context) ([]string, error)
 	return names, nil
 }
 
-// fanOutByEvent runs fn once per event name, a few at a time. An empty names list
-// means every event defined in the project. Events CleverTap refuses to export are
-// skipped rather than failing the whole table.
+// fanOutByEvent runs fn per event name, a few at a time; an empty list means every
+// event in the project. Events CleverTap refuses to export are skipped.
 func (s *CleverTapSource) fanOutByEvent(ctx context.Context, names []string, fn func(context.Context, string) error) error {
 	if len(names) == 0 {
 		discovered, err := s.fetchEventNames(ctx)
@@ -795,16 +783,13 @@ func (s *CleverTapSource) fanOutByEvent(ctx context.Context, names []string, fn 
 	return <-errs
 }
 
-// readProfiles fetches the users who raised one event. Sweeping several events
-// returns the same person once per event they fired; replace de-duplicates them
-// on object_id.
+// readProfiles fetches the users who raised one event. Sweeping several returns a
+// person once per event they fired; replace de-duplicates on object_id.
 func (s *CleverTapSource) readProfiles(ctx context.Context, eventName string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[CLEVERTAP] reading profiles for %q", eventName)
 
-	// The interval is deliberately ignored. CleverTap selects profiles by event
-	// activity, not by when the profile changed, so a narrow window would drop
-	// users who were merely dormant while still returning current attributes for
-	// everyone else. Only a full sweep gives a complete, consistent snapshot.
+	// Interval ignored: profiles are selected by event activity, not by when the
+	// profile changed, so only a full sweep is complete.
 	from, to := yyyymmdd(defaultStartDate), yyyymmdd(time.Now().UTC())
 	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
 	query := map[string]string{
@@ -914,14 +899,8 @@ func (s *CleverTapSource) readContentBlocks(ctx context.Context, opts source.Rea
 func (s *CleverTapSource) readMessageReports(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[CLEVERTAP] reading message_reports")
 
-	// The interval is ignored for the same reason as campaigns: from/to select on
-	// when a message was sent, while its delivery and engagement counts keep rising
-	// for days afterwards, so a narrow window would freeze stale counts.
-	//
-	// Only from/to are sent. Omitting channel, delivery, status, message_type and
-	// label applies no filter on any of them, so every channel and status is
-	// covered. daily is left at its false default, which keeps one aggregated
-	// entry per message and so one row per message_id.
+	// Interval ignored: from/to select on send date while counts keep rising after
+	// it. The optional filters are omitted so every channel and status is covered.
 	from, to := yyyymmdd(defaultStartDate), yyyymmdd(time.Now().UTC())
 	resp, err := s.client.R(ctx).
 		SetBody(map[string]interface{}{"from": from, "to": to}).
@@ -976,10 +955,8 @@ func liftMessageID(item map[string]interface{}) map[string]interface{} {
 	return item
 }
 
-// fetchCampaigns walks the full history in 31-day windows and invokes fn once per
-// window. The interval is deliberately ignored: the endpoint selects on a campaign's
-// scheduled date, so a narrow window would miss status changes and late-arriving
-// reports for campaigns scheduled earlier.
+// fetchCampaigns walks the full history in 31-day windows, invoking fn per window.
+// The interval is ignored; see the strategy note in GetTable.
 func (s *CleverTapSource) fetchCampaigns(ctx context.Context, opts source.ReadOptions, fn func([]map[string]interface{}) error) error {
 	start := defaultStartDate
 	// Campaigns are selected by their scheduled date, which for a pending campaign
@@ -1120,9 +1097,8 @@ func (s *CleverTapSource) sendCampaignReport(ctx context.Context, id json.Number
 	if err != nil {
 		return fmt.Errorf("failed to fetch campaign report for %s: %w", id, err)
 	}
-	// A campaign with no report yet is expected, not an error. The docs promise a
-	// 409, but a completed campaign that produced no results answers 500 with
-	// "This target has no result as of yet", so match on the message too.
+	// No report yet is expected, not an error. The docs promise 409 but a 500 with
+	// "no result as of yet" also occurs, so match on the message too.
 	if resp.StatusCode() == 409 || hasNoResultYet(resp.Body()) {
 		config.Debug("[CLEVERTAP] campaign %s has no report yet, skipping", id)
 		skipped.Add(1)

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -554,11 +554,22 @@ func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts
 
 	// The API filters by whole days but delete+insert removes an exact instant
 	// range, so trim the day padding or the edges duplicate on every run.
+	var undated int64
 	keep := func(item map[string]interface{}) bool {
+		// A record whose ts did not parse cannot be placed in the delete window, so
+		// keeping it would insert a duplicate on every run.
+		if _, ok := item["ts"].(time.Time); !ok {
+			undated++
+			return false
+		}
 		return withinInterval(item["ts"], opts.IntervalStart, opts.IntervalEnd)
 	}
 
-	return s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
+	err := s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
+	if undated > 0 {
+		output.Warnf("Warning: clevertap dropped %d %q record(s) with an unreadable timestamp\n", undated, eventName)
+	}
+	return err
 }
 
 // withinInterval reports whether a converted timestamp is inside the bounds. Both

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -1,0 +1,1167 @@
+package clevertap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
+)
+
+const (
+	maxPageSize = 5000
+	maxPages    = 10000
+	// /v1/contentBlock/list paginates by page number and caps pageSize at 100.
+	contentBlockPageSize = 100
+	// Its date filters insist on milliseconds; plain RFC3339 is rejected with
+	// "Enter date in ISO format".
+	contentBlockTimeFormat = "2006-01-02T15:04:05.000Z"
+	// CleverTap caps concurrent requests (3 for the export APIs) rather than
+	// enforcing a per-minute quota, so this keeps in-flight requests under that.
+	rateLimit                 = 3.0
+	rateLimitBurst            = 3
+	campaignReportParallelism = 3
+	eventFanOutParallelism    = 3
+	// CleverTap prepares each batch asynchronously and rejects a fetch that
+	// arrives while the previous one is still running.
+	transientRetries    = 6
+	transientRetryDelay = 2 * time.Second
+	// /1/targets/list.json is only optimized for ranges of 31 days or less.
+	campaignWindowDays = 31
+	// How far past today the campaign sweep runs, so campaigns scheduled for a
+	// future date are picked up while they are still pending.
+	campaignFutureMonths = 12
+)
+
+var supportedTables = []string{
+	"events",
+	"profiles",
+	"campaigns",
+	"campaign_reports",
+	"content_blocks",
+	"message_reports",
+	"event_schema",
+	"user_properties",
+	"category_groups",
+}
+
+// errExportNotAllowed marks events CleverTap refuses to export (notification
+// events, which are only available through its S3/GCP exports).
+var errExportNotAllowed = errors.New("export not allowed for this event")
+
+// validRegions maps a region code to its API host prefix. Europe is served from
+// the unprefixed host, and the dashboard labels that project "global", so both
+// spellings are accepted for it.
+var validRegions = map[string]string{
+	"eu1":    "",
+	"global": "",
+	"in1":    "in1",
+	"us1":    "us1",
+	"sg1":    "sg1",
+	"aps3":   "aps3",
+	"mec1":   "mec1",
+}
+
+// defaultStartDate bounds the export when no interval is supplied; the CleverTap
+// export endpoints require an explicit from/to range. CleverTap was founded in
+// 2013, so no project can hold data from before then and nothing is cut off.
+var defaultStartDate = time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC)
+
+type CleverTapSource struct {
+	client   *httpclient.Client
+	timezone *time.Location
+}
+
+func NewCleverTapSource() *CleverTapSource {
+	return &CleverTapSource{}
+}
+
+func (s *CleverTapSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *CleverTapSource) Schemes() []string {
+	return []string{"clevertap"}
+}
+
+type clevertapCredentials struct {
+	accountID string
+	passcode  string
+	region    string
+	timezone  *time.Location
+}
+
+func parseURI(uri string) (clevertapCredentials, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return clevertapCredentials{}, fmt.Errorf("invalid clevertap URI: %w", err)
+	}
+	if parsed.Scheme != "clevertap" {
+		return clevertapCredentials{}, fmt.Errorf("invalid clevertap URI: must start with clevertap://")
+	}
+
+	params := parsed.Query()
+
+	accountID := params.Get("account_id")
+	if accountID == "" {
+		return clevertapCredentials{}, fmt.Errorf("account_id is required in clevertap URI")
+	}
+
+	passcode := params.Get("passcode")
+	if passcode == "" {
+		return clevertapCredentials{}, fmt.Errorf("passcode is required in clevertap URI")
+	}
+
+	region := params.Get("region")
+	if region == "" {
+		region = "eu1"
+	}
+	if _, ok := validRegions[region]; !ok {
+		return clevertapCredentials{}, fmt.Errorf("invalid region %q: must be one of eu1 (or global), in1, us1, sg1, aps3, mec1", region)
+	}
+
+	// Event timestamps come back in the project's timezone with nothing in the
+	// response naming it, so the caller has to declare it.
+	timezone := params.Get("timezone")
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		return clevertapCredentials{}, fmt.Errorf("invalid timezone %q: must be an IANA name such as UTC or Asia/Kolkata", timezone)
+	}
+
+	return clevertapCredentials{accountID: accountID, passcode: passcode, region: region, timezone: loc}, nil
+}
+
+// regionBaseURL maps a region code to its API host; Europe is the unprefixed default.
+func regionBaseURL(region string) string {
+	prefix, ok := validRegions[region]
+	if !ok || prefix == "" {
+		return "https://api.clevertap.com"
+	}
+	return fmt.Sprintf("https://%s.api.clevertap.com", prefix)
+}
+
+func (s *CleverTapSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.timezone = creds.timezone
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(regionBaseURL(creds.region)),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithHeader("X-CleverTap-Account-Id", creds.accountID),
+		httpclient.WithHeader("X-CleverTap-Passcode", creds.passcode),
+		httpclient.WithHeader("Content-Type", "application/json"),
+	)
+
+	config.Debug("[CLEVERTAP] Connected to region %s", creds.region)
+	return nil
+}
+
+func (s *CleverTapSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+type clevertapParams struct {
+	// A comma-separated list, so several events can be loaded into one table
+	// without falling back to every event in the project.
+	EventName []string `mapstructure:"event_name"`
+}
+
+func parseTableName(raw string) (string, clevertapParams, error) {
+	var p clevertapParams
+	path, hasParams, err := tablespec.Parse(raw, &p, tablespec.WithListSeparator(","))
+	if err != nil {
+		return "", p, err
+	}
+	if !hasParams {
+		return raw, p, nil
+	}
+	return path, p, nil
+}
+
+func isValidTable(table string) bool {
+	for _, t := range supportedTables {
+		if t == table {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *CleverTapSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	table, params, err := parseTableName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !isValidTable(table) {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", table, strings.Join(supportedTables, ", "))
+	}
+
+	var primaryKeys []string
+	incrementalKey := ""
+	strategy := config.StrategyMerge
+
+	switch table {
+	case "events":
+		// Event records carry no unique id, so merge is impossible; delete+insert
+		// rewrites the loaded window instead, which also refreshes the profile
+		// snapshot each record embeds.
+		incrementalKey = "ts"
+		strategy = config.StrategyDeleteInsert
+	case "profiles":
+		// CleverTap exposes no way to detect profile edits or deletions, so the
+		// table is rebuilt from a full sweep rather than accumulated; merging
+		// would leave deleted users and dormant edits behind forever.
+		primaryKeys = []string{"object_id"}
+		strategy = config.StrategyReplace
+	case "campaigns", "campaign_reports":
+		// The endpoint filters on a campaign's scheduled date, which says nothing
+		// about when it last changed: a campaign's status moves through running to
+		// completed long after that date, and its report only exists once it has
+		// finished. A narrow window would freeze both, so each run rebuilds from a
+		// full sweep.
+		primaryKeys = []string{"id"}
+		strategy = config.StrategyReplace
+	case "content_blocks":
+		primaryKeys = []string{"id"}
+		incrementalKey = "updatedAt"
+	case "message_reports":
+		// start_date is when a message went out, not when its counts last moved,
+		// so there is nothing to load incrementally on.
+		primaryKeys = []string{"message_id"}
+		strategy = config.StrategyReplace
+	case "event_schema", "user_properties":
+		// A catalog of what exists in the project, with no date dimension to
+		// load incrementally, so each run replaces the snapshot.
+		primaryKeys = []string{"name"}
+		strategy = config.StrategyReplace
+	case "category_groups":
+		// Also a catalog; keyed on the numeric group id rather than its name.
+		primaryKeys = []string{"key"}
+		strategy = config.StrategyReplace
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           table,
+		TablePrimaryKeys:    primaryKeys,
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("clevertap source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, table, params, opts)
+		},
+	}, nil
+}
+
+func (s *CleverTapSource) read(ctx context.Context, table string, params clevertapParams, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "events":
+			err = s.fanOutByEvent(ctx, params.EventName, func(ctx context.Context, name string) error {
+				return s.readEvents(ctx, name, opts, results)
+			})
+		case "profiles":
+			err = s.fanOutByEvent(ctx, params.EventName, func(ctx context.Context, name string) error {
+				return s.readProfiles(ctx, name, opts, results)
+			})
+		case "campaigns":
+			err = s.readCampaigns(ctx, opts, results)
+		case "campaign_reports":
+			err = s.readCampaignReports(ctx, opts, results)
+		case "content_blocks":
+			err = s.readContentBlocks(ctx, opts, results)
+		case "message_reports":
+			err = s.readMessageReports(ctx, opts, results)
+		case "event_schema":
+			err = s.readSchema(ctx, "events", "events", opts, results)
+		case "user_properties":
+			err = s.readSchema(ctx, "userProperties", "userProperties", opts, results)
+		case "category_groups":
+			err = s.readCategoryGroups(ctx, opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", table)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func jsonUseNumber(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+// dateRange converts the ingestion interval into the inclusive YYYYMMDD bounds the
+// CleverTap export endpoints require.
+func dateRange(opts source.ReadOptions) (int, int) {
+	from := defaultStartDate
+	to := time.Now().UTC()
+	if opts.IntervalStart != nil {
+		from = opts.IntervalStart.UTC()
+	}
+	if opts.IntervalEnd != nil {
+		to = opts.IntervalEnd.UTC()
+	}
+	return yyyymmdd(from), yyyymmdd(to)
+}
+
+func yyyymmdd(t time.Time) int {
+	n, _ := strconv.Atoi(t.Format("20060102"))
+	return n
+}
+
+// isRequestInProgress reports that CleverTap is still preparing a batch. Its
+// exports run asynchronously, so an overlapping fetch is refused and retryable.
+func isRequestInProgress(status, apiError string) bool {
+	return status == "fail" && strings.Contains(strings.ToLower(apiError), "still in progress")
+}
+
+// hasNoResultYet reports that a campaign has produced no report. CleverTap sends
+// this as a 500 rather than the documented 409, so the body has to be inspected.
+func hasNoResultYet(body []byte) bool {
+	var parsed struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false
+	}
+	return parsed.Status == "fail" && strings.Contains(strings.ToLower(parsed.Error), "no result as of yet")
+}
+
+// isExportNotAllowed reports CleverTap's refusal to export an event. Notification
+// events answer this way and are only reachable through its S3/GCP exports.
+func isExportNotAllowed(body []byte) bool {
+	var parsed struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false
+	}
+	return parsed.Status == "fail" && strings.Contains(strings.ToLower(parsed.Error), "export not allowed")
+}
+
+// cursorExport runs CleverTap's two-step export: a POST returns a cursor, then each
+// GET returns one batch plus the cursor for the next, until next_cursor is absent.
+func (s *CleverTapSource) cursorExport(
+	ctx context.Context,
+	endpoint string,
+	body map[string]interface{},
+	query map[string]string,
+	transform func(map[string]interface{}) map[string]interface{},
+	keep func(map[string]interface{}) bool,
+	opts source.ReadOptions,
+	results chan<- source.RecordBatchResult,
+) error {
+	req := s.client.R(ctx).SetBody(body)
+	for k, v := range query {
+		req.SetQueryParam(k, v)
+	}
+
+	resp, err := req.Post(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to open %s cursor: %w", endpoint, err)
+	}
+	// The refusal arrives as a 400, so it has to be recognised before the generic
+	// non-success check turns it into a plain error.
+	if isExportNotAllowed(resp.Body()) {
+		return errExportNotAllowed
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("%s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+	}
+
+	var start struct {
+		Status string `json:"status"`
+		Cursor string `json:"cursor"`
+		Error  string `json:"error"`
+	}
+	if err := jsonUseNumber(resp.Body(), &start); err != nil {
+		return fmt.Errorf("failed to parse %s cursor response: %w", endpoint, err)
+	}
+	if start.Status == "fail" {
+		return fmt.Errorf("%s failed to open cursor: %s", endpoint, start.Error)
+	}
+
+	cursor := start.Cursor
+	totalSent := 0
+
+	for pages := 0; cursor != ""; pages++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if pages >= maxPages {
+			config.Debug("[CLEVERTAP] %s hit the %d page cap, stopping", endpoint, maxPages)
+			break
+		}
+
+		var page struct {
+			Status     string                   `json:"status"`
+			NextCursor string                   `json:"next_cursor"`
+			Records    []map[string]interface{} `json:"records"`
+			Error      string                   `json:"error"`
+		}
+
+		// The same cursor is re-requested while CleverTap is still preparing the
+		// batch; the attempt is not a page, so it does not advance the cursor.
+		var lastBody string
+		for attempt := 0; ; attempt++ {
+			resp, err := s.client.R(ctx).SetQueryParam("cursor", decodeCursor(cursor)).Get(endpoint)
+			if err != nil {
+				return fmt.Errorf("failed to fetch %s batch: %w", endpoint, err)
+			}
+			if !resp.IsSuccess() {
+				return fmt.Errorf("%s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+			}
+
+			page.Status, page.NextCursor, page.Records, page.Error = "", "", nil, ""
+			if err := jsonUseNumber(resp.Body(), &page); err != nil {
+				return fmt.Errorf("failed to parse %s batch: %w", endpoint, err)
+			}
+			lastBody = resp.String()
+
+			if !isRequestInProgress(page.Status, page.Error) {
+				break
+			}
+			if attempt >= transientRetries {
+				return fmt.Errorf("%s batch still not ready after %d retries: %s", endpoint, transientRetries, lastBody)
+			}
+			config.Debug("[CLEVERTAP] %s batch not ready, retrying (%d/%d)", endpoint, attempt+1, transientRetries)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(transientRetryDelay):
+			}
+		}
+
+		if page.Status == "fail" {
+			return fmt.Errorf("%s batch failed: %s", endpoint, page.Error)
+		}
+
+		if len(page.Records) > 0 {
+			items := make([]map[string]interface{}, 0, len(page.Records))
+			for _, raw := range page.Records {
+				if transform != nil {
+					raw = transform(raw)
+				}
+				if keep != nil && !keep(raw) {
+					continue
+				}
+				items = append(items, raw)
+			}
+
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+			if err != nil {
+				return fmt.Errorf("failed to convert %s records to Arrow: %w", endpoint, err)
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case results <- source.RecordBatchResult{Batch: record}:
+			}
+
+			totalSent += len(items)
+			config.Debug("[CLEVERTAP] %s sent %d records (total: %d)", endpoint, len(items), totalSent)
+		}
+
+		cursor = page.NextCursor
+	}
+
+	return nil
+}
+
+// decodeCursor undoes the percent-encoding CleverTap applies to cursors, since the
+// request builder encodes query values again.
+func decodeCursor(cursor string) string {
+	if decoded, err := url.QueryUnescape(cursor); err == nil {
+		return decoded
+	}
+	return cursor
+}
+
+func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading events for %q", eventName)
+
+	from, to := dateRange(opts)
+	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
+	// The profile enrichments are all off: they would copy profile_data, the
+	// device list and the lifetime activity summary onto every event row, and the
+	// profiles table already holds those. objectId is returned either way.
+	query := map[string]string{
+		"batch_size": strconv.Itoa(maxPageSize),
+		"app":        "false",
+		"events":     "false",
+		"profile":    "false",
+	}
+
+	transform := func(item map[string]interface{}) map[string]interface{} {
+		// The export does not echo the event name back, so records from different
+		// events would be indistinguishable in one table.
+		item["event_name"] = eventName
+		if profile, ok := item["profile"].(map[string]interface{}); ok {
+			// object_id identifies the device, so it only joins to the one device
+			// profiles happens to key on. identity is the person and joins reliably;
+			// it is empty for users who never logged in.
+			if id, ok := profile["objectId"].(string); ok {
+				item["object_id"] = id
+			}
+			if identity, ok := profile["identity"].(string); ok {
+				item["identity"] = identity
+			}
+		}
+		if ts, ok := parseEventTimestamp(item["ts"], s.timezone); ok {
+			item["ts"] = ts
+		}
+		return item
+	}
+
+	// CleverTap filters by whole days, but delete+insert removes exactly the
+	// requested instant range, so anything outside it would be re-inserted every
+	// run without ever being deleted. Trim the day padding to keep runs idempotent.
+	keep := func(item map[string]interface{}) bool {
+		return withinInterval(item["ts"], opts.IntervalStart, opts.IntervalEnd)
+	}
+
+	return s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
+}
+
+// withinInterval reports whether an already-converted event timestamp falls inside the
+// requested bounds. Both ends are inclusive to match the delete+insert delete predicate.
+// A value that is absent or was never converted is kept rather than silently dropped.
+func withinInterval(v interface{}, start, end *time.Time) bool {
+	ts, ok := v.(time.Time)
+	if !ok {
+		return true
+	}
+	if start != nil && ts.Before(*start) {
+		return false
+	}
+	if end != nil && ts.After(*end) {
+		return false
+	}
+	return true
+}
+
+// parseEventTimestamp turns CleverTap's 14-digit yyyyMMddHHmmss event timestamp into
+// a real instant. It is reported in the project's timezone, so loc supplies the offset;
+// an unparseable value is left untouched rather than dropped.
+func parseEventTimestamp(v interface{}, loc *time.Location) (time.Time, bool) {
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	var raw string
+	switch t := v.(type) {
+	case json.Number:
+		raw = t.String()
+	case string:
+		raw = t
+	default:
+		return time.Time{}, false
+	}
+
+	parsed, err := time.ParseInLocation("20060102150405", raw, loc)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+// readSchema loads one of CleverTap's project catalogs. responseKey is the array
+// field the endpoint wraps its records in.
+func (s *CleverTapSource) readSchema(ctx context.Context, schemaType, responseKey string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading schema %s", schemaType)
+
+	resp, err := s.client.R(ctx).SetQueryParam("type", schemaType).Get("/getSchema")
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s schema: %w", schemaType, err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("%s schema returned status %d: %s", schemaType, resp.StatusCode(), resp.String())
+	}
+
+	var body map[string]interface{}
+	if err := jsonUseNumber(resp.Body(), &body); err != nil {
+		return fmt.Errorf("failed to parse %s schema response: %w", schemaType, err)
+	}
+	if status, _ := body["status"].(string); status == "fail" {
+		return fmt.Errorf("%s schema request failed: %v", schemaType, body["error"])
+	}
+
+	raw, _ := body[responseKey].([]interface{})
+	items := make([]map[string]interface{}, 0, len(raw))
+	for _, r := range raw {
+		if item, ok := r.(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert %s schema to Arrow: %w", schemaType, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case results <- source.RecordBatchResult{Batch: record}:
+	}
+
+	config.Debug("[CLEVERTAP] %s schema sent %d records", schemaType, len(items))
+	return nil
+}
+
+// readCategoryGroups loads the project's messaging subscription groups. It takes no
+// parameters and wraps its records in a "list" field rather than a named one.
+func (s *CleverTapSource) readCategoryGroups(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading category_groups")
+
+	resp, err := s.client.R(ctx).Get("/category-groups")
+	if err != nil {
+		return fmt.Errorf("failed to fetch category groups: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("category groups returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+
+	var body struct {
+		Status string                   `json:"status"`
+		List   []map[string]interface{} `json:"list"`
+		Error  string                   `json:"error"`
+	}
+	if err := jsonUseNumber(resp.Body(), &body); err != nil {
+		return fmt.Errorf("failed to parse category groups response: %w", err)
+	}
+	if body.Status == "fail" {
+		return fmt.Errorf("category groups request failed: %s", body.Error)
+	}
+	if len(body.List) == 0 {
+		return nil
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(body.List, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert category groups to Arrow: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case results <- source.RecordBatchResult{Batch: record}:
+	}
+
+	config.Debug("[CLEVERTAP] category_groups sent %d records", len(body.List))
+	return nil
+}
+
+// fetchEventNames lists every event name in the project. Nothing is filtered out:
+// eventCount only covers the current and previous month and reads zero for events
+// that hold data, and a Discarded event has merely stopped collecting new data
+// while keeping its history. The export call decides what is actually available.
+func (s *CleverTapSource) fetchEventNames(ctx context.Context) ([]string, error) {
+	resp, err := s.client.R(ctx).SetQueryParam("type", "events").Get("/getSchema")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch event schema: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("event schema returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+
+	var body struct {
+		Status string `json:"status"`
+		Events []struct {
+			Name string `json:"name"`
+		} `json:"events"`
+		Error string `json:"error"`
+	}
+	if err := jsonUseNumber(resp.Body(), &body); err != nil {
+		return nil, fmt.Errorf("failed to parse event schema response: %w", err)
+	}
+	if body.Status == "fail" {
+		return nil, fmt.Errorf("event schema request failed: %s", body.Error)
+	}
+
+	names := make([]string, 0, len(body.Events))
+	for _, e := range body.Events {
+		if e.Name != "" {
+			names = append(names, e.Name)
+		}
+	}
+	return names, nil
+}
+
+// fanOutByEvent runs fn once per event name, a few at a time. An empty names list
+// means every event defined in the project. Events CleverTap refuses to export are
+// skipped rather than failing the whole table.
+func (s *CleverTapSource) fanOutByEvent(ctx context.Context, names []string, fn func(context.Context, string) error) error {
+	if len(names) == 0 {
+		discovered, err := s.fetchEventNames(ctx)
+		if err != nil {
+			return err
+		}
+		names = discovered
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	config.Debug("[CLEVERTAP] fanning out over %d events", len(names))
+
+	nameCh := make(chan string)
+	errs := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for i := 0; i < eventFanOutParallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for name := range nameCh {
+				err := fn(ctx, name)
+				if errors.Is(err, errExportNotAllowed) {
+					config.Debug("[CLEVERTAP] %q cannot be exported, skipping", name)
+					continue
+				}
+				if err != nil {
+					select {
+					case errs <- err:
+					default:
+					}
+					cancel()
+					return
+				}
+			}
+		}()
+	}
+
+	for _, name := range names {
+		select {
+		case nameCh <- name:
+		case <-ctx.Done():
+		}
+	}
+	close(nameCh)
+
+	wg.Wait()
+	close(errs)
+
+	return <-errs
+}
+
+// readProfiles fetches the users who raised one event. Sweeping several events
+// returns the same person once per event they fired; replace de-duplicates them
+// on object_id.
+func (s *CleverTapSource) readProfiles(ctx context.Context, eventName string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading profiles for %q", eventName)
+
+	// The interval is deliberately ignored. CleverTap selects profiles by event
+	// activity, not by when the profile changed, so a narrow window would drop
+	// users who were merely dormant while still returning current attributes for
+	// everyone else. Only a full sweep gives a complete, consistent snapshot.
+	from, to := yyyymmdd(defaultStartDate), yyyymmdd(time.Now().UTC())
+	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
+	query := map[string]string{
+		"batch_size": strconv.Itoa(maxPageSize),
+		"app":        "true",
+		"events":     "true",
+		"profile":    "true",
+	}
+
+	return s.cursorExport(ctx, "/1/profiles.json", body, query, liftProfileObjectID, nil, opts, results)
+}
+
+// liftProfileObjectID promotes the CleverTap user id to a top-level column for merge.
+// Profiles matched only through a device carry it inside platformInfo instead.
+func liftProfileObjectID(item map[string]interface{}) map[string]interface{} {
+	if id, ok := item["objectId"].(string); ok && id != "" {
+		item["object_id"] = id
+		return item
+	}
+	platforms, ok := item["platformInfo"].([]interface{})
+	if !ok {
+		return item
+	}
+	for _, p := range platforms {
+		entry, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if id, ok := entry["objectId"].(string); ok && id != "" {
+			item["object_id"] = id
+			return item
+		}
+	}
+	return item
+}
+
+func (s *CleverTapSource) readContentBlocks(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading content_blocks")
+
+	totalSent := 0
+	for page := 1; page <= maxPages; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("pageNumber", strconv.Itoa(page)).
+			SetQueryParam("pageSize", strconv.Itoa(contentBlockPageSize))
+		if opts.IntervalStart != nil {
+			req.SetQueryParam("updatedFrom", opts.IntervalStart.UTC().Format(contentBlockTimeFormat))
+		}
+		if opts.IntervalEnd != nil {
+			req.SetQueryParam("updatedTo", opts.IntervalEnd.UTC().Format(contentBlockTimeFormat))
+		}
+
+		resp, err := req.Get("/v1/contentBlock/list")
+		if err != nil {
+			return fmt.Errorf("failed to fetch content blocks: %w", err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("content blocks returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+
+		var body struct {
+			Status        string                   `json:"status"`
+			ContentBlocks []map[string]interface{} `json:"contentBlocks"`
+			Total         json.Number              `json:"total"`
+			Error         string                   `json:"error"`
+		}
+		if err := jsonUseNumber(resp.Body(), &body); err != nil {
+			return fmt.Errorf("failed to parse content blocks response: %w", err)
+		}
+		if body.Status == "fail" {
+			return fmt.Errorf("content blocks request failed: %s", body.Error)
+		}
+		if len(body.ContentBlocks) == 0 {
+			break
+		}
+
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(body.ContentBlocks, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert content blocks to Arrow: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case results <- source.RecordBatchResult{Batch: record}:
+		}
+
+		totalSent += len(body.ContentBlocks)
+		config.Debug("[CLEVERTAP] content_blocks sent %d records (total: %d)", len(body.ContentBlocks), totalSent)
+
+		if len(body.ContentBlocks) < contentBlockPageSize {
+			break
+		}
+		if page == maxPages {
+			config.Debug("[CLEVERTAP] content_blocks hit the %d page cap, stopping", maxPages)
+		}
+	}
+
+	return nil
+}
+
+func (s *CleverTapSource) readMessageReports(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading message_reports")
+
+	// The interval is ignored for the same reason as campaigns: from/to select on
+	// when a message was sent, while its delivery and engagement counts keep rising
+	// for days afterwards, so a narrow window would freeze stale counts.
+	//
+	// Only from/to are sent. Omitting channel, delivery, status, message_type and
+	// label applies no filter on any of them, so every channel and status is
+	// covered. daily is left at its false default, which keeps one aggregated
+	// entry per message and so one row per message_id.
+	from, to := yyyymmdd(defaultStartDate), yyyymmdd(time.Now().UTC())
+	resp, err := s.client.R(ctx).
+		SetBody(map[string]interface{}{"from": from, "to": to}).
+		Post("/1/message/report.json")
+	if err != nil {
+		return fmt.Errorf("failed to fetch message reports: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("message reports returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+
+	var body struct {
+		Status   string                   `json:"status"`
+		Messages []map[string]interface{} `json:"messages"`
+		Error    string                   `json:"error"`
+	}
+	if err := jsonUseNumber(resp.Body(), &body); err != nil {
+		return fmt.Errorf("failed to parse message reports response: %w", err)
+	}
+	if body.Status == "fail" {
+		return fmt.Errorf("message reports request failed: %s", body.Error)
+	}
+	if len(body.Messages) == 0 {
+		return nil
+	}
+
+	for _, m := range body.Messages {
+		liftMessageID(m)
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(body.Messages, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert message reports to Arrow: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case results <- source.RecordBatchResult{Batch: record}:
+	}
+
+	config.Debug("[CLEVERTAP] message_reports sent %d records", len(body.Messages))
+	return nil
+}
+
+// liftMessageID copies the "message id" field, whose space makes it awkward as a
+// merge key, to a conventional message_id column.
+func liftMessageID(item map[string]interface{}) map[string]interface{} {
+	if id, ok := item["message id"]; ok {
+		item["message_id"] = id
+	}
+	return item
+}
+
+// fetchCampaigns walks the full history in 31-day windows and invokes fn once per
+// window. The interval is deliberately ignored: the endpoint selects on a campaign's
+// scheduled date, so a narrow window would miss status changes and late-arriving
+// reports for campaigns scheduled earlier.
+func (s *CleverTapSource) fetchCampaigns(ctx context.Context, opts source.ReadOptions, fn func([]map[string]interface{}) error) error {
+	start := defaultStartDate
+	// Campaigns are selected by their scheduled date, which for a pending campaign
+	// is in the future, so the sweep has to run past today to see them at all.
+	end := time.Now().UTC().AddDate(0, campaignFutureMonths, 0)
+
+	for windowStart := start; !windowStart.After(end); windowStart = windowStart.AddDate(0, 0, campaignWindowDays) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		windowEnd := windowStart.AddDate(0, 0, campaignWindowDays-1)
+		if windowEnd.After(end) {
+			windowEnd = end
+		}
+
+		body := map[string]interface{}{"from": yyyymmdd(windowStart), "to": yyyymmdd(windowEnd)}
+		resp, err := s.client.R(ctx).SetBody(body).Post("/1/targets/list.json")
+		if err != nil {
+			return fmt.Errorf("failed to fetch campaigns: %w", err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("campaigns returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+
+		var page struct {
+			Status  string                   `json:"status"`
+			Targets []map[string]interface{} `json:"targets"`
+			Error   string                   `json:"error"`
+		}
+		if err := jsonUseNumber(resp.Body(), &page); err != nil {
+			return fmt.Errorf("failed to parse campaigns response: %w", err)
+		}
+		if page.Status == "fail" {
+			return fmt.Errorf("campaigns request failed: %s", page.Error)
+		}
+		if len(page.Targets) == 0 {
+			continue
+		}
+
+		if err := fn(page.Targets); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *CleverTapSource) readCampaigns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading campaigns")
+
+	return s.fetchCampaigns(ctx, opts, func(targets []map[string]interface{}) error {
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(targets, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert campaigns to Arrow: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case results <- source.RecordBatchResult{Batch: record}:
+		}
+		config.Debug("[CLEVERTAP] campaigns sent %d records", len(targets))
+		return nil
+	})
+}
+
+func (s *CleverTapSource) readCampaignReports(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[CLEVERTAP] reading campaign_reports")
+
+	ids := make([]json.Number, 0)
+	err := s.fetchCampaigns(ctx, opts, func(targets []map[string]interface{}) error {
+		for _, t := range targets {
+			if id, ok := t["id"].(json.Number); ok {
+				ids = append(ids, id)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	idCh := make(chan json.Number, campaignReportParallelism)
+	errs := make(chan error, 1)
+	var wg sync.WaitGroup
+	var skipped atomic.Int64
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for i := 0; i < campaignReportParallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for id := range idCh {
+				if err := s.sendCampaignReport(ctx, id, opts, results, &skipped); err != nil {
+					select {
+					case errs <- err:
+					default:
+					}
+					cancel()
+					return
+				}
+			}
+		}()
+	}
+
+	for _, id := range ids {
+		select {
+		case idCh <- id:
+		case <-ctx.Done():
+		}
+	}
+	close(idCh)
+
+	wg.Wait()
+	close(errs)
+
+	if err := <-errs; err != nil {
+		return err
+	}
+
+	// Reported once rather than per campaign: on a busy account most campaigns are
+	// pending or running at any moment, and each one would otherwise log a line.
+	if n := skipped.Load(); n > 0 {
+		output.Warnf("Warning: clevertap skipped %d of %d campaign(s) that have no report yet\n", n, len(ids))
+	}
+	return nil
+}
+
+func (s *CleverTapSource) sendCampaignReport(ctx context.Context, id json.Number, opts source.ReadOptions, results chan<- source.RecordBatchResult, skipped *atomic.Int64) error {
+	resp, err := s.client.R(ctx).SetBody(map[string]interface{}{"id": id}).Post("/1/targets/result.json")
+	if err != nil {
+		return fmt.Errorf("failed to fetch campaign report for %s: %w", id, err)
+	}
+	// A campaign with no report yet is expected, not an error. The docs promise a
+	// 409, but a completed campaign that produced no results answers 500 with
+	// "This target has no result as of yet", so match on the message too.
+	if resp.StatusCode() == 409 || hasNoResultYet(resp.Body()) {
+		config.Debug("[CLEVERTAP] campaign %s has no report yet, skipping", id)
+		skipped.Add(1)
+		return nil
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("campaign report for %s returned status %d: %s", id, resp.StatusCode(), resp.String())
+	}
+
+	var page struct {
+		Status string                 `json:"status"`
+		Result map[string]interface{} `json:"result"`
+		Error  string                 `json:"error"`
+	}
+	if err := jsonUseNumber(resp.Body(), &page); err != nil {
+		return fmt.Errorf("failed to parse campaign report for %s: %w", id, err)
+	}
+	if page.Status == "fail" {
+		return fmt.Errorf("campaign report for %s failed: %s", id, page.Error)
+	}
+	// A campaign that never delivered answers 200 with an explanatory message and
+	// no result, so this is a normal skip rather than a failure.
+	if page.Result == nil {
+		config.Debug("[CLEVERTAP] campaign %s has no report: %s", id, page.Error)
+		skipped.Add(1)
+		return nil
+	}
+
+	page.Result["id"] = id
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema([]map[string]interface{}{page.Result}, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert campaign report for %s to Arrow: %w", id, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case results <- source.RecordBatchResult{Batch: record}:
+	}
+	return nil
+}

--- a/pkg/source/clevertap/clevertap.go
+++ b/pkg/source/clevertap/clevertap.go
@@ -322,9 +322,9 @@ func jsonUseNumber(data []byte, v any) error {
 	return dec.Decode(v)
 }
 
-// dateRange converts the interval into inclusive YYYYMMDD bounds. Resolved in loc
-// because CleverTap's days are project-local; UTC dates would skip a boundary day.
-func dateRange(opts source.ReadOptions, loc *time.Location) (int, int) {
+// intervalBounds resolves the ingestion interval in loc, since CleverTap's days
+// are project-local and UTC dates would skip the day a boundary falls on.
+func intervalBounds(opts source.ReadOptions, loc *time.Location) (time.Time, time.Time) {
 	if loc == nil {
 		loc = time.UTC
 	}
@@ -336,16 +336,37 @@ func dateRange(opts source.ReadOptions, loc *time.Location) (int, int) {
 	if opts.IntervalEnd != nil {
 		to = *opts.IntervalEnd
 	}
-	return yyyymmdd(from.In(loc)), yyyymmdd(to.In(loc))
+	return from.In(loc), to.In(loc)
 }
 
-// nowIn is today in the project's timezone, which is the day CleverTap's
-// date filters are measured against.
+// nowIn is today in the project's timezone, which is the day CleverTap's date
+// filters are measured against.
 func nowIn(loc *time.Location) time.Time {
 	if loc == nil {
 		loc = time.UTC
 	}
 	return time.Now().In(loc)
+}
+
+// forEachDateWindow calls fn with the inclusive YYYYMMDD bounds of each window, so
+// one export never has to walk the whole history in a single cursor.
+func forEachDateWindow(ctx context.Context, start, end time.Time, days int, fn func(from, to int) error) error {
+	for windowStart := start; !windowStart.After(end); windowStart = windowStart.AddDate(0, 0, days) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		windowEnd := windowStart.AddDate(0, 0, days-1)
+		if windowEnd.After(end) {
+			windowEnd = end
+		}
+		if err := fn(yyyymmdd(windowStart), yyyymmdd(windowEnd)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func yyyymmdd(t time.Time) int {
@@ -428,20 +449,23 @@ func (s *CleverTapSource) cursorExport(
 	}
 
 	cursor := start.Cursor
+	previousCursor := ""
 	totalSent := 0
 
-	for pages := 0; cursor != ""; pages++ {
+	// No page cap: capping a cursor walk truncates the export, and delete+insert
+	// would commit the short result over the full window. A cursor that repeats
+	// is the only way the walk fails to terminate, so guard on that instead.
+	for cursor != "" {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		// Stopping here would truncate silently, and delete+insert would commit the
-		// short result over the full window.
-		if pages >= maxPages {
-			return fmt.Errorf("%s exceeded the %d page cap; narrow the interval", endpoint, maxPages)
+		if cursor == previousCursor {
+			return fmt.Errorf("%s cursor stopped advancing after %d records", endpoint, totalSent)
 		}
+		previousCursor = cursor
 
 		var page struct {
 			Status     string                   `json:"status"`
@@ -531,8 +555,6 @@ func decodeCursor(cursor string) string {
 func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[CLEVERTAP] reading events for %q", eventName)
 
-	from, to := dateRange(opts, s.timezone)
-	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
 	// Enrichments off: they would copy onto every row what profiles already holds.
 	// objectId and identity are returned either way.
 	query := map[string]string{
@@ -572,6 +594,12 @@ func (s *CleverTapSource) readEvents(ctx context.Context, eventName string, opts
 		return withinInterval(item["ts"], opts.IntervalStart, opts.IntervalEnd)
 	}
 
+	start, end := intervalBounds(opts, s.timezone)
+	body := map[string]interface{}{
+		"event_name": eventName,
+		"from":       yyyymmdd(start),
+		"to":         yyyymmdd(end),
+	}
 	return s.cursorExport(ctx, "/1/events.json", body, query, transform, keep, opts, results)
 }
 
@@ -809,8 +837,6 @@ func (s *CleverTapSource) readProfiles(ctx context.Context, eventName string, op
 
 	// Interval ignored: profiles are selected by event activity, not by when the
 	// profile changed, so only a full sweep is complete.
-	from, to := yyyymmdd(defaultStartDate), yyyymmdd(nowIn(s.timezone))
-	body := map[string]interface{}{"event_name": eventName, "from": from, "to": to}
 	query := map[string]string{
 		"batch_size": strconv.Itoa(maxPageSize),
 		"app":        "true",
@@ -818,6 +844,11 @@ func (s *CleverTapSource) readProfiles(ctx context.Context, eventName string, op
 		"profile":    "true",
 	}
 
+	body := map[string]interface{}{
+		"event_name": eventName,
+		"from":       yyyymmdd(defaultStartDate),
+		"to":         yyyymmdd(nowIn(s.timezone)),
+	}
 	return s.cursorExport(ctx, "/1/profiles.json", body, query, liftProfileObjectID, nil, opts, results)
 }
 
@@ -908,7 +939,7 @@ func (s *CleverTapSource) readContentBlocks(ctx context.Context, opts source.Rea
 			break
 		}
 		if page == maxPages {
-			return fmt.Errorf("content blocks exceeded the %d page cap; narrow the interval", maxPages)
+			return fmt.Errorf("content blocks did not terminate within %d pages", maxPages)
 		}
 	}
 
@@ -982,19 +1013,8 @@ func (s *CleverTapSource) fetchCampaigns(ctx context.Context, opts source.ReadOp
 	// is in the future, so the sweep has to run past today to see them at all.
 	end := nowIn(s.timezone).AddDate(0, campaignFutureMonths, 0)
 
-	for windowStart := start; !windowStart.After(end); windowStart = windowStart.AddDate(0, 0, campaignWindowDays) {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		windowEnd := windowStart.AddDate(0, 0, campaignWindowDays-1)
-		if windowEnd.After(end) {
-			windowEnd = end
-		}
-
-		body := map[string]interface{}{"from": yyyymmdd(windowStart), "to": yyyymmdd(windowEnd)}
+	return forEachDateWindow(ctx, start, end, campaignWindowDays, func(from, to int) error {
+		body := map[string]interface{}{"from": from, "to": to}
 		resp, err := s.client.R(ctx).SetBody(body).Post("/1/targets/list.json")
 		if err != nil {
 			return fmt.Errorf("failed to fetch campaigns: %w", err)
@@ -1015,15 +1035,11 @@ func (s *CleverTapSource) fetchCampaigns(ctx context.Context, opts source.ReadOp
 			return fmt.Errorf("campaigns request failed: %s", page.Error)
 		}
 		if len(page.Targets) == 0 {
-			continue
+			return nil
 		}
 
-		if err := fn(page.Targets); err != nil {
-			return err
-		}
-	}
-
-	return nil
+		return fn(page.Targets)
+	})
 }
 
 func (s *CleverTapSource) readCampaigns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {

--- a/pkg/source/clevertap/clevertap_test.go
+++ b/pkg/source/clevertap/clevertap_test.go
@@ -258,14 +258,41 @@ func TestDateRange(t *testing.T) {
 	start := time.Date(2024, 3, 5, 13, 0, 0, 0, time.UTC)
 	end := time.Date(2024, 4, 1, 6, 0, 0, 0, time.UTC)
 
-	from, to := dateRange(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	from, to := dateRange(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}, time.UTC)
 	require.Equal(t, 20240305, from)
 	require.Equal(t, 20240401, to)
 
 	// With no interval the export still needs bounds: a fixed floor and today.
-	from, to = dateRange(source.ReadOptions{})
+	from, to = dateRange(source.ReadOptions{}, time.UTC)
 	require.Equal(t, 20130101, from)
 	require.Equal(t, yyyymmdd(time.Now().UTC()), to)
+}
+
+func TestDateRangeUsesProjectTimezone(t *testing.T) {
+	t.Parallel()
+
+	// 20:00Z on the 6th is already 01:30 on the 7th in Kolkata. CleverTap's days
+	// are project-local, so the 7th has to be requested or those events are never
+	// fetched while delete+insert still removes them from the destination.
+	start := time.Date(2026, 8, 5, 20, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 6, 20, 0, 0, 0, time.UTC)
+	opts := source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}
+
+	from, to := dateRange(opts, kolkata(t))
+	require.Equal(t, 20260806, from)
+	require.Equal(t, 20260807, to)
+
+	// The same instants in UTC land on the previous day at both ends.
+	from, to = dateRange(opts, time.UTC)
+	require.Equal(t, 20260805, from)
+	require.Equal(t, 20260806, to)
+
+	// A negative offset shifts the other way.
+	ny, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	midnightUTC := time.Date(2026, 8, 6, 0, 30, 0, 0, time.UTC)
+	from, _ = dateRange(source.ReadOptions{IntervalStart: &midnightUTC}, ny)
+	require.Equal(t, 20260805, from)
 }
 
 func TestDecodeCursor(t *testing.T) {

--- a/pkg/source/clevertap/clevertap_test.go
+++ b/pkg/source/clevertap/clevertap_test.go
@@ -391,6 +391,22 @@ func TestLiftProfileObjectIDIsDeviceScoped(t *testing.T) {
 	require.Equal(t, "bruin-user-1", item["identity"])
 }
 
+func TestWithinIntervalRequiresConvertedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	inside := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+
+	require.True(t, withinInterval(inside, &start, &end))
+	require.False(t, withinInterval(time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC), &start, &end))
+	require.True(t, withinInterval(inside, nil, nil))
+
+	// readEvents drops records whose ts never converted, because delete+insert
+	// cannot place them in a window; withinInterval itself keeps non-time values.
+	require.True(t, withinInterval(json.Number("20260815000000"), &start, &end))
+}
+
 func TestIsRequestInProgress(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/source/clevertap/clevertap_test.go
+++ b/pkg/source/clevertap/clevertap_test.go
@@ -1,0 +1,440 @@
+package clevertap
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func kolkata(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("Asia/Kolkata")
+	require.NoError(t, err)
+	return loc
+}
+
+func TestParseURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    clevertapCredentials
+		wantErr string
+	}{
+		{
+			name: "valid with explicit region",
+			uri:  "clevertap://?account_id=TEST-ABC-123&passcode=SECRET&region=in1",
+			want: clevertapCredentials{accountID: "TEST-ABC-123", passcode: "SECRET", region: "in1", timezone: time.UTC},
+		},
+		{
+			name: "region and timezone default",
+			uri:  "clevertap://?account_id=TEST-ABC-123&passcode=SECRET",
+			want: clevertapCredentials{accountID: "TEST-ABC-123", passcode: "SECRET", region: "eu1", timezone: time.UTC},
+		},
+		{
+			name: "explicit timezone",
+			uri:  "clevertap://?account_id=A&passcode=B&timezone=Asia/Kolkata",
+			want: clevertapCredentials{accountID: "A", passcode: "B", region: "eu1", timezone: kolkata(t)},
+		},
+		{
+			name: "passcode with url-encoded characters",
+			uri:  "clevertap://?account_id=A-B-C&passcode=p%2Fss%2Bword",
+			want: clevertapCredentials{accountID: "A-B-C", passcode: "p/ss+word", region: "eu1", timezone: time.UTC},
+		},
+		{
+			name:    "missing account_id",
+			uri:     "clevertap://?passcode=SECRET",
+			wantErr: "account_id is required",
+		},
+		{
+			name:    "missing passcode",
+			uri:     "clevertap://?account_id=TEST-ABC-123",
+			wantErr: "passcode is required",
+		},
+		{
+			name:    "no parameters at all",
+			uri:     "clevertap://",
+			wantErr: "account_id is required",
+		},
+		{
+			name:    "wrong scheme",
+			uri:     "clickup://?account_id=TEST-ABC-123&passcode=SECRET",
+			wantErr: "must start with clevertap://",
+		},
+		{
+			// The dashboard labels the default EU project "global", so a value
+			// copied straight from it has to be accepted.
+			name: "region global is accepted",
+			uri:  "clevertap://?account_id=A&passcode=B&region=global",
+			want: clevertapCredentials{accountID: "A", passcode: "B", region: "global", timezone: time.UTC},
+		},
+		{
+			name:    "invalid region",
+			uri:     "clevertap://?account_id=A&passcode=B&region=uk1",
+			wantErr: `invalid region "uk1"`,
+		},
+		{
+			name:    "invalid timezone",
+			uri:     "clevertap://?account_id=A&passcode=B&timezone=Mars/Olympus",
+			wantErr: `invalid timezone "Mars/Olympus"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseURI(tt.uri)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRegionBaseURL(t *testing.T) {
+	t.Parallel()
+
+	// Every one of these hosts was confirmed to serve the API.
+	require.Equal(t, "https://api.clevertap.com", regionBaseURL("eu1"))
+	require.Equal(t, "https://api.clevertap.com", regionBaseURL("global"))
+	require.Equal(t, "https://in1.api.clevertap.com", regionBaseURL("in1"))
+	require.Equal(t, "https://us1.api.clevertap.com", regionBaseURL("us1"))
+	require.Equal(t, "https://sg1.api.clevertap.com", regionBaseURL("sg1"))
+	require.Equal(t, "https://aps3.api.clevertap.com", regionBaseURL("aps3"))
+	require.Equal(t, "https://mec1.api.clevertap.com", regionBaseURL("mec1"))
+}
+
+func TestIsValidTable(t *testing.T) {
+	t.Parallel()
+
+	for _, table := range supportedTables {
+		require.True(t, isValidTable(table), "expected %q to be supported", table)
+	}
+
+	for _, table := range []string{"", "Events", "EVENTS", "event", "unknown", "campaign"} {
+		require.False(t, isValidTable(table), "expected %q to be unsupported", table)
+	}
+}
+
+func TestParseTableName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		wantTable string
+		wantEvent []string
+		wantErr   string
+	}{
+		{
+			name:      "table without parameters",
+			raw:       "campaigns",
+			wantTable: "campaigns",
+		},
+		{
+			name:      "event name parameter",
+			raw:       "events?event_name=Charged",
+			wantTable: "events",
+			wantEvent: []string{"Charged"},
+		},
+		{
+			name:      "several event names",
+			raw:       "events?event_name=Charged,App Launched",
+			wantTable: "events",
+			wantEvent: []string{"Charged", "App Launched"},
+		},
+		{
+			name:      "surrounding spaces are trimmed",
+			raw:       "events?event_name=Charged , App Launched",
+			wantTable: "events",
+			wantEvent: []string{"Charged", "App Launched"},
+		},
+		{
+			name:      "event name with encoded space",
+			raw:       "events?event_name=App%20Launched",
+			wantTable: "events",
+			wantEvent: []string{"App Launched"},
+		},
+		{
+			name:      "event name with plus as space",
+			raw:       "profiles?event_name=App+Launched",
+			wantTable: "profiles",
+			wantEvent: []string{"App Launched"},
+		},
+		{
+			name:    "unknown parameter is rejected",
+			raw:     "events?event=Charged",
+			wantErr: "unknown table parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			table, params, err := parseTableName(tt.raw)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantTable, table)
+			require.Equal(t, tt.wantEvent, params.EventName)
+		})
+	}
+}
+
+func TestGetTableParameters(t *testing.T) {
+	t.Parallel()
+
+	s := NewCleverTapSource()
+
+	// No table requires event_name any more: events and profiles fall back to
+	// discovering every event from the schema endpoint.
+	for _, table := range supportedTables {
+		got, err := s.GetTable(t.Context(), source.TableRequest{Name: table})
+		require.NoError(t, err, "table %s should not require parameters", table)
+		require.Equal(t, table, got.Name())
+	}
+
+	_, err := s.GetTable(t.Context(), source.TableRequest{Name: "nope"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported table")
+}
+
+func TestTableStrategies(t *testing.T) {
+	t.Parallel()
+
+	s := NewCleverTapSource()
+
+	tests := []struct {
+		table       string
+		primaryKeys []string
+		incremental string
+		strategy    config.IncrementalStrategy
+	}{
+		// No unique event id exists, so the loaded window is rewritten wholesale.
+		{"events?event_name=X", nil, "ts", config.StrategyDeleteInsert},
+		// CleverTap cannot report profile edits or deletions, so it is a full rebuild.
+		{"profiles?event_name=X", []string{"object_id"}, "", config.StrategyReplace},
+		// scheduled_on is not a change timestamp, so neither table loads incrementally.
+		{"campaigns", []string{"id"}, "", config.StrategyReplace},
+		{"campaign_reports", []string{"id"}, "", config.StrategyReplace},
+		{"content_blocks", []string{"id"}, "updatedAt", config.StrategyMerge},
+		{"message_reports", []string{"message_id"}, "", config.StrategyReplace},
+		// Catalogs have no date dimension, so each run replaces the snapshot.
+		{"event_schema", []string{"name"}, "", config.StrategyReplace},
+		{"user_properties", []string{"name"}, "", config.StrategyReplace},
+		// Subscription groups are keyed on their numeric id, not their name.
+		{"category_groups", []string{"key"}, "", config.StrategyReplace},
+		// events without an event_name fans out over every discovered event.
+		{"events", nil, "ts", config.StrategyDeleteInsert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.table, func(t *testing.T) {
+			t.Parallel()
+			got, err := s.GetTable(t.Context(), source.TableRequest{Name: tt.table})
+			require.NoError(t, err)
+			require.Equal(t, tt.primaryKeys, got.PrimaryKeys())
+			require.Equal(t, tt.incremental, got.IncrementalKey())
+			require.Equal(t, tt.strategy, got.Strategy())
+		})
+	}
+}
+
+func TestDateRange(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2024, 3, 5, 13, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 4, 1, 6, 0, 0, 0, time.UTC)
+
+	from, to := dateRange(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	require.Equal(t, 20240305, from)
+	require.Equal(t, 20240401, to)
+
+	// With no interval the export still needs bounds: a fixed floor and today.
+	from, to = dateRange(source.ReadOptions{})
+	require.Equal(t, 20130101, from)
+	require.Equal(t, yyyymmdd(time.Now().UTC()), to)
+}
+
+func TestDecodeCursor(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "abc/def+ghi", decodeCursor("abc%2Fdef%2Bghi"))
+	require.Equal(t, "plaincursor", decodeCursor("plaincursor"))
+	// An unescapable value is passed through rather than dropped.
+	require.Equal(t, "bad%zz", decodeCursor("bad%zz"))
+}
+
+func TestLiftProfileObjectID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("top level objectId wins", func(t *testing.T) {
+		t.Parallel()
+		item := liftProfileObjectID(map[string]interface{}{
+			"objectId":     "top-level-id",
+			"platformInfo": []interface{}{map[string]interface{}{"objectId": "device-id"}},
+		})
+		require.Equal(t, "top-level-id", item["object_id"])
+	})
+
+	t.Run("falls back to platformInfo", func(t *testing.T) {
+		t.Parallel()
+		item := liftProfileObjectID(map[string]interface{}{
+			"platformInfo": []interface{}{
+				map[string]interface{}{"platform": "iOS"},
+				map[string]interface{}{"objectId": "device-id"},
+			},
+		})
+		require.Equal(t, "device-id", item["object_id"])
+	})
+
+	t.Run("absent when nothing carries an id", func(t *testing.T) {
+		t.Parallel()
+		item := liftProfileObjectID(map[string]interface{}{"identity": "5555"})
+		_, ok := item["object_id"]
+		require.False(t, ok)
+	})
+}
+
+func TestParseEventTimestamp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("json.Number parsed in UTC", func(t *testing.T) {
+		t.Parallel()
+		got, ok := parseEventTimestamp(json.Number("20260801072952"), time.UTC)
+		require.True(t, ok)
+		require.Equal(t, time.Date(2026, 8, 1, 7, 29, 52, 0, time.UTC), got.UTC())
+	})
+
+	t.Run("project timezone shifts the instant", func(t *testing.T) {
+		t.Parallel()
+		got, ok := parseEventTimestamp(json.Number("20260801072952"), kolkata(t))
+		require.True(t, ok)
+		// 07:29:52 +05:30 is 01:59:52Z.
+		require.Equal(t, time.Date(2026, 8, 1, 1, 59, 52, 0, time.UTC), got.UTC())
+	})
+
+	t.Run("nil location falls back to UTC", func(t *testing.T) {
+		t.Parallel()
+		got, ok := parseEventTimestamp(json.Number("20260801072952"), nil)
+		require.True(t, ok)
+		require.Equal(t, time.Date(2026, 8, 1, 7, 29, 52, 0, time.UTC), got.UTC())
+	})
+
+	t.Run("string form is accepted", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseEventTimestamp("20260801072952", time.UTC)
+		require.True(t, ok)
+	})
+
+	t.Run("unparseable values are rejected, not guessed", func(t *testing.T) {
+		t.Parallel()
+		for _, v := range []interface{}{nil, "", "not-a-timestamp", json.Number("123"), 42} {
+			_, ok := parseEventTimestamp(v, time.UTC)
+			require.False(t, ok, "expected %v to be rejected", v)
+		}
+	})
+}
+
+func TestLiftProfileObjectIDIsDeviceScoped(t *testing.T) {
+	t.Parallel()
+
+	// A person with two devices has two objectIds but only the first becomes the
+	// key, which is why events must join to profiles on identity instead.
+	item := liftProfileObjectID(map[string]interface{}{
+		"identity": "bruin-user-1",
+		"platformInfo": []interface{}{
+			map[string]interface{}{"objectId": "device-a"},
+			map[string]interface{}{"objectId": "device-b"},
+		},
+	})
+	require.Equal(t, "device-a", item["object_id"])
+	require.Equal(t, "bruin-user-1", item["identity"])
+}
+
+func TestIsRequestInProgress(t *testing.T) {
+	t.Parallel()
+
+	// Exports run asynchronously, so an overlapping fetch is refused and retryable.
+	require.True(t, isRequestInProgress("fail", "Request still in progress, please retry later"))
+	require.False(t, isRequestInProgress("fail", "Export not allowed for this event"))
+	require.False(t, isRequestInProgress("success", ""))
+}
+
+func TestHasNoResultYet(t *testing.T) {
+	t.Parallel()
+
+	// Observed live: CleverTap answers 500 here, not the documented 409.
+	require.True(t, hasNoResultYet([]byte(`{"status":"fail","error":"This target has no result as of yet","code":500}`)))
+	require.False(t, hasNoResultYet([]byte(`{"status":"fail","error":"Invalid campaign id","code":400}`)))
+	require.False(t, hasNoResultYet([]byte(`{"status":"success","result":{"sent":82}}`)))
+	require.False(t, hasNoResultYet([]byte(`not json`)))
+
+	// A third variant seen live on a scheduled campaign: HTTP 200, status
+	// "success", an error message and no result. The nil-result check skips it.
+	var page struct {
+		Status string                 `json:"status"`
+		Result map[string]interface{} `json:"result"`
+	}
+	require.NoError(t, jsonUseNumber([]byte(`{"status":"success","error":"This target hasn't been completed","code":200}`), &page))
+	require.Equal(t, "success", page.Status)
+	require.Nil(t, page.Result)
+}
+
+func TestIsExportNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	// CleverTap sends this as a 400, so it must be recognised from the body.
+	require.True(t, isExportNotAllowed([]byte(`{"status":"fail","error":"Export not allowed for this event","code":400}`)))
+	require.False(t, isExportNotAllowed([]byte(`{"status":"fail","error":"Incorrect Usage","code":3}`)))
+	require.False(t, isExportNotAllowed([]byte(`{"status":"success","cursor":"abc"}`)))
+	require.False(t, isExportNotAllowed([]byte(`not json`)))
+}
+
+func TestLiftMessageID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("spaced field is copied to message_id", func(t *testing.T) {
+		t.Parallel()
+		item := liftMessageID(map[string]interface{}{
+			"message id":   json.Number("1457432766"),
+			"message_name": "Welcome",
+		})
+		require.Equal(t, json.Number("1457432766"), item["message_id"])
+		// The original key is preserved so nothing is lost from the payload.
+		require.Equal(t, json.Number("1457432766"), item["message id"])
+	})
+
+	t.Run("absent when the API omits the field", func(t *testing.T) {
+		t.Parallel()
+		item := liftMessageID(map[string]interface{}{"message_name": "Welcome"})
+		_, ok := item["message_id"]
+		require.False(t, ok)
+	})
+}
+
+func TestJSONUseNumber(t *testing.T) {
+	t.Parallel()
+
+	var out map[string]interface{}
+	err := jsonUseNumber([]byte(`{"id":1457432766123456789,"rate":1.5,"name":"x"}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, json.Number("1457432766123456789"), out["id"])
+	require.Equal(t, json.Number("1.5"), out["rate"])
+	require.Equal(t, "x", out["name"])
+
+	require.Error(t, jsonUseNumber([]byte(`{"id":`), &out))
+}

--- a/pkg/source/clevertap/clevertap_test.go
+++ b/pkg/source/clevertap/clevertap_test.go
@@ -1,6 +1,7 @@
 package clevertap
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -252,23 +253,23 @@ func TestTableStrategies(t *testing.T) {
 	}
 }
 
-func TestDateRange(t *testing.T) {
+func TestIntervalBounds(t *testing.T) {
 	t.Parallel()
 
 	start := time.Date(2024, 3, 5, 13, 0, 0, 0, time.UTC)
 	end := time.Date(2024, 4, 1, 6, 0, 0, 0, time.UTC)
 
-	from, to := dateRange(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}, time.UTC)
-	require.Equal(t, 20240305, from)
-	require.Equal(t, 20240401, to)
+	from, to := intervalBounds(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}, time.UTC)
+	require.Equal(t, 20240305, yyyymmdd(from))
+	require.Equal(t, 20240401, yyyymmdd(to))
 
 	// With no interval the export still needs bounds: a fixed floor and today.
-	from, to = dateRange(source.ReadOptions{}, time.UTC)
-	require.Equal(t, 20130101, from)
-	require.Equal(t, yyyymmdd(time.Now().UTC()), to)
+	from, to = intervalBounds(source.ReadOptions{}, time.UTC)
+	require.Equal(t, 20130101, yyyymmdd(from))
+	require.Equal(t, yyyymmdd(time.Now().UTC()), yyyymmdd(to))
 }
 
-func TestDateRangeUsesProjectTimezone(t *testing.T) {
+func TestIntervalBoundsUsesProjectTimezone(t *testing.T) {
 	t.Parallel()
 
 	// 20:00Z on the 6th is already 01:30 on the 7th in Kolkata. CleverTap's days
@@ -278,21 +279,61 @@ func TestDateRangeUsesProjectTimezone(t *testing.T) {
 	end := time.Date(2026, 8, 6, 20, 0, 0, 0, time.UTC)
 	opts := source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}
 
-	from, to := dateRange(opts, kolkata(t))
-	require.Equal(t, 20260806, from)
-	require.Equal(t, 20260807, to)
+	from, to := intervalBounds(opts, kolkata(t))
+	require.Equal(t, 20260806, yyyymmdd(from))
+	require.Equal(t, 20260807, yyyymmdd(to))
 
 	// The same instants in UTC land on the previous day at both ends.
-	from, to = dateRange(opts, time.UTC)
-	require.Equal(t, 20260805, from)
-	require.Equal(t, 20260806, to)
+	from, to = intervalBounds(opts, time.UTC)
+	require.Equal(t, 20260805, yyyymmdd(from))
+	require.Equal(t, 20260806, yyyymmdd(to))
 
 	// A negative offset shifts the other way.
 	ny, err := time.LoadLocation("America/New_York")
 	require.NoError(t, err)
 	midnightUTC := time.Date(2026, 8, 6, 0, 30, 0, 0, time.UTC)
-	from, _ = dateRange(source.ReadOptions{IntervalStart: &midnightUTC}, ny)
-	require.Equal(t, 20260805, from)
+	from, _ = intervalBounds(source.ReadOptions{IntervalStart: &midnightUTC}, ny)
+	require.Equal(t, 20260805, yyyymmdd(from))
+}
+
+func TestForEachDateWindow(t *testing.T) {
+	t.Parallel()
+
+	collect := func(start, end time.Time, days int) [][2]int {
+		var got [][2]int
+		require.NoError(t, forEachDateWindow(context.Background(), start, end, days, func(from, to int) error {
+			got = append(got, [2]int{from, to})
+			return nil
+		}))
+		return got
+	}
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// The last window is clamped to the end rather than running past it.
+	require.Equal(t, [][2]int{{20240101, 20240110}, {20240111, 20240115}},
+		collect(start, start.AddDate(0, 0, 14), 10))
+
+	// Windows are contiguous and never overlap, so nothing is fetched twice.
+	windows := collect(start, start.AddDate(0, 0, 29), 10)
+	require.Len(t, windows, 3)
+	for i := 1; i < len(windows); i++ {
+		require.Greater(t, windows[i][0], windows[i-1][1])
+	}
+
+	// A range shorter than one window still yields exactly one.
+	require.Equal(t, [][2]int{{20240101, 20240101}}, collect(start, start, 365))
+
+	// An end before the start yields nothing at all.
+	require.Empty(t, collect(start, start.AddDate(0, 0, -1), 10))
+
+	// Cancellation stops the walk instead of running every window.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, forEachDateWindow(ctx, start, start.AddDate(10, 0, 0), 1, func(int, int) error {
+		t.Fatal("window ran after cancellation")
+		return nil
+	}), context.Canceled)
 }
 
 func TestDecodeCursor(t *testing.T) {

--- a/pkg/source/clevertap/register.go
+++ b/pkg/source/clevertap/register.go
@@ -1,0 +1,10 @@
+package clevertap
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"clevertap"},
+		func() interface{} { return NewCleverTapSource() },
+	)
+}


### PR DESCRIPTION
Adds [CleverTap](https://clevertap.com/) as a source — customer engagement and retention analytics for mobile and web apps, same category as the existing `braze` and `customerio` sources.

## Tables

| Table | PK | Inc Key | Strategy |
| --- | --- | --- | --- |
| `events` | – | `ts` | delete+insert |
| `profiles` | `object_id` | – | replace |
| `campaigns` | `id` | – | replace |
| `campaign_reports` | `id` | – | replace |
| `content_blocks` | `id` | `updatedAt` | merge |
| `message_reports` | `message_id` | – | replace |
| `event_schema` | `name` | – | replace |
| `user_properties` | `name` | – | replace |
| `category_groups` | `key` | – | replace |