### PR TITLE
docs: remove dlt references and correct s3/gcs output structure

### DIFF
--- a/docs/supported-sources/clickhouse.md
+++ b/docs/supported-sources/clickhouse.md
@@ -74,9 +74,6 @@ ingestr ingest \
 ```
 
 
-<!-- 
-    see https://github.com/dlt-hub/dlt/issues/2248
--->
 > [!WARNING]
 > ingestr does not use ClickHouse transactions. ClickHouse `delete+insert` is supported as a best-effort two-step operation: ingestr runs `ALTER TABLE ... DELETE`, waits for the mutation to finish, and then inserts rows from the staging table. This is not a single atomic transaction.
 

--- a/docs/supported-sources/cratedb.md
+++ b/docs/supported-sources/cratedb.md
@@ -128,7 +128,7 @@ docker run --rm -it --name=cratedb \
 ```
 
 We are tracking development progress and incompatibilities at 
-[Support for ingestr/CrateDB]. Please join the discussion
+[Support for ingestr/CrateDB] and [CrateDB ingestr issues]. Please join the discussion
 or share relevant issue reports that help us improve interoperability. Thanks!
 
 
@@ -136,3 +136,4 @@ or share relevant issue reports that help us improve interoperability. Thanks!
 [CrateDB Cloud]: https://console.cratedb.cloud/
 [PostgreSQL SSL Mode Descriptions]: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
 [Support for ingestr/CrateDB]: https://github.com/crate/crate-clients-tools/issues/86
+[CrateDB ingestr issues]: https://github.com/crate/crate/issues?q=state%3Aopen%20label%3A%22tool%3A%20dlt%2Fingestr%22

--- a/docs/supported-sources/cratedb.md
+++ b/docs/supported-sources/cratedb.md
@@ -128,7 +128,7 @@ docker run --rm -it --name=cratedb \
 ```
 
 We are tracking development progress and incompatibilities at 
-[Support for ingestr/CrateDB] and ["tool: dlt/ingestr"]. Please join the discussion
+[Support for ingestr/CrateDB]. Please join the discussion
 or share relevant issue reports that help us improve interoperability. Thanks!
 
 
@@ -136,4 +136,3 @@ or share relevant issue reports that help us improve interoperability. Thanks!
 [CrateDB Cloud]: https://console.cratedb.cloud/
 [PostgreSQL SSL Mode Descriptions]: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
 [Support for ingestr/CrateDB]: https://github.com/crate/crate-clients-tools/issues/86
-["tool: dlt/ingestr"]: https://github.com/crate/crate/issues?q=state%3Aopen%20label%3A%22tool%3A%20dlt%2Fingestr%22

--- a/docs/supported-sources/gcs.md
+++ b/docs/supported-sources/gcs.md
@@ -71,16 +71,12 @@ This will result in a file structure like the following:
 ```
 my-org-bucket/
 └── records
-    ├── _dlt_loads
-    ├── _dlt_pipeline_state
-    ├── _dlt_version
-    └── users
-        └── <load_id>.<file_id>.parquet
+    └── <load_id>.<file_id>.parquet
 ```
 
-The value of `load_id` and `file_id` is determined at runtime. The default layout creates a folder with the same table name as the source and places the data inside a parquet file. This layout is configurable using the `layout` parameter.
+The value of `load_id` and `file_id` is determined at runtime. The default layout writes the data as one or more parquet files named `<load_id>.<file_id>.parquet` under the destination path. This layout is configurable using the `layout` parameter.
 
-For example, if you would like to create a parquet file with the same name as the source table (as opposed to a folder) you can set `layout` to `{table_name}.{ext}` in the command line above:
+For example, if you would like to write a parquet file named after the destination table instead, you can set `layout` to `{table_name}.{ext}` in the command line above:
 
 ```sh
 ingestr ingest \
@@ -94,10 +90,7 @@ Result:
 ```
 my-org-bucket/
 └── records
-    ├── _dlt_loads
-    ├── _dlt_pipeline_state
-    ├── _dlt_version
-    └── users.parquet
+    └── records.parquet
 ```
 
 ### Available Layout Placeholders

--- a/docs/supported-sources/s3.md
+++ b/docs/supported-sources/s3.md
@@ -125,16 +125,12 @@ This will result in a file structure like the following:
 ```
 my_bucket/
 └── records
-    ├── _dlt_loads
-    ├── _dlt_pipeline_state
-    ├── _dlt_version
-    └── users
-        └── <load_id>.<file_id>.parquet
+    └── <load_id>.<file_id>.parquet
 ```
 
-The value of `load_id` and `file_id` is determined at runtime. The default layout creates a folder with the same table name as the source and places the data inside a parquet file. This layout is configurable using the `layout` parameter.
+The value of `load_id` and `file_id` is determined at runtime. The default layout writes the data as one or more parquet files named `<load_id>.<file_id>.parquet` under the destination path. This layout is configurable using the `layout` parameter.
 
-For example, if you would like to create a parquet file with the same name as the source table (as opposed to a folder) you can set `layout` to `{table_name}.{ext}` in the commandline above:
+For example, if you would like to write a parquet file named after the destination table instead, you can set `layout` to `{table_name}.{ext}` in the commandline above:
 
 ```sh
 ingestr ingest \
@@ -148,10 +144,7 @@ Result:
 ```
 my_bucket/
 └── records
-    ├── _dlt_loads
-    ├── _dlt_pipeline_state
-    ├── _dlt_version
-    └── users.parquet
+    └── records.parquet
 ```
 
 ### Available Layout Placeholders


### PR DESCRIPTION
## What

Removes leftover references from the docs and corrects the S3/GCS destination output examples to match what ingestr actually writes today.