### PR TITLE
fix(oracle): UTC-anchor delete+insert bounds for temporal keys

### DIFF
--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -671,14 +671,42 @@ func (d *OracleDestination) DeleteInsertTable(ctx context.Context, opts destinat
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE %s >= :1 AND %s <= :2",
-		quoteTable(opts.TargetTable),
-		quoteColumn(opts.IncrementalKey),
-		quoteColumn(opts.IncrementalKey),
-	)
+	key := quoteColumn(opts.IncrementalKey)
+	// Emit UTC-anchored literals for temporal keys so the DELETE window ignores the
+	// go-ora process timezone and session NLS_DATE_FORMAT (BRU-5586).
+	bound := func(v interface{}) (string, bool) {
+		if p, ok := v.(*time.Time); ok && p != nil {
+			v = *p
+		}
+		switch opts.IncrementalKeyType {
+		case schema.TypeDate:
+			if s, ok := v.(string); ok {
+				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", s), true
+			}
+			if t, ok := v.(time.Time); ok {
+				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", t.UTC().Format("2006-01-02")), true
+			}
+		case schema.TypeTimestamp:
+			if t, ok := v.(time.Time); ok {
+				return fmt.Sprintf("TO_TIMESTAMP('%s', 'YYYY-MM-DD HH24:MI:SS.FF6')", t.UTC().Format("2006-01-02 15:04:05.000000")), true
+			}
+		case schema.TypeTimestampTZ:
+			if t, ok := v.(time.Time); ok {
+				return fmt.Sprintf("TO_TIMESTAMP_TZ('%s', 'YYYY-MM-DD HH24:MI:SS.FF6 TZHTZM')", t.UTC().Format("2006-01-02 15:04:05.000000 -0700")), true
+			}
+		}
+		return "", false
+	}
+	deleteSQL := fmt.Sprintf("DELETE FROM %s WHERE %s >= :1 AND %s <= :2", quoteTable(opts.TargetTable), key, key)
+	deleteArgs := []interface{}{opts.IntervalStart, opts.IntervalEnd}
+	if start, ok := bound(opts.IntervalStart); ok {
+		if end, ok := bound(opts.IntervalEnd); ok {
+			deleteSQL = fmt.Sprintf("DELETE FROM %s WHERE %s >= %s AND %s <= %s", quoteTable(opts.TargetTable), key, start, key, end)
+			deleteArgs = nil
+		}
+	}
 	config.Debug("[DELETE+INSERT] Executing DELETE: %s", deleteSQL)
-	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
+	if _, err := tx.ExecContext(ctx, deleteSQL, deleteArgs...); err != nil {
 		config.LogFailedQuery(deleteSQL, err)
 		return fmt.Errorf("failed to delete records: %w", err)
 	}

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -681,10 +681,14 @@ func (d *OracleDestination) DeleteInsertTable(ctx context.Context, opts destinat
 		switch opts.IncrementalKeyType {
 		case schema.TypeDate:
 			if s, ok := v.(string); ok {
+				if _, err := time.Parse("2006-01-02", s); err != nil {
+					return "", false
+				}
 				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", s), true
 			}
 			if t, ok := v.(time.Time); ok {
-				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", t.UTC().Format("2006-01-02")), true
+				// Date bounds carry a wall date, not an instant; match toDateOnly semantics.
+				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", t.Format("2006-01-02")), true
 			}
 		case schema.TypeTimestamp:
 			if t, ok := v.(time.Time); ok {

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -686,10 +686,6 @@ func (d *OracleDestination) DeleteInsertTable(ctx context.Context, opts destinat
 				}
 				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", s), true
 			}
-			if t, ok := v.(time.Time); ok {
-				// Date bounds carry a wall date, not an instant; match toDateOnly semantics.
-				return fmt.Sprintf("TO_DATE('%s', 'YYYY-MM-DD')", t.Format("2006-01-02")), true
-			}
 		case schema.TypeTimestamp:
 			if t, ok := v.(time.Time); ok {
 				return fmt.Sprintf("TO_TIMESTAMP('%s', 'YYYY-MM-DD HH24:MI:SS.FF6')", t.UTC().Format("2006-01-02 15:04:05.000000")), true

--- a/pkg/strategy/delete_insert_date_bound_test.go
+++ b/pkg/strategy/delete_insert_date_bound_test.go
@@ -1,0 +1,22 @@
+package strategy
+
+import (
+	"testing"
+	"time"
+)
+
+// TestToDateOnlyStringifiesDateBounds pins the invariant the Oracle delete+insert DATE path
+// relies on: DATE bounds reach destinations as YYYY-MM-DD strings, not time.Time (BRU-5586).
+func TestToDateOnlyStringifiesDateBounds(t *testing.T) {
+	ts := time.Date(2026, 8, 5, 13, 30, 0, 0, time.UTC)
+	for _, in := range []interface{}{ts, &ts} {
+		got := toDateOnly(in)
+		s, ok := got.(string)
+		if !ok {
+			t.Fatalf("toDateOnly(%T) = %T, want string; Oracle DeleteInsertTable emits a TO_DATE literal only for string DATE bounds and otherwise falls back to bare binds (ORA-01861)", in, got)
+		}
+		if s != "2026-08-05" {
+			t.Fatalf("toDateOnly(%T) = %q, want 2026-08-05", in, s)
+		}
+	}
+}

--- a/tests/integration/oracle_delete_insert_tz_test.go
+++ b/tests/integration/oracle_delete_insert_tz_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc"
+	_ "github.com/sijms/go-ora/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOracleDeleteInsertTimezoneAndDateBounds is the BRU-5586 regression: delete+insert
+// must stay idempotent under a non-UTC process timezone for DATE/TIMESTAMP/TIMESTAMPTZ keys.
+func TestOracleDeleteInsertTimezoneAndDateBounds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if oracleDest.uri == "" {
+		t.Skip("shared oracle destination container not available")
+	}
+
+	ist, err := time.LoadLocation("Europe/Istanbul")
+	require.NoError(t, err)
+	prevLocal := time.Local
+	time.Local = ist
+	t.Cleanup(func() { time.Local = prevLocal })
+
+	ctx := t.Context()
+	db, err := sql.Open("oracle", oracleSQLConnString(oracleDest.uri))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	cases := []struct {
+		name       string
+		columnType string
+		values     []string
+	}{
+		{"date", "DATE", []string{"DATE '2026-08-05'", "DATE '2026-08-05'", "DATE '2026-08-05'"}},
+		{"timestamp", "TIMESTAMP", []string{"TIMESTAMP '2026-08-05 00:00:00'", "TIMESTAMP '2026-08-05 12:00:00'", "TIMESTAMP '2026-08-05 23:00:00'"}},
+		{"timestamptz", "TIMESTAMPTZ", []string{"TIMESTAMPTZ '2026-08-05 00:00:00+00'", "TIMESTAMPTZ '2026-08-05 12:00:00+00'", "TIMESTAMPTZ '2026-08-05 23:00:00+00'"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srcPath := filepath.Join(t.TempDir(), "src.duckdb")
+			srcDB, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", srcPath))
+			require.NoError(t, err)
+			execDuckDB(t, srcDB, fmt.Sprintf("CREATE TABLE events (id INTEGER, event_key %s, name VARCHAR)", tc.columnType))
+			for i, v := range tc.values {
+				execDuckDB(t, srcDB, fmt.Sprintf("INSERT INTO events VALUES (%d, %s, 'r%d')", i+1, v, i+1))
+			}
+			require.NoError(t, srcDB.Close())
+
+			table := "DI_TZ_" + tc.name + "_" + uniqueSuffix()
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE %s PURGE", quoteTableOracle(table)))
+			})
+
+			cfg := &config.IngestConfig{
+				SourceURI:           fmt.Sprintf("duckdb:///%s", srcPath),
+				SourceTable:         "events",
+				DestURI:             oracleDest.uri,
+				DestTable:           table,
+				IncrementalStrategy: config.StrategyDeleteInsert,
+				IncrementalKey:      "event_key",
+			}
+
+			require.NoError(t, pipeline.New(cfg).Run(ctx), "first run should succeed")
+			require.Equal(t, 3, oracleTableRowCount(t, db, table), "row count after first run")
+
+			require.NoError(t, pipeline.New(cfg).Run(ctx), "second run should succeed")
+			require.Equal(t, 3, oracleTableRowCount(t, db, table), "row count after second run (idempotent)")
+		})
+	}
+}
+
+func execDuckDB(t *testing.T, db *sql.DB, query string) {
+	t.Helper()
+	rows, err := db.Query(query)
+	require.NoError(t, err)
+	require.NoError(t, rows.Close())
+}
+
+func oracleTableRowCount(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteTableOracle(table))).Scan(&n))
+	return n
+}


### PR DESCRIPTION
## Summary

Fixes two pre-existing `delete+insert` defects on the **Oracle** destination (BRU-5586). Both stem from `OracleDestination.DeleteInsertTable` binding the incremental interval as bare params, which lets the go-ora process timezone and the session `NLS_DATE_FORMAT` distort the DELETE window.

- **`DATE` keys hard-failed** on the first run with `ORA-01861: literal does not match format string` — the date-only string bound (`2026-08-05`) was implicitly cast using the session `NLS_DATE_FORMAT` (default `DD-MON-RR`), not ISO `YYYY-MM-DD`. The ingest never completed.
- **naive `TIMESTAMP` / `TIMESTAMPTZ` keys** had the delete window shifted by the process-local UTC offset, so under a non-UTC `TZ` boundary rows survived the DELETE and were re-inserted every run — silent duplicates on positive offsets, data loss on negative offsets.

## Fix

Emit **UTC-anchored SQL literals** (`TO_DATE` / `TO_TIMESTAMP` / `TO_TIMESTAMP_TZ`) for temporal incremental keys, mirroring the BigQuery/Snowflake/ClickHouse paths. Non-temporal keys (integer/string) keep the existing `:1`/`:2` bind params unchanged.

## Compatibility

- Only `OracleDestination.DeleteInsertTable` changes; no other strategy or destination is touched.
- Non-temporal keys execute byte-for-byte identical SQL.
- Temporal keys under UTC produce the same window as before; the only behavioral changes are where the old code was already broken (DATE failure, non-UTC dupes/loss).

## Testing

Verified live against Oracle Free in Docker across all three key types:

| key type | TZ | before | after |
| -- | -- | -- | -- |
| `DATE` | any | `ORA-01861` ❌ | 3 → 3 ✅ |
| `TIMESTAMP` | `Europe/Istanbul` | 3 → 4 ❌ | 3 → 3 ✅ |
| `TIMESTAMP` | `UTC` | 3 → 3 ✅ | 3 → 3 ✅ |
| `TIMESTAMPTZ` | `Europe/Istanbul` | (broken class) | 3 → 3 ✅ |

Adds `TestOracleDeleteInsertTimezoneAndDateBounds` — runs `delete+insert` twice under `TZ=Europe/Istanbul` across `DATE`/`TIMESTAMP`/`TIMESTAMPTZ` and asserts idempotency. Confirmed it fails on the pre-fix code (DATE → `ORA-01861`, TIMESTAMP → count drift) and passes with the fix.