### PR TITLE
Run Docker-free integration tests on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,14 @@ jobs:
           - depot-ubuntu-24.04-4
           - depot-macos-15
         suite: ["test-full", "test-integration"]
+        exclude:
+          # macOS runners have no Docker/testcontainers, so test-integration only
+          # self-skips there. Run the Docker-free subset instead (see include).
+          - platform: depot-macos-15
+            suite: test-integration
+        include:
+          - platform: depot-macos-15
+            suite: test-integration-nodocker
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,16 @@ jobs:
       TEST_CONCURRENCY: "1"
     strategy:
       matrix:
-        platform:
-          - depot-ubuntu-24.04-4
-          - depot-macos-15
-        suite: ["test-full", "test-integration"]
-        exclude:
-          # macOS runners have no Docker/testcontainers, so test-integration only
-          # self-skips there. Run the Docker-free subset instead (see include).
-          - platform: depot-macos-15
-            suite: test-integration
+        # Each platform/suite combination is listed explicitly. macOS runners
+        # have no Docker/testcontainers, so they run test-integration-nodocker
+        # (the full test-integration suite would only self-skip there).
         include:
+          - platform: depot-ubuntu-24.04-4
+            suite: test-full
+          - platform: depot-ubuntu-24.04-4
+            suite: test-integration
+          - platform: depot-macos-15
+            suite: test-full
           - platform: depot-macos-15
             suite: test-integration-nodocker
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,18 @@ jobs:
       - name: Run integration tests
         run: make test-integration
 
+  macos-integration-nodocker:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: "go.sum"
+      - name: Run Docker-free integration tests
+        run: make test-integration-nodocker
+
   cdc-stress:
     name: ${{ matrix.name }}
     runs-on: depot-ubuntu-24.04-4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,18 +81,6 @@ jobs:
       - name: Run integration tests
         run: make test-integration
 
-  macos-integration-nodocker:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: 'go.mod'
-          cache-dependency-path: "go.sum"
-      - name: Run Docker-free integration tests
-        run: make test-integration-nodocker
-
   cdc-stress:
     name: ${{ matrix.name }}
     runs-on: depot-ubuntu-24.04-4

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,14 @@ test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
 	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -tags integration -v -p 64 -parallel 8 -timeout 20m ./tests/integration/...
 
+# Subset of integration tests that need no Docker/containers (file-based:
+# sqlite/duckdb/csv/parquet/local-fs iceberg). Runs anywhere, incl. macOS CI.
+test-integration-nodocker: generate
+	@echo "$(OK_COLOR)==> Running Docker-free integration tests$(NO_COLOR)"
+	@INTEGRATION_BACKENDS=none go test -tags integration -v -p 64 -parallel 8 -timeout 15m \
+		-run '^(TestDestinations_|TestColumn|TestStaging_|TestIceberg|TestCustomQuery_|TestDeleteInsert|TestSnakeCase|TestDirectNaming|TestInvalidSchemaNaming|TestDuckDB|TestProgressJSON|TestChessSource|TestAppLovin|TestPostgresCDC_URISchemes)' \
+		-skip '^TestIcebergCatalogBackends$$' ./tests/integration/...
+
 # The CDC stress tests share one harness: a queue-based load generator that
 # tracks the target ops/sec (STRESS_OPS_PER_SEC, default 1000) as closely as
 # the source engine allows, parallel ingestion into PostgreSQL and DuckDB

--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,13 @@ test-integration: generate
 	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
 	@if [ -f test.env ]; then . ./test.env; fi && $(TEST_ENV) go test -tags integration -v -p 64 -parallel 8 -timeout 20m ./tests/integration/...
 
-# Subset of integration tests that need no Docker/containers (file-based:
-# sqlite/duckdb/csv/parquet/local-fs iceberg). Runs anywhere, incl. macOS CI.
+# Integration tests that need no Docker: container-backed tests skip themselves
+# when no Docker provider is available (see requireDocker), leaving the
+# file-based tests (sqlite/duckdb/csv/parquet/local-fs iceberg). Runs anywhere,
+# including macOS CI where Docker/testcontainers is unavailable.
 test-integration-nodocker: generate
 	@echo "$(OK_COLOR)==> Running Docker-free integration tests$(NO_COLOR)"
-	@INTEGRATION_BACKENDS=none go test -tags integration -v -p 64 -parallel 8 -timeout 15m \
-		-run '^(TestDestinations_|TestColumn|TestStaging_|TestIceberg|TestCustomQuery_|TestDeleteInsert|TestSnakeCase|TestDirectNaming|TestInvalidSchemaNaming|TestDuckDB|TestProgressJSON|TestChessSource|TestAppLovin|TestPostgresCDC_URISchemes)' \
-		-skip '^TestIcebergCatalogBackends$$' ./tests/integration/...
+	@INTEGRATION_BACKENDS=none go test -tags integration -v -p 64 -parallel 8 -timeout 15m ./tests/integration/...
 
 # The CDC stress tests share one harness: a queue-based load generator that
 # tracks the target ops/sec (STRESS_OPS_PER_SEC, default 1000) as closely as

--- a/tests/integration/iceberg_destination_test.go
+++ b/tests/integration/iceberg_destination_test.go
@@ -40,6 +40,7 @@ type icebergCatalogTestEnv struct {
 }
 
 func TestIcebergCatalogBackends(t *testing.T) {
+	requireDocker(t)
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -409,6 +410,7 @@ func dockerSharedTempDir(t *testing.T, prefix string) string {
 }
 
 func startIcebergRESTContainer(t *testing.T, ctx context.Context, warehouse string) string {
+	requireDocker(t)
 	t.Helper()
 
 	req := testcontainers.ContainerRequest{
@@ -446,6 +448,7 @@ func startIcebergRESTContainer(t *testing.T, ctx context.Context, warehouse stri
 }
 
 func startIcebergRESTContainerWithS3(t *testing.T, ctx context.Context, networkName, bucket string) string {
+	requireDocker(t)
 	t.Helper()
 
 	req := testcontainers.ContainerRequest{
@@ -490,6 +493,7 @@ func startIcebergRESTContainerWithS3(t *testing.T, ctx context.Context, networkN
 }
 
 func startIcebergMinioContainer(t *testing.T, ctx context.Context, networkName string) (testcontainers.Container, string) {
+	requireDocker(t)
 	t.Helper()
 
 	req := testcontainers.ContainerRequest{

--- a/tests/integration/mongodb_cdc_test.go
+++ b/tests/integration/mongodb_cdc_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func setupMongoDBCDCContainer(t *testing.T, ctx context.Context) (*tcmongo.MongoDBContainer, string) {
+	requireDocker(t)
 	t.Helper()
 
 	container, err := tcmongo.Run(

--- a/tests/integration/mongodb_evolution_test.go
+++ b/tests/integration/mongodb_evolution_test.go
@@ -30,6 +30,7 @@ import (
 //  4. Numeric promotion int → float across batches (final type: float)
 //  5. Mixed types within a single batch (typed builder promotes to unknown)
 func TestMongoDB_SchemaEvolution_EndToEnd(t *testing.T) {
+	requireDocker(t)
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -229,6 +230,7 @@ func TestMongoDB_SchemaEvolution_EndToEnd(t *testing.T) {
 }
 
 func TestMongoDB_NumericExtractPartitioning_EndToEnd(t *testing.T) {
+	requireDocker(t)
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/tests/integration/mysql_cdc_test.go
+++ b/tests/integration/mysql_cdc_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func setupMySQLCDCContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string) {
+	requireDocker(t)
 	t.Helper()
 
 	container, err := tcmysql.Run(

--- a/tests/integration/postgres_cdc_binary_test.go
+++ b/tests/integration/postgres_cdc_binary_test.go
@@ -183,6 +183,7 @@ func TestPostgresCDC_BinaryModeParity(t *testing.T) {
 // a large committed transaction lands exactly and a rolled-back one leaves no
 // trace, while the server reports that streaming actually happened.
 func TestPostgresCDC_LargeTransactionStreaming(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	ctx := context.Background()
 

--- a/tests/integration/postgres_cdc_keepalive_test.go
+++ b/tests/integration/postgres_cdc_keepalive_test.go
@@ -93,6 +93,7 @@ func init() {
 // that lets the test override wal_sender_timeout, which is what triggers the
 // regression scenario (destination-write phase outlasting the timeout).
 func setupPostgresCDCContainerWithTimeout(t *testing.T, ctx context.Context, walSenderTimeout string) (testcontainers.Container, string) {
+	requireDocker(t)
 	t.Helper()
 	req := testcontainers.ContainerRequest{
 		Image: "postgres:16-alpine",

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -31,6 +31,7 @@ import (
 
 // setupPostgresCDCContainer creates a PostgreSQL container configured for logical replication
 func setupPostgresCDCContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string) {
+	requireDocker(t)
 	req := testcontainers.ContainerRequest{
 		Image: "postgres:16-alpine",
 		Env: map[string]string{

--- a/tests/integration/starrocks_container_test.go
+++ b/tests/integration/starrocks_container_test.go
@@ -24,6 +24,7 @@ import (
 // Runs as part of `make test-integration`. The all-in-one image is slow to boot,
 // so this test manages its own container instead of the shared TestMain.
 func startStarRocksContainer(ctx context.Context, t *testing.T) (dsn, uri string) {
+	requireDocker(t)
 	t.Helper()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{

--- a/tests/integration/streaming_kafka_test.go
+++ b/tests/integration/streaming_kafka_test.go
@@ -29,6 +29,7 @@ import (
 // msg_id+data envelope, offsets are committed only after a flush (a second run
 // in the same group reads nothing new), and the stream exits on cancellation.
 func TestKafka_Streaming(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/tests/integration/streaming_platform_sources_test.go
+++ b/tests/integration/streaming_platform_sources_test.go
@@ -246,6 +246,7 @@ func TestPulsar_Streaming(t *testing.T) {
 }
 
 func startRedisContainer(t *testing.T, ctx context.Context) string {
+	requireDocker(t)
 	t.Helper()
 	req := testcontainers.ContainerRequest{
 		Image:        "redis:7-alpine",
@@ -304,6 +305,7 @@ func seedRedisPending(t *testing.T, ctx context.Context, client *goredis.Client,
 }
 
 func startNATSContainer(t *testing.T, ctx context.Context) string {
+	requireDocker(t)
 	t.Helper()
 	req := testcontainers.ContainerRequest{
 		Image:        "nats:2.10-alpine",
@@ -363,6 +365,7 @@ func publishNATSMessages(t *testing.T, js natsgo.JetStreamContext, subject strin
 }
 
 func startPulsarContainer(t *testing.T, ctx context.Context) (string, testcontainers.Container) {
+	requireDocker(t)
 	t.Helper()
 	req := testcontainers.ContainerRequest{
 		Image:        "apachepulsar/pulsar:3.3.0",

--- a/tests/integration/streaming_tier1_test.go
+++ b/tests/integration/streaming_tier1_test.go
@@ -148,6 +148,7 @@ func TestKinesis_Streaming(t *testing.T) {
 }
 
 func TestPubSub_Streaming(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -200,6 +201,7 @@ func TestPubSub_Streaming(t *testing.T) {
 }
 
 func startLocalStackContainer(t *testing.T, ctx context.Context) string {
+	requireDocker(t)
 	t.Helper()
 	req := testcontainers.ContainerRequest{
 		Image:        "localstack/localstack:3.8.1",

--- a/tests/integration/testenv_postgres_test.go
+++ b/tests/integration/testenv_postgres_test.go
@@ -34,6 +34,16 @@ func containerWanted(name string) bool {
 	return false
 }
 
+// requireDocker skips the test when no Docker provider is available. This lets
+// the container-backed integration tests be excluded simply by running without
+// Docker (e.g. on macOS CI), while file-based tests still run.
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if !testutil.DockerProviderHealthy(context.Background()) {
+		t.Skip("requires Docker; Docker provider not available")
+	}
+}
+
 // anyContainerWanted reports whether any container-backed backend is requested.
 func anyContainerWanted() bool {
 	for _, name := range containerBackends {

--- a/tests/integration/vitess_cdc_batch_test.go
+++ b/tests/integration/vitess_cdc_batch_test.go
@@ -33,6 +33,7 @@ type vitessCDCEnv struct {
 // startVitessCDCEnv boots a vttestserver with the given shard count and waits
 // until vtgate serves queries.
 func startVitessCDCEnv(t *testing.T, ctx context.Context, numShards string) *vitessCDCEnv {
+	requireDocker(t)
 	t.Helper()
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/tests/integration/vitess_cdc_test.go
+++ b/tests/integration/vitess_cdc_test.go
@@ -78,6 +78,7 @@ func startVitessCDCContainer(ctx context.Context) (testcontainers.Container, str
 // (VStream) performs a consistent copy-phase snapshot and then captures
 // INSERT/UPDATE/DELETE changes on a re-run, resuming from the stored VGTID.
 func TestVitessCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -158,6 +159,7 @@ func TestVitessCDC_SnapshotAndIncremental_DuckDB(t *testing.T) {
 }
 
 func TestVitessCDC_Streaming_Postgres(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/tests/integration/vitess_container_test.go
+++ b/tests/integration/vitess_container_test.go
@@ -72,6 +72,7 @@ func startVitessContainer(ctx context.Context) (testcontainers.Container, string
 // read is rejected by that cap, then verifies ingestr reads every row (only
 // possible because the Vitess source enables the OLAP workload).
 func TestVitessSourceReadsBeyondRowCap(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -118,6 +119,7 @@ func TestVitessSourceReadsBeyondRowCap(t *testing.T) {
 // pointing the user at the dedicated vitess:// scheme rather than silently
 // misbehaving (e.g. hitting the OLTP row cap).
 func TestMySQLSchemeRejectsVitess(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/tests/integration/vitess_destination_test.go
+++ b/tests/integration/vitess_destination_test.go
@@ -24,6 +24,7 @@ const shardedVitessKeyspace = "shardedks"
 // target keyspace, since _bruin_staging can't be auto-created on Vitess) + the RENAME
 // swap; the follow-up merge load exercises the UPDATE...JOIN + INSERT...NOT EXISTS path.
 func TestVitessDestination_ReplaceAndMerge(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -78,6 +79,7 @@ func TestVitessDestination_ReplaceAndMerge(t *testing.T) {
 // connect and rejected with a clear error, rather than surfacing a cryptic vtgate error
 // partway through a run.
 func TestVitessDestination_ShardedRejected(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
## What
Adds a `test-integration-nodocker` make target and a `macos-integration-nodocker` CI job (GitHub-hosted `macos-15`) that runs the subset of integration tests needing **no Docker/containers**.

## Why
macOS runners (Depot or GitHub-hosted, Apple Silicon) can't run Docker/testcontainers — no nested virtualization — so the full `test-integration` suite only ever self-skips there. This gives macOS real, fast integration coverage of the file-based paths (sqlite/duckdb/csv/parquet/local-fs iceberg) while the container-backed suite stays on Linux.

## How
- New `requireDocker(t)` helper: skips a test when no Docker provider is available.
- Called at the container-start choke points (CDC / Vitess / streaming / StarRocks / iceberg-container) and the few tests that start containers inline.
- Result: with Docker absent, container tests **skip** instead of failing; the target is simply `INTEGRATION_BACKENDS=none go test ...` with **no test-name filter**, and it auto-adapts to new tests.