### PR TITLE
style: fix gofumpt/gci formatting drift

### DIFF
--- a/pkg/destination/onelake/delta_io.go
+++ b/pkg/destination/onelake/delta_io.go
@@ -329,7 +329,8 @@ func unifyRewriteBatches(target, staging []arrow.RecordBatch, declared *deltaStr
 	if declared != nil {
 		if missing, ok := columnsNotIn(staging[0].Schema(), deltaFieldNames(declared)); !ok {
 			return nil, nil, noop, fmt.Errorf(
-				"cannot rewrite the table: column %q is not declared in its Delta schema (declared columns are %v)", missing, deltaFieldNames(declared))
+				"cannot rewrite the table: column %q is not declared in its Delta schema (declared columns are %v)", missing, deltaFieldNames(declared),
+			)
 		}
 	}
 	if len(target) == 0 {
@@ -394,7 +395,8 @@ func unifiedRewriteSchema(target, staging []arrow.RecordBatch, declared *deltaSt
 			// not "evolve" — filling it would break that declaration.
 			if !field.Nullable {
 				return nil, fmt.Errorf(
-					"cannot rewrite the table: column %q is required but the incoming rows do not have it", field.Name)
+					"cannot rewrite the table: column %q is required but the incoming rows do not have it", field.Name,
+				)
 			}
 			fields[i] = field
 			continue

--- a/pkg/source/stripe/governor.go
+++ b/pkg/source/stripe/governor.go
@@ -250,7 +250,8 @@ func (g *requestGovernor) observeRateLimit(path string, err error) {
 		return
 	}
 
-	config.Debug("[STRIPE] Governor adjusted after %s on %s (global %.1f req/s, endpoint %.1f req/s, global concurrency %d, endpoint concurrency %d)",
+	config.Debug(
+		"[STRIPE] Governor adjusted after %s on %s (global %.1f req/s, endpoint %.1f req/s, global concurrency %d, endpoint concurrency %d)",
 		reason,
 		endpointPath,
 		g.globalRate.limit(),

--- a/pkg/source/stripe/stripe.go
+++ b/pkg/source/stripe/stripe.go
@@ -129,7 +129,8 @@ func (s *StripeSource) Close(ctx context.Context) error {
 	if s.governor != nil {
 		config.Debug("[STRIPE] Request governor: %s", s.governor.stats())
 		for _, endpoint := range s.governor.endpointStats() {
-			config.Debug("[STRIPE] Endpoint %s: %d requests, %d errors, %d rate-limited, %d waits totaling %s, average API time %s",
+			config.Debug(
+				"[STRIPE] Endpoint %s: %d requests, %d errors, %d rate-limited, %d waits totaling %s, average API time %s",
 				endpoint.path,
 				endpoint.requests,
 				endpoint.errors,

--- a/tests/integration/elasticsearch_test.go
+++ b/tests/integration/elasticsearch_test.go
@@ -79,7 +79,8 @@ func TestElasticsearchDestinationReplace(t *testing.T) {
 	index := "destination_users_" + uniqueSuffix()
 	t.Cleanup(func() { deleteElasticsearchIndex(t, context.Background(), index) })
 
-	initialPath := writeElasticsearchJSONL(t, "initial.jsonl",
+	initialPath := writeElasticsearchJSONL(
+		t, "initial.jsonl",
 		`{"id":"user-1","name":"Alice","score":10,"active":true}`,
 		`{"id":"user-2","name":"Bob","score":20,"active":false}`,
 	)
@@ -95,7 +96,8 @@ func TestElasticsearchDestinationReplace(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, initialActive)
 
-	replacementPath := writeElasticsearchJSONL(t, "replacement.jsonl",
+	replacementPath := writeElasticsearchJSONL(
+		t, "replacement.jsonl",
 		`{"id":"user-2","name":"Bob Updated","score":30,"active":true}`,
 		`{"id":"user-3","name":"Carol","score":40,"active":true}`,
 	)


### PR DESCRIPTION
## Summary
- Pure `make format` (gofumpt/gci) line-wrapping fixes for `pkg/destination/onelake/delta_io.go`, `pkg/source/stripe/governor.go`, `pkg/source/stripe/stripe.go`, and `tests/integration/elasticsearch_test.go`.
- No logic or argument changes — verified with `git diff --word-diff` that only whitespace/line breaks moved.