### PR TITLE
fix(cast): make --columns decimal overrides work, and error on overflow

### DIFF
--- a/pkg/databuffer/file.go
+++ b/pkg/databuffer/file.go
@@ -297,10 +297,28 @@ func castArrayToType(ctx context.Context, arr arrow.Array, target arrow.DataType
 		}
 	}
 
+	// Arrow's safe decimal→decimal cast errors when the target scale drops digits;
+	// rescale unsafely so it truncates. castToDecimalTruncating still rejects overflow.
+	if isDecimalType(arr.DataType()) && isDecimalType(target) {
+		return castToDecimalTruncating(ctx, arr, target)
+	}
+
+	// Arrow refuses int→decimal unless the precision fits the int type's full range,
+	// even when values fit; widen through decimal(38,0) (lossless) then rescale.
+	if isIntegerType(arr.DataType()) && isDecimalType(target) {
+		wide, werr := compute.CastArray(ctx, arr, compute.UnsafeCastOptions(&arrow.Decimal128Type{Precision: 38, Scale: 0}))
+		if werr != nil {
+			return nil, werr
+		}
+		result, rerr := castToDecimalTruncating(ctx, wide, target)
+		wide.Release()
+		return result, rerr
+	}
+
 	var casted arrow.Array
 	if safe {
 		casted, err = compute.CastArray(ctx, arr, compute.SafeCastOptions(target))
-	} else if (arr.DataType().ID() == arrow.DECIMAL128 || arr.DataType().ID() == arrow.DECIMAL256) && isIntegerType(target) {
+	} else if isDecimalType(arr.DataType()) && isIntegerType(target) {
 		// Cast decimal via float64 to truncate toward zero (matching Python's int()).
 		// Arrow's direct decimal → int path rounds instead of truncating.
 		floatArr, floatErr := compute.CastArray(ctx, arr, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
@@ -736,6 +754,53 @@ func isIntegerType(dt arrow.DataType) bool {
 		return true
 	}
 	return false
+}
+
+func isDecimalType(dt arrow.DataType) bool {
+	return dt.ID() == arrow.DECIMAL128 || dt.ID() == arrow.DECIMAL256
+}
+
+// castToDecimalTruncating rescales to a decimal target unsafely (a smaller scale
+// truncates toward zero), but errors when a value's magnitude overflows the precision.
+func castToDecimalTruncating(ctx context.Context, arr arrow.Array, target arrow.DataType) (arrow.Array, error) {
+	out, err := compute.CastArray(ctx, arr, compute.UnsafeCastOptions(target))
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureDecimalFits(out, target); err != nil {
+		out.Release()
+		return nil, err
+	}
+	return out, nil
+}
+
+// ensureDecimalFits reports an error if any non-null value does not fit the target
+// decimal's precision (an overflow the unsafe cast would otherwise pass through).
+func ensureDecimalFits(arr arrow.Array, target arrow.DataType) error {
+	var precision, scale int32
+	switch t := target.(type) {
+	case *arrow.Decimal128Type:
+		precision, scale = t.Precision, t.Scale
+	case *arrow.Decimal256Type:
+		precision, scale = t.Precision, t.Scale
+	default:
+		return nil
+	}
+	switch a := arr.(type) {
+	case *array.Decimal128:
+		for i := 0; i < a.Len(); i++ {
+			if !a.IsNull(i) && !a.Value(i).FitsInPrecision(precision) {
+				return fmt.Errorf("value %s overflows %s", a.Value(i).ToString(scale), target)
+			}
+		}
+	case *array.Decimal256:
+		for i := 0; i < a.Len(); i++ {
+			if !a.IsNull(i) && !a.Value(i).FitsInPrecision(precision) {
+				return fmt.Errorf("value %s overflows %s", a.Value(i).ToString(scale), target)
+			}
+		}
+	}
+	return nil
 }
 
 func isJSONType(dt arrow.DataType) bool {

--- a/pkg/databuffer/file_test.go
+++ b/pkg/databuffer/file_test.go
@@ -704,6 +704,136 @@ func TestCastRecordToSchema(t *testing.T) {
 	})
 }
 
+func TestCastRecordToSchema_DecimalRescale(t *testing.T) {
+	mem := memory.DefaultAllocator
+	srcType := &arrow.Decimal128Type{Precision: 8, Scale: 5}
+	tgtType := &arrow.Decimal128Type{Precision: 10, Scale: 2}
+
+	b := array.NewDecimal128Builder(mem, srcType)
+	for _, s := range []string{"3.14159", "100.50000"} {
+		v, err := decimal128.FromString(s, srcType.Precision, srcType.Scale)
+		require.NoError(t, err)
+		b.Append(v)
+	}
+	arr := b.NewArray()
+	b.Release()
+
+	record := array.NewRecordBatch(
+		arrow.NewSchema([]arrow.Field{{Name: "amount", Type: srcType, Nullable: true}}, nil),
+		[]arrow.Array{arr}, 2,
+	)
+	arr.Release()
+	defer record.Release()
+
+	tgtSchema := arrow.NewSchema([]arrow.Field{{Name: "amount", Type: tgtType, Nullable: true}}, nil)
+
+	// safe=true is the path that previously failed with "invalid: %!s(<nil>)" when
+	// the rescale dropped scale digits (e.g. a --columns decimal precision/scale override).
+	casted, err := CastRecordToSchema(record, tgtSchema, true)
+	require.NoError(t, err)
+	defer casted.Release()
+
+	require.True(t, arrow.TypeEqual(tgtType, casted.Schema().Field(0).Type))
+	col := casted.Column(0).(*array.Decimal128)
+	assert.Equal(t, "3.14", col.Value(0).ToString(tgtType.Scale))
+	assert.Equal(t, "100.50", col.Value(1).ToString(tgtType.Scale))
+}
+
+func TestCastRecordToSchema_IntAndFloatToDecimal(t *testing.T) {
+	mem := memory.DefaultAllocator
+	tgt := &arrow.Decimal128Type{Precision: 10, Scale: 2}
+
+	makeInt := func() arrow.Array {
+		b := array.NewInt64Builder(mem)
+		b.AppendValues([]int64{5, 12345}, nil)
+		defer b.Release()
+		return b.NewArray()
+	}
+	makeFloat := func() arrow.Array {
+		b := array.NewFloat64Builder(mem)
+		b.AppendValues([]float64{3.14159, 100.5}, nil)
+		defer b.Release()
+		return b.NewArray()
+	}
+
+	cases := []struct {
+		name  string
+		arr   arrow.Array
+		want0 string
+		want1 string
+	}{
+		// int64 needs precision 21 to hold its full range, so Arrow refuses the
+		// direct int→decimal(10,2) cast; we widen through decimal(38,0) instead.
+		{"int64", makeInt(), "5.00", "12345.00"},
+		{"float64", makeFloat(), "3.14", "100.50"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			record := array.NewRecordBatch(
+				arrow.NewSchema([]arrow.Field{{Name: "v", Type: tt.arr.DataType(), Nullable: true}}, nil),
+				[]arrow.Array{tt.arr}, int64(tt.arr.Len()),
+			)
+			defer record.Release()
+			defer tt.arr.Release()
+
+			tgtSchema := arrow.NewSchema([]arrow.Field{{Name: "v", Type: tgt, Nullable: true}}, nil)
+			casted, err := CastRecordToSchema(record, tgtSchema, true)
+			require.NoError(t, err)
+			defer casted.Release()
+
+			col := casted.Column(0).(*array.Decimal128)
+			assert.Equal(t, tt.want0, col.Value(0).ToString(tgt.Scale))
+			assert.Equal(t, tt.want1, col.Value(1).ToString(tgt.Scale))
+		})
+	}
+}
+
+func TestCastRecordToSchema_DecimalOverflowErrors(t *testing.T) {
+	mem := memory.DefaultAllocator
+
+	t.Run("decimal value too large for target precision", func(t *testing.T) {
+		srcType := &arrow.Decimal128Type{Precision: 10, Scale: 5}
+		b := array.NewDecimal128Builder(mem, srcType)
+		v, err := decimal128.FromString("12345.67891", srcType.Precision, srcType.Scale)
+		require.NoError(t, err)
+		b.Append(v)
+		arr := b.NewArray()
+		b.Release()
+
+		record := array.NewRecordBatch(
+			arrow.NewSchema([]arrow.Field{{Name: "v", Type: srcType, Nullable: true}}, nil),
+			[]arrow.Array{arr}, 1,
+		)
+		arr.Release()
+		defer record.Release()
+
+		tgt := arrow.NewSchema([]arrow.Field{{Name: "v", Type: &arrow.Decimal128Type{Precision: 6, Scale: 2}, Nullable: true}}, nil)
+		_, err = CastRecordToSchema(record, tgt, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "overflows")
+	})
+
+	t.Run("integer value too large for target precision", func(t *testing.T) {
+		b := array.NewInt64Builder(mem)
+		b.AppendValues([]int64{99999999999}, nil)
+		arr := b.NewArray()
+		b.Release()
+
+		record := array.NewRecordBatch(
+			arrow.NewSchema([]arrow.Field{{Name: "v", Type: arrow.PrimitiveTypes.Int64, Nullable: true}}, nil),
+			[]arrow.Array{arr}, 1,
+		)
+		arr.Release()
+		defer record.Release()
+
+		tgt := arrow.NewSchema([]arrow.Field{{Name: "v", Type: &arrow.Decimal128Type{Precision: 10, Scale: 2}, Nullable: true}}, nil)
+		_, err := CastRecordToSchema(record, tgt, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "overflows")
+	})
+}
+
 func TestCastRecordToSchema_UnknownToJSONEncodesScalarStrings(t *testing.T) {
 	mem := memory.DefaultAllocator
 


### PR DESCRIPTION
## Problem

When a `--columns` override changes a column to a sized decimal (`decimal(p,s)`), ingestr casts the source Arrow data to that target decimal in-memory before the bulk load. Two of those casts were mishandled by Arrow:

- **decimal → decimal**: Arrow's *safe* cast returns a malformed error (`invalid: %!s(<nil>)`) the moment the target scale drops digits, so any decimal-source column re-scaled via `--columns` failed the run. The pipeline's `SchemaAligner` (and the BigQuery/OneLake load paths) use safe casts, so this was hit in normal ingestion.
- **int → decimal**: Arrow refuses the cast unless the target precision can hold the integer type's *entire* range, so `int64 → decimal(10,2)` failed even when the actual values fit.

Because ingestr converts types in the Arrow layer (destinations bulk-load already-typed Arrow/Parquet/COPY-binary — there is no SQL `CAST` seam in the write path), this had to be fixed here.

## Fix (`pkg/databuffer/file.go`)

- **decimal → decimal**: rescale with an unsafe cast so a smaller scale is applied (truncates toward zero, matching the existing truncating decimal/float → int conversions).
- **int → decimal**: widen through a lossless `decimal(38,0)` first, then rescale.
- **Overflow is a hard error**, not silent corruption: after the unsafe rescale, `ensureDecimalFits` verifies every value's magnitude fits the target precision and errors (`value … overflows decimal(p,s)`) otherwise. Scale reduction (truncation) stays silent since that's the requested behavior.

`float → decimal` and `string → decimal` already worked and are unchanged.

## Behavior

| Conversion | Input | Result |
| --- | --- | --- |
| `decimal(8,5) → decimal(10,2)` | `3.14159` | `3.14` |
| `decimal(10,3) → decimal(5,2)` | `999.999` | `999.99` (truncates) |
| `int64 → decimal(10,2)` | `12345` | `12345.00` |
| `decimal(10,3) → decimal(5,2)` | `12345.678` | **error: value 12345.67 overflows decimal(5, 2)** |
| `int64 → decimal(10,2)` | `99999999999` | **error: overflows decimal(10, 2)** |