### PR TITLE
Support source params in table names for chess and frankfurter

### DIFF
--- a/docs/supported-sources/chess.md
+++ b/docs/supported-sources/chess.md
@@ -26,6 +26,16 @@ ingestr ingest --source-uri 'chess://?players=max2,peter23' --source-table 'prof
 
 The result of this command will be a table in the `chess.duckdb` database.
 
+## Specifying players per table
+
+Players can also be supplied directly in the `--source-table` value, appended after a colon as a comma-separated list:
+
+```sh
+ingestr ingest --source-uri 'chess://' --source-table 'profiles:max2,peter23' --dest-uri 'duckdb:///chess.duckdb' --dest-table 'players.profiles'
+```
+
+When players are given this way they take precedence over the `players` URI parameter, so you can pull different players into different tables from a single connection. If no players are given in either place, data for a default set of players is fetched.
+
 ## Tables
 
 Chess source allows ingesting the following sources into separate tables:

--- a/docs/supported-sources/frankfurter.md
+++ b/docs/supported-sources/frankfurter.md
@@ -26,11 +26,25 @@ ingestr ingest \
 --interval-start '2025-03-20' \ 
 --interval-end '2025-03-28' \       
 --source-table 'exchange_rates' \    
---dest-uri 'duckdb///frankfurter.duckdb' \
+--dest-uri 'duckdb:///frankfurter.duckdb' \
 --dest-table 'my_schema.exchange_rates'
 ```
 
 The result of this command will be a list of currency exchange rates from 20.03.2025-28.03.2025 with INR as the base currency in your DuckDB database. 
+
+## Specifying the base currency per table
+
+The base currency can also be supplied directly in the `--source-table` value, appended after a colon:
+
+```bash
+ingestr ingest \
+--source-uri 'frankfurter://' \
+--source-table 'latest:USD' \
+--dest-uri 'duckdb:///frankfurter.duckdb' \
+--dest-table 'my_schema.latest'
+```
+
+When the base is given this way it takes precedence over the `base` URI parameter, so you can pull different base currencies into different tables from a single connection. If no base is given in either place, it defaults to `EUR`.
 
 ## Tables
 

--- a/pkg/source/chess/chess.go
+++ b/pkg/source/chess/chess.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -86,6 +87,8 @@ func parsePlayersFromURI(uri string) ([]string, error) {
 		return strings.Split(defaultPlayers, ","), nil
 	}
 
+	output.Warnf("Warning: specifying players in the chess:// connection URI is deprecated and will be removed in a future release; provide them in the table name instead, e.g. --source-table 'profiles:hikaru,magnuscarlsen'\n")
+
 	players := strings.Split(playersParam, ",")
 	for i := range players {
 		players[i] = strings.TrimSpace(players[i])
@@ -111,6 +114,18 @@ func (s *ChessSource) Close(ctx context.Context) error {
 
 func (s *ChessSource) HandlesIncrementality() bool {
 	return true
+}
+
+// normalizePlayers splits a comma-separated list of player usernames, trimming
+// whitespace and dropping empty entries.
+func normalizePlayers(raw string) []string {
+	var players []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			players = append(players, p)
+		}
+	}
+	return players
 }
 
 func (s *ChessSource) getTables() map[string]source.SourceTable {
@@ -158,9 +173,21 @@ func (s *ChessSource) getTables() map[string]source.SourceTable {
 }
 
 func (s *ChessSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
-	table, ok := s.tables[req.Name]
+	tableName := req.Name
+
+	// Players may be supplied inline in the table name (e.g. "profiles:hikaru,magnuscarlsen"),
+	// which takes precedence over the players configured on the connection URI.
+	if strings.Contains(tableName, ":") {
+		parts := strings.SplitN(tableName, ":", 2)
+		tableName = parts[0]
+		if players := normalizePlayers(parts[1]); len(players) > 0 {
+			s.players = players
+		}
+	}
+
+	table, ok := s.tables[tableName]
 	if !ok {
-		return nil, fmt.Errorf("unsupported table: %s (supported: profiles, games, archives)", req.Name)
+		return nil, fmt.Errorf("unsupported table: %s (supported: profiles, games, archives)", tableName)
 	}
 	return table, nil
 }

--- a/pkg/source/chess/chess_test.go
+++ b/pkg/source/chess/chess_test.go
@@ -1,6 +1,7 @@
 package chess
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -8,12 +9,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureOutput redirects the output package to a buffer for the duration of fn
+// and returns whatever was written, restoring the previous writers afterwards.
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	prevOut, prevErr, prevMode := output.Current()
+	t.Cleanup(func() { output.Init(prevOut, prevErr, prevMode) })
+	var buf bytes.Buffer
+	output.Init(&buf, &buf, output.ModeText)
+	fn()
+	return buf.String()
+}
 
 func TestParsePlayersFromURI(t *testing.T) {
 	tests := []struct {
@@ -153,6 +167,128 @@ func TestChessSource_ReadUnsupportedTable(t *testing.T) {
 	_, err = s.GetTable(context.Background(), source.TableRequest{Name: "invalid"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported table")
+}
+
+func TestChessSource_DeprecationWarning(t *testing.T) {
+	t.Run("warns when players supplied in URI", func(t *testing.T) {
+		out := captureOutput(t, func() {
+			s := NewChessSource()
+			require.NoError(t, s.Connect(context.Background(), "chess://?players=hikaru"))
+		})
+		assert.Contains(t, out, "deprecated")
+		assert.Contains(t, out, "source-table")
+	})
+
+	t.Run("no warning without players in URI", func(t *testing.T) {
+		out := captureOutput(t, func() {
+			s := NewChessSource()
+			require.NoError(t, s.Connect(context.Background(), "chess://"))
+		})
+		assert.Empty(t, out)
+	})
+}
+
+func TestNormalizePlayers(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"single", "hikaru", []string{"hikaru"}},
+		{"multiple", "hikaru,magnuscarlsen", []string{"hikaru", "magnuscarlsen"}},
+		{"trims whitespace", "hikaru, magnuscarlsen , gothamchess", []string{"hikaru", "magnuscarlsen", "gothamchess"}},
+		{"drops empty entries", "hikaru,,magnuscarlsen,", []string{"hikaru", "magnuscarlsen"}},
+		{"all empty", " , ", nil},
+		{"empty string", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizePlayers(tt.raw))
+		})
+	}
+}
+
+func TestChessSource_GetTable_StripsInlinePlayers(t *testing.T) {
+	s := NewChessSource()
+	err := s.Connect(context.Background(), "chess://?players=testuser")
+	require.NoError(t, err)
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "profiles:hikaru,magnuscarlsen"})
+	require.NoError(t, err)
+	// The inline players must not leak into the table name.
+	assert.Equal(t, "profiles", table.Name())
+}
+
+func TestChessSource_GetTable_UnsupportedTableWithInlinePlayers(t *testing.T) {
+	s := NewChessSource()
+	err := s.Connect(context.Background(), "chess://?players=testuser")
+	require.NoError(t, err)
+
+	_, err = s.GetTable(context.Background(), source.TableRequest{Name: "invalid:hikaru"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported table")
+}
+
+func TestChessSource_InlinePlayersOverrideURI(t *testing.T) {
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"username": r.URL.Path})
+	}))
+	defer server.Close()
+
+	s := NewChessSource()
+	err := s.Connect(context.Background(), "chess://?players=uriplayer")
+	require.NoError(t, err)
+	_ = s.client.Close()
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(server.URL),
+		httpclient.WithDisableRetry(),
+	)
+	defer func() { _ = s.client.Close() }()
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "profiles:hikaru,magnuscarlsen"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	for range results {
+	}
+
+	assert.ElementsMatch(t, []string{"/player/hikaru", "/player/magnuscarlsen"}, requested)
+	assert.NotContains(t, requested, "/player/uriplayer")
+}
+
+func TestChessSource_FallsBackToURIPlayers(t *testing.T) {
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"username": r.URL.Path})
+	}))
+	defer server.Close()
+
+	s := NewChessSource()
+	err := s.Connect(context.Background(), "chess://?players=uriplayer")
+	require.NoError(t, err)
+	_ = s.client.Close()
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(server.URL),
+		httpclient.WithDisableRetry(),
+	)
+	defer func() { _ = s.client.Close() }()
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "profiles"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	for range results {
+	}
+
+	assert.Equal(t, []string{"/player/uriplayer"}, requested)
 }
 
 func TestItemsToArrowRecordWithSchema(t *testing.T) {

--- a/pkg/source/frankfurter/frankfurter.go
+++ b/pkg/source/frankfurter/frankfurter.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -73,6 +74,7 @@ func parseFrankfurterURI(uri string) (string, error) {
 		}
 		if b := values.Get("base"); b != "" {
 			base = strings.ToUpper(b)
+			output.Warnf("Warning: specifying base in the frankfurter:// connection URI is deprecated and will be removed in a future release; provide it in the table name instead, e.g. --source-table 'latest:USD'\n")
 		}
 	}
 
@@ -105,9 +107,20 @@ func (s *FrankfurterSource) Close(ctx context.Context) error {
 
 func (s *FrankfurterSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
 	tableName := req.Name
+	base := s.base
+
+	// The base currency may be supplied inline in the table name (e.g. "latest:USD"),
+	// which takes precedence over the base configured on the connection URI.
+	if strings.Contains(tableName, ":") {
+		parts := strings.SplitN(tableName, ":", 2)
+		tableName = parts[0]
+		if b := strings.ToUpper(strings.TrimSpace(parts[1])); b != "" {
+			base = b
+		}
+	}
 
 	if !isValidTable(tableName) {
-		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", req.Name, strings.Join(supportedTables, ", "))
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, strings.Join(supportedTables, ", "))
 	}
 
 	tableSchema, primaryKeys := s.getSchema(tableName)
@@ -133,7 +146,7 @@ func (s *FrankfurterSource) GetTable(ctx context.Context, req source.TableReques
 			return tableSchema, nil
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
-			return s.read(ctx, tableName, opts)
+			return s.read(ctx, tableName, base, opts)
 		},
 	}, nil
 }
@@ -169,7 +182,7 @@ func isValidTable(table string) bool {
 	return false
 }
 
-func (s *FrankfurterSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+func (s *FrankfurterSource) read(ctx context.Context, table, base string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -180,9 +193,9 @@ func (s *FrankfurterSource) read(ctx context.Context, table string, opts source.
 		case "currencies":
 			err = s.readCurrencies(ctx, opts, results)
 		case "latest":
-			err = s.readLatest(ctx, opts, results)
+			err = s.readLatest(ctx, base, opts, results)
 		case "exchange_rates":
-			err = s.readExchangeRates(ctx, opts, results)
+			err = s.readExchangeRates(ctx, base, opts, results)
 		default:
 			err = fmt.Errorf("unsupported table: %s", table)
 		}
@@ -235,10 +248,10 @@ func (s *FrankfurterSource) readCurrencies(ctx context.Context, opts source.Read
 	return nil
 }
 
-func (s *FrankfurterSource) readLatest(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *FrankfurterSource) readLatest(ctx context.Context, base string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[FRANKFURTER] Fetching latest rates")
 
-	resp, err := s.client.R(ctx).Get(fmt.Sprintf("latest?base=%s", s.base))
+	resp, err := s.client.R(ctx).Get(fmt.Sprintf("latest?base=%s", base))
 	if err != nil {
 		return fmt.Errorf("failed to fetch latest rates: %w", err)
 	}
@@ -269,7 +282,7 @@ func (s *FrankfurterSource) readLatest(ctx context.Context, opts source.ReadOpti
 	return nil
 }
 
-func (s *FrankfurterSource) readExchangeRates(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *FrankfurterSource) readExchangeRates(ctx context.Context, base string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	config.Debug("[FRANKFURTER] Fetching exchange rates")
 
 	now := time.Now().UTC()
@@ -282,7 +295,7 @@ func (s *FrankfurterSource) readExchangeRates(ctx context.Context, opts source.R
 		endDate = now.Format("2006-01-02")
 	}
 
-	endpoint := fmt.Sprintf("%s..%s?base=%s", startDate, endDate, s.base)
+	endpoint := fmt.Sprintf("%s..%s?base=%s", startDate, endDate, base)
 	config.Debug("[FRANKFURTER] Fetching exchange rates from %s to %s", startDate, endDate)
 
 	resp, err := s.client.R(ctx).Get(endpoint)

--- a/pkg/source/frankfurter/frankfurter_test.go
+++ b/pkg/source/frankfurter/frankfurter_test.go
@@ -1,12 +1,31 @@
 package frankfurter
 
 import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/bruin-data/ingestr/internal/output"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureOutput redirects the output package to a buffer for the duration of fn
+// and returns whatever was written, restoring the previous writers afterwards.
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	prevOut, prevErr, prevMode := output.Current()
+	t.Cleanup(func() { output.Init(prevOut, prevErr, prevMode) })
+	var buf bytes.Buffer
+	output.Init(&buf, &buf, output.ModeText)
+	fn()
+	return buf.String()
+}
 
 func TestParseFrankfurterURI(t *testing.T) {
 	tests := []struct {
@@ -35,6 +54,102 @@ func TestParseFrankfurterURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFrankfurterSource_DeprecationWarning(t *testing.T) {
+	t.Run("warns when base supplied in URI", func(t *testing.T) {
+		out := captureOutput(t, func() {
+			s := NewFrankfurterSource()
+			require.NoError(t, s.Connect(context.Background(), "frankfurter://?base=USD"))
+		})
+		assert.Contains(t, out, "deprecated")
+		assert.Contains(t, out, "source-table")
+	})
+
+	t.Run("no warning without base in URI", func(t *testing.T) {
+		out := captureOutput(t, func() {
+			s := NewFrankfurterSource()
+			require.NoError(t, s.Connect(context.Background(), "frankfurter://"))
+		})
+		assert.Empty(t, out)
+	})
+}
+
+func TestFrankfurterSource_GetTable_StripsInlineBase(t *testing.T) {
+	s := NewFrankfurterSource()
+	require.NoError(t, s.Connect(context.Background(), "frankfurter://"))
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "latest:USD"})
+	require.NoError(t, err)
+	// The inline base must not leak into the table name.
+	assert.Equal(t, "latest", table.Name())
+}
+
+func TestFrankfurterSource_GetTable_UnsupportedTableWithInlineBase(t *testing.T) {
+	s := NewFrankfurterSource()
+	require.NoError(t, s.Connect(context.Background(), "frankfurter://"))
+
+	_, err := s.GetTable(context.Background(), source.TableRequest{Name: "invalid:USD"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported table")
+}
+
+func TestFrankfurterSource_InlineBaseOverridesURI(t *testing.T) {
+	var gotBase string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBase = r.URL.Query().Get("base")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"base":"` + gotBase + `","date":"2024-01-01","rates":{"EUR":0.9}}`))
+	}))
+	defer server.Close()
+
+	s := NewFrankfurterSource()
+	require.NoError(t, s.Connect(context.Background(), "frankfurter://?base=EUR"))
+	_ = s.client.Close()
+	s.client = ingestrhttp.New(
+		ingestrhttp.WithBaseURL(server.URL+"/"),
+		ingestrhttp.WithDisableRetry(),
+	)
+	defer func() { _ = s.client.Close() }()
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "latest:USD"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	for range results {
+	}
+
+	assert.Equal(t, "USD", gotBase)
+}
+
+func TestFrankfurterSource_FallsBackToURIBase(t *testing.T) {
+	var gotBase string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBase = r.URL.Query().Get("base")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"base":"` + gotBase + `","date":"2024-01-01","rates":{"USD":1.1}}`))
+	}))
+	defer server.Close()
+
+	s := NewFrankfurterSource()
+	require.NoError(t, s.Connect(context.Background(), "frankfurter://?base=GBP"))
+	_ = s.client.Close()
+	s.client = ingestrhttp.New(
+		ingestrhttp.WithBaseURL(server.URL+"/"),
+		ingestrhttp.WithDisableRetry(),
+	)
+	defer func() { _ = s.client.Close() }()
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "latest"})
+	require.NoError(t, err)
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	for range results {
+	}
+
+	assert.Equal(t, "GBP", gotBase)
 }
 
 func TestFlattenRates_IncludesBaseCurrency(t *testing.T) {


### PR DESCRIPTION
## What

Lets the **chess** players and **frankfurter** base currency be specified directly in the source table name, matching the convention already used by other sources (e.g. appstore's `table:app_ids`):

```sh
ingestr ingest --source-uri 'chess://'       --source-table 'profiles:hikaru,magnuscarlsen' ...
ingestr ingest --source-uri 'frankfurter://' --source-table 'latest:USD' ...
```

Inline values take precedence over the connection URI parameters, so a single connection can feed different players / base currencies into different tables.

## Why

These are public, credential-less sources whose only "connection" content is a source parameter (`players` / `base`). Carrying that on the connection URI forces users to register a connection just to hold a query param. Moving the param to the table name aligns them with the rest of the sources and is a step toward not requiring a manually-added connection at all.

## Backward compatibility

The existing URI parameters (`chess://?players=...`, `frankfurter://?base=...`) keep working, so nothing breaks. When they are used, ingestr now emits a **deprecation warning** (via the existing `output.Warnf` seam) pointing users to the table-name syntax. A bare `chess://` / `frankfurter://` produces no warning.