### PR TITLE
fix(pipeline): report overrides on unknown-type columns as "set to"

### DIFF
--- a/pkg/pipeline/column_override_message_test.go
+++ b/pkg/pipeline/column_override_message_test.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+// An override on a column with no known source type is reported as "set to",
+// not "changed from unknown to ...", which would imply a type mutated when
+// nothing was known before.
+func TestColumnOverrideMessage_UnknownSourceType(t *testing.T) {
+	var out bytes.Buffer
+	output.Init(&out, &out, output.ModeText)
+	t.Cleanup(func() { output.Init(os.Stdout, os.Stderr, output.ModeText) })
+
+	src := schema.TableSchema{Columns: []schema.Column{{Name: "payload", DataType: schema.TypeUnknown}}}
+	p := &Pipeline{config: &config.IngestConfig{Columns: "payload:json"}}
+	if err := p.applyColumnOverrides(&src); err != nil {
+		t.Fatalf("applyColumnOverrides() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, `type set to json`) || strings.Contains(got, "changed from") {
+		t.Errorf("unexpected override message: %q", got)
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2530,7 +2530,10 @@ func (p *Pipeline) applyColumnOverrides(sourceSchema *schema.TableSchema) error 
 
 		if override.DataType != schema.TypeUnknown {
 			newCol := override.ApplyToColumn(col)
-			if col.DataType != newCol.DataType || col.Precision != newCol.Precision || col.Scale != newCol.Scale || col.MaxLength != newCol.MaxLength {
+			if col.DataType == schema.TypeUnknown {
+				output.Infof("Column override: %q type set to %s(p=%v,s=%v,len=%v)\n",
+					col.Name, newCol.DataType, newCol.Precision, newCol.Scale, newCol.MaxLength)
+			} else if col.DataType != newCol.DataType || col.Precision != newCol.Precision || col.Scale != newCol.Scale || col.MaxLength != newCol.MaxLength {
 				output.Infof("Column override: %q type changed from %s(p=%v,s=%v,len=%v) to %s(p=%v,s=%v,len=%v)\n",
 					col.Name, col.DataType, col.Precision, col.Scale, col.MaxLength, newCol.DataType, newCol.Precision, newCol.Scale, newCol.MaxLength)
 			}


### PR DESCRIPTION
## What

When a `--columns` override targets a column whose **source type is unknown**, the override notice printed:

```
Column override: "payload" type changed from unknown(p=0,s=0,len=0) to json(p=0,s=0,len=0)
```

Saying the type *changed from* `unknown` implies a real type mutated, when in fact nothing was ever known about the column. This happens for an all-null column in a schema-less source (e.g. MongoDB) that a `--columns` override protected from being dropped during inference — so it survives as `TypeUnknown` and the override is the first thing to give it a type.

## Change

For the unknown case we now report:

```
Column override: "payload" type set to json(p=0,s=0,len=0)
```

`changed from ... to ...` is reserved for columns that had a concrete prior type. Columns with a known source type (the common case for SQL sources) are unaffected.