### PR TITLE
onelake: fix workspace names with spaces and GUID item targets

### DIFF
--- a/docs/supported-sources/onelake.md
+++ b/docs/supported-sources/onelake.md
@@ -14,11 +14,30 @@ onelake://<workspace>/<lakehouse>?tenant_id=<tenant_id>&client_id=<client_id>&cl
 ```
 
 URI parameters:
-- `workspace`: the Fabric workspace name or GUID (the URI host)
-- `lakehouse`: the Lakehouse name or GUID (the URI path). A `.Lakehouse` item suffix is added automatically; pass an explicit suffix (e.g. `mywh.Warehouse`) to target a different item type.
+- `workspace`: the Fabric workspace name or GUID (the first path segment)
+- `lakehouse`: the Lakehouse name or GUID (the second path segment). A `.Lakehouse` item suffix is added automatically **unless the value is a GUID or already contains a `.`** — Fabric addresses items by GUID with no type suffix. Pass an explicit suffix (e.g. `mywh.Warehouse`) to target a different item type.
 - `tenant_id`, `client_id`, `client_secret` (optional): Microsoft Entra service principal credentials
 - `sas_token` (optional): a SAS token issued for OneLake
 - `layout` (optional): file-name template for **Files** mode (default `{load_id}.{file_id}.{ext}`); supports `{table_name}`, `{load_id}`, `{file_id}` and `{ext}`
+
+### Names, spaces and GUIDs
+
+The workspace and the item may each independently be a friendly name or a GUID, and the
+two forms can be mixed (a named workspace with a GUID item is fine, and vice versa).
+
+Workspace and item names containing spaces work either quoted or percent-encoded — both
+spellings resolve to the same name:
+
+```bash
+--dest-uri "onelake://Fabric Dev/Sales LH"
+--dest-uri "onelake://Fabric%20Dev/Sales%20LH"
+```
+
+Prefer the `%20` form in config files and CI, where quoting is easier to get wrong.
+
+Neither segment may contain a `/`. A literal `%` in a name needs no escaping unless it is
+followed by two hex digits, in which case write it as `%25` (so a workspace actually named
+`Fabric%20Dev` is `Fabric%2520Dev`).
 
 The **mode and table** come from `--dest-table`, mirroring OneLake's path layout:
 - `Tables/<name>` (or `Tables/<schema>/<name>`) → a Delta table
@@ -29,6 +48,12 @@ For Delta tables, `.` and `/` are interchangeable separators and the leading `Ta
 
 The final object path is:
 `https://onelake.dfs.fabric.microsoft.com/<workspace>/<lakehouse>.Lakehouse/<Tables|Files>/<rest>`
+
+or, addressing both by GUID:
+`https://onelake.dfs.fabric.microsoft.com/<workspaceGUID>/<itemGUID>/<Tables|Files>/<rest>`
+
+Names are percent-encoded on the wire, so the `Fabric Dev` workspace becomes
+`https://onelake.dfs.fabric.microsoft.com/Fabric%20Dev/...`.
 
 ## Authentication
 
@@ -58,6 +83,16 @@ ingestr ingest \
     --source-table "public.users" \
     --dest-uri "onelake://myworkspace/mylakehouse?sas_token=$SAS_TOKEN" \
     --dest-table "Files/exports/users"
+```
+
+Load into a workspace whose name contains a space, addressing the Lakehouse by GUID:
+
+```bash
+ingestr ingest \
+    --source-uri "postgres://user:pass@host:5432/db" \
+    --source-table "public.users" \
+    --dest-uri "onelake://Fabric%20Dev/22222222-2222-2222-2222-222222222222?tenant_id=$TENANT_ID&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" \
+    --dest-table "Tables/users"
 ```
 
 Append new rows to an existing Delta table (adds a new Delta commit):

--- a/internal/adlsutil/adlsutil_test.go
+++ b/internal/adlsutil/adlsutil_test.go
@@ -1,9 +1,15 @@
 package adlsutil
 
 import (
+	"io"
+	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,4 +138,108 @@ func TestDirectoryPrefixes(t *testing.T) {
 			assert.Equal(t, tt.want, directoryPrefixes(tt.path, tt.skipPrefixSegments))
 		})
 	}
+}
+
+func TestPathURLWithSuffixEscapesWorkspace(t *testing.T) {
+	got, err := PathURLWithSuffix(OneLakeAccountName, OneLakeDNSSuffix, "Fabric Dev", "lh.Lakehouse/Tables/users/_delta_log/00000000000000000000.json")
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://onelake.dfs.fabric.microsoft.com/Fabric%20Dev/lh.Lakehouse/Tables/users/_delta_log/00000000000000000000.json",
+		got,
+	)
+}
+
+func TestFilesystemURLWithSuffixEscapesWorkspace(t *testing.T) {
+	assert.Equal(
+		t,
+		"https://onelake.dfs.fabric.microsoft.com/Fabric%20Dev",
+		FilesystemURLWithSuffix(OneLakeAccountName, OneLakeDNSSuffix, "/Fabric Dev/"),
+	)
+}
+
+func TestRenameSourceHeader(t *testing.T) {
+	assert.Equal(
+		t,
+		"/Fabric%20Dev/lh.Lakehouse/Tables/t/_bruin_delta_tmp/x.tmp",
+		renameSourceHeader("Fabric Dev", "lh.Lakehouse/Tables/t/_bruin_delta_tmp/x.tmp"),
+	)
+	assert.Equal(t, "/ws/a/b", renameSourceHeader("/ws/", "/a/b/"))
+}
+
+type recordingTransport struct {
+	req    *http.Request
+	status int
+}
+
+func (t *recordingTransport) Do(req *http.Request) (*http.Response, error) {
+	t.req = req
+	return &http.Response{
+		StatusCode: t.status,
+		Header:     http.Header{"X-Ms-Error-Code": []string{string(datalakeerror.PathAlreadyExists)}},
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    req,
+	}, nil
+}
+
+func TestRenameIfNotExistsSendsEscapedSourceAndIfNoneMatch(t *testing.T) {
+	transport := &recordingTransport{status: http.StatusCreated}
+	client := &DataLakeClient{
+		accountName: OneLakeAccountName,
+		dnsSuffix:   OneLakeDNSSuffix,
+		pipeline: azruntime.NewPipeline("test", "v1", azruntime.PipelineOptions{}, &policy.ClientOptions{
+			Transport: transport,
+		}),
+	}
+
+	err := client.RenameIfNotExists(
+		t.Context(),
+		"Fabric Dev",
+		"lh.Lakehouse/Tables/t/_bruin_delta_tmp/x.tmp",
+		"lh.Lakehouse/Tables/t/_delta_log/00000000000000000001.json",
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, transport.req)
+	assert.Equal(t, http.MethodPut, transport.req.Method)
+	assert.Equal(
+		t,
+		"/Fabric%20Dev/lh.Lakehouse/Tables/t/_bruin_delta_tmp/x.tmp",
+		transport.req.Header.Get("x-ms-rename-source"),
+	)
+	assert.Equal(t, "*", transport.req.Header.Get("If-None-Match"))
+	assert.Equal(t, dfsServiceVersion, transport.req.Header.Get("x-ms-version"))
+	assert.Equal(t, "/Fabric%20Dev/lh.Lakehouse/Tables/t/_delta_log/00000000000000000001.json", transport.req.URL.EscapedPath())
+	assert.Equal(t, "resource=file", transport.req.URL.RawQuery)
+}
+
+func TestRenameIfNotExistsReportsConflictAsResponseError(t *testing.T) {
+	transport := &recordingTransport{status: http.StatusConflict}
+	client := &DataLakeClient{
+		accountName: OneLakeAccountName,
+		dnsSuffix:   OneLakeDNSSuffix,
+		pipeline: azruntime.NewPipeline("test", "v1", azruntime.PipelineOptions{}, &policy.ClientOptions{
+			Transport: transport,
+		}),
+	}
+
+	err := client.RenameIfNotExists(t.Context(), "ws", "a/b.tmp", "a/c.json")
+	require.Error(t, err)
+	assert.True(t, datalakeerror.HasCode(err, datalakeerror.PathAlreadyExists))
+}
+
+func TestRenameIfNotExistsAppendsSASToken(t *testing.T) {
+	transport := &recordingTransport{status: http.StatusCreated}
+	client := &DataLakeClient{
+		accountName: OneLakeAccountName,
+		dnsSuffix:   OneLakeDNSSuffix,
+		sasToken:    "sv=2021&sig=abc",
+		pipeline: azruntime.NewPipeline("test", "v1", azruntime.PipelineOptions{}, &policy.ClientOptions{
+			Transport: transport,
+		}),
+	}
+
+	require.NoError(t, client.RenameIfNotExists(t.Context(), "Fabric Dev", "a/b.tmp", "a/c.json"))
+	assert.Equal(t, "resource=file&sv=2021&sig=abc", transport.req.URL.RawQuery)
+	assert.Equal(t, "/Fabric%20Dev/a/b.tmp?sv=2021&sig=abc", transport.req.Header.Get("x-ms-rename-source"))
 }

--- a/internal/adlsutil/datalake.go
+++ b/internal/adlsutil/datalake.go
@@ -4,17 +4,26 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	datalakedirectory "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/directory"
 	datalakefile "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/file"
 	datalakefilesystem "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/filesystem"
 )
+
+// dfsServiceVersion matches the version the azdatalake SDK sends, so the
+// hand-built rename request below behaves like the rest of the client.
+const dfsServiceVersion = "2026-02-06"
+
+const dfsTokenScope = "https://storage.azure.com/.default"
 
 // OneLakeDNSSuffix is the DFS endpoint suffix for Microsoft Fabric OneLake.
 // OneLake speaks the ADLS Gen2 protocol with a fixed account name of "onelake".
@@ -34,6 +43,8 @@ const OneLakeManagedPrefixSegments = 2
 type DataLakeClient struct {
 	accountName         string
 	dnsSuffix           string
+	sasToken            string
+	pipeline            azruntime.Pipeline
 	newFileClient       func(pathURL string) (*datalakefile.Client, error)
 	newDirectoryClient  func(pathURL string) (*datalakedirectory.Client, error)
 	newFilesystemClient func(fsURL string) (*datalakefilesystem.Client, error)
@@ -45,6 +56,9 @@ func NewDataLakeClientWithToken(accountName, dnsSuffix string, cred azcore.Token
 	return &DataLakeClient{
 		accountName: accountName,
 		dnsSuffix:   dnsSuffix,
+		pipeline: azruntime.NewPipeline("ingestr-adlsutil", "v1", azruntime.PipelineOptions{
+			PerRetry: []policy.Policy{azruntime.NewBearerTokenPolicy(cred, []string{dfsTokenScope}, nil)},
+		}, nil),
 		newFileClient: func(pathURL string) (*datalakefile.Client, error) {
 			return datalakefile.NewClient(pathURL, cred, nil)
 		},
@@ -63,6 +77,8 @@ func NewDataLakeClientWithSAS(accountName, dnsSuffix, sasToken string) *DataLake
 	return &DataLakeClient{
 		accountName: accountName,
 		dnsSuffix:   dnsSuffix,
+		sasToken:    sasToken,
+		pipeline:    azruntime.NewPipeline("ingestr-adlsutil", "v1", azruntime.PipelineOptions{}, nil),
 		newFileClient: func(pathURL string) (*datalakefile.Client, error) {
 			return datalakefile.NewClientWithNoCredential(AppendSASToken(pathURL, sasToken), nil)
 		},
@@ -209,6 +225,51 @@ func (c *DataLakeClient) DeleteDir(ctx context.Context, fileSystem, dirPath stri
 		return fmt.Errorf("failed to delete directory %s: %w", dirPath, err)
 	}
 	return nil
+}
+
+// RenameIfNotExists moves srcPath to destPath, failing with a ConditionNotMet
+// response error if destPath already exists.
+//
+// It issues the DFS rename directly rather than going through
+// datalakefile.Client.Rename, which derives the x-ms-rename-source header from
+// the percent-decoded URL path. Azure requires that header to be percent-encoded,
+// and a OneLake workspace name may contain characters that need escaping.
+func (c *DataLakeClient) RenameIfNotExists(ctx context.Context, fileSystem, srcPath, destPath string) error {
+	destURL, err := c.pathURL(fileSystem, destPath)
+	if err != nil {
+		return err
+	}
+
+	source := renameSourceHeader(fileSystem, srcPath)
+	if c.sasToken != "" {
+		source += "?" + c.sasToken
+	}
+
+	req, err := azruntime.NewRequest(ctx, http.MethodPut, AppendSASToken(destURL+"?resource=file", c.sasToken))
+	if err != nil {
+		return fmt.Errorf("failed to build rename request for %s: %w", destPath, err)
+	}
+	req.Raw().Header.Set("x-ms-version", dfsServiceVersion)
+	req.Raw().Header.Set("x-ms-rename-source", source)
+	req.Raw().Header.Set("If-None-Match", string(azcore.ETagAny))
+
+	resp, err := c.pipeline.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %w", srcPath, destPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !azruntime.HasStatusCode(resp, http.StatusCreated, http.StatusOK) {
+		return azruntime.NewResponseError(resp)
+	}
+	return nil
+}
+
+// renameSourceHeader builds the percent-encoded "/<filesystem>/<path>" value the
+// DFS rename expects in x-ms-rename-source.
+func renameSourceHeader(fileSystem, path string) string {
+	u := &url.URL{Path: "/" + strings.Trim(fileSystem, "/") + "/" + strings.Trim(path, "/")}
+	return u.EscapedPath()
 }
 
 // DeltaLogEntry identifies a Delta JSON commit and its storage version.

--- a/internal/uri/parser.go
+++ b/internal/uri/parser.go
@@ -26,6 +26,11 @@ var fileBasedSchemes = map[string]bool{
 	"sqlite": true, "duckdb": true, "motherduck": true, "md": true, "mmap": true,
 }
 
+// authorityOpaqueSchemes carry a value in the authority position that url.Parse
+// cannot represent — a OneLake workspace name may contain a space. Their
+// connectors parse the raw URI themselves.
+var authorityOpaqueSchemes = map[string]bool{"onelake": true}
+
 func Parse(rawURI string) (*ParsedURI, error) {
 	scheme, err := ExtractScheme(rawURI)
 	if err != nil {
@@ -34,8 +39,10 @@ func Parse(rawURI string) (*ParsedURI, error) {
 
 	normalizedScheme := NormalizeScheme(scheme)
 
-	// For file-based schemes, skip url.Parse to avoid Windows path issues
-	if fileBasedSchemes[normalizedScheme] {
+	// Skip url.Parse where it cannot represent the URI: file-based schemes carry
+	// Windows paths, and authority-opaque schemes carry names with characters that
+	// are invalid in a host.
+	if fileBasedSchemes[normalizedScheme] || authorityOpaqueSchemes[normalizedScheme] {
 		return &ParsedURI{
 			Scheme: normalizedScheme,
 			RawURI: rawURI,

--- a/internal/uri/parser_test.go
+++ b/internal/uri/parser_test.go
@@ -68,3 +68,36 @@ func TestParseSchemeVariants(t *testing.T) {
 		})
 	}
 }
+
+// A OneLake workspace name may contain a space, which url.Parse rejects in the
+// authority position — both raw ("invalid character") and percent-encoded
+// ("invalid URL escape"). Parse must hand these to the connector untouched.
+func TestParseSkipsStrictParseForAuthorityOpaqueSchemes(t *testing.T) {
+	for _, raw := range []string{
+		"onelake://Fabric Dev/lh",
+		"onelake://Fabric%20Dev/lh?client_secret=s",
+	} {
+		parsed, err := Parse(raw)
+		if err != nil {
+			t.Fatalf("Parse(%q): unexpected error: %v", raw, err)
+		}
+		if parsed.Scheme != "onelake" {
+			t.Errorf("Parse(%q): scheme = %q, want onelake", raw, parsed.Scheme)
+		}
+		if parsed.RawURI != raw {
+			t.Errorf("Parse(%q): RawURI = %q", raw, parsed.RawURI)
+		}
+		if parsed.Params == nil {
+			t.Errorf("Parse(%q): Params is nil", raw)
+		}
+		// The authority is deliberately left unparsed; the connector reads RawURI.
+		if parsed.Host != "" || parsed.Database != "" {
+			t.Errorf("Parse(%q): host = %q, database = %q, want both empty", raw, parsed.Host, parsed.Database)
+		}
+	}
+
+	// The leniency is scoped to onelake: other schemes still validate the host.
+	if _, err := Parse("postgres://Fabric Dev/db"); err == nil {
+		t.Error("Parse(postgres with a space in the host): expected an error")
+	}
+}

--- a/pkg/destination/onelake/local_store_test.go
+++ b/pkg/destination/onelake/local_store_test.go
@@ -127,6 +127,30 @@ func (c *localDataLakeClient) Download(ctx context.Context, _ string, path strin
 	return os.ReadFile(fullPath)
 }
 
+func (c *localDataLakeClient) RenameIfNotExists(ctx context.Context, _ string, srcPath, destPath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	src, err := c.path(srcPath)
+	if err != nil {
+		return err
+	}
+	dest, err := c.path(destPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	if err := os.Link(src, dest); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return errDeltaCommitConflict
+		}
+		return err
+	}
+	return os.Remove(src)
+}
+
 func (c *localDataLakeClient) publishCommit(ctx context.Context, logDir string, version int64, commit []byte) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -177,7 +201,6 @@ func newLocalOneLakeDestination(root string) (*OneLakeDestination, *localDataLak
 		client:    client,
 		layout:    defaultLayout,
 	}
-	destination.publishCommit = client.publishCommit
 	return destination, client
 }
 

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -48,6 +48,7 @@ type dataLakeClient interface {
 	ListLogVersions(context.Context, string, string) ([]int64, error)
 	ListLogEntries(context.Context, string, string) ([]adlsutil.DeltaLogEntry, error)
 	Download(context.Context, string, string) ([]byte, error)
+	RenameIfNotExists(context.Context, string, string, string) error
 }
 
 // OneLakeDestination writes data to a Microsoft Fabric OneLake lakehouse. It can
@@ -94,28 +95,40 @@ type parsedOneLakeURI struct {
 	layout            string
 }
 
-func parseOneLakeURI(uri string) (*parsedOneLakeURI, error) {
-	u, err := url.Parse(uri)
-	if err != nil {
-		return nil, err
+// parseOneLakeURI splits onelake://<workspace>/<lakehouse>?<params>. url.Parse
+// cannot be used: the workspace sits in the authority, where it rejects both raw
+// spaces and percent-escaped ASCII, and Fabric workspace names may contain
+// spaces. Errors never quote the URI, which carries credentials.
+func parseOneLakeURI(rawURI string) (*parsedOneLakeURI, error) {
+	scheme, rest, ok := strings.Cut(rawURI, "://")
+	if !ok {
+		return nil, fmt.Errorf("invalid OneLake URI: expected onelake://<workspace>/<lakehouse>")
 	}
-	if u.Scheme != "onelake" {
-		return nil, fmt.Errorf("unsupported scheme for OneLake: %s", u.Scheme)
+	if !strings.EqualFold(scheme, "onelake") {
+		return nil, fmt.Errorf("unsupported scheme for OneLake: %s", scheme)
 	}
 
-	workspace := u.Host
-	lakehouse := strings.Trim(u.Path, "/")
-	if workspace == "" {
-		return nil, fmt.Errorf("workspace is required: onelake://<workspace>/<lakehouse>")
+	path, rawQuery, _ := strings.Cut(rest, "?")
+	// Segments are split before decoding so an encoded separator inside a name is
+	// not mistaken for a real one.
+	segments := strings.Split(strings.TrimRight(path, "/"), "/")
+	if len(segments) > 2 {
+		return nil, fmt.Errorf("lakehouse must be a single path segment, got %q", strings.Join(segments[1:], "/"))
 	}
-	if lakehouse == "" {
+
+	workspace := decodeURISegment(segments[0])
+	if workspace == "" || strings.Contains(workspace, "/") {
+		return nil, fmt.Errorf("workspace must be a single non-empty path segment: onelake://<workspace>/<lakehouse>")
+	}
+	if len(segments) < 2 {
 		return nil, fmt.Errorf("lakehouse is required: onelake://<workspace>/<lakehouse>")
 	}
-	if strings.Contains(lakehouse, "/") {
-		return nil, fmt.Errorf("lakehouse must be a single path segment, got %q", lakehouse)
+	lakehouse := decodeURISegment(segments[1])
+	if lakehouse == "" || strings.Contains(lakehouse, "/") {
+		return nil, fmt.Errorf("lakehouse must be a single non-empty path segment: onelake://<workspace>/<lakehouse>")
 	}
 
-	q := u.Query()
+	q, _ := url.ParseQuery(rawQuery)
 	return &parsedOneLakeURI{
 		workspace:         workspace,
 		lakehouse:         lakehouse,
@@ -123,6 +136,16 @@ func parseOneLakeURI(uri string) (*parsedOneLakeURI, error) {
 		clientCredentials: adlsutil.ParseClientCredentials(q),
 		layout:            q.Get("layout"),
 	}, nil
+}
+
+// decodeURISegment percent-decodes a path segment, leaving it untouched when it
+// is not valid percent-encoding so a name containing a literal "%" still works.
+func decodeURISegment(segment string) string {
+	decoded, err := url.PathUnescape(segment)
+	if err != nil {
+		return segment
+	}
+	return decoded
 }
 
 func (d *OneLakeDestination) Connect(ctx context.Context, uri string) error {
@@ -161,12 +184,20 @@ func (d *OneLakeDestination) Close(ctx context.Context) error {
 	return nil
 }
 
-// itemPath returns the OneLake item segment, e.g. "mylakehouse.Lakehouse".
+// itemPath returns the OneLake item segment, e.g. "mylakehouse.Lakehouse". A
+// GUID addresses the item directly and Fabric rejects a type suffix on it.
 func (d *OneLakeDestination) itemPath() string {
-	if strings.Contains(d.lakehouse, ".") {
+	if strings.Contains(d.lakehouse, ".") || isItemGUID(d.lakehouse) {
 		return d.lakehouse
 	}
 	return d.lakehouse + ".Lakehouse"
+}
+
+// isItemGUID reports whether s is a canonical 8-4-4-4-12 GUID. The length gate
+// rejects the urn, braced and dashless forms uuid.Validate also accepts, none of
+// which is a valid Fabric path segment.
+func isItemGUID(s string) bool {
+	return len(s) == 36 && uuid.Validate(s) == nil
 }
 
 // tableDir returns the path of a Delta table directory within the filesystem.
@@ -413,21 +444,25 @@ func (d *OneLakeDestination) uploadDeltaCommit(ctx context.Context, logDir strin
 		return fmt.Errorf("failed to upload temporary delta commit %s: %w", tempPath, err)
 	}
 
-	tempFileClient, err := d.newOneLakeFileClient(tempPath)
-	if err != nil {
-		return err
-	}
-
-	if _, err := tempFileClient.Rename(ctx, commitPath, deltaCommitRenameOptions()); err != nil {
-		if _, deleteErr := tempFileClient.Delete(ctx, nil); deleteErr != nil {
-			config.Debug("[ONELAKE] Failed to delete temporary delta commit %s: %v", tempPath, deleteErr)
-		}
+	if err := d.client.RenameIfNotExists(ctx, d.workspace, tempPath, commitPath); err != nil {
+		d.deleteTempCommit(ctx, tempPath)
 		if isDeltaCommitConflict(err) {
 			return errDeltaCommitConflict
 		}
 		return fmt.Errorf("failed to publish delta commit %s: %w", commitPath, err)
 	}
 	return nil
+}
+
+func (d *OneLakeDestination) deleteTempCommit(ctx context.Context, tempPath string) {
+	tempFileClient, err := d.newOneLakeFileClient(tempPath)
+	if err != nil {
+		config.Debug("[ONELAKE] Failed to build client for temporary delta commit %s: %v", tempPath, err)
+		return
+	}
+	if _, err := tempFileClient.Delete(ctx, nil); err != nil {
+		config.Debug("[ONELAKE] Failed to delete temporary delta commit %s: %v", tempPath, err)
+	}
 }
 
 func (d *OneLakeDestination) newOneLakeFileClient(path string) (*datalakefile.Client, error) {
@@ -452,24 +487,13 @@ func (d *OneLakeDestination) ensureDirectories(ctx context.Context, path string)
 	return d.client.EnsureDirectoriesSkippingPrefix(ctx, d.workspace, path, adlsutil.OneLakeManagedPrefixSegments)
 }
 
-func deltaCommitRenameOptions() *datalakefile.RenameOptions {
-	etagAny := azcore.ETagAny
-	return &datalakefile.RenameOptions{
-		AccessConditions: &datalakefile.AccessConditions{
-			ModifiedAccessConditions: &datalakefile.ModifiedAccessConditions{
-				IfNoneMatch: &etagAny,
-			},
-		},
-	}
-}
-
 func deltaCommitTempPath(logDir string) string {
 	tableDir := strings.TrimSuffix(logDir, "/_delta_log")
 	return tableDir + "/_bruin_delta_tmp/" + uuid.New().String() + ".tmp"
 }
 
 func isDeltaCommitConflict(err error) bool {
-	return datalakeerror.HasCode(
+	return errors.Is(err, errDeltaCommitConflict) || datalakeerror.HasCode(
 		err,
 		datalakeerror.ConditionNotMet,
 		datalakeerror.PathAlreadyExists,

--- a/pkg/destination/onelake/onelake_test.go
+++ b/pkg/destination/onelake/onelake_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
@@ -53,9 +52,57 @@ func TestParseOneLakeURI(t *testing.T) {
 			wantLH:    "lh",
 			wantLayou: "{table_name}.parquet",
 		},
+		{
+			name:   "workspace with raw space",
+			uri:    "onelake://Fabric Dev/lh",
+			wantWS: "Fabric Dev",
+			wantLH: "lh",
+		},
+		{
+			name:   "workspace percent encoded",
+			uri:    "onelake://Fabric%20Dev/Sales%20LH",
+			wantWS: "Fabric Dev",
+			wantLH: "Sales LH",
+		},
+		{
+			name:   "workspace with literal percent",
+			uri:    "onelake://100% Club/lh",
+			wantWS: "100% Club",
+			wantLH: "lh",
+		},
+		{
+			name:   "guid workspace and lakehouse",
+			uri:    "onelake://11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+			wantWS: "11111111-1111-1111-1111-111111111111",
+			wantLH: "22222222-2222-2222-2222-222222222222",
+		},
+		{
+			name:    "sas token with escapes",
+			uri:     "onelake://ws/lh?sas_token=sv%3D2021%26sig%3Dab%2Fcd%3D",
+			wantWS:  "ws",
+			wantLH:  "lh",
+			wantSAS: "sv=2021&sig=ab/cd=",
+		},
+		{
+			name:      "encoded layout",
+			uri:       "onelake://ws/lh?layout=%7Btable_name%7D.parquet",
+			wantWS:    "ws",
+			wantLH:    "lh",
+			wantLayou: "{table_name}.parquet",
+		},
+		{
+			name:   "trailing slash",
+			uri:    "onelake://ws/lh/",
+			wantWS: "ws",
+			wantLH: "lh",
+		},
 		{name: "missing lakehouse", uri: "onelake://ws", wantErr: true},
 		{name: "nested lakehouse", uri: "onelake://ws/a/b", wantErr: true},
 		{name: "wrong scheme", uri: "s3://ws/lh", wantErr: true},
+		{name: "encoded lakehouse separator", uri: "onelake://ws/a%2Fb", wantErr: true},
+		{name: "encoded workspace separator", uri: "onelake://a%2Fb/lh", wantErr: true},
+		{name: "missing workspace", uri: "onelake:///lh", wantErr: true},
+		{name: "no scheme separator", uri: "onelake:ws/lh", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +121,15 @@ func TestParseOneLakeURI(t *testing.T) {
 			assert.Equal(t, tt.wantLayou, parsed.layout)
 		})
 	}
+}
+
+func TestParseOneLakeURIDoesNotLeakSecrets(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOneLakeURI("onelake://ws/a/b?client_secret=supersecret&sas_token=topsecret")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "supersecret")
+	assert.NotContains(t, err.Error(), "topsecret")
 }
 
 func TestParseTarget(t *testing.T) {
@@ -118,6 +174,40 @@ func TestItemAndDirPaths(t *testing.T) {
 	// Already-typed item segment is preserved.
 	d2 := &OneLakeDestination{lakehouse: "wh.Warehouse", relPath: "t"}
 	assert.Equal(t, "wh.Warehouse", d2.itemPath())
+}
+
+func TestItemPathGUID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		lakehouse string
+		want      string
+	}{
+		{"22222222-2222-2222-2222-222222222222", "22222222-2222-2222-2222-222222222222"},
+		{"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"},
+		// Non-canonical GUID spellings are not valid Fabric path segments, so they
+		// are treated as ordinary names.
+		{"22222222222222222222222222222222", "22222222222222222222222222222222.Lakehouse"},
+		{"urn:uuid:22222222-2222-2222-2222-222222222222", "urn:uuid:22222222-2222-2222-2222-222222222222.Lakehouse"},
+	}
+	for _, c := range cases {
+		d := &OneLakeDestination{lakehouse: c.lakehouse, relPath: "users"}
+		assert.Equal(t, c.want, d.itemPath(), c.lakehouse)
+	}
+
+	d := &OneLakeDestination{lakehouse: "22222222-2222-2222-2222-222222222222", relPath: "users"}
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222/Tables/users", d.tableDir())
+}
+
+func TestNewOneLakeFileClientEscapesWorkspace(t *testing.T) {
+	t.Parallel()
+
+	d := NewOneLakeDestination()
+	require.NoError(t, d.Connect(t.Context(), "onelake://Fabric Dev/lh?sas_token=sig=abc"))
+
+	client, err := d.newOneLakeFileClient("lh.Lakehouse/Tables/users/x.parquet")
+	require.NoError(t, err)
+	assert.Contains(t, client.DFSURL(), "/Fabric%20Dev/lh.Lakehouse/Tables/users/x.parquet")
 }
 
 func TestConnectBuildsClient(t *testing.T) {
@@ -276,16 +366,6 @@ func TestBuildAppendCommit(t *testing.T) {
 	// No protocol/metaData on append commits.
 	_, hasProtocol := lines[0]["protocol"]
 	assert.False(t, hasProtocol)
-}
-
-func TestDeltaCommitRenameOptionsUsesIfNoneMatchAny(t *testing.T) {
-	t.Parallel()
-
-	opts := deltaCommitRenameOptions()
-	require.NotNil(t, opts.AccessConditions)
-	require.NotNil(t, opts.AccessConditions.ModifiedAccessConditions)
-	require.NotNil(t, opts.AccessConditions.ModifiedAccessConditions.IfNoneMatch)
-	assert.Equal(t, azcore.ETagAny, *opts.AccessConditions.ModifiedAccessConditions.IfNoneMatch)
 }
 
 func TestDeltaCommitTempPathStaysOutsideDeltaLog(t *testing.T) {


### PR DESCRIPTION
Fixes two reported failures in the `onelake` destination, plus a third found while tracing the first end to end.

## Workspace names containing a space were unusable

The Fabric workspace sits in the URI authority (`onelake://<workspace>/<lakehouse>`), where Go's `net/url` rejects both a raw space and a percent-escaped one. A workspace named `Fabric Dev` could not be expressed in any form:

| URI | Before |
|---|---|
| `onelake://Fabric%20Dev/lh` | `failed to parse URI: invalid URL escape "%20"` |
| `onelake://Fabric Dev/lh` | `invalid character " " in host name` |

Two parsers needed changing:

- `internal/uri/parser.go` runs `url.Parse` on every non-file-based URI *before* scheme dispatch, so it rejected the URI before the connector saw it. It now has an `authorityOpaqueSchemes` map alongside the existing `fileBasedSchemes`. Nothing reads the parsed host/database/params for a destination, so the scheme-only result is equivalent.
- `parseOneLakeURI` now splits the URI itself. Path segments are cut *before* percent-decoding so an encoded separator can't be mistaken for a real one, and decoding falls back to the raw segment when it isn't valid percent-encoding, so a literal `%` in a name still works.

Both `Fabric Dev` and `Fabric%20Dev` are now accepted and resolve to the same workspace.

## GUID item targets got a bogus `.Lakehouse` suffix

`itemPath()` appended `.Lakehouse` to anything without a dot, but Fabric addresses items by GUID with *no* type suffix and rejects the decorated path. The suffix is now skipped for a canonical 8-4-4-4-12 GUID. The length gate is deliberate: `uuid.Validate` also accepts the urn, braced and dashless forms, none of which is a valid Fabric path segment.

## Delta commits sent an unescaped rename source

Tracing the first fix through to a real write surfaced a third problem. A Delta commit is made atomic by renaming a temp file into place, and `azdatalake`'s `file.Client.Rename` derives `x-ms-rename-source` from the **decoded** URL path (`file/client.go:259`) — Azure requires that header to be percent-encoded. For `Fabric Dev` the header went out as `/Fabric Dev/...`, and a workspace containing a literal `%` would have broken outright.

`adlsutil.RenameIfNotExists` now issues the DFS rename directly with a correctly escaped header, preserving the `If-None-Match: *` condition the commit retry loop depends on. It returns a response error carrying the `x-ms-error-code`, so `datalakeerror.HasCode` and the existing conflict detection are unchanged.

## Secret leak in URI errors

`parseOneLakeURI` returned `url.Parse`'s error unwrapped, and `*url.Error` embeds the entire URI — so a malformed URI printed `client_secret` and `sas_token` into the log. Errors no longer quote the URI.

## Verification

Reproduced both reported failures against the pre-fix code and confirmed they are gone:

| URI | Before | After |
|---|---|---|
| `onelake://Fabric%20Dev/lh` | `invalid URL escape "%20"` | reaches Azure auth |
| `onelake://Fabric Dev/lh` | `invalid character " " in host name` | reaches Azure auth |
| `onelake://<wsGUID>/<itemGUID>` | target `…-222222222222.Lakehouse/Tables/t` | target `…-222222222222/Tables/t` |

Tests cover URI parsing (raw space, `%20`, literal `%`, GUIDs, escaped SAS tokens, rejected `%2F`), GUID item paths, outbound URL escaping, and transport-level assertions that the rename sends an escaped `x-ms-rename-source` plus `If-None-Match: *`. The local-store tests no longer bypass the commit path through the `publishCommit` seam, so they now exercise the real upload-and-rename flow.

The rename change has not been exercised against live Fabric — it is correct per the DFS spec, but wants one Tables-mode load against a real spaced-name workspace before it is trusted.

## Trade-off

A workspace named *literally* `Fabric%20Dev` must now be written `Fabric%2520Dev`. Documented in `docs/supported-sources/onelake.md`.