### PR TITLE
Preserve unchanged TOAST/VARIANT columns in Snowflake CDC merges

### DIFF
--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -1490,9 +1490,14 @@ func cdcMergeAssign(colName, colQuoted, targetExpr, sourceExpr, unchangedColsExp
 	// The source emits _cdc_unchanged_cols using the source column names (e.g. lower case).
 	// The merge column name may be folded to upper case when the schema is read
 	// back from the destination on an incremental run, so compare case-insensitively.
+	//
+	// ARRAY_CONTAINS returns NULL when the marker list is NULL/unparseable;
+	// plain IFF would then fall through to source and wipe TOAST/VARIANT
+	// targets. COALESCE(..., TRUE) fails closed: preserve the target unless the
+	// marker is a valid JSON array that does not list this column.
 	colLit := strings.ReplaceAll(strings.ToLower(colName), "'", "''")
 	return fmt.Sprintf(
-		"%s = IFF(ARRAY_CONTAINS(TO_VARIANT('%s'), TRY_PARSE_JSON(LOWER(%s))), %s, %s)",
+		"%s = IFF(COALESCE(ARRAY_CONTAINS(TO_VARIANT('%s'), TRY_PARSE_JSON(LOWER(%s))), TRUE), %s, %s)",
 		colQuoted, colLit, unchangedColsExpr, targetExpr, sourceExpr,
 	)
 }

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -105,7 +105,7 @@ func TestBuildMergeSQL(t *testing.T) {
 		sql := buildMergeSQL("staging_schema.staging_tbl", "target_schema.target_tbl", []string{"id"}, columns, "", nil)
 
 		assert.Contains(t, sql, `AND (source."_CDC_DELETED" = false OR (source."__INGESTR_HAS_ACTIVE" AND (target."_CDC_LSN" IS NULL OR source."__INGESTR_ACTIVE_LSN" >= target."_CDC_LSN"))) THEN`)
-		assert.Contains(t, sql, `"CONFIG_DATA" = IFF(ARRAY_CONTAINS(TO_VARIANT('config_data'), TRY_PARSE_JSON(LOWER(source."_CDC_UNCHANGED_COLS"))), target."CONFIG_DATA", source."CONFIG_DATA")`)
+		assert.Contains(t, sql, `"CONFIG_DATA" = IFF(COALESCE(ARRAY_CONTAINS(TO_VARIANT('config_data'), TRY_PARSE_JSON(LOWER(source."_CDC_UNCHANGED_COLS"))), TRUE), target."CONFIG_DATA", source."CONFIG_DATA")`)
 		// staging-only column must not be persisted on the destination
 		assert.Contains(t, sql, "INSERT (\"ID\", \"NAME\", \"CONFIG_DATA\", \"_CDC_LSN\", \"_CDC_DELETED\", \"_CDC_SYNCED_AT\")\n")
 		assert.NotContains(t, sql, `INSERT ("ID", "NAME", "CONFIG_DATA", "_CDC_LSN", "_CDC_DELETED", "_CDC_SYNCED_AT", "_CDC_UNCHANGED_COLS")`)

--- a/tests/integration/postgres_cdc_snowflake_toast_test.go
+++ b/tests/integration/postgres_cdc_snowflake_toast_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Postgres JSONB under REPLICA IDENTITY DEFAULT: an UPDATE that touches only a
+// non-TOASTed column omits the TOASTed payload from the WAL tuple, so the merge
+// into Snowflake VARIANT must keep the existing document.
+func TestPostgresCDC_SnowflakeMergePreservesUnchangedJSONB(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	snowflakeTestURI := os.Getenv("GONG_TEST_SNOWFLAKE_URI")
+	if snowflakeTestURI == "" {
+		t.Skip("GONG_TEST_SNOWFLAKE_URI not set")
+	}
+
+	ctx := context.Background()
+	suffix := uniqueSuffix()
+	pubName := "test_toast_sf_pub_" + strings.ToLower(suffix)
+	srcTable := "public.test_toast_sf_" + strings.ToLower(suffix)
+	destTable := "PUBLIC.TEST_TOAST_SF_" + suffix
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	sourcePool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer sourcePool.Close()
+
+	items := make([]int, 200)
+	for i := range items {
+		items[i] = i
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"items":   items,
+		"padding": strings.Repeat("x", 8*1024),
+	})
+	require.NoError(t, err)
+
+	_, err = sourcePool.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL PRIMARY KEY,
+			payload JSONB NOT NULL,
+			status TEXT NOT NULL
+		)
+	`, srcTable))
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, fmt.Sprintf(`CREATE PUBLICATION %s FOR TABLE %s`, pubName, srcTable))
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+	_, err = sourcePool.Exec(
+		ctx,
+		fmt.Sprintf(`INSERT INTO %s (payload, status) VALUES ($1::jsonb, 'pending')`, srcTable),
+		string(payload),
+	)
+	require.NoError(t, err)
+
+	db, err := snowflakeOpenDB()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+destTable)
+		_ = db.Close()
+	})
+
+	cfg := &config.IngestConfig{
+		SourceURI: "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+			"&publication=" + pubName + "&mode=batch",
+		DestURI:             snowflakeTestURI,
+		SourceTable:         srcTable,
+		DestTable:           destTable,
+		PrimaryKeys:         []string{"id"},
+		IncrementalStrategy: "merge",
+	}
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	_, err = sourcePool.Exec(ctx, fmt.Sprintf(`UPDATE %s SET status = 'completed' WHERE id = 1`, srcTable))
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	var sourcePayload string
+	var sourceLen int
+	require.NoError(t, sourcePool.QueryRow(ctx, fmt.Sprintf(`
+		SELECT payload::text, jsonb_array_length(payload->'items')
+		FROM %s WHERE id = 1
+	`, srcTable)).Scan(&sourcePayload, &sourceLen))
+
+	var destLen int
+	var destStatus string
+	var matches bool
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT ARRAY_SIZE(PAYLOAD:"items"), STATUS, EQUAL_NULL(PARSE_JSON('%s'), PAYLOAD)
+		FROM %s WHERE ID = 1
+	`, escapeSnowflakeLiteral(sourcePayload), destTable)).Scan(&destLen, &destStatus, &matches))
+	assert.Equal(t, sourceLen, destLen, "items array length should match")
+	assert.True(t, matches, "unchanged JSONB payload should survive the partial-update merge")
+	assert.Equal(t, "completed", destStatus)
+}

--- a/tests/integration/snowflake_destination_cdc_lsn_fence_test.go
+++ b/tests/integration/snowflake_destination_cdc_lsn_fence_test.go
@@ -241,6 +241,98 @@ func TestSnowflakeDestinationCDCMergeAvoidsInternalAliasCollisions(t *testing.T)
 	require.Equal(t, "2026-01-03", synced)
 }
 
+// Unchanged-TOAST preservation on a VARIANT column: the staged value carries no
+// authoritative payload (NULL or empty), so the merge must keep the target JSON
+// unless the marker list explicitly says the column changed.
+func TestSnowflakeDestinationCDCMergePreservesUnchangedVariant(t *testing.T) {
+	snowflakeTestURI := os.Getenv("GONG_TEST_SNOWFLAKE_URI")
+	if snowflakeTestURI == "" {
+		t.Skip("GONG_TEST_SNOWFLAKE_URI not set")
+	}
+
+	ctx := t.Context()
+	targetTable := "PUBLIC.CDC_VARIANT_TARGET_" + uniqueSuffix()
+	stagingTable := "PUBLIC.CDC_VARIANT_STAGING_" + uniqueSuffix()
+	dest := snowflakedest.NewSnowflakeDestination()
+	require.NoError(t, dest.Connect(ctx, snowflakeTestURI))
+	t.Cleanup(func() { _ = dest.Close(context.Background()) })
+	db, err := snowflakeOpenDB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+stagingTable)
+		_, _ = db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+targetTable)
+	})
+
+	const originalJSON = `{"items":[1,2,3],"nested":{"a":"b"}}`
+	for _, statement := range []string{
+		fmt.Sprintf(`CREATE TABLE %s (
+			ID NUMBER(38,0),
+			PAYLOAD VARIANT,
+			STATUS VARCHAR,
+			_CDC_LSN VARCHAR,
+			_CDC_DELETED BOOLEAN,
+			_CDC_SYNCED_AT TIMESTAMP_NTZ
+		)`, targetTable),
+		fmt.Sprintf(`CREATE TABLE %s (
+			ID NUMBER(38,0),
+			PAYLOAD VARIANT,
+			STATUS VARCHAR,
+			_CDC_LSN VARCHAR,
+			_CDC_DELETED BOOLEAN,
+			_CDC_SYNCED_AT TIMESTAMP_NTZ,
+			_cdc_unchanged_cols VARCHAR
+		)`, stagingTable),
+		fmt.Sprintf(`INSERT INTO %s SELECT 1, PARSE_JSON('%s'), 'pending', '00000000000000000010', false, '2026-01-01'`, targetTable, originalJSON),
+	} {
+		require.NoError(t, dest.Exec(ctx, statement))
+	}
+
+	opts := destination.MergeOptions{
+		TargetTable:  targetTable,
+		StagingTable: stagingTable,
+		PrimaryKeys:  []string{"id"},
+		Columns: []string{
+			"ID", "PAYLOAD", "STATUS",
+			destination.CDCLSNColumn, destination.CDCDeletedColumn, destination.CDCSyncedAtColumn, destination.CDCUnchangedColsColumn,
+		},
+	}
+	stage := func(values string) {
+		t.Helper()
+		require.NoError(t, dest.Exec(ctx, "TRUNCATE TABLE "+stagingTable))
+		require.NoError(t, dest.Exec(ctx, fmt.Sprintf("INSERT INTO %s VALUES %s", stagingTable, values)))
+		require.NoError(t, dest.MergeTable(ctx, opts))
+	}
+
+	preserved := []struct {
+		name   string
+		values string
+		status string
+	}{
+		{"null payload with marker", `(1, NULL, 'done', '00000000000000000020', false, '2026-01-02', '["payload"]')`, "done"},
+		{"empty payload with marker", `(1, ''::VARIANT, 'done-2', '00000000000000000030', false, '2026-01-03', '["payload"]')`, "done-2"},
+	}
+	for _, tc := range preserved {
+		stage(tc.values)
+		var matches bool
+		var status, typeOf string
+		require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT EQUAL_NULL(PARSE_JSON('%s'), PAYLOAD), TYPEOF(PAYLOAD), STATUS FROM %s WHERE ID = 1
+		`, originalJSON, targetTable)).Scan(&matches, &typeOf, &status))
+		require.True(t, matches, "%s: target VARIANT must survive (TYPEOF=%s)", tc.name, typeOf)
+		require.Equal(t, tc.status, status, tc.name)
+	}
+
+	stage(`(1, NULL, 'cleared', '00000000000000000050', false, '2026-01-05', '[]')`)
+	var payloadIsNull bool
+	var status string
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT PAYLOAD IS NULL, STATUS FROM %s WHERE ID = 1", targetTable,
+	)).Scan(&payloadIsNull, &status))
+	require.True(t, payloadIsNull, "intentional NULL with empty marker must clear the target")
+	require.Equal(t, "cleared", status)
+}
+
 func assertSnowflakeCDCRow(t *testing.T, ctx context.Context, db *sql.DB, table, wantPayload, wantLSN string, wantDeleted bool) {
 	t.Helper()
 	var payload, lsn string


### PR DESCRIPTION
## What

Postgres CDC under `REPLICA IDENTITY DEFAULT` omits unchanged TOASTed columns (e.g. large `JSONB`) from WAL updates. Snowflake merge then used `IFF(ARRAY_CONTAINS(...), target, source)` to preserve those columns via `_cdc_unchanged_cols`. When that marker list was NULL or unparseable, `ARRAY_CONTAINS` returned NULL and `IFF` fell through to source — wiping VARIANT targets to NULL or `''`.

This PR fails closed: preserve the target unless the marker is a valid JSON array that does not list the column.

## Changes
- `pkg/destination/snowflake/snowflake.go` — wrap `ARRAY_CONTAINS` in `COALESCE(..., TRUE)` in `cdcMergeAssign`
- `pkg/destination/snowflake/snowflake_test.go` — update merge SQL assertion
- `tests/integration/snowflake_destination_cdc_lsn_fence_test.go` — VARIANT merge fixture (NULL/empty staging + marker preserves; intentional NULL with `[]` clears)
- `tests/integration/postgres_cdc_snowflake_toast_test.go` — Postgres → Snowflake end-to-end TOAST/`JSONB` regression

## How to test
1. `make test`
2. With `GONG_TEST_SNOWFLAKE_URI` set: `go test -tags integration -run 'TestSnowflakeDestinationCDCMergePreservesUnchangedVariant|TestPostgresCDC_SnowflakeMergePreservesUnchangedJSONB' ./tests/integration/`

## Risk & rollback
- **Risk:** Low — only changes CDC merge assignment when `_cdc_unchanged_cols` is present; intentional clears still use marker `[]`.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [ ] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues