### PR TITLE
cdc: let --source-table name a subset of tables

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/pipeline"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/strategy"
+	"github.com/bruin-data/ingestr/pkg/tablename"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v3"
 )
@@ -41,7 +42,7 @@ func IngestCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "source-table",
-				Usage:   "The table name in the source to fetch (optional for CDC multi-table mode)",
+				Usage:   "The table name in the source to fetch (optional for CDC multi-table mode; CDC sources also accept a comma-separated list to replicate just those tables)",
 				Sources: cli.EnvVars("SOURCE_TABLE", "INGESTR_SOURCE_TABLE"),
 			},
 			&cli.StringFlag{
@@ -280,7 +281,9 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 
 	cfg.SourceURI = c.String("source-uri")
 	cfg.DestURI = c.String("dest-uri")
-	cfg.SourceTable = c.String("source-table")
+	if err := applySourceTable(cfg, c.String("source-table")); err != nil {
+		return err
+	}
 	cfg.DestTable = c.String("dest-table")
 	cfg.IncrementalKey = c.String("incremental-key")
 	cfg.IncrementalPredicate = c.String("incremental-predicate")
@@ -416,6 +419,46 @@ func runIngest(ctx context.Context, c *cli.Command) (err error) {
 	return nil
 }
 
+// applySourceTable routes --source-table to either the single-table field or
+// the multi-table subset.
+//
+// The value is only ever split for CDC sources, and only when it contains a
+// comma. Every other source keeps the raw string: --source-table legitimately
+// carries commas elsewhere, in custom queries ("query:SELECT a, b FROM t") and
+// in structured SaaS table specs ("campaigns:123,456").
+func applySourceTable(cfg *config.IngestConfig, raw string) error {
+	if !strings.ContainsRune(raw, ',') || !config.IsCDCSourceURI(cfg.SourceURI) {
+		cfg.SourceTable = raw
+		return nil
+	}
+	names := tablename.SplitList(raw)
+	switch len(names) {
+	case 0:
+		// Widening an intended subset to the whole database would be the worst
+		// possible reading of a malformed list, so refuse it.
+		return fmt.Errorf("--source-table lists no table names")
+	case 1:
+		cfg.SourceTable = names[0]
+	default:
+		cfg.SourceTable = ""
+		cfg.SourceTables = names
+	}
+	return nil
+}
+
+// telemetryTableSelection reports how the run chose its tables. It is an
+// allowlisted enum: table names must never reach telemetry.
+func telemetryTableSelection(cfg *config.IngestConfig) string {
+	switch {
+	case len(cfg.SourceTables) > 0:
+		return "subset"
+	case cfg.SourceTable != "":
+		return "single"
+	default:
+		return "all"
+	}
+}
+
 func ingestTelemetryProperties(cfg *config.IngestConfig) map[string]any {
 	properties := map[string]any{}
 	if cfg == nil {
@@ -430,6 +473,7 @@ func ingestTelemetryProperties(cfg *config.IngestConfig) map[string]any {
 	properties["execution_mode"] = telemetryExecutionMode(cfg)
 	properties["full_refresh"] = cfg.FullRefresh
 	properties["multi_table"] = cfg.IsCDCSource() && cfg.SourceTable == ""
+	properties["table_selection"] = telemetryTableSelection(cfg)
 	properties["schema_inference_disabled"] = cfg.NoInference
 	properties["masking_enabled"] = len(cfg.Mask) > 0
 	properties["partitioned_extract"] = cfg.ExtractPartitionBy != ""

--- a/cmd/ingest_test.go
+++ b/cmd/ingest_test.go
@@ -107,3 +107,87 @@ func TestApplyExtractPartitionIntervalDoesNotDefaultWithoutPartitionBy(t *testin
 		t.Fatal("ExtractPartitionAuto = true, want false")
 	}
 }
+
+func TestApplySourceTableKeepsCommasForNonCDCSources(t *testing.T) {
+	// --source-table carries commas legitimately outside CDC: custom queries
+	// and structured SaaS table specs. Splitting those would break them.
+	tests := []struct {
+		name      string
+		sourceURI string
+		raw       string
+	}{
+		{"custom query", "postgres://user:pass@localhost:5432/db", "query:SELECT a, b FROM t"},
+		{"facebook ads account list", "facebookads://?access_token=x", "campaigns:1234567890,9876543210"},
+		{"fluxx field list", "fluxx://instance?client_id=x", "grant_request:id,name,amount"},
+		{"plain table", "postgres://user:pass@localhost:5432/db", "public.users"},
+		{"cdc single table", "postgres+cdc://user:pass@localhost:5432/db", "public.users"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.SourceURI = tt.sourceURI
+			if err := applySourceTable(cfg, tt.raw); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.SourceTable != tt.raw {
+				t.Fatalf("SourceTable = %q, want %q", cfg.SourceTable, tt.raw)
+			}
+			if cfg.SourceTables != nil {
+				t.Fatalf("SourceTables = %v, want nil", cfg.SourceTables)
+			}
+		})
+	}
+}
+
+func TestApplySourceTableSplitsCDCLists(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "postgres+cdc://user:pass@localhost:5432/db"
+	if err := applySourceTable(cfg, "public.users, sales.orders"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SourceTable != "" {
+		t.Fatalf("SourceTable = %q, want empty so the multi-table path runs", cfg.SourceTable)
+	}
+	if len(cfg.SourceTables) != 2 || cfg.SourceTables[0] != "public.users" || cfg.SourceTables[1] != "sales.orders" {
+		t.Fatalf("SourceTables = %v, want [public.users sales.orders]", cfg.SourceTables)
+	}
+}
+
+func TestApplySourceTableSingleEntryListStaysSingleTable(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "mysql+cdc://user:pass@localhost:3306/app"
+	if err := applySourceTable(cfg, "users,"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SourceTable != "users" || cfg.SourceTables != nil {
+		t.Fatalf("got SourceTable=%q SourceTables=%v, want users and nil", cfg.SourceTable, cfg.SourceTables)
+	}
+}
+
+func TestApplySourceTableRejectsEmptyList(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = "postgres+cdc://user:pass@localhost:5432/db"
+	// Reading this as "every table" would silently widen an intended subset.
+	if err := applySourceTable(cfg, " , "); err == nil {
+		t.Fatal("expected a list with no names to be rejected")
+	}
+}
+
+func TestTelemetryTableSelection(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.IngestConfig
+		want string
+	}{
+		{"all", &config.IngestConfig{}, "all"},
+		{"single", &config.IngestConfig{SourceTable: "users"}, "single"},
+		{"subset", &config.IngestConfig{SourceTables: []string{"users", "orders"}}, "subset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := telemetryTableSelection(tt.cfg); got != tt.want {
+				t.Fatalf("telemetryTableSelection = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -17,7 +17,7 @@ ingestr ingest \
 
 - `--source-uri TEXT`: Required. Specifies the URI of the data source.
 - `--dest-uri TEXT`: Required. Specifies the URI of the destination where data will be ingested.
-- `--source-table TEXT`: Required. Defines the source table to fetch data from.
+- `--source-table TEXT`: Defines the source table to fetch data from. Required except for CDC sources, which replicate every table in their capture set when it is omitted. CDC sources also accept a comma-separated list (`public.users,public.orders`) to replicate just those tables; see [Multi-table CDC](/getting-started/cdc#multi-table-cdc).
 
 ## Optional flags
 

--- a/docs/getting-started/cdc.md
+++ b/docs/getting-started/cdc.md
@@ -70,13 +70,31 @@ How quickly a change is noticed depends on the table. A busy table surfaces it r
 
 ### Multi-table CDC
 
-If you omit `--source-table`, most CDC connectors run in multi-table mode and replicate every eligible table in the source's capture set. Each table is snapshotted and streamed from its own position; a multi-table run is not a single global point-in-time snapshot across all tables, but each table is individually consistent. Use the `dest_schema` URI parameter to control where multi-table output lands. It applies to multi-table runs only: once `--source-table` is set, the destination comes from `--dest-table` and `dest_schema` is ignored.
+If you omit `--source-table`, most CDC connectors run in multi-table mode and replicate every eligible table in the source's capture set. Each table is snapshotted and streamed from its own position; a multi-table run is not a single global point-in-time snapshot across all tables, but each table is individually consistent. Use the `dest_schema` URI parameter to control where multi-table output lands. It applies to multi-table runs only: once `--source-table` names a single table, the destination comes from `--dest-table` and `dest_schema` is ignored.
 
 ```plaintext
 postgres+cdc://user:pass@host:5432/mydb?dest_schema=analytics
 ```
 
-For PostgreSQL, a schema change to a table already in the stream is handled in process, as described above. A brand-new table showing up is a bigger event: a one-shot run simply picks it up on its next start, but a running stream can't snapshot it mid-flight — when the periodic check finds one, the stream stops cleanly before touching any destination data and expects whatever supervises it (systemd, Kubernetes, a scheduler) to start it again. The restarted process snapshots the new table and then continues from the WAL still held by the existing slot, so no changes are missed in between. If you manage the publication yourself, remember to add the new table to it — ingestr won't do it for you.
+To replicate only some of those tables, give `--source-table` a comma-separated list. This is still a multi-table run — `dest_schema` applies, and each table gets its own destination table — just restricted to the tables you name.
+
+```bash
+ingestr ingest \
+    --source-uri "postgres+cdc://user:pass@host:5432/mydb?dest_schema=analytics" \
+    --source-table "public.users,public.orders" \
+    --dest-uri "bigquery://my-project"
+```
+
+Name tables the way the connector reports them: schema-qualified for PostgreSQL outside the `public` schema (`sales.orders`) and for SQL Server always (`dbo.users`), bare for MySQL, Vitess, PlanetScale and MongoDB. Matching is case-insensitive, and a qualifier that the connector drops is accepted either way, so `public.users` and `users` both select the same PostgreSQL table. A name that matches nothing fails the run rather than quietly ingesting less than you asked for.
+
+Two things to know before switching an existing pipeline to a list:
+
+- **The table set is fixed for the run.** A new table at the source is not picked up while a subset is in effect, and the stream is not interrupted by one appearing.
+- **A subset is a separate connector.** Its replication slot, run lease and CDC state are keyed to the set of tables you named, so changing the list — or moving between a list and no list — starts a fresh snapshot rather than resuming. That is deliberate: the slot for one subset advances past changes to the tables it filters out, so resuming a different set from it would silently skip them. It also means the old connector's replication slot is left behind holding WAL; drop it once you have moved off it.
+
+For PostgreSQL, listing tables does **not** narrow the publication. `ingestr_publication` is shared across every managed run against the database, so narrowing it would make concurrent pipelines overwrite each other's capture set. The source still receives the other tables' changes and discards them. To stop PostgreSQL from sending them at all, create your own publication and pass `?publication=`, which ingestr never rewrites.
+
+For PostgreSQL, a schema change to a table already in the stream is handled in process, as described above. A brand-new table showing up is a bigger event (unless `--source-table` names a fixed list, in which case new tables are ignored): a one-shot run simply picks it up on its next start, but a running stream can't snapshot it mid-flight — when the periodic check finds one, the stream stops cleanly before touching any destination data and expects whatever supervises it (systemd, Kubernetes, a scheduler) to start it again. The restarted process snapshots the new table and then continues from the WAL still held by the existing slot, so no changes are missed in between. If you manage the publication yourself, remember to add the new table to it — ingestr won't do it for you.
 
 ## Supported CDC platforms
 

--- a/docs/getting-started/telemetry.md
+++ b/docs/getting-started/telemetry.md
@@ -14,6 +14,7 @@ ingestr uses a basic form of usage telemetry to understand adoption at a high le
   - source and destination connector types, such as `postgres` or `bigquery`
   - execution mode, such as batch, stream, or CDC stream
   - non-identifying feature flags, such as full refresh, multi-table, masking, and schema inference
+  - whether the run read one table, a named subset, or every table — never which tables
   - coarse duration and CPU-capacity buckets
   - coarse deployment and invocation categories, such as Kubernetes, container, CI, or interactive
 

--- a/docs/supported-sources/mongodb.md
+++ b/docs/supported-sources/mongodb.md
@@ -175,7 +175,7 @@ ingestr ingest \
 This path reads a consistent snapshot of the collection first, then follows the change stream for inserts, updates, and deletes. It produces the `_cdc_lsn` (a change-stream resume token), `_cdc_deleted`, and `_cdc_synced_at` metadata columns and resumes from the stored token on subsequent runs. Incremental runs use the `merge` strategy so changes are applied by `_id`; deletes are soft (`_cdc_deleted = true`, and because MongoDB delete events carry only the `_id`, the row's other values are left untouched). Run with `--full-refresh` to rebuild from a fresh snapshot, or `--stream` to ingest continuously instead of once per invocation.
 
 CDC URI parameters:
-- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` names a single table; the destination is then `--dest-table`. A comma-separated `--source-table` is still a multi-table run, so `dest_schema` applies.
 
 Requirements:
 - Change streams require a **replica set** (or sharded cluster); they aren't available on a standalone `mongod`. Atlas clusters already satisfy this.

--- a/docs/supported-sources/mssql.md
+++ b/docs/supported-sources/mssql.md
@@ -79,7 +79,7 @@ Requirements:
 
 CDC URI parameters:
 - `capture_instance`: optional capture-instance name; defaults to the single instance registered for the table.
-- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` names a single table; the destination is then `--dest-table`. A comma-separated `--source-table` is still a multi-table run, so `dest_schema` applies.
 
 For a full walkthrough — enabling CDC and replicating a table into DuckDB — see [Replicate SQL Server to DuckDB with CDC](/tutorials/cdc-sqlserver-duckdb.md).
 

--- a/docs/supported-sources/mysql.md
+++ b/docs/supported-sources/mysql.md
@@ -70,10 +70,10 @@ Requirements:
 CDC URI parameters:
 - `mode`: **deprecated and ignored.** Continuous ingestion is controlled by `--stream`. `mode=batch` is accepted as a no-op; `mode=stream` is rejected unless `--stream` is also passed.
 - `server_id`: optional positive uint32 replication server id; generated automatically when omitted. Pin a unique value for scheduled or overlapping CDC runs.
-- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` names a single table; the destination is then `--dest-table`. A comma-separated `--source-table` is still a multi-table run, so `dest_schema` applies.
 - `flavor`: `mysql` or `mariadb`; inferred from the URI scheme unless overridden.
 
-Multi-table CDC snapshots each selected table independently and then stream each table from its own snapshot position. Each table is consistent on its own, but a multi-table run is not a single global point-in-time snapshot across all tables.
+Omit `--source-table` to replicate every table in the database, or pass a comma-separated list (for example `users,orders`) to replicate only those. Multi-table CDC snapshots each selected table independently and then stream each table from its own snapshot position. Each table is consistent on its own, but a multi-table run is not a single global point-in-time snapshot across all tables.
 
 ### Tutorial
 

--- a/docs/supported-sources/planetscale.md
+++ b/docs/supported-sources/planetscale.md
@@ -81,7 +81,7 @@ Position is tracked per shard and serialized into `_cdc_lsn`, and subsequent run
 
 CDC URI parameters:
 - `tls`: auto-enabled for the `ps_mysql://` scheme; set it explicitly only to choose a different mode (see [TLS](#tls)).
-- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` names a single table; the destination is then `--dest-table`. A comma-separated `--source-table` is still a multi-table run, so `dest_schema` applies.
 
 Requirements:
 - PlanetScale database credentials (`user:password`) with read access to the branch/keyspace.

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -35,16 +35,18 @@ CDC-specific URI parameters (all optional):
 - `slot`: the replication slot name. When omitted, ingestr derives a stable name from the publication.
 - `state_id`: an optional stable identity for this logical connector. Ingestr otherwise derives one from the source, destination, slot/publication, and table configuration. Set it when multiple otherwise-identical CDC connectors write to the same destination and must keep independent state.
 - `mode`: **deprecated and ignored.** Continuous ingestion is controlled by `--stream`. `mode=batch` is accepted as a no-op; `mode=stream` is rejected unless `--stream` is also passed.
-- `dest_schema`: optional destination schema/dataset for multi-table CDC runs. It is ignored when `--source-table` is set; in that case the destination is `--dest-table` (defaulting to the source table name), which must carry its own schema/dataset qualifier.
+- `dest_schema`: optional destination schema/dataset for multi-table CDC runs. It is ignored when `--source-table` names a single table; in that case the destination is `--dest-table` (defaulting to the source table name), which must carry its own schema/dataset qualifier. A comma-separated `--source-table` is still a multi-table run, so `dest_schema` applies.
 - `discover_interval`: how often a running stream re-checks the source for new tables (default `30s`, e.g. `1m`, `10s`). Set to `0` or `off` to disable mid-stream discovery.
 
-Without `--source-table`, CDC runs in multi-table mode and replicates every table in the publication. Deletes are soft: rows are kept in the destination with `_cdc_deleted = true`.
+Without `--source-table`, CDC runs in multi-table mode and replicates every table in the publication. Pass a comma-separated `--source-table` (for example `public.users,sales.orders`) to replicate only some of them; tables in the `public` schema can be named with or without the schema. Deletes are soft: rows are kept in the destination with `_cdc_deleted = true`.
+
+Listing tables does not narrow the publication — `ingestr_publication` is shared by every managed run against the database — so PostgreSQL still sends the other tables' changes and ingestr discards them. Supply your own `publication=` to control what the WAL carries. A subset also gets its own replication slot and CDC state, so changing the list starts a fresh snapshot; see [Multi-table CDC](/getting-started/cdc#multi-table-cdc).
 
 CDC progress is stored in a shared `cdc_state` event table and `cdc_targets` ownership registry in the destination's managed staging namespace (`_bruin_staging` by default, or the destination-specific staging placement). Rows are isolated by connector and source-table identity, so multiple connectors can safely share both tables. Resume never relies on the maximum `_cdc_lsn` in a user table. A table becomes resumable only after its complete snapshot marker is durable, so an interrupted snapshot is safely replaced on restart. PostgreSQL `TRUNCATE` events replace the affected destination table before later rows from the same transaction are applied.
 
 ### New tables
 
-Tables created on the source after CDC has been set up are picked up automatically:
+Tables created on the source after CDC has been set up are picked up automatically, unless `--source-table` names a fixed list — a subset never grows on its own:
 
 - **Without `--stream`**: the next run detects tables that have no state in the destination, snapshots their existing rows through a temporary replication slot (the main slot's position is untouched), and then streams their changes alongside the other tables.
 - **With `--stream`**: the running stream re-checks the source every `discover_interval`. When a new eligible table appears, the stream exits before changing destination data and reports that a restart is required. On restart, the table is included in the normal snapshot-and-stream path while the replication slot retains intervening WAL.

--- a/docs/supported-sources/vitess.md
+++ b/docs/supported-sources/vitess.md
@@ -61,11 +61,11 @@ Vitess CDC URI parameters:
 - `grpc_host`: optional vtgate gRPC host; defaults to the host in the URI.
 - `grpc_tls`: optional override for the gRPC connection's TLS, independent of `tls`. `true` verifies the server certificate, `skip-verify` skips verification, `false` forces plaintext. When omitted, the gRPC connection inherits `tls` (`true`/`skip-verify` enable it; `preferred` and custom CA names do not).
 - `mode`: deprecated and ignored; continuous ingestion is controlled by `--stream`.
-- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` is set; the destination is then `--dest-table`.
+- `dest_schema`: optional destination schema for multi-table CDC runs. Ignored when `--source-table` names a single table; the destination is then `--dest-table`. A comma-separated `--source-table` is still a multi-table run, so `dest_schema` applies.
 
 Requirements:
 - The vtgate gRPC endpoint must be reachable (`grpc_port`, plus `grpc_host` if it differs from the MySQL host).
-- Source tables must have primary keys, or `--primary-key` must be provided.
+- Source tables must have primary keys, or `--primary-key` must be provided. A keyless table fails a whole-keyspace run; name the tables you want with a comma-separated `--source-table` to replicate the rest of the keyspace around it.
 - Source tables must not contain `ENUM`, `SET`, or `BIT` columns.
 - Multi-table streaming cannot start with a mix of already-synced tables and new tables without stored cursors. Run once without `--stream` to establish cursors for the new tables, or use `--full-refresh` to rebuild all selected tables before starting the stream.
 

--- a/ingestr/_runner.py
+++ b/ingestr/_runner.py
@@ -198,7 +198,12 @@ def build_ingest_args(
     query_annotations: Optional[Union[str, Mapping[str, Any]]] = None,
     extra_args: Optional[Sequence[object]] = None,
 ) -> List[str]:
-    """Build CLI arguments for `ingestr ingest` without executing the command."""
+    """Build CLI arguments for `ingestr ingest` without executing the command.
+
+    ``source_table`` is passed through verbatim, so a CDC source can be given a
+    comma-separated list (``"public.users,public.orders"``) to replicate just
+    those tables.
+    """
 
     args = ["ingest"]
     _append_option(args, "source-uri", source_uri)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,13 @@ type IngestConfig struct {
 	SourceTable string
 	DestTable   string
 
+	// SourceTables restricts a multi-table CDC run to the named tables. It is
+	// populated from a comma-separated --source-table and is mutually
+	// exclusive with SourceTable: a single name stays in SourceTable and takes
+	// the single-table path, two or more move here and leave SourceTable empty
+	// so the multi-table path runs against just this set.
+	SourceTables []string
+
 	IncrementalStrategy         IncrementalStrategy
 	IncrementalStrategyExplicit bool
 	IncrementalKey              string
@@ -159,8 +166,11 @@ func (c *IngestConfig) Validate() error {
 		return &ValidationError{Field: "dest-uri", Message: "is required"}
 	}
 	// Source table is required unless this is a CDC source (multi-table mode)
-	if c.SourceTable == "" && !c.IsCDCSource() {
+	if c.SourceTable == "" && len(c.SourceTables) == 0 && !c.IsCDCSource() {
 		return &ValidationError{Field: "source-table", Message: "is required"}
+	}
+	if err := c.validateSourceTables(); err != nil {
+		return err
 	}
 	if c.DestTable == "" {
 		c.DestTable = c.SourceTable
@@ -284,11 +294,58 @@ func (c *IngestConfig) validateExtractPartitioning() error {
 
 // IsCDCSource returns true if the source URI is a CDC source.
 func (c *IngestConfig) IsCDCSource() bool {
-	schemeEnd := strings.Index(c.SourceURI, "://")
+	return IsCDCSourceURI(c.SourceURI)
+}
+
+// IsCDCSourceURI reports whether a source URI names a CDC connector. It is
+// exported so the CLI can decide how to parse --source-table before a config
+// exists.
+func IsCDCSourceURI(sourceURI string) bool {
+	schemeEnd := strings.Index(sourceURI, "://")
 	if schemeEnd == -1 {
 		return false
 	}
-	return strings.Contains(strings.ToLower(c.SourceURI[:schemeEnd]), "+cdc")
+	return strings.Contains(strings.ToLower(sourceURI[:schemeEnd]), "+cdc")
+}
+
+// validateSourceTables checks the multi-table subset produced by a
+// comma-separated --source-table.
+func (c *IngestConfig) validateSourceTables() error {
+	if len(c.SourceTables) == 0 {
+		return nil
+	}
+	if c.SourceTable != "" {
+		return &ValidationError{
+			Field:   "source-table",
+			Message: "cannot name both a single table and a table list",
+		}
+	}
+	if !c.IsCDCSource() {
+		return &ValidationError{
+			Field:   "source-table",
+			Message: "accepts a comma-separated list of tables for CDC sources only",
+		}
+	}
+	if len(c.SourceTables) < 2 {
+		return &ValidationError{
+			Field:   "source-table",
+			Message: "table list needs at least two tables; name one table directly to ingest it alone",
+		}
+	}
+	seen := make(map[string]struct{}, len(c.SourceTables))
+	for _, table := range c.SourceTables {
+		if strings.TrimSpace(table) == "" {
+			return &ValidationError{Field: "source-table", Message: "table list has an empty entry"}
+		}
+		if _, ok := seen[table]; ok {
+			return &ValidationError{
+				Field:   "source-table",
+				Message: fmt.Sprintf("table list repeats %s", table),
+			}
+		}
+		seen[table] = struct{}{}
+	}
+	return nil
 }
 
 // validateCDCMode enforces the deprecation of the ?mode= CDC URI parameter.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -478,3 +478,88 @@ func TestIngestConfigValidate_ChangeTrackingAllowsExplicitReplaceWithFullRefresh
 		t.Fatalf("Validate() error = %v", err)
 	}
 }
+
+func TestIngestConfigValidate_SourceTables(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(c *IngestConfig)
+		wantErr string
+	}{
+		{
+			name:   "valid subset",
+			mutate: func(c *IngestConfig) { c.SourceTables = []string{"users", "orders"} },
+		},
+		{
+			name: "single table is unaffected",
+			mutate: func(c *IngestConfig) {
+				c.SourceTable = "users"
+			},
+		},
+		{
+			name: "cannot combine with a single table",
+			mutate: func(c *IngestConfig) {
+				c.SourceTable = "users"
+				c.SourceTables = []string{"users", "orders"}
+			},
+			wantErr: "both a single table and a table list",
+		},
+		{
+			name: "non-cdc source rejected",
+			mutate: func(c *IngestConfig) {
+				c.SourceURI = "postgres://localhost:5432/db"
+				c.SourceTables = []string{"users", "orders"}
+			},
+			wantErr: "CDC sources only",
+		},
+		{
+			name:    "single-entry list rejected",
+			mutate:  func(c *IngestConfig) { c.SourceTables = []string{"users"} },
+			wantErr: "at least two tables",
+		},
+		{
+			name:    "blank entry rejected",
+			mutate:  func(c *IngestConfig) { c.SourceTables = []string{"users", " "} },
+			wantErr: "empty entry",
+		},
+		{
+			name:    "duplicate entry rejected",
+			mutate:  func(c *IngestConfig) { c.SourceTables = []string{"users", "users"} },
+			wantErr: "repeats users",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.SourceURI = "postgres+cdc://localhost:5432/db"
+			cfg.DestURI = "duckdb://out.duckdb"
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIngestConfigValidate_SubsetLeavesDestTableEmpty(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SourceURI = "postgres+cdc://localhost:5432/db"
+	cfg.DestURI = "duckdb://out.duckdb"
+	cfg.SourceTables = []string{"users", "orders"}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Multi-table runs derive each destination table from the source table, so
+	// DestTable must not be defaulted to a joined name.
+	if cfg.DestTable != "" {
+		t.Fatalf("DestTable = %q, want empty", cfg.DestTable)
+	}
+}

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -11,12 +11,26 @@ import (
 	"github.com/fatih/color"
 )
 
+// sourceTableSummary describes the tables the run will read. The confirmation
+// prompt is the user's last chance to catch a mistyped table list, so a subset
+// has to be visible here rather than showing an empty source table.
+func sourceTableSummary(cfg *config.IngestConfig) string {
+	if len(cfg.SourceTables) == 0 {
+		return cfg.SourceTable
+	}
+	const maxNamed = 5
+	if len(cfg.SourceTables) <= maxNamed {
+		return fmt.Sprintf("%d tables (%s)", len(cfg.SourceTables), strings.Join(cfg.SourceTables, ", "))
+	}
+	return fmt.Sprintf("%d tables (%s, ...)", len(cfg.SourceTables), strings.Join(cfg.SourceTables[:maxNamed], ", "))
+}
+
 func PrintSummary(cfg *config.IngestConfig) {
 	if output.IsJSON() {
 		output.EventStart(output.StartInfo{
 			SourceType:     displayFromURI(cfg.SourceURI)[0],
 			DestType:       displayFromURI(cfg.DestURI)[0],
-			SourceTable:    cfg.SourceTable,
+			SourceTable:    sourceTableSummary(cfg),
 			DestTable:      cfg.DestTable,
 			Strategy:       string(cfg.IncrementalStrategy),
 			IncrementalKey: cfg.IncrementalKey,
@@ -48,7 +62,7 @@ func PrintSummary(cfg *config.IngestConfig) {
 		}
 	}
 
-	printConnectionLine("Source:", displayFromURI(cfg.SourceURI), cfg.SourceTable)
+	printConnectionLine("Source:", displayFromURI(cfg.SourceURI), sourceTableSummary(cfg))
 	printConnectionLine("Destination:", displayFromURI(cfg.DestURI), cfg.DestTable)
 
 	strategyValue := string(cfg.IncrementalStrategy)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -195,7 +195,10 @@ func (s *Server) resolveRunRequest(req *RunJobRequest) error {
 	if req.DestURI == "" {
 		return fmt.Errorf("dest-uri is required")
 	}
-	if req.DestTable == "" {
+	// A comma-separated sourceTable selects a CDC subset, whose destination
+	// tables are derived per table; copying the list here would name one
+	// nonsense table.
+	if req.DestTable == "" && !strings.Contains(req.SourceTable, ",") {
 		req.DestTable = req.SourceTable
 	}
 	if req.IncrementalStrategy == "" && req.Strategy != "" {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -128,6 +129,18 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 	if validator, ok := src.(source.ConnectorPreflightValidator); ok {
 		if err := validator.ValidateConnectorPreflight(ctx, source.ConnectorPreflightOptions{Streaming: p.config.Stream}); err != nil {
 			return fmt.Errorf("source connector preflight failed: %w", err)
+		}
+	}
+	// Hand the source its table subset before anything discovers tables, so
+	// every later listing -- the initial GetTables, a streaming source's own
+	// re-discovery, and the periodic new-table check -- sees the same set.
+	if len(p.config.SourceTables) > 0 {
+		selector, ok := src.(source.TableSelector)
+		if !ok {
+			return fmt.Errorf("source does not support replicating a subset of tables; name a single table with --source-table, or omit it to replicate every table")
+		}
+		if err := selector.SelectTables(p.config.SourceTables); err != nil {
+			return err
 		}
 	}
 
@@ -277,7 +290,7 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 		}
 	}
 	if hasIgnoredDestSchema(p.config) {
-		output.Warnf("Warning: dest_schema is ignored when --source-table is set; the destination is %q. Omit --source-table for multi-table mode, or qualify --dest-table instead\n", p.config.DestTable)
+		output.Warnf("Warning: dest_schema is ignored when --source-table names a single table; the destination is %q. Omit --source-table, or list several tables, for multi-table mode, or qualify --dest-table instead\n", p.config.DestTable)
 	}
 	sourceIncarnation := ""
 	sourceSchemaFingerprint := ""
@@ -2821,6 +2834,11 @@ func resolvedCDCStateConnectorID(cfg *config.IngestConfig, identity source.Conne
 		cfg.SourceTable,
 		destinationTarget,
 	}
+	// Appended only when a subset is in play, so runs without one keep the
+	// connector ID they already have and never re-snapshot on upgrade.
+	if selection := cdcSelectionIdentity(cfg); selection != "" {
+		identityParts = append(identityParts, selection)
+	}
 	connectorIdentity := strings.Join(identityParts, "\x00")
 	sum := sha256.Sum256([]byte(connectorIdentity))
 	return fmt.Sprintf("%x", sum[:8])
@@ -2873,14 +2891,40 @@ func managedCDCDestinationTarget(cfg *config.IngestConfig, dest destination.Dest
 }
 
 func genericCDCConnectorID(cfg *config.IngestConfig) string {
-	identity := strings.Join([]string{
+	parts := []string{
 		canonicalCDCStateURI(cfg.SourceURI),
 		canonicalCDCStateURI(cfg.DestURI),
 		cfg.SourceTable,
 		cfg.DestTable,
-	}, "\x00")
+	}
+	if selection := cdcSelectionIdentity(cfg); selection != "" {
+		parts = append(parts, selection)
+	}
+	identity := strings.Join(parts, "\x00")
 	sum := sha256.Sum256([]byte(identity))
 	return fmt.Sprintf("%x", sum[:8])
+}
+
+// cdcSelectionIdentity contributes a table subset to the connector identity, so
+// a subset run gets its own replication slot, run lease and CDC state rather
+// than sharing them with the all-tables run against the same source and
+// destination.
+//
+// Sharing would be unsafe in both directions. The slot advances past changes to
+// tables the run filters out, so a later wider run would resume from a position
+// that has already skipped them and silently lose data; and --full-refresh
+// resets the state manager's completion markers wholesale, which would discard
+// the snapshot state of every table outside the subset. An empty selection
+// hashes to the empty string, so all-tables runs keep the identity they have
+// today.
+func cdcSelectionIdentity(cfg *config.IngestConfig) string {
+	if len(cfg.SourceTables) == 0 {
+		return ""
+	}
+	names := make([]string, len(cfg.SourceTables))
+	copy(names, cfg.SourceTables)
+	sort.Strings(names)
+	return strings.Join(names, ",")
 }
 
 func canonicalCDCStateURI(rawURI string) string {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2905,18 +2905,12 @@ func genericCDCConnectorID(cfg *config.IngestConfig) string {
 	return fmt.Sprintf("%x", sum[:8])
 }
 
-// cdcSelectionIdentity contributes a table subset to the connector identity, so
-// a subset run gets its own replication slot, run lease and CDC state rather
-// than sharing them with the all-tables run against the same source and
-// destination.
-//
-// Sharing would be unsafe in both directions. The slot advances past changes to
-// tables the run filters out, so a later wider run would resume from a position
-// that has already skipped them and silently lose data; and --full-refresh
-// resets the state manager's completion markers wholesale, which would discard
-// the snapshot state of every table outside the subset. An empty selection
-// hashes to the empty string, so all-tables runs keep the identity they have
-// today.
+// cdcSelectionIdentity gives a table subset its own replication slot, run lease
+// and CDC state. Sharing them with the all-tables run would lose data both
+// ways: the slot advances past changes to filtered-out tables, and
+// --full-refresh resets completion markers wholesale. An empty selection
+// returns "" and is left out of the identity, so existing connectors keep the
+// ID they have.
 func cdcSelectionIdentity(cfg *config.IngestConfig) string {
 	if len(cfg.SourceTables) == 0 {
 		return ""

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3883,3 +3883,58 @@ func TestValidateMultiTableNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestCDCConnectorIDIsolatesTableSubsets(t *testing.T) {
+	// A subset run must not share a slot or CDC state with the all-tables run
+	// against the same source and destination. Sharing would let the slot
+	// advance past changes to filtered-out tables, so a later wider run would
+	// resume from a position that has already skipped them; and --full-refresh
+	// resets the state manager's completion markers wholesale, discarding the
+	// snapshot state of every table outside the subset.
+	all := &config.IngestConfig{
+		SourceURI: "mysql+cdc://reader@source/app",
+		DestURI:   "mysql://loader@warehouse/analytics",
+	}
+	subset := *all
+	subset.SourceTables = []string{"users", "orders"}
+	otherSubset := *all
+	otherSubset.SourceTables = []string{"users", "invoices"}
+
+	require.NotEqual(t, genericCDCConnectorID(all), genericCDCConnectorID(&subset),
+		"a table subset must not share connector state with the all-tables run")
+	require.NotEqual(t, genericCDCConnectorID(&subset), genericCDCConnectorID(&otherSubset),
+		"different table subsets must not share connector state")
+
+	// Order is not meaningful, so the same set must resolve to the same ID.
+	reordered := *all
+	reordered.SourceTables = []string{"orders", "users"}
+	require.Equal(t, genericCDCConnectorID(&subset), genericCDCConnectorID(&reordered))
+
+	require.NotEqual(t,
+		cdcSlotSuffix(canonicalCDCStateURI(all.DestURI)+"\x00"+genericCDCConnectorID(all)),
+		cdcSlotSuffix(canonicalCDCStateURI(subset.DestURI)+"\x00"+genericCDCConnectorID(&subset)),
+		"a table subset must not share an automatic replication slot with the all-tables run")
+}
+
+func TestCDCConnectorIDUnchangedWithoutASubset(t *testing.T) {
+	// Existing pipelines must keep the connector ID they have today, byte for
+	// byte, or every running CDC connector would re-snapshot on upgrade. The
+	// selection is appended only when there is one, so no extra separator
+	// creeps into the hashed identity.
+	cfg := &config.IngestConfig{
+		SourceURI:   "mysql+cdc://reader@source/app",
+		SourceTable: "orders",
+		DestURI:     "mysql://loader@warehouse/analytics",
+		DestTable:   "orders",
+	}
+	require.Equal(t, "", cdcSelectionIdentity(cfg))
+
+	legacy := strings.Join([]string{
+		canonicalCDCStateURI(cfg.SourceURI),
+		canonicalCDCStateURI(cfg.DestURI),
+		cfg.SourceTable,
+		cfg.DestTable,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(legacy))
+	require.Equal(t, fmt.Sprintf("%x", sum[:8]), genericCDCConnectorID(cfg))
+}

--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemainfer"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -52,6 +53,7 @@ type MongoDBCDCSource struct {
 	uri       string
 	cdcConfig MongoDBCDCConfig
 	lag       *mongoLagState
+	selection *source.TableSelection
 }
 
 // mongoLagState tracks the cluster time of the last processed change event
@@ -411,10 +413,23 @@ func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]so
 	}
 	sort.Strings(collections)
 
+	selection := s.selection
+	if len(filter) > 0 {
+		// A caller-supplied filter (tests, and the legacy
+		// MultiTableReadOptions.Tables field) narrows further.
+		explicit, err := source.NewTableSelection(filter, s.selectionOptions())
+		if err != nil {
+			return nil, err
+		}
+		selection = explicit
+	}
+
 	selected := make([]source.SourceTableInfo, 0, len(collections))
 	pks := []string{"_id"}
 	for _, collection := range collections {
-		if len(filter) > 0 && !mongoCDCMatchesTable(filter, s.database, collection) {
+		// Filter before inferring the collection schema, which samples
+		// documents and is the expensive part of discovery.
+		if !selection.Includes(collection) {
 			continue
 		}
 		ns := mongoNamespace{Database: s.database, Collection: collection, Name: collection}
@@ -429,22 +444,50 @@ func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]so
 			DestSchema:  s.cdcConfig.DestSchema,
 		})
 	}
+	names := make([]string, 0, len(selected))
+	for _, table := range selected {
+		names = append(names, table.Name)
+	}
+	if err := selection.Validate(names, nil); err != nil {
+		return nil, err
+	}
 	if len(selected) == 0 {
-		if len(filter) > 0 {
-			return nil, fmt.Errorf("no MongoDB collections matched %s", strings.Join(filter, ", "))
-		}
 		return nil, fmt.Errorf("no MongoDB collections found in database %s", s.database)
 	}
 	return selected, nil
 }
 
-func mongoCDCMatchesTable(filter []string, db, collection string) bool {
-	for _, table := range filter {
-		if table == collection || table == db+"."+collection {
-			return true
-		}
+// selectionOptions describes how MongoDB CDC names its collections. A
+// collection is reported bare, so an optional database prefix is stripped.
+func (s *MongoDBCDCSource) selectionOptions() source.TableSelectionOptions {
+	return source.TableSelectionOptions{
+		Subject: "MongoDB collection",
+		Scope:   fmt.Sprintf("the collections in database %s", s.database),
+		Canonicalize: func(name string) (string, error) {
+			parts := tablename.Split(name)
+			switch len(parts) {
+			case 1:
+				return parts[0], nil
+			case 2:
+				if !strings.EqualFold(parts[0], s.database) {
+					return "", fmt.Errorf("MongoDB collection %q names database %q, but the source URI selects %q", name, parts[0], s.database)
+				}
+				return parts[1], nil
+			default:
+				return "", fmt.Errorf("MongoDB collection name must be collection or database.collection, %q given", name)
+			}
+		},
 	}
-	return false
+}
+
+// SelectTables restricts this source to the named collections.
+func (s *MongoDBCDCSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, s.selectionOptions())
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
 }
 
 func (s *MongoDBCDCSource) inferCollectionSchema(ctx context.Context, ns mongoNamespace, primaryKeys []string) (*schema.TableSchema, error) {
@@ -1026,5 +1069,6 @@ var (
 	_ source.Source           = (*MongoDBCDCSource)(nil)
 	_ source.StreamingSource  = (*MongoDBCDCSource)(nil)
 	_ source.MultiTableSource = (*MongoDBCDCSource)(nil)
+	_ source.TableSelector    = (*MongoDBCDCSource)(nil)
 	_ source.SourceTable      = (*MongoDBCDCTable)(nil)
 )

--- a/pkg/source/mongodb/cdc.go
+++ b/pkg/source/mongodb/cdc.go
@@ -247,11 +247,11 @@ func (s *MongoDBCDCSource) IsMultiTable() bool {
 }
 
 func (s *MongoDBCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
-	return s.getTables(ctx, nil)
+	return s.getTables(ctx)
 }
 
 func (s *MongoDBCDCSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
-	tables, err := s.getTables(ctx, opts.Tables)
+	tables, err := s.getTables(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func mongoCDCPrimaryKeys(pks []string) ([]string, error) {
 	return nil, fmt.Errorf("MongoDB CDC currently requires _id as the primary key because delete events only include documentKey")
 }
 
-func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]source.SourceTableInfo, error) {
+func (s *MongoDBCDCSource) getTables(ctx context.Context) ([]source.SourceTableInfo, error) {
 	if s.database == "" {
 		return nil, fmt.Errorf("MongoDB CDC multi-table mode requires a database in the source URI")
 	}
@@ -413,23 +413,17 @@ func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]so
 	}
 	sort.Strings(collections)
 
-	selection := s.selection
-	if len(filter) > 0 {
-		// A caller-supplied filter (tests, and the legacy
-		// MultiTableReadOptions.Tables field) narrows further.
-		explicit, err := source.NewTableSelection(filter, s.selectionOptions())
-		if err != nil {
-			return nil, err
-		}
-		selection = explicit
+	// Resolve before inferring collection schemas, which samples documents and
+	// is the expensive part of discovery.
+	requested, err := s.selection.Resolve(collections)
+	if err != nil {
+		return nil, err
 	}
 
-	selected := make([]source.SourceTableInfo, 0, len(collections))
+	selected := make([]source.SourceTableInfo, 0, len(requested))
 	pks := []string{"_id"}
 	for _, collection := range collections {
-		// Filter before inferring the collection schema, which samples
-		// documents and is the expensive part of discovery.
-		if !selection.Includes(collection) {
+		if _, ok := requested[collection]; !ok {
 			continue
 		}
 		ns := mongoNamespace{Database: s.database, Collection: collection, Name: collection}
@@ -448,7 +442,7 @@ func (s *MongoDBCDCSource) getTables(ctx context.Context, filter []string) ([]so
 	for _, table := range selected {
 		names = append(names, table.Name)
 	}
-	if err := selection.Validate(names, nil); err != nil {
+	if err := s.selection.Validate(names, nil); err != nil {
 		return nil, err
 	}
 	if len(selected) == 0 {

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -543,13 +543,32 @@ func TestMongoCDCSelectTables(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, collection := range []string{"users", "orders", "Users", "ORDERS"} {
-		if !src.selection.Includes(collection) {
+	// Both a bare and a database-qualified request resolve to the collection
+	// name the source reports, case-insensitively.
+	resolved, err := src.selection.Resolve([]string{"Users", "ORDERS", "invoices"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, collection := range []string{"Users", "ORDERS"} {
+		if _, ok := resolved[collection]; !ok {
 			t.Fatalf("expected %q to be selected", collection)
 		}
 	}
-	if src.selection.Includes("invoices") {
+	if _, ok := resolved["invoices"]; ok {
 		t.Fatal("did not expect an unrequested collection to be selected")
+	}
+
+	// MongoDB collection names are case-sensitive, so a case-insensitive match
+	// must never pull in a second collection alongside the one requested.
+	resolved, err = src.selection.Resolve([]string{"users", "Users", "orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resolved["Users"]; ok {
+		t.Fatalf("resolved = %v, want only the exactly-named users", resolved)
+	}
+	if _, ok := resolved["users"]; !ok {
+		t.Fatalf("resolved = %v, want users", resolved)
 	}
 
 	if err := src.SelectTables([]string{"users", "other.users"}); err == nil {

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -537,20 +537,26 @@ func TestParseMongoCDCNamespace(t *testing.T) {
 	}
 }
 
-func TestMongoCDCMatchesTableIsCaseSensitive(t *testing.T) {
-	filter := []string{"users", "app.orders"}
+func TestMongoCDCSelectTables(t *testing.T) {
+	src := &MongoDBCDCSource{database: "app"}
+	if err := src.SelectTables([]string{"users", "app.orders"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	if !mongoCDCMatchesTable(filter, "app", "users") {
-		t.Fatal("expected exact collection match")
+	for _, collection := range []string{"users", "orders", "Users", "ORDERS"} {
+		if !src.selection.Includes(collection) {
+			t.Fatalf("expected %q to be selected", collection)
+		}
 	}
-	if !mongoCDCMatchesTable(filter, "app", "orders") {
-		t.Fatal("expected exact qualified collection match")
+	if src.selection.Includes("invoices") {
+		t.Fatal("did not expect an unrequested collection to be selected")
 	}
-	if mongoCDCMatchesTable(filter, "app", "Users") {
-		t.Fatal("did not expect case-insensitive collection match")
+
+	if err := src.SelectTables([]string{"users", "other.users"}); err == nil {
+		t.Fatal("expected a collection naming a different database to be rejected")
 	}
-	if mongoCDCMatchesTable(filter, "App", "orders") {
-		t.Fatal("did not expect case-insensitive database match")
+	if err := src.SelectTables([]string{"users", "app.users"}); err == nil {
+		t.Fatal("expected two spellings of the same collection to be rejected")
 	}
 }
 

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -476,22 +476,6 @@ func (s *MSSQLCDCSource) SelectTables(names []string) error {
 	return nil
 }
 
-// selectTables applies the requested-table filter. A filter entry that
-// matches nothing is a hard error: silently ingesting nothing (and, in
-// streaming mode, polling forever) would hide a typo or an unqualified
-// table name.
-func selectTables(allTables []source.SourceTableInfo, skipped []skippedTable, requested []string) ([]source.SourceTableInfo, error) {
-	selection, err := source.NewTableSelection(requested, mssqlTableSelectionOptions)
-	if err != nil {
-		return nil, err
-	}
-	selected := selection.FilterTables(allTables)
-	if err := selection.Validate(tableInfoNames(selected), skippedReasons(skipped)); err != nil {
-		return nil, err
-	}
-	return selected, nil
-}
-
 func tableInfoNames(tables []source.SourceTableInfo) []string {
 	names := make([]string, 0, len(tables))
 	for _, table := range tables {
@@ -524,12 +508,21 @@ func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInf
 		return nil, nil, fmt.Errorf("no SQL Server CDC-enabled tables found")
 	}
 
-	tables := make([]source.SourceTableInfo, 0, len(metas))
+	inventory := make([]string, 0, len(metas))
+	for _, meta := range metas {
+		inventory = append(inventory, tableName(meta))
+	}
+	// Resolve before the per-table schema, incarnation and fingerprint queries
+	// so an unselected table costs nothing.
+	selected, err := s.selection.Resolve(inventory)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tables := make([]source.SourceTableInfo, 0, len(selected))
 	var skipped []skippedTable
 	for _, meta := range metas {
-		// Filter before the per-table schema, incarnation and fingerprint
-		// queries so an unselected table costs nothing.
-		if !s.selection.Includes(tableName(meta)) {
+		if _, ok := selected[tableName(meta)]; !ok {
 			continue
 		}
 		tableSchema, err := s.getCapturedSchema(ctx, meta)
@@ -576,11 +569,7 @@ func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInf
 }
 
 func (s *MSSQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
-	allTables, skipped, err := s.getTables(ctx)
-	if err != nil {
-		return nil, err
-	}
-	selected, err := selectTables(allTables, skipped, opts.Tables)
+	selected, _, err := s.getTables(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,6 +91,7 @@ type MSSQLCDCSource struct {
 	lag            *mssqlLagState
 	health         captureHealth
 	guidConversion bool
+	selection      *source.TableSelection
 
 	stateMu sync.Mutex
 	state   source.CDCStateCommitToken
@@ -458,45 +458,57 @@ type skippedTable struct {
 	reason string
 }
 
+// mssqlTableSelectionOptions describes how SQL Server CDC names its tables.
+// Names are always schema-qualified, including dbo, so no rewriting is needed.
+var mssqlTableSelectionOptions = source.TableSelectionOptions{
+	Subject: "SQL Server CDC table",
+	Scope:   "SQL Server CDC-enabled tables",
+	Hint:    "use schema-qualified names (e.g. dbo.users)",
+}
+
+// SelectTables restricts this source to the named tables.
+func (s *MSSQLCDCSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, mssqlTableSelectionOptions)
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
+}
+
 // selectTables applies the requested-table filter. A filter entry that
 // matches nothing is a hard error: silently ingesting nothing (and, in
 // streaming mode, polling forever) would hide a typo or an unqualified
 // table name.
 func selectTables(allTables []source.SourceTableInfo, skipped []skippedTable, requested []string) ([]source.SourceTableInfo, error) {
-	filter := map[string]string{}
-	for _, table := range requested {
-		table = strings.TrimSpace(table)
-		if table == "" {
-			continue
-		}
-		filter[strings.ToLower(table)] = table
+	selection, err := source.NewTableSelection(requested, mssqlTableSelectionOptions)
+	if err != nil {
+		return nil, err
 	}
-	filtered := len(filter) > 0
-
-	selected := make([]source.SourceTableInfo, 0, len(allTables))
-	for _, table := range allTables {
-		key := strings.ToLower(table.Name)
-		if filtered && filter[key] == "" {
-			continue
-		}
-		delete(filter, key)
-		selected = append(selected, table)
-	}
-
-	for _, st := range skipped {
-		if requestedName, ok := filter[strings.ToLower(st.name)]; ok {
-			return nil, fmt.Errorf("SQL Server CDC table %s cannot be ingested: %s", requestedName, st.reason)
-		}
-	}
-	if len(filter) > 0 {
-		missing := make([]string, 0, len(filter))
-		for _, requestedName := range filter {
-			missing = append(missing, requestedName)
-		}
-		sort.Strings(missing)
-		return nil, fmt.Errorf("tables not found among SQL Server CDC-enabled tables: %s; use schema-qualified names (e.g. dbo.users)", strings.Join(missing, ", "))
+	selected := selection.FilterTables(allTables)
+	if err := selection.Validate(tableInfoNames(selected), skippedReasons(skipped)); err != nil {
+		return nil, err
 	}
 	return selected, nil
+}
+
+func tableInfoNames(tables []source.SourceTableInfo) []string {
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.Name)
+	}
+	return names
+}
+
+func skippedReasons(skipped []skippedTable) map[string]string {
+	if len(skipped) == 0 {
+		return nil
+	}
+	reasons := make(map[string]string, len(skipped))
+	for _, st := range skipped {
+		reasons[st.name] = st.reason
+	}
+	return reasons
 }
 
 // getTables lists ingestible CDC-enabled tables. Tables that cannot join a
@@ -515,6 +527,11 @@ func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInf
 	tables := make([]source.SourceTableInfo, 0, len(metas))
 	var skipped []skippedTable
 	for _, meta := range metas {
+		// Filter before the per-table schema, incarnation and fingerprint
+		// queries so an unselected table costs nothing.
+		if !s.selection.Includes(tableName(meta)) {
+			continue
+		}
 		tableSchema, err := s.getCapturedSchema(ctx, meta)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get schema for %s: %w", tableName(meta), err)
@@ -549,6 +566,9 @@ func (s *MSSQLCDCSource) getTables(ctx context.Context) ([]source.SourceTableInf
 		})
 	}
 
+	if err := s.selection.Validate(tableInfoNames(tables), skippedReasons(skipped)); err != nil {
+		return nil, skipped, err
+	}
 	if len(tables) == 0 {
 		return nil, skipped, fmt.Errorf("no SQL Server CDC-enabled tables with a primary key found")
 	}
@@ -2130,6 +2150,7 @@ func isZeroLSN(lsn string) bool {
 var (
 	_ source.Source           = (*MSSQLCDCSource)(nil)
 	_ source.MultiTableSource = (*MSSQLCDCSource)(nil)
+	_ source.TableSelector    = (*MSSQLCDCSource)(nil)
 	_ source.StreamingSource  = (*MSSQLCDCSource)(nil)
 	_ source.SourceTable      = (*CDCTable)(nil)
 )

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -356,21 +356,58 @@ func TestSelectTables(t *testing.T) {
 	}
 	skipped := []skippedTable{{name: "dbo.audit_log", reason: "it has no primary key"}}
 
-	selected, err := selectTables(all, skipped, nil)
+	selectTables := func(requested []string) ([]source.SourceTableInfo, error) {
+		selection, err := source.NewTableSelection(requested, mssqlTableSelectionOptions)
+		if err != nil {
+			return nil, err
+		}
+		resolved, err := selection.Resolve(tableInfoNames(all))
+		if err != nil {
+			return nil, err
+		}
+		selected := make([]source.SourceTableInfo, 0, len(resolved))
+		for _, table := range all {
+			if _, ok := resolved[table.Name]; ok {
+				selected = append(selected, table)
+			}
+		}
+		if err := selection.Validate(tableInfoNames(selected), skippedReasons(skipped)); err != nil {
+			return nil, err
+		}
+		return selected, nil
+	}
+
+	selected, err := selectTables(nil)
 	require.NoError(t, err)
 	assert.Len(t, selected, 2, "no filter selects every ingestible table")
 
-	selected, err = selectTables(all, skipped, []string{"DBO.Users"})
+	selected, err = selectTables([]string{"DBO.Users"})
 	require.NoError(t, err)
 	require.Len(t, selected, 1)
 	assert.Equal(t, "dbo.users", selected[0].Name)
 
-	_, err = selectTables(all, skipped, []string{"dbo.users", "dbo.missing"})
+	_, err = selectTables([]string{"dbo.users", "dbo.missing"})
 	assert.ErrorContains(t, err, "dbo.missing")
 	assert.ErrorContains(t, err, "schema-qualified")
 
-	_, err = selectTables(all, skipped, []string{"dbo.audit_log"})
+	// A table that exists but cannot be ingested says why, rather than
+	// reporting as missing.
+	_, err = selectTables([]string{"dbo.audit_log"})
 	assert.ErrorContains(t, err, "no primary key")
+}
+
+func TestMSSQLCDCSelectTables(t *testing.T) {
+	src := &MSSQLCDCSource{}
+	require.NoError(t, src.SelectTables([]string{"DBO.Users"}))
+
+	// SQL Server reports schema-qualified names; matching is case-insensitive.
+	resolved, err := src.selection.Resolve([]string{"dbo.users", "dbo.orders"})
+	require.NoError(t, err)
+	assert.Contains(t, resolved, "dbo.users")
+	assert.NotContains(t, resolved, "dbo.orders")
+
+	require.Error(t, src.SelectTables([]string{"dbo.users", "DBO.USERS"}),
+		"two spellings of the same table must be rejected")
 }
 
 func TestValidateCapturedPrimaryKeys(t *testing.T) {

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -573,19 +573,30 @@ func (s *MySQLCDCSource) getMySQLCDCTableNames(ctx context.Context, q mysqlCDCPo
 	}
 	defer func() { _ = rows.Close() }()
 
-	var tableNames []string
+	var inventory []string
 	for rows.Next() {
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan MySQL table: %w", err)
 		}
-		if !s.selection.Includes(tableName) {
-			continue
-		}
-		tableNames = append(tableNames, tableName)
+		inventory = append(inventory, tableName)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+	if s.selection.Empty() {
+		return inventory, nil
+	}
+
+	selected, err := s.selection.Resolve(inventory)
+	if err != nil {
+		return nil, err
+	}
+	tableNames := make([]string, 0, len(selected))
+	for _, tableName := range inventory {
+		if _, ok := selected[tableName]; ok {
+			tableNames = append(tableNames, tableName)
+		}
 	}
 	if err := s.selection.Validate(tableNames, nil); err != nil {
 		return nil, err
@@ -642,28 +653,19 @@ func (s *MySQLCDCSource) warnKeylessTable(name string) {
 	fmt.Printf("Warning: table %s has no primary key; ingesting it as an append-only change log (_cdc_deleted marks deletes, updates arrive as delete+insert pairs)\n", name)
 }
 
-func (s *MySQLCDCSource) getSelectedTables(ctx context.Context, opts source.MultiTableReadOptions) ([]source.SourceTableInfo, error) {
+// getSelectedTables lists the tables this run covers. getMySQLCDCTableNames has
+// already applied the user's selection, so the inventory it returns is the set
+// every later drift check compares against.
+func (s *MySQLCDCSource) getSelectedTables(ctx context.Context) ([]source.SourceTableInfo, error) {
 	tableNames, err := s.getMySQLCDCTableNames(ctx, s.db)
 	if err != nil {
 		return nil, err
 	}
-	if len(tableNames) == 0 && len(opts.Tables) == 0 {
+	if len(tableNames) == 0 {
 		return nil, fmt.Errorf("no MySQL tables found in database %s", s.database)
 	}
 
-	filter := map[string]bool{}
-	for _, table := range opts.Tables {
-		filter[strings.ToLower(table)] = true
-	}
-
-	selectedNames := make([]string, 0, len(tableNames))
-	for _, tableName := range tableNames {
-		if len(filter) > 0 && !filter[strings.ToLower(tableName)] {
-			continue
-		}
-		selectedNames = append(selectedNames, tableName)
-	}
-	selected, err := s.loadMySQLCDCTables(ctx, selectedNames, false)
+	selected, err := s.loadMySQLCDCTables(ctx, tableNames, false)
 	if err != nil {
 		return nil, err
 	}
@@ -676,11 +678,11 @@ func (s *MySQLCDCSource) getSelectedTables(ctx context.Context, opts source.Mult
 }
 
 func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
-	selected, err := s.getSelectedTables(ctx, opts)
+	selected, err := s.getSelectedTables(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.validateMySQLCDCDiscoveredSchemas(selected, opts.Tables); err != nil {
+	if err := s.validateMySQLCDCDiscoveredSchemas(selected); err != nil {
 		return nil, err
 	}
 
@@ -718,7 +720,7 @@ func (s *MySQLCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRead
 			}
 
 			inventoryValidator := func(validationCtx context.Context, q mysqlCDCPositionQueryer) error {
-				return s.validateMySQLCDCInventory(validationCtx, q, opts.Tables)
+				return s.validateMySQLCDCInventory(validationCtx, q)
 			}
 			snapshotCheckpoint, err := s.snapshotTable(ctx, meta, table.Schema, opts.ReadOptions, results, table.Name, inventoryValidator)
 			if err != nil {
@@ -757,7 +759,11 @@ func cloneMySQLCDCTableSchema(tableSchema *schema.TableSchema) *schema.TableSche
 	return &cloned
 }
 
-func (s *MySQLCDCSource) validateMySQLCDCDiscoveredSchemas(selected []source.SourceTableInfo, requested []string) error {
+// validateMySQLCDCDiscoveredSchemas checks that the tables this run covers have
+// not changed since discovery. The inventory is already narrowed to the user's
+// selection, so a table outside it can appear or vanish without disturbing the
+// run.
+func (s *MySQLCDCSource) validateMySQLCDCDiscoveredSchemas(selected []source.SourceTableInfo) error {
 	s.schemaMu.Lock()
 	defer s.schemaMu.Unlock()
 	if s.discoveredSchemas == nil {
@@ -767,10 +773,8 @@ func (s *MySQLCDCSource) validateMySQLCDCDiscoveredSchemas(selected []source.Sou
 		}
 	}
 	current := make(map[string]*schema.TableSchema, len(selected))
-	currentFolded := make(map[string]struct{}, len(selected))
 	for _, table := range selected {
 		current[table.Name] = table.Schema
-		currentFolded[strings.ToLower(table.Name)] = struct{}{}
 		expected, exists := s.discoveredSchemas[table.Name]
 		if !exists {
 			return fmt.Errorf("MySQL table %s appeared after CDC table discovery and before snapshots began; retry so it can be prepared safely", table.Name)
@@ -779,23 +783,18 @@ func (s *MySQLCDCSource) validateMySQLCDCDiscoveredSchemas(selected []source.Sou
 			return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before its snapshot; run with --full-refresh to restart with the current schema", table.Name)
 		}
 	}
-	if len(requested) == 0 {
-		for table := range s.discoveredSchemas {
-			if _, exists := current[table]; !exists {
-				return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before its snapshot; run with --full-refresh to restart with the current schema", table)
-			}
-		}
-		return nil
-	}
-	for _, table := range requested {
-		if _, exists := currentFolded[strings.ToLower(table)]; !exists {
-			return fmt.Errorf("selected MySQL table %s is no longer available after CDC table discovery; run with --full-refresh to restart with the current schema", table)
+	for table := range s.discoveredSchemas {
+		if _, exists := current[table]; !exists {
+			return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before its snapshot; run with --full-refresh to restart with the current schema", table)
 		}
 	}
 	return nil
 }
 
-func (s *MySQLCDCSource) validateMySQLCDCInventory(ctx context.Context, q mysqlCDCPositionQueryer, requested []string) error {
+// validateMySQLCDCInventory re-lists at a snapshot boundary and fails if the
+// set of tables this run covers has shifted. Both sides are narrowed to the
+// user's selection, so tables outside it are invisible to the comparison.
+func (s *MySQLCDCSource) validateMySQLCDCInventory(ctx context.Context, q mysqlCDCPositionQueryer) error {
 	tableNames, err := s.getMySQLCDCTableNames(ctx, q)
 	if err != nil {
 		return err
@@ -811,26 +810,14 @@ func (s *MySQLCDCSource) validateMySQLCDCInventory(ctx context.Context, q mysqlC
 	for table := range s.discoveredSchemas {
 		expected[strings.ToLower(table)] = table
 	}
-	if len(requested) == 0 {
-		for table, original := range expected {
-			if _, exists := current[table]; !exists {
-				return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before snapshots began; run with --full-refresh to restart with the current schema", original)
-			}
+	for table, original := range expected {
+		if _, exists := current[table]; !exists {
+			return fmt.Errorf("MySQL table %s changed after CDC schema discovery and before snapshots began; run with --full-refresh to restart with the current schema", original)
 		}
-		for table := range current {
-			if _, exists := expected[table]; !exists {
-				return fmt.Errorf("MySQL table %s appeared after CDC table discovery and before snapshots began; retry so it can be prepared safely", table)
-			}
-		}
-		return nil
 	}
-	for _, table := range requested {
-		folded := strings.ToLower(table)
-		if _, discovered := expected[folded]; !discovered {
-			return fmt.Errorf("selected MySQL table %s appeared after CDC table discovery; retry so it can be prepared safely", table)
-		}
-		if _, exists := current[folded]; !exists {
-			return fmt.Errorf("selected MySQL table %s is no longer available after CDC table discovery; run with --full-refresh to restart with the current schema", table)
+	for table := range current {
+		if _, exists := expected[table]; !exists {
+			return fmt.Errorf("MySQL table %s appeared after CDC table discovery and before snapshots began; retry so it can be prepared safely", table)
 		}
 	}
 	return nil

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/mysqluri"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 	mysqldriver "github.com/go-sql-driver/mysql"
@@ -96,6 +97,10 @@ type MySQLCDCSource struct {
 	state             source.CDCStateCommitToken
 	schemaMu          sync.Mutex
 	discoveredSchemas map[string]*schema.TableSchema
+	// selection restricts the capture set to the tables the user named. It is
+	// applied in getMySQLCDCTableNames so both the discovered schemas and every
+	// later inventory re-check see the same narrowed set.
+	selection *source.TableSelection
 	// keylessWarned dedupes the append-only notice per table: discovery runs
 	// repeatedly (initial run, catch-up runs, streaming rediscovery) and the
 	// warning should print once per table, not once per pass.
@@ -522,6 +527,39 @@ func (s *MySQLCDCSource) getTables(ctx context.Context, validateSupported bool) 
 	return tables, nil
 }
 
+// bareTableName strips an optional database or keyspace prefix from a
+// user-supplied name. MySQL, Vitess and PlanetScale all report bare table
+// names, so "app.users" and "users" must resolve to the same table.
+func bareTableName(name string) (string, error) {
+	parts := tablename.Split(name)
+	switch len(parts) {
+	case 1:
+		return parts[0], nil
+	case 2:
+		return parts[1], nil
+	default:
+		return "", fmt.Errorf("table name must be table or database.table, %q given", name)
+	}
+}
+
+// mysqlTableSelectionOptions describes how MySQL CDC names its tables. Names
+// are bare, so an optional database prefix is stripped.
+var mysqlTableSelectionOptions = source.TableSelectionOptions{
+	Subject:      "MySQL CDC table",
+	Scope:        "the database's tables",
+	Canonicalize: bareTableName,
+}
+
+// SelectTables restricts this source to the named tables.
+func (s *MySQLCDCSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, mysqlTableSelectionOptions)
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
+}
+
 func (s *MySQLCDCSource) getMySQLCDCTableNames(ctx context.Context, q mysqlCDCPositionQueryer) ([]string, error) {
 	rows, err := q.QueryContext(ctx, `
 		SELECT TABLE_NAME
@@ -541,9 +579,15 @@ func (s *MySQLCDCSource) getMySQLCDCTableNames(ctx context.Context, q mysqlCDCPo
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan MySQL table: %w", err)
 		}
+		if !s.selection.Includes(tableName) {
+			continue
+		}
 		tableNames = append(tableNames, tableName)
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := s.selection.Validate(tableNames, nil); err != nil {
 		return nil, err
 	}
 	return tableNames, nil
@@ -3195,6 +3239,7 @@ func mysqlBinlogSequence(name string) uint64 {
 var (
 	_ source.Source           = (*MySQLCDCSource)(nil)
 	_ source.MultiTableSource = (*MySQLCDCSource)(nil)
+	_ source.TableSelector    = (*MySQLCDCSource)(nil)
 	_ source.StreamingSource  = (*MySQLCDCSource)(nil)
 	_ source.SourceTable      = (*MySQLCDCTable)(nil)
 )

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -170,7 +170,8 @@ func TestMySQLCDCReadAllValidatesOnlySelectedTables(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"}))
 
 	src := &MySQLCDCSource{db: db, database: "app"}
-	selected, err := src.getSelectedTables(context.Background(), source.MultiTableReadOptions{Tables: []string{"good"}})
+	require.NoError(t, src.SelectTables([]string{"good"}))
+	selected, err := src.getSelectedTables(context.Background())
 	require.NoError(t, err)
 	require.Len(t, selected, 1)
 	assert.Equal(t, "good", selected[0].Name)
@@ -210,7 +211,8 @@ func TestMySQLCDCReadAllInitializesFilteredDiscoveryWithoutGetTables(t *testing.
 		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
 
 	src := &MySQLCDCSource{db: db, database: "app"}
-	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{Tables: []string{"good"}})
+	require.NoError(t, src.SelectTables([]string{"good"}))
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{})
 	require.NoError(t, err)
 	var batches int
 	for result := range results {
@@ -283,8 +285,9 @@ func TestMySQLCDCReadAllRejectsMissingOrEmptyInventoryWithoutGetTables(t *testin
 			WithArgs("app").
 			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("other"))
 		src := &MySQLCDCSource{db: db, database: "app"}
-		_, err = src.ReadAll(t.Context(), source.MultiTableReadOptions{Tables: []string{"missing"}})
-		require.ErrorContains(t, err, "no longer available")
+		require.NoError(t, src.SelectTables([]string{"missing"}))
+		_, err = src.ReadAll(t.Context(), source.MultiTableReadOptions{})
+		require.ErrorContains(t, err, "missing")
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -460,7 +463,8 @@ func TestMySQLCDCReadAllIgnoresUnrequestedInventoryChangesAtSnapshotBoundaries(t
 		WillReturnRows(sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000012", "345"))
 
 	src := &MySQLCDCSource{db: db, database: "app"}
-	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{Tables: []string{"first", "second"}})
+	require.NoError(t, src.SelectTables([]string{"first", "second"}))
+	results, err := src.ReadAll(t.Context(), source.MultiTableReadOptions{})
 	require.NoError(t, err)
 	var batches int
 	for result := range results {
@@ -1075,22 +1079,19 @@ func TestValidateMySQLCDCSnapshotSchemaRejectsDiscoveryRace(t *testing.T) {
 func TestValidateMySQLCDCDiscoveredSchemasRejectsMultiTableRace(t *testing.T) {
 	expected := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
 	src := &MySQLCDCSource{discoveredSchemas: map[string]*schema.TableSchema{"items": expected}}
-	require.NoError(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{{Name: "items", Schema: cloneMySQLCDCTableSchema(expected)}}, nil))
+	require.NoError(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{{Name: "items", Schema: cloneMySQLCDCTableSchema(expected)}}))
 
 	changed := cloneMySQLCDCTableSchema(expected)
 	changed.Columns = append(changed.Columns, schema.Column{Name: "added", DataType: schema.TypeString})
-	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{{Name: "items", Schema: changed}}, nil), "--full-refresh")
+	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{{Name: "items", Schema: changed}}), "--full-refresh")
 	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas([]source.SourceTableInfo{
 		{Name: "items", Schema: expected},
 		{Name: "late", Schema: expected},
-	}, nil), "appeared after")
+	}), "appeared after")
 
-	src.discoveredSchemas["ignored"] = cloneMySQLCDCTableSchema(expected)
-	require.NoError(t, src.validateMySQLCDCDiscoveredSchemas(
-		[]source.SourceTableInfo{{Name: "items", Schema: cloneMySQLCDCTableSchema(expected)}},
-		[]string{"items"},
-	))
-	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas(nil, []string{"items"}), "no longer available")
+	// A discovered table vanishing between discovery and its snapshot is a
+	// drift the run cannot absorb, whether or not a subset was requested.
+	require.ErrorContains(t, src.validateMySQLCDCDiscoveredSchemas(nil), "--full-refresh")
 }
 
 func TestBeginMySQLConsistentSnapshotLocksAroundPosition(t *testing.T) {
@@ -1153,7 +1154,7 @@ func TestBeginMySQLConsistentSnapshotValidatesInventoryBeforeUnlock(t *testing.T
 	}
 
 	_, err = beginMySQLConsistentSnapshotWithValidation(ctx, conn, func(validationCtx context.Context, q mysqlCDCPositionQueryer) error {
-		return src.validateMySQLCDCInventory(validationCtx, q, nil)
+		return src.validateMySQLCDCInventory(validationCtx, q)
 	})
 	require.ErrorContains(t, err, "appeared after")
 	require.NoError(t, mock.ExpectationsWereMet())

--- a/pkg/source/mysql/cdc_test.go
+++ b/pkg/source/mysql/cdc_test.go
@@ -1531,3 +1531,67 @@ func TestMySQLCDCTableReadErrorsWhenResumePositionInvalid(t *testing.T) {
 	assert.False(t, ok)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestMySQLCDCSelectTablesNarrowsDiscovery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).
+			AddRow("bad").
+			AddRow("good"))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	// A database-qualified name resolves to the bare name the source reports.
+	require.NoError(t, src.SelectTables([]string{"app.good"}))
+
+	// The filter is applied while listing, so an unselected table never reaches
+	// the per-table schema queries and never enters the inventory that the
+	// snapshot-boundary checks compare against.
+	names, err := src.getMySQLCDCTableNames(t.Context(), db)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"good"}, names)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCSelectTablesRejectsUnknownTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("good"))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	require.NoError(t, src.SelectTables([]string{"good", "typo"}))
+
+	// Ingesting nothing for "typo" would hide the mistake, and in streaming
+	// mode the run would poll forever.
+	_, err = src.getMySQLCDCTableNames(t.Context(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "typo")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMySQLCDCSelectTablesIgnoresUnselectedTableAppearing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("INFORMATION_SCHEMA\\.TABLES").
+		WithArgs("app").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("good").AddRow("late"))
+
+	src := &MySQLCDCSource{db: db, database: "app"}
+	require.NoError(t, src.SelectTables([]string{"good"}))
+
+	// "late" showing up mid-run must not trip the inventory-drift guard, which
+	// compares against what discovery saw.
+	names, err := src.getMySQLCDCTableNames(t.Context(), db)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"good"}, names)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/source/mysql/planetscale_cdc.go
+++ b/pkg/source/mysql/planetscale_cdc.go
@@ -188,17 +188,29 @@ func (s *PlanetScaleCDCSource) getTables(ctx context.Context) ([]source.SourceTa
 	}
 	defer func() { _ = rows.Close() }()
 
-	var tables []source.SourceTableInfo
+	var inventory []string
 	for rows.Next() {
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan PlanetScale table: %w", err)
 		}
+		inventory = append(inventory, tableName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
-		// Filter before the per-table schema and support checks: an unselected
-		// table costs nothing, and a keyless table outside the selection no
-		// longer blocks the whole keyspace.
-		if !s.selection.Includes(tableName) {
+	// Resolve before the per-table schema and support checks: an unselected
+	// table costs nothing, and a keyless table outside the selection no longer
+	// blocks the whole keyspace.
+	selected, err := s.selection.Resolve(inventory)
+	if err != nil {
+		return nil, err
+	}
+
+	tables := make([]source.SourceTableInfo, 0, len(selected))
+	for _, tableName := range inventory {
+		if _, ok := selected[tableName]; !ok {
 			continue
 		}
 
@@ -221,9 +233,6 @@ func (s *PlanetScaleCDCSource) getTables(ctx context.Context) ([]source.SourceTa
 			DestSchema:  s.destSchema,
 		})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
 	names := make([]string, 0, len(tables))
 	for _, table := range tables {
 		names = append(names, table.Name)
@@ -243,17 +252,9 @@ func (s *PlanetScaleCDCSource) ReadAll(ctx context.Context, opts source.MultiTab
 		return nil, err
 	}
 
-	filter := map[string]bool{}
-	for _, table := range opts.Tables {
-		filter[strings.ToLower(table)] = true
-	}
-
 	targets := make([]psdbCDCTarget, 0, len(all))
 	resumeByTable := make(map[string]string, len(all))
 	for _, info := range all {
-		if len(filter) > 0 && !filter[strings.ToLower(info.Name)] {
-			continue
-		}
 		_, bare := parseMySQLTableName(s.keyspace, info.Name)
 		targets = append(targets, psdbCDCTarget{bareName: bare, resultName: info.Name, schema: info.Schema})
 		if lsn := strings.TrimSpace(opts.CDCResumeLSNs[info.Name]); lsn != "" {

--- a/pkg/source/mysql/planetscale_cdc.go
+++ b/pkg/source/mysql/planetscale_cdc.go
@@ -37,6 +37,7 @@ type PlanetScaleCDCSource struct {
 	db         *sql.DB
 	keyspace   string
 	destSchema string
+	selection  *source.TableSelection
 	host       string
 	username   string
 	password   string
@@ -156,6 +157,24 @@ func (s *PlanetScaleCDCSource) GetTables(ctx context.Context) ([]source.SourceTa
 	return s.getTables(ctx)
 }
 
+// planetScaleTableSelectionOptions describes how this source names its tables. Names
+// are bare, so an optional keyspace prefix is stripped.
+var planetScaleTableSelectionOptions = source.TableSelectionOptions{
+	Subject:      "PlanetScale CDC table",
+	Scope:        "the keyspace's tables",
+	Canonicalize: bareTableName,
+}
+
+// SelectTables restricts this source to the named tables.
+func (s *PlanetScaleCDCSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, planetScaleTableSelectionOptions)
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
+}
+
 func (s *PlanetScaleCDCSource) getTables(ctx context.Context) ([]source.SourceTableInfo, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT TABLE_NAME
@@ -174,6 +193,13 @@ func (s *PlanetScaleCDCSource) getTables(ctx context.Context) ([]source.SourceTa
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan PlanetScale table: %w", err)
+		}
+
+		// Filter before the per-table schema and support checks: an unselected
+		// table costs nothing, and a keyless table outside the selection no
+		// longer blocks the whole keyspace.
+		if !s.selection.Includes(tableName) {
+			continue
 		}
 
 		fullSchema, err := getMySQLSchema(ctx, s.db, s.keyspace, tableName)
@@ -196,6 +222,13 @@ func (s *PlanetScaleCDCSource) getTables(ctx context.Context) ([]source.SourceTa
 		})
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.Name)
+	}
+	if err := s.selection.Validate(names, nil); err != nil {
 		return nil, err
 	}
 	if len(tables) == 0 {
@@ -1073,5 +1106,6 @@ var (
 	_ source.Source           = (*PlanetScaleCDCSource)(nil)
 	_ source.StreamingSource  = (*PlanetScaleCDCSource)(nil)
 	_ source.MultiTableSource = (*PlanetScaleCDCSource)(nil)
+	_ source.TableSelector    = (*PlanetScaleCDCSource)(nil)
 	_ source.SourceTable      = (*PlanetScaleCDCTable)(nil)
 )

--- a/pkg/source/mysql/vitess_cdc.go
+++ b/pkg/source/mysql/vitess_cdc.go
@@ -202,17 +202,29 @@ func (s *VitessCDCSource) getTables(ctx context.Context) ([]source.SourceTableIn
 	}
 	defer func() { _ = rows.Close() }()
 
-	var tables []source.SourceTableInfo
+	var inventory []string
 	for rows.Next() {
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan Vitess table: %w", err)
 		}
+		inventory = append(inventory, tableName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
-		// Filter before the per-table schema and support checks: an unselected
-		// table costs nothing, and a keyless table outside the selection no
-		// longer blocks the whole keyspace.
-		if !s.selection.Includes(tableName) {
+	// Resolve before the per-table schema and support checks: an unselected
+	// table costs nothing, and a keyless table outside the selection no longer
+	// blocks the whole keyspace.
+	selected, err := s.selection.Resolve(inventory)
+	if err != nil {
+		return nil, err
+	}
+
+	tables := make([]source.SourceTableInfo, 0, len(selected))
+	for _, tableName := range inventory {
+		if _, ok := selected[tableName]; !ok {
 			continue
 		}
 
@@ -235,9 +247,6 @@ func (s *VitessCDCSource) getTables(ctx context.Context) ([]source.SourceTableIn
 			DestSchema:  s.destSchema,
 		})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
 	names := make([]string, 0, len(tables))
 	for _, table := range tables {
 		names = append(names, table.Name)
@@ -257,17 +266,9 @@ func (s *VitessCDCSource) ReadAll(ctx context.Context, opts source.MultiTableRea
 		return nil, err
 	}
 
-	filter := map[string]bool{}
-	for _, table := range opts.Tables {
-		filter[strings.ToLower(table)] = true
-	}
-
 	targets := make([]vitessCDCTarget, 0, len(all))
 	resumeByBare := make(map[string]string, len(all))
 	for _, info := range all {
-		if len(filter) > 0 && !filter[strings.ToLower(info.Name)] {
-			continue
-		}
 		_, bare := parseMySQLTableName(s.keyspace, info.Name)
 		targets = append(targets, vitessCDCTarget{bareName: bare, resultName: info.Name, schema: info.Schema})
 		if lsn := strings.TrimSpace(opts.CDCResumeLSNs[info.Name]); lsn != "" {

--- a/pkg/source/mysql/vitess_cdc.go
+++ b/pkg/source/mysql/vitess_cdc.go
@@ -49,6 +49,7 @@ type VitessCDCSource struct {
 	db         *sql.DB
 	keyspace   string
 	destSchema string
+	selection  *source.TableSelection
 	grpcTarget string
 	grpcCreds  credentials.TransportCredentials
 }
@@ -170,6 +171,24 @@ func (s *VitessCDCSource) GetTables(ctx context.Context) ([]source.SourceTableIn
 	return s.getTables(ctx)
 }
 
+// vitessTableSelectionOptions describes how this source names its tables. Names
+// are bare, so an optional keyspace prefix is stripped.
+var vitessTableSelectionOptions = source.TableSelectionOptions{
+	Subject:      "Vitess CDC table",
+	Scope:        "the keyspace's tables",
+	Canonicalize: bareTableName,
+}
+
+// SelectTables restricts this source to the named tables.
+func (s *VitessCDCSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, vitessTableSelectionOptions)
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
+}
+
 func (s *VitessCDCSource) getTables(ctx context.Context) ([]source.SourceTableInfo, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT TABLE_NAME
@@ -188,6 +207,13 @@ func (s *VitessCDCSource) getTables(ctx context.Context) ([]source.SourceTableIn
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return nil, fmt.Errorf("failed to scan Vitess table: %w", err)
+		}
+
+		// Filter before the per-table schema and support checks: an unselected
+		// table costs nothing, and a keyless table outside the selection no
+		// longer blocks the whole keyspace.
+		if !s.selection.Includes(tableName) {
+			continue
 		}
 
 		fullSchema, err := getMySQLSchema(ctx, s.db, s.keyspace, tableName)
@@ -210,6 +236,13 @@ func (s *VitessCDCSource) getTables(ctx context.Context) ([]source.SourceTableIn
 		})
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.Name)
+	}
+	if err := s.selection.Validate(names, nil); err != nil {
 		return nil, err
 	}
 	if len(tables) == 0 {
@@ -1062,5 +1095,6 @@ var (
 	_ source.Source           = (*VitessCDCSource)(nil)
 	_ source.StreamingSource  = (*VitessCDCSource)(nil)
 	_ source.MultiTableSource = (*VitessCDCSource)(nil)
+	_ source.TableSelector    = (*VitessCDCSource)(nil)
 	_ source.SourceTable      = (*VitessCDCTable)(nil)
 )

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -378,7 +378,10 @@ func (r *MultiTableCDCReader) rebuildStream(ctx context.Context, slotName string
 		}
 	}
 
-	tables, err := r.source.GetTables(ctx)
+	// Re-list without re-validating the selection: a selected table that has
+	// disappeared is handled by the coverage-gap path below, not by failing the
+	// stream.
+	tables, err := r.source.getTables(ctx, false)
 	if err != nil {
 		return 0, fmt.Errorf("failed to refresh table list: %w", err)
 	}

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -1248,20 +1248,42 @@ func (s *PostgresCDCSource) getTables(ctx context.Context, validateSelection boo
 	}
 	defer func() { rows.Close() }()
 
-	var tables []source.SourceTableInfo
+	type publicationTable struct {
+		fullName    string
+		incarnation string
+	}
+	var inventory []publicationTable
 	for rows.Next() {
 		var schemaName, tableName, incarnation string
 		if err := rows.Scan(&schemaName, &tableName, &incarnation); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
+		inventory = append(inventory, publicationTable{
+			fullName:    publicationTableFullName(schemaName, tableName),
+			incarnation: incarnation,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
 
-		fullName := publicationTableFullName(schemaName, tableName)
+	names := make([]string, 0, len(inventory))
+	for _, entry := range inventory {
+		names = append(names, entry.fullName)
+	}
+	// Resolve before the per-table schema and fingerprint queries so an
+	// unselected table costs nothing.
+	selected, err := s.selection.Resolve(names)
+	if err != nil {
+		return nil, err
+	}
 
-		// Filter before the per-table schema and fingerprint queries so an
-		// unselected table costs nothing.
-		if !s.selection.Includes(fullName) {
+	tables := make([]source.SourceTableInfo, 0, len(selected))
+	for _, entry := range inventory {
+		if _, ok := selected[entry.fullName]; !ok {
 			continue
 		}
+		fullName, incarnation := entry.fullName, entry.incarnation
 
 		// Get schema for this table
 		tableSchema, err := getTableSchema(ctx, s.queryPool, fullName)
@@ -1292,20 +1314,16 @@ func (s *PostgresCDCSource) getTables(ctx context.Context, validateSelection boo
 		config.Debug("[CDC] Found table in publication: %s (PKs: %v)", fullName, tableSchema.PrimaryKeys)
 	}
 
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating rows: %w", err)
-	}
-
 	if validateSelection && !s.selection.Empty() {
-		names := make([]string, 0, len(tables))
+		found := make([]string, 0, len(tables))
 		for _, table := range tables {
-			names = append(names, table.Name)
+			found = append(found, table.Name)
 		}
-		if err := s.selection.Validate(names, nil); err != nil {
+		if err := s.selection.Validate(found, nil); err != nil {
 			// A table can also be missing because it is unpublishable rather
 			// than absent. Re-check with the exclusion reasons, which cost an
 			// extra catalog query only on this already-failing path.
-			if detailed := s.selection.Validate(names, s.unpublishableReasons(ctx)); detailed != nil {
+			if detailed := s.selection.Validate(found, s.unpublishableReasons(ctx)); detailed != nil {
 				return nil, detailed
 			}
 			return nil, err
@@ -1376,11 +1394,17 @@ func (s *PostgresCDCSource) listEligibleTableIncarnations(ctx context.Context) (
 	if s.selection.Empty() {
 		return incarnations, nil
 	}
-	selected := make(map[string]string, len(incarnations))
-	for name, incarnation := range incarnations {
-		if s.selection.Includes(name) {
-			selected[name] = incarnation
-		}
+	names := make([]string, 0, len(incarnations))
+	for name := range incarnations {
+		names = append(names, name)
+	}
+	resolved, err := s.selection.Resolve(names)
+	if err != nil {
+		return nil, err
+	}
+	selected := make(map[string]string, len(resolved))
+	for name := range resolved {
+		selected[name] = incarnations[name]
 	}
 	return selected, nil
 }

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -64,7 +65,11 @@ type PostgresCDCSource struct {
 	// managedPublication is true when ingestr owns the publication (none was
 	// supplied in the URI) and may reconcile its table set.
 	managedPublication bool
-	cdcConfig          CDCConfig
+	// selection restricts the capture set to the tables the user named. It is
+	// set once before any discovery runs and read-only afterwards, so the
+	// discovery timer and the stream-rebuild path can both consult it.
+	selection *source.TableSelection
+	cdcConfig CDCConfig
 	// serverVersion is the source's server_version_num, used to gate pgoutput
 	// options added in newer PostgreSQL releases.
 	serverVersion int
@@ -928,6 +933,19 @@ type skippedTable struct {
 	reason skipReason
 }
 
+// reasonText explains the exclusion without naming a publication, for callers
+// that already have the table in hand.
+func (s skippedTable) reasonText() string {
+	switch s.reason {
+	case skipUnlogged:
+		return "it is unlogged; changes to unlogged tables are not replicated"
+	case skipNoReplicaIdentity:
+		return "it has no replica identity (no primary key); including it would make UPDATE/DELETE on the source fail"
+	default:
+		return "it cannot be replicated"
+	}
+}
+
 // warning returns the user-facing message describing why the table is skipped.
 func (s skippedTable) warning(pubName string) string {
 	switch s.reason {
@@ -1120,8 +1138,68 @@ func (s *PostgresCDCSource) IsMultiTable() bool {
 	return true
 }
 
-// GetTables returns all tables in the publication with their schemas.
+// postgresTableSelectionOptions describes how PostgreSQL CDC names its tables.
+// publicationTableFullName leaves a table in the public schema unqualified, so
+// "public.users" and "users" both have to resolve to the same table.
+var postgresTableSelectionOptions = source.TableSelectionOptions{
+	Subject:      "PostgreSQL CDC table",
+	Scope:        "the publication's replicable tables",
+	Hint:         "qualify a table outside the public schema (e.g. sales.orders)",
+	Canonicalize: canonicalPublicationTableName,
+}
+
+func canonicalPublicationTableName(name string) (string, error) {
+	parts := tablename.Split(name)
+	switch len(parts) {
+	case 1:
+		return publicationTableFullName("public", parts[0]), nil
+	case 2:
+		return publicationTableFullName(parts[0], parts[1]), nil
+	default:
+		return "", fmt.Errorf("PostgreSQL CDC table name must be table or schema.table, %q given", name)
+	}
+}
+
+// SelectTables restricts this source to the named tables. The managed
+// publication is deliberately left alone: it is a shared, database-scoped
+// object that every managed run reconciles, so narrowing it here would make
+// concurrent pipelines overwrite each other's capture set. Use ?publication=
+// to control what the WAL carries.
+func (s *PostgresCDCSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, postgresTableSelectionOptions)
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
+}
+
+// unpublishableReasons explains why tables are absent from the capture set.
+// The exclusions happen in SQL (replicaIdentityClause), so without this a
+// keyless or unlogged table would be reported as simply not found.
+func (s *PostgresCDCSource) unpublishableReasons(ctx context.Context) map[string]string {
+	_, skipped, err := selectPublishableTables(ctx, s.queryPool)
+	if err != nil {
+		return nil
+	}
+	reasons := make(map[string]string, len(skipped))
+	for _, st := range skipped {
+		reasons[publicationTableFullName(st.ref.schema, st.ref.name)] = st.reasonText()
+	}
+	return reasons
+}
+
+// GetTables returns the tables in the publication with their schemas,
+// narrowed to the user's selection when one was given.
 func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
+	return s.getTables(ctx, true)
+}
+
+// getTables lists the capture set. validateSelection is true only for the
+// caller that establishes the run's table set; the mid-stream re-listing passes
+// false so a selected table disappearing at the source keeps its existing
+// coverage-gap handling instead of failing the stream.
+func (s *PostgresCDCSource) getTables(ctx context.Context, validateSelection bool) ([]source.SourceTableInfo, error) {
 	// Check if this is a "FOR ALL TABLES" publication
 	var pubAllTables bool
 	err := s.queryPool.QueryRow(ctx, "SELECT puballtables FROM pg_publication WHERE pubname = $1", s.cdcConfig.Publication).Scan(&pubAllTables)
@@ -1179,6 +1257,12 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 
 		fullName := publicationTableFullName(schemaName, tableName)
 
+		// Filter before the per-table schema and fingerprint queries so an
+		// unselected table costs nothing.
+		if !s.selection.Includes(fullName) {
+			continue
+		}
+
 		// Get schema for this table
 		tableSchema, err := getTableSchema(ctx, s.queryPool, fullName)
 		if err != nil {
@@ -1210,6 +1294,22 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if validateSelection && !s.selection.Empty() {
+		names := make([]string, 0, len(tables))
+		for _, table := range tables {
+			names = append(names, table.Name)
+		}
+		if err := s.selection.Validate(names, nil); err != nil {
+			// A table can also be missing because it is unpublishable rather
+			// than absent. Re-check with the exclusion reasons, which cost an
+			// extra catalog query only on this already-failing path.
+			if detailed := s.selection.Validate(names, s.unpublishableReasons(ctx)); detailed != nil {
+				return nil, detailed
+			}
+			return nil, err
+		}
 	}
 
 	if len(tables) == 0 {
@@ -1252,7 +1352,9 @@ func publicationTableFullName(schemaName, tableName string) string {
 // reconciled to it); for a user-supplied publication it is the publication's
 // membership (or all eligible tables for FOR ALL TABLES publications).
 func (s *PostgresCDCSource) listEligibleTableNames(ctx context.Context) (map[string]struct{}, error) {
-	incarnations, err := s.listEligibleTableIncarnations(ctx)
+	// Unfiltered on purpose: this backs single-table validation, which never
+	// runs alongside a selection.
+	incarnations, err := s.listAllEligibleTableIncarnations(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1263,7 +1365,27 @@ func (s *PostgresCDCSource) listEligibleTableNames(ctx context.Context) (map[str
 	return names, nil
 }
 
+// listEligibleTableIncarnations reports the tables the stream should currently
+// cover, narrowed to the user's selection. The periodic new-table check reads
+// it, so a table outside the selection never registers as newly appeared.
 func (s *PostgresCDCSource) listEligibleTableIncarnations(ctx context.Context) (map[string]string, error) {
+	incarnations, err := s.listAllEligibleTableIncarnations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if s.selection.Empty() {
+		return incarnations, nil
+	}
+	selected := make(map[string]string, len(incarnations))
+	for name, incarnation := range incarnations {
+		if s.selection.Includes(name) {
+			selected[name] = incarnation
+		}
+	}
+	return selected, nil
+}
+
+func (s *PostgresCDCSource) listAllEligibleTableIncarnations(ctx context.Context) (map[string]string, error) {
 	names := make(map[string]string)
 
 	if s.managedPublication {
@@ -1447,6 +1569,7 @@ const (
 var (
 	_ source.Source            = (*PostgresCDCSource)(nil)
 	_ source.MultiTableSource  = (*PostgresCDCSource)(nil)
+	_ source.TableSelector     = (*PostgresCDCSource)(nil)
 	_ source.StreamingSource   = (*PostgresCDCSource)(nil)
 	_ source.StreamCommitter   = (*PostgresCDCSource)(nil)
 	_ source.CDCBatchFinalizer = (*PostgresCDCSource)(nil)

--- a/pkg/source/postgres_cdc/source_test.go
+++ b/pkg/source/postgres_cdc/source_test.go
@@ -2,6 +2,7 @@ package postgres_cdc
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pglogrepl"
@@ -202,4 +203,73 @@ func TestBuildReplicationConnString(t *testing.T) {
 	poolURI := buildReplicationConnString("postgres://user:pass@localhost:5432/mydb?pool_max_conns=1&sslmode=disable")
 	assert.NotContains(t, poolURI, "pool_max_conns")
 	assert.Contains(t, poolURI, "sslmode=disable")
+}
+
+func TestCanonicalPublicationTableName(t *testing.T) {
+	// publicationTableFullName leaves public-schema tables unqualified, so both
+	// spellings have to resolve to the same name.
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "users", want: "users"},
+		{in: "public.users", want: "users"},
+		{in: "sales.orders", want: "sales.orders"},
+		{in: `"Sales"."Orders"`, want: "Sales.Orders"},
+		{in: `"od.d"`, want: "od.d"},
+		{in: "db.public.users", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := canonicalPublicationTableName(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("canonicalPublicationTableName(%q) = %q, want an error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("canonicalPublicationTableName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgresCDCSelectTables(t *testing.T) {
+	src := &PostgresCDCSource{}
+	if err := src.SelectTables([]string{"public.users", "sales.orders"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The names the source reports are what the selection must match.
+	if !src.selection.Includes("users") {
+		t.Fatal("expected public.users to match the bare name the source reports")
+	}
+	if !src.selection.Includes("sales.orders") {
+		t.Fatal("expected sales.orders to match")
+	}
+	if src.selection.Includes("invoices") {
+		t.Fatal("did not expect an unrequested table to match")
+	}
+
+	if err := src.SelectTables([]string{"users", "public.users"}); err == nil {
+		t.Fatal("expected two spellings of the same table to be rejected")
+	}
+}
+
+func TestSkippedTableReasonText(t *testing.T) {
+	// A requested-but-unpublishable table must explain itself rather than
+	// reporting as simply not found, since the exclusion happens in SQL.
+	unlogged := skippedTable{ref: pgTableRef{schema: "public", name: "scratch"}, reason: skipUnlogged}
+	if got := unlogged.reasonText(); !strings.Contains(got, "unlogged") {
+		t.Fatalf("reasonText = %q, want it to mention unlogged", got)
+	}
+	keyless := skippedTable{ref: pgTableRef{schema: "public", name: "audit"}, reason: skipNoReplicaIdentity}
+	if got := keyless.reasonText(); !strings.Contains(got, "replica identity") {
+		t.Fatalf("reasonText = %q, want it to mention replica identity", got)
+	}
 }

--- a/pkg/source/postgres_cdc/source_test.go
+++ b/pkg/source/postgres_cdc/source_test.go
@@ -246,13 +246,17 @@ func TestPostgresCDCSelectTables(t *testing.T) {
 	}
 
 	// The names the source reports are what the selection must match.
-	if !src.selection.Includes("users") {
+	resolved, err := src.selection.Resolve([]string{"users", "sales.orders", "invoices"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resolved["users"]; !ok {
 		t.Fatal("expected public.users to match the bare name the source reports")
 	}
-	if !src.selection.Includes("sales.orders") {
+	if _, ok := resolved["sales.orders"]; !ok {
 		t.Fatal("expected sales.orders to match")
 	}
-	if src.selection.Includes("invoices") {
+	if _, ok := resolved["invoices"]; ok {
 		t.Fatal("did not expect an unrequested table to match")
 	}
 

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -363,13 +363,6 @@ type SourceTableInfo struct {
 // MultiTableReadOptions extends ReadOptions for multi-table reads.
 type MultiTableReadOptions struct {
 	ReadOptions
-	// Tables filters to specific tables (empty = all tables).
-	//
-	// Deprecated: the pipeline no longer sets this. A user-requested subset
-	// reaches the source through TableSelector before any discovery runs, so it
-	// also narrows a source's own re-listing. Kept for tests and for callers
-	// that drive a source directly.
-	Tables                      []string
 	KnownTables                 []string          // Tables already prepared by the pipeline before ReadAll
 	CDCResumeLSNs               map[string]string // Per-table CDC resume LSNs: table name → max LSN already processed
 	CDCResumeIncarnations       map[string]string

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -363,7 +363,13 @@ type SourceTableInfo struct {
 // MultiTableReadOptions extends ReadOptions for multi-table reads.
 type MultiTableReadOptions struct {
 	ReadOptions
-	Tables                      []string          // Filter to specific tables (empty = all tables)
+	// Tables filters to specific tables (empty = all tables).
+	//
+	// Deprecated: the pipeline no longer sets this. A user-requested subset
+	// reaches the source through TableSelector before any discovery runs, so it
+	// also narrows a source's own re-listing. Kept for tests and for callers
+	// that drive a source directly.
+	Tables                      []string
 	KnownTables                 []string          // Tables already prepared by the pipeline before ReadAll
 	CDCResumeLSNs               map[string]string // Per-table CDC resume LSNs: table name → max LSN already processed
 	CDCResumeIncarnations       map[string]string

--- a/pkg/source/tableselect.go
+++ b/pkg/source/tableselect.go
@@ -1,0 +1,159 @@
+package source
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// TableSelector is an optional capability for multi-table sources that can
+// restrict their capture set to a user-supplied list of tables. The pipeline
+// calls SelectTables once, right after Connect, so the selection is in place
+// before any table discovery runs.
+type TableSelector interface {
+	SelectTables(names []string) error
+}
+
+// TableSelectionOptions describes how a source matches and reports table names.
+type TableSelectionOptions struct {
+	// Subject names one table the way the source refers to it, e.g.
+	// "SQL Server CDC table" or "MongoDB collection".
+	Subject string
+	// Scope names the set being searched, e.g. "SQL Server CDC-enabled tables".
+	Scope string
+	// Hint is optional trailing guidance for a not-found error, e.g.
+	// "use schema-qualified names (e.g. dbo.users)".
+	Hint string
+	// Canonicalize rewrites a user-supplied name into the form the source uses
+	// for SourceTableInfo.Name. It may reject a malformed name.
+	Canonicalize func(string) (string, error)
+}
+
+// TableSelection is an immutable, canonicalized set of requested tables.
+//
+// Every method is pure and a nil selection means "all tables", so a source can
+// consult one selection from its discovery timer and its stream-rebuild path
+// concurrently without synchronisation.
+type TableSelection struct {
+	opts  TableSelectionOptions
+	byKey map[string]string // folded canonical name -> the user's original spelling
+}
+
+// NewTableSelection canonicalizes and validates the requested names. It returns
+// a nil selection when nothing was requested, which every method treats as
+// "select everything".
+func NewTableSelection(requested []string, opts TableSelectionOptions) (*TableSelection, error) {
+	byKey := make(map[string]string, len(requested))
+	for _, raw := range requested {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		name := raw
+		if opts.Canonicalize != nil {
+			canonical, err := opts.Canonicalize(raw)
+			if err != nil {
+				return nil, err
+			}
+			name = canonical
+		}
+		key := strings.ToLower(name)
+		// Two spellings can collapse only after canonicalization (Postgres
+		// "public.users" and "users"), so name both to make the fix obvious.
+		if previous, ok := byKey[key]; ok {
+			if previous == raw {
+				return nil, fmt.Errorf("%s %s is listed more than once", opts.Subject, raw)
+			}
+			return nil, fmt.Errorf("%s %s and %s name the same table", opts.Subject, previous, raw)
+		}
+		byKey[key] = raw
+	}
+	if len(byKey) == 0 {
+		return nil, nil
+	}
+	return &TableSelection{opts: opts, byKey: byKey}, nil
+}
+
+// Empty reports whether the selection covers every table.
+func (s *TableSelection) Empty() bool {
+	return s == nil || len(s.byKey) == 0
+}
+
+// Includes reports whether name was requested. A nil selection includes
+// everything.
+func (s *TableSelection) Includes(name string) bool {
+	if s.Empty() {
+		return true
+	}
+	_, ok := s.byKey[strings.ToLower(name)]
+	return ok
+}
+
+// FilterNames returns the requested subset of all, preserving order.
+func (s *TableSelection) FilterNames(all []string) []string {
+	if s.Empty() {
+		return all
+	}
+	filtered := make([]string, 0, len(s.byKey))
+	for _, name := range all {
+		if s.Includes(name) {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
+}
+
+// FilterTables returns the requested subset of all, preserving order.
+func (s *TableSelection) FilterTables(all []SourceTableInfo) []SourceTableInfo {
+	if s.Empty() {
+		return all
+	}
+	filtered := make([]SourceTableInfo, 0, len(s.byKey))
+	for _, table := range all {
+		if s.Includes(table.Name) {
+			filtered = append(filtered, table)
+		}
+	}
+	return filtered
+}
+
+// Validate reports requested tables that the source cannot ingest. present is
+// the full inventory the source discovered; ineligible maps a present-but-
+// unusable table to the reason it was excluded (no primary key, unlogged, …).
+//
+// A requested name that matches nothing is an error rather than a silent
+// no-op: ingesting nothing would hide a typo, and in streaming mode the run
+// would poll forever.
+func (s *TableSelection) Validate(present []string, ineligible map[string]string) error {
+	if s.Empty() {
+		return nil
+	}
+	found := make(map[string]struct{}, len(present))
+	for _, name := range present {
+		found[strings.ToLower(name)] = struct{}{}
+	}
+	reasons := make(map[string]string, len(ineligible))
+	for name, reason := range ineligible {
+		reasons[strings.ToLower(name)] = reason
+	}
+
+	missing := make([]string, 0, len(s.byKey))
+	for key, raw := range s.byKey {
+		if _, ok := found[key]; ok {
+			continue
+		}
+		if reason, ok := reasons[key]; ok {
+			return fmt.Errorf("%s %s cannot be ingested: %s", s.opts.Subject, raw, reason)
+		}
+		missing = append(missing, raw)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	message := fmt.Sprintf("tables not found among %s: %s", s.opts.Scope, strings.Join(missing, ", "))
+	if s.opts.Hint != "" {
+		message += "; " + s.opts.Hint
+	}
+	return fmt.Errorf("%s", message)
+}

--- a/pkg/source/tableselect.go
+++ b/pkg/source/tableselect.go
@@ -9,7 +9,8 @@ import (
 // TableSelector is an optional capability for multi-table sources that can
 // restrict their capture set to a user-supplied list of tables. The pipeline
 // calls SelectTables once, right after Connect, so the selection is in place
-// before any table discovery runs.
+// before any table discovery runs -- including a source's own re-listing
+// inside ReadAll and any periodic new-table check.
 type TableSelector interface {
 	SelectTables(names []string) error
 }
@@ -29,6 +30,14 @@ type TableSelectionOptions struct {
 	Canonicalize func(string) (string, error)
 }
 
+// requestedTable is one entry of the user's list, kept in both spellings: the
+// canonical form is what discovered names are compared against, the raw form is
+// what diagnostics quote back.
+type requestedTable struct {
+	raw       string
+	canonical string
+}
+
 // TableSelection is an immutable, canonicalized set of requested tables.
 //
 // Every method is pure and a nil selection means "all tables", so a source can
@@ -36,37 +45,37 @@ type TableSelectionOptions struct {
 // concurrently without synchronisation.
 type TableSelection struct {
 	opts  TableSelectionOptions
-	byKey map[string]string // folded canonical name -> the user's original spelling
+	byKey map[string]requestedTable // folded canonical name -> request
 }
 
 // NewTableSelection canonicalizes and validates the requested names. It returns
 // a nil selection when nothing was requested, which every method treats as
 // "select everything".
 func NewTableSelection(requested []string, opts TableSelectionOptions) (*TableSelection, error) {
-	byKey := make(map[string]string, len(requested))
+	byKey := make(map[string]requestedTable, len(requested))
 	for _, raw := range requested {
 		raw = strings.TrimSpace(raw)
 		if raw == "" {
 			continue
 		}
-		name := raw
+		canonical := raw
 		if opts.Canonicalize != nil {
-			canonical, err := opts.Canonicalize(raw)
+			rewritten, err := opts.Canonicalize(raw)
 			if err != nil {
 				return nil, err
 			}
-			name = canonical
+			canonical = rewritten
 		}
-		key := strings.ToLower(name)
+		key := strings.ToLower(canonical)
 		// Two spellings can collapse only after canonicalization (Postgres
 		// "public.users" and "users"), so name both to make the fix obvious.
 		if previous, ok := byKey[key]; ok {
-			if previous == raw {
+			if previous.raw == raw {
 				return nil, fmt.Errorf("%s %s is listed more than once", opts.Subject, raw)
 			}
-			return nil, fmt.Errorf("%s %s and %s name the same table", opts.Subject, previous, raw)
+			return nil, fmt.Errorf("%s %s and %s name the same table", opts.Subject, previous.raw, raw)
 		}
-		byKey[key] = raw
+		byKey[key] = requestedTable{raw: raw, canonical: canonical}
 	}
 	if len(byKey) == 0 {
 		return nil, nil
@@ -79,47 +88,66 @@ func (s *TableSelection) Empty() bool {
 	return s == nil || len(s.byKey) == 0
 }
 
-// Includes reports whether name was requested. A nil selection includes
-// everything.
-func (s *TableSelection) Includes(name string) bool {
+// Resolve maps a source's discovered inventory onto the requested subset,
+// returning the names to ingest.
+//
+// Matching is case-insensitive so a user need not reproduce the catalog's
+// casing, but an exact spelling always wins: a source holding both "users" and
+// "Users" ingests only the one that was named. A request that matches several
+// discovered names and none of them exactly is genuinely ambiguous, and
+// resolving fails rather than quietly ingesting all of them.
+func (s *TableSelection) Resolve(inventory []string) (map[string]struct{}, error) {
+	selected := make(map[string]struct{}, len(inventory))
 	if s.Empty() {
-		return true
+		for _, name := range inventory {
+			selected[name] = struct{}{}
+		}
+		return selected, nil
 	}
-	_, ok := s.byKey[strings.ToLower(name)]
-	return ok
-}
 
-// FilterNames returns the requested subset of all, preserving order.
-func (s *TableSelection) FilterNames(all []string) []string {
-	if s.Empty() {
-		return all
-	}
-	filtered := make([]string, 0, len(s.byKey))
-	for _, name := range all {
-		if s.Includes(name) {
-			filtered = append(filtered, name)
+	matches := make(map[string][]string, len(s.byKey))
+	for _, name := range inventory {
+		key := strings.ToLower(name)
+		if _, ok := s.byKey[key]; ok {
+			matches[key] = append(matches[key], name)
 		}
 	}
-	return filtered
-}
 
-// FilterTables returns the requested subset of all, preserving order.
-func (s *TableSelection) FilterTables(all []SourceTableInfo) []SourceTableInfo {
-	if s.Empty() {
-		return all
+	keys := make([]string, 0, len(matches))
+	for key := range matches {
+		keys = append(keys, key)
 	}
-	filtered := make([]SourceTableInfo, 0, len(s.byKey))
-	for _, table := range all {
-		if s.Includes(table.Name) {
-			filtered = append(filtered, table)
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		found := matches[key]
+		request := s.byKey[key]
+		if len(found) == 1 {
+			selected[found[0]] = struct{}{}
+			continue
 		}
+		exact := ""
+		for _, name := range found {
+			if name == request.canonical {
+				exact = name
+				break
+			}
+		}
+		if exact == "" {
+			sorted := append([]string(nil), found...)
+			sort.Strings(sorted)
+			return nil, fmt.Errorf("%s %s matches several tables that differ only in case (%s); name one of them exactly",
+				s.opts.Subject, request.raw, strings.Join(sorted, ", "))
+		}
+		selected[exact] = struct{}{}
 	}
-	return filtered
+	return selected, nil
 }
 
 // Validate reports requested tables that the source cannot ingest. present is
-// the full inventory the source discovered; ineligible maps a present-but-
-// unusable table to the reason it was excluded (no primary key, unlogged, …).
+// what the source actually discovered for this selection; ineligible maps a
+// present-but-unusable table to the reason it was excluded (no primary key,
+// unlogged, ...).
 //
 // A requested name that matches nothing is an error rather than a silent
 // no-op: ingesting nothing would hide a typo, and in streaming mode the run
@@ -138,14 +166,14 @@ func (s *TableSelection) Validate(present []string, ineligible map[string]string
 	}
 
 	missing := make([]string, 0, len(s.byKey))
-	for key, raw := range s.byKey {
+	for key, request := range s.byKey {
 		if _, ok := found[key]; ok {
 			continue
 		}
 		if reason, ok := reasons[key]; ok {
-			return fmt.Errorf("%s %s cannot be ingested: %s", s.opts.Subject, raw, reason)
+			return fmt.Errorf("%s %s cannot be ingested: %s", s.opts.Subject, request.raw, reason)
 		}
-		missing = append(missing, raw)
+		missing = append(missing, request.raw)
 	}
 	if len(missing) == 0 {
 		return nil

--- a/pkg/source/tableselect_test.go
+++ b/pkg/source/tableselect_test.go
@@ -1,0 +1,174 @@
+package source
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// stripPublicSchema stands in for a source canonicalizer: it folds an explicit
+// "public." prefix away and rejects a malformed name.
+func stripPublicSchema(name string) (string, error) {
+	if strings.Contains(name, " ") {
+		return "", fmt.Errorf("malformed table name %q", name)
+	}
+	return strings.TrimPrefix(name, "public."), nil
+}
+
+func TestTableSelectionEmptySelectsEverything(t *testing.T) {
+	selection, err := NewTableSelection(nil, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if selection != nil {
+		t.Fatal("no requested names should yield a nil selection")
+	}
+	if !selection.Empty() {
+		t.Fatal("a nil selection is empty")
+	}
+	if !selection.Includes("anything") {
+		t.Fatal("a nil selection includes every table")
+	}
+	if err := selection.Validate(nil, nil); err != nil {
+		t.Fatalf("a nil selection never fails validation: %v", err)
+	}
+}
+
+func TestTableSelectionMatchesCaseInsensitively(t *testing.T) {
+	selection, err := NewTableSelection([]string{"DBO.Users"}, TableSelectionOptions{
+		Subject: "SQL Server CDC table",
+		Scope:   "SQL Server CDC-enabled tables",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !selection.Includes("dbo.users") {
+		t.Fatal("expected a case-insensitive match")
+	}
+	if selection.Includes("dbo.orders") {
+		t.Fatal("did not expect an unrequested table to match")
+	}
+}
+
+func TestTableSelectionCanonicalizes(t *testing.T) {
+	selection, err := NewTableSelection([]string{"public.users", "sales.orders"}, TableSelectionOptions{
+		Subject:      "table",
+		Scope:        "tables",
+		Canonicalize: stripPublicSchema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !selection.Includes("users") {
+		t.Fatal("public.users should canonicalize to users")
+	}
+	if !selection.Includes("sales.orders") {
+		t.Fatal("sales.orders should stay qualified")
+	}
+}
+
+func TestTableSelectionRejectsBadName(t *testing.T) {
+	_, err := NewTableSelection([]string{"a b"}, TableSelectionOptions{
+		Subject:      "table",
+		Scope:        "tables",
+		Canonicalize: stripPublicSchema,
+	})
+	if err == nil {
+		t.Fatal("expected the canonicalizer's error to surface")
+	}
+}
+
+func TestTableSelectionRejectsDuplicates(t *testing.T) {
+	_, err := NewTableSelection([]string{"users", "users"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err == nil || !strings.Contains(err.Error(), "more than once") {
+		t.Fatalf("expected a repeated-entry error, got %v", err)
+	}
+
+	// Two spellings collapse only after canonicalization; both must be named.
+	_, err = NewTableSelection([]string{"public.users", "users"}, TableSelectionOptions{
+		Subject:      "table",
+		Scope:        "tables",
+		Canonicalize: stripPublicSchema,
+	})
+	if err == nil {
+		t.Fatal("expected post-canonicalization duplicates to be rejected")
+	}
+	if !strings.Contains(err.Error(), "public.users") || !strings.Contains(err.Error(), "users") {
+		t.Fatalf("error should name both spellings, got %v", err)
+	}
+}
+
+func TestTableSelectionValidateReportsMissing(t *testing.T) {
+	selection, err := NewTableSelection([]string{"dbo.users", "dbo.missing", "dbo.absent"}, TableSelectionOptions{
+		Subject: "SQL Server CDC table",
+		Scope:   "SQL Server CDC-enabled tables",
+		Hint:    "use schema-qualified names (e.g. dbo.users)",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = selection.Validate([]string{"dbo.users"}, nil)
+	if err == nil {
+		t.Fatal("expected an error for tables that matched nothing")
+	}
+	// Deterministic, sorted, and pointing at the format.
+	want := "tables not found among SQL Server CDC-enabled tables: dbo.absent, dbo.missing; use schema-qualified names (e.g. dbo.users)"
+	if err.Error() != want {
+		t.Fatalf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestTableSelectionValidatePrefersIneligibleReason(t *testing.T) {
+	selection, err := NewTableSelection([]string{"dbo.audit_log"}, TableSelectionOptions{
+		Subject: "SQL Server CDC table",
+		Scope:   "SQL Server CDC-enabled tables",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = selection.Validate(nil, map[string]string{"DBO.Audit_Log": "it has no primary key"})
+	if err == nil || !strings.Contains(err.Error(), "no primary key") {
+		t.Fatalf("expected the exclusion reason, got %v", err)
+	}
+}
+
+func TestTableSelectionFilters(t *testing.T) {
+	selection, err := NewTableSelection([]string{"users"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	names := selection.FilterNames([]string{"users", "orders"})
+	if len(names) != 1 || names[0] != "users" {
+		t.Fatalf("FilterNames = %v, want [users]", names)
+	}
+	tables := selection.FilterTables([]SourceTableInfo{{Name: "orders"}, {Name: "users"}})
+	if len(tables) != 1 || tables[0].Name != "users" {
+		t.Fatalf("FilterTables = %v, want [users]", tables)
+	}
+}
+
+// The discovery timer and the stream-rebuild path consult one selection
+// concurrently, so matching must not mutate it.
+func TestTableSelectionIsSafeForConcurrentUse(t *testing.T) {
+	selection, err := NewTableSelection([]string{"users", "orders"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	done := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 200; j++ {
+				selection.Includes("users")
+				selection.FilterNames([]string{"users", "orders", "invoices"})
+				_ = selection.Validate([]string{"users", "orders"}, nil)
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		<-done
+	}
+	if err := selection.Validate([]string{"users", "orders"}, nil); err != nil {
+		t.Fatalf("selection should be unchanged after matching: %v", err)
+	}
+}

--- a/pkg/source/tableselect_test.go
+++ b/pkg/source/tableselect_test.go
@@ -26,8 +26,12 @@ func TestTableSelectionEmptySelectsEverything(t *testing.T) {
 	if !selection.Empty() {
 		t.Fatal("a nil selection is empty")
 	}
-	if !selection.Includes("anything") {
-		t.Fatal("a nil selection includes every table")
+	resolved, err := selection.Resolve([]string{"anything", "else"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("a nil selection resolves to every table, got %v", resolved)
 	}
 	if err := selection.Validate(nil, nil); err != nil {
 		t.Fatalf("a nil selection never fails validation: %v", err)
@@ -42,11 +46,62 @@ func TestTableSelectionMatchesCaseInsensitively(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !selection.Includes("dbo.users") {
+	resolved, err := selection.Resolve([]string{"dbo.users", "dbo.orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resolved["dbo.users"]; !ok {
 		t.Fatal("expected a case-insensitive match")
 	}
-	if selection.Includes("dbo.orders") {
+	if _, ok := resolved["dbo.orders"]; ok {
 		t.Fatal("did not expect an unrequested table to match")
+	}
+}
+
+// Case-insensitive matching must not pull in a second, distinctly-cased table.
+func TestTableSelectionPrefersExactSpelling(t *testing.T) {
+	selection, err := NewTableSelection([]string{"users"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resolved, err := selection.Resolve([]string{"users", "Users"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("resolved = %v, want only the exactly-named table", resolved)
+	}
+	if _, ok := resolved["users"]; !ok {
+		t.Fatalf("resolved = %v, want users", resolved)
+	}
+
+	// The other spelling is selectable in its own right.
+	upper, err := NewTableSelection([]string{"Users"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resolved, err = upper.Resolve([]string{"users", "Users"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resolved["Users"]; !ok || len(resolved) != 1 {
+		t.Fatalf("resolved = %v, want only Users", resolved)
+	}
+}
+
+func TestTableSelectionRejectsUnresolvableCaseCollision(t *testing.T) {
+	selection, err := NewTableSelection([]string{"USERS"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Neither discovered table is spelled the way the user asked, so picking
+	// one would be a guess and picking both would ingest an unrequested table.
+	_, err = selection.Resolve([]string{"users", "Users"})
+	if err == nil {
+		t.Fatal("expected an ambiguous request to be rejected")
+	}
+	if !strings.Contains(err.Error(), "users") || !strings.Contains(err.Error(), "Users") {
+		t.Fatalf("error should name both candidates, got %v", err)
 	}
 }
 
@@ -59,11 +114,18 @@ func TestTableSelectionCanonicalizes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !selection.Includes("users") {
+	resolved, err := selection.Resolve([]string{"users", "sales.orders", "invoices"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resolved["users"]; !ok {
 		t.Fatal("public.users should canonicalize to users")
 	}
-	if !selection.Includes("sales.orders") {
+	if _, ok := resolved["sales.orders"]; !ok {
 		t.Fatal("sales.orders should stay qualified")
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("resolved = %v, want exactly the two requested tables", resolved)
 	}
 }
 
@@ -132,21 +194,6 @@ func TestTableSelectionValidatePrefersIneligibleReason(t *testing.T) {
 	}
 }
 
-func TestTableSelectionFilters(t *testing.T) {
-	selection, err := NewTableSelection([]string{"users"}, TableSelectionOptions{Subject: "table", Scope: "tables"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	names := selection.FilterNames([]string{"users", "orders"})
-	if len(names) != 1 || names[0] != "users" {
-		t.Fatalf("FilterNames = %v, want [users]", names)
-	}
-	tables := selection.FilterTables([]SourceTableInfo{{Name: "orders"}, {Name: "users"}})
-	if len(tables) != 1 || tables[0].Name != "users" {
-		t.Fatalf("FilterTables = %v, want [users]", tables)
-	}
-}
-
 // The discovery timer and the stream-rebuild path consult one selection
 // concurrently, so matching must not mutate it.
 func TestTableSelectionIsSafeForConcurrentUse(t *testing.T) {
@@ -159,8 +206,7 @@ func TestTableSelectionIsSafeForConcurrentUse(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 			for j := 0; j < 200; j++ {
-				selection.Includes("users")
-				selection.FilterNames([]string{"users", "orders", "invoices"})
+				_, _ = selection.Resolve([]string{"users", "orders", "invoices"})
 				_ = selection.Validate([]string{"users", "orders"}, nil)
 			}
 		}()

--- a/pkg/tablename/tablename.go
+++ b/pkg/tablename/tablename.go
@@ -55,6 +55,28 @@ func Split(name string) []string {
 // identifier delimiters and escaping. It is intended for code that must render
 // a derived identifier back into the same catalog or schema.
 func SplitRaw(name string) []string {
+	return splitRaw(name, '.')
+}
+
+// SplitList breaks a comma-separated list of table identifiers into its
+// elements, honoring the same quoting rules as Split so a quoted identifier
+// containing a comma stays whole. Elements are trimmed and empty ones dropped.
+// Quoting is preserved so callers can parse each element with Split.
+func SplitList(list string) []string {
+	if strings.TrimSpace(list) == "" {
+		return nil
+	}
+	parts := splitRaw(list, ',')
+	names := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			names = append(names, part)
+		}
+	}
+	return names
+}
+
+func splitRaw(name string, sep byte) []string {
 	name = strings.TrimSpace(name)
 	var parts []string
 	var cur strings.Builder
@@ -76,19 +98,19 @@ func SplitRaw(name string) []string {
 			continue
 		}
 
-		switch ch {
-		case '[':
-			closer = ']'
-			cur.WriteByte(ch)
-		case '"':
-			closer = '"'
-			cur.WriteByte(ch)
-		case '`':
-			closer = '`'
-			cur.WriteByte(ch)
-		case '.':
+		switch {
+		case ch == sep:
 			parts = append(parts, cur.String())
 			cur.Reset()
+		case ch == '[':
+			closer = ']'
+			cur.WriteByte(ch)
+		case ch == '"':
+			closer = '"'
+			cur.WriteByte(ch)
+		case ch == '`':
+			closer = '`'
+			cur.WriteByte(ch)
 		default:
 			cur.WriteByte(ch)
 		}

--- a/pkg/tablename/tablename.go
+++ b/pkg/tablename/tablename.go
@@ -98,17 +98,17 @@ func splitRaw(name string, sep byte) []string {
 			continue
 		}
 
-		switch {
-		case ch == sep:
+		switch ch {
+		case sep:
 			parts = append(parts, cur.String())
 			cur.Reset()
-		case ch == '[':
+		case '[':
 			closer = ']'
 			cur.WriteByte(ch)
-		case ch == '"':
+		case '"':
 			closer = '"'
 			cur.WriteByte(ch)
-		case ch == '`':
+		case '`':
 			closer = '`'
 			cur.WriteByte(ch)
 		default:

--- a/pkg/tablename/tablename_test.go
+++ b/pkg/tablename/tablename_test.go
@@ -137,3 +137,47 @@ func TestContainerToCreate(t *testing.T) {
 		}
 	}
 }
+
+func TestSplitList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single", "users", []string{"users"}},
+		{"two", "users,orders", []string{"users", "orders"}},
+		{"qualified", "public.users, sales.orders", []string{"public.users", "sales.orders"}},
+		{"quoted comma", `"od,d".t,public.users`, []string{`"od,d".t`, "public.users"}},
+		{"bracketed comma", "[a,b].c,d", []string{"[a,b].c", "d"}},
+		{"backticked comma", "`a,b`,c", []string{"`a,b`", "c"}},
+		{"trailing comma", "users,orders,", []string{"users", "orders"}},
+		{"blank entries", " users , , orders ", []string{"users", "orders"}},
+		{"empty", "", nil},
+		{"separators only", " , ", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitList(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("SplitList(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("SplitList(%q) = %v, want %v", tt.in, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSplitListElementsStayParsable(t *testing.T) {
+	// A list element keeps its quoting so callers can Split it themselves.
+	names := SplitList(`"od,d"."t.1",users`)
+	if len(names) != 2 {
+		t.Fatalf("SplitList = %v, want 2 elements", names)
+	}
+	parts := Split(names[0])
+	if len(parts) != 2 || parts[0] != "od,d" || parts[1] != "t.1" {
+		t.Fatalf("Split(%q) = %v, want [od,d t.1]", names[0], parts)
+	}
+}

--- a/tests/integration/multitable_conformance_test.go
+++ b/tests/integration/multitable_conformance_test.go
@@ -39,6 +39,7 @@ type mockMultiTableSource struct {
 	tables    map[string]string // table name -> file path
 	schemas   map[string]*schema.TableSchema
 	connected bool
+	selection *source.TableSelection
 }
 
 func newMockMultiTableSource() *mockMultiTableSource {
@@ -93,6 +94,18 @@ func (s *mockMultiTableSource) IsMultiTable() bool {
 	return true
 }
 
+func (s *mockMultiTableSource) SelectTables(names []string) error {
+	selection, err := source.NewTableSelection(names, source.TableSelectionOptions{
+		Subject: "test table",
+		Scope:   "the source's tables",
+	})
+	if err != nil {
+		return err
+	}
+	s.selection = selection
+	return nil
+}
+
 func (s *mockMultiTableSource) GetTables(ctx context.Context) ([]source.SourceTableInfo, error) {
 	var tables []source.SourceTableInfo
 
@@ -104,6 +117,9 @@ func (s *mockMultiTableSource) GetTables(ctx context.Context) ([]source.SourceTa
 	sort.Strings(tableNames)
 
 	for _, name := range tableNames {
+		if !s.selection.Includes(name) {
+			continue
+		}
 		filePath := s.tables[name]
 		tblSchema, err := s.inferSchemaFromFile(filePath)
 		if err != nil {
@@ -128,6 +144,14 @@ func (s *mockMultiTableSource) GetTables(ctx context.Context) ([]source.SourceTa
 		})
 	}
 
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.Name)
+	}
+	if err := s.selection.Validate(names, nil); err != nil {
+		return nil, err
+	}
+
 	return tables, nil
 }
 
@@ -141,6 +165,9 @@ func (s *mockMultiTableSource) ReadAll(ctx context.Context, opts source.MultiTab
 		for tableName, filePath := range s.tables {
 			if ctx.Err() != nil {
 				return
+			}
+			if !s.selection.Includes(tableName) {
+				continue
 			}
 
 			batches, err := s.readJSONLFile(filePath, tableName)
@@ -747,4 +774,5 @@ func createMultiTableTestFile(t *testing.T, name string, items []map[string]inte
 var (
 	_ source.Source           = (*mockMultiTableSource)(nil)
 	_ source.MultiTableSource = (*mockMultiTableSource)(nil)
+	_ source.TableSelector    = (*mockMultiTableSource)(nil)
 )

--- a/tests/integration/multitable_conformance_test.go
+++ b/tests/integration/multitable_conformance_test.go
@@ -116,8 +116,13 @@ func (s *mockMultiTableSource) GetTables(ctx context.Context) ([]source.SourceTa
 	}
 	sort.Strings(tableNames)
 
+	selected, err := s.selection.Resolve(tableNames)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, name := range tableNames {
-		if !s.selection.Includes(name) {
+		if _, ok := selected[name]; !ok {
 			continue
 		}
 		filePath := s.tables[name]
@@ -156,6 +161,15 @@ func (s *mockMultiTableSource) GetTables(ctx context.Context) ([]source.SourceTa
 }
 
 func (s *mockMultiTableSource) ReadAll(ctx context.Context, opts source.MultiTableReadOptions) (<-chan source.RecordBatchResult, error) {
+	names := make([]string, 0, len(s.tables))
+	for name := range s.tables {
+		names = append(names, name)
+	}
+	selected, err := s.selection.Resolve(names)
+	if err != nil {
+		return nil, err
+	}
+
 	results := make(chan source.RecordBatchResult, 16)
 
 	go func() {
@@ -166,7 +180,7 @@ func (s *mockMultiTableSource) ReadAll(ctx context.Context, opts source.MultiTab
 			if ctx.Err() != nil {
 				return
 			}
-			if !s.selection.Includes(tableName) {
+			if _, ok := selected[tableName]; !ok {
 				continue
 			}
 

--- a/tests/integration/multitable_subset_test.go
+++ b/tests/integration/multitable_subset_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// multiTableSubsetSource writes three JSONL tables and returns a source URI
+// covering all of them.
+func multiTableSubsetSource(t *testing.T) string {
+	t.Helper()
+
+	usersFile := createMultiTableTestFile(t, "users", []map[string]interface{}{
+		{"id": 1, "name": "alice"},
+		{"id": 2, "name": "bob"},
+	})
+	t.Cleanup(func() { _ = os.Remove(usersFile) })
+
+	ordersFile := createMultiTableTestFile(t, "orders", []map[string]interface{}{
+		{"id": 1, "user_id": 1, "amount": 100.50},
+	})
+	t.Cleanup(func() { _ = os.Remove(ordersFile) })
+
+	productsFile := createMultiTableTestFile(t, "products", []map[string]interface{}{
+		{"id": 1, "name": "Widget"},
+		{"id": 2, "name": "Gadget"},
+		{"id": 3, "name": "Gizmo"},
+	})
+	t.Cleanup(func() { _ = os.Remove(productsFile) })
+
+	return fmt.Sprintf("multitable-test://users=%s,orders=%s,products=%s", usersFile, ordersFile, productsFile)
+}
+
+// TestMultiTable_SubsetIngestsOnlySelectedTables is the pipeline-level contract:
+// a subset must narrow every stage, not just the read. The excluded table's
+// destination table must never be created, since destination naming, schema
+// evolution and CDC state registration all iterate the discovered table set.
+func TestMultiTable_SubsetIngestsOnlySelectedTables(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceURI := multiTableSubsetSource(t)
+
+	for _, tc := range multiTableDestinationCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			destURI, destPrefix, cleanup := tc.setup(t, ctx)
+			defer cleanup()
+
+			cfg := &config.IngestConfig{
+				SourceURI:           sourceURI,
+				SourceTables:        []string{"users", "products"},
+				DestURI:             destURI,
+				DestTable:           destPrefix,
+				IncrementalStrategy: config.StrategyReplace,
+			}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+			db, err := tc.sqlBackend.openDB(destURI)
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			var users, products int
+			require.NoError(t, db.QueryRow(tc.sqlBackend.countQuery(fmt.Sprintf("%s.users", destPrefix))).Scan(&users))
+			assert.Equal(t, 2, users)
+			require.NoError(t, db.QueryRow(tc.sqlBackend.countQuery(fmt.Sprintf("%s.products", destPrefix))).Scan(&products))
+			assert.Equal(t, 3, products)
+
+			var orders int
+			err = db.QueryRow(tc.sqlBackend.countQuery(fmt.Sprintf("%s.orders", destPrefix))).Scan(&orders)
+			assert.Error(t, err, "the unselected table must not be created at the destination")
+		})
+	}
+}
+
+// TestMultiTable_SubsetRejectsUnknownTable guards the hard-error contract:
+// silently ingesting nothing would hide a typo, and under --stream the run
+// would poll forever.
+func TestMultiTable_SubsetRejectsUnknownTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	sourceURI := multiTableSubsetSource(t)
+
+	tc := multiTableDestinationCases()[len(multiTableDestinationCases())-1]
+	destURI, destPrefix, cleanup := tc.setup(t, ctx)
+	defer cleanup()
+
+	cfg := &config.IngestConfig{
+		SourceURI:           sourceURI,
+		SourceTables:        []string{"users", "typo"},
+		DestURI:             destURI,
+		DestTable:           destPrefix,
+		IncrementalStrategy: config.StrategyReplace,
+	}
+	err := pipeline.New(cfg).Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "typo")
+}

--- a/tests/integration/postgres_cdc_subset_test.go
+++ b/tests/integration/postgres_cdc_subset_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostgresCDC_TableSubset covers the whole contract for a comma-separated
+// --source-table against PostgreSQL: only the named tables reach the
+// destination, both spellings of a public-schema table work, a table created
+// later is ignored because the selection pins the capture set, and the
+// publication is deliberately left covering everything.
+func TestPostgresCDC_TableSubset(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if pgDest.uri == "" {
+		t.Skip("shared postgres dest container not available")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.users (id INT PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.users (id, name) VALUES (1, 'alice'), (2, 'bob')`)
+	require.NoError(t, err)
+
+	_, err = srcPool.Exec(ctx, `CREATE SCHEMA sales`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `CREATE TABLE sales.orders (id INT PRIMARY KEY, amount INT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO sales.orders (id, amount) VALUES (1, 100)`)
+	require.NoError(t, err)
+
+	// Eligible, but not selected: it must never reach the destination.
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.products (id INT PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.products (id, name) VALUES (1, 'widget')`)
+	require.NoError(t, err)
+
+	_, err = srcPool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	destSchema := uniqueSchemaName(t, "cdc_subset")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
+
+	cfg := &config.IngestConfig{
+		SourceURI: "postgres+cdc://" + sourceConnString[len("postgres://"):] +
+			"&mode=batch&dest_schema=" + destSchema,
+		// "public.users" is spelled with its schema even though the connector
+		// reports it bare; "sales.orders" must stay qualified.
+		SourceTables: []string{"public.users", "sales.orders"},
+		DestURI:      pgDest.uri,
+	}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	pg, err := sql.Open("pgx", pgDest.uri)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+
+	var count int
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.users`, destSchema)).Scan(&count))
+	assert.Equal(t, 2, count, "users snapshot")
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q."sales_orders"`, destSchema)).Scan(&count))
+	assert.Equal(t, 1, count, "sales.orders snapshot")
+
+	assertRelationAbsent(t, ctx, pg, destSchema, "products")
+
+	// The managed publication still covers everything: narrowing it would make
+	// concurrent pipelines against this database fight over its table set.
+	var published int
+	require.NoError(t, srcPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM pg_publication_tables WHERE pubname = 'ingestr_publication'`).Scan(&published))
+	assert.Equal(t, 3, published, "the managed publication must not be narrowed by a table subset")
+
+	// A table created after the first run is not picked up: the selection pins
+	// the capture set.
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.invoices (id INT PRIMARY KEY, total INT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.invoices (id, total) VALUES (1, 5)`)
+	require.NoError(t, err)
+
+	// Changes to the selected tables still propagate on the next run.
+	_, err = srcPool.Exec(ctx, `INSERT INTO public.users (id, name) VALUES (3, 'carol')`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `UPDATE sales.orders SET amount = 250 WHERE id = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %q.users`, destSchema)).Scan(&count))
+	assert.Equal(t, 3, count, "users after CDC insert")
+	var amount int
+	require.NoError(t, pg.QueryRowContext(ctx, fmt.Sprintf(`SELECT amount FROM %q."sales_orders" WHERE id = 1`, destSchema)).Scan(&amount))
+	assert.Equal(t, 250, amount, "sales.orders after CDC update")
+
+	assertRelationAbsent(t, ctx, pg, destSchema, "products")
+	assertRelationAbsent(t, ctx, pg, destSchema, "invoices")
+}
+
+// TestPostgresCDC_TableSubsetRejectsUnknownTable proves the hard-error
+// contract, including the specific reason for a table that exists but cannot be
+// replicated -- that exclusion happens in SQL, so it would otherwise be
+// reported as simply not found.
+func TestPostgresCDC_TableSubsetRejectsUnknownTable(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if pgDest.uri == "" {
+		t.Skip("shared postgres dest container not available")
+	}
+
+	ctx := context.Background()
+
+	sourceContainer, sourceConnString := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = sourceContainer.Terminate(ctx) }()
+
+	srcPool, err := pgxpool.New(ctx, sourceConnString)
+	require.NoError(t, err)
+	defer srcPool.Close()
+
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.users (id INT PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `CREATE TABLE public.logs_nopk (id INT, msg TEXT)`)
+	require.NoError(t, err)
+	_, err = srcPool.Exec(ctx, `ALTER USER testuser REPLICATION`)
+	require.NoError(t, err)
+
+	destSchema := uniqueSchemaName(t, "cdc_subset_err")
+	ensurePostgresSchema(t, ctx, pgDest.uri, destSchema)
+	t.Cleanup(func() { dropPostgresSchema(t, ctx, pgDest.uri, destSchema) })
+
+	base := "postgres+cdc://" + sourceConnString[len("postgres://"):] + "&mode=batch&dest_schema=" + destSchema
+
+	typo := &config.IngestConfig{
+		SourceURI:    base,
+		SourceTables: []string{"users", "userz"},
+		DestURI:      pgDest.uri,
+	}
+	err = pipeline.New(typo).Run(ctx)
+	require.Error(t, err, "a typo must fail the run rather than quietly ingesting less")
+	assert.Contains(t, err.Error(), "userz")
+
+	keyless := &config.IngestConfig{
+		SourceURI:    base,
+		SourceTables: []string{"users", "logs_nopk"},
+		DestURI:      pgDest.uri,
+	}
+	err = pipeline.New(keyless).Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replica identity",
+		"a table that exists but cannot be replicated must say why, not report as missing")
+}


### PR DESCRIPTION
## What

CDC table selection was binary: `--source-table` picked exactly one table, omitting it replicated **every** table in the source's capture set. There was no way to say "replicate these five tables" short of reshaping the source — hand-managing a Postgres publication, enabling CDC on only some SQL Server tables — which is awkward, and for MySQL/Vitess impossible.

`--source-table` now accepts a comma-separated list:

```bash
ingestr ingest \
    --source-uri "postgres+cdc://user:pass@host:5432/mydb?dest_schema=analytics" \
    --source-table "public.users,public.orders" \
    --dest-uri "bigquery://my-project"
```

One name keeps today's single-table behaviour byte for byte; two or more select multi-table mode restricted to that set; omitting it still means all tables. Supported across every CDC connector: PostgreSQL, MySQL/MariaDB, SQL Server, MongoDB, Vitess and PlanetScale.

## How

**Splitting is CDC-gated.** The value is only split for CDC sources, and only when it contains a comma. `--source-table` legitimately carries commas elsewhere — custom queries (`query:SELECT a, b FROM t`) and structured SaaS table specs (`campaigns:123,456`) — so every existing invocation takes an unchanged code path.

**The selection lives on the source**, via a new optional `TableSelector` capability set once after `Connect` and before any discovery. A pipeline-level filter would not be enough: `postgres_cdc.ReadAll` re-lists tables itself, and under `--stream` it classifies anything outside `opts.KnownTables` as newly observed, turning every *excluded* table into a "new table" announcement. Postgres also re-lists from the `discover_interval` timer and from `rebuildStream`. Storing the selection on the source covers all three, and makes `GetTables` return the narrowed set so the pipeline needs no filtering of its own.

**One shared matcher.** `TableSelection` generalizes `mssql_cdc.selectTables`, keyed on names rather than `SourceTableInfo` so each source filters before its per-table schema queries, with a `canonicalize` hook because the reported name differs per source — Postgres leaves public-schema tables unqualified, so `public.users` and `users` resolve to the same table. Matching is case-insensitive. It is immutable and pure, since the discovery timer and the stream-rebuild path consult it concurrently.

**Unmatched names fail the run.** Ingesting nothing would hide a typo, and in streaming mode would poll forever. A table that exists but cannot be replicated reports the concrete reason instead of "not found". This also upgrades MySQL, MongoDB, Vitess and PlanetScale from silently skipping unmatched names.

**A subset is its own connector.** The selection participates in the connector identity, so it gets its own replication slot, run lease and CDC state. Sharing with the all-tables run would be unsafe in both directions: the slot advances past changes to tables the run filters out, so a later wider run would resume from a position that has already skipped them; and `--full-refresh` resets the state manager's completion markers wholesale, discarding the snapshot state of every table outside the subset. The selection is appended to the identity **only when there is one**, so existing connectors keep the ID they have and never re-snapshot on upgrade (asserted by a test).

**The Postgres managed publication is deliberately not narrowed.** `ingestr_publication` is a shared, database-scoped object that every managed run reconciles with `ALTER PUBLICATION ... SET TABLE`, so narrowing it per run would make concurrent pipelines overwrite each other's capture set. Users wanting the WAL itself narrowed keep supplying `?publication=`, which ingestr never rewrites.

### Side effect

Filtering before the per-table checks unblocks Vitess/PlanetScale keyspaces containing a keyless table, which previously failed the whole run.

## Notes

- `MultiTableReadOptions.Tables` is now documented as test-only. The pipeline does not set it: a non-empty value selects the weaker validation branch in MySQL's inventory checks, losing the "appeared" guard.
- The run summary shown before `--yes` lists the selected tables, so a mistyped list is visible at the confirmation prompt.
- Telemetry gains `table_selection` (`single` / `subset` / `all`) — an enum, never table names.

## Tests

- `TableSelection`: canonicalization, case-insensitivity, post-canonicalization duplicates, missing vs ineligible errors, purity under `-race`.
- CLI regressions pinning that `query:SELECT a, b`, `campaigns:123,456` and fluxx field lists are **not** split.
- Connector identity: subsets isolated from each other and from the all-tables run; the no-subset ID asserted byte-identical to the pre-change hash.
- Postgres CDC integration (verified against a real database): only selected tables replicated, both spellings accepted, the publication still covers all three tables, a table created later is ignored, changes propagate on a second run, a typo errors, and a keyless table reports "replica identity".
- Pipeline-level subset test on the Docker-free multi-table harness.