### PR TITLE
ci: publish linux/arm64 container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -358,9 +358,19 @@ jobs:
             BRANCH_NAME=${{ github.ref_name }}
 
   docker-test:
-    runs-on: depot-ubuntu-latest
-    name: Test Docker Image
+    runs-on: ${{ matrix.runner }}
+    name: Test Docker Image (${{ matrix.arch }})
     needs: [docker-build]
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each runner is natively the architecture under test, so `docker pull`
+        # resolves the matching variant out of the multi-arch manifest on its own.
+        include:
+          - arch: amd64
+            runner: depot-ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes #1102.

The published container images were `linux/amd64` only, so they couldn't be scheduled on arm64 Kubernetes nodes.

## Changes

**`docker-build` (release.yml) now builds `linux/amd64,linux/arm64`.**

No build changes were needed to add the platform:

- The `Dockerfile` is already architecture-agnostic — a native CGO build on top of the multi-arch `golang:1.26-bookworm` and `debian:bookworm-slim` base images, with no arch-pinned downloads.
- GoReleaser has been shipping a CGO `linux/arm64` binary all along (`.goreleaser.yaml`, `ingestr-linux-arm64`), so the toolchain and the cgo dependencies are already known to work on the target.
- Depot builds both platforms on native builders, so the second platform costs no emulation time.

**`dockerBuild` (tests.yml) builds both platforms too**, so an arm64 break surfaces on the pull request rather than at release time. This job doesn't push, so it stays a build-only check.

**`docker-test` is now a per-architecture matrix.** Previously the arm64 image would have been published without ever being executed. The arm64 leg runs on a native `ubuntu-24.04-arm` runner (free for public repos), so both variants run the existing `--version` and CSV → DuckDB checks. Each runner is natively the architecture under test, so `docker pull` resolves the matching variant out of the multi-arch manifest without any `--platform` plumbing. `fail-fast: false` keeps one arch's failure from masking the other's result.

The CSV → DuckDB case matters beyond the binary itself: DuckDB is reached through a runtime-downloaded ADBC driver, so the arm64 leg also confirms the driver resolves and loads on that architecture.