### PR TITLE
Add Deel API source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -205,6 +205,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "CleverTap", link: "/supported-sources/clevertap.md" },
               { text: "ClickUp", link: "/supported-sources/clickup.md" },
               { text: "Cursor", link: "/supported-sources/cursor.md" },
+              { text: "Deel", link: "/supported-sources/deel.md" },
               { text: "Docebo", link: "/supported-sources/docebo.md" },
               { text: "Dune", link: "/supported-sources/dune.md" },
               {

--- a/docs/supported-sources/deel.md
+++ b/docs/supported-sources/deel.md
@@ -1,0 +1,136 @@
+# Deel
+
+[Deel](https://www.deel.com/) is a global workforce platform for contracts, HR, payroll, expenses, time off, recruiting, immigration, and IT operations.
+
+ingestr supports Deel as a source through the [Deel REST API](https://developer.deel.com/api/quickstart).
+
+## URI format
+
+```plaintext
+deel://?api_key=<api_key>
+deel://?api_key=<api_key>&environment=sandbox
+```
+
+URI parameters:
+
+- `api_key`: A Deel organization API token. Give the token the read scopes needed by the tables you plan to ingest.
+- `environment`: Optional. Use `production` (the default) or `sandbox`. Sandbox tokens are separate from production tokens.
+
+Some tables contain sensitive personal, employment, and payroll information. Deel returns only the fields and resources allowed by the token's scopes and sensitive-data settings.
+
+## Example usage
+
+```bash
+ingestr ingest \
+  --source-uri 'deel://?api_key=<api_key>' \
+  --source-table people \
+  --dest-uri duckdb:///deel.duckdb \
+  --dest-table main.people
+```
+
+Nested Deel objects and arrays are preserved as JSON columns. Tables whose names start with `contract_`, `people_`, `person_`, `eor_`, `legal_entity_`, `payroll_`, or `gp_` may make one request per matching parent record.
+
+## Organization and workforce tables
+
+| Table | Primary key | Strategy | Data |
+| --- | --- | --- | --- |
+| `organizations` | `id` | replace | Current organization |
+| `legal_entities` | `id` | merge | Legal entities, including archived entities and payroll settings |
+| `people` | `id` | merge | Organization-wide people directory and employment summaries |
+| `people_details` | `id` | merge | Full profile for every person, including custom fields and worker relations |
+| `people_personal` | `person_id` | replace | Personal information for every accessible person |
+| `people_positions` | `person_id`, `id` | replace | HRIS positions for every person |
+| `people_worker_relations` | `person_id`, `id` | replace | Worker relationships for every person |
+| `person_custom_field_values` | `person_id`, `id` | replace | Custom-field values for every person |
+| `people_custom_fields` | `id` | replace | People custom-field definitions |
+| `departments` | `id` | replace | Departments |
+| `teams` | `id` | replace | Teams |
+| `groups` | `id` | merge | Groups, including archived groups |
+| `roles` | `id` | replace | Organization roles |
+| `working_locations` | `id` | replace | Working locations |
+| `managers` | `id` | replace | Managers |
+| `onboarding` | `unique_id` | replace | Onboarding tracker records |
+| `offboarding` | `unique_id` | replace | Offboarding tracker records |
+| `organization_tasks` | `id` | replace | Organization tasks |
+| `organization_structures` | `id` | replace | HRIS organization structures |
+| `worker_relation_types` | `id` | replace | Worker-relation type definitions |
+| `industries` | `id` | merge | Industry subcategories |
+
+## Contract, time, payroll, and accounting tables
+
+| Table | Primary key | Strategy | Data |
+| --- | --- | --- | --- |
+| `contracts` | `id` | replace | Contract summaries and cost centers |
+| `contract_details` | `id` | merge | Full details for every contract |
+| `contract_templates` | `id` | replace | Contract templates |
+| `contract_termination_reasons` | `id` | merge | Contract termination reasons |
+| `contract_custom_fields` | `id` | replace | Contract custom-field definitions |
+| `contract_custom_field_values` | `contract_id`, `id` | replace | Custom-field values for every contract |
+| `contract_adjustments` | `id` | merge | Adjustments for every contract |
+| `contract_amendments` | `id` | merge | Amendments for every contract |
+| `contract_ic_invoicing_taxes` | `contract_id` | replace | Independent-contractor invoicing taxes |
+| `contract_milestones` | `id` | replace | Milestones for milestone contracts |
+| `contract_off_cycle_payments` | `id` | replace | Contractor off-cycle payments |
+| `contract_payment_cycles` | `contract_id`, `id` | replace | Contractor payment cycles |
+| `contract_tasks` | `contract_id`, `id` | replace | Contractor tasks |
+| `eor_benefits` | `contract_id`, `id` | replace | Benefits for EOR contracts |
+| `eor_amendments` | `id` | merge | Amendments for EOR contracts |
+| `eor_documents` | `contract_id`, `document_type` | replace | Documents for EOR contracts |
+| `timesheets` | `id` | merge | Timesheets |
+| `hourly_report_root_presets` | `id` | replace | Hourly-report root presets |
+| `adjustment_categories` | `id` | replace | Adjustment categories |
+| `invoice_adjustments` | `id` | merge | Invoice adjustments |
+| `invoices` | `id` | merge | Organization invoices |
+| `deel_invoices` | `id` | replace | Deel fee invoices |
+| `payments` | `id` | merge | Payment receipts |
+| `refund_statements` | `id` | merge | Refund statements |
+| `time_offs` | `id` | merge | Time-off requests, including deleted requests |
+| `shift_rates` | `external_id` | merge | Time-tracking shift rates |
+| `shifts` | `external_id` | merge | Time-tracking shifts |
+| `legal_entity_cost_centers` | `id` | merge | Cost centers for every legal entity |
+| `payroll_cycles` | `id` | merge | Payroll cycles for every legal entity |
+| `gross_to_net_reports` | `payroll_cycle_id`, `contract_oid` | merge | Gross-to-net records for payroll cycles |
+| `gp_payroll_events` | `id` | replace | Global Payroll events for every legal entity |
+| `gp_gross_to_net_reports` | `payroll_event_id`, `contractId` | merge | Global Payroll gross-to-net records |
+
+## Recruiting, IT, immigration, and webhook tables
+
+| Table | Primary key | Strategy | Data |
+| --- | --- | --- | --- |
+| `ats_application_sources` | `id` | merge | ATS application sources |
+| `ats_applications` | `id` | replace | ATS applications |
+| `ats_candidates` | `id` | merge | ATS candidates |
+| `ats_departments` | `id` | merge | ATS departments |
+| `ats_employment_types` | `id` | merge | ATS employment types |
+| `ats_hiring_members` | `id` | merge | ATS hiring members |
+| `ats_job_boards` | `id` | merge | ATS job boards |
+| `ats_jobs` | `id` | merge | ATS jobs |
+| `ats_locations` | `id` | merge | ATS locations |
+| `ats_offers` | `id` | merge | ATS offers |
+| `ats_candidate_archivation_reasons` | `id` | replace | Candidate archivation reasons |
+| `ats_offer_rejection_reasons` | `id` | replace | Offer rejection reasons |
+| `ats_job_closure_reasons` | `id` | replace | Job closure reasons |
+| `ats_email_templates` | `id` | merge | Published ATS email templates |
+| `ats_interviews` | `id` | merge | ATS interviews |
+| `ats_job_postings` | `id` | merge | ATS job postings |
+| `ats_openings` | `id` | merge | ATS job openings |
+| `ats_tags` | `id` | merge | ATS candidate tags |
+| `ats_teams` | `id` | merge | ATS teams |
+| `it_assets` | `id` | merge | Deel IT assets |
+| `it_orders` | `id` | merge | Deel IT orders |
+| `it_policies` | `id` | replace | Deel IT hardware policies |
+| `immigration_cases` | `id` | merge | Client immigration cases |
+| `webhooks` | `id` | replace | Configured webhooks |
+| `webhook_event_types` | `id` | merge | Available webhook event types |
+
+## Lookup tables
+
+| Table | Primary key | Data |
+| --- | --- | --- |
+| `countries` | `code` | Supported countries and country capabilities |
+| `currencies` | `code` | Supported currencies |
+| `job_titles` | `id` | Job titles |
+| `seniorities` | `id` | Seniority levels |
+| `time_off_types` | `name` | Time-off type names |
+
+Feature-specific tables return an API error when the corresponding Deel product or token scope is not enabled for the organization.

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -66,6 +66,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Airtable](/supported-sources/airtable.md)
 - [Asana](/supported-sources/asana.md)
 - [ClickUp](/supported-sources/clickup.md)
+- [Deel](/supported-sources/deel.md)
 - [Docebo](/supported-sources/docebo.md)
 - [Fireflies](/supported-sources/fireflies.md)
 - [Fluxx](/supported-sources/fluxx.md)

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -310,6 +310,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("customerio", "Customer.io", []string{"customerio"}, true, false),
 		genericURIConnector("databricks", "Databricks", []string{"databricks"}, true, true),
 		genericURIConnector("db2", "Db2", []string{"db2", "ibmdb2"}, true, false),
+		genericURIConnector("deel", "Deel", []string{"deel"}, true, false),
 		genericURIConnector("discard", "Discard", []string{"discard"}, false, true),
 		genericURIConnector("docebo", "Docebo", []string{"docebo"}, true, false),
 		genericURIConnector("ducklake", "DuckLake", []string{"ducklake"}, true, true),

--- a/pkg/source/deel/deel.go
+++ b/pkg/source/deel/deel.go
@@ -1,0 +1,1151 @@
+package deel
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	productionBaseURL  = "https://api.letsdeel.com/rest"
+	sandboxBaseURL     = "https://api-sandbox.demo.deel.com/rest"
+	stableAPIVersion   = "2026-01-01"
+	requestTimeout     = 60 * time.Second
+	maxPageSize        = 100
+	maxInvoicePageSize = 50
+	maxPages           = 100000
+	fanoutWorkers      = 4
+	// Deel only returns payroll cycles fully contained in a query and caps ranges at one year.
+	payrollWindowMonths    = 6
+	payrollLookaheadMonths = 5
+
+	// Deel allows 5 requests per second per organization. Four requests per second
+	// with no burst leaves headroom for other clients sharing the organization quota.
+	rateLimit      = 4
+	rateLimitBurst = 1
+)
+
+type paginationStyle int
+
+const (
+	paginationNone paginationStyle = iota
+	paginationOffset
+	paginationPageCursor
+	paginationNextCursor
+	paginationCursor
+	paginationDataNextCursor
+	paginationTimeOffNext
+	paginationOffboarding
+)
+
+type intervalFormat int
+
+const (
+	intervalNone intervalFormat = iota
+	intervalDate
+	intervalDateTime
+)
+
+type endpointMeta struct {
+	path                string
+	primaryKeys         []string
+	incrementalKey      string
+	strategy            config.IncrementalStrategy
+	pagination          paginationStyle
+	pageSize            int
+	pageSizeParam       string
+	offsetParam         string
+	cursorParam         string
+	dataPath            string
+	primitiveField      string
+	query               map[string]string
+	queryValues         url.Values
+	version             string
+	intervalStartParam  string
+	intervalEndParam    string
+	intervalFormat      intervalFormat
+	startParamExclusive bool
+	clientFilter        bool
+}
+
+type fanoutMeta struct {
+	parentTable       string
+	parentIDField     string
+	parentOutputField string
+	pathPlaceholder   string
+	endpoint          endpointMeta
+	allowedTypes      map[string]bool
+	skipNotFound      bool
+	defaultFiveYears  bool
+}
+
+var directTables = map[string]endpointMeta{
+	"organizations": {
+		path: "/organizations", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"legal_entities": {
+		path: "/legal-entities", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationPageCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		query: map[string]string{"include_archived": "true", "include_payroll_settings": "true"}, clientFilter: true,
+	},
+	"people": {
+		path: "/people", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset", clientFilter: true,
+	},
+	"contracts": {
+		path: "/contracts", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationPageCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "after_cursor",
+		query: map[string]string{"expand": "cost_centers"},
+	},
+	"contract_templates": {
+		path: "/contract-templates", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"contract_termination_reasons": {
+		path: "/contracts/termination-reasons", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"contract_custom_fields": {
+		path: "/contracts/custom_fields", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"people_custom_fields": {
+		path: "/people/custom_fields", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"departments": {
+		path: "/departments", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"teams": {
+		path: "/teams", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"groups": {
+		path: "/groups", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationPageCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		query: map[string]string{"include_archived_groups": "true"}, clientFilter: true,
+	},
+	"roles": {
+		path: "/roles", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"working_locations": {
+		path: "/working-locations", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"managers": {
+		path: "/managers", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset",
+	},
+	"onboarding": {
+		path: "/onboarding/tracker", primaryKeys: []string{"unique_id"}, strategy: config.StrategyReplace,
+		pagination: paginationPageCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+	},
+	"offboarding": {
+		path: "/offboarding/tracker", primaryKeys: []string{"unique_id"}, strategy: config.StrategyReplace,
+		pagination: paginationOffboarding, pageSize: maxPageSize, pageSizeParam: "limit",
+		query: map[string]string{"ignore_date_range": "true"},
+	},
+	"organization_tasks": {
+		path: "/organizations/tasks", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		queryValues: url.Values{"statuses": {"PENDING", "COMPLETED", "DISMISSED", "FAILED"}},
+	},
+	"organization_structures": {
+		path: "/hris/organization_structures", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset",
+	},
+	"worker_relation_types": {
+		path: "/hris/worker_relations/types", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"industries": {
+		path: "/industries", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"timesheets": {
+		path: "/timesheets", primaryKeys: []string{"id"}, incrementalKey: "date_submitted", strategy: config.StrategyMerge,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset", clientFilter: true,
+		intervalStartParam: "date_from", intervalEndParam: "date_to", intervalFormat: intervalDate,
+	},
+	"invoice_adjustments": {
+		path: "/invoice-adjustments", primaryKeys: []string{"id"}, incrementalKey: "date_submitted", strategy: config.StrategyMerge,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset", clientFilter: true,
+		intervalStartParam: "date_from", intervalEndParam: "date_to", intervalFormat: intervalDate,
+	},
+	"invoices": {
+		path: "/invoices", primaryKeys: []string{"id"}, incrementalKey: "issued_at", strategy: config.StrategyMerge,
+		pagination: paginationOffset, pageSize: maxInvoicePageSize, pageSizeParam: "limit", offsetParam: "offset", clientFilter: true,
+		query:              map[string]string{"status": "all"},
+		intervalStartParam: "issued_from_date", intervalEndParam: "issued_to_date", intervalFormat: intervalDate,
+	},
+	"deel_invoices": {
+		path: "/invoices/deel", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationOffset, pageSize: maxInvoicePageSize, pageSizeParam: "limit", offsetParam: "offset",
+	},
+	"payments": {
+		path: "/payments", primaryKeys: []string{"id"}, incrementalKey: "created_at", strategy: config.StrategyMerge,
+		pagination: paginationDataNextCursor, cursorParam: "cursor", dataPath: "data.rows", clientFilter: true,
+		intervalStartParam: "date_from", intervalEndParam: "date_to", intervalFormat: intervalDate,
+	},
+	"refund_statements": {
+		path: "/refund-statements", primaryKeys: []string{"id"}, incrementalKey: "created_at", strategy: config.StrategyMerge,
+		pagination: paginationDataNextCursor, cursorParam: "cursor", dataPath: "data.rows", clientFilter: true,
+		intervalStartParam: "date_from", intervalEndParam: "date_to", intervalFormat: intervalDate,
+	},
+	"time_offs": {
+		path: "/time_offs", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationTimeOffNext, pageSize: maxPageSize, pageSizeParam: "page_size", cursorParam: "next",
+		query:              map[string]string{"include_deleted_time_offs": "true"},
+		intervalStartParam: "updated_start_date", intervalEndParam: "updated_end_date", intervalFormat: intervalDateTime,
+	},
+	"shift_rates": {
+		path: "/v2/time_tracking/shift_rates", primaryKeys: []string{"external_id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset", clientFilter: true,
+	},
+	"shifts": {
+		path: "/v2/time_tracking/shifts", primaryKeys: []string{"external_id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset", clientFilter: true,
+	},
+	"adjustment_categories": {
+		path: "/adjustments/categories", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		queryValues: url.Values{"contract_types": {"peo", "global_payroll", "hris_direct_employee", "eor", "employee", "independent_contractor"}},
+	},
+	"hourly_report_root_presets": {
+		path: "/timesheets/root-presets", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationPageCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+	},
+	"countries": {
+		path: "/lookups/countries", primaryKeys: []string{"code"}, strategy: config.StrategyReplace,
+	},
+	"currencies": {
+		path: "/lookups/currencies", primaryKeys: []string{"code"}, strategy: config.StrategyReplace,
+	},
+	"job_titles": {
+		path: "/lookups/job-titles", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationPageCursor, cursorParam: "after_cursor",
+	},
+	"seniorities": {
+		path: "/lookups/seniorities", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		query: map[string]string{"is_eor_contract": "false"},
+	},
+	"time_off_types": {
+		path: "/lookups/time-off-types", primaryKeys: []string{"name"}, strategy: config.StrategyReplace, primitiveField: "name",
+	},
+	"webhooks": {
+		path: "/webhooks", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"webhook_event_types": {
+		path: "/webhooks/events/types", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge, clientFilter: true,
+	},
+	"it_assets": {
+		path: "/it/assets", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"it_orders": {
+		path: "/it/orders", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"it_policies": {
+		path: "/it/policies", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+	},
+	"immigration_cases": {
+		path: "/immigration/client/cases", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_application_sources": {
+		path: "/ats/application-sources", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_applications": {
+		path: "/ats/applications", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+	},
+	"ats_candidates": {
+		path: "/ats/candidates", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		intervalStartParam: "updated_after", intervalFormat: intervalDateTime, startParamExclusive: true, clientFilter: true,
+	},
+	"ats_departments": {
+		path: "/ats/departments", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_employment_types": {
+		path: "/ats/employment-types", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_hiring_members": {
+		path: "/ats/hiring-members", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_job_boards": {
+		path: "/ats/job-boards", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_jobs": {
+		path: "/ats/jobs", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		intervalStartParam: "updated_after", intervalFormat: intervalDateTime, startParamExclusive: true, clientFilter: true,
+	},
+	"ats_locations": {
+		path: "/ats/locations", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_offers": {
+		path: "/ats/offers", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge, clientFilter: true,
+		pagination: paginationNextCursor, cursorParam: "cursor",
+	},
+	"ats_candidate_archivation_reasons": {
+		path: "/ats/reasons", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		query: map[string]string{"reason_group_slug": "CANDIDATE_ARCHIVATION"},
+	},
+	"ats_offer_rejection_reasons": {
+		path: "/ats/reasons", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		query: map[string]string{"reason_group_slug": "OFFER_REJECTION"},
+	},
+	"ats_job_closure_reasons": {
+		path: "/ats/reasons", primaryKeys: []string{"id"}, strategy: config.StrategyReplace,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		query: map[string]string{"reason_group_slug": "JOB_CLOSURE"},
+	},
+	"ats_email_templates": {
+		path: "/ats/email-templates", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+		intervalStartParam: "updated_after", intervalFormat: intervalDateTime, startParamExclusive: true, clientFilter: true,
+	},
+	"ats_interviews": {
+		path: "/ats/interviews", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", version: "2026-06-03",
+		intervalStartParam: "updated_after", intervalFormat: intervalDateTime, startParamExclusive: true, clientFilter: true,
+	},
+	"ats_job_postings": {
+		path: "/ats/job-postings", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_openings": {
+		path: "/ats/openings", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", version: "2026-06-15", clientFilter: true,
+	},
+	"ats_tags": {
+		path: "/ats/tags", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+	},
+	"ats_teams": {
+		path: "/ats/teams", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+		pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", version: "2026-06-24", clientFilter: true,
+	},
+}
+
+var contractorTypes = map[string]bool{
+	"ongoing_time_based":       true,
+	"milestones":               true,
+	"time_based":               true,
+	"pay_as_you_go_time_based": true,
+	"commission":               true,
+	"payg_milestones":          true,
+	"payg_tasks":               true,
+}
+
+var fanoutTables = map[string]fanoutMeta{
+	"contract_details": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "id", pathPlaceholder: "{contract_id}",
+		endpoint: endpointMeta{path: "/contracts/{contract_id}", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge, clientFilter: true},
+	},
+	"contract_adjustments": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}",
+		endpoint: endpointMeta{path: "/contracts/{contract_id}/adjustments", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge, clientFilter: true},
+	},
+	"contract_amendments": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: contractorTypes,
+		endpoint: endpointMeta{
+			path: "/contracts/{contract_id}/amendments", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+			pagination: paginationCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+		},
+	},
+	"contract_custom_field_values": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/contracts/{contract_id}/custom_fields", primaryKeys: []string{"contract_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"contract_ic_invoicing_taxes": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: contractorTypes,
+		endpoint: endpointMeta{path: "/contracts/{contract_id}/ic-invoicing-taxes", primaryKeys: []string{"contract_id"}, strategy: config.StrategyReplace},
+	},
+	"contract_milestones": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}",
+		allowedTypes: map[string]bool{"milestones": true, "payg_milestones": true},
+		endpoint:     endpointMeta{path: "/contracts/{contract_id}/milestones", primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	},
+	"contract_off_cycle_payments": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: contractorTypes,
+		endpoint: endpointMeta{path: "/contracts/{contract_id}/off-cycle-payments", primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	},
+	"contract_payment_cycles": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: contractorTypes, skipNotFound: true,
+		endpoint: endpointMeta{path: "/contracts/{contract_id}/payment_cycles", primaryKeys: []string{"contract_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"contract_tasks": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: contractorTypes,
+		endpoint: endpointMeta{path: "/contracts/{contract_id}/tasks", primaryKeys: []string{"contract_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"eor_benefits": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: map[string]bool{"eor": true}, skipNotFound: true,
+		endpoint: endpointMeta{path: "/eor/{contract_id}/benefits", primaryKeys: []string{"contract_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"eor_amendments": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: map[string]bool{"eor": true},
+		endpoint: endpointMeta{path: "/eor/contracts/{contract_id}/amendments", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge, clientFilter: true},
+	},
+	"eor_documents": {
+		parentTable: "contracts", parentIDField: "id", parentOutputField: "contract_id", pathPlaceholder: "{contract_id}", allowedTypes: map[string]bool{"eor": true},
+		endpoint: endpointMeta{path: "/eor/contracts/{contract_id}/documents", primaryKeys: []string{"contract_id", "document_type"}, strategy: config.StrategyReplace},
+	},
+	"people_details": {
+		parentTable: "people", parentIDField: "id", parentOutputField: "id", pathPlaceholder: "{person_id}", skipNotFound: true,
+		endpoint: endpointMeta{
+			path: "/people/{person_id}", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge,
+			query: map[string]string{"include_custom_fields": "true", "include_worker_relations": "true"}, clientFilter: true,
+		},
+	},
+	"person_custom_field_values": {
+		parentTable: "people", parentIDField: "id", parentOutputField: "person_id", pathPlaceholder: "{person_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/people/{person_id}/custom_fields", primaryKeys: []string{"person_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"people_personal": {
+		parentTable: "people", parentIDField: "id", parentOutputField: "person_id", pathPlaceholder: "{person_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/people/{person_id}/personal", primaryKeys: []string{"person_id"}, strategy: config.StrategyReplace},
+	},
+	"people_positions": {
+		parentTable: "people", parentIDField: "id", parentOutputField: "person_id", pathPlaceholder: "{person_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/hris/positions/profile/{person_id}", primaryKeys: []string{"person_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"people_worker_relations": {
+		parentTable: "people", parentIDField: "id", parentOutputField: "person_id", pathPlaceholder: "{person_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/hris/worker_relations/profile/{person_id}", primaryKeys: []string{"person_id", "id"}, strategy: config.StrategyReplace},
+	},
+	"legal_entity_cost_centers": {
+		parentTable: "legal_entities", parentIDField: "id", parentOutputField: "legal_entity_id", pathPlaceholder: "{legal_entity_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/legal-entities/{legal_entity_id}/cost-centers", primaryKeys: []string{"id"}, incrementalKey: "updated_at", strategy: config.StrategyMerge, clientFilter: true},
+	},
+	"payroll_cycles": {
+		parentTable: "legal_entities", parentIDField: "id", parentOutputField: "legal_entity_id", pathPlaceholder: "{legal_entity_id}", skipNotFound: true, defaultFiveYears: true,
+		endpoint: endpointMeta{
+			path: "/legal-entities/{legal_entity_id}/payroll-events", primaryKeys: []string{"id"}, incrementalKey: "date_start", strategy: config.StrategyMerge,
+			pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor", clientFilter: true,
+			intervalStartParam: "date_start", intervalEndParam: "date_end", intervalFormat: intervalDate,
+		},
+	},
+	"gp_payroll_events": {
+		parentTable: "legal_entities", parentIDField: "id", parentOutputField: "legal_entity_id", pathPlaceholder: "{legal_entity_id}", skipNotFound: true,
+		endpoint: endpointMeta{path: "/gp/legal-entities/{legal_entity_id}/reports", primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	},
+}
+
+type credentials struct {
+	apiKey      string
+	environment string
+}
+
+type DeelSource struct {
+	client  *httpclient.Client
+	apiKey  string
+	baseURL string
+}
+
+func NewDeelSource() *DeelSource {
+	return &DeelSource{}
+}
+
+func (s *DeelSource) Schemes() []string {
+	return []string{"deel"}
+}
+
+func (s *DeelSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *DeelSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.apiKey = creds.apiKey
+	if s.baseURL == "" {
+		s.baseURL = productionBaseURL
+		if creds.environment == "sandbox" {
+			s.baseURL = sandboxBaseURL
+		}
+	}
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(s.baseURL),
+		httpclient.WithTimeout(requestTimeout),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithAuth(httpclient.NewBearerAuth(s.apiKey)),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithHeader("Accept", "application/json"),
+		httpclient.WithHeader("X-Version", stableAPIVersion),
+	)
+
+	config.Debug("[DEEL] Connected successfully")
+	return nil
+}
+
+func parseURI(uri string) (credentials, error) {
+	if !strings.HasPrefix(uri, "deel://") {
+		return credentials{}, fmt.Errorf("invalid deel URI: must start with deel://")
+	}
+
+	rest := strings.TrimPrefix(uri, "deel://")
+	if rest == "" || rest == "?" {
+		return credentials{}, fmt.Errorf("api_key is required in deel URI")
+	}
+
+	values, err := url.ParseQuery(strings.TrimPrefix(rest, "?"))
+	if err != nil {
+		return credentials{}, fmt.Errorf("failed to parse deel URI query: %w", err)
+	}
+
+	apiKey := values.Get("api_key")
+	if apiKey == "" {
+		return credentials{}, fmt.Errorf("api_key is required in deel URI")
+	}
+
+	environment := values.Get("environment")
+	if environment == "" {
+		environment = "production"
+	}
+	if environment != "production" && environment != "sandbox" {
+		return credentials{}, fmt.Errorf("invalid deel environment %q: must be production or sandbox", environment)
+	}
+
+	return credentials{apiKey: apiKey, environment: environment}, nil
+}
+
+func (s *DeelSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *DeelSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	meta, ok := tableMeta(req.Name)
+	if !ok {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", req.Name, strings.Join(supportedTableNames(), ", "))
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           req.Name,
+		TablePrimaryKeys:    meta.primaryKeys,
+		TableIncrementalKey: meta.incrementalKey,
+		TableStrategy:       meta.strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("deel source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, req.Name, opts)
+		},
+	}, nil
+}
+
+func tableMeta(table string) (endpointMeta, bool) {
+	if meta, ok := directTables[table]; ok {
+		return meta, true
+	}
+	if meta, ok := fanoutTables[table]; ok {
+		return meta.endpoint, true
+	}
+	switch table {
+	case "gross_to_net_reports":
+		return endpointMeta{primaryKeys: []string{"payroll_cycle_id", "contract_oid"}, strategy: config.StrategyMerge}, true
+	case "gp_gross_to_net_reports":
+		return endpointMeta{primaryKeys: []string{"payroll_event_id", "contractId"}, strategy: config.StrategyMerge}, true
+	default:
+		return endpointMeta{}, false
+	}
+}
+
+func supportedTableNames() []string {
+	tables := make([]string, 0, len(directTables)+len(fanoutTables)+2)
+	for table := range directTables {
+		tables = append(tables, table)
+	}
+	for table := range fanoutTables {
+		tables = append(tables, table)
+	}
+	tables = append(tables, "gross_to_net_reports", "gp_gross_to_net_reports")
+	sort.Strings(tables)
+	return tables
+}
+
+func isValidTable(table string) bool {
+	_, ok := tableMeta(table)
+	return ok
+}
+
+func (s *DeelSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	if !isValidTable(table) {
+		return nil, fmt.Errorf("unsupported table: %s", table)
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "gross_to_net_reports":
+			err = s.readGrossToNetReports(ctx, opts, results)
+		case "gp_gross_to_net_reports":
+			err = s.readGPGrossToNetReports(ctx, opts, results)
+		default:
+			if meta, ok := directTables[table]; ok {
+				err = s.readDirect(ctx, table, meta, opts, results)
+			} else {
+				err = s.readFanout(ctx, table, fanoutTables[table], opts, results)
+			}
+		}
+
+		if err != nil {
+			_ = sendResult(ctx, results, source.RecordBatchResult{Err: err})
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *DeelSource) readDirect(ctx context.Context, table string, meta endpointMeta, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[DEEL] reading %s", table)
+	return s.fetchPages(ctx, meta, opts, func(items []map[string]any) error {
+		return sendItems(ctx, items, meta, opts, results)
+	})
+}
+
+func (s *DeelSource) readFanout(ctx context.Context, table string, meta fanoutMeta, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[DEEL] reading %s", table)
+	childOptions := []source.ReadOptions{opts}
+	if meta.defaultFiveYears {
+		childOptions = payrollIntervals(opts)
+	}
+
+	parentMeta := directTables[meta.parentTable]
+	return s.fetchPages(ctx, parentMeta, source.ReadOptions{}, func(parents []map[string]any) error {
+		group, groupCtx := errgroup.WithContext(ctx)
+		group.SetLimit(fanoutWorkers)
+		for _, parent := range parents {
+			parent := parent
+			group.Go(func() error {
+				if len(meta.allowedTypes) > 0 && !meta.allowedTypes[stringValue(parent["type"])] {
+					return nil
+				}
+
+				parentID := stringValue(parent[meta.parentIDField])
+				if parentID == "" {
+					return nil
+				}
+
+				childMeta := meta.endpoint
+				childMeta.path = strings.ReplaceAll(childMeta.path, meta.pathPlaceholder, url.PathEscape(parentID))
+				for _, childOpts := range childOptions {
+					requestOpts := childOpts
+					if meta.defaultFiveYears {
+						requestOpts = payrollRequestOptions(childOpts)
+					}
+					err := s.fetchPages(groupCtx, childMeta, requestOpts, func(items []map[string]any) error {
+						for _, item := range items {
+							item[meta.parentOutputField] = parentID
+						}
+						return sendItems(groupCtx, items, childMeta, childOpts, results)
+					})
+					if err != nil {
+						var statusErr *apiStatusError
+						if meta.skipNotFound && errors.As(err, &statusErr) && statusErr.statusCode == http.StatusNotFound {
+							return nil
+						}
+						return fmt.Errorf("failed to fetch %s for parent: %w", table, err)
+					}
+				}
+				return nil
+			})
+		}
+		return group.Wait()
+	})
+}
+
+func (s *DeelSource) readGrossToNetReports(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[DEEL] reading gross_to_net_reports")
+	cycleOptions := payrollIntervals(opts)
+	entityMeta := directTables["legal_entities"]
+	return s.fetchPages(ctx, entityMeta, source.ReadOptions{}, func(entities []map[string]any) error {
+		for _, entity := range entities {
+			entityID := stringValue(entity["id"])
+			if entityID == "" {
+				continue
+			}
+
+			cycleMeta := fanoutTables["payroll_cycles"].endpoint
+			cycleMeta.path = strings.ReplaceAll(cycleMeta.path, "{legal_entity_id}", url.PathEscape(entityID))
+			for _, cycleOpts := range cycleOptions {
+				err := s.fetchPages(ctx, cycleMeta, payrollRequestOptions(cycleOpts), func(cycles []map[string]any) error {
+					cycles = filterItemsByInterval(cycles, cycleMeta.incrementalKey, cycleOpts.IntervalStart, cycleOpts.IntervalEnd)
+					for _, cycle := range cycles {
+						if hasReport, ok := cycle["has_g2n_report"].(bool); ok && !hasReport {
+							continue
+						}
+						cycleID := stringValue(cycle["id"])
+						if cycleID == "" {
+							continue
+						}
+
+						reportMeta := endpointMeta{
+							path:       "/reports/payroll/cycles/" + url.PathEscape(cycleID) + "/gross-to-net",
+							pagination: paginationNextCursor, pageSize: maxPageSize, pageSizeParam: "limit", cursorParam: "cursor",
+						}
+						if err := s.fetchPages(ctx, reportMeta, source.ReadOptions{}, func(items []map[string]any) error {
+							for _, item := range items {
+								item["payroll_cycle_id"] = cycleID
+								item["legal_entity_id"] = entityID
+							}
+							return sendItems(ctx, items, reportMeta, source.ReadOptions{}, results)
+						}); err != nil {
+							return fmt.Errorf("failed to fetch gross-to-net report: %w", err)
+						}
+					}
+					return nil
+				})
+				if err != nil {
+					var statusErr *apiStatusError
+					if errors.As(err, &statusErr) && statusErr.statusCode == http.StatusNotFound {
+						break
+					}
+					return fmt.Errorf("failed to fetch payroll cycles: %w", err)
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func (s *DeelSource) readGPGrossToNetReports(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[DEEL] reading gp_gross_to_net_reports")
+	entityMeta := directTables["legal_entities"]
+	return s.fetchPages(ctx, entityMeta, source.ReadOptions{}, func(entities []map[string]any) error {
+		for _, entity := range entities {
+			entityID := stringValue(entity["id"])
+			if entityID == "" {
+				continue
+			}
+
+			eventsMeta := fanoutTables["gp_payroll_events"].endpoint
+			eventsMeta.path = strings.ReplaceAll(eventsMeta.path, "{legal_entity_id}", url.PathEscape(entityID))
+			err := s.fetchPages(ctx, eventsMeta, source.ReadOptions{}, func(events []map[string]any) error {
+				for _, event := range events {
+					eventID := stringValue(event["id"])
+					if eventID == "" {
+						continue
+					}
+
+					reportMeta := endpointMeta{
+						path:       "/gp/reports/" + url.PathEscape(eventID) + "/gross_to_net",
+						pagination: paginationOffset, pageSize: maxPageSize, pageSizeParam: "limit", offsetParam: "offset",
+					}
+					if err := s.fetchPages(ctx, reportMeta, opts, func(items []map[string]any) error {
+						flattenReportCell(items, "contractId")
+						for _, item := range items {
+							item["payroll_event_id"] = eventID
+							item["legal_entity_id"] = entityID
+						}
+						return sendItems(ctx, items, reportMeta, opts, results)
+					}); err != nil {
+						return fmt.Errorf("failed to fetch GP gross-to-net report: %w", err)
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				var statusErr *apiStatusError
+				if errors.As(err, &statusErr) && statusErr.statusCode == http.StatusNotFound {
+					continue
+				}
+				return fmt.Errorf("failed to fetch GP payroll events: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+type apiStatusError struct {
+	path       string
+	statusCode int
+	body       string
+}
+
+func (e *apiStatusError) Error() string {
+	return fmt.Sprintf("Deel API %s returned status %d: %s", e.path, e.statusCode, e.body)
+}
+
+func (s *DeelSource) fetchPages(ctx context.Context, meta endpointMeta, opts source.ReadOptions, onPage func([]map[string]any) error) error {
+	cursor := ""
+	cursorParams := map[string]string{}
+	offset := 0
+	dataPath := meta.dataPath
+	if dataPath == "" {
+		dataPath = "data"
+	}
+
+	for page := 0; page < maxPages; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx)
+		if len(meta.query) > 0 {
+			req.SetQueryParams(meta.query)
+		}
+		if len(meta.queryValues) > 0 {
+			req.SetQueryParamValues(meta.queryValues)
+		}
+		if meta.version != "" {
+			req.SetHeader("X-Version", meta.version)
+		}
+		if meta.pageSizeParam != "" && meta.pageSize > 0 {
+			req.SetQueryParam(meta.pageSizeParam, strconv.Itoa(meta.pageSize))
+		}
+		if meta.pagination == paginationOffset {
+			req.SetQueryParam(meta.offsetParam, strconv.Itoa(offset))
+		} else if meta.pagination == paginationOffboarding {
+			for key, value := range cursorParams {
+				req.SetQueryParam("pagination["+key+"]", value)
+			}
+		} else if cursor != "" {
+			req.SetQueryParam(meta.cursorParam, cursor)
+		}
+		setIntervalParams(req, meta, opts)
+
+		resp, err := req.Get(meta.path)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", meta.path, err)
+		}
+		if !resp.IsSuccess() {
+			return &apiStatusError{path: meta.path, statusCode: resp.StatusCode(), body: resp.String()}
+		}
+
+		body, err := decodeObject(resp.Body())
+		if err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", meta.path, err)
+		}
+		items, err := extractItems(body, dataPath, meta.primitiveField)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s items: %w", meta.path, err)
+		}
+
+		if len(items) > 0 {
+			if err := onPage(items); err != nil {
+				return err
+			}
+		}
+		config.Debug("[DEEL] fetched %d items from %s", len(items), meta.path)
+
+		switch meta.pagination {
+		case paginationNone:
+			return nil
+		case paginationOffset:
+			if len(items) < meta.pageSize {
+				return nil
+			}
+			offset += meta.pageSize
+		case paginationPageCursor:
+			cursor = nestedString(body, "page", "cursor")
+			if cursor == "" {
+				return nil
+			}
+		case paginationNextCursor:
+			cursor = nestedString(body, "next_cursor")
+			if cursor == "" {
+				return nil
+			}
+		case paginationCursor:
+			cursor = nestedString(body, "cursor")
+			if cursor == "" {
+				return nil
+			}
+		case paginationDataNextCursor:
+			cursor = nestedString(body, "data", "next_cursor")
+			if cursor == "" {
+				return nil
+			}
+		case paginationTimeOffNext:
+			cursor = nestedString(body, "next")
+			if cursor == "" {
+				return nil
+			}
+		case paginationOffboarding:
+			cursor = nestedString(body, "page", "cursor")
+			if cursor == "" {
+				return nil
+			}
+			cursorParams, err = decodeOffboardingCursor(cursor)
+			if err != nil {
+				return fmt.Errorf("failed to decode offboarding cursor: %w", err)
+			}
+		}
+	}
+
+	config.Debug("[DEEL] stopped %s after reaching maxPages=%d", meta.path, maxPages)
+	return fmt.Errorf("stopped fetching %s after %d pages", meta.path, maxPages)
+}
+
+func setIntervalParams(req *httpclient.Request, meta endpointMeta, opts source.ReadOptions) {
+	if meta.intervalFormat == intervalNone {
+		return
+	}
+
+	format := time.RFC3339Nano
+	if meta.intervalFormat == intervalDate {
+		format = time.DateOnly
+	}
+	if opts.IntervalStart != nil && meta.intervalStartParam != "" {
+		start := opts.IntervalStart.UTC()
+		if meta.startParamExclusive {
+			start = start.Add(-time.Second)
+		}
+		req.SetQueryParam(meta.intervalStartParam, start.Format(format))
+	}
+	if opts.IntervalEnd != nil && meta.intervalEndParam != "" {
+		end := opts.IntervalEnd.UTC()
+		if meta.intervalFormat == intervalDate && end != end.Truncate(24*time.Hour) {
+			end = end.Truncate(24*time.Hour).AddDate(0, 0, 1)
+		}
+		req.SetQueryParam(meta.intervalEndParam, end.Format(format))
+	}
+}
+
+func decodeObject(data []byte) (map[string]any, error) {
+	var result map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func extractItems(body map[string]any, dataPath, primitiveField string) ([]map[string]any, error) {
+	var value any = body
+	for _, part := range strings.Split(dataPath, ".") {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s is not an object", strings.Join(strings.Split(dataPath, "."), "."))
+		}
+		value = object[part]
+	}
+
+	if value == nil {
+		return nil, nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		return []map[string]any{typed}, nil
+	case []any:
+		items := make([]map[string]any, 0, len(typed))
+		for _, raw := range typed {
+			if item, ok := raw.(map[string]any); ok {
+				items = append(items, item)
+				continue
+			}
+			if primitiveField == "" {
+				return nil, fmt.Errorf("received a primitive item without a field mapping")
+			}
+			items = append(items, map[string]any{primitiveField: raw})
+		}
+		return items, nil
+	default:
+		if primitiveField != "" {
+			return []map[string]any{{primitiveField: typed}}, nil
+		}
+		return nil, fmt.Errorf("unexpected item container %T", value)
+	}
+}
+
+func sendItems(ctx context.Context, items []map[string]any, meta endpointMeta, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if meta.clientFilter {
+		items = filterItemsByInterval(items, meta.incrementalKey, opts.IntervalStart, opts.IntervalEnd)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert Deel records to Arrow: %w", err)
+	}
+	return sendResult(ctx, results, source.RecordBatchResult{Batch: record})
+}
+
+func sendResult(ctx context.Context, results chan<- source.RecordBatchResult, result source.RecordBatchResult) error {
+	select {
+	case results <- result:
+		return nil
+	case <-ctx.Done():
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		return ctx.Err()
+	}
+}
+
+func flattenReportCell(items []map[string]any, field string) {
+	for _, item := range items {
+		cell, ok := item[field].(map[string]any)
+		if !ok {
+			continue
+		}
+		if value, ok := cell["currentValue"]; ok {
+			item[field] = value
+		}
+	}
+}
+
+func filterItemsByInterval(items []map[string]any, field string, start, end *time.Time) []map[string]any {
+	if field == "" || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		timestamp, ok := parseTimestamp(item[field])
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && timestamp.Before(*start) {
+			continue
+		}
+		if end != nil && !timestamp.Before(*end) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func parseTimestamp(value any) (time.Time, bool) {
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.DateOnly} {
+		parsed, err := time.Parse(layout, text)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func nestedString(body map[string]any, path ...string) string {
+	var value any = body
+	for _, part := range path {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return ""
+		}
+		value = object[part]
+	}
+	return stringValue(value)
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case json.Number:
+		return typed.String()
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+func decodeOffboardingCursor(cursor string) (map[string]string, error) {
+	data, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64 cursor: %w", err)
+	}
+
+	decoded, err := decodeObject(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor payload: %w", err)
+	}
+	pagination, ok := decoded["pagination"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("cursor payload does not contain pagination fields")
+	}
+
+	params := make(map[string]string, len(pagination))
+	for key, value := range pagination {
+		params[key] = stringValue(value)
+	}
+	return params, nil
+}
+
+func withDefaultFiveYearInterval(opts source.ReadOptions) source.ReadOptions {
+	now := time.Now().UTC()
+	if opts.IntervalStart == nil {
+		start := now.AddDate(-5, 0, 0)
+		opts.IntervalStart = &start
+	}
+	if opts.IntervalEnd == nil {
+		end := now
+		opts.IntervalEnd = &end
+	}
+	return opts
+}
+
+func payrollIntervals(opts source.ReadOptions) []source.ReadOptions {
+	opts = withDefaultFiveYearInterval(opts)
+	start := opts.IntervalStart.UTC()
+	end := opts.IntervalEnd.UTC()
+	if !start.Before(end) {
+		return nil
+	}
+
+	intervals := make([]source.ReadOptions, 0, 5)
+	for start.Before(end) {
+		windowEnd := start.AddDate(0, payrollWindowMonths, 0)
+		if windowEnd.After(end) {
+			windowEnd = end
+		}
+		windowStart := start
+		windowOpts := opts
+		windowOpts.IntervalStart = &windowStart
+		windowOpts.IntervalEnd = &windowEnd
+		intervals = append(intervals, windowOpts)
+		start = windowEnd
+	}
+	return intervals
+}
+
+func payrollRequestOptions(opts source.ReadOptions) source.ReadOptions {
+	if opts.IntervalEnd != nil {
+		end := opts.IntervalEnd.AddDate(0, payrollLookaheadMonths, 0)
+		opts.IntervalEnd = &end
+	}
+	return opts
+}

--- a/pkg/source/deel/deel_test.go
+++ b/pkg/source/deel/deel_test.go
@@ -1,0 +1,554 @@
+package deel
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name            string
+		uri             string
+		wantKey         string
+		wantEnvironment string
+		wantErr         bool
+	}{
+		{name: "production default", uri: "deel://?api_key=token-123", wantKey: "token-123", wantEnvironment: "production"},
+		{name: "production explicit", uri: "deel://?api_key=token-123&environment=production", wantKey: "token-123", wantEnvironment: "production"},
+		{name: "sandbox", uri: "deel://?api_key=token-123&environment=sandbox", wantKey: "token-123", wantEnvironment: "sandbox"},
+		{name: "without question mark", uri: "deel://api_key=token-123", wantKey: "token-123", wantEnvironment: "production"},
+		{name: "missing key", uri: "deel://?environment=sandbox", wantErr: true},
+		{name: "invalid environment", uri: "deel://?api_key=token-123&environment=staging", wantErr: true},
+		{name: "wrong scheme", uri: "stripe://?api_key=token-123", wantErr: true},
+		{name: "empty", uri: "deel://", wantErr: true},
+		{name: "empty query", uri: "deel://?", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := parseURI(tt.uri)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if creds.apiKey != tt.wantKey {
+				t.Errorf("api key = %q, want %q", creds.apiKey, tt.wantKey)
+			}
+			if creds.environment != tt.wantEnvironment {
+				t.Errorf("environment = %q, want %q", creds.environment, tt.wantEnvironment)
+			}
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	for _, table := range supportedTableNames() {
+		if !isValidTable(table) {
+			t.Errorf("isValidTable(%q) = false, want true", table)
+		}
+	}
+
+	for _, table := range []string{"", "unknown", "People", "CONTRACTS", "contract"} {
+		if isValidTable(table) {
+			t.Errorf("isValidTable(%q) = true, want false", table)
+		}
+	}
+}
+
+func TestReviewedEndpointMetadata(t *testing.T) {
+	if got := directTables["ats_offers"].pageSizeParam; got != "" {
+		t.Errorf("ats_offers page size parameter = %q, want empty", got)
+	}
+	if got := directTables["invoices"].query["status"]; got != "all" {
+		t.Errorf("invoices status = %q, want all", got)
+	}
+	if got := fanoutTables["contract_amendments"].endpoint.pagination; got != paginationCursor {
+		t.Errorf("contract_amendments pagination = %v, want paginationCursor", got)
+	}
+
+	expectedVersions := map[string]string{
+		"ats_interviews": "2026-06-03",
+		"ats_openings":   "2026-06-15",
+		"ats_teams":      "2026-06-24",
+	}
+	for table, want := range expectedVersions {
+		if got := directTables[table].version; got != want {
+			t.Errorf("%s version = %q, want %q", table, got, want)
+		}
+	}
+
+	for _, table := range []string{"ats_candidates", "ats_jobs", "ats_email_templates", "ats_interviews"} {
+		if !directTables[table].clientFilter {
+			t.Errorf("%s must apply the interval end client-side", table)
+		}
+		if !directTables[table].startParamExclusive {
+			t.Errorf("%s must overlap its exclusive updated_after lower bound", table)
+		}
+	}
+
+	for _, table := range []string{"timesheets", "invoice_adjustments", "invoices", "payments", "refund_statements"} {
+		if !directTables[table].clientFilter {
+			t.Errorf("%s must apply exact timestamp bounds client-side", table)
+		}
+	}
+
+	if got := directTables["seniorities"].query["is_eor_contract"]; got != "false" {
+		t.Errorf("seniorities is_eor_contract = %q, want false", got)
+	}
+	wantContractTypes := []string{"peo", "global_payroll", "hris_direct_employee", "eor", "employee", "independent_contractor"}
+	if got := directTables["adjustment_categories"].queryValues["contract_types"]; !slices.Equal(got, wantContractTypes) {
+		t.Errorf("adjustment_categories contract_types = %v, want %v", got, wantContractTypes)
+	}
+	if got := directTables["hourly_report_root_presets"].queryValues; len(got) != 0 {
+		t.Errorf("hourly_report_root_presets query values = %v, want none", got)
+	}
+	for _, table := range []string{"contract_custom_field_values", "contract_payment_cycles", "eor_benefits"} {
+		if !fanoutTables[table].skipNotFound {
+			t.Errorf("%s must treat a missing child collection as empty", table)
+		}
+	}
+	if !fanoutTables["payroll_cycles"].endpoint.clientFilter {
+		t.Error("payroll_cycles must enforce exact bounds across overlapping date queries")
+	}
+}
+
+func TestFlattenReportCell(t *testing.T) {
+	items := []map[string]any{
+		{"contractId": map[string]any{"type": "text", "currentValue": "contract-123"}},
+		{"contractId": "already-flat"},
+		{"contractId": map[string]any{"type": "text"}},
+	}
+
+	flattenReportCell(items, "contractId")
+
+	if got := items[0]["contractId"]; got != "contract-123" {
+		t.Errorf("flattened contractId = %v, want contract-123", got)
+	}
+	if got := items[1]["contractId"]; got != "already-flat" {
+		t.Errorf("flat contractId = %v, want already-flat", got)
+	}
+	if _, ok := items[2]["contractId"].(map[string]any); !ok {
+		t.Errorf("cell without currentValue should remain unchanged")
+	}
+}
+
+func TestSendItemsStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sendItems(ctx, []map[string]any{{"id": "one"}}, endpointMeta{}, source.ReadOptions{}, make(chan source.RecordBatchResult))
+	if err != context.Canceled {
+		t.Fatalf("sendItems returned %v, want context.Canceled", err)
+	}
+}
+
+func TestSendErrorStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sendResult(ctx, make(chan source.RecordBatchResult), source.RecordBatchResult{Err: context.Canceled})
+	if err != context.Canceled {
+		t.Fatalf("sendResult returned %v, want context.Canceled", err)
+	}
+}
+
+func TestDecodeObjectUsesNumber(t *testing.T) {
+	result, err := decodeObject([]byte(`{"data":[{"id":9007199254740993}]}`))
+	if err != nil {
+		t.Fatalf("decodeObject returned an error: %v", err)
+	}
+
+	items, err := extractItems(result, "data", "")
+	if err != nil {
+		t.Fatalf("extractItems returned an error: %v", err)
+	}
+	id, ok := items[0]["id"].(json.Number)
+	if !ok {
+		t.Fatalf("id has type %T, want json.Number", items[0]["id"])
+	}
+	if id.String() != "9007199254740993" {
+		t.Errorf("id = %s, want 9007199254740993", id)
+	}
+}
+
+func TestExtractItems(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           map[string]any
+		path           string
+		primitiveField string
+		want           []map[string]any
+	}{
+		{
+			name: "array", path: "data",
+			body: map[string]any{"data": []any{map[string]any{"id": "one"}, map[string]any{"id": "two"}}},
+			want: []map[string]any{{"id": "one"}, {"id": "two"}},
+		},
+		{
+			name: "singleton", path: "data",
+			body: map[string]any{"data": map[string]any{"id": "one"}},
+			want: []map[string]any{{"id": "one"}},
+		},
+		{
+			name: "nested", path: "data.rows",
+			body: map[string]any{"data": map[string]any{"rows": []any{map[string]any{"id": "one"}}}},
+			want: []map[string]any{{"id": "one"}},
+		},
+		{
+			name: "primitives", path: "data", primitiveField: "name",
+			body: map[string]any{"data": []any{"paid", "unpaid"}},
+			want: []map[string]any{{"name": "paid"}, {"name": "unpaid"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractItems(tt.body, tt.path, tt.primitiveField)
+			if err != nil {
+				t.Fatalf("extractItems returned an error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d items, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				for key, want := range tt.want[i] {
+					if got[i][key] != want {
+						t.Errorf("item %d %s = %v, want %v", i, key, got[i][key], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFilterItemsByInterval(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	items := []map[string]any{
+		{"id": "before", "updated_at": "2025-12-31T23:59:59Z"},
+		{"id": "at-start", "updated_at": "2026-01-01T00:00:00Z"},
+		{"id": "inside", "updated_at": "2026-01-15T12:00:00.123456Z"},
+		{"id": "at-end", "updated_at": "2026-02-01T00:00:00Z"},
+		{"id": "missing"},
+	}
+
+	got := filterItemsByInterval(items, "updated_at", &start, &end)
+	if len(got) != 3 || got[0]["id"] != "at-start" || got[1]["id"] != "inside" || got[2]["id"] != "missing" {
+		t.Fatalf("filterItemsByInterval returned %v", got)
+	}
+	if got := filterItemsByInterval(items, "", &start, &end); len(got) != len(items) {
+		t.Errorf("empty field returned %d items, want %d", len(got), len(items))
+	}
+}
+
+func TestFetchPages(t *testing.T) {
+	tests := []struct {
+		name       string
+		meta       endpointMeta
+		responses  []string
+		wantParams []map[string]string
+	}{
+		{
+			name: "page cursor",
+			meta: endpointMeta{path: "/records", pagination: paginationPageCursor, pageSize: 2, pageSizeParam: "limit", cursorParam: "after_cursor"},
+			responses: []string{
+				`{"data":[{"id":"one"},{"id":"two"}],"page":{"cursor":"next-page"}}`,
+				`{"data":[{"id":"three"}],"page":{"cursor":null}}`,
+			},
+			wantParams: []map[string]string{{"limit": "2"}, {"limit": "2", "after_cursor": "next-page"}},
+		},
+		{
+			name: "offset",
+			meta: endpointMeta{path: "/records", pagination: paginationOffset, pageSize: 2, pageSizeParam: "limit", offsetParam: "offset"},
+			responses: []string{
+				`{"data":[{"id":"one"},{"id":"two"}]}`,
+				`{"data":[{"id":"three"}]}`,
+			},
+			wantParams: []map[string]string{{"limit": "2", "offset": "0"}, {"limit": "2", "offset": "2"}},
+		},
+		{
+			name: "nested cursor",
+			meta: endpointMeta{path: "/records", pagination: paginationDataNextCursor, cursorParam: "cursor", dataPath: "data.rows"},
+			responses: []string{
+				`{"data":{"rows":[{"id":"one"}],"next_cursor":"next-page"}}`,
+				`{"data":{"rows":[{"id":"two"}],"next_cursor":null}}`,
+			},
+			wantParams: []map[string]string{{}, {"cursor": "next-page"}},
+		},
+		{
+			name: "top-level cursor",
+			meta: endpointMeta{path: "/records", pagination: paginationCursor, pageSize: 2, pageSizeParam: "limit", cursorParam: "cursor"},
+			responses: []string{
+				`{"data":[{"id":"one"},{"id":"two"}],"cursor":"next-page"}`,
+				`{"data":[{"id":"three"}],"cursor":null}`,
+			},
+			wantParams: []map[string]string{{"limit": "2"}, {"limit": "2", "cursor": "next-page"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestIndex := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if requestIndex >= len(tt.responses) {
+					t.Errorf("unexpected request %d", requestIndex)
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+					return
+				}
+				for key, want := range tt.wantParams[requestIndex] {
+					if got := r.URL.Query().Get(key); got != want {
+						t.Errorf("request %d query %s = %q, want %q", requestIndex, key, got, want)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.responses[requestIndex]))
+				requestIndex++
+			}))
+			defer server.Close()
+
+			s := NewDeelSource()
+			s.client = httpclient.New(httpclient.WithBaseURL(server.URL))
+			t.Cleanup(func() {
+				if err := s.client.Close(); err != nil {
+					t.Errorf("failed to close HTTP client: %v", err)
+				}
+			})
+
+			var ids []string
+			err := s.fetchPages(context.Background(), tt.meta, source.ReadOptions{}, func(items []map[string]any) error {
+				for _, item := range items {
+					ids = append(ids, stringValue(item["id"]))
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("fetchPages returned an error: %v", err)
+			}
+			if requestIndex != len(tt.responses) {
+				t.Errorf("made %d requests, want %d", requestIndex, len(tt.responses))
+			}
+			if len(ids) != 3 && tt.name != "nested cursor" {
+				t.Errorf("received %d records, want 3", len(ids))
+			}
+			if tt.name == "nested cursor" && len(ids) != 2 {
+				t.Errorf("received %d records, want 2", len(ids))
+			}
+		})
+	}
+}
+
+func TestFetchPagesSendsRepeatedQueryValues(t *testing.T) {
+	wantStatuses := []string{"PENDING", "COMPLETED", "DISMISSED", "FAILED"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query()["statuses"]; !slices.Equal(got, wantStatuses) {
+			t.Errorf("statuses = %v, want %v", got, wantStatuses)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	s := NewDeelSource()
+	s.client = httpclient.New(httpclient.WithBaseURL(server.URL))
+	t.Cleanup(func() {
+		if err := s.client.Close(); err != nil {
+			t.Errorf("failed to close HTTP client: %v", err)
+		}
+	})
+
+	if err := s.fetchPages(context.Background(), directTables["organization_tasks"], source.ReadOptions{}, func(items []map[string]any) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("fetchPages returned an error: %v", err)
+	}
+}
+
+func TestSetIntervalParams(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 123456789, time.UTC)
+	nonMidnightEnd := time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
+	midnightEnd := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	for _, tt := range []struct {
+		name     string
+		meta     endpointMeta
+		end      time.Time
+		wantFrom string
+		wantTo   string
+	}{
+		{
+			name: "date range broadens non-midnight end",
+			meta: endpointMeta{intervalStartParam: "from", intervalEndParam: "to", intervalFormat: intervalDate},
+			end:  nonMidnightEnd, wantFrom: "2026-01-02", wantTo: "2026-01-04",
+		},
+		{
+			name: "date range preserves midnight end",
+			meta: endpointMeta{intervalStartParam: "from", intervalEndParam: "to", intervalFormat: intervalDate},
+			end:  midnightEnd, wantFrom: "2026-01-02", wantTo: "2026-01-03",
+		},
+		{
+			name: "datetime preserves fractional seconds",
+			meta: endpointMeta{intervalStartParam: "from", intervalEndParam: "to", intervalFormat: intervalDateTime},
+			end:  nonMidnightEnd.Add(987654321), wantFrom: "2026-01-02T03:04:05.123456789Z", wantTo: "2026-01-03T12:00:00.987654321Z",
+		},
+		{
+			name: "exclusive start overlaps",
+			meta: endpointMeta{intervalStartParam: "from", intervalEndParam: "to", intervalFormat: intervalDateTime, startParamExclusive: true},
+			end:  nonMidnightEnd, wantFrom: "2026-01-02T03:04:04.123456789Z", wantTo: "2026-01-03T12:00:00Z",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var queryValues map[string]string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				queryValues = map[string]string{
+					"from": r.URL.Query().Get("from"),
+					"to":   r.URL.Query().Get("to"),
+				}
+				_, _ = w.Write([]byte(`{"data":[]}`))
+			}))
+			defer server.Close()
+
+			s := NewDeelSource()
+			s.client = httpclient.New(httpclient.WithBaseURL(server.URL))
+			t.Cleanup(func() {
+				if err := s.client.Close(); err != nil {
+					t.Errorf("failed to close HTTP client: %v", err)
+				}
+			})
+
+			meta := tt.meta
+			meta.path = "/records"
+			err := s.fetchPages(context.Background(), meta, source.ReadOptions{IntervalStart: &start, IntervalEnd: &tt.end}, func(items []map[string]any) error {
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("fetchPages returned an error: %v", err)
+			}
+			if queryValues["from"] != tt.wantFrom || queryValues["to"] != tt.wantTo {
+				t.Errorf("query values = %v, want from=%q to=%q", queryValues, tt.wantFrom, tt.wantTo)
+			}
+		})
+	}
+}
+
+func TestOffboardingPagination(t *testing.T) {
+	payload := `{"limit":2,"pagination":{"progressStatusWeight":1,"referenceDate":"2026-01-01T00:00:00Z","contractId":"contract-123"},"sortOrder":"ASC"}`
+	cursor := base64.RawURLEncoding.EncodeToString([]byte(payload))
+
+	params, err := decodeOffboardingCursor(cursor)
+	if err != nil {
+		t.Fatalf("decodeOffboardingCursor returned an error: %v", err)
+	}
+	if params["contractId"] != "contract-123" || params["progressStatusWeight"] != "1" {
+		t.Fatalf("decoded parameters = %v", params)
+	}
+
+	requestIndex := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestIndex == 1 {
+			if got := r.URL.Query().Get("pagination[contractId]"); got != "contract-123" {
+				t.Errorf("pagination[contractId] = %q, want contract-123", got)
+			}
+			if got := r.URL.Query().Get("pagination[progressStatusWeight]"); got != "1" {
+				t.Errorf("pagination[progressStatusWeight] = %q, want 1", got)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if requestIndex == 0 {
+			_, _ = w.Write([]byte(`{"data":[{"id":"one"}],"page":{"cursor":"` + cursor + `"}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"data":[{"id":"two"}],"page":{"cursor":null}}`))
+		}
+		requestIndex++
+	}))
+	defer server.Close()
+
+	s := NewDeelSource()
+	s.client = httpclient.New(httpclient.WithBaseURL(server.URL))
+	t.Cleanup(func() {
+		if err := s.client.Close(); err != nil {
+			t.Errorf("failed to close HTTP client: %v", err)
+		}
+	})
+
+	meta := endpointMeta{path: "/offboarding", pagination: paginationOffboarding, pageSize: 2, pageSizeParam: "limit"}
+	var count int
+	err = s.fetchPages(context.Background(), meta, source.ReadOptions{}, func(items []map[string]any) error {
+		count += len(items)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("fetchPages returned an error: %v", err)
+	}
+	if requestIndex != 2 || count != 2 {
+		t.Errorf("made %d requests and received %d rows, want 2 and 2", requestIndex, count)
+	}
+}
+
+func TestPayrollIntervals(t *testing.T) {
+	start := time.Date(2023, 3, 1, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	intervals := payrollIntervals(source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+
+	if len(intervals) != 7 {
+		t.Fatalf("payrollIntervals returned %d intervals, want 7", len(intervals))
+	}
+	for i, interval := range intervals {
+		requestOpts := payrollRequestOptions(interval)
+		if requestOpts.IntervalEnd.After(interval.IntervalStart.AddDate(1, 0, 0)) {
+			t.Errorf("request interval %d is longer than one year: %s to %s", i, interval.IntervalStart, requestOpts.IntervalEnd)
+		}
+		if i > 0 {
+			wantStart := *intervals[i-1].IntervalEnd
+			if !interval.IntervalStart.Equal(wantStart) {
+				t.Errorf("interval %d starts at %s, want %s", i, interval.IntervalStart, wantStart)
+			}
+		}
+	}
+	if !intervals[0].IntervalStart.Equal(start) || !intervals[len(intervals)-1].IntervalEnd.Equal(end) {
+		t.Errorf("intervals do not cover the requested bounds")
+	}
+}
+
+func TestStringValue(t *testing.T) {
+	for _, tt := range []struct {
+		input any
+		want  string
+	}{
+		{input: "abc", want: "abc"},
+		{input: json.Number("9007199254740993"), want: "9007199254740993"},
+		{input: float64(42), want: "42"},
+		{input: nil, want: ""},
+	} {
+		if got := stringValue(tt.input); got != tt.want {
+			t.Errorf("stringValue(%v) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func BenchmarkExtractItems(b *testing.B) {
+	data := make([]any, 100)
+	for i := range data {
+		data[i] = map[string]any{"id": strconv.Itoa(i)}
+	}
+	body := map[string]any{"data": data}
+	b.ResetTimer()
+	for range b.N {
+		_, _ = extractItems(body, "data", "")
+	}
+}

--- a/pkg/source/deel/register.go
+++ b/pkg/source/deel/register.go
@@ -1,0 +1,10 @@
+package deel
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"deel"},
+		func() interface{} { return NewDeelSource() },
+	)
+}


### PR DESCRIPTION
## What

Adds Deel as a source with broad REST API coverage, incremental filtering, pagination, rate limiting, and sandbox support.

## Changes

- Adds 83 Deel tables, live-verified fan-outs, payroll boundary handling, tests, catalog registration, and documentation.

## How to test

1. Run `make format && make lint && make test`.
2. Ingest Deel sandbox tables into DuckDB with a valid token.

## Risk & rollback

- **Risk:** Medium; API behavior varies by enabled Deel products and token scopes.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

None.