### PR TITLE
Add BambooHR source

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>BambooHR</td>
+        <td>✅</td>
+        <td>-</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Braze</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -198,6 +198,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Attio", link: "/supported-sources/attio.md" },
               { text: "Azure Data Lake Storage Gen2", link: "/supported-sources/adls.md" },
               { text: "BallDontLie FIFA", link: "/supported-sources/balldontlie.md" },
+              { text: "BambooHR", link: "/supported-sources/bamboohr.md" },
               { text: "Braze", link: "/supported-sources/braze.md" },
               { text: "Bruin", link: "/supported-sources/bruin.md" },
               { text: "Chargebee", link: "/supported-sources/chargebee.md" },

--- a/docs/supported-sources/bamboohr.md
+++ b/docs/supported-sources/bamboohr.md
@@ -1,0 +1,83 @@
+# BambooHR
+
+[BambooHR](https://www.bamboohr.com/) is an HR platform for employee records, time off,
+time tracking, and related workforce data.
+
+ingestr supports BambooHR as a source.
+
+## URI format
+
+```text
+bamboohr://<company-domain>?api_key=<api-key>
+bamboohr://<company-domain>?access_token=<oauth-access-token>
+```
+
+- `company-domain` is the part before `.bamboohr.com` in the company URL. For
+  `https://acme.bamboohr.com`, use `acme`.
+- `api_key` is a BambooHR API key. BambooHR applies the permissions of the user who
+  created the key, so the source only returns fields and employees that user can access.
+- `access_token` is an OAuth bearer token. Use either `api_key` or `access_token`, not both.
+- `timezone` is the company's IANA timezone, such as `America/Denver`. It is required for
+  `timesheet_entries`, whose date boundaries BambooHR interprets in the company timezone.
+
+To create a key, sign in to BambooHR, open the user menu in the lower-left corner, choose
+**API Keys**, and create a new key. See BambooHR's
+[API getting-started guide](https://documentation.bamboohr.com/docs/getting-started) for details.
+The same guide documents the OAuth authorization flow for hosted or third-party integrations.
+
+API-key authentication is intended for a customer's own, internally operated integration. Do
+not share an API key with a hosted third-party service; use OAuth for that scenario, as required
+by BambooHR's [Developer Terms](https://www.bamboohr.com/legal/developer-terms-of-service).
+
+## Example
+
+```sh
+ingestr ingest \
+  --source-uri 'bamboohr://acme?api_key=secret' \
+  --source-table 'employees?fields=workEmail,hireDate,departmentName,locationName' \
+  --dest-uri duckdb:///bamboohr.duckdb \
+  --dest-table 'main.employees'
+```
+
+The `employees` table always includes BambooHR's default employee fields. Add a
+comma-separated `fields` table parameter to request other standard or custom field aliases
+that the API-key owner can read. Discover account-specific aliases with the
+`employee_fields` table.
+
+## Tables
+
+| Table | Primary key | Incremental key | Strategy | Details |
+| --- | --- | --- | --- | --- |
+| `employees` | `employeeId` | - | replace | Complete employee roster, including active and inactive employees, with optional extra fields |
+| `employee_directory` | `id` | - | replace | Published company directory, including future-dated hires where the account exposes them |
+| `employee_fields` | `id` | - | replace | Standard and custom employee-field metadata |
+| `users` | `id` | - | replace | Enabled and disabled BambooHR user accounts |
+| `locations` | `id` | - | replace | Active and archived job locations, including expanded state and country data; requires an OAuth token with the `field` scope |
+| `time_off_requests` | `id` | `start` | merge | Time-off requests that overlap the requested date interval |
+| `time_off_types` | `id` | - | replace | Available time-off categories |
+| `time_off_default_hours` | `name` | - | replace | Default work hours by weekday |
+| `time_off_policies` | `id` | - | replace | Non-deleted time-off policies |
+| `timesheet_entries` | `id` | `date` | merge | Clock and hour entries from BambooHR Time Tracking |
+
+`time_off_requests` uses `--interval-start` and `--interval-end` as an inclusive overlap
+window. Without an interval it requests the full supported date range.
+
+BambooHR only exposes the latest 365 days through its timesheet endpoint. Therefore,
+`timesheet_entries` defaults to that entire available window and rejects dates outside it. Add
+the company timezone to the URI, for example:
+
+```sh
+--source-uri 'bamboohr://acme?api_key=secret&timezone=America%2FDenver'
+```
+
+## Test accounts and demo data
+
+BambooHR's [developer guide](https://documentation.bamboohr.com/docs/getting-started) recommends
+developing against a test BambooHR account. The public trial is not a dependable self-service
+API sandbox, so live connector validation requires an account controlled by the tester and
+populated with non-production data in accordance with BambooHR's
+[Developer Terms](https://www.bamboohr.com/legal/developer-terms-of-service).
+
+For connector development without an account, ingestr's BambooHR tests run against a local fake
+HTTP server with synthetic employees, locations, time-off records, and timesheet entries; no
+customer data or credentials are stored in the repository.

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -65,6 +65,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 
 - [Airtable](/supported-sources/airtable.md)
 - [Asana](/supported-sources/asana.md)
+- [BambooHR](/supported-sources/bamboohr.md)
 - [ClickUp](/supported-sources/clickup.md)
 - [Docebo](/supported-sources/docebo.md)
 - [Fireflies](/supported-sources/fireflies.md)

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -296,6 +296,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("attio", "Attio", []string{"attio"}, true, false),
 		genericURIConnector("avro", "Avro File", []string{"avro"}, true, false),
 		genericURIConnector("balldontlie", "balldontlie", []string{"balldontlie"}, true, false),
+		genericURIConnector("bamboohr", "BambooHR", []string{"bamboohr"}, true, false),
 		genericURIConnector("blobstore", "Object Storage", []string{"s3", "gs", "gcs", "az", "azure", "adls", "adlsgen2", "azdatalake", "abfs", "abfss"}, true, true),
 		genericURIConnector("braze", "Braze", []string{"braze"}, true, false),
 		genericURIConnector("bruin", "Bruin", []string{"bruin"}, true, false),

--- a/pkg/source/bamboohr/bamboohr.go
+++ b/pkg/source/bamboohr/bamboohr.go
@@ -1,0 +1,640 @@
+package bamboohr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
+)
+
+const (
+	employeePageSize = 2500
+	locationPageSize = 500
+	maxPages         = 10000
+	requestTimeout   = 60 * time.Second
+
+	// BambooHR publishes no numeric quota and may throttle frequent requests with
+	// 503 + Retry-After. One request per second is a conservative client-side cap.
+	rateLimit      = 1.0
+	rateLimitBurst = 2
+)
+
+var (
+	companyDomainPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$`)
+	supportedTables      = []string{
+		"employees",
+		"employee_directory",
+		"employee_fields",
+		"users",
+		"locations",
+		"time_off_requests",
+		"time_off_types",
+		"time_off_default_hours",
+		"time_off_policies",
+		"timesheet_entries",
+	}
+)
+
+type tableMeta struct {
+	primaryKeys    []string
+	incrementalKey string
+	strategy       config.IncrementalStrategy
+}
+
+var tableMetadata = map[string]tableMeta{
+	"employees":              {primaryKeys: []string{"employeeId"}, strategy: config.StrategyReplace},
+	"employee_directory":     {primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	"employee_fields":        {primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	"users":                  {primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	"locations":              {primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	"time_off_requests":      {primaryKeys: []string{"id"}, incrementalKey: "start", strategy: config.StrategyMerge},
+	"time_off_types":         {primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	"time_off_default_hours": {primaryKeys: []string{"name"}, strategy: config.StrategyReplace},
+	"time_off_policies":      {primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	"timesheet_entries":      {primaryKeys: []string{"id"}, incrementalKey: "date", strategy: config.StrategyMerge},
+}
+
+type BambooHRSource struct {
+	client          *httpclient.Client
+	companyTimezone *time.Location
+	usesOAuth       bool
+	now             func() time.Time
+}
+
+type bambooHRCredentials struct {
+	companyDomain string
+	apiKey        string
+	accessToken   string
+	timezone      *time.Location
+}
+
+type tableParams struct {
+	Fields []string `mapstructure:"fields"`
+}
+
+func NewBambooHRSource() *BambooHRSource {
+	return &BambooHRSource{now: time.Now}
+}
+
+func (s *BambooHRSource) Schemes() []string {
+	return []string{"bamboohr"}
+}
+
+func (s *BambooHRSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *BambooHRSource) Connect(ctx context.Context, uri string) error {
+	creds, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	var auth httpclient.Authenticator
+	if creds.apiKey != "" {
+		auth = httpclient.NewBasicAuth(creds.apiKey, "x")
+	} else {
+		auth = httpclient.NewBearerAuth(creds.accessToken)
+	}
+	s.client = newHTTPClient(fmt.Sprintf("https://%s.bamboohr.com", creds.companyDomain), auth)
+	s.companyTimezone = creds.timezone
+	s.usesOAuth = creds.accessToken != ""
+
+	config.Debug("[BAMBOOHR] Connected to company domain: %s", creds.companyDomain)
+	return nil
+}
+
+func newHTTPClient(baseURL string, auth httpclient.Authenticator, extraOptions ...httpclient.Option) *httpclient.Client {
+	options := []httpclient.Option{
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(requestTimeout),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithAuth(auth),
+		httpclient.WithHeader("Accept", "application/json"),
+		httpclient.WithDebug(config.DebugMode),
+	}
+	options = append(options, extraOptions...)
+	return httpclient.New(options...)
+}
+
+func (s *BambooHRSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseURI(rawURI string) (bambooHRCredentials, error) {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return bambooHRCredentials{}, fmt.Errorf("invalid bamboohr URI: %w", err)
+	}
+	if parsed.Scheme != "bamboohr" {
+		return bambooHRCredentials{}, fmt.Errorf("invalid bamboohr URI: must start with bamboohr://")
+	}
+
+	companyDomain := strings.TrimSpace(parsed.Host)
+	companyDomain = strings.TrimSuffix(companyDomain, ".bamboohr.com")
+	if companyDomain == "" {
+		return bambooHRCredentials{}, fmt.Errorf("company domain is required in bamboohr URI: bamboohr://<company-domain>?api_key=<api-key>")
+	}
+	if !companyDomainPattern.MatchString(companyDomain) {
+		return bambooHRCredentials{}, fmt.Errorf("invalid BambooHR company domain %q", companyDomain)
+	}
+
+	query := parsed.Query()
+	for key := range query {
+		if key != "api_key" && key != "access_token" && key != "timezone" {
+			return bambooHRCredentials{}, fmt.Errorf("unknown bamboohr URI parameter %q (supported: api_key, access_token, timezone)", key)
+		}
+	}
+	apiKey := query.Get("api_key")
+	accessToken := query.Get("access_token")
+	if apiKey == "" && accessToken == "" {
+		return bambooHRCredentials{}, fmt.Errorf("one of api_key or access_token is required in bamboohr URI")
+	}
+	if apiKey != "" && accessToken != "" {
+		return bambooHRCredentials{}, fmt.Errorf("api_key and access_token are mutually exclusive in bamboohr URI")
+	}
+
+	var timezone *time.Location
+	if timezoneName := query.Get("timezone"); timezoneName != "" {
+		timezone, err = time.LoadLocation(timezoneName)
+		if err != nil {
+			return bambooHRCredentials{}, fmt.Errorf("invalid BambooHR company timezone %q: %w", timezoneName, err)
+		}
+	}
+
+	return bambooHRCredentials{
+		companyDomain: strings.ToLower(companyDomain),
+		apiKey:        apiKey,
+		accessToken:   accessToken,
+		timezone:      timezone,
+	}, nil
+}
+
+func parseTableSpec(raw string) (string, tableParams, error) {
+	var params tableParams
+	name, hasParams, err := tablespec.Parse(raw, &params, tablespec.WithListSeparator(","))
+	if err != nil {
+		return "", tableParams{}, fmt.Errorf("invalid BambooHR table: %w", err)
+	}
+	if hasParams && name != "employees" {
+		return "", tableParams{}, fmt.Errorf("table parameters are only supported for employees")
+	}
+	return name, params, nil
+}
+
+func isValidTable(table string) bool {
+	_, ok := tableMetadata[table]
+	return ok
+}
+
+func (s *BambooHRSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tableName, params, err := parseTableSpec(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	meta, ok := tableMetadata[tableName]
+	if !ok {
+		return nil, fmt.Errorf("unsupported table: %s (supported: %s)", tableName, strings.Join(supportedTables, ", "))
+	}
+	if tableName == "locations" && !s.usesOAuth {
+		return nil, fmt.Errorf("locations requires access_token authentication with the BambooHR field scope")
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    meta.primaryKeys,
+		TableIncrementalKey: meta.incrementalKey,
+		TableStrategy:       meta.strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("bamboohr source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, params, opts)
+		},
+	}, nil
+}
+
+func (s *BambooHRSource) read(ctx context.Context, table string, params tableParams, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch table {
+		case "employees":
+			err = s.readEmployees(ctx, params.Fields, opts, results)
+		case "employee_directory":
+			err = s.readEmployeeDirectory(ctx, opts, results)
+		case "employee_fields":
+			err = s.readEmployeeFields(ctx, opts, results)
+		case "users":
+			err = s.readUsers(ctx, opts, results)
+		case "locations":
+			err = s.readLocations(ctx, opts, results)
+		case "time_off_requests":
+			err = s.readTimeOffRequests(ctx, opts, results)
+		case "time_off_types":
+			err = s.readTimeOffTypes(ctx, opts, results)
+		case "time_off_default_hours":
+			err = s.readTimeOffDefaultHours(ctx, opts, results)
+		case "time_off_policies":
+			err = s.readTimeOffPolicies(ctx, opts, results)
+		case "timesheet_entries":
+			err = s.readTimesheetEntries(ctx, opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", table)
+		}
+
+		if err != nil {
+			select {
+			case results <- source.RecordBatchResult{Err: err}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *BambooHRSource) readEmployees(ctx context.Context, fields []string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading employees")
+	cursor := ""
+	seenCursors := make(map[string]struct{})
+
+	for page := 1; page <= maxPages; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req := s.client.R(ctx).SetQueryParam("page[limit]", strconv.Itoa(employeePageSize))
+		if cursor != "" {
+			req.SetQueryParam("page[after]", cursor)
+		}
+		if len(fields) > 0 {
+			req.SetQueryParam("fields", strings.Join(fields, ","))
+		}
+
+		resp, err := req.Get("/api/v1/employees")
+		if err != nil {
+			return fmt.Errorf("failed to fetch employees: %w", err)
+		}
+		if err := responseError(resp, "employees"); err != nil {
+			return err
+		}
+
+		var payload struct {
+			Data []map[string]interface{} `json:"data"`
+			Meta struct {
+				Page struct {
+					NextCursor *string `json:"nextCursor"`
+				} `json:"page"`
+			} `json:"meta"`
+		}
+		if err := jsonUseNumber(resp.Body(), &payload); err != nil {
+			return fmt.Errorf("failed to parse employees response: %w", err)
+		}
+		if err := sendItems(ctx, "employees", payload.Data, opts, results); err != nil {
+			return err
+		}
+
+		if payload.Meta.Page.NextCursor == nil || *payload.Meta.Page.NextCursor == "" {
+			return nil
+		}
+		next := *payload.Meta.Page.NextCursor
+		if _, exists := seenCursors[next]; exists {
+			return fmt.Errorf("employees pagination returned repeated cursor %q", next)
+		}
+		seenCursors[next] = struct{}{}
+		cursor = next
+	}
+
+	config.Debug("[BAMBOOHR] employees pagination stopped at maxPages=%d", maxPages)
+	return fmt.Errorf("employees pagination exceeded maximum of %d pages", maxPages)
+}
+
+func (s *BambooHRSource) readEmployeeDirectory(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading employee_directory")
+	resp, err := s.client.R(ctx).
+		SetQueryParam("onlyCurrent", "false").
+		Get("/api/v1/employees/directory")
+	if err != nil {
+		return fmt.Errorf("failed to fetch employee_directory: %w", err)
+	}
+	if resp.StatusCode() == 404 {
+		return nil
+	}
+	if err := responseError(resp, "employee_directory"); err != nil {
+		return err
+	}
+
+	var payload struct {
+		Employees []map[string]interface{} `json:"employees"`
+	}
+	if err := jsonUseNumber(resp.Body(), &payload); err != nil {
+		return fmt.Errorf("failed to parse employee_directory response: %w", err)
+	}
+	return sendItems(ctx, "employee_directory", payload.Employees, opts, results)
+}
+
+func (s *BambooHRSource) readEmployeeFields(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading employee_fields")
+	items, err := s.getArray(ctx, "/api/v1/meta/fields", "employee_fields", nil)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if id, ok := item["id"]; ok {
+			item["id"] = fmt.Sprint(id)
+		}
+	}
+	return sendItems(ctx, "employee_fields", items, opts, results)
+}
+
+func (s *BambooHRSource) readUsers(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading users")
+	resp, err := s.client.R(ctx).Get("/api/v1/meta/users")
+	if err != nil {
+		return fmt.Errorf("failed to fetch users: %w", err)
+	}
+	if err := responseError(resp, "users"); err != nil {
+		return err
+	}
+
+	var keyedUsers map[string]map[string]interface{}
+	if err := jsonUseNumber(resp.Body(), &keyedUsers); err != nil {
+		return fmt.Errorf("failed to parse users response: %w", err)
+	}
+	keys := make([]string, 0, len(keyedUsers))
+	for key := range keyedUsers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	items := make([]map[string]interface{}, 0, len(keys))
+	for _, key := range keys {
+		item := keyedUsers[key]
+		item["id"] = key
+		items = append(items, item)
+	}
+	return sendItems(ctx, "users", items, opts, results)
+}
+
+func (s *BambooHRSource) readLocations(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading locations")
+	for _, archived := range []bool{false, true} {
+		if err := s.readLocationState(ctx, archived, opts, results); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BambooHRSource) readLocationState(ctx context.Context, archived bool, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	for page := 0; page < maxPages; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		resp, err := s.client.R(ctx).
+			SetQueryParam("page", strconv.Itoa(page)).
+			SetQueryParam("pageSize", strconv.Itoa(locationPageSize)).
+			SetQueryParam("filter", fmt.Sprintf("archived eq %t", archived)).
+			SetQueryParam("expand", "state,country").
+			Get("/api/v1/hris/org/locations")
+		if err != nil {
+			return fmt.Errorf("failed to fetch locations: %w", err)
+		}
+		if err := responseError(resp, "locations"); err != nil {
+			return err
+		}
+
+		var payload struct {
+			Data []map[string]interface{} `json:"data"`
+			Meta struct {
+				TotalPages int `json:"totalPages"`
+			} `json:"meta"`
+		}
+		if err := jsonUseNumber(resp.Body(), &payload); err != nil {
+			return fmt.Errorf("failed to parse locations response: %w", err)
+		}
+		if err := sendItems(ctx, "locations", payload.Data, opts, results); err != nil {
+			return err
+		}
+		if payload.Meta.TotalPages == 0 || page+1 >= payload.Meta.TotalPages {
+			return nil
+		}
+	}
+
+	config.Debug("[BAMBOOHR] locations pagination stopped at maxPages=%d for archived=%t", maxPages, archived)
+	return fmt.Errorf("locations pagination exceeded maximum of %d pages for archived=%t", maxPages, archived)
+}
+
+func (s *BambooHRSource) readTimeOffRequests(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading time_off_requests")
+	start, end, err := timeOffWindow(opts)
+	if err != nil {
+		return err
+	}
+	items, err := s.getArray(ctx, "/api/v1/time_off/requests", "time_off_requests", map[string]string{
+		"start": start,
+		"end":   end,
+	})
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, "time_off_requests", items, opts, results)
+}
+
+type timeOffTypesResponse struct {
+	TimeOffTypes []map[string]interface{} `json:"timeOffTypes"`
+	DefaultHours []map[string]interface{} `json:"defaultHours"`
+}
+
+func (s *BambooHRSource) getTimeOffTypes(ctx context.Context) (timeOffTypesResponse, error) {
+	resp, err := s.client.R(ctx).Get("/api/v1/meta/time_off/types")
+	if err != nil {
+		return timeOffTypesResponse{}, fmt.Errorf("failed to fetch time_off_types: %w", err)
+	}
+	if err := responseError(resp, "time_off_types"); err != nil {
+		return timeOffTypesResponse{}, err
+	}
+
+	var payload timeOffTypesResponse
+	if err := jsonUseNumber(resp.Body(), &payload); err != nil {
+		return timeOffTypesResponse{}, fmt.Errorf("failed to parse time_off_types response: %w", err)
+	}
+	return payload, nil
+}
+
+func (s *BambooHRSource) readTimeOffTypes(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading time_off_types")
+	payload, err := s.getTimeOffTypes(ctx)
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, "time_off_types", payload.TimeOffTypes, opts, results)
+}
+
+func (s *BambooHRSource) readTimeOffDefaultHours(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading time_off_default_hours")
+	payload, err := s.getTimeOffTypes(ctx)
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, "time_off_default_hours", payload.DefaultHours, opts, results)
+}
+
+func (s *BambooHRSource) readTimeOffPolicies(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading time_off_policies")
+	items, err := s.getArray(ctx, "/api/v1/meta/time_off/policies", "time_off_policies", nil)
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, "time_off_policies", items, opts, results)
+}
+
+func (s *BambooHRSource) readTimesheetEntries(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[BAMBOOHR] reading timesheet_entries")
+	if s.companyTimezone == nil {
+		return fmt.Errorf("timezone is required in the BambooHR URI when reading timesheet_entries")
+	}
+	start, end, err := timesheetWindow(opts, s.now(), s.companyTimezone)
+	if err != nil {
+		return err
+	}
+	items, err := s.getArray(ctx, "/api/v1/time_tracking/timesheet_entries", "timesheet_entries", map[string]string{
+		"start": start,
+		"end":   end,
+	})
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, "timesheet_entries", items, opts, results)
+}
+
+func (s *BambooHRSource) getArray(ctx context.Context, endpoint, label string, params map[string]string) ([]map[string]interface{}, error) {
+	req := s.client.R(ctx)
+	if params != nil {
+		req.SetQueryParams(params)
+	}
+	resp, err := req.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", label, err)
+	}
+	if err := responseError(resp, label); err != nil {
+		return nil, err
+	}
+
+	var items []map[string]interface{}
+	if err := jsonUseNumber(resp.Body(), &items); err != nil {
+		return nil, fmt.Errorf("failed to parse %s response: %w", label, err)
+	}
+	return items, nil
+}
+
+func responseError(resp *httpclient.Response, label string) error {
+	if resp.IsSuccess() {
+		return nil
+	}
+	body := strings.TrimSpace(resp.String())
+	message := strings.TrimSpace(resp.Header().Get("X-BambooHR-Error-Message"))
+	if message != "" && body != "" {
+		return fmt.Errorf("BambooHR %s endpoint returned status %d: %s (%s)", label, resp.StatusCode(), message, body)
+	}
+	if message != "" {
+		return fmt.Errorf("BambooHR %s endpoint returned status %d: %s", label, resp.StatusCode(), message)
+	}
+	return fmt.Errorf("BambooHR %s endpoint returned status %d: %s", label, resp.StatusCode(), body)
+}
+
+func sendItems(ctx context.Context, label string, items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert %s to Arrow: %w", label, err)
+	}
+	select {
+	case results <- source.RecordBatchResult{Batch: record}:
+		return nil
+	case <-ctx.Done():
+		record.Release()
+		return ctx.Err()
+	}
+}
+
+func jsonUseNumber(data []byte, target interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	return decoder.Decode(target)
+}
+
+func timeOffWindow(opts source.ReadOptions) (string, string, error) {
+	start := time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(9999, time.December, 31, 0, 0, 0, 0, time.UTC)
+	if opts.IntervalStart != nil {
+		start = calendarDate(*opts.IntervalStart)
+	}
+	if opts.IntervalEnd != nil {
+		end = calendarDate(*opts.IntervalEnd)
+	}
+	if start.After(end) {
+		return "", "", fmt.Errorf("invalid time_off_requests interval: start date must not be after end date")
+	}
+	return start.Format(time.DateOnly), end.Format(time.DateOnly), nil
+}
+
+func timesheetWindow(opts source.ReadOptions, now time.Time, companyTimezone *time.Location) (string, string, error) {
+	today := calendarDate(now.In(companyTimezone))
+	end := today
+	if opts.IntervalEnd != nil {
+		end = calendarDate(*opts.IntervalEnd)
+	}
+	start := end.AddDate(0, 0, -364)
+	if opts.IntervalStart != nil {
+		start = calendarDate(*opts.IntervalStart)
+	}
+
+	if start.After(end) {
+		return "", "", fmt.Errorf("invalid timesheet_entries interval: start date must not be after end date")
+	}
+	if end.After(today) {
+		return "", "", fmt.Errorf("invalid timesheet_entries interval: end date cannot be in the future")
+	}
+	oldestAllowed := today.AddDate(0, 0, -364)
+	if start.Before(oldestAllowed) {
+		return "", "", fmt.Errorf("invalid timesheet_entries interval: BambooHR only exposes the last 365 days")
+	}
+	if end.Sub(start) > 364*24*time.Hour {
+		return "", "", fmt.Errorf("invalid timesheet_entries interval: date range cannot exceed 365 days")
+	}
+
+	return start.Format(time.DateOnly), end.Format(time.DateOnly), nil
+}
+
+func calendarDate(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/pkg/source/bamboohr/bamboohr.go
+++ b/pkg/source/bamboohr/bamboohr.go
@@ -611,11 +611,11 @@ func timesheetWindow(opts source.ReadOptions, now time.Time, companyTimezone *ti
 	today := calendarDate(now.In(companyTimezone))
 	end := today
 	if opts.IntervalEnd != nil {
-		end = calendarDate(*opts.IntervalEnd)
+		end = calendarDate(opts.IntervalEnd.In(companyTimezone))
 	}
 	start := end.AddDate(0, 0, -364)
 	if opts.IntervalStart != nil {
-		start = calendarDate(*opts.IntervalStart)
+		start = calendarDate(opts.IntervalStart.In(companyTimezone))
 	}
 
 	if start.After(end) {

--- a/pkg/source/bamboohr/bamboohr_test.go
+++ b/pkg/source/bamboohr/bamboohr_test.go
@@ -1,0 +1,448 @@
+package bamboohr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantDomain string
+		wantKey    string
+		wantToken  string
+		wantZone   string
+		wantError  string
+	}{
+		{
+			name:       "company subdomain",
+			uri:        "bamboohr://acme?api_key=secret",
+			wantDomain: "acme",
+			wantKey:    "secret",
+		},
+		{
+			name:       "full company host",
+			uri:        "bamboohr://Example-Org.bamboohr.com?api_key=key%2Fwith%2Fslashes",
+			wantDomain: "example-org",
+			wantKey:    "key/with/slashes",
+		},
+		{
+			name:       "oauth token and company timezone",
+			uri:        "bamboohr://acme?access_token=oauth-token&timezone=America%2FDenver",
+			wantDomain: "acme",
+			wantToken:  "oauth-token",
+			wantZone:   "America/Denver",
+		},
+		{name: "wrong scheme", uri: "https://acme.bamboohr.com", wantError: "must start with bamboohr://"},
+		{name: "missing company domain", uri: "bamboohr://?api_key=secret", wantError: "company domain is required"},
+		{name: "invalid company domain", uri: "bamboohr://bad_domain?api_key=secret", wantError: "invalid BambooHR company domain"},
+		{name: "missing credentials", uri: "bamboohr://acme", wantError: "api_key or access_token"},
+		{name: "multiple credential types", uri: "bamboohr://acme?api_key=secret&access_token=token", wantError: "mutually exclusive"},
+		{name: "invalid timezone", uri: "bamboohr://acme?api_key=secret&timezone=Mars%2FOlympus", wantError: "invalid BambooHR company timezone"},
+		{name: "unknown parameter", uri: "bamboohr://acme?api_key=secret&region=us", wantError: "unknown bamboohr URI parameter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := parseURI(tt.uri)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDomain, creds.companyDomain)
+			assert.Equal(t, tt.wantKey, creds.apiKey)
+			assert.Equal(t, tt.wantToken, creds.accessToken)
+			if tt.wantZone == "" {
+				assert.Nil(t, creds.timezone)
+			} else {
+				require.NotNil(t, creds.timezone)
+				assert.Equal(t, tt.wantZone, creds.timezone.String())
+			}
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	for _, table := range supportedTables {
+		assert.Truef(t, isValidTable(table), "expected %s to be valid", table)
+	}
+	assert.False(t, isValidTable(""))
+	assert.False(t, isValidTable("Employees"))
+	assert.False(t, isValidTable("goals"))
+}
+
+func TestGetTableMetadataAndParameters(t *testing.T) {
+	src := NewBambooHRSource()
+
+	employees, err := src.GetTable(context.Background(), source.TableRequest{
+		Name: "employees?fields=workEmail,hireDate&fields=departmentName",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "employees", employees.Name())
+	assert.Equal(t, []string{"employeeId"}, employees.PrimaryKeys())
+	assert.Empty(t, employees.IncrementalKey())
+	assert.Equal(t, config.StrategyReplace, employees.Strategy())
+	assert.False(t, employees.HasKnownSchema())
+
+	timeOff, err := src.GetTable(context.Background(), source.TableRequest{Name: "time_off_requests"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, timeOff.PrimaryKeys())
+	assert.Equal(t, "start", timeOff.IncrementalKey())
+	assert.Equal(t, config.StrategyMerge, timeOff.Strategy())
+
+	timesheets, err := src.GetTable(context.Background(), source.TableRequest{Name: "timesheet_entries"})
+	require.NoError(t, err)
+	assert.Equal(t, "date", timesheets.IncrementalKey())
+	assert.Equal(t, config.StrategyMerge, timesheets.Strategy())
+
+	_, err = src.GetTable(context.Background(), source.TableRequest{Name: "users?fields=email"})
+	require.ErrorContains(t, err, "only supported for employees")
+	_, err = src.GetTable(context.Background(), source.TableRequest{Name: "employees?field=workEmail"})
+	require.ErrorContains(t, err, "unknown table parameter")
+	_, err = src.GetTable(context.Background(), source.TableRequest{Name: "goals"})
+	require.ErrorContains(t, err, "unsupported table")
+}
+
+func TestEmployeesUsesBasicAuthFieldsAndCursorPagination(t *testing.T) {
+	var mu sync.Mutex
+	var cursors []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "test-key", username)
+		assert.Equal(t, "x", password)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "/api/v1/employees", r.URL.Path)
+		assert.Equal(t, "2500", r.URL.Query().Get("page[limit]"))
+		assert.Equal(t, "workEmail,hireDate,departmentName", r.URL.Query().Get("fields"))
+
+		cursor := r.URL.Query().Get("page[after]")
+		mu.Lock()
+		cursors = append(cursors, cursor)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if cursor == "" {
+			_, _ = fmt.Fprint(w, `{"data":[{"employeeId":"101","firstName":"Ada","lastName":"Lovelace","teams":[{"id":7,"name":"Platform"}]}],"meta":{"total":2,"page":{"limit":2500,"nextCursor":"next-page","prevCursor":null}},"_links":{}}`)
+			return
+		}
+		require.Equal(t, "next-page", cursor)
+		_, _ = fmt.Fprint(w, `{"data":[{"employeeId":"102","firstName":"Grace","lastName":"Hopper"}],"meta":{"total":2,"page":{"limit":2500,"nextCursor":null,"prevCursor":"previous"}},"_links":{}}`)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{
+		Name: "employees?fields=workEmail,hireDate,departmentName",
+	})
+	require.NoError(t, err)
+
+	rows, batches := drainTable(t, table, source.ReadOptions{})
+	assert.EqualValues(t, 2, rows)
+	assert.Equal(t, 2, batches)
+	assert.Equal(t, []string{"", "next-page"}, cursors)
+}
+
+func TestOAuthBearerAuthentication(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer oauth-token", r.Header.Get("Authorization"))
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	client := newHTTPClient(
+		server.URL,
+		httpclient.NewBearerAuth("oauth-token"),
+		httpclient.WithRateLimiter(1000, 1000),
+		httpclient.WithDisableRetry(),
+	)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	src := &BambooHRSource{client: client, now: time.Now}
+
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "employee_fields"})
+	require.NoError(t, err)
+	rows, batches := drainTable(t, table, source.ReadOptions{})
+	assert.Zero(t, rows)
+	assert.Zero(t, batches)
+}
+
+func TestEmployeeDirectoryIncludesFutureEmployees(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/employees/directory", r.URL.Path)
+		assert.Equal(t, "false", r.URL.Query().Get("onlyCurrent"))
+		_, _ = fmt.Fprint(w, `{"fields":[{"id":"displayName","type":"text","name":"Display Name"}],"employees":[{"id":"101","displayName":"Ada Lovelace","supervisor":{"id":"99","displayName":"Charles Babbage"}}]}`)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "employee_directory"})
+	require.NoError(t, err)
+	rows, batches := drainTable(t, table, source.ReadOptions{})
+	assert.EqualValues(t, 1, rows)
+	assert.Equal(t, 1, batches)
+}
+
+func TestEmployeeDirectoryTreatsEmptyDirectory404AsEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "employee_directory"})
+	require.NoError(t, err)
+	rows, batches := drainTable(t, table, source.ReadOptions{})
+	assert.Zero(t, rows)
+	assert.Zero(t, batches)
+}
+
+func TestMetadataAndTimeOffReferenceTablesUseFakeData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/meta/fields":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"First Name","type":"text","alias":"firstName"},{"id":"4340.4","name":"Custom Skill","type":"list","alias":"customSkill"}]`)
+		case "/api/v1/meta/users":
+			_, _ = fmt.Fprint(w, `{"9007199254740993":{"employeeId":101,"firstName":"Ada","lastName":"Lovelace","email":"ada@example.test","status":"enabled"}}`)
+		case "/api/v1/meta/time_off/types":
+			_, _ = fmt.Fprint(w, `{"timeOffTypes":[{"id":"64","name":"Vacation","units":"days","color":"56afdd","icon":"airplane","source":"internal"}],"defaultHours":[{"name":"Monday","amount":"8"},{"name":"Friday","amount":"8"}]}`)
+		case "/api/v1/meta/time_off/policies":
+			_, _ = fmt.Fprint(w, `[{"id":7,"timeOffTypeId":64,"name":"Standard Vacation","effectiveDate":null,"type":"accruing"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	for _, tt := range []struct {
+		table string
+		rows  int64
+	}{
+		{table: "employee_fields", rows: 2},
+		{table: "users", rows: 1},
+		{table: "time_off_types", rows: 1},
+		{table: "time_off_default_hours", rows: 2},
+		{table: "time_off_policies", rows: 1},
+	} {
+		t.Run(tt.table, func(t *testing.T) {
+			src := newTestSource(t, server.URL)
+			table, err := src.GetTable(context.Background(), source.TableRequest{Name: tt.table})
+			require.NoError(t, err)
+			rows, _ := drainTable(t, table, source.ReadOptions{})
+			assert.Equal(t, tt.rows, rows)
+		})
+	}
+}
+
+func TestLocationsFetchesActiveArchivedAndAllPages(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer oauth-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "/api/v1/hris/org/locations", r.URL.Path)
+		assert.Equal(t, "500", r.URL.Query().Get("pageSize"))
+		assert.Equal(t, "state,country", r.URL.Query().Get("expand"))
+		filter := r.URL.Query().Get("filter")
+		page := r.URL.Query().Get("page")
+		requests = append(requests, filter+":"+page)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch filter + ":" + page {
+		case "archived eq false:0":
+			_, _ = fmt.Fprint(w, `{"data":[{"id":1,"label":"London","archived":false,"address":{"city":"London","country":{"id":44,"name":"United Kingdom"}}}],"meta":{"page":0,"pageSize":500,"totalPages":2,"totalItems":2}}`)
+		case "archived eq false:1":
+			_, _ = fmt.Fprint(w, `{"data":[{"id":2,"label":"Remote","archived":false,"address":{"remoteLocation":true}}],"meta":{"page":1,"pageSize":500,"totalPages":2,"totalItems":2}}`)
+		case "archived eq true:0":
+			_, _ = fmt.Fprint(w, `{"data":[{"id":3,"label":"Old Office","archived":true,"archivedAt":"2025-01-01T00:00:00Z"}],"meta":{"page":0,"pageSize":500,"totalPages":1,"totalItems":1}}`)
+		default:
+			t.Fatalf("unexpected locations request %s:%s", filter, page)
+		}
+	}))
+	defer server.Close()
+
+	src := newOAuthTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "locations"})
+	require.NoError(t, err)
+	rows, batches := drainTable(t, table, source.ReadOptions{})
+	assert.EqualValues(t, 3, rows)
+	assert.Equal(t, 3, batches)
+	assert.Equal(t, []string{"archived eq false:0", "archived eq false:1", "archived eq true:0"}, requests)
+}
+
+func TestLocationsRejectsAPIKeyAuthentication(t *testing.T) {
+	src := NewBambooHRSource()
+	_, err := src.GetTable(context.Background(), source.TableRequest{Name: "locations"})
+	require.ErrorContains(t, err, "requires access_token authentication")
+}
+
+func TestTimeOffRequestsUsesInclusiveOverlapWindow(t *testing.T) {
+	start := time.Date(2026, time.January, 10, 15, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.February, 5, 22, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/time_off/requests", r.URL.Path)
+		assert.Equal(t, "2026-01-10", r.URL.Query().Get("start"))
+		assert.Equal(t, "2026-02-05", r.URL.Query().Get("end"))
+		_, _ = fmt.Fprint(w, `[{"id":"1348","employeeId":"101","name":"Ada Lovelace","start":"2026-02-01","end":"2026-02-03","created":"2026-01-10","status":{"lastChanged":"2026-01-11","status":"approved"},"type":{"id":"64","name":"Vacation"},"amount":{"unit":"days","amount":3},"dates":{"2026-02-01":1}}]`)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "time_off_requests"})
+	require.NoError(t, err)
+	rows, _ := drainTable(t, table, source.ReadOptions{IntervalStart: &start, IntervalEnd: &end})
+	assert.EqualValues(t, 1, rows)
+}
+
+func TestTimeOffRequestsWithoutIntervalRequestsFullRange(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "1900-01-01", r.URL.Query().Get("start"))
+		assert.Equal(t, "9999-12-31", r.URL.Query().Get("end"))
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "time_off_requests"})
+	require.NoError(t, err)
+	rows, batches := drainTable(t, table, source.ReadOptions{})
+	assert.Zero(t, rows)
+	assert.Zero(t, batches)
+}
+
+func TestTimesheetEntriesDefaultsToAvailable365DayWindow(t *testing.T) {
+	now := time.Date(2026, time.August, 18, 20, 30, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/time_tracking/timesheet_entries", r.URL.Path)
+		assert.Equal(t, "2025-08-19", r.URL.Query().Get("start"))
+		assert.Equal(t, "2026-08-18", r.URL.Query().Get("end"))
+		_, _ = fmt.Fprint(w, `[{"id":9007199254740993,"employeeId":101,"type":"clock","date":"2026-08-18","start":"2026-08-18T08:00:00+00:00","end":"2026-08-18T16:00:00+00:00","hours":8,"projectInfo":{"project":{"id":1,"name":"Connector"}},"approved":true,"createdAt":"2026-08-18T08:00:00+00:00","updatedAt":"2026-08-18T16:01:00+00:00"}]`)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	src.now = func() time.Time { return now }
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "timesheet_entries"})
+	require.NoError(t, err)
+	rows, _ := drainTable(t, table, source.ReadOptions{})
+	assert.EqualValues(t, 1, rows)
+}
+
+func TestTimesheetEntriesRequiresCompanyTimezone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("timesheet request should not be sent without a company timezone")
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	src.companyTimezone = nil
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "timesheet_entries"})
+	require.NoError(t, err)
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.ErrorContains(t, result.Err, "timezone is required")
+}
+
+func TestTimesheetWindowValidation(t *testing.T) {
+	now := time.Date(2026, time.August, 18, 0, 0, 0, 0, time.UTC)
+	tooOld := time.Date(2025, time.August, 18, 0, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 0, 1)
+	start := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+	beforeStart := time.Date(2026, time.August, 9, 0, 0, 0, 0, time.UTC)
+
+	_, _, err := timesheetWindow(source.ReadOptions{IntervalStart: &tooOld}, now, time.UTC)
+	require.ErrorContains(t, err, "last 365 days")
+	_, _, err = timesheetWindow(source.ReadOptions{IntervalEnd: &future}, now, time.UTC)
+	require.ErrorContains(t, err, "future")
+	_, _, err = timesheetWindow(source.ReadOptions{IntervalStart: &start, IntervalEnd: &beforeStart}, now, time.UTC)
+	require.ErrorContains(t, err, "start date must not be after end date")
+}
+
+func TestTimesheetWindowUsesCompanyTimezoneForToday(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	require.NoError(t, err)
+	now := time.Date(2026, time.August, 19, 3, 0, 0, 0, time.UTC)
+
+	start, end, err := timesheetWindow(source.ReadOptions{}, now, denver)
+	require.NoError(t, err)
+	assert.Equal(t, "2025-08-19", start)
+	assert.Equal(t, "2026-08-18", end)
+}
+
+func TestJSONUseNumberPreservesLargeIntegers(t *testing.T) {
+	var payload map[string]interface{}
+	require.NoError(t, jsonUseNumber([]byte(`{"id":9007199254740993}`), &payload))
+	assert.Equal(t, json.Number("9007199254740993"), payload["id"])
+}
+
+func TestAPIErrorIncludesBambooHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-BambooHR-Error-Message", "Directory disabled for this account")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, server.URL)
+	table, err := src.GetTable(context.Background(), source.TableRequest{Name: "employee_directory"})
+	require.NoError(t, err)
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.ErrorContains(t, result.Err, "Directory disabled for this account")
+}
+
+func newTestSource(t *testing.T, baseURL string) *BambooHRSource {
+	t.Helper()
+	client := newHTTPClient(
+		baseURL,
+		httpclient.NewBasicAuth("test-key", "x"),
+		httpclient.WithRateLimiter(1000, 1000),
+		httpclient.WithDisableRetry(),
+	)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	return &BambooHRSource{client: client, companyTimezone: time.UTC, now: time.Now}
+}
+
+func newOAuthTestSource(t *testing.T, baseURL string) *BambooHRSource {
+	t.Helper()
+	client := newHTTPClient(
+		baseURL,
+		httpclient.NewBearerAuth("oauth-token"),
+		httpclient.WithRateLimiter(1000, 1000),
+		httpclient.WithDisableRetry(),
+	)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	return &BambooHRSource{client: client, companyTimezone: time.UTC, usesOAuth: true, now: time.Now}
+}
+
+func drainTable(t *testing.T, table source.SourceTable, opts source.ReadOptions) (int64, int) {
+	t.Helper()
+	results, err := table.Read(context.Background(), opts)
+	require.NoError(t, err)
+
+	var rows int64
+	var batches int
+	for result := range results {
+		require.NoError(t, result.Err)
+		if result.Batch == nil {
+			continue
+		}
+		rows += result.Batch.NumRows()
+		batches++
+		result.Batch.Release()
+	}
+	return rows, batches
+}

--- a/pkg/source/bamboohr/bamboohr_test.go
+++ b/pkg/source/bamboohr/bamboohr_test.go
@@ -382,6 +382,22 @@ func TestTimesheetWindowUsesCompanyTimezoneForToday(t *testing.T) {
 	assert.Equal(t, "2026-08-18", end)
 }
 
+func TestTimesheetWindowUsesCompanyTimezoneForExplicitBounds(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	require.NoError(t, err)
+	now := time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)
+	startBoundary := time.Date(2026, time.August, 19, 1, 0, 0, 0, time.UTC)
+	endBoundary := time.Date(2026, time.August, 20, 1, 0, 0, 0, time.UTC)
+
+	start, end, err := timesheetWindow(source.ReadOptions{
+		IntervalStart: &startBoundary,
+		IntervalEnd:   &endBoundary,
+	}, now, denver)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-08-18", start)
+	assert.Equal(t, "2026-08-19", end)
+}
+
 func TestJSONUseNumberPreservesLargeIntegers(t *testing.T) {
 	var payload map[string]interface{}
 	require.NoError(t, jsonUseNumber([]byte(`{"id":9007199254740993}`), &payload))

--- a/pkg/source/bamboohr/register.go
+++ b/pkg/source/bamboohr/register.go
@@ -1,0 +1,10 @@
+package bamboohr
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"bamboohr"},
+		func() interface{} { return NewBambooHRSource() },
+	)
+}


### PR DESCRIPTION
## What

Adds BambooHR as an ingestr source.

## Changes

- Supports employees, directory, metadata, locations, time off, and timesheets with API key or OAuth authentication.
- Adds cursor/date filtering, rate limiting, synthetic API coverage, connector registration, and documentation.

## How to test

1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback

- **Risk:** Medium; API behavior is contract-tested but has not been verified against a live BambooHR account.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (not affected)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

None.
