### PR TITLE
onelake: mark the delta commit rename with mode=legacy

### DIFF
--- a/internal/adlsutil/adlsutil_test.go
+++ b/internal/adlsutil/adlsutil_test.go
@@ -247,11 +247,8 @@ func TestRenameIfNotExistsAppendsSASToken(t *testing.T) {
 }
 
 // TestRenameIfNotExistsMatchesSDKRequest pins the hand-built rename to the
-// request datalakefile.Client.Rename produces. The two diverged once already:
-// sending "resource=file" instead of "mode=legacy" turned the Create Path call
-// into a plain create, and OneLake rejected x-ms-rename-source with a 400
-// UnsupportedHeader. Only the header value may differ, and only for names that
-// need percent-encoding, which is why the rename is hand-built at all.
+// request datalakefile.Client.Rename produces. Only x-ms-rename-source may
+// differ, and only for names needing percent-encoding.
 func TestRenameIfNotExistsMatchesSDKRequest(t *testing.T) {
 	const (
 		workspace = "FabricDev"
@@ -296,9 +293,8 @@ func TestRenameIfNotExistsMatchesSDKRequest(t *testing.T) {
 	}
 }
 
-// headerValue looks a header up without canonicalizing the name. The generated
-// SDK client assigns straight into the map with lowercase keys, so http.Header.Get
-// misses those entries even though the wire format is case-insensitive.
+// headerValue looks a header up without canonicalizing the name: the generated
+// SDK client assigns straight into the map with lowercase keys that Get misses.
 func headerValue(h http.Header, name string) string {
 	for key, values := range h {
 		if strings.EqualFold(key, name) && len(values) > 0 {

--- a/internal/adlsutil/adlsutil_test.go
+++ b/internal/adlsutil/adlsutil_test.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
+	datalakefile "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/file"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -210,7 +212,7 @@ func TestRenameIfNotExistsSendsEscapedSourceAndIfNoneMatch(t *testing.T) {
 	assert.Equal(t, "*", transport.req.Header.Get("If-None-Match"))
 	assert.Equal(t, dfsServiceVersion, transport.req.Header.Get("x-ms-version"))
 	assert.Equal(t, "/Fabric%20Dev/lh.Lakehouse/Tables/t/_delta_log/00000000000000000001.json", transport.req.URL.EscapedPath())
-	assert.Equal(t, "resource=file", transport.req.URL.RawQuery)
+	assert.Equal(t, "mode=legacy", transport.req.URL.RawQuery)
 }
 
 func TestRenameIfNotExistsReportsConflictAsResponseError(t *testing.T) {
@@ -240,6 +242,68 @@ func TestRenameIfNotExistsAppendsSASToken(t *testing.T) {
 	}
 
 	require.NoError(t, client.RenameIfNotExists(t.Context(), "Fabric Dev", "a/b.tmp", "a/c.json"))
-	assert.Equal(t, "resource=file&sv=2021&sig=abc", transport.req.URL.RawQuery)
+	assert.Equal(t, "mode=legacy&sv=2021&sig=abc", transport.req.URL.RawQuery)
 	assert.Equal(t, "/Fabric%20Dev/a/b.tmp?sv=2021&sig=abc", transport.req.Header.Get("x-ms-rename-source"))
+}
+
+// TestRenameIfNotExistsMatchesSDKRequest pins the hand-built rename to the
+// request datalakefile.Client.Rename produces. The two diverged once already:
+// sending "resource=file" instead of "mode=legacy" turned the Create Path call
+// into a plain create, and OneLake rejected x-ms-rename-source with a 400
+// UnsupportedHeader. Only the header value may differ, and only for names that
+// need percent-encoding, which is why the rename is hand-built at all.
+func TestRenameIfNotExistsMatchesSDKRequest(t *testing.T) {
+	const (
+		workspace = "FabricDev"
+		srcPath   = "lh.Lakehouse/Tables/t/_bruin_delta_tmp/x.tmp"
+		destPath  = "lh.Lakehouse/Tables/t/_delta_log/00000000000000000000.json"
+	)
+
+	srcURL, err := PathURLWithSuffix(OneLakeAccountName, OneLakeDNSSuffix, workspace, srcPath)
+	require.NoError(t, err)
+
+	sdkTransport := &recordingTransport{status: http.StatusCreated}
+	sdkClient, err := datalakefile.NewClientWithNoCredential(srcURL, &datalakefile.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: sdkTransport},
+	})
+	require.NoError(t, err)
+
+	etagAny := azcore.ETagAny
+	_, err = sdkClient.Rename(t.Context(), destPath, &datalakefile.RenameOptions{
+		AccessConditions: &datalakefile.AccessConditions{
+			ModifiedAccessConditions: &datalakefile.ModifiedAccessConditions{IfNoneMatch: &etagAny},
+		},
+	})
+	require.NoError(t, err)
+
+	ourTransport := &recordingTransport{status: http.StatusCreated}
+	client := &DataLakeClient{
+		accountName: OneLakeAccountName,
+		dnsSuffix:   OneLakeDNSSuffix,
+		pipeline: azruntime.NewPipeline("test", "v1", azruntime.PipelineOptions{}, &policy.ClientOptions{
+			Transport: ourTransport,
+		}),
+	}
+	require.NoError(t, client.RenameIfNotExists(t.Context(), workspace, srcPath, destPath))
+
+	require.NotNil(t, sdkTransport.req)
+	require.NotNil(t, ourTransport.req)
+	assert.Equal(t, sdkTransport.req.Method, ourTransport.req.Method)
+	assert.Equal(t, sdkTransport.req.URL.EscapedPath(), ourTransport.req.URL.EscapedPath())
+	assert.Equal(t, sdkTransport.req.URL.RawQuery, ourTransport.req.URL.RawQuery)
+	for _, header := range []string{"x-ms-rename-source", "x-ms-version", "If-None-Match"} {
+		assert.Equal(t, headerValue(sdkTransport.req.Header, header), headerValue(ourTransport.req.Header, header), header)
+	}
+}
+
+// headerValue looks a header up without canonicalizing the name. The generated
+// SDK client assigns straight into the map with lowercase keys, so http.Header.Get
+// misses those entries even though the wire format is case-insensitive.
+func headerValue(h http.Header, name string) string {
+	for key, values := range h {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
 }

--- a/internal/adlsutil/datalake.go
+++ b/internal/adlsutil/datalake.go
@@ -234,6 +234,10 @@ func (c *DataLakeClient) DeleteDir(ctx context.Context, fileSystem, dirPath stri
 // datalakefile.Client.Rename, which derives the x-ms-rename-source header from
 // the percent-decoded URL path. Azure requires that header to be percent-encoded,
 // and a OneLake workspace name may contain characters that need escaping.
+//
+// The request mirrors what the SDK sends: "mode=legacy" marks the Create Path
+// call as a rename. Sending "resource=file" instead makes it a plain create,
+// and OneLake then rejects x-ms-rename-source as an unsupported header.
 func (c *DataLakeClient) RenameIfNotExists(ctx context.Context, fileSystem, srcPath, destPath string) error {
 	destURL, err := c.pathURL(fileSystem, destPath)
 	if err != nil {
@@ -245,7 +249,7 @@ func (c *DataLakeClient) RenameIfNotExists(ctx context.Context, fileSystem, srcP
 		source += "?" + c.sasToken
 	}
 
-	req, err := azruntime.NewRequest(ctx, http.MethodPut, AppendSASToken(destURL+"?resource=file", c.sasToken))
+	req, err := azruntime.NewRequest(ctx, http.MethodPut, AppendSASToken(destURL+"?mode=legacy", c.sasToken))
 	if err != nil {
 		return fmt.Errorf("failed to build rename request for %s: %w", destPath, err)
 	}

--- a/internal/adlsutil/datalake.go
+++ b/internal/adlsutil/datalake.go
@@ -235,9 +235,8 @@ func (c *DataLakeClient) DeleteDir(ctx context.Context, fileSystem, dirPath stri
 // the percent-decoded URL path. Azure requires that header to be percent-encoded,
 // and a OneLake workspace name may contain characters that need escaping.
 //
-// The request mirrors what the SDK sends: "mode=legacy" marks the Create Path
-// call as a rename. Sending "resource=file" instead makes it a plain create,
-// and OneLake then rejects x-ms-rename-source as an unsupported header.
+// "mode=legacy" is what marks the Create Path call as a rename; with
+// "resource=file" it is a plain create, which rejects x-ms-rename-source.
 func (c *DataLakeClient) RenameIfNotExists(ctx context.Context, fileSystem, srcPath, destPath string) error {
 	destURL, err := c.pathURL(fileSystem, destPath)
 	if err != nil {


### PR DESCRIPTION
Publishing any Delta commit to a OneLake lakehouse currently fails:

```
RESPONSE 400: One of the headers specified in the request is not supported.
ERROR CODE: UnsupportedHeader
HeaderName: x-ms-rename-source
```

## Cause

9d794bb3 (`onelake: fix workspace names with spaces and GUID item targets`) stopped calling `datalakefile.Client.Rename` — which derives `x-ms-rename-source` from the percent-decoded URL path — and issued the DFS rename directly instead. The hand-built request sent `resource=file` as its query parameter.

The ADLS Gen2 *Path - Create* endpoint uses that parameter to tell a create from a rename: `resource={file|directory}` creates a new empty path, while `mode=legacy` marks the call as a rename and makes the service read `x-ms-rename-source`. Sending `resource=file` turned every commit publish into a plain create, and `x-ms-rename-source` is not a header a create accepts.

The break was not limited to the workspace names that motivated 9d794bb3. For a workspace needing no escaping the header value is unchanged, so the query parameter was the only difference — the first commit of every table failed regardless of how the workspace was named.

## Change

Send `mode=legacy` and no `resource`, matching what the SDK's `FormatRenameOptions()` produces. The percent-encoding fix from 9d794bb3 is retained.

`TestRenameIfNotExistsMatchesSDKRequest` pins the hand-built request to the SDK's so the two cannot drift again: it builds both and compares method, escaped path, query and the rename headers. The comparison deliberately avoids `http.Header.Get` — the generated SDK client assigns into the header map with lowercase keys that `Get` does not canonicalize to.