### PR TITLE
fix(trino): support Iceberg variant JSON columns

### DIFF
--- a/docs/supported-sources/trino.md
+++ b/docs/supported-sources/trino.md
@@ -10,7 +10,7 @@ ingestr supports Trino as both a source and destination.
 The URI format for Trino is as follows:
 
 ```plaintext
-trino://<username>:<password>@<host>:<port>/<catalog>
+trino://<username>:<password>@<host>:<port>/<catalog>/<schema>
 ```
 
 URI parameters:
@@ -19,6 +19,11 @@ URI parameters:
 - `host`: the Trino server hostname or IP address
 - `port`: the Trino server port (default: 8080)
 - `catalog`: the Trino catalog to connect to
+- `schema`: the default schema (default: `default`)
+
+Destination URI parameters:
+
+- `json_type`: controls how ingestr writes JSON columns. `varchar` is the default and works across Trino catalogs. `variant` writes Iceberg v3 `VARIANT` columns and requires Trino 481 or newer.
 
 The same URI structure can be used both for sources and destinations. You can read more about SQLAlchemy's Trino dialect [here](https://github.com/trinodb/trino-python-client).
 
@@ -79,6 +84,20 @@ ingestr ingest \
     --dest-table 'sales.orders'
 ```
 
+### Iceberg v3 variant columns
+
+Use `json_type=variant` to preserve JSON values as native Iceberg v3 semi-structured data:
+
+```bash
+ingestr ingest \
+    --source-uri 'postgresql://user:pass@localhost:5432/sourcedb' \
+    --source-table 'public.events' \
+    --dest-uri 'trino://admin@localhost:8080/iceberg/sales?json_type=variant' \
+    --dest-table 'sales.events'
+```
+
+Ingestr creates new tables with `WITH (format_version = 3)` and writes JSON values as `VARIANT`. Existing tables must already use Iceberg format version 3; ingestr does not upgrade them implicitly.
+
 ## Supported write dispositions
 When using Trino as a destination, ingestr supports `replace`, `append`, `merge`, and `scd2`.
 
@@ -86,7 +105,7 @@ When using Trino as a destination, ingestr supports `replace`, `append`, `merge`
 
 ## Data type handling
 Trino automatically handles most SQL data type conversions. When used as a destination:
-- JSON types are converted to TEXT/VARCHAR
+- JSON types are converted to `VARCHAR` by default, or to Iceberg v3 `VARIANT` with `json_type=variant`
 - Binary types are converted to TEXT/VARCHAR
 - All integer types are mapped to BIGINT for compatibility
 
@@ -94,5 +113,5 @@ Trino automatically handles most SQL data type conversions. When used as a desti
 
 ### As a destination
 - Case-sensitive identifiers (table and column names preserve case)
-- JSON and Binary types are converted to STRING
+- `VARIANT` JSON columns require Iceberg format version 3 and Trino 481 or newer
 - Memory catalog does not support DELETE and UPDATE operations (affects merge/scd2 in test environments)

--- a/docs/supported-sources/trino.md
+++ b/docs/supported-sources/trino.md
@@ -96,7 +96,7 @@ ingestr ingest \
     --dest-table 'sales.events'
 ```
 
-Ingestr creates new tables with `WITH (format_version = 3)` and writes JSON values as `VARIANT`. Existing tables must already use Iceberg format version 3; ingestr does not upgrade them implicitly.
+Ingestr creates new tables with `WITH (format_version = 3)` and writes JSON values as `VARIANT`. Existing tables must already use Iceberg format version 3 and their corresponding JSON columns must be `VARIANT`; ingestr does not upgrade tables or columns implicitly.
 
 ## Supported write dispositions
 When using Trino as a destination, ingestr supports `replace`, `append`, `merge`, and `scd2`.

--- a/pkg/destination/trino/dialect.go
+++ b/pkg/destination/trino/dialect.go
@@ -8,7 +8,9 @@ import (
 )
 
 // Dialect implements the destination.Dialect interface for Trino.
-type Dialect struct{}
+type Dialect struct {
+	jsonType jsonTypeMode
+}
 
 func (d *Dialect) Name() string {
 	return "Trino"
@@ -30,53 +32,7 @@ func (d *Dialect) SupportsAlterType() bool {
 }
 
 func (d *Dialect) TypeName(col schema.Column) string {
-	switch col.DataType {
-	case schema.TypeBoolean:
-		return "BOOLEAN"
-	case schema.TypeInt8:
-		return "TINYINT"
-	case schema.TypeInt16:
-		return "SMALLINT"
-	case schema.TypeInt32:
-		return "INTEGER"
-	case schema.TypeInt64:
-		return "BIGINT"
-	case schema.TypeFloat32:
-		return "REAL"
-	case schema.TypeFloat64:
-		return "DOUBLE"
-	case schema.TypeDecimal:
-		if col.Precision > 0 {
-			return fmt.Sprintf("DECIMAL(%d,%d)", col.Precision, col.Scale)
-		}
-		return "DECIMAL(38,9)"
-	case schema.TypeString:
-		if col.MaxLength > 0 {
-			return fmt.Sprintf("VARCHAR(%d)", col.MaxLength)
-		}
-		return "VARCHAR"
-	case schema.TypeBinary:
-		return "VARBINARY"
-	case schema.TypeDate:
-		return "DATE"
-	case schema.TypeTime:
-		return "TIME(6)"
-	case schema.TypeTimestamp:
-		return "TIMESTAMP(6)"
-	case schema.TypeTimestampTZ:
-		return "TIMESTAMP(6) WITH TIME ZONE"
-	case schema.TypeInterval:
-		return "VARCHAR"
-	case schema.TypeJSON:
-		return "JSON"
-	case schema.TypeUUID:
-		return "UUID"
-	case schema.TypeArray:
-		elemCol := schema.Column{DataType: col.ArrayType}
-		return fmt.Sprintf("ARRAY(%s)", d.TypeName(elemCol))
-	default:
-		return "VARCHAR"
-	}
+	return mapDataTypeToTrino(col, d.jsonType)
 }
 
 func (d *Dialect) QuoteIdentifier(name string) string {

--- a/pkg/destination/trino/evolve.go
+++ b/pkg/destination/trino/evolve.go
@@ -10,7 +10,7 @@ import (
 // ApplySchemaEvolution renders the abstract schema-change plan into this
 // destination's DDL using the local dialect and applies each statement.
 func (d *TrinoDestination) ApplySchemaEvolution(ctx context.Context, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
-	return destination.ApplyEvolution(ctx, d, &Dialect{}, table, comparison)
+	return destination.ApplyEvolution(ctx, d, &Dialect{jsonType: d.jsonType}, table, comparison)
 }
 
 // SupportsColumnTypeChanges reports whether this destination can change a column's type.

--- a/pkg/destination/trino/json_test.go
+++ b/pkg/destination/trino/json_test.go
@@ -80,9 +80,11 @@ func TestValidateExistingVariantTable(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     string
+		columnType  string
 		wantErrText string
 	}{
-		{name: "version 3", version: "3"},
+		{name: "version 3 with variant column", version: "3", columnType: "variant"},
+		{name: "version 3 with varchar column", version: "3", columnType: "varchar", wantErrText: "requires existing JSON column iceberg.events.records.payload to use VARIANT; found varchar"},
 		{name: "version 2", version: "2", wantErrText: "uses format version 2"},
 		{name: "invalid version", version: "unknown", wantErrText: `invalid format version "unknown"`},
 	}
@@ -100,8 +102,12 @@ func TestValidateExistingVariantTable(t *testing.T) {
 				WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT value FROM "iceberg"."events"."records$properties" WHERE key = 'format-version'`)).
 				WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(tt.version))
+			if tt.version == "3" {
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT column_name, data_type FROM "iceberg".information_schema.columns WHERE table_schema = 'events' AND table_name = 'records'`)).
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type"}).AddRow("payload", tt.columnType))
+			}
 
-			err = dest.validateExistingVariantTable(t.Context(), "iceberg", "events", "records")
+			err = dest.validateExistingVariantTable(t.Context(), "iceberg", "events", "records", []schema.Column{{Name: "payload", DataType: schema.TypeJSON}})
 			if tt.wantErrText == "" {
 				require.NoError(t, err)
 			} else {
@@ -123,6 +129,6 @@ func TestValidateExistingVariantTableAllowsMissingTable(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1 FROM "iceberg".information_schema.tables WHERE table_schema = 'events' AND table_name = 'records'`)).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}))
 
-	require.NoError(t, dest.validateExistingVariantTable(t.Context(), "iceberg", "events", "records"))
+	require.NoError(t, dest.validateExistingVariantTable(t.Context(), "iceberg", "events", "records", []schema.Column{{Name: "payload", DataType: schema.TypeJSON}}))
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/destination/trino/json_test.go
+++ b/pkg/destination/trino/json_test.go
@@ -1,0 +1,128 @@
+package trino
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONTypeMapping(t *testing.T) {
+	t.Parallel()
+
+	jsonColumn := schema.Column{Name: "payload", DataType: schema.TypeJSON}
+	jsonArrayColumn := schema.Column{Name: "payloads", DataType: schema.TypeArray, ArrayType: schema.TypeJSON}
+
+	require.Equal(t, "VARCHAR", MapDataTypeToTrino(jsonColumn))
+	require.Equal(t, "ARRAY(VARCHAR)", MapDataTypeToTrino(jsonArrayColumn))
+	require.Equal(t, "VARIANT", mapDataTypeToTrino(jsonColumn, jsonTypeVariant))
+	require.Equal(t, "ARRAY(VARIANT)", mapDataTypeToTrino(jsonArrayColumn, jsonTypeVariant))
+	require.Equal(t, "VARIANT", (&Dialect{jsonType: jsonTypeVariant}).TypeName(jsonColumn))
+}
+
+func TestBuildCreateTableSQLJSONTypes(t *testing.T) {
+	t.Parallel()
+
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "payload", DataType: schema.TypeJSON},
+	}
+
+	varcharSQL := buildCreateTableSQL("iceberg", "events", "records", columns, jsonTypeVarchar)
+	require.Contains(t, varcharSQL, `"payload" VARCHAR`)
+	require.NotContains(t, varcharSQL, "format_version")
+
+	variantSQL := buildCreateTableSQL("iceberg", "events", "records", columns, jsonTypeVariant)
+	require.Contains(t, variantSQL, `"payload" VARIANT`)
+	require.Contains(t, variantSQL, "WITH (format_version = 3)")
+}
+
+func TestFormatJSONValueForSQL(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	builder := schema.NewJSONBuilder(mem)
+	builder.Append(`{"owner":"O'Reilly"}`)
+	builder.AppendNull()
+	values := builder.NewArray()
+	builder.Release()
+	defer values.Release()
+
+	require.Equal(t, `'{"owner":"O''Reilly"}'`, formatValueForSQL(values, 0, jsonTypeVarchar))
+	require.Equal(t, `CAST(JSON '{"owner":"O''Reilly"}' AS VARIANT)`, formatValueForSQL(values, 0, jsonTypeVariant))
+	require.Equal(t, "CAST(NULL AS VARCHAR)", formatValueForSQL(values, 1, jsonTypeVarchar))
+	require.Equal(t, "CAST(NULL AS VARIANT)", formatValueForSQL(values, 1, jsonTypeVariant))
+}
+
+func TestFormatJSONArrayForVariant(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	builder := array.NewListBuilder(mem, schema.JSONArrowType)
+	extensionBuilder := builder.ValueBuilder().(*array.ExtensionBuilder)
+	storageBuilder := extensionBuilder.Builder.(*array.StringBuilder)
+	builder.Append(true)
+	storageBuilder.Append(`{"id":1}`)
+	values := builder.NewArray()
+	builder.Release()
+	defer values.Release()
+
+	require.Equal(t, `ARRAY[CAST(JSON '{"id":1}' AS VARIANT)]`, formatValueForSQL(values, 0, jsonTypeVariant))
+}
+
+func TestValidateExistingVariantTable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		version     string
+		wantErrText string
+	}{
+		{name: "version 3", version: "3"},
+		{name: "version 2", version: "2", wantErrText: "uses format version 2"},
+		{name: "invalid version", version: "unknown", wantErrText: `invalid format version "unknown"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = db.Close() })
+
+			dest := &TrinoDestination{db: db, jsonType: jsonTypeVariant}
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1 FROM "iceberg".information_schema.tables WHERE table_schema = 'events' AND table_name = 'records'`)).
+				WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT value FROM "iceberg"."events"."records$properties" WHERE key = 'format-version'`)).
+				WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(tt.version))
+
+			err = dest.validateExistingVariantTable(t.Context(), "iceberg", "events", "records")
+			if tt.wantErrText == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErrText)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestValidateExistingVariantTableAllowsMissingTable(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	dest := &TrinoDestination{db: db, jsonType: jsonTypeVariant}
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1 FROM "iceberg".information_schema.tables WHERE table_schema = 'events' AND table_name = 'records'`)).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}))
+
+	require.NoError(t, dest.validateExistingVariantTable(t.Context(), "iceberg", "events", "records"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/destination/trino/mapper.go
+++ b/pkg/destination/trino/mapper.go
@@ -7,11 +7,10 @@ import (
 )
 
 func MapDataTypeToTrino(col schema.Column) string {
-	baseType := mapBaseType(col)
-	return baseType
+	return mapDataTypeToTrino(col, jsonTypeVarchar)
 }
 
-func mapBaseType(col schema.Column) string {
+func mapDataTypeToTrino(col schema.Column, jsonType jsonTypeMode) string {
 	switch col.DataType {
 	case schema.TypeBoolean:
 		return "BOOLEAN"
@@ -50,12 +49,15 @@ func mapBaseType(col schema.Column) string {
 	case schema.TypeInterval:
 		return "VARCHAR"
 	case schema.TypeJSON:
-		return "JSON"
+		if jsonType.normalized() == jsonTypeVariant {
+			return "VARIANT"
+		}
+		return "VARCHAR"
 	case schema.TypeUUID:
 		return "UUID"
 	case schema.TypeArray:
 		elemCol := schema.Column{DataType: col.ArrayType}
-		return fmt.Sprintf("ARRAY(%s)", mapBaseType(elemCol))
+		return fmt.Sprintf("ARRAY(%s)", mapDataTypeToTrino(elemCol, jsonType))
 	default:
 		return "VARCHAR"
 	}

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -76,7 +76,7 @@ func (d *TrinoDestination) PrepareTable(ctx context.Context, opts destination.Pr
 		return fmt.Errorf("failed to ensure schema exists: %w", err)
 	}
 	if d.jsonType.normalized() == jsonTypeVariant && !opts.DropFirst {
-		if err := d.validateExistingVariantTable(ctx, catalog, schemaName, tableName); err != nil {
+		if err := d.validateExistingVariantTable(ctx, catalog, schemaName, tableName, opts.Schema.Columns); err != nil {
 			return err
 		}
 	}
@@ -103,7 +103,7 @@ func (d *TrinoDestination) PrepareTable(ctx context.Context, opts destination.Pr
 	return nil
 }
 
-func (d *TrinoDestination) validateExistingVariantTable(ctx context.Context, catalog, schemaName, tableName string) error {
+func (d *TrinoDestination) validateExistingVariantTable(ctx context.Context, catalog, schemaName, tableName string, columns []schema.Column) error {
 	existsSQL := fmt.Sprintf(
 		"SELECT 1 FROM %s.information_schema.tables WHERE table_schema = %s AND table_name = %s",
 		quoteIdentifier(catalog), escapeString(schemaName), escapeString(tableName),
@@ -131,6 +131,40 @@ func (d *TrinoDestination) validateExistingVariantTable(ctx context.Context, cat
 	}
 	if version < 3 {
 		return fmt.Errorf("json_type=variant requires an Iceberg format version 3 table; existing table %s.%s.%s uses format version %d", catalog, schemaName, tableName, version)
+	}
+
+	expectedTypes := make(map[string]string)
+	for _, col := range columns {
+		if col.DataType == schema.TypeJSON || col.DataType == schema.TypeArray && col.ArrayType == schema.TypeJSON {
+			expectedTypes[col.Name] = mapDataTypeToTrino(col, jsonTypeVariant)
+		}
+	}
+	if len(expectedTypes) == 0 {
+		return nil
+	}
+
+	columnsSQL := fmt.Sprintf(
+		"SELECT column_name, data_type FROM %s.information_schema.columns WHERE table_schema = %s AND table_name = %s",
+		quoteIdentifier(catalog), escapeString(schemaName), escapeString(tableName),
+	)
+	rows, err := d.db.QueryContext(ctx, columnsSQL)
+	if err != nil {
+		return fmt.Errorf("failed to read columns for existing Trino table %s.%s.%s: %w", catalog, schemaName, tableName, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name, dataType string
+		if err := rows.Scan(&name, &dataType); err != nil {
+			return fmt.Errorf("failed to read column type for existing Trino table %s.%s.%s: %w", catalog, schemaName, tableName, err)
+		}
+		expected, ok := expectedTypes[name]
+		if ok && !strings.EqualFold(strings.ReplaceAll(dataType, " ", ""), strings.ReplaceAll(expected, " ", "")) {
+			return fmt.Errorf("json_type=variant requires existing JSON column %s.%s.%s.%s to use %s; found %s", catalog, schemaName, tableName, name, expected, dataType)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to read columns for existing Trino table %s.%s.%s: %w", catalog, schemaName, tableName, err)
 	}
 	return nil
 }

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,13 +21,14 @@ import (
 )
 
 type TrinoDestination struct {
-	db      *sql.DB
-	catalog string
-	schema  string
+	db       *sql.DB
+	catalog  string
+	schema   string
+	jsonType jsonTypeMode
 }
 
 func NewTrinoDestination() *TrinoDestination {
-	return &TrinoDestination{}
+	return &TrinoDestination{jsonType: jsonTypeVarchar}
 }
 
 func (d *TrinoDestination) Schemes() []string {
@@ -34,12 +36,12 @@ func (d *TrinoDestination) Schemes() []string {
 }
 
 func (d *TrinoDestination) Connect(ctx context.Context, uri string) error {
-	dsn, catalog, schemaName, err := parseTrinoURI(uri)
+	connectionConfig, err := parseTrinoURI(uri)
 	if err != nil {
 		return fmt.Errorf("failed to parse Trino URI: %w", err)
 	}
 
-	db, err := sql.Open("trino", dsn)
+	db, err := sql.Open("trino", connectionConfig.dsn)
 	if err != nil {
 		return fmt.Errorf("failed to open Trino connection: %w", err)
 	}
@@ -50,9 +52,10 @@ func (d *TrinoDestination) Connect(ctx context.Context, uri string) error {
 	}
 
 	d.db = db
-	d.catalog = catalog
-	d.schema = schemaName
-	config.Debug("[TRINO] Connected to catalog: %s, schema: %s", catalog, schemaName)
+	d.catalog = connectionConfig.catalog
+	d.schema = connectionConfig.schema
+	d.jsonType = connectionConfig.jsonType
+	config.Debug("[TRINO] Connected to catalog: %s, schema: %s, JSON type: %s", d.catalog, d.schema, d.jsonType)
 	return nil
 }
 
@@ -72,6 +75,11 @@ func (d *TrinoDestination) PrepareTable(ctx context.Context, opts destination.Pr
 	if err := d.ensureSchemaExists(ctx, catalog, schemaName); err != nil {
 		return fmt.Errorf("failed to ensure schema exists: %w", err)
 	}
+	if d.jsonType.normalized() == jsonTypeVariant && !opts.DropFirst {
+		if err := d.validateExistingVariantTable(ctx, catalog, schemaName, tableName); err != nil {
+			return err
+		}
+	}
 
 	if opts.DropFirst {
 		startDrop := time.Now()
@@ -84,7 +92,7 @@ func (d *TrinoDestination) PrepareTable(ctx context.Context, opts destination.Pr
 	}
 
 	startCreate := time.Now()
-	createSQL := buildCreateTableSQL(catalog, schemaName, tableName, opts.Schema.Columns)
+	createSQL := buildCreateTableSQL(catalog, schemaName, tableName, opts.Schema.Columns, d.jsonType)
 	config.Debug("[TRINO] CREATE SQL: %s", createSQL)
 	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
 		config.LogFailedQuery(createSQL, err)
@@ -92,6 +100,38 @@ func (d *TrinoDestination) PrepareTable(ctx context.Context, opts destination.Pr
 	}
 	config.Debug("[TRINO] CREATE TABLE took %v", time.Since(startCreate))
 
+	return nil
+}
+
+func (d *TrinoDestination) validateExistingVariantTable(ctx context.Context, catalog, schemaName, tableName string) error {
+	existsSQL := fmt.Sprintf(
+		"SELECT 1 FROM %s.information_schema.tables WHERE table_schema = %s AND table_name = %s",
+		quoteIdentifier(catalog), escapeString(schemaName), escapeString(tableName),
+	)
+	var one int
+	err := d.db.QueryRowContext(ctx, existsSQL).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check whether Trino table exists: %w", err)
+	}
+
+	propertiesTable := fmt.Sprintf(
+		"%s.%s.%s",
+		quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(tableName+"$properties"),
+	)
+	var rawVersion string
+	if err := d.db.QueryRowContext(ctx, "SELECT value FROM "+propertiesTable+" WHERE key = 'format-version'").Scan(&rawVersion); err != nil {
+		return fmt.Errorf("json_type=variant requires an Iceberg format version 3 table; failed to read properties for existing table %s.%s.%s: %w", catalog, schemaName, tableName, err)
+	}
+	version, err := strconv.Atoi(rawVersion)
+	if err != nil {
+		return fmt.Errorf("json_type=variant requires an Iceberg format version 3 table; existing table %s.%s.%s has invalid format version %q", catalog, schemaName, tableName, rawVersion)
+	}
+	if version < 3 {
+		return fmt.Errorf("json_type=variant requires an Iceberg format version 3 table; existing table %s.%s.%s uses format version %d", catalog, schemaName, tableName, version)
+	}
 	return nil
 }
 
@@ -175,7 +215,7 @@ func (d *TrinoDestination) writeBatch(ctx context.Context, records <-chan source
 				chunkEnd = numRows
 			}
 
-			insertSQL := buildInsertSQLWithValues(catalog, schemaName, tableName, columns, record, int(chunkStart), int(chunkEnd))
+			insertSQL := buildInsertSQLWithValues(catalog, schemaName, tableName, columns, record, int(chunkStart), int(chunkEnd), d.jsonType)
 
 			if _, err := d.db.ExecContext(ctx, insertSQL); err != nil {
 				config.LogFailedQuery(insertSQL, err)
@@ -434,10 +474,31 @@ func (d *TrinoDestination) GetTableSchema(ctx context.Context, table string) (*s
 	return nil, nil
 }
 
-func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
+type jsonTypeMode string
+
+const (
+	jsonTypeVarchar jsonTypeMode = "varchar"
+	jsonTypeVariant jsonTypeMode = "variant"
+)
+
+type trinoConnectionConfig struct {
+	dsn      string
+	catalog  string
+	schema   string
+	jsonType jsonTypeMode
+}
+
+func (m jsonTypeMode) normalized() jsonTypeMode {
+	if m == jsonTypeVariant {
+		return jsonTypeVariant
+	}
+	return jsonTypeVarchar
+}
+
+func parseTrinoURI(uri string) (trinoConnectionConfig, error) {
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return "", "", "", fmt.Errorf("invalid URI: %w", err)
+		return trinoConnectionConfig{}, fmt.Errorf("invalid URI: %w", err)
 	}
 
 	host := parsed.Hostname()
@@ -451,15 +512,13 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 	}
 
 	pathParts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	catalog := "memory"
 	if len(pathParts) >= 1 && pathParts[0] != "" {
 		catalog = pathParts[0]
-	} else {
-		catalog = "memory"
 	}
+	schemaName := "default"
 	if len(pathParts) >= 2 {
 		schemaName = pathParts[1]
-	} else {
-		schemaName = "default"
 	}
 
 	username := ""
@@ -475,6 +534,10 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 
 	scheme := "http"
 	query := parsed.Query()
+	jsonType, err := parseJSONTypeMode(query.Get("json_type"))
+	if err != nil {
+		return trinoConnectionConfig{}, err
+	}
 	if query.Get("secure") == "true" || query.Get("SSL") == "true" || strings.EqualFold(query.Get("http_scheme"), "https") {
 		scheme = "https"
 	}
@@ -483,7 +546,7 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 
 	customClient, err := buildAndRegisterCustomClient(query)
 	if err != nil {
-		return "", "", "", err
+		return trinoConnectionConfig{}, err
 	}
 
 	userinfo := url.PathEscape(username)
@@ -491,7 +554,7 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 		userinfo = url.PathEscape(username) + ":" + url.PathEscape(password)
 	}
 
-	dsn = fmt.Sprintf("%s://%s@%s:%s?catalog=%s&schema=%s",
+	dsn := fmt.Sprintf("%s://%s@%s:%s?catalog=%s&schema=%s",
 		scheme, userinfo, host, port, catalog, schemaName)
 
 	if customClient != "" {
@@ -507,7 +570,23 @@ func parseTrinoURI(uri string) (dsn, catalog, schemaName string, err error) {
 		}
 	}
 
-	return dsn, catalog, schemaName, nil
+	return trinoConnectionConfig{
+		dsn:      dsn,
+		catalog:  catalog,
+		schema:   schemaName,
+		jsonType: jsonType,
+	}, nil
+}
+
+func parseJSONTypeMode(raw string) (jsonTypeMode, error) {
+	switch jsonTypeMode(strings.ToLower(strings.TrimSpace(raw))) {
+	case "", jsonTypeVarchar:
+		return jsonTypeVarchar, nil
+	case jsonTypeVariant:
+		return jsonTypeVariant, nil
+	default:
+		return "", fmt.Errorf("trino uri: invalid json_type %q; expected varchar or variant", raw)
+	}
 }
 
 // isReservedURIKey lists query parameters consumed by parseTrinoURI itself —
@@ -517,6 +596,8 @@ func isReservedURIKey(key string) bool {
 	case "secure", "SSL", "http_scheme":
 		return true
 	case "cert", "key", "http_headers", "verify":
+		return true
+	case "json_type":
 		return true
 	case "custom_client":
 		// We register our own client; never forward a user-supplied value
@@ -534,10 +615,10 @@ func (d *TrinoDestination) parseTableName(table string) (catalog, schemaName, ta
 	return tn.Catalog, tn.Schema, tn.Table
 }
 
-func buildCreateTableSQL(catalog, schemaName, table string, columns []schema.Column) string {
+func buildCreateTableSQL(catalog, schemaName, table string, columns []schema.Column, jsonType jsonTypeMode) string {
 	var colDefs []string
 	for _, col := range columns {
-		colType := MapDataTypeToTrino(col)
+		colType := mapDataTypeToTrino(col, jsonType)
 		colDefs = append(colDefs, fmt.Sprintf("%s %s", quoteIdentifier(col.Name), colType))
 	}
 
@@ -546,11 +627,14 @@ func buildCreateTableSQL(catalog, schemaName, table string, columns []schema.Col
 		quoteIdentifier(catalog), quoteIdentifier(schemaName), quoteIdentifier(table),
 		strings.Join(colDefs, ",\n  "),
 	)
+	if jsonType.normalized() == jsonTypeVariant {
+		sql += "\nWITH (format_version = 3)"
+	}
 
 	return sql
 }
 
-func buildInsertSQLWithValues(catalog, schemaName, table string, columns []string, record arrow.RecordBatch, startRow, endRow int) string {
+func buildInsertSQLWithValues(catalog, schemaName, table string, columns []string, record arrow.RecordBatch, startRow, endRow int, jsonType jsonTypeMode) string {
 	quotedCols := make([]string, len(columns))
 	for i, col := range columns {
 		quotedCols[i] = quoteIdentifier(col)
@@ -560,7 +644,7 @@ func buildInsertSQLWithValues(catalog, schemaName, table string, columns []strin
 	for rowIdx := startRow; rowIdx < endRow; rowIdx++ {
 		var values []string
 		for colIdx := 0; colIdx < len(columns); colIdx++ {
-			values = append(values, formatValueForSQL(record.Column(colIdx), rowIdx))
+			values = append(values, formatValueForSQL(record.Column(colIdx), rowIdx, jsonType))
 		}
 		rows = append(rows, "("+strings.Join(values, ", ")+")")
 	}
@@ -571,9 +655,9 @@ func buildInsertSQLWithValues(catalog, schemaName, table string, columns []strin
 		strings.Join(rows, ", "))
 }
 
-func formatValueForSQL(arr arrow.Array, idx int) string {
+func formatValueForSQL(arr arrow.Array, idx int, jsonType jsonTypeMode) string {
 	if arr.IsNull(idx) {
-		return castNull(arr.DataType())
+		return castNull(arr.DataType(), jsonType)
 	}
 
 	switch a := arr.(type) {
@@ -636,17 +720,21 @@ func formatValueForSQL(arr arrow.Array, idx int) string {
 		if extType.ExtensionName() == "json" {
 			storage := a.Storage()
 			if strArr, ok := storage.(*array.String); ok {
-				return fmt.Sprintf("JSON %s", escapeString(strArr.Value(idx)))
+				value := escapeString(strArr.Value(idx))
+				if jsonType.normalized() == jsonTypeVariant {
+					return fmt.Sprintf("CAST(JSON %s AS VARIANT)", value)
+				}
+				return value
 			}
 		}
 		storage := a.Storage()
-		return formatValueForSQL(storage, idx)
+		return formatValueForSQL(storage, idx, jsonType)
 	case *array.List:
 		start, end := a.ValueOffsets(idx)
 		listValues := a.ListValues()
 		var elements []string
 		for i := int(start); i < int(end); i++ {
-			elements = append(elements, formatValueForSQL(listValues, i))
+			elements = append(elements, formatValueForSQL(listValues, i, jsonType))
 		}
 		return "ARRAY[" + strings.Join(elements, ", ") + "]"
 	default:
@@ -654,7 +742,7 @@ func formatValueForSQL(arr arrow.Array, idx int) string {
 	}
 }
 
-func castNull(dt arrow.DataType) string {
+func castNull(dt arrow.DataType, jsonType jsonTypeMode) string {
 	switch dt.ID() {
 	case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
 		return "CAST(NULL AS BIGINT)"
@@ -671,7 +759,17 @@ func castNull(dt arrow.DataType) string {
 	case arrow.BINARY:
 		return "CAST(NULL AS VARBINARY)"
 	case arrow.EXTENSION:
-		return "CAST(NULL AS JSON)"
+		ext, ok := dt.(arrow.ExtensionType)
+		if !ok {
+			return "CAST(NULL AS VARCHAR)"
+		}
+		if ext.ExtensionName() == schema.JSONExtensionName {
+			if jsonType.normalized() == jsonTypeVariant {
+				return "CAST(NULL AS VARIANT)"
+			}
+			return "CAST(NULL AS VARCHAR)"
+		}
+		return castNull(ext.StorageType(), jsonType)
 	default:
 		return "CAST(NULL AS VARCHAR)"
 	}

--- a/pkg/destination/trino/trino_test.go
+++ b/pkg/destination/trino/trino_test.go
@@ -13,6 +13,7 @@ func TestParseTrinoURI(t *testing.T) {
 		uri          string
 		wantCatalog  string
 		wantSchema   string
+		wantJSONType jsonTypeMode
 		wantInDSN    []string
 		wantNotInDSN []string
 	}{
@@ -93,28 +94,43 @@ func TestParseTrinoURI(t *testing.T) {
 			wantInDSN:    []string{"custom_client=ingestr-trino-"},
 			wantNotInDSN: []string{"verify=", "SSLCertPath="},
 		},
+		{
+			uri:          "trino://user@host:8080/iceberg/default?json_type=variant",
+			wantCatalog:  "iceberg",
+			wantSchema:   "default",
+			wantJSONType: jsonTypeVariant,
+			wantInDSN:    []string{"catalog=iceberg", "schema=default"},
+			wantNotInDSN: []string{"json_type"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.uri, func(t *testing.T) {
-			dsn, catalog, schemaName, err := parseTrinoURI(tt.uri)
+			connectionConfig, err := parseTrinoURI(tt.uri)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if catalog != tt.wantCatalog {
-				t.Errorf("catalog mismatch: got %q want %q", catalog, tt.wantCatalog)
+			if connectionConfig.catalog != tt.wantCatalog {
+				t.Errorf("catalog mismatch: got %q want %q", connectionConfig.catalog, tt.wantCatalog)
 			}
-			if schemaName != tt.wantSchema {
-				t.Errorf("schema mismatch: got %q want %q", schemaName, tt.wantSchema)
+			if connectionConfig.schema != tt.wantSchema {
+				t.Errorf("schema mismatch: got %q want %q", connectionConfig.schema, tt.wantSchema)
+			}
+			wantJSONType := tt.wantJSONType
+			if wantJSONType == "" {
+				wantJSONType = jsonTypeVarchar
+			}
+			if connectionConfig.jsonType != wantJSONType {
+				t.Errorf("json type mismatch: got %q want %q", connectionConfig.jsonType, wantJSONType)
 			}
 			for _, want := range tt.wantInDSN {
-				if !strings.Contains(dsn, want) {
-					t.Errorf("dsn %q missing %q", dsn, want)
+				if !strings.Contains(connectionConfig.dsn, want) {
+					t.Errorf("dsn %q missing %q", connectionConfig.dsn, want)
 				}
 			}
 			for _, notWant := range tt.wantNotInDSN {
-				if strings.Contains(dsn, notWant) {
-					t.Errorf("dsn %q should not contain %q", dsn, notWant)
+				if strings.Contains(connectionConfig.dsn, notWant) {
+					t.Errorf("dsn %q should not contain %q", connectionConfig.dsn, notWant)
 				}
 			}
 		})
@@ -122,16 +138,23 @@ func TestParseTrinoURI(t *testing.T) {
 }
 
 func TestParseTrinoURI_InvalidHTTPHeaders(t *testing.T) {
-	_, _, _, err := parseTrinoURI("trino://host:443/cat?http_headers=not-json")
+	_, err := parseTrinoURI("trino://host:443/cat?http_headers=not-json")
 	if err == nil {
 		t.Fatal("expected error for invalid http_headers JSON, got nil")
 	}
 }
 
 func TestParseTrinoURI_CertWithoutKey(t *testing.T) {
-	_, _, _, err := parseTrinoURI("trino://host:443/cat?cert=/etc/ssl/client.pem")
+	_, err := parseTrinoURI("trino://host:443/cat?cert=/etc/ssl/client.pem")
 	if err == nil {
 		t.Fatal("expected error when cert is provided without key, got nil")
+	}
+}
+
+func TestParseTrinoURI_InvalidJSONType(t *testing.T) {
+	_, err := parseTrinoURI("trino://host:8080/iceberg?json_type=json")
+	if err == nil || !strings.Contains(err.Error(), "expected varchar or variant") {
+		t.Fatalf("parseTrinoURI() error = %v, want invalid json_type error", err)
 	}
 }
 


### PR DESCRIPTION
## What
Fixes #1108 by storing Trino JSON as `VARCHAR` by default and adding opt-in Iceberg v3 `VARIANT` support through `json_type=variant`.

## Changes
- Make Trino JSON DDL, values, nulls, arrays, and schema evolution mode-aware; guard existing pre-v3 Iceberg tables; add tests and docs.

## How to test
1. Run `make format`, `make lint`, and `make test`.
2. Ingest PostgreSQL JSONB into Trino Iceberg with and without `json_type=variant`, then verify the column type and Iceberg format version.

## Risk & rollback
- **Risk:** Medium — the default Trino JSON representation changes from `JSON` to the documented `VARCHAR` behavior.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #1108
