### PR TITLE
Checkpoint PostgreSQL CDC batch runs at the emitted barrier LSN

### DIFF
--- a/pkg/source/postgres_cdc/batch_barrier.go
+++ b/pkg/source/postgres_cdc/batch_barrier.go
@@ -83,13 +83,6 @@ func matchesStreamHeartbeat(message *pglogrepl.LogicalDecodingMessage) bool {
 	return message != nil && !message.Transactional && message.Prefix == streamHeartbeatPrefix
 }
 
-func batchCaughtUpLSN(decoded, emitted pglogrepl.LSN) pglogrepl.LSN {
-	if emitted > decoded {
-		return emitted
-	}
-	return decoded
-}
-
 func validateBatchBarrierSupport(serverVersion int) error {
 	if serverVersion < 140000 {
 		return fmt.Errorf("PostgreSQL CDC batch mode requires PostgreSQL 14 or newer for a safe logical-decoding barrier (server reports %d); use --stream or upgrade PostgreSQL", serverVersion)

--- a/pkg/source/postgres_cdc/batch_barrier_test.go
+++ b/pkg/source/postgres_cdc/batch_barrier_test.go
@@ -118,9 +118,44 @@ func TestBatchBarrierVersionRequirement(t *testing.T) {
 	require.NoError(t, validateBatchBarrierSupport(140000))
 }
 
-func TestBatchCaughtUpLSNIncludesEmittedBarrierEnd(t *testing.T) {
-	assert.Equal(t, pglogrepl.LSN(30), batchCaughtUpLSN(20, 30))
-	assert.Equal(t, pglogrepl.LSN(30), batchCaughtUpLSN(30, 20))
+// TestBatchCheckpointStaysAtEmittedBarrier is a regression test for a run that
+// persisted checkpoint 00008367/1181E504 while its slot sat around 661/...,
+// leaving the next run unable to resume and forcing a replacement snapshot.
+// The checkpoint used to be max(decoded, emitted), so a decoded position past
+// the barrier — the protocol position, which also advances on keepalives and on
+// WAL that was never handed to the destination — became the resume point. Only
+// the SQL-emitted barrier LSN is known to have everything before it decoded and
+// flushed, so it is what a completed batch persists and confirms.
+func TestBatchCheckpointStaysAtEmittedBarrier(t *testing.T) {
+	const (
+		emitted  = pglogrepl.LSN(30)
+		startLSN = pglogrepl.LSN(20)
+	)
+
+	// The barrier marker is decoded at protocol position 40, past the LSN that
+	// pg_logical_emit_message reported for it.
+	repl := &fakeReplicator{steps: []replStep{
+		{hadActivity: true, lsn: 25, changes: makeInsertChanges(1, 1, 25)},
+		{hadActivity: true, lsn: 40, barrier: true},
+	}}
+	results := make(chan source.RecordBatchResult, 4)
+	require.NoError(t, streamLoop(context.Background(), repl, 100, testAccumulator(100), results, false))
+	close(results)
+	for res := range results {
+		if res.Batch != nil {
+			res.Batch.Release()
+		}
+	}
+	require.Greater(t, repl.CurrentLSN(), emitted, "the decoded position must run past the barrier for this test to mean anything")
+
+	src := NewPostgresCDCSource()
+	src.checkpointBatchBarrier(context.Background(), emitted, startLSN, "slot")
+
+	assert.Equal(t, emitted, src.caughtUp.Committed())
+	assert.Equal(t, FormatLSN(emitted), src.CDCState().Position, "the persisted checkpoint must be the emitted barrier, not the decoded position")
+
+	require.NoError(t, src.FinalizeBatch(context.Background()))
+	assert.Equal(t, FormatLSN(emitted), src.CDCState().Position)
 }
 
 func TestReadersRejectPre14BatchBeforeSnapshot(t *testing.T) {

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -932,24 +932,20 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		if barrierNonce != "" && repl.BarrierReached() {
 			_, pending := repl.PendingLowWater()
 			if !pending {
-				currentLSN := batchCaughtUpLSN(repl.CurrentLSN(), barrierLSN)
-				config.Debug("[CDC] Batch mode: decoded logical barrier at %s", currentLSN)
+				config.Debug("[CDC] Batch mode: decoded logical barrier at %s", barrierLSN)
 				if err := accum.flushAllContext(ctx, results, token); err != nil {
 					return nil, err
 				}
-				// Record the caught-up position so FinalizeBatch can confirm it
-				// to the slot once the destination write is durable.
-				r.source.recordCaughtUpLSN(currentLSN, slotName, true)
 				// Stop the WAL receiver before the keepalive goroutine takes
 				// over the replication connection — they must never use it
 				// concurrently. Close is idempotent for the deferred call.
 				if err := repl.Close(ctx); err != nil {
 					return nil, err
 				}
-				// Keep the walsender alive while the destination drains the
-				// results channel. FinalizeBatch will stop it before sending
-				// the final WALFlush-bearing standby update.
-				r.source.startKeepalive(ctx, currentLSN, startLSN)
+				// The emitted barrier is the position FinalizeBatch may confirm
+				// to the slot after the destination write is durable; the
+				// keepalive holds the walsender open until then.
+				r.source.checkpointBatchBarrier(ctx, barrierLSN, startLSN, slotName)
 				return nil, nil
 			}
 		}

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -249,14 +249,12 @@ func (r *CDCReader) runStream(ctx context.Context, startLSN pglogrepl.LSN, slotN
 
 	err = streamLoop(ctx, repl, batchSize, accum, results, opts.Streaming)
 	if err == nil && !opts.Streaming {
-		// Record the caught-up position so FinalizeBatch can confirm it to the
-		// slot once the destination write is durable.
-		caughtUp := batchCaughtUpLSN(repl.CurrentLSN(), barrierLSN)
-		r.source.recordCaughtUpLSN(caughtUp, slotName, true)
-		// Keep the walsender alive while the destination drains the results
-		// channel. FinalizeBatch will stop it before sending the final
-		// WALFlush-bearing standby update.
-		r.source.startKeepalive(ctx, caughtUp, startLSN)
+		// streamLoop only returns nil in batch mode once the barrier marker is
+		// decoded, so the emitted barrier is the position FinalizeBatch may
+		// confirm to the slot after the destination write is durable. It also
+		// keeps the walsender alive while the destination drains the results
+		// channel.
+		r.source.checkpointBatchBarrier(ctx, barrierLSN, startLSN, slotName)
 	}
 	return err
 }
@@ -471,7 +469,7 @@ func streamLoop(ctx context.Context, repl batchReplicator, batchSize int, accum 
 		if !streaming && repl.BarrierReached() {
 			_, pending := repl.PendingLowWater()
 			if !pending {
-				config.Debug("[CDC] Batch mode: decoded logical barrier at %s", repl.CurrentLSN())
+				config.Debug("[CDC] Batch mode: decoded logical barrier, stream position %s", repl.CurrentLSN())
 				if err := accum.flushAllContext(ctx, results, token); err != nil {
 					return err
 				}

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -629,6 +629,24 @@ func (s *PostgresCDCSource) recordCaughtUpLSN(lsn pglogrepl.LSN, slotName string
 	}
 }
 
+// checkpointBatchBarrier records the position a completed batch run may persist
+// and confirm to the slot: the LSN pg_logical_emit_message returned for this
+// run's barrier marker, and nothing beyond it. Once that marker is decoded,
+// every WAL record before it has been decoded and handed to the destination,
+// which is exactly what a resumable checkpoint must guarantee. The
+// replicator's decoded position is not interchangeable with it — it also
+// tracks protocol keepalives and server WAL head reports, so it can name a
+// position whose WAL was never persisted, and a checkpoint there would skip
+// that WAL on the next run.
+//
+// The keepalive that holds the walsender open during the destination write
+// uses the same barrier, so the position pinged mid-write and the position
+// FinalizeBatch confirms cannot diverge.
+func (s *PostgresCDCSource) checkpointBatchBarrier(ctx context.Context, barrierLSN, startLSN pglogrepl.LSN, slotName string) {
+	s.recordCaughtUpLSN(barrierLSN, slotName, true)
+	s.startKeepalive(ctx, barrierLSN, startLSN)
+}
+
 // FinalizeBatch sends a final standby status update confirming the LSN the batch
 // run caught up to. The pipeline calls it only after a successful, durable
 // write, so confirming the streamed position cannot discard WAL the destination


### PR DESCRIPTION
## What
PostgreSQL CDC batch runs previously checkpointed `max(decoded, emitted)` LSN. The protocol cursor can sit past the `pg_logical_emit_message` barrier, so a run could persist a resume point ahead of the slot. The next run then skipped WAL or fell back to a replacement snapshot.

Batch mode now persists and confirms the SQL-emitted barrier LSN only. Streaming is unchanged. WAL after the barrier may be re-delivered on the next run; that is the safe side of the trade.

## Changes
- `pkg/source/postgres_cdc/source.go` — added `checkpointBatchBarrier` to record and keepalive the emitted barrier LSN
- `pkg/source/postgres_cdc/reader.go` — single-table batch path checkpoints the barrier, not `CurrentLSN()`
- `pkg/source/postgres_cdc/multitable_reader.go` — same for the multi-table batch path
- `pkg/source/postgres_cdc/batch_barrier.go` — removed `batchCaughtUpLSN`
- `pkg/source/postgres_cdc/batch_barrier_test.go` — regression that decoded LSN past the barrier still persists the emitted LSN

## How to test
1. `go test ./pkg/source/postgres_cdc`
2. `make format && make lint && make test`

## Risk & rollback
- **Risk:** low — batch-only checkpoint bound; streaming and snapshot paths are untouched. Worst case on resume is duplicate apply of a post-barrier in-flight commit, not skipped WAL.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues