### PR TITLE
sources: bound SQL query batches by MaxBatchBytes

### DIFF
--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -974,6 +974,12 @@ func RowBytes(item map[string]interface{}) int64 {
 	return n
 }
 
+// ValueBytes returns the approximate content size of a decoded value using the
+// same estimation as RowBytes.
+func ValueBytes(v interface{}) int64 {
+	return valueLen(v)
+}
+
 func valueLen(v interface{}) int64 {
 	switch x := v.(type) {
 	case nil:

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -513,3 +513,31 @@ func TestRowBytes(t *testing.T) {
 		t.Error("cheap estimate should under-count json.Marshal (no punctuation)")
 	}
 }
+
+func TestValueBytes(t *testing.T) {
+	// ValueBytes is the per-value sizer SQL sources call per scanned column; it
+	// must agree with the per-value contribution RowBytes uses internally.
+	if got := ValueBytes(nil); got != 0 {
+		t.Errorf("nil = %d, want 0", got)
+	}
+	if got := ValueBytes(true); got != 1 {
+		t.Errorf("bool = %d, want 1", got)
+	}
+	if got := ValueBytes(int64(42)); got != 8 {
+		t.Errorf("number = %d, want 8", got)
+	}
+	if got := ValueBytes("hello"); got != int64(len("hello")) {
+		t.Errorf("string = %d, want %d", got, len("hello"))
+	}
+	if got := ValueBytes([]byte("abcd")); got != 4 {
+		t.Errorf("bytes = %d, want 4", got)
+	}
+	// larger content -> larger size
+	if ValueBytes("xxxxxxxxxx") <= ValueBytes("x") {
+		t.Error("larger value should produce a larger size")
+	}
+	// RowBytes of a single-column row equals key length + ValueBytes(value)
+	if got, want := RowBytes(map[string]interface{}{"k": "value"}), int64(len("k"))+ValueBytes("value"); got != want {
+		t.Errorf("RowBytes/ValueBytes disagree: got %d, want %d", got, want)
+	}
+}

--- a/pkg/source/adbc/batch.go
+++ b/pkg/source/adbc/batch.go
@@ -36,10 +36,9 @@ func CopyString(s string) string {
 	return string([]byte(s))
 }
 
-// RowsToArrowBatch converts sql.Rows to an Arrow record batch.
-// It reads up to batchSize rows and builds an Arrow record.
-// Returns the record, row count, and any error.
-func RowsToArrowBatch(rows *sql.Rows, arrowSchema *arrow.Schema, batchSize int) (arrow.RecordBatch, int64, error) {
+// RowsToArrowBatch converts up to batchSize SQL rows to Arrow, stopping when
+// maxBatchBytes is reached. A zero limit disables the respective bound.
+func RowsToArrowBatch(rows *sql.Rows, arrowSchema *arrow.Schema, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	numFields := arrowSchema.NumFields()
 	builders := make([]array.Builder, numFields)
@@ -49,6 +48,7 @@ func RowsToArrowBatch(rows *sql.Rows, arrowSchema *arrow.Schema, batchSize int) 
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		// Create scan destinations
 		values := make([]interface{}, numFields)
@@ -68,10 +68,16 @@ func RowsToArrowBatch(rows *sql.Rows, arrowSchema *arrow.Schema, batchSize int) 
 			// CRITICAL: Copy values to avoid ADBC Arrow buffer lifetime issues
 			actualVal = CopyValue(actualVal)
 			arrowconv.AppendValue(builders[i], actualVal)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(actualVal)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/adbc/source.go
+++ b/pkg/source/adbc/source.go
@@ -410,7 +410,7 @@ func (s *ADBCSource) ExecuteCustomQuery(ctx context.Context, query string, opts 
 		arrowSchema := BuildArrowSchema(columns)
 
 		for {
-			record, count, err := RowsToArrowBatch(rows, arrowSchema, batchSize)
+			record, count, err := RowsToArrowBatch(rows, arrowSchema, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -529,7 +529,7 @@ func (s *ADBCSource) readQuery(ctx context.Context, table string, columns []sche
 
 		for {
 			startBatch := time.Now()
-			record, count, err := RowsToArrowBatch(rows, arrowSchema, batchSize)
+			record, count, err := RowsToArrowBatch(rows, arrowSchema, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return

--- a/pkg/source/athena/athena.go
+++ b/pkg/source/athena/athena.go
@@ -188,7 +188,7 @@ func (s *AthenaSource) read(ctx context.Context, table string, tableSchema *sche
 	go func() {
 		defer close(out)
 		query := buildSelectQuery(db, tbl, columns, opts)
-		if err := s.streamQuery(ctx, query, db, arrowSchema, columns, batchSize, out); err != nil {
+		if err := s.streamQuery(ctx, query, db, arrowSchema, columns, batchSize, opts.MaxBatchBytes, out); err != nil {
 			out <- source.RecordBatchResult{Err: err}
 		}
 	}()
@@ -333,7 +333,7 @@ func (s *AthenaSource) ExecuteCustomQuery(ctx context.Context, query string, opt
 		}
 		arrowSchema := buildArrowSchema(columns)
 
-		if err := s.streamQueryFromExecID(ctx, execID, arrowSchema, columns, batchSize, out); err != nil {
+		if err := s.streamQueryFromExecID(ctx, execID, arrowSchema, columns, batchSize, opts.MaxBatchBytes, out); err != nil {
 			out <- source.RecordBatchResult{Err: err}
 		}
 	}()

--- a/pkg/source/athena/query.go
+++ b/pkg/source/athena/query.go
@@ -151,6 +151,7 @@ func (s *AthenaSource) streamQuery(
 	arrowSchema *arrow.Schema,
 	columns []schema.Column,
 	batchSize int,
+	maxBatchBytes int64,
 	out chan<- source.RecordBatchResult,
 ) error {
 	execID, err := s.startQuery(ctx, query, database)
@@ -160,7 +161,7 @@ func (s *AthenaSource) streamQuery(
 	if err := s.waitForQuery(ctx, execID); err != nil {
 		return err
 	}
-	return s.streamQueryFromExecID(ctx, execID, arrowSchema, columns, batchSize, out)
+	return s.streamQueryFromExecID(ctx, execID, arrowSchema, columns, batchSize, maxBatchBytes, out)
 }
 
 func (s *AthenaSource) streamQueryFromExecID(
@@ -169,6 +170,7 @@ func (s *AthenaSource) streamQueryFromExecID(
 	arrowSchema *arrow.Schema,
 	columns []schema.Column,
 	batchSize int,
+	maxBatchBytes int64,
 	out chan<- source.RecordBatchResult,
 ) error {
 	mem := memory.NewGoAllocator()
@@ -208,6 +210,7 @@ func (s *AthenaSource) streamQueryFromExecID(
 		skipHeader = true
 		builders   = newBuilders()
 		rowCount   int64
+		accBytes   int64
 	)
 
 	for {
@@ -248,13 +251,17 @@ func (s *AthenaSource) streamQueryFromExecID(
 						}
 						return fmt.Errorf("failed to append value for column %s: %w", columns[colIdx].Name, err)
 					}
+					if maxBatchBytes > 0 && strPtr != nil {
+						accBytes += int64(len(*strPtr))
+					}
 				}
 				rowCount++
 
-				if batchSize > 0 && rowCount >= int64(batchSize) {
+				if (batchSize > 0 && rowCount >= int64(batchSize)) || (maxBatchBytes > 0 && accBytes >= maxBatchBytes) {
 					flush(builders, rowCount)
 					builders = newBuilders()
 					rowCount = 0
+					accBytes = 0
 				}
 			}
 		}

--- a/pkg/source/clickhouse/clickhouse.go
+++ b/pkg/source/clickhouse/clickhouse.go
@@ -211,7 +211,7 @@ func (s *ClickHouseSource) read(ctx context.Context, table string, tableSchema *
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, rawTypes, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, rawTypes, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -271,7 +271,7 @@ func (s *ClickHouseSource) ExecuteCustomQuery(ctx context.Context, query string,
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, rawTypes, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, rawTypes, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -803,7 +803,7 @@ func extractValue(target interface{}) interface{} {
 	}
 }
 
-func rowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, rawTypes []string, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, rawTypes []string, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -812,6 +812,7 @@ func rowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		scanTargets := createTypedScanTargets(columns, rawTypes)
 
@@ -825,10 +826,16 @@ func rowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns
 		for i, target := range scanTargets {
 			val := extractValue(target)
 			arrowconv.AppendValue(builders[i], convertValue(val, columns[i]))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/cratedb/cratedb.go
+++ b/pkg/source/cratedb/cratedb.go
@@ -247,7 +247,7 @@ func (s *CrateDBSource) read(ctx context.Context, table string, tableSchema *sch
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -317,7 +317,7 @@ func (s *CrateDBSource) ExecuteCustomQuery(ctx context.Context, query string, op
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -412,7 +412,7 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	return query
 }
 
-func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -421,6 +421,7 @@ func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		values, err := rows.Values()
 		if err != nil {
@@ -432,10 +433,16 @@ func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []
 
 		for i, val := range values {
 			arrowconv.AppendValue(builders[i], convertValue(val))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/db2/db2.go
+++ b/pkg/source/db2/db2.go
@@ -237,7 +237,7 @@ func (s *Db2Source) read(ctx context.Context, table string, tableSchema *schema.
 		defer close(results)
 
 		query := buildSelectQueryForSchema(table, schemaToUse, columns, opts)
-		accumulator := newArrowBatchAccumulator(ctx, results, arrowSchema, columns, batchSize)
+		accumulator := newArrowBatchAccumulator(ctx, results, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 		defer accumulator.Release()
 
 		err := s.client.Stream(ctx, query, db2StreamHandler{
@@ -284,7 +284,7 @@ func (s *Db2Source) ExecuteCustomQuery(ctx context.Context, query string, opts s
 					accumulator.Release()
 				}
 				columns := db2ColumnsToSchemaColumns(db2Columns)
-				accumulator = newArrowBatchAccumulator(ctx, results, buildArrowSchema(columns), columns, batchSize)
+				accumulator = newArrowBatchAccumulator(ctx, results, buildArrowSchema(columns), columns, batchSize, opts.MaxBatchBytes)
 				return nil
 			},
 			Rows: func(rows [][]any) error {
@@ -441,30 +441,33 @@ func db2ColumnsToSchemaColumns(db2Columns []db2Column) []schema.Column {
 }
 
 type arrowBatchAccumulator struct {
-	ctx         context.Context
-	results     chan<- source.RecordBatchResult
-	arrowSchema *arrow.Schema
-	columns     []schema.Column
-	builders    []array.Builder
-	batchSize   int
-	rowCount    int64
-	totalRows   int64
-	batchCount  int
+	ctx           context.Context
+	results       chan<- source.RecordBatchResult
+	arrowSchema   *arrow.Schema
+	columns       []schema.Column
+	builders      []array.Builder
+	batchSize     int
+	maxBatchBytes int64
+	rowCount      int64
+	accBytes      int64
+	totalRows     int64
+	batchCount    int
 }
 
-func newArrowBatchAccumulator(ctx context.Context, results chan<- source.RecordBatchResult, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) *arrowBatchAccumulator {
+func newArrowBatchAccumulator(ctx context.Context, results chan<- source.RecordBatchResult, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) *arrowBatchAccumulator {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 	for i, field := range arrowSchema.Fields() {
 		builders[i] = array.NewBuilder(mem, field.Type)
 	}
 	return &arrowBatchAccumulator{
-		ctx:         ctx,
-		results:     results,
-		arrowSchema: arrowSchema,
-		columns:     columns,
-		builders:    builders,
-		batchSize:   batchSize,
+		ctx:           ctx,
+		results:       results,
+		arrowSchema:   arrowSchema,
+		columns:       columns,
+		builders:      builders,
+		batchSize:     batchSize,
+		maxBatchBytes: maxBatchBytes,
 	}
 }
 
@@ -473,7 +476,7 @@ func (a *arrowBatchAccumulator) AppendRows(rows [][]any) error {
 		if err := a.appendRow(row); err != nil {
 			return err
 		}
-		if a.rowCount >= int64(a.batchSize) {
+		if a.rowCount >= int64(a.batchSize) || (a.maxBatchBytes > 0 && a.accBytes >= a.maxBatchBytes) {
 			if err := a.Flush(); err != nil {
 				return err
 			}
@@ -491,7 +494,11 @@ func (a *arrowBatchAccumulator) appendRow(row []any) error {
 			a.builders[i].AppendNull()
 			continue
 		}
-		arrowconv.AppendValue(a.builders[i], normalizeValue(row[i], a.columns[i].DataType))
+		v := normalizeValue(row[i], a.columns[i].DataType)
+		arrowconv.AppendValue(a.builders[i], v)
+		if a.maxBatchBytes > 0 {
+			a.accBytes += arrowconv.ValueBytes(v)
+		}
 	}
 	a.rowCount++
 	return nil
@@ -509,6 +516,7 @@ func (a *arrowBatchAccumulator) Flush() error {
 
 	rows := a.rowCount
 	a.rowCount = 0
+	a.accBytes = 0
 	record := array.NewRecordBatch(a.arrowSchema, arrays, rows)
 	for _, arr := range arrays {
 		arr.Release()

--- a/pkg/source/fabric/fabric.go
+++ b/pkg/source/fabric/fabric.go
@@ -332,7 +332,7 @@ func (s *FabricSource) read(ctx context.Context, table string, tableSchema *sche
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -396,7 +396,7 @@ func (s *FabricSource) ExecuteCustomQuery(ctx context.Context, query string, opt
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -494,7 +494,7 @@ func quoteColumn(name string) string {
 	return fmt.Sprintf("[%s]", strings.ReplaceAll(name, "]", "]]"))
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -508,6 +508,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -519,10 +520,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		for i, dest := range scanDest {
 			val := *dest.(*interface{})
 			arrowconv.AppendValue(builders[i], val)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/hana/hana.go
+++ b/pkg/source/hana/hana.go
@@ -245,7 +245,7 @@ func (s *HanaSource) read(ctx context.Context, table string, tableSchema *schema
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -309,7 +309,7 @@ func (s *HanaSource) ExecuteCustomQuery(ctx context.Context, query string, opts 
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -544,7 +544,23 @@ func makeTypedAppenders(columns []schema.Column, builders []array.Builder) []typ
 	return appenders
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+// hanaScannedValueBytes measures variable-length scan destinations and counts
+// fixed-width numeric and temporal destinations as 8 bytes.
+func hanaScannedValueBytes(dest interface{}) int64 {
+	switch d := dest.(type) {
+	case *sql.NullString:
+		if d.Valid {
+			return int64(len(d.String))
+		}
+		return 0
+	case *interface{}:
+		return arrowconv.ValueBytes(*d)
+	default:
+		return 8
+	}
+}
+
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -561,6 +577,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -571,10 +588,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 
 		for i := range appenders {
 			appenders[i].append()
+			if maxBatchBytes > 0 {
+				accBytes += hanaScannedValueBytes(scanDest[i])
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/maxcompute/maxcompute.go
+++ b/pkg/source/maxcompute/maxcompute.go
@@ -163,7 +163,7 @@ func (s *MaxComputeSource) read(ctx context.Context, table string, tableSchema *
 		return s.readStorageAPI(ctx, table, columns, opts)
 	}
 	query := buildSelectQuery(table, columns, opts)
-	return s.queryToRecordBatches(ctx, query, columns, opts.PageSize)
+	return s.queryToRecordBatches(ctx, query, columns, opts.PageSize, opts.MaxBatchBytes)
 }
 
 func (s *MaxComputeSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
@@ -209,7 +209,7 @@ func (s *MaxComputeSource) ExecuteCustomQuery(ctx context.Context, query string,
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -224,7 +224,7 @@ func (s *MaxComputeSource) ExecuteCustomQuery(ctx context.Context, query string,
 	return results, nil
 }
 
-func (s *MaxComputeSource) queryToRecordBatches(ctx context.Context, query string, columns []schema.Column, batchSize int) (<-chan source.RecordBatchResult, error) {
+func (s *MaxComputeSource) queryToRecordBatches(ctx context.Context, query string, columns []schema.Column, batchSize int, maxBatchBytes int64) (<-chan source.RecordBatchResult, error) {
 	if batchSize <= 0 {
 		batchSize = 100000
 	}
@@ -242,7 +242,7 @@ func (s *MaxComputeSource) queryToRecordBatches(ctx context.Context, query strin
 		defer func() { _ = rows.Close() }()
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, maxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -495,7 +495,7 @@ func intervalLiteral(columns []schema.Column, key string, value time.Time) strin
 	return fmt.Sprintf("'%s'", value.Format("2006-01-02 15:04:05"))
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 	for i, field := range arrowSchema.Fields() {
@@ -508,6 +508,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -516,10 +517,17 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 			return nil, 0, fmt.Errorf("failed to scan row: %w", err)
 		}
 		for i, dest := range scanDest {
-			arrowconv.AppendValue(builders[i], convertValue(*dest.(*interface{})))
+			val := *dest.(*interface{})
+			arrowconv.AppendValue(builders[i], convertValue(val))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/maxcompute/maxcompute_test.go
+++ b/pkg/source/maxcompute/maxcompute_test.go
@@ -61,7 +61,7 @@ func TestRowsToArrowRecordBatchReturnsIteratorErrorBeforeFirstRow(t *testing.T) 
 	defer func() { _ = rows.Close() }()
 
 	columns := []schema.Column{{Name: "id", DataType: schema.TypeInt64, Nullable: true}}
-	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 100)
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 100, 0)
 	if !errors.Is(err, errRowsIteration) {
 		t.Fatalf("rowsToArrowRecordBatch error = %v, want %v", err, errRowsIteration)
 	}

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -595,7 +595,7 @@ func (s *MSSQLChangeTrackingSource) rowsToCTBatches(rows *sql.Rows, columns []sc
 	var totalRows int64
 
 	for {
-		record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
+		record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes, s.guidConversion)
 		if err != nil {
 			return totalRows, err
 		}

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -450,7 +450,7 @@ func (s *MSSQLSource) readQuery(ctx context.Context, table string, columns []sch
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes, s.guidConversion)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -536,7 +536,7 @@ func (s *MSSQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, s.guidConversion)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes, s.guidConversion)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -717,7 +717,7 @@ func quoteColumn(name string) string {
 	return fmt.Sprintf("[%s]", strings.ReplaceAll(name, "]", "]]"))
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, guidConversion bool) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64, guidConversion bool) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -732,6 +732,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -753,10 +754,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 				}
 			}
 			arrowconv.AppendValue(builders[i], val)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -1599,7 +1599,7 @@ func (s *MSSQLCDCSource) rowsToSnapshotBatches(ctx context.Context, rows *sql.Ro
 
 	var pending arrow.RecordBatch
 	for {
-		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, s.guidConversion, func(builders []array.Builder) {
+		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, opts.MaxBatchBytes, s.guidConversion, func(builders []array.Builder) {
 			appendCDCValues(builders, len(sourceColumns), incompleteLSN, false, syncedAt)
 		})
 		if err != nil {
@@ -1662,7 +1662,7 @@ func (s *MSSQLCDCSource) rowsToChangeBatches(ctx context.Context, rows *sql.Rows
 	}
 
 	for {
-		record, count, err := buildChangeBatch(rows, tableSchema, sourceColumns, batchSize, s.guidConversion, syncedAt, pairer)
+		record, count, err := buildChangeBatch(rows, tableSchema, sourceColumns, batchSize, opts.MaxBatchBytes, s.guidConversion, syncedAt, pairer)
 		if err != nil {
 			return err
 		}
@@ -1809,7 +1809,7 @@ func normalizeSourceValue(col schema.Column, val any, guidConversion bool) (any,
 	return normalized, nil
 }
 
-func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, guidConversion bool, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
+func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, maxBatchBytes int64, guidConversion bool, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	arrowSchema := buildArrowSchema(tableSchema.Columns)
 
@@ -1824,6 +1824,7 @@ func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			releaseBuilders(builders)
@@ -1837,6 +1838,9 @@ func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns [
 				return nil, 0, err
 			}
 			arrowconv.AppendValue(builders[i], val)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		appendCDC(builders)
 
@@ -1844,12 +1848,15 @@ func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns [
 		if batchSize > 0 && rowCount >= int64(batchSize) {
 			break
 		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
+			break
+		}
 	}
 
 	return finishBatch(rows, arrowSchema, builders, rowCount)
 }
 
-func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, guidConversion bool, syncedAt time.Time, pairer *updatePairer) (arrow.RecordBatch, int64, error) {
+func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, maxBatchBytes int64, guidConversion bool, syncedAt time.Time, pairer *updatePairer) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	arrowSchema := buildArrowSchema(tableSchema.Columns)
 
@@ -1864,6 +1871,7 @@ func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceCol
 	}
 
 	var rowCount int64
+	var accBytes int64
 	exhausted := true
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
@@ -1890,11 +1898,14 @@ func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceCol
 		for _, change := range pairer.push(values, lsn, op) {
 			for i, v := range change.values {
 				arrowconv.AppendValue(builders[i], v)
+				if maxBatchBytes > 0 {
+					accBytes += arrowconv.ValueBytes(v)
+				}
 			}
 			appendCDCValues(builders, len(sourceColumns), change.lsn, change.deleted, syncedAt)
 			rowCount++
 		}
-		if batchSize > 0 && rowCount >= int64(batchSize) {
+		if (batchSize > 0 && rowCount >= int64(batchSize)) || (maxBatchBytes > 0 && accBytes >= maxBatchBytes) {
 			exhausted = false
 			break
 		}

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -1599,8 +1599,9 @@ func (s *MSSQLCDCSource) rowsToSnapshotBatches(ctx context.Context, rows *sql.Ro
 
 	var pending arrow.RecordBatch
 	for {
-		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, opts.MaxBatchBytes, s.guidConversion, func(builders []array.Builder) {
+		record, count, err := buildBatch(rows, tableSchema, sourceColumns, batchSize, opts.MaxBatchBytes, s.guidConversion, func(builders []array.Builder) int64 {
 			appendCDCValues(builders, len(sourceColumns), incompleteLSN, false, syncedAt)
+			return cdcMetadataBytes(incompleteLSN)
 		})
 		if err != nil {
 			if pending != nil {
@@ -1809,7 +1810,7 @@ func normalizeSourceValue(col schema.Column, val any, guidConversion bool) (any,
 	return normalized, nil
 }
 
-func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, maxBatchBytes int64, guidConversion bool, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
+func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, maxBatchBytes int64, guidConversion bool, appendCDC func([]array.Builder) int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	arrowSchema := buildArrowSchema(tableSchema.Columns)
 
@@ -1842,7 +1843,10 @@ func buildBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns [
 				accBytes += arrowconv.ValueBytes(val)
 			}
 		}
-		appendCDC(builders)
+		metaBytes := appendCDC(builders)
+		if maxBatchBytes > 0 {
+			accBytes += metaBytes
+		}
 
 		rowCount++
 		if batchSize > 0 && rowCount >= int64(batchSize) {
@@ -1903,6 +1907,9 @@ func buildChangeBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceCol
 				}
 			}
 			appendCDCValues(builders, len(sourceColumns), change.lsn, change.deleted, syncedAt)
+			if maxBatchBytes > 0 {
+				accBytes += cdcMetadataBytes(change.lsn)
+			}
 			rowCount++
 		}
 		if (batchSize > 0 && rowCount >= int64(batchSize)) || (maxBatchBytes > 0 && accBytes >= maxBatchBytes) {
@@ -1956,6 +1963,13 @@ func appendCDCValues(builders []array.Builder, offset int, lsn string, deleted b
 	builders[offset].(*array.StringBuilder).Append(lsn)
 	builders[offset+1].(*array.BooleanBuilder).Append(deleted)
 	builders[offset+2].(*array.TimestampBuilder).Append(arrow.Timestamp(syncedAt.UnixMicro()))
+}
+
+// cdcMetadataBytes approximates the byte footprint of the CDC metadata columns
+// appended per row (_lsn string + _deleted bool + _synced_at timestamp) so the
+// MaxBatchBytes accounting reflects the full emitted row, not just source values.
+func cdcMetadataBytes(lsn string) int64 {
+	return int64(len(lsn)) + 1 + 8
 }
 
 func operationValue(v any) (int, error) {

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -261,6 +262,114 @@ func TestRowsToSnapshotBatchesMarksOnlyFinalBatchComplete(t *testing.T) {
 	assert.Equal(t, snapshotIncompleteLSN(snapshotLSN), stamps[1])
 	assert.Equal(t, snapshotCompleteLSN(snapshotLSN), stamps[2], "only the final batch may carry the complete stamp")
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRowsToSnapshotBatchesSplitsByMaxBatchBytes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	const rowCount = 6
+	bigName := strings.Repeat("x", 200) // each row's value bytes dwarf a tiny cap
+	mockRows := sqlmock.NewRows([]string{"id", "name"})
+	for i := 1; i <= rowCount; i++ {
+		mockRows.AddRow(int64(i), bigName)
+	}
+	mock.ExpectQuery("SELECT").WillReturnRows(mockRows)
+
+	rows, err := db.Query("SELECT")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	tableSchema := addCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, rowCount+1)
+	s := &MSSQLCDCSource{}
+
+	const snapshotLSN = "0000002F0000010D0002"
+	// PageSize huge so only the 50-byte cap can split; each 200+ byte row
+	// (source value + CDC metadata) exceeds it, so every row is its own batch.
+	err = s.rowsToSnapshotBatches(t.Context(), rows, tableSchema,
+		source.ReadOptions{PageSize: 1_000_000, MaxBatchBytes: 50}, snapshotLSN, results, "items")
+	require.NoError(t, err)
+	close(results)
+
+	var ids []int64
+	var stamps []string
+	for res := range results {
+		require.NoError(t, res.Err)
+		require.EqualValues(t, 1, res.Batch.NumRows())
+		ids = append(ids, res.Batch.Column(0).(*array.Int64).Value(0))
+		stamps = append(stamps, res.Batch.Column(2).(*array.String).Value(0))
+		res.Batch.Release()
+	}
+
+	require.Len(t, ids, rowCount, "50-byte cap must split every row into its own batch")
+	assert.Equal(t, []int64{1, 2, 3, 4, 5, 6}, ids, "byte-split batches must preserve row order and data")
+	for i := 0; i < rowCount-1; i++ {
+		assert.Equal(t, snapshotIncompleteLSN(snapshotLSN), stamps[i])
+	}
+	assert.Equal(t, snapshotCompleteLSN(snapshotLSN), stamps[rowCount-1],
+		"only the final byte-split batch may carry the complete stamp")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRowsToSnapshotBatchesCountsCDCMetadataTowardCap(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	const rowCount = 6
+	mockRows := sqlmock.NewRows([]string{"id", "name"})
+	for i := 1; i <= rowCount; i++ {
+		mockRows.AddRow(int64(i), "") // ~8 source bytes/row; only metadata can tip the cap
+	}
+	mock.ExpectQuery("SELECT").WillReturnRows(mockRows)
+
+	rows, err := db.Query("SELECT")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	tableSchema := addCDCColumns(&schema.TableSchema{
+		Name: "items",
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+			{Name: "name", DataType: schema.TypeString, Nullable: true},
+		},
+		PrimaryKeys: []string{"id"},
+	})
+	results := make(chan source.RecordBatchResult, rowCount+1)
+	s := &MSSQLCDCSource{}
+
+	const snapshotLSN = "0000002F0000010D0002"
+	// Cap == the per-row CDC metadata size. A row's ~8 source bytes are below it,
+	// so batches split one-per-row only if metadata is counted toward the cap.
+	cap := cdcMetadataBytes(snapshotIncompleteLSN(snapshotLSN))
+	require.Greater(t, cap, int64(8), "metadata must exceed the source value bytes for this test to be meaningful")
+
+	err = s.rowsToSnapshotBatches(t.Context(), rows, tableSchema,
+		source.ReadOptions{PageSize: 1_000_000, MaxBatchBytes: cap}, snapshotLSN, results, "items")
+	require.NoError(t, err)
+	close(results)
+
+	batches := 0
+	total := int64(0)
+	for res := range results {
+		require.NoError(t, res.Err)
+		batches++
+		total += res.Batch.NumRows()
+		res.Batch.Release()
+	}
+
+	assert.Equal(t, int64(rowCount), total, "all rows preserved")
+	assert.Equal(t, rowCount, batches,
+		"metadata bytes must be counted: without them, ~8-byte rows would pack many per batch")
 }
 
 func TestRowsToSnapshotBatchesReturnsIteratorErrorForEmptyBatch(t *testing.T) {

--- a/pkg/source/mysql/arrow_value_test.go
+++ b/pkg/source/mysql/arrow_value_test.go
@@ -55,7 +55,7 @@ func TestDriverRowsToArrowRecordBatch(t *testing.T) {
 		},
 	}
 	dataCapacities := make([]int, len(columns))
-	record, count, err := driverRowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 25_000, dataCapacities)
+	record, count, err := driverRowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 25_000, 0, dataCapacities)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,6 +90,51 @@ func TestDriverRowsToArrowRecordBatch(t *testing.T) {
 	}
 	if dataCapacities[1] == 0 || dataCapacities[6] == 0 {
 		t.Fatalf("variable-width capacities were not recorded: %v", dataCapacities)
+	}
+}
+
+func TestDriverRowsToArrowRecordBatchByteCap(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id", DataType: schema.TypeInt64},
+		{Name: "blob", DataType: schema.TypeString},
+	}
+	// Each row carries ~1 KiB of string payload.
+	payload := make([]byte, 1024)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	values := make([][]driver.Value, 0, 10)
+	for i := 0; i < 10; i++ {
+		values = append(values, []driver.Value{int64(i), append([]byte(nil), payload...)})
+	}
+	newRows := func() *testDriverRows {
+		return &testDriverRows{columns: []string{"id", "blob"}, values: values}
+	}
+
+	// Byte cap disabled: the whole result set comes back in one batch (batchSize is large).
+	dc := make([]int, len(columns))
+	rec, count, err := driverRowsToArrowRecordBatch(newRows(), buildArrowSchema(columns), columns, 25_000, 0, dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Release()
+	if count != 10 {
+		t.Fatalf("uncapped count = %d, want 10", count)
+	}
+
+	// Byte cap of ~2 KiB: append-then-break flushes after the accumulated payload
+	// crosses the cap, so a single call returns far fewer than 10 rows.
+	dc = make([]int, len(columns))
+	rec, capped, err := driverRowsToArrowRecordBatch(newRows(), buildArrowSchema(columns), columns, 25_000, 2048, dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Release()
+	if capped == 0 || capped >= count {
+		t.Fatalf("capped count = %d, want a partial batch (0 < n < %d)", capped, count)
+	}
+	if capped > 3 {
+		t.Fatalf("capped count = %d, want ~2 rows for a 2 KiB cap over 1 KiB rows", capped)
 	}
 }
 

--- a/pkg/source/mysql/cdc.go
+++ b/pkg/source/mysql/cdc.go
@@ -2661,7 +2661,7 @@ func rowsToMySQLCDCSnapshotBatches(rows *sql.Rows, tableSchema *schema.TableSche
 	syncedAt := time.Now().UTC()
 
 	for {
-		record, count, err := buildMySQLCDCSQLBatch(rows, tableSchema, sourceColumns, batchSize, func(builders []array.Builder) {
+		record, count, err := buildMySQLCDCSQLBatch(rows, tableSchema, sourceColumns, batchSize, opts.MaxBatchBytes, func(builders []array.Builder) {
 			appendMySQLCDCValues(builders, len(sourceColumns), cdcLSN, false, syncedAt)
 		})
 		if err != nil {
@@ -2674,7 +2674,7 @@ func rowsToMySQLCDCSnapshotBatches(rows *sql.Rows, tableSchema *schema.TableSche
 	}
 }
 
-func buildMySQLCDCSQLBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
+func buildMySQLCDCSQLBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sourceColumns []schema.Column, batchSize int, maxBatchBytes int64, appendCDC func([]array.Builder)) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	arrowSchema := buildArrowSchema(tableSchema.Columns)
 
@@ -2689,6 +2689,7 @@ func buildMySQLCDCSQLBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sour
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			releaseMySQLCDCBuilders(builders)
@@ -2702,11 +2703,17 @@ func buildMySQLCDCSQLBatch(rows *sql.Rows, tableSchema *schema.TableSchema, sour
 				return nil, 0, err
 			}
 			arrowconv.AppendValue(builders[i], convertMySQLCDCValue(value, sourceColumns[i]))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(value)
+			}
 		}
 		appendCDC(builders)
 
 		rowCount++
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/mysql/mysql.go
+++ b/pkg/source/mysql/mysql.go
@@ -432,7 +432,7 @@ func (s *MySQLSource) readQuery(ctx context.Context, table string, columns []sch
 		defer close(results)
 
 		query := buildSelectQuery(table, columns, opts)
-		usedDirect, err := s.readQueryDirect(ctx, query, columns, arrowSchema, batchSize, startTotal, results)
+		usedDirect, err := s.readQueryDirect(ctx, query, columns, arrowSchema, batchSize, opts.MaxBatchBytes, startTotal, results)
 		if usedDirect {
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
@@ -462,7 +462,7 @@ func (s *MySQLSource) readQuery(ctx context.Context, table string, columns []sch
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -487,7 +487,7 @@ func (s *MySQLSource) readQuery(ctx context.Context, table string, columns []sch
 
 var errDirectDriverRowsUnsupported = errors.New("direct driver rows unsupported")
 
-func (s *MySQLSource) readQueryDirect(ctx context.Context, query string, columns []schema.Column, arrowSchema *arrow.Schema, batchSize int, startTotal time.Time, results chan<- source.RecordBatchResult) (bool, error) {
+func (s *MySQLSource) readQueryDirect(ctx context.Context, query string, columns []schema.Column, arrowSchema *arrow.Schema, batchSize int, maxBatchBytes int64, startTotal time.Time, results chan<- source.RecordBatchResult) (bool, error) {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return true, fmt.Errorf("failed to acquire connection: %w", err)
@@ -529,7 +529,7 @@ func (s *MySQLSource) readQueryDirect(ctx context.Context, query string, columns
 		allocator := newMySQLArrowAllocator()
 		for {
 			startBatch := time.Now()
-			record, count, err := driverRowsToArrowRecordBatchWithAllocator(rows, arrowSchema, columns, batchSize, dataCapacities, allocator)
+			record, count, err := driverRowsToArrowRecordBatchWithAllocator(rows, arrowSchema, columns, batchSize, maxBatchBytes, dataCapacities, allocator)
 			if err != nil {
 				return err
 			}
@@ -672,7 +672,7 @@ func (s *MySQLSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -796,7 +796,7 @@ func quoteColumn(name string) string {
 	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -814,6 +814,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -824,10 +825,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 
 		for i, dest := range scanDest {
 			appendMySQLScannedValue(builders[i], dest)
+			if maxBatchBytes > 0 {
+				accBytes += mysqlScannedValueBytes(dest)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}
@@ -861,11 +868,11 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	return record, rowCount, nil
 }
 
-func driverRowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, dataCapacities []int) (arrow.RecordBatch, int64, error) {
-	return driverRowsToArrowRecordBatchWithAllocator(rows, arrowSchema, columns, batchSize, dataCapacities, newMySQLArrowAllocator())
+func driverRowsToArrowRecordBatch(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64, dataCapacities []int) (arrow.RecordBatch, int64, error) {
+	return driverRowsToArrowRecordBatchWithAllocator(rows, arrowSchema, columns, batchSize, maxBatchBytes, dataCapacities, newMySQLArrowAllocator())
 }
 
-func driverRowsToArrowRecordBatchWithAllocator(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, dataCapacities []int, mem memory.Allocator) (arrow.RecordBatch, int64, error) {
+func driverRowsToArrowRecordBatchWithAllocator(rows driver.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64, dataCapacities []int, mem memory.Allocator) (arrow.RecordBatch, int64, error) {
 	builders := make([]array.Builder, len(columns))
 	for i, field := range arrowSchema.Fields() {
 		builders[i] = array.NewBuilder(mem, field.Type)
@@ -888,6 +895,7 @@ func driverRowsToArrowRecordBatchWithAllocator(rows driver.Rows, arrowSchema *ar
 
 	values := make([]driver.Value, len(columns))
 	var rowCount int64
+	var accBytes int64
 	for batchSize <= 0 || rowCount < int64(batchSize) {
 		err := rows.Next(values)
 		if errors.Is(err, io.EOF) {
@@ -899,8 +907,14 @@ func driverRowsToArrowRecordBatchWithAllocator(rows driver.Rows, arrowSchema *ar
 		}
 		for i, value := range values {
 			appenders[i](value)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(value)
+			}
 		}
 		rowCount++
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
+			break
+		}
 	}
 
 	if rowCount == 0 {
@@ -1221,6 +1235,19 @@ func appendMySQLScannedValue(builder array.Builder, dest interface{}) {
 		return
 	}
 	appendMySQLValue(builder, *dest.(*interface{}))
+}
+
+// mysqlScannedValueBytes measures the scan destinations produced by
+// mysqlScanDestination.
+func mysqlScannedValueBytes(dest interface{}) int64 {
+	switch d := dest.(type) {
+	case *sql.RawBytes:
+		return int64(len(*d))
+	case *interface{}:
+		return arrowconv.ValueBytes(*d)
+	default:
+		return 8
+	}
 }
 
 func appendMySQLValue(builder array.Builder, val interface{}) {

--- a/pkg/source/oracle/oracle.go
+++ b/pkg/source/oracle/oracle.go
@@ -366,7 +366,7 @@ func (s *OracleSource) read(ctx context.Context, table string, tableSchema *sche
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -430,7 +430,7 @@ func (s *OracleSource) ExecuteCustomQuery(ctx context.Context, query string, opt
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -532,7 +532,7 @@ func quoteTable(table string) string {
 	return quoteIdentifier(strings.ToUpper(table))
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -546,6 +546,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -557,10 +558,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		for i, dest := range scanDest {
 			val := *dest.(*interface{})
 			arrowconv.AppendValue(builders[i], val)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -298,7 +298,7 @@ func (s *PostgresSource) readQuery(ctx context.Context, table string, columns []
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -435,7 +435,7 @@ func (s *PostgresSource) ExecuteCustomQuery(ctx context.Context, query string, o
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -528,7 +528,7 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	return query
 }
 
-func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -556,16 +556,26 @@ func rowsToArrowRecordBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
-		if err := appendPostgresRawRow(appenders, builders, rows.RawValues()); err != nil {
+		raw := rows.RawValues()
+		if err := appendPostgresRawRow(appenders, builders, raw); err != nil {
 			for _, b := range builders {
 				b.Release()
 			}
 			return nil, 0, err
 		}
 		rowCount++
+		if maxBatchBytes > 0 {
+			for _, rv := range raw {
+				accBytes += int64(len(rv))
+			}
+		}
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/postgres/postgres_benchmark_test.go
+++ b/pkg/source/postgres/postgres_benchmark_test.go
@@ -151,7 +151,7 @@ func BenchmarkPostgresRowBatchToArrow(b *testing.B) {
 			rows := &syntheticBenchmarkRows{
 				fields: fields, values: values, typeMap: pgtype.NewMap(), rows: benchmarkPostgresBatchSize,
 			}
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, benchmarkPostgresBatchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, benchmarkPostgresBatchSize, 0)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -289,7 +289,7 @@ func TestPostgresRawBatchMatchesLegacyForBenchmarkTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer legacy.Release()
-	optimized, _, err := rowsToArrowRecordBatch(rawRows, arrowSchema, columns, 1)
+	optimized, _, err := rowsToArrowRecordBatch(rawRows, arrowSchema, columns, 1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/source/postgres/raw_decoder_test.go
+++ b/pkg/source/postgres/raw_decoder_test.go
@@ -82,7 +82,7 @@ func TestRowsToArrowRecordBatchUsesRawPostgresValues(t *testing.T) {
 		},
 	}
 
-	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 25_000)
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 25_000, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestRowsToArrowRecordBatchHandlesBinaryPostgresValues(t *testing.T) {
 		}},
 	}
 
-	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 1)
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/source/postgres_cdc/snapshot.go
+++ b/pkg/source/postgres_cdc/snapshot.go
@@ -279,7 +279,7 @@ func (s *Snapshot) readWithSnapshot(ctx context.Context, snapshotName string, ls
 	var totalRows int64
 
 	for {
-		record, count, err := s.rowsToBatch(rows, arrowSchema, sourceColumns, batchSize, lsnStr, syncedAt)
+		record, count, err := s.rowsToBatch(rows, arrowSchema, sourceColumns, batchSize, opts.MaxBatchBytes, lsnStr, syncedAt)
 		if err != nil {
 			return fmt.Errorf("failed to convert rows to batch: %w", err)
 		}
@@ -301,7 +301,7 @@ func (s *Snapshot) readWithSnapshot(ctx context.Context, snapshotName string, ls
 	return nil
 }
 
-func (s *Snapshot) rowsToBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, lsn string, syncedAt time.Time) (arrow.RecordBatch, int64, error) {
+func (s *Snapshot) rowsToBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64, lsn string, syncedAt time.Time) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 
 	// Create builders for all columns including CDC columns
@@ -311,6 +311,7 @@ func (s *Snapshot) rowsToBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		values, err := rows.Values()
 		if err != nil {
@@ -330,6 +331,9 @@ func (s *Snapshot) rowsToBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns
 				return nil, 0, fmt.Errorf("failed to convert snapshot column %q: %w", columns[i].Name, err)
 			}
 			arrowconv.AppendValue(builders[i], converted)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 
 		builders[len(columns)].(*array.StringBuilder).Append(lsn)
@@ -340,6 +344,9 @@ func (s *Snapshot) rowsToBatch(rows pgx.Rows, arrowSchema *arrow.Schema, columns
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/postgres_cdc/snapshot_value_test.go
+++ b/pkg/source/postgres_cdc/snapshot_value_test.go
@@ -80,6 +80,7 @@ func TestSnapshotRowsToBatchDoesNotTreatFirstRowDecodeErrorAsEmpty(t *testing.T)
 		buildArrowSchema(columns),
 		columns[:1],
 		100,
+		0,
 		"0/1",
 		time.Now(),
 	)

--- a/pkg/source/spanner/spanner.go
+++ b/pkg/source/spanner/spanner.go
@@ -358,7 +358,7 @@ func (s *SpannerSource) read(ctx context.Context, table string, tableSchema *sch
 
 		for {
 			startBatch := time.Now()
-			record, count, err := s.rowsToArrowBatch(iter, arrowSchema, columns, batchSize)
+			record, count, err := s.rowsToArrowBatch(iter, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -381,7 +381,7 @@ func (s *SpannerSource) read(ctx context.Context, table string, tableSchema *sch
 	return results, nil
 }
 
-func (s *SpannerSource) rowsToArrowBatch(iter *spanner.RowIterator, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func (s *SpannerSource) rowsToArrowBatch(iter *spanner.RowIterator, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 	for i, field := range arrowSchema.Fields() {
@@ -389,6 +389,7 @@ func (s *SpannerSource) rowsToArrowBatch(iter *spanner.RowIterator, arrowSchema 
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for {
 		row, err := iter.Next()
 		if err == iterator.Done {
@@ -404,10 +405,16 @@ func (s *SpannerSource) rowsToArrowBatch(iter *spanner.RowIterator, arrowSchema 
 		for i := range columns {
 			val := extractColumnValue(row, i, columns[i])
 			arrowconv.AppendValue(builders[i], val)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}
@@ -629,13 +636,50 @@ func (s *SpannerSource) ExecuteCustomQuery(ctx context.Context, query string, op
 		for i, field := range arrowSchema.Fields() {
 			builders[i] = array.NewBuilder(mem, field.Type)
 		}
+		defer func() {
+			for _, builder := range builders {
+				builder.Release()
+			}
+		}()
 
-		// Process first row
-		for i := range columns {
-			val := extractColumnValue(firstRow, i, columns[i])
-			arrowconv.AppendValue(builders[i], val)
+		var rowCount int64
+		var accBytes int64
+		appendRow := func(row *spanner.Row) {
+			for i := range columns {
+				val := extractColumnValue(row, i, columns[i])
+				arrowconv.AppendValue(builders[i], val)
+				if opts.MaxBatchBytes > 0 {
+					accBytes += arrowconv.ValueBytes(val)
+				}
+			}
+			rowCount++
 		}
-		rowCount := int64(1)
+		shouldFlush := func() bool {
+			return rowCount >= int64(batchSize) || (opts.MaxBatchBytes > 0 && accBytes >= opts.MaxBatchBytes)
+		}
+		flush := func() {
+			arrays := make([]arrow.Array, len(builders))
+			for i, builder := range builders {
+				arrays[i] = builder.NewArray()
+			}
+			record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
+			for _, arr := range arrays {
+				arr.Release()
+			}
+			results <- source.RecordBatchResult{Batch: record}
+
+			for i, builder := range builders {
+				builder.Release()
+				builders[i] = array.NewBuilder(mem, arrowSchema.Field(i).Type)
+			}
+			rowCount = 0
+			accBytes = 0
+		}
+
+		appendRow(firstRow)
+		if shouldFlush() {
+			flush()
+		}
 
 		for {
 			row, err := iter.Next()
@@ -643,50 +687,18 @@ func (s *SpannerSource) ExecuteCustomQuery(ctx context.Context, query string, op
 				break
 			}
 			if err != nil {
-				for _, b := range builders {
-					b.Release()
-				}
 				results <- source.RecordBatchResult{Err: err}
 				return
 			}
 
-			for i := range columns {
-				val := extractColumnValue(row, i, columns[i])
-				arrowconv.AppendValue(builders[i], val)
-			}
-			rowCount++
-
-			if rowCount >= int64(batchSize) {
-				arrays := make([]arrow.Array, len(builders))
-				for i, b := range builders {
-					arrays[i] = b.NewArray()
-				}
-				record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
-				for _, arr := range arrays {
-					arr.Release()
-				}
-				results <- source.RecordBatchResult{Batch: record}
-
-				// Reset for next batch
-				for i, b := range builders {
-					b.Release()
-					builders[i] = array.NewBuilder(mem, arrowSchema.Field(i).Type)
-				}
-				rowCount = 0
+			appendRow(row)
+			if shouldFlush() {
+				flush()
 			}
 		}
 
 		if rowCount > 0 {
-			arrays := make([]arrow.Array, len(builders))
-			for i, b := range builders {
-				arrays[i] = b.NewArray()
-				b.Release()
-			}
-			record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
-			for _, arr := range arrays {
-				arr.Release()
-			}
-			results <- source.RecordBatchResult{Batch: record}
+			flush()
 		}
 	}()
 

--- a/pkg/source/sqlite/sqlite.go
+++ b/pkg/source/sqlite/sqlite.go
@@ -213,7 +213,7 @@ func (s *SQLiteSource) readQuery(ctx context.Context, table string, columns []sc
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -301,7 +301,7 @@ func (s *SQLiteSource) ExecuteCustomQuery(ctx context.Context, query string, opt
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -388,7 +388,7 @@ func buildSelectQuery(table string, columns []schema.Column, opts source.ReadOpt
 	return query
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -402,6 +402,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -413,10 +414,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		for i, dest := range scanDest {
 			val := *dest.(*interface{})
 			arrowconv.AppendValue(builders[i], convertValue(val, columns[i]))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/sqlite/sqlite_test.go
+++ b/pkg/source/sqlite/sqlite_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -200,6 +201,49 @@ func TestCustomQueryExtractPartitioning(t *testing.T) {
 		result.Batch.Release()
 	}
 	assert.Equal(t, int64(4), rowCount)
+}
+
+func TestReadRespectsMaxBatchBytes(t *testing.T) {
+	ctx := context.Background()
+	src := NewSQLiteSource()
+	uri := "sqlite:///" + filepath.Join(t.TempDir(), "source.db")
+	require.NoError(t, src.Connect(ctx, uri))
+	t.Cleanup(func() { require.NoError(t, src.Close(ctx)) })
+
+	_, err := src.db.ExecContext(ctx, `CREATE TABLE wide (id INTEGER, blob TEXT);`)
+	require.NoError(t, err)
+
+	const rowCount = 20
+	payload := strings.Repeat("x", 1024) // ~1 KiB per row
+	for i := 0; i < rowCount; i++ {
+		_, err := src.db.ExecContext(ctx, `INSERT INTO wide VALUES (?, ?);`, i, payload)
+		require.NoError(t, err)
+	}
+
+	read := func(maxBatchBytes int64) (batches int, total int64) {
+		table, err := src.GetTable(ctx, source.TableRequest{Name: "wide"})
+		require.NoError(t, err)
+		records, err := table.Read(ctx, source.ReadOptions{MaxBatchBytes: maxBatchBytes})
+		require.NoError(t, err)
+		for result := range records {
+			require.NoError(t, result.Err)
+			batches++
+			total += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+		return batches, total
+	}
+
+	// No cap: one page holds all 20 rows in a single batch.
+	uncappedBatches, uncappedTotal := read(0)
+	assert.Equal(t, int64(rowCount), uncappedTotal)
+	assert.Equal(t, 1, uncappedBatches)
+
+	// ~4 KiB cap over ~1 KiB rows forces the reader to flush several batches,
+	// while still delivering every row exactly once.
+	cappedBatches, cappedTotal := read(4096)
+	assert.Equal(t, int64(rowCount), cappedTotal)
+	assert.Greater(t, cappedBatches, 1, "byte cap should split the read into multiple batches")
 }
 
 func TestExtractTableName(t *testing.T) {

--- a/pkg/source/starrocks/starrocks.go
+++ b/pkg/source/starrocks/starrocks.go
@@ -233,7 +233,7 @@ func (s *StarRocksSource) read(ctx context.Context, table string, tableSchema *s
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -283,7 +283,7 @@ func (s *StarRocksSource) ExecuteCustomQuery(ctx context.Context, query string, 
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -387,7 +387,7 @@ func buildArrowSchema(columns []schema.Column) *arrow.Schema {
 	return arrow.NewSchema(fields, nil)
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -401,6 +401,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -412,10 +413,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		for i, dest := range scanDest {
 			val := *dest.(*interface{})
 			arrowconv.AppendValue(builders[i], convertValue(val))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/pkg/source/trino/trino.go
+++ b/pkg/source/trino/trino.go
@@ -194,7 +194,7 @@ func (s *TrinoSource) read(ctx context.Context, table string, tableSchema *schem
 
 		for {
 			startBatch := time.Now()
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -258,7 +258,7 @@ func (s *TrinoSource) ExecuteCustomQuery(ctx context.Context, query string, opts
 		arrowSchema := buildArrowSchema(columns)
 
 		for {
-			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize)
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
 			if err != nil {
 				results <- source.RecordBatchResult{Err: err}
 				return
@@ -376,7 +376,7 @@ func buildArrowSchema(columns []schema.Column) *arrow.Schema {
 	return arrow.NewSchema(fields, nil)
 }
 
-func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int) (arrow.RecordBatch, int64, error) {
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
 	mem := memory.NewGoAllocator()
 	builders := make([]array.Builder, len(columns))
 
@@ -390,6 +390,7 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 	}
 
 	var rowCount int64
+	var accBytes int64
 	for rows.Next() {
 		if err := rows.Scan(scanDest...); err != nil {
 			for _, b := range builders {
@@ -401,10 +402,16 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		for i, dest := range scanDest {
 			val := *dest.(*interface{})
 			arrowconv.AppendValue(builders[i], convertValue(val, columns[i]))
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
 		}
 		rowCount++
 
 		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
 			break
 		}
 	}

--- a/tests/integration/max_batch_bytes_remaining_live_test.go
+++ b/tests/integration/max_batch_bytes_remaining_live_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	databaseadmin "cloud.google.com/go/spanner/admin/database/apiv1"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	instanceadmin "cloud.google.com/go/spanner/admin/instance/apiv1"
+	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/bruin-data/ingestr/internal/uri"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestMSSQLChangeTrackingMaxBatchBytesLive(t *testing.T) {
+	ctx := context.Background()
+	dbName, db := setupMSSQLCTDatabase(t, ctx)
+	createMSSQLCTItemsTable(t, ctx, db)
+	sourceURI := mssqlURIForDatabase(t, mssqlDest.uri, "mssql+ct", dbName, nil)
+	assertRemainingLiveBatchRows(t, sourceURI, "dbo.items", "", 3)
+
+	var version int64
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT CHANGE_TRACKING_CURRENT_VERSION()`).Scan(&version))
+	_, err := db.ExecContext(ctx, `INSERT INTO dbo.items (id, name, value) VALUES
+		(4, N'item4', 400), (5, N'item5', 500), (6, N'item6', 600),
+		(7, N'item7', 700), (8, N'item8', 800)`)
+	require.NoError(t, err)
+	assertRemainingLiveBatchRows(t, sourceURI, "dbo.items", fmt.Sprintf("%020d", version), 5)
+}
+
+func TestSpannerMaxBatchBytesLive(t *testing.T) {
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "gcr.io/cloud-spanner-emulator/emulator:latest",
+			ExposedPorts: []string{"9010/tcp", "9020/tcp"},
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort("9010/tcp"),
+				wait.ForLog("gRPC server listening at 0.0.0.0:9010"),
+			).WithStartupTimeoutDefault(120 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	grpcPort, err := container.MappedPort(ctx, "9010")
+	require.NoError(t, err)
+	t.Setenv("SPANNER_EMULATOR_HOST", fmt.Sprintf("%s:%s", host, grpcPort.Port()))
+
+	instanceClient, err := instanceadmin.NewInstanceAdminClient(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = instanceClient.Close() })
+	instancePath := "projects/test-project/instances/test-instance"
+	instanceOp, err := instanceClient.CreateInstance(ctx, &instancepb.CreateInstanceRequest{
+		Parent:     "projects/test-project",
+		InstanceId: "test-instance",
+		Instance: &instancepb.Instance{
+			Name: instancePath, Config: "projects/test-project/instanceConfigs/emulator-config",
+			DisplayName: "test-instance", NodeCount: 1,
+		},
+	})
+	require.NoError(t, err)
+	_, err = instanceOp.Wait(ctx)
+	require.NoError(t, err)
+
+	databaseClient, err := databaseadmin.NewDatabaseAdminClient(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = databaseClient.Close() })
+	databaseOp, err := databaseClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+		Parent:          instancePath,
+		CreateStatement: "CREATE DATABASE `test-db`",
+		ExtraStatements: []string{"CREATE TABLE Probe (Id INT64 NOT NULL, Payload STRING(256)) PRIMARY KEY (Id)"},
+	})
+	require.NoError(t, err)
+	database, err := databaseOp.Wait(ctx)
+	require.NoError(t, err)
+
+	dataClient, err := spanner.NewClient(ctx, database.Name)
+	require.NoError(t, err)
+	t.Cleanup(dataClient.Close)
+	mutations := make([]*spanner.Mutation, 5)
+	for i := range mutations {
+		mutations[i] = spanner.Insert("Probe", []string{"Id", "Payload"}, []interface{}{int64(i + 1), strings.Repeat("x", 256)})
+	}
+	_, err = dataClient.Apply(ctx, mutations)
+	require.NoError(t, err)
+
+	assertRemainingLiveBatchRows(t,
+		"spanner://?project_id=test-project&instance_id=test-instance&database=test-db", "Probe", "", 5)
+}
+
+func assertRemainingLiveBatchRows(t *testing.T, sourceURI, tableName, resumeLSN string, expectedRows int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	src, err := uri.DefaultRegistry.GetSource(sourceURI)
+	require.NoError(t, err)
+	require.NoError(t, src.Connect(ctx, sourceURI))
+	t.Cleanup(func() { _ = src.Close(context.Background()) })
+	table, err := src.GetTable(ctx, source.TableRequest{Name: tableName})
+	require.NoError(t, err)
+	records, err := table.Read(ctx, source.ReadOptions{PageSize: 1000, MaxBatchBytes: 1, CDCResumeLSN: resumeLSN})
+	require.NoError(t, err)
+	rows := make([]int64, 0, expectedRows)
+	for result := range records {
+		require.NoError(t, result.Err)
+		if result.Batch == nil {
+			continue
+		}
+		rows = append(rows, result.Batch.NumRows())
+		result.Batch.Release()
+	}
+	require.Len(t, rows, expectedRows)
+	for _, count := range rows {
+		require.Equal(t, int64(1), count)
+	}
+}


### PR DESCRIPTION
Adds the configured `MaxBatchBytes` soft flush threshold to query-based SQL readers and CDC snapshot/polling batches. Each reader appends a complete row, then flushes when its approximate accumulated content size reaches the threshold; existing row-count limits still apply.

Covered paths include:
- shared ADBC SQL reads and custom queries;
- Athena, ClickHouse, CrateDB, DB2, Fabric, HANA, MaxCompute SQL, MSSQL/change tracking/CDC, MySQL, Oracle, PostgreSQL, Spanner, SQLite, StarRocks, and Trino;
- MySQL and PostgreSQL CDC snapshots;
- Redshift and Vitess indirectly through PostgreSQL and MySQL.

Native/prebuilt Arrow paths are intentionally outside this PR: BigQuery Storage API, Snowflake native Arrow, MaxCompute Storage API, Databricks, and live MySQL/PostgreSQL CDC accumulation.
