### PR TITLE
sources: bound deel, csv, and mongodb batches by MaxBatchBytes

### DIFF
--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -961,11 +961,8 @@ func marshalJSON(v interface{}) ([]byte, error) {
 	return b, nil
 }
 
-// RowBytes returns an approximate byte size of a decoded row: the sum of key
-// and value content lengths. Sources use it to bound a batch by size (not just
-// row count) without allocating. It ignores JSON structure (punctuation, number
-// formatting), so it under-counts somewhat — acceptable because the byte limit
-// is a soft bound, not an exact target.
+// RowBytes returns an approximate byte size of a decoded row (sum of key and
+// value content lengths), used to bound a batch by size as a soft limit.
 func RowBytes(item map[string]interface{}) int64 {
 	var n int64
 	for k, v := range item {
@@ -974,12 +971,8 @@ func RowBytes(item map[string]interface{}) int64 {
 	return n
 }
 
-// CellsBytes approximates the content size of a row-oriented record whose values
-// are already raw string cells (e.g. a CSV record). It is the []string analog of
-// RowBytes: sources use it to bound a batch by size without allocating a map just
-// to measure it. Each cell is measured through valueLen so the per-value byte
-// rule stays single-sourced; column names are fixed header metadata, not per-row
-// payload, so only cell content is counted.
+// CellsBytes is the []string analog of RowBytes for raw CSV cells: it sums each
+// cell through valueLen so the per-value byte rule stays single-sourced.
 func CellsBytes(cells []string) int64 {
 	var n int64
 	for _, cell := range cells {

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -974,6 +974,20 @@ func RowBytes(item map[string]interface{}) int64 {
 	return n
 }
 
+// CellsBytes approximates the content size of a row-oriented record whose values
+// are already raw string cells (e.g. a CSV record). It is the []string analog of
+// RowBytes: sources use it to bound a batch by size without allocating a map just
+// to measure it. Each cell is measured through valueLen so the per-value byte
+// rule stays single-sourced; column names are fixed header metadata, not per-row
+// payload, so only cell content is counted.
+func CellsBytes(cells []string) int64 {
+	var n int64
+	for _, cell := range cells {
+		n += valueLen(cell)
+	}
+	return n
+}
+
 func valueLen(v interface{}) int64 {
 	switch x := v.(type) {
 	case nil:

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -961,8 +961,11 @@ func marshalJSON(v interface{}) ([]byte, error) {
 	return b, nil
 }
 
-// RowBytes returns an approximate byte size of a decoded row (sum of key and
-// value content lengths), used to bound a batch by size as a soft limit.
+// RowBytes returns an approximate byte size of a decoded row: the sum of key
+// and value content lengths. Sources use it to bound a batch by size (not just
+// row count) without allocating. It ignores JSON structure (punctuation, number
+// formatting), so it under-counts somewhat — acceptable because the byte limit
+// is a soft bound, not an exact target.
 func RowBytes(item map[string]interface{}) int64 {
 	var n int64
 	for k, v := range item {

--- a/pkg/source/applovinmax/applovinmax.go
+++ b/pkg/source/applovinmax/applovinmax.go
@@ -631,8 +631,7 @@ func lastNonEmptyCSVValue(record []string, indexes []int) (string, bool) {
 }
 
 // estimateCSVRowBytes approximates a row's content size for the byte-bounded
-// batcher: the CSV cells (via the shared arrowconv estimator) plus the injected
-// partition_date/platform values.
+// batcher: the CSV cells plus the injected partition_date/platform values.
 func estimateCSVRowBytes(record []string, date, platform string) int64 {
 	return arrowconv.CellsBytes(record) + int64(len(date)+len(platform))
 }

--- a/pkg/source/applovinmax/applovinmax.go
+++ b/pkg/source/applovinmax/applovinmax.go
@@ -584,7 +584,7 @@ func streamCSV(
 			break
 		}
 
-		rowBytes := estimateCSVRowBytes(headers, record, date, platform)
+		rowBytes := estimateCSVRowBytes(record, date, platform)
 		if builder.rows > 0 && (builder.rows >= batchRows || builder.bytes+rowBytes > batchBytes) {
 			if err := flush(); err != nil {
 				return totalRows, err
@@ -630,15 +630,11 @@ func lastNonEmptyCSVValue(record []string, indexes []int) (string, bool) {
 	return "", false
 }
 
-func estimateCSVRowBytes(headers, record []string, date, platform string) int64 {
-	size := int64(len("partition_date") + len(date) + len("platform") + len(platform))
-	for i, value := range record {
-		if i >= len(headers) {
-			break
-		}
-		size += int64(len(headers[i]) + len(strings.TrimSpace(value)))
-	}
-	return size
+// estimateCSVRowBytes approximates a row's content size for the byte-bounded
+// batcher: the CSV cells (via the shared arrowconv estimator) plus the injected
+// partition_date/platform values.
+func estimateCSVRowBytes(record []string, date, platform string) int64 {
+	return arrowconv.CellsBytes(record) + int64(len(date)+len(platform))
 }
 
 func resolveDateRange(intervalStart, intervalEnd interface{}) (time.Time, time.Time) {

--- a/pkg/source/applovinmax/applovinmax_test.go
+++ b/pkg/source/applovinmax/applovinmax_test.go
@@ -292,6 +292,35 @@ func TestStreamCSVHonorsLimitAcrossBatches(t *testing.T) {
 	assert.Equal(t, []int64{3, 2}, batchRows)
 }
 
+func TestStreamCSVSplitsByMaxBatchBytes(t *testing.T) {
+	// 6 single-cell rows, each 10 content bytes; date+platform add 13 more, so
+	// estimateCSVRowBytes = 23/row. PageSize huge so only the byte cap splits.
+	// A 50-byte cap fits two rows (46) but not three (69) -> [2, 2, 2].
+	input := strings.NewReader("event_id\n0123456789\n0123456789\n0123456789\n0123456789\n0123456789\n0123456789\n")
+	results := make(chan source.RecordBatchResult, 4)
+
+	rows, err := streamCSV(
+		context.Background(),
+		input,
+		"2026-08-16", // 10 bytes
+		"ios",        // 3 bytes
+		source.ReadOptions{PageSize: 1_000_000, MaxBatchBytes: 50},
+		newRowLimiter(0),
+		results,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 6, rows)
+
+	close(results)
+	var batchRows []int64
+	for result := range results {
+		require.NoError(t, result.Err)
+		batchRows = append(batchRows, result.Batch.NumRows())
+		result.Batch.Release()
+	}
+	assert.Equal(t, []int64{2, 2, 2}, batchRows, "50-byte cap must split the 23-byte rows two per batch")
+}
+
 func TestStreamCSVEmitsBeforeInputCompletes(t *testing.T) {
 	reader, writer := io.Pipe()
 	results := make(chan source.RecordBatchResult)

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -241,7 +241,7 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 
 			builder.appendRow(record)
 			if opts.MaxBatchBytes > 0 {
-				accBytes += csvRowBytes(record)
+				accBytes += arrowconv.CellsBytes(record)
 			}
 
 			if builder.rows >= batchSize || (opts.MaxBatchBytes > 0 && accBytes >= opts.MaxBatchBytes) {
@@ -262,16 +262,6 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 	}()
 
 	return results, nil
-}
-
-// csvRowBytes approximates the content size of a raw CSV record so batches can
-// honor opts.MaxBatchBytes alongside the row-count limit.
-func csvRowBytes(record []string) int64 {
-	var n int64
-	for _, cell := range record {
-		n += int64(len(cell))
-	}
-	return n
 }
 
 // batchBuilder builds record batches directly from CSV records, bypassing

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -185,6 +185,7 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 		batchNum := 0
 		totalRows := 0
 		lineNum := 1
+		var accBytes int64
 
 		flush := func() bool {
 			rec := builder.finish()
@@ -239,11 +240,15 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 			}
 
 			builder.appendRow(record)
+			if opts.MaxBatchBytes > 0 {
+				accBytes += csvRowBytes(record)
+			}
 
-			if builder.rows >= batchSize {
+			if builder.rows >= batchSize || (opts.MaxBatchBytes > 0 && accBytes >= opts.MaxBatchBytes) {
 				if !flush() {
 					return
 				}
+				accBytes = 0
 			}
 		}
 
@@ -257,6 +262,16 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 	}()
 
 	return results, nil
+}
+
+// csvRowBytes approximates the content size of a raw CSV record so batches can
+// honor opts.MaxBatchBytes alongside the row-count limit.
+func csvRowBytes(record []string) int64 {
+	var n int64
+	for _, cell := range record {
+		n += int64(len(cell))
+	}
+	return n
 }
 
 // batchBuilder builds record batches directly from CSV records, bypassing

--- a/pkg/source/csv/csv_test.go
+++ b/pkg/source/csv/csv_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -196,5 +197,59 @@ func TestRead_BuildsBatchesDirectly(t *testing.T) {
 		if ok == wantName[i].null || (ok && got != wantName[i].val) {
 			t.Errorf("name[%d] = (%q, notnull=%v); want (%q, notnull=%v)", i, got, ok, wantName[i].val, !wantName[i].null)
 		}
+	}
+}
+
+func TestRead_ByteCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wide.csv")
+	wide := strings.Repeat("x", 2048)
+	var b strings.Builder
+	b.WriteString("id,name\n")
+	const rows = 50
+	for i := 0; i < rows; i++ {
+		b.WriteString(strconv.Itoa(i))
+		b.WriteByte(',')
+		b.WriteString(wide)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(max int64) (batches, total int) {
+		src := NewCSVSource()
+		if err := src.Connect(context.Background(), "csv://"+path); err != nil {
+			t.Fatal(err)
+		}
+		table, err := src.GetTable(context.Background(), source.TableRequest{Name: "t"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ch, err := table.Read(context.Background(), source.ReadOptions{PageSize: 100_000, MaxBatchBytes: max})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for res := range ch {
+			if res.Err != nil {
+				t.Fatal(res.Err)
+			}
+			batches++
+			total += int(res.Batch.NumRows())
+			res.Batch.Release()
+		}
+		return batches, total
+	}
+
+	offB, offR := run(0)
+	if offB != 1 {
+		t.Fatalf("cap-off batches=%d, want 1", offB)
+	}
+	onB, onR := run(4096)
+	if onB <= 1 {
+		t.Fatalf("cap-on batches=%d, want >1", onB)
+	}
+	if offR != onR || offR != rows {
+		t.Fatalf("row mismatch: off=%d on=%d want=%d", offR, onR, rows)
 	}
 }

--- a/pkg/source/csv/parallel.go
+++ b/pkg/source/csv/parallel.go
@@ -280,6 +280,7 @@ type segmentParser struct {
 	builder   *batchBuilder
 	incIdx    []int
 	startTime *time.Time
+	accBytes  int64
 }
 
 func newSegmentParser(headers []string, opts source.ReadOptions, batchSize int) *segmentParser {
@@ -338,8 +339,12 @@ func (p *segmentParser) parse(seg csvSegment) []source.RecordBatchResult {
 		}
 
 		p.builder.appendRow(record)
-		if p.builder.rows >= p.batchSize {
+		if p.opts.MaxBatchBytes > 0 {
+			p.accBytes += csvRowBytes(record)
+		}
+		if p.builder.rows >= p.batchSize || (p.opts.MaxBatchBytes > 0 && p.accBytes >= p.opts.MaxBatchBytes) {
 			out = append(out, source.RecordBatchResult{Batch: p.builder.finish()})
+			p.accBytes = 0
 		}
 	}
 

--- a/pkg/source/csv/parallel.go
+++ b/pkg/source/csv/parallel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/araddon/dateparse"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
 
@@ -340,7 +341,7 @@ func (p *segmentParser) parse(seg csvSegment) []source.RecordBatchResult {
 
 		p.builder.appendRow(record)
 		if p.opts.MaxBatchBytes > 0 {
-			p.accBytes += csvRowBytes(record)
+			p.accBytes += arrowconv.CellsBytes(record)
 		}
 		if p.builder.rows >= p.batchSize || (p.opts.MaxBatchBytes > 0 && p.accBytes >= p.opts.MaxBatchBytes) {
 			out = append(out, source.RecordBatchResult{Batch: p.builder.finish()})

--- a/pkg/source/csv/parallel.go
+++ b/pkg/source/csv/parallel.go
@@ -301,6 +301,11 @@ func newSegmentParser(headers []string, opts source.ReadOptions, batchSize int) 
 func (p *segmentParser) parse(seg csvSegment) []source.RecordBatchResult {
 	var out []source.RecordBatchResult
 
+	// The parser is reused across segments; the trailing flush below (and the
+	// error path) finish() the builder without touching accBytes, so start each
+	// segment from a clean byte count rather than carrying the prior tail over.
+	p.accBytes = 0
+
 	cr := csv.NewReader(bytes.NewReader(seg.data))
 	cr.FieldsPerRecord = -1
 	cr.ReuseRecord = true

--- a/pkg/source/csv/parallel_test.go
+++ b/pkg/source/csv/parallel_test.go
@@ -212,6 +212,42 @@ func TestSplitSegments_TruncatedFileReturnsError(t *testing.T) {
 	}
 }
 
+func TestSegmentParser_ByteCap(t *testing.T) {
+	wide := strings.Repeat("x", 2048)
+	var sb strings.Builder
+	const rows = 40
+	for i := 0; i < rows; i++ {
+		fmt.Fprintf(&sb, "%d,%s\n", i, wide)
+	}
+	seg := csvSegment{data: []byte(sb.String()), startRecord: 2}
+
+	run := func(max int64) (batches, total int) {
+		p := newSegmentParser([]string{"id", "name"}, source.ReadOptions{MaxBatchBytes: max}, 100_000)
+		defer p.builder.rb.Release()
+		for _, res := range p.parse(seg) {
+			if res.Err != nil {
+				t.Fatal(res.Err)
+			}
+			batches++
+			total += int(res.Batch.NumRows())
+			res.Batch.Release()
+		}
+		return batches, total
+	}
+
+	offB, offR := run(0)
+	if offB != 1 {
+		t.Fatalf("cap-off batches=%d, want 1", offB)
+	}
+	onB, onR := run(4096)
+	if onB <= 1 {
+		t.Fatalf("cap-on batches=%d, want >1", onB)
+	}
+	if offR != onR || offR != rows {
+		t.Fatalf("row mismatch: off=%d on=%d want=%d", offR, onR, rows)
+	}
+}
+
 func TestLastRecordBoundary(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/source/csv/parallel_test.go
+++ b/pkg/source/csv/parallel_test.go
@@ -248,6 +248,39 @@ func TestSegmentParser_ByteCap(t *testing.T) {
 	}
 }
 
+func TestSegmentParser_ByteCapIgnoresCarryOver(t *testing.T) {
+	// A worker reuses one parser across segments, and a segment's tail is emitted
+	// by the trailing flush without resetting accBytes. Simulate that residual and
+	// assert it does not split a fresh, wholly sub-cap segment: pre-fix, the first
+	// row would immediately cross the cap and flush early (2 batches).
+	var sb strings.Builder
+	const rows = 6
+	for i := 0; i < rows; i++ {
+		fmt.Fprintf(&sb, "%d,name-%d\n", i, i)
+	}
+	seg := csvSegment{data: []byte(sb.String()), startRecord: 2}
+
+	p := newSegmentParser([]string{"id", "name"}, source.ReadOptions{MaxBatchBytes: 4096}, 100_000)
+	defer p.builder.rb.Release()
+	p.accBytes = 1 << 20 // residual left by a prior segment's trailing flush
+
+	var batches, total int
+	for _, res := range p.parse(seg) {
+		if res.Err != nil {
+			t.Fatal(res.Err)
+		}
+		batches++
+		total += int(res.Batch.NumRows())
+		res.Batch.Release()
+	}
+	if batches != 1 {
+		t.Fatalf("carry-over accBytes split a sub-cap segment: got %d batches, want 1", batches)
+	}
+	if total != rows {
+		t.Fatalf("row count mismatch: got %d want %d", total, rows)
+	}
+}
+
 func TestLastRecordBoundary(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/source/databricks/databricks.go
+++ b/pkg/source/databricks/databricks.go
@@ -270,36 +270,45 @@ func (s *DatabricksSource) read(ctx context.Context, table string, tableSchema *
 			return
 		}
 
-		s.processResults(ctx, resp, arrowSchema, columns, results)
+		s.processResults(ctx, resp, arrowSchema, columns, opts.MaxBatchBytes, results)
 	}()
 
 	return results, nil
 }
 
-func (s *DatabricksSource) processResults(ctx context.Context, resp *dbsql.StatementResponse, arrowSchema *arrow.Schema, columns []schema.Column, results chan<- source.RecordBatchResult) {
+func (s *DatabricksSource) processResults(ctx context.Context, resp *dbsql.StatementResponse, arrowSchema *arrow.Schema, columns []schema.Column, maxBatchBytes int64, results chan<- source.RecordBatchResult) {
 	batchSize := defaultBatchSize
 	alloc := memory.NewGoAllocator()
 
-	processChunk := func(dataArray [][]string) {
-		if len(dataArray) == 0 {
-			return
+	flush := func(chunk [][]string) bool {
+		batch, err := s.buildRecordBatch(alloc, arrowSchema, columns, chunk)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to build record batch: %w", err)}
+			return false
 		}
+		results <- source.RecordBatchResult{Batch: batch}
+		config.Debug("[DATABRICKS] Sent batch with %d rows", len(chunk))
+		return true
+	}
 
-		for start := 0; start < len(dataArray); start += batchSize {
-			end := start + batchSize
-			if end > len(dataArray) {
-				end = len(dataArray)
+	processChunk := func(dataArray [][]string) {
+		start := 0
+		var accBytes int64
+		for i, row := range dataArray {
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.CellsBytes(row)
 			}
-
-			chunk := dataArray[start:end]
-			batch, err := s.buildRecordBatch(alloc, arrowSchema, columns, chunk)
-			if err != nil {
-				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to build record batch: %w", err)}
-				return
+			rows := i - start + 1
+			if rows >= batchSize || (maxBatchBytes > 0 && accBytes >= maxBatchBytes) {
+				if !flush(dataArray[start : i+1]) {
+					return
+				}
+				start = i + 1
+				accBytes = 0
 			}
-
-			results <- source.RecordBatchResult{Batch: batch}
-			config.Debug("[DATABRICKS] Sent batch with %d rows", len(chunk))
+		}
+		if start < len(dataArray) {
+			flush(dataArray[start:])
 		}
 	}
 
@@ -425,7 +434,7 @@ func (s *DatabricksSource) ExecuteCustomQuery(ctx context.Context, query string,
 		}
 		arrowSchema := buildArrowSchema(columns)
 
-		s.processResults(ctx, resp, arrowSchema, columns, results)
+		s.processResults(ctx, resp, arrowSchema, columns, opts.MaxBatchBytes, results)
 	}()
 
 	return results, nil

--- a/pkg/source/databricks/databricks_test.go
+++ b/pkg/source/databricks/databricks_test.go
@@ -1,11 +1,14 @@
 package databricks
 
 import (
+	"context"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	dbsql "github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,4 +101,36 @@ func TestBuildRecordBatchPreservesEmptyStringCells(t *testing.T) {
 	assert.True(t, values.IsNull(2))
 	assert.False(t, values.IsNull(3))
 	assert.Equal(t, "value", values.Value(3))
+}
+
+func TestProcessResultsByteCap(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "a", DataType: schema.TypeString, Nullable: true},
+		{Name: "b", DataType: schema.TypeString, Nullable: true},
+	}
+	const rowCount = 60
+	rows := make([][]string, rowCount)
+	for i := range rows {
+		rows[i] = []string{"0123456789", "0123456789"} // 20 content bytes/row
+	}
+	resp := &dbsql.StatementResponse{Result: &dbsql.ResultData{DataArray: rows}}
+
+	results := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(results)
+		(&DatabricksSource{}).processResults(context.Background(), resp, buildArrowSchema(columns), columns, 50, results)
+	}()
+
+	batches := 0
+	total := int64(0)
+	for res := range results {
+		require.NoError(t, res.Err)
+		require.NotNil(t, res.Batch)
+		batches++
+		total += res.Batch.NumRows()
+		res.Batch.Release()
+	}
+
+	assert.Equal(t, int64(rowCount), total)
+	assert.Greater(t, batches, 1, "50-byte cap should split 60 rows into many batches")
 }

--- a/pkg/source/databricks/databricks_test.go
+++ b/pkg/source/databricks/databricks_test.go
@@ -113,24 +113,41 @@ func TestProcessResultsByteCap(t *testing.T) {
 	for i := range rows {
 		rows[i] = []string{"0123456789", "0123456789"} // 20 content bytes/row
 	}
-	resp := &dbsql.StatementResponse{Result: &dbsql.ResultData{DataArray: rows}}
 
-	results := make(chan source.RecordBatchResult)
-	go func() {
-		defer close(results)
-		(&DatabricksSource{}).processResults(context.Background(), resp, buildArrowSchema(columns), columns, 50, results)
-	}()
-
-	batches := 0
-	total := int64(0)
-	for res := range results {
-		require.NoError(t, res.Err)
-		require.NotNil(t, res.Batch)
-		batches++
-		total += res.Batch.NumRows()
-		res.Batch.Release()
+	cases := []struct {
+		name          string
+		maxBatchBytes int64
+		wantBatches   int
+	}{
+		// Disabled cap: 60 rows well under defaultBatchSize -> one batch, exactly
+		// matching the original row-count-only behavior.
+		{"cap disabled", 0, 1},
+		// 20 bytes/row, 50-byte cap: flush after the row that reaches >=50, i.e.
+		// every 3rd row -> 20 batches.
+		{"50 byte cap", 50, 20},
 	}
 
-	assert.Equal(t, int64(rowCount), total)
-	assert.Greater(t, batches, 1, "50-byte cap should split 60 rows into many batches")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &dbsql.StatementResponse{Result: &dbsql.ResultData{DataArray: rows}}
+			results := make(chan source.RecordBatchResult)
+			go func() {
+				defer close(results)
+				(&DatabricksSource{}).processResults(context.Background(), resp, buildArrowSchema(columns), columns, tc.maxBatchBytes, results)
+			}()
+
+			batches := 0
+			total := int64(0)
+			for res := range results {
+				require.NoError(t, res.Err)
+				require.NotNil(t, res.Batch)
+				batches++
+				total += res.Batch.NumRows()
+				res.Batch.Release()
+			}
+
+			assert.Equal(t, int64(rowCount), total, "all rows must be preserved")
+			assert.Equal(t, tc.wantBatches, batches)
+		})
+	}
 }

--- a/pkg/source/deel/deel.go
+++ b/pkg/source/deel/deel.go
@@ -990,11 +990,36 @@ func sendItems(ctx context.Context, items []map[string]any, meta endpointMeta, o
 		return nil
 	}
 
-	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
-	if err != nil {
-		return fmt.Errorf("failed to convert Deel records to Arrow: %w", err)
+	flush := func(batch []map[string]any) error {
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert Deel records to Arrow: %w", err)
+		}
+		return sendResult(ctx, results, source.RecordBatchResult{Batch: record})
 	}
-	return sendResult(ctx, results, source.RecordBatchResult{Batch: record})
+
+	if opts.MaxBatchBytes <= 0 {
+		return flush(items)
+	}
+
+	var batch []map[string]any
+	var accBytes int64
+	for _, item := range items {
+		rowBytes := arrowconv.RowBytes(item)
+		if len(batch) > 0 && accBytes+rowBytes > opts.MaxBatchBytes {
+			if err := flush(batch); err != nil {
+				return err
+			}
+			batch = nil
+			accBytes = 0
+		}
+		batch = append(batch, item)
+		accBytes += rowBytes
+	}
+	if len(batch) > 0 {
+		return flush(batch)
+	}
+	return nil
 }
 
 func sendResult(ctx context.Context, results chan<- source.RecordBatchResult, result source.RecordBatchResult) error {

--- a/pkg/source/deel/deel_test.go
+++ b/pkg/source/deel/deel_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -154,6 +155,45 @@ func TestSendItemsStopsOnCancellation(t *testing.T) {
 	err := sendItems(ctx, []map[string]any{{"id": "one"}}, endpointMeta{}, source.ReadOptions{}, make(chan source.RecordBatchResult))
 	if err != context.Canceled {
 		t.Fatalf("sendItems returned %v, want context.Canceled", err)
+	}
+}
+
+func TestSendItemsByteCap(t *testing.T) {
+	wide := strings.Repeat("x", 2048)
+	items := make([]map[string]any, 50)
+	for i := range items {
+		items[i] = map[string]any{"id": strconv.Itoa(i), "name": wide}
+	}
+
+	run := func(max int64) (batches, rows int) {
+		results := make(chan source.RecordBatchResult)
+		go func() {
+			defer close(results)
+			if err := sendItems(context.Background(), items, endpointMeta{}, source.ReadOptions{MaxBatchBytes: max}, results); err != nil {
+				t.Errorf("sendItems returned %v", err)
+			}
+		}()
+		for res := range results {
+			if res.Err != nil {
+				t.Fatalf("batch error: %v", res.Err)
+			}
+			batches++
+			rows += int(res.Batch.NumRows())
+			res.Batch.Release()
+		}
+		return batches, rows
+	}
+
+	offB, offR := run(0)
+	if offB != 1 {
+		t.Fatalf("cap-off batches=%d, want 1", offB)
+	}
+	onB, onR := run(4096)
+	if onB <= 1 {
+		t.Fatalf("cap-on batches=%d, want >1", onB)
+	}
+	if offR != onR || offR != len(items) {
+		t.Fatalf("row mismatch: off=%d on=%d want=%d", offR, onR, len(items))
 	}
 }
 

--- a/pkg/source/mongodb/mongodb.go
+++ b/pkg/source/mongodb/mongodb.go
@@ -740,6 +740,7 @@ func (s *MongoDBSource) consumeCursor(ctx context.Context, cursor *mongo.Cursor,
 			builder = newMongoSchemaBatchBuilderWithAllocator(mem, opts.Schema.Columns, opts.ExcludeColumns, batchSize)
 		}
 		batchRows := 0
+		var accBytes int64
 
 		for batchRows < batchSize && cursor.Next(ctx) {
 			if err := builder.AppendRawDocument(cursor.Current); err != nil {
@@ -748,6 +749,12 @@ func (s *MongoDBSource) consumeCursor(ctx context.Context, cursor *mongo.Cursor,
 				return
 			}
 			batchRows++
+			if opts.MaxBatchBytes > 0 {
+				accBytes += int64(len(cursor.Current))
+				if accBytes >= opts.MaxBatchBytes {
+					break
+				}
+			}
 		}
 
 		if err := cursor.Err(); err != nil {

--- a/pkg/source/mongodb/mongodb_test.go
+++ b/pkg/source/mongodb/mongodb_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
@@ -1931,5 +1932,48 @@ func TestConvertMongoShellToExtendedJSON(t *testing.T) {
 				t.Errorf("\ngot:  %s\nwant: %s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestConsumeCursorByteCap(t *testing.T) {
+	wide := strings.Repeat("x", 2048)
+	const rows = 40
+	docs := make([]interface{}, rows)
+	for i := range docs {
+		docs[i] = bson.D{{Key: "_id", Value: i}, {Key: "name", Value: wide}}
+	}
+
+	run := func(max int64) (batches, total int) {
+		cursor, err := mongo.NewCursorFromDocuments(docs, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		results := make(chan source.RecordBatchResult)
+		s := &MongoDBSource{}
+		go func() {
+			defer close(results)
+			s.consumeCursor(context.Background(), cursor, 100_000, source.ReadOptions{MaxBatchBytes: max}, results, time.Now())
+		}()
+		for res := range results {
+			if res.Err != nil {
+				t.Fatalf("batch error: %v", res.Err)
+			}
+			batches++
+			total += int(res.Batch.NumRows())
+			res.Batch.Release()
+		}
+		return batches, total
+	}
+
+	offB, offR := run(0)
+	if offB != 1 {
+		t.Fatalf("cap-off batches=%d, want 1", offB)
+	}
+	onB, onR := run(4096)
+	if onB <= 1 {
+		t.Fatalf("cap-on batches=%d, want >1", onB)
+	}
+	if offR != onR || offR != rows {
+		t.Fatalf("row mismatch: off=%d on=%d want=%d", offR, onR, rows)
 	}
 }


### PR DESCRIPTION
## What

Extends the byte-based batch cap (`MaxBatchBytes`, from `--batch-size`) to the three batch-reader sources that still emitted batches sized only by row count.

Follows PRs #1095 / #1096 / #1097 / #1115.