### PR TITLE
ci: add daily Codex Security scan feeding Code Scanning

### DIFF
--- a/.github/SECURITY_SCANNING.md
+++ b/.github/SECURITY_SCANNING.md
@@ -1,0 +1,70 @@
+# Codex Security daily scan
+
+[`.github/workflows/codex-security.yml`](workflows/codex-security.yml) runs a full
+[Codex Security](https://developers.openai.com/codex/security) scan of the default
+branch once a day and publishes the results to GitHub Code Scanning.
+
+## At a glance
+
+| | |
+| --- | --- |
+| Schedule | Daily at 04:27 UTC, plus **Actions → codex_security → Run workflow** |
+| Scope | The whole working tree of the default branch. No PR, push, or diff scans |
+| Secret | `OPENAI_API_KEY` (repository or organization Actions secret) |
+| Findings | **Security → Code scanning**, filtered by tool `Codex Security` |
+| Cost ceiling | `CODEX_SECURITY_MAX_COST` in the workflow (default `20` USD per scan) |
+| Job timeout | 180 minutes |
+
+## Where findings go
+
+Code Scanning is the findings inbox. The workflow does not open issues, comment on
+pull requests, or block merges. Use the Security tab to read a finding, jump to its
+source location, and dismiss it as a false positive or accepted risk.
+
+Alerts are uploaded under the category `codex-security` against
+`refs/heads/<default-branch>`. GitHub matches results across uploads by source-line
+fingerprint, so re-running the scan updates existing alerts rather than duplicating
+them, a fixed finding is resolved by the next scan, and a dismissal survives later
+uploads.
+
+Code scanning uploads require GitHub Advanced Security to be enabled on private
+repositories.
+
+## What fails the job, and what does not
+
+A vulnerability is not a build failure. The scan runs report-only — no
+`--fail-on-severity` — so a completed scan exits `0` no matter what it found.
+
+The job fails only on operational problems: a missing or rejected `OPENAI_API_KEY`,
+a scanner crash, an interrupted run, a failed SARIF export, or a failed upload.
+
+Incomplete coverage also fails the job, and in that case **nothing is uploaded**.
+This is deliberate: GitHub resolves alerts that a new upload no longer reports, so
+publishing the partial results of a scan that stopped early would silently close
+real alerts the scanner never got around to re-finding. The most likely cause is the
+scan hitting its cost ceiling; raise `CODEX_SECURITY_MAX_COST` and re-run.
+
+## Handling scan output
+
+Scan state, artifacts, and the exported SARIF are written to `/tmp/codex-security`,
+outside the checkout, so findings and source snippets cannot end up as repository
+files. The scanner also refuses an output directory inside the scanned git worktree.
+
+The uploaded SARIF is the only durable output. The workflow intentionally does not
+upload build artifacts: the scan directory contains vulnerability details and source
+snippets. The job summary reports finding counts by severity only.
+
+To debug a failing scan, start with the step logs, then add `--verbose` to the scan
+command on a branch. If you need the raw artifacts, add a temporary
+`actions/upload-artifact` step with `retention-days: 1` and remove it afterwards.
+
+## Reusing this in another repository
+
+1. Copy `.github/workflows/codex-security.yml` and merge it to the default branch —
+   `schedule` and `workflow_dispatch` only take effect from there.
+2. Make `OPENAI_API_KEY` available to the repository.
+3. Enable code scanning (GitHub Advanced Security on private repositories).
+4. Dispatch the workflow manually a few times before relying on the schedule, and
+   check runtime and cost against `CODEX_SECURITY_MAX_COST`.
+
+Bump `CODEX_SECURITY_VERSION` to pick up a new `@openai/codex-security` release.

--- a/.github/workflows/codex-security.yml
+++ b/.github/workflows/codex-security.yml
@@ -2,8 +2,7 @@ name: codex_security
 
 on:
   schedule:
-    # Daily at 04:27 UTC. Deliberately off the hour: GitHub queues scheduled
-    # workflows, and runs starting on the hour are the most likely to be delayed.
+    # Off the hour: GitHub delays scheduled runs starting at :00 the most.
     - cron: '27 4 * * *'
   workflow_dispatch:
     inputs:
@@ -15,24 +14,19 @@ on:
 permissions:
   contents: read
   security-events: write
-  # upload-sarif reads the workflow run; only required in private repositories.
-  actions: read
+  actions: read # upload-sarif, private repositories only
 
-# A full scan is expensive, and Code Scanning tracks alerts per (ref, category),
-# so two concurrent uploads for the same ref would fight over alert state.
+# Two concurrent uploads for the same ref would fight over alert state.
 concurrency:
   group: codex-security-${{ github.repository }}
   cancel-in-progress: false
 
 env:
   CODEX_SECURITY_VERSION: '0.1.20'
-  # Stops the scan once estimated spend exceeds this many USD. A stopped scan
-  # has incomplete coverage, which fails the job rather than uploading partial
-  # results. Raise it here if scans start hitting the ceiling.
+  # Estimated USD ceiling per scan; exceeding it stops the scan.
   CODEX_SECURITY_MAX_COST: '20'
-  # Scan state, artifacts, and the exported SARIF all live outside the checkout
-  # so findings and source snippets never become repository files. The scanner
-  # also requires its output directory to be outside any enclosing git worktree.
+  # Outside the checkout: keeps findings out of the repo, and the scanner
+  # rejects an output directory inside the scanned worktree.
   SCAN_ROOT: /tmp/codex-security
   CODEX_SECURITY_STATE_DIR: /tmp/codex-security/state
   CODEX_SECURITY_NO_UPDATE_NOTICE: '1'
@@ -58,11 +52,9 @@ jobs:
       - name: Checkout default branch
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          # Pinned explicitly so a manual dispatch from a topic branch still
-          # scans, and reports against, the default branch.
+          # Scan the default branch even when dispatched from a topic branch.
           ref: ${{ steps.target.outputs.branch }}
-          # The scanner runs an agent with shell access inside the checkout;
-          # keep the Actions token out of the working tree.
+          # The scanner runs an agent with shell access inside the checkout.
           persist-credentials: false
 
       - name: Record scanned commit
@@ -121,17 +113,14 @@ jobs:
             --output-dir "${SCAN_ROOT}/results" \
             --max-cost "$max_cost" || status=$?
 
-          # Exit 0 means the scan completed with full coverage, whether or not it
-          # found vulnerabilities. Findings are triaged in Code Scanning and must
-          # not fail this workflow. Every other status is operational: the scan
-          # never produced a trustworthy full picture, so uploading its partial
-          # results would resolve alerts it simply never got around to re-finding.
+          # Only exit 0 means full coverage; partial results are never uploaded.
+          # Rationale in .github/SECURITY_SCANNING.md.
           case "$status" in
             0)
               echo "Scan completed with full coverage. Findings, if any, are reported through Code Scanning."
               ;;
             2)
-              echo "::error::Codex Security could not complete the scan (invalid input, incomplete coverage, or a runtime error). Nothing is uploaded, so existing Code Scanning alerts are left untouched. If the scan stopped on the ${max_cost} USD ceiling, raise CODEX_SECURITY_MAX_COST."
+              echo "::error::Codex Security could not complete the scan (invalid input, incomplete coverage, or a runtime error). Nothing is uploaded. If it stopped on the ${max_cost} USD ceiling, raise CODEX_SECURITY_MAX_COST."
               ;;
             130|143)
               echo "::error::Codex Security was interrupted before it finished (exit ${status})."
@@ -163,8 +152,7 @@ jobs:
           # Report against the default branch even when dispatched elsewhere.
           ref: refs/heads/${{ steps.target.outputs.branch }}
           sha: ${{ steps.commit.outputs.sha }}
-          # Scopes alert tracking to this tool so adding another scanner later
-          # does not resolve each other's alerts.
+          # Scopes alert tracking so a second scanner cannot resolve these.
           category: codex-security
 
       - name: Summarize findings
@@ -184,8 +172,7 @@ jobs:
             else
               echo "Reported ${total} finding(s):"
               echo
-              # Severity levels only. Titles, locations, and messages stay in
-              # Code Scanning rather than the job log.
+              # Levels only; titles and locations stay in Code Scanning.
               jq -r '[.runs[].results[]?]
                      | group_by(.level // "warning")
                      | .[]

--- a/.github/workflows/codex-security.yml
+++ b/.github/workflows/codex-security.yml
@@ -1,0 +1,196 @@
+name: codex_security
+
+on:
+  schedule:
+    # Daily at 04:27 UTC. Deliberately off the hour: GitHub queues scheduled
+    # workflows, and runs starting on the hour are the most likely to be delayed.
+    - cron: '27 4 * * *'
+  workflow_dispatch:
+    inputs:
+      max_cost:
+        description: 'Estimated USD cost ceiling for this run (blank uses CODEX_SECURITY_MAX_COST)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  security-events: write
+  # upload-sarif reads the workflow run; only required in private repositories.
+  actions: read
+
+# A full scan is expensive, and Code Scanning tracks alerts per (ref, category),
+# so two concurrent uploads for the same ref would fight over alert state.
+concurrency:
+  group: codex-security-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  CODEX_SECURITY_VERSION: '0.1.20'
+  # Stops the scan once estimated spend exceeds this many USD. A stopped scan
+  # has incomplete coverage, which fails the job rather than uploading partial
+  # results. Raise it here if scans start hitting the ceiling.
+  CODEX_SECURITY_MAX_COST: '20'
+  # Scan state, artifacts, and the exported SARIF all live outside the checkout
+  # so findings and source snippets never become repository files. The scanner
+  # also requires its output directory to be outside any enclosing git worktree.
+  SCAN_ROOT: /tmp/codex-security
+  CODEX_SECURITY_STATE_DIR: /tmp/codex-security/state
+  CODEX_SECURITY_NO_UPDATE_NOTICE: '1'
+
+jobs:
+  scan:
+    name: full scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Resolve default branch
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          branch="$DEFAULT_BRANCH"
+          if [ -z "$branch" ]; then
+            branch="$(gh api "repos/${GITHUB_REPOSITORY}" --jq .default_branch)"
+          fi
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout default branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Pinned explicitly so a manual dispatch from a topic branch still
+          # scans, and reports against, the default branch.
+          ref: ${{ steps.target.outputs.branch }}
+          # The scanner runs an agent with shell access inside the checkout;
+          # keep the Actions token out of the working tree.
+          persist-credentials: false
+
+      - name: Record scanned commit
+        id: commit
+        run: |
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - name: Setup Python
+        id: python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Codex Security
+        run: npm install -g "@openai/codex-security@${CODEX_SECURITY_VERSION}"
+
+      - name: Prepare scan workspace
+        run: |
+          rm -rf "$SCAN_ROOT"
+          mkdir -p "$SCAN_ROOT"
+          # The scanner rejects an output location that other users can read.
+          chmod 700 "$SCAN_ROOT"
+
+      - name: Run Codex Security scan
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PYTHON: ${{ steps.python.outputs.python-path }}
+          INPUT_MAX_COST: ${{ inputs.max_cost }}
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "::error::OPENAI_API_KEY is not available. Add it as an Actions secret for this repository."
+            exit 1
+          fi
+
+          max_cost="${INPUT_MAX_COST:-}"
+          if [ -z "$max_cost" ]; then
+            max_cost="$CODEX_SECURITY_MAX_COST"
+          fi
+          case "$max_cost" in
+            ''|*[!0-9.]*)
+              echo "::error::max_cost must be a number, got '${max_cost}'."
+              exit 1
+              ;;
+          esac
+
+          status=0
+          codex-security scan "$GITHUB_WORKSPACE" \
+            --auth api-key \
+            --headless \
+            --output-dir "${SCAN_ROOT}/results" \
+            --max-cost "$max_cost" || status=$?
+
+          # Exit 0 means the scan completed with full coverage, whether or not it
+          # found vulnerabilities. Findings are triaged in Code Scanning and must
+          # not fail this workflow. Every other status is operational: the scan
+          # never produced a trustworthy full picture, so uploading its partial
+          # results would resolve alerts it simply never got around to re-finding.
+          case "$status" in
+            0)
+              echo "Scan completed with full coverage. Findings, if any, are reported through Code Scanning."
+              ;;
+            2)
+              echo "::error::Codex Security could not complete the scan (invalid input, incomplete coverage, or a runtime error). Nothing is uploaded, so existing Code Scanning alerts are left untouched. If the scan stopped on the ${max_cost} USD ceiling, raise CODEX_SECURITY_MAX_COST."
+              ;;
+            130|143)
+              echo "::error::Codex Security was interrupted before it finished (exit ${status})."
+              ;;
+            *)
+              echo "::error::Codex Security exited with an unexpected status ${status}."
+              ;;
+          esac
+          exit "$status"
+
+      - name: Export SARIF
+        env:
+          PYTHON: ${{ steps.python.outputs.python-path }}
+        run: |
+          codex-security export "${SCAN_ROOT}/results" \
+            --export-format sarif \
+            --source-root "$GITHUB_WORKSPACE" \
+            --output "${SCAN_ROOT}/results.sarif"
+
+          if [ ! -s "${SCAN_ROOT}/results.sarif" ]; then
+            echo "::error::SARIF export produced no output at ${SCAN_ROOT}/results.sarif."
+            exit 1
+          fi
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          sarif_file: ${{ env.SCAN_ROOT }}/results.sarif
+          # Report against the default branch even when dispatched elsewhere.
+          ref: refs/heads/${{ steps.target.outputs.branch }}
+          sha: ${{ steps.commit.outputs.sha }}
+          # Scopes alert tracking to this tool so adding another scanner later
+          # does not resolve each other's alerts.
+          category: codex-security
+
+      - name: Summarize findings
+        env:
+          BRANCH: ${{ steps.target.outputs.branch }}
+          SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          sarif="${SCAN_ROOT}/results.sarif"
+          total="$(jq '[.runs[].results[]?] | length' "$sarif")"
+          {
+            echo "### Codex Security scan"
+            echo
+            echo "Scanned \`${BRANCH}\` at \`${SHA}\`."
+            echo
+            if [ "$total" -eq 0 ]; then
+              echo "No findings reported."
+            else
+              echo "Reported ${total} finding(s):"
+              echo
+              # Severity levels only. Titles, locations, and messages stay in
+              # Code Scanning rather than the job log.
+              jq -r '[.runs[].results[]?]
+                     | group_by(.level // "warning")
+                     | .[]
+                     | "- \(.[0].level // "warning"): \(length)"' "$sarif"
+            fi
+            echo
+            echo "Review them under [Security → Code scanning](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Pull requests are welcome. However, please open an issue first to discuss what y
 > [!NOTE]
 > After cloning `ingestr` make sure to run `make setup` to install githooks.
 
+A [daily Codex Security scan](.github/SECURITY_SCANNING.md) runs against the default branch; its findings are reviewed under Security → Code scanning.
+
 ## Supported sources & destinations
 <table>
     <tr>


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow that runs a full [Codex Security](https://developers.openai.com/codex/security) scan of the default branch once a day, exports the findings as SARIF, and uploads them to GitHub Code Scanning.

## What this adds

- `.github/workflows/codex-security.yml` — daily at 04:27 UTC plus manual dispatch. No `pull_request` or `push` trigger, so cost stays bounded at one full scan per day. Incremental/diff scans are out of scope.
- `.github/SECURITY_SCANNING.md` — schedule, required secret, failure semantics, and where to review findings.
- A one-line pointer to that doc from the README's Contributing section.

## Design notes

**Findings do not fail the job.** The scan runs report-only (no `--fail-on-severity`), so a completed scan exits `0` whether or not it found vulnerabilities. Findings are triaged in Security → Code scanning. Every other exit status the scanner produces is operational — auth failure, crash, interruption, failed export, failed upload — and does fail the job.

**Incomplete coverage skips the upload.** GitHub resolves alerts that a new upload no longer reports. Publishing the partial results of a scan that stopped early (hitting the cost ceiling, for instance) would silently close real alerts the scanner never got around to re-finding, so a scan that did not complete uploads nothing and fails loudly instead.

**Nothing sensitive is persisted.** Scan state, artifacts, and the SARIF live in `/tmp/codex-security`, outside the checkout, so vulnerability details and source snippets cannot become repository files. No build artifacts are uploaded; the job summary reports finding counts by severity only. The checkout uses `persist-credentials: false` because the scanner runs an agent with shell access inside the working tree.

**Alert tracking.** SARIF is uploaded under category `codex-security` against `refs/heads/<default-branch>`, with `--source-root` set so the exporter emits GitHub's source-line fingerprints. Re-scans update existing alerts rather than duplicating them, fixed findings get resolved, and dismissals survive later uploads. The default branch is resolved and checked out explicitly, so a manual dispatch from a topic branch still scans and reports against the default branch.

**Cost control.** `CODEX_SECURITY_MAX_COST` (default 20 USD) caps estimated spend per scan and can be overridden per manual run via a workflow input. `concurrency` prevents two full scans racing on the same alert state, and the job has a 180-minute timeout.

## Before this can run

- `OPENAI_API_KEY` is not currently configured as a repository or organization secret — it needs to be added.
- `schedule` and `workflow_dispatch` only take effect once this workflow is on the default branch, so the workflow has not been executed yet. Dispatch it manually a few times after merge to confirm runtime, cost, and that findings land in Code Scanning with useful locations.

## Verification so far

Workflow YAML passes `actionlint`. The exact `scan` invocation was validated against `@openai/codex-security@0.1.20` with `--dry-run` (target, output location, cost ceiling, and `api_key` auth via `OPENAI_API_KEY` all resolve), and the `export` flag set was confirmed against the same version. The scan step's exit-code handling and the max-cost input validation were exercised against a stubbed CLI across exit codes 0/1/2/130.